### PR TITLE
refactor(keeper): type compaction planner failures

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -68,8 +68,10 @@ let register_record_pre_compact
 type compaction_rejection =
   | Runtime_identity_unavailable
   | Summarizer_unavailable
-  | Plan_unavailable_or_invalid
+  | Plan_provider_unavailable
+  | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
+  | No_eligible_history
   | Structurally_unchanged
   | Checkpoint_not_reduced
   | Invalid_structural_evidence of Keeper_compaction_evidence.decode_error
@@ -77,9 +79,11 @@ type compaction_rejection =
 let compaction_rejection_to_tag = function
   | Runtime_identity_unavailable -> "runtime_identity_unavailable"
   | Summarizer_unavailable -> "summarizer_unavailable"
-  | Plan_unavailable_or_invalid -> "plan_unavailable_or_invalid"
+  | Plan_provider_unavailable -> "plan_provider_unavailable"
+  | Invalid_compaction_plan -> "invalid_compaction_plan"
   | Invalid_structure error ->
     "invalid_structure:" ^ Keeper_compaction_unit.show_structural_error error
+  | No_eligible_history -> "no_eligible_history"
   | Structurally_unchanged -> "structurally_unchanged"
   | Checkpoint_not_reduced -> "checkpoint_not_reduced"
   | Invalid_structural_evidence _ -> "invalid_structural_evidence"
@@ -266,10 +270,10 @@ let selected_message_count units selected =
 let requested_messages (meta : keeper_meta) messages =
   match Keeper_compaction_unit.partition messages with
   | Error error -> Error (Invalid_structure error)
-  | Ok { closed_prefix = []; _ } -> Error Structurally_unchanged
+  | Ok { closed_prefix = []; _ } -> Error No_eligible_history
   | Ok { closed_prefix = units; protected_suffix } ->
     if not (Keeper_compaction_llm_summarizer.has_eligible_units units)
-    then Error Structurally_unchanged
+    then Error No_eligible_history
     else
       (match compaction_runtime_ids meta with
        | [] -> Error Runtime_identity_unavailable
@@ -283,8 +287,11 @@ let requested_messages (meta : keeper_meta) messages =
           | None -> Error Summarizer_unavailable
           | Some summarize ->
             (match summarize ~units with
-             | None -> Error Plan_unavailable_or_invalid
-             | Some plan ->
+             | Error Keeper_compaction_llm_summarizer.Provider_unavailable ->
+               Error Plan_provider_unavailable
+             | Error Keeper_compaction_llm_summarizer.Invalid_plan ->
+               Error Invalid_compaction_plan
+             | Ok plan ->
                if not (Keeper_compaction_llm_summarizer.has_changes plan)
                then Error Structurally_unchanged
                else

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -6,8 +6,10 @@
 type compaction_rejection =
   | Runtime_identity_unavailable
   | Summarizer_unavailable
-  | Plan_unavailable_or_invalid
+  | Plan_provider_unavailable
+  | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
+  | No_eligible_history
   | Structurally_unchanged
   | Checkpoint_not_reduced
   | Invalid_structural_evidence of Keeper_compaction_evidence.decode_error

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -30,8 +30,13 @@ type compaction_plan =
   ; source_units : Keeper_compaction_unit.closed_unit list
   }
 
+type summarization_failure =
+  | Provider_unavailable
+  | Invalid_plan
+
 type summarizer =
-  units:Keeper_compaction_unit.closed_unit list -> compaction_plan option
+  units:Keeper_compaction_unit.closed_unit list ->
+  (compaction_plan, summarization_failure) result
 
 type complete_fn = Keeper_provider_subcall.complete_fn
 
@@ -349,9 +354,9 @@ let run_plan
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~units
-    () : compaction_plan option =
+    () : (compaction_plan, summarization_failure) result =
   if not (has_eligible_units units)
-  then None
+  then Error Invalid_plan
   else
     let provider_cfg = provider_for_plan provider_cfg in
     let request = messages_for_plan ~units in
@@ -363,15 +368,15 @@ let run_plan
       Log.Keeper.warn ~keeper_name
         "compaction LLM plan failed runtime=%s: %s"
         runtime_id (Provider_http_error.to_message err);
-      None
+      Error Provider_unavailable
     | Ok response ->
       (match plan_of_response ~runtime_id ~units response with
-       | Ok plan -> Some plan
+       | Ok plan -> Ok plan
        | Error detail ->
          Log.Keeper.warn ~keeper_name
            "compaction LLM plan rejected runtime=%s: %s"
            runtime_id detail;
-         None)
+         Error Invalid_plan)
 
 type candidate =
   { runtime_id : string
@@ -470,26 +475,29 @@ let make_resolved ?complete ~(runtime_ids : string list) ~(keeper_name : string)
        let clock = Eio_context.get_clock_opt () in
        Some
          (fun ~units ->
-           let rec attempt = function
+           let rec attempt saw_provider_failure = function
              | [] ->
                Log.Keeper.warn ~keeper_name
                  "compaction LLM candidate chain exhausted assignments=%s"
                  assignments_label;
-               None
+               if saw_provider_failure
+               then Error Provider_unavailable
+               else Error Invalid_plan
              | candidate :: rest ->
                (match
                   run_plan ?complete ?clock ~keeper_name
                     ~runtime_id:candidate.runtime_id ~sw ~net
                     ~provider_cfg:candidate.provider_cfg ~units ()
                 with
-                | Some _ as plan ->
+                | Ok _ as plan ->
                   Log.Keeper.info ~keeper_name
                     "compaction LLM candidate succeeded assignments=%s runtime=%s"
                     assignments_label candidate.runtime_id;
                   plan
-                | None -> attempt rest)
+                | Error Provider_unavailable -> attempt true rest
+                | Error Invalid_plan -> attempt saw_provider_failure rest)
            in
-           attempt candidates)
+           attempt false candidates)
      | _ ->
        List.iter
          (fun candidate ->

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -7,12 +7,16 @@
     plan cannot be applied to a different source. *)
 type compaction_plan
 
-(** [summarizer ~units] returns [Some plan] when the LLM produced a valid plan
-    over [units], or [None] on any failure (provider error, empty
-    or invalid structured response). Total and synchronous; the effect is
-    hidden in the closure captured by {!make}. *)
+type summarization_failure =
+  | Provider_unavailable
+  | Invalid_plan
+
+(** A provider/transport failure remains retryable; a response that reached
+    the exact source but violated the closed plan contract is a typed terminal
+    for that source. *)
 type summarizer =
-  units:Keeper_compaction_unit.closed_unit list -> compaction_plan option
+  units:Keeper_compaction_unit.closed_unit list ->
+  (compaction_plan, summarization_failure) result
 
 (** The low-level provider completion the summarizer drives. Defaulted to
     {!Llm_provider.Complete.complete}; overridable in tests. *)

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -124,11 +124,13 @@ let compaction_recovery_error_data ?dispatch_error error =
         Keeper_checkpoint_store.Ref_not_found -> Not_found
     | Compaction_rejected Runtime_identity_unavailable
     | Compaction_rejected (Invalid_structure _)
+    | Compaction_rejected No_eligible_history
     | Compaction_rejected Structurally_unchanged
     | Compaction_rejected Checkpoint_not_reduced ->
       Precondition_failed
     | Compaction_rejected Summarizer_unavailable
-    | Compaction_rejected Plan_unavailable_or_invalid
+    | Compaction_rejected Plan_provider_unavailable
+    | Compaction_rejected Invalid_compaction_plan
     | Compaction_rejected (Invalid_structural_evidence _)
     | Compaction_evidence_missing
     | Unexpected_compaction_decision _

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -108,6 +108,29 @@ let test_regular_post_turn_does_not_auto_compact () =
     check bool "checkpoint messages retained exactly" true
       (retained.messages = checkpoint.messages)
 
+let test_invalid_plan_is_distinct_from_provider_unavailable () =
+  let meta = make_meta () in
+  let context =
+    Masc.Keeper_context_core.context_of_oas_checkpoint (make_checkpoint ())
+  in
+  let decision failure =
+    Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+      (fun ~runtime_ids:_ ~keeper_name:_ () ->
+         Some (fun ~units:_ -> Error failure))
+      (fun () ->
+         Compact_policy.compact_for_request_typed
+           ~meta
+           ~trigger:Compaction_trigger.Manual
+           context)
+    |> fun preparation -> preparation.Compact_policy.decision
+  in
+  (match decision Masc.Keeper_compaction_llm_summarizer.Invalid_plan with
+   | Compact_policy.Rejected (Manual, Invalid_compaction_plan) -> ()
+   | _ -> fail "invalid provider plan was not a typed source terminal");
+  match decision Masc.Keeper_compaction_llm_summarizer.Provider_unavailable with
+  | Compact_policy.Rejected (Manual, Plan_provider_unavailable) -> ()
+  | _ -> fail "provider failure was collapsed into an invalid plan"
+
 let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
@@ -338,7 +361,8 @@ let test_manual_compaction_serializes_owner_lane () =
                              ]
                          ] )
                    ])
-               |> Result.to_option))
+               |> Result.map_error (fun _ ->
+                 Masc.Keeper_compaction_llm_summarizer.Invalid_plan)))
           run_cycle
       in
       (match outcome with
@@ -417,7 +441,8 @@ let test_manual_compaction_serializes_owner_lane () =
                              ]
                          ] )
                    ])
-               |> Result.to_option))
+               |> Result.map_error (fun _ ->
+                 Masc.Keeper_compaction_llm_summarizer.Invalid_plan)))
           (fun () ->
              Post_turn.recover_latest_checkpoint_for_compaction
                ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
@@ -491,6 +516,8 @@ let () =
         `Quick test_compaction_rejection_tag_is_stable;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
+      test_case "invalid plan is distinct from provider unavailability"
+        `Quick test_invalid_plan_is_distinct_from_provider_unavailable;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "malformed structure preserves checkpoint"


### PR DESCRIPTION
## Why

The compaction planner collapsed provider/transport failure and an invalid structured plan into one optional absence. That made the caller unable to distinguish a retryable provider outage from a source-bound terminal result.

## What

- return a typed result from the LLM summarizer
- keep provider/transport failure retryable
- classify a reached-but-invalid plan separately
- distinguish no eligible closed history from an unchanged valid plan

## Scope

First leaf of a three-PR stack. 102 changed lines (76 additions, 26 deletions). No queue settlement behavior changes yet.

## Validation

- ocamlformat on touched files
- ocamlc -stop-after parsing on touched implementations
- focused Dune build queued behind the shared repo lock; CI is the full-build authority