### PR TITLE
refactor(operator)!: expose strict context metrics reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - The process supervisor now records the real server exit code: `|| true` before `exit_code=$?` reported every exit — including SIGSEGV (139) and SIGTERM (143) — as `code=0`; exits above 128 additionally decode the signal name. Takeover kills now leave a JSON breadcrumb next to the pid lock, the victim's SIGTERM path logs the attribution (or its absence: external sender), and the next boot reports a breadcrumb after a SIGKILL escalation.
+- Keeper context-metrics projection now reads its JSONL ledger through `Dated_jsonl.read_recent_result` and exposes typed storage or malformed-row unavailability instead of silently falling back to metadata. `Operator_control_context_snapshot.latest_keeper_context_snapshot_from_files` now returns a `result`; there is no compatibility wrapper for the former `option` signature.
 
 ### Removed
 - Removed the public MASC JSON Schema classifiers `Tool_bridge.param_type_of_string` and `Sdk_tool_contract.param_type_of_schema_opt`, plus the zero-consumer `Sdk_tool_contract.tool_params_of_input_schema`. Consumers must use the OAS-owned `Agent_sdk.Mcp.json_schema_to_params`; missing, unsupported, or ambiguous property types now fail at that boundary instead of defaulting to `String`. No compatibility alias remains.

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -129,12 +129,22 @@ let dated_jsonl_read_error_code = function
   | Dated_jsonl.Io_error _ -> "io_error"
 ;;
 
+let dated_jsonl_read_error_path = function
+  | Dated_jsonl.Invalid_offset _ -> None
+  | Dated_jsonl.Not_a_directory { path }
+  | Dated_jsonl.Non_regular_file { path; _ }
+  | Dated_jsonl.Io_error { path; _ } -> Some path
+  | Dated_jsonl.Invalid_layout_entry { parent; entry; _ } ->
+    Some (Filename.concat parent entry)
+;;
+
 let context_metrics_unavailable_json = function
   | None -> `Null
   | Some (Storage_read_failed error) ->
     `Assoc
       [ "kind", `String "storage_read_failed"
       ; "reason", `String (dated_jsonl_read_error_code error)
+      ; "path", Json_util.string_opt_to_json (dated_jsonl_read_error_path error)
       ; "detail", `String (Dated_jsonl.read_error_to_string error)
       ]
   | Some (Malformed_metrics_row { path; line_number; detail }) ->

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -19,11 +19,20 @@ let compute_context_ratio (meta : Keeper_meta_contract.keeper_meta) : float opti
     None
 ;;
 
+type context_metrics_read_error =
+  | Storage_read_failed of Dated_jsonl.read_error
+  | Malformed_metrics_row of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+
 type keeper_context_snapshot =
   { context_ratio : float option
   ; context_tokens : int option
   ; context_max : int option
   ; context_source : string option
+  ; context_metrics_unavailable : context_metrics_read_error option
   }
 
 let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
@@ -31,6 +40,7 @@ let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
   && snapshot.context_tokens = None
   && snapshot.context_max = None
   && snapshot.context_source = None
+  && snapshot.context_metrics_unavailable = None
 ;;
 
 let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
@@ -46,35 +56,42 @@ let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
             | Some channel when String.trim channel <> "" ->
               Some ("metrics_" ^ String.trim channel)
             | Some _ | None -> Some "metrics_log"))
+    ; context_metrics_unavailable = None
     }
   in
   if keeper_context_snapshot_is_empty snapshot then None else Some snapshot
 ;;
 
 let latest_keeper_context_snapshot_from_files config keeper_name =
-  let metrics_lines =
-    let store = Keeper_types_support.keeper_metrics_store config keeper_name in
-    Dated_jsonl.read_recent_lines store 32
+  let ( let* ) = Result.bind in
+  let store = Keeper_types_support.keeper_metrics_store config keeper_name in
+  let* entries =
+    Dated_jsonl.read_recent_result store 32
+    |> Result.map_error (fun error -> Storage_read_failed error)
   in
-  let snapshots =
-    List.rev metrics_lines
-    |> List.filter_map (fun line ->
-      try
-        let json = Yojson.Safe.from_string line in
-        keeper_context_snapshot_from_metrics_json json
-      with
-      | Yojson.Json_error _ -> None)
+  let rec snapshots_newest_first snapshots = function
+    | [] -> Ok snapshots
+    | Dated_jsonl.Parsed json :: rest ->
+      let snapshots =
+        match keeper_context_snapshot_from_metrics_json json with
+        | Some snapshot -> snapshot :: snapshots
+        | None -> snapshots
+      in
+      snapshots_newest_first snapshots rest
+    | Dated_jsonl.Malformed_json { path; line_number; detail } :: _ ->
+      Error (Malformed_metrics_row { path; line_number; detail })
   in
+  let* snapshots = snapshots_newest_first [] entries in
   match
     List.find_opt
       (fun snapshot -> snapshot.context_source = Some "keeper_context_status")
       snapshots
   with
-  | Some snapshot -> Some snapshot
+  | Some snapshot -> Ok (Some snapshot)
   | None ->
     (match snapshots with
-     | snapshot :: _ -> Some snapshot
-     | [] -> None)
+     | snapshot :: _ -> Ok (Some snapshot)
+     | [] -> Ok None)
 ;;
 
 let fallback_keeper_context_snapshot (meta : Keeper_meta_contract.keeper_meta) =
@@ -87,13 +104,47 @@ let fallback_keeper_context_snapshot (meta : Keeper_meta_contract.keeper_meta) =
        | _ -> None)
   ; context_max = if max_tokens > 0 then Some max_tokens else None
   ; context_source = Some "fallback_metadata"
+  ; context_metrics_unavailable = None
   }
 ;;
 
 let keeper_context_snapshot_of_meta config (meta : Keeper_meta_contract.keeper_meta) =
   match latest_keeper_context_snapshot_from_files config meta.name with
-  | Some snapshot -> snapshot
-  | None -> fallback_keeper_context_snapshot meta
+  | Ok (Some snapshot) -> snapshot
+  | Ok None -> fallback_keeper_context_snapshot meta
+  | Error error ->
+    { context_ratio = None
+    ; context_tokens = None
+    ; context_max = None
+    ; context_source = None
+    ; context_metrics_unavailable = Some error
+    }
+;;
+
+let dated_jsonl_read_error_code = function
+  | Dated_jsonl.Invalid_offset _ -> "invalid_offset"
+  | Dated_jsonl.Not_a_directory _ -> "not_a_directory"
+  | Dated_jsonl.Invalid_layout_entry _ -> "invalid_layout_entry"
+  | Dated_jsonl.Non_regular_file _ -> "non_regular_file"
+  | Dated_jsonl.Io_error _ -> "io_error"
+;;
+
+let context_metrics_unavailable_json = function
+  | None -> `Null
+  | Some (Storage_read_failed error) ->
+    `Assoc
+      [ "kind", `String "storage_read_failed"
+      ; "reason", `String (dated_jsonl_read_error_code error)
+      ; "detail", `String (Dated_jsonl.read_error_to_string error)
+      ]
+  | Some (Malformed_metrics_row { path; line_number; detail }) ->
+    `Assoc
+      [ "kind", `String "malformed_json"
+      ; "reason", `String "malformed_metrics_row"
+      ; "path", `String path
+      ; "line_number", Json_util.int_opt_to_json line_number
+      ; "detail", `String detail
+      ]
 ;;
 
 let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
@@ -112,6 +163,8 @@ let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
       , Json_util.option_to_yojson
           (fun value -> `Int value)
           snapshot.context_max )
+    ; ( "metrics_unavailable"
+      , context_metrics_unavailable_json snapshot.context_metrics_unavailable )
     ]
   in
   [ ( "context_ratio"
@@ -128,6 +181,8 @@ let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
         snapshot.context_max )
   ; ( "context_source"
     , Json_util.string_opt_to_json snapshot.context_source )
+  ; ( "context_metrics_unavailable"
+    , context_metrics_unavailable_json snapshot.context_metrics_unavailable )
   ; ( "context", `Assoc assoc_fields )
   ]
 ;;

--- a/lib/operator/operator_control_context_snapshot.mli
+++ b/lib/operator/operator_control_context_snapshot.mli
@@ -2,11 +2,20 @@
 
 val compute_context_ratio : Keeper_meta_contract.keeper_meta -> float option
 
+type context_metrics_read_error =
+  | Storage_read_failed of Dated_jsonl.read_error
+  | Malformed_metrics_row of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+
 type keeper_context_snapshot =
   { context_ratio : float option
   ; context_tokens : int option
   ; context_max : int option
   ; context_source : string option
+  ; context_metrics_unavailable : context_metrics_read_error option
   }
 
 val keeper_context_snapshot_is_empty : keeper_context_snapshot -> bool
@@ -15,7 +24,8 @@ val keeper_context_snapshot_from_metrics_json :
   Yojson.Safe.t -> keeper_context_snapshot option
 
 val latest_keeper_context_snapshot_from_files :
-  Workspace.config -> string -> keeper_context_snapshot option
+  Workspace.config -> string ->
+  (keeper_context_snapshot option, context_metrics_read_error) result
 
 val fallback_keeper_context_snapshot :
   Keeper_meta_contract.keeper_meta -> keeper_context_snapshot

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -49,6 +49,8 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                  ; "context_tokens", field_or_null "context_tokens"
                  ; "context_max", field_or_null "context_max"
                  ; "context_source", field_or_null "context_source"
+                 ; ( "context_metrics_unavailable"
+                   , field_or_null "context_metrics_unavailable" )
                  ; "last_model_used", field_or_null "last_model_used"
                  ; "active_model", field_or_null "active_model"
                  ; "active_model_label", field_or_null "active_model_label"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -366,10 +366,20 @@ let init_context_test_runtime () =
 ;;
 
 let write_raw_metrics_row config keeper_name row =
-  let metrics_dir = Keeper_types_support.keeper_metrics_dir config keeper_name in
-  let month_dir = Filename.concat metrics_dir "2026-07" in
-  Fs_compat.mkdir_p month_dir;
-  let path = Filename.concat month_dir "18.jsonl" in
+  let store = Keeper_types_support.keeper_metrics_store config keeper_name in
+  Dated_jsonl.append store (`Assoc [ "fixture", `Bool true ]);
+  let only_entry label directory =
+    match Sys.readdir directory |> Array.to_list with
+    | [ entry ] -> Filename.concat directory entry
+    | entries ->
+      Alcotest.failf
+        "expected one %s entry under %s, found %d"
+        label
+        directory
+        (List.length entries)
+  in
+  let month_dir = only_entry "month" (Dated_jsonl.base_dir store) in
+  let path = only_entry "day file" month_dir in
   Fs_compat.save_file path (row ^ "\n");
   path
 ;;
@@ -473,7 +483,9 @@ let test_context_snapshot_storage_failure_is_unavailable () =
        Alcotest.(check string) "typed storage failure" "storage_read_failed"
          Yojson.Safe.Util.(unavailable |> member "kind" |> to_string);
        Alcotest.(check string) "exact storage reason" "not_a_directory"
-         Yojson.Safe.Util.(unavailable |> member "reason" |> to_string))
+         Yojson.Safe.Util.(unavailable |> member "reason" |> to_string);
+       Alcotest.(check string) "exact storage path" metrics_dir
+         Yojson.Safe.Util.(unavailable |> member "path" |> to_string))
 ;;
 
 let test_keeper_up_clears_dead_tombstone_resume_state () =

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -335,6 +335,147 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       Alcotest.(check bool) "nested context payload omitted" true
         (Yojson.Safe.Util.member "context" keeper = `Null))
 
+let context_test_meta ~name ~last_input_tokens =
+  let base =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String (name ^ "-agent")
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "runtime_id", `String "primary"
+          ])
+    with
+    | Ok meta -> meta
+    | Error error -> Alcotest.fail error
+  in
+  { base with
+    runtime =
+      { base.runtime with
+        usage = { base.runtime.usage with last_input_tokens }
+      }
+  }
+;;
+
+let init_context_test_runtime () =
+  let root = Masc_test_deps.find_project_root () in
+  let config_path = Filename.concat root "config/runtime.toml" in
+  match Runtime.init_default ~config_path with
+  | Ok () -> ()
+  | Error error -> Alcotest.failf "Runtime.init_default failed: %s" error
+;;
+
+let write_raw_metrics_row config keeper_name row =
+  let metrics_dir = Keeper_types_support.keeper_metrics_dir config keeper_name in
+  let month_dir = Filename.concat metrics_dir "2026-07" in
+  Fs_compat.mkdir_p month_dir;
+  let path = Filename.concat month_dir "18.jsonl" in
+  Fs_compat.save_file path (row ^ "\n");
+  path
+;;
+
+let test_context_snapshot_missing_metrics_uses_observed_metadata () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       init_context_test_runtime ();
+       let config = Workspace.default_config base_dir in
+       let meta = context_test_meta ~name:"metrics-missing" ~last_input_tokens:731 in
+       (match
+          Operator_control_context_snapshot.latest_keeper_context_snapshot_from_files
+            config
+            meta.name
+        with
+        | Ok None -> ()
+        | Ok (Some _) -> Alcotest.fail "missing metrics store returned a snapshot"
+        | Error _ -> Alcotest.fail "missing metrics store returned a read failure");
+       let snapshot =
+         Operator_control_context_snapshot.keeper_context_snapshot_of_meta config meta
+       in
+       Alcotest.(check (option int)) "metadata token observation" (Some 731)
+         snapshot.context_tokens;
+       Alcotest.(check (option string)) "explicit metadata source"
+         (Some "fallback_metadata") snapshot.context_source;
+       Alcotest.(check bool) "no metrics failure" true
+         (snapshot.context_metrics_unavailable = None))
+;;
+
+let test_context_snapshot_malformed_metrics_is_unavailable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       init_context_test_runtime ();
+       let config = Workspace.default_config base_dir in
+       let meta = context_test_meta ~name:"metrics-malformed" ~last_input_tokens:991 in
+       let path = write_raw_metrics_row config meta.name "{not-json" in
+       (match
+          Operator_control_context_snapshot.latest_keeper_context_snapshot_from_files
+            config
+            meta.name
+        with
+        | Error
+            (Operator_control_context_snapshot.Malformed_metrics_row
+              { path = error_path; line_number = None; _ }) ->
+          Alcotest.(check string) "exact malformed row path" path error_path
+        | Error _ -> Alcotest.fail "unexpected metrics read error"
+        | Ok _ -> Alcotest.fail "malformed metrics row was silently accepted");
+       let snapshot =
+         Operator_control_context_snapshot.keeper_context_snapshot_of_meta config meta
+       in
+       Alcotest.(check (option int)) "no metadata token fallback" None
+         snapshot.context_tokens;
+       Alcotest.(check (option string)) "no fabricated source" None
+         snapshot.context_source;
+       let json =
+         `Assoc
+           (Operator_control_context_snapshot.keeper_context_snapshot_fields snapshot)
+       in
+       let unavailable =
+         Yojson.Safe.Util.member "context_metrics_unavailable" json
+       in
+       Alcotest.(check string) "typed decode failure" "malformed_json"
+         Yojson.Safe.Util.(unavailable |> member "kind" |> to_string);
+       Alcotest.(check string) "decode failure path" path
+         Yojson.Safe.Util.(unavailable |> member "path" |> to_string))
+;;
+
+let test_context_snapshot_storage_failure_is_unavailable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       init_context_test_runtime ();
+       let config = Workspace.default_config base_dir in
+       let meta = context_test_meta ~name:"metrics-storage-error" ~last_input_tokens:557 in
+       let metrics_dir = Keeper_types_support.keeper_metrics_dir config meta.name in
+       Fs_compat.mkdir_p (Filename.dirname metrics_dir);
+       Fs_compat.save_file metrics_dir "not a directory";
+       let snapshot =
+         Operator_control_context_snapshot.keeper_context_snapshot_of_meta config meta
+       in
+       Alcotest.(check (option int)) "no metadata token fallback" None
+         snapshot.context_tokens;
+       let json =
+         `Assoc
+           (Operator_control_context_snapshot.keeper_context_snapshot_fields snapshot)
+       in
+       let unavailable =
+         Yojson.Safe.Util.member "context_metrics_unavailable" json
+       in
+       Alcotest.(check string) "typed storage failure" "storage_read_failed"
+         Yojson.Safe.Util.(unavailable |> member "kind" |> to_string);
+       Alcotest.(check string) "exact storage reason" "not_a_directory"
+         Yojson.Safe.Util.(unavailable |> member "reason" |> to_string))
+;;
+
 let test_keeper_up_clears_dead_tombstone_resume_state () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1724,6 +1865,20 @@ let () =
             "null runtime signal preserves surface status"
             `Quick
             test_align_keeper_runtime_status_tolerates_null_status_json;
+        ] );
+      ( "context metrics ledger"
+      , [ Alcotest.test_case
+            "missing ledger uses observed metadata"
+            `Quick
+            test_context_snapshot_missing_metrics_uses_observed_metadata
+        ; Alcotest.test_case
+            "malformed row is typed unavailable"
+            `Quick
+            test_context_snapshot_malformed_metrics_is_unavailable
+        ; Alcotest.test_case
+            "storage failure is typed unavailable"
+            `Quick
+            test_context_snapshot_storage_failure_is_unavailable
         ] );
     ]
 ;;


### PR DESCRIPTION
## Problem

The operator context projection read recent keeper metrics JSONL rows through `Dated_jsonl.read_recent_lines`, parsed raw strings locally, and silently skipped malformed JSON. Storage corruption therefore became apparently valid metadata fallback.

PR #25226 attempted the strict-read fix but targeted closed, unmerged parent #25211. Its main comparison pulled the parent's unrelated context-capacity authority across 20 files, so that stack cannot reach main safely.

## Change

- Read the bounded context metrics window through `Dated_jsonl.read_recent_result`.
- Return a typed `context_metrics_read_error` for storage failures and malformed rows, including exact path and available line metadata.
- Use metadata fallback only for `Ok []`; read/decode failure produces explicit unavailability with no fabricated context value.
- Project the typed failure into nested context JSON and the persistent-agent operator row.
- Expose the storage error path as a structural JSON field by projecting the `Dated_jsonl.read_error` variant; consumers do not need to parse the human-readable detail string.
- Change `latest_keeper_context_snapshot_from_files` from `option` to `result` and record the hard cut in `CHANGELOG.md`; no compatibility wrapper remains.
- Generate the malformed-row fixture through the public `Dated_jsonl` writer instead of hardcoding a calendar path or depending on the private `Jsonl_writer` module.

## Boundary

This leaf deliberately excludes every #25211 capacity-observation change. It does not introduce `context_unavailable_reason`, `apply_capacity_observation`, runtime/model changes, fallback budget policy, retry, timeout, or string-based error classification. `Dated_jsonl.read_error` remains the storage SSOT.

## Verification

- parent-only residue scan (`apply_capacity_observation`, `context_unavailable_reason`, capacity observation): zero
- caller scan for the changed public function: implementation plus focused tests only
- rebased onto `main` commit `fdbf1c08d66ecb582ee15f6e4cfcf719b7807922`
- `git diff --check`: PASS
- `ocamlformat --check` on all touched OCaml files: PASS
- `ocamlc -stop-after parsing` on all touched OCaml files: PASS
- `scripts/dune-local.sh build test/test_operator_control_snapshot.exe`: PASS
- exact built executable `_build/default/test/test_operator_control_snapshot.exe`: PASS, 11/11

The focused compiler additionally found and removed the old stack's unavailable `List.hd_opt` call. The focused test run found and repaired two invalid fixtures: missing runtime initialization and a storage-error setup that failed before reaching the ledger reader.

Supersedes #25226.
