### PR TITLE
fix(board): observe SSE hook failures

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -869,9 +869,29 @@ let board_sse_hook : (board_sse_event -> unit) option Atomic.t = Atomic.make Non
 let set_board_sse_hook hook =
   Atomic.set board_sse_hook (Some hook)
 
+let board_sse_event_log_context = function
+  | Post_created { post_id; _ } -> "post_created", post_id
+  | Comment_added { comment_id; _ } -> "comment_added", comment_id
+  | Post_voted { post_id; _ } -> "post_voted", post_id
+  | Comment_voted { comment_id; _ } -> "comment_voted", comment_id
+  | Reaction_changed { target_id; _ } -> "reaction_changed", target_id
+;;
+
 let emit_board_sse_event event =
   match Atomic.get board_sse_hook with
-  | Some hook -> Safe_ops.protect ~default:() (fun () -> hook event)
+  | Some hook ->
+    (try hook event with
+     | (Eio.Cancel.Cancelled _ | Out_of_memory | Stack_overflow) as cause ->
+       Printexc.raise_with_backtrace cause (Printexc.get_raw_backtrace ())
+     | cause ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       let event_kind, subject_id = board_sse_event_log_context event in
+       Log.BoardLog.error
+         "Board SSE hook failed event_kind=%s subject_id=%s: %s\n%s"
+         event_kind
+         subject_id
+         (Printexc.to_string cause)
+         (Printexc.raw_backtrace_to_string backtrace))
   | None -> ()
 
 let is_initialized () =

--- a/test/test_board_flusher_autonomous_retry.ml
+++ b/test/test_board_flusher_autonomous_retry.ml
@@ -196,6 +196,28 @@ let test_routing_recovery_resumes_on_replacement_owner () =
     Eio.Time.with_timeout_exn clock 1.0 (fun () -> Eio.Promise.await delivered))
 ;;
 
+let test_sse_hook_failure_boundary () =
+  let event =
+    Board_dispatch.Post_voted
+      { post_id = "sse-failure-boundary-post"
+      ; voter = "sse-failure-boundary-voter"
+      ; direction = Board.Up
+      }
+  in
+  Board_dispatch.set_board_sse_hook (fun _ ->
+    raise (Failure "forced observable SSE hook failure"));
+  Board_dispatch.emit_board_sse_event event;
+  Board_dispatch.set_board_sse_hook (fun _ -> raise Out_of_memory);
+  (match Board_dispatch.emit_board_sse_event event with
+   | exception Out_of_memory -> ()
+   | exception cause ->
+     Alcotest.failf
+       "expected Out_of_memory propagation, got %s"
+       (Printexc.to_string cause)
+   | () -> Alcotest.fail "Out_of_memory must not be suppressed as an SSE failure");
+  Board_dispatch.set_board_sse_hook (fun _ -> ())
+;;
+
 let () =
   Alcotest.run
     "board_flusher_autonomous_retry"
@@ -214,6 +236,12 @@ let () =
             "routing recovery resumes on replacement owner"
             `Quick
             test_routing_recovery_resumes_on_replacement_owner
+        ] )
+    ; ( "sse"
+      , [ Alcotest.test_case
+            "hook failure boundary"
+            `Quick
+            test_sse_hook_failure_boundary
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- delete the `Safe_ops.protect ~default:()` boundary that silently discarded Board SSE hook exceptions
- log the typed Board event kind, exact subject id, exception, and raw backtrace without rolling back the already-committed Board mutation
- propagate Eio cancellation, `Out_of_memory`, and `Stack_overflow` with their original backtraces
- keep the optional no-hook state as a valid no-subscriber state

## Regression evidence
- a regular hook exception remains isolated from the Board mutation/fanout caller and is emitted as an ERROR record
- `Out_of_memory` is no longer converted into synthetic success
- captured test output contains `Board SSE hook failed event_kind=post_voted subject_id=sse-failure-boundary-post`

## Validation
- `scripts/dune-local.sh build test/test_board_flusher_autonomous_retry.exe`
- `MASC_BOARD_FLUSH_INTERVAL_SEC=0.01 ./_build/default/test/test_board_flusher_autonomous_retry.exe` — 4/4 pass in 0.038s
- `ocamlc -stop-after parsing -c` on touched files
- `ocamlformat -i` and `git diff --check`