### PR TITLE
fix(metrics): count generation recovery on a non-error counter (#25217 P2)

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -586,14 +586,13 @@ let checkpoint_generation_with_fallback ?generation_fallback checkpoint =
       "checkpoint generation key absent; recovering from meta SSOT \
        generation=%d (pre-#25046 checkpoint, #25217)"
       fallback;
+    (* A successful recovery is not an execution error — dashboard.ml aggregates
+       [OasExecutionErrors] into its error total, so counting it there inflated
+       the error signal. Record it on a dedicated non-error counter instead. *)
     Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string OasExecutionErrors)
+      Keeper_metrics.(to_string CheckpointGenerationRecovered)
       ~labels:
-        [ ( "phase"
-          , Keeper_oas_execution_error_phase.(
-              to_label Compaction_checkpoint_load) )
-        ; "kind", "generation_recovered_from_meta"
-        ]
+        [ "source", "meta_ssot"; "context", "compaction_checkpoint_load" ]
       ();
     Ok fallback
   | Error _ as error, _ -> error

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -120,6 +120,7 @@ type t =
   | WorkspaceHeartbeatFailures
   | TurnMetricsSnapshotFailures
   | OasExecutionErrors
+  | CheckpointGenerationRecovered
   | EpisodeCreateFailures
   | MemoryActivityEmitFailures
   | SupervisorSweepFailures
@@ -338,6 +339,8 @@ let to_string = function
   | WorkspaceHeartbeatFailures -> "masc_keeper_workspace_heartbeat_failures_total"
   | TurnMetricsSnapshotFailures -> "masc_keeper_turn_metrics_snapshot_failures_total"
   | OasExecutionErrors -> "masc_keeper_oas_execution_errors_total"
+  | CheckpointGenerationRecovered ->
+    "masc_keeper_checkpoint_generation_recovered_total"
   | EpisodeCreateFailures -> "masc_keeper_episode_create_failures_total"
   | MemoryActivityEmitFailures -> "masc_keeper_memory_activity_emit_failures_total"
   | SupervisorSweepFailures -> "masc_keeper_supervisor_sweep_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -111,6 +111,7 @@ type t =
   | WorkspaceHeartbeatFailures
   | TurnMetricsSnapshotFailures
   | OasExecutionErrors
+  | CheckpointGenerationRecovered
   | EpisodeCreateFailures
   | MemoryActivityEmitFailures
   | SupervisorSweepFailures


### PR DESCRIPTION
## 목표
#25275(머지됨)의 **머지 후 적대 리뷰 P2**를 해소해요. 별도 PR로 진행합니다(#25275는 이미 squash-merge).

## 문제
`checkpoint_generation_with_fallback`가 generation-less checkpoint를 **성공적으로 복구**할 때 `masc_keeper_oas_execution_errors_total`를 증가시켜요. `dashboard.ml`이 이 metric total을 **에러 집계**에 그대로 더해서, 정상 복구(처리된 legacy 조건)가 operator-facing 에러 신호를 부풀려요.

## 변경
- 전용 counter `CheckpointGenerationRecovered`(`masc_keeper_checkpoint_generation_recovered_total`) 추가.
- 복구 성공을 이 counter에 `source=meta_ssot`, `context=compaction_checkpoint_load` 라벨로 기록. execution-error counter는 진짜 에러에만.

## 남은점 (별도)
#25275의 **P1(동시성)**: `save_oas_if_source`의 legacy-source CAS가 `prepare_compaction`에서 캡처한 stale generation을 쓸 수 있음(dead revival이 `meta.runtime.generation`을 동시 advance 시). CAS 직전 meta.generation 재검증 필요 — save_oas_if_source 내부 변경이라 별도 PR로 분리.

## 검증
- 로컬 dune 빌드 미실행(CI가 빌드 권위). exhaustive to_string이라 컴파일러가 새 variant 강제.

RFC-WAIVED: metrics counter 추가 + telemetry 분류 수정으로, credential/identity/operator/sandbox/hooks/workflow subsystem 무관.
