### PR TITLE
feat(keeper): persist typed no-compaction settlement

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -268,8 +268,6 @@ let settlement_of_failure ~settled_at failure =
   match failure.Keeper_unified_turn.source_lease_disposition with
   | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
     Keeper_registry_event_queue.Ack
-  | Keeper_unified_turn.Acknowledge_after_no_compaction { source; reason } ->
-    Keeper_registry_event_queue.No_compaction { source; reason }
   | Keeper_unified_turn.Requeue_after_context_compaction ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
@@ -812,7 +810,6 @@ let run_keepalive_unified_turn
           | Some (Cycle.Failed { failure; _ }) ->
             (match failure.Keeper_unified_turn.source_lease_disposition with
              | Keeper_unified_turn.Requeue_after_context_compaction
-             | Keeper_unified_turn.Acknowledge_after_no_compaction _
              | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
              | Keeper_unified_turn.Follow_failure_route ->
                (match failure.Keeper_unified_turn.route with

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -268,6 +268,8 @@ let settlement_of_failure ~settled_at failure =
   match failure.Keeper_unified_turn.source_lease_disposition with
   | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
     Keeper_registry_event_queue.Ack
+  | Keeper_unified_turn.Acknowledge_after_no_compaction { source; reason } ->
+    Keeper_registry_event_queue.No_compaction { source; reason }
   | Keeper_unified_turn.Requeue_after_context_compaction ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
@@ -379,6 +381,8 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
   | Some (Cycle.Manual_compaction_failed _) ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
+  | Some (Cycle.Manual_compaction_not_applied { no_compaction = { source; reason }; _ }) ->
+    Keeper_registry_event_queue.No_compaction { source; reason }
   | None ->
     if stop_requested
     then Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Cancelled
@@ -411,7 +415,8 @@ let settle_claimed_lease
 ;;
 
 let settlement_is_ack = function
-  | Keeper_registry_event_queue.Ack -> true
+  | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.No_compaction _ -> true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false
@@ -473,6 +478,7 @@ let run_keepalive_unified_turn
           | Cycle.Busy _
           | Cycle.Judgment_settled _
           | Cycle.Manual_compaction_failed _
+          | Cycle.Manual_compaction_not_applied _
           | Cycle.Manual_compaction_applied _ )
       | None ->
         record_crashed_cycle_failure
@@ -806,6 +812,7 @@ let run_keepalive_unified_turn
           | Some (Cycle.Failed { failure; _ }) ->
             (match failure.Keeper_unified_turn.source_lease_disposition with
              | Keeper_unified_turn.Requeue_after_context_compaction
+             | Keeper_unified_turn.Acknowledge_after_no_compaction _
              | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
              | Keeper_unified_turn.Follow_failure_route ->
                (match failure.Keeper_unified_turn.route with
@@ -841,6 +848,9 @@ let run_keepalive_unified_turn
           | Some (Cycle.Manual_compaction_failed _) ->
             record_settlement_failure
               "manual compaction failed without an owning event queue lease"
+          | Some (Cycle.Manual_compaction_not_applied _) ->
+            record_settlement_failure
+              "manual no-compaction terminal has no owning event queue lease"
           | Some (Cycle.Manual_compaction_applied _) ->
             record_settlement_failure
               "manual compaction completed without an owning event queue lease"

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -55,6 +55,10 @@ type cycle_outcome =
       { meta : keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
+  | Manual_compaction_not_applied of
+      { meta : keeper_meta
+      ; no_compaction : Keeper_post_turn.no_compaction
+      }
   | Manual_compaction_applied of cycle_outcome
 
 and failure_judgment_terminal =
@@ -71,7 +75,8 @@ let rec meta = function
   | Failed { meta; _ }
   | Busy { meta; _ }
   | Judgment_settled { meta; _ }
-  | Manual_compaction_failed { meta; _ } ->
+  | Manual_compaction_failed { meta; _ }
+  | Manual_compaction_not_applied { meta; _ } ->
     meta
   | Manual_compaction_applied outcome -> meta outcome
 ;;
@@ -80,13 +85,15 @@ let rec turn_failure = function
   | Failed { failure; _ } -> Some failure
   | Manual_compaction_applied outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Busy _
-  | Judgment_settled _ | Manual_compaction_failed _ -> None
+  | Judgment_settled _ | Manual_compaction_failed _
+  | Manual_compaction_not_applied _ -> None
 ;;
 
 let manual_compaction_followup_failure = function
   | Manual_compaction_applied outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Failed _ | Busy _
-  | Judgment_settled _ | Manual_compaction_failed _ -> None
+  | Judgment_settled _ | Manual_compaction_failed _
+  | Manual_compaction_not_applied _ -> None
 ;;
 
 let record_failure_judgment_outcome
@@ -400,5 +407,11 @@ let run_keeper_cycle
          "manual compaction failed in owner lane: %s"
          (Keeper_manual_compaction.failure_to_string failure);
        Manual_compaction_failed { meta = meta_after_triage; failure }
+     | `No_compaction no_compaction ->
+       Log.Keeper.info
+         ~keeper_name:meta_after_triage.name
+         "manual compaction reached typed terminal: %s"
+         (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
+       Manual_compaction_not_applied { meta = meta_after_triage; no_compaction }
      | `Applied _success -> Manual_compaction_applied (run_standard_cycle ()))
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -20,6 +20,10 @@ type cycle_outcome =
       { meta : Keeper_meta_contract.keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
+  | Manual_compaction_not_applied of
+      { meta : Keeper_meta_contract.keeper_meta
+      ; no_compaction : Keeper_post_turn.no_compaction
+      }
   | Manual_compaction_applied of cycle_outcome
 
 and failure_judgment_terminal =

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -4,6 +4,10 @@ type success =
   ; manifest : (unit, string) result
   }
 
+type operation_outcome =
+  | Compacted of success
+  | No_compaction of Keeper_post_turn.no_compaction
+
 type lifecycle_stage =
   | Operator_request
   | Compaction_started
@@ -105,6 +109,13 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
             ~meta
             ~trigger:Compaction_trigger.Manual
         with
+        | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
+          let failure_dispatch =
+            dispatch_failed (Keeper_post_turn.compaction_recovery_error_to_tag error)
+          in
+          (match failure_dispatch with
+           | Ok () -> Ok (No_compaction no_compaction)
+           | Error _ -> Error (Recovery (error, failure_dispatch)))
         | Error error ->
           let failure_dispatch =
             dispatch_failed (Keeper_post_turn.compaction_recovery_error_to_tag error)
@@ -129,7 +140,7 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
              Keeper_unified_metrics.broadcast_compaction
                ~name:meta.name
                recovery;
-             Ok { recovery; manifest })))
+             Ok (Compacted { recovery; manifest }))))
 ;;
 
 let lifecycle_stage_to_string = function
@@ -193,7 +204,8 @@ let run_admitted ~(config : Workspace.config) ~(meta : keeper_meta) =
   with
   | `Busy block -> `Busy block
   | `Ran (Error failure) -> `Compaction_failed failure
-  | `Ran (Ok success) ->
+  | `Ran (Ok (Compacted success)) ->
     observe_manifest ~keeper_name:meta.name success.manifest;
     `Applied success
+  | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction
 ;;

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -3,6 +3,10 @@ type success =
   ; manifest : (unit, string) result
   }
 
+type operation_outcome =
+  | Compacted of success
+  | No_compaction of Keeper_post_turn.no_compaction
+
 type lifecycle_stage =
   | Operator_request
   | Compaction_started
@@ -27,12 +31,13 @@ type failure =
 val run
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
-  -> (success, failure) result
+  -> (operation_outcome, failure) result
 
 val run_admitted
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> [ `Applied of success
+     | `No_compaction of Keeper_post_turn.no_compaction
      | `Compaction_failed of failure
      | `Busy of Keeper_turn_admission.autonomous_block
      ]

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -60,14 +60,17 @@ type compaction_recovery = {
   turn_generation : int;
 }
 
+type no_compaction = Keeper_event_queue_state.no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : Keeper_event_queue_state.no_compaction_reason
+  }
+
 type compaction_recovery_error =
   | Checkpoint_ref_load_failed of Keeper_checkpoint_store.checkpoint_ref_load_error
   | Checkpoint_cas_failed of Keeper_checkpoint_store.checkpoint_cas_error
-  | Checkpoint_structure_invalid of Keeper_compaction_unit.structural_error
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
-  | Compaction_evidence_missing
-  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | No_compaction of no_compaction
 
 let compaction_recovery_error_to_tag = function
   | Checkpoint_ref_load_failed Keeper_checkpoint_store.Ref_not_found ->
@@ -89,12 +92,11 @@ let compaction_recovery_error_to_tag = function
     "checkpoint_commit_durability_unknown"
   | Checkpoint_cas_failed (Transaction_outcome_unknown _) ->
     "checkpoint_transaction_outcome_unknown"
-  | Checkpoint_structure_invalid _ -> "checkpoint_structure_invalid"
   | Checkpoint_candidate_failed _ -> "checkpoint_candidate_failed"
   | Compaction_rejected reason ->
     Keeper_compact_policy.compaction_rejection_to_tag reason
-  | Compaction_evidence_missing -> "compaction_evidence_missing"
-  | Unexpected_compaction_decision _ -> "unexpected_compaction_decision"
+  | No_compaction { reason; _ } ->
+    "no_compaction:" ^ Keeper_event_queue_state.no_compaction_reason_label reason
 
 let checkpoint_load_error_detail = function
   | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
@@ -174,18 +176,18 @@ let checkpoint_cas_error_detail = function
 let compaction_recovery_error_to_string = function
   | Checkpoint_ref_load_failed error -> checkpoint_ref_load_error_detail error
   | Checkpoint_cas_failed error -> checkpoint_cas_error_detail error
-  | Checkpoint_structure_invalid error ->
-    "checkpoint structure invalid: "
-    ^ Keeper_compaction_unit.show_structural_error error
   | Checkpoint_candidate_failed detail -> detail
   | Compaction_rejected reason ->
     "compaction rejected: "
     ^ Keeper_compact_policy.compaction_rejection_to_string reason
-  | Compaction_evidence_missing ->
-    "prepared compaction did not carry structural evidence"
-  | Unexpected_compaction_decision decision ->
-    "unexpected compaction decision: "
-    ^ Keeper_compact_policy.compaction_decision_to_string decision
+  | No_compaction { source; reason } ->
+    Printf.sprintf
+      "no compaction for trace_id=%s generation=%d turn_count=%d sha256=%s: %s"
+      (Keeper_id.Trace_id.to_string source.trace_id)
+      source.generation
+      source.turn_count
+      source.sha256
+      (Keeper_event_queue_state.no_compaction_reason_label reason)
 
 (* ── Tier A6: resilience post-turn wire-in (Cycle 23) ──────────────
    Feature-flag-gated layer that runs before tool emission and
@@ -486,6 +488,19 @@ let commit_prepared_after_save ~trigger ~save =
   | Ok checkpoint -> Ok (checkpoint, trigger)
 ;;
 
+let terminal_reason_of_rejection = function
+  | Keeper_compact_policy.No_eligible_history ->
+    Some Keeper_event_queue_state.No_eligible_history
+  | Invalid_structure _ -> Some Invalid_structural_source
+  | Structurally_unchanged -> Some Structurally_unchanged
+  | Checkpoint_not_reduced -> Some Checkpoint_not_reduced
+  | Invalid_compaction_plan
+  | Invalid_structural_evidence _
+  | Runtime_identity_unavailable
+  | Summarizer_unavailable
+  | Plan_provider_unavailable -> None
+;;
+
 let recover_latest_checkpoint_for_compaction
     ~(base_dir : string)
     ~(meta : keeper_meta)
@@ -534,7 +549,13 @@ let recover_latest_checkpoint_for_compaction
     in
     (match preparation.decision, preparation.evidence with
      | Keeper_compact_policy.Prepared _, None ->
-       Error Compaction_evidence_missing
+       (* Prepared-without-evidence is a planner invariant violation (a bug),
+          not a deterministic no-op: it must surface as a visible failure,
+          never settle as a durable terminal no-compaction. *)
+       Error
+         (Checkpoint_candidate_failed
+            "compaction preparation completed without structural evidence \
+             (planner invariant violation)")
      | Keeper_compact_policy.Prepared prepared_trigger, Some evidence ->
        (try
           match
@@ -551,8 +572,11 @@ let recover_latest_checkpoint_for_compaction
                   ~expected_source_ref:source_ref
                 |> Result.map fst
                 |> Result.map_error (function
-                  | Tool_history_invalid error ->
-                    Checkpoint_structure_invalid error
+                  | Tool_history_invalid _ ->
+                    No_compaction
+                      { source = source_ref
+                      ; reason = Keeper_event_queue_state.Invalid_structural_source
+                      }
                   | Persistence_error error -> Checkpoint_cas_failed error))
           with
           | Ok (saved_checkpoint, trigger) ->
@@ -597,8 +621,17 @@ let recover_latest_checkpoint_for_compaction
             exn;
           Error (Checkpoint_candidate_failed detail))
      | Keeper_compact_policy.Rejected (_, reason), _ ->
-       Error (Compaction_rejected reason)
+       (match terminal_reason_of_rejection reason with
+        | Some reason -> Error (No_compaction { source = source_ref; reason })
+        | None -> Error (Compaction_rejected reason))
      | (Keeper_compact_policy.Applied _
        | Keeper_compact_policy.Not_requested
        | Keeper_compact_policy.Skipped_no_checkpoint) as decision, _ ->
-       Error (Unexpected_compaction_decision decision))
+       (* Reaching recovery with a non-preparation decision is an invariant
+          violation: surface it as a visible failure with the decision
+          detail, never as a hidden terminal no-compaction. *)
+       Error
+         (Checkpoint_candidate_failed
+            (Printf.sprintf
+               "compaction recovery reached a non-preparation decision: %s"
+               (Keeper_compact_policy.compaction_decision_to_string decision))))

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -35,14 +35,17 @@ type compaction_recovery =
   ; turn_generation : int
   } [@@warning "-69"]
 
+type no_compaction = Keeper_event_queue_state.no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : Keeper_event_queue_state.no_compaction_reason
+  }
+
 type compaction_recovery_error =
   | Checkpoint_ref_load_failed of Keeper_checkpoint_store.checkpoint_ref_load_error
   | Checkpoint_cas_failed of Keeper_checkpoint_store.checkpoint_cas_error
-  | Checkpoint_structure_invalid of Keeper_compaction_unit.structural_error
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
-  | Compaction_evidence_missing
-  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | No_compaction of no_compaction
 
 val compaction_recovery_error_to_tag : compaction_recovery_error -> string
 val compaction_recovery_error_to_string : compaction_recovery_error -> string

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -21,6 +21,7 @@ type stimulus_kind =
 type reaction_kind =
   | Turn_started
   | Event_queue_ack
+  | Event_queue_no_compaction
   | Event_queue_requeued
   | Event_queue_escalated
   | Cursor_ack
@@ -69,6 +70,7 @@ let stimulus_kind_of_string = function
 let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
   | Event_queue_ack -> "event_queue_ack"
+  | Event_queue_no_compaction -> "event_queue_no_compaction"
   | Event_queue_requeued -> "event_queue_requeued"
   | Event_queue_escalated -> "event_queue_escalated"
   | Cursor_ack -> "cursor_ack"
@@ -79,6 +81,7 @@ let reaction_kind_to_string = function
 let reaction_kind_of_string = function
   | "turn_started" -> Ok Turn_started
   | "event_queue_ack" -> Ok Event_queue_ack
+  | "event_queue_no_compaction" -> Ok Event_queue_no_compaction
   | "event_queue_requeued" -> Ok Event_queue_requeued
   | "event_queue_escalated" -> Ok Event_queue_escalated
   | "cursor_ack" -> Ok Cursor_ack
@@ -291,6 +294,7 @@ let record_event_queue_turn_started ~base_path ~keeper_name stimulus =
 
 let reaction_kind_of_settlement = function
   | Keeper_event_queue_state.Ack -> Event_queue_ack
+  | Keeper_event_queue_state.No_compaction _ -> Event_queue_no_compaction
   | Keeper_event_queue_state.Requeue _ -> Event_queue_requeued
   | Keeper_event_queue_state.Escalate _ -> Event_queue_escalated
 ;;
@@ -663,16 +667,27 @@ let require_finite_float ~missing ~non_finite field json =
 let reaction_kind_matches_settlement reaction_kind settlement =
   match reaction_kind, settlement with
   | Event_queue_ack, Keeper_event_queue_state.Ack -> true
+  | Event_queue_no_compaction, Keeper_event_queue_state.No_compaction _ -> true
   | Event_queue_requeued, Keeper_event_queue_state.Requeue _ -> true
   | Event_queue_escalated, Keeper_event_queue_state.Escalate _ -> true
   | Turn_started, _
   | Cursor_ack, _
   | Event_queue_ack,
-    (Keeper_event_queue_state.Requeue _ | Keeper_event_queue_state.Escalate _)
+    ( Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Requeue _
+    | Keeper_event_queue_state.Escalate _ )
+  | Event_queue_no_compaction,
+    ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.Requeue _
+    | Keeper_event_queue_state.Escalate _ )
   | Event_queue_requeued,
-    (Keeper_event_queue_state.Ack | Keeper_event_queue_state.Escalate _)
+    ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Escalate _ )
   | Event_queue_escalated,
-    (Keeper_event_queue_state.Ack | Keeper_event_queue_state.Requeue _) -> false
+    ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Requeue _ ) -> false
 ;;
 
 let decode_reaction_stimulus_reference reaction =
@@ -790,7 +805,8 @@ let decode_reaction_row ~event_id metadata reaction =
     if String.equal event_id expected_event_id
     then Ok (Current_reaction { metadata; reaction_kind; transition_receipt = None })
     else Error Event_identity_mismatch
-  | (Event_queue_ack | Event_queue_requeued | Event_queue_escalated),
+  | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_requeued
+    | Event_queue_escalated ),
     "keeper_event_queue_settlement" ->
     let* transition_receipt =
       decode_transition_reaction
@@ -807,12 +823,13 @@ let decode_reaction_row ~event_id metadata reaction =
   | Cursor_ack, "keeper_world_observation.board_cursor" ->
     Error Reaction_source_mismatch
   | Turn_started, "keeper_event_queue_settlement"
-  | (Event_queue_ack | Event_queue_requeued | Event_queue_escalated),
+  | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_requeued
+    | Event_queue_escalated ),
     "keeper_event_queue"
   | Cursor_ack, ("keeper_event_queue" | "keeper_event_queue_settlement") ->
     Error Reaction_source_mismatch
-  | ( Turn_started | Event_queue_ack | Event_queue_requeued
-    | Event_queue_escalated | Cursor_ack ),
+  | ( Turn_started | Event_queue_ack | Event_queue_no_compaction
+    | Event_queue_requeued | Event_queue_escalated | Cursor_ack ),
     _ -> Error Unknown_reaction_source
 ;;
 
@@ -1053,7 +1070,8 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
              := max_recorded_at !event_queue_ack_recorded_at recorded_at
          | Current_reaction
              { reaction_kind =
-                 Event_queue_requeued | Event_queue_escalated | Cursor_ack
+                 ( Event_queue_no_compaction | Event_queue_requeued
+                 | Event_queue_escalated | Cursor_ack )
              ; _
              }
          | Current_cursor_ack _ -> ())
@@ -1291,6 +1309,7 @@ let summarize_rows ~keeper_name ~limit rows =
   let reaction_count = ref 0 in
   let turn_started_count = ref 0 in
   let event_queue_ack_count = ref 0 in
+  let event_queue_no_compaction_count = ref 0 in
   let event_queue_requeue_count = ref 0 in
   let event_queue_escalation_count = ref 0 in
   let event_queue_external_input_count = ref 0 in
@@ -1354,6 +1373,7 @@ let summarize_rows ~keeper_name ~limit rows =
     match reaction_kind, transition_receipt with
     | Turn_started, None -> incr turn_started_count
     | Event_queue_ack, Some _ -> incr event_queue_ack_count
+    | Event_queue_no_compaction, Some _ -> incr event_queue_no_compaction_count
     | Event_queue_requeued, Some _ -> incr event_queue_requeue_count
     | Event_queue_escalated, Some receipt ->
       incr event_queue_escalation_count;
@@ -1361,10 +1381,13 @@ let summarize_rows ~keeper_name ~limit rows =
        | Keeper_event_queue_state.Escalate { reason; _ } ->
          if Keeper_event_queue_state.escalation_reason_requests_external_input reason
          then incr event_queue_external_input_count
-       | Keeper_event_queue_state.Ack | Keeper_event_queue_state.Requeue _ -> ())
+       | Keeper_event_queue_state.Ack
+       | Keeper_event_queue_state.No_compaction _
+       | Keeper_event_queue_state.Requeue _ -> ())
     | Cursor_ack, None -> incr cursor_ack_count
     | Turn_started, Some _
-    | (Event_queue_ack | Event_queue_requeued | Event_queue_escalated), None
+    | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_requeued
+      | Event_queue_escalated ), None
     | Cursor_ack, Some _ -> ()
   in
   let note_current_row current_row =
@@ -1431,6 +1454,7 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "reaction_count", `Int !reaction_count
     ; "turn_started_count", `Int !turn_started_count
     ; "event_queue_ack_count", `Int !event_queue_ack_count
+    ; "event_queue_no_compaction_count", `Int !event_queue_no_compaction_count
     ; "event_queue_requeue_count", `Int !event_queue_requeue_count
     ; "event_queue_escalation_count", `Int !event_queue_escalation_count
     ; "event_queue_external_input_count", `Int !event_queue_external_input_count
@@ -1464,6 +1488,7 @@ let error_summary ~keeper_name ~limit error =
     ; "reaction_count", `Int 0
     ; "turn_started_count", `Int 0
     ; "event_queue_ack_count", `Int 0
+    ; "event_queue_no_compaction_count", `Int 0
     ; "event_queue_requeue_count", `Int 0
     ; "event_queue_escalation_count", `Int 0
     ; "cursor_ack_count", `Int 0

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -30,6 +30,7 @@ type stimulus_kind =
 type reaction_kind =
   | Turn_started
   | Event_queue_ack
+  | Event_queue_no_compaction
   | Event_queue_requeued
   | Event_queue_escalated
   | Cursor_ack

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -29,8 +29,20 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       ; rationale : string
       }
 
+type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
+  | No_eligible_history
+  | Invalid_structural_source
+  | Structurally_unchanged
+  | Checkpoint_not_reduced
+
+type no_compaction = Keeper_event_queue_persistence.no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : no_compaction_reason
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
+  | No_compaction of no_compaction
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -28,8 +28,20 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       ; rationale : string
       }
 
+type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
+  | No_eligible_history
+  | Invalid_structural_source
+  | Structurally_unchanged
+  | Checkpoint_not_reduced
+
+type no_compaction = Keeper_event_queue_persistence.no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : no_compaction_reason
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
+  | No_compaction of no_compaction
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -111,11 +111,9 @@ let compaction_recovery_error_data ?dispatch_error error =
       Outcome_unknown, `Null
     | Checkpoint_ref_load_failed _
     | Checkpoint_cas_failed _
-    | Checkpoint_structure_invalid _
     | Checkpoint_candidate_failed _
     | Compaction_rejected _
-    | Compaction_evidence_missing
-    | Unexpected_compaction_decision _ ->
+    | No_compaction _ ->
       Not_installed, `Bool false
   in
   let recovery_code =
@@ -126,14 +124,13 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Compaction_rejected (Invalid_structure _)
     | Compaction_rejected No_eligible_history
     | Compaction_rejected Structurally_unchanged
-    | Compaction_rejected Checkpoint_not_reduced ->
+    | Compaction_rejected Checkpoint_not_reduced
+    | No_compaction _ ->
       Precondition_failed
     | Compaction_rejected Summarizer_unavailable
     | Compaction_rejected Plan_provider_unavailable
     | Compaction_rejected Invalid_compaction_plan
     | Compaction_rejected (Invalid_structural_evidence _)
-    | Compaction_evidence_missing
-    | Unexpected_compaction_decision _
     | Checkpoint_ref_load_failed _
     | Checkpoint_cas_failed (Source_unavailable _)
     | Checkpoint_cas_failed (Candidate_identity_invalid _)
@@ -141,7 +138,6 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Checkpoint_cas_failed (Candidate_generation_mismatch _)
     | Checkpoint_cas_failed (Candidate_turn_regressed _)
     | Checkpoint_cas_failed (Commit_not_installed _)
-    | Checkpoint_structure_invalid _
     | Checkpoint_candidate_failed _ -> Internal_error
     | Checkpoint_cas_failed (Source_changed _)
     | Checkpoint_cas_failed (Commit_durability_unknown _)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -22,6 +22,7 @@ include Keeper_unified_turn_phase_plan
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
+  | Acknowledge_after_no_compaction of Keeper_post_turn.no_compaction
   | Acknowledge_after_in_turn_handling
 
 type turn_failure =
@@ -126,6 +127,7 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
 type provider_overflow_recovery =
   | Not_provider_overflow
   | Provider_overflow_applied of Keeper_context_runtime.compaction_recovery
+  | Provider_overflow_no_compaction of Keeper_post_turn.no_compaction
   | Provider_overflow_retry_without_checkpoint of
       { trigger : Compaction_trigger.t
       ; reason : string
@@ -172,16 +174,18 @@ let recover_provider_context_overflow_in_lane
           "compaction_failed"
           (Keeper_state_machine.Compaction_failed { reason })
       with
-      | Ok () -> ()
+      | Ok () -> Ok ()
       | Error detail ->
         Log.Keeper.error
           ~keeper_name:meta.name
           "provider overflow recovery could not release compaction lifecycle: %s"
-          detail
+          detail;
+        Error detail
     in
     let retry_after_started ?recovery reason =
       record_overflow_failure ~config ~meta ~reason;
-      release_failed_lifecycle reason;
+      (* fire-and-forget: retry proceeds from the recorded failure either way. *)
+      ignore (release_failed_lifecycle reason);
       match recovery with
       | None -> Provider_overflow_retry_without_checkpoint { trigger; reason }
       | Some recovery -> Provider_overflow_retry_with_checkpoint { reason; recovery }
@@ -201,6 +205,12 @@ let recover_provider_context_overflow_in_lane
                  ~meta
                  ~trigger
              with
+             | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
+               let reason = Keeper_post_turn.compaction_recovery_error_to_string error in
+               record_overflow_failure ~config ~meta ~reason;
+               (match release_failed_lifecycle reason with
+                | Ok () -> Provider_overflow_no_compaction no_compaction
+                | Error _ -> Provider_overflow_retry_without_checkpoint { trigger; reason })
              | Error error ->
                retry_after_started
                  (Keeper_post_turn.compaction_recovery_error_to_string error)
@@ -227,11 +237,23 @@ let recover_provider_context_overflow_in_lane
            | Eio.Cancel.Cancelled _ as exn ->
              let backtrace = Printexc.get_raw_backtrace () in
              Eio.Cancel.protect (fun () ->
-               try release_failed_lifecycle "provider overflow compaction cancelled" with
+               try
+                 match
+                   release_failed_lifecycle
+                     "provider overflow compaction cancelled"
+                 with
+                 | Ok () -> ()
+                 | Error detail ->
+                   Log.Keeper.error
+                     ~keeper_name:meta.name
+                     "provider overflow cancellation cleanup failed: %s"
+                     detail
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
                | cleanup_exn ->
                  Log.Keeper.error
                    ~keeper_name:meta.name
-                   "provider overflow cancellation cleanup failed: %s"
+                   "provider overflow cancellation cleanup raised: %s"
                    (Printexc.to_string cleanup_exn));
              Printexc.raise_with_backtrace exn backtrace
            | exn -> retry_after_started (Printexc.to_string exn))))
@@ -288,6 +310,14 @@ let append_provider_overflow_manifest
   in
   match outcome with
   | Not_provider_overflow -> Follow_failure_route, turn_state
+  | Provider_overflow_no_compaction no_compaction ->
+    Log.Keeper.info
+      "provider overflow compaction reached typed terminal trace_id=%s generation=%d turn_count=%d reason=%s"
+      (Keeper_id.Trace_id.to_string no_compaction.source.trace_id)
+      no_compaction.source.generation
+      no_compaction.source.turn_count
+      (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
+    Acknowledge_after_no_compaction no_compaction, turn_state
   | Provider_overflow_applied recovery ->
     let turn_state =
       append_recovery

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -22,7 +22,6 @@ include Keeper_unified_turn_phase_plan
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
-  | Acknowledge_after_no_compaction of Keeper_post_turn.no_compaction
   | Acknowledge_after_in_turn_handling
 
 type turn_failure =
@@ -312,12 +311,16 @@ let append_provider_overflow_manifest
   | Not_provider_overflow -> Follow_failure_route, turn_state
   | Provider_overflow_no_compaction no_compaction ->
     Log.Keeper.info
-      "provider overflow compaction reached typed terminal trace_id=%s generation=%d turn_count=%d reason=%s"
+      "provider overflow compaction made no progress; preserving the source failure route trace_id=%s generation=%d turn_count=%d reason=%s"
       (Keeper_id.Trace_id.to_string no_compaction.source.trace_id)
       no_compaction.source.generation
       no_compaction.source.turn_count
       (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
-    Acknowledge_after_no_compaction no_compaction, turn_state
+    (* [No_compaction] is terminal evidence for an explicit manual-compaction
+       operation, not successful handling of the product event whose provider
+       turn overflowed. Preserve the typed context-overflow route so the
+       owning source lease is escalated instead of silently consumed. *)
+    Follow_failure_route, turn_state
   | Provider_overflow_applied recovery ->
     let turn_state =
       append_recovery

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -140,14 +140,11 @@ val record_streaming_cancelled_observation
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
-  | Acknowledge_after_no_compaction of Keeper_post_turn.no_compaction
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
     cycle reloads the durably compacted checkpoint.
-    [Acknowledge_after_no_compaction] binds a typed terminal to the exact
-    checkpoint source and consumes the request lease without another attempt.
     [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -140,11 +140,14 @@ val record_streaming_cancelled_observation
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
+  | Acknowledge_after_no_compaction of Keeper_post_turn.no_compaction
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
     cycle reloads the durably compacted checkpoint.
+    [Acknowledge_after_no_compaction] binds a typed terminal to the exact
+    checkpoint source and consumes the request lease without another attempt.
     [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -32,6 +32,7 @@
   masc_eio_context
   masc.config
   masc.keeper_registry
+  masc.keeper_checkpoint_ref
   masc.keeper_toml
   masc.config_dir_resolver
   masc.fs_compat

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -26,8 +26,20 @@ type escalation_reason = State.escalation_reason =
       ; rationale : string
       }
 
+type no_compaction_reason = State.no_compaction_reason =
+  | No_eligible_history
+  | Invalid_structural_source
+  | Structurally_unchanged
+  | Checkpoint_not_reduced
+
+type no_compaction = State.no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : no_compaction_reason
+  }
+
 type settlement = State.settlement =
   | Ack
+  | No_compaction of no_compaction
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -30,8 +30,20 @@ type escalation_reason = Keeper_event_queue_state.escalation_reason =
       ; rationale : string
       }
 
+type no_compaction_reason = Keeper_event_queue_state.no_compaction_reason =
+  | No_eligible_history
+  | Invalid_structural_source
+  | Structurally_unchanged
+  | Checkpoint_not_reduced
+
+type no_compaction = Keeper_event_queue_state.no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : no_compaction_reason
+  }
+
 type settlement = Keeper_event_queue_state.settlement =
   | Ack
+  | No_compaction of no_compaction
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -23,6 +23,17 @@ type escalation_reason =
       ; rationale : string
       }
 
+type no_compaction_reason =
+  | No_eligible_history
+  | Invalid_structural_source
+  | Structurally_unchanged
+  | Checkpoint_not_reduced
+
+type no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : no_compaction_reason
+  }
+
 let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
@@ -31,6 +42,7 @@ let escalation_reason_requests_external_input = function
 
 type settlement =
   | Ack
+  | No_compaction of no_compaction
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -353,6 +365,7 @@ let escalation_reason_of_wire ~label ~detail_json =
 
 let settlement_kind_label = function
   | Ack -> "ack"
+  | No_compaction _ -> "no_compaction"
   | Requeue _ -> "requeue"
   | Escalate _ -> "escalate"
 ;;
@@ -376,14 +389,18 @@ let successor_equal left right =
 let settlement_equal left right =
   match left, right with
   | Ack, Ack -> true
+  | No_compaction left, No_compaction right ->
+    Keeper_checkpoint_ref.equal left.source right.source
+    && left.reason = right.reason
   | Requeue left, Requeue right -> left = right
   | ( Escalate { reason = left_reason; successor = left_successor }
     , Escalate { reason = right_reason; successor = right_successor } ) ->
     left_reason = right_reason
     && successor_equal left_successor right_successor
-  | Ack, (Requeue _ | Escalate _)
-  | Requeue _, (Ack | Escalate _)
-  | Escalate _, (Ack | Requeue _) ->
+  | Ack, (No_compaction _ | Requeue _ | Escalate _)
+  | No_compaction _, (Ack | Requeue _ | Escalate _)
+  | Requeue _, (Ack | No_compaction _ | Escalate _)
+  | Escalate _, (Ack | No_compaction _ | Requeue _) ->
     false
 ;;
 
@@ -397,7 +414,7 @@ let transition_receipt_equal left right =
 ;;
 
 let validate_settlement = function
-  | Ack | Requeue _ -> Ok ()
+  | Ack | No_compaction _ | Requeue _ -> Ok ()
   | Escalate
       { reason = Failure_judgment_requested
       ; successor =
@@ -509,7 +526,7 @@ let settle ~settled_at ~lease ~settlement state =
   | Some committed ->
     let pending =
       match settlement with
-      | Ack -> state.pending
+      | Ack | No_compaction _ -> state.pending
       | Requeue
           ( Retry_after_observed
           | Context_compaction_retry
@@ -671,6 +688,13 @@ let float_field ~context name fields =
   | _ -> Error (Printf.sprintf "%s.%s must be a number" context name)
 ;;
 
+let int_field ~context name fields =
+  let* value = required_field ~context name fields in
+  match value with
+  | `Int value -> Ok value
+  | _ -> Error (Printf.sprintf "%s.%s must be an int" context name)
+;;
+
 let int64_field ~context name fields =
   let* value = required_field ~context name fields in
   match value with
@@ -747,8 +771,62 @@ let lease_of_yojson json =
   else Ok { lease_id; sequence; kind; claimed_at; stimuli }
 ;;
 
+let no_compaction_reason_label = function
+  | No_eligible_history -> "no_eligible_history"
+  | Invalid_structural_source -> "invalid_structural_source"
+  | Structurally_unchanged -> "structurally_unchanged"
+  | Checkpoint_not_reduced -> "checkpoint_not_reduced"
+;;
+
+let no_compaction_reason_of_label = function
+  | "no_eligible_history" -> Ok No_eligible_history
+  | "invalid_structural_source" -> Ok Invalid_structural_source
+  | "structurally_unchanged" -> Ok Structurally_unchanged
+  | "checkpoint_not_reduced" -> Ok Checkpoint_not_reduced
+  | reason -> Error (Printf.sprintf "unknown no-compaction reason: %s" reason)
+;;
+
+let checkpoint_source_to_yojson (source : Keeper_checkpoint_ref.t) =
+  `Assoc
+    [ "trace_id", `String (Keeper_id.Trace_id.to_string source.trace_id)
+    ; "generation", `Int source.generation
+    ; "turn_count", `Int source.turn_count
+    ; "sha256", `String source.sha256
+    ]
+;;
+
+let checkpoint_source_of_yojson json =
+  let context = "no-compaction checkpoint source" in
+  let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:[ "trace_id"; "generation"; "turn_count"; "sha256" ]
+      fields
+  in
+  let* trace_id_raw = string_field ~context "trace_id" fields in
+  let* trace_id = Keeper_id.Trace_id.of_string trace_id_raw in
+  let* generation = int_field ~context "generation" fields in
+  let* turn_count = int_field ~context "turn_count" fields in
+  let* sha256 = string_field ~context "sha256" fields in
+  Keeper_checkpoint_ref.of_persisted ~trace_id ~generation ~turn_count ~sha256
+  |> Result.map_error (function
+    | Keeper_checkpoint_ref.Negative_generation value ->
+      Printf.sprintf "no-compaction checkpoint generation is negative: %d" value
+    | Negative_turn_count value ->
+      Printf.sprintf "no-compaction checkpoint turn count is negative: %d" value
+    | Invalid_sha256 value ->
+      Printf.sprintf "no-compaction checkpoint digest is invalid: %s" value)
+;;
+
 let settlement_to_yojson = function
   | Ack -> `Assoc [ "kind", `String "ack" ]
+  | No_compaction { source; reason } ->
+    `Assoc
+      [ "kind", `String "no_compaction"
+      ; "reason", `String (no_compaction_reason_label reason)
+      ; "source", checkpoint_source_to_yojson source
+      ]
   | Requeue reason ->
     `Assoc
       [ "kind", `String "requeue"
@@ -774,6 +852,15 @@ let settlement_of_yojson json =
   | "ack" ->
     let* () = exact_fields ~context ~expected:[ "kind" ] fields in
     Ok Ack
+  | "no_compaction" ->
+    let* () =
+      exact_fields ~context ~expected:[ "kind"; "reason"; "source" ] fields
+    in
+    let* reason_label = string_field ~context "reason" fields in
+    let* reason = no_compaction_reason_of_label reason_label in
+    let* source_json = required_field ~context "source" fields in
+    let* source = checkpoint_source_of_yojson source_json in
+    Ok (No_compaction { source; reason })
   | "requeue" ->
     let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -460,6 +460,20 @@ let validate_settlement = function
     Error "external-input failure judgment must not enqueue a successor"
 ;;
 
+let validate_settlement_for_lease settlement (lease : lease) =
+  match settlement, lease.stimuli with
+  | No_compaction _,
+    [ { Keeper_event_queue.payload =
+          Keeper_event_queue.Manual_compaction_requested
+      ; _
+      } ] ->
+    Ok ()
+  | No_compaction _, _ ->
+    Error
+      "no-compaction settlement requires one manual-compaction request stimulus"
+  | (Ack | Requeue _ | Escalate _), _ -> Ok ()
+;;
+
 let receipt_for_lease ~settled_at ~settlement (lease : lease) =
   let transition_id = transition_id lease settlement in
   { transition_id
@@ -524,6 +538,7 @@ let settle ~settled_at ~lease ~settlement state =
   | Some committed when not (lease_equal committed lease) ->
     Error (Printf.sprintf "event queue lease payload conflict: %s" lease.lease_id)
   | Some committed ->
+    let* () = validate_settlement_for_lease settlement committed in
     let pending =
       match settlement with
       | Ack | No_compaction _ -> state.pending

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -30,6 +30,20 @@ type escalation_reason =
       ; rationale : string
       }
 
+type no_compaction_reason =
+  | No_eligible_history
+  | Invalid_structural_source
+  | Structurally_unchanged
+  | Checkpoint_not_reduced
+
+type no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : no_compaction_reason
+  }
+
+val no_compaction_reason_label : no_compaction_reason -> string
+val no_compaction_reason_of_label : string -> (no_compaction_reason, string) result
+
 val escalation_reason_requests_external_input : escalation_reason -> bool
 (** [true] only when the LLM judgment explicitly reports that the Keeper must
     await unavailable external input. A judgment-boundary failure remains a
@@ -37,6 +51,7 @@ val escalation_reason_requests_external_input : escalation_reason -> bool
 
 type settlement =
   | Ack
+  | No_compaction of no_compaction
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -128,8 +128,10 @@ val settle :
 
     [Retry_after_observed] and [Context_compaction_retry] retain the exact
     leased stimuli at the pending FIFO tail so unrelated work in the same lane
-    can proceed before another provider attempt. Non-finite settlement times
-    are rejected. *)
+    can proceed before another provider attempt. [No_compaction] is accepted
+    only for a lease containing exactly one typed
+    [Manual_compaction_requested] stimulus; it cannot retire product work whose
+    provider turn failed. Non-finite settlement times are rejected. *)
 
 val replay_transition_receipt : transition_receipt -> t -> (t, string) result
 (** Apply one canonical durable receipt to its exact active lease. Replaying

--- a/test/dune
+++ b/test/dune
@@ -651,7 +651,7 @@
 (test
  (name test_keeper_event_queue_state_v2)
  (modules test_keeper_event_queue_state_v2)
- (libraries alcotest masc_test_deps))
+ (libraries alcotest masc_test_deps masc.keeper_checkpoint_ref))
 
 (test
  (name test_keeper_current_operations)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -27,6 +27,98 @@ let claim_head state =
   |> require_ok "claim head"
 ;;
 
+let checkpoint_source ~turn_count =
+  let trace_id =
+    Keeper_id.Trace_id.of_string "trace-no-compaction-source"
+    |> require_ok "parse no-compaction trace"
+  in
+  Keeper_checkpoint_ref.of_persisted
+    ~trace_id
+    ~generation:3
+    ~turn_count
+    ~sha256:(String.make 64 'a')
+  |> Result.get_ok
+;;
+
+let no_compaction ~turn_count reason : State.no_compaction =
+  { source = checkpoint_source ~turn_count; reason }
+;;
+
+let test_stochastic_reasons_have_no_terminal_codec () =
+  (* Stochastic planner failures (invalid plan, malformed evidence) and
+     planner invariant violations are retryable/escalated outcomes — they
+     must not be expressible as a durable terminal no-compaction reason,
+     or a flaky LLM could permanently retire a compaction operation. *)
+  List.iter
+    (fun label ->
+       match State.no_compaction_reason_of_label label with
+       | Error _ -> ()
+       | Ok _ ->
+         Alcotest.failf
+           "stochastic/invariant outcome %S encodable as terminal no-compaction"
+           label)
+    [ "invalid_compaction_plan"
+    ; "invalid_structural_evidence"
+    ; "compaction_invariant_violation"
+    ]
+;;
+
+let test_no_compaction_terminal_consumes_exact_request () =
+  let request =
+    stimulus
+      ~payload:Queue.Manual_compaction_requested
+      Queue.manual_compaction_post_id
+      1.0
+  in
+  let peer_work = stimulus "peer-work" 2.0 in
+  let claimed, lease =
+    State.with_pending (queue [ request; peer_work ]) State.empty |> claim_head
+  in
+  let lease = require_some "no-compaction lease" lease in
+  let terminal = no_compaction ~turn_count:7 State.No_eligible_history in
+  let settled, result =
+    State.settle
+      ~settled_at:11.0
+      ~lease
+      ~settlement:(State.No_compaction terminal)
+      claimed
+    |> require_ok "settle no-compaction terminal"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "first no-compaction was already settled"
+  in
+  Alcotest.(check string)
+    "typed transition identity"
+    "lease:1:no_compaction"
+    receipt.transition_id;
+  Alcotest.(check (list string))
+    "request is terminal while unrelated work remains runnable"
+    [ "peer-work" ]
+    (post_ids (State.pending settled));
+  let decoded =
+    State.transition_receipt_to_yojson receipt
+    |> State.transition_receipt_of_yojson
+    |> require_ok "no-compaction receipt roundtrip"
+  in
+  Alcotest.(check bool)
+    "source-bound receipt roundtrips exactly"
+    true
+    (State.transition_receipt_equal receipt decoded);
+  match
+    State.settle
+      ~settled_at:12.0
+      ~lease
+      ~settlement:
+        (State.No_compaction
+           (no_compaction ~turn_count:8 State.No_eligible_history))
+      settled
+  with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "different checkpoint source reused a settled request"
+;;
+
 let test_claim_codec_ack_idempotency () =
   let first = stimulus "first" 1.0 in
   let state = State.with_pending (queue [ first ]) State.empty in
@@ -587,6 +679,55 @@ let cycle_meta () =
   with
   | Ok meta -> meta
   | Error message -> Alcotest.failf "cycle meta fixture: %s" message
+;;
+
+let test_manual_and_overflow_no_compaction_are_terminal () =
+  let lease =
+    lease_for
+      (stimulus
+         ~payload:Queue.Manual_compaction_requested
+         Queue.manual_compaction_post_id
+         1.0)
+  in
+  let source = checkpoint_source ~turn_count:7 in
+  let no_compaction : Masc.Keeper_post_turn.no_compaction =
+    { source; reason = State.No_eligible_history }
+  in
+  let expect_terminal = function
+    | Masc.Keeper_registry_event_queue.No_compaction terminal ->
+      Alcotest.(check bool)
+        "exact checkpoint source is retained"
+        true
+        (Keeper_checkpoint_ref.equal source terminal.source);
+      Alcotest.(check string)
+        "typed reason is retained"
+        "no_eligible_history"
+        (State.no_compaction_reason_label terminal.reason)
+    | _ -> Alcotest.fail "no-compaction source was requeued"
+  in
+  expect_terminal
+    (Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
+       ~base_path:"/tmp/no-compaction-manual"
+       ~settled_at:2.0
+       ~stop_requested:false
+       ~lease
+       (Some
+          (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_not_applied
+             { meta = cycle_meta (); no_compaction })));
+  let overflow_failure =
+    { (turn_failure
+         (Keeper_runtime_failure_route.Retry_after_observed
+            { retry_class = Keeper_runtime_failure_route.Capacity_backpressure
+            ; retry_after = None
+            })) with
+      source_lease_disposition =
+        Masc.Keeper_unified_turn.Acknowledge_after_no_compaction no_compaction
+    }
+  in
+  expect_terminal
+    (Masc.Keeper_heartbeat_loop.settlement_of_failure
+       ~settled_at:3.0
+       overflow_failure)
 ;;
 
 let test_applied_compaction_settles_followup_atomically () =
@@ -1179,6 +1320,10 @@ let () =
             `Quick
             test_receipt_codec_is_closed_and_finite
         ; Alcotest.test_case
+            "no-compaction terminal consumes exact request"
+            `Quick
+            test_no_compaction_terminal_consumes_exact_request
+        ; Alcotest.test_case
             "claim earliest ready without reordering"
             `Quick
             test_claim_leases_earliest_ready_without_reordering_skipped_work
@@ -1192,6 +1337,14 @@ let () =
             "applied compaction settles follow-up atomically"
             `Quick
             test_applied_compaction_settles_followup_atomically
+        ; Alcotest.test_case
+            "manual and overflow no-compaction are terminal"
+            `Quick
+            test_manual_and_overflow_no_compaction_are_terminal
+        ; Alcotest.test_case
+            "stochastic reasons have no terminal codec"
+            `Quick
+            test_stochastic_reasons_have_no_terminal_codec
         ; Alcotest.test_case
             "cancelled and skipped cycles requeue"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -119,6 +119,46 @@ let test_no_compaction_terminal_consumes_exact_request () =
   | Ok _ -> Alcotest.fail "different checkpoint source reused a settled request"
 ;;
 
+let test_no_compaction_rejects_scheduled_product_work () =
+  let scheduled_wake : Queue.scheduled_wake =
+    { schedule_id = "scheduled-product-work"
+    ; due_at = 1.0
+    ; payload_digest = "scheduled-product-work-digest"
+    ; title = Some "Scheduled product work"
+    ; message = "Execute this product task"
+    }
+  in
+  let work =
+    stimulus
+      ~payload:(Queue.Schedule_due scheduled_wake)
+      "schedule-occurrence:scheduled-product-work"
+      1.0
+  in
+  let claimed, lease =
+    State.with_pending (queue [ work ]) State.empty |> claim_head
+  in
+  let lease = require_some "product work lease" lease in
+  match
+    State.settle
+      ~settled_at:11.0
+      ~lease
+      ~settlement:
+        (State.No_compaction
+           (no_compaction ~turn_count:7 State.No_eligible_history))
+      claimed
+  with
+  | Error message ->
+    Alcotest.(check string)
+      "typed settlement authority rejects product work"
+      "no-compaction settlement requires one manual-compaction request stimulus"
+      message;
+    Alcotest.(check int)
+      "rejected settlement keeps the source lease active"
+      1
+      (List.length (State.leases claimed))
+  | Ok _ -> Alcotest.fail "no-compaction consumed a non-compaction product event"
+;;
+
 let test_claim_codec_ack_idempotency () =
   let first = stimulus "first" 1.0 in
   let state = State.with_pending (queue [ first ]) State.empty in
@@ -681,7 +721,7 @@ let cycle_meta () =
   | Error message -> Alcotest.failf "cycle meta fixture: %s" message
 ;;
 
-let test_manual_and_overflow_no_compaction_are_terminal () =
+let test_manual_no_compaction_is_terminal_but_overflow_escalates () =
   let lease =
     lease_for
       (stimulus
@@ -714,20 +754,27 @@ let test_manual_and_overflow_no_compaction_are_terminal () =
        (Some
           (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_not_applied
              { meta = cycle_meta (); no_compaction })));
-  let overflow_failure =
-    { (turn_failure
-         (Keeper_runtime_failure_route.Retry_after_observed
-            { retry_class = Keeper_runtime_failure_route.Capacity_backpressure
-            ; retry_after = None
-            })) with
-      source_lease_disposition =
-        Masc.Keeper_unified_turn.Acknowledge_after_no_compaction no_compaction
-    }
+  let judgment_route =
+    Keeper_runtime_failure_route.Escalate_judgment
+      { judgment = Keeper_runtime_failure_route.Context_overflow
+      ; provenance = Keeper_runtime_failure_route.Oas_api_error
+      ; detail = "typed provider context overflow"
+      }
   in
-  expect_terminal
-    (Masc.Keeper_heartbeat_loop.settlement_of_failure
-       ~settled_at:3.0
-       overflow_failure)
+  let overflow_failure =
+    turn_failure judgment_route
+  in
+  match
+    Masc.Keeper_heartbeat_loop.settlement_of_failure
+      ~settled_at:3.0
+      overflow_failure
+  with
+  | Masc.Keeper_registry_event_queue.Escalate
+      { reason = Masc.Keeper_registry_event_queue.Failure_judgment_requested
+      ; successor = Some { payload = Queue.Failure_judgment _; _ }
+      } ->
+    ()
+  | _ -> Alcotest.fail "provider overflow no-compaction consumed the source lease"
 ;;
 
 let test_applied_compaction_settles_followup_atomically () =
@@ -1324,6 +1371,10 @@ let () =
             `Quick
             test_no_compaction_terminal_consumes_exact_request
         ; Alcotest.test_case
+            "no-compaction rejects scheduled product work"
+            `Quick
+            test_no_compaction_rejects_scheduled_product_work
+        ; Alcotest.test_case
             "claim earliest ready without reordering"
             `Quick
             test_claim_leases_earliest_ready_without_reordering_skipped_work
@@ -1338,9 +1389,9 @@ let () =
             `Quick
             test_applied_compaction_settles_followup_atomically
         ; Alcotest.test_case
-            "manual and overflow no-compaction are terminal"
+            "manual no-compaction is terminal but overflow escalates"
             `Quick
-            test_manual_and_overflow_no_compaction_are_terminal
+            test_manual_no_compaction_is_terminal_but_overflow_escalates
         ; Alcotest.test_case
             "stochastic reasons have no terminal codec"
             `Quick

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -500,7 +500,8 @@ let test_manual_compaction_preserves_failed_failure_dispatch () =
   let recovery_detail =
     KMC.failure_to_string
       (KMC.Recovery
-         ( Masc.Keeper_post_turn.Compaction_evidence_missing
+         ( Masc.Keeper_post_turn.Compaction_rejected
+             Masc.Keeper_compact_policy.Summarizer_unavailable
          , Error failure_dispatch ))
   in
   check bool "recovery failure dispatch rejection is rendered" true


### PR DESCRIPTION
## Why

An impossible compaction request needs a durable terminal distinct from generic acknowledgement or requeue. Without that canonical outcome, manual and overflow requests can repeatedly reclaim the same owner-lane lease.

## What

- add typed No_compaction settlement to the existing event-queue SSOT
- bind it to exact Keeper_checkpoint_ref identity
- persist it through the existing settlement WAL and transition receipt codec
- project it through the existing reaction ledger without adding another writer
- prove exact-source idempotency and preservation of unrelated FIFO work

## Scope

Second leaf of the stack, based on #25221. 281 changed lines (270 additions, 11 deletions). Producers are wired in the next leaf.

## Validation

- ocamlformat on touched files
- ocamlc -stop-after parsing on touched implementations
- focused Dune build queued behind the shared repo lock; CI is the full-build authority