### PR TITLE
fix(tool-schema): make limit a single strict type — fleet-wide keeper crash (#18472 revert)

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -55,15 +55,11 @@ let base_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ (* Issue #18472: LLM keepers emit [limit] as a JSON
-                           string (["5"]); strict ["integer"] routes through
-                           [correction_pipeline] for a silent coerce. The
-                           runtime handler reads via [Safe_ops.json_int] /
-                           [json_float] which accepts both shapes, so this is
-                           wire-format only. Mirrors PR #19383's widening on
-                           [tool_execute.timeout_sec]. *)
-                        ( "type"
-                        , `List [ `String "integer"; `String "string" ] )
+                      [ (* #18472 widening removed: a multi-type schema trips
+                           OAS #2343 fail-closed and crashes the keeper cycle.
+                           Runtime reads via [Safe_ops.json_int]/[json_float]
+                           which coerce string->int, so strict integer is safe. *)
+                        ( "type", `String "integer" )
                       ; ( "description"
                         , `String
                             "max results (1-10, default 5). Numeric strings \

--- a/lib/tool_surface/tool_shard_types_schemas_board.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_board.ml
@@ -132,13 +132,10 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ (* Issue #18472: same wire-format widening as
-                           PR #19383 on [tool_execute.timeout_sec]. The
-                           board_list runtime accepts both shapes; the
-                           strict ["integer"] only fires Anthropic-SDK
-                           [correction_pipeline] coerce. *)
-                        ( "type"
-                        , `List [ `String "integer"; `String "string" ] )
+                      [ (* #18472 widening removed: a multi-type schema trips
+                           OAS #2343 fail-closed and crashes the keeper cycle.
+                           Runtime coerces string->int, so strict integer is safe. *)
+                        ( "type", `String "integer" )
                       ; "default", `Int 20
                       ; "minimum", `Int 1
                       ; "maximum", `Int 50
@@ -283,13 +280,10 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ (* Issue #18472: same widening as PR #19383 / sibling
-                           sites above. No fleet evidence yet on this site
-                           (board_search), but bundled here per RFC-0088 §3
-                           N-of-M avoidance — three [limit] sites with the
-                           same defect; fix all at once. *)
-                        ( "type"
-                        , `List [ `String "integer"; `String "string" ] )
+                      [ (* #18472 widening removed: a multi-type schema trips
+                           OAS #2343 fail-closed and crashes the keeper cycle.
+                           Runtime coerces string->int, so strict integer is safe. *)
+                        ( "type", `String "integer" )
                       ; "default", `Int 20
                       ; "minimum", `Int 1
                       ; "maximum", `Int 100

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -29,12 +29,10 @@ let taskboard_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ (* Issue #18472: wire-format widening — same
-                           pattern as PR #19383 on [limit] siblings.
-                           The runtime accepts both shapes; strict
-                           ["integer"] only fires correction_pipeline. *)
-                        ( "type"
-                        , `List [ `String "integer"; `String "string" ] )
+                      [ (* #18472 widening removed: a multi-type schema trips
+                           OAS #2343 fail-closed and crashes the keeper cycle.
+                           Runtime coerces string->int, so strict integer is safe. *)
+                        ( "type", `String "integer" )
                       ; "description", `String "Max tasks to return (default: 50)"
                       ; "minimum", `Int 1
                       ; "maximum", `Int 100
@@ -55,11 +53,10 @@ let taskboard_tools : Masc_domain.tool_schema list =
             , `Assoc
                 [ ( "limit"
                   , `Assoc
-                      [ (* Issue #18472: wire-format widening — bundled
-                           with keeper_tasks_list.limit above per
-                           RFC-0088 §3 N-of-M avoidance. *)
-                        ( "type"
-                        , `List [ `String "integer"; `String "string" ] )
+                      [ (* #18472 widening removed: a multi-type schema trips
+                           OAS #2343 fail-closed and crashes the keeper cycle.
+                           Runtime coerces string->int, so strict integer is safe. *)
+                        ( "type", `String "integer" )
                       ; "description", `String "Max orphans to return (default: 20)"
                       ; "minimum", `Int 1
                       ; "maximum", `Int 50

--- a/test/test_limit_schema_widen.ml
+++ b/test/test_limit_schema_widen.ml
@@ -1,25 +1,22 @@
-(* Issue #18472 follow-up to PR #19383: widen [limit] from strict
-   ["integer"] to ["integer", "string"] across the three sites that
-   advertise it — [keeper_memory_search], [keeper_board_list],
-   [keeper_board_search]. Fleet evidence on 2026-05-29 partial:
+(* Reversal of Issue #18472's [limit] wire-format widening.
 
-     fields=limit stages=coercion total:        18
-       ReadFile (Anthropic-native, not ours):  13
-       keeper_board_list:                       4
-       keeper_memory_search:                    1
-       keeper_board_search:                     0  ← no traffic yet but
-                                                     same defect; bundled
-                                                     per RFC-0088 §3 N-of-M.
+   #18472 widened [limit] from strict ["integer"] to the union
+   ["integer", "string"] across five sites so the correction_pipeline
+   would not fire when an LLM emitted a numeric string. OAS #2343 then
+   made mcp_schema fail-closed: a [type] array with more than one
+   non-null member raises Invalid_argument
+   ("property \"limit\" type array must contain exactly one non-null
+   type") during tool-schema conversion, which propagated to the keeper
+   cycle and crashed every keeper on 2026-07-19.
 
-   Runtime handlers in [Keeper_tool_memory_runtime] and the board list /
-   search dispatchers read [limit] via [Safe_ops.json_int] which already
-   accepts both shapes. The Anthropic-SDK schema rejection is purely a
-   wire-format quirk. *)
+   The runtime handlers already read [limit] via [Safe_ops.json_int],
+   which coerces string->int, so a single strict ["integer"] loses no
+   behaviour. This test guards AGAINST re-widening: every advertised
+   [limit] must be a single scalar JSON Schema type, never a multi-type
+   array. Covers all five sites #18472 touched, not the three the
+   original widening test pinned. *)
 
 open Alcotest
-
-module Base = Tool_shard_types
-module Board = Tool_shard_types
 
 let find_tool_schema schemas name =
   List.find_opt (fun (s : Masc_domain.tool_schema) -> String.equal s.name name) schemas
@@ -41,45 +38,51 @@ let limit_type schema =
      | _ -> Alcotest.failf "%s: properties not an Assoc" schema.name)
   | _ -> Alcotest.failf "%s: input_schema not an Assoc" schema.name
 
-let check_widened name type_value =
+(* A [type] array with more than one non-null member is exactly what OAS
+   #2343 fail-closed rejects. Assert every [limit] is a single scalar. *)
+let check_single_type name type_value =
   match type_value with
-  | `List xs ->
-    let strings =
-      List.map
-        (function
-          | `String s -> s
-          | _ -> Alcotest.failf "%s: limit type list contains non-string" name)
-        xs
-    in
-    check (list string)
-      (Printf.sprintf "%s: limit type widened to integer + string" name)
-      [ "integer"; "string" ]
-      strings
   | `String single ->
+    check string
+      (Printf.sprintf "%s: limit type is a single scalar" name)
+      "integer"
+      single
+  | `List _ ->
     Alcotest.failf
-      "%s: limit type is still scalar %S; widening regressed"
-      name single
+      "%s: limit type is a multi-type array; OAS #2343 fail-closed rejects it \
+       and crashes the keeper cycle (see #18472 revert)"
+      name
   | other ->
-    Alcotest.failf "%s: limit type has unexpected JSON: %s" name
+    Alcotest.failf
+      "%s: limit type has unexpected JSON: %s"
+      name
       (Yojson.Safe.to_string other)
 
-let memory_search_limit_widened () =
-  let schema = find_tool_schema Base.base_tools "keeper_memory_search" in
-  check_widened "keeper_memory_search" (limit_type schema)
-
-let board_list_limit_widened () =
-  let schema = find_tool_schema Board.board_tools "keeper_board_list" in
-  check_widened "keeper_board_list" (limit_type schema)
-
-let board_search_limit_widened () =
-  let schema = find_tool_schema Board.board_tools "keeper_board_search" in
-  check_widened "keeper_board_search" (limit_type schema)
+let case tools name () = check_single_type name (limit_type (find_tool_schema tools name))
 
 let () =
-  run "limit_schema_widen"
-    [ "all three limit sites accept integer + string"
-    , [ test_case "keeper_memory_search" `Quick memory_search_limit_widened
-      ; test_case "keeper_board_list" `Quick board_list_limit_widened
-      ; test_case "keeper_board_search" `Quick board_search_limit_widened
-      ]
+  run
+    "limit_schema_strict"
+    [ ( "every advertised limit is a single strict type"
+      , [ test_case
+            "keeper_tasks_list"
+            `Quick
+            (case Tool_shard_types.taskboard_tools "keeper_tasks_list")
+        ; test_case
+            "keeper_tasks_audit"
+            `Quick
+            (case Tool_shard_types.taskboard_tools "keeper_tasks_audit")
+        ; test_case
+            "keeper_memory_search"
+            `Quick
+            (case Tool_shard_types.base_tools "keeper_memory_search")
+        ; test_case
+            "keeper_board_list"
+            `Quick
+            (case Tool_shard_types.board_tools "keeper_board_list")
+        ; test_case
+            "keeper_board_search"
+            `Quick
+            (case Tool_shard_types.board_tools "keeper_board_search")
+        ] )
     ]


### PR DESCRIPTION
## Symptom (live P0, 2026-07-19)

Every keeper crashes its cycle each turn:

```
[ERROR] [Keeper] rondo: keeper cycle exception (recorded as turn failure):
  Invalid_argument("property \"limit\" type array must contain exactly one non-null type")
```

Observed on rondo, nick0cave, albini, executor — fleet-wide, every cycle. The `String.index_rec`/`contains_from` backtrace is misattributed; the real signal is the message.

## Root cause — two individually-reasonable changes collided

- **masc** widened five `[limit]` schema properties from `"integer"` to the union `["integer","string"]` (Issue #18472, PRs #19383/#19388/#20558) so an LLM emitting a numeric string (`"5"`) would not fire `correction_pipeline`.
- **OAS #2343** made `mcp_schema` fail-closed: a `[type]` array with >1 non-null member raises `Invalid_argument` in `property_type_from_union` (`lib/protocol/mcp_schema.ml:65`), unwrapped to an exception at the `invalid_arg` boundary.

When masc bumped to an OAS build carrying #2343, the long-standing union started failing closed during per-turn tool-schema conversion → crashed the keeper cycle for every keeper.

## Fix

Revert all five sites to a single strict `"integer"`. The runtime already reads `[limit]` via `Safe_ops.json_int`, which coerces `string→int`, so the union was cosmetic (it only avoided `correction_pipeline`). Under strict structured output the model is guided to emit integers directly.

Sites: `keeper_tasks_list`, `keeper_tasks_audit`, `keeper_memory_search`, `keeper_board_list`, `keeper_board_search`.

- A scanner confirms **0** multi-non-null `type` unions remain (3 nullable `[X,"null"]` sites are unaffected — OAS accepts one non-null + null).
- `test_limit_schema_widen` is flipped from **pinning** the widening to **guarding against** it, now across all five sites (the original pinned three — the two taskboard sites were never covered).

This is a workaround removal (the `["integer","string"]` widening), not a new one.

## Verification

- Local: `ocamlformat --check` clean on all four files; completeness scanner = 0 remaining unions.
- Build/test: deferred to CI per the repo's build-in-CI policy (masc full build + `test_limit_schema_widen`).

## Follow-up (separate)

OAS should not let a single malformed tool schema crash the whole keeper cycle. The `invalid_arg` in `mcp_schema` should surface as a typed error the caller can skip/log per-tool, so one bad schema degrades to a disabled tool, not a fleet-wide crash. Filed separately.

## Deployment

Code fix only — the running fleet needs a rebuild + restart to clear the live crash.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
