### PR TITLE
feat(keeper): settle paused work from typed terminal receipt

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -417,6 +417,7 @@ let settlement_is_ack = function
   | Keeper_registry_event_queue.No_compaction _
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _ -> true
+  | Keeper_registry_event_queue.Settle_from_source_terminal _ -> true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -13,9 +13,17 @@ type transfer_owner =
   ; continuation_binding : continuation_binding
   }
 
+type source_terminal_operation =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; settled_at : float
+  ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
+  }
+
 type operation =
   | Resume_owner
   | Transfer_owner of transfer_owner
+  | Settle_from_source_terminal of source_terminal_operation
 
 type keeper_lock = { keeper_name : string }
 
@@ -92,6 +100,19 @@ let validate receipt =
         <> continuation_binding_of_source transfer.source
       then Error "paused-work transfer continuation binding does not match source"
       else Ok ()
+    | Settle_from_source_terminal operation ->
+      if Int64.compare operation.source_revision 0L < 0
+      then Error "paused-work source-terminal revision must not be negative"
+      else if not (Float.is_finite operation.settled_at)
+      then Error "paused-work source-terminal settlement time must be finite"
+      else
+        let* exact =
+          Keeper_event_queue_state.source_terminal_receipt_of_stimulus
+            operation.source
+        in
+        if exact = operation.source_receipt
+        then Ok ()
+        else Error "paused-work source-terminal receipt does not match source"
 ;;
 
 let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
@@ -131,6 +152,22 @@ let transfer_owner_to_yojson transfer =
     ]
 ;;
 
+let source_terminal_receipt_kind = function
+  | Keeper_event_queue_state.Fusion_terminal _ -> "fusion_terminal"
+  | Keeper_event_queue_state.Background_job_terminal _ ->
+    "background_job_terminal"
+  | Keeper_event_queue_state.Hitl_terminal _ -> "hitl_terminal"
+;;
+
+let source_terminal_operation_to_yojson operation =
+  `Assoc
+    [ "source", Keeper_event_queue.stimulus_to_yojson operation.source
+    ; "source_revision", `Intlit (Int64.to_string operation.source_revision)
+    ; "settled_at", `Float operation.settled_at
+    ; "source_receipt_kind", `String (source_terminal_receipt_kind operation.source_receipt)
+    ]
+;;
+
 let to_yojson receipt =
   let common operation schema extra =
     `Assoc
@@ -153,6 +190,11 @@ let to_yojson receipt =
       "transfer_owner"
       "masc.keeper.paused-work-disposition.v2"
       [ "transfer", transfer_owner_to_yojson transfer ]
+  | Settle_from_source_terminal operation ->
+    common
+      "settle_from_source_terminal"
+      "masc.keeper.paused-work-disposition.v3"
+      [ "source_terminal", source_terminal_operation_to_yojson operation ]
 ;;
 
 let sorted fields =
@@ -174,8 +216,8 @@ let source_revision_of_yojson = function
   | `Intlit value ->
     (match Int64.of_string_opt value with
      | Some value -> Ok value
-     | None -> Error "paused-work transfer source revision is invalid")
-  | _ -> Error "paused-work transfer source revision must be an integer"
+     | None -> Error "paused-work disposition source revision is invalid")
+  | _ -> Error "paused-work disposition source revision must be an integer"
 ;;
 
 let continuation_binding_of_yojson = function
@@ -220,6 +262,30 @@ let transfer_owner_of_yojson = function
          }
      | _ -> Error "paused-work transfer fields are not exact")
   | _ -> Error "paused-work transfer must be an object"
+;;
+
+let source_terminal_operation_of_yojson = function
+  | `Assoc fields ->
+    (match sorted fields with
+     | [ ("settled_at", settled_at_json)
+       ; ("source", source_json)
+       ; ("source_receipt_kind", `String source_receipt_kind)
+       ; ("source_revision", source_revision_json)
+       ] ->
+       let* source = Keeper_event_queue.stimulus_of_yojson source_json in
+       let* source_revision = source_revision_of_yojson source_revision_json in
+       let* settled_at = requested_at_of_yojson settled_at_json in
+       let* source_receipt =
+         Keeper_event_queue_state.source_terminal_receipt_of_stimulus source
+       in
+       let* () =
+         if String.equal source_receipt_kind (source_terminal_receipt_kind source_receipt)
+         then Ok ()
+         else Error "paused-work source-terminal receipt kind does not match source"
+       in
+       Ok { source; source_revision; settled_at; source_receipt }
+     | _ -> Error "paused-work source-terminal fields are not exact")
+  | _ -> Error "paused-work source-terminal operation must be an object"
 ;;
 
 let receipt_of_common
@@ -280,6 +346,23 @@ let of_yojson = function
          ~operator_operation_id
          ~requested_at_json
          ~operation:(Transfer_owner transfer)
+     | [ ("expected_generation", `Int expected_generation)
+       ; ("expected_trace_id", `String expected_trace_id)
+       ; ("keeper_name", `String keeper_name)
+       ; ("operation", `String "settle_from_source_terminal")
+       ; ("operator_operation_id", `String operator_operation_id)
+       ; ("requested_at", requested_at_json)
+       ; ("schema", `String "masc.keeper.paused-work-disposition.v3")
+       ; ("source_terminal", source_terminal_json)
+       ] ->
+       let* operation = source_terminal_operation_of_yojson source_terminal_json in
+       receipt_of_common
+         ~keeper_name
+         ~expected_trace_id
+         ~expected_generation
+         ~operator_operation_id
+         ~requested_at_json
+         ~operation:(Settle_from_source_terminal operation)
      | _ -> Error "paused-work disposition receipt fields are not exact")
   | _ -> Error "paused-work disposition receipt must be a JSON object"
 ;;

--- a/lib/keeper/keeper_paused_work_disposition_receipt.mli
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.mli
@@ -15,9 +15,17 @@ type transfer_owner =
   ; continuation_binding : continuation_binding
   }
 
+type source_terminal_operation =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; settled_at : float
+  ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
+  }
+
 type operation =
   | Resume_owner
   | Transfer_owner of transfer_owner
+  | Settle_from_source_terminal of source_terminal_operation
 
 type t =
   { keeper_name : string

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -341,6 +341,7 @@ let settle_pending config ~keeper_name request =
              Error { cause; reservation_release = Some reservation_release })
         with
         | exn ->
+          (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
 ;;

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -1,0 +1,346 @@
+type request =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
+  ; operator_operation_id : string
+  ; settled_at : float
+  }
+
+type failure =
+  | Invalid_request of string
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Receipt_lock_failed of string
+  | Receipt_read_failed of string
+  | Receipt_conflict of Keeper_paused_work_disposition_receipt.t
+  | Receipt_write_failed of string
+  | Durable_meta_read_failed of string
+  | Durable_meta_missing
+  | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
+  | Durable_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Durable_owner_identity_changed
+  | Source_queue_validation_failed of string
+  | Committed_settlement_failed of string
+
+type error =
+  { cause : failure
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
+  }
+
+type commit_status =
+  | Committed
+  | Already_committed
+
+type projection =
+  | Applied of Keeper_registry_event_queue.settle_result
+  | Committed_followup_failed of failure
+
+type success =
+  { receipt : Keeper_paused_work_disposition_receipt.t
+  ; commit_status : commit_status
+  ; projection : projection
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+let ( let* ) = Result.bind
+
+let failure_to_string = function
+  | Invalid_request detail ->
+    "invalid Settle_from_source_terminal request: " ^ detail
+  | Reservation_conflict owner ->
+    "Settle_from_source_terminal lifecycle reservation conflict: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+  | Receipt_lock_failed detail ->
+    "Settle_from_source_terminal receipt lock failed: " ^ detail
+  | Receipt_read_failed detail ->
+    "Settle_from_source_terminal receipt read failed: " ^ detail
+  | Receipt_conflict receipt ->
+    Printf.sprintf
+      "Settle_from_source_terminal operation ID conflicts with keeper=%s generation=%d requested_at=%.17g"
+      receipt.keeper_name
+      receipt.expected_generation
+      receipt.requested_at
+  | Receipt_write_failed detail ->
+    "Settle_from_source_terminal receipt write failed: " ^ detail
+  | Durable_meta_read_failed detail ->
+    "Settle_from_source_terminal durable metadata read failed: " ^ detail
+  | Durable_meta_missing ->
+    "Settle_from_source_terminal durable Keeper metadata is missing"
+  | Durable_owner_not_paused ->
+    "Settle_from_source_terminal requires a paused Keeper"
+  | Durable_owner_dead_tombstone ->
+    "Settle_from_source_terminal cannot use a Dead tombstone"
+  | Durable_owner_generation_changed { expected; actual } ->
+    Printf.sprintf
+      "Settle_from_source_terminal generation changed: expected %d, actual %d"
+      expected
+      actual
+  | Durable_owner_identity_changed ->
+    "Settle_from_source_terminal trace identity changed"
+  | Source_queue_validation_failed detail ->
+    "Settle_from_source_terminal source queue validation failed: " ^ detail
+  | Committed_settlement_failed detail ->
+    "Settle_from_source_terminal committed receipt but settlement failed: " ^ detail
+;;
+
+let error_to_string error =
+  let base = failure_to_string error.cause in
+  match error.reservation_release with
+  | None -> base
+  | Some Keeper_lifecycle_reservation.Released ->
+    base ^ "; reservation_release=released"
+  | Some Keeper_lifecycle_reservation.Release_missing ->
+    base ^ "; reservation_release=release_missing"
+  | Some (Keeper_lifecycle_reservation.Release_not_owner owner) ->
+    base
+    ^ "; reservation_release=release_not_owner: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+;;
+
+let validate_request request =
+  if request.owner_generation < 0
+  then Error "owner generation must not be negative"
+  else if Int64.compare request.source_revision 0L < 0
+  then Error "source revision must not be negative"
+  else if String.equal (String.trim request.source.post_id) ""
+  then Error "source post id must not be empty"
+  else if String.equal (String.trim request.operator_operation_id) ""
+  then Error "operator operation ID must not be empty"
+  else if not (Float.is_finite request.settled_at)
+  then Error "settlement time must be finite"
+  else
+    let* exact =
+      Keeper_event_queue_state.source_terminal_receipt_of_stimulus request.source
+    in
+    if exact = request.source_receipt
+    then Ok ()
+    else Error "source receipt does not match the exact source event"
+;;
+
+let read_meta config keeper_name =
+  match Keeper_meta_store.read_meta config keeper_name with
+  | Error detail -> Error (Durable_meta_read_failed detail)
+  | Ok None -> Error Durable_meta_missing
+  | Ok (Some meta) -> Ok meta
+;;
+
+let validate_paused_owner request (meta : Keeper_meta_contract.keeper_meta) =
+  match
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  with
+  | Keeper_lifecycle_admission.Active -> Error Durable_owner_not_paused
+  | Keeper_lifecycle_admission.Dead_tombstone ->
+    Error Durable_owner_dead_tombstone
+  | Keeper_lifecycle_admission.Paused _ ->
+    if Int.equal meta.runtime.generation request.owner_generation
+    then Ok meta
+    else
+      Error
+        (Durable_owner_generation_changed
+           { expected = request.owner_generation; actual = meta.runtime.generation })
+;;
+
+let validate_source_queue config ~keeper_name request =
+  let* state =
+    Keeper_event_queue_persistence.load_state_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+    |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
+  in
+  if not (Int64.equal (Keeper_event_queue_state.revision state) request.source_revision)
+  then Error (Source_queue_validation_failed "source revision changed")
+  else if Keeper_event_queue_state.leases state <> []
+  then Error (Source_queue_validation_failed "source lane has an active lease")
+  else if Keeper_event_queue_state.transition_outbox state <> []
+  then Error (Source_queue_validation_failed "source lane has a pending transition outbox")
+  else
+    let matching =
+      Keeper_event_queue.to_list (Keeper_event_queue_state.pending state)
+      |> List.filter (fun source ->
+        Keeper_event_queue.stimulus_identity_equal request.source source)
+    in
+    match matching with
+    | [ source ] when source = request.source -> Ok ()
+    | [ _ ] -> Error (Source_queue_validation_failed "source snapshot changed")
+    | [] -> Error (Source_queue_validation_failed "source is not pending")
+    | _ :: _ :: _ ->
+      Error (Source_queue_validation_failed "source identity is duplicated")
+;;
+
+let operation_of_receipt receipt =
+  match receipt.Keeper_paused_work_disposition_receipt.operation with
+  | Keeper_paused_work_disposition_receipt.Settle_from_source_terminal operation ->
+    Ok operation
+  | Keeper_paused_work_disposition_receipt.Resume_owner
+  | Keeper_paused_work_disposition_receipt.Transfer_owner _ ->
+    Error (Receipt_conflict receipt)
+;;
+
+let receipt_matches_request ~keeper_name request receipt =
+  match operation_of_receipt receipt with
+  | Error _ -> false
+  | Ok operation ->
+    String.equal receipt.keeper_name keeper_name
+    && Int.equal receipt.expected_generation request.owner_generation
+    && String.equal receipt.operator_operation_id request.operator_operation_id
+    && operation.source = request.source
+    && Int64.equal operation.source_revision request.source_revision
+    && Float.equal operation.settled_at request.settled_at
+    && operation.source_receipt = request.source_receipt
+;;
+
+let create_receipt config ~keeper_name request =
+  let* meta = read_meta config keeper_name in
+  let* meta = validate_paused_owner request meta in
+  let* () = validate_source_queue config ~keeper_name request in
+  let operation : Keeper_paused_work_disposition_receipt.source_terminal_operation =
+    { source = request.source
+    ; source_revision = request.source_revision
+    ; settled_at = request.settled_at
+    ; source_receipt = request.source_receipt
+    }
+  in
+  Ok
+    ({ keeper_name
+     ; expected_trace_id = meta.runtime.trace_id
+     ; expected_generation = request.owner_generation
+     ; operator_operation_id = request.operator_operation_id
+     ; requested_at = Time_compat.now ()
+     ; operation =
+         Keeper_paused_work_disposition_receipt.Settle_from_source_terminal
+           operation
+     }
+     : Keeper_paused_work_disposition_receipt.t)
+;;
+
+let project_receipt config receipt =
+  let* operation = operation_of_receipt receipt in
+  let source_terminal : Keeper_registry_event_queue.accepted_source_terminal =
+    { source = operation.source
+    ; source_revision = operation.source_revision
+    ; owner_generation = receipt.Keeper_paused_work_disposition_receipt.expected_generation
+    ; operator_operation_id = receipt.operator_operation_id
+    ; source_receipt = operation.source_receipt
+    }
+  in
+  let base_path = config.Workspace.base_path in
+  let* state =
+    Keeper_event_queue_persistence.load_state_result
+      ~base_path
+      ~keeper_name:receipt.keeper_name
+    |> Result.map_error (fun detail -> Committed_settlement_failed detail)
+  in
+  let* prior =
+    Keeper_event_queue_state.accepted_pending_source_terminal_replay
+      source_terminal
+      state
+    |> Result.map_error (fun detail -> Committed_settlement_failed detail)
+  in
+  match prior with
+  | Some prior -> Ok (Keeper_registry_event_queue.Already_settled prior)
+  | None ->
+    let* current = read_meta config receipt.keeper_name in
+    let* () =
+      if not (Int.equal current.runtime.generation receipt.expected_generation)
+      then
+        Error
+          (Durable_owner_generation_changed
+             { expected = receipt.expected_generation
+             ; actual = current.runtime.generation
+             })
+      else if not (Keeper_id.Trace_id.equal current.runtime.trace_id receipt.expected_trace_id)
+      then Error Durable_owner_identity_changed
+      else Ok ()
+    in
+    Keeper_registry_event_queue.settle_pending_from_source_terminal_result
+      ~base_path
+      receipt.keeper_name
+      ~current_owner_generation:current.runtime.generation
+      ~settled_at:operation.settled_at
+      ~source_terminal
+    |> Result.map_error (fun detail -> Committed_settlement_failed detail)
+;;
+
+let run_owned receipt_lock config ~keeper_name request =
+  let* existing =
+    Keeper_paused_work_disposition_receipt.load
+      config
+      ~keeper_name
+      ~operator_operation_id:request.operator_operation_id
+    |> Result.map_error (fun detail -> Receipt_read_failed detail)
+  in
+  let* receipt, commit_status =
+    match existing with
+    | Some receipt when receipt_matches_request ~keeper_name request receipt ->
+      Ok (receipt, Already_committed)
+    | Some receipt -> Error (Receipt_conflict receipt)
+    | None ->
+      let* receipt = create_receipt config ~keeper_name request in
+      (match
+         Keeper_paused_work_disposition_receipt.save_if_absent
+           receipt_lock
+           config
+           receipt
+       with
+       | Error detail -> Error (Receipt_write_failed detail)
+       | Ok Keeper_paused_work_disposition_receipt.Created ->
+         Ok (receipt, Committed)
+       | Ok (Keeper_paused_work_disposition_receipt.Existing existing)
+         when Keeper_paused_work_disposition_receipt.equal existing receipt ->
+         Ok (existing, Already_committed)
+       | Ok (Keeper_paused_work_disposition_receipt.Existing existing) ->
+         Error (Receipt_conflict existing))
+  in
+  let projection =
+    match project_receipt config receipt with
+    | Ok settlement -> Applied settlement
+    | Error failure -> Committed_followup_failed failure
+  in
+  Ok (receipt, commit_status, projection)
+;;
+
+let settle_pending config ~keeper_name request =
+  match validate_request request with
+  | Error detail ->
+    Error { cause = Invalid_request detail; reservation_release = None }
+  | Ok () ->
+    (match
+       Keeper_lifecycle_reservation.acquire
+         ~base_path:config.Workspace.base_path
+         ~keeper_name
+         ~expected_generation:request.owner_generation
+         ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+     with
+     | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+       Error
+         { cause = Reservation_conflict owner; reservation_release = None }
+     | Ok token ->
+       (try
+          let outcome =
+            match
+              Keeper_paused_work_disposition_receipt.with_keeper_lock
+                config
+                ~keeper_name
+                (fun receipt_lock ->
+                   run_owned receipt_lock config ~keeper_name request)
+            with
+            | Error detail -> Error (Receipt_lock_failed detail)
+            | Ok outcome -> outcome
+          in
+          let reservation_release = Keeper_lifecycle_reservation.release token in
+          (match outcome with
+           | Ok (receipt, commit_status, projection) ->
+             Ok { receipt; commit_status; projection; reservation_release }
+           | Error cause ->
+             Error { cause; reservation_release = Some reservation_release })
+        with
+        | exn ->
+          ignore (Keeper_lifecycle_reservation.release token : _);
+          raise exn))
+;;

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.mli
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.mli
@@ -1,0 +1,60 @@
+(** Receipt-first terminal settlement for one exact paused-lane source event. *)
+
+type request =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
+  ; operator_operation_id : string
+  ; settled_at : float
+  }
+
+type failure =
+  | Invalid_request of string
+  | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
+  | Receipt_lock_failed of string
+  | Receipt_read_failed of string
+  | Receipt_conflict of Keeper_paused_work_disposition_receipt.t
+  | Receipt_write_failed of string
+  | Durable_meta_read_failed of string
+  | Durable_meta_missing
+  | Durable_owner_not_paused
+  | Durable_owner_dead_tombstone
+  | Durable_owner_generation_changed of
+      { expected : int
+      ; actual : int
+      }
+  | Durable_owner_identity_changed
+  | Source_queue_validation_failed of string
+  | Committed_settlement_failed of string
+
+type error =
+  { cause : failure
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome option
+  }
+
+type commit_status =
+  | Committed
+  | Already_committed
+
+type projection =
+  | Applied of Keeper_registry_event_queue.settle_result
+  | Committed_followup_failed of failure
+
+type success =
+  { receipt : Keeper_paused_work_disposition_receipt.t
+  ; commit_status : commit_status
+  ; projection : projection
+  ; reservation_release : Keeper_lifecycle_reservation.release_outcome
+  }
+
+val error_to_string : error -> string
+
+val settle_pending :
+  Workspace.config ->
+  keeper_name:string ->
+  request ->
+  (success, error) result
+(** Persist [Settle_from_source_terminal] before committing the exact
+    source-bearing terminal settlement WAL. Replays never infer terminality
+    from time, prose, or an external fallback owner. *)

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -235,6 +235,8 @@ let transfer_of_receipt receipt =
   | Keeper_paused_work_disposition_receipt.Transfer_owner transfer -> Ok transfer
   | Keeper_paused_work_disposition_receipt.Resume_owner ->
     Error (Receipt_conflict receipt)
+  | Keeper_paused_work_disposition_receipt.Settle_from_source_terminal _ ->
+    Error (Receipt_conflict receipt)
 ;;
 
 let receipt_matches_request ~from_keeper ~to_keeper request receipt =

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -283,7 +283,8 @@ let create_receipt config ~from_keeper ~to_keeper request =
      : Keeper_paused_work_disposition_receipt.t)
 ;;
 
-let source_settlement config receipt transfer =
+let source_settlement config receipt
+      (transfer : Keeper_paused_work_disposition_receipt.transfer_owner) =
   let causal : Keeper_registry_event_queue.accepted_transfer =
     { source = transfer.Keeper_paused_work_disposition_receipt.source
     ; source_revision = transfer.source_revision

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -300,6 +300,7 @@ let reaction_kind_of_settlement = function
   | Keeper_event_queue_state.No_compaction _ -> Event_queue_no_compaction
   | Keeper_event_queue_state.Cancel_accepted _ -> Event_queue_cancelled
   | Keeper_event_queue_state.Transfer_accepted _ -> Event_queue_ack
+  | Keeper_event_queue_state.Settle_from_source_terminal _ -> Event_queue_ack
   | Keeper_event_queue_state.Requeue _ -> Event_queue_requeued
   | Keeper_event_queue_state.Escalate _ -> Event_queue_escalated
 ;;
@@ -673,6 +674,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
   match reaction_kind, settlement with
   | Event_queue_ack, Keeper_event_queue_state.Ack -> true
   | Event_queue_ack, Keeper_event_queue_state.Transfer_accepted _ -> true
+  | Event_queue_ack, Keeper_event_queue_state.Settle_from_source_terminal _ -> true
   | Event_queue_no_compaction, Keeper_event_queue_state.No_compaction _ -> true
   | Event_queue_cancelled, Keeper_event_queue_state.Cancel_accepted _ -> true
   | Event_queue_requeued, Keeper_event_queue_state.Requeue _ -> true
@@ -688,12 +690,14 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
+    | Keeper_event_queue_state.Settle_from_source_terminal _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_cancelled,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Transfer_accepted _
+    | Keeper_event_queue_state.Settle_from_source_terminal _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_requeued,
@@ -701,12 +705,14 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
+    | Keeper_event_queue_state.Settle_from_source_terminal _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_escalated,
     ( Keeper_event_queue_state.Ack
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
+    | Keeper_event_queue_state.Settle_from_source_terminal _
     | Keeper_event_queue_state.Requeue _ ) -> false
 ;;
 
@@ -1418,6 +1424,7 @@ let summarize_rows ~keeper_name ~limit rows =
        | Keeper_event_queue_state.No_compaction _
        | Keeper_event_queue_state.Cancel_accepted _
        | Keeper_event_queue_state.Transfer_accepted _
+       | Keeper_event_queue_state.Settle_from_source_terminal _
        | Keeper_event_queue_state.Requeue _ -> ())
     | Cursor_ack, None -> incr cursor_ack_count
     | Turn_started, Some _

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -57,11 +57,25 @@ type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
   ; to_keeper : string
   }
 
+type source_terminal_receipt = Keeper_event_queue_persistence.source_terminal_receipt =
+  | Fusion_terminal of Keeper_event_queue.fusion_completion
+  | Background_job_terminal of Keeper_event_queue.bg_job_completion
+  | Hitl_terminal of Keeper_event_queue.hitl_resolution
+
+type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_terminal =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; source_receipt : source_terminal_receipt
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
+  | Settle_from_source_terminal of accepted_source_terminal
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -444,6 +458,23 @@ let transfer_pending_accepted_result
     ~current_owner_generation
     ~settled_at
     ~transfer
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;
+
+let settle_pending_from_source_terminal_result
+      ~base_path
+      name
+      ~current_owner_generation
+      ~settled_at
+      ~source_terminal
+  =
+  Keeper_event_queue_persistence.settle_pending_from_source_terminal_result
+    ~base_path
+    ~keeper_name:name
+    ~current_owner_generation
+    ~settled_at
+    ~source_terminal
     ~after_commit:(publish_pending ~base_path name)
     ()
 ;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -56,11 +56,25 @@ type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
   ; to_keeper : string
   }
 
+type source_terminal_receipt = Keeper_event_queue_persistence.source_terminal_receipt =
+  | Fusion_terminal of Keeper_event_queue.fusion_completion
+  | Background_job_terminal of Keeper_event_queue.bg_job_completion
+  | Hitl_terminal of Keeper_event_queue.hitl_resolution
+
+type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_terminal =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; source_receipt : source_terminal_receipt
+  }
+
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
+  | Settle_from_source_terminal of accepted_source_terminal
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -139,6 +153,14 @@ val transfer_pending_accepted_result :
   (settle_result, string) result
 (** Commit an exact pending accepted transfer settlement and publish the
     post-commit source pending projection when the owner is registered. *)
+
+val settle_pending_from_source_terminal_result :
+  base_path:string ->
+  string ->
+  current_owner_generation:int ->
+  settled_at:float ->
+  source_terminal:accepted_source_terminal ->
+  (settle_result, string) result
 
 (** Enqueue a stimulus on the keeper's event queue. When the keeper is not
     registered yet, persist the stimulus to the durable snapshot so later

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -54,11 +54,25 @@ type accepted_transfer = State.accepted_transfer =
   ; to_keeper : string
   }
 
+type source_terminal_receipt = State.source_terminal_receipt =
+  | Fusion_terminal of Keeper_event_queue.fusion_completion
+  | Background_job_terminal of Keeper_event_queue.bg_job_completion
+  | Hitl_terminal of Keeper_event_queue.hitl_resolution
+
+type accepted_source_terminal = State.accepted_source_terminal =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; source_receipt : source_terminal_receipt
+  }
+
 type settlement = State.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
+  | Settle_from_source_terminal of accepted_source_terminal
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -913,6 +927,42 @@ let transfer_pending_accepted_result
        Error
          (Printf.sprintf
             "event queue pending accepted transfer raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let settle_pending_from_source_terminal_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~current_owner_generation
+      ~settled_at
+      ~source_terminal
+      ()
+  =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           commit_settlement_transition_unlocked
+             owner
+             ~after_commit
+             (State.settle_pending_from_source_terminal
+                ~current_owner_generation
+                ~settled_at
+                ~source_terminal)
+             state
+           |> Result.map fst)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue pending source-terminal settlement raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -58,11 +58,25 @@ type accepted_transfer = Keeper_event_queue_state.accepted_transfer =
   ; to_keeper : string
   }
 
+type source_terminal_receipt = Keeper_event_queue_state.source_terminal_receipt =
+  | Fusion_terminal of Keeper_event_queue.fusion_completion
+  | Background_job_terminal of Keeper_event_queue.bg_job_completion
+  | Hitl_terminal of Keeper_event_queue.hitl_resolution
+
+type accepted_source_terminal = Keeper_event_queue_state.accepted_source_terminal =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; source_receipt : source_terminal_receipt
+  }
+
 type settlement = Keeper_event_queue_state.settlement =
   | Ack
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
+  | Settle_from_source_terminal of accepted_source_terminal
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -222,6 +236,16 @@ val transfer_pending_accepted_result :
   (settle_result, string) result
 (** Append and fsync the canonical source-bearing transfer settlement before
     checkpointing removal of the exact pending source. *)
+
+val settle_pending_from_source_terminal_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  current_owner_generation:int ->
+  settled_at:float ->
+  source_terminal:accepted_source_terminal ->
+  unit ->
+  (settle_result, string) result
 
 val prepare_registration_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -51,6 +51,19 @@ type accepted_transfer =
   ; to_keeper : string
   }
 
+type source_terminal_receipt =
+  | Fusion_terminal of Keeper_event_queue.fusion_completion
+  | Background_job_terminal of Keeper_event_queue.bg_job_completion
+  | Hitl_terminal of Keeper_event_queue.hitl_resolution
+
+type accepted_source_terminal =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; source_receipt : source_terminal_receipt
+  }
+
 let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
@@ -62,6 +75,7 @@ type settlement =
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
+  | Settle_from_source_terminal of accepted_source_terminal
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -387,6 +401,7 @@ let settlement_kind_label = function
   | No_compaction _ -> "no_compaction"
   | Cancel_accepted _ -> "cancel_accepted"
   | Transfer_accepted _ -> "transfer_accepted"
+  | Settle_from_source_terminal _ -> "settle_from_source_terminal"
   | Requeue _ -> "requeue"
   | Escalate _ -> "escalate"
 ;;
@@ -415,17 +430,20 @@ let settlement_equal left right =
     && left.reason = right.reason
   | Cancel_accepted left, Cancel_accepted right -> left = right
   | Transfer_accepted left, Transfer_accepted right -> left = right
+  | Settle_from_source_terminal left, Settle_from_source_terminal right ->
+    left = right
   | Requeue left, Requeue right -> left = right
   | ( Escalate { reason = left_reason; successor = left_successor }
     , Escalate { reason = right_reason; successor = right_successor } ) ->
     left_reason = right_reason
     && successor_equal left_successor right_successor
-  | Ack, (No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Requeue _ | Escalate _)
-  | No_compaction _, (Ack | Cancel_accepted _ | Transfer_accepted _ | Requeue _ | Escalate _)
-  | Cancel_accepted _, (Ack | No_compaction _ | Transfer_accepted _ | Requeue _ | Escalate _)
-  | Transfer_accepted _, (Ack | No_compaction _ | Cancel_accepted _ | Requeue _ | Escalate _)
-  | Requeue _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Escalate _)
-  | Escalate _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Requeue _) ->
+  | Ack, (No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
+  | No_compaction _, (Ack | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
+  | Cancel_accepted _, (Ack | No_compaction _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
+  | Transfer_accepted _, (Ack | No_compaction _ | Cancel_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
+  | Settle_from_source_terminal _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Requeue _ | Escalate _)
+  | Requeue _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Escalate _)
+  | Escalate _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _) ->
     false
 ;;
 
@@ -470,10 +488,46 @@ let validate_accepted_transfer transfer =
   else Ok ()
 ;;
 
+let source_terminal_receipt_of_stimulus source =
+  match source.Keeper_event_queue.payload with
+  | Keeper_event_queue.Fusion_completed completion ->
+    Ok (Fusion_terminal completion)
+  | Keeper_event_queue.Bg_completed completion ->
+    Ok (Background_job_terminal completion)
+  | Keeper_event_queue.Hitl_resolved resolution -> Ok (Hitl_terminal resolution)
+  | Keeper_event_queue.Board_signal _
+  | Keeper_event_queue.Board_attention _
+  | Keeper_event_queue.Bootstrap
+  | Keeper_event_queue.Schedule_due _
+  | Keeper_event_queue.Connector_attention _
+  | Keeper_event_queue.Failure_judgment _
+  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Goal_assigned _ ->
+    Error "source event does not carry a typed terminal receipt"
+;;
+
+let validate_accepted_source_terminal source_terminal =
+  if String.equal (String.trim source_terminal.source.post_id) ""
+  then Error "source-terminal settlement source post id must not be empty"
+  else if Int64.compare source_terminal.source_revision 0L < 0
+  then Error "source-terminal settlement source revision must not be negative"
+  else if source_terminal.owner_generation < 0
+  then Error "source-terminal settlement owner generation must not be negative"
+  else if String.equal (String.trim source_terminal.operator_operation_id) ""
+  then Error "source-terminal settlement operation id must not be empty"
+  else
+    let* receipt = source_terminal_receipt_of_stimulus source_terminal.source in
+    if receipt = source_terminal.source_receipt
+    then Ok ()
+    else Error "source-terminal settlement receipt does not match source payload"
+;;
+
 let validate_settlement = function
   | Ack | No_compaction _ | Requeue _ -> Ok ()
   | Cancel_accepted cancellation -> validate_accepted_cancellation cancellation
   | Transfer_accepted transfer -> validate_accepted_transfer transfer
+  | Settle_from_source_terminal source_terminal ->
+    validate_accepted_source_terminal source_terminal
   | Escalate
       { reason = Failure_judgment_requested
       ; successor =
@@ -545,6 +599,12 @@ let validate_settlement_for_stimuli settlement stimuli =
     Error "accepted transfer source does not match its exact event stimulus"
   | Transfer_accepted _, _ ->
     Error "accepted transfer requires exactly one accepted event stimulus"
+  | Settle_from_source_terminal source_terminal, [ source ]
+    when source_terminal.source = source -> Ok ()
+  | Settle_from_source_terminal _, [ _ ] ->
+    Error "source-terminal receipt does not match its exact event stimulus"
+  | Settle_from_source_terminal _, _ ->
+    Error "source-terminal settlement requires exactly one accepted event stimulus"
   | (Ack | Requeue _ | Escalate _), _ -> Ok ()
 ;;
 
@@ -619,7 +679,8 @@ let settle_committed ~settled_at ~lease ~settlement state =
     let* () = validate_settlement_for_lease settlement committed in
     let pending =
       match settlement with
-      | Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ -> state.pending
+      | Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _
+      | Settle_from_source_terminal _ -> state.pending
       | Requeue
           ( Retry_after_observed
           | Context_compaction_retry
@@ -651,7 +712,7 @@ let settle_committed ~settled_at ~lease ~settlement state =
 
 let settle ~settled_at ~lease ~settlement state =
   match settlement with
-  | Cancel_accepted _ | Transfer_accepted _ ->
+  | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ ->
     Error "accepted disposition requires its owner-fenced boundary"
   | Ack | No_compaction _ | Requeue _ | Escalate _ ->
     settle_committed ~settled_at ~lease ~settlement state
@@ -692,12 +753,19 @@ let cancel_accepted
     settle_committed ~settled_at ~lease ~settlement state
 ;;
 
-let prior_cancellation_by_operation_id operation_id state =
+let disposition_operation_id = function
+  | Cancel_accepted cancellation -> Some cancellation.operator_operation_id
+  | Transfer_accepted transfer -> Some transfer.operator_operation_id
+  | Settle_from_source_terminal source_terminal ->
+    Some source_terminal.operator_operation_id
+  | Ack | No_compaction _ | Requeue _ | Escalate _ -> None
+;;
+
+let prior_disposition_by_operation_id operation_id state =
   let is_same_operation receipt =
-    match receipt.settlement with
-    | Cancel_accepted cancellation ->
-      String.equal cancellation.operator_operation_id operation_id
-    | Ack | No_compaction _ | Transfer_accepted _ | Requeue _ | Escalate _ -> false
+    match disposition_operation_id receipt.settlement with
+    | Some committed -> String.equal committed operation_id
+    | None -> false
   in
   match state.transition_outbox with
   | [ entry ] when is_same_operation entry.receipt -> Some entry.receipt
@@ -711,7 +779,7 @@ let prior_cancellation_by_operation_id operation_id state =
 let accepted_pending_cancellation_replay cancellation state =
   let requested = Cancel_accepted cancellation in
   match
-    prior_cancellation_by_operation_id cancellation.operator_operation_id state
+    prior_disposition_by_operation_id cancellation.operator_operation_id state
   with
   | None -> Ok None
   | Some receipt when settlement_equal receipt.settlement requested ->
@@ -789,25 +857,9 @@ let cancel_pending_accepted
        settle_committed ~settled_at ~lease ~settlement claimed)
 ;;
 
-let prior_transfer_by_operation_id operation_id state =
-  let is_same_operation receipt =
-    match receipt.settlement with
-    | Transfer_accepted transfer ->
-      String.equal transfer.operator_operation_id operation_id
-    | Ack | No_compaction _ | Cancel_accepted _ | Requeue _ | Escalate _ -> false
-  in
-  match state.transition_outbox with
-  | [ entry ] when is_same_operation entry.receipt -> Some entry.receipt
-  | [] | [ _ ] ->
-    (match state.last_settlement with
-     | Some receipt when is_same_operation receipt -> Some receipt
-     | Some _ | None -> None)
-  | _ :: _ :: _ -> None
-;;
-
 let accepted_pending_transfer_replay transfer state =
   let requested = Transfer_accepted transfer in
-  match prior_transfer_by_operation_id transfer.operator_operation_id state with
+  match prior_disposition_by_operation_id transfer.operator_operation_id state with
   | None -> Ok None
   | Some receipt when settlement_equal receipt.settlement requested ->
     Ok (Some receipt)
@@ -879,6 +931,90 @@ let transfer_pending_accepted
          match lease with
          | Some lease -> Ok lease
          | None -> Error "accepted transfer did not create its synthetic lease"
+       in
+       settle_committed ~settled_at ~lease ~settlement claimed)
+;;
+
+let accepted_pending_source_terminal_replay source_terminal state =
+  let requested = Settle_from_source_terminal source_terminal in
+  match
+    prior_disposition_by_operation_id
+      source_terminal.operator_operation_id
+      state
+  with
+  | None -> Ok None
+  | Some receipt when settlement_equal receipt.settlement requested ->
+    Ok (Some receipt)
+  | Some _ ->
+    Error
+      (Printf.sprintf
+         "source-terminal settlement operation conflict: %s"
+         source_terminal.operator_operation_id)
+;;
+
+let settle_pending_from_source_terminal
+      ~current_owner_generation
+      ~settled_at
+      ~source_terminal
+      state
+  =
+  let settlement = Settle_from_source_terminal source_terminal in
+  match accepted_pending_source_terminal_replay source_terminal state with
+  | Error _ as error -> error
+  | Ok (Some receipt) -> Ok (state, Already_settled receipt)
+  | Ok None ->
+    let* () = validate_accepted_source_terminal source_terminal in
+    let* () =
+      if Int.equal current_owner_generation source_terminal.owner_generation
+      then Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "source-terminal settlement owner generation changed: expected %d, current %d"
+             source_terminal.owner_generation
+             current_owner_generation)
+    in
+    let* () =
+      if Int64.equal state.revision source_terminal.source_revision
+      then Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "source-terminal settlement source revision changed: expected %Ld, current %Ld"
+             source_terminal.source_revision
+             state.revision)
+    in
+    let* () =
+      if lease_admission_blocked state
+      then Error "event queue cannot settle pending source while a lease or outbox exists"
+      else Ok ()
+    in
+    let matching, retained =
+      Keeper_event_queue.to_list state.pending
+      |> List.partition (fun source ->
+        Keeper_event_queue.stimulus_identity_equal source_terminal.source source)
+    in
+    (match matching with
+     | [] -> Error "source-terminal settlement source is not pending"
+     | _ :: _ :: _ ->
+       Error "source-terminal settlement source identity is duplicated"
+     | [ source ] when source <> source_terminal.source ->
+       Error "source-terminal settlement source snapshot changed"
+     | [ source ] ->
+       let pending =
+         List.fold_left
+           Keeper_event_queue.enqueue
+           Keeper_event_queue.empty
+           retained
+       in
+       let* claimed, lease =
+         make_lease ~kind:Single ~claimed_at:None [ source ] { state with pending }
+       in
+       let* lease =
+         match lease with
+         | Some lease -> Ok lease
+         | None ->
+           Error "source-terminal settlement did not create its synthetic lease"
        in
        settle_committed ~settled_at ~lease ~settlement claimed)
 ;;
@@ -1034,6 +1170,41 @@ let replay_transition_outbox_entry entry state =
              Error "pending transfer WAL source conflicts with its receipt"
            | Transfer_accepted _, ([] | _ :: _ :: _) ->
              Error "pending transfer WAL must carry exactly one source"
+           | Settle_from_source_terminal source_terminal, [ source ]
+             when source = source_terminal.source ->
+             if not (Int64.equal state.next_lease_sequence entry.receipt.lease_sequence)
+             then
+               Error
+                 (Printf.sprintf
+                    "pending source-terminal WAL lease sequence changed: expected %Ld, current %Ld"
+                    entry.receipt.lease_sequence
+                    state.next_lease_sequence)
+             else
+               let* replayed, result =
+                 settle_pending_from_source_terminal
+                   ~current_owner_generation:source_terminal.owner_generation
+                   ~settled_at:entry.receipt.settled_at
+                   ~source_terminal
+                   state
+               in
+               let actual_receipt =
+                 match result with
+                 | Settled receipt | Already_settled receipt -> receipt
+               in
+               (match replayed.transition_outbox with
+                | [ actual ]
+                  when transition_receipt_equal entry.receipt actual_receipt
+                       && actual = entry ->
+                  Ok replayed
+                | [] | [ _ ] | _ :: _ :: _ ->
+                  Error
+                    (Printf.sprintf
+                       "pending source-terminal WAL replay conflict: %s"
+                       entry.receipt.transition_id))
+           | Settle_from_source_terminal _, [ _ ] ->
+             Error "pending source-terminal WAL source conflicts with its receipt"
+           | Settle_from_source_terminal _, ([] | _ :: _ :: _) ->
+             Error "pending source-terminal WAL must carry exactly one source"
            | (Ack | No_compaction _ | Requeue _ | Escalate _), _ ->
              Error
                (Printf.sprintf
@@ -1298,6 +1469,21 @@ let settlement_to_yojson = function
       ; "from_keeper", `String transfer.from_keeper
       ; "to_keeper", `String transfer.to_keeper
       ]
+  | Settle_from_source_terminal source_terminal ->
+    let receipt_kind =
+      match source_terminal.source_receipt with
+      | Fusion_terminal _ -> "fusion_terminal"
+      | Background_job_terminal _ -> "background_job_terminal"
+      | Hitl_terminal _ -> "hitl_terminal"
+    in
+    `Assoc
+      [ "kind", `String "settle_from_source_terminal"
+      ; "source", Keeper_event_queue.stimulus_to_yojson source_terminal.source
+      ; "source_revision", int64_json source_terminal.source_revision
+      ; "owner_generation", `Int source_terminal.owner_generation
+      ; "operator_operation_id", `String source_terminal.operator_operation_id
+      ; "source_receipt_kind", `String receipt_kind
+      ]
   | Requeue reason ->
     `Assoc
       [ "kind", `String "requeue"
@@ -1394,6 +1580,52 @@ let settlement_of_yojson json =
     in
     let* () = validate_accepted_transfer transfer in
     Ok (Transfer_accepted transfer)
+  | "settle_from_source_terminal" ->
+    let* () =
+      exact_fields
+        ~context
+        ~expected:
+          [ "kind"
+          ; "source"
+          ; "source_revision"
+          ; "owner_generation"
+          ; "operator_operation_id"
+          ; "source_receipt_kind"
+          ]
+        fields
+    in
+    let* source_json = required_field ~context "source" fields in
+    let* source = Keeper_event_queue.stimulus_of_yojson source_json in
+    let* source_revision = int64_field ~context "source_revision" fields in
+    let* owner_generation = int_field ~context "owner_generation" fields in
+    let* operator_operation_id =
+      string_field ~context "operator_operation_id" fields
+    in
+    let* source_receipt_kind =
+      string_field ~context "source_receipt_kind" fields
+    in
+    let* source_receipt = source_terminal_receipt_of_stimulus source in
+    let expected_kind =
+      match source_receipt with
+      | Fusion_terminal _ -> "fusion_terminal"
+      | Background_job_terminal _ -> "background_job_terminal"
+      | Hitl_terminal _ -> "hitl_terminal"
+    in
+    let* () =
+      if String.equal source_receipt_kind expected_kind
+      then Ok ()
+      else Error "source-terminal receipt kind does not match source payload"
+    in
+    let source_terminal =
+      { source
+      ; source_revision
+      ; owner_generation
+      ; operator_operation_id
+      ; source_receipt
+      }
+    in
+    let* () = validate_accepted_source_terminal source_terminal in
+    Ok (Settle_from_source_terminal source_terminal)
   | "requeue" ->
     let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -470,7 +470,7 @@ let validate_accepted_cancellation (cancellation : accepted_cancellation) =
   else Ok ()
 ;;
 
-let validate_accepted_transfer transfer =
+let validate_accepted_transfer (transfer : accepted_transfer) =
   if String.equal (String.trim transfer.source.post_id) ""
   then Error "accepted transfer source post id must not be empty"
   else if Int64.compare transfer.source_revision 0L < 0

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -65,6 +65,21 @@ type accepted_transfer =
     this settlement links the source queue terminal effect to that receipt by
     stable operator operation ID. *)
 
+type source_terminal_receipt =
+  | Fusion_terminal of Keeper_event_queue.fusion_completion
+  | Background_job_terminal of Keeper_event_queue.bg_job_completion
+  | Hitl_terminal of Keeper_event_queue.hitl_resolution
+(** Closed terminal source families that are intrinsically represented by a
+    durable event payload. No prose or external status inference is admitted. *)
+
+type accepted_source_terminal =
+  { source : Keeper_event_queue.stimulus
+  ; source_revision : int64
+  ; owner_generation : int
+  ; operator_operation_id : string
+  ; source_receipt : source_terminal_receipt
+  }
+
 val no_compaction_reason_label : no_compaction_reason -> string
 val no_compaction_reason_of_label : string -> (no_compaction_reason, string) result
 
@@ -78,6 +93,7 @@ type settlement =
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
+  | Settle_from_source_terminal of accepted_source_terminal
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -194,6 +210,15 @@ val transfer_pending_accepted :
     are checked before removal, and the source-bearing WAL remains the replay
     authority until the target projection completes. *)
 
+val settle_pending_from_source_terminal :
+  current_owner_generation:int ->
+  settled_at:float ->
+  source_terminal:accepted_source_terminal ->
+  t ->
+  (t * settle_result, string) result
+(** Terminally settle one exact pending event only when its closed payload
+    exactly matches [source_terminal.source_receipt]. *)
+
 val accepted_cancellation_replay :
   lease ->
   accepted_cancellation ->
@@ -216,6 +241,16 @@ val accepted_pending_transfer_replay :
   (transition_receipt option, string) result
 (** Look up an already committed pending transfer by its stable operator
     operation ID and exact source-bearing settlement. *)
+
+val accepted_pending_source_terminal_replay :
+  accepted_source_terminal ->
+  t ->
+  (transition_receipt option, string) result
+
+val source_terminal_receipt_of_stimulus :
+  Keeper_event_queue.stimulus -> (source_terminal_receipt, string) result
+(** Accept only [Fusion_completed], [Bg_completed], or [Hitl_resolved] and
+    retain their exact typed terminal payload. *)
 
 val replay_transition_receipt : transition_receipt -> t -> (t, string) result
 (** Apply one canonical durable receipt to its exact active lease. Replaying

--- a/test/dune
+++ b/test/dune
@@ -678,6 +678,11 @@
  (libraries alcotest masc_test_deps eio_main))
 
 (test
+ (name test_keeper_paused_work_source_terminal_transaction)
+ (modules test_keeper_paused_work_source_terminal_transaction)
+ (libraries alcotest masc_test_deps eio_main))
+
+(test
  (name test_keeper_current_operations)
  (modules test_keeper_current_operations)
  (libraries alcotest masc_test_deps))

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -29,7 +29,7 @@ let with_source_terminal_lane f =
   let base_path = Filename.temp_dir "keeper-paused-source-terminal" "" in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       remove_tree base_path)
     (fun () ->
        let config = Workspace.default_config base_path in

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -1,0 +1,225 @@
+open Masc
+
+module Queue = Keeper_event_queue
+module State = Keeper_event_queue_state
+module Persistence = Keeper_event_queue_persistence
+module Receipt = Keeper_paused_work_disposition_receipt
+module Transaction = Keeper_paused_work_source_terminal_transaction
+
+let require_ok label = function
+  | Ok value -> value
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
+let require_some label = function
+  | Some value -> value
+  | None -> Alcotest.failf "%s: expected Some" label
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_source_terminal_lane f =
+  let base_path = Filename.temp_dir "keeper-paused-source-terminal" "" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      remove_tree base_path)
+    (fun () ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "paused-source-terminal-owner" in
+       let meta =
+         Masc_test_deps.meta_of_json_fixture
+           (`Assoc
+              [ "name", `String keeper_name
+              ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
+              ; "trace_id", `String "trace-paused-source-terminal-owner"
+              ; "runtime_id", `String "runtime.primary"
+              ; "autoboot_enabled", `Bool false
+              ])
+         |> require_ok "parse Keeper metadata fixture"
+       in
+       let meta =
+         { meta with
+           paused = true
+         ; latched_reason =
+             Some
+               (Keeper_latched_reason.Operator_paused
+                  { operator_actor =
+                      Keeper_latched_reason.operator_actor_grpc_directive
+                  })
+         ; runtime = { meta.runtime with generation = 51 }
+         }
+       in
+       Keeper_meta_store.write_meta config meta |> require_ok "persist Keeper metadata";
+       let channel =
+         Keeper_continuation_channel.dashboard ~thread_id:"thread-terminal-1"
+         |> require_ok "construct terminal continuation channel"
+       in
+       let resolution : Queue.hitl_resolution =
+         { approval_id = "approval-terminal-1"
+         ; decision = Queue.Hitl_rejected "operator rejected"
+         ; channel
+         }
+       in
+       let source : Queue.stimulus =
+         { post_id = Queue.hitl_resolution_post_id resolution
+         ; urgency = Queue.Immediate
+         ; arrived_at = 1.0
+         ; payload = Queue.Hitl_resolved resolution
+         }
+       in
+       Persistence.update_result ~base_path ~keeper_name (fun pending ->
+         Queue.enqueue pending source)
+       |> require_ok "seed source-terminal event";
+       let source_revision =
+         Persistence.load_state_result ~base_path ~keeper_name
+         |> require_ok "load source-terminal revision"
+         |> State.revision
+       in
+       let request : Transaction.request =
+         { source
+         ; source_revision
+         ; owner_generation = meta.runtime.generation
+         ; source_receipt = State.Hitl_terminal resolution
+         ; operator_operation_id = "operator-source-terminal-1"
+         ; settled_at = 2.0
+         }
+       in
+       f config keeper_name meta request)
+;;
+
+let check_applied = function
+  | Transaction.Applied
+      (Keeper_registry_event_queue.Settled _
+      | Keeper_registry_event_queue.Already_settled _) -> ()
+  | Transaction.Applied
+      (Keeper_registry_event_queue.Committed_followup_failed { detail; _ }) ->
+    Alcotest.fail detail
+  | Transaction.Committed_followup_failed failure ->
+    Alcotest.fail
+      (Transaction.error_to_string
+         { cause = failure; reservation_release = None })
+;;
+
+let test_exact_terminal_receipt_settles_once () =
+  with_source_terminal_lane (fun config keeper_name meta request ->
+    let first =
+      Transaction.settle_pending config ~keeper_name request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "commit Settle_from_source_terminal"
+    in
+    (match first.commit_status with
+     | Transaction.Committed -> ()
+     | Transaction.Already_committed -> Alcotest.fail "first settlement was replayed");
+    check_applied first.projection;
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load source-terminal settlement"
+    in
+    Alcotest.(check int) "source removed" 0 (Queue.length (State.pending state));
+    (match State.transition_outbox state with
+     | [ { receipt = { settlement = State.Settle_from_source_terminal exact; _ }
+         ; stimuli = [ source ]
+         } ] ->
+       Alcotest.(check bool) "outbox retains exact source" true (source = request.source);
+       Alcotest.(check bool)
+         "outbox retains exact terminal receipt"
+         true
+         (exact.source_receipt = request.source_receipt)
+     | _ -> Alcotest.fail "source-terminal settlement outbox is not exact");
+    let replacement =
+      let resumed = Keeper_meta_contract.mark_resumed meta in
+      { resumed with runtime = { resumed.runtime with generation = 52 } }
+    in
+    Keeper_meta_store.write_meta config replacement
+    |> require_ok "persist replacement owner after settlement";
+    let replay =
+      Transaction.settle_pending config ~keeper_name request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "replay Settle_from_source_terminal"
+    in
+    (match replay.commit_status with
+     | Transaction.Already_committed -> ()
+     | Transaction.Committed -> Alcotest.fail "replay created another receipt");
+    check_applied replay.projection)
+;;
+
+let test_mismatched_terminal_receipt_is_rejected_before_commit () =
+  with_source_terminal_lane (fun config keeper_name _meta request ->
+    let other_channel =
+      Keeper_continuation_channel.dashboard ~thread_id:"thread-terminal-other"
+      |> require_ok "construct other terminal channel"
+    in
+    let mismatch : Queue.hitl_resolution =
+      { approval_id = "approval-terminal-other"
+      ; decision = Queue.Hitl_approved
+      ; channel = other_channel
+      }
+    in
+    let request = { request with source_receipt = State.Hitl_terminal mismatch } in
+    (match Transaction.settle_pending config ~keeper_name request with
+     | Error { cause = Transaction.Invalid_request _; _ } -> ()
+     | Error error -> Alcotest.fail (Transaction.error_to_string error)
+     | Ok _ -> Alcotest.fail "mismatched terminal receipt was accepted");
+    (match
+       Receipt.load
+         config
+         ~keeper_name
+         ~operator_operation_id:request.operator_operation_id
+     with
+     | Ok None -> ()
+     | Ok (Some _) -> Alcotest.fail "invalid terminal receipt was persisted"
+     | Error detail -> Alcotest.fail detail);
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load rejected source-terminal lane"
+    in
+    Alcotest.(check int) "invalid receipt retains source" 1 (Queue.length (State.pending state)))
+;;
+
+let test_nonterminal_payload_is_rejected () =
+  with_source_terminal_lane (fun config keeper_name _meta request ->
+    let bootstrap =
+      { request.source with
+        post_id = "nonterminal-bootstrap"
+      ; payload = Queue.Bootstrap
+      }
+    in
+    let request = { request with source = bootstrap } in
+    match Transaction.settle_pending config ~keeper_name request with
+    | Error { cause = Transaction.Invalid_request _; _ } -> ()
+    | Error error -> Alcotest.fail (Transaction.error_to_string error)
+    | Ok _ -> Alcotest.fail "nonterminal source payload was accepted")
+;;
+
+let () =
+  Alcotest.run
+    "keeper paused-work source-terminal transaction"
+    [ ( "Settle_from_source_terminal"
+      , [ Alcotest.test_case
+            "exact receipt settles once"
+            `Quick
+            test_exact_terminal_receipt_settles_once
+        ; Alcotest.test_case
+            "mismatched receipt is rejected"
+            `Quick
+            test_mismatched_terminal_receipt_is_rejected_before_commit
+        ; Alcotest.test_case
+            "nonterminal payload is rejected"
+            `Quick
+            test_nonterminal_payload_is_rejected
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Implements the typed pending-event slice of #25191 `Settle_from_source_terminal { source_receipt }`.

- admits only three closed terminal source families already present in durable queue payloads:
  - `Fusion_completed`
  - `Bg_completed`
  - `Hitl_resolved`
- rejects board/bootstrap/schedule/connector/failure/compaction/goal payloads without prose or age inference
- requires the supplied typed source receipt to equal the exact durable payload, including approval/job/run identity and continuation channel
- persists a v3 paused-work disposition receipt before queue projection while preserving v1 `Resume_owner` and v2 `Transfer_owner` decoding
- commits a source-bearing `Settle_from_source_terminal` WAL settlement before pending removal
- replays the canonical settlement after crashes and owner replacement without applying a second terminal effect
- shares one operation-ID conflict domain across cancel, transfer, and source-terminal dispositions
- adds coverage for exact settlement/replay, mismatched typed receipt rejection, and nonterminal payload rejection

## Safety boundary

This operation does not infer terminality from TTL, event text, idle time, or a fallback owner. The exact durable event payload is the typed source receipt authority.

## Validation

Passed locally:

- `ocamlc -stop-after parsing` for every changed `.ml` / `.mli`
- `ocamlformat --check` for every changed OCaml file
- `git diff --cached --check`
- static exhaustive-match and forbidden-pattern scans
- root `~/me` checkout remains on `main`

Not run locally by explicit operator request:

- Dune build
- test executables
- typecheck

The operator is running builds separately; this draft relies on PR CI for build/test authority.

## Stack

Base: `codex/paused-work-transfer-transaction-20260720` (#25358)
