### PR TITLE
feat(fusion): persist typed deliberation evidence

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -9,16 +9,9 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-type deliberation =
-  { panel : Fusion_types.panel_outcome list
-  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
-  ; judges : Fusion_types.judge_node list
-  ; judge_usage : Fusion_types.usage
-  }
-
 type compute_outcome =
   | Compute_denied of Fusion_types.deny_reason
-  | Computed of deliberation
+  | Computed of Fusion_types.deliberation_evidence
 
 let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
   match Fusion_policy.decide ~policy request with
@@ -378,13 +371,25 @@ let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
             | Error (_, u) -> u
           in
           List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
-          Computed { panel; judge; judges = judge_nodes; judge_usage })
+          Computed
+            { Fusion_types.question = req.prompt
+            ; panel
+            ; judge
+            ; judges = judge_nodes
+            ; judge_usage
+            })
 
-let project ~base_dir ~topology ~(request : Fusion_types.fusion_request) deliberation =
+let project
+    ~base_dir
+    ~topology
+    ~(request : Fusion_types.fusion_request)
+    (deliberation : Fusion_types.deliberation_evidence)
+  =
   match
     Fusion_sink.emit ~base_dir ~keeper:request.keeper ~run_id:request.run_id
-      ~question:request.prompt ~panel:deliberation.panel ~judge:deliberation.judge
-      ~judges:deliberation.judges ~judge_usage:deliberation.judge_usage
+      ~question:deliberation.question ~panel:deliberation.panel
+      ~judge:deliberation.judge ~judges:deliberation.judges
+      ~judge_usage:deliberation.judge_usage
   with
   | Ok () ->
     Fusion_metrics.record_invocation ~topology `Completed;

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -16,16 +16,9 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-type deliberation =
-  { panel : Fusion_types.panel_outcome list
-  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
-  ; judges : Fusion_types.judge_node list
-  ; judge_usage : Fusion_types.usage
-  }
-
 type compute_outcome =
   | Compute_denied of Fusion_types.deny_reason
-  | Computed of deliberation
+  | Computed of Fusion_types.deliberation_evidence
 
 (** Run panel and judge computation without Board, chat, wake, or run-registry
     projection. The caller can durably claim the semantic terminal before
@@ -44,7 +37,7 @@ val project
   :  base_dir:string
   -> topology:Fusion_types.fusion_topology
   -> request:Fusion_types.fusion_request
-  -> deliberation
+  -> Fusion_types.deliberation_evidence
   -> outcome
 
 (** 요청을 심의한다.

--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -10,20 +10,16 @@ type registration =
   }
 [@@deriving yojson, show, eq]
 type terminal =
-  | Succeeded of string
-  | Failed of
-      { code : string
-      ; detail : string
-      }
+  | Deliberated of Fusion_types.deliberation_evidence
+  | Aborted of string
   | Cancelled of string
+  | Interrupted_after_restart
 [@@deriving yojson, show, eq]
 type error =
   | Empty_keeper
   | Empty_run_id
   | Invalid_started_at of float
-  | Empty_success_answer
-  | Empty_failure_code
-  | Empty_failure_detail
+  | Empty_abort_detail
   | Empty_cancellation_detail
   | Partial_tail
   | Unsupported_schema_version of { line : int; found : int }
@@ -84,15 +80,14 @@ let validate_identity = function
   | _ -> Ok ()
 ;;
 let validate_terminal = function
-  | Succeeded "" -> Error Empty_success_answer
-  | Succeeded _ -> Ok ()
-  | Failed { code = ""; _ } -> Error Empty_failure_code
-  | Failed { detail = ""; _ } -> Error Empty_failure_detail
-  | Failed _ -> Ok ()
+  | Deliberated _ -> Ok ()
+  | Aborted "" -> Error Empty_abort_detail
+  | Aborted _ -> Ok ()
   | Cancelled "" -> Error Empty_cancellation_detail
   | Cancelled _ -> Ok ()
+  | Interrupted_after_restart -> Ok ()
 ;;
-let schema_version = 1
+let schema_version = 2
 let event_line event =
   Yojson.Safe.to_string (persisted_record_to_yojson { schema_version; event }) ^ "\n"
 ;;
@@ -109,13 +104,13 @@ let parse_events content =
       | line :: rest ->
         let parsed =
           try
-            let parsed =
+            let record_result =
               Yojson.Safe.from_string line
               |> persisted_record_of_yojson
               |> Result.map_error (fun detail ->
                 Invalid_record { line = line_number; detail })
             in
-            Result.bind parsed (fun record ->
+            Result.bind record_result (fun record ->
               if Int.equal record.schema_version schema_version
               then Ok record.event
               else

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -9,20 +9,16 @@ type registration =
   ; started_at : float
   }
 type terminal =
-  | Succeeded of string
-  | Failed of
-      { code : string
-      ; detail : string
-      }
+  | Deliberated of Fusion_types.deliberation_evidence
+  | Aborted of string
   | Cancelled of string
+  | Interrupted_after_restart
 val equal_terminal : terminal -> terminal -> bool
 type error =
   | Empty_keeper
   | Empty_run_id
   | Invalid_started_at of float
-  | Empty_success_answer
-  | Empty_failure_code
-  | Empty_failure_detail
+  | Empty_abort_detail
   | Empty_cancellation_detail
   | Partial_tail
   | Unsupported_schema_version of { line : int; found : int }

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -255,6 +255,43 @@ type judge_outcome =
   | Judge_failed of judge_error_node  (** panel [Failed] 대칭. *)
 [@@deriving yojson, show, eq]
 
+let result_to_yojson ok_to_yojson error_to_yojson = function
+  | Ok value -> `List [ `String "Ok"; ok_to_yojson value ]
+  | Error error -> `List [ `String "Error"; error_to_yojson error ]
+;;
+
+let result_of_yojson ok_of_yojson error_of_yojson = function
+  | `List [ `String "Ok"; value ] -> Result.map (fun value -> Ok value) (ok_of_yojson value)
+  | `List [ `String "Error"; error ] ->
+    Result.map (fun error -> Error error) (error_of_yojson error)
+  | json ->
+    Error
+      (Printf.sprintf
+         "Fusion_types.deliberation_evidence.judge: unsupported shape %s"
+         (Yojson.Safe.to_string json))
+;;
+
+let equal_result equal_ok equal_error left right =
+  match left, right with
+  | Ok left, Ok right -> equal_ok left right
+  | Error left, Error right -> equal_error left right
+  | Ok _, Error _ | Error _, Ok _ -> false
+;;
+
+let pp_result pp_ok pp_error formatter = function
+  | Ok value -> Format.fprintf formatter "(Ok %a)" pp_ok value
+  | Error error -> Format.fprintf formatter "(Error %a)" pp_error error
+;;
+
+type deliberation_evidence =
+  { question : string
+  ; panel : panel_outcome list
+  ; judge : (judge_synthesis, judge_failure) result
+  ; judges : judge_outcome list
+  ; judge_usage : usage
+  }
+[@@deriving yojson, show, eq]
+
 type fusion_trigger =
   | Explicit_tool_call
   | Low_confidence

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -266,6 +266,18 @@ type judge_outcome =
   | Judge_failed of judge_error_node
 [@@deriving yojson, show, eq]
 
+(** One completed panel+judge computation before any Board/chat/wake projection.
+    This is the durable semantic evidence claimed by the run authority; projection
+    failures are deliberately outside this record. *)
+type deliberation_evidence =
+  { question : string
+  ; panel : panel_outcome list
+  ; judge : (judge_synthesis, judge_failure) result
+  ; judges : judge_outcome list
+  ; judge_usage : usage
+  }
+[@@deriving yojson, show, eq]
+
 (** {1 트리거} *)
 
 (** fusion 발동 사유 — 게이트 입력(이유 라벨). catch-all 없음.

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -1,4 +1,5 @@
 open Alcotest
+open Fusion_types
 module A = Fusion_run_authority
 let fresh_base () =
   let path = Filename.temp_file "fusion-authority-" "" in
@@ -6,8 +7,60 @@ let fresh_base () =
   Unix.mkdir path 0o700;
   path
 ;;
-let success answer = A.Succeeded answer
-let failure ~code detail = A.Failed { code; detail }
+let usage input_tokens output_tokens : Fusion_types.usage =
+  { input_tokens; output_tokens }
+;;
+
+let synthesis resolved_answer : Fusion_types.judge_synthesis =
+  { consensus = [ { text = "typed consensus"; supporting_models = [ "panel-a" ] } ]
+  ; contradictions = []
+  ; partial_coverage = []
+  ; unique_insights = [ { insight_text = "typed insight"; from_model = "panel-a" } ]
+  ; blind_spots = [ "unobserved edge" ]
+  ; resolved_answer
+  ; decision = Answer resolved_answer
+  }
+;;
+
+let successful_evidence () : Fusion_types.deliberation_evidence =
+  let judge = synthesis "durable answer" in
+  { question = "Which design preserves the authority boundary?"
+  ; panel =
+      [ Answered { model = "panel-a"; answer = "typed answer"; usage = usage 7 3 }
+      ; Failed { failed_model = "panel-b"; reason = Provider_error "transport" }
+      ]
+  ; judge = Ok judge
+  ; judges =
+      [ Synthesized { role = First "judge-a"; synthesis = judge; usage = usage 11 5 }
+      ; Judge_failed
+          { failed_role = First "judge-b"
+          ; failure = Timeout
+          ; usage = usage 13 0
+          ; elapsed_s = Some 0.5
+          }
+      ]
+  ; judge_usage = usage 24 5
+  }
+;;
+
+let failed_evidence () : Fusion_types.deliberation_evidence =
+  let failure = Panels_unavailable (No_panel_answers { total = 1 }) in
+  { question = "Can a typed judge failure survive restart?"
+  ; panel = [ Failed { failed_model = "panel-a"; reason = Timeout } ]
+  ; judge = Error failure
+  ; judges =
+      [ Judge_failed
+          { failed_role = Single
+          ; failure
+          ; usage = usage 2 0
+          ; elapsed_s = Some 0.25
+          }
+      ]
+  ; judge_usage = usage 2 0
+  }
+;;
+
+let deliberated evidence = A.Deliberated evidence
 let run_file directory keeper run_id =
   let key = Printf.sprintf "%d:%s%d:%s" (String.length keeper) keeper (String.length run_id) run_id in
   let digest = Digestif.SHA256.(digest_string key |> to_hex) in
@@ -32,7 +85,7 @@ let test_exact_lifecycle_and_validation () =
   (match A.register restarted ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
    | Ok A.Already_running -> ()
    | _ -> fail "exact registration retry must be idempotent");
-  let winner = success "answer" in
+  let winner = deliberated (successful_evidence ()) in
   (match A.claim_terminal store ~keeper:"k" ~run_id:"r" winner with
    | Ok A.First_committed -> ()
    | _ -> fail "first terminal must commit");
@@ -45,23 +98,32 @@ let test_exact_lifecycle_and_validation () =
    | _ -> fail "restart must retain the winner");
   (match
      A.claim_terminal store ~keeper:"k" ~run_id:"r"
-       (failure ~code:"judge_failed" "detail")
+       (deliberated (failed_evidence ()))
    with
    | Ok (A.Conflict terminal) ->
      check bool "conflict returns exact winner" true (A.equal_terminal winner terminal)
    | _ -> fail "different terminal must conflict");
-  let reject terminal expected =
-    match A.claim_terminal store ~keeper:"k" ~run_id:"other" terminal, expected with
-    | Error A.Empty_success_answer, `Answer
-    | Error A.Empty_failure_code, `Code
-    | Error A.Empty_failure_detail, `Detail
-    | Error A.Empty_cancellation_detail, `Cancel -> ()
-    | _ -> fail "terminal validation returned the wrong result"
-  in
-  reject (success "") `Answer;
-  reject (failure ~code:"" "detail") `Code;
-  reject (failure ~code:"code" "") `Detail;
-  reject (A.Cancelled "") `Cancel;
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"other" (A.Cancelled "") with
+   | Error A.Empty_cancellation_detail -> ()
+   | _ -> fail "empty cancellation detail was accepted");
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"other" (A.Aborted "") with
+   | Error A.Empty_abort_detail -> ()
+   | _ -> fail "empty abort detail was accepted");
+  (match
+     A.register store ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:2.
+   with
+   | Ok A.Registered -> ()
+   | _ -> fail "typed-failure registration failed");
+  let typed_failure = deliberated (failed_evidence ()) in
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"typed-failure" typed_failure with
+   | Ok A.First_committed -> ()
+   | _ -> fail "typed failure terminal did not commit");
+  (match
+     A.register restarted ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:2.
+   with
+   | Ok (A.Already_settled terminal) ->
+     check bool "typed failure survives restart" true (A.equal_terminal typed_failure terminal)
+   | _ -> fail "typed failure terminal was not reloaded exactly");
   match A.claim_terminal store ~keeper:"k" ~run_id:"missing" (A.Cancelled "shutdown") with
   | Error A.Orphan_terminal -> ()
   | _ -> fail "terminal without durable registration must be rejected"
@@ -79,42 +141,60 @@ let test_corruption_is_per_run_and_semantic () =
   let bad_path = run_file directory "k" "bad" in
   let registered = Fs_compat.load_file bad_path in
   Fs_compat.save_file bad_path (String.sub registered 0 (String.length registered - 1));
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (success "answer") with
+  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (deliberated (successful_evidence ())) with
    | Error A.Partial_tail -> ()
    | _ -> fail "partial tail must fail explicitly");
   register "peer";
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"peer" (success "peer answer") with
+  (match
+     A.claim_terminal store ~keeper:"k" ~run_id:"peer"
+       (deliberated (successful_evidence ()))
+   with
    | Ok A.First_committed -> ()
    | _ -> fail "corrupt peer must not block an unrelated run");
   let versioned =
     match Yojson.Safe.from_string registered with
-    | `Assoc fields -> `Assoc (("schema_version", `Int 2) :: List.remove_assoc "schema_version" fields)
+    | `Assoc fields -> `Assoc (("schema_version", `Int 1) :: List.remove_assoc "schema_version" fields)
     | _ -> fail "registered record was not an object"
   in
   Fs_compat.save_file bad_path (Yojson.Safe.to_string versioned ^ "\n");
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (success "answer") with
-   | Error (A.Unsupported_schema_version { found = 2; _ }) -> ()
+  (match
+     A.claim_terminal store ~keeper:"k" ~run_id:"bad"
+       (deliberated (successful_evidence ()))
+   with
+   | Error (A.Unsupported_schema_version { found = 1; _ }) -> ()
    | _ -> fail "unsupported schema version must fail explicitly");
   register "order";
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+  (match
+     A.claim_terminal store ~keeper:"k" ~run_id:"order"
+       (deliberated (successful_evidence ()))
+   with
    | Ok A.First_committed -> ()
    | _ -> fail "ordered terminal did not commit");
   let order_path = run_file directory "k" "order" in
   (match String.split_on_char '\n' (Fs_compat.load_file order_path) with
    | [ registration; terminal; "" ] ->
      Fs_compat.save_file order_path (terminal ^ "\n");
-     (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+     (match
+        A.claim_terminal store ~keeper:"k" ~run_id:"order"
+          (deliberated (successful_evidence ()))
+      with
       | Error A.Orphan_terminal -> ()
       | _ -> fail "orphan terminal must fail explicitly");
      Fs_compat.save_file order_path (terminal ^ "\n" ^ registration ^ "\n");
-     (match A.claim_terminal store ~keeper:"k" ~run_id:"order" (success "ordered") with
+     (match
+        A.claim_terminal store ~keeper:"k" ~run_id:"order"
+          (deliberated (successful_evidence ()))
+      with
       | Error A.Reversed_records -> ()
       | _ -> fail "reversed records must fail explicitly")
    | _ -> fail "expected exact register/terminal JSONL pair");
   let foreign_path = run_file directory "k" "foreign" in
   Fs_compat.save_file foreign_path
     (Fs_compat.load_file (run_file directory "k" "peer"));
-  match A.claim_terminal store ~keeper:"k" ~run_id:"foreign" (success "foreign") with
+  match
+    A.claim_terminal store ~keeper:"k" ~run_id:"foreign"
+      (deliberated (successful_evidence ()))
+  with
   | Error (A.Identity_mismatch _) -> ()
   | _ -> fail "hashed path must still verify persisted identity"
 ;;


### PR DESCRIPTION
## What
- define Fusion_types.deliberation_evidence as the single semantic result type
- preserve question, panel outcomes, typed judge result, judge topology, and usage
- persist Deliberated, Aborted, Cancelled, and Interrupted_after_restart terminals
- hard-cut the unreleased authority schema to version 2
- project the exact question carried by the claimed evidence

## Why
An answer-only terminal cannot reconstruct Board/chat evidence after restart and collapses typed judge failures. Projection identifiers also do not belong in semantic authority. The authority must retain the complete LLM deliberation before any external effect runs.

## Proof
- focused authority and orchestrator builds passed
- authority executable: 2/2 tests passed
- typed judge failure round-trips across restart
- corrupt run remains isolated from its peer
- git diff --check passed

Stacked on #25269. 259 changed lines.