### PR TITLE
fix(keeper): require exact Board attention batch responses

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -708,20 +708,30 @@ let update_ledger ~base_path ~keeper_name decide =
      made every update O(n^2) because the durable transaction re-parses the whole
      ledger before writing. Rewriting keeps the file bounded to the number of
      distinct candidates. *)
-  match
-    Fs_compat.rewrite_private_file_durable_locked_result path (fun content ->
-      match load_candidates_from_content content with
-      | Error detail -> None, Error detail
-      | Ok candidates ->
-        (match decide candidates with
-         | Error _ as error -> None, error
-         | Ok (None, result) -> None, Ok result
-         | Ok (Some candidate, result) ->
-           let compacted = latest_candidates (candidates @ [ candidate ]) in
-           Some (serialize_candidates compacted), Ok result))
+  try
+    match
+      Fs_compat.rewrite_private_file_durable_locked_result path (fun content ->
+        match load_candidates_from_content content with
+        | Error detail -> None, Error detail
+        | Ok candidates ->
+          (match decide candidates with
+           | Error _ as error -> None, error
+           | Ok (None, result) -> None, Ok result
+           | Ok (Some candidate, result) ->
+             let compacted = latest_candidates (candidates @ [ candidate ]) in
+             Some (serialize_candidates compacted), Ok result))
+    with
+    | Error error -> Error error
+    | Ok result -> result
   with
-  | Error error -> Error error
-  | Ok result -> result
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "Board attention ledger update failed keeper=%s path=%s: %s"
+         keeper_name
+         path
+         (Printexc.to_string exn))
 ;;
 
 let find_candidate candidates candidate_id =
@@ -1126,14 +1136,51 @@ let chunks_of size items =
 
 let record_batch_failure ~base_path candidate failure =
   match record_retryable_failure ~base_path candidate failure with
-  | Ok _ -> ()
+  | Ok _ -> Ok ()
   | Error detail ->
-    Log.Keeper.error
-      "Board attention batch failure evidence could not be persisted keeper=%s \
-       candidate=%s: %s"
-      candidate.keeper_name
-      candidate.candidate_id
-      detail
+    Error
+      (Printf.sprintf
+         "Board attention batch failure evidence could not be persisted keeper=%s \
+          candidate=%s: %s"
+         candidate.keeper_name
+         candidate.candidate_id
+         detail)
+;;
+
+let record_batch_failures ~base_path candidates failure =
+  List.fold_left
+    (fun result candidate ->
+       let* () = result in
+       record_batch_failure ~base_path candidate failure)
+    (Ok ())
+    candidates
+;;
+
+let validate_batch_coverage candidates judgments =
+  let requested =
+    List.fold_left
+      (fun ids candidate -> Id_set.add candidate.candidate_id ids)
+      Id_set.empty
+      candidates
+  in
+  let returned =
+    Candidate_map.fold
+      (fun candidate_id _ ids -> Id_set.add candidate_id ids)
+      judgments
+      Id_set.empty
+  in
+  if Id_set.equal requested returned
+  then Ok ()
+  else
+    let missing = Id_set.diff requested returned |> Id_set.elements in
+    let unknown = Id_set.diff returned requested |> Id_set.elements in
+    Error
+      (failure
+         ~kind:Response_contract_unavailable
+         (Printf.sprintf
+            "batch verdict identity mismatch missing=[%s] unknown=[%s]"
+            (String.concat "," missing)
+            (String.concat "," unknown)))
 ;;
 
 let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
@@ -1170,50 +1217,59 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
   let rec loop report = function
     | [] -> Ok report
     | batch :: rest ->
+      let deferred =
+        List.fold_left
+          (fun count rest_batch -> count + List.length rest_batch)
+          (List.length batch)
+          rest
+      in
       (match judge_batch batch with
        | Error failure ->
-         List.iter
-           (fun candidate -> record_batch_failure ~base_path candidate failure)
-           batch;
-         let deferred =
-           List.fold_left
-             (fun count rest_batch -> count + List.length rest_batch)
-             (List.length batch)
-             rest
-         in
+         let* () = record_batch_failures ~base_path batch failure in
          Ok
            { report with
              attempted = report.attempted + List.length batch
            ; remaining = report.remaining + deferred
            }
        | Ok map ->
-         (match
-            List.fold_left
-              (fun result candidate ->
-                 match result with
-                 | Error _ -> result
-                 | Ok (consumed, remaining) ->
-                   (match Candidate_map.find_opt candidate.candidate_id map with
-                    | None -> Ok (consumed, remaining + 1)
-                    | Some judgment ->
-                      (match apply_judgment ~base_path candidate judgment with
-                       | Ok current ->
-                         (match current.status with
-                          | Consumed _ -> Ok (consumed + 1, remaining)
-                          | Pending _ | Judged _ ->
-                            Ok (consumed, remaining + 1))
-                       | Error detail -> Error detail)))
-              (Ok (0, 0))
-              batch
-          with
-          | Error detail -> Error detail
-          | Ok (consumed, remaining) ->
-            loop
-              { attempted = report.attempted + List.length batch
-              ; consumed = report.consumed + consumed
-              ; remaining = report.remaining + remaining
+         (match validate_batch_coverage batch map with
+          | Error failure ->
+            let* () = record_batch_failures ~base_path batch failure in
+            Ok
+              { report with
+                attempted = report.attempted + List.length batch
+              ; remaining = report.remaining + deferred
               }
-              rest))
+          | Ok () ->
+            (match
+               List.fold_left
+                 (fun result candidate ->
+                    match result with
+                    | Error _ -> result
+                    | Ok (consumed, remaining) ->
+                      (match Candidate_map.find_opt candidate.candidate_id map with
+                       | None ->
+                         Error
+                           "validated batch verdict disappeared before application"
+                       | Some judgment ->
+                         (match apply_judgment ~base_path candidate judgment with
+                          | Ok current ->
+                            (match current.status with
+                             | Consumed _ -> Ok (consumed + 1, remaining)
+                             | Pending _ | Judged _ ->
+                               Ok (consumed, remaining + 1))
+                          | Error detail -> Error detail)))
+                 (Ok (0, 0))
+                 batch
+             with
+             | Error detail -> Error detail
+             | Ok (consumed, remaining) ->
+               loop
+                 { attempted = report.attempted + List.length batch
+                 ; consumed = report.consumed + consumed
+                 ; remaining = report.remaining + remaining
+                 }
+                 rest)))
   in
   let* batch_report = loop { attempted = 0; consumed = 0; remaining = 0 } batches in
   Ok

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -151,9 +151,11 @@ val drain_pending_on_owner_lane :
       {!batch_max_candidates} per model call. A failed batch aborts the round:
       the next keepalive turn owns the retry cadence, so provider outages
       cannot turn the drain into a hot retry loop.
-    - Verdicts referencing unknown or duplicate candidate identities are
-      rejected as response-contract failures. Candidates absent from a
-      successful batch verdict stay [Pending] without failure evidence. *)
+    - A successful response must cover the exact requested candidate-id set.
+      Unknown, duplicate, or missing identities fail the attempted batch and
+      persist retryable response-contract evidence on every requested row.
+    - Failure-evidence persistence errors propagate to the caller; they are
+      never reduced to logs. *)
 
 val batch_max_candidates : int
 (** Maximum candidates judged per model call. *)

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -637,7 +637,7 @@ let test_pending_has_no_wall_clock_expiry () =
     Alcotest.fail "durable pending candidate did not reach judgment"
 ;;
 
-let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
+let test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence () =
   with_temp_base "board-attention-partial" @@ fun base_path ->
   let keeper_name = "sangsu" in
   let first = record_or_fail ~base_path (candidate ~keeper_name ()) in
@@ -662,18 +662,29 @@ let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
     | Error detail -> Alcotest.failf "partial drain failed: %s" detail
   in
   Alcotest.(check int) "both attempted" 2 report.attempted;
-  Alcotest.(check int) "one consumed" 1 report.consumed;
-  Alcotest.(check int) "one remains" 1 report.remaining;
+  Alcotest.(check int) "partial response consumes nothing" 0 report.consumed;
+  Alcotest.(check int) "whole batch remains" 2 report.remaining;
   match A.load_candidates ~base_path ~keeper_name with
   | Ok candidates ->
-    (match
-       List.find_opt
-         (fun (c : A.candidate) -> String.equal c.candidate_id second.candidate_id)
-         candidates
-     with
-     | Some { status = A.Pending { last_failure = None }; _ } -> ()
-     | Some _ -> Alcotest.fail "unjudged candidate gained failure evidence"
-     | None -> Alcotest.fail "unjudged candidate vanished from the ledger")
+    List.iter
+      (fun (target : A.candidate) ->
+         match
+           List.find_opt
+             (fun (c : A.candidate) -> String.equal c.candidate_id target.candidate_id)
+             candidates
+         with
+         | Some
+             { status =
+                 A.Pending
+                   { last_failure =
+                       Some { kind = A.Response_contract_unavailable; _ }
+                   }
+             ; _
+             } ->
+           ()
+         | Some _ -> Alcotest.fail "partial response lacked contract-failure evidence"
+         | None -> Alcotest.fail "partial-response candidate vanished")
+      [ first; second ]
   | Error detail -> Alcotest.failf "candidate load failed: %s" detail
 ;;
 
@@ -736,6 +747,30 @@ let test_batch_failure_aborts_round_and_records_evidence () =
      | Some { status = A.Pending { last_failure = None }; _ } -> ()
      | Some _ -> Alcotest.fail "deferred batch gained failure evidence"
      | None -> Alcotest.fail "deferred candidate vanished")
+;;
+
+let test_batch_failure_evidence_write_error_propagates () =
+  with_temp_base "board-attention-failure-write" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  ignore (record_or_fail ~base_path (candidate ~keeper_name ()) : A.candidate);
+  let path = ledger_path_or_fail ~base_path ~keeper_name in
+  let failure : A.retryable_failure =
+    { kind = A.Provider_unavailable
+    ; detail = "provider unavailable"
+    ; failed_at = 100.0
+    }
+  in
+  match
+    A.For_testing.drain_pending_with_judge_batch
+      ~base_path
+      ~keeper_name
+      ~judge_batch:(fun _ ->
+        Sys.remove path;
+        Unix.mkdir path 0o700;
+        Error failure)
+  with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "failure-evidence storage error was silently accepted"
 ;;
 
 let test_removed_expired_status_is_rejected () =
@@ -875,13 +910,17 @@ let () =
             `Quick
             test_pending_has_no_wall_clock_expiry
         ; Alcotest.test_case
-            "missing verdict keeps candidate pending"
+            "missing verdict fails whole batch with evidence"
             `Quick
-            test_batch_verdict_missing_candidate_stays_pending_without_failure
+            test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence
         ; Alcotest.test_case
             "batch failure aborts round with evidence"
             `Quick
             test_batch_failure_aborts_round_and_records_evidence
+        ; Alcotest.test_case
+            "batch failure evidence write error propagates"
+            `Quick
+            test_batch_failure_evidence_write_error_propagates
         ; Alcotest.test_case
             "removed expired status is rejected"
             `Quick


### PR DESCRIPTION
## Stack

Depends on #25363. Review only commit 1dd690c285.

## Problem

A successful batch response could omit requested candidate IDs. The returned subset was consumed while omitted durable work stayed Pending without typed failure evidence. Batch failure-evidence writes were also reduced to logs, and lower ledger I/O exceptions could escape a result-returning API.

## Change

- require the returned candidate-id set to equal the requested set
- treat missing or unknown identities as Response_contract_unavailable for the whole attempted batch
- persist the typed failure on every requested candidate before returning a non-consuming report
- propagate failure-evidence persistence errors instead of logging and continuing
- normalize non-cancellation ledger I/O exceptions at the Board attention persistence boundary

This leaf does not add context grouping, guessed capacity, one-call-per-admission governance, or atomic multi-row judgment commit. Those remain separate reviewable changes.

## Validation

- ocamlformat --check on touched files
- git diff --check
- focused executable build passed
- test_keeper_board_attention_candidate: 19/19 passed, including missing-ID and failure-evidence-storage cases

The shared local switch has unrelated agent_sdk pin drift, so focused build/test used the wrapper documented one-shot MASC_SKIP_PIN_CHECK=1 bypass. PR CI remains authoritative.