### PR TITLE
fix(dashboard): dedup context-metrics diagnostics by keeper identity

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -25,6 +25,7 @@ async function loadOps() {
 
   return {
     Ops: mod.Ops,
+    contextMetricsDiagnostics: mod.contextMetricsDiagnostics,
     route: router.route,
     operatorActionLog: operatorStore.operatorActionLog,
     operatorDigestError: operatorStore.operatorDigestError,
@@ -477,6 +478,73 @@ describe('Ops surface', () => {
     expect(empty).toBeTruthy()
     expect(empty?.textContent).toContain('No operator activity in the last 3 days')
     expect(empty?.textContent).not.toContain('paused')
+  }, 60000)
+
+  it('collapses a keeper present in both keepers and persistent_agents into one diagnostic (source keeper)', async () => {
+    const { contextMetricsDiagnostics } = await loadOps()
+
+    // persistent_agents is a filtered projection of keepers (same rows emitted by
+    // rows_from_keeper_rows), so an autoboot keeper with a context-metrics failure
+    // shows up in both sections under the SAME name. Pre-fix this returned 2
+    // diagnostics for that one identity (rendered twice: Keeper + Persistent agent).
+    const snapshot = {
+      root: { paused: false },
+      sessions: [],
+      keepers: [{
+        name: 'autoboot-a',
+        context_metrics_unavailable: {
+          kind: 'storage_read_failed',
+          reason: 'io_error',
+          path: '/tmp/autoboot-a-metrics.jsonl',
+          detail: 'permission denied',
+        },
+      }],
+      persistent_agents: [{
+        name: 'autoboot-a',
+        context_metrics_unavailable: {
+          kind: 'storage_read_failed',
+          reason: 'io_error',
+          path: '/tmp/autoboot-a-metrics.jsonl',
+          detail: 'permission denied',
+        },
+      }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    const diagnostics = contextMetricsDiagnostics(snapshot)
+    const forName = diagnostics.filter(d => d.keeper.name === 'autoboot-a')
+    expect(forName).toHaveLength(1)
+    expect(forName[0]?.source).toBe('keeper')
+  }, 60000)
+
+  it('keeps a persistent-agent-only entity so future drift from the subset invariant still surfaces', async () => {
+    const { contextMetricsDiagnostics } = await loadOps()
+
+    const snapshot = {
+      root: { paused: false },
+      sessions: [],
+      keepers: [],
+      persistent_agents: [{
+        name: 'orphan-agent',
+        context_metrics_unavailable: {
+          kind: 'malformed_json',
+          reason: 'malformed_metrics_row',
+          path: '/tmp/orphan-metrics.jsonl',
+          line_number: 3,
+          detail: 'unexpected end of input',
+        },
+      }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    const diagnostics = contextMetricsDiagnostics(snapshot)
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.keeper.name).toBe('orphan-agent')
+    expect(diagnostics[0]?.source).toBe('persistent_agent')
   }, 60000)
 
   it('filters out entries older than 3 days so stale reviews stop showing', async () => {

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -56,7 +56,7 @@ interface ContextMetricsDiagnostic {
   error: OperatorContextMetricsUnavailable
 }
 
-function contextMetricsDiagnostics(snapshot: OperatorSnapshot | null): ContextMetricsDiagnostic[] {
+export function contextMetricsDiagnostics(snapshot: OperatorSnapshot | null): ContextMetricsDiagnostic[] {
   if (!snapshot) return []
   const keepers = snapshot.keepers
     .filter((keeper): keeper is OperatorKeeperSnapshot & { context_metrics_unavailable: OperatorContextMetricsUnavailable } =>
@@ -66,7 +66,14 @@ function contextMetricsDiagnostics(snapshot: OperatorSnapshot | null): ContextMe
     .filter((keeper): keeper is OperatorKeeperSnapshot & { context_metrics_unavailable: OperatorContextMetricsUnavailable } =>
       keeper.context_metrics_unavailable !== undefined)
     .map(keeper => ({ keeper, source: 'persistent_agent' as const, error: keeper.context_metrics_unavailable }))
-  return [...keepers, ...persistentAgents]
+  const byName = new Map<string, ContextMetricsDiagnostic>()
+  for (const diagnostic of [...keepers, ...persistentAgents]) {
+    // persistent_agents is a filtered projection of keepers (same rows), so an
+    // autoboot keeper appears in both sections. Collapse to one diagnostic per
+    // keeper identity, preferring the canonical 'keeper' source (inserted first).
+    if (!byName.has(diagnostic.keeper.name)) byName.set(diagnostic.keeper.name, diagnostic)
+  }
+  return [...byName.values()]
 }
 
 function renderContextMetricsDiagnostic(diagnostic: ContextMetricsDiagnostic) {


### PR DESCRIPTION
## 증상
Ops "Context metrics unavailable" 진단에서 autoboot keeper 하나가 "Keeper"와
"Persistent agent" 두 라벨로 **중복 렌더링**됩니다.

## 근본 원인
`snapshot.persistent_agents` 는 `snapshot.keepers` 의 필터링된 projection 입니다
(백엔드 `operator_control_snapshot_persistent_agents.rows_from_keeper_rows` 가
`keeper_rows` 에 이미 있는 행만 방출). `contextMetricsDiagnostics` 가 두 리스트를
단순 concat(`[...keepers, ...persistentAgents]`) 하여 같은 identity 가 두 번 나옵니다.
이건 데이터 계층 버그가 아니라 render 계층 결함입니다.

## 수정
`keeper.name` 기준으로 dedup 하여 첫 등장(keeper source, 먼저 삽입)을 유지하고
삽입 순서를 보존했습니다. persistent-agent-only 엔티티는 subset invariant 가
미래에 깨질 경우에도 라벨을 유지한 채 생존하도록 남겨 무손실입니다. wire 타입과
`renderContextMetricsDiagnostic` 는 변경하지 않았습니다(render-layer only).

## 테스트
`contextMetricsDiagnostics` 를 export 하고 counterfactual 테스트 2건을 추가했습니다.
같은 name 이 양쪽 섹션에 있으면 결과 length 1 + `source === 'keeper'` 단언(수정 전
concat 은 2 반환 → red 확인), persistent-only 엔티티 생존 단언. `tsc --noEmit` /
`vitest` (11 passed) / eslint(ops) 통과.

Closes #25260 (미해소 codex P2).

RFC-WAIVED: `dashboard/src/components/ops/` 는 RFC-gated 경로가 아닙니다
(gated = `credential-settings`, `keeper-repo-mapping` 만).
