### PR TITLE
fix(keeper): commit Board attention failure evidence atomically

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -852,27 +852,31 @@ let same_failure left right =
   left.kind = right.kind && String.equal left.detail right.detail
 ;;
 
+let candidate_with_retryable_failure current failure =
+  match current.status with
+  | Pending pending ->
+    (match pending.last_failure with
+     | Some existing when same_failure existing failure -> current
+     | Some _ | None ->
+       { current with status = Pending { last_failure = Some failure } })
+  | Judged judged ->
+    (match judged.last_failure with
+     | Some existing when same_failure existing failure -> current
+     | Some _ | None ->
+       { current with
+         status = Judged { judged with last_failure = Some failure }
+       })
+  | Consumed _ -> current
+;;
+
 let record_retryable_failure ~base_path candidate failure =
   update_candidate
     ~base_path
     candidate.candidate_id
     candidate.keeper_name
     (fun current ->
-       match current.status with
-       | Pending pending ->
-         (match pending.last_failure with
-          | Some existing when same_failure existing failure -> None
-          | Some _ | None ->
-            Some { current with status = Pending { last_failure = Some failure } })
-       | Judged judged ->
-         (match judged.last_failure with
-          | Some existing when same_failure existing failure -> None
-          | Some _ | None ->
-            Some
-              { current with
-                status = Judged { judged with last_failure = Some failure }
-              })
-       | Consumed _ -> None)
+       let updated = candidate_with_retryable_failure current failure in
+       if updated = current then None else Some updated)
 ;;
 
 let record_judgment ~base_path candidate judgment =
@@ -1210,26 +1214,69 @@ let chunks_of size items =
   loop [] 0 [] items
 ;;
 
-let record_batch_failure ~base_path candidate failure =
-  match record_retryable_failure ~base_path candidate failure with
-  | Ok _ -> Ok ()
-  | Error detail ->
-    Error
-      (Printf.sprintf
-         "Board attention batch failure evidence could not be persisted keeper=%s \
-          candidate=%s: %s"
-         candidate.keeper_name
-         candidate.candidate_id
-         detail)
-;;
-
 let record_batch_failures ~base_path candidates failure =
-  List.fold_left
-    (fun result candidate ->
-       let* () = result in
-       record_batch_failure ~base_path candidate failure)
-    (Ok ())
-    candidates
+  match candidates with
+  | [] -> Ok ()
+  | first :: _ ->
+    let keeper_name = first.keeper_name in
+    let* requested =
+      List.fold_left
+        (fun result candidate ->
+           let* ids = result in
+           if not (String.equal candidate.keeper_name keeper_name)
+           then
+             Error
+               (Printf.sprintf
+                  "Board attention failure batch keeper mismatch expected=%s actual=%s \
+                   candidate=%s"
+                  keeper_name
+                  candidate.keeper_name
+                  candidate.candidate_id)
+           else if Id_set.mem candidate.candidate_id ids
+           then
+             Error
+               ("duplicate candidate in Board attention failure batch: "
+                ^ candidate.candidate_id)
+           else Ok (Id_set.add candidate.candidate_id ids))
+        (Ok Id_set.empty)
+        candidates
+    in
+    update_ledger_many ~base_path ~keeper_name (fun current_rows ->
+      let current_by_id =
+        List.fold_left
+          (fun map candidate -> Candidate_map.add candidate.candidate_id candidate map)
+          Candidate_map.empty
+          current_rows
+      in
+      let* updated, changed =
+        List.fold_left
+          (fun result candidate ->
+             let* rows, changed = result in
+             match Candidate_map.find_opt candidate.candidate_id current_by_id with
+             | None ->
+               Error
+                 ("Board attention candidate not found for atomic failure evidence: "
+                  ^ candidate.candidate_id)
+             | Some current ->
+               (match current.status with
+                | Consumed _ ->
+                  Error
+                    ("Consumed Board attention candidate cannot receive batch failure \
+                      evidence: "
+                     ^ candidate.candidate_id)
+                | Pending _ | Judged _ ->
+                  let next = candidate_with_retryable_failure current failure in
+                  Ok (next :: rows, changed || next <> current)))
+          (Ok ([], false))
+          candidates
+        |> Result.map (fun (rows, changed) -> List.rev rows, changed)
+      in
+      if Id_set.cardinal requested <> List.length updated
+      then Error "Board attention atomic failure evidence cardinality changed"
+      else
+        Ok
+          ( (if changed then Some updated else None)
+          , () ))
 ;;
 
 let validate_batch_coverage candidates judgments =

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -174,7 +174,8 @@ val drain_pending_on_owner_lane :
       and terminal [Consumed] transitions then proceed idempotently from the
       committed judgments; they are not presented as a cross-file transaction.
     - Failure-evidence persistence errors propagate to the caller; they are
-      never reduced to logs. *)
+      never reduced to logs. Evidence for one attempted batch is committed in
+      one candidate-ledger rewrite or not committed at all. *)
 
 val batch_max_candidates : int
 (** Maximum candidates judged per model call. *)

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -844,25 +844,50 @@ let test_batch_failure_aborts_round_and_records_evidence () =
 let test_batch_failure_evidence_write_error_propagates () =
   with_temp_base "board-attention-failure-write" @@ fun base_path ->
   let keeper_name = "sangsu" in
-  ignore (record_or_fail ~base_path (candidate ~keeper_name ()) : A.candidate);
+  List.iter
+    (fun post_id ->
+       ignore
+         (record_or_fail
+            ~base_path
+            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())
+          : A.candidate))
+    [ "post-1"; "post-2" ];
   let path = ledger_path_or_fail ~base_path ~keeper_name in
+  let backup = path ^ ".before-failure-evidence" in
   let failure : A.retryable_failure =
     { kind = A.Provider_unavailable
     ; detail = "provider unavailable"
     ; failed_at = 100.0
     }
   in
-  match
-    A.For_testing.drain_pending_with_judge_batch
-      ~base_path
-      ~keeper_name
-      ~judge_batch:(fun _ ->
-        Sys.remove path;
-        Unix.mkdir path 0o700;
-        Error failure)
-  with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "failure-evidence storage error was silently accepted"
+  let result =
+    Fun.protect
+      ~finally:(fun () ->
+        if Sys.file_exists path && Sys.is_directory path then Unix.rmdir path;
+        if Sys.file_exists backup then Sys.rename backup path)
+      (fun () ->
+         A.For_testing.drain_pending_with_judge_batch
+           ~base_path
+           ~keeper_name
+           ~judge_batch:(fun _ ->
+             Sys.rename path backup;
+             Unix.mkdir path 0o700;
+             Error failure))
+  in
+  (match result with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "failure-evidence storage error was silently accepted");
+  match A.load_candidates ~base_path ~keeper_name with
+  | Error detail -> Alcotest.failf "candidate reload failed: %s" detail
+  | Ok candidates ->
+    Alcotest.(check int) "both candidates retained" 2 (List.length candidates);
+    List.iter
+      (fun (candidate : A.candidate) ->
+         match candidate.status with
+         | A.Pending { last_failure = None } -> ()
+         | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
+           Alcotest.fail "failed atomic evidence commit changed part of the batch")
+      candidates
 ;;
 
 let test_atomic_judgment_commit_failure_preserves_all_pending () =


### PR DESCRIPTION
## Stack

Depends on #25367 → #25366 → #25365 → #25363. Review only commit 377f79c0f9.

## Problem

Batch failure evidence was explicit but persisted one candidate at a time. A storage failure between rewrites could leave only a prefix carrying the typed provider or response-contract failure.

## Change

- extract the pure immutable candidate failure transition shared by single and batch paths
- validate one Keeper identity, unique candidate IDs, and complete current-ledger membership before mutation
- reject terminal Consumed rows as impossible attempted-batch members
- commit all changed failure-evidence rows in one candidate-ledger rewrite or commit none
- avoid a rewrite when every row already contains the same failure kind and detail

## Validation

- ocamlformat --check on touched files
- git diff --check
- focused executable build passed
- test_keeper_board_attention_candidate: 22/22 passed
- two-candidate fault injection after Provider failure verified the original all-Pending ledger survives an unavailable commit destination

The shared local switch has unrelated agent_sdk pin drift, so focused build/test used the wrapper documented one-shot MASC_SKIP_PIN_CHECK=1 bypass. PR CI remains authoritative.