### PR TITLE
test(fs_compat): force temp-creation failure via missing parent, not chmod

### DIFF
--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -131,20 +131,20 @@ let test_save_file_atomic_returns_temp_creation_failure () =
   Fs_compat.clear_fs ();
   with_tmp_dir
   @@ fun base ->
-  let blocked = Filename.concat base "blocked" in
-  let target = Filename.concat blocked "out.json" in
-  Unix.mkdir blocked 0o700;
-  Unix.chmod blocked 0o500;
-  let result =
-    Fun.protect
-      ~finally:(fun () -> Unix.chmod blocked 0o700)
-      (fun () -> Fs_compat.save_file_atomic target "new")
-  in
+  (* Force temp-file creation to fail without relying on DAC write-blocking.
+     The target's parent directory does not exist, so Filename.temp_file fails
+     with ENOENT (a path-resolution error, not a permission check) for every
+     UID, root included. The previous approach used Unix.chmod blocked 0o500,
+     but chmod is a no-op for root (UID 0): under a root sandbox temp_file
+     succeeded and the regression assertion could not run. See masc#25210. *)
+  let missing = Filename.concat base "does_not_exist" in
+  let target = Filename.concat missing "out.json" in
+  let result = Fs_compat.save_file_atomic target "new" in
   match result with
   | Error message ->
     check bool "temp creation error names the atomic operation" true
       (String.starts_with message ~prefix:"save_file_atomic ")
-  | Ok () -> fail "atomic save unexpectedly wrote into a non-writable directory"
+  | Ok () -> fail "atomic save unexpectedly wrote into a missing directory"
 ;;
 
 let test_read_dir_and_path_kind_use_typed_inventory ~fs () =


### PR DESCRIPTION
## 증상
`test_save_file_atomic_returns_temp_creation_failure`가 `Unix.chmod blocked 0o500`
으로 temp 생성 실패를 강제했지만, chmod의 write 차단은 **root(UID 0)에서 no-op**
입니다. root 샌드박스/컨테이너에서는 `Filename.temp_file`이 성공해
`save_file_atomic`이 `Ok`를 반환하고, 테스트가 구현이 아니라 **러너 권한** 때문에
실패합니다(회귀 테스트가 root 환경에서 실행 불가).

## 수정
target의 부모 디렉토리를 존재하지 않게 지정합니다. 그러면 `Filename.temp_file`이
모든 UID(root 포함)에서 `ENOENT`(경로 해석 실패, 권한 검사가 아님)로 실패합니다.
assertion 의미는 그대로(Error가 atomic 연산명을 포함 / Ok는 실패)이며,
mkdir/chmod/`Fun.protect` restore를 제거했습니다.

## 테스트
`test_fs_compat` 17/17 통과. 부모 부재 → ENOENT는 UID 무관이므로 root 샌드박스
에서도 회귀 assertion이 정상 실행됩니다.

Closes #25210 (미해소 codex P2).

RFC-WAIVED: `test/` 경로만 변경, RFC-gated subsystem 비해당.
