### PR TITLE
feat(keeper): type owner-fenced accepted cancellation

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -414,7 +414,8 @@ let settle_claimed_lease
 
 let settlement_is_ack = function
   | Keeper_registry_event_queue.Ack
-  | Keeper_registry_event_queue.No_compaction _ -> true
+  | Keeper_registry_event_queue.No_compaction _
+  | Keeper_registry_event_queue.Cancel_accepted _ -> true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -22,6 +22,7 @@ type reaction_kind =
   | Turn_started
   | Event_queue_ack
   | Event_queue_no_compaction
+  | Event_queue_cancelled
   | Event_queue_requeued
   | Event_queue_escalated
   | Cursor_ack
@@ -71,6 +72,7 @@ let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
   | Event_queue_ack -> "event_queue_ack"
   | Event_queue_no_compaction -> "event_queue_no_compaction"
+  | Event_queue_cancelled -> "event_queue_cancelled"
   | Event_queue_requeued -> "event_queue_requeued"
   | Event_queue_escalated -> "event_queue_escalated"
   | Cursor_ack -> "cursor_ack"
@@ -82,6 +84,7 @@ let reaction_kind_of_string = function
   | "turn_started" -> Ok Turn_started
   | "event_queue_ack" -> Ok Event_queue_ack
   | "event_queue_no_compaction" -> Ok Event_queue_no_compaction
+  | "event_queue_cancelled" -> Ok Event_queue_cancelled
   | "event_queue_requeued" -> Ok Event_queue_requeued
   | "event_queue_escalated" -> Ok Event_queue_escalated
   | "cursor_ack" -> Ok Cursor_ack
@@ -295,6 +298,7 @@ let record_event_queue_turn_started ~base_path ~keeper_name stimulus =
 let reaction_kind_of_settlement = function
   | Keeper_event_queue_state.Ack -> Event_queue_ack
   | Keeper_event_queue_state.No_compaction _ -> Event_queue_no_compaction
+  | Keeper_event_queue_state.Cancel_accepted _ -> Event_queue_cancelled
   | Keeper_event_queue_state.Requeue _ -> Event_queue_requeued
   | Keeper_event_queue_state.Escalate _ -> Event_queue_escalated
 ;;
@@ -668,25 +672,35 @@ let reaction_kind_matches_settlement reaction_kind settlement =
   match reaction_kind, settlement with
   | Event_queue_ack, Keeper_event_queue_state.Ack -> true
   | Event_queue_no_compaction, Keeper_event_queue_state.No_compaction _ -> true
+  | Event_queue_cancelled, Keeper_event_queue_state.Cancel_accepted _ -> true
   | Event_queue_requeued, Keeper_event_queue_state.Requeue _ -> true
   | Event_queue_escalated, Keeper_event_queue_state.Escalate _ -> true
   | Turn_started, _
   | Cursor_ack, _
   | Event_queue_ack,
     ( Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_no_compaction,
     ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.Cancel_accepted _
+    | Keeper_event_queue_state.Requeue _
+    | Keeper_event_queue_state.Escalate _ )
+  | Event_queue_cancelled,
+    ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_requeued,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_escalated,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Requeue _ ) -> false
 ;;
 
@@ -805,8 +819,8 @@ let decode_reaction_row ~event_id metadata reaction =
     if String.equal event_id expected_event_id
     then Ok (Current_reaction { metadata; reaction_kind; transition_receipt = None })
     else Error Event_identity_mismatch
-  | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_requeued
-    | Event_queue_escalated ),
+  | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_cancelled
+    | Event_queue_requeued | Event_queue_escalated ),
     "keeper_event_queue_settlement" ->
     let* transition_receipt =
       decode_transition_reaction
@@ -823,13 +837,14 @@ let decode_reaction_row ~event_id metadata reaction =
   | Cursor_ack, "keeper_world_observation.board_cursor" ->
     Error Reaction_source_mismatch
   | Turn_started, "keeper_event_queue_settlement"
-  | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_requeued
-    | Event_queue_escalated ),
+  | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_cancelled
+    | Event_queue_requeued | Event_queue_escalated ),
     "keeper_event_queue"
   | Cursor_ack, ("keeper_event_queue" | "keeper_event_queue_settlement") ->
     Error Reaction_source_mismatch
   | ( Turn_started | Event_queue_ack | Event_queue_no_compaction
-    | Event_queue_requeued | Event_queue_escalated | Cursor_ack ),
+    | Event_queue_cancelled | Event_queue_requeued | Event_queue_escalated
+    | Cursor_ack ),
     _ -> Error Unknown_reaction_source
 ;;
 
@@ -1070,8 +1085,8 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
              := max_recorded_at !event_queue_ack_recorded_at recorded_at
          | Current_reaction
              { reaction_kind =
-                 ( Event_queue_no_compaction | Event_queue_requeued
-                 | Event_queue_escalated | Cursor_ack )
+                 ( Event_queue_no_compaction | Event_queue_cancelled
+                 | Event_queue_requeued | Event_queue_escalated | Cursor_ack )
              ; _
              }
          | Current_cursor_ack _ -> ())
@@ -1310,6 +1325,7 @@ let summarize_rows ~keeper_name ~limit rows =
   let turn_started_count = ref 0 in
   let event_queue_ack_count = ref 0 in
   let event_queue_no_compaction_count = ref 0 in
+  let event_queue_cancelled_count = ref 0 in
   let event_queue_requeue_count = ref 0 in
   let event_queue_escalation_count = ref 0 in
   let event_queue_external_input_count = ref 0 in
@@ -1374,6 +1390,7 @@ let summarize_rows ~keeper_name ~limit rows =
     | Turn_started, None -> incr turn_started_count
     | Event_queue_ack, Some _ -> incr event_queue_ack_count
     | Event_queue_no_compaction, Some _ -> incr event_queue_no_compaction_count
+    | Event_queue_cancelled, Some _ -> incr event_queue_cancelled_count
     | Event_queue_requeued, Some _ -> incr event_queue_requeue_count
     | Event_queue_escalated, Some receipt ->
       incr event_queue_escalation_count;
@@ -1383,11 +1400,12 @@ let summarize_rows ~keeper_name ~limit rows =
          then incr event_queue_external_input_count
        | Keeper_event_queue_state.Ack
        | Keeper_event_queue_state.No_compaction _
+       | Keeper_event_queue_state.Cancel_accepted _
        | Keeper_event_queue_state.Requeue _ -> ())
     | Cursor_ack, None -> incr cursor_ack_count
     | Turn_started, Some _
-    | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_requeued
-      | Event_queue_escalated ), None
+    | ( Event_queue_ack | Event_queue_no_compaction | Event_queue_cancelled
+      | Event_queue_requeued | Event_queue_escalated ), None
     | Cursor_ack, Some _ -> ()
   in
   let note_current_row current_row =
@@ -1455,6 +1473,7 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "turn_started_count", `Int !turn_started_count
     ; "event_queue_ack_count", `Int !event_queue_ack_count
     ; "event_queue_no_compaction_count", `Int !event_queue_no_compaction_count
+    ; "event_queue_cancelled_count", `Int !event_queue_cancelled_count
     ; "event_queue_requeue_count", `Int !event_queue_requeue_count
     ; "event_queue_escalation_count", `Int !event_queue_escalation_count
     ; "event_queue_external_input_count", `Int !event_queue_external_input_count
@@ -1489,6 +1508,7 @@ let error_summary ~keeper_name ~limit error =
     ; "turn_started_count", `Int 0
     ; "event_queue_ack_count", `Int 0
     ; "event_queue_no_compaction_count", `Int 0
+    ; "event_queue_cancelled_count", `Int 0
     ; "event_queue_requeue_count", `Int 0
     ; "event_queue_escalation_count", `Int 0
     ; "cursor_ack_count", `Int 0

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -991,9 +991,11 @@ type event_queue_reaction_evidence =
   ; stimulus_seen : bool
   ; turn_started_seen : bool
   ; event_queue_ack_seen : bool
+  ; event_queue_cancelled_seen : bool
   ; stimulus_recorded_at : float option
   ; turn_started_recorded_at : float option
   ; event_queue_ack_recorded_at : float option
+  ; event_queue_cancelled_recorded_at : float option
   ; latest_recorded_at : float option
   ; matched_record_count : int
   ; quarantined_record_count : int
@@ -1030,9 +1032,11 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
   let stimulus_seen = ref false in
   let turn_started_seen = ref false in
   let event_queue_ack_seen = ref false in
+  let event_queue_cancelled_seen = ref false in
   let stimulus_recorded_at = ref None in
   let turn_started_recorded_at = ref None in
   let event_queue_ack_recorded_at = ref None in
+  let event_queue_cancelled_recorded_at = ref None in
   let latest_recorded_at = ref None in
   let matched_record_count = ref 0 in
   let quarantined_record_count = ref 0 in
@@ -1083,10 +1087,14 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
            event_queue_ack_seen := true;
            event_queue_ack_recorded_at
              := max_recorded_at !event_queue_ack_recorded_at recorded_at
+         | Current_reaction { reaction_kind = Event_queue_cancelled; _ } ->
+           event_queue_cancelled_seen := true;
+           event_queue_cancelled_recorded_at
+             := max_recorded_at !event_queue_cancelled_recorded_at recorded_at
          | Current_reaction
              { reaction_kind =
-                 ( Event_queue_no_compaction | Event_queue_cancelled
-                 | Event_queue_requeued | Event_queue_escalated | Cursor_ack )
+                 ( Event_queue_no_compaction | Event_queue_requeued
+                 | Event_queue_escalated | Cursor_ack )
              ; _
              }
          | Current_cursor_ack _ -> ())
@@ -1112,9 +1120,11 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
       ; stimulus_seen = !stimulus_seen
       ; turn_started_seen = !turn_started_seen
       ; event_queue_ack_seen = !event_queue_ack_seen
+      ; event_queue_cancelled_seen = !event_queue_cancelled_seen
       ; stimulus_recorded_at = !stimulus_recorded_at
       ; turn_started_recorded_at = !turn_started_recorded_at
       ; event_queue_ack_recorded_at = !event_queue_ack_recorded_at
+      ; event_queue_cancelled_recorded_at = !event_queue_cancelled_recorded_at
       ; latest_recorded_at = !latest_recorded_at
       ; matched_record_count = !matched_record_count
       ; quarantined_record_count = !quarantined_record_count
@@ -1570,6 +1580,7 @@ let unavailable_fleet_summary_json () =
     ; "turn_started_count", `Int 0
     ; "event_queue_ack_count", `Int 0
     ; "event_queue_no_compaction_count", `Int 0
+    ; "event_queue_cancelled_count", `Int 0
     ; "event_queue_requeue_count", `Int 0
     ; "event_queue_escalation_count", `Int 0
     ; "event_queue_external_input_count", `Int 0
@@ -1837,6 +1848,8 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "event_queue_ack_count", `Int (total_int "event_queue_ack_count")
     ; ( "event_queue_no_compaction_count"
       , `Int (total_int "event_queue_no_compaction_count") )
+    ; ( "event_queue_cancelled_count"
+      , `Int (total_int "event_queue_cancelled_count") )
     ; "event_queue_requeue_count", `Int (total_int "event_queue_requeue_count")
     ; ( "event_queue_escalation_count"
       , `Int (total_int "event_queue_escalation_count") )

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -31,6 +31,7 @@ type reaction_kind =
   | Turn_started
   | Event_queue_ack
   | Event_queue_no_compaction
+  | Event_queue_cancelled
   | Event_queue_requeued
   | Event_queue_escalated
   | Cursor_ack

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -85,9 +85,11 @@ type event_queue_reaction_evidence =
   ; stimulus_seen : bool
   ; turn_started_seen : bool
   ; event_queue_ack_seen : bool
+  ; event_queue_cancelled_seen : bool
   ; stimulus_recorded_at : float option
   ; turn_started_recorded_at : float option
   ; event_queue_ack_recorded_at : float option
+  ; event_queue_cancelled_recorded_at : float option
   ; latest_recorded_at : float option
   ; matched_record_count : int
   ; quarantined_record_count : int
@@ -116,8 +118,9 @@ val event_queue_reaction_evidence_result :
     semantic-invalid rows produce {!Evidence_quarantined}. Syntax-invalid rows
     and parseable rows without the queried identity remain visible through the
     operator summary, but cannot be attributed to this occurrence and therefore
-    do not become its negative evidence. Empty query identities and storage
-    failures remain typed errors. *)
+    do not become its negative evidence. Exact ACK and accepted-cancellation
+    terminals remain distinct typed evidence. Empty query identities and
+    storage failures remain typed errors. *)
 
 val record_board_cursor_ack :
   base_path:string ->

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -40,9 +40,17 @@ type no_compaction = Keeper_event_queue_persistence.no_compaction =
   ; reason : no_compaction_reason
   }
 
+type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellation =
+  { source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; reason : string
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
   | No_compaction of no_compaction
+  | Cancel_accepted of accepted_cancellation
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -39,9 +39,17 @@ type no_compaction = Keeper_event_queue_persistence.no_compaction =
   ; reason : no_compaction_reason
   }
 
+type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellation =
+  { source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; reason : string
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
   | No_compaction of no_compaction
+  | Cancel_accepted of accepted_cancellation
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -37,9 +37,17 @@ type no_compaction = State.no_compaction =
   ; reason : no_compaction_reason
   }
 
+type accepted_cancellation = State.accepted_cancellation =
+  { source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; reason : string
+  }
+
 type settlement = State.settlement =
   | Ack
   | No_compaction of no_compaction
+  | Cancel_accepted of accepted_cancellation
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -41,9 +41,17 @@ type no_compaction = Keeper_event_queue_state.no_compaction =
   ; reason : no_compaction_reason
   }
 
+type accepted_cancellation = Keeper_event_queue_state.accepted_cancellation =
+  { source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; reason : string
+  }
+
 type settlement = Keeper_event_queue_state.settlement =
   | Ack
   | No_compaction of no_compaction
+  | Cancel_accepted of accepted_cancellation
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -34,6 +34,13 @@ type no_compaction =
   ; reason : no_compaction_reason
   }
 
+type accepted_cancellation =
+  { source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; reason : string
+  }
+
 let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
@@ -43,6 +50,7 @@ let escalation_reason_requests_external_input = function
 type settlement =
   | Ack
   | No_compaction of no_compaction
+  | Cancel_accepted of accepted_cancellation
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -366,6 +374,7 @@ let escalation_reason_of_wire ~label ~detail_json =
 let settlement_kind_label = function
   | Ack -> "ack"
   | No_compaction _ -> "no_compaction"
+  | Cancel_accepted _ -> "cancel_accepted"
   | Requeue _ -> "requeue"
   | Escalate _ -> "escalate"
 ;;
@@ -392,15 +401,17 @@ let settlement_equal left right =
   | No_compaction left, No_compaction right ->
     Keeper_checkpoint_ref.equal left.source right.source
     && left.reason = right.reason
+  | Cancel_accepted left, Cancel_accepted right -> left = right
   | Requeue left, Requeue right -> left = right
   | ( Escalate { reason = left_reason; successor = left_successor }
     , Escalate { reason = right_reason; successor = right_successor } ) ->
     left_reason = right_reason
     && successor_equal left_successor right_successor
-  | Ack, (No_compaction _ | Requeue _ | Escalate _)
-  | No_compaction _, (Ack | Requeue _ | Escalate _)
-  | Requeue _, (Ack | No_compaction _ | Escalate _)
-  | Escalate _, (Ack | No_compaction _ | Requeue _) ->
+  | Ack, (No_compaction _ | Cancel_accepted _ | Requeue _ | Escalate _)
+  | No_compaction _, (Ack | Cancel_accepted _ | Requeue _ | Escalate _)
+  | Cancel_accepted _, (Ack | No_compaction _ | Requeue _ | Escalate _)
+  | Requeue _, (Ack | No_compaction _ | Cancel_accepted _ | Escalate _)
+  | Escalate _, (Ack | No_compaction _ | Cancel_accepted _ | Requeue _) ->
     false
 ;;
 
@@ -413,8 +424,21 @@ let transition_receipt_equal left right =
   && left.settlement = right.settlement
 ;;
 
+let validate_accepted_cancellation cancellation =
+  if Int64.compare cancellation.source_revision 0L < 0
+  then Error "accepted cancellation source revision must not be negative"
+  else if cancellation.owner_generation < 0
+  then Error "accepted cancellation owner generation must not be negative"
+  else if String.equal (String.trim cancellation.operator_operation_id) ""
+  then Error "accepted cancellation operator operation id must not be empty"
+  else if String.equal (String.trim cancellation.reason) ""
+  then Error "accepted cancellation reason must not be empty"
+  else Ok ()
+;;
+
 let validate_settlement = function
   | Ack | No_compaction _ | Requeue _ -> Ok ()
+  | Cancel_accepted cancellation -> validate_accepted_cancellation cancellation
   | Escalate
       { reason = Failure_judgment_requested
       ; successor =
@@ -462,9 +486,8 @@ let validate_settlement = function
 
 (* Pure receipt-vs-stimuli invariant. Kept in ONE place so the live settle
    path (via [validate_settlement_for_lease]) and the persist decode boundary
-   (via [outbox_entry_of_yojson]) enforce the same rule: a [No_compaction]
-   settlement is only well-formed when paired with exactly one
-   manual-compaction request stimulus. *)
+   (via [outbox_entry_of_yojson]) enforce the same closed settlement/source
+   rules. *)
 let validate_settlement_for_stimuli settlement stimuli =
   match settlement, stimuli with
   | No_compaction _,
@@ -476,6 +499,9 @@ let validate_settlement_for_stimuli settlement stimuli =
   | No_compaction _, _ ->
     Error
       "no-compaction settlement requires one manual-compaction request stimulus"
+  | Cancel_accepted _, [ _ ] -> Ok ()
+  | Cancel_accepted _, _ ->
+    Error "accepted cancellation requires exactly one accepted event stimulus"
   | (Ack | Requeue _ | Escalate _), _ -> Ok ()
 ;;
 
@@ -524,7 +550,7 @@ let lease_equal (left : lease) (right : lease) =
   && List.for_all2 Keeper_event_queue.stimulus_identity_equal left.stimuli right.stimuli
 ;;
 
-let settle ~settled_at ~lease ~settlement state =
+let settle_committed ~settled_at ~lease ~settlement state =
   let* () =
     if Float.is_finite settled_at
     then Ok ()
@@ -550,7 +576,7 @@ let settle ~settled_at ~lease ~settlement state =
     let* () = validate_settlement_for_lease settlement committed in
     let pending =
       match settlement with
-      | Ack | No_compaction _ -> state.pending
+      | Ack | No_compaction _ | Cancel_accepted _ -> state.pending
       | Requeue
           ( Retry_after_observed
           | Context_compaction_retry
@@ -580,6 +606,49 @@ let settle ~settled_at ~lease ~settlement state =
       , Settled receipt )
 ;;
 
+let settle ~settled_at ~lease ~settlement state =
+  match settlement with
+  | Cancel_accepted _ ->
+    Error "accepted cancellation requires the owner-fenced cancellation boundary"
+  | Ack | No_compaction _ | Requeue _ | Escalate _ ->
+    settle_committed ~settled_at ~lease ~settlement state
+;;
+
+let cancel_accepted
+      ~current_owner_generation
+      ~settled_at
+      ~(lease : lease)
+      ~cancellation
+      state
+  =
+  let settlement = Cancel_accepted cancellation in
+  match find_prior_receipt lease.lease_id state with
+  | Some _ -> settle_committed ~settled_at ~lease ~settlement state
+  | None ->
+    let* () = validate_accepted_cancellation cancellation in
+    let* () =
+      if Int.equal current_owner_generation cancellation.owner_generation
+      then Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "accepted cancellation owner generation changed: expected %d, current %d"
+             cancellation.owner_generation
+             current_owner_generation)
+    in
+    let* () =
+      if Int64.equal state.revision cancellation.source_revision
+      then Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "accepted cancellation source revision changed: expected %Ld, current %Ld"
+             cancellation.source_revision
+             state.revision)
+    in
+    settle_committed ~settled_at ~lease ~settlement state
+;;
+
 let replay_transition_receipt receipt state =
   match
     List.find_opt
@@ -588,7 +657,7 @@ let replay_transition_receipt receipt state =
   with
   | Some lease ->
     let* state, result =
-      settle
+      settle_committed
         ~settled_at:receipt.settled_at
         ~lease
         ~settlement:receipt.settlement
@@ -851,6 +920,14 @@ let settlement_to_yojson = function
       ; "reason", `String (no_compaction_reason_label reason)
       ; "source", checkpoint_source_to_yojson source
       ]
+  | Cancel_accepted cancellation ->
+    `Assoc
+      [ "kind", `String "cancel_accepted"
+      ; "source_revision", int64_json cancellation.source_revision
+      ; "owner_generation", `Int cancellation.owner_generation
+      ; "operator_operation_id", `String cancellation.operator_operation_id
+      ; "reason", `String cancellation.reason
+      ]
   | Requeue reason ->
     `Assoc
       [ "kind", `String "requeue"
@@ -885,6 +962,30 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = checkpoint_source_of_yojson source_json in
     Ok (No_compaction { source; reason })
+  | "cancel_accepted" ->
+    let* () =
+      exact_fields
+        ~context
+        ~expected:
+          [ "kind"
+          ; "source_revision"
+          ; "owner_generation"
+          ; "operator_operation_id"
+          ; "reason"
+          ]
+        fields
+    in
+    let* source_revision = int64_field ~context "source_revision" fields in
+    let* owner_generation = int_field ~context "owner_generation" fields in
+    let* operator_operation_id =
+      string_field ~context "operator_operation_id" fields
+    in
+    let* reason = string_field ~context "reason" fields in
+    let cancellation =
+      { source_revision; owner_generation; operator_operation_id; reason }
+    in
+    let* () = validate_accepted_cancellation cancellation in
+    Ok (Cancel_accepted cancellation)
   | "requeue" ->
     let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in
@@ -990,8 +1091,7 @@ let outbox_entry_of_yojson json =
     list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
   in
   (* Re-enforce the settle-time receipt-vs-stimuli invariant at the decode
-     boundary: a persisted [No_compaction] receipt paired with a non-manual or
-     mismatched stimulus is rejected as Error, not silently accepted as Ok. *)
+     boundary; malformed typed terminal receipts are rejected as [Error]. *)
   let* () = validate_settlement_for_stimuli receipt.settlement stimuli in
   Ok { receipt; stimuli }
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -41,6 +41,16 @@ type no_compaction =
   ; reason : no_compaction_reason
   }
 
+type accepted_cancellation =
+  { source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; reason : string
+  }
+(** Exact operator authority for terminally cancelling one accepted event.
+    [source_revision] and [owner_generation] fence the observed paused owner;
+    [operator_operation_id] makes replay/conflict explicit. *)
+
 val no_compaction_reason_label : no_compaction_reason -> string
 val no_compaction_reason_of_label : string -> (no_compaction_reason, string) result
 
@@ -52,6 +62,7 @@ val escalation_reason_requests_external_input : escalation_reason -> bool
 type settlement =
   | Ack
   | No_compaction of no_compaction
+  | Cancel_accepted of accepted_cancellation
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -132,6 +143,19 @@ val settle :
     only for a lease containing exactly one typed
     [Manual_compaction_requested] stimulus; it cannot retire product work whose
     provider turn failed. Non-finite settlement times are rejected. *)
+
+val cancel_accepted :
+  current_owner_generation:int ->
+  settled_at:float ->
+  lease:lease ->
+  cancellation:accepted_cancellation ->
+  t ->
+  (t * settle_result, string) result
+(** Terminally settle exactly one leased accepted event when both the durable
+    queue revision and owner generation still match the operator snapshot.
+    Generic {!settle} rejects [Cancel_accepted], so callers cannot bypass this
+    owner-fenced boundary. Replaying the same committed cancellation is
+    idempotent; a different operation is a conflict. *)
 
 val replay_transition_receipt : transition_receipt -> t -> (t, string) result
 (** Apply one canonical durable receipt to its exact active lease. Replaying

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -57,7 +57,11 @@ let wake_enqueue_counts_of_dispatches dispatches =
           | Error _ -> counts
           | Ok
               (Consumers.Keeper_wake_enqueued
-                { occurrence_status = Consumers.Keeper_wake_already_acked; _ }) ->
+                { occurrence_status =
+                    ( Consumers.Keeper_wake_already_acked
+                    | Consumers.Keeper_wake_already_cancelled )
+                ; _
+                }) ->
             counts
           | Ok
               (Consumers.Keeper_wake_enqueued

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2678,6 +2678,8 @@ let schedule_keeper_reaction_evidence_dashboard_json
                   ; "stimulus_seen", `Bool evidence.stimulus_seen
                   ; "turn_started_seen", `Bool evidence.turn_started_seen
                   ; "event_queue_ack_seen", `Bool evidence.event_queue_ack_seen
+                  ; ( "event_queue_cancelled_seen"
+                    , `Bool evidence.event_queue_cancelled_seen )
                   ; "matched_record_count", `Int evidence.matched_record_count
                   ; ( "quarantined_record_count"
                     , `Int evidence.quarantined_record_count )
@@ -2699,6 +2701,13 @@ let schedule_keeper_reaction_evidence_dashboard_json
                       | Some ts -> `Float ts )
                   ; ( "event_queue_ack_recorded_at_iso"
                     , unix_iso_option_json evidence.event_queue_ack_recorded_at )
+                  ; ( "event_queue_cancelled_recorded_at"
+                    , match evidence.event_queue_cancelled_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "event_queue_cancelled_recorded_at_iso"
+                    , unix_iso_option_json
+                        evidence.event_queue_cancelled_recorded_at )
                   ; ( "latest_recorded_at"
                     , match evidence.latest_recorded_at with
                       | None -> `Null
@@ -2751,7 +2760,13 @@ let schedule_keeper_reaction_evidence_dashboard_json
                    @ [ "stimulus_id", `String stimulus_id ])
               | Ok (Keeper_reaction_ledger.Evidence_complete evidence) ->
                 let projection_status =
-                  if evidence.event_queue_ack_seen
+                  if
+                    evidence.event_queue_ack_seen
+                    && evidence.event_queue_cancelled_seen
+                  then "conflicting_terminal_settlement"
+                  else if evidence.event_queue_cancelled_seen
+                  then "matched_terminal_cancelled"
+                  else if evidence.event_queue_ack_seen
                   then "matched_consumed_ack"
                   else if evidence.turn_started_seen
                   then "matched_turn_started"

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -117,15 +117,18 @@ let keeper_wake_reaction_ledger_status_json_fields = function
 type keeper_wake_occurrence_status =
   | Keeper_wake_awaiting_ack
   | Keeper_wake_already_acked
+  | Keeper_wake_already_cancelled
 
 let keeper_wake_occurrence_status_to_string = function
   | Keeper_wake_awaiting_ack -> "awaiting_ack"
   | Keeper_wake_already_acked -> "already_acked"
+  | Keeper_wake_already_cancelled -> "already_cancelled"
 ;;
 
 let keeper_wake_occurrence_status_of_string = function
   | "awaiting_ack" -> Ok Keeper_wake_awaiting_ack
   | "already_acked" -> Ok Keeper_wake_already_acked
+  | "already_cancelled" -> Ok Keeper_wake_already_cancelled
   | value -> Error ("unsupported occurrence_status: " ^ value)
 ;;
 
@@ -250,7 +253,8 @@ let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
 
 type keeper_wake_acceptance =
   | Wake_required
-  | Already_drained
+  | Already_acked
+  | Already_cancelled
 
 let retryable_dispatch_failure detail =
   Error (Schedule_runner.Retryable_dispatch_failure detail)
@@ -292,11 +296,23 @@ let accept_keeper_wake_occurrence
          stimulus_id
          (Keeper_reaction_ledger.row_quarantine_reason_to_string first_reason))
   | Ok (Keeper_reaction_ledger.Evidence_complete evidence)
+    when evidence.event_queue_ack_seen && evidence.event_queue_cancelled_seen ->
+    retryable_dispatch_failure
+      (Printf.sprintf
+         "keeper reaction ledger has conflicting terminal settlements for occurrence %s"
+         stimulus_id)
+  | Ok (Keeper_reaction_ledger.Evidence_complete evidence)
+    when evidence.event_queue_cancelled_seen ->
+    (* The transition projector appends this exact-id cancellation before
+       retiring its outbox entry. Producer recovery must therefore preserve
+       the terminal operator disposition instead of recreating the wake. *)
+    Ok Already_cancelled
+  | Ok (Keeper_reaction_ledger.Evidence_complete evidence)
     when evidence.event_queue_ack_seen ->
     (* The transition projector appends this exact-id ACK before retiring its
        outbox entry. It is therefore the durable terminal occurrence fence,
        independent of pending/lease/outbox retention. *)
-    Ok Already_drained
+    Ok Already_acked
   | Ok (Keeper_reaction_ledger.Evidence_complete evidence) ->
     (match
        Keeper_registry_event_queue.enqueue_stimulus_durable_result
@@ -364,10 +380,11 @@ let dispatch_keeper_wake
   let occurrence_status =
     match acceptance with
     | Wake_required -> Keeper_wake_awaiting_ack
-    | Already_drained -> Keeper_wake_already_acked
+    | Already_acked -> Keeper_wake_already_acked
+    | Already_cancelled -> Keeper_wake_already_cancelled
   in
   (match acceptance with
-   | Already_drained -> ()
+   | Already_acked | Already_cancelled -> ()
    | Wake_required ->
      let wakeup_outcome =
        Keeper_registry.wakeup_running

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -7,6 +7,7 @@ type keeper_wake_reaction_ledger_status =
 type keeper_wake_occurrence_status =
   | Keeper_wake_awaiting_ack
   | Keeper_wake_already_acked
+  | Keeper_wake_already_cancelled
 
 type dispatch_receipt =
   | Keeper_wake_enqueued of

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -225,6 +225,132 @@ let test_no_compaction_decode_rejects_mismatched_stimulus () =
       "decode accepted a No_compaction receipt paired with a non-manual stimulus"
 ;;
 
+let accepted_cancellation ~source_revision ~owner_generation operation_id
+    : State.accepted_cancellation
+  =
+  { source_revision
+  ; owner_generation
+  ; operator_operation_id = operation_id
+  ; reason = "operator cancelled retained work"
+  }
+;;
+
+let test_accepted_cancellation_is_exact_owner_fenced_terminal () =
+  let accepted = stimulus "accepted-event" 1.0 in
+  let peer = stimulus "peer-event" 2.0 in
+  let source =
+    State.empty
+    |> State.with_pending (queue [ accepted; peer ])
+    |> State.with_revision 7L
+  in
+  let claimed, lease =
+    State.claim_when
+      ~claimed_at:3.0
+      ~ready:(Queue.stimulus_identity_equal accepted)
+      source
+    |> require_ok "claim exact accepted event"
+  in
+  let lease = require_some "accepted event lease" lease in
+  let cancellation = accepted_cancellation ~source_revision:7L ~owner_generation:4 "op-1" in
+  (match
+     State.settle
+       ~settled_at:4.0
+       ~lease
+       ~settlement:(State.Cancel_accepted cancellation)
+       claimed
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "generic settlement bypassed the owner fence");
+  let settled, result =
+    State.cancel_accepted
+      ~current_owner_generation:4
+      ~settled_at:4.0
+      ~lease
+      ~cancellation
+      claimed
+    |> require_ok "cancel accepted event"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "first cancellation was already settled"
+  in
+  Alcotest.(check string)
+    "typed transition identity"
+    "lease:1:cancel_accepted"
+    receipt.transition_id;
+  Alcotest.(check (list string))
+    "only the exact accepted event is terminal"
+    [ "peer-event" ]
+    (post_ids (State.pending settled));
+  let outbox = State.transition_outbox settled in
+  let source_stimuli =
+    match outbox with
+    | [ entry ] -> entry.stimuli
+    | _ -> Alcotest.fail "cancellation did not retain one exact outbox source"
+  in
+  Alcotest.(check bool)
+    "outbox retains the exact source identity"
+    true
+    (match source_stimuli with
+     | [ source ] -> Queue.stimulus_identity_equal source accepted
+     | _ -> false);
+  let decoded =
+    State.transition_receipt_to_yojson receipt
+    |> State.transition_receipt_of_yojson
+    |> require_ok "accepted cancellation receipt roundtrip"
+  in
+  Alcotest.(check bool)
+    "cancellation receipt roundtrips"
+    true
+    (State.transition_receipt_equal receipt decoded);
+  (match
+     State.cancel_accepted
+       ~current_owner_generation:99
+       ~settled_at:5.0
+       ~lease
+       ~cancellation
+       settled
+   with
+   | Ok (_, State.Already_settled repeated) ->
+     Alcotest.(check string)
+       "same operation replays the committed receipt"
+       receipt.transition_id
+       repeated.transition_id
+   | Ok (_, State.Settled _) -> Alcotest.fail "replay created a second cancellation"
+   | Error message -> Alcotest.failf "committed cancellation did not replay: %s" message)
+;;
+
+let test_accepted_cancellation_rejects_stale_fences () =
+  let accepted = stimulus "accepted-event" 1.0 in
+  let claimed, lease =
+    State.empty
+    |> State.with_pending (queue [ accepted ])
+    |> State.with_revision 7L
+    |> State.claim_when ~claimed_at:3.0 ~ready:(fun _ -> true)
+    |> require_ok "claim stale-fence fixture"
+  in
+  let lease = require_some "stale-fence lease" lease in
+  let cancel cancellation current_owner_generation =
+    State.cancel_accepted
+      ~current_owner_generation
+      ~settled_at:4.0
+      ~lease
+      ~cancellation
+      claimed
+  in
+  (match cancel (accepted_cancellation ~source_revision:7L ~owner_generation:4 "op-1") 5 with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "stale owner generation cancelled accepted work");
+  (match cancel (accepted_cancellation ~source_revision:6L ~owner_generation:4 "op-1") 4 with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "stale queue revision cancelled accepted work");
+  Alcotest.(check int)
+    "rejected cancellation keeps the exact lease active"
+    1
+    (List.length (State.leases claimed))
+;;
+
 let test_claim_codec_ack_idempotency () =
   let first = stimulus "first" 1.0 in
   let state = State.with_pending (queue [ first ]) State.empty in
@@ -1440,6 +1566,14 @@ let () =
             "no-compaction rejects scheduled product work"
             `Quick
             test_no_compaction_rejects_scheduled_product_work
+        ; Alcotest.test_case
+            "accepted cancellation is exact and owner-fenced"
+            `Quick
+            test_accepted_cancellation_is_exact_owner_fenced_terminal
+        ; Alcotest.test_case
+            "accepted cancellation rejects stale fences"
+            `Quick
+            test_accepted_cancellation_rejects_stale_fences
         ; Alcotest.test_case
             "claim earliest ready without reordering"
             `Quick

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -317,6 +317,8 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   check bool "exact stimulus seen" true stimulus_only.stimulus_seen;
   check bool "turn reaction absent" false stimulus_only.turn_started_seen;
   check bool "event queue ack absent" false stimulus_only.event_queue_ack_seen;
+  check bool "event queue cancellation absent" false
+    stimulus_only.event_queue_cancelled_seen;
   check int "one exact row before reaction" 1 stimulus_only.matched_record_count;
   Keeper_reaction_ledger.record_event_queue_turn_started
     ~base_path
@@ -332,6 +334,8 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   check bool "exact stimulus still seen" true reacted.stimulus_seen;
   check bool "turn reaction seen" true reacted.turn_started_seen;
   check bool "event queue ack still absent" false reacted.event_queue_ack_seen;
+  check bool "event queue cancellation still absent" false
+    reacted.event_queue_cancelled_seen;
   check int "two exact rows after reaction" 2 reacted.matched_record_count;
   ignore
     (persist_transition_outbox
@@ -351,6 +355,8 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
     |> require_complete_evidence "acknowledged evidence"
   in
   check bool "event queue ack seen" true acknowledged.event_queue_ack_seen;
+  check bool "ack is not cancellation" false
+    acknowledged.event_queue_cancelled_seen;
   check int "three exact rows after ack" 3 acknowledged.matched_record_count;
   let summary =
     Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
@@ -369,6 +375,7 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   check bool "missing stimulus absent" false missing.stimulus_seen;
   check bool "missing reaction absent" false missing.turn_started_seen;
   check bool "missing ack absent" false missing.event_queue_ack_seen;
+  check bool "missing cancellation absent" false missing.event_queue_cancelled_seen;
   check int "missing exact rows" 0 missing.matched_record_count;
   match
     Keeper_reaction_ledger.event_queue_reaction_evidence_result
@@ -1224,11 +1231,37 @@ let test_cancelled_transition_is_projected_as_typed_history () =
     ~base_path
     ~keeper_name
   |> require_ok "project cancellation receipt";
+  let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
+  let evidence =
+    Keeper_reaction_ledger.event_queue_reaction_evidence_result
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+    |> require_complete_evidence "accepted cancellation evidence"
+  in
+  check bool "accepted cancellation is exact terminal evidence" true
+    evidence.event_queue_cancelled_seen;
+  check bool "accepted cancellation is not ack evidence" false
+    evidence.event_queue_ack_seen;
+  check bool "accepted cancellation keeps its timestamp" true
+    (Option.is_some evidence.event_queue_cancelled_recorded_at);
   let summary =
     Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
   in
   check int "summary counts accepted cancellation" 1
     (summary |> member "event_queue_cancelled_count" |> to_int);
+  let fleet =
+    Keeper_reaction_ledger.fleet_summary_json
+      ~base_path
+      ~keeper_names:[ keeper_name ]
+      ~limit_per_keeper:10
+  in
+  check int "fleet counts accepted cancellation" 1
+    (fleet |> member "event_queue_cancelled_count" |> to_int);
+  check int "unavailable fleet preserves cancellation field" 0
+    (Keeper_reaction_ledger.unavailable_fleet_summary_json ()
+     |> member "event_queue_cancelled_count"
+     |> to_int);
   check int "typed cancellation row is current" 0
     (summary |> member "quarantined_row_count" |> to_int)
 ;;

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -1169,6 +1169,8 @@ let test_reaction_kind_string_roundtrip () =
       check bool "reaction_kind round-trips through string" true (roundtrips k))
     [ Keeper_reaction_ledger.Turn_started
     ; Keeper_reaction_ledger.Event_queue_ack
+    ; Keeper_reaction_ledger.Event_queue_no_compaction
+    ; Keeper_reaction_ledger.Event_queue_cancelled
     ; Keeper_reaction_ledger.Event_queue_requeued
     ; Keeper_reaction_ledger.Event_queue_escalated
     ; Keeper_reaction_ledger.Cursor_ack
@@ -1177,6 +1179,58 @@ let test_reaction_kind_string_roundtrip () =
   | Error (Keeper_reaction_ledger.Unknown_reaction_kind value) ->
     check string "unknown reaction decoder preserves evidence" "unknown_custom" value
   | Ok _ -> fail "unknown reaction string must not decode"
+;;
+
+let test_cancelled_transition_is_projected_as_typed_history () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cancelled-transition-keeper" in
+  let stimulus = board_stimulus () in
+  let pending = Keeper_event_queue.enqueue Keeper_event_queue.empty stimulus in
+  let state = Keeper_event_queue_state.with_pending pending Keeper_event_queue_state.empty in
+  let claimed, lease =
+    Keeper_event_queue_state.claim_when
+      ~claimed_at:1235.0
+      ~ready:(fun _ -> true)
+      state
+    |> require_ok "claim cancellation stimulus"
+  in
+  let lease =
+    match lease with
+    | Some lease -> lease
+    | None -> fail "cancellation stimulus was not claimed"
+  in
+  let cancellation : Keeper_event_queue_state.accepted_cancellation =
+    { source_revision = Keeper_event_queue_state.revision claimed
+    ; owner_generation = 7
+    ; operator_operation_id = "operator-cancel-1"
+    ; reason = "operator rejected paused work"
+    }
+  in
+  let cancelled, _ =
+    Keeper_event_queue_state.cancel_accepted
+      ~current_owner_generation:7
+      ~settled_at:1236.0
+      ~lease
+      ~cancellation
+      claimed
+    |> require_ok "commit cancellation receipt"
+  in
+  let snapshot_path = event_queue_snapshot_path ~base_path ~keeper_name in
+  mkdir_p (Filename.dirname snapshot_path);
+  write_file
+    snapshot_path
+    (Yojson.Safe.to_string (Keeper_event_queue_state.to_yojson cancelled));
+  Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+    ~base_path
+    ~keeper_name
+  |> require_ok "project cancellation receipt";
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check int "summary counts accepted cancellation" 1
+    (summary |> member "event_queue_cancelled_count" |> to_int);
+  check int "typed cancellation row is current" 0
+    (summary |> member "quarantined_row_count" |> to_int)
 ;;
 
 let test_unexpected_schema_rows_are_quarantined_without_double_counting () =
@@ -1555,6 +1609,10 @@ let () =
             "fleet summary aggregates no-compaction count across keepers"
             `Quick
             test_fleet_summary_aggregates_no_compaction_count
+        ; test_case
+            "accepted cancellation projects as typed history"
+            `Quick
+            test_cancelled_transition_is_projected_as_typed_history
         ] )
     ]
 ;;

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -53,6 +53,12 @@ let reaction_ledger_dir ~base_path ~keeper_name =
     "v4"
 ;;
 
+let event_queue_snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
+;;
+
 let write_malformed_reaction_ledger_row ~base_path ~keeper_name =
   let month_dir =
     Filename.concat (reaction_ledger_dir ~base_path ~keeper_name) "2026-01"
@@ -556,6 +562,116 @@ let test_acked_occurrence_recovery_does_not_enqueue_or_wake_again () =
          |> Keeper_event_queue.length))
 ;;
 
+let test_cancelled_occurrence_recovery_does_not_enqueue_or_wake_again () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let entry =
+    Keeper_registry.register ~base_path keeper_name (keeper_meta_for_name keeper_name)
+  in
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+    (fun () ->
+      let request = create_keeper_wake_schedule config in
+      let signal =
+        match Schedule_runner.tick config ~now:201.0 with
+        | Ok { emitted = [ signal ]; _ } -> signal
+        | Ok _ -> fail "expected one durable schedule signal"
+        | Error err -> fail (Schedule_runner.runner_error_to_string err)
+      in
+      let running =
+        match
+          Schedule_store.start_due_candidate
+            config
+            ~now:201.5
+            ~schedule_id:request.schedule_id
+        with
+        | Ok running -> running
+        | Error err -> fail (Schedule_store.store_error_to_string err)
+      in
+      Atomic.set entry.fiber_wakeup false;
+      (match Server_schedule_consumers.consumer.dispatch config ~now:202.0 signal running with
+       | Ok _ -> ()
+       | Error _ -> fail "initial schedule occurrence dispatch failed");
+      check bool "initial cancelled dispatch wakes lane" true
+        (Atomic.get entry.fiber_wakeup);
+      let lease =
+        match
+          Keeper_registry_event_queue.claim_when_result
+            ~base_path
+            keeper_name
+            ~claimed_at:202.5
+            ~ready:(fun _ -> true)
+        with
+        | Ok (Some lease) -> lease
+        | Ok None -> fail "scheduled occurrence was not queued"
+        | Error detail -> fail detail
+      in
+      let claimed_state =
+        Keeper_event_queue_persistence.load_state_result ~base_path ~keeper_name
+        |> function
+        | Ok state -> state
+        | Error detail -> fail detail
+      in
+      let generation = entry.meta.runtime.generation in
+      let cancellation : Keeper_event_queue_state.accepted_cancellation =
+        { source_revision = Keeper_event_queue_state.revision claimed_state
+        ; owner_generation = generation
+        ; operator_operation_id = "cancel-schedule-occurrence"
+        ; reason = "operator cancelled retained schedule work"
+        }
+      in
+      let cancelled_state, cancellation_result =
+        Keeper_event_queue_state.cancel_accepted
+          ~current_owner_generation:generation
+          ~settled_at:203.0
+          ~lease
+          ~cancellation
+          claimed_state
+        |> function
+        | Ok result -> result
+        | Error detail -> fail detail
+      in
+      (match cancellation_result with
+       | Keeper_event_queue_state.Settled _ -> ()
+       | Keeper_event_queue_state.Already_settled _ ->
+         fail "first schedule cancellation was already settled");
+      write_file
+        (event_queue_snapshot_path ~base_path ~keeper_name)
+        (Yojson.Safe.to_string
+           (Keeper_event_queue_state.to_yojson cancelled_state));
+      (match Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      (match Schedule_store.recover_running_on_startup config ~now:204.0 with
+       | Ok (_, 1) -> ()
+       | Ok (_, recovered) -> failf "expected one recovered schedule, got %d" recovered
+       | Error err -> fail (Schedule_store.store_error_to_string err));
+      Atomic.set entry.fiber_wakeup false;
+      let retried = tick_ok config ~now:205.0 in
+      check bool "cancelled retry sends no second wake" false
+        (Atomic.get entry.fiber_wakeup);
+      (match List.hd retried.dispatches with
+       | { detail = Some detail; _ } ->
+         check string "retry observes terminal cancellation" "already_cancelled"
+           Yojson.Safe.Util.(detail |> member "occurrence_status" |> to_string)
+       | _ -> fail "cancelled retry completion receipt missing");
+      check int "cancelled retry enqueues no second occurrence" 0
+        (Keeper_registry_event_queue.snapshot ~base_path keeper_name
+         |> Keeper_event_queue.length);
+      let evidence =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+        |> Yojson.Safe.Util.member "keeper_reaction_evidence"
+      in
+      check string "dashboard preserves terminal cancellation"
+        "matched_terminal_cancelled"
+        Yojson.Safe.Util.(evidence |> member "projection_status" |> to_string);
+      check bool "dashboard exposes exact cancelled evidence" true
+        Yojson.Safe.Util.(evidence |> member "event_queue_cancelled_seen" |> to_bool))
+;;
+
 let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
   with_workspace
   @@ fun config ->
@@ -1041,6 +1157,9 @@ let () =
             test_keeper_wake_durable_enqueue_failure_retries_same_occurrence
         ; test_case "acked occurrence recovery does not enqueue or wake again" `Quick
             test_acked_occurrence_recovery_does_not_enqueue_or_wake_again
+        ; test_case "cancelled occurrence recovery does not enqueue or wake again"
+            `Quick
+            test_cancelled_occurrence_recovery_does_not_enqueue_or_wake_again
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "dashboard live supported non-terminal evidence matches supported request"


### PR DESCRIPTION
## Summary

- add a closed `Cancel_accepted` settlement receipt carrying the observed queue revision, owner generation, operator operation ID, and reason
- require an exact single-event lease plus matching revision/generation at the pure cancellation boundary; generic settlement cannot bypass the fence
- retain the exact source stimulus in the durable transition outbox and project cancellation as typed reaction-ledger history with a dedicated count
- preserve exact cancellation evidence across producer recovery so a terminally cancelled schedule occurrence is not re-enqueued or woken again
- aggregate accepted-cancellation history across keeper fleet and unavailable projections
- cover exact removal, idempotent replay, stale-fence rejection, strict receipt round-trip, projection behavior, and schedule recovery

## Scope boundary

This is the first foundation slice of #25191. It intentionally does **not** expose an operator mutation API or implement cross-owner transfer/source-terminal settlement. Those require the lifecycle reservation and typed producer-receipt boundaries in follow-up changes, so #25191 remains open.

## Validation

- `ocamlformat --check <changed OCaml files>`
- `ocamlc -stop-after parsing -impl <changed implementation/test files>`
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail`
- focused Dune build/test intentionally left to the operator and PR CI

Refs #25191
