### PR TITLE
feat(keeper): route dashboard resume through typed receipts

### DIFF
--- a/dashboard/src/api/keeper-bulk.test.ts
+++ b/dashboard/src/api/keeper-bulk.test.ts
@@ -35,15 +35,32 @@ describe('bulkKeeperDirective', () => {
     }
     stubFetch(expected)
 
-    const res = await bulkKeeperDirective(['rondo', 'qa-king'], 'resume')
+    const res = await bulkKeeperDirective(
+      [
+        { name: 'rondo', ownerGeneration: 3, operatorOperationId: 'resume-rondo-1' },
+        { name: 'qa-king', ownerGeneration: 5, operatorOperationId: 'resume-qa-1' },
+      ],
+      'resume',
+    )
 
     const call = mockFetch.mock.calls[0]!
     const init = call[1] as RequestInit
     expect(call[0]).toBe('/api/v1/keepers_bulk/directive')
     expect(init.method).toBe('POST')
     expect(JSON.parse(init.body as string)).toEqual({
-      names: ['rondo', 'qa-king'],
       action: 'resume',
+      targets: [
+        {
+          name: 'rondo',
+          owner_generation: 3,
+          operator_operation_id: 'resume-rondo-1',
+        },
+        {
+          name: 'qa-king',
+          owner_generation: 5,
+          operator_operation_id: 'resume-qa-1',
+        },
+      ],
     })
     expect(res).toEqual(expected)
   })
@@ -60,7 +77,13 @@ describe('bulkKeeperDirective', () => {
       ],
     })
 
-    const res = await bulkKeeperDirective(['rondo', 'ghost'], 'resume')
+    const res = await bulkKeeperDirective(
+      [
+        { name: 'rondo', ownerGeneration: 3, operatorOperationId: 'resume-rondo-2' },
+        { name: 'ghost', ownerGeneration: 0, operatorOperationId: 'resume-ghost-1' },
+      ],
+      'resume',
+    )
 
     expect(res.ok).toBe(true)
     expect(res.succeeded).toBe(1)

--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -13,13 +13,57 @@ import {
 
 interface KeeperLifecycleResponse {
   ok: boolean
-  action?: 'boot' | 'shutdown' | 'reset' | 'clear'
+  action?: 'boot' | 'shutdown' | 'reset' | 'clear' | 'pause' | 'resume' | 'wakeup'
   name?: string
   detail?: unknown
   error?: string
+  committed?: boolean
 }
 interface KeeperControlOptions {
   signal?: AbortSignal
+}
+interface KeeperResumeOptions extends KeeperControlOptions {
+  operatorOperationId?: string
+}
+
+interface PendingResumeIntent {
+  ownerGeneration: number
+  operatorOperationId: string
+}
+
+const pendingResumeIntents = new Map<string, PendingResumeIntent>()
+
+function createResumeOperationId(): string {
+  return `dashboard-resume-${crypto.randomUUID()}`
+}
+
+function resumeIntent(
+  name: string,
+  ownerGeneration: number,
+  explicitOperationId?: string,
+): PendingResumeIntent {
+  if (explicitOperationId) {
+    return { ownerGeneration, operatorOperationId: explicitOperationId }
+  }
+  const pending = pendingResumeIntents.get(name)
+  if (pending?.ownerGeneration === ownerGeneration) return pending
+  const created = {
+    ownerGeneration,
+    operatorOperationId: createResumeOperationId(),
+  }
+  pendingResumeIntents.set(name, created)
+  return created
+}
+
+function clearCommittedResumeIntent(name: string, intent: PendingResumeIntent): void {
+  const pending = pendingResumeIntents.get(name)
+  if (pending?.operatorOperationId === intent.operatorOperationId) {
+    pendingResumeIntents.delete(name)
+  }
+}
+
+function isOwnerGeneration(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
 }
 async function safeJsonResponse<T>(resp: Response, fallbackError: string): Promise<T> {
   try {
@@ -246,16 +290,32 @@ export function pauseKeeper(
   )
 }
 
-export function resumeKeeper(
+export async function resumeKeeper(
   name: string,
-  opts: KeeperControlOptions = {},
+  ownerGeneration: number | null | undefined,
+  opts: KeeperResumeOptions = {},
 ): Promise<KeeperLifecycleResponse> {
-  return safeKeeperPostWithBody(
+  if (!isOwnerGeneration(ownerGeneration)) {
+    return {
+      ok: false,
+      action: 'resume',
+      name,
+      error: `Cannot resume ${name}: current owner generation is unavailable`,
+    }
+  }
+  const intent = resumeIntent(name, ownerGeneration, opts.operatorOperationId)
+  const result = await safeKeeperPostWithBody(
     `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
-    { action: 'resume' },
+    {
+      action: 'resume',
+      owner_generation: intent.ownerGeneration,
+      operator_operation_id: intent.operatorOperationId,
+    },
     `Failed to resume ${name}`,
     opts,
   )
+  if (result.ok) clearCommittedResumeIntent(name, intent)
+  return result
 }
 
 export function wakeKeeper(
@@ -271,6 +331,12 @@ export function wakeKeeper(
 }
 
 export type BulkKeeperDirectiveAction = 'pause' | 'resume' | 'wakeup'
+
+export interface BulkKeeperResumeTarget {
+  name: string
+  ownerGeneration: number
+  operatorOperationId?: string
+}
 
 export interface BulkKeeperDirectiveResult {
   name: string
@@ -292,19 +358,64 @@ export interface BulkKeeperDirectiveResponse {
  * invalidate at the end, so dashboard rebuild cost is O(1) instead of
  * O(N). Returns a per-keeper result array for granular UI feedback.
  */
-export async function bulkKeeperDirective(
+export function bulkKeeperDirective(
+  targets: BulkKeeperResumeTarget[],
+  action: 'resume',
+  opts?: KeeperControlOptions,
+): Promise<BulkKeeperDirectiveResponse>
+export function bulkKeeperDirective(
   names: string[],
+  action: 'pause' | 'wakeup',
+  opts?: KeeperControlOptions,
+): Promise<BulkKeeperDirectiveResponse>
+export async function bulkKeeperDirective(
+  subjects: string[] | BulkKeeperResumeTarget[],
   action: BulkKeeperDirectiveAction,
   opts: KeeperControlOptions = {},
 ): Promise<BulkKeeperDirectiveResponse> {
-  const fallbackError = `Failed to ${action} ${names.length} keeper(s)`
+  const names = subjects.map(subject => typeof subject === 'string' ? subject : subject.name)
+  const fallbackError = `Failed to ${action} ${subjects.length} keeper(s)`
+  const resumeTargets = action === 'resume' ? subjects as BulkKeeperResumeTarget[] : []
+  const invalidResumeTarget = resumeTargets.find(
+    target => typeof target.name !== 'string' || !isOwnerGeneration(target.ownerGeneration),
+  )
+  if (invalidResumeTarget) {
+    const error = `Cannot resume ${invalidResumeTarget.name}: current owner generation is unavailable`
+    return {
+      ok: false,
+      action,
+      requested: subjects.length,
+      succeeded: 0,
+      results: names.map(name => ({ name, ok: false, error })),
+    }
+  }
+  const resumeIntents = action === 'resume'
+    ? resumeTargets.map(target => ({
+        name: target.name,
+        intent: resumeIntent(
+          target.name,
+          target.ownerGeneration,
+          target.operatorOperationId,
+        ),
+      }))
+    : []
+  const body = action === 'resume'
+    ? {
+        action,
+        targets: resumeIntents.map(({ name, intent }) => ({
+          name,
+          owner_generation: intent.ownerGeneration,
+          operator_operation_id: intent.operatorOperationId,
+        })),
+      }
+    : { names, action }
   try {
     const resp = await fetchControlPlane(
       '/api/v1/keepers_bulk/directive',
       {
         method: 'POST',
         headers: jsonHeaders(),
-        body: JSON.stringify({ names, action }),
+        body: JSON.stringify(body),
         signal: opts.signal,
       },
     )
@@ -312,8 +423,13 @@ export async function bulkKeeperDirective(
       resp,
       fallbackError,
     )
-    if (resp.ok && isRecord(payload) && payload.ok === true) {
-      return payload
+    if (isRecord(payload) && Array.isArray(payload.results)) {
+      for (const result of payload.results) {
+        if (!isRecord(result) || result.ok !== true || typeof result.name !== 'string') continue
+        const committed = resumeIntents.find(({ name }) => name === result.name)
+        if (committed) clearCommittedResumeIntent(committed.name, committed.intent)
+      }
+      return payload as unknown as BulkKeeperDirectiveResponse
     }
     return {
       ok: false,

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1303,12 +1303,52 @@ describe('keeper lifecycle', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await resumeKeeper('janitor')
+    const result = await resumeKeeper('janitor', 7, {
+      operatorOperationId: 'dashboard-resume-test-1',
+    })
 
     expect(result.ok).toBe(true)
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe('/api/v1/keepers/janitor/directive')
-    expect(JSON.parse(init.body)).toEqual({ action: 'resume' })
+    expect(JSON.parse(init.body)).toEqual({
+      action: 'resume',
+      owner_generation: 7,
+      operator_operation_id: 'dashboard-resume-test-1',
+    })
+  })
+
+  it('reuses the same resume operation ID after an ambiguous failed response', async () => {
+    vi.stubGlobal('crypto', { randomUUID: vi.fn(() => 'stable-resume-uuid') })
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, action: 'resume', name: 'janitor' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect((await resumeKeeper('janitor', 7)).ok).toBe(false)
+    expect((await resumeKeeper('janitor', 7)).ok).toBe(true)
+
+    const firstInit = fetchMock.mock.calls[0]![1] as RequestInit
+    const secondInit = fetchMock.mock.calls[1]![1] as RequestInit
+    const first = JSON.parse(String(firstInit.body))
+    const second = JSON.parse(String(secondInit.body))
+    expect(first.operator_operation_id).toBe('dashboard-resume-stable-resume-uuid')
+    expect(second.operator_operation_id).toBe(first.operator_operation_id)
+  })
+
+  it('refuses resume when the current owner generation is unavailable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resumeKeeper('janitor', undefined)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('current owner generation is unavailable')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('sends POST with action=wakeup via directive endpoint', async () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -107,6 +107,7 @@ export type {
   BulkKeeperDirectiveAction,
   BulkKeeperDirectiveResult,
   BulkKeeperDirectiveResponse,
+  BulkKeeperResumeTarget,
 } from './keeper-lifecycle'
 export {
   bootKeeper,

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -18,7 +18,7 @@ vi.mock('../store', () => ({
   refreshKeeperRuntimeStatus: vi.fn(async () => undefined),
 }))
 
-import { pauseKeeper } from '../api/keeper'
+import { pauseKeeper, resumeKeeper } from '../api/keeper'
 import { keeperActionVisibility } from '../lib/keeper-predicates'
 import { applyOptimisticKeeperDirective, refreshKeeperRuntimeStatus } from '../store'
 import { runKeeperAction } from './keeper-action-panel'
@@ -152,5 +152,13 @@ describe('runKeeperAction', () => {
 
     expect(applyOptimisticKeeperDirective).toHaveBeenCalledWith('rondo', 'pause')
     expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith()
+  })
+
+  it('forwards the observed owner generation for typed resume', async () => {
+    vi.mocked(resumeKeeper).mockResolvedValueOnce({ ok: true })
+
+    await runKeeperAction('rondo', 'resume', 7)
+
+    expect(resumeKeeper).toHaveBeenCalledWith('rondo', 7)
   })
 })

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -6,7 +6,8 @@
 //
 // Actions available per keeper:
 //   pause     → POST /api/v1/keepers/:name/directive  { action: "pause" }
-//   resume    → POST /api/v1/keepers/:name/directive  { action: "resume" }
+//   resume    → POST /api/v1/keepers/:name/directive
+//               { action: "resume", owner_generation, operator_operation_id }
 //   wakeup    → POST /api/v1/keepers/:name/directive  { action: "wakeup" }
 //   boot      → POST /api/v1/keepers/:name/boot
 //   shutdown  → POST /api/v1/keepers/:name/shutdown
@@ -118,6 +119,7 @@ export const KEEPER_ACTION_LABELS: Record<KeeperActionKey, KeeperActionLabel> = 
 export async function runKeeperAction(
   name: string,
   action: KeeperActionKey,
+  ownerGeneration?: number,
 ): Promise<void> {
   if (action === 'shutdown') {
     const confirmed = await requestConfirm({
@@ -141,7 +143,7 @@ export async function runKeeperAction(
     let res: { ok: boolean; error?: string }
     switch (action) {
       case 'pause':    res = await pauseKeeper(name);    break
-      case 'resume':   res = await resumeKeeper(name);   break
+      case 'resume':   res = await resumeKeeper(name, ownerGeneration);   break
       case 'wakeup':   res = await wakeKeeper(name);     break
       case 'boot':     res = await bootKeeper(name);     break
       case 'shutdown': res = await shutdownKeeper(name); break
@@ -192,7 +194,11 @@ export function KeeperActionButtons({
     if (busy.value) return
     busy.value = true
     try {
-      await runKeeperAction(keeper.name, action)
+      if (action === 'resume') {
+        await runKeeperAction(keeper.name, action, keeper.generation)
+      } else {
+        await runKeeperAction(keeper.name, action)
+      }
     } finally {
       busy.value = false
     }

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -1053,7 +1053,7 @@ describe('KeeperConfigPanel', () => {
     await flush()
     await flush()
 
-    expect(mocks.resumeKeeper).toHaveBeenCalledWith('keeper-sangsu')
+    expect(mocks.resumeKeeper).toHaveBeenCalledWith('keeper-sangsu', 3)
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(2)
     expect(container.textContent).toContain('running')
     expect(container.textContent).toContain('alive')

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1666,7 +1666,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         action === 'pause'
           ? await pauseKeeper(keeperName)
           : action === 'resume'
-            ? await resumeKeeper(keeperName)
+            ? await resumeKeeper(keeperName, c.metrics.generation)
             : await wakeKeeper(keeperName)
       if (!result.ok) {
         throw new Error(result.error || `${action} directive failed`)

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -239,11 +239,12 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const handleDirective = async (action: 'pause' | 'resume' | 'wakeup') => {
     directiveLoading.value = true
     try {
-      const fn =
-        action === 'pause' ? pauseKeeper
-          : action === 'resume' ? resumeKeeper
-          : wakeKeeper
-      const res = await fn(keeper.name)
+      const res =
+        action === 'pause'
+          ? await pauseKeeper(keeper.name)
+          : action === 'resume'
+            ? await resumeKeeper(keeper.name, keeper.generation)
+            : await wakeKeeper(keeper.name)
       if (res.ok) {
         const msg =
           action === 'pause' ? `${keeper.name} 일시정지됨`

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -88,7 +88,9 @@ function lifecycleCommands(keeper: Keeper): WorkspaceCommand[] {
       title: copy.title,
       icon: copy.icon,
       danger: copy.danger,
-      onClick: () => runKeeperAction(keeper.name, key),
+      onClick: () => key === 'resume'
+        ? runKeeperAction(keeper.name, key, keeper.generation)
+        : runKeeperAction(keeper.name, key),
     }
   })
 }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -325,8 +325,12 @@ function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
   return actions
 }
 
-async function runRosterKeeperAction(name: string, action: KeeperActionKey): Promise<void> {
-  await runKeeperAction(name, action)
+async function runRosterKeeperAction(keeper: Keeper, action: KeeperActionKey): Promise<void> {
+  if (action === 'resume') {
+    await runKeeperAction(keeper.name, action, keeper.generation)
+  } else {
+    await runKeeperAction(keeper.name, action)
+  }
 }
 
 function rosterActivityText(activity: KeeperActivityDisplay): string | null {
@@ -405,7 +409,7 @@ function KeeperRosterMenu({
             class=${`kw-kp-menu-item${copy.danger ? ' danger' : ''}`}
             title=${copy.title}
             onClick=${() => {
-              void runRosterKeeperAction(keeper.name, action)
+              void runRosterKeeperAction(keeper, action)
               onClose()
             }}
             data-testid=${`kw-roster-menu-${action}`}

--- a/dashboard/src/store-optimistic-keeper.test.ts
+++ b/dashboard/src/store-optimistic-keeper.test.ts
@@ -60,12 +60,11 @@ describe('applyOptimisticKeeperDirective', () => {
     expect(keepers.value[0]).toEqual(original)
   })
 
-  it('wakeup behaves like resume (paused → running) for the optimistic patch', () => {
+  it('wakeup never clears an operator pause in the optimistic patch', () => {
     keepers.value = [baseKeeper({ name: 'rondo', paused: true, phase: 'Paused' })]
     applyOptimisticKeeperDirective('rondo', 'wakeup')
-    expect(keepers.value[0]!.paused).toBe(false)
-    expect(keepers.value[0]!.phase).toBe('Running')
-    expect(keepers.value[0]!.lifecycle_phase).toBe('Running')
+    expect(keepers.value[0]!.paused).toBe(true)
+    expect(keepers.value[0]!.phase).toBe('Paused')
   })
 
   it('patches lifecycle_phase so the roster status dot tone flips immediately', () => {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -143,8 +143,9 @@ function patchForDirective(action: OptimisticKeeperDirective): Partial<Keeper> {
     case 'pause':
       return { paused: true, phase: 'Paused', lifecycle_phase: 'Paused', pipeline_stage: 'paused', status: 'paused' }
     case 'resume':
-    case 'wakeup':
       return { paused: false, phase: 'Running', lifecycle_phase: 'Running', pipeline_stage: 'idle', status: 'idle' }
+    case 'wakeup':
+      return {}
   }
 }
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -370,38 +370,16 @@ let process_directive ~agent_name directive =
       (Printf.sprintf "directive: resuming keeper %s" agent_name);
     set_keeper_paused_state ~agent_name false
   | Keeper_directive.Wakeup ->
-    (* Dashboard "깨우기" is an explicit operator action and therefore a
-       superset of resume: a deliberately paused Keeper re-enters the run loop
-       before the wakeup signal is delivered. *)
-    let entry_opt = keeper_entry_by_identity_opt agent_name in
-    let entry_paused =
-      match entry_opt with
-      | Some e -> e.meta.paused
-      | None ->
-        (match Keeper_tool_shared_runtime.find_registry_meta
-                 ~keeper_name:agent_name
-                 ~source_layer:"keepalive"
-         with
-         | Some meta -> meta.paused
-         | None -> false)
-    in
-    let prepare_wakeup () = true in
-    if entry_paused
-    then (
-      Log.Keeper.emit
-        Log.Info
-        ~category:Log.Directive
-        ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "wakeup_resume" ])
-        (Printf.sprintf "directive: waking up %s (explicitly resuming paused keeper)" agent_name);
-      set_keeper_paused_state ~agent_name false)
-    else (
-      Log.Keeper.emit
-        Log.Debug
-        ~category:Log.Directive
-        ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "wakeup" ])
-        (Printf.sprintf "directive: waking up %s" agent_name);
-      if prepare_wakeup ()
-      then wakeup_keeper_by_agent_name ~agent_name)
+    (* Wakeup is only a scheduling signal. It must never clear an operator
+       pause: paused-work disposition belongs to the receipt-first
+       [Resume_owner] transaction. Lifecycle admission keeps a paused lane
+       parked until that transaction commits. *)
+    Log.Keeper.emit
+      Log.Debug
+      ~category:Log.Directive
+      ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "wakeup" ])
+      (Printf.sprintf "directive: waking up %s" agent_name);
+    wakeup_keeper_by_agent_name ~agent_name
   | Keeper_directive.Assign_task task_id ->
     let task_id_string = Keeper_id.Task_id.to_string task_id in
     Log.Keeper.emit

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -12,7 +12,9 @@ val get_bus : unit -> Agent_sdk.Event_bus.t option
 
 val register_grpc_heartbeat_starter : Keeper_keepalive_signal.grpc_heartbeat_starter_fn -> unit
 
-(** Apply one typed control-plane directive to a Keeper lane. *)
+(** Apply one typed control-plane directive to a Keeper lane. [Wakeup] only
+    signals scheduling and never clears an operator pause; paused-work resume
+    belongs to [Keeper_paused_work_resume_transaction]. *)
 val process_directive : agent_name:string -> Keeper_directive.t -> unit
 
 (** Test-visible helper for the [current_task_id] sent in gRPC heartbeats.

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -200,20 +200,20 @@ val handle_keeper_directive_post :
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
   Mcp_server.server_state ->
   string -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
-(** Handle [POST /directive] (operator directive injection). *)
+(** Handle [POST /directive] (operator directive injection). A resume body
+    must carry [owner_generation] and a stable [operator_operation_id], and is
+    committed through the typed paused-work disposition transaction. *)
 
 val handle_keeper_bulk_directive_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
   Mcp_server.server_state ->
   string -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
-(** Handle [POST /api/v1/keepers_bulk/directive]. Body:
-    [{"names": [...], "action": "pause"|"resume"|"wakeup"}]. Runs the
-    same per-keeper meta read / persist / dispatch path as
-    [handle_keeper_directive_post], but issues a single cache invalidate
-    for the whole batch. Trades per-keeper observability granularity for
-    bulk performance: a fleet-wide resume is 1 round-trip + 1 rebuild
-    instead of N + N. *)
+(** Handle [POST /api/v1/keepers_bulk/directive]. Pause and wakeup use
+    [{"names": [...]}]. Resume uses exact per-owner
+    [{"targets": [{"name", "owner_generation", "operator_operation_id"}, ...]}]
+    fences and commits each target through the typed paused-work disposition
+    transaction. Cache invalidation runs once for the whole batch. *)
 
 val handle_keeper_get_subroutes :
   Mcp_server.server_state ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -896,6 +896,8 @@ let required_resume_owner_request json =
   | _, None -> Error "resume requires string \"operator_operation_id\""
 
 let parse_keeper_directive_json json =
+  (* STR-OK: HTTP boundary parse of the untrusted wire "action" field into a
+     typed directive; any unknown value becomes a typed Error. *)
   match Safe_ops.json_string_opt "action" json with
   | Some "pause" -> Ok (Plain_directive Plain_pause)
   | Some "resume" ->
@@ -957,6 +959,8 @@ let parse_bulk_plain_names json =
   | Some _ | None -> Error "names must be a non-empty list of valid keeper names"
 
 let parse_bulk_directive_json json =
+  (* STR-OK: HTTP boundary parse of the untrusted wire "action" field into a
+     typed directive; any unknown value becomes a typed Error. *)
   match Safe_ops.json_string_opt "action" json with
   | Some "resume" ->
     Result.map

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -855,55 +855,230 @@ let handle_keeper_secrets_post state req reqd body_str =
 let handle_keeper_lifecycle_post =
   Server_dashboard_http_keeper_api_lifecycle_post.handle_keeper_lifecycle_post
 
-let directive_action_to_string = function
-  | Keeper_directive.Pause -> "pause"
-  | Keeper_directive.Resume -> "resume"
-  | Keeper_directive.Wakeup -> "wakeup"
-  | Keeper_directive.Assign_task _ -> "assign_task"
+type plain_keeper_directive =
+  | Plain_pause
+  | Plain_wakeup
 
-let keeper_ctx_of_dashboard_state ~sw ~clock state agent_name :
-    _ Keeper_tool_surface.context =
-  let workspace_scope = Mcp_server.workspace_scope state in
-  {
-    config = workspace_scope.config;
-    agent_name;
-    sw;
-    clock;
-    proc_mgr = state.Mcp_server.proc_mgr;
-    net = state.Mcp_server.net;
-    publication_recovery_provider =
-      Mcp_server.publication_recovery_availability_provider state;
+let plain_directive_action = function
+  | Plain_pause -> "pause"
+  | Plain_wakeup -> "wakeup"
+
+let plain_directive_to_keeper_directive = function
+  | Plain_pause -> Keeper_directive.Pause
+  | Plain_wakeup -> Keeper_directive.Wakeup
+
+type parsed_keeper_directive =
+  | Plain_directive of plain_keeper_directive
+  | Resume_owner of Keeper_paused_work_resume_transaction.request
+
+type bulk_resume_target =
+  { name : string
+  ; request : Keeper_paused_work_resume_transaction.request
   }
 
-let meta_with_directive_paused_state
-    (meta : Keeper_meta_contract.keeper_meta)
-    paused =
-  let base =
-    if paused
-    then
-      (* Pause: set the bit and drop the stale blocker; any existing latch
-         stays paired with [paused = true]. *)
-      { meta with paused = true; runtime = { meta.runtime with last_blocker = None } }
-    else
-      (* Resume: [mark_resumed] couples clearing [paused] with clearing the
-         typed latch (Dead_tombstone included). Previously this path set
-         [paused = false] while leaving [latched_reason], stranding the keeper
-         in the un-recoverable paused=false + Dead_tombstone split that
-         lifecycle admission denies forever. *)
-      Keeper_meta_contract.mark_resumed meta
+type parsed_bulk_directive =
+  | Bulk_plain of
+      { names : string list
+      ; directive : plain_keeper_directive
+      }
+  | Bulk_resume_owner of bulk_resume_target list
+
+let required_resume_owner_request json =
+  match
+    Safe_ops.json_int_opt "owner_generation" json,
+    Safe_ops.json_string_opt "operator_operation_id" json
+  with
+  | Some owner_generation, Some operator_operation_id ->
+    Ok
+      Keeper_paused_work_resume_transaction.
+        { owner_generation; operator_operation_id }
+  | None, _ -> Error "resume requires integer \"owner_generation\""
+  | _, None -> Error "resume requires string \"operator_operation_id\""
+
+let parse_keeper_directive_json json =
+  match Safe_ops.json_string_opt "action" json with
+  | Some "pause" -> Ok (Plain_directive Plain_pause)
+  | Some "resume" ->
+    Result.map
+      (fun request -> Resume_owner request)
+      (required_resume_owner_request json)
+  | Some "wakeup" -> Ok (Plain_directive Plain_wakeup)
+  | Some action ->
+    Error
+      (Printf.sprintf
+         "invalid action %S: expected pause, resume, or wakeup"
+         action)
+  | None -> Error "missing \"action\" field"
+
+let parse_bulk_resume_target = function
+  | `Assoc _ as json ->
+    (match Safe_ops.json_string_opt "name" json with
+     | Some name when is_valid_keeper_name name ->
+       Result.map
+         (fun request -> { name; request })
+         (required_resume_owner_request json)
+     | Some _ -> Error "resume target has an invalid keeper name"
+     | None -> Error "resume target requires string \"name\"")
+  | _ -> Error "resume targets must be JSON objects"
+
+let parse_bulk_resume_targets json =
+  match Json_util.assoc_member_opt "targets" json with
+  | Some (`List targets) when targets <> [] ->
+    let rec collect seen parsed = function
+      | [] -> Ok (List.rev parsed)
+      | target :: rest ->
+        (match parse_bulk_resume_target target with
+         | Ok target when List.mem target.name seen ->
+           Error (Printf.sprintf "duplicate resume target %S" target.name)
+         | Ok target -> collect (target.name :: seen) (target :: parsed) rest
+         | Error _ as error -> error)
+    in
+    collect [] [] targets
+  | Some (`List []) -> Error "resume targets must be a non-empty list"
+  | Some _ -> Error "resume requires array \"targets\""
+  | None -> Error "resume requires array \"targets\""
+
+let parse_bulk_plain_names json =
+  match Json_util.assoc_member_opt "names" json with
+  | Some (`List items) ->
+    let rec collect seen parsed = function
+      | [] -> Ok (List.rev parsed)
+      | `String name :: rest when is_valid_keeper_name name ->
+        if List.mem name seen
+        then Error (Printf.sprintf "duplicate keeper name %S" name)
+        else collect (name :: seen) (name :: parsed) rest
+      | `String name :: _ ->
+        Error (Printf.sprintf "invalid keeper name %S" name)
+      | _ :: _ -> Error "names must contain only valid keeper-name strings"
+    in
+    (match items with
+     | [] -> Error "names must be a non-empty list of valid keeper names"
+     | _ -> collect [] [] items)
+  | Some _ | None -> Error "names must be a non-empty list of valid keeper names"
+
+let parse_bulk_directive_json json =
+  match Safe_ops.json_string_opt "action" json with
+  | Some "resume" ->
+    Result.map
+      (fun targets -> Bulk_resume_owner targets)
+      (parse_bulk_resume_targets json)
+  | Some "pause" ->
+    Result.map
+      (fun names -> Bulk_plain { names; directive = Plain_pause })
+      (parse_bulk_plain_names json)
+  | Some "wakeup" ->
+    Result.map
+      (fun names -> Bulk_plain { names; directive = Plain_wakeup })
+      (parse_bulk_plain_names json)
+  | Some action ->
+    Error
+      (Printf.sprintf
+         "invalid action %S: expected pause, resume, or wakeup"
+         action)
+  | None -> Error "missing \"action\" field"
+
+module For_testing = struct
+  let parse_resume_request json =
+    match parse_keeper_directive_json json with
+    | Ok (Resume_owner request) ->
+      Ok (request.owner_generation, request.operator_operation_id)
+    | Ok (Plain_directive _) -> Error "request is not Resume_owner"
+    | Error _ as error -> error
+  ;;
+
+  let parse_bulk_resume_requests json =
+    match parse_bulk_directive_json json with
+    | Ok (Bulk_resume_owner targets) ->
+      Ok
+        (List.map
+           (fun target ->
+              ( target.name
+              , target.request.owner_generation
+              , target.request.operator_operation_id ))
+           targets)
+    | Ok (Bulk_plain _) -> Error "request is not bulk Resume_owner"
+    | Error _ as error -> error
+  ;;
+end
+
+let resume_failure_message failure =
+  Keeper_paused_work_resume_transaction.error_to_string
+    Keeper_paused_work_resume_transaction.
+      { cause = failure; reservation_release = None }
+
+let resume_error_status (error : Keeper_paused_work_resume_transaction.error) =
+  match error.cause with
+  | Invalid_request _ -> `Bad_request
+  | Durable_meta_missing -> `Not_found
+  | Reservation_conflict _
+  | Receipt_conflict _
+  | Durable_owner_generation_changed _
+  | Durable_owner_identity_changed
+  | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
+  | Registry_owner_generation_changed _
+  | Registry_owner_identity_changed
+  | Registry_owner_not_paused _ -> `Conflict
+  | Receipt_lock_failed _
+  | Receipt_read_failed _
+  | Receipt_write_failed _
+  | Durable_meta_read_failed _
+  | Registry_owner_missing
+  | Projection_failed _ -> `Internal_server_error
+
+let resume_receipt_json
+    (receipt : Keeper_paused_work_disposition_receipt.t) =
+  `Assoc
+    [ "keeper_name", `String receipt.keeper_name
+    ; "expected_trace_id", `String (Keeper_id.Trace_id.to_string receipt.expected_trace_id)
+    ; "expected_generation", `Int receipt.expected_generation
+    ; "operator_operation_id", `String receipt.operator_operation_id
+    ; "requested_at", `Float receipt.requested_at
+    ; "operation", `String "resume_owner"
+    ]
+
+let resume_result_json ~name
+    (success : Keeper_paused_work_resume_transaction.success) =
+  let commit_status =
+    match success.commit_status with
+    | Committed -> "committed"
+    | Already_committed -> "already_committed"
   in
-  { base with updated_at = Keeper_meta_contract.now_iso () }
+  let ok, projection, error =
+    match success.projection with
+    | Applied phase ->
+      true, Keeper_state_machine.phase_to_string phase, None
+    | Committed_followup_failed failure ->
+      false, "committed_followup_failed", Some (resume_failure_message failure)
+  in
+  `Assoc
+    ([ "ok", `Bool ok
+     ; "action", `String "resume"
+     ; "operation", `String "resume_owner"
+     ; "name", `String name
+     ; "committed", `Bool true
+     ; "commit_status", `String commit_status
+     ; "projection", `String projection
+     ; "receipt", resume_receipt_json success.receipt
+     ]
+     @ match error with
+       | None -> []
+       | Some message -> [ "error", `String message ])
 
-let should_persist_directive_paused_state directive (meta : Keeper_meta_contract.keeper_meta) paused =
-  match directive with
-  | Keeper_directive.Resume -> true
-  | Keeper_directive.Pause | Keeper_directive.Wakeup
-  | Keeper_directive.Assign_task _ -> not (Bool.equal meta.paused paused)
+let run_resume_owner config ~name request =
+  Keeper_paused_work_resume_transaction.resume config ~keeper_name:name request
 
-let persist_directive_paused_state ~config ~name ~action_str directive meta paused =
-  let updated_meta = meta_with_directive_paused_state meta paused in
-    (* Pause/resume toggle via CAS merge: do not rewind a concurrent
-       turn's cumulative usage counters. *)
+let persist_directive_pause ~config ~name
+    (meta : Keeper_meta_contract.keeper_meta) =
+  let updated_meta =
+    { meta with
+      paused = true
+    ; runtime = { meta.runtime with last_blocker = None }
+    ; updated_at = Keeper_meta_contract.now_iso ()
+    }
+  in
+  (* Pause toggle via CAS merge: do not rewind a concurrent turn's cumulative
+     usage counters. Resume is owned exclusively by the receipt transaction. *)
   match
        Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.monotonic_usage_counters
@@ -913,8 +1088,7 @@ let persist_directive_paused_state ~config ~name ~action_str directive meta paus
   | Ok () -> Ok ()
   | Error err ->
     Log.Keeper.warn
-      "directive %s: write_meta failed for %s: %s"
-      action_str
+      "directive pause: write_meta failed for %s: %s"
       name
       err;
     Otel_metric_store.inc_counter
@@ -927,254 +1101,180 @@ let persist_directive_paused_state ~config ~name ~action_str directive meta paus
       ();
     Error err
 
-let ensure_registered_for_resume ~sw ~clock state agent_name name =
-  let config = Mcp_server.workspace_config state in
-  match Keeper_registry.get ~base_path:config.base_path name with
-  | Some _ -> Ok `Already_registered
-  | None ->
-      let keeper_ctx = keeper_ctx_of_dashboard_state ~sw ~clock state agent_name in
-      let args = `Assoc [ ("name", `String name) ] in
-      (match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_up" ~args with
-       | Some result when Tool_result.is_success result ->
-           (match Keeper_registry.get ~base_path:config.base_path name with
-            | Some _ -> Ok `Booted_missing_registry
-            | None ->
-                Error
-                  (Printf.sprintf
-                     "resume boot for %s succeeded but no registry entry was created"
-                     name))
-       | Some result -> Error (Tool_result.message result)
-       | None -> Error "masc_keeper_up dispatch returned None")
-
-let handle_keeper_directive_post ~sw ~clock state agent_name req reqd body_str =
+let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_directive in
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let action =
+    let parsed =
       try
         let json = Yojson.Safe.from_string body_str in
-        match Safe_ops.json_string_opt "action" json with
-        | Some "pause" -> Ok Keeper_directive.Pause
-        | Some "resume" -> Ok Keeper_directive.Resume
-        | Some "wakeup" -> Ok Keeper_directive.Wakeup
-        | Some a ->
-            Error
-              (Printf.sprintf
-                 "invalid action %S: expected pause, resume, or wakeup" a)
-        | None -> Error "missing \"action\" field"
+        parse_keeper_directive_json json
       with Yojson.Json_error e ->
         Error (Printf.sprintf "invalid json: %s" e)
     in
-  match action with
-  | Error msg ->
-      respond_error ~ok:false reqd msg
-    | Ok directive ->
-        let config = (Mcp_server.workspace_config state) in
-        let action_str = directive_action_to_string directive in
-        (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from [Error _]
-           (IO/parse failure). For pause/resume the operator expects state to
-           change; silent 200 hides the failure. For wakeup we preserve the
-           prior best-effort semantics (wakeup does not require meta). *)
-        let read_result = Keeper_meta_store.read_meta config name in
-        let meta_opt =
-          match read_result with
-          | Ok (Some meta) -> Some meta
-          | Ok None -> None
-          | Error err ->
-              Log.Keeper.warn "directive %s %s: read_meta failed: %s"
-                action_str name err;
-              None
+    match parsed with
+    | Error message -> respond_error ~ok:false reqd message
+    | Ok (Resume_owner request) ->
+      let config = Mcp_server.workspace_config state in
+      (match run_resume_owner config ~name request with
+       | Error error ->
+         Log.Keeper.warn
+           "directive resume_owner rejected for %s generation=%d operation_id=%s: %s"
+           name
+           request.owner_generation
+           request.operator_operation_id
+           (Keeper_paused_work_resume_transaction.error_to_string error);
+         Http.Response.json_value
+           ~status:(resume_error_status error)
+           ~request:req
+           (`Assoc
+              [ "ok", `Bool false
+              ; "action", `String "resume"
+              ; "operation", `String "resume_owner"
+              ; "name", `String name
+              ; "committed", `Bool false
+              ; "error", `String (Keeper_paused_work_resume_transaction.error_to_string error)
+              ])
+           reqd
+       | Ok success ->
+         refresh_keeper_execution_surfaces ~config ~name "resume_owner";
+         let response = resume_result_json ~name success in
+         (match success.projection with
+          | Applied _ ->
+            Log.Keeper.info
+              "directive resume_owner applied for %s generation=%d operation_id=%s"
+              name
+              request.owner_generation
+              request.operator_operation_id;
+            Http.Response.json_value ~compress:true ~request:req response reqd
+          | Committed_followup_failed failure ->
+            Log.Keeper.warn
+              "directive resume_owner committed with pending projection for %s generation=%d operation_id=%s: %s"
+              name
+              request.owner_generation
+              request.operator_operation_id
+              (resume_failure_message failure);
+            Http.Response.json_value
+              ~status:`Accepted
+              ~compress:true
+              ~request:req
+              response
+              reqd))
+    | Ok (Plain_directive plain_directive) ->
+      let config = Mcp_server.workspace_config state in
+      let action_str = plain_directive_action plain_directive in
+      let directive = plain_directive_to_keeper_directive plain_directive in
+      let read_result = Keeper_meta_store.read_meta config name in
+      let needs_meta =
+        match plain_directive with
+        | Plain_pause -> true
+        | Plain_wakeup -> false
+      in
+      let proceed meta_opt =
+        let persist_result =
+          match plain_directive, meta_opt with
+          | Plain_pause, Some meta ->
+            persist_directive_pause ~config ~name meta
+          | Plain_pause, None | Plain_wakeup, _ -> Ok ()
         in
-        let persist_paused_state paused =
-          match meta_opt with
-          | Some meta
-            when should_persist_directive_paused_state directive meta paused ->
-              persist_directive_paused_state
-                ~config
-                ~name
-                ~action_str
-                directive
-                meta
-                paused
-          | Some _ | None -> Ok ()
-        in
-        let proceed () =
-          let ensure_result =
-            match directive with
-            | Keeper_directive.Resume ->
-              ensure_registered_for_resume ~sw ~clock state agent_name name
-            | Keeper_directive.Pause | Keeper_directive.Wakeup
-            | Keeper_directive.Assign_task _ -> Ok `Already_registered
+        match persist_result with
+        | Error error ->
+          Http.Response.json_value
+            ~status:`Internal_server_error
+            ~request:req
+            (`Assoc
+               [ "ok", `Bool false
+               ; "action", `String action_str
+               ; "name", `String name
+               ; "error", `String error
+               ])
+            reqd
+        | Ok () ->
+          let resolved_agent_name =
+            match Keeper_registry_lookup.find_by_name name, meta_opt with
+            | Some entry, _ -> entry.meta.agent_name
+            | None, Some meta -> meta.agent_name
+            | None, None -> Keeper_identity.keeper_agent_name name
           in
-          match ensure_result with
-          | Error err ->
-              Log.Keeper.error
-                "directive %s: failed to ensure registered keeper for %s: %s"
-                action_str
-                name
-                err;
-              Http.Response.json_value ~status:`Internal_server_error ~request:req
-                (`Assoc
-                   [
-                     ("ok", `Bool false);
-                     ("action", `String action_str);
-                     ("name", `String name);
-                     ("error", `String err);
-                   ])
-                reqd
-          | Ok registration_state ->
-              let persist_result =
-                match directive, registration_state with
-                | Keeper_directive.Pause, _ -> persist_paused_state true
-                | Keeper_directive.Resume, `Already_registered ->
-                  persist_paused_state false
-                | Keeper_directive.Resume, `Booted_missing_registry -> Ok ()
-                | Keeper_directive.Wakeup, _
-                | Keeper_directive.Assign_task _, _ -> Ok ()
-              in
-              (match persist_result with
-              | Error err ->
-                  Log.Keeper.error
-                    "directive %s: failed to persist paused state for %s: %s"
-                    action_str
-                    name
-                    err;
-                  Http.Response.json_value
-                    ~status:`Internal_server_error
-                    ~request:req
-                    (`Assoc
-                       [
-                         ("ok", `Bool false);
-                         ("action", `String action_str);
-                         ("name", `String name);
-                         ("error", `String err);
-                       ])
-                    reqd
-              | Ok () ->
-                  let resolved_agent_name =
-                    match Keeper_registry_lookup.find_by_name name with
-                    | Some entry -> entry.meta.agent_name
-                    | None -> (
-                        match meta_opt with
-                        | Some meta -> meta.agent_name
-                        | None -> Keeper_identity.keeper_agent_name name)
-                  in
-                  Keeper_keepalive.process_directive
-                    ~agent_name:resolved_agent_name directive;
-                  (match directive with
-                   | Keeper_directive.Pause ->
-                     refresh_keeper_execution_surfaces ~config ~name "paused"
-                   | Keeper_directive.Resume ->
-                       refresh_keeper_execution_surfaces ~config ~name "resumed"
-                   | Keeper_directive.Wakeup
-                   | Keeper_directive.Assign_task _ ->
-                     invalidate_keeper_execution_surfaces ~config ());
-                  Http.Response.json_value ~compress:true ~request:req
-                    (`Assoc
-                       [
-                         ("ok", `Bool true);
-                         ("action", `String action_str);
-                         ("name", `String name);
-                       ])
-                    reqd)
-        in
-        let needs_meta_for_state_transition =
-          match directive with
-          | Keeper_directive.Pause | Keeper_directive.Resume -> true
-          | Keeper_directive.Wakeup | Keeper_directive.Assign_task _ -> false
-        in
-        (match read_result, needs_meta_for_state_transition with
-         | Error err, true ->
-             Log.Keeper.error
-               "directive %s: read_meta failed for %s: %s"
-               action_str
-               name
-               err;
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string PausedStatePersistErrors)
-               ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Directive));
-                        ("reason", "read_meta_error")]
-               ();
-             Http.Response.json_value ~status:`Internal_server_error ~request:req
-               (`Assoc
-                  [
-                    ("ok", `Bool false);
-                    ("action", `String action_str);
-                    ("name", `String name);
-                    ("error", `String (Printf.sprintf "read_meta failed: %s" err));
-                  ])
-               reqd
-         | Ok None, true ->
-             Log.Keeper.warn
-               "directive %s: keeper meta missing for %s — refusing silent no-op"
-               action_str
-               name;
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string PausedStatePersistErrors)
-               ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Directive));
-                        ("reason", "meta_missing")]
-               ();
-             Http.Response.json_value ~status:`Not_found ~request:req
-               (`Assoc
-                  [
-                    ("ok", `Bool false);
-                    ("action", `String action_str);
-                    ("name", `String name);
-                    ("error", `String "keeper meta not found");
-                  ])
-               reqd
-         | Error err, false ->
-             (* Wakeup does not require meta; log but proceed. *)
-             Log.Keeper.warn
-               "directive %s: read_meta failed for %s (best-effort proceed): %s"
-               action_str
-               name
-               err;
-             proceed ()
-         | Ok None, false
-         | Ok (Some _), _ ->
-             proceed ())
+          Keeper_keepalive.process_directive
+            ~agent_name:resolved_agent_name
+            directive;
+          (match plain_directive with
+           | Plain_pause ->
+             refresh_keeper_execution_surfaces ~config ~name "paused"
+           | Plain_wakeup ->
+             invalidate_keeper_execution_surfaces ~config ());
+          Http.Response.json_value ~compress:true ~request:req
+            (`Assoc
+               [ "ok", `Bool true
+               ; "action", `String action_str
+               ; "name", `String name
+               ])
+            reqd
+      in
+      (match read_result, needs_meta with
+       | Error error, true ->
+         Log.Keeper.error
+           "directive %s: read_meta failed for %s: %s"
+           action_str
+           name
+           error;
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string PausedStatePersistErrors)
+           ~labels:
+             [ "phase", Keeper_paused_state_persist_phase.(to_label Directive)
+             ; "reason", "read_meta_error"
+             ]
+           ();
+         Http.Response.json_value ~status:`Internal_server_error ~request:req
+           (`Assoc
+              [ "ok", `Bool false
+              ; "action", `String action_str
+              ; "name", `String name
+              ; "error", `String (Printf.sprintf "read_meta failed: %s" error)
+              ])
+           reqd
+       | Ok None, true ->
+         Log.Keeper.warn
+           "directive %s: keeper meta missing for %s — refusing silent no-op"
+           action_str
+           name;
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string PausedStatePersistErrors)
+           ~labels:
+             [ "phase", Keeper_paused_state_persist_phase.(to_label Directive)
+             ; "reason", "meta_missing"
+             ]
+           ();
+         Http.Response.json_value ~status:`Not_found ~request:req
+           (`Assoc
+              [ "ok", `Bool false
+              ; "action", `String action_str
+              ; "name", `String name
+              ; "error", `String "keeper meta not found"
+              ])
+           reqd
+       | Error error, false ->
+         Log.Keeper.warn
+           "directive %s: read_meta failed for %s (best-effort proceed): %s"
+           action_str
+           name
+           error;
+         proceed None
+       | Ok None, false -> proceed None
+       | Ok (Some meta), _ -> proceed (Some meta))
 
-(** Bulk variant of [handle_keeper_directive_post].
-    Accepts [{names: [name, ...], action: "pause"|"resume"|"wakeup"}].
-    Each keeper goes through the same meta read / persist / dispatch path
-    as the per-name handler, but cache invalidation runs once at the end.
-    This avoids N round-trip latency and N×cache-rebuild cost when an
-    operator wants to (re)pause the whole fleet from the dashboard.
-    @since 0.20.0 *)
-let handle_keeper_bulk_directive_post ~sw ~clock state agent_name req reqd body_str =
+(** Bulk variant of [handle_keeper_directive_post]. Pause and wakeup accept
+    [{names: [name, ...]}]. Resume accepts exact per-owner
+    [{targets: [{name, owner_generation, operator_operation_id}, ...]}] fences.
+    Cache invalidation still runs once for the whole batch. *)
+let handle_keeper_bulk_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_str =
   let parsed =
     try
       let json = Yojson.Safe.from_string body_str in
-      let names_list =
-        match Json_util.assoc_member_opt "names" json with
-        | Some (`List items) ->
-            List.filter_map
-              (function
-                | `String s when is_valid_keeper_name s -> Some s
-                | _ -> None)
-              items
-            |> List.sort_uniq String.compare
-        | None | Some _ -> []
-      in
-      let action_result =
-        match Safe_ops.json_string_opt "action" json with
-        | Some "pause" -> Ok Keeper_directive.Pause
-        | Some "resume" -> Ok Keeper_directive.Resume
-        | Some "wakeup" -> Ok Keeper_directive.Wakeup
-        | Some a ->
-            Error
-              (Printf.sprintf
-                 "invalid action %S: expected pause, resume, or wakeup" a)
-        | None -> Error "missing \"action\" field"
-      in
-      match action_result with
-      | Error e -> Error e
-      | Ok _ when names_list = [] ->
-          Error "names must be a non-empty list of valid keeper names"
-      | Ok action -> Ok (names_list, action)
+      parse_bulk_directive_json json
     with Yojson.Json_error e ->
       Error (Printf.sprintf "invalid json: %s" (String.escaped e))
   in
@@ -1183,92 +1283,79 @@ let handle_keeper_bulk_directive_post ~sw ~clock state agent_name req reqd body_
       Http.Response.json_value ~status:`Bad_request
         (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
         reqd
-  | Ok (names, directive) ->
-      let config = (Mcp_server.workspace_config state) in
-      let action_str = directive_action_to_string directive in
-      let needs_meta =
-        match directive with
-        | Keeper_directive.Pause | Keeper_directive.Resume -> true
-        | Keeper_directive.Wakeup | Keeper_directive.Assign_task _ -> false
-      in
-      let process_one name =
-        let read_result = Keeper_meta_store.read_meta config name in
-        let meta_opt =
-          match read_result with
-          | Ok (Some m) -> Some m
-          | Ok None | Error _ -> None
-        in
-        match read_result, needs_meta with
-        | Error err, true ->
-            `Assoc
-              [
-                ("name", `String name);
-                ("ok", `Bool false);
-                ( "error",
-                  `String (Printf.sprintf "read_meta failed: %s" err) );
-              ]
-        | Ok None, true ->
-            `Assoc
-              [
-                ("name", `String name);
-                ("ok", `Bool false);
-                ("error", `String "keeper meta not found");
-              ]
-        | Error _, false | Ok None, false | Ok (Some _), _ ->
-            let target_paused =
-              match directive with
-              | Keeper_directive.Pause -> Some true
-              | Keeper_directive.Resume -> Some false
-              | Keeper_directive.Wakeup | Keeper_directive.Assign_task _ -> None
-            in
-            (match
-               match directive with
-               | Keeper_directive.Resume ->
-                 ensure_registered_for_resume ~sw ~clock state agent_name name
-               | Keeper_directive.Pause | Keeper_directive.Wakeup
-               | Keeper_directive.Assign_task _ -> Ok `Already_registered
-             with
-             | Error err ->
+  | Ok parsed ->
+      let config = Mcp_server.workspace_config state in
+      let action_str, requested_count, results =
+        match parsed with
+        | Bulk_resume_owner targets ->
+          let process_target target =
+            match run_resume_owner config ~name:target.name target.request with
+            | Error error ->
+              `Assoc
+                [ "name", `String target.name
+                ; "ok", `Bool false
+                ; "committed", `Bool false
+                ; "error", `String (Keeper_paused_work_resume_transaction.error_to_string error)
+                ]
+            | Ok success -> resume_result_json ~name:target.name success
+          in
+          "resume", List.length targets, List.map process_target targets
+        | Bulk_plain { names; directive = plain_directive } ->
+          let action_str = plain_directive_action plain_directive in
+          let directive = plain_directive_to_keeper_directive plain_directive in
+          let needs_meta =
+            match plain_directive with
+            | Plain_pause -> true
+            | Plain_wakeup -> false
+          in
+          let process_name name =
+            let read_result = Keeper_meta_store.read_meta config name in
+            match read_result, needs_meta with
+            | Error error, true ->
+              `Assoc
+                [ "name", `String name
+                ; "ok", `Bool false
+                ; "error", `String (Printf.sprintf "read_meta failed: %s" error)
+                ]
+            | Ok None, true ->
+              `Assoc
+                [ "name", `String name
+                ; "ok", `Bool false
+                ; "error", `String "keeper meta not found"
+                ]
+            | Error _, false | Ok None, false | Ok (Some _), _ ->
+              let meta_opt =
+                match read_result with
+                | Ok meta -> meta
+                | Error _ -> None
+              in
+              let persist_result =
+                match plain_directive, meta_opt with
+                | Plain_pause, Some meta ->
+                  persist_directive_pause ~config ~name meta
+                | Plain_pause, None | Plain_wakeup, _ -> Ok ()
+              in
+              (match persist_result with
+               | Error error ->
                  `Assoc
-                   [ ("name", `String name); ("ok", `Bool false); ("error", `String err) ]
-             | Ok registration_state ->
-                 let persist_result =
-                   match directive, registration_state, target_paused, meta_opt with
-                   | Keeper_directive.Resume, `Booted_missing_registry, _, _ -> Ok ()
-                   | _, _, Some target, Some meta
-                     when should_persist_directive_paused_state directive meta target
-                     ->
-                       persist_directive_paused_state
-                         ~config
-                         ~name
-                         ~action_str
-                         directive
-                         meta
-                         target
-                   | _ -> Ok ()
+                   [ "name", `String name
+                   ; "ok", `Bool false
+                   ; "error", `String error
+                   ]
+               | Ok () ->
+                 let resolved_agent_name =
+                   match Keeper_registry_lookup.find_by_name name, meta_opt with
+                   | Some entry, _ -> entry.meta.agent_name
+                   | None, Some meta -> meta.agent_name
+                   | None, None -> Keeper_identity.keeper_agent_name name
                  in
-                 (match persist_result with
-                  | Error err ->
-                      `Assoc
-                        [
-                          ("name", `String name);
-                          ("ok", `Bool false);
-                          ("error", `String err);
-                        ]
-                  | Ok () ->
-                      let resolved_agent_name =
-                        match Keeper_registry_lookup.find_by_name name with
-                        | Some entry -> entry.meta.agent_name
-                        | None -> (
-                            match meta_opt with
-                            | Some meta -> meta.agent_name
-                            | None -> Keeper_identity.keeper_agent_name name)
-                      in
-                      Keeper_keepalive.process_directive
-                        ~agent_name:resolved_agent_name directive;
-                      `Assoc [ ("name", `String name); ("ok", `Bool true) ]))
+                 Keeper_keepalive.process_directive
+                   ~agent_name:resolved_agent_name
+                   directive;
+                 `Assoc [ "name", `String name; "ok", `Bool true ])
+          in
+          action_str, List.length names, List.map process_name names
       in
-      let results = List.map process_one names in
       let ok_count =
         List.fold_left
           (fun acc r ->
@@ -1277,9 +1364,18 @@ let handle_keeper_bulk_directive_post ~sw ~clock state agent_name req reqd body_
             | _ -> acc)
           0 results
       in
-      let requested_count = List.length names in
       let failed_count = requested_count - ok_count in
-      if ok_count > 0 then invalidate_keeper_execution_surfaces ~config ();
+      let committed_count =
+        List.fold_left
+          (fun acc result ->
+             match Json_util.assoc_member_opt "committed" result with
+             | Some (`Bool true) -> acc + 1
+             | _ -> acc)
+          0
+          results
+      in
+      if ok_count > 0 || committed_count > 0
+      then invalidate_keeper_execution_surfaces ~config ();
       let response =
         `Assoc
           [
@@ -1293,6 +1389,9 @@ let handle_keeper_bulk_directive_post ~sw ~clock state agent_name req reqd body_
       in
       if failed_count = 0 then
         Http.Response.json_value ~compress:true ~request:req response reqd
+      else if committed_count > 0 then
+        Http.Response.json_value ~status:`Accepted ~compress:true
+          ~request:req response reqd
       else
         Http.Response.json_value ~status:`Internal_server_error ~compress:true
           ~request:req response reqd

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -113,6 +113,8 @@ val handle_keeper_directive_post :
   Httpun.Reqd.t ->
   string ->
   unit
+(** A resume body requires [owner_generation] and a stable
+    [operator_operation_id]; raw action-only resume is rejected. *)
 
 val handle_keeper_bulk_directive_post :
   sw:Eio.Switch.t ->
@@ -123,3 +125,13 @@ val handle_keeper_bulk_directive_post :
   Httpun.Reqd.t ->
   string ->
   unit
+(** Pause/wakeup accept a [names] list. Resume accepts a [targets] list whose
+    entries carry [name], [owner_generation], and [operator_operation_id]. *)
+
+module For_testing : sig
+  val parse_resume_request :
+    Yojson.Safe.t -> (int * string, string) result
+
+  val parse_bulk_resume_requests :
+    Yojson.Safe.t -> ((string * int * string) list, string) result
+end

--- a/test/dune
+++ b/test/dune
@@ -115,6 +115,7 @@
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os
   test_server_dashboard_http_keeper_api_trace
+  test_keeper_paused_work_resume_surface
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state
@@ -428,6 +429,7 @@
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os
   test_server_dashboard_http_keeper_api_trace
+  test_keeper_paused_work_resume_surface
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -203,6 +203,18 @@ let test_grpc_pause_directive_records_reason () =
         | None -> fail "expected registered keeper after pause directive");
        Keeper_keepalive.process_directive
          ~agent_name:keeper_name
+         Keeper_directive.Wakeup;
+       (match Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          check bool "wakeup does not resume paused keeper" true entry.meta.paused;
+          check
+            (option string)
+            "wakeup preserves the operator pause receipt boundary"
+            (Some wire_grpc_directive)
+            (latched_reason_wire entry.meta)
+        | None -> fail "expected registered keeper after wakeup directive");
+       Keeper_keepalive.process_directive
+         ~agent_name:keeper_name
          Keeper_directive.Resume;
        match Keeper_registry.get ~base_path:config.base_path keeper_name with
        | Some entry ->

--- a/test/test_keeper_paused_work_resume_surface.ml
+++ b/test/test_keeper_paused_work_resume_surface.ml
@@ -1,0 +1,79 @@
+open Alcotest
+open Masc
+
+module Surface = Server_dashboard_http_keeper_api_post.For_testing
+
+let require_ok label = function
+  | Ok value -> value
+  | Error error -> failf "%s: %s" label error
+;;
+
+let test_single_resume_requires_exact_fences () =
+  let action_only = `Assoc [ "action", `String "resume" ] in
+  (match Surface.parse_resume_request action_only with
+   | Error _ -> ()
+   | Ok _ -> fail "action-only resume was accepted");
+  let parsed =
+    Surface.parse_resume_request
+      (`Assoc
+         [ "action", `String "resume"
+         ; "owner_generation", `Int 7
+         ; "operator_operation_id", `String "dashboard-resume-7"
+         ])
+    |> require_ok "parse exact Resume_owner"
+  in
+  check (pair int string) "exact fences" (7, "dashboard-resume-7") parsed
+;;
+
+let test_bulk_resume_requires_per_owner_targets () =
+  let names_only =
+    `Assoc
+      [ "action", `String "resume"
+      ; "names", `List [ `String "rondo"; `String "qa-king" ]
+      ]
+  in
+  (match Surface.parse_bulk_resume_requests names_only with
+   | Error _ -> ()
+   | Ok _ -> fail "names-only bulk resume was accepted");
+  let parsed =
+    Surface.parse_bulk_resume_requests
+      (`Assoc
+         [ "action", `String "resume"
+         ; ( "targets"
+           , `List
+               [ `Assoc
+                   [ "name", `String "rondo"
+                   ; "owner_generation", `Int 3
+                   ; "operator_operation_id", `String "resume-rondo-1"
+                   ]
+               ; `Assoc
+                   [ "name", `String "qa-king"
+                   ; "owner_generation", `Int 5
+                   ; "operator_operation_id", `String "resume-qa-1"
+                   ]
+               ] )
+         ])
+    |> require_ok "parse bulk Resume_owner"
+  in
+  check
+    (list (triple string int string))
+    "per-owner fences"
+    [ "rondo", 3, "resume-rondo-1"; "qa-king", 5, "resume-qa-1" ]
+    parsed
+;;
+
+let () =
+  run
+    "keeper paused-work resume surface"
+    [ ( "resume request contract"
+      , [ test_case
+            "single requires generation and operation id"
+            `Quick
+            test_single_resume_requires_exact_fences
+        ; test_case
+            "bulk requires per-owner targets"
+            `Quick
+            test_bulk_resume_requires_per_owner_targets
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- require `owner_generation` and a stable `operator_operation_id` for single dashboard resume
- require exact per-Keeper resume targets for the bulk dashboard endpoint
- route both surfaces through `Keeper_paused_work_resume_transaction`
- remove the raw `Keeper_directive.Resume` path from these dashboard handlers
- make `Wakeup` a scheduling signal only; it no longer clears an operator pause in runtime or optimistic dashboard state
- return receipt/commit/projection truth, including HTTP 202 for a committed intent whose follow-up projection remains pending
- keep one client operation ID across an ambiguous failed response and forward the observed generation from every dashboard resume control
- add OCaml request-contract/wakeup-boundary tests and dashboard API/call-site tests

## Stack and scope

Base: `codex/paused-work-resume-transaction-20260720` (draft PR #25349).

This leaf closes the direct dashboard single/bulk resume bypass and the wakeup-as-resume alias. `masc_keeper_up`, dashboard boot-resume, and legacy gRPC `Resume` decode still have separate lifecycle/dead-revival boundaries and are intentionally not changed here. `Transfer_owner`, `Settle_from_source_terminal`, fleet paused-retained metrics, and the 10-Keeper 8-hour acceptance run remain.

## Validation

- OCaml parser checks for every changed `.ml`/`.mli`
- `ocamlformat --check` for every changed OCaml file
- TypeScript syntax parser for every changed `.ts` file
- `git diff --check`
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail` — 0 new violations
- static scan confirms no raw `Keeper_directive.Resume`, `mark_resumed`, or `paused = false` path remains in the dashboard directive handler
- static scan confirms the former `wakeup_resume` runtime path is removed

The targeted ESLint command reported these files are outside the repository's curated ESLint file list, so it provided no lint coverage. Local Dune build/tests, TypeScript typecheck, and dashboard tests were intentionally not run; the operator is running builds separately and PR CI remains the build authority.