### PR TITLE
refactor(fusion): split computation from projection

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -9,16 +9,27 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
+type deliberation =
+  { panel : Fusion_types.panel_outcome list
+  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
+  ; judges : Fusion_types.judge_node list
+  ; judge_usage : Fusion_types.usage
+  }
+
+type compute_outcome =
+  | Compute_denied of Fusion_types.deny_reason
+  | Computed of deliberation
+
+let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
   match Fusion_policy.decide ~policy request with
   | Fusion_types.Deny reason ->
     Fusion_metrics.record_invocation ~topology `Denied;
-    Denied reason
+    Compute_denied reason
   | Fusion_types.Allow req ->
     (match Fusion_policy.find_preset policy req.Fusion_types.preset with
-     | None ->
-       Fusion_metrics.record_invocation ~topology `Denied;
-       Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
+       | None ->
+         Fusion_metrics.record_invocation ~topology `Denied;
+         Compute_denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
      | Some vp ->
           let preset = Fusion_policy.Validated_preset.preset vp in
           let groups = preset.Fusion_policy.panels in
@@ -367,14 +378,23 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Error (_, u) -> u
           in
           List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
-          (match
-             Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper
-               ~run_id:req.Fusion_types.run_id ~question:req.Fusion_types.prompt
-               ~panel ~judge ~judges:judge_nodes ~judge_usage
-           with
-           | Ok () ->
-             Fusion_metrics.record_invocation ~topology `Completed;
-             Completed { panel; judge }
-           | Error msg ->
-             Fusion_metrics.record_invocation ~topology `Sink_failed;
-             Sink_failed msg))
+          Computed { panel; judge; judges = judge_nodes; judge_usage })
+
+let project ~base_dir ~topology ~(request : Fusion_types.fusion_request) deliberation =
+  match
+    Fusion_sink.emit ~base_dir ~keeper:request.keeper ~run_id:request.run_id
+      ~question:request.prompt ~panel:deliberation.panel ~judge:deliberation.judge
+      ~judges:deliberation.judges ~judge_usage:deliberation.judge_usage
+  with
+  | Ok () ->
+    Fusion_metrics.record_invocation ~topology `Completed;
+    Completed { panel = deliberation.panel; judge = deliberation.judge }
+  | Error msg ->
+    Fusion_metrics.record_invocation ~topology `Sink_failed;
+    Sink_failed msg
+;;
+
+let run ~sw ~net ~base_dir ~policy ~topology ~request () =
+  match compute ~sw ~net ~policy ~topology ~request () with
+  | Compute_denied reason -> Denied reason
+  | Computed deliberation -> project ~base_dir ~topology ~request deliberation

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -16,6 +16,37 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
+type deliberation =
+  { panel : Fusion_types.panel_outcome list
+  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
+  ; judges : Fusion_types.judge_node list
+  ; judge_usage : Fusion_types.usage
+  }
+
+type compute_outcome =
+  | Compute_denied of Fusion_types.deny_reason
+  | Computed of deliberation
+
+(** Run panel and judge computation without Board, chat, wake, or run-registry
+    projection. The caller can durably claim the semantic terminal before
+    passing a [Computed] value to {!project}. *)
+val compute
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> policy:Fusion_policy.t
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> unit
+  -> compute_outcome
+
+(** Project one already-computed deliberation to the existing sink. *)
+val project
+  :  base_dir:string
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> deliberation
+  -> outcome
+
 (** 요청을 심의한다.
 
     + [Fusion_policy.decide]로 정책 판정 → [Deny]면 [Denied] 반환(부작용 없음).

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -497,7 +497,7 @@ let test_missing_board_post_id_fallback () =
   check string "synthetic fallback post id" "fusion-run:fus-9" ev.post_id
 ;;
 
-let test_emit_success_projects_board_chat_and_registry () =
+let test_orchestrator_project_success_projects_board_chat_and_registry () =
   with_isolated_base_path "fusion-success-sink" (fun base_dir ->
     let keeper = "fusion-keeper" in
     let run_id = Printf.sprintf "fus-success-%d" (Random.bits ()) in
@@ -521,11 +521,26 @@ let test_emit_success_projects_board_chat_and_registry () =
     in
     Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id ~keeper
       ~preset:"unit-test" ~started_at:2.0;
-    let result =
-      Fusion_sink.emit ~base_dir ~keeper ~run_id ~question ~panel
-        ~judge:(Ok synthesis) ~judges ~judge_usage
+    let request : Fusion_types.fusion_request =
+      { run_id
+      ; keeper
+      ; prompt = question
+      ; preset = "unit-test"
+      ; web_tools = false
+      ; depth = Fusion_types.Fusion_depth.Top
+      ; trigger = Fusion_types.Explicit_tool_call
+      }
     in
-    check bool "emit succeeds" true (Result.is_ok result);
+    let deliberation : Fusion_orchestrator.deliberation =
+      { panel; judge = Ok synthesis; judges; judge_usage }
+    in
+    (match
+       Fusion_orchestrator.project ~base_dir ~topology:Fusion_types.Simple ~request
+         deliberation
+     with
+     | Fusion_orchestrator.Completed _ -> ()
+     | Fusion_orchestrator.Denied _ -> fail "project must not re-run admission"
+     | Fusion_orchestrator.Sink_failed error -> fail error);
     let post =
       match Board.find_post_by_run_id (Board.global ()) ~run_id with
       | Some post -> post
@@ -956,9 +971,9 @@ let () =
             `Quick
             test_missing_board_post_id_fallback
         ; test_case
-            "emit success projects board, chat block, and registry"
+            "orchestrator project emits board, chat block, and registry"
             `Quick
-            test_emit_success_projects_board_chat_and_registry
+            test_orchestrator_project_success_projects_board_chat_and_registry
         ; test_case
             "wake route: register/take/discard, unrouted never stored"
             `Quick


### PR DESCRIPTION
## What
- add a side-effect-free Fusion_orchestrator.compute phase
- add an explicit projection phase for the existing sink
- preserve the current run API by composing compute then project

## Why
A caller must durably claim the semantic Fusion result before Board, chat, registry, or wake projection. The previous orchestrator emitted those effects internally, so a competing loser could already be visible before winner selection.

## Boundary
This leaf deliberately does not wire the new authority yet and does not change admission behavior. It is the enabling cut for the next stacked leaf.

## Verification
- ocamlformat/parser checks passed
- git diff --check passed
- full build/test delegated to PR CI per repository workflow

Stacked on #25265.