### PR TITLE
test(tool-schema): catalog-wide OAS boundary regression guard (complements #25274)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -273,6 +273,7 @@
   test_keeper_sandbox_read_backend
   test_keeper_path_ssot
   test_tool_input_validation
+  test_tool_schema_oas_boundary
   test_task_completion_claim
   test_ocaml_north_star_task_lifecycle
   test_tool_blob_store
@@ -580,6 +581,7 @@
   test_keeper_sandbox_read_backend
   test_keeper_path_ssot
   test_tool_input_validation
+  test_tool_schema_oas_boundary
   ; test_contract_risk removed (team session cleanup)
   ; test_contract_composer removed (team session cleanup)
   test_task_completion_claim

--- a/test/test_tool_schema_oas_boundary.ml
+++ b/test/test_tool_schema_oas_boundary.ml
@@ -1,0 +1,62 @@
+(** Regression guard for #25272 — keeper tool schemas must convert cleanly
+    through the OAS boundary.
+
+    On 2026-07-19T01:41Z every keeper cycle began crashing with
+
+      Invalid_argument("property \"limit\" type array must contain exactly
+                        one non-null type")
+
+    A [limit] property had been widened to ["type": ["integer","string"]] to
+    accept numeric-string arguments (Issue #18472). But
+    [Tool_bridge.params_of_json_schema] delegates to
+    [Agent_sdk.Mcp.json_schema_to_params] (OAS #2343, fail-closed on schema
+    types it cannot map to a single param type), which raises Invalid_argument
+    on a multi-non-null-type union. The uncaught exception took down the whole
+    keeper turn — every tool, not just the offending one.
+
+    This test asserts the canonical keeper catalog never reintroduces a schema
+    the OAS boundary cannot convert (multi-type union, unknown property type,
+    malformed [type], ...). It runs the real boundary function used at
+    dispatch, so it fails the same way the runtime would — before deploy,
+    not in production. *)
+
+open Masc
+
+(** Every schema the keeper projects to its model, from the canonical
+    catalog. New shards added to [Tool_shard.all_keeper_tool_schemas] are
+    covered automatically. *)
+let keeper_schemas : Masc_domain.tool_schema list = Tool_shard.all_keeper_tool_schemas
+
+let test_catalog_non_empty () =
+  Alcotest.(check bool)
+    "keeper catalog is non-empty (guards against an empty-list false pass)"
+    true
+    (keeper_schemas <> [])
+
+let test_all_keeper_schemas_convert () =
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+       match Agent_sdk.Mcp.json_schema_to_params_result schema.input_schema with
+       | Ok _ -> ()
+       | Error detail ->
+         Alcotest.failf
+           "tool schema %S is not convertible by the OAS boundary \
+            (Agent_sdk.Mcp.json_schema_to_params): %s. A multi-non-null-type \
+            union or an unknown property type here raises Invalid_argument and \
+            crashes the keeper turn (#25272). Use a single [type] per property."
+           schema.name
+           detail)
+    keeper_schemas
+
+let () =
+  Alcotest.run
+    "tool_schema_oas_boundary"
+    [ ( "boundary"
+      , [ Alcotest.test_case "keeper catalog non-empty" `Quick test_catalog_non_empty
+        ; Alcotest.test_case
+            "all keeper tool schemas convert through the OAS boundary"
+            `Quick
+            test_all_keeper_schemas_convert
+        ] )
+    ]
+;;

--- a/test/test_tool_schema_oas_boundary.ml
+++ b/test/test_tool_schema_oas_boundary.ml
@@ -14,18 +14,20 @@
     on a multi-non-null-type union. The uncaught exception took down the whole
     keeper turn — every tool, not just the offending one.
 
-    This test asserts the canonical keeper catalog never reintroduces a schema
-    the OAS boundary cannot convert (multi-type union, unknown property type,
-    malformed [type], ...). It runs the real boundary function used at
-    dispatch, so it fails the same way the runtime would — before deploy,
-    not in production. *)
+    This test asserts the descriptor-derived Keeper model catalog never
+    reintroduces a schema the OAS boundary cannot convert (multi-type union,
+    unknown property type, malformed [type], ...). It runs the same MASC/OAS
+    bridge used while constructing the Keeper tool bundle, so it fails the
+    same way the runtime would — before deploy, not in production. *)
 
 open Masc
 
-(** Every schema the keeper projects to its model, from the canonical
-    catalog. New shards added to [Tool_shard.all_keeper_tool_schemas] are
-    covered automatically. *)
-let keeper_schemas : Masc_domain.tool_schema list = Tool_shard.all_keeper_tool_schemas
+(** Every descriptor-derived schema projected into the OAS Keeper tool bundle.
+    This is the same materialized catalog consumed by
+    [Keeper_tools_oas_bundle.make_tool_bundle], including descriptor-owned
+    schemas that do not appear in [Tool_shard.all_keeper_tool_schemas]. *)
+let keeper_schemas : Masc_domain.tool_schema list =
+  Keeper_tool_policy.keeper_model_tool_schemas ()
 
 let test_catalog_non_empty () =
   Alcotest.(check bool)
@@ -36,14 +38,14 @@ let test_catalog_non_empty () =
 let test_all_keeper_schemas_convert () =
   List.iter
     (fun (schema : Masc_domain.tool_schema) ->
-       match Agent_sdk.Mcp.json_schema_to_params_result schema.input_schema with
-       | Ok _ -> ()
-       | Error detail ->
+       match Tool_bridge.params_of_json_schema schema.input_schema with
+       | _ -> ()
+       | exception Invalid_argument detail ->
          Alcotest.failf
-           "tool schema %S is not convertible by the OAS boundary \
-            (Agent_sdk.Mcp.json_schema_to_params): %s. A multi-non-null-type \
-            union or an unknown property type here raises Invalid_argument and \
-            crashes the keeper turn (#25272). Use a single [type] per property."
+           "Keeper model tool schema %S is not convertible by the MASC/OAS \
+            boundary (Tool_bridge.params_of_json_schema): %s. Fix the reported \
+            descriptor-owned or canonical schema before exposing it to OAS \
+            (#25272)."
            schema.name
            detail)
     keeper_schemas


### PR DESCRIPTION
## 목표

tool 스키마가 OAS 경계에서 크래시하는 결함 **클래스**를 컴파일-검증 가드로 닫는다. #25274(이미 머지)를 보완.

## 배경

#25274가 `limit` 유니온(`["integer","string"]`, Issue #18472)을 단일 타입으로 되돌려 keeper-cycle 전면 크래시(#25272, `Invalid_argument("property "limit" type array must contain exactly one non-null type")`)를 수리했다. 함께 추가된 `test_limit_schema_widen`은 **5개 명명 도구의 `limit` 속성**이 단일 스칼라인지 문자열 검사한다.

그 가드는 `limit` 특정이다. 같은 결함 클래스는 다른 속성/새 도구에서도 재발할 수 있다:
- 다른 파라미터(`count`, `max_results` 등)에 동일한 wire-format 유니온 widening
- 새 도구가 unknown/malformed JSON Schema 타입을 노출
- 이들은 모두 `json_schema_to_params`를 `invalid_arg`로 크래시시키지만 `limit` 검사는 못 잡는다.

## 변경

`test/test_tool_schema_oas_boundary.ml` 추가 — **정규 keeper 카탈로그 전량**(`Tool_shard.all_keeper_tool_schemas`)을 **실제 OAS 경계 함수** `Agent_sdk.Mcp.json_schema_to_params_result`에 통과시켜 모든 스키마가 `Ok`로 변환됨을 단언한다.

- 특정 속성명이 아닌 **경계 함수 자체**로 검증 → multi-type union·unknown type·malformed type 등 boundary를 크래시시킬 모든 스키마 결함을 잡는다.
- 카탈로그 기반이므로 **새 shard/도구가 추가되면 자동 커버**된다.
- 빈 카탈로그 false-pass 방지용 non-empty 단언 포함.

`test_limit_schema_widen`(값 검사, limit 특정)과 상보: 이 PR은 결함 *클래스*(경계 변환 실패)를, 그 테스트는 특정 회귀(limit union)를 방어한다.

## 검증

- 로컬 빌드 + 테스트: green 2/2 (main 기준, #25274 fix 반영 상태) — `<채우기>`.
- Counterfactual(이전 검증, #25282 최초 리비전): `limit`을 유니온으로 되돌리면 이 테스트가 `[FAIL] keeper_board_list ... exactly one non-null type`로 red → 실효성 확인.

## 이력

이 PR은 원래 #25272 fix(스키마 단일화)로 열렸으나, 같은 시각 #25274가 fix를 먼저 머지했다. 중복 스키마 편집을 버리고 **비중복 잔여물(카탈로그 전수 boundary 가드)만 salvage**해 재목적화했다.

관련: #25272(원 P0), #25274(fix, merged), #25278(P0가 가렸던 garnet wedge, 별도).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
