### PR TITLE
fix(keeper): supersede per-turn world-state prompt instead of accumulating (#25193)

### DIFF
--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -92,7 +92,12 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
       tool_call_id =
         (Json_util.get_string json "tool_call_id"
          |> Option.map Inference_utils.sanitize_text_utf8);
-      metadata = [];
+      (* Round-trip metadata: the OAS checkpoint codec already preserves it,
+         and dropping it here silently discarded message provenance (e.g. the
+         world-state injection stamp, #25193) on every masc-side
+         re-serialization. [metadata_of_json] was defined for exactly this
+         and never wired in. *)
+      metadata = metadata_of_json json;
     }
 
 (** Extract human-readable text from a single history.jsonl line.

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -111,10 +111,45 @@ let build_turn_context
       user_hash=%s dyn_length=%d dyn_hash=%s"
      meta.agent_name (start_turn_count + 1) user_seg.Keeper_agent_prompt_metrics.bytes
      (pick_hash16 user_seg) dyn_seg.Keeper_agent_prompt_metrics.bytes (pick_hash16 dyn_seg));
-  (* 6. Append user message and persist. *)
-  let user_msg = Agent_sdk.Types.user_msg user_message in
+  (* 6. Append user message and persist. A world-state prompt supersedes the
+     previous one instead of accumulating (#25193): the block is a turn-scoped
+     observation, and the jsonl replay path already drops this channel
+     ([classify_history_entry] -> [Drop_line]), so keeping every copy in the
+     live context was pure duplication — a live checkpoint measured 180
+     near-identical copies (50.8% of its bytes). The injected message is
+     stamped with typed metadata provenance, and prior stamped copies are
+     removed by exact metadata equality before the new one is appended;
+     message content is never inspected, so operator-authored text that
+     merely looks like a world-state block is untouched (as are legacy
+     pre-tag copies, which compaction owns). *)
+  let is_world_state_prompt_turn =
+    Keeper_types_support.is_prompt_history_source history_user_source
+  in
+  let user_msg =
+    let plain = Agent_sdk.Types.user_msg user_message in
+    if is_world_state_prompt_turn
+    then
+      Keeper_types_support.tag_message_history_source
+        ~source:Keeper_types_support.world_state_prompt_history_source plain
+    else plain
+  in
   let history_messages =
-    Keeper_context_runtime.messages_of_context ctx_work
+    let all = Keeper_context_runtime.messages_of_context ctx_work in
+    if is_world_state_prompt_turn
+    then
+      List.filter
+        (fun message ->
+          not (Keeper_types_support.message_is_world_state_prompt message))
+        all
+    else all
+  in
+  let ctx_work =
+    { ctx_work with
+      checkpoint =
+        { ctx_work.checkpoint with
+          Agent_sdk.Checkpoint.messages = history_messages
+        }
+    }
   in
   let ctx_work = Keeper_context_runtime.append ctx_work user_msg in
   if not is_retry

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -221,13 +221,53 @@ let keeper_internal_history_path config trace_id =
 let normalize_history_source (source : string) =
   source |> String.trim |> String.lowercase_ascii
 
+let world_state_prompt_history_source = "world_state_prompt"
+
 let is_prompt_history_source (source : string) =
-  String.equal (normalize_history_source source) "world_state_prompt"
+  String.equal (normalize_history_source source) world_state_prompt_history_source
 
 let is_internal_history_source (source : string) =
   match normalize_history_source source with
   | "world_state_prompt" | "internal_assistant" -> true
   | _ -> false
+
+(* Message-level provenance for per-turn injected prompts (#25193).
+
+   The world-state block is a turn-scoped observation, yet it is appended to
+   the persisted conversation every scheduler turn: a live checkpoint was
+   measured at 180 near-identical copies = 50.8% of its bytes. The history
+   jsonl replay path already drops [world_state_prompt] lines
+   ([classify_history_entry] -> [Drop_line]); tagging the live message lets
+   the in-context copy be superseded the same way. The tag is message
+   [metadata], which the OAS checkpoint codec round-trips and deliberately
+   never forwards to provider payloads. Identification is exact key/value
+   equality on metadata this process wrote — never content inspection. *)
+let history_source_metadata_key = "history_source"
+
+let tag_message_history_source ~(source : string)
+    (message : Agent_sdk.Types.message) : Agent_sdk.Types.message =
+  { message with
+    Agent_sdk.Types.metadata =
+      (history_source_metadata_key, `String source)
+      :: List.remove_assoc history_source_metadata_key
+           message.Agent_sdk.Types.metadata
+  }
+
+let message_is_world_state_prompt (message : Agent_sdk.Types.message) : bool =
+  match message.Agent_sdk.Types.role with
+  | Agent_sdk.Types.User ->
+    (match
+       List.assoc_opt history_source_metadata_key
+         message.Agent_sdk.Types.metadata
+     with
+     | Some (`String source) -> is_prompt_history_source source
+     | Some
+         (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `List _
+         | `Assoc _ | `Tuple _ | `Variant _)
+     | None -> false)
+  | Agent_sdk.Types.System
+  | Agent_sdk.Types.Assistant
+  | Agent_sdk.Types.Tool -> false
 
 let keeper_decision_log_path config name =
   Filename.concat

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -81,8 +81,27 @@ val keeper_internal_history_path : Workspace.config -> string -> string
 (** Trim + lowercase a history-source label. *)
 val normalize_history_source : string -> string
 
+(** Canonical source label for the per-turn world-state prompt channel.
+    Single definition of the wire literal; call sites must reference this
+    value instead of re-spelling it. *)
+val world_state_prompt_history_source : string
+
 (** Whether [source] denotes the world-state prompt history channel. *)
 val is_prompt_history_source : string -> bool
+
+(** Message-metadata key carrying the history-source provenance of a
+    message this process injected (#25193). *)
+val history_source_metadata_key : string
+
+(** Stamp [source] provenance on [message]'s metadata, replacing any
+    previous value under {!history_source_metadata_key}. *)
+val tag_message_history_source :
+  source:string -> Agent_sdk.Types.message -> Agent_sdk.Types.message
+
+(** [true] iff [message] is a user message this process stamped as a
+    world-state prompt injection. Exact metadata equality only — message
+    content is never inspected. *)
+val message_is_world_state_prompt : Agent_sdk.Types.message -> bool
 
 (** Whether [source] denotes a turn-internal (non-user-facing) history
     channel. *)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -188,7 +188,8 @@ let run (ctx : ctx)
                  ~runtime_id:execution.runtime_id
                  ~world_observation:observation
                  ~generation:run_generation
-                 ~history_user_source:"world_state_prompt"
+                 ~history_user_source:
+                   Keeper_types_support.world_state_prompt_history_source
                  ~history_assistant_source:"internal_assistant"
                  ~degraded_retry_applied:
                    (Option.is_some turn_state.degraded_retry_info)

--- a/test/dune
+++ b/test/dune
@@ -1825,6 +1825,8 @@
 
 (include stanzas/test_keeper_context_isolation.inc)
 
+(include stanzas/test_keeper_world_state_supersede.inc)
+
 (include stanzas/test_keeper_turn_up_args.inc)
 
 (include stanzas/test_keeper_cwd_response.inc)

--- a/test/stanzas/test_keeper_world_state_supersede.inc
+++ b/test/stanzas/test_keeper_world_state_supersede.inc
@@ -1,0 +1,8 @@
+; World-state prompt provenance stamp + supersession (#25193): typed
+; metadata detection (role-gated, content never inspected) and the masc
+; message-json metadata round-trip fix.
+
+(test
+ (name test_keeper_world_state_supersede)
+ (modules test_keeper_world_state_supersede)
+ (libraries masc_test_deps))

--- a/test/test_keeper_world_state_supersede.ml
+++ b/test/test_keeper_world_state_supersede.ml
@@ -1,0 +1,114 @@
+(** World-state prompt provenance and supersession (#25193).
+
+    The per-turn world-state block used to accumulate in the persisted
+    conversation (a live checkpoint measured 180 near-identical copies =
+    50.8% of its bytes). The fix stamps the injected message with typed
+    metadata provenance and removes prior stamped copies by exact metadata
+    equality before appending the new one. These tests pin the typed
+    surface: stamping, detection (role-gated, metadata-only — content is
+    never inspected), and metadata round-trip through the masc message
+    serializer (which previously dropped metadata on read). *)
+
+open Alcotest
+module Support = Masc.Keeper_types_support
+
+let world_state_source = Support.world_state_prompt_history_source
+
+let tagged text =
+  Support.tag_message_history_source ~source:world_state_source
+    (Agent_sdk.Types.user_msg text)
+
+let test_tagged_message_is_detected () =
+  check bool "stamped user message is a world-state prompt" true
+    (Support.message_is_world_state_prompt (tagged "## Current World State\n..."));
+  check bool "plain user message is not" false
+    (Support.message_is_world_state_prompt
+       (Agent_sdk.Types.user_msg "operator says hi"))
+
+let test_content_lookalike_is_not_detected () =
+  (* Operator-authored text that merely looks like a world-state block must
+     stay untouched: detection is metadata-only, never content inspection. *)
+  check bool "content lookalike without the stamp is not detected" false
+    (Support.message_is_world_state_prompt
+       (Agent_sdk.Types.user_msg
+          "## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1"))
+
+let test_non_user_roles_are_never_detected () =
+  let assistant =
+    Support.tag_message_history_source ~source:world_state_source
+      (Agent_sdk.Types.make_message ~role:Agent_sdk.Types.Assistant
+         [ Agent_sdk.Types.Text "reply" ])
+  in
+  check bool "stamped assistant message is role-gated out" false
+    (Support.message_is_world_state_prompt assistant)
+
+let test_tag_replaces_previous_stamp () =
+  let twice =
+    Support.tag_message_history_source ~source:world_state_source
+      (Support.tag_message_history_source ~source:"operator_chat"
+         (Agent_sdk.Types.user_msg "x"))
+  in
+  let stamps =
+    List.filter
+      (fun (key, _) -> String.equal key Support.history_source_metadata_key)
+      twice.Agent_sdk.Types.metadata
+  in
+  check int "exactly one provenance stamp survives re-tagging" 1
+    (List.length stamps);
+  check bool "the surviving stamp is the latest source" true
+    (Support.message_is_world_state_prompt twice)
+
+let test_masc_json_round_trip_preserves_stamp () =
+  (* Counterfactual for the serializer fix: [message_of_json] used to
+     hard-reset [metadata = []], so the stamp died on every masc-side
+     re-serialization and supersession would silently stop. *)
+  let round_tripped =
+    tagged "## Current World State\n..."
+    |> Masc.Keeper_context_runtime.message_to_json
+    |> Masc.Keeper_context_runtime.message_of_json
+  in
+  check bool "stamp survives masc message json round-trip" true
+    (Support.message_is_world_state_prompt round_tripped)
+
+let test_supersede_filter_keeps_everything_else () =
+  let conversation =
+    [ tagged "## Current World State (turn 1)"
+    ; Agent_sdk.Types.user_msg "operator question"
+    ; Agent_sdk.Types.make_message ~role:Agent_sdk.Types.Assistant
+        [ Agent_sdk.Types.Text "assistant answer" ]
+    ; tagged "## Current World State (turn 2)"
+    ]
+  in
+  let survivors =
+    List.filter
+      (fun message -> not (Support.message_is_world_state_prompt message))
+      conversation
+  in
+  check int "both stamped copies removed, both real messages kept" 2
+    (List.length survivors);
+  check bool "operator message survives" true
+    (List.exists
+       (fun (m : Agent_sdk.Types.message) ->
+         m.Agent_sdk.Types.content
+         = [ Agent_sdk.Types.Text "operator question" ])
+       survivors)
+
+let () =
+  run "Keeper world-state supersession"
+    [
+      ( "provenance",
+        [
+          test_case "stamped message is detected" `Quick
+            test_tagged_message_is_detected;
+          test_case "content lookalike is not detected" `Quick
+            test_content_lookalike_is_not_detected;
+          test_case "non-user roles are never detected" `Quick
+            test_non_user_roles_are_never_detected;
+          test_case "re-tagging keeps one stamp" `Quick
+            test_tag_replaces_previous_stamp;
+          test_case "masc json round-trip preserves the stamp" `Quick
+            test_masc_json_round_trip_preserves_stamp;
+          test_case "supersede filter keeps non-stamped messages" `Quick
+            test_supersede_filter_keeps_everything_else;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
#25193 근본 수리 — "애초에 중복 안 되도록". per-turn world-state 주입이 영속 대화에 매 턴 누적되던 것을, **직전 주입을 supersede**하도록 바꾼다.

### 근거 (라이브 실측)
garnet 체크포인트 `trace-1783826424111` (319,668B, 422 msgs): "## Current World State" user 메시지 **180개 = user 181개 중 180개 = 전체 바이트의 50.8%**. 블록 내부 "Pending Messages (50)" 창이 소비 워터마크 없이 매 턴 통째 재복사되어 140개는 바이트 동일. 이게 컨텍스트 팽창 1차 원인이고, 컴팩션 수요·실패의 입력이다.

### 변경
1. **provenance 태그 + supersede** (`keeper_run_prompt.ml`): world-state 턴이면 주입 user 메시지에 typed metadata(`history_source=world_state_prompt`)를 stamp하고, append 전에 in-context history에서 **이전 stamp된 복사본을 exact metadata 동등성으로 제거**. content는 절대 검사 안 함 → operator가 world-state처럼 쓴 텍스트, legacy pre-tag 복사본(컴팩션 소관)은 불변. jsonl replay 경로가 이미 `world_state_prompt`를 `Drop_line`하므로(영속 history) live context와 정합.
2. **metadata round-trip 버그 수정** (`keeper_context_core_message_json.ml`): `message_of_json`이 `metadata=[]`로 하드리셋 → masc측 재직렬화마다 provenance 소멸. 정의돼 있으나 미배선이던 `metadata_of_json`을 배선. OAS checkpoint codec은 이미 metadata를 round-trip하고 provider payload엔 의도적으로 미전달.
3. **SSOT**: `world_state_prompt` 리터럴 → `Keeper_types_support.world_state_prompt_history_source`.

### 안전 경계 (typed, content-free)
- 감지는 `role=User` + metadata 정확 일치만. 문자열/substring 분류기 아님.
- catch-all 추가 없음 — Yojson variant 전부 명시.
- legacy(태그 없는 과거 복사본)는 이 PR이 건드리지 않음 → 무손실. 컴팩션이 별도로 처리.

### 테스트
신규 `test_keeper_world_state_supersede` 6케이스: stamp 감지 / **content lookalike 미감지**(operator 보호) / non-User role 배제 / re-tag 시 stamp 1개 유지 / **masc json round-trip이 stamp 보존**(#2 counterfactual — 수정 전엔 소멸) / supersede 필터가 비-stamp 메시지 전부 보존.

### 효과 (예상, 미측정)
차기 배포 후 신규 world-state 주입은 1개만 상주. 기존 checkpoint의 legacy 180개는 다음 컴팩션 때 정리. 측정은 배포 후 checkpoint 재해부로 확인 예정 (이 PR엔 수치 주장 없음).

### 미포함 (별도 추적)
- 턴당 `memory_os_recall` 217KB 주입 비대 (프롬프트 조립 레이어).
- before-state 보존 (#25194).

Refs #25193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
