### PR TITLE
refactor(fusion): bind computation to async identity

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -9,16 +9,9 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-type deliberation =
-  { panel : Fusion_types.panel_outcome list
-  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
-  ; judges : Fusion_types.judge_node list
-  ; judge_usage : Fusion_types.usage
-  }
-
 type compute_outcome =
   | Compute_denied of Fusion_types.deny_reason
-  | Computed of deliberation
+  | Computed of Fusion_types.deliberation_evidence
 
 let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
   match Fusion_policy.decide ~policy request with
@@ -378,13 +371,25 @@ let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
             | Error (_, u) -> u
           in
           List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
-          Computed { panel; judge; judges = judge_nodes; judge_usage })
+          Computed
+            { Fusion_types.question = req.prompt
+            ; panel
+            ; judge
+            ; judges = judge_nodes
+            ; judge_usage
+            })
 
-let project ~base_dir ~topology ~(request : Fusion_types.fusion_request) deliberation =
+let project
+    ~base_dir
+    ~topology
+    ~(request : Fusion_types.fusion_request)
+    (deliberation : Fusion_types.deliberation_evidence)
+  =
   match
     Fusion_sink.emit ~base_dir ~keeper:request.keeper ~run_id:request.run_id
-      ~question:request.prompt ~panel:deliberation.panel ~judge:deliberation.judge
-      ~judges:deliberation.judges ~judge_usage:deliberation.judge_usage
+      ~question:deliberation.question ~panel:deliberation.panel
+      ~judge:deliberation.judge ~judges:deliberation.judges
+      ~judge_usage:deliberation.judge_usage
   with
   | Ok () ->
     Fusion_metrics.record_invocation ~topology `Completed;

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -9,16 +9,27 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
+type deliberation =
+  { panel : Fusion_types.panel_outcome list
+  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
+  ; judges : Fusion_types.judge_node list
+  ; judge_usage : Fusion_types.usage
+  }
+
+type compute_outcome =
+  | Compute_denied of Fusion_types.deny_reason
+  | Computed of deliberation
+
+let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
   match Fusion_policy.decide ~policy request with
   | Fusion_types.Deny reason ->
     Fusion_metrics.record_invocation ~topology `Denied;
-    Denied reason
+    Compute_denied reason
   | Fusion_types.Allow req ->
     (match Fusion_policy.find_preset policy req.Fusion_types.preset with
-     | None ->
-       Fusion_metrics.record_invocation ~topology `Denied;
-       Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
+       | None ->
+         Fusion_metrics.record_invocation ~topology `Denied;
+         Compute_denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
      | Some vp ->
           let preset = Fusion_policy.Validated_preset.preset vp in
           let groups = preset.Fusion_policy.panels in
@@ -367,14 +378,23 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Error (_, u) -> u
           in
           List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
-          (match
-             Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper
-               ~run_id:req.Fusion_types.run_id ~question:req.Fusion_types.prompt
-               ~panel ~judge ~judges:judge_nodes ~judge_usage
-           with
-           | Ok () ->
-             Fusion_metrics.record_invocation ~topology `Completed;
-             Completed { panel; judge }
-           | Error msg ->
-             Fusion_metrics.record_invocation ~topology `Sink_failed;
-             Sink_failed msg))
+          Computed { panel; judge; judges = judge_nodes; judge_usage })
+
+let project ~base_dir ~topology ~(request : Fusion_types.fusion_request) deliberation =
+  match
+    Fusion_sink.emit ~base_dir ~keeper:request.keeper ~run_id:request.run_id
+      ~question:request.prompt ~panel:deliberation.panel ~judge:deliberation.judge
+      ~judges:deliberation.judges ~judge_usage:deliberation.judge_usage
+  with
+  | Ok () ->
+    Fusion_metrics.record_invocation ~topology `Completed;
+    Completed { panel = deliberation.panel; judge = deliberation.judge }
+  | Error msg ->
+    Fusion_metrics.record_invocation ~topology `Sink_failed;
+    Sink_failed msg
+;;
+
+let run ~sw ~net ~base_dir ~policy ~topology ~request () =
+  match compute ~sw ~net ~policy ~topology ~request () with
+  | Compute_denied reason -> Denied reason
+  | Computed deliberation -> project ~base_dir ~topology ~request deliberation

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -16,16 +16,9 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
-type deliberation =
-  { panel : Fusion_types.panel_outcome list
-  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
-  ; judges : Fusion_types.judge_node list
-  ; judge_usage : Fusion_types.usage
-  }
-
 type compute_outcome =
   | Compute_denied of Fusion_types.deny_reason
-  | Computed of deliberation
+  | Computed of Fusion_types.deliberation_evidence
 
 (** Run panel and judge computation without Board, chat, wake, or run-registry
     projection. The caller can durably claim the semantic terminal before
@@ -44,7 +37,7 @@ val project
   :  base_dir:string
   -> topology:Fusion_types.fusion_topology
   -> request:Fusion_types.fusion_request
-  -> deliberation
+  -> Fusion_types.deliberation_evidence
   -> outcome
 
 (** 요청을 심의한다.

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -16,6 +16,37 @@ type outcome =
       ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
+type deliberation =
+  { panel : Fusion_types.panel_outcome list
+  ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
+  ; judges : Fusion_types.judge_node list
+  ; judge_usage : Fusion_types.usage
+  }
+
+type compute_outcome =
+  | Compute_denied of Fusion_types.deny_reason
+  | Computed of deliberation
+
+(** Run panel and judge computation without Board, chat, wake, or run-registry
+    projection. The caller can durably claim the semantic terminal before
+    passing a [Computed] value to {!project}. *)
+val compute
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> policy:Fusion_policy.t
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> unit
+  -> compute_outcome
+
+(** Project one already-computed deliberation to the existing sink. *)
+val project
+  :  base_dir:string
+  -> topology:Fusion_types.fusion_topology
+  -> request:Fusion_types.fusion_request
+  -> deliberation
+  -> outcome
+
 (** 요청을 심의한다.
 
     + [Fusion_policy.decide]로 정책 판정 → [Deny]면 [Denied] 반환(부작용 없음).

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -255,6 +255,44 @@ type judge_outcome =
   | Judge_failed of judge_error_node  (** panel [Failed] 대칭. *)
 [@@deriving yojson, show, eq]
 
+let result_to_yojson ok_to_yojson error_to_yojson = function
+  | Ok value -> `List [ `String "Ok"; ok_to_yojson value ]
+  | Error error -> `List [ `String "Error"; error_to_yojson error ]
+;;
+
+let result_of_yojson ok_of_yojson error_of_yojson = function
+  | `List [ `String "Ok"; value ] ->
+    Result.map (fun value -> Ok value) (ok_of_yojson value)
+  | `List [ `String "Error"; error ] ->
+    Result.map (fun error -> Error error) (error_of_yojson error)
+  | json ->
+    Error
+      (Printf.sprintf
+         "Fusion_types.deliberation_evidence.judge: unsupported shape %s"
+         (Yojson.Safe.to_string json))
+;;
+
+let equal_result equal_ok equal_error left right =
+  match left, right with
+  | Ok left, Ok right -> equal_ok left right
+  | Error left, Error right -> equal_error left right
+  | Ok _, Error _ | Error _, Ok _ -> false
+;;
+
+let pp_result pp_ok pp_error formatter = function
+  | Ok value -> Format.fprintf formatter "(Ok %a)" pp_ok value
+  | Error error -> Format.fprintf formatter "(Error %a)" pp_error error
+;;
+
+type deliberation_evidence =
+  { question : string
+  ; panel : panel_outcome list
+  ; judge : (judge_synthesis, judge_failure) result
+  ; judges : judge_outcome list
+  ; judge_usage : usage
+  }
+[@@deriving yojson, show, eq]
+
 type fusion_trigger =
   | Explicit_tool_call
   | Low_confidence

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -266,6 +266,18 @@ type judge_outcome =
   | Judge_failed of judge_error_node
 [@@deriving yojson, show, eq]
 
+(** One completed panel+judge computation before any Board/chat/wake
+    projection. This is the typed payload stored in the common async request's
+    canonical terminal record; projection failures are outside this record. *)
+type deliberation_evidence =
+  { question : string
+  ; panel : panel_outcome list
+  ; judge : (judge_synthesis, judge_failure) result
+  ; judges : judge_outcome list
+  ; judge_usage : usage
+  }
+[@@deriving yojson, show, eq]
+
 (** {1 트리거} *)
 
 (** fusion 발동 사유 — 게이트 입력(이유 라벨). catch-all 없음.

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -2159,7 +2159,9 @@ let runtime_cancelled_status () =
 ;;
 
 let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
-    ~base_path ~caller ~(f : Eio.Switch.t -> tool_result) ~keeper_name () :
+    ~base_path ~caller
+    ~(f : request_id:string -> Eio.Switch.t -> tool_result)
+    ~keeper_name () :
     (submit_outcome, submit_error) result =
   match resolve_access_identity ~base_path ~caller with
   | Error rejection -> Error (Submit_rejected rejection)
@@ -2369,7 +2371,7 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
            | `Operator_cancelled -> raise CancelledByOperator
            | `Already_settled entry -> raise (Worker_already_settled entry)
            | `Preempted reason -> raise (Worker_preempted reason));
-          let result = f req_sw in
+          let result = f ~request_id req_sw in
           let data =
             match Tool_result.data result with
             | `String _ -> None
@@ -2457,7 +2459,15 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
           background_start_failed (Printexc.to_string exn))))))
 ;;
 
-let submit = submit_with_ops production_request_ops
+let submit_with_request_id = submit_with_ops production_request_ops
+
+let submit ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
+    ~base_path ~caller ~f ~keeper_name () =
+  submit_with_request_id ?on_accepted ?on_worker_aborted ?on_worker_settled
+    ~background_sw ~base_path ~caller
+    ~f:(fun ~request_id:_ request_sw -> f request_sw)
+    ~keeper_name ()
+;;
 
 (** Exact owner check for both the process-global table and persisted rows. *)
 let owner_rejection ~caller (entry : entry) =
@@ -2844,7 +2854,15 @@ module For_testing = struct
   let atomic_staging_dir = atomic_staging_dir
   let load_record = load_record
   let recover_lost_disk_records = recover_lost_disk_records
-  let submit = submit_with_ops
+  let submit_with_request_id = submit_with_ops
+
+  let submit ops ?on_accepted ?on_worker_aborted ?on_worker_settled
+      ~background_sw ~base_path ~caller ~f ~keeper_name () =
+    submit_with_request_id ops ?on_accepted ?on_worker_aborted
+      ?on_worker_settled ~background_sw ~base_path ~caller
+      ~f:(fun ~request_id:_ request_sw -> f request_sw)
+      ~keeper_name ()
+  ;;
   let cancel = cancel_with_ops
   let reserved_request_id_count () =
     Eio.Mutex.use_ro mu (fun () -> Store_transition_table.length reserved_request_ids)

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -305,6 +305,23 @@ val submit
   -> unit
   -> (submit_outcome, submit_error) result
 
+(** Same lifecycle and durability contract as {!submit}, but the worker also
+    receives the canonical request id generated and accepted by this module.
+    Use this when a producer's durable artifacts must share that identity;
+    callers needing only fire-and-forget execution should keep using
+    {!submit}. *)
+val submit_with_request_id
+  :  ?on_accepted:(string -> (unit, string) result)
+  -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
+  -> ?on_worker_settled:(worker_settlement -> unit)
+  -> background_sw:Eio.Switch.t
+  -> base_path:string
+  -> caller:string
+  -> f:(request_id:string -> Eio.Switch.t -> Keeper_types_profile.tool_result)
+  -> keeper_name:string
+  -> unit
+  -> (submit_outcome, submit_error) result
+
 (** [poll ~base_path ~caller request_id] returns [Found entry] for a known request,
     [Absent] when no record exists, and [Unreadable reason] when a persisted
     record exists but cannot be decoded. [Rejected reason] means the request
@@ -412,6 +429,19 @@ module For_testing : sig
     -> base_path:string
     -> caller:string
     -> f:(Eio.Switch.t -> Keeper_types_profile.tool_result)
+    -> keeper_name:string
+    -> unit
+    -> (submit_outcome, submit_error) result
+
+  val submit_with_request_id
+    :  request_ops
+    -> ?on_accepted:(string -> (unit, string) result)
+    -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
+    -> ?on_worker_settled:(worker_settlement -> unit)
+    -> background_sw:Eio.Switch.t
+    -> base_path:string
+    -> caller:string
+    -> f:(request_id:string -> Eio.Switch.t -> Keeper_types_profile.tool_result)
     -> keeper_name:string
     -> unit
     -> (submit_outcome, submit_error) result

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1384,6 +1384,27 @@ let test_judge_error_node_timed_out () =
       None n2.elapsed_s
   | _ -> Alcotest.fail "expected Judge_failed roundtrip"
 
+let test_deliberation_evidence_roundtrip () =
+  let evidence : Fusion_types.deliberation_evidence =
+    { question = "Which implementation is sound?"
+    ; panel = []
+    ; judge = Error Fusion_types.Empty_result
+    ; judges = []
+    ; judge_usage = { input_tokens = 11; output_tokens = 7 }
+    }
+  in
+  match
+    Fusion_types.deliberation_evidence_to_yojson evidence
+    |> Fusion_types.deliberation_evidence_of_yojson
+  with
+  | Ok decoded ->
+    Alcotest.(check bool)
+      "typed evidence is lossless"
+      true
+      (Fusion_types.equal_deliberation_evidence evidence decoded)
+  | Error detail -> Alcotest.fail detail
+;;
+
 let () =
   Alcotest.run "fusion_core"
     [ ( "gate"
@@ -1488,6 +1509,8 @@ let () =
       , [ Alcotest.test_case "roundtrip" `Quick test_judge_outcome_roundtrip
         ; Alcotest.test_case "timed_out_elapsed_s" `Quick
             test_judge_error_node_timed_out
+        ; Alcotest.test_case "deliberation evidence roundtrip" `Quick
+            test_deliberation_evidence_roundtrip
         ] )
     ; ( "panel_guard"
       , [ Alcotest.test_case "min_answered_range" `Quick test_validated_bad_min_answered

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -75,6 +75,29 @@ let wait_until ~clock ~max_iterations ~interval_sec predicate =
   loop max_iterations
 ;;
 
+let test_identified_worker_receives_accepted_request_id () =
+  with_temp_base (fun base_path ->
+    Eio_main.run (fun _env ->
+      Eio.Switch.run (fun sw ->
+        let observed, resolve_observed = Eio.Promise.create () in
+        let accepted =
+          Keeper_msg_async.submit_with_request_id
+            ~background_sw:sw
+            ~base_path
+            ~caller
+            ~keeper_name:"terminal-event-identified"
+            ~f:(fun ~request_id _request_sw ->
+              Eio.Promise.resolve resolve_observed request_id;
+              Keeper_types_profile.tool_result_ok "completed")
+            ()
+          |> accepted_request_id
+        in
+        check string
+          "worker identity is the accepted request id"
+          accepted
+          (Eio.Promise.await observed))))
+;;
+
 let test_operator_cancel_running_worker_invokes_on_worker_aborted () =
   with_temp_base (fun base_path ->
     Eio_main.run (fun env ->
@@ -343,7 +366,11 @@ let test_closed_background_switch_rejects_worker_acceptance () =
 let () =
   run
     "keeper_msg_async_terminal_event"
-    [ ( "on_worker_aborted"
+    [ ( "worker identity"
+      , [ test_case "identified worker receives accepted request id" `Quick
+            test_identified_worker_receives_accepted_request_id
+        ] )
+    ; ( "on_worker_aborted"
       , [ test_case "operator cancel running worker invokes on_worker_aborted" `Quick
             test_operator_cancel_running_worker_invokes_on_worker_aborted
         ; test_case "abort callback failure stays inside the request lane" `Quick


### PR DESCRIPTION
Stacked on #25348.

Splits Fusion computation from projection, persists the complete typed deliberation evidence shape, and lets identity-sensitive producers receive the canonical Keeper_msg_async request id without changing the simple submit API. This is the boundary required to use the common async lifecycle as the Fusion run authority.

Validation:
- ocamlc -stop-after parsing on touched OCaml files
- ocamlformat --check on touched OCaml files
- git diff --check
- focused Dune waited on the shared wrapper lock held by another focused build and was stopped; CI is authoritative