### PR TITLE
fix(runtime): enforce native context fit on agent turns

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -930,6 +930,7 @@ let resume_from_checkpoint
         (Agent_sdk.Agent.resume ~net ~checkpoint:prepared_resume.patched_checkpoint
            ~tools:config.tools ?context:config.context
            ~provider_config:config.provider_cfg
+           ~context_fit_admission:prepared_resume.context_fit_admission
            ~options ~config:prepared_resume.agent_config
            ?checkpoint_sink:config.checkpoint_sink
            ()))

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -135,6 +135,8 @@ let default_config
 let oas_tracer_ref = Atomic.make Agent_sdk.Tracing.null
 let set_oas_tracer tracer = Atomic.set oas_tracer_ref tracer
 
+let context_fit_admission = Agent_sdk.Agent.Enforce_when_supported
+
 let builder
       ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
       ~(config : config)
@@ -148,6 +150,7 @@ let builder
     |> Agent_sdk.Builder.with_name config.name
     |> Agent_sdk.Builder.with_system_prompt config.system_prompt
     |> Agent_sdk.Builder.with_tools config.tools
+    |> Agent_sdk.Builder.with_context_fit_admission context_fit_admission
   in
   let builder =
     match config.temperature with
@@ -269,6 +272,7 @@ type prepared_resume =
   { patched_checkpoint : Agent_sdk.Checkpoint.t
   ; agent_config : Agent_sdk.Types.agent_config
   ; options : Agent_sdk.Agent.options
+  ; context_fit_admission : Agent_sdk.Agent.context_fit_admission
   }
 
 let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
@@ -319,5 +323,5 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; on_run_complete = config.on_run_complete
     }
   in
-  { patched_checkpoint; agent_config; options }
+  { patched_checkpoint; agent_config; options; context_fit_admission }
 ;;

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -111,12 +111,18 @@ val builder :
 (** [builder ~net ~config ?transport ()] builds an {!Agent_sdk.Builder.t}
     from [config]. *)
 
+val context_fit_admission : Agent_sdk.Agent.context_fit_admission
+(** Exact provider-fit policy shared by fresh and resumed agents. The OAS
+    provider capability SSOT decides whether native request measurement exists;
+    unsupported providers retain compatibility dispatch. *)
+
 (** {1 Resume preparation} *)
 
 type prepared_resume = {
   patched_checkpoint : Agent_sdk.Checkpoint.t;
   agent_config : Agent_sdk.Types.agent_config;
   options : Agent_sdk.Agent.options;
+  context_fit_admission : Agent_sdk.Agent.context_fit_admission;
 }
 (** Output of {!prepare_resume}. [patched_checkpoint] has runtime identity
     fields adjusted. *)

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1396,6 +1396,145 @@ let test_runtime_agent_context_leaves_tool_choice_unset_with_tools () =
         Eio.Switch.on_release sw (fun () ->
           Agent_sdk.Agent.close agent)))
 
+let fresh_loopback_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt socket Unix.SO_REUSEADDR true;
+  Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname socket with
+    | Unix.ADDR_INET (_, port) -> port
+    | _ -> fail "loopback socket did not expose a TCP port"
+  in
+  Unix.close socket;
+  port
+
+let with_native_count_server f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let port = fresh_loopback_port () in
+  let paths = ref [] in
+  let handler _conn request body =
+    let _body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let path = Cohttp.Request.uri request |> Uri.path in
+    paths := path :: !paths;
+    if String.equal path "/v1/messages/count_tokens"
+    then Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"input_tokens":500}|} ()
+    else
+      Cohttp_eio.Server.respond_string
+        ~status:`Internal_server_error
+        ~body:{|{"error":"completion must not be dispatched"}|}
+        ()
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:4
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let result = f ~sw ~net ~base_url in
+  result, List.rev !paths
+
+let context_fit_provider_config base_url =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Anthropic
+    ~model_id:"context-fit-fixture"
+    ~base_url
+    ~api_key:"test-key"
+    ~headers:[ "Content-Type", "application/json"; "anthropic-version", "2023-06-01" ]
+    ~request_path:"/v1/messages"
+    ~max_tokens:64
+    ~max_context:512
+    ~temperature:0.2
+    ()
+
+let context_fit_runtime_config base_url =
+  Runtime_agent.default_config
+    ~name:"context-fit-fixture"
+    ~provider_cfg:(context_fit_provider_config base_url)
+    ~system_prompt:"Count the exact provider request before dispatch."
+    ~tools:[]
+
+let context_fit_checkpoint () =
+  { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
+  ; session_id = "context-fit-session"
+  ; agent_name = "context-fit-fixture"
+  ; model = "context-fit-fixture"
+  ; system_prompt = Some "stale"
+  ; messages = []
+  ; usage = Agent_sdk.Types.empty_usage
+  ; turn_count = 3
+  ; created_at = 0.0
+  ; tools = []
+  ; tool_choice = None
+  ; disable_parallel_tool_use = false
+  ; temperature = None
+  ; top_p = None
+  ; top_k = None
+  ; min_p = None
+  ; reasoning_effort = None
+  ; enable_thinking = None
+  ; preserve_thinking = None
+  ; response_format = Agent_sdk.Types.Off
+  ; thinking_budget = None
+  ; cache_system_prompt = false
+  ; context = Agent_sdk.Context.create_sync ()
+  ; mcp_sessions = []
+  ; working_context = None
+  }
+
+let check_context_fit_overflow = function
+  | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.ContextOverflow { limit = Some 512; _ })) ->
+    ()
+  | Error error -> fail (Agent_sdk.Error.to_string error)
+  | Ok _ -> fail "overflowed request must not reach completion dispatch"
+
+let test_runtime_agent_fresh_build_enforces_native_context_fit () =
+  let (), paths =
+    with_native_count_server
+    @@ fun ~sw ~net ~base_url ->
+    let config = context_fit_runtime_config base_url in
+    let agent =
+      match Runtime_agent.build ~sw ~net ~config with
+      | Ok agent -> agent
+      | Error error -> fail (Agent_sdk.Error.to_string error)
+    in
+    Fun.protect
+      ~finally:(fun () -> Agent_sdk.Agent.close agent)
+      (fun () -> Agent_sdk.Agent.run ~sw agent "overflow" |> check_context_fit_overflow)
+  in
+  check (list string) "fresh request paths" [ "/v1/messages/count_tokens" ] paths
+
+let test_runtime_agent_resume_enforces_native_context_fit () =
+  let (), paths =
+    with_native_count_server
+    @@ fun ~sw ~net ~base_url ->
+    let config = context_fit_runtime_config base_url in
+    let agent =
+      match
+        Runtime_agent.resume_from_checkpoint
+          ~sw
+          ~net
+          ~config
+          ~checkpoint:(context_fit_checkpoint ())
+      with
+      | Ok agent -> agent
+      | Error error -> fail (Agent_sdk.Error.to_string error)
+    in
+    Fun.protect
+      ~finally:(fun () -> Agent_sdk.Agent.close agent)
+      (fun () -> Agent_sdk.Agent.run ~sw agent "overflow" |> check_context_fit_overflow)
+  in
+  check (list string) "resumed request paths" [ "/v1/messages/count_tokens" ] paths
+
 (* RFC-OAS-026 §4.6: a configured stream-idle deadline with no resolvable clock
    must fail loudly rather than silently disarm the only I2-legitimate
    streaming timeout. *)
@@ -1612,6 +1751,14 @@ let () =
             "runtime agent context leaves tool_choice unset with tools"
             `Quick
             test_runtime_agent_context_leaves_tool_choice_unset_with_tools
+        ; test_case
+            "runtime fresh build enforces native context fit"
+            `Quick
+            test_runtime_agent_fresh_build_enforces_native_context_fit
+        ; test_case
+            "runtime resume enforces native context fit"
+            `Quick
+            test_runtime_agent_resume_enforces_native_context_fit
         ; test_case
             "dashboard runtime provider reachability contracts"
             `Quick


### PR DESCRIPTION
## Outcome

Fresh and resumed Runtime_agent instances now opt into OAS provider-native context-fit admission. Supported providers measure the exact prepared request and return typed ContextOverflow before completion dispatch; unsupported providers retain compatibility behavior.

Part of #25294
Depends on jeong-sik/oas#2705 for Kimi native count support and a subsequent agent_sdk pin.

## Mechanism

- Runtime_agent_context owns one Enforce_when_supported policy value.
- Fresh builders apply it through Builder.with_context_fit_admission.
- prepare_resume carries the same typed value and Runtime_agent.resume_from_checkpoint passes it explicitly to Agent.resume.
- Existing Keeper ContextOverflow FSM remains the sole compaction/recovery mechanism; no estimate, threshold, margin, model-name match, or provider prose parser was added.

## Counterfactual regression

A loopback Anthropic-compatible Messages server returns input_tokens=500 while max_context=512 and reserved output=64.

- fresh Runtime_agent.build -> typed ContextOverflow; observed paths are exactly [/v1/messages/count_tokens]
- resumed checkpoint -> typed ContextOverflow; observed paths are exactly [/v1/messages/count_tokens]
- any completion dispatch produces an HTTP 500 and fails the test

## Validation

- ocamlformat --check: pass
- git diff --check: pass
- Focused local build was refused by the repo wrapper because another session was running bare Dune outside the machine-wide lock. No lock bypass or process termination was used; Draft CI is the compile/test authority for this push.

## Deployment dependency

This PR is safe to merge before the OAS update because Enforce_when_supported is capability-gated. It does not fix live Kimi overflow until:

1. OAS #2705 is merged and released.
2. MASC pins that agent_sdk release.
3. Kimi runtime uses the registered messages-http provider at https://api.kimi.com/coding.

RFC-WAIVED: typed runtime policy wiring and focused transport-boundary tests only; no credential schema, operator control, sandbox, identity, hook, or workflow contract changes.