### PR TITLE
refactor(operator)!: expose strict context metrics reads

### DIFF
--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -17,12 +17,21 @@ let compute_context_ratio (meta : Keeper_meta_contract.keeper_meta) : float opti
   | Keeper_context_runtime.Unavailable _ -> None
 ;;
 
+type context_metrics_read_error =
+  | Storage_read_failed of Dated_jsonl.read_error
+  | Malformed_metrics_row of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+
 type keeper_context_snapshot =
   { context_ratio : float option
   ; context_tokens : int option
   ; context_max : int option
   ; context_source : string option
   ; context_unavailable_reason : Keeper_context_runtime.max_context_resolution_error option
+  ; context_metrics_unavailable : context_metrics_read_error option
   }
 
 let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
@@ -31,6 +40,7 @@ let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
   && snapshot.context_max = None
   && snapshot.context_source = None
   && snapshot.context_unavailable_reason = None
+  && snapshot.context_metrics_unavailable = None
 ;;
 
 let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
@@ -52,35 +62,39 @@ let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
               Some ("metrics_" ^ String.trim channel)
             | Some _ | None -> Some "metrics_log"))
     ; context_unavailable_reason = None
+    ; context_metrics_unavailable = None
     }
   in
   if keeper_context_snapshot_is_empty snapshot then None else Some snapshot
 ;;
 
 let latest_keeper_context_snapshot_from_files config keeper_name =
-  let metrics_lines =
-    let store = Keeper_types_support.keeper_metrics_store config keeper_name in
-    Dated_jsonl.read_recent_lines store 32
+  let ( let* ) = Result.bind in
+  let store = Keeper_types_support.keeper_metrics_store config keeper_name in
+  let* entries =
+    Dated_jsonl.read_recent_result store 32
+    |> Result.map_error (fun error -> Storage_read_failed error)
   in
-  let snapshots =
-    List.rev metrics_lines
-    |> List.filter_map (fun line ->
-      try
-        let json = Yojson.Safe.from_string line in
-        keeper_context_snapshot_from_metrics_json json
-      with
-      | Yojson.Json_error _ -> None)
+  let rec snapshots_newest_first snapshots = function
+    | [] -> Ok snapshots
+    | Dated_jsonl.Parsed json :: rest ->
+      let snapshots =
+        match keeper_context_snapshot_from_metrics_json json with
+        | Some snapshot -> snapshot :: snapshots
+        | None -> snapshots
+      in
+      snapshots_newest_first snapshots rest
+    | Dated_jsonl.Malformed_json { path; line_number; detail } :: _ ->
+      Error (Malformed_metrics_row { path; line_number; detail })
   in
+  let* snapshots = snapshots_newest_first [] entries in
   match
     List.find_opt
       (fun snapshot -> snapshot.context_source = Some "keeper_context_status")
       snapshots
   with
-  | Some snapshot -> Some snapshot
-  | None ->
-    (match snapshots with
-     | snapshot :: _ -> Some snapshot
-     | [] -> None)
+  | Some snapshot -> Ok (Some snapshot)
+  | None -> Ok (List.hd_opt snapshots)
 ;;
 
 let apply_capacity_observation meta snapshot =
@@ -118,13 +132,50 @@ let fallback_keeper_context_snapshot (meta : Keeper_meta_contract.keeper_meta) =
     ; context_max = None
     ; context_source = Some "fallback_metadata"
     ; context_unavailable_reason = None
+    ; context_metrics_unavailable = None
     }
 ;;
 
 let keeper_context_snapshot_of_meta config (meta : Keeper_meta_contract.keeper_meta) =
   match latest_keeper_context_snapshot_from_files config meta.name with
-  | Some snapshot -> apply_capacity_observation meta snapshot
-  | None -> fallback_keeper_context_snapshot meta
+  | Ok (Some snapshot) -> apply_capacity_observation meta snapshot
+  | Ok None -> fallback_keeper_context_snapshot meta
+  | Error error ->
+    apply_capacity_observation
+      meta
+      { context_ratio = None
+      ; context_tokens = None
+      ; context_max = None
+      ; context_source = None
+      ; context_unavailable_reason = None
+      ; context_metrics_unavailable = Some error
+      }
+;;
+
+let dated_jsonl_read_error_code = function
+  | Dated_jsonl.Invalid_offset _ -> "invalid_offset"
+  | Dated_jsonl.Not_a_directory _ -> "not_a_directory"
+  | Dated_jsonl.Invalid_layout_entry _ -> "invalid_layout_entry"
+  | Dated_jsonl.Non_regular_file _ -> "non_regular_file"
+  | Dated_jsonl.Io_error _ -> "io_error"
+;;
+
+let context_metrics_unavailable_json = function
+  | None -> `Null
+  | Some (Storage_read_failed error) ->
+    `Assoc
+      [ "kind", `String "storage_read_failed"
+      ; "reason", `String (dated_jsonl_read_error_code error)
+      ; "detail", `String (Dated_jsonl.read_error_to_string error)
+      ]
+  | Some (Malformed_metrics_row { path; line_number; detail }) ->
+    `Assoc
+      [ "kind", `String "malformed_json"
+      ; "reason", `String "malformed_metrics_row"
+      ; "path", `String path
+      ; "line_number", Json_util.int_opt_to_json line_number
+      ; "detail", `String detail
+      ]
 ;;
 
 let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
@@ -149,6 +200,8 @@ let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
           (fun value -> `Int value)
           snapshot.context_max )
     ; "unavailable_reason", unavailable_reason
+    ; ( "metrics_unavailable"
+      , context_metrics_unavailable_json snapshot.context_metrics_unavailable )
     ]
   in
   [ ( "context_ratio"
@@ -166,6 +219,8 @@ let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
   ; ( "context_source"
     , Json_util.string_opt_to_json snapshot.context_source )
   ; "context_unavailable_reason", unavailable_reason
+  ; ( "context_metrics_unavailable"
+    , context_metrics_unavailable_json snapshot.context_metrics_unavailable )
   ; ( "context", `Assoc assoc_fields )
   ]
 ;;

--- a/lib/operator/operator_control_context_snapshot.mli
+++ b/lib/operator/operator_control_context_snapshot.mli
@@ -2,12 +2,21 @@
 
 val compute_context_ratio : Keeper_meta_contract.keeper_meta -> float option
 
+type context_metrics_read_error =
+  | Storage_read_failed of Dated_jsonl.read_error
+  | Malformed_metrics_row of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+
 type keeper_context_snapshot =
   { context_ratio : float option
   ; context_tokens : int option
   ; context_max : int option
   ; context_source : string option
   ; context_unavailable_reason : Keeper_context_runtime.max_context_resolution_error option
+  ; context_metrics_unavailable : context_metrics_read_error option
   }
 
 val keeper_context_snapshot_is_empty : keeper_context_snapshot -> bool
@@ -16,7 +25,8 @@ val keeper_context_snapshot_from_metrics_json :
   Yojson.Safe.t -> keeper_context_snapshot option
 
 val latest_keeper_context_snapshot_from_files :
-  Workspace.config -> string -> keeper_context_snapshot option
+  Workspace.config -> string ->
+  (keeper_context_snapshot option, context_metrics_read_error) result
 
 val fallback_keeper_context_snapshot :
   Keeper_meta_contract.keeper_meta -> keeper_context_snapshot

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -49,6 +49,10 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                  ; "context_tokens", field_or_null "context_tokens"
                  ; "context_max", field_or_null "context_max"
                  ; "context_source", field_or_null "context_source"
+                 ; ( "context_unavailable_reason"
+                   , field_or_null "context_unavailable_reason" )
+                 ; ( "context_metrics_unavailable"
+                   , field_or_null "context_metrics_unavailable" )
                  ; "last_model_used", field_or_null "last_model_used"
                  ; "active_model", field_or_null "active_model"
                  ; "active_model_label", field_or_null "active_model_label"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -335,6 +335,135 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       Alcotest.(check bool) "nested context payload omitted" true
         (Yojson.Safe.Util.member "context" keeper = `Null))
 
+let context_test_meta ~name ~last_input_tokens =
+  let base =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String (name ^ "-agent")
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "runtime_id", `String "primary"
+          ])
+    with
+    | Ok meta -> meta
+    | Error error -> Alcotest.fail error
+  in
+  { base with
+    runtime =
+      { base.runtime with
+        usage = { base.runtime.usage with last_input_tokens }
+      }
+  }
+;;
+
+let write_raw_metrics_row config keeper_name row =
+  let metrics_dir = Keeper_types_support.keeper_metrics_dir config keeper_name in
+  let month_dir = Filename.concat metrics_dir "2026-07" in
+  Fs_compat.mkdir_p month_dir;
+  let path = Filename.concat month_dir "18.jsonl" in
+  Fs_compat.save_file path (row ^ "\n");
+  path
+;;
+
+let test_context_snapshot_missing_metrics_uses_observed_metadata () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       let config = Workspace.default_config base_dir in
+       let meta = context_test_meta ~name:"metrics-missing" ~last_input_tokens:731 in
+       (match
+          Operator_control_context_snapshot.latest_keeper_context_snapshot_from_files
+            config
+            meta.name
+        with
+        | Ok None -> ()
+        | Ok (Some _) -> Alcotest.fail "missing metrics store returned a snapshot"
+        | Error _ -> Alcotest.fail "missing metrics store returned a read failure");
+       let snapshot =
+         Operator_control_context_snapshot.keeper_context_snapshot_of_meta config meta
+       in
+       Alcotest.(check (option int)) "metadata token observation" (Some 731)
+         snapshot.context_tokens;
+       Alcotest.(check (option string)) "explicit metadata source"
+         (Some "fallback_metadata") snapshot.context_source;
+       Alcotest.(check bool) "no metrics failure" true
+         (snapshot.context_metrics_unavailable = None))
+;;
+
+let test_context_snapshot_malformed_metrics_is_unavailable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       let config = Workspace.default_config base_dir in
+       let meta = context_test_meta ~name:"metrics-malformed" ~last_input_tokens:991 in
+       let path = write_raw_metrics_row config meta.name "{not-json" in
+       (match
+          Operator_control_context_snapshot.latest_keeper_context_snapshot_from_files
+            config
+            meta.name
+        with
+        | Error
+            (Operator_control_context_snapshot.Malformed_metrics_row
+              { path = error_path; line_number = None; _ }) ->
+          Alcotest.(check string) "exact malformed row path" path error_path
+        | Error _ -> Alcotest.fail "unexpected metrics read error"
+        | Ok _ -> Alcotest.fail "malformed metrics row was silently accepted");
+       let snapshot =
+         Operator_control_context_snapshot.keeper_context_snapshot_of_meta config meta
+       in
+       Alcotest.(check (option int)) "no metadata token fallback" None
+         snapshot.context_tokens;
+       Alcotest.(check (option string)) "no fabricated source" None
+         snapshot.context_source;
+       let json =
+         `Assoc
+           (Operator_control_context_snapshot.keeper_context_snapshot_fields snapshot)
+       in
+       let unavailable =
+         Yojson.Safe.Util.member "context_metrics_unavailable" json
+       in
+       Alcotest.(check string) "typed decode failure" "malformed_json"
+         Yojson.Safe.Util.(unavailable |> member "kind" |> to_string);
+       Alcotest.(check string) "decode failure path" path
+         Yojson.Safe.Util.(unavailable |> member "path" |> to_string))
+;;
+
+let test_context_snapshot_storage_failure_is_unavailable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       let config = Workspace.default_config base_dir in
+       let meta = context_test_meta ~name:"metrics-storage-error" ~last_input_tokens:557 in
+       let metrics_dir = Keeper_types_support.keeper_metrics_dir config meta.name in
+       Fs_compat.save_file metrics_dir "not a directory";
+       let snapshot =
+         Operator_control_context_snapshot.keeper_context_snapshot_of_meta config meta
+       in
+       Alcotest.(check (option int)) "no metadata token fallback" None
+         snapshot.context_tokens;
+       let json =
+         `Assoc
+           (Operator_control_context_snapshot.keeper_context_snapshot_fields snapshot)
+       in
+       let unavailable =
+         Yojson.Safe.Util.member "context_metrics_unavailable" json
+       in
+       Alcotest.(check string) "typed storage failure" "storage_read_failed"
+         Yojson.Safe.Util.(unavailable |> member "kind" |> to_string);
+       Alcotest.(check string) "exact storage reason" "not_a_directory"
+         Yojson.Safe.Util.(unavailable |> member "reason" |> to_string))
+;;
+
 let test_keeper_up_clears_dead_tombstone_resume_state () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1724,6 +1853,20 @@ let () =
             "null runtime signal preserves surface status"
             `Quick
             test_align_keeper_runtime_status_tolerates_null_status_json;
+        ] );
+      ( "context metrics ledger"
+      , [ Alcotest.test_case
+            "missing ledger uses observed metadata"
+            `Quick
+            test_context_snapshot_missing_metrics_uses_observed_metadata
+        ; Alcotest.test_case
+            "malformed row is typed unavailable"
+            `Quick
+            test_context_snapshot_malformed_metrics_is_unavailable
+        ; Alcotest.test_case
+            "storage failure is typed unavailable"
+            `Quick
+            test_context_snapshot_storage_failure_is_unavailable
         ] );
     ]
 ;;


### PR DESCRIPTION
## Why

The operator context projection read recent JSONL rows with a raw string parser and silently skipped malformed JSON. That turned storage corruption into apparently valid fallback metadata and violated the explicit-unavailability contract introduced by the parent capacity leaf.

## What

- read the context metrics ledger through strict `Dated_jsonl.read_recent_result`
- return typed storage and malformed-row errors, including path and line number
- use metadata fallback only for a valid empty ledger
- preserve capacity unavailability and ledger unavailability as independent observations
- expose the exact ledger failure in operator/dashboard JSON
- cover empty, malformed and storage-failure cases

## Scope

Stacked exactly on #25211 (`60d91e039f`). 250 changed lines (231 additions, 19 deletions). No fallback capacity or parser compatibility path is added.

## Validation

- `git diff --check`: PASS
- `ocamlformat --check` on touched files: PASS
- focused wrapper build entered OCaml compilation, but its final exit was not captured after the validating agent turn was interrupted; no local green is claimed
- PR CI is the full-build authority

Draft only.
