### PR TITLE
chore(otel): drop dead metric declarations and stale oas log-bridge rules

### DIFF
--- a/lib/agent_sdk_log_bridge.ml
+++ b/lib/agent_sdk_log_bridge.ml
@@ -102,47 +102,9 @@ let interpolate_printf_message message details =
     in
     List.fold_left replace_first_placeholder message replacements
 
-let render_agent_tools_message ~message ~details =
-  let detail_segments keys =
-    keys
-    |> List.filter_map (fun key ->
-         match first_detail_label details [ key ] with
-         | Some value -> Some (Printf.sprintf "%s=%s" key value)
-         | None -> None)
-  in
-  match
-    first_detail_label details [ "tool_name"; "tool" ],
-    first_detail_label details [ "fixes"; "count" ]
-  with
-  | Some tool_name, Some fixes
-    when String.equal message "correction_pipeline fixed tool input fields"
-         || String.equal message
-              "tool %s: correction_pipeline fixed %d field(s)" ->
-      let detail =
-        detail_segments
-          [ "fields"
-          ; "stages"
-          ; "input_keys"
-          ; "corrected_keys"
-          ; "added_fields"
-          ; "changed_fields"
-          ]
-      in
-      Some
-        (String.concat " "
-           (Printf.sprintf "tool %s: correction_pipeline fixed %s field(s)"
-              tool_name fixes
-            :: detail))
-  | _ -> None
-
 let render_record_message (record : Agent_sdk.Log.record) : string =
   let details = details_of_fields record.fields in
-  match record.module_name with
-  | "agent_tools" -> (
-      match render_agent_tools_message ~message:record.message ~details with
-      | Some rendered -> rendered
-      | None -> interpolate_printf_message record.message details)
-  | _ -> interpolate_printf_message record.message details
+  interpolate_printf_message record.message details
 
 let level_to_masc (level : Agent_sdk.Log.level) : Log.level =
   match level with
@@ -182,28 +144,6 @@ let summarize_fields ~message (fields : Agent_sdk.Log.field list) : string list 
            | Some rendered -> Some (Printf.sprintf "%s=%s" key rendered)
            | None -> None))
 
-let should_promote_warn_to_error (record : Agent_sdk.Log.record) =
-  match record.level, record.module_name, record.message with
-  | Warn, "agent_config", "MCP server failed" -> true
-  | Warn, "agent_turn", "context_injector raised" -> true
-  | _ -> false
-
-let should_demote_info_to_debug (record : Agent_sdk.Log.record) =
-  match record.level, record.module_name, record.message with
-  | ( Info,
-      "completion_contract",
-      "tool_choice contract relaxed (provider does not support tool_choice)" ) ->
-      true
-  | _ -> false
-
-let effective_level (record : Agent_sdk.Log.record) : Log.level =
-  if should_promote_warn_to_error record then
-    Log.Error
-  else if should_demote_info_to_debug record then
-    Log.Debug
-  else
-    level_to_masc record.level
-
 let render_message_with_summary (record : Agent_sdk.Log.record) =
   let base_message = render_record_message record in
   if not (String.equal base_message record.message) then
@@ -214,40 +154,19 @@ let render_message_with_summary (record : Agent_sdk.Log.record) =
     | summary ->
         Printf.sprintf "%s %s" base_message (String.concat " " summary)
 
-let emit_correction_pipeline_metric (record : Agent_sdk.Log.record) =
-  match record.module_name with
-  | "agent_tools" -> (
-      let details = details_of_fields record.fields in
-      match
-        ( first_detail_label details [ "tool_name"; "tool" ],
-          first_detail_label details [ "fixes"; "count" ] )
-      with
-      | Some tool_name, Some _fixes
-        when String.equal record.message
-               "correction_pipeline fixed tool input fields"
-             || String.equal record.message
-                  "tool %s: correction_pipeline fixed %d field(s)" ->
-          Otel_metric_store.inc_counter
-            Otel_metric_store.metric_oas_correction_pipeline_fixes_total
-            ~labels:[ ("tool_name", tool_name) ]
-            ()
-      | _ -> ())
-  | _ -> ()
-
 (** Build the sink function.  Prefix the module name with ["oas:"] so a
     record emitted by [Agent_sdk.Log.create ~module_name:"agent"] lands
     as ["oas:agent"] in the masc log stream, distinct from any
     masc module called "agent". *)
 let make_sink () : Agent_sdk.Log.sink =
  fun record ->
-  emit_correction_pipeline_metric record;
   let message = render_message_with_summary record in
   let details =
     match record.fields with
     | [] -> None
     | fields -> Some (`Assoc (List.map field_to_json fields))
   in
-  Log.emit (effective_level record)
+  Log.emit (level_to_masc record.level)
     ~module_name:("oas:" ^ record.module_name)
     ?details
     message

--- a/lib/agent_sdk_log_bridge.mli
+++ b/lib/agent_sdk_log_bridge.mli
@@ -14,8 +14,3 @@ val install : unit -> unit
     once before any keeper turn fires an LLM call.  Idempotent via an
     internal [Atomic.t] latch, so re-entering bootstrap (test harness,
     in-process restart) is safe. *)
-
-val effective_level : Agent_sdk.Log.record -> Log.level
-(** Return the effective log level for an OAS record after bridge-level
-    promotion/demotion rules (e.g. MCP server failure → Error).
-    Test-only surface — do not call from production code paths. *)

--- a/lib/otel_metric_store.ml
+++ b/lib/otel_metric_store.ml
@@ -75,14 +75,6 @@ let record_error ?(error_type = "unknown") () =
   inc_counter metric_errors ~labels:[ "type", error_type ] ()
 ;;
 
-let set_active_agents count =
-  set_gauge metric_active_agents (Float.of_int count)
-;;
-
-let set_pending_tasks count =
-  set_gauge metric_pending_tasks (Float.of_int count)
-;;
-
 let reconcile_active_agents_gauge (_masc_dir : string) = ()
 
 let update_uptime () = ()
@@ -120,8 +112,6 @@ let init () =
     [ 0.001; 0.005; 0.01; 0.025; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0 ];
   reg "masc_keeper_turn_phase_duration_seconds"
     [ 0.1; 0.5; 1.0; 5.0; 10.0; 30.0; 60.0; 120.0; 300.0; 600.0 ];
-  reg "masc_keeper_gated_gh_block_time_seconds"
-    [ 0.0; 0.001; 0.005; 0.01; 0.05; 0.1; 0.5; 1.0; 5.0 ];
   reg "masc_workspace_broadcast_duration_seconds"
     [ 0.001; 0.005; 0.01; 0.05; 0.1; 0.5; 1.0; 5.0; 10.0 ];
   reg "masc_file_lock_acquire_seconds"

--- a/lib/otel_metric_store/otel_builtin_metric_names.ml
+++ b/lib/otel_metric_store/otel_builtin_metric_names.ml
@@ -71,13 +71,9 @@ include Otel_transport_metric_names
 (* Process-level FD gauges — used in init() and update_fd_gauges. *)
 include Otel_core_metric_names
 
-(* RFC-0107 Phase D.4 — piaf-backed connection pool gauges/counters. *)
-let metric_pool_idle_total = "masc_pool_idle_total"
-let metric_pool_inflight_total = "masc_pool_inflight_total"
-let metric_pool_reuse_total = Otel_metric_store_core.declare_counter "masc_pool_reuse_total"
-let metric_pool_evict_total = Otel_metric_store_core.declare_counter "masc_pool_evict_total"
-let metric_pool_evict_failure_total = Otel_metric_store_core.declare_counter "masc_pool_evict_failure_total"
-let metric_pool_create_total = Otel_metric_store_core.declare_counter "masc_pool_create_total"
+(* masc_pool_* series are emitted solely by [Otel_runtime_observables]
+   (computed at exporter tick from [Pool_metrics.current_snapshot]); no
+   store cells are declared here, so there is no 0-cell duplicate. *)
 
 include Otel_policy_metric_names
 
@@ -102,17 +98,9 @@ let metric_oas_bridge_unmigrated_payload_kind =
   Otel_metric_store_core.declare_counter "masc_oas_bridge_unmigrated_payload_kind_total"
 ;;
 
-let metric_keeper_context_tool_result_compacted =
-  Otel_metric_store_core.declare_counter "masc_keeper_context_tool_result_compacted_total"
-;;
-
 let metric_process_timeout = Otel_metric_store_core.declare_counter "masc_process_timeout_total"
 let metric_build_identity_probe_failures = Otel_metric_store_core.declare_counter "masc_build_identity_probe_failures_total"
 let metric_distributed_lock_acquire_failed = Otel_metric_store_core.declare_counter "masc_distributed_lock_acquire_failed_total"
-
-let metric_ide_orphan_reads =
-  Otel_metric_store_core.declare_counter "masc_ide_orphan_reads_total"
-;;
 
 (* #10130: boot-time sweep of [save_file_atomic] orphan temp
    files.  Labels: [size_class = empty | with_data].  The

--- a/lib/otel_metric_store/otel_builtin_metric_names.mli
+++ b/lib/otel_metric_store/otel_builtin_metric_names.mli
@@ -55,12 +55,9 @@ include module type of Otel_runtime_metric_names
 (** {1 Core counters / gauges} *)
 
 include module type of Otel_core_metric_names
-val metric_pool_idle_total : string
-val metric_pool_inflight_total : string
-val metric_pool_reuse_total : string
-val metric_pool_evict_total : string
-val metric_pool_evict_failure_total : string
-val metric_pool_create_total : string
+
+(* masc_pool_* series are emitted solely by [Otel_runtime_observables]; no
+   store cells are declared here. *)
 
 include module type of Otel_policy_metric_names
 
@@ -85,7 +82,6 @@ val metric_oas_bus_capacity : string
     [bus], [purpose], [capacity], and [overflow]. *)
 
 val metric_oas_bridge_unmigrated_payload_kind : string
-val metric_keeper_context_tool_result_compacted : string
 
 (** #9632: subprocess executions that exceeded their configured
     timeout. Labels: [program, timeout_sec]. *)
@@ -113,11 +109,6 @@ val metric_build_identity_probe_failures : string
 val metric_distributed_lock_acquire_failed : string
 (** #9645: distributed lock acquire retry-budget exhaustions.
     Labels: [key, attempts]. *)
-
-(** IDE read routes that resolved to the shared orphan partition instead of
-    [by-url/<canonical-repo>]. Labels: [reason] =
-    [no_canonical_url | unmatched | base_unresolved | legacy_default]. *)
-val metric_ide_orphan_reads : string
 
 (** #10130: boot-time sweep of save_file_atomic orphan temp files.
     Labels: [size_class = empty | with_data]. *)

--- a/lib/otel_metric_store/otel_metric_names.ml
+++ b/lib/otel_metric_store/otel_metric_names.ml
@@ -265,10 +265,3 @@ let metric_cache_desync_cleared = Otel_metric_store_core.declare_counter "masc_c
 let metric_persistence_read_drops = Otel_metric_store_core.declare_counter "masc_persistence_read_drops_total"
 let metric_persistence_utf8_repair = Otel_metric_store_core.declare_counter "masc_persistence_utf8_repair_total"
 let metric_discovery_history_failures = Otel_metric_store_core.declare_counter "masc_discovery_history_failures_total"
-
-(* #18855: per-tool correction_pipeline fix counter.
-   Incremented when the OAS agent_tools module reports that
-   correction_pipeline fixed input fields for a tool.
-   Labels: [tool_name]. *)
-let metric_oas_correction_pipeline_fixes_total =
-  Otel_metric_store_core.declare_counter "masc_oas_correction_pipeline_fixes_total"

--- a/lib/otel_metric_store/otel_metric_names.mli
+++ b/lib/otel_metric_store/otel_metric_names.mli
@@ -267,9 +267,3 @@ val metric_persistence_read_drops : string
 val metric_persistence_utf8_repair : string
 
 val metric_discovery_history_failures : string
-
-(** #18855: per-tool correction_pipeline fix counter.
-    Incremented when the OAS agent_tools module reports that
-    correction_pipeline fixed input fields for a tool.
-    Labels: [tool_name]. *)
-val metric_oas_correction_pipeline_fixes_total : string

--- a/lib/pool_metrics/pool_metrics.ml
+++ b/lib/pool_metrics/pool_metrics.ml
@@ -1,22 +1,14 @@
 (** RFC-0107 Phase D.4 — Otel_metric_store exporter for [Masc_http_client.Pool].
 
-    Read-only adapter: owns the metric name constants and exposes a
-    snapshot accessor over [Masc_http_client.all_domain_pools].  The
-    actual Otel_metric_store [set_gauge] calls live in {!Otel_metric_store} (see
-    [update_pool_metrics_gauges] there) to avoid a Otel_metric_store ↔
-    Pool_metrics module cycle.
+    Read-only adapter: exposes a snapshot accessor over
+    [Masc_http_client.all_domain_pools].  The metric name constants and
+    sample emission live in [Otel_runtime_observables] (single export
+    wiring); this module deliberately owns no metric names.
 
     Aggregation: sums integer counters across all OCaml Domains so the
     exported gauges reflect process-wide totals.  [idle_per_host] from
     each domain pool is concatenated so the per-host breakdown remains
     available. *)
-
-let metric_idle_total = "masc_pool_idle_total"
-let metric_inflight_total = "masc_pool_inflight_total"
-let metric_reuse_total = "masc_pool_reuse_total"
-let metric_evict_total = "masc_pool_evict_total"
-let metric_evict_failure_total = "masc_pool_evict_failure_total"
-let metric_create_total = "masc_pool_create_total"
 
 let current_snapshot () =
   let pools = Masc_http_client.all_domain_pools () in

--- a/lib/pool_metrics/pool_metrics.mli
+++ b/lib/pool_metrics/pool_metrics.mli
@@ -1,48 +1,23 @@
-(** RFC-0107 Phase D.4 — Otel_metric_store exporter for the piaf-backed
+(** RFC-0107 Phase D.4 — snapshot accessor for the piaf-backed
     connection pool defined in {!Masc_http_client.Pool}.
 
-    Read-only adapter: snapshots [Pool.stats] and pushes 5 metric
-    families to the Otel_metric_store registry on each export.  The pool
-    itself is not modified; the lazy singleton is observed via
+    Read-only adapter: snapshots [Pool.stats]; the actual sample emission
+    lives in [Otel_runtime_observables], which calls
+    {!current_snapshot} on each exporter tick.  The pool itself is not
+    modified; the lazy singleton is observed via
     {!Masc_http_client.pool_singleton_opt}.
 
-    Metric names (no shared prefix beyond [masc_pool_]):
-    - [masc_pool_idle_total] (gauge, label [host="scheme://host:port"])
+    Metric names emitted there (no shared prefix beyond [masc_pool_]):
+    - [masc_pool_idle_total] (gauge)
     - [masc_pool_inflight_total] (gauge)
     - [masc_pool_reuse_total] (counter)
     - [masc_pool_evict_total] (counter)
     - [masc_pool_evict_failure_total] (counter)
     - [masc_pool_create_total] (counter)
 
-    The cumulative counters use [Pool.stats.*_total] snapshot values
-    written directly via [Otel_metric_store.set_gauge] on Counter-typed
-    metrics; the metric_type registered in {!Otel_metric_store.init} controls
-    text-format rendering (TYPE counter), so the cumulative-monotonic
-    invariant holds as long as [Pool] never resets its counters. *)
-
-(** {1 Metric name constants} *)
-
-val metric_idle_total : string
-(** [masc_pool_idle_total] — gauge labelled by host. *)
-
-val metric_inflight_total : string
-(** [masc_pool_inflight_total] — gauge, single time series. *)
-
-val metric_reuse_total : string
-(** [masc_pool_reuse_total] — counter, single time series. *)
-
-val metric_evict_total : string
-(** [masc_pool_evict_total] — counter, single time series. *)
-
-val metric_evict_failure_total : string
-(** [masc_pool_evict_failure_total] — counter, single time series.
-    Increments when the periodic eviction fiber catches an exception
-    while sweeping idle entries. Operator-visible signal that the
-    pool's TTL cleanup is silently failing (previously swallowed by
-    [with _ -> ()]). *)
-
-val metric_create_total : string
-(** [masc_pool_create_total] — counter, single time series. *)
+    The cumulative counters use [Pool.stats.*_total] snapshot values, so
+    the cumulative-monotonic invariant holds as long as [Pool] never
+    resets its counters. *)
 
 (** {1 Snapshot accessor} *)
 

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -134,56 +134,6 @@ let test_recent_before_seq_returns_only_older_entries () =
        (Log.Ring.recent ~limit:10 ~module_filter:module_name
           ~since_seq:(seq_of m0) ~before_seq:(seq_of m2) ()))
 
-let oas_record ?(level = Agent_sdk.Log.Info) ~module_name ~message fields =
-  Agent_sdk.Log.
-    {
-      ts = Unix.gettimeofday ();
-      level;
-      module_name;
-      message;
-      fields;
-      trace_id = None;
-      span_id = None;
-    }
-
-let test_oas_bridge_promotes_mcp_server_failures_to_error () =
-  let level =
-    Masc.Agent_sdk_log_bridge.effective_level
-      (oas_record
-         ~level:Agent_sdk.Log.Warn
-         ~module_name:"agent_config"
-         ~message:"MCP server failed"
-         [ Agent_sdk.Log.S ("server", "demo");
-           Agent_sdk.Log.S ("error", "connection refused") ])
-  in
-  Alcotest.(check string) "mcp server failure promoted" "ERROR"
-    (Log.level_to_string level)
-
-let test_oas_bridge_promotes_context_injector_failures_to_error () =
-  let level =
-    Masc.Agent_sdk_log_bridge.effective_level
-      (oas_record
-         ~level:Agent_sdk.Log.Warn
-         ~module_name:"agent_turn"
-         ~message:"context_injector raised"
-         [ Agent_sdk.Log.S ("tool", "tool_read_file");
-           Agent_sdk.Log.S ("error", "boom") ])
-  in
-  Alcotest.(check string) "context injector failure promoted" "ERROR"
-    (Log.level_to_string level)
-
-let test_oas_bridge_demotes_tool_choice_relaxation_to_debug () =
-  let level =
-    Masc.Agent_sdk_log_bridge.effective_level
-      (oas_record
-         ~level:Agent_sdk.Log.Info
-         ~module_name:"completion_contract"
-         ~message:"tool_choice contract relaxed (provider does not support tool_choice)"
-         [ Agent_sdk.Log.S ("provider", "glm") ])
-  in
-  Alcotest.(check string) "tool_choice fallback demoted" "DEBUG"
-    (Log.level_to_string level)
-
 let test_entry_to_json_keeper_name_none_serializes_system () =
   (* #18465: keeper_name=None must serialize as "system", not null *)
   let entry : Log.Ring.entry = {
@@ -259,15 +209,6 @@ let () =
           test_recent_since_seq_returns_only_new_entries;
         Alcotest.test_case "recent before_seq returns only older entries" `Quick
           test_recent_before_seq_returns_only_older_entries;
-        Alcotest.test_case
-          "oas bridge promotes MCP server failures"
-          `Quick test_oas_bridge_promotes_mcp_server_failures_to_error;
-        Alcotest.test_case
-          "oas bridge promotes context injector failures"
-          `Quick test_oas_bridge_promotes_context_injector_failures_to_error;
-        Alcotest.test_case
-          "oas bridge demotes normal tool_choice relaxation"
-          `Quick test_oas_bridge_demotes_tool_choice_relaxation_to_debug;
         Alcotest.test_case
           "file sink reopens when current log path is deleted"
           `Quick test_file_sink_reopens_when_log_path_is_deleted;

--- a/test/test_pool_metrics.ml
+++ b/test/test_pool_metrics.ml
@@ -1,32 +1,16 @@
 (** RFC-0107 Phase D.4 — Pool_metrics registry regression test.
 
-    Pinned-name + registry-shape checks for the piaf connection pool
-    metrics.  Verifies:
+    Verifies:
 
-    - Five metric name constants stay stable (dashboards pin these names).
     - [register ()] is idempotent and does not raise.
     - [current_snapshot ()] returns [None] before the pool is
       lazy-initialized (no HTTP traffic from the test).
-    - The Otel_metric_store store registers all metric families with the intended
-      counter/gauge type for the OTel observable source.
+    - The observable export source yields no masc_pool_* samples while
+      no pool exists.
 *)
 
 open Alcotest
 module PM = Pool_metrics
-
-let metric_names = [
-  PM.metric_idle_total, "masc_pool_idle_total";
-  PM.metric_inflight_total, "masc_pool_inflight_total";
-  PM.metric_reuse_total, "masc_pool_reuse_total";
-  PM.metric_evict_total, "masc_pool_evict_total";
-  PM.metric_create_total, "masc_pool_create_total";
-]
-
-let test_metric_name_constants () =
-  List.iter
-    (fun (actual, expected) ->
-      check string (Printf.sprintf "metric name %s" expected) expected actual)
-    metric_names
 
 let test_register_idempotent () =
   PM.register ();
@@ -70,9 +54,6 @@ let test_observable_export_absent_without_pool () =
 
 let () =
   run "Pool_metrics" [
-    "name constants", [
-      test_case "metric names stable" `Quick test_metric_name_constants;
-    ];
     "register", [
       test_case "register is idempotent" `Quick test_register_idempotent;
     ];

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -400,28 +400,6 @@ let test_keeper_mainline_failures_log_at_error () =
     (file_not_contains_pattern "lib/keeper/keeper_agent_run.ml"
        {|episode_create failed|})
 
-let test_oas_mainline_warns_are_promoted_in_bridge () =
-  check bool "bridge promotes MCP server failure" true
-    (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
-       {|Warn, "agent_config", "MCP server failed" -> true|});
-  check bool "bridge promotes context injector failure" true
-    (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
-       {|Warn, "agent_turn", "context_injector raised" -> true|})
-
-let test_correction_pipeline_log_preserves_detail_fields () =
-  List.iter
-    (fun (key, pattern) ->
-      check bool ("bridge renders correction detail " ^ key) true
-        (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
-           pattern))
-    [ "fields", {|[ "fields"|}
-    ; "stages", {|; "stages"|}
-    ; "input_keys", {|; "input_keys"|}
-    ; "corrected_keys", {|; "corrected_keys"|}
-    ; "added_fields", {|; "added_fields"|}
-    ; "changed_fields", {|; "changed_fields"|}
-    ]
-
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
@@ -453,9 +431,5 @@ let () =
         [
           test_case "keeper mainline failures log at error" `Quick
             test_keeper_mainline_failures_log_at_error;
-          test_case "oas mainline warns are promoted in bridge" `Quick
-            test_oas_mainline_warns_are_promoted_in_bridge;
-          test_case "correction pipeline log preserves detail fields" `Quick
-            test_correction_pipeline_log_preserves_detail_fields;
         ] );
     ]


### PR DESCRIPTION
## Problem

1. **`masc_pool_*" double emission**: names defined in 3 places; bootstrap registers both `otel_builtin_metric_names` (permanent 0-cells via `declare_counter`) and `otel_runtime_observables` (real values, documented as "the pool export wiring"). Same (name, attributes) series emitted twice per tick — 0-cells can shadow real values in backends.
2. **Dead declarations** (producers removed long ago, permanently-zero series): `keeper_context_tool_result_compacted`, `ide_orphan_reads`, `set_pending_tasks`/`set_active_agents` helpers, `gated_gh_block_time_seconds` bucket.
3. **Unfireable log-bridge rules**: `agent_sdk_log_bridge`'s 4 string-match rules target messages the pinned oas no longer emits (removed in oas #2590/#1867). Tests synthesized the dead strings to stay green. Includes the permanently-zero `masc_oas_correction_pipeline_fixes_total` counter.

## Fix

- Keep `otel_runtime_observables` as the pool SSOT; delete builtin declarations + orphaned `pool_metrics` constants
- Delete the dead declarations in (2)
- Delete the 4 rules, `render_agent_tools_message`, `emit_correction_pipeline_metric`, the counter, and the synthesized-string tests (including 2 source-pinning cases in `test_warn_root_causes.ml`). Bridge `install`/default level mapping stays.
- Grafana dashboards improve as a side effect (no more 0-cell shadowing)

## Verification

- `dune build lib/` ✓
- `test_pool_metrics` 3 ✓ / `test_warn_root_causes` 9 ✓ / `test_otel_runtime_observables` 4 ✓ / `test_masc_log` 5/6 — the 1 failure is pre-existing on main, filed as #25200
- Residual grep for all removed symbols + metric literals: zero ✓

Found by adversarial wiring audit (2026-07-17).