### PR TITLE
fix(compaction): include required json token in json_object-mode plan prompt (#25324)

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -131,7 +131,8 @@ let messages_for_plan ~units =
      unit contributes no state, decision, evidence, constraint, unresolved \
      work, or outcome. For keep and drop, summary must be null. For summarize, \
      summary must be a non-empty string. Do not infer recency policy, merge \
-     units, relocate facts, invent facts, or include markdown fences."
+     units, relocate facts, invent facts, or include markdown fences. Respond \
+     with a single JSON object and no other text."
   in
   let user =
     Printf.sprintf

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -305,7 +305,16 @@ let apply_schema_or_prompt_tier ~log_label schema provider_cfg =
    json_object-only provider is silently dropped from structured lanes,
    leaving the single json_schema-capable native endpoint (minimax) as a SPOF.
    Use ONLY where the prompt states the schema and the parse is validated
-   downstream; [apply_to_provider_config] stays the strict default. *)
+   downstream; [apply_to_provider_config] stays the strict default.
+
+   CONTRACT (#25324): the OpenAI-compatible [json_object] response format
+   requires the request messages to contain the literal token "json"
+   (case-insensitive) or the endpoint returns HTTP 400. DeepSeek and Kimi
+   enforce this; GLM is lenient. This function only sets [response_format] on
+   [provider_cfg] and cannot see the messages, so any caller that reaches the
+   JsonMode tier MUST include a "json" token in its prompt. The compaction
+   summarizer does so in [Keeper_compaction_llm_summarizer.messages_for_plan]
+   (locked by test_compaction_llm_summarizer). *)
 let apply_schema_json_mode_or_prompt_tier ~log_label schema provider_cfg =
   let native_cfg = apply_to_provider_config schema provider_cfg in
   match Llm_provider.Provider_config.validate_output_schema_request native_cfg with

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -449,6 +449,28 @@ let test_request_excludes_protected_content () =
     ; "SECRET_METADATA"
     ]
 
+(* #25324: the json_object (JsonMode) tier is admitted for GLM/DeepSeek/Kimi,
+   but the OpenAI-compatible json_object contract rejects (HTTP 400) any request
+   whose messages lack the literal token "json" (DeepSeek/Kimi enforce; GLM is
+   lenient, which masked the defect in GLM-only live traffic). The plan prompt
+   must state that it returns JSON so every json_object-mode request is
+   contract-valid. This locks the token in place. *)
+let test_plan_prompt_states_json_contract () =
+  let units =
+    [ ordinary (text T.System "system directive")
+    ; ordinary (text T.User "user context")
+    ; ordinary (text T.Assistant "VISIBLE_ASSISTANT")
+    ]
+  in
+  let wire =
+    C.For_testing.messages_for_plan ~units
+    |> List.map T.text_of_message
+    |> String.concat "\n"
+    |> String.lowercase_ascii
+  in
+  Alcotest.(check bool) "plan prompt contains the json_object contract token" true
+    (Astring.String.is_infix ~affix:"json" wire)
+
 let test_apply_preserves_protected_units_and_source_order () =
   let system = text T.System "system" in
   let first = text T.Assistant "first" in
@@ -520,6 +542,8 @@ let () =
             test_only_plain_assistant_text_is_eligible
         ; Alcotest.test_case "protected content never reaches provider" `Quick
             test_request_excludes_protected_content
+        ; Alcotest.test_case "plan prompt states json_object contract token" `Quick
+            test_plan_prompt_states_json_contract
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid source decisions accepted" `Quick


### PR DESCRIPTION
## Symptom

The compaction summarizer's `json_object` (JsonMode) tier, added in #25324 to lift the
single-provider (`minimax` `json_schema`) SPOF across GLM/DeepSeek/Kimi, ships requests
that the OpenAI-compatible `json_object` contract rejects. That contract requires the
request messages to contain the literal token `json` (case-insensitive) or the endpoint
returns HTTP 400 (`messages must contain the word 'json'`).

- DeepSeek and Kimi/Moonshot **enforce** this rule → deterministic 400.
- GLM is **lenient** (does not enforce) → live compaction traffic, which is GLM, looked
  green and masked the defect.

Net effect: the tier that was supposed to give GLM/DeepSeek/Kimi coverage only actually
works on GLM; DeepSeek and Kimi are admitted-but-deterministically-rejected. This is the
unaddressed codex P1 flagged on the merged PR #25324.

## Confirmed defect location

- `lib/keeper/keeper_structured_output_schema.ml` — `apply_schema_json_mode_or_prompt_tier`
  sets `response_format = Agent_sdk.Types.JsonMode` for `supports_response_format_json`
  providers, but only receives `provider_cfg` and cannot see/ensure the messages.
- `lib/keeper/keeper_compaction_llm_summarizer.ml` — `messages_for_plan` builds the
  `system` + `user` prompt. Independently verified by direct read: neither string
  contained the literal token `json`. The schema field-names in the `Return {...}` template
  are `decisions` / `unit_index` / `action` / `summary` / `keep` / `drop` / `summarize`
  (none contains `json`), and the system prompt ended `"...or include markdown fences."`.

## Root fix (small, no semantic change)

`messages_for_plan` already emits a JSON object and the caller already validates the parse.
This makes the implicit explicit: the system prompt now ends
`"...or include markdown fences. Respond with a single JSON object and no other text."`,
so any `json_object`/JsonMode request built from this prompt is contract-valid on
DeepSeek and Kimi as well as GLM.

- No change to the schema shape, decision semantics, or compaction behavior — only the
  contract-required token is added to the instruction text.
- Added a `CONTRACT (#25324)` note at the JsonMode selection site cross-referencing the
  summarizer, so the next author of a `json_object`-mode caller knows the prompt must
  carry a `json` token (the function cannot enforce it — it only sees `provider_cfg`).

## Tests

`test/test_compaction_llm_summarizer.ml`: new case
`eligibility / plan prompt states json_object contract token` builds the plan messages via
`For_testing.messages_for_plan` with representative non-empty units and asserts the
concatenated `system + user` prompt contains `json` (case-insensitive). This fails if the
fix is reverted (the token disappears), locking the `json_object` contract.

## Build

Verified locally: `scripts/dune-local.sh build test/test_compaction_llm_summarizer.exe`
(first attempt aborted on an unrelated `agent_sdk` opam pin-drift guard; re-run with the
guard's own `MASC_SKIP_PIN_CHECK=1` bypass). Executable built; the new test case runs `[OK]`.
`.ocamlformat` is `disable = true` repo-wide (RFC-0010); changes match the surrounding
hand-formatting.

## Why this is a root fix, not a workaround

This adds the contract-required token that the `json_object` protocol mandates — it makes
the request valid at the protocol boundary rather than suppressing a symptom. No telemetry,
no string classifier, no N-of-M patch, no cap/cooldown/dedup/repair.

RFC-WAIVED: lib/keeper compaction summarizer + test — not an RFC-gated subsystem.

Closes the unaddressed codex P1 on #25324.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
