### PR TITLE
feat(slack): triggered-lane attention parity with Discord

### DIFF
--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -162,7 +162,7 @@ let slack_attention_surface ~team_id ~channel_id ~thread_ts =
   Keeper_external_attention.Slack { team_id; channel_id; thread_ts }
 
 let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
-    ~thread_ts ~ts ~user_id ~user_name ~content ~mentions_bot =
+    ~thread_ts ~ts ~user_id ~user_name ~content ~mentions_bot ~route ~urgency =
   let surface = slack_attention_surface ~team_id ~channel_id ~thread_ts in
   let conversation_id = slack_conversation_id ~channel_id in
   let dedupe_key = Printf.sprintf "slack:%s:%s" conversation_id ts in
@@ -180,7 +180,7 @@ let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
         ; display_name = user_name
         ; authority = Keeper_chat_store.External
         }
-    ; urgency = Keeper_external_attention.Ambient
+    ; urgency
     ; content_preview = content
     ; content_ref = None
     ; received_at =
@@ -189,7 +189,7 @@ let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
            as event evidence and for pending-order projection; it does not
            branch deterministic policy. *)
     ; metadata =
-        [ "route", "ambient"
+        [ "route", route
         ; "mentions_bot", string_of_bool mentions_bot
         ; "slack_channel_id", channel_id
         ]
@@ -206,6 +206,21 @@ let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
       channel_id keeper_name error;
     None
 
+let mark_attention_resolved ~base_dir ~keeper_name ~event_id ~reason =
+  match
+    Keeper_external_attention.mark_resolved
+      ~base_path:base_dir
+      ~keeper_name
+      ~event_ids:[ event_id ]
+      ~reason
+      ()
+  with
+  | Ok () -> ()
+  | Error error ->
+    Log.Server.warn
+      "slack external attention resolve failed (keeper=%s event=%s): %s"
+      keeper_name event_id error
+
 (* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)
 (* ---------------------------------------------------------------- *)
@@ -214,10 +229,11 @@ type accepted_inbound =
   { channel_id : string
   ; reply_to_thread_ts : string
   ; keeper_name : string
+  ; attention_event_id : string option
   ; outcome : (Channel_gate.outbound_message, Channel_gate.gate_error) result
   }
 
-let accept_inbound ~resolved_binding ~dispatch_for_delivery ~team_id ~channel_id
+let accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id ~channel_id
     ~thread_ts ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention =
   match resolved_binding with
   | None ->
@@ -269,6 +285,21 @@ let accept_inbound ~resolved_binding ~dispatch_for_delivery ~team_id ~channel_id
     (* DET-OK: rendering-only fallback to stable [user_id]; identity keys
        use [user_id] directly. *)
     let user_name = Option.value user_name ~default:user_id in
+    let urgency =
+      if mentions_bot || is_app_mention then Keeper_external_attention.Mention
+      else
+        (* A Slack DM is indistinguishable from a channel message at this
+           layer (the FSM does not decode [channel_type]); a non-mention
+           triggered message in a bound channel is ambient-grade attention.
+           [Direct_message] stays for a future channel_type-aware event. *)
+        Keeper_external_attention.Ambient
+    in
+    let attention_event_id =
+      record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
+        ~thread_ts ~ts ~user_id ~user_name:(Some user_name) ~content:text
+        ~mentions_bot:(mentions_bot || is_app_mention) ~route:"triggered"
+        ~urgency
+    in
     let delivery =
       slack_delivery ~team_id ~channel_id ~thread_ts ~reply_to_thread_ts ~user_id
         ~user_name ~ts
@@ -277,13 +308,16 @@ let accept_inbound ~resolved_binding ~dispatch_for_delivery ~team_id ~channel_id
       { channel_id
       ; reply_to_thread_ts
       ; keeper_name
+      ; attention_event_id
       ; outcome =
           Channel_gate.handle_inbound
             ~dispatch:(dispatch_for_delivery delivery) msg
       }
 
-let deliver_inbound ~clock accepted =
-  let { channel_id; reply_to_thread_ts; keeper_name; outcome } = accepted in
+let deliver_inbound ~clock ~base_dir accepted =
+  let { channel_id; reply_to_thread_ts; keeper_name; attention_event_id
+      ; outcome } = accepted
+  in
   match outcome with
      | Error gate_err -> (
        match gate_err with
@@ -319,6 +353,11 @@ let deliver_inbound ~clock accepted =
            (Channel_gate.gate_error_to_string gate_err))
      | Ok out ->
        if String.equal out.content "" then begin
+         (match attention_event_id with
+          | Some event_id ->
+            mark_attention_resolved ~base_dir ~keeper_name ~event_id
+              ~reason:"slack_empty_reply"
+          | None -> ());
          Slack_observability.record_inbound_dispatch
            Slack_observability.Empty_reply;
          Slack_observability.record_reply Slack_observability.Reply_empty
@@ -329,6 +368,11 @@ let deliver_inbound ~clock accepted =
              ~reply_to_message_id:reply_to_thread_ts ()
          with
          | Ok _ ->
+           (match attention_event_id with
+            | Some event_id ->
+              mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                ~reason:"slack_reply_sent"
+            | None -> ());
            Slack_observability.record_inbound_dispatch
              Slack_observability.Reply_sent;
            Slack_observability.record_reply Slack_observability.Reply_send_ok
@@ -340,7 +384,7 @@ let deliver_inbound ~clock accepted =
              channel_id
              (Format.asprintf "%a" State.pp_send_error e)
 
-let accept_event ~resolved_binding ~dispatch_for_delivery ~team_id
+let accept_event ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
     (ev : Gw.slack_event) =
   match ev with
   | Gw.Message_create
@@ -357,17 +401,19 @@ let accept_event ~resolved_binding ~dispatch_for_delivery ~team_id
     | None ->
       Slack_observability.record_gateway_event
         ~route:Slack_observability.Triggered Slack_observability.Message_create;
-      accept_inbound ~resolved_binding ~dispatch_for_delivery ~team_id ~channel_id
-        ~thread_ts ~user_id ~user_name ~text ~ts ~mentions_bot
+      accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
+        ~channel_id ~thread_ts ~user_id ~user_name ~text ~ts ~mentions_bot
         ~is_app_mention:false)
   | Gw.App_mention { channel_id; thread_ts; user_id; text; ts } ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Triggered
       Slack_observability.App_mention;
-    accept_inbound ~resolved_binding ~dispatch_for_delivery ~team_id ~channel_id
-      ~thread_ts ~user_id
+    accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
+      ~channel_id ~thread_ts ~user_id
       ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true
   | Gw.Reaction_added _ ->
-    (* Ambient this pass: reactions are not turn-starters (RFC-0317). *)
+    (* Unreachable from the FSM's triggered lane: reactions are emitted on the
+       ambient lane only (see {!Slack_gateway_state.step}). Kept explicit for
+       the closed sum; the ambient handler records the same observability. *)
     Slack_observability.record_gateway_event ~route:Slack_observability.Ambient
       Slack_observability.Reaction_added;
     None
@@ -377,7 +423,7 @@ let accept_event ~resolved_binding ~dispatch_for_delivery ~team_id
     None
 
 let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
-    (ev : Gw.slack_event) =
+    ~base_dir (ev : Gw.slack_event) =
   let submit ~channel_id ~event_id =
     match State.resolve_keeper_for_channel_result ~channel_id with
     | Error reason ->
@@ -387,7 +433,7 @@ let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
         channel_id event_id
         (Channel_gate_binding_store.binding_store_error_to_string reason)
     | Ok resolved_binding -> (
-      match accept_event ~resolved_binding ~dispatch_for_delivery ~team_id ev with
+      match accept_event ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id ev with
       | None -> ()
       | Some accepted ->
         let lane = Connector_ingress_lane.Keeper_lane accepted.keeper_name in
@@ -397,7 +443,7 @@ let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
         let delivery =
           match deliver with
           | Some deliver -> deliver
-          | None -> fun () -> deliver_inbound ~clock accepted
+          | None -> fun () -> deliver_inbound ~clock ~base_dir accepted
         in
         match
           Connector_ingress_lane.submit
@@ -417,12 +463,12 @@ let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
   match ev with
   | Gw.Message_create { bot_id = Some _; _ } ->
     (* See [accept_event]: this variant only records observability. *)
-    ignore (accept_event ~resolved_binding:None ~dispatch_for_delivery ~team_id ev)
+    ignore (accept_event ~resolved_binding:None ~dispatch_for_delivery ~base_dir ~team_id ev)
   | Gw.Message_create { channel_id; ts; bot_id = None; _ }
   | Gw.App_mention { channel_id; ts; _ } -> submit ~channel_id ~event_id:ts
   | Gw.Reaction_added _ | Gw.Ignored_event _ ->
     (* See [accept_event]: these variants only record observability. *)
-    ignore (accept_event ~resolved_binding:None ~dispatch_for_delivery ~team_id ev)
+    ignore (accept_event ~resolved_binding:None ~dispatch_for_delivery ~base_dir ~team_id ev)
 ;;
 
 (* Ambient lane recording: a bound-channel message that failed the trigger
@@ -464,6 +510,7 @@ let handle_ambient ?resolved_keeper_name ~base_dir ~team_id ~channel_id
       let attention_event_id =
         record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
           ~thread_ts ~ts ~user_id ~user_name ~content:trimmed ~mentions_bot
+          ~route:"ambient" ~urgency:Keeper_external_attention.Ambient
       in
       Keeper_chat_store.append_user_message
         ~base_dir ~keeper_name ~content:trimmed
@@ -617,6 +664,8 @@ let submit_ambient_event ?team_id ingress ~base_dir (ev : Gw.slack_event) =
 module For_testing = struct
   let submit_event = submit_event
   let submit_ambient_event = submit_ambient_event
+  let record_external_attention = record_external_attention
+  let mark_attention_resolved = mark_attention_resolved
 end
 
 (* ---------------------------------------------------------------- *)
@@ -699,6 +748,7 @@ let start ~sw ~env ~state =
                  ~dispatch_for_delivery:(dispatch_for_config config)
                  ?team_id
                  ~clock
+                 ~base_dir:config.base_path
                  ev)
              ~on_ambient:(fun ev ->
                let config = Mcp_server.workspace_config state in

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -67,6 +67,7 @@ module For_testing : sig
     dispatch_for_delivery:
       (Gate_keeper_backend.connector_delivery -> Channel_gate.dispatch_fn) ->
     clock:_ Eio.Time.clock ->
+    base_dir:string ->
     Slack_socket_client.slack_event ->
     unit
 
@@ -75,6 +76,30 @@ module For_testing : sig
     Connector_ingress_lane.t ->
     base_dir:string ->
     Slack_socket_client.slack_event ->
+    unit
+
+  val record_external_attention :
+    base_dir:string ->
+    keeper_name:string ->
+    team_id:string option ->
+    channel_id:string ->
+    thread_ts:string option ->
+    ts:string ->
+    user_id:string ->
+    user_name:string option ->
+    content:string ->
+    mentions_bot:bool ->
+    route:string ->
+    urgency:Keeper_external_attention.urgency ->
+    string option
+  (** The durable attention producer used by both the triggered and ambient
+      lanes; exposed for durable round-trip tests. *)
+
+  val mark_attention_resolved :
+    base_dir:string ->
+    keeper_name:string ->
+    event_id:string ->
+    reason:string ->
     unit
 end
 

--- a/test/dune
+++ b/test/dune
@@ -1638,6 +1638,8 @@
 
 (include stanzas/test_slack_rest_client.inc)
 
+(include stanzas/test_server_slack_gateway_attention.inc)
+
 (include stanzas/test_discord_wss_bridge.inc)
 
 (include stanzas/test_discord_wss_lifecycle.inc)

--- a/test/stanzas/test_server_slack_gateway_attention.inc
+++ b/test/stanzas/test_server_slack_gateway_attention.inc
@@ -1,0 +1,6 @@
+; Slack gateway external-attention durable round trips (triggered + ambient).
+; Links masc_test_deps for masc.server (Server_slack_*).
+(test
+ (name test_server_slack_gateway_attention)
+ (modules test_server_slack_gateway_attention)
+ (libraries alcotest masc masc_test_deps))

--- a/test/test_server_slack_gateway_attention.ml
+++ b/test/test_server_slack_gateway_attention.ml
@@ -1,0 +1,114 @@
+(* Slack gateway external-attention round trips.
+
+   Pins the durable producer the Slack gateway's triggered and ambient lanes
+   share ({!Server_slack_in_process_gateway.For_testing.record_external_attention})
+   and the reply-time resolution ({!mark_attention_resolved}): a recorded
+   Slack event is pending with its typed surface/urgency, a duplicate wire
+   delivery dedups to the same event identity, and a sent reply retires the
+   event from the pending projection. *)
+
+open Alcotest
+module G = Server_slack_in_process_gateway
+module A = Masc.Keeper_external_attention
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let with_temp_base name f =
+  let base_path = temp_base_path name in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_path with _ -> ())
+    (fun () -> f base_path)
+
+let pending ~base_path ~keeper_name =
+  A.pending_for_keeper ~base_path ~keeper_name ~limit:10 ()
+
+let record ~base_path ?(team_id = Some "T1") ?(thread_ts = None) ~ts ~route
+    ~urgency () =
+  G.For_testing.record_external_attention ~base_dir:base_path
+    ~keeper_name:"sangsu" ~team_id ~channel_id:"C1" ~thread_ts ~ts
+    ~user_id:"U1" ~user_name:(Some "user-one") ~content:"hello keeper"
+    ~mentions_bot:(urgency = A.Mention) ~route ~urgency
+
+let test_triggered_record_is_pending_with_slack_surface () =
+  with_temp_base "slack-attention-triggered" @@ fun base_path ->
+  match record ~base_path ~ts:"1700000000.000100" ~route:"triggered"
+          ~urgency:A.Mention () with
+  | None -> fail "record returned None"
+  | Some event_id -> (
+    match pending ~base_path ~keeper_name:"sangsu" with
+    | [ item ] ->
+      check string "event id" event_id item.A.event_id;
+      check string "urgency" "mention" (A.urgency_to_string item.A.urgency);
+      check string "conversation" "slack:channel:C1"
+        item.A.conversation.A.conversation_id;
+      (match item.A.conversation.A.surface with
+       | A.Slack { team_id; channel_id; thread_ts } ->
+         check (option string) "team" (Some "T1") team_id;
+         check string "channel" "C1" channel_id;
+         check (option string) "thread" None thread_ts
+       | _ -> fail "expected Slack surface")
+    | items ->
+      failf "expected exactly one pending item, got %d" (List.length items))
+
+let test_ambient_record_uses_ambient_urgency () =
+  with_temp_base "slack-attention-ambient" @@ fun base_path ->
+  match record ~base_path ~ts:"1700000000.000200" ~route:"ambient"
+          ~urgency:A.Ambient () with
+  | None -> fail "record returned None"
+  | Some _ -> (
+    match pending ~base_path ~keeper_name:"sangsu" with
+    | [ item ] ->
+      check string "urgency" "ambient" (A.urgency_to_string item.A.urgency)
+    | items ->
+      failf "expected exactly one pending item, got %d" (List.length items))
+
+let test_duplicate_wire_delivery_keeps_one_pending () =
+  with_temp_base "slack-attention-dedupe" @@ fun base_path ->
+  let first =
+    record ~base_path ~ts:"1700000000.000300" ~route:"triggered"
+      ~urgency:A.Mention ()
+  in
+  let second =
+    record ~base_path ~ts:"1700000000.000300" ~route:"triggered"
+      ~urgency:A.Mention ()
+  in
+  check (option string) "same event id" first second;
+  check int "one pending" 1 (List.length (pending ~base_path ~keeper_name:"sangsu"))
+
+let test_sent_reply_retires_attention () =
+  with_temp_base "slack-attention-resolve" @@ fun base_path ->
+  match record ~base_path ~ts:"1700000000.000400" ~route:"triggered"
+          ~urgency:A.Mention () with
+  | None -> fail "record returned None"
+  | Some event_id ->
+    check int "pending before reply" 1
+      (List.length (pending ~base_path ~keeper_name:"sangsu"));
+    G.For_testing.mark_attention_resolved ~base_dir:base_path
+      ~keeper_name:"sangsu" ~event_id ~reason:"slack_reply_sent";
+    check int "pending after reply" 0
+      (List.length (pending ~base_path ~keeper_name:"sangsu"))
+
+let () =
+  run "Server_slack_gateway_attention"
+    [ "attention"
+      , [ test_case "triggered record pending with slack surface" `Quick
+            test_triggered_record_is_pending_with_slack_surface
+        ; test_case "ambient record uses ambient urgency" `Quick
+            test_ambient_record_uses_ambient_urgency
+        ; test_case "duplicate wire delivery keeps one pending" `Quick
+            test_duplicate_wire_delivery_keeps_one_pending
+        ; test_case "sent reply retires attention" `Quick
+            test_sent_reply_retires_attention
+        ]
+    ]

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -257,6 +257,7 @@ let test_bound_message_queues_exact_slack_ts () =
           failwith "observe Slack ingress identity")
         ingress ~dispatch_for_delivery
         ~clock:(Eio.Stdenv.clock env)
+        ~base_dir:(Env_config_core.base_path ())
         (slack_message ~ts:"1710000000.123456");
       check bool "accept completed before handoff" true !accepted_before_delivery;
       (match !observed_delivery with
@@ -335,6 +336,7 @@ let test_binding_store_failure_does_not_enqueue () =
       ~deliver:(fun () -> fail "binding failure must not schedule delivery")
       ingress ~dispatch_for_delivery
       ~clock:(Eio.Stdenv.clock env)
+      ~base_dir:(Env_config_core.base_path ())
       (slack_message ~ts:"1710000000.654321");
     Eio.Fiber.yield ();
     check bool "no volatile job accepted" false !dispatch_called;


### PR DESCRIPTION
## 무엇을 바꾸나

#25262(ambient lane, 머지됨)가 남긴 attention parity 괴리를 닫는 후속. Discord의 triggered 경로는 accept 시점에 durable external attention을 기록(route=triggered)하고 reply가 settle되면 resolve하는데, Slack의 `deliver_inbound`는 둘 다 없었다 — Slack triggered lane에서 attention row가 생기지도 retire되지도 않았다.

**변경**:
- `accept_inbound`: durable attention 기록(urgency: 봇 mention이면 `Mention`, 아니면 `Ambient`) + event id를 `accepted_inbound`에 스레딩
- `deliver_inbound`: reply settle 시 resolve — 빈 keeper 응답은 `slack_empty_reply`, 전송 성공은 `slack_reply_sent`. gate error/오프라인 notice/전송 실패는 pending 유지(Discord와 동일)
- `record_external_attention`을 `~route`/`~urgency`로 일반화(ambient lane은 `route=ambient`/`Ambient` 그대로)
- Direct_message 미분류는 명시적 보류: Slack message event의 `channel_type`을 FSM이 decode하지 않아 DM과 채널을 구분할 수 없음. 코드 주석 + 이 본문에 기록

## 검증 (head `80897c22f1`, 최신 main rebase 후)

- focused build `lib/server` 통과
- 신규 `test_server_slack_gateway_attention` 4개 통과(record→pending→dedupe→resolve 왕복)
- 기존 `test_server_slack_trigger_policy` 17개, `test_slack_gateway_state` 28개 회귀 없음(새 `~base_dir` 인자 반영)
- ocamlformat 0.29.0 --check 통과

## 관련

- 선행: #25262(ambient lane parity, 머지), RFC-0226, RFC-0317
- goal matrix G9 connector attention 라인