### PR TITLE
feat(keeper): transfer paused work by durable receipt

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -415,7 +415,8 @@ let settle_claimed_lease
 let settlement_is_ack = function
   | Keeper_registry_event_queue.Ack
   | Keeper_registry_event_queue.No_compaction _
-  | Keeper_registry_event_queue.Cancel_accepted _ -> true
+  | Keeper_registry_event_queue.Cancel_accepted _
+  | Keeper_registry_event_queue.Transfer_accepted _ -> true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -1,4 +1,21 @@
-type operation = Resume_owner
+type continuation_binding =
+  | Routed of Keeper_continuation_channel.t
+  | No_channel
+
+type transfer_owner =
+  { from_keeper : string
+  ; to_keeper : string
+  ; target_trace_id : Keeper_id.Trace_id.t
+  ; target_generation : int
+  ; source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; settled_at : float
+  ; continuation_binding : continuation_binding
+  }
+
+type operation =
+  | Resume_owner
+  | Transfer_owner of transfer_owner
 
 type keeper_lock = { keeper_name : string }
 
@@ -27,6 +44,22 @@ let equal left right =
   && left.operation = right.operation
 ;;
 
+let continuation_binding_of_source source =
+  match source.Keeper_event_queue.payload with
+  | Keeper_event_queue.Fusion_completed completion -> Routed completion.channel
+  | Keeper_event_queue.Connector_attention attention -> Routed attention.channel
+  | Keeper_event_queue.Hitl_resolved resolution -> Routed resolution.channel
+  | Keeper_event_queue.Board_signal _
+  | Keeper_event_queue.Board_attention _
+  | Keeper_event_queue.Bootstrap
+  | Keeper_event_queue.Bg_completed _
+  | Keeper_event_queue.Schedule_due _
+  | Keeper_event_queue.Failure_judgment _
+  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Goal_assigned _ ->
+    No_channel
+;;
+
 let validate receipt =
   if String.equal (String.trim receipt.keeper_name) ""
   then Error "paused-work disposition keeper name must not be empty"
@@ -36,7 +69,29 @@ let validate receipt =
   then Error "paused-work disposition operation ID must not be empty"
   else if not (Float.is_finite receipt.requested_at)
   then Error "paused-work disposition request time must be finite"
-  else Ok ()
+  else
+    match receipt.operation with
+    | Resume_owner -> Ok ()
+    | Transfer_owner transfer ->
+      if not (String.equal transfer.from_keeper receipt.keeper_name)
+      then Error "paused-work transfer source Keeper does not match receipt owner"
+      else if String.equal (String.trim transfer.to_keeper) ""
+      then Error "paused-work transfer target Keeper must not be empty"
+      else if String.equal transfer.from_keeper transfer.to_keeper
+      then Error "paused-work transfer source and target Keepers must differ"
+      else if transfer.target_generation < 0
+      then Error "paused-work transfer target generation must not be negative"
+      else if Int64.compare transfer.source_revision 0L < 0
+      then Error "paused-work transfer source revision must not be negative"
+      else if not (Float.is_finite transfer.settled_at)
+      then Error "paused-work transfer settlement time must be finite"
+      else if String.equal (String.trim transfer.source.post_id) ""
+      then Error "paused-work transfer source post id must not be empty"
+      else if
+        transfer.continuation_binding
+        <> continuation_binding_of_source transfer.source
+      then Error "paused-work transfer continuation binding does not match source"
+      else Ok ()
 ;;
 
 let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
@@ -54,25 +109,145 @@ let receipt_path config ~keeper_name ~operator_operation_id =
     ("operation-" ^ sha256 operator_operation_id ^ ".json")
 ;;
 
-let to_yojson receipt =
+let continuation_binding_to_yojson = function
+  | Routed channel ->
+    `Assoc
+      [ "kind", `String "routed"
+      ; "channel", Keeper_continuation_channel.to_yojson channel
+      ]
+  | No_channel -> `Assoc [ "kind", `String "no_channel" ]
+;;
+
+let transfer_owner_to_yojson transfer =
   `Assoc
-    [ "schema", `String "masc.keeper.paused-work-disposition.v1"
-    ; "operation", `String "resume_owner"
-    ; "keeper_name", `String receipt.keeper_name
-    ; ( "expected_trace_id"
-      , `String (Keeper_id.Trace_id.to_string receipt.expected_trace_id) )
-    ; "expected_generation", `Int receipt.expected_generation
-    ; "operator_operation_id", `String receipt.operator_operation_id
-    ; "requested_at", `Float receipt.requested_at
+    [ "from_keeper", `String transfer.from_keeper
+    ; "to_keeper", `String transfer.to_keeper
+    ; "target_trace_id", `String (Keeper_id.Trace_id.to_string transfer.target_trace_id)
+    ; "target_generation", `Int transfer.target_generation
+    ; "source", Keeper_event_queue.stimulus_to_yojson transfer.source
+    ; "source_revision", `Intlit (Int64.to_string transfer.source_revision)
+    ; "settled_at", `Float transfer.settled_at
+    ; "continuation_binding", continuation_binding_to_yojson transfer.continuation_binding
     ]
+;;
+
+let to_yojson receipt =
+  let common operation schema extra =
+    `Assoc
+      ([ "schema", `String schema
+       ; "operation", `String operation
+       ; "keeper_name", `String receipt.keeper_name
+       ; ( "expected_trace_id"
+         , `String (Keeper_id.Trace_id.to_string receipt.expected_trace_id) )
+       ; "expected_generation", `Int receipt.expected_generation
+       ; "operator_operation_id", `String receipt.operator_operation_id
+       ; "requested_at", `Float receipt.requested_at
+       ]
+       @ extra)
+  in
+  match receipt.operation with
+  | Resume_owner ->
+    common "resume_owner" "masc.keeper.paused-work-disposition.v1" []
+  | Transfer_owner transfer ->
+    common
+      "transfer_owner"
+      "masc.keeper.paused-work-disposition.v2"
+      [ "transfer", transfer_owner_to_yojson transfer ]
+;;
+
+let sorted fields =
+  List.sort (fun (left, _) (right, _) -> String.compare left right) fields
+;;
+
+let requested_at_of_yojson = function
+  | `Float value -> Ok value
+  | `Int value -> Ok (Float.of_int value)
+  | `Intlit value ->
+    (match Float.of_string_opt value with
+     | Some value -> Ok value
+     | None -> Error "paused-work disposition request time is invalid")
+  | _ -> Error "paused-work disposition request time must be numeric"
+;;
+
+let source_revision_of_yojson = function
+  | `Int value -> Ok (Int64.of_int value)
+  | `Intlit value ->
+    (match Int64.of_string_opt value with
+     | Some value -> Ok value
+     | None -> Error "paused-work transfer source revision is invalid")
+  | _ -> Error "paused-work transfer source revision must be an integer"
+;;
+
+let continuation_binding_of_yojson = function
+  | `Assoc fields ->
+    (match sorted fields with
+     | [ "kind", `String "no_channel" ] -> Ok No_channel
+     | [ "channel", channel_json; "kind", `String "routed" ] ->
+       let* channel = Keeper_continuation_channel.of_yojson channel_json in
+       Ok (Routed channel)
+     | _ -> Error "paused-work transfer continuation binding fields are not exact")
+  | _ -> Error "paused-work transfer continuation binding must be an object"
+;;
+
+let transfer_owner_of_yojson = function
+  | `Assoc fields ->
+    (match sorted fields with
+     | [ ("continuation_binding", continuation_binding_json)
+       ; ("from_keeper", `String from_keeper)
+       ; ("settled_at", settled_at_json)
+       ; ("source", source_json)
+       ; ("source_revision", source_revision_json)
+       ; ("target_generation", `Int target_generation)
+       ; ("target_trace_id", `String target_trace_id)
+       ; ("to_keeper", `String to_keeper)
+       ] ->
+       let* target_trace_id = Keeper_id.Trace_id.of_string target_trace_id in
+       let* source = Keeper_event_queue.stimulus_of_yojson source_json in
+       let* source_revision = source_revision_of_yojson source_revision_json in
+       let* settled_at = requested_at_of_yojson settled_at_json in
+       let* continuation_binding =
+         continuation_binding_of_yojson continuation_binding_json
+       in
+       Ok
+         { from_keeper
+         ; to_keeper
+         ; target_trace_id
+         ; target_generation
+         ; source
+         ; source_revision
+         ; settled_at
+         ; continuation_binding
+         }
+     | _ -> Error "paused-work transfer fields are not exact")
+  | _ -> Error "paused-work transfer must be an object"
+;;
+
+let receipt_of_common
+      ~keeper_name
+      ~expected_trace_id
+      ~expected_generation
+      ~operator_operation_id
+      ~requested_at_json
+      ~operation
+  =
+  let* requested_at = requested_at_of_yojson requested_at_json in
+  let* expected_trace_id = Keeper_id.Trace_id.of_string expected_trace_id in
+  let receipt =
+    { keeper_name
+    ; expected_trace_id
+    ; expected_generation
+    ; operator_operation_id
+    ; requested_at
+    ; operation
+    }
+  in
+  let* () = validate receipt in
+  Ok receipt
 ;;
 
 let of_yojson = function
   | `Assoc fields ->
-    let fields =
-      List.sort (fun (left, _) (right, _) -> String.compare left right) fields
-    in
-    (match fields with
+    (match sorted fields with
      | [ ("expected_generation", `Int expected_generation)
        ; ("expected_trace_id", `String expected_trace_id)
        ; ("keeper_name", `String keeper_name)
@@ -81,28 +256,30 @@ let of_yojson = function
        ; ("requested_at", requested_at_json)
        ; ("schema", `String "masc.keeper.paused-work-disposition.v1")
        ] ->
-       let* requested_at =
-         match requested_at_json with
-         | `Float value -> Ok value
-         | `Int value -> Ok (Float.of_int value)
-         | `Intlit value ->
-           (match Float.of_string_opt value with
-            | Some value -> Ok value
-            | None -> Error "paused-work disposition request time is invalid")
-         | _ -> Error "paused-work disposition request time must be numeric"
-       in
-       let* expected_trace_id = Keeper_id.Trace_id.of_string expected_trace_id in
-       let receipt =
-         { keeper_name
-         ; expected_trace_id
-         ; expected_generation
-         ; operator_operation_id
-         ; requested_at
-         ; operation = Resume_owner
-         }
-       in
-       let* () = validate receipt in
-       Ok receipt
+       receipt_of_common
+         ~keeper_name
+         ~expected_trace_id
+         ~expected_generation
+         ~operator_operation_id
+         ~requested_at_json
+         ~operation:Resume_owner
+     | [ ("expected_generation", `Int expected_generation)
+       ; ("expected_trace_id", `String expected_trace_id)
+       ; ("keeper_name", `String keeper_name)
+       ; ("operation", `String "transfer_owner")
+       ; ("operator_operation_id", `String operator_operation_id)
+       ; ("requested_at", requested_at_json)
+       ; ("schema", `String "masc.keeper.paused-work-disposition.v2")
+       ; ("transfer", transfer_json)
+       ] ->
+       let* transfer = transfer_owner_of_yojson transfer_json in
+       receipt_of_common
+         ~keeper_name
+         ~expected_trace_id
+         ~expected_generation
+         ~operator_operation_id
+         ~requested_at_json
+         ~operation:(Transfer_owner transfer)
      | _ -> Error "paused-work disposition receipt fields are not exact")
   | _ -> Error "paused-work disposition receipt must be a JSON object"
 ;;

--- a/lib/keeper/keeper_paused_work_disposition_receipt.mli
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.mli
@@ -1,6 +1,23 @@
 (** Durable typed intent receipts for explicit paused-work disposition. *)
 
-type operation = Resume_owner
+type continuation_binding =
+  | Routed of Keeper_continuation_channel.t
+  | No_channel
+
+type transfer_owner =
+  { from_keeper : string
+  ; to_keeper : string
+  ; target_trace_id : Keeper_id.Trace_id.t
+  ; target_generation : int
+  ; source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; settled_at : float
+  ; continuation_binding : continuation_binding
+  }
+
+type operation =
+  | Resume_owner
+  | Transfer_owner of transfer_owner
 
 type t =
   { keeper_name : string
@@ -18,6 +35,11 @@ type save_result =
 type keeper_lock
 
 val equal : t -> t -> bool
+
+val continuation_binding_of_source :
+  Keeper_event_queue.stimulus -> continuation_binding
+(** Extract the exact routed channel carried by channel-bearing source kinds;
+    all other typed stimuli use [No_channel]. *)
 
 val load :
   Workspace.config ->

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -363,7 +363,7 @@ let project_receipt config receipt =
   let* transfer = transfer_of_receipt receipt in
   let* source_settlement = source_settlement config receipt transfer in
   let* target_projection = target_enqueue config transfer in
-  Ok { source_settlement; target_projection }
+  Ok (Applied { source_settlement; target_projection })
 ;;
 
 let run_owned receipt_lock config ~from_keeper ~to_keeper request =
@@ -399,7 +399,7 @@ let run_owned receipt_lock config ~from_keeper ~to_keeper request =
   in
   let projection =
     match project_receipt config receipt with
-    | Ok applied -> Applied applied
+    | Ok projection -> projection
     | Error failure -> Committed_followup_failed failure
   in
   Ok (receipt, commit_status, projection)

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -441,6 +441,7 @@ let transfer_pending config ~from_keeper ~to_keeper request =
              Error { cause; reservation_release = Some reservation_release })
         with
         | exn ->
+          (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
 ;;

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -1,0 +1,446 @@
+type request =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; target_generation : int
+  ; continuation_binding : Keeper_paused_work_disposition_receipt.continuation_binding
+  ; operator_operation_id : string
+  ; settled_at : float
+  }
+
+type projection_stage =
+  | Source_settlement
+  | Target_enqueue
+
+type failure =
+  | Invalid_request of string
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Receipt_lock_failed of string
+  | Receipt_read_failed of string
+  | Receipt_conflict of Keeper_paused_work_disposition_receipt.t
+  | Receipt_write_failed of string
+  | Durable_meta_read_failed of
+      { keeper_name : string
+      ; detail : string
+      }
+  | Durable_meta_missing of string
+  | Source_owner_not_paused
+  | Source_owner_dead_tombstone
+  | Source_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Source_owner_identity_changed
+  | Target_owner_not_active
+  | Target_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Continuation_binding_mismatch
+  | Source_queue_validation_failed of string
+  | Committed_projection_failed of
+      { stage : projection_stage
+      ; detail : string
+      }
+
+type error =
+  { cause : failure
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
+  }
+
+type commit_status =
+  | Committed
+  | Already_committed
+
+type target_projection =
+  | Enqueued
+  | Already_present
+
+type projection =
+  | Applied of
+      { source_settlement : Keeper_registry_event_queue.settle_result
+      ; target_projection : target_projection
+      }
+  | Committed_followup_failed of failure
+
+type success =
+  { receipt : Keeper_paused_work_disposition_receipt.t
+  ; commit_status : commit_status
+  ; projection : projection
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+let ( let* ) = Result.bind
+
+let projection_stage_to_string = function
+  | Source_settlement -> "source_settlement"
+  | Target_enqueue -> "target_enqueue"
+;;
+
+let failure_to_string = function
+  | Invalid_request detail -> "invalid Transfer_owner request: " ^ detail
+  | Reservation_conflict owner ->
+    "Transfer_owner lifecycle reservation conflict: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+  | Receipt_lock_failed detail -> "Transfer_owner receipt lock failed: " ^ detail
+  | Receipt_read_failed detail -> "Transfer_owner receipt read failed: " ^ detail
+  | Receipt_conflict receipt ->
+    Printf.sprintf
+      "Transfer_owner operation ID conflicts with keeper=%s generation=%d requested_at=%.17g"
+      receipt.keeper_name
+      receipt.expected_generation
+      receipt.requested_at
+  | Receipt_write_failed detail -> "Transfer_owner receipt write failed: " ^ detail
+  | Durable_meta_read_failed { keeper_name; detail } ->
+    Printf.sprintf "Transfer_owner durable metadata read failed keeper=%s: %s" keeper_name detail
+  | Durable_meta_missing keeper_name ->
+    "Transfer_owner durable Keeper metadata is missing: " ^ keeper_name
+  | Source_owner_not_paused -> "Transfer_owner source Keeper must be paused"
+  | Source_owner_dead_tombstone ->
+    "Transfer_owner cannot use a Dead source tombstone"
+  | Source_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "Transfer_owner source generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Source_owner_identity_changed ->
+    "Transfer_owner source trace identity changed"
+  | Target_owner_not_active -> "Transfer_owner target Keeper must be active"
+  | Target_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "Transfer_owner target generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Continuation_binding_mismatch ->
+    "Transfer_owner continuation binding does not match the exact source event"
+  | Source_queue_validation_failed detail ->
+    "Transfer_owner source queue validation failed: " ^ detail
+  | Committed_projection_failed { stage; detail } ->
+    Printf.sprintf
+      "Transfer_owner committed receipt but %s projection failed: %s"
+      (projection_stage_to_string stage)
+      detail
+;;
+
+let error_to_string error =
+  let base = failure_to_string error.cause in
+  match error.reservation_release with
+  | None -> base
+  | Some Keeper_lifecycle_reservation.Released -> base ^ "; reservation_release=released"
+  | Some Keeper_lifecycle_reservation.Release_missing ->
+    base ^ "; reservation_release=release_missing"
+  | Some (Keeper_lifecycle_reservation.Release_not_owner owner) ->
+    base
+    ^ "; reservation_release=release_not_owner: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+;;
+
+let validate_request ~from_keeper ~to_keeper request =
+  if String.equal (String.trim from_keeper) ""
+  then Error "source Keeper must not be empty"
+  else if String.equal (String.trim to_keeper) ""
+  then Error "target Keeper must not be empty"
+  else if String.equal from_keeper to_keeper
+  then Error "source and target Keepers must differ"
+  else if request.owner_generation < 0
+  then Error "source owner generation must not be negative"
+  else if request.target_generation < 0
+  then Error "target owner generation must not be negative"
+  else if Int64.compare request.source_revision 0L < 0
+  then Error "source revision must not be negative"
+  else if String.equal (String.trim request.source.post_id) ""
+  then Error "source post id must not be empty"
+  else if String.equal (String.trim request.operator_operation_id) ""
+  then Error "operator operation ID must not be empty"
+  else if not (Float.is_finite request.settled_at)
+  then Error "settlement time must be finite"
+  else if
+    request.continuation_binding
+    <> Keeper_paused_work_disposition_receipt.continuation_binding_of_source
+         request.source
+  then Error "continuation binding does not match source"
+  else Ok ()
+;;
+
+let read_meta config keeper_name =
+  match Keeper_meta_store.read_meta config keeper_name with
+  | Error detail -> Error (Durable_meta_read_failed { keeper_name; detail })
+  | Ok None -> Error (Durable_meta_missing keeper_name)
+  | Ok (Some meta) -> Ok meta
+;;
+
+let validate_source_owner request (meta : Keeper_meta_contract.keeper_meta) =
+  match
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  with
+  | Keeper_lifecycle_admission.Active -> Error Source_owner_not_paused
+  | Keeper_lifecycle_admission.Dead_tombstone -> Error Source_owner_dead_tombstone
+  | Keeper_lifecycle_admission.Paused _ ->
+    if Int.equal meta.runtime.generation request.owner_generation
+    then Ok meta
+    else
+      Error
+        (Source_owner_generation_changed
+           { expected = request.owner_generation; actual = meta.runtime.generation })
+;;
+
+let validate_target_owner request (meta : Keeper_meta_contract.keeper_meta) =
+  if not (Int.equal meta.runtime.generation request.target_generation)
+  then
+    Error
+      (Target_owner_generation_changed
+         { expected = request.target_generation; actual = meta.runtime.generation })
+  else
+    match
+      Keeper_lifecycle_admission.state
+        ~paused:meta.paused
+        ~latched_reason:meta.latched_reason
+    with
+    | Keeper_lifecycle_admission.Active -> Ok meta
+    | Keeper_lifecycle_admission.Paused _
+    | Keeper_lifecycle_admission.Dead_tombstone -> Error Target_owner_not_active
+;;
+
+let validate_source_queue config ~from_keeper request =
+  let* state =
+    Keeper_event_queue_persistence.load_state_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:from_keeper
+    |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
+  in
+  if not (Int64.equal (Keeper_event_queue_state.revision state) request.source_revision)
+  then Error (Source_queue_validation_failed "source revision changed")
+  else if Keeper_event_queue_state.leases state <> []
+  then Error (Source_queue_validation_failed "source lane has an active lease")
+  else if Keeper_event_queue_state.transition_outbox state <> []
+  then Error (Source_queue_validation_failed "source lane has a pending transition outbox")
+  else
+    let matching =
+      Keeper_event_queue.to_list (Keeper_event_queue_state.pending state)
+      |> List.filter (fun source ->
+        Keeper_event_queue.stimulus_identity_equal request.source source)
+    in
+    match matching with
+    | [ source ] when source = request.source -> Ok ()
+    | [ _ ] -> Error (Source_queue_validation_failed "source snapshot changed")
+    | [] -> Error (Source_queue_validation_failed "source is not pending")
+    | _ :: _ :: _ ->
+      Error (Source_queue_validation_failed "source identity is duplicated")
+;;
+
+let transfer_of_receipt receipt =
+  match receipt.Keeper_paused_work_disposition_receipt.operation with
+  | Keeper_paused_work_disposition_receipt.Transfer_owner transfer -> Ok transfer
+  | Keeper_paused_work_disposition_receipt.Resume_owner ->
+    Error (Receipt_conflict receipt)
+;;
+
+let receipt_matches_request ~from_keeper ~to_keeper request receipt =
+  match transfer_of_receipt receipt with
+  | Error _ -> false
+  | Ok transfer ->
+    String.equal receipt.keeper_name from_keeper
+    && Int.equal receipt.expected_generation request.owner_generation
+    && String.equal receipt.operator_operation_id request.operator_operation_id
+    && String.equal transfer.from_keeper from_keeper
+    && String.equal transfer.to_keeper to_keeper
+    && Int.equal transfer.target_generation request.target_generation
+    && transfer.source = request.source
+    && Int64.equal transfer.source_revision request.source_revision
+    && Float.equal transfer.settled_at request.settled_at
+    && transfer.continuation_binding = request.continuation_binding
+;;
+
+let create_receipt config ~from_keeper ~to_keeper request =
+  let* source_meta = read_meta config from_keeper in
+  let* source_meta = validate_source_owner request source_meta in
+  let* target_meta = read_meta config to_keeper in
+  let* target_meta = validate_target_owner request target_meta in
+  let* () = validate_source_queue config ~from_keeper request in
+  let transfer : Keeper_paused_work_disposition_receipt.transfer_owner =
+    { from_keeper
+    ; to_keeper
+    ; target_trace_id = target_meta.runtime.trace_id
+    ; target_generation = request.target_generation
+    ; source = request.source
+    ; source_revision = request.source_revision
+    ; settled_at = request.settled_at
+    ; continuation_binding = request.continuation_binding
+    }
+  in
+  Ok
+    ({ keeper_name = from_keeper
+     ; expected_trace_id = source_meta.runtime.trace_id
+     ; expected_generation = request.owner_generation
+     ; operator_operation_id = request.operator_operation_id
+     ; requested_at = Time_compat.now ()
+     ; operation = Keeper_paused_work_disposition_receipt.Transfer_owner transfer
+     }
+     : Keeper_paused_work_disposition_receipt.t)
+;;
+
+let source_settlement config receipt transfer =
+  let causal : Keeper_registry_event_queue.accepted_transfer =
+    { source = transfer.Keeper_paused_work_disposition_receipt.source
+    ; source_revision = transfer.source_revision
+    ; owner_generation = receipt.Keeper_paused_work_disposition_receipt.expected_generation
+    ; operator_operation_id = receipt.operator_operation_id
+    ; from_keeper = transfer.from_keeper
+    ; to_keeper = transfer.to_keeper
+    }
+  in
+  let base_path = config.Workspace.base_path in
+  let* source_state =
+    Keeper_event_queue_persistence.load_state_result
+      ~base_path
+      ~keeper_name:transfer.from_keeper
+    |> Result.map_error (fun detail ->
+      Committed_projection_failed { stage = Source_settlement; detail })
+  in
+  let* prior =
+    Keeper_event_queue_state.accepted_pending_transfer_replay causal source_state
+    |> Result.map_error (fun detail ->
+      Committed_projection_failed { stage = Source_settlement; detail })
+  in
+  match prior with
+  | Some prior -> Ok (Keeper_registry_event_queue.Already_settled prior)
+  | None ->
+    let* current = read_meta config transfer.from_keeper in
+    let* () =
+      if not (Int.equal current.runtime.generation receipt.expected_generation)
+      then
+        Error
+          (Source_owner_generation_changed
+             { expected = receipt.expected_generation
+             ; actual = current.runtime.generation
+             })
+      else if not (Keeper_id.Trace_id.equal current.runtime.trace_id receipt.expected_trace_id)
+      then Error Source_owner_identity_changed
+      else Ok ()
+    in
+    Keeper_registry_event_queue.transfer_pending_accepted_result
+      ~base_path
+      transfer.from_keeper
+      ~current_owner_generation:current.runtime.generation
+      ~settled_at:transfer.settled_at
+      ~transfer:causal
+    |> Result.map_error (fun detail ->
+      Committed_projection_failed { stage = Source_settlement; detail })
+;;
+
+let validate_committed_target config transfer =
+  let* meta = read_meta config transfer.Keeper_paused_work_disposition_receipt.to_keeper in
+  if not (Int.equal meta.runtime.generation transfer.target_generation)
+  then
+    Error
+      (Target_owner_generation_changed
+         { expected = transfer.target_generation; actual = meta.runtime.generation })
+  else if not (Keeper_id.Trace_id.equal meta.runtime.trace_id transfer.target_trace_id)
+  then
+    Error
+      (Committed_projection_failed
+         { stage = Target_enqueue; detail = "target trace identity changed" })
+  else Ok ()
+;;
+
+let target_enqueue config transfer =
+  let* () = validate_committed_target config transfer in
+  match
+    Keeper_registry_event_queue.enqueue_exact_stimulus_durable_result
+      ~base_path:config.Workspace.base_path
+      transfer.Keeper_paused_work_disposition_receipt.to_keeper
+      transfer.source
+  with
+  | Keeper_registry_event_queue.Stimulus_enqueued -> Ok Enqueued
+  | Keeper_registry_event_queue.Stimulus_already_present -> Ok Already_present
+  | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+    Error (Committed_projection_failed { stage = Target_enqueue; detail })
+;;
+
+let project_receipt config receipt =
+  let* transfer = transfer_of_receipt receipt in
+  let* source_settlement = source_settlement config receipt transfer in
+  let* target_projection = target_enqueue config transfer in
+  Ok { source_settlement; target_projection }
+;;
+
+let run_owned receipt_lock config ~from_keeper ~to_keeper request =
+  let* existing =
+    Keeper_paused_work_disposition_receipt.load
+      config
+      ~keeper_name:from_keeper
+      ~operator_operation_id:request.operator_operation_id
+    |> Result.map_error (fun detail -> Receipt_read_failed detail)
+  in
+  let* receipt, commit_status =
+    match existing with
+    | Some receipt
+      when receipt_matches_request ~from_keeper ~to_keeper request receipt ->
+      Ok (receipt, Already_committed)
+    | Some receipt -> Error (Receipt_conflict receipt)
+    | None ->
+      let* receipt = create_receipt config ~from_keeper ~to_keeper request in
+      (match
+         Keeper_paused_work_disposition_receipt.save_if_absent
+           receipt_lock
+           config
+           receipt
+       with
+       | Error detail -> Error (Receipt_write_failed detail)
+       | Ok Keeper_paused_work_disposition_receipt.Created ->
+         Ok (receipt, Committed)
+       | Ok (Keeper_paused_work_disposition_receipt.Existing existing)
+         when Keeper_paused_work_disposition_receipt.equal existing receipt ->
+         Ok (existing, Already_committed)
+       | Ok (Keeper_paused_work_disposition_receipt.Existing existing) ->
+         Error (Receipt_conflict existing))
+  in
+  let projection =
+    match project_receipt config receipt with
+    | Ok applied -> Applied applied
+    | Error failure -> Committed_followup_failed failure
+  in
+  Ok (receipt, commit_status, projection)
+;;
+
+let transfer_pending config ~from_keeper ~to_keeper request =
+  match validate_request ~from_keeper ~to_keeper request with
+  | Error detail ->
+    Error { cause = Invalid_request detail; reservation_release = None }
+  | Ok () ->
+    (match
+       Keeper_lifecycle_reservation.acquire
+         ~base_path:config.Workspace.base_path
+         ~keeper_name:from_keeper
+         ~expected_generation:request.owner_generation
+         ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+     with
+     | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+       Error
+         { cause = Reservation_conflict owner; reservation_release = None }
+     | Ok token ->
+       (try
+          let outcome =
+            match
+              Keeper_paused_work_disposition_receipt.with_keeper_lock
+                config
+                ~keeper_name:from_keeper
+                (fun receipt_lock ->
+                   run_owned receipt_lock config ~from_keeper ~to_keeper request)
+            with
+            | Error detail -> Error (Receipt_lock_failed detail)
+            | Ok outcome -> outcome
+          in
+          let reservation_release = Keeper_lifecycle_reservation.release token in
+          (match outcome with
+           | Ok (receipt, commit_status, projection) ->
+             Ok { receipt; commit_status; projection; reservation_release }
+           | Error cause ->
+             Error { cause; reservation_release = Some reservation_release })
+        with
+        | exn ->
+          ignore (Keeper_lifecycle_reservation.release token : _);
+          raise exn))
+;;

--- a/lib/keeper/keeper_paused_work_transfer_transaction.mli
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.mli
@@ -1,0 +1,86 @@
+(** Receipt-first transfer of one exact pending event from a paused Keeper. *)
+
+type request =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; target_generation : int
+  ; continuation_binding : Keeper_paused_work_disposition_receipt.continuation_binding
+  ; operator_operation_id : string
+  ; settled_at : float
+  }
+
+type projection_stage =
+  | Source_settlement
+  | Target_enqueue
+
+type failure =
+  | Invalid_request of string
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Receipt_lock_failed of string
+  | Receipt_read_failed of string
+  | Receipt_conflict of Keeper_paused_work_disposition_receipt.t
+  | Receipt_write_failed of string
+  | Durable_meta_read_failed of
+      { keeper_name : string
+      ; detail : string
+      }
+  | Durable_meta_missing of string
+  | Source_owner_not_paused
+  | Source_owner_dead_tombstone
+  | Source_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Source_owner_identity_changed
+  | Target_owner_not_active
+  | Target_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Continuation_binding_mismatch
+  | Source_queue_validation_failed of string
+  | Committed_projection_failed of
+      { stage : projection_stage
+      ; detail : string
+      }
+
+type error =
+  { cause : failure
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
+  }
+
+type commit_status =
+  | Committed
+  | Already_committed
+
+type target_projection =
+  | Enqueued
+  | Already_present
+
+type projection =
+  | Applied of
+      { source_settlement : Keeper_registry_event_queue.settle_result
+      ; target_projection : target_projection
+      }
+  | Committed_followup_failed of failure
+
+type success =
+  { receipt : Keeper_paused_work_disposition_receipt.t
+  ; commit_status : commit_status
+  ; projection : projection
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+val error_to_string : error -> string
+
+val transfer_pending :
+  Workspace.config ->
+  from_keeper:string ->
+  to_keeper:string ->
+  request ->
+  (success, error) result
+(** Persist a typed [Transfer_owner] receipt before terminally settling the
+    exact source event, then enqueue that receipt's original stimulus on the
+    target lane. Replaying the same receipt completes either interrupted
+    projection without duplicating the target event. *)

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -299,6 +299,7 @@ let reaction_kind_of_settlement = function
   | Keeper_event_queue_state.Ack -> Event_queue_ack
   | Keeper_event_queue_state.No_compaction _ -> Event_queue_no_compaction
   | Keeper_event_queue_state.Cancel_accepted _ -> Event_queue_cancelled
+  | Keeper_event_queue_state.Transfer_accepted _ -> Event_queue_ack
   | Keeper_event_queue_state.Requeue _ -> Event_queue_requeued
   | Keeper_event_queue_state.Escalate _ -> Event_queue_escalated
 ;;
@@ -671,6 +672,7 @@ let require_finite_float ~missing ~non_finite field json =
 let reaction_kind_matches_settlement reaction_kind settlement =
   match reaction_kind, settlement with
   | Event_queue_ack, Keeper_event_queue_state.Ack -> true
+  | Event_queue_ack, Keeper_event_queue_state.Transfer_accepted _ -> true
   | Event_queue_no_compaction, Keeper_event_queue_state.No_compaction _ -> true
   | Event_queue_cancelled, Keeper_event_queue_state.Cancel_accepted _ -> true
   | Event_queue_requeued, Keeper_event_queue_state.Requeue _ -> true
@@ -685,22 +687,26 @@ let reaction_kind_matches_settlement reaction_kind settlement =
   | Event_queue_no_compaction,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.Cancel_accepted _
+    | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_cancelled,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
+    | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_requeued,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
+    | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_escalated,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
+    | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Requeue _ ) -> false
 ;;
 
@@ -1411,6 +1417,7 @@ let summarize_rows ~keeper_name ~limit rows =
        | Keeper_event_queue_state.Ack
        | Keeper_event_queue_state.No_compaction _
        | Keeper_event_queue_state.Cancel_accepted _
+       | Keeper_event_queue_state.Transfer_accepted _
        | Keeper_event_queue_state.Requeue _ -> ())
     | Cursor_ack, None -> incr cursor_ack_count
     | Turn_started, Some _

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -48,10 +48,20 @@ type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellatio
   ; reason : string
   }
 
+type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; from_keeper : string
+  ; to_keeper : string
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
+  | Transfer_accepted of accepted_transfer
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -291,6 +301,19 @@ let enqueue_stimulus_durable_result ~base_path name stimulus =
   | Error detail -> Stimulus_storage_error detail
 ;;
 
+let enqueue_exact_stimulus_durable_result ~base_path name stimulus =
+  match
+    Keeper_event_queue_persistence.enqueue_exact_stimulus_if_absent_result
+      ~base_path
+      ~keeper_name:name
+      ~after_commit:(publish_pending ~base_path name)
+      stimulus
+  with
+  | Ok Keeper_event_queue_persistence.Enqueued -> Stimulus_enqueued
+  | Ok Keeper_event_queue_persistence.Already_present -> Stimulus_already_present
+  | Error detail -> Stimulus_storage_error detail
+;;
+
 let enqueue_hitl_resolution_durable_result
     ~base_path
     ~keeper_name
@@ -404,6 +427,23 @@ let cancel_pending_accepted_result
     ~current_owner_generation
     ~settled_at
     ~cancellation
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;
+
+let transfer_pending_accepted_result
+      ~base_path
+      name
+      ~current_owner_generation
+      ~settled_at
+      ~transfer
+  =
+  Keeper_event_queue_persistence.transfer_pending_accepted_result
+    ~base_path
+    ~keeper_name:name
+    ~current_owner_generation
+    ~settled_at
+    ~transfer
     ~after_commit:(publish_pending ~base_path name)
     ()
 ;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -47,10 +47,20 @@ type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellatio
   ; reason : string
   }
 
+type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; from_keeper : string
+  ; to_keeper : string
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
+  | Transfer_accepted of accepted_transfer
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -120,6 +130,16 @@ val cancel_pending_accepted_result :
 (** Commit an exact pending accepted cancellation and publish the post-commit
     pending projection when the owner currently has a live registry lane. *)
 
+val transfer_pending_accepted_result :
+  base_path:string ->
+  string ->
+  current_owner_generation:int ->
+  settled_at:float ->
+  transfer:accepted_transfer ->
+  (settle_result, string) result
+(** Commit an exact pending accepted transfer settlement and publish the
+    post-commit source pending projection when the owner is registered. *)
+
 (** Enqueue a stimulus on the keeper's event queue. When the keeper is not
     registered yet, persist the stimulus to the durable snapshot so later
     registration can replay it instead of dropping the wake at the
@@ -171,6 +191,14 @@ val enqueue_stimulus_durable_result :
     path is for structurally addressed signals whose delivery must commit
     before a wake hint. Board-attention judgments use the stricter
     opaque-event-id API above. *)
+
+val enqueue_exact_stimulus_durable_result :
+  base_path:string
+  -> string
+  -> Keeper_event_queue.stimulus
+  -> enqueue_stimulus_durable_result
+(** Strict transfer projection: replay succeeds only for the exact full source
+    snapshot. Same identity with changed arrival/payload is a storage conflict. *)
 
 val enqueue_hitl_resolution_durable_result :
   base_path:string

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -45,10 +45,20 @@ type accepted_cancellation = State.accepted_cancellation =
   ; reason : string
   }
 
+type accepted_transfer = State.accepted_transfer =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; from_keeper : string
+  ; to_keeper : string
+  }
+
 type settlement = State.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
+  | Transfer_accepted of accepted_transfer
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -626,6 +636,35 @@ let enqueue_stimulus_if_absent_result
       Ok (State.with_pending pending state, Enqueued))
 ;;
 
+let accounted_stimuli state =
+  Keeper_event_queue.to_list (State.pending state)
+  @ List.concat_map (fun (lease : lease) -> lease.stimuli) (State.leases state)
+  @ List.concat_map
+      (fun (entry : outbox_entry) -> entry.stimuli)
+      (State.transition_outbox state)
+;;
+
+let enqueue_exact_stimulus_if_absent_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      stimulus
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    let matching =
+      accounted_stimuli state
+      |> List.filter (fun candidate ->
+        Keeper_event_queue.stimulus_identity_equal candidate stimulus)
+    in
+    match matching with
+    | [] ->
+      let pending = Keeper_event_queue.enqueue (State.pending state) stimulus in
+      Ok (State.with_pending pending state, Enqueued)
+    | [ existing ] when existing = stimulus -> Ok (state, Already_present)
+    | [ _ ] -> Error "exact stimulus identity exists with a different source snapshot"
+    | _ :: _ :: _ -> Error "exact stimulus identity is duplicated in durable target state")
+;;
+
 let update_result ?after_commit ~base_path ~keeper_name f =
   update_checked_result ?after_commit ~base_path ~keeper_name (fun queue -> Ok (f queue))
 ;;
@@ -838,6 +877,42 @@ let cancel_pending_accepted_result
        Error
          (Printf.sprintf
             "event queue pending accepted cancellation raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let transfer_pending_accepted_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~current_owner_generation
+      ~settled_at
+      ~transfer
+      ()
+  =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           commit_settlement_transition_unlocked
+             owner
+             ~after_commit
+             (State.transfer_pending_accepted
+                ~current_owner_generation
+                ~settled_at
+                ~transfer)
+             state
+           |> Result.map fst)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue pending accepted transfer raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -49,10 +49,20 @@ type accepted_cancellation = Keeper_event_queue_state.accepted_cancellation =
   ; reason : string
   }
 
+type accepted_transfer = Keeper_event_queue_state.accepted_transfer =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; from_keeper : string
+  ; to_keeper : string
+  }
+
 type settlement = Keeper_event_queue_state.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
+  | Transfer_accepted of accepted_transfer
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -201,6 +211,18 @@ val cancel_pending_accepted_result :
     checkpointing removal of the exact pending source. WAL replay can complete
     the transition from the pre-removal state after a crash. *)
 
+val transfer_pending_accepted_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  current_owner_generation:int ->
+  settled_at:float ->
+  transfer:accepted_transfer ->
+  unit ->
+  (settle_result, string) result
+(** Append and fsync the canonical source-bearing transfer settlement before
+    checkpointing removal of the exact pending source. *)
+
 val prepare_registration_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
@@ -252,6 +274,16 @@ val enqueue_stimulus_if_absent_result :
   (enqueue_stimulus_result, string) result
 (** Atomically enqueue only when the same typed stimulus is absent from the
     full durable state: pending, active leases, and transition outbox. *)
+
+val enqueue_exact_stimulus_if_absent_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  Keeper_event_queue.stimulus ->
+  (enqueue_stimulus_result, string) result
+(** Transfer-only strict variant: an existing identity is idempotent only when
+    the full source snapshot, including [arrived_at], is structurally equal.
+    A changed snapshot or duplicate accounted identity is a conflict. *)
 
 val persist_snapshot :
   base_path:string -> keeper_name:string -> (unit -> Keeper_event_queue.t) -> unit

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -42,6 +42,15 @@ type accepted_cancellation =
   ; reason : string
   }
 
+type accepted_transfer =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; from_keeper : string
+  ; to_keeper : string
+  }
+
 let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
@@ -52,6 +61,7 @@ type settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
+  | Transfer_accepted of accepted_transfer
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -376,6 +386,7 @@ let settlement_kind_label = function
   | Ack -> "ack"
   | No_compaction _ -> "no_compaction"
   | Cancel_accepted _ -> "cancel_accepted"
+  | Transfer_accepted _ -> "transfer_accepted"
   | Requeue _ -> "requeue"
   | Escalate _ -> "escalate"
 ;;
@@ -403,16 +414,18 @@ let settlement_equal left right =
     Keeper_checkpoint_ref.equal left.source right.source
     && left.reason = right.reason
   | Cancel_accepted left, Cancel_accepted right -> left = right
+  | Transfer_accepted left, Transfer_accepted right -> left = right
   | Requeue left, Requeue right -> left = right
   | ( Escalate { reason = left_reason; successor = left_successor }
     , Escalate { reason = right_reason; successor = right_successor } ) ->
     left_reason = right_reason
     && successor_equal left_successor right_successor
-  | Ack, (No_compaction _ | Cancel_accepted _ | Requeue _ | Escalate _)
-  | No_compaction _, (Ack | Cancel_accepted _ | Requeue _ | Escalate _)
-  | Cancel_accepted _, (Ack | No_compaction _ | Requeue _ | Escalate _)
-  | Requeue _, (Ack | No_compaction _ | Cancel_accepted _ | Escalate _)
-  | Escalate _, (Ack | No_compaction _ | Cancel_accepted _ | Requeue _) ->
+  | Ack, (No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Requeue _ | Escalate _)
+  | No_compaction _, (Ack | Cancel_accepted _ | Transfer_accepted _ | Requeue _ | Escalate _)
+  | Cancel_accepted _, (Ack | No_compaction _ | Transfer_accepted _ | Requeue _ | Escalate _)
+  | Transfer_accepted _, (Ack | No_compaction _ | Cancel_accepted _ | Requeue _ | Escalate _)
+  | Requeue _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Escalate _)
+  | Escalate _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Requeue _) ->
     false
 ;;
 
@@ -439,9 +452,28 @@ let validate_accepted_cancellation cancellation =
   else Ok ()
 ;;
 
+let validate_accepted_transfer transfer =
+  if String.equal (String.trim transfer.source.post_id) ""
+  then Error "accepted transfer source post id must not be empty"
+  else if Int64.compare transfer.source_revision 0L < 0
+  then Error "accepted transfer source revision must not be negative"
+  else if transfer.owner_generation < 0
+  then Error "accepted transfer owner generation must not be negative"
+  else if String.equal (String.trim transfer.operator_operation_id) ""
+  then Error "accepted transfer operator operation id must not be empty"
+  else if String.equal (String.trim transfer.from_keeper) ""
+  then Error "accepted transfer source Keeper must not be empty"
+  else if String.equal (String.trim transfer.to_keeper) ""
+  then Error "accepted transfer target Keeper must not be empty"
+  else if String.equal transfer.from_keeper transfer.to_keeper
+  then Error "accepted transfer source and target Keepers must differ"
+  else Ok ()
+;;
+
 let validate_settlement = function
   | Ack | No_compaction _ | Requeue _ -> Ok ()
   | Cancel_accepted cancellation -> validate_accepted_cancellation cancellation
+  | Transfer_accepted transfer -> validate_accepted_transfer transfer
   | Escalate
       { reason = Failure_judgment_requested
       ; successor =
@@ -508,6 +540,11 @@ let validate_settlement_for_stimuli settlement stimuli =
     Error "accepted cancellation source does not match its exact event stimulus"
   | Cancel_accepted _, _ ->
     Error "accepted cancellation requires exactly one accepted event stimulus"
+  | Transfer_accepted transfer, [ source ] when transfer.source = source -> Ok ()
+  | Transfer_accepted _, [ _ ] ->
+    Error "accepted transfer source does not match its exact event stimulus"
+  | Transfer_accepted _, _ ->
+    Error "accepted transfer requires exactly one accepted event stimulus"
   | (Ack | Requeue _ | Escalate _), _ -> Ok ()
 ;;
 
@@ -582,7 +619,7 @@ let settle_committed ~settled_at ~lease ~settlement state =
     let* () = validate_settlement_for_lease settlement committed in
     let pending =
       match settlement with
-      | Ack | No_compaction _ | Cancel_accepted _ -> state.pending
+      | Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ -> state.pending
       | Requeue
           ( Retry_after_observed
           | Context_compaction_retry
@@ -614,8 +651,8 @@ let settle_committed ~settled_at ~lease ~settlement state =
 
 let settle ~settled_at ~lease ~settlement state =
   match settlement with
-  | Cancel_accepted _ ->
-    Error "accepted cancellation requires the owner-fenced cancellation boundary"
+  | Cancel_accepted _ | Transfer_accepted _ ->
+    Error "accepted disposition requires its owner-fenced boundary"
   | Ack | No_compaction _ | Requeue _ | Escalate _ ->
     settle_committed ~settled_at ~lease ~settlement state
 ;;
@@ -660,7 +697,7 @@ let prior_cancellation_by_operation_id operation_id state =
     match receipt.settlement with
     | Cancel_accepted cancellation ->
       String.equal cancellation.operator_operation_id operation_id
-    | Ack | No_compaction _ | Requeue _ | Escalate _ -> false
+    | Ack | No_compaction _ | Transfer_accepted _ | Requeue _ | Escalate _ -> false
   in
   match state.transition_outbox with
   | [ entry ] when is_same_operation entry.receipt -> Some entry.receipt
@@ -748,6 +785,100 @@ let cancel_pending_accepted
          match lease with
          | Some lease -> Ok lease
          | None -> Error "accepted cancellation did not create its synthetic lease"
+       in
+       settle_committed ~settled_at ~lease ~settlement claimed)
+;;
+
+let prior_transfer_by_operation_id operation_id state =
+  let is_same_operation receipt =
+    match receipt.settlement with
+    | Transfer_accepted transfer ->
+      String.equal transfer.operator_operation_id operation_id
+    | Ack | No_compaction _ | Cancel_accepted _ | Requeue _ | Escalate _ -> false
+  in
+  match state.transition_outbox with
+  | [ entry ] when is_same_operation entry.receipt -> Some entry.receipt
+  | [] | [ _ ] ->
+    (match state.last_settlement with
+     | Some receipt when is_same_operation receipt -> Some receipt
+     | Some _ | None -> None)
+  | _ :: _ :: _ -> None
+;;
+
+let accepted_pending_transfer_replay transfer state =
+  let requested = Transfer_accepted transfer in
+  match prior_transfer_by_operation_id transfer.operator_operation_id state with
+  | None -> Ok None
+  | Some receipt when settlement_equal receipt.settlement requested ->
+    Ok (Some receipt)
+  | Some _ ->
+    Error
+      (Printf.sprintf
+         "accepted transfer operation conflict: %s"
+         transfer.operator_operation_id)
+;;
+
+let transfer_pending_accepted
+      ~current_owner_generation
+      ~settled_at
+      ~transfer
+      state
+  =
+  let settlement = Transfer_accepted transfer in
+  match accepted_pending_transfer_replay transfer state with
+  | Error _ as error -> error
+  | Ok (Some receipt) -> Ok (state, Already_settled receipt)
+  | Ok None ->
+    let* () = validate_accepted_transfer transfer in
+    let* () =
+      if Int.equal current_owner_generation transfer.owner_generation
+      then Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "accepted transfer owner generation changed: expected %d, current %d"
+             transfer.owner_generation
+             current_owner_generation)
+    in
+    let* () =
+      if Int64.equal state.revision transfer.source_revision
+      then Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "accepted transfer source revision changed: expected %Ld, current %Ld"
+             transfer.source_revision
+             state.revision)
+    in
+    let* () =
+      if lease_admission_blocked state
+      then Error "event queue cannot transfer pending work while a lease or outbox exists"
+      else Ok ()
+    in
+    let matching, retained =
+      Keeper_event_queue.to_list state.pending
+      |> List.partition (fun source ->
+        Keeper_event_queue.stimulus_identity_equal transfer.source source)
+    in
+    (match matching with
+     | [] -> Error "accepted transfer source is not pending"
+     | _ :: _ :: _ -> Error "accepted transfer source identity is duplicated"
+     | [ source ] when source <> transfer.source ->
+       Error "accepted transfer source snapshot changed"
+     | [ source ] ->
+       let pending =
+         List.fold_left
+           Keeper_event_queue.enqueue
+           Keeper_event_queue.empty
+           retained
+       in
+       let* claimed, lease =
+         make_lease ~kind:Single ~claimed_at:None [ source ] { state with pending }
+       in
+       let* lease =
+         match lease with
+         | Some lease -> Ok lease
+         | None -> Error "accepted transfer did not create its synthetic lease"
        in
        settle_committed ~settled_at ~lease ~settlement claimed)
 ;;
@@ -869,6 +1000,40 @@ let replay_transition_outbox_entry entry state =
              Error "pending cancellation WAL source conflicts with its receipt"
            | Cancel_accepted _, ([] | _ :: _ :: _) ->
              Error "pending cancellation WAL must carry exactly one source"
+           | Transfer_accepted transfer, [ source ] when source = transfer.source ->
+             if not (Int64.equal state.next_lease_sequence entry.receipt.lease_sequence)
+             then
+               Error
+                 (Printf.sprintf
+                    "pending transfer WAL lease sequence changed: expected %Ld, current %Ld"
+                    entry.receipt.lease_sequence
+                    state.next_lease_sequence)
+             else
+               let* replayed, result =
+                 transfer_pending_accepted
+                   ~current_owner_generation:transfer.owner_generation
+                   ~settled_at:entry.receipt.settled_at
+                   ~transfer
+                   state
+               in
+               let actual_receipt =
+                 match result with
+                 | Settled receipt | Already_settled receipt -> receipt
+               in
+               (match replayed.transition_outbox with
+                | [ actual ]
+                  when transition_receipt_equal entry.receipt actual_receipt
+                       && actual = entry ->
+                  Ok replayed
+                | [] | [ _ ] | _ :: _ :: _ ->
+                  Error
+                    (Printf.sprintf
+                       "pending transfer WAL replay conflict: %s"
+                       entry.receipt.transition_id))
+           | Transfer_accepted _, [ _ ] ->
+             Error "pending transfer WAL source conflicts with its receipt"
+           | Transfer_accepted _, ([] | _ :: _ :: _) ->
+             Error "pending transfer WAL must carry exactly one source"
            | (Ack | No_compaction _ | Requeue _ | Escalate _), _ ->
              Error
                (Printf.sprintf
@@ -1123,6 +1288,16 @@ let settlement_to_yojson = function
       ; "operator_operation_id", `String cancellation.operator_operation_id
       ; "reason", `String cancellation.reason
       ]
+  | Transfer_accepted transfer ->
+    `Assoc
+      [ "kind", `String "transfer_accepted"
+      ; "source", Keeper_event_queue.stimulus_to_yojson transfer.source
+      ; "source_revision", int64_json transfer.source_revision
+      ; "owner_generation", `Int transfer.owner_generation
+      ; "operator_operation_id", `String transfer.operator_operation_id
+      ; "from_keeper", `String transfer.from_keeper
+      ; "to_keeper", `String transfer.to_keeper
+      ]
   | Requeue reason ->
     `Assoc
       [ "kind", `String "requeue"
@@ -1184,6 +1359,41 @@ let settlement_of_yojson json =
     in
     let* () = validate_accepted_cancellation cancellation in
     Ok (Cancel_accepted cancellation)
+  | "transfer_accepted" ->
+    let* () =
+      exact_fields
+        ~context
+        ~expected:
+          [ "kind"
+          ; "source"
+          ; "source_revision"
+          ; "owner_generation"
+          ; "operator_operation_id"
+          ; "from_keeper"
+          ; "to_keeper"
+          ]
+        fields
+    in
+    let* source_json = required_field ~context "source" fields in
+    let* source = Keeper_event_queue.stimulus_of_yojson source_json in
+    let* source_revision = int64_field ~context "source_revision" fields in
+    let* owner_generation = int_field ~context "owner_generation" fields in
+    let* operator_operation_id =
+      string_field ~context "operator_operation_id" fields
+    in
+    let* from_keeper = string_field ~context "from_keeper" fields in
+    let* to_keeper = string_field ~context "to_keeper" fields in
+    let transfer =
+      { source
+      ; source_revision
+      ; owner_generation
+      ; operator_operation_id
+      ; from_keeper
+      ; to_keeper
+      }
+    in
+    let* () = validate_accepted_transfer transfer in
+    Ok (Transfer_accepted transfer)
   | "requeue" ->
     let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -438,7 +438,7 @@ let transition_receipt_equal left right =
   && left.settlement = right.settlement
 ;;
 
-let validate_accepted_cancellation cancellation =
+let validate_accepted_cancellation (cancellation : accepted_cancellation) =
   if String.equal (String.trim cancellation.source.post_id) ""
   then Error "accepted cancellation source post id must not be empty"
   else if Int64.compare cancellation.source_revision 0L < 0

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -52,6 +52,19 @@ type accepted_cancellation =
     [source_revision] and [owner_generation] fence the observed paused owner;
     [operator_operation_id] makes replay/conflict explicit. *)
 
+type accepted_transfer =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; from_keeper : string
+  ; to_keeper : string
+  }
+(** Exact causal authority for terminally transferring one accepted event.
+    The durable disposition receipt retains the target continuation binding;
+    this settlement links the source queue terminal effect to that receipt by
+    stable operator operation ID. *)
+
 val no_compaction_reason_label : no_compaction_reason -> string
 val no_compaction_reason_of_label : string -> (no_compaction_reason, string) result
 
@@ -64,6 +77,7 @@ type settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
+  | Transfer_accepted of accepted_transfer
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -169,6 +183,17 @@ val cancel_pending_accepted :
     generation are checked before removal. This pure transition is committed
     through a source-bearing WAL outbox entry by persistence. *)
 
+val transfer_pending_accepted :
+  current_owner_generation:int ->
+  settled_at:float ->
+  transfer:accepted_transfer ->
+  t ->
+  (t * settle_result, string) result
+(** Atomically create and terminally settle a synthetic single-event lease for
+    the exact pending transfer source. The source revision and owner generation
+    are checked before removal, and the source-bearing WAL remains the replay
+    authority until the target projection completes. *)
+
 val accepted_cancellation_replay :
   lease ->
   accepted_cancellation ->
@@ -183,6 +208,13 @@ val accepted_pending_cancellation_replay :
   t ->
   (transition_receipt option, string) result
 (** Look up an already committed pending cancellation by its stable operator
+    operation ID and exact source-bearing settlement. *)
+
+val accepted_pending_transfer_replay :
+  accepted_transfer ->
+  t ->
+  (transition_receipt option, string) result
+(** Look up an already committed pending transfer by its stable operator
     operation ID and exact source-bearing settlement. *)
 
 val replay_transition_receipt : transition_receipt -> t -> (t, string) result

--- a/test/dune
+++ b/test/dune
@@ -673,6 +673,11 @@
  (libraries alcotest masc_test_deps eio_main))
 
 (test
+ (name test_keeper_paused_work_transfer_transaction)
+ (modules test_keeper_paused_work_transfer_transaction)
+ (libraries alcotest masc_test_deps eio_main))
+
+(test
  (name test_keeper_current_operations)
  (modules test_keeper_current_operations)
  (libraries alcotest masc_test_deps))

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -60,7 +60,7 @@ let with_transfer_lane f =
   let base_path = Filename.temp_dir "keeper-paused-transfer-transaction" "" in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       remove_tree base_path)
     (fun () ->
        let config = Workspace.default_config base_path in
@@ -232,13 +232,15 @@ let test_replay_after_source_settlement_projects_target () =
       ; to_keeper
       }
     in
-    Keeper_registry_event_queue.transfer_pending_accepted_result
-      ~base_path:config.Workspace.base_path
-      from_keeper
-      ~current_owner_generation:request.owner_generation
-      ~settled_at:request.settled_at
-      ~transfer:causal
-    |> require_ok "simulate committed source settlement";
+    (* fire-and-forget: the settlement value is only a fixture precondition here. *)
+    ignore
+      (Keeper_registry_event_queue.transfer_pending_accepted_result
+         ~base_path:config.Workspace.base_path
+         from_keeper
+         ~current_owner_generation:request.owner_generation
+         ~settled_at:request.settled_at
+         ~transfer:causal
+       |> require_ok "simulate committed source settlement");
     let replay =
       Transaction.transfer_pending config ~from_keeper ~to_keeper request
       |> Result.map_error Transaction.error_to_string

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -1,0 +1,308 @@
+open Masc
+
+module Queue = Keeper_event_queue
+module State = Keeper_event_queue_state
+module Persistence = Keeper_event_queue_persistence
+module Receipt = Keeper_paused_work_disposition_receipt
+module Transaction = Keeper_paused_work_transfer_transaction
+
+let require_ok label = function
+  | Ok value -> value
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
+let require_some label = function
+  | Some value -> value
+  | None -> Alcotest.failf "%s: expected Some" label
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let write_meta config ~keeper_name ~trace_id ~generation ~paused =
+  let meta =
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String keeper_name
+         ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
+         ; "trace_id", `String trace_id
+         ; "runtime_id", `String "runtime.primary"
+         ; "autoboot_enabled", `Bool false
+         ])
+    |> require_ok "parse Keeper metadata fixture"
+  in
+  let meta =
+    { meta with
+      paused
+    ; latched_reason =
+        (if paused
+         then
+           Some
+             (Keeper_latched_reason.Operator_paused
+                { operator_actor =
+                    Keeper_latched_reason.operator_actor_grpc_directive
+                })
+         else None)
+    ; runtime = { meta.runtime with generation }
+    }
+  in
+  Keeper_meta_store.write_meta config meta |> require_ok "persist Keeper metadata";
+  meta
+;;
+
+let with_transfer_lane f =
+  let base_path = Filename.temp_dir "keeper-paused-transfer-transaction" "" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      remove_tree base_path)
+    (fun () ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "operator"));
+       let from_keeper = "paused-transfer-source" in
+       let to_keeper = "active-transfer-target" in
+       let source_meta =
+         write_meta
+           config
+           ~keeper_name:from_keeper
+           ~trace_id:"trace-paused-transfer-source"
+           ~generation:31
+           ~paused:true
+       in
+       let target_meta =
+         write_meta
+           config
+           ~keeper_name:to_keeper
+           ~trace_id:"trace-active-transfer-target"
+           ~generation:41
+           ~paused:false
+       in
+       let channel =
+         Keeper_continuation_channel.slack
+           ~team_id:(Some "team-1")
+           ~channel_id:"channel-1"
+           ~thread_ts:(Some "thread-1")
+           ~user_id:"user-1"
+         |> require_ok "construct source continuation channel"
+       in
+       let resolution : Queue.hitl_resolution =
+         { approval_id = "approval-1"
+         ; decision = Queue.Hitl_approved
+         ; channel
+         }
+       in
+       let source : Queue.stimulus =
+         { post_id = Queue.hitl_resolution_post_id resolution
+         ; urgency = Queue.Immediate
+         ; arrived_at = 1.0
+         ; payload = Queue.Hitl_resolved resolution
+         }
+       in
+       Persistence.update_result ~base_path ~keeper_name:from_keeper (fun pending ->
+         Queue.enqueue pending source)
+       |> require_ok "seed transfer source";
+       let source_revision =
+         Persistence.load_state_result ~base_path ~keeper_name:from_keeper
+         |> require_ok "load transfer source revision"
+         |> State.revision
+       in
+       let request : Transaction.request =
+         { source
+         ; source_revision
+         ; owner_generation = source_meta.runtime.generation
+         ; target_generation = target_meta.runtime.generation
+         ; continuation_binding = Receipt.Routed channel
+         ; operator_operation_id = "operator-transfer-1"
+         ; settled_at = 3.0
+         }
+       in
+       f config from_keeper to_keeper source_meta target_meta request)
+;;
+
+let check_applied ~expected_target = function
+  | Transaction.Applied { source_settlement; target_projection } ->
+    (match source_settlement with
+     | Keeper_registry_event_queue.Settled _
+     | Keeper_registry_event_queue.Already_settled _ -> ()
+     | Keeper_registry_event_queue.Committed_followup_failed { detail; _ } ->
+       Alcotest.fail detail);
+    Alcotest.(check bool)
+      "target projection status"
+      true
+      (target_projection = expected_target)
+  | Transaction.Committed_followup_failed failure ->
+    Alcotest.fail
+      (Transaction.error_to_string
+         { cause = failure; reservation_release = None })
+;;
+
+let assert_converged config ~from_keeper ~to_keeper source =
+  let source_state =
+    Persistence.load_state_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:from_keeper
+    |> require_ok "load settled source lane"
+  in
+  Alcotest.(check int)
+    "source pending removed"
+    0
+    (Queue.length (State.pending source_state));
+  (match State.transition_outbox source_state with
+   | [ { receipt = { settlement = State.Transfer_accepted transfer; _ }; stimuli = [ retained ] } ] ->
+     Alcotest.(check bool) "terminal receipt retains source" true (retained = source);
+     Alcotest.(check string) "causal target" to_keeper transfer.to_keeper
+   | _ -> Alcotest.fail "source transfer settlement outbox is not exact");
+  let target_state =
+    Persistence.load_state_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:to_keeper
+    |> require_ok "load transfer target lane"
+  in
+  Alcotest.(check bool)
+    "target has the exact source once"
+    true
+    (Queue.to_list (State.pending target_state) = [ source ])
+;;
+
+let test_transfer_commits_and_replays_exactly_once () =
+  with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
+    let first =
+      Transaction.transfer_pending config ~from_keeper ~to_keeper request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "commit Transfer_owner"
+    in
+    (match first.commit_status with
+     | Transaction.Committed -> ()
+     | Transaction.Already_committed -> Alcotest.fail "first transfer was a replay");
+    check_applied ~expected_target:Transaction.Enqueued first.projection;
+    assert_converged config ~from_keeper ~to_keeper request.source;
+    let replay =
+      Transaction.transfer_pending config ~from_keeper ~to_keeper request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "replay Transfer_owner"
+    in
+    (match replay.commit_status with
+     | Transaction.Already_committed -> ()
+     | Transaction.Committed -> Alcotest.fail "transfer replay created a receipt");
+    check_applied ~expected_target:Transaction.Already_present replay.projection;
+    assert_converged config ~from_keeper ~to_keeper request.source)
+;;
+
+let test_replay_after_source_settlement_projects_target () =
+  with_transfer_lane (fun config from_keeper to_keeper source_meta target_meta request ->
+    let transfer : Receipt.transfer_owner =
+      { from_keeper
+      ; to_keeper
+      ; target_trace_id = target_meta.runtime.trace_id
+      ; target_generation = request.target_generation
+      ; source = request.source
+      ; source_revision = request.source_revision
+      ; settled_at = request.settled_at
+      ; continuation_binding = request.continuation_binding
+      }
+    in
+    let receipt : Receipt.t =
+      { keeper_name = from_keeper
+      ; expected_trace_id = source_meta.runtime.trace_id
+      ; expected_generation = request.owner_generation
+      ; operator_operation_id = request.operator_operation_id
+      ; requested_at = 2.0
+      ; operation = Receipt.Transfer_owner transfer
+      }
+    in
+    (match
+       Receipt.with_keeper_lock config ~keeper_name:from_keeper (fun lock ->
+         Receipt.save_if_absent lock config receipt)
+     with
+     | Ok (Ok Receipt.Created) -> ()
+     | Ok (Ok (Receipt.Existing _)) -> Alcotest.fail "prepared receipt already existed"
+     | Ok (Error detail) | Error detail -> Alcotest.fail detail);
+    let causal : Keeper_registry_event_queue.accepted_transfer =
+      { source = request.source
+      ; source_revision = request.source_revision
+      ; owner_generation = request.owner_generation
+      ; operator_operation_id = request.operator_operation_id
+      ; from_keeper
+      ; to_keeper
+      }
+    in
+    Keeper_registry_event_queue.transfer_pending_accepted_result
+      ~base_path:config.Workspace.base_path
+      from_keeper
+      ~current_owner_generation:request.owner_generation
+      ~settled_at:request.settled_at
+      ~transfer:causal
+    |> require_ok "simulate committed source settlement";
+    let replay =
+      Transaction.transfer_pending config ~from_keeper ~to_keeper request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "resume after source settlement"
+    in
+    (match replay.commit_status with
+     | Transaction.Already_committed -> ()
+     | Transaction.Committed -> Alcotest.fail "prepared receipt was replaced");
+    check_applied ~expected_target:Transaction.Enqueued replay.projection;
+    assert_converged config ~from_keeper ~to_keeper request.source)
+;;
+
+let test_stale_source_revision_has_no_receipt_or_target_effect () =
+  with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
+    let unrelated : Queue.stimulus =
+      { post_id = "unrelated"
+      ; urgency = Queue.Low
+      ; arrived_at = 2.0
+      ; payload = Queue.Bootstrap
+      }
+    in
+    Persistence.update_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:from_keeper
+      (fun pending -> Queue.enqueue pending unrelated)
+    |> require_ok "advance source revision";
+    (match Transaction.transfer_pending config ~from_keeper ~to_keeper request with
+     | Error { cause = Transaction.Source_queue_validation_failed _; _ } -> ()
+     | Error error -> Alcotest.fail (Transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "stale source revision committed transfer");
+    (match
+       Receipt.load
+         config
+         ~keeper_name:from_keeper
+         ~operator_operation_id:request.operator_operation_id
+     with
+     | Ok None -> ()
+     | Ok (Some _) -> Alcotest.fail "stale transfer persisted an operation receipt"
+     | Error detail -> Alcotest.fail detail);
+    let target =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name:to_keeper
+      |> require_ok "load untouched transfer target"
+    in
+    Alcotest.(check int) "stale transfer target effect" 0 (Queue.length (State.pending target)))
+;;
+
+let () =
+  Alcotest.run
+    "keeper paused-work transfer transaction"
+    [ ( "Transfer_owner"
+      , [ Alcotest.test_case
+            "commit and replay exactly once"
+            `Quick
+            test_transfer_commits_and_replays_exactly_once
+        ; Alcotest.test_case
+            "replay after source settlement projects target"
+            `Quick
+            test_replay_after_source_settlement_projects_target
+        ; Alcotest.test_case
+            "stale source revision has no effect"
+            `Quick
+            test_stale_source_revision_has_no_receipt_or_target_effect
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Implements the receipt-first pending-event slice of #25191 `Transfer_owner`.

- extends paused-work disposition receipts with an exact v2 transfer operation while preserving v1 `Resume_owner` decoding
- binds the source Keeper generation/trace, target generation/trace, exact typed stimulus, source queue revision, settlement time, and typed continuation channel
- commits the operation receipt before any queue projection
- terminally settles the source as `Transfer_accepted` through the source-bearing queue WAL before target enqueue
- replays interrupted projection idempotently: source settlement becomes `Already_settled`, target exact enqueue becomes `Already_present`
- rejects stale source revision/generation and changed target identity
- uses a transfer-only exact target enqueue so same identity with changed payload/channel/`arrived_at` is a visible conflict
- adds regression coverage for first commit, exact replay, crash after source settlement, and stale source revision with zero target effect

## Ordering and crash contract

```
Transfer_owner receipt
  -> source Transfer_accepted WAL settlement
  -> exact target enqueue
```

The durable receipt retains the original source stimulus, so a crash after source settlement can still complete target projection without reconstructing content or choosing an implicit owner.

## Validation

Passed locally:

- `ocamlc -stop-after parsing` for every changed `.ml` / `.mli`
- `ocamlformat --check` for every changed OCaml file
- `git diff --cached --check`
- static scan: no TODO/FIXME/stub/Obj.magic/string-routing additions
- root `~/me` checkout remains on `main`

Not run locally by explicit operator request:

- Dune build
- test executables
- typecheck

The operator is running builds separately; this draft relies on PR CI for build/test authority.

## Stack

Base: `codex/paused-work-up-retain-20260720` (#25356)
