### PR TITLE
feat(fusion): coordinate durable run ownership

### DIFF
--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -48,6 +48,8 @@ let keepers_runtime_dirname = "keepers"
 let masc_dir_from_base_path ~base_path =
   Filename.concat base_path masc_dirname
 
+let fusion_run_authority_dir_from_base_path ~base_path =
+  Filename.concat (masc_dir_from_base_path ~base_path) "fusion-run-authority"
 (* Default-cluster keeper OUTPUT dir for callers holding only [base_path].
    Low-level on purpose: the cluster-aware [Workspace.keepers_runtime_dir]
    cannot be called from workspace-internal or accountability modules without a

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -45,6 +45,8 @@ val masc_dir_from_base_path : base_path:string -> string
     [Filename.concat base_path masc_dirname]. Canonical way to spell
     [<base_path>/.masc]. *)
 
+val fusion_run_authority_dir_from_base_path : base_path:string -> string
+(** Durable per-run Fusion authority root under [<base_path>/.masc]. *)
 val keepers_runtime_dirname : string
 (** OUTPUT root segment for server-written keeper runtime state. Single literal
     behind both keeper-dir SSOT functions; the input/output relocation flips it. *)

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -14,16 +14,12 @@ type compute_outcome =
   | Computed of Fusion_types.deliberation_evidence
 
 let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
-  match Fusion_policy.decide ~policy request with
-  | Fusion_types.Deny reason ->
+  match Fusion_policy.find_preset policy request.Fusion_types.preset with
+  | None ->
     Fusion_metrics.record_invocation ~topology `Denied;
-    Compute_denied reason
-  | Fusion_types.Allow req ->
-    (match Fusion_policy.find_preset policy req.Fusion_types.preset with
-       | None ->
-         Fusion_metrics.record_invocation ~topology `Denied;
-         Compute_denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
-     | Some vp ->
+    Compute_denied (Fusion_types.Preset_unknown request.preset)
+  | Some vp ->
+    let req = request in
           let preset = Fusion_policy.Validated_preset.preset vp in
           let groups = preset.Fusion_policy.panels in
           let effective_groups =
@@ -377,7 +373,7 @@ let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
             ; judge
             ; judges = judge_nodes
             ; judge_usage
-            })
+            }
 
 let project
     ~base_dir
@@ -400,6 +396,11 @@ let project
 ;;
 
 let run ~sw ~net ~base_dir ~policy ~topology ~request () =
-  match compute ~sw ~net ~policy ~topology ~request () with
-  | Compute_denied reason -> Denied reason
-  | Computed deliberation -> project ~base_dir ~topology ~request deliberation
+  match Fusion_policy.decide ~policy request with
+  | Fusion_types.Deny reason ->
+    Fusion_metrics.record_invocation ~topology `Denied;
+    Denied reason
+  | Fusion_types.Allow admitted ->
+    (match compute ~sw ~net ~policy ~topology ~request:admitted () with
+     | Compute_denied reason -> Denied reason
+     | Computed deliberation -> project ~base_dir ~topology ~request:admitted deliberation)

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -20,9 +20,10 @@ type compute_outcome =
   | Compute_denied of Fusion_types.deny_reason
   | Computed of Fusion_types.deliberation_evidence
 
-(** Run panel and judge computation without Board, chat, wake, or run-registry
-    projection. The caller can durably claim the semantic terminal before
-    passing a [Computed] value to {!project}. *)
+(** Run panel and judge computation for an already-admitted request, without
+    Board, chat, wake, or run-registry projection. The caller owns the single
+    [Fusion_policy.decide] boundary and can durably claim the semantic terminal
+    before passing a [Computed] value to {!project}. *)
 val compute
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -40,8 +40,8 @@ let append_chat_failure ~base_dir ~keeper ~run_id ~failure_code content =
        ()
    with
    | Eio.Cancel.Cancelled _ as exn ->
-     (* 구조적 취소는 재전파. registry는 위에서 이미 Completed로 확정됨. *)
-     raise exn
+     let bt = Printexc.get_raw_backtrace () in
+     Printexc.raise_with_backtrace exn bt
    | exn ->
      Log.Keeper.warn ~keeper_name:keeper
        "fusion run %s failed to append failure message: %s" run_id
@@ -68,18 +68,44 @@ let append_chat_failure ~base_dir ~keeper ~run_id ~failure_code content =
       run_id
       reason
 
-type orchestrator_runner =
+type computation =
   sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> base_dir:string
   -> policy:Fusion_policy.t
   -> topology:Fusion_types.fusion_topology
   -> request:Fusion_types.fusion_request
   -> unit
+  -> Fusion_orchestrator.compute_outcome
+
+type projection =
+  base_dir:string
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> Fusion_types.deliberation_evidence
   -> Fusion_orchestrator.outcome
 
-let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~run_id
-      ~policy ?continuation_channel ~args () : Tool_result.result =
+let log_authority_error ~keeper ~run_id ~operation error =
+  Log.Keeper.error ~keeper_name:keeper
+    "fusion run %s authority %s failed: %s"
+    run_id operation (Fusion_run_authority.error_to_string error)
+;;
+
+let claim_first ~authority ~keeper ~run_id phase =
+  match Fusion_run_authority.commit_phase authority ~keeper ~run_id phase with
+  | Ok Fusion_run_authority.First_committed -> true
+  | Ok Fusion_run_authority.Already_same
+  | Ok (Fusion_run_authority.Conflict _) -> false
+  | Error error ->
+    let detail = Fusion_run_authority.error_to_string error in
+    log_authority_error ~keeper ~run_id ~operation:"phase commit" error;
+    Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
+      ~failure:detail ~failure_code:"authority_failed" ~ok:false ();
+    Fusion_wake_route.discard ~run_id;
+    false
+;;
+
+let handle_with_runtime_result ~compute ~project ~fork ~authority ~sw ~net ~base_dir
+      ~keeper ~now_unix ~run_id ~policy ?continuation_channel ~args () : Tool_result.result =
   let tool_name = "masc_fusion" in
   let prompt = Tool_args.get_string args "prompt" "" in
   let preset = Tool_args.get_string args "preset" policy.Fusion_policy.default_preset in
@@ -133,89 +159,120 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
         ; ("reason", `String (Fusion_types.deny_reason_label reason))
         ]
     | Fusion_types.Allow allowed ->
-      (* RFC-0266 §7: 진행중 가시성을 위해 fork 직전 run을 Running으로 등록한다
-         (sink/실패 경로가 Completed로 갱신). 등록은 부수효과 없는 in-memory 기록일
-         뿐, 키퍼를 깨우지 않는다(wake는 별개). *)
-      Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id ~keeper
-        ~preset ~started_at:now_unix;
-      (* Reply route: captured next to [register_running] so route lifetime
-         tracks the run. [register] drops [Unrouted] itself; the completion
-         wake ([Fusion_sink.wake_keeper_on_fusion_completion], success AND
-         failure paths) consumes it exactly once. *)
-      Option.iter
-        (fun channel -> Fusion_wake_route.register ~run_id channel)
-        continuation_channel;
-      (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
-         (no polling). wake-free, broadcast-failure-safe; see
-         Fusion_sink.broadcast_run_status. *)
-      Fusion_sink.broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
-      (* out-of-band: fiber fork → 키퍼 턴은 즉시 진행, 결과는 sink가 chat lane에.
-         배경 fiber 실패/거부/싱크 실패는 동일한 chat lane에 기록해 started-but-failed
-         상태가 남지 않도록 한다. 호출자는 이 fiber가 키퍼 턴보다 오래 살아도록 root
-         switch를 sw로 넘긴다 (turn switch면 턴 종료 시 심의가 취소됨). *)
-      Eio.Fiber.fork ~sw (fun () ->
-        match
-          run_orchestrator ~sw ~net ~base_dir ~policy ~topology ~request:allowed ()
-        with
-        | Fusion_orchestrator.Completed _ -> ()
-        | Fusion_orchestrator.Denied reason ->
-          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"denied"
-            (Printf.sprintf "**Fusion run `%s`** _(denied after start: %s)_" run_id
-               (Fusion_types.deny_reason_label reason))
-        | Fusion_orchestrator.Sink_failed msg ->
-          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
-            (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
-        | exception (Eio.Cancel.Cancelled _ as exn) ->
-          (* RFC-0266 §7: 취소도 종료 상태다. register_running(위 line 73)으로 [Running]
-             으로 등록된 run을 [Completed{ok=false}]로 갱신하지 않으면, in-memory registry
-             ([global], 서버 수명)에 영구 "running"으로 남아 dashboard fusion-runs 패널과
-             masc_fusion_status가 거짓 "심의중"을 보인다(prune는 [Running]을 evict하지 않음 —
-             fusion_run_registry.ml). 다른 종료 분기(Denied/Sink_failed/exception)는
-             append_chat_failure 경유로 이미 mark_completed 하는데 이 분기만 빠져 있었다.
-             [mark_completed]는 순수 in-memory CAS(suspension 없음)라 취소 컨텍스트에서도
-             안전하다. broadcast는 [Sse.broadcast]가 mailbox에서 suspend/block할 수 있어
-             취소/셧다운 캐스케이드를 deadlock시킬 위험이 있으므로 이 경로에선 생략한다 —
-             registry가 정확해 다음 HTTP fetch / tab-refresh가 패널을 self-heal한다.
-             그 뒤 구조적 취소는 흡수하지 않고 재전파한다 (Eio 규약). *)
-          Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
-            ~failure:"cancelled: structural cancellation (shutdown or sibling switch failure)"
-            ~failure_code:"cancelled" ~ok:false ();
-          (* No completion wake fires on this path, so drop the reply route
-             here or it leaks for the process lifetime. *)
-          Fusion_wake_route.discard ~run_id;
-          raise exn
-        | exception exn ->
-          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
-            (Printf.sprintf "**Fusion run `%s`** _(aborted: %s)_" run_id
-               (Printexc.to_string exn)));
-      (* [delivery] 필드는 도구 결과의 async 계약을 명시한다: 완료 시 키퍼는
-         [Fusion_completed] wake로 깨워지고 결론/실패 사유가 chat lane에 durable하게
-         남는다. 2026-07-01 관측: 이 계약이 결과 JSON에 없어서 키퍼들이 3-5초 간격
-         masc_fusion_status 폴링으로 턴을 소모했다(8 run에 35 poll + nudge 8회). *)
-      status_result
-        ~tool_name
-        ~class_:Tool_result.Runtime_failure
-        ~ok:true
-        [ ("status", `String "fusion_started")
-        ; ("run_id", `String run_id)
-        ; ( "delivery"
-          , `String
-              "async: you will be woken with the result when deliberation \
-               completes; the conclusion (or failure reason) also lands on \
-               your chat lane. No need to poll masc_fusion_status." )
-        ]
+      (match
+         Fusion_run_authority.register authority ~topology ~request:allowed
+           ~started_at:now_unix
+       with
+       | Error error ->
+         let message = Fusion_run_authority.error_to_string error in
+         log_authority_error ~keeper ~run_id ~operation:"registration" error;
+         status_result ~tool_name ~class_:Tool_result.Runtime_failure ~ok:false
+           [ "error", `String message ]
+       | Ok (Fusion_run_authority.Already_registered (Registered_run _)) ->
+         status_result ~tool_name ~class_:Tool_result.Runtime_failure ~ok:true
+           [ "status", `String "fusion_already_running"; "run_id", `String run_id ]
+       | Ok
+           (Fusion_run_authority.Already_registered
+              (Computation_committed_run _ | Stopped_without_computation_run _)) ->
+         status_result ~tool_name ~class_:Tool_result.Runtime_failure ~ok:true
+           [ "status", `String "fusion_already_settled"; "run_id", `String run_id ]
+       | Ok Fusion_run_authority.Registered ->
+         let cancellation exn bt =
+           let detail = Printexc.to_string exn in
+           Eio.Cancel.protect (fun () ->
+             if
+               claim_first ~authority ~keeper ~run_id
+                 (Fusion_run_authority.Stopped_without_computation (Cancelled detail))
+             then (
+               Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
+                 ~failure:detail ~failure_code:"cancelled" ~ok:false ();
+               Fusion_wake_route.discard ~run_id));
+           Printexc.raise_with_backtrace exn bt
+         in
+         let abort detail =
+           if
+            claim_first ~authority ~keeper ~run_id
+               (Fusion_run_authority.Stopped_without_computation (Aborted detail))
+           then
+             append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
+               (Printf.sprintf "**Fusion run `%s`** _(aborted: %s)_" run_id detail)
+         in
+         let run_background () =
+           match compute ~sw ~net ~policy ~topology ~request:allowed () with
+           | exception (Eio.Cancel.Cancelled _ as exn) ->
+             cancellation exn (Printexc.get_raw_backtrace ())
+           | exception exn -> abort (Printexc.to_string exn)
+           | Fusion_orchestrator.Compute_denied reason ->
+             let detail = Fusion_types.deny_reason_label reason in
+             if
+               claim_first ~authority ~keeper ~run_id
+                 (Fusion_run_authority.Stopped_without_computation (Denied reason))
+             then
+               append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"denied"
+                 (Printf.sprintf "**Fusion run `%s`** _(compute denied: %s)_" run_id detail)
+           | Fusion_orchestrator.Computed evidence ->
+             if
+               claim_first ~authority ~keeper ~run_id
+                 (Fusion_run_authority.Computation_committed evidence)
+             then
+               (match project ~base_dir ~topology ~request:allowed evidence with
+                | Fusion_orchestrator.Completed _ -> ()
+                | Fusion_orchestrator.Denied reason ->
+                  append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
+                    (Printf.sprintf "**Fusion run `%s`** _(projection denied: %s)_" run_id
+                       (Fusion_types.deny_reason_label reason))
+                | Fusion_orchestrator.Sink_failed msg ->
+                  append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
+                    (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
+                | exception (Eio.Cancel.Cancelled _ as exn) ->
+                  let bt = Printexc.get_raw_backtrace () in
+                  Fusion_wake_route.discard ~run_id;
+                  Printexc.raise_with_backtrace exn bt
+                | exception exn ->
+                  append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
+                    (Printf.sprintf "**Fusion run `%s`** _(projection failed: %s)_" run_id
+                       (Printexc.to_string exn)))
+         in
+         (try
+            Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id
+              ~keeper ~preset:allowed.preset ~started_at:now_unix;
+            Option.iter
+              (fun channel -> Fusion_wake_route.register ~run_id channel)
+              continuation_channel;
+            Fusion_sink.broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
+            fork run_background;
+            status_result ~tool_name ~class_:Tool_result.Runtime_failure ~ok:true
+              [ ("status", `String "fusion_started")
+              ; ("run_id", `String run_id)
+              ; ( "delivery"
+                , `String
+                    "async: you will be woken with the result when deliberation \
+                     completes; the conclusion (or failure reason) also lands on \
+                     your chat lane. No need to poll masc_fusion_status." )
+              ]
+          with
+          | Eio.Cancel.Cancelled _ as exn ->
+            cancellation exn (Printexc.get_raw_backtrace ())
+          | exn ->
+            let detail = Printexc.to_string exn in
+            abort detail;
+            status_result ~tool_name ~class_:Tool_result.Runtime_failure ~ok:false
+              [ "error", `String detail ]))
 
-let handle_result ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy
+let handle_result ~sw ~net ~authority ~base_dir ~keeper ~now_unix ~run_id ~policy
       ?continuation_channel ~args () =
-  handle_with_runner_result ~run_orchestrator:Fusion_orchestrator.run ~sw ~net ~base_dir
-    ~keeper ~now_unix ~run_id ~policy ?continuation_channel ~args ()
+  handle_with_runtime_result ~compute:Fusion_orchestrator.compute
+    ~project:Fusion_orchestrator.project ~fork:(fun fn -> Eio.Fiber.fork ~sw fn)
+    ~authority ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy
+    ?continuation_channel ~args ()
 
-let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ?continuation_channel
-      ~args () : string =
+let handle ~sw ~net ~authority ~base_dir ~keeper ~now_unix ~run_id ~policy
+      ?continuation_channel ~args () : string =
   Tool_result.message
     (handle_result
        ~sw
        ~net
+       ~authority
        ~base_dir
        ~keeper
        ~now_unix
@@ -226,15 +283,19 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ?continuation_ch
        ())
 
 module For_test = struct
-  type nonrec orchestrator_runner = orchestrator_runner
+  type nonrec computation = computation
+  type nonrec projection = projection
 
-  let handle_with_runner ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix
-        ~run_id ~policy ?continuation_channel ~args () =
+  let handle_with_runtime ~compute ~project ~fork ~sw ~net ~authority ~base_dir
+        ~keeper ~now_unix ~run_id ~policy ?continuation_channel ~args () =
     Tool_result.message
-      (handle_with_runner_result
-         ~run_orchestrator
+      (handle_with_runtime_result
+         ~compute
+         ~project
+         ~fork
          ~sw
          ~net
+         ~authority
          ~base_dir
          ~keeper
          ~now_unix

--- a/lib/fusion/fusion_tool.mli
+++ b/lib/fusion/fusion_tool.mli
@@ -21,6 +21,7 @@
 val handle
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> authority:Fusion_run_authority.t
   -> base_dir:string
   -> keeper:string
   -> now_unix:float
@@ -34,6 +35,7 @@ val handle
 val handle_result
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> authority:Fusion_run_authority.t
   -> base_dir:string
   -> keeper:string
   -> now_unix:float
@@ -45,30 +47,31 @@ val handle_result
   -> Tool_result.result
 
 module For_test : sig
-  (** [handle]이 background fiber에서 실행하는 orchestrator contract.
-
-      기본값은 {!Fusion_orchestrator.run}이다. 테스트는 이 contract를 주입해 handler의
-      async delivery wiring(Running 등록, background 완료 후 sink/registry projection)을
-      실제 provider 호출 없이 결정적으로 검증한다. *)
-  type orchestrator_runner =
+  type computation =
     sw:Eio.Switch.t
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-    -> base_dir:string
     -> policy:Fusion_policy.t
     -> topology:Fusion_types.fusion_topology
     -> request:Fusion_types.fusion_request
     -> unit
+    -> Fusion_orchestrator.compute_outcome
+
+  type projection =
+    base_dir:string
+    -> topology:Fusion_types.fusion_topology
+    -> request:Fusion_types.fusion_request
+    -> Fusion_types.deliberation_evidence
     -> Fusion_orchestrator.outcome
 
-  (** [handle]과 같은 계약이되 background runner를 명시적으로 받는다.
-
-      Production dispatch는 {!handle}만 호출한다. 이 함수는 provider/network 시간을
-      끌어들이지 않고 handler의 async state transition을 테스트하기 위한 동일-contract
-      entrypoint다. *)
-  val handle_with_runner
-    :  run_orchestrator:orchestrator_runner
+  (** Explicit seams prove that durable registration precedes fiber creation
+      and that committed computation ownership precedes projection. *)
+  val handle_with_runtime
+    :  compute:computation
+    -> project:projection
+    -> fork:((unit -> unit) -> unit)
     -> sw:Eio.Switch.t
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+    -> authority:Fusion_run_authority.t
     -> base_dir:string
     -> keeper:string
     -> now_unix:float

--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -47,6 +47,31 @@ type error =
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
+
+let error_to_string = function
+  | Empty_keeper -> "keeper identity is empty"
+  | Empty_run_id -> "run identity is empty"
+  | Invalid_started_at value -> Printf.sprintf "started_at is not finite: %g" value
+  | Empty_abort_detail -> "abort detail is empty"
+  | Empty_cancellation_detail -> "cancellation detail is empty"
+  | Partial_tail -> "authority journal has a partial tail"
+  | Unsupported_schema_version { line; found } ->
+    Printf.sprintf "authority journal line %d has unsupported schema version %d" line found
+  | Invalid_record { line; detail } ->
+    Printf.sprintf "authority journal line %d is invalid: %s" line detail
+  | Empty_authority_record -> "authority journal is empty"
+  | Evidence_question_mismatch { expected; found } ->
+    Printf.sprintf "authority evidence question mismatch: expected=%S found=%S" expected found
+  | Invalid_transition { event_index; state; event } ->
+    Printf.sprintf "authority event %d cannot apply %s to %s"
+      event_index (show_event_kind event) (show_state_kind state)
+  | Identity_mismatch identity ->
+    Printf.sprintf "authority identity mismatch: %s" (show_identity identity)
+  | Registration_conflict registration ->
+    Printf.sprintf "authority registration conflict: %s" (show_registration registration)
+  | Durable_append_failed error -> Fs_compat.durable_append_error_to_string error
+;;
+
 type register_outcome =
   | Registered
   | Already_registered of recovered_run

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -34,6 +34,7 @@ type error =
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
+val error_to_string : error -> string
 type register_outcome =
   | Registered
   | Already_registered of recovered_run

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -791,9 +791,15 @@ let handle_masc_fusion_with_outcome ~(config : Workspace.config) ~(meta : keeper
      | Ok policy ->
        let now_unix = Time_compat.now () in
        let run_id = Random_id.prefixed ~prefix:"fus-" ~bytes:16 in
+       let authority =
+         Fusion_run_authority.create
+           ~directory:(Common.fusion_run_authority_dir_from_base_path
+             ~base_path:config.Workspace.base_path)
+       in
        Fusion_tool.handle_result
          ~sw
          ~net
+         ~authority
          ~base_dir:config.Workspace.base_path
          ~keeper:meta.name
          ~now_unix

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -108,10 +108,16 @@ let handle_keeper_catchup_judge_post state req reqd body_str =
                   ]
               in
               let run_id = Random_id.prefixed ~prefix:"fus-" ~bytes:16 in
+              let authority =
+                Fusion_run_authority.create
+                  ~directory:(Common.fusion_run_authority_dir_from_base_path
+                    ~base_path:config.base_path)
+              in
               let raw =
                 Fusion_tool.handle
                   ~sw
                   ~net
+                  ~authority
                   ~base_dir:config.base_path
                   ~keeper:name
                   ~now_unix

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -280,6 +280,18 @@ let test_restart_scan_preserves_valid_peers_and_corruption () =
          | A.Registered_run _ | A.Stopped_without_computation_run _ -> false)
        valid_runs)
 ;;
+
+let test_typed_errors_keep_transition_evidence () =
+  check string "prompt mismatch evidence"
+    "authority evidence question mismatch: expected=\"q\" found=\"other\""
+    (A.error_to_string (A.Evidence_question_mismatch { expected = "q"; found = "other" }));
+  check string "transition evidence"
+    "authority event 7 cannot apply Computation_event to Empty_state"
+    (A.error_to_string
+       (A.Invalid_transition
+          { event_index = 7; state = A.Empty_state; event = A.Computation_event }))
+;;
+
 let () =
   run "fusion_run_authority"
     [ ( "authority"
@@ -289,6 +301,8 @@ let () =
             test_corruption_is_per_run_and_semantic
         ; test_case "restart scan preserves valid peers and corruption" `Quick
             test_restart_scan_preserves_valid_peers_and_corruption
+        ; test_case "typed errors retain transition evidence" `Quick
+            test_typed_errors_keep_transition_evidence
         ] )
     ]
 ;;

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -531,8 +531,8 @@ let test_orchestrator_project_success_projects_board_chat_and_registry () =
       ; trigger = Fusion_types.Explicit_tool_call
       }
     in
-    let deliberation : Fusion_orchestrator.deliberation =
-      { panel; judge = Ok synthesis; judges; judge_usage }
+    let deliberation : Fusion_types.deliberation_evidence =
+      { question; panel; judge = Ok synthesis; judges; judge_usage }
     in
     (match
        Fusion_orchestrator.project ~base_dir ~topology:Fusion_types.Simple ~request
@@ -640,7 +640,7 @@ let test_orchestrator_project_success_projects_board_chat_and_registry () =
 
 (* Fusion_wake_route contract: the reply route registered at masc_fusion call
    time is consumed exactly once by the completion wake. Pure map semantics
-   plus the registration edge inside [handle_with_runner]. *)
+   plus the registration edge inside [handle_with_runtime]. *)
 let discord_channel =
   Keeper_continuation_channel.discord
     ~guild_id:(Some "g-1")
@@ -798,23 +798,27 @@ let test_tool_handle_async_success_projects_running_then_completed () =
     in
     let release_promise, resolve_release = Eio.Promise.create () in
     let completed_promise, resolve_completed = Eio.Promise.create () in
-    let run_orchestrator ~sw:_ ~net:_ ~base_dir ~policy:_ ~topology:_ ~request () =
+    let authority =
+      Fusion_run_authority.create ~directory:(Filename.concat base_dir "authority")
+    in
+    let evidence : Fusion_types.deliberation_evidence =
+      { question; panel; judge = Ok synthesis; judges; judge_usage }
+    in
+    let compute ~sw:_ ~net:_ ~policy:_ ~topology:_ ~request:_ () =
       Eio.Promise.await release_promise;
+      Fusion_orchestrator.Computed evidence
+    in
+    let project ~base_dir ~topology ~request evidence =
       let outcome =
-        match
-          Fusion_sink.emit ~base_dir ~keeper:request.Fusion_types.keeper
-            ~run_id:request.Fusion_types.run_id ~question:request.Fusion_types.prompt
-            ~panel ~judge:(Ok synthesis) ~judges ~judge_usage
-        with
-        | Ok () -> Fusion_orchestrator.Completed { panel; judge = Ok synthesis }
-        | Error msg -> Fusion_orchestrator.Sink_failed msg
+        Fusion_orchestrator.project ~base_dir ~topology ~request evidence
       in
       Eio.Promise.resolve resolve_completed outcome;
       outcome
     in
     let response =
-      Fusion_tool.For_test.handle_with_runner ~run_orchestrator ~sw
-        ~net:(Eio.Stdenv.net env) ~base_dir ~keeper ~now_unix:4.0 ~run_id
+      Fusion_tool.For_test.handle_with_runtime ~compute ~project
+        ~fork:(fun fn -> Eio.Fiber.fork ~sw fn) ~sw ~net:(Eio.Stdenv.net env)
+        ~authority ~base_dir ~keeper ~now_unix:4.0 ~run_id
         ~policy:(fusion_tool_policy ())
         ~args:(`Assoc [ ("prompt", `String question) ])
         ()
@@ -903,6 +907,53 @@ let test_tool_handle_async_success_projects_running_then_completed () =
       fail "fusion run should not remain Running after background success"
     | None -> fail "fusion run should remain visible after background success")
 ;;
+
+let test_tool_authority_suppresses_duplicate_and_conflict_loser () =
+  with_isolated_eio_base_path "fusion-tool-authority" (fun env sw base_dir ->
+    let keeper = "fusion-authority-keeper" in
+    let run_id = Printf.sprintf "fus-authority-%d" (Random.bits ()) in
+    let authority = Fusion_run_authority.create ~directory:(Filename.concat base_dir "authority") in
+    let evidence : Fusion_types.deliberation_evidence =
+      { question = "q"; panel = []; judge = Ok (judge_synthesis "a"); judges = []
+      ; judge_usage = Fusion_types.zero_usage }
+    in
+    let forked, resolve_forked = Eio.Promise.create () in
+    let projected, resolve_projected = Eio.Promise.create () in
+    let fork fn =
+      let request : Fusion_types.fusion_request =
+        { run_id; keeper; prompt = "q"; preset = "unit"; web_tools = false
+        ; depth = Fusion_types.Fusion_depth.Top; trigger = Explicit_tool_call }
+      in
+      match Fusion_run_authority.register authority ~topology:Simple ~request ~started_at:5.0 with
+      | Ok (Fusion_run_authority.Already_registered (Registered_run _)) ->
+        Eio.Promise.resolve resolve_forked fn
+      | _ -> fail "authority must be registered before fork"
+    in
+    let compute ~sw:_ ~net:_ ~policy:_ ~topology:_ ~request:_ () = Fusion_orchestrator.Computed evidence in
+    let project ~base_dir:_ ~topology:_ ~request:_ _ = Eio.Promise.resolve resolve_projected ();
+      Fusion_orchestrator.Completed { panel = []; judge = evidence.judge }
+    in
+    let call () =
+      Fusion_tool.For_test.handle_with_runtime ~compute ~project ~fork ~sw
+        ~net:(Eio.Stdenv.net env) ~authority ~base_dir ~keeper ~now_unix:5.0 ~run_id
+        ~policy:(fusion_tool_policy ()) ~args:(`Assoc [ "prompt", `String "q" ]) ()
+      |> Yojson.Safe.from_string |> assoc_fields "response" |> fun fields ->
+      string_field "response" fields "status"
+    in
+    check string "first call starts" "fusion_started" (call ());
+    check string "duplicate does not fork" "fusion_already_running" (call ());
+    (match Fusion_run_authority.commit_phase authority ~keeper ~run_id
+             (Fusion_run_authority.Stopped_without_computation (Aborted "winner")) with
+     | Ok Fusion_run_authority.First_committed -> () | _ -> fail "external terminal wins");
+    Eio.Promise.await forked ();
+    check bool "loser does not project" true (Eio.Promise.peek projected = None);
+    check bool "loser creates no board post" true (Board.find_post_by_run_id (Board.global ()) ~run_id = None);
+    check int "loser appends no chat" 0 (List.length (Keeper_chat_store.load ~base_dir ~keeper_name:keeper));
+    check int "loser queues no wake" 0
+      (Keeper_event_queue.length (Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper));
+    check string "settled duplicate does not fork" "fusion_already_settled" (call ()))
+;;
+
 let test_emit_board_failure_is_best_effort () =
   with_isolated_base_path "fusion-board-best-effort" (fun base_dir ->
     let keeper = "bad/keeper" in
@@ -998,6 +1049,8 @@ let () =
             "tool handle returns Running then async success projects evidence"
             `Quick
             test_tool_handle_async_success_projects_running_then_completed
+        ; test_case "tool authority suppresses duplicate and conflict loser" `Quick
+            test_tool_authority_suppresses_duplicate_and_conflict_loser
         ; test_case
             "emit treats board post failure as best-effort"
             `Quick


### PR DESCRIPTION
## 목적

Fusion 실행의 durable registration을 비동기 fiber보다 먼저 확정하고,
computation evidence를 처음 commit한 실행만 Board/chat/wake projection을
수행하게 합니다.

## 변경

- policy admission은 한 번만 수행합니다.
- exact topology와 full request registration이 registry, reply route,
  dashboard broadcast, fiber fork보다 먼저 성공해야 합니다.
- duplicate는 동일 replay envelope일 때만 기존 running/settled 상태를 받습니다.
- compute와 projection을 분리하고, computation winner만 외부 projection을 수행합니다.
- post-admission deny, cancellation, abort는 서로 다른 typed stop으로 commit합니다.
- authority phase commit 실패는 명시적으로 기록하고 process-local registry를
  `authority_failed`로 settle하여 running 상태로 남기지 않습니다.
- cancellation commit/cleanup만 `Eio.Cancel.protect`로 보호하고 원래 cancellation과
  raw backtrace는 재전파합니다.
- 새 timeout, retry cap, risk level, governance heuristic은 추가하지 않습니다.

## Stack / merge blocker

- Base: #25333, which stacks on #25329 and #25293.
- 다음 authority leaf가 projection commit/failure를 같은 per-run state machine에
  추가해야 restart reconciliation이 computation과 delivery를 구분할 수 있습니다.
- #25277의 exact Keeper wake route가 `main`에 들어온 뒤 downstream route API를
  `keeper + run_id`에 맞춰 최종 rebase해야 합니다.
- cancelled-context 회귀 테스트는 바로 다음 stacked leaf #25320입니다.

## 검증

- 변경량: 265 insertions + 130 deletions = 395 lines
- OCaml parse 및 `ocamlformat --check` green
- `git diff --check` green
- focused Dune은 machine-wide lock 선행 작업 뒤 실행 중이며 Draft CI를 exact-head
  build authority로 사용합니다.

Full CI가 최종 merge gate입니다.
