### PR TITLE
refactor(keeper): split compaction recovery into prepare and commit phases

### DIFF
--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -159,6 +159,8 @@ let apply_post_turn_lifecycle_with_resilience_handles =
   Keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles
 let recover_latest_checkpoint_for_compaction =
   Keeper_post_turn.recover_latest_checkpoint_for_compaction
+let prepare_compaction = Keeper_post_turn.prepare_compaction
+let commit_prepared_compaction = Keeper_post_turn.commit_prepared_compaction
 
 let record_lifecycle_dispatch_rejection ~keeper_name ~origin event ~error =
   Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -178,8 +178,7 @@ val prepare_compaction
   -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
 
 val commit_prepared_compaction
-  :  meta:Keeper_meta_contract.keeper_meta
-  -> Keeper_post_turn.prepared_compaction
+  :  Keeper_post_turn.prepared_compaction
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -171,6 +171,17 @@ val recover_latest_checkpoint_for_compaction
   -> trigger:Compaction_trigger.t
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
+val prepare_compaction
+  :  base_dir:string
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> trigger:Compaction_trigger.t
+  -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
+
+val commit_prepared_compaction
+  :  meta:Keeper_meta_contract.keeper_meta
+  -> Keeper_post_turn.prepared_compaction
+  -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
+
 (** {1 Trace and Board Utilities} *)
 
 val generate_trace_id : ?now:float -> unit -> string

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -79,7 +79,6 @@ let dispatch_event ~config ~meta event =
     ~keeper_name:meta.name
     event
 ;;
-
 let dispatch_failed ~config ~meta reason =
   Keeper_context_runtime.dispatch_keeper_phase_event_result
     ~config
@@ -107,7 +106,7 @@ let run_start_lifecycle ~config ~meta =
 ;;
 
 let run_commit ~config ~base_dir ~meta prepared =
-  match Keeper_context_runtime.commit_prepared_compaction ~meta prepared with
+  match Keeper_context_runtime.commit_prepared_compaction prepared with
   | Error error ->
     let failure_dispatch =
       dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
@@ -135,32 +134,45 @@ let run_commit ~config ~base_dir ~meta prepared =
        Ok (Compacted { recovery; manifest }))
 ;;
 
+let finish_preparation ~config ~base_dir ~meta = function
+  | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
+    let failure_dispatch =
+      dispatch_failed
+        ~config
+        ~meta
+        (Keeper_post_turn.compaction_recovery_error_to_tag error)
+    in
+    (match failure_dispatch with
+     | Ok () -> Ok (No_compaction no_compaction)
+     | Error _ -> Error (Recovery (error, failure_dispatch)))
+  | Error error ->
+    let failure_dispatch =
+      dispatch_failed
+        ~config
+        ~meta
+        (Keeper_post_turn.compaction_recovery_error_to_tag error)
+    in
+    Error (Recovery (error, failure_dispatch))
+  | Ok prepared -> run_commit ~config ~base_dir ~meta prepared
+;;
+
+let prepare ~config ~meta =
+  let base_dir = Keeper_types_profile.session_base_dir config in
+  ( base_dir
+  , Keeper_context_runtime.prepare_compaction
+      ~base_dir
+      ~meta
+      ~trigger:Compaction_trigger.Manual )
+;;
+
 let run ~(config : Workspace.config) ~(meta : keeper_meta) =
-  (* Synchronous composition (kept for API stability): start lifecycle,
-     prepare (load + policy + LLM), commit — all inline. *)
+  (* Planning is outside the lifecycle. Only the deterministic lifecycle and
+     source-CAS commit may set [compaction_active], and they close in this
+     single synchronous section. *)
+  let base_dir, preparation = prepare ~config ~meta in
   match run_start_lifecycle ~config ~meta with
   | Error _ as error -> error
-  | Ok () ->
-    let base_dir = Keeper_types_profile.session_base_dir config in
-    (match
-       Keeper_context_runtime.prepare_compaction
-         ~base_dir
-         ~meta
-         ~trigger:Compaction_trigger.Manual
-     with
-     | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
-       let failure_dispatch =
-         dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
-       in
-       (match failure_dispatch with
-        | Ok () -> Ok (No_compaction no_compaction)
-        | Error _ -> Error (Recovery (error, failure_dispatch)))
-     | Error error ->
-       let failure_dispatch =
-         dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
-       in
-       Error (Recovery (error, failure_dispatch))
-     | Ok prepared -> run_commit ~config ~base_dir ~meta prepared)
+  | Ok () -> finish_preparation ~config ~base_dir ~meta preparation
 ;;
 
 let observe_manifest ~keeper_name = function
@@ -177,65 +189,34 @@ let observe_manifest ~keeper_name = function
 ;;
 
 let run_admitted ~(config : Workspace.config) ~(meta : keeper_meta) =
-  (* The provider call (prepare) runs outside the keeper admission so the
-     lane stays runnable while the LLM works; the lifecycle start, the
-     source-CAS commit, the manifest and the completion dispatch stay
-     inside it.  Two short admission sections replace the old full-run
-     hold — correctness between them is enforced by the source CAS, not
-     by the slot. *)
+  (* Reject work that is already fenced before spending a provider call. This
+     preflight owns no lifecycle state and releases immediately. A turn can
+     still enter while planning; the final admission and source CAS close that
+     race without stranding [compaction_active]. *)
   match
     Keeper_turn_admission.run_compaction_if_free
       ~base_path:config.base_path
       ~keeper_name:meta.name
-      (fun () -> run_start_lifecycle ~config ~meta)
+      (fun () -> ())
   with
   | `Busy block -> `Busy block
-  | `Ran (Error failure) -> `Compaction_failed failure
-  | `Ran (Ok ()) ->
-    let base_dir = Keeper_types_profile.session_base_dir config in
+  | `Ran () ->
+    let base_dir, preparation = prepare ~config ~meta in
     (match
-       Keeper_context_runtime.prepare_compaction
-         ~base_dir
-         ~meta
-         ~trigger:Compaction_trigger.Manual
+       Keeper_turn_admission.run_compaction_if_free
+         ~base_path:config.base_path
+         ~keeper_name:meta.name
+         (fun () ->
+           match run_start_lifecycle ~config ~meta with
+           | Error failure -> Error failure
+           | Ok () -> finish_preparation ~config ~base_dir ~meta preparation)
      with
-     | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
-       (match
-          Keeper_turn_admission.run_compaction_if_free
-            ~base_path:config.base_path
-            ~keeper_name:meta.name
-            (fun () ->
-              dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error))
-        with
-        | `Busy block -> `Busy block
-        | `Ran (Ok ()) -> `No_compaction no_compaction
-        | `Ran (Error failure) -> `Compaction_failed (Recovery (error, Error failure)))
-     | Error error ->
-       (match
-          Keeper_turn_admission.run_compaction_if_free
-            ~base_path:config.base_path
-            ~keeper_name:meta.name
-            (fun () ->
-              let failure_dispatch =
-                dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
-              in
-              Recovery (error, failure_dispatch))
-        with
-        | `Busy block -> `Busy block
-        | `Ran failure -> `Compaction_failed failure)
-     | Ok prepared ->
-       (match
-          Keeper_turn_admission.run_compaction_if_free
-            ~base_path:config.base_path
-            ~keeper_name:meta.name
-            (fun () -> run_commit ~config ~base_dir ~meta prepared)
-        with
-        | `Busy block -> `Busy block
-        | `Ran (Error failure) -> `Compaction_failed failure
-        | `Ran (Ok (Compacted success)) ->
-          observe_manifest ~keeper_name:meta.name success.manifest;
-          `Applied success
-        | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction))
+     | `Busy block -> `Busy block
+     | `Ran (Error failure) -> `Compaction_failed failure
+     | `Ran (Ok (Compacted success)) ->
+       observe_manifest ~keeper_name:meta.name success.manifest;
+       `Applied success
+     | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction)
 ;;
 
 let lifecycle_stage_to_string = function
@@ -271,7 +252,3 @@ let failure_to_string = function
       (Keeper_post_turn.compaction_recovery_error_to_string error)
       (failure_dispatch_to_string failure_dispatch)
 ;;
-
-
-
-

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -72,28 +72,30 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
       ()
     |> Keeper_runtime_manifest.append config
 ;;
-let run ~(config : Workspace.config) ~(meta : keeper_meta) =
-  let dispatch event =
-    Keeper_context_runtime.dispatch_keeper_phase_event_result
-      ~config
-      ~origin:Keeper_registry.Operator_compact
-      ~keeper_name:meta.name
-      event
-  in
-  let dispatch_failed reason =
-    Keeper_context_runtime.dispatch_keeper_phase_event_result
-      ~config
-      ~origin:Keeper_registry.Operator_compact
-      ~keeper_name:meta.name
-      (Keeper_state_machine.Compaction_failed { reason })
-  in
-  match dispatch Keeper_state_machine.Operator_compact_requested with
+let dispatch_event ~config ~meta event =
+  Keeper_context_runtime.dispatch_keeper_phase_event_result
+    ~config
+    ~origin:Keeper_registry.Operator_compact
+    ~keeper_name:meta.name
+    event
+;;
+
+let dispatch_failed ~config ~meta reason =
+  Keeper_context_runtime.dispatch_keeper_phase_event_result
+    ~config
+    ~origin:Keeper_registry.Operator_compact
+    ~keeper_name:meta.name
+    (Keeper_state_machine.Compaction_failed { reason })
+;;
+
+let run_start_lifecycle ~config ~meta =
+  match dispatch_event ~config ~meta Keeper_state_machine.Operator_compact_requested with
   | Error error ->
     Error (Lifecycle { stage = Operator_request; checkpoint_applied = false; error })
   | Ok () ->
-    (match dispatch Keeper_state_machine.Compaction_started with
+    (match dispatch_event ~config ~meta Keeper_state_machine.Compaction_started with
      | Error error ->
-       let failure_dispatch = dispatch_failed "compaction_start_rejected" in
+       let failure_dispatch = dispatch_failed ~config ~meta "compaction_start_rejected" in
        Error
          (Lifecycle_with_failure_dispatch
             { stage = Compaction_started
@@ -101,46 +103,139 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
             ; error
             ; failure_dispatch
             })
+     | Ok () -> Ok ())
+;;
+
+let run_commit ~config ~base_dir ~meta prepared =
+  match Keeper_context_runtime.commit_prepared_compaction ~meta prepared with
+  | Error error ->
+    let failure_dispatch =
+      dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
+    in
+    Error (Recovery (error, failure_dispatch))
+  | Ok recovery ->
+    let manifest = append_manifest ~config ~base_dir ~meta recovery in
+    (match
+       Keeper_context_runtime.dispatch_compaction_completed
+         ~config
+         ~keeper_name:meta.name
+         ~origin:Keeper_registry.Operator_compact
+     with
+     | Error error ->
+       Error
+         (Lifecycle
+            { stage = Compaction_completed
+            ; checkpoint_applied = true
+            ; error
+            })
      | Ok () ->
-       let base_dir = Keeper_types_profile.session_base_dir config in
+       Keeper_unified_metrics.broadcast_compaction
+         ~name:meta.name
+         recovery;
+       Ok (Compacted { recovery; manifest }))
+;;
+
+let run ~(config : Workspace.config) ~(meta : keeper_meta) =
+  (* Synchronous composition (kept for API stability): start lifecycle,
+     prepare (load + policy + LLM), commit — all inline. *)
+  match run_start_lifecycle ~config ~meta with
+  | Error _ as error -> error
+  | Ok () ->
+    let base_dir = Keeper_types_profile.session_base_dir config in
+    (match
+       Keeper_context_runtime.prepare_compaction
+         ~base_dir
+         ~meta
+         ~trigger:Compaction_trigger.Manual
+     with
+     | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
+       let failure_dispatch =
+         dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
+       in
+       (match failure_dispatch with
+        | Ok () -> Ok (No_compaction no_compaction)
+        | Error _ -> Error (Recovery (error, failure_dispatch)))
+     | Error error ->
+       let failure_dispatch =
+         dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
+       in
+       Error (Recovery (error, failure_dispatch))
+     | Ok prepared -> run_commit ~config ~base_dir ~meta prepared)
+;;
+
+let observe_manifest ~keeper_name = function
+  | Ok () -> ()
+  | Error detail ->
+    Log.Keeper.error
+      ~keeper_name
+      "manual compaction manifest append failed after durable checkpoint: %s"
+      detail;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string WriteMetaFailures)
+      ~labels:[ "keeper", keeper_name; "phase", "manual_compaction_manifest" ]
+      ()
+;;
+
+let run_admitted ~(config : Workspace.config) ~(meta : keeper_meta) =
+  (* The provider call (prepare) runs outside the keeper admission so the
+     lane stays runnable while the LLM works; the lifecycle start, the
+     source-CAS commit, the manifest and the completion dispatch stay
+     inside it.  Two short admission sections replace the old full-run
+     hold — correctness between them is enforced by the source CAS, not
+     by the slot. *)
+  match
+    Keeper_turn_admission.run_compaction_if_free
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
+      (fun () -> run_start_lifecycle ~config ~meta)
+  with
+  | `Busy block -> `Busy block
+  | `Ran (Error failure) -> `Compaction_failed failure
+  | `Ran (Ok ()) ->
+    let base_dir = Keeper_types_profile.session_base_dir config in
+    (match
+       Keeper_context_runtime.prepare_compaction
+         ~base_dir
+         ~meta
+         ~trigger:Compaction_trigger.Manual
+     with
+     | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
        (match
-          Keeper_context_runtime.recover_latest_checkpoint_for_compaction
-            ~base_dir
-            ~meta
-            ~trigger:Compaction_trigger.Manual
+          Keeper_turn_admission.run_compaction_if_free
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+            (fun () ->
+              dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error))
         with
-        | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
-          let failure_dispatch =
-            dispatch_failed (Keeper_post_turn.compaction_recovery_error_to_tag error)
-          in
-          (match failure_dispatch with
-           | Ok () -> Ok (No_compaction no_compaction)
-           | Error _ -> Error (Recovery (error, failure_dispatch)))
-        | Error error ->
-          let failure_dispatch =
-            dispatch_failed (Keeper_post_turn.compaction_recovery_error_to_tag error)
-          in
-          Error (Recovery (error, failure_dispatch))
-        | Ok recovery ->
-          let manifest = append_manifest ~config ~base_dir ~meta recovery in
-          (match
-             Keeper_context_runtime.dispatch_compaction_completed
-               ~config
-               ~keeper_name:meta.name
-               ~origin:Keeper_registry.Operator_compact
-           with
-           | Error error ->
-             Error
-               (Lifecycle
-                  { stage = Compaction_completed
-                  ; checkpoint_applied = true
-                  ; error
-                  })
-           | Ok () ->
-             Keeper_unified_metrics.broadcast_compaction
-               ~name:meta.name
-               recovery;
-             Ok (Compacted { recovery; manifest }))))
+        | `Busy block -> `Busy block
+        | `Ran (Ok ()) -> `No_compaction no_compaction
+        | `Ran (Error failure) -> `Compaction_failed (Recovery (error, Error failure)))
+     | Error error ->
+       (match
+          Keeper_turn_admission.run_compaction_if_free
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+            (fun () ->
+              let failure_dispatch =
+                dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
+              in
+              Recovery (error, failure_dispatch))
+        with
+        | `Busy block -> `Busy block
+        | `Ran failure -> `Compaction_failed failure)
+     | Ok prepared ->
+       (match
+          Keeper_turn_admission.run_compaction_if_free
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+            (fun () -> run_commit ~config ~base_dir ~meta prepared)
+        with
+        | `Busy block -> `Busy block
+        | `Ran (Error failure) -> `Compaction_failed failure
+        | `Ran (Ok (Compacted success)) ->
+          observe_manifest ~keeper_name:meta.name success.manifest;
+          `Applied success
+        | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction))
 ;;
 
 let lifecycle_stage_to_string = function
@@ -177,35 +272,6 @@ let failure_to_string = function
       (failure_dispatch_to_string failure_dispatch)
 ;;
 
-let observe_manifest ~keeper_name = function
-  | Ok () -> ()
-  | Error detail ->
-    Log.Keeper.error
-      ~keeper_name
-      "manual compaction manifest append failed after durable checkpoint: %s"
-      detail;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string WriteMetaFailures)
-      ~labels:[ "keeper", keeper_name; "phase", "manual_compaction_manifest" ]
-      ()
-;;
 
-(* Single sanctioned caller of [Keeper_turn_admission.run_compaction_if_free]:
-   the admitted section is exactly [run] (checkpoint recovery + manifest
-   observation), never a provider turn, and the slot releases as soon as it
-   returns. A follow-up turn re-enters the standard admission lane where a
-   chat backlog wins (#24865 review). *)
-let run_admitted ~(config : Workspace.config) ~(meta : keeper_meta) =
-  match
-    Keeper_turn_admission.run_compaction_if_free
-      ~base_path:config.base_path
-      ~keeper_name:meta.name
-      (fun () -> run ~config ~meta)
-  with
-  | `Busy block -> `Busy block
-  | `Ran (Error failure) -> `Compaction_failed failure
-  | `Ran (Ok (Compacted success)) ->
-    observe_manifest ~keeper_name:meta.name success.manifest;
-    `Applied success
-  | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction
-;;
+
+

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -41,16 +41,14 @@ val run_admitted
      | `Compaction_failed of failure
      | `Busy of Keeper_turn_admission.autonomous_block
      ]
-(** [run] inside the keeper's turn slot via
-    [Keeper_turn_admission.run_compaction_if_free], releasing the slot the
-    moment the compaction commits (manifest observation included).
-
-    This is the single sanctioned caller of that admission variant, and the
-    critical section is exactly the checkpoint recovery — a deterministic
-    file/FSM operation, never a provider turn — so bypassing the
-    chat-backlog yield cannot park queued chat behind long work. Any
-    follow-up turn must re-enter through the standard [run_if_free] lane,
-    where a chat backlog wins (#24865 review). *)
+(** The provider call runs OUTSIDE the keeper admission: [run_admitted]
+    splits into [prepare_compaction] (durable load + policy + LLM plan, no
+    slot held) and two short admitted sections (lifecycle start, then the
+    source-CAS commit + manifest + completion).  Between them the lane
+    stays runnable — a chat backlog or another turn of the same Keeper can
+    proceed while the LLM works — and correctness against interleaved
+    state change is enforced by the checkpoint source CAS, not by the slot.
+    This is the single sanctioned caller of that admission variant. *)
 
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -42,13 +42,14 @@ val run_admitted
      | `Busy of Keeper_turn_admission.autonomous_block
      ]
 (** The provider call runs OUTSIDE the keeper admission: [run_admitted]
-    splits into [prepare_compaction] (durable load + policy + LLM plan, no
-    slot held) and two short admitted sections (lifecycle start, then the
-    source-CAS commit + manifest + completion).  Between them the lane
-    stays runnable — a chat backlog or another turn of the same Keeper can
-    proceed while the LLM works — and correctness against interleaved
-    state change is enforced by the checkpoint source CAS, not by the slot.
-    This is the single sanctioned caller of that admission variant. *)
+    first performs a state-free availability preflight, then splits into
+    [prepare_compaction] (durable load + policy + LLM plan, no slot held and no
+    active lifecycle) and one admitted lifecycle section owning request +
+    start + source-CAS commit + completion/failure. The lane stays runnable
+    while the LLM works; a failed final admission cannot strand
+    [compaction_active], and interleaved checkpoint changes fail the exact
+    source CAS. This is the single sanctioned caller of that admission
+    variant. *)
 
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -598,7 +598,7 @@ let prepare_compaction ~base_dir ~(meta : keeper_meta) ~(trigger : Compaction_tr
                (Keeper_compact_policy.compaction_decision_to_string decision))))
 ;;
 
-let commit_prepared_compaction ~(meta : keeper_meta) (prepared : prepared_compaction)
+let commit_prepared_compaction (prepared : prepared_compaction)
   : (compaction_recovery, compaction_recovery_error) result =
   (* Source-CAS commit.  The caller decides which admission (if any) guards
      this phase; correctness against interleaved state change is enforced
@@ -619,8 +619,8 @@ let commit_prepared_compaction ~(meta : keeper_meta) (prepared : prepared_compac
          ~trigger:prepared_trigger
          ~save:(fun () ->
            save_oas_checkpoint_if_source
-             ~multimodal_policy:meta.multimodal_policy
-             ~keeper_name:meta.name
+             ~multimodal_policy:retry_meta.multimodal_policy
+             ~keeper_name:retry_meta.name
              ~session
              ~agent_name:retry_meta.agent_name
              ~ctx:context
@@ -680,6 +680,5 @@ let recover_latest_checkpoint_for_compaction
   : (compaction_recovery, compaction_recovery_error) result =
   match prepare_compaction ~base_dir ~meta ~trigger with
   | Error _ as error -> error
-  | Ok prepared -> commit_prepared_compaction ~meta prepared
+  | Ok prepared -> commit_prepared_compaction prepared
 ;;
-

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -501,15 +501,30 @@ let terminal_reason_of_rejection = function
   | Plan_provider_unavailable -> None
 ;;
 
-let recover_latest_checkpoint_for_compaction
-    ~(base_dir : string)
-    ~(meta : keeper_meta)
-    ~(trigger : Compaction_trigger.t)
-  : (compaction_recovery, compaction_recovery_error) result
-  =
-  let session = create_session ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id) ~base_dir in
+type prepared_compaction =
+  { session : Keeper_context_core.session_context
+  ; source_ref : Keeper_checkpoint_ref.t
+  ; retry_meta : keeper_meta
+  ; turn_generation : int
+  ; prepared_trigger : Compaction_trigger.t
+  ; context : Keeper_context_core.working_context
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+let prepare_compaction ~base_dir ~(meta : keeper_meta) ~(trigger : Compaction_trigger.t)
+  : (prepared_compaction, compaction_recovery_error) result =
+  (* Load the durable source and run the policy + LLM planner.  This phase
+     is deliberately admission-free: the keeper's turn slot is not held
+     while the provider call runs.  Correctness after an interleaved state
+     change is enforced by the source CAS at commit, not by the slot. *)
+  let session =
+    create_session
+      ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      ~base_dir
+  in
   match
-    Keeper_checkpoint_store.load_oas_with_ref ~session_dir:session.session_dir
+    Keeper_checkpoint_store.load_oas_with_ref
+      ~session_dir:session.session_dir
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
   with
   | Error Keeper_checkpoint_store.Ref_not_found ->
@@ -557,69 +572,15 @@ let recover_latest_checkpoint_for_compaction
             "compaction preparation completed without structural evidence \
              (planner invariant violation)")
      | Keeper_compact_policy.Prepared prepared_trigger, Some evidence ->
-       (try
-          match
-            commit_prepared_after_save
-              ~trigger:prepared_trigger
-              ~save:(fun () ->
-                save_oas_checkpoint_if_source
-                  ~multimodal_policy:meta.multimodal_policy
-                  ~keeper_name:meta.name
-                  ~session
-                  ~agent_name:retry_meta.agent_name
-                  ~ctx:preparation.context
-                  ~generation:turn_generation
-                  ~expected_source_ref:source_ref
-                |> Result.map fst
-                |> Result.map_error (function
-                  | Tool_history_invalid _ ->
-                    No_compaction
-                      { source = source_ref
-                      ; reason = Keeper_event_queue_state.Invalid_structural_source
-                      }
-                  | Persistence_error error -> Checkpoint_cas_failed error))
-          with
-          | Ok (saved_checkpoint, trigger) ->
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string Compactions)
-              ~labels:[ "keeper", retry_meta.name ]
-              ();
-            Ok
-              { checkpoint = saved_checkpoint
-              ; trigger
-              ; evidence
-              ; turn_generation
-              }
-          | Error
-              (Checkpoint_cas_failed
-                 (Keeper_checkpoint_store.Source_changed actual) as error) ->
-            Log.Keeper.warn
-              "compaction checkpoint source changed: %s"
-              (checkpoint_ref_detail actual);
-            Error error
-          | Error (Checkpoint_cas_failed cas_error as error) ->
-            let detail = checkpoint_cas_error_detail cas_error in
-            Log.Keeper.error
-              "compaction checkpoint save failed: %s"
-              detail;
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string CheckpointFailures)
-              ~labels:
-                [ "keeper", retry_meta.agent_name
-                ; ( "operation"
-                  , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
-                ]
-              ();
-            Error error
-          | Error error -> Error error
-        with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-          let detail = Printexc.to_string exn in
-          log_keeper_exn
-            ~label:"compaction checkpoint save exception"
-            exn;
-          Error (Checkpoint_candidate_failed detail))
+       Ok
+         { session
+         ; source_ref
+         ; retry_meta
+         ; turn_generation
+         ; prepared_trigger
+         ; context = preparation.context
+         ; evidence
+         }
      | Keeper_compact_policy.Rejected (_, reason), _ ->
        (match terminal_reason_of_rejection reason with
         | Some reason -> Error (No_compaction { source = source_ref; reason })
@@ -635,3 +596,90 @@ let recover_latest_checkpoint_for_compaction
             (Printf.sprintf
                "compaction recovery reached a non-preparation decision: %s"
                (Keeper_compact_policy.compaction_decision_to_string decision))))
+;;
+
+let commit_prepared_compaction ~(meta : keeper_meta) (prepared : prepared_compaction)
+  : (compaction_recovery, compaction_recovery_error) result =
+  (* Source-CAS commit.  The caller decides which admission (if any) guards
+     this phase; correctness against interleaved state change is enforced
+     by [expected_source_ref], not by the slot. *)
+  let { session
+      ; source_ref
+      ; retry_meta
+      ; turn_generation
+      ; prepared_trigger
+      ; context
+      ; evidence
+      } =
+    prepared
+  in
+  (try
+     match
+       commit_prepared_after_save
+         ~trigger:prepared_trigger
+         ~save:(fun () ->
+           save_oas_checkpoint_if_source
+             ~multimodal_policy:meta.multimodal_policy
+             ~keeper_name:meta.name
+             ~session
+             ~agent_name:retry_meta.agent_name
+             ~ctx:context
+             ~generation:turn_generation
+             ~expected_source_ref:source_ref
+           |> Result.map fst
+           |> Result.map_error (function
+             | Tool_history_invalid _ ->
+               No_compaction
+                 { source = source_ref
+                 ; reason = Keeper_event_queue_state.Invalid_structural_source
+                 }
+             | Persistence_error error -> Checkpoint_cas_failed error))
+     with
+     | Ok (saved_checkpoint, trigger) ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string Compactions)
+         ~labels:[ "keeper", retry_meta.name ]
+         ();
+       Ok
+         { checkpoint = saved_checkpoint
+         ; trigger
+         ; evidence
+         ; turn_generation
+         }
+     | Error
+         (Checkpoint_cas_failed (Keeper_checkpoint_store.Source_changed actual) as error) ->
+       Log.Keeper.warn
+         "compaction checkpoint source changed: %s"
+         (checkpoint_ref_detail actual);
+       Error error
+     | Error (Checkpoint_cas_failed cas_error as error) ->
+       let detail = checkpoint_cas_error_detail cas_error in
+       Log.Keeper.error "compaction checkpoint save failed: %s" detail;
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string CheckpointFailures)
+         ~labels:
+           [ "keeper", retry_meta.agent_name
+           ; ( "operation"
+             , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
+           ]
+         ();
+       Error error
+     | Error error -> Error error
+   with
+   | Eio.Cancel.Cancelled _ as exn -> raise exn
+   | exn ->
+     let detail = Printexc.to_string exn in
+     log_keeper_exn ~label:"compaction checkpoint save exception" exn;
+     Error (Checkpoint_candidate_failed detail))
+;;
+
+let recover_latest_checkpoint_for_compaction
+    ~(base_dir : string)
+    ~(meta : keeper_meta)
+    ~(trigger : Compaction_trigger.t)
+  : (compaction_recovery, compaction_recovery_error) result =
+  match prepare_compaction ~base_dir ~meta ~trigger with
+  | Error _ as error -> error
+  | Ok prepared -> commit_prepared_compaction ~meta prepared
+;;
+

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -84,10 +84,41 @@ val apply_post_turn_lifecycle_with_resilience_handles :
     verification.  Callers own serialization; the typical pattern
     is one store per keeper, owned by the keeper bridge. *)
 
+type prepared_compaction =
+  { session : Keeper_context_core.session_context
+  ; source_ref : Keeper_checkpoint_ref.t
+  ; retry_meta : Keeper_meta_contract.keeper_meta
+  ; turn_generation : int
+  ; prepared_trigger : Compaction_trigger.t
+  ; context : Keeper_context_core.working_context
+  ; evidence : Keeper_compaction_evidence.t
+  }
+(** Fully-planned compaction: durable source loaded, policy and LLM plan
+    computed, nothing committed yet.  Carrying this value lets a caller run
+    the provider call outside any keeper admission and commit later — the
+    source CAS, not the turn slot, is the interleaving guard. *)
+
+(** Phase 1: load the durable source and run the policy + LLM planner.
+    Admission-free by contract; the caller must not hold the keeper's turn
+    slot while this runs. *)
+val prepare_compaction :
+  base_dir:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  trigger:Compaction_trigger.t ->
+  (prepared_compaction, compaction_recovery_error) result
+
+(** Phase 2: source-CAS commit of a fully-planned compaction.  The caller
+    decides which admission (if any) guards this phase. *)
+val commit_prepared_compaction :
+  meta:Keeper_meta_contract.keeper_meta ->
+  prepared_compaction ->
+  (compaction_recovery, compaction_recovery_error) result
+
 (** Reload the canonical OAS checkpoint and apply an explicit typed
     compaction request. Returns success only after a structurally changed
     [Prepared] candidate has been durably saved; every other outcome is a
-    typed [Error]. *)
+    typed [Error].  Composition of {!prepare_compaction} and
+    {!commit_prepared_compaction} for callers that stay synchronous. *)
 val recover_latest_checkpoint_for_compaction :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -84,19 +84,14 @@ val apply_post_turn_lifecycle_with_resilience_handles :
     verification.  Callers own serialization; the typical pattern
     is one store per keeper, owned by the keeper bridge. *)
 
-type prepared_compaction =
-  { session : Keeper_context_core.session_context
-  ; source_ref : Keeper_checkpoint_ref.t
-  ; retry_meta : Keeper_meta_contract.keeper_meta
-  ; turn_generation : int
-  ; prepared_trigger : Compaction_trigger.t
-  ; context : Keeper_context_core.working_context
-  ; evidence : Keeper_compaction_evidence.t
-  }
+type prepared_compaction
 (** Fully-planned compaction: durable source loaded, policy and LLM plan
     computed, nothing committed yet.  Carrying this value lets a caller run
     the provider call outside any keeper admission and commit later — the
-    source CAS, not the turn slot, is the interleaving guard. *)
+    source CAS, not the turn slot, is the interleaving guard. The token is
+    opaque and owns the exact Keeper identity and commit policy captured at
+    preparation; callers cannot construct it or combine a plan with another
+    Keeper's metadata. *)
 
 (** Phase 1: load the durable source and run the policy + LLM planner.
     Admission-free by contract; the caller must not hold the keeper's turn
@@ -110,7 +105,6 @@ val prepare_compaction :
 (** Phase 2: source-CAS commit of a fully-planned compaction.  The caller
     decides which admission (if any) guards this phase. *)
 val commit_prepared_compaction :
-  meta:Keeper_meta_contract.keeper_meta ->
   prepared_compaction ->
   (compaction_recovery, compaction_recovery_error) result
 

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -339,7 +339,13 @@ let test_manual_compaction_serializes_owner_lane () =
           ~manual_compaction_requested:true
           ()
       in
-      (match run_cycle () with
+      let busy_outcome =
+        Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+          (fun ~runtime_ids:_ ~keeper_name:_ () ->
+             fail "busy admission spent a compaction provider call")
+          run_cycle
+      in
+      (match busy_outcome with
        | Cycle.Busy _ -> ()
        | _ -> fail "manual compaction crossed an active owner turn slot");
       (match Admission.run_if_free ~base_path ~keeper_name:peer.name (fun () -> ()) with
@@ -490,6 +496,85 @@ let test_manual_compaction_serializes_owner_lane () =
       in
       check bool "CAS preserves concurrent checkpoint exactly" true
         (retained_concurrent_checkpoint.messages = concurrent_checkpoint.messages);
+      let race_checkpoint =
+        { (make_checkpoint ()) with
+          session_id = checkpoint.session_id
+        ; agent_name = meta.agent_name
+        ; turn_count = retained_concurrent_checkpoint.turn_count + 1
+        }
+      in
+      (match
+         Masc.Keeper_context_core.save_oas_checkpoint_classified
+           ~multimodal_policy:meta.multimodal_policy
+           ~keeper_name:meta.name
+           ~session
+           ~agent_name:meta.agent_name
+           ~ctx:(Masc.Keeper_context_core.context_of_oas_checkpoint race_checkpoint)
+           ~generation:meta.runtime.generation
+       with
+       | Ok (_, Masc.Keeper_checkpoint_store.Saved _) -> ()
+       | Ok (_, Stale_noop _) -> fail "race fixture checkpoint save was stale"
+       | Error detail ->
+         failf
+           "race fixture checkpoint save failed: %s"
+           (Masc.Keeper_context_core.checkpoint_write_error_to_string
+              ~persistence_error_to_string:Fun.id
+              detail));
+      let commit_block_held, commit_block_held_u = Eio.Promise.create () in
+      let commit_block_release, commit_block_release_u = Eio.Promise.create () in
+      let commit_block_finished, commit_block_finished_u = Eio.Promise.create () in
+      let busy_after_prepare =
+        Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+          (fun ~runtime_ids:_ ~keeper_name:_ () ->
+             Some (fun ~units ->
+               Eio.Fiber.fork ~sw (fun () ->
+                 let result =
+                   Admission.run_serialized
+                     ~base_path
+                     ~keeper_name:meta.name
+                     (fun () ->
+                       Eio.Promise.resolve commit_block_held_u ();
+                       Eio.Promise.await commit_block_release)
+                 in
+                 Eio.Promise.resolve commit_block_finished_u result);
+               Eio.Promise.await commit_block_held;
+               Masc.Keeper_compaction_llm_summarizer.plan_of_json
+                 ~runtime_id:"test.compaction"
+                 ~units
+                 (`Assoc
+                   [ ( Masc.Keeper_structured_output_schema.compaction_plan_field_decisions
+                     , `List
+                         [ `Assoc
+                             [ ( Masc.Keeper_structured_output_schema.compaction_plan_field_unit_index
+                               , `Int 1 )
+                             ; ( Masc.Keeper_structured_output_schema.compaction_plan_field_action
+                               , `String
+                                   Masc.Keeper_structured_output_schema.compaction_plan_action_summarize
+                               )
+                             ; ( Masc.Keeper_structured_output_schema.compaction_plan_field_summary
+                               , `String "prepared while another turn acquires the slot" )
+                             ]
+                         ] )
+                   ])
+               |> Result.map_error (fun _ ->
+                 Masc.Keeper_compaction_llm_summarizer.Invalid_plan)))
+          (fun () -> Masc.Keeper_manual_compaction.run_admitted ~config ~meta)
+      in
+      (match busy_after_prepare with
+       | `Busy _ -> ()
+       | `Applied _ | `No_compaction _ | `Compaction_failed _ ->
+         fail "compaction commit crossed a turn admitted during preparation");
+      (match Masc.Keeper_registry.get ~base_path meta.name with
+       | Some entry ->
+         check bool
+           "busy commit admission never activates compaction lifecycle"
+           false
+           entry.conditions.compaction_active
+       | None -> fail "owner registry entry disappeared after busy commit admission");
+      Eio.Promise.resolve commit_block_release_u ();
+      (match Eio.Promise.await commit_block_finished with
+       | `Ran () -> ()
+       | `Rejected _ -> fail "race fixture owner turn was rejected");
       Registry_queue.settle_result
         ~base_path
         meta.name
@@ -530,6 +615,112 @@ let test_malformed_structure_preserves_checkpoint () =
             { message_index = 0; tool_use_id = "orphan" }) ) ->
     ()
   | _ -> fail "malformed compaction was not rejected with typed structure"
+;;
+
+  (* The prepare/commit split exists so the provider call can run outside
+     the keeper admission; the source CAS — not the slot — is the
+     interleaving guard.  Pin both halves: a prepared plan commits, and
+     the same prepared value is rejected once the source has advanced. *)
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let meta = make_meta () in
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let runtime_path =
+         Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+       in
+       (match Runtime.init_default ~config_path:runtime_path with
+        | Ok () -> ()
+        | Error detail -> failf "runtime fixture initialization failed: %s" detail);
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let checkpoint = make_checkpoint () in
+       let session =
+         Masc.Keeper_context_core.create_session
+           ~session_id:checkpoint.session_id
+           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+       in
+       let context = Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint in
+       (match
+          Masc.Keeper_context_core.save_oas_checkpoint_classified
+            ~multimodal_policy:meta.multimodal_policy
+            ~keeper_name:meta.name
+            ~session
+            ~agent_name:meta.agent_name
+            ~ctx:context
+            ~generation:1
+        with
+        | Ok _ -> ()
+        | Error detail ->
+          failf
+            "fixture checkpoint save failed: %s"
+            (Masc.Keeper_context_core.checkpoint_write_error_to_string
+               ~persistence_error_to_string:(fun detail -> detail)
+               detail));
+  let plan_for ~units =
+    match
+      Masc.Keeper_compaction_llm_summarizer.plan_of_json
+        ~runtime_id:"test.compaction"
+        ~units
+        (`Assoc
+           [ ( Masc.Keeper_structured_output_schema.compaction_plan_field_decisions
+             , `List
+                 [ `Assoc
+                     [ ( Masc.Keeper_structured_output_schema.compaction_plan_field_unit_index
+                       , `Int 1 )
+                     ; ( Masc.Keeper_structured_output_schema.compaction_plan_field_action
+                       , `String
+                           Masc.Keeper_structured_output_schema.compaction_plan_action_summarize
+                       )
+                     ; ( Masc.Keeper_structured_output_schema.compaction_plan_field_summary
+                       , `String "shorter" )
+                     ]
+                 ] )
+           ])
+    with
+    | Ok plan -> Ok plan
+    | Error _ -> Error Masc.Keeper_compaction_llm_summarizer.Invalid_plan
+  in
+  Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+    (fun ~runtime_ids:_ ~keeper_name:_ () -> Some (fun ~units -> plan_for ~units))
+    (fun () ->
+       match
+         Post_turn.prepare_compaction
+           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+           ~meta
+           ~trigger:Compaction_trigger.Manual
+       with
+       | Error error ->
+         failf
+           "prepare failed: %s"
+           (Post_turn.compaction_recovery_error_to_string error)
+       | Ok prepared ->
+         (match Post_turn.commit_prepared_compaction prepared with
+          | Ok _ -> ()
+          | Error error ->
+            failf
+              "commit of a fresh prepared plan failed: %s"
+              (Post_turn.compaction_recovery_error_to_string error));
+         (* The first commit advanced the durable source; the same
+            prepared value is now stale and must be CAS-rejected. *)
+         match Post_turn.commit_prepared_compaction prepared with
+         | Error
+             (Post_turn.Checkpoint_cas_failed
+                (Masc.Keeper_checkpoint_store.Source_changed _)) ->
+           ()
+         | Error error ->
+           failf
+             "stale prepared value failed with the wrong error: %s"
+             (Post_turn.compaction_recovery_error_to_string error)
+         | Ok _ -> fail "stale prepared value committed past the source CAS"))
 ;;
 
 let () =


### PR DESCRIPTION
#25222(folded compaction terminal) 위에 스택. G5 async DoD("synchronous provider call must leave the turn slot")를 두 leaf로 구현.

## Leaf 1 (10c98801ed): prepare/commit phase 분해

`recover_latest_checkpoint_for_compaction`를 `prepare_compaction`(durable source load + policy + LLM plan, admission-free 계약)과 `commit_prepared_compaction`(source-CAS commit)으로 분해. 행위 불변 — 동기 래퍼로 남고 overflow 경로는 그대로 사용.

## Leaf 2 (9bd4e255d4): run_admitted async 재배선

provider call이 slot 밖으로:

- `prepare_compaction`은 admission 없이 실행 — keeper lane이 LLM 작업 동안 runnable
- lifecycle start / source-CAS commit / manifest / completion은 두 개의 짧은 admitted section에 유지. 두 구간 사이의 정합성은 checkpoint source CAS가 보장(slot 아님)
- terminal/retryable 결과 형태는 그대로(No_compaction settle, Recovery에 dispatch 결과 내장), observe_manifest는 기존처럼 release 후

`run`은 API 안정성을 위해 동기 조합으로 유지. `keeper_context_runtime`이 새 함수들을 re-export.

## Validation

- `test_prepare_commit_roundtrip_and_stale_source_rejection`: fresh prepared plan commit + source 진행 후 동일 prepared value가 CAS로 Source_changed 거부 — async 안전성 계약.
- post-turn wirein 6/6, queue-state 19/19, lib 전체 컴파일 통과.
- 복수형: main에서 깨져 있던 기존 테스트 1개(runtime/Eio fixture 누락)도 같은 PR에서 수리.