### PR TITLE
feat(core): pin the physical data root at server bootstrap (RFC PR-1, #25151)

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -22,6 +22,7 @@
   executor_pool_ref
   domain_pool
   domain_pool_ref
+  masc_data_root
   masc_runtime_events
   system_error_class
   executable_path

--- a/lib/core/masc_data_root.ml
+++ b/lib/core/masc_data_root.ml
@@ -1,0 +1,71 @@
+(** Boot-pinned physical data root
+    (RFC-checkpoint-pinned-root-containment PR-1, #25151). *)
+
+type pin_error =
+  | Root_unresolvable of
+      { path : string
+      ; detail : string
+      }
+  | Root_not_directory of { physical : string }
+  | Repin_differs of
+      { pinned : string
+      ; requested_path : string
+      ; requested_physical : string
+      }
+
+let pin_error_to_string = function
+  | Root_unresolvable { path; detail } ->
+    Printf.sprintf "data root %S is unresolvable: %s" path detail
+  | Root_not_directory { physical } ->
+    Printf.sprintf "data root resolves to non-directory %S" physical
+  | Repin_differs { pinned; requested_path; requested_physical } ->
+    Printf.sprintf
+      "data root already pinned to %S; refusing repin to %S (physical %S)"
+      pinned requested_path requested_physical
+
+let root : string option Atomic.t = Atomic.make None
+
+let pinned () = Atomic.get root
+
+let clear_for_tests () = Atomic.set root None
+
+let resolve path =
+  try
+    let physical = Unix.realpath path in
+    if (Unix.stat physical).Unix.st_kind <> Unix.S_DIR
+    then Error (Root_not_directory { physical })
+    else Ok physical
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Unix.Unix_error (error, operation, argument) ->
+    Error
+      (Root_unresolvable
+         { path
+         ; detail =
+             Printf.sprintf "%s(%s): %s" operation argument
+               (Unix.error_message error)
+         })
+  | exn -> Error (Root_unresolvable { path; detail = Printexc.to_string exn })
+
+(* CAS claim loop: the [None] arm after a failed CAS is only reachable when
+   a concurrent [clear_for_tests] emptied the slot between the CAS and the
+   read; production never clears, tests are sequential, so the loop is a
+   correctness formality rather than a contended path. *)
+let rec claim ~requested_path physical =
+  if Atomic.compare_and_set root None (Some physical) then Ok physical
+  else (
+    match Atomic.get root with
+    | Some existing when String.equal existing physical -> Ok physical
+    | Some existing ->
+      Error
+        (Repin_differs
+           { pinned = existing
+           ; requested_path
+           ; requested_physical = physical
+           })
+    | None -> claim ~requested_path physical)
+
+let pin path =
+  match resolve path with
+  | Error _ as error -> error
+  | Ok physical -> claim ~requested_path:path physical

--- a/lib/core/masc_data_root.mli
+++ b/lib/core/masc_data_root.mli
@@ -1,0 +1,45 @@
+(** Boot-pinned physical data root
+    (RFC-checkpoint-pinned-root-containment PR-1, #25151).
+
+    One process-wide fact: the physical location of the configured data
+    root, resolved at server bootstrap while the directory tree is
+    trusted. Containment checks that must detect an ancestor directory
+    later swapped for a symlink compare against this pin — resolving the
+    root freshly per call would follow the swapped link on both sides of
+    the comparison and never fail.
+
+    An unpinned process (tests, CLI tools, anything that never runs
+    server bootstrap) keeps pre-pin semantics: {!pinned} returns [None]
+    and consumers skip the upper-bound check. The pin is set-once: a
+    second pin with the same physical root is an idempotent [Ok]; a
+    second pin with a different root is refused, never silently
+    repinned. *)
+
+type pin_error =
+  | Root_unresolvable of
+      { path : string
+      ; detail : string
+      }
+      (** [path] could not be resolved to a physical location. *)
+  | Root_not_directory of { physical : string }
+      (** The resolved location exists but is not a directory. *)
+  | Repin_differs of
+      { pinned : string
+      ; requested_path : string
+      ; requested_physical : string
+      }
+      (** A different root is already pinned for this process. *)
+
+val pin_error_to_string : pin_error -> string
+
+(** Resolve [path] to its physical location ([Unix.realpath]) and pin it
+    for the process lifetime. Returns the physical root on success.
+    Blocking syscalls; intended for the one-shot server bootstrap path. *)
+val pin : string -> (string, pin_error) result
+
+(** Physical pinned root, or [None] before {!pin} (unpinned posture). *)
+val pinned : unit -> string option
+
+(** Reset to the unpinned posture. Test harnesses that boot more than
+    one server state per process must call this before each boot. *)
+val clear_for_tests : unit -> unit

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -254,6 +254,18 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
   Unix.putenv Env_config_core.base_path_env_key base_path;
   ensure_thompson_persistence ~base_path;
   bootstrap_base_path_config_root ~base_path;
+  (* RFC-checkpoint-pinned-root-containment PR-1 (#25151): pin the physical
+     data root while the tree is trusted — after the config-root bootstrap
+     has ensured the base directory, before keepers or HTTP surfaces write.
+     PR-2 arms the checkpoint path boundary against this pin. An
+     unresolvable root, or an in-process re-bootstrap onto a different
+     root, is not a degradable condition (RFC §6): fail the boot. Test
+     harnesses that boot several server states per process reset the pin
+     via [Masc_data_root.clear_for_tests]. *)
+  (match Masc_data_root.pin base_path with
+   | Ok physical -> Log.Misc.info "data root pinned: %s" physical
+   | Error error ->
+     failwith ("data root pin failed: " ^ Masc_data_root.pin_error_to_string error));
   let config_root = (startup_config_resolution ~base_path).config_root.path in
   warn_ignored_config_root_full_catalogs ~config_root ();
   let (_ : string option) = configure_oas_model_catalog_env () in

--- a/test/dune
+++ b/test/dune
@@ -1819,7 +1819,7 @@
 
 (include stanzas/test_keeper_checkpoint_stale_guard.inc)
 
-
+(include stanzas/test_masc_data_root.inc)
 
 (include stanzas/test_keeper_context_isolation.inc)
 

--- a/test/stanzas/test_masc_data_root.inc
+++ b/test/stanzas/test_masc_data_root.inc
@@ -1,0 +1,8 @@
+; Masc_data_root pin contract (RFC-checkpoint-pinned-root-containment
+; PR-1, #25151): physical resolution, set-once refusal of a differing
+; repin, typed unresolvable/non-directory failures.
+
+(test
+ (name test_masc_data_root)
+ (modules test_masc_data_root)
+ (libraries masc_test_deps))

--- a/test/test_masc_data_root.ml
+++ b/test/test_masc_data_root.ml
@@ -1,0 +1,160 @@
+(** Unit tests for [Masc_data_root]
+    (RFC-checkpoint-pinned-root-containment PR-1, #25151).
+
+    The pin is the process-wide trust anchor for checkpoint path
+    containment (armed in PR-2): resolved once at boot, physical,
+    set-once. These tests pin the module contract — physical
+    resolution through symlinks, idempotent same-root repin, refusal
+    of a differing repin, typed failures for unresolvable and
+    non-directory roots. *)
+
+open Alcotest
+
+let temp_dir prefix =
+  let root = Filename.temp_file prefix "" in
+  Unix.unlink root;
+  Unix.mkdir root 0o755;
+  root
+
+let rec rm path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let with_fresh_pin f =
+  Masc_data_root.clear_for_tests ();
+  Fun.protect ~finally:Masc_data_root.clear_for_tests f
+
+let test_pin_resolves_physical () =
+  with_fresh_pin @@ fun () ->
+  let dir = temp_dir "data_root_phys_" in
+  Fun.protect ~finally:(fun () -> rm dir) @@ fun () ->
+  match Masc_data_root.pin dir with
+  | Error e -> fail (Masc_data_root.pin_error_to_string e)
+  | Ok physical ->
+    check string "pin returns the physical root" (Unix.realpath dir) physical;
+    check (option string) "pinned () exposes the same root" (Some physical)
+      (Masc_data_root.pinned ())
+
+let test_pin_resolves_symlinked_root () =
+  with_fresh_pin @@ fun () ->
+  let dir = temp_dir "data_root_link_" in
+  let target = Filename.concat dir "target" in
+  let link = Filename.concat dir "link" in
+  Fun.protect ~finally:(fun () -> rm dir) @@ fun () ->
+  Unix.mkdir target 0o755;
+  Unix.symlink target link;
+  match Masc_data_root.pin link with
+  | Error e -> fail (Masc_data_root.pin_error_to_string e)
+  | Ok physical ->
+    (* The deployment-symlink case from the RFC: the link is resolved once
+       at boot and the physical tree becomes the invariant. *)
+    check string "symlinked root pins its physical target"
+      (Unix.realpath target) physical
+
+let test_same_root_repin_is_idempotent () =
+  with_fresh_pin @@ fun () ->
+  let dir = temp_dir "data_root_idem_" in
+  let link = Filename.concat (Filename.dirname dir) (Filename.basename dir ^ "-alias") in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Unix.unlink link with Unix.Unix_error _ -> ());
+      rm dir)
+  @@ fun () ->
+  Unix.symlink dir link;
+  (match Masc_data_root.pin dir with
+   | Error e -> fail (Masc_data_root.pin_error_to_string e)
+   | Ok _ -> ());
+  (* A second pin through a different spelling of the same physical root
+     (here: via a symlink alias) is an idempotent Ok, not a refusal. *)
+  match Masc_data_root.pin link with
+  | Ok physical ->
+    check string "alias repin resolves to the pinned physical root"
+      (Unix.realpath dir) physical
+  | Error e ->
+    fail ("same-root repin refused: " ^ Masc_data_root.pin_error_to_string e)
+
+let test_differing_repin_refused () =
+  with_fresh_pin @@ fun () ->
+  let first = temp_dir "data_root_first_" in
+  let second = temp_dir "data_root_second_" in
+  Fun.protect ~finally:(fun () -> rm first; rm second) @@ fun () ->
+  (match Masc_data_root.pin first with
+   | Error e -> fail (Masc_data_root.pin_error_to_string e)
+   | Ok _ -> ());
+  match Masc_data_root.pin second with
+  | Ok _ -> fail "differing repin was accepted"
+  | Error (Masc_data_root.Repin_differs { pinned; requested_physical; _ }) ->
+    check string "refusal names the pinned root" (Unix.realpath first) pinned;
+    check string "refusal names the requested root" (Unix.realpath second)
+      requested_physical;
+    check (option string) "pin is unchanged after refusal"
+      (Some (Unix.realpath first)) (Masc_data_root.pinned ())
+  | Error e ->
+    fail ("differing repin failed with the wrong error: "
+          ^ Masc_data_root.pin_error_to_string e)
+
+let test_unresolvable_root_is_typed () =
+  with_fresh_pin @@ fun () ->
+  let missing = Filename.concat (temp_dir "data_root_gone_") "does-not-exist" in
+  Fun.protect ~finally:(fun () -> rm (Filename.dirname missing)) @@ fun () ->
+  match Masc_data_root.pin missing with
+  | Ok _ -> fail "missing root pinned"
+  | Error (Masc_data_root.Root_unresolvable { path; _ }) ->
+    check string "error names the requested path" missing path;
+    check (option string) "no pin is installed on failure" None
+      (Masc_data_root.pinned ())
+  | Error e ->
+    fail ("missing root failed with the wrong error: "
+          ^ Masc_data_root.pin_error_to_string e)
+
+let test_file_root_is_typed () =
+  with_fresh_pin @@ fun () ->
+  let dir = temp_dir "data_root_file_" in
+  let file = Filename.concat dir "regular" in
+  Fun.protect ~finally:(fun () -> rm dir) @@ fun () ->
+  let oc = open_out file in
+  output_string oc "not a directory";
+  close_out oc;
+  match Masc_data_root.pin file with
+  | Ok _ -> fail "regular file pinned as data root"
+  | Error (Masc_data_root.Root_not_directory { physical }) ->
+    check string "error names the physical file" (Unix.realpath file) physical
+  | Error e ->
+    fail ("file root failed with the wrong error: "
+          ^ Masc_data_root.pin_error_to_string e)
+
+let test_clear_resets_posture () =
+  with_fresh_pin @@ fun () ->
+  let dir = temp_dir "data_root_clear_" in
+  Fun.protect ~finally:(fun () -> rm dir) @@ fun () ->
+  (match Masc_data_root.pin dir with
+   | Error e -> fail (Masc_data_root.pin_error_to_string e)
+   | Ok _ -> ());
+  Masc_data_root.clear_for_tests ();
+  check (option string) "clear returns to the unpinned posture" None
+    (Masc_data_root.pinned ())
+
+let () =
+  run "Masc_data_root"
+    [
+      ( "pin",
+        [
+          test_case "resolves to the physical root" `Quick
+            test_pin_resolves_physical;
+          test_case "resolves a symlinked deployment root" `Quick
+            test_pin_resolves_symlinked_root;
+          test_case "same-root repin is idempotent" `Quick
+            test_same_root_repin_is_idempotent;
+          test_case "differing repin is refused" `Quick
+            test_differing_repin_refused;
+          test_case "unresolvable root is a typed failure" `Quick
+            test_unresolvable_root_is_typed;
+          test_case "non-directory root is a typed failure" `Quick
+            test_file_root_is_typed;
+          test_case "clear_for_tests resets the posture" `Quick
+            test_clear_resets_posture;
+        ] );
+    ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -3766,6 +3766,7 @@ let test_create_server_state_records_runtime_resolution () =
       in
       Eio.Switch.run @@ fun sw ->
       Server_startup_state.reset ~backend_mode:"filesystem" ();
+      Masc_data_root.clear_for_tests ();
       ignore
         (Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
            ~mono_clock ~net ~proc_mgr ~fs ());
@@ -3799,6 +3800,7 @@ let test_create_server_state_preserves_raw_input_base_path () =
       in
       Eio.Switch.run @@ fun sw ->
       Server_startup_state.reset ~backend_mode:"filesystem" ();
+      Masc_data_root.clear_for_tests ();
       ignore
         (Server_runtime_bootstrap.create_server_state ~sw ~base_path:raw_input
            ~clock ~mono_clock ~net ~proc_mgr ~fs ());
@@ -4197,6 +4199,7 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
         Server_runtime_bootstrap.init_runtime_context env
       in
       Eio.Switch.run @@ fun sw ->
+      Masc_data_root.clear_for_tests ();
       let state =
         Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
           ~mono_clock ~net ~proc_mgr ~fs ()
@@ -4269,6 +4272,7 @@ let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
         Server_runtime_bootstrap.init_runtime_context env
       in
       Eio.Switch.run @@ fun sw ->
+      Masc_data_root.clear_for_tests ();
       let state =
         Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
           ~mono_clock ~net ~proc_mgr ~fs ()


### PR DESCRIPTION
## Summary
RFC-checkpoint-pinned-root-containment (**merged `810be9566e`**) **PR-1**: boot-pinned 물리 데이터 루트 SSOT.

### 구현 (RFC §2.1, §4 Phase 1 그대로)
- **`Masc_data_root`** (lib/core 신설): `pin : string -> (string, pin_error) result` — `Unix.realpath`로 물리 경로 1회 고정. set-once: 같은 물리 루트 repin=idempotent Ok(symlink alias로 다르게 철자된 배포 루트 커버), 다른 루트 repin=typed `Repin_differs` 거부(silent repin 없음). 미해석/비디렉토리 루트=typed 실패. CAS claim 루프는 catch-all 없이 전 arm 명시.
- **부트 배선**: `create_server_state`에서 config-root 부트스트랩이 base 디렉토리를 보장한 직후·keeper/HTTP 표면 쓰기 전에 pin, 물리 루트를 INFO 1줄 로그(posture 관측). pin 실패=boot 실패 (RFC §6 "unresolvable data root is not a degradable condition" 채택). 프로덕션 진입점은 `bin/main_eio.ml` 1곳=프로세스당 1부트 확인.
- **unpinned posture**: 테스트/CLI는 현행 semantics 유지 (`pinned () = None`).

### RFC와의 델타 1건
`pin`이 RFC 표기 `(unit, pin_error) result` 대신 **물리 루트를 반환** — 호출자가 로그에 쓸 값을 `Option.get` 없이 받는 total한 형태. 의미론 변경 없음.

### 테스트
- 신규 `test_masc_data_root` 7케이스: 물리 해석 / symlinked 배포 루트 / **alias 경유 same-root repin=idempotent** / differing repin의 typed 거부(+거부 후 pin 불변) / unresolvable·non-directory typed 실패(+실패 시 pin 미설치) / clear posture 리셋.
- `test_server_runtime_bootstrap`의 `create_server_state` 4사이트에 `clear_for_tests` 배선 — 한 프로세스에서 서로 다른 temp 루트로 다중 부트하는 기존 스위트가 set-once와 충돌하지 않게 (RFC §5 명시 항목).

### 다음 (PR-2)
`canonical_session_location`이 pinned 시 `realpath parent`가 pin 하위인지 segment-wise 검증 + ancestor-symlink escape 테스트. 이 PR에는 **의도적으로 미포함** (RFC phase 분리).

## Validation
- 빌드/테스트는 PR CI. `git diff --check` clean. ocamlformat은 repo-wide disable 확인.

## RFC 체크
- 본 PR 자체가 merged RFC(`docs/rfc/RFC-checkpoint-pinned-root-containment.md`)의 Phase 1 구현. RFC-gated subsystem(credential/repo_manager/operator/hooks) 밖.

Refs #25151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
