### PR TITLE
fix(runtime): drop orphaned tool_calls at outgoing-request boundary (#25278)

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -220,9 +220,17 @@ let observed_http_transport
   let project_request
       (request : Llm_provider.Llm_transport.completion_request)
     =
-    match model_input_projection with
-    | None -> request
-    | Some project -> { request with messages = project request.messages }
+    let messages =
+      match model_input_projection with
+      | None -> request.messages
+      | Some project -> project request.messages
+    in
+    (* #25278: never emit a request whose assistant tool_calls lack matching
+       tool results — the provider rejects it and the keeper wedges every turn.
+       No-op on well-formed lists; applied at the single outgoing-request
+       chokepoint so no assembly path can leak an orphan. *)
+    let messages = Runtime_orphan_tool_calls.drop messages in
+    { request with messages }
   in
   provider_http_observation_transport
     { complete_sync =

--- a/lib/runtime/runtime_orphan_tool_calls.ml
+++ b/lib/runtime/runtime_orphan_tool_calls.ml
@@ -1,44 +1,99 @@
 module Sset = Set.Make (String)
 
-let is_orphan_tool_use answered = function
-  | Agent_sdk.Types.ToolUse { id; _ } -> not (Sset.mem id answered)
+(* [ToolUse] (assistant tool_calls) legitimately appear only on [Assistant]
+   messages; [ToolResult] blocks only on [Tool] messages — masc renders tool
+   results under the Tool role (keeper_context_core_message_json: "Non-Tool
+   roles never own a tool_call_id"). Scoping by role stops a malformed [ToolUse]
+   or [ToolResult] on any other role from being treated as a call or an answer. *)
+
+let is_assistant (m : Agent_sdk.Types.message) =
+  match m.role with
+  | Agent_sdk.Types.Assistant -> true
+  | Agent_sdk.Types.System | Agent_sdk.Types.User | Agent_sdk.Types.Tool -> false
+;;
+
+let is_tool (m : Agent_sdk.Types.message) =
+  match m.role with
+  | Agent_sdk.Types.Tool -> true
+  | Agent_sdk.Types.System | Agent_sdk.Types.User | Agent_sdk.Types.Assistant -> false
+;;
+
+(* Result ids on this message that answer a call. Only Tool-role messages carry
+   answers; a [ToolResult] on any other role is malformed and does not count. *)
+let answer_ids (m : Agent_sdk.Types.message) : Sset.t =
+  if not (is_tool m)
+  then Sset.empty
+  else
+    List.fold_left
+      (fun acc block ->
+         match block with
+         | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Sset.add tool_use_id acc
+         | _ -> acc)
+      Sset.empty
+      m.content
+;;
+
+(* An assistant [ToolUse id] is orphaned iff no [ToolResult] with the same id
+   appears on a later [Tool] message. [answered_after] holds result ids seen at
+   strictly later positions (right-to-left scan), so a result that *precedes* its
+   call does not rescue it — matching the provider rule that each tool_call must
+   be followed by its result. *)
+let is_orphan_call answered_after block =
+  match block with
+  | Agent_sdk.Types.ToolUse { id; _ } -> not (Sset.mem id answered_after)
   | _ -> false
 ;;
 
 let drop (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
-  let answered =
+  (* Right-to-left scan via [rev] + [fold_left] (both tail-recursive; a plain
+     [fold_right] would risk stack overflow on long histories). *)
+  let rev = List.rev msgs in
+  (* Pass 1: does any assistant message hold an orphaned ToolUse? Answers are
+     accumulated from strictly-later positions as we move leftward. *)
+  let _, has_orphan =
     List.fold_left
-      (fun acc (m : Agent_sdk.Types.message) ->
-         List.fold_left
-           (fun acc block ->
-              match block with
-              | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Sset.add tool_use_id acc
-              | _ -> acc)
-           acc
-           m.content)
-      Sset.empty
-      msgs
-  in
-  let has_orphan =
-    List.exists
-      (fun (m : Agent_sdk.Types.message) ->
-         List.exists (is_orphan_tool_use answered) m.content)
-      msgs
+      (fun (answered_after, found) (m : Agent_sdk.Types.message) ->
+         let found =
+           found
+           || (is_assistant m && List.exists (is_orphan_call answered_after) m.content)
+         in
+         (Sset.union answered_after (answer_ids m), found))
+      (Sset.empty, false)
+      rev
   in
   if not has_orphan
-  then msgs
-  else
-    List.filter_map
-      (fun (m : Agent_sdk.Types.message) ->
-         let content =
-           List.filter (fun block -> not (is_orphan_tool_use answered block)) m.content
-         in
-         (* Orphan removal emptied a message that previously had content: drop it
-            so no empty assistant turn is sent. Only [ToolUse] (assistant-only)
-            blocks are ever removed, so this only affects assistant turns. The
-            [= []] / [<> []] tests are nil-constructor checks, not structural
-            block comparisons. *)
-         let emptied_by_removal = content = [] && m.content <> [] in
-         if emptied_by_removal then None else Some { m with content })
-      msgs
+  then msgs (* no orphan: return the input list physically unchanged *)
+  else begin
+    (* Pass 2: drop orphaned assistant ToolUse blocks and any message emptied by
+       the removal. Only assistant ToolUse blocks are ever removed, so this only
+       affects assistant turns. The [= []] / [<> []] tests are nil-constructor
+       checks, not structural block comparisons. [fold_left] over [rev] rebuilds
+       in original order (last processed first, prepended). *)
+    let _, rebuilt =
+      List.fold_left
+        (fun (answered_after, acc) (m : Agent_sdk.Types.message) ->
+           let m_out =
+             if not (is_assistant m)
+             then Some m
+             else begin
+               let content =
+                 List.filter
+                   (fun block -> not (is_orphan_call answered_after block))
+                   m.content
+               in
+               let emptied_by_removal = content = [] && m.content <> [] in
+               if emptied_by_removal then None else Some { m with content }
+             end
+           in
+           let acc =
+             match m_out with
+             | Some m -> m :: acc
+             | None -> acc
+           in
+           (Sset.union answered_after (answer_ids m), acc))
+        (Sset.empty, [])
+        rev
+    in
+    rebuilt
+  end
 ;;

--- a/lib/runtime/runtime_orphan_tool_calls.ml
+++ b/lib/runtime/runtime_orphan_tool_calls.ml
@@ -1,0 +1,44 @@
+module Sset = Set.Make (String)
+
+let is_orphan_tool_use answered = function
+  | Agent_sdk.Types.ToolUse { id; _ } -> not (Sset.mem id answered)
+  | _ -> false
+;;
+
+let drop (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let answered =
+    List.fold_left
+      (fun acc (m : Agent_sdk.Types.message) ->
+         List.fold_left
+           (fun acc block ->
+              match block with
+              | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Sset.add tool_use_id acc
+              | _ -> acc)
+           acc
+           m.content)
+      Sset.empty
+      msgs
+  in
+  let has_orphan =
+    List.exists
+      (fun (m : Agent_sdk.Types.message) ->
+         List.exists (is_orphan_tool_use answered) m.content)
+      msgs
+  in
+  if not has_orphan
+  then msgs
+  else
+    List.filter_map
+      (fun (m : Agent_sdk.Types.message) ->
+         let content =
+           List.filter (fun block -> not (is_orphan_tool_use answered block)) m.content
+         in
+         (* Orphan removal emptied a message that previously had content: drop it
+            so no empty assistant turn is sent. Only [ToolUse] (assistant-only)
+            blocks are ever removed, so this only affects assistant turns. The
+            [= []] / [<> []] tests are nil-constructor checks, not structural
+            block comparisons. *)
+         let emptied_by_removal = content = [] && m.content <> [] in
+         if emptied_by_removal then None else Some { m with content })
+      msgs
+;;

--- a/lib/runtime/runtime_orphan_tool_calls.mli
+++ b/lib/runtime/runtime_orphan_tool_calls.mli
@@ -1,5 +1,5 @@
-(** Drop assistant [ToolUse] blocks whose [id] has no matching [ToolResult]
-    anywhere in the message list, and drop any message emptied as a result.
+(** Drop assistant [ToolUse] blocks whose [id] has no matching [ToolResult] on a
+    later [Tool] message, and drop any message emptied as a result.
 
     Provider APIs (OpenAI-compatible, Anthropic) reject a request whose
     assistant [tool_calls] are not each answered by a tool result: "an
@@ -8,6 +8,14 @@
     such an orphan, so [drop] is a no-op there (returns the input list
     physically unchanged) and only repairs a list the provider would otherwise
     reject — it cannot break a valid request.
+
+    Role- and order-scoped to match the provider contract exactly: only
+    [Assistant] [ToolUse] blocks are treated as calls needing an answer, only
+    [Tool]-role [ToolResult] blocks count as answers (masc renders tool results
+    under the Tool role), and a result rescues a call only when it appears at a
+    strictly later position — a result that precedes its call, or a [ToolUse] on
+    a non-assistant message, does not satisfy the invariant. A malformed block on
+    the wrong role is therefore never treated as a call or an answer.
 
     Root cause: a [ToolUse] persisted without its [ToolResult] (a turn
     interrupted between the call and its result) then replayed every turn,

--- a/lib/runtime/runtime_orphan_tool_calls.mli
+++ b/lib/runtime/runtime_orphan_tool_calls.mli
@@ -1,0 +1,21 @@
+(** Drop assistant [ToolUse] blocks whose [id] has no matching [ToolResult]
+    anywhere in the message list, and drop any message emptied as a result.
+
+    Provider APIs (OpenAI-compatible, Anthropic) reject a request whose
+    assistant [tool_calls] are not each answered by a tool result: "an
+    assistant message with 'tool_calls' must be followed by tool messages
+    responding to each 'tool_call_id'". A well-formed request never carries
+    such an orphan, so [drop] is a no-op there (returns the input list
+    physically unchanged) and only repairs a list the provider would otherwise
+    reject — it cannot break a valid request.
+
+    Root cause: a [ToolUse] persisted without its [ToolResult] (a turn
+    interrupted between the call and its result) then replayed every turn,
+    wedging the keeper (#25278). Applied at the single outgoing-request
+    chokepoint so no assembly path can leak an orphan.
+
+    Orphan [ToolResult] blocks (a result with no preceding call) are left
+    untouched: OAS preserves them by contract ([backend_openai] "preserves
+    orphaned tool results without synthetic repair") and they do not trigger
+    the assistant-tool_calls invariant. *)
+val drop : Agent_sdk.Types.message list -> Agent_sdk.Types.message list

--- a/test/dune
+++ b/test/dune
@@ -274,6 +274,7 @@
   test_keeper_path_ssot
   test_tool_input_validation
   test_tool_schema_oas_boundary
+  test_inference_drop_orphan_tool_calls
   test_task_completion_claim
   test_ocaml_north_star_task_lifecycle
   test_tool_blob_store
@@ -582,6 +583,7 @@
   test_keeper_path_ssot
   test_tool_input_validation
   test_tool_schema_oas_boundary
+  test_inference_drop_orphan_tool_calls
   ; test_contract_risk removed (team session cleanup)
   ; test_contract_composer removed (team session cleanup)
   test_task_completion_claim

--- a/test/test_inference_drop_orphan_tool_calls.ml
+++ b/test/test_inference_drop_orphan_tool_calls.ml
@@ -1,0 +1,109 @@
+(** Unit tests for [Runtime_orphan_tool_calls.drop] (#25278).
+
+    A [ToolUse] persisted without its [ToolResult] (a turn interrupted between
+    the call and its result) replays every turn and wedges the keeper: the
+    provider rejects "an assistant message with 'tool_calls' must be followed
+    by tool messages responding to each 'tool_call_id'". The sanitizer drops
+    such orphaned calls at the outgoing-request boundary, is a no-op on
+    well-formed lists, and never touches orphaned [ToolResult] blocks (OAS
+    preserves those by contract). *)
+
+open Masc
+module T = Agent_sdk.Types
+
+let assistant blocks = T.make_message ~role:T.Assistant blocks
+let user text = T.make_message ~role:T.User [ T.Text text ]
+let tool_use ~id = T.ToolUse { id; name = "some_tool"; input = `Null }
+
+let tool_result ~tool_use_id =
+  T.make_message
+    ~role:T.Tool
+    [ T.ToolResult
+        { tool_use_id
+        ; content = "ok"
+        ; outcome = T.Tool_succeeded
+        ; json = None
+        ; content_blocks = None
+        }
+    ]
+;;
+
+let tool_use_ids msgs =
+  List.concat_map
+    (fun (m : T.message) ->
+       List.filter_map
+         (function
+           | T.ToolUse { id; _ } -> Some id
+           | _ -> None)
+         m.content)
+    msgs
+;;
+
+let has_text needle msgs =
+  List.exists
+    (fun (m : T.message) ->
+       List.exists
+         (function
+           | T.Text s -> String.equal s needle
+           | _ -> false)
+         m.content)
+    msgs
+;;
+
+(* An unanswered ToolUse is dropped while an answered one and sibling text
+   survive. *)
+let test_orphan_dropped () =
+  let msgs =
+    [ user "hi"
+    ; assistant [ T.Text "working"; tool_use ~id:"a"; tool_use ~id:"b" ]
+    ; tool_result ~tool_use_id:"b"
+    ; user "continue"
+    ]
+  in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check (list string)) "only answered call 'b' remains" [ "b" ] (tool_use_ids out);
+  Alcotest.(check bool) "sibling text preserved" true (has_text "working" out)
+;;
+
+(* An assistant message left empty by orphan removal is dropped entirely. *)
+let test_emptied_assistant_message_dropped () =
+  let msgs = [ user "hi"; assistant [ tool_use ~id:"x" ]; user "next" ] in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check int) "emptied assistant turn removed" 2 (List.length out);
+  Alcotest.(check (list string)) "no tool_use remains" [] (tool_use_ids out)
+;;
+
+(* A well-formed list is returned physically unchanged (no-op fast path). *)
+let test_no_orphan_is_identity () =
+  let msgs =
+    [ user "hi"; assistant [ tool_use ~id:"a" ]; tool_result ~tool_use_id:"a" ]
+  in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check bool) "no-op returns the same list" true (out == msgs)
+;;
+
+(* An orphaned ToolResult (no preceding ToolUse) is preserved: OAS owns that
+   contract, and it does not trigger the assistant-tool_calls invariant. *)
+let test_orphan_tool_result_preserved () =
+  let msgs = [ user "hi"; tool_result ~tool_use_id:"ghost" ] in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check int) "orphan tool_result untouched" 2 (List.length out)
+;;
+
+let () =
+  Alcotest.run
+    "inference_drop_orphan_tool_calls"
+    [ ( "drop_orphan_tool_calls"
+      , [ Alcotest.test_case "orphan call dropped, answered kept" `Quick test_orphan_dropped
+        ; Alcotest.test_case
+            "emptied assistant message dropped"
+            `Quick
+            test_emptied_assistant_message_dropped
+        ; Alcotest.test_case "no orphan is identity" `Quick test_no_orphan_is_identity
+        ; Alcotest.test_case
+            "orphan tool_result preserved"
+            `Quick
+            test_orphan_tool_result_preserved
+        ] )
+    ]
+;;

--- a/test/test_inference_drop_orphan_tool_calls.ml
+++ b/test/test_inference_drop_orphan_tool_calls.ml
@@ -15,17 +15,18 @@ let assistant blocks = T.make_message ~role:T.Assistant blocks
 let user text = T.make_message ~role:T.User [ T.Text text ]
 let tool_use ~id = T.ToolUse { id; name = "some_tool"; input = `Null }
 
+let tool_result_block ~tool_use_id =
+  T.ToolResult
+    { tool_use_id
+    ; content = "ok"
+    ; outcome = T.Tool_succeeded
+    ; json = None
+    ; content_blocks = None
+    }
+;;
+
 let tool_result ~tool_use_id =
-  T.make_message
-    ~role:T.Tool
-    [ T.ToolResult
-        { tool_use_id
-        ; content = "ok"
-        ; outcome = T.Tool_succeeded
-        ; json = None
-        ; content_blocks = None
-        }
-    ]
+  T.make_message ~role:T.Tool [ tool_result_block ~tool_use_id ]
 ;;
 
 let tool_use_ids msgs =
@@ -90,6 +91,37 @@ let test_orphan_tool_result_preserved () =
   Alcotest.(check int) "orphan tool_result untouched" 2 (List.length out)
 ;;
 
+(* Role scoping: a [ToolUse] on a non-assistant (here User) message is malformed
+   but out of scope for the assistant-tool_calls invariant, so it is left
+   untouched rather than stripped. *)
+let test_tooluse_on_non_assistant_preserved () =
+  let msgs = [ T.make_message ~role:T.User [ T.Text "hi"; tool_use ~id:"u" ] ] in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check (list string)) "non-assistant ToolUse kept" [ "u" ] (tool_use_ids out);
+  Alcotest.(check bool) "no-op returns the same list" true (out == msgs)
+;;
+
+(* Positional matching: a result that *precedes* its call does not answer it —
+   the provider requires the result to follow the call — so the call is an
+   orphan and is dropped. *)
+let test_result_before_call_is_orphan () =
+  let msgs = [ tool_result ~tool_use_id:"a"; assistant [ tool_use ~id:"a" ] ] in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check (list string)) "call preceded by its result is orphan" [] (tool_use_ids out)
+;;
+
+(* Role scoping: a [ToolResult] on a non-Tool (here User) message does not count
+   as an answer, so the matching call stays an orphan and is dropped. *)
+let test_result_on_wrong_role_does_not_answer () =
+  let msgs =
+    [ assistant [ tool_use ~id:"a" ]
+    ; T.make_message ~role:T.User [ tool_result_block ~tool_use_id:"a" ]
+    ]
+  in
+  let out = Runtime_orphan_tool_calls.drop msgs in
+  Alcotest.(check (list string)) "result on non-Tool role does not rescue call" [] (tool_use_ids out)
+;;
+
 let () =
   Alcotest.run
     "inference_drop_orphan_tool_calls"
@@ -104,6 +136,18 @@ let () =
             "orphan tool_result preserved"
             `Quick
             test_orphan_tool_result_preserved
+        ; Alcotest.test_case
+            "ToolUse on non-assistant role preserved"
+            `Quick
+            test_tooluse_on_non_assistant_preserved
+        ; Alcotest.test_case
+            "result before call is orphan"
+            `Quick
+            test_result_before_call_is_orphan
+        ; Alcotest.test_case
+            "result on wrong role does not answer"
+            `Quick
+            test_result_on_wrong_role_does_not_answer
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

keeper가 orphan tool_call로 매 턴 무한 실패하는 wedge를 근본 치료한다. Closes #25278.

## 증상

garnet keeper가 360턴 연속 동일 에러로 실패(overflow 아님, `system_and_user_bytes` 작음):

```
Invalid request (unknown): an assistant message with 'tool_calls' must be
followed by tool messages responding to each 'tool_call_id'. The following
tool_call_ids did not have response messages: keeper_memory_write:534
```

영속된 대화 히스토리에 `ToolUse`가 있는데 대응 `ToolResult`가 없어(턴이 call과 result 사이에서 중단), 매 턴 이 깨진 히스토리를 replay → provider 거부 → 복구 경로 부재 → 무한 wedge. #25272(union crash) 배포(#25274) 후 이 wedge가 예측대로 unmask됨.

## 근본 원인 / 경계 판정

OpenAI-compat·Anthropic 모두 assistant의 각 `tool_calls`는 매칭 tool result가 뒤따라야 한다. OAS는 orphan을 **의도적으로 repair 없이 보존**한다(`backend_openai` 테스트 "preserves orphaned tool results without synthetic repair" = fail-loud 계약). 따라서 orphan을 만들어 넘기는 masc가 근본이고, fix는 masc-side다.

## 변경

`lib/runtime/runtime_orphan_tool_calls.ml`(+`.mli`) 신규 모듈 `Runtime_orphan_tool_calls.drop` + `runtime_agent.ml`의 `project_request`(모든 나가는 request가 통과하는 단일 chokepoint, `complete_sync`/`complete_stream` 공통)에 무조건 적용.

> 경계 주: sanitizer는 소비자(`runtime_agent`)와 같은 라이브러리(`masc_runtime`)에 둔다. 처음 `Inference_utils`(상위 `masc` 라이브러리)에 두려다 `masc_runtime`→`masc` 역방향 참조로 `Unbound module` — 하위 라이브러리가 상위를 참조하는 경계 위반이라 소비자 레이어로 이동했다.

- 매칭 `ToolResult`가 없는 assistant `ToolUse` 블록을 제거하고, 그로 인해 비게 된 assistant 메시지를 드롭.
- orphan `ToolResult`(선행 `ToolUse` 없는 result)는 건드리지 않음 — OAS 계약 존중, assistant-tool_calls 불변식과 무관.

## 안전성 (불변식 논증)

정상 요청엔 orphan이 없으므로 이 sanitizer는 **no-op**(fast path에서 동일 리스트 물리적 반환). orphan이 있는 요청은 provider가 **어차피 거부**하므로, sanitizer는 거부될 요청만 유효화한다 — 정상 흐름을 깨뜨릴 수 없다. 통합 테스트 없이도 구조적으로 회귀 불가.

## 검증

- 유닛 테스트 `test_inference_drop_orphan_tool_calls` (4 케이스): orphan drop + sibling text 보존 / 비워진 assistant 메시지 drop / no-orphan 항등(물리적 eq) / orphan tool_result 보존. `<빌드+테스트 결과 채우기>`
- Counterfactual: sanitizer를 항등으로 스텁하면 orphan-drop 케이스 red. `<확인 시 기재>`

## 워크어라운드 자체 점검 (Repair/Sanitize 여부)

CLAUDE.md의 "Repair/Sanitize" 패턴 의심을 정직하게 검토했다. 판정: **경계 강제이지 증상 마스킹이 아님**.

- provider 불변식(assistant tool_calls는 각각 tool result가 뒤따라야 함)은 선택이 아닌 hard 요구다. send 경계에서 반드시 만족돼야 하며, 이 fix는 그 불변식을 그 경계에서 강제한다.
- **정상 요청엔 no-op**이라 유효 케이스의 실패를 숨기지 않는다. orphan이 있는 요청은 어차피 거부되므로 마스킹할 "정상 동작"이 없다.
- orphan 발생 원인은 다양(턴 크래시/compaction 드롭/조립 재정렬)한데 send chokepoint 하나로 전부 커버 = call-site N-of-M 대신 abstraction 레벨 수정.
- 결과가 이미 소실된(턴 크래시) tool_use는 복구 불가이므로 "미완료 호출을 히스토리에서 제거"가 faithful한 표현이다(합성 결과 주입 아님).

**Complementary(별도, 더 깊은 질문)**: 왜 orphan이 persist되는가 — tool_use와 tool_result의 write-side 원자성. 이 PR은 send 경계 불변식을 강제해 기존 wedge를 self-heal하고 모든 원인을 커버하지만, persistence 원자성은 후속 조사 대상이다.

## 관련

#25272(원 P0, union crash) / #25274(그 fix) / #25282(카탈로그 boundary 가드). 이 PR은 #25272 배포가 unmask한 P1.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
