### PR TITLE
fix(mcp): derive failure logs from typed result

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -161,9 +161,23 @@ let arguments_of_params = function
   | _ -> `Null
 ;;
 
+let failure_observation ~duration_ms
+    : Tool_result.result -> (Tool_result.tool_failure_class * string) option
+  = function
+  | Tool_result.Failed { class_; message; _ } ->
+    let truncated =
+      let error_preview_max = 200 in
+      String_util.utf8_safe ~max_bytes:(error_preview_max + 3) ~suffix:"..." message
+      |> String_util.to_string
+    in
+    Some (class_, Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated)
+  | Tool_result.Completed _ | Tool_result.Deferred _ -> None
+;;
+
 module For_testing = struct
   let activity_tool_called_payload = activity_tool_called_payload
   let arguments_of_params = arguments_of_params
+  let failure_observation = failure_observation
   let record_mcp_server_operation_duration = record_mcp_server_operation_duration
   let record_mcp_server_operation_duration_sample =
     record_mcp_server_operation_duration_sample
@@ -597,16 +611,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let telemetry_operation_id = Json_util.get_string_nonempty arguments "operation_id" in
   let telemetry_worker_run_id = Json_util.get_string_nonempty arguments "worker_run_id" in
-  let failure_observation =
-    match result with
-    | Tool_result.Failed { class_; message; _ } ->
-      let truncated =
-        let error_preview_max = 200 in
-        String_util.utf8_safe ~max_bytes:(error_preview_max + 3) ~suffix:"..." message |> String_util.to_string
-      in
-      Some (class_, Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated)
-    | Tool_result.Completed _ | Tool_result.Deferred _ -> None
-  in
+  let failure_observation = failure_observation ~duration_ms result in
   let error_detail =
     Option.map (fun (_failure_class, detail) -> detail) failure_observation
   in

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -597,25 +597,26 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let telemetry_operation_id = Json_util.get_string_nonempty arguments "operation_id" in
   let telemetry_worker_run_id = Json_util.get_string_nonempty arguments "worker_run_id" in
-  let error_detail =
-    if success then None
-    else
+  let failure_observation =
+    match result with
+    | Tool_result.Failed { class_; message; _ } ->
       let truncated =
         let error_preview_max = 200 in
         String_util.utf8_safe ~max_bytes:(error_preview_max + 3) ~suffix:"..." message |> String_util.to_string
       in
-      Some (Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated)
+      Some (class_, Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated)
+    | Tool_result.Completed _ | Tool_result.Deferred _ -> None
+  in
+  let error_detail =
+    Option.map (fun (_failure_class, detail) -> detail) failure_observation
   in
   let otel_trace_id = Otel_spans.current_trace_id () in
   Audit_log.log_tool_call config
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
-  if not success then (
-    let failure_class =
-      match Tool_result.failure_class result with
-      | Some cls -> cls
-      | None -> Tool_result.Runtime_failure
-    in
+  (match failure_observation with
+   | None -> ()
+   | Some (failure_class, error_detail) ->
     Log.Mcp.emit (Tool_result.log_level_of_failure_class failure_class)
       ~details:
         (`Assoc
@@ -631,10 +632,10 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
             ("agent_name", `String agent_name);
             ("duration_ms", `Int duration_ms);
             ("attempts", `Int attempts);
-            ("error_detail", `String (Option.value ~default:"" error_detail));
+            ("error_detail", `String error_detail);
           ])
       (Printf.sprintf "tool call failed: %s — %s" name
-         (Option.value ~default:"(no detail)" error_detail)));
+         error_detail));
 
   (* Classify call source: Keeper_internal only when the resolved agent_name
      matches a keeper in the admission workspace.  A process-global lookup
@@ -667,12 +668,12 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      here so [track_tool_called] can fan out a paired
      [Error_occurred] event for the previously-dead ADT variant. *)
   let telemetry_error_kind =
-    if not success then
-      Some (Telemetry_eio.error_kind_of_string "tool_failure")
-    else None
+    match failure_observation with
+    | Some _ -> Some (Telemetry_eio.error_kind_of_string "tool_failure")
+    | None -> None
   in
   let telemetry_failure_class =
-    if success then None else Tool_result.failure_class result
+    Option.map (fun (failure_class, _detail) -> failure_class) failure_observation
   in
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
   let telemetry_enabled = Env_config_core.telemetry_enabled () in

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -36,6 +36,11 @@ val record_mcp_server_operation_duration_sample :
 module For_testing : sig
   val arguments_of_params : Yojson.Safe.t -> Yojson.Safe.t
 
+  val failure_observation :
+    duration_ms:int ->
+    Tool_result.result ->
+    (Tool_result.tool_failure_class * string) option
+
   val activity_tool_called_payload :
     tool_name:string ->
     success:bool ->

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -436,6 +436,37 @@ let test_activity_payload_sanitizes_invalid_utf8 () =
   check int "numeric field preserved" 15310
     (payload |> U.member "pr_number" |> U.to_int)
 
+let test_failure_observation_uses_typed_failed_payload () =
+  let failed : Tool_result.result =
+    Tool_result.Failed
+      { class_ = Tool_result.Policy_rejection
+      ; message = "operator denied"
+      ; data = `Null
+      ; tool_name = "restricted-tool"
+      ; duration_ms = 0.0
+      }
+  in
+  let completed : Tool_result.result =
+    Tool_result.Completed
+      { data = `Null
+      ; metadata = None
+      ; tool_name = "completed-tool"
+      ; duration_ms = 0.0
+      }
+  in
+  check
+    (option (pair (testable Tool_result.pp_tool_failure_class ( = )) string))
+    "failed payload is the sole class/detail source"
+    (Some (Tool_result.Policy_rejection, "duration_ms=42|detail=operator denied"))
+    (Masc.Mcp_server_eio_call_tool.For_testing.failure_observation
+       ~duration_ms:42 failed);
+  check
+    (option (pair (testable Tool_result.pp_tool_failure_class ( = )) string))
+    "completed result has no failure observation"
+    None
+    (Masc.Mcp_server_eio_call_tool.For_testing.failure_observation
+       ~duration_ms:42 completed)
+
 let test_records_mcp_server_operation_duration_metric () =
   let context =
     { Otel_dispatch_hook.jsonrpc_request_id = Some "metric-request-otel"
@@ -771,6 +802,8 @@ let () =
             test_threads_exact_mcp_invocation_identity;
           test_case "activity payload sanitizes invalid UTF-8" `Quick
             test_activity_payload_sanitizes_invalid_utf8;
+          test_case "failure observation follows typed failed payload" `Quick
+            test_failure_observation_uses_typed_failed_payload;
           test_case "records MCP server operation duration metric" `Quick
             test_records_mcp_server_operation_duration_metric;
           test_case "runtime MCP log context uses keeper trace/current turn" `Quick


### PR DESCRIPTION
## Goal

Remove the fabricated empty/placeholder detail from MCP tool-failure logs and
derive all failure observation from the canonical typed `Tool_result.Failed`
payload.

## Root cause

The handler first reduced `Tool_result.result` to a `success` boolean, then
looked up `failure_class` and `error_detail` independently with permissive
fallbacks. A failed result already carries a required failure class and message,
so those defaults were unreachable dual sources and were rejected by the
deterministic-boundary ratchet when the file entered another PR's diff.

## Change

- pattern-match the closed `Tool_result.result` once
- carry `(failure_class, error_detail)` as one local observation
- emit logs only from that typed failed branch
- reuse the same observation for telemetry failure kind/class
- remove the fabricated empty string, `(no detail)`, and default
  `Runtime_failure` paths

This does not change successful or deferred tool behavior and adds no runtime
budget, timeout, string classification, or compatibility path.

## Validation

- rebased on `origin/main` `abf9a6f53e`; head `d7c25d6891`
- functional regression proves a typed failed payload preserves its exact
  failure class/detail and completed results emit no failure observation
- `ocamlc -stop-after parsing` on changed implementation/interface/test
- `ocamlformat --check` on changed implementation/interface/test
- `git diff --check`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`

Focused/full Dune remains Draft PR CI authority per repository policy.

Co-Authored-By: Codex <agent@masc.local>
