### PR TITLE
refactor(keeper): type Board attention context authority

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -314,6 +314,78 @@ let candidate_to_json candidate =
 
 let ( let* ) = Result.bind
 
+module Context_key = struct
+  type t = Yojson.Safe.t
+
+  let rec canonicalize ~context = function
+    | `Assoc fields ->
+      let* canonical_fields =
+        List.fold_left
+          (fun result (key, value) ->
+             let* fields = result in
+             let* value = canonicalize ~context:(context ^ "." ^ key) value in
+             Ok ((key, value) :: fields))
+          (Ok [])
+          fields
+        |> Result.map List.rev
+      in
+      let sorted =
+        List.sort
+          (fun (left, _) (right, _) -> String.compare left right)
+          canonical_fields
+      in
+      let rec reject_duplicate_keys previous = function
+        | [] -> Ok ()
+        | (key, _) :: rest ->
+          (match previous with
+           | Some prior when String.equal prior key ->
+             Error (Printf.sprintf "%s contains duplicate object key %S" context key)
+           | Some _ | None -> reject_duplicate_keys (Some key) rest)
+      in
+      let* () = reject_duplicate_keys None sorted in
+      Ok (`Assoc sorted)
+    | `List values ->
+      List.fold_left
+        (fun result value ->
+           let* values = result in
+           let* value = canonicalize ~context value in
+           Ok (value :: values))
+        (Ok [])
+        values
+      |> Result.map (fun values -> `List (List.rev values))
+    | `Float value when not (Float.is_finite value) ->
+      Error (context ^ " contains a non-finite number")
+    | `Float value ->
+      Ok (`Float (if Float.equal value 0.0 then 0.0 else value))
+    | (`Bool _ | `Int _ | `Intlit _ | `Null | `String _) as scalar -> Ok scalar
+  ;;
+
+  let of_yojson = function
+    | `Assoc _ as context -> canonicalize ~context:"keeper_context" context
+    | _ -> Error "keeper_context must be an object"
+  ;;
+
+  let of_candidate candidate =
+    match candidate.judgment_request with
+    | `Assoc fields ->
+      let contexts =
+        List.filter_map
+          (fun (key, value) ->
+             if String.equal key "keeper_context" then Some value else None)
+          fields
+      in
+      (match contexts with
+       | [ context ] -> of_yojson context
+       | [] -> Error "judgment request lacks keeper_context"
+       | _ -> Error "judgment request contains multiple keeper_context fields")
+    | _ -> Error "judgment request must be an object"
+  ;;
+
+  let to_yojson context = context
+  let to_canonical_string context = Yojson.Safe.to_string context
+  let equal = ( = )
+end
+
 let exact_fields ~context expected fields =
   let actual = List.map fst fields in
   if List.length actual = List.length expected

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -57,6 +57,21 @@ type candidate =
   ; status : status
   }
 
+module Context_key : sig
+  type t
+
+  val of_candidate : candidate -> (t, string) result
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+  val to_yojson : t -> Yojson.Safe.t
+  val to_canonical_string : t -> string
+  val equal : t -> t -> bool
+end
+(** Exact persisted Keeper-context identity for immutable judgment
+    partitions. Object field order is canonicalized, while duplicate object
+    keys, missing context, or multiple [keeper_context] fields are rejected.
+    Lists retain their original order. No prompt-size, token, time, or provider
+    capacity estimate participates in this identity. *)
+
 type record_result =
   | Recorded of candidate
   | Duplicate of candidate

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -163,6 +163,98 @@ let test_roundtrip_preserves_full_evidence_and_pending_state () =
   | Error detail -> Alcotest.failf "candidate decode failed: %s" detail
 ;;
 
+let context_key_or_fail candidate =
+  match A.Context_key.of_candidate candidate with
+  | Ok key -> key
+  | Error detail -> Alcotest.failf "context key failed: %s" detail
+;;
+
+let candidate_with_context context =
+  { (candidate ()) with
+    judgment_request = `Assoc [ "keeper_context", context ]
+  }
+;;
+
+let test_context_key_is_exact_and_object_order_independent () =
+  let left =
+    candidate_with_context
+      (`Assoc
+         [ "instructions", `String "continue"
+         ; "goals", `List [ `String "g-1"; `String "g-2" ]
+         ; "runtime", `Assoc [ "model", `String "judge"; "tools", `Bool true ]
+         ])
+    |> context_key_or_fail
+  in
+  let reordered =
+    candidate_with_context
+      (`Assoc
+         [ "runtime", `Assoc [ "tools", `Bool true; "model", `String "judge" ]
+         ; "goals", `List [ `String "g-1"; `String "g-2" ]
+         ; "instructions", `String "continue"
+         ])
+    |> context_key_or_fail
+  in
+  let changed_list_order =
+    candidate_with_context
+      (`Assoc
+         [ "runtime", `Assoc [ "tools", `Bool true; "model", `String "judge" ]
+         ; "goals", `List [ `String "g-2"; `String "g-1" ]
+         ; "instructions", `String "continue"
+         ])
+    |> context_key_or_fail
+  in
+  Alcotest.(check bool)
+    "object field order is not identity"
+    true
+    (A.Context_key.equal left reordered);
+  Alcotest.(check bool)
+    "list order remains identity"
+    false
+    (A.Context_key.equal left changed_list_order);
+  let positive_zero =
+    candidate_with_context (`Assoc [ "offset", `Float 0.0 ])
+    |> context_key_or_fail
+  in
+  let negative_zero =
+    candidate_with_context (`Assoc [ "offset", `Float (-0.0) ])
+    |> context_key_or_fail
+  in
+  Alcotest.(check string)
+    "signed zero has one durable identity"
+    (A.Context_key.to_canonical_string positive_zero)
+    (A.Context_key.to_canonical_string negative_zero)
+;;
+
+let test_context_key_rejects_ambiguous_authority () =
+  let expect_error label candidate =
+    match A.Context_key.of_candidate candidate with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s was accepted" label
+  in
+  expect_error
+    "missing keeper_context"
+    { (candidate ()) with judgment_request = `Assoc [] };
+  expect_error
+    "multiple keeper_context fields"
+    { (candidate ()) with
+      judgment_request =
+        `Assoc
+          [ "keeper_context", `Assoc [ "instructions", `String "first" ]
+          ; "keeper_context", `Assoc [ "instructions", `String "second" ]
+          ]
+    };
+  expect_error
+    "duplicate nested context key"
+    (candidate_with_context
+       (`Assoc
+          [ "instructions", `String "first"
+          ; "instructions", `String "second"
+          ]));
+  expect_error
+    "non-finite context number"
+    (candidate_with_context (`Assoc [ "temperature", `Float Float.nan ]))
+;;
+
 let test_record_dedupes_exact_candidate_identity () =
   with_temp_base "keeper-board-attention-dedup" @@ fun base_path ->
   let first = candidate () in
@@ -900,6 +992,14 @@ let () =
             "roundtrip preserves full evidence and Pending"
             `Quick
             test_roundtrip_preserves_full_evidence_and_pending_state
+        ; Alcotest.test_case
+            "context identity is exact and object-order independent"
+            `Quick
+            test_context_key_is_exact_and_object_order_independent
+        ; Alcotest.test_case
+            "context identity rejects ambiguous authority"
+            `Quick
+            test_context_key_rejects_ambiguous_authority
         ; Alcotest.test_case
             "record dedupes exact candidate identity"
             `Quick


### PR DESCRIPTION
## Stack

Depends on #25366 → #25365 → #25363. Review only commit 627feb2a4a.

## Problem

The durable partition worker needs an exact immutable Keeper-context identity. The previous experimental stack used an untyped canonical JSON string and accepted ambiguous duplicate object keys through first-match lookup.

## Change

- add an opaque Candidate.Context_key type
- derive it only from exactly one persisted keeper_context field
- recursively canonicalize object field order while retaining list order
- reject missing or multiple keeper_context fields
- reject duplicate nested object keys and non-finite numbers
- normalize signed zero so equality and durable canonical representation agree

No token estimate, capacity guess, context hash collision assumption, worker lifecycle, or owner-lane behavior change is included. This is the typed authority required by the next durable partition leaf.

## Validation

- ocamlformat --check on touched files
- git diff --check
- focused executable build passed
- test_keeper_board_attention_candidate: 22/22 passed

The shared local switch has unrelated agent_sdk pin drift, so focused build/test used the wrapper documented one-shot MASC_SKIP_PIN_CHECK=1 bypass. PR CI remains authoritative.