### PR TITLE
feat(keeper): surface reactive compaction failure reason in status (RFC #25268 PR-1)

### DIFF
--- a/dashboard/src/components/keeper-detail-debug.ts
+++ b/dashboard/src/components/keeper-detail-debug.ts
@@ -38,6 +38,7 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
   if (keeper.handoff_count_total != null) extras.push({ title: '핸드오프 총합', value: String(keeper.handoff_count_total) })
   if (keeper.compaction_count != null) extras.push({ title: '압축 횟수', value: String(keeper.compaction_count) })
   if (keeper.last_compaction_saved_tokens != null) extras.push({ title: '마지막 압축 절약', value: formatTokens(keeper.last_compaction_saved_tokens) })
+  if (keeper.last_compaction_decision) extras.push({ title: '마지막 압축 결정', value: keeper.last_compaction_decision })
   if (keeper.context?.message_count != null) extras.push({ title: '메시지 수', value: String(keeper.context.message_count) })
   if (keeper.context?.has_checkpoint != null) extras.push({ title: '체크포인트 보유', value: keeper.context.has_checkpoint ? '예' : '아니오' })
 

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -773,6 +773,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),
         compaction_count: asNumber(row.compaction_count),
         last_compaction_saved_tokens: asNumber(row.last_compaction_saved_tokens),
+        last_compaction_decision: asString(row.last_compaction_decision) ?? null,
         metrics_series: metricsSeries.length > 0 ? metricsSeries : undefined,
         metrics_window: metricsWindow,
         agent: normalizedAgent,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1267,6 +1267,10 @@ export interface Keeper {
   handoff_count_total?: number
   compaction_count?: number
   last_compaction_saved_tokens?: number
+  // Most recent compaction decision string (e.g. a provider-overflow recovery
+  // failure reason). Backend emits it as `last_compaction_decision`; surfaced so
+  // a stuck/looping compaction shows its cause instead of appearing idle.
+  last_compaction_decision?: string | null
   metrics_window?: MetricsWindow
   agent?: {
     name?: string

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -220,6 +220,11 @@ val clear_error : base_path:string -> string -> unit
 (** Set the structured failure reason for cohort detection. *)
 val set_failure_reason : base_path:string -> string -> failure_reason option -> unit
 
+(** [set_compaction_decision ~base_path name decision] stamps [decision] onto the
+    keeper's [compaction_rt.last_decision] so provider-overflow compaction
+    outcomes are observable in status (surfaced as [last_compaction_decision]). *)
+val set_compaction_decision : base_path:string -> string -> string -> unit
+
 (** Store the OAS Event_bus [correlation_id] from the most recent turn. *)
 val set_last_correlation_id : base_path:string -> string -> string -> unit
 

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -1022,6 +1022,24 @@ let set_failure_reason ~base_path name reason =
   Error_tracking.set_failure_reason ~base_path name reason ~update_entry:update_entry_unit
 ;;
 
+let set_compaction_decision ~base_path name decision =
+  (* Reactive provider-overflow recovery has no other path to
+     [compaction_rt]: the [update_entry] helpers mutate only the turn
+     observation, and [meta.compaction_rt] is otherwise persisted wholesale by
+     the turn lifecycle (post_turn returns [updated_meta]; its caller persists).
+     Stamping the specific recovery decision onto the already-serialized
+     [last_decision] lets the dashboard surface why an overflow compaction
+     failed instead of only a generic [Turn_overflow_failure]. *)
+  update_entry_unit ~base_path name (fun e ->
+    { e with
+      meta =
+        map_compaction_rt
+          (fun rt ->
+            { rt with last_decision = compaction_runtime_decision_of_string decision })
+          e.meta
+    })
+;;
+
 let set_last_correlation_id ~base_path name cid =
   Error_tracking.set_last_correlation_id ~base_path name cid ~update_entry:update_entry_unit
 ;;

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -408,6 +408,13 @@ let context_overflow_event_of_error
     Some (Keeper_state_machine.Context_overflow_detected { limit_tokens = limit })
   | _ -> None
 
+(* Prefix that tags a [last_compaction_decision] value as a provider-overflow
+   recovery failure. Kept as a named binding so the observability regression test
+   can assert the tag without duplicating the literal. *)
+let provider_overflow_decision_prefix = "provider_overflow_recovery_failed: "
+
+let provider_overflow_decision ~reason = provider_overflow_decision_prefix ^ reason
+
 let record_overflow_failure
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
@@ -416,6 +423,13 @@ let record_overflow_failure
     ~base_path:config.base_path
     meta.name
     (Some Keeper_registry.Turn_overflow_failure);
+  (* Also stamp the specific recovery reason onto compaction_rt so the reactive
+     overflow spiral's failure is visible in status (last_compaction_decision),
+     not dropped to the generic Turn_overflow_failure enum. *)
+  Keeper_registry.set_compaction_decision
+    ~base_path:config.base_path
+    meta.name
+    (provider_overflow_decision ~reason);
   Log.Keeper.warn
     "%s: unresolved context overflow observed (%s); Keeper lifecycle remains active"
     meta.name

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -197,13 +197,21 @@ val context_overflow_event_of_error :
 (** [Some] only for typed [Api (ContextOverflow _)]. The event preserves the
     provider-declared limit and never invents an actual input-token count. *)
 
+val provider_overflow_decision : reason:string -> string
+(** The [compaction_rt.last_decision] value stamped by [record_overflow_failure]
+    for a provider-overflow recovery failure. Exposed so the observability
+    regression test can assert the stamped decision without duplicating the tag. *)
+
 val record_overflow_failure :
   config:Workspace.config ->
   meta:keeper_meta ->
   reason:string ->
   unit
 (** Record unresolved context overflow as explicit failure evidence without
-    rewriting Keeper lifecycle. *)
+    rewriting Keeper lifecycle. Also stamps [compaction_rt.last_decision] via
+    {!Keeper_registry.set_compaction_decision} so the failure is visible in
+    status ([last_compaction_decision]), not only as a generic
+    [Turn_overflow_failure]. *)
 
 val current_keeper_meta :
   config:Workspace.config ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1130,6 +1130,34 @@ instructions = "missing sandbox profile"
           | Some (`Assoc _) -> ()
           | _ -> Alcotest.fail "fleet error row missing effective_meta_error")
 
+(* Regression: before the fix the reactive provider-overflow path recorded only a
+   generic Turn_overflow_failure, so compaction_rt.last_decision (surfaced as
+   last_compaction_decision) never showed why a compaction failed. The stamp must
+   now carry the specific recovery reason. *)
+let test_reactive_overflow_stamps_compaction_decision () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
+  let name = "overflow-observability" in
+  let config = Workspace.default_config base in
+  let meta = seed_runtime_meta config name in
+  Masc.Keeper_registry.clear ();
+  ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+  Fun.protect ~finally:Masc.Keeper_registry.clear (fun () ->
+      let reason = "plan_provider_unavailable" in
+      Masc.Keeper_turn_runtime_budget.record_overflow_failure ~config ~meta ~reason;
+      let latest =
+        Masc.Keeper_turn_runtime_budget.current_keeper_meta
+          ~config
+          ~fallback_meta:meta
+      in
+      let decision =
+        Masc.Keeper_meta_contract.compaction_runtime_decision_to_string
+          latest.runtime.compaction_rt.last_decision
+      in
+      Alcotest.(check string)
+        "reactive overflow stamps the specific recovery decision onto compaction_rt"
+        (Masc.Keeper_turn_runtime_budget.provider_overflow_decision ~reason)
+        decision)
+
 let () =
   init_runtime_default_for_tests ();
   Alcotest.run "keeper_effective_meta_overlay"
@@ -1188,5 +1216,8 @@ let () =
           Alcotest.test_case
             "sandbox status fleet surfaces effective meta errors"
             `Quick test_sandbox_status_fleet_surfaces_effective_meta_errors;
+          Alcotest.test_case
+            "reactive overflow stamps compaction decision for observability"
+            `Quick test_reactive_overflow_stamps_compaction_decision;
         ] );
     ]


### PR DESCRIPTION
## 요약
RFC #25268(컴팩션 설계실패 근본수리)의 **PR-1: 관측성(harness-first)**. reactive provider-overflow 복구 실패의 **구체 이유가 status에서 드롭**되던 문제를 수정합니다.

## 문제 (코드 확인)
- reactive 경로 `record_overflow_failure`(`keeper_turn_runtime_budget.ml`)는 generic `Turn_overflow_failure` enum만 기록. 구체 이유(`plan_provider_unavailable` 등)는 manifest/trace에만 남고 status엔 안 감.
- `compaction_rt.last_decision`(이미 직렬화·`last_compaction_decision`로 emit)는 pre-check 결정만 받음.
- 프론트 `keeper-store-normalize.ts`는 emit되는 `last_compaction_decision`를 **안 읽음**.
- 결과: 컴팩션이 26/28 실패하는데 operator는 이유를 볼 수 없음 = "되는지 안 되는지 UI 피드백 없음".

## 변경
- **backend**: `Keeper_registry.set_compaction_decision ~base_path name decision` 신설. registry updater들은 turn observation만 갱신하고 `meta.compaction_rt`는 turn lifecycle이 통째 영속하므로, reactive 경로가 compaction_rt에 접근할 유일한 경로가 없었음 → 이 함수가 그 갭을 메움(`map_compaction_rt`로 이미 직렬화되는 `last_decision` 재사용).
- `record_overflow_failure`가 구체 이유를 `provider_overflow_recovery_failed: <reason>`으로 stamp.
- **frontend**: `last_compaction_decision`를 normalize + 타입 + debug 패널 렌더.
- **test**: reactive overflow가 `compaction_rt.last_decision`에 구체 이유를 stamp하는지 회귀(수정 전 red).

## 워크어라운드 self-check (텔레메트리-as-fix 아님)
- **fix가 아니라 관측만 추가한 것 아닌가?** — 이 PR은 관측성만이라고 **명시**합니다. 죽음의 나선 자체의 수리는 PR-2(결정적 floor). counter를 추가해 fix라 주장하지 않음.
- 실패 상태(fail-closed rejection)는 이미 **correct behavior**. 결함은 그게 status에 표현 불가능했던 것뿐 → 정당한 관측 갭 수리.
- 새 문자열 포맷은 표시용이며 파서 소비자 없음(확인). 새 typed variant(`compaction_outcome`)는 floor와 함께 PR-2에서 도입.

## 검증
- 로컬 빌드 없음(repo 규칙). CI Build/Test에서 확인 예정.
- 영향 파일: registry(관측 필드 추가, 동작 무변경) / turn_runtime_budget(stamp 1회 추가) / dashboard(read+render) / test.

Refs #25268

🤖 Generated with [Claude Code](https://claude.com/claude-code)