### PR TITLE
feat(compaction): prepare provider-native fit boundary

### DIFF
--- a/lib/keeper/keeper_compaction_projection_target.ml
+++ b/lib/keeper/keeper_compaction_projection_target.ml
@@ -397,6 +397,30 @@ let context_to_json (context : Fit.context) =
 
 let json_kind kind fields = `Assoc (("kind", `String kind) :: fields)
 
+(* Persisted evidence carries only a closed classification code.  The raw
+   [Llm_provider.Error.to_string] text is derived from provider response
+   bodies and network error messages: it is unbounded free text and can
+   embed endpoint addresses, so it must not reach durable evidence JSON. *)
+let provider_error_code (error : Llm_provider.Error.provider_error) =
+  match error with
+  | MissingApiKey _ -> "missing_api_key"
+  | InvalidConfig _ -> "invalid_config"
+  | ParseError _ -> "parse_error"
+  | UnknownVariant _ -> "unknown_variant"
+  | ProviderUnavailable _ -> "provider_unavailable"
+  | RateLimit _ -> "rate_limit"
+  | HardQuota _ -> "hard_quota"
+  | CapacityExhausted _ -> "capacity_exhausted"
+  | AuthError _ -> "auth_error"
+  | AuthorizationError _ -> "authorization_error"
+  | ServerError { code; _ } -> Printf.sprintf "server_error_%d" code
+  | NetworkError _ -> "network_error"
+  | Timeout _ -> "timeout"
+  | InvalidRequest _ -> "invalid_request"
+  | NotFound _ -> "not_found"
+  | ProviderTerminal _ -> "provider_terminal"
+;;
+
 let input_count_error_to_json = function
   | Llm_provider.Input_token_count.Unsupported { protocol; model_id } ->
     json_kind
@@ -407,9 +431,7 @@ let input_count_error_to_json = function
   | Transport error ->
     json_kind
       "transport"
-      [ ( "detail"
-        , `String (Llm_provider.Error.(of_http_error error |> to_string)) )
-      ]
+      [ "code", `String (provider_error_code (Llm_provider.Error.of_http_error error)) ]
   | Invalid_response { protocol; model_id; detail } ->
     json_kind
       "invalid_response"
@@ -482,29 +504,42 @@ let measure_checkpoint_fit ?connection_cache ?clock ~sw ~net = function
     }
   | Exact_committed { evidence; checkpoint_ref; prepared_request } ->
     let result =
-      match
-        Llm_provider.Complete.measure_request
-          ?connection_cache
-          ?clock
-          ~sw
-          ~net
-          prepared_request
-      with
-      | Error error -> Fit.Unavailable (unavailable_of_measurement_error error)
-      | Ok measured ->
-        (match Llm_provider.Complete.admit_request measured with
-         | Ok admitted ->
-           Fit.Fits
-             (Llm_provider.Complete.admitted_fit admitted |> context_of_oas)
-         | Error (Context_window_exceeded fit) ->
-           Fit.Exceeds (context_of_oas fit)
-         | Error (Context_limit_unknown { model_id }) ->
-           Fit.Unavailable (Context_limit_unknown { model_id })
-         | Error (Invalid_context_limit { model_id; max_context_tokens }) ->
-           Fit.Unavailable
-             (Invalid_context_limit { model_id; max_context_tokens })
-         | Error (Output_reservation_unknown { model_id }) ->
-           Fit.Unavailable (Output_reservation_unknown { model_id }))
+      (* Resolve the context limit before measurement: a pre-knowable limit
+         failure must not cost a count round-trip (agent_sdk v0.219.0+). *)
+      match Llm_provider.Complete.resolve_context_limit prepared_request with
+      | Error (Context_limit_unknown { model_id }) ->
+        Fit.Unavailable (Context_limit_unknown { model_id })
+      | Error (Invalid_context_limit { model_id; max_context_tokens }) ->
+        Fit.Unavailable (Invalid_context_limit { model_id; max_context_tokens })
+      | Error (Output_reservation_unknown { model_id }) ->
+        Fit.Unavailable (Output_reservation_unknown { model_id })
+      | Error (Context_window_exceeded fit) -> Fit.Exceeds (context_of_oas fit)
+      | Ok max_context_tokens ->
+        (match
+           Llm_provider.Complete.measure_request
+             ?connection_cache
+             ?clock
+             ~sw
+             ~net
+             prepared_request
+         with
+         | Error error -> Fit.Unavailable (unavailable_of_measurement_error error)
+         | Ok measured ->
+           (match
+              Llm_provider.Complete.admit_request ~max_context_tokens measured
+            with
+            | Ok admitted ->
+              Fit.Fits
+                (Llm_provider.Complete.admitted_fit admitted |> context_of_oas)
+            | Error (Context_window_exceeded fit) ->
+              Fit.Exceeds (context_of_oas fit)
+            | Error (Context_limit_unknown { model_id }) ->
+              Fit.Unavailable (Context_limit_unknown { model_id })
+            | Error (Invalid_context_limit { model_id; max_context_tokens }) ->
+              Fit.Unavailable
+                (Invalid_context_limit { model_id; max_context_tokens })
+            | Error (Output_reservation_unknown { model_id }) ->
+              Fit.Unavailable (Output_reservation_unknown { model_id })))
     in
     { checkpoint_ref; target = Exact evidence; result }
 ;;

--- a/lib/keeper/keeper_compaction_projection_target.ml
+++ b/lib/keeper/keeper_compaction_projection_target.ml
@@ -98,7 +98,6 @@ type exact_target =
   { evidence : exact
   ; provider_config : Llm_provider.Provider_config.t
   }
-[@@warning "-69"]
 
 type t =
   | Exact_target of exact_target
@@ -159,10 +158,226 @@ let capture = function
 ;;
 
 type committed =
-  { target : t
-  ; checkpoint_ref : Keeper_checkpoint_ref.t
+  | Exact_committed of
+      { evidence : exact
+      ; checkpoint_ref : Keeper_checkpoint_ref.t
+      ; prepared_request : Llm_provider.Complete.prepared_request
+      }
+  | Unavailable_committed of
+      { reason : unavailable
+      ; checkpoint_ref : Keeper_checkpoint_ref.t
+      }
+
+let provider_config_for_checkpoint
+      (provider_config : Llm_provider.Provider_config.t)
+      (checkpoint : Agent_sdk.Checkpoint.t)
+  =
+  let agent_config : Agent_sdk.Types.agent_config =
+    { (Agent_sdk.Types.default_config ~model:provider_config.model_id) with
+      name = checkpoint.agent_name
+    ; system_prompt = checkpoint.system_prompt
+    ; max_tokens = provider_config.max_tokens
+    ; temperature = checkpoint.temperature
+    ; top_p = checkpoint.top_p
+    ; top_k = checkpoint.top_k
+    ; min_p = checkpoint.min_p
+    ; enable_thinking = checkpoint.enable_thinking
+    ; preserve_thinking = checkpoint.preserve_thinking
+    ; response_format = checkpoint.response_format
+    ; thinking_budget = checkpoint.thinking_budget
+    ; reasoning_effort = checkpoint.reasoning_effort
+    ; tool_choice = checkpoint.tool_choice
+    ; disable_parallel_tool_use = checkpoint.disable_parallel_tool_use
+    ; cache_system_prompt = checkpoint.cache_system_prompt
+    }
+  in
+  Agent_sdk.Provider.provider_config_with_agent_config
+    ~config:agent_config
+    provider_config
+;;
+
+let bind_committed_checkpoint
+      ~(checkpoint : Agent_sdk.Checkpoint.t)
+      checkpoint_ref
+  = function
+  | Unavailable_target reason -> Unavailable_committed { reason; checkpoint_ref }
+  | Exact_target { evidence; provider_config } ->
+    let config = provider_config_for_checkpoint provider_config checkpoint in
+    let tools =
+      List.map Agent_sdk.Types.tool_schema_to_json checkpoint.tools
+    in
+    let prepared_request =
+      Llm_provider.Complete.prepare_request
+        ~config
+        ~messages:checkpoint.messages
+        ~tools
+        ~capture_id:checkpoint_ref.sha256
+        ()
+    in
+    Exact_committed { evidence; checkpoint_ref; prepared_request }
+;;
+
+let committed_evidence = function
+  | Exact_committed { evidence; _ } -> Exact evidence
+  | Unavailable_committed { reason; _ } -> Unavailable reason
+;;
+
+let checkpoint_ref = function
+  | Exact_committed { checkpoint_ref; _ }
+  | Unavailable_committed { checkpoint_ref; _ } -> checkpoint_ref
+;;
+
+type target_unavailable = unavailable
+
+module Fit = struct
+  type context =
+    { input_tokens : int
+    ; reserved_output_tokens : int
+    ; max_context_tokens : int
+    }
+
+  type unavailable =
+    | Projection_target_unavailable of target_unavailable
+    | Input_count_failed of Llm_provider.Input_token_count.error
+    | Output_token_ceiling_missing
+    | Invalid_completion_request of string
+    | Context_limit_unknown of { model_id : string }
+    | Invalid_context_limit of
+        { model_id : string
+        ; max_context_tokens : int
+        }
+    | Output_reservation_unknown of { model_id : string }
+
+  type t =
+    | Fits of context
+    | Exceeds of context
+    | Unavailable of unavailable
+end
+
+type fit_evidence =
+  { checkpoint_ref : Keeper_checkpoint_ref.t
+  ; target : evidence
+  ; result : Fit.t
   }
 
-let bind_committed_checkpoint checkpoint_ref target = { target; checkpoint_ref }
-let committed_evidence committed = captured_evidence committed.target
-let checkpoint_ref committed = committed.checkpoint_ref
+let context_to_json (context : Fit.context) =
+  `Assoc
+    [ "input_tokens", `Int context.input_tokens
+    ; "reserved_output_tokens", `Int context.reserved_output_tokens
+    ; "max_context_tokens", `Int context.max_context_tokens
+    ]
+;;
+
+let json_kind kind fields = `Assoc (("kind", `String kind) :: fields)
+
+let input_count_error_to_json = function
+  | Llm_provider.Input_token_count.Unsupported { protocol; model_id } ->
+    json_kind
+      "unsupported"
+      [ "protocol", `String (Llm_provider.Input_token_count.show_protocol protocol)
+      ; "model_id", `String model_id
+      ]
+  | Transport error ->
+    json_kind
+      "transport"
+      [ ( "detail"
+        , `String (Llm_provider.Error.(of_http_error error |> to_string)) )
+      ]
+  | Invalid_response { protocol; model_id; detail } ->
+    json_kind
+      "invalid_response"
+      [ "protocol", `String (Llm_provider.Input_token_count.show_protocol protocol)
+      ; "model_id", `String model_id
+      ; "detail", `String detail
+      ]
+;;
+
+let unavailable_to_fit_json = function
+  | Fit.Projection_target_unavailable reason ->
+    json_kind
+      "projection_target_unavailable"
+      [ "detail", unavailable_to_json reason ]
+  | Input_count_failed error ->
+    json_kind "input_count_failed" [ "detail", input_count_error_to_json error ]
+  | Output_token_ceiling_missing ->
+    json_kind "output_token_ceiling_missing" []
+  | Invalid_completion_request detail ->
+    json_kind "invalid_completion_request" [ "detail", `String detail ]
+  | Context_limit_unknown { model_id } ->
+    json_kind "context_limit_unknown" [ "model_id", `String model_id ]
+  | Invalid_context_limit { model_id; max_context_tokens } ->
+    json_kind
+      "invalid_context_limit"
+      [ "model_id", `String model_id
+      ; "max_context_tokens", `Int max_context_tokens
+      ]
+  | Output_reservation_unknown { model_id } ->
+    json_kind "output_reservation_unknown" [ "model_id", `String model_id ]
+;;
+
+let fit_evidence_to_json evidence =
+  let checkpoint_ref = evidence.checkpoint_ref in
+  let result =
+    match evidence.result with
+    | Fit.Fits context -> json_kind "fits" [ "context", context_to_json context ]
+    | Fit.Exceeds context ->
+      json_kind "exceeds" [ "context", context_to_json context ]
+    | Fit.Unavailable reason ->
+      json_kind "unavailable" [ "reason", unavailable_to_fit_json reason ]
+  in
+  `Assoc
+    [ "checkpoint_ref", Keeper_checkpoint_ref.to_yojson checkpoint_ref
+    ; "target", evidence_to_json evidence.target
+    ; "result", result
+    ]
+;;
+
+let context_of_oas (fit : Llm_provider.Complete.context_fit) : Fit.context =
+  { input_tokens = fit.input_tokens
+  ; reserved_output_tokens = fit.reserved_output_tokens
+  ; max_context_tokens = fit.max_context_tokens
+  }
+;;
+
+let unavailable_of_measurement_error = function
+  | Llm_provider.Count_tokens_sync.Input_count_failed error ->
+    Fit.Input_count_failed error
+  | Output_token_resolution_failed Required_output_token_ceiling_missing ->
+    Output_token_ceiling_missing
+  | Invalid_completion_request detail -> Invalid_completion_request detail
+;;
+
+let measure_checkpoint_fit ?connection_cache ?clock ~sw ~net = function
+  | Unavailable_committed { reason; checkpoint_ref } ->
+    { checkpoint_ref
+    ; target = Unavailable reason
+    ; result = Fit.Unavailable (Projection_target_unavailable reason)
+    }
+  | Exact_committed { evidence; checkpoint_ref; prepared_request } ->
+    let result =
+      match
+        Llm_provider.Complete.measure_request
+          ?connection_cache
+          ?clock
+          ~sw
+          ~net
+          prepared_request
+      with
+      | Error error -> Fit.Unavailable (unavailable_of_measurement_error error)
+      | Ok measured ->
+        (match Llm_provider.Complete.admit_request measured with
+         | Ok admitted ->
+           Fit.Fits
+             (Llm_provider.Complete.admitted_fit admitted |> context_of_oas)
+         | Error (Context_window_exceeded fit) ->
+           Fit.Exceeds (context_of_oas fit)
+         | Error (Context_limit_unknown { model_id }) ->
+           Fit.Unavailable (Context_limit_unknown { model_id })
+         | Error (Invalid_context_limit { model_id; max_context_tokens }) ->
+           Fit.Unavailable
+             (Invalid_context_limit { model_id; max_context_tokens })
+         | Error (Output_reservation_unknown { model_id }) ->
+           Fit.Unavailable (Output_reservation_unknown { model_id }))
+    in
+    { checkpoint_ref; target = Exact evidence; result }
+;;

--- a/lib/keeper/keeper_compaction_projection_target.ml
+++ b/lib/keeper/keeper_compaction_projection_target.ml
@@ -4,12 +4,21 @@ type context_window_resolution =
   | Invalid_context_window of int
 
 type request =
-  { assignment_id : string
-  ; resolve_context_window : Runtime.t -> context_window_resolution
-  }
+  | Resolve_assignment of
+      { assignment_id : string
+      ; resolve_context_window : Runtime.t -> context_window_resolution
+      }
+  | Exact_runtime of
+      { runtime : Runtime.t
+      ; effective_max_context : int
+      }
 
 let request ~assignment_id ~resolve_context_window =
-  { assignment_id; resolve_context_window }
+  Resolve_assignment { assignment_id; resolve_context_window }
+;;
+
+let exact_request ~runtime ~effective_max_context =
+  Exact_runtime { runtime; effective_max_context }
 ;;
 
 type unavailable =
@@ -125,25 +134,28 @@ let capture_exact effective_max_context (runtime : Runtime.t) =
       }
 ;;
 
-let capture { assignment_id; resolve_context_window } =
-  if String.equal assignment_id ""
-  then Unavailable_target Empty_assignment
-  else
-    match Runtime.resolve_assignment assignment_id with
-    | `Lane _ -> Unavailable_target (Assignment_ambiguous { assignment_id })
-    | `Missing ->
-      Unavailable_target (Runtime_unavailable { runtime_id = assignment_id })
-    | `Single_runtime runtime ->
-      (match resolve_context_window runtime with
-       | Resolved_context_window effective_max_context ->
-         capture_exact effective_max_context runtime
-       | Context_window_not_resolved ->
-         Unavailable_target
-           (Context_window_unavailable { runtime_id = runtime.id })
-       | Invalid_context_window effective_max_context ->
-         Unavailable_target
-           (Invalid_effective_context_window
-              { runtime_id = runtime.id; effective_max_context }))
+let capture = function
+  | Exact_runtime { runtime; effective_max_context } ->
+    capture_exact effective_max_context runtime
+  | Resolve_assignment { assignment_id; resolve_context_window } ->
+    if String.equal assignment_id ""
+    then Unavailable_target Empty_assignment
+    else
+      match Runtime.resolve_assignment assignment_id with
+      | `Lane _ -> Unavailable_target (Assignment_ambiguous { assignment_id })
+      | `Missing ->
+        Unavailable_target (Runtime_unavailable { runtime_id = assignment_id })
+      | `Single_runtime runtime ->
+        (match resolve_context_window runtime with
+         | Resolved_context_window effective_max_context ->
+           capture_exact effective_max_context runtime
+         | Context_window_not_resolved ->
+           Unavailable_target
+             (Context_window_unavailable { runtime_id = runtime.id })
+         | Invalid_context_window effective_max_context ->
+           Unavailable_target
+             (Invalid_effective_context_window
+                { runtime_id = runtime.id; effective_max_context }))
 ;;
 
 type committed =

--- a/lib/keeper/keeper_compaction_projection_target.ml
+++ b/lib/keeper/keeper_compaction_projection_target.ml
@@ -90,8 +90,135 @@ let evidence_to_json = function
   | Unavailable reason ->
     `Assoc
       [ "kind", `String "unavailable"
-      ; "detail", unavailable_to_json reason
-      ]
+       ; "detail", unavailable_to_json reason
+       ]
+;;
+
+let object_fields label = function
+  | `Assoc fields -> Ok fields
+  | json ->
+    Error
+      (Printf.sprintf
+         "%s must be an object (received %s)"
+         label
+         (Yojson.Safe.to_string json))
+;;
+
+let exact_fields label expected fields =
+  let actual = List.map fst fields |> List.sort String.compare in
+  let expected = List.sort String.compare expected in
+  if List.equal String.equal expected actual
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf "%s contains an invalid or duplicate field set" label)
+;;
+
+let required_string label key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" label key)
+  | None -> Error (Printf.sprintf "%s.%s is missing" label key)
+;;
+
+let required_int label key fields =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be an int" label key)
+  | None -> Error (Printf.sprintf "%s.%s is missing" label key)
+;;
+
+let required_json label key fields =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s.%s is missing" label key)
+;;
+
+let unavailable_of_json json =
+  let ( let* ) = Result.bind in
+  let label = "compaction projection target detail" in
+  let* fields = object_fields label json in
+  let* reason = required_string label "reason" fields in
+  match reason with
+  | "empty_assignment" ->
+    let* () = exact_fields label [ "reason" ] fields in
+    Ok Empty_assignment
+  | "assignment_ambiguous" ->
+    let* () = exact_fields label [ "assignment_id"; "reason" ] fields in
+    let* assignment_id = required_string label "assignment_id" fields in
+    Ok (Assignment_ambiguous { assignment_id })
+  | "runtime_unavailable" ->
+    let* () = exact_fields label [ "reason"; "runtime_id" ] fields in
+    let* runtime_id = required_string label "runtime_id" fields in
+    Ok (Runtime_unavailable { runtime_id })
+  | "context_window_unavailable" ->
+    let* () = exact_fields label [ "reason"; "runtime_id" ] fields in
+    let* runtime_id = required_string label "runtime_id" fields in
+    Ok (Context_window_unavailable { runtime_id })
+  | "invalid_effective_context_window" ->
+    let* () =
+      exact_fields
+        label
+        [ "effective_max_context"; "reason"; "runtime_id" ]
+        fields
+    in
+    let* runtime_id = required_string label "runtime_id" fields in
+    let* effective_max_context =
+      required_int label "effective_max_context" fields
+    in
+    if effective_max_context <= 0
+    then Ok (Invalid_effective_context_window { runtime_id; effective_max_context })
+    else Error "invalid effective context evidence must be non-positive"
+  | unknown ->
+    Error (Printf.sprintf "unknown compaction projection target reason: %s" unknown)
+;;
+
+let evidence_of_json json =
+  let ( let* ) = Result.bind in
+  let label = "compaction projection target" in
+  let* fields = object_fields label json in
+  let* kind = required_string label "kind" fields in
+  match kind with
+  | "exact" ->
+    let* () =
+      exact_fields
+        label
+        [ "effective_max_context"
+        ; "kind"
+        ; "model_id"
+        ; "oas_provider_kind"
+        ; "protocol"
+        ; "provider_id"
+        ; "runtime_id"
+        ]
+        fields
+    in
+    let* runtime_id = required_string label "runtime_id" fields in
+    let* provider_id = required_string label "provider_id" fields in
+    let* protocol = required_string label "protocol" fields in
+    let* oas_provider_kind = required_string label "oas_provider_kind" fields in
+    let* model_id = required_string label "model_id" fields in
+    let* effective_max_context =
+      required_int label "effective_max_context" fields
+    in
+    if effective_max_context <= 0
+    then Error "exact effective context evidence must be positive"
+    else
+      Ok
+        (Exact
+           { runtime_id
+           ; provider_id
+           ; protocol
+           ; oas_provider_kind
+           ; model_id
+           ; effective_max_context
+           })
+  | "unavailable" ->
+    let* () = exact_fields label [ "detail"; "kind" ] fields in
+    let* detail = required_json label "detail" fields in
+    let* reason = unavailable_of_json detail in
+    Ok (Unavailable reason)
+  | unknown -> Error (Printf.sprintf "unknown compaction projection kind: %s" unknown)
 ;;
 
 type exact_target =

--- a/lib/keeper/keeper_compaction_projection_target.mli
+++ b/lib/keeper/keeper_compaction_projection_target.mli
@@ -20,6 +20,12 @@ val request :
   resolve_context_window:(Runtime.t -> context_window_resolution) ->
   request
 
+(** Capture the exact immutable runtime already selected for a provider turn.
+    This path performs no registry lookup, so a later runtime reload cannot
+    change the provider/model attributed to an overflow recovery. *)
+val exact_request :
+  runtime:Runtime.t -> effective_max_context:int -> request
+
 type unavailable =
   | Empty_assignment
   | Assignment_ambiguous of { assignment_id : string }

--- a/lib/keeper/keeper_compaction_projection_target.mli
+++ b/lib/keeper/keeper_compaction_projection_target.mli
@@ -50,6 +50,7 @@ type evidence =
   | Unavailable of unavailable
 
 val evidence_to_json : evidence -> Yojson.Safe.t
+val evidence_of_json : Yojson.Safe.t -> (evidence, string) result
 
 type t
 

--- a/lib/keeper/keeper_compaction_projection_target.mli
+++ b/lib/keeper/keeper_compaction_projection_target.mli
@@ -63,9 +63,58 @@ val captured_evidence : t -> evidence
 type committed
 
 (** Bind the captured target to the exact SHA-bearing checkpoint reference
-    returned by the successful source CAS. This is pure and performs no
-    observation or I/O. *)
-val bind_committed_checkpoint : Keeper_checkpoint_ref.t -> t -> committed
+    returned by the successful source CAS, and prepare the canonical OAS
+    request projection for that exact saved checkpoint. This is pure and
+    performs no observation or I/O. *)
+val bind_committed_checkpoint :
+  checkpoint:Agent_sdk.Checkpoint.t -> Keeper_checkpoint_ref.t -> t -> committed
 
 val committed_evidence : committed -> evidence
 val checkpoint_ref : committed -> Keeper_checkpoint_ref.t
+
+type target_unavailable = unavailable
+
+module Fit : sig
+  type context =
+    { input_tokens : int
+    ; reserved_output_tokens : int
+    ; max_context_tokens : int
+    }
+
+  type unavailable =
+    | Projection_target_unavailable of target_unavailable
+    | Input_count_failed of Llm_provider.Input_token_count.error
+    | Output_token_ceiling_missing
+    | Invalid_completion_request of string
+    | Context_limit_unknown of { model_id : string }
+    | Invalid_context_limit of
+        { model_id : string
+        ; max_context_tokens : int
+        }
+    | Output_reservation_unknown of { model_id : string }
+
+  type t =
+    | Fits of context
+    | Exceeds of context
+    | Unavailable of unavailable
+end
+
+type fit_evidence = private
+  { checkpoint_ref : Keeper_checkpoint_ref.t
+  ; target : evidence
+  ; result : Fit.t
+  }
+
+val fit_evidence_to_json : fit_evidence -> Yojson.Safe.t
+
+(** Native-count then admit the same opaque request; no estimate, truncation,
+    retry, lookup, or completion occurs. Cancellation propagates. [Fit.Fits]
+    proves only the committed checkpoint: future dispatch retains OAS
+    admission. Callers schedule and persist this I/O outside Keeper admission. *)
+val measure_checkpoint_fit :
+  ?connection_cache:Llm_provider.Http_client.cache ->
+  ?clock:_ Eio.Time.clock ->
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  committed ->
+  fit_evidence

--- a/lib/keeper/keeper_compaction_projection_target.mli
+++ b/lib/keeper/keeper_compaction_projection_target.mli
@@ -26,7 +26,10 @@ val request :
 val exact_request :
   runtime:Runtime.t -> effective_max_context:int -> request
 
-type unavailable =
+(* Private: external code may inspect but never construct these values, so
+   the encode→decode roundtrip invariants (Exact positive, invalid-window
+   non-positive) cannot be bypassed by direct construction. *)
+type unavailable = private
   | Empty_assignment
   | Assignment_ambiguous of { assignment_id : string }
   | Runtime_unavailable of { runtime_id : string }
@@ -36,7 +39,7 @@ type unavailable =
       ; effective_max_context : int
       }
 
-type exact =
+type exact = private
   { runtime_id : string
   ; provider_id : string
   ; protocol : string

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -693,6 +693,7 @@ let commit_prepared_compaction (prepared : prepared_compaction)
          ; turn_generation
          ; projection_target =
              Keeper_compaction_projection_target.bind_committed_checkpoint
+               ~checkpoint:saved_checkpoint
                installed_ref
                projection_target
          }

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -14,6 +14,7 @@ module StringMap = Set_util.StringMap
 
 type runtime_execution = {
   runtime_id : string;
+  runtime : Runtime.t;
   max_context_resolution : Keeper_context_runtime.max_context_resolution;
   max_context : int;
   temperature : float;

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -12,6 +12,7 @@ module EC = Keeper_error_classify
 
 type runtime_execution = {
   runtime_id : string;
+  runtime : Runtime.t;
   max_context_resolution : max_context_resolution;
   max_context : int;
   temperature : float;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1134,11 +1134,10 @@ dominant source of the observed CAS race exhaustion after
                       ~base_dir
                       ~meta
                       ~projection_request:
-                        (Keeper_compaction_projection_target.request
-                           ~assignment_id:final_execution.runtime_id
-                           ~resolve_context_window:(fun _ ->
-                             Keeper_compaction_projection_target.Resolved_context_window
-                               final_execution.max_context_resolution.effective_budget))
+                        (Keeper_compaction_projection_target.exact_request
+                           ~runtime:final_execution.runtime
+                           ~effective_max_context:
+                             final_execution.max_context_resolution.effective_budget)
                       err
                   in
                   let source_lease_disposition, turn_state =

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -65,12 +65,9 @@ let build_runtime_execution
        log_pre_dispatch_error ~site:"ensure_local_discovery_ready" e;
        Error (Agent_sdk.Error.Internal e)
      | Ok () ->
-       (match
-          Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
-            ~requested_override:meta.max_context_override
-            ~runtime_id
-        with
-        | Error error ->
+       (match Runtime.get_runtime_by_id runtime_id with
+        | None ->
+          let error = Runtime_context_window_unavailable { runtime_id } in
           let detail =
             Keeper_context_runtime.max_context_resolution_error_to_string error
           in
@@ -79,20 +76,36 @@ let build_runtime_execution
             (Agent_sdk.Error.Config
                (Agent_sdk.Error.InvalidConfig
                   { field = "runtime.context_window"; detail }))
-        | Ok max_context_resolution ->
-          let max_context =
-            Keeper_turn_runtime_budget.resolved_max_context_for_turn
-              ~meta
-              max_context_resolution
-          in
-          let temperature =
-            Runtime_inference.resolve_temperature
-              ~runtime_id
-              ~fallback:Keeper_config.keeper_unified_temperature
-          in
-          Ok
-            { Keeper_turn_runtime_budget.runtime_id
-            ; max_context_resolution
-            ; max_context
-            ; temperature
-            }))
+        | Some runtime ->
+          (match
+             Keeper_context_runtime.resolve_max_context_resolution_for_runtime
+               ~requested_override:meta.max_context_override
+               runtime
+           with
+           | Error error ->
+             let detail =
+               Keeper_context_runtime.max_context_resolution_error_to_string error
+             in
+             log_pre_dispatch_error ~site:"resolve_context_window" detail;
+             Error
+               (Agent_sdk.Error.Config
+                  (Agent_sdk.Error.InvalidConfig
+                     { field = "runtime.context_window"; detail }))
+           | Ok max_context_resolution ->
+             let max_context =
+               Keeper_turn_runtime_budget.resolved_max_context_for_turn
+                 ~meta
+                 max_context_resolution
+             in
+             let temperature =
+               Runtime_inference.resolve_temperature
+                 ~runtime_id
+                 ~fallback:Keeper_config.keeper_unified_temperature
+             in
+             Ok
+               { Keeper_turn_runtime_budget.runtime_id
+               ; runtime
+               ; max_context_resolution
+               ; max_context
+               ; temperature
+               })))

--- a/lib/keeper_checkpoint_ref/dune
+++ b/lib/keeper_checkpoint_ref/dune
@@ -5,4 +5,4 @@
  (public_name masc.keeper_checkpoint_ref)
  (wrapped false)
  (modules keeper_checkpoint_ref)
- (libraries digestif masc.keeper_registry))
+ (libraries digestif masc.keeper_registry yojson))

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
@@ -46,3 +46,54 @@ let equal left right =
   && Int.equal left.turn_count right.turn_count
   && String.equal left.sha256 right.sha256
 ;;
+
+let to_yojson checkpoint =
+  `Assoc
+    [ "trace_id", `String (Keeper_id.Trace_id.to_string checkpoint.trace_id)
+    ; "generation", `Int checkpoint.generation
+    ; "turn_count", `Int checkpoint.turn_count
+    ; "sha256", `String checkpoint.sha256
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    let expected = [ "generation"; "sha256"; "trace_id"; "turn_count" ] in
+    let actual = List.map fst fields |> List.sort String.compare in
+    if not (List.equal String.equal expected actual)
+    then
+      Error
+        "checkpoint identity must contain exactly trace_id, generation, turn_count, sha256"
+    else (
+      let required_string key =
+        match List.assoc_opt key fields with
+        | Some (`String value) -> Ok value
+        | Some _ -> Error (Printf.sprintf "checkpoint field %s must be a string" key)
+        | None -> Error (Printf.sprintf "checkpoint field %s is missing" key)
+      in
+      let required_int key =
+        match List.assoc_opt key fields with
+        | Some (`Int value) -> Ok value
+        | Some _ -> Error (Printf.sprintf "checkpoint field %s must be an int" key)
+        | None -> Error (Printf.sprintf "checkpoint field %s is missing" key)
+      in
+      let ( let* ) = Result.bind in
+      let* trace_id_raw = required_string "trace_id" in
+      let* trace_id = Keeper_id.Trace_id.of_string trace_id_raw in
+      let* generation = required_int "generation" in
+      let* turn_count = required_int "turn_count" in
+      let* sha256 = required_string "sha256" in
+      of_persisted ~trace_id ~generation ~turn_count ~sha256
+      |> Result.map_error (function
+        | Negative_generation value ->
+          Printf.sprintf "checkpoint generation is negative: %d" value
+        | Negative_turn_count value ->
+          Printf.sprintf "checkpoint turn count is negative: %d" value
+        | Invalid_sha256 value ->
+          Printf.sprintf "checkpoint digest is invalid: %s" value))
+  | json ->
+    Error
+      (Printf.sprintf
+         "checkpoint identity must be an object (received %s)"
+         (Yojson.Safe.to_string json))
+;;

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
@@ -30,3 +30,9 @@ val of_persisted
     Non-canonical or malformed digests are rejected. *)
 
 val equal : t -> t -> bool
+
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Exact persisted representation of a checkpoint identity. Unknown fields,
+    invalid coordinates, invalid trace ids, and non-canonical digests are
+    rejected at this single decoder boundary. *)

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -1553,38 +1553,8 @@ let no_compaction_reason_of_label = function
   | reason -> Error (Printf.sprintf "unknown no-compaction reason: %s" reason)
 ;;
 
-let checkpoint_source_to_yojson (source : Keeper_checkpoint_ref.t) =
-  `Assoc
-    [ "trace_id", `String (Keeper_id.Trace_id.to_string source.trace_id)
-    ; "generation", `Int source.generation
-    ; "turn_count", `Int source.turn_count
-    ; "sha256", `String source.sha256
-    ]
-;;
-
-let checkpoint_source_of_yojson json =
-  let context = "no-compaction checkpoint source" in
-  let* fields = assoc_fields ~context json in
-  let* () =
-    exact_fields
-      ~context
-      ~expected:[ "trace_id"; "generation"; "turn_count"; "sha256" ]
-      fields
-  in
-  let* trace_id_raw = string_field ~context "trace_id" fields in
-  let* trace_id = Keeper_id.Trace_id.of_string trace_id_raw in
-  let* generation = int_field ~context "generation" fields in
-  let* turn_count = int_field ~context "turn_count" fields in
-  let* sha256 = string_field ~context "sha256" fields in
-  Keeper_checkpoint_ref.of_persisted ~trace_id ~generation ~turn_count ~sha256
-  |> Result.map_error (function
-    | Keeper_checkpoint_ref.Negative_generation value ->
-      Printf.sprintf "no-compaction checkpoint generation is negative: %d" value
-    | Negative_turn_count value ->
-      Printf.sprintf "no-compaction checkpoint turn count is negative: %d" value
-    | Invalid_sha256 value ->
-      Printf.sprintf "no-compaction checkpoint digest is invalid: %s" value)
-;;
+let checkpoint_source_to_yojson = Keeper_checkpoint_ref.to_yojson
+let checkpoint_source_of_yojson = Keeper_checkpoint_ref.of_yojson
 
 let settlement_to_yojson = function
   | Ack -> `Assoc [ "kind", `String "ack" ]

--- a/test/keeper_checkpoint_ref/dune
+++ b/test/keeper_checkpoint_ref/dune
@@ -1,3 +1,3 @@
 (test
  (name test_keeper_checkpoint_ref)
- (libraries alcotest masc.keeper_checkpoint_ref masc.keeper_registry))
+ (libraries alcotest masc.keeper_checkpoint_ref masc.keeper_registry yojson))

--- a/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
+++ b/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
@@ -75,6 +75,35 @@ let test_persisted_roundtrip_is_canonical () =
     [ String.uppercase_ascii expected.sha256; String.sub expected.sha256 0 62; " " ^ expected.sha256 ]
 ;;
 
+let test_json_roundtrip_is_exact () =
+  let expected = create {|{"messages":["before"]}|} in
+  let json = Keeper_checkpoint_ref.to_yojson expected in
+  let restored = Keeper_checkpoint_ref.of_yojson json |> result_ok in
+  Alcotest.(check bool)
+    "json identity"
+    true
+    (Keeper_checkpoint_ref.equal expected restored);
+  let reordered =
+    `Assoc
+      [ "sha256", `String expected.sha256
+      ; "turn_count", `Int expected.turn_count
+      ; "trace_id", `String (Keeper_id.Trace_id.to_string expected.trace_id)
+      ; "generation", `Int expected.generation
+      ]
+  in
+  let reordered = Keeper_checkpoint_ref.of_yojson reordered |> result_ok in
+  Alcotest.(check bool)
+    "object field order is not identity"
+    true
+    (Keeper_checkpoint_ref.equal expected reordered);
+  match json with
+  | `Assoc fields ->
+    (match Keeper_checkpoint_ref.of_yojson (`Assoc (("extra", `Bool true) :: fields)) with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "unknown checkpoint identity field was accepted")
+  | _ -> Alcotest.fail "checkpoint identity encoder returned a non-object"
+;;
+
 let () =
   Alcotest.run
     "keeper checkpoint ref"
@@ -85,5 +114,6 @@ let () =
             "persisted canonical roundtrip"
             `Quick
             test_persisted_roundtrip_is_canonical
+        ; Alcotest.test_case "json roundtrip" `Quick test_json_roundtrip_is_exact
         ] )
     ]

--- a/test/stanzas/test_keeper_post_turn_wirein_order.inc
+++ b/test/stanzas/test_keeper_post_turn_wirein_order.inc
@@ -1,4 +1,7 @@
 (test
  (name test_keeper_post_turn_wirein_order)
  (modules test_keeper_post_turn_wirein_order)
- (libraries masc_test_deps masc.keeper_compaction_evidence))
+ (libraries
+  masc_test_deps
+  masc.keeper_compaction_evidence
+  masc.keeper_checkpoint_ref))

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -192,6 +192,88 @@ let test_invalid_plan_is_distinct_from_provider_unavailable () =
       | Compact_policy.Rejected (Manual, Plan_provider_unavailable) -> ()
       | _ -> fail "provider failure was collapsed into an invalid plan")
 
+let rec json_has_key key = function
+  | `Assoc fields ->
+    List.exists
+      (fun (field, value) -> String.equal field key || json_has_key key value)
+      fields
+  | `List values -> List.exists (json_has_key key) values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> false
+;;
+
+let test_projection_target_is_immutable_and_credential_free () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+      let runtime_path =
+        Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+      in
+      (match Runtime.init_default ~config_path:runtime_path with
+       | Ok () -> ()
+       | Error detail -> failf "runtime fixture initialization failed: %s" detail);
+      let runtime =
+        Runtime.get_default_runtime ()
+        |> Option.get
+      in
+      let target =
+        Projection_target.request
+          ~assignment_id:runtime.id
+          ~resolve_context_window:(fun _ ->
+            Projection_target.Resolved_context_window 17)
+        |> Projection_target.capture
+      in
+      let captured =
+        Projection_target.captured_evidence target
+      in
+      (match captured with
+       | Projection_target.Exact exact ->
+         check string "runtime identity" runtime.id exact.runtime_id;
+         check int "effective context snapshot" 17 exact.effective_max_context
+       | Projection_target.Unavailable _ ->
+         fail "single runtime did not produce an exact target");
+      let public_json =
+        Projection_target.evidence_to_json captured
+      in
+      List.iter
+        (fun key -> check bool ("credential field excluded: " ^ key) false (json_has_key key public_json))
+        [ "api_key"; "base_url"; "credentials"; "endpoint"; "headers" ];
+      let unresolved_identity = " missing-runtime " in
+      let unresolved =
+        Projection_target.request
+          ~assignment_id:unresolved_identity
+          ~resolve_context_window:(fun _ ->
+            Projection_target.Resolved_context_window 17)
+        |> Projection_target.capture
+        |> Projection_target.captured_evidence
+      in
+      (match unresolved with
+       | Projection_target.Unavailable
+           (Projection_target.Runtime_unavailable { runtime_id }) ->
+         check string "assignment identity is not normalized" unresolved_identity runtime_id
+       | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+         fail "missing runtime identity was normalized or reclassified");
+      let lane_target =
+        Projection_target.request
+          ~assignment_id:"default"
+          ~resolve_context_window:(fun _ ->
+            Projection_target.Resolved_context_window 17)
+        |> Projection_target.capture
+      in
+      match
+        Projection_target.captured_evidence lane_target
+      with
+      | Projection_target.Unavailable
+          (Projection_target.Assignment_ambiguous { assignment_id = "default" }) ->
+        Runtime.For_testing.restore runtime_snapshot;
+        check bool
+          "captured evidence survives runtime state replacement"
+          true
+          (Projection_target.captured_evidence target = captured)
+      | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+        fail "lane target guessed a provider candidate")
+;;
+
 let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
@@ -744,7 +826,20 @@ let test_malformed_structure_preserves_checkpoint () =
            (Post_turn.compaction_recovery_error_to_string error)
        | Ok prepared ->
          (match Post_turn.commit_prepared_compaction prepared with
-          | Ok _ -> ()
+          | Ok recovery ->
+            let committed_ref =
+              Projection_target.checkpoint_ref recovery.projection_target
+            in
+            let _, durable_ref =
+              Masc.Keeper_checkpoint_store.load_oas_with_ref
+                ~session_dir:session.session_dir
+                ~session_id:checkpoint.session_id
+              |> Result.get_ok
+            in
+            check bool
+              "projection target retains exact committed checkpoint ref"
+              true
+              (Keeper_checkpoint_ref.equal committed_ref durable_ref)
           | Error error ->
             failf
               "commit of a fresh prepared plan failed: %s"
@@ -860,6 +955,8 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "invalid plan is distinct from provider unavailability"
         `Quick test_invalid_plan_is_distinct_from_provider_unavailable;
+      test_case "projection target snapshot excludes credentials"
+        `Quick test_projection_target_is_immutable_and_credential_free;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "malformed structure preserves checkpoint"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -182,7 +182,6 @@ let test_invalid_plan_is_distinct_from_provider_unavailable () =
              Compact_policy.compact_for_request_typed
                ~meta
                ~trigger:Compaction_trigger.Manual
-               ~projection_request:(projection_request_of_meta meta)
                context)
         |> fun preparation -> preparation.Compact_policy.decision
       in

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -235,6 +235,19 @@ let test_projection_target_is_immutable_and_credential_free () =
       let public_json =
         Projection_target.evidence_to_json captured
       in
+      check bool
+        "exact evidence roundtrips"
+        true
+        (Projection_target.evidence_of_json public_json = Ok captured);
+      let extra_field_json =
+        match public_json with
+        | `Assoc fields -> `Assoc (("unexpected", `Null) :: fields)
+        | _ -> fail "projection evidence encoder returned a non-object"
+      in
+      check bool
+        "unknown evidence field is rejected"
+        true
+        (Result.is_error (Projection_target.evidence_of_json extra_field_json));
       List.iter
         (fun key -> check bool ("credential field excluded: " ^ key) false (json_has_key key public_json))
         [ "api_key"; "base_url"; "credentials"; "endpoint"; "headers" ];
@@ -251,8 +264,14 @@ let test_projection_target_is_immutable_and_credential_free () =
        | Projection_target.Unavailable
            (Projection_target.Runtime_unavailable { runtime_id }) ->
          check string "assignment identity is not normalized" unresolved_identity runtime_id
-       | Projection_target.Exact _ | Projection_target.Unavailable _ ->
-         fail "missing runtime identity was normalized or reclassified");
+        | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+          fail "missing runtime identity was normalized or reclassified");
+      check bool
+        "unavailable evidence roundtrips"
+        true
+        (Projection_target.evidence_of_json
+           (Projection_target.evidence_to_json unresolved)
+         = Ok unresolved);
       let lane_target =
         Projection_target.request
           ~assignment_id:"default"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -274,6 +274,113 @@ let test_projection_target_is_immutable_and_credential_free () =
         fail "lane target guessed a provider candidate")
 ;;
 
+let with_input_count_response input_tokens f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:1
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+  in
+  let port =
+    match Eio.Net.listening_addr socket with
+    | `Tcp (_, port) -> port
+    | _ -> fail "input-count fixture did not bind a TCP socket"
+  in
+  let callback _conn _request _body =
+    Cohttp_eio.Server.respond_string
+      ~status:`OK
+      ~body:(Printf.sprintf {|{"input_tokens":%d}|} input_tokens)
+      ()
+  in
+  let server = Cohttp_eio.Server.make ~callback () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:raise);
+  f ~sw ~net ~base_url:(Printf.sprintf "http://127.0.0.1:%d" port)
+;;
+
+let test_checkpoint_projection_uses_provider_native_fit () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+  let runtime_path =
+    Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+  in
+  (match Runtime.init_default ~config_path:runtime_path with
+   | Ok () -> ()
+   | Error detail -> failf "runtime fixture initialization failed: %s" detail);
+  let checkpoint =
+    { (make_checkpoint ()) with
+      system_prompt = Some "Measure this exact compacted checkpoint."
+    }
+  in
+  let trace_id =
+    Keeper_id.Trace_id.of_string checkpoint.session_id |> Result.get_ok
+  in
+  let checkpoint_ref =
+    Keeper_checkpoint_ref.create
+      ~trace_id
+      ~generation:3
+      ~turn_count:checkpoint.turn_count
+      ~canonical_checkpoint_bytes:(Agent_sdk.Checkpoint.to_string checkpoint)
+    |> Result.get_ok
+  in
+  let observe input_tokens =
+    with_input_count_response input_tokens (fun ~sw ~net ~base_url ->
+      let runtime = Runtime.get_default_runtime () |> Option.get in
+      let provider_config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_config.Anthropic
+          ~model_id:"compaction-fit-fixture"
+          ~base_url
+          ~api_key:"test-key"
+          ~request_path:"/v1/messages"
+          ~max_tokens:64
+          ()
+      in
+      let runtime = { runtime with Runtime.provider_config = provider_config } in
+      Projection_target.exact_request
+        ~runtime
+        ~effective_max_context:512
+      |> Projection_target.capture
+      |> Projection_target.bind_committed_checkpoint ~checkpoint checkpoint_ref
+      |> Projection_target.measure_checkpoint_fit ~sw ~net)
+  in
+  let fitting = observe 321 in
+  check bool
+    "fit is correlated to committed checkpoint"
+    true
+    (Keeper_checkpoint_ref.equal fitting.checkpoint_ref checkpoint_ref);
+  check bool
+    "fit evidence excludes API keys"
+    false
+    (json_has_key "api_key" (Projection_target.fit_evidence_to_json fitting));
+  (match fitting.result with
+   | Projection_target.Fit.Fits fit ->
+     check int "provider input count" 321 fit.input_tokens;
+     check int "reserved output" 64 fit.reserved_output_tokens;
+     check int "captured context" 512 fit.max_context_tokens
+   | Projection_target.Fit.Exceeds _
+   | Projection_target.Fit.Unavailable _ ->
+     fail "provider-native measurement should fit");
+  let exceeding = observe 500 in
+  match exceeding.result with
+  | Projection_target.Fit.Exceeds fit ->
+    check int "overflow input count" 500 fit.input_tokens;
+    check int "overflow output reservation" 64 fit.reserved_output_tokens;
+    check int "overflow context" 512 fit.max_context_tokens
+  | Projection_target.Fit.Fits _
+  | Projection_target.Fit.Unavailable _ ->
+    fail "provider-native measurement should exceed the captured context")
+;;
+
 let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
@@ -957,6 +1064,8 @@ let () =
         `Quick test_invalid_plan_is_distinct_from_provider_unavailable;
       test_case "projection target snapshot excludes credentials"
         `Quick test_projection_target_is_immutable_and_credential_free;
+      test_case "checkpoint projection uses provider-native fit"
+        `Quick test_checkpoint_projection_uses_provider_native_fit;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "malformed structure preserves checkpoint"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -400,6 +400,166 @@ let test_checkpoint_projection_uses_provider_native_fit () =
     fail "provider-native measurement should exceed the captured context")
 ;;
 
+let string_contains ~needle haystack =
+  let needle_length = String.length needle in
+  let rec scan index =
+    index + needle_length <= String.length haystack
+    && (String.equal (String.sub haystack index needle_length) needle
+        || scan (index + 1))
+  in
+  scan 0
+;;
+
+let rec json_contains_text needle = function
+  | `String value -> string_contains ~needle value
+  | `Assoc fields ->
+    List.exists (fun (_, value) -> json_contains_text needle value) fields
+  | `List values -> List.exists (json_contains_text needle) values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ -> false
+;;
+
+(* Reserve an ephemeral loopback port and release it before the measurement,
+   so the provider count request fails with a refused connection. *)
+let with_closed_loopback_port f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let port =
+    Eio.Switch.run
+    @@ fun probe_sw ->
+    let socket =
+      Eio.Net.listen
+        net
+        ~sw:probe_sw
+        ~backlog:1
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+    in
+    match Eio.Net.listening_addr socket with
+    | `Tcp (_, port) -> port
+    | _ -> fail "transport fixture did not bind a TCP socket"
+  in
+  f ~sw ~net ~base_url:(Printf.sprintf "http://127.0.0.1:%d" port)
+;;
+
+let test_checkpoint_fit_transport_failure_is_classified () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+  let runtime_path =
+    Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+  in
+  (match Runtime.init_default ~config_path:runtime_path with
+   | Ok () -> ()
+   | Error detail -> failf "runtime fixture initialization failed: %s" detail);
+  let checkpoint =
+    { (make_checkpoint ()) with
+      system_prompt = Some "Measure this exact compacted checkpoint."
+    }
+  in
+  let trace_id =
+    Keeper_id.Trace_id.of_string checkpoint.session_id |> Result.get_ok
+  in
+  let checkpoint_ref =
+    Keeper_checkpoint_ref.create
+      ~trace_id
+      ~generation:3
+      ~turn_count:checkpoint.turn_count
+      ~canonical_checkpoint_bytes:(Agent_sdk.Checkpoint.to_string checkpoint)
+    |> Result.get_ok
+  in
+  let evidence =
+    with_closed_loopback_port (fun ~sw ~net ~base_url ->
+      let runtime = Runtime.get_default_runtime () |> Option.get in
+      let provider_config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_config.Anthropic
+          ~model_id:"compaction-fit-fixture"
+          ~base_url
+          ~api_key:"test-key"
+          ~request_path:"/v1/messages"
+          ~max_tokens:64
+          ()
+      in
+      let runtime = { runtime with Runtime.provider_config = provider_config } in
+      Projection_target.exact_request
+        ~runtime
+        ~effective_max_context:512
+      |> Projection_target.capture
+      |> Projection_target.bind_committed_checkpoint ~checkpoint checkpoint_ref
+      |> Projection_target.measure_checkpoint_fit ~sw ~net)
+  in
+  (match evidence.result with
+   | Projection_target.Fit.Unavailable
+       (Projection_target.Fit.Input_count_failed
+          (Llm_provider.Input_token_count.Transport _)) -> ()
+   | Projection_target.Fit.Fits _
+   | Projection_target.Fit.Exceeds _
+   | Projection_target.Fit.Unavailable _ ->
+     fail "refused connection must surface as a transport input-count failure");
+  let json = Projection_target.fit_evidence_to_json evidence in
+  check bool
+    "transport evidence excludes API keys"
+    false
+    (json_has_key "api_key" json);
+  check bool
+    "transport failure is classified, not raw"
+    true
+    (json_contains_text "transport" json && json_has_key "code" json);
+  check bool
+    "transport evidence leaks no endpoint address"
+    false
+    (json_contains_text "127.0.0.1" json))
+;;
+
+let test_checkpoint_fit_of_unavailable_target_short_circuits () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let checkpoint = make_checkpoint () in
+  let trace_id =
+    Keeper_id.Trace_id.of_string checkpoint.session_id |> Result.get_ok
+  in
+  let checkpoint_ref =
+    Keeper_checkpoint_ref.create
+      ~trace_id
+      ~generation:3
+      ~turn_count:checkpoint.turn_count
+      ~canonical_checkpoint_bytes:(Agent_sdk.Checkpoint.to_string checkpoint)
+    |> Result.get_ok
+  in
+  let evidence =
+    Projection_target.request
+      ~assignment_id:""
+      ~resolve_context_window:(fun _ ->
+        Projection_target.Resolved_context_window 17)
+    |> Projection_target.capture
+    |> Projection_target.bind_committed_checkpoint ~checkpoint checkpoint_ref
+    |> Projection_target.measure_checkpoint_fit ~sw ~net
+  in
+  (match evidence.target with
+   | Projection_target.Unavailable Projection_target.Empty_assignment -> ()
+   | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+     fail "empty assignment target was reclassified");
+  (match evidence.result with
+   | Projection_target.Fit.Unavailable
+       (Projection_target.Fit.Projection_target_unavailable
+          Projection_target.Empty_assignment) -> ()
+   | Projection_target.Fit.Fits _
+   | Projection_target.Fit.Exceeds _
+   | Projection_target.Fit.Unavailable _ ->
+     fail "unavailable target must short-circuit provider measurement");
+  check bool
+    "unavailable fit evidence excludes API keys"
+    false
+    (json_has_key "api_key" (Projection_target.fit_evidence_to_json evidence))
+;;
+
 let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
@@ -1085,6 +1245,10 @@ let () =
         `Quick test_projection_target_is_immutable_and_credential_free;
       test_case "checkpoint projection uses provider-native fit"
         `Quick test_checkpoint_projection_uses_provider_native_fit;
+      test_case "transport failure persists a classified fit code"
+        `Quick test_checkpoint_fit_transport_failure_is_classified;
+      test_case "unavailable target short-circuits provider measurement"
+        `Quick test_checkpoint_fit_of_unavailable_target_short_circuits;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "malformed structure preserves checkpoint"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -182,6 +182,7 @@ let test_invalid_plan_is_distinct_from_provider_unavailable () =
              Compact_policy.compact_for_request_typed
                ~meta
                ~trigger:Compaction_trigger.Manual
+               ~projection_request:(projection_request_of_meta meta)
                context)
         |> fun preparation -> preparation.Compact_policy.decision
       in

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -856,7 +856,9 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
     let setup_failures = ref [] in
     let yielded = ref 0 in
     let retry_execution runtime_id : Masc.Keeper_turn_runtime_budget.runtime_execution =
+      let runtime = Runtime.get_runtime_by_id runtime_id |> Option.get in
       { runtime_id
+      ; runtime
       ; max_context_resolution = retry_context_resolution
       ; max_context = retry_context_resolution.requested_context_window
       ; temperature = 0.0


### PR DESCRIPTION
## 목적

Committed compaction checkpoint를 현재 Provider/Model의 native token-count
protocol로 측정하고, 같은 opaque OAS request를 explicit max-context에 admit하여
`Fits | Exceeds | Unavailable` 증거를 생성합니다.

## 변경

- captured provider config + exact saved checkpoint system/messages/tools/turn controls로 canonical `Complete.prepared_request`를 한 번 생성합니다.
- 동일 opaque request에 `Complete.measure_request` 후 `Complete.admit_request`를 적용합니다.
- checkpoint ref, credential-free target, typed result를 private immutable evidence로 결속합니다.
- provider-native input count, reserved output, captured max context를 그대로 보존합니다.
- unsupported/transport/invalid response/context-limit/output-reservation 실패를 typed unavailable로 유지합니다.
- JSON evidence는 API key/endpoint/header를 포함하지 않습니다.
- estimate, truncation, retry, timeout, provider re-resolution, completion dispatch는 없습니다.

## Stack / 아직 아닌 것

- base: #25347
- next: strict projection-evidence decoder, then durable scheduled/terminal observer
- 이 PR은 실제 measurement operation과 test를 구현하지만 production Keeper lane에서 아직 호출하지 않습니다. Inline call이나 fire-and-forget fiber로 가짜 완성을 만들지 않습니다.

## 검증

- 392 changed lines
- loopback Anthropic count endpoint로 Fits와 Exceeds를 모두 검증
- checkpoint SHA correlation과 credential-free JSON 검증
- OCaml parse, `ocamlformat --check`, `git diff --check`
- focused build에서 잘못된 공개 checkpoint-ref 경로와 하위 API 호출 누락을 먼저 발견해 각 원인 leaf에서 수정했습니다.
- 수정된 누적 head의 focused build는 공용 wrapper lock 뒤에서 재검증 중이며, Draft CI를 exact-head build authority로 사용합니다.
