### PR TITLE
feat(fusion): render typed authority failures

### DIFF
--- a/lib/fusion_core/fusion_run_authority.ml
+++ b/lib/fusion_core/fusion_run_authority.ml
@@ -47,6 +47,31 @@ type error =
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
+
+let error_to_string = function
+  | Empty_keeper -> "keeper identity is empty"
+  | Empty_run_id -> "run identity is empty"
+  | Invalid_started_at value -> Printf.sprintf "started_at is not finite: %g" value
+  | Empty_abort_detail -> "abort detail is empty"
+  | Empty_cancellation_detail -> "cancellation detail is empty"
+  | Partial_tail -> "authority journal has a partial tail"
+  | Unsupported_schema_version { line; found } ->
+    Printf.sprintf "authority journal line %d has unsupported schema version %d" line found
+  | Invalid_record { line; detail } ->
+    Printf.sprintf "authority journal line %d is invalid: %s" line detail
+  | Empty_authority_record -> "authority journal is empty"
+  | Evidence_question_mismatch { expected; found } ->
+    Printf.sprintf "authority evidence question mismatch: expected=%S found=%S" expected found
+  | Invalid_transition { event_index; state; event } ->
+    Printf.sprintf "authority event %d cannot apply %s to %s"
+      event_index (show_event_kind event) (show_state_kind state)
+  | Identity_mismatch identity ->
+    Printf.sprintf "authority identity mismatch: %s" (show_identity identity)
+  | Registration_conflict registration ->
+    Printf.sprintf "authority registration conflict: %s" (show_registration registration)
+  | Durable_append_failed error -> Fs_compat.durable_append_error_to_string error
+;;
+
 type register_outcome =
   | Registered
   | Already_registered of recovered_run

--- a/lib/fusion_core/fusion_run_authority.mli
+++ b/lib/fusion_core/fusion_run_authority.mli
@@ -34,6 +34,7 @@ type error =
   | Identity_mismatch of identity
   | Registration_conflict of registration
   | Durable_append_failed of Fs_compat.durable_append_error
+val error_to_string : error -> string
 type register_outcome =
   | Registered
   | Already_registered of recovered_run

--- a/test/test_fusion_run_authority.ml
+++ b/test/test_fusion_run_authority.ml
@@ -286,6 +286,18 @@ let test_restart_scan_preserves_valid_peers_and_corruption () =
          | A.Registered_run _ | A.Stopped_without_computation_run _ -> false)
        valid_runs)
 ;;
+
+let test_typed_errors_keep_transition_evidence () =
+  check string "prompt mismatch evidence"
+    "authority evidence question mismatch: expected=\"q\" found=\"other\""
+    (A.error_to_string (A.Evidence_question_mismatch { expected = "q"; found = "other" }));
+  check string "transition evidence"
+    "authority event 7 cannot apply Computation_event to Empty_state"
+    (A.error_to_string
+       (A.Invalid_transition
+          { event_index = 7; state = A.Empty_state; event = A.Computation_event }))
+;;
+
 let () =
   run "fusion_run_authority"
     [ ( "authority"
@@ -295,6 +307,8 @@ let () =
             test_corruption_is_per_run_and_semantic
         ; test_case "restart scan preserves valid peers and corruption" `Quick
             test_restart_scan_preserves_valid_peers_and_corruption
+        ; test_case "typed errors retain transition evidence" `Quick
+            test_typed_errors_keep_transition_evidence
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- render every typed Fusion authority failure without reparsing journal text
- retain event index, typed state, and typed event in invalid-transition output
- surface prompt/evidence mismatches and durable append failures explicitly
- pin prompt-mismatch and invalid-transition rendering in a focused test

## Stack

- base: #25329
- next: #25319 consumes this error surface at the Keeper tool boundary

## Validation

- 40 changed lines against the stacked base
- OCaml parse checks for implementation and interface
- `ocamlformat --check`
- `git diff --check`
