### PR TITLE
fix(keeper): keep Board attention pending until judgment

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -40,13 +40,10 @@ type consumed_state =
   ; consumed_at : float
   }
 
-type expired_state = { expired_at : float }
-
 type status =
   | Pending of pending_state
   | Judged of judged_state
   | Consumed of consumed_state
-  | Expired of expired_state
 
 type candidate =
   { candidate_id : string
@@ -302,11 +299,6 @@ let status_to_yojson = function
       ; "delivery", `String (delivery_to_string consumed.delivery)
       ; "consumed_at", `Float consumed.consumed_at
       ]
-  | Expired expired ->
-    `Assoc
-      [ "kind", `String "expired"
-      ; "expired_at", `Float expired.expired_at
-      ]
 ;;
 
 let candidate_to_json candidate =
@@ -534,11 +526,6 @@ let status_of_yojson json =
     let* consumed_at_json = field ~context "consumed_at" fields in
     let* consumed_at = float_json ~context:(context ^ ".consumed_at") consumed_at_json in
     Ok (Consumed { judgment; delivery; consumed_at })
-  | "expired" ->
-    let* () = exact_fields ~context [ "kind"; "expired_at" ] fields in
-    let* expired_at_json = field ~context "expired_at" fields in
-    let* expired_at = float_json ~context:(context ^ ".expired_at") expired_at_json in
-    Ok (Expired { expired_at })
   | value -> Error (Printf.sprintf "unknown Board attention candidate status %S" value)
 ;;
 
@@ -795,7 +782,7 @@ let record_retryable_failure ~base_path candidate failure =
               { current with
                 status = Judged { judged with last_failure = Some failure }
               })
-       | Consumed _ | Expired _ -> None)
+       | Consumed _ -> None)
 ;;
 
 let record_judgment ~base_path candidate judgment =
@@ -810,7 +797,7 @@ let record_judgment ~base_path candidate judgment =
            { current with
              status = Judged { judgment; last_failure = None }
            }
-       | Judged _ | Consumed _ | Expired _ -> None)
+       | Judged _ | Consumed _ -> None)
 ;;
 
 let mark_consumed ~base_path candidate judgment delivery =
@@ -827,7 +814,7 @@ let mark_consumed ~base_path candidate judgment delivery =
                Consumed
                  { judgment; delivery; consumed_at = Time_compat.now () }
            }
-       | Pending _ | Consumed _ | Expired _ -> None)
+       | Pending _ | Consumed _ -> None)
 ;;
 
 let failure ~kind detail = { kind; detail; failed_at = Time_compat.now () }
@@ -930,7 +917,7 @@ let reject_unregistered_tool ~name ~args:_ =
 
 let rec process_with_judge ~base_path ~judge candidate =
   match candidate.status with
-  | Consumed _ | Expired _ -> Ok candidate
+  | Consumed _ -> Ok candidate
   | Judged judged -> consume_judged ~base_path candidate judged
   | Pending _ ->
     (match judge candidate with
@@ -953,7 +940,7 @@ let record_and_wake ~base_path candidate =
       match persisted.status with
       | Pending _ | Judged _ ->
         Wake_requested (request_owner_wake ~site:"duplicate" ~base_path persisted)
-      | Consumed _ | Expired _ -> Wake_not_required
+      | Consumed _ -> Wake_not_required
     in
     Ok
       { candidate = persisted
@@ -962,30 +949,10 @@ let record_and_wake ~base_path candidate =
       }
 ;;
 
-(* ── TTL and batch judgment ───────────────────────────── *)
+(* ── Batch judgment ───────────────────────────────────── *)
 
 let prompt_name_batch = Keeper_prompt_names.board_attention_judgment_batch
 let batch_max_candidates = 8
-let candidate_ttl_sec = 86_400.0
-
-let is_pending_expired ~now candidate =
-  match candidate.status with
-  | Pending _ ->
-    Float.compare candidate.recorded_at (now -. candidate_ttl_sec) < 0
-  | Judged _ | Consumed _ | Expired _ -> false
-;;
-
-let expire_candidate ~base_path ~now candidate =
-  update_candidate
-    ~base_path
-    candidate.candidate_id
-    candidate.keeper_name
-    (fun current ->
-       match current.status with
-       | Pending _ ->
-         Some { current with status = Expired { expired_at = now } }
-       | Judged _ | Consumed _ | Expired _ -> None)
-;;
 
 let batch_request_json candidates =
   let keeper_context_of candidate =
@@ -1169,35 +1136,18 @@ let record_batch_failure ~base_path candidate failure =
       detail
 ;;
 
-let drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch =
+let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
   let* candidates = load_candidates ~base_path ~keeper_name in
-  let stale, judged_ready, pending =
+  let judged_ready, pending =
     List.fold_left
-      (fun (stale, judged_ready, pending) candidate ->
+      (fun (judged_ready, pending) candidate ->
          match candidate.status with
-         | Pending _ when is_pending_expired ~now candidate ->
-           candidate :: stale, judged_ready, pending
-         | Pending _ -> stale, judged_ready, candidate :: pending
-         | Judged judged -> stale, (candidate, judged) :: judged_ready, pending
-         | Consumed _ | Expired _ -> stale, judged_ready, pending)
-      ([], [], [])
+         | Pending _ -> judged_ready, candidate :: pending
+         | Judged judged -> (candidate, judged) :: judged_ready, pending
+         | Consumed _ -> judged_ready, pending)
+      ([], [])
       candidates
   in
-  (* Stale pending rows expire first: the durable backlog must die even while
-     the provider is unavailable. *)
-  let* () =
-    List.fold_left
-      (fun result candidate ->
-         match result with
-         | Error _ -> result
-         | Ok () ->
-           (match expire_candidate ~base_path ~now candidate with
-            | Ok _ -> Ok ()
-            | Error detail -> Error detail))
-      (Ok ())
-      stale
-  in
-  let expired_count = List.length stale in
   (* Already-judged verdicts deliver without new model calls. *)
   let* judged_consumed, judged_remaining =
     List.fold_left
@@ -1209,7 +1159,7 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch =
             | Ok current ->
               (match current.status with
                | Consumed _ -> Ok (consumed + 1, remaining)
-               | Pending _ | Judged _ | Expired _ -> Ok (consumed, remaining + 1))
+               | Pending _ | Judged _ -> Ok (consumed, remaining + 1))
             | Error detail -> Error detail))
       (Ok (0, 0))
       judged_ready
@@ -1250,7 +1200,7 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch =
                        | Ok current ->
                          (match current.status with
                           | Consumed _ -> Ok (consumed + 1, remaining)
-                          | Pending _ | Judged _ | Expired _ ->
+                          | Pending _ | Judged _ ->
                             Ok (consumed, remaining + 1))
                        | Error detail -> Error detail)))
               (Ok (0, 0))
@@ -1268,7 +1218,7 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch =
   let* batch_report = loop { attempted = 0; consumed = 0; remaining = 0 } batches in
   Ok
     { attempted = batch_report.attempted + judged_consumed + judged_remaining
-    ; consumed = batch_report.consumed + judged_consumed + expired_count
+    ; consumed = batch_report.consumed + judged_consumed
     ; remaining = batch_report.remaining + judged_remaining
     }
 ;;
@@ -1277,14 +1227,13 @@ let drain_pending_on_owner_lane ~base_path ~keeper_name =
   drain_pending_with_judge_batch
     ~base_path
     ~keeper_name
-    ~now:(Time_compat.now ())
     ~judge_batch:(run_judge_batch ~base_path)
 ;;
 
 module For_testing = struct
   let drain_pending_with_judge_batch = drain_pending_with_judge_batch
 
-  let drain_pending_with_judge ~base_path ~keeper_name ~now ~judge =
+  let drain_pending_with_judge ~base_path ~keeper_name ~judge =
     let judge_batch candidates =
       let rec fold map = function
         | [] -> Ok map
@@ -1296,7 +1245,7 @@ module For_testing = struct
       in
       fold Candidate_map.empty candidates
     in
-    drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch
+    drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch
   ;;
 end
 ;;

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -1,11 +1,11 @@
 (** Durable Board-attention judgment boundary.
 
     A candidate is persisted before any model call. Its lifecycle is
-    [Pending -> Judged -> Consumed], with [Pending -> Expired] as the terminal
-    path for rows that outlived their relevance window. Relevant judgments
-    become normal Keeper-lane events only after an exact candidate-id durable
-    queue commit; failures retain the latest retryable evidence and never
-    consume the candidate. *)
+    [Pending -> Judged -> Consumed]. Relevant judgments become normal
+    Keeper-lane events only after an exact candidate-id durable queue commit;
+    failures retain the latest retryable evidence and never consume the
+    candidate. Pending work has no wall-clock expiry: it remains durable until
+    judgment and delivery succeed. *)
 
 type retryable_failure_kind =
   | Runtime_configuration_unavailable
@@ -43,13 +43,10 @@ type consumed_state =
   ; consumed_at : float
   }
 
-type expired_state = { expired_at : float }
-
 type status =
   | Pending of pending_state
   | Judged of judged_state
   | Consumed of consumed_state
-  | Expired of expired_state
 
 type candidate =
   { candidate_id : string
@@ -149,21 +146,14 @@ val drain_pending_on_owner_lane :
     dashboard/producer domain may call it.
 
     Semantics:
-    - Pending rows older than {!candidate_ttl_sec} transition to [Expired]
-      first; the durable backlog dies even while the provider is unavailable.
     - Already-judged verdicts deliver without new model calls.
-    - Fresh pending rows are judged in batches of up to
+    - Pending rows are judged in batches of up to
       {!batch_max_candidates} per model call. A failed batch aborts the round:
       the next keepalive turn owns the retry cadence, so provider outages
       cannot turn the drain into a hot retry loop.
     - Verdicts referencing unknown or duplicate candidate identities are
       rejected as response-contract failures. Candidates absent from a
-      successful batch verdict stay [Pending] without failure evidence.
-    [drain_report.consumed] includes expired rows. *)
-
-val candidate_ttl_sec : float
-(** Operational policy constant: a pending candidate older than this many
-    seconds (24h) is expired by the next drain. *)
+      successful batch verdict stay [Pending] without failure evidence. *)
 
 val batch_max_candidates : int
 (** Maximum candidates judged per model call. *)
@@ -174,7 +164,6 @@ module For_testing : sig
   val drain_pending_with_judge :
     base_path:string ->
     keeper_name:string ->
-    now:float ->
     judge:(candidate -> (judgment, retryable_failure) result) ->
     (drain_report, string) result
   (** Per-candidate judging adapter over the batch engine. *)
@@ -182,7 +171,6 @@ module For_testing : sig
   val drain_pending_with_judge_batch :
     base_path:string ->
     keeper_name:string ->
-    now:float ->
     judge_batch:(candidate list -> (judgment Candidate_map.t, retryable_failure) result) ->
     (drain_report, string) result
 end

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -136,7 +136,7 @@ let test_roundtrip_preserves_full_evidence_and_pending_state () =
   let candidate = candidate () in
   (match candidate.status with
    | A.Pending { last_failure = None } -> ()
-   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
      Alcotest.fail "new candidate was not clean Pending");
   let request_fields =
     match candidate.judgment_request with
@@ -204,7 +204,7 @@ let test_worker_record_wakes_then_owner_lane_drains () =
             } ->
           (match persisted.status with
            | A.Pending { last_failure = None } -> ()
-           | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+           | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
              Alcotest.fail "worker-side record invoked or mutated the judgment")
         | Ok _ -> Alcotest.fail "worker-side record returned the wrong typed acceptance"
         | Error detail -> Alcotest.failf "worker-side record failed: %s" detail);
@@ -218,7 +218,6 @@ let test_worker_record_wakes_then_owner_lane_drains () =
            A.For_testing.drain_pending_with_judge
              ~base_path
              ~keeper_name:pending.keeper_name
-             ~now:100.0
              ~judge:(fun _ -> Ok (judgment J.Relevant))
          with
          | Ok report -> report
@@ -270,7 +269,7 @@ let test_retryable_judge_failure_remains_pending () =
       "typed failure preserved"
       "provider_unavailable"
       (A.retryable_failure_kind_to_string observed.kind)
-  | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+  | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
     Alcotest.fail "retryable judge failure consumed the candidate"
 ;;
 
@@ -289,7 +288,7 @@ let test_not_relevant_transitions_directly_to_consumed () =
   in
   (match current.status with
    | A.Consumed { delivery = A.Not_relevant; _ } -> ()
-   | A.Consumed _ | A.Pending _ | A.Judged _ | A.Expired _ ->
+   | A.Consumed _ | A.Pending _ | A.Judged _ ->
      Alcotest.fail "not-relevant verdict did not reach Consumed");
   let queue =
     Keeper_event_queue_persistence.load
@@ -317,7 +316,7 @@ let test_relevant_consumes_only_after_exact_durable_enqueue () =
   in
   (match current.status with
    | A.Consumed { delivery = A.Enqueued_to_keeper_lane; _ } -> ()
-   | A.Consumed _ | A.Pending _ | A.Judged _ | A.Expired _ ->
+   | A.Consumed _ | A.Pending _ | A.Judged _ ->
      Alcotest.fail "relevant verdict consumed before durable delivery");
   let queue =
     Keeper_event_queue_persistence.load
@@ -368,7 +367,7 @@ let test_delivery_storage_error_retains_judged_state () =
   | A.Judged
       { last_failure = Some { kind = A.Durable_delivery_unavailable; _ }; _ } ->
     ()
-  | A.Judged _ | A.Pending _ | A.Consumed _ | A.Expired _ ->
+  | A.Judged _ | A.Pending _ | A.Consumed _ ->
     Alcotest.fail "durable delivery storage error did not retain Judged"
 ;;
 
@@ -470,7 +469,7 @@ let test_update_ledger_compacts_to_distinct () =
          "latest failure wins after compaction"
          "provider unavailable 5"
          observed.detail
-     | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+     | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
        Alcotest.fail "compaction dropped the latest pending failure")
   | Ok candidates ->
     Alcotest.failf "expected one compacted candidate, got %d" (List.length candidates)
@@ -615,8 +614,8 @@ let all_not_relevant candidates =
        candidates)
 ;;
 
-let test_drain_expires_stale_pending_without_model_call () =
-  with_temp_base "board-attention-ttl" @@ fun base_path ->
+let test_pending_has_no_wall_clock_expiry () =
+  with_temp_base "board-attention-no-expiry" @@ fun base_path ->
   let keeper_name = "sangsu" in
   let _ = record_or_fail ~base_path (candidate ~keeper_name ()) in
   let report =
@@ -624,43 +623,18 @@ let test_drain_expires_stale_pending_without_model_call () =
       A.For_testing.drain_pending_with_judge_batch
         ~base_path
         ~keeper_name
-        ~now:(100.0 +. A.candidate_ttl_sec +. 1.0)
-        ~judge_batch:(fun _ ->
-          Alcotest.fail "stale candidate reached the model judge")
-    with
-    | Ok report -> report
-    | Error detail -> Alcotest.failf "ttl drain failed: %s" detail
-  in
-  Alcotest.(check int) "no model attempt for stale rows" 0 report.attempted;
-  Alcotest.(check int) "stale row counted as consumed" 1 report.consumed;
-  Alcotest.(check int) "nothing remains" 0 report.remaining;
-  match (only_loaded ~base_path ~keeper_name).status with
-  | A.Expired _ -> ()
-  | A.Pending _ | A.Judged _ | A.Consumed _ ->
-    Alcotest.fail "stale candidate was not expired"
-;;
-
-let test_drain_fresh_pending_is_not_expired () =
-  with_temp_base "board-attention-fresh" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  let _ = record_or_fail ~base_path (candidate ~keeper_name ()) in
-  let report =
-    match
-      A.For_testing.drain_pending_with_judge_batch
-        ~base_path
-        ~keeper_name
-        ~now:100.0
         ~judge_batch:all_not_relevant
     with
     | Ok report -> report
-    | Error detail -> Alcotest.failf "fresh drain failed: %s" detail
+    | Error detail -> Alcotest.failf "pending drain failed: %s" detail
   in
-  Alcotest.(check int) "fresh row attempted" 1 report.attempted;
-  Alcotest.(check int) "fresh row consumed" 1 report.consumed;
+  Alcotest.(check int) "pending row attempted" 1 report.attempted;
+  Alcotest.(check int) "pending row consumed" 1 report.consumed;
+  Alcotest.(check int) "nothing remains" 0 report.remaining;
   match (only_loaded ~base_path ~keeper_name).status with
   | A.Consumed { delivery = A.Not_relevant; _ } -> ()
-  | A.Consumed _ | A.Pending _ | A.Judged _ | A.Expired _ ->
-    Alcotest.fail "fresh candidate did not consume as not_relevant"
+  | A.Consumed _ | A.Pending _ | A.Judged _ ->
+    Alcotest.fail "durable pending candidate did not reach judgment"
 ;;
 
 let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
@@ -677,7 +651,6 @@ let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
       A.For_testing.drain_pending_with_judge_batch
         ~base_path
         ~keeper_name
-        ~now:100.0
         ~judge_batch:(fun _ ->
           Ok
             (A.Candidate_map.add
@@ -724,7 +697,6 @@ let test_batch_failure_aborts_round_and_records_evidence () =
       A.For_testing.drain_pending_with_judge_batch
         ~base_path
         ~keeper_name
-        ~now:100.0
         ~judge_batch:(fun _ -> Error failure)
     with
     | Ok report -> report
@@ -766,16 +738,28 @@ let test_batch_failure_aborts_round_and_records_evidence () =
      | None -> Alcotest.fail "deferred candidate vanished")
 ;;
 
-let test_expired_status_codec_roundtrip () =
-  let fixture = candidate () in
-  let expired = { fixture with status = A.Expired { expired_at = 123.5 } } in
-  match A.candidate_of_json (A.candidate_to_json expired) with
-  | Ok decoded ->
-    (match decoded.status with
-     | A.Expired { expired_at } -> Alcotest.(check (float 0.001)) "expired_at" 123.5 expired_at
-     | A.Pending _ | A.Judged _ | A.Consumed _ ->
-       Alcotest.fail "expired status did not roundtrip")
-  | Error detail -> Alcotest.failf "expired codec failed: %s" detail
+let test_removed_expired_status_is_rejected () =
+  let fixture = A.candidate_to_json (candidate ()) in
+  let legacy =
+    match fixture with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+              if String.equal key "status"
+              then
+                ( key
+                , `Assoc
+                    [ "kind", `String "expired"
+                    ; "expired_at", `Float 123.5
+                    ] )
+              else key, value)
+           fields)
+    | _ -> Alcotest.fail "candidate fixture must encode as an object"
+  in
+  match A.candidate_of_json legacy with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "removed expired status was accepted"
 ;;
 
 let test_batch_verdict_codec_roundtrip () =
@@ -887,13 +871,9 @@ let () =
         ] )
     ; ( "batch drain"
       , [ Alcotest.test_case
-            "stale pending expires without model call"
+            "pending work has no wall-clock expiry"
             `Quick
-            test_drain_expires_stale_pending_without_model_call
-        ; Alcotest.test_case
-            "fresh pending is not expired"
-            `Quick
-            test_drain_fresh_pending_is_not_expired
+            test_pending_has_no_wall_clock_expiry
         ; Alcotest.test_case
             "missing verdict keeps candidate pending"
             `Quick
@@ -903,9 +883,9 @@ let () =
             `Quick
             test_batch_failure_aborts_round_and_records_evidence
         ; Alcotest.test_case
-            "expired status codec roundtrip"
+            "removed expired status is rejected"
             `Quick
-            test_expired_status_codec_roundtrip
+            test_removed_expired_status_is_rejected
         ; Alcotest.test_case
             "batch verdict codec roundtrip"
             `Quick


### PR DESCRIPTION
## Problem

Board attention candidates could transition from Pending to Expired solely from a 24-hour wall-clock TTL. That silently terminalized accepted durable work without an LLM judgment or durable delivery, violating the mixed-workload no-loss contract.

## Change

- delete the Expired state and its runtime codec
- delete candidate_ttl_sec and all wall-clock expiry transitions
- remove the unused now authority from the internal drain test surface
- keep Pending candidates durable until judgment and delivery succeed
- reject legacy expired wire rows explicitly as an unknown status

No runtime migration is included: the live base-path store contained no expired rows when checked, and silently converting discarded work back to Pending would invent recovery semantics.

This is the first small lifecycle leaf recut from the oversized #25092 stack. It intentionally does not retain that PRs fixed-cap governance, context batching, atomic commit, or worker-plane changes.

## Validation

- ocamlformat --check on all three touched files
- git diff --check
- scripts/dune-local.sh build test/test_keeper_board_attention_candidate.exe
- scripts/dune-local.sh exec ./test/test_keeper_board_attention_candidate.exe: 18/18 passed

The shared local switch had an unrelated agent_sdk pin drift, so the focused wrapper build/test used its documented one-shot MASC_SKIP_PIN_CHECK=1 bypass. PR CI remains the build authority.