### PR TITLE
fix(keeper): bind checkpoint generation at OAS input boundary

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -567,43 +567,12 @@ let checkpoint_generation_strict (checkpoint : Agent_sdk.Checkpoint.t) =
      | None -> Error Generation_not_integer)
   | Some _ -> Error Generation_not_integer
 
-(* [generation_fallback] closes the pre-#25046 checkpoint gap (#25217): a
-   keeper's OAS turn-persist path serializes the live context, which does not
-   carry [keeper_generation] in its Session scope, so its primary checkpoint
-   is written without the key that #25046's strict identity requires. On the
-   load side the keeper's own [meta.runtime.generation] is the authoritative
-   generation SSOT — using it when (and only when) the persisted key is
-   absent recovers identity from an equally-authoritative source rather than
-   fabricating one. Only [Generation_missing] is recovered; a present-but-
-   malformed value ([Generation_not_integer]) stays a hard error. The save
-   path never passes a fallback, so the write invariant "a freshly built
-   checkpoint must carry its own generation" is unchanged. *)
-let checkpoint_generation_with_fallback ?generation_fallback checkpoint =
-  match checkpoint_generation_strict checkpoint, generation_fallback with
-  | Ok generation, _ -> Ok generation
-  | Error Generation_missing, Some fallback ->
-    Log.Keeper.warn
-      "checkpoint generation key absent; recovering from meta SSOT \
-       generation=%d (pre-#25046 checkpoint, #25217)"
-      fallback;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string OasExecutionErrors)
-      ~labels:
-        [ ( "phase"
-          , Keeper_oas_execution_error_phase.(
-              to_label Compaction_checkpoint_load) )
-        ; "kind", "generation_recovered_from_meta"
-        ]
-      ();
-    Ok fallback
-  | Error _ as error, _ -> error
-
-let checkpoint_ref_of_canonical_bytes ?generation_fallback canonical_bytes
+let checkpoint_ref_of_canonical_bytes canonical_bytes
     (checkpoint : Agent_sdk.Checkpoint.t) =
   match Keeper_id.Trace_id.of_string checkpoint.Agent_sdk.Checkpoint.session_id with
   | Error reason -> Error (Session_id_invalid reason)
   | Ok trace_id ->
-    (match checkpoint_generation_with_fallback ?generation_fallback checkpoint with
+    (match checkpoint_generation_strict checkpoint with
      | Error _ as error -> error
      | Ok generation ->
        Keeper_checkpoint_ref.create
@@ -613,12 +582,8 @@ let checkpoint_ref_of_canonical_bytes ?generation_fallback canonical_bytes
          ~canonical_checkpoint_bytes:canonical_bytes
        |> Result.map_error (fun error -> Ref_create_failed error))
 
-let exact_snapshot_of_checkpoint ?generation_fallback ~expected_session_id
-    ~canonical_bytes checkpoint =
-  match
-    checkpoint_ref_of_canonical_bytes ?generation_fallback canonical_bytes
-      checkpoint
-  with
+let exact_snapshot_of_checkpoint ~expected_session_id ~canonical_bytes checkpoint =
+  match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
   | Error error -> Error (Ref_identity_invalid error)
   | Ok reference
     when not
@@ -630,19 +595,17 @@ let exact_snapshot_of_checkpoint ?generation_fallback ~expected_session_id
   | Ok reference -> Ok { checkpoint; reference; canonical_bytes }
 ;;
 
-let exact_snapshot_of_canonical_bytes ?generation_fallback ~expected_session_id
-    canonical_bytes =
+let exact_snapshot_of_canonical_bytes ~expected_session_id canonical_bytes =
   match decode_checkpoint_off_scheduler canonical_bytes with
   | Error error -> Error (Ref_read_failed (classify_sdk_error error))
   | Ok checkpoint ->
     exact_snapshot_of_checkpoint
-      ?generation_fallback
       ~expected_session_id
       ~canonical_bytes
       checkpoint
 ;;
 
-let load_ref_locked ?generation_fallback ~session_dir ~expected_session_id () =
+let load_ref_locked ~session_dir ~expected_session_id =
   let canonical_path =
     oas_checkpoint_path
       ~session_dir
@@ -653,24 +616,23 @@ let load_ref_locked ?generation_fallback ~session_dir ~expected_session_id () =
   | Ok None -> Error Ref_not_found
   | Ok (Some (canonical_bytes, checkpoint)) ->
     exact_snapshot_of_checkpoint
-      ?generation_fallback
       ~expected_session_id
       ~canonical_bytes
       checkpoint
 
-let load_oas_exact_snapshot ?generation_fallback ~session_dir ~session_id () =
+let load_oas_exact_snapshot ~session_dir ~session_id =
   match Keeper_id.Trace_id.of_string session_id with
   | Error reason -> Error (Ref_identity_invalid (Session_id_invalid reason))
   | Ok expected_session_id ->
     (match
        with_session_lock ~session_dir (fun session_dir ->
-         load_ref_locked ?generation_fallback ~session_dir ~expected_session_id ())
+         load_ref_locked ~session_dir ~expected_session_id)
      with
      | Ok result -> result
      | Error detail -> Error (Ref_lock_failed detail))
 
-let load_oas_with_ref ?generation_fallback ~session_dir ~session_id () =
-  load_oas_exact_snapshot ?generation_fallback ~session_dir ~session_id ()
+let load_oas_with_ref ~session_dir ~session_id =
+  load_oas_exact_snapshot ~session_dir ~session_id
   |> Result.map (fun snapshot ->
     exact_snapshot_checkpoint snapshot, exact_snapshot_reference snapshot)
 ;;
@@ -699,7 +661,6 @@ let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
                   (File_lock_eio.durable_lock_error_to_string error)))))
 
 let save_oas_if_source
-    ?generation_fallback
     ~session_dir
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
     (candidate : Agent_sdk.Checkpoint.t) =
@@ -735,17 +696,7 @@ let save_oas_if_source
   | Ok candidate_ref ->
     let expected_session_id = expected_source_ref.trace_id in
     with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
-      (* The CAS source reread re-reads the EXISTING installed checkpoint (not
-         the freshly built candidate) to detect a concurrent change. For a
-         pre-#25046 source that checkpoint lacks [keeper_generation], so it
-         needs the same [generation_fallback] the initial recovery load used —
-         and [expected_source_ref] was itself built with that fallback, so a
-         strict reread would both fail closed AND disagree with the ref it is
-         compared against. The candidate above is still built strictly from
-         [~generation], preserving the write invariant. *)
-      match
-        load_ref_locked ?generation_fallback ~session_dir ~expected_session_id ()
-      with
+      match load_ref_locked ~session_dir ~expected_session_id with
       | Error error -> Error (Source_unavailable error)
       | Ok snapshot
         when not

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -159,34 +159,24 @@ val exact_snapshot_reference :
 val exact_snapshot_canonical_bytes : exact_checkpoint_snapshot -> string
 
 (** Strictly decode exact canonical bytes and derive their reference without
-    re-encoding. [generation_fallback] recovers identity for a pre-#25046
-    checkpoint whose persisted context lacks [keeper_generation]: it is used
-    only when the key is absent ([Generation_missing]), never when it is
-    present-but-malformed, and never on the save path (#25217). *)
+    re-encoding. *)
 val exact_snapshot_of_canonical_bytes :
-  ?generation_fallback:int ->
   expected_session_id:Keeper_id.Trace_id.t ->
   string ->
   (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
 
-(** Load an exact canonical checkpoint snapshot under the session lock.
-    See {!exact_snapshot_of_canonical_bytes} for [generation_fallback]. *)
+(** Load an exact canonical checkpoint snapshot under the session lock. *)
 val load_oas_exact_snapshot :
-  ?generation_fallback:int ->
   session_dir:string ->
   session_id:string ->
-  unit ->
   (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
 
 (** Load one canonical checkpoint and its exact source identity from the same
     locked byte snapshot. No size, mtime, timestamp, or process cache
-    participates in the identity. See {!exact_snapshot_of_canonical_bytes}
-    for [generation_fallback]. *)
+    participates in the identity. *)
 val load_oas_with_ref :
-  ?generation_fallback:int ->
   session_dir:string ->
   session_id:string ->
-  unit ->
   ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_ref.t
   , checkpoint_ref_load_error )
   result
@@ -229,12 +219,7 @@ type checkpoint_cas_error =
     payload-store commit is not an operation terminal fact; the Keeper operation
     journal owns that authority. *)
 val save_oas_if_source :
-  ?generation_fallback:int ->
   session_dir:string ->
   expected_source_ref:Keeper_checkpoint_ref.t ->
   Agent_sdk.Checkpoint.t ->
   (Keeper_checkpoint_ref.t, checkpoint_cas_error) result
-(** [generation_fallback] is used for the CAS source reread of a pre-#25046
-    checkpoint (no [keeper_generation]); it must match the fallback used to
-    build [expected_source_ref]. The candidate is always built strictly from
-    its own generation, so the write invariant is unchanged (#25217). *)

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -133,7 +133,6 @@ let save_oas_checkpoint_if_source
   | Ok checkpoint ->
     (match
        Keeper_checkpoint_store.save_oas_if_source
-         ~generation_fallback:generation
          ~session_dir:session.session_dir
          ~expected_source_ref
          checkpoint

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -524,10 +524,8 @@ let prepare_compaction ~base_dir ~(meta : keeper_meta) ~(trigger : Compaction_tr
   in
   match
     Keeper_checkpoint_store.load_oas_with_ref
-      ~generation_fallback:meta.runtime.generation
       ~session_dir:session.session_dir
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-      ()
   with
   | Error Keeper_checkpoint_store.Ref_not_found ->
     Log.Keeper.debug

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -105,6 +105,11 @@ let prepare_run_context
     | Some ctx -> ctx
     | None -> Agent_sdk.Context.create ()
   in
+  (* OAS uses the caller-supplied context as the checkpoint context for both
+     new and resumed agents. Bind MASC's generation before dispatch so every
+     OAS-produced checkpoint carries the current keeper identity. *)
+  Agent_sdk.Context.set_scoped shared_context Agent_sdk.Context.Session
+    Keeper_checkpoint_store.keeper_generation_context_key (`Int generation);
   (* 1. Ensure session directory tree exists *)
   let session_dir =
     Filename.concat base_dir (Keeper_id.Trace_id.to_string meta.runtime.trace_id)

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -488,7 +488,7 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
       "CAS seed save";
     let source_ref =
       match
-        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id ()
+        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
       with
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS source load failed"
@@ -516,7 +516,7 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
     check int "exactly one writer commits" 1 (List.length committed);
     check int "the competing source is rejected" 1 changed;
     match committed,
-      Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id ()
+      Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
     with
     | [ (winner, committed_ref) ], Ok (checkpoint, disk_ref) ->
       check bool "committed ref identifies installed canonical bytes" true
@@ -538,7 +538,7 @@ let test_exact_source_cas_updates_canonical_watermark () =
       "CAS watermark seed save";
     let source_ref =
       match
-        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id ()
+        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
       with
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS watermark source load failed"
@@ -571,109 +571,13 @@ let test_checkpoint_ref_requires_generation () =
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
     let session_id = "sess-ref-generation" in
     save_ok ~session_dir
-      (make_checkpoint ~session_id ~turn_count:1 ~marker:"legacy")
+      (make_checkpoint ~session_id ~turn_count:1 ~marker:"missing-generation")
       "generation-less seed";
-    match Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id () with
+    match Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id with
     | Error
         (Keeper_checkpoint_store.Ref_identity_invalid
            Keeper_checkpoint_store.Generation_missing) -> ()
     | _ -> fail "generation-less checkpoint acquired an exact ref")
-
-(* #25217: a pre-#25046 checkpoint (no [keeper_generation] key, as written by
-   the OAS turn-persist path) must load through [load_oas_with_ref] when the
-   keeper supplies its own [meta.runtime.generation] as [generation_fallback]
-   — the authoritative generation SSOT — and the recovered ref must carry
-   exactly that generation. Without the fallback the same checkpoint still
-   fails closed (test above), and the save path never passes one, so the
-   write invariant is unchanged. *)
-let test_generation_fallback_recovers_pre_25046_checkpoint () =
-  let session_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let session_id = "sess-generation-fallback" in
-    save_ok ~session_dir
-      (make_checkpoint ~session_id ~turn_count:1 ~marker:"pre-25046")
-      "generation-less seed";
-    match
-      Keeper_checkpoint_store.load_oas_with_ref
-        ~generation_fallback:7 ~session_dir ~session_id ()
-    with
-    | Ok (_checkpoint, reference) ->
-      check int "ref generation recovered from meta SSOT" 7
-        reference.Keeper_checkpoint_ref.generation
-    | Error _ ->
-      fail "generation fallback did not recover the pre-25046 checkpoint")
-
-(* #25217 review P0: the initial recovery load is only half the path. The
-   compaction CAS commit re-reads the same generation-less source under the
-   lock; that reread must use the same fallback, or the very checkpoint just
-   recovered is rejected again and the wedge persists. This drives the full
-   cycle — fallback recovery load -> CAS commit of a forward candidate -> the
-   candidate installs — over a pre-#25046 source. *)
-let test_generation_fallback_permits_cas_commit_over_legacy_source () =
-  let session_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let session_id = "sess-generation-cas" in
-    (* Legacy source: no keeper_generation key, turn_count=8. *)
-    save_ok ~session_dir
-      (make_checkpoint ~session_id ~turn_count:8 ~marker:"legacy-source")
-      "legacy source seed";
-    let source_ref =
-      match
-        Keeper_checkpoint_store.load_oas_with_ref
-          ~generation_fallback:5 ~session_dir ~session_id ()
-      with
-      | Ok (_, reference) -> reference
-      | Error _ -> fail "recovery load of legacy source failed"
-    in
-    check int "recovered source ref carries the fallback generation" 5
-      source_ref.Keeper_checkpoint_ref.generation;
-    (* Forward candidate at the same recovered generation must commit — the
-       CAS source reread has to recover the legacy source with the same
-       fallback for the ref comparison to match. *)
-    (match
-       Keeper_checkpoint_store.save_oas_if_source
-         ~generation_fallback:5
-         ~session_dir
-         ~expected_source_ref:source_ref
-         (make_checkpoint ~session_id ~turn_count:9 ~marker:"forward"
-          |> with_generation 5)
-     with
-     | Ok installed_ref ->
-       check int "installed candidate advanced the turn" 9
-         installed_ref.Keeper_checkpoint_ref.turn_count
-     | Error _ -> fail "CAS commit over a recovered legacy source failed");
-    (* And a stale expected_source_ref must still be rejected: concurrent-change
-       detection is not weakened by the fallback. *)
-    match
-      Keeper_checkpoint_store.save_oas_if_source
-        ~generation_fallback:5
-        ~session_dir
-        ~expected_source_ref:source_ref (* now stale: disk is at turn 9 *)
-        (make_checkpoint ~session_id ~turn_count:10 ~marker:"racing"
-         |> with_generation 5)
-    with
-    | Error (Keeper_checkpoint_store.Source_changed _) -> ()
-    | _ -> fail "stale source ref was not rejected after the source advanced")
-
-(* A present-but-malformed generation is a corruption, not an absence: the
-   fallback must NOT paper over it. *)
-let test_generation_fallback_rejects_malformed_generation () =
-  let session_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let session_id = "sess-generation-malformed" in
-    let checkpoint = make_checkpoint ~session_id ~turn_count:1 ~marker:"bad" in
-    let context = Agent_sdk.Context.copy ~eio:false checkpoint.context in
-    Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-      Keeper_checkpoint_store.keeper_generation_context_key (`String "not-an-int");
-    save_ok ~session_dir { checkpoint with context } "malformed generation seed";
-    match
-      Keeper_checkpoint_store.load_oas_with_ref
-        ~generation_fallback:7 ~session_dir ~session_id ()
-    with
-    | Error
-        (Keeper_checkpoint_store.Ref_identity_invalid
-           Keeper_checkpoint_store.Generation_not_integer) -> ()
-    | _ -> fail "malformed generation must not be recovered by the fallback")
 
 let test_exact_snapshot_preserves_locked_canonical_bytes () =
   let session_dir = temp_dir () in
@@ -694,7 +598,6 @@ let test_exact_snapshot_preserves_locked_canonical_bytes () =
       Keeper_checkpoint_store.load_oas_exact_snapshot
         ~session_dir
         ~session_id
-        ()
     with
     | Error _ -> fail "exact snapshot load failed"
     | Ok snapshot ->
@@ -750,12 +653,6 @@ let () =
             test_exact_source_cas_updates_canonical_watermark;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
-          test_case "generation fallback recovers pre-25046 checkpoint" `Quick
-            test_generation_fallback_recovers_pre_25046_checkpoint;
-          test_case "generation fallback permits CAS commit over legacy source" `Quick
-            test_generation_fallback_permits_cas_commit_over_legacy_source;
-          test_case "generation fallback rejects malformed generation" `Quick
-            test_generation_fallback_rejects_malformed_generation;
           test_case "exact snapshot preserves canonical bytes" `Quick
             test_exact_snapshot_preserves_locked_canonical_bytes;
         ] );

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -88,6 +88,50 @@ let save_ok ~session_dir ckpt label =
   | Ok _ -> ()
   | Error e -> fail (label ^ " unexpectedly failed: " ^ e)
 
+let test_run_context_binds_generation_before_oas_checkpoint () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Eio.Switch.on_release sw (fun () -> cleanup_dir base_dir);
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc [ "name", `String "generation-context" ])
+    with
+    | Ok meta -> meta
+    | Error detail -> fail ("meta fixture failed: " ^ detail)
+  in
+  let shared_context = Agent_sdk.Context.create () in
+  let run_context =
+    Keeper_run_context.prepare_run_context
+      ~config:(Workspace.default_config base_dir)
+      ~meta
+      ~profile_defaults:Keeper_types_profile_defaults.empty_keeper_profile_defaults
+      ~base_dir
+      ~runtime_id:"unconfigured-test-runtime"
+      ~shared_context
+      ~generation:7
+      ()
+  in
+  check bool "caller-owned context remains the OAS context" true
+    (run_context.shared_context == shared_context);
+  let agent =
+    Agent_sdk.Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~config:(Agent_sdk.Agent.default_config ~model:"test-model")
+      ~context:run_context.shared_context
+      ()
+  in
+  let checkpoint = Agent_sdk.Agent.checkpoint agent in
+  match
+    Agent_sdk.Context.get_scoped checkpoint.context Agent_sdk.Context.Session
+      Keeper_checkpoint_store.keeper_generation_context_key
+  with
+  | Some (`Int generation) ->
+    check int "OAS checkpoint carries current keeper generation" 7 generation
+  | _ -> fail "OAS checkpoint omitted the bound keeper generation"
+
 let test_forward_equal_and_stale () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -678,6 +722,8 @@ let () =
     [
       ( "checkpoint transaction",
         [
+          test_case "run context binds generation before OAS checkpoint" `Quick
+            test_run_context_binds_generation_before_oas_checkpoint;
           test_case "forward and equal saves pass, stale save is no-op" `Quick
             test_forward_equal_and_stale;
           test_case "canonical disk is the watermark SSOT" `Quick

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -119,7 +119,7 @@ let test_run_context_binds_generation_before_oas_checkpoint () =
   let agent =
     Agent_sdk.Agent.create
       ~net:(Eio.Stdenv.net env)
-      ~config:(Agent_sdk.Agent.default_config ~model:"test-model")
+      ~config:(Agent_sdk.Types.default_config ~model:"test-model")
       ~context:run_context.shared_context
       ()
   in


### PR DESCRIPTION
## Summary

- bind the current keeper generation to the caller-owned `Agent_sdk.Context.t` before every OAS dispatch
- let OAS preserve that context naturally in checkpoints for both new and resumed agents
- remove the optional load/CAS generation fallback, its recovery metric, and its legacy-repair tests from #25275
- keep generation-less or malformed checkpoint identity fail-closed

## Root cause

MASC passed a `shared_context` to OAS without the MASC-owned `keeper_generation` key. OAS correctly treats a caller-supplied context as authoritative for both `Agent.create` and `Agent.resume`, then copies that context into every checkpoint. The per-turn writer therefore persisted generation-less checkpoints.

#25275 repaired the consumer by threading an optional generation through generic checkpoint load and CAS APIs. Because the active writer still omitted the field, that was a permanent second authority rather than a bounded migration.

This PR fixes the producer boundary instead: MASC writes its product identity into the context it already owns before invoking OAS. No OAS type or behavior becomes MASC-aware.

## Hard-cut behavior

- no checkpoint migration
- no inferred generation
- no optional fallback parameter
- no silent repair
- a persisted checkpoint without an exact generation remains invalid for compaction identity

## Proof

The focused regression constructs the real OAS `Agent.t` from the context returned by `Keeper_run_context.prepare_run_context`, creates an OAS checkpoint, and asserts that it contains the exact current keeper generation. The existing negative test continues to prove that a generation-less checkpoint cannot acquire an exact reference.

## Validation

- `ocamlformat --check` on all six touched OCaml files
- `ocamlc -stop-after parsing -c` on all touched implementations/tests
- `git diff --check origin/main...HEAD`
- focused Dune build was requested but cancelled after waiting behind the shared global Dune lock for more than 25 minutes; no local type/test pass is claimed, and exact-head PR CI is the remaining authority

Replaces the fallback implementation merged by #25275.
