### PR TITLE
feat(compaction): decode projection evidence strictly

### DIFF
--- a/lib/keeper/keeper_compaction_projection_target.ml
+++ b/lib/keeper/keeper_compaction_projection_target.ml
@@ -90,8 +90,135 @@ let evidence_to_json = function
   | Unavailable reason ->
     `Assoc
       [ "kind", `String "unavailable"
-      ; "detail", unavailable_to_json reason
-      ]
+       ; "detail", unavailable_to_json reason
+       ]
+;;
+
+let object_fields label = function
+  | `Assoc fields -> Ok fields
+  | json ->
+    Error
+      (Printf.sprintf
+         "%s must be an object (received %s)"
+         label
+         (Yojson.Safe.to_string json))
+;;
+
+let exact_fields label expected fields =
+  let actual = List.map fst fields |> List.sort String.compare in
+  let expected = List.sort String.compare expected in
+  if List.equal String.equal expected actual
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf "%s contains an invalid or duplicate field set" label)
+;;
+
+let required_string label key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" label key)
+  | None -> Error (Printf.sprintf "%s.%s is missing" label key)
+;;
+
+let required_int label key fields =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be an int" label key)
+  | None -> Error (Printf.sprintf "%s.%s is missing" label key)
+;;
+
+let required_json label key fields =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s.%s is missing" label key)
+;;
+
+let unavailable_of_json json =
+  let ( let* ) = Result.bind in
+  let label = "compaction projection target detail" in
+  let* fields = object_fields label json in
+  let* reason = required_string label "reason" fields in
+  match reason with
+  | "empty_assignment" ->
+    let* () = exact_fields label [ "reason" ] fields in
+    Ok Empty_assignment
+  | "assignment_ambiguous" ->
+    let* () = exact_fields label [ "assignment_id"; "reason" ] fields in
+    let* assignment_id = required_string label "assignment_id" fields in
+    Ok (Assignment_ambiguous { assignment_id })
+  | "runtime_unavailable" ->
+    let* () = exact_fields label [ "reason"; "runtime_id" ] fields in
+    let* runtime_id = required_string label "runtime_id" fields in
+    Ok (Runtime_unavailable { runtime_id })
+  | "context_window_unavailable" ->
+    let* () = exact_fields label [ "reason"; "runtime_id" ] fields in
+    let* runtime_id = required_string label "runtime_id" fields in
+    Ok (Context_window_unavailable { runtime_id })
+  | "invalid_effective_context_window" ->
+    let* () =
+      exact_fields
+        label
+        [ "effective_max_context"; "reason"; "runtime_id" ]
+        fields
+    in
+    let* runtime_id = required_string label "runtime_id" fields in
+    let* effective_max_context =
+      required_int label "effective_max_context" fields
+    in
+    if effective_max_context <= 0
+    then Ok (Invalid_effective_context_window { runtime_id; effective_max_context })
+    else Error "invalid effective context evidence must be non-positive"
+  | unknown ->
+    Error (Printf.sprintf "unknown compaction projection target reason: %s" unknown)
+;;
+
+let evidence_of_json json =
+  let ( let* ) = Result.bind in
+  let label = "compaction projection target" in
+  let* fields = object_fields label json in
+  let* kind = required_string label "kind" fields in
+  match kind with
+  | "exact" ->
+    let* () =
+      exact_fields
+        label
+        [ "effective_max_context"
+        ; "kind"
+        ; "model_id"
+        ; "oas_provider_kind"
+        ; "protocol"
+        ; "provider_id"
+        ; "runtime_id"
+        ]
+        fields
+    in
+    let* runtime_id = required_string label "runtime_id" fields in
+    let* provider_id = required_string label "provider_id" fields in
+    let* protocol = required_string label "protocol" fields in
+    let* oas_provider_kind = required_string label "oas_provider_kind" fields in
+    let* model_id = required_string label "model_id" fields in
+    let* effective_max_context =
+      required_int label "effective_max_context" fields
+    in
+    if effective_max_context <= 0
+    then Error "exact effective context evidence must be positive"
+    else
+      Ok
+        (Exact
+           { runtime_id
+           ; provider_id
+           ; protocol
+           ; oas_provider_kind
+           ; model_id
+           ; effective_max_context
+           })
+  | "unavailable" ->
+    let* () = exact_fields label [ "detail"; "kind" ] fields in
+    let* detail = required_json label "detail" fields in
+    let* reason = unavailable_of_json detail in
+    Ok (Unavailable reason)
+  | unknown -> Error (Printf.sprintf "unknown compaction projection kind: %s" unknown)
 ;;
 
 type exact_target =

--- a/lib/keeper/keeper_compaction_projection_target.mli
+++ b/lib/keeper/keeper_compaction_projection_target.mli
@@ -50,6 +50,7 @@ type evidence =
   | Unavailable of unavailable
 
 val evidence_to_json : evidence -> Yojson.Safe.t
+val evidence_of_json : Yojson.Safe.t -> (evidence, string) result
 
 type t
 

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -235,6 +235,19 @@ let test_projection_target_is_immutable_and_credential_free () =
       let public_json =
         Projection_target.evidence_to_json captured
       in
+      check bool
+        "exact evidence roundtrips"
+        true
+        (Projection_target.evidence_of_json public_json = Ok captured);
+      let extra_field_json =
+        match public_json with
+        | `Assoc fields -> `Assoc (("unexpected", `Null) :: fields)
+        | _ -> fail "projection evidence encoder returned a non-object"
+      in
+      check bool
+        "unknown evidence field is rejected"
+        true
+        (Result.is_error (Projection_target.evidence_of_json extra_field_json));
       List.iter
         (fun key -> check bool ("credential field excluded: " ^ key) false (json_has_key key public_json))
         [ "api_key"; "base_url"; "credentials"; "endpoint"; "headers" ];
@@ -251,8 +264,14 @@ let test_projection_target_is_immutable_and_credential_free () =
        | Projection_target.Unavailable
            (Projection_target.Runtime_unavailable { runtime_id }) ->
          check string "assignment identity is not normalized" unresolved_identity runtime_id
-       | Projection_target.Exact _ | Projection_target.Unavailable _ ->
-         fail "missing runtime identity was normalized or reclassified");
+        | Projection_target.Exact _ | Projection_target.Unavailable _ ->
+          fail "missing runtime identity was normalized or reclassified");
+      check bool
+        "unavailable evidence roundtrips"
+        true
+        (Projection_target.evidence_of_json
+           (Projection_target.evidence_to_json unresolved)
+         = Ok unresolved);
       let lane_target =
         Projection_target.request
           ~assignment_id:"default"


### PR DESCRIPTION
## 목적

Runtime manifest restart fold가 compaction projection target JSON을 opaque payload로
신뢰하지 않고, exact typed evidence로 fail-closed 복원할 수 있게 합니다.

## 변경

- exact/unavailable target evidence의 strict inverse decoder 추가
- missing/duplicate/unknown fields 거부
- exact context는 positive, invalid-context evidence는 non-positive invariant 검증
- wire enum은 exact canonical labels만 허용하며 substring/heuristic matching은 없음
- exact와 unavailable roundtrip 및 unknown-field rejection 테스트

## Stack

- base: provider-native compaction fit boundary
- next: durable scheduled/terminal observation and restart reconciliation

## 검증

- 155 changed lines
- OCaml parse, `ocamlformat --check`, `git diff --check`
- focused build에서 잘못된 공개 checkpoint-ref 경로와 하위 API 호출 누락을 먼저 발견해 각 원인 leaf에서 수정했습니다.
- 수정된 누적 head의 focused build는 공용 wrapper lock 뒤에서 재검증 중이며, Draft CI를 exact-head build authority로 사용합니다.
