### PR TITLE
fix(tool-schema): align limit guidance with strict integer schema

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -56,15 +56,18 @@ let base_tools : Masc_domain.tool_schema list =
                 ; ( "limit"
                   , `Assoc
                       [ (* #18472 widening removed: a multi-type schema trips
-                           OAS #2343 fail-closed and crashes the keeper cycle.
-                           Runtime reads via [Safe_ops.json_int]/[json_float]
-                           which coerce string->int, so strict integer is safe. *)
+                           OAS #2343 fail-closed and crashes the keeper cycle, so
+                           [limit] stays a single scalar "integer". Wire contract:
+                           Tool_input_validation rejects a string [limit] against
+                           this integer schema (OAS 0.212 strict typing) in
+                           keeper_tools_oas_handler, before Safe_ops.json_int would
+                           coerce it, so the description must ask for a bare integer,
+                           not a numeric string (codex #25274 P2). *)
                         ( "type", `String "integer" )
                       ; ( "description"
                         , `String
-                            "max results (1-10, default 5). Numeric strings \
-                             (e.g. \"5\") are accepted; prefer the bare \
-                             integer form." )
+                            "max results (1-10, default 5). Must be a bare \
+                             integer (e.g. 5); a quoted value is rejected." )
                       ] )
                 ; (* Issue #8484: derive from local mirror that tracks
            [Keeper_tool_memory_runtime.valid_memory_search_source_strings]. *)

--- a/lib/tool_surface/tool_shard_types_schemas_board.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_board.ml
@@ -133,17 +133,20 @@ let board_tools : Masc_domain.tool_schema list =
                 ; ( "limit"
                   , `Assoc
                       [ (* #18472 widening removed: a multi-type schema trips
-                           OAS #2343 fail-closed and crashes the keeper cycle.
-                           Runtime coerces string->int, so strict integer is safe. *)
+                           OAS #2343 fail-closed and crashes the keeper cycle, so
+                           [limit] stays a single scalar "integer". Tool_input_validation
+                           rejects a string [limit] against this integer schema, so the
+                           description must ask for a bare integer, not a numeric string
+                           (codex #25274 P2). *)
                         ( "type", `String "integer" )
                       ; "default", `Int 20
                       ; "minimum", `Int 1
                       ; "maximum", `Int 50
                       ; ( "description"
                         , `String
-                            "Max posts to return (default: 20, max: 50). \
-                             Numeric strings are accepted; prefer the bare \
-                             integer form." )
+                            "Max posts to return (default: 20, max: 50). Must \
+                             be a bare integer (e.g. 20); a quoted value is \
+                             rejected." )
                       ] )
                 ; (* Issue #8513: derive from local mirror tracking
            [Board_dispatch.valid_sort_order_strings].  Schema used to
@@ -281,16 +284,19 @@ let board_tools : Masc_domain.tool_schema list =
                 ; ( "limit"
                   , `Assoc
                       [ (* #18472 widening removed: a multi-type schema trips
-                           OAS #2343 fail-closed and crashes the keeper cycle.
-                           Runtime coerces string->int, so strict integer is safe. *)
+                           OAS #2343 fail-closed and crashes the keeper cycle, so
+                           [limit] stays a single scalar "integer". Tool_input_validation
+                           rejects a string [limit] against this integer schema, so the
+                           description must ask for a bare integer, not a numeric string
+                           (codex #25274 P2). *)
                         ( "type", `String "integer" )
                       ; "default", `Int 20
                       ; "minimum", `Int 1
                       ; "maximum", `Int 100
                       ; ( "description"
                         , `String
-                            "Max results (default: 20, max: 100). Numeric \
-                             strings are accepted; prefer the bare integer form." )
+                            "Max results (default: 20, max: 100). Must be a \
+                             bare integer (e.g. 20); a quoted value is rejected." )
                       ] )
                 ; (* Mirror masc_board_search: the search backend
                      (board_tool_handlers.ml handle_search) already reads

--- a/test/test_limit_schema_widen.ml
+++ b/test/test_limit_schema_widen.ml
@@ -38,6 +38,57 @@ let limit_type schema =
      | _ -> Alcotest.failf "%s: properties not an Assoc" schema.name)
   | _ -> Alcotest.failf "%s: input_schema not an Assoc" schema.name
 
+let limit_description schema =
+  match schema.Masc_domain.input_schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc props) ->
+       (match List.assoc_opt "limit" props with
+        | Some (`Assoc limit_fields) ->
+          (match List.assoc_opt "description" limit_fields with
+           | Some (`String d) -> d
+           | Some _ | None ->
+             Alcotest.failf "%s: limit field missing string 'description'" schema.name)
+        | _ -> Alcotest.failf "%s: limit field missing in properties" schema.name)
+     | _ -> Alcotest.failf "%s: properties not an Assoc" schema.name)
+  | _ -> Alcotest.failf "%s: input_schema not an Assoc" schema.name
+
+let contains ~substr s =
+  let n = String.length s and m = String.length substr in
+  if m = 0 then true
+  else if m > n then false
+  else begin
+    let rec go i =
+      if i + m > n then false
+      else if String.equal (String.sub s i m) substr then true
+      else go (i + 1)
+    in
+    go 0
+  end
+
+(* #25274 P2 (codex): under a strict integer [limit] schema,
+   Tool_input_validation rejects a numeric-string [limit] before dispatch,
+   so a description that tells keepers numeric strings are accepted steers
+   them straight into the #18472 crash class. Pin the prose: it must ask
+   for a bare integer and must not claim strings are accepted. *)
+let check_limit_description name desc =
+  let d = String.lowercase_ascii desc in
+  check bool
+    (Printf.sprintf "%s: limit description mentions integer" name)
+    true
+    (contains ~substr:"integer" d);
+  check bool
+    (Printf.sprintf "%s: limit description does not mention numeric string" name)
+    false
+    (contains ~substr:"numeric string" d);
+  check bool
+    (Printf.sprintf "%s: limit description does not claim strings accepted" name)
+    false
+    (contains ~substr:"accepted" d)
+
+let desc_case tools name () =
+  check_limit_description name (limit_description (find_tool_schema tools name))
+
 (* A [type] array with more than one non-null member is exactly what OAS
    #2343 fail-closed rejects. Assert every [limit] is a single scalar. *)
 let check_single_type name type_value =
@@ -84,5 +135,19 @@ let () =
             "keeper_board_search"
             `Quick
             (case Tool_shard_types.board_tools "keeper_board_search")
+        ] )
+    ; ( "limit description asks for a bare integer, not a numeric string"
+      , [ test_case
+            "keeper_memory_search"
+            `Quick
+            (desc_case Tool_shard_types.base_tools "keeper_memory_search")
+        ; test_case
+            "keeper_board_list"
+            `Quick
+            (desc_case Tool_shard_types.board_tools "keeper_board_list")
+        ; test_case
+            "keeper_board_search"
+            `Quick
+            (desc_case Tool_shard_types.board_tools "keeper_board_search")
         ] )
     ]


### PR DESCRIPTION
## 증상
`limit` 스키마는 #25274에서 strict `integer`로 되돌렸으나(#18472 revert),
`keeper_memory_search`·`keeper_board_list`·`keeper_board_search` 설명은 여전히
"숫자 문자열(예: `"5"`)도 허용"이라 안내합니다.

## 근본 원인
dispatch 전 `keeper_tools_oas_handler.ml:102`의 `Tool_input_validation.validate_args`가
integer 스키마에 대해 문자열을 거부합니다(OAS 0.212 strict typing;
`test_tool_input_validation.ml:1261-1279`이 strict Reject를 증명). 따라서
`Safe_ops.json_int`의 string→int coercion에 도달하기 전에 문자열이 검증에서
죽습니다. 안내를 따른 keeper는 #25274가 되돌리려던 #18472 검증 실패/크래시
계열을 그대로 유발합니다.

## 수정
세 설명(복붙된 3개 사이트 전부 — N-of-M 부분수정 회피)을 bare integer
(`{"limit": 5}`) 요구로 정렬하고 실제 동작("따옴표 값은 거부됨")을 명시했습니다.
인접 주석의 오해 소지 문구("런타임이 coerce하므로 strict integer가 안전")도 실제
검증 동작(coercion 전에 거부)으로 교정했습니다. 스키마는 strict integer를 그대로
유지했습니다(느슨하게 하지 않음).

## 테스트
`test_limit_schema_widen`에 설명 문구 pin 3건 추가(integer 언급 / "numeric string"·
"accepted" 부재 단언). 로컬 빌드 exit 0, 8 tests OK(기존 5 + 신규 3).

Closes #25274 (미해소 codex P2).

RFC-WAIVED: `lib/tool_surface/*`, `test/*`만 변경 — RFC-gated subsystem 비해당.
