### PR TITLE
feat(keeper): persist typed paused-owner resume intent

### DIFF
--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -1,5 +1,7 @@
 type operation = Resume_owner
 
+type keeper_lock = { keeper_name : string }
+
 type t =
   { keeper_name : string
   ; expected_trace_id : Keeper_id.Trace_id.t
@@ -13,7 +15,6 @@ type save_result =
   | Created
   | Existing of t
 
-type keeper_lock = { keeper_name : string }
 
 let ( let* ) = Result.bind
 
@@ -143,13 +144,13 @@ let with_keeper_lock config ~keeper_name f =
     (match
        File_lock_eio.with_durable_lock
          ~lock_path:(Filename.concat dir "keeper-disposition.lock")
-         (fun () -> f { keeper_name })
+         (fun () -> f ({ keeper_name } : keeper_lock))
      with
      | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
      | Ok result -> Ok result)
 ;;
 
-let save_if_absent lock config receipt =
+let save_if_absent (lock : keeper_lock) config receipt =
   let* () = validate receipt in
   let* () =
     if String.equal lock.keeper_name receipt.keeper_name

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -132,6 +132,8 @@ let with_keeper_lock config ~keeper_name f =
     let dir = keeper_dir config keeper_name in
     let prepared =
       try
+        (* [ensure_dir] returns the created path; only its side effect matters
+           here, and any failure is caught below and surfaced as [Error]. *)
         ignore (Keeper_fs.ensure_dir dir : string);
         Ok ()
       with

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -132,8 +132,7 @@ let with_keeper_lock config ~keeper_name f =
     let dir = keeper_dir config keeper_name in
     let prepared =
       try
-        (* [ensure_dir] returns the created path; only its side effect matters
-           here, and any failure is caught below and surfaced as [Error]. *)
+        (* fire-and-forget: only [ensure_dir]'s side effect matters; a failure is caught below and surfaced as [Error]. *)
         ignore (Keeper_fs.ensure_dir dir : string);
         Ok ()
       with

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -1,0 +1,193 @@
+type operation = Resume_owner
+
+type t =
+  { keeper_name : string
+  ; expected_trace_id : Keeper_id.Trace_id.t
+  ; expected_generation : int
+  ; operator_operation_id : string
+  ; requested_at : float
+  ; operation : operation
+  }
+
+type save_result =
+  | Created
+  | Existing of t
+
+type keeper_lock = { keeper_name : string }
+
+let ( let* ) = Result.bind
+
+let equal left right =
+  String.equal left.keeper_name right.keeper_name
+  && Keeper_id.Trace_id.equal left.expected_trace_id right.expected_trace_id
+  && Int.equal left.expected_generation right.expected_generation
+  && String.equal left.operator_operation_id right.operator_operation_id
+  && Float.equal left.requested_at right.requested_at
+  && left.operation = right.operation
+;;
+
+let validate receipt =
+  if String.equal (String.trim receipt.keeper_name) ""
+  then Error "paused-work disposition keeper name must not be empty"
+  else if receipt.expected_generation < 0
+  then Error "paused-work disposition owner generation must not be negative"
+  else if String.equal (String.trim receipt.operator_operation_id) ""
+  then Error "paused-work disposition operation ID must not be empty"
+  else if not (Float.is_finite receipt.requested_at)
+  then Error "paused-work disposition request time must be finite"
+  else Ok ()
+;;
+
+let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
+
+let keeper_dir config keeper_name =
+  let root = Workspace.masc_root_dir config in
+  Filename.concat
+    (Filename.concat root "paused-work-dispositions")
+    ("keeper-" ^ sha256 keeper_name)
+;;
+
+let receipt_path config ~keeper_name ~operator_operation_id =
+  Filename.concat
+    (keeper_dir config keeper_name)
+    ("operation-" ^ sha256 operator_operation_id ^ ".json")
+;;
+
+let to_yojson receipt =
+  `Assoc
+    [ "schema", `String "masc.keeper.paused-work-disposition.v1"
+    ; "operation", `String "resume_owner"
+    ; "keeper_name", `String receipt.keeper_name
+    ; ( "expected_trace_id"
+      , `String (Keeper_id.Trace_id.to_string receipt.expected_trace_id) )
+    ; "expected_generation", `Int receipt.expected_generation
+    ; "operator_operation_id", `String receipt.operator_operation_id
+    ; "requested_at", `Float receipt.requested_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    let fields =
+      List.sort (fun (left, _) (right, _) -> String.compare left right) fields
+    in
+    (match fields with
+     | [ ("expected_generation", `Int expected_generation)
+       ; ("expected_trace_id", `String expected_trace_id)
+       ; ("keeper_name", `String keeper_name)
+       ; ("operation", `String "resume_owner")
+       ; ("operator_operation_id", `String operator_operation_id)
+       ; ("requested_at", requested_at_json)
+       ; ("schema", `String "masc.keeper.paused-work-disposition.v1")
+       ] ->
+       let* requested_at =
+         match requested_at_json with
+         | `Float value -> Ok value
+         | `Int value -> Ok (Float.of_int value)
+         | `Intlit value ->
+           (match Float.of_string_opt value with
+            | Some value -> Ok value
+            | None -> Error "paused-work disposition request time is invalid")
+         | _ -> Error "paused-work disposition request time must be numeric"
+       in
+       let* expected_trace_id = Keeper_id.Trace_id.of_string expected_trace_id in
+       let receipt =
+         { keeper_name
+         ; expected_trace_id
+         ; expected_generation
+         ; operator_operation_id
+         ; requested_at
+         ; operation = Resume_owner
+         }
+       in
+       let* () = validate receipt in
+       Ok receipt
+     | _ -> Error "paused-work disposition receipt fields are not exact")
+  | _ -> Error "paused-work disposition receipt must be a JSON object"
+;;
+
+let load config ~keeper_name ~operator_operation_id =
+  if String.equal (String.trim keeper_name) ""
+  then Error "paused-work disposition keeper name must not be empty"
+  else if String.equal (String.trim operator_operation_id) ""
+  then Error "paused-work disposition operation ID must not be empty"
+  else
+    let path = receipt_path config ~keeper_name ~operator_operation_id in
+    if not (Fs_compat.file_exists path)
+    then Ok None
+    else
+      let* json = Safe_ops.read_json_file_safe path in
+      let* receipt = of_yojson json in
+      if
+        String.equal receipt.keeper_name keeper_name
+        && String.equal receipt.operator_operation_id operator_operation_id
+      then Ok (Some receipt)
+      else Error "paused-work disposition receipt path identity does not match payload"
+;;
+
+let with_keeper_lock config ~keeper_name f =
+  if String.equal (String.trim keeper_name) ""
+  then Error "paused-work disposition keeper name must not be empty"
+  else
+    let dir = keeper_dir config keeper_name in
+    let prepared =
+      try
+        ignore (Keeper_fs.ensure_dir dir : string);
+        Ok ()
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> Error (Printexc.to_string exn)
+    in
+    let* () = prepared in
+    (match
+       File_lock_eio.with_durable_lock
+         ~lock_path:(Filename.concat dir "keeper-disposition.lock")
+         (fun () -> f { keeper_name })
+     with
+     | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
+     | Ok result -> Ok result)
+;;
+
+let save_if_absent lock config receipt =
+  let* () = validate receipt in
+  let* () =
+    if String.equal lock.keeper_name receipt.keeper_name
+    then Ok ()
+    else Error "paused-work disposition lock owner does not match receipt"
+  in
+  let root = Workspace.masc_root_dir config in
+  let path =
+    receipt_path
+      config
+      ~keeper_name:receipt.keeper_name
+      ~operator_operation_id:receipt.operator_operation_id
+  in
+  let* existing =
+    load
+      config
+      ~keeper_name:receipt.keeper_name
+      ~operator_operation_id:receipt.operator_operation_id
+  in
+  match existing with
+  | Some existing -> Ok (Existing existing)
+  | None ->
+    (match
+       Keeper_fs.save_json_durable_atomic
+         ~ownership_root:root
+         ~pretty:false
+         path
+         (to_yojson receipt)
+     with
+     | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+     | Ok () ->
+       let* persisted =
+         load
+           config
+           ~keeper_name:receipt.keeper_name
+           ~operator_operation_id:receipt.operator_operation_id
+       in
+       (match persisted with
+        | Some persisted when equal persisted receipt -> Ok Created
+        | Some _ -> Error "paused-work disposition receipt changed after durable write"
+        | None -> Error "paused-work disposition receipt missing after durable write"))
+;;

--- a/lib/keeper/keeper_paused_work_disposition_receipt.mli
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.mli
@@ -1,0 +1,38 @@
+(** Durable typed intent receipts for explicit paused-work disposition. *)
+
+type operation = Resume_owner
+
+type t =
+  { keeper_name : string
+  ; expected_trace_id : Keeper_id.Trace_id.t
+  ; expected_generation : int
+  ; operator_operation_id : string
+  ; requested_at : float
+  ; operation : operation
+  }
+
+type save_result =
+  | Created
+  | Existing of t
+
+type keeper_lock
+
+val equal : t -> t -> bool
+
+val load :
+  Workspace.config ->
+  keeper_name:string ->
+  operator_operation_id:string ->
+  (t option, string) result
+
+val with_keeper_lock :
+  Workspace.config ->
+  keeper_name:string ->
+  (keeper_lock -> 'a) ->
+  ('a, string) result
+(** Serialize every disposition operation for one Keeper across processes. *)
+
+val save_if_absent :
+  keeper_lock -> Workspace.config -> t -> (save_result, string) result
+(** Persist [t] with a strict durable atomic write. An existing operation ID is
+    returned for exact replay or conflict handling and is never overwritten. *)

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -367,6 +367,9 @@ let resume config ~keeper_name request =
            | Error cause -> Error { cause; reservation_release = Some reservation_release })
         with
         | exn ->
+          (* Best-effort release on the exception path: the original [exn] is
+             re-raised immediately, so a release failure must not replace it
+             (Fun.Finally_raised-style masking). *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
 ;;

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -1,0 +1,372 @@
+type request =
+  { owner_generation : int
+  ; operator_operation_id : string
+  }
+
+type projection_stage =
+  | Durable_meta
+  | Registry_meta
+  | Registry_transition
+
+type failure =
+  | Invalid_request of string
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Receipt_lock_failed of string
+  | Receipt_read_failed of string
+  | Receipt_conflict of Keeper_paused_work_disposition_receipt.t
+  | Receipt_write_failed of string
+  | Durable_meta_read_failed of string
+  | Durable_meta_missing
+  | Durable_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Durable_owner_identity_changed
+  | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
+  | Registry_owner_missing
+  | Registry_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Registry_owner_identity_changed
+  | Registry_owner_not_paused of Keeper_state_machine.phase
+  | Projection_failed of
+      { stage : projection_stage
+      ; detail : string
+      }
+
+type error =
+  { cause : failure
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
+  }
+
+type commit_status =
+  | Committed
+  | Already_committed
+
+type projection =
+  | Applied of Keeper_state_machine.phase
+  | Committed_followup_failed of failure
+
+type success =
+  { receipt : Keeper_paused_work_disposition_receipt.t
+  ; commit_status : commit_status
+  ; projection : projection
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+let ( let* ) = Result.bind
+
+let projection_stage_to_string = function
+  | Durable_meta -> "durable_meta"
+  | Registry_meta -> "registry_meta"
+  | Registry_transition -> "registry_transition"
+;;
+
+let failure_to_string = function
+  | Invalid_request detail -> "invalid Resume_owner request: " ^ detail
+  | Reservation_conflict owner ->
+    "Resume_owner lifecycle reservation conflict: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+  | Receipt_lock_failed detail -> "Resume_owner receipt lock failed: " ^ detail
+  | Receipt_read_failed detail -> "Resume_owner receipt read failed: " ^ detail
+  | Receipt_conflict receipt ->
+    Printf.sprintf
+      "Resume_owner operation ID conflicts with keeper=%s generation=%d requested_at=%.17g"
+      receipt.keeper_name
+      receipt.expected_generation
+      receipt.requested_at
+  | Receipt_write_failed detail -> "Resume_owner receipt write failed: " ^ detail
+  | Durable_meta_read_failed detail -> "Resume_owner durable meta read failed: " ^ detail
+  | Durable_meta_missing -> "Resume_owner durable Keeper metadata is missing"
+  | Durable_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "Resume_owner durable generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Durable_owner_identity_changed -> "Resume_owner durable trace identity changed"
+  | Durable_owner_not_paused -> "Resume_owner requires a durably paused Keeper"
+  | Durable_owner_dead_tombstone ->
+    "Resume_owner cannot revive a Dead tombstone; use the dead-revival transaction"
+  | Registry_owner_missing -> "Resume_owner requires the exact registered Keeper lane"
+  | Registry_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "Resume_owner registry generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Registry_owner_identity_changed -> "Resume_owner registry trace identity changed"
+  | Registry_owner_not_paused phase ->
+    Printf.sprintf
+      "Resume_owner requires a paused registry lane, actual phase=%s"
+      (Keeper_state_machine.phase_to_string phase)
+  | Projection_failed { stage; detail } ->
+    Printf.sprintf
+      "Resume_owner committed receipt but %s projection failed: %s"
+      (projection_stage_to_string stage)
+      detail
+;;
+
+let error_to_string error =
+  let base = failure_to_string error.cause in
+  match error.reservation_release with
+  | None -> base
+  | Some release ->
+    let release =
+      match release with
+      | Keeper_lifecycle_reservation.Released -> "released"
+      | Keeper_lifecycle_reservation.Release_missing -> "release_missing"
+      | Keeper_lifecycle_reservation.Release_not_owner owner ->
+        "release_not_owner: " ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+    in
+    base ^ "; reservation_release=" ^ release
+;;
+
+let validate_request request =
+  if request.owner_generation < 0
+  then Error "owner generation must not be negative"
+  else if String.equal (String.trim request.operator_operation_id) ""
+  then Error "operator operation ID must not be empty"
+  else Ok ()
+;;
+
+let receipt_matches_request ~keeper_name request receipt =
+  String.equal receipt.Keeper_paused_work_disposition_receipt.keeper_name keeper_name
+  && Int.equal receipt.expected_generation request.owner_generation
+  && String.equal receipt.operator_operation_id request.operator_operation_id
+  && receipt.operation = Keeper_paused_work_disposition_receipt.Resume_owner
+;;
+
+let read_meta config keeper_name =
+  Keeper_meta_store.read_meta config keeper_name
+  |> Result.map_error (fun detail -> Durable_meta_read_failed detail)
+;;
+
+let validate_identity receipt (meta : Keeper_meta_contract.keeper_meta) =
+  if not (Int.equal meta.runtime.generation receipt.expected_generation)
+  then
+    Error
+      (Durable_owner_generation_changed
+         { expected = receipt.expected_generation; actual = meta.runtime.generation })
+  else if not (Keeper_id.Trace_id.equal meta.runtime.trace_id receipt.expected_trace_id)
+  then Error Durable_owner_identity_changed
+  else Ok ()
+;;
+
+let paused_meta receipt (meta : Keeper_meta_contract.keeper_meta) =
+  match
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  with
+  | Keeper_lifecycle_admission.Dead_tombstone -> Error Durable_owner_dead_tombstone
+  | Keeper_lifecycle_admission.Active -> Error Durable_owner_not_paused
+  | Keeper_lifecycle_admission.Paused _ ->
+    let* () = validate_identity receipt meta in
+    Ok meta
+;;
+
+let registered_owner_opt config receipt =
+  match
+    Keeper_registry.get
+      ~base_path:config.Workspace.base_path
+      receipt.Keeper_paused_work_disposition_receipt.keeper_name
+  with
+  | None -> Ok None
+  | Some entry when entry.meta.runtime.generation <> receipt.expected_generation ->
+    Error
+      (Registry_owner_generation_changed
+         { expected = receipt.expected_generation
+         ; actual = entry.meta.runtime.generation
+         })
+  | Some entry
+    when not
+           (Keeper_id.Trace_id.equal
+              entry.meta.runtime.trace_id
+              receipt.expected_trace_id) ->
+    Error Registry_owner_identity_changed
+  | Some entry -> Ok (Some entry)
+;;
+
+let update_registry_meta token entry committed =
+  match
+    Keeper_registry.update_entry_exact_for_lifecycle token entry (fun current ->
+      { current with meta = committed })
+  with
+  | Keeper_registry.Exact_updated -> Ok ()
+  | Keeper_registry.Exact_update_missing -> Error "registered lane disappeared"
+  | Keeper_registry.Exact_update_replaced -> Error "registered lane was replaced"
+  | Keeper_registry.Exact_update_invalid error ->
+    Error (Keeper_registry.registry_entry_validation_error_to_string error)
+;;
+
+let project_registry token entry committed =
+  let* () =
+    update_registry_meta token entry committed
+    |> Result.map_error (fun detail -> Projection_failed { stage = Registry_meta; detail })
+  in
+  let* phase =
+    match entry.phase with
+    | Keeper_state_machine.Paused ->
+      Keeper_registry.dispatch_event_exact_for_lifecycle
+        token
+        entry
+        Keeper_state_machine.Operator_resume
+      |> Result.map (fun transition -> transition.new_phase)
+      |> Result.map_error (fun error ->
+        Projection_failed
+          { stage = Registry_transition
+          ; detail = Keeper_state_machine.transition_error_to_string error
+          })
+    | phase -> Ok phase
+  in
+  if not (Keeper_state_machine.is_terminal phase)
+  then Atomic.set entry.fiber_wakeup true;
+  Ok phase
+;;
+
+let project_receipt token config receipt =
+  let* current = read_meta config receipt.keeper_name in
+  let* current =
+    match current with
+    | None -> Error Durable_meta_missing
+    | Some current ->
+      let* () = validate_identity receipt current in
+      Ok current
+  in
+  let* entry = registered_owner_opt config receipt in
+  let* committed =
+    if current.paused
+    then
+      let* paused = paused_meta receipt current in
+      let candidate =
+        { (Keeper_meta_contract.mark_resumed paused) with
+          updated_at = Keeper_meta_contract.now_iso ()
+        }
+      in
+      let* () =
+        Keeper_meta_store.write_meta_with_merge_for_lifecycle
+          token
+          ~merge:Keeper_meta_merge.monotonic_usage_counters
+          config
+          candidate
+        |> Result.map_error (fun detail ->
+          Projection_failed { stage = Durable_meta; detail })
+      in
+      (match read_meta config receipt.keeper_name with
+       | Error _ as error -> error
+       | Ok None -> Error Durable_meta_missing
+       | Ok (Some committed) ->
+         let* () = validate_identity receipt committed in
+         if committed.paused
+         then
+           Error
+             (Projection_failed
+                { stage = Durable_meta
+                ; detail = "durable pause bit remained set after commit"
+                })
+         else Ok committed)
+    else Ok current
+  in
+  match entry with
+  | None -> Error Registry_owner_missing
+  | Some entry -> project_registry token entry committed
+;;
+
+let create_receipt config ~keeper_name request =
+  let* current = read_meta config keeper_name in
+  let* current =
+    match current with
+    | None -> Error Durable_meta_missing
+    | Some current -> Ok current
+  in
+  let receipt : Keeper_paused_work_disposition_receipt.t =
+    { keeper_name
+    ; expected_trace_id = current.runtime.trace_id
+    ; expected_generation = request.owner_generation
+    ; operator_operation_id = request.operator_operation_id
+    ; requested_at = Time_compat.now ()
+    ; operation = Keeper_paused_work_disposition_receipt.Resume_owner
+    }
+  in
+  let* _ = paused_meta receipt current in
+  let* entry = registered_owner_opt config receipt in
+  match entry with
+  | None -> Ok receipt
+  | Some entry when entry.phase = Keeper_state_machine.Paused -> Ok receipt
+  | Some entry -> Error (Registry_owner_not_paused entry.phase)
+;;
+
+let run_owned receipt_lock token config ~keeper_name request =
+  let* existing =
+    Keeper_paused_work_disposition_receipt.load
+      config
+      ~keeper_name
+      ~operator_operation_id:request.operator_operation_id
+    |> Result.map_error (fun detail -> Receipt_read_failed detail)
+  in
+  let* receipt, commit_status =
+    match existing with
+    | Some receipt when receipt_matches_request ~keeper_name request receipt ->
+      Ok (receipt, Already_committed)
+    | Some receipt -> Error (Receipt_conflict receipt)
+    | None ->
+      let* receipt = create_receipt config ~keeper_name request in
+      (match
+         Keeper_paused_work_disposition_receipt.save_if_absent
+           receipt_lock
+           config
+           receipt
+       with
+       | Error detail -> Error (Receipt_write_failed detail)
+       | Ok Created -> Ok (receipt, Committed)
+       | Ok (Existing existing)
+         when Keeper_paused_work_disposition_receipt.equal existing receipt ->
+         Ok (existing, Already_committed)
+       | Ok (Existing existing) -> Error (Receipt_conflict existing))
+  in
+  let projection =
+    match project_receipt token config receipt with
+    | Ok phase -> Applied phase
+    | Error failure -> Committed_followup_failed failure
+  in
+  Ok (receipt, commit_status, projection)
+;;
+
+let resume config ~keeper_name request =
+  match validate_request request with
+  | Error detail ->
+    Error { cause = Invalid_request detail; reservation_release = None }
+  | Ok () ->
+    (match
+       Keeper_lifecycle_reservation.acquire
+         ~base_path:config.Workspace.base_path
+         ~keeper_name
+         ~expected_generation:request.owner_generation
+         ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+     with
+     | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+       Error { cause = Reservation_conflict owner; reservation_release = None }
+     | Ok token ->
+       (try
+          let outcome =
+            match
+              Keeper_paused_work_disposition_receipt.with_keeper_lock
+                config
+                ~keeper_name
+                (fun receipt_lock ->
+                   run_owned receipt_lock token config ~keeper_name request)
+            with
+            | Error detail -> Error (Receipt_lock_failed detail)
+            | Ok outcome -> outcome
+          in
+          let reservation_release = Keeper_lifecycle_reservation.release token in
+          (match outcome with
+           | Ok (receipt, commit_status, projection) ->
+             Ok { receipt; commit_status; projection; reservation_release }
+           | Error cause -> Error { cause; reservation_release = Some reservation_release })
+        with
+        | exn ->
+          ignore (Keeper_lifecycle_reservation.release token : _);
+          raise exn))
+;;

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -367,9 +367,7 @@ let resume config ~keeper_name request =
            | Error cause -> Error { cause; reservation_release = Some reservation_release })
         with
         | exn ->
-          (* Best-effort release on the exception path: the original [exn] is
-             re-raised immediately, so a release failure must not replace it
-             (Fun.Finally_raised-style masking). *)
+          (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
 ;;

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -142,7 +142,8 @@ let read_meta config keeper_name =
   |> Result.map_error (fun detail -> Durable_meta_read_failed detail)
 ;;
 
-let validate_identity receipt (meta : Keeper_meta_contract.keeper_meta) =
+let validate_identity (receipt : Keeper_paused_work_disposition_receipt.t)
+      (meta : Keeper_meta_contract.keeper_meta) =
   if not (Int.equal meta.runtime.generation receipt.expected_generation)
   then
     Error
@@ -212,7 +213,8 @@ let project_registry token entry committed =
         token
         entry
         Keeper_state_machine.Operator_resume
-      |> Result.map (fun transition -> transition.new_phase)
+      |> Result.map (fun (transition : Keeper_state_machine.transition_result) ->
+           transition.new_phase)
       |> Result.map_error (fun error ->
         Projection_failed
           { stage = Registry_transition
@@ -225,7 +227,7 @@ let project_registry token entry committed =
   Ok phase
 ;;
 
-let project_receipt token config receipt =
+let project_receipt token config (receipt : Keeper_paused_work_disposition_receipt.t) =
   let* current = read_meta config receipt.keeper_name in
   let* current =
     match current with

--- a/lib/keeper/keeper_paused_work_resume_transaction.mli
+++ b/lib/keeper/keeper_paused_work_resume_transaction.mli
@@ -1,0 +1,72 @@
+(** Receipt-first [Resume_owner] transaction for a paused Keeper lane. *)
+
+type request =
+  { owner_generation : int
+  ; operator_operation_id : string
+  }
+
+type projection_stage =
+  | Durable_meta
+  | Registry_meta
+  | Registry_transition
+
+type failure =
+  | Invalid_request of string
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Receipt_lock_failed of string
+  | Receipt_read_failed of string
+  | Receipt_conflict of Keeper_paused_work_disposition_receipt.t
+  | Receipt_write_failed of string
+  | Durable_meta_read_failed of string
+  | Durable_meta_missing
+  | Durable_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Durable_owner_identity_changed
+  | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
+  | Registry_owner_missing
+  | Registry_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Registry_owner_identity_changed
+  | Registry_owner_not_paused of Keeper_state_machine.phase
+  | Projection_failed of
+      { stage : projection_stage
+      ; detail : string
+      }
+
+type error =
+  { cause : failure
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
+  }
+
+type commit_status =
+  | Committed
+  | Already_committed
+
+type projection =
+  | Applied of Keeper_state_machine.phase
+  | Committed_followup_failed of failure
+
+type success =
+  { receipt : Keeper_paused_work_disposition_receipt.t
+  ; commit_status : commit_status
+  ; projection : projection
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+val error_to_string : error -> string
+
+val resume :
+  Workspace.config ->
+  keeper_name:string ->
+  request ->
+  (success, error) result
+(** Persist a typed [Resume_owner] receipt before clearing durable pause state,
+    then project the exact registered lane through [Operator_resume] and wake
+    it. A post-receipt failure is returned as [Committed_followup_failed], not
+    as an uncommitted [Error]. Retry of the same receipt completes any
+    interrupted projection. *)

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -5,6 +5,8 @@ module Persistence = Keeper_event_queue_persistence
 module Registry_queue = Keeper_registry_event_queue
 module State = Keeper_event_queue_state
 module Transaction = Keeper_paused_work_cancellation_transaction
+module Disposition_receipt = Keeper_paused_work_disposition_receipt
+module Resume_transaction = Keeper_paused_work_resume_transaction
 
 let require_ok label = function
   | Ok value -> value
@@ -169,6 +171,16 @@ let check_replayed_without_reservation = function
        | Keeper_lifecycle_reservation.Release_missing -> "release_missing"
        | Keeper_lifecycle_reservation.Release_not_owner owner ->
          "release_not_owner: " ^ Keeper_lifecycle_reservation.snapshot_to_string owner)
+;;
+
+let check_resume_released = function
+  | Keeper_lifecycle_reservation.Released -> ()
+  | Keeper_lifecycle_reservation.Release_missing ->
+    Alcotest.fail "Resume_owner lifecycle reservation disappeared before release"
+  | Keeper_lifecycle_reservation.Release_not_owner owner ->
+    Alcotest.failf
+      "Resume_owner lifecycle reservation owner changed: %s"
+      (Keeper_lifecycle_reservation.snapshot_to_string owner)
 ;;
 
 let test_paused_owner_cancellation_commits_once () =
@@ -371,6 +383,285 @@ let test_stale_generation_is_rejected_before_commit () =
       (List.length (State.leases state)))
 ;;
 
+let resume_request generation operation_id : Resume_transaction.request =
+  { owner_generation = generation
+  ; operator_operation_id = operation_id
+  }
+;;
+
+let test_resume_owner_commits_receipt_and_preserves_pending () =
+  with_seeded_owner ~paused:true ~generation:21 (fun config keeper_name source ->
+    let request = resume_request 21 "operator-resume-1" in
+    let first =
+      Resume_transaction.resume config ~keeper_name request
+      |> Result.map_error Resume_transaction.error_to_string
+      |> require_ok "commit Resume_owner"
+    in
+    check_resume_released first.reservation_release;
+    (match first.commit_status with
+     | Resume_transaction.Committed -> ()
+     | Resume_transaction.Already_committed ->
+       Alcotest.fail "first Resume_owner call replayed an existing receipt");
+    (match first.projection with
+     | Resume_transaction.Applied phase ->
+       Alcotest.(check bool)
+         "Resume_owner leaves paused phase"
+         false
+         (phase = Keeper_state_machine.Paused)
+     | Resume_transaction.Committed_followup_failed failure ->
+       Alcotest.fail
+         (Resume_transaction.error_to_string
+            { cause = failure; reservation_release = None }));
+    let durable =
+      Keeper_meta_store.read_meta config keeper_name
+      |> require_ok "read resumed durable owner"
+      |> require_some "resumed durable owner"
+    in
+    Alcotest.(check bool) "durable pause cleared" false durable.paused;
+    let registered =
+      Keeper_registry.get ~base_path:config.Workspace.base_path keeper_name
+      |> require_some "resumed registry owner"
+    in
+    Alcotest.(check bool) "registry pause cleared" false registered.meta.paused;
+    let queue_state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load resumed pending queue"
+    in
+    Alcotest.(check bool)
+      "Resume_owner preserves exact pending work"
+      true
+      (Queue.to_list (State.pending queue_state) = [ source ]);
+    let stored =
+      Disposition_receipt.load
+        config
+        ~keeper_name
+        ~operator_operation_id:request.operator_operation_id
+      |> require_ok "load Resume_owner receipt"
+      |> require_some "Resume_owner receipt"
+    in
+    Alcotest.(check bool)
+      "returned receipt is the durable receipt"
+      true
+      (Disposition_receipt.equal first.receipt stored);
+    let replay =
+      Resume_transaction.resume config ~keeper_name request
+      |> Result.map_error Resume_transaction.error_to_string
+      |> require_ok "replay Resume_owner"
+    in
+    check_resume_released replay.reservation_release;
+    (match replay.projection with
+     | Resume_transaction.Applied _ -> ()
+     | Resume_transaction.Committed_followup_failed failure ->
+       Alcotest.fail
+         (Resume_transaction.error_to_string
+            { cause = failure; reservation_release = None }));
+    (match replay.commit_status with
+     | Resume_transaction.Already_committed -> ()
+     | Resume_transaction.Committed ->
+       Alcotest.fail "Resume_owner replay created a second receipt");
+    let conflicting = { request with owner_generation = 20 } in
+    (match Resume_transaction.resume config ~keeper_name conflicting with
+     | Error { Resume_transaction.cause = Resume_transaction.Receipt_conflict _; _ } -> ()
+     | Error error -> Alcotest.fail (Resume_transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "Resume_owner operation ID accepted a different request");
+    let second_operation = resume_request 21 "operator-resume-2" in
+    (match Resume_transaction.resume config ~keeper_name second_operation with
+     | Error
+         { Resume_transaction.cause = Resume_transaction.Durable_owner_not_paused
+         ; _
+         } -> ()
+     | Error error -> Alcotest.fail (Resume_transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "active owner accepted a second Resume_owner receipt");
+    match
+      Disposition_receipt.load
+        config
+        ~keeper_name
+        ~operator_operation_id:second_operation.operator_operation_id
+    with
+    | Ok None -> ()
+    | Ok (Some _) -> Alcotest.fail "active owner persisted a second Resume_owner receipt"
+    | Error detail -> Alcotest.fail detail)
+;;
+
+let test_resume_owner_completes_prepared_receipt_projection () =
+  with_seeded_owner ~paused:true ~generation:22 (fun config keeper_name _source ->
+    let request = resume_request 22 "operator-resume-prepared" in
+    let durable =
+      Keeper_meta_store.read_meta config keeper_name
+      |> require_ok "read prepared Resume_owner durable owner"
+      |> require_some "prepared Resume_owner durable owner"
+    in
+    let prepared : Disposition_receipt.t =
+      { keeper_name
+      ; expected_trace_id = durable.runtime.trace_id
+      ; expected_generation = request.owner_generation
+      ; operator_operation_id = request.operator_operation_id
+      ; requested_at = 5.0
+      ; operation = Disposition_receipt.Resume_owner
+      }
+    in
+    (match
+       Disposition_receipt.with_keeper_lock config ~keeper_name (fun lock ->
+         Disposition_receipt.save_if_absent lock config prepared)
+     with
+     | Ok (Ok Disposition_receipt.Created) -> ()
+     | Ok (Ok (Disposition_receipt.Existing _)) ->
+       Alcotest.fail "prepared Resume_owner receipt already existed"
+     | Ok (Error detail) | Error detail -> Alcotest.fail detail);
+    Keeper_registry.clear ();
+    let interrupted =
+      Resume_transaction.resume config ~keeper_name request
+      |> Result.map_error Resume_transaction.error_to_string
+      |> require_ok "observe prepared Resume_owner without registry projection"
+    in
+    check_resume_released interrupted.reservation_release;
+    (match interrupted.projection with
+     | Resume_transaction.Committed_followup_failed
+         Resume_transaction.Registry_owner_missing -> ()
+     | Resume_transaction.Committed_followup_failed failure ->
+       Alcotest.fail
+         (Resume_transaction.error_to_string
+            { cause = failure; reservation_release = None })
+     | Resume_transaction.Applied _ ->
+       Alcotest.fail "Resume_owner claimed registry projection without a lane");
+    let durably_resumed =
+      Keeper_meta_store.read_meta config keeper_name
+      |> require_ok "read interrupted Resume_owner owner"
+      |> require_some "interrupted Resume_owner owner"
+    in
+    Alcotest.(check bool)
+      "receipt projects durable resume before reporting missing registry"
+      false
+      durably_resumed.paused;
+    ignore
+      (Keeper_registry.register
+         ~base_path:config.Workspace.base_path
+         keeper_name
+         durably_resumed);
+    (match Keeper_registry.get ~base_path:config.Workspace.base_path keeper_name with
+     | Some _ -> ()
+     | None -> Alcotest.fail "failed to restore registry lane for replay");
+    let replay =
+      Resume_transaction.resume config ~keeper_name request
+      |> Result.map_error Resume_transaction.error_to_string
+      |> require_ok "complete prepared Resume_owner receipt"
+    in
+    check_resume_released replay.reservation_release;
+    (match replay.projection with
+     | Resume_transaction.Applied _ -> ()
+     | Resume_transaction.Committed_followup_failed failure ->
+       Alcotest.fail
+         (Resume_transaction.error_to_string
+            { cause = failure; reservation_release = None }));
+    (match replay.commit_status with
+     | Resume_transaction.Already_committed -> ()
+     | Resume_transaction.Committed ->
+       Alcotest.fail "prepared Resume_owner receipt was written twice");
+    let resumed =
+      Keeper_meta_store.read_meta config keeper_name
+      |> require_ok "read prepared-receipt projection"
+      |> require_some "prepared-receipt projection"
+    in
+    Alcotest.(check bool) "prepared receipt clears durable pause" false resumed.paused)
+;;
+
+let test_resume_owner_rejects_stale_generation_without_receipt () =
+  with_seeded_owner ~paused:true ~generation:23 (fun config keeper_name _source ->
+    let request = resume_request 22 "operator-resume-stale" in
+    (match Resume_transaction.resume config ~keeper_name request with
+     | Error
+         { Resume_transaction.cause =
+             Resume_transaction.Durable_owner_generation_changed
+               { expected = 22; actual = 23 }
+         ; reservation_release = Some release
+         } ->
+       check_resume_released release
+     | Error error -> Alcotest.fail (Resume_transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "stale Resume_owner generation committed");
+    match
+      Disposition_receipt.load
+        config
+        ~keeper_name
+        ~operator_operation_id:request.operator_operation_id
+    with
+    | Ok None -> ()
+    | Ok (Some _) -> Alcotest.fail "stale Resume_owner persisted a receipt"
+    | Error detail -> Alcotest.fail detail)
+;;
+
+let test_resume_owner_commits_for_unregistered_durable_lane () =
+  with_seeded_owner
+    ~registered:false
+    ~paused:true
+    ~generation:25
+    (fun config keeper_name source ->
+       let request = resume_request 25 "operator-resume-unregistered" in
+       let outcome =
+         Resume_transaction.resume config ~keeper_name request
+         |> Result.map_error Resume_transaction.error_to_string
+         |> require_ok "commit Resume_owner for unregistered lane"
+       in
+       check_resume_released outcome.reservation_release;
+       (match outcome.commit_status with
+        | Resume_transaction.Committed -> ()
+        | Resume_transaction.Already_committed ->
+          Alcotest.fail "unregistered Resume_owner replayed on first commit");
+       (match outcome.projection with
+        | Resume_transaction.Committed_followup_failed
+            Resume_transaction.Registry_owner_missing -> ()
+        | Resume_transaction.Committed_followup_failed failure ->
+          Alcotest.fail
+            (Resume_transaction.error_to_string
+               { cause = failure; reservation_release = None })
+        | Resume_transaction.Applied _ ->
+          Alcotest.fail "unregistered Resume_owner claimed a live projection");
+       let durable =
+         Keeper_meta_store.read_meta config keeper_name
+         |> require_ok "read unregistered resumed owner"
+         |> require_some "unregistered resumed owner"
+       in
+       Alcotest.(check bool) "unregistered durable pause cleared" false durable.paused;
+       let queue_state =
+         Persistence.load_state_result
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+         |> require_ok "load unregistered resumed queue"
+       in
+       Alcotest.(check bool)
+         "unregistered Resume_owner preserves exact pending work"
+         true
+         (Queue.to_list (State.pending queue_state) = [ source ]))
+;;
+
+let test_resume_owner_rejects_dead_tombstone_without_receipt () =
+  with_seeded_owner
+    ~registered:false
+    ~latched_reason:Keeper_latched_reason.Dead_tombstone
+    ~paused:true
+    ~generation:24
+    (fun config keeper_name _source ->
+       let request = resume_request 24 "operator-resume-dead" in
+       (match Resume_transaction.resume config ~keeper_name request with
+        | Error
+            { Resume_transaction.cause = Resume_transaction.Durable_owner_dead_tombstone
+            ; reservation_release = Some release
+            } ->
+          check_resume_released release
+        | Error error -> Alcotest.fail (Resume_transaction.error_to_string error)
+        | Ok _ -> Alcotest.fail "Resume_owner revived a Dead tombstone");
+       match
+         Disposition_receipt.load
+           config
+           ~keeper_name
+           ~operator_operation_id:request.operator_operation_id
+       with
+       | Ok None -> ()
+       | Ok (Some _) -> Alcotest.fail "Dead Resume_owner persisted a receipt"
+       | Error detail -> Alcotest.fail detail)
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -401,6 +692,26 @@ let () =
             "pending cancellation replays after owner transition"
             `Quick
             test_pending_cancellation_replays_after_owner_transition
+        ; Alcotest.test_case
+            "Resume_owner commits receipt and preserves pending"
+            `Quick
+            test_resume_owner_commits_receipt_and_preserves_pending
+        ; Alcotest.test_case
+            "Resume_owner completes prepared receipt projection"
+            `Quick
+            test_resume_owner_completes_prepared_receipt_projection
+        ; Alcotest.test_case
+            "Resume_owner rejects stale generation without receipt"
+            `Quick
+            test_resume_owner_rejects_stale_generation_without_receipt
+        ; Alcotest.test_case
+            "Resume_owner commits for unregistered durable lane"
+            `Quick
+            test_resume_owner_commits_for_unregistered_durable_lane
+        ; Alcotest.test_case
+            "Resume_owner rejects Dead tombstone without receipt"
+            `Quick
+            test_resume_owner_rejects_dead_tombstone_without_receipt
         ] )
     ]
 ;;

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -510,7 +510,7 @@ let test_resume_owner_completes_prepared_receipt_projection () =
      | Ok (Ok (Disposition_receipt.Existing _)) ->
        Alcotest.fail "prepared Resume_owner receipt already existed"
      | Ok (Error detail) | Error detail -> Alcotest.fail detail);
-    Keeper_registry.clear ();
+    Keeper_registry.For_testing.clear ();
     let interrupted =
       Resume_transaction.resume config ~keeper_name request
       |> Result.map_error Resume_transaction.error_to_string
@@ -536,7 +536,7 @@ let test_resume_owner_completes_prepared_receipt_projection () =
       false
       durably_resumed.paused;
     ignore
-      (Keeper_registry.register
+      (Keeper_registry.For_testing.register
          ~base_path:config.Workspace.base_path
          keeper_name
          durably_resumed);


### PR DESCRIPTION
## Summary

- add a typed durable `Resume_owner` receipt keyed by Keeper and stable operator operation ID
- serialize all paused-work disposition intents for one Keeper with a cross-process durable lock
- validate the exact durable generation and trace identity, reject Dead tombstones, and reserve the existing `Paused_work_disposition` lifecycle boundary
- persist the receipt before clearing durable pause state
- project the exact registered lane through `Operator_resume` and wake it without touching the event queue
- return post-receipt projection failures as typed `Committed_followup_failed` outcomes so retry completes the same intent
- support durable-only resume when the live registry lane is absent; the committed outcome explicitly reports the missing live projection
- reject a second operation ID once the owner is active and reject conflicting reuse of one operation ID

## Why

`Pause` remains nonterminal and retained events stay untouched. A deliberate resume still needs a durable operator intent that survives a lost response or a crash between intent commit, metadata projection, and live registry projection.

The receipt is the commit point. Durable and live projection can be replayed from that receipt without inventing TTL, owner fallback, or event matching rules.

## Stack and scope

Base: `codex/paused-pending-cancel-receipt-20260720` (draft PR #25339).

This leaf implements the domain receipt store and exact `Resume_owner` transaction. Existing HTTP/MCP/directive resume surfaces are not routed through it yet; that wiring remains a separate follow-up. `Transfer_owner`, `Settle_from_source_terminal`, paused-retained fleet count/oldest-age projection, and the 10-Keeper 8-hour acceptance run also remain.

## Validation

- `ocamlc -stop-after parsing` for every changed implementation and interface
- `ocamlformat --check` for every changed OCaml file
- `git diff --check`
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail` — 0 new violations
- static scan: no new `Obj.magic`, `failwith`, `assert false`, TODO/FIXME, Lazy, or direct Mutex usage

Local Dune build/tests were intentionally not run; the operator is running builds separately and PR CI is the build authority.