### PR TITLE
fix(fs): preserve offset transaction close settlement

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1906,7 +1906,7 @@ let private_jsonl_snapshot_success_receipt = function
        Ok { value; settlement_error = Some settlement_error }
      | Some
          ( (Cursor_succeeded _ | Cursor_precondition_succeeded _)
-         , _settlement_error )
+         , _ )
      | None -> Error error)
 ;;
 
@@ -1918,7 +1918,7 @@ let private_jsonl_cursor_success_receipt = function
        Ok { value; settlement_error = Some settlement_error }
      | Some
          ( (Snapshot_succeeded _ | Cursor_precondition_succeeded _)
-         , _settlement_error )
+         , _ )
      | None -> Error error)
 ;;
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1804,11 +1804,13 @@ type private_jsonl_transaction_operation =
   | Read_stable_lock_state
   | Write_stable_lock_state
   | Sync_stable_lock
+  | Close_stable_lock
   | Open_transaction_data
   | Set_transaction_data_permissions
   | Inspect_transaction_data
   | Inspect_transaction_path
   | Read_transaction_data
+  | Close_transaction_data
   | Create_rewrite_stage
   | Set_rewrite_stage_permissions
   | Write_rewrite_stage
@@ -1825,7 +1827,15 @@ type private_jsonl_operation_failure =
   ; backtrace : Printexc.raw_backtrace
   }
 
-type private_jsonl_transaction_error =
+type private_jsonl_transaction_success =
+  | Snapshot_succeeded of private_jsonl_snapshot
+  | Cursor_succeeded of Private_jsonl_cursor.t
+
+type private_jsonl_transaction_primary =
+  | Transaction_succeeded of private_jsonl_transaction_success
+  | Transaction_failed of private_jsonl_transaction_error
+
+and private_jsonl_transaction_error =
   | Stable_lock_contended of { lock_path : string }
   | Unexpected_stable_lock_permissions of
       { path : string
@@ -1856,6 +1866,10 @@ type private_jsonl_transaction_error =
       { cursor : Private_jsonl_cursor.t option
       ; failure : private_jsonl_operation_failure
       }
+  | Transaction_settlement_failed of
+      { primary : private_jsonl_transaction_primary
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
   | Transaction_append_failed of durable_append_error
 
 let private_jsonl_operation_to_string = function
@@ -1869,11 +1883,13 @@ let private_jsonl_operation_to_string = function
   | Read_stable_lock_state -> "read stable lock state"
   | Write_stable_lock_state -> "write stable lock state"
   | Sync_stable_lock -> "sync stable lock"
+  | Close_stable_lock -> "close stable lock"
   | Open_transaction_data -> "open transaction data"
   | Set_transaction_data_permissions -> "set transaction data permissions"
   | Inspect_transaction_data -> "inspect transaction data"
   | Inspect_transaction_path -> "inspect transaction path"
   | Read_transaction_data -> "read transaction data"
+  | Close_transaction_data -> "close transaction data"
   | Create_rewrite_stage -> "create rewrite stage"
   | Set_rewrite_stage_permissions -> "set rewrite stage permissions"
   | Write_rewrite_stage -> "write rewrite stage"
@@ -1892,7 +1908,7 @@ let private_jsonl_operation_failure_to_string failure =
     (Printexc.to_string failure.exception_)
 ;;
 
-let private_jsonl_transaction_error_to_string = function
+let rec private_jsonl_transaction_error_to_string = function
   | Stable_lock_contended { lock_path } ->
     Printf.sprintf "private JSONL stable lock is contended: %s" lock_path
   | Unexpected_stable_lock_permissions { path; actual } ->
@@ -1957,6 +1973,26 @@ let private_jsonl_transaction_error_to_string = function
        | None -> "unknown"
        | Some cursor -> Private_jsonl_cursor.to_string cursor)
       (private_jsonl_operation_failure_to_string failure)
+  | Transaction_settlement_failed { primary; cleanup_failures } ->
+    let primary =
+      match primary with
+      | Transaction_succeeded (Snapshot_succeeded snapshot) ->
+        Printf.sprintf
+          "private JSONL snapshot read succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string snapshot.cursor)
+      | Transaction_succeeded (Cursor_succeeded cursor) ->
+        Printf.sprintf
+          "private JSONL cursor operation succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string cursor)
+      | Transaction_failed primary ->
+        private_jsonl_transaction_error_to_string primary
+    in
+    Printf.sprintf
+      "%s; descriptor settlement failed: %s"
+      primary
+      (cleanup_failures
+       |> List.map private_jsonl_operation_failure_to_string
+       |> String.concat "; ")
   | Transaction_append_failed append_error ->
     durable_append_error_to_string append_error
 ;;
@@ -1972,13 +2008,70 @@ let private_jsonl_capture operation f =
   | exception exception_ -> Error (private_jsonl_failure operation exception_)
 ;;
 
+let private_jsonl_add_cleanup_failure error cleanup_failure =
+  match error with
+  | Transaction_settlement_failed { primary; cleanup_failures } ->
+    Transaction_settlement_failed
+      { primary; cleanup_failures = cleanup_failures @ [ cleanup_failure ] }
+  | (Stable_lock_contended _
+    | Unexpected_stable_lock_permissions _
+    | Invalid_stable_lock_state _
+    | Cursor_mismatch _
+    | Unexpected_transaction_file_kind _
+    | Ambiguous_transaction_file_identity _
+    | Transaction_path_binding_changed _
+    | Incomplete_transaction_tail _
+    | Invalid_transaction_suffix
+    | Private_jsonl_operation_failed _
+    | Rewrite_stage_failed _
+    | Rewrite_published_durability_unknown _
+    | Transaction_append_failed _) as primary ->
+    Transaction_settlement_failed
+      { primary = Transaction_failed primary
+      ; cleanup_failures = [ cleanup_failure ]
+      }
+;;
+
+let private_jsonl_settlement_failed ~success result cleanup_failure =
+  match result with
+  | Ok value ->
+    Error
+      (Transaction_settlement_failed
+         { primary = Transaction_succeeded (success value)
+         ; cleanup_failures = [ cleanup_failure ]
+         })
+  | Error error -> Error (private_jsonl_add_cleanup_failure error cleanup_failure)
+;;
+
+let private_jsonl_with_fd ~close_operation ~close_fd ~success fd f =
+  match f () with
+  | result ->
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> result
+     | Error cleanup_failure ->
+       private_jsonl_settlement_failed ~success result cleanup_failure)
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Printexc.raise_with_backtrace exception_ backtrace
+     | Error cleanup_failure ->
+       let combined, combined_backtrace =
+         Eio.Exn.combine
+           (exception_, backtrace)
+           (cleanup_failure.exception_, cleanup_failure.backtrace)
+       in
+       Printexc.raise_with_backtrace combined combined_backtrace)
+;;
+
 let private_jsonl_lock_path path = path ^ ".lock"
 
 type private_jsonl_transaction_io_for_testing =
-  { before_sync_parent : string -> unit }
+  { before_sync_parent : string -> unit
+  ; close_fd : Unix.file_descr -> unit
+  }
 
 let private_jsonl_transaction_unix_io =
-  { before_sync_parent = (fun _dir -> ()) }
+  { before_sync_parent = (fun _dir -> ()); close_fd = Unix.close }
 ;;
 
 let private_jsonl_stable_lock_ready_marker = "\xA5"
@@ -2151,7 +2244,7 @@ let rec try_lock_whole_file fd =
   | exception Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> false
 ;;
 
-let with_private_jsonl_stable_lock ~io requested_path f =
+let with_private_jsonl_stable_lock ~io ~success requested_path f =
   let requested_dir = Filename.dirname requested_path in
   run_blocking_private_file_transaction
     ~label:"fs-compat-private-jsonl-transaction"
@@ -2175,8 +2268,11 @@ let with_private_jsonl_stable_lock ~io requested_path f =
               match private_jsonl_open_stable_lock lock_path with
               | Error _ as error -> error
               | Ok stable_lock ->
-                Fun.protect
-                  ~finally:(fun () -> Unix.close stable_lock.fd)
+                private_jsonl_with_fd
+                  ~close_operation:Close_stable_lock
+                  ~close_fd:io.close_fd
+                  ~success
+                  stable_lock.fd
                   (fun () ->
                      let ( let* ) = Result.bind in
                      let* () =
@@ -2222,7 +2318,7 @@ let private_jsonl_cursor_of_stats stats =
          })
 ;;
 
-let private_jsonl_open_existing path flags =
+let private_jsonl_open_existing ~close_fd path flags =
   match Unix.openfile path (Unix.O_CLOEXEC :: flags) 0 with
   | fd ->
     (match
@@ -2233,8 +2329,10 @@ let private_jsonl_open_existing path flags =
      with
      | Ok () -> Ok (Some fd)
      | Error error ->
-       Unix.close fd;
-       Error error)
+       (match private_jsonl_capture Close_transaction_data (fun () -> close_fd fd) with
+        | Ok () -> Error error
+        | Error cleanup_failure ->
+          Error (private_jsonl_add_cleanup_failure error cleanup_failure)))
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
   | exception (Eio.Cancel.Cancelled _ as cancellation) -> raise cancellation
   | exception exception_ ->
@@ -2289,8 +2387,9 @@ let private_jsonl_read_exact fd ~from ~end_offset =
 ;;
 
 let read_private_jsonl_durable_locked_with_io ~io path ~after =
-  with_private_jsonl_stable_lock ~io path @@ fun ~dir:_ ~path ->
-  match private_jsonl_open_existing path [ Unix.O_RDONLY ] with
+  let success snapshot = Snapshot_succeeded snapshot in
+  with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir:_ ~path ->
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None ->
     let actual = Private_jsonl_cursor.Missing in
@@ -2301,8 +2400,11 @@ let read_private_jsonl_durable_locked_with_io ~io path ~after =
        then Ok { bytes = ""; cursor = actual }
        else Error (Cursor_mismatch { expected; actual }))
   | Ok (Some fd) ->
-    Fun.protect
-      ~finally:(fun () -> Unix.close fd)
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
       (fun () ->
          match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
          with
@@ -2349,13 +2451,17 @@ let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =
   read_private_jsonl_durable_locked_with_io ~io path ~after
 ;;
 
-let private_jsonl_current_cursor path =
-  match private_jsonl_open_existing path [ Unix.O_RDONLY ] with
+let private_jsonl_current_cursor ~io path =
+  let success cursor = Cursor_succeeded cursor in
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None -> Ok Private_jsonl_cursor.Missing
   | Ok (Some fd) ->
-    Fun.protect
-      ~finally:(fun () -> Unix.close fd)
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
       (fun () ->
          match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
          with
@@ -2458,14 +2564,19 @@ let private_jsonl_replace_locked ~dir path content =
                         { cursor = Some cursor; failure }))))))
 ;;
 
-let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
+let append_private_jsonl_durable_locked_at_cursor_with_io ~io path ~expected suffix =
   if String.equal suffix ""
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
   then Error Invalid_transaction_suffix
   else
-    with_private_jsonl_stable_lock ~io:private_jsonl_transaction_unix_io path
-    @@ fun ~dir ~path ->
-    match private_jsonl_open_existing path [ Unix.O_RDWR; Unix.O_APPEND ] with
+    let success cursor = Cursor_succeeded cursor in
+    with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir ~path ->
+    match
+      private_jsonl_open_existing
+        ~close_fd:io.close_fd
+        path
+        [ Unix.O_RDWR; Unix.O_APPEND ]
+    with
     | Error _ as error -> error
     | Ok None ->
       let actual = Private_jsonl_cursor.Missing in
@@ -2473,8 +2584,11 @@ let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
       then Error (Cursor_mismatch { expected; actual })
       else private_jsonl_replace_locked ~dir path suffix
     | Ok (Some fd) ->
-      Fun.protect
-        ~finally:(fun () -> Unix.close fd)
+      private_jsonl_with_fd
+        ~close_operation:Close_transaction_data
+        ~close_fd:io.close_fd
+        ~success
+        fd
         (fun () ->
            match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
            with
@@ -2516,7 +2630,29 @@ let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
                              private_jsonl_cursor_of_stats committed_stats))))))
 ;;
 
-let rewrite_private_jsonl_durable_locked_at_cursor_result
+let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
+  append_private_jsonl_durable_locked_at_cursor_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    suffix
+;;
+
+let append_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected
+      suffix
+  =
+  append_private_jsonl_durable_locked_at_cursor_with_io
+    ~io
+    path
+    ~expected
+    suffix
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_with_io
+      ~io
       path
       ~expected
       content
@@ -2525,14 +2661,29 @@ let rewrite_private_jsonl_durable_locked_at_cursor_result
      && not (Char.equal content.[String.length content - 1] '\n')
   then Error Invalid_transaction_suffix
   else
-    with_private_jsonl_stable_lock ~io:private_jsonl_transaction_unix_io path
+    with_private_jsonl_stable_lock
+      ~io
+      ~success:(fun cursor -> Cursor_succeeded cursor)
+      path
     @@ fun ~dir ~path ->
-    match private_jsonl_current_cursor path with
+    match private_jsonl_current_cursor ~io path with
     | Error _ as error -> error
     | Ok actual ->
       if not (Private_jsonl_cursor.equal expected actual)
       then Error (Cursor_mismatch { expected; actual })
       else private_jsonl_replace_locked ~dir path content
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_result
+      path
+      ~expected
+      content
+  =
+  rewrite_private_jsonl_durable_locked_at_cursor_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    content
 ;;
 
 module Private_jsonl_slice = struct

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1801,6 +1801,9 @@ type private_jsonl_transaction_operation =
   | Set_stable_lock_permissions
   | Sync_stable_lock_parent
   | Acquire_stable_lock
+  | Read_stable_lock_state
+  | Write_stable_lock_state
+  | Sync_stable_lock
   | Open_transaction_data
   | Set_transaction_data_permissions
   | Inspect_transaction_data
@@ -1824,6 +1827,14 @@ type private_jsonl_operation_failure =
 
 type private_jsonl_transaction_error =
   | Stable_lock_contended of { lock_path : string }
+  | Unexpected_stable_lock_permissions of
+      { path : string
+      ; actual : int
+      }
+  | Invalid_stable_lock_state of
+      { path : string
+      ; observed_length : int
+      }
   | Cursor_mismatch of
       { expected : Private_jsonl_cursor.t
       ; actual : Private_jsonl_cursor.t
@@ -1855,6 +1866,9 @@ let private_jsonl_operation_to_string = function
   | Set_stable_lock_permissions -> "set stable lock permissions"
   | Sync_stable_lock_parent -> "sync stable lock parent"
   | Acquire_stable_lock -> "acquire stable lock"
+  | Read_stable_lock_state -> "read stable lock state"
+  | Write_stable_lock_state -> "write stable lock state"
+  | Sync_stable_lock -> "sync stable lock"
   | Open_transaction_data -> "open transaction data"
   | Set_transaction_data_permissions -> "set transaction data permissions"
   | Inspect_transaction_data -> "inspect transaction data"
@@ -1881,6 +1895,16 @@ let private_jsonl_operation_failure_to_string failure =
 let private_jsonl_transaction_error_to_string = function
   | Stable_lock_contended { lock_path } ->
     Printf.sprintf "private JSONL stable lock is contended: %s" lock_path
+  | Unexpected_stable_lock_permissions { path; actual } ->
+    Printf.sprintf
+      "private JSONL stable lock permissions are %04o, expected 0600: %s"
+      actual
+      path
+  | Invalid_stable_lock_state { path; observed_length } ->
+    Printf.sprintf
+      "private JSONL stable lock has invalid durable state: %s (%d bytes)"
+      path
+      observed_length
   | Cursor_mismatch { expected; actual } ->
     Printf.sprintf
       "private JSONL cursor mismatch: expected %s, observed %s"
@@ -1950,6 +1974,144 @@ let private_jsonl_capture operation f =
 
 let private_jsonl_lock_path path = path ^ ".lock"
 
+type private_jsonl_transaction_io_for_testing =
+  { before_sync_parent : string -> unit }
+
+let private_jsonl_transaction_unix_io =
+  { before_sync_parent = (fun _dir -> ()) }
+;;
+
+let private_jsonl_stable_lock_ready_marker = "\xA5"
+
+type private_jsonl_stable_lock_state =
+  | Stable_lock_initializing
+  | Stable_lock_ready
+
+type private_jsonl_stable_lock_creation =
+  | Stable_lock_created
+  | Stable_lock_existing
+
+type private_jsonl_stable_lock =
+  { fd : Unix.file_descr
+  ; creation : private_jsonl_stable_lock_creation
+  }
+
+let private_jsonl_open_stable_lock lock_path =
+  match
+    private_jsonl_capture Open_stable_lock (fun () ->
+      Unix.openfile
+        lock_path
+        [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_EXCL; Unix.O_CLOEXEC ]
+        0o600)
+  with
+  | Ok fd -> Ok { fd; creation = Stable_lock_created }
+  | Error failure ->
+    (match failure.exception_ with
+     | Unix.Unix_error (error, _, _) when error = Unix.EEXIST ->
+       private_jsonl_capture Open_stable_lock (fun () ->
+         Unix.openfile lock_path [ Unix.O_RDWR; Unix.O_CLOEXEC ] 0)
+       |> Result.map (fun fd -> { fd; creation = Stable_lock_existing })
+       |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+     (* DET-OK: [exn] is open. Every non-EEXIST open failure remains typed. *)
+     | _ -> Error (Private_jsonl_operation_failed failure))
+;;
+
+let rec private_jsonl_write_substring_all fd value offset =
+  if offset < String.length value
+  then
+    match Unix.write_substring fd value offset (String.length value - offset) with
+    | 0 ->
+      raise
+        (Unix.Unix_error
+           (Unix.EIO, "write", "private JSONL stable lock made no progress"))
+    | count -> private_jsonl_write_substring_all fd value (offset + count)
+    | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+      private_jsonl_write_substring_all fd value offset
+;;
+
+let private_jsonl_read_stable_lock_state path fd =
+  match private_jsonl_capture Read_stable_lock_state (fun () -> Unix.fstat fd) with
+  | Error failure -> Error (Private_jsonl_operation_failed failure)
+  | Ok stats ->
+    let observed_length = stats.Unix.st_size in
+    if observed_length = 0
+    then Ok Stable_lock_initializing
+    else if observed_length <> String.length private_jsonl_stable_lock_ready_marker
+    then Error (Invalid_stable_lock_state { path; observed_length })
+    else
+      (match private_jsonl_capture Read_stable_lock_state (fun () ->
+         let bytes = Bytes.create observed_length in
+         ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+         let rec read_all offset =
+           if offset = observed_length
+           then ()
+           else
+             match Unix.read fd bytes offset (observed_length - offset) with
+             | 0 -> raise End_of_file
+             | count -> read_all (offset + count)
+             | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_all offset
+         in
+         read_all 0;
+         Bytes.unsafe_to_string bytes)
+       with
+       | Error failure -> Error (Private_jsonl_operation_failed failure)
+       | Ok marker ->
+         if String.equal marker private_jsonl_stable_lock_ready_marker
+         then Ok Stable_lock_ready
+         else Error (Invalid_stable_lock_state { path; observed_length }))
+;;
+
+let private_jsonl_sync_stable_lock fd =
+  private_jsonl_capture Sync_stable_lock (fun () -> Unix.fsync fd)
+  |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+;;
+
+let private_jsonl_initialize_stable_lock ~io ~dir fd =
+  let ( let* ) = Result.bind in
+  let* () = private_jsonl_sync_stable_lock fd in
+  let* () =
+    private_jsonl_capture Sync_stable_lock_parent (fun () ->
+      io.before_sync_parent dir;
+      fsync_parent_directory dir)
+    |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+  in
+  let* () =
+    private_jsonl_capture Write_stable_lock_state (fun () ->
+      ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+      private_jsonl_write_substring_all
+        fd
+        private_jsonl_stable_lock_ready_marker
+        0)
+    |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+  in
+  private_jsonl_sync_stable_lock fd
+;;
+
+let private_jsonl_prepare_stable_lock ~io ~dir ~path stable_lock =
+  let ( let* ) = Result.bind in
+  let* () =
+    match stable_lock.creation with
+    | Stable_lock_created ->
+      private_jsonl_capture Set_stable_lock_permissions (fun () ->
+        Unix.fchmod stable_lock.fd 0o600)
+      |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+    | Stable_lock_existing -> Ok ()
+  in
+  let* permissions =
+    private_jsonl_capture Inspect_stable_lock (fun () ->
+      (Unix.fstat stable_lock.fd).Unix.st_perm land 0o7777)
+    |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+  in
+  if permissions <> 0o600
+  then Error (Unexpected_stable_lock_permissions { path; actual = permissions })
+  else
+    let* state = private_jsonl_read_stable_lock_state path stable_lock.fd in
+    match state with
+    | Stable_lock_initializing ->
+      private_jsonl_initialize_stable_lock ~io ~dir stable_lock.fd
+    | Stable_lock_ready -> Ok ()
+;;
+
 let private_jsonl_same_identity left right =
   Int.equal left.Unix.st_dev right.Unix.st_dev
   && Int.equal left.Unix.st_ino right.Unix.st_ino
@@ -1989,7 +2151,7 @@ let rec try_lock_whole_file fd =
   | exception Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> false
 ;;
 
-let with_private_jsonl_stable_lock requested_path f =
+let with_private_jsonl_stable_lock ~io requested_path f =
   let requested_dir = Filename.dirname requested_path in
   run_blocking_private_file_transaction
     ~label:"fs-compat-private-jsonl-transaction"
@@ -2010,56 +2172,42 @@ let with_private_jsonl_stable_lock requested_path f =
             let lock_path = private_jsonl_lock_path path in
             let path_mu = get_append_path_mutex path in
             Stdlib.Mutex.protect path_mu (fun () ->
-              match private_jsonl_capture Open_stable_lock (fun () ->
-                Unix.openfile
-                  lock_path
-                  [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_CLOEXEC ]
-                  0o600)
-              with
-              | Error failure -> Error (Private_jsonl_operation_failed failure)
-              | Ok lock_fd ->
+              match private_jsonl_open_stable_lock lock_path with
+              | Error _ as error -> error
+              | Ok stable_lock ->
                 Fun.protect
-                  ~finally:(fun () -> Unix.close lock_fd)
+                  ~finally:(fun () -> Unix.close stable_lock.fd)
                   (fun () ->
-                     match
+                     let ( let* ) = Result.bind in
+                     let* () =
                        private_jsonl_validate_open_binding
                          ~operation:Inspect_stable_lock
                          ~path:lock_path
-                         lock_fd
-                     with
-                     | Error _ as error -> error
-                     | Ok () ->
-                       (match
-                          private_jsonl_capture Set_stable_lock_permissions (fun () ->
-                            Unix.fchmod lock_fd 0o600)
-                        with
-                        | Error failure ->
-                          Error (Private_jsonl_operation_failed failure)
-                        | Ok () ->
-                          (match
-                             private_jsonl_capture Sync_stable_lock_parent (fun () ->
-                               fsync_parent_directory dir)
-                           with
-                           | Error failure ->
-                             Error (Private_jsonl_operation_failed failure)
-                           | Ok () ->
-                             (match
-                                private_jsonl_capture Acquire_stable_lock (fun () ->
-                                  try_lock_whole_file lock_fd)
-                              with
-                              | Error failure ->
-                                Error (Private_jsonl_operation_failed failure)
-                              | Ok false ->
-                                Error (Stable_lock_contended { lock_path })
-                              | Ok true ->
-                                (match
-                                   private_jsonl_validate_open_binding
-                                     ~operation:Inspect_stable_lock
-                                     ~path:lock_path
-                                     lock_fd
-                                 with
-                                 | Error _ as error -> error
-                                 | Ok () -> f ~dir ~path))))))))
+                         stable_lock.fd
+                     in
+                     let* acquired =
+                       private_jsonl_capture Acquire_stable_lock (fun () ->
+                         try_lock_whole_file stable_lock.fd)
+                       |> Result.map_error (fun failure ->
+                         Private_jsonl_operation_failed failure)
+                     in
+                     if not acquired
+                     then Error (Stable_lock_contended { lock_path })
+                     else
+                       let* () =
+                         private_jsonl_validate_open_binding
+                           ~operation:Inspect_stable_lock
+                           ~path:lock_path
+                           stable_lock.fd
+                       in
+                       let* () =
+                         private_jsonl_prepare_stable_lock
+                           ~io
+                           ~dir
+                           ~path:lock_path
+                           stable_lock
+                       in
+                       f ~dir ~path))))
 ;;
 
 let private_jsonl_cursor_of_stats stats =
@@ -2140,8 +2288,8 @@ let private_jsonl_read_exact fd ~from ~end_offset =
   |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
 ;;
 
-let read_private_jsonl_durable_locked_result path ~after =
-  with_private_jsonl_stable_lock path @@ fun ~dir:_ ~path ->
+let read_private_jsonl_durable_locked_with_io ~io path ~after =
+  with_private_jsonl_stable_lock ~io path @@ fun ~dir:_ ~path ->
   match private_jsonl_open_existing path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None ->
@@ -2188,6 +2336,17 @@ let read_private_jsonl_durable_locked_result path ~after =
                       ~from
                       ~end_offset:stats.Unix.st_size
                     |> Result.map (fun bytes -> { bytes; cursor = actual })))))
+;;
+
+let read_private_jsonl_durable_locked_result path ~after =
+  read_private_jsonl_durable_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~after
+;;
+
+let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =
+  read_private_jsonl_durable_locked_with_io ~io path ~after
 ;;
 
 let private_jsonl_current_cursor path =
@@ -2304,7 +2463,8 @@ let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
   then Error Invalid_transaction_suffix
   else
-    with_private_jsonl_stable_lock path @@ fun ~dir ~path ->
+    with_private_jsonl_stable_lock ~io:private_jsonl_transaction_unix_io path
+    @@ fun ~dir ~path ->
     match private_jsonl_open_existing path [ Unix.O_RDWR; Unix.O_APPEND ] with
     | Error _ as error -> error
     | Ok None ->
@@ -2365,7 +2525,8 @@ let rewrite_private_jsonl_durable_locked_at_cursor_result
      && not (Char.equal content.[String.length content - 1] '\n')
   then Error Invalid_transaction_suffix
   else
-    with_private_jsonl_stable_lock path @@ fun ~dir ~path ->
+    with_private_jsonl_stable_lock ~io:private_jsonl_transaction_unix_io path
+    @@ fun ~dir ~path ->
     match private_jsonl_current_cursor path with
     | Error _ as error -> error
     | Ok actual ->

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1827,6 +1827,18 @@ type private_jsonl_operation_failure =
   ; backtrace : Printexc.raw_backtrace
   }
 
+type ('value, 'error) private_file_transaction_outcome =
+  | Private_file_succeeded of 'value
+  | Private_file_succeeded_with_cleanup_failure of
+      { value : 'value
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+  | Private_file_failed of 'error
+  | Private_file_failed_with_cleanup_failure of
+      { error : 'error
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+
 type private_jsonl_transaction_success =
   | Snapshot_succeeded of private_jsonl_snapshot
   | Cursor_succeeded of Private_jsonl_cursor.t
@@ -1958,6 +1970,12 @@ let private_jsonl_operation_failure_to_string failure =
     (Printexc.to_string failure.exception_)
 ;;
 
+let private_jsonl_cleanup_failures_to_string cleanup_failures =
+  cleanup_failures
+  |> List.map private_jsonl_operation_failure_to_string
+  |> String.concat "; "
+;;
+
 let rec private_jsonl_transaction_error_to_string = function
   | Stable_lock_contended { lock_path } ->
     Printf.sprintf "private JSONL stable lock is contended: %s" lock_path
@@ -2011,9 +2029,7 @@ let rec private_jsonl_transaction_error_to_string = function
       | cleanup_failures ->
         Printf.sprintf
           "; cleanup also failed: %s"
-          (cleanup_failures
-           |> List.map private_jsonl_operation_failure_to_string
-           |> String.concat "; ")
+          (private_jsonl_cleanup_failures_to_string cleanup_failures)
     in
     private_jsonl_operation_failure_to_string failure ^ cleanup
   | Rewrite_published_durability_unknown { cursor; failure } ->
@@ -2044,9 +2060,7 @@ let rec private_jsonl_transaction_error_to_string = function
     Printf.sprintf
       "%s; descriptor settlement failed: %s"
       primary
-      (cleanup_failures
-       |> List.map private_jsonl_operation_failure_to_string
-       |> String.concat "; ")
+      (private_jsonl_cleanup_failures_to_string cleanup_failures)
   | Transaction_append_failed append_error ->
     durable_append_error_to_string append_error
 ;;
@@ -2060,6 +2074,44 @@ let private_jsonl_capture operation f =
   | value -> Ok value
   | exception (Eio.Cancel.Cancelled _ as cancellation) -> raise cancellation
   | exception exception_ -> Error (private_jsonl_failure operation exception_)
+;;
+
+let private_file_transaction_map f = function
+  | Private_file_succeeded value -> Private_file_succeeded (f value)
+  | Private_file_succeeded_with_cleanup_failure
+      { value; cleanup_failure } ->
+    Private_file_succeeded_with_cleanup_failure
+      { value = f value; cleanup_failure }
+  | Private_file_failed error -> Private_file_failed error
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Private_file_failed_with_cleanup_failure { error; cleanup_failure }
+;;
+
+let private_jsonl_with_fd_outcome ~close_operation ~close_fd fd f =
+  match f () with
+  | Ok value ->
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Private_file_succeeded value
+     | Error cleanup_failure ->
+       Private_file_succeeded_with_cleanup_failure
+         { value; cleanup_failure })
+  | Error error ->
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Private_file_failed error
+     | Error cleanup_failure ->
+       Private_file_failed_with_cleanup_failure
+         { error; cleanup_failure })
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Printexc.raise_with_backtrace exception_ backtrace
+     | Error cleanup_failure ->
+       let combined, combined_backtrace =
+         Eio.Exn.combine
+           (exception_, backtrace)
+           (cleanup_failure.exception_, cleanup_failure.backtrace)
+       in
+       Printexc.raise_with_backtrace combined combined_backtrace)
 ;;
 
 let private_jsonl_add_cleanup_failure error cleanup_failure =
@@ -2098,23 +2150,14 @@ let private_jsonl_settlement_failed ~success result cleanup_failure =
 ;;
 
 let private_jsonl_with_fd ~close_operation ~close_fd ~success fd f =
-  match f () with
-  | result ->
-    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
-     | Ok () -> result
-     | Error cleanup_failure ->
-       private_jsonl_settlement_failed ~success result cleanup_failure)
-  | exception exception_ ->
-    let backtrace = Printexc.get_raw_backtrace () in
-    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
-     | Ok () -> Printexc.raise_with_backtrace exception_ backtrace
-     | Error cleanup_failure ->
-       let combined, combined_backtrace =
-         Eio.Exn.combine
-           (exception_, backtrace)
-           (cleanup_failure.exception_, cleanup_failure.backtrace)
-       in
-       Printexc.raise_with_backtrace combined combined_backtrace)
+  match private_jsonl_with_fd_outcome ~close_operation ~close_fd fd f with
+  | Private_file_succeeded value -> Ok value
+  | Private_file_failed error -> Error error
+  | Private_file_succeeded_with_cleanup_failure
+      { value; cleanup_failure } ->
+    private_jsonl_settlement_failed ~success (Ok value) cleanup_failure
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error (private_jsonl_add_cleanup_failure error cleanup_failure)
 ;;
 
 let private_jsonl_lock_path path = path ^ ".lock"
@@ -2784,10 +2827,10 @@ module Private_jsonl_slice = struct
   ;;
 end
 
-let read_private_jsonl_slice_locked_result path ~from =
+let read_private_jsonl_slice_locked_with_io ~io path ~from =
   let open Private_jsonl_slice in
   if from < 0
-  then Error (Negative_offset from)
+  then Private_file_failed (Negative_offset from)
   else
     try
       test_exec_home_guard ~op:"read_private_jsonl_slice_locked" path;
@@ -2800,63 +2843,85 @@ let read_private_jsonl_slice_locked_result path ~from =
              match Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 with
              | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
                if from = 0
-               then Ok { bytes = ""; end_offset = 0 }
-               else Error (Missing_file_after_offset from)
+               then Private_file_succeeded { bytes = ""; end_offset = 0 }
+               else Private_file_failed (Missing_file_after_offset from)
              | fd ->
-               Fun.protect
-                 ~finally:(fun () -> Unix.close fd)
+               private_jsonl_with_fd_outcome
+                 ~close_operation:Close_transaction_data
+                 ~close_fd:io.close_fd
+                 fd
                  (fun () ->
-                    lock_whole_file_shared fd;
-                    let end_offset = Unix.lseek fd 0 Unix.SEEK_END in
-                    if from > end_offset
-                    then Error (Offset_beyond_end { offset = from; end_offset })
-                    else (
-                      let byte_at offset =
-                        (* See Unix.lseek: only the file-position side effect is required. *)
-                        ignore (Unix.lseek fd offset Unix.SEEK_SET : int);
-                        let byte = Bytes.create 1 in
-                        let rec read () =
-                          match Unix.read fd byte 0 1 with
-                          | 1 -> Bytes.get byte 0
-                          | 0 -> raise End_of_file
-                          | count ->
-                            invalid_arg
-                              (Printf.sprintf
-                                 "single-byte JSONL read returned %d bytes"
-                                 count)
-                          | exception Unix.Unix_error (Unix.EINTR, _, _) -> read ()
-                        in
-                        read ()
-                      in
-                      if from > 0 && not (Char.equal (byte_at (from - 1)) '\n')
-                      then Error (Offset_not_at_row_boundary from)
-                      else if
-                        end_offset > 0
-                        && not (Char.equal (byte_at (end_offset - 1)) '\n')
-                      then Error (Incomplete_tail end_offset)
+                    try
+                      lock_whole_file_shared fd;
+                      let end_offset = Unix.lseek fd 0 Unix.SEEK_END in
+                      if from > end_offset
+                      then Error (Offset_beyond_end { offset = from; end_offset })
                       else (
-                        let length = end_offset - from in
-                        (* See Unix.lseek: only the file-position side effect is required. *)
-                        ignore (Unix.lseek fd from Unix.SEEK_SET : int);
-                        let bytes = Bytes.create length in
-                        let rec read_all offset =
-                          if offset = length
-                          then ()
-                          else
-                            match Unix.read fd bytes offset (length - offset) with
+                        let byte_at offset =
+                          (* See Unix.lseek: only the file-position side effect is required. *)
+                          ignore (Unix.lseek fd offset Unix.SEEK_SET : int);
+                          let byte = Bytes.create 1 in
+                          let rec read () =
+                            match Unix.read fd byte 0 1 with
+                            | 1 -> Bytes.get byte 0
                             | 0 -> raise End_of_file
-                            | count -> read_all (offset + count)
+                            | count ->
+                              invalid_arg
+                                (Printf.sprintf
+                                   "single-byte JSONL read returned %d bytes"
+                                   count)
                             | exception Unix.Unix_error (Unix.EINTR, _, _) ->
-                              read_all offset
+                              read ()
+                          in
+                          read ()
                         in
-                        read_all 0;
-                        Ok { bytes = Bytes.unsafe_to_string bytes; end_offset })))))
+                        if from > 0
+                           && not (Char.equal (byte_at (from - 1)) '\n')
+                        then Error (Offset_not_at_row_boundary from)
+                        else if
+                          end_offset > 0
+                          && not (Char.equal (byte_at (end_offset - 1)) '\n')
+                        then Error (Incomplete_tail end_offset)
+                        else (
+                          let length = end_offset - from in
+                          (* See Unix.lseek: only the file-position side effect is required. *)
+                          ignore (Unix.lseek fd from Unix.SEEK_SET : int);
+                          let bytes = Bytes.create length in
+                          let rec read_all offset =
+                            if offset = length
+                            then ()
+                            else
+                              match Unix.read fd bytes offset (length - offset) with
+                              | 0 -> raise End_of_file
+                              | count -> read_all (offset + count)
+                              | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+                                read_all offset
+                          in
+                          read_all 0;
+                          Ok
+                            { bytes = Bytes.unsafe_to_string bytes
+                            ; end_offset
+                            }))
+                    with
+                    | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+                    | exn -> Error (Io_failed exn))))
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Io_failed exn)
+    | exn -> Private_file_failed (Io_failed exn)
 ;;
 
-let update_private_file_durable_locked_result path decide =
+let read_private_jsonl_slice_locked_result path ~from =
+  read_private_jsonl_slice_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~from
+;;
+
+let read_private_jsonl_slice_locked_with_io_for_testing ~io path ~from =
+  read_private_jsonl_slice_locked_with_io ~io path ~from
+;;
+
+let update_private_file_durable_locked_with_io ~io path decide =
   test_exec_home_guard ~op:"update_private_file_durable_locked" path;
   let dir = Filename.dirname path in
   mkdir_p_memoized dir;
@@ -2871,8 +2936,10 @@ let update_private_file_durable_locked_result path decide =
           [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
           0o600
       in
-      Fun.protect
-        ~finally:(fun () -> Unix.close fd)
+      private_jsonl_with_fd_outcome
+        ~close_operation:Close_transaction_data
+        ~close_fd:io.close_fd
+        fd
         (fun () ->
            Unix.fchmod fd 0o600;
            fsync_parent_directory dir;
@@ -2894,6 +2961,17 @@ let update_private_file_durable_locked_result path decide =
                 ~original_length
                 suffix
               |> Result.map (fun () -> result))))
+;;
+
+let update_private_file_durable_locked_result path decide =
+  update_private_file_durable_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    decide
+;;
+
+let update_private_file_durable_locked_with_io_for_testing ~io path decide =
+  update_private_file_durable_locked_with_io ~io path decide
 ;;
 
 let rewrite_private_file_durable_locked_result path decide =
@@ -2941,17 +3019,19 @@ let private_jsonl_append_error_to_string = function
   | Durable_jsonl_append_failed error -> durable_append_error_to_string error
 ;;
 
-let append_private_jsonl_durable_locked_with_expected_end_offset_result
+let append_private_jsonl_durable_locked_with_expected_end_offset_with_io
+      ~io
       path
       ~expected_end_offset
       suffix
   =
   if String.equal suffix ""
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
-  then Error Invalid_jsonl_suffix
+  then Private_file_failed Invalid_jsonl_suffix
   else
     match expected_end_offset with
-    | Some offset when offset < 0 -> Error (Negative_expected_end_offset offset)
+    | Some offset when offset < 0 ->
+      Private_file_failed (Negative_expected_end_offset offset)
     | _ ->
       run_blocking_private_file_transaction
         ~label:"fs-compat-durable-append"
@@ -2971,8 +3051,10 @@ let append_private_jsonl_durable_locked_with_expected_end_offset_result
                  [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
                  0o600
              in
-             Fun.protect
-               ~finally:(fun () -> Unix.close fd)
+             private_jsonl_with_fd_outcome
+               ~close_operation:Close_transaction_data
+               ~close_fd:io.close_fd
+               fd
                (fun () ->
                   Unix.fchmod fd 0o600;
                   fsync_parent_directory dir;
@@ -3018,6 +3100,18 @@ let append_private_jsonl_durable_locked_with_expected_end_offset_result
                         original_length + String.length suffix)))))
 ;;
 
+let append_private_jsonl_durable_locked_with_expected_end_offset_result
+      path
+      ~expected_end_offset
+      suffix
+  =
+  append_private_jsonl_durable_locked_with_expected_end_offset_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected_end_offset
+    suffix
+;;
+
 let append_private_jsonl_durable_locked_with_end_offset_result path suffix =
   append_private_jsonl_durable_locked_with_expected_end_offset_result
     path
@@ -3038,7 +3132,20 @@ let append_private_jsonl_durable_locked_at_end_offset_result
 
 let append_private_jsonl_durable_locked_result path suffix =
   append_private_jsonl_durable_locked_with_end_offset_result path suffix
-  |> Result.map ignore
+  |> private_file_transaction_map ignore
+;;
+
+let append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing
+      ~io
+      path
+      ~expected_end_offset
+      suffix
+  =
+  append_private_jsonl_durable_locked_with_expected_end_offset_with_io
+    ~io
+    path
+    ~expected_end_offset:(Some expected_end_offset)
+    suffix
 ;;
 
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1872,6 +1872,29 @@ and private_jsonl_transaction_error =
       }
   | Transaction_append_failed of durable_append_error
 
+type 'a private_jsonl_success_receipt =
+  { value : 'a
+  ; settlement_error : private_jsonl_transaction_error option
+  }
+
+let private_jsonl_snapshot_success_receipt = function
+  | Ok value -> Ok { value; settlement_error = None }
+  | Error
+      (Transaction_settlement_failed
+        { primary = Transaction_succeeded (Snapshot_succeeded value); _ } as error) ->
+    Ok { value; settlement_error = Some error }
+  | Error error -> Error error
+;;
+
+let private_jsonl_cursor_success_receipt = function
+  | Ok value -> Ok { value; settlement_error = None }
+  | Error
+      (Transaction_settlement_failed
+        { primary = Transaction_succeeded (Cursor_succeeded value); _ } as error) ->
+    Ok { value; settlement_error = Some error }
+  | Error error -> Error error
+;;
+
 let private_jsonl_operation_to_string = function
   | Create_parent_directory -> "create parent directory"
   | Canonicalize_parent_directory -> "canonicalize parent directory"

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1830,6 +1830,7 @@ type private_jsonl_operation_failure =
 type private_jsonl_transaction_success =
   | Snapshot_succeeded of private_jsonl_snapshot
   | Cursor_succeeded of Private_jsonl_cursor.t
+  | Cursor_precondition_succeeded of Private_jsonl_cursor.t
 
 type private_jsonl_transaction_primary =
   | Transaction_succeeded of private_jsonl_transaction_success
@@ -2006,6 +2007,10 @@ let rec private_jsonl_transaction_error_to_string = function
       | Transaction_succeeded (Cursor_succeeded cursor) ->
         Printf.sprintf
           "private JSONL cursor operation succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string cursor)
+      | Transaction_succeeded (Cursor_precondition_succeeded cursor) ->
+        Printf.sprintf
+          "private JSONL cursor precondition read succeeded (cursor=%s)"
           (Private_jsonl_cursor.to_string cursor)
       | Transaction_failed primary ->
         private_jsonl_transaction_error_to_string primary
@@ -2475,7 +2480,7 @@ let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =
 ;;
 
 let private_jsonl_current_cursor ~io path =
-  let success cursor = Cursor_succeeded cursor in
+  let success cursor = Cursor_precondition_succeeded cursor in
   match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
   | Error _ as error -> error
   | Ok None -> Ok Private_jsonl_cursor.Missing
@@ -2704,6 +2709,19 @@ let rewrite_private_jsonl_durable_locked_at_cursor_result
   =
   rewrite_private_jsonl_durable_locked_at_cursor_with_io
     ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    content
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected
+      content
+  =
+  rewrite_private_jsonl_durable_locked_at_cursor_with_io
+    ~io
     path
     ~expected
     content

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1878,22 +1878,48 @@ type 'a private_jsonl_success_receipt =
   ; settlement_error : private_jsonl_transaction_error option
   }
 
+let private_jsonl_settlement_success = function
+  | (Transaction_settlement_failed
+      { primary = Transaction_succeeded success; _ } as error) ->
+    Some (success, error)
+  | Transaction_settlement_failed { primary = Transaction_failed _; _ }
+  | Stable_lock_contended _
+  | Unexpected_stable_lock_permissions _
+  | Invalid_stable_lock_state _
+  | Cursor_mismatch _
+  | Unexpected_transaction_file_kind _
+  | Ambiguous_transaction_file_identity _
+  | Transaction_path_binding_changed _
+  | Incomplete_transaction_tail _
+  | Invalid_transaction_suffix
+  | Private_jsonl_operation_failed _
+  | Rewrite_stage_failed _
+  | Rewrite_published_durability_unknown _
+  | Transaction_append_failed _ -> None
+;;
+
 let private_jsonl_snapshot_success_receipt = function
   | Ok value -> Ok { value; settlement_error = None }
-  | Error
-      (Transaction_settlement_failed
-        { primary = Transaction_succeeded (Snapshot_succeeded value); _ } as error) ->
-    Ok { value; settlement_error = Some error }
-  | Error error -> Error error
+  | Error error ->
+    (match private_jsonl_settlement_success error with
+     | Some (Snapshot_succeeded value, settlement_error) ->
+       Ok { value; settlement_error = Some settlement_error }
+     | Some
+         ( (Cursor_succeeded _ | Cursor_precondition_succeeded _)
+         , _settlement_error )
+     | None -> Error error)
 ;;
 
 let private_jsonl_cursor_success_receipt = function
   | Ok value -> Ok { value; settlement_error = None }
-  | Error
-      (Transaction_settlement_failed
-        { primary = Transaction_succeeded (Cursor_succeeded value); _ } as error) ->
-    Ok { value; settlement_error = Some error }
-  | Error error -> Error error
+  | Error error ->
+    (match private_jsonl_settlement_success error with
+     | Some (Cursor_succeeded value, settlement_error) ->
+       Ok { value; settlement_error = Some settlement_error }
+     | Some
+         ( (Snapshot_succeeded _ | Cursor_precondition_succeeded _)
+         , _settlement_error )
+     | None -> Error error)
 ;;
 
 let private_jsonl_operation_to_string = function

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -862,6 +862,27 @@ and private_jsonl_transaction_error =
       }
   | Transaction_append_failed of durable_append_error
 
+type 'a private_jsonl_success_receipt =
+  { value : 'a
+  ; settlement_error : private_jsonl_transaction_error option
+  }
+(** A completed transaction value together with exact evidence that descriptor
+    settlement remained incomplete. Consumers may advance from [value], but
+    must observe [settlement_error]. Primary failures and mismatched success
+    kinds are never converted to receipts. *)
+
+val private_jsonl_snapshot_success_receipt :
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result ->
+  ( private_jsonl_snapshot private_jsonl_success_receipt
+  , private_jsonl_transaction_error )
+  result
+
+val private_jsonl_cursor_success_receipt :
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result ->
+  ( Private_jsonl_cursor.t private_jsonl_success_receipt
+  , private_jsonl_transaction_error )
+  result
+
 val private_jsonl_transaction_error_to_string :
   private_jsonl_transaction_error -> string
 

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -741,13 +741,6 @@ module Private_jsonl_slice : sig
   val error_to_string : error -> string
 end
 
-(** Read the exact complete JSONL bytes in [[from, end_offset)] while holding
-    the same per-path in-process mutex and a cross-process read lock used by
-    durable private JSONL writers. A missing file at offset zero is the empty
-    stream; every other cursor mismatch is explicit. *)
-val read_private_jsonl_slice_locked_result :
-  string -> from:int -> (Private_jsonl_slice.t, Private_jsonl_slice.error) result
-
 type durable_append_operation =
   | Write
   | Append_fsync
@@ -816,6 +809,38 @@ type private_jsonl_operation_failure =
   ; exception_ : exn
   ; backtrace : Printexc.raw_backtrace
   }
+
+type ('value, 'error) private_file_transaction_outcome =
+  | Private_file_succeeded of 'value
+  | Private_file_succeeded_with_cleanup_failure of
+      { value : 'value
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+  | Private_file_failed of 'error
+  | Private_file_failed_with_cleanup_failure of
+      { error : 'error
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+(** Result and descriptor-settlement outcome of a blocking private-file
+    transaction. A cleanup failure never replaces the primary value/error, and
+    a successful durable effect remains distinguishable from a primary failure
+    so callers cannot retry it accidentally. Exceptions documented by the
+    underlying operation still propagate. *)
+
+val private_jsonl_operation_failure_to_string :
+  private_jsonl_operation_failure -> string
+
+(** Read the exact complete JSONL bytes in [[from, end_offset)] while holding
+    the same per-path in-process mutex and a cross-process read lock used by
+    durable private JSONL writers. A missing file at offset zero is the empty
+    stream; every other cursor mismatch is explicit. Descriptor-close failure
+    preserves the successful slice or primary read error. *)
+val read_private_jsonl_slice_locked_result :
+  string ->
+  from:int ->
+  ( Private_jsonl_slice.t
+  , Private_jsonl_slice.error )
+  private_file_transaction_outcome
 
 type private_jsonl_transaction_success =
   | Snapshot_succeeded of private_jsonl_snapshot
@@ -908,6 +933,20 @@ type private_jsonl_transaction_io_for_testing =
   ; close_fd : Unix.file_descr -> unit
   }
 
+val read_private_jsonl_slice_locked_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  from:int ->
+  ( Private_jsonl_slice.t
+  , Private_jsonl_slice.error )
+  private_file_transaction_outcome
+
+val update_private_file_durable_locked_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  (string -> string option * 'a) ->
+  ('a, durable_append_error) private_file_transaction_outcome
+
 (** Production-path seam for deterministic stable-lock creation and descriptor
     settlement tests. *)
 val read_private_jsonl_durable_locked_with_io_for_testing :
@@ -964,21 +1003,25 @@ val durable_append_error_to_string : durable_append_error -> string
 (** [update_private_file_durable_locked_result path decide] serializes in-process
     callers with the shared per-path append mutex, takes a cross-process file
     lock, reads the exact existing bytes, and calls [decide]. [Some suffix]
-    appends the complete suffix and fsyncs it before returning [Ok]; [None]
-    performs no write. If writing or the append fsync fails, the file is
-    truncated to its original length and that rollback is fsynced. [Error]
-    preserves the append failure and every rollback failure. Setup, read, and
-    [decide] exceptions still propagate. The file is created with mode [0600],
-    and every transaction fsyncs its parent directory before touching payload
-    bytes so a failed creation can be retried without silently skipping that
-    durability boundary. Filesystems that reject directory fsync fail
-    explicitly. The shared path mutex serializes this operation with cached
-    JSONL writers without closing their already-flushed descriptors. When the
-    Eio filesystem is active, the transaction and [decide] run in a system
-    thread so a contended file cannot stop unrelated fibers; [decide] therefore
-    must not perform Eio effects. *)
+    appends the complete suffix and fsyncs it before returning a successful
+    outcome; [None] performs no write. If writing or the append fsync fails,
+    the file is truncated to its original length and that rollback is fsynced.
+    A failed outcome preserves the append failure and every rollback failure.
+    Descriptor-close failure is returned together with the primary value or
+    error, so a committed append is never misclassified as retryable. Setup,
+    read, and [decide] exceptions still propagate. The file is created with
+    mode [0600], and every transaction fsyncs its parent directory before
+    touching payload bytes so a failed creation can be retried without silently
+    skipping that durability boundary. Filesystems that reject directory fsync
+    fail explicitly. The shared path mutex serializes this operation with
+    cached JSONL writers without closing their already-flushed descriptors.
+    When the Eio filesystem is active, the transaction and [decide] run in a
+    system thread so a contended file cannot stop unrelated fibers; [decide]
+    therefore must not perform Eio effects. *)
 val update_private_file_durable_locked_result :
-  string -> (string -> string option * 'a) -> ('a, durable_append_error) result
+  string ->
+  (string -> string option * 'a) ->
+  ('a, durable_append_error) private_file_transaction_outcome
 
 (** [rewrite_private_file_durable_locked_result path decide] is the whole-file
     replacement sibling of {!update_private_file_durable_locked_result}. It takes
@@ -1015,9 +1058,12 @@ type private_jsonl_append_error =
     fiber, the entire blocking lock/write/fsync transaction runs in a system
     thread, including directory creation and in-process mutex acquisition, so
     one contended file cannot stop unrelated fibers. Non-Eio callers execute
-    the same transaction directly. *)
+    the same transaction directly. Descriptor-close failure is returned with
+    the primary commit or rejection. *)
 val append_private_jsonl_durable_locked_with_end_offset_result :
-  string -> string -> (int, private_jsonl_append_error) result
+  string ->
+  string ->
+  (int, private_jsonl_append_error) private_file_transaction_outcome
 
 (** Append only when the file's locked byte length is exactly
     [expected_end_offset]. A stale writer receives [End_offset_mismatch] and
@@ -1027,12 +1073,21 @@ val append_private_jsonl_durable_locked_at_end_offset_result :
   string ->
   expected_end_offset:int ->
   string ->
-  (int, private_jsonl_append_error) result
+  (int, private_jsonl_append_error) private_file_transaction_outcome
 
 (** As {!append_private_jsonl_durable_locked_with_end_offset_result}, discarding
     the committed newline-end byte offset. *)
 val append_private_jsonl_durable_locked_result :
-  string -> string -> (unit, private_jsonl_append_error) result
+  string ->
+  string ->
+  (unit, private_jsonl_append_error) private_file_transaction_outcome
+
+val append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  expected_end_offset:int ->
+  string ->
+  (int, private_jsonl_append_error) private_file_transaction_outcome
 
 val private_jsonl_append_error_to_string : private_jsonl_append_error -> string
 

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -820,6 +820,7 @@ type private_jsonl_operation_failure =
 type private_jsonl_transaction_success =
   | Snapshot_succeeded of private_jsonl_snapshot
   | Cursor_succeeded of Private_jsonl_cursor.t
+  | Cursor_precondition_succeeded of Private_jsonl_cursor.t
 
 type private_jsonl_transaction_primary =
   | Transaction_succeeded of private_jsonl_transaction_success
@@ -940,6 +941,15 @@ val append_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
     fsynced; no directory-fsync failure is suppressed. The stable sibling lock
     remains the serialization authority across the inode replacement. *)
 val rewrite_private_jsonl_durable_locked_at_cursor_result :
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Production-path seam proving that a descriptor settlement failure while
+    reading the rewrite precondition is not classified as a committed rewrite. *)
+val rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
   string ->
   expected:Private_jsonl_cursor.t ->
   string ->

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -791,6 +791,9 @@ type private_jsonl_transaction_operation =
   | Set_stable_lock_permissions
   | Sync_stable_lock_parent
   | Acquire_stable_lock
+  | Read_stable_lock_state
+  | Write_stable_lock_state
+  | Sync_stable_lock
   | Open_transaction_data
   | Set_transaction_data_permissions
   | Inspect_transaction_data
@@ -814,6 +817,14 @@ type private_jsonl_operation_failure =
 
 type private_jsonl_transaction_error =
   | Stable_lock_contended of { lock_path : string }
+  | Unexpected_stable_lock_permissions of
+      { path : string
+      ; actual : int
+      }
+  | Invalid_stable_lock_state of
+      { path : string
+      ; observed_length : int
+      }
   | Cursor_mismatch of
       { expected : Private_jsonl_cursor.t
       ; actual : Private_jsonl_cursor.t
@@ -852,6 +863,17 @@ val private_jsonl_lock_path : string -> string
     The returned cursor distinguishes a missing store from a present empty
     store. *)
 val read_private_jsonl_durable_locked_result :
+  string ->
+  after:Private_jsonl_cursor.t option ->
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result
+
+type private_jsonl_transaction_io_for_testing =
+  { before_sync_parent : string -> unit }
+
+(** Production-path seam for deterministic stable-lock creation durability
+    tests. *)
+val read_private_jsonl_durable_locked_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
   string ->
   after:Private_jsonl_cursor.t option ->
   (private_jsonl_snapshot, private_jsonl_transaction_error) result

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -794,11 +794,13 @@ type private_jsonl_transaction_operation =
   | Read_stable_lock_state
   | Write_stable_lock_state
   | Sync_stable_lock
+  | Close_stable_lock
   | Open_transaction_data
   | Set_transaction_data_permissions
   | Inspect_transaction_data
   | Inspect_transaction_path
   | Read_transaction_data
+  | Close_transaction_data
   | Create_rewrite_stage
   | Set_rewrite_stage_permissions
   | Write_rewrite_stage
@@ -815,7 +817,15 @@ type private_jsonl_operation_failure =
   ; backtrace : Printexc.raw_backtrace
   }
 
-type private_jsonl_transaction_error =
+type private_jsonl_transaction_success =
+  | Snapshot_succeeded of private_jsonl_snapshot
+  | Cursor_succeeded of Private_jsonl_cursor.t
+
+type private_jsonl_transaction_primary =
+  | Transaction_succeeded of private_jsonl_transaction_success
+  | Transaction_failed of private_jsonl_transaction_error
+
+and private_jsonl_transaction_error =
   | Stable_lock_contended of { lock_path : string }
   | Unexpected_stable_lock_permissions of
       { path : string
@@ -846,6 +856,10 @@ type private_jsonl_transaction_error =
       { cursor : Private_jsonl_cursor.t option
       ; failure : private_jsonl_operation_failure
       }
+  | Transaction_settlement_failed of
+      { primary : private_jsonl_transaction_primary
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
   | Transaction_append_failed of durable_append_error
 
 val private_jsonl_transaction_error_to_string :
@@ -868,10 +882,12 @@ val read_private_jsonl_durable_locked_result :
   (private_jsonl_snapshot, private_jsonl_transaction_error) result
 
 type private_jsonl_transaction_io_for_testing =
-  { before_sync_parent : string -> unit }
+  { before_sync_parent : string -> unit
+  ; close_fd : Unix.file_descr -> unit
+  }
 
-(** Production-path seam for deterministic stable-lock creation durability
-    tests. *)
+(** Production-path seam for deterministic stable-lock creation and descriptor
+    settlement tests. *)
 val read_private_jsonl_durable_locked_with_io_for_testing :
   io:private_jsonl_transaction_io_for_testing ->
   string ->
@@ -885,6 +901,14 @@ val read_private_jsonl_durable_locked_with_io_for_testing :
     on the old inode. Lock contention and stale cursors fail explicitly without
     timeout, retry, or backoff policy. *)
 val append_private_jsonl_durable_locked_at_cursor_result :
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Production-path seam for cancellation during descriptor settlement. *)
+val append_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
   string ->
   expected:Private_jsonl_cursor.t ->
   string ->

--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -60,6 +60,10 @@ type binding_store_error =
 
 type audit_append_error =
   | Audit_append_failed of Fs_compat.private_jsonl_append_error
+  | Audit_append_failed_with_cleanup of {
+      error : Fs_compat.private_jsonl_append_error;
+      cleanup_failure : Fs_compat.private_jsonl_operation_failure;
+    }
   | Audit_io_failed of string
 
 type mutation_error =
@@ -95,6 +99,11 @@ let binding_store_error_to_string = function
 
 let audit_append_error_to_string = function
   | Audit_append_failed error -> Fs_compat.private_jsonl_append_error_to_string error
+  | Audit_append_failed_with_cleanup { error; cleanup_failure } ->
+    Printf.sprintf
+      "%s; descriptor settlement failed: %s"
+      (Fs_compat.private_jsonl_append_error_to_string error)
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure)
   | Audit_io_failed detail -> detail
 
 let mutation_error_to_string = function
@@ -274,8 +283,18 @@ let append_audit_event_result store event =
   let path = store.binding_audit_path () in
   let suffix = Yojson.Safe.to_string (audit_event_json store event) ^ "\n" in
   try
-    Fs_compat.append_private_jsonl_durable_locked_result path suffix
-    |> Result.map_error (fun error -> Audit_append_failed error)
+    match Fs_compat.append_private_jsonl_durable_locked_result path suffix with
+    | Private_file_succeeded () -> Ok ()
+    | Private_file_succeeded_with_cleanup_failure
+        { value = (); cleanup_failure } ->
+      Log.Gate.error
+        "binding audit append succeeded with descriptor settlement failure path=%s: %s"
+        path
+        (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+      Ok ()
+    | Private_file_failed error -> Error (Audit_append_failed error)
+    | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+      Error (Audit_append_failed_with_cleanup { error; cleanup_failure })
   with
   | Sys_error detail -> Error (Audit_io_failed detail)
   | Unix.Unix_error (code, fn, arg) ->

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -45,6 +45,10 @@ type binding_store_error =
 
 type audit_append_error =
   | Audit_append_failed of Fs_compat.private_jsonl_append_error
+  | Audit_append_failed_with_cleanup of {
+      error : Fs_compat.private_jsonl_append_error;
+      cleanup_failure : Fs_compat.private_jsonl_operation_failure;
+    }
   | Audit_io_failed of string
 
 type mutation_error =

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -622,8 +622,21 @@ let read_locked path parse =
     Fs_compat.update_private_file_durable_locked_result path (fun content ->
       None, parse content)
   with
-  | Error error -> Error (durable_error_to_string error)
-  | Ok result -> result
+  | Private_file_failed error -> Error (durable_error_to_string error)
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "%s; descriptor settlement failed: %s"
+         (durable_error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
+  | Private_file_succeeded result -> result
+  | Private_file_succeeded_with_cleanup_failure
+      { value = result; cleanup_failure } ->
+    Log.Keeper.error
+      "board attention candidate read succeeded with descriptor settlement failure path=%s: %s"
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    result
 ;;
 
 (* Read-side stat memo. Owner-lane drains call [load_candidates] far more often

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -373,8 +373,21 @@ let read_locked ledger_path =
     Fs_compat.update_private_file_durable_locked_result ledger_path (fun content ->
       None, parse_rows content)
   with
-  | Error error -> Error (durable_error_to_string error)
-  | Ok result -> result
+  | Private_file_failed error -> Error (durable_error_to_string error)
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "%s; descriptor settlement failed: %s"
+         (durable_error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
+  | Private_file_succeeded result -> result
+  | Private_file_succeeded_with_cleanup_failure
+      { value = result; cleanup_failure } ->
+    Log.Keeper.error
+      "board attention partition read succeeded with descriptor settlement failure path=%s: %s"
+      ledger_path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    result
 ;;
 
 let load ~base_path ~keeper_name =

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -698,20 +698,49 @@ let append_line_once path ~delivery_key ~transcript_slot ~row_id line =
         None, Ok (Already_present { row_id = existing_row_id })
       | Ok None -> Some (line ^ "\n"), Ok (Appended { row_id }))
   with
-  | Ok result -> result
-  | Error error -> Error (Fs_compat.durable_append_error_to_string error)
+  | Private_file_succeeded result -> result
+  | Private_file_succeeded_with_cleanup_failure
+      { value = result; cleanup_failure } ->
+    Log.Keeper.error
+      "keeper_chat_store: provenance update succeeded with descriptor settlement failure path=%s: %s"
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    result
+  | Private_file_failed error ->
+    Error (Fs_compat.durable_append_error_to_string error)
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "%s; descriptor settlement failed: %s"
+         (Fs_compat.durable_append_error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
 ;;
 
 let append_chat_payload_durable path payload =
   match Fs_compat.append_private_jsonl_durable_locked_result path payload with
-  | Ok () -> ()
-  | Error error ->
+  | Private_file_succeeded () -> ()
+  | Private_file_succeeded_with_cleanup_failure
+      { value = (); cleanup_failure } ->
+    Log.Keeper.error
+      "keeper_chat_store: payload append succeeded with descriptor settlement failure path=%s: %s"
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure)
+  | Private_file_failed error ->
     raise
       (Sys_error
          (Printf.sprintf
             "%s: %s"
             path
             (Fs_compat.private_jsonl_append_error_to_string error)))
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    raise
+      (Sys_error
+         (Printf.sprintf
+            "%s: %s; descriptor settlement failed: %s"
+            path
+            (Fs_compat.private_jsonl_append_error_to_string error)
+            (Fs_compat.private_jsonl_operation_failure_to_string
+               cleanup_failure)))
 ;;
 
 (* Tool calls with empty accumulated arguments are normalised to "{}" so

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -277,35 +277,56 @@ let replay_settlement_wal_bytes owner state bytes =
 
 let replay_settlement_wal_unlocked owner state =
   let path = settlement_wal_path_of_owner owner in
+  let replay_slice slice =
+    match slice.Fs_compat.Private_jsonl_slice.bytes with
+    | "" -> Ok state
+    | bytes ->
+      (match replay_settlement_wal_bytes owner state bytes with
+       | Error detail ->
+         Error (Printf.sprintf "failed to replay %s: %s" path detail)
+       | Ok replayed ->
+         (match bump_revision replayed with
+          | Error _ as error -> error
+          | Ok replayed ->
+            (match save_state_unlocked owner replayed with
+             | Ok () ->
+               (match compact_settlement_wal_unlocked owner with
+                | Ok () -> Ok replayed
+                | Error detail ->
+                  Error
+                    ("settlement WAL checkpoint recovered but compaction failed: "
+                     ^ detail))
+             | Error detail ->
+               Error
+                 (Printf.sprintf
+                    "settlement WAL is committed but checkpoint replay failed: %s"
+                    detail))))
+  in
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
-  | Error error ->
+  | Private_file_failed error ->
     Error
       (Printf.sprintf
          "failed to read settlement WAL keeper=%s path=%s: %s"
          (keeper_name_of_owner owner)
          path
          (Fs_compat.Private_jsonl_slice.error_to_string error))
-  | Ok { bytes = ""; _ } -> Ok state
-  | Ok slice ->
-    (match replay_settlement_wal_bytes owner state slice.bytes with
-     | Error detail -> Error (Printf.sprintf "failed to replay %s: %s" path detail)
-     | Ok replayed ->
-       (match bump_revision replayed with
-        | Error _ as error -> error
-        | Ok replayed ->
-          (match save_state_unlocked owner replayed with
-           | Ok () ->
-             (match compact_settlement_wal_unlocked owner with
-              | Ok () -> Ok replayed
-              | Error detail ->
-                Error
-                  ("settlement WAL checkpoint recovered but compaction failed: "
-                   ^ detail))
-           | Error detail ->
-             Error
-               (Printf.sprintf
-                  "settlement WAL is committed but checkpoint replay failed: %s"
-                  detail))))
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "failed to read settlement WAL keeper=%s path=%s: %s; descriptor settlement failed: %s"
+         (keeper_name_of_owner owner)
+         path
+         (Fs_compat.Private_jsonl_slice.error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
+  | Private_file_succeeded slice -> replay_slice slice
+  | Private_file_succeeded_with_cleanup_failure
+      { value = slice; cleanup_failure } ->
+    Log.Keeper.error
+      "settlement WAL read succeeded with descriptor settlement failure keeper=%s path=%s: %s"
+      (keeper_name_of_owner owner)
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    replay_slice slice
 ;;
 
 let load_state_unlocked owner =
@@ -660,52 +681,72 @@ let commit_settlement_unlocked
      | Ok checkpoint ->
        let suffix = settlement_wal_entry_to_line owner receipt in
        let path = settlement_wal_path_of_owner owner in
+       let continue_after_commit () =
+         let pending = State.pending checkpoint in
+         match save_state_unlocked owner checkpoint with
+         | Error detail ->
+           Ok
+             ( Committed_followup_failed
+                 { receipt; stage = `Checkpoint; detail }
+             , pending )
+         | Ok () ->
+           (match compact_settlement_wal_unlocked owner with
+            | Error detail ->
+              Ok
+                ( Committed_followup_failed
+                    { receipt; stage = `Wal_compaction; detail }
+                , pending )
+            | Ok () ->
+              (match
+                 try
+                   after_commit pending;
+                   Ok ()
+                 with
+                 | Eio.Cancel.Cancelled _ as exn ->
+                   Error
+                     ("pending projection cancelled after settlement commit: "
+                      ^ Printexc.to_string exn)
+                 | exn -> Error (Printexc.to_string exn)
+               with
+               | Ok () -> Ok (Settled receipt, pending)
+               | Error detail ->
+                 Ok
+                   ( Committed_followup_failed
+                       { receipt; stage = `Projection; detail }
+                   , pending )))
+       in
        (match
           Fs_compat.append_private_jsonl_durable_locked_at_end_offset_result
             path
             ~expected_end_offset:0
             suffix
         with
-        | Error error ->
+        | Private_file_failed error ->
           Error
             (Printf.sprintf
                "settlement WAL commit failed keeper=%s path=%s: %s"
                (keeper_name_of_owner owner)
                path
                (Fs_compat.private_jsonl_append_error_to_string error))
-        | Ok _committed_end_offset ->
-          let pending = State.pending checkpoint in
-          (match save_state_unlocked owner checkpoint with
-           | Error detail ->
-             Ok
-               ( Committed_followup_failed
-                   { receipt; stage = `Checkpoint; detail }
-               , pending )
-           | Ok () ->
-             (match compact_settlement_wal_unlocked owner with
-              | Error detail ->
-                Ok
-                  ( Committed_followup_failed
-                      { receipt; stage = `Wal_compaction; detail }
-                  , pending )
-              | Ok () ->
-                (match
-                   try
-                     after_commit pending;
-                     Ok ()
-                   with
-                   | Eio.Cancel.Cancelled _ as exn ->
-                     Error
-                       ("pending projection cancelled after settlement commit: "
-                        ^ Printexc.to_string exn)
-                   | exn -> Error (Printexc.to_string exn)
-                 with
-                 | Ok () -> Ok (Settled receipt, pending)
-                 | Error detail ->
-                   Ok
-                     ( Committed_followup_failed
-                         { receipt; stage = `Projection; detail }
-                     , pending ))))))
+        | Private_file_failed_with_cleanup_failure
+            { error; cleanup_failure } ->
+          Error
+            (Printf.sprintf
+               "settlement WAL commit failed keeper=%s path=%s: %s; descriptor settlement failed: %s"
+               (keeper_name_of_owner owner)
+               path
+               (Fs_compat.private_jsonl_append_error_to_string error)
+               (Fs_compat.private_jsonl_operation_failure_to_string
+                  cleanup_failure))
+        | Private_file_succeeded _committed_end_offset -> continue_after_commit ()
+        | Private_file_succeeded_with_cleanup_failure
+            { value = _committed_end_offset; cleanup_failure } ->
+          Log.Keeper.error
+            "settlement WAL commit succeeded with descriptor settlement failure keeper=%s path=%s: %s"
+            (keeper_name_of_owner owner)
+            path
+            (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+          continue_after_commit ()))
 ;;
 
 let settle_result

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -510,12 +510,13 @@ let test_private_jsonl_transaction_preserves_primary_when_data_close_fails () =
 let test_private_jsonl_transaction_accumulates_nested_close_failures () =
   with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
   let io, calls = injected_close_io ~fail_calls:[ 1; 2 ] in
-  (match
-     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
-       ~io
-       path
-       ~after:None
-   with
+  let result =
+    Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+      ~io
+      path
+      ~after:None
+  in
+  (match result with
    | Error
        (Fs_compat.Transaction_settlement_failed
          { primary =
@@ -531,7 +532,41 @@ let test_private_jsonl_transaction_accumulates_nested_close_failures () =
      check_transaction_close_failure
        ~label:"stable lock descriptor cleanup"
        ~operation:Fs_compat.Close_stable_lock
-       lock_failure
+       lock_failure;
+     (match Fs_compat.private_jsonl_snapshot_success_receipt result with
+      | Ok { value; settlement_error = Some _ } ->
+        check string "classified snapshot receipt" snapshot.bytes value.bytes
+      | Ok { settlement_error = None; _ } ->
+        fail "snapshot classifier discarded settlement evidence"
+      | Error error ->
+        fail (Fs_compat.private_jsonl_transaction_error_to_string error));
+     let cursor_settlement_error =
+       Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Cursor_succeeded snapshot.cursor)
+         ; cleanup_failures = [ data_failure; lock_failure ]
+         }
+     in
+     (match
+        Fs_compat.private_jsonl_cursor_success_receipt
+          (Error cursor_settlement_error)
+      with
+      | Ok { value; settlement_error = Some _ } ->
+        check bool
+          "classified cursor receipt"
+          true
+          (Fs_compat.Private_jsonl_cursor.equal snapshot.cursor value)
+      | Ok { settlement_error = None; _ } ->
+        fail "cursor classifier discarded settlement evidence"
+      | Error error ->
+        fail (Fs_compat.private_jsonl_transaction_error_to_string error));
+     (match
+        Fs_compat.private_jsonl_snapshot_success_receipt
+          (Error cursor_settlement_error)
+      with
+      | Error _ -> ()
+      | Ok _ -> fail "snapshot classifier accepted a cursor success receipt")
    | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
    | Ok _ -> fail "nested close failures were silently accepted");
   check int "both nested descriptors closed" 2 !calls

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -231,8 +231,12 @@ let test_private_jsonl_append_preserves_complete_history () =
        path
        "{\"row\":2}\n{\"row\":3}\n"
    with
-   | Ok () -> ()
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+   | Fs_compat.Private_file_succeeded () -> ()
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "unexpected descriptor settlement failure");
   check string
     "complete rows appended"
     "{\"row\":1}\n{\"row\":2}\n{\"row\":3}\n"
@@ -248,12 +252,16 @@ let test_private_jsonl_append_returns_committed_end_offset () =
        path
        suffix
    with
-   | Ok end_offset ->
+   | Fs_compat.Private_file_succeeded end_offset ->
      check int
        "committed newline-end byte offset"
        (String.length original + String.length suffix)
        end_offset
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error))
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "unexpected descriptor settlement failure")
 ;;
 
 let test_private_jsonl_append_at_exact_end_offset () =
@@ -266,12 +274,16 @@ let test_private_jsonl_append_at_exact_end_offset () =
        ~expected_end_offset:(String.length original)
        suffix
    with
-   | Ok end_offset ->
+   | Fs_compat.Private_file_succeeded end_offset ->
      check int
        "committed newline-end byte offset"
        (String.length original + String.length suffix)
        end_offset
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "unexpected descriptor settlement failure");
   check string "exact append bytes" (original ^ suffix) (Fs_compat.load_file path)
 ;;
 
@@ -284,12 +296,16 @@ let test_private_jsonl_append_rejects_stale_end_offset () =
        ~expected_end_offset:0
        "{\"row\":2}\n"
    with
-   | Error
+   | Fs_compat.Private_file_failed
        (Fs_compat.End_offset_mismatch
           { expected = 0; actual }) ->
      check int "locked actual byte offset" (String.length original) actual
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
-   | Ok _ -> fail "stale cursor unexpectedly appended");
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded _
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "stale cursor unexpectedly appended");
   check string "stale append writes no bytes" original (Fs_compat.load_file path)
 ;;
 
@@ -303,25 +319,32 @@ let test_private_jsonl_slice_reads_exact_cursor_suffix () =
       path
       ~from:(String.length row1)
   with
-  | Ok slice ->
+  | Fs_compat.Private_file_succeeded slice ->
     check string "exact suffix" (row2 ^ row3) slice.bytes;
     check int
       "locked end offset"
       (String.length row1 + String.length row2 + String.length row3)
       slice.end_offset
-  | Error _ -> fail "complete cursor slice was rejected"
+  | Fs_compat.Private_file_failed _ -> fail "complete cursor slice was rejected"
+  | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+  | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+    fail "unexpected descriptor settlement failure"
 ;;
 
 let test_private_jsonl_slice_rejects_invalid_cursors () =
   with_temp_jsonl "{\"row\":1}\n" @@ fun path ->
   (match Fs_compat.read_private_jsonl_slice_locked_result path ~from:(-1) with
-   | Error (Fs_compat.Private_jsonl_slice.Negative_offset (-1)) -> ()
+   | Fs_compat.Private_file_failed
+       (Fs_compat.Private_jsonl_slice.Negative_offset (-1)) ->
+     ()
    | _ -> fail "negative cursor was not rejected");
   (match Fs_compat.read_private_jsonl_slice_locked_result path ~from:1 with
-   | Error (Fs_compat.Private_jsonl_slice.Offset_not_at_row_boundary 1) -> ()
+   | Fs_compat.Private_file_failed
+       (Fs_compat.Private_jsonl_slice.Offset_not_at_row_boundary 1) ->
+     ()
    | _ -> fail "mid-row cursor was not rejected");
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:1024 with
-  | Error
+  | Fs_compat.Private_file_failed
       (Fs_compat.Private_jsonl_slice.Offset_beyond_end
         { offset = 1024; end_offset = 10 }) ->
     ()
@@ -332,17 +355,21 @@ let test_private_jsonl_slice_missing_store_contract () =
   let path = Filename.temp_file "masc_private_jsonl_missing_" ".jsonl" in
   Sys.remove path;
   (match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
-   | Ok { bytes = ""; end_offset = 0 } -> ()
+   | Fs_compat.Private_file_succeeded { bytes = ""; end_offset = 0 } -> ()
    | _ -> fail "missing origin was not treated as an empty stream");
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:1 with
-  | Error (Fs_compat.Private_jsonl_slice.Missing_file_after_offset 1) -> ()
+  | Fs_compat.Private_file_failed
+      (Fs_compat.Private_jsonl_slice.Missing_file_after_offset 1) ->
+    ()
   | _ -> fail "missing non-origin cursor was not rejected"
 ;;
 
 let test_private_jsonl_slice_rejects_incomplete_tail () =
   with_temp_jsonl "{\"row\":1}" @@ fun path ->
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
-  | Error (Fs_compat.Private_jsonl_slice.Incomplete_tail 9) -> ()
+  | Fs_compat.Private_file_failed
+      (Fs_compat.Private_jsonl_slice.Incomplete_tail 9) ->
+    ()
   | _ -> fail "incomplete JSONL tail was not rejected"
 ;;
 
@@ -351,18 +378,26 @@ let test_private_jsonl_append_rejects_incomplete_tail () =
   (match
      Fs_compat.append_private_jsonl_durable_locked_result path "{\"row\":2}\n"
    with
-   | Error Fs_compat.Incomplete_jsonl_tail -> ()
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
-   | Ok () -> fail "append accepted an incomplete existing JSONL row");
+   | Fs_compat.Private_file_failed Fs_compat.Incomplete_jsonl_tail -> ()
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded _
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "append accepted an incomplete existing JSONL row");
   check string "incomplete bytes unchanged" "{\"row\":1}" (Fs_compat.load_file path)
 ;;
 
 let test_private_jsonl_append_rejects_incomplete_suffix () =
   with_temp_jsonl "" @@ fun path ->
   match Fs_compat.append_private_jsonl_durable_locked_result path "{\"row\":1}" with
-  | Error Fs_compat.Invalid_jsonl_suffix -> ()
-  | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
-  | Ok () -> fail "append accepted a non-terminated JSONL suffix"
+  | Fs_compat.Private_file_failed Fs_compat.Invalid_jsonl_suffix -> ()
+  | Fs_compat.Private_file_failed error ->
+    fail (Fs_compat.private_jsonl_append_error_to_string error)
+  | Fs_compat.Private_file_succeeded _
+  | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+  | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+    fail "append accepted a non-terminated JSONL suffix"
 ;;
 
 let test_private_jsonl_append_respects_execution_context () =
@@ -375,16 +410,24 @@ let test_private_jsonl_append_respects_execution_context () =
        (match
           Fs_compat.append_private_jsonl_durable_locked_result path "{\"fiber\":1}\n"
         with
-        | Ok () -> ()
-        | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+        | Fs_compat.Private_file_succeeded () -> ()
+        | Fs_compat.Private_file_failed error ->
+          fail (Fs_compat.private_jsonl_append_error_to_string error)
+        | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+        | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+          fail "unexpected descriptor settlement failure");
        let raw_domain_result =
          Domain.spawn (fun () ->
            Fs_compat.append_private_jsonl_durable_locked_result path "{\"domain\":2}\n")
          |> Domain.join
        in
        (match raw_domain_result with
-        | Ok () -> ()
-        | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+        | Fs_compat.Private_file_succeeded () -> ()
+        | Fs_compat.Private_file_failed error ->
+          fail (Fs_compat.private_jsonl_append_error_to_string error)
+        | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+        | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+          fail "unexpected descriptor settlement failure");
        check string
          "Eio fiber and raw Domain append once"
          "{\"fiber\":1}\n{\"domain\":2}\n"
@@ -480,6 +523,100 @@ let check_transaction_close_failure
          "%s lost injected close failure: %s"
          label
          (Printexc.to_string exception_))
+;;
+
+let test_private_jsonl_slice_returns_value_with_close_failure () =
+  with_temp_jsonl "{\"row\":1}\n" @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.read_private_jsonl_slice_locked_with_io_for_testing
+       ~io
+       path
+       ~from:0
+   with
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure
+       { value = slice; cleanup_failure } ->
+     check string "read value preserved" "{\"row\":1}\n" slice.bytes;
+     check_transaction_close_failure
+       ~label:"offset read descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "offset read did not preserve its value and close failure");
+  check int "offset read descriptor closed once" 1 !calls
+;;
+
+let test_private_jsonl_append_returns_commit_with_close_failure () =
+  let original = "{\"row\":1}\n" in
+  let suffix = "{\"row\":2}\n" in
+  with_temp_jsonl original @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing
+       ~io
+       path
+       ~expected_end_offset:(String.length original)
+       suffix
+   with
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure
+       { value = end_offset; cleanup_failure } ->
+     check int
+       "committed offset preserved"
+       (String.length original + String.length suffix)
+       end_offset;
+     check_transaction_close_failure
+       ~label:"offset append descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "offset append did not preserve its commit and close failure");
+  check int "offset append descriptor closed once" 1 !calls;
+  check string "offset append commits once" (original ^ suffix) (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_append_preserves_rejection_with_close_failure () =
+  let original = "{\"row\":1}\n" in
+  with_temp_jsonl original @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing
+       ~io
+       path
+       ~expected_end_offset:0
+       "{\"row\":2}\n"
+   with
+   | Fs_compat.Private_file_failed_with_cleanup_failure
+       { error = Fs_compat.End_offset_mismatch { expected = 0; actual }
+       ; cleanup_failure
+       } ->
+     check int "rejection actual offset" (String.length original) actual;
+     check_transaction_close_failure
+       ~label:"rejected offset append descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "offset append did not preserve its rejection and close failure");
+  check int "rejected append descriptor closed once" 1 !calls;
+  check string "rejected append writes nothing" original (Fs_compat.load_file path)
+;;
+
+let test_private_file_update_returns_value_with_close_failure () =
+  let original = "{\"row\":1}\n" in
+  let suffix = "{\"row\":2}\n" in
+  with_temp_jsonl original @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.update_private_file_durable_locked_with_io_for_testing
+       ~io
+       path
+       (fun _existing -> Some suffix, `Committed)
+   with
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure
+       { value = `Committed; cleanup_failure } ->
+     check_transaction_close_failure
+       ~label:"private update descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "private update did not preserve its value and close failure");
+  check int "private update descriptor closed once" 1 !calls;
+  check string "private update commits once" (original ^ suffix) (Fs_compat.load_file path)
 ;;
 
 let test_private_jsonl_transaction_preserves_primary_when_data_close_fails () =
@@ -1063,6 +1200,22 @@ let () =
             "private JSONL data close preserves primary error"
             `Quick
             test_private_jsonl_transaction_preserves_primary_when_data_close_fails
+        ; test_case
+            "private JSONL offset read preserves close failure"
+            `Quick
+            test_private_jsonl_slice_returns_value_with_close_failure
+        ; test_case
+            "private JSONL offset append preserves committed close failure"
+            `Quick
+            test_private_jsonl_append_returns_commit_with_close_failure
+        ; test_case
+            "private JSONL offset append preserves rejected close failure"
+            `Quick
+            test_private_jsonl_append_preserves_rejection_with_close_failure
+        ; test_case
+            "private file update preserves committed close failure"
+            `Quick
+            test_private_file_update_returns_value_with_close_failure
         ; test_case
             "private JSONL nested close failures accumulate"
             `Quick

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -448,6 +448,200 @@ let transaction_append path ~expected suffix =
   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
 ;;
 
+let injected_close_io ~fail_calls =
+  let calls = ref 0 in
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> ())
+    ; close_fd =
+        (fun fd ->
+          incr calls;
+          Unix.close fd;
+          if List.mem !calls fail_calls
+          then
+            raise
+              (Unix.Unix_error
+                 (Unix.EIO, "injected_private_jsonl_close", string_of_int !calls)))
+    }
+  in
+  io, calls
+;;
+
+let check_transaction_close_failure
+      ~label
+      ~operation
+      (failure : Fs_compat.private_jsonl_operation_failure)
+  =
+  check bool (label ^ " operation") true (failure.operation = operation);
+  match failure.exception_ with
+  | Unix.Unix_error (Unix.EIO, "injected_private_jsonl_close", _) -> ()
+  | exception_ ->
+    fail
+      (Printf.sprintf
+         "%s lost injected close failure: %s"
+         label
+         (Printexc.to_string exception_))
+;;
+
+let test_private_jsonl_transaction_preserves_primary_when_data_close_fails () =
+  with_transaction_jsonl (Some "incomplete") @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_failed
+               (Fs_compat.Incomplete_transaction_tail _)
+         ; cleanup_failures = [ cleanup_failure ]
+         }) ->
+     check_transaction_close_failure
+       ~label:"data descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "data close failure was silently accepted");
+  check int "data and stable lock descriptors closed" 2 !calls
+;;
+
+let test_private_jsonl_transaction_accumulates_nested_close_failures () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1; 2 ] in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Snapshot_succeeded snapshot)
+         ; cleanup_failures = [ data_failure; lock_failure ]
+         }) ->
+     check string "successful snapshot receipt" "{\"row\":1}\n" snapshot.bytes;
+     check_transaction_close_failure
+       ~label:"data descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       data_failure;
+     check_transaction_close_failure
+       ~label:"stable lock descriptor cleanup"
+       ~operation:Fs_compat.Close_stable_lock
+       lock_failure
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "nested close failures were silently accepted");
+  check int "both nested descriptors closed" 2 !calls
+;;
+
+exception Requested_private_jsonl_cancellation
+
+type private_jsonl_append_cancellation_outcome =
+  | Append_returned of
+      ( Fs_compat.Private_jsonl_cursor.t
+        , Fs_compat.private_jsonl_transaction_error )
+        result
+  | Append_cancelled
+
+type private_jsonl_close_barrier =
+  { entered : unit Eio.Promise.t
+  ; resolve_entered : unit Eio.Promise.u
+  ; first_close : bool Atomic.t
+  ; close_calls : int Atomic.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Stdlib.Condition.t
+  ; mutable released : bool
+  }
+
+let private_jsonl_close_barrier () =
+  let entered, resolve_entered = Eio.Promise.create () in
+  { entered
+  ; resolve_entered
+  ; first_close = Atomic.make true
+  ; close_calls = Atomic.make 0
+  ; mutex = Stdlib.Mutex.create ()
+  ; condition = Stdlib.Condition.create ()
+  ; released = false
+  }
+;;
+
+let release_private_jsonl_close barrier =
+  Stdlib.Mutex.protect barrier.mutex (fun () ->
+    if not barrier.released
+    then (
+      barrier.released <- true;
+      Stdlib.Condition.broadcast barrier.condition))
+;;
+
+let private_jsonl_blocking_close_io barrier =
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> ())
+    ; close_fd =
+        (fun fd ->
+          ignore (Atomic.fetch_and_add barrier.close_calls 1 : int);
+          if Atomic.compare_and_set barrier.first_close true false
+          then (
+            Eio.Promise.resolve barrier.resolve_entered ();
+            Stdlib.Mutex.protect barrier.mutex (fun () ->
+              while not barrier.released do
+                Stdlib.Condition.wait barrier.condition barrier.mutex
+              done));
+          Unix.close fd)
+    }
+  in
+  io
+;;
+
+let test_private_jsonl_append_cancellation_settles_once_with_receipt () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  Eio_main.run @@ fun _env ->
+  let origin = transaction_snapshot path ~after:None in
+  let barrier = private_jsonl_close_barrier () in
+  let context, resolve_context = Eio.Promise.create () in
+  let outcome, resolve_outcome = Eio.Promise.create () in
+  Fun.protect
+    ~finally:(fun () -> release_private_jsonl_close barrier)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let outcome =
+           try
+             Eio.Cancel.sub @@ fun context ->
+             Eio.Promise.resolve resolve_context context;
+             Append_returned
+               (Fs_compat.append_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+                  ~io:(private_jsonl_blocking_close_io barrier)
+                  path
+                  ~expected:origin.cursor
+                  "{\"row\":2}\n")
+           with
+           | Eio.Cancel.Cancelled _ -> Append_cancelled
+         in
+         Eio.Promise.resolve resolve_outcome outcome);
+       let context = Eio.Promise.await context in
+       Eio.Promise.await barrier.entered;
+       Eio.Cancel.cancel context Requested_private_jsonl_cancellation;
+       release_private_jsonl_close barrier;
+       match Eio.Promise.await outcome with
+       | Append_cancelled ->
+         fail "committed append lost its terminal receipt to cancellation"
+       | Append_returned (Error error) ->
+         fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+       | Append_returned (Ok committed) ->
+         check bool
+           "cancellation path returns committed cursor"
+           false
+           (Fs_compat.Private_jsonl_cursor.equal origin.cursor committed));
+  check int "cancellation path closes both descriptors" 2 (Atomic.get barrier.close_calls);
+  check string
+    "cancellation path commits suffix exactly once"
+    "{\"row\":1}\n{\"row\":2}\n"
+    (Fs_compat.load_file path)
+;;
+
 let test_private_jsonl_transaction_missing_and_delta_contract () =
   with_transaction_jsonl None @@ fun path ->
   let origin = transaction_snapshot path ~after:None in
@@ -527,7 +721,9 @@ let test_private_jsonl_stable_lock_parent_sync_is_one_shot () =
   with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
   let parent_syncs = ref 0 in
   let io : Fs_compat.private_jsonl_transaction_io_for_testing =
-    { before_sync_parent = (fun _dir -> incr parent_syncs) }
+    { before_sync_parent = (fun _dir -> incr parent_syncs)
+    ; close_fd = Unix.close
+    }
   in
   let snapshot = transaction_snapshot_with_io ~io path ~after:None in
   ignore (transaction_snapshot_with_io ~io path ~after:(Some snapshot.cursor));
@@ -541,6 +737,7 @@ let test_private_jsonl_stable_lock_parent_sync_failure_retries () =
     { before_sync_parent =
         (fun dir ->
           raise (Unix.Unix_error (Unix.EIO, "injected_parent_fsync", dir)))
+    ; close_fd = Unix.close
     }
   in
   (match
@@ -788,6 +985,18 @@ let () =
             "private JSONL stable lock rejects symlink aliases"
             `Quick
             test_private_jsonl_transaction_rejects_symlink_lock_without_chmod
+        ; test_case
+            "private JSONL data close preserves primary error"
+            `Quick
+            test_private_jsonl_transaction_preserves_primary_when_data_close_fails
+        ; test_case
+            "private JSONL nested close failures accumulate"
+            `Quick
+            test_private_jsonl_transaction_accumulates_nested_close_failures
+        ; test_case
+            "private JSONL append cancellation settles once with receipt"
+            `Quick
+            test_private_jsonl_append_cancellation_settles_once_with_receipt
         ] )
     ]
 ;;

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -572,6 +572,45 @@ let test_private_jsonl_transaction_accumulates_nested_close_failures () =
   check int "both nested descriptors closed" 2 !calls
 ;;
 
+let test_private_jsonl_rewrite_rejects_precondition_close_as_commit () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let origin = transaction_snapshot path ~after:None in
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  let result =
+    Fs_compat.rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected:origin.cursor
+      "{\"row\":2}\n"
+  in
+  (match result with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Cursor_precondition_succeeded observed)
+         ; cleanup_failures = [ cleanup_failure ]
+         }) ->
+     check bool
+       "precondition cursor preserved"
+       true
+       (Fs_compat.Private_jsonl_cursor.equal origin.cursor observed);
+     check_transaction_close_failure
+       ~label:"rewrite precondition descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure;
+     (match Fs_compat.private_jsonl_cursor_success_receipt result with
+      | Error _ -> ()
+      | Ok _ -> fail "precondition cursor was classified as a committed rewrite")
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "rewrite continued after precondition descriptor settlement failed");
+  check int "precondition and stable lock descriptors closed" 2 !calls;
+  check string
+    "failed precondition leaves target unchanged"
+    "{\"row\":1}\n"
+    (Fs_compat.load_file path)
+;;
+
 exception Requested_private_jsonl_cancellation
 
 type private_jsonl_append_cancellation_outcome =
@@ -1028,6 +1067,10 @@ let () =
             "private JSONL nested close failures accumulate"
             `Quick
             test_private_jsonl_transaction_accumulates_nested_close_failures
+        ; test_case
+            "private JSONL rewrite precondition close is not a commit"
+            `Quick
+            test_private_jsonl_rewrite_rejects_precondition_close_as_commit
         ; test_case
             "private JSONL append cancellation settles once with receipt"
             `Quick

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -418,6 +418,25 @@ let transaction_snapshot path ~after =
   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
 ;;
 
+let transaction_snapshot_with_io ~io path ~after =
+  match
+    Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+      ~io
+      path
+      ~after
+  with
+  | Ok snapshot -> snapshot
+  | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+;;
+
+let write_stable_lock_fixture path contents permissions =
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  let output = open_out_bin lock_path in
+  output_string output contents;
+  close_out output;
+  Unix.chmod lock_path permissions
+;;
+
 let transaction_append path ~expected suffix =
   match
     Fs_compat.append_private_jsonl_durable_locked_at_cursor_result
@@ -502,6 +521,73 @@ let test_private_jsonl_transaction_lock_is_private () =
     (Unix.stat (Fs_compat.private_jsonl_lock_path path)).Unix.st_perm land 0o777
   in
   check int "stable lock permissions" 0o600 permissions
+;;
+
+let test_private_jsonl_stable_lock_parent_sync_is_one_shot () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let parent_syncs = ref 0 in
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> incr parent_syncs) }
+  in
+  let snapshot = transaction_snapshot_with_io ~io path ~after:None in
+  ignore (transaction_snapshot_with_io ~io path ~after:(Some snapshot.cursor));
+  ignore (transaction_snapshot_with_io ~io path ~after:(Some snapshot.cursor));
+  check int "stable lock parent sync count" 1 !parent_syncs
+;;
+
+let test_private_jsonl_stable_lock_parent_sync_failure_retries () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent =
+        (fun dir ->
+          raise (Unix.Unix_error (Unix.EIO, "injected_parent_fsync", dir)))
+    }
+  in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Private_jsonl_operation_failed
+         { operation = Fs_compat.Sync_stable_lock_parent; _ }) ->
+     ()
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "stable lock parent-sync failure was silently accepted");
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  check string "failed initialization remains preparing" "" (Fs_compat.load_file lock_path);
+  ignore (transaction_snapshot path ~after:None);
+  check bool
+    "successful retry publishes ready state"
+    true
+    (String.length (Fs_compat.load_file lock_path) > 0)
+;;
+
+let test_private_jsonl_stable_lock_invalid_state_fails_closed () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let invalid = "invalid-ready-state" in
+  write_stable_lock_fixture path invalid 0o600;
+  match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+  | Error (Fs_compat.Invalid_stable_lock_state { observed_length; _ }) ->
+    check int "invalid stable lock length" (String.length invalid) observed_length
+  | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+  | Ok _ -> fail "invalid stable lock state was accepted"
+;;
+
+let test_private_jsonl_stable_lock_permission_drift_fails_closed () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  write_stable_lock_fixture path "" 0o640;
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  (match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+   | Error (Fs_compat.Unexpected_stable_lock_permissions { actual; _ }) ->
+     check int "observed stable lock permissions" 0o640 actual
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "stable lock permission drift was silently repaired");
+  check int
+    "permission drift remains untouched"
+    0o640
+    ((Unix.stat lock_path).Unix.st_perm land 0o7777)
 ;;
 
 let test_private_jsonl_transaction_rejects_data_aliases () =
@@ -678,6 +764,22 @@ let () =
             "private JSONL stable lock is private"
             `Quick
             test_private_jsonl_transaction_lock_is_private
+        ; test_case
+            "private JSONL stable lock parent sync is one-shot"
+            `Quick
+            test_private_jsonl_stable_lock_parent_sync_is_one_shot
+        ; test_case
+            "private JSONL stable lock retries failed parent sync"
+            `Quick
+            test_private_jsonl_stable_lock_parent_sync_failure_retries
+        ; test_case
+            "private JSONL stable lock invalid state fails closed"
+            `Quick
+            test_private_jsonl_stable_lock_invalid_state_fails_closed
+        ; test_case
+            "private JSONL stable lock permission drift fails closed"
+            `Quick
+            test_private_jsonl_stable_lock_permission_drift_fails_closed
         ; test_case
             "private JSONL transaction rejects data aliases"
             `Quick


### PR DESCRIPTION
## Summary
- introduce a four-state private-file outcome that preserves primary value/error and one descriptor cleanup failure
- migrate offset read, durable update, and offset append APIs plus Chat/Event Queue/Gate consumers
- keep committed writes authoritative on close failure while logging settlement evidence; preserve primary rejection plus cleanup failure together
- add deterministic close-failure coverage for read, committed append, rejected append, and update

## Architecture
- stacked on #25312
- no MASC/OAS boundary change
- no timeout, retry, heuristic, or capacity policy added
- single data descriptor means the public outcome exposes one cleanup_failure, not an impossible empty/list state

## Verification
- ocamlformat --check: pass
- ocamlc parse checks for every touched ml/mli: pass
- git diff --check: pass
- focused Dune requested via scripts/dune-local.sh build test/test_fs_compat_durable_append.exe; wrapper exited 75 after detecting two live bare Dune processes (test_keeper_checkpoint_stale_guard.exe and test_keeper_status_bridge.exe). No bypass or process termination was used; PR CI remains the type/build authority.