### PR TITLE
fix(config): reject non-finite schedule-runner interval at the boundary

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -192,16 +192,16 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_AUTONOMY_STARVATION_BONUS_COEF` | typed:float | unclassified | unclassified | 36 |  |
 | `MASC_AUTONOMY_THOMPSON_WEIGHT` | typed:float | unclassified | unclassified | 39 |  |
 | `MASC_AUTONOMY_VOTE_DECAY_FACTOR` | typed:float | unclassified | unclassified | 42 |  |
-| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 109 | Dashboard fixture name override. |
-| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 105 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
-| `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 118 | Default runtime label (e.g. "glm:pro,openai:gpt-4.1"). |
+| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 123 | Dashboard fixture name override. |
+| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 119 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
+| `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 132 | Default runtime label (e.g. "glm:pro,openai:gpt-4.1"). |
 | `MASC_MAINTENANCE_PULSE_INTERVAL_SEC` | typed:float | Runtime | operator | 55 | Maintenance Pulse interval (seconds). Controls the orphan-observation and channel-dedup consumers. Clamped to >= 1.0 ... |
-| `MASC_OPERATOR_CACHE_BACKGROUND_REVALIDATE` | feature_flag | n/a | n/a | 96 | Enable background revalidation when serving stale snapshots. Default: true. Disabling makes stale entries behave like... |
-| `MASC_OPERATOR_CACHE_STALE_GRACE_FACTOR` | typed:float | Timeouts | operator | 90 | Stale-while-revalidate grace factor. After the TTL expires, the previous snapshot is still served for [ttl * factor] ... |
-| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 82 | Operator snapshot cache TTL (seconds). Default: 30. |
+| `MASC_OPERATOR_CACHE_BACKGROUND_REVALIDATE` | feature_flag | n/a | n/a | 110 | Enable background revalidation when serving stale snapshots. Default: true. Disabling makes stale entries behave like... |
+| `MASC_OPERATOR_CACHE_STALE_GRACE_FACTOR` | typed:float | Timeouts | operator | 104 | Stale-while-revalidate grace factor. After the TTL expires, the previous snapshot is still served for [ttl * factor] ... |
+| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 96 | Operator snapshot cache TTL (seconds). Default: 30. |
 | `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 8 | Cleanup interval for stale rate limit buckets (seconds) |
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 12 | Max age for rate limit entries before cleanup (seconds) |
-| `MASC_SCHEDULE_RUNNER_INTERVAL_SEC` | typed:float | unclassified | unclassified | 75 |  |
+| `MASC_SCHEDULE_RUNNER_INTERVAL_SEC` | typed:float | unclassified | unclassified | 89 |  |
 
 ## Env_config_sandbox (15 knobs; typed classification 1/14)
 

--- a/lib/config/env_config_runtime_services.ml
+++ b/lib/config/env_config_runtime_services.ml
@@ -66,13 +66,27 @@ module ScheduleRunner = struct
       @ops_class operator *)
   let interval_floor_sec = 1.0
 
+  (* Default poll cadence when the env var is unset or non-finite. Single
+     source of truth: used by both the [get_float] default and the
+     non-finite fallback below, so the two never drift. *)
+  let schedule_runner_interval_default_sec = 15.0
+
   (* Exposed as a pure function so the floor contract is testable in-process:
      [interval_sec] is read once at module load, so a test cannot exercise the
      clamp by setting a sub-floor env var. *)
-  let clamp_interval_sec value = Float.max interval_floor_sec value
+  let clamp_interval_sec value =
+    (* [Float.max] passes nan through and treats +inf as the max, so a
+       non-finite env value would reach [Eio.Time.sleep] and stall the
+       schedule runner (fiber sleeps forever / on nan; no more occurrences
+       fire until process restart). Reject non-finite at the boundary. *)
+    if Float.is_finite value then Float.max interval_floor_sec value
+    else schedule_runner_interval_default_sec
 
   let interval_sec =
-    clamp_interval_sec (get_float ~default:15.0 "MASC_SCHEDULE_RUNNER_INTERVAL_SEC")
+    clamp_interval_sec
+      (get_float
+         ~default:schedule_runner_interval_default_sec
+         "MASC_SCHEDULE_RUNNER_INTERVAL_SEC")
 end
 
 (** {1 Operator Snapshot Cache Configuration} *)

--- a/test/test_env_config_schedule_runner.ml
+++ b/test/test_env_config_schedule_runner.ml
@@ -24,6 +24,34 @@ let test_interval_floor () =
     (Env_config_runtime_services.ScheduleRunner.clamp_interval_sec 42.0)
 ;;
 
+let test_interval_non_finite () =
+  (* Regression for the nan/+inf sleep-forever defect (PR #25258 P2):
+     [Float.max floor nan = nan] and [Float.max floor +inf = +inf], so the
+     floor clamp alone let a non-finite env value reach [Eio.Time.sleep],
+     stalling the schedule runner until process restart. The boundary now
+     rejects non-finite and falls back to the documented default (15.0).
+     Deleting the [Float.is_finite] guard turns these cases red. *)
+  let clamp = Env_config_runtime_services.ScheduleRunner.clamp_interval_sec in
+  Alcotest.(check bool) "nan yields a finite interval" true (Float.is_finite (clamp Float.nan));
+  Alcotest.(check (float 0.001)) "nan falls back to the documented default" 15.0 (clamp Float.nan);
+  Alcotest.(check bool)
+    "+inf yields a finite interval"
+    true
+    (Float.is_finite (clamp Float.infinity));
+  Alcotest.(check (float 0.001))
+    "+inf falls back to the documented default"
+    15.0
+    (clamp Float.infinity);
+  Alcotest.(check bool)
+    "-inf yields a finite interval"
+    true
+    (Float.is_finite (clamp Float.neg_infinity));
+  Alcotest.(check (float 0.001))
+    "-inf falls back to the documented default"
+    15.0
+    (clamp Float.neg_infinity)
+;;
+
 let test_interval_default () =
   match Sys.getenv_opt "MASC_SCHEDULE_RUNNER_INTERVAL_SEC" with
   | Some _ ->
@@ -43,6 +71,7 @@ let () =
     "env_config_schedule_runner"
     [ ( "schedule_runner"
       , [ Alcotest.test_case "floor clamp" `Quick test_interval_floor
+        ; Alcotest.test_case "non-finite fallback" `Quick test_interval_non_finite
         ; Alcotest.test_case "documented default" `Quick test_interval_default
         ] )
     ]


### PR DESCRIPTION
## 증상
`MASC_SCHEDULE_RUNNER_INTERVAL_SEC` 가 `nan` 또는 `+inf` 로 설정되면 schedule
runner fiber 가 영원히(또는 `nan` 값으로) sleep 하여, 프로세스 재시작 전까지
예약된 occurrence 가 더 이상 발화하지 않습니다.

## 근본 원인
`clamp_interval_sec` 가 `Float.max interval_floor_sec value` 라서 음수만 floor 로
막고, `Float.max floor nan = nan` / `Float.max floor +inf = +inf` 로 비유한(non-finite)
값이 그대로 통과해 `Eio.Time.sleep` 까지 도달합니다.
경로: `ScheduleRunner.interval_sec` → `Server_schedule_runner_policy.interval_sec`
→ `server_bootstrap_maintenance.ml:303` (`Eio.Time.sleep clock`).

## 수정
경계에서 non-finite 를 거부하도록 `clamp_interval_sec` 를 total 하게 변경하고,
기본값 `15.0` 을 `schedule_runner_interval_default_sec` 상수로 추출해 `get_float`
default 와 fallback 이 단일 출처를 공유하도록 했습니다(drift 방지). 음수 처리는
기존 floor clamp 그대로입니다.

```
if Float.is_finite value then Float.max interval_floor_sec value
else schedule_runner_interval_default_sec
```

## 테스트
`test_env_config_schedule_runner` 에 `nan`/`+inf`/`-inf` 회귀 케이스를 추가했습니다.
counterfactual 검증: clamp body 를 pre-fix `Float.max` 로 되돌리면 `non-finite fallback`
케이스가 red(`nan yields a finite interval: Expected true, Received false`) 가 되고,
수정 복원 시 green 임을 확인했습니다(테스트가 결함을 실제로 재현).

PR #25258 에서 codex 가 미해결로 남긴 P2 를 종결합니다.

RFC-WAIVED: 변경 경로가 `lib/config/` 스케줄 노브 + `test/` 로, credential/identity/
operator-control/sandbox/hooks/workflow 등 RFC-gated subsystem 에 해당하지 않습니다.
