### PR TITLE
refactor(keeper): carry settlement identity canonically

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -214,11 +214,14 @@ type settlement_origin =
 
 type worker_settlement =
   | Status_settlement of
-      { status : request_status
+      { entry : entry
       ; durability : settlement_durability
       ; origin : settlement_origin
       }
-  | Settlement_projection_error of { poll_result : load_result }
+  | Settlement_projection_error of
+      { attempted_entry : entry
+      ; poll_result : load_result
+      }
 
 module Request_key = struct
   type t =
@@ -524,7 +527,7 @@ let with_keeper_persistence_lock ~base_path ~keeper_name f =
 
 exception CancelledByOperator
 exception Worker_preempted of string
-exception Worker_already_settled of request_status
+exception Worker_already_settled of entry
 let record_schema_version = 3
 
 let server_background_switch () =
@@ -1994,11 +1997,11 @@ let project_canonical_integrity_failure_locked ~ops key transition_lock
   match poll_result with
   | Found canonical when is_terminal_status canonical.status ->
     Status_settlement
-      { status = canonical.status
+      { entry = canonical
       ; durability = Durable
       ; origin = Canonical_reconciliation
       }
-  | poll_result -> Settlement_projection_error { poll_result }
+  | poll_result -> Settlement_projection_error { attempted_entry; poll_result }
 ;;
 
 let persist_failure_locked ~ops key transition_lock (attempted_entry : entry) reason =
@@ -2017,14 +2020,14 @@ let persist_failure_locked ~ops key transition_lock (attempted_entry : entry) re
   | Ok () ->
     remove_runtime_if_owned key transition_lock;
     Status_settlement
-      { status = failure_entry.status
+      { entry = failure_entry
       ; durability = Durable
       ; origin = Transition_commit
       }
   | Error (Write_failed (Published_uncertain _)) ->
     publish_if_owned key transition_lock failure_entry;
     Status_settlement
-      { status = failure_entry.status
+      { entry = failure_entry
       ; durability = Volatile_persistence_failure
       ; origin = Transition_commit
       }
@@ -2035,7 +2038,7 @@ let persist_failure_locked ~ops key transition_lock (attempted_entry : entry) re
        row to typed [Lost]. *)
     publish_if_owned key transition_lock failure_entry;
     Status_settlement
-      { status = failure_entry.status
+      { entry = failure_entry
       ; durability = Volatile_persistence_failure
       ; origin = Transition_commit
       }
@@ -2089,7 +2092,7 @@ let set_status ~ops ?(preserve_terminal = false) key status =
            else publish_if_owned key transition_lock updated;
            Some
              (Status_settlement
-                { status = updated.status
+                { entry = updated
                 ; durability = Durable
                 ; origin = Transition_commit
                 })
@@ -2101,7 +2104,7 @@ let set_status ~ops ?(preserve_terminal = false) key status =
            publish_if_owned key transition_lock updated;
            Some
              (Status_settlement
-                { status = updated.status
+                { entry = updated
                 ; durability = Volatile_persistence_failure
                 ; origin = Transition_commit
                 })
@@ -2283,7 +2286,8 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
                     "keeper_msg_async: on_worker_settled callback failed request_id=%s status=%s error=%s"
                     request_id
                     (match settlement with
-                     | Status_settlement { status; _ } -> status_to_string status
+                     | Status_settlement { entry; _ } ->
+                       status_to_string entry.status
                      | Settlement_projection_error _ -> "projection_error")
                     (Printexc.to_string exn))
           in
@@ -2323,8 +2327,8 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
       set_status_protected ~ops ~preserve_terminal:true key Running
     in
     match running_settlement with
-    | Some (Status_settlement { status; _ } as settlement)
-      when is_terminal_status status ->
+    | Some (Status_settlement { entry; _ } as settlement)
+      when is_terminal_status entry.status ->
       (* A failed Running write can durably commit its Persistence_failed
          marker and remove the runtime row. Project that exact settlement
          before stopping: falling through to worker admission would
@@ -2353,18 +2357,17 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
               | Some { status = Queued | Running; _ } -> `Run
               | Some { status = Cancelling _; _ } -> `Operator_cancelled
               | Some
-                  { status =
-                      ((Done _ | Lost _ | Cancelled _ | Persistence_failed _) as
-                       status)
-                  ; _
-                  } ->
-                `Already_settled status
+                  ({ status =
+                       (Done _ | Lost _ | Cancelled _ | Persistence_failed _)
+                   ; _
+                   } as entry) ->
+                `Already_settled entry
               | None -> `Preempted "keeper_msg request disappeared before worker start")
           in
           (match admission with
            | `Run -> ()
            | `Operator_cancelled -> raise CancelledByOperator
-           | `Already_settled status -> raise (Worker_already_settled status)
+           | `Already_settled entry -> raise (Worker_already_settled entry)
            | `Preempted reason -> raise (Worker_preempted reason));
           let result = f req_sw in
           let data =
@@ -2399,15 +2402,15 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
               (Worker_cancelled { cancelled_by = Runtime_cancellation; reason })
             |> Option.iter notify_settled);
         runtime_cancelled_status ()
-      | Worker_already_settled status ->
+      | Worker_already_settled entry ->
         clear_active_switch key;
         notify_settled
           (Status_settlement
-             { status
+             { entry
              ; durability = Volatile_persistence_failure
              ; origin = Transition_commit
              });
-        status
+        entry.status
       | Eio.Cancel.Cancelled _ as e ->
         (* [notify_aborted] observes callback exceptions without letting one
            request fail the server root switch. The switch-table release must

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -234,11 +234,14 @@ type settlement_origin =
 
 type worker_settlement =
   | Status_settlement of
-      { status : request_status
+      { entry : entry
       ; durability : settlement_durability
       ; origin : settlement_origin
       }
-  | Settlement_projection_error of { poll_result : load_result }
+  | Settlement_projection_error of
+      { attempted_entry : entry
+      ; poll_result : load_result
+      }
 
 (** {1 Submit and poll} *)
 
@@ -281,12 +284,15 @@ val server_background_switch : unit -> (Eio.Switch.t, submit_error) result
     root switch.
 
     [on_worker_settled] is invoked only for terminal truth that exact in-process
-    poll also returns: a durably committed status, a typed volatile persistence
+    poll also returns: a durably committed entry, a typed volatile persistence
     overlay, or an already-existing canonical durable terminal discovered
-    during an integrity conflict. Ambiguous durable evidence has no fabricated
-    callback projection. It is the single projection boundary for SSE or other
-    live terminal notifications. Projection exceptions are observed and
-    isolated from request truth. *)
+    during an integrity conflict. The settlement carries that exact immutable
+    entry, so a projector never has to recover request, Keeper, BasePath, or
+    owner identity from an ambient mutable closure. Ambiguous durable evidence
+    carries the attempted entry beside the exact canonical lookup result; it
+    has no fabricated callback status. This is the single projection boundary
+    for SSE or other live terminal notifications. Projection exceptions are
+    observed and isolated from request truth. *)
 val submit
   :  ?on_accepted:(string -> (unit, string) result)
   -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1276,7 +1276,7 @@ let completion_of_worker_settlement ~queued_turn ~staged_completion
     if queued_turn then Some (Failed { kind; detail }) else None
   in
   match settlement with
-  | Keeper_msg_async.Settlement_projection_error { poll_result } ->
+  | Keeper_msg_async.Settlement_projection_error { poll_result; _ } ->
     let body =
       match poll_result with
       | Keeper_msg_async.Unreadable reason -> reason
@@ -1296,7 +1296,8 @@ let completion_of_worker_settlement ~queued_turn ~staged_completion
          ; body
          ; queued_outcome = queued_failure Transcript_persist_failed body
          })
-  | Keeper_msg_async.Status_settlement { status; durability; origin } ->
+  | Keeper_msg_async.Status_settlement { entry; durability; origin } ->
+    let status = entry.Keeper_msg_async.status in
     (match durability, origin, status with
      | Keeper_msg_async.Volatile_persistence_failure, _, _ ->
        let body =
@@ -1584,8 +1585,8 @@ let process_single_turn ~user_row_origin ~queued_turn
     | None ->
       let status =
         match settlement with
-        | Keeper_msg_async.Status_settlement { status; _ } ->
-          Keeper_msg_async.status_to_string status
+        | Keeper_msg_async.Status_settlement { entry; _ } ->
+          Keeper_msg_async.status_to_string entry.status
         | Keeper_msg_async.Settlement_projection_error _ -> "projection_error"
       in
       Log.Keeper.error

--- a/test/test_keeper_chat_direct_delivery.ml
+++ b/test/test_keeper_chat_direct_delivery.ml
@@ -443,7 +443,7 @@ let await_settlement ~ops ~background_sw ~base_path ~request_id =
 
 let expect_durable_done = function
   | Keeper_msg_async.Status_settlement
-      { status = Keeper_msg_async.Done _
+      { entry = { status = Keeper_msg_async.Done _; _ }
       ; durability = Keeper_msg_async.Durable
       ; _
       } -> ()
@@ -548,7 +548,7 @@ let test_startup_checkpoint_rejects_volatile_poll_terminal _env =
       in
       (match settlement with
        | Keeper_msg_async.Status_settlement
-           { status = Keeper_msg_async.Done _
+           { entry = { status = Keeper_msg_async.Done _; _ }
            ; durability = Keeper_msg_async.Volatile_persistence_failure
            ; _
            } -> ()

--- a/test/test_keeper_msg_async_durable_active_inventory.ml
+++ b/test/test_keeper_msg_async_durable_active_inventory.ml
@@ -94,7 +94,7 @@ let test_reports_terminal_residue () =
     in
     (match Eio.Promise.await settled with
      | Async.Status_settlement
-         { status = Async.Done _
+         { entry = { status = Async.Done _; _ }
          ; durability = Async.Durable
          ; origin = Async.Transition_commit
          } ->

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -133,16 +133,28 @@ let test_operator_cancel_running_worker_invokes_on_worker_aborted () =
              (List.length reasons)));
         (match !settled with
          | [ Keeper_msg_async.Status_settlement
-               { status = Keeper_msg_async.Cancelled _
+               { entry
                ; durability = Keeper_msg_async.Durable
                ; origin = Keeper_msg_async.Transition_commit
                }
            ] ->
-           ()
-         | [ Keeper_msg_async.Status_settlement { status; _ } ] ->
+           (match entry.status with
+            | Keeper_msg_async.Cancelled _ -> ()
+            | status ->
+              failf
+                "unexpected settlement status=%s"
+                (Keeper_msg_async.status_to_string status));
+           check string "settlement carries request identity" request_id entry.request_id;
+           check string
+             "settlement carries Keeper identity"
+             "terminal-event-operator-cancel"
+             entry.keeper_name;
+           check string "settlement carries BasePath identity" base_path entry.base_path;
+           check string "settlement carries owner identity" caller entry.submitted_by
+         | [ Keeper_msg_async.Status_settlement { entry; _ } ] ->
            failf
              "unexpected settlement status=%s"
-             (Keeper_msg_async.status_to_string status)
+             (Keeper_msg_async.status_to_string entry.status)
          | [ Keeper_msg_async.Settlement_projection_error _ ] ->
            fail "unexpected settlement projection error"
          | settlements ->

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -756,15 +756,15 @@ let test_keeper_msg_async_running_write_failure_projects_durable_marker_once () 
          (List.length !aborts);
        (match !settlements with
         | [ Keeper_msg_async.Status_settlement
-              { status = Persistence_failed _
+              { entry = { status = Persistence_failed _; _ }
               ; durability = Keeper_msg_async.Durable
               ; origin = Keeper_msg_async.Transition_commit
               }
           ] ->
           ()
-        | [ Keeper_msg_async.Status_settlement { status; _ } ] ->
+        | [ Keeper_msg_async.Status_settlement { entry; _ } ] ->
           Alcotest.failf "unexpected settlement status=%s"
-            (Keeper_msg_async.status_to_string status)
+            (Keeper_msg_async.status_to_string entry.status)
         | [ Keeper_msg_async.Settlement_projection_error _ ] ->
           Alcotest.fail "unexpected settlement projection error"
         | settlements ->
@@ -1566,16 +1566,16 @@ let test_keeper_msg_async_integrity_conflict_projects_canonical_terminal () =
        let callback_body =
          match !settlements with
          | [ Keeper_msg_async.Status_settlement
-               { status = Done { ok = true; body; _ }
+               { entry = { status = Done { ok = true; body; _ }; _ }
                ; durability = Keeper_msg_async.Durable
                ; origin = Keeper_msg_async.Canonical_reconciliation
                }
            ] ->
            body
-         | [ Keeper_msg_async.Status_settlement { status; _ } ] ->
+         | [ Keeper_msg_async.Status_settlement { entry; _ } ] ->
            Alcotest.failf
              "integrity conflict fabricated callback status=%s"
-             (Keeper_msg_async.status_to_string status)
+             (Keeper_msg_async.status_to_string entry.status)
          | [ Keeper_msg_async.Settlement_projection_error _ ] ->
            Alcotest.fail "canonical terminal projected an integrity error"
          | settlements ->
@@ -1603,10 +1603,20 @@ let test_keeper_stream_canonical_settlement_ignores_staged_worker_result () =
       { ok = true; body = "canonical-disk"; data = None }
   in
   let project origin =
+    let entry : Keeper_msg_async.entry =
+      { request_id = "canonical-settlement"
+      ; keeper_name = "keeper"
+      ; base_path = Filename.concat (Filename.get_temp_dir_name ()) "canonical-settlement"
+      ; submitted_by = "owner"
+      ; status
+      ; submitted_at = 0.
+      ; completed_at = Some 0.
+      }
+    in
     Server_routes_http_keeper_stream.For_testing.worker_settlement_terminal_body
       ~staged_body:(Some "staged-worker")
       (Keeper_msg_async.Status_settlement
-         { status; durability = Keeper_msg_async.Durable; origin })
+         { entry; durability = Keeper_msg_async.Durable; origin })
   in
   Alcotest.(check (option string))
     "canonical reconciliation uses disk body"
@@ -1668,16 +1678,18 @@ let test_keeper_msg_async_integrity_ambiguity_projects_exact_poll_error () =
          | [] -> Alcotest.fail "integrity projection error callback was dropped"
        in
        await_settlement 100;
-       let callback_reason =
+       let callback_reason, attempted_entry =
          match !settlements with
          | [ Keeper_msg_async.Settlement_projection_error
-               { poll_result = Keeper_msg_async.Unreadable reason }
+               { attempted_entry
+               ; poll_result = Keeper_msg_async.Unreadable reason
+               }
            ] ->
-           reason
-         | [ Keeper_msg_async.Status_settlement { status; _ } ] ->
+           reason, attempted_entry
+         | [ Keeper_msg_async.Status_settlement { entry; _ } ] ->
            Alcotest.failf
              "ambiguous evidence fabricated status=%s"
-             (Keeper_msg_async.status_to_string status)
+             (Keeper_msg_async.status_to_string entry.status)
          | [ Keeper_msg_async.Settlement_projection_error _ ] ->
            Alcotest.fail "ambiguous evidence projected the wrong load result"
          | settlements ->
@@ -1685,6 +1697,22 @@ let test_keeper_msg_async_integrity_ambiguity_projects_exact_poll_error () =
              "integrity projection callback count=%d"
              (List.length settlements)
        in
+       Alcotest.(check string)
+         "projection error carries request identity"
+         request_id
+         attempted_entry.request_id;
+       Alcotest.(check string)
+         "projection error carries Keeper identity"
+         "integrity-projection-error"
+         attempted_entry.keeper_name;
+       Alcotest.(check string)
+         "projection error carries BasePath identity"
+         base_path
+         attempted_entry.base_path;
+       Alcotest.(check string)
+         "projection error carries owner identity"
+         caller
+         attempted_entry.submitted_by;
        match Keeper_msg_async.poll ~base_path ~caller request_id with
        | Keeper_msg_async.Unreadable reason ->
          Alcotest.(check string) "callback carries exact poll error" reason


### PR DESCRIPTION
## Summary

- replace the status-only worker settlement projection with the exact immutable canonical request entry
- carry the attempted entry beside ambiguous canonical lookup evidence
- remove the need for durable projectors to recover request, Keeper, BasePath, or owner identity from mutable callback closures
- update every production consumer and focused lifecycle test

## Why

`Keeper_msg_async` is the existing durable background execution SSOT. A generic Job/Fusion projector must receive the exact terminal identity from that owner; status-only callbacks force a parallel identity channel and can misattribute completion after retries or reconciliation.

This PR changes no provider admission, timeout, retry cap, or Keeper pause policy.

## Validation

- `ocamlc -stop-after parsing` on all changed OCaml files
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- focused Dune targets were queued through `scripts/dune-local.sh` but did not start because another legitimate machine-wide build held the shared lock; Draft CI is the build authority

## Stack direction

This is the first recut leaf for G7. Fusion should consume this common settlement identity instead of adding another generic lifecycle to `Fusion_run_authority`.

[근거] `git diff --check`, `ocamlc -stop-after parsing`, `ocamlformat --check`, and machine-wide Dune lock observation; 2026-07-20 KST; 신뢰도 High.