### PR TITLE
refactor(keeper): extract last_compaction_decision null-guard to SSOT helper (#25323)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -922,11 +922,8 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                  keeper_status.ml does, so keeper-store-normalize.ts reads a
                  populated last_compaction_decision instead of null. *)
               ( "last_compaction_decision",
-                let decision =
-                  Keeper_meta_contract.compaction_runtime_decision_to_string
-                    m.runtime.compaction_rt.last_decision
-                in
-                if String.trim decision = "" then `Null else `String decision );
+                Keeper_meta_contract.compaction_decision_json_or_null
+                  m.runtime.compaction_rt.last_decision );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -29,6 +29,16 @@ type compaction_runtime_decision = Compaction_runtime_decision of string
 let compaction_runtime_decision_to_string (Compaction_runtime_decision value) = value
 let compaction_runtime_decision_of_string value = Compaction_runtime_decision value
 
+(* SSOT for the API/dashboard projection of [last_compaction_decision]: the
+   decision string, or [`Null] when empty. keeper_status.ml and
+   dashboard_http_keeper.ml share this null-guard so the policy is defined once
+   (previously copied verbatim across both — issue #25323). keeper_meta_json.ml
+   serializes the raw string for its own on-disk representation and does not use
+   this guard. *)
+let compaction_decision_json_or_null decision : Yojson.Safe.t =
+  let s = compaction_runtime_decision_to_string decision in
+  if String.trim s = "" then `Null else `String s
+
 type compaction_runtime =
   { count : int
   ; last_ts : float

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -48,6 +48,14 @@ val compaction_runtime_decision_to_string :
 val compaction_runtime_decision_of_string :
   string -> compaction_runtime_decision
 
+val compaction_decision_json_or_null :
+  compaction_runtime_decision -> Yojson.Safe.t
+(** API/dashboard projection of [last_compaction_decision]: the decision
+    string, or [`Null] when empty. Shared by keeper_status.ml and
+    dashboard_http_keeper.ml so the null-guard policy has one definition
+    (issue #25323). Not used by keeper_meta_json.ml, whose on-disk
+    representation serializes the raw string. *)
+
 type compaction_runtime = {
   count : int;
   last_ts : float;

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -166,11 +166,7 @@ let handle_keeper_list ctx args : tool_result =
               ("proactive_visible_count_total", `Int m.runtime.proactive_rt.visible_count_total);
               ("last_compaction_check_ts", `Float m.runtime.compaction_rt.last_check_ts);
               ( "last_compaction_decision",
-                let decision =
-                  compaction_runtime_decision_to_string
-                    m.runtime.compaction_rt.last_decision
-                in
-                if String.trim decision = "" then `Null else `String decision );
+                compaction_decision_json_or_null m.runtime.compaction_rt.last_decision );
               ("last_proactive_ts", `Float m.runtime.proactive_rt.last_ts);
               ("last_visible_proactive_ts", `Float m.runtime.proactive_rt.last_visible_ts);
               ("last_visible_proactive_ago_s", `Float last_visible_proactive_ago_s);

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -87,10 +87,57 @@ let test_nonempty_live_meta_still_reports_profile_override () =
     (Keeper_status_bridge.live_override_fields meta defaults_with_prompt_fields)
 ;;
 
+(* SSOT: last_compaction_decision null-guard policy (issue #25323). Extracted to
+   Keeper_meta_contract.compaction_decision_json_or_null and reused by
+   keeper_status.ml / dashboard_http_keeper.ml. Pin the policy so the guard can't
+   silently diverge across projection sites again. Counterfactual: dropping the
+   [String.trim = ""] guard turns the empty/whitespace cases red. *)
+let test_compaction_decision_empty_is_null () =
+  let d = Keeper_meta_contract.compaction_runtime_decision_of_string "" in
+  Alcotest.(check bool)
+    "empty decision serializes to `Null"
+    true
+    (Keeper_meta_contract.compaction_decision_json_or_null d = `Null)
+;;
+
+let test_compaction_decision_whitespace_is_null () =
+  let d = Keeper_meta_contract.compaction_runtime_decision_of_string "   " in
+  Alcotest.(check bool)
+    "whitespace-only decision serializes to `Null"
+    true
+    (Keeper_meta_contract.compaction_decision_json_or_null d = `Null)
+;;
+
+let test_compaction_decision_value_is_string () =
+  let d =
+    Keeper_meta_contract.compaction_runtime_decision_of_string "provider_overflow"
+  in
+  Alcotest.(check bool)
+    "non-empty decision serializes to `String"
+    true
+    (Keeper_meta_contract.compaction_decision_json_or_null d
+     = `String "provider_overflow")
+;;
+
 let () =
   Alcotest.run
     "keeper_status_bridge"
     [
+      ( "last_compaction_decision null-guard SSOT",
+        [
+          Alcotest.test_case
+            "empty decision -> `Null"
+            `Quick
+            test_compaction_decision_empty_is_null;
+          Alcotest.test_case
+            "whitespace decision -> `Null"
+            `Quick
+            test_compaction_decision_whitespace_is_null;
+          Alcotest.test_case
+            "value decision -> `String"
+            `Quick
+            test_compaction_decision_value_is_string;
+        ] );
       ( "profile default override provenance",
         [
           Alcotest.test_case


### PR DESCRIPTION
## 요약
`last_compaction_decision`의 JSON 직렬화 null-guard가 `keeper_status.ml`과 `dashboard_http_keeper.ml`에 **verbatim 복제**된 SSOT 위반(issue #25323)을 수정한다. dashboard 사본은 PR #25313(관찰성 완결)이 추가했다.

## 변경
- **`Keeper_meta_contract.compaction_decision_json_or_null`** helper 신설(타입·`to_string` 소유 모듈): decision → `` `String ``, 빈/공백 → `` `Null ``. null-guard 정책의 SSOT.
- `keeper_status.ml` / `dashboard_http_keeper.ml`: verbatim 블록 → helper 호출.
- `test_keeper_status_bridge.ml`: 정책 pin(empty/whitespace → `` `Null ``, value → `` `String ``). counterfactual: `String.trim = ""` guard 제거 시 empty 케이스 red.

## 통일하지 않은 것 (의도)
`keeper_meta_json.ml`은 raw-string on-disk 직렬화를 유지한다. `of_json`이 `last_compaction_decision`을 역직렬화하지 않아(round-trip 아님) durable 표현이 API의 null-guard와 **의미상 다르다**. 억지 통일은 durable 표현을 바꾸는 회귀가 되므로 남긴다. 실제 중복(status↔dashboard)만 추출.

## 검증
- 로컬 빌드 성공(`dune build --root .`), `test_keeper_status_bridge` 5 tests green(신규 3 + 기존 2).
- Behavior-preserving 리팩터 — 동작 불변, 회귀 위험 낮음.

Closes #25323. 발견: 세션 SSOT 적대 감사(2026-07-19), #25313 리뷰가 관찰성 렌즈로만 봐서 놓친 duplicated-logic.
