### PR TITLE
fix(keeper): terminate impossible compaction requests

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -268,6 +268,8 @@ let settlement_of_failure ~settled_at failure =
   match failure.Keeper_unified_turn.source_lease_disposition with
   | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
     Keeper_registry_event_queue.Ack
+  | Keeper_unified_turn.Acknowledge_after_no_compaction { source; reason } ->
+    Keeper_registry_event_queue.No_compaction { source; reason }
   | Keeper_unified_turn.Requeue_after_context_compaction ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
@@ -379,6 +381,8 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
   | Some (Cycle.Manual_compaction_failed _) ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
+  | Some (Cycle.Manual_compaction_not_applied { no_compaction = { source; reason }; _ }) ->
+    Keeper_registry_event_queue.No_compaction { source; reason }
   | None ->
     if stop_requested
     then Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Cancelled
@@ -411,7 +415,8 @@ let settle_claimed_lease
 ;;
 
 let settlement_is_ack = function
-  | Keeper_registry_event_queue.Ack -> true
+  | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.No_compaction _ -> true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false
@@ -473,6 +478,7 @@ let run_keepalive_unified_turn
           | Cycle.Busy _
           | Cycle.Judgment_settled _
           | Cycle.Manual_compaction_failed _
+          | Cycle.Manual_compaction_not_applied _
           | Cycle.Manual_compaction_applied _ )
       | None ->
         record_crashed_cycle_failure
@@ -806,6 +812,7 @@ let run_keepalive_unified_turn
           | Some (Cycle.Failed { failure; _ }) ->
             (match failure.Keeper_unified_turn.source_lease_disposition with
              | Keeper_unified_turn.Requeue_after_context_compaction
+             | Keeper_unified_turn.Acknowledge_after_no_compaction _
              | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
              | Keeper_unified_turn.Follow_failure_route ->
                (match failure.Keeper_unified_turn.route with
@@ -841,6 +848,9 @@ let run_keepalive_unified_turn
           | Some (Cycle.Manual_compaction_failed _) ->
             record_settlement_failure
               "manual compaction failed without an owning event queue lease"
+          | Some (Cycle.Manual_compaction_not_applied _) ->
+            record_settlement_failure
+              "manual no-compaction terminal has no owning event queue lease"
           | Some (Cycle.Manual_compaction_applied _) ->
             record_settlement_failure
               "manual compaction completed without an owning event queue lease"

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -55,6 +55,10 @@ type cycle_outcome =
       { meta : keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
+  | Manual_compaction_not_applied of
+      { meta : keeper_meta
+      ; no_compaction : Keeper_post_turn.no_compaction
+      }
   | Manual_compaction_applied of cycle_outcome
 
 and failure_judgment_terminal =
@@ -71,7 +75,8 @@ let rec meta = function
   | Failed { meta; _ }
   | Busy { meta; _ }
   | Judgment_settled { meta; _ }
-  | Manual_compaction_failed { meta; _ } ->
+  | Manual_compaction_failed { meta; _ }
+  | Manual_compaction_not_applied { meta; _ } ->
     meta
   | Manual_compaction_applied outcome -> meta outcome
 ;;
@@ -80,13 +85,15 @@ let rec turn_failure = function
   | Failed { failure; _ } -> Some failure
   | Manual_compaction_applied outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Busy _
-  | Judgment_settled _ | Manual_compaction_failed _ -> None
+  | Judgment_settled _ | Manual_compaction_failed _
+  | Manual_compaction_not_applied _ -> None
 ;;
 
 let manual_compaction_followup_failure = function
   | Manual_compaction_applied outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Failed _ | Busy _
-  | Judgment_settled _ | Manual_compaction_failed _ -> None
+  | Judgment_settled _ | Manual_compaction_failed _
+  | Manual_compaction_not_applied _ -> None
 ;;
 
 let record_failure_judgment_outcome
@@ -400,5 +407,11 @@ let run_keeper_cycle
          "manual compaction failed in owner lane: %s"
          (Keeper_manual_compaction.failure_to_string failure);
        Manual_compaction_failed { meta = meta_after_triage; failure }
+     | `No_compaction no_compaction ->
+       Log.Keeper.info
+         ~keeper_name:meta_after_triage.name
+         "manual compaction reached typed terminal: %s"
+         (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
+       Manual_compaction_not_applied { meta = meta_after_triage; no_compaction }
      | `Applied _success -> Manual_compaction_applied (run_standard_cycle ()))
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -20,6 +20,10 @@ type cycle_outcome =
       { meta : Keeper_meta_contract.keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
+  | Manual_compaction_not_applied of
+      { meta : Keeper_meta_contract.keeper_meta
+      ; no_compaction : Keeper_post_turn.no_compaction
+      }
   | Manual_compaction_applied of cycle_outcome
 
 and failure_judgment_terminal =

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -4,6 +4,10 @@ type success =
   ; manifest : (unit, string) result
   }
 
+type operation_outcome =
+  | Compacted of success
+  | No_compaction of Keeper_post_turn.no_compaction
+
 type lifecycle_stage =
   | Operator_request
   | Compaction_started
@@ -105,6 +109,13 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
             ~meta
             ~trigger:Compaction_trigger.Manual
         with
+        | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
+          let failure_dispatch =
+            dispatch_failed (Keeper_post_turn.compaction_recovery_error_to_tag error)
+          in
+          (match failure_dispatch with
+           | Ok () -> Ok (No_compaction no_compaction)
+           | Error _ -> Error (Recovery (error, failure_dispatch)))
         | Error error ->
           let failure_dispatch =
             dispatch_failed (Keeper_post_turn.compaction_recovery_error_to_tag error)
@@ -129,7 +140,7 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
              Keeper_unified_metrics.broadcast_compaction
                ~name:meta.name
                recovery;
-             Ok { recovery; manifest })))
+             Ok (Compacted { recovery; manifest }))))
 ;;
 
 let lifecycle_stage_to_string = function
@@ -193,7 +204,8 @@ let run_admitted ~(config : Workspace.config) ~(meta : keeper_meta) =
   with
   | `Busy block -> `Busy block
   | `Ran (Error failure) -> `Compaction_failed failure
-  | `Ran (Ok success) ->
+  | `Ran (Ok (Compacted success)) ->
     observe_manifest ~keeper_name:meta.name success.manifest;
     `Applied success
+  | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction
 ;;

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -3,6 +3,10 @@ type success =
   ; manifest : (unit, string) result
   }
 
+type operation_outcome =
+  | Compacted of success
+  | No_compaction of Keeper_post_turn.no_compaction
+
 type lifecycle_stage =
   | Operator_request
   | Compaction_started
@@ -27,12 +31,13 @@ type failure =
 val run
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
-  -> (success, failure) result
+  -> (operation_outcome, failure) result
 
 val run_admitted
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> [ `Applied of success
+     | `No_compaction of Keeper_post_turn.no_compaction
      | `Compaction_failed of failure
      | `Busy of Keeper_turn_admission.autonomous_block
      ]

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -60,14 +60,17 @@ type compaction_recovery = {
   turn_generation : int;
 }
 
+type no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : Keeper_event_queue_state.no_compaction_reason
+  }
+
 type compaction_recovery_error =
   | Checkpoint_ref_load_failed of Keeper_checkpoint_store.checkpoint_ref_load_error
   | Checkpoint_cas_failed of Keeper_checkpoint_store.checkpoint_cas_error
-  | Checkpoint_structure_invalid of Keeper_compaction_unit.structural_error
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
-  | Compaction_evidence_missing
-  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | No_compaction of no_compaction
 
 let compaction_recovery_error_to_tag = function
   | Checkpoint_ref_load_failed Keeper_checkpoint_store.Ref_not_found ->
@@ -89,12 +92,11 @@ let compaction_recovery_error_to_tag = function
     "checkpoint_commit_durability_unknown"
   | Checkpoint_cas_failed (Transaction_outcome_unknown _) ->
     "checkpoint_transaction_outcome_unknown"
-  | Checkpoint_structure_invalid _ -> "checkpoint_structure_invalid"
   | Checkpoint_candidate_failed _ -> "checkpoint_candidate_failed"
   | Compaction_rejected reason ->
     Keeper_compact_policy.compaction_rejection_to_tag reason
-  | Compaction_evidence_missing -> "compaction_evidence_missing"
-  | Unexpected_compaction_decision _ -> "unexpected_compaction_decision"
+  | No_compaction { reason; _ } ->
+    "no_compaction:" ^ Keeper_event_queue_state.no_compaction_reason_label reason
 
 let checkpoint_load_error_detail = function
   | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
@@ -174,18 +176,18 @@ let checkpoint_cas_error_detail = function
 let compaction_recovery_error_to_string = function
   | Checkpoint_ref_load_failed error -> checkpoint_ref_load_error_detail error
   | Checkpoint_cas_failed error -> checkpoint_cas_error_detail error
-  | Checkpoint_structure_invalid error ->
-    "checkpoint structure invalid: "
-    ^ Keeper_compaction_unit.show_structural_error error
   | Checkpoint_candidate_failed detail -> detail
   | Compaction_rejected reason ->
     "compaction rejected: "
     ^ Keeper_compact_policy.compaction_rejection_to_string reason
-  | Compaction_evidence_missing ->
-    "prepared compaction did not carry structural evidence"
-  | Unexpected_compaction_decision decision ->
-    "unexpected compaction decision: "
-    ^ Keeper_compact_policy.compaction_decision_to_string decision
+  | No_compaction { source; reason } ->
+    Printf.sprintf
+      "no compaction for trace_id=%s generation=%d turn_count=%d sha256=%s: %s"
+      (Keeper_id.Trace_id.to_string source.trace_id)
+      source.generation
+      source.turn_count
+      source.sha256
+      (Keeper_event_queue_state.no_compaction_reason_label reason)
 
 (* ── Tier A6: resilience post-turn wire-in (Cycle 23) ──────────────
    Feature-flag-gated layer that runs before tool emission and
@@ -486,6 +488,19 @@ let commit_prepared_after_save ~trigger ~save =
   | Ok checkpoint -> Ok (checkpoint, trigger)
 ;;
 
+let terminal_reason_of_rejection = function
+  | Keeper_compact_policy.No_eligible_history ->
+    Some Keeper_event_queue_state.No_eligible_history
+  | Invalid_structure _ -> Some Invalid_structural_source
+  | Structurally_unchanged -> Some Structurally_unchanged
+  | Checkpoint_not_reduced -> Some Checkpoint_not_reduced
+  | Invalid_compaction_plan
+  | Invalid_structural_evidence _
+  | Runtime_identity_unavailable
+  | Summarizer_unavailable
+  | Plan_provider_unavailable -> None
+;;
+
 let recover_latest_checkpoint_for_compaction
     ~(base_dir : string)
     ~(meta : keeper_meta)
@@ -534,7 +549,13 @@ let recover_latest_checkpoint_for_compaction
     in
     (match preparation.decision, preparation.evidence with
      | Keeper_compact_policy.Prepared _, None ->
-       Error Compaction_evidence_missing
+       (* Prepared-without-evidence is a planner invariant violation (a bug),
+          not a deterministic no-op: it must surface as a visible failure,
+          never settle as a durable terminal no-compaction. *)
+       Error
+         (Checkpoint_candidate_failed
+            "compaction preparation completed without structural evidence \
+             (planner invariant violation)")
      | Keeper_compact_policy.Prepared prepared_trigger, Some evidence ->
        (try
           match
@@ -551,8 +572,11 @@ let recover_latest_checkpoint_for_compaction
                   ~expected_source_ref:source_ref
                 |> Result.map fst
                 |> Result.map_error (function
-                  | Tool_history_invalid error ->
-                    Checkpoint_structure_invalid error
+                  | Tool_history_invalid _ ->
+                    No_compaction
+                      { source = source_ref
+                      ; reason = Keeper_event_queue_state.Invalid_structural_source
+                      }
                   | Persistence_error error -> Checkpoint_cas_failed error))
           with
           | Ok (saved_checkpoint, trigger) ->
@@ -597,8 +621,17 @@ let recover_latest_checkpoint_for_compaction
             exn;
           Error (Checkpoint_candidate_failed detail))
      | Keeper_compact_policy.Rejected (_, reason), _ ->
-       Error (Compaction_rejected reason)
+       (match terminal_reason_of_rejection reason with
+        | Some reason -> Error (No_compaction { source = source_ref; reason })
+        | None -> Error (Compaction_rejected reason))
      | (Keeper_compact_policy.Applied _
        | Keeper_compact_policy.Not_requested
        | Keeper_compact_policy.Skipped_no_checkpoint) as decision, _ ->
-       Error (Unexpected_compaction_decision decision))
+       (* Reaching recovery with a non-preparation decision is an invariant
+          violation: surface it as a visible failure with the decision
+          detail, never as a hidden terminal no-compaction. *)
+       Error
+         (Checkpoint_candidate_failed
+            (Printf.sprintf
+               "compaction recovery reached a non-preparation decision: %s"
+               (Keeper_compact_policy.compaction_decision_to_string decision))))

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -35,14 +35,17 @@ type compaction_recovery =
   ; turn_generation : int
   } [@@warning "-69"]
 
+type no_compaction =
+  { source : Keeper_checkpoint_ref.t
+  ; reason : Keeper_event_queue_state.no_compaction_reason
+  }
+
 type compaction_recovery_error =
   | Checkpoint_ref_load_failed of Keeper_checkpoint_store.checkpoint_ref_load_error
   | Checkpoint_cas_failed of Keeper_checkpoint_store.checkpoint_cas_error
-  | Checkpoint_structure_invalid of Keeper_compaction_unit.structural_error
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
-  | Compaction_evidence_missing
-  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | No_compaction of no_compaction
 
 val compaction_recovery_error_to_tag : compaction_recovery_error -> string
 val compaction_recovery_error_to_string : compaction_recovery_error -> string

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -111,11 +111,9 @@ let compaction_recovery_error_data ?dispatch_error error =
       Outcome_unknown, `Null
     | Checkpoint_ref_load_failed _
     | Checkpoint_cas_failed _
-    | Checkpoint_structure_invalid _
     | Checkpoint_candidate_failed _
     | Compaction_rejected _
-    | Compaction_evidence_missing
-    | Unexpected_compaction_decision _ ->
+    | No_compaction _ ->
       Not_installed, `Bool false
   in
   let recovery_code =
@@ -126,14 +124,13 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Compaction_rejected (Invalid_structure _)
     | Compaction_rejected No_eligible_history
     | Compaction_rejected Structurally_unchanged
-    | Compaction_rejected Checkpoint_not_reduced ->
+    | Compaction_rejected Checkpoint_not_reduced
+    | No_compaction _ ->
       Precondition_failed
     | Compaction_rejected Summarizer_unavailable
     | Compaction_rejected Plan_provider_unavailable
     | Compaction_rejected Invalid_compaction_plan
     | Compaction_rejected (Invalid_structural_evidence _)
-    | Compaction_evidence_missing
-    | Unexpected_compaction_decision _
     | Checkpoint_ref_load_failed _
     | Checkpoint_cas_failed (Source_unavailable _)
     | Checkpoint_cas_failed (Candidate_identity_invalid _)
@@ -141,7 +138,6 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Checkpoint_cas_failed (Candidate_generation_mismatch _)
     | Checkpoint_cas_failed (Candidate_turn_regressed _)
     | Checkpoint_cas_failed (Commit_not_installed _)
-    | Checkpoint_structure_invalid _
     | Checkpoint_candidate_failed _ -> Internal_error
     | Checkpoint_cas_failed (Source_changed _)
     | Checkpoint_cas_failed (Commit_durability_unknown _)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -22,6 +22,7 @@ include Keeper_unified_turn_phase_plan
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
+  | Acknowledge_after_no_compaction of Keeper_post_turn.no_compaction
   | Acknowledge_after_in_turn_handling
 
 type turn_failure =
@@ -126,6 +127,7 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
 type provider_overflow_recovery =
   | Not_provider_overflow
   | Provider_overflow_applied of Keeper_context_runtime.compaction_recovery
+  | Provider_overflow_no_compaction of Keeper_post_turn.no_compaction
   | Provider_overflow_retry_without_checkpoint of
       { trigger : Compaction_trigger.t
       ; reason : string
@@ -172,16 +174,17 @@ let recover_provider_context_overflow_in_lane
           "compaction_failed"
           (Keeper_state_machine.Compaction_failed { reason })
       with
-      | Ok () -> ()
+      | Ok () -> Ok ()
       | Error detail ->
         Log.Keeper.error
           ~keeper_name:meta.name
           "provider overflow recovery could not release compaction lifecycle: %s"
-          detail
+          detail;
+        Error detail
     in
     let retry_after_started ?recovery reason =
       record_overflow_failure ~config ~meta ~reason;
-      release_failed_lifecycle reason;
+      ignore (release_failed_lifecycle reason);
       match recovery with
       | None -> Provider_overflow_retry_without_checkpoint { trigger; reason }
       | Some recovery -> Provider_overflow_retry_with_checkpoint { reason; recovery }
@@ -201,6 +204,12 @@ let recover_provider_context_overflow_in_lane
                  ~meta
                  ~trigger
              with
+             | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
+               let reason = Keeper_post_turn.compaction_recovery_error_to_string error in
+               record_overflow_failure ~config ~meta ~reason;
+               (match release_failed_lifecycle reason with
+                | Ok () -> Provider_overflow_no_compaction no_compaction
+                | Error _ -> Provider_overflow_retry_without_checkpoint { trigger; reason })
              | Error error ->
                retry_after_started
                  (Keeper_post_turn.compaction_recovery_error_to_string error)
@@ -227,7 +236,7 @@ let recover_provider_context_overflow_in_lane
            | Eio.Cancel.Cancelled _ as exn ->
              let backtrace = Printexc.get_raw_backtrace () in
              Eio.Cancel.protect (fun () ->
-               try release_failed_lifecycle "provider overflow compaction cancelled" with
+               try ignore (release_failed_lifecycle "provider overflow compaction cancelled") with
                | cleanup_exn ->
                  Log.Keeper.error
                    ~keeper_name:meta.name
@@ -288,6 +297,14 @@ let append_provider_overflow_manifest
   in
   match outcome with
   | Not_provider_overflow -> Follow_failure_route, turn_state
+  | Provider_overflow_no_compaction no_compaction ->
+    Log.Keeper.info
+      "provider overflow compaction reached typed terminal trace_id=%s generation=%d turn_count=%d reason=%s"
+      (Keeper_id.Trace_id.to_string no_compaction.source.trace_id)
+      no_compaction.source.generation
+      no_compaction.source.turn_count
+      (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
+    Acknowledge_after_no_compaction no_compaction, turn_state
   | Provider_overflow_applied recovery ->
     let turn_state =
       append_recovery

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -140,11 +140,14 @@ val record_streaming_cancelled_observation
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
+  | Acknowledge_after_no_compaction of Keeper_post_turn.no_compaction
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
     cycle reloads the durably compacted checkpoint.
+    [Acknowledge_after_no_compaction] binds a typed terminal to the exact
+    checkpoint source and consumes the request lease without another attempt.
     [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -500,7 +500,8 @@ let test_manual_compaction_preserves_failed_failure_dispatch () =
   let recovery_detail =
     KMC.failure_to_string
       (KMC.Recovery
-         ( Masc.Keeper_post_turn.Compaction_evidence_missing
+         ( Masc.Keeper_post_turn.Compaction_rejected
+             Masc.Keeper_compact_policy.Summarizer_unavailable
          , Error failure_dispatch ))
   in
   check bool "recovery failure dispatch rejection is rendered" true


### PR DESCRIPTION
## Why

Manual and provider-overflow compaction currently map every non-applied result to Context_compaction_retry. Deterministic no-op and invalid-plan outcomes therefore reclaim the same active lease forever and can starve that Keeper lane.

## What

- classify source-bound deterministic no-compaction outcomes explicitly
- preserve provider/runtime failures as retryable
- release the compaction lifecycle before exposing a terminal outcome
- settle manual and overflow source leases through canonical No_compaction
- consume only the owning request while peer/unrelated work remains runnable
- remove legacy evidence-missing, unexpected-decision, and orphan structural-error pseudo-failures

## Deliberate boundary

No_compaction terminal-consumes the exact currently leased provider-overflow stimulus so the owner lane can continue. It does not recover or replay that failed user/connector operation, and it does not implement async compaction, provider-fit sizing, multi-wave compaction, or oversized ToolResult/tool-progress compaction. Those remain separate follow-up work; this leaf only removes deterministic infinite requeue starvation.

## Scope

Final P0 leaf, based on #25222. 228 changed lines (187 additions, 41 deletions).

## Validation

- ocamlformat on touched files
- ocamlc -stop-after parsing on touched implementations
- focused Dune build queued behind the shared repo lock; CI is the full-build authority