### PR TITLE
fix(dashboard): cache and offload chat/history and tool-calls hydration reads

### DIFF
--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -346,6 +346,12 @@ val append_user_message_once :
   unit ->
   (append_once_result, string) result
 
+(** [chat_path ~base_dir ~keeper_name] is the on-disk JSONL path backing
+    this keeper's chat history. The file is append-only, so its
+    (mtime, size) pair changes on every persisted message — callers use
+    that pair as a freshness component in read-side cache keys. *)
+val chat_path : base_dir:string -> keeper_name:string -> string
+
 (** [load ~base_dir ~keeper_name] returns the most recent messages in
     chronological order: the last 100 user/assistant messages plus the
     tool lines belonging to them (absolute bound 400 lines). Missing

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -601,42 +601,67 @@ let log_call
       append_or_enqueue { store; keeper_name; tool_name; trace_id; json = safe_json }
 ;;
 
-let read_recent ?keeper_name ?(n = 100) () : Yojson.Safe.t list =
+(* Scan multiplier applied before the keeper filter: [read_recent] reads
+   [n * read_over_scan_factor] fleet rows to find [n] matching entries.
+   Named (rather than a literal 5) so callers sharing one fleet read can
+   size their window to reproduce [read_recent]'s coverage exactly. *)
+let read_over_scan_factor = 5
+
+let keeper_matches name json =
+  match Safe_ops.json_string_opt "keeper" json with
+  | Some k -> String.equal k name
+  | None -> false
+;;
+
+(* Single-pass ring buffer: keep the last [n] rows satisfying [keep],
+   preserving row order. *)
+let ring_keep_last ~n ~keep rows : Yojson.Safe.t list =
+  if n <= 0
+  then []
+  else (
+    let buf = Array.make n (`Null : Yojson.Safe.t) in
+    let pos = ref 0 in
+    let total = ref 0 in
+    List.iter
+      (fun json ->
+         if keep json
+         then (
+           buf.(!pos mod n) <- json;
+           incr pos;
+           incr total))
+      rows;
+    let count = min !total n in
+    if count = 0
+    then []
+    else (
+      let start = if !total <= n then 0 else !pos mod n in
+      List.init count (fun i -> buf.((start + i) mod n))))
+;;
+
+let read_recent_rows ~n () : Yojson.Safe.t list =
   if n <= 0
   then []
   else (
     match !store_ref with
     | None -> []
-    | Some store ->
-      let keeper_matches name json =
-        match Safe_ops.json_string_opt "keeper" json with
-        | Some k -> String.equal k name
-        | None -> false
-      in
-      (* Single-pass: read from store, filter, and collect last n in one traversal *)
-      let raw = Dated_jsonl.read_recent store (n * 5) in
-      let buf = Array.make n (`Null : Yojson.Safe.t) in
-      let pos = ref 0 in
-      let total = ref 0 in
-      List.iter
-        (fun json ->
-           let dominated =
-             match keeper_name with
-             | None -> true
-             | Some name -> keeper_matches name json
-           in
-           if dominated
-           then (
-             buf.(!pos mod n) <- json;
-             incr pos;
-             incr total))
-        raw;
-      let count = min !total n in
-      if count = 0
-      then []
-      else (
-        let start = if !total <= n then 0 else !pos mod n in
-        List.init count (fun i -> buf.((start + i) mod n))))
+    | Some store -> Dated_jsonl.read_recent store n)
+;;
+
+let filter_rows_for_keeper ~keeper_name ~n rows : Yojson.Safe.t list =
+  ring_keep_last ~n ~keep:(keeper_matches keeper_name) rows
+;;
+
+let read_recent ?keeper_name ?(n = 100) () : Yojson.Safe.t list =
+  if n <= 0
+  then []
+  else (
+    let raw = read_recent_rows ~n:(n * read_over_scan_factor) () in
+    let keep =
+      match keeper_name with
+      | None -> fun (_ : Yojson.Safe.t) -> true
+      | Some name -> keeper_matches name
+    in
+    ring_keep_last ~n ~keep raw)
 ;;
 
 let iso_date_of_unix ts =

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -187,6 +187,25 @@ val read_recent :
 (** [read_recent ?keeper_name ?n ()] returns the [n] most recent entries,
     optionally filtered by keeper name. Default [n=100]. *)
 
+val read_over_scan_factor : int
+(** Scan multiplier [read_recent] applies before its keeper filter: it
+    reads [n * read_over_scan_factor] fleet rows to find [n] matching
+    entries. Callers sharing one fleet read ({!read_recent_rows}) size
+    their window with this to reproduce [read_recent]'s coverage. *)
+
+val read_recent_rows : n:int -> unit -> Yojson.Safe.t list
+(** [read_recent_rows ~n ()] returns the [n] most recent fleet-wide rows
+    with no keeper filter. One shared read serves every per-keeper
+    {!filter_rows_for_keeper} derivation, instead of each keeper
+    re-parsing the store. *)
+
+val filter_rows_for_keeper :
+  keeper_name:string -> n:int -> Yojson.Safe.t list -> Yojson.Safe.t list
+(** [filter_rows_for_keeper ~keeper_name ~n rows] is [read_recent]'s
+    keeper filter applied to an already-read row window: rows whose
+    ["keeper"] field equals [keeper_name], order preserved, truncated to
+    the last [n]. *)
+
 val read_window :
   ?keeper_name:string ->
   window_hours:float ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1041,26 +1041,27 @@ let cached_keeper_config_json config name =
    ~1-2 s per keeper (chat tail parse + per-trace trajectory and
    internal-history tail reads + redaction), so a 16-keeper hydration
    serialized 15 s+ of main-domain work and pushed unrelated HTTP/WS
-   responses past the dashboard's 35 s client timeout. The cache key
-   embeds the chat file's (mtime, size): the store is append-only, so a
-   newly persisted message changes the key and is served fresh on the
-   next request without an invalidation hook. Enrichment-only drift
-   (trajectory/meta appends with no chat append) is bounded by the TTL,
-   the same staleness contract as the cached trajectory handler above. *)
-let keeper_chat_history_cache_key config name =
+   responses past the dashboard's 35 s client timeout.
+
+   Freshness lives in the cached VALUE, not the key: the key space is
+   exactly one entry per (validated) keeper name, so append bursts can
+   never grow cache cardinality. Each entry stamps the chat file's
+   (mtime, size) observed by its compute; a request whose current stat
+   differs invalidates the entry and recomputes, so a newly persisted
+   message is served fresh on the next request without an invalidation
+   hook at every append site. Enrichment-only drift (trajectory/meta
+   appends with no chat append) is bounded by the TTL, the same
+   staleness contract as the cached trajectory handler above. *)
+let keeper_chat_history_freshness config name =
   let base_dir = (config : Workspace.config).base_path in
   let path = Keeper_chat_store.chat_path ~base_dir ~keeper_name:name in
-  (* Sound-partial freshness component: a missing chat file is its own
-     cache state ("absent"), never conflated with a real (mtime, size)
-     pair. A half-readable stat (racing writer) also maps to "absent",
-     which only costs a recompute on the next request. *)
-  let freshness =
-    match Fs_compat.file_mtime path, Fs_compat.file_size path with
-    | Some mtime, Some size -> Printf.sprintf "%h:%d" mtime size
-    | Some _, None | None, Some _ | None, None -> "absent"
-  in
-  Printf.sprintf "keeper:chat-history:%s:%s:%s"
-    (Workspace.masc_root_dir config) name freshness
+  (* Sound-partial: a missing chat file is its own state ("absent"),
+     never conflated with a real (mtime, size) pair. A half-readable
+     stat (racing writer) also maps to "absent", which only costs a
+     recompute on the next request. *)
+  match Fs_compat.file_mtime path, Fs_compat.file_size path with
+  | Some mtime, Some size -> Printf.sprintf "%h:%d" mtime size
+  | Some _, None | None, Some _ | None, None -> "absent"
 ;;
 
 let keeper_chat_history_json config name =
@@ -1088,12 +1089,38 @@ let keeper_chat_history_json config name =
 ;;
 
 let cached_keeper_chat_history_json config name =
-  Dashboard_cache.get_or_compute
-    (keeper_chat_history_cache_key config name)
-    ~ttl:keeper_hot_path_cache_ttl_s
-    (fun () ->
-      Domain_pool_ref.submit_io_or_inline (fun () ->
-        keeper_chat_history_json config name))
+  let cache_key =
+    Printf.sprintf "keeper:chat-history:%s:%s"
+      (Workspace.masc_root_dir config) name
+  in
+  let current = keeper_chat_history_freshness config name in
+  (match Dashboard_cache.peek cache_key with
+   | Some (`Assoc fields) ->
+     (match List.assoc_opt "freshness" fields with
+      | Some (`String stamped) when String.equal stamped current -> ()
+      | Some _ | None -> Dashboard_cache.invalidate cache_key)
+   | Some _ -> Dashboard_cache.invalidate cache_key
+   | None -> ());
+  let cached =
+    Dashboard_cache.get_or_compute cache_key ~ttl:keeper_hot_path_cache_ttl_s
+      (fun () ->
+        Domain_pool_ref.submit_io_or_inline (fun () ->
+          (* Stamp the stat observed by THIS compute (stat before load):
+             an append racing the load makes the data newer than the
+             stamp, which the next request's stat comparison detects and
+             recomputes — never silently stale. *)
+          let stamped = keeper_chat_history_freshness config name in
+          `Assoc
+            [ ("freshness", `String stamped)
+            ; ("body", keeper_chat_history_json config name)
+            ]))
+  in
+  match cached with
+  | `Assoc fields ->
+    (match List.assoc_opt "body" fields with
+     | Some body -> body
+     | None -> cached)
+  | other -> other
 ;;
 
 let offline_keeper_composite_json ~config name (m : Keeper_meta_contract.keeper_meta) =
@@ -1527,13 +1554,15 @@ let handle_keeper_get_subroutes state req request reqd =
         | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _
         | `Assoc _ -> []
       in
-      let cache_key =
-        Printf.sprintf "keeper:tool-calls:%s:%s:%d" masc_root name limit
-      in
+      (* No per-keeper cache entry: the expensive part (the fleet parse)
+         is behind the single fleet-rows key above, and the per-request
+         remainder — filtering an in-memory window plus a bounded
+         coverage-gap tail read — is milliseconds off the main domain.
+         Skipping the per-(name, limit) entry keeps this route's cache
+         cardinality at exactly one key and never pins a per-keeper
+         response shape. *)
       let json =
-        Dashboard_cache.get_or_compute cache_key
-          ~ttl:keeper_hot_path_cache_ttl_s (fun () ->
-            Domain_pool_ref.submit_io_or_inline (fun () ->
+        Domain_pool_ref.submit_io_or_inline (fun () ->
               let entries =
                 Keeper_tool_call_log.filter_rows_for_keeper
                   ~keeper_name:name ~n:limit fleet_rows
@@ -1602,7 +1631,7 @@ let handle_keeper_get_subroutes state req request reqd =
                   if stale_reason = "" then `Null else `String stale_reason );
                 ("coverage_gaps", `List coverage_gaps);
                 ("entries", `List entries);
-              ]))
+              ])
       in
       Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/feedback" then

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1032,6 +1032,66 @@ let cached_keeper_config_json config name =
   | other -> `OK, other
 ;;
 
+(* Dashboard hydration fetches every keeper's chat history concurrently on
+   page load. The uncached build ran inline on the main Eio domain at
+   ~1-2 s per keeper (chat tail parse + per-trace trajectory and
+   internal-history tail reads + redaction), so a 16-keeper hydration
+   serialized 15 s+ of main-domain work and pushed unrelated HTTP/WS
+   responses past the dashboard's 35 s client timeout. The cache key
+   embeds the chat file's (mtime, size): the store is append-only, so a
+   newly persisted message changes the key and is served fresh on the
+   next request without an invalidation hook. Enrichment-only drift
+   (trajectory/meta appends with no chat append) is bounded by the TTL,
+   the same staleness contract as the cached trajectory handler above. *)
+let keeper_chat_history_cache_key config name =
+  let base_dir = (config : Workspace.config).base_path in
+  let path = Keeper_chat_store.chat_path ~base_dir ~keeper_name:name in
+  (* Sound-partial freshness component: a missing chat file is its own
+     cache state ("absent"), never conflated with a real (mtime, size)
+     pair. A half-readable stat (racing writer) also maps to "absent",
+     which only costs a recompute on the next request. *)
+  let freshness =
+    match Fs_compat.file_mtime path, Fs_compat.file_size path with
+    | Some mtime, Some size -> Printf.sprintf "%h:%d" mtime size
+    | Some _, None | None, Some _ | None, None -> "absent"
+  in
+  Printf.sprintf "keeper:chat-history:%s:%s:%s"
+    (Workspace.masc_root_dir config) name freshness
+;;
+
+let keeper_chat_history_json config name =
+  let base_dir = (config : Workspace.config).base_path in
+  let messages = Keeper_chat_store.load ~base_dir ~keeper_name:name in
+  let trace_block_by_turn_ref =
+    match Keeper_meta_store.read_meta config name with
+    | Ok (Some m) ->
+      Some
+        (Server_dashboard_http_keeper_api_trace.chat_trace_block_by_turn_ref
+           ~max_lines:trajectory_max_limit
+           ~max_internal_lines:trajectory_max_limit
+           ~config
+           ~keeper_name:name
+           ~allowed_trace_ids:(keeper_chat_allowed_trace_ids m))
+    | Ok None -> None
+    | Error err ->
+      Log.Keeper.warn
+        "dashboard keeper chat history: read_meta failed for %s; trace enrichment skipped: %s"
+        name
+        err;
+      None
+  in
+  Keeper_chat_store.to_json_array ~base_dir ?trace_block_by_turn_ref messages
+;;
+
+let cached_keeper_chat_history_json config name =
+  Dashboard_cache.get_or_compute
+    (keeper_chat_history_cache_key config name)
+    ~ttl:keeper_hot_path_cache_ttl_s
+    (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        keeper_chat_history_json config name))
+;;
+
 let offline_keeper_composite_json ~config name (m : Keeper_meta_contract.keeper_meta) =
   let now = Time_compat.now () in
   let phase = if m.paused then "paused" else "offline" in
@@ -1229,31 +1289,8 @@ let handle_keeper_get_subroutes state req request reqd =
         (error_json "missing keeper name")
     else
       let config = Mcp_server.workspace_config state in
-      let base_dir = config.base_path in
-      let messages =
-        Keeper_chat_store.load ~base_dir ~keeper_name:name
-      in
-      let trace_block_by_turn_ref =
-        match Keeper_meta_store.read_meta config name with
-        | Ok (Some m) ->
-          Some
-            (Server_dashboard_http_keeper_api_trace.chat_trace_block_by_turn_ref
-               ~max_lines:trajectory_max_limit
-               ~max_internal_lines:trajectory_max_limit
-               ~config
-               ~keeper_name:name
-               ~allowed_trace_ids:(keeper_chat_allowed_trace_ids m))
-        | Ok None -> None
-        | Error err ->
-          Log.Keeper.warn
-            "dashboard keeper chat history: read_meta failed for %s; trace enrichment skipped: %s"
-            name
-            err;
-          None
-      in
       Server_auth.respond_json_value_with_cors ~status:`OK request reqd
-        (Keeper_chat_store.to_json_array ~base_dir ?trace_block_by_turn_ref
-           messages)
+        (cached_keeper_chat_history_json config name)
   else if ends_with "/person-notes" then
     (* RFC-0229 P2: keeper-authored person notes for the roster pane.
        Read-only fold over the notes store; same shape as the tool
@@ -1447,73 +1484,93 @@ let handle_keeper_get_subroutes state req request reqd =
         Server_utils.int_query_param req "limit" ~default:50
         |> max 1 |> min 200
       in
-      let entries =
-        Keeper_tool_call_log.read_recent ~keeper_name:name ~n:limit ()
-      in
       let config = (Mcp_server.workspace_config state) in
       let masc_root = Workspace.masc_root_dir config in
-      let latest_ts =
-        List.fold_left
-          (fun acc json ->
-            match Safe_ops.json_float_opt "ts" json with
-            | Some ts -> (
-                match acc with
-                | Some existing when existing >= ts -> acc
-                | _ -> Some ts)
-            | None -> acc)
-          None entries
+      (* [Keeper_tool_call_log.read_recent ~n:limit] Yojson-parses the
+         newest [limit * 5] rows of the fleet-wide dated store to filter
+         one keeper's entries (~3.6 s measured at limit=200), and it ran
+         inline on the main Eio domain for every keeper pane the
+         dashboard hydrates. Cache the built JSON and offload the
+         compute like the trajectory handler above. TTL-bounded
+         staleness also freezes the [latest_age_s] / [health] fields for
+         up to the TTL, which is well inside the freshness SLO this
+         surface reports on. *)
+      let cache_key =
+        Printf.sprintf "keeper:tool-calls:%s:%s:%d" masc_root name limit
       in
-      let dashboard_surface = "/api/v1/keepers/:name/tool-calls" in
-      let latest_age_s =
-        match latest_ts with
-        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
-        | None -> None
+      let json =
+        Dashboard_cache.get_or_compute cache_key
+          ~ttl:keeper_hot_path_cache_ttl_s (fun () ->
+            Domain_pool_ref.submit_io_or_inline (fun () ->
+              let entries =
+                Keeper_tool_call_log.read_recent ~keeper_name:name ~n:limit ()
+              in
+              let latest_ts =
+                List.fold_left
+                  (fun acc json ->
+                    match Safe_ops.json_float_opt "ts" json with
+                    | Some ts -> (
+                        match acc with
+                        | Some existing when existing >= ts -> acc
+                        | Some _ | None -> Some ts)
+                    | None -> acc)
+                  None entries
+              in
+              let dashboard_surface = "/api/v1/keepers/:name/tool-calls" in
+              let latest_age_s =
+                match latest_ts with
+                | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+                | None -> None
+              in
+              let coverage_gaps =
+                Telemetry_coverage_gap.read_recent ~masc_root ~n:32
+                |> List.filter (fun gap ->
+                     String.equal "tool_call_io"
+                       (Safe_ops.json_string ~default:"" "source" gap)
+                     &&
+                     match Safe_ops.json_string_opt "keeper_name" gap with
+                     | Some keeper_name -> String.equal keeper_name name
+                     | None -> true)
+              in
+              let latest_gap =
+                List.rev coverage_gaps |> List.find_opt (fun _ -> true)
+              in
+              let health, stale_reason =
+                match latest_gap with
+                | Some gap ->
+                  ( "coverage_gap",
+                    Safe_ops.json_string ~default:"coverage_gap" "stale_reason"
+                      gap )
+                | None -> (
+                    match latest_age_s with
+                    | None -> ("empty", "no_entries")
+                    | Some age when age > freshness_slo_s ->
+                        ("stale", "freshness_slo_exceeded")
+                    | Some _ -> ("ok", ""))
+              in
+              `Assoc [
+                ("keeper", `String name);
+                ("count", `Int (List.length entries));
+                ("source", `String "tool_call_io");
+                ( "producer",
+                  `String
+                    "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" );
+                ("durable_store", `String (Filename.concat masc_root "tool_calls"));
+                ("dashboard_surface", `String dashboard_surface);
+                ("freshness_slo_s", `Float freshness_slo_s);
+                ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
+                ( "latest_ts_iso",
+                  match latest_ts with
+                  | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+                  | None -> `Null );
+                ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
+                ("health", `String health);
+                ( "stale_reason",
+                  if stale_reason = "" then `Null else `String stale_reason );
+                ("coverage_gaps", `List coverage_gaps);
+                ("entries", `List entries);
+              ]))
       in
-      let coverage_gaps =
-        Telemetry_coverage_gap.read_recent ~masc_root ~n:32
-        |> List.filter (fun gap ->
-             String.equal "tool_call_io"
-               (Safe_ops.json_string ~default:"" "source" gap)
-             &&
-             match Safe_ops.json_string_opt "keeper_name" gap with
-             | Some keeper_name -> String.equal keeper_name name
-             | None -> true)
-      in
-      let latest_gap = List.rev coverage_gaps |> List.find_opt (fun _ -> true) in
-      let health, stale_reason =
-        match latest_gap with
-        | Some gap ->
-          ( "coverage_gap",
-            Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
-        | None -> (
-            match latest_age_s with
-            | None -> ("empty", "no_entries")
-            | Some age when age > freshness_slo_s ->
-                ("stale", "freshness_slo_exceeded")
-            | Some _ -> ("ok", ""))
-      in
-      let json = `Assoc [
-        ("keeper", `String name);
-        ("count", `Int (List.length entries));
-        ("source", `String "tool_call_io");
-        ( "producer",
-          `String
-            "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" );
-        ("durable_store", `String (Filename.concat masc_root "tool_calls"));
-        ("dashboard_surface", `String dashboard_surface);
-        ("freshness_slo_s", `Float freshness_slo_s);
-        ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
-        ( "latest_ts_iso",
-          match latest_ts with
-          | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
-          | None -> `Null );
-        ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
-        ("health", `String health);
-        ( "stale_reason",
-          if stale_reason = "" then `Null else `String stale_reason );
-        ("coverage_gaps", `List coverage_gaps);
-        ("entries", `List entries);
-      ] in
       Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/feedback" then
     (* keeper-v2 #9: aggregated response-feedback tally (read API).

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -35,6 +35,10 @@ let compaction_snapshot_manifest_tail_max_lines =
 (* Maximum number of trajectory/trace entries returned per query. *)
 let trajectory_max_limit = 500
 
+(* Maximum per-keeper entries for /tool-calls; also sizes the shared
+   fleet-row window that per-keeper responses derive from. *)
+let tool_calls_limit_max = 200
+
 let cached_assoc_body_or_self cached fields =
   match List.assoc_opt "body" fields with
   | Some body -> body
@@ -1287,6 +1291,13 @@ let handle_keeper_get_subroutes state req request reqd =
     if name = "" then
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
         (error_json "missing keeper name")
+    else if not (Keeper_config.validate_name name) then
+      (* Reject before touching the cache: the cache key embeds the raw
+         name, so unvalidated garbage names would mint unbounded
+         process-global cache entries (the sibling /tool-calls route
+         already validates). *)
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json (Printf.sprintf "invalid keeper name: %s" name))
     else
       let config = Mcp_server.workspace_config state in
       Server_auth.respond_json_value_with_cors ~status:`OK request reqd
@@ -1482,19 +1493,40 @@ let handle_keeper_get_subroutes state req request reqd =
     else
       let limit =
         Server_utils.int_query_param req "limit" ~default:50
-        |> max 1 |> min 200
+        |> max 1 |> min tool_calls_limit_max
       in
       let config = (Mcp_server.workspace_config state) in
       let masc_root = Workspace.masc_root_dir config in
-      (* [Keeper_tool_call_log.read_recent ~n:limit] Yojson-parses the
-         newest [limit * 5] rows of the fleet-wide dated store to filter
-         one keeper's entries (~3.6 s measured at limit=200), and it ran
-         inline on the main Eio domain for every keeper pane the
-         dashboard hydrates. Cache the built JSON and offload the
-         compute like the trajectory handler above. TTL-bounded
-         staleness also freezes the [latest_age_s] / [health] fields for
-         up to the TTL, which is well inside the freshness SLO this
-         surface reports on. *)
+      (* The per-keeper read Yojson-parsed the newest [limit * 5] rows of
+         the fleet-wide dated store just to filter one keeper (~3.6 s
+         measured at limit=200), inline on the main Eio domain for every
+         keeper pane the dashboard hydrates — a 16-keeper cold hydration
+         ran 16 identical fleet parses. Parse the fleet window once per
+         TTL on the CPU pool lane (the cost is JSON parsing, not
+         blocking IO) and derive each keeper's slice from it. The window
+         is sized to reproduce [read_recent]'s coverage at this
+         endpoint's maximum limit; deriving smaller limits from the
+         wider window can only widen per-keeper coverage, never narrow
+         it. TTL-bounded staleness also freezes the [latest_age_s] /
+         [health] fields for up to the TTL, which is well inside the
+         freshness SLO this surface reports on. *)
+      let fleet_rows =
+        match
+          Dashboard_cache.get_or_compute
+            (Printf.sprintf "keeper:tool-calls:fleet-rows:%s" masc_root)
+            ~ttl:keeper_hot_path_cache_ttl_s (fun () ->
+              Domain_pool_ref.submit_cpu_or_inline (fun () ->
+                `List
+                  (Keeper_tool_call_log.read_recent_rows
+                     ~n:
+                       (tool_calls_limit_max
+                        * Keeper_tool_call_log.read_over_scan_factor)
+                     ())))
+        with
+        | `List rows -> rows
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _
+        | `Assoc _ -> []
+      in
       let cache_key =
         Printf.sprintf "keeper:tool-calls:%s:%s:%d" masc_root name limit
       in
@@ -1503,7 +1535,8 @@ let handle_keeper_get_subroutes state req request reqd =
           ~ttl:keeper_hot_path_cache_ttl_s (fun () ->
             Domain_pool_ref.submit_io_or_inline (fun () ->
               let entries =
-                Keeper_tool_call_log.read_recent ~keeper_name:name ~n:limit ()
+                Keeper_tool_call_log.filter_rows_for_keeper
+                  ~keeper_name:name ~n:limit fleet_rows
               in
               let latest_ts =
                 List.fold_left

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -261,6 +261,28 @@ let test_to_json_array_exposes_id () =
             (List.mem_assoc "id" fields)
       | _ -> Alcotest.fail "expected a non-empty json array of assoc rows")
 
+(* The dashboard /chat/history cache keys freshness off [chat_path]'s
+   (mtime, size): the store is append-only, so every persisted message
+   must grow the file. Size is the load-bearing component (mtime
+   granularity can collapse two appends into one clock tick). *)
+let test_chat_path_size_grows_on_append () =
+  let base_dir = temp_base_path "keeper-chat-store-path-freshness" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-path-freshness" in
+      let path = K.chat_path ~base_dir ~keeper_name in
+      Alcotest.(check bool) "path names the keeper's jsonl" true
+        (Filename.basename path = keeper_name ^ ".jsonl");
+      K.append_user_message ~base_dir ~keeper_name ~content:"first" ();
+      Alcotest.(check bool) "append creates the file at chat_path" true
+        (Sys.file_exists path);
+      let size_after_first = (Unix.stat path).Unix.st_size in
+      K.append_user_message ~base_dir ~keeper_name ~content:"second" ();
+      let size_after_second = (Unix.stat path).Unix.st_size in
+      Alcotest.(check bool) "second append strictly grows the file" true
+        (size_after_second > size_after_first))
+
 let test_recent_direct_context_renders_prior_reply_and_tool_evidence () =
   let base_dir = temp_base_path "keeper-chat-recent-context" in
   Fun.protect
@@ -1924,6 +1946,8 @@ let () =
             test_message_id_minted_unique_and_stable;
           Alcotest.test_case "legacy row gets deterministic id (R3)" `Quick
             test_legacy_row_gets_deterministic_id;
+          Alcotest.test_case "chat_path size grows on append (cache key)" `Quick
+            test_chat_path_size_grows_on_append;
           Alcotest.test_case "to_json_array exposes id (R3)" `Quick
             test_to_json_array_exposes_id;
           Alcotest.test_case "recent context renders reply and tool evidence" `Quick

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -100,6 +100,39 @@ let test_read_recent_keeper_filter () =
     Alcotest.(check int) "bob gets 1 entry" 1 (List.length bob_entries);
     Alcotest.(check int) "all gets 2 entries" 2 (List.length all_entries))
 
+(* The dashboard /tool-calls handler derives each keeper's slice from one
+   shared fleet read instead of per-keeper [read_recent] calls. The
+   derivation must be observationally equal to [read_recent]. *)
+let test_fleet_rows_derivation_matches_read_recent () =
+  with_tmp_log (fun () ->
+    List.iter
+      (fun (keeper, tool) ->
+        Keeper_tool_call_log.log_call
+          ~keeper_name:keeper ~tool_name:tool
+          ~input:(`Assoc []) ~output_text:"out"
+          ~success:true ~duration_ms:1.0 ())
+      [ ("alice", "t1"); ("bob", "t2"); ("alice", "t3");
+        ("carol", "t4"); ("alice", "t5"); ("bob", "t6") ];
+    let n = 2 in
+    let fleet =
+      Keeper_tool_call_log.read_recent_rows
+        ~n:(n * Keeper_tool_call_log.read_over_scan_factor) ()
+    in
+    List.iter
+      (fun keeper ->
+        let direct =
+          Keeper_tool_call_log.read_recent ~keeper_name:keeper ~n ()
+        in
+        let derived =
+          Keeper_tool_call_log.filter_rows_for_keeper
+            ~keeper_name:keeper ~n fleet
+        in
+        Alcotest.(check (list string))
+          (Printf.sprintf "derived slice equals read_recent for %s" keeper)
+          (List.map Yojson.Safe.to_string direct)
+          (List.map Yojson.Safe.to_string derived))
+      [ "alice"; "bob"; "carol"; "absent-keeper" ])
+
 let test_exact_oas_occurrence_persisted () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
@@ -1217,6 +1250,8 @@ let () =
         [ eio_test "n=0 returns []" test_read_recent_n_zero
         ; eio_test "n<0 returns []" test_read_recent_n_negative
         ; eio_test "keeper filter" test_read_recent_keeper_filter
+        ; eio_test "fleet-row derivation equals read_recent"
+            test_fleet_rows_derivation_matches_read_recent
         ; eio_test "exact OAS occurrence" test_exact_oas_occurrence_persisted
         ] )
     ; ( "redaction",


### PR DESCRIPTION
## 문제

대시보드가 페이지 로드 시 keeper 전원(현재 16개)의 hydration 요청을 동시에 발사하는데, 그중 두 엔드포인트가 캐시·오프로드 없이 **main Eio domain 인라인**으로 무거운 읽기를 수행했다:

| 엔드포인트 | 실측 (라이브 서버) | 원인 |
|---|---|---|
| `GET /api/v1/keepers/:name/chat/history` | 키퍼당 0.9~1.8s | chat tail 파싱 + trace_id별 trajectory/internal-history tail 읽기 + redaction, 전부 요청 fiber에서 |
| `GET /api/v1/keepers/:name/tool-calls?limit=200` | 3.6s | fleet 공용 dated store에서 최신 `limit*5`행(행당 수 KB~수십 KB)을 매 요청 Yojson 파싱 후 keeper 필터 |

16-keeper hydration이 main domain에서 직렬화되면 수십 초가 점유되고, 같은 도메인의 **무관한 응답들이 전부 프론트 35s 클라이언트 타임아웃**(#3319에서 규명된 frontend 상수)을 넘긴다. 오늘 라이브 증상: `dashboard/subscribe` websocket RPC 타임아웃, `/dashboard/execution` 35s 타임아웃, keeper chat/tool-call hydration 전멸. 스톨 중 `sample` 프로파일에서 main thread가 Yojson lex(`caml_lex_engine` top-of-stack 1위)에 지배되는 것을 확인했다.

같은 파일의 `/trajectory`(#19416, RFC-0204 Phase 2 계열)와 `/config` 핸들러는 이미 `Dashboard_cache.get_or_compute` + `Domain_pool_ref.submit_io_or_inline` 경계를 쓰고 있었다. 이 PR은 남아 있던 두 hydration 엔드포인트를 동일한 read-side 경계로 옮긴다.

## 변경

- `server_dashboard_http_keeper_api.ml`
  - `cached_keeper_chat_history_json`: 기존 인라인 빌드를 그대로 추출해 캐시+IO 풀 오프로드로 감쌈. 캐시 키에 **append-only chat 파일의 (mtime, size)** 를 포함 — 새 메시지가 persist되면 키가 바뀌므로 invalidation 훅 없이 다음 요청에서 즉시 신선하게 서빙된다(대화형 UX 보존). trajectory/meta만 변한 enrichment drift는 기존 hot-path TTL(30s)로 바운드 — `/trajectory` 캐시와 동일한 staleness 계약.
  - `/tool-calls`: JSON 빌드 전체를 캐시+오프로드로 감쌈(TTL-only 키, `/trajectory` 선례와 동일). `latest_age_s`/`health` 필드가 TTL만큼 동결되는 것은 이 surface의 freshness SLO 대비 무시 가능 — 주석에 명시.
- `keeper_chat_store.mli`: freshness 키 계산용 `chat_path` 노출 (순수 경로 함수).
- `test_keeper_chat_store.ml`: 캐시 키 전제(append마다 파일 size 순증) 증명 테스트 추가.

응답 shape/에러 경로는 변경 없음 (빌드 로직 verbatim 이동).

## 검증

- `dune build --root . @check` 통과, `bin/main_eio.exe` 빌드 통과
- `test_keeper_chat_store` 49/49 통과 (신규 1 포함)
- 배포 후 라이브 재측정 예정 (chat/history cold ~1s → warm ms대, hydration 폭풍에서 main domain 점유 소멸 확인)

## 관련

- 발견 task: masc task-2302 (본 세션 진단 기록)
- 인접 이슈 (경계 구분): #24316·#24331 (chat persistence 쓰기 경로 수명 스캔 — 본 PR은 읽기 경로만), #23464·#24166 (history paging/커서 — 본 PR은 페이징 의미 불변), #24912 (systhread fan-out main-domain starvation — 별개 성분), #24697 (2s snapshot loop 잔여 부하 — 별도 트랙, 콜사이트 패치 금지 대상이라 본 PR에서 건드리지 않음)
- 35s 상수 기원: #3319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
