### PR TITLE
fix(gateway): gate ambient user-line append on typed fresh/duplicate record

### DIFF
--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -30,6 +30,7 @@ type inbound_outcome =
 
 type ambient_outcome =
   | Ambient_recorded
+  | Ambient_deduped
   | Ambient_binding_store_error
   | Ambient_dropped_unbound
   | Ambient_dropped_empty
@@ -62,6 +63,7 @@ let inbound_outcome_label = function
 
 let ambient_outcome_label = function
   | Ambient_recorded -> "recorded"
+  | Ambient_deduped -> "deduped"
   | Ambient_binding_store_error -> "binding_store_error"
   | Ambient_dropped_unbound -> "dropped_unbound"
   | Ambient_dropped_empty -> "dropped_empty"

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -34,6 +34,10 @@ type inbound_outcome =
 
 type ambient_outcome =
   | Ambient_recorded
+  | Ambient_deduped
+      (** Redelivery of an already-recorded event: the attention store held the
+          duplicate, so the ambient arm skipped the non-idempotent transcript
+          append (masc#25262). *)
   | Ambient_binding_store_error
   | Ambient_dropped_unbound
   | Ambient_dropped_empty

--- a/lib/gate/slack_observability.ml
+++ b/lib/gate/slack_observability.ml
@@ -28,6 +28,7 @@ type inbound_outcome =
 
 type ambient_outcome =
   | Ambient_recorded
+  | Ambient_deduped
   | Ambient_binding_store_error
   | Ambient_dropped_unbound
   | Ambient_dropped_empty
@@ -60,6 +61,7 @@ let inbound_outcome_label = function
 
 let ambient_outcome_label = function
   | Ambient_recorded -> "recorded"
+  | Ambient_deduped -> "deduped"
   | Ambient_binding_store_error -> "binding_store_error"
   | Ambient_dropped_unbound -> "dropped_unbound"
   | Ambient_dropped_empty -> "dropped_empty"

--- a/lib/gate/slack_observability.mli
+++ b/lib/gate/slack_observability.mli
@@ -25,6 +25,10 @@ type inbound_outcome =
 
 type ambient_outcome =
   | Ambient_recorded
+  | Ambient_deduped
+      (** Redelivery of an already-recorded event: the attention store held the
+          duplicate, so the ambient arm skipped the non-idempotent transcript
+          append (masc#25262). *)
   | Ambient_binding_store_error
   | Ambient_dropped_unbound
   | Ambient_dropped_empty

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -158,6 +158,16 @@ let discord_delivery ~guild_id ~channel_id ~message_id ~author_id :
   ; external_message_id = Some message_id
   }
 
+(* Typed outcome of recording an external-attention event, so the ambient arm
+   can gate the non-idempotent transcript append on the store's already-computed
+   fresh-vs-duplicate decision (masc#25262). The event_id is carried in both
+   the [Fresh] and [Duplicate] cases because the durable stimulus enqueue is
+   idempotent and must run on a redelivery too. *)
+type attention_record =
+  | Fresh of string  (** first delivery — event_id newly recorded *)
+  | Duplicate of string  (** redelivery — event_id already present in the store *)
+  | Record_failed  (** the attention store could not record the event *)
+
 let record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
       ~message_id ~author_id ~author_name ~content ~mentions_bot ~route ~urgency
   =
@@ -197,13 +207,13 @@ let record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
     }
   in
   match Keeper_external_attention.record ~base_path:base_dir item with
-  | `Recorded -> Some event_id
-  | `Duplicate item -> Some item.event_id
+  | `Recorded -> Fresh event_id
+  | `Duplicate item -> Duplicate item.event_id
   | `Error error ->
       Log.Server.warn
         "discord external attention record failed (channel=%s keeper=%s): %s"
         channel_id keeper_name error;
-      None
+      Record_failed
 
 let mark_attention_resolved ~base_dir ~keeper_name ~event_id ~reason =
   match
@@ -295,10 +305,18 @@ let accept_message_create ~resolved_binding ~dispatch_for_delivery
         | None -> Keeper_external_attention.Direct_message
         | Some _ -> Keeper_external_attention.Ambient
     in
+    (* Triggered path: the dispatch boundary owns the transcript append + turn.
+       This arm only needs the event_id (fresh or duplicate) to resolve the
+       attention row after a reply, so collapse the typed record to an option
+       and keep the prior behavior. *)
     let attention_event_id =
-      record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
-        ~message_id ~author_id ~author_name ~content ~mentions_bot
-        ~route:"triggered" ~urgency
+      match
+        record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
+          ~message_id ~author_id ~author_name ~content ~mentions_bot
+          ~route:"triggered" ~urgency
+      with
+      | Fresh event_id | Duplicate event_id -> Some event_id
+      | Record_failed -> None
     in
     let msg : Channel_gate.inbound_message =
       { channel = State.channel
@@ -484,39 +502,56 @@ let handle_ambient ?resolved_keeper_name ~base_dir
     else begin
       let parent_channel_id = State.parent_channel_of_thread ~channel_id in
       let thread_id = Option.map (fun _ -> channel_id) parent_channel_id in
-      let attention_event_id =
+      let recorded =
         record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
           ~message_id ~author_id ~author_name ~content:trimmed
           ~mentions_bot:false ~route:"ambient"
           ~urgency:Keeper_external_attention.Ambient
       in
-      Keeper_chat_store.append_user_message
-        ~base_dir ~keeper_name ~content:trimmed
-        ~surface:
-          (Surface_ref.Discord
-             {
-               guild_id;
-               channel_id;
-               parent_channel_id;
-               thread_id;
-             })
-        ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
-        ~external_message_id:message_id
-        ~speaker:
-          { Keeper_chat_store.speaker_id = Some author_id
-          ; speaker_name = author_name
-          ; speaker_authority = Keeper_chat_store.External
-          }
-        ();
-      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
+      (* RFC-0226 redelivery (masc#25262): the attention store already deduped
+         this event and the durable stimulus enqueue below is idempotent, but
+         [append_user_message] is not. Append + broadcast the user line only for
+         a freshly recorded event. A [Duplicate] is a gateway redelivery whose
+         line is already in the transcript — skip the append and count it as
+         deduped. [Record_failed] keeps the prior at-least-once behavior:
+         fresh-vs-duplicate is unknown, so a transient store outage must not
+         silently drop a genuinely new line. *)
+      (match recorded with
+       | Fresh _ | Record_failed ->
+         Keeper_chat_store.append_user_message
+           ~base_dir ~keeper_name ~content:trimmed
+           ~surface:
+             (Surface_ref.Discord
+                {
+                  guild_id;
+                  channel_id;
+                  parent_channel_id;
+                  thread_id;
+                })
+           ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
+           ~external_message_id:message_id
+           ~speaker:
+             { Keeper_chat_store.speaker_id = Some author_id
+             ; speaker_name = author_name
+             ; speaker_authority = Keeper_chat_store.External
+             }
+           ();
+         Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
+         Discord_observability.record_ambient
+           Discord_observability.Ambient_recorded
+       | Duplicate _ ->
+         Discord_observability.record_ambient
+           Discord_observability.Ambient_deduped);
       (* Every accepted Connector event is a durable per-Keeper stimulus. The
          event identity comes from the producer-owned external-attention row;
          no content, channel activity, elapsed-time window, or rollout flag may
          suppress it. The wake is only a hint after the durable commit, so a
          busy or lifecycle-deferred Keeper retains the exact event for its next
-         lane cycle. *)
-      (match attention_event_id with
-       | Some event_id ->
+         lane cycle. The stimulus re-offer is idempotent
+         ([enqueue_stimulus_durable_result] returns [Stimulus_already_present]),
+         so it runs on a [Duplicate] redelivery too. *)
+      (match recorded with
+       | Fresh event_id | Duplicate event_id ->
          let stimulus =
            { Keeper_event_queue.post_id = event_id
            ; urgency = Keeper_event_queue.Low
@@ -586,9 +621,7 @@ let handle_ambient ?resolved_keeper_name ~base_dir
                  keeper_name
                  event_id
                  (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)))
-       | None -> ());
-      Discord_observability.record_ambient
-        Discord_observability.Ambient_recorded
+       | Record_failed -> ())
     end
 
 let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
@@ -648,10 +681,6 @@ let submit_ingress ingress ~lane ~event_id run =
       (accept_event ~resolved_binding:None ~dispatch_for_delivery ~base_dir ev)
 ;;
 
-module For_testing = struct
-  let submit_triggered_event = submit_triggered_event
-end
-
 let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create { channel_id; message_id; _ } ->
@@ -674,6 +703,11 @@ let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
   | Gw.Thread_removed _
   | Gw.Ignored _ -> on_ambient ~base_dir ev
 ;;
+
+module For_testing = struct
+  let submit_triggered_event = submit_triggered_event
+  let submit_ambient_event = submit_ambient_event
+end
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)

--- a/lib/server/server_discord_in_process_gateway.mli
+++ b/lib/server/server_discord_in_process_gateway.mli
@@ -65,6 +65,12 @@ module For_testing : sig
     base_dir:string ->
     Discord_gateway_client.gateway_event ->
     unit
+
+  val submit_ambient_event :
+    Connector_ingress_lane.t ->
+    base_dir:string ->
+    Discord_gateway_client.gateway_event ->
+    unit
 end
 
 val start :

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -161,6 +161,16 @@ let slack_delivery ~team_id ~channel_id ~thread_ts ~reply_to_thread_ts ~user_id
 let slack_attention_surface ~team_id ~channel_id ~thread_ts =
   Keeper_external_attention.Slack { team_id; channel_id; thread_ts }
 
+(* Typed outcome of recording an external-attention event, so the ambient arm
+   can gate the non-idempotent transcript append on the store's already-computed
+   fresh-vs-duplicate decision (masc#25262). The event_id is carried in both
+   the [Fresh] and [Duplicate] cases because the durable stimulus enqueue is
+   idempotent and must run on a redelivery too. *)
+type attention_record =
+  | Fresh of string  (** first delivery — event_id newly recorded *)
+  | Duplicate of string  (** redelivery — event_id already present in the store *)
+  | Record_failed  (** the attention store could not record the event *)
+
 let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
     ~thread_ts ~ts ~user_id ~user_name ~content ~mentions_bot =
   let surface = slack_attention_surface ~team_id ~channel_id ~thread_ts in
@@ -198,13 +208,13 @@ let record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
     }
   in
   match Keeper_external_attention.record ~base_path:base_dir item with
-  | `Recorded -> Some event_id
-  | `Duplicate item -> Some item.event_id
+  | `Recorded -> Fresh event_id
+  | `Duplicate item -> Duplicate item.event_id
   | `Error error ->
     Log.Server.warn
       "slack external attention record failed (channel=%s keeper=%s): %s"
       channel_id keeper_name error;
-    None
+    Record_failed
 
 (* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)
@@ -461,30 +471,45 @@ let handle_ambient ?resolved_keeper_name ~base_dir ~team_id ~channel_id
       Slack_observability.record_ambient
         Slack_observability.Ambient_dropped_too_long
     else begin
-      let attention_event_id =
+      let recorded =
         record_external_attention ~base_dir ~keeper_name ~team_id ~channel_id
           ~thread_ts ~ts ~user_id ~user_name ~content:trimmed ~mentions_bot
       in
-      Keeper_chat_store.append_user_message
-        ~base_dir ~keeper_name ~content:trimmed
-        ~surface:(Surface_ref.Slack { team_id; channel_id; thread_ts })
-        ~conversation_id:(slack_conversation_id ~channel_id)
-        ~external_message_id:ts
-        ~speaker:
-          { Keeper_chat_store.speaker_id = Some user_id
-          ; speaker_name = user_name
-          ; speaker_authority = Keeper_chat_store.External
-          }
-        ();
-      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
+      (* RFC-0226 redelivery (masc#25262): the attention store already deduped
+         this event and the durable stimulus enqueue below is idempotent, but
+         [append_user_message] is not. Append + broadcast the user line only for
+         a freshly recorded event. A [Duplicate] is a Slack Socket-Mode
+         redelivery whose line is already in the transcript — skip the append and
+         count it as deduped. [Record_failed] keeps the prior at-least-once
+         behavior: fresh-vs-duplicate is unknown, so a transient store outage
+         must not silently drop a genuinely new line. *)
+      (match recorded with
+       | Fresh _ | Record_failed ->
+         Keeper_chat_store.append_user_message
+           ~base_dir ~keeper_name ~content:trimmed
+           ~surface:(Surface_ref.Slack { team_id; channel_id; thread_ts })
+           ~conversation_id:(slack_conversation_id ~channel_id)
+           ~external_message_id:ts
+           ~speaker:
+             { Keeper_chat_store.speaker_id = Some user_id
+             ; speaker_name = user_name
+             ; speaker_authority = Keeper_chat_store.External
+             }
+           ();
+         Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
+         Slack_observability.record_ambient Slack_observability.Ambient_recorded
+       | Duplicate _ ->
+         Slack_observability.record_ambient Slack_observability.Ambient_deduped);
       (* Every accepted Connector event is a durable per-Keeper stimulus. The
          event identity comes from the producer-owned external-attention row;
          no content, channel activity, elapsed-time window, or rollout flag may
          suppress it. The wake is only a hint after the durable commit, so a
          busy or lifecycle-deferred Keeper retains the exact event for its next
-         lane cycle. *)
-      (match attention_event_id with
-       | Some event_id ->
+         lane cycle. The stimulus re-offer is idempotent
+         ([enqueue_stimulus_durable_result] returns [Stimulus_already_present]),
+         so it runs on a [Duplicate] redelivery too. *)
+      (match recorded with
+       | Fresh event_id | Duplicate event_id ->
          let stimulus =
            { Keeper_event_queue.post_id = event_id
            ; urgency = Keeper_event_queue.Low
@@ -550,8 +575,7 @@ let handle_ambient ?resolved_keeper_name ~base_dir ~team_id ~channel_id
                  keeper_name
                  event_id
                  (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)))
-       | None -> ());
-      Slack_observability.record_ambient Slack_observability.Ambient_recorded
+       | Record_failed -> ())
     end
 
 let on_ambient ?resolved_keeper_name ?team_id ~base_dir (ev : Gw.slack_event) =

--- a/test/stanzas/test_server_discord_trigger_policy.inc
+++ b/test/stanzas/test_server_discord_trigger_policy.inc
@@ -3,4 +3,4 @@
 (test
  (name test_server_discord_trigger_policy)
  (modules test_server_discord_trigger_policy)
- (libraries alcotest masc masc_test_deps))
+ (libraries alcotest masc masc_test_deps otel_metric_store))

--- a/test/stanzas/test_server_slack_trigger_policy.inc
+++ b/test/stanzas/test_server_slack_trigger_policy.inc
@@ -3,4 +3,4 @@
 (test
  (name test_server_slack_trigger_policy)
  (modules test_server_slack_trigger_policy)
- (libraries alcotest masc masc_test_deps))
+ (libraries alcotest masc masc_test_deps otel_metric_store))

--- a/test/test_server_discord_trigger_policy.ml
+++ b/test/test_server_discord_trigger_policy.ml
@@ -11,6 +11,8 @@ open Alcotest
 open Masc
 module G = Server_discord_in_process_gateway
 module State = Channel_gate_discord_state
+module Metrics = Otel_metric_store_core
+module Names = Otel_transport_metric_names
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
@@ -282,6 +284,105 @@ let test_durable_accept_precedes_delivery_handoff () =
     failf "expected Keeper lane, got connector:%s" connector_id
 ;;
 
+let discord_ambient_message ~message_id =
+  Discord_gateway_client.Message_create
+    { channel_id = "C123"
+    ; guild_id = Some "G123"
+    ; message_id
+    ; author_id = "U123"
+    ; author_name = Some "operator"
+    ; content = "ambient discord chatter"
+    ; raw_content = "ambient discord chatter"
+    ; resolved_mentions = []
+    ; mention_user_ids = []
+    ; mentions_bot = false
+    ; explicit_mentions_bot = false
+    ; author_is_bot = false
+    ; message_reference_channel_id = None
+    ; message_reference_message_id = None
+    ; referenced_message_author_id = None
+    }
+;;
+
+(* masc#25262 counterfactual (Discord parity): a gateway redelivery replays the
+   same ambient message (identical message_id). The attention store already
+   deduped the event, but the pre-fix ambient arm re-ran the non-idempotent
+   [append_user_message], leaving two identical user lines. With the fix the
+   second delivery is a [Duplicate]: the append is skipped (exactly one user
+   line) while the idempotent durable stimulus re-offer still runs. *)
+let test_ambient_redelivery_appends_user_line_once () =
+  with_temp_dir @@ fun base_dir ->
+  with_env Env_config_core.base_path_env_key base_dir @@ fun () ->
+  with_env Env_config_core.base_path_input_env_key base_dir @@ fun () ->
+  with_env "MASC_DISCORD_BINDING_STORE_PATH"
+    (Filename.concat base_dir "bindings.json")
+  @@ fun () ->
+  with_env "MASC_DISCORD_BINDING_AUDIT_PATH"
+    (Filename.concat base_dir "audit.jsonl")
+  @@ fun () ->
+  with_env "MASC_DISCORD_NAMES_PATH" (Filename.concat base_dir "names.json")
+  @@ fun () ->
+  (match State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test" with
+   | Error detail -> fail detail
+   | Ok _ -> ());
+  let content = "ambient discord chatter" in
+  let ambient_labels outcome =
+    [ ("outcome", Discord_observability.ambient_outcome_label outcome) ]
+  in
+  let read_metric outcome =
+    Metrics.metric_value_or_zero Names.metric_discord_ambient_record
+      ~labels:(ambient_labels outcome) ()
+  in
+  let recorded_before = read_metric Discord_observability.Ambient_recorded in
+  let deduped_before = read_metric Discord_observability.Ambient_deduped in
+  let failures = ref [] in
+  let message_id = "discord-redelivered-222" in
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let ingress =
+    Connector_ingress_lane.create ~sw
+      ~on_failure:(fun failure ->
+        failures :=
+          Connector_ingress_lane.failure_reason_to_string
+            failure.Connector_ingress_lane.reason
+          :: !failures)
+      ()
+  in
+  (* Deliver the identical ambient message twice — the gateway redelivery. *)
+  G.For_testing.submit_ambient_event ingress ~base_dir
+    (discord_ambient_message ~message_id);
+  G.For_testing.submit_ambient_event ingress ~base_dir
+    (discord_ambient_message ~message_id);
+  (* Drain the per-Keeper lane: a sentinel job on the same lane runs after both
+     ambient appends (FIFO), so awaiting it proves both completed. *)
+  let drained, resolve_drained = Eio.Promise.create () in
+  (match
+     Connector_ingress_lane.submit ingress
+       ~lane:(Connector_ingress_lane.Keeper_lane "luna")
+       ~event_id:
+         { Connector_ingress_lane.source = "test_drain"; opaque_id = message_id }
+       (fun () -> Eio.Promise.resolve resolve_drained ())
+   with
+   | Ok () -> ()
+   | Error error ->
+     failf "sentinel submit rejected: %s"
+       (Connector_ingress_lane.submit_error_to_string error));
+  Eio.Promise.await drained;
+  check (list string) "no ingress job failures" [] !failures;
+  let user_lines =
+    Keeper_chat_store.load ~base_dir ~keeper_name:"luna"
+    |> List.filter (fun (m : Keeper_chat_store.chat_message) ->
+         Keeper_chat_store.Role.equal m.role Keeper_chat_store.Role.User
+         && String.equal m.content content)
+  in
+  check int "exactly one user line for the redelivered event" 1
+    (List.length user_lines);
+  check (float 0.0001) "one fresh record" 1.0
+    (read_metric Discord_observability.Ambient_recorded -. recorded_before);
+  check (float 0.0001) "one dedup" 1.0
+    (read_metric Discord_observability.Ambient_deduped -. deduped_before)
+;;
+
 let () =
   run "server_discord_trigger_policy"
     [ ( "toml_loader"
@@ -306,5 +407,9 @@ let () =
     ; ( "ingress handoff"
       , [ test_case "durable accept precedes Discord delivery" `Quick
             test_durable_accept_precedes_delivery_handoff
+        ] )
+    ; ( "ambient redelivery"
+      , [ test_case "duplicate ambient event appends one user line" `Quick
+            test_ambient_redelivery_appends_user_line_once
         ] )
     ]

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -12,6 +12,8 @@ open Alcotest
 open Masc
 module G = Server_slack_in_process_gateway
 module State = Channel_gate_slack_state
+module Metrics = Otel_metric_store_core
+module Names = Otel_transport_metric_names
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
@@ -342,6 +344,89 @@ let test_binding_store_failure_does_not_enqueue () =
   with Exit -> ()
 ;;
 
+let slack_ambient_message ~ts =
+  Slack_gateway_state.Message_create
+    { channel_id = "C123"
+    ; thread_ts = None
+    ; user_id = "U123"
+    ; user_name = Some "operator"
+    ; text = "ambient chatter, no mention"
+    ; ts
+    ; mentions_bot = false
+    ; bot_id = None
+    }
+;;
+
+(* masc#25262 counterfactual: a Slack Socket-Mode redelivery replays the same
+   ambient event (identical ts). The attention store already deduped the event,
+   but the pre-fix ambient arm re-ran the non-idempotent [append_user_message],
+   leaving two identical user lines in the transcript. With the fix the second
+   delivery is a [Duplicate]: the append is skipped (exactly one user line)
+   while the idempotent durable stimulus re-offer still runs. *)
+let test_ambient_redelivery_appends_user_line_once () =
+  with_temp_base (fun () ->
+    match State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test" with
+    | Error detail -> fail detail
+    | Ok _ ->
+      let base_dir = Env_config_core.base_path () in
+      let content = "ambient chatter, no mention" in
+      let ambient_labels outcome =
+        [ ("outcome", Slack_observability.ambient_outcome_label outcome) ]
+      in
+      let read_metric outcome =
+        Metrics.metric_value_or_zero Names.metric_slack_ambient_record
+          ~labels:(ambient_labels outcome) ()
+      in
+      let recorded_before = read_metric Slack_observability.Ambient_recorded in
+      let deduped_before = read_metric Slack_observability.Ambient_deduped in
+      let failures = ref [] in
+      let ts = "1710000000.222222" in
+      Eio_main.run @@ fun _env ->
+      Eio.Switch.run @@ fun sw ->
+      let ingress =
+        Connector_ingress_lane.create ~sw
+          ~on_failure:(fun failure ->
+            failures :=
+              Connector_ingress_lane.failure_reason_to_string
+                failure.Connector_ingress_lane.reason
+              :: !failures)
+          ()
+      in
+      (* Deliver the identical ambient event twice — the Socket-Mode redelivery. *)
+      G.For_testing.submit_ambient_event ~team_id:"T123" ingress ~base_dir
+        (slack_ambient_message ~ts);
+      G.For_testing.submit_ambient_event ~team_id:"T123" ingress ~base_dir
+        (slack_ambient_message ~ts);
+      (* Drain the per-Keeper lane: a sentinel job on the same lane runs after
+         both ambient appends (FIFO), so awaiting it proves both completed. *)
+      let drained, resolve_drained = Eio.Promise.create () in
+      (match
+         Connector_ingress_lane.submit ingress
+           ~lane:(Connector_ingress_lane.Keeper_lane "luna")
+           ~event_id:
+             { Connector_ingress_lane.source = "test_drain"; opaque_id = ts }
+           (fun () -> Eio.Promise.resolve resolve_drained ())
+       with
+       | Ok () -> ()
+       | Error error ->
+         failf "sentinel submit rejected: %s"
+           (Connector_ingress_lane.submit_error_to_string error));
+      Eio.Promise.await drained;
+      check (list string) "no ingress job failures" [] !failures;
+      let user_lines =
+        Keeper_chat_store.load ~base_dir ~keeper_name:"luna"
+        |> List.filter (fun (m : Keeper_chat_store.chat_message) ->
+             Keeper_chat_store.Role.equal m.role Keeper_chat_store.Role.User
+             && String.equal m.content content)
+      in
+      check int "exactly one user line for the redelivered event" 1
+        (List.length user_lines);
+      check (float 0.0001) "one fresh record" 1.0
+        (read_metric Slack_observability.Ambient_recorded -. recorded_before);
+      check (float 0.0001) "one dedup" 1.0
+        (read_metric Slack_observability.Ambient_deduped -. deduped_before))
+;;
+
 let () =
   run "server_slack_trigger_policy"
     [ ( "parse_trigger_policy"
@@ -380,5 +465,9 @@ let () =
             test_bound_message_queues_exact_slack_ts
         ; test_case "binding store failure does not enqueue" `Quick
             test_binding_store_failure_does_not_enqueue
+        ] )
+    ; ( "ambient redelivery"
+      , [ test_case "duplicate ambient event appends one user line" `Quick
+            test_ambient_redelivery_appends_user_line_once
         ] )
     ]


### PR DESCRIPTION
## 증상
Slack Socket Mode(및 Discord 게이트웨이) 재전송 시 ambient 경로가 비멱등
`append_user_message`를 다시 실행해, 동일 이벤트가 keeper transcript에 user
라인을 두 번 남겼습니다. attention row와 durable stimulus는 이미 dedup됩니다.

## 근본 원인
`record_external_attention`가 Recorded/Duplicate 신호를 계산하고도 버린 채
둘 다 `Some event_id`로 합쳐, `handle_ambient`가 무조건 append했습니다.

## 수정
`record_external_attention` 반환을 `Fresh | Duplicate | Record_failed` 합타입
으로 변경했습니다. `Fresh`에서만 append+broadcast하고, `Duplicate`는 append를
건너뛰되 멱등 stimulus 재투입과 wakeup은 유지합니다. `Ambient_deduped` 관측
지표를 추가했습니다. Discord triggered 경로(dispatch 경계가 append 소유)는
option으로 collapse해 기존 동작을 보존했습니다. **ingress-lane dedup은 추가하지
않았습니다(비영속 in-memory = 잘못된 계층, 증상억제)**. 드문 `Record_failed`
(attention store 오류로 fresh/duplicate 불명)에서는 기존 at-least-once append를
유지합니다 — transient 장애가 진짜 새 라인을 조용히 버리지 않도록.

## 테스트
두 게이트웨이에 동일 이벤트 2회 전달 후 `Keeper_chat_store.load`가 user 라인
정확히 1개를 반환함을 검증(recorded 1 + deduped 1). append 게이트를 되돌리면
2개가 관찰됨(Expected 1, Received 2)을 counterfactual로 확인했습니다. Slack
18/18, Discord 13/13, discord_observability 8/8 통과.

Closes #25262 (미해소 codex P2).

RFC-WAIVED: 변경 경로(`lib/server/*`, `lib/gate/*`, `test/*`)가 credential/
identity/operator-control/sandbox/keeper-credential/hooks/workflow 등 RFC-gated
subsystem에 해당하지 않습니다.
