### PR TITLE
refactor(fusion): commit computation authority phase

### DIFF
--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -3,18 +3,28 @@ type identity =
   ; run_id : string
   }
 [@@deriving yojson, show, eq]
+type replay =
+  { topology : Fusion_types.fusion_topology
+  ; request : Fusion_types.fusion_request
+  }
+[@@deriving yojson, show, eq]
 type registration =
-  { identity : identity
-  ; preset : string
+  { replay : replay
   ; started_at : float
   }
 [@@deriving yojson, show, eq]
-type terminal =
-  | Deliberated of Fusion_types.deliberation_evidence
-  | Aborted of string
+type uncommitted_stop =
+  | Denied of Fusion_types.deny_reason
   | Cancelled of string
-  | Interrupted_after_restart
+  | Aborted of string
+  | Interrupted_without_computation_restart
 [@@deriving yojson, show, eq]
+type phase =
+  | Computation_committed of Fusion_types.deliberation_evidence
+  | Stopped_without_computation of uncommitted_stop
+[@@deriving yojson, show, eq]
+type state_kind = Empty_state | Registered_state | Phase_committed_state [@@deriving show]
+type event_kind = Registration_event | Computation_event | Uncommitted_stop_event [@@deriving show]
 type error =
   | Empty_keeper
   | Empty_run_id
@@ -27,26 +37,24 @@ type error =
       { line : int
       ; detail : string
       }
-  | Orphan_terminal
-  | Reversed_records
-  | Unexpected_sequence of int
+  | Empty_authority_record
+  | Evidence_question_mismatch of { expected : string; found : string }
+  | Invalid_transition of
+      { event_index : int
+      ; state : state_kind
+      ; event : event_kind
+      }
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
 type register_outcome =
   | Registered
-  | Already_running
-  | Already_settled of terminal
-type claim_outcome =
-  | First_committed
-  | Already_same
-  | Conflict of terminal
-type recovered_run =
-  | Running_run of registration
-  | Settled_run of
-      { registration : registration
-      ; terminal : terminal
-      }
+  | Already_registered of recovered_run
+and recovered_run =
+  | Registered_run of registration
+  | Computation_committed_run of registration * Fusion_types.deliberation_evidence
+  | Stopped_without_computation_run of registration * uncommitted_stop
+type claim_outcome = First_committed | Already_same | Conflict of phase
 type scan_entry_error =
   | Invalid_entry_name of string
   | Entry_disappeared
@@ -71,14 +79,14 @@ type scan_error =
   | Directory_inspection_failed of directory_io_failure
   | Directory_inventory_failed of directory_io_failure
   | Directory_identity_changed
-type terminal_record =
+type phase_record =
   { identity : identity
-  ; terminal : terminal
+  ; phase : phase
   }
 [@@deriving yojson]
 type persisted_event =
   | Run_registered of registration
-  | Terminal_committed of terminal_record
+  | Phase_committed of phase_record
 [@@deriving yojson]
 type persisted_record =
   { schema_version : int
@@ -87,8 +95,8 @@ type persisted_record =
 [@@deriving yojson]
 type persisted_state =
   | Empty
-  | Running of registration
-  | Settled of registration * terminal
+  | Registered_state_value of registration
+  | Phase_committed_state_value of registration * phase
 type t = { root : string }
 let create ~directory = { root = directory }
 let identity_key identity =
@@ -110,22 +118,33 @@ let validate_identity = function
   | _ -> Ok ()
 ;;
 let validate_registration (registration : registration) =
-  match validate_identity registration.identity with
+  let request = registration.replay.request in
+  match validate_identity { keeper = request.keeper; run_id = request.run_id } with
   | Error _ as error -> error
   | Ok () ->
     if Float.is_finite registration.started_at
     then Ok ()
     else Error (Invalid_started_at registration.started_at)
 ;;
-let validate_terminal = function
-  | Deliberated _ -> Ok ()
-  | Aborted "" -> Error Empty_abort_detail
-  | Aborted _ -> Ok ()
+let validate_stop = function
   | Cancelled "" -> Error Empty_cancellation_detail
-  | Cancelled _ -> Ok ()
-  | Interrupted_after_restart -> Ok ()
+  | Aborted "" -> Error Empty_abort_detail
+  | Cancelled _ | Aborted _ -> Ok ()
+  | Denied _ | Interrupted_without_computation_restart -> Ok ()
 ;;
-let schema_version = 2
+let identity_of_registration registration =
+  let request = registration.replay.request in
+  { keeper = request.keeper; run_id = request.run_id }
+;;
+let validate_phase registration = function
+  | Computation_committed evidence ->
+    let expected = registration.replay.request.prompt in
+    if String.equal expected evidence.Fusion_types.question
+    then Ok ()
+    else Error (Evidence_question_mismatch { expected; found = evidence.question })
+  | Stopped_without_computation stop -> validate_stop stop
+;;
+let schema_version = 3
 let event_line event =
   Yojson.Safe.to_string (persisted_record_to_yojson { schema_version; event }) ^ "\n"
 ;;
@@ -165,52 +184,64 @@ let parse_events content =
 let check_identity expected actual =
   if equal_identity expected actual then Ok () else Error (Identity_mismatch actual)
 ;;
-let state_of_events expected events =
+let event_kind = function
+  | Run_registered _ -> Registration_event
+  | Phase_committed { phase = Computation_committed _; _ } -> Computation_event
+  | Phase_committed { phase = Stopped_without_computation _; _ } ->
+    Uncommitted_stop_event
+;;
+let state_kind = function
+  | Empty -> Empty_state
+  | Registered_state_value _ -> Registered_state
+  | Phase_committed_state_value _ -> Phase_committed_state
+;;
+let identity_of_event = function
+  | Run_registered registration -> identity_of_registration registration
+  | Phase_committed record -> record.identity
+;;
+let apply_event expected event_index state event =
   let ( let* ) = Result.bind in
-  match events with
-  | [] -> Ok Empty
-  | [ Run_registered registration ] ->
+  let* () = check_identity expected (identity_of_event event) in
+  match state, event with
+  | Empty, Run_registered registration ->
     let* () = validate_registration registration in
-    let* () = check_identity expected registration.identity in
-    Ok (Running registration)
-  | [ Run_registered registration; Terminal_committed terminal_record ] ->
-    let* () = validate_registration registration in
-    let* () = check_identity expected registration.identity in
-    let* () = check_identity expected terminal_record.identity in
-    let* () = validate_terminal terminal_record.terminal in
-    Ok (Settled (registration, terminal_record.terminal))
-  | [ Terminal_committed terminal_record ] ->
-    let* () = check_identity expected terminal_record.identity in
-    Error Orphan_terminal
-  | [ Terminal_committed terminal_record; Run_registered registration ] ->
-    let* () = check_identity expected terminal_record.identity in
-    let* () = validate_registration registration in
-    let* () = check_identity expected registration.identity in
-    Error Reversed_records
-  | events -> Error (Unexpected_sequence (List.length events))
+    Ok (Registered_state_value registration)
+  | Registered_state_value registration, Phase_committed record ->
+    let* () = validate_phase registration record.phase in
+    Ok (Phase_committed_state_value (registration, record.phase))
+  | _ ->
+    Error
+      (Invalid_transition
+         { event_index; state = state_kind state; event = event_kind event })
+;;
+let state_of_events expected events =
+  let rec loop index state = function
+    | [] -> Ok state
+    | event :: rest ->
+      Result.bind (apply_event expected index state event) (fun state ->
+        loop (index + 1) state rest)
+  in
+  loop 1 Empty events
 ;;
 let state_of_content expected content =
   Result.bind (parse_events content) (state_of_events expected)
-;;
-
-let identity_of_event = function
-  | Run_registered registration -> registration.identity
-  | Terminal_committed terminal_record -> terminal_record.identity
 ;;
 
 let recovered_run_of_content content =
   let ( let* ) = Result.bind in
   let* events = parse_events content in
   match events with
-  | [] -> Error (Unexpected_sequence 0)
+  | [] -> Error Empty_authority_record
   | first :: _ ->
     let identity = identity_of_event first in
     let* state = state_of_events identity events in
     (match state with
-     | Empty -> Error (Unexpected_sequence 0)
-     | Running registration -> Ok (identity, Running_run registration)
-     | Settled (registration, terminal) ->
-       Ok (identity, Settled_run { registration; terminal }))
+     | Empty -> Error Empty_authority_record
+     | Registered_state_value registration -> Ok (identity, Registered_run registration)
+     | Phase_committed_state_value (registration, Computation_committed evidence) ->
+       Ok (identity, Computation_committed_run (registration, evidence))
+     | Phase_committed_state_value (registration, Stopped_without_computation stop) ->
+       Ok (identity, Stopped_without_computation_run (registration, stop)))
 ;;
 
 let directory_io_failure_of_unix error function_name argument =
@@ -289,45 +320,58 @@ let transact path decide =
   | Ok result -> result
   | Error error -> Error (Durable_append_failed error)
 ;;
-let register t ~keeper ~run_id ~preset ~started_at =
+let register t ~topology ~request ~started_at =
   if not (Float.is_finite started_at)
   then Error (Invalid_started_at started_at)
   else
-    let identity = { keeper; run_id } in
-    let requested = { identity; preset; started_at } in
+    let identity = { keeper = request.Fusion_types.keeper; run_id = request.run_id } in
+    let requested = { replay = { topology; request }; started_at } in
     match validate_identity identity with
     | Error error -> Error error
     | Ok () ->
-      transact (run_file t ~keeper ~run_id) (fun content ->
+      transact (run_file t ~keeper:identity.keeper ~run_id:identity.run_id) (fun content ->
+        let retry existing recovered =
+          if equal_replay existing.replay requested.replay
+          then None, Ok (Already_registered recovered)
+          else None, Error (Registration_conflict existing)
+        in
         match state_of_content identity content with
         | Error error -> None, Error error
         | Ok Empty -> Some (event_line (Run_registered requested)), Ok Registered
-        | Ok (Running existing) ->
-          if equal_registration existing requested
-          then None, Ok Already_running
-          else None, Error (Registration_conflict existing)
-        | Ok (Settled (existing, terminal)) ->
-          if equal_registration existing requested
-          then None, Ok (Already_settled terminal)
-          else None, Error (Registration_conflict existing))
+        | Ok (Registered_state_value registration) -> retry registration (Registered_run registration)
+        | Ok (Phase_committed_state_value (registration, Computation_committed evidence)) ->
+          retry registration (Computation_committed_run (registration, evidence))
+        | Ok (Phase_committed_state_value (registration, Stopped_without_computation stop)) ->
+          retry registration (Stopped_without_computation_run (registration, stop)))
 ;;
-let claim_terminal t ~keeper ~run_id terminal =
-  match validate_terminal terminal with
+let commit_phase t ~keeper ~run_id phase =
+  let identity = { keeper; run_id } in
+  let phase_validation =
+    match phase with
+    | Computation_committed _ -> Ok ()
+    | Stopped_without_computation stop -> validate_stop stop
+  in
+  match Result.bind (validate_identity identity) (fun () -> phase_validation) with
   | Error error -> Error error
   | Ok () ->
-    let identity = { keeper; run_id } in
-    (match validate_identity identity with
-     | Error error -> Error error
-     | Ok () ->
-       transact (run_file t ~keeper ~run_id) (fun content ->
-         match state_of_content identity content with
+    transact (run_file t ~keeper ~run_id) (fun content ->
+      match state_of_content identity content with
+      | Error error -> None, Error error
+      | Ok Empty ->
+        ( None
+        , Error
+            (Invalid_transition
+               { event_index = 1; state = Empty_state; event = event_kind (Phase_committed { identity; phase }) }) )
+      | Ok (Registered_state_value registration) ->
+        (match validate_phase registration phase with
          | Error error -> None, Error error
-         | Ok Empty -> None, Error Orphan_terminal
-         | Ok (Running _) ->
-           let record = { identity; terminal } in
-           Some (event_line (Terminal_committed record)), Ok First_committed
-         | Ok (Settled (_, winner)) ->
-           if equal_terminal winner terminal
+         | Ok () ->
+           Some (event_line (Phase_committed { identity; phase })), Ok First_committed)
+      | Ok (Phase_committed_state_value (registration, winner)) ->
+        (match validate_phase registration phase with
+         | Error error -> None, Error error
+         | Ok () ->
+           if equal_phase winner phase
            then None, Ok Already_same
            else None, Ok (Conflict winner)))
 ;;

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -3,17 +3,18 @@ type identity =
   { keeper : string
   ; run_id : string
   }
-type registration =
-  { identity : identity
-  ; preset : string
-  ; started_at : float
+type replay =
+  { topology : Fusion_types.fusion_topology
+  ; request : Fusion_types.fusion_request
   }
-type terminal =
-  | Deliberated of Fusion_types.deliberation_evidence
-  | Aborted of string
+type registration = { replay : replay; started_at : float }
+type uncommitted_stop =
+  | Denied of Fusion_types.deny_reason
   | Cancelled of string
-  | Interrupted_after_restart
-val equal_terminal : terminal -> terminal -> bool
+  | Aborted of string
+  | Interrupted_without_computation_restart
+type state_kind = Empty_state | Registered_state | Phase_committed_state
+type event_kind = Registration_event | Computation_event | Uncommitted_stop_event
 type error =
   | Empty_keeper
   | Empty_run_id
@@ -23,27 +24,28 @@ type error =
   | Partial_tail
   | Unsupported_schema_version of { line : int; found : int }
   | Invalid_record of { line : int; detail : string }
-  | Orphan_terminal
-  | Reversed_records
-  | Unexpected_sequence of int
+  | Empty_authority_record
+  | Evidence_question_mismatch of { expected : string; found : string }
+  | Invalid_transition of
+      { event_index : int
+      ; state : state_kind
+      ; event : event_kind
+      }
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
 type register_outcome =
   | Registered
-  | Already_running
-  | Already_settled of terminal
-type claim_outcome =
-  | First_committed
-  | Already_same
-  | Conflict of terminal
-
-type recovered_run =
-  | Running_run of registration
-  | Settled_run of
-      { registration : registration
-      ; terminal : terminal
-      }
+  | Already_registered of recovered_run
+and recovered_run =
+  | Registered_run of registration
+  | Computation_committed_run of registration * Fusion_types.deliberation_evidence
+  | Stopped_without_computation_run of registration * uncommitted_stop
+type phase =
+  | Computation_committed of Fusion_types.deliberation_evidence
+  | Stopped_without_computation of uncommitted_stop
+val equal_phase : phase -> phase -> bool
+type claim_outcome = First_committed | Already_same | Conflict of phase
 
 type scan_entry_error =
   | Invalid_entry_name of string
@@ -85,14 +87,13 @@ val scan : t -> (scan_outcome, scan_error) result
 
 val register
   :  t
-  -> keeper:string
-  -> run_id:string
-  -> preset:string
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
   -> started_at:float
   -> (register_outcome, error) result
-val claim_terminal
+val commit_phase
   :  t
   -> keeper:string
   -> run_id:string
-  -> terminal
+  -> phase
   -> (claim_outcome, error) result

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -97,8 +97,11 @@ let test_exact_lifecycle_and_validation () =
    | Ok A.First_committed -> ()
    | _ -> fail "first terminal must commit");
   (match register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:3. with
-   | Ok (A.Already_registered (A.Computation_committed_run (_, phase))) ->
-     check bool "settled retry returns winner" true (A.equal_phase winner phase)
+   | Ok (A.Already_registered (A.Computation_committed_run (_, evidence))) ->
+     check bool
+       "settled retry returns winner"
+       true
+       (A.equal_phase winner (A.Computation_committed evidence))
    | _ -> fail "settled registration retry could start another run");
   (match A.commit_phase restarted ~keeper:"k" ~run_id:"r" winner with
    | Ok A.Already_same -> ()
@@ -134,8 +137,11 @@ let test_exact_lifecycle_and_validation () =
   (match
      register restarted ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:4.
    with
-   | Ok (A.Already_registered (A.Computation_committed_run (_, phase))) ->
-     check bool "typed failure survives restart" true (A.equal_phase typed_failure phase)
+   | Ok (A.Already_registered (A.Computation_committed_run (_, evidence))) ->
+     check bool
+       "typed failure survives restart"
+       true
+       (A.equal_phase typed_failure (A.Computation_committed evidence))
    | _ -> fail "typed failure terminal was not reloaded exactly");
   match A.commit_phase store ~keeper:"k" ~run_id:"missing"
           (A.Stopped_without_computation (A.Cancelled "shutdown")) with
@@ -274,9 +280,9 @@ let test_restart_scan_preserves_valid_peers_and_corruption () =
   check bool "settled terminal survives scan" true
     (List.exists
        (function
-         | A.Computation_committed_run (registration, phase) ->
+         | A.Computation_committed_run (registration, evidence) ->
            String.equal registration.replay.request.run_id "settled"
-           && A.equal_phase winner phase
+           && A.equal_phase winner (A.Computation_committed evidence)
          | A.Registered_run _ | A.Stopped_without_computation_run _ -> false)
        valid_runs)
 ;;

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -60,72 +60,86 @@ let failed_evidence () : Fusion_types.deliberation_evidence =
   }
 ;;
 
-let deliberated evidence = A.Deliberated evidence
+let deliberated evidence = A.Computation_committed evidence
 let run_file directory keeper run_id =
   let key = Printf.sprintf "%d:%s%d:%s" (String.length keeper) keeper (String.length run_id) run_id in
   let digest = Digestif.SHA256.(digest_string key |> to_hex) in
   Filename.concat directory (digest ^ ".jsonl")
 ;;
+let register ?(topology = Refine) store ~keeper ~run_id ~preset ~started_at =
+  let request : Fusion_types.fusion_request =
+    { run_id; keeper; prompt = (successful_evidence ()).question; preset
+    ; web_tools = true; depth = Fusion_depth.Top; trigger = Operator_requested }
+  in
+  A.register store ~topology ~request ~started_at
+;;
 let test_exact_lifecycle_and_validation () =
   let base_path = fresh_base () in
   let store = A.create ~directory:(Filename.concat base_path "runs") in
-  (match A.register store ~keeper:"" ~run_id:"r" ~preset:"p" ~started_at:1. with
+  (match register store ~keeper:"" ~run_id:"r" ~preset:"p" ~started_at:1. with
    | Error A.Empty_keeper -> ()
    | _ -> fail "empty keeper identity was accepted");
-  (match A.register store ~keeper:"k" ~run_id:"" ~preset:"p" ~started_at:1. with
+  (match register store ~keeper:"k" ~run_id:"" ~preset:"p" ~started_at:1. with
    | Error A.Empty_run_id -> ()
    | _ -> fail "empty run identity was accepted");
-  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:Float.nan with
+  (match register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:Float.nan with
    | Error (A.Invalid_started_at _) -> ()
    | _ -> fail "non-finite start time was accepted");
-  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
+  (match register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
    | Ok A.Registered -> ()
    | _ -> fail "first registration must be durable");
   let restarted = A.create ~directory:(Filename.concat base_path "runs") in
-  (match A.register restarted ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
-   | Ok A.Already_running -> ()
-   | _ -> fail "exact registration retry must be idempotent");
+  (match register ~topology:Simple restarted ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:2. with
+   | Error (A.Registration_conflict _) -> ()
+   | _ -> fail "changed replay envelope did not conflict");
   let winner = deliberated (successful_evidence ()) in
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"r" winner with
+  (match A.commit_phase store ~keeper:"k" ~run_id:"r" winner with
    | Ok A.First_committed -> ()
    | _ -> fail "first terminal must commit");
-  (match A.register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:1. with
-   | Ok (A.Already_settled terminal) ->
-     check bool "settled retry returns winner" true (A.equal_terminal winner terminal)
+  (match register store ~keeper:"k" ~run_id:"r" ~preset:"p" ~started_at:3. with
+   | Ok (A.Already_registered (A.Computation_committed_run (_, phase))) ->
+     check bool "settled retry returns winner" true (A.equal_phase winner phase)
    | _ -> fail "settled registration retry could start another run");
-  (match A.claim_terminal restarted ~keeper:"k" ~run_id:"r" winner with
+  (match A.commit_phase restarted ~keeper:"k" ~run_id:"r" winner with
    | Ok A.Already_same -> ()
    | _ -> fail "restart must retain the winner");
+  (match A.commit_phase store ~keeper:"k" ~run_id:"r" (deliberated (failed_evidence ())) with
+   | Error (A.Evidence_question_mismatch _) -> () | _ -> fail "foreign question was accepted");
   (match
-     A.claim_terminal store ~keeper:"k" ~run_id:"r"
-       (deliberated (failed_evidence ()))
+     A.commit_phase store ~keeper:"k" ~run_id:"r"
+       (deliberated { (failed_evidence ()) with question = (successful_evidence ()).question })
    with
    | Ok (A.Conflict terminal) ->
-     check bool "conflict returns exact winner" true (A.equal_terminal winner terminal)
+     check bool "conflict returns exact winner" true (A.equal_phase winner terminal)
    | _ -> fail "different terminal must conflict");
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"other" (A.Cancelled "") with
+  (match A.commit_phase store ~keeper:"k" ~run_id:"other"
+           (A.Stopped_without_computation (A.Cancelled "")) with
    | Error A.Empty_cancellation_detail -> ()
    | _ -> fail "empty cancellation detail was accepted");
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"other" (A.Aborted "") with
+  (match A.commit_phase store ~keeper:"k" ~run_id:"other"
+           (A.Stopped_without_computation (A.Aborted "")) with
    | Error A.Empty_abort_detail -> ()
    | _ -> fail "empty abort detail was accepted");
   (match
-     A.register store ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:2.
+     register store ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:2.
    with
    | Ok A.Registered -> ()
    | _ -> fail "typed-failure registration failed");
-  let typed_failure = deliberated (failed_evidence ()) in
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"typed-failure" typed_failure with
+  let typed_failure =
+    deliberated { (failed_evidence ()) with question = (successful_evidence ()).question }
+  in
+  (match A.commit_phase store ~keeper:"k" ~run_id:"typed-failure" typed_failure with
    | Ok A.First_committed -> ()
    | _ -> fail "typed failure terminal did not commit");
   (match
-     A.register restarted ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:2.
+     register restarted ~keeper:"k" ~run_id:"typed-failure" ~preset:"p" ~started_at:4.
    with
-   | Ok (A.Already_settled terminal) ->
-     check bool "typed failure survives restart" true (A.equal_terminal typed_failure terminal)
+   | Ok (A.Already_registered (A.Computation_committed_run (_, phase))) ->
+     check bool "typed failure survives restart" true (A.equal_phase typed_failure phase)
    | _ -> fail "typed failure terminal was not reloaded exactly");
-  match A.claim_terminal store ~keeper:"k" ~run_id:"missing" (A.Cancelled "shutdown") with
-  | Error A.Orphan_terminal -> ()
+  match A.commit_phase store ~keeper:"k" ~run_id:"missing"
+          (A.Stopped_without_computation (A.Cancelled "shutdown")) with
+  | Error (A.Invalid_transition { state = A.Empty_state; _ }) -> ()
   | _ -> fail "terminal without durable registration must be rejected"
 ;;
 let test_corruption_is_per_run_and_semantic () =
@@ -133,7 +147,7 @@ let test_corruption_is_per_run_and_semantic () =
   let directory = Filename.concat base_path "runs" in
   let store = A.create ~directory in
   let register run_id =
-    match A.register store ~keeper:"k" ~run_id ~preset:"p" ~started_at:1. with
+    match register store ~keeper:"k" ~run_id ~preset:"p" ~started_at:1. with
     | Ok A.Registered -> ()
     | _ -> fail (run_id ^ " registration failed")
   in
@@ -141,12 +155,12 @@ let test_corruption_is_per_run_and_semantic () =
   let bad_path = run_file directory "k" "bad" in
   let registered = Fs_compat.load_file bad_path in
   Fs_compat.save_file bad_path (String.sub registered 0 (String.length registered - 1));
-  (match A.claim_terminal store ~keeper:"k" ~run_id:"bad" (deliberated (successful_evidence ())) with
+  (match A.commit_phase store ~keeper:"k" ~run_id:"bad" (deliberated (successful_evidence ())) with
    | Error A.Partial_tail -> ()
    | _ -> fail "partial tail must fail explicitly");
   register "peer";
   (match
-     A.claim_terminal store ~keeper:"k" ~run_id:"peer"
+     A.commit_phase store ~keeper:"k" ~run_id:"peer"
        (deliberated (successful_evidence ()))
    with
    | Ok A.First_committed -> ()
@@ -158,14 +172,14 @@ let test_corruption_is_per_run_and_semantic () =
   in
   Fs_compat.save_file bad_path (Yojson.Safe.to_string versioned ^ "\n");
   (match
-     A.claim_terminal store ~keeper:"k" ~run_id:"bad"
+     A.commit_phase store ~keeper:"k" ~run_id:"bad"
        (deliberated (successful_evidence ()))
    with
    | Error (A.Unsupported_schema_version { found = 1; _ }) -> ()
    | _ -> fail "unsupported schema version must fail explicitly");
   register "order";
   (match
-     A.claim_terminal store ~keeper:"k" ~run_id:"order"
+     A.commit_phase store ~keeper:"k" ~run_id:"order"
        (deliberated (successful_evidence ()))
    with
    | Ok A.First_committed -> ()
@@ -175,32 +189,35 @@ let test_corruption_is_per_run_and_semantic () =
    | [ registration; terminal; "" ] ->
      Fs_compat.save_file order_path (terminal ^ "\n");
      (match
-        A.claim_terminal store ~keeper:"k" ~run_id:"order"
+        A.commit_phase store ~keeper:"k" ~run_id:"order"
           (deliberated (successful_evidence ()))
       with
-      | Error A.Orphan_terminal -> ()
+      | Error (A.Invalid_transition { state = A.Empty_state; _ }) -> ()
       | _ -> fail "orphan terminal must fail explicitly");
      Fs_compat.save_file order_path (terminal ^ "\n" ^ registration ^ "\n");
      (match
-        A.claim_terminal store ~keeper:"k" ~run_id:"order"
+        A.commit_phase store ~keeper:"k" ~run_id:"order"
           (deliberated (successful_evidence ()))
       with
-      | Error A.Reversed_records -> ()
+      | Error (A.Invalid_transition { state = A.Empty_state; _ }) -> ()
       | _ -> fail "reversed records must fail explicitly")
    | _ -> fail "expected exact register/terminal JSONL pair");
   let foreign_path = run_file directory "k" "foreign" in
   Fs_compat.save_file foreign_path
     (Fs_compat.load_file (run_file directory "k" "peer"));
   match
-    A.claim_terminal store ~keeper:"k" ~run_id:"foreign"
+    A.commit_phase store ~keeper:"k" ~run_id:"foreign"
       (deliberated (successful_evidence ()))
   with
   | Error (A.Identity_mismatch _) -> ()
   | _ -> fail "hashed path must still verify persisted identity"
 ;;
 let identity_of_recovered = function
-  | A.Running_run registration -> registration.identity
-  | A.Settled_run { registration; _ } -> registration.identity
+  | A.Registered_run registration
+  | A.Computation_committed_run (registration, _)
+  | A.Stopped_without_computation_run (registration, _) ->
+    { A.keeper = registration.replay.request.keeper
+    ; run_id = registration.replay.request.run_id }
 ;;
 
 let test_restart_scan_preserves_valid_peers_and_corruption () =
@@ -208,16 +225,20 @@ let test_restart_scan_preserves_valid_peers_and_corruption () =
   let directory = Filename.concat base_path "runs" in
   let store = A.create ~directory in
   let register run_id started_at =
-    match A.register store ~keeper:"keeper-a" ~run_id ~preset:"p" ~started_at with
+    match register store ~keeper:"keeper-a" ~run_id ~preset:"p" ~started_at with
     | Ok A.Registered -> ()
     | _ -> fail (run_id ^ " registration failed")
   in
   register "running" 1.;
   register "settled" 2.;
   register "corrupt" 3.;
+  (match A.commit_phase store ~keeper:"keeper-a" ~run_id:"corrupt"
+           (A.Stopped_without_computation (A.Denied Fusion_types.Disabled)) with
+   | Ok A.First_committed -> ()
+   | _ -> fail "typed uncommitted stop did not commit");
   let winner = deliberated (successful_evidence ()) in
   (match
-     A.claim_terminal store ~keeper:"keeper-a" ~run_id:"settled"
+     A.commit_phase store ~keeper:"keeper-a" ~run_id:"settled"
        winner
    with
    | Ok A.First_committed -> ()
@@ -253,10 +274,10 @@ let test_restart_scan_preserves_valid_peers_and_corruption () =
   check bool "settled terminal survives scan" true
     (List.exists
        (function
-         | A.Settled_run { registration; terminal } ->
-           String.equal registration.identity.run_id "settled"
-           && A.equal_terminal winner terminal
-         | A.Running_run _ -> false)
+         | A.Computation_committed_run (registration, phase) ->
+           String.equal registration.replay.request.run_id "settled"
+           && A.equal_phase winner phase
+         | A.Registered_run _ | A.Stopped_without_computation_run _ -> false)
        valid_runs)
 ;;
 let () =

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -531,8 +531,8 @@ let test_orchestrator_project_success_projects_board_chat_and_registry () =
       ; trigger = Fusion_types.Explicit_tool_call
       }
     in
-    let deliberation : Fusion_orchestrator.deliberation =
-      { panel; judge = Ok synthesis; judges; judge_usage }
+    let deliberation : Fusion_types.deliberation_evidence =
+      { question; panel; judge = Ok synthesis; judges; judge_usage }
     in
     (match
        Fusion_orchestrator.project ~base_dir ~topology:Fusion_types.Simple ~request


### PR DESCRIPTION
## Summary

- hard-cut the per-run authority schema to one typed v3 state machine
- persist the exact Fusion topology and full request needed for replay
- commit either computation evidence or a typed stop without committed evidence
- preserve the first registration timestamp across idempotent retries
- reject changed replay envelopes and evidence for a different prompt
- report invalid transitions with the actual event index, state, and event

## Boundary

This is a MASC-owned Fusion durability boundary. It does not add provider,
product, risk-level, or tool-name policy to OAS. It replaces the previous
terminal-shaped authority API; there is no compatibility reader or second
writer.

## Stack

- base: #25293
- next: #25319 must be rebased onto this leaf and consume the new typed phases

## Validation

- changed lines against the stacked base: 396
- `ocamlc -stop-after parsing` for implementation, interface, and test
- `ocamlformat --check` for changed OCaml files
- `git diff --check`
- focused Dune was not claimed locally because another session held/bypassed the
  machine-wide Dune lock; Draft CI remains the build authority
