### PR TITLE
refactor(runtime)!: delete dead context-window hint stubs

### DIFF
--- a/lib/runtime/runtime_candidate.ml
+++ b/lib/runtime/runtime_candidate.ml
@@ -79,21 +79,10 @@ let runtime_health_keys_of_labels labels =
   |> List.filter_map runtime_health_key_of_label
   |> List.sort_uniq String.compare
 
-type context_window_hint =
-  { context_window : int
-  ; is_local_model : bool
-  }
-
 type attempt_timeout_resolution =
   { timeout_s : float option
   ; source : string
   }
-
-(* Collapsed: the deleted version was already a no-op stub (tier-based local
-   classification removed); context window comes from the Runtime model spec. *)
-let context_window_hint_of_labels labels =
-  let _ = labels in
-  { context_window = 0; is_local_model = false }
 
 let runtime_id_of_label label =
   match Provider_kind_resolver.resolve label with

--- a/lib/runtime/runtime_candidate.mli
+++ b/lib/runtime/runtime_candidate.mli
@@ -1,10 +1,5 @@
 type t
 
-type context_window_hint =
-  { context_window : int
-  ; is_local_model : bool
-  }
-
 type attempt_timeout_resolution =
   { timeout_s : float option
   ; source : string
@@ -32,7 +27,6 @@ val is_structurally_unmetered_runtime_provider : string -> bool
 val runtime_label_for_active_id : configured_labels:string list -> active:string -> string
 val runtime_health_keys_of_labels : string list -> string list
 val resolve_reported_runtime_id : labels:string list -> reported_runtime_id:string -> string
-val context_window_hint_of_labels : string list -> context_window_hint
 val threshold_multipliers_of_runtime_id : string -> float * float
 
 val health_key : t -> string

--- a/lib/runtime_model/runtime_provider_binding.ml
+++ b/lib/runtime_model/runtime_provider_binding.ml
@@ -164,16 +164,6 @@ let label_matches_runtime_id ~label ~runtime_id =
   (not (String.equal runtime_id "")) && String.equal label_id runtime_id
 ;;
 
-type context_window_hint =
-  { context_window : int
-  ; is_local_model : bool
-  }
-
-let context_window_hint_of_labels labels =
-  let _ = labels in
-  { context_window = 0; is_local_model = false }
-;;
-
 let provider_name_matches_default_local_openai_runtime provider_name =
   match default_local_openai_runtime_provider_id () with
   | Some id -> String.equal (normalize_provider_id provider_name) (normalize_provider_id id)

--- a/lib/runtime_model/runtime_provider_binding.mli
+++ b/lib/runtime_model/runtime_provider_binding.mli
@@ -52,13 +52,6 @@ val normalize_runtime_name_for_bucket : string -> string
 
 val label_matches_runtime_id : label:string -> runtime_id:string -> bool
 
-type context_window_hint =
-  { context_window : int
-  ; is_local_model : bool
-  }
-
-val context_window_hint_of_labels : string list -> context_window_hint
-
 val provider_name_matches_default_local_openai_runtime : string -> bool
 
 val provider_name_matches_kind_default :


### PR DESCRIPTION
## Summary
- delete both zero-caller context_window_hint APIs
- remove their fabricated zero-capacity records
- keep runtime capacity ownership in the typed Runtime model contract

## Boundary
- no Keeper stop or admission behavior added
- no provider/tool/product matching
- no compatibility shim

## Verification
- 4 files, 34 deletions
- OCaml parser pass
- ocamlformat pass
- git diff --check pass
- residue search: zero context_window_hint references
- full build/test authority: PR CI

Stacked on #25195.