### PR TITLE
fix(keeper): persist reactive overflow decision durably and wire it into dashboard rows

### DIFF
--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -120,6 +120,22 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect('compaction_token_gate' in (keeper ?? {})).toBe(false)
   })
 
+  it('surfaces last_compaction_decision emitted by the backend row', () => {
+    const [withDecision] = normalizeKeepers([
+      {
+        name: 'sangsu',
+        status: 'active',
+        last_compaction_decision: 'provider_overflow_recovery_failed: plan_provider_unavailable',
+      },
+    ])
+    expect(withDecision?.last_compaction_decision).toBe(
+      'provider_overflow_recovery_failed: plan_provider_unavailable',
+    )
+
+    const [withoutDecision] = normalizeKeepers([{ name: 'sangsu', status: 'active' }])
+    expect(withoutDecision?.last_compaction_decision).toBeNull()
+  })
+
   it('normalizes live activity projection and current approval gate', () => {
     const [keeper] = normalizeKeepers([
       {

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -918,6 +918,15 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ("last_latency_ms", last_latency_ms_json m.runtime.usage.last_latency_ms);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
+              (* Surface the reactive-overflow recovery reason the same way
+                 keeper_status.ml does, so keeper-store-normalize.ts reads a
+                 populated last_compaction_decision instead of null. *)
+              ( "last_compaction_decision",
+                let decision =
+                  Keeper_meta_contract.compaction_runtime_decision_to_string
+                    m.runtime.compaction_rt.last_decision
+                in
+                if String.trim decision = "" then `Null else `String decision );
               ("compaction_profile", `String m.compaction.profile);
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -518,6 +518,45 @@ let write_meta_with_merge_for_lifecycle token ?max_retries ~merge config m =
     m
 ;;
 
+(* Durable write-through of [compaction_rt.last_decision].
+
+   The status/dashboard read paths (read_meta_resolved / keepers_dashboard_json)
+   surface [last_compaction_decision] from the on-disk meta, not from the
+   in-memory registry. The reactive provider-overflow failure path stamps the
+   decision onto the registry entry (in-memory) and the turn-failure path had
+   already flushed [updated_meta] — derived from the pre-overflow meta, without
+   this decision — to disk before recovery ran. Persisting here is the only path
+   that makes the reactive overflow reason durable, so it is both readable by
+   status and preserved across a restart.
+
+   Read the current on-disk meta (already carrying the just-written turn-failure
+   metrics), stamp only [last_decision], and write back with a field-level merge
+   so a concurrent heartbeat/turn CAS race re-applies the stamp instead of
+   dropping it. [`No_durable_meta] is a distinct, non-fatal outcome (keeper meta
+   never persisted) rather than a swallowed error. *)
+let persist_compaction_decision config ~keeper_name ~decision
+  : ([ `Persisted | `No_durable_meta ], string) result
+  =
+  let stamp (m : Keeper_meta_contract.keeper_meta) =
+    Keeper_meta_contract.map_compaction_rt
+      (fun rt ->
+        { rt with
+          last_decision =
+            Keeper_meta_contract.compaction_runtime_decision_of_string decision
+        })
+      m
+  in
+  match read_meta config keeper_name with
+  | Error msg -> Error msg
+  | Ok None -> Ok `No_durable_meta
+  | Ok (Some disk_meta) ->
+    write_meta_with_merge
+      ~merge:(fun ~latest ~caller:_ -> stamp latest)
+      config
+      (stamp disk_meta)
+    |> Result.map (fun () -> `Persisted)
+;;
+
 type identity_update_error =
   | Identity_missing
   | Identity_changed

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -540,10 +540,7 @@ let persist_compaction_decision config ~keeper_name ~decision
   let stamp (m : Keeper_meta_contract.keeper_meta) =
     Keeper_meta_contract.map_compaction_rt
       (fun rt ->
-        { rt with
-          last_decision =
-            Keeper_meta_contract.compaction_runtime_decision_of_string decision
-        })
+        { rt with last_decision = decision })
       m
   in
   match read_meta config keeper_name with

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -248,5 +248,5 @@ val write_meta_with_merge_for_lifecycle :
 val persist_compaction_decision :
   Workspace.config ->
   keeper_name:string ->
-  decision:string ->
+  decision:Keeper_meta_contract.compaction_runtime_decision ->
   ([ `Persisted | `No_durable_meta ], string) result

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -233,3 +233,20 @@ val write_meta_with_merge_for_lifecycle :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
+
+(** [persist_compaction_decision config ~keeper_name ~decision] stamps [decision]
+    onto the durable on-disk [compaction_rt.last_decision], the field the
+    status and dashboard read paths surface as [last_compaction_decision].
+
+    Used by the reactive provider-overflow failure path, whose registry stamp is
+    in-memory only and whose turn-failure meta flush persists a pre-overflow meta
+    without the decision. Reads the current on-disk meta, stamps only
+    [last_decision], and writes back via {!write_meta_with_merge} so a CAS race
+    with a concurrent heartbeat/turn write re-applies the stamp. [`No_durable_meta]
+    reports that no on-disk meta exists to stamp (non-fatal); [Error] carries a
+    read/write failure. *)
+val persist_compaction_decision :
+  Workspace.config ->
+  keeper_name:string ->
+  decision:string ->
+  ([ `Persisted | `No_durable_meta ], string) result

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -441,7 +441,8 @@ let record_overflow_failure
      Keeper_meta_store.persist_compaction_decision
        config
        ~keeper_name:meta.name
-       ~decision
+       ~decision:
+         (Keeper_meta_contract.compaction_runtime_decision_of_string decision)
    with
    | Ok `Persisted -> ()
    | Ok `No_durable_meta ->

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -423,13 +423,36 @@ let record_overflow_failure
     ~base_path:config.base_path
     meta.name
     (Some Keeper_registry.Turn_overflow_failure);
-  (* Also stamp the specific recovery reason onto compaction_rt so the reactive
-     overflow spiral's failure is visible in status (last_compaction_decision),
-     not dropped to the generic Turn_overflow_failure enum. *)
+  let decision = provider_overflow_decision ~reason in
+  (* Stamp the specific recovery reason onto the in-memory registry entry's
+     compaction_rt so in-memory run_state readers stay consistent. *)
   Keeper_registry.set_compaction_decision
     ~base_path:config.base_path
     meta.name
-    (provider_overflow_decision ~reason);
+    decision;
+  (* Persist the same decision to the durable on-disk meta. The registry stamp
+     above is in-memory only, and the turn-failure path already flushed
+     [updated_meta] (derived from the pre-overflow meta, without this decision)
+     to disk before recovery ran. Status (read_meta_resolved) and the dashboard
+     projection (keepers_dashboard_json) read [last_compaction_decision] from the
+     persisted meta, so without this write-through the reactive overflow reason
+     is never surfaced and is lost across a restart. *)
+  (match
+     Keeper_meta_store.persist_compaction_decision
+       config
+       ~keeper_name:meta.name
+       ~decision
+   with
+   | Ok `Persisted -> ()
+   | Ok `No_durable_meta ->
+     Log.Keeper.debug
+       "%s: no durable meta to persist provider-overflow compaction decision (registry stamp retained)"
+       meta.name
+   | Error msg ->
+     Log.Keeper.warn
+       "%s: failed to persist provider-overflow compaction decision to disk: %s"
+       meta.name
+       msg);
   Log.Keeper.warn
     "%s: unresolved context overflow observed (%s); Keeper lifecycle remains active"
     meta.name

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1158,6 +1158,36 @@ let test_reactive_overflow_stamps_compaction_decision () =
         (Masc.Keeper_turn_runtime_budget.provider_overflow_decision ~reason)
         decision)
 
+(* Regression (codex #25270 P2#1): the reactive overflow decision must be durable
+   on disk. Status (read_meta_resolved) and the dashboard projection read
+   last_compaction_decision from the persisted meta, not the in-memory registry.
+   Counterfactual: without the disk write-through in record_overflow_failure the
+   on-disk last_decision stays at the seeded/empty value and the recovery reason
+   is never surfaced (or is lost across a restart). *)
+let test_reactive_overflow_persists_compaction_decision_to_disk () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
+  let name = "overflow-durable" in
+  let config = Workspace.default_config base in
+  let meta = seed_runtime_meta config name in
+  Masc.Keeper_registry.clear ();
+  ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+  Fun.protect ~finally:Masc.Keeper_registry.clear (fun () ->
+      let reason = "plan_provider_unavailable" in
+      Masc.Keeper_turn_runtime_budget.record_overflow_failure ~config ~meta ~reason;
+      match Store.read_meta config name with
+      | Error err -> Alcotest.failf "read_meta failed: %s" err
+      | Ok None ->
+        Alcotest.fail "keeper meta missing from disk after overflow failure"
+      | Ok (Some disk_meta) ->
+        let decision =
+          Masc.Keeper_meta_contract.compaction_runtime_decision_to_string
+            disk_meta.runtime.compaction_rt.last_decision
+        in
+        Alcotest.(check string)
+          "reactive overflow persists the recovery decision to the durable on-disk meta"
+          (Masc.Keeper_turn_runtime_budget.provider_overflow_decision ~reason)
+          decision)
+
 let () =
   init_runtime_default_for_tests ();
   Alcotest.run "keeper_effective_meta_overlay"
@@ -1219,5 +1249,8 @@ let () =
           Alcotest.test_case
             "reactive overflow stamps compaction decision for observability"
             `Quick test_reactive_overflow_stamps_compaction_decision;
+          Alcotest.test_case
+            "reactive overflow persists compaction decision to durable disk meta"
+            `Quick test_reactive_overflow_persists_compaction_decision_to_disk;
         ] );
     ]


### PR DESCRIPTION
## 요약
머지된 #25270(RFC #25268 PR-1)의 미해결 codex P2 2건을 근본 수리합니다.

## P2#1 — status가 읽는 durable 상태에 미영속 (persist)
- 증상: reactive provider-overflow 복구 실패 이유가 in-memory registry에만 stamp됨. status(`read_meta_resolved`)와 대시보드 프로젝션은 **on-disk meta**의 `last_compaction_decision`을 읽고, turn-failure 경로가 복구 이전에 pre-overflow meta로 `updated_meta`를 이미 disk에 flush → 이유가 표시 안 되고 재시작 시 소실.
- 근본: on-disk meta(SSOT)에 write-through 부재.
- 수리: `Keeper_meta_store.persist_compaction_decision` 신설(disk meta read → `last_decision`만 stamp → `write_meta_with_merge`로 CAS-race 시 재적용). `record_overflow_failure`가 registry stamp 후 이를 호출. `No_durable_meta`/`Error`는 명시 처리(silent swallow 없음).
- 테스트: `record_overflow_failure` 후 disk meta에서 이유가 durable하게 읽히는지 회귀.

## P2#2 — 대시보드 row에 필드 미방출 (dashboard-wire)
- 증상: `keeper-store-normalize.ts`는 `row.last_compaction_decision`을 읽지만, `normalizeKeepers`에 데이터를 공급하는 `keepers_dashboard_json`은 `compaction_count`/`last_compaction_saved_tokens`만 방출하고 이 키는 누락 → UI에서 항상 null.
- 수리: `keeper_status.ml`과 동일하게 `last_compaction_decision`을 방출.
- 테스트: 필드가 있는 row는 통과, 없으면 null로 정규화되는지 vitest.

## 검증
- dashboard: `tsc --noEmit` 통과, `vitest` 39 passed(신규 케이스 포함).
- OCaml: 로컬 serial-lock cold 빌드 미완료로 **build-unverified** — CI Build/Test에서 확인(그전까지 Draft 유지).

Closes #25270 P2s. Refs #25268.

RFC-WAIVED: 변경 경로(`lib/keeper/keeper_meta_store*`, `keeper_turn_runtime_budget`, `lib/dashboard/dashboard_http_keeper`, tests)는 credential/identity/operator-control/sandbox/keeper-credential/hooks/workflow 등 RFC-gated subsystem 비해당. 본 작업은 RFC #25268 관찰성 트랙의 PR-2.
