### PR TITLE
refactor(checkpoint): centralize persisted identity codec

### DIFF
--- a/lib/keeper_checkpoint_ref/dune
+++ b/lib/keeper_checkpoint_ref/dune
@@ -5,4 +5,4 @@
  (public_name masc.keeper_checkpoint_ref)
  (wrapped false)
  (modules keeper_checkpoint_ref)
- (libraries digestif masc.keeper_registry))
+ (libraries digestif masc.keeper_registry yojson))

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
@@ -46,3 +46,54 @@ let equal left right =
   && Int.equal left.turn_count right.turn_count
   && String.equal left.sha256 right.sha256
 ;;
+
+let to_yojson checkpoint =
+  `Assoc
+    [ "trace_id", `String (Keeper_id.Trace_id.to_string checkpoint.trace_id)
+    ; "generation", `Int checkpoint.generation
+    ; "turn_count", `Int checkpoint.turn_count
+    ; "sha256", `String checkpoint.sha256
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    let expected = [ "generation"; "sha256"; "trace_id"; "turn_count" ] in
+    let actual = List.map fst fields |> List.sort String.compare in
+    if not (List.equal String.equal expected actual)
+    then
+      Error
+        "checkpoint identity must contain exactly trace_id, generation, turn_count, sha256"
+    else (
+      let required_string key =
+        match List.assoc_opt key fields with
+        | Some (`String value) -> Ok value
+        | Some _ -> Error (Printf.sprintf "checkpoint field %s must be a string" key)
+        | None -> Error (Printf.sprintf "checkpoint field %s is missing" key)
+      in
+      let required_int key =
+        match List.assoc_opt key fields with
+        | Some (`Int value) -> Ok value
+        | Some _ -> Error (Printf.sprintf "checkpoint field %s must be an int" key)
+        | None -> Error (Printf.sprintf "checkpoint field %s is missing" key)
+      in
+      let ( let* ) = Result.bind in
+      let* trace_id_raw = required_string "trace_id" in
+      let* trace_id = Keeper_id.Trace_id.of_string trace_id_raw in
+      let* generation = required_int "generation" in
+      let* turn_count = required_int "turn_count" in
+      let* sha256 = required_string "sha256" in
+      of_persisted ~trace_id ~generation ~turn_count ~sha256
+      |> Result.map_error (function
+        | Negative_generation value ->
+          Printf.sprintf "checkpoint generation is negative: %d" value
+        | Negative_turn_count value ->
+          Printf.sprintf "checkpoint turn count is negative: %d" value
+        | Invalid_sha256 value ->
+          Printf.sprintf "checkpoint digest is invalid: %s" value))
+  | json ->
+    Error
+      (Printf.sprintf
+         "checkpoint identity must be an object (received %s)"
+         (Yojson.Safe.to_string json))
+;;

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
@@ -30,3 +30,9 @@ val of_persisted
     Non-canonical or malformed digests are rejected. *)
 
 val equal : t -> t -> bool
+
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Exact persisted representation of a checkpoint identity. Unknown fields,
+    invalid coordinates, invalid trace ids, and non-canonical digests are
+    rejected at this single decoder boundary. *)

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -810,38 +810,8 @@ let no_compaction_reason_of_label = function
   | reason -> Error (Printf.sprintf "unknown no-compaction reason: %s" reason)
 ;;
 
-let checkpoint_source_to_yojson (source : Keeper_checkpoint_ref.t) =
-  `Assoc
-    [ "trace_id", `String (Keeper_id.Trace_id.to_string source.trace_id)
-    ; "generation", `Int source.generation
-    ; "turn_count", `Int source.turn_count
-    ; "sha256", `String source.sha256
-    ]
-;;
-
-let checkpoint_source_of_yojson json =
-  let context = "no-compaction checkpoint source" in
-  let* fields = assoc_fields ~context json in
-  let* () =
-    exact_fields
-      ~context
-      ~expected:[ "trace_id"; "generation"; "turn_count"; "sha256" ]
-      fields
-  in
-  let* trace_id_raw = string_field ~context "trace_id" fields in
-  let* trace_id = Keeper_id.Trace_id.of_string trace_id_raw in
-  let* generation = int_field ~context "generation" fields in
-  let* turn_count = int_field ~context "turn_count" fields in
-  let* sha256 = string_field ~context "sha256" fields in
-  Keeper_checkpoint_ref.of_persisted ~trace_id ~generation ~turn_count ~sha256
-  |> Result.map_error (function
-    | Keeper_checkpoint_ref.Negative_generation value ->
-      Printf.sprintf "no-compaction checkpoint generation is negative: %d" value
-    | Negative_turn_count value ->
-      Printf.sprintf "no-compaction checkpoint turn count is negative: %d" value
-    | Invalid_sha256 value ->
-      Printf.sprintf "no-compaction checkpoint digest is invalid: %s" value)
-;;
+let checkpoint_source_to_yojson = Keeper_checkpoint_ref.to_yojson
+let checkpoint_source_of_yojson = Keeper_checkpoint_ref.of_yojson
 
 let settlement_to_yojson = function
   | Ack -> `Assoc [ "kind", `String "ack" ]

--- a/test/keeper_checkpoint_ref/dune
+++ b/test/keeper_checkpoint_ref/dune
@@ -1,3 +1,3 @@
 (test
  (name test_keeper_checkpoint_ref)
- (libraries alcotest masc.keeper_checkpoint_ref masc.keeper_registry))
+ (libraries alcotest masc.keeper_checkpoint_ref masc.keeper_registry yojson))

--- a/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
+++ b/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
@@ -75,6 +75,35 @@ let test_persisted_roundtrip_is_canonical () =
     [ String.uppercase_ascii expected.sha256; String.sub expected.sha256 0 62; " " ^ expected.sha256 ]
 ;;
 
+let test_json_roundtrip_is_exact () =
+  let expected = create {|{"messages":["before"]}|} in
+  let json = Keeper_checkpoint_ref.to_yojson expected in
+  let restored = Keeper_checkpoint_ref.of_yojson json |> result_ok in
+  Alcotest.(check bool)
+    "json identity"
+    true
+    (Keeper_checkpoint_ref.equal expected restored);
+  let reordered =
+    `Assoc
+      [ "sha256", `String expected.sha256
+      ; "turn_count", `Int expected.turn_count
+      ; "trace_id", `String (Keeper_id.Trace_id.to_string expected.trace_id)
+      ; "generation", `Int expected.generation
+      ]
+  in
+  let reordered = Keeper_checkpoint_ref.of_yojson reordered |> result_ok in
+  Alcotest.(check bool)
+    "object field order is not identity"
+    true
+    (Keeper_checkpoint_ref.equal expected reordered);
+  match json with
+  | `Assoc fields ->
+    (match Keeper_checkpoint_ref.of_yojson (`Assoc (("extra", `Bool true) :: fields)) with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "unknown checkpoint identity field was accepted")
+  | _ -> Alcotest.fail "checkpoint identity encoder returned a non-object"
+;;
+
 let () =
   Alcotest.run
     "keeper checkpoint ref"
@@ -85,5 +114,6 @@ let () =
             "persisted canonical roundtrip"
             `Quick
             test_persisted_roundtrip_is_canonical
+        ; Alcotest.test_case "json roundtrip" `Quick test_json_roundtrip_is_exact
         ] )
     ]

--- a/test/stanzas/test_keeper_post_turn_wirein_order.inc
+++ b/test/stanzas/test_keeper_post_turn_wirein_order.inc
@@ -1,4 +1,7 @@
 (test
  (name test_keeper_post_turn_wirein_order)
  (modules test_keeper_post_turn_wirein_order)
- (libraries masc_test_deps masc.keeper_compaction_evidence))
+ (libraries
+  masc_test_deps
+  masc.keeper_compaction_evidence
+  masc.keeper_checkpoint_ref))

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -192,6 +192,88 @@ let test_invalid_plan_is_distinct_from_provider_unavailable () =
       | Compact_policy.Rejected (Manual, Plan_provider_unavailable) -> ()
       | _ -> fail "provider failure was collapsed into an invalid plan")
 
+let rec json_has_key key = function
+  | `Assoc fields ->
+    List.exists
+      (fun (field, value) -> String.equal field key || json_has_key key value)
+      fields
+  | `List values -> List.exists (json_has_key key) values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> false
+;;
+
+let test_projection_target_is_immutable_and_credential_free () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+      let runtime_path =
+        Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+      in
+      (match Runtime.init_default ~config_path:runtime_path with
+       | Ok () -> ()
+       | Error detail -> failf "runtime fixture initialization failed: %s" detail);
+      let runtime =
+        Runtime.get_default_runtime ()
+        |> Option.get
+      in
+      let target =
+        Projection_target.request
+          ~assignment_id:runtime.id
+          ~resolve_context_window:(fun _ ->
+            Projection_target.Resolved_context_window 17)
+        |> Projection_target.capture
+      in
+      let captured =
+        Projection_target.captured_evidence target
+      in
+      (match captured with
+       | Projection_target.Exact exact ->
+         check string "runtime identity" runtime.id exact.runtime_id;
+         check int "effective context snapshot" 17 exact.effective_max_context
+       | Projection_target.Unavailable _ ->
+         fail "single runtime did not produce an exact target");
+      let public_json =
+        Projection_target.evidence_to_json captured
+      in
+      List.iter
+        (fun key -> check bool ("credential field excluded: " ^ key) false (json_has_key key public_json))
+        [ "api_key"; "base_url"; "credentials"; "endpoint"; "headers" ];
+      let unresolved_identity = " missing-runtime " in
+      let unresolved =
+        Projection_target.request
+          ~assignment_id:unresolved_identity
+          ~resolve_context_window:(fun _ ->
+            Projection_target.Resolved_context_window 17)
+        |> Projection_target.capture
+        |> Projection_target.captured_evidence
+      in
+      (match unresolved with
+       | Projection_target.Unavailable
+           (Projection_target.Runtime_unavailable { runtime_id }) ->
+         check string "assignment identity is not normalized" unresolved_identity runtime_id
+       | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+         fail "missing runtime identity was normalized or reclassified");
+      let lane_target =
+        Projection_target.request
+          ~assignment_id:"default"
+          ~resolve_context_window:(fun _ ->
+            Projection_target.Resolved_context_window 17)
+        |> Projection_target.capture
+      in
+      match
+        Projection_target.captured_evidence lane_target
+      with
+      | Projection_target.Unavailable
+          (Projection_target.Assignment_ambiguous { assignment_id = "default" }) ->
+        Runtime.For_testing.restore runtime_snapshot;
+        check bool
+          "captured evidence survives runtime state replacement"
+          true
+          (Projection_target.captured_evidence target = captured)
+      | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+        fail "lane target guessed a provider candidate")
+;;
+
 let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
@@ -744,7 +826,20 @@ let test_malformed_structure_preserves_checkpoint () =
            (Post_turn.compaction_recovery_error_to_string error)
        | Ok prepared ->
          (match Post_turn.commit_prepared_compaction prepared with
-          | Ok _ -> ()
+          | Ok recovery ->
+            let committed_ref =
+              Projection_target.checkpoint_ref recovery.projection_target
+            in
+            let _, durable_ref =
+              Masc.Keeper_checkpoint_store.load_oas_with_ref
+                ~session_dir:session.session_dir
+                ~session_id:checkpoint.session_id
+              |> Result.get_ok
+            in
+            check bool
+              "projection target retains exact committed checkpoint ref"
+              true
+              (Keeper_checkpoint_ref.equal committed_ref durable_ref)
           | Error error ->
             failf
               "commit of a fresh prepared plan failed: %s"
@@ -774,6 +869,8 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "invalid plan is distinct from provider unavailability"
         `Quick test_invalid_plan_is_distinct_from_provider_unavailable;
+      test_case "projection target snapshot excludes credentials"
+        `Quick test_projection_target_is_immutable_and_credential_free;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "malformed structure preserves checkpoint"


### PR DESCRIPTION
## 목적

Compaction observation과 Keeper event queue가 checkpoint identity JSON을 각각
다르게 구현하지 않도록 `Keeper_checkpoint_ref` 자체를 persisted codec SSOT로 둡니다.

## 변경

- exact `to_yojson` / fail-closed `of_yojson` 추가
- field order는 identity에 포함하지 않되 missing/duplicate/unknown field는 거부
- invalid trace id, negative coordinates, non-canonical SHA는 기존 typed constructor로 검증
- event queue의 duplicate checkpoint-source codec 제거
- roundtrip, field-order independence, unknown-field rejection 테스트

## Stack

- base: #25343
- next: provider-native compaction fit boundary

## 검증

- 125 changed lines
- OCaml parse and `ocamlformat --check`
- `git diff --check`
- focused Dune is serialized behind another active repository build; Draft CI is the exact-head build authority
