### PR TITLE
feat(schedule): typed RFC 5545 RECUR value parser (iCalendar leaf 1)

### DIFF
--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -11,6 +11,7 @@
  (modules
   schedule_domain
   schedule_occurrence_id
+  schedule_ical_recur
   schedule_supported_kinds
   schedule_store
   schedule_service

--- a/lib/schedule/schedule_ical_recur.ml
+++ b/lib/schedule/schedule_ical_recur.ml
@@ -136,20 +136,22 @@ let parse_until raw =
   let n = String.length raw in
   if n = 8 then
     match parse_date raw with
+    | Error _ as error -> error
     | Ok d -> Ok (Until_date d)
-    | Error _ -> Error (Invalid_until raw)
   else if n = 15 && raw.[8] = 'T' then
-    match
-      (parse_date (String.sub raw 0 8), parse_time_of_day (String.sub raw 9 6))
-    with
-    | Ok d, Ok t -> Ok (Until_local (d, t))
-    | _ -> Error (Invalid_until raw)
+    (match parse_date (String.sub raw 0 8) with
+     | Error _ as error -> error
+     | Ok d ->
+       (match parse_time_of_day (String.sub raw 9 6) with
+        | Error _ as error -> error
+        | Ok t -> Ok (Until_local (d, t))))
   else if n = 16 && raw.[8] = 'T' && raw.[15] = 'Z' then
-    match
-      (parse_date (String.sub raw 0 8), parse_time_of_day (String.sub raw 9 6))
-    with
-    | Ok d, Ok t -> Ok (Until_utc (d, t))
-    | _ -> Error (Invalid_until raw)
+    (match parse_date (String.sub raw 0 8) with
+     | Error _ as error -> error
+     | Ok d ->
+       (match parse_time_of_day (String.sub raw 9 6) with
+        | Error _ as error -> error
+        | Ok t -> Ok (Until_utc (d, t))))
   else Error (Invalid_until raw)
 
 (* ---------------------------------------------------------------- *)
@@ -324,15 +326,17 @@ let empty_builder =
   ; b_wkst = None
   }
 
-(* [via parsed ~slot ~update] threads one rule part: a prior occurrence of
+(* [via parse ~slot ~update] threads one rule part: a prior occurrence of
    the same part is [Duplicate_part] (§3.3.10: each part at most once), a
    parse failure propagates, and success stores the value in the builder. *)
 let apply_part builder name raw_value =
-  let via parsed ~slot ~update =
-    match parsed, slot with
-    | (Error _ as error), _ -> error
-    | _, Some _ -> Error (Duplicate_part name)
-    | Ok value, None -> Ok (update value)
+  let via parse ~slot ~update =
+    match slot with
+    | Some _ -> Error (Duplicate_part name)
+    | None ->
+      (match parse () with
+       | Error _ as error -> error
+       | Ok value -> Ok (update value))
   in
   let nonzero ~min ~max values =
     if List.exists (fun n -> n = 0) values then
@@ -346,67 +350,90 @@ let apply_part builder name raw_value =
   in
   match name with
   | "FREQ" ->
-    via (freq_of_string (String.uppercase_ascii raw_value))
+    via (fun () -> freq_of_string (String.uppercase_ascii raw_value))
       ~slot:builder.b_freq
       ~update:(fun v -> { builder with b_freq = Some v })
   | "UNTIL" ->
-    via (parse_until raw_value) ~slot:builder.b_until
+    via (fun () -> parse_until raw_value) ~slot:builder.b_until
       ~update:(fun v -> { builder with b_until = Some v })
   | "COUNT" ->
-    via (positive_int ()) ~slot:builder.b_count
+    via positive_int ~slot:builder.b_count
       ~update:(fun v -> { builder with b_count = Some v })
   | "INTERVAL" ->
-    via (positive_int ()) ~slot:builder.b_interval
+    via positive_int ~slot:builder.b_interval
       ~update:(fun v -> { builder with b_interval = Some v })
   | "BYSECOND" ->
-    via (parse_int_list ~part:name ~min:0 ~max:60 ~max_digits:2 raw_value)
+    via
+      (fun () ->
+        parse_int_list ~part:name ~min:0 ~max:60 ~max_digits:2 raw_value)
       ~slot:builder.b_bysecond
       ~update:(fun v -> { builder with b_bysecond = Some v })
   | "BYMINUTE" ->
-    via (parse_int_list ~part:name ~min:0 ~max:59 ~max_digits:2 raw_value)
+    via
+      (fun () ->
+        parse_int_list ~part:name ~min:0 ~max:59 ~max_digits:2 raw_value)
       ~slot:builder.b_byminute
       ~update:(fun v -> { builder with b_byminute = Some v })
   | "BYHOUR" ->
-    via (parse_int_list ~part:name ~min:0 ~max:23 ~max_digits:2 raw_value)
+    via
+      (fun () ->
+        parse_int_list ~part:name ~min:0 ~max:23 ~max_digits:2 raw_value)
       ~slot:builder.b_byhour
       ~update:(fun v -> { builder with b_byhour = Some v })
   | "BYDAY" ->
-    via (parse_byday raw_value) ~slot:builder.b_byday
+    via (fun () -> parse_byday raw_value) ~slot:builder.b_byday
       ~update:(fun v -> { builder with b_byday = Some v })
   | "BYMONTHDAY" ->
     via
-      (match parse_signed_list ~part:name ~min:(-31) ~max:31 ~max_digits:2 raw_value with
-       | Error _ as error -> error
-       | Ok values -> nonzero ~min:(-31) ~max:31 values)
+      (fun () ->
+        match
+          parse_signed_list ~part:name ~min:(-31) ~max:31 ~max_digits:2
+            raw_value
+        with
+        | Error _ as error -> error
+        | Ok values -> nonzero ~min:(-31) ~max:31 values)
       ~slot:builder.b_bymonthday
       ~update:(fun v -> { builder with b_bymonthday = Some v })
   | "BYYEARDAY" ->
     via
-      (match parse_signed_list ~part:name ~min:(-366) ~max:366 ~max_digits:3 raw_value with
-       | Error _ as error -> error
-       | Ok values -> nonzero ~min:(-366) ~max:366 values)
+      (fun () ->
+        match
+          parse_signed_list ~part:name ~min:(-366) ~max:366 ~max_digits:3
+            raw_value
+        with
+        | Error _ as error -> error
+        | Ok values -> nonzero ~min:(-366) ~max:366 values)
       ~slot:builder.b_byyearday
       ~update:(fun v -> { builder with b_byyearday = Some v })
   | "BYWEEKNO" ->
     via
-      (match parse_signed_list ~part:name ~min:(-53) ~max:53 ~max_digits:2 raw_value with
-       | Error _ as error -> error
-       | Ok values -> nonzero ~min:(-53) ~max:53 values)
+      (fun () ->
+        match
+          parse_signed_list ~part:name ~min:(-53) ~max:53 ~max_digits:2 raw_value
+        with
+        | Error _ as error -> error
+        | Ok values -> nonzero ~min:(-53) ~max:53 values)
       ~slot:builder.b_byweekno
       ~update:(fun v -> { builder with b_byweekno = Some v })
   | "BYMONTH" ->
-    via (parse_int_list ~part:name ~min:1 ~max:12 ~max_digits:2 raw_value)
+    via
+      (fun () ->
+        parse_int_list ~part:name ~min:1 ~max:12 ~max_digits:2 raw_value)
       ~slot:builder.b_bymonth
       ~update:(fun v -> { builder with b_bymonth = Some v })
   | "BYSETPOS" ->
     via
-      (match parse_signed_list ~part:name ~min:(-366) ~max:366 ~max_digits:3 raw_value with
-       | Error _ as error -> error
-       | Ok values -> nonzero ~min:(-366) ~max:366 values)
+      (fun () ->
+        match
+          parse_signed_list ~part:name ~min:(-366) ~max:366 ~max_digits:3
+            raw_value
+        with
+        | Error _ as error -> error
+        | Ok values -> nonzero ~min:(-366) ~max:366 values)
       ~slot:builder.b_bysetpos
       ~update:(fun v -> { builder with b_bysetpos = Some v })
   | "WKST" ->
-    via (weekday_of_string (String.uppercase_ascii raw_value))
+    via (fun () -> weekday_of_string (String.uppercase_ascii raw_value))
       ~slot:builder.b_wkst
       ~update:(fun v -> { builder with b_wkst = Some v })
   | _ -> Error (Unknown_part name)

--- a/lib/schedule/schedule_ical_recur.ml
+++ b/lib/schedule/schedule_ical_recur.ml
@@ -1,0 +1,581 @@
+(* See .mli for the contract. RFC 5545 §3.3.10 RECUR value type. *)
+
+type freq = Secondly | Minutely | Hourly | Daily | Weekly | Monthly | Yearly
+
+type weekday =
+  | Sunday | Monday | Tuesday | Wednesday | Thursday | Friday | Saturday
+
+type weekday_num = { ordinal : int option; day : weekday }
+type date = { year : int; month : int; day : int }
+type time_of_day = { hour : int; minute : int; second : int }
+
+type until =
+  | Until_date of date
+  | Until_local of date * time_of_day
+  | Until_utc of date * time_of_day
+
+type bound =
+  | Forever
+  | Count of int
+  | Until of until
+
+type t =
+  { freq : freq
+  ; bound : bound
+  ; interval : int
+  ; bysecond : int list
+  ; byminute : int list
+  ; byhour : int list
+  ; byday : weekday_num list
+  ; bymonthday : int list
+  ; byyearday : int list
+  ; byweekno : int list
+  ; bymonth : int list
+  ; bysetpos : int list
+  ; wkst : weekday
+  }
+
+type parse_error =
+  | Empty_part
+  | Missing_equals of string
+  | Unknown_part of string
+  | Duplicate_part of string
+  | Missing_freq
+  | Invalid_freq of string
+  | Invalid_number of { part : string; value : string }
+  | Out_of_range of { part : string; value : int; min : int; max : int }
+  | Invalid_date of string
+  | Invalid_time of string
+  | Invalid_until of string
+  | Invalid_weekday of string
+  | Until_count_conflict
+  | Numeric_byday_not_allowed of freq
+  | Numeric_byday_with_byweekno
+  | Bymonthday_with_weekly
+  | Byyearday_not_allowed of freq
+  | Byweekno_not_allowed of freq
+  | Bysetpos_without_byxxx
+
+(* ---------------------------------------------------------------- *)
+(* Small total parsers                                              *)
+(* ---------------------------------------------------------------- *)
+
+let is_digit c = Char.code c >= Char.code '0' && Char.code c <= Char.code '9'
+
+let all_digits s =
+  let n = String.length s in
+  n > 0
+  &&
+  let rec loop i = i >= n || (is_digit s.[i] && loop (i + 1)) in
+  loop 0
+
+let parse_digits ~part value =
+  if all_digits value then
+    match int_of_string_opt value with
+    | Some n -> Ok n
+    | None -> Error (Invalid_number { part; value })
+  else Error (Invalid_number { part; value })
+
+(* Grammar-signed integers: one optional [+/-] then digits. *)
+let parse_signed ~part value =
+  let n = String.length value in
+  let body, negative =
+    if n > 0 && value.[0] = '-' then
+      (String.sub value 1 (n - 1), true)
+    else if n > 0 && value.[0] = '+' then
+      (String.sub value 1 (n - 1), false)
+    else (value, false)
+  in
+  match parse_digits ~part body with
+  | Error _ -> Error (Invalid_number { part; value })
+  | Ok magnitude -> Ok (if negative then -magnitude else magnitude)
+
+let check_range ~part ~min ~max value =
+  if value >= min && value <= max then Ok value
+  else Error (Out_of_range { part; value; min; max })
+
+(* ---------------------------------------------------------------- *)
+(* Date / time validation (proleptic Gregorian)                     *)
+(* ---------------------------------------------------------------- *)
+
+let is_leap_year year =
+  year mod 4 = 0 && (year mod 100 <> 0 || year mod 400 = 0)
+
+let days_in_month year month =
+  match month with
+  | 1 | 3 | 5 | 7 | 8 | 10 | 12 -> 31
+  | 4 | 6 | 9 | 11 -> 30
+  | 2 -> if is_leap_year year then 29 else 28
+  | _ -> 0
+
+let valid_date year month day =
+  month >= 1 && month <= 12 && day >= 1 && day <= days_in_month year month
+
+let parse_date raw =
+  if String.length raw = 8 && all_digits raw then begin
+    let year = int_of_string (String.sub raw 0 4) in
+    let month = int_of_string (String.sub raw 4 2) in
+    let day = int_of_string (String.sub raw 6 2) in
+    if valid_date year month day then Ok { year; month; day }
+    else Error (Invalid_date raw)
+  end
+  else Error (Invalid_date raw)
+
+let parse_time_of_day raw =
+  if String.length raw = 6 && all_digits raw then begin
+    let hour = int_of_string (String.sub raw 0 2) in
+    let minute = int_of_string (String.sub raw 2 2) in
+    let second = int_of_string (String.sub raw 4 2) in
+    if hour <= 23 && minute <= 59 && second <= 60 then
+      Ok { hour; minute; second }
+    else Error (Invalid_time raw)
+  end
+  else Error (Invalid_time raw)
+
+let parse_until raw =
+  let n = String.length raw in
+  if n = 8 then
+    match parse_date raw with
+    | Ok d -> Ok (Until_date d)
+    | Error _ -> Error (Invalid_until raw)
+  else if n = 15 && raw.[8] = 'T' then
+    match
+      (parse_date (String.sub raw 0 8), parse_time_of_day (String.sub raw 9 6))
+    with
+    | Ok d, Ok t -> Ok (Until_local (d, t))
+    | _ -> Error (Invalid_until raw)
+  else if n = 16 && raw.[8] = 'T' && raw.[15] = 'Z' then
+    match
+      (parse_date (String.sub raw 0 8), parse_time_of_day (String.sub raw 9 6))
+    with
+    | Ok d, Ok t -> Ok (Until_utc (d, t))
+    | _ -> Error (Invalid_until raw)
+  else Error (Invalid_until raw)
+
+(* ---------------------------------------------------------------- *)
+(* Enumerations                                                     *)
+(* ---------------------------------------------------------------- *)
+
+let freq_of_string = function
+  | "SECONDLY" -> Ok Secondly
+  | "MINUTELY" -> Ok Minutely
+  | "HOURLY" -> Ok Hourly
+  | "DAILY" -> Ok Daily
+  | "WEEKLY" -> Ok Weekly
+  | "MONTHLY" -> Ok Monthly
+  | "YEARLY" -> Ok Yearly
+  | other -> Error (Invalid_freq other)
+
+let freq_to_string = function
+  | Secondly -> "SECONDLY"
+  | Minutely -> "MINUTELY"
+  | Hourly -> "HOURLY"
+  | Daily -> "DAILY"
+  | Weekly -> "WEEKLY"
+  | Monthly -> "MONTHLY"
+  | Yearly -> "YEARLY"
+
+let weekday_of_string = function
+  | "SU" -> Ok Sunday
+  | "MO" -> Ok Monday
+  | "TU" -> Ok Tuesday
+  | "WE" -> Ok Wednesday
+  | "TH" -> Ok Thursday
+  | "FR" -> Ok Friday
+  | "SA" -> Ok Saturday
+  | other -> Error (Invalid_weekday other)
+
+let weekday_to_string = function
+  | Sunday -> "SU"
+  | Monday -> "MO"
+  | Tuesday -> "TU"
+  | Wednesday -> "WE"
+  | Thursday -> "TH"
+  | Friday -> "FR"
+  | Saturday -> "SA"
+
+(* ---------------------------------------------------------------- *)
+(* BYxxx list elements                                              *)
+(* ---------------------------------------------------------------- *)
+
+let split_list ~part raw =
+  let items = String.split_on_char ',' raw in
+  if List.exists (fun item -> String.length item = 0) items then
+    Error (Invalid_number { part; value = raw })
+  else Ok items
+
+let map_list items ~f =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | item :: rest -> (
+      match f item with
+      | Error _ as error -> error
+      | Ok value -> loop (value :: acc) rest)
+  in
+  loop [] items
+
+let parse_int_list ~part ~min ~max ~max_digits raw =
+  match split_list ~part raw with
+  | Error _ as error -> error
+  | Ok items ->
+    map_list items ~f:(fun item ->
+      (* Grammar digit caps ([seconds]/[minutes]/[hour]/... are 1*2DIGIT,
+         [ordyrday] is 1*3DIGIT): excess digits are rejected, not
+         normalized. *)
+      if String.length item > max_digits then
+        Error (Invalid_number { part; value = item })
+      else
+        match parse_digits ~part item with
+        | Error _ as error -> error
+        | Ok n -> check_range ~part ~min ~max n)
+
+let parse_signed_list ~part ~min ~max ~max_digits raw =
+  match split_list ~part raw with
+  | Error _ as error -> error
+  | Ok items ->
+    map_list items ~f:(fun item ->
+      let digit_len =
+        if String.length item > 0 && (item.[0] = '+' || item.[0] = '-')
+        then String.length item - 1
+        else String.length item
+      in
+      if digit_len > max_digits then
+        Error (Invalid_number { part; value = item })
+      else
+        match parse_signed ~part item with
+        | Error _ as error -> error
+        | Ok n -> check_range ~part ~min ~max n)
+
+let parse_weekday_num raw =
+  (* [[plus / minus] ordwk] weekday — optional signed ordinal, then a
+     two-letter weekday token. *)
+  let n = String.length raw in
+  let sign_len =
+    if n > 0 && (raw.[0] = '+' || raw.[0] = '-') then 1 else 0
+  in
+  let digit_end =
+    let rec loop i = if i < n && is_digit raw.[i] then loop (i + 1) else i in
+    loop sign_len
+  in
+  let ordinal_raw = String.sub raw 0 digit_end in
+  let weekday_raw = String.sub raw digit_end (n - digit_end) in
+  if digit_end - sign_len > 2 then
+    (* [ordwk] is 1*2DIGIT: [001MO] is a grammar violation, not [1MO]. *)
+    Error (Invalid_number { part = "BYDAY"; value = raw })
+  else
+  match weekday_of_string (String.uppercase_ascii weekday_raw) with
+  | Error _ as error -> error
+  | Ok day -> (
+    if String.length ordinal_raw = 0 then Ok { ordinal = None; day }
+    else
+      match parse_signed ~part:"BYDAY" ordinal_raw with
+      | Error _ as error -> error
+      | Ok ord -> (
+        match check_range ~part:"BYDAY" ~min:(-53) ~max:53 ord with
+        | Error _ as error -> error
+        | Ok _ ->
+          if ord = 0 then
+            Error
+              (Out_of_range { part = "BYDAY"; value = 0; min = -53; max = 53 })
+          else Ok { ordinal = Some ord; day }))
+
+let parse_byday raw =
+  match split_list ~part:"BYDAY" raw with
+  | Error _ as error -> error
+  | Ok items -> map_list items ~f:parse_weekday_num
+
+(* ---------------------------------------------------------------- *)
+(* Part assembly                                                    *)
+(* ---------------------------------------------------------------- *)
+
+(* Accumulator: [None] means the part has not occurred yet, so a second
+   occurrence is detected exactly (§3.3.10: each part at most once). *)
+type builder =
+  { b_freq : freq option
+  ; b_until : until option
+  ; b_count : int option
+  ; b_interval : int option
+  ; b_bysecond : int list option
+  ; b_byminute : int list option
+  ; b_byhour : int list option
+  ; b_byday : weekday_num list option
+  ; b_bymonthday : int list option
+  ; b_byyearday : int list option
+  ; b_byweekno : int list option
+  ; b_bymonth : int list option
+  ; b_bysetpos : int list option
+  ; b_wkst : weekday option
+  }
+
+let empty_builder =
+  { b_freq = None
+  ; b_until = None
+  ; b_count = None
+  ; b_interval = None
+  ; b_bysecond = None
+  ; b_byminute = None
+  ; b_byhour = None
+  ; b_byday = None
+  ; b_bymonthday = None
+  ; b_byyearday = None
+  ; b_byweekno = None
+  ; b_bymonth = None
+  ; b_bysetpos = None
+  ; b_wkst = None
+  }
+
+(* [via parsed ~slot ~update] threads one rule part: a prior occurrence of
+   the same part is [Duplicate_part] (§3.3.10: each part at most once), a
+   parse failure propagates, and success stores the value in the builder. *)
+let apply_part builder name raw_value =
+  let via parsed ~slot ~update =
+    match parsed, slot with
+    | (Error _ as error), _ -> error
+    | _, Some _ -> Error (Duplicate_part name)
+    | Ok value, None -> Ok (update value)
+  in
+  let nonzero ~min ~max values =
+    if List.exists (fun n -> n = 0) values then
+      Error (Out_of_range { part = name; value = 0; min; max })
+    else Ok values
+  in
+  let positive_int () =
+    match parse_digits ~part:name raw_value with
+    | Error _ as error -> error
+    | Ok n -> check_range ~part:name ~min:1 ~max:max_int n
+  in
+  match name with
+  | "FREQ" ->
+    via (freq_of_string (String.uppercase_ascii raw_value))
+      ~slot:builder.b_freq
+      ~update:(fun v -> { builder with b_freq = Some v })
+  | "UNTIL" ->
+    via (parse_until raw_value) ~slot:builder.b_until
+      ~update:(fun v -> { builder with b_until = Some v })
+  | "COUNT" ->
+    via (positive_int ()) ~slot:builder.b_count
+      ~update:(fun v -> { builder with b_count = Some v })
+  | "INTERVAL" ->
+    via (positive_int ()) ~slot:builder.b_interval
+      ~update:(fun v -> { builder with b_interval = Some v })
+  | "BYSECOND" ->
+    via (parse_int_list ~part:name ~min:0 ~max:60 ~max_digits:2 raw_value)
+      ~slot:builder.b_bysecond
+      ~update:(fun v -> { builder with b_bysecond = Some v })
+  | "BYMINUTE" ->
+    via (parse_int_list ~part:name ~min:0 ~max:59 ~max_digits:2 raw_value)
+      ~slot:builder.b_byminute
+      ~update:(fun v -> { builder with b_byminute = Some v })
+  | "BYHOUR" ->
+    via (parse_int_list ~part:name ~min:0 ~max:23 ~max_digits:2 raw_value)
+      ~slot:builder.b_byhour
+      ~update:(fun v -> { builder with b_byhour = Some v })
+  | "BYDAY" ->
+    via (parse_byday raw_value) ~slot:builder.b_byday
+      ~update:(fun v -> { builder with b_byday = Some v })
+  | "BYMONTHDAY" ->
+    via
+      (match parse_signed_list ~part:name ~min:(-31) ~max:31 ~max_digits:2 raw_value with
+       | Error _ as error -> error
+       | Ok values -> nonzero ~min:(-31) ~max:31 values)
+      ~slot:builder.b_bymonthday
+      ~update:(fun v -> { builder with b_bymonthday = Some v })
+  | "BYYEARDAY" ->
+    via
+      (match parse_signed_list ~part:name ~min:(-366) ~max:366 ~max_digits:3 raw_value with
+       | Error _ as error -> error
+       | Ok values -> nonzero ~min:(-366) ~max:366 values)
+      ~slot:builder.b_byyearday
+      ~update:(fun v -> { builder with b_byyearday = Some v })
+  | "BYWEEKNO" ->
+    via
+      (match parse_signed_list ~part:name ~min:(-53) ~max:53 ~max_digits:2 raw_value with
+       | Error _ as error -> error
+       | Ok values -> nonzero ~min:(-53) ~max:53 values)
+      ~slot:builder.b_byweekno
+      ~update:(fun v -> { builder with b_byweekno = Some v })
+  | "BYMONTH" ->
+    via (parse_int_list ~part:name ~min:1 ~max:12 ~max_digits:2 raw_value)
+      ~slot:builder.b_bymonth
+      ~update:(fun v -> { builder with b_bymonth = Some v })
+  | "BYSETPOS" ->
+    via
+      (match parse_signed_list ~part:name ~min:(-366) ~max:366 ~max_digits:3 raw_value with
+       | Error _ as error -> error
+       | Ok values -> nonzero ~min:(-366) ~max:366 values)
+      ~slot:builder.b_bysetpos
+      ~update:(fun v -> { builder with b_bysetpos = Some v })
+  | "WKST" ->
+    via (weekday_of_string (String.uppercase_ascii raw_value))
+      ~slot:builder.b_wkst
+      ~update:(fun v -> { builder with b_wkst = Some v })
+  | _ -> Error (Unknown_part name)
+
+(* Cross-part semantic constraints (§3.3.10 prose). Each rule is a typed
+   error; none is silently dropped or defaulted away. Absent [BYxxx] parts
+   are exactly the empty list (the RFC assigns them no default), and
+   [INTERVAL]=1 / [WKST]=MO are the RFC-mandated defaults — written out as
+   explicit matches, not catch-all fallbacks. *)
+let assemble_with_bound freq (b : builder) bound =
+  let list_of = function Some values -> values | None -> [] in
+  let byday = list_of b.b_byday in
+  let bymonthday = list_of b.b_bymonthday in
+  let byyearday = list_of b.b_byyearday in
+  let byweekno = list_of b.b_byweekno in
+  let bysetpos = list_of b.b_bysetpos in
+  let has_numeric_byday =
+    List.exists (fun (wn : weekday_num) -> Option.is_some wn.ordinal) byday
+  in
+  if has_numeric_byday && freq <> Monthly && freq <> Yearly then
+    Error (Numeric_byday_not_allowed freq)
+  else if has_numeric_byday && freq = Yearly && byweekno <> [] then
+    Error Numeric_byday_with_byweekno
+  else if bymonthday <> [] && freq = Weekly then
+    Error Bymonthday_with_weekly
+  else if byyearday <> [] && (freq = Daily || freq = Weekly || freq = Monthly)
+  then Error (Byyearday_not_allowed freq)
+  else if byweekno <> [] && freq <> Yearly then
+    Error (Byweekno_not_allowed freq)
+  else if
+    bysetpos <> []
+    && list_of b.b_bysecond = []
+    && list_of b.b_byminute = []
+    && list_of b.b_byhour = []
+    && byday = []
+    && bymonthday = []
+    && byyearday = []
+    && byweekno = []
+    && list_of b.b_bymonth = []
+  then Error Bysetpos_without_byxxx
+  else
+    Ok
+      { freq
+      ; bound
+      ; interval = (match b.b_interval with Some n -> n | None -> 1)
+      ; bysecond = list_of b.b_bysecond
+      ; byminute = list_of b.b_byminute
+      ; byhour = list_of b.b_byhour
+      ; byday
+      ; bymonthday
+      ; byyearday
+      ; byweekno
+      ; bymonth = list_of b.b_bymonth
+      ; bysetpos
+      ; wkst = (match b.b_wkst with Some day -> day | None -> Monday)
+      }
+
+let assemble (b : builder) : (t, parse_error) result =
+  match b.b_freq with
+  | None -> Error Missing_freq
+  | Some freq -> (
+    match b.b_until, b.b_count with
+    | Some _, Some _ -> Error Until_count_conflict
+    | Some until, None -> assemble_with_bound freq b (Until until)
+    | None, Some count -> assemble_with_bound freq b (Count count)
+    | None, None -> assemble_with_bound freq b Forever)
+
+let parse value =
+  let parts = String.split_on_char ';' value in
+  let rec loop builder = function
+    | [] -> assemble builder
+    | part :: rest -> (
+      if String.length part = 0 then Error Empty_part
+      else
+        match String.index_opt part '=' with
+        | None -> Error (Missing_equals part)
+        | Some eq ->
+          let name = String.uppercase_ascii (String.sub part 0 eq) in
+          let raw_value =
+            String.sub part (eq + 1) (String.length part - eq - 1)
+          in
+          (match apply_part builder name raw_value with
+           | Error _ as error -> error
+           | Ok builder -> loop builder rest))
+  in
+  loop empty_builder parts
+
+(* ---------------------------------------------------------------- *)
+(* Canonical serialization                                          *)
+(* ---------------------------------------------------------------- *)
+
+let date_to_string { year; month; day } =
+  Printf.sprintf "%04d%02d%02d" year month day
+
+let time_to_string { hour; minute; second } =
+  Printf.sprintf "%02d%02d%02d" hour minute second
+
+let until_to_string = function
+  | Until_date d -> date_to_string d
+  | Until_local (d, t) -> date_to_string d ^ "T" ^ time_to_string t
+  | Until_utc (d, t) -> date_to_string d ^ "T" ^ time_to_string t ^ "Z"
+
+let int_list_to_string values = String.concat "," (List.map string_of_int values)
+
+let weekday_num_to_string { ordinal; day } =
+  match ordinal with
+  | None -> weekday_to_string day
+  | Some n -> string_of_int n ^ weekday_to_string day
+
+let to_string t =
+  let parts = ref [ "FREQ=" ^ freq_to_string t.freq ] in
+  (match t.bound with
+   | Forever -> ()
+   | Count n -> parts := !parts @ [ "COUNT=" ^ string_of_int n ]
+   | Until until -> parts := !parts @ [ "UNTIL=" ^ until_to_string until ]);
+  parts := !parts @ [ "INTERVAL=" ^ string_of_int t.interval ];
+  if t.bysecond <> [] then
+    parts := !parts @ [ "BYSECOND=" ^ int_list_to_string t.bysecond ];
+  if t.byminute <> [] then
+    parts := !parts @ [ "BYMINUTE=" ^ int_list_to_string t.byminute ];
+  if t.byhour <> [] then
+    parts := !parts @ [ "BYHOUR=" ^ int_list_to_string t.byhour ];
+  if t.byday <> [] then
+    parts :=
+      !parts @ [ "BYDAY=" ^ String.concat "," (List.map weekday_num_to_string t.byday) ];
+  if t.bymonthday <> [] then
+    parts := !parts @ [ "BYMONTHDAY=" ^ int_list_to_string t.bymonthday ];
+  if t.byyearday <> [] then
+    parts := !parts @ [ "BYYEARDAY=" ^ int_list_to_string t.byyearday ];
+  if t.byweekno <> [] then
+    parts := !parts @ [ "BYWEEKNO=" ^ int_list_to_string t.byweekno ];
+  if t.bymonth <> [] then
+    parts := !parts @ [ "BYMONTH=" ^ int_list_to_string t.bymonth ];
+  if t.bysetpos <> [] then
+    parts := !parts @ [ "BYSETPOS=" ^ int_list_to_string t.bysetpos ];
+  parts := !parts @ [ "WKST=" ^ weekday_to_string t.wkst ];
+  String.concat ";" !parts
+
+(* ---------------------------------------------------------------- *)
+(* Diagnostics                                                      *)
+(* ---------------------------------------------------------------- *)
+
+let parse_error_to_string = function
+  | Empty_part -> "empty rule part (a ;; run or leading/trailing ;)"
+  | Missing_equals part -> Printf.sprintf "rule part %S has no = separator" part
+  | Unknown_part name -> Printf.sprintf "unknown rule part %S" name
+  | Duplicate_part name -> Printf.sprintf "duplicate rule part %S" name
+  | Missing_freq -> "FREQ rule part is required"
+  | Invalid_freq value -> Printf.sprintf "invalid FREQ value %S" value
+  | Invalid_number { part; value } ->
+    Printf.sprintf "%s: invalid number %S" part value
+  | Out_of_range { part; value; min; max } ->
+    Printf.sprintf "%s: value %d out of range %d..%d" part value min max
+  | Invalid_date value -> Printf.sprintf "invalid date %S" value
+  | Invalid_time value -> Printf.sprintf "invalid time %S" value
+  | Invalid_until value -> Printf.sprintf "invalid UNTIL value %S" value
+  | Invalid_weekday value -> Printf.sprintf "invalid weekday %S" value
+  | Until_count_conflict -> "UNTIL and COUNT must not occur in the same recur"
+  | Numeric_byday_not_allowed freq ->
+    Printf.sprintf
+      "numeric BYDAY is only allowed with FREQ=MONTHLY or FREQ=YEARLY (got %s)"
+      (freq_to_string freq)
+  | Numeric_byday_with_byweekno ->
+    "numeric BYDAY with FREQ=YEARLY forbids BYWEEKNO"
+  | Bymonthday_with_weekly -> "BYMONTHDAY is not allowed with FREQ=WEEKLY"
+  | Byyearday_not_allowed freq ->
+    Printf.sprintf "BYYEARDAY is not allowed with FREQ=%s"
+      (freq_to_string freq)
+  | Byweekno_not_allowed freq ->
+    Printf.sprintf "BYWEEKNO is only allowed with FREQ=YEARLY (got %s)"
+      (freq_to_string freq)
+  | Bysetpos_without_byxxx -> "BYSETPOS requires another BYxxx rule part"

--- a/lib/schedule/schedule_ical_recur.mli
+++ b/lib/schedule/schedule_ical_recur.mli
@@ -1,0 +1,114 @@
+(** Schedule_ical_recur — RFC 5545 §3.3.10 RECUR value type.
+
+    Typed parser and canonical serializer for the iCalendar recurrence rule
+    value (the value of the [RRULE] property). Pure: no I/O, no evaluation
+    engine. This is the first leaf of the RFC 5545 adapter tracked by issue
+    #24553; occurrence expansion, [RDATE]/[EXDATE], [DTSTART] consistency
+    (e.g. UNTIL value-type agreement), and [VTIMEZONE]/[TZID] resolution are
+    later leaves that build on this type.
+
+    Exactness stance (no silent coercion, matching the repo's fail-closed
+    policy):
+    - Every grammar rule of §3.3.10 is enforced: unknown/duplicate parts,
+      missing [FREQ], [UNTIL]+[COUNT] conflict, per-part numeric ranges, and
+      the [FREQ]-dependent [BYxxx] restrictions are all typed parse errors.
+    - Case-insensitivity follows the RFC: part names and enumerated values
+      ([FREQ], weekdays) are case-insensitive; nothing else is normalized.
+    - The parser is total: any input string yields a typed result, never an
+      exception. *)
+
+type freq = Secondly | Minutely | Hourly | Daily | Weekly | Monthly | Yearly
+
+type weekday =
+  | Sunday | Monday | Tuesday | Wednesday | Thursday | Friday | Saturday
+
+(** A [BYDAY] element. [ordinal] is the signed nth-occurrence prefix
+    ([[+/-]ordwk] in the grammar, range -53..-1 or 1..53); [None] means the
+    bare weekday form. *)
+type weekday_num = private { ordinal : int option; day : weekday }
+
+(** Proleptic Gregorian calendar date, validated (month 1-12, day within the
+    month including the leap-year rule). *)
+type date = private { year : int; month : int; day : int }
+
+(** Time of day. [second] admits 0-60 so a leap second is representable
+    (§3.3.12 [time-second]). *)
+type time_of_day = private { hour : int; minute : int; second : int }
+
+(** The [UNTIL] bound in its three wire forms. Which form is legal depends on
+    the companion [DTSTART] value type (§3.3.10); that cross-property check is
+    the VEVENT layer's job, not this module's. *)
+type until = private
+  | Until_date of date
+  | Until_local of date * time_of_day
+  | Until_utc of date * time_of_day
+
+(** Recurrence bound: [UNTIL] and [COUNT] are mutually exclusive (§3.3.10). *)
+type bound = private
+  | Forever
+  | Count of int  (** >= 1 *)
+  | Until of until
+
+(** A validated RECUR value. All lists preserve wire order; an empty list
+    means the part was absent (the RFC assigns no default to any [BYxxx]
+    part). [interval] defaults to 1 and [wkst] to [Monday] per the RFC.
+
+    The validation-sensitive types above and [t] itself are [private]:
+    external code can read and pattern-match but cannot construct. The only
+    producer is {!parse}, so every constructible [t] satisfies the documented
+    invariants — and {!to_string} therefore never has to re-validate, which is
+    what makes the [parse (to_string t) = Ok t] contract total. *)
+type t = private
+  { freq : freq
+  ; bound : bound
+  ; interval : int  (** >= 1 *)
+  ; bysecond : int list  (** each 0-60 *)
+  ; byminute : int list  (** each 0-59 *)
+  ; byhour : int list  (** each 0-23 *)
+  ; byday : weekday_num list
+  ; bymonthday : int list  (** each -31..-1 or 1..31 *)
+  ; byyearday : int list  (** each -366..-1 or 1..366 *)
+  ; byweekno : int list  (** each -53..-1 or 1..53 *)
+  ; bymonth : int list  (** each 1-12 *)
+  ; bysetpos : int list  (** each -366..-1 or 1..366 *)
+  ; wkst : weekday
+  }
+
+(** Closed sum of every rejection the parser can produce. Carries the
+    offending part name or value so diagnostics are exact, not positional. *)
+type parse_error =
+  | Empty_part  (** A [;;] run or a leading/trailing [;]. *)
+  | Missing_equals of string  (** A part with no [=] separator. *)
+  | Unknown_part of string
+  | Duplicate_part of string
+  | Missing_freq
+  | Invalid_freq of string
+  | Invalid_number of { part : string; value : string }
+  | Out_of_range of { part : string; value : int; min : int; max : int }
+  | Invalid_date of string
+  | Invalid_time of string
+  | Invalid_until of string
+  | Invalid_weekday of string
+  | Until_count_conflict
+  | Numeric_byday_not_allowed of freq
+      (** Numeric [BYDAY] requires [FREQ=MONTHLY] or [FREQ=YEARLY]. *)
+  | Numeric_byday_with_byweekno
+      (** Numeric [BYDAY] with [FREQ=YEARLY] forbids [BYWEEKNO]. *)
+  | Bymonthday_with_weekly  (** [BYMONTHDAY] forbids [FREQ=WEEKLY]. *)
+  | Byyearday_not_allowed of freq
+      (** [BYYEARDAY] forbids [FREQ=DAILY|WEEKLY|MONTHLY]. *)
+  | Byweekno_not_allowed of freq  (** [BYWEEKNO] requires [FREQ=YEARLY]. *)
+  | Bysetpos_without_byxxx  (** [BYSETPOS] requires another [BYxxx] part. *)
+
+val parse : string -> (t, parse_error) result
+(** Parse one RECUR value (the text after [RRULE:]). Total. *)
+
+val to_string : t -> string
+(** Canonical serialization: [FREQ] first (RFC-required for backward
+    compatibility), then the bound, [INTERVAL], the [BYxxx] parts in grammar
+    order, and [WKST] last. Round-trips: [parse (to_string t) = Ok t]. *)
+
+val parse_error_to_string : parse_error -> string
+
+val freq_to_string : freq -> string
+val weekday_to_string : weekday -> string

--- a/test/dune
+++ b/test/dune
@@ -1306,6 +1306,11 @@
  (libraries alcotest yojson masc_schedule))
 
 (test
+ (name test_schedule_ical_recur)
+ (modules test_schedule_ical_recur)
+ (libraries alcotest masc_schedule))
+
+(test
  (name test_schedule_store)
  (modules test_schedule_store)
  (libraries

--- a/test/test_schedule_ical_recur.ml
+++ b/test/test_schedule_ical_recur.ml
@@ -1,0 +1,423 @@
+(* RFC 5545 §3.3.10 RECUR value tests for Schedule_ical_recur.
+
+   Pure parser/serializer tests: valid fixtures bind exact typed values,
+   malformed/semantic violations bind the exact typed error, and the
+   canonical serializer round-trips through the parser. *)
+
+open Alcotest
+module R = Schedule_ical_recur
+
+let parse_ok raw =
+  match R.parse raw with
+  | Ok t -> t
+  | Error e -> failf "parse %S rejected: %s" raw (R.parse_error_to_string e)
+
+let parse_error raw =
+  match R.parse raw with
+  | Ok _ -> failf "parse %S unexpectedly accepted" raw
+  | Error e -> e
+
+(* ---------------------------------------------------------------- *)
+(* Valid grammar                                                    *)
+(* ---------------------------------------------------------------- *)
+
+let test_freq_only_defaults () =
+  let t = parse_ok "FREQ=DAILY" in
+  check bool "freq" true (t.R.freq = R.Daily);
+  check int "interval default 1" 1 t.R.interval;
+  check bool "forever" true (match t.R.bound with R.Forever -> true | _ -> false);
+  check bool "wkst default MO" true (t.R.wkst = R.Monday);
+  check bool "by lists empty" true
+    (t.R.bysecond = [] && t.R.byminute = [] && t.R.byhour = []
+    && t.R.byday = [] && t.R.bymonthday = [] && t.R.byyearday = []
+    && t.R.byweekno = [] && t.R.bymonth = [] && t.R.bysetpos = [])
+
+let test_all_freqs_accepted () =
+  List.iter
+    (fun (raw, expected) ->
+      let t = parse_ok ("FREQ=" ^ raw) in
+      check bool raw true (t.R.freq = expected))
+    [ "SECONDLY", R.Secondly
+    ; "MINUTELY", R.Minutely
+    ; "HOURLY", R.Hourly
+    ; "DAILY", R.Daily
+    ; "WEEKLY", R.Weekly
+    ; "MONTHLY", R.Monthly
+    ; "YEARLY", R.Yearly
+    ]
+
+let test_parts_any_order () =
+  (* The RFC requires parsers to accept any part order. *)
+  let t = parse_ok "INTERVAL=2;COUNT=10;FREQ=WEEKLY;BYDAY=MO,WE" in
+  check int "interval" 2 t.R.interval;
+  check bool "count" true
+    (match t.R.bound with R.Count 10 -> true | _ -> false);
+  check bool "byday" true
+    (match t.R.byday with
+     | [ { R.ordinal = None; day = R.Monday }
+       ; { R.ordinal = None; day = R.Wednesday }
+       ] -> true
+     | _ -> false)
+
+let test_case_insensitive_names_and_enums () =
+  let t = parse_ok "freq=weekly;byday=mo,fr;wkst=su" in
+  check bool "freq" true (t.R.freq = R.Weekly);
+  check bool "wkst" true (t.R.wkst = R.Sunday)
+
+let test_numeric_byday_monthly () =
+  let t = parse_ok "FREQ=MONTHLY;BYDAY=1MO,-1FR" in
+  check bool "ordinals" true
+    (match t.R.byday with
+     | [ { R.ordinal = Some 1; day = R.Monday }
+       ; { R.ordinal = Some (-1); day = R.Friday }
+       ] -> true
+     | _ -> false)
+
+let test_until_utc () =
+  let t = parse_ok "FREQ=DAILY;UNTIL=19971102T020000Z" in
+  match t.R.bound with
+  | R.Until (R.Until_utc (d, tm)) ->
+    check bool "date" true
+      (d.R.year = 1997 && d.R.month = 11 && d.R.day = 2);
+    check bool "time" true
+      (tm.R.hour = 2 && tm.R.minute = 0 && tm.R.second = 0)
+  | _ -> fail "expected Until_utc"
+
+let test_until_date_and_local () =
+  let a = parse_ok "FREQ=DAILY;UNTIL=19971102" in
+  (match a.R.bound with
+   | R.Until (R.Until_date d) ->
+     check bool "date form" true
+       (d.R.year = 1997 && d.R.month = 11 && d.R.day = 2)
+   | _ -> fail "expected Until_date");
+  let b = parse_ok "FREQ=DAILY;UNTIL=19971102T020000" in
+  match b.R.bound with
+  | R.Until (R.Until_local (d, tm)) ->
+    check bool "local date" true
+      (d.R.year = 1997 && d.R.month = 11 && d.R.day = 2);
+    check bool "local time" true
+      (tm.R.hour = 2 && tm.R.minute = 0 && tm.R.second = 0)
+  | _ -> fail "expected Until_local"
+
+let test_full_example () =
+  (* RFC 5545 example: last work day of the month. *)
+  let t = parse_ok "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1" in
+  check bool "bysetpos" true (t.R.bysetpos = [ -1 ]);
+  check int "byday length" 5 (List.length t.R.byday)
+
+let test_signed_lists () =
+  let t =
+    parse_ok
+      "FREQ=YEARLY;BYWEEKNO=20,-1;BYMONTH=1,12;BYYEARDAY=1,-306;BYMONTHDAY=1,-31"
+  in
+  check bool "byweekno" true (t.R.byweekno = [ 20; -1 ]);
+  check bool "bymonth" true (t.R.bymonth = [ 1; 12 ]);
+  check bool "byyearday" true (t.R.byyearday = [ 1; -306 ]);
+  check bool "bymonthday" true (t.R.bymonthday = [ 1; -31 ])
+
+let test_leap_second_and_date () =
+  let t = parse_ok "FREQ=MINUTELY;BYSECOND=0,60;UNTIL=20240229T235960Z" in
+  check bool "bysecond 60 ok" true (t.R.bysecond = [ 0; 60 ]);
+  match t.R.bound with
+  | R.Until (R.Until_utc (d, tm)) ->
+    check bool "leap day ok" true
+      (d.R.year = 2024 && d.R.month = 2 && d.R.day = 29);
+    check bool "leap second ok" true
+      (tm.R.hour = 23 && tm.R.minute = 59 && tm.R.second = 60)
+  | _ -> fail "expected Until_utc"
+
+(* ---------------------------------------------------------------- *)
+(* Grammar violations                                               *)
+(* ---------------------------------------------------------------- *)
+
+let test_missing_freq () =
+  match parse_error "COUNT=3" with
+  | R.Missing_freq -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+let test_empty_input_and_parts () =
+  check bool "empty" true (R.parse "" = Error R.Empty_part);
+  check bool "double semicolon" true
+    (R.parse "FREQ=DAILY;;INTERVAL=2" = Error R.Empty_part);
+  check bool "trailing semicolon" true
+    (R.parse "FREQ=DAILY;" = Error R.Empty_part)
+
+let test_missing_equals () =
+  match parse_error "FREQ" with
+  | R.Missing_equals "FREQ" -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+let test_unknown_part () =
+  match parse_error "FREQ=DAILY;BYEPOCH=1" with
+  | R.Unknown_part "BYEPOCH" -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+let test_duplicate_part () =
+  match parse_error "FREQ=DAILY;FREQ=WEEKLY" with
+  | R.Duplicate_part "FREQ" -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+let test_invalid_freq () =
+  match parse_error "FREQ=FORTNIGHTLY" with
+  | R.Invalid_freq "FORTNIGHTLY" -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+let test_invalid_number () =
+  check bool "nondigit" true
+    (match R.parse "FREQ=DAILY;INTERVAL=x" with
+     | Error (R.Invalid_number { part = "INTERVAL"; _ }) -> true
+     | _ -> false);
+  check bool "signed count rejected" true
+    (match R.parse "FREQ=DAILY;COUNT=+3" with
+     | Error (R.Invalid_number { part = "COUNT"; _ }) -> true
+     | _ -> false);
+  check bool "empty list element" true
+    (match R.parse "FREQ=DAILY;BYMONTH=1,,2" with
+     | Error (R.Invalid_number { part = "BYMONTH"; _ }) -> true
+     | _ -> false)
+
+let test_out_of_range () =
+  let cases =
+    [ "FREQ=DAILY;BYHOUR=24", ("BYHOUR", 24, 0, 23)
+    ; "FREQ=DAILY;BYMINUTE=60", ("BYMINUTE", 60, 0, 59)
+    ; "FREQ=DAILY;BYSECOND=61", ("BYSECOND", 61, 0, 60)
+    ; "FREQ=DAILY;BYMONTH=13", ("BYMONTH", 13, 1, 12)
+    ; "FREQ=YEARLY;BYWEEKNO=54", ("BYWEEKNO", 54, -53, 53)
+    ; "FREQ=DAILY;BYMONTHDAY=32", ("BYMONTHDAY", 32, -31, 31)
+    ; "FREQ=YEARLY;BYYEARDAY=367", ("BYYEARDAY", 367, -366, 366)
+    ; "FREQ=MONTHLY;BYDAY=54MO", ("BYDAY", 54, -53, 53)
+    ; "FREQ=DAILY;INTERVAL=0", ("INTERVAL", 0, 1, max_int)
+    ; "FREQ=DAILY;COUNT=0", ("COUNT", 0, 1, max_int)
+    ]
+  in
+  List.iter
+    (fun (raw, (part, value, min, max)) ->
+      match R.parse raw with
+      | Error (R.Out_of_range got) ->
+        check string "part" part got.part;
+        check int "value" value got.value;
+        check int "min" min got.min;
+        check int "max" max got.max
+      | _ -> failf "parse %S: expected Out_of_range" raw)
+    cases
+
+let test_zero_in_signed_lists () =
+  check bool "byday 0" true
+    (R.parse "FREQ=MONTHLY;BYDAY=0MO"
+    = Error (R.Out_of_range { part = "BYDAY"; value = 0; min = -53; max = 53 }));
+  check bool "bysetpos 0" true
+    (match R.parse "FREQ=MONTHLY;BYDAY=MO;BYSETPOS=0" with
+     | Error (R.Out_of_range { part = "BYSETPOS"; value = 0; _ }) -> true
+     | _ -> false)
+
+let test_grammar_digit_caps () =
+  (* Bounded numeric parts carry ABNF digit caps (1*2DIGIT / 1*3DIGIT);
+     excess digits are a grammar violation, not a value to normalize. *)
+  let rejected =
+    [ "FREQ=MONTHLY;BYDAY=001MO", "BYDAY"
+    ; "FREQ=DAILY;BYSECOND=001", "BYSECOND"
+    ; "FREQ=DAILY;BYMINUTE=007", "BYMINUTE"
+    ; "FREQ=DAILY;BYHOUR=009", "BYHOUR"
+    ; "FREQ=DAILY;BYMONTH=013", "BYMONTH"
+    ; "FREQ=DAILY;BYMONTHDAY=015", "BYMONTHDAY"
+    ; "FREQ=YEARLY;BYWEEKNO=020", "BYWEEKNO"
+    ; "FREQ=YEARLY;BYYEARDAY=0001", "BYYEARDAY"
+    ; "FREQ=MONTHLY;BYDAY=MO;BYSETPOS=0001", "BYSETPOS"
+    ]
+  in
+  List.iter
+    (fun (raw, part) ->
+      match R.parse raw with
+      | Error (R.Invalid_number got) ->
+        check string "part" part got.part
+      | _ -> failf "parse %S: expected Invalid_number" raw)
+    rejected;
+  (* COUNT and INTERVAL are 1*DIGIT (uncapped): leading zeros are legal. *)
+  (match R.parse "FREQ=DAILY;COUNT=000003" with
+   | Ok t ->
+     check bool "count leading zeros" true
+       (match t.R.bound with R.Count 3 -> true | _ -> false)
+   | Error e -> failf "COUNT leading zeros rejected: %s"
+       (R.parse_error_to_string e));
+  match R.parse "FREQ=DAILY;INTERVAL=007" with
+  | Ok t -> check int "interval leading zeros" 7 t.R.interval
+  | Error e -> failf "INTERVAL leading zeros rejected: %s"
+      (R.parse_error_to_string e)
+
+let test_invalid_dates () =
+  check bool "feb 30" true
+    (R.parse "FREQ=DAILY;UNTIL=20260230"
+    = Error (R.Invalid_until "20260230"));
+  check bool "month 13" true
+    (R.parse "FREQ=DAILY;UNTIL=20261301"
+    = Error (R.Invalid_until "20261301"));
+  check bool "non-leap feb 29" true
+    (R.parse "FREQ=DAILY;UNTIL=20260229"
+    = Error (R.Invalid_until "20260229"));
+  check bool "leap feb 29 ok" true
+    (match R.parse "FREQ=DAILY;UNTIL=20280229" with
+     | Ok _ -> true
+     | Error _ -> false)
+
+let test_invalid_until_shape () =
+  check bool "garbage" true
+    (match R.parse "FREQ=DAILY;UNTIL=tomorrow" with
+     | Error (R.Invalid_until _) -> true
+     | _ -> false);
+  check bool "offset form forbidden" true
+    (match R.parse "FREQ=DAILY;UNTIL=19980119T230000-0800" with
+     | Error (R.Invalid_until _) -> true
+     | _ -> false)
+
+let test_invalid_weekday () =
+  match parse_error "FREQ=WEEKLY;BYDAY=XX" with
+  | R.Invalid_weekday "XX" -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+(* ---------------------------------------------------------------- *)
+(* Semantic (cross-part) violations                                 *)
+(* ---------------------------------------------------------------- *)
+
+let test_until_count_conflict () =
+  match parse_error "FREQ=DAILY;UNTIL=19971102T020000Z;COUNT=3" with
+  | R.Until_count_conflict -> ()
+  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+
+let test_numeric_byday_freq_rule () =
+  check bool "daily rejected" true
+    (R.parse "FREQ=DAILY;BYDAY=1MO"
+    = Error (R.Numeric_byday_not_allowed R.Daily));
+  check bool "weekly rejected" true
+    (R.parse "FREQ=WEEKLY;BYDAY=1MO"
+    = Error (R.Numeric_byday_not_allowed R.Weekly));
+  check bool "monthly ok" true
+    (match R.parse "FREQ=MONTHLY;BYDAY=1MO" with
+     | Ok _ -> true
+     | Error _ -> false);
+  check bool "yearly ok" true
+    (match R.parse "FREQ=YEARLY;BYDAY=20MO" with
+     | Ok _ -> true
+     | Error _ -> false)
+
+let test_numeric_byday_with_byweekno () =
+  check bool "yearly+byweekno rejected" true
+    (R.parse "FREQ=YEARLY;BYDAY=1MO;BYWEEKNO=20"
+    = Error R.Numeric_byday_with_byweekno)
+
+let test_bymonthday_weekly () =
+  check bool "weekly rejected" true
+    (R.parse "FREQ=WEEKLY;BYMONTHDAY=15" = Error R.Bymonthday_with_weekly)
+
+let test_byyearday_freq_rule () =
+  List.iter
+    (fun (raw_freq, expected) ->
+      check bool raw_freq true
+        (R.parse (Printf.sprintf "FREQ=%s;BYYEARDAY=100" raw_freq)
+        = Error (R.Byyearday_not_allowed expected)))
+    [ "DAILY", R.Daily; "WEEKLY", R.Weekly; "MONTHLY", R.Monthly ];
+  check bool "yearly ok" true
+    (match R.parse "FREQ=YEARLY;BYYEARDAY=100" with
+     | Ok _ -> true
+     | Error _ -> false)
+
+let test_byweekno_freq_rule () =
+  check bool "monthly rejected" true
+    (R.parse "FREQ=MONTHLY;BYWEEKNO=20"
+    = Error (R.Byweekno_not_allowed R.Monthly))
+
+let test_bysetpos_requires_byxxx () =
+  check bool "alone rejected" true
+    (R.parse "FREQ=MONTHLY;BYSETPOS=-1" = Error R.Bysetpos_without_byxxx);
+  check bool "with bymonth ok" true
+    (match R.parse "FREQ=YEARLY;BYMONTH=6,7;BYSETPOS=1" with
+     | Ok _ -> true
+     | Error _ -> false)
+
+(* ---------------------------------------------------------------- *)
+(* Canonical serialization round-trip                               *)
+(* ---------------------------------------------------------------- *)
+
+let test_round_trip () =
+  let fixtures =
+    [ "FREQ=DAILY"
+    ; "FREQ=SECONDLY;INTERVAL=90"
+    ; "FREQ=WEEKLY;BYDAY=MO,WE,FR;WKST=SU;COUNT=10"
+    ; "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1"
+    ; "FREQ=MONTHLY;BYDAY=1MO,-1FR;BYMONTH=3,6,9,12"
+    ; "FREQ=YEARLY;BYWEEKNO=20;BYDAY=MO;BYMONTH=5"
+    ; "FREQ=YEARLY;BYYEARDAY=1,100,-1;BYHOUR=9,18;BYMINUTE=30;BYSECOND=0"
+    ; "FREQ=DAILY;UNTIL=19971102T020000Z"
+    ; "FREQ=DAILY;UNTIL=19971102"
+    ; "FREQ=DAILY;UNTIL=19971102T020000"
+    ; "FREQ=HOURLY;INTERVAL=3;UNTIL=20280229T000000Z"
+    ; "FREQ=YEARLY;BYMONTHDAY=1,-31;BYMONTH=2"
+    ]
+  in
+  List.iter
+    (fun raw ->
+      let t = parse_ok raw in
+      let rendered = R.to_string t in
+      match R.parse rendered with
+      | Ok t2 ->
+        check bool (Printf.sprintf "round-trip %S" raw) true (t = t2)
+      | Error e ->
+        failf "re-parse of %S failed: %s" rendered
+          (R.parse_error_to_string e))
+    fixtures
+
+let test_canonical_order () =
+  (* FREQ first regardless of input order (RFC backward-compat rule). *)
+  let t = parse_ok "COUNT=5;BYDAY=TU;FREQ=WEEKLY" in
+  check string "canonical" "FREQ=WEEKLY;COUNT=5;INTERVAL=1;BYDAY=TU;WKST=MO"
+    (R.to_string t)
+
+(* ---------------------------------------------------------------- *)
+
+let () =
+  run "Schedule_ical_recur"
+    [ "valid"
+      , [ test_case "freq only defaults" `Quick test_freq_only_defaults
+        ; test_case "all freqs accepted" `Quick test_all_freqs_accepted
+        ; test_case "parts any order" `Quick test_parts_any_order
+        ; test_case "case insensitive" `Quick
+            test_case_insensitive_names_and_enums
+        ; test_case "numeric byday monthly" `Quick test_numeric_byday_monthly
+        ; test_case "until utc" `Quick test_until_utc
+        ; test_case "until date and local" `Quick test_until_date_and_local
+        ; test_case "full example" `Quick test_full_example
+        ; test_case "signed lists" `Quick test_signed_lists
+        ; test_case "leap second and date" `Quick test_leap_second_and_date
+        ]
+    ; "grammar violations"
+      , [ test_case "missing freq" `Quick test_missing_freq
+        ; test_case "empty input and parts" `Quick
+            test_empty_input_and_parts
+        ; test_case "missing equals" `Quick test_missing_equals
+        ; test_case "unknown part" `Quick test_unknown_part
+        ; test_case "duplicate part" `Quick test_duplicate_part
+        ; test_case "invalid freq" `Quick test_invalid_freq
+        ; test_case "invalid number" `Quick test_invalid_number
+        ; test_case "out of range" `Quick test_out_of_range
+        ; test_case "zero in signed lists" `Quick test_zero_in_signed_lists
+        ; test_case "grammar digit caps" `Quick test_grammar_digit_caps
+        ; test_case "invalid dates" `Quick test_invalid_dates
+        ; test_case "invalid until shape" `Quick test_invalid_until_shape
+        ; test_case "invalid weekday" `Quick test_invalid_weekday
+        ]
+    ; "semantic violations"
+      , [ test_case "until+count conflict" `Quick test_until_count_conflict
+        ; test_case "numeric byday freq rule" `Quick
+            test_numeric_byday_freq_rule
+        ; test_case "numeric byday + byweekno" `Quick
+            test_numeric_byday_with_byweekno
+        ; test_case "bymonthday weekly" `Quick test_bymonthday_weekly
+        ; test_case "byyearday freq rule" `Quick test_byyearday_freq_rule
+        ; test_case "byweekno freq rule" `Quick test_byweekno_freq_rule
+        ; test_case "bysetpos requires byxxx" `Quick
+            test_bysetpos_requires_byxxx
+        ]
+    ; "serialization"
+      , [ test_case "round trip" `Quick test_round_trip
+        ; test_case "canonical order" `Quick test_canonical_order
+        ]
+    ]

--- a/test/test_schedule_ical_recur.ml
+++ b/test/test_schedule_ical_recur.ml
@@ -153,9 +153,12 @@ let test_unknown_part () =
   | e -> failf "wrong error: %s" (R.parse_error_to_string e)
 
 let test_duplicate_part () =
-  match parse_error "FREQ=DAILY;FREQ=WEEKLY" with
-  | R.Duplicate_part "FREQ" -> ()
-  | e -> failf "wrong error: %s" (R.parse_error_to_string e)
+  List.iter
+    (fun raw ->
+      match parse_error raw with
+      | R.Duplicate_part "FREQ" -> ()
+      | e -> failf "parse %S: wrong error: %s" raw (R.parse_error_to_string e))
+    [ "FREQ=DAILY;FREQ=WEEKLY"; "FREQ=DAILY;FREQ=BOGUS" ]
 
 let test_invalid_freq () =
   match parse_error "FREQ=FORTNIGHTLY" with
@@ -247,13 +250,13 @@ let test_grammar_digit_caps () =
 let test_invalid_dates () =
   check bool "feb 30" true
     (R.parse "FREQ=DAILY;UNTIL=20260230"
-    = Error (R.Invalid_until "20260230"));
+    = Error (R.Invalid_date "20260230"));
   check bool "month 13" true
     (R.parse "FREQ=DAILY;UNTIL=20261301"
-    = Error (R.Invalid_until "20261301"));
+    = Error (R.Invalid_date "20261301"));
   check bool "non-leap feb 29" true
     (R.parse "FREQ=DAILY;UNTIL=20260229"
-    = Error (R.Invalid_until "20260229"));
+    = Error (R.Invalid_date "20260229"));
   check bool "leap feb 29 ok" true
     (match R.parse "FREQ=DAILY;UNTIL=20280229" with
      | Ok _ -> true
@@ -262,12 +265,15 @@ let test_invalid_dates () =
 let test_invalid_until_shape () =
   check bool "garbage" true
     (match R.parse "FREQ=DAILY;UNTIL=tomorrow" with
-     | Error (R.Invalid_until _) -> true
+     | Error (R.Invalid_date "tomorrow") -> true
      | _ -> false);
   check bool "offset form forbidden" true
     (match R.parse "FREQ=DAILY;UNTIL=19980119T230000-0800" with
      | Error (R.Invalid_until _) -> true
-     | _ -> false)
+     | _ -> false);
+  check bool "invalid time remains typed" true
+    (R.parse "FREQ=DAILY;UNTIL=19980119T246000"
+    = Error (R.Invalid_time "246000"))
 
 let test_invalid_weekday () =
   match parse_error "FREQ=WEEKLY;BYDAY=XX" with


### PR DESCRIPTION
## 무엇을 바꾸나

issue #24553의 iCalendar adapter 첫 leaf입니다. `Schedule_ical_recur`는 RFC 5545 §3.3.10 RECUR 값의 순수·total parser와 canonical serializer를 제공합니다. I/O, occurrence expansion, timezone policy는 포함하지 않습니다.

## 계약

- unknown/duplicate/missing part, missing `=`, empty part, missing FREQ를 typed `parse_error`로 거부
- duplicate part는 value parsing보다 먼저 판정하므로 `FREQ=DAILY;FREQ=BOGUS`도 정확히 `Duplicate_part "FREQ"`
- numeric ranges와 ABNF digit cap을 exact하게 강제하고 `001MO` 같은 silent normalization을 거부
- `UNTIL`의 invalid date/time/shape를 `Invalid_date` / `Invalid_time` / `Invalid_until`로 보존
- UNTIL+COUNT, numeric BYDAY, BYMONTHDAY/BYYEARDAY/BYWEEKNO/BYSETPOS cross-part constraints를 typed error로 거부
- validation-sensitive 공개 타입은 `private`; 외부는 읽기와 pattern match만 가능하고 invalid state를 구성할 수 없음
- `to_string`은 FREQ-first canonical order이며 `parse (to_string t) = Ok t`

## 범위 경계

후속 leaf가 content-line, VEVENT identity, DTSTART/UNTIL value-type consistency, RDATE/EXDATE, VTIMEZONE/TZID, occurrence expansion을 담당합니다. 이 leaf는 scheduler policy나 heuristic을 추가하지 않습니다.

## 현재 검증

- latest `origin/main` `d8f071c9a8` 위로 재베이스
- exact head `97fac51fb8ddfb623b11710124d4cf7101ca4c95`
- `scripts/dune-local.sh build test/test_schedule_ical_recur.exe` PASS
- `test_schedule_ical_recur` 32/32 PASS
- `ocamlformat --check` PASS
- `git diff --check origin/main...HEAD` PASS

## 관련

- issue #24553
- RFC 5545 §3.3.10