### PR TITLE
feat(fusion): isolate durable run authority

### DIFF
--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -10,6 +10,6 @@
  (name masc_fusion_core)
  (public_name masc.fusion_core)
  (wrapped false)
- (libraries fs_compat masc_log yojson otoml)
+ (libraries digestif eio fs_compat masc_log unix yojson otoml)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -1,0 +1,196 @@
+type identity =
+  { keeper : string
+  ; run_id : string
+  }
+[@@deriving yojson, show, eq]
+type registration =
+  { identity : identity
+  ; preset : string
+  ; started_at : float
+  }
+[@@deriving yojson, show, eq]
+type terminal =
+  | Succeeded of
+      { answer : string
+      ; board_post_id : string option
+      }
+  | Failed of
+      { code : string
+      ; detail : string
+      ; board_post_id : string option
+      }
+  | Cancelled of string
+[@@deriving yojson, show, eq]
+type error =
+  | Empty_keeper
+  | Empty_run_id
+  | Invalid_started_at of float
+  | Empty_success_answer
+  | Empty_failure_code
+  | Empty_failure_detail
+  | Empty_cancellation_detail
+  | Empty_board_post_id
+  | Partial_tail
+  | Invalid_record of
+      { line : int
+      ; detail : string
+      }
+  | Orphan_terminal
+  | Reversed_records
+  | Unexpected_sequence of int
+  | Identity_mismatch of identity
+  | Registration_conflict of registration
+  | Durable_append_failed of Fs_compat.durable_append_error
+  | Storage_failed of exn
+type register_outcome =
+  | Registered
+  | Already_registered
+type claim_outcome =
+  | First_committed
+  | Already_same
+  | Conflict of terminal
+type terminal_record =
+  { identity : identity
+  ; terminal : terminal
+  }
+[@@deriving yojson]
+type persisted_event =
+  | Run_registered of registration
+  | Terminal_committed of terminal_record
+[@@deriving yojson]
+type persisted_state =
+  | Empty
+  | Running of registration
+  | Settled of registration * terminal
+type t = { root : string }
+let create ~directory = { root = directory }
+let identity_key identity =
+  Printf.sprintf
+    "%d:%s%d:%s"
+    (String.length identity.keeper)
+    identity.keeper
+    (String.length identity.run_id)
+    identity.run_id
+;;
+let run_file t ~keeper ~run_id =
+  let identity = { keeper; run_id } in
+  let digest = Digestif.SHA256.(digest_string (identity_key identity) |> to_hex) in
+  Filename.concat t.root (digest ^ ".jsonl")
+;;
+let validate_identity = function
+  | { keeper = ""; _ } -> Error Empty_keeper
+  | { run_id = ""; _ } -> Error Empty_run_id
+  | _ -> Ok ()
+;;
+let validate_board_post_id = function
+  | Some "" -> Error Empty_board_post_id
+  | None | Some _ -> Ok ()
+;;
+let validate_terminal = function
+  | Succeeded { answer = ""; _ } -> Error Empty_success_answer
+  | Succeeded { board_post_id; _ } -> validate_board_post_id board_post_id
+  | Failed { code = ""; _ } -> Error Empty_failure_code
+  | Failed { detail = ""; _ } -> Error Empty_failure_detail
+  | Failed { board_post_id; _ } -> validate_board_post_id board_post_id
+  | Cancelled "" -> Error Empty_cancellation_detail
+  | Cancelled _ -> Ok ()
+;;
+let event_line event = Yojson.Safe.to_string (persisted_event_to_yojson event) ^ "\n"
+let parse_events content =
+  if String.equal content ""
+  then Ok []
+  else if not (Char.equal content.[String.length content - 1] '\n')
+  then Error Partial_tail
+  else
+    let body = String.sub content 0 (String.length content - 1) in
+    let lines = String.split_on_char '\n' body in
+    let rec parse line_number acc = function
+      | [] -> Ok (List.rev acc)
+      | line :: rest ->
+        let parsed =
+          try
+            Yojson.Safe.from_string line
+            |> persisted_event_of_yojson
+            |> Result.map_error (fun detail -> Invalid_record { line = line_number; detail })
+          with
+          | Yojson.Json_error detail -> Error (Invalid_record { line = line_number; detail })
+        in
+        Result.bind parsed (fun event -> parse (line_number + 1) (event :: acc) rest)
+    in
+    parse 1 [] lines
+;;
+let check_identity expected actual =
+  if equal_identity expected actual then Ok () else Error (Identity_mismatch actual)
+;;
+let state_of_content expected content =
+  let ( let* ) = Result.bind in
+  let* events = parse_events content in
+  match events with
+  | [] -> Ok Empty
+  | [ Run_registered registration ] ->
+    let* () = check_identity expected registration.identity in
+    Ok (Running registration)
+  | [ Run_registered registration; Terminal_committed terminal_record ] ->
+    let* () = check_identity expected registration.identity in
+    let* () = check_identity expected terminal_record.identity in
+    let* () = validate_terminal terminal_record.terminal in
+    Ok (Settled (registration, terminal_record.terminal))
+  | [ Terminal_committed terminal_record ] ->
+    let* () = check_identity expected terminal_record.identity in
+    Error Orphan_terminal
+  | [ Terminal_committed terminal_record; Run_registered registration ] ->
+    let* () = check_identity expected terminal_record.identity in
+    let* () = check_identity expected registration.identity in
+    Error Reversed_records
+  | events -> Error (Unexpected_sequence (List.length events))
+;;
+let transact path decide =
+  try
+    match Fs_compat.update_private_file_durable_locked_result path decide with
+    | Ok result -> result
+    | Error error -> Error (Durable_append_failed error)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Storage_failed exn)
+;;
+let register t ~keeper ~run_id ~preset ~started_at =
+  if not (Float.is_finite started_at)
+  then Error (Invalid_started_at started_at)
+  else
+    let identity = { keeper; run_id } in
+    let requested = { identity; preset; started_at } in
+    match validate_identity identity with
+    | Error error -> Error error
+    | Ok () ->
+      transact (run_file t ~keeper ~run_id) (fun content ->
+        match state_of_content identity content with
+        | Error error -> None, Error error
+        | Ok Empty -> Some (event_line (Run_registered requested)), Ok Registered
+        | Ok (Running existing | Settled (existing, _)) ->
+          if equal_registration existing requested
+          then None, Ok Already_registered
+          else None, Error (Registration_conflict existing))
+;;
+let claim_terminal t ~keeper ~run_id terminal =
+  match validate_terminal terminal with
+  | Error error -> Error error
+  | Ok () ->
+    let identity = { keeper; run_id } in
+    (match validate_identity identity with
+     | Error error -> Error error
+     | Ok () ->
+       transact (run_file t ~keeper ~run_id) (fun content ->
+         match state_of_content identity content with
+         | Error error -> None, Error error
+         | Ok Empty -> None, Error Orphan_terminal
+         | Ok (Running _) ->
+           let record = { identity; terminal } in
+           Some (event_line (Terminal_committed record)), Ok First_committed
+         | Ok (Settled (_, winner)) ->
+           if equal_terminal winner terminal
+           then None, Ok Already_same
+           else None, Ok (Conflict winner)))
+;;
+module For_testing = struct
+  let run_file = run_file
+end

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -1,0 +1,65 @@
+type t
+type identity =
+  { keeper : string
+  ; run_id : string
+  }
+type registration =
+  { identity : identity
+  ; preset : string
+  ; started_at : float
+  }
+type terminal =
+  | Succeeded of
+      { answer : string
+      ; board_post_id : string option
+      }
+  | Failed of
+      { code : string
+      ; detail : string
+      ; board_post_id : string option
+      }
+  | Cancelled of string
+val equal_terminal : terminal -> terminal -> bool
+type error =
+  | Empty_keeper
+  | Empty_run_id
+  | Invalid_started_at of float
+  | Empty_success_answer
+  | Empty_failure_code
+  | Empty_failure_detail
+  | Empty_cancellation_detail
+  | Empty_board_post_id
+  | Partial_tail
+  | Invalid_record of { line : int; detail : string }
+  | Orphan_terminal
+  | Reversed_records
+  | Unexpected_sequence of int
+  | Identity_mismatch of identity
+  | Registration_conflict of registration
+  | Durable_append_failed of Fs_compat.durable_append_error
+  | Storage_failed of exn
+type register_outcome =
+  | Registered
+  | Already_registered
+type claim_outcome =
+  | First_committed
+  | Already_same
+  | Conflict of terminal
+(** [directory] is the exact store root resolved by the outer MASC path owner. *)
+val create : directory:string -> t
+val register
+  :  t
+  -> keeper:string
+  -> run_id:string
+  -> preset:string
+  -> started_at:float
+  -> (register_outcome, error) result
+val claim_terminal
+  :  t
+  -> keeper:string
+  -> run_id:string
+  -> terminal
+  -> (claim_outcome, error) result
+module For_testing : sig
+  val run_file : t -> keeper:string -> run_id:string -> string
+end

--- a/test/dune
+++ b/test/dune
@@ -798,6 +798,11 @@
  (modules test_fusion_run_registry_persist)
  (libraries alcotest fs_compat yojson masc.fusion_core))
 
+(test
+ (name test_fusion_run_authority)
+ (modules test_fusion_run_authority)
+ (libraries alcotest fs_compat masc.fusion_core))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -1,0 +1,127 @@
+open Alcotest
+module A = Fusion_run_authority
+let fresh_base () =
+  let path = Filename.temp_file "fusion-authority-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  path
+;;
+let success ?board_post_id answer = A.Succeeded { answer; board_post_id }
+let failure ?board_post_id ~code detail =
+  A.Failed { code; detail; board_post_id }
+;;
+let test_exact_lifecycle_and_validation () =
+  let base_path = fresh_base () in
+  let store = A.create ~directory:(Filename.concat base_path "runs") in
+  (match A.register store ~keeper:"" ~run_id:"r" ~preset:"p" ~started_at:1. with
+   | Error A.Empty_keeper -> ()
+   | _ -> fail "empty keeper identity was accepted");
+  (match A.register store ~keeper:"k" ~run_id:"" ~preset:"p" ~started_at:1. with
+   | Error A.Empty_run_id -> ()
+   | _ -> fail "empty run identity was accepted");
+  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:Float.nan with
+   | Error (A.Invalid_started_at _) -> ()
+   | _ -> fail "non-finite start time was accepted");
+  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
+   | Ok A.Registered -> ()
+   | _ -> fail "first registration must be durable");
+  (match
+     A.register (A.create ~directory:(Filename.concat base_path "runs")) ~keeper:"k"
+       ~run_id:"r" ~preset:"p"
+       ~started_at:1.
+   with
+   | Ok A.Already_registered -> ()
+   | _ -> fail "exact registration retry must be idempotent");
+  let winner = success ~board_post_id:"post" "answer" in
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"r" winner with
+   | Ok A.First_committed -> ()
+   | _ -> fail "first terminal must commit");
+  (match
+     A.claim_terminal
+       (A.create ~directory:(Filename.concat base_path "runs"))
+       ~keeper:"k" ~run_id:"r" winner
+   with
+   | Ok A.Already_same -> ()
+   | _ -> fail "restart must retain the winner");
+  (match
+     A.claim_terminal store ~keeper:"k" ~run_id:"r"
+       (failure ~code:"judge_failed" "detail")
+   with
+   | Ok (A.Conflict terminal) ->
+     check bool "conflict returns exact winner" true (A.equal_terminal winner terminal)
+   | _ -> fail "different terminal must conflict");
+  let reject terminal expected =
+    match A.claim_terminal store ~keeper:"k" ~run_id:"other" terminal, expected with
+    | Error A.Empty_success_answer, `Answer
+    | Error A.Empty_board_post_id, `Board
+    | Error A.Empty_failure_code, `Code
+    | Error A.Empty_failure_detail, `Detail
+    | Error A.Empty_cancellation_detail, `Cancel -> ()
+    | _ -> fail "terminal validation returned the wrong result"
+  in
+  reject (success "") `Answer;
+  reject (success ~board_post_id:"" "answer") `Board;
+  reject (failure ~code:"" "detail") `Code;
+  reject (failure ~code:"code" "") `Detail;
+  reject (failure ~board_post_id:"" ~code:"code" "detail") `Board;
+  reject (A.Cancelled "") `Cancel;
+  match A.claim_terminal store ~keeper:"k" ~run_id:"missing" (A.Cancelled "shutdown") with
+  | Error A.Orphan_terminal -> ()
+  | _ -> fail "terminal without durable registration must be rejected"
+;;
+let test_corruption_is_per_run_and_semantic () =
+  let base_path = fresh_base () in
+  let store = A.create ~directory:(Filename.concat base_path "runs") in
+  let register run_id =
+    match A.register store ~keeper:"k" ~run_id ~preset:"p" ~started_at:1. with
+    | Ok A.Registered -> ()
+    | _ -> fail (run_id ^ " registration failed")
+  in
+  register "bad";
+  let bad_path = A.For_testing.run_file store ~keeper:"k" ~run_id:"bad" in
+  let registered = Fs_compat.load_file bad_path in
+  Fs_compat.save_file bad_path (String.sub registered 0 (String.length registered - 1));
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (success "answer") with
+   | Error A.Partial_tail -> ()
+   | _ -> fail "partial tail must fail explicitly");
+  register "peer";
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"peer" (success "peer answer") with
+   | Ok A.First_committed -> ()
+   | _ -> fail "corrupt peer must not block an unrelated run");
+  Fs_compat.save_file bad_path "not-json\n";
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (success "answer") with
+   | Error (A.Invalid_record _) -> ()
+   | _ -> fail "invalid JSON must fail explicitly");
+  register "order";
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+   | Ok A.First_committed -> ()
+   | _ -> fail "ordered terminal did not commit");
+  let order_path = A.For_testing.run_file store ~keeper:"k" ~run_id:"order" in
+  (match String.split_on_char '\n' (Fs_compat.load_file order_path) with
+   | [ registration; terminal; "" ] ->
+     Fs_compat.save_file order_path (terminal ^ "\n");
+     (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+      | Error A.Orphan_terminal -> ()
+      | _ -> fail "orphan terminal must fail explicitly");
+     Fs_compat.save_file order_path (terminal ^ "\n" ^ registration ^ "\n");
+     (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+      | Error A.Reversed_records -> ()
+      | _ -> fail "reversed records must fail explicitly")
+   | _ -> fail "expected exact register/terminal JSONL pair");
+  let foreign_path = A.For_testing.run_file store ~keeper:"k" ~run_id:"foreign" in
+  Fs_compat.save_file foreign_path
+    (Fs_compat.load_file (A.For_testing.run_file store ~keeper:"k" ~run_id:"peer"));
+  match A.claim_terminal store ~keeper:"k" ~run_id:"foreign" (success "foreign") with
+  | Error (A.Identity_mismatch _) -> ()
+  | _ -> fail "hashed path must still verify persisted identity"
+;;
+let () =
+  run "fusion_run_authority"
+    [ ( "authority"
+      , [ test_case "exact lifecycle and validation" `Quick
+            test_exact_lifecycle_and_validation
+        ; test_case "per-run corruption and semantic validation" `Quick
+            test_corruption_is_per_run_and_semantic
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Outcome

Adds the core-only durable authority for one Fusion run. It does not claim production wiring yet.

- one per-run locked JSONL authority; malformed data is isolated to that run
- durable registration must precede a terminal claim
- first terminal wins; exact retry is idempotent; conflicting terminal returns the canonical winner
- exact persisted keeper/run identity is revalidated after restart
- empty identity/evidence and non-finite start times fail as typed errors
- cancellation is re-raised; storage/setup failures are explicit results
- outer MASC owns the resolved store directory; physical ledger access is test-only

## Boundary

This PR intentionally does not change Fusion tool/sink production call sites. The next stack must register before starting the fiber, hard-cut Fusion_run_registry mark_completed writers, claim success/failure/cancel here, and project/wake only the committed winner.

## Verification

- ocamlformat --check: pass
- ocamlc -stop-after parsing for all changed OCaml files: pass
- git diff --check: pass
- focused Dune: not run because scripts/dune-local.sh correctly refused while external bare dune PID 40372 held the machine-wide build authority; no bypass used
- changed lines: 395 total, below 400

Stacked on #25231.