### PR TITLE
fix(runtime)!: canonicalize capability namespace

### DIFF
--- a/config/oas-models-overlay.toml
+++ b/config/oas-models-overlay.toml
@@ -72,24 +72,6 @@ ignored_sampling_parameters = ["temperature", "top_p"]
 input_per_million = 0.0
 output_per_million = 0.0
 
-# Deployment transport alias for the vllm-qwen3-mtp serving contract.
-[[models]]
-id_prefix = "qwen36-35b-a3b-mtp"
-provider_name = "runpod_mtp"
-base = "openai_chat"
-max_context_tokens = 131072
-supports_tools = true
-supports_tool_choice = true
-supports_parallel_tool_calls = true
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "chat_template_kwargs"
-preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
-reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
-supports_native_streaming = true
-
 # Local Ollama Gemma 4 QAT build, probed on 2026-06-12.
 [[models]]
 id_prefix = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"

--- a/docs/rfc/RFC-0342-capability-catalog-overlay-and-boot-posture.md
+++ b/docs/rfc/RFC-0342-capability-catalog-overlay-and-boot-posture.md
@@ -20,6 +20,13 @@
 > config-root/parent full-catalog discovery and the repo full fork are retired.
 > Remaining masc-side work: D2 and D4.
 
+> 2026-07-19 update: D3 is implemented. A provider may declare the exact OAS
+> serving-contract id with `capability-namespace`; `Runtime_adapter` uses that
+> value only for `Provider_config.provider_id`, while transport lookup remains
+> keyed by the MASC provider id. The deployment overlay no longer duplicates
+> the `runpod_mtp/qwen36-35b-a3b-mtp` capability row or its reasoning replay
+> policy; OAS `vllm-qwen3-mtp` is the sole capability SSOT.
+
 ## 1. Problem
 
 2026-07-15, the server refused to boot: every routed runtime was reported
@@ -99,7 +106,7 @@ fail the load, they are not defaulted (same Unknown→Permissive bar as the
 gate). The capability gate then fires only for bindings that declare
 capabilities in neither the catalog nor runtime.toml.
 
-### D3. Alias → serving-contract mapping (masc, small)
+### D3. Alias → serving-contract mapping (masc, implemented)
 
 `[providers.<id>]` gains an optional key:
 

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -348,9 +348,12 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
     (provider : Runtime_schema.provider) (spec : Runtime_schema.model_spec)
   : (Llm_provider.Provider_config.t, string) result =
   let registry_entry = find_registry_entry provider.id in
+  let capability_provider_id =
+    Option.value provider.capability_namespace ~default:provider.id
+  in
   let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
   let model_capabilities_override =
-    model_capabilities_override_of_model_spec ~provider_id:provider.id spec
+    model_capabilities_override_of_model_spec ~provider_id:capability_provider_id spec
   in
   match provider.transport with
   | Http base_url ->
@@ -381,15 +384,11 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
        Ok
          (Llm_provider.Provider_config.make
             ~kind
-            (* [provider_id] is the runtime.toml [providers.<id>] table name. It is
-               the capability-catalog qualification key: [capability_provider_label]
-               prefers it over the wire [kind], so provider-qualified catalog rows
-               ([provider_name = "<id>"]) resolve per declared provider instead of
-               collapsing every OpenAI-compatible endpoint into the "openai_compat"
-               label (which no catalog row carries — the 2026-07-15 boot-gate
-               wipeout). OAS's own binding layer passes it the same way
-               (provider_runtime_binding.ml [runtime_binding_provider_config]). *)
-            ~provider_id:provider.id
+            (* [provider_id] is the OAS capability-catalog qualification key.
+               The optional deployment [capability-namespace] maps the MASC
+               transport id onto an OAS serving-contract id; absent that exact
+               declaration, the runtime.toml provider table id remains the key. *)
+            ~provider_id:capability_provider_id
             ~model_id:spec.api_name
             ~base_url
             ~api_key
@@ -415,7 +414,7 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
          (Llm_provider.Provider_config.make
             ~kind
             (* Same capability-qualification key as the Http branch above. *)
-            ~provider_id:provider.id
+            ~provider_id:capability_provider_id
             ~model_id:spec.api_name
             ~base_url:""
             ~api_key:(api_key_of_credential ?registry_entry provider.credentials)

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -349,7 +349,9 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
   : (Llm_provider.Provider_config.t, string) result =
   let registry_entry = find_registry_entry provider.id in
   let capability_provider_id =
-    Option.value provider.capability_namespace ~default:provider.id
+    match provider.capability_namespace with
+    | Some capability_namespace -> capability_namespace
+    | None -> provider.id
   in
   let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
   let model_capabilities_override =

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -46,6 +46,8 @@ let connect_timeout_s_key = "connect-timeout-s"
 
 type provider =
   { id : string
+  ; capability_namespace : string option
+    (** OAS serving-contract provider identity. [None] uses [id]. *)
   ; display_name : string
   ; protocol : string
   ; api_format : api_format

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -37,6 +37,10 @@ val connect_timeout_s_key : string
 
 type provider =
   { id : string
+  ; capability_namespace : string option
+    (** OAS serving-contract provider identity. [None] uses [id]. This maps a
+        deployment transport name to an OAS-owned capability catalog namespace
+        without copying model capability rows into MASC configuration. *)
   ; display_name : string
   ; protocol : string
   ; api_format : api_format

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -288,10 +288,27 @@ let parse_provider (id : string) (tbl : Otoml.t)
     | None -> Error "missing required field 'protocol'"
   in
   let transport_result = transport_of_provider tbl id in
-  match protocol_result, transport_result with
-  | Error e, _ -> Error (error (path ^ ".protocol") e)
-  | _, Error e -> Error (error path e)
-  | Ok (protocol, api_format), Ok transport ->
+  let capability_namespace_result =
+    match typed_find "string" path tbl "capability-namespace" Otoml.get_string with
+    | Error _ as error -> error
+    | Ok None -> Ok None
+    | Ok (Some value) when String.trim value = "" ->
+      Error
+        (error
+           (path ^ ".capability-namespace")
+           "capability-namespace must be non-empty")
+    | Ok (Some value) when value <> String.trim value ->
+      Error
+        (error
+           (path ^ ".capability-namespace")
+           "capability-namespace must not have leading or trailing whitespace")
+    | Ok (Some value) -> Ok (Some value)
+  in
+  match protocol_result, transport_result, capability_namespace_result with
+  | Error e, _, _ -> Error (error (path ^ ".protocol") e)
+  | _, Error e, _ -> Error (error path e)
+  | _, _, Error errors -> Error errors
+  | Ok (protocol, api_format), Ok transport, Ok capability_namespace ->
     let is_non_interactive =
       Otoml.find_or ~default:false tbl Otoml.get_boolean [ "is-non-interactive" ]
     in
@@ -345,6 +362,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
         | Ok healthcheck_path, Ok connect_timeout_s ->
           Ok
             { Runtime_schema.id
+            ; capability_namespace
             ; display_name
             ; protocol
             ; api_format

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -343,10 +343,10 @@ let with_deployment_oas_model_catalog f =
          | None -> fail "embedded plus deployment overlay catalog should load"
          | Some catalog -> f catalog)
 
-let test_deployment_oas_model_catalog_covers_live_runpod_mtp () =
+let test_deployment_oas_model_catalog_uses_upstream_qwen_mtp_contract () =
   with_deployment_oas_model_catalog @@ fun catalog ->
   let runpod_model_id = "qwen36-35b-a3b-mtp" in
-  let provider_labels = [ "runpod_mtp"; "vllm-qwen3-mtp" ] in
+  let provider_labels = [ "vllm-qwen3-mtp" ] in
   let expect_provider_lookup provider_name =
     match
       Llm_provider.Model_catalog.lookup_for_provider
@@ -390,8 +390,17 @@ let test_deployment_oas_model_catalog_covers_live_runpod_mtp () =
          failf "expected RunPod qwen3.6 capability lookup for %s" provider_label
        | Some caps -> expect_runpod_caps provider_label caps)
     provider_labels;
-  (* Verify both the deployment transport alias and the upstream serving
-     contract without bare fallback. *)
+  check
+    (option string)
+    "deployment alias does not duplicate the upstream capability row"
+    None
+    (Option.map
+       (fun (entry : Llm_provider.Model_catalog.model_entry) -> entry.id_prefix)
+       (Llm_provider.Model_catalog.lookup_for_provider
+          catalog
+          ~provider_name:"runpod_mtp"
+          ~model_id:runpod_model_id));
+  (* Verify the upstream serving contract without bare fallback. *)
   List.iter
     (fun provider_label ->
        let name = "RunPod qwen3.6 gate " ^ provider_label in
@@ -590,7 +599,7 @@ let test_deployment_oas_model_catalog_preserve_axes_resolve () =
            caps.reasoning_replay_override = Force_preserve_always))
   in
   expect_request_side_preserve
-    ~provider_name:"runpod_mtp"
+    ~provider_name:"vllm-qwen3-mtp"
     ~model_id:"qwen36-35b-a3b-mtp";
   expect_preserve_always_replay
     ~provider_name:"ollama_cloud"
@@ -2338,8 +2347,8 @@ let () =
     [ ( "runtime TOML gate",
         [ test_case "runtime.json is not a repo config source" `Quick
             test_runtime_json_not_in_repo_config;
-          test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
-            test_deployment_oas_model_catalog_covers_live_runpod_mtp;
+          test_case "deployment OAS catalog uses upstream Qwen MTP contract" `Quick
+            test_deployment_oas_model_catalog_uses_upstream_qwen_mtp_contract;
           test_case
             "deployment OAS catalog covers live RunPod RTX A6000 Gemma runtime"
             `Quick test_deployment_oas_model_catalog_covers_live_runpod_rtxa6000_gemma;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -30,6 +30,7 @@ let with_env key value f =
 
 let runpod_provider =
   { Runtime_schema.id = "runpod_mtp"
+  ; capability_namespace = None
   ; display_name = "RunPod"
   ; protocol = "openai-compatible-http"
   ; api_format = Chat_completions_api
@@ -174,6 +175,53 @@ let test_runtime_toml_threads_provider_connect_timeout () =
        failf "expected one provider/binding, got %d/%d"
          (List.length providers)
          (List.length bindings))
+
+let test_runtime_toml_threads_capability_namespace () =
+  let content =
+    runtime_toml_with_credentials
+      ~provider_extra:"capability-namespace = \"vllm-qwen3-mtp\""
+      inline_credentials
+  in
+  match Runtime_toml.parse_string content with
+  | Error errors ->
+    failf
+      "expected capability namespace to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (error : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" error.path error.message)
+            errors))
+  | Ok cfg ->
+    (match cfg.providers, cfg.bindings with
+     | [ provider ], [ binding ] ->
+       check (option string) "typed provider field"
+         (Some "vllm-qwen3-mtp")
+         provider.Runtime_schema.capability_namespace;
+       (match Runtime_adapter.binding_to_provider_config cfg binding with
+        | Error message -> failf "unexpected adapter error: %s" message
+        | Ok provider_cfg ->
+          check (option string) "OAS provider qualification"
+            (Some "vllm-qwen3-mtp")
+            provider_cfg.provider_id)
+     | providers, bindings ->
+       failf "expected one provider/binding, got %d/%d"
+         (List.length providers)
+         (List.length bindings))
+
+let test_runtime_toml_rejects_padded_capability_namespace () =
+  let content =
+    runtime_toml_with_credentials
+      ~provider_extra:"capability-namespace = \" vllm-qwen3-mtp \""
+      inline_credentials
+  in
+  match Runtime_toml.parse_string content with
+  | Ok _ -> fail "padded capability namespace must fail"
+  | Error errors ->
+    check_parse_error
+      errors
+      "providers.runpod_mtp.capability-namespace"
+      "capability-namespace must not have leading or trailing whitespace"
 
 let test_runtime_toml_threads_model_sampling_config () =
   let content =
@@ -879,6 +927,35 @@ let test_adapter_stamps_declared_provider_id () =
     (Some "runpod_mtp")
     (provider_cfg ()).provider_id
 
+let test_adapter_stamps_declared_capability_namespace () =
+  let provider =
+    { runpod_provider with
+      capability_namespace = Some "vllm-qwen3-mtp"
+    }
+  in
+  let cfg =
+    { Runtime_schema.providers = [ provider ]
+    ; models = [ { qwen_model with api_name = "qwen36-35b-a3b-mtp" } ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; librarian_runtime_id = None
+    ; structured_judge_runtime_id = None
+    ; hitl_summary_runtime_id = None
+    ; cross_verifier_runtime_id = None
+    ; keeper_assignments = []
+    ; media_failover = []
+    ; lane_decls = []
+    }
+  in
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  | Error message -> failf "unexpected adapter error: %s" message
+  | Ok provider_cfg ->
+    check
+      (option string)
+      "OAS serving-contract provider id"
+      (Some "vllm-qwen3-mtp")
+      provider_cfg.provider_id
+
 let test_provider_scoped_catalog_row_resolves_for_declared_provider () =
   with_model_catalog
     {|
@@ -1489,6 +1566,10 @@ let () =
             `Quick
             test_adapter_stamps_declared_provider_id
         ; test_case
+            "adapter stamps declared capability namespace"
+            `Quick
+            test_adapter_stamps_declared_capability_namespace
+        ; test_case
             "provider-scoped catalog row resolves for declared provider"
             `Quick
             test_provider_scoped_catalog_row_resolves_for_declared_provider
@@ -1520,6 +1601,14 @@ let () =
             "runtime TOML threads provider connect timeout"
             `Quick
             test_runtime_toml_threads_provider_connect_timeout
+        ; test_case
+            "runtime TOML threads capability namespace"
+            `Quick
+            test_runtime_toml_threads_capability_namespace
+        ; test_case
+            "runtime TOML rejects padded capability namespace"
+            `Quick
+            test_runtime_toml_rejects_padded_capability_namespace
         ; test_case
             "runtime TOML threads model sampling config"
             `Quick


### PR DESCRIPTION
## Goal

Remove the deployment-owned duplicate capability row for `runpod_mtp/qwen36-35b-a3b-mtp` and make the OAS serving contract the only capability/reasoning-replay SSOT.

## Root cause

The deployment overlay copied the OAS `vllm-qwen3-mtp` row but changed `reasoning_replay` from `latest_user_turn_tool_calls` to `drop_without_tool_preserve_with_tool`. That made transport configuration override provider/model feedback semantics and could replay old tool-call reasoning across later user turns.

## Change

- add typed optional `[providers.<id>].capability-namespace`
- keep transport/credential lookup keyed by the MASC provider id
- pass the declared serving-contract id only as OAS `Provider_config.provider_id`
- use the same id for catalog lookup before deciding whether a complete runtime capability override is needed
- delete the duplicate `runpod_mtp` model row from `oas-models-overlay.toml`
- reject blank, padded, and non-string namespace values at the TOML boundary

The runtime binding remains `runpod_mtp.<model>`; only its OAS capability qualification becomes `vllm-qwen3-mtp` when explicitly declared. OAS remains unaware of MASC.

## Validation

- `ocamlc -stop-after parsing` on all changed OCaml sources/tests
- `ocamlformat --check` on all changed OCaml sources/tests
- `git diff --check`
- focused Dune build was attempted twice but not run because another worktree held the machine-wide `/tmp/me-dune-local.lock`; Draft CI is the build authority

## RFC

- RFC-0342 D3
- OAS RFC-OAS-036

Co-Authored-By: Codex <agent@masc.local>
