### PR TITLE
fix(keeper): commit Board attention judgments atomically

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -699,7 +699,7 @@ let serialize_candidates candidates =
   String.concat "" (List.map append_row candidates)
 ;;
 
-let update_ledger ~base_path ~keeper_name decide =
+let update_ledger_many ~base_path ~keeper_name decide =
   let path = candidate_path ~base_path ~keeper_name in
   (* Compact on write: a committed change rewrites the ledger as the deduped
      latest-per-id set (via [latest_candidates]) instead of appending one row.
@@ -717,8 +717,8 @@ let update_ledger ~base_path ~keeper_name decide =
           (match decide candidates with
            | Error _ as error -> None, error
            | Ok (None, result) -> None, Ok result
-           | Ok (Some candidate, result) ->
-             let compacted = latest_candidates (candidates @ [ candidate ]) in
+           | Ok (Some updated, result) ->
+             let compacted = latest_candidates (candidates @ updated) in
              Some (serialize_candidates compacted), Ok result))
     with
     | Error error -> Error error
@@ -732,6 +732,14 @@ let update_ledger ~base_path ~keeper_name decide =
          keeper_name
          path
          (Printexc.to_string exn))
+;;
+
+let update_ledger ~base_path ~keeper_name decide =
+  update_ledger_many ~base_path ~keeper_name (fun candidates ->
+    match decide candidates with
+    | Error _ as error -> error
+    | Ok (None, result) -> Ok (None, result)
+    | Ok (Some candidate, result) -> Ok (Some [ candidate ], result))
 ;;
 
 let find_candidate candidates candidate_id =
@@ -1116,10 +1124,6 @@ let run_judge_batch ~base_path candidates =
 
 (* ── Owner-lane batch drain ───────────────────────────── *)
 
-let apply_judgment ~base_path candidate judgment =
-  process_with_judge ~base_path ~judge:(fun _ -> Ok judgment) candidate
-;;
-
 let chunks_of size items =
   let rec loop current count chunks = function
     | [] ->
@@ -1183,6 +1187,80 @@ let validate_batch_coverage candidates judgments =
             (String.concat "," unknown)))
 ;;
 
+let record_batch_judgments ~base_path ~keeper_name candidates judgments =
+  match candidates with
+  | [] -> Ok []
+  | _ ->
+    let* requested =
+      List.fold_left
+        (fun result candidate ->
+           let* ids = result in
+           if not (String.equal candidate.keeper_name keeper_name)
+           then
+             Error
+               (Printf.sprintf
+                  "Board attention atomic batch keeper mismatch expected=%s actual=%s \
+                   candidate=%s"
+                  keeper_name
+                  candidate.keeper_name
+                  candidate.candidate_id)
+           else if Id_set.mem candidate.candidate_id ids
+           then
+             Error
+               (Printf.sprintf
+                  "duplicate candidate in Board attention atomic batch: %s"
+                  candidate.candidate_id)
+           else Ok (Id_set.add candidate.candidate_id ids))
+        (Ok Id_set.empty)
+        candidates
+    in
+    update_ledger_many ~base_path ~keeper_name (fun current_rows ->
+      let current_by_id =
+        List.fold_left
+          (fun map candidate -> Candidate_map.add candidate.candidate_id candidate map)
+          Candidate_map.empty
+          current_rows
+      in
+      let* updated =
+        List.fold_left
+          (fun result candidate ->
+             let* rows = result in
+             match Candidate_map.find_opt candidate.candidate_id current_by_id with
+             | None ->
+               Error
+                 (Printf.sprintf
+                    "Board attention candidate not found for atomic judgment commit: %s"
+                    candidate.candidate_id)
+             | Some current ->
+               (match current.status with
+                | Judged _ | Consumed _ ->
+                  Error
+                    (Printf.sprintf
+                       "Board attention candidate is not Pending for atomic judgment \
+                        commit: %s"
+                       candidate.candidate_id)
+                | Pending _ ->
+                  (match Candidate_map.find_opt candidate.candidate_id judgments with
+                   | None ->
+                     Error
+                       (Printf.sprintf
+                          "Board attention judgment missing from validated atomic batch: %s"
+                          candidate.candidate_id)
+                   | Some judgment ->
+                     Ok
+                       ({ current with
+                          status = Judged { judgment; last_failure = None }
+                        }
+                        :: rows))))
+          (Ok [])
+          candidates
+        |> Result.map List.rev
+      in
+      if Id_set.cardinal requested <> List.length updated
+      then Error "Board attention atomic judgment commit cardinality changed"
+      else Ok (Some updated, updated))
+;;
+
 let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
   let* candidates = load_candidates ~base_path ~keeper_name in
   let judged_ready, pending =
@@ -1241,18 +1319,23 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
               ; remaining = report.remaining + deferred
               }
           | Ok () ->
+            let* judged =
+              record_batch_judgments ~base_path ~keeper_name batch map
+            in
             (match
                List.fold_left
                  (fun result candidate ->
                     match result with
                     | Error _ -> result
                     | Ok (consumed, remaining) ->
-                      (match Candidate_map.find_opt candidate.candidate_id map with
-                       | None ->
+                      (match candidate.status with
+                       | Pending _ | Consumed _ ->
                          Error
-                           "validated batch verdict disappeared before application"
-                       | Some judgment ->
-                         (match apply_judgment ~base_path candidate judgment with
+                           (Printf.sprintf
+                              "atomic judgment commit returned non-Judged candidate: %s"
+                              candidate.candidate_id)
+                       | Judged judged_state ->
+                         (match consume_judged ~base_path candidate judged_state with
                           | Ok current ->
                             (match current.status with
                              | Consumed _ -> Ok (consumed + 1, remaining)
@@ -1260,7 +1343,7 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
                                Ok (consumed, remaining + 1))
                           | Error detail -> Error detail)))
                  (Ok (0, 0))
-                 batch
+                 judged
              with
              | Error detail -> Error detail
              | Ok (consumed, remaining) ->

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -154,6 +154,10 @@ val drain_pending_on_owner_lane :
     - A successful response must cover the exact requested candidate-id set.
       Unknown, duplicate, or missing identities fail the attempted batch and
       persist retryable response-contract evidence on every requested row.
+    - An exact response commits all requested [Pending -> Judged] transitions
+      in one candidate-ledger rewrite or commits none. Durable queue delivery
+      and terminal [Consumed] transitions then proceed idempotently from the
+      committed judgments; they are not presented as a cross-file transaction.
     - Failure-evidence persistence errors propagate to the caller; they are
       never reduced to logs. *)
 

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -773,6 +773,49 @@ let test_batch_failure_evidence_write_error_propagates () =
   | Ok _ -> Alcotest.fail "failure-evidence storage error was silently accepted"
 ;;
 
+let test_atomic_judgment_commit_failure_preserves_all_pending () =
+  with_temp_base "board-attention-atomic-judgment-failure" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  List.iter
+    (fun post_id ->
+       ignore
+         (record_or_fail
+            ~base_path
+            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())
+          : A.candidate))
+    [ "post-1"; "post-2" ];
+  let path = ledger_path_or_fail ~base_path ~keeper_name in
+  let backup = path ^ ".before-atomic-commit" in
+  let result =
+    Fun.protect
+      ~finally:(fun () ->
+        if Sys.file_exists path && Sys.is_directory path then Unix.rmdir path;
+        if Sys.file_exists backup then Sys.rename backup path)
+      (fun () ->
+         A.For_testing.drain_pending_with_judge_batch
+           ~base_path
+           ~keeper_name
+           ~judge_batch:(fun candidates ->
+             Sys.rename path backup;
+             Unix.mkdir path 0o700;
+             all_not_relevant candidates))
+  in
+  (match result with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "atomic judgment storage failure was accepted");
+  match A.load_candidates ~base_path ~keeper_name with
+  | Error detail -> Alcotest.failf "candidate reload failed: %s" detail
+  | Ok candidates ->
+    Alcotest.(check int) "both candidates retained" 2 (List.length candidates);
+    List.iter
+      (fun (candidate : A.candidate) ->
+         match candidate.status with
+         | A.Pending { last_failure = None } -> ()
+         | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
+           Alcotest.fail "failed atomic commit changed part of the batch")
+      candidates
+;;
+
 let test_removed_expired_status_is_rejected () =
   let fixture = A.candidate_to_json (candidate ()) in
   let legacy =
@@ -921,6 +964,10 @@ let () =
             "batch failure evidence write error propagates"
             `Quick
             test_batch_failure_evidence_write_error_propagates
+        ; Alcotest.test_case
+            "atomic judgment failure preserves all pending"
+            `Quick
+            test_atomic_judgment_commit_failure_preserves_all_pending
         ; Alcotest.test_case
             "removed expired status is rejected"
             `Quick


### PR DESCRIPTION
## Stack

Depends on #25365, which depends on #25363. Review only commit 99dd020589.

## Problem

Even after exact response-set validation, judgment application rewrote the candidate ledger once per candidate and immediately entered delivery. A mid-batch storage failure could therefore leave only a prefix durably Judged or Consumed.

## Change

- generalize the private candidate-ledger transaction to commit multiple updated rows in one durable rewrite
- validate duplicate IDs, keeper ownership, current Pending state, and exact judgment presence inside that transaction
- commit every requested Pending to Judged together or commit none
- only begin idempotent queue delivery after the atomic judgment commit returns
- keep delivery and Consumed transitions explicitly separate because the event queue and candidate ledger are different durable files

No fake cross-file transaction, test-only production hook, context grouping, capacity guess, or worker-plane change is included.

## Validation

- ocamlformat --check on touched files
- git diff --check
- focused executable build passed
- test_keeper_board_attention_candidate: 20/20 passed
- fault injection after Provider judgment but before ledger commit verified both candidates remain Pending

The shared local switch has unrelated agent_sdk pin drift, so focused build/test used the wrapper documented one-shot MASC_SKIP_PIN_CHECK=1 bypass. PR CI remains authoritative.