### PR TITLE
refactor(keeper)!: hard-delete dead working-context capacity

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -669,7 +669,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
           let max_context_resolution =
             Keeper_context_runtime.resolve_max_context_resolution_of_meta m
           in
-          let primary_max_context = max_context_resolution.effective_budget in
           let context_budget =
             Keeper_context_runtime.context_budget_json_of_resolution
               ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta m)
@@ -689,7 +688,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                      let (_session, ctx_opt) =
                        Keeper_execution.load_context_from_checkpoint
                          ~trace_id:(Keeper_id.Trace_id.to_string m.runtime.trace_id)
-                         ~primary_model_max_tokens:primary_max_context
                          ~base_dir
                      in
                      match ctx_opt with

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -309,7 +309,6 @@ let run_turn
       ~meta
       ~profile_defaults
       ~base_dir
-      ~max_context
       ~runtime_id
       ?temperature
       ?shared_context

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -375,11 +375,11 @@ let compact_for_request_typed
       ~message_count:before_messages;
     { context = ctx; decision = Rejected (trigger, reason); evidence = None }
   | Ok requested ->
+    let checkpoint =
+      { (checkpoint_of_context ctx) with messages = requested.messages }
+    in
     let compacted_ctx =
-      { ctx with
-        checkpoint =
-          { (checkpoint_of_context ctx) with messages = requested.messages }
-      }
+      sync_oas_context { checkpoint }
     in
     let after_bytes = serialized_bytes compacted_ctx in
     let reject reason =

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -30,26 +30,14 @@ let resume_checkpoint_of_context (ctx : working_context) : Agent_sdk.Checkpoint.
     context = checkpoint_context;
   }
 
-(* OAS no longer persists a cumulative-token cap on the checkpoint
-   (budget enforcement removed). The per-response output max_tokens is
-   resolved from the model default at restore time. *)
-let checkpoint_max_tokens (_cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  fallback
-
-let context_of_oas_checkpoint
-    (cp : Agent_sdk.Checkpoint.t)
-    ~(primary_model_max_tokens : int) : working_context =
+let context_of_oas_checkpoint (cp : Agent_sdk.Checkpoint.t) : working_context =
   let system_prompt = Option.value ~default:"" cp.system_prompt in
-  let max_tokens =
-    checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
-  in
   let messages = cp.messages in
   let context = Agent_sdk.Context.copy ~eio:true cp.context in
   let checkpoint =
     { cp with system_prompt = Some system_prompt; messages; context }
   in
-  sync_oas_context
-    { checkpoint; max_tokens }
+  sync_oas_context { checkpoint }
 
 let checkpoint_for_persistence
     ~(multimodal_policy : Keeper_types_profile.multimodal_policy)
@@ -190,7 +178,7 @@ let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
 (* Checkpoint Loading                                                *)
 (* ================================================================ *)
 
-let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
+let load_context_from_checkpoint ~trace_id ~base_dir =
   let session = create_session ~session_id:trace_id ~base_dir in
   let oas_result =
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
@@ -236,13 +224,7 @@ let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
   in
   match oas_checkpoint with
   | Some checkpoint ->
-      let ctx =
-        context_of_oas_checkpoint checkpoint ~primary_model_max_tokens
-      in
-      let ctx =
-        if primary_model_max_tokens <= 0 then ctx
-        else sync_oas_context { ctx with max_tokens = primary_model_max_tokens }
-      in
+      let ctx = context_of_oas_checkpoint checkpoint in
       (session, Some ctx)
   | None ->
       (* No canonical OAS checkpoint is available. Non-trivial OAS errors

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -11,24 +11,18 @@ type working_context = Keeper_types.working_context
 type session_context = Keeper_types.session_context
 
 val message_count : working_context -> int
-val max_tokens_of_context : working_context -> int
-
-(** Replace the working-context's [max_tokens]; mirrors the value
-    into [checkpoint.max_total_tokens]. *)
-val with_max_tokens : working_context -> int -> working_context
 
 (** Re-export of [Agent_sdk.Types.text_of_message]. *)
 val text_of_message : Agent_sdk.Types.message -> string
 
 (** {1 Working-context construction & mutation} *)
 
-(** Construct a fresh working context with the given system prompt
-    and token budget.
+(** Construct a fresh working context with the given system prompt.
 
     [~eio:true] selects the OAS context backend required when the context can
     be touched by Eio fibers. Use [~eio:false] only for synchronous tests or
     serialization fixtures. *)
-val create : eio:bool -> system_prompt:string -> max_tokens:int -> working_context
+val create : eio:bool -> system_prompt:string -> working_context
 
 val set_system_prompt :
   working_context -> system_prompt:string -> working_context
@@ -73,8 +67,6 @@ val serialize_context : working_context -> string
 val serialized_bytes : working_context -> int
 (** Exact byte length of {!serialize_context}. This is structural observation,
     not a token estimate or provider context-window admission signal. *)
-val deserialize_context : eio:bool -> string -> max_tokens:int -> working_context
-val context_to_json : working_context -> Yojson.Safe.t
 
 (** {1 Session lifecycle} *)
 
@@ -172,21 +164,17 @@ val save_oas_checkpoint_if_source :
 (** {1 OAS checkpoint inspection} *)
 
 val checkpoint_generation : Agent_sdk.Checkpoint.t -> fallback:int -> int
-val checkpoint_max_tokens : Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 (** Project an OAS checkpoint to a working context without rewriting its
     messages. *)
 val context_of_oas_checkpoint :
-  Agent_sdk.Checkpoint.t ->
-  primary_model_max_tokens:int ->
-  working_context
+  Agent_sdk.Checkpoint.t -> working_context
 
 (** Load the canonical OAS checkpoint for a given
     [trace_id]. Returns the session plus the recovered
     working_context (or [None] when nothing was found). *)
 val load_context_from_checkpoint :
   trace_id:string ->
-  primary_model_max_tokens:int ->
   base_dir:string ->
   session_context * working_context option
 

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -38,21 +38,13 @@ let checkpoint_of_context (ctx : working_context) = ctx.checkpoint
 
 let oas_context_of_context (ctx : working_context) = ctx.checkpoint.context
 
-let max_tokens_of_context (ctx : working_context) =
-  ctx.max_tokens
-
-let with_max_tokens (ctx : working_context) max_tokens =
-  (* OAS no longer carries a cumulative-token cap on the checkpoint; the
-     working_context [max_tokens] is the per-response output limit only. *)
-  { ctx with max_tokens }
-
 let system_prompt_of_context (ctx : working_context) =
   Option.value ~default:"" ctx.checkpoint.system_prompt
 
 let messages_of_context (ctx : working_context) =
   ctx.checkpoint.messages
 
-let empty_runtime_checkpoint ~system_prompt ~messages ~max_tokens
+let empty_runtime_checkpoint ~system_prompt ~messages
     ~(context : Agent_sdk.Context.t) : Agent_sdk.Checkpoint.t =
   {
     Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
@@ -88,12 +80,12 @@ let message_count (ctx : working_context) =
 let create_oas_context ~eio =
   if eio then Agent_sdk.Context.create () else Agent_sdk.Context.create_sync ()
 
-let create ~eio ~system_prompt ~max_tokens =
+let create ~eio ~system_prompt =
   let context = create_oas_context ~eio in
   let checkpoint =
-    empty_runtime_checkpoint ~system_prompt ~messages:[] ~max_tokens ~context
+    empty_runtime_checkpoint ~system_prompt ~messages:[] ~context
   in
-  { checkpoint; max_tokens }
+  { checkpoint }
 
 let set_system_prompt (ctx : working_context) ~system_prompt =
   let messages =
@@ -107,13 +99,13 @@ let set_system_prompt (ctx : working_context) ~system_prompt =
   let checkpoint =
     { ctx.checkpoint with system_prompt = Some system_prompt; messages }
   in
-  { ctx with checkpoint }
+  { checkpoint }
 
 let append ctx (msg : Agent_sdk.Types.message) =
   let checkpoint =
     { ctx.checkpoint with messages = messages_of_context ctx @ [ msg ] }
   in
-  { ctx with checkpoint }
+  { checkpoint }
 
 let append_many ctx msgs =
   List.fold_left append ctx msgs
@@ -141,35 +133,11 @@ let serialize_context (ctx : working_context) : string =
       `String
         (Inference_utils.sanitize_text_utf8 (system_prompt_of_context ctx)) );
     ("messages", `List (List.map message_to_json (messages_of_context ctx)));
-    ("max_tokens", `Int (max_tokens_of_context ctx));
   ] in
   Yojson.Safe.to_string json
 
 let serialized_bytes (ctx : working_context) : int =
   String.length (serialize_context ctx)
-
-let deserialize_context ~eio (s : string) ~max_tokens : working_context =
-  let json = Yojson.Safe.from_string s in
-  let system_prompt = (match Json_util.assoc_member_opt "system_prompt" json with Some (`String s) -> s | _ -> "") in
-  let messages =
-    (match Json_util.assoc_member_opt "messages" json with Some (`List l) -> l | _ -> []) |> List.map message_of_json
-  in
-  let context = create_oas_context ~eio in
-  let checkpoint =
-    empty_runtime_checkpoint ~system_prompt ~messages ~max_tokens ~context
-  in
-  sync_oas_context
-    { checkpoint; max_tokens }
-
-let context_to_json (ctx : working_context) : Yojson.Safe.t =
-  `Assoc [
-    ( "system_prompt",
-      `String
-        (Inference_utils.sanitize_text_utf8 (system_prompt_of_context ctx)) );
-    ("messages", `List (List.map message_to_json (messages_of_context ctx)));
-    ("max_tokens", `Int (max_tokens_of_context ctx));
-  ]
-
 
 let create_session ~session_id ~base_dir =
   let session_dir = Filename.concat base_dir session_id in

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -21,14 +21,12 @@ type working_context = Keeper_types.working_context
 type session_context = Keeper_types.session_context
 
 let text_of_message = Keeper_context_core.text_of_message
-let max_tokens_of_context = Keeper_context_core.max_tokens_of_context
 let message_count = Keeper_context_core.message_count
 let serialized_bytes = Keeper_context_core.serialized_bytes
 let checkpoint_of_context = Keeper_context_core.checkpoint_of_context
 let resume_checkpoint_of_context =
   Keeper_context_core.resume_checkpoint_of_context
 let oas_context_of_context = Keeper_context_core.oas_context_of_context
-let with_max_tokens = Keeper_context_core.with_max_tokens
 let system_prompt_of_context = Keeper_context_core.system_prompt_of_context
 let messages_of_context = Keeper_context_core.messages_of_context
 let create = Keeper_context_core.create
@@ -41,8 +39,6 @@ let role_of_string_opt = Keeper_context_core.role_of_string_opt
 let message_to_json = Keeper_context_core.message_to_json
 let message_of_json = Keeper_context_core.message_of_json
 let serialize_context = Keeper_context_core.serialize_context
-let deserialize_context = Keeper_context_core.deserialize_context
-let context_to_json = Keeper_context_core.context_to_json
 let create_session = Keeper_context_core.create_session
 let persist_message = Keeper_context_core.persist_message
 
@@ -52,7 +48,6 @@ let usage_of_response = Keeper_context_core.usage_of_response
 let total_tokens = Keeper_context_core.total_tokens
 
 let log_keeper_exn = Keeper_context_core.log_keeper_exn
-let checkpoint_max_tokens = Keeper_context_core.checkpoint_max_tokens
 let context_of_oas_checkpoint = Keeper_context_core.context_of_oas_checkpoint
 let save_oas_checkpoint = Keeper_context_core.save_oas_checkpoint
 let load_context_from_checkpoint = Keeper_context_core.load_context_from_checkpoint

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -18,16 +18,14 @@ type session_context = Keeper_types.session_context
 (** {1 Working Context Operations} *)
 
 val text_of_message : Agent_sdk.Types.message -> string
-val max_tokens_of_context : working_context -> int
 val message_count : working_context -> int
 val serialized_bytes : working_context -> int
 val checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
 val resume_checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
 val oas_context_of_context : working_context -> Agent_sdk.Context.t
-val with_max_tokens : working_context -> int -> working_context
 val system_prompt_of_context : working_context -> string
 val messages_of_context : working_context -> Agent_sdk.Types.message list
-val create : eio:bool -> system_prompt:string -> max_tokens:int -> working_context
+val create : eio:bool -> system_prompt:string -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
 val append : working_context -> Agent_sdk.Types.message -> working_context
 val append_many : working_context -> Agent_sdk.Types.message list -> working_context
@@ -43,8 +41,6 @@ val role_of_string_opt : string -> Agent_sdk.Types.role option
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
 val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
 val serialize_context : working_context -> string
-val deserialize_context : eio:bool -> string -> max_tokens:int -> working_context
-val context_to_json : working_context -> Yojson.Safe.t
 val create_session : session_id:string -> base_dir:string -> session_context
 val persist_message : ?source:string -> session_context -> Agent_sdk.Types.message -> unit
 
@@ -58,11 +54,9 @@ val total_tokens : Agent_sdk.Types.api_usage -> int
 (** {1 Keeper Context Lifecycle} *)
 
 val log_keeper_exn : label:string -> exn -> unit
-val checkpoint_max_tokens : Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 val context_of_oas_checkpoint
   :  Agent_sdk.Checkpoint.t
-  -> primary_model_max_tokens:int
   -> working_context
 
 val save_oas_checkpoint
@@ -113,7 +107,6 @@ type compaction_recovery =
 
 val load_context_from_checkpoint
   :  trace_id:string
-  -> primary_model_max_tokens:int
   -> base_dir:string
   -> session_context * working_context option
 
@@ -134,7 +127,6 @@ val apply_post_turn_lifecycle_with_resilience_handles
   :  resilience_audit_store:Shared_audit.Store.t option
   -> resilience_strategy_executor:Resilience.Recovery.strategy_executor option
   -> meta:keeper_meta
-  -> primary_model_max_tokens:int
   -> checkpoint:Agent_sdk.Checkpoint.t option
   -> post_turn_lifecycle
 
@@ -177,7 +169,6 @@ val recover_latest_checkpoint_for_compaction
   :  base_dir:string
   -> meta:keeper_meta
   -> trigger:Compaction_trigger.t
-  -> primary_model_max_tokens:int
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -20,7 +20,6 @@ val log_keeper_exn : label:string -> exn -> unit
 (** Load keeper context from checkpoint for resumption. *)
 val load_context_from_checkpoint :
   trace_id:string ->
-  primary_model_max_tokens:int ->
   base_dir:string ->
   Keeper_context_runtime.session_context * Keeper_context_runtime.working_context option
 

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -25,24 +25,11 @@ let write_heartbeat_snapshot
   let metrics_store =
     Keeper_types_support.keeper_metrics_store ctx.config meta_current.name
   in
-  let runtime_models =
-    Provider_runtime_projection.default_execution_model_strings
-      ((Keeper_meta_contract.runtime_id_of_meta meta_current))
-  in
-  let max_runtime_context =
-    let resolution =
-      Keeper_context_runtime.resolve_max_context_resolution
-        ~requested_override:meta_current.max_context_override
-        runtime_models
-    in
-    resolution.effective_budget
-  in
   let base_dir = session_base_dir ctx.config in
   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)));
   let _session, ctx_opt =
     load_context_from_checkpoint
       ~trace_id:(Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
-      ~primary_model_max_tokens:max_runtime_context
       ~base_dir
   in
   let message_count =

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -25,10 +25,6 @@ type failure =
   | Recovery of
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
-let primary_max_context meta =
-  let resolution = Keeper_context_runtime.resolve_max_context_resolution_of_meta meta in
-  resolution.effective_budget
-;;
 let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
   let trigger = recovery.Keeper_context_runtime.trigger in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
@@ -108,7 +104,6 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
             ~base_dir
             ~meta
             ~trigger:Compaction_trigger.Manual
-            ~primary_model_max_tokens:(primary_max_context meta)
         with
         | Error error ->
           let failure_dispatch =

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -379,7 +379,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
     ~(resilience_audit_store : Shared_audit.Store.t option)
     ~(resilience_strategy_executor : Resilience.Recovery.strategy_executor option)
     ~(meta : keeper_meta)
-    ~(primary_model_max_tokens : int)
     ~(checkpoint : Agent_sdk.Checkpoint.t option) : post_turn_lifecycle =
   (* Reviewer #13214: an executor without an audit store would let
      retry/fallback/handoff/abort callbacks mutate live state
@@ -427,11 +426,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
         message_count = 0;
       }
   | Some cp ->
-      let ctx =
-        context_of_oas_checkpoint
-          cp
-          ~primary_model_max_tokens
-      in
+      let ctx = context_of_oas_checkpoint cp in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -495,7 +490,6 @@ let recover_latest_checkpoint_for_compaction
     ~(base_dir : string)
     ~(meta : keeper_meta)
     ~(trigger : Compaction_trigger.t)
-    ~(primary_model_max_tokens : int)
   : (compaction_recovery, compaction_recovery_error) result
   =
   let session = create_session ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id) ~base_dir in
@@ -527,7 +521,7 @@ let recover_latest_checkpoint_for_compaction
     let turn_generation =
       checkpoint_generation checkpoint ~fallback:meta.runtime.generation
     in
-    let ctx = context_of_oas_checkpoint checkpoint ~primary_model_max_tokens in
+    let ctx = context_of_oas_checkpoint checkpoint in
     let retry_meta =
       if turn_generation = meta.runtime.generation then meta
       else map_runtime (fun rt -> { rt with generation = turn_generation }) meta

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -54,7 +54,6 @@ val apply_post_turn_lifecycle_with_resilience_handles :
   resilience_audit_store:Shared_audit.Store.t option ->
   resilience_strategy_executor:Resilience.Recovery.strategy_executor option ->
   meta:Keeper_meta_contract.keeper_meta ->
-  primary_model_max_tokens:int ->
   checkpoint:Agent_sdk.Checkpoint.t option ->
   post_turn_lifecycle
 (** Apply the keeper post-turn lifecycle with explicit resilience handles.
@@ -90,5 +89,4 @@ val recover_latest_checkpoint_for_compaction :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   trigger:Compaction_trigger.t ->
-  primary_model_max_tokens:int ->
   (compaction_recovery, compaction_recovery_error) result

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -69,7 +69,6 @@ let prepare_run_context
       ~(meta : keeper_meta)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ~(base_dir : string)
-      ~(max_context : int)
       ~(runtime_id : string)
       ?temperature
       ?shared_context
@@ -115,7 +114,6 @@ let prepare_run_context
   let session, ctx_opt =
     Keeper_context_runtime.load_context_from_checkpoint
       ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-      ~primary_model_max_tokens:max_context
       ~base_dir
   in
   let loaded_checkpoint_present = Option.is_some ctx_opt in
@@ -138,7 +136,6 @@ let prepare_run_context
     | Some c -> c
     | None ->
       Keeper_context_runtime.create ~eio:true ~system_prompt:base_system_prompt
-        ~max_tokens:max_context
   in
   let ctx_work =
     Keeper_context_runtime.set_system_prompt base_ctx ~system_prompt:base_system_prompt

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -35,7 +35,6 @@ val prepare_run_context :
   -> meta:keeper_meta
   -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
   -> base_dir:string
-  -> max_context:int
   -> runtime_id:string
   -> ?temperature:float
   -> ?shared_context:Agent_sdk.Context.t

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -369,7 +369,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
       let max_context_resolution =
         Keeper_context_runtime.resolve_max_context_resolution_of_meta m
       in
-      let primary_max_context = max_context_resolution.effective_budget in
       let context_budget =
         Keeper_context_runtime.context_budget_json_of_resolution
           ~runtime_id:(runtime_id_of_meta m)
@@ -381,7 +380,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              let (_session, ctx_opt) =
                load_context_from_checkpoint
                  ~trace_id:(Keeper_id.Trace_id.to_string m.runtime.trace_id)
-                 ~primary_model_max_tokens:primary_max_context
                  ~base_dir
              in
              ctx_opt

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -655,12 +655,12 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
             else
               []
           in
-          let cleared_ctx =
-            {
-              wctx with
-              checkpoint = { messages = cleared_messages };
+          let checkpoint =
+            { (Keeper_context_runtime.checkpoint_of_context wctx) with
+              messages = cleared_messages
             }
           in
+          let cleared_ctx = { checkpoint } in
           (* Increment generation from meta to signal a new context epoch.
              Using a hardcoded value would violate generation monotonicity
              — the keeper_unified_turn retry loop uses meta.runtime.generation

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -658,11 +658,7 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
           let cleared_ctx =
             {
               wctx with
-              checkpoint =
-                {
-                  (Keeper_context_runtime.checkpoint_of_context wctx) with
-                  messages = cleared_messages;
-                };
+              checkpoint = { messages = cleared_messages };
             }
           in
           (* Increment generation from meta to signal a new context epoch.

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -489,20 +489,6 @@ let keeper_reset_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_reset ctx args : tool_result =
   keeper_reset_body ~config:ctx.config args
 
-(** Resolve the primary model max context for a keeper.
-
-    Returns the resolved primary provider/runtime context window, separate from
-    any requested [max_context_override].
-    Returns the configured default Runtime capacity when meta is unavailable. *)
-let resolve_primary_max_context (meta : Keeper_meta_contract.keeper_meta option) : int =
-  match meta with
-  | None -> Runtime.default_max_context ()
-  | Some meta ->
-    let resolution =
-      Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
-    in
-    resolution.effective_budget
-
 let manual_compaction_wakeup_observation ~base_path keeper_name =
   match
     Keeper_registry.wakeup_running
@@ -647,11 +633,9 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
         | Some meta -> Keeper_id.Trace_id.to_string meta.runtime.trace_id
         | None -> Keeper_context_runtime.generate_trace_id ()
       in
-      let max_tokens = resolve_primary_max_context meta_for_trace in
       let session, ctx_opt =
         Keeper_context_runtime.load_context_from_checkpoint
           ~trace_id
-          ~primary_model_max_tokens:max_tokens
           ~base_dir
       in
       let checkpoint_found = Option.is_some ctx_opt in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -871,7 +871,7 @@ let run_keeper_invocation_turn_admitted
               restart_keepalive_after_message_turn ctx meta;
               Progress.stop_tracking turn_task_id;
               tool_result_error user_message
-	            | Ok (result, final_max_runtime_context) ->
+            | Ok (result, _) ->
               (try
                  let _ = Trajectory.finalize trajectory_acc
                    Trajectory.Completed in
@@ -889,7 +889,6 @@ let run_keeper_invocation_turn_admitted
                   ~resilience_strategy_executor:
                     resilience_handles.resilience_strategy_executor
 	                  ~meta
-	                  ~primary_model_max_tokens:final_max_runtime_context
                   ~checkpoint:result.checkpoint
                 |> resilience_handles.sync_lifecycle_meta
               in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -119,13 +119,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   ~fallback_message:env_message_gate
                   ~fallback_token:env_token_gate
               in
-              let primary_max_context =
-                match p.max_context_override_opt with
-                | Some v -> v
-                (* Boundary: Keeper consumes an opaque context budget, not a
-                   provider/model identity. *)
-                | None -> Runtime.default_max_context ()
-              in
               Progress.Tracker.step tracker ~message:"Initializing session directory" ();
               let trace_id = generate_trace_id () in
               match Keeper_id.Trace_id.of_string trace_id with
@@ -210,7 +203,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       in
       let ctx0 =
         Keeper_context_runtime.create ~eio:true ~system_prompt
-          ~max_tokens:primary_max_context
       in
       (* next_generation keys the per-(keeper, trace) counter by the trace_id
          string; episodes live under that same string dir (ensure_dir/of

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -139,7 +139,6 @@ let recover_provider_context_overflow_in_lane
       ~(config : Workspace.config)
       ~base_dir
       ~(meta : keeper_meta)
-      ~primary_model_max_tokens
       error
   =
   match context_overflow_event_of_error error with
@@ -201,7 +200,6 @@ let recover_provider_context_overflow_in_lane
                  ~base_dir
                  ~meta
                  ~trigger
-                 ~primary_model_max_tokens
              with
              | Error error ->
                retry_after_started
@@ -1079,7 +1077,6 @@ dominant source of the observed CAS race exhaustion after
                       ~config
                       ~base_dir
                       ~meta
-                      ~primary_model_max_tokens:final_execution.max_context
                       err
                   in
                   let source_lease_disposition, turn_state =
@@ -1144,7 +1141,6 @@ dominant source of the observed CAS race exhaustion after
                       ~meta
                       ~turn_ctx_cell
                       ~observation
-                      ~final_execution
                       ~latency_ms
                       ~degraded_retry_applied
                       ~degraded_retry_runtime

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -16,7 +16,6 @@ let turn_cost result = KUM.estimate_usage_cost_usd result.Keeper_agent_run.usage
 let apply_lifecycle
       ~config
       ~meta
-      ~final_execution
       (result : Keeper_agent_run.run_result)
   =
   let resilience_handles = KCB.post_turn_resilience_handles ~config ~meta in
@@ -25,7 +24,6 @@ let apply_lifecycle
       ~resilience_audit_store:resilience_handles.resilience_audit_store
       ~resilience_strategy_executor:resilience_handles.resilience_strategy_executor
       ~meta
-      ~primary_model_max_tokens:final_execution.KCB.max_context
       ~checkpoint:result.checkpoint
     |> resilience_handles.sync_lifecycle_meta
   in
@@ -519,7 +517,6 @@ let handle
       ~meta
       ~turn_ctx_cell
       ~observation
-      ~final_execution
       ~latency_ms
       ~degraded_retry_applied
       ~degraded_retry_runtime
@@ -532,7 +529,6 @@ let handle
     apply_lifecycle
       ~config
       ~meta
-      ~final_execution
       result
   in
   let updated_meta =

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -39,7 +39,6 @@ val handle
   -> meta:Keeper_meta_contract.keeper_meta
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> observation:Keeper_world_observation.world_observation
-  -> final_execution:Keeper_turn_runtime_budget.runtime_execution
   -> latency_ms:int
   -> degraded_retry_applied:bool
   -> degraded_retry_runtime:string option

--- a/lib/keeper_types/keeper_types.ml
+++ b/lib/keeper_types/keeper_types.ml
@@ -52,9 +52,7 @@ type tool_call_entry =
 (* ================================================================ *)
 
 type working_context =
-  { checkpoint : Agent_sdk.Checkpoint.t
-  ; max_tokens : int
-  }
+  { checkpoint : Agent_sdk.Checkpoint.t }
 
 type session_context =
   { session_id : string

--- a/lib/keeper_types/keeper_types.mli
+++ b/lib/keeper_types/keeper_types.mli
@@ -44,7 +44,6 @@ type tool_call_entry = {
 
 type working_context = {
   checkpoint : Agent_sdk.Checkpoint.t;
-  max_tokens : int;
 }
 
 type session_context = {

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -76,7 +76,6 @@ let make_meta ?(name = "keeper-completion-trust") () =
 
 let make_ctx () =
   Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-    ~max_tokens:4000
 
 let with_ws name fn =
   let dir = temp_dir name in

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -226,7 +226,7 @@ let test_resume_checkpoint_preserves_all_messages_in_order () =
     List.init 130 (fun index -> text_message (Printf.sprintf "message-%03d" index))
   in
   let context =
-    C.create ~eio:false ~system_prompt:"system" ~max_tokens:4096
+    C.create ~eio:false ~system_prompt:"system"
     |> fun context -> C.append_many context messages
   in
   let resumed = C.resume_checkpoint_of_context context in
@@ -262,7 +262,7 @@ let test_resume_checkpoint_preserves_full_tool_result () =
     }
   in
   let context =
-    C.create ~eio:false ~system_prompt:"system" ~max_tokens:4096
+    C.create ~eio:false ~system_prompt:"system"
     |> fun context -> C.append context tool_result
   in
   let resumed = C.resume_checkpoint_of_context context in
@@ -287,7 +287,7 @@ let test_checkpoint_save_load_preserves_exact_messages () =
           text_message (Printf.sprintf "persisted-%03d" index))
       in
       let context =
-        C.create ~eio:true ~system_prompt:"system" ~max_tokens:4096
+        C.create ~eio:true ~system_prompt:"system"
         |> fun context -> C.append_many context messages
       in
       (match
@@ -309,7 +309,6 @@ let test_checkpoint_save_load_preserves_exact_messages () =
       let _, loaded =
         C.load_context_from_checkpoint
           ~trace_id:session_id
-          ~primary_model_max_tokens:4096
           ~base_dir
       in
       match loaded with

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -337,7 +337,7 @@ let test_checkpoint_write_accepts_exact_open_tool_cycle () =
         }
       in
       let context =
-        C.create ~eio:true ~system_prompt:"system" ~max_tokens:4096
+        C.create ~eio:true ~system_prompt:"system"
         |> fun context -> C.append context open_tool_use
       in
       match
@@ -383,7 +383,7 @@ let test_checkpoint_write_rejects_orphan_tool_result () =
         }
       in
       let context =
-        C.create ~eio:true ~system_prompt:"system" ~max_tokens:4096
+        C.create ~eio:true ~system_prompt:"system"
         |> fun context -> C.append context orphan
       in
       (match

--- a/test/test_keeper_memory_bank_compaction_errors.ml
+++ b/test/test_keeper_memory_bank_compaction_errors.ml
@@ -194,7 +194,6 @@ let test_memory_search_json_returns_partial_bank_match () =
     Masc.Keeper_context_runtime.create
       ~eio:false
       ~system_prompt:"test"
-      ~max_tokens:4000
   in
   let raw =
     Search.keeper_memory_search_json

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -182,9 +182,7 @@ let test_manual_compaction_serializes_owner_lane () =
       in
       let checkpoint =
         let context =
-          Masc.Keeper_context_core.context_of_oas_checkpoint
-            checkpoint
-            ~primary_model_max_tokens:8192
+          Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint
         in
         match
           Masc.Keeper_context_core.save_oas_checkpoint_classified
@@ -424,8 +422,7 @@ let test_manual_compaction_serializes_owner_lane () =
              Post_turn.recover_latest_checkpoint_for_compaction
                ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
                ~meta
-               ~trigger:Compaction_trigger.Manual
-               ~primary_model_max_tokens:8192)
+               ~trigger:Compaction_trigger.Manual)
       in
       (match stale_plan_result with
        | Error
@@ -461,10 +458,7 @@ let test_malformed_structure_preserves_checkpoint () =
   let orphan = block_message User [ tool_result "orphan" ] in
   let checkpoint = { (make_checkpoint ()) with messages = [ orphan ] } in
   let context =
-    Masc.Keeper_context_core.context_of_oas_checkpoint
-      checkpoint
-      ~primary_model_max_tokens:8192
-  in
+    Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint in
   let make_called = Atomic.make false in
   let preparation =
     Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -99,7 +99,6 @@ let test_regular_post_turn_does_not_auto_compact () =
       ~resilience_audit_store:None
       ~resilience_strategy_executor:None
       ~meta
-      ~primary_model_max_tokens:8192
       ~checkpoint:(Some checkpoint)
   in
   match result.checkpoint with
@@ -360,7 +359,6 @@ let test_manual_compaction_serializes_owner_lane () =
       let _, reinjectable =
         Masc.Keeper_context_runtime.load_context_from_checkpoint
           ~trace_id:checkpoint.session_id
-          ~primary_model_max_tokens:8192
           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
       in
       check int "compacted checkpoint available to same-lane injection" 8

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -410,7 +410,6 @@ let test_tool_dispatch_preserves_exact_meta_after_replacement () =
          Out_channel.output_string channel evidence);
        let ctx_work =
          Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-           ~max_tokens:4000
        in
        let _original_entry =
          KR.register ~base_path:config.base_path meta.name meta

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -79,7 +79,6 @@ let make_meta ?(name = "keeper-exec-tools") () =
 
 let make_ctx () =
   Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-    ~max_tokens:4000
 
 let with_exec_fixture ?(process = false) ?(always_allow = false) name fn =
   let dir = temp_dir name in

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -372,7 +372,6 @@ let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
         Masc.Keeper_context_runtime.create
           ~eio:false
           ~system_prompt:"keeper fusion schema regression"
-          ~max_tokens:4000
       in
       Masc_test_deps.with_publication_recovery_registry
         ~sw

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -174,7 +174,6 @@ let make_fixture
   let ctx =
     Masc.Keeper_context_runtime.create ~eio:false
       ~system_prompt:"keeper tool matrix"
-      ~max_tokens:4000
     |> fun ctx ->
     Masc.Keeper_context_runtime.append ctx
       (Agent_sdk.Types.user_msg "tool matrix memory needle")

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -75,7 +75,7 @@ let test_checkpoint_patch_updates_visible_text_and_clears_working_context () =
     }
   in
   let context =
-    KC.create ~eio:false ~system_prompt:"system" ~max_tokens:4096
+    KC.create ~eio:false ~system_prompt:"system"
     |> fun ctx -> KC.append_many ctx [ user_text "question"; assistant ]
   in
   let checkpoint = KC.checkpoint_of_context context in

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -86,7 +86,6 @@ let test_web_alias_bundle_visible_without_injected_masc_schema () =
       let meta = make_meta ~name:"test-web-alias-no-injected-schema" () in
       let ctx_snapshot =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-          ~max_tokens:4000
       in
       with_publication_recovery_registry ~registry_root:dir
       @@ fun publication_recovery_registry ->
@@ -138,7 +137,6 @@ let test_fusion_default_descriptor_is_bundle_visible () =
       let meta = make_meta ~name:"test-fusion-default-descriptor" () in
       let ctx_snapshot =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-          ~max_tokens:4000
       in
       with_publication_recovery_registry ~registry_root:dir
       @@ fun publication_recovery_registry ->
@@ -175,7 +173,7 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
       let config = Workspace.default_config dir in
       let meta = make_meta ~name:"test-complete-tool-bundle" () in
       let ctx_snapshot =
-        Keeper_context_runtime.create ~eio:false ~system_prompt:"test" ~max_tokens:4000
+        Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
       in
       with_publication_recovery_registry ~registry_root:dir
       @@ fun publication_recovery_registry ->
@@ -234,7 +232,6 @@ let test_missing_current_task_reconciled_before_transition_hint () =
       in
       let ctx_snapshot =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-          ~max_tokens:4000
       in
       with_publication_recovery_registry ~registry_root:dir
       @@ fun publication_recovery_registry ->
@@ -281,7 +278,6 @@ let test_tool_bundle_does_not_emit_full_universe_assignment () =
       let meta = make_meta ~name:"test-assignment-bundle" () in
       let ctx_snapshot =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
-          ~max_tokens:4000
       in
       with_publication_recovery_registry ~registry_root:dir
       @@ fun publication_recovery_registry ->


### PR DESCRIPTION
## Summary

- hard-delete `working_context.max_tokens`
- remove restore-time `primary_model_max_tokens` and checkpoint fallback plumbing
- remove zero-caller working-context codec/accessor residue
- stop heartbeat/checkpoint loading from resolving a capacity value that compaction never consumes

## Why deletion, not a stricter gate

The removed value never reaches the LLM compaction plan or the exact provider request. It was copied into a MASC working-context record, serialized into byte evidence, and threaded back through checkpoint restore. Rejecting manual compaction when this dead value is unavailable would block a Keeper without improving provider fit.

Actual turn admission remains on the selected Runtime/OAS request path. Typed capacity observation is intentionally a following stacked leaf.

## Preserved behavior

- checkpoint messages, ToolResult payloads, Agent context and generation survive save/load unchanged
- the newly merged exact structural compaction source contract from `origin/main` is preserved through the rebase
- manual owner-lane compaction, reinjection and peer-lane nonblocking assertions remain
- dashboard/status `context_budget`, checkpoint bytes and message count remain
- heartbeat message count remains
- no new gate, timeout, budget, fallback, heuristic, or silent failure

## Size

- base: `f5f45f97c37922500e68e69eedeeb1fd648f7f09`
- head: `864c06b91dcef3a9f07296dc845247f5a61da1b1`
- 34 files, 36 insertions, 208 deletions = 244 changed lines

## Verification

- all touched ML/MLI files: `ocamlformat` passed
- all touched ML/MLI files: OCaml parser passed
- exact focused context-core call-site residue was enumerated and removed after the first CI compile reports
- `git diff --check` passed
- removed-symbol residue: zero production/test callers
- two independent hostile reviews before rebase: P0 0, P1 0
- focused target: `scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe`
- full build/type authority: exact-head PR CI; no shared Dune lock bypass

Draft only. This leaf removes fake capacity authority; it does not claim provider-fit compaction or make `keeper_clear` safe.
