### PR TITLE
feat(schedule): typed VEVENT recurrence identity (iCalendar leaf 3)

### DIFF
--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -13,6 +13,7 @@
   schedule_occurrence_id
   schedule_ical_recur
   schedule_ical_content_line
+  schedule_ical_vevent
   schedule_supported_kinds
   schedule_store
   schedule_service

--- a/lib/schedule/schedule_ical_recur.ml
+++ b/lib/schedule/schedule_ical_recur.ml
@@ -132,6 +132,9 @@ let parse_time_of_day raw =
   end
   else Error (Invalid_time raw)
 
+let parse_date_value = parse_date
+let parse_time_of_day_value = parse_time_of_day
+
 let parse_until raw =
   let n = String.length raw in
   if n = 8 then

--- a/lib/schedule/schedule_ical_recur.mli
+++ b/lib/schedule/schedule_ical_recur.mli
@@ -110,5 +110,14 @@ val to_string : t -> string
 
 val parse_error_to_string : parse_error -> string
 
+val parse_date_value : string -> (date, parse_error) result
+(** Parse and validate an RFC 5545 DATE value ([YYYYMMDD]). Exposed for
+    property layers (DTSTART, RECURRENCE-ID, RDATE/EXDATE) that share the
+    same value grammar. *)
+
+val parse_time_of_day_value : string -> (time_of_day, parse_error) result
+(** Parse and validate an RFC 5545 TIME value ([HHMMSS], leap second
+    admitted). *)
+
 val freq_to_string : freq -> string
 val weekday_to_string : weekday -> string

--- a/lib/schedule/schedule_ical_vevent.ml
+++ b/lib/schedule/schedule_ical_vevent.ml
@@ -1,0 +1,262 @@
+(* See .mli for the contract. RFC 5545 VEVENT recurrence identity. *)
+
+module Content_line = Schedule_ical_content_line
+module Recur = Schedule_ical_recur
+
+type tzid = string
+
+type dtstart =
+  | Start_date of Recur.date
+  | Start_local of Recur.date * Recur.time_of_day
+  | Start_utc of Recur.date * Recur.time_of_day
+  | Start_tzid of tzid * Recur.date * Recur.time_of_day
+
+type range =
+  | This_and_prior
+  | This_and_future
+
+type recurrence_id =
+  { value : dtstart
+  ; range : range
+  }
+
+type t =
+  { uid : string
+  ; dtstart : dtstart
+  ; recurrence_id : recurrence_id option
+  ; rrule : Recur.t option
+  }
+
+type parse_error =
+  | Missing_uid
+  | Duplicate_uid
+  | Empty_uid
+  | Missing_dtstart
+  | Duplicate_dtstart
+  | Invalid_dtstart of { value : string; detail : string }
+  | Duplicate_recurrence_id
+  | Invalid_recurrence_id of { value : string; detail : string }
+  | Recurrence_id_value_mismatch
+  | Invalid_range of string
+  | Duplicate_rrule
+  | Rrule_error of Recur.parse_error
+  | Until_dtstart_mismatch of { dtstart_form : string; until_form : string }
+
+let parse_error_to_string = function
+  | Missing_uid -> "VEVENT recurrence identity requires UID"
+  | Duplicate_uid -> "UID occurs more than once"
+  | Empty_uid -> "UID must be non-empty"
+  | Missing_dtstart -> "VEVENT recurrence identity requires DTSTART"
+  | Duplicate_dtstart -> "DTSTART occurs more than once"
+  | Invalid_dtstart { value; detail } ->
+    Printf.sprintf "invalid DTSTART value %S: %s" value detail
+  | Duplicate_recurrence_id -> "RECURRENCE-ID occurs more than once"
+  | Invalid_recurrence_id { value; detail } ->
+    Printf.sprintf "invalid RECURRENCE-ID value %S: %s" value detail
+  | Recurrence_id_value_mismatch ->
+    "RECURRENCE-ID value form must match DTSTART's"
+  | Invalid_range raw -> Printf.sprintf "invalid RANGE value %S" raw
+  | Duplicate_rrule -> "RRULE occurs more than once"
+  | Rrule_error err ->
+    Printf.sprintf "RRULE rejected: %s" (Recur.parse_error_to_string err)
+  | Until_dtstart_mismatch { dtstart_form; until_form } ->
+    Printf.sprintf
+      "UNTIL value form %S does not agree with DTSTART value form %S"
+      until_form dtstart_form
+
+(* ---------------------------------------------------------------- *)
+(* Value parsing                                                    *)
+(* ---------------------------------------------------------------- *)
+
+let make_tzid raw =
+  let trimmed = String.trim raw in
+  if String.equal trimmed "" then None else Some trimmed
+
+(* Single-valued parameters only; a multi-valued TZID/VALUE is malformed,
+   not absent. *)
+let single_param name (line : Content_line.t) =
+  match Content_line.find_param ~name line.Content_line.params with
+  | None -> Ok None
+  | Some { Content_line.values = [ raw ]; _ } -> Ok (Some raw)
+  | Some _ -> Error (Printf.sprintf "%s parameter has multiple values" name)
+
+(* A DATE-TIME value: YYYYMMDDTHHMMSS with an optional trailing Z. *)
+let parse_datetime raw =
+  let n = String.length raw in
+  if n = 15 && raw.[8] = 'T' then (
+    match
+      ( Recur.parse_date_value (String.sub raw 0 8)
+      , Recur.parse_time_of_day_value (String.sub raw 9 6) )
+    with
+    | Ok d, Ok t -> Ok (`Local (d, t))
+    | _ -> Error "expected YYYYMMDDTHHMMSS")
+  else if n = 16 && raw.[8] = 'T' && raw.[15] = 'Z' then (
+    match
+      ( Recur.parse_date_value (String.sub raw 0 8)
+      , Recur.parse_time_of_day_value (String.sub raw 9 6) )
+    with
+    | Ok d, Ok t -> Ok (`Utc (d, t))
+    | _ -> Error "expected YYYYMMDDTHHMMSSZ")
+  else Error "expected YYYYMMDDTHHMMSS[Z]"
+
+let parse_dtstart_like (line : Content_line.t) =
+  let value = line.Content_line.value in
+  let invalid detail = Error (value, detail) in
+  match single_param "VALUE" line with
+  | Error detail -> invalid detail
+  | Ok (Some raw_value) when not (String.equal (String.uppercase_ascii raw_value) "DATE") ->
+    invalid (Printf.sprintf "unsupported VALUE=%s" raw_value)
+  | Ok (Some _) -> (
+    match Recur.parse_date_value value with
+    | Ok d -> Ok (Start_date d)
+    | Error err -> invalid (Recur.parse_error_to_string err))
+  | Ok None -> (
+    match parse_datetime value with
+    | Error detail -> invalid detail
+    | Ok (`Utc (d, t)) -> (
+      match single_param "TZID" line with
+      | Error detail -> invalid detail
+      | Ok (Some _) -> invalid "TZID parameter on a UTC value"
+      | Ok None -> Ok (Start_utc (d, t)))
+    | Ok (`Local (d, t)) -> (
+      match single_param "TZID" line with
+      | Error detail -> invalid detail
+      | Ok (Some raw) -> (
+        match make_tzid raw with
+        | Some tzid -> Ok (Start_tzid (tzid, d, t))
+        | None -> invalid "TZID parameter is empty")
+      | Ok None -> Ok (Start_local (d, t))))
+
+let parse_range (line : Content_line.t) =
+  match Content_line.find_param ~name:"RANGE" line.Content_line.params with
+  | None -> Ok This_and_prior
+  | Some { Content_line.values = [ raw ]; _ } -> (
+    match String.uppercase_ascii raw with
+    | "THISANDPRIOR" -> Ok This_and_prior
+    | "THISANDFUTURE" -> Ok This_and_future
+    | other -> Error other)
+  | Some _ -> Error "multiple RANGE values"
+
+let same_form a b =
+  match a, b with
+  | Start_date _, Start_date _ -> true
+  | Start_local _, Start_local _ -> true
+  | Start_utc _, Start_utc _ -> true
+  | Start_tzid (tz_a, _, _), Start_tzid (tz_b, _, _) -> String.equal tz_a tz_b
+  | _ -> false
+
+let form_label = function
+  | Start_date _ -> "date"
+  | Start_local _ -> "local"
+  | Start_utc _ -> "utc"
+  | Start_tzid _ -> "tzid"
+
+let until_form_label (until : Recur.until) =
+  match until with
+  | Recur.Until_date _ -> "date"
+  | Recur.Until_local _ -> "local"
+  | Recur.Until_utc _ -> "utc"
+
+(* §3.3.10: UNTIL agrees with DTSTART — DATE with DATE, floating local with
+   local, UTC or TZID-referenced DTSTART with UTC. *)
+let until_agrees ~dtstart (until : Recur.until) =
+  match dtstart, until with
+  | Start_date _, Recur.Until_date _ -> true
+  | Start_local _, Recur.Until_local _ -> true
+  | Start_utc _, Recur.Until_utc _ -> true
+  | Start_tzid _, Recur.Until_utc _ -> true
+  | _ -> false
+
+(* ---------------------------------------------------------------- *)
+(* Assembly                                                         *)
+(* ---------------------------------------------------------------- *)
+
+type builder =
+  { b_uid : string option
+  ; b_dtstart : dtstart option
+  ; b_recurrence_id : recurrence_id option
+  ; b_rrule : Recur.t option
+  }
+
+let empty = { b_uid = None; b_dtstart = None; b_recurrence_id = None; b_rrule = None }
+
+let apply (line : Content_line.t) b =
+  match line.Content_line.name with
+  | "UID" -> (
+    match b.b_uid with
+    | Some _ -> Error Duplicate_uid
+    | None ->
+      let uid = String.trim line.Content_line.value in
+      if String.equal uid "" then Error Empty_uid
+      else Ok { b with b_uid = Some uid })
+  | "DTSTART" -> (
+    match b.b_dtstart with
+    | Some _ -> Error Duplicate_dtstart
+    | None -> (
+      match parse_dtstart_like line with
+      | Error (value, detail) -> Error (Invalid_dtstart { value; detail })
+      | Ok dtstart -> Ok { b with b_dtstart = Some dtstart }))
+  | "RECURRENCE-ID" -> (
+    match b.b_recurrence_id with
+    | Some _ -> Error Duplicate_recurrence_id
+    | None -> (
+      match parse_dtstart_like line with
+      | Error (value, detail) ->
+        Error (Invalid_recurrence_id { value; detail })
+      | Ok value -> (
+        match parse_range line with
+        | Error raw -> Error (Invalid_range raw)
+        | Ok range ->
+          Ok { b with b_recurrence_id = Some { value; range } })))
+  | "RRULE" -> (
+    match b.b_rrule with
+    | Some _ -> Error Duplicate_rrule
+    | None -> (
+      match Recur.parse line.Content_line.value with
+      | Error err -> Error (Rrule_error err)
+      | Ok rrule -> Ok { b with b_rrule = Some rrule }))
+  | _ -> Ok b
+
+let parse lines =
+  let rec loop b = function
+    | [] -> (
+      match b.b_uid with
+      | None -> Error Missing_uid
+      | Some uid -> (
+        match b.b_dtstart with
+        | None -> Error Missing_dtstart
+        | Some dtstart -> (
+          match b.b_recurrence_id with
+          | Some rid when not (same_form rid.value dtstart) ->
+            Error Recurrence_id_value_mismatch
+          | _ -> (
+            match b.b_rrule with
+            | Some rrule -> (
+              match rrule.Recur.bound with
+              | Recur.Until until
+                when not (until_agrees ~dtstart until) ->
+                Error
+                  (Until_dtstart_mismatch
+                     { dtstart_form = form_label dtstart
+                     ; until_form = until_form_label until
+                     })
+              | _ ->
+                Ok
+                  { uid
+                  ; dtstart
+                  ; recurrence_id = b.b_recurrence_id
+                  ; rrule = Some rrule
+                  })
+            | None ->
+              Ok
+                { uid
+                ; dtstart
+                ; recurrence_id = b.b_recurrence_id
+                ; rrule = None
+                }))))
+    | line :: rest -> (
+      match apply line b with
+      | Error _ as error -> error
+      | Ok b -> loop b rest)
+  in
+  loop empty lines

--- a/lib/schedule/schedule_ical_vevent.ml
+++ b/lib/schedule/schedule_ical_vevent.ml
@@ -12,13 +12,22 @@ type dtstart =
   | Start_tzid of tzid * Recur.date * Recur.time_of_day
 
 type range =
-  | This_and_prior
   | This_and_future
 
 type recurrence_id =
   { value : dtstart
-  ; range : range
+  ; range : range option
   }
+
+type parameter_error =
+  | Duplicate_parameter of
+      { property : string
+      ; parameter : string
+      }
+  | Multiple_parameter_values of
+      { property : string
+      ; parameter : string
+      }
 
 type t =
   { uid : string
@@ -38,6 +47,7 @@ type parse_error =
   | Invalid_recurrence_id of { value : string; detail : string }
   | Recurrence_id_value_mismatch
   | Invalid_range of string
+  | Parameter_error of parameter_error
   | Duplicate_rrule
   | Rrule_error of Recur.parse_error
   | Until_dtstart_mismatch of { dtstart_form : string; until_form : string }
@@ -56,6 +66,10 @@ let parse_error_to_string = function
   | Recurrence_id_value_mismatch ->
     "RECURRENCE-ID value form must match DTSTART's"
   | Invalid_range raw -> Printf.sprintf "invalid RANGE value %S" raw
+  | Parameter_error (Duplicate_parameter { property; parameter }) ->
+    Printf.sprintf "%s repeats parameter %s" property parameter
+  | Parameter_error (Multiple_parameter_values { property; parameter }) ->
+    Printf.sprintf "%s parameter %s must have exactly one value" property parameter
   | Duplicate_rrule -> "RRULE occurs more than once"
   | Rrule_error err ->
     Printf.sprintf "RRULE rejected: %s" (Recur.parse_error_to_string err)
@@ -69,16 +83,20 @@ let parse_error_to_string = function
 (* ---------------------------------------------------------------- *)
 
 let make_tzid raw =
-  let trimmed = String.trim raw in
-  if String.equal trimmed "" then None else Some trimmed
+  if String.equal raw "" then None else Some raw
 
 (* Single-valued parameters only; a multi-valued TZID/VALUE is malformed,
    not absent. *)
-let single_param name (line : Content_line.t) =
-  match Content_line.find_param ~name line.Content_line.params with
-  | None -> Ok None
-  | Some { Content_line.values = [ raw ]; _ } -> Ok (Some raw)
-  | Some _ -> Error (Printf.sprintf "%s parameter has multiple values" name)
+let single_param ~property name (line : Content_line.t) =
+  match Content_line.find_unique_param ~name line.Content_line.params with
+  | Error (Content_line.Duplicate_parameter parameter) ->
+    Error (Parameter_error (Duplicate_parameter { property; parameter }))
+  | Ok None -> Ok None
+  | Ok (Some { Content_line.values = [ raw ]; _ }) -> Ok (Some raw)
+  | Ok (Some _) ->
+    Error
+      (Parameter_error
+         (Multiple_parameter_values { property; parameter = name }))
 
 (* A DATE-TIME value: YYYYMMDDTHHMMSS with an optional trailing Z. *)
 let parse_datetime raw =
@@ -99,43 +117,44 @@ let parse_datetime raw =
     | _ -> Error "expected YYYYMMDDTHHMMSSZ")
   else Error "expected YYYYMMDDTHHMMSS[Z]"
 
-let parse_dtstart_like (line : Content_line.t) =
+let parse_dtstart_like ~property ~invalid (line : Content_line.t) =
+  let ( let* ) = Result.bind in
   let value = line.Content_line.value in
-  let invalid detail = Error (value, detail) in
-  match single_param "VALUE" line with
-  | Error detail -> invalid detail
-  | Ok (Some raw_value) when not (String.equal (String.uppercase_ascii raw_value) "DATE") ->
-    invalid (Printf.sprintf "unsupported VALUE=%s" raw_value)
-  | Ok (Some _) -> (
+  let reject detail = Error (invalid ~value ~detail) in
+  let* value_parameter = single_param ~property "VALUE" line in
+  let* tzid_parameter = single_param ~property "TZID" line in
+  match Option.map String.uppercase_ascii value_parameter with
+  | Some "DATE" -> (
+    match tzid_parameter with
+    | Some _ -> reject "TZID parameter on a DATE value"
+    | None ->
     match Recur.parse_date_value value with
     | Ok d -> Ok (Start_date d)
-    | Error err -> invalid (Recur.parse_error_to_string err))
-  | Ok None -> (
+    | Error err -> reject (Recur.parse_error_to_string err))
+  | Some "DATE-TIME" | None -> (
     match parse_datetime value with
-    | Error detail -> invalid detail
-    | Ok (`Utc (d, t)) -> (
-      match single_param "TZID" line with
-      | Error detail -> invalid detail
-      | Ok (Some _) -> invalid "TZID parameter on a UTC value"
-      | Ok None -> Ok (Start_utc (d, t)))
-    | Ok (`Local (d, t)) -> (
-      match single_param "TZID" line with
-      | Error detail -> invalid detail
-      | Ok (Some raw) -> (
+    | Error detail -> reject detail
+    | Ok (`Utc (d, t)) ->
+      (match tzid_parameter with
+       | Some _ -> reject "TZID parameter on a UTC value"
+       | None -> Ok (Start_utc (d, t)))
+    | Ok (`Local (d, t)) ->
+      (match tzid_parameter with
+       | Some raw -> (
         match make_tzid raw with
         | Some tzid -> Ok (Start_tzid (tzid, d, t))
-        | None -> invalid "TZID parameter is empty")
-      | Ok None -> Ok (Start_local (d, t))))
+        | None -> reject "TZID parameter is empty")
+       | None -> Ok (Start_local (d, t))))
+  | Some raw_value -> reject (Printf.sprintf "unsupported VALUE=%s" raw_value)
 
 let parse_range (line : Content_line.t) =
-  match Content_line.find_param ~name:"RANGE" line.Content_line.params with
-  | None -> Ok This_and_prior
-  | Some { Content_line.values = [ raw ]; _ } -> (
-    match String.uppercase_ascii raw with
-    | "THISANDPRIOR" -> Ok This_and_prior
-    | "THISANDFUTURE" -> Ok This_and_future
-    | other -> Error other)
-  | Some _ -> Error "multiple RANGE values"
+  match single_param ~property:"RECURRENCE-ID" "RANGE" line with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some raw) ->
+    if String.equal (String.uppercase_ascii raw) "THISANDFUTURE" then
+      Ok (Some This_and_future)
+    else Error (Invalid_range raw)
 
 let same_form a b =
   match a, b with
@@ -186,26 +205,35 @@ let apply (line : Content_line.t) b =
     match b.b_uid with
     | Some _ -> Error Duplicate_uid
     | None ->
-      let uid = String.trim line.Content_line.value in
+      let uid = line.Content_line.value in
       if String.equal uid "" then Error Empty_uid
       else Ok { b with b_uid = Some uid })
   | "DTSTART" -> (
     match b.b_dtstart with
     | Some _ -> Error Duplicate_dtstart
     | None -> (
-      match parse_dtstart_like line with
-      | Error (value, detail) -> Error (Invalid_dtstart { value; detail })
+      match
+        parse_dtstart_like
+          ~property:"DTSTART"
+          ~invalid:(fun ~value ~detail -> Invalid_dtstart { value; detail })
+          line
+      with
+      | Error _ as error -> error
       | Ok dtstart -> Ok { b with b_dtstart = Some dtstart }))
   | "RECURRENCE-ID" -> (
     match b.b_recurrence_id with
     | Some _ -> Error Duplicate_recurrence_id
     | None -> (
-      match parse_dtstart_like line with
-      | Error (value, detail) ->
-        Error (Invalid_recurrence_id { value; detail })
+      match
+        parse_dtstart_like
+          ~property:"RECURRENCE-ID"
+          ~invalid:(fun ~value ~detail -> Invalid_recurrence_id { value; detail })
+          line
+      with
+      | Error _ as error -> error
       | Ok value -> (
         match parse_range line with
-        | Error raw -> Error (Invalid_range raw)
+        | Error _ as error -> error
         | Ok range ->
           Ok { b with b_recurrence_id = Some { value; range } })))
   | "RRULE" -> (

--- a/lib/schedule/schedule_ical_vevent.ml
+++ b/lib/schedule/schedule_ical_vevent.ml
@@ -139,14 +139,18 @@ let single_param ~property name (line : Content_line.t) =
 (* A DATE-TIME value: YYYYMMDDTHHMMSS with an optional trailing Z. *)
 let parse_datetime raw =
   let n = String.length raw in
-  if n = 15 && raw.[8] = 'T' then (
+  if n = 15 && Char.uppercase_ascii raw.[8] = 'T' then (
     match
       ( Recur.parse_date_value (String.sub raw 0 8)
       , Recur.parse_time_of_day_value (String.sub raw 9 6) )
     with
     | Ok d, Ok t -> Ok (`Local (d, t))
     | _ -> Error "expected YYYYMMDDTHHMMSS")
-  else if n = 16 && raw.[8] = 'T' && raw.[15] = 'Z' then (
+  else if
+    n = 16
+    && Char.uppercase_ascii raw.[8] = 'T'
+    && Char.uppercase_ascii raw.[15] = 'Z'
+  then (
     match
       ( Recur.parse_date_value (String.sub raw 0 8)
       , Recur.parse_time_of_day_value (String.sub raw 9 6) )
@@ -242,13 +246,20 @@ let apply (line : Content_line.t) b =
   | "UID" -> (
     match b.b_uid with
     | Some _ -> Error Duplicate_uid
-    | None ->
+    | None -> (
       let value = line.Content_line.value in
       if String.equal value "" then Error Empty_uid
-      else (
-        match decode_text value with
-        | Ok uid -> Ok { b with b_uid = Some uid }
-        | Error detail -> Error (Invalid_uid { value; detail })))
+      else
+        match single_param ~property:"UID" "VALUE" line with
+        | Error _ as error -> error
+        | Ok (Some raw) when not (String.equal (String.uppercase_ascii raw) "TEXT") ->
+          Error
+            (Invalid_uid
+               { value; detail = Printf.sprintf "unsupported VALUE=%s" raw })
+        | Ok None | Ok (Some _) -> (
+          match decode_text value with
+          | Ok uid -> Ok { b with b_uid = Some uid }
+          | Error detail -> Error (Invalid_uid { value; detail }))))
   | "DTSTART" -> (
     match b.b_dtstart with
     | Some _ -> Error Duplicate_dtstart

--- a/lib/schedule/schedule_ical_vevent.ml
+++ b/lib/schedule/schedule_ical_vevent.ml
@@ -40,6 +40,7 @@ type parse_error =
   | Missing_uid
   | Duplicate_uid
   | Empty_uid
+  | Invalid_uid of { value : string; detail : string }
   | Missing_dtstart
   | Duplicate_dtstart
   | Invalid_dtstart of { value : string; detail : string }
@@ -56,6 +57,8 @@ let parse_error_to_string = function
   | Missing_uid -> "VEVENT recurrence identity requires UID"
   | Duplicate_uid -> "UID occurs more than once"
   | Empty_uid -> "UID must be non-empty"
+  | Invalid_uid { value; detail } ->
+    Printf.sprintf "invalid UID value %S: %s" value detail
   | Missing_dtstart -> "VEVENT recurrence identity requires DTSTART"
   | Duplicate_dtstart -> "DTSTART occurs more than once"
   | Invalid_dtstart { value; detail } ->
@@ -84,6 +87,41 @@ let parse_error_to_string = function
 
 let make_tzid raw =
   if String.equal raw "" then None else Some raw
+
+(* RFC 5545 section 3.3.11 TEXT decoding. The content-line layer preserves
+   raw property values; property leaves own value-type decoding. *)
+let decode_text raw =
+  let length = String.length raw in
+  let decoded = Buffer.create length in
+  let rec loop index =
+    if index = length then Ok (Buffer.contents decoded)
+    else
+      match raw.[index] with
+      | ',' -> Error "COMMA must be escaped in a TEXT value"
+      | ';' -> Error "SEMICOLON must be escaped in a TEXT value"
+      | '\\' ->
+        if index + 1 = length then Error "trailing BACKSLASH in a TEXT value"
+        else (
+          match raw.[index + 1] with
+          | '\\' ->
+            Buffer.add_char decoded '\\';
+            loop (index + 2)
+          | ';' ->
+            Buffer.add_char decoded ';';
+            loop (index + 2)
+          | ',' ->
+            Buffer.add_char decoded ',';
+            loop (index + 2)
+          | 'N' | 'n' ->
+            Buffer.add_char decoded '\n';
+            loop (index + 2)
+          | escaped ->
+            Error (Printf.sprintf "invalid TEXT escape \\%c" escaped))
+      | char ->
+        Buffer.add_char decoded char;
+        loop (index + 1)
+  in
+  loop 0
 
 (* Single-valued parameters only; a multi-valued TZID/VALUE is malformed,
    not absent. *)
@@ -205,9 +243,12 @@ let apply (line : Content_line.t) b =
     match b.b_uid with
     | Some _ -> Error Duplicate_uid
     | None ->
-      let uid = line.Content_line.value in
-      if String.equal uid "" then Error Empty_uid
-      else Ok { b with b_uid = Some uid })
+      let value = line.Content_line.value in
+      if String.equal value "" then Error Empty_uid
+      else (
+        match decode_text value with
+        | Ok uid -> Ok { b with b_uid = Some uid }
+        | Error detail -> Error (Invalid_uid { value; detail })))
   | "DTSTART" -> (
     match b.b_dtstart with
     | Some _ -> Error Duplicate_dtstart
@@ -224,17 +265,18 @@ let apply (line : Content_line.t) b =
     match b.b_recurrence_id with
     | Some _ -> Error Duplicate_recurrence_id
     | None -> (
-      match
-        parse_dtstart_like
-          ~property:"RECURRENCE-ID"
-          ~invalid:(fun ~value ~detail -> Invalid_recurrence_id { value; detail })
-          line
-      with
+      match parse_range line with
       | Error _ as error -> error
-      | Ok value -> (
-        match parse_range line with
+      | Ok range -> (
+        match
+          parse_dtstart_like
+            ~property:"RECURRENCE-ID"
+            ~invalid:(fun ~value ~detail ->
+              Invalid_recurrence_id { value; detail })
+            line
+        with
         | Error _ as error -> error
-        | Ok range ->
+        | Ok value ->
           Ok { b with b_recurrence_id = Some { value; range } })))
   | "RRULE" -> (
     match b.b_rrule with

--- a/lib/schedule/schedule_ical_vevent.mli
+++ b/lib/schedule/schedule_ical_vevent.mli
@@ -8,14 +8,17 @@
 
     Enforced cross-property rules (typed errors, no silent coercion):
     - [UID] exactly once, non-empty (§3.8.4.7).
-    - [DTSTART] exactly once (§3.8.2.4: REQUIRED for VEVENT).
+    - This recurrence-identity projection requires [DTSTART] exactly once.
+      Full VEVENT validation of §3.8.2.4's outer [METHOD]-dependent optionality
+      is outside this leaf because it does not receive the VCALENDAR envelope.
     - [RECURRENCE-ID] at most once; its value form must match [DTSTART]'s
       (§3.8.4.4), including the TZID reference when present.
     - [RRULE] at most once (§3.8.5.3); when it carries [UNTIL], the UNTIL
       value form must agree with [DTSTART] per §3.3.10: DATE with DATE,
       floating local with local, UTC or TZID-referenced DTSTART with UTC.
-    - [RANGE] on [RECURRENCE-ID] is typed ([THISANDPRIOR] default,
-      [THISANDFUTURE]); anything else is rejected.
+    - [RANGE] on [RECURRENCE-ID] is absent for one exact recurrence or is the
+      RFC-defined [THISANDFUTURE] value; [THISANDPRIOR] and every other value
+      are rejected.
 
     TZID is carried as a validated opaque identifier; timezone resolution
     (VTIMEZONE/IANA) is a later leaf. *)
@@ -32,13 +35,22 @@ type dtstart =
   | Start_tzid of tzid * Recur.date * Recur.time_of_day
 
 type range =
-  | This_and_prior  (** RFC default. *)
   | This_and_future
 
 type recurrence_id = private
   { value : dtstart
-  ; range : range
+  ; range : range option
   }
+
+type parameter_error =
+  | Duplicate_parameter of
+      { property : string
+      ; parameter : string
+      }
+  | Multiple_parameter_values of
+      { property : string
+      ; parameter : string
+      }
 
 type t = private
   { uid : string
@@ -58,6 +70,7 @@ type parse_error =
   | Invalid_recurrence_id of { value : string; detail : string }
   | Recurrence_id_value_mismatch
   | Invalid_range of string
+  | Parameter_error of parameter_error
   | Duplicate_rrule
   | Rrule_error of Recur.parse_error
   | Until_dtstart_mismatch of { dtstart_form : string; until_form : string }

--- a/lib/schedule/schedule_ical_vevent.mli
+++ b/lib/schedule/schedule_ical_vevent.mli
@@ -1,0 +1,68 @@
+(** Schedule_ical_vevent — RFC 5545 VEVENT recurrence identity (leaf 3).
+
+    Projects the recurrence-identity properties of one VEVENT — [UID],
+    [DTSTART], [RECURRENCE-ID], [RRULE] — from already-parsed content lines
+    ({!Schedule_ical_content_line.t}) into one typed value. Pure and total.
+    Non-identity properties ([SUMMARY], [DTEND], x-props, ...) are ignored:
+    this module projects identity, not the whole component.
+
+    Enforced cross-property rules (typed errors, no silent coercion):
+    - [UID] exactly once, non-empty (§3.8.4.7).
+    - [DTSTART] exactly once (§3.8.2.4: REQUIRED for VEVENT).
+    - [RECURRENCE-ID] at most once; its value form must match [DTSTART]'s
+      (§3.8.4.4), including the TZID reference when present.
+    - [RRULE] at most once (§3.8.5.3); when it carries [UNTIL], the UNTIL
+      value form must agree with [DTSTART] per §3.3.10: DATE with DATE,
+      floating local with local, UTC or TZID-referenced DTSTART with UTC.
+    - [RANGE] on [RECURRENCE-ID] is typed ([THISANDPRIOR] default,
+      [THISANDFUTURE]); anything else is rejected.
+
+    TZID is carried as a validated opaque identifier; timezone resolution
+    (VTIMEZONE/IANA) is a later leaf. *)
+
+module Content_line = Schedule_ical_content_line
+module Recur = Schedule_ical_recur
+
+type tzid = private string
+
+type dtstart =
+  | Start_date of Recur.date
+  | Start_local of Recur.date * Recur.time_of_day
+  | Start_utc of Recur.date * Recur.time_of_day
+  | Start_tzid of tzid * Recur.date * Recur.time_of_day
+
+type range =
+  | This_and_prior  (** RFC default. *)
+  | This_and_future
+
+type recurrence_id = private
+  { value : dtstart
+  ; range : range
+  }
+
+type t = private
+  { uid : string
+  ; dtstart : dtstart
+  ; recurrence_id : recurrence_id option
+  ; rrule : Recur.t option
+  }
+
+type parse_error =
+  | Missing_uid
+  | Duplicate_uid
+  | Empty_uid
+  | Missing_dtstart
+  | Duplicate_dtstart
+  | Invalid_dtstart of { value : string; detail : string }
+  | Duplicate_recurrence_id
+  | Invalid_recurrence_id of { value : string; detail : string }
+  | Recurrence_id_value_mismatch
+  | Invalid_range of string
+  | Duplicate_rrule
+  | Rrule_error of Recur.parse_error
+  | Until_dtstart_mismatch of { dtstart_form : string; until_form : string }
+
+val parse : Content_line.t list -> (t, parse_error) result
+(** Project the recurrence identity from one VEVENT's content lines. Total. *)
+
+val parse_error_to_string : parse_error -> string

--- a/lib/schedule/schedule_ical_vevent.mli
+++ b/lib/schedule/schedule_ical_vevent.mli
@@ -7,7 +7,8 @@
     this module projects identity, not the whole component.
 
     Enforced cross-property rules (typed errors, no silent coercion):
-    - [UID] exactly once, non-empty (§3.8.4.7).
+    - [UID] exactly once, non-empty, and decoded from its RFC [TEXT] wire
+      representation without trimming (§3.3.11, §3.8.4.7).
     - This recurrence-identity projection requires [DTSTART] exactly once.
       Full VEVENT validation of §3.8.2.4's outer [METHOD]-dependent optionality
       is outside this leaf because it does not receive the VCALENDAR envelope.
@@ -63,6 +64,7 @@ type parse_error =
   | Missing_uid
   | Duplicate_uid
   | Empty_uid
+  | Invalid_uid of { value : string; detail : string }
   | Missing_dtstart
   | Duplicate_dtstart
   | Invalid_dtstart of { value : string; detail : string }

--- a/test/dune
+++ b/test/dune
@@ -1316,6 +1316,11 @@
  (libraries alcotest masc_schedule))
 
 (test
+ (name test_schedule_ical_vevent)
+ (modules test_schedule_ical_vevent)
+ (libraries alcotest masc_schedule))
+
+(test
  (name test_schedule_store)
  (modules test_schedule_store)
  (libraries

--- a/test/test_schedule_ical_vevent.ml
+++ b/test/test_schedule_ical_vevent.ml
@@ -117,6 +117,15 @@ let test_uid_identity_is_exact () =
   let t = parse_ok [ "UID:  event-identity  "; "DTSTART:19980118T230000Z" ] in
   check string "uid bytes" "  event-identity  " t.V.uid
 
+let test_uid_text_decoding () =
+  let t =
+    parse_ok
+      [ "UID:event\\,one\\;line\\\\tail\\nnext"
+      ; "DTSTART:19980118T230000Z"
+      ]
+  in
+  check string "decoded uid" "event,one;line\\tail\nnext" t.V.uid
+
 let test_tzid_identity_is_exact () =
   let t =
     parse_ok
@@ -151,6 +160,16 @@ let test_empty_uid () =
   match parse_error [ "UID:"; "DTSTART:19980118T230000Z" ] with
   | Error V.Empty_uid -> ()
   | _ -> fail "expected Empty_uid"
+
+let test_invalid_uid_text () =
+  let invalid_values = [ "event,one"; "event;one"; "event\\x"; "event\\" ] in
+  List.iter
+    (fun value ->
+       match parse_error [ "UID:" ^ value; "DTSTART:19980118T230000Z" ] with
+       | Error (V.Invalid_uid { value = actual; _ }) ->
+         check string "wire value" value actual
+       | _ -> failf "invalid UID TEXT %S was accepted" value)
+    invalid_values
 
 let test_duplicate_uid () =
   match
@@ -205,7 +224,7 @@ let test_duplicate_parameters_rejected () =
       , "TZID" )
     ; ( [ "UID:e1"
         ; "DTSTART:19980118T230000Z"
-        ; "RECURRENCE-ID;RANGE=THISANDFUTURE;RANGE=THISANDFUTURE:19980125T230000Z"
+        ; "RECURRENCE-ID;RANGE=THISANDFUTURE;RANGE=THISANDFUTURE:NOT-A-DATE"
         ]
       , "RECURRENCE-ID"
       , "RANGE" )
@@ -339,6 +358,7 @@ let () =
         ; test_case "range thisandfuture" `Quick test_range_this_and_future
         ; test_case "explicit date-time value" `Quick test_explicit_date_time_value
         ; test_case "uid identity exact" `Quick test_uid_identity_is_exact
+        ; test_case "uid text decoding" `Quick test_uid_text_decoding
         ; test_case "tzid identity exact" `Quick test_tzid_identity_is_exact
         ; test_case "other properties ignored" `Quick
             test_ignored_other_properties
@@ -346,6 +366,7 @@ let () =
     ; "rejections"
       , [ test_case "missing uid" `Quick test_missing_uid
         ; test_case "empty uid" `Quick test_empty_uid
+        ; test_case "invalid uid text" `Quick test_invalid_uid_text
         ; test_case "duplicate uid" `Quick test_duplicate_uid
         ; test_case "missing dtstart" `Quick test_missing_dtstart
         ; test_case "duplicate dtstart" `Quick test_duplicate_dtstart

--- a/test/test_schedule_ical_vevent.ml
+++ b/test/test_schedule_ical_vevent.ml
@@ -113,6 +113,16 @@ let test_explicit_date_time_value () =
   | V.Start_utc _ -> ()
   | _ -> fail "explicit VALUE=DATE-TIME must be accepted"
 
+let test_datetime_literals_are_case_insensitive () =
+  let t = parse_ok [ "UID:lowercase-literals"; "DTSTART:19980118t230000z" ] in
+  match t.V.dtstart with
+  | V.Start_utc _ -> ()
+  | _ -> fail "lowercase DATE-TIME literals must be accepted"
+
+let test_explicit_uid_text_value () =
+  let t = parse_ok [ "UID;VALUE=TEXT:event-1"; "DTSTART:19980118T230000Z" ] in
+  check string "uid" "event-1" t.V.uid
+
 let test_uid_identity_is_exact () =
   let t = parse_ok [ "UID:  event-identity  "; "DTSTART:19980118T230000Z" ] in
   check string "uid bytes" "  event-identity  " t.V.uid
@@ -171,6 +181,15 @@ let test_invalid_uid_text () =
        | _ -> failf "invalid UID TEXT %S was accepted" value)
     invalid_values
 
+let test_invalid_uid_value_type () =
+  match
+    parse_error
+      [ "UID;VALUE=DATE:20260719"; "DTSTART:19980118T230000Z" ]
+  with
+  | Error (V.Invalid_uid { detail; _ }) ->
+    check string "detail" "unsupported VALUE=DATE" detail
+  | _ -> fail "UID with a non-TEXT value type was accepted"
+
 let test_duplicate_uid () =
   match
     parse_error [ "UID:a"; "UID:b"; "DTSTART:19980118T230000Z" ]
@@ -228,6 +247,11 @@ let test_duplicate_parameters_rejected () =
         ]
       , "RECURRENCE-ID"
       , "RANGE" )
+    ; ( [ "UID;VALUE=TEXT;VALUE=TEXT:e1"
+        ; "DTSTART:19980118T230000Z"
+        ]
+      , "UID"
+      , "VALUE" )
     ]
   in
   List.iter
@@ -243,16 +267,23 @@ let test_duplicate_parameters_rejected () =
     cases
 
 let test_multi_valued_parameter_rejected () =
-  match
-    parse_error
-      [ "UID:e1"; "DTSTART;VALUE=DATE,DATE-TIME:19980118" ]
-  with
-  | Error
-      (V.Parameter_error
-        (V.Multiple_parameter_values
-          { property = "DTSTART"; parameter = "VALUE" })) ->
-    ()
-  | _ -> fail "multi-valued VALUE was not rejected"
+  let cases =
+    [ ( [ "UID:e1"; "DTSTART;VALUE=DATE,DATE-TIME:19980118" ]
+      , "DTSTART" )
+    ; ( [ "UID;VALUE=TEXT,DATE:e1"; "DTSTART:19980118T230000Z" ]
+      , "UID" )
+    ]
+  in
+  List.iter
+    (fun (lines, property) ->
+       match parse_error lines with
+       | Error
+           (V.Parameter_error
+             (V.Multiple_parameter_values
+               { property = actual_property; parameter = "VALUE" })) ->
+         check string "property" property actual_property
+       | _ -> failf "%s multi-valued VALUE was not rejected" property)
+    cases
 
 let test_recurrence_id_form_mismatch () =
   match
@@ -357,6 +388,9 @@ let () =
             test_recurrence_id_matching_form
         ; test_case "range thisandfuture" `Quick test_range_this_and_future
         ; test_case "explicit date-time value" `Quick test_explicit_date_time_value
+        ; test_case "date-time literals case-insensitive" `Quick
+            test_datetime_literals_are_case_insensitive
+        ; test_case "explicit uid text value" `Quick test_explicit_uid_text_value
         ; test_case "uid identity exact" `Quick test_uid_identity_is_exact
         ; test_case "uid text decoding" `Quick test_uid_text_decoding
         ; test_case "tzid identity exact" `Quick test_tzid_identity_is_exact
@@ -367,6 +401,7 @@ let () =
       , [ test_case "missing uid" `Quick test_missing_uid
         ; test_case "empty uid" `Quick test_empty_uid
         ; test_case "invalid uid text" `Quick test_invalid_uid_text
+        ; test_case "invalid uid value type" `Quick test_invalid_uid_value_type
         ; test_case "duplicate uid" `Quick test_duplicate_uid
         ; test_case "missing dtstart" `Quick test_missing_dtstart
         ; test_case "duplicate dtstart" `Quick test_duplicate_dtstart

--- a/test/test_schedule_ical_vevent.ml
+++ b/test/test_schedule_ical_vevent.ml
@@ -1,0 +1,274 @@
+(* RFC 5545 VEVENT recurrence-identity tests for Schedule_ical_vevent. *)
+
+open Alcotest
+module V = Schedule_ical_vevent
+module C = Schedule_ical_content_line
+module R = Schedule_ical_recur
+
+let cl line =
+  match C.parse ~line:1 line with
+  | Ok cl -> cl
+  | Error e -> failf "content line %S rejected: %s" line (C.parse_error_to_string e)
+
+let parse_ok lines =
+  match V.parse (List.map cl lines) with
+  | Ok t -> t
+  | Error e -> failf "vevent rejected: %s" (V.parse_error_to_string e)
+
+let parse_error lines = V.parse (List.map cl lines)
+
+let test_minimal_utc () =
+  let t =
+    parse_ok
+      [ "UID:event-1@example.com"
+      ; "DTSTART:19980118T230000Z"
+      ]
+  in
+  check string "uid" "event-1@example.com" t.V.uid;
+  (match t.V.dtstart with
+   | V.Start_utc (d, tm) ->
+     check bool "date" true (d.R.year = 1998 && d.R.month = 1 && d.R.day = 18);
+     check bool "time" true (tm.R.hour = 23 && tm.R.minute = 0 && tm.R.second = 0)
+   | _ -> fail "expected Start_utc");
+  check bool "no rid" true (t.V.recurrence_id = None);
+  check bool "no rrule" true (t.V.rrule = None)
+
+let test_date_dtstart_with_date_until () =
+  let t =
+    parse_ok
+      [ "UID:e2"
+      ; "DTSTART;VALUE=DATE:19980118"
+      ; "RRULE:FREQ=DAILY;UNTIL=19980201"
+      ]
+  in
+  (match t.V.dtstart with
+   | V.Start_date d ->
+     check bool "date" true (d.R.year = 1998 && d.R.month = 1 && d.R.day = 18)
+   | _ -> fail "expected Start_date");
+  match t.V.rrule with
+  | Some r -> (
+    match r.R.bound with
+    | R.Until (R.Until_date d) ->
+      check bool "until date" true (d.R.month = 2 && d.R.day = 1)
+    | _ -> fail "expected Until_date")
+  | None -> fail "expected rrule"
+
+let test_tzid_dtstart_allows_utc_until () =
+  let t =
+    parse_ok
+      [ "UID:e3"
+      ; "DTSTART;TZID=America/New_York:19980119T020000"
+      ; "RRULE:FREQ=WEEKLY;UNTIL=19980301T000000Z"
+      ]
+  in
+  match t.V.dtstart with
+  | V.Start_tzid (tzid, _, _) ->
+    check string "tzid" "America/New_York" (tzid :> string)
+  | _ -> fail "expected Start_tzid"
+
+let test_local_dtstart_with_local_until () =
+  let _ =
+    parse_ok
+      [ "UID:e4"
+      ; "DTSTART:19980119T020000"
+      ; "RRULE:FREQ=DAILY;UNTIL=19980131T000000"
+      ]
+  in
+  ()
+
+let test_recurrence_id_matching_form () =
+  let t =
+    parse_ok
+      [ "UID:e5"
+      ; "DTSTART:19980118T230000Z"
+      ; "RECURRENCE-ID:19980125T230000Z"
+      ; "RRULE:FREQ=WEEKLY"
+      ]
+  in
+  match t.V.recurrence_id with
+  | Some { V.value = V.Start_utc (d, _); range = V.This_and_prior } ->
+    check bool "rid date" true (d.R.day = 25)
+  | _ -> fail "expected utc recurrence-id with default range"
+
+let test_range_this_and_future () =
+  let t =
+    parse_ok
+      [ "UID:e6"
+      ; "DTSTART:19980118T230000Z"
+      ; "RECURRENCE-ID;RANGE=THISANDFUTURE:19980125T230000Z"
+      ]
+  in
+  match t.V.recurrence_id with
+  | Some { V.range = V.This_and_future; _ } -> ()
+  | _ -> fail "expected THISANDFUTURE"
+
+let test_ignored_other_properties () =
+  let t =
+    parse_ok
+      [ "UID:e7"
+      ; "SUMMARY:Weekly sync"
+      ; "DTSTART:19980118T230000Z"
+      ; "X-CUSTOM:anything"
+      ]
+  in
+  check string "uid" "e7" t.V.uid
+
+(* ---------------------------------------------------------------- *)
+
+let test_missing_uid () =
+  match parse_error [ "DTSTART:19980118T230000Z" ] with
+  | Error V.Missing_uid -> ()
+  | _ -> fail "expected Missing_uid"
+
+let test_empty_uid () =
+  match parse_error [ "UID:  " ; "DTSTART:19980118T230000Z" ] with
+  | Error V.Empty_uid -> ()
+  | _ -> fail "expected Empty_uid"
+
+let test_duplicate_uid () =
+  match
+    parse_error [ "UID:a"; "UID:b"; "DTSTART:19980118T230000Z" ]
+  with
+  | Error V.Duplicate_uid -> ()
+  | _ -> fail "expected Duplicate_uid"
+
+let test_missing_dtstart () =
+  match parse_error [ "UID:e1" ] with
+  | Error V.Missing_dtstart -> ()
+  | _ -> fail "expected Missing_dtstart"
+
+let test_duplicate_dtstart () =
+  match
+    parse_error
+      [ "UID:e1"; "DTSTART:19980118T230000Z"; "DTSTART:19980119T230000Z" ]
+  with
+  | Error V.Duplicate_dtstart -> ()
+  | _ -> fail "expected Duplicate_dtstart"
+
+let test_invalid_dtstart () =
+  match parse_error [ "UID:e1"; "DTSTART:not-a-date" ] with
+  | Error (V.Invalid_dtstart _) -> ()
+  | _ -> fail "expected Invalid_dtstart"
+
+let test_tzid_on_utc_rejected () =
+  match
+    parse_error [ "UID:e1"; "DTSTART;TZID=UTC:19980118T230000Z" ]
+  with
+  | Error (V.Invalid_dtstart _) -> ()
+  | _ -> fail "expected Invalid_dtstart (TZID on UTC value)"
+
+let test_recurrence_id_form_mismatch () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART;VALUE=DATE:19980118"
+      ; "RECURRENCE-ID:19980125T230000Z"
+      ]
+  with
+  | Error V.Recurrence_id_value_mismatch -> ()
+  | _ -> fail "expected Recurrence_id_value_mismatch"
+
+let test_recurrence_id_tzid_mismatch () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART;TZID=Asia/Seoul:19980119T020000"
+      ; "RECURRENCE-ID;TZID=America/New_York:19980126T020000"
+      ]
+  with
+  | Error V.Recurrence_id_value_mismatch -> ()
+  | _ -> fail "expected Recurrence_id_value_mismatch"
+
+let test_invalid_range () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART:19980118T230000Z"
+      ; "RECURRENCE-ID;RANGE=EVERYTHING:19980125T230000Z"
+      ]
+  with
+  | Error (V.Invalid_range _) -> ()
+  | _ -> fail "expected Invalid_range"
+
+let test_duplicate_rrule () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART:19980118T230000Z"
+      ; "RRULE:FREQ=DAILY"
+      ; "RRULE:FREQ=WEEKLY"
+      ]
+  with
+  | Error V.Duplicate_rrule -> ()
+  | _ -> fail "expected Duplicate_rrule"
+
+let test_rrule_error_propagates () =
+  match
+    parse_error
+      [ "UID:e1"; "DTSTART:19980118T230000Z"; "RRULE:FREQ=FORTNIGHTLY" ]
+  with
+  | Error (V.Rrule_error (R.Invalid_freq "FORTNIGHTLY")) -> ()
+  | _ -> fail "expected Rrule_error Invalid_freq"
+
+let test_until_form_mismatch () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART;VALUE=DATE:19980118"
+      ; "RRULE:FREQ=DAILY;UNTIL=19980201T000000Z"
+      ]
+  with
+  | Error
+      (V.Until_dtstart_mismatch
+        { dtstart_form = "date"; until_form = "utc" }) ->
+    ()
+  | _ -> fail "expected Until_dtstart_mismatch"
+
+let test_local_dtstart_utc_until_mismatch () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART:19980119T020000"
+      ; "RRULE:FREQ=DAILY;UNTIL=19980131T000000Z"
+      ]
+  with
+  | Error (V.Until_dtstart_mismatch _) -> ()
+  | _ -> fail "expected Until_dtstart_mismatch"
+
+let () =
+  run "Schedule_ical_vevent"
+    [ "valid"
+      , [ test_case "minimal utc" `Quick test_minimal_utc
+        ; test_case "date dtstart + date until" `Quick
+            test_date_dtstart_with_date_until
+        ; test_case "tzid dtstart allows utc until" `Quick
+            test_tzid_dtstart_allows_utc_until
+        ; test_case "local dtstart + local until" `Quick
+            test_local_dtstart_with_local_until
+        ; test_case "recurrence-id matching form" `Quick
+            test_recurrence_id_matching_form
+        ; test_case "range thisandfuture" `Quick test_range_this_and_future
+        ; test_case "other properties ignored" `Quick
+            test_ignored_other_properties
+        ]
+    ; "rejections"
+      , [ test_case "missing uid" `Quick test_missing_uid
+        ; test_case "empty uid" `Quick test_empty_uid
+        ; test_case "duplicate uid" `Quick test_duplicate_uid
+        ; test_case "missing dtstart" `Quick test_missing_dtstart
+        ; test_case "duplicate dtstart" `Quick test_duplicate_dtstart
+        ; test_case "invalid dtstart" `Quick test_invalid_dtstart
+        ; test_case "tzid on utc rejected" `Quick test_tzid_on_utc_rejected
+        ; test_case "recurrence-id form mismatch" `Quick
+            test_recurrence_id_form_mismatch
+        ; test_case "recurrence-id tzid mismatch" `Quick
+            test_recurrence_id_tzid_mismatch
+        ; test_case "invalid range" `Quick test_invalid_range
+        ; test_case "duplicate rrule" `Quick test_duplicate_rrule
+        ; test_case "rrule error propagates" `Quick
+            test_rrule_error_propagates
+        ; test_case "until form mismatch" `Quick test_until_form_mismatch
+        ; test_case "local dtstart utc until mismatch" `Quick
+            test_local_dtstart_utc_until_mismatch
+        ]
+    ]

--- a/test/test_schedule_ical_vevent.ml
+++ b/test/test_schedule_ical_vevent.ml
@@ -86,9 +86,9 @@ let test_recurrence_id_matching_form () =
       ]
   in
   match t.V.recurrence_id with
-  | Some { V.value = V.Start_utc (d, _); range = V.This_and_prior } ->
+  | Some { V.value = V.Start_utc (d, _); range = None } ->
     check bool "rid date" true (d.R.day = 25)
-  | _ -> fail "expected utc recurrence-id with default range"
+  | _ -> fail "expected one exact utc recurrence-id"
 
 let test_range_this_and_future () =
   let t =
@@ -99,8 +99,35 @@ let test_range_this_and_future () =
       ]
   in
   match t.V.recurrence_id with
-  | Some { V.range = V.This_and_future; _ } -> ()
+  | Some { V.range = Some V.This_and_future; _ } -> ()
   | _ -> fail "expected THISANDFUTURE"
+
+let test_explicit_date_time_value () =
+  let t =
+    parse_ok
+      [ "UID:explicit-date-time"
+      ; "DTSTART;VALUE=DATE-TIME:19980118T230000Z"
+      ]
+  in
+  match t.V.dtstart with
+  | V.Start_utc _ -> ()
+  | _ -> fail "explicit VALUE=DATE-TIME must be accepted"
+
+let test_uid_identity_is_exact () =
+  let t = parse_ok [ "UID:  event-identity  "; "DTSTART:19980118T230000Z" ] in
+  check string "uid bytes" "  event-identity  " t.V.uid
+
+let test_tzid_identity_is_exact () =
+  let t =
+    parse_ok
+      [ "UID:tzid-identity"
+      ; "DTSTART;TZID=\" America/New_York \":19980119T020000"
+      ]
+  in
+  match t.V.dtstart with
+  | V.Start_tzid (tzid, _, _) ->
+    check string "tzid bytes" " America/New_York " (tzid :> string)
+  | _ -> fail "expected TZID-referenced DTSTART"
 
 let test_ignored_other_properties () =
   let t =
@@ -121,7 +148,7 @@ let test_missing_uid () =
   | _ -> fail "expected Missing_uid"
 
 let test_empty_uid () =
-  match parse_error [ "UID:  " ; "DTSTART:19980118T230000Z" ] with
+  match parse_error [ "UID:"; "DTSTART:19980118T230000Z" ] with
   | Error V.Empty_uid -> ()
   | _ -> fail "expected Empty_uid"
 
@@ -157,6 +184,57 @@ let test_tzid_on_utc_rejected () =
   | Error (V.Invalid_dtstart _) -> ()
   | _ -> fail "expected Invalid_dtstart (TZID on UTC value)"
 
+let test_tzid_on_date_rejected () =
+  match
+    parse_error [ "UID:e1"; "DTSTART;VALUE=DATE;TZID=Asia/Seoul:19980118" ]
+  with
+  | Error (V.Invalid_dtstart _) -> ()
+  | _ -> fail "expected Invalid_dtstart (TZID on DATE value)"
+
+let test_duplicate_parameters_rejected () =
+  let cases =
+    [ ( [ "UID:e1"
+        ; "DTSTART;VALUE=DATE;VALUE=DATE:19980118"
+        ]
+      , "DTSTART"
+      , "VALUE" )
+    ; ( [ "UID:e1"
+        ; "DTSTART;TZID=Asia/Seoul;TZID=Asia/Seoul:19980119T020000"
+        ]
+      , "DTSTART"
+      , "TZID" )
+    ; ( [ "UID:e1"
+        ; "DTSTART:19980118T230000Z"
+        ; "RECURRENCE-ID;RANGE=THISANDFUTURE;RANGE=THISANDFUTURE:19980125T230000Z"
+        ]
+      , "RECURRENCE-ID"
+      , "RANGE" )
+    ]
+  in
+  List.iter
+    (fun (lines, property, parameter) ->
+       match parse_error lines with
+       | Error
+           (V.Parameter_error
+              (V.Duplicate_parameter
+                 { property = actual_property; parameter = actual_parameter })) ->
+         check string "property" property actual_property;
+         check string "parameter" parameter actual_parameter
+       | _ -> failf "%s duplicate %s was not rejected" property parameter)
+    cases
+
+let test_multi_valued_parameter_rejected () =
+  match
+    parse_error
+      [ "UID:e1"; "DTSTART;VALUE=DATE,DATE-TIME:19980118" ]
+  with
+  | Error
+      (V.Parameter_error
+        (V.Multiple_parameter_values
+          { property = "DTSTART"; parameter = "VALUE" })) ->
+    ()
+  | _ -> fail "multi-valued VALUE was not rejected"
+
 let test_recurrence_id_form_mismatch () =
   match
     parse_error
@@ -184,11 +262,22 @@ let test_invalid_range () =
     parse_error
       [ "UID:e1"
       ; "DTSTART:19980118T230000Z"
-      ; "RECURRENCE-ID;RANGE=EVERYTHING:19980125T230000Z"
+      ; "RECURRENCE-ID;RANGE=Everything:19980125T230000Z"
       ]
   with
-  | Error (V.Invalid_range _) -> ()
+  | Error (V.Invalid_range "Everything") -> ()
   | _ -> fail "expected Invalid_range"
+
+let test_this_and_prior_rejected () =
+  match
+    parse_error
+      [ "UID:e1"
+      ; "DTSTART:19980118T230000Z"
+      ; "RECURRENCE-ID;RANGE=THISANDPRIOR:19980125T230000Z"
+      ]
+  with
+  | Error (V.Invalid_range "THISANDPRIOR") -> ()
+  | _ -> fail "THISANDPRIOR is not defined by RFC 5545"
 
 let test_duplicate_rrule () =
   match
@@ -248,6 +337,9 @@ let () =
         ; test_case "recurrence-id matching form" `Quick
             test_recurrence_id_matching_form
         ; test_case "range thisandfuture" `Quick test_range_this_and_future
+        ; test_case "explicit date-time value" `Quick test_explicit_date_time_value
+        ; test_case "uid identity exact" `Quick test_uid_identity_is_exact
+        ; test_case "tzid identity exact" `Quick test_tzid_identity_is_exact
         ; test_case "other properties ignored" `Quick
             test_ignored_other_properties
         ]
@@ -259,11 +351,17 @@ let () =
         ; test_case "duplicate dtstart" `Quick test_duplicate_dtstart
         ; test_case "invalid dtstart" `Quick test_invalid_dtstart
         ; test_case "tzid on utc rejected" `Quick test_tzid_on_utc_rejected
+        ; test_case "tzid on date rejected" `Quick test_tzid_on_date_rejected
+        ; test_case "duplicate parameters rejected" `Quick
+            test_duplicate_parameters_rejected
+        ; test_case "multi-valued parameter rejected" `Quick
+            test_multi_valued_parameter_rejected
         ; test_case "recurrence-id form mismatch" `Quick
             test_recurrence_id_form_mismatch
         ; test_case "recurrence-id tzid mismatch" `Quick
             test_recurrence_id_tzid_mismatch
         ; test_case "invalid range" `Quick test_invalid_range
+        ; test_case "thisandprior rejected" `Quick test_this_and_prior_rejected
         ; test_case "duplicate rrule" `Quick test_duplicate_rrule
         ; test_case "rrule error propagates" `Quick
             test_rrule_error_propagates


### PR DESCRIPTION
## 무엇을 바꾸나

issue #24553 iCalendar 어댑터의 세 번째 bounded leaf입니다. main에 병합된 #25301의 typed content line 위에서 `UID` / `DTSTART` / `RECURRENCE-ID` / `RRULE` recurrence identity를 순수하게 프로젝션합니다. I/O, occurrence 확장, timezone 추측은 없습니다.

## 계약

- `UID`: 정확히 1회이며 RFC 5545 `TEXT` escape를 strict decode합니다. unescaped comma/semicolon, trailing backslash, unknown escape는 `Invalid_uid`이고 semantic identity에는 `String.trim`을 적용하지 않습니다.
- 이 recurrence-identity projection은 `DTSTART`를 정확히 1회 요구합니다. RFC 5545 §3.8.2.4의 VCALENDAR `METHOD` 의존 optionality는 envelope를 받지 않는 이 leaf의 전체 VEVENT 검증 범위 밖입니다.
- `RECURRENCE-ID`: 최대 1회이며 DATE/local/UTC/TZID form과 TZID 식별자가 `DTSTART`와 정확히 일치해야 합니다.
- `RANGE`: 파라미터가 없으면 exact single recurrence(`None`)이고 RFC 5545가 정의한 `THISANDFUTURE`만 typed 값으로 받습니다. `THISANDPRIOR` 및 다른 값은 typed error입니다.
- `RRULE`: 최대 1회이며 `UNTIL` form은 RFC 5545 §3.3.10에 따라 `DTSTART`와 일치해야 합니다.
- `VALUE` / `TZID` / `RANGE` 중복과 다중값은 first-match/drop하지 않고 `Parameter_error`로 보존합니다. RANGE 구조 오류는 RECURRENCE-ID 값 파싱보다 먼저 판정합니다.
- 명시적 `VALUE=DATE-TIME`을 허용하고 DATE+TZID 및 UTC+TZID는 typed error로 거부합니다.
- TZID는 임의 정규화 없이 exact identity를 보존합니다. TZID registry/VTIMEZONE 해석은 후속 leaf 책임입니다.

## SSOT와 경계

날짜·시각 검증은 #25264의 `Schedule_ical_recur.parse_date_value` / `parse_time_of_day_value`를 재사용합니다. content-line parameter uniqueness는 #25301의 `find_unique_param`을 사용합니다. 이 leaf가 별도 날짜 파서·timezone catalog·fallback을 만들지 않습니다.

## 검증

- base: `main` exact head `3b5160457d42b586724be427b1f8d508db474739`
- current exact head: `731d18d32802bb807b4e1afef1f6bc31139e824a`
- VEVENT focused test 30/30 PASS
- `git diff --check origin/main...HEAD` PASS
- repo-wide `@fmt`는 main에 이미 존재하는 무관한 Dune formatting drift 때문에 NONPASS; 이 PR의 exact-head CI로 changed-file 포맷과 full build를 검증합니다.

## 스택

- merged predecessors: #25264 (RECUR leaf), #25301 (content-line leaf), #25362 (OAS v0.216.5 pin)
- #25301 병합 후 고유 3개 커밋만 새 main에 rebase했고 base를 main으로 retarget했습니다.
- exact-head full CI green 전까지 do-not-merge를 유지합니다.
