### PR TITLE
fix(fs): type atomic temp creation failures

### DIFF
--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -2524,25 +2524,32 @@ let save_file_atomic
   : (unit, string) Result.t
   =
   let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
+  let error exn =
+    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
   in
   try
-    save_file tmp content;
-    fsync_path tmp;
-    Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
-    Ok ()
+    let tmp =
+      Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
+    in
+    (try
+       save_file tmp content;
+       fsync_path tmp;
+       Stdlib.Sys.rename tmp path;
+       (try fsync_path dir with
+        | Unix.Unix_error _ -> ());
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn ->
+       (try Stdlib.Sys.remove tmp with
+        | Sys_error _ -> ());
+       raise exn
+     | exn ->
+       (try Stdlib.Sys.remove tmp with
+        | Sys_error _ -> ());
+       error exn)
   with
-  | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    raise e
-  | exn ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> error exn
 ;;
 
 let has_atomic_temp_shape ~prefix name =

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -2549,7 +2549,10 @@ let save_file_atomic
        error exn)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> error exn
+  (* Filename.temp_file's only documented failure is Sys_error; anything
+     else (Out_of_memory, Assert_failure, ...) is fatal and must stay loud
+     rather than collapse into the string error channel. *)
+  | Sys_error _ as exn -> error exn
 ;;
 
 let has_atomic_temp_shape ~prefix name =

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -9,8 +9,7 @@
 
     Crash recovery is provided by [cleanup_atomic_orphans], a boot-time sweep
     for canonical [.atomic_*.tmp] files left behind when the owning process was
-    SIGKILL'd or temp-file creation itself raised ENFILE/EMFILE before the
-    with-handler could register.
+    SIGKILL'd after creating its temp file.
 
     The [save_file] primitive is injected so this module stays free of
     [Fs_compat]'s Eio bridge. Recovery uses only typed [Unix] operations and
@@ -20,8 +19,8 @@
     a temp file in [path]'s directory, fsyncs the tmp, renames it
     over [path], and best-effort fsyncs the parent directory.
 
-    Returns [Ok ()] on success or [Error msg] when the write or
-    rename fails (the tmp is cleaned up). Re-raises
+    Returns [Ok ()] on success or [Error msg] when temp-file creation,
+    writing, fsync, or rename fails (an existing tmp is cleaned up). Re-raises
     [Eio.Cancel.Cancelled] after cleaning up the tmp — cancellation
     must not be swallowed (RFC-0143). *)
 val save_file_atomic

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -127,6 +127,26 @@ let test_save_file_atomic_overwrites_existing () =
   check string "overwrite succeeded" "new" (Fs_compat.load_file target)
 ;;
 
+let test_save_file_atomic_returns_temp_creation_failure () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir
+  @@ fun base ->
+  let blocked = Filename.concat base "blocked" in
+  let target = Filename.concat blocked "out.json" in
+  Unix.mkdir blocked 0o700;
+  Unix.chmod blocked 0o500;
+  let result =
+    Fun.protect
+      ~finally:(fun () -> Unix.chmod blocked 0o700)
+      (fun () -> Fs_compat.save_file_atomic target "new")
+  in
+  match result with
+  | Error message ->
+    check bool "temp creation error names the atomic operation" true
+      (String.starts_with message ~prefix:"save_file_atomic ")
+  | Ok () -> fail "atomic save unexpectedly wrote into a non-writable directory"
+;;
+
 let test_read_dir_and_path_kind_use_typed_inventory ~fs () =
   with_tmp_dir
   @@ fun base ->
@@ -422,6 +442,10 @@ let () =
             "overwrites existing target"
             `Quick
             test_save_file_atomic_overwrites_existing
+        ; test_case
+            "returns temp creation failure"
+            `Quick
+            test_save_file_atomic_returns_temp_creation_failure
         ; test_case
             "temp writer uses canonical shared shape"
             `Quick


### PR DESCRIPTION
## 문제

`Atomic_write.save_file_atomic`은 `(unit, string) result` 경계를 제공하지만,
`Filename.temp_file`이 `try` 바깥에 있어 임시 파일 생성 실패가 예외로 누출됐습니다.
Keeper queue의 WAL commit 이후 checkpoint 저장이 실패할 때 이 예외가 typed
`Committed_followup_failed` 경로를 우회했습니다.

Fixes #25201

## 변경

- 임시 파일 생성부터 write/fsync/rename까지 전체 I/O 경계를 `Result`로 반환
- temp가 생성된 뒤 실패한 경우에만 정리
- `Eio.Cancel.Cancelled`는 기존 계약대로 다시 raise
- `Filename.temp_file`의 문서화된 `Sys_error`만 Result로 내리고 fatal exception은 전파
- 쓰기 불가 디렉터리에서 temp 생성 실패가 `Error`로 돌아오는 회귀 테스트 추가
- 인터페이스 문서를 실제 실패 경계와 일치하도록 수정

정책적 재시도, 휴리스틱, stub 또는 silent fallback은 추가하지 않습니다.

## 검증

- `ocamlformat --check lib/fs_compat/atomic_write.ml lib/fs_compat/atomic_write.mli test/test_fs_compat.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_fs_compat.exe test/test_keeper_event_queue_state_v2.exe`
- `ALCOTEST_COMPACT=true _build/default/test/test_fs_compat.exe` — 17/17 pass
- `ALCOTEST_COMPACT=true _build/default/test/test_keeper_event_queue_state_v2.exe` — 16/16 pass

Exact head `c3f92fe28b56f333974cca7a88207930ab8cdc3e`에서 GitHub Build and
Test, Health, Lint, ocamlformat-check와 CI Gate가 모두 통과했습니다.
