### PR TITLE
feat(keeper): commit paused leased-work cancellation

### DIFF
--- a/lib/keeper/keeper_lifecycle_reservation.ml
+++ b/lib/keeper/keeper_lifecycle_reservation.ml
@@ -1,6 +1,8 @@
 module StringMap = Set_util.StringMap
 
-type purpose = Keeper_registry_types.lifecycle_transaction_purpose = Dead_revival
+type purpose = Keeper_registry_types.lifecycle_transaction_purpose =
+  | Dead_revival
+  | Paused_work_disposition
 
 type snapshot = Keeper_registry_types.lifecycle_reservation_snapshot =
   { owner_id : string
@@ -46,6 +48,7 @@ let key_locks_mutex = Mutex.create ()
 
 let purpose_to_string = function
   | Dead_revival -> "dead_revival"
+  | Paused_work_disposition -> "paused_work_disposition"
 ;;
 
 let snapshot_to_string snapshot =

--- a/lib/keeper/keeper_lifecycle_reservation.mli
+++ b/lib/keeper/keeper_lifecycle_reservation.mli
@@ -7,7 +7,9 @@
     {!Keeper_dead_revival_transaction}; this module deliberately contains no
     MASC/OAS runtime policy. *)
 
-type purpose = Keeper_registry_types.lifecycle_transaction_purpose = Dead_revival
+type purpose = Keeper_registry_types.lifecycle_transaction_purpose =
+  | Dead_revival
+  | Paused_work_disposition
 
 type token
 

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -1,0 +1,169 @@
+type request =
+  { source_revision : int64
+  ; owner_generation : int
+  ; lease : Keeper_registry_event_queue.lease
+  ; operator_operation_id : string
+  ; reason : string
+  ; settled_at : float
+  }
+
+type failure =
+  | Durable_meta_read_failed of string
+  | Durable_meta_missing
+  | Durable_owner_not_paused
+  | Durable_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Registry_owner_missing
+  | Registry_owner_not_paused of Keeper_state_machine.phase
+  | Registry_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Queue_commit_failed of string
+
+type success =
+  { settlement : Keeper_registry_event_queue.settle_result
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+type error =
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Failed of
+      { cause : failure
+      ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+      }
+
+let failure_to_string = function
+  | Durable_meta_read_failed detail -> "durable Keeper metadata read failed: " ^ detail
+  | Durable_meta_missing -> "durable Keeper metadata is missing"
+  | Durable_owner_not_paused -> "durable Keeper owner is not paused"
+  | Durable_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "durable Keeper owner generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Registry_owner_missing -> "live Keeper owner is missing"
+  | Registry_owner_not_paused phase ->
+    Printf.sprintf
+      "live Keeper owner is not paused: phase=%s"
+      (Keeper_state_machine.phase_to_string phase)
+  | Registry_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "live Keeper owner generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Queue_commit_failed detail -> "accepted cancellation commit failed: " ^ detail
+;;
+
+let release_outcome_to_string = function
+  | Keeper_lifecycle_reservation.Released -> "released"
+  | Keeper_lifecycle_reservation.Release_missing -> "release_missing"
+  | Keeper_lifecycle_reservation.Release_not_owner owner ->
+    "release_not_owner: " ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+;;
+
+let error_to_string = function
+  | Reservation_conflict owner ->
+    "Keeper lifecycle reservation conflict: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+  | Failed { cause; reservation_release } ->
+    Printf.sprintf
+      "%s; reservation_release=%s"
+      (failure_to_string cause)
+      (release_outcome_to_string reservation_release)
+;;
+
+let validate_durable_owner config ~keeper_name ~expected_generation =
+  match Keeper_meta_store.read_meta config keeper_name with
+  | Error detail -> Error (Durable_meta_read_failed detail)
+  | Ok None -> Error Durable_meta_missing
+  | Ok (Some meta) when not meta.paused -> Error Durable_owner_not_paused
+  | Ok (Some meta) when meta.runtime.generation <> expected_generation ->
+    Error
+      (Durable_owner_generation_changed
+         { expected = expected_generation; actual = meta.runtime.generation })
+  | Ok (Some _) -> Ok ()
+;;
+
+let validate_registry_owner ~base_path ~keeper_name ~expected_generation =
+  match Keeper_registry.get ~base_path keeper_name with
+  | None -> Error Registry_owner_missing
+  | Some entry
+    when (not entry.meta.paused) || entry.phase <> Keeper_state_machine.Paused ->
+    Error (Registry_owner_not_paused entry.phase)
+  | Some entry when entry.meta.runtime.generation <> expected_generation ->
+    Error
+      (Registry_owner_generation_changed
+         { expected = expected_generation
+         ; actual = entry.meta.runtime.generation
+         })
+  | Some entry -> Ok entry
+;;
+
+let run config ~keeper_name request =
+  let base_path = config.Workspace.base_path in
+  match
+    validate_durable_owner
+      config
+      ~keeper_name
+      ~expected_generation:request.owner_generation
+  with
+  | Error _ as error -> error
+  | Ok () ->
+    (match
+       validate_registry_owner
+         ~base_path
+         ~keeper_name
+         ~expected_generation:request.owner_generation
+     with
+     | Error _ as error -> error
+     | Ok entry ->
+       let cancellation : Keeper_registry_event_queue.accepted_cancellation =
+         { source_revision = request.source_revision
+         ; owner_generation = request.owner_generation
+         ; operator_operation_id = request.operator_operation_id
+         ; reason = request.reason
+         }
+       in
+       Keeper_registry_event_queue.cancel_accepted_result
+         ~base_path
+         keeper_name
+         ~current_owner_generation:entry.meta.runtime.generation
+         ~settled_at:request.settled_at
+         ~lease:request.lease
+         ~cancellation
+       |> Result.map_error (fun detail -> Queue_commit_failed detail))
+;;
+
+let cancel config ~keeper_name request =
+  match
+    Keeper_lifecycle_reservation.acquire
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+      ~expected_generation:request.owner_generation
+      ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+  with
+  | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+    Error (Reservation_conflict owner)
+  | Ok token ->
+    (try
+       let outcome = run config ~keeper_name request in
+       let reservation_release = Keeper_lifecycle_reservation.release token in
+       match outcome with
+       | Ok settlement -> Ok { settlement; reservation_release }
+       | Error cause -> Error (Failed { cause; reservation_release })
+     with
+     | exn ->
+       let release = Keeper_lifecycle_reservation.release token in
+       (match release with
+        | Keeper_lifecycle_reservation.Released -> ()
+        | Keeper_lifecycle_reservation.Release_missing
+        | Keeper_lifecycle_reservation.Release_not_owner _ ->
+          Log.Keeper.error
+            "paused cancellation exception release failed keeper=%s outcome=%s"
+            keeper_name
+            (release_outcome_to_string release));
+       raise exn)
+;;

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -15,7 +15,6 @@ type failure =
       { expected : int
       ; actual : int
       }
-  | Registry_owner_missing
   | Registry_owner_not_paused of Keeper_state_machine.phase
   | Registry_owner_generation_changed of
       { expected : int
@@ -44,7 +43,6 @@ let failure_to_string = function
       "durable Keeper owner generation changed: expected %d, actual %d"
       expected
       actual
-  | Registry_owner_missing -> "live Keeper owner is missing"
   | Registry_owner_not_paused phase ->
     Printf.sprintf
       "live Keeper owner is not paused: phase=%s"
@@ -84,12 +82,12 @@ let validate_durable_owner config ~keeper_name ~expected_generation =
     Error
       (Durable_owner_generation_changed
          { expected = expected_generation; actual = meta.runtime.generation })
-  | Ok (Some _) -> Ok ()
+  | Ok (Some meta) -> Ok meta
 ;;
 
 let validate_registry_owner ~base_path ~keeper_name ~expected_generation =
   match Keeper_registry.get ~base_path keeper_name with
-  | None -> Error Registry_owner_missing
+  | None -> Ok ()
   | Some entry
     when (not entry.meta.paused) || entry.phase <> Keeper_state_machine.Paused ->
     Error (Registry_owner_not_paused entry.phase)
@@ -99,7 +97,7 @@ let validate_registry_owner ~base_path ~keeper_name ~expected_generation =
          { expected = expected_generation
          ; actual = entry.meta.runtime.generation
          })
-  | Some entry -> Ok entry
+  | Some _ -> Ok ()
 ;;
 
 let run config ~keeper_name request =
@@ -111,7 +109,7 @@ let run config ~keeper_name request =
       ~expected_generation:request.owner_generation
   with
   | Error _ as error -> error
-  | Ok () ->
+  | Ok durable_meta ->
     (match
        validate_registry_owner
          ~base_path
@@ -119,7 +117,7 @@ let run config ~keeper_name request =
          ~expected_generation:request.owner_generation
      with
      | Error _ as error -> error
-     | Ok entry ->
+     | Ok () ->
        let cancellation : Keeper_registry_event_queue.accepted_cancellation =
          { source_revision = request.source_revision
          ; owner_generation = request.owner_generation
@@ -130,7 +128,7 @@ let run config ~keeper_name request =
        Keeper_registry_event_queue.cancel_accepted_result
          ~base_path
          keeper_name
-         ~current_owner_generation:entry.meta.runtime.generation
+         ~current_owner_generation:durable_meta.runtime.generation
          ~settled_at:request.settled_at
          ~lease:request.lease
          ~cancellation

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -11,6 +11,7 @@ type failure =
   | Durable_meta_read_failed of string
   | Durable_meta_missing
   | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
   | Durable_owner_generation_changed of
       { expected : int
       ; actual : int
@@ -38,6 +39,7 @@ let failure_to_string = function
   | Durable_meta_read_failed detail -> "durable Keeper metadata read failed: " ^ detail
   | Durable_meta_missing -> "durable Keeper metadata is missing"
   | Durable_owner_not_paused -> "durable Keeper owner is not paused"
+  | Durable_owner_dead_tombstone -> "durable Keeper owner is a terminal dead tombstone"
   | Durable_owner_generation_changed { expected; actual } ->
     Printf.sprintf
       "durable Keeper owner generation changed: expected %d, actual %d"
@@ -77,12 +79,22 @@ let validate_durable_owner config ~keeper_name ~expected_generation =
   match Keeper_meta_store.read_meta config keeper_name with
   | Error detail -> Error (Durable_meta_read_failed detail)
   | Ok None -> Error Durable_meta_missing
-  | Ok (Some meta) when not meta.paused -> Error Durable_owner_not_paused
-  | Ok (Some meta) when meta.runtime.generation <> expected_generation ->
-    Error
-      (Durable_owner_generation_changed
-         { expected = expected_generation; actual = meta.runtime.generation })
-  | Ok (Some meta) -> Ok meta
+  | Ok (Some meta) ->
+    (match
+       Keeper_lifecycle_admission.state
+         ~paused:meta.paused
+         ~latched_reason:meta.latched_reason
+     with
+     | Keeper_lifecycle_admission.Active -> Error Durable_owner_not_paused
+     | Keeper_lifecycle_admission.Dead_tombstone ->
+       Error Durable_owner_dead_tombstone
+     | Keeper_lifecycle_admission.Paused _ ->
+       if meta.runtime.generation <> expected_generation
+       then
+         Error
+           (Durable_owner_generation_changed
+              { expected = expected_generation; actual = meta.runtime.generation })
+       else Ok meta)
 ;;
 
 let validate_registry_owner ~base_path ~keeper_name ~expected_generation =

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -21,18 +21,19 @@ type failure =
       { expected : int
       ; actual : int
       }
+  | Queue_replay_failed of string
   | Queue_commit_failed of string
 
 type success =
   { settlement : Keeper_registry_event_queue.settle_result
-  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
   }
 
 type error =
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Failed of
       { cause : failure
-      ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+      ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
       }
 
 let failure_to_string = function
@@ -54,6 +55,7 @@ let failure_to_string = function
       "live Keeper owner generation changed: expected %d, actual %d"
       expected
       actual
+  | Queue_replay_failed detail -> "accepted cancellation replay failed: " ^ detail
   | Queue_commit_failed detail -> "accepted cancellation commit failed: " ^ detail
 ;;
 
@@ -69,10 +71,34 @@ let error_to_string = function
     "Keeper lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner
   | Failed { cause; reservation_release } ->
-    Printf.sprintf
-      "%s; reservation_release=%s"
-      (failure_to_string cause)
-      (release_outcome_to_string reservation_release)
+    (match reservation_release with
+     | None -> failure_to_string cause
+     | Some release ->
+       Printf.sprintf
+         "%s; reservation_release=%s"
+         (failure_to_string cause)
+         (release_outcome_to_string release))
+;;
+
+let cancellation_of_request (request : request) :
+  Keeper_registry_event_queue.accepted_cancellation
+  =
+  { source_revision = request.source_revision
+  ; owner_generation = request.owner_generation
+  ; operator_operation_id = request.operator_operation_id
+  ; reason = request.reason
+  }
+;;
+
+let replay_committed ~base_path ~keeper_name request =
+  match Keeper_event_queue_persistence.load_state_result ~base_path ~keeper_name with
+  | Error detail -> Error (Queue_replay_failed detail)
+  | Ok state ->
+    Keeper_event_queue_state.accepted_cancellation_replay
+      request.lease
+      (cancellation_of_request request)
+      state
+    |> Result.map_error (fun detail -> Queue_replay_failed detail)
 ;;
 
 let validate_durable_owner config ~keeper_name ~expected_generation =
@@ -130,13 +156,7 @@ let run config ~keeper_name request =
      with
      | Error _ as error -> error
      | Ok () ->
-       let cancellation : Keeper_registry_event_queue.accepted_cancellation =
-         { source_revision = request.source_revision
-         ; owner_generation = request.owner_generation
-         ; operator_operation_id = request.operator_operation_id
-         ; reason = request.reason
-         }
-       in
+       let cancellation = cancellation_of_request request in
        Keeper_registry_event_queue.cancel_accepted_result
          ~base_path
          keeper_name
@@ -148,32 +168,50 @@ let run config ~keeper_name request =
 ;;
 
 let cancel config ~keeper_name request =
-  match
-    Keeper_lifecycle_reservation.acquire
-      ~base_path:config.Workspace.base_path
-      ~keeper_name
-      ~expected_generation:request.owner_generation
-      ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
-  with
-  | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
-    Error (Reservation_conflict owner)
-  | Ok token ->
-    (try
-       let outcome = run config ~keeper_name request in
-       let reservation_release = Keeper_lifecycle_reservation.release token in
-       match outcome with
-       | Ok settlement -> Ok { settlement; reservation_release }
-       | Error cause -> Error (Failed { cause; reservation_release })
-     with
-     | exn ->
-       let release = Keeper_lifecycle_reservation.release token in
-       (match release with
-        | Keeper_lifecycle_reservation.Released -> ()
-        | Keeper_lifecycle_reservation.Release_missing
-        | Keeper_lifecycle_reservation.Release_not_owner _ ->
-          Log.Keeper.error
-            "paused cancellation exception release failed keeper=%s outcome=%s"
-            keeper_name
-            (release_outcome_to_string release));
-       raise exn)
+  let base_path = config.Workspace.base_path in
+  let finish token outcome =
+    let reservation_release = Keeper_lifecycle_reservation.release token in
+    match outcome with
+    | Ok settlement -> Ok { settlement; reservation_release = Some reservation_release }
+    | Error cause ->
+      Error (Failed { cause; reservation_release = Some reservation_release })
+  in
+  let acquire () =
+    match
+      Keeper_lifecycle_reservation.acquire
+        ~base_path
+        ~keeper_name
+        ~expected_generation:request.owner_generation
+        ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+    with
+    | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+      Error (Reservation_conflict owner)
+    | Ok token ->
+      (try
+         match replay_committed ~base_path ~keeper_name request with
+         | Error cause -> finish token (Error cause)
+         | Ok (Some receipt) ->
+           finish token (Ok (Keeper_registry_event_queue.Already_settled receipt))
+         | Ok None -> finish token (run config ~keeper_name request)
+       with
+       | exn ->
+         let release = Keeper_lifecycle_reservation.release token in
+         (match release with
+          | Keeper_lifecycle_reservation.Released -> ()
+          | Keeper_lifecycle_reservation.Release_missing
+          | Keeper_lifecycle_reservation.Release_not_owner _ ->
+            Log.Keeper.error
+              "paused cancellation exception release failed keeper=%s outcome=%s"
+              keeper_name
+              (release_outcome_to_string release));
+         raise exn)
+  in
+  match replay_committed ~base_path ~keeper_name request with
+  | Error cause -> Error (Failed { cause; reservation_release = None })
+  | Ok (Some receipt) ->
+    Ok
+      { settlement = Keeper_registry_event_queue.Already_settled receipt
+      ; reservation_release = None
+      }
+  | Ok None -> acquire ()
 ;;

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -1,4 +1,4 @@
-(** Owner-fenced terminal cancellation for one accepted event on a paused
+(** Owner-fenced terminal cancellation for one leased accepted event on a paused
     Keeper lane.
 
     The transaction reserves the Keeper lifecycle generation, verifies both

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -28,18 +28,19 @@ type failure =
       { expected : int
       ; actual : int
       }
+  | Queue_replay_failed of string
   | Queue_commit_failed of string
 
 type success =
   { settlement : Keeper_registry_event_queue.settle_result
-  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
   }
 
 type error =
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Failed of
       { cause : failure
-      ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+      ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
       }
 
 val failure_to_string : failure -> string

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -1,0 +1,57 @@
+(** Owner-fenced terminal cancellation for one accepted event on a paused
+    Keeper lane.
+
+    The transaction reserves the Keeper lifecycle generation, verifies both
+    durable and live pause ownership, then commits the exact cancellation
+    receipt through the event-queue WAL boundary. *)
+
+type request =
+  { source_revision : int64
+  ; owner_generation : int
+  ; lease : Keeper_registry_event_queue.lease
+  ; operator_operation_id : string
+  ; reason : string
+  ; settled_at : float
+  }
+
+type failure =
+  | Durable_meta_read_failed of string
+  | Durable_meta_missing
+  | Durable_owner_not_paused
+  | Durable_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Registry_owner_missing
+  | Registry_owner_not_paused of Keeper_state_machine.phase
+  | Registry_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Queue_commit_failed of string
+
+type success =
+  { settlement : Keeper_registry_event_queue.settle_result
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+type error =
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Failed of
+      { cause : failure
+      ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+      }
+
+val failure_to_string : failure -> string
+val error_to_string : error -> string
+
+val cancel :
+  Workspace.config ->
+  keeper_name:string ->
+  request ->
+  (success, error) result
+(** Cancel the exact accepted lease only while its durable and live Keeper
+    owner remain explicitly paused at [request.owner_generation]. The queue
+    revision is checked inside the durable owner lock. A committed settlement
+    remains a success even if reservation release reports an anomaly; callers
+    can inspect [reservation_release] without retrying a committed operation. *)

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -22,7 +22,6 @@ type failure =
       { expected : int
       ; actual : int
       }
-  | Registry_owner_missing
   | Registry_owner_not_paused of Keeper_state_machine.phase
   | Registry_owner_generation_changed of
       { expected : int

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -18,6 +18,7 @@ type failure =
   | Durable_meta_read_failed of string
   | Durable_meta_missing
   | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
   | Durable_owner_generation_changed of
       { expected : int
       ; actual : int

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -370,3 +370,22 @@ let settle_result ~base_path name ~settled_at ~lease ~settlement =
     ~after_commit:(publish_pending ~base_path name)
     ()
 ;;
+
+let cancel_accepted_result
+      ~base_path
+      name
+      ~current_owner_generation
+      ~settled_at
+      ~lease
+      ~cancellation
+  =
+  Keeper_event_queue_persistence.cancel_accepted_result
+    ~base_path
+    ~keeper_name:name
+    ~current_owner_generation
+    ~settled_at
+    ~lease
+    ~cancellation
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -98,6 +98,17 @@ val settle_result :
   settlement:settlement ->
   (settle_result, string) result
 
+val cancel_accepted_result :
+  base_path:string ->
+  string ->
+  current_owner_generation:int ->
+  settled_at:float ->
+  lease:lease ->
+  cancellation:accepted_cancellation ->
+  (settle_result, string) result
+(** Commit an owner-fenced accepted cancellation and publish the resulting
+    pending projection to the exact live registry lane after durable commit. *)
+
 (** Enqueue a stimulus on the keeper's event queue. When the keeper is not
     registered yet, persist the stimulus to the durable snapshot so later
     registration can replay it instead of dropping the wake at the

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -89,7 +89,9 @@ type turn_measurement =
 
 type done_resolution = [ `Stopped | `Crashed of string ]
 
-type lifecycle_transaction_purpose = Dead_revival
+type lifecycle_transaction_purpose =
+  | Dead_revival
+  | Paused_work_disposition
 
 type lifecycle_reservation_snapshot =
   { owner_id : string

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -401,7 +401,9 @@ type turn_measurement = {
 
 type done_resolution = [ `Stopped | `Crashed of string ]
 
-type lifecycle_transaction_purpose = Dead_revival
+type lifecycle_transaction_purpose =
+  | Dead_revival
+  | Paused_work_disposition
 
 type lifecycle_reservation_snapshot =
   { owner_id : string

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -650,15 +650,8 @@ let claim_board_result
     | Ok (state, lease) -> Ok (state, lease))
 ;;
 
-let commit_settlement_unlocked
-      owner
-      ~after_commit
-      ~settled_at
-      ~lease
-      ~settlement
-      current
-  =
-  match State.settle ~settled_at ~lease ~settlement current with
+let commit_settlement_transition_unlocked owner ~after_commit transition current =
+  match transition current with
   | Error _ as error -> error
   | Ok (state, State.Already_settled receipt) ->
     Ok (Already_settled receipt, State.pending state)
@@ -733,12 +726,10 @@ let settle_result
          match load_state_unlocked owner with
          | Error _ as error -> error
          | Ok state ->
-           commit_settlement_unlocked
+           commit_settlement_transition_unlocked
              owner
              ~after_commit
-             ~settled_at
-             ~lease
-             ~settlement
+             (State.settle ~settled_at ~lease ~settlement)
              state
            |> Result.map fst)
      with
@@ -747,6 +738,44 @@ let settle_result
        Error
          (Printf.sprintf
             "event queue settlement raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let cancel_accepted_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~current_owner_generation
+      ~settled_at
+      ~lease
+      ~cancellation
+      ()
+  =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           commit_settlement_transition_unlocked
+             owner
+             ~after_commit
+             (State.cancel_accepted
+                ~current_owner_generation
+                ~settled_at
+                ~lease
+                ~cancellation)
+             state
+           |> Result.map fst)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue accepted cancellation raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;
@@ -770,12 +799,13 @@ let prepare_registration_result
             | None -> Ok (State.pending state)
             | Some lease ->
               (match
-                 commit_settlement_unlocked
+                 commit_settlement_transition_unlocked
                    owner
                    ~after_commit
-                   ~settled_at
-                   ~lease
-                   ~settlement:(Requeue Registration_recovery)
+                   (State.settle
+                      ~settled_at
+                      ~lease
+                      ~settlement:(Requeue Registration_recovery))
                    state
                with
                | Error _ as error -> error

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -172,6 +172,21 @@ val settle_result :
     WAL-compaction or pending-projection failure is returned as a committed
     outcome, never relabelled as an uncommitted error. *)
 
+val cancel_accepted_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  current_owner_generation:int ->
+  settled_at:float ->
+  lease:lease ->
+  cancellation:accepted_cancellation ->
+  unit ->
+  (settle_result, string) result
+(** Commit one terminal accepted cancellation under the same durable owner lock
+    that reads the current queue revision. The pure state boundary checks the
+    supplied owner generation and observed source revision before the receipt
+    WAL is appended, so callers cannot split fence validation from commit. *)
+
 val prepare_registration_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -649,6 +649,21 @@ let cancel_accepted
     settle_committed ~settled_at ~lease ~settlement state
 ;;
 
+let accepted_cancellation_replay (lease : lease) cancellation state =
+  let requested = Cancel_accepted cancellation in
+  match find_prior_receipt lease.lease_id state with
+  | None -> Ok None
+  | Some receipt when settlement_equal receipt.settlement requested ->
+    Ok (Some receipt)
+  | Some receipt ->
+    Error
+      (Printf.sprintf
+         "event queue lease %s already settled as %s; refusing %s"
+         lease.lease_id
+         (settlement_kind_label receipt.settlement)
+         (settlement_kind_label requested))
+;;
+
 let replay_transition_receipt receipt state =
   match
     List.find_opt

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -157,6 +157,15 @@ val cancel_accepted :
     owner-fenced boundary. Replaying the same committed cancellation is
     idempotent; a different operation is a conflict. *)
 
+val accepted_cancellation_replay :
+  lease ->
+  accepted_cancellation ->
+  t ->
+  (transition_receipt option, string) result
+(** Return the canonical receipt for an already committed exact cancellation
+    without applying current owner-generation or queue-revision fences. A
+    different terminal settlement for the same lease is an explicit conflict. *)
+
 val replay_transition_receipt : transition_receipt -> t -> (t, string) result
 (** Apply one canonical durable receipt to its exact active lease. Replaying
     the same retained receipt is idempotent; a different receipt or a missing

--- a/test/dune
+++ b/test/dune
@@ -656,6 +656,11 @@
  (libraries alcotest masc_test_deps masc.keeper_checkpoint_ref))
 
 (test
+ (name test_keeper_paused_work_cancellation_transaction)
+ (modules test_keeper_paused_work_cancellation_transaction)
+ (libraries alcotest masc_test_deps eio_main))
+
+(test
  (name test_keeper_current_operations)
  (modules test_keeper_current_operations)
  (libraries alcotest masc_test_deps))

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1199,6 +1199,113 @@ let test_settlement_wal_commit_replay_and_owner_fence () =
     | Ok _ -> Alcotest.fail "another Keeper owner's WAL receipt was replayed")
 ;;
 
+let test_accepted_cancellation_persistence_is_atomic_and_idempotent () =
+  with_temp_dir "keeper-event-queue-accepted-cancellation" (fun base_path ->
+    let keeper_name = "cancel_owner" in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending (stimulus "cancel-source" 1.0))
+    |> require_ok "seed cancellation owner";
+    let lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:2.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim cancellation source"
+      |> require_some "cancellation lease"
+    in
+    let source_revision =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load cancellation revision"
+      |> State.revision
+    in
+    let cancellation : Persistence.accepted_cancellation =
+      { source_revision
+      ; owner_generation = 7
+      ; operator_operation_id = "cancel-operation-1"
+      ; reason = "operator rejected paused work"
+      }
+    in
+    let cancel () =
+      Persistence.cancel_accepted_result
+        ~base_path
+        ~keeper_name
+        ~current_owner_generation:7
+        ~settled_at:3.0
+        ~lease
+        ~cancellation
+        ()
+      |> require_ok "commit accepted cancellation"
+    in
+    let receipt =
+      match cancel () with
+      | Persistence.Settled receipt -> receipt
+      | Persistence.Already_settled _ ->
+        Alcotest.fail "first accepted cancellation was already settled"
+      | Persistence.Committed_followup_failed { receipt; _ } -> receipt
+    in
+    (match cancel () with
+     | Persistence.Already_settled replayed ->
+       Alcotest.(check bool)
+         "same operation replays the canonical receipt"
+         true
+         (State.transition_receipt_equal receipt replayed)
+     | Persistence.Settled _ | Persistence.Committed_followup_failed _ ->
+       Alcotest.fail "accepted cancellation retry committed twice");
+    let settled =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load cancelled owner"
+    in
+    Alcotest.(check int) "cancelled lease removed" 0 (List.length (State.leases settled));
+    Alcotest.(check int)
+      "cancelled source retained for projection"
+      1
+      (List.length (State.transition_outbox settled));
+    let stale_keeper = "stale_cancel_owner" in
+    Persistence.update_result ~base_path ~keeper_name:stale_keeper (fun pending ->
+      Queue.enqueue pending (stimulus "stale-cancel-source" 4.0))
+    |> require_ok "seed stale cancellation owner";
+    let stale_lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name:stale_keeper
+        ~claimed_at:5.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim stale cancellation source"
+      |> require_some "stale cancellation lease"
+    in
+    let stale_revision =
+      Persistence.load_state_result ~base_path ~keeper_name:stale_keeper
+      |> require_ok "load stale cancellation revision"
+      |> State.revision
+    in
+    let stale_cancellation : Persistence.accepted_cancellation =
+      { cancellation with source_revision = Int64.pred stale_revision }
+    in
+    (match
+       Persistence.cancel_accepted_result
+         ~base_path
+         ~keeper_name:stale_keeper
+         ~current_owner_generation:7
+         ~settled_at:6.0
+         ~lease:stale_lease
+         ~cancellation:stale_cancellation
+         ()
+     with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "stale queue revision committed cancellation");
+    let unchanged =
+      Persistence.load_state_result ~base_path ~keeper_name:stale_keeper
+      |> require_ok "load rejected stale cancellation"
+    in
+    Alcotest.(check int)
+      "stale rejection retains active lease"
+      1
+      (List.length (State.leases unchanged)))
+;;
+
 let test_context_compaction_retry_is_durable_and_lane_local () =
   with_temp_dir "keeper-event-queue-v2-retry-tail" (fun base_path ->
     let keeper_name = "retry_tail_keeper" in
@@ -1614,6 +1721,10 @@ let () =
             "settlement WAL commit replay and owner fence"
             `Quick
             test_settlement_wal_commit_replay_and_owner_fence
+        ; Alcotest.test_case
+            "accepted cancellation persistence is atomic and idempotent"
+            `Quick
+            test_accepted_cancellation_persistence_is_atomic_and_idempotent
         ; Alcotest.test_case
             "unsupported snapshots fail closed"
             `Quick

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -25,7 +25,7 @@ let rec remove_tree path =
     else Sys.remove path
 ;;
 
-let with_lane ~paused ~generation f =
+let with_lane ?(registered = true) ~paused ~generation f =
   let base_path = Filename.temp_dir "keeper-paused-cancel-transaction" "" in
   Fun.protect
     ~finally:(fun () ->
@@ -67,26 +67,29 @@ let with_lane ~paused ~generation f =
            ; payload = Queue.Bootstrap
            })
        |> require_ok "seed accepted source";
-       ignore (Keeper_registry.register ~base_path keeper_name persisted);
-       if paused
-       then
-         (match
-            Keeper_registry.dispatch_event
-              ~base_path
-              keeper_name
-              Keeper_state_machine.Operator_pause
-          with
-          | Ok _ -> ()
-          | Error error ->
-            Alcotest.failf
-              "pause live Keeper owner: %s"
-              (Keeper_state_machine.transition_error_to_string error));
+       if registered
+       then (
+         ignore (Keeper_registry.register ~base_path keeper_name persisted);
+         if paused
+         then
+           match
+             Keeper_registry.dispatch_event
+               ~base_path
+               keeper_name
+               Keeper_state_machine.Operator_pause
+           with
+           | Ok _ -> ()
+           | Error error ->
+             Alcotest.failf
+               "pause live Keeper owner: %s"
+               (Keeper_state_machine.transition_error_to_string error));
        let lease =
-         Registry_queue.claim_when_result
+         Persistence.claim_when_result
            ~base_path
-           keeper_name
+           ~keeper_name
            ~claimed_at:2.0
            ~ready:(fun _ -> true)
+           ()
          |> require_ok "claim accepted source"
          |> require_some "accepted source lease"
        in
@@ -182,6 +185,30 @@ let test_running_owner_is_rejected_before_commit () =
       (List.length (State.leases state)))
 ;;
 
+let test_durable_paused_owner_can_cancel_without_live_registry () =
+  with_lane ~registered:false ~paused:true ~generation:14 (fun config keeper_name request ->
+    let outcome =
+      Transaction.cancel config ~keeper_name request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "cancel durable paused work without live registry"
+    in
+    check_released outcome.reservation_release;
+    (match outcome.settlement with
+     | Registry_queue.Settled _ | Registry_queue.Committed_followup_failed _ -> ()
+     | Registry_queue.Already_settled _ ->
+       Alcotest.fail "first durable paused cancellation was already settled");
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load cancelled unregistered lane"
+    in
+    Alcotest.(check int)
+      "unregistered paused lease removed"
+      0
+      (List.length (State.leases state)))
+;;
+
 let test_stale_generation_is_rejected_before_commit () =
   with_lane ~paused:true ~generation:13 (fun config keeper_name request ->
     let stale = { request with owner_generation = 12 } in
@@ -226,6 +253,10 @@ let () =
             "stale generation is rejected before commit"
             `Quick
             test_stale_generation_is_rejected_before_commit
+        ; Alcotest.test_case
+            "durable paused owner can cancel without live registry"
+            `Quick
+            test_durable_paused_owner_can_cancel_without_live_registry
         ] )
     ]
 ;;

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -112,13 +112,26 @@ let with_lane ?(registered = true) ?latched_reason ~paused ~generation f =
 ;;
 
 let check_released = function
-  | Keeper_lifecycle_reservation.Released -> ()
-  | Keeper_lifecycle_reservation.Release_missing ->
+  | Some Keeper_lifecycle_reservation.Released -> ()
+  | Some Keeper_lifecycle_reservation.Release_missing ->
     Alcotest.fail "lifecycle reservation disappeared before release"
-  | Keeper_lifecycle_reservation.Release_not_owner owner ->
+  | Some (Keeper_lifecycle_reservation.Release_not_owner owner) ->
     Alcotest.failf
       "lifecycle reservation owner changed: %s"
       (Keeper_lifecycle_reservation.snapshot_to_string owner)
+  | None -> Alcotest.fail "new cancellation did not acquire a lifecycle reservation"
+;;
+
+let check_replayed_without_reservation = function
+  | None -> ()
+  | Some release ->
+    Alcotest.failf
+      "committed replay acquired a lifecycle reservation: %s"
+      (match release with
+       | Keeper_lifecycle_reservation.Released -> "released"
+       | Keeper_lifecycle_reservation.Release_missing -> "release_missing"
+       | Keeper_lifecycle_reservation.Release_not_owner owner ->
+         "release_not_owner: " ^ Keeper_lifecycle_reservation.snapshot_to_string owner)
 ;;
 
 let test_paused_owner_cancellation_commits_once () =
@@ -136,12 +149,27 @@ let test_paused_owner_cancellation_commits_once () =
         Alcotest.fail "first paused cancellation was already settled"
       | Registry_queue.Committed_followup_failed { receipt; _ } -> receipt
     in
+    let current_meta =
+      Keeper_meta_store.read_meta config keeper_name
+      |> require_ok "read committed cancellation owner"
+      |> require_some "committed cancellation owner"
+    in
+    let resumed =
+      let resumed = Keeper_meta_contract.mark_resumed current_meta in
+      { resumed with
+        runtime =
+          { resumed.runtime with generation = resumed.runtime.generation + 1 }
+      }
+    in
+    Keeper_meta_store.write_meta config resumed
+    |> require_ok "persist replacement owner generation";
+    Keeper_registry.clear ();
     let replay =
       Transaction.cancel config ~keeper_name request
       |> Result.map_error Transaction.error_to_string
       |> require_ok "replay accepted paused cancellation"
     in
-    check_released replay.reservation_release;
+    check_replayed_without_reservation replay.reservation_release;
     (match replay.settlement with
      | Registry_queue.Already_settled replayed ->
        Alcotest.(check bool)

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -1,0 +1,231 @@
+open Masc
+
+module Queue = Keeper_event_queue
+module Persistence = Keeper_event_queue_persistence
+module Registry_queue = Keeper_registry_event_queue
+module State = Keeper_event_queue_state
+module Transaction = Keeper_paused_work_cancellation_transaction
+
+let require_ok label = function
+  | Ok value -> value
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
+let require_some label = function
+  | Some value -> value
+  | None -> Alcotest.failf "%s: expected Some" label
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_lane ~paused ~generation f =
+  let base_path = Filename.temp_dir "keeper-paused-cancel-transaction" "" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      remove_tree base_path)
+    (fun () ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "paused-cancel-owner" in
+       let meta =
+         Masc_test_deps.meta_of_json_fixture
+           (`Assoc
+              [ "name", `String keeper_name
+              ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
+              ; "trace_id", `String "trace-paused-cancel-owner"
+              ; "runtime_id", `String "runtime.primary"
+              ; "autoboot_enabled", `Bool false
+              ])
+         |> require_ok "parse Keeper metadata fixture"
+       in
+       let meta =
+         { meta with
+           paused
+         ; runtime = { meta.runtime with generation }
+         }
+       in
+       Keeper_meta_store.write_meta config meta |> require_ok "persist Keeper metadata";
+       let persisted =
+         Keeper_meta_store.read_meta config keeper_name
+         |> require_ok "read persisted Keeper metadata"
+         |> require_some "persisted Keeper metadata"
+       in
+       Persistence.update_result ~base_path ~keeper_name (fun pending ->
+         Queue.enqueue
+           pending
+           { post_id = "accepted-source"
+           ; urgency = Queue.Normal
+           ; arrived_at = 1.0
+           ; payload = Queue.Bootstrap
+           })
+       |> require_ok "seed accepted source";
+       ignore (Keeper_registry.register ~base_path keeper_name persisted);
+       if paused
+       then
+         (match
+            Keeper_registry.dispatch_event
+              ~base_path
+              keeper_name
+              Keeper_state_machine.Operator_pause
+          with
+          | Ok _ -> ()
+          | Error error ->
+            Alcotest.failf
+              "pause live Keeper owner: %s"
+              (Keeper_state_machine.transition_error_to_string error));
+       let lease =
+         Registry_queue.claim_when_result
+           ~base_path
+           keeper_name
+           ~claimed_at:2.0
+           ~ready:(fun _ -> true)
+         |> require_ok "claim accepted source"
+         |> require_some "accepted source lease"
+       in
+       let source_revision =
+         Persistence.load_state_result ~base_path ~keeper_name
+         |> require_ok "load accepted source revision"
+         |> State.revision
+       in
+       let request : Transaction.request =
+         { source_revision
+         ; owner_generation = generation
+         ; lease
+         ; operator_operation_id = "operator-cancel-1"
+         ; reason = "operator rejected retained paused work"
+         ; settled_at = 3.0
+         }
+       in
+       f config keeper_name request)
+;;
+
+let check_released = function
+  | Keeper_lifecycle_reservation.Released -> ()
+  | Keeper_lifecycle_reservation.Release_missing ->
+    Alcotest.fail "lifecycle reservation disappeared before release"
+  | Keeper_lifecycle_reservation.Release_not_owner owner ->
+    Alcotest.failf
+      "lifecycle reservation owner changed: %s"
+      (Keeper_lifecycle_reservation.snapshot_to_string owner)
+;;
+
+let test_paused_owner_cancellation_commits_once () =
+  with_lane ~paused:true ~generation:11 (fun config keeper_name request ->
+    let first =
+      Transaction.cancel config ~keeper_name request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "cancel accepted paused work"
+    in
+    check_released first.reservation_release;
+    let receipt =
+      match first.settlement with
+      | Registry_queue.Settled receipt -> receipt
+      | Registry_queue.Already_settled _ ->
+        Alcotest.fail "first paused cancellation was already settled"
+      | Registry_queue.Committed_followup_failed { receipt; _ } -> receipt
+    in
+    let replay =
+      Transaction.cancel config ~keeper_name request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "replay accepted paused cancellation"
+    in
+    check_released replay.reservation_release;
+    (match replay.settlement with
+     | Registry_queue.Already_settled replayed ->
+       Alcotest.(check bool)
+         "replay returns the canonical receipt"
+         true
+         (State.transition_receipt_equal receipt replayed)
+     | Registry_queue.Settled _ | Registry_queue.Committed_followup_failed _ ->
+       Alcotest.fail "paused cancellation replay committed twice");
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load cancelled paused lane"
+    in
+    Alcotest.(check int) "accepted lease removed" 0 (List.length (State.leases state));
+    Alcotest.(check int)
+      "exact source retained in transition outbox"
+      1
+      (List.length (State.transition_outbox state)))
+;;
+
+let test_running_owner_is_rejected_before_commit () =
+  with_lane ~paused:false ~generation:12 (fun config keeper_name request ->
+    (match Transaction.cancel config ~keeper_name request with
+     | Error
+         (Transaction.Failed
+            { cause = Transaction.Durable_owner_not_paused
+            ; reservation_release
+            }) ->
+       check_released reservation_release
+     | Error error -> Alcotest.fail (Transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "running Keeper owner accepted paused cancellation");
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load rejected running lane"
+    in
+    Alcotest.(check int)
+      "rejected running owner retains active lease"
+      1
+      (List.length (State.leases state)))
+;;
+
+let test_stale_generation_is_rejected_before_commit () =
+  with_lane ~paused:true ~generation:13 (fun config keeper_name request ->
+    let stale = { request with owner_generation = 12 } in
+    (match Transaction.cancel config ~keeper_name stale with
+     | Error
+         (Transaction.Failed
+            { cause =
+                Transaction.Durable_owner_generation_changed
+                  { expected = 12; actual = 13 }
+            ; reservation_release
+            }) ->
+       check_released reservation_release
+     | Error error -> Alcotest.fail (Transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "stale Keeper generation accepted cancellation");
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load stale-generation lane"
+    in
+    Alcotest.(check int)
+      "stale generation retains active lease"
+      1
+      (List.length (State.leases state)))
+;;
+
+let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Alcotest.run
+    "paused work cancellation transaction"
+    [ ( "transaction"
+      , [ Alcotest.test_case
+            "paused owner cancellation commits once"
+            `Quick
+            test_paused_owner_cancellation_commits_once
+        ; Alcotest.test_case
+            "running owner is rejected before commit"
+            `Quick
+            test_running_owner_is_rejected_before_commit
+        ; Alcotest.test_case
+            "stale generation is rejected before commit"
+            `Quick
+            test_stale_generation_is_rejected_before_commit
+        ] )
+    ]
+;;

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -25,7 +25,7 @@ let rec remove_tree path =
     else Sys.remove path
 ;;
 
-let with_lane ?(registered = true) ~paused ~generation f =
+let with_lane ?(registered = true) ?latched_reason ~paused ~generation f =
   let base_path = Filename.temp_dir "keeper-paused-cancel-transaction" "" in
   Fun.protect
     ~finally:(fun () ->
@@ -49,6 +49,7 @@ let with_lane ?(registered = true) ~paused ~generation f =
        let meta =
          { meta with
            paused
+         ; latched_reason
          ; runtime = { meta.runtime with generation }
          }
        in
@@ -209,6 +210,34 @@ let test_durable_paused_owner_can_cancel_without_live_registry () =
       (List.length (State.leases state)))
 ;;
 
+let test_dead_tombstone_cannot_use_operator_cancellation () =
+  with_lane
+    ~registered:false
+    ~latched_reason:Keeper_latched_reason.Dead_tombstone
+    ~paused:true
+    ~generation:15
+    (fun config keeper_name request ->
+       (match Transaction.cancel config ~keeper_name request with
+        | Error
+            (Transaction.Failed
+               { cause = Transaction.Durable_owner_dead_tombstone
+               ; reservation_release
+               }) ->
+          check_released reservation_release
+        | Error error -> Alcotest.fail (Transaction.error_to_string error)
+        | Ok _ -> Alcotest.fail "dead tombstone accepted operator cancellation");
+       let state =
+         Persistence.load_state_result
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+         |> require_ok "load rejected dead-tombstone lane"
+       in
+       Alcotest.(check int)
+         "dead-tombstone rejection retains active lease"
+         1
+         (List.length (State.leases state)))
+;;
+
 let test_stale_generation_is_rejected_before_commit () =
   with_lane ~paused:true ~generation:13 (fun config keeper_name request ->
     let stale = { request with owner_generation = 12 } in
@@ -257,6 +286,10 @@ let () =
             "durable paused owner can cancel without live registry"
             `Quick
             test_durable_paused_owner_can_cancel_without_live_registry
+        ; Alcotest.test_case
+            "dead tombstone cannot use operator cancellation"
+            `Quick
+            test_dead_tombstone_cannot_use_operator_cancellation
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- add a typed `Paused_work_disposition` lifecycle reservation purpose so cancellation cannot race Keeper registry/meta ownership changes
- add `cancel_accepted_result` for one active accepted lease, checking queue revision and owner generation inside the durable event-queue owner lock before appending the canonical receipt WAL
- add a paused-owner transaction that verifies typed durable `Paused` ownership and, when a live registry lane exists, its exact paused generation before committing; permanently paused unregistered lanes remain operable while terminal `Dead_tombstone` owners are rejected
- replay an already committed canonical cancellation receipt before current lifecycle/generation fences, so lost-response retries remain idempotent after owner resume or replacement
- publish the post-commit pending projection back to the live registry lane
- cover durable idempotency across owner transition, stale revision/generation rejection, running/dead-owner rejection, unregistered durable-owner cancellation, exact lease removal, and retained transition-outbox source evidence

## Stack

- Base: #25318
- This remains a focused follow-up slice of #25191. It does not cancel still-pending paused backlog, expose the HTTP/tool operator surface, or implement owner transfer/source-terminal settlement; those need a pre-removal operation receipt that can replay without an active lease.

## Validation

- `ocamlformat --check <changed OCaml files>`
- `ocamlc -stop-after parsing -impl <changed implementation/test files>`
- `ocamlc -stop-after parsing -intf <changed interfaces>`
- `git diff --check`
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail`
- focused Dune build/test intentionally left to the operator and PR CI

Refs #25191
