### PR TITLE
fix(keeper): compaction summarizer schema-or-prompt tier — unblock summarizer_unavailable deadlock (#25266)

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -1,7 +1,8 @@
 (** LLM-backed keeper context compaction (RFC-0313-adjacent W2).
     See keeper_compaction_llm_summarizer.mli. Structure mirrors
     Keeper_memory_llm_summary: opt-in gate + fiber-local Eio capture +
-    schema-capable provider filter + fail-closed [None]. *)
+    the shared structured-output tier ([apply_schema_or_prompt_tier]: native
+    schema when the provider accepts it, prompt tier otherwise). *)
 
 module Schema = Keeper_structured_output_schema
 module Int_set = Set.Make (Int)
@@ -45,15 +46,18 @@ let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
     tool_choice = None
   ; disable_parallel_tool_use = true
   }
-  (* Full module path (not the [Schema] alias): the structured-output
-     coverage test resolves callees literally via Ast_grep.count_calls, so
-     this call must read [Keeper_structured_output_schema.apply_to_provider_config]
-     in source — same pattern as the other registry entries. *)
-  |> Keeper_structured_output_schema.apply_to_provider_config
+  (* One structured-output surface for every summarizer runtime, the same SSOT
+     tier [Fusion_judge] uses: [apply_schema_or_prompt_tier] sends the native
+     JSON Schema to providers that accept it and falls back to the prompt tier
+     for the rest — the [messages_for_plan] prompt already spells out the plan
+     JSON, and [structured_json_of_response] extracts it from the visible text
+     either way. #25266: the previous schema-only gate left glm/kimi keepers
+     with an empty candidate pool -> Summarizer_unavailable -> compaction
+     deadlock; with the tier every assigned runtime is a candidate and the
+     failover chain in [make_resolved] does its ordinary job. *)
+  |> Keeper_structured_output_schema.apply_schema_or_prompt_tier
+       ~log_label:"compaction summarizer"
        Schema.compaction_plan_output_schema
-
-let plan_schema_supported provider_cfg =
-  Schema.provider_config_accepts_schema Schema.compaction_plan_output_schema provider_cfg
 
 let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
 
@@ -383,17 +387,15 @@ type candidate =
   ; provider_cfg : Llm_provider.Provider_config.t
   }
 
-let eligible_candidate ~keeper_name (runtime : Runtime.t) =
-  let runtime_id = runtime.Runtime.id in
-  let provider_cfg = runtime.Runtime.provider_config in
-  if not (plan_schema_supported provider_cfg)
-  then (
-    Log.Keeper.warn ~keeper_name
-      "compaction LLM candidate skipped runtime=%s: provider does not support \
-       the compaction plan schema"
-      runtime_id;
-    None)
-  else Some { runtime_id; provider_cfg }
+let eligible_candidate ~keeper_name:_ (runtime : Runtime.t) =
+  (* Every assigned runtime is an eligible summarizer candidate. Providers that
+     cannot accept the native plan schema degrade to the prompt tier in
+     [provider_for_plan] rather than being excluded here, so [make_resolved]'s
+     failover chain always has targets (#25266). *)
+  Some
+    { runtime_id = runtime.Runtime.id
+    ; provider_cfg = runtime.Runtime.provider_config
+    }
 
 let candidates_for_assignment ~keeper_name assignment_id =
   let rec resolve_lane acc = function

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -201,39 +201,42 @@ let with_lane_split_runtime f =
       | Error detail -> Alcotest.failf "runtime config should load: %s" detail
       | Ok () -> f ())
 
-let test_ineligible_chat_runtime_alone_has_no_candidate () =
+let test_ineligible_chat_runtime_alone_is_prompt_tier_candidate () =
   with_lane_split_runtime @@ fun () ->
-  (* Reproduces the #25051 P0 symptom directly: when the keeper's own chat
-     runtime is the only seed (the pre-fix behaviour), an ineligible model
-     resolves to zero candidates, so the summarizer is permanently
-     unavailable for that keeper. *)
+  (* #25266: a runtime that does not advertise supports-structured-output is no
+     longer excluded. It becomes a candidate and compacts through the prompt
+     tier ([provider_for_plan] -> [apply_schema_or_prompt_tier]), so a keeper
+     whose only seed is its own chat runtime can still compact instead of
+     deadlocking on [Summarizer_unavailable]. *)
   Alcotest.(check (option (list string)))
-    "an ineligible seed alone resolves no candidates"
-    (Some [])
+    "an ineligible seed alone is a prompt-tier candidate"
+    (Some [ ineligible_chat_runtime_id ])
     (C.For_testing.candidate_runtime_ids_for_assignment
        ~keeper_name:"keeper-test"
        ~runtime_id:ineligible_chat_runtime_id)
 
-let test_structured_judge_seed_reaches_eligible_candidate () =
+let test_structured_judge_seed_ordered_before_chat_runtime () =
   with_lane_split_runtime @@ fun () ->
-  (* The fix: seeding the chain with the structured-judge id first gives the
-     chain an eligible candidate even though the keeper's own chat runtime
-     (still present as a lower-priority seed) remains ineligible. *)
+  (* #25266: both seeds are candidates now (the chat runtime via the prompt
+     tier), and seed order is preserved — the schema-capable judge is still
+     tried first, so a healthy native-schema runtime keeps its priority while
+     the chat runtime remains a failover target rather than being dropped. *)
   Alcotest.(check (list string))
-    "structured-judge seed supplies the only eligible candidate, ordered first"
-    [ eligible_judge_runtime_id ]
+    "schema-capable judge is ordered first, chat runtime kept as failover"
+    [ eligible_judge_runtime_id; ineligible_chat_runtime_id ]
     (C.For_testing.candidate_runtime_ids_for_assignments
        ~keeper_name:"keeper-test"
        ~runtime_ids:[ eligible_judge_runtime_id; ineligible_chat_runtime_id ])
 
-let test_both_seeds_unresolvable_yields_no_candidate () =
+let test_unresolvable_seed_skipped_ineligible_seed_kept () =
   with_lane_split_runtime @@ fun () ->
-  (* No silent fallback: an unresolvable structured-judge id alongside an
-     ineligible chat runtime must still resolve to zero candidates, never a
-     surprise fallback onto the ineligible model. *)
+  (* An unresolvable seed id contributes no candidate (it names no configured
+     runtime), but the ineligible chat runtime alongside it is now a valid
+     prompt-tier candidate (#25266). Resolution failure still drops only the
+     seed that failed to resolve — never the whole chain. *)
   Alcotest.(check (list string))
-    "no candidate when every seed fails to resolve or is ineligible"
-    []
+    "unresolvable seed drops out, ineligible seed kept as prompt-tier candidate"
+    [ ineligible_chat_runtime_id ]
     (C.For_testing.candidate_runtime_ids_for_assignments
        ~keeper_name:"keeper-test"
        ~runtime_ids:[ "no.such.runtime"; ineligible_chat_runtime_id ])
@@ -504,12 +507,12 @@ let () =
             test_lane_candidates_keep_declared_order
         ] )
     ; ( "structured_judge_lane_split_25051"
-      , [ Alcotest.test_case "ineligible chat runtime alone has no candidate" `Quick
-            test_ineligible_chat_runtime_alone_has_no_candidate
-        ; Alcotest.test_case "structured-judge seed reaches an eligible candidate" `Quick
-            test_structured_judge_seed_reaches_eligible_candidate
-        ; Alcotest.test_case "both seeds unresolvable yields no candidate" `Quick
-            test_both_seeds_unresolvable_yields_no_candidate
+      , [ Alcotest.test_case "ineligible chat runtime alone is a prompt-tier candidate" `Quick
+            test_ineligible_chat_runtime_alone_is_prompt_tier_candidate
+        ; Alcotest.test_case "structured-judge seed ordered before chat runtime" `Quick
+            test_structured_judge_seed_ordered_before_chat_runtime
+        ; Alcotest.test_case "unresolvable seed skipped, ineligible seed kept" `Quick
+            test_unresolvable_seed_skipped_ineligible_seed_kept
         ; Alcotest.test_case "duplicate seed collapses to one candidate" `Quick
             test_duplicate_seed_collapses_to_one_candidate
         ; Alcotest.test_case "compact policy prefers structured judge over chat runtime" `Quick


### PR DESCRIPTION
## 목표

compaction summarizer가 `summarizer_unavailable`로 100% 실패하며 keeper들이 컨텍스트 나선에 빠지는 문제를 근본 치료한다. Closes #25266.

## 증상 (라이브)

재기동 후에도 compaction 0 성공. `manual compaction failed: recovery_error=compaction rejected: summarizer_unavailable`. 실패 keeper(sangsu/analyst/idealist)의 compaction 배정 runtime은 `glm-coding.glm-5-turbo` / `kimi_code.kimi-for-coding` — 둘 다 `supports-structured-output`가 아니다. config에서 유일한 schema-capable runtime은 `minimax-m3-native-structured` 하나뿐이고, 그것은 주간 429로 소진(2시간 6866건)이다.

## 근본 원인

compaction summarizer는 후보 runtime을 **하드 스키마 필터**로 걸렀다:

- `eligible_candidate`: `if not (plan_schema_supported provider_cfg) then None` — schema 미지원 runtime을 후보에서 제외.
- `provider_for_plan`: `apply_to_provider_config`로 native JsonSchema를 **강제**.

결과: glm/kimi만 배정된 keeper는 후보 풀이 **비고**, `make`가 `None` → `Summarizer_unavailable`. `make_resolved`에 **failover 체인은 존재하지만 빈 풀 위에서 돌아** 무력했다. 즉 failover가 특수-필터 뒤에 가려진 "dual surface"였다.

## 변경 (failover를 일반 동작으로 — 단일 SSOT 티어)

fusion_judge가 이미 쓰는 SSOT 티어 `apply_schema_or_prompt_tier`로 compaction summarizer를 수렴시킨다:

- `provider_for_plan`: `apply_to_provider_config` → **`apply_schema_or_prompt_tier`**. schema 수용 provider는 native schema, 나머지(glm/kimi)는 **prompt 티어**로 강등(프롬프트가 이미 plan JSON 형태를 명시, `structured_json_of_response`가 visible text에서 추출).
- `eligible_candidate`: 하드 스키마 필터 제거 → **배정된 모든 runtime이 후보**. `make_resolved`의 failover 체인이 실제 타깃을 가진다.
- 이제 unused인 `plan_schema_supported` 제거.

효과: schema-capable runtime(structured_judge/minimax) 없이도 glm/kimi로 compaction이 동작. 단일 schema runtime SPOF 제거.

## 검증

- `test_compaction_llm_summarizer` 21/21 green. #25051 후보 테스트 3개를 새 동작으로 갱신:
  - ineligible runtime 단독 → prompt-티어 후보(구: no candidate).
  - judge+chat seed → 둘 다 후보, judge 우선(구: judge만).
  - unresolvable seed → skip, ineligible seed는 유지(구: 전부 배제).
- Counterfactual: 하드 스키마 필터를 되돌리면 위 3 케이스 red (TEST_EXIT=1) 확인 후 복원.
- bug-class 게이트(DET/SIL/BND/log-severity/enum) PASS.

## Trade-off / 후속

prompt-티어 plan 출력은 native schema보다 신뢰도가 낮을 수 있다. 완화: (1) 프롬프트가 JSON 형태를 명시, (2) `plan_of_response` 파싱 실패 시 `Invalid_plan` → **기존 failover가 다음 후보로**, (3) fusion_judge가 같은 티어로 이미 라이브 검증됨. glm/kimi의 prompt-티어 plan 신뢰도는 배포 후 실측 대상.

관련: #25051(구 schema-seed 접근), #25281(deterministic floor, 상보), #25217(generation-missing, 별개).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
