### PR TITLE
fix(keeper): re-enforce no-compaction receipt invariant at decode boundary and aggregate its fleet count

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -1549,6 +1549,7 @@ let unavailable_fleet_summary_json () =
     ; "reaction_count", `Int 0
     ; "turn_started_count", `Int 0
     ; "event_queue_ack_count", `Int 0
+    ; "event_queue_no_compaction_count", `Int 0
     ; "event_queue_requeue_count", `Int 0
     ; "event_queue_escalation_count", `Int 0
     ; "event_queue_external_input_count", `Int 0
@@ -1814,6 +1815,8 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "reaction_count", `Int (total_int "reaction_count")
     ; "turn_started_count", `Int (total_int "turn_started_count")
     ; "event_queue_ack_count", `Int (total_int "event_queue_ack_count")
+    ; ( "event_queue_no_compaction_count"
+      , `Int (total_int "event_queue_no_compaction_count") )
     ; "event_queue_requeue_count", `Int (total_int "event_queue_requeue_count")
     ; ( "event_queue_escalation_count"
       , `Int (total_int "event_queue_escalation_count") )

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -460,8 +460,13 @@ let validate_settlement = function
     Error "external-input failure judgment must not enqueue a successor"
 ;;
 
-let validate_settlement_for_lease settlement (lease : lease) =
-  match settlement, lease.stimuli with
+(* Pure receipt-vs-stimuli invariant. Kept in ONE place so the live settle
+   path (via [validate_settlement_for_lease]) and the persist decode boundary
+   (via [outbox_entry_of_yojson]) enforce the same rule: a [No_compaction]
+   settlement is only well-formed when paired with exactly one
+   manual-compaction request stimulus. *)
+let validate_settlement_for_stimuli settlement stimuli =
+  match settlement, stimuli with
   | No_compaction _,
     [ { Keeper_event_queue.payload =
           Keeper_event_queue.Manual_compaction_requested
@@ -472,6 +477,10 @@ let validate_settlement_for_lease settlement (lease : lease) =
     Error
       "no-compaction settlement requires one manual-compaction request stimulus"
   | (Ack | Requeue _ | Escalate _), _ -> Ok ()
+;;
+
+let validate_settlement_for_lease settlement (lease : lease) =
+  validate_settlement_for_stimuli settlement lease.stimuli
 ;;
 
 let receipt_for_lease ~settled_at ~settlement (lease : lease) =
@@ -980,6 +989,10 @@ let outbox_entry_of_yojson json =
   let* stimuli =
     list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
   in
+  (* Re-enforce the settle-time receipt-vs-stimuli invariant at the decode
+     boundary: a persisted [No_compaction] receipt paired with a non-manual or
+     mismatched stimulus is rejected as Error, not silently accepted as Ok. *)
+  let* () = validate_settlement_for_stimuli receipt.settlement stimuli in
   Ok { receipt; stimuli }
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -645,7 +645,7 @@
   test_board_context_inference_resolution)
  (libraries
   masc_test_deps masc.keeper_chat_delivery_identity masc_schedule multimodal
-  bigstringaf))
+  bigstringaf masc.keeper_checkpoint_ref))
 
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -159,6 +159,72 @@ let test_no_compaction_rejects_scheduled_product_work () =
   | Ok _ -> Alcotest.fail "no-compaction consumed a non-compaction product event"
 ;;
 
+let test_no_compaction_decode_rejects_mismatched_stimulus () =
+  (* Persist decode boundary re-enforces the settle-time receipt-vs-stimuli
+     invariant (parse, don't validate). A persisted state whose No_compaction
+     outbox receipt is paired with a non-manual stimulus must decode to Error,
+     not silently Ok. Counterfactual: without the decode-boundary call the same
+     tampered JSON decodes Ok. *)
+  let request =
+    stimulus
+      ~payload:Queue.Manual_compaction_requested
+      Queue.manual_compaction_post_id
+      1.0
+  in
+  let claimed, lease =
+    State.with_pending (queue [ request ]) State.empty |> claim_head
+  in
+  let lease = require_some "no-compaction lease" lease in
+  let terminal = no_compaction ~turn_count:7 State.No_eligible_history in
+  let settled, _ =
+    State.settle
+      ~settled_at:11.0
+      ~lease
+      ~settlement:(State.No_compaction terminal)
+      claimed
+    |> require_ok "settle no-compaction terminal"
+  in
+  let json = State.to_yojson settled in
+  (* The untampered persisted state decodes cleanly. *)
+  ignore (State.of_yojson json |> require_ok "untampered no-compaction decode");
+  let substitute =
+    Queue.stimulus_to_yojson (stimulus ~payload:Queue.Bootstrap "peer-work" 2.0)
+  in
+  let tamper_outbox_entry = function
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+              if String.equal key "stimuli"
+              then key, `List [ substitute ]
+              else key, value)
+           fields)
+    | other -> other
+  in
+  let tampered =
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+              match key, value with
+              | "transition_outbox", `List entries ->
+                key, `List (List.map tamper_outbox_entry entries)
+              | _ -> key, value)
+           fields)
+    | other -> other
+  in
+  match State.of_yojson tampered with
+  | Error message ->
+    Alcotest.(check string)
+      "decode boundary rejects mismatched no-compaction stimulus"
+      "no-compaction settlement requires one manual-compaction request stimulus"
+      message
+  | Ok _ ->
+    Alcotest.fail
+      "decode accepted a No_compaction receipt paired with a non-manual stimulus"
+;;
+
 let test_claim_codec_ack_idempotency () =
   let first = stimulus "first" 1.0 in
   let state = State.with_pending (queue [ first ]) State.empty in
@@ -1430,6 +1496,10 @@ let () =
             "lane write fault isolation"
             `Quick
             test_failed_owner_write_does_not_block_peer_lane
+        ; Alcotest.test_case
+            "no-compaction decode rejects mismatched stimulus"
+            `Quick
+            test_no_compaction_decode_rejects_mismatched_stimulus
         ] )
     ]
 ;;

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -85,6 +85,32 @@ let require_ok label = function
   | Error message -> failf "%s: %s" label message
 ;;
 
+let manual_compaction_stimulus () : Keeper_event_queue.stimulus =
+  { post_id = Keeper_event_queue.manual_compaction_post_id
+  ; urgency = Keeper_event_queue.Immediate
+  ; arrived_at = 1234.5
+  ; payload = Keeper_event_queue.Manual_compaction_requested
+  }
+;;
+
+let no_compaction_settlement ~turn_count reason :
+  Keeper_event_queue_state.settlement
+  =
+  let trace_id =
+    Keeper_id.Trace_id.of_string "trace-ledger-no-compaction"
+    |> require_ok "parse no-compaction trace"
+  in
+  let source =
+    Keeper_checkpoint_ref.of_persisted
+      ~trace_id
+      ~generation:3
+      ~turn_count
+      ~sha256:(String.make 64 'a')
+    |> Result.get_ok
+  in
+  Keeper_event_queue_state.No_compaction { source; reason }
+;;
+
 let persist_transition_outbox ~base_path ~keeper_name ~settlement stimuli =
   Keeper_event_queue_persistence.update_result
     ~base_path
@@ -1380,6 +1406,51 @@ let test_missing_identity_does_not_claim_an_occurrence_identity () =
   check_member_string "identity quarantine reason" "missing_stimulus_id" "reason" reason
 ;;
 
+let test_fleet_summary_aggregates_no_compaction_count () =
+  with_temp_base
+  @@ fun base_path ->
+  let record_no_compaction keeper_name =
+    let stimulus = manual_compaction_stimulus () in
+    ignore
+      (persist_transition_outbox
+         ~base_path
+         ~keeper_name
+         ~settlement:
+           (no_compaction_settlement
+              ~turn_count:7
+              Keeper_event_queue_state.No_eligible_history)
+         [ stimulus ]);
+    Keeper_reaction_ledger.record_event_queue_stimulus
+      ~base_path
+      ~keeper_name
+      stimulus;
+    Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+      ~base_path
+      ~keeper_name
+    |> require_ok "project no-compaction transition"
+  in
+  let keeper_a = "no-compaction-keeper-a" in
+  let keeper_b = "no-compaction-keeper-b" in
+  record_no_compaction keeper_a;
+  record_no_compaction keeper_b;
+  List.iter
+    (fun keeper_name ->
+      let summary =
+        Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+      in
+      check int "per-keeper no-compaction count" 1
+        (summary |> member "event_queue_no_compaction_count" |> to_int))
+    [ keeper_a; keeper_b ];
+  let fleet =
+    Keeper_reaction_ledger.fleet_summary_json
+      ~base_path
+      ~keeper_names:[ keeper_a; keeper_b ]
+      ~limit_per_keeper:10
+  in
+  check int "fleet summary aggregates no-compaction across keepers" 2
+    (fleet |> member "event_queue_no_compaction_count" |> to_int)
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -1480,6 +1551,10 @@ let () =
             "reaction_kind string round-trip drift guard"
             `Quick
             test_reaction_kind_string_roundtrip
+        ; test_case
+            "fleet summary aggregates no-compaction count across keepers"
+            `Quick
+            test_fleet_summary_aggregates_no_compaction_count
         ] )
     ]
 ;;


### PR DESCRIPTION
PR #25222의 미해결 codex P2 2건을 근본 수정합니다.

## P2#1 (keeper_event_queue_state) — 영속 decode 경계의 불변식 미강제
라이브 settle 경로는 `validate_settlement_for_lease`로 receipt↔stimuli 불변식
(`No_compaction`은 정확히 1개 manual-compaction request stimulus와 짝지어져야 함)을
강제하지만, 영속화 decode 경계(`outbox_entry_of_yojson`)는 이를 건너뛰어
`No_compaction` receipt가 비-manual/불일치 stimulus와 짝지어져도 조용히 `Ok`로
통과했습니다(손상·변조된 스냅샷이 불변식을 우회).

수정: 불변식 본체를 pure 함수 `validate_settlement_for_stimuli settlement stimuli`로
추출해 **한 곳에만** 두고(`validate_settlement_for_lease`가 이를 재사용), decode
경계에서 호출해 불일치를 `Error`로 막습니다. Parse, don't validate — 새 의미론 없음.

## P2#2 (keeper_reaction_ledger) — fleet 요약에서 필드 누락
키퍼별 요약은 `event_queue_no_compaction_count`를 내보내지만
`fleet_summary_json` / `unavailable_fleet_summary_json`은 이를 집계에서 누락했습니다.
`total_int`로 합산하고 unavailable 요약에 `0` 필드를 추가했습니다(관찰성 완결).

## 테스트
- P2#1: tampering된 `No_compaction`/비-manual 짝을 `of_yojson`이 거부(반례: decode
  경계 호출이 없으면 `Ok`).
- P2#2: 두 키퍼의 no-compaction settlement을 fleet 요약이 `2`로 집계(오늘: 키 부재).

## 검증
로컬 build는 fresh worktree cold 빌드가 lock 경합으로 타임아웃(**build-unverified**) —
API명은 `.mli`/기존 테스트 사용처와 대조 확인. CI Build&Test에서 검증합니다(그전까지 Draft).

Closes #25222 P2s.

RFC-WAIVED: `lib/keeper/*`, `lib/keeper_runtime/*`, `test/*`만 변경 — RFC-gated subsystem 비해당.
