### PR TITLE
feat(keeper): json_object(JSON mode) fallback tier for compaction structured output

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -45,15 +45,21 @@ let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
     tool_choice = None
   ; disable_parallel_tool_use = true
   }
-  (* Full module path (not the [Schema] alias): the structured-output
-     coverage test resolves callees literally via Ast_grep.count_calls, so
-     this call must read [Keeper_structured_output_schema.apply_to_provider_config]
-     in source — same pattern as the other registry entries. *)
-  |> Keeper_structured_output_schema.apply_to_provider_config
+  (* Three-tier (#25266): json_schema when the provider enforces it, else JSON
+     mode for json_object-only providers (GLM/DeepSeek/Kimi), else prompt only.
+     The plan prompt already states the exact decisions schema and
+     [plan_of_response] validates every decision, so the json_object tier is
+     safe here — it lifts the minimax-native SPOF. Full module path (not the
+     [Schema] alias): the structured-output coverage test resolves callees
+     literally via Ast_grep.count_calls. *)
+  |> Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
+       ~log_label:"compaction summarizer"
        Schema.compaction_plan_output_schema
 
 let plan_schema_supported provider_cfg =
-  Schema.provider_config_accepts_schema Schema.compaction_plan_output_schema provider_cfg
+  Schema.provider_config_accepts_schema_or_json_mode
+    Schema.compaction_plan_output_schema
+    provider_cfg
 
 let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
 
@@ -386,11 +392,20 @@ type candidate =
 let eligible_candidate ~keeper_name (runtime : Runtime.t) =
   let runtime_id = runtime.Runtime.id in
   let provider_cfg = runtime.Runtime.provider_config in
+  (* #25266: a provider is eligible when it can enforce the schema (strict
+     json_schema) OR at least honor JSON mode (json_object). This admits the
+     json_object-only endpoints (GLM/DeepSeek/Kimi) that the strict-schema
+     gate used to drop, which had left the single json_schema-native endpoint
+     (minimax) as a SPOF — nearly every cloud model supports json_object, so
+     compaction now works across them. A provider that supports NEITHER is
+     still filtered: without any format guarantee, a prompt-only attempt would
+     just churn the parser. [provider_for_plan] then selects the strongest
+     available tier for the accepted provider. *)
   if not (plan_schema_supported provider_cfg)
   then (
     Log.Keeper.warn ~keeper_name
-      "compaction LLM candidate skipped runtime=%s: provider does not support \
-       the compaction plan schema"
+      "compaction LLM candidate skipped runtime=%s: provider supports neither \
+       the compaction plan schema nor json mode"
       runtime_id;
     None)
   else Some { runtime_id; provider_cfg }

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -294,6 +294,41 @@ let apply_schema_or_prompt_tier ~log_label schema provider_cfg =
     provider_cfg
 ;;
 
+(* Capability-aware three-tier response-format selection for a request whose
+   prompt already states the exact output shape (#25266). Tier 1: a provider
+   that supports strict [json_schema] gets the schema enforced. Tier 2: a
+   provider that supports only [json_object] JSON mode (GLM/DeepSeek/Kimi —
+   the OpenAI-compat endpoints that reject json_schema) gets [JsonMode], which
+   at least forces syntactically valid JSON; the caller's prompt carries the
+   schema and the caller validates the parse, so the missing strict guarantee
+   is covered. Tier 3: neither — prompt only. Without tier 2 every
+   json_object-only provider is silently dropped from structured lanes,
+   leaving the single json_schema-capable native endpoint (minimax) as a SPOF.
+   Use ONLY where the prompt states the schema and the parse is validated
+   downstream; [apply_to_provider_config] stays the strict default. *)
+let apply_schema_json_mode_or_prompt_tier ~log_label schema provider_cfg =
+  let native_cfg = apply_to_provider_config schema provider_cfg in
+  match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
+  | Ok () -> native_cfg
+  | Error detail ->
+    (match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
+     | Some caps when caps.Llm_provider.Capabilities.supports_response_format_json ->
+       Log.Keeper.info
+         "%s: json_object tier (native schema unavailable: %s)"
+         log_label
+         detail;
+       { provider_cfg with
+         response_format = Agent_sdk.Types.JsonMode
+       ; output_schema = None
+       }
+     | _ ->
+       Log.Keeper.info
+         "%s: prompt tier (native schema and json mode unavailable: %s)"
+         log_label
+         detail;
+       provider_cfg)
+;;
+
 let validate_provider_config schema provider_cfg =
   provider_cfg
   |> apply_to_provider_config schema
@@ -304,4 +339,18 @@ let provider_config_accepts_schema schema provider_cfg =
   match validate_provider_config schema provider_cfg with
   | Ok () -> true
   | Error _ -> false
+;;
+
+(* A provider is an eligible structured-lane candidate when it can enforce the
+   schema (strict) OR at least honor JSON mode (#25266). The prompt-tier
+   fallback exists but is not sufficient for eligibility: a provider with
+   neither capability is filtered out, matching the pre-#25266 fail-closed
+   behavior for that case. *)
+let provider_config_accepts_schema_or_json_mode schema provider_cfg =
+  match validate_provider_config schema provider_cfg with
+  | Ok () -> true
+  | Error _ ->
+    (match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
+     | Some caps -> caps.Llm_provider.Capabilities.supports_response_format_json
+     | None -> false)
 ;;

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -70,6 +70,17 @@ val apply_schema_or_prompt_tier
     downgrade with the validation detail. Use only for keeper operation paths
     whose parser remains fail-loud after the provider response. *)
 
+val apply_schema_json_mode_or_prompt_tier
+  :  log_label:string
+  -> Yojson.Safe.t
+  -> Llm_provider.Provider_config.t
+  -> Llm_provider.Provider_config.t
+(** Three-tier response-format selection (#25266): enforce [schema] when the
+    provider supports strict json_schema; else set JSON mode ([JsonMode]) when
+    the provider supports json_object; else prompt only. Use ONLY where the
+    prompt already states the schema and the parser validates the response —
+    the json_object tier drops the strict guarantee. *)
+
 val validate_provider_config
   :  Yojson.Safe.t
   -> Llm_provider.Provider_config.t
@@ -81,3 +92,11 @@ val provider_config_accepts_schema
   -> Llm_provider.Provider_config.t
   -> bool
 (** True when [validate_provider_config] accepts [provider_cfg]. *)
+
+val provider_config_accepts_schema_or_json_mode
+  :  Yojson.Safe.t
+  -> Llm_provider.Provider_config.t
+  -> bool
+(** True when the provider can enforce [schema] (strict) OR honor JSON mode
+    (#25266). Eligibility gate for structured lanes that have a
+    json_object fallback; a provider with neither capability is rejected. *)

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -168,6 +168,67 @@ let test_apply_schema_or_prompt_tier_keeps_prompt_config_when_native_rejected ()
      | Error _ -> false)
 ;;
 
+(* #25266: a json_object-only provider (structured_output=false,
+   response_format_json=true — GLM/DeepSeek/Kimi's OpenAI-compat endpoints)
+   must get JsonMode from the three-tier selector, not be dropped to the
+   prompt tier. [prompt_tier_oas_provider_config] is exactly this shape:
+   openai_compat_chat_extended has response_format_json=true, and it disables
+   only structured_output. *)
+let test_json_mode_tier_selects_json_mode_for_json_object_only () =
+  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
+  let base = prompt_tier_oas_provider_config () in
+  let configured =
+    Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
+      ~log_label:"test json_mode"
+      schema
+      base
+  in
+  check bool "json_object-only provider gets JsonMode" true
+    (match configured.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.JsonMode -> true
+     | Agent_sdk.Types.JsonSchema _ | Agent_sdk.Types.Off -> false);
+  check (option bool) "JsonMode carries no output_schema" None
+    (Option.map
+       (Yojson.Safe.equal schema)
+       configured.Llm_provider.Provider_config.output_schema)
+
+let test_json_mode_tier_uses_native_schema_when_supported () =
+  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
+  let base = schema_capable_oas_provider_config () in
+  let configured =
+    Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
+      ~log_label:"test native over json_mode"
+      schema
+      base
+  in
+  check bool "schema-capable provider still gets strict json_schema" true
+    (has_json_schema_response_format schema configured)
+
+let test_accepts_schema_or_json_mode_admits_json_object_only () =
+  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
+  (* json_schema-capable and json_object-only are both eligible; neither is not. *)
+  check bool "json_schema provider is eligible" true
+    (Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
+       schema (schema_capable_oas_provider_config ()));
+  check bool "json_object-only provider is eligible" true
+    (Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
+       schema (prompt_tier_oas_provider_config ()));
+  let neither =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"neither-ratchet"
+      ~base_url:"https://neither.invalid/v1"
+      ~model_capabilities_override:
+        { Llm_provider.Capabilities.openai_compat_chat_extended_capabilities with
+          supports_structured_output = false
+        ; supports_response_format_json = false
+        }
+      ()
+  in
+  check bool "provider with neither capability is rejected" false
+    (Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
+       schema neither)
+
 let test_operator_remote_tool_name_ssot_matches_remote_schemas () =
   let schema_names =
     Operator_tool.remote_schemas
@@ -351,6 +412,18 @@ let () =
             "schema-or-prompt helper keeps prompt tier when native rejected"
             `Quick
             test_apply_schema_or_prompt_tier_keeps_prompt_config_when_native_rejected
+        ; test_case
+            "json_mode tier selects JsonMode for json_object-only provider"
+            `Quick
+            test_json_mode_tier_selects_json_mode_for_json_object_only
+        ; test_case
+            "json_mode tier still uses strict schema when supported"
+            `Quick
+            test_json_mode_tier_uses_native_schema_when_supported
+        ; test_case
+            "accepts-schema-or-json-mode admits json_object-only, rejects neither"
+            `Quick
+            test_accepts_schema_or_json_mode_admits_json_object_only
         ] )
     ; ( "dashboard schemas"
       , [ test_case


### PR DESCRIPTION
## 문제

컴팩션 summarizer는 항상 `response_format = JsonSchema`(strict)로 OAS 경계에 요청한다. 그런데 strict json_schema를 실제로 받아주는 provider는 ollama-native(minimax) 경로뿐이라, runpod을 끄면 컴팩션 lane 전체가 `summarizer_unavailable`로 죽는다. GLM/DeepSeek/Kimi는 json_schema strict는 거부하지만 `json_object`(JSON mode)는 지원하는데, masc가 그 tier를 한 번도 시도하지 않았다.

즉 단일 provider(minimax) SPOF. 모델이 무엇이든 컴팩션이 동작해야 한다는 요구를 충족하지 못한다.

## 변경

`Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier` 추가 — provider capability에 따라 3-tier로 response_format을 선택한다:

1. `supports_structured_output` (strict json_schema) → `JsonSchema schema` + `output_schema`
2. else `supports_response_format_json` (JSON mode) → `JsonMode`, `output_schema = None`
3. else → prompt only (response_format 미설정)

tier 2/3는 prompt가 이미 스키마를 명시하고(`messages_for_plan`이 `{"decisions":[{"unit_index":integer,"action":"keep|drop|summarize","summary":string|null}]}`를 그대로 요구), `plan_of_response`가 응답을 typed하게 검증하므로 strict 보장이 없어도 파서가 fail-loud로 잡는다.

eligibility gate도 `provider_config_accepts_schema_or_json_mode`(strict OR json_mode)로 넓혀, capability 둘 다 없는 provider만 ineligible 처리한다(#25051 fixture 유지).

## Provider capability matrix (공식 문서 + 실측)

| provider | strict json_schema | json_object | tier | 검증 |
|---|---|---|---|---|
| OpenAI (gpt-5.5) | O | O | 1 | 실측 O (json_schema strict, "ok"→drop 의미 정확) |
| Anthropic (Fable 5/Opus 4.8/Sonnet 5) | O (`output_config.format`) | - | 1 | 공식 GA 문서 O, OAS wire와 바이트 일치. 실측은 계정 키 폐기(2026-03-08)로 불가 |
| Gemini | O | O | 1 | capability O |
| GLM (glm-4.6, z.ai) | X | O | 2 | 실측 O (json_object, plan+의미 정확) |
| Kimi | X | O | 2 | 실측 O (temperature=1 요구, runtime cfg 존중) |
| DeepSeek | X | O | 2 | 문서 O. 실측은 잔액 부족(계정 문제, 코드 아님) |
| ollama-native (minimax) | O | - | 1 | 프로덕션 live (기존 유일 경로) |

- OAS Anthropic backend는 `JsonSchema`/`output_schema`를 `output_config.format = {type: json_schema, schema}`로 변환(`backend_anthropic.ml:143,378`), `anthropic-version: 2023-06-01`, beta 헤더 없음(`provider.ml:164`). 공식 GA 문서와 정확히 일치.
- OpenAI/GLM/Kimi/DeepSeek는 openai_compat 경계에서 `response_format`(json_schema strict / json_object)로 나간다.

## 테스트

- `test_keeper_structured_output_schema` 12/12: json_mode tier→JsonMode 선택, strict tier 유지, accepts-schema-or-json-mode 판정 신규 3종 포함.
- `test_compaction_llm_summarizer` 21/21: eligibility/plan_of_json/apply 회귀 유지.
- 전체 keeper lib 빌드 green, ocamlformat clean.

## 관련

- `summarizer_unavailable` 벽(#25051 structured_judge lane 회귀)을 config 편집 없이 해소하는 선행 인프라.
- 이 PR이 머지되면 structured_judge를 multi-model lane으로 복원(minimax SPOF 제거) 가능.
- generation-missing 수정(#25275)과 독립.
