### PR TITLE
feat(slack): record-only ambient lane parity with Discord (RFC-0226)

### DIFF
--- a/lib/gate/slack_gateway_state.ml
+++ b/lib/gate/slack_gateway_state.ml
@@ -77,6 +77,7 @@ type gateway_effect =
   | Close_wss
   | Send_ack of { envelope_id : string }
   | Emit_event of slack_event
+  | Emit_ambient of slack_event
   | Schedule_backoff of { delay_ms : int }
   | Log of { level : [ `Info | `Warn | `Error ]; message : string }
 
@@ -130,6 +131,12 @@ let passes_policy (cfg : config) = function
   | Ignored_event _ -> false
 ;;
 
+let is_self bot_user_id user_id =
+  match bot_user_id with
+  | Some id -> String.equal id user_id
+  | None -> false
+;;
+
 let ack_effect env =
   match env.envelope_id with Some id -> [ Send_ack { envelope_id = id } ] | None -> []
 ;;
@@ -158,7 +165,22 @@ let rec step t ~now_mono input =
     let emit =
       match event with
       | Some e when passes_policy t.config e -> [ Emit_event e ]
-      | _ -> []
+      (* RFC-0226 parity with the Discord FSM: a policy-failing message from a
+         human is still conversation in a channel the bot sits in — surface it
+         for record-only ambient handling. Bot/app authors are dropped here
+         (loop guard; the gateway keeps its own defense on the turn path). *)
+      | Some (Message_create { bot_id = None; _ } as e) -> [ Emit_ambient e ]
+      (* Reactions are never turn-starters (see [passes_policy]); a human
+         reaction is ambient signal, the bot's own reaction is echo. *)
+      | Some (Reaction_added { user_id; _ } as e)
+        when not (is_self t.config.bot_user_id user_id) ->
+        [ Emit_ambient e ]
+      | Some (Message_create { bot_id = Some _; _ })
+      | Some (Reaction_added _)
+      | Some (App_mention _)
+      | Some (Ignored_event _)
+      | None ->
+        []
     in
     (t, ack @ emit)
   | Connected, Envelope_received ({ kind = Hello_env; envelope_id; _ } as env) ->

--- a/lib/gate/slack_gateway_state.mli
+++ b/lib/gate/slack_gateway_state.mli
@@ -113,6 +113,12 @@ type gateway_effect =
   | Send_ack of { envelope_id : string }
       (** Ack an envelope — Slack retransmits + eventually drops without it. *)
   | Emit_event of slack_event      (** Surface to the caller's [on_event]. *)
+  | Emit_ambient of slack_event
+      (** Record-only delivery (RFC-0226 parity with the Discord FSM): a
+          [Message_create] from a human author that failed [trigger_policy],
+          or a [Reaction_added] from someone other than the bot itself. The
+          I/O layer routes it to the caller's [on_ambient]; it must not start
+          a turn. *)
   | Schedule_backoff of { delay_ms : int }
   | Log of { level : [ `Info | `Warn | `Error ]; message : string }
 

--- a/lib/gate/slack_observability.ml
+++ b/lib/gate/slack_observability.ml
@@ -26,6 +26,13 @@ type inbound_outcome =
   | Reply_sent
   | Reply_send_error
 
+type ambient_outcome =
+  | Ambient_recorded
+  | Ambient_binding_store_error
+  | Ambient_dropped_unbound
+  | Ambient_dropped_empty
+  | Ambient_dropped_too_long
+
 type reply_outcome =
   | Reply_empty
   | Reply_send_ok
@@ -51,6 +58,13 @@ let inbound_outcome_label = function
   | Reply_sent -> "reply_sent"
   | Reply_send_error -> "reply_send_error"
 
+let ambient_outcome_label = function
+  | Ambient_recorded -> "recorded"
+  | Ambient_binding_store_error -> "binding_store_error"
+  | Ambient_dropped_unbound -> "dropped_unbound"
+  | Ambient_dropped_empty -> "dropped_empty"
+  | Ambient_dropped_too_long -> "dropped_too_long"
+
 let reply_outcome_label = function
   | Reply_empty -> "empty"
   | Reply_send_ok -> "sent"
@@ -71,6 +85,11 @@ let record_inbound_dispatch outcome =
   inc
     Otel_transport_metric_names.metric_slack_inbound_dispatch
     ~labels:[ "outcome", inbound_outcome_label outcome ]
+
+let record_ambient outcome =
+  inc
+    Otel_transport_metric_names.metric_slack_ambient_record
+    ~labels:[ "outcome", ambient_outcome_label outcome ]
 
 let record_reply outcome =
   inc

--- a/lib/gate/slack_observability.mli
+++ b/lib/gate/slack_observability.mli
@@ -23,6 +23,13 @@ type inbound_outcome =
   | Reply_sent
   | Reply_send_error
 
+type ambient_outcome =
+  | Ambient_recorded
+  | Ambient_binding_store_error
+  | Ambient_dropped_unbound
+  | Ambient_dropped_empty
+  | Ambient_dropped_too_long
+
 type reply_outcome =
   | Reply_empty
   | Reply_send_ok
@@ -31,6 +38,7 @@ type reply_outcome =
 val gateway_route_label : gateway_route -> string
 val gateway_event_label : gateway_event -> string
 val inbound_outcome_label : inbound_outcome -> string
+val ambient_outcome_label : ambient_outcome -> string
 val reply_outcome_label : reply_outcome -> string
 
 val record_gateway_event : route:gateway_route -> gateway_event -> unit
@@ -40,6 +48,11 @@ val record_gateway_event : route:gateway_route -> gateway_event -> unit
 val record_inbound_dispatch : inbound_outcome -> unit
 (** Increment [masc_slack_inbound_dispatch_total] with an [outcome] label for a
     triggered inbound message after keeper binding lookup. *)
+
+val record_ambient : ambient_outcome -> unit
+(** Increment [masc_slack_ambient_record_total] with an [outcome] label for a
+    record-only ambient message after keeper binding lookup (RFC-0226 parity
+    with the Discord gateway). *)
 
 val record_reply : reply_outcome -> unit
 (** Increment [masc_slack_outbound_replies_total] with an [outcome] label for a

--- a/lib/gate/slack_socket_client.ml
+++ b/lib/gate/slack_socket_client.ml
@@ -138,7 +138,8 @@ let fetch_wss_url ?clock ?(timeout_sec = 10.0) ~app_token () =
 let ack_payload envelope_id =
   Yojson.Safe.to_string (`Assoc [ ("envelope_id", `String envelope_id) ])
 
-let run ~sw ~env ~bot_user_id ~app_token ~trigger_policy ~on_event () =
+let run ~sw ~env ~bot_user_id ~app_token ~trigger_policy ~on_event ~on_ambient
+    () =
   if String.equal app_token "" then
     (* No-op: a server without Slack configured must be unaffected. *)
     Log.Slack.info "slack socket mode disabled (empty app token)"
@@ -254,6 +255,7 @@ let run ~sw ~env ~bot_user_id ~app_token ~trigger_policy ~on_event () =
         | Some conn ->
           Discord_wss_connection.send_text conn (ack_payload envelope_id))
       | Slack_gateway_state.Emit_event ev -> on_event ev
+      | Slack_gateway_state.Emit_ambient ev -> on_ambient ev
       | Slack_gateway_state.Schedule_backoff { delay_ms } ->
         Eio.Fiber.fork ~sw (fun () ->
             (* ±25% jitter, same shape as Discord_gateway_client. The FSM's

--- a/lib/gate/slack_socket_client.mli
+++ b/lib/gate/slack_socket_client.mli
@@ -21,6 +21,7 @@ val run :
   app_token:string ->
   trigger_policy:trigger_policy ->
   on_event:(slack_event -> unit) ->
+  on_ambient:(slack_event -> unit) ->
   unit ->
   unit
 (** Connect to Slack Socket Mode and dispatch events that pass
@@ -34,6 +35,10 @@ val run :
       read by [Channel_gate_slack_state] at send time, not here.
     - [on_event] receives [Message_create] / [App_mention] events that pass the
       trigger policy. [Reaction_added] and ignored events do not start a turn.
+    - [on_ambient] receives the record-only lane (RFC-0226 parity): human
+      [Message_create] events that failed the trigger policy and
+      [Reaction_added] events from users other than the bot itself. It must
+      not start a turn.
 
     Internally:
     1. Create {!Slack_gateway_state.t} with [trigger_policy].

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -97,6 +97,10 @@ let metric_slack_inbound_dispatch =
   Otel_metric_store_core.declare_counter "masc_slack_inbound_dispatch_total"
 ;;
 
+let metric_slack_ambient_record =
+  Otel_metric_store_core.declare_counter "masc_slack_ambient_record_total"
+;;
+
 let metric_slack_outbound_replies =
   Otel_metric_store_core.declare_counter "masc_slack_outbound_replies_total"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -95,6 +95,12 @@ val metric_slack_gateway_events : string
      reply_sent | reply_send_error]. RFC-0317. *)
 val metric_slack_inbound_dispatch : string
 
+(** Record-only ambient Slack messages (RFC-0226 parity with Discord).
+    Labels: [outcome] =
+    [recorded | binding_store_error | dropped_unbound | dropped_empty |
+     dropped_too_long]. *)
+val metric_slack_ambient_record : string
+
 (** Slack REST replies attempted by the gateway reply path.
     Labels: [outcome] = [sent | send_error | empty]. RFC-0317. *)
 val metric_slack_outbound_replies : string

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -7,11 +7,12 @@
    callback returns. The connector lane then projects only the threaded ACK;
    the durable queue consumer owns the Keeper turn and final reply.
 
-   Differences from the Discord gateway:
-   - No ambient/wake path this pass: the FSM only surfaces policy-passing
-     Message_create / App_mention and (ambient) Reaction_added. Recording
-     ambient user lines and waking idle keepers on them is RFC-0317 follow-up
-     scope, matching the Discord gateway's staged rollout. *)
+   Ambient parity with the Discord gateway (RFC-0226): a human message that
+   fails the trigger policy is delivered on the record-only ambient lane —
+   persisted as external attention + one chat-store user line, committed as a
+   durable [Connector_attention] stimulus, and followed by a best-effort wake
+   hint. Reactions are ambient observability signal only: they never start a
+   turn on either connector. *)
 
 module State = Channel_gate_slack_state
 module Gw = Slack_gateway_state
@@ -152,6 +153,58 @@ let slack_delivery ~team_id ~channel_id ~thread_ts ~reply_to_thread_ts ~user_id
   ; conversation_id = Some (slack_conversation_id ~channel_id)
   ; external_message_id = Some ts
   }
+
+(* ---------------------------------------------------------------- *)
+(* Ambient lane (RFC-0226 parity with the Discord gateway)          *)
+(* ---------------------------------------------------------------- *)
+
+let slack_attention_surface ~team_id ~channel_id ~thread_ts =
+  Keeper_external_attention.Slack { team_id; channel_id; thread_ts }
+
+let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
+    ~thread_ts ~ts ~user_id ~user_name ~content ~mentions_bot =
+  let surface = slack_attention_surface ~team_id ~channel_id ~thread_ts in
+  let conversation_id = slack_conversation_id ~channel_id in
+  let dedupe_key = Printf.sprintf "slack:%s:%s" conversation_id ts in
+  let event_id = Keeper_external_attention.event_id_of_dedupe_key dedupe_key in
+  let item : Keeper_external_attention.item =
+    { event_id
+    ; dedupe_key
+    ; keeper_name
+    ; conversation = { conversation_id; surface }
+    ; external_message =
+        Some { surface; message_id = ts; reply_to_message_id = thread_ts }
+    ; source_label = State.channel
+    ; actor =
+        { actor_id = Some user_id
+        ; display_name = user_name
+        ; authority = Keeper_chat_store.External
+        }
+    ; urgency = Keeper_external_attention.Ambient
+    ; content_preview = content
+    ; content_ref = None
+    ; received_at =
+        Unix.gettimeofday ()
+        (* NDT-OK: Slack ingress wall-clock timestamp. The value is persisted
+           as event evidence and for pending-order projection; it does not
+           branch deterministic policy. *)
+    ; metadata =
+        [ "route", "ambient"
+        ; "mentions_bot", string_of_bool mentions_bot
+        ; "slack_channel_id", channel_id
+        ]
+        @ metadata_opt "slack_team_id" team_id
+        @ metadata_opt "slack_thread_ts" thread_ts
+    }
+  in
+  match Keeper_external_attention.record ~base_path:base_dir item with
+  | `Recorded -> Some event_id
+  | `Duplicate item -> Some item.event_id
+  | `Error error ->
+    Log.Server.warn
+      "slack external attention record failed (channel=%s keeper=%s): %s"
+      channel_id keeper_name error;
+    None
 
 (* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)
@@ -372,8 +425,198 @@ let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
     ignore (accept_event ~resolved_binding:None ~dispatch_for_delivery ~team_id ev)
 ;;
 
+(* Ambient lane recording: a bound-channel message that failed the trigger
+   policy is still conversation the keeper sits in. Persist durable attention
+   plus a single user line, commit the exact event as a durable
+   [Connector_attention] stimulus, then offer a best-effort wake hint — no
+   dispatch, no turn. Unbound channels drop, as on the dispatch path. *)
+let handle_ambient ?resolved_keeper_name ~base_dir ~team_id ~channel_id
+    ~thread_ts ~user_id ~user_name ~text ~ts ~mentions_bot () =
+  let keeper_name =
+    match resolved_keeper_name with
+    | Some keeper_name -> Ok (Some keeper_name)
+    | None -> (
+      match State.resolve_keeper_for_channel_result ~channel_id with
+      | Ok (Some resolution) -> Ok (Some resolution.State.keeper_name)
+      | Ok None -> Ok None
+      | Error _ as error -> error)
+  in
+  match keeper_name with
+  | Error reason ->
+    Log.Server.error
+      "Slack ambient binding lookup failed (channel=%s): %s" channel_id
+      (Channel_gate_binding_store.binding_store_error_to_string reason);
+    Slack_observability.record_ambient
+      Slack_observability.Ambient_binding_store_error
+  | Ok None ->
+    Slack_observability.record_ambient Slack_observability.Ambient_dropped_unbound
+  | Ok (Some keeper_name) ->
+    let trimmed = String.trim text in
+    if String.equal trimmed "" then
+      Slack_observability.record_ambient Slack_observability.Ambient_dropped_empty
+    else if String.length trimmed > Channel_gate.max_content_length () then
+      (* Same inbound bound the turn path enforces
+         ([Channel_gate.handle_inbound] validation): a message this size cannot
+         become a turn either; it is rejected, not truncated. *)
+      Slack_observability.record_ambient
+        Slack_observability.Ambient_dropped_too_long
+    else begin
+      let attention_event_id =
+        record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
+          ~thread_ts ~ts ~user_id ~user_name ~content:trimmed ~mentions_bot
+      in
+      Keeper_chat_store.append_user_message
+        ~base_dir ~keeper_name ~content:trimmed
+        ~surface:(Surface_ref.Slack { team_id; channel_id; thread_ts })
+        ~conversation_id:(slack_conversation_id ~channel_id)
+        ~external_message_id:ts
+        ~speaker:
+          { Keeper_chat_store.speaker_id = Some user_id
+          ; speaker_name = user_name
+          ; speaker_authority = Keeper_chat_store.External
+          }
+        ();
+      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
+      (* Every accepted Connector event is a durable per-Keeper stimulus. The
+         event identity comes from the producer-owned external-attention row;
+         no content, channel activity, elapsed-time window, or rollout flag may
+         suppress it. The wake is only a hint after the durable commit, so a
+         busy or lifecycle-deferred Keeper retains the exact event for its next
+         lane cycle. *)
+      (match attention_event_id with
+       | Some event_id ->
+         let stimulus =
+           { Keeper_event_queue.post_id = event_id
+           ; urgency = Keeper_event_queue.Low
+           ; arrived_at = Unix.gettimeofday ()
+             (* NDT-OK: stimulus receipt time, used only for ordering/age *)
+           ; payload =
+               (* RFC-0320: carry the originating Slack channel+author so a
+                  woken keeper replies into the same thread, not its own state. *)
+               Keeper_event_queue.Connector_attention
+                 { event_id
+                 ; channel =
+                     (match
+                        Keeper_continuation_channel.slack ~team_id ~channel_id
+                          ~thread_ts ~user_id
+                      with
+                      | Ok channel -> channel
+                      | Error message -> invalid_arg message)
+                 }
+           }
+         in
+         (match
+            Keeper_registry_event_queue.enqueue_stimulus_durable_result
+              ~base_path:base_dir
+              keeper_name
+              stimulus
+          with
+          | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string KeepaliveSignalFailures)
+              ~labels:
+                [ ("keeper", keeper_name)
+                ; ("phase", "connector_attention_delivery")
+                ]
+              ();
+            Log.Server.error
+              "connector attention durable delivery failed (keeper=%s event=%s): %s"
+              keeper_name
+              event_id
+              detail
+          | Keeper_registry_event_queue.Stimulus_enqueued
+          | Keeper_registry_event_queue.Stimulus_already_present ->
+            (match
+               Keeper_registry.wakeup_running
+                 ~intent:Keeper_registry.Reactive_signal
+                 ~base_path:base_dir
+                 keeper_name
+             with
+             | Keeper_registry.Signaled -> ()
+             | Keeper_registry.Deferred_unregistered ->
+               Log.Server.info
+                 "connector attention durably queued; wake deferred for unregistered Keeper (keeper=%s event=%s)"
+                 keeper_name
+                 event_id
+             | Keeper_registry.Deferred_not_running phase ->
+               Log.Server.info
+                 "connector attention durably queued; wake deferred by Keeper phase (keeper=%s event=%s phase=%s)"
+                 keeper_name
+                 event_id
+                 (Keeper_state_machine.phase_to_string phase)
+             | Keeper_registry.Deferred_lifecycle denial ->
+               Log.Server.info
+                 "connector attention durably queued; wake deferred by lifecycle (keeper=%s event=%s reason=%s)"
+                 keeper_name
+                 event_id
+                 (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)))
+       | None -> ());
+      Slack_observability.record_ambient Slack_observability.Ambient_recorded
+    end
+
+let on_ambient ?resolved_keeper_name ?team_id ~base_dir (ev : Gw.slack_event) =
+  match ev with
+  | Gw.Message_create
+      { channel_id; thread_ts; user_id; user_name; text; ts; mentions_bot
+      ; bot_id = None
+      } ->
+    handle_ambient ?resolved_keeper_name ~base_dir ~team_id ~channel_id
+      ~thread_ts ~user_id ~user_name ~text ~ts ~mentions_bot ()
+  | Gw.Message_create { bot_id = Some _; _ } | Gw.App_mention _ ->
+    (* Unreachable from the FSM's ambient lane: bot echoes are dropped and an
+       app_mention always passes policy. Kept explicit — closed sum. *)
+    ()
+  | Gw.Reaction_added _ ->
+    (* Reactions are observability signal only; they are not attention records
+       and never start a turn (Discord parity). *)
+    Slack_observability.record_gateway_event ~route:Slack_observability.Ambient
+      Slack_observability.Reaction_added
+  | Gw.Ignored_event _ -> ()
+
+let submit_ambient_event ?team_id ingress ~base_dir (ev : Gw.slack_event) =
+  match ev with
+  | Gw.Message_create { channel_id; ts; bot_id = None; _ } -> (
+    match State.resolve_keeper_for_channel_result ~channel_id with
+    | Error reason ->
+      Log.Server.error
+        "Slack ambient binding unavailable channel=%s event=%s: %s" channel_id
+        ts
+        (Channel_gate_binding_store.binding_store_error_to_string reason);
+      Slack_observability.record_ambient
+        Slack_observability.Ambient_binding_store_error
+    | Ok None -> on_ambient ?team_id ~base_dir ev
+    | Ok (Some resolution) -> (
+      let lane =
+        Connector_ingress_lane.Keeper_lane resolution.State.keeper_name
+      in
+      let ingress_event_id =
+        Connector_ingress_lane.{ source = "slack_ambient"; opaque_id = ts }
+      in
+      match
+        Connector_ingress_lane.submit
+          ingress
+          ~lane
+          ~event_id:ingress_event_id
+          (fun () ->
+            on_ambient
+              ~resolved_keeper_name:resolution.State.keeper_name
+              ?team_id ~base_dir ev)
+      with
+      | Ok () -> ()
+      | Error error ->
+        Log.Server.error
+          "Slack ambient ingress submission rejected lane=%s event=%s: %s"
+          (Connector_ingress_lane.lane_to_string lane)
+          (Connector_ingress_lane.event_id_to_string ingress_event_id)
+          (Connector_ingress_lane.submit_error_to_string error)))
+  | Gw.Message_create { bot_id = Some _; _ }
+  | Gw.App_mention _ | Gw.Reaction_added _ | Gw.Ignored_event _ ->
+    on_ambient ?team_id ~base_dir ev
+;;
+
 module For_testing = struct
   let submit_event = submit_event
+  let submit_ambient_event = submit_ambient_event
 end
 
 (* ---------------------------------------------------------------- *)
@@ -456,6 +699,10 @@ let start ~sw ~env ~state =
                  ~dispatch_for_delivery:(dispatch_for_config config)
                  ?team_id
                  ~clock
+                 ev)
+             ~on_ambient:(fun ev ->
+               let config = Mcp_server.workspace_config state in
+               submit_ambient_event ingress ?team_id ~base_dir:config.base_path
                  ev)
              ()
          with

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -12,13 +12,17 @@
        Keeper-scoped connector lane; the durable chat-queue consumer owns the
        eventual Keeper turn and connector reply.
 
+    Ambient parity with the Discord gateway (RFC-0226): a human message that
+    fails the trigger policy is persisted as durable external attention plus a
+    single chat-store user line, committed as a durable [Connector_attention]
+    stimulus, and followed by a best-effort wake hint for the bound keeper.
+    Reactions are record-only observability signal on both connectors; a
+    reaction never starts a turn.
+
     Off by default: if [SLACK_APP_TOKEN] is unset the gateway logs a
     warning and skips startup; the server still boots normally. A message
     arriving while the keeper is in flight is enqueued with the leaf-owned
     Slack delivery source for deferred delivery, not dropped.
-
-    Not covered this pass (RFC-0317 follow-up): ambient recording + idle-keeper
-    wake on non-triggering messages, and reaction-as-trigger.
 
     See: docs/rfc/RFC-0317-slack-builtin-gateway.md. *)
 
@@ -63,6 +67,13 @@ module For_testing : sig
     dispatch_for_delivery:
       (Gate_keeper_backend.connector_delivery -> Channel_gate.dispatch_fn) ->
     clock:_ Eio.Time.clock ->
+    Slack_socket_client.slack_event ->
+    unit
+
+  val submit_ambient_event :
+    ?team_id:string ->
+    Connector_ingress_lane.t ->
+    base_dir:string ->
     Slack_socket_client.slack_event ->
     unit
 end

--- a/test/test_slack_gateway_state.ml
+++ b/test/test_slack_gateway_state.ml
@@ -25,6 +25,7 @@ let effect_summary : S.gateway_effect -> string = function
   | S.Close_wss -> "close_wss"
   | S.Send_ack _ -> "send_ack"
   | S.Emit_event _ -> "emit_event"
+  | S.Emit_ambient _ -> "emit_ambient"
   | S.Schedule_backoff _ -> "schedule_backoff"
   | S.Log _ -> "log"
 
@@ -133,6 +134,13 @@ let full_connect () =
   let (t, _) = S.step t ~now_mono:0.0 (S.Envelope_received hello) in
   t
 
+let full_connect_config config =
+  let t = S.create ~config in
+  let (t, _) = S.step t ~now_mono:0.0 S.Connect_requested in
+  let hello = { S.kind = S.Hello_env; envelope_id = None; event = None } in
+  let (t, _) = S.step t ~now_mono:0.0 (S.Envelope_received hello) in
+  t
+
 (* ---------------------------------------------------------------- *)
 (* step: per-envelope ack (the type-level guarantee)                 *)
 (* ---------------------------------------------------------------- *)
@@ -187,6 +195,81 @@ let test_app_mention_always_emits () =
   let effects = effects_of t (S.Envelope_received env) in
   check bool "emit (app_mention is a mention)" true
     (List.mem "emit_event" effects)
+
+(* ---------------------------------------------------------------- *)
+(* step: ambient lane (RFC-0226 parity)                              *)
+(* ---------------------------------------------------------------- *)
+
+let mk_event_reaction ?(channel = "C1") ?(message_ts = "1700000000.000100")
+    ?(user = "U1") ?(reaction = "thumbsup") () =
+  S.Reaction_added
+    { channel_id = channel; message_ts; user_id = user; reaction }
+
+let test_non_passing_human_message_emits_ambient () =
+  let t =
+    full_connect_config (cfg ~policy:S.Mention_only ~bot_user_id:"UBOT" ())
+  in
+  let env =
+    env_events_api ~envelope_id:"EA1" (mk_event_message ~mentions:false ())
+  in
+  let l = effects_of t (S.Envelope_received env) in
+  check string "ack + ambient" "[send_ack; emit_ambient]"
+    ("[" ^ String.concat "; " l ^ "]")
+
+let test_passing_message_emits_event_not_ambient () =
+  let t = full_connect () in
+  let env =
+    env_events_api ~envelope_id:"EA2" (mk_event_message ~mentions:false ())
+  in
+  let effects = effects_of t (S.Envelope_received env) in
+  check bool "emit_event" true (List.mem "emit_event" effects);
+  check bool "no emit_ambient" false (List.mem "emit_ambient" effects)
+
+let test_bot_message_is_not_ambient () =
+  let t =
+    full_connect_config (cfg ~policy:S.Mention_only ~bot_user_id:"UBOT" ())
+  in
+  let ev =
+    S.Message_create
+      { channel_id = "C1"
+      ; thread_ts = None
+      ; user_id = "U2"
+      ; user_name = None
+      ; text = "bot echo"
+      ; ts = "1700000000.000300"
+      ; mentions_bot = false
+      ; bot_id = Some "B1"
+      }
+  in
+  let env = env_events_api ~envelope_id:"EA3" ev in
+  let effects = effects_of t (S.Envelope_received env) in
+  check bool "acks" true (List.mem "send_ack" effects);
+  check bool "no emit_event" false (List.mem "emit_event" effects);
+  check bool "no emit_ambient (loop guard)" false
+    (List.mem "emit_ambient" effects)
+
+let test_human_reaction_emits_ambient () =
+  let t =
+    full_connect_config (cfg ~policy:S.Mention_only ~bot_user_id:"UBOT" ())
+  in
+  let env =
+    env_events_api ~envelope_id:"EA4" (mk_event_reaction ~user:"U1" ())
+  in
+  let effects = effects_of t (S.Envelope_received env) in
+  check bool "no emit_event (reactions never turn)" false
+    (List.mem "emit_event" effects);
+  check bool "emit_ambient" true (List.mem "emit_ambient" effects)
+
+let test_self_reaction_dropped () =
+  let t = full_connect_config (cfg ~policy:S.All ~bot_user_id:"UBOT" ()) in
+  let env =
+    env_events_api ~envelope_id:"EA5" (mk_event_reaction ~user:"UBOT" ())
+  in
+  let effects = effects_of t (S.Envelope_received env) in
+  check bool "acks" true (List.mem "send_ack" effects);
+  check bool "no emit_event" false (List.mem "emit_event" effects);
+  check bool "no emit_ambient (self echo)" false
+    (List.mem "emit_ambient" effects)
 
 (* ---------------------------------------------------------------- *)
 (* step: reconnect                                                   *)
@@ -364,6 +447,17 @@ let () =
         ; test_case "mention_only suppresses non-mention" `Quick
             test_mention_only_suppresses_non_mention
         ; test_case "app_mention always emits" `Quick test_app_mention_always_emits
+        ]
+    ; "ambient"
+      , [ test_case "non-passing human message emits ambient" `Quick
+            test_non_passing_human_message_emits_ambient
+        ; test_case "passing message emits event, not ambient" `Quick
+            test_passing_message_emits_event_not_ambient
+        ; test_case "bot message is not ambient" `Quick
+            test_bot_message_is_not_ambient
+        ; test_case "human reaction emits ambient" `Quick
+            test_human_reaction_emits_ambient
+        ; test_case "self reaction dropped" `Quick test_self_reaction_dropped
         ]
     ; "reconnect"
       , [ test_case "disconnect envelope reconnects" `Quick


### PR DESCRIPTION
## 무엇을 바꾸나

Slack in-process 게이트웨이(RFC-0317)에 Discord 게이트웨이의 RFC-0226 ambient lane을 대칭 구현한다. goal matrix G9의 `Slack ambient/reaction parity` 괴리 해소.

**이전 흐름**: trigger policy를 통과하지 못한 인간 메시지는 FSM(`slack_gateway_state.ml`) 안에서 소실됐다. decode는 되지만 `Emit_event`가 나오지 않아 게이트웨이까지 도달하지 못했고, `Reaction_added`의 게이트웨이 처리 분기는 도달 불가능한 죽은 코드였다.

**이후 흐름**:
1. FSM: policy 실패한 인간 `Message_create`(bot_id=None)와 봇 이외 사용자의 `Reaction_added`를 새 `Emit_ambient` effect로 표출. 봇 echo/self-reaction은 기존처럼 drop(loop guard).
2. I/O(`slack_socket_client.run`): `~on_ambient` 콜백으로 라우팅(Discord 클라이언트와 같은 형태).
3. 게이트웨이 `handle_ambient`: durable external attention(`Surface_ref.Slack`) 기록 → chat store에 사용자 라인 1건 append → 정확한 이벤트를 durable `Connector_attention` stimulus로 커밋(`Keeper_continuation_channel.slack`) → `wakeup_running` 힌트. Discord와 동일한 `enqueue_stimulus_durable_result` 경로를 쓴다. turn은 시작하지 않는다(record-only).
4. unbound/empty/oversized는 typed `ambient_outcome` observability로 drop이 보이게 처리. `masc_slack_ambient_record_total` 카운터 추가.

**의도된 비대칭 1곳**: Discord는 `All`/`User_only` policy에서 reaction을 `Emit_event`(triggered 관측)로 표출하지만 양쪽 커넥터 모두 reaction은 turn을 만들지 않는다. Slack은 reaction을 항상 ambient 경로로 본다 — turn 동작은 동일하고 관측 route 라벨만 다르다. RFC-0317의 `reactions are not turn-starters` 선언을 유지하기 위한 단순화.

## 검증

- focused build: `lib/gate` `lib/server` `lib/otel_metric_store` 통과
- `test_slack_gateway_state` 28개 통과(신규 5개: policy 실패 인간 메시지→emit_ambient, 통과 메시지→emit_event만, 봇 메시지→ambient 아님, 인간 reaction→ambient, self reaction→drop)
- `test_server_slack_trigger_policy` 17개, `test_keeper_chat_slack` 26개 통과
- ocamlformat 0.29.0 --check 통과, lint-ignore/fun-protect 변경 파일 무해

## 관련

- 선행: RFC-0226(Discord ambient), RFC-0317(Slack gateway), #25258(G9 cadence, 머지됨)
- goal matrix G9 행의 다음 단계 중 `Slack ambient parity`에 해당