### PR TITLE
feat(observability): log resolved runtime knobs at boot

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -271,6 +271,18 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
        Log.Server.error "runtime.toml load failed: %s" msg;
        raise (Env_config_core.Config_error msg));
   Keeper_runtime_resolved.init ();
+  (* Boot-time observability: emit the resolved runtime knobs once, right after
+     they freeze. The opt-in timeouts (stream_idle_timeout_sec and the
+     body-timeout override) are None when unset; without this line a knob that
+     is CONFIGURED in runtime.toml but did not reach Keeper_runtime_resolved is
+     indistinguishable at runtime from an unset one — the exact ambiguity that
+     blocked diagnosing #25128 (idle timeout configured at 120s yet never
+     observed to fire). No existing surface exposes the resolved value. *)
+  Log.Runtime.info
+    ~category:Log.Boundary
+    "resolved runtime config: %s"
+    (Yojson.Safe.to_string
+       (Keeper_runtime_resolved.to_yojson (Keeper_runtime_resolved.current ())));
   Keeper_task_owner_backend.install_hooks ();
   let state =
     Mcp_eio.create_state_eio ~sw ~proc_mgr ~fs ~clock

--- a/test/dune
+++ b/test/dune
@@ -65,6 +65,7 @@
   test_masc_runtime_events
   test_cancel_wall_bucket
   test_provider_http_error
+  test_keeper_runtime_resolved_observability
   test_oas_diag_sink
   test_shutdown_benign_termination
   test_stop_reason_label
@@ -369,6 +370,7 @@
   test_masc_runtime_events
   test_cancel_wall_bucket
   test_provider_http_error
+  test_keeper_runtime_resolved_observability
   test_oas_diag_sink
   test_shutdown_benign_termination
   test_stop_reason_label

--- a/test/test_keeper_runtime_resolved_observability.ml
+++ b/test/test_keeper_runtime_resolved_observability.ml
@@ -1,0 +1,47 @@
+(** Pins the observability contract that the boot-time resolved-runtime-config
+    log depends on (server_runtime_bootstrap): the serialized resolved config
+    must expose the opt-in timeout knobs by name, so an operator can tell a
+    configured-but-unapplied knob from an unset one at runtime. This is the
+    surface that would have disambiguated #25128 (idle timeout configured yet
+    never observed to fire). [masc] is re-exported by [masc_test_deps]. *)
+
+module Rr = Masc.Keeper_runtime_resolved
+
+let field_names json =
+  match json with
+  | `Assoc fields -> List.map fst fields
+  | _ -> []
+
+let test_resolved_config_exposes_timeout_knobs () =
+  Rr.reset_for_tests ();
+  Rr.init ();
+  let json = Rr.to_yojson (Rr.current ()) in
+  let names = field_names json in
+  (* The boot log serializes exactly this value; assert the knobs the #25128
+     diagnosis needs are present and named, whatever their resolved value. *)
+  Alcotest.(check bool)
+    "resolved config exposes stream_idle_timeout_sec"
+    true
+    (List.mem "stream_idle_timeout_sec" names);
+  Alcotest.(check bool)
+    "resolved config exposes body_timeout_override_sec"
+    true
+    (List.mem "body_timeout_override_sec" names)
+
+let test_to_yojson_is_a_json_object () =
+  Rr.reset_for_tests ();
+  Rr.init ();
+  match Rr.to_yojson (Rr.current ()) with
+  | `Assoc _ -> ()
+  | _ -> Alcotest.fail "resolved runtime config must serialize as a JSON object"
+
+let () =
+  Alcotest.run
+    "keeper_runtime_resolved_observability"
+    [ ( "resolved_config_surface"
+      , [ Alcotest.test_case "exposes timeout knobs" `Quick
+            test_resolved_config_exposes_timeout_knobs
+        ; Alcotest.test_case "serializes as object" `Quick
+            test_to_yojson_is_a_json_object
+        ] )
+    ]


### PR DESCRIPTION
## Why

#25128 could not be diagnosed because **no live surface exposes the resolved value of the opt-in runtime timeouts**. Confirmed across attempts: process env is restricted (macOS), boot logs never print them, `/api/v1/keepers/*` and config endpoints 404, and `masc_config` returns only tool categories. So a knob CONFIGURED in `runtime.toml` (`[turn] stream_idle_timeout_sec = 120`) but not applied to `Keeper_runtime_resolved` is indistinguishable at runtime from an unset one.

That ambiguity is exactly what blocked #25128: `stream_idle_timeout_sec` is 120 in runtime.toml, yet the pool idle-timeout cancellation (`idle timeout after`) fires **0 times** in the live log — with no way to tell whether the resolved value is `Some 120.` (an enforcement/other issue, or a slow-but-alive stream that #24386 correctly allows) or `None` (a config-load gap).

## What

Emit `Keeper_runtime_resolved.to_yojson (current ())` once at boot, right after `init` freezes it (`server_runtime_bootstrap.ml`), via `Log.Runtime` at `Boundary` category. This is diagnostic observability of a config-resolution boundary — **not** a symptom counter and not a fix for the hang; it makes the resolved config answerable so the #25128 root can be determined from the next boot.

## Verification

- `server_runtime_bootstrap` compiles; the boot log uses only already-exposed functions (`init`/`current`/`to_yojson`).
- 2 unit cases pin the observability contract: the serialized resolved config names `stream_idle_timeout_sec` and `body_timeout_override_sec`, and serializes as a JSON object.
- `ocamlformat --check` clean.

RFC-WAIVED: observability-only boot log in `lib/server`; no behavior change, no new policy/default, no destructive op. Reads config through the existing `Keeper_runtime_resolved` surface.

Refs #25128 (unblocks its root determination).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
