### PR TITLE
fix(keeper): retain pause outside Resume_owner

### DIFF
--- a/lib/keeper/keeper_directive.ml
+++ b/lib/keeper/keeper_directive.ml
@@ -1,5 +1,4 @@
 type t =
   | Pause
-  | Resume
   | Wakeup
   | Assign_task of Keeper_id.Task_id.t

--- a/lib/keeper/keeper_directive.mli
+++ b/lib/keeper/keeper_directive.mli
@@ -5,6 +5,5 @@
 
 type t =
   | Pause
-  | Resume
   | Wakeup
   | Assign_task of Keeper_id.Task_id.t

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -362,13 +362,6 @@ let process_directive ~agent_name directive =
       ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "pause" ])
       (Printf.sprintf "directive: pausing keeper %s" agent_name);
     set_keeper_paused_state ~agent_name true
-  | Keeper_directive.Resume ->
-    Log.Keeper.emit
-      Log.Info
-      ~category:Log.Directive
-      ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "resume" ])
-      (Printf.sprintf "directive: resuming keeper %s" agent_name);
-    set_keeper_paused_state ~agent_name false
   | Keeper_directive.Wakeup ->
     (* Wakeup is only a scheduling signal. It must never clear an operator
        pause: paused-work disposition belongs to the receipt-first

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -46,7 +46,7 @@ let revival_decision ~(latched_reason : Keeper_latched_reason.t option)
   in
   {
     dead_revival_requested;
-    clear_pause_state = paused || dead_revival_requested;
+    clear_pause_state = dead_revival_requested;
   }
 
 let update_keeper ?(preserve_prompt_defaults = false)
@@ -106,7 +106,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
       | None -> "none", ""
     in
     Log.Keeper.warn
-      "update_keeper resumed paused keeper %s; clearing \
+      "update_keeper reviving dead keeper %s; clearing \
        last_blocker.klass=%s last_blocker.detail=%S"
       old.name blocker_class blocker_detail);
   let source_meta = old in
@@ -128,11 +128,9 @@ let update_keeper ?(preserve_prompt_defaults = false)
     autoboot_enabled;
     active_goal_ids;
     paused = if clear_pause_state then false else old.paused;
-    (* Operator-sanctioned resume clears the terminal latch (Dead_tombstone
-       included) so a sanctioned keeper_up revives a latched keeper.  Without
-       this [latched_reason] survives a paused-clearing resume and every
-       latch-keyed lifecycle admission keeps denying revival forever even after
-       [paused] is cleared. *)
+    (* The dedicated Dead-tombstone revival clears the terminal latch together
+       with [paused]. Ordinary keeper_up reconfiguration preserves both fields;
+       it cannot impersonate the receipt-first Resume_owner transaction. *)
     latched_reason =
       if clear_pause_state then None else source_meta.latched_reason;
     runtime =
@@ -238,9 +236,9 @@ let update_keeper ?(preserve_prompt_defaults = false)
                builds [updated] from a meta snapshot ([old]), so a concurrent
                keeper turn that bumped cumulative usage counters between the
                read and this write would otherwise be silently rewound
-               (total_turns 385->370, 2026-06-10). This is an explicit operator
-               lifecycle action, so it owns pause/resume fields while taking
-               cumulative counters as [max latest caller]. *)
+               (total_turns 385->370, 2026-06-10). This operator lifecycle edit
+               preserves the observed pause disposition while taking cumulative
+               counters as [max latest caller]. *)
             (match
                Keeper_shutdown_supersession.preflight
                  ~config:ctx.config

--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -21,8 +21,9 @@ type revival_decision = {
           {!Keeper_dead_revival_transaction.revive} instead of the normal
           CAS-merge write path. *)
   clear_pause_state : bool;
-      (** Clear [paused], [latched_reason], and [runtime.last_blocker] on
-          the updated meta before it is persisted. *)
+      (** Clear [paused], [latched_reason], and [runtime.last_blocker] only for
+          the dedicated Dead-tombstone revival transaction. Ordinary paused
+          owners remain paused. *)
 }
 
 (** Decide the dead-revival / pause-clearing outcome for an existing
@@ -49,9 +50,11 @@ type revival_decision = {
     the revival transaction; the stranded [paused = false] + [Dead_tombstone]
     split now does too.
 
-    [clear_pause_state] is [paused || dead_revival_requested]: an ordinary
-    [masc_keeper_up] call on a keeper that is merely paused resumes it, and
-    a dead-revival always clears pause/latch state as well. *)
+    [clear_pause_state] is exactly [dead_revival_requested]. An ordinary
+    [masc_keeper_up] call may reconfigure a paused Keeper but cannot resume it;
+    resume belongs to the receipt-first [Resume_owner] transaction. A
+    Dead-tombstone revival still clears pause/latch state in its separate
+    transaction. *)
 val revival_decision :
   latched_reason:Keeper_latched_reason.t option ->
   paused:bool ->

--- a/lib/keeper_failure_taxonomy/keeper_paused_state_persist_phase.ml
+++ b/lib/keeper_failure_taxonomy/keeper_paused_state_persist_phase.ml
@@ -1,10 +1,8 @@
 type t =
-  | Boot_resume_persist
-  | Boot_resume_check
+  | Lifecycle_pause_persist
   | Directive
 
 let to_label = function
-  | Boot_resume_persist -> "boot_resume_persist"
-  | Boot_resume_check -> "boot_resume_check"
+  | Lifecycle_pause_persist -> "lifecycle_pause_persist"
   | Directive -> "directive"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_paused_state_persist_phase.mli
+++ b/lib/keeper_failure_taxonomy/keeper_paused_state_persist_phase.mli
@@ -1,21 +1,15 @@
 (** Keeper_paused_state_persist_phase — closed sum for the [phase] label on
     [metric_keeper_paused_state_persist_errors].
 
-    Replaces 3 hardcoded string literals scattered across 6 emit sites
-    in [server_dashboard_http_keeper_api.ml]
-    (`"boot_resume_persist"` / `"boot_resume_check"` / `"directive"`).
+    Replaces hardcoded string literals in the dashboard Keeper API.
     Each phase corresponds to a distinct write path; closing the set
     forces every emit site through the compiler. *)
 
 type t =
-  | Boot_resume_persist
-  (** Persist-time failure during boot-time resume of a previously
-          paused keeper (writing the resumed state record). *)
-  | Boot_resume_check
-  (** Read-back failure during boot-time resume (verifying the
-          persisted state). *)
+  | Lifecycle_pause_persist
+  (** Persist-time failure while shutdown/clear retains a paused Keeper. *)
   | Directive
-  (** Failure persisting an operator-issued pause/resume directive
+  (** Failure persisting an operator-issued pause directive
           (e.g. POST /dashboard/api/keepers/:name/pause). *)
 
 val to_label : t -> string

--- a/lib/server/masc_grpc_types.ml
+++ b/lib/server/masc_grpc_types.ml
@@ -152,7 +152,6 @@ module HeartbeatAck = struct
   let directive_of_wire raw =
     match raw with
     | "pause" -> Ok Keeper_directive.Pause
-    | "resume" -> Ok Keeper_directive.Resume
     | "wakeup" -> Ok Keeper_directive.Wakeup
     | _ ->
       (match String.index_opt raw ':' with
@@ -177,7 +176,6 @@ module HeartbeatAck = struct
 
   let directive_to_wire = function
     | Keeper_directive.Pause -> "pause"
-    | Keeper_directive.Resume -> "resume"
     | Keeper_directive.Wakeup -> "wakeup"
     | Keeper_directive.Assign_task task_id ->
       "claim:" ^ Keeper_id.Task_id.to_string task_id

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -192,8 +192,9 @@ val handle_keeper_lifecycle_post :
   action:String.t ->
   Mcp_server.server_state ->
   string -> Httpun.Request.t -> Httpun.Reqd.t -> unit
-(** Generic handler for boot / shutdown / reset / clear posts; the
-    [action] parameter selects the keeper FSM event. *)
+(** Generic handler for boot / shutdown / reset / clear posts. Boot does not
+    resume an ordinary paused owner; callers must commit [Resume_owner] through
+    the directive endpoint. Dead-tombstone revival remains separate. *)
 
 val handle_keeper_directive_post :
   sw:Eio.Switch.t ->

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -97,6 +97,11 @@ type lifecycle_outcome =
   | Dispatch_none
   | Persist_failed
 
+type boot_preflight =
+  | Boot_allowed
+  | Boot_operator_paused
+  | Boot_meta_read_failed of string
+
 let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     state agent_name req reqd =
   let req_path = Http.Request.path req in
@@ -119,33 +124,15 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
   else
     let workspace_scope = Mcp_server.workspace_scope state in
     let config = workspace_scope.config in
-    let resolve_keeper_agent_name () =
-      match Keeper_registry_lookup.find_by_name name with
-      | Some entry -> Some entry.meta.agent_name
-      | None -> (
-          match Keeper_meta_store.read_meta config name with
-          | Ok (Some meta) -> Some meta.agent_name
-          | Ok None -> None
-          | Error err ->
-              Log.Keeper.warn
-                "resolve_keeper_agent_name %s: read_meta failed: %s"
-                name err;
-              None)
-    in
-    let persist_keeper_paused_state paused =
+    let persist_keeper_pause () =
       match Keeper_meta_store.read_meta config name with
-      | Ok (Some meta) when Bool.equal meta.paused paused -> true
+      | Ok (Some meta) when meta.paused -> true
       | Ok (Some meta) ->
            let updated_meta =
-             (* Resume ([paused = false]) routes through [mark_resumed] so the
-                boot-resume writer clears the typed latch together with the
-                pause bit — it must never persist paused=false + Dead_tombstone
-                (rejected by the meta store). Pause keeps the latch paired. *)
-             let base =
-               if paused then { meta with paused = true }
-               else Keeper_meta_contract.mark_resumed meta
-             in
-             { base with updated_at = Keeper_meta_contract.now_iso () }
+             { meta with
+               paused = true
+             ; updated_at = Keeper_meta_contract.now_iso ()
+             }
            in
            (match
               Keeper_meta_store.write_meta_with_merge
@@ -154,76 +141,34 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
             | Ok () -> true
             | Error err ->
               Log.Keeper.warn
-                "keeper %s %s: write_meta failed: %s"
+                "keeper %s pause: write_meta failed: %s"
                 name
-                (if paused then "pause" else "resume")
                 err;
               false)
       (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from
-         [Error _] (IO/parse failure) so silent failures become visible.
-         The boot HTTP contract is unchanged — explicit resume persistence is
-         a best-effort side effect of [boot], not the primary action. *)
+         [Error _] (IO/parse failure) so lifecycle pause persistence after
+         clear/shutdown cannot silently disappear. *)
       | Ok None ->
           Log.Keeper.warn
-            "keeper %s %s: meta missing — skipping paused-state persist"
-            name
-            (if paused then "pause" else "resume");
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string PausedStatePersistErrors)
-            ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Boot_resume_persist));
-                     ("reason", "meta_missing")]
-            ();
-          false
-      | Error err ->
-          Log.Keeper.error
-            "keeper %s %s: read_meta failed: %s"
-            name
-            (if paused then "pause" else "resume")
-            err;
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string PausedStatePersistErrors)
-            ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Boot_resume_persist));
-                     ("reason", "read_meta_error")]
-            ();
-          false
-    in
-    let resume_booted_keeper_if_needed () =
-      match Keeper_meta_store.read_meta config name with
-      | Ok (Some meta) when meta.paused ->
-          if persist_keeper_paused_state false
-          then (
-            match resolve_keeper_agent_name () with
-            | Some keeper_agent_name ->
-              Keeper_keepalive.process_directive
-                ~agent_name:keeper_agent_name
-                Keeper_directive.Resume
-            | None ->
-              Log.Keeper.warn
-                "keeper boot: agent_name not found for paused keeper %s"
-                name)
-      | Ok (Some _) -> ()
-      (* Issue #8391 HIGH #1: split [Ok None] from [Error _] — boot itself
-         already succeeded via Keeper_tool_surface.dispatch, so we don't change the
-         HTTP status. We make the failure observable instead. *)
-      | Ok None ->
-          Log.Keeper.warn
-            "keeper %s boot: meta missing — skipping resume check"
+            "keeper %s pause: meta missing — skipping paused-state persist"
             name;
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string PausedStatePersistErrors)
-            ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Boot_resume_check));
+            ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Lifecycle_pause_persist));
                      ("reason", "meta_missing")]
-            ()
+            ();
+          false
       | Error err ->
           Log.Keeper.error
-            "keeper %s boot: read_meta failed during resume check: %s"
+            "keeper %s pause: read_meta failed: %s"
             name
             err;
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string PausedStatePersistErrors)
-            ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Boot_resume_check));
+            ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Lifecycle_pause_persist));
                      ("reason", "read_meta_error")]
-            ()
+            ();
+          false
     in
     let keeper_ctx : _ Keeper_tool_surface.context =
       {
@@ -286,6 +231,41 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
         in
         Log.Server.info "keeper lifecycle %s name=%s actor=%s started"
           action name agent_name;
+        let boot_preflight =
+          if not (String.equal action "boot")
+          then Boot_allowed
+          else
+            match Keeper_meta_store.read_meta config name with
+            | Error error -> Boot_meta_read_failed error
+            | Ok None -> Boot_allowed
+            | Ok (Some meta) ->
+              (match
+                 Keeper_lifecycle_admission.state
+                   ~paused:meta.paused
+                   ~latched_reason:meta.latched_reason
+               with
+               | Keeper_lifecycle_admission.Paused _ -> Boot_operator_paused
+               | Keeper_lifecycle_admission.Active
+               | Keeper_lifecycle_admission.Dead_tombstone -> Boot_allowed)
+        in
+        (match boot_preflight with
+         | Boot_meta_read_failed error ->
+           log_lifecycle_result Persist_failed;
+           respond_error
+             ~status:`Internal_server_error
+             ~request:req
+             ~ok:false
+             reqd
+             (Printf.sprintf "keeper boot preflight read failed: %s" error)
+         | Boot_operator_paused ->
+           log_lifecycle_result Rejected;
+           respond_error
+             ~status:`Conflict
+             ~request:req
+             ~ok:false
+             reqd
+             "keeper is operator-paused; commit Resume_owner through the directive endpoint"
+         | Boot_allowed ->
         let live_boot_entry =
           match Keeper_registry.get ~base_path:config.base_path name with
           | Some entry
@@ -298,14 +278,21 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
           | Some _ | None -> None
         in
         (match live_boot_entry with
+         | Some entry when entry.phase = Keeper_state_machine.Paused ->
+           log_lifecycle_result Rejected;
+           respond_error
+             ~status:`Conflict
+             ~request:req
+             ~ok:false
+             reqd
+             "keeper registry lane is paused; commit Resume_owner through the directive endpoint"
          | Some entry ->
            (* Dashboard boot is an idempotent lifecycle action.  If a keeper
               is already live, do not send it through masc_keeper_up's update
               path: that path intentionally stop/starts changed keepers, and
               doing so during an active turn creates duplicate fibers and
-              contradictory stopped/executing surfaces.  Resume and wake the
-              existing fiber instead. *)
-           resume_booted_keeper_if_needed ();
+              contradictory stopped/executing surfaces. Wake an already
+              running fiber without changing its pause disposition. *)
            Keeper_keepalive.process_directive
              ~agent_name:entry.meta.agent_name
              Keeper_directive.Wakeup;
@@ -335,13 +322,12 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               let post_action_result =
                 if String.equal action "boot"
                 then (
-                  resume_booted_keeper_if_needed ();
                   refresh_keeper_execution_surfaces ~config ~name "started";
                   Ok ())
                 else (
                   match Keeper_registry.get_phase ~base_path:config.base_path name with
                   | Some Keeper_state_machine.Paused
-                    when not (persist_keeper_paused_state true) ->
+                    when not (persist_keeper_pause ()) ->
                     Error "paused-state persist failed after clear"
                   | Some Keeper_state_machine.Paused | Some _ | None ->
                     invalidate_keeper_execution_surfaces ~config ();
@@ -371,7 +357,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               let post_action_result =
                 match action with
                 | "shutdown" ->
-                  if persist_keeper_paused_state true
+                  if persist_keeper_pause ()
                   then (
                     refresh_keeper_execution_surfaces ~config ~name "stopped";
                     Ok ())
@@ -408,10 +394,4 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
             | None ->
               log_lifecycle_result Dispatch_none;
               respond_error ~status:`Internal_server_error ~request:req ~ok:false
-                reqd "dispatch returned None"))
-
-(** POST /api/v1/keepers/:name/directive — pause / resume / wakeup.
-
-    Delegates to [Keeper_keepalive.process_directive] which updates
-    registry state, dispatches a state-machine event, and optionally
-    wakes up the keeper fiber. *)
+                reqd "dispatch returned None")))

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
@@ -8,8 +8,10 @@ val handle_keeper_lifecycle_post :
   action:String.t ->
   Mcp_server.server_state ->
   string -> Httpun.Request.t -> Httpun.Reqd.t -> unit
-(** Generic handler for boot / shutdown / reset / clear posts; the
-    [action] parameter selects the keeper FSM event. *)
+(** Generic handler for boot / shutdown / reset / clear posts; the [action]
+    parameter selects the keeper FSM event. Boot rejects an ordinary paused
+    owner instead of implicitly resuming it; Dead-tombstone revival remains a
+    separate boot transaction. *)
 
 val refresh_keeper_execution_surfaces :
   config:Workspace.config -> name:string -> string -> unit

--- a/test/test_grpc_client.ml
+++ b/test/test_grpc_client.ml
@@ -210,13 +210,12 @@ let test_heartbeat_ack_directive_types () =
       [ Keeper_directive.Pause
       ; Keeper_directive.Assign_task (task_id "T-42")
       ; Keeper_directive.Wakeup
-      ; Keeper_directive.Resume
       ];
   } in
   let bytes = T.HeartbeatAck.to_bytes ack in
   let decoded = T.HeartbeatAck.of_bytes bytes in
   Alcotest.(check (list string)) "P3 directives roundtrip"
-    ["pause"; "claim:T-42"; "wakeup"; "resume"]
+    ["pause"; "claim:T-42"; "wakeup"]
     (List.map T.HeartbeatAck.directive_to_wire decoded.directives);
   let rejects raw =
     match T.HeartbeatAck.directive_of_wire raw with
@@ -224,6 +223,7 @@ let test_heartbeat_ack_directive_types () =
     | Error _ -> true
   in
   Alcotest.(check bool) "unknown directive rejected" true (rejects "compact");
+  Alcotest.(check bool) "legacy raw resume rejected" true (rejects "resume");
   Alcotest.(check bool) "empty task assignment rejected" true (rejects "claim:");
   Alcotest.(check bool)
     "near-prefix tag rejected"

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -213,18 +213,7 @@ let test_grpc_pause_directive_records_reason () =
             (Some wire_grpc_directive)
             (latched_reason_wire entry.meta)
         | None -> fail "expected registered keeper after wakeup directive");
-       Keeper_keepalive.process_directive
-         ~agent_name:keeper_name
-         Keeper_directive.Resume;
-       match Keeper_registry.get ~base_path:config.base_path keeper_name with
-       | Some entry ->
-         check bool "resume directive resumes keeper" false entry.meta.paused;
-         check
-           (option string)
-           "resume clears the latched reason together with the pause bit"
-           None
-           (latched_reason_wire entry.meta)
-       | None -> fail "expected registered keeper after resume directive")
+       ())
 
 (* ── Site 2: keeper_down retain (remove_meta=false) ─────────── *)
 

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -447,14 +447,14 @@ let test_revival_decision_matrix () =
   in
   case ~label:"no latch, not paused" ~latched_reason:None ~paused:false
     ~expect_dead_revival:false ~expect_clear:false;
-  case ~label:"no latch, paused (plain resume)" ~latched_reason:None ~paused:true
-    ~expect_dead_revival:false ~expect_clear:true;
+  case ~label:"no latch, paused (keeper_up retains pause)" ~latched_reason:None ~paused:true
+    ~expect_dead_revival:false ~expect_clear:false;
   case ~label:"operator_paused latch, not paused (inconsistent state, not dead-revival)"
     ~latched_reason:(Some grpc_directive_pause) ~paused:false
     ~expect_dead_revival:false ~expect_clear:false;
-  case ~label:"operator_paused latch, paused (canonical operator-pause resume)"
+  case ~label:"operator_paused latch, paused (keeper_up retains pause)"
     ~latched_reason:(Some grpc_directive_pause) ~paused:true
-    ~expect_dead_revival:false ~expect_clear:true;
+    ~expect_dead_revival:false ~expect_clear:false;
   case ~label:"dead_tombstone latch, not paused (stranded -- must still revive)"
     ~latched_reason:(Some Keeper_latched_reason.Dead_tombstone) ~paused:false
     ~expect_dead_revival:true ~expect_clear:true;


### PR DESCRIPTION
## Summary

- make ordinary `masc_keeper_up` reconfiguration preserve `paused` and its typed latch
- keep pause clearing exclusive to the existing Dead-tombstone revival transaction or typed `Resume_owner`
- reject dashboard `boot` with HTTP 409 when durable or live registry truth says the owner is ordinarily paused
- remove boot-time best-effort unpause and its stale resume-specific metric phases
- retire the payload-free `Keeper_directive.Resume` variant and reject legacy gRPC `"resume"`, because that wire format cannot carry generation or operation-ID fences
- preserve Dead-tombstone boot/revival as a separate explicit lifecycle authority

## Stack and scope

Base: `codex/paused-work-resume-surface-20260720` (draft PR #25352).

Together with the base, this removes the known unreceipted resume aliases: dashboard resume, wakeup, keeper_up, dashboard boot, and legacy gRPC raw resume. It does not implement `Transfer_owner`, `Settle_from_source_terminal`, paused-retained fleet metrics, or the 10-Keeper 8-hour acceptance run.

## Validation

- `ocamlc -stop-after parsing` for every changed implementation/interface/test
- `ocamlformat --check` for every changed OCaml file
- `git diff --check`
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail` — 0 new violations
- static scan: no `Keeper_directive.Resume`, `wakeup_resume`, boot-resume helper, or retired boot-resume metric labels remain

Local Dune build/tests were intentionally not run; the operator is running builds separately and PR CI remains the build authority.