### PR TITLE
fix(dashboard): single-flight snapshot bootstrap on the cold path

### DIFF
--- a/lib/core/domain_pool_ref.ml
+++ b/lib/core/domain_pool_ref.ml
@@ -25,3 +25,9 @@ let submit_cpu_or_inline f =
   | Some p -> Domain_pool.submit_cpu p f
   | None -> f ()
 ;;
+
+let submit_cpu_detached ~sw f =
+  match Atomic.get pool with
+  | Some p -> ignore (Domain_pool.submit_cpu_async ~sw p f)
+  | None -> ignore (Eio.Fiber.fork ~sw f)
+;;

--- a/lib/core/domain_pool_ref.mli
+++ b/lib/core/domain_pool_ref.mli
@@ -18,3 +18,10 @@ val submit_io_or_inline : (unit -> 'a) -> 'a
 
 val submit_cpu_or_inline : (unit -> 'a) -> 'a
 (** Submit CPU-bound work to the shared domain pool, or run inline when absent. *)
+
+val submit_cpu_detached : sw:Eio.Switch.t -> (unit -> unit) -> unit
+(** Fire-and-forget CPU-weight submit: the job runs on a pool worker
+    attached to [sw] and outlives the submitting fiber.  Used when the
+    caller must not own the job's lifecycle (a cancelled caller must not
+    cancel or abandon shared work).  Before the pool is installed, forks
+    the job on the caller's domain under [sw]. *)

--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -139,10 +139,56 @@ let bootstrap ~(config : Workspace.config) : t =
   t
 ;;
 
+(* Single-flight bootstrap.  Before the refresh loop's first publish, every
+   wait-free read path falls back to a synchronous compute — and on a cold
+   server each dashboard panel load fires several of those at once, so N
+   concurrent request fibers used to pay the same 10-40s compute N times
+   (the loser discards it, per the CAS in [bootstrap]).  One winner now
+   computes offloaded to the CPU pool; concurrent callers await the shared
+   promise instead of duplicating the work.  If the winner fails, waiters
+   observe the exception and each retries their own path — no dogpile on
+   the happy path, no hidden failure either. *)
+let bootstrap_in_flight : (t, exn) result Eio.Promise.t option Atomic.t =
+  Atomic.make None
+;;
+
+let rec bootstrap_single_flight ~(compute : unit -> t) : t =
+  match Atomic.get slot with
+  | Some t -> t
+  | None ->
+    (match Atomic.get bootstrap_in_flight with
+     | Some promise ->
+       (match Eio.Promise.await promise with
+        | Ok t -> t
+        | Error exn -> raise exn)
+     | None ->
+       let promise, resolver = Eio.Promise.create () in
+       if not (Atomic.compare_and_set bootstrap_in_flight None (Some promise))
+       then bootstrap_single_flight ~compute
+       else (
+         (* The promise must resolve and the slot must clear on EVERY exit,
+            including cancellation — otherwise waiters hang on an unresolved
+            promise and later callers see a stale in-flight marker.  The
+            exception (cancel or failure) is delivered to waiters as
+            [Error exn] and re-raised here: nothing is swallowed. *)
+         let result =
+           try Ok (compute ()) with
+           | exn -> Error exn
+         in
+         Atomic.set bootstrap_in_flight None;
+         Eio.Promise.resolve resolver result;
+         match result with
+         | Ok t -> t
+         | Error exn -> raise exn))
+;;
+
 let current_or_bootstrap ~config =
   match Atomic.get slot with
   | Some t -> t
-  | None -> bootstrap ~config
+  | None ->
+    bootstrap_single_flight
+      ~compute:(fun () ->
+        Domain_pool_ref.submit_cpu_or_inline (fun () -> bootstrap ~config))
 ;;
 
 (* RFC-0138 Phase 3: refresh loop optionally accepts [~state] so it
@@ -306,4 +352,7 @@ let make_for_test ~shell ?(shell_light = `Null) ~tools ~namespace_truth
   }
 ;;
 
-let reset_for_test () = Atomic.set slot None
+let reset_for_test () =
+  Atomic.set slot None;
+  Atomic.set bootstrap_in_flight None
+;;

--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -70,7 +70,9 @@ let bootstrap ~(config : Workspace.config) : t =
   let shell =
     try
       (!dashboard_shell_payload_json_ref) config
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       Log.Dashboard.warn "dashboard_snapshot bootstrap shell failed: %s"
         (Printexc.to_string exn);
       `Null
@@ -78,7 +80,9 @@ let bootstrap ~(config : Workspace.config) : t =
   let shell_light =
     try
       (!dashboard_shell_payload_json_ref) ~light:true config
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       Log.Dashboard.warn "dashboard_snapshot bootstrap shell_light failed: %s"
         (Printexc.to_string exn);
       `Null
@@ -86,7 +90,9 @@ let bootstrap ~(config : Workspace.config) : t =
   let tools =
     try
       (!dashboard_tools_http_json_ref) config
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       Log.Dashboard.warn "dashboard_snapshot bootstrap tools failed: %s"
         (Printexc.to_string exn);
       `Null
@@ -96,7 +102,9 @@ let bootstrap ~(config : Workspace.config) : t =
       let base_path = config.base_path in
       let masc_root = Workspace.masc_root_dir config in
       Telemetry_unified.summary_json ~base_path ~masc_root ()
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
       Log.Dashboard.warn "dashboard_snapshot bootstrap telemetry_summary failed: %s"
         (Printexc.to_string exn);
       `Null
@@ -143,16 +151,31 @@ let bootstrap ~(config : Workspace.config) : t =
    wait-free read path falls back to a synchronous compute — and on a cold
    server each dashboard panel load fires several of those at once, so N
    concurrent request fibers used to pay the same 10-40s compute N times
-   (the loser discards it, per the CAS in [bootstrap]).  One winner now
-   computes offloaded to the CPU pool; concurrent callers await the shared
-   promise instead of duplicating the work.  If the winner fails, waiters
-   observe the exception and each retries their own path — no dogpile on
-   the happy path, no hidden failure either. *)
-let bootstrap_in_flight : (t, exn) result Eio.Promise.t option Atomic.t =
+   (the loser discards it, per the CAS in [bootstrap]).
+
+   Ownership: the in-flight marker and the result promise are owned by the
+   detached compute, never by any request fiber.  A caller that wins the
+   CAS merely STARTS the worker; a caller cancelled while awaiting only
+   cancels its own wait — the marker stays, the worker still finishes and
+   publishes, and no cancelled request can restart the dogpile (observed
+   failure mode of the request-owned variant: a 15-35s request
+   cancellation cleared the marker mid-flight and the next request started
+   a second worker).  The marker clears and the promise resolves exactly
+   once, in the worker's completion path; only a starter that fails before
+   detaching resolves inline so waiters cannot hang. *)
+let bootstrap_in_flight : (t, exn * Printexc.raw_backtrace) result Eio.Promise.t option Atomic.t =
   Atomic.make None
 ;;
 
-let rec bootstrap_single_flight ~(compute : unit -> t) : t =
+let raise_with_backtrace (exn, backtrace) =
+  if String.equal (Printexc.raw_backtrace_to_string backtrace) ""
+  then raise exn
+  else Printexc.raise_with_backtrace exn backtrace
+;;
+
+let rec bootstrap_single_flight
+    ~(start_compute : resolve:((t, exn * Printexc.raw_backtrace) result -> unit) -> unit)
+  : t =
   match Atomic.get slot with
   | Some t -> t
   | None ->
@@ -160,35 +183,49 @@ let rec bootstrap_single_flight ~(compute : unit -> t) : t =
      | Some promise ->
        (match Eio.Promise.await promise with
         | Ok t -> t
-        | Error exn -> raise exn)
+        | Error err -> raise_with_backtrace err)
      | None ->
        let promise, resolver = Eio.Promise.create () in
        if not (Atomic.compare_and_set bootstrap_in_flight None (Some promise))
-       then bootstrap_single_flight ~compute
+       then bootstrap_single_flight ~start_compute
        else (
-         (* The promise must resolve and the slot must clear on EVERY exit,
-            including cancellation — otherwise waiters hang on an unresolved
-            promise and later callers see a stale in-flight marker.  The
-            exception (cancel or failure) is delivered to waiters as
-            [Error exn] and re-raised here: nothing is swallowed. *)
-         let result =
-           try Ok (compute ()) with
-           | exn -> Error exn
+         let resolve result =
+           Atomic.set bootstrap_in_flight None;
+           Eio.Promise.resolve resolver result
          in
-         Atomic.set bootstrap_in_flight None;
-         Eio.Promise.resolve resolver result;
-         match result with
+         (try start_compute ~resolve with
+          | exn ->
+            let backtrace = Printexc.get_raw_backtrace () in
+            resolve (Error (exn, backtrace)));
+         (* Await THIS promise — never re-check the marker.  The worker
+            resolves it (possibly synchronously inside [start_compute]);
+            re-reading the shared state here would restart a fresh flight
+            forever when the compute does not itself publish to [slot]. *)
+         match Eio.Promise.await promise with
          | Ok t -> t
-         | Error exn -> raise exn))
+         | Error err -> raise_with_backtrace err))
+;;
+
+let start_bootstrap_compute ~config ~resolve =
+  let run () =
+    try resolve (Ok (bootstrap ~config)) with
+    | Eio.Cancel.Cancelled _ as exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      resolve (Error (exn, backtrace));
+      raise exn
+    | exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      resolve (Error (exn, backtrace))
+  in
+  (match Eio_context.get_root_switch_opt () with
+   | Some sw -> Domain_pool_ref.submit_cpu_detached ~sw run
+   | None -> run ())
 ;;
 
 let current_or_bootstrap ~config =
   match Atomic.get slot with
   | Some t -> t
-  | None ->
-    bootstrap_single_flight
-      ~compute:(fun () ->
-        Domain_pool_ref.submit_cpu_or_inline (fun () -> bootstrap ~config))
+  | None -> bootstrap_single_flight ~start_compute:(start_bootstrap_compute ~config)
 ;;
 
 (* RFC-0138 Phase 3: refresh loop optionally accepts [~state] so it

--- a/lib/dashboard/dashboard_snapshot.mli
+++ b/lib/dashboard/dashboard_snapshot.mli
@@ -68,13 +68,18 @@ val current_or_bootstrap : config:Workspace.config -> t
     concurrent callers share that one compute instead of each paying
     it (boot-gap dogpile fix). *)
 
-val bootstrap_single_flight : compute:(unit -> t) -> t
-(** {!current} if populated; otherwise one winner runs [compute]
-    (production: offloaded to the CPU pool) while concurrent callers
-    await the shared [(t, exn) result Eio.Promise.t].  A winner failure
-    resolves the promise with [Error exn] so waiters re-raise it in
-    their own context and can fall back to their own compute instead of
-    hanging.  [compute] is a parameter so tests can count invocations
+val bootstrap_single_flight :
+  start_compute:(resolve:((t, exn * Printexc.raw_backtrace) result -> unit) -> unit) -> t
+(** {!current} if populated; otherwise one CAS winner starts a detached
+    compute via [start_compute] and every caller (including the winner)
+    awaits the shared promise.  Ownership rule: the in-flight marker and
+    the promise are owned by the detached compute, never by a request
+    fiber — a cancelled caller only cancels its own wait; the marker
+    clears and the promise resolves exactly once, in the worker's
+    completion path.  Only a [start_compute] that raises before
+    detaching resolves inline (so waiters cannot hang).  Waiters
+    re-raise the worker's exception with its captured backtrace.
+    [start_compute] is a parameter so tests control timing/ownership
     without a workspace. *)
 
 val refresh_loop :

--- a/lib/dashboard/dashboard_snapshot.mli
+++ b/lib/dashboard/dashboard_snapshot.mli
@@ -62,10 +62,20 @@ val current : unit -> t option
     successful publish.  Wait-free; total. *)
 
 val current_or_bootstrap : config:Workspace.config -> t
-(** [current ()] if populated; otherwise a single bootstrap value
-    computed synchronously on the calling fiber.  The bootstrap path is
-    taken at most once per process lifetime (first request before the
-    refresh loop has emitted). *)
+(** [current ()] if populated; otherwise the single-flight bootstrap
+    below.  The bootstrap path is taken at most once per process
+    lifetime (first request before the refresh loop has emitted), and
+    concurrent callers share that one compute instead of each paying
+    it (boot-gap dogpile fix). *)
+
+val bootstrap_single_flight : compute:(unit -> t) -> t
+(** {!current} if populated; otherwise one winner runs [compute]
+    (production: offloaded to the CPU pool) while concurrent callers
+    await the shared [(t, exn) result Eio.Promise.t].  A winner failure
+    resolves the promise with [Error exn] so waiters re-raise it in
+    their own context and can fall back to their own compute instead of
+    hanging.  [compute] is a parameter so tests can count invocations
+    without a workspace. *)
 
 val refresh_loop :
   sw:Eio.Switch.t ->

--- a/lib/operator/operator_control_snapshot_trust.ml
+++ b/lib/operator/operator_control_snapshot_trust.ml
@@ -7,16 +7,25 @@ let non_empty_trimmed_string_opt value =
   if trimmed = "" then None else Some trimmed
 
 
-(* TTL must exceed the operator_snapshot publish interval
-   (MASC_OPERATOR_REFRESH_INTERVAL_S, default 60s).  With the previous
-   3.0s, every trust entry aged out long before the next snapshot round,
-   so EVERY round recomputed all keepers (measured p50=319ms x 16 per
-   round).  65s lets a value computed in round N serve round N+1;
-   steady-state cost collapses to the misses alone.  Worst-case
-   staleness grows from one publish interval (60s) to two (~125s) —
-   trust fields are attention/disposition observations, not lifecycle
-   authority (RFC-0341), so the trade is acceptable. *)
-let compact_runtime_trust_cache_ttl_sec = 65.0
+(* TTL is derived from the operator_snapshot publish interval knob —
+   the same [MASC_OPERATOR_REFRESH_INTERVAL_S] (default 60s, min 10s,
+   max 600s) the server layer reads — so a value computed in round N
+   still serves round N+1.  With the previous fixed 3.0s, every trust
+   entry aged out long before the next snapshot round, so EVERY round
+   recomputed all keepers (measured p50=319ms x 16 per round).  The +5s
+   margin covers scheduling jitter between the TTL clock and the
+   publish clock.  Worst-case staleness grows from one publish interval
+   to two (interval x 2 + margin) — trust fields are
+   attention/disposition observations, not lifecycle authority
+   (RFC-0341), so the trade is acceptable. *)
+let compact_runtime_trust_cache_ttl_sec =
+  Keeper_config_rp_helpers.float_of_env_default
+    "MASC_OPERATOR_REFRESH_INTERVAL_S"
+    ~default:60.0
+    ~min_v:10.0
+    ~max_v:600.0
+  +. 5.0
+;;
 
 (* Cache key for the per-keeper runtime-trust projection.
 
@@ -38,16 +47,16 @@ let compact_runtime_trust_cache_ttl_sec = 65.0
      was meant to allow reuse between dashboard refresh cycles, but the
      operator_snapshot publish interval is 60s: a 3.0s TTL still expired
      before every round, so every round recomputed all keepers anyway
-     (measured p50=319ms x 16).  The TTL is now derived from the publish
-     cadence (65s > 60s interval) — see the constant's comment.
+     (measured p50=319ms x 16).  The TTL is now derived from the actual
+     publish-interval knob (interval + 5s) — see the constant's comment.
 
    Identity bits the key keeps:
    - [meta.runtime.generation]: bumped on supervisor restart / takeover.
    - [meta.paused]: explicit pause/unpause toggle.
 
    Result: each keeper has exactly one cache slot.  Turn transitions
-   are picked up on TTL expiry (~65s).  Pollution shrinks from
-   N keepers × M turns_per_window to just N keepers. *)
+   are picked up on TTL expiry (publish interval + 5s).  Pollution
+   shrinks from N keepers × M turns_per_window to just N keepers. *)
 let compact_runtime_trust_cache_key
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)

--- a/lib/operator/operator_control_snapshot_trust.ml
+++ b/lib/operator/operator_control_snapshot_trust.ml
@@ -7,7 +7,16 @@ let non_empty_trimmed_string_opt value =
   if trimmed = "" then None else Some trimmed
 
 
-let compact_runtime_trust_cache_ttl_sec = 3.0
+(* TTL must exceed the operator_snapshot publish interval
+   (MASC_OPERATOR_REFRESH_INTERVAL_S, default 60s).  With the previous
+   3.0s, every trust entry aged out long before the next snapshot round,
+   so EVERY round recomputed all keepers (measured p50=319ms x 16 per
+   round).  65s lets a value computed in round N serve round N+1;
+   steady-state cost collapses to the misses alone.  Worst-case
+   staleness grows from one publish interval (60s) to two (~125s) —
+   trust fields are attention/disposition observations, not lifecycle
+   authority (RFC-0341), so the trade is acceptable. *)
+let compact_runtime_trust_cache_ttl_sec = 65.0
 
 (* Cache key for the per-keeper runtime-trust projection.
 
@@ -26,16 +35,18 @@ let compact_runtime_trust_cache_ttl_sec = 3.0
    - TTL was 1.0s, intended as the invalidation signal.  In practice
      dashboard polls every 5-7s, so the cache NEVER hit — every refresh
      paid 400-580ms for receipt file I/O per keeper.  Raising to 3.0s
-     keeps data fresh (at most 3s stale) while allowing cache reuse
-     between dashboard refresh cycles.  Measured impact: trust sub-op
-     drops from 400-580ms (miss) to ~43ms (hit) on warm cycles.
+     was meant to allow reuse between dashboard refresh cycles, but the
+     operator_snapshot publish interval is 60s: a 3.0s TTL still expired
+     before every round, so every round recomputed all keepers anyway
+     (measured p50=319ms x 16).  The TTL is now derived from the publish
+     cadence (65s > 60s interval) — see the constant's comment.
 
    Identity bits the key keeps:
    - [meta.runtime.generation]: bumped on supervisor restart / takeover.
    - [meta.paused]: explicit pause/unpause toggle.
 
    Result: each keeper has exactly one cache slot.  Turn transitions
-   are picked up via the 3s TTL refresh.  Pollution shrinks from
+   are picked up on TTL expiry (~65s).  Pollution shrinks from
    N keepers × M turns_per_window to just N keepers. *)
 let compact_runtime_trust_cache_key
       ~(config : Workspace.config)

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -125,7 +125,7 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
      serialization (loops already back off adaptively when slow). *)
   let compute () =
     Eio.Semaphore.acquire offload_slots;
-    Fun.protect
+    Eio_guard.protect
       ~finally:(fun () -> Eio.Semaphore.release offload_slots)
       (fun () -> Domain_pool_ref.submit_cpu_or_inline compute)
   in

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -95,40 +95,30 @@ let notify_error config exn =
   | Some f -> Safe_ops.protect ~default:() (fun () -> f exn)
   | None -> ()
 
-let offload_slots = Eio.Semaphore.make 1
-
 let start ~sw ~clock ~config:raw_config ~compute ~on_result =
   (* Run [compute] off the serving domain.  Every refresh loop that goes
      through [start] (operator_snapshot, operator_digest, execution,
      execution_trust, mission, full_health_snapshot, …) used to run its
      blocking file I/O + JSON construction inline on the main Eio domain,
      starving HTTP/WS/keeper fibers — the measured 60s dashboard_execution
-     renders with keepers=0 and the per-refresh 24-60s timeouts.  The CPU
-     pool already exists for exactly this (Dashboard_snapshot.refresh_loop
-     and the single-flight bootstrap use it).  [submit_cpu_or_inline]
-     reserves one worker slot and falls back to inline before the pool is
-     installed at boot.  Concurrent runs of different loops may touch the
-     same Jsonl_incremental_projection tables from different worker domains;
-     those projections are designed to tolerate racing rebuilds of the same
-     key (idempotent re-fold, later Hashtbl.replace wins — see
-     jsonl_incremental_projection.ml "Concurrency").
+     renders with keepers=0 and the per-refresh 24-60s timeouts.
 
-     [offload_slots] bounds how many refresh computes occupy the pool at
-     once.  The pool is one shared Eio.Executor_pool where a CPU submit
-     costs weight 1.0 (a whole worker) and a request-path IO submit costs
-     0.05; on small hosts (CI: domain_count 1-2) an unbounded boot wave of
-     refresh computes consumed the entire weight budget and starved
-     pool-served endpoints (/api/v1/dashboard/transport-health timed out
-     25x in the transport truth harness).  One slot keeps the heavy
-     background work off the serving domain while leaving pool capacity
-     for request-path submits; the refresh cadence absorbs the
-     serialization (loops already back off adaptively when slow). *)
-  let compute () =
-    Eio.Semaphore.acquire offload_slots;
-    Eio_guard.protect
-      ~finally:(fun () -> Eio.Semaphore.release offload_slots)
-      (fun () -> Domain_pool_ref.submit_cpu_or_inline compute)
-  in
+     The computes are I/O-bound (per-keeper file tail reads with bounded
+     JSON), so they submit at IO weight (0.05 of a worker), not CPU weight
+     (1.0): a CPU-weight submit of blocking I/O both wastes a full worker
+     and, on small hosts, lets a boot wave of refresh computes consume the
+     whole pool budget (observed in CI: pool-served endpoints timing out).
+     IO weight keeps many refreshes and request-path submits admitted
+     concurrently — no separate throttle is needed or wanted (a shared
+     semaphore would be a fleet-wide head-of-line block whose timeout
+     swallows every other producer).  [submit_io_or_inline] falls back to
+     inline before the pool is installed at boot.  Concurrent runs of
+     different loops may touch the same Jsonl_incremental_projection tables
+     from different worker domains; those projections are designed to
+     tolerate racing rebuilds of the same key (idempotent re-fold, later
+     Hashtbl.replace wins — see jsonl_incremental_projection.ml
+     "Concurrency"). *)
+  let compute () = Domain_pool_ref.submit_io_or_inline compute in
   (* Clamp timeout below interval to prevent overlapping refreshes.
      When timeout >= interval, a timed-out compute runs past the next
      scheduled refresh, causing cascading failures (#7164). *)

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -95,6 +95,8 @@ let notify_error config exn =
   | Some f -> Safe_ops.protect ~default:() (fun () -> f exn)
   | None -> ()
 
+let offload_slots = Eio.Semaphore.make 1
+
 let start ~sw ~clock ~config:raw_config ~compute ~on_result =
   (* Run [compute] off the serving domain.  Every refresh loop that goes
      through [start] (operator_snapshot, operator_digest, execution,
@@ -109,8 +111,24 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
      same Jsonl_incremental_projection tables from different worker domains;
      those projections are designed to tolerate racing rebuilds of the same
      key (idempotent re-fold, later Hashtbl.replace wins — see
-     jsonl_incremental_projection.ml "Concurrency"). *)
-  let compute () = Domain_pool_ref.submit_cpu_or_inline compute in
+     jsonl_incremental_projection.ml "Concurrency").
+
+     [offload_slots] bounds how many refresh computes occupy the pool at
+     once.  The pool is one shared Eio.Executor_pool where a CPU submit
+     costs weight 1.0 (a whole worker) and a request-path IO submit costs
+     0.05; on small hosts (CI: domain_count 1-2) an unbounded boot wave of
+     refresh computes consumed the entire weight budget and starved
+     pool-served endpoints (/api/v1/dashboard/transport-health timed out
+     25x in the transport truth harness).  One slot keeps the heavy
+     background work off the serving domain while leaving pool capacity
+     for request-path submits; the refresh cadence absorbs the
+     serialization (loops already back off adaptively when slow). *)
+  let compute () =
+    Eio.Semaphore.acquire offload_slots;
+    Fun.protect
+      ~finally:(fun () -> Eio.Semaphore.release offload_slots)
+      (fun () -> Domain_pool_ref.submit_cpu_or_inline compute)
+  in
   (* Clamp timeout below interval to prevent overlapping refreshes.
      When timeout >= interval, a timed-out compute runs past the next
      scheduled refresh, causing cascading failures (#7164). *)

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -96,6 +96,21 @@ let notify_error config exn =
   | None -> ()
 
 let start ~sw ~clock ~config:raw_config ~compute ~on_result =
+  (* Run [compute] off the serving domain.  Every refresh loop that goes
+     through [start] (operator_snapshot, operator_digest, execution,
+     execution_trust, mission, full_health_snapshot, …) used to run its
+     blocking file I/O + JSON construction inline on the main Eio domain,
+     starving HTTP/WS/keeper fibers — the measured 60s dashboard_execution
+     renders with keepers=0 and the per-refresh 24-60s timeouts.  The CPU
+     pool already exists for exactly this (Dashboard_snapshot.refresh_loop
+     and the single-flight bootstrap use it).  [submit_cpu_or_inline]
+     reserves one worker slot and falls back to inline before the pool is
+     installed at boot.  Concurrent runs of different loops may touch the
+     same Jsonl_incremental_projection tables from different worker domains;
+     those projections are designed to tolerate racing rebuilds of the same
+     key (idempotent re-fold, later Hashtbl.replace wins — see
+     jsonl_incremental_projection.ml "Concurrency"). *)
+  let compute () = Domain_pool_ref.submit_cpu_or_inline compute in
   (* Clamp timeout below interval to prevent overlapping refreshes.
      When timeout >= interval, a timed-out compute runs past the next
      scheduled refresh, causing cascading failures (#7164). *)

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -41,10 +41,11 @@ val start :
     loop, bounded by [config.timeout_s].
 
     [compute] runs off the serving domain via
-    {!Domain_pool_ref.submit_cpu_or_inline} (one CPU-pool worker slot;
-    inline fallback before the pool is installed at boot), so blocking
-    file I/O and JSON construction in refresh loops no longer starve
-    HTTP/WS/keeper fibers on the main Eio domain.
+    {!Domain_pool_ref.submit_io_or_inline} at IO weight (0.05 of a worker;
+    the computes are file-I/O-bound), so blocking file I/O and JSON
+    construction in refresh loops no longer starve HTTP/WS/keeper fibers
+    on the main Eio domain nor consume whole CPU-pool workers.
+    Inline fallback before the pool is installed at boot.
 
     When [config.on_error] is set, it is called on timeout or exception,
     allowing callers to record the failure (e.g. mark_cached_surface_error). *)

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -40,5 +40,11 @@ val start :
     to a ref).  A warm-cache run executes synchronously before the async
     loop, bounded by [config.timeout_s].
 
+    [compute] runs off the serving domain via
+    {!Domain_pool_ref.submit_cpu_or_inline} (one CPU-pool worker slot;
+    inline fallback before the pool is installed at boot), so blocking
+    file I/O and JSON construction in refresh loops no longer starve
+    HTTP/WS/keeper fibers on the main Eio domain.
+
     When [config.on_error] is set, it is called on timeout or exception,
     allowing callers to record the failure (e.g. mark_cached_surface_error). *)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -593,22 +593,28 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                         let path = Filename.concat dir name in
                         if mtime_of path < cutoff
                         then (
-                          (try
-                             if Sys.is_directory path
-                             then Fs_compat.remove_tree path
-                             else Sys.remove path
-                           with
-                           | Sys_error _ | Unix.Unix_error _ -> ());
-                          incr deleted)));
+                          let removed =
+                            try
+                              if Sys.is_directory path
+                              then (
+                                Fs_compat.remove_tree path;
+                                true)
+                              else (
+                                Sys.remove path;
+                                true)
+                            with
+                            | Sys_error _ | Unix.Unix_error _ -> false
+                          in
+                          if removed
+                          then incr deleted
+                          else
+                            Log.Server.warn
+                              "periodic JSONL prune: could not remove %s"
+                              path)));
                  !deleted)
              in
-             (* trajectories/<keeper>/ and tool_blobs/<shard>/ accumulate
-                regular files; delete files older than the cutoff, then drop
-                emptied subdirectories.  tool_blobs is safe to age-prune
-                because [Tool_blob_store.put] atomically rewrites a blob on
-                every put, refreshing its mtime — so a blob's mtime is the
-                date of its newest referencing tool_calls row, and rows older
-                than the retention window are pruned in this same round. *)
+             (* trajectories/<keeper>/ accumulates regular files; delete files
+                older than the cutoff, then drop emptied subdirectories. *)
              let prune_files_by_mtime dir =
                if not (Sys.file_exists dir)
                then 0
@@ -625,9 +631,18 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                            then walk p
                            else if mtime_of p < cutoff
                            then (
-                             (try Sys.remove p with
-                              | Sys_error _ -> ());
-                             incr deleted))
+                             let removed =
+                               try
+                                 Sys.remove p;
+                                 true
+                               with
+                               | Sys_error _ -> false
+                             in
+                             if removed
+                             then incr deleted
+                             else
+                               Log.Server.warn
+                                 "periodic JSONL prune: could not remove %s" p))
                         entries
                     | exception Sys_error _ -> ());
                    if not (String.equal path dir)
@@ -664,14 +679,18 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                   2026-06-10, scanned by every store-fallback read. *)
                + prune_dir (Filename.concat masc "transition-audit")
                (* 2026-07-18: oas-events and costs share the dated layout;
-                  traces, trajectories and tool_blobs had no retention at
-                  all (114k/177k cold files observed) and are pruned by age
-                  on the same knob. *)
+                  traces and trajectories had no retention at all (114k cold
+                  files observed) and are pruned by age on the same knob.
+                  tool_blobs is deliberately NOT age-pruned here: blobs are
+                  referenced not only by tool_calls rows but also by keeper
+                  context/history via keeper_artifact_hydrator, whose
+                  retention horizon is longer and unmeasured — an mtime-only
+                  prune can leave live references dangling.  A blob GC must
+                  compute its keep-set from every referencing store first. *)
                + prune_dir (Filename.concat masc "oas-events")
                + prune_dir (Filename.concat masc "costs")
                + prune_trace_dirs (Filename.concat masc "traces")
                + prune_files_by_mtime (Filename.concat masc "trajectories")
-               + prune_files_by_mtime (Filename.concat masc "tool_blobs")
              in
              if total > 0
              then

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -568,6 +568,75 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                then Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
                else 0
              in
+             (* Age-based pruners for stores that do not use the dated-JSONL
+                layout.  All share the same retention knob. *)
+             let cutoff = now -. (float_of_int days *. Masc_time_constants.day) in
+             let mtime_of path =
+               try (Unix.stat path).Unix.st_mtime with
+               | Unix.Unix_error _ -> cutoff
+             in
+             (* traces/<trace-id> dirs hold per-turn snapshots; the dir mtime
+                tracks the last snapshot write (snapshot saves are atomic
+                renames into the dir), so a dir older than the cutoff is
+                finished and cold.  Top-level trace-*.checkpoint.lock files
+                follow the same horizon. *)
+             let prune_trace_dirs dir =
+               if not (Sys.file_exists dir)
+               then 0
+               else (
+                 let deleted = ref 0 in
+                 (try Sys.readdir dir with
+                  | Sys_error _ -> [||])
+                 |> Array.iter (fun name ->
+                      if String.starts_with ~prefix:"trace-" name
+                      then (
+                        let path = Filename.concat dir name in
+                        if mtime_of path < cutoff
+                        then (
+                          (try
+                             if Sys.is_directory path
+                             then Fs_compat.remove_tree path
+                             else Sys.remove path
+                           with
+                           | Sys_error _ | Unix.Unix_error _ -> ());
+                          incr deleted)));
+                 !deleted)
+             in
+             (* trajectories/<keeper>/ and tool_blobs/<shard>/ accumulate
+                regular files; delete files older than the cutoff, then drop
+                emptied subdirectories.  tool_blobs is safe to age-prune
+                because [Tool_blob_store.put] atomically rewrites a blob on
+                every put, refreshing its mtime — so a blob's mtime is the
+                date of its newest referencing tool_calls row, and rows older
+                than the retention window are pruned in this same round. *)
+             let prune_files_by_mtime dir =
+               if not (Sys.file_exists dir)
+               then 0
+               else (
+                 let deleted = ref 0 in
+                 let rec walk path =
+                   (match Sys.readdir path with
+                    | entries ->
+                      Array.iter
+                        (fun name ->
+                           let p = Filename.concat path name in
+                           if (try Sys.is_directory p with
+                               | Sys_error _ -> false)
+                           then walk p
+                           else if mtime_of p < cutoff
+                           then (
+                             (try Sys.remove p with
+                              | Sys_error _ -> ());
+                             incr deleted))
+                        entries
+                    | exception Sys_error _ -> ());
+                   if not (String.equal path dir)
+                   then (try Unix.rmdir path with
+                         | Unix.Unix_error _ -> ())
+                 in
+                 walk dir;
+                 !deleted)
+             in
              let prune_recall_injections () =
                match
                  Keeper_recall_injection_ledger.prune_older_than
@@ -594,11 +663,20 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                   introduction (RFC-0002) — 82 MB across 3 month-dirs by
                   2026-06-10, scanned by every store-fallback read. *)
                + prune_dir (Filename.concat masc "transition-audit")
+               (* 2026-07-18: oas-events and costs share the dated layout;
+                  traces, trajectories and tool_blobs had no retention at
+                  all (114k/177k cold files observed) and are pruned by age
+                  on the same knob. *)
+               + prune_dir (Filename.concat masc "oas-events")
+               + prune_dir (Filename.concat masc "costs")
+               + prune_trace_dirs (Filename.concat masc "traces")
+               + prune_files_by_mtime (Filename.concat masc "trajectories")
+               + prune_files_by_mtime (Filename.concat masc "tool_blobs")
              in
              if total > 0
              then
                Log.Server.info
-                 "periodic JSONL prune: pruned %d day-files (retention=%dd)"
+                 "periodic JSONL prune: pruned %d day-files/dirs (retention=%dd)"
                  total
                  days;
                (* Schedule terminal-row GC on the same 24h cadence: terminal

--- a/lib/server/server_dashboard_snapshot_select.ml
+++ b/lib/server/server_dashboard_snapshot_select.ml
@@ -9,45 +9,49 @@ let select_shell_json
     | Some t -> t
     | None -> Server_timing.create ()
   in
+  let with_auth shell =
+    match request with
+    | None -> shell
+    | Some request ->
+      Server_dashboard_http_core.dashboard_shell_with_request_auth_json
+        ~request config shell
+  in
+  let serve_snapshot project =
+    match Dashboard_snapshot.current () with
+    | Some snap ->
+      let shell =
+        Server_timing.measure
+          timing_obj
+          (Server_timing.Custom "snapshot_read")
+          (fun () -> project snap)
+      in
+      with_auth shell
+    | None ->
+      (* Cold window before the first publish: share the single-flight
+         bootstrap instead of paying a per-request synchronous compute
+         (every concurrent panel request used to pay it independently). *)
+      (match
+         (try Some (Dashboard_snapshot.current_or_bootstrap ~config) with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            Log.Dashboard.warn
+              "shell fallback bootstrap failed, using direct compute: %s"
+              (Printexc.to_string exn);
+            None)
+       with
+       | Some snap -> with_auth (project snap)
+       | None ->
+         Server_dashboard_http_core.dashboard_shell_http_json
+           ?clock ?request ~timing:timing_obj ~light config)
+  in
   if light
-  then (
+  then
     (* RFC-0204 section 8.3 ("A"): serve the published light projection
        wait-free.  Mirrors the non-light branch below but reads
        [snap.shell_light]; falls back to the (offloaded, timeout-guarded)
        recompute only before the first snapshot publish. *)
-    match Dashboard_snapshot.current () with
-    | Some snap ->
-      let shell =
-        Server_timing.measure
-          timing_obj
-          (Server_timing.Custom "snapshot_read")
-          (fun () -> snap.shell_light)
-      in
-      (match request with
-       | None -> shell
-       | Some request ->
-         Server_dashboard_http_core.dashboard_shell_with_request_auth_json
-           ~request config shell)
-    | None ->
-      Server_dashboard_http_core.dashboard_shell_http_json
-        ?clock ?request ~timing:timing_obj ~light config)
-  else (
-    match Dashboard_snapshot.current () with
-    | Some snap ->
-      let shell =
-        Server_timing.measure
-          timing_obj
-          (Server_timing.Custom "snapshot_read")
-          (fun () -> snap.shell)
-      in
-      (match request with
-       | None -> shell
-       | Some request ->
-         Server_dashboard_http_core.dashboard_shell_with_request_auth_json
-           ~request config shell)
-    | None ->
-      Server_dashboard_http_core.dashboard_shell_http_json
-        ?clock ?request ~timing:timing_obj ~light config)
+    serve_snapshot (fun snap -> snap.shell_light)
+  else serve_snapshot (fun snap -> snap.shell)
 ;;
 let select_tools_json
       ?actor ?timing (config : Workspace.config)
@@ -64,7 +68,24 @@ let select_tools_json
       timing_obj
       (Server_timing.Custom "snapshot_read")
       (fun () -> snap.tools)
-  | _ ->
+  | None, None ->
+    (* Cold window before the first publish: share the single-flight
+       bootstrap instead of paying a per-request synchronous compute
+       (every concurrent panel request used to pay it independently). *)
+    (match
+       (try Some (Dashboard_snapshot.current_or_bootstrap ~config) with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Log.Dashboard.warn
+            "tools fallback bootstrap failed, using direct compute: %s"
+            (Printexc.to_string exn);
+          None)
+     with
+     | Some snap -> snap.tools
+     | None ->
+       Server_dashboard_http_runtime_info.dashboard_tools_http_json
+         ?actor ~timing:timing_obj config)
+  | Some _, _ ->
     Server_dashboard_http_runtime_info.dashboard_tools_http_json
       ?actor ~timing:timing_obj config
 ;;

--- a/test/test_dashboard_snapshot.ml
+++ b/test/test_dashboard_snapshot.ml
@@ -92,7 +92,7 @@ let test_generated_at_recent () =
    reaches [compute] at all. *)
 let test_single_flight_dedups_concurrent_bootstrap () =
   Dashboard_snapshot.reset_for_test ();
-  let compute_count = Atomic.make 0 in
+  let starter_calls = Atomic.make 0 in
   let snap =
     Dashboard_snapshot.make_for_test
       ~shell:(`String "shared") ~tools:`Null
@@ -101,25 +101,21 @@ let test_single_flight_dedups_concurrent_bootstrap () =
   let results = Array.make 8 None in
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
-      let compute () =
-        ignore (Atomic.fetch_and_add compute_count 1);
-        (* Yield so the other fibers run and queue on the in-flight
-           promise; a non-yielding compute would serialize the fibers
-           and measure nothing. *)
-        Eio.Time.sleep env#clock 0.05;
-        snap
+      let start_compute ~resolve =
+        ignore (Atomic.fetch_and_add starter_calls 1);
+        Eio.Fiber.fork ~sw (fun () ->
+          Eio.Time.sleep env#clock 0.05;
+          resolve (Ok snap))
       in
       Array.iteri
         (fun i _ ->
           Eio.Fiber.fork ~sw (fun () ->
             results.(i) <-
               Some
-                (Dashboard_snapshot.bootstrap_single_flight ~compute)
+                (Dashboard_snapshot.bootstrap_single_flight ~start_compute)
                   .Dashboard_snapshot.generation))
         results));
-  (* The switch joined every fiber before returning; assertions outside
-     the switch body cannot race the workers. *)
-  Alcotest.(check int) "compute ran exactly once" 1 (Atomic.get compute_count);
+  Alcotest.(check int) "compute ran exactly once" 1 (Atomic.get starter_calls);
   let generations =
     Array.to_list results
     |> List.filter_map Fun.id
@@ -136,10 +132,78 @@ let test_single_flight_skips_compute_when_populated () =
       ~namespace_truth:`Null ~telemetry_summary:`Null ()
   in
   Dashboard_snapshot.publish_for_test snap;
-  let compute () = Alcotest.fail "compute ran despite a live snapshot" in
-  let observed = Dashboard_snapshot.bootstrap_single_flight ~compute in
+  let start_compute ~resolve:_ =
+    Alcotest.fail "start_compute ran despite a live snapshot"
+  in
+  let observed = Dashboard_snapshot.bootstrap_single_flight ~start_compute in
   Alcotest.(check int)
     "returned the published snapshot" snap.generation observed.generation
+;;
+
+(* A cancelled caller must not restart the flight: the worker owns the
+   marker and the promise, so a mid-flight client disconnect neither
+   clears the marker nor blocks the resolution for later callers. *)
+let test_caller_cancellation_keeps_flight_alive () =
+  Dashboard_snapshot.reset_for_test ();
+  let starter_calls = Atomic.make 0 in
+  let snap =
+    Dashboard_snapshot.make_for_test
+      ~shell:(`String "survivor") ~tools:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
+  in
+  let observed = ref None in
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let start_compute ~resolve =
+        ignore (Atomic.fetch_and_add starter_calls 1);
+        Eio.Fiber.fork ~sw (fun () ->
+          Eio.Time.sleep env#clock 0.1;
+          resolve (Ok snap))
+      in
+      (* Caller A disconnects 20ms into the flight. *)
+      Eio.Fiber.fork ~sw (fun () ->
+        (try
+           Eio.Switch.run (fun sw_a ->
+             Eio.Fiber.fork ~sw:sw_a (fun () ->
+               Eio.Time.sleep env#clock 0.02;
+               Eio.Switch.fail sw_a (Failure "client disconnect"));
+             ignore
+               (Dashboard_snapshot.bootstrap_single_flight ~start_compute))
+         with
+         | Eio.Cancel.Cancelled _ | Failure _ -> ()));
+      (* Caller B joins after A is gone. *)
+      Eio.Time.sleep env#clock 0.05;
+      observed := Some (Dashboard_snapshot.bootstrap_single_flight ~start_compute)));
+  Alcotest.(check int) "starter ran exactly once" 1 (Atomic.get starter_calls);
+  match !observed with
+  | None -> Alcotest.fail "caller B never observed the flight result"
+  | Some t ->
+    Alcotest.(check int) "caller B got the worker's snapshot" snap.generation t.generation
+;;
+
+(* A worker failure resolves waiters with the error and clears the
+   marker so the next caller retries a fresh flight. *)
+let test_failure_resolves_error_and_allows_retry () =
+  Dashboard_snapshot.reset_for_test ();
+  let starter_calls = Atomic.make 0 in
+  let snap =
+    Dashboard_snapshot.make_for_test
+      ~shell:(`String "recovered") ~tools:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
+  in
+  let boom = Failure "provider exploded" in
+  let start_compute ~resolve =
+    let attempt = Atomic.fetch_and_add starter_calls 1 in
+    if attempt = 0
+    then resolve (Error (boom, Printexc.get_raw_backtrace ()))
+    else resolve (Ok snap)
+  in
+  (match Dashboard_snapshot.bootstrap_single_flight ~start_compute with
+   | exception Failure msg when String.equal msg "provider exploded" -> ()
+   | _ -> Alcotest.fail "worker failure was not re-raised to the waiter");
+  let recovered = Dashboard_snapshot.bootstrap_single_flight ~start_compute in
+  Alcotest.(check int) "retry ran a second flight" 2 (Atomic.get starter_calls);
+  Alcotest.(check int) "retry returned the recovered snapshot" snap.generation recovered.generation
 ;;
 
 let () =
@@ -167,6 +231,10 @@ let () =
             `Quick test_single_flight_dedups_concurrent_bootstrap;
           Alcotest.test_case "populated slot skips compute"
             `Quick test_single_flight_skips_compute_when_populated;
+          Alcotest.test_case "caller cancellation keeps flight alive"
+            `Quick test_caller_cancellation_keeps_flight_alive;
+          Alcotest.test_case "failure resolves error and allows retry"
+            `Quick test_failure_resolves_error_and_allows_retry;
         ] );
     ]
 ;;

--- a/test/test_dashboard_snapshot.ml
+++ b/test/test_dashboard_snapshot.ml
@@ -87,6 +87,61 @@ let test_generated_at_recent () =
     true (s.generated_at <= after)
 ;;
 
+(* Single-flight: N concurrent callers share exactly one [compute]
+   invocation and observe the same snapshot; a populated slot never
+   reaches [compute] at all. *)
+let test_single_flight_dedups_concurrent_bootstrap () =
+  Dashboard_snapshot.reset_for_test ();
+  let compute_count = Atomic.make 0 in
+  let snap =
+    Dashboard_snapshot.make_for_test
+      ~shell:(`String "shared") ~tools:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
+  in
+  let results = Array.make 8 None in
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let compute () =
+        ignore (Atomic.fetch_and_add compute_count 1);
+        (* Yield so the other fibers run and queue on the in-flight
+           promise; a non-yielding compute would serialize the fibers
+           and measure nothing. *)
+        Eio.Time.sleep env#clock 0.05;
+        snap
+      in
+      Array.iteri
+        (fun i _ ->
+          Eio.Fiber.fork ~sw (fun () ->
+            results.(i) <-
+              Some
+                (Dashboard_snapshot.bootstrap_single_flight ~compute)
+                  .Dashboard_snapshot.generation))
+        results));
+  (* The switch joined every fiber before returning; assertions outside
+     the switch body cannot race the workers. *)
+  Alcotest.(check int) "compute ran exactly once" 1 (Atomic.get compute_count);
+  let generations =
+    Array.to_list results
+    |> List.filter_map Fun.id
+    |> List.sort_uniq compare
+  in
+  Alcotest.(check int) "all callers saw the same snapshot" 1 (List.length generations)
+;;
+
+let test_single_flight_skips_compute_when_populated () =
+  Dashboard_snapshot.reset_for_test ();
+  let snap =
+    Dashboard_snapshot.make_for_test
+      ~shell:`Null ~tools:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
+  in
+  Dashboard_snapshot.publish_for_test snap;
+  let compute () = Alcotest.fail "compute ran despite a live snapshot" in
+  let observed = Dashboard_snapshot.bootstrap_single_flight ~compute in
+  Alcotest.(check int)
+    "returned the published snapshot" snap.generation observed.generation
+;;
+
 let () =
   Alcotest.run "Dashboard_snapshot"
     [
@@ -105,6 +160,13 @@ let () =
             `Quick test_generation_monotonic;
           Alcotest.test_case "generated_at within call window"
             `Quick test_generated_at_recent;
+        ] );
+      ( "single-flight bootstrap",
+        [
+          Alcotest.test_case "concurrent callers share one compute"
+            `Quick test_single_flight_dedups_concurrent_bootstrap;
+          Alcotest.test_case "populated slot skips compute"
+            `Quick test_single_flight_skips_compute_when_populated;
         ] );
     ]
 ;;


### PR DESCRIPTION
## 문제 (실측)

`Dashboard_snapshot.current ()`가 refresh loop의 첫 publish 전까지 `None`이다. 그 창(콜드 부팅 직후 수십 초)에 "wait-free" 엔드포인트(tools/shell/shell light)가 전부 요청별 동기 계산으로 떨어진다. 대시보드 패널은 부팅 직후 ~10개를 동시에 열기 때문에, 같은 10~40초짜리 계산을 N개 fiber가 각각 따로 돌리고(`bootstrap`의 CAS는 패자의 작업을 버린다) 서로를 밀어낸다 — 대시보드 전체가 죽어 보이는 구간. 07-17 스크린샷의 전 면 취소(`tools` 15s 취소, `shell` 35s 취소 등)는 이 구조가 스톰과 겹친 것이고, 스톰 제거 후에도 콜드 창에서는 재현됐다(tools 17~36s, shell 12~26s, dev-token 12~14s → 슬롯 채워진 뒤엔 전부 50ms 이하).

## 수정

- `Dashboard_snapshot.bootstrap_single_flight`: 승자 1명만 계산(프로덕션은 CPU 풀 오프로드), 동시 호출자는 공유 `(t, exn) result Eio.Promise.t`를 기다린다. 중복 계산 제거.
- promise는 취소 포함 모든 종료 경로에서 resolve되고 in-flight 마커가 해제된다 — 대기자 행잉/마커 오염 불가. 승자 실패 시 `Error exn`으로 resolve해 대기자가 자기 문맥에서 재발생시키고 자체 fallback으로 낸다.
- `select_tools_json`/`select_shell_json`의 콜드 fallback을 `current_or_bootstrap`으로 연결. actor 필터 경로는 기존 per-actor 경로 유지(공유 스냅샷은 비파라미터라 적용 불가).
- `reset_for_test`가 in-flight 마커도 지운다.

## 검증

- `test_dashboard_snapshot` 7/7: 동시 8개 호출이 계산을 정확히 1회 공유하는 것, populated 슬롯에서 계산 생략, 기존 storage/metadata 테스트 회귀 없음.
- `dune build lib/` 전체 컴파일 통과.

## 범위 밖 (후속 후보)

- 부팅 시퀀스에서 첫 publish를 기다리게 하는 pre-warm(이 PR의 single-flight으로 dogpile은 죽었고, 첫 호출자 1명만 비용을 지는 형태라 우선순위는 낮음).
- operator_digest/execution 등 별도 refresh loop의 타임아웃 반복 실패(같은 누적-스캔 기질) — 별개 결함으로 추적 필요.

---

## 추가 커밋: 회전 없는 스토어 30d prune (c103df043f)

같은 라이브 관측에서 발견된 후속 조치. dated-layout이 아니라서 prune 대상이 아니던 5개 스토어가 무제한 누적 중이었다(07-17 실측: traces 11.4만 파일, tool_blobs 17.8만 파일, + GB 단위 trajectories/oas-events/costs).

- oas-events, costs: dated layout이라 기존 Dated_jsonl prune에 추가.
- traces/<trace-id>: dir mtime이 cutoff보다 오래되면 통째로 제거(snapshot 저장이 dir로의 atomic rename이라 dir mtime이 마지막 활동 시각).
- trajectories, tool_blobs: 파일 mtime 기준 prune + 빈 shard/keeper 디렉터리 정리. tool_blobs의 age-prune은 `Tool_blob_store.put`이 매 put마다 blob을 atomic rewrite해 mtime을 갱신하므로, blob의 mtime = 최신 참조 row 날짜 — retention보다 오래된 blob은 같은 라운드에서 잘리는 row만 참조한다는 게 성립.
- 전부 기존 `MASC_JSONL_RETENTION_DAYS`(기본 30d) 노브와 24h cadence 공유.

검증: lib/ 전체 컴파일 통과. 동작은 첫 prune 라운드 로그(periodic JSONL prune: pruned N day-files/dirs)로 관측 가능.

---

## 추가 커밋: refresh loop compute의 serving 도메인 이탈 (0bd2105d2e)

07-18 라이브 측정으로 확인된 마지막 병목. `proactive_refresh.start`를 쓰는 모든 refresh loop(operator_snapshot/digest/execution/execution_trust/mission/full_health_snapshot)이 blocking file I/O + JSON 구성을 main Eio 도메인에서 인라인 실행 — HTTP/WS/keeper fiber를 굶겼다(실측: dashboard_execution 60s 타임아웃(keepers=0), refresh_timeout 24~60s, snapshot_json 7.8s/keepers_json 6.5s, trust sub-op p50=319ms).

- 단일 지점(`start`)에서 compute를 `Domain_pool_ref.submit_cpu_or_inline`으로 래핑 — 전 loop가 CPU 풀 워커에서 실행(풀 미설치 시 인라인 fallback). `on_result` 발행은 loop fiber에 유지.
- projection 경합: 서로 다른 loop가 다른 워커 도메인에서 같은 Jsonl_incremental_projection 테이블을 만질 수 있으나, 그 테이블은 같은 key의 경합 재구축을 허용하도록 설계됨(idempotent re-fold, replace wins — jsonl_incremental_projection.ml "Concurrency").

검증: lib/ 전체 컴파일 통과. 배포 후 refresh_timeout/"refreshed" 비율과 dashboard endpoint 지연으로 효과 측정.

---

## 추가 커밋: trust 캐시 TTL을 스냅샷 주기에서 도출 (308fed8630)

offload로 serving 도메인은 비웠지만 keepers_json 라운드 비용 자체는 남아 있었다. 근인: trust sub-op의 TTL이 3.0s인데 operator_snapshot 발행 주기는 60s — 항목이 다음 라운드 전에 전부 만료돼 매 라운드 16 keepers × ~450ms를 재계산(실측 trust p50=319ms ≈ keepers_json 6.5s의 주된 몫).

- TTL 65s(> 발행 주기 60s)로 N라운드 값이 N+1라운드를 서빙 — 정상 상태 비용이 miss뿐이 된다.
- 최악 staleness가 1주기(60s)에서 2주기(~125s)로 커지는 트레이드 — trust 필드는 lifecycle 권한이 아닌 관찰값(RFC-0341)이라 수용 가능, 주석에 명시.

검증: lib/ 전체 컴파일 통과. 배포 후 keepers_json 시간과 trust sub-op p50으로 측정.

---

## 추가 커밋: refresh compute의 풀 점유 상한 (96e3c9084d)

offload(0bd2105d2e)의 부작용을 CI가 잡아냈다: 모든 refresh compute가 weight 1.0(워커 1개)로 공유 Executor_pool에 몰리면서, 작은 호스트(CI: domain_count 1~2)의 부팅 파도가 풀 예산을 전부 소비 → 풀 경유 엔드포인트(`submit_io` 0.05)가 굶어 transport truth harness에서 transport-health 25회 타임아웃으로 실패.

- refresh compute에 1슬롯 세마포어 — 무거운 백그라운드 refresh끼리만 직렬화(이미 적응형 backoff 보유)하고, 풀은 request-path 제출에 용량을 남긴다. serving 도메인 격리(0bd2105d2e의 목적)는 유지.

---

## 적대 리뷰 대응 (442b1da836)

3라운드 리뷰 지적을 수용/수정:

- **P1 single-flight ownership/cancellation**: producer를 worker 소유로 재설계 — 마커/promise는 detached compute가 소유하고, 호출자 취소는 자기 대기만 취소한다(15~35s 요청 취소로 dogpile 재발하던 경로 제거). 승자는 공유 상태를 재확인하지 않고 **자기 promise만 await**(동기 resolve 시 무한 재비행하던 설계 결함도 함께 제거). 실패는 raw backtrace 포함 Error로 전파, waiter 문맥에서 `raise_with_backtrace`. bootstrap 4개 표면의 catch-all이 Cancelled를 삼켜 shutdown에 all-Null 스냅샷을 publish하던 것도 재전파로 수정.
- **P1 EXECUTION**: refresh compute는 file-I/O 위주이므로 `submit_io`(weight 0.05)로 전환 — CPU weight 1.0의 워커 점유/플러딩 해소. 그리고 추가했던 1슬롯 세마포어는 fleet-wide head-of-line block(타임아웃이 다른 producer까지 삼킴)이라 제거.
- **P1/P2 TTL SSOT**: 65.0 하드코딩이 아니라 `MASC_OPERATOR_REFRESH_INTERVAL_S` 노브에서 실제 도출(interval + 5s).
- **P0 DATA(tool_blobs)**: 수용 — blob이 keeper context/history(hydrator)에서도 참조돼 보존 지평이 길다는 점을 확인하고 mtime prune 스코프에서 제외. 참조 무결성을 증명하는 keep-set GC가 먼저다.
- **P1 SILENT FAILURE**: 삭제 실패는 카운트 제외 + warn 로그.
- **P1 PROOF**: cancellation/failure 경로 테스트 2건 추가(9/9 통과).

미수용 1건: P2 SCOPE(4개 독립 단위) — 주제가 "대시보드/서버 부팅·갱신 경로의 성능"으로 하나라 이 PR에서 함께 간다. rollback 단위는 커밋별로 유지.
