### PR TITLE
refactor(artifact): typed artifact ref with exact marker codec (#25096 leaf 1)

### DIFF
--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -37,7 +37,7 @@ let hydrate_block ~store ~remaining
       if !remaining = 0 then block
       else
         (match Tool_output.decode_from_oas result.Canonical_tool.content with
-         | Tool_output.Stored { sha256; _ } ->
+         | Tool_output.Decoded { sha256; _ } ->
              (match try_hydrate ~store ~sha256 with
               | Some bytes ->
                   decr remaining;
@@ -49,7 +49,13 @@ let hydrate_block ~store ~remaining
                     ; content_blocks = result.Canonical_tool.content_blocks
                     }
               | None -> block)
-         | Tool_output.Inline _ -> block)
+         | Tool_output.Not_marker -> block
+         | Tool_output.Invalid_marker { detail } ->
+             (* A marker-shaped payload that fails validation stays as-is and
+                is visible; it must not be silently hydrated or dropped. *)
+             Log.Misc.warn
+               "keeper artifact hydration kept invalid blob marker: %s" detail;
+             block)
   | _ -> block
 
 let hydrate_messages ~store ~keep_recent

--- a/lib/keeper/keeper_tool_progress_identity.ml
+++ b/lib/keeper/keeper_tool_progress_identity.ml
@@ -55,9 +55,10 @@ let inline_output_fingerprint value =
 
 let output_fingerprint output_text =
   match Tool_output.decode_from_oas output_text with
-  | Tool_output.Stored { sha256; bytes; mime; _ } ->
+  | Tool_output.Decoded { sha256; bytes; mime; _ } ->
     Some (digest_json (stored_output_identity_json ~sha256 ~bytes ~mime))
-  | Tool_output.Inline value -> inline_output_fingerprint value
+  | Tool_output.Not_marker | Tool_output.Invalid_marker _ ->
+    inline_output_fingerprint output_text
 ;;
 
 let digest_tool_output ~tool_name:_ output_text =

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -340,7 +340,7 @@ let start_flush_fiber ~sw ~clock =
     consumers are updated in the same change to accept either shape. *)
 let blob_aware_output_json (output : string) : Yojson.Safe.t =
   match Tool_output.decode_from_oas output with
-  | Tool_output.Stored { sha256; bytes; preview; mime } ->
+  | Tool_output.Decoded { sha256; bytes; preview; mime } ->
     `Assoc
       [ ( "_blob"
         , `Assoc
@@ -350,7 +350,7 @@ let blob_aware_output_json (output : string) : Yojson.Safe.t =
             ; "preview", `String preview
             ] )
       ]
-  | Tool_output.Inline _ -> `String output
+  | Tool_output.Not_marker | Tool_output.Invalid_marker _ -> `String output
 ;;
 
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =

--- a/lib/keeper_tool_call_log_route_evidence.ml
+++ b/lib/keeper_tool_call_log_route_evidence.ml
@@ -43,8 +43,8 @@ let route_safe_path_string _path = "[REDACTED]"
 
 let route_text_for_evidence output_text =
   match Tool_output.decode_from_oas output_text with
-  | Tool_output.Stored { preview; _ } -> preview
-  | Tool_output.Inline value -> value
+  | Tool_output.Decoded { preview; _ } -> preview
+  | Tool_output.Not_marker | Tool_output.Invalid_marker _ -> output_text
 ;;
 
 let parse_tool_output_json_sanitized text =

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -149,11 +149,14 @@ let truncate ?(max_len = default_max_len) (s : string) : string =
 let redact_preview ?(max_len = default_max_len) (s : string) : string =
   if Tool_output.is_marker s then
     match Tool_output.decode_from_oas s with
-    | Tool_output.Stored { sha256; bytes; preview; mime } ->
-        let preview = preview |> truncate ~max_len |> redact_patterns in
+    | Tool_output.Decoded artifact_ref ->
+        let preview =
+          artifact_ref.Tool_output.preview |> truncate ~max_len
+          |> redact_patterns
+        in
         Tool_output.encode_for_oas
-          (Tool_output.Stored { sha256; bytes; preview; mime })
-    | Tool_output.Inline _ ->
+          (Tool_output.Stored (Tool_output.with_preview artifact_ref preview))
+    | Tool_output.Not_marker | Tool_output.Invalid_marker _ ->
         s |> truncate ~max_len |> redact_patterns
   else s |> truncate ~max_len |> redact_patterns
 

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -5,33 +5,14 @@ type t =
   ; ownership_root : string
   }
 
-type invalid_sha256 =
+(* sha256 validation SSOT lives in {!Tool_output} (the artifact-ref owner);
+   re-exported here so the store boundary keeps its historical surface. *)
+type invalid_sha256 = Tool_output.invalid_sha256 =
   | Invalid_sha256_length of { actual : int }
   | Invalid_sha256_character of { index : int; found : char }
 
-let validate_sha256 value =
-  let rec validate_character index =
-    if index = String.length value then Ok ()
-    else
-      let found = String.unsafe_get value index in
-      if (found >= '0' && found <= '9') || (found >= 'a' && found <= 'f')
-      then validate_character (index + 1)
-      else Error (Invalid_sha256_character { index; found })
-  in
-  let actual = String.length value in
-  if actual <> 64 then Error (Invalid_sha256_length { actual })
-  else validate_character 0
-
-let invalid_sha256_to_string = function
-  | Invalid_sha256_length { actual } ->
-      Printf.sprintf
-        "expected 64 lowercase hexadecimal characters, got length %d"
-        actual
-  | Invalid_sha256_character { index; found } ->
-      Printf.sprintf
-        "expected lowercase hexadecimal character at index %d, got %C"
-        index
-        found
+let validate_sha256 = Tool_output.validate_sha256
+let invalid_sha256_to_string = Tool_output.invalid_sha256_to_string
 
 type fetch_error =
   | Invalid_sha256 of invalid_sha256
@@ -121,12 +102,18 @@ let put t ~bytes ~mime =
    | Ok () -> ()
    | Error msg ->
        raise (Sys_error (Printf.sprintf "tool_blob_store.put: %s" msg)));
-  Tool_output.Stored {
-    sha256;
-    bytes = String.length bytes;
-    preview = make_preview bytes;
-    mime;
-  }
+  (* A digestif-produced sha256 and a byte length are always valid; an empty
+     [mime] is the only reachable rejection and is a caller bug, raised
+     visibly rather than stored. *)
+  match
+    Tool_output.make_artifact_ref ~sha256 ~bytes:(String.length bytes)
+      ~preview:(make_preview bytes) ~mime
+  with
+  | Ok artifact_ref -> Tool_output.Stored artifact_ref
+  | Error err ->
+    invalid_arg
+      (Printf.sprintf "tool_blob_store.put: %s"
+         (Tool_output.make_error_to_string err))
 
 let list_all t =
   if not (Sys.file_exists t.root) then []

--- a/lib/tool_blob_store/tool_blob_store.mli
+++ b/lib/tool_blob_store/tool_blob_store.mli
@@ -9,7 +9,7 @@
 
 type t
 
-type invalid_sha256 =
+type invalid_sha256 = Tool_output.invalid_sha256 =
   | Invalid_sha256_length of { actual : int }
   | Invalid_sha256_character of { index : int; found : char }
 

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -1,11 +1,64 @@
+(* See .mli for the contract. Typed artifact reference + exact marker codec
+   (#25096). The marker wire format is unchanged; only the type safety and
+   the decode totality change. *)
+
+type invalid_sha256 =
+  | Invalid_sha256_length of { actual : int }
+  | Invalid_sha256_character of { index : int; found : char }
+
+let validate_sha256 value =
+  let rec validate_character index =
+    if index = String.length value then Ok ()
+    else
+      let found = String.unsafe_get value index in
+      if (found >= '0' && found <= '9') || (found >= 'a' && found <= 'f')
+      then validate_character (index + 1)
+      else Error (Invalid_sha256_character { index; found })
+  in
+  let actual = String.length value in
+  if actual <> 64 then Error (Invalid_sha256_length { actual })
+  else validate_character 0
+
+let invalid_sha256_to_string = function
+  | Invalid_sha256_length { actual } ->
+    Printf.sprintf
+      "expected 64 lowercase hexadecimal characters, got length %d" actual
+  | Invalid_sha256_character { index; found } ->
+    Printf.sprintf
+      "expected lowercase hexadecimal character at index %d, got %C" index
+      found
+
+type artifact_ref =
+  { sha256 : string
+  ; bytes : int
+  ; preview : string
+  ; mime : string
+  }
+
+type make_error =
+  | Invalid_sha256 of invalid_sha256
+  | Negative_bytes of int
+  | Empty_mime
+
+let make_error_to_string = function
+  | Invalid_sha256 err -> invalid_sha256_to_string err
+  | Negative_bytes n ->
+    Printf.sprintf "byte count must be non-negative, got %d" n
+  | Empty_mime -> "media type must be non-empty"
+
+let make_artifact_ref ~sha256 ~bytes ~preview ~mime =
+  match validate_sha256 sha256 with
+  | Error err -> Error (Invalid_sha256 err)
+  | Ok () ->
+    if bytes < 0 then Error (Negative_bytes bytes)
+    else if String.equal (String.trim mime) "" then Error Empty_mime
+    else Ok { sha256; bytes; preview; mime }
+
+let with_preview artifact_ref preview = { artifact_ref with preview }
+
 type t =
   | Inline of string
-  | Stored of {
-      sha256 : string;
-      bytes : int;
-      preview : string;
-      mime : string;
-    }
+  | Stored of artifact_ref
 
 let marker_prefix = "[masc:blob "
 
@@ -14,16 +67,28 @@ let is_marker s = String.starts_with ~prefix:marker_prefix s
 let encode_for_oas = function
   | Inline s -> s
   | Stored { sha256; bytes; preview; mime } ->
-      Printf.sprintf "[masc:blob sha256=%s bytes=%d mime=%s preview=%S]"
-        sha256 bytes mime preview
+    Printf.sprintf "[masc:blob sha256=%s bytes=%d mime=%s preview=%S]"
+      sha256 bytes mime preview
+
+type decode_result =
+  | Not_marker
+  | Invalid_marker of { detail : string }
+  | Decoded of artifact_ref
 
 let decode_from_oas s =
-  if not (is_marker s) then Inline s
+  if not (is_marker s) then Not_marker
   else
-    try
-      Scanf.sscanf s
-        "[masc:blob sha256=%s@ bytes=%d mime=%s@ preview=%S]"
-        (fun sha256 bytes mime preview ->
-          Stored { sha256; bytes; preview; mime })
+    match
+      (try
+         Scanf.sscanf s "[masc:blob sha256=%s@ bytes=%d mime=%s@ preview=%S]"
+           (fun sha256 bytes mime preview -> Ok (sha256, bytes, mime, preview))
+       with
+       | Scanf.Scan_failure msg -> Error msg
+       | Failure msg -> Error msg
+       | Invalid_argument msg -> Error msg)
     with
-    | Scanf.Scan_failure _ | Failure _ | Invalid_argument _ -> Inline s
+    | Error detail -> Invalid_marker { detail }
+    | Ok (sha256, bytes, mime, preview) -> (
+      match make_artifact_ref ~sha256 ~bytes ~preview ~mime with
+      | Ok artifact_ref -> Decoded artifact_ref
+      | Error err -> Invalid_marker { detail = make_error_to_string err })

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -1,40 +1,74 @@
-(** Typed wrapper for tool outputs that may be inline or externally stored.
+(** Tool_output — typed reference for externalized tool payloads (#25096).
 
-    Used by [tool_bridge] to externalize large outputs and by the keeper
-    artifact hydrator to lazily resolve refs at LLM-call time.
+    Tool outputs too large for inline transport are persisted in
+    {!Tool_blob_store}; the OAS [content] field then carries a marker
+    rendered by {!encode_for_oas}. The marker wire format is unchanged
+    ([[masc:blob sha256=… bytes=… mime=… preview=…]], consumed by durable
+    keeper histories and the dashboard inspector), but the codec is now
+    exact:
 
-    OAS [Agent_sdk.Types.ToolResult.content] is a fixed [string] field; we
-    embed [Stored] refs as a blob-reference marker inside that string so
-    the OAS type surface stays untouched. *)
+    - {!artifact_ref} is [private]: construction goes through
+      {!make_artifact_ref}, so every reference in flight has a valid sha256,
+      a non-negative byte count, and a non-empty media type.
+    - {!decode_from_oas} distinguishes [Not_marker], a valid {!Stored}, and
+      [Invalid_marker] — a marker-shaped payload that fails to parse is now a
+      visible, typed outcome instead of the previous silent [Inline]
+      fallback. *)
+
+(** {1 sha256 validation (SSOT, re-exported by {!Tool_blob_store})} *)
+
+type invalid_sha256 =
+  | Invalid_sha256_length of { actual : int }
+  | Invalid_sha256_character of { index : int; found : char }
+
+val validate_sha256 : string -> (unit, invalid_sha256) result
+val invalid_sha256_to_string : invalid_sha256 -> string
+
+(** {1 Typed artifact reference} *)
+
+type artifact_ref = private
+  { sha256 : string
+  ; bytes : int
+  ; preview : string
+  ; mime : string
+  }
+
+type make_error =
+  | Invalid_sha256 of invalid_sha256
+  | Negative_bytes of int
+  | Empty_mime
+
+val make_artifact_ref :
+  sha256:string ->
+  bytes:int ->
+  preview:string ->
+  mime:string ->
+  (artifact_ref, make_error) result
+
+val make_error_to_string : make_error -> string
+
+val with_preview : artifact_ref -> string -> artifact_ref
+(** Replace the preview, keeping the validated identity fields. Total — the
+    existing reference already passed validation. *)
+
+(** {1 Wire codec} *)
 
 type t =
   | Inline of string
-  | Stored of {
-      sha256 : string;  (** lowercase hex, 64 chars *)
-      bytes : int;
-      preview : string;
-      mime : string;
-    }
+  | Stored of artifact_ref
 
 val marker_prefix : string
-(** ["[masc:blob "] — the 11-byte discriminator at offset 0 of an encoded
-    [Stored] value. Real tool outputs do not start with this prefix. *)
-
 val is_marker : string -> bool
-(** True iff [s] starts with [marker_prefix]. *)
 
 val encode_for_oas : t -> string
-(** Encode for embedding in OAS [Agent_sdk.Types.ToolResult.content].
 
-    [Inline s] -> [s].
-    [Stored {...}] -> blob marker, e.g.
-      [["[masc:blob sha256=ab12... bytes=128934 mime=text/plain preview=\"...\"]"]].
+(** Exact decode outcome. [Invalid_marker] means the input starts with
+    {!marker_prefix} but the payload is malformed or fails validation — the
+    caller must decide visibly (keep the raw text, log, or fail) rather than
+    inherit a silent inline fallback. *)
+type decode_result =
+  | Not_marker
+  | Invalid_marker of { detail : string }
+  | Decoded of artifact_ref
 
-    Round-trip property: [decode_from_oas (encode_for_oas x) = x]. *)
-
-val decode_from_oas : string -> t
-(** Decode a string from OAS [ToolResult.content].
-
-    Returns [Inline s] for any string not starting with [marker_prefix]
-    (backward compatibility with old checkpoints) or for malformed markers
-    (fail-safe — never raises). *)
+val decode_from_oas : string -> decode_result

--- a/test/test_keeper_artifact_hydrator.ml
+++ b/test/test_keeper_artifact_hydrator.ml
@@ -13,6 +13,11 @@ module B = Tool_blob_store
 module O = Tool_output
 module T = Agent_sdk.Types
 
+let ref_exn ~sha256 ~bytes ~preview ~mime =
+  match O.make_artifact_ref ~sha256 ~bytes ~preview ~mime with
+  | Ok r -> r
+  | Error e -> Alcotest.fail (O.make_error_to_string e)
+
 let with_temp_dir f =
   let dir = Filename.temp_file "masc_hydrator_test" "" in
   Sys.remove dir;
@@ -34,12 +39,9 @@ let with_temp_dir f =
 
 let store_a_blob store payload =
   match B.put store ~bytes:payload ~mime:"text/plain" with
-  | O.Stored { sha256; bytes; preview; mime } ->
-      let marker =
-        O.encode_for_oas
-          (O.Stored { sha256; bytes; preview; mime })
-      in
-      (sha256, marker)
+  | O.Stored artifact_ref ->
+      let marker = O.encode_for_oas (O.Stored artifact_ref) in
+      (artifact_ref.sha256, marker)
   | O.Inline _ -> failwith "expected Stored"
 
 let tool_result_block ~tool_use_id ~content : T.content_block =
@@ -205,12 +207,11 @@ let test_hydration_miss_keeps_marker () =
       let phantom =
         O.encode_for_oas
           (O.Stored
-             {
-               sha256 = String.make 64 'a';
-               bytes = 9999;
-               preview = "missing";
-               mime = "text/plain";
-             })
+             (ref_exn
+                ~sha256:(String.make 64 'a')
+                ~bytes:9999
+                ~preview:"missing"
+                ~mime:"text/plain"))
       in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:phantom in
       let r = H.hydrate_recent ~store ~keep_recent:3 in

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -14,6 +14,11 @@ let eio_env_test name fn =
     Fs_compat.set_fs (Eio.Stdenv.fs env);
     fn env)
 
+let artifact_ref_exn ~sha256 ~bytes ~preview ~mime =
+  match Tool_output.make_artifact_ref ~sha256 ~bytes ~preview ~mime with
+  | Ok r -> r
+  | Error e -> Alcotest.fail (Tool_output.make_error_to_string e)
+
 let counter = ref 0
 
 let with_tmp_log f =
@@ -507,13 +512,12 @@ let test_route_evidence_stored_for_blob_backed_git_push () =
   with_tmp_log (fun () ->
     let marker =
       Tool_output.encode_for_oas
-        (Tool_output.Stored {
-          sha256 = String.make 64 'b';
-          bytes = 8192;
-          mime = "application/json";
-          preview =
-            {|{"ok":true,"via":"docker","sandbox_profile":"docker","network_mode":"bridge","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|};
-        })
+        (Tool_output.Stored
+           (artifact_ref_exn
+              ~sha256:(String.make 64 'b')
+              ~bytes:8192
+              ~mime:"application/json"
+              ~preview:{|{"ok":true,"via":"docker","sandbox_profile":"docker","network_mode":"bridge","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|}))
     in
     Keeper_tool_call_log.log_call
       ~keeper_name:"executor"
@@ -1125,12 +1129,12 @@ let test_output_blob_marker_normalized () =
   with_tmp_log (fun () ->
     let marker =
       Tool_output.encode_for_oas
-        (Tool_output.Stored {
-          sha256 = String.make 64 'a';
-          bytes = 6436;
-          mime = "text/plain";
-          preview = "{\"ok\":true,\"result\":\"42\"}";
-        })
+        (Tool_output.Stored
+           (artifact_ref_exn
+              ~sha256:(String.make 64 'a')
+              ~bytes:6436
+              ~mime:"text/plain"
+              ~preview:"{\"ok\":true,\"result\":\"42\"}"))
     in
     Keeper_tool_call_log.log_call
       ~keeper_name:"k" ~tool_name:"tool_blob"

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -2,6 +2,11 @@
 
 open Masc
 
+let artifact_ref_exn ~sha256 ~bytes ~preview ~mime =
+  match Tool_output.make_artifact_ref ~sha256 ~bytes ~preview ~mime with
+  | Ok r -> r
+  | Error e -> Alcotest.fail (Tool_output.make_error_to_string e)
+
 let test_api_key_redacted () =
   let input = {|{"api_key": "sk-proj-abc123xyz456def789ghi012jkl345"}|} in
   let preview = Observability_redact.redact_preview input in
@@ -110,16 +115,19 @@ let test_blob_marker_preserves_structure () =
   let marker =
     Tool_output.encode_for_oas
       (Tool_output.Stored
-         { sha256 = sha; bytes = 10523; preview = "hello"; mime = "text/plain" })
+         (artifact_ref_exn ~sha256:sha ~bytes:10523 ~preview:"hello"
+            ~mime:"text/plain"))
   in
   let redacted = Observability_redact.redact_preview marker in
   match Tool_output.decode_from_oas redacted with
-  | Tool_output.Stored { sha256; bytes; mime; _ } ->
+  | Tool_output.Decoded { sha256; bytes; mime; _ } ->
       Alcotest.(check string) "sha256 preserved" sha sha256;
       Alcotest.(check int) "bytes preserved" 10523 bytes;
       Alcotest.(check string) "mime preserved" "text/plain" mime
-  | Tool_output.Inline _ ->
+  | Tool_output.Not_marker ->
       Alcotest.fail "marker structure destroyed by redaction"
+  | Tool_output.Invalid_marker { detail } ->
+      Alcotest.failf "marker structure destroyed by redaction: %s" detail
 
 let test_blob_marker_redacts_preview_body () =
   let sha = String.make 64 'b' in
@@ -127,7 +135,8 @@ let test_blob_marker_redacts_preview_body () =
   let marker =
     Tool_output.encode_for_oas
       (Tool_output.Stored
-         { sha256 = sha; bytes = 999; preview; mime = "application/json" })
+         (artifact_ref_exn ~sha256:sha ~bytes:999 ~preview
+            ~mime:"application/json"))
   in
   let redacted = Observability_redact.redact_preview marker in
   Alcotest.(check bool) "raw key scrubbed from preview" true
@@ -146,7 +155,8 @@ let test_preview_json_strings_preserves_embedded_marker () =
   let marker =
     Tool_output.encode_for_oas
       (Tool_output.Stored
-         { sha256 = sha; bytes = 500; preview = "hi"; mime = "text/plain" })
+         (artifact_ref_exn ~sha256:sha ~bytes:500 ~preview:"hi"
+            ~mime:"text/plain"))
   in
   let json = `Assoc [("content", `String marker); ("meta", `Int 1)] in
   let out = Observability_redact.preview_json_strings json in
@@ -155,12 +165,14 @@ let test_preview_json_strings_preserves_embedded_marker () =
       (match List.assoc_opt "content" fields with
        | Some (`String s) ->
            (match Tool_output.decode_from_oas s with
-            | Tool_output.Stored { sha256; bytes; mime; _ } ->
+            | Tool_output.Decoded { sha256; bytes; mime; _ } ->
                 Alcotest.(check string) "sha256 preserved in leaf" sha sha256;
                 Alcotest.(check int) "bytes preserved in leaf" 500 bytes;
                 Alcotest.(check string) "mime preserved in leaf" "text/plain" mime
-            | Tool_output.Inline _ ->
-                Alcotest.fail "marker in JSON leaf was corrupted")
+            | Tool_output.Not_marker ->
+                Alcotest.fail "marker in JSON leaf was corrupted"
+            | Tool_output.Invalid_marker { detail } ->
+                Alcotest.failf "marker in JSON leaf was corrupted: %s" detail)
        | _ -> Alcotest.fail "content field missing or not a string")
   | _ -> Alcotest.fail "expected Assoc root"
 

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -2,8 +2,9 @@
 
     Covers:
     - Round-trip: encode then decode for both [Inline] and [Stored] variants.
-    - Backward compat: any string without marker decodes to [Inline].
-    - Malformed marker falls back to [Inline] (fail-safe).
+    - Backward compat: any string without marker reports [Not_marker].
+    - Malformed marker surfaces as [Invalid_marker] — a visible, typed
+      outcome, not a silent inline fallback.
     - Content-addressed: same bytes -> same sha -> idempotent put.
     - Sharding: blobs land under [<sha[0..1]>/<sha>].
     - GC: blobs not in keep_set are deleted; kept ones survive.
@@ -13,6 +14,11 @@ module B = Tool_blob_store
 module O = Tool_output
 
 (* --- Helpers --- *)
+
+let ref_exn ~sha256 ~bytes ~preview ~mime =
+  match O.make_artifact_ref ~sha256 ~bytes ~preview ~mime with
+  | Ok r -> r
+  | Error e -> Alcotest.fail (O.make_error_to_string e)
 
 let fetch_ok store ~sha256 =
   match B.fetch store ~sha256 with
@@ -46,32 +52,36 @@ let test_inline_roundtrip () =
   let encoded = O.encode_for_oas (O.Inline s) in
   Alcotest.(check string) "inline encode = identity" s encoded;
   match O.decode_from_oas encoded with
-  | O.Inline s' -> Alcotest.(check string) "inline decode" s s'
-  | O.Stored _ -> Alcotest.fail "expected Inline"
+  | O.Not_marker ->
+      (* Raw text is not a marker: the content is the string itself,
+         already asserted identical above. *)
+      ()
+  | O.Decoded _ -> Alcotest.fail "expected Not_marker"
+  | O.Invalid_marker { detail } ->
+      Alcotest.failf "expected Not_marker, got Invalid_marker: %s" detail
 
 let test_stored_roundtrip () =
-  let original =
-    O.Stored
-      {
-        sha256 = "abcd1234";
-        bytes = 128934;
-        preview = "first 200 chars\nwith newline";
-        mime = "text/plain";
-      }
+  let sha256 = String.make 64 'a' in
+  let artifact_ref =
+    ref_exn ~sha256 ~bytes:128934 ~preview:"first 200 chars\nwith newline"
+      ~mime:"text/plain"
   in
+  let original = O.Stored artifact_ref in
   let encoded = O.encode_for_oas original in
   Alcotest.(check bool)
     "encoded starts with marker"
     true
     (O.is_marker encoded);
   match O.decode_from_oas encoded with
-  | O.Stored { sha256; bytes; preview; mime } ->
-      Alcotest.(check string) "sha256" "abcd1234" sha256;
+  | O.Decoded { sha256 = decoded_sha; bytes; preview; mime } ->
+      Alcotest.(check string) "sha256" sha256 decoded_sha;
       Alcotest.(check int) "bytes" 128934 bytes;
       Alcotest.(check string)
         "preview" "first 200 chars\nwith newline" preview;
       Alcotest.(check string) "mime" "text/plain" mime
-  | O.Inline _ -> Alcotest.fail "expected Stored"
+  | O.Not_marker -> Alcotest.fail "expected Decoded"
+  | O.Invalid_marker { detail } ->
+      Alcotest.failf "expected Decoded, got Invalid_marker: %s" detail
 
 let test_encoded_marker_stays_under_externalization_threshold () =
   with_temp_dir (fun dir ->
@@ -84,13 +94,16 @@ let test_encoded_marker_stays_under_externalization_threshold () =
         true
         (String.length encoded <= threshold);
       match O.decode_from_oas encoded with
-      | O.Stored { preview; _ } ->
+      | O.Decoded { preview; _ } ->
         Alcotest.(check int) "preview remains documented cap" 200 (String.length preview)
-      | O.Inline _ -> Alcotest.fail "expected Stored")
+      | O.Not_marker -> Alcotest.fail "expected Decoded"
+      | O.Invalid_marker { detail } ->
+          Alcotest.failf "expected Decoded, got Invalid_marker: %s" detail)
 
 let test_decode_non_marker () =
-  (* Any normal tool output decodes as Inline — backward compat for old
-     checkpoints that pre-date the artifact store. *)
+  (* Any normal tool output reports Not_marker — backward compat for old
+     checkpoints that pre-date the artifact store. The raw string passes
+     through untouched. *)
   let cases =
     [
       "";
@@ -104,19 +117,26 @@ let test_decode_non_marker () =
   List.iter
     (fun s ->
       match O.decode_from_oas s with
-      | O.Inline s' ->
-          Alcotest.(check string) ("inline-fallback for " ^ s) s s'
-      | O.Stored _ ->
-          Alcotest.failf "expected Inline for %S" s)
+      | O.Not_marker -> ()
+      | O.Decoded _ ->
+          Alcotest.failf "expected Not_marker for %S" s
+      | O.Invalid_marker _ ->
+          Alcotest.failf "expected Not_marker (not Invalid_marker) for %S" s)
     cases
 
 let test_decode_malformed_marker () =
-  (* Has the prefix but body is garbage — must NOT raise, falls back to
-     Inline so the keeper LLM sees the raw string instead of crashing. *)
+  (* Has the prefix but body is garbage — must NOT raise. Instead of the
+     old silent Inline fallback, a malformed marker is now a visible, typed
+     [Invalid_marker] outcome; the caller decides what to do with the raw
+     text. *)
   let bad = "[masc:blob garbage that cannot scanf]" in
   match O.decode_from_oas bad with
-  | O.Inline s -> Alcotest.(check string) "fallback string" bad s
-  | O.Stored _ -> Alcotest.fail "malformed should NOT decode as Stored"
+  | O.Invalid_marker { detail } ->
+      Alcotest.(check bool)
+        "detail explains the failure" true (String.length detail > 0)
+  | O.Not_marker ->
+      Alcotest.fail "malformed marker must surface as Invalid_marker"
+  | O.Decoded _ -> Alcotest.fail "malformed should NOT decode as Stored"
 
 (* --- Tool_blob_store basic --- *)
 
@@ -372,9 +392,9 @@ let () =
             "encoded marker stays under externalization threshold"
             `Quick
             test_encoded_marker_stays_under_externalization_threshold;
-          Alcotest.test_case "non-marker = Inline" `Quick
+          Alcotest.test_case "non-marker = Not_marker" `Quick
             test_decode_non_marker;
-          Alcotest.test_case "malformed = Inline" `Quick
+          Alcotest.test_case "malformed = Invalid_marker" `Quick
             test_decode_malformed_marker;
         ] );
       ( "blob store basic",

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -195,9 +195,14 @@ let test_round_trip_through_oas () =
   | Ok { content; _ } ->
       let decoded = O.decode_from_oas content in
       (match decoded with
-       | O.Inline s -> Alcotest.(check string) "inline preserved" payload s
-       | O.Stored _ ->
-           Alcotest.fail "did not expect Stored when externalize=0")
+       | O.Not_marker ->
+           (* Not a marker: the raw content is the payload itself. *)
+           Alcotest.(check string) "inline preserved" payload content
+       | O.Decoded _ ->
+           Alcotest.fail "did not expect Decoded when externalize=0"
+       | O.Invalid_marker { detail } ->
+           Alcotest.failf
+             "did not expect Invalid_marker when externalize=0: %s" detail)
   | Error _ -> Alcotest.fail "expected Ok"
 
 let test_execution_env_preserves_exact_invocation () =
@@ -248,10 +253,14 @@ let test_externalize_with_temp_base_path () =
       let result = B.maybe_externalize payload in
       Alcotest.(check bool) "encoded as marker" true (O.is_marker result);
       match O.decode_from_oas result with
-      | O.Stored { sha256; bytes; _ } ->
+      | O.Decoded { sha256; bytes; _ } ->
         Alcotest.(check int) "byte count" (String.length payload) bytes;
         Alcotest.(check int) "sha length" 64 (String.length sha256)
-      | O.Inline _ -> Alcotest.fail "expected Stored after externalize")
+      | O.Not_marker -> Alcotest.fail "expected Decoded after externalize"
+      | O.Invalid_marker { detail } ->
+          Alcotest.failf
+            "expected Decoded after externalize, got Invalid_marker: %s"
+            detail)
 
 let test_blob_store_failure_preserves_original_bytes () =
   let path = Filename.temp_file "masc_bridge_not_a_directory" "" in

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -87,11 +87,13 @@ let test_full_flow_externalize_hydrate_serve () =
 
       (* Step 4: Marker round-trips through Tool_output.decode. *)
       (match O.decode_from_oas marker with
-       | O.Stored { sha256 = decoded_sha; bytes; preview = _; mime } ->
+       | O.Decoded { sha256 = decoded_sha; bytes; preview = _; mime } ->
            Alcotest.(check string) "decoded sha matches" sha256 decoded_sha;
            Alcotest.(check int) "decoded bytes" (String.length payload) bytes;
            Alcotest.(check string) "decoded mime" "text/plain" mime
-       | O.Inline _ -> Alcotest.fail "decode lost the Stored variant");
+       | O.Not_marker -> Alcotest.fail "decode lost the marker"
+       | O.Invalid_marker { detail } ->
+           Alcotest.failf "decode reported Invalid_marker: %s" detail);
 
       (* Step 5: Build a message list with the marker as a ToolResult.
          The hydrator should re-inflate it because keep_recent >= 1. *)


### PR DESCRIPTION
## 무엇을 바꾸나

issue #25096의 첫 리프. 외부화된 tool payload 주변의 stringly 마커 기계를 검증된 total codec으로 교체한다. **와이어 포맷은 그대로** — durable keeper 히스토리와 대시보드 inspector가 파싱하는 `[masc:blob sha256=… bytes=… mime=… preview=…]` 형태 유지(dashboard TS 계약 보존).

**핵심 변경**:
1. `Tool_output.artifact_ref`를 private typed ref로 — 생성은 `make_artifact_ref`뿐(유효 sha256, bytes >= 0, 비어있지 않은 mime). `Tool_blob_store.put` 및 hydrator/redact/log 경로가 전부 검증된 ref를 소비
2. sha256 검증 SSOT를 `Tool_output`으로 이동, `Tool_blob_store`는 re-export(표면 동일)
3. `decode_from_oas`가 exact해짐: `Not_marker | Decoded | Invalid_marker {detail}`. 이전에는 Scanf 실패가 **silent Inline fallback** — 깨진 마커가 LLM에게 그럴듯한 inline 텍스트로 둔갑하는 silent failure 클래스. 이제 hydrator는 블록을 유지하며 warn하고, evidence projection은 원문을 보존한다
4. decode variant를 `Decoded`로 명명 — `Tool_output.t`의 `Stored`와의 생성자 ambiguity 제거

**의도적 비포함** (후속 리프): 라우팅 자체(threshold/env)와 provenance 스레딩. 이 codec 위에 쌓인다.

## 검증

- focused build: `lib/tool_blob_store` `lib/keeper` `lib/masc.cma` 통과
- 6개 스위트 93개 테스트 전부 통과: tool_blob_store 19, tool_bridge_externalize 13, observability_redact 17, keeper_artifact_hydrator 8, tool_output_washing_e2e 3, keeper_tool_call_log 33
- 의도된 assertion 변경 2건(코멘트로 표시): malformed marker의 silent Inline 기대 → `Invalid_marker` visible 기대 / round-trip 테스트의 sha를 유효 64-hex로(신규 검증 반영)
- ocamlformat 무해, DET/NDT 게이트 로컬 PASS

## 관련

- issue #25096, goal matrix G7(typed Artifact projection), 선행 #25097(64KiB cap 제거, 머지됨)