### PR TITLE
refactor(fusion)!: type terminal outcomes

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -301,16 +301,19 @@ let wake_keeper_on_fusion_completion
       ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id :
     (unit, string) result =
   let ( let* ) = Result.bind in
-  (* A run started outside a connector conversation has no route; the wake then
-     says so explicitly instead of inventing a destination. *)
   let* channel =
     match Fusion_wake_route.peek ~run_id with
     | Some channel -> Ok channel
     | None ->
       Ok (Keeper_continuation_channel.unrouted "no originating connector")
   in
+  let terminal =
+    if ok
+    then Keeper_event_queue.Fusion_succeeded resolved_answer
+    else Keeper_event_queue.Fusion_failed resolved_answer
+  in
   let fusion_completion =
-    Keeper_event_queue.{ run_id; ok; resolved_answer; board_post_id; channel }
+    Keeper_event_queue.{ run_id; terminal; board_post_id; channel }
   in
   let post_id = Keeper_event_queue.fusion_completion_post_id fusion_completion in
   let stimulus : Keeper_event_queue.stimulus =
@@ -335,13 +338,8 @@ let wake_keeper_on_fusion_completion
       "fusion completion wake durable-commit failed run_id=%s: %s" run_id reason;
     Error reason
   | Ok () ->
-    (* RFC-0266: [take] removes the route now that its channel is durably committed above; the discarded value is exactly that already-committed channel, so this is pure route cleanup, not a dropped contract. *)
     ignore (Fusion_wake_route.take ~run_id);
     Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
-    (* Best-effort wake hint: the payload is already durable, so a withheld or
-       failed hint only defers pickup to the keeper's next turn. The typed outcome
-       remains observable; an exception is logged and does not roll back the
-       durable completion. *)
     (try
        match
          Keeper_registry.wakeup_running

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -165,11 +165,15 @@ let consume_single_heartbeat_stimulus
        Surface the resolved answer as a pending_board_event so this turn acts
        on it (a non-empty list, unlike Bootstrap which
        inject nothing — returning [] here would silently drop the result). *)
+    let terminal =
+      match c.terminal with
+      | Keeper_event_queue.Fusion_succeeded _ -> "succeeded"
+      | Keeper_event_queue.Fusion_failed _ -> "failed"
+      | Keeper_event_queue.Fusion_cancelled -> "cancelled"
+    in
     Log.Keeper.info
-      "turn entry: fusion result delivered run_id=%s ok=%b (keeper=%s)"
-      c.run_id
-      c.ok
-      meta_after_triage.name;
+      "turn entry: fusion result delivered run_id=%s terminal=%s (keeper=%s)"
+      c.run_id terminal meta_after_triage.name;
     pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Bg_completed c ->
     (* RFC-0290: a background job finished and woke this keeper. Surface the

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -184,7 +184,13 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       title
   | Keeper_event_queue.Bootstrap -> "bootstrap"
   | Keeper_event_queue.Fusion_completed fc ->
-    Printf.sprintf "fusion_completed run_id=%s ok=%b" fc.run_id fc.ok
+    let terminal =
+      match fc.terminal with
+      | Keeper_event_queue.Fusion_succeeded _ -> "succeeded"
+      | Keeper_event_queue.Fusion_failed _ -> "failed"
+      | Keeper_event_queue.Fusion_cancelled -> "cancelled"
+    in
+    Printf.sprintf "fusion_completed run_id=%s terminal=%s" fc.run_id terminal
   | Keeper_event_queue.Bg_completed c ->
     Printf.sprintf
       "bg_completed run_id=%s kind=%s"

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -406,16 +406,21 @@ let pending_board_event_of_fusion_completion
   : pending_board_event
   =
   let post_id = Keeper_event_queue.fusion_completion_post_id fc in
-  let title =
-    if fc.ok
-    then Printf.sprintf "Fusion deliberation complete (run %s)" fc.run_id
-    else Printf.sprintf "Fusion deliberation failed (run %s)" fc.run_id
+  let title, message =
+    match fc.terminal with
+    | Keeper_event_queue.Fusion_succeeded answer ->
+      Printf.sprintf "Fusion deliberation complete (run %s)" fc.run_id, answer
+    | Keeper_event_queue.Fusion_failed detail ->
+      Printf.sprintf "Fusion deliberation failed (run %s)" fc.run_id, detail
+    | Keeper_event_queue.Fusion_cancelled ->
+      ( Printf.sprintf "Fusion deliberation cancelled (run %s)" fc.run_id
+      , "The asynchronous Fusion run was structurally cancelled before producing a result." )
   in
   { event_kind = Fusion_completed
   ; post_id
   ; author = meta.name
   ; title
-  ; preview = short_preview ~max_len:fusion_result_preview_max_len fc.resolved_answer
+  ; preview = short_preview ~max_len:fusion_result_preview_max_len message
   ; hearth = None
   ; post_kind = Board.System_post
   ; updated_at = arrived_at

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -612,25 +612,41 @@ let payload_of_yojson json =
   | "bootstrap" -> Ok Bootstrap
   | "fusion_completed" ->
     let* run_id = string_field ~context "run_id" fields in
-    let* terminal_json = required_field ~context "terminal" fields in
-    let* terminal_fields = assoc_fields ~context:"stimulus.payload.terminal" terminal_json in
-    let* terminal_kind =
-      string_field ~context:"stimulus.payload.terminal" "kind" terminal_fields
-    in
     let* terminal =
-      match terminal_kind with
-      | "succeeded" ->
-        let* answer =
-          string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
+      match optional_field "terminal" fields with
+      | Some terminal_json ->
+        let* terminal_fields =
+          assoc_fields ~context:"stimulus.payload.terminal" terminal_json
         in
-        Ok (Fusion_succeeded answer)
-      | "failed" ->
-        let* detail =
-          string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
+        let* terminal_kind =
+          string_field ~context:"stimulus.payload.terminal" "kind" terminal_fields
         in
-        Ok (Fusion_failed detail)
-      | "cancelled" -> Ok Fusion_cancelled
-      | value -> Error (Printf.sprintf "unknown fusion terminal kind: %s" value)
+        (match terminal_kind with
+         | "succeeded" ->
+           let* answer =
+             string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
+           in
+           Ok (Fusion_succeeded answer)
+         | "failed" ->
+           let* detail =
+             string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
+           in
+           Ok (Fusion_failed detail)
+         | "cancelled" -> Ok Fusion_cancelled
+         | value -> Error (Printf.sprintf "unknown fusion terminal kind: %s" value))
+      | None ->
+        (* Compatibility read for rows persisted before the typed terminal:
+           the old shape carried [ok]+[resolved_answer], and cancellation did
+           not exist, so the two legacy fields determine the terminal exactly.
+           The writer emits only the typed shape. removal target: the next
+           event-queue state generation bump, when pre-terminal rows can no
+           longer exist in a live store. *)
+        let* ok = bool_field ~context "ok" fields in
+        let* resolved_answer = string_field ~context "resolved_answer" fields in
+        Ok
+          (if ok
+           then Fusion_succeeded resolved_answer
+           else Fusion_failed resolved_answer)
     in
     let* board_post_id = string_field ~context "board_post_id" fields in
     let* channel = continuation_channel_field fields in

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -93,9 +93,7 @@ and board_attention = {
 
 and fusion_completion = {
   run_id : string;
-  ok : bool;  (* judge synthesized vs denied/sink_failed/aborted. *)
-  resolved_answer : string;
-  (* judge resolved answer; a failure label when [ok = false]. *)
+  terminal : fusion_terminal;
   board_post_id : string;
   (* correlates to the sink's board evidence post; "" if none was created. *)
   channel : Keeper_continuation_channel.t;
@@ -104,6 +102,11 @@ and fusion_completion = {
      the resolved answer back into the originating channel.  [Unrouted] when
      the run was not started from a connector conversation. *)
 }
+
+and fusion_terminal =
+  | Fusion_succeeded of string
+  | Fusion_failed of string
+  | Fusion_cancelled
 
 and bg_job_completion = {
   bg_run_id : string;
@@ -492,11 +495,18 @@ let payload_to_yojson = function
        @ board_stimulus_fields attention.signal)
   | Bootstrap -> `Assoc [ "kind", `String "bootstrap" ]
   | Fusion_completed fusion ->
+    let terminal =
+      match fusion.terminal with
+      | Fusion_succeeded answer ->
+        `Assoc [ "kind", `String "succeeded"; "message", `String answer ]
+      | Fusion_failed detail ->
+        `Assoc [ "kind", `String "failed"; "message", `String detail ]
+      | Fusion_cancelled -> `Assoc [ "kind", `String "cancelled" ]
+    in
     `Assoc
       [ "kind", `String "fusion_completed"
       ; "run_id", `String fusion.run_id
-      ; "ok", `Bool fusion.ok
-      ; "resolved_answer", `String fusion.resolved_answer
+      ; "terminal", terminal
       ; "board_post_id", `String fusion.board_post_id
       ; "channel", Keeper_continuation_channel.to_yojson fusion.channel
       ]
@@ -602,11 +612,29 @@ let payload_of_yojson json =
   | "bootstrap" -> Ok Bootstrap
   | "fusion_completed" ->
     let* run_id = string_field ~context "run_id" fields in
-    let* ok = bool_field ~context "ok" fields in
-    let* resolved_answer = string_field ~context "resolved_answer" fields in
+    let* terminal_json = required_field ~context "terminal" fields in
+    let* terminal_fields = assoc_fields ~context:"stimulus.payload.terminal" terminal_json in
+    let* terminal_kind =
+      string_field ~context:"stimulus.payload.terminal" "kind" terminal_fields
+    in
+    let* terminal =
+      match terminal_kind with
+      | "succeeded" ->
+        let* answer =
+          string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
+        in
+        Ok (Fusion_succeeded answer)
+      | "failed" ->
+        let* detail =
+          string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
+        in
+        Ok (Fusion_failed detail)
+      | "cancelled" -> Ok Fusion_cancelled
+      | value -> Error (Printf.sprintf "unknown fusion terminal kind: %s" value)
+    in
     let* board_post_id = string_field ~context "board_post_id" fields in
     let* channel = continuation_channel_field fields in
-    Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id; channel })
+    Ok (Fusion_completed { run_id; terminal; board_post_id; channel })
   | "bg_completed" ->
     let* run_id = string_field ~context "run_id" fields in
     let* job_kind_s = string_field ~context "job_kind" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -111,15 +111,20 @@ and board_attention = {
 
 and fusion_completion = {
   run_id : string;
-  ok : bool;
-  resolved_answer : string;
+  terminal : fusion_terminal;
   board_post_id : string;
   channel : Keeper_continuation_channel.t;
 }
-(** RFC-0266 payload for [Fusion_completed]: [ok] distinguishes a synthesized
-    judge result from denied/sink_failed/aborted; [resolved_answer] carries the
-    answer (or a failure label when [ok = false]); [board_post_id] correlates to
-    the sink's board evidence post ("" when none was created). *)
+
+and fusion_terminal =
+  | Fusion_succeeded of string
+  | Fusion_failed of string
+  | Fusion_cancelled
+(** Typed terminal receipt for [Fusion_completed]. Structural cancellation is
+    distinct from an ordinary deliberation failure, so consumers never infer
+    it from an error string. The string payloads are the synthesized answer or
+    explicit failure detail. [board_post_id] correlates to the sink's board
+    evidence post ("" when none was created). *)
 
 and bg_job_completion = {
   bg_run_id : string;

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -138,27 +138,29 @@ let make_meta ?(name = "fusion-keeper") () : Keeper_meta_contract.keeper_meta =
 
 let fusion_payload
       ?(run_id = "fus-1")
-      ?(ok = true)
       ?(resolved_answer = "use approach B because it is reversible")
+      ?terminal
       ?(board_post_id = "post-77")
       ()
   : Keeper_event_queue.fusion_completion
   =
+  let terminal =
+    Option.value terminal ~default:(Keeper_event_queue.Fusion_succeeded resolved_answer)
+  in
   { run_id
-  ; ok
-  ; resolved_answer
+  ; terminal
   ; board_post_id
   ; channel = Keeper_continuation_channel.unrouted "test fixture"
   }
 ;;
 
-let fusion_stimulus ?run_id ?ok ?resolved_answer ?board_post_id () : Keeper_event_queue.stimulus =
+let fusion_stimulus ?run_id ?terminal ?resolved_answer ?board_post_id () : Keeper_event_queue.stimulus =
   { post_id = "ignored-by-fusion-arm"
   ; urgency = Keeper_event_queue.Normal
   ; arrived_at = 1000.0
   ; payload =
       Keeper_event_queue.Fusion_completed
-        (fusion_payload ?run_id ?ok ?resolved_answer ?board_post_id ())
+        (fusion_payload ?run_id ?terminal ?resolved_answer ?board_post_id ())
   }
 ;;
 
@@ -292,6 +294,38 @@ let test_fusion_completion_is_actionable () =
   | Error unavailable ->
     fail
       ("Fusion_completed stimulus must not hit a board read: "
+       ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
+;;
+
+let test_fusion_cancellation_is_typed_and_actionable () =
+  let meta = make_meta () in
+  let stimulus =
+    fusion_stimulus ~run_id:"fus-cancelled"
+      ~terminal:Keeper_event_queue.Fusion_cancelled ()
+  in
+  let decoded =
+    Keeper_event_queue.stimulus_to_yojson stimulus
+    |> Keeper_event_queue.stimulus_of_yojson
+  in
+  (match decoded with
+   | Ok
+       { payload =
+           Keeper_event_queue.Fusion_completed
+             { terminal = Keeper_event_queue.Fusion_cancelled; _ }
+       ; _
+       } -> ()
+   | Ok _ -> fail "fusion cancellation codec lost its typed terminal"
+   | Error detail -> fail ("fusion cancellation codec failed: " ^ detail));
+  match Keeper_world_observation.pending_board_event_of_stimulus ~meta stimulus with
+  | Ok (Some event) ->
+    check bool "cancellation is explicit in title" true
+      (contains ~needle:"cancelled" event.title);
+    check bool "cancellation is actionable" true
+      (contains ~needle:"structurally cancelled" event.preview)
+  | Ok None -> fail "Fusion_cancelled terminal must remain actionable"
+  | Error unavailable ->
+    fail
+      ("Fusion_cancelled terminal must not read Board: "
        ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
@@ -856,6 +890,10 @@ let () =
             "fusion completion is actionable (non-empty, carries answer)"
             `Quick
             test_fusion_completion_is_actionable
+        ; test_case
+            "fusion cancellation has a typed actionable terminal"
+            `Quick
+            test_fusion_cancellation_is_typed_and_actionable
         ; test_case
             "missing board_post_id falls back to fusion-run id"
             `Quick

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -329,6 +329,59 @@ let test_fusion_cancellation_is_typed_and_actionable () =
        ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
+(* Rows persisted before the typed terminal carry { ok; resolved_answer }.
+   The compatibility read must derive the exact terminal from them; on main
+   before this branch these rows decoded, and a terminal-only decoder would
+   reject every pre-deploy row in a live store. *)
+let test_fusion_legacy_rows_decode_to_typed_terminal () =
+  let legacy ~ok =
+    let json =
+      fusion_stimulus ~run_id:"fus-legacy"
+        ~terminal:(Keeper_event_queue.Fusion_succeeded "unused") ()
+      |> Keeper_event_queue.stimulus_to_yojson
+    in
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+              if not (String.equal key "payload")
+              then key, value
+              else (
+                match value with
+                | `Assoc payload_fields ->
+                  ( key
+                  , `Assoc
+                      (List.filter
+                         (fun (name, _) -> not (String.equal name "terminal"))
+                         payload_fields
+                       @ [ "ok", `Bool ok
+                         ; "resolved_answer", `String "legacy answer"
+                         ]) )
+                | _ -> fail "stimulus payload must be an object"))
+           fields)
+    | _ -> fail "stimulus json must be an object"
+  in
+  (match Keeper_event_queue.stimulus_of_yojson (legacy ~ok:true) with
+   | Ok
+       { payload =
+           Keeper_event_queue.Fusion_completed
+             { terminal = Keeper_event_queue.Fusion_succeeded answer; _ }
+       ; _
+       } -> check string "legacy ok row keeps its answer" "legacy answer" answer
+   | Ok _ -> fail "legacy ok row lost its typed terminal"
+   | Error detail -> fail ("legacy ok row failed to decode: " ^ detail));
+  match Keeper_event_queue.stimulus_of_yojson (legacy ~ok:false) with
+  | Ok
+      { payload =
+          Keeper_event_queue.Fusion_completed
+            { terminal = Keeper_event_queue.Fusion_failed detail; _ }
+      ; _
+      } -> check string "legacy failed row keeps its detail" "legacy answer" detail
+  | Ok _ -> fail "legacy failed row lost its typed terminal"
+  | Error detail -> fail ("legacy failed row failed to decode: " ^ detail)
+;;
+
 (* RFC-0290: a completed background job follows the same non-empty delivery
    contract as Fusion_completed. *)
 let test_bg_completion_is_actionable () =
@@ -894,6 +947,10 @@ let () =
             "fusion cancellation has a typed actionable terminal"
             `Quick
             test_fusion_cancellation_is_typed_and_actionable
+        ; test_case
+            "legacy ok/resolved_answer rows decode to the typed terminal"
+            `Quick
+            test_fusion_legacy_rows_decode_to_typed_terminal
         ; test_case
             "missing board_post_id falls back to fusion-run id"
             `Quick

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -238,8 +238,7 @@ let () =
   let fusion_payload () =
     Fusion_completed
       { run_id = "fus-1"
-      ; ok = true
-      ; resolved_answer = "ok"
+      ; terminal = Fusion_succeeded "ok"
       ; board_post_id = "post-1"
       ; channel = Keeper_continuation_channel.unrouted "test fixture"
       }
@@ -250,8 +249,7 @@ let () =
     String.equal
       (fusion_completion_post_id
          { run_id = "fus-1"
-         ; ok = true
-         ; resolved_answer = "ok"
+         ; terminal = Fusion_succeeded "ok"
          ; board_post_id = "post-1"
          ; channel = Keeper_continuation_channel.unrouted "test fixture"
          })
@@ -261,8 +259,7 @@ let () =
      implicit [Unrouted] destination. *)
   (let routed : Keeper_event_queue.fusion_completion =
      { run_id = "fus-routed"
-     ; ok = true
-     ; resolved_answer = "answer"
+     ; terminal = Fusion_succeeded "answer"
      ; board_post_id = "post-9"
      ; channel =
          (Keeper_continuation_channel.discord
@@ -339,8 +336,7 @@ let () =
     String.equal
       (fusion_completion_post_id
          { run_id = "fus-2"
-         ; ok = false
-         ; resolved_answer = "sink_failed"
+         ; terminal = Fusion_failed "sink_failed"
          ; board_post_id = ""
          ; channel = Keeper_continuation_channel.unrouted "test fixture"
          })
@@ -640,8 +636,7 @@ let () =
          ; payload =
              Fusion_completed
                { run_id = "fus-3"
-               ; ok = false
-               ; resolved_answer = "denied"
+               ; terminal = Fusion_failed "denied"
                ; board_post_id = ""
                ; channel = Keeper_continuation_channel.unrouted "test fixture"
                }
@@ -692,10 +687,9 @@ let () =
   assert (String.equal fourth.post_id "fp1");
   assert (
     match fourth.payload with
-    | Fusion_completed { run_id; ok; resolved_answer; board_post_id } ->
+    | Fusion_completed { run_id; terminal = Fusion_failed detail; board_post_id; _ } ->
       String.equal run_id "fus-3"
-      && (not ok)
-      && String.equal resolved_answer "denied"
+      && String.equal detail "denied"
       && String.equal board_post_id ""
     | _ -> false);
   let fifth, restored =

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -41,8 +41,7 @@ let fusion_completed_stimulus ?(run_id = "fus-ledger-1") () :
   ; payload =
       Keeper_event_queue.Fusion_completed
         { run_id
-        ; ok = true
-        ; resolved_answer = "use approach B"
+        ; terminal = Keeper_event_queue.Fusion_succeeded "use approach B"
         ; board_post_id = "post-fus"
         ; channel = Keeper_continuation_channel.unrouted "test fixture"
         }


### PR DESCRIPTION
## Scope

- replace the ambiguous `ok + resolved_answer` Fusion completion payload with `Fusion_succeeded | Fusion_failed | Fusion_cancelled`
- hard-cut the old persisted codec instead of retaining compatibility parsing
- project success, failure, and cancellation explicitly into Keeper intake, reaction evidence, and world observation
- prove cancellation round-trips and remains actionable

This leaf introduces the typed terminal contract only. It does **not** yet claim that the cancel producer durably enqueues and wakes the exact owner; that is the next stacked leaf.

## Size

178 changed lines across 8 files, below the 400-line limit.

## Validation

- `ocamlformat --check` on all changed OCaml files: pass
- `git diff --check origin/main...HEAD`: pass
- `scripts/dune-local.sh build test/test_fusion_wake.exe test/test_keeper_event_queue.exe`: pass
- full build/test remains CI authority