### PR TITLE
refactor(compaction): capture committed projection target

### DIFF
--- a/lib/keeper/keeper_compaction_projection_target.ml
+++ b/lib/keeper/keeper_compaction_projection_target.ml
@@ -1,0 +1,156 @@
+type context_window_resolution =
+  | Resolved_context_window of int
+  | Context_window_not_resolved
+  | Invalid_context_window of int
+
+type request =
+  { assignment_id : string
+  ; resolve_context_window : Runtime.t -> context_window_resolution
+  }
+
+let request ~assignment_id ~resolve_context_window =
+  { assignment_id; resolve_context_window }
+;;
+
+type unavailable =
+  | Empty_assignment
+  | Assignment_ambiguous of { assignment_id : string }
+  | Runtime_unavailable of { runtime_id : string }
+  | Context_window_unavailable of { runtime_id : string }
+  | Invalid_effective_context_window of
+      { runtime_id : string
+      ; effective_max_context : int
+      }
+
+type exact =
+  { runtime_id : string
+  ; provider_id : string
+  ; protocol : string
+  ; oas_provider_kind : string
+  ; model_id : string
+  ; effective_max_context : int
+  }
+
+type evidence =
+  | Exact of exact
+  | Unavailable of unavailable
+
+let unavailable_to_json = function
+  | Empty_assignment -> `Assoc [ "reason", `String "empty_assignment" ]
+  | Assignment_ambiguous { assignment_id } ->
+    `Assoc
+      [ "reason", `String "assignment_ambiguous"
+      ; "assignment_id", `String assignment_id
+      ]
+  | Runtime_unavailable { runtime_id } ->
+    `Assoc
+      [ "reason", `String "runtime_unavailable"
+      ; "runtime_id", `String runtime_id
+      ]
+  | Context_window_unavailable { runtime_id } ->
+    `Assoc
+      [ "reason", `String "context_window_unavailable"
+      ; "runtime_id", `String runtime_id
+      ]
+  | Invalid_effective_context_window { runtime_id; effective_max_context } ->
+    `Assoc
+      [ "reason", `String "invalid_effective_context_window"
+      ; "runtime_id", `String runtime_id
+      ; "effective_max_context", `Int effective_max_context
+      ]
+;;
+
+let evidence_to_json = function
+  | Exact
+      { runtime_id
+      ; provider_id
+      ; protocol
+      ; oas_provider_kind
+      ; model_id
+      ; effective_max_context
+      } ->
+    `Assoc
+      [ "kind", `String "exact"
+      ; "runtime_id", `String runtime_id
+      ; "provider_id", `String provider_id
+      ; "protocol", `String protocol
+      ; "oas_provider_kind", `String oas_provider_kind
+      ; "model_id", `String model_id
+      ; "effective_max_context", `Int effective_max_context
+      ]
+  | Unavailable reason ->
+    `Assoc
+      [ "kind", `String "unavailable"
+      ; "detail", unavailable_to_json reason
+      ]
+;;
+
+type exact_target =
+  { evidence : exact
+  ; provider_config : Llm_provider.Provider_config.t
+  }
+[@@warning "-69"]
+
+type t =
+  | Exact_target of exact_target
+  | Unavailable_target of unavailable
+
+let captured_evidence = function
+  | Exact_target target -> Exact target.evidence
+  | Unavailable_target reason -> Unavailable reason
+;;
+
+let capture_exact effective_max_context (runtime : Runtime.t) =
+  if effective_max_context <= 0
+  then
+    Unavailable_target
+      (Invalid_effective_context_window
+         { runtime_id = runtime.id; effective_max_context })
+  else
+    let provider_config =
+      { runtime.provider_config with max_context = Some effective_max_context }
+    in
+    Exact_target
+      { evidence =
+          { runtime_id = runtime.id
+          ; provider_id = runtime.provider.id
+          ; protocol = runtime.provider.protocol
+          ; oas_provider_kind =
+              Llm_provider.Provider_config.string_of_provider_kind
+                provider_config.kind
+          ; model_id = provider_config.model_id
+          ; effective_max_context
+          }
+      ; provider_config
+      }
+;;
+
+let capture { assignment_id; resolve_context_window } =
+  if String.equal assignment_id ""
+  then Unavailable_target Empty_assignment
+  else
+    match Runtime.resolve_assignment assignment_id with
+    | `Lane _ -> Unavailable_target (Assignment_ambiguous { assignment_id })
+    | `Missing ->
+      Unavailable_target (Runtime_unavailable { runtime_id = assignment_id })
+    | `Single_runtime runtime ->
+      (match resolve_context_window runtime with
+       | Resolved_context_window effective_max_context ->
+         capture_exact effective_max_context runtime
+       | Context_window_not_resolved ->
+         Unavailable_target
+           (Context_window_unavailable { runtime_id = runtime.id })
+       | Invalid_context_window effective_max_context ->
+         Unavailable_target
+           (Invalid_effective_context_window
+              { runtime_id = runtime.id; effective_max_context }))
+;;
+
+type committed =
+  { target : t
+  ; checkpoint_ref : Keeper_checkpoint_ref.t
+  }
+
+let bind_committed_checkpoint checkpoint_ref target = { target; checkpoint_ref }
+let committed_evidence committed = captured_evidence committed.target
+let checkpoint_ref committed = committed.checkpoint_ref

--- a/lib/keeper/keeper_compaction_projection_target.mli
+++ b/lib/keeper/keeper_compaction_projection_target.mli
@@ -1,0 +1,65 @@
+(** Immutable provider/model target for measuring a committed compaction.
+
+    The opaque value captures the materialized provider configuration exactly
+    once, before compaction planning starts.  Public evidence is a distinct
+    credential-free type, so an API key, endpoint, or header cannot be
+    serialized through this module. *)
+
+type context_window_resolution =
+  | Resolved_context_window of int
+  | Context_window_not_resolved
+  | Invalid_context_window of int
+
+type request
+
+(** Build a prepare-time capture request. [assignment_id] is preserved byte for
+    byte. [resolve_context_window] receives the same immutable [Runtime.t]
+    snapshot that will supply the provider configuration. *)
+val request :
+  assignment_id:string ->
+  resolve_context_window:(Runtime.t -> context_window_resolution) ->
+  request
+
+type unavailable =
+  | Empty_assignment
+  | Assignment_ambiguous of { assignment_id : string }
+  | Runtime_unavailable of { runtime_id : string }
+  | Context_window_unavailable of { runtime_id : string }
+  | Invalid_effective_context_window of
+      { runtime_id : string
+      ; effective_max_context : int
+      }
+
+type exact =
+  { runtime_id : string
+  ; provider_id : string
+  ; protocol : string
+  ; oas_provider_kind : string
+  ; model_id : string
+  ; effective_max_context : int
+  }
+
+type evidence =
+  | Exact of exact
+  | Unavailable of unavailable
+
+val evidence_to_json : evidence -> Yojson.Safe.t
+
+type t
+
+(** Resolve and snapshot one runtime assignment.  A lane is deliberately
+    [Unavailable]: choosing one of its candidates here would guess which
+    provider actually handled the turn. *)
+val capture : request -> t
+
+val captured_evidence : t -> evidence
+
+type committed
+
+(** Bind the captured target to the exact SHA-bearing checkpoint reference
+    returned by the successful source CAS. This is pure and performs no
+    observation or I/O. *)
+val bind_committed_checkpoint : Keeper_checkpoint_ref.t -> t -> committed
+
+val committed_evidence : committed -> evidence
+val checkpoint_ref : committed -> Keeper_checkpoint_ref.t

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -93,6 +93,7 @@ type compaction_recovery = Keeper_post_turn.compaction_recovery = {
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
+  projection_target : Keeper_compaction_projection_target.committed;
 }
 
 type max_context_resolution = {
@@ -341,33 +342,41 @@ let resolve_max_context_resolution ~requested_override (labels : string list)
   ; effective_budget
   }
 
-let resolve_max_context_resolution_for_runtime_id
+let resolve_max_context_resolution_for_runtime
       ~requested_override
-      ~runtime_id
+      (runtime : Runtime.t)
   =
   match requested_override with
   | Some requested when requested <= 0 ->
     Error (Invalid_requested_context_override requested)
   | Some _ | None ->
-    (match Runtime.get_runtime_by_id runtime_id with
-     | None -> Error (Runtime_context_window_unavailable { runtime_id })
-     | Some runtime ->
-       (match Runtime.resolve_max_context_of_runtime runtime with
-        | None -> Error (Runtime_context_window_unavailable { runtime_id })
-        | Some (runtime_budget, _) ->
-          let requested_context_window =
-            match requested_override with
-            | None -> runtime_budget
-            | Some requested -> requested
-          in
-          let effective_budget = min requested_context_window runtime_budget in
-          Ok
-            { requested_override
-            ; primary_budget = runtime_budget
-            ; runtime_budget
-            ; requested_context_window
-            ; effective_budget
-            }))
+    (match Runtime.resolve_max_context_of_runtime runtime with
+     | None ->
+       Error (Runtime_context_window_unavailable { runtime_id = runtime.id })
+     | Some (runtime_budget, _) ->
+       let requested_context_window =
+         match requested_override with
+         | None -> runtime_budget
+         | Some requested -> requested
+       in
+       let effective_budget = min requested_context_window runtime_budget in
+       Ok
+         { requested_override
+         ; primary_budget = runtime_budget
+         ; runtime_budget
+         ; requested_context_window
+         ; effective_budget
+         })
+;;
+
+let resolve_max_context_resolution_for_runtime_id
+      ~requested_override
+      ~runtime_id
+  =
+  match Runtime.get_runtime_by_id runtime_id with
+  | None -> Error (Runtime_context_window_unavailable { runtime_id })
+  | Some runtime ->
+    resolve_max_context_resolution_for_runtime ~requested_override runtime
 
 let resolve_max_context_resolution_of_meta (m : keeper_meta)
     : max_context_resolution =

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -101,6 +101,7 @@ type compaction_recovery =
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
+  ; projection_target : Keeper_compaction_projection_target.committed
   }
 
 (** {1 Checkpoint Loading} *)
@@ -169,12 +170,14 @@ val recover_latest_checkpoint_for_compaction
   :  base_dir:string
   -> meta:keeper_meta
   -> trigger:Compaction_trigger.t
+  -> projection_request:Keeper_compaction_projection_target.request
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 val prepare_compaction
   :  base_dir:string
   -> meta:Keeper_meta_contract.keeper_meta
   -> trigger:Compaction_trigger.t
+  -> projection_request:Keeper_compaction_projection_target.request
   -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
 
 val commit_prepared_compaction
@@ -202,6 +205,14 @@ val resolve_max_context_resolution_for_runtime_id
   :  requested_override:int option
   -> runtime_id:string
   -> (max_context_resolution, max_context_resolution_error) result
+
+val resolve_max_context_resolution_for_runtime
+  :  requested_override:int option
+  -> Runtime.t
+  -> (max_context_resolution, max_context_resolution_error) result
+(** Resolve against the supplied immutable runtime snapshot. Callers that need
+    another projection of the same provider/model must use this form rather
+    than resolving the runtime id twice across a config refresh. *)
 
 val max_context_resolution_error_to_string
   :  max_context_resolution_error

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -158,11 +158,29 @@ let finish_preparation ~config ~base_dir ~meta = function
 
 let prepare ~config ~meta =
   let base_dir = Keeper_types_profile.session_base_dir config in
+  let projection_request =
+    Keeper_compaction_projection_target.request
+      ~assignment_id:(runtime_id_of_meta meta)
+      ~resolve_context_window:(fun runtime ->
+        match
+          Keeper_context_runtime.resolve_max_context_resolution_for_runtime
+            ~requested_override:meta.max_context_override
+            runtime
+        with
+        | Ok resolution ->
+          Keeper_compaction_projection_target.Resolved_context_window
+            resolution.effective_budget
+        | Error (Invalid_requested_context_override value) ->
+          Keeper_compaction_projection_target.Invalid_context_window value
+        | Error (Runtime_context_window_unavailable _) ->
+          Keeper_compaction_projection_target.Context_window_not_resolved)
+  in
   ( base_dir
   , Keeper_context_runtime.prepare_compaction
       ~base_dir
       ~meta
-      ~trigger:Compaction_trigger.Manual )
+      ~trigger:Compaction_trigger.Manual
+      ~projection_request )
 ;;
 
 let run ~(config : Workspace.config) ~(meta : keeper_meta) =

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -58,6 +58,7 @@ type compaction_recovery = {
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
+  projection_target : Keeper_compaction_projection_target.committed;
 }
 
 type no_compaction = Keeper_event_queue_state.no_compaction =
@@ -507,16 +508,24 @@ type prepared_compaction =
   ; retry_meta : keeper_meta
   ; turn_generation : int
   ; prepared_trigger : Compaction_trigger.t
+  ; projection_target : Keeper_compaction_projection_target.t
   ; context : Keeper_context_core.working_context
   ; evidence : Keeper_compaction_evidence.t
   }
 
-let prepare_compaction ~base_dir ~(meta : keeper_meta) ~(trigger : Compaction_trigger.t)
+let prepare_compaction
+      ~base_dir
+      ~(meta : keeper_meta)
+      ~(trigger : Compaction_trigger.t)
+      ~projection_request
   : (prepared_compaction, compaction_recovery_error) result =
   (* Load the durable source and run the policy + LLM planner.  This phase
      is deliberately admission-free: the keeper's turn slot is not held
      while the provider call runs.  Correctness after an interleaved state
      change is enforced by the source CAS at commit, not by the slot. *)
+  let projection_target =
+    Keeper_compaction_projection_target.capture projection_request
+  in
   let session =
     create_session
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
@@ -578,6 +587,7 @@ let prepare_compaction ~base_dir ~(meta : keeper_meta) ~(trigger : Compaction_tr
          ; retry_meta
          ; turn_generation
          ; prepared_trigger
+         ; projection_target
          ; context = preparation.context
          ; evidence
          }
@@ -608,6 +618,7 @@ let commit_prepared_compaction (prepared : prepared_compaction)
       ; retry_meta
       ; turn_generation
       ; prepared_trigger
+      ; projection_target
       ; context
       ; evidence
       } =
@@ -626,7 +637,6 @@ let commit_prepared_compaction (prepared : prepared_compaction)
              ~ctx:context
              ~generation:turn_generation
              ~expected_source_ref:source_ref
-           |> Result.map fst
            |> Result.map_error (function
              | Tool_history_invalid _ ->
                No_compaction
@@ -635,7 +645,7 @@ let commit_prepared_compaction (prepared : prepared_compaction)
                  }
              | Persistence_error error -> Checkpoint_cas_failed error))
      with
-     | Ok (saved_checkpoint, trigger) ->
+     | Ok ((saved_checkpoint, installed_ref), trigger) ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string Compactions)
          ~labels:[ "keeper", retry_meta.name ]
@@ -645,6 +655,10 @@ let commit_prepared_compaction (prepared : prepared_compaction)
          ; trigger
          ; evidence
          ; turn_generation
+         ; projection_target =
+             Keeper_compaction_projection_target.bind_committed_checkpoint
+               installed_ref
+               projection_target
          }
      | Error
          (Checkpoint_cas_failed (Keeper_checkpoint_store.Source_changed actual) as error) ->
@@ -677,8 +691,9 @@ let recover_latest_checkpoint_for_compaction
     ~(base_dir : string)
     ~(meta : keeper_meta)
     ~(trigger : Compaction_trigger.t)
+    ~projection_request
   : (compaction_recovery, compaction_recovery_error) result =
-  match prepare_compaction ~base_dir ~meta ~trigger with
+  match prepare_compaction ~base_dir ~meta ~trigger ~projection_request with
   | Error _ as error -> error
   | Ok prepared -> commit_prepared_compaction prepared
 ;;

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -33,6 +33,7 @@ type compaction_recovery =
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
+  ; projection_target : Keeper_compaction_projection_target.committed
   } [@@warning "-69"]
 
 type no_compaction = Keeper_event_queue_state.no_compaction =
@@ -100,6 +101,7 @@ val prepare_compaction :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   trigger:Compaction_trigger.t ->
+  projection_request:Keeper_compaction_projection_target.request ->
   (prepared_compaction, compaction_recovery_error) result
 
 (** Phase 2: source-CAS commit of a fully-planned compaction.  The caller
@@ -117,4 +119,5 @@ val recover_latest_checkpoint_for_compaction :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   trigger:Compaction_trigger.t ->
+  projection_request:Keeper_compaction_projection_target.request ->
   (compaction_recovery, compaction_recovery_error) result

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -140,6 +140,7 @@ let recover_provider_context_overflow_in_lane
       ~(config : Workspace.config)
       ~base_dir
       ~(meta : keeper_meta)
+      ~projection_request
       error
   =
   match context_overflow_event_of_error error with
@@ -203,6 +204,7 @@ let recover_provider_context_overflow_in_lane
                  ~base_dir
                  ~meta
                  ~trigger
+                 ~projection_request
              with
              | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
                let reason = Keeper_post_turn.compaction_recovery_error_to_string error in
@@ -1110,6 +1112,12 @@ dominant source of the observed CAS race exhaustion after
                       ~config
                       ~base_dir
                       ~meta
+                      ~projection_request:
+                        (Keeper_compaction_projection_target.request
+                           ~assignment_id:final_execution.runtime_id
+                           ~resolve_context_window:(fun _ ->
+                             Keeper_compaction_projection_target.Resolved_context_window
+                               final_execution.max_context_resolution.effective_budget))
                       err
                   in
                   let source_lease_disposition, turn_state =

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -182,7 +182,6 @@ let test_invalid_plan_is_distinct_from_provider_unavailable () =
              Compact_policy.compact_for_request_typed
                ~meta
                ~trigger:Compaction_trigger.Manual
-               ~projection_request:(projection_request_of_meta meta)
                context)
         |> fun preparation -> preparation.Compact_policy.decision
       in
@@ -737,6 +736,7 @@ let test_malformed_structure_preserves_checkpoint () =
            ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
            ~meta
            ~trigger:Compaction_trigger.Manual
+           ~projection_request:(projection_request_of_meta meta)
        with
        | Error error ->
          failf

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -9,6 +9,7 @@ module Cycle = Masc.Keeper_heartbeat_loop_cycle
 module Queue = Keeper_event_queue
 module Registry_queue = Masc.Keeper_registry_event_queue
 module WO = Masc.Keeper_world_observation
+module Projection_target = Masc.Keeper_compaction_projection_target
 
 let test_compaction_rejection_tag_is_stable () =
   let error =
@@ -25,6 +26,24 @@ let test_compaction_rejection_tag_is_stable () =
     "compaction rejected: invalid_structural_evidence:no_messages_compacted"
     (Post_turn.compaction_recovery_error_to_string error)
 
+let test_empty_projection_target_is_typed () =
+  let resolver_called = ref false in
+  let evidence =
+    Projection_target.request
+      ~assignment_id:""
+      ~resolve_context_window:(fun _ ->
+        resolver_called := true;
+        Projection_target.Resolved_context_window 1)
+    |> Projection_target.capture
+    |> Projection_target.captured_evidence
+  in
+  check bool "empty assignment skips runtime resolution" false !resolver_called;
+  match evidence with
+  | Projection_target.Unavailable Projection_target.Empty_assignment -> ()
+  | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+    fail "empty assignment was not retained as typed unavailable evidence"
+;;
+
 let make_meta
       ?(name = "post-turn-no-auto-compact")
       ?(trace_id = "trace-post-turn-no-auto-compact")
@@ -40,6 +59,25 @@ let make_meta
   with
   | Ok meta -> meta
   | Error detail -> failf "keeper meta fixture failed: %s" detail
+
+let projection_request_of_meta
+      (meta : Masc.Keeper_meta_contract.keeper_meta)
+  =
+  Projection_target.request
+    ~assignment_id:(Masc.Keeper_meta_contract.runtime_id_of_meta meta)
+    ~resolve_context_window:(fun runtime ->
+      match
+        Masc.Keeper_context_runtime.resolve_max_context_resolution_for_runtime
+          ~requested_override:meta.max_context_override
+          runtime
+      with
+      | Ok resolution ->
+        Projection_target.Resolved_context_window resolution.effective_budget
+      | Error (Invalid_requested_context_override value) ->
+        Projection_target.Invalid_context_window value
+      | Error (Runtime_context_window_unavailable _) ->
+        Projection_target.Context_window_not_resolved)
+;;
 
 let make_checkpoint () =
   Agent_sdk.Checkpoint.
@@ -476,7 +514,8 @@ let test_manual_compaction_serializes_owner_lane () =
              Post_turn.recover_latest_checkpoint_for_compaction
                ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
                ~meta
-               ~trigger:Compaction_trigger.Manual)
+               ~trigger:Compaction_trigger.Manual
+               ~projection_request:(projection_request_of_meta meta))
       in
       (match stale_plan_result with
        | Error
@@ -728,6 +767,8 @@ let () =
     "durable compaction", [
       test_case "compaction rejection tag is stable"
         `Quick test_compaction_rejection_tag_is_stable;
+      test_case "empty projection target is typed"
+        `Quick test_empty_projection_target_is_typed;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "invalid plan is distinct from provider unavailability"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -182,6 +182,7 @@ let test_invalid_plan_is_distinct_from_provider_unavailable () =
              Compact_policy.compact_for_request_typed
                ~meta
                ~trigger:Compaction_trigger.Manual
+               ~projection_request:(projection_request_of_meta meta)
                context)
         |> fun preparation -> preparation.Compact_policy.decision
       in


### PR DESCRIPTION
## 목적

MASC compaction이 저장한 checkpoint를 나중에 provider-native 방식으로 측정할 때,
Provider/Model/MaxContext와 SHA-bearing checkpoint identity가 서로 분리되지 않도록
하나의 opaque immutable target으로 묶습니다.

## 변경

- compaction prepare 시 exact Runtime provider config와 effective context를 한 번 capture합니다.
- runtime id, provider id/protocol/kind, model id, effective max context만 credential-free evidence로 노출합니다.
- lane/empty/missing/invalid context는 닫힌 typed `Unavailable`로 보존합니다.
- source CAS 성공 뒤 실제 installed checkpoint ref를 target에 bind합니다.
- empty assignment가 runtime resolver를 호출하지 않고 typed unavailable로 남는 focused test를 포함합니다.
- 기존 CAS 회귀 테스트도 새 projection request 계약을 실제 Runtime snapshot 해석으로 전달합니다.
- #25259의 prepare/commit, one-admission, opaque `prepared_compaction`, CAS 순서는 변경하지 않습니다.
- 측정 I/O, gating, truncation, timeout, retry, 새 journal은 추가하지 않습니다.

## Stack

- base: current `main` including #25316 and #25324
- next: exact overflow Runtime snapshot leaf, then focused identity tests
- provider-native measurement and durable observation are later stacked leaves; 이 PR만으로 compaction fit 관측이 동작한다고 주장하지 않습니다.

## 검증

- 380 changed lines
- OCaml parse and `ocamlformat --check`
- `git diff --check`
- focused build에서 새 인자 누락을 발견해 이 leaf에서 수정했고, fresh run은 공용 wrapper lock 뒤에서 재검증 중입니다. Draft CI is the exact-head build authority.
