### PR TITLE
feat(fusion): scan durable run authority

### DIFF
--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -41,6 +41,36 @@ type claim_outcome =
   | First_committed
   | Already_same
   | Conflict of terminal
+type recovered_run =
+  | Running_run of registration
+  | Settled_run of
+      { registration : registration
+      ; terminal : terminal
+      }
+type scan_entry_error =
+  | Invalid_entry_name of string
+  | Entry_disappeared
+  | Entry_read_failed of Fs_compat.owned_regular_file_read_error
+  | Entry_record_failed of error
+type scan_entry =
+  { entry_name : string
+  ; outcome : (recovered_run, scan_entry_error) result
+  }
+type scan_outcome =
+  | Store_missing
+  | Store_scanned of scan_entry list
+type directory_io_failure =
+  | Directory_unix_error of
+      { error : Unix.error
+      ; function_name : string
+      ; argument : string
+      }
+  | Directory_sys_error of string
+type scan_error =
+  | Directory_boundary_rejected of Fs_compat.owned_directory_chain_rejection
+  | Directory_inspection_failed of directory_io_failure
+  | Directory_inventory_failed of directory_io_failure
+  | Directory_identity_changed
 type terminal_record =
   { identity : identity
   ; terminal : terminal
@@ -78,6 +108,14 @@ let validate_identity = function
   | { keeper = ""; _ } -> Error Empty_keeper
   | { run_id = ""; _ } -> Error Empty_run_id
   | _ -> Ok ()
+;;
+let validate_registration (registration : registration) =
+  match validate_identity registration.identity with
+  | Error _ as error -> error
+  | Ok () ->
+    if Float.is_finite registration.started_at
+    then Ok ()
+    else Error (Invalid_started_at registration.started_at)
 ;;
 let validate_terminal = function
   | Deliberated _ -> Ok ()
@@ -127,15 +165,16 @@ let parse_events content =
 let check_identity expected actual =
   if equal_identity expected actual then Ok () else Error (Identity_mismatch actual)
 ;;
-let state_of_content expected content =
+let state_of_events expected events =
   let ( let* ) = Result.bind in
-  let* events = parse_events content in
   match events with
   | [] -> Ok Empty
   | [ Run_registered registration ] ->
+    let* () = validate_registration registration in
     let* () = check_identity expected registration.identity in
     Ok (Running registration)
   | [ Run_registered registration; Terminal_committed terminal_record ] ->
+    let* () = validate_registration registration in
     let* () = check_identity expected registration.identity in
     let* () = check_identity expected terminal_record.identity in
     let* () = validate_terminal terminal_record.terminal in
@@ -145,9 +184,105 @@ let state_of_content expected content =
     Error Orphan_terminal
   | [ Terminal_committed terminal_record; Run_registered registration ] ->
     let* () = check_identity expected terminal_record.identity in
+    let* () = validate_registration registration in
     let* () = check_identity expected registration.identity in
     Error Reversed_records
   | events -> Error (Unexpected_sequence (List.length events))
+;;
+let state_of_content expected content =
+  Result.bind (parse_events content) (state_of_events expected)
+;;
+
+let identity_of_event = function
+  | Run_registered registration -> registration.identity
+  | Terminal_committed terminal_record -> terminal_record.identity
+;;
+
+let recovered_run_of_content content =
+  let ( let* ) = Result.bind in
+  let* events = parse_events content in
+  match events with
+  | [] -> Error (Unexpected_sequence 0)
+  | first :: _ ->
+    let identity = identity_of_event first in
+    let* state = state_of_events identity events in
+    (match state with
+     | Empty -> Error (Unexpected_sequence 0)
+     | Running registration -> Ok (identity, Running_run registration)
+     | Settled (registration, terminal) ->
+       Ok (identity, Settled_run { registration; terminal }))
+;;
+
+let directory_io_failure_of_unix error function_name argument =
+  Directory_unix_error { error; function_name; argument }
+;;
+
+let inspect_directory t =
+  try
+    match Fs_compat.inspect_owned_directory_chain ~ownership_root:t.root t.root with
+    | Ok observation -> Ok observation
+    | Error rejection -> Error (Directory_boundary_rejected rejection)
+  with
+  | Unix.Unix_error (error, function_name, argument) ->
+    Error
+      (Directory_inspection_failed
+         (directory_io_failure_of_unix error function_name argument))
+  | Sys_error detail ->
+    Error (Directory_inspection_failed (Directory_sys_error detail))
+;;
+
+let same_directory_identity (before : Unix.stats) (after : Unix.stats) =
+  before.st_dev = after.st_dev && before.st_ino = after.st_ino
+;;
+
+let scan_entry t entry_name =
+  let outcome =
+    if not (Fs_compat.is_capability_leaf entry_name)
+    then Error (Invalid_entry_name entry_name)
+    else
+      let path = Filename.concat t.root entry_name in
+      match Fs_compat.load_owned_regular_file ~ownership_root:t.root path with
+      | Error error -> Error (Entry_read_failed error)
+      | Ok None -> Error Entry_disappeared
+      | Ok (Some content) ->
+        (match recovered_run_of_content content with
+         | Error error -> Error (Entry_record_failed error)
+         | Ok (identity, recovered) ->
+           let expected_path =
+             run_file t ~keeper:identity.keeper ~run_id:identity.run_id
+           in
+           if String.equal path expected_path
+           then Ok recovered
+           else Error (Entry_record_failed (Identity_mismatch identity)))
+  in
+  { entry_name; outcome }
+;;
+
+let scan t =
+  match inspect_directory t with
+  | Error _ as error -> error
+  | Ok Fs_compat.Owned_directory_missing -> Ok Store_missing
+  | Ok (Fs_compat.Owned_directory before) ->
+    let inventory =
+      try Ok (Fs_compat.read_dir t.root) with
+      | Unix.Unix_error (error, function_name, argument) ->
+        Error
+          (Directory_inventory_failed
+             (directory_io_failure_of_unix error function_name argument))
+      | Sys_error detail ->
+        Error (Directory_inventory_failed (Directory_sys_error detail))
+    in
+    (match inventory with
+     | Error _ as error -> error
+     | Ok entry_names ->
+       let entries = List.map (scan_entry t) entry_names in
+       (match inspect_directory t with
+        | Error _ as error -> error
+        | Ok Fs_compat.Owned_directory_missing -> Error Directory_identity_changed
+        | Ok (Fs_compat.Owned_directory after) ->
+          if same_directory_identity before after
+          then Ok (Store_scanned entries)
+          else Error Directory_identity_changed))
 ;;
 let transact path decide =
   match Fs_compat.update_private_file_durable_locked_result path decide with

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -37,8 +37,52 @@ type claim_outcome =
   | First_committed
   | Already_same
   | Conflict of terminal
+
+type recovered_run =
+  | Running_run of registration
+  | Settled_run of
+      { registration : registration
+      ; terminal : terminal
+      }
+
+type scan_entry_error =
+  | Invalid_entry_name of string
+  | Entry_disappeared
+  | Entry_read_failed of Fs_compat.owned_regular_file_read_error
+  | Entry_record_failed of error
+
+type scan_entry =
+  { entry_name : string
+  ; outcome : (recovered_run, scan_entry_error) result
+  }
+
+type scan_outcome =
+  | Store_missing
+  | Store_scanned of scan_entry list
+
+type directory_io_failure =
+  | Directory_unix_error of
+      { error : Unix.error
+      ; function_name : string
+      ; argument : string
+      }
+  | Directory_sys_error of string
+
+type scan_error =
+  | Directory_boundary_rejected of Fs_compat.owned_directory_chain_rejection
+  | Directory_inspection_failed of directory_io_failure
+  | Directory_inventory_failed of directory_io_failure
+  | Directory_identity_changed
+
 (** [directory] is the exact store root resolved by the outer MASC path owner. *)
 val create : directory:string -> t
+
+(** [scan t] returns every observed authority entry in deterministic filename
+    order. One unreadable or invalid entry is retained as an explicit error and
+    does not hide valid peers. [Store_missing] means that no run has created the
+    injected store directory yet. *)
+val scan : t -> (scan_outcome, scan_error) result
+
 val register
   :  t
   -> keeper:string

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -198,6 +198,67 @@ let test_corruption_is_per_run_and_semantic () =
   | Error (A.Identity_mismatch _) -> ()
   | _ -> fail "hashed path must still verify persisted identity"
 ;;
+let identity_of_recovered = function
+  | A.Running_run registration -> registration.identity
+  | A.Settled_run { registration; _ } -> registration.identity
+;;
+
+let test_restart_scan_preserves_valid_peers_and_corruption () =
+  let base_path = fresh_base () in
+  let directory = Filename.concat base_path "runs" in
+  let store = A.create ~directory in
+  let register run_id started_at =
+    match A.register store ~keeper:"keeper-a" ~run_id ~preset:"p" ~started_at with
+    | Ok A.Registered -> ()
+    | _ -> fail (run_id ^ " registration failed")
+  in
+  register "running" 1.;
+  register "settled" 2.;
+  register "corrupt" 3.;
+  let winner = deliberated (successful_evidence ()) in
+  (match
+     A.claim_terminal store ~keeper:"keeper-a" ~run_id:"settled"
+       winner
+   with
+   | Ok A.First_committed -> ()
+   | _ -> fail "settled terminal did not commit");
+  let corrupt_path = run_file directory "keeper-a" "corrupt" in
+  let registered = Fs_compat.load_file corrupt_path in
+  Fs_compat.save_file corrupt_path
+    (String.sub registered 0 (String.length registered - 1));
+  let entries =
+    match A.scan (A.create ~directory) with
+    | Ok (A.Store_scanned entries) -> entries
+    | Ok A.Store_missing -> fail "existing authority store was reported missing"
+    | Error _ -> fail "authority directory scan failed"
+  in
+  check int "all observed entries retained" 3 (List.length entries);
+  let valid_runs, corruptions =
+    List.fold_left
+      (fun (valid, corrupt) (entry : A.scan_entry) ->
+         match entry.outcome with
+         | Ok recovered -> recovered :: valid, corrupt
+         | Error (A.Entry_record_failed A.Partial_tail) -> valid, entry.entry_name :: corrupt
+         | Error _ -> fail "scan returned an unexpected per-entry failure")
+      ([], [])
+      entries
+  in
+  let valid_run_ids =
+    valid_runs
+    |> List.map (fun recovered -> (identity_of_recovered recovered).run_id)
+    |> List.sort String.compare
+  in
+  check (list string) "valid peers survive corrupt entry" [ "running"; "settled" ] valid_run_ids;
+  check int "corruption remains explicit" 1 (List.length corruptions);
+  check bool "settled terminal survives scan" true
+    (List.exists
+       (function
+         | A.Settled_run { registration; terminal } ->
+           String.equal registration.identity.run_id "settled"
+           && A.equal_terminal winner terminal
+         | A.Running_run _ -> false)
+       valid_runs)
+;;
 let () =
   run "fusion_run_authority"
     [ ( "authority"
@@ -205,6 +266,8 @@ let () =
             test_exact_lifecycle_and_validation
         ; test_case "per-run corruption and semantic validation" `Quick
             test_corruption_is_per_run_and_semantic
+        ; test_case "restart scan preserves valid peers and corruption" `Quick
+            test_restart_scan_preserves_valid_peers_and_corruption
         ] )
     ]
 ;;


### PR DESCRIPTION
## Goal

Recover every durable per-run Fusion authority record after restart without allowing one corrupt entry to hide valid peers.

## Changes

- add immutable typed scan results for running and settled runs
- preserve invalid names, vanished entries, owned-read failures, and record corruption per entry
- verify persisted identity against the exact SHA-256 authority path
- surface directory boundary, inventory, and identity failures explicitly
- add a focused mixed scan test with two valid peers and one partial-tail record

## Boundary

This leaf does not wire production reconciliation and does not read or write the legacy `fusion-runs.jsonl` registry. The next leaf owns retry/reconciliation semantics.

## Verification

- `scripts/dune-local.sh build test/test_fusion_run_authority.exe`
- `_build/default/test/test_fusion_run_authority.exe` — 3/3
- `git diff --check codex/fusion-durable-deliberation-evidence-20260719..HEAD`

## Remaining risk

A concurrent terminal append can surface as an explicit `Filesystem_identity_changed` entry error. The production reconciler must observe and retry that typed failure.

Co-Authored-By: Codex
