### PR TITLE
fix(fusion): make completion projection idempotent

### DIFF
--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -46,6 +46,7 @@ let create_store () =
   ; last_sweep = Time_compat.now ()
   ; mutex = Eio.Mutex.create ()
   ; persist_mutex = Eio.Mutex.create ()
+  ; origin_create_mutex = Eio.Mutex.create ()
   ; karma_cache = None
   ; sorted_posts_cache = None
   ; comments_by_post = Hashtbl.create 1024
@@ -648,6 +649,122 @@ let create_post
            rollback_fresh_post store post;
            Error e)
       | Error _ as e -> e)
+;;
+
+type create_post_once_result =
+  | Post_created of post
+  | Post_already_present of post
+
+let create_post_once_by_fusion_run_id
+      store
+      ~fusion_run_id
+      ~author
+      ~content
+      ~post_kind
+      ?meta_json
+      ~visibility
+      ~ttl_hours
+      ~origin
+      ()
+  =
+  let option_equal equal left right =
+    match left, right with
+    | None, None -> true
+    | Some left, Some right -> equal left right
+    | None, Some _ | Some _, None -> false
+  in
+  let origin_equal left right =
+    option_equal Ids.Turn_ref.equal left.turn_ref right.turn_ref
+    && option_equal String.equal left.source right.source
+    && option_equal String.equal left.fusion_run_id right.fusion_run_id
+  in
+  let post_kind_equal left right =
+    match left, right with
+    | Human_post, Human_post
+    | Automation_post, Automation_post
+    | System_post, System_post -> true
+    | Human_post, (Automation_post | System_post)
+    | Automation_post, (Human_post | System_post)
+    | System_post, (Human_post | Automation_post) -> false
+  in
+  let visibility_equal left right =
+    match left, right with
+    | Public, Public
+    | Unlisted, Unlisted
+    | Internal, Internal
+    | Direct, Direct -> true
+    | Public, (Unlisted | Internal | Direct)
+    | Unlisted, (Public | Internal | Direct)
+    | Internal, (Public | Unlisted | Direct)
+    | Direct, (Public | Unlisted | Internal) -> false
+  in
+  if String.equal fusion_run_id ""
+  then Error (Validation_error "fusion_run_id must not be empty")
+  else if ttl_hours < 0
+  then Error (Validation_error "ttl_hours must be non-negative")
+  else
+    match origin.fusion_run_id with
+    | Some origin_run_id when String.equal origin_run_id fusion_run_id ->
+      (match
+         Agent_id.of_string author,
+         normalize_post_payload ~content ~post_kind ?meta_json ()
+       with
+       | Error error, _ -> Error error
+       | _, Error (Meta_not_assoc payload) ->
+         Error
+           (Validation_error
+              (Printf.sprintf
+                 "Malformed meta_json: expected JSON object, got %s"
+                 (Yojson.Safe.to_string payload)))
+       | Ok author_id, Ok (title, body, post_kind, meta_json) ->
+         if String.equal body ""
+         then Error (Validation_error "Content cannot be empty")
+         else
+           Eio.Mutex.use_rw ~protect:true store.origin_create_mutex (fun () ->
+             maybe_sweep store;
+             let existing_post =
+               with_lock store (fun () ->
+                 match Hashtbl.find_opt store.posts_by_run_id fusion_run_id with
+                 | None -> None
+                 | Some post_id -> Hashtbl.find_opt store.posts post_id)
+             in
+             match existing_post with
+             | Some post ->
+               let exact_replay =
+                 String.equal (Agent_id.to_string post.author) (Agent_id.to_string author_id)
+                 && String.equal post.title title
+                 && String.equal post.body body
+                 && String.equal post.content body
+                 && post_kind_equal post.post_kind post_kind
+                 && option_equal Yojson.Safe.equal post.meta_json meta_json
+                 && visibility_equal post.visibility visibility
+                 && Option.is_none post.hearth
+                 && Option.is_none post.thread_id
+                 && option_equal origin_equal post.origin (Some origin)
+               in
+               if exact_replay
+               then Ok (Post_already_present post)
+               else
+                 Error
+                   (Already_exists
+                      (Printf.sprintf
+                         "conflicting Fusion Board projection for run_id=%S"
+                         fusion_run_id))
+             | None ->
+               create_post store ~author ~content ~post_kind ?meta_json
+                 ~visibility ~ttl_hours ~origin ()
+               |> Result.map (fun post -> Post_created post)))
+    | Some origin_run_id ->
+      Error
+        (Validation_error
+           (Printf.sprintf
+              "fusion_run_id mismatch: argument=%S origin=%S"
+              fusion_run_id
+              origin_run_id))
+    | None ->
+      Error
+        (Validation_error
+           "create_post_once_by_fusion_run_id requires typed fusion origin")
 ;;
 
 (* Owner-gated in-place edit of an existing post's title/body. The edited content is

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -92,6 +92,27 @@ val create_post :
   unit ->
   (post, board_error) result
 
+type create_post_once_result =
+  | Post_created of post
+  | Post_already_present of post
+
+val create_post_once_by_fusion_run_id :
+  store ->
+  fusion_run_id:string ->
+  author:string ->
+  content:string ->
+  post_kind:post_kind ->
+  ?meta_json:Yojson.Safe.t ->
+  visibility:visibility ->
+  ttl_hours:int ->
+  origin:post_origin ->
+  unit ->
+  (create_post_once_result, board_error) result
+(** Serialize exact-origin create attempts with a fiber-aware store mutex.
+    An exact normalized payload replay for the same typed Fusion run returns
+    the committed post instead of appending another row. A conflicting replay
+    returns [Already_exists]. The regular create path remains unchanged. *)
+
 (** Owner-gated in-place edit of an existing post's title/body.  Returns
     [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
     missing id, and [Validation_error] for empty/oversized content or invalid

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -395,6 +395,20 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
        Ok post
      | Error _ as error -> error)
 
+let create_post_once_by_fusion_run_id ~fusion_run_id ~author ~content ~post_kind
+    ?meta_json ~visibility ~ttl_hours ~origin () =
+  match backend () with
+  | Jsonl store ->
+    (match
+       Board.create_post_once_by_fusion_run_id store ~fusion_run_id ~author
+         ~content ~post_kind ?meta_json ~visibility ~ttl_hours ~origin ()
+     with
+     | Ok (Board.Post_created post as outcome) ->
+       emit_post_created post;
+       Ok outcome
+     | Ok (Board.Post_already_present _ as outcome) -> Ok outcome
+     | Error _ as error -> error)
+
 let update_post ~post_id ~editor ~content ?title ?body ?new_author () =
   match backend () with
   | Jsonl store ->

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -400,13 +400,13 @@ let create_post_once_by_fusion_run_id ~fusion_run_id ~author ~content ~post_kind
   match backend () with
   | Jsonl store ->
     (match
-       Board.create_post_once_by_fusion_run_id store ~fusion_run_id ~author
+       Board_core_persist.create_post_once_by_fusion_run_id store ~fusion_run_id ~author
          ~content ~post_kind ?meta_json ~visibility ~ttl_hours ~origin ()
      with
-     | Ok (Board.Post_created post as outcome) ->
+     | Ok (Board_core_persist.Post_created post as outcome) ->
        emit_post_created post;
        Ok outcome
-     | Ok (Board.Post_already_present _ as outcome) -> Ok outcome
+     | Ok (Board_core_persist.Post_already_present _ as outcome) -> Ok outcome
      | Error _ as error -> error)
 
 let update_post ~post_id ~editor ~content ?title ?body ?new_author () =

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -158,7 +158,7 @@ val create_post_once_by_fusion_run_id :
   ttl_hours:int ->
   origin:Board.post_origin ->
   unit ->
-  (Board.create_post_once_result, Board.board_error) Result.t
+  (Board_core_persist.create_post_once_result, Board.board_error) Result.t
 (** Emit post-created hooks only for the durable first creation. Exact replays
     return the existing typed-origin post without a duplicate Board signal;
     conflicting replays return [Already_exists]. *)

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -148,6 +148,21 @@ val create_post :
   unit ->
   (Board.post, Board.board_error) Result.t
 
+val create_post_once_by_fusion_run_id :
+  fusion_run_id:string ->
+  author:string ->
+  content:string ->
+  post_kind:Board.post_kind ->
+  ?meta_json:Yojson.Safe.t ->
+  visibility:Board.visibility ->
+  ttl_hours:int ->
+  origin:Board.post_origin ->
+  unit ->
+  (Board.create_post_once_result, Board.board_error) Result.t
+(** Emit post-created hooks only for the durable first creation. Exact replays
+    return the existing typed-origin post without a duplicate Board signal;
+    conflicting replays return [Already_exists]. *)
+
 (** Owner-gated in-place edit of an existing post's title/body.  Returns
     [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
     missing id, and [Validation_error] for empty/oversized content or invalid

--- a/lib/board_core_persist.ml
+++ b/lib/board_core_persist.ml
@@ -1,0 +1,1 @@
+include Masc_board_handlers.Board_core_persist

--- a/lib/board_core_persist.mli
+++ b/lib/board_core_persist.mli
@@ -1,0 +1,3 @@
+include module type of struct
+  include Masc_board_handlers.Board_core_persist
+end

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -319,6 +319,7 @@ type store = {
   mutable last_sweep: float;
   mutex: Eio.Mutex.t;
   persist_mutex: Eio.Mutex.t;
+  origin_create_mutex: Eio.Mutex.t;
   (* Phase 2 caches *)
   mutable karma_cache: (string * int) list option;       (** None = stale *)
   mutable sorted_posts_cache: post list option;           (** None = stale *)

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -245,6 +245,7 @@ type store = {
   mutable last_sweep : float;
   mutex : Eio.Mutex.t;
   persist_mutex : Eio.Mutex.t;
+  origin_create_mutex : Eio.Mutex.t;
   mutable karma_cache : (string * int) list option;
   (** [None] = stale. *)
   mutable sorted_posts_cache : post list option;

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -9,16 +9,20 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
+type compute_outcome =
+  | Compute_denied of Fusion_types.deny_reason
+  | Computed of Fusion_types.deliberation_evidence
+
+let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
   match Fusion_policy.decide ~policy request with
   | Fusion_types.Deny reason ->
     Fusion_metrics.record_invocation ~topology `Denied;
-    Denied reason
+    Compute_denied reason
   | Fusion_types.Allow req ->
     (match Fusion_policy.find_preset policy req.Fusion_types.preset with
-     | None ->
-       Fusion_metrics.record_invocation ~topology `Denied;
-       Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
+       | None ->
+         Fusion_metrics.record_invocation ~topology `Denied;
+         Compute_denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
      | Some vp ->
           let preset = Fusion_policy.Validated_preset.preset vp in
           let groups = preset.Fusion_policy.panels in
@@ -367,14 +371,35 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Error (_, u) -> u
           in
           List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
-          (match
-             Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper
-               ~run_id:req.Fusion_types.run_id ~question:req.Fusion_types.prompt
-               ~panel ~judge ~judges:judge_nodes ~judge_usage
-           with
-           | Ok () ->
-             Fusion_metrics.record_invocation ~topology `Completed;
-             Completed { panel; judge }
-           | Error msg ->
-             Fusion_metrics.record_invocation ~topology `Sink_failed;
-             Sink_failed msg))
+          Computed
+            { Fusion_types.question = req.prompt
+            ; panel
+            ; judge
+            ; judges = judge_nodes
+            ; judge_usage
+            })
+
+let project
+    ~base_dir
+    ~topology
+    ~(request : Fusion_types.fusion_request)
+    (deliberation : Fusion_types.deliberation_evidence)
+  =
+  match
+    Fusion_sink.emit ~base_dir ~keeper:request.keeper ~run_id:request.run_id
+      ~question:deliberation.question ~panel:deliberation.panel
+      ~judge:deliberation.judge ~judges:deliberation.judges
+      ~judge_usage:deliberation.judge_usage
+  with
+  | Ok () ->
+    Fusion_metrics.record_invocation ~topology `Completed;
+    Completed { panel = deliberation.panel; judge = deliberation.judge }
+  | Error msg ->
+    Fusion_metrics.record_invocation ~topology `Sink_failed;
+    Sink_failed msg
+;;
+
+let run ~sw ~net ~base_dir ~policy ~topology ~request () =
+  match compute ~sw ~net ~policy ~topology ~request () with
+  | Compute_denied reason -> Denied reason
+  | Computed deliberation -> project ~base_dir ~topology ~request deliberation

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -16,6 +16,30 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
+type compute_outcome =
+  | Compute_denied of Fusion_types.deny_reason
+  | Computed of Fusion_types.deliberation_evidence
+
+(** Run panel and judge computation without Board, chat, wake, or run-registry
+    projection. The caller can durably claim the semantic terminal before
+    passing a [Computed] value to {!project}. *)
+val compute
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> policy:Fusion_policy.t
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> unit
+  -> compute_outcome
+
+(** Project one already-computed deliberation to the existing sink. *)
+val project
+  :  base_dir:string
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> Fusion_types.deliberation_evidence
+  -> outcome
+
 (** 요청을 심의한다.
 
     + [Fusion_policy.decide]로 정책 판정 → [Deny]면 [Denied] 반환(부작용 없음).

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -485,7 +485,7 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
       with
       | Error (Board.Already_exists detail) ->
         Error (Printf.sprintf "Fusion Board projection identity conflict: %s" detail)
-      | Ok (Board.Post_created post | Board.Post_already_present post) ->
+      | Ok (Board_core_persist.Post_created post | Board_core_persist.Post_already_present post) ->
         Ok (Ok post)
       | Error error -> Ok (Error error)
     in

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -387,6 +387,14 @@ let wake_keeper_on_fusion_completion
 
 let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage :
     (unit, string) result =
+  let ( let* ) = Result.bind in
+  let* delivery_key =
+    Keeper_chat_delivery_identity.Request_id.of_string run_id
+    |> Result.map (fun request_id ->
+      Keeper_chat_delivery_identity.Async_request request_id)
+    |> Result.map_error (fun detail ->
+      Printf.sprintf "invalid Fusion run delivery identity: %s" detail)
+  in
   try
     (* 비용 관측(제약 아님) — 패널 N + 심판 1 실측 토큰 합산 (RFC §10). board 증거에만
        남긴다 (cost cap은 v1 제외, 측정값만 — 괴상한 제약 제거 원칙). 실패한 패널/심판은
@@ -468,10 +476,18 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
     let origin : Board.post_origin =
       { turn_ref = None; source = Some "fusion"; fusion_run_id = Some run_id }
     in
-    let board_result =
-      Board_dispatch.create_post ~author:keeper ~content:board_headline
-        ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
-        ~ttl_hours:board_post_ttl_hours ~origin ()
+    let* board_result =
+      match
+        Board_dispatch.create_post_once_by_fusion_run_id ~fusion_run_id:run_id
+          ~author:keeper ~content:board_headline
+          ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
+          ~ttl_hours:board_post_ttl_hours ~origin ()
+      with
+      | Error (Board.Already_exists detail) ->
+        Error (Printf.sprintf "Fusion Board projection identity conflict: %s" detail)
+      | Ok (Board.Post_created post | Board.Post_already_present post) ->
+        Ok (Ok post)
+      | Error error -> Ok (Error error)
     in
     (* 키퍼 메인 흐름 통합 ("결과를 키퍼 흐름에 녹이기", RFC-0252 §8 개정).
        상세 트랜스크립트(패널 답변 N개)는 위 board post 증거로만 남기고, 키퍼 chat
@@ -514,13 +530,14 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
          실패를 삼켜 emit이 Ok를 반환했었다(silent drop). [_result] 변형으로 실패를
          surface한다. 성공한 경우에만 broadcast한다. *)
       match
-        Keeper_chat_store.append_assistant_message_result ~base_dir
-          ~keeper_name:keeper ~content ?blocks ()
+        Keeper_chat_store.append_assistant_message_once ~base_dir
+          ~keeper_name:keeper ~delivery_key ~content ?blocks ()
       with
-      | Ok () ->
+      | Ok (Keeper_chat_store.Appended _) ->
         Keeper_chat_broadcast.chat_appended ~keeper_name:keeper
           ~source:"fusion" ~content ();
         Ok ()
+      | Ok (Keeper_chat_store.Already_present _) -> Ok ()
       | Error _ as e -> e
     in
     (* RFC-0266 (개정, board best-effort): completion 여부는 *키퍼가 결론을 받았는가*

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -255,6 +255,44 @@ type judge_outcome =
   | Judge_failed of judge_error_node  (** panel [Failed] 대칭. *)
 [@@deriving yojson, show, eq]
 
+let result_to_yojson ok_to_yojson error_to_yojson = function
+  | Ok value -> `List [ `String "Ok"; ok_to_yojson value ]
+  | Error error -> `List [ `String "Error"; error_to_yojson error ]
+;;
+
+let result_of_yojson ok_of_yojson error_of_yojson = function
+  | `List [ `String "Ok"; value ] ->
+    Result.map (fun value -> Ok value) (ok_of_yojson value)
+  | `List [ `String "Error"; error ] ->
+    Result.map (fun error -> Error error) (error_of_yojson error)
+  | json ->
+    Error
+      (Printf.sprintf
+         "Fusion_types.deliberation_evidence.judge: unsupported shape %s"
+         (Yojson.Safe.to_string json))
+;;
+
+let equal_result equal_ok equal_error left right =
+  match left, right with
+  | Ok left, Ok right -> equal_ok left right
+  | Error left, Error right -> equal_error left right
+  | Ok _, Error _ | Error _, Ok _ -> false
+;;
+
+let pp_result pp_ok pp_error formatter = function
+  | Ok value -> Format.fprintf formatter "(Ok %a)" pp_ok value
+  | Error error -> Format.fprintf formatter "(Error %a)" pp_error error
+;;
+
+type deliberation_evidence =
+  { question : string
+  ; panel : panel_outcome list
+  ; judge : (judge_synthesis, judge_failure) result
+  ; judges : judge_outcome list
+  ; judge_usage : usage
+  }
+[@@deriving yojson, show, eq]
+
 type fusion_trigger =
   | Explicit_tool_call
   | Low_confidence

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -266,6 +266,18 @@ type judge_outcome =
   | Judge_failed of judge_error_node
 [@@deriving yojson, show, eq]
 
+(** One completed panel+judge computation before any Board/chat/wake
+    projection. This is the typed payload stored in the common async request's
+    canonical terminal record; projection failures are outside this record. *)
+type deliberation_evidence =
+  { question : string
+  ; panel : panel_outcome list
+  ; judge : (judge_synthesis, judge_failure) result
+  ; judges : judge_outcome list
+  ; judge_usage : usage
+  }
+[@@deriving yojson, show, eq]
+
 (** {1 트리거} *)
 
 (** fusion 발동 사유 — 게이트 입력(이유 라벨). catch-all 없음.

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -2159,7 +2159,9 @@ let runtime_cancelled_status () =
 ;;
 
 let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
-    ~base_path ~caller ~(f : Eio.Switch.t -> tool_result) ~keeper_name () :
+    ~base_path ~caller
+    ~(f : request_id:string -> Eio.Switch.t -> tool_result)
+    ~keeper_name () :
     (submit_outcome, submit_error) result =
   match resolve_access_identity ~base_path ~caller with
   | Error rejection -> Error (Submit_rejected rejection)
@@ -2369,7 +2371,7 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
            | `Operator_cancelled -> raise CancelledByOperator
            | `Already_settled entry -> raise (Worker_already_settled entry)
            | `Preempted reason -> raise (Worker_preempted reason));
-          let result = f req_sw in
+          let result = f ~request_id req_sw in
           let data =
             match Tool_result.data result with
             | `String _ -> None
@@ -2457,7 +2459,15 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
           background_start_failed (Printexc.to_string exn))))))
 ;;
 
-let submit = submit_with_ops production_request_ops
+let submit_with_request_id = submit_with_ops production_request_ops
+
+let submit ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
+    ~base_path ~caller ~f ~keeper_name () =
+  submit_with_request_id ?on_accepted ?on_worker_aborted ?on_worker_settled
+    ~background_sw ~base_path ~caller
+    ~f:(fun ~request_id:_ request_sw -> f request_sw)
+    ~keeper_name ()
+;;
 
 (** Exact owner check for both the process-global table and persisted rows. *)
 let owner_rejection ~caller (entry : entry) =
@@ -2844,7 +2854,15 @@ module For_testing = struct
   let atomic_staging_dir = atomic_staging_dir
   let load_record = load_record
   let recover_lost_disk_records = recover_lost_disk_records
-  let submit = submit_with_ops
+  let submit_with_request_id = submit_with_ops
+
+  let submit ops ?on_accepted ?on_worker_aborted ?on_worker_settled
+      ~background_sw ~base_path ~caller ~f ~keeper_name () =
+    submit_with_request_id ops ?on_accepted ?on_worker_aborted
+      ?on_worker_settled ~background_sw ~base_path ~caller
+      ~f:(fun ~request_id:_ request_sw -> f request_sw)
+      ~keeper_name ()
+  ;;
   let cancel = cancel_with_ops
   let reserved_request_id_count () =
     Eio.Mutex.use_ro mu (fun () -> Store_transition_table.length reserved_request_ids)

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -305,6 +305,23 @@ val submit
   -> unit
   -> (submit_outcome, submit_error) result
 
+(** Same lifecycle and durability contract as {!submit}, but the worker also
+    receives the canonical request id generated and accepted by this module.
+    Use this when a producer's durable artifacts must share that identity;
+    callers needing only fire-and-forget execution should keep using
+    {!submit}. *)
+val submit_with_request_id
+  :  ?on_accepted:(string -> (unit, string) result)
+  -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
+  -> ?on_worker_settled:(worker_settlement -> unit)
+  -> background_sw:Eio.Switch.t
+  -> base_path:string
+  -> caller:string
+  -> f:(request_id:string -> Eio.Switch.t -> Keeper_types_profile.tool_result)
+  -> keeper_name:string
+  -> unit
+  -> (submit_outcome, submit_error) result
+
 (** [poll ~base_path ~caller request_id] returns [Found entry] for a known request,
     [Absent] when no record exists, and [Unreadable reason] when a persisted
     record exists but cannot be decoded. [Rejected reason] means the request
@@ -412,6 +429,19 @@ module For_testing : sig
     -> base_path:string
     -> caller:string
     -> f:(Eio.Switch.t -> Keeper_types_profile.tool_result)
+    -> keeper_name:string
+    -> unit
+    -> (submit_outcome, submit_error) result
+
+  val submit_with_request_id
+    :  request_ops
+    -> ?on_accepted:(string -> (unit, string) result)
+    -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
+    -> ?on_worker_settled:(worker_settlement -> unit)
+    -> background_sw:Eio.Switch.t
+    -> base_path:string
+    -> caller:string
+    -> f:(request_id:string -> Eio.Switch.t -> Keeper_types_profile.tool_result)
     -> keeper_name:string
     -> unit
     -> (submit_outcome, submit_error) result

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
@@ -86,6 +86,7 @@ end
 
 type delivery_key =
   | Direct_request of Request_id.t
+  | Async_request of Request_id.t
   | Queue_receipts of Receipt_ids.t
 
 type transcript_slot =
@@ -133,6 +134,11 @@ let delivery_key_to_yojson = function
       [ "kind", `String "direct_request"
       ; "request_id", `String (Request_id.to_string request_id)
       ]
+  | Async_request request_id ->
+    `Assoc
+      [ "kind", `String "async_request"
+      ; "request_id", `String (Request_id.to_string request_id)
+      ]
   | Queue_receipts receipt_ids ->
     `Assoc
       [ "kind", `String "queue_receipts"
@@ -158,6 +164,16 @@ let delivery_key_of_yojson = function
        let* request_id = string_field "request_id" fields in
        let* request_id = Request_id.of_string request_id in
        Ok (Direct_request request_id)
+     | "async_request" ->
+       let* () =
+         validate_fields
+           ~context:"async request delivery identity"
+           ~expected:[ "kind"; "request_id" ]
+           fields
+       in
+       let* request_id = string_field "request_id" fields in
+       let* request_id = Request_id.of_string request_id in
+       Ok (Async_request request_id)
      | "queue_receipts" ->
        let* () =
          validate_fields
@@ -194,6 +210,7 @@ let delivery_key_of_yojson = function
 let delivery_key_equal left right =
   match left, right with
   | Direct_request left, Direct_request right -> Request_id.equal left right
+  | Async_request left, Async_request right -> Request_id.equal left right
   | Queue_receipts left, Queue_receipts right ->
     let rec equal_lists left right =
       match left, right with
@@ -203,8 +220,9 @@ let delivery_key_equal left right =
       | [], _ :: _ | _ :: _, [] -> false
     in
     equal_lists (Receipt_ids.to_list left) (Receipt_ids.to_list right)
-  | Direct_request _, Queue_receipts _
-  | Queue_receipts _, Direct_request _ -> false
+  | Direct_request _, (Async_request _ | Queue_receipts _)
+  | Async_request _, (Direct_request _ | Queue_receipts _)
+  | Queue_receipts _, (Direct_request _ | Async_request _) -> false
 ;;
 
 let delivery_key_file_stem key =
@@ -217,6 +235,7 @@ let delivery_key_file_stem key =
   in
   match key with
   | Direct_request _ -> "direct-" ^ digest
+  | Async_request _ -> "async-" ^ digest
   | Queue_receipts _ -> "queue-" ^ digest
 ;;
 

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
@@ -33,6 +33,7 @@ end
 
 type delivery_key =
   | Direct_request of Request_id.t
+  | Async_request of Request_id.t
   | Queue_receipts of Receipt_ids.t
 
 type transcript_slot =

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -261,6 +261,26 @@ let failure_judgment_identity_equal left right =
        left.fj_provenance
        right.fj_provenance
 
+let fusion_terminal_equal left right =
+  match left, right with
+  | Fusion_succeeded left, Fusion_succeeded right
+  | Fusion_failed left, Fusion_failed right -> String.equal left right
+  | Fusion_cancelled, Fusion_cancelled -> true
+  | Fusion_succeeded _, (Fusion_failed _ | Fusion_cancelled)
+  | Fusion_failed _, (Fusion_succeeded _ | Fusion_cancelled)
+  | Fusion_cancelled, (Fusion_succeeded _ | Fusion_failed _) -> false
+
+let fusion_completion_identity_equal left right =
+  String.equal left.run_id right.run_id
+  && fusion_terminal_equal left.terminal right.terminal
+  && String.equal left.board_post_id right.board_post_id
+  (* The first durably committed row owns recipient authority. A replay after
+     that commit no longer has the consumed in-memory route and therefore
+     carries [Unrouted]; treating [channel] as event identity would turn an
+     exact result replay into a false conflict. [enqueue_external_decision]
+     retains the existing row, so excluding the channel here never overwrites
+     the authoritative recipient. *)
+
 let stimulus_identity_equal a b =
   String.equal a.post_id b.post_id
   && a.urgency = b.urgency
@@ -268,6 +288,8 @@ let stimulus_identity_equal a b =
   match a.payload, b.payload with
   | Failure_judgment left, Failure_judgment right ->
     failure_judgment_identity_equal left right
+  | Fusion_completed left, Fusion_completed right ->
+    fusion_completion_identity_equal left right
   | _ -> identity_payload a.payload = identity_payload b.payload
 
 let to_list (queue : t) : stimulus list =

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -178,9 +178,7 @@ and goal_assignment = {
      repeat assignments of the same goal dedup regardless of actor. *)
 }
 
-let fusion_completion_post_id (fc : fusion_completion) =
-  if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
-  else fc.board_post_id
+let fusion_completion_post_id (fc : fusion_completion) = "fusion-run:" ^ fc.run_id
 
 let bg_job_completion_post_id (c : bg_job_completion) =
   if String.equal c.bg_board_post_id "" then "bg-run:" ^ c.bg_run_id
@@ -273,13 +271,11 @@ let fusion_terminal_equal left right =
 let fusion_completion_identity_equal left right =
   String.equal left.run_id right.run_id
   && fusion_terminal_equal left.terminal right.terminal
-  && String.equal left.board_post_id right.board_post_id
-  (* The first durably committed row owns recipient authority. A replay after
-     that commit no longer has the consumed in-memory route and therefore
-     carries [Unrouted]; treating [channel] as event identity would turn an
-     exact result replay into a false conflict. [enqueue_external_decision]
-     retains the existing row, so excluding the channel here never overwrites
-     the authoritative recipient. *)
+  (* The first durably committed row owns optional Board evidence and recipient
+     authority. A retry may observe a recovered Board sink or a consumed
+     in-memory route; neither changes the Fusion result identity.
+     [enqueue_external_decision] retains the existing row, so excluding these
+     projections never overwrites their first committed values. *)
 
 let stimulus_identity_equal a b =
   String.equal a.post_id b.post_id

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -250,7 +250,11 @@ val enqueue : t -> stimulus -> t
 val stimulus_identity_equal : stimulus -> stimulus -> bool
 (** [true] when two stimuli describe the same durable event. The comparison
     intentionally ignores [arrived_at], so restart/bootstrap re-enqueues do
-    not create an unbounded backlog of otherwise identical stimuli. *)
+    not create an unbounded backlog of otherwise identical stimuli. For a
+    [Fusion_completed] event, [channel] is also excluded: the first committed
+    row owns recipient authority, while a replay after route consumption is
+    expected to be [Unrouted]. Result, run, and Board evidence must still
+    match exactly. *)
 
 val to_list : t -> stimulus list
 (** Return the FIFO contents. *)

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -203,9 +203,9 @@ and goal_assignment = {
 
 
 val fusion_completion_post_id : fusion_completion -> post_id
-(** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the
-    sink created a board evidence post, otherwise falls back to
-    ["fusion-run:<run_id>"]. *)
+(** Canonical dedup/correlation id for [Fusion_completed], always
+    ["fusion-run:<run_id>"]. Board projection availability is not event
+    identity. *)
 
 val bg_job_completion_post_id : bg_job_completion -> post_id
 (** RFC-0290 dedup/correlation id for [Bg_completed]. Uses [bg_board_post_id]
@@ -251,10 +251,10 @@ val stimulus_identity_equal : stimulus -> stimulus -> bool
 (** [true] when two stimuli describe the same durable event. The comparison
     intentionally ignores [arrived_at], so restart/bootstrap re-enqueues do
     not create an unbounded backlog of otherwise identical stimuli. For a
-    [Fusion_completed] event, [channel] is also excluded: the first committed
-    row owns recipient authority, while a replay after route consumption is
-    expected to be [Unrouted]. Result, run, and Board evidence must still
-    match exactly. *)
+    [Fusion_completed] event, [board_post_id] and [channel] are also excluded:
+    the first committed row owns those projections, while a retry may observe
+    Board recovery or route consumption. Result and run must still match
+    exactly. *)
 
 val to_list : t -> stimulus list
 (** Return the FIFO contents. *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1682,8 +1682,10 @@ let process_single_turn ~user_row_origin ~queued_turn
     match queued_turn, delivery_key with
     | true, Some (Keeper_chat_delivery_identity.Queue_receipts _ as key) ->
       Ok key
-    | true, Some (Keeper_chat_delivery_identity.Direct_request _) ->
-      Error "queued Keeper turn received a direct-request delivery identity"
+    | true, Some
+        (Keeper_chat_delivery_identity.Direct_request _
+        | Keeper_chat_delivery_identity.Async_request _) ->
+      Error "queued Keeper turn received a non-queue delivery identity"
     | true, None ->
       Error "queued Keeper turn is missing its receipt delivery identity"
     | false, _ -> Error "non-queued Keeper turn requested queue delivery identity"

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1384,6 +1384,27 @@ let test_judge_error_node_timed_out () =
       None n2.elapsed_s
   | _ -> Alcotest.fail "expected Judge_failed roundtrip"
 
+let test_deliberation_evidence_roundtrip () =
+  let evidence : Fusion_types.deliberation_evidence =
+    { question = "Which implementation is sound?"
+    ; panel = []
+    ; judge = Error Fusion_types.Empty_result
+    ; judges = []
+    ; judge_usage = { input_tokens = 11; output_tokens = 7 }
+    }
+  in
+  match
+    Fusion_types.deliberation_evidence_to_yojson evidence
+    |> Fusion_types.deliberation_evidence_of_yojson
+  with
+  | Ok decoded ->
+    Alcotest.(check bool)
+      "typed evidence is lossless"
+      true
+      (Fusion_types.equal_deliberation_evidence evidence decoded)
+  | Error detail -> Alcotest.fail detail
+;;
+
 let () =
   Alcotest.run "fusion_core"
     [ ( "gate"
@@ -1488,6 +1509,8 @@ let () =
       , [ Alcotest.test_case "roundtrip" `Quick test_judge_outcome_roundtrip
         ; Alcotest.test_case "timed_out_elapsed_s" `Quick
             test_judge_error_node_timed_out
+        ; Alcotest.test_case "deliberation evidence roundtrip" `Quick
+            test_deliberation_evidence_roundtrip
         ] )
     ; ( "panel_guard"
       , [ Alcotest.test_case "min_answered_range" `Quick test_validated_bad_min_answered

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -91,8 +91,8 @@ let restore_env name = function
   | None -> Unix.putenv name ""
 ;;
 
-(* Board_dispatch.create_post (via Fusion_sink.emit) needs a live Eio
-   scheduler for its lock/cancellation-context effects (Effect.Unhandled
+(* Fusion_sink's Board projection needs a live Eio scheduler for its
+   lock/cancellation-context effects (Effect.Unhandled
    (Eio.Cancel.Get_context) otherwise) — same [Eio_main.run] +
    [Fs_compat.set_fs] wrapper test_board_dispatch.ml's [with_eio] uses. *)
 let with_isolated_eio_base_path prefix f =
@@ -614,6 +614,58 @@ let test_emit_success_projects_board_chat_and_registry () =
        check string "chat fusion block post id" post_id block_post_id;
        check string "chat fusion block run id" run_id block_run_id
      | None -> fail "chat lane should carry a Fusion block for the board evidence");
+    let replay =
+      Fusion_sink.emit ~base_dir ~keeper ~run_id ~question ~panel
+        ~judge:(Ok synthesis) ~judges ~judge_usage
+    in
+    check bool "same completion replay succeeds" true (Result.is_ok replay);
+    let posts_for_run =
+      Board.list_posts (Board.global ()) ()
+      |> List.filter (fun (candidate : Board.post) ->
+        match candidate.origin with
+        | Some { fusion_run_id = Some candidate_run_id; _ } ->
+          String.equal candidate_run_id run_id
+        | Some { fusion_run_id = None; _ } | None -> false)
+    in
+    check int "same completion creates one Board post" 1
+      (List.length posts_for_run);
+    let replay_messages =
+      Keeper_chat_store.load ~base_dir ~keeper_name:keeper
+      |> List.filter (fun (message : Keeper_chat_store.chat_message) ->
+        contains ~needle:resolved_answer message.content)
+    in
+    check int "same completion appends one chat row" 1
+      (List.length replay_messages);
+    check int "same completion queues one durable wake" 1
+      (Keeper_event_queue.length
+         (Keeper_event_queue_persistence.load
+            ~base_path:base_dir
+            ~keeper_name:keeper));
+    let conflicting_replay =
+      Fusion_sink.emit ~base_dir ~keeper ~run_id
+        ~question:(question ^ " changed") ~panel ~judge:(Ok synthesis) ~judges
+        ~judge_usage
+    in
+    check bool "changed completion replay is rejected" true
+      (Result.is_error conflicting_replay);
+    check int "conflicting replay keeps one Board post" 1
+      (Board.list_posts (Board.global ()) ()
+       |> List.filter (fun (candidate : Board.post) ->
+         match candidate.origin with
+         | Some { fusion_run_id = Some candidate_run_id; _ } ->
+           String.equal candidate_run_id run_id
+         | Some { fusion_run_id = None; _ } | None -> false)
+       |> List.length);
+    check int "conflicting replay keeps one chat row" 1
+      (Keeper_chat_store.load ~base_dir ~keeper_name:keeper
+       |> List.filter (fun (message : Keeper_chat_store.chat_message) ->
+         contains ~needle:resolved_answer message.content)
+       |> List.length);
+    check int "conflicting replay keeps one durable wake" 1
+      (Keeper_event_queue.length
+         (Keeper_event_queue_persistence.load
+            ~base_path:base_dir
+            ~keeper_name:keeper));
     match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
     | Some { Fusion_run_registry.status = Completed { ok = true; _ }; _ } -> ()
     | Some { Fusion_run_registry.status = Completed { ok = false; _ }; _ } ->
@@ -736,20 +788,45 @@ let test_wake_durable_commit_carries_channel_and_consumes_route () =
     check bool "wake commits durably" true (Result.is_ok result);
     check bool "route consumed only after the durable commit" true
       (Fusion_wake_route.peek ~keeper ~run_id = None);
+    (match
+       Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+       |> Keeper_event_queue.dequeue
+     with
+     | Some ({ payload = Keeper_event_queue.Fusion_completed fc; _ }, _) ->
+       check string "durable completion run id" run_id fc.run_id;
+       (match fc.channel with
+        | Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ } -> ()
+        | other ->
+          fail
+            (Printf.sprintf "durable channel must be the originating route, got %s"
+               (Keeper_continuation_channel.describe other)))
+     | Some _ -> fail "unexpected durable stimulus kind"
+     | None -> fail "completion stimulus must be durably persisted with its channel");
+    let replay =
+      Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
+        ~ok:true ~resolved_answer:"WAKE-DURABLE-ANSWER"
+        ~board_post_id:"post-wake-1"
+    in
+    check bool "route-less replay accepts the committed recipient" true
+      (Result.is_ok replay);
     match
       Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
       |> Keeper_event_queue.dequeue
     with
-    | Some ({ payload = Keeper_event_queue.Fusion_completed fc; _ }, _) ->
-      check string "durable completion run id" run_id fc.run_id;
+    | Some
+        ( { payload = Keeper_event_queue.Fusion_completed fc; _ }
+        , remaining ) ->
+      check int "route-less replay keeps one durable completion" 0
+        (Keeper_event_queue.length remaining);
       (match fc.channel with
        | Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ } -> ()
        | other ->
          fail
-           (Printf.sprintf "durable channel must be the originating route, got %s"
+           (Printf.sprintf
+              "replay must preserve the first committed recipient, got %s"
               (Keeper_continuation_channel.describe other)))
-    | Some _ -> fail "unexpected durable stimulus kind"
-    | None -> fail "completion stimulus must be durably persisted with its channel")
+    | Some _ -> fail "unexpected durable stimulus kind after replay"
+    | None -> fail "durable completion disappeared after replay")
 ;;
 
 (* P1-A fail-closed: when the durable commit fails (here a conflicting durable

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -277,7 +277,7 @@ let test_fusion_completion_is_actionable () =
       ~arrived_at:1000.0
       fc
   in
-  check string "post_id correlates to the board post" "post-77" ev.post_id;
+  check string "post_id is canonical Fusion identity" "fusion-run:fus-1" ev.post_id;
   check bool "preview carries the resolved answer" true (contains ~needle:"ANSWER-TOKEN-xyz" ev.preview);
   check string "author remains context" meta.name ev.author;
   check bool "post kind remains context" true
@@ -486,8 +486,7 @@ let test_scheduled_wake_is_actionable () =
        ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
-(* (3) an empty board_post_id (sink failed to create the post) still delivers
-   the answer under a synthetic, non-empty post id. *)
+(* (3) Board availability never changes the durable completion identity. *)
 let test_missing_board_post_id_fallback () =
   let meta = make_meta () in
   let fc = fusion_payload ~run_id:"fus-9" ~board_post_id:"" () in
@@ -838,13 +837,15 @@ let test_wake_fail_closed_preserves_route () =
     let keeper = Printf.sprintf "fusion-wake-fc-%d" (Random.bits ()) in
     let run_id = Printf.sprintf "fus-wake-fc-%d" (Random.bits ()) in
     let board_post_id = "post-wake-fc-1" in
+    let conflicting_payload =
+      fusion_payload ~run_id ~board_post_id
+        ~resolved_answer:"CONFLICTING-PRIOR-ANSWER" ()
+    in
     let conflicting : Keeper_event_queue.stimulus =
-      { post_id = board_post_id
+      { post_id = Keeper_event_queue.fusion_completion_post_id conflicting_payload
       ; urgency = Keeper_event_queue.Normal
       ; arrived_at = 1.0
-      ; payload =
-          Keeper_event_queue.Fusion_completed
-            (fusion_payload ~run_id ~board_post_id ~resolved_answer:"CONFLICTING-PRIOR-ANSWER" ())
+      ; payload = Keeper_event_queue.Fusion_completed conflicting_payload
       }
     in
     (match
@@ -892,6 +893,39 @@ let test_completion_wake_does_not_signal_replacement_lane () =
            (Atomic.get captured.fiber_wakeup);
          check bool "replacement lane is not signaled" false
            (Atomic.get replacement.fiber_wakeup)))
+;;
+
+let test_wake_board_recovery_keeps_canonical_identity () =
+  with_isolated_base_path "fusion-wake-board-recovery" (fun base_dir ->
+    let keeper = Printf.sprintf "fusion-board-recovery-%d" (Random.bits ()) in
+    let run_id = Printf.sprintf "fus-board-recovery-%d" (Random.bits ()) in
+    Fusion_wake_route.register ~base_path:base_dir ~keeper ~run_id (Some discord_channel);
+    let first =
+      Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
+        ~ok:true ~resolved_answer:"RECOVERED-ANSWER" ~board_post_id:""
+    in
+    check bool "completion without Board evidence commits" true (Result.is_ok first);
+    let replay =
+      Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
+        ~ok:true ~resolved_answer:"RECOVERED-ANSWER"
+        ~board_post_id:"post-created-on-retry"
+    in
+    check bool "Board recovery replay is idempotent" true (Result.is_ok replay);
+    match
+      Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+      |> Keeper_event_queue.to_list
+    with
+    | [ { post_id; payload = Keeper_event_queue.Fusion_completed completion; _ } ] ->
+      check string "canonical durable identity" ("fusion-run:" ^ run_id) post_id;
+      check string "first committed Board projection remains authoritative" ""
+        completion.board_post_id;
+      (match completion.channel with
+       | Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ } -> ()
+       | other ->
+         fail
+           (Printf.sprintf "first committed route changed: %s"
+              (Keeper_continuation_channel.describe other)))
+    | _ -> fail "Board recovery replay created more than one durable completion")
 ;;
 
 let test_completion_stimulus_persists_without_live_registry () =
@@ -1139,6 +1173,10 @@ let () =
             "completion wake never signals a replacement Keeper lane"
             `Quick
             test_completion_wake_does_not_signal_replacement_lane
+        ; test_case
+            "Board recovery replay keeps canonical wake identity"
+            `Quick
+            test_wake_board_recovery_keeps_canonical_identity
         ; test_case
             "completion stimulus persists without live registry"
             `Quick

--- a/test/test_keeper_chat_delivery_identity.ml
+++ b/test/test_keeper_chat_delivery_identity.ml
@@ -49,6 +49,26 @@ let test_queue_requires_nonempty_receipts () =
     (Identity.delivery_key_equal key decoded)
 ;;
 
+let test_async_roundtrip () =
+  let request_id =
+    Identity.Request_id.of_string "fus-async-test" |> expect_ok
+  in
+  let key = Identity.Async_request request_id in
+  let decoded =
+    Identity.delivery_key_to_yojson key
+    |> Identity.delivery_key_of_yojson
+    |> expect_ok
+  in
+  check bool "async identity roundtrips" true
+    (Identity.delivery_key_equal key decoded);
+  check bool "async namespace differs from direct" false
+    (Identity.delivery_key_equal key (Identity.Direct_request request_id));
+  check bool "async filename namespace is stable" true
+    (String.equal
+       (Identity.delivery_key_file_stem key)
+       (Identity.delivery_key_file_stem decoded))
+;;
+
 let test_transcript_slot_roundtrip () =
   let slots =
     [ Identity.Accepted_user
@@ -109,6 +129,10 @@ let () =
     "keeper chat delivery identity"
     [ ( "identity"
       , [ test_case "direct roundtrip" `Quick test_direct_roundtrip
+        ; test_case
+            "async request roundtrip"
+            `Quick
+            test_async_roundtrip
         ; test_case
             "queue identity is nonempty"
             `Quick

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -75,6 +75,29 @@ let wait_until ~clock ~max_iterations ~interval_sec predicate =
   loop max_iterations
 ;;
 
+let test_identified_worker_receives_accepted_request_id () =
+  with_temp_base (fun base_path ->
+    Eio_main.run (fun _env ->
+      Eio.Switch.run (fun sw ->
+        let observed, resolve_observed = Eio.Promise.create () in
+        let accepted =
+          Keeper_msg_async.submit_with_request_id
+            ~background_sw:sw
+            ~base_path
+            ~caller
+            ~keeper_name:"terminal-event-identified"
+            ~f:(fun ~request_id _request_sw ->
+              Eio.Promise.resolve resolve_observed request_id;
+              Keeper_types_profile.tool_result_ok "completed")
+            ()
+          |> accepted_request_id
+        in
+        check string
+          "worker identity is the accepted request id"
+          accepted
+          (Eio.Promise.await observed))))
+;;
+
 let test_operator_cancel_running_worker_invokes_on_worker_aborted () =
   with_temp_base (fun base_path ->
     Eio_main.run (fun env ->
@@ -343,7 +366,11 @@ let test_closed_background_switch_rejects_worker_acceptance () =
 let () =
   run
     "keeper_msg_async_terminal_event"
-    [ ( "on_worker_aborted"
+    [ ( "worker identity"
+      , [ test_case "identified worker receives accepted request id" `Quick
+            test_identified_worker_receives_accepted_request_id
+        ] )
+    ; ( "on_worker_aborted"
       , [ test_case "operator cancel running worker invokes on_worker_aborted" `Quick
             test_operator_cancel_running_worker_invokes_on_worker_aborted
         ; test_case "abort callback failure stays inside the request lane" `Quick


### PR DESCRIPTION
Stacked on #25340.\n\nMakes Fusion completion replay exact and idempotent across Board, keeper chat, and durable wake projection. Conflicting same-run Board payloads fail explicitly. The first durably committed continuation channel remains recipient authority when a retry occurs after the in-memory route was consumed.\n\nValidation:\n- ocamlc -stop-after parsing on touched OCaml files\n- ocamlformat --check on touched OCaml files\n- git diff --check\n- focused Dune deferred because a machine-wide bare dune build is active; CI is authoritative