### PR TITLE
fix(fusion): wake only the captured Keeper lane

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -300,12 +300,12 @@ let broadcast_run_status ~registry ~run_id =
 let wake_keeper_on_fusion_completion
       ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id :
     (unit, string) result =
-  let ( let* ) = Result.bind in
-  let* channel =
-    match Fusion_wake_route.peek ~run_id with
-    | Some channel -> Ok channel
-    | None ->
-      Ok (Keeper_continuation_channel.unrouted "no originating connector")
+  let route = Fusion_wake_route.peek ~keeper ~run_id in
+  let channel =
+    match route with
+    | Some { Fusion_wake_route.channel = Some channel; _ } -> channel
+    | Some { channel = None; _ } | None ->
+      Keeper_continuation_channel.unrouted "no originating connector"
   in
   let terminal =
     if ok
@@ -338,30 +338,44 @@ let wake_keeper_on_fusion_completion
       "fusion completion wake durable-commit failed run_id=%s: %s" run_id reason;
     Error reason
   | Ok () ->
-    ignore (Fusion_wake_route.take ~run_id);
+    (match Fusion_wake_route.take ~keeper ~run_id with
+     | Some _ | None -> ());
     Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
     (try
-       match
-         Keeper_registry.wakeup_running
-           ~intent:Keeper_registry.Reactive_signal
-           ~base_path:base_dir
-           keeper
-       with
-       | Keeper_registry.Signaled -> ()
-       | Keeper_registry.Deferred_unregistered ->
+       match Option.bind route (fun route -> route.Fusion_wake_route.owner) with
+       | None ->
          Log.Keeper.info ~keeper_name:keeper
-           "fusion completion wake deferred: keeper is no longer registered run_id=%s"
+           "fusion completion exact wake deferred: no owner captured run_id=%s"
            run_id
-       | Keeper_registry.Deferred_not_running phase ->
-         Log.Keeper.info ~keeper_name:keeper
-           "fusion completion wake deferred: phase=%s run_id=%s"
-           (Keeper_state_machine.phase_to_string phase)
-           run_id
-       | Keeper_registry.Deferred_lifecycle denial ->
-         Log.Keeper.info ~keeper_name:keeper
-           "fusion completion wake deferred by lifecycle: reason=%s run_id=%s"
-           (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
-           run_id
+       | Some owner ->
+         (match
+            Keeper_registry.wakeup_running_exact
+              ~intent:Keeper_registry.Reactive_signal
+              owner
+          with
+          | Keeper_registry.Exact_wake_signaled -> ()
+          | Keeper_registry.Exact_wake_missing ->
+            Log.Keeper.info ~keeper_name:keeper
+              "fusion completion exact wake deferred: owner missing run_id=%s"
+              run_id
+          | Keeper_registry.Exact_wake_replaced ->
+            Log.Keeper.info ~keeper_name:keeper
+              "fusion completion exact wake deferred: owner replaced run_id=%s"
+              run_id
+          | Keeper_registry.Exact_wake_not_running phase ->
+            Log.Keeper.info ~keeper_name:keeper
+              "fusion completion exact wake deferred: phase=%s run_id=%s"
+              (Keeper_state_machine.phase_to_string phase)
+              run_id
+          | Keeper_registry.Exact_wake_lifecycle_denied denial ->
+            Log.Keeper.info ~keeper_name:keeper
+              "fusion completion exact wake deferred by lifecycle: reason=%s run_id=%s"
+              (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
+              run_id
+          | Keeper_registry.Exact_wake_lifecycle_reserved _ ->
+            Log.Keeper.info ~keeper_name:keeper
+              "fusion completion exact wake deferred: lifecycle reserved run_id=%s"
+              run_id)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -142,9 +142,7 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
          tracks the run. [register] drops [Unrouted] itself; the completion
          wake ([Fusion_sink.wake_keeper_on_fusion_completion], success AND
          failure paths) consumes it exactly once. *)
-      Option.iter
-        (fun channel -> Fusion_wake_route.register ~run_id channel)
-        continuation_channel;
+      Fusion_wake_route.register ~base_path:base_dir ~keeper ~run_id continuation_channel;
       (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
          (no polling). wake-free, broadcast-failure-safe; see
          Fusion_sink.broadcast_run_status. *)
@@ -182,7 +180,7 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
             ~failure_code:"cancelled" ~ok:false ();
           (* No completion wake fires on this path, so drop the reply route
              here or it leaks for the process lifetime. *)
-          Fusion_wake_route.discard ~run_id;
+          Fusion_wake_route.discard ~keeper ~run_id;
           raise exn
         | exception exn ->
           append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"

--- a/lib/fusion/fusion_wake_route.ml
+++ b/lib/fusion/fusion_wake_route.ml
@@ -4,21 +4,44 @@
    Fusion call-rate limit, so lookup/update complexity must not depend on an
    assumed small number of concurrent runs. *)
 
-module Routes = Map.Make (String)
+module Route_id = struct
+  type t =
+    { keeper : string
+    ; run_id : string
+    }
 
-let routes : Keeper_continuation_channel.t Routes.t Atomic.t =
-  Atomic.make Routes.empty
+  let compare left right =
+    match String.compare left.keeper right.keeper with
+    | 0 -> String.compare left.run_id right.run_id
+    | order -> order
+  ;;
+end
+
+module Routes = Map.Make (Route_id)
+
+type route =
+  { owner : Keeper_registry.registry_entry option
+  ; channel : Keeper_continuation_channel.t option
+  }
+
+let routes : route Routes.t Atomic.t = Atomic.make Routes.empty
 
 let rec update f =
   let cur = Atomic.get routes in
   let next = f cur in
   if not (Atomic.compare_and_set routes cur next) then update f
 
-let register ~run_id channel =
-  if Keeper_continuation_channel.is_routable channel then
-    update (Routes.add run_id channel)
+let register ~base_path ~keeper ~run_id channel =
+  let owner = Keeper_registry.get ~base_path keeper in
+  let channel =
+    Option.bind channel (fun channel ->
+      if Keeper_continuation_channel.is_routable channel then Some channel else None)
+  in
+  match owner, channel with
+  | None, None -> ()
+  | _ -> update (Routes.add Route_id.{ keeper; run_id } { owner; channel })
 
-let take ~run_id =
+let take ~keeper ~run_id =
   (* Read-then-CAS: the value returned is the one observed in [cur]; the CAS
      retry re-reads, so a concurrent register/take converges like the
      registry's [update]. A completion wake fires once per run, so the only
@@ -26,10 +49,12 @@ let take ~run_id =
      order leaves the route removed. *)
   let found = ref None in
   update (fun cur ->
-    found := Routes.find_opt run_id cur;
-    Routes.remove run_id cur);
+    let id = Route_id.{ keeper; run_id } in
+    found := Routes.find_opt id cur;
+    Routes.remove id cur);
   !found
 
-let peek ~run_id = Routes.find_opt run_id (Atomic.get routes)
+let peek ~keeper ~run_id =
+  Routes.find_opt Route_id.{ keeper; run_id } (Atomic.get routes)
 
-let discard ~run_id = update (Routes.remove run_id)
+let discard ~keeper ~run_id = update (Routes.remove Route_id.{ keeper; run_id })

--- a/lib/fusion/fusion_wake_route.mli
+++ b/lib/fusion/fusion_wake_route.mli
@@ -15,23 +15,35 @@
     in-flight fibers they route for (boot replay already drops [Running]
     runs), so a persisted route could never fire anyway. *)
 
-(** [register ~run_id channel] remembers the originating channel for an
-    in-flight run.  Unroutable channels ([Unrouted]) are not stored — the
-    wake-side default already says "no originating connector". *)
-val register : run_id:string -> Keeper_continuation_channel.t -> unit
+type route =
+  { owner : Keeper_registry.registry_entry option
+  ; channel : Keeper_continuation_channel.t option
+  }
+
+(** [register] captures both the exact live Keeper lane and the optional
+    originating connector channel under the composite [(keeper, run_id)]
+    identity. Unroutable channels are discarded, while a captured Keeper owner
+    is retained even without a connector so completion cannot wake a later
+    replacement lane. *)
+val register
+  :  base_path:string
+  -> keeper:string
+  -> run_id:string
+  -> Keeper_continuation_channel.t option
+  -> unit
 
 (** [take ~run_id] returns the registered channel and removes the route
     (a completion wake fires once; keeping the route would leak).  [None]
     when the run was started without a routable channel. *)
-val take : run_id:string -> Keeper_continuation_channel.t option
+val take : keeper:string -> run_id:string -> route option
 
 (** [peek ~run_id] returns the registered channel without removing the route.
     The completion wake builds its stimulus from this value and durably commits
     it before calling [take]: the route is the sole in-memory carrier of the
     reply channel, so a failed durable commit must leave it intact for a later
     retry instead of destroying it up front. [None] mirrors [take]. *)
-val peek : run_id:string -> Keeper_continuation_channel.t option
+val peek : keeper:string -> run_id:string -> route option
 
 (** [discard ~run_id] drops the route without returning it — the structural
     cancellation path terminates a run without emitting a completion wake. *)
-val discard : run_id:string -> unit
+val discard : keeper:string -> run_id:string -> unit

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -637,39 +637,87 @@ let discord_channel =
 ;;
 
 let test_wake_route_register_take_discard () =
+  let base_path = Filename.get_temp_dir_name () in
+  let keeper = "fusion-route-keeper" in
   let run_id = Printf.sprintf "fus-route-%d" (Random.bits ()) in
-  Fusion_wake_route.register ~run_id discord_channel;
-  (match Fusion_wake_route.take ~run_id with
-   | Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ }) -> ()
-   | Some other ->
+  Fusion_wake_route.register ~base_path ~keeper ~run_id (Some discord_channel);
+  (match Fusion_wake_route.take ~keeper ~run_id with
+   | Some
+       { Fusion_wake_route.channel =
+           Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ })
+       ; _
+       } ->
+     ()
+   | Some { channel = Some other; _ } ->
      fail
        (Printf.sprintf "unexpected route: %s"
           (Keeper_continuation_channel.describe other))
+   | Some { channel = None; _ } -> fail "registered route lost its channel"
    | None -> fail "registered route must be takeable");
-  check bool "take removes the route" true (Fusion_wake_route.take ~run_id = None);
+  check bool "take removes the route" true
+    (Fusion_wake_route.take ~keeper ~run_id = None);
   (* Unrouted is never stored: the wake-side default already says so. *)
-  Fusion_wake_route.register ~run_id
-    (Keeper_continuation_channel.unrouted "not a connector turn");
-  check bool "unrouted is not registered" true (Fusion_wake_route.take ~run_id = None);
-  Fusion_wake_route.register ~run_id discord_channel;
-  Fusion_wake_route.discard ~run_id;
-  check bool "discard drops the route" true (Fusion_wake_route.take ~run_id = None)
+  Fusion_wake_route.register ~base_path ~keeper ~run_id
+    (Some (Keeper_continuation_channel.unrouted "not a connector turn"));
+  check bool "unrouted is not registered" true
+    (Fusion_wake_route.take ~keeper ~run_id = None);
+  Fusion_wake_route.register ~base_path ~keeper ~run_id (Some discord_channel);
+  Fusion_wake_route.discard ~keeper ~run_id;
+  check bool "discard drops the route" true
+    (Fusion_wake_route.take ~keeper ~run_id = None)
 ;;
 
 (* P1-A: [peek] reads the route without consuming it, so the completion wake can
    build+commit the stimulus before the destructive [take]. *)
 let test_wake_route_peek_is_non_destructive () =
+  let base_path = Filename.get_temp_dir_name () in
+  let keeper = "fusion-peek-keeper" in
   let run_id = Printf.sprintf "fus-peek-%d" (Random.bits ()) in
-  Fusion_wake_route.register ~run_id discord_channel;
+  Fusion_wake_route.register ~base_path ~keeper ~run_id (Some discord_channel);
   let is_chan9 = function
-    | Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ }) -> true
+    | Some
+        { Fusion_wake_route.channel =
+            Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ })
+        ; _
+        } ->
+      true
     | _ -> false
   in
-  check bool "peek returns the registered route" true (is_chan9 (Fusion_wake_route.peek ~run_id));
+  check bool "peek returns the registered route" true
+    (is_chan9 (Fusion_wake_route.peek ~keeper ~run_id));
   check bool "peek is non-destructive (second peek still sees it)" true
-    (is_chan9 (Fusion_wake_route.peek ~run_id));
-  check bool "take still consumes after peeks" true (is_chan9 (Fusion_wake_route.take ~run_id));
-  check bool "route gone after take" true (Fusion_wake_route.peek ~run_id = None)
+    (is_chan9 (Fusion_wake_route.peek ~keeper ~run_id));
+  check bool "take still consumes after peeks" true
+    (is_chan9 (Fusion_wake_route.take ~keeper ~run_id));
+  check bool "route gone after take" true
+    (Fusion_wake_route.peek ~keeper ~run_id = None)
+;;
+
+let test_wake_route_isolates_keeper_run_identity () =
+  let base_path = Filename.get_temp_dir_name () in
+  let run_id = Printf.sprintf "fus-shared-%d" (Random.bits ()) in
+  let other_channel =
+    Keeper_continuation_channel.discord
+      ~guild_id:(Some "g-1")
+      ~channel_id:"chan-10"
+      ~parent_channel_id:None
+      ~thread_id:None
+      ~user_id:"user-4"
+    |> Result.get_ok
+  in
+  Fusion_wake_route.register ~base_path ~keeper:"keeper-a" ~run_id
+    (Some discord_channel);
+  Fusion_wake_route.register ~base_path ~keeper:"keeper-b" ~run_id
+    (Some other_channel);
+  ignore (Fusion_wake_route.take ~keeper:"keeper-a" ~run_id);
+  match Fusion_wake_route.peek ~keeper:"keeper-b" ~run_id with
+  | Some
+      { Fusion_wake_route.channel =
+          Some (Keeper_continuation_channel.Discord { channel_id = "chan-10"; _ })
+      ; _
+      } ->
+    Fusion_wake_route.discard ~keeper:"keeper-b" ~run_id
+  | _ -> fail "one Keeper consuming a shared run_id removed its peer route"
 ;;
 
 (* P1-A: the completion wake commits the channel-carrying stimulus through the
@@ -680,14 +728,14 @@ let test_wake_durable_commit_carries_channel_and_consumes_route () =
   with_isolated_base_path "fusion-wake-durable" (fun base_dir ->
     let keeper = Printf.sprintf "fusion-wake-%d" (Random.bits ()) in
     let run_id = Printf.sprintf "fus-wake-%d" (Random.bits ()) in
-    Fusion_wake_route.register ~run_id discord_channel;
+    Fusion_wake_route.register ~base_path:base_dir ~keeper ~run_id (Some discord_channel);
     let result =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
         ~resolved_answer:"WAKE-DURABLE-ANSWER" ~board_post_id:"post-wake-1"
     in
     check bool "wake commits durably" true (Result.is_ok result);
     check bool "route consumed only after the durable commit" true
-      (Fusion_wake_route.peek ~run_id = None);
+      (Fusion_wake_route.peek ~keeper ~run_id = None);
     match
       Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
       |> Keeper_event_queue.dequeue
@@ -727,15 +775,46 @@ let test_wake_fail_closed_preserves_route () =
      with
      | Ok () -> ()
      | Error e -> fail (Printf.sprintf "seeding the conflicting durable row should commit: %s" e));
-    Fusion_wake_route.register ~run_id discord_channel;
+    Fusion_wake_route.register ~base_path:base_dir ~keeper ~run_id (Some discord_channel);
     let result =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
         ~resolved_answer:"REAL-ANSWER" ~board_post_id
     in
     check bool "conflicting durable commit fails the wake" true (Result.is_error result);
-    match Fusion_wake_route.peek ~run_id with
-    | Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ }) -> ()
+    match Fusion_wake_route.peek ~keeper ~run_id with
+    | Some
+        { Fusion_wake_route.channel =
+            Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ })
+        ; _
+        } ->
+      ()
     | _ -> fail "route must survive a failed durable commit (peek, not take)")
+;;
+
+let test_completion_wake_does_not_signal_replacement_lane () =
+  with_isolated_base_path "fusion-wake-exact-owner" (fun base_dir ->
+    Keeper_registry.clear ();
+    Fun.protect
+      ~finally:Keeper_registry.clear
+      (fun () ->
+         let keeper = Printf.sprintf "fusion-exact-%d" (Random.bits ()) in
+         let run_id = Printf.sprintf "fus-exact-%d" (Random.bits ()) in
+         let meta = make_meta ~name:keeper () in
+         let captured = Keeper_registry.register ~base_path:base_dir keeper meta in
+         Atomic.set captured.fiber_wakeup false;
+         Fusion_wake_route.register ~base_path:base_dir ~keeper ~run_id None;
+         let replacement = Keeper_registry.register ~base_path:base_dir keeper meta in
+         Atomic.set replacement.fiber_wakeup false;
+         let result =
+           Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
+             ~resolved_answer:"EXACT-OWNER-ANSWER" ~board_post_id:"post-exact-owner"
+         in
+         check bool "completion commits despite replaced live owner" true
+           (Result.is_ok result);
+         check bool "captured stale lane is not signaled" false
+           (Atomic.get captured.fiber_wakeup);
+         check bool "replacement lane is not signaled" false
+           (Atomic.get replacement.fiber_wakeup)))
 ;;
 
 let test_completion_stimulus_persists_without_live_registry () =
@@ -968,6 +1047,10 @@ let () =
             `Quick
             test_wake_route_peek_is_non_destructive
         ; test_case
+            "wake route: keeper/run identity isolates equal run ids"
+            `Quick
+            test_wake_route_isolates_keeper_run_identity
+        ; test_case
             "wake durably commits the channel and consumes the route on Ok"
             `Quick
             test_wake_durable_commit_carries_channel_and_consumes_route
@@ -975,6 +1058,10 @@ let () =
             "wake fail-closed: a failed durable commit preserves the route"
             `Quick
             test_wake_fail_closed_preserves_route
+        ; test_case
+            "completion wake never signals a replacement Keeper lane"
+            `Quick
+            test_completion_wake_does_not_signal_replacement_lane
         ; test_case
             "completion stimulus persists without live registry"
             `Quick


### PR DESCRIPTION
## What
- key in-flight Fusion routes by typed keeper/run identity
- capture the exact Keeper registry entry before the background fiber starts
- commit the durable completion first, then signal only that captured lane
- keep connector routing optional and independent from lane ownership

## Why
A name-based completion lookup can wake a replacement Keeper lane that did not start the Fusion. A run_id-only route also aliases equal run ids across different Keepers. The completion must preserve both space identity and lane ownership without blocking peers.

## Proof
- focused build: test/test_fusion_wake.exe
- focused executable: 18/18 tests passed
- same run id across two Keepers remains isolated
- a replacement lane is not signaled after durable completion
- git diff --check passed

Based on merged #25267. 277 changed lines.