### PR TITLE
fix(board): schedule independent flusher recovery obligations

### DIFF
--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -61,9 +61,8 @@ val persist_transaction_error :
 
 (** {1 Configuration} *)
 
-(** Re-export of [Env_config.Board.flush_interval_sec].  How
-    often the board flusher actor consumes a [Flush] message
-    from {!store.flusher_inbox}. *)
+(** Re-export of [Env_config.Board.flush_interval_sec].  The cadence for
+    scheduling deferred flushes and retrying failed flusher obligations. *)
 val flush_interval_sec : float
 
 (** {1 Store lifecycle} *)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -15,6 +15,8 @@ include module type of struct
   include Board_core_json
 end
 
+(** Canonical cadence for deferred flush scheduling and failed flusher
+    obligation retry. *)
 val flush_interval_sec : float
 val flusher_inbox_capacity : int
 (** Capacity of {!store.flusher_inbox}. The scheduler reserves room for a whole

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -274,6 +274,19 @@ type dirty_projection_flush_failure =
       backtrace : Printexc.raw_backtrace;
     }
 
+type flusher_attempt_failure =
+  | Dirty_projection_flush_failed of dirty_projection_flush_failure
+  | Sweep_routing_references_unavailable of string
+  | Sweep_raised of {
+      cause : exn;
+      backtrace : Printexc.raw_backtrace;
+    }
+
+type flusher_retry_obligations = {
+  flush_retry_at : float option;
+  sweep_retry_at : float option;
+}
+
 exception Runtime_actor_start_failure of runtime_actor_start_failures
 
 let runtime_actor_to_string = function
@@ -317,63 +330,167 @@ let spawn_runtime_actor_on_switch ~sw ~clock store actor =
     try
       match Board.flush_dirty store with
       | Ok () -> Ok ()
-      | Error error -> Error (Flush_rejected error)
+      | Error error ->
+        Error
+          ( Board_types.Flush
+          , Dirty_projection_flush_failed (Flush_rejected error) )
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | (Out_of_memory | Stack_overflow) as exn -> raise exn
     | exn ->
       Error
-        (Flush_raised
-           { cause = exn; backtrace = Printexc.get_raw_backtrace () })
+        ( Board_types.Flush
+        , Dirty_projection_flush_failed
+            (Flush_raised
+               { cause = exn; backtrace = Printexc.get_raw_backtrace () }) )
   in
-  let rec settle_dirty_projection ~recovering =
-    match flush_attempt () with
-    | Ok () ->
-      if recovering
-      then Log.BoardLog.info "Board dirty projection autonomous retry recovered"
-    | Error failure ->
-      (match failure with
-       | Flush_rejected error ->
-         Log.BoardLog.error
-           "Board dirty projection flush failed; autonomous retry remains active: %s"
-           (Board.show_board_error error)
-       | Flush_raised { cause; backtrace } ->
-         Log.BoardLog.error
-           "Board dirty projection flush raised; autonomous retry remains active: %s\n%s"
-           (Printexc.to_string cause)
-           (Printexc.raw_backtrace_to_string backtrace));
-      Eio.Time.sleep clock Board.flush_interval_sec;
-      settle_dirty_projection ~recovering:true
+  let sweep_attempt () =
+    try
+      with_routing_mutation_lock (fun () ->
+        match prepared_routing_references () with
+        | Error detail ->
+          Error
+            (Board_types.Sweep, Sweep_routing_references_unavailable detail)
+        | Ok references ->
+          (match
+             Board.sweep_and_flush
+               ~protected_post_ids:references.post_ids
+               ~protected_comment_ids:references.comment_ids
+               store
+           with
+           | Ok _ -> Ok ()
+           | Error error ->
+             (* The sweep mutation completed before its projection flush was
+                rejected.  Only the dirty projection remains an obligation. *)
+             Error
+               ( Board_types.Flush
+               , Dirty_projection_flush_failed (Flush_rejected error) )))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | (Out_of_memory | Stack_overflow) as exn -> raise exn
+    | exn ->
+      Error
+        ( Board_types.Sweep
+        , Sweep_raised
+            { cause = exn; backtrace = Printexc.get_raw_backtrace () } )
+  in
+  let operation_to_string = function
+    | Board_types.Flush -> "flush_projection"
+    | Board_types.Sweep -> "sweep_board"
+  in
+  let retry_deadline obligations = function
+    | Board_types.Flush -> obligations.flush_retry_at
+    | Board_types.Sweep -> obligations.sweep_retry_at
+  in
+  let without_retry obligations = function
+    | Board_types.Flush -> { obligations with flush_retry_at = None }
+    | Board_types.Sweep -> { obligations with sweep_retry_at = None }
+  in
+  let with_retry_at obligations operation retry_at =
+    match operation with
+    | Board_types.Flush -> { obligations with flush_retry_at = Some retry_at }
+    | Board_types.Sweep -> { obligations with sweep_retry_at = Some retry_at }
+  in
+  let earliest_retry obligations =
+    match obligations.flush_retry_at, obligations.sweep_retry_at with
+    | None, None -> None
+    | Some retry_at, None -> Some (retry_at, Board_types.Flush)
+    | None, Some retry_at -> Some (retry_at, Board_types.Sweep)
+    | Some flush_at, Some sweep_at ->
+      if Float.compare flush_at sweep_at <= 0
+      then Some (flush_at, Board_types.Flush)
+      else Some (sweep_at, Board_types.Sweep)
+  in
+  let retry_obligation obligations operation =
+    let proposed_retry_at = Eio.Time.now clock +. Board.flush_interval_sec in
+    let retry_at =
+      match retry_deadline obligations operation with
+      | None -> proposed_retry_at
+      | Some current_retry_at -> Float.min current_retry_at proposed_retry_at
+    in
+    with_retry_at obligations operation retry_at
+  in
+  let rec await_operation obligations =
+    let now = Eio.Time.now clock in
+    match earliest_retry obligations with
+    | Some (retry_at, operation) when Float.compare retry_at now <= 0 ->
+      operation, true, without_retry obligations operation
+    | retry ->
+      (match retry with
+       | None ->
+         let operation = Eio.Stream.take store.Board.flusher_inbox in
+         let recovering =
+           Option.is_some (retry_deadline obligations operation)
+         in
+         operation, recovering, without_retry obligations operation
+       | Some (retry_at, _) ->
+         let remaining = retry_at -. now in
+         (match
+            Eio.Time.with_timeout clock remaining (fun () ->
+              Ok (Eio.Stream.take store.Board.flusher_inbox))
+          with
+          | Ok message ->
+            let operation = message in
+            let recovering =
+              Option.is_some (retry_deadline obligations operation)
+            in
+            operation, recovering, without_retry obligations operation
+          | Error `Timeout -> await_operation obligations))
+  in
+  let log_attempt_failure ~operation ~retry_operation = function
+    | Dirty_projection_flush_failed (Flush_rejected error) ->
+      Log.BoardLog.error
+        "Board flusher operation=%s failed; retry obligation=%s remains active: %s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        (Board.show_board_error error)
+    | Dirty_projection_flush_failed (Flush_raised { cause; backtrace }) ->
+      Log.BoardLog.error
+        "Board flusher operation=%s raised; retry obligation=%s remains active: %s\n%s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        (Printexc.to_string cause)
+        (Printexc.raw_backtrace_to_string backtrace)
+    | Sweep_routing_references_unavailable detail ->
+      Log.BoardLog.warn
+        "Board flusher operation=%s deferred; retry obligation=%s remains active: %s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        detail
+    | Sweep_raised { cause; backtrace } ->
+      Log.BoardLog.error
+        "Board flusher operation=%s raised; retry obligation=%s remains active: %s\n%s"
+        (operation_to_string operation)
+        (operation_to_string retry_operation)
+        (Printexc.to_string cause)
+        (Printexc.raw_backtrace_to_string backtrace)
   in
   let flusher_loop () =
     Log.BoardLog.info "Board flusher actor started";
-    while true do
-      match Eio.Stream.take store.Board.flusher_inbox with
-      | Board_types.Flush -> settle_dirty_projection ~recovering:false
-      | Board_types.Sweep ->
-          (try
-             with_routing_mutation_lock (fun () ->
-               match prepared_routing_references () with
-               | Ok references ->
-                 (match
-                    Board.sweep_and_flush
-                      ~protected_post_ids:references.post_ids
-                      ~protected_comment_ids:references.comment_ids
-                      store
-                  with
-                  | Ok _ -> ()
-                  | Error error ->
-                    Log.BoardLog.error
-                      "Post-sweep flush failed: %s"
-                      (Board.show_board_error error))
-               | Error detail ->
-                 Log.BoardLog.warn
-                   "Board sweep deferred because routing references are unavailable: %s"
-                   detail)
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
-    done
+    let rec loop obligations =
+      let operation, recovering, obligations = await_operation obligations in
+      let outcome =
+        match operation with
+        | Board_types.Flush -> flush_attempt ()
+        | Board_types.Sweep -> sweep_attempt ()
+      in
+      match outcome with
+      | Ok () ->
+        if recovering
+        then
+          Log.BoardLog.info
+            "Board flusher obligation settled operation=%s"
+            (operation_to_string operation);
+        loop obligations
+      | Error (retry_operation, failure) ->
+        log_attempt_failure ~operation ~retry_operation failure;
+        loop (retry_obligation obligations retry_operation)
+    in
+    let startup_reconciliation_at = Eio.Time.now clock in
+    loop
+      { flush_retry_at = Some startup_reconciliation_at
+      ; sweep_retry_at = Some startup_reconciliation_at
+      }
   in
   let routing_retry_loop () =
     Log.BoardLog.info "Board routing retry actor started";

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -525,9 +525,7 @@ let spawn_runtime_actor_on_switch ~sw ~clock store actor =
     | Flusher -> flusher_loop
     | Routing_retry -> routing_retry_loop
   in
-  Eio.Fiber.fork_daemon ~sw (fun () ->
-    loop ();
-    `Stop_daemon)
+  Eio.Fiber.fork_daemon ~sw (fun () -> loop ())
 
 (** Claim and start the Board runtime actors against the caller-owned root
     switch.  A losing caller yields and re-reads the typed backend state until

--- a/test/test_board_flusher_autonomous_retry.ml
+++ b/test/test_board_flusher_autonomous_retry.ml
@@ -67,9 +67,15 @@ let test_failed_flush_retries_without_new_board_activity () =
     (match Board.request_flush store with
      | Ok () -> ()
      | Error detail -> Alcotest.fail detail);
-    await ~clock (fun () -> Board.persist_error_count () > errors_before);
-    Unix.unlink board_dir;
-    Fs_compat.mkdir_p board_dir;
+    await ~clock (fun () -> Board.persist_error_count () > errors_before));
+  Unix.unlink board_dir;
+  Fs_compat.mkdir_p board_dir;
+  Eio.Switch.run (fun sw ->
+    (match Board_dispatch.start_runtime_actors ~sw ~clock with
+     | Ok () -> ()
+     | Error failures ->
+       Alcotest.fail
+         (Board_dispatch.runtime_actor_start_failures_to_string failures));
     await ~clock (fun () -> not store.Board.dirty_posts));
   let persisted_ids =
     Fs_compat.load_file (Board.persist_path ())
@@ -85,6 +91,57 @@ let test_failed_flush_retries_without_new_board_activity () =
     (List.exists (String.equal post_id) persisted_ids)
 ;;
 
+let test_failed_flush_does_not_block_sweep () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Unix.putenv "MASC_BASE_PATH" (fresh_base "masc-board-flusher-fair-source");
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  let store =
+    match Board_dispatch.backend () with
+    | Board_dispatch.Jsonl store -> store
+  in
+  let post =
+    match
+      Board.create_post store ~author:"flusher-fair-author"
+        ~content:"an expired post must sweep while flush recovery is pending"
+        ~post_kind:Board.Human_post ~ttl_hours:1 ()
+    with
+    | Ok post -> post
+    | Error error -> Alcotest.fail (Board.show_board_error error)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  Hashtbl.replace store.Board.posts post_id
+    { post with expires_at = Time_compat.now () -. 1.0 };
+  (match
+     Board.vote store ~voter:"flusher-fair-voter" ~post_id
+       ~direction:Board.Up
+   with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Board.show_board_error error));
+  let recovery_base = fresh_base "masc-board-flusher-fair-recovery" in
+  Unix.putenv "MASC_BASE_PATH" recovery_base;
+  let persist_path = Board.persist_path () in
+  Fs_compat.mkdir_p persist_path;
+  let errors_before = Board.persist_error_count () in
+  Eio.Switch.run (fun sw ->
+    (match Board_dispatch.start_runtime_actors ~sw ~clock with
+     | Ok () -> ()
+     | Error failures ->
+       Alcotest.fail
+         (Board_dispatch.runtime_actor_start_failures_to_string failures));
+    await ~clock (fun () -> Board.persist_error_count () > errors_before);
+    await ~clock (fun () -> not (Hashtbl.mem store.Board.posts post_id));
+    Unix.rmdir persist_path;
+    await ~clock (fun () -> not store.Board.dirty_posts));
+  Alcotest.(check bool)
+    "expired post remained swept after projection recovery"
+    false
+    (Hashtbl.mem store.Board.posts post_id)
+;;
+
 let () =
   Alcotest.run
     "board_flusher_autonomous_retry"
@@ -93,6 +150,10 @@ let () =
             "failed flush retries without new Board activity"
             `Quick
             test_failed_flush_retries_without_new_board_activity
+        ; Alcotest.test_case
+            "failed flush does not block sweep"
+            `Quick
+            test_failed_flush_does_not_block_sweep
         ] )
     ]
 ;;

--- a/test/test_board_flusher_autonomous_retry.ml
+++ b/test/test_board_flusher_autonomous_retry.ml
@@ -7,6 +7,8 @@ open Masc
 
 let () = Random.self_init ()
 
+let request_flush = Masc_board_handlers.Board_core_persist.request_flush
+
 let fresh_base prefix =
   Filename.concat
     (Filename.get_temp_dir_name ())
@@ -64,7 +66,7 @@ let test_failed_flush_retries_without_new_board_activity () =
      | Error failures ->
        Alcotest.fail
          (Board_dispatch.runtime_actor_start_failures_to_string failures));
-    (match Board.request_flush store with
+    (match request_flush store with
      | Ok () -> ()
      | Error detail -> Alcotest.fail detail);
     await ~clock (fun () -> Board.persist_error_count () > errors_before));


### PR DESCRIPTION
## Summary
- replace blocking recursive Flush recovery with immutable per-operation retry deadlines
- retain Sweep failures as typed obligations and convert post-sweep projection failures into Flush-only recovery
- reconcile both Flush and Sweep whenever a new flusher owner starts, so switch/process restart cannot erase actor-local work
- keep inbox work responsive while another operation waits for its retry deadline

## Regression evidence
- failed dirty projection survives owner-switch shutdown and is settled by the replacement owner without new Board activity
- a failed Flush does not block the startup Sweep quantum; the expired post is removed while the projection path remains broken

## Validation
- `ocamlformat -i` on all touched OCaml files
- `ocamlc -stop-after parsing -c` on all touched OCaml files
- `git diff --check`
- focused `scripts/dune-local.sh build test/test_board_flusher_autonomous_retry.exe` stopped before compilation by shared agent_sdk pin drift: actual `9d8c54b665c69b927ac1541bec58891ac3cc93d9`, expected `2102d4de5cdce118cfd6100a8c88e1ed52b0678b`; no bypass or shared-opam mutation used