### PR TITLE
fix(board): retry dirty projection flushes autonomously

### DIFF
--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -61,9 +61,8 @@ val persist_transaction_error :
 
 (** {1 Configuration} *)
 
-(** Re-export of [Env_config.Board.flush_interval_sec].  How
-    often the board flusher actor consumes a [Flush] message
-    from {!store.flusher_inbox}. *)
+(** Re-export of [Env_config.Board.flush_interval_sec].  The cadence for
+    scheduling deferred flushes and retrying failed flusher obligations. *)
 val flush_interval_sec : float
 
 (** {1 Store lifecycle} *)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -15,6 +15,8 @@ include module type of struct
   include Board_core_json
 end
 
+(** Canonical cadence for deferred flush scheduling and failed flusher
+    obligation retry. *)
 val flush_interval_sec : float
 val flusher_inbox_capacity : int
 (** Capacity of {!store.flusher_inbox}. The scheduler reserves room for a whole

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -274,6 +274,19 @@ type dirty_projection_flush_failure =
       backtrace : Printexc.raw_backtrace;
     }
 
+type flusher_attempt_failure =
+  | Dirty_projection_flush_failed of dirty_projection_flush_failure
+  | Sweep_routing_references_unavailable of string
+  | Sweep_raised of {
+      cause : exn;
+      backtrace : Printexc.raw_backtrace;
+    }
+
+type flusher_retry_obligations = {
+  flush_retry_at : float option;
+  sweep_retry_at : float option;
+}
+
 exception Runtime_actor_start_failure of runtime_actor_start_failures
 
 let runtime_actor_to_string = function
@@ -317,63 +330,167 @@ let spawn_runtime_actor_on_switch ~sw ~clock store actor =
     try
       match Board.flush_dirty store with
       | Ok () -> Ok ()
-      | Error error -> Error (Flush_rejected error)
+      | Error error ->
+        Error
+          ( Board_types.Flush
+          , Dirty_projection_flush_failed (Flush_rejected error) )
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | (Out_of_memory | Stack_overflow) as exn -> raise exn
     | exn ->
       Error
-        (Flush_raised
-           { cause = exn; backtrace = Printexc.get_raw_backtrace () })
+        ( Board_types.Flush
+        , Dirty_projection_flush_failed
+            (Flush_raised
+               { cause = exn; backtrace = Printexc.get_raw_backtrace () }) )
   in
-  let rec settle_dirty_projection ~recovering =
-    match flush_attempt () with
-    | Ok () ->
-      if recovering
-      then Log.BoardLog.info "Board dirty projection autonomous retry recovered"
-    | Error failure ->
-      (match failure with
-       | Flush_rejected error ->
-         Log.BoardLog.error
-           "Board dirty projection flush failed; autonomous retry remains active: %s"
-           (Board.show_board_error error)
-       | Flush_raised { cause; backtrace } ->
-         Log.BoardLog.error
-           "Board dirty projection flush raised; autonomous retry remains active: %s\n%s"
-           (Printexc.to_string cause)
-           (Printexc.raw_backtrace_to_string backtrace));
-      Eio.Time.sleep clock Board.flush_interval_sec;
-      settle_dirty_projection ~recovering:true
+  let sweep_attempt () =
+    try
+      with_routing_mutation_lock (fun () ->
+        match prepared_routing_references () with
+        | Error detail ->
+          Error
+            (Board_types.Sweep, Sweep_routing_references_unavailable detail)
+        | Ok references ->
+          (match
+             Board.sweep_and_flush
+               ~protected_post_ids:references.post_ids
+               ~protected_comment_ids:references.comment_ids
+               store
+           with
+           | Ok _ -> Ok ()
+           | Error error ->
+             (* The sweep mutation completed before its projection flush was
+                rejected.  Only the dirty projection remains an obligation. *)
+             Error
+               ( Board_types.Flush
+               , Dirty_projection_flush_failed (Flush_rejected error) )))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | (Out_of_memory | Stack_overflow) as exn -> raise exn
+    | exn ->
+      Error
+        ( Board_types.Sweep
+        , Sweep_raised
+            { cause = exn; backtrace = Printexc.get_raw_backtrace () } )
+  in
+  let operation_to_string = function
+    | Board_types.Flush -> "flush_projection"
+    | Board_types.Sweep -> "sweep_board"
+  in
+  let retry_deadline obligations = function
+    | Board_types.Flush -> obligations.flush_retry_at
+    | Board_types.Sweep -> obligations.sweep_retry_at
+  in
+  let without_retry obligations = function
+    | Board_types.Flush -> { obligations with flush_retry_at = None }
+    | Board_types.Sweep -> { obligations with sweep_retry_at = None }
+  in
+  let with_retry_at obligations operation retry_at =
+    match operation with
+    | Board_types.Flush -> { obligations with flush_retry_at = Some retry_at }
+    | Board_types.Sweep -> { obligations with sweep_retry_at = Some retry_at }
+  in
+  let earliest_retry obligations =
+    match obligations.flush_retry_at, obligations.sweep_retry_at with
+    | None, None -> None
+    | Some retry_at, None -> Some (retry_at, Board_types.Flush)
+    | None, Some retry_at -> Some (retry_at, Board_types.Sweep)
+    | Some flush_at, Some sweep_at ->
+      if Float.compare flush_at sweep_at <= 0
+      then Some (flush_at, Board_types.Flush)
+      else Some (sweep_at, Board_types.Sweep)
+  in
+  let retry_obligation obligations operation =
+    let proposed_retry_at = Eio.Time.now clock +. Board.flush_interval_sec in
+    let retry_at =
+      match retry_deadline obligations operation with
+      | None -> proposed_retry_at
+      | Some current_retry_at -> Float.min current_retry_at proposed_retry_at
+    in
+    with_retry_at obligations operation retry_at
+  in
+  let rec await_operation obligations =
+    let now = Eio.Time.now clock in
+    match earliest_retry obligations with
+    | Some (retry_at, operation) when Float.compare retry_at now <= 0 ->
+      operation, true, without_retry obligations operation
+    | retry ->
+      (match retry with
+       | None ->
+         let operation = Eio.Stream.take store.Board.flusher_inbox in
+         let recovering =
+           Option.is_some (retry_deadline obligations operation)
+         in
+         operation, recovering, without_retry obligations operation
+       | Some (retry_at, _) ->
+         let remaining = retry_at -. now in
+         (match
+            Eio.Time.with_timeout clock remaining (fun () ->
+              Ok (Eio.Stream.take store.Board.flusher_inbox))
+          with
+          | Ok message ->
+            let operation = message in
+            let recovering =
+              Option.is_some (retry_deadline obligations operation)
+            in
+            operation, recovering, without_retry obligations operation
+          | Error `Timeout -> await_operation obligations))
+  in
+  let log_attempt_failure ~operation ~retry_operation = function
+    | Dirty_projection_flush_failed (Flush_rejected error) ->
+      Log.BoardLog.error
+        "Board flusher operation=%s failed; retry obligation=%s remains active: %s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        (Board.show_board_error error)
+    | Dirty_projection_flush_failed (Flush_raised { cause; backtrace }) ->
+      Log.BoardLog.error
+        "Board flusher operation=%s raised; retry obligation=%s remains active: %s\n%s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        (Printexc.to_string cause)
+        (Printexc.raw_backtrace_to_string backtrace)
+    | Sweep_routing_references_unavailable detail ->
+      Log.BoardLog.warn
+        "Board flusher operation=%s deferred; retry obligation=%s remains active: %s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        detail
+    | Sweep_raised { cause; backtrace } ->
+      Log.BoardLog.error
+        "Board flusher operation=%s raised; retry obligation=%s remains active: %s\n%s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        (Printexc.to_string cause)
+        (Printexc.raw_backtrace_to_string backtrace)
   in
   let flusher_loop () =
     Log.BoardLog.info "Board flusher actor started";
-    while true do
-      match Eio.Stream.take store.Board.flusher_inbox with
-      | Board_types.Flush -> settle_dirty_projection ~recovering:false
-      | Board_types.Sweep ->
-          (try
-             with_routing_mutation_lock (fun () ->
-               match prepared_routing_references () with
-               | Ok references ->
-                 (match
-                    Board.sweep_and_flush
-                      ~protected_post_ids:references.post_ids
-                      ~protected_comment_ids:references.comment_ids
-                      store
-                  with
-                  | Ok _ -> ()
-                  | Error error ->
-                    Log.BoardLog.error
-                      "Post-sweep flush failed: %s"
-                      (Board.show_board_error error))
-               | Error detail ->
-                 Log.BoardLog.warn
-                   "Board sweep deferred because routing references are unavailable: %s"
-                   detail)
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
-    done
+    let rec loop obligations =
+      let operation, recovering, obligations = await_operation obligations in
+      let outcome =
+        match operation with
+        | Board_types.Flush -> flush_attempt ()
+        | Board_types.Sweep -> sweep_attempt ()
+      in
+      match outcome with
+      | Ok () ->
+        if recovering
+        then
+          Log.BoardLog.info
+            "Board flusher obligation settled operation=%s"
+            (operation_to_string operation);
+        loop obligations
+      | Error (retry_operation, failure) ->
+        log_attempt_failure ~operation ~retry_operation failure;
+        loop (retry_obligation obligations retry_operation)
+    in
+    let startup_reconciliation_at = Eio.Time.now clock in
+    loop
+      { flush_retry_at = Some startup_reconciliation_at
+      ; sweep_retry_at = Some startup_reconciliation_at
+      }
   in
   let routing_retry_loop () =
     Log.BoardLog.info "Board routing retry actor started";
@@ -408,9 +525,7 @@ let spawn_runtime_actor_on_switch ~sw ~clock store actor =
     | Flusher -> flusher_loop
     | Routing_retry -> routing_retry_loop
   in
-  Eio.Fiber.fork_daemon ~sw (fun () ->
-    loop ();
-    `Stop_daemon)
+  Eio.Fiber.fork_daemon ~sw (fun () -> loop ())
 
 (** Claim and start the Board runtime actors against the caller-owned root
     switch.  A losing caller yields and re-reads the typed backend state until

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -57,12 +57,12 @@ type board_backend =
   | Jsonl of Board.store
 
 (** Lifecycle state carried inside [Active] for each long-lived Board actor.
-    Keeping the immutable record in the backend state makes backend publication
-    and both independent actor owners one atomic fact. *)
+    A live transition retains its exact owner switch, so backend publication,
+    actor liveness, and cleanup authority remain one immutable atomic fact. *)
 type actor_status =
   | Actor_stopped
-  | Actor_starting
-  | Actor_started
+  | Actor_starting of Eio.Switch.t
+  | Actor_started of Eio.Switch.t
 
 type runtime_actor_state = {
   flusher : actor_status;
@@ -383,8 +383,9 @@ let spawn_runtime_actor_on_switch ~sw ~clock store actor =
 
 (** Claim and start the Board runtime actors against the caller-owned root
     switch.  A losing caller yields and re-reads the typed backend state until
-    another caller publishes [Actor_started] or it can claim the transition.
-    There is no retry budget or timing policy. *)
+    another caller publishes a live owner or it can claim the transition.  An
+    unavailable prior owner is retired by exact switch identity.  There is no
+    retry budget or timing policy. *)
 let actor_status actors = function
   | Flusher -> actors.flusher
   | Routing_retry -> actors.routing_retry
@@ -396,63 +397,118 @@ let with_actor_status actors actor status =
   | Routing_retry -> { actors with routing_retry = status }
 ;;
 
+let switch_is_available sw = Option.is_none (Eio.Switch.get_error sw)
+
+(** Switches are opaque allocated capabilities.  Physical equality expresses
+    exact capability identity; structural comparison is neither available nor
+    meaningful for this ownership check. *)
+let actor_status_owned_by sw = function
+  | Actor_starting owner
+  | Actor_started owner -> owner == sw
+  | Actor_stopped -> false
+;;
+
+let rec stop_runtime_actor_owned_by ~sw actor =
+  let current = Atomic.get backend_state in
+  match current with
+  | Uninitialized -> false
+  | Active (backend, actors) ->
+    let status = actor_status actors actor in
+    if not (actor_status_owned_by sw status)
+    then false
+    else
+      let stopped_state =
+        Active (backend, with_actor_status actors actor Actor_stopped)
+      in
+      if Atomic.compare_and_set backend_state current stopped_state
+      then true
+      else stop_runtime_actor_owned_by ~sw actor
+;;
+
+let retire_unavailable_actor_owner actor owner =
+  if switch_is_available owner
+  then false
+  else begin
+    let _retired = stop_runtime_actor_owned_by ~sw:owner actor in
+    true
+  end
+;;
+
 let start_runtime_actor ~sw ~clock actor =
   let rec loop () =
     let current = Atomic.get backend_state in
     match current with
     | Uninitialized -> Error Backend_uninitialized
-    | Active (_, actors) when actor_status actors actor = Actor_started -> Ok ()
-    | Active (_, actors) when actor_status actors actor = Actor_starting ->
-      Eio.Fiber.yield ();
-      loop ()
     | Active (Jsonl store as backend, actors) ->
-      let starting_actors = with_actor_status actors actor Actor_starting in
-      let starting_state = Active (backend, starting_actors) in
-      if Atomic.compare_and_set backend_state current starting_state
-      then begin
-        let rollback () =
-          let stopped_state =
-            Active (backend, with_actor_status starting_actors actor Actor_stopped)
-          in
-          Atomic.compare_and_set backend_state starting_state stopped_state
-        in
-        let record outcome =
-          Board_metrics_hooks.inc_runtime_actor_start_outcome ~actor ~outcome
-        in
-        match Eio.Switch.get_error sw with
-        | Some exn ->
-          let rolled_back = rollback () in
-          record Start_failed;
-          if rolled_back
-          then Error (Switch_unavailable (actor, exn))
-          else Error (Backend_replaced_during_start actor)
-        | None ->
-          (try
-             spawn_runtime_actor_on_switch ~sw ~clock store actor;
-             let started_state =
-               Active (backend, with_actor_status starting_actors actor Actor_started)
-             in
-             if Atomic.compare_and_set backend_state starting_state started_state
-             then begin
-               record Started;
-               Ok ()
-             end
-             else begin
-               record Start_failed;
-               Error (Backend_replaced_during_start actor)
-             end
-           with
-           | exn ->
-             let _rolled_back = rollback () in
+      (match actor_status actors actor with
+       | Actor_started owner ->
+         if retire_unavailable_actor_owner actor owner then loop () else Ok ()
+       | Actor_starting owner ->
+         if retire_unavailable_actor_owner actor owner
+         then loop ()
+         else begin
+           Eio.Fiber.yield ();
+           loop ()
+         end
+       | Actor_stopped ->
+         let starting_actors =
+           with_actor_status actors actor (Actor_starting sw)
+         in
+         let starting_state = Active (backend, starting_actors) in
+         if Atomic.compare_and_set backend_state current starting_state
+         then begin
+           let rollback () =
+             stop_runtime_actor_owned_by ~sw actor
+           in
+           let record outcome =
+             Board_metrics_hooks.inc_runtime_actor_start_outcome ~actor ~outcome
+           in
+           match Eio.Switch.get_error sw with
+           | Some exn ->
+             let rolled_back = rollback () in
              record Start_failed;
-             (match exn with
-              | Eio.Cancel.Cancelled _ -> raise exn
-              | _ -> Error (Actor_spawn_failed (actor, exn))))
-      end
-      else begin
-        Eio.Fiber.yield ();
-        loop ()
-      end
+             if rolled_back
+             then Error (Switch_unavailable (actor, exn))
+             else Error (Backend_replaced_during_start actor)
+           | None ->
+             (try
+                Eio.Switch.on_release sw (fun () ->
+                  if stop_runtime_actor_owned_by ~sw actor
+                  then
+                    Log.BoardLog.info
+                      "Board runtime actor stopped with owner switch: actor=%s"
+                      (runtime_actor_to_string actor));
+                spawn_runtime_actor_on_switch ~sw ~clock store actor;
+                let started_state =
+                  Active
+                    ( backend
+                    , with_actor_status starting_actors actor (Actor_started sw) )
+                in
+                if Atomic.compare_and_set backend_state starting_state started_state
+                then begin
+                  record Started;
+                  Ok ()
+                end
+                else begin
+                  record Start_failed;
+                  Error (Backend_replaced_during_start actor)
+                end
+              with
+              | exn ->
+                let _rolled_back = rollback () in
+                record Start_failed;
+                (match exn with
+                 | Eio.Cancel.Cancelled _ -> raise exn
+                 | _ ->
+                   (match Eio.Switch.get_error sw with
+                    | Some owner_error ->
+                      Error (Switch_unavailable (actor, owner_error))
+                    | None -> Error (Actor_spawn_failed (actor, exn)))))
+         end
+         else begin
+           Eio.Fiber.yield ();
+           loop ()
+         end)
   in
   loop ()
 
@@ -502,8 +558,8 @@ let admit_routing_mutation mutation =
 let set_board_signal_hook hook =
   Atomic.set board_signal_hook (Some hook);
   match Atomic.get backend_state with
-  | Active (_, { routing_retry = Actor_started; _ }) -> request_routing_retry ()
-  | Active (_, { routing_retry = (Actor_stopped | Actor_starting); _ })
+  | Active (_, { routing_retry = Actor_started _; _ }) -> request_routing_retry ()
+  | Active (_, { routing_retry = (Actor_stopped | Actor_starting _); _ })
   | Uninitialized ->
     (match
        run_routing_callback
@@ -610,8 +666,8 @@ let commit_routing_event ~event_id value =
 
 let drain_after_mutation () =
   match Atomic.get backend_state with
-  | Active (_, { routing_retry = Actor_started; _ }) -> request_routing_retry ()
-  | Active (_, { routing_retry = (Actor_stopped | Actor_starting); _ })
+  | Active (_, { routing_retry = Actor_started _; _ }) -> request_routing_retry ()
+  | Active (_, { routing_retry = (Actor_stopped | Actor_starting _); _ })
   | Uninitialized ->
     (match
        run_routing_callback

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -267,6 +267,13 @@ type runtime_actor_start_failures =
   | Both_actors_start_failed of
       runtime_actor_start_error * runtime_actor_start_error
 
+type dirty_projection_flush_failure =
+  | Flush_rejected of Board_types.board_error
+  | Flush_raised of {
+      cause : exn;
+      backtrace : Printexc.raw_backtrace;
+    }
+
 exception Runtime_actor_start_failure of runtime_actor_start_failures
 
 let runtime_actor_to_string = function
@@ -306,19 +313,43 @@ let () =
 ;;
 
 let spawn_runtime_actor_on_switch ~sw ~clock store actor =
+  let flush_attempt () =
+    try
+      match Board.flush_dirty store with
+      | Ok () -> Ok ()
+      | Error error -> Error (Flush_rejected error)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | (Out_of_memory | Stack_overflow) as exn -> raise exn
+    | exn ->
+      Error
+        (Flush_raised
+           { cause = exn; backtrace = Printexc.get_raw_backtrace () })
+  in
+  let rec settle_dirty_projection ~recovering =
+    match flush_attempt () with
+    | Ok () ->
+      if recovering
+      then Log.BoardLog.info "Board dirty projection autonomous retry recovered"
+    | Error failure ->
+      (match failure with
+       | Flush_rejected error ->
+         Log.BoardLog.error
+           "Board dirty projection flush failed; autonomous retry remains active: %s"
+           (Board.show_board_error error)
+       | Flush_raised { cause; backtrace } ->
+         Log.BoardLog.error
+           "Board dirty projection flush raised; autonomous retry remains active: %s\n%s"
+           (Printexc.to_string cause)
+           (Printexc.raw_backtrace_to_string backtrace));
+      Eio.Time.sleep clock Board.flush_interval_sec;
+      settle_dirty_projection ~recovering:true
+  in
   let flusher_loop () =
     Log.BoardLog.info "Board flusher actor started";
     while true do
       match Eio.Stream.take store.Board.flusher_inbox with
-      | Board_types.Flush ->
-          (try
-             match Board.flush_dirty store with
-             | Ok () -> ()
-             | Error error ->
-               Log.BoardLog.error "Flush failed: %s" (Board.show_board_error error)
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
+      | Board_types.Flush -> settle_dirty_projection ~recovering:false
       | Board_types.Sweep ->
           (try
              with_routing_mutation_lock (fun () ->

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -162,8 +162,10 @@ val start_runtime_actors :
 (** Attach the Board flusher and durable routing retry actors to the explicit
     runtime root switch.  Each actor is attempted independently and failures
     are aggregated, so one actor's startup failure does not suppress the other.
-    Idempotent after success; concurrent callers cooperate through typed state
-    without timing policy. *)
+    Idempotent while the owning switch is available.  Switch release returns
+    only that switch's actors to the stopped state, allowing a replacement root
+    switch to start fresh actors without an unowned global lifecycle flag.
+    Concurrent callers cooperate through typed state without timing policy. *)
 
 val reset_for_test : unit -> unit
 (** Drop the in-memory backend. Test-only. *)

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -275,9 +275,26 @@ module Board = struct
     | Pg -> "pg"
     | Unknown_backend value -> value
 
-  (** Flush interval for board persistence (seconds). Default: 30. *)
+  (** Flush interval for board persistence (seconds). Default: 30.
+      Once a dirty projection fails, this value becomes the autonomous retry
+      cadence, so zero, negative, and non-finite values would create either a
+      hot loop or an obligation that can never make progress.  Reject those at
+      the configuration boundary instead of coercing them. *)
   let flush_interval_sec =
-    get_float ~default:30.0 "MASC_BOARD_FLUSH_INTERVAL_SEC"
+    let key = "MASC_BOARD_FLUSH_INTERVAL_SEC" in
+    match raw_value_opt key |> trim_opt with
+    | None -> 30.0
+    | Some raw ->
+      (match Safe_ops.float_of_string_safe raw with
+       | Some value when Float.is_finite value && Float.compare value 0.0 > 0 -> value
+       | Some value ->
+         raise
+           (Config_error
+              (Printf.sprintf "%s must be a positive finite float; got %g" key value))
+       | None ->
+         raise
+           (Config_error
+              (Printf.sprintf "%s must be a positive finite float; got %S" key raw)))
 
   (** Capacity of the board flusher inbox (scheduled sweep/flush messages
       enqueued by the sweeper). Single source of truth shared by the

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -132,6 +132,9 @@ module Board : sig
   val backend_of_string : string -> backend
   val backend_to_string : backend -> string
   val flush_interval_sec : float
+  (** Positive finite Board persistence and autonomous flush-retry cadence.
+      Invalid configured values raise {!Env_config_core.Config_error} during
+      configuration initialization. *)
   val flusher_inbox_capacity : int
   val backend_opt : unit -> backend option
 end

--- a/test/dune
+++ b/test/dune
@@ -2090,6 +2090,16 @@
  (modules test_tool_descriptors_gen)
  (libraries masc_test_deps))
 
+; Board flusher recovery uses the production persistence interval SSOT.  This
+; focused executable shortens only that interval so a real failure/recovery
+; cycle stays fast without changing the shared test environment.
+(test
+ (name test_board_flusher_autonomous_retry)
+ (modules test_board_flusher_autonomous_retry)
+ (libraries masc_test_deps)
+ (action
+  (setenv MASC_BOARD_FLUSH_INTERVAL_SEC 0.01 (run %{test}))))
+
 (test
  (name test_provider_prefix_boundary)
  (modules test_provider_prefix_boundary)

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -2185,6 +2185,42 @@ let test_runtime_actors_reject_finished_switch_and_allow_retry () =
   with Exit -> ()
 ;;
 
+let test_runtime_actors_restart_after_owner_switch_release () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ignore (fresh_test_base_path ());
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  Eio.Switch.run (fun first_owner ->
+    match Board_dispatch.start_runtime_actors ~sw:first_owner ~clock with
+    | Ok () -> ()
+    | Error failures ->
+      Alcotest.fail
+        (Board_dispatch.runtime_actor_start_failures_to_string failures));
+  let delivered, resolve_delivered = Eio.Promise.create () in
+  let delivery_resolved = Atomic.make false in
+  Board_dispatch.set_board_signal_hook (fun _event ->
+    if Atomic.compare_and_set delivery_resolved false true
+    then Eio.Promise.resolve resolve_delivered ();
+    Ok Board_dispatch.Atomic_sink_accepted);
+  Eio.Switch.run (fun replacement_owner ->
+    (match Board_dispatch.start_runtime_actors ~sw:replacement_owner ~clock with
+     | Ok () -> ()
+     | Error failures ->
+       Alcotest.fail
+         (Board_dispatch.runtime_actor_start_failures_to_string failures));
+    (match
+       Board_dispatch.create_post ~author:"replacement-owner-test"
+         ~content:"replacement switch owns a live routing actor"
+         ~post_kind:Board.Human_post ()
+     with
+     | Ok _ -> ()
+     | Error error -> Alcotest.fail (Board.show_board_error error));
+    Eio.Time.with_timeout_exn clock 1.0 (fun () -> Eio.Promise.await delivered))
+;;
+
 (** {1 Reaction Operations} *)
 
 let test_reaction_toggle_and_summary () =
@@ -3419,6 +3455,8 @@ let () =
         test_vote_persisted_by_flusher_actor;
       Alcotest.test_case "runtime actors reject finished switch and allow retry" `Quick
         test_runtime_actors_reject_finished_switch_and_allow_retry;
+      Alcotest.test_case "runtime actors restart after owner switch release" `Quick
+        test_runtime_actors_restart_after_owner_switch_release;
     ];
     "reactions", [
       Alcotest.test_case "toggle and summary" `Quick

--- a/test/test_board_flusher_autonomous_retry.ml
+++ b/test/test_board_flusher_autonomous_retry.ml
@@ -1,0 +1,98 @@
+(** Regression for autonomous Board dirty-projection recovery.
+
+    This executable has a test-only persistence flush interval in [test/dune].
+    Production continues to use the operator-owned Board flush interval. *)
+
+open Masc
+
+let () = Random.self_init ()
+
+let fresh_base prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%06x" prefix (Random.bits ()))
+;;
+
+let await ~clock predicate =
+  Eio.Time.with_timeout_exn clock 1.0 (fun () ->
+    let rec loop () =
+      if predicate ()
+      then ()
+      else begin
+        Eio.Time.sleep clock 0.002;
+        loop ()
+      end
+    in
+    loop ())
+;;
+
+let test_failed_flush_retries_without_new_board_activity () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Unix.putenv "MASC_BASE_PATH" (fresh_base "masc-board-flush-source");
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  let store =
+    match Board_dispatch.backend () with
+    | Board_dispatch.Jsonl store -> store
+  in
+  let post =
+    match
+      Board.create_post store ~author:"flusher-retry-author"
+        ~content:"dirty projection survives a transient filesystem failure"
+        ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error error -> Alcotest.fail (Board.show_board_error error)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match Board.vote store ~voter:"flusher-retry-voter" ~post_id ~direction:Board.Up with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Board.show_board_error error));
+  Alcotest.(check bool) "vote dirtied the post projection" true store.Board.dirty_posts;
+  let recovery_base = fresh_base "masc-board-flush-recovery" in
+  Unix.putenv "MASC_BASE_PATH" recovery_base;
+  let board_dir = Filename.dirname (Board.persist_path ()) in
+  Fs_compat.mkdir_p (Filename.dirname board_dir);
+  Fs_compat.save_file board_dir "blocks Board projection directory creation";
+  let errors_before = Board.persist_error_count () in
+  Eio.Switch.run (fun sw ->
+    (match Board_dispatch.start_runtime_actors ~sw ~clock with
+     | Ok () -> ()
+     | Error failures ->
+       Alcotest.fail
+         (Board_dispatch.runtime_actor_start_failures_to_string failures));
+    (match Board.request_flush store with
+     | Ok () -> ()
+     | Error detail -> Alcotest.fail detail);
+    await ~clock (fun () -> Board.persist_error_count () > errors_before);
+    Unix.unlink board_dir;
+    Fs_compat.mkdir_p board_dir;
+    await ~clock (fun () -> not store.Board.dirty_posts));
+  let persisted_ids =
+    Fs_compat.load_file (Board.persist_path ())
+    |> String.split_on_char '\n'
+    |> List.filter_map (fun row ->
+      if String.equal row ""
+      then None
+      else Yojson.Safe.from_string row |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string_option)
+  in
+  Alcotest.(check bool)
+    "autonomous retry persisted the original post"
+    true
+    (List.exists (String.equal post_id) persisted_ids)
+;;
+
+let () =
+  Alcotest.run
+    "board_flusher_autonomous_retry"
+    [ ( "recovery"
+      , [ Alcotest.test_case
+            "failed flush retries without new Board activity"
+            `Quick
+            test_failed_flush_retries_without_new_board_activity
+        ] )
+    ]
+;;

--- a/test/test_board_flusher_autonomous_retry.ml
+++ b/test/test_board_flusher_autonomous_retry.ml
@@ -7,6 +7,8 @@ open Masc
 
 let () = Random.self_init ()
 
+let request_flush = Masc_board_handlers.Board_core_persist.request_flush
+
 let fresh_base prefix =
   Filename.concat
     (Filename.get_temp_dir_name ())
@@ -64,12 +66,18 @@ let test_failed_flush_retries_without_new_board_activity () =
      | Error failures ->
        Alcotest.fail
          (Board_dispatch.runtime_actor_start_failures_to_string failures));
-    (match Board.request_flush store with
+    (match request_flush store with
      | Ok () -> ()
      | Error detail -> Alcotest.fail detail);
-    await ~clock (fun () -> Board.persist_error_count () > errors_before);
-    Unix.unlink board_dir;
-    Fs_compat.mkdir_p board_dir;
+    await ~clock (fun () -> Board.persist_error_count () > errors_before));
+  Unix.unlink board_dir;
+  Fs_compat.mkdir_p board_dir;
+  Eio.Switch.run (fun sw ->
+    (match Board_dispatch.start_runtime_actors ~sw ~clock with
+     | Ok () -> ()
+     | Error failures ->
+       Alcotest.fail
+         (Board_dispatch.runtime_actor_start_failures_to_string failures));
     await ~clock (fun () -> not store.Board.dirty_posts));
   let persisted_ids =
     Fs_compat.load_file (Board.persist_path ())
@@ -85,6 +93,57 @@ let test_failed_flush_retries_without_new_board_activity () =
     (List.exists (String.equal post_id) persisted_ids)
 ;;
 
+let test_failed_flush_does_not_block_sweep () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Unix.putenv "MASC_BASE_PATH" (fresh_base "masc-board-flusher-fair-source");
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  let store =
+    match Board_dispatch.backend () with
+    | Board_dispatch.Jsonl store -> store
+  in
+  let post =
+    match
+      Board.create_post store ~author:"flusher-fair-author"
+        ~content:"an expired post must sweep while flush recovery is pending"
+        ~post_kind:Board.Human_post ~ttl_hours:1 ()
+    with
+    | Ok post -> post
+    | Error error -> Alcotest.fail (Board.show_board_error error)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  Hashtbl.replace store.Board.posts post_id
+    { post with expires_at = Time_compat.now () -. 1.0 };
+  (match
+     Board.vote store ~voter:"flusher-fair-voter" ~post_id
+       ~direction:Board.Up
+   with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Board.show_board_error error));
+  let recovery_base = fresh_base "masc-board-flusher-fair-recovery" in
+  Unix.putenv "MASC_BASE_PATH" recovery_base;
+  let persist_path = Board.persist_path () in
+  Fs_compat.mkdir_p persist_path;
+  let errors_before = Board.persist_error_count () in
+  Eio.Switch.run (fun sw ->
+    (match Board_dispatch.start_runtime_actors ~sw ~clock with
+     | Ok () -> ()
+     | Error failures ->
+       Alcotest.fail
+         (Board_dispatch.runtime_actor_start_failures_to_string failures));
+    await ~clock (fun () -> Board.persist_error_count () > errors_before);
+    await ~clock (fun () -> not (Hashtbl.mem store.Board.posts post_id));
+    Unix.rmdir persist_path;
+    await ~clock (fun () -> not store.Board.dirty_posts));
+  Alcotest.(check bool)
+    "expired post remained swept after projection recovery"
+    false
+    (Hashtbl.mem store.Board.posts post_id)
+;;
+
 let () =
   Alcotest.run
     "board_flusher_autonomous_retry"
@@ -93,6 +152,10 @@ let () =
             "failed flush retries without new Board activity"
             `Quick
             test_failed_flush_retries_without_new_board_activity
+        ; Alcotest.test_case
+            "failed flush does not block sweep"
+            `Quick
+            test_failed_flush_does_not_block_sweep
         ] )
     ]
 ;;


### PR DESCRIPTION
## Goal

Keep a failed Board dirty projection under autonomous recovery without requiring a later unrelated Board read or mutation to wake the flusher.

## Root cause

The flusher consumed `Flush` before calling `Board.flush_dirty`. On `Error` or an unexpected exception it only logged and returned to `Stream.take`; the dirty flags remained true, but no wake token remained. With no later Board activity, recovery could remain pending forever.

## Change

- Treat the existing dirty flags and source ledgers as the projection obligation SSOT; do not add a second persisted flag.
- Convert recoverable Board errors and unexpected actor-boundary exceptions into a closed typed failure sum.
- Preserve cancellation and fatal runtime exceptions.
- Retry the same dirty projection until success using the existing Board persistence flush interval; no attempt cap, pause state, or new timing number.
- Record both retry-pending failures and the eventual recovered transition.
- Reject zero, negative, non-finite, or malformed flush intervals at the config boundary so recovery cannot become a hot loop or non-progressing timer.
- Add a focused real-filesystem regression: force the first snapshot rewrite to fail, repair the directory, perform no new Board activity, and require the actor to persist the original post and clear dirty state.

## Evidence

- OCaml 5.5 parser: pass for all touched `.ml` / `.mli` files.
- `ocamlformat --check`: pass.
- `git diff --check`: pass.
- Added-risk grep: no new `Obj.magic`, stub, string-match classifier, manual mutex, `Fun.protect`, or silent catch.
- Focused wrapper was queued behind another repository worktree's shared Dune lock and was stopped rather than bypassing the lock. The parent leaf also records a global OAS pin mismatch, so exact compile/test proof is delegated to CI.

## Stack

Base: `codex/board-runtime-actor-owner-recovery-20260719` / PR #25290.

Draft; do not merge before the Board routing stack and owner-switch leaf land.
