### PR TITLE
feat(schedule): typed RFC 5545 content-line parser (iCalendar leaf 2)

### DIFF
--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -12,6 +12,7 @@
   schedule_domain
   schedule_occurrence_id
   schedule_ical_recur
+  schedule_ical_content_line
   schedule_supported_kinds
   schedule_store
   schedule_service

--- a/lib/schedule/schedule_ical_content_line.ml
+++ b/lib/schedule/schedule_ical_content_line.ml
@@ -1,0 +1,230 @@
+(* See .mli for the contract. RFC 5545 §3.1 content lines. *)
+
+type param = { name : string; values : string list }
+type t = { name : string; params : param list; value : string }
+
+type parse_error =
+  | Lone_carriage_return of { position : int }
+  | Orphan_continuation of { line : int }
+  | Empty_name of { line : int }
+  | Invalid_name_char of { line : int; name : string }
+  | Missing_colon of { line : int }
+  | Invalid_param_name_char of { line : int; name : string }
+  | Missing_param_equals of { line : int; param : string }
+  | Unterminated_quoted_string of { line : int; param : string }
+  | Control_character of { line : int; position : int; code : int }
+
+let parse_error_to_string = function
+  | Lone_carriage_return { position } ->
+    Printf.sprintf "lone CR at byte %d (CR must be followed by LF)" position
+  | Orphan_continuation { line } ->
+    Printf.sprintf "line %d: folded continuation with no preceding line" line
+  | Empty_name { line } -> Printf.sprintf "line %d: empty property name" line
+  | Invalid_name_char { line; name } ->
+    Printf.sprintf "line %d: invalid property name %S" line name
+  | Missing_colon { line } ->
+    Printf.sprintf "line %d: content line has no value separator (:)" line
+  | Invalid_param_name_char { line; name } ->
+    Printf.sprintf "line %d: invalid parameter name %S" line name
+  | Missing_param_equals { line; param } ->
+    Printf.sprintf "line %d: parameter %S has no = separator" line param
+  | Unterminated_quoted_string { line; param } ->
+    Printf.sprintf "line %d: parameter %S has an unterminated quoted-string"
+      line param
+  | Control_character { line; position; code } ->
+    Printf.sprintf "line %d: control character 0x%02X at byte %d" line code
+      position
+
+(* ---------------------------------------------------------------- *)
+(* Unfold                                                           *)
+(* ---------------------------------------------------------------- *)
+
+(* Physical lines: CRLF or bare LF delimited; a lone CR is an error. *)
+let split_physical input =
+  let n = String.length input in
+  let rec loop start i acc line_no =
+    if i >= n then
+      let last = String.sub input start (i - start) in
+      Ok (List.rev ((last, line_no) :: acc))
+    else
+      match input.[i] with
+      | '\r' ->
+        if i + 1 < n && input.[i + 1] = '\n' then
+          loop (i + 2) (i + 2)
+            ((String.sub input start (i - start), line_no) :: acc)
+            (line_no + 1)
+        else Error (Lone_carriage_return { position = i })
+      | '\n' ->
+        loop (i + 1) (i + 1)
+          ((String.sub input start (i - start), line_no) :: acc)
+          (line_no + 1)
+      | _ -> loop start (i + 1) acc line_no
+  in
+  loop 0 0 [] 1
+
+(* §3.1 unfolding: a physical line beginning with SPACE/HTAB continues the
+   previous logical line (the leading whitespace is removed). Empty physical
+   lines carry no content and are skipped. Each returned logical line keeps
+   the physical line number it started on for error reporting. *)
+let unfold_numbered input =
+  match split_physical input with
+  | Error _ as error -> error
+  | Ok physical ->
+    let rec join acc current = function
+      | [] -> (
+        match current with
+        | None -> Ok (List.rev acc)
+        | Some pair -> Ok (List.rev (pair :: acc)))
+      | (line, line_no) :: rest ->
+        if String.length line = 0 then join acc current rest
+        else if line.[0] = ' ' || line.[0] = '\t' then (
+          let fragment = String.sub line 1 (String.length line - 1) in
+          match current with
+          | None -> Error (Orphan_continuation { line = line_no })
+          | Some (text, start_line) ->
+            join acc (Some (text ^ fragment, start_line)) rest)
+        else
+          let acc =
+            match current with
+            | None -> acc
+            | Some pair -> pair :: acc
+          in
+          join acc (Some (line, line_no)) rest
+    in
+    join [] None physical
+
+let unfold input =
+  match unfold_numbered input with
+  | Error _ as error -> error
+  | Ok numbered -> Ok (List.map fst numbered)
+
+(* ---------------------------------------------------------------- *)
+(* Parse one logical line                                           *)
+(* ---------------------------------------------------------------- *)
+
+let is_name_char c =
+  (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+  || c = '-'
+
+let valid_name s =
+  let n = String.length s in
+  n > 0 &&
+  let rec loop i = i >= n || (is_name_char s.[i] && loop (i + 1)) in
+  loop 0
+
+let is_control c =
+  let code = Char.code c in
+  (code < 0x20 && c <> '\t') || code = 0x7F
+
+let reject_control ~line text =
+  let n = String.length text in
+  let rec loop i =
+    if i >= n then Ok ()
+    else if is_control text.[i] then
+      Error (Control_character { line; position = i; code = Char.code text.[i] })
+    else loop (i + 1)
+  in
+  loop 0
+
+(* Index of the first occurrence of [target] outside a quoted-string.
+   QSAFE-CHAR excludes DQUOTE, so a quote always toggles quote state. *)
+let index_outside_quotes text target =
+  let n = String.length text in
+  let rec loop i in_quote =
+    if i >= n then None
+    else
+      match text.[i] with
+      | '"' -> loop (i + 1) (not in_quote)
+      | c when c = target && not in_quote -> Some i
+      | _ -> loop (i + 1) in_quote
+  in
+  loop 0 false
+
+(* Split on [sep] outside quoted-strings, preserving empties. *)
+let split_outside_quotes text sep =
+  let n = String.length text in
+  let rec loop start i in_quote acc =
+    if i >= n then List.rev (String.sub text start (i - start) :: acc)
+    else
+      match text.[i] with
+      | '"' -> loop start (i + 1) (not in_quote) acc
+      | c when c = sep && not in_quote ->
+        loop (i + 1) (i + 1) false (String.sub text start (i - start) :: acc)
+      | _ -> loop start (i + 1) in_quote acc
+  in
+  loop 0 0 false []
+
+let parse_param_value ~line ~param_name raw =
+  let n = String.length raw in
+  if n > 0 && raw.[0] = '"' then
+    if n >= 2 && raw.[n - 1] = '"' then
+      Ok (String.sub raw 1 (n - 2))
+    else Error (Unterminated_quoted_string { line; param = param_name })
+  else Ok raw
+
+let parse_param ~line raw =
+  match String.index_opt raw '=' with
+  | None -> Error (Missing_param_equals { line; param = raw })
+  | Some eq ->
+    let name = String.sub raw 0 eq in
+    if not (valid_name name) then
+      Error (Invalid_param_name_char { line; name })
+    else
+      let values_raw = String.sub raw (eq + 1) (String.length raw - eq - 1) in
+      let pieces = split_outside_quotes values_raw ',' in
+      let rec values acc = function
+        | [] -> Ok (List.rev acc)
+        | piece :: rest -> (
+          match parse_param_value ~line ~param_name:name piece with
+          | Error _ as error -> error
+          | Ok value -> values (value :: acc) rest)
+      in
+      (match values [] pieces with
+       | Error _ as error -> error
+       | Ok values -> Ok { name = String.uppercase_ascii name; values })
+
+let parse ~line text =
+  match reject_control ~line text with
+  | Error _ as error -> error
+  | Ok () -> (
+    match index_outside_quotes text ':' with
+    | None -> Error (Missing_colon { line })
+    | Some colon ->
+      let head = String.sub text 0 colon in
+      let value = String.sub text (colon + 1) (String.length text - colon - 1) in
+      let segments = split_outside_quotes head ';' in
+      (match segments with
+       | [] -> Error (Empty_name { line })
+       | name_raw :: params_raw ->
+         if String.length name_raw = 0 then Error (Empty_name { line })
+         else if not (valid_name name_raw) then
+           Error (Invalid_name_char { line; name = name_raw })
+         else
+           let rec params acc = function
+             | [] -> Ok (List.rev acc)
+             | raw :: rest -> (
+               match parse_param ~line raw with
+               | Error _ as error -> error
+               | Ok param -> params (param :: acc) rest)
+           in
+           (match params [] params_raw with
+            | Error _ as error -> error
+            | Ok params ->
+              Ok { name = String.uppercase_ascii name_raw; params; value })))
+
+let parse_many input =
+  match unfold_numbered input with
+  | Error _ as error -> error
+  | Ok lines ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | (text, line_no) :: rest -> (
+        match parse ~line:line_no text with
+        | Error _ as error -> error
+        | Ok content_line -> loop (content_line :: acc) rest)
+    in
+    loop [] lines
+
+let find_param ~name params =
+  let upper = String.uppercase_ascii name in
+  List.find_opt (fun (p : param) -> String.equal p.name upper) params

--- a/lib/schedule/schedule_ical_content_line.ml
+++ b/lib/schedule/schedule_ical_content_line.ml
@@ -83,11 +83,14 @@ let unfold_numbered input =
   match split_physical input with
   | Error _ as error -> error
   | Ok physical ->
+    let finish (fragments_rev, start_line) =
+      String.concat "" (List.rev fragments_rev), start_line
+    in
     let rec join acc current = function
       | [] -> (
         match current with
         | None -> Ok (List.rev acc)
-        | Some pair -> Ok (List.rev (pair :: acc)))
+        | Some fragments -> Ok (List.rev (finish fragments :: acc)))
       | (line, line_no) :: rest ->
         if String.length line = 0 then
           Error (Empty_physical_line { line = line_no })
@@ -95,15 +98,15 @@ let unfold_numbered input =
           let fragment = String.sub line 1 (String.length line - 1) in
           match current with
           | None -> Error (Orphan_continuation { line = line_no })
-          | Some (text, start_line) ->
-            join acc (Some (text ^ fragment, start_line)) rest)
+          | Some (fragments_rev, start_line) ->
+            join acc (Some (fragment :: fragments_rev, start_line)) rest)
         else
           let acc =
             match current with
             | None -> acc
-            | Some pair -> pair :: acc
+            | Some fragments -> finish fragments :: acc
           in
-          join acc (Some (line, line_no)) rest
+          join acc (Some ([ line ], line_no)) rest
     in
     join [] None physical
 
@@ -180,8 +183,7 @@ let value_separator ~line text =
           None
       | '"' ->
         (match first_equals with
-         | Some eq
-           when i > 0 && (text.[i - 1] = '=' || text.[i - 1] = ',') ->
+         | Some eq when i = eq + 1 || (i > eq + 1 && text.[i - 1] = ',') ->
           let param = String.sub text param_start (eq - param_start) in
           loop (i + 1) true param_start first_equals (Some param)
          | _ -> Error (Invalid_quoted_string { line; position = i }))

--- a/lib/schedule/schedule_ical_content_line.ml
+++ b/lib/schedule/schedule_ical_content_line.ml
@@ -2,9 +2,13 @@
 
 type param = { name : string; values : string list }
 type t = { name : string; params : param list; value : string }
+type unique_param_error = Duplicate_parameter of string
 
 type parse_error =
   | Lone_carriage_return of { position : int }
+  | Lone_line_feed of { position : int }
+  | Missing_final_crlf of { position : int }
+  | Empty_physical_line of { line : int }
   | Orphan_continuation of { line : int }
   | Empty_name of { line : int }
   | Invalid_name_char of { line : int; name : string }
@@ -12,11 +16,19 @@ type parse_error =
   | Invalid_param_name_char of { line : int; name : string }
   | Missing_param_equals of { line : int; param : string }
   | Unterminated_quoted_string of { line : int; param : string }
+  | Invalid_quoted_string of { line : int; position : int }
+  | Invalid_utf8 of { line : int }
   | Control_character of { line : int; position : int; code : int }
 
 let parse_error_to_string = function
   | Lone_carriage_return { position } ->
     Printf.sprintf "lone CR at byte %d (CR must be followed by LF)" position
+  | Lone_line_feed { position } ->
+    Printf.sprintf "lone LF at byte %d (content lines require CRLF)" position
+  | Missing_final_crlf { position } ->
+    Printf.sprintf "content stream is not CRLF-terminated at byte %d" position
+  | Empty_physical_line { line } ->
+    Printf.sprintf "line %d: empty physical line" line
   | Orphan_continuation { line } ->
     Printf.sprintf "line %d: folded continuation with no preceding line" line
   | Empty_name { line } -> Printf.sprintf "line %d: empty property name" line
@@ -31,6 +43,9 @@ let parse_error_to_string = function
   | Unterminated_quoted_string { line; param } ->
     Printf.sprintf "line %d: parameter %S has an unterminated quoted-string"
       line param
+  | Invalid_quoted_string { line; position } ->
+    Printf.sprintf "line %d: invalid DQUOTE placement at byte %d" line position
+  | Invalid_utf8 { line } -> Printf.sprintf "line %d: invalid UTF-8" line
   | Control_character { line; position; code } ->
     Printf.sprintf "line %d: control character 0x%02X at byte %d" line code
       position
@@ -39,13 +54,14 @@ let parse_error_to_string = function
 (* Unfold                                                           *)
 (* ---------------------------------------------------------------- *)
 
-(* Physical lines: CRLF or bare LF delimited; a lone CR is an error. *)
+(* Physical lines are CRLF-delimited. Bare CR, bare LF, and a non-empty
+   unterminated final line are distinct typed errors. *)
 let split_physical input =
   let n = String.length input in
   let rec loop start i acc line_no =
     if i >= n then
-      let last = String.sub input start (i - start) in
-      Ok (List.rev ((last, line_no) :: acc))
+      if start = i then Ok (List.rev acc)
+      else Error (Missing_final_crlf { position = i })
     else
       match input.[i] with
       | '\r' ->
@@ -54,18 +70,15 @@ let split_physical input =
             ((String.sub input start (i - start), line_no) :: acc)
             (line_no + 1)
         else Error (Lone_carriage_return { position = i })
-      | '\n' ->
-        loop (i + 1) (i + 1)
-          ((String.sub input start (i - start), line_no) :: acc)
-          (line_no + 1)
+      | '\n' -> Error (Lone_line_feed { position = i })
       | _ -> loop start (i + 1) acc line_no
   in
-  loop 0 0 [] 1
+  if n = 0 then Ok [] else loop 0 0 [] 1
 
 (* §3.1 unfolding: a physical line beginning with SPACE/HTAB continues the
-   previous logical line (the leading whitespace is removed). Empty physical
-   lines carry no content and are skipped. Each returned logical line keeps
-   the physical line number it started on for error reporting. *)
+   previous logical line (the leading whitespace is removed). An empty
+   physical line is not a content line and is rejected. Each returned logical
+   line keeps the physical line number it started on for error reporting. *)
 let unfold_numbered input =
   match split_physical input with
   | Error _ as error -> error
@@ -76,7 +89,8 @@ let unfold_numbered input =
         | None -> Ok (List.rev acc)
         | Some pair -> Ok (List.rev (pair :: acc)))
       | (line, line_no) :: rest ->
-        if String.length line = 0 then join acc current rest
+        if String.length line = 0 then
+          Error (Empty_physical_line { line = line_no })
         else if line.[0] = ' ' || line.[0] = '\t' then (
           let fragment = String.sub line 1 (String.length line - 1) in
           match current with
@@ -126,19 +140,54 @@ let reject_control ~line text =
   in
   loop 0
 
-(* Index of the first occurrence of [target] outside a quoted-string.
-   QSAFE-CHAR excludes DQUOTE, so a quote always toggles quote state. *)
-let index_outside_quotes text target =
+(* Locate the property-value separator while validating the quoted-string
+   boundaries in the parameter head. A DQUOTE can open only as the first
+   byte of a parameter value (after [=] or [,]); after its closing DQUOTE,
+   only a value/parameter/property separator may follow. *)
+let value_separator ~line text =
   let n = String.length text in
-  let rec loop i in_quote =
-    if i >= n then None
+  let valid_after_quote i =
+    i + 1 >= n
+    ||
+    match text.[i + 1] with
+    | ',' | ';' | ':' -> true
+    | _ -> false
+  in
+  let rec loop i in_quote param_start first_equals quoted_param =
+    if i >= n then
+      if in_quote then
+        Error
+          (Unterminated_quoted_string
+             { line
+             ; param =
+                 (match quoted_param with Some name -> name | None -> "")
+             })
+      else Error (Missing_colon { line })
+    else if in_quote then
+      if text.[i] = '"' then
+        if valid_after_quote i then
+          loop (i + 1) false param_start first_equals None
+        else Error (Invalid_quoted_string { line; position = i })
+      else loop (i + 1) true param_start first_equals quoted_param
     else
       match text.[i] with
-      | '"' -> loop (i + 1) (not in_quote)
-      | c when c = target && not in_quote -> Some i
-      | _ -> loop (i + 1) in_quote
+      | ':' -> Ok i
+      | ';' -> loop (i + 1) false (i + 1) None None
+      | '=' ->
+        loop (i + 1) false param_start
+          (if param_start = 0 then None
+           else match first_equals with None -> Some i | some -> some)
+          None
+      | '"' ->
+        (match first_equals with
+         | Some eq
+           when i > 0 && (text.[i - 1] = '=' || text.[i - 1] = ',') ->
+          let param = String.sub text param_start (eq - param_start) in
+          loop (i + 1) true param_start first_equals (Some param)
+         | _ -> Error (Invalid_quoted_string { line; position = i }))
+      | _ -> loop (i + 1) false param_start first_equals None
   in
-  loop 0 false
+  loop 0 false 0 None None
 
 (* Split on [sep] outside quoted-strings, preserving empties. *)
 let split_outside_quotes text sep =
@@ -184,12 +233,15 @@ let parse_param ~line raw =
        | Ok values -> Ok { name = String.uppercase_ascii name; values })
 
 let parse ~line text =
-  match reject_control ~line text with
+  match String.is_valid_utf_8 text with
+  | false -> Error (Invalid_utf8 { line })
+  | true ->
+  (match reject_control ~line text with
   | Error _ as error -> error
   | Ok () -> (
-    match index_outside_quotes text ':' with
-    | None -> Error (Missing_colon { line })
-    | Some colon ->
+    match value_separator ~line text with
+    | Error _ as error -> error
+    | Ok colon ->
       let head = String.sub text 0 colon in
       let value = String.sub text (colon + 1) (String.length text - colon - 1) in
       let segments = split_outside_quotes head ';' in
@@ -210,7 +262,7 @@ let parse ~line text =
            (match params [] params_raw with
             | Error _ as error -> error
             | Ok params ->
-              Ok { name = String.uppercase_ascii name_raw; params; value })))
+              Ok { name = String.uppercase_ascii name_raw; params; value }))))
 
 let parse_many input =
   match unfold_numbered input with
@@ -225,6 +277,14 @@ let parse_many input =
     in
     loop [] lines
 
-let find_param ~name params =
+let find_unique_param ~name params =
   let upper = String.uppercase_ascii name in
-  List.find_opt (fun (p : param) -> String.equal p.name upper) params
+  let rec loop found = function
+    | [] -> Ok found
+    | (param : param) :: rest when String.equal param.name upper ->
+      (match found with
+       | None -> loop (Some param) rest
+       | Some _ -> Error (Duplicate_parameter upper))
+    | _ :: rest -> loop found rest
+  in
+  loop None params

--- a/lib/schedule/schedule_ical_content_line.mli
+++ b/lib/schedule/schedule_ical_content_line.mli
@@ -7,8 +7,8 @@
     ({!Schedule_ical_recur} and later leaves).
 
     Exactness stance, matching {!Schedule_ical_recur}:
-    - Line delimiters are CRLF; a bare LF is also accepted (documented
-      leniency for non-compliant producers), but a lone CR is a typed error.
+    - Line delimiters are exactly CRLF. Bare CR, bare LF, an unterminated final
+      line, and an empty physical line are distinct typed errors.
     - Folding is exactly §3.1: a CRLF followed by SPACE or HTAB is removed
       with the whitespace character. A continuation without a preceding line
       is a typed error.
@@ -36,8 +36,13 @@ type t = private
   ; value : string  (** Raw value text; property layers decode it. *)
   }
 
+type unique_param_error = Duplicate_parameter of string
+
 type parse_error =
   | Lone_carriage_return of { position : int }
+  | Lone_line_feed of { position : int }
+  | Missing_final_crlf of { position : int }
+  | Empty_physical_line of { line : int }
   | Orphan_continuation of { line : int }
       (** A folded continuation (leading SPACE/HTAB) with no preceding
           content line. *)
@@ -47,15 +52,16 @@ type parse_error =
   | Invalid_param_name_char of { line : int; name : string }
   | Missing_param_equals of { line : int; param : string }
   | Unterminated_quoted_string of { line : int; param : string }
+  | Invalid_quoted_string of { line : int; position : int }
+  | Invalid_utf8 of { line : int }
   | Control_character of { line : int; position : int; code : int }
 
 val parse_error_to_string : parse_error -> string
 
 val unfold : string -> (string list, parse_error) result
-(** Split an iCalendar stream into logical content lines: CRLF/LF delimited,
-    §3.1 folding rejoined. Empty physical lines carry no content and are
-    skipped (this is what makes a trailing newline at end of stream legal).
-    [line] numbers in errors are 1-based physical line numbers. *)
+(** Split a CRLF-terminated iCalendar stream into logical content lines and
+    rejoin §3.1 folding. Empty physical lines are rejected. [line] numbers in
+    errors are 1-based physical line numbers. *)
 
 val parse : line:int -> string -> (t, parse_error) result
 (** Parse one logical content line. [line] is the physical line number the
@@ -64,5 +70,7 @@ val parse : line:int -> string -> (t, parse_error) result
 val parse_many : string -> (t list, parse_error) result
 (** [unfold] then [parse] for every logical line, in order. *)
 
-val find_param : name:string -> param list -> param option
-(** Case-insensitive lookup helper for property layers. *)
+val find_unique_param :
+  name:string -> param list -> (param option, unique_param_error) result
+(** Case-insensitive lookup for property layers. A repeated name is an
+    explicit error rather than an arbitrary first-match selection. *)

--- a/lib/schedule/schedule_ical_content_line.mli
+++ b/lib/schedule/schedule_ical_content_line.mli
@@ -1,0 +1,68 @@
+(** Schedule_ical_content_line — RFC 5545 §3.1 content lines.
+
+    The lexical layer under every iCalendar property parser: unfolding and
+    the [name *( ";" param ) ":" value] split. Pure and total: any input
+    string yields a typed result, never an exception. Property-specific value
+    decoding (DATE-TIME, RECUR, ...) lives in the property layers above
+    ({!Schedule_ical_recur} and later leaves).
+
+    Exactness stance, matching {!Schedule_ical_recur}:
+    - Line delimiters are CRLF; a bare LF is also accepted (documented
+      leniency for non-compliant producers), but a lone CR is a typed error.
+    - Folding is exactly §3.1: a CRLF followed by SPACE or HTAB is removed
+      with the whitespace character. A continuation without a preceding line
+      is a typed error.
+    - Property and parameter names are case-insensitive and normalized to
+      uppercase; nothing else is normalized. Name characters must satisfy
+      [iana-token] / [x-name].
+    - [":"] and [";"] inside quoted parameter values do not split. An
+      unterminated quoted-string is a typed error.
+    - CONTROL characters (except HTAB) are rejected, not sanitized.
+
+    Records are [private]: external code can read and pattern-match but
+    cannot construct, so the uppercase-name invariant cannot be forged
+    outside {!parse}. *)
+
+type param = private
+  { name : string  (** Uppercase-normalized parameter name. *)
+  ; values : string list
+    (** COMMA-separated parameter values in wire order; surrounding DQUOTEs
+        are stripped from quoted-strings. *)
+  }
+
+type t = private
+  { name : string  (** Uppercase-normalized property name. *)
+  ; params : param list
+  ; value : string  (** Raw value text; property layers decode it. *)
+  }
+
+type parse_error =
+  | Lone_carriage_return of { position : int }
+  | Orphan_continuation of { line : int }
+      (** A folded continuation (leading SPACE/HTAB) with no preceding
+          content line. *)
+  | Empty_name of { line : int }
+  | Invalid_name_char of { line : int; name : string }
+  | Missing_colon of { line : int }
+  | Invalid_param_name_char of { line : int; name : string }
+  | Missing_param_equals of { line : int; param : string }
+  | Unterminated_quoted_string of { line : int; param : string }
+  | Control_character of { line : int; position : int; code : int }
+
+val parse_error_to_string : parse_error -> string
+
+val unfold : string -> (string list, parse_error) result
+(** Split an iCalendar stream into logical content lines: CRLF/LF delimited,
+    §3.1 folding rejoined. Empty physical lines carry no content and are
+    skipped (this is what makes a trailing newline at end of stream legal).
+    [line] numbers in errors are 1-based physical line numbers. *)
+
+val parse : line:int -> string -> (t, parse_error) result
+(** Parse one logical content line. [line] is the physical line number the
+    logical line started on, used only for error reporting. *)
+
+val parse_many : string -> (t list, parse_error) result
+(** [unfold] then [parse] for every logical line, in order. *)
+
+val find_param : name:string -> param list -> param option
+(** Case-insensitive lookup helper for property layers. *)

--- a/test/dune
+++ b/test/dune
@@ -1311,6 +1311,11 @@
  (libraries alcotest masc_schedule))
 
 (test
+ (name test_schedule_ical_content_line)
+ (modules test_schedule_ical_content_line)
+ (libraries alcotest masc_schedule))
+
+(test
  (name test_schedule_store)
  (modules test_schedule_store)
  (libraries

--- a/test/test_schedule_ical_content_line.ml
+++ b/test/test_schedule_ical_content_line.ml
@@ -165,6 +165,11 @@ let test_parse_rejects_unquoted_dquote () =
   | C.Invalid_quoted_string _ -> ()
   | e -> failf "wrong error: %s" (C.parse_error_to_string e)
 
+let test_parse_rejects_quote_after_nested_equals () =
+  match parse_error "PROP;P=a=\"b\":v" with
+  | C.Invalid_quoted_string _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
 let test_parse_control_character () =
   match parse_error "A:has\001control" with
   | C.Control_character _ -> ()
@@ -241,6 +246,8 @@ let () =
             test_parse_open_quote_hides_colon
         ; test_case "unquoted DQUOTE rejected" `Quick
             test_parse_rejects_unquoted_dquote
+        ; test_case "quote after nested equals rejected" `Quick
+            test_parse_rejects_quote_after_nested_equals
         ; test_case "control character" `Quick test_parse_control_character
         ; test_case "utf8 value allowed" `Quick test_parse_utf8_value_allowed
         ; test_case "invalid utf8 rejected" `Quick

--- a/test/test_schedule_ical_content_line.ml
+++ b/test/test_schedule_ical_content_line.ml
@@ -27,10 +27,10 @@ let test_unfold_crlf_basic () =
   | Ok other -> failf "wrong lines: %d" (List.length other)
   | Error e -> fail (C.parse_error_to_string e)
 
-let test_unfold_bare_lf_accepted () =
+let test_unfold_bare_lf_rejected () =
   match C.unfold "A:1\nB:2\n" with
-  | Ok [ "A:1"; "B:2" ] -> ()
-  | _ -> fail "bare LF lines must split"
+  | Error (C.Lone_line_feed { position = 3 }) -> ()
+  | _ -> fail "bare LF must be a typed error"
 
 let test_unfold_lone_cr_rejected () =
   match C.unfold "A:1\rB:2" with
@@ -46,19 +46,24 @@ let test_unfold_folding_rejoins () =
   | Error e -> fail (C.parse_error_to_string e)
 
 let test_unfold_folding_tab () =
-  match C.unfold "A:12\r\n\t34" with
+  match C.unfold "A:12\r\n\t34\r\n" with
   | Ok [ "A:1234" ] -> ()
   | _ -> fail "HTAB fold must rejoin"
 
 let test_unfold_orphan_continuation () =
-  match C.unfold " orphan" with
+  match C.unfold " orphan\r\n" with
   | Error (C.Orphan_continuation { line = 1 }) -> ()
   | _ -> fail "leading continuation must be rejected"
 
-let test_unfold_skips_empty_lines () =
+let test_unfold_rejects_empty_lines () =
   match C.unfold "A:1\r\n\r\nB:2\r\n" with
-  | Ok [ "A:1"; "B:2" ] -> ()
-  | _ -> fail "empty physical lines must be skipped"
+  | Error (C.Empty_physical_line { line = 2 }) -> ()
+  | _ -> fail "empty physical lines must be a typed error"
+
+let test_unfold_requires_final_crlf () =
+  match C.unfold "A:1" with
+  | Error (C.Missing_final_crlf { position = 3 }) -> ()
+  | _ -> fail "non-empty stream must end with CRLF"
 
 (* ---------------------------------------------------------------- *)
 (* Parse                                                            *)
@@ -110,10 +115,16 @@ let test_parse_semicolon_in_quoted_param () =
 let test_parse_multiple_params () =
   let cl = parse_ok "DTSTART;TZID=America/New_York;VALUE=DATE-TIME:19980119T020000" in
   check int "two params" 2 (List.length cl.C.params);
-  (match C.find_param ~name:"tzid" cl.C.params with
-   | Some { C.values = [ "America/New_York" ]; _ } -> ()
+  (match C.find_unique_param ~name:"tzid" cl.C.params with
+   | Ok (Some { C.values = [ "America/New_York" ]; _ }) -> ()
    | _ -> fail "TZID param lookup failed");
   check string "value" "19980119T020000" cl.C.value
+
+let test_unique_param_rejects_duplicate_name () =
+  let cl = parse_ok "DTSTART;TZID=A;TZID=B:19980119T020000" in
+  match C.find_unique_param ~name:"TZID" cl.C.params with
+  | Error (C.Duplicate_parameter "TZID") -> ()
+  | _ -> fail "duplicate parameter name was silently selected"
 
 let test_parse_value_may_contain_colon () =
   let cl = parse_ok "URL:http://example.com/path" in
@@ -140,16 +151,18 @@ let test_parse_param_missing_equals () =
   | e -> failf "wrong error: %s" (C.parse_error_to_string e)
 
 let test_parse_unterminated_quote () =
-  (* A quote that opens and never closes swallows the value separator, so
-     the accurate diagnosis is the missing colon. A closed quote followed by
-     junk is the unterminated/malformed quoted-string case. *)
   match parse_error "PROP;P=\"abc\"def:x" with
-  | C.Unterminated_quoted_string _ -> ()
+  | C.Invalid_quoted_string _ -> ()
   | e -> failf "wrong error: %s" (C.parse_error_to_string e)
 
 let test_parse_open_quote_hides_colon () =
   match parse_error "PROP;P=\"unterminated:x" with
-  | C.Missing_colon _ -> ()
+  | C.Unterminated_quoted_string { param = "P"; _ } -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_rejects_unquoted_dquote () =
+  match parse_error "PROP;P=ab\"cd:x" with
+  | C.Invalid_quoted_string _ -> ()
   | e -> failf "wrong error: %s" (C.parse_error_to_string e)
 
 let test_parse_control_character () =
@@ -160,6 +173,12 @@ let test_parse_control_character () =
 let test_parse_utf8_value_allowed () =
   let cl = parse_ok "SUMMARY:한국어 제목" in
   check string "utf8 kept" "한국어 제목" cl.C.value
+
+let test_parse_invalid_utf8_rejected () =
+  let invalid = "SUMMARY:" ^ String.make 1 (Char.chr 0xff) in
+  match parse_error invalid with
+  | C.Invalid_utf8 { line = 1 } -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
 
 (* ---------------------------------------------------------------- *)
 (* parse_many                                                       *)
@@ -187,13 +206,16 @@ let () =
   run "Schedule_ical_content_line"
     [ "unfold"
       , [ test_case "crlf basic" `Quick test_unfold_crlf_basic
-        ; test_case "bare lf accepted" `Quick test_unfold_bare_lf_accepted
+        ; test_case "bare lf rejected" `Quick test_unfold_bare_lf_rejected
         ; test_case "lone cr rejected" `Quick test_unfold_lone_cr_rejected
         ; test_case "folding rejoins" `Quick test_unfold_folding_rejoins
         ; test_case "folding tab" `Quick test_unfold_folding_tab
         ; test_case "orphan continuation" `Quick
             test_unfold_orphan_continuation
-        ; test_case "empty lines skipped" `Quick test_unfold_skips_empty_lines
+        ; test_case "empty lines rejected" `Quick
+            test_unfold_rejects_empty_lines
+        ; test_case "final CRLF required" `Quick
+            test_unfold_requires_final_crlf
         ]
     ; "parse"
       , [ test_case "simple" `Quick test_parse_simple
@@ -205,6 +227,8 @@ let () =
         ; test_case "semicolon in quoted param" `Quick
             test_parse_semicolon_in_quoted_param
         ; test_case "multiple params" `Quick test_parse_multiple_params
+        ; test_case "duplicate param lookup rejected" `Quick
+            test_unique_param_rejects_duplicate_name
         ; test_case "value may contain colon" `Quick
             test_parse_value_may_contain_colon
         ; test_case "missing colon" `Quick test_parse_missing_colon
@@ -215,8 +239,12 @@ let () =
         ; test_case "unterminated quote" `Quick test_parse_unterminated_quote
         ; test_case "open quote hides colon" `Quick
             test_parse_open_quote_hides_colon
+        ; test_case "unquoted DQUOTE rejected" `Quick
+            test_parse_rejects_unquoted_dquote
         ; test_case "control character" `Quick test_parse_control_character
         ; test_case "utf8 value allowed" `Quick test_parse_utf8_value_allowed
+        ; test_case "invalid utf8 rejected" `Quick
+            test_parse_invalid_utf8_rejected
         ]
     ; "parse_many"
       , [ test_case "tracks physical lines" `Quick

--- a/test/test_schedule_ical_content_line.ml
+++ b/test/test_schedule_ical_content_line.ml
@@ -150,6 +150,24 @@ let test_parse_param_missing_equals () =
   | C.Missing_param_equals _ -> ()
   | e -> failf "wrong error: %s" (C.parse_error_to_string e)
 
+let test_parse_accepts_empty_unquoted_param_value () =
+  let cl = parse_ok "PROP;P=:v" in
+  match cl.C.params with
+  | [ { C.values = [ "" ]; _ } ] -> ()
+  | _ -> fail "empty paramtext value was not preserved"
+
+let test_parse_accepts_empty_multi_param_value () =
+  let cl = parse_ok "PROP;P=a,,b:v" in
+  match cl.C.params with
+  | [ { C.values = [ "a"; ""; "b" ]; _ } ] -> ()
+  | _ -> fail "empty paramtext list member was not preserved"
+
+let test_parse_accepts_empty_quoted_param_value () =
+  let cl = parse_ok "PROP;P=\"\":v" in
+  match cl.C.params with
+  | [ { C.values = [ "" ]; _ } ] -> ()
+  | _ -> fail "empty quoted-string value was not preserved"
+
 let test_parse_unterminated_quote () =
   match parse_error "PROP;P=\"abc\"def:x" with
   | C.Invalid_quoted_string _ -> ()
@@ -241,6 +259,12 @@ let () =
         ; test_case "invalid name char" `Quick test_parse_invalid_name_char
         ; test_case "param missing equals" `Quick
             test_parse_param_missing_equals
+        ; test_case "empty unquoted param accepted" `Quick
+            test_parse_accepts_empty_unquoted_param_value
+        ; test_case "empty multi param accepted" `Quick
+            test_parse_accepts_empty_multi_param_value
+        ; test_case "empty quoted param accepted" `Quick
+            test_parse_accepts_empty_quoted_param_value
         ; test_case "unterminated quote" `Quick test_parse_unterminated_quote
         ; test_case "open quote hides colon" `Quick
             test_parse_open_quote_hides_colon

--- a/test/test_schedule_ical_content_line.ml
+++ b/test/test_schedule_ical_content_line.ml
@@ -1,0 +1,227 @@
+(* RFC 5545 §3.1 content-line tests for Schedule_ical_content_line.
+
+   Covers physical splitting (CRLF / bare LF / lone CR), folding, the
+   name/param/value split with quoted-string protection, and the typed
+   rejection of every malformed shape. *)
+
+open Alcotest
+module C = Schedule_ical_content_line
+
+let parse_ok line =
+  match C.parse ~line:1 line with
+  | Ok cl -> cl
+  | Error e -> failf "parse %S rejected: %s" line (C.parse_error_to_string e)
+
+let parse_error line =
+  match C.parse ~line:1 line with
+  | Ok _ -> failf "parse %S unexpectedly accepted" line
+  | Error e -> e
+
+(* ---------------------------------------------------------------- *)
+(* Unfold                                                           *)
+(* ---------------------------------------------------------------- *)
+
+let test_unfold_crlf_basic () =
+  match C.unfold "A:1\r\nB:2\r\n" with
+  | Ok [ "A:1"; "B:2" ] -> ()
+  | Ok other -> failf "wrong lines: %d" (List.length other)
+  | Error e -> fail (C.parse_error_to_string e)
+
+let test_unfold_bare_lf_accepted () =
+  match C.unfold "A:1\nB:2\n" with
+  | Ok [ "A:1"; "B:2" ] -> ()
+  | _ -> fail "bare LF lines must split"
+
+let test_unfold_lone_cr_rejected () =
+  match C.unfold "A:1\rB:2" with
+  | Error (C.Lone_carriage_return _) -> ()
+  | _ -> fail "lone CR must be a typed error"
+
+let test_unfold_folding_rejoins () =
+  (* CRLF followed by SPACE or HTAB is removed with the whitespace. *)
+  match C.unfold "DESCRIPTION:This is a lo\r\n ng description\r\n" with
+  | Ok [ "DESCRIPTION:This is a long description" ] -> ()
+  | Ok other ->
+    failf "fold produced %d lines" (List.length other)
+  | Error e -> fail (C.parse_error_to_string e)
+
+let test_unfold_folding_tab () =
+  match C.unfold "A:12\r\n\t34" with
+  | Ok [ "A:1234" ] -> ()
+  | _ -> fail "HTAB fold must rejoin"
+
+let test_unfold_orphan_continuation () =
+  match C.unfold " orphan" with
+  | Error (C.Orphan_continuation { line = 1 }) -> ()
+  | _ -> fail "leading continuation must be rejected"
+
+let test_unfold_skips_empty_lines () =
+  match C.unfold "A:1\r\n\r\nB:2\r\n" with
+  | Ok [ "A:1"; "B:2" ] -> ()
+  | _ -> fail "empty physical lines must be skipped"
+
+(* ---------------------------------------------------------------- *)
+(* Parse                                                            *)
+(* ---------------------------------------------------------------- *)
+
+let test_parse_simple () =
+  let cl = parse_ok "UID:12345@example.com" in
+  check string "name" "UID" cl.C.name;
+  check string "value" "12345@example.com" cl.C.value;
+  check int "no params" 0 (List.length cl.C.params)
+
+let test_parse_name_uppercased () =
+  let cl = parse_ok "dtstart:19980118T230000" in
+  check string "name" "DTSTART" cl.C.name
+
+let test_parse_params () =
+  let cl = parse_ok "RDATE;VALUE=DATE:19970304,19970504" in
+  check string "name" "RDATE" cl.C.name;
+  (match cl.C.params with
+   | [ { C.name; values } ] ->
+     check string "param name" "VALUE" name;
+     check bool "values" true (values = [ "DATE" ])
+   | _ -> fail "expected one param");
+  check string "value" "19970304,19970504" cl.C.value
+
+let test_parse_multi_value_param () =
+  let cl = parse_ok "ATTENDEE;MEMBER=a,b,c:x" in
+  match cl.C.params with
+  | [ { C.values; _ } ] ->
+    check bool "three values" true (values = [ "a"; "b"; "c" ])
+  | _ -> fail "expected one param"
+
+let test_parse_quoted_param_protects_separators () =
+  (* [;] [:] [,] inside a quoted param value must not split. *)
+  let cl = parse_ok "DESCRIPTION;ALTREP=\"cid:part1,0001@example.org\":Fall" in
+  (match cl.C.params with
+   | [ { C.name; values } ] ->
+     check string "param name" "ALTREP" name;
+     check bool "quoted value" true (values = [ "cid:part1,0001@example.org" ])
+   | _ -> fail "expected one param");
+  check string "value" "Fall" cl.C.value
+
+let test_parse_semicolon_in_quoted_param () =
+  let cl = parse_ok "X-PROP;X-P=\"a;b\":v" in
+  match cl.C.params with
+  | [ { C.values; _ } ] -> check bool "semicolon kept" true (values = [ "a;b" ])
+  | _ -> fail "expected one param"
+
+let test_parse_multiple_params () =
+  let cl = parse_ok "DTSTART;TZID=America/New_York;VALUE=DATE-TIME:19980119T020000" in
+  check int "two params" 2 (List.length cl.C.params);
+  (match C.find_param ~name:"tzid" cl.C.params with
+   | Some { C.values = [ "America/New_York" ]; _ } -> ()
+   | _ -> fail "TZID param lookup failed");
+  check string "value" "19980119T020000" cl.C.value
+
+let test_parse_value_may_contain_colon () =
+  let cl = parse_ok "URL:http://example.com/path" in
+  check string "value" "http://example.com/path" cl.C.value
+
+let test_parse_missing_colon () =
+  match parse_error "NO-COLON-HERE" with
+  | C.Missing_colon { line = 1 } -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_empty_name () =
+  match parse_error ":value" with
+  | C.Empty_name _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_invalid_name_char () =
+  match parse_error "BAD NAME:x" with
+  | C.Invalid_name_char _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_param_missing_equals () =
+  match parse_error "PROP;PARAM:x" with
+  | C.Missing_param_equals _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_unterminated_quote () =
+  (* A quote that opens and never closes swallows the value separator, so
+     the accurate diagnosis is the missing colon. A closed quote followed by
+     junk is the unterminated/malformed quoted-string case. *)
+  match parse_error "PROP;P=\"abc\"def:x" with
+  | C.Unterminated_quoted_string _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_open_quote_hides_colon () =
+  match parse_error "PROP;P=\"unterminated:x" with
+  | C.Missing_colon _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_control_character () =
+  match parse_error "A:has\001control" with
+  | C.Control_character _ -> ()
+  | e -> failf "wrong error: %s" (C.parse_error_to_string e)
+
+let test_parse_utf8_value_allowed () =
+  let cl = parse_ok "SUMMARY:한국어 제목" in
+  check string "utf8 kept" "한국어 제목" cl.C.value
+
+(* ---------------------------------------------------------------- *)
+(* parse_many                                                       *)
+(* ---------------------------------------------------------------- *)
+
+let test_parse_many_tracks_physical_lines () =
+  let input = "A:1\r\n fold\r\nB:x\r\n" in
+  match C.parse_many input with
+  | Ok [ a; b ] ->
+    check string "a" "A" a.C.name;
+    (* §3.1: the CRLF and the continuation's leading whitespace are both
+       removed, so "1" + "fold" joins with no space. *)
+    check string "a folded" "1fold" a.C.value;
+    check string "b" "B" b.C.name
+  | Ok other -> failf "expected 2 lines, got %d" (List.length other)
+  | Error e -> fail (C.parse_error_to_string e)
+
+let test_parse_many_error_line_number () =
+  match C.parse_many "A:1\r\nB:2\r\nNOPE\r\n" with
+  | Error (C.Missing_colon { line = 3 }) -> ()
+  | Error e -> failf "wrong error: %s" (C.parse_error_to_string e)
+  | Ok _ -> fail "must reject"
+
+let () =
+  run "Schedule_ical_content_line"
+    [ "unfold"
+      , [ test_case "crlf basic" `Quick test_unfold_crlf_basic
+        ; test_case "bare lf accepted" `Quick test_unfold_bare_lf_accepted
+        ; test_case "lone cr rejected" `Quick test_unfold_lone_cr_rejected
+        ; test_case "folding rejoins" `Quick test_unfold_folding_rejoins
+        ; test_case "folding tab" `Quick test_unfold_folding_tab
+        ; test_case "orphan continuation" `Quick
+            test_unfold_orphan_continuation
+        ; test_case "empty lines skipped" `Quick test_unfold_skips_empty_lines
+        ]
+    ; "parse"
+      , [ test_case "simple" `Quick test_parse_simple
+        ; test_case "name uppercased" `Quick test_parse_name_uppercased
+        ; test_case "params" `Quick test_parse_params
+        ; test_case "multi value param" `Quick test_parse_multi_value_param
+        ; test_case "quoted param protects separators" `Quick
+            test_parse_quoted_param_protects_separators
+        ; test_case "semicolon in quoted param" `Quick
+            test_parse_semicolon_in_quoted_param
+        ; test_case "multiple params" `Quick test_parse_multiple_params
+        ; test_case "value may contain colon" `Quick
+            test_parse_value_may_contain_colon
+        ; test_case "missing colon" `Quick test_parse_missing_colon
+        ; test_case "empty name" `Quick test_parse_empty_name
+        ; test_case "invalid name char" `Quick test_parse_invalid_name_char
+        ; test_case "param missing equals" `Quick
+            test_parse_param_missing_equals
+        ; test_case "unterminated quote" `Quick test_parse_unterminated_quote
+        ; test_case "open quote hides colon" `Quick
+            test_parse_open_quote_hides_colon
+        ; test_case "control character" `Quick test_parse_control_character
+        ; test_case "utf8 value allowed" `Quick test_parse_utf8_value_allowed
+        ]
+    ; "parse_many"
+      , [ test_case "tracks physical lines" `Quick
+            test_parse_many_tracks_physical_lines
+        ; test_case "error line number" `Quick
+            test_parse_many_error_line_number
+        ]
+    ]


### PR DESCRIPTION
## 무엇을 바꾸나

issue #24553 iCalendar adapter leaf 2입니다. `Schedule_ical_content_line`은 RFC 5545 §3.1 content line의 순수·total lexical parser입니다. 선행 RECUR leaf #25264와 OAS pin leaf #25362가 main에 도달한 뒤 최신 main 위의 독립 leaf로 재적층했습니다.

## exact grammar

- physical line delimiter는 CRLF만 허용; lone CR, bare LF, non-terminated final line, empty physical line을 각각 typed error로 거부
- folding은 정확히 `CRLF + SPACE/HTAB` 한 글자를 제거하며 orphan continuation을 거부하고, fragment list를 한 번만 결합해 folded input을 선형 시간에 처리
- parameter quoted-string은 parameter value 시작(첫 assignment `=` 또는 `,` 직후)에서만 열 수 있고 closing quote 뒤에는 `, ; :` 또는 end만 허용
- RFC 5545의 `paramtext = *SAFE-CHAR`에 따라 empty unquoted/quoted parameter value를 그대로 보존
- unquoted DQUOTE, unterminated quote, control character, invalid UTF-8를 typed error로 거부
- property/parameter name만 RFC에 따라 uppercase canonicalization; raw value와 parameter value identity는 보존
- repeated parameter를 first-match로 고르지 않고 `find_unique_param`이 `Duplicate_parameter`를 반환
- parsed records는 private

## 범위 경계

이 leaf는 content-line syntax만 소유합니다. DTSTART/RECURRENCE-ID/RRULE의 property semantics는 후속 VEVENT leaf #25311이 담당합니다. scheduler policy, recurrence expansion, timezone resolution은 포함하지 않습니다.

## 검증

- base: MASC main `5222f92e19573c21d79800fb496a09dfd377253e`
- exact head: `27027e3afca0e4c5032cc8c4b5aca43072723277`
- focused content-line test 33/33 PASS
- touched OCaml files `ocamlformat --check`, parser checks, `git diff --check` PASS
- repository-wide `@fmt`는 이 PR이 건드리지 않은 기존 dune 파일 drift로 실패하며 exact-head PR CI에서 분리 확인 중

## 관련

- merged predecessor: #25264, #25362
- stacked successor: #25311
- issue #24553
- RFC 5545 §3.1
