### PR TITLE
test(keeper): run compaction override distinction test under Runtime fixture

### DIFF
--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -109,27 +109,50 @@ let test_regular_post_turn_does_not_auto_compact () =
       (retained.messages = checkpoint.messages)
 
 let test_invalid_plan_is_distinct_from_provider_unavailable () =
-  let meta = make_meta () in
-  let context =
-    Masc.Keeper_context_core.context_of_oas_checkpoint (make_checkpoint ())
-  in
-  let decision failure =
-    Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
-      (fun ~runtime_ids:_ ~keeper_name:_ () ->
-         Some (fun ~units:_ -> Error failure))
-      (fun () ->
-         Compact_policy.compact_for_request_typed
-           ~meta
-           ~trigger:Compaction_trigger.Manual
-           context)
-    |> fun preparation -> preparation.Compact_policy.decision
-  in
-  (match decision Masc.Keeper_compaction_llm_summarizer.Invalid_plan with
-   | Compact_policy.Rejected (Manual, Invalid_compaction_plan) -> ()
-   | _ -> fail "invalid provider plan was not a typed source terminal");
-  match decision Masc.Keeper_compaction_llm_summarizer.Provider_unavailable with
-  | Compact_policy.Rejected (Manual, Plan_provider_unavailable) -> ()
-  | _ -> fail "provider failure was collapsed into an invalid plan"
+  (* This test asserts the typed distinction between a provider transport
+     failure ([Plan_provider_unavailable]) and a closed-plan-contract violation
+     ([Invalid_compaction_plan]). Both terminals live *after* the runtime-id
+     gate in [Keeper_compact_policy.requested_messages]: with an uninitialized
+     global Runtime, [compaction_runtime_ids] is [[]] and the decision short-
+     circuits to [Runtime_identity_unavailable] before the summarizer override
+     is ever consulted, so both branches under test would be dead. Building the
+     working context also drives [Context.set_scoped], which requires an Eio
+     fiber. So this test must run inside [Eio_main.run] with the same Runtime
+     fixture the sibling [test_manual_compaction_serializes_owner_lane] uses. *)
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+      let runtime_path =
+        Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+      in
+      (match Runtime.init_default ~config_path:runtime_path with
+       | Ok () -> ()
+       | Error detail -> failf "runtime fixture initialization failed: %s" detail);
+      let meta = make_meta () in
+      let context =
+        Masc.Keeper_context_core.context_of_oas_checkpoint (make_checkpoint ())
+      in
+      let decision failure =
+        Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+          (fun ~runtime_ids:_ ~keeper_name:_ () ->
+             Some (fun ~units:_ -> Error failure))
+          (fun () ->
+             Compact_policy.compact_for_request_typed
+               ~meta
+               ~trigger:Compaction_trigger.Manual
+               context)
+        |> fun preparation -> preparation.Compact_policy.decision
+      in
+      (match decision Masc.Keeper_compaction_llm_summarizer.Invalid_plan with
+       | Compact_policy.Rejected (Manual, Invalid_compaction_plan) -> ()
+       | _ -> fail "invalid provider plan was not a typed source terminal");
+      match decision Masc.Keeper_compaction_llm_summarizer.Provider_unavailable with
+      | Compact_policy.Rejected (Manual, Plan_provider_unavailable) -> ()
+      | _ -> fail "provider failure was collapsed into an invalid plan")
 
 let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in


### PR DESCRIPTION
## 증상 (false-green)
`test_invalid_plan_is_distinct_from_provider_unavailable`가 전역 Runtime이
초기화되지 않은 채 실행돼, `compaction_runtime_ids`가 `[]`로 떨어지고
`compact_for_request_typed`가 summarizer override를 보기 전에
`Runtime_identity_unavailable`로 단락됩니다. 그 결과 두 assertion
(`Invalid_plan → Invalid_compaction_plan`, `Provider_unavailable →
Plan_provider_unavailable`)이 **모두 dead**였고, CI의 changed-surface 선택이
이 바이너리를 실행하지 않아 표면화되지 않았습니다. PR의 핵심 typed-distinction
guard가 사실상 무커버리지(false-green)였습니다.

## 수정
sibling `test_manual_compaction_serializes_owner_lane`가 쓰는 것과 동일한
`Eio_main.run` + `Runtime.init_default` fixture로 감쌌습니다. Runtime이
초기화되면 `compaction_runtime_ids`가 비어 있지 않아 override에 도달하고, 두
terminal의 구분이 실제로 실행됩니다. **test-only, 라이브러리 변경 없음.**

## 검증
non-tautology 확인: override를 항상 `Provider_unavailable`로 바꾸면
`decision Invalid_plan` assertion이 실패(테스트가 잘못된 override를 잡음).
원본 `Error failure`로 복원하면 두 케이스가 각 terminal로 통과합니다.

Closes #25221 (미해소 codex P1/false-green).

참고: 이 테스트 파일을 수정하므로 CI changed-surface가 이번엔 바이너리를 실행합니다
(원래 이 파일이 실행되지 않은 것이 false-green을 흘려보낸 별도 CI-selection 갭).

RFC-WAIVED: `test/` 경로만 변경, RFC-gated subsystem 비해당.
