### PR TITLE
fix(keeper): remove inferred quota suppression

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -221,18 +221,10 @@ let is_auto_recoverable_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error
       (Keeper_turn_driver.Runtime_exhausted
          { reason = Keeper_turn_driver.Capacity_exhausted; _ }) ->
       true
-  | Some (Keeper_turn_driver.Capacity_backpressure { cooldown_cause; _ }) ->
-      (* A pre-dispatch provider-health cooldown block carries the failure that
-         armed the cooldown.  Deterministic causes (config/build error, depleted
-         balance, structural provider failure) re-fail on the next tick, so they
-         must NOT be auto-recoverable: returning [false] makes [counts_toward_crash]
-         true so the existing failure-streak policy escalates instead of the
-         keeper oscillating (#23438).  Genuine upstream capacity backpressure
-         ([None]) and transient causes stay auto-recoverable. *)
-      (match cooldown_cause with
-       | Some cause ->
-         not (Keeper_turn_driver.provider_cooldown_cause_is_deterministic cause)
-       | None -> true)
+  | Some (Keeper_turn_driver.Capacity_backpressure _) ->
+      (* Legacy [cooldown_cause] values are diagnostic-only. A decoded receipt
+         from the retired pre-dispatch gate must not regain lifecycle authority. *)
+      true
   | Some (Keeper_turn_driver.Runtime_exhausted _) ->
       false
   | Some (Keeper_turn_driver.Accept_rejected _)
@@ -453,10 +445,9 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            where OAS surfaces the error directly) should still trigger rotation
            when a different runtime may succeed.
 
-           429 rate-limit (non-hard-quota): rotate only to candidates outside
-           the throttled runtime's credential pool. The filter lives at the
-           candidate boundary below, where runtime/provider credentials are
-           available.
+           429 rate-limit (non-hard-quota): rotate through explicitly declared
+           candidates. The error type does not carry model/account/provider
+           scope, so this boundary must not infer a broader blocked set.
 
            [ServerError]: the provider is unhealthy or overloaded; a
            different runtime may be healthy.
@@ -466,8 +457,7 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
 
            [PaymentRequired] and provider [HardQuota] are handled above by
            [sdk_error_is_hard_quota]. Rate limits intentionally keep [Rate_limit]
-           so pool-aware candidate filtering can preserve independent-provider
-           failover. *)
+           so declared runtime fallback remains available. *)
         (match err with
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
              Some Rate_limit
@@ -580,10 +570,8 @@ let default_degraded_rotation_candidates
     (* Phase B-1: include the full runtime catalog so transient infrastructure
        failures (notably capacity_backpressure) can fail over to a healthy
        runtime outside the narrow [base; default; phase_recovery] set.
-       Without this, two runtimes in cooldown had nowhere to go (#23373,
-       incidents 2026-05-21 / 2026-07-06). Credential-pool filtering is
-       applied downstream by [degraded_rotation_after_recoverable_error] via
-       [filter_quota_pool_rotation_candidates]. *)
+       Without this, two unavailable runtimes had nowhere to go (#23373,
+       incidents 2026-05-21 / 2026-07-06). *)
     candidates_with_catalog
   | Some (Hard_quota | Rate_limit)
   | None ->
@@ -629,23 +617,7 @@ let degraded_rotation_candidates
   |> List.filter (fun candidate ->
          not (String.equal candidate normalized_effective))
 
-let filter_quota_pool_rotation_candidates
-      ~credential_pool_of_runtime_id
-      ~effective_runtime
-      candidates
-  =
-  match credential_pool_of_runtime_id effective_runtime with
-  | None -> candidates
-  | Some effective_pool ->
-    List.filter
-      (fun candidate ->
-         match credential_pool_of_runtime_id candidate with
-         | None -> true
-         | Some candidate_pool -> not (String.equal candidate_pool effective_pool))
-      candidates
-
 let degraded_rotation_after_recoverable_error
-      ?(credential_pool_of_runtime_id = fun _ -> None)
       ?fallback_hint
       ~(base_runtime : string)
       ~(effective_runtime : string)
@@ -669,23 +641,6 @@ let degraded_rotation_after_recoverable_error
           ~fallback_reason
           ~fallback_hint
           ~base_runtime ~effective_runtime
-      in
-      let candidates =
-        match fallback_reason with
-        | Hard_quota
-        | Rate_limit ->
-          filter_quota_pool_rotation_candidates
-            ~credential_pool_of_runtime_id
-            ~effective_runtime
-            candidates
-        | Empty_no_progress
-        | Thinking_only_no_progress
-        | Resumable_cli_session
-        | Runtime_candidates_filtered
-        | Runtime_exhausted
-        | Capacity_backpressure
-        | Server_error
-        | Auth_error -> candidates
       in
       let untried =
         List.find_opt

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -120,8 +120,7 @@ val fallback_runtime_for_unavailable_profile :
     Typed rotation: raw API errors that are not wrapped in a MASC
     internal error are also classified when a different runtime may succeed:
     - [PaymentRequired] / provider [HardQuota] → ["hard_quota"]
-    - [RateLimited] provider throttles → ["rate_limit"] (rotation filters
-      candidates sharing the same credential pool)
+    - [RateLimited] provider throttles → ["rate_limit"]
     - [Overloaded] / [CapacityExhausted] → ["capacity_backpressure"]
     - API [ServerError] and transient provider [ServerError] → ["server_error"]
     - [AuthError] → ["auth_error"]
@@ -151,17 +150,13 @@ val degraded_retry_after_recoverable_error :
     any other candidate; if it duplicates the effective runtime or has
     already been attempted, the next legal candidate is returned.
 
-    For ["hard_quota"] and ["rate_limit"], candidates sharing the effective
-    runtime's credential pool, as reported by [credential_pool_of_runtime_id],
-    are excluded before attempt filtering, preserving independent-provider
-    failover while avoiding same-account fan-out. If no pool function is
-    supplied, no credential-pool filtering is applied. Once every typed
-    candidate has been attempted, the current turn stops rotating. A later
-    Keeper turn may make a fresh attempt; this function does not synthesize a
-    timed retry cycle.
+    Quota and rate-limit observations do not imply account-wide scope: every
+    untried runtime in the declaratively selected recovery group remains
+    eligible. Once every typed candidate has been attempted, the current turn
+    stops rotating. A later Keeper turn may make a fresh attempt; this function
+    does not synthesize a timed retry cycle.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
-  ?credential_pool_of_runtime_id:(string -> string option) ->
   ?fallback_hint:string ->
   base_runtime:string ->
   effective_runtime:string ->

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -30,5 +30,5 @@ val capacity_backpressure_of_pending :
 
 (* [capacity_backpressure_of_sdk_error] was removed (#23438): a dead substring
    classifier that laundered opaque [Internal] errors into the auto-recoverable
-   capacity-backpressure class.  The typed [cooldown_cause] on the pre-dispatch
-   cooldown gate replaces it. *)
+   capacity-backpressure class. Legacy decoded [cooldown_cause] values are
+   diagnostic-only. *)

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -6,24 +6,6 @@ open Keeper_types_profile
 open Keeper_context_runtime
 module EC = Keeper_error_classify
 
-let credential_pool_of_runtime_id runtime_id =
-  match Runtime.get_runtime_by_id runtime_id with
-  | None -> None
-  | Some (runtime : Runtime.t) ->
-    let transport =
-      match runtime.provider.transport with
-      | Runtime_schema.Http endpoint -> "http:" ^ endpoint
-      | Runtime_schema.Cli command -> "cli:" ^ command
-    in
-    let credential =
-      match runtime.provider.credentials with
-      | Some (Runtime_schema.Env key) -> "env:" ^ key
-      | Some (Runtime_schema.File path) -> "file:" ^ path
-      | Some (Runtime_schema.Inline _) -> "inline:" ^ runtime.provider.id
-      | None -> "none"
-    in
-    Some (transport ^ "|" ^ credential)
-
 let next_fail_open_runtime_for_turn
       ~(base_runtime : string)
       ~(effective_runtime : string)
@@ -32,7 +14,6 @@ let next_fail_open_runtime_for_turn
   : EC.degraded_retry option
   =
   EC.degraded_rotation_after_recoverable_error
-    ~credential_pool_of_runtime_id
     ~base_runtime
     ~effective_runtime
     ~attempted_runtimes

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -50,7 +50,8 @@ type capacity_retry_after =
   | Explicit of float
   | No_retry_hint
 
-(** Legacy cause carried by persisted [Capacity_backpressure] envelopes. *)
+(** Legacy diagnostic carried by persisted [Capacity_backpressure] envelopes.
+    It has no retry, admission, or lifecycle authority. *)
 type provider_cooldown_cause =
   | Cooldown_provider_capacity
   | Cooldown_soft_rate_limited
@@ -78,22 +79,6 @@ let provider_cooldown_cause_of_string = function
   | "provider_error" -> Some Cooldown_provider_error
   | "rejected" -> Some Cooldown_rejected
   | _ -> None
-
-(** [true] when waiting out the cooldown cannot resolve the cause: the next
-    attempt hits the same deterministic condition (config/build error, depleted
-    balance, structural provider failure, rejected output).  Transient causes
-    (provider capacity, HTTP 429, HTTP 5xx) are expected to recover, so a
-    cooldown block armed by them stays auto-recoverable.  A deterministic cause
-    must instead flow into the crash/pause escalation path so the keeper stops
-    oscillating.  #23438. *)
-let provider_cooldown_cause_is_deterministic = function
-  | Cooldown_hard_quota
-  | Cooldown_terminal_failure
-  | Cooldown_provider_error
-  | Cooldown_rejected -> true
-  | Cooldown_provider_capacity
-  | Cooldown_soft_rate_limited
-  | Cooldown_server_error -> false
 
 type runtime_exhaustion_reason =
   | Connection_refused
@@ -235,9 +220,8 @@ type masc_internal_error =
       detail : string;
       retry_after : capacity_retry_after;
       cooldown_cause : provider_cooldown_cause option;
-      (* [Some cause] iff this is a pre-dispatch provider-health cooldown block
-         (the arming failure's cause).  [None] for genuine capacity backpressure
-         surfaced from an upstream capacity-exhaustion signal.  #23438. *)
+      (* Legacy diagnostic only. Current producers use [None]; decoded values
+         never grant retry, admission, or lifecycle authority. *)
     }
   | Resumable_cli_session of {
       runtime_id : string;

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -25,7 +25,8 @@ type capacity_retry_after =
   | Explicit of float
   | No_retry_hint
 
-(** Legacy cause carried by persisted [Capacity_backpressure] envelopes. *)
+(** Legacy diagnostic carried by persisted [Capacity_backpressure] envelopes.
+    It has no retry, admission, or lifecycle authority. *)
 type provider_cooldown_cause =
   | Cooldown_provider_capacity
   | Cooldown_soft_rate_limited
@@ -37,12 +38,6 @@ type provider_cooldown_cause =
 
 val provider_cooldown_cause_to_string : provider_cooldown_cause -> string
 val provider_cooldown_cause_of_string : string -> provider_cooldown_cause option
-
-(** [true] when waiting out the cooldown cannot resolve the cause (deterministic
-    config/build/credential/quota/structural failure); [false] for transient
-    causes expected to recover (capacity, HTTP 429, HTTP 5xx).  Drives whether a
-    cooldown-block turn error is auto-recoverable or escalates.  #23438. *)
-val provider_cooldown_cause_is_deterministic : provider_cooldown_cause -> bool
 
 type runtime_exhaustion_reason =
   | Connection_refused
@@ -96,8 +91,8 @@ type masc_internal_error =
       detail : string;
       retry_after : capacity_retry_after;
       cooldown_cause : provider_cooldown_cause option;
-      (** [Some cause] iff this is a pre-dispatch provider-health cooldown block;
-          [None] for genuine upstream capacity backpressure.  #23438. *)
+      (** Legacy diagnostic only. Current producers use [None]; decoded values
+          never grant retry, admission, or lifecycle authority. *)
     }
   | Resumable_cli_session of {
       runtime_id : string;

--- a/lib/keeper_runtime/keeper_runtime_failure_route.mli
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.mli
@@ -27,7 +27,7 @@
 
 (** Typed class of the observed retryable provider/runtime failure. *)
 type retry_class =
-  | Rate_limited  (** soft 429 throttle; rotation keeps the credential-pool filter *)
+  | Rate_limited  (** soft 429 throttle; declared runtimes remain eligible *)
   | Hard_quota  (** account-level quota/balance exhaustion (402 family) *)
   | Capacity_backpressure
       (** typed provider overload / capacity-exhausted pools *)

--- a/test/test_keeper_cooldown_cause_23438.ml
+++ b/test/test_keeper_cooldown_cause_23438.ml
@@ -1,24 +1,18 @@
 (* test/test_keeper_cooldown_cause_23438.ml
 
-   #23438: the pre-dispatch provider-health cooldown gate must carry the
-   failure that armed the cooldown instead of erasing it into an
-   unconditional provider_capacity claim. On 2026-07-06 that erasure let
-   ~25 deterministic provider errors oscillate into 1,041 blocked turns:
-   Capacity_backpressure was always auto-recoverable, so no escalation
-   path could ever fire.
+   #23438 compatibility: persisted envelopes from the retired pre-dispatch
+   provider-health gate may still carry [cooldown_cause]. The field remains
+   decodable for evidence, but it has no retry, admission, or lifecycle
+   authority.
 
    Pinned invariants:
-   1. [provider_cooldown_cause_is_deterministic] truth table: hard_quota /
-      terminal_failure / provider_error / rejected are deterministic;
-      provider_capacity / soft_rate_limited / server_error are transient.
-   2. to_string/of_string is a total roundtrip over every constructor.
-   3. sdk_error embed -> classify roundtrip preserves [cooldown_cause]
+   1. to_string/of_string is a total roundtrip over every constructor.
+   2. sdk_error embed -> classify roundtrip preserves [cooldown_cause]
       (Some and None) through the JSON wire payload.
-   4. [summary_of_masc_internal_error] names the true cause; a cause-less
+   3. [summary_of_masc_internal_error] names the diagnostic; a cause-less
       block renders without the suffix (legacy shape preserved).
-   5. Classification: deterministic cause -> NOT auto-recoverable (feeds
-      counts_toward_crash so the failure-streak policy escalates);
-      transient cause and None -> auto-recoverable (today's behaviour). *)
+   4. Every legacy cause remains auto-recoverable; decoded history cannot
+      alter Keeper lifecycle behavior. *)
 
 module KIE = Keeper_internal_error
 module EC = Masc.Keeper_error_classify
@@ -34,19 +28,6 @@ let all_causes =
   ; KIE.Cooldown_rejected
   ]
 
-let deterministic_causes =
-  [ KIE.Cooldown_hard_quota
-  ; KIE.Cooldown_terminal_failure
-  ; KIE.Cooldown_provider_error
-  ; KIE.Cooldown_rejected
-  ]
-
-let transient_causes =
-  [ KIE.Cooldown_provider_capacity
-  ; KIE.Cooldown_soft_rate_limited
-  ; KIE.Cooldown_server_error
-  ]
-
 let backpressure_error ?cooldown_cause () =
   KIE.Capacity_backpressure
     { runtime_id = "runpod_rtxa6000.gemma4-coder-fable5-q4km"
@@ -55,26 +36,6 @@ let backpressure_error ?cooldown_cause () =
     ; retry_after = KIE.No_retry_hint
     ; cooldown_cause
     }
-
-let test_deterministic_truth_table () =
-  List.iter
-    (fun cause ->
-      Alcotest.(check bool)
-        (Printf.sprintf
-           "%s is deterministic"
-           (KIE.provider_cooldown_cause_to_string cause))
-        true
-        (KIE.provider_cooldown_cause_is_deterministic cause))
-    deterministic_causes;
-  List.iter
-    (fun cause ->
-      Alcotest.(check bool)
-        (Printf.sprintf
-           "%s is transient"
-           (KIE.provider_cooldown_cause_to_string cause))
-        false
-        (KIE.provider_cooldown_cause_is_deterministic cause))
-    transient_causes
 
 let test_cause_string_roundtrip () =
   List.iter
@@ -158,7 +119,7 @@ let test_summary_names_the_cause () =
     false
     (contains ~needle:"cooldown_cause=" legacy)
 
-let test_classification_escalates_deterministic_causes () =
+let test_legacy_causes_have_no_lifecycle_authority () =
   List.iter
     (fun cause ->
       let sdk_error =
@@ -167,24 +128,11 @@ let test_classification_escalates_deterministic_causes () =
       in
       Alcotest.(check bool)
         (Printf.sprintf
-           "deterministic %s is not auto-recoverable"
-           (KIE.provider_cooldown_cause_to_string cause))
-        false
-        (EC.is_auto_recoverable_turn_error sdk_error))
-    deterministic_causes;
-  List.iter
-    (fun cause ->
-      let sdk_error =
-        KTD.sdk_error_of_masc_internal_error
-          (backpressure_error ~cooldown_cause:cause ())
-      in
-      Alcotest.(check bool)
-        (Printf.sprintf
-           "transient %s stays auto-recoverable"
+           "legacy %s stays auto-recoverable"
            (KIE.provider_cooldown_cause_to_string cause))
         true
         (EC.is_auto_recoverable_turn_error sdk_error))
-    transient_causes;
+    all_causes;
   let cause_less =
     KTD.sdk_error_of_masc_internal_error (backpressure_error ())
   in
@@ -198,10 +146,6 @@ let () =
     "keeper_cooldown_cause_23438"
     [ ( "cooldown_cause"
       , [ Alcotest.test_case
-            "deterministic truth table"
-            `Quick
-            test_deterministic_truth_table
-        ; Alcotest.test_case
             "to_string/of_string roundtrip"
             `Quick
             test_cause_string_roundtrip
@@ -214,12 +158,12 @@ let () =
             `Quick
             test_sdk_error_roundtrip_none_cause
         ; Alcotest.test_case
-            "summary names the true cause"
+            "summary preserves the legacy diagnostic"
             `Quick
             test_summary_names_the_cause
         ; Alcotest.test_case
-            "deterministic causes escalate, transient stay recoverable"
+            "legacy causes have no lifecycle authority"
             `Quick
-            test_classification_escalates_deterministic_causes
+            test_legacy_causes_have_no_lifecycle_authority
         ] )
     ]

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -508,13 +508,6 @@ let test_static_error_classification_preserves_retry_semantics () =
        (Llm_provider.Error.UnknownVariant { type_name = "provider"; value = "new" }))
 ;;
 
-let rate_limit_pool_of_runtime_id = function
-  | "same.a"
-  | "same.b" -> Some "pool:same"
-  | "other.c" -> Some "pool:other"
-  | _ -> Some "pool:same"
-;;
-
 let with_temp_runtime_toml content f =
   let path = Filename.temp_file "runtime-rate-limit-pool" ".toml" in
   let oc = open_out path in
@@ -641,28 +634,33 @@ let test_generic_accept_rejected_is_not_locally_recoverable () =
       (EC.degraded_retry_reason_to_string reason)
 ;;
 
-let test_soft_rate_limit_skips_same_credential_pool () =
+let test_soft_rate_limit_preserves_declared_same_credential_runtime () =
   init_rate_limit_pool_runtime ();
-  let retry =
+  match
     EC.degraded_rotation_after_recoverable_error
-      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"same.b"
       ~base_runtime:"same.a"
       ~effective_runtime:"same.a"
       ~attempted_runtimes:[ "same.a" ]
       soft_rate_limit_err
-  in
-  Alcotest.(check bool)
-    "same credential pool is not a rotation target"
-    false
-    (Option.is_some retry)
+  with
+  | Some { EC.next_runtime; fallback_reason = EC.Rate_limit } ->
+    Alcotest.(check string)
+      "declared same-credential runtime remains eligible"
+      "same.b"
+      next_runtime
+  | Some { fallback_reason; next_runtime } ->
+    Alcotest.failf
+      "expected rate_limit -> same.b, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None -> Alcotest.fail "expected declared same-credential runtime fallback"
 ;;
 
-let test_soft_rate_limit_preserves_independent_pool_failover () =
+let test_soft_rate_limit_preserves_other_declared_runtime () =
   init_rate_limit_pool_runtime ();
   match
     EC.degraded_rotation_after_recoverable_error
-      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"other.c"
       ~base_runtime:"same.a"
       ~effective_runtime:"same.a"
@@ -671,7 +669,7 @@ let test_soft_rate_limit_preserves_independent_pool_failover () =
   with
   | Some { EC.next_runtime; fallback_reason = EC.Rate_limit } ->
     Alcotest.(check string)
-      "independent credential pool remains eligible"
+      "other declared runtime remains eligible"
       "other.c"
       next_runtime
   | Some { fallback_reason; next_runtime } ->
@@ -679,31 +677,36 @@ let test_soft_rate_limit_preserves_independent_pool_failover () =
       "expected rate_limit -> other.c, got %s -> %s"
       (EC.degraded_retry_reason_to_string fallback_reason)
       next_runtime
-  | None -> Alcotest.fail "expected independent credential pool failover"
+  | None -> Alcotest.fail "expected other declared runtime fallback"
 ;;
 
-let test_hard_quota_skips_same_credential_pool () =
+let test_hard_quota_preserves_declared_same_credential_runtime () =
   init_rate_limit_pool_runtime ();
-  let retry =
+  match
     EC.degraded_rotation_after_recoverable_error
-      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"same.b"
       ~base_runtime:"same.a"
       ~effective_runtime:"same.a"
       ~attempted_runtimes:[ "same.a" ]
       hard_quota_err
-  in
-  Alcotest.(check bool)
-    "hard quota does not fan out to the same credential pool"
-    false
-    (Option.is_some retry)
+  with
+  | Some { EC.next_runtime; fallback_reason = EC.Hard_quota } ->
+    Alcotest.(check string)
+      "declared same-credential runtime remains eligible"
+      "same.b"
+      next_runtime
+  | Some { fallback_reason; next_runtime } ->
+    Alcotest.failf
+      "expected hard_quota -> same.b, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None -> Alcotest.fail "expected declared same-credential runtime fallback"
 ;;
 
-let test_hard_quota_preserves_independent_pool_failover () =
+let test_hard_quota_preserves_other_declared_runtime () =
   init_rate_limit_pool_runtime ();
   match
     EC.degraded_rotation_after_recoverable_error
-      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"other.c"
       ~base_runtime:"same.a"
       ~effective_runtime:"same.a"
@@ -712,7 +715,7 @@ let test_hard_quota_preserves_independent_pool_failover () =
   with
   | Some { EC.next_runtime; fallback_reason = EC.Hard_quota } ->
     Alcotest.(check string)
-      "independent credential pool remains eligible"
+      "other declared runtime remains eligible"
       "other.c"
       next_runtime
   | Some { fallback_reason; next_runtime } ->
@@ -720,7 +723,7 @@ let test_hard_quota_preserves_independent_pool_failover () =
       "expected hard_quota -> other.c, got %s -> %s"
       (EC.degraded_retry_reason_to_string fallback_reason)
       next_runtime
-  | None -> Alcotest.fail "expected independent credential pool failover"
+  | None -> Alcotest.fail "expected other declared runtime fallback"
 ;;
 
 let test_server_error_classifies_as_runtime_recoverable () =
@@ -742,7 +745,6 @@ let test_rate_limit_exhaustion_stops_after_candidate_pass () =
   let attempted = [ "same.a"; "same.b"; "other.c" ] in
   match
     EC.degraded_rotation_after_recoverable_error
-      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"other.c"
       ~base_runtime:"same.a"
       ~effective_runtime:"same.a"
@@ -839,21 +841,21 @@ let () =
             `Quick
             test_overloaded_with_quota_prose_is_not_hard_quota
         ; Alcotest.test_case
-            "soft rate limits skip same credential-pool candidates"
+            "soft rate limits preserve declared same-credential runtimes"
             `Quick
-            test_soft_rate_limit_skips_same_credential_pool
+            test_soft_rate_limit_preserves_declared_same_credential_runtime
         ; Alcotest.test_case
-            "soft rate limits preserve independent credential-pool failover"
+            "soft rate limits preserve other declared runtimes"
             `Quick
-            test_soft_rate_limit_preserves_independent_pool_failover
+            test_soft_rate_limit_preserves_other_declared_runtime
         ; Alcotest.test_case
-            "hard quota skips same credential-pool candidates"
+            "hard quota preserves declared same-credential runtimes"
             `Quick
-            test_hard_quota_skips_same_credential_pool
+            test_hard_quota_preserves_declared_same_credential_runtime
         ; Alcotest.test_case
-            "hard quota preserves independent credential-pool failover"
+            "hard quota preserves other declared runtimes"
             `Quick
-            test_hard_quota_preserves_independent_pool_failover
+            test_hard_quota_preserves_other_declared_runtime
         ; Alcotest.test_case
             "500 classifies as recoverable server_error"
             `Quick


### PR DESCRIPTION
## 문제

Keeper fallback은 typed `RateLimited` / `HardQuota`에 실제 scope 정보가 없는데도 endpoint와 credential source가 같으면 account-wide failure라고 추정했습니다. 그 결과 같은 credential을 쓰는 다른 선언 모델은 provider 호출 전에 후보에서 제거됐고, recovery group이 그 pool뿐이면 turn이 즉시 종료됐습니다.

과거 pre-dispatch cooldown envelope의 `cooldown_cause`도 현재 producer가 없는데 decoded history만으로 failure-counting 행동을 바꿀 수 있었습니다.

## 변경

- credential-pool identity와 quota candidate filter를 삭제
- typed quota/rate-limit 뒤에도 declaratively selected recovery group의 모든 untried runtime을 후보로 유지
- legacy `cooldown_cause` wire decode/표시는 보존하되 retry/admission/lifecycle 권한 제거
- provider/quota failure로 global ledger, shared cooldown, Keeper pause를 추가하지 않음
- bounded one-pass 계약은 유지: 한 turn에서 각 후보는 최대 1회, 새 timed retry cycle은 생성하지 않음

## Before / After

- same-credential declared fallback eligibility: `0/1` -> `1/1`
- other declared runtime eligibility: `1/1` -> `1/1`
- legacy cooldown causes with behavioral authority: `4/7` -> `0/7`
- provider/quota paths writing `paused = true`: `0` -> `0`

## 검증

- `scripts/dune-local.sh build test/test_keeper_sdk_error_typed_bridge.exe test/test_keeper_cooldown_cause_23438.exe`
- `test_keeper_sdk_error_typed_bridge`: 18/18
- `test_keeper_cooldown_cause_23438`: 5/5
- `ocamlformat --check` (9 touched OCaml files)
- `git diff --check`

Context: #25295. 이 PR은 durable/global quota admission을 구현하지 않고, 반대로 scope 없는 quota 관측의 실행 억제 권한을 제거합니다.


## Hard_quota scope 문서와의 관계 (병합 시 판단 기록)

`keeper_runtime_failure_route.mli`의 `Hard_quota (** account-level quota/balance exhaustion (402 family) *)` 문서는 유지됩니다. typed error가 credential scope를 *증명*하지 않는 이상, 같은-credential sibling으로의 bounded one-pass 시도는 허용 가능한 비용입니다: 시도는 턴당 1회로 유계이며, 대안(추론 기반 suppression)은 #25295가 보인 턴 전체 종료(과잉 제약)로 이어졌습니다. scope 증명이 필요해지면 typed scope를 error에 실어오는 것이 정답이지, 문자열/휴리스틱 추론 복원이 아닙니다.
