### PR TITLE
test(tla): restore MemoryCompaction bug model (collateral deletion in #24332)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-19T04:26:55Z (HEAD: 5af1df4ab0)
+Generated: 2026-07-19T14:32:22Z (HEAD: bda1e52a2d)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -62,7 +62,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | FileLockStarvation.tla | FileLockStarvation | manual | 2 | 1 | clean={inv:TypeOK, inv:FlockMutex, inv:SingleMutexPerPath} buggy={inv:TypeOK, inv:FlockMutex, inv:SingleMutexPerPath} | 60a4f68df073 |
 | KeeperTurnSingleFlight.tla | KeeperTurnSingleFlight | manual | 2 | 1 | clean={inv:TypeOK, inv:SingleFlight} buggy={inv:TypeOK, inv:SingleFlight} | 3729df26b85a |
 | KeeperWorktreeContainment.tla | KeeperWorktreeContainment | manual | 3 | 2 | clean={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} other-playground-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} server-root-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} | fc57677b6dc2 |
-| MemoryCompaction.tla | MemoryCompaction | manual | 2 | 1 | clean={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} buggy={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} | d2a73301faa2 |
+| MemoryCompaction.tla | MemoryCompaction | manual | 2 | 1 | clean={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected ResultNotUnderfilled} buggy={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected ResultNotUnderfilled} | d4600c147a3e |
 | OllamaBodyIntegrity.tla | OllamaBodyIntegrity | manual | 2 | 1 | clean={inv:BalancedNeverFails, inv:ParseErrorImpliesUnbalanced} buggy={inv:BalancedNeverFails} | 4b99edc99fe1 |
 | SSEBroadcastBlock.tla | SSEBroadcastBlock | manual | 2 | 1 | clean={inv:TypeOK, inv:NoPermanentBlock} buggy={inv:TypeOK, inv:NoPermanentBlock} | baa8b016ef40 |
 | SlotScheduler.tla | SlotScheduler | manual | 2 | 1 | clean={inv:TypeOK, inv:MutualExclusion, inv:NeverStuck} buggy={inv:TypeOK, inv:NeverStuck} | 5d3029adffa6 |

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-18T06:06:32Z (HEAD: 9a49a1d1a2)
+Generated: 2026-07-19T04:26:55Z (HEAD: 5af1df4ab0)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 41 |
-| Manual specs | 41 |
+| Total .tla files | 42 |
+| Manual specs | 42 |
 | TTrace (auto-generated) | 0 |
 | Directories | 12 |
-| Total .cfg files | 85 |
-| Buggy .cfg (bug-model pair) | 44 |
+| Total .cfg files | 87 |
+| Buggy .cfg (bug-model pair) | 45 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -49,7 +49,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | SandboxDispatch.tla | SandboxDispatch | manual | 2 | 1 | clean={inv:TypeOK, inv:DockerImpliesDockerVia} buggy={inv:DockerImpliesDockerVia} | 812039212d1b |
 | TurnEvidenceChain.tla | TurnEvidenceChain | manual | 2 | 1 | clean={inv:TypeOK, inv:TerminalHasFullEvidence, inv:TerminalVisibleInRuntimeLens, inv:OasBoundaryGeneric} buggy={inv:TerminalHasFullEvidence} | 1c05d24d93ea |
 
-### specs/bug-models (12 specs)
+### specs/bug-models (13 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
@@ -62,6 +62,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | FileLockStarvation.tla | FileLockStarvation | manual | 2 | 1 | clean={inv:TypeOK, inv:FlockMutex, inv:SingleMutexPerPath} buggy={inv:TypeOK, inv:FlockMutex, inv:SingleMutexPerPath} | 60a4f68df073 |
 | KeeperTurnSingleFlight.tla | KeeperTurnSingleFlight | manual | 2 | 1 | clean={inv:TypeOK, inv:SingleFlight} buggy={inv:TypeOK, inv:SingleFlight} | 3729df26b85a |
 | KeeperWorktreeContainment.tla | KeeperWorktreeContainment | manual | 3 | 2 | clean={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} other-playground-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} server-root-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} | fc57677b6dc2 |
+| MemoryCompaction.tla | MemoryCompaction | manual | 2 | 1 | clean={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} buggy={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} | d2a73301faa2 |
 | OllamaBodyIntegrity.tla | OllamaBodyIntegrity | manual | 2 | 1 | clean={inv:BalancedNeverFails, inv:ParseErrorImpliesUnbalanced} buggy={inv:BalancedNeverFails} | 4b99edc99fe1 |
 | SSEBroadcastBlock.tla | SSEBroadcastBlock | manual | 2 | 1 | clean={inv:TypeOK, inv:NoPermanentBlock} buggy={inv:TypeOK, inv:NoPermanentBlock} | baa8b016ef40 |
 | SlotScheduler.tla | SlotScheduler | manual | 2 | 1 | clean={inv:TypeOK, inv:MutualExclusion, inv:NeverStuck} buggy={inv:TypeOK, inv:NeverStuck} | 5d3029adffa6 |

--- a/specs/bug-models/MemoryCompaction-buggy.cfg
+++ b/specs/bug-models/MemoryCompaction-buggy.cfg
@@ -1,0 +1,9 @@
+\* Buggy model: priority-only compaction ignores kind caps.
+\* Expected: GoalsPreserved VIOLATED (long_term fills all slots).
+SPECIFICATION SpecBuggy
+INVARIANT GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected
+CONSTANTS
+    TargetNotes = 8
+    SmallKindCap = 2
+    LongTermCap = 3
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/MemoryCompaction-buggy.cfg
+++ b/specs/bug-models/MemoryCompaction-buggy.cfg
@@ -1,7 +1,7 @@
 \* Buggy model: priority-only compaction ignores kind caps.
 \* Expected: GoalsPreserved VIOLATED (long_term fills all slots).
 SPECIFICATION SpecBuggy
-INVARIANT GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected
+INVARIANT GoalsPreserved NeverEmpty ResultBounded LongTermProtected ResultNotUnderfilled
 CONSTANTS
     TargetNotes = 8
     SmallKindCap = 2

--- a/specs/bug-models/MemoryCompaction.cfg
+++ b/specs/bug-models/MemoryCompaction.cfg
@@ -1,7 +1,7 @@
 \* Clean model: compaction respects per-kind caps.
 \* Expected: no error (all five invariants hold).
 SPECIFICATION Spec
-INVARIANT GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected
+INVARIANT GoalsPreserved NeverEmpty ResultBounded LongTermProtected ResultNotUnderfilled
 CONSTANTS
     TargetNotes = 8
     SmallKindCap = 2

--- a/specs/bug-models/MemoryCompaction.cfg
+++ b/specs/bug-models/MemoryCompaction.cfg
@@ -1,0 +1,9 @@
+\* Clean model: compaction respects per-kind caps.
+\* Expected: no error (all five invariants hold).
+SPECIFICATION Spec
+INVARIANT GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected
+CONSTANTS
+    TargetNotes = 8
+    SmallKindCap = 2
+    LongTermCap = 3
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/MemoryCompaction.tla
+++ b/specs/bug-models/MemoryCompaction.tla
@@ -2,31 +2,37 @@
 \* Bug Model: Memory bank compaction drops important notes.
 \*
 \* Models keeper_memory_bank.ml compact_memory_bank_if_needed.
-\* Correct code: selection respects kind caps + recent floor.
+\* Correct code: selection respects kind caps + fallback fill by recency.
 \* Bug: priority-only selection lets high-priority long_term notes
 \* fill all slots, starving goals and other kinds.
 \*
 \* Reference (verified 2026-07-19 — restored after collateral deletion in
-\* #24332; symbol refs, not line numbers, per ml-line-refs gate):
+\* #24332, then hardened per adversarial review; symbol refs, not line
+\* numbers, per ml-line-refs gate):
 \*   lib/keeper/keeper_memory_bank.ml — compact_memory_bank_if_needed entry point
-\*   lib/keeper/keeper_memory_bank.ml — memory_kind_caps_for_compaction (per-target cap derivation)
+\*   lib/keeper/keeper_memory_bank.ml — add_row (hard total cap + per-kind cap + dedup)
 \*   lib/keeper/keeper_memory_policy.ml — kind_caps () : (memory_kind * int) list, closed-variant SSOT
+\*   lib/keeper/keeper_memory_policy.ml — priority_for_kind (closed-variant priorities)
 \*
 \* ── Abstraction note ──
-\* The real kind_caps SSOT enumerates 5 closed memory_kind constructors,
-\* rendered canonically on the wire as:
-\*   decision:2, goal:2, progress:2, open_question:2, long_term:4
-\* This bug model collapses them to 4 representative kinds for the
-\* "starvation under priority-only selection" invariant:
-\*   goal        — collapses {goal}
-\*   decision    — collapses {decision}
-\*   progress    — collapses {progress, open_question}
-\*                 (all per-cap=2 generic notes)
-\*   long_term   — collapses {long_term} (only kind with cap=4)
-\* Two abstract caps (SmallKindCap, LongTermCap) are sufficient to
-\* express the bug because the asymmetry that causes starvation is
-\* between "the high-priority kind" (long_term) and "the small-cap
-\* kinds" (everything else with cap=2).
+\* The real kind_caps SSOT enumerates 5 closed memory_kind constructors. This
+\* model uses 4 representative kinds for the "starvation under priority-only
+\* selection" invariant:
+\*   goal        — {goal}      (priority 72, cap = SmallKindCap)
+\*   decision    — {decision}  (priority 86, cap = SmallKindCap)
+\*   progress    — {progress, open_question}
+\*   long_term   — {long_term} (priority 95, only kind with cap = LongTermCap)
+\* Scope of the collapse: open_question is folded into the small-cap bucket
+\* ONLY because the modeled bug is long_term (>=90) monopolizing every slot —
+\* which starves goals regardless of the ordering among the sub-90 kinds. The
+\* collapse is therefore conservative for THIS invariant: it neither creates nor
+\* hides the long_term-monopoly starvation. It does NOT model open_question's
+\* own starvation vector — open_question priority is 76, ABOVE goal (72), so a
+\* priority-only selection that ranked sub-90 kinds would starve goals with
+\* open_questions too. That distinct vector is out of this model's scope (a
+\* candidate follow-up spec), not asserted equivalent to progress here.
+\* Constant abstraction: production long_term cap is 4; the model uses
+\* LongTermCap = 3 (cfg). This only scales the per-kind bound, not the bug.
 
 EXTENDS Naturals, Sequences, FiniteSets
 
@@ -36,24 +42,29 @@ CONSTANTS
     LongTermCap        \* Max long_term notes to keep (e.g. 3)
 
 VARIABLES
-    bank,              \* Sequence of notes: [kind |-> "...", priority |-> Nat]
+    bank,              \* Sequence of notes: [id |-> Nat, kind |-> "...", priority |-> Nat]
     result,            \* Sequence of notes after compaction
     phase              \* "accumulating" | "compacting" | "done"
 
 vars == <<bank, result, phase>>
 
-\* Kinds and their priorities (matching OCaml code)
+\* Kinds and their priorities (matching keeper_memory_policy.ml priority_for_kind)
 Kinds == {"goal", "decision", "progress", "long_term"}
 
 \* Count notes of a given kind in a sequence
 KindCount(seq, kind) ==
     Cardinality({i \in 1..Len(seq) : seq[i].kind = kind})
 
+\* Ids present in a sequence (notes carry a unique monotonic id so the fallback
+\* fill can exclude already-selected notes — mirrors add_row's dedup by key).
+IdSet(seq) == {seq[i].id : i \in 1..Len(seq)}
+
 TypeOK ==
     /\ phase \in {"accumulating", "compacting", "done"}
     /\ \A i \in 1..Len(bank) :
          /\ bank[i].kind \in Kinds
          /\ bank[i].priority \in 0..100
+         /\ bank[i].id \in Nat
 
 Init ==
     /\ bank = <<>>
@@ -61,30 +72,21 @@ Init ==
     /\ phase = "accumulating"
 
 \* ── Accumulation (add notes to bank) ──────────────────
+\* Bounded just past the first compactable size (TargetNotes) so the state
+\* space stays small while still admitting the starvation witness (enough
+\* long_term notes to monopolize every slot alongside at least one goal).
 
-AppendGoal ==
-    /\ phase = "accumulating"
-    /\ Len(bank) < TargetNotes * 2   \* Allow growth beyond target
-    /\ bank' = Append(bank, [kind |-> "goal", priority |-> 72])
+CanAppend == phase = "accumulating" /\ Len(bank) < TargetNotes + 1
+
+AppendNote(k, p) ==
+    /\ CanAppend
+    /\ bank' = Append(bank, [id |-> Len(bank) + 1, kind |-> k, priority |-> p])
     /\ UNCHANGED <<result, phase>>
 
-AppendDecision ==
-    /\ phase = "accumulating"
-    /\ Len(bank) < TargetNotes * 2
-    /\ bank' = Append(bank, [kind |-> "decision", priority |-> 86])
-    /\ UNCHANGED <<result, phase>>
-
-AppendProgress ==
-    /\ phase = "accumulating"
-    /\ Len(bank) < TargetNotes * 2
-    /\ bank' = Append(bank, [kind |-> "progress", priority |-> 66])
-    /\ UNCHANGED <<result, phase>>
-
-AppendLongTerm ==
-    /\ phase = "accumulating"
-    /\ Len(bank) < TargetNotes * 2
-    /\ bank' = Append(bank, [kind |-> "long_term", priority |-> 95])
-    /\ UNCHANGED <<result, phase>>
+AppendGoal     == AppendNote("goal", 72)
+AppendDecision == AppendNote("decision", 86)
+AppendProgress == AppendNote("progress", 66)
+AppendLongTerm == AppendNote("long_term", 95)
 
 \* ── Trigger compaction (when bank exceeds target) ─────
 
@@ -96,24 +98,21 @@ TriggerCompaction ==
 
 \* ── Safe compaction (with kind caps) ──────────────────
 
-\* Select notes respecting per-kind caps.
-\* Priority-sorted, but each kind limited to its cap.
+\* First-cap of a kind: the leading notes of that kind, up to [cap].
+CapKind(kind, cap) ==
+    LET notes == SelectSeq(bank, LAMBDA n : n.kind = kind)
+    IN SubSeq(notes, 1, IF Len(notes) > cap THEN cap ELSE Len(notes))
+
+\* Select notes respecting per-kind caps, then fill any remaining slots from the
+\* notes NOT already selected (by recency = bank order). The fallback excludes
+\* already-selected ids so no note is counted twice — mirroring
+\* keeper_memory_bank.ml add_row, which skips keys already in selected_keys.
 SafeCompact ==
     /\ phase = "compacting"
     /\ LET
-         \* Phase 1: kind-capped selection (respects per-kind caps)
-         goals == SelectSeq(bank, LAMBDA n : n.kind = "goal")
-         kept_goals == SubSeq(goals, 1, IF Len(goals) > SmallKindCap
-                                          THEN SmallKindCap
-                                          ELSE Len(goals))
-         longtermNotes == SelectSeq(bank, LAMBDA n : n.kind = "long_term")
-         kept_longterm == SubSeq(longtermNotes, 1, IF Len(longtermNotes) > LongTermCap
-                                                   THEN LongTermCap
-                                                   ELSE Len(longtermNotes))
-         decisions == SelectSeq(bank, LAMBDA n : n.kind = "decision")
-         kept_decisions == SubSeq(decisions, 1, IF Len(decisions) > SmallKindCap
-                                                THEN SmallKindCap
-                                                ELSE Len(decisions))
+         kept_goals    == CapKind("goal", SmallKindCap)
+         kept_longterm == CapKind("long_term", LongTermCap)
+         kept_decisions == CapKind("decision", SmallKindCap)
          progress == SelectSeq(bank, LAMBDA n : n.kind = "progress")
          remaining == TargetNotes - Len(kept_goals)
                                   - Len(kept_longterm)
@@ -122,13 +121,15 @@ SafeCompact ==
                                               THEN IF remaining > 0 THEN remaining ELSE 0
                                               ELSE Len(progress))
          capped == kept_goals \o kept_longterm \o kept_decisions \o kept_progress
-         \* Phase 2: fallback fill (ignore kind caps to reach TargetNotes).
-         \* Models keeper_memory_bank.ml compact_memory_bank_if_needed fallback fill:
-         \*   if !selected_count < target_notes then
-         \*     List.iter (fun row -> add_row ~ignore_kind_cap:true row) by_recency;
+         \* Fallback fill (ignore kind caps to reach TargetNotes), drawing only
+         \* from notes not already selected, by recency (bank order).
+         selectedIds == IdSet(capped)
+         notSelected == SelectSeq(bank, LAMBDA n : n.id \notin selectedIds)
          deficit == TargetNotes - Len(capped)
          extra == IF deficit > 0
-                  THEN SubSeq(bank, 1, IF Len(bank) > deficit THEN deficit ELSE Len(bank))
+                  THEN SubSeq(notSelected, 1,
+                              IF Len(notSelected) > deficit THEN deficit
+                              ELSE Len(notSelected))
                   ELSE <<>>
        IN
          /\ result' = capped \o extra
@@ -140,16 +141,12 @@ SafeCompact ==
 BugPriorityOnlyCompact ==
     /\ phase = "compacting"
     /\ LET
-         \* Just take the first TargetNotes entries (bank is appended
-         \* in priority order: long_term(95) > decision(86) > goal(72) > progress(66))
-         \* So highest-priority notes fill all slots, starving lower kinds.
-         \*
-         \* Sort by priority descending: long_term first, then decision,
-         \* then goal, then progress. If there are more long_term notes
-         \* than TargetNotes, goals get 0 slots.
-         sortedByPri == SelectSeq(bank, LAMBDA n : n.priority >= 90)
+         \* Priority-only: the highest-priority notes (long_term, 95 >= 90) are
+         \* taken first, then the rest in bank order. When long_term notes alone
+         \* reach TargetNotes, every other kind — goals included — gets 0 slots.
+         topPri == SelectSeq(bank, LAMBDA n : n.priority >= 90)
          lowPri == SelectSeq(bank, LAMBDA n : n.priority < 90)
-         allSorted == sortedByPri \o lowPri
+         allSorted == topPri \o lowPri
          taken == SubSeq(allSorted, 1, IF Len(allSorted) > TargetNotes
                                        THEN TargetNotes
                                        ELSE Len(allSorted))
@@ -201,14 +198,12 @@ LongTermProtected ==
             THEN LongTermCap
             ELSE KindCount(bank, "long_term")
 
-\* Recent floor: compaction keeps at least min(bank_size, RecentFloor) notes.
-\* OCaml: let recent_floor = max 16 (min 64 (target_notes / 5))
-\* For our small model (TargetNotes=8), RecentFloor = max(16, min(64, 8/5)) = 16,
-\* but bank never reaches 16 in the model, so the effective floor is Len(bank).
-\* We express the general property: result is never smaller than
-\* min(Len(bank), TargetNotes).  This catches a hypothetical bug where
-\* compaction over-prunes below the available input.
-RecentFloorRespected ==
+\* Completeness bound: compaction fills up to the available input, never
+\* under-pruning below min(Len(bank), TargetNotes). This is NOT a recency
+\* guarantee — the real recent_floor (max 16 …) never binds at this model's
+\* scale (bank <= TargetNotes+1 < 16), so recency is out of scope here. It only
+\* guards against a compaction that drops notes it had room to keep.
+ResultNotUnderfilled ==
     phase = "done" =>
         Len(result) >= IF Len(bank) < TargetNotes
                        THEN Len(bank)

--- a/specs/bug-models/MemoryCompaction.tla
+++ b/specs/bug-models/MemoryCompaction.tla
@@ -1,0 +1,217 @@
+---- MODULE MemoryCompaction ----
+\* Bug Model: Memory bank compaction drops important notes.
+\*
+\* Models keeper_memory_bank.ml compact_memory_bank_if_needed.
+\* Correct code: selection respects kind caps + recent floor.
+\* Bug: priority-only selection lets high-priority long_term notes
+\* fill all slots, starving goals and other kinds.
+\*
+\* Reference (verified 2026-07-19 — restored after collateral deletion in
+\* #24332; symbol refs, not line numbers, per ml-line-refs gate):
+\*   lib/keeper/keeper_memory_bank.ml — compact_memory_bank_if_needed entry point
+\*   lib/keeper/keeper_memory_bank.ml — memory_kind_caps_for_compaction (per-target cap derivation)
+\*   lib/keeper/keeper_memory_policy.ml — kind_caps () : (memory_kind * int) list, closed-variant SSOT
+\*
+\* ── Abstraction note ──
+\* The real kind_caps SSOT enumerates 5 closed memory_kind constructors,
+\* rendered canonically on the wire as:
+\*   decision:2, goal:2, progress:2, open_question:2, long_term:4
+\* This bug model collapses them to 4 representative kinds for the
+\* "starvation under priority-only selection" invariant:
+\*   goal        — collapses {goal}
+\*   decision    — collapses {decision}
+\*   progress    — collapses {progress, open_question}
+\*                 (all per-cap=2 generic notes)
+\*   long_term   — collapses {long_term} (only kind with cap=4)
+\* Two abstract caps (SmallKindCap, LongTermCap) are sufficient to
+\* express the bug because the asymmetry that causes starvation is
+\* between "the high-priority kind" (long_term) and "the small-cap
+\* kinds" (everything else with cap=2).
+
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    TargetNotes,       \* Max notes after compaction (e.g. 8 for small model)
+    SmallKindCap,      \* Max notes to keep for each ordinary kind (e.g. 2)
+    LongTermCap        \* Max long_term notes to keep (e.g. 3)
+
+VARIABLES
+    bank,              \* Sequence of notes: [kind |-> "...", priority |-> Nat]
+    result,            \* Sequence of notes after compaction
+    phase              \* "accumulating" | "compacting" | "done"
+
+vars == <<bank, result, phase>>
+
+\* Kinds and their priorities (matching OCaml code)
+Kinds == {"goal", "decision", "progress", "long_term"}
+
+\* Count notes of a given kind in a sequence
+KindCount(seq, kind) ==
+    Cardinality({i \in 1..Len(seq) : seq[i].kind = kind})
+
+TypeOK ==
+    /\ phase \in {"accumulating", "compacting", "done"}
+    /\ \A i \in 1..Len(bank) :
+         /\ bank[i].kind \in Kinds
+         /\ bank[i].priority \in 0..100
+
+Init ==
+    /\ bank = <<>>
+    /\ result = <<>>
+    /\ phase = "accumulating"
+
+\* ── Accumulation (add notes to bank) ──────────────────
+
+AppendGoal ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2   \* Allow growth beyond target
+    /\ bank' = Append(bank, [kind |-> "goal", priority |-> 72])
+    /\ UNCHANGED <<result, phase>>
+
+AppendDecision ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2
+    /\ bank' = Append(bank, [kind |-> "decision", priority |-> 86])
+    /\ UNCHANGED <<result, phase>>
+
+AppendProgress ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2
+    /\ bank' = Append(bank, [kind |-> "progress", priority |-> 66])
+    /\ UNCHANGED <<result, phase>>
+
+AppendLongTerm ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2
+    /\ bank' = Append(bank, [kind |-> "long_term", priority |-> 95])
+    /\ UNCHANGED <<result, phase>>
+
+\* ── Trigger compaction (when bank exceeds target) ─────
+
+TriggerCompaction ==
+    /\ phase = "accumulating"
+    /\ Len(bank) > TargetNotes
+    /\ phase' = "compacting"
+    /\ UNCHANGED <<bank, result>>
+
+\* ── Safe compaction (with kind caps) ──────────────────
+
+\* Select notes respecting per-kind caps.
+\* Priority-sorted, but each kind limited to its cap.
+SafeCompact ==
+    /\ phase = "compacting"
+    /\ LET
+         \* Phase 1: kind-capped selection (respects per-kind caps)
+         goals == SelectSeq(bank, LAMBDA n : n.kind = "goal")
+         kept_goals == SubSeq(goals, 1, IF Len(goals) > SmallKindCap
+                                          THEN SmallKindCap
+                                          ELSE Len(goals))
+         longtermNotes == SelectSeq(bank, LAMBDA n : n.kind = "long_term")
+         kept_longterm == SubSeq(longtermNotes, 1, IF Len(longtermNotes) > LongTermCap
+                                                   THEN LongTermCap
+                                                   ELSE Len(longtermNotes))
+         decisions == SelectSeq(bank, LAMBDA n : n.kind = "decision")
+         kept_decisions == SubSeq(decisions, 1, IF Len(decisions) > SmallKindCap
+                                                THEN SmallKindCap
+                                                ELSE Len(decisions))
+         progress == SelectSeq(bank, LAMBDA n : n.kind = "progress")
+         remaining == TargetNotes - Len(kept_goals)
+                                  - Len(kept_longterm)
+                                  - Len(kept_decisions)
+         kept_progress == SubSeq(progress, 1, IF Len(progress) > remaining
+                                              THEN IF remaining > 0 THEN remaining ELSE 0
+                                              ELSE Len(progress))
+         capped == kept_goals \o kept_longterm \o kept_decisions \o kept_progress
+         \* Phase 2: fallback fill (ignore kind caps to reach TargetNotes).
+         \* Models keeper_memory_bank.ml compact_memory_bank_if_needed fallback fill:
+         \*   if !selected_count < target_notes then
+         \*     List.iter (fun row -> add_row ~ignore_kind_cap:true row) by_recency;
+         deficit == TargetNotes - Len(capped)
+         extra == IF deficit > 0
+                  THEN SubSeq(bank, 1, IF Len(bank) > deficit THEN deficit ELSE Len(bank))
+                  ELSE <<>>
+       IN
+         /\ result' = capped \o extra
+         /\ phase' = "done"
+         /\ UNCHANGED <<bank>>
+
+\* ── Buggy compaction (priority-only, no kind caps) ────
+
+BugPriorityOnlyCompact ==
+    /\ phase = "compacting"
+    /\ LET
+         \* Just take the first TargetNotes entries (bank is appended
+         \* in priority order: long_term(95) > decision(86) > goal(72) > progress(66))
+         \* So highest-priority notes fill all slots, starving lower kinds.
+         \*
+         \* Sort by priority descending: long_term first, then decision,
+         \* then goal, then progress. If there are more long_term notes
+         \* than TargetNotes, goals get 0 slots.
+         sortedByPri == SelectSeq(bank, LAMBDA n : n.priority >= 90)
+         lowPri == SelectSeq(bank, LAMBDA n : n.priority < 90)
+         allSorted == sortedByPri \o lowPri
+         taken == SubSeq(allSorted, 1, IF Len(allSorted) > TargetNotes
+                                       THEN TargetNotes
+                                       ELSE Len(allSorted))
+       IN
+         /\ result' = taken
+         /\ phase' = "done"
+         /\ UNCHANGED <<bank>>
+
+\* ── Specifications ────────────────────────────────────
+
+NextSafe ==
+    \/ AppendGoal \/ AppendDecision \/ AppendProgress \/ AppendLongTerm
+    \/ TriggerCompaction
+    \/ SafeCompact
+
+NextBuggy ==
+    \/ AppendGoal \/ AppendDecision \/ AppendProgress \/ AppendLongTerm
+    \/ TriggerCompaction
+    \/ BugPriorityOnlyCompact
+
+Spec == Init /\ [][NextSafe]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety Invariants ─────────────────────────────────
+
+\* After compaction, goal notes are preserved up to their cap.
+\* If the bank had N goal notes, the result must have min(N, SmallKindCap).
+GoalsPreserved ==
+    phase = "done" =>
+        KindCount(result, "goal") >=
+            IF KindCount(bank, "goal") > SmallKindCap
+            THEN SmallKindCap
+            ELSE KindCount(bank, "goal")
+
+\* Compaction never produces an empty result from a non-empty bank.
+NeverEmpty ==
+    (phase = "done" /\ Len(bank) > 0) => Len(result) > 0
+
+\* Result never exceeds target.
+ResultBounded ==
+    phase = "done" => Len(result) <= TargetNotes
+
+\* Long-term notes are preserved up to their cap.
+\* Mirrors GoalsPreserved but for the long_term kind.
+LongTermProtected ==
+    phase = "done" =>
+        KindCount(result, "long_term") >=
+            IF KindCount(bank, "long_term") > LongTermCap
+            THEN LongTermCap
+            ELSE KindCount(bank, "long_term")
+
+\* Recent floor: compaction keeps at least min(bank_size, RecentFloor) notes.
+\* OCaml: let recent_floor = max 16 (min 64 (target_notes / 5))
+\* For our small model (TargetNotes=8), RecentFloor = max(16, min(64, 8/5)) = 16,
+\* but bank never reaches 16 in the model, so the effective floor is Len(bank).
+\* We express the general property: result is never smaller than
+\* min(Len(bank), TargetNotes).  This catches a hypothetical bug where
+\* compaction over-prunes below the available input.
+RecentFloorRespected ==
+    phase = "done" =>
+        Len(result) >= IF Len(bank) < TargetNotes
+                       THEN Len(bank)
+                       ELSE TargetNotes
+
+====


### PR DESCRIPTION
## 요약

#24332 (`refactor: replace Keeper governance with a nonhierarchical Gate`)가 governance→Gate 아키텍처 전환과 함께 **50+ 개 TLA+ spec을 삭제**했다. 그 중 상당수는 구 governance 아키텍처의 obsolete spec으로 삭제가 정당하나, **governance와 무관한 bug model이 collateral로 함께 삭제**됐다. baseline 미갱신 + ratchet CI 미연결(#25298)로 bug model coverage 98→44 급감이 조용히 방치됐다.

이 PR은 정합성이 확인된 **MemoryCompaction** 하나를 복원하는 **파일럿**이다.

## MemoryCompaction 정합성 (복원 정당 근거)

- **모델 대상**: `keeper_memory_bank.ml compact_memory_bank_if_needed` — priority-only selection이 per-kind cap을 무시하면 high-priority `long_term` 노트가 슬롯을 독점해 `goal` 등을 starve시키는 버그.
- **governance 무관**: spec 본문에 governance/gate/approval 언급 0.
- **대응 코드 live**: `compact_memory_bank_if_needed`, `memory_kind_caps_for_compaction`, `keeper_memory_policy.ml kind_caps` 모두 현재 main에 존재. 검증 대상이 살아있으므로 회귀 가드로 여전히 유효.
- **로직 불변**: 삭제 전 spec과 로직 라인 100% 동일. diff는 주석뿐 (colon-form `ml:346` → symbol ref, ml-line-refs gate 준수).

## 검증

- clean cfg: `GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected` (per-kind cap 존중 → invariant 유지).
- buggy cfg: priority-only compaction → `GoalsPreserved` 위반 (long_term이 슬롯 독점).
- 로컬 TLC(v1.8.0)는 상태공간이 커 장시간 소요 — 로직이 삭제 전과 동일하고 원 spec이 2026-04~07-08 CI를 통과했으므로, 이 PR의 TLA+ Model Checking CI가 최종 재검증한다.
- ml-line-refs / cfg-orphan / INDEX drift 로컬 clean.

## 이건 파일럿 (N-of-M 자인)

50+ 삭제 spec은 정당(구 governance)/collateral(무관)이 섞여 있고 governance 문자열로 구분되지 않아 **개별 정합성 판정**이 필요하다. 섣부른 배치 복원은 stale spec 부활 위험. 이 PR로 복원 패턴(정합성 확인 → colon-form 수정 → 로직 불변 diff → CI 검증)을 확립하고, 후속 배치로 확대한다. 근본 재발 방지(ratchet CI 연결)는 #25298 조치 옵션 3.

Tracking: #25298
