### PR TITLE
feat(fusion): isolate durable run authority

### DIFF
--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -10,6 +10,6 @@
  (name masc_fusion_core)
  (public_name masc.fusion_core)
  (wrapped false)
- (libraries fs_compat masc_log yojson otoml)
+ (libraries digestif fs_compat masc_log unix yojson otoml)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -1,0 +1,200 @@
+type identity =
+  { keeper : string
+  ; run_id : string
+  }
+[@@deriving yojson, show, eq]
+type registration =
+  { identity : identity
+  ; preset : string
+  ; started_at : float
+  }
+[@@deriving yojson, show, eq]
+type terminal =
+  | Succeeded of string
+  | Failed of
+      { code : string
+      ; detail : string
+      }
+  | Cancelled of string
+[@@deriving yojson, show, eq]
+type error =
+  | Empty_keeper
+  | Empty_run_id
+  | Invalid_started_at of float
+  | Empty_success_answer
+  | Empty_failure_code
+  | Empty_failure_detail
+  | Empty_cancellation_detail
+  | Partial_tail
+  | Unsupported_schema_version of { line : int; found : int }
+  | Invalid_record of
+      { line : int
+      ; detail : string
+      }
+  | Orphan_terminal
+  | Reversed_records
+  | Unexpected_sequence of int
+  | Identity_mismatch of identity
+  | Registration_conflict of registration
+  | Durable_append_failed of Fs_compat.durable_append_error
+type register_outcome =
+  | Registered
+  | Already_running
+  | Already_settled of terminal
+type claim_outcome =
+  | First_committed
+  | Already_same
+  | Conflict of terminal
+type terminal_record =
+  { identity : identity
+  ; terminal : terminal
+  }
+[@@deriving yojson]
+type persisted_event =
+  | Run_registered of registration
+  | Terminal_committed of terminal_record
+[@@deriving yojson]
+type persisted_record =
+  { schema_version : int
+  ; event : persisted_event
+  }
+[@@deriving yojson]
+type persisted_state =
+  | Empty
+  | Running of registration
+  | Settled of registration * terminal
+type t = { root : string }
+let create ~directory = { root = directory }
+let identity_key identity =
+  Printf.sprintf
+    "%d:%s%d:%s"
+    (String.length identity.keeper)
+    identity.keeper
+    (String.length identity.run_id)
+    identity.run_id
+;;
+let run_file t ~keeper ~run_id =
+  let identity = { keeper; run_id } in
+  let digest = Digestif.SHA256.(digest_string (identity_key identity) |> to_hex) in
+  Filename.concat t.root (digest ^ ".jsonl")
+;;
+let validate_identity = function
+  | { keeper = ""; _ } -> Error Empty_keeper
+  | { run_id = ""; _ } -> Error Empty_run_id
+  | _ -> Ok ()
+;;
+let validate_terminal = function
+  | Succeeded "" -> Error Empty_success_answer
+  | Succeeded _ -> Ok ()
+  | Failed { code = ""; _ } -> Error Empty_failure_code
+  | Failed { detail = ""; _ } -> Error Empty_failure_detail
+  | Failed _ -> Ok ()
+  | Cancelled "" -> Error Empty_cancellation_detail
+  | Cancelled _ -> Ok ()
+;;
+let schema_version = 1
+let event_line event =
+  Yojson.Safe.to_string (persisted_record_to_yojson { schema_version; event }) ^ "\n"
+;;
+let parse_events content =
+  if String.equal content ""
+  then Ok []
+  else if not (Char.equal content.[String.length content - 1] '\n')
+  then Error Partial_tail
+  else
+    let body = String.sub content 0 (String.length content - 1) in
+    let lines = String.split_on_char '\n' body in
+    let rec parse line_number acc = function
+      | [] -> Ok (List.rev acc)
+      | line :: rest ->
+        let parsed =
+          try
+            Yojson.Safe.from_string line
+            |> persisted_record_of_yojson
+            |> Result.map_error (fun detail -> Invalid_record { line = line_number; detail })
+            |> Result.bind (fun record ->
+              if Int.equal record.schema_version schema_version
+              then Ok record.event
+              else
+                Error
+                  (Unsupported_schema_version
+                     { line = line_number; found = record.schema_version }))
+          with
+          | Yojson.Json_error detail -> Error (Invalid_record { line = line_number; detail })
+        in
+        Result.bind parsed (fun event -> parse (line_number + 1) (event :: acc) rest)
+    in
+    parse 1 [] lines
+;;
+let check_identity expected actual =
+  if equal_identity expected actual then Ok () else Error (Identity_mismatch actual)
+;;
+let state_of_content expected content =
+  let ( let* ) = Result.bind in
+  let* events = parse_events content in
+  match events with
+  | [] -> Ok Empty
+  | [ Run_registered registration ] ->
+    let* () = check_identity expected registration.identity in
+    Ok (Running registration)
+  | [ Run_registered registration; Terminal_committed terminal_record ] ->
+    let* () = check_identity expected registration.identity in
+    let* () = check_identity expected terminal_record.identity in
+    let* () = validate_terminal terminal_record.terminal in
+    Ok (Settled (registration, terminal_record.terminal))
+  | [ Terminal_committed terminal_record ] ->
+    let* () = check_identity expected terminal_record.identity in
+    Error Orphan_terminal
+  | [ Terminal_committed terminal_record; Run_registered registration ] ->
+    let* () = check_identity expected terminal_record.identity in
+    let* () = check_identity expected registration.identity in
+    Error Reversed_records
+  | events -> Error (Unexpected_sequence (List.length events))
+;;
+let transact path decide =
+  match Fs_compat.update_private_file_durable_locked_result path decide with
+  | Ok result -> result
+  | Error error -> Error (Durable_append_failed error)
+;;
+let register t ~keeper ~run_id ~preset ~started_at =
+  if not (Float.is_finite started_at)
+  then Error (Invalid_started_at started_at)
+  else
+    let identity = { keeper; run_id } in
+    let requested = { identity; preset; started_at } in
+    match validate_identity identity with
+    | Error error -> Error error
+    | Ok () ->
+      transact (run_file t ~keeper ~run_id) (fun content ->
+        match state_of_content identity content with
+        | Error error -> None, Error error
+        | Ok Empty -> Some (event_line (Run_registered requested)), Ok Registered
+        | Ok (Running existing) ->
+          if equal_registration existing requested
+          then None, Ok Already_running
+          else None, Error (Registration_conflict existing)
+        | Ok (Settled (existing, terminal)) ->
+          if equal_registration existing requested
+          then None, Ok (Already_settled terminal)
+          else None, Error (Registration_conflict existing))
+;;
+let claim_terminal t ~keeper ~run_id terminal =
+  match validate_terminal terminal with
+  | Error error -> Error error
+  | Ok () ->
+    let identity = { keeper; run_id } in
+    (match validate_identity identity with
+     | Error error -> Error error
+     | Ok () ->
+       transact (run_file t ~keeper ~run_id) (fun content ->
+         match state_of_content identity content with
+         | Error error -> None, Error error
+         | Ok Empty -> None, Error Orphan_terminal
+         | Ok (Running _) ->
+           let record = { identity; terminal } in
+           Some (event_line (Terminal_committed record)), Ok First_committed
+         | Ok (Settled (_, winner)) ->
+           if equal_terminal winner terminal
+           then None, Ok Already_same
+           else None, Ok (Conflict winner)))
+;;

--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -109,10 +109,13 @@ let parse_events content =
       | line :: rest ->
         let parsed =
           try
-            Yojson.Safe.from_string line
-            |> persisted_record_of_yojson
-            |> Result.map_error (fun detail -> Invalid_record { line = line_number; detail })
-            |> Result.bind (fun record ->
+            let parsed =
+              Yojson.Safe.from_string line
+              |> persisted_record_of_yojson
+              |> Result.map_error (fun detail ->
+                Invalid_record { line = line_number; detail })
+            in
+            Result.bind parsed (fun record ->
               if Int.equal record.schema_version schema_version
               then Ok record.event
               else

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -1,0 +1,59 @@
+type t
+type identity =
+  { keeper : string
+  ; run_id : string
+  }
+type registration =
+  { identity : identity
+  ; preset : string
+  ; started_at : float
+  }
+type terminal =
+  | Succeeded of string
+  | Failed of
+      { code : string
+      ; detail : string
+      }
+  | Cancelled of string
+val equal_terminal : terminal -> terminal -> bool
+type error =
+  | Empty_keeper
+  | Empty_run_id
+  | Invalid_started_at of float
+  | Empty_success_answer
+  | Empty_failure_code
+  | Empty_failure_detail
+  | Empty_cancellation_detail
+  | Partial_tail
+  | Unsupported_schema_version of { line : int; found : int }
+  | Invalid_record of { line : int; detail : string }
+  | Orphan_terminal
+  | Reversed_records
+  | Unexpected_sequence of int
+  | Identity_mismatch of identity
+  | Registration_conflict of registration
+  | Durable_append_failed of Fs_compat.durable_append_error
+  | Read_failed of Fs_compat.owned_regular_file_read_error
+type register_outcome =
+  | Registered
+  | Already_running
+  | Already_settled of terminal
+type claim_outcome =
+  | First_committed
+  | Already_same
+  | Conflict of terminal
+(** [directory] is the exact store root resolved by the outer MASC path owner. *)
+val create : directory:string -> t
+val register
+  :  t
+  -> keeper:string
+  -> run_id:string
+  -> preset:string
+  -> started_at:float
+  -> (register_outcome, error) result
+val claim_terminal
+  :  t
+  -> keeper:string
+  -> run_id:string
+  -> terminal
+  -> (claim_outcome, error) result

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -33,7 +33,6 @@ type error =
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
-  | Read_failed of Fs_compat.owned_regular_file_read_error
 type register_outcome =
   | Registered
   | Already_running

--- a/test/dune
+++ b/test/dune
@@ -778,6 +778,11 @@
  (modules test_fusion_run_registry_persist)
  (libraries alcotest fs_compat yojson masc.fusion_core))
 
+(test
+ (name test_fusion_run_authority)
+ (modules test_fusion_run_authority)
+ (libraries alcotest digestif fs_compat masc.fusion_core unix yojson))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -1,0 +1,130 @@
+open Alcotest
+module A = Fusion_run_authority
+let fresh_base () =
+  let path = Filename.temp_file "fusion-authority-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  path
+;;
+let success answer = A.Succeeded answer
+let failure ~code detail = A.Failed { code; detail }
+let run_file directory keeper run_id =
+  let key = Printf.sprintf "%d:%s%d:%s" (String.length keeper) keeper (String.length run_id) run_id in
+  let digest = Digestif.SHA256.(digest_string key |> to_hex) in
+  Filename.concat directory (digest ^ ".jsonl")
+;;
+let test_exact_lifecycle_and_validation () =
+  let base_path = fresh_base () in
+  let store = A.create ~directory:(Filename.concat base_path "runs") in
+  (match A.register store ~keeper:"" ~run_id:"r" ~preset:"p" ~started_at:1. with
+   | Error A.Empty_keeper -> ()
+   | _ -> fail "empty keeper identity was accepted");
+  (match A.register store ~keeper:"k" ~run_id:"" ~preset:"p" ~started_at:1. with
+   | Error A.Empty_run_id -> ()
+   | _ -> fail "empty run identity was accepted");
+  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:Float.nan with
+   | Error (A.Invalid_started_at _) -> ()
+   | _ -> fail "non-finite start time was accepted");
+  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
+   | Ok A.Registered -> ()
+   | _ -> fail "first registration must be durable");
+  let restarted = A.create ~directory:(Filename.concat base_path "runs") in
+  (match A.register restarted ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
+   | Ok A.Already_running -> ()
+   | _ -> fail "exact registration retry must be idempotent");
+  let winner = success "answer" in
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"r" winner with
+   | Ok A.First_committed -> ()
+   | _ -> fail "first terminal must commit");
+  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
+   | Ok (A.Already_settled terminal) ->
+     check bool "settled retry returns winner" true (A.equal_terminal winner terminal)
+   | _ -> fail "settled registration retry could start another run");
+  (match A.claim_terminal restarted ~keeper:"k" ~run_id:"r" winner with
+   | Ok A.Already_same -> ()
+   | _ -> fail "restart must retain the winner");
+  (match
+     A.claim_terminal store ~keeper:"k" ~run_id:"r"
+       (failure ~code:"judge_failed" "detail")
+   with
+   | Ok (A.Conflict terminal) ->
+     check bool "conflict returns exact winner" true (A.equal_terminal winner terminal)
+   | _ -> fail "different terminal must conflict");
+  let reject terminal expected =
+    match A.claim_terminal store ~keeper:"k" ~run_id:"other" terminal, expected with
+    | Error A.Empty_success_answer, `Answer
+    | Error A.Empty_failure_code, `Code
+    | Error A.Empty_failure_detail, `Detail
+    | Error A.Empty_cancellation_detail, `Cancel -> ()
+    | _ -> fail "terminal validation returned the wrong result"
+  in
+  reject (success "") `Answer;
+  reject (failure ~code:"" "detail") `Code;
+  reject (failure ~code:"code" "") `Detail;
+  reject (A.Cancelled "") `Cancel;
+  match A.claim_terminal store ~keeper:"k" ~run_id:"missing" (A.Cancelled "shutdown") with
+  | Error A.Orphan_terminal -> ()
+  | _ -> fail "terminal without durable registration must be rejected"
+;;
+let test_corruption_is_per_run_and_semantic () =
+  let base_path = fresh_base () in
+  let directory = Filename.concat base_path "runs" in
+  let store = A.create ~directory in
+  let register run_id =
+    match A.register store ~keeper:"k" ~run_id ~preset:"p" ~started_at:1. with
+    | Ok A.Registered -> ()
+    | _ -> fail (run_id ^ " registration failed")
+  in
+  register "bad";
+  let bad_path = run_file directory "k" "bad" in
+  let registered = Fs_compat.load_file bad_path in
+  Fs_compat.save_file bad_path (String.sub registered 0 (String.length registered - 1));
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (success "answer") with
+   | Error A.Partial_tail -> ()
+   | _ -> fail "partial tail must fail explicitly");
+  register "peer";
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"peer" (success "peer answer") with
+   | Ok A.First_committed -> ()
+   | _ -> fail "corrupt peer must not block an unrelated run");
+  let versioned =
+    match Yojson.Safe.from_string registered with
+    | `Assoc fields -> `Assoc (("schema_version", `Int 2) :: List.remove_assoc "schema_version" fields)
+    | _ -> fail "registered record was not an object"
+  in
+  Fs_compat.save_file bad_path (Yojson.Safe.to_string versioned ^ "\n");
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (success "answer") with
+   | Error (A.Unsupported_schema_version { found = 2; _ }) -> ()
+   | _ -> fail "unsupported schema version must fail explicitly");
+  register "order";
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+   | Ok A.First_committed -> ()
+   | _ -> fail "ordered terminal did not commit");
+  let order_path = run_file directory "k" "order" in
+  (match String.split_on_char '\n' (Fs_compat.load_file order_path) with
+   | [ registration; terminal; "" ] ->
+     Fs_compat.save_file order_path (terminal ^ "\n");
+     (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+      | Error A.Orphan_terminal -> ()
+      | _ -> fail "orphan terminal must fail explicitly");
+     Fs_compat.save_file order_path (terminal ^ "\n" ^ registration ^ "\n");
+     (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+      | Error A.Reversed_records -> ()
+      | _ -> fail "reversed records must fail explicitly")
+   | _ -> fail "expected exact register/terminal JSONL pair");
+  let foreign_path = run_file directory "k" "foreign" in
+  Fs_compat.save_file foreign_path
+    (Fs_compat.load_file (run_file directory "k" "peer"));
+  match A.claim_terminal store ~keeper:"k" ~run_id:"foreign" (success "foreign") with
+  | Error (A.Identity_mismatch _) -> ()
+  | _ -> fail "hashed path must still verify persisted identity"
+;;
+let () =
+  run "fusion_run_authority"
+    [ ( "authority"
+      , [ test_case "exact lifecycle and validation" `Quick
+            test_exact_lifecycle_and_validation
+        ; test_case "per-run corruption and semantic validation" `Quick
+            test_corruption_is_per_run_and_semantic
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Outcome

Adds the core-only durable authority for one Fusion run. Production callsites are intentionally the next stack.

- per-run locked JSONL authority; malformed data is isolated to that run
- durable registration precedes terminal claim
- registration retry distinguishes Already_running from Already_settled winner, so a caller cannot treat both as permission to fork again
- first terminal wins; exact retry is idempotent; conflict returns the canonical winner
- terminal owns semantic evidence only; Board/chat/wake identifiers remain outer projection state
- persisted identity is revalidated after restart
- empty identity/evidence and non-finite start times are typed failures
- unexpected setup/read/programming exceptions propagate; typed durable append failure remains a Result
- the outer MASC layer owns the exact store directory; no physical ledger path is public

## Boundary

Next stacks must split Fusion compute from projection, register before fiber start, claim success/failure/cancel before any Board/chat/wake projection, then hard-cut the legacy fusion-runs.jsonl writer and project only the committed winner.

## Verification

- ocamlformat --check: pass
- ocamlc parse checks: pass
- git diff --check: pass
- focused Dune first found and fixed a missing unix test dependency; rerun is currently blocked behind the shared Dune/opam lock and was not bypassed
- 381 changed lines

Re-cut on main after #25231 merged and GitHub closed the former stacked #25249.