### PR TITLE
fix(keeper): retain transfer target accounting

### DIFF
--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -283,7 +283,9 @@ let create_receipt config ~from_keeper ~to_keeper request =
      : Keeper_paused_work_disposition_receipt.t)
 ;;
 
-let accepted_transfer receipt transfer : Keeper_registry_event_queue.accepted_transfer =
+let accepted_transfer receipt
+      (transfer : Keeper_paused_work_disposition_receipt.transfer_owner)
+    : Keeper_registry_event_queue.accepted_transfer =
   { source = transfer.Keeper_paused_work_disposition_receipt.source
   ; source_revision = transfer.source_revision
   ; owner_generation = receipt.Keeper_paused_work_disposition_receipt.expected_generation
@@ -368,7 +370,7 @@ let project_receipt config receipt =
   let* transfer = transfer_of_receipt receipt in
   let* source_settlement = source_settlement config receipt transfer in
   let* target_projection = target_enqueue config receipt transfer in
-  Ok { source_settlement; target_projection }
+  Ok (Applied { source_settlement; target_projection })
 ;;
 
 let run_owned receipt_lock config ~from_keeper ~to_keeper request =
@@ -404,7 +406,7 @@ let run_owned receipt_lock config ~from_keeper ~to_keeper request =
   in
   let projection =
     match project_receipt config receipt with
-    | Ok applied -> Applied applied
+    | Ok projection -> projection
     | Error failure -> Committed_followup_failed failure
   in
   Ok (receipt, commit_status, projection)
@@ -446,6 +448,7 @@ let transfer_pending config ~from_keeper ~to_keeper request =
              Error { cause; reservation_release = Some reservation_release })
         with
         | exn ->
+          (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
 ;;

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -283,17 +283,18 @@ let create_receipt config ~from_keeper ~to_keeper request =
      : Keeper_paused_work_disposition_receipt.t)
 ;;
 
-let source_settlement config receipt
-      (transfer : Keeper_paused_work_disposition_receipt.transfer_owner) =
-  let causal : Keeper_registry_event_queue.accepted_transfer =
-    { source = transfer.Keeper_paused_work_disposition_receipt.source
-    ; source_revision = transfer.source_revision
-    ; owner_generation = receipt.Keeper_paused_work_disposition_receipt.expected_generation
-    ; operator_operation_id = receipt.operator_operation_id
-    ; from_keeper = transfer.from_keeper
-    ; to_keeper = transfer.to_keeper
-    }
-  in
+let accepted_transfer receipt transfer : Keeper_registry_event_queue.accepted_transfer =
+  { source = transfer.Keeper_paused_work_disposition_receipt.source
+  ; source_revision = transfer.source_revision
+  ; owner_generation = receipt.Keeper_paused_work_disposition_receipt.expected_generation
+  ; operator_operation_id = receipt.operator_operation_id
+  ; from_keeper = transfer.from_keeper
+  ; to_keeper = transfer.to_keeper
+  }
+;;
+
+let source_settlement config receipt transfer =
+  let causal = accepted_transfer receipt transfer in
   let base_path = config.Workspace.base_path in
   let* source_state =
     Keeper_event_queue_persistence.load_state_result
@@ -348,13 +349,14 @@ let validate_committed_target config transfer =
   else Ok ()
 ;;
 
-let target_enqueue config transfer =
+let target_enqueue config receipt transfer =
   let* () = validate_committed_target config transfer in
+  let causal = accepted_transfer receipt transfer in
   match
-    Keeper_registry_event_queue.enqueue_exact_stimulus_durable_result
+    Keeper_registry_event_queue.project_accepted_transfer_durable_result
       ~base_path:config.Workspace.base_path
       transfer.Keeper_paused_work_disposition_receipt.to_keeper
-      transfer.source
+      ~transfer:causal
   with
   | Keeper_registry_event_queue.Stimulus_enqueued -> Ok Enqueued
   | Keeper_registry_event_queue.Stimulus_already_present -> Ok Already_present
@@ -365,8 +367,8 @@ let target_enqueue config transfer =
 let project_receipt config receipt =
   let* transfer = transfer_of_receipt receipt in
   let* source_settlement = source_settlement config receipt transfer in
-  let* target_projection = target_enqueue config transfer in
-  Ok (Applied { source_settlement; target_projection })
+  let* target_projection = target_enqueue config receipt transfer in
+  Ok { source_settlement; target_projection }
 ;;
 
 let run_owned receipt_lock config ~from_keeper ~to_keeper request =
@@ -402,7 +404,7 @@ let run_owned receipt_lock config ~from_keeper ~to_keeper request =
   in
   let projection =
     match project_receipt config receipt with
-    | Ok projection -> projection
+    | Ok applied -> Applied applied
     | Error failure -> Committed_followup_failed failure
   in
   Ok (receipt, commit_status, projection)
@@ -444,7 +446,6 @@ let transfer_pending config ~from_keeper ~to_keeper request =
              Error { cause; reservation_release = Some reservation_release })
         with
         | exn ->
-          (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
 ;;

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -319,16 +319,17 @@ let enqueue_stimulus_durable_result ~base_path name stimulus =
   | Error detail -> Stimulus_storage_error detail
 ;;
 
-let enqueue_exact_stimulus_durable_result ~base_path name stimulus =
+let project_accepted_transfer_durable_result ~base_path name ~transfer =
   match
-    Keeper_event_queue_persistence.enqueue_exact_stimulus_if_absent_result
+    Keeper_event_queue_persistence.project_accepted_transfer_result
       ~base_path
       ~keeper_name:name
       ~after_commit:(publish_pending ~base_path name)
-      stimulus
+      ~transfer
   with
-  | Ok Keeper_event_queue_persistence.Enqueued -> Stimulus_enqueued
-  | Ok Keeper_event_queue_persistence.Already_present -> Stimulus_already_present
+  | Ok Keeper_event_queue_persistence.Transfer_projected -> Stimulus_enqueued
+  | Ok Keeper_event_queue_persistence.Transfer_already_projected ->
+    Stimulus_already_present
   | Error detail -> Stimulus_storage_error detail
 ;;
 

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -218,13 +218,14 @@ val enqueue_stimulus_durable_result :
     before a wake hint. Board-attention judgments use the stricter
     opaque-event-id API above. *)
 
-val enqueue_exact_stimulus_durable_result :
+val project_accepted_transfer_durable_result :
   base_path:string
   -> string
-  -> Keeper_event_queue.stimulus
+  -> transfer:accepted_transfer
   -> enqueue_stimulus_durable_result
-(** Strict transfer projection: replay succeeds only for the exact full source
-    snapshot. Same identity with changed arrival/payload is a storage conflict. *)
+(** Strict target transfer projection. The exact source and operation identity
+    are durably accounted in the target queue state before the pending
+    projection becomes visible. Accounting survives consumption. *)
 
 val enqueue_hitl_resolution_durable_result :
   base_path:string

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -96,6 +96,10 @@ type settle_result =
       ; detail : string
       }
 
+type transfer_projection_result = State.transfer_projection_result =
+  | Transfer_projected
+  | Transfer_already_projected
+
 let lease_stimuli (lease : lease) = lease.stimuli
 let lease_kind = State.lease_kind
 
@@ -230,12 +234,10 @@ let read_primary_unlocked owner =
   | Ok (Some json) ->
     (match schema_field json with
      | Error message -> Error (Printf.sprintf "%s: %s" path message)
-     | Ok schema when String.equal schema State.schema ->
+     | Ok _ ->
        (match State.of_yojson json with
         | Ok state -> Ok (Primary_current state)
-        | Error message -> Error (Printf.sprintf "%s: %s" path message))
-     | Ok schema ->
-       Error (Printf.sprintf "%s: unsupported snapshot schema %s" path schema))
+        | Error message -> Error (Printf.sprintf "%s: %s" path message)))
 ;;
 
 let reject_unsupported_inflight owner =
@@ -654,33 +656,21 @@ let enqueue_stimulus_if_absent_result
       Ok (State.with_pending pending state, Enqueued))
 ;;
 
-let accounted_stimuli state =
-  Keeper_event_queue.to_list (State.pending state)
-  @ List.concat_map (fun (lease : lease) -> lease.stimuli) (State.leases state)
-  @ List.concat_map
-      (fun (entry : outbox_entry) -> entry.stimuli)
-      (State.transition_outbox state)
-;;
-
-let enqueue_exact_stimulus_if_absent_result
+let project_accepted_transfer_result
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
-      stimulus
+      ~transfer
   =
-  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
-    let matching =
-      accounted_stimuli state
-      |> List.filter (fun candidate ->
-        Keeper_event_queue.stimulus_identity_equal candidate stimulus)
-    in
-    match matching with
-    | [] ->
-      let pending = Keeper_event_queue.enqueue (State.pending state) stimulus in
-      Ok (State.with_pending pending state, Enqueued)
-    | [ existing ] when existing = stimulus -> Ok (state, Already_present)
-    | [ _ ] -> Error "exact stimulus identity exists with a different source snapshot"
-    | _ :: _ :: _ -> Error "exact stimulus identity is duplicated in durable target state")
+  if not (String.equal transfer.to_keeper keeper_name)
+  then Error "target transfer projection owner does not match the durable queue owner"
+  else
+    commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+      match State.project_accepted_transfer transfer state with
+      | Error _ as error -> error
+      | Ok (next, result) ->
+        if next == state then after_commit (State.pending next);
+        Ok (next, result))
 ;;
 
 let update_result ?after_commit ~base_path ~keeper_name f =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -657,7 +657,7 @@ let enqueue_stimulus_if_absent_result
 ;;
 
 let project_accepted_transfer_result
-      ?(after_commit = fun _ -> ())
+      ~after_commit
       ~base_path
       ~keeper_name
       ~transfer

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -309,7 +309,7 @@ val enqueue_stimulus_if_absent_result :
     full durable state: pending, active leases, and transition outbox. *)
 
 val project_accepted_transfer_result :
-  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
   keeper_name:string ->
   transfer:accepted_transfer ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,9 +1,10 @@
 (** Durable per-Keeper Event Layer state.
 
-    [event-queue.json] keeps the v3 envelope containing pending stimuli, active
-    typed leases, the monotonic lease sequence and the transition outbox.
-    Older schemas are unsupported. [event-queue-inflight.json] is rejected
-    explicitly rather than migrated or treated as a second authority. *)
+    [event-queue.json] keeps the v4 envelope containing pending stimuli, active
+    typed leases, the monotonic lease sequence, transition outbox, and durable
+    accepted-transfer target accounting. Strict v3 is the only supported
+    predecessor. [event-queue-inflight.json] is rejected explicitly rather
+    than migrated or treated as a second authority. *)
 
 type lease_kind = Keeper_event_queue_state.lease_kind =
   | Single
@@ -99,6 +100,10 @@ type settle_result =
       ; stage : [ `Checkpoint | `Wal_compaction | `Projection ]
       ; detail : string
       }
+
+type transfer_projection_result =
+  | Transfer_projected
+  | Transfer_already_projected
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
 val lease_kind : lease -> lease_kind
@@ -303,23 +308,23 @@ val enqueue_stimulus_if_absent_result :
 (** Atomically enqueue only when the same typed stimulus is absent from the
     full durable state: pending, active leases, and transition outbox. *)
 
-val enqueue_exact_stimulus_if_absent_result :
+val project_accepted_transfer_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
   keeper_name:string ->
-  Keeper_event_queue.stimulus ->
-  (enqueue_stimulus_result, string) result
-(** Transfer-only strict variant: an existing identity is idempotent only when
-    the full source snapshot, including [arrived_at], is structurally equal.
-    A changed snapshot or duplicate accounted identity is a conflict. *)
+  transfer:accepted_transfer ->
+  (transfer_projection_result, string) result
+(** Atomically persist target-side transfer accounting with the exact enqueue.
+    The accounting survives target consumption and makes later receipt replay
+    return [Transfer_already_projected] without a second target effect. *)
 
 val persist_snapshot :
   base_path:string -> keeper_name:string -> (unit -> Keeper_event_queue.t) -> unit
 
 val record_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
-(** Legacy source/test adapter.  Writes a typed [Legacy_inflight] lease into the
-    v3 envelope; it never creates [event-queue-inflight.json]. *)
+(** Legacy source/test adapter. Writes a typed [Legacy_inflight] lease into the
+    v4 envelope; it never creates [event-queue-inflight.json]. *)
 
 val ack_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -1885,7 +1885,8 @@ let duplicate_by key values =
 ;;
 
 let duplicate_transfer_source (transfers : accepted_transfer list) =
-  let rec loop seen = function
+  let rec loop seen (l : accepted_transfer list) =
+    match l with
     | [] -> None
     | transfer :: rest ->
       (match

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -123,13 +123,19 @@ type t =
   ; leases : lease list
   ; last_settlement : transition_receipt option
   ; transition_outbox : outbox_entry list
+  ; accepted_transfer_projections : accepted_transfer list
   }
 
 type settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
 
-let schema = "keeper.event_queue.state.v3"
+type transfer_projection_result =
+  | Transfer_projected
+  | Transfer_already_projected
+
+let schema = "keeper.event_queue.state.v4"
+let predecessor_schema = "keeper.event_queue.state.v3"
 
 let empty =
   { revision = 0L
@@ -138,6 +144,7 @@ let empty =
   ; leases = []
   ; last_settlement = None
   ; transition_outbox = []
+  ; accepted_transfer_projections = []
   }
 ;;
 
@@ -147,11 +154,63 @@ let pending state = state.pending
 let leases state = state.leases
 let last_settlement state = state.last_settlement
 let transition_outbox state = state.transition_outbox
+let accepted_transfer_projections state = state.accepted_transfer_projections
 let lease_kind (lease : lease) = lease.kind
 let active_lease state =
   match state.leases with
   | [] -> None
   | lease :: _ -> Some lease
+;;
+
+let accounted_stimuli state =
+  Keeper_event_queue.to_list state.pending
+  @ List.concat_map (fun (lease : lease) -> lease.stimuli) state.leases
+  @ List.concat_map
+      (fun (entry : outbox_entry) -> entry.stimuli)
+      state.transition_outbox
+;;
+
+let project_accepted_transfer (transfer : accepted_transfer) state =
+  let same_operation (candidate : accepted_transfer) =
+    String.equal candidate.operator_operation_id transfer.operator_operation_id
+  in
+  match List.find_opt same_operation state.accepted_transfer_projections with
+  | Some existing when existing = transfer -> Ok (state, Transfer_already_projected)
+  | Some _ -> Error "target transfer operation ID conflicts with its durable projection"
+  | None ->
+    let same_source (candidate : accepted_transfer) =
+      Keeper_event_queue.stimulus_identity_equal candidate.source transfer.source
+    in
+    (match List.find_opt same_source state.accepted_transfer_projections with
+     | Some _ ->
+       Error "target transfer source identity was already projected by another operation"
+     | None ->
+       let matching =
+         accounted_stimuli state
+         |> List.filter (fun candidate ->
+           Keeper_event_queue.stimulus_identity_equal candidate transfer.source)
+       in
+       (match matching with
+        | [] ->
+          let pending = Keeper_event_queue.enqueue state.pending transfer.source in
+          Ok
+            ( { state with
+                pending
+              ; accepted_transfer_projections =
+                  state.accepted_transfer_projections @ [ transfer ]
+              }
+            , Transfer_projected )
+        | [ existing ] when existing = transfer.source ->
+          Ok
+            ( { state with
+                accepted_transfer_projections =
+                  state.accepted_transfer_projections @ [ transfer ]
+              }
+            , Transfer_already_projected )
+        | [ _ ] ->
+          Error "target transfer source identity has a different durable snapshot"
+        | _ :: _ :: _ ->
+          Error "target transfer source identity is duplicated in durable state"))
 ;;
 
 let mark_transition_projected ~transition_id state =
@@ -1695,6 +1754,22 @@ let settlement_of_yojson json =
   | kind -> Error (Printf.sprintf "unknown event queue settlement kind: %s" kind)
 ;;
 
+let accepted_transfer_projection_to_yojson (transfer : accepted_transfer) =
+  settlement_to_yojson (Transfer_accepted transfer)
+;;
+
+let accepted_transfer_projection_of_yojson json =
+  let* settlement = settlement_of_yojson json in
+  match settlement with
+  | Transfer_accepted transfer -> Ok transfer
+  | Ack
+  | No_compaction _
+  | Cancel_accepted _
+  | Settle_from_source_terminal _
+  | Requeue _
+  | Escalate _ -> Error "target transfer projection must contain transfer_accepted"
+;;
+
 let transition_receipt_to_yojson receipt =
   `Assoc
     [ "transition_id", `String receipt.transition_id
@@ -1789,6 +1864,11 @@ let to_yojson state =
         | Some receipt -> transition_receipt_to_yojson receipt )
     ; ( "transition_outbox"
       , `List (List.map outbox_entry_to_yojson state.transition_outbox) )
+    ; ( "accepted_transfer_projections"
+      , `List
+          (List.map
+             accepted_transfer_projection_to_yojson
+             state.accepted_transfer_projections) )
     ]
 ;;
 
@@ -1802,6 +1882,24 @@ let duplicate_by key values =
       else loop (key :: seen) rest
   in
   loop [] values
+;;
+
+let duplicate_transfer_source (transfers : accepted_transfer list) =
+  let rec loop seen = function
+    | [] -> None
+    | transfer :: rest ->
+      (match
+         List.find_opt
+           (fun (prior : accepted_transfer) ->
+              Keeper_event_queue.stimulus_identity_equal
+                prior.source
+                transfer.source)
+           seen
+       with
+       | Some prior -> Some (prior, transfer)
+       | None -> loop (transfer :: seen) rest)
+  in
+  loop [] transfers
 ;;
 
 let validate_state state =
@@ -1833,37 +1931,66 @@ let validate_state state =
        | Some transition_id ->
          Error (Printf.sprintf "duplicate event queue transition id: %s" transition_id)
        | None ->
-         let max_sequence =
-           List.fold_left
-             (fun acc (lease : lease) -> Int64.max acc lease.sequence)
-             0L
-             state.leases
-         in
-         let max_sequence =
-           List.fold_left
-             (fun acc entry -> Int64.max acc entry.receipt.lease_sequence)
-             max_sequence
-             state.transition_outbox
-         in
-         let max_sequence =
-           match state.last_settlement with
-           | None -> max_sequence
-           | Some receipt -> Int64.max max_sequence receipt.lease_sequence
-         in
-         if Int64.compare state.next_lease_sequence max_sequence <= 0
-         then
-           Error
-             "event queue next lease sequence must exceed every lease and receipt sequence"
-         else Ok state)
+         (match
+            duplicate_by
+              (fun (transfer : accepted_transfer) -> transfer.operator_operation_id)
+              state.accepted_transfer_projections
+          with
+          | Some operation_id ->
+            Error
+              (Printf.sprintf
+                 "duplicate target transfer projection operation id: %s"
+                 operation_id)
+          | None ->
+            (match duplicate_transfer_source state.accepted_transfer_projections with
+             | Some _ -> Error "duplicate target transfer projection source identity"
+             | None ->
+               let max_sequence =
+                 List.fold_left
+                   (fun acc (lease : lease) -> Int64.max acc lease.sequence)
+                   0L
+                   state.leases
+               in
+               let max_sequence =
+                 List.fold_left
+                   (fun acc entry -> Int64.max acc entry.receipt.lease_sequence)
+                   max_sequence
+                   state.transition_outbox
+               in
+               let max_sequence =
+                 match state.last_settlement with
+                 | None -> max_sequence
+                 | Some receipt -> Int64.max max_sequence receipt.lease_sequence
+               in
+               if Int64.compare state.next_lease_sequence max_sequence <= 0
+               then
+                 Error
+                   "event queue next lease sequence must exceed every lease and receipt sequence"
+               else Ok state)))
 ;;
 
 let of_yojson json =
   let context = "keeper event queue state" in
   let* fields = assoc_fields ~context json in
   let* schema_value = string_field ~context "schema" fields in
-  if not (String.equal schema_value schema)
+  if
+    not
+      (String.equal schema_value schema
+       || String.equal schema_value predecessor_schema)
   then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
   else
+    let expected_fields =
+      [ "schema"
+      ; "revision"
+      ; "next_lease_sequence"
+      ; "pending"
+      ; "leases"
+      ; "last_settlement"
+      ; "transition_outbox"
+      ]
+      @ if String.equal schema_value schema then [ "accepted_transfer_projections" ] else []
+    in
+    let* () = exact_fields ~context ~expected:expected_fields fields in
     let* revision = int64_field ~context "revision" fields in
     let* next_lease_sequence = int64_field ~context "next_lease_sequence" fields in
     let* pending_json = required_field ~context "pending" fields in
@@ -1878,6 +2005,16 @@ let of_yojson json =
     let* transition_outbox =
       list_field ~context "transition_outbox" outbox_entry_of_yojson fields
     in
+    let* accepted_transfer_projections =
+      if String.equal schema_value predecessor_schema
+      then Ok []
+      else
+        list_field
+          ~context
+          "accepted_transfer_projections"
+          accepted_transfer_projection_of_yojson
+          fields
+    in
     validate_state
       { revision
       ; next_lease_sequence
@@ -1885,5 +2022,6 @@ let of_yojson json =
       ; leases
       ; last_settlement
       ; transition_outbox
+      ; accepted_transfer_projections
       }
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -137,6 +137,10 @@ type settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
 
+type transfer_projection_result =
+  | Transfer_projected
+  | Transfer_already_projected
+
 val empty : t
 val revision : t -> int64
 val next_lease_sequence : t -> int64
@@ -144,6 +148,7 @@ val pending : t -> Keeper_event_queue.t
 val leases : t -> lease list
 val last_settlement : t -> transition_receipt option
 val transition_outbox : t -> outbox_entry list
+val accepted_transfer_projections : t -> accepted_transfer list
 val lease_kind : lease -> lease_kind
 
 val with_pending : Keeper_event_queue.t -> t -> t
@@ -251,6 +256,13 @@ val accepted_pending_transfer_replay :
 (** Look up an already committed pending transfer by its stable operator
     operation ID and exact source-bearing settlement. *)
 
+val project_accepted_transfer :
+  accepted_transfer -> t -> (t * transfer_projection_result, string) result
+(** Atomically account for one exact target-side transfer projection and
+    enqueue its source only on the first projection. The durable accounting
+    survives target consumption, so receipt replay cannot enqueue the same
+    transferred event again. *)
+
 val accepted_pending_source_terminal_replay :
   accepted_source_terminal ->
   t ->
@@ -303,4 +315,5 @@ val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
 val schema : string
-(** ["keeper.event_queue.state.v3"]. *)
+(** ["keeper.event_queue.state.v4"]. Strict v3 snapshots are read as the sole
+    supported predecessor and upgraded on their next durable mutation. *)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1782,6 +1782,47 @@ let test_unsupported_snapshots_fail_closed () =
      | Ok _ -> Alcotest.fail "old primary schema was migrated"))
 ;;
 
+let test_v3_snapshot_upgrades_with_empty_transfer_projection_ledger () =
+  with_temp_dir "keeper-event-queue-v3-upgrade" (fun base_path ->
+    let keeper_name = "v3_upgrade_keeper" in
+    let path = Filename.concat (keeper_dir ~base_path ~keeper_name) "event-queue.json" in
+    let v3 =
+      match State.to_yojson State.empty with
+      | `Assoc fields ->
+        `Assoc
+          (("schema", `String "keeper.event_queue.state.v3")
+           :: List.filter
+                (fun (name, _) ->
+                   not
+                     (String.equal name "schema"
+                      || String.equal name "accepted_transfer_projections"))
+                fields)
+      | _ -> Alcotest.fail "current event queue state codec is not an object"
+    in
+    Fs_compat.mkdir_p (Filename.dirname path);
+    Fs_compat.save_file_atomic path (Yojson.Safe.to_string v3)
+    |> require_ok "write strict v3 predecessor";
+    let upgraded =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load strict v3 predecessor"
+    in
+    Alcotest.(check int)
+      "v3 starts with no target transfer accounting"
+      0
+      (List.length (State.accepted_transfer_projections upgraded));
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending (stimulus "upgrade" 1.0))
+    |> require_ok "mutate upgraded queue";
+    let persisted =
+      Safe_ops.read_json_file_safe path |> require_ok "read upgraded queue"
+    in
+    let open Yojson.Safe.Util in
+    Alcotest.(check string)
+      "next durable write uses v4"
+      "keeper.event_queue.state.v4"
+      (persisted |> member "schema" |> to_string))
+;;
+
 let test_transition_outbox_projects_with_stable_identity () =
   with_temp_dir "keeper-event-queue-v2-outbox" (fun base_path ->
     let keeper_name = "projection_keeper" in
@@ -2058,6 +2099,10 @@ let () =
             "unsupported snapshots fail closed"
             `Quick
             test_unsupported_snapshots_fail_closed
+        ; Alcotest.test_case
+            "v3 upgrades with empty transfer projection ledger"
+            `Quick
+            test_v3_snapshot_upgrades_with_empty_transfer_projection_ledger
         ; Alcotest.test_case
             "transition outbox projection"
             `Quick

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -194,6 +194,60 @@ let test_transfer_commits_and_replays_exactly_once () =
     assert_converged config ~from_keeper ~to_keeper request.source)
 ;;
 
+let test_replay_after_target_consumption_has_no_second_effect () =
+  with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
+    let base_path = config.Workspace.base_path in
+    let first =
+      Transaction.transfer_pending config ~from_keeper ~to_keeper request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "commit Transfer_owner before target consumption"
+    in
+    check_applied ~expected_target:Transaction.Enqueued first.projection;
+    let lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name:to_keeper
+        ~claimed_at:4.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim transferred target source"
+      |> require_some "transferred target lease"
+    in
+    (match
+       Persistence.settle_result
+         ~base_path
+         ~keeper_name:to_keeper
+         ~settled_at:5.0
+         ~lease
+         ~settlement:State.Ack
+         ()
+     with
+     | Ok (Persistence.Settled _ | Persistence.Already_settled _) -> ()
+     | Ok (Persistence.Committed_followup_failed { detail; _ })
+     | Error detail -> Alcotest.fail detail);
+    let replay =
+      Transaction.transfer_pending config ~from_keeper ~to_keeper request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "replay Transfer_owner after target consumption"
+    in
+    (match replay.commit_status with
+     | Transaction.Already_committed -> ()
+     | Transaction.Committed -> Alcotest.fail "target-consumed replay replaced receipt");
+    check_applied ~expected_target:Transaction.Already_present replay.projection;
+    let target =
+      Persistence.load_state_result ~base_path ~keeper_name:to_keeper
+      |> require_ok "load replayed consumed target"
+    in
+    Alcotest.(check int)
+      "target source was not enqueued again"
+      0
+      (Queue.length (State.pending target));
+    Alcotest.(check int)
+      "one durable target projection"
+      1
+      (List.length (State.accepted_transfer_projections target)))
+;;
+
 let test_replay_after_source_settlement_projects_target () =
   with_transfer_lane (fun config from_keeper to_keeper source_meta target_meta request ->
     let transfer : Receipt.transfer_owner =
@@ -301,6 +355,10 @@ let () =
             "replay after source settlement projects target"
             `Quick
             test_replay_after_source_settlement_projects_target
+        ; Alcotest.test_case
+            "replay after target consumption has no second effect"
+            `Quick
+            test_replay_after_target_consumption_has_no_second_effect
         ; Alcotest.test_case
             "stale source revision has no effect"
             `Quick


### PR DESCRIPTION
## Summary
- close a receipt replay hole that could enqueue a transferred event again after the target had already consumed it
- atomically persist exact accepted-transfer target accounting with the target queue enqueue
- retain operation ID and full source snapshot without TTL, recent-N retention, or heuristic lookup
- hard-cut the old exact enqueue writer that lost identity after pending/lease/outbox consumption
- upgrade strict event queue v3 snapshots to v4 on their next mutation

## Regression
The new case commits a transfer, claims and ACKs the target event so it disappears from pending/lease/outbox, then replays the same Transfer_owner receipt. The target remains empty and has one durable projection record.

## Validation
- OCaml 5.5 parser checks for every changed .ml/.mli file
- repository ocamlformat check for every changed OCaml file
- git diff --check
- static removed-writer and schema-boundary scans

Per user instruction, no local build, test execution, or typecheck was run. The user will run builds separately; PR CI is the automated validation authority.

## Stack
- base: #25369
- issue: #25191