### PR TITLE
fix(fs): preserve private JSONL close settlement

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1906,7 +1906,7 @@ let private_jsonl_snapshot_success_receipt = function
        Ok { value; settlement_error = Some settlement_error }
      | Some
          ( (Cursor_succeeded _ | Cursor_precondition_succeeded _)
-         , _settlement_error )
+         , _ )
      | None -> Error error)
 ;;
 
@@ -1918,7 +1918,7 @@ let private_jsonl_cursor_success_receipt = function
        Ok { value; settlement_error = Some settlement_error }
      | Some
          ( (Snapshot_succeeded _ | Cursor_precondition_succeeded _)
-         , _settlement_error )
+         , _ )
      | None -> Error error)
 ;;
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1804,11 +1804,13 @@ type private_jsonl_transaction_operation =
   | Read_stable_lock_state
   | Write_stable_lock_state
   | Sync_stable_lock
+  | Close_stable_lock
   | Open_transaction_data
   | Set_transaction_data_permissions
   | Inspect_transaction_data
   | Inspect_transaction_path
   | Read_transaction_data
+  | Close_transaction_data
   | Create_rewrite_stage
   | Set_rewrite_stage_permissions
   | Write_rewrite_stage
@@ -1825,7 +1827,15 @@ type private_jsonl_operation_failure =
   ; backtrace : Printexc.raw_backtrace
   }
 
-type private_jsonl_transaction_error =
+type private_jsonl_transaction_success =
+  | Snapshot_succeeded of private_jsonl_snapshot
+  | Cursor_succeeded of Private_jsonl_cursor.t
+
+type private_jsonl_transaction_primary =
+  | Transaction_succeeded of private_jsonl_transaction_success
+  | Transaction_failed of private_jsonl_transaction_error
+
+and private_jsonl_transaction_error =
   | Stable_lock_contended of { lock_path : string }
   | Unexpected_stable_lock_permissions of
       { path : string
@@ -1856,6 +1866,10 @@ type private_jsonl_transaction_error =
       { cursor : Private_jsonl_cursor.t option
       ; failure : private_jsonl_operation_failure
       }
+  | Transaction_settlement_failed of
+      { primary : private_jsonl_transaction_primary
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
   | Transaction_append_failed of durable_append_error
 
 let private_jsonl_operation_to_string = function
@@ -1869,11 +1883,13 @@ let private_jsonl_operation_to_string = function
   | Read_stable_lock_state -> "read stable lock state"
   | Write_stable_lock_state -> "write stable lock state"
   | Sync_stable_lock -> "sync stable lock"
+  | Close_stable_lock -> "close stable lock"
   | Open_transaction_data -> "open transaction data"
   | Set_transaction_data_permissions -> "set transaction data permissions"
   | Inspect_transaction_data -> "inspect transaction data"
   | Inspect_transaction_path -> "inspect transaction path"
   | Read_transaction_data -> "read transaction data"
+  | Close_transaction_data -> "close transaction data"
   | Create_rewrite_stage -> "create rewrite stage"
   | Set_rewrite_stage_permissions -> "set rewrite stage permissions"
   | Write_rewrite_stage -> "write rewrite stage"
@@ -1892,7 +1908,7 @@ let private_jsonl_operation_failure_to_string failure =
     (Printexc.to_string failure.exception_)
 ;;
 
-let private_jsonl_transaction_error_to_string = function
+let rec private_jsonl_transaction_error_to_string = function
   | Stable_lock_contended { lock_path } ->
     Printf.sprintf "private JSONL stable lock is contended: %s" lock_path
   | Unexpected_stable_lock_permissions { path; actual } ->
@@ -1957,6 +1973,26 @@ let private_jsonl_transaction_error_to_string = function
        | None -> "unknown"
        | Some cursor -> Private_jsonl_cursor.to_string cursor)
       (private_jsonl_operation_failure_to_string failure)
+  | Transaction_settlement_failed { primary; cleanup_failures } ->
+    let primary =
+      match primary with
+      | Transaction_succeeded (Snapshot_succeeded snapshot) ->
+        Printf.sprintf
+          "private JSONL snapshot read succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string snapshot.cursor)
+      | Transaction_succeeded (Cursor_succeeded cursor) ->
+        Printf.sprintf
+          "private JSONL cursor operation succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string cursor)
+      | Transaction_failed primary ->
+        private_jsonl_transaction_error_to_string primary
+    in
+    Printf.sprintf
+      "%s; descriptor settlement failed: %s"
+      primary
+      (cleanup_failures
+       |> List.map private_jsonl_operation_failure_to_string
+       |> String.concat "; ")
   | Transaction_append_failed append_error ->
     durable_append_error_to_string append_error
 ;;
@@ -1972,13 +2008,70 @@ let private_jsonl_capture operation f =
   | exception exception_ -> Error (private_jsonl_failure operation exception_)
 ;;
 
+let private_jsonl_add_cleanup_failure error cleanup_failure =
+  match error with
+  | Transaction_settlement_failed { primary; cleanup_failures } ->
+    Transaction_settlement_failed
+      { primary; cleanup_failures = cleanup_failures @ [ cleanup_failure ] }
+  | (Stable_lock_contended _
+    | Unexpected_stable_lock_permissions _
+    | Invalid_stable_lock_state _
+    | Cursor_mismatch _
+    | Unexpected_transaction_file_kind _
+    | Ambiguous_transaction_file_identity _
+    | Transaction_path_binding_changed _
+    | Incomplete_transaction_tail _
+    | Invalid_transaction_suffix
+    | Private_jsonl_operation_failed _
+    | Rewrite_stage_failed _
+    | Rewrite_published_durability_unknown _
+    | Transaction_append_failed _) as primary ->
+    Transaction_settlement_failed
+      { primary = Transaction_failed primary
+      ; cleanup_failures = [ cleanup_failure ]
+      }
+;;
+
+let private_jsonl_settlement_failed ~success result cleanup_failure =
+  match result with
+  | Ok value ->
+    Error
+      (Transaction_settlement_failed
+         { primary = Transaction_succeeded (success value)
+         ; cleanup_failures = [ cleanup_failure ]
+         })
+  | Error error -> Error (private_jsonl_add_cleanup_failure error cleanup_failure)
+;;
+
+let private_jsonl_with_fd ~close_operation ~close_fd ~success fd f =
+  match f () with
+  | result ->
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> result
+     | Error cleanup_failure ->
+       private_jsonl_settlement_failed ~success result cleanup_failure)
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Printexc.raise_with_backtrace exception_ backtrace
+     | Error cleanup_failure ->
+       let combined, combined_backtrace =
+         Eio.Exn.combine
+           (exception_, backtrace)
+           (cleanup_failure.exception_, cleanup_failure.backtrace)
+       in
+       Printexc.raise_with_backtrace combined combined_backtrace)
+;;
+
 let private_jsonl_lock_path path = path ^ ".lock"
 
 type private_jsonl_transaction_io_for_testing =
-  { before_sync_parent : string -> unit }
+  { before_sync_parent : string -> unit
+  ; close_fd : Unix.file_descr -> unit
+  }
 
 let private_jsonl_transaction_unix_io =
-  { before_sync_parent = (fun _dir -> ()) }
+  { before_sync_parent = (fun _dir -> ()); close_fd = Unix.close }
 ;;
 
 let private_jsonl_stable_lock_ready_marker = "\xA5"
@@ -2151,7 +2244,7 @@ let rec try_lock_whole_file fd =
   | exception Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> false
 ;;
 
-let with_private_jsonl_stable_lock ~io requested_path f =
+let with_private_jsonl_stable_lock ~io ~success requested_path f =
   let requested_dir = Filename.dirname requested_path in
   run_blocking_private_file_transaction
     ~label:"fs-compat-private-jsonl-transaction"
@@ -2175,8 +2268,11 @@ let with_private_jsonl_stable_lock ~io requested_path f =
               match private_jsonl_open_stable_lock lock_path with
               | Error _ as error -> error
               | Ok stable_lock ->
-                Fun.protect
-                  ~finally:(fun () -> Unix.close stable_lock.fd)
+                private_jsonl_with_fd
+                  ~close_operation:Close_stable_lock
+                  ~close_fd:io.close_fd
+                  ~success
+                  stable_lock.fd
                   (fun () ->
                      let ( let* ) = Result.bind in
                      let* () =
@@ -2222,7 +2318,7 @@ let private_jsonl_cursor_of_stats stats =
          })
 ;;
 
-let private_jsonl_open_existing path flags =
+let private_jsonl_open_existing ~close_fd path flags =
   match Unix.openfile path (Unix.O_CLOEXEC :: flags) 0 with
   | fd ->
     (match
@@ -2233,8 +2329,10 @@ let private_jsonl_open_existing path flags =
      with
      | Ok () -> Ok (Some fd)
      | Error error ->
-       Unix.close fd;
-       Error error)
+       (match private_jsonl_capture Close_transaction_data (fun () -> close_fd fd) with
+        | Ok () -> Error error
+        | Error cleanup_failure ->
+          Error (private_jsonl_add_cleanup_failure error cleanup_failure)))
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
   | exception (Eio.Cancel.Cancelled _ as cancellation) -> raise cancellation
   | exception exception_ ->
@@ -2289,8 +2387,9 @@ let private_jsonl_read_exact fd ~from ~end_offset =
 ;;
 
 let read_private_jsonl_durable_locked_with_io ~io path ~after =
-  with_private_jsonl_stable_lock ~io path @@ fun ~dir:_ ~path ->
-  match private_jsonl_open_existing path [ Unix.O_RDONLY ] with
+  let success snapshot = Snapshot_succeeded snapshot in
+  with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir:_ ~path ->
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None ->
     let actual = Private_jsonl_cursor.Missing in
@@ -2301,8 +2400,11 @@ let read_private_jsonl_durable_locked_with_io ~io path ~after =
        then Ok { bytes = ""; cursor = actual }
        else Error (Cursor_mismatch { expected; actual }))
   | Ok (Some fd) ->
-    Fun.protect
-      ~finally:(fun () -> Unix.close fd)
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
       (fun () ->
          match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
          with
@@ -2349,13 +2451,17 @@ let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =
   read_private_jsonl_durable_locked_with_io ~io path ~after
 ;;
 
-let private_jsonl_current_cursor path =
-  match private_jsonl_open_existing path [ Unix.O_RDONLY ] with
+let private_jsonl_current_cursor ~io path =
+  let success cursor = Cursor_succeeded cursor in
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None -> Ok Private_jsonl_cursor.Missing
   | Ok (Some fd) ->
-    Fun.protect
-      ~finally:(fun () -> Unix.close fd)
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
       (fun () ->
          match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
          with
@@ -2458,14 +2564,19 @@ let private_jsonl_replace_locked ~dir path content =
                         { cursor = Some cursor; failure }))))))
 ;;
 
-let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
+let append_private_jsonl_durable_locked_at_cursor_with_io ~io path ~expected suffix =
   if String.equal suffix ""
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
   then Error Invalid_transaction_suffix
   else
-    with_private_jsonl_stable_lock ~io:private_jsonl_transaction_unix_io path
-    @@ fun ~dir ~path ->
-    match private_jsonl_open_existing path [ Unix.O_RDWR; Unix.O_APPEND ] with
+    let success cursor = Cursor_succeeded cursor in
+    with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir ~path ->
+    match
+      private_jsonl_open_existing
+        ~close_fd:io.close_fd
+        path
+        [ Unix.O_RDWR; Unix.O_APPEND ]
+    with
     | Error _ as error -> error
     | Ok None ->
       let actual = Private_jsonl_cursor.Missing in
@@ -2473,8 +2584,11 @@ let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
       then Error (Cursor_mismatch { expected; actual })
       else private_jsonl_replace_locked ~dir path suffix
     | Ok (Some fd) ->
-      Fun.protect
-        ~finally:(fun () -> Unix.close fd)
+      private_jsonl_with_fd
+        ~close_operation:Close_transaction_data
+        ~close_fd:io.close_fd
+        ~success
+        fd
         (fun () ->
            match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
            with
@@ -2516,7 +2630,29 @@ let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
                              private_jsonl_cursor_of_stats committed_stats))))))
 ;;
 
-let rewrite_private_jsonl_durable_locked_at_cursor_result
+let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
+  append_private_jsonl_durable_locked_at_cursor_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    suffix
+;;
+
+let append_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected
+      suffix
+  =
+  append_private_jsonl_durable_locked_at_cursor_with_io
+    ~io
+    path
+    ~expected
+    suffix
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_with_io
+      ~io
       path
       ~expected
       content
@@ -2525,14 +2661,29 @@ let rewrite_private_jsonl_durable_locked_at_cursor_result
      && not (Char.equal content.[String.length content - 1] '\n')
   then Error Invalid_transaction_suffix
   else
-    with_private_jsonl_stable_lock ~io:private_jsonl_transaction_unix_io path
+    with_private_jsonl_stable_lock
+      ~io
+      ~success:(fun cursor -> Cursor_succeeded cursor)
+      path
     @@ fun ~dir ~path ->
-    match private_jsonl_current_cursor path with
+    match private_jsonl_current_cursor ~io path with
     | Error _ as error -> error
     | Ok actual ->
       if not (Private_jsonl_cursor.equal expected actual)
       then Error (Cursor_mismatch { expected; actual })
       else private_jsonl_replace_locked ~dir path content
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_result
+      path
+      ~expected
+      content
+  =
+  rewrite_private_jsonl_durable_locked_at_cursor_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    content
 ;;
 
 module Private_jsonl_slice = struct

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1872,6 +1872,29 @@ and private_jsonl_transaction_error =
       }
   | Transaction_append_failed of durable_append_error
 
+type 'a private_jsonl_success_receipt =
+  { value : 'a
+  ; settlement_error : private_jsonl_transaction_error option
+  }
+
+let private_jsonl_snapshot_success_receipt = function
+  | Ok value -> Ok { value; settlement_error = None }
+  | Error
+      (Transaction_settlement_failed
+        { primary = Transaction_succeeded (Snapshot_succeeded value); _ } as error) ->
+    Ok { value; settlement_error = Some error }
+  | Error error -> Error error
+;;
+
+let private_jsonl_cursor_success_receipt = function
+  | Ok value -> Ok { value; settlement_error = None }
+  | Error
+      (Transaction_settlement_failed
+        { primary = Transaction_succeeded (Cursor_succeeded value); _ } as error) ->
+    Ok { value; settlement_error = Some error }
+  | Error error -> Error error
+;;
+
 let private_jsonl_operation_to_string = function
   | Create_parent_directory -> "create parent directory"
   | Canonicalize_parent_directory -> "canonicalize parent directory"

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1830,6 +1830,7 @@ type private_jsonl_operation_failure =
 type private_jsonl_transaction_success =
   | Snapshot_succeeded of private_jsonl_snapshot
   | Cursor_succeeded of Private_jsonl_cursor.t
+  | Cursor_precondition_succeeded of Private_jsonl_cursor.t
 
 type private_jsonl_transaction_primary =
   | Transaction_succeeded of private_jsonl_transaction_success
@@ -2006,6 +2007,10 @@ let rec private_jsonl_transaction_error_to_string = function
       | Transaction_succeeded (Cursor_succeeded cursor) ->
         Printf.sprintf
           "private JSONL cursor operation succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string cursor)
+      | Transaction_succeeded (Cursor_precondition_succeeded cursor) ->
+        Printf.sprintf
+          "private JSONL cursor precondition read succeeded (cursor=%s)"
           (Private_jsonl_cursor.to_string cursor)
       | Transaction_failed primary ->
         private_jsonl_transaction_error_to_string primary
@@ -2475,7 +2480,7 @@ let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =
 ;;
 
 let private_jsonl_current_cursor ~io path =
-  let success cursor = Cursor_succeeded cursor in
+  let success cursor = Cursor_precondition_succeeded cursor in
   match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None -> Ok Private_jsonl_cursor.Missing
@@ -2704,6 +2709,19 @@ let rewrite_private_jsonl_durable_locked_at_cursor_result
   =
   rewrite_private_jsonl_durable_locked_at_cursor_with_io
     ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    content
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected
+      content
+  =
+  rewrite_private_jsonl_durable_locked_at_cursor_with_io
+    ~io
     path
     ~expected
     content

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1878,22 +1878,48 @@ type 'a private_jsonl_success_receipt =
   ; settlement_error : private_jsonl_transaction_error option
   }
 
+let private_jsonl_settlement_success = function
+  | (Transaction_settlement_failed
+      { primary = Transaction_succeeded success; _ } as error) ->
+    Some (success, error)
+  | Transaction_settlement_failed { primary = Transaction_failed _; _ }
+  | Stable_lock_contended _
+  | Unexpected_stable_lock_permissions _
+  | Invalid_stable_lock_state _
+  | Cursor_mismatch _
+  | Unexpected_transaction_file_kind _
+  | Ambiguous_transaction_file_identity _
+  | Transaction_path_binding_changed _
+  | Incomplete_transaction_tail _
+  | Invalid_transaction_suffix
+  | Private_jsonl_operation_failed _
+  | Rewrite_stage_failed _
+  | Rewrite_published_durability_unknown _
+  | Transaction_append_failed _ -> None
+;;
+
 let private_jsonl_snapshot_success_receipt = function
   | Ok value -> Ok { value; settlement_error = None }
-  | Error
-      (Transaction_settlement_failed
-        { primary = Transaction_succeeded (Snapshot_succeeded value); _ } as error) ->
-    Ok { value; settlement_error = Some error }
-  | Error error -> Error error
+  | Error error ->
+    (match private_jsonl_settlement_success error with
+     | Some (Snapshot_succeeded value, settlement_error) ->
+       Ok { value; settlement_error = Some settlement_error }
+     | Some
+         ( (Cursor_succeeded _ | Cursor_precondition_succeeded _)
+         , _settlement_error )
+     | None -> Error error)
 ;;
 
 let private_jsonl_cursor_success_receipt = function
   | Ok value -> Ok { value; settlement_error = None }
-  | Error
-      (Transaction_settlement_failed
-        { primary = Transaction_succeeded (Cursor_succeeded value); _ } as error) ->
-    Ok { value; settlement_error = Some error }
-  | Error error -> Error error
+  | Error error ->
+    (match private_jsonl_settlement_success error with
+     | Some (Cursor_succeeded value, settlement_error) ->
+       Ok { value; settlement_error = Some settlement_error }
+     | Some
+         ( (Snapshot_succeeded _ | Cursor_precondition_succeeded _)
+         , _settlement_error )
+     | None -> Error error)
 ;;
 
 let private_jsonl_operation_to_string = function

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -862,6 +862,27 @@ and private_jsonl_transaction_error =
       }
   | Transaction_append_failed of durable_append_error
 
+type 'a private_jsonl_success_receipt =
+  { value : 'a
+  ; settlement_error : private_jsonl_transaction_error option
+  }
+(** A completed transaction value together with exact evidence that descriptor
+    settlement remained incomplete. Consumers may advance from [value], but
+    must observe [settlement_error]. Primary failures and mismatched success
+    kinds are never converted to receipts. *)
+
+val private_jsonl_snapshot_success_receipt :
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result ->
+  ( private_jsonl_snapshot private_jsonl_success_receipt
+  , private_jsonl_transaction_error )
+  result
+
+val private_jsonl_cursor_success_receipt :
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result ->
+  ( Private_jsonl_cursor.t private_jsonl_success_receipt
+  , private_jsonl_transaction_error )
+  result
+
 val private_jsonl_transaction_error_to_string :
   private_jsonl_transaction_error -> string
 

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -820,6 +820,7 @@ type private_jsonl_operation_failure =
 type private_jsonl_transaction_success =
   | Snapshot_succeeded of private_jsonl_snapshot
   | Cursor_succeeded of Private_jsonl_cursor.t
+  | Cursor_precondition_succeeded of Private_jsonl_cursor.t
 
 type private_jsonl_transaction_primary =
   | Transaction_succeeded of private_jsonl_transaction_success
@@ -940,6 +941,15 @@ val append_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
     fsynced; no directory-fsync failure is suppressed. The stable sibling lock
     remains the serialization authority across the inode replacement. *)
 val rewrite_private_jsonl_durable_locked_at_cursor_result :
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Production-path seam proving that a descriptor settlement failure while
+    reading the rewrite precondition is not classified as a committed rewrite. *)
+val rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
   string ->
   expected:Private_jsonl_cursor.t ->
   string ->

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -794,11 +794,13 @@ type private_jsonl_transaction_operation =
   | Read_stable_lock_state
   | Write_stable_lock_state
   | Sync_stable_lock
+  | Close_stable_lock
   | Open_transaction_data
   | Set_transaction_data_permissions
   | Inspect_transaction_data
   | Inspect_transaction_path
   | Read_transaction_data
+  | Close_transaction_data
   | Create_rewrite_stage
   | Set_rewrite_stage_permissions
   | Write_rewrite_stage
@@ -815,7 +817,15 @@ type private_jsonl_operation_failure =
   ; backtrace : Printexc.raw_backtrace
   }
 
-type private_jsonl_transaction_error =
+type private_jsonl_transaction_success =
+  | Snapshot_succeeded of private_jsonl_snapshot
+  | Cursor_succeeded of Private_jsonl_cursor.t
+
+type private_jsonl_transaction_primary =
+  | Transaction_succeeded of private_jsonl_transaction_success
+  | Transaction_failed of private_jsonl_transaction_error
+
+and private_jsonl_transaction_error =
   | Stable_lock_contended of { lock_path : string }
   | Unexpected_stable_lock_permissions of
       { path : string
@@ -846,6 +856,10 @@ type private_jsonl_transaction_error =
       { cursor : Private_jsonl_cursor.t option
       ; failure : private_jsonl_operation_failure
       }
+  | Transaction_settlement_failed of
+      { primary : private_jsonl_transaction_primary
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
   | Transaction_append_failed of durable_append_error
 
 val private_jsonl_transaction_error_to_string :
@@ -868,10 +882,12 @@ val read_private_jsonl_durable_locked_result :
   (private_jsonl_snapshot, private_jsonl_transaction_error) result
 
 type private_jsonl_transaction_io_for_testing =
-  { before_sync_parent : string -> unit }
+  { before_sync_parent : string -> unit
+  ; close_fd : Unix.file_descr -> unit
+  }
 
-(** Production-path seam for deterministic stable-lock creation durability
-    tests. *)
+(** Production-path seam for deterministic stable-lock creation and descriptor
+    settlement tests. *)
 val read_private_jsonl_durable_locked_with_io_for_testing :
   io:private_jsonl_transaction_io_for_testing ->
   string ->
@@ -885,6 +901,14 @@ val read_private_jsonl_durable_locked_with_io_for_testing :
     on the old inode. Lock contention and stale cursors fail explicitly without
     timeout, retry, or backoff policy. *)
 val append_private_jsonl_durable_locked_at_cursor_result :
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Production-path seam for cancellation during descriptor settlement. *)
+val append_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
   string ->
   expected:Private_jsonl_cursor.t ->
   string ->

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -510,12 +510,13 @@ let test_private_jsonl_transaction_preserves_primary_when_data_close_fails () =
 let test_private_jsonl_transaction_accumulates_nested_close_failures () =
   with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
   let io, calls = injected_close_io ~fail_calls:[ 1; 2 ] in
-  (match
-     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
-       ~io
-       path
-       ~after:None
-   with
+  let result =
+    Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+      ~io
+      path
+      ~after:None
+  in
+  (match result with
    | Error
        (Fs_compat.Transaction_settlement_failed
          { primary =
@@ -531,7 +532,41 @@ let test_private_jsonl_transaction_accumulates_nested_close_failures () =
      check_transaction_close_failure
        ~label:"stable lock descriptor cleanup"
        ~operation:Fs_compat.Close_stable_lock
-       lock_failure
+       lock_failure;
+     (match Fs_compat.private_jsonl_snapshot_success_receipt result with
+      | Ok { value; settlement_error = Some _ } ->
+        check string "classified snapshot receipt" snapshot.bytes value.bytes
+      | Ok { settlement_error = None; _ } ->
+        fail "snapshot classifier discarded settlement evidence"
+      | Error error ->
+        fail (Fs_compat.private_jsonl_transaction_error_to_string error));
+     let cursor_settlement_error =
+       Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Cursor_succeeded snapshot.cursor)
+         ; cleanup_failures = [ data_failure; lock_failure ]
+         }
+     in
+     (match
+        Fs_compat.private_jsonl_cursor_success_receipt
+          (Error cursor_settlement_error)
+      with
+      | Ok { value; settlement_error = Some _ } ->
+        check bool
+          "classified cursor receipt"
+          true
+          (Fs_compat.Private_jsonl_cursor.equal snapshot.cursor value)
+      | Ok { settlement_error = None; _ } ->
+        fail "cursor classifier discarded settlement evidence"
+      | Error error ->
+        fail (Fs_compat.private_jsonl_transaction_error_to_string error));
+     (match
+        Fs_compat.private_jsonl_snapshot_success_receipt
+          (Error cursor_settlement_error)
+      with
+      | Error _ -> ()
+      | Ok _ -> fail "snapshot classifier accepted a cursor success receipt")
    | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
    | Ok _ -> fail "nested close failures were silently accepted");
   check int "both nested descriptors closed" 2 !calls

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -448,6 +448,200 @@ let transaction_append path ~expected suffix =
   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
 ;;
 
+let injected_close_io ~fail_calls =
+  let calls = ref 0 in
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> ())
+    ; close_fd =
+        (fun fd ->
+          incr calls;
+          Unix.close fd;
+          if List.mem !calls fail_calls
+          then
+            raise
+              (Unix.Unix_error
+                 (Unix.EIO, "injected_private_jsonl_close", string_of_int !calls)))
+    }
+  in
+  io, calls
+;;
+
+let check_transaction_close_failure
+      ~label
+      ~operation
+      (failure : Fs_compat.private_jsonl_operation_failure)
+  =
+  check bool (label ^ " operation") true (failure.operation = operation);
+  match failure.exception_ with
+  | Unix.Unix_error (Unix.EIO, "injected_private_jsonl_close", _) -> ()
+  | exception_ ->
+    fail
+      (Printf.sprintf
+         "%s lost injected close failure: %s"
+         label
+         (Printexc.to_string exception_))
+;;
+
+let test_private_jsonl_transaction_preserves_primary_when_data_close_fails () =
+  with_transaction_jsonl (Some "incomplete") @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_failed
+               (Fs_compat.Incomplete_transaction_tail _)
+         ; cleanup_failures = [ cleanup_failure ]
+         }) ->
+     check_transaction_close_failure
+       ~label:"data descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "data close failure was silently accepted");
+  check int "data and stable lock descriptors closed" 2 !calls
+;;
+
+let test_private_jsonl_transaction_accumulates_nested_close_failures () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1; 2 ] in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Snapshot_succeeded snapshot)
+         ; cleanup_failures = [ data_failure; lock_failure ]
+         }) ->
+     check string "successful snapshot receipt" "{\"row\":1}\n" snapshot.bytes;
+     check_transaction_close_failure
+       ~label:"data descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       data_failure;
+     check_transaction_close_failure
+       ~label:"stable lock descriptor cleanup"
+       ~operation:Fs_compat.Close_stable_lock
+       lock_failure
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "nested close failures were silently accepted");
+  check int "both nested descriptors closed" 2 !calls
+;;
+
+exception Requested_private_jsonl_cancellation
+
+type private_jsonl_append_cancellation_outcome =
+  | Append_returned of
+      ( Fs_compat.Private_jsonl_cursor.t
+        , Fs_compat.private_jsonl_transaction_error )
+        result
+  | Append_cancelled
+
+type private_jsonl_close_barrier =
+  { entered : unit Eio.Promise.t
+  ; resolve_entered : unit Eio.Promise.u
+  ; first_close : bool Atomic.t
+  ; close_calls : int Atomic.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Stdlib.Condition.t
+  ; mutable released : bool
+  }
+
+let private_jsonl_close_barrier () =
+  let entered, resolve_entered = Eio.Promise.create () in
+  { entered
+  ; resolve_entered
+  ; first_close = Atomic.make true
+  ; close_calls = Atomic.make 0
+  ; mutex = Stdlib.Mutex.create ()
+  ; condition = Stdlib.Condition.create ()
+  ; released = false
+  }
+;;
+
+let release_private_jsonl_close barrier =
+  Stdlib.Mutex.protect barrier.mutex (fun () ->
+    if not barrier.released
+    then (
+      barrier.released <- true;
+      Stdlib.Condition.broadcast barrier.condition))
+;;
+
+let private_jsonl_blocking_close_io barrier =
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> ())
+    ; close_fd =
+        (fun fd ->
+          ignore (Atomic.fetch_and_add barrier.close_calls 1 : int);
+          if Atomic.compare_and_set barrier.first_close true false
+          then (
+            Eio.Promise.resolve barrier.resolve_entered ();
+            Stdlib.Mutex.protect barrier.mutex (fun () ->
+              while not barrier.released do
+                Stdlib.Condition.wait barrier.condition barrier.mutex
+              done));
+          Unix.close fd)
+    }
+  in
+  io
+;;
+
+let test_private_jsonl_append_cancellation_settles_once_with_receipt () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  Eio_main.run @@ fun _env ->
+  let origin = transaction_snapshot path ~after:None in
+  let barrier = private_jsonl_close_barrier () in
+  let context, resolve_context = Eio.Promise.create () in
+  let outcome, resolve_outcome = Eio.Promise.create () in
+  Fun.protect
+    ~finally:(fun () -> release_private_jsonl_close barrier)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let outcome =
+           try
+             Eio.Cancel.sub @@ fun context ->
+             Eio.Promise.resolve resolve_context context;
+             Append_returned
+               (Fs_compat.append_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+                  ~io:(private_jsonl_blocking_close_io barrier)
+                  path
+                  ~expected:origin.cursor
+                  "{\"row\":2}\n")
+           with
+           | Eio.Cancel.Cancelled _ -> Append_cancelled
+         in
+         Eio.Promise.resolve resolve_outcome outcome);
+       let context = Eio.Promise.await context in
+       Eio.Promise.await barrier.entered;
+       Eio.Cancel.cancel context Requested_private_jsonl_cancellation;
+       release_private_jsonl_close barrier;
+       match Eio.Promise.await outcome with
+       | Append_cancelled ->
+         fail "committed append lost its terminal receipt to cancellation"
+       | Append_returned (Error error) ->
+         fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+       | Append_returned (Ok committed) ->
+         check bool
+           "cancellation path returns committed cursor"
+           false
+           (Fs_compat.Private_jsonl_cursor.equal origin.cursor committed));
+  check int "cancellation path closes both descriptors" 2 (Atomic.get barrier.close_calls);
+  check string
+    "cancellation path commits suffix exactly once"
+    "{\"row\":1}\n{\"row\":2}\n"
+    (Fs_compat.load_file path)
+;;
+
 let test_private_jsonl_transaction_missing_and_delta_contract () =
   with_transaction_jsonl None @@ fun path ->
   let origin = transaction_snapshot path ~after:None in
@@ -527,7 +721,9 @@ let test_private_jsonl_stable_lock_parent_sync_is_one_shot () =
   with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
   let parent_syncs = ref 0 in
   let io : Fs_compat.private_jsonl_transaction_io_for_testing =
-    { before_sync_parent = (fun _dir -> incr parent_syncs) }
+    { before_sync_parent = (fun _dir -> incr parent_syncs)
+    ; close_fd = Unix.close
+    }
   in
   let snapshot = transaction_snapshot_with_io ~io path ~after:None in
   ignore (transaction_snapshot_with_io ~io path ~after:(Some snapshot.cursor));
@@ -541,6 +737,7 @@ let test_private_jsonl_stable_lock_parent_sync_failure_retries () =
     { before_sync_parent =
         (fun dir ->
           raise (Unix.Unix_error (Unix.EIO, "injected_parent_fsync", dir)))
+    ; close_fd = Unix.close
     }
   in
   (match
@@ -788,6 +985,18 @@ let () =
             "private JSONL stable lock rejects symlink aliases"
             `Quick
             test_private_jsonl_transaction_rejects_symlink_lock_without_chmod
+        ; test_case
+            "private JSONL data close preserves primary error"
+            `Quick
+            test_private_jsonl_transaction_preserves_primary_when_data_close_fails
+        ; test_case
+            "private JSONL nested close failures accumulate"
+            `Quick
+            test_private_jsonl_transaction_accumulates_nested_close_failures
+        ; test_case
+            "private JSONL append cancellation settles once with receipt"
+            `Quick
+            test_private_jsonl_append_cancellation_settles_once_with_receipt
         ] )
     ]
 ;;

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -572,6 +572,45 @@ let test_private_jsonl_transaction_accumulates_nested_close_failures () =
   check int "both nested descriptors closed" 2 !calls
 ;;
 
+let test_private_jsonl_rewrite_rejects_precondition_close_as_commit () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let origin = transaction_snapshot path ~after:None in
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  let result =
+    Fs_compat.rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected:origin.cursor
+      "{\"row\":2}\n"
+  in
+  (match result with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Cursor_precondition_succeeded observed)
+         ; cleanup_failures = [ cleanup_failure ]
+         }) ->
+     check bool
+       "precondition cursor preserved"
+       true
+       (Fs_compat.Private_jsonl_cursor.equal origin.cursor observed);
+     check_transaction_close_failure
+       ~label:"rewrite precondition descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure;
+     (match Fs_compat.private_jsonl_cursor_success_receipt result with
+      | Error _ -> ()
+      | Ok _ -> fail "precondition cursor was classified as a committed rewrite")
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "rewrite continued after precondition descriptor settlement failed");
+  check int "precondition and stable lock descriptors closed" 2 !calls;
+  check string
+    "failed precondition leaves target unchanged"
+    "{\"row\":1}\n"
+    (Fs_compat.load_file path)
+;;
+
 exception Requested_private_jsonl_cancellation
 
 type private_jsonl_append_cancellation_outcome =
@@ -1028,6 +1067,10 @@ let () =
             "private JSONL nested close failures accumulate"
             `Quick
             test_private_jsonl_transaction_accumulates_nested_close_failures
+        ; test_case
+            "private JSONL rewrite precondition close is not a commit"
+            `Quick
+            test_private_jsonl_rewrite_rejects_precondition_close_as_commit
         ; test_case
             "private JSONL append cancellation settles once with receipt"
             `Quick


### PR DESCRIPTION
## Summary

- Replace raw stable-lock/data fd finalizers with one typed settlement boundary.
- Preserve either the successful snapshot/cursor receipt or the typed primary error alongside every close failure.
- Flatten nested data + stable-lock cleanup failures without discarding evidence.
- Retain a committed append cursor through Eio systhread cancellation so callers do not retry an already-applied effect.
- Centralize snapshot/cursor successful-settlement classification in `Fs_compat`; primary failures and mismatched receipt kinds remain fail-closed.
- Distinguish a rewrite precondition cursor read from the cursor proving a published append/rewrite. A precondition close failure can no longer advance a consumer cache as if the rewrite committed.

## Focused proof

- Deterministic injected data/stable close failures; no timing-based race test.
- Barrier-driven cancellation proof: two descriptors closed, one suffix committed, terminal cursor returned.
- Receipt classifier proof covers snapshot success, cursor success, retained settlement evidence, and wrong-kind rejection.
- Rewrite-precondition proof verifies the target remains unchanged and the precondition receipt is rejected as a commit.
- `ocamlformat`, OCaml parsing, and `git diff --check`: pass.
- Current-head GitHub policy/coverage checks: pass; format check is running.
- Focused Dune rerun is pending because another workspace process launched bare `dune build .`; the repository wrapper correctly refused concurrent execution and was not bypassed.

## Stack

- Parent: #25314
- Stack: #25185 -> #25314 -> #25312
- Downstream consumers: #25198 (partition) -> #25218 (candidate)
- Bounded process-owned blocking executor/health telemetry remains a separate #25240 leaf.

Refs #25240
