### PR TITLE
fix(gate): bind judgments to OAS tool occurrences

### DIFF
--- a/lib/keeper/keeper_gate_causal_context.ml
+++ b/lib/keeper/keeper_gate_causal_context.ml
@@ -53,3 +53,23 @@ let snapshot t : Keeper_gate.causal_context =
         ]
   }
 ;;
+
+let with_oas_tool_occurrence
+      (context : Keeper_gate.causal_context)
+      invocation
+  =
+  { context with
+    snapshot =
+      `Assoc
+        [ "turn_context", context.snapshot
+        ; ( "oas_tool_occurrence"
+          , `Assoc
+              [ ( "tool_use_id"
+                , `String (Agent_sdk.Tool.Invocation.tool_use_id invocation) )
+              ; "turn", `Int (Agent_sdk.Tool.Invocation.turn invocation)
+              ; ( "planned_index"
+                , `Int (Agent_sdk.Tool.Invocation.planned_index invocation) )
+              ] )
+        ]
+  }
+;;

--- a/lib/keeper/keeper_gate_causal_context.mli
+++ b/lib/keeper/keeper_gate_causal_context.mli
@@ -13,3 +13,11 @@ val record_tool_result :
   t -> operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit
 
 val snapshot : t -> Keeper_gate.causal_context
+
+(** Bind one exact OAS model-tool occurrence to an immutable turn snapshot.
+    Provider [tool_use_id] values may be blank or repeated, so [turn] and
+    [planned_index] remain part of the occurrence identity. *)
+val with_oas_tool_occurrence :
+  Keeper_gate.causal_context ->
+  Agent_sdk.Tool.Invocation.t ->
+  Keeper_gate.causal_context

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -32,6 +32,16 @@ let execute_with_observers
   =
   let t0 = Time_compat.now () in
   let invocation_fields = oas_invocation_fields oas_invocation in
+  let gate_context =
+    match gate_context, oas_invocation with
+    | Some current_context, Some invocation ->
+      Some (fun () ->
+        Keeper_gate_causal_context.with_oas_tool_occurrence
+          (current_context ())
+          invocation)
+    | (Some _ as context), None -> context
+    | None, (Some _ | None) -> None
+  in
   try
     let result, duration_ms =
       Inference_utils.timed (fun () ->

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -177,6 +177,71 @@ let test_second_tool_snapshot_contains_first_tool_result () =
   | _ -> failf "expected one completed call, got %d" (List.length calls)
 ;;
 
+let oas_invocation ~tool_use_id ~turn ~planned_index =
+  Agent_sdk.Tool.Invocation.create
+    ~tool_use_id
+    ~turn
+    ~schedule:
+      { planned_index
+      ; batch_index = 0
+      ; batch_size = 1
+      ; execution_mode = Agent_sdk.Tool.Serial
+      }
+;;
+
+let deferred_id = function
+  | Keeper_gate.Deferred { approval_id; _ } -> approval_id
+  | Keeper_gate.Allow _ -> fail "manual Gate unexpectedly allowed an effect"
+  | Keeper_gate.Unavailable reason ->
+    fail (Keeper_gate.unavailable_reason_to_string reason)
+;;
+
+let test_oas_occurrence_partitions_fresh_gate_decisions () =
+  with_clean_gate_runtime @@ fun () ->
+  let base_path = temp_dir "keeper-gate-oas-occurrence" in
+  Fun.protect ~finally:(fun () -> remove_tree base_path) @@ fun () ->
+  let config = Workspace.default_config base_path in
+  (match Keeper_gate_mode.set config ~actor:"test" Keeper_gate_mode.Manual with
+   | Ok _ -> ()
+   | Error error -> fail ("failed to select manual Gate mode: " ^ error));
+  let turn_context =
+    Keeper_gate_causal_context.create
+      ~turn_id:(Some 41)
+      ~initial:(`Assoc [ "runtime_id", `String "run-41" ])
+  in
+  let request invocation : Keeper_gate.request =
+    { keeper_name = "occurrence-keeper"
+    ; operation = "external-effect"
+    ; input = `Assoc [ "target", `String "same" ]
+    ; base_path
+    ; causal_context =
+        Some
+          (Keeper_gate_causal_context.with_oas_tool_occurrence
+             (Keeper_gate_causal_context.snapshot turn_context)
+             invocation)
+    ; task_id = None
+    ; goal_ids = []
+    ; continuation_channel = None
+    }
+  in
+  let first_occurrence = oas_invocation ~tool_use_id:"" ~turn:7 ~planned_index:0 in
+  let second_occurrence = oas_invocation ~tool_use_id:"" ~turn:7 ~planned_index:1 in
+  let decide invocation =
+    Keeper_gate.decide
+      ~keeper_always_allow:false
+      (request invocation)
+    |> deferred_id
+  in
+  let first = decide first_occurrence in
+  let duplicate_delivery = decide first_occurrence in
+  let second = decide second_occurrence in
+  check string "same occurrence delivery is idempotent" first duplicate_delivery;
+  check bool "independent occurrence gets a fresh decision" true
+    (not (String.equal first second));
+  check int "two occurrences are durably pending" 2
+    (Keeper_approval_queue.pending_count ())
+;;
+
 let test_keeper_effects_defer_without_dispatch () =
   with_clean_gate_runtime @@ fun () ->
   let base_path = temp_dir "keeper-gate-deferred" in
@@ -438,6 +503,10 @@ let () =
             "second tool snapshot contains first tool result"
             `Quick
             test_second_tool_snapshot_contains_first_tool_result
+        ; test_case
+            "OAS occurrence partitions fresh Gate decisions"
+            `Quick
+            test_oas_occurrence_partitions_fresh_gate_decisions
         ] )
     ; ( "keeper_effects"
       , [ test_case


### PR DESCRIPTION
## Goal

Require a fresh Gate decision for each exact OAS model-tool occurrence instead of allowing two independent occurrences with the same operation, input, and turn snapshot to share one pending judgment.

## Change

- Preserve OAS `tool_use_id`, `turn`, and `planned_index` inside the existing immutable Gate causal snapshot.
- Bind that occurrence evidence before any Keeper external-effect handler evaluates the Gate.
- Keep duplicate delivery of the same occurrence idempotent while assigning a distinct pending decision to another planned occurrence.
- Add a focused regression with blank `tool_use_id` values to prove identity does not depend on provider IDs being present or unique.

## Boundary and SSOT

- OAS remains the source of model-tool occurrence facts only.
- MASC remains the sole owner of Gate policy, pending judgment state, resolution, and authorization.
- No second journal, dual-write path, semantic classifier, string matching, retry budget, or compatibility fallback is introduced.
- Existing explicit Always Allow and one-shot human resolution semantics are unchanged.

## Stack

- Base: #25245 (`fix(gate): reject unversioned causal context`)
- This leaf is 107 added lines across four files and does not include unrelated main changes.

## Verification

- `ocamlformat -i` on all touched OCaml files
- `ocamlc -stop-after parsing` on all touched `.ml`/`.mli` files
- `git diff --check`
- focused Dune target was attempted twice through `scripts/dune-local.sh` and correctly refused because unrelated bare PID 40372 is running `dune build --root .`; no lock bypass or process interruption was used
- CI is the build authority

## Remaining scope

This closes the production OAS Keeper-tool occurrence path. Non-OAS producers must supply their own durable product occurrence identity in later leaf PRs; this PR does not fabricate IDs for them.
