### PR TITLE
refactor(config): retire four duplicate env-knob spellings

### DIFF
--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -183,8 +183,18 @@ let should_use_sse_for_body (request : Httpun.Request.t) body_str accept_mode =
       && Http_negotiation.accepts_sse_header
            (Httpun.Headers.get request.headers "accept")
 
-let force_json_response =
-  env_flag "MASC_FORCE_JSON_RESPONSE" || env_flag "MCP_FORCE_JSON_RESPONSE"
+(* MCP_FORCE_JSON_RESPONSE was retired (masc#25123 Wave 2):
+   MASC_FORCE_JSON_RESPONSE is the single spelling, matching the MASC_*
+   namespace every other knob uses. A set-but-ignored legacy spelling would
+   silently change transport behavior for whoever still exports it, so it
+   warns once at module init. *)
+let () =
+  if env_flag "MCP_FORCE_JSON_RESPONSE" then
+    Log.Server.warn
+      "retired env knob ignored env=MCP_FORCE_JSON_RESPONSE; use \
+       MASC_FORCE_JSON_RESPONSE"
+
+let force_json_response = env_flag "MASC_FORCE_JSON_RESPONSE"
 
 let sse_retry_ms = 3000
 

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -91,10 +91,11 @@ val request_force_json_response : Httpun.Request.t -> bool
     overrides Accept negotiation. *)
 
 val force_json_response : bool
-(** Module-init cache of [MASC_FORCE_JSON_RESPONSE] OR
-    [MCP_FORCE_JSON_RESPONSE] env flags (truthy semantics matching
-    {!request_force_json_response}).  Either flag forces every
-    response to plain JSON regardless of Accept negotiation. *)
+(** Module-init cache of the [MASC_FORCE_JSON_RESPONSE] env flag (truthy
+    semantics matching {!request_force_json_response}).  Forces every
+    response to plain JSON regardless of Accept negotiation.  The retired
+    [MCP_FORCE_JSON_RESPONSE] spelling is ignored with a one-time warning
+    (masc#25123 Wave 2). *)
 
 (** {1 Header builders} *)
 

--- a/lib/server/server_mcp_transport_http_protocol.mli
+++ b/lib/server/server_mcp_transport_http_protocol.mli
@@ -140,5 +140,5 @@ val should_use_sse_for_body :
 val force_json_response : bool
 (** Re-export of
     {!Server_mcp_transport_http_headers.force_json_response}.
-    [true] iff [MASC_FORCE_JSON_RESPONSE] or [MCP_FORCE_JSON_RESPONSE]
+    [true] iff [MASC_FORCE_JSON_RESPONSE]
     is set at module init. *)

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -12,7 +12,7 @@ Usage: scripts/dune-local.sh [dune-subcommand] [args...]
 Local Dune wrapper for multi-agent development:
   - serializes local Dune invocations with a machine-wide lock
   - serializes opam switch validation with opam pin mutations
-  - defaults local concurrency to DUNE_LOCAL_JOBS, or 2
+  - defaults local concurrency to DUNE_JOBS, or 2
   - disables the shared Dune artifact cache by default for local builds
   - injects --root <repo-root> unless --root is already present
   - asserts agent_sdk opam pin matches the repo SSOT before each build
@@ -21,7 +21,7 @@ Local Dune wrapper for multi-agent development:
 
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_DUNE_CACHE=enabled or enabled-except-user-rules to opt into the shared Dune cache.
-Set MASC_OPAM_LOCK=0 or MASC_SKIP_OPAM_LOCK=1 to bypass the shared opam switch lock.
+Set MASC_SKIP_OPAM_LOCK=1 to bypass the shared opam switch lock.
 Set MASC_OPAM_LOCK_PATH=/path/to/lock to override the shared opam lock path.
 Set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=seconds to bound opam-lock wait after the Dune lock (0 = wait forever).
 Set MASC_DUNE_LOCK_DIAG=0 to suppress best-effort lock holder diagnostics.
@@ -284,7 +284,12 @@ _check_unwrapped_dune_processes
 
 _needs_opam_lock() {
   [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 1
-  [[ "${MASC_OPAM_LOCK:-1}" != "0" ]] || return 1
+  # MASC_OPAM_LOCK=0 was retired (masc#25123 Wave 2): MASC_SKIP_OPAM_LOCK=1
+  # is the single opt-out. Warn so an operator habit does not silently stop
+  # working.
+  if [[ "${MASC_OPAM_LOCK:-1}" == "0" ]]; then
+    echo "[dune-local] MASC_OPAM_LOCK is retired and ignored; use MASC_SKIP_OPAM_LOCK=1" >&2
+  fi
   [[ "${MASC_SKIP_OPAM_LOCK:-0}" != "1" ]] || return 1
   [[ "${MASC_DUNE_DRY_RUN:-0}" != "1" ]] || return 1
   [[ "${_subcommand}" != "clean" ]] || return 1
@@ -376,7 +381,13 @@ if _needs_opam_lock; then
 fi
 
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
-  export DUNE_JOBS="${DUNE_JOBS:-${DUNE_LOCAL_JOBS:-2}}"
+  # DUNE_LOCAL_JOBS was retired (masc#25123 Wave 2): DUNE_JOBS is the single
+  # concurrency knob (CI sets it directly; start-masc.sh derives it from
+  # MASC_DUNE_JOBS).
+  if [[ -n "${DUNE_LOCAL_JOBS:-}" && -z "${DUNE_JOBS:-}" ]]; then
+    echo "[dune-local] DUNE_LOCAL_JOBS is retired and ignored; set DUNE_JOBS" >&2
+  fi
+  export DUNE_JOBS="${DUNE_JOBS:-2}"
   export DUNE_BUILD_DIR="${DUNE_BUILD_DIR:-$repo_root/_build}"
   # The shared Dune cache can return native artifacts compiled against an
   # older local opam pin, which then link with fresh CMIs and fail with

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -38,8 +38,12 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 opam_lock_path="${MASC_OPAM_LOCK_PATH:-/tmp/me-opam-switch.lock}"
 agent_sdk_floor_path="${MASC_AGENT_SDK_FLOOR_PATH:-/tmp/me-agent-sdk-floor}"
 
-if [[ "${MASC_OPAM_LOCK:-1}" != "0" \
-      && "${MASC_SKIP_OPAM_LOCK:-0}" != "1" \
+if [[ "${MASC_OPAM_LOCK:-1}" == "0" ]]; then
+  # Retired alias (masc#25123 Wave 2): MASC_SKIP_OPAM_LOCK=1 is the single
+  # opt-out.
+  echo "[opam-pin] MASC_OPAM_LOCK is retired and ignored; use MASC_SKIP_OPAM_LOCK=1" >&2
+fi
+if [[ "${MASC_SKIP_OPAM_LOCK:-0}" != "1" \
       && "${MASC_OPAM_LOCK_HELD:-0}" != "1" ]]; then
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
   env_cmd="${ENV_CMD:-/usr/bin/env}"
@@ -180,8 +184,13 @@ print_opam_lock_holder() {
 }
 
 allow_agent_sdk_pin_downgrade() {
-  [[ "${MASC_ALLOW_OAS_PIN_DOWNGRADE:-0}" == "1" \
-    || "${MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE:-0}" == "1" ]]
+  # MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE was retired (masc#25123 Wave 2): the
+  # pin target is the oas repo, so MASC_ALLOW_OAS_PIN_DOWNGRADE is the single
+  # opt-in. Warn so an intentional rollback does not silently stop working.
+  if [[ "${MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE:-0}" == "1" ]]; then
+    echo "[opam-pin] MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE is retired and ignored; use MASC_ALLOW_OAS_PIN_DOWNGRADE=1" >&2
+  fi
+  [[ "${MASC_ALLOW_OAS_PIN_DOWNGRADE:-0}" == "1" ]]
 }
 
 guard_agent_sdk_downgrade() {
@@ -200,7 +209,7 @@ guard_agent_sdk_downgrade() {
       echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
       echo "[opam-pin] lock path: ${opam_lock_path}" >&2
       print_opam_lock_holder
-      echo "[opam-pin] repair: rebase/update this worktree to the current OAS pin, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1/MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE=1 for an intentional rollback" >&2
+      echo "[opam-pin] repair: rebase/update this worktree to the current OAS pin, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1 for an intentional rollback" >&2
       exit 1
     fi
   fi
@@ -219,7 +228,7 @@ guard_agent_sdk_downgrade() {
         echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
         echo "[opam-pin] lock path: ${opam_lock_path}" >&2
         print_opam_lock_holder
-        echo "[opam-pin] repair: fix opam switch inspection, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1/MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE=1 for an intentional rollback" >&2
+        echo "[opam-pin] repair: fix opam switch inspection, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1 for an intentional rollback" >&2
         exit 1
         ;;
     esac
@@ -232,7 +241,7 @@ guard_agent_sdk_downgrade() {
     echo "[opam-pin] installed: agent_sdk ${installed_version}" >&2
     echo "[opam-pin] lock path: ${opam_lock_path}" >&2
     print_opam_lock_holder
-    echo "[opam-pin] repair: use the newer worktree pin, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1/MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE=1 for an intentional downgrade" >&2
+    echo "[opam-pin] repair: use the newer worktree pin, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1 for an intentional downgrade" >&2
     exit 1
   fi
 }

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -102,7 +102,7 @@ run_dune_local() {
         echo "Run builds through scripts/dune-local.sh so local agents share the machine-wide Dune lock." >&2
         return 127
     fi
-    env DUNE_LOCAL_JOBS="$DUNE_JOBS" DUNE_JOBS="$DUNE_JOBS" "$wrapper" "$@"
+    env DUNE_JOBS="$DUNE_JOBS" "$wrapper" "$@"
 }
 
 dune_build_with_stale_retry() {

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -300,7 +300,7 @@ let write_fake_dune_local ~path ~log_file =
        {|
 #!/bin/sh
 set -eu
-printf 'dune-local %%s DUNE_JOBS=%%s DUNE_LOCAL_JOBS=%%s DUNE_CACHE=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_LOCAL_JOBS:-}" "${DUNE_CACHE:-}" >> %s
+printf 'dune-local %%s DUNE_JOBS=%%s DUNE_CACHE=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_CACHE:-}" >> %s
 exec dune "$@"
 |}
        (quote log_file))
@@ -862,7 +862,7 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
                "dune-local build bin/main_eio.exe");
           check bool "startup forwards DUNE_JOBS into wrapper under CI" true
             (contains_substring dune_local_calls
-               "DUNE_JOBS=2 DUNE_LOCAL_JOBS=2");
+               "DUNE_JOBS=2");
           check bool "stale cleanup uses dune-local wrapper" true
             (contains_substring dune_local_calls "dune-local clean");
           check bool "original stale artifact error preserved" true
@@ -918,10 +918,10 @@ let test_dune_cache_temp_error_retries_with_cache_disabled () =
           let dune_local_calls = read_file dune_local_log in
           check bool "initial startup build used cache default" true
             (contains_substring dune_local_calls
-               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_LOCAL_JOBS=2 DUNE_CACHE=");
+               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=");
           check bool "retry disabled Dune cache" true
             (contains_substring dune_local_calls
-               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled");
+               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=disabled");
           check bool "original cache temp error preserved" true
             (contains_substring stderr
                "rmdir(/Users/test/.cache/dune/db/temp/dune_6eb519_artifacts): Directory not empty");

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -329,7 +329,7 @@ let write_fake_dune_local ~path ~log_file =
        {|
 #!/bin/sh
 set -eu
-printf 'dune-local %%s DUNE_JOBS=%%s DUNE_LOCAL_JOBS=%%s DUNE_CACHE=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_LOCAL_JOBS:-}" "${DUNE_CACHE:-}" >> %s
+printf 'dune-local %%s DUNE_JOBS=%%s DUNE_CACHE=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_CACHE:-}" >> %s
 exec dune "$@"
 |}
        (quote log_file))
@@ -889,7 +889,7 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
                "dune-local build bin/main_eio.exe");
           check bool "startup forwards DUNE_JOBS into wrapper under CI" true
             (contains_substring dune_local_calls
-               "DUNE_JOBS=2 DUNE_LOCAL_JOBS=2");
+               "DUNE_JOBS=2");
           check bool "stale cleanup uses dune-local wrapper" true
             (contains_substring dune_local_calls "dune-local clean");
           check bool "original stale artifact error preserved" true
@@ -945,10 +945,10 @@ let test_dune_cache_temp_error_retries_with_cache_disabled () =
           let dune_local_calls = read_file dune_local_log in
           check bool "initial startup build used cache default" true
             (contains_substring dune_local_calls
-               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_LOCAL_JOBS=2 DUNE_CACHE=");
+               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=");
           check bool "retry disabled Dune cache" true
             (contains_substring dune_local_calls
-               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled");
+               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=disabled");
           check bool "original cache temp error preserved" true
             (contains_substring stderr
                "rmdir(/Users/test/.cache/dune/db/temp/dune_6eb519_artifacts): Directory not empty");


### PR DESCRIPTION
## Summary

#25123 감사 **Wave 2** — 같은 효과에 철자만 다른 env 노브 4가족을 하나씩으로 통합. 은퇴 철자는 조용히 무시하지 않고 **명시 경고 후 무시**(`retired_env_warnings` 관용구) — 오퍼레이터 습관이 소리 없이 어긋나는 것을 방지.

## 통합표

| 은퇴 | 생존 | 근거 |
|---|---|---|
| `DUNE_LOCAL_JOBS` | `DUNE_JOBS` | dune-local.sh가 이미 DUNE_JOBS 우선, start-masc.sh는 같은 값 이중 export — 별칭이 의미를 갖는 경우는 "혼자 설정"뿐. CI는 DUNE_JOBS 직접 설정 |
| `MASC_OPAM_LOCK=0` | `MASC_SKIP_OPAM_LOCK=1` | 래퍼의 나머지 opt-out 전부가 SKIP_* 계열 |
| `MASC_ALLOW_AGENT_SDK_PIN_DOWNGRADE` | `MASC_ALLOW_OAS_PIN_DOWNGRADE` | 두 플래그가 항상 OR로만 평가됨; pin 대상 리포=oas. 안내문 3곳 단일화 |
| `MCP_FORCE_JSON_RESPONSE` | `MASC_FORCE_JSON_RESPONSE` | MASC_* 네임스페이스 관례. transport 플래그라 1회 WARN(module init) — 무언 무시는 응답 프레이밍을 몰래 바꿈 |

## 검증 (로컬)

- `test_start_masc_script` **23/23**, `test_start_masc_mcp_script` green (픽스처에서 별칭 제거 동반)
- `masc_server` 컴파일, `bash -n` 양 스크립트
- 외부 설정자 조사: CI yml은 `DUNE_JOBS`만 설정(별칭 미사용), 나머지 3가족은 오퍼레이터 셸 전용 — #25123 감사 Class 4 근거

## 관련

- #25123 (캠페인 마스터 — Wave 2 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
