### PR TITLE
fix(dashboard): surface context metrics failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- The Ops surface now preserves and displays the operator snapshot's typed context-metrics storage and malformed-row failures per Keeper instead of presenting unavailable context as an unexplained blank value. Invalid diagnostic wire payloads remain explicitly visible as contract failures.
 - The process supervisor now records the real server exit code: `|| true` before `exit_code=$?` reported every exit — including SIGSEGV (139) and SIGTERM (143) — as `code=0`; exits above 128 additionally decode the signal name. Takeover kills now leave a JSON breadcrumb next to the pid lock, the victim's SIGTERM path logs the attribution (or its absence: external sender), and the next boot reports a breadcrumb after a SIGKILL escalation.
 - Keeper context-metrics projection now reads its JSONL ledger through `Dated_jsonl.read_recent_result` and exposes typed storage or malformed-row unavailability instead of silently falling back to metadata. `Operator_control_context_snapshot.latest_keeper_context_snapshot_from_files` now returns a `result`; there is no compatibility wrapper for the former `option` signature.
 

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -176,6 +176,63 @@ describe('Ops surface', () => {
     expect(container.querySelector('.v2-command-surface')).not.toBeNull()
   }, 60000)
 
+  it('surfaces typed context metrics failures instead of rendering missing context as blank', async () => {
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorWorkspaceDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorDigestError.value = null
+    operatorWorkspaceDigest.value = null
+    operatorActionLog.value = []
+    operatorSnapshot.value = {
+      root: { paused: false },
+      sessions: [],
+      keepers: [{
+        name: 'sojin',
+        context_metrics_unavailable: {
+          kind: 'storage_read_failed',
+          reason: 'io_error',
+          path: '/tmp/sojin-metrics.jsonl',
+          detail: 'permission denied',
+        },
+      }],
+      persistent_agents: [{
+        name: 'watcher',
+        context_metrics_unavailable: {
+          kind: 'malformed_json',
+          reason: 'malformed_metrics_row',
+          path: '/tmp/watcher-metrics.jsonl',
+          line_number: 7,
+          detail: 'unexpected end of input',
+        },
+      }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const panel = container.querySelector('[data-testid="ops-context-metrics-unavailable"]')
+    expect(panel?.textContent).toContain('Keeper sojin')
+    expect(panel?.textContent).toContain('io_error')
+    expect(panel?.textContent).toContain('/tmp/sojin-metrics.jsonl')
+    expect(panel?.textContent).toContain('Persistent agent watcher')
+    expect(panel?.textContent).toContain('/tmp/watcher-metrics.jsonl:7')
+    expect(panel?.textContent).toContain('unexpected end of input')
+  }, 60000)
+
   it('marks raw ops banner panels and activity rows with v2-command-* classes', async () => {
     const {
       Ops,

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -17,7 +17,13 @@ import {
   workflowContextForRoute,
   workflowTargetLabel,
 } from '../../workflow-context'
-import type { OperatorActionLogEntry, OperatorReviewDecision } from '../../types'
+import type {
+  OperatorActionLogEntry,
+  OperatorContextMetricsUnavailable,
+  OperatorKeeperSnapshot,
+  OperatorReviewDecision,
+  OperatorSnapshot,
+} from '../../types'
 import { ComposerV2 } from '../board/composer-v2'
 import {
   actionTypeLabel,
@@ -42,6 +48,60 @@ interface OpsActivityTimelineEntry {
   target: string
   detail: string
   tone: ActivityTone
+}
+
+interface ContextMetricsDiagnostic {
+  keeper: OperatorKeeperSnapshot
+  source: 'keeper' | 'persistent_agent'
+  error: OperatorContextMetricsUnavailable
+}
+
+function contextMetricsDiagnostics(snapshot: OperatorSnapshot | null): ContextMetricsDiagnostic[] {
+  if (!snapshot) return []
+  const keepers = snapshot.keepers
+    .filter((keeper): keeper is OperatorKeeperSnapshot & { context_metrics_unavailable: OperatorContextMetricsUnavailable } =>
+      keeper.context_metrics_unavailable !== undefined)
+    .map(keeper => ({ keeper, source: 'keeper' as const, error: keeper.context_metrics_unavailable }))
+  const persistentAgents = (snapshot.persistent_agents ?? [])
+    .filter((keeper): keeper is OperatorKeeperSnapshot & { context_metrics_unavailable: OperatorContextMetricsUnavailable } =>
+      keeper.context_metrics_unavailable !== undefined)
+    .map(keeper => ({ keeper, source: 'persistent_agent' as const, error: keeper.context_metrics_unavailable }))
+  return [...keepers, ...persistentAgents]
+}
+
+function renderContextMetricsDiagnostic(diagnostic: ContextMetricsDiagnostic) {
+  const { keeper, source, error } = diagnostic
+  const sourceLabel = source === 'keeper' ? 'Keeper' : 'Persistent agent'
+  if (error.kind === 'invalid_payload') {
+    return html`
+      <li
+        class="grid gap-1 text-sm text-[var(--color-fg-primary)]"
+        data-testid="ops-context-metrics-diagnostic"
+        data-error-kind=${error.kind}
+      >
+        <strong>${sourceLabel} ${keeper.name}</strong>
+        <span>invalid context metrics diagnostic</span>
+        ${error.reported_kind ? html`<span>kind: ${error.reported_kind}</span>` : null}
+        ${error.reported_reason ? html`<span>reason: ${error.reported_reason}</span>` : null}
+      </li>
+    `
+  }
+
+  const location = error.kind === 'malformed_json' && error.line_number !== null
+    ? `${error.path}:${error.line_number}`
+    : error.path
+  return html`
+    <li
+      class="grid gap-1 text-sm text-[var(--color-fg-primary)]"
+      data-testid="ops-context-metrics-diagnostic"
+      data-error-kind=${error.kind}
+    >
+      <strong>${sourceLabel} ${keeper.name}</strong>
+      <span>${error.reason}</span>
+      ${location ? html`<span>${location}</span>` : null}
+      <span>${error.detail}</span>
+    </li>
+  `
 }
 
 function parseTimestamp(value?: string | null): number {
@@ -182,6 +242,7 @@ function renderActivityTimeline() {
 
 export function Ops() {
   const snapshot = operatorSnapshot.value
+  const metricsDiagnostics = contextMetricsDiagnostics(snapshot)
   const workflowContext = route.value.tab === 'command' ? workflowContextForRoute(route.value) : null
   const workflowReady = workflowTargetReady(workflowContext, snapshot?.keepers ?? [])
 
@@ -211,6 +272,16 @@ export function Ops() {
     <section class="v2-command-surface flex flex-col gap-4" aria-label="Operations panel">
       ${operatorError.value ? html`<section class="ops-banner v2-command-panel rounded-[var(--r-1)] py-3 px-3.5 border border-[var(--color-border-default)] error" role="alert">${operatorError.value}</section>` : null}
       ${operatorDigestError.value ? html`<section class="ops-banner v2-command-panel rounded-[var(--r-1)] py-3 px-3.5 border border-[var(--color-border-default)] error" role="alert">${operatorDigestError.value}</section>` : null}
+      ${metricsDiagnostics.length > 0 ? html`
+        <section
+          class="ops-banner v2-command-panel rounded-[var(--r-1)] py-3 px-3.5 border border-[var(--color-border-default)] error"
+          role="alert"
+          data-testid="ops-context-metrics-unavailable"
+        >
+          <strong>Context metrics unavailable</strong>
+          <ul class="mt-2 grid gap-2">${metricsDiagnostics.map(renderContextMetricsDiagnostic)}</ul>
+        </section>
+      ` : null}
 
       ${workflowContext ? html`
         <section class="ops-banner v2-command-panel rounded-[var(--r-1)] py-3 px-3.5 border border-[var(--color-border-default)] ${workflowReady ? 'info' : 'warn'} grid gap-2" aria-label="Workflow context">

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -288,6 +288,66 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers[0]!.context_source).toBe('keeper_context_status')
   })
 
+  it('preserves typed keeper context metrics storage failures', () => {
+    const result = normalizeOperatorSnapshot({
+      keepers: [
+        {
+          name: 'sojin',
+          context_metrics_unavailable: {
+            kind: 'storage_read_failed',
+            reason: 'io_error',
+            path: '/tmp/metrics.jsonl',
+            detail: 'permission denied',
+          },
+        },
+      ],
+    })
+
+    expect(result.keepers[0]!.context_metrics_unavailable).toEqual({
+      kind: 'storage_read_failed',
+      reason: 'io_error',
+      path: '/tmp/metrics.jsonl',
+      detail: 'permission denied',
+    })
+  })
+
+  it('preserves malformed metrics rows and makes invalid diagnostics explicit', () => {
+    const result = normalizeOperatorSnapshot({
+      persistent_agents: [
+        {
+          name: 'watcher',
+          context_metrics_unavailable: {
+            kind: 'malformed_json',
+            reason: 'malformed_metrics_row',
+            path: '/tmp/metrics.jsonl',
+            line_number: 7,
+            detail: 'unexpected end of input',
+          },
+        },
+        {
+          name: 'broken-wire-contract',
+          context_metrics_unavailable: {
+            kind: 'new_failure_kind',
+            reason: 'new_reason',
+          },
+        },
+      ],
+    })
+
+    expect(result.persistent_agents![0]!.context_metrics_unavailable).toEqual({
+      kind: 'malformed_json',
+      reason: 'malformed_metrics_row',
+      path: '/tmp/metrics.jsonl',
+      line_number: 7,
+      detail: 'unexpected end of input',
+    })
+    expect(result.persistent_agents![1]!.context_metrics_unavailable).toEqual({
+      kind: 'invalid_payload',
+      reported_kind: 'new_failure_kind',
+      reported_reason: 'new_reason',
+    })
+  })
+
   it('filters keepers without name', () => {
     const result = normalizeOperatorSnapshot({
       keepers: [

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -19,6 +19,8 @@ import type {
   OperatorGuidanceSummary,
   OperatorJudgment,
   OperatorKeeperSnapshot,
+  OperatorContextMetricsStorageReadFailureReason,
+  OperatorContextMetricsUnavailable,
   OperatorReviewDecision,
   OperatorRecommendedAction,
   OperatorSessionSnapshot,
@@ -27,6 +29,7 @@ import type {
   PendingConfirmation,
 } from './types'
 import { SYSTEM_ACTOR_NAME } from './types/core'
+import { OPERATOR_CONTEXT_METRICS_STORAGE_READ_FAILURE_REASONS } from './types/dashboard-mission'
 
 function normalizeMessage(raw: unknown): Message | null {
   if (!isRecord(raw)) return null
@@ -50,6 +53,50 @@ function normalizeNamespace(raw: unknown): OperatorNamespaceSnapshot {
     paused_by: asString(raw.paused_by) ?? null,
     paused_at: asString(raw.paused_at) ?? null,
   }
+}
+
+const contextMetricsStorageReadFailureReasons = new Set<OperatorContextMetricsStorageReadFailureReason>([
+  ...OPERATOR_CONTEXT_METRICS_STORAGE_READ_FAILURE_REASONS,
+])
+
+function normalizeContextMetricsUnavailable(raw: unknown): OperatorContextMetricsUnavailable | undefined {
+  if (raw === null || raw === undefined) return undefined
+  if (!isRecord(raw)) {
+    return { kind: 'invalid_payload', reported_kind: null, reported_reason: null }
+  }
+
+  const kind = asString(raw.kind) ?? null
+  const reason = asString(raw.reason) ?? null
+  const path = raw.path === null ? null : asString(raw.path)
+  const detail = typeof raw.detail === 'string' ? raw.detail : undefined
+
+  if (
+    kind === 'storage_read_failed'
+    && reason !== null
+    && contextMetricsStorageReadFailureReasons.has(reason as OperatorContextMetricsStorageReadFailureReason)
+    && path !== undefined
+    && detail !== undefined
+  ) {
+    return {
+      kind,
+      reason: reason as OperatorContextMetricsStorageReadFailureReason,
+      path,
+      detail,
+    }
+  }
+
+  const lineNumber = raw.line_number === null ? null : asNumber(raw.line_number)
+  if (
+    kind === 'malformed_json'
+    && reason === 'malformed_metrics_row'
+    && typeof path === 'string'
+    && (lineNumber === null || (lineNumber !== undefined && Number.isSafeInteger(lineNumber)))
+    && detail !== undefined
+  ) {
+    return { kind, reason, path, line_number: lineNumber, detail }
+  }
+
+  return { kind: 'invalid_payload', reported_kind: kind, reported_reason: reason }
 }
 
 function normalizeStringRecord(raw: unknown): Record<string, string> | undefined {
@@ -237,6 +284,7 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     context_tokens: asNumber(raw.context_tokens) ?? asNumber(contextRaw?.context_tokens),
     context_max: asNumber(raw.context_max) ?? asNumber(contextRaw?.context_max),
     context_source: asString(raw.context_source) ?? asString(contextRaw?.source),
+    context_metrics_unavailable: normalizeContextMetricsUnavailable(raw.context_metrics_unavailable),
     generation: asNumber(raw.generation),
     active_goal_ids: asStringArray(raw.active_goal_ids),
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -351,6 +351,37 @@ export interface OperatorSessionSnapshot {
   recent_events?: Record<string, unknown>[]
 }
 
+export const OPERATOR_CONTEXT_METRICS_STORAGE_READ_FAILURE_REASONS = [
+  'invalid_offset',
+  'not_a_directory',
+  'invalid_layout_entry',
+  'non_regular_file',
+  'io_error',
+] as const
+
+export type OperatorContextMetricsStorageReadFailureReason =
+  typeof OPERATOR_CONTEXT_METRICS_STORAGE_READ_FAILURE_REASONS[number]
+
+export type OperatorContextMetricsUnavailable =
+  | {
+      kind: 'storage_read_failed'
+      reason: OperatorContextMetricsStorageReadFailureReason
+      path: string | null
+      detail: string
+    }
+  | {
+      kind: 'malformed_json'
+      reason: 'malformed_metrics_row'
+      path: string
+      line_number: number | null
+      detail: string
+    }
+  | {
+      kind: 'invalid_payload'
+      reported_kind: string | null
+      reported_reason: string | null
+    }
+
 export interface OperatorKeeperSnapshot {
   name: string
   runtime_class?: 'keeper'
@@ -370,6 +401,7 @@ export interface OperatorKeeperSnapshot {
   context_tokens?: number
   context_max?: number
   context_source?: string
+  context_metrics_unavailable?: OperatorContextMetricsUnavailable
   keepalive_running?: boolean
   autonomous_action_count?: number
   autonomous_turn_count?: number


### PR DESCRIPTION
## 문제

#25252가 Keeper context ledger의 storage/malformed-row 실패를 `context_metrics_unavailable` 구조체로 노출하지만, dashboard의 `normalizeOperatorSnapshot`이 이 필드를 버렸습니다. 따라서 operator UI는 실제 read failure와 정상적인 context 부재를 구분하지 못했습니다.

후속 대상: https://github.com/jeong-sik/masc/pull/25252#discussion_r3609258867

## 변경

- OCaml wire contract와 대응하는 closed TypeScript union을 추가합니다.
- `storage_read_failed`와 `malformed_json`을 keeper/persistent-agent snapshot에 보존합니다.
- 계약 밖 payload는 누락시키지 않고 `invalid_payload`로 명시합니다.
- Ops 화면에서 keeper 이름, typed reason, path/line, detail을 표시합니다.
- normalizer와 실제 Ops render 회귀 테스트를 추가합니다.

OAS/Provider 호출, Keeper 실행 정책, 컴팩션 정책에는 관여하지 않습니다.

## 검증

- `tsc --noEmit --pretty false`
- `vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/operator-normalizers.test.ts src/components/ops/index.test.ts` — 53/53
- `git diff --check`

## 병합 조건

- Draft / do-not-merge
- exact-head CI green
- 미해결 review thread 없음
