### PR TITLE
feat(keeper): move attention judgment off owner lane

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -2,7 +2,6 @@
 
 module Board_signal = Keeper_world_observation_board_signal
 module Candidate_map = Map.Make (String)
-module Id_set = Set.Make (String)
 
 type retryable_failure_kind =
   | Runtime_configuration_unavailable
@@ -64,19 +63,13 @@ type persistence =
   | Candidate_already_present
 
 type wake_decision =
-  | Wake_requested of Keeper_registry.wakeup_outcome
+  | Judgment_worker_requested of Keeper_board_attention_worker_wake.wake_result
   | Wake_not_required
 
 type record_acceptance =
   { candidate : candidate
   ; persistence : persistence
   ; wake : wake_decision
-  }
-
-type drain_report =
-  { attempted : int
-  ; consumed : int
-  ; remaining : int
   }
 
 exception Candidate_unavailable of string
@@ -852,6 +845,12 @@ let same_failure left right =
   left.kind = right.kind && String.equal left.detail right.detail
 ;;
 
+let same_judgment left right =
+  left.verdict = right.verdict
+  && String.equal left.runtime_id right.runtime_id
+  && Float.equal left.judged_at right.judged_at
+;;
+
 let candidate_with_retryable_failure current failure =
   match current.status with
   | Pending pending ->
@@ -880,35 +879,62 @@ let record_retryable_failure ~base_path candidate failure =
 ;;
 
 let record_judgment ~base_path candidate judgment =
-  update_candidate
-    ~base_path
-    candidate.candidate_id
-    candidate.keeper_name
-    (fun current ->
-       match current.status with
+  update_ledger ~base_path ~keeper_name:candidate.keeper_name (fun candidates ->
+    match find_candidate candidates candidate.candidate_id with
+    | None ->
+      Error
+        (Printf.sprintf
+           "Board attention candidate not found: %s"
+           candidate.candidate_id)
+    | Some current ->
+      (match current.status with
        | Pending _ ->
-         Some
+         let updated =
            { current with
              status = Judged { judgment; last_failure = None }
            }
-       | Judged _ | Consumed _ -> None)
+         in
+         Ok (Some updated, updated)
+       | Judged judged when same_judgment judged.judgment judgment ->
+         Ok (None, current)
+       | Consumed consumed when same_judgment consumed.judgment judgment ->
+         Ok (None, current)
+       | Judged _ | Consumed _ ->
+         Error
+           ("Board attention candidate judgment conflict: "
+            ^ candidate.candidate_id)))
 ;;
 
 let mark_consumed ~base_path candidate judgment delivery =
-  update_candidate
-    ~base_path
-    candidate.candidate_id
-    candidate.keeper_name
-    (fun current ->
-       match current.status with
-       | Judged _ ->
-         Some
+  update_ledger ~base_path ~keeper_name:candidate.keeper_name (fun candidates ->
+    match find_candidate candidates candidate.candidate_id with
+    | None ->
+      Error
+        (Printf.sprintf
+           "Board attention candidate not found: %s"
+           candidate.candidate_id)
+    | Some current ->
+      (match current.status with
+       | Judged judged when same_judgment judged.judgment judgment ->
+         let updated =
            { current with
              status =
                Consumed
                  { judgment; delivery; consumed_at = Time_compat.now () }
            }
-       | Pending _ | Consumed _ -> None)
+         in
+         Ok (Some updated, updated)
+       | Consumed consumed
+         when same_judgment consumed.judgment judgment
+              && consumed.delivery = delivery -> Ok (None, current)
+       | Pending _ ->
+         Error
+           ("Pending Board attention candidate cannot be consumed: "
+            ^ candidate.candidate_id)
+       | Judged _ | Consumed _ ->
+         Error
+           ("Board attention candidate consumption conflict: "
+            ^ candidate.candidate_id)))
 ;;
 
 let failure ~kind detail = { kind; detail; failed_at = Time_compat.now () }
@@ -1009,32 +1035,26 @@ let reject_unregistered_tool ~name ~args:_ =
     "Board attention judgment is a tool-free boundary"
 ;;
 
-let rec process_with_judge ~base_path ~judge candidate =
-  match candidate.status with
-  | Consumed _ -> Ok candidate
-  | Judged judged -> consume_judged ~base_path candidate judged
-  | Pending _ ->
-    (match judge candidate with
-     | Error failure -> record_retryable_failure ~base_path candidate failure
-     | Ok judgment ->
-       let* current = record_judgment ~base_path candidate judgment in
-       process_with_judge ~base_path ~judge current)
-;;
-
 let record_and_wake ~base_path candidate =
+  let request_worker persisted =
+    let* wake =
+      Keeper_board_attention_worker_wake.request
+        ~base_path
+        ~keeper_name:persisted.keeper_name
+    in
+    Ok (Judgment_worker_requested wake)
+  in
   match record ~base_path candidate with
   | Record_error detail -> Error detail
   | Recorded persisted ->
-    let wake =
-      Wake_requested (request_owner_wake ~site:"recorded" ~base_path persisted)
-    in
+    let* wake = request_worker persisted in
     Ok { candidate = persisted; persistence = Candidate_recorded; wake }
   | Duplicate persisted ->
-    let wake =
+    let* wake =
       match persisted.status with
       | Pending _ | Judged _ ->
-        Wake_requested (request_owner_wake ~site:"duplicate" ~base_path persisted)
-      | Consumed _ -> Wake_not_required
+        request_worker persisted
+      | Consumed _ -> Ok Wake_not_required
     in
     Ok
       { candidate = persisted
@@ -1043,46 +1063,37 @@ let record_and_wake ~base_path candidate =
       }
 ;;
 
-(* ── Batch judgment ───────────────────────────────────── *)
+(* The configured output contract remains a one-item [verdicts] array so the
+   prompt/schema SSOT does not fork. Partition membership itself is singleton:
+   no candidate count, byte estimate, or token heuristic participates. *)
 
 let prompt_name_batch = Keeper_prompt_names.board_attention_judgment_batch
-let batch_max_candidates = 8
 
-let batch_request_json candidates =
-  let keeper_context_of candidate =
-    match candidate.judgment_request with
-    | `Assoc fields -> List.assoc_opt "keeper_context" fields
-    | _ -> None
-  in
-  let item_of candidate =
-    match candidate.judgment_request with
-    | `Assoc fields ->
-      `Assoc
-        (List.filter
-           (fun (key, _) -> not (String.equal key "keeper_context"))
-           fields)
-    | other -> other
-  in
-  match candidates with
-  | [] -> None
-  | first :: _ ->
-    (match keeper_context_of first with
-     | None -> None
-     | Some keeper_context ->
-       Some
+let singleton_request_json candidate =
+  match candidate.judgment_request with
+  | `Assoc fields ->
+    let contexts, item_fields =
+      List.partition
+        (fun (key, _) -> String.equal key "keeper_context")
+        fields
+    in
+    (match contexts with
+     | [ (_, keeper_context) ] ->
+       Ok
          (`Assoc
             [ "keeper_context", keeper_context
-            ; "items", `List (List.map item_of candidates)
-            ]))
+            ; "items", `List [ `Assoc item_fields ]
+            ])
+     | [] -> Error "singleton judgment request lacks keeper_context"
+     | _ -> Error "singleton judgment request contains multiple keeper_context fields")
+  | _ -> Error "singleton judgment request must be an object"
 ;;
 
-let build_batch_prompt candidates =
-  match batch_request_json candidates with
-  | None -> Error "batch request lacks the shared keeper context"
-  | Some json ->
-    Prompt_registry.render_prompt_template
-      prompt_name_batch
-      [ "batch_request_json", Yojson.Safe.to_string json ]
+let build_singleton_prompt candidate =
+  let* json = singleton_request_json candidate in
+  Prompt_registry.render_prompt_template
+    prompt_name_batch
+    [ "batch_request_json", Yojson.Safe.to_string json ]
 ;;
 
 let apply_batch_output_schema provider_config =
@@ -1093,417 +1104,106 @@ let apply_batch_output_schema provider_config =
        provider_config)
 ;;
 
-let run_judge_batch ~base_path candidates =
-  match candidates with
-  | [] -> Ok Candidate_map.empty
-  | first :: _ ->
-    let runtime_id_result =
-      try Ok (Runtime.runtime_id_for_structured_judge ()) with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn ->
-        Error
-          (failure
-             ~kind:Runtime_configuration_unavailable
-             (Printexc.to_string exn))
-    in
-    (match runtime_id_result with
-     | Error _ as error -> error
-     | Ok runtime_id ->
-       (match build_batch_prompt candidates with
-        | Error detail -> Error (failure ~kind:Prompt_contract_unavailable detail)
-        | Ok prompt ->
-          let provider_result =
-            try
-              match
-                Keeper_turn_driver_wrappers.run_named_with_masc_tools
-                  ~runtime_id
-                  ~keeper_name:first.keeper_name
-                  ~goal:prompt
-                  ~base_path
-                  ~masc_tools:[]
-                  ~dispatch:reject_unregistered_tool
-                  ~provider_config_transform:apply_batch_output_schema
-                  ()
-              with
-              | Ok result -> Ok result
-              | Error error ->
-                Error
-                  (failure
-                     ~kind:Provider_unavailable
-                     (Agent_sdk.Error.to_string error))
-            with
-            | Eio.Cancel.Cancelled _ as exn -> raise exn
-            | exn ->
-              Error (failure ~kind:Provider_unavailable (Printexc.to_string exn))
-          in
-          (match provider_result with
-           | Error _ as error -> error
-           | Ok result ->
-             (match
-                Agent_sdk_response.structured_json_of_response
-                  ~schema_name:Keeper_board_attention_judgment.batch_schema_name
-                  result.response
-              with
+let judge_singleton ~sw ~net ~base_path candidate =
+  let runtime_id_result =
+    try Ok (Runtime.runtime_id_for_structured_judge ()) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (failure
+           ~kind:Runtime_configuration_unavailable
+           (Printexc.to_string exn))
+  in
+  match runtime_id_result with
+  | Error _ as error -> error
+  | Ok runtime_id ->
+    (match build_singleton_prompt candidate with
+     | Error detail -> Error (failure ~kind:Prompt_contract_unavailable detail)
+     | Ok prompt ->
+       let provider_result =
+         try
+           match
+             Keeper_turn_driver_wrappers.run_named_with_masc_tools
+               ~runtime_id
+               ~keeper_name:candidate.keeper_name
+               ~goal:prompt
+               ~base_path
+               ~masc_tools:[]
+               ~dispatch:reject_unregistered_tool
+               ~provider_config_transform:apply_batch_output_schema
+               ~sw
+               ?net
+               ()
+           with
+           | Ok result -> Ok result
+           | Error error ->
+             Error
+               (failure
+                  ~kind:Provider_unavailable
+                  (Agent_sdk.Error.to_string error))
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn -> Error (failure ~kind:Provider_unavailable (Printexc.to_string exn))
+       in
+       (match provider_result with
+        | Error _ as error -> error
+        | Ok result ->
+          (match
+             Agent_sdk_response.structured_json_of_response
+               ~schema_name:Keeper_board_attention_judgment.batch_schema_name
+               result.response
+           with
+           | Error detail -> Error (failure ~kind:Response_contract_unavailable detail)
+           | Ok json ->
+             (match Keeper_board_attention_judgment.batch_of_yojson json with
               | Error detail ->
                 Error (failure ~kind:Response_contract_unavailable detail)
-              | Ok json ->
-                (match Keeper_board_attention_judgment.batch_of_yojson json with
-                 | Error detail ->
-                   Error (failure ~kind:Response_contract_unavailable detail)
-                 | Ok items ->
-                   let ids =
-                     List.fold_left
-                       (fun set candidate -> Id_set.add candidate.candidate_id set)
-                       Id_set.empty
-                       candidates
-                   in
-                   (match
-                      List.find_opt
-                        (fun (item : Keeper_board_attention_judgment.batch_item) ->
-                           not (Id_set.mem item.candidate_id ids))
-                        items
-                    with
-                    | Some item ->
-                      Error
-                        (failure
-                           ~kind:Response_contract_unavailable
-                           (Printf.sprintf
-                              "batch verdict references unknown candidate_id %S"
-                              item.candidate_id))
-                    | None ->
-                      let judged_at = Time_compat.now () in
-                      List.fold_left
-                        (fun result (item : Keeper_board_attention_judgment.batch_item) ->
-                           match result with
-                           | Error _ -> result
-                           | Ok map ->
-                             if Candidate_map.mem item.candidate_id map
-                             then
-                               Error
-                                 (failure
-                                    ~kind:Response_contract_unavailable
-                                    (Printf.sprintf
-                                       "batch verdict duplicates candidate_id %S"
-                                       item.candidate_id))
-                             else
-                               Ok
-                                 (Candidate_map.add
-                                    item.candidate_id
-                                    { verdict = item.verdict
-                                    ; runtime_id
-                                    ; judged_at
-                                    }
-                                    map))
-                        (Ok Candidate_map.empty)
-                        items))))))
+              | Ok [ item ] when String.equal item.candidate_id candidate.candidate_id ->
+                Ok
+                  { verdict = item.verdict
+                  ; runtime_id
+                  ; judged_at = Time_compat.now ()
+                  }
+              | Ok [ item ] ->
+                Error
+                  (failure
+                     ~kind:Response_contract_unavailable
+                     (Printf.sprintf
+                        "singleton verdict identity mismatch expected=%S actual=%S"
+                        candidate.candidate_id
+                        item.candidate_id))
+              | Ok items ->
+                Error
+                  (failure
+                     ~kind:Response_contract_unavailable
+                     (Printf.sprintf
+                        "singleton verdict count must be exactly one, got %d"
+                        (List.length items)))))))
 ;;
 
-(* ── Owner-lane batch drain ───────────────────────────── *)
-
-let chunks_of size items =
-  let rec loop current count chunks = function
-    | [] ->
-      (match current with
-       | [] -> List.rev chunks
-       | _ -> List.rev (List.rev current :: chunks))
-    | x :: rest ->
-      if count = size
-      then loop [ x ] 1 (List.rev current :: chunks) rest
-      else loop (x :: current) (count + 1) chunks rest
-  in
-  loop [] 0 [] items
-;;
-
-let record_batch_failures ~base_path candidates failure =
-  match candidates with
-  | [] -> Ok ()
-  | first :: _ ->
-    let keeper_name = first.keeper_name in
-    let* requested =
-      List.fold_left
-        (fun result candidate ->
-           let* ids = result in
-           if not (String.equal candidate.keeper_name keeper_name)
-           then
-             Error
-               (Printf.sprintf
-                  "Board attention failure batch keeper mismatch expected=%s actual=%s \
-                   candidate=%s"
-                  keeper_name
-                  candidate.keeper_name
-                  candidate.candidate_id)
-           else if Id_set.mem candidate.candidate_id ids
-           then
-             Error
-               ("duplicate candidate in Board attention failure batch: "
-                ^ candidate.candidate_id)
-           else Ok (Id_set.add candidate.candidate_id ids))
-        (Ok Id_set.empty)
-        candidates
-    in
-    update_ledger_many ~base_path ~keeper_name (fun current_rows ->
-      let current_by_id =
-        List.fold_left
-          (fun map candidate -> Candidate_map.add candidate.candidate_id candidate map)
-          Candidate_map.empty
-          current_rows
-      in
-      let* updated, changed =
-        List.fold_left
-          (fun result candidate ->
-             let* rows, changed = result in
-             match Candidate_map.find_opt candidate.candidate_id current_by_id with
-             | None ->
-               Error
-                 ("Board attention candidate not found for atomic failure evidence: "
-                  ^ candidate.candidate_id)
-             | Some current ->
-               (match current.status with
-                | Consumed _ ->
-                  Error
-                    ("Consumed Board attention candidate cannot receive batch failure \
-                      evidence: "
-                     ^ candidate.candidate_id)
-                | Pending _ | Judged _ ->
-                  let next = candidate_with_retryable_failure current failure in
-                  Ok (next :: rows, changed || next <> current)))
-          (Ok ([], false))
-          candidates
-        |> Result.map (fun (rows, changed) -> List.rev rows, changed)
-      in
-      if Id_set.cardinal requested <> List.length updated
-      then Error "Board attention atomic failure evidence cardinality changed"
-      else
-        Ok
-          ( (if changed then Some updated else None)
-          , () ))
-;;
-
-let validate_batch_coverage candidates judgments =
-  let requested =
-    List.fold_left
-      (fun ids candidate -> Id_set.add candidate.candidate_id ids)
-      Id_set.empty
-      candidates
-  in
-  let returned =
-    Candidate_map.fold
-      (fun candidate_id _ ids -> Id_set.add candidate_id ids)
-      judgments
-      Id_set.empty
-  in
-  if Id_set.equal requested returned
-  then Ok ()
-  else
-    let missing = Id_set.diff requested returned |> Id_set.elements in
-    let unknown = Id_set.diff returned requested |> Id_set.elements in
-    Error
-      (failure
-         ~kind:Response_contract_unavailable
-         (Printf.sprintf
-            "batch verdict identity mismatch missing=[%s] unknown=[%s]"
-            (String.concat "," missing)
-            (String.concat "," unknown)))
-;;
-
-let record_batch_judgments ~base_path ~keeper_name candidates judgments =
-  match candidates with
-  | [] -> Ok []
-  | _ ->
-    let* requested =
-      List.fold_left
-        (fun result candidate ->
-           let* ids = result in
-           if not (String.equal candidate.keeper_name keeper_name)
-           then
-             Error
-               (Printf.sprintf
-                  "Board attention atomic batch keeper mismatch expected=%s actual=%s \
-                   candidate=%s"
-                  keeper_name
-                  candidate.keeper_name
-                  candidate.candidate_id)
-           else if Id_set.mem candidate.candidate_id ids
-           then
-             Error
-               (Printf.sprintf
-                  "duplicate candidate in Board attention atomic batch: %s"
-                  candidate.candidate_id)
-           else Ok (Id_set.add candidate.candidate_id ids))
-        (Ok Id_set.empty)
-        candidates
-    in
-    update_ledger_many ~base_path ~keeper_name (fun current_rows ->
-      let current_by_id =
-        List.fold_left
-          (fun map candidate -> Candidate_map.add candidate.candidate_id candidate map)
-          Candidate_map.empty
-          current_rows
-      in
-      let* updated =
-        List.fold_left
-          (fun result candidate ->
-             let* rows = result in
-             match Candidate_map.find_opt candidate.candidate_id current_by_id with
-             | None ->
-               Error
-                 (Printf.sprintf
-                    "Board attention candidate not found for atomic judgment commit: %s"
-                    candidate.candidate_id)
-             | Some current ->
-               (match current.status with
-                | Judged _ | Consumed _ ->
-                  Error
-                    (Printf.sprintf
-                       "Board attention candidate is not Pending for atomic judgment \
-                        commit: %s"
-                       candidate.candidate_id)
-                | Pending _ ->
-                  (match Candidate_map.find_opt candidate.candidate_id judgments with
-                   | None ->
-                     Error
-                       (Printf.sprintf
-                          "Board attention judgment missing from validated atomic batch: %s"
-                          candidate.candidate_id)
-                   | Some judgment ->
-                     Ok
-                       ({ current with
-                          status = Judged { judgment; last_failure = None }
-                        }
-                        :: rows))))
-          (Ok [])
-          candidates
-        |> Result.map List.rev
-      in
-      if Id_set.cardinal requested <> List.length updated
-      then Error "Board attention atomic judgment commit cardinality changed"
-      else Ok (Some updated, updated))
-;;
-
-let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
+let apply_judgment_and_deliver ~base_path ~keeper_name ~candidate_id ~judgment =
   let* candidates = load_candidates ~base_path ~keeper_name in
-  let judged_ready, pending =
-    List.fold_left
-      (fun (judged_ready, pending) candidate ->
-         match candidate.status with
-         | Pending _ -> judged_ready, candidate :: pending
-         | Judged judged -> (candidate, judged) :: judged_ready, pending
-         | Consumed _ -> judged_ready, pending)
-      ([], [])
-      candidates
+  let* candidate =
+    match find_candidate candidates candidate_id with
+    | Some candidate -> Ok candidate
+    | None -> Error ("Board attention candidate not found: " ^ candidate_id)
   in
-  (* Already-judged verdicts deliver without new model calls. *)
-  let* judged_consumed, judged_remaining =
-    List.fold_left
-      (fun result (candidate, judged) ->
-         match result with
-         | Error _ -> result
-         | Ok (consumed, remaining) ->
-           (match consume_judged ~base_path candidate judged with
-            | Ok current ->
-              (match current.status with
-               | Consumed _ -> Ok (consumed + 1, remaining)
-               | Pending _ | Judged _ -> Ok (consumed, remaining + 1))
-            | Error detail -> Error detail))
-      (Ok (0, 0))
-      judged_ready
+  let* judged_candidate =
+    match candidate.status with
+    | Pending _ -> record_judgment ~base_path candidate judgment
+    | Judged judged when same_judgment judged.judgment judgment -> Ok candidate
+    | Consumed consumed when same_judgment consumed.judgment judgment -> Ok candidate
+    | Judged _ | Consumed _ ->
+      Error ("Board attention candidate judgment conflicts with worker result: " ^ candidate_id)
   in
-  (* Fresh pending rows are judged in batches. A failed batch aborts the
-     round: the next keepalive turn owns the retry cadence, not a hot loop. *)
-  let batches = chunks_of batch_max_candidates (List.rev pending) in
-  let rec loop report = function
-    | [] -> Ok report
-    | batch :: rest ->
-      let deferred =
-        List.fold_left
-          (fun count rest_batch -> count + List.length rest_batch)
-          (List.length batch)
-          rest
-      in
-      (match judge_batch batch with
-       | Error failure ->
-         let* () = record_batch_failures ~base_path batch failure in
-         Ok
-           { report with
-             attempted = report.attempted + List.length batch
-           ; remaining = report.remaining + deferred
-           }
-       | Ok map ->
-         (match validate_batch_coverage batch map with
-          | Error failure ->
-            let* () = record_batch_failures ~base_path batch failure in
-            Ok
-              { report with
-                attempted = report.attempted + List.length batch
-              ; remaining = report.remaining + deferred
-              }
-          | Ok () ->
-            let* judged =
-              record_batch_judgments ~base_path ~keeper_name batch map
-            in
-            (match
-               List.fold_left
-                 (fun result candidate ->
-                    match result with
-                    | Error _ -> result
-                    | Ok (consumed, remaining) ->
-                      (match candidate.status with
-                       | Pending _ | Consumed _ ->
-                         Error
-                           (Printf.sprintf
-                              "atomic judgment commit returned non-Judged candidate: %s"
-                              candidate.candidate_id)
-                       | Judged judged_state ->
-                         (match consume_judged ~base_path candidate judged_state with
-                          | Ok current ->
-                            (match current.status with
-                             | Consumed _ -> Ok (consumed + 1, remaining)
-                             | Pending _ | Judged _ ->
-                               Ok (consumed, remaining + 1))
-                          | Error detail -> Error detail)))
-                 (Ok (0, 0))
-                 judged
-             with
-             | Error detail -> Error detail
-             | Ok (consumed, remaining) ->
-               loop
-                 { attempted = report.attempted + List.length batch
-                 ; consumed = report.consumed + consumed
-                 ; remaining = report.remaining + remaining
-                 }
-                 rest)))
-  in
-  let* batch_report = loop { attempted = 0; consumed = 0; remaining = 0 } batches in
-  Ok
-    { attempted = batch_report.attempted + judged_consumed + judged_remaining
-    ; consumed = batch_report.consumed + judged_consumed
-    ; remaining = batch_report.remaining + judged_remaining
-    }
-;;
-
-let drain_pending_on_owner_lane ~base_path ~keeper_name =
-  drain_pending_with_judge_batch
-    ~base_path
-    ~keeper_name
-    ~judge_batch:(run_judge_batch ~base_path)
-;;
-
-module For_testing = struct
-  let drain_pending_with_judge_batch = drain_pending_with_judge_batch
-
-  let drain_pending_with_judge ~base_path ~keeper_name ~judge =
-    let judge_batch candidates =
-      let rec fold map = function
-        | [] -> Ok map
-        | candidate :: rest ->
-          (match judge candidate with
-           | Ok judgment ->
-             fold (Candidate_map.add candidate.candidate_id judgment map) rest
-           | Error failure -> Error failure)
-      in
-      fold Candidate_map.empty candidates
-    in
-    drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch
-  ;;
-end
+  match judged_candidate.status with
+  | Consumed _ -> Ok judged_candidate
+  | Pending _ ->
+    Error ("Board attention candidate remained Pending after judgment commit: " ^ candidate_id)
+  | Judged judged ->
+    let* delivered = consume_judged ~base_path judged_candidate judged in
+    (match delivered.status with
+     | Consumed _ -> Ok delivered
+     | Pending _ | Judged _ ->
+       Error ("Board attention candidate delivery did not reach Consumed: " ^ candidate_id))
 ;;

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -82,19 +82,13 @@ type persistence =
   | Candidate_already_present
 
 type wake_decision =
-  | Wake_requested of Keeper_registry.wakeup_outcome
+  | Judgment_worker_requested of Keeper_board_attention_worker_wake.wake_result
   | Wake_not_required
 
 type record_acceptance =
   { candidate : candidate
   ; persistence : persistence
   ; wake : wake_decision
-  }
-
-type drain_report =
-  { attempted : int
-  ; consumed : int
-  ; remaining : int
   }
 
 exception Candidate_unavailable of string
@@ -142,61 +136,29 @@ val record_retryable_failure :
 val record_judgment :
   base_path:string -> candidate -> judgment -> (candidate, string) result
 
-val process_with_judge :
+val judge_singleton :
+  sw:Eio.Switch.t ->
+  net:Eio_context.eio_net option ->
   base_path:string ->
-  judge:(candidate -> (judgment, retryable_failure) result) ->
   candidate ->
+  (judgment, retryable_failure) result
+(** Invoke the configured structured judge for exactly one immutable
+    candidate. The response must cover that exact candidate identity. This is
+    Provider work and must never run under Keeper turn admission. *)
+
+val apply_judgment_and_deliver :
+  base_path:string ->
+  keeper_name:string ->
+  candidate_id:string ->
+  judgment:judgment ->
   (candidate, string) result
-(** Testable state-machine boundary. Production drains the configured
-    structured judge through {!drain_pending_on_owner_lane}. *)
+(** Idempotently apply one completed worker judgment and finish its durable
+    event delivery. Success means the candidate is [Consumed]. Conflicting
+    prior judgment or a non-terminal delivery result is explicit. *)
 
 val record_and_wake :
   base_path:string -> candidate -> (record_acceptance, string) result
-(** Persist the exact candidate, then request a live wake from the registered
-    running Keeper. The durable row is authoritative: a deferred wake remains
-    a successful acceptance and is returned as a typed
-    {!Keeper_registry.wakeup_outcome}. A consumed duplicate needs no wake.
-    This function never invokes the model judge. *)
-
-val drain_pending_on_owner_lane :
-  base_path:string -> keeper_name:string -> (drain_report, string) result
-(** Synchronously process every non-terminal durable candidate. Production
-    calls this only while holding the Keeper's turn admission slot; no
-    dashboard/producer domain may call it.
-
-    Semantics:
-    - Already-judged verdicts deliver without new model calls.
-    - Pending rows are judged in batches of up to
-      {!batch_max_candidates} per model call. A failed batch aborts the round:
-      the next keepalive turn owns the retry cadence, so provider outages
-      cannot turn the drain into a hot retry loop.
-    - A successful response must cover the exact requested candidate-id set.
-      Unknown, duplicate, or missing identities fail the attempted batch and
-      persist retryable response-contract evidence on every requested row.
-    - An exact response commits all requested [Pending -> Judged] transitions
-      in one candidate-ledger rewrite or commits none. Durable queue delivery
-      and terminal [Consumed] transitions then proceed idempotently from the
-      committed judgments; they are not presented as a cross-file transaction.
-    - Failure-evidence persistence errors propagate to the caller; they are
-      never reduced to logs. Evidence for one attempted batch is committed in
-      one candidate-ledger rewrite or not committed at all. *)
-
-val batch_max_candidates : int
-(** Maximum candidates judged per model call. *)
-
-module Candidate_map : Map.S with type key = string
-
-module For_testing : sig
-  val drain_pending_with_judge :
-    base_path:string ->
-    keeper_name:string ->
-    judge:(candidate -> (judgment, retryable_failure) result) ->
-    (drain_report, string) result
-  (** Per-candidate judging adapter over the batch engine. *)
-
-  val drain_pending_with_judge_batch :
-    base_path:string ->
-    keeper_name:string ->
-    judge_batch:(candidate list -> (judgment Candidate_map.t, retryable_failure) result) ->
-    (drain_report, string) result
-end
+(** Persist the exact candidate, then request the per-Keeper judgment worker.
+    The durable row is authoritative: an unregistered worker is a typed,
+    successful deferral recovered by worker startup drain. A consumed duplicate
+    needs no wake. This function never invokes the model judge. *)

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -489,8 +489,8 @@ let ensure_roots ~base_path ~keeper_name candidates =
               else
                 let* () = valid_time "candidate recorded_at" candidate.recorded_at in
                 match candidate.status with
-                | Candidate.Judged _ | Candidate.Consumed _ -> Ok roots
-                | Candidate.Pending _ ->
+                | Candidate.Consumed _ -> Ok roots
+                | Candidate.Pending _ | Candidate.Judged _ ->
                   let* context_key = Candidate.Context_key.of_candidate candidate in
                   (match Id_map.find_opt candidate.candidate_id owners with
                    | Some owner

--- a/lib/keeper/keeper_board_attention_partition.mli
+++ b/lib/keeper/keeper_board_attention_partition.mli
@@ -1,6 +1,6 @@
 (** Durable, capacity-agnostic Board-attention judgment partitions.
 
-    Every currently-unassigned Pending candidate receives one singleton root.
+    Every currently-unassigned non-terminal candidate receives one singleton root.
     A candidate is the irreducible work identity until the dispatched Provider
     exposes typed actual-wire split authority. No byte count, token estimate,
     wall-clock expiry, retry counter, or configured batch cap chooses
@@ -74,7 +74,8 @@ val ensure_roots :
   keeper_name:string ->
   Candidate.candidate list ->
   (int, string) result
-(** Persist one deterministic singleton root for each unassigned Pending
+(** Persist one deterministic singleton root for each unassigned [Pending] or
+    [Judged]
     candidate and return the number created by this transaction. Existing live
     membership is validated as one-to-one. *)
 

--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1,0 +1,366 @@
+module Candidate = Keeper_board_attention_candidate
+module Partition = Keeper_board_attention_partition
+module Wake = Keeper_board_attention_worker_wake
+
+type step =
+  | Idle
+  | Judgment_completed of
+      { candidate_id : string
+      ; owner_wake : Keeper_registry.wakeup_outcome
+      }
+  | Judgment_deferred of
+      { candidate_id : string
+      ; failure : Candidate.retryable_failure
+      }
+  | Candidate_already_consumed of { candidate_id : string }
+  | Partition_blocked of
+      { candidate_id : string
+      ; reason : Partition.blocked_reason
+      }
+
+type settlement =
+  | No_completed_partition
+  | Partition_settled of
+      { candidate_id : string
+      ; continuation_wake : Keeper_registry.wakeup_outcome option
+      }
+
+let ( let* ) = Result.bind
+
+let owner_wake ~base_path ~keeper_name =
+  Keeper_registry.wakeup_running
+    ~intent:Keeper_registry.Attention_result
+    ~base_path
+    keeper_name
+;;
+
+let recover_claim ~worker_epoch ~base_path partition original_error =
+  match
+    Partition.recover_claim_after_lane_abort
+      ~worker_epoch
+      ~base_path
+      ~partition
+  with
+  | Ok (Partition.Claim_released _ | Partition.Claim_already_transitioned _) ->
+    Error original_error
+  | Error recovery_error ->
+    Error
+      (Printf.sprintf
+         "%s; exact claim recovery also failed: %s"
+         original_error
+         recovery_error)
+;;
+
+let complete ~now ~worker_epoch ~base_path partition judgment =
+  let item : Partition.completed_item =
+    { candidate_id = partition.Partition.candidate_id; judgment }
+  in
+  match
+    Partition.complete
+      ~now
+      ~worker_epoch
+      ~base_path
+      ~partition
+      ~item
+  with
+  | Ok (Partition.Partition_completed completed) -> Ok completed
+  | Ok (Partition.Partition_deferred _ | Partition.Partition_blocked _) ->
+    recover_claim
+      ~worker_epoch
+      ~base_path
+      partition
+      "partition completion returned a non-Completed state"
+  | Error detail -> recover_claim ~worker_epoch ~base_path partition detail
+;;
+
+let block ~now ~worker_epoch ~base_path partition reason =
+  match Partition.block ~now ~worker_epoch ~base_path ~partition reason with
+  | Ok (Partition.Partition_blocked _) ->
+    Ok (Partition_blocked { candidate_id = partition.candidate_id; reason })
+  | Ok (Partition.Partition_completed _ | Partition.Partition_deferred _) ->
+    recover_claim
+      ~worker_epoch
+      ~base_path
+      partition
+      "partition block returned a non-Blocked state"
+  | Error detail -> recover_claim ~worker_epoch ~base_path partition detail
+;;
+
+let defer ~now ~worker_epoch ~base_path partition failure =
+  match Partition.defer ~now ~worker_epoch ~base_path ~partition failure with
+  | Ok (Partition.Partition_deferred _) ->
+    Ok (Judgment_deferred { candidate_id = partition.candidate_id; failure })
+  | Ok (Partition.Partition_completed _ | Partition.Partition_blocked _) ->
+    recover_claim
+      ~worker_epoch
+      ~base_path
+      partition
+      "partition defer returned a non-Deferred state"
+  | Error detail -> recover_claim ~worker_epoch ~base_path partition detail
+;;
+
+let complete_and_signal ~now ~worker_epoch ~base_path partition judgment =
+  let* completed = complete ~now ~worker_epoch ~base_path partition judgment in
+  let owner_wake =
+    owner_wake ~base_path ~keeper_name:completed.Partition.keeper_name
+  in
+  Ok (Judgment_completed { candidate_id = completed.candidate_id; owner_wake })
+;;
+
+let candidate_by_id candidate_id candidates =
+  List.find_opt
+    (fun (candidate : Candidate.candidate) ->
+       String.equal candidate.candidate_id candidate_id)
+    candidates
+;;
+
+let validate_partition_member partition candidate =
+  if not (String.equal partition.Partition.keeper_name candidate.Candidate.keeper_name)
+  then Error "partition member Keeper identity changed"
+  else if not (Float.equal partition.created_at candidate.recorded_at)
+  then Error "partition member recorded_at changed"
+  else
+    let* context_key = Candidate.Context_key.of_candidate candidate in
+    if Candidate.Context_key.equal partition.context_key context_key
+    then Ok ()
+    else Error "partition member Keeper context changed"
+;;
+
+let process_claimed ~now ~worker_epoch ~base_path ~judge candidates partition =
+  match candidate_by_id partition.Partition.candidate_id candidates with
+  | None ->
+    block
+      ~now:(now ())
+      ~worker_epoch
+      ~base_path
+      partition
+      (Partition.Candidate_membership_conflict
+         ("candidate ledger lacks partition member " ^ partition.candidate_id))
+  | Some candidate ->
+    (match validate_partition_member partition candidate with
+     | Error detail ->
+       block
+         ~now:(now ())
+         ~worker_epoch
+         ~base_path
+         partition
+         (Partition.Candidate_membership_conflict detail)
+     | Ok () ->
+       (match candidate.status with
+        | Candidate.Pending _ ->
+          (match judge candidate with
+           | Ok judgment ->
+             complete_and_signal
+               ~now:(now ())
+               ~worker_epoch
+               ~base_path
+               partition
+               judgment
+           | Error failure ->
+             defer ~now:(now ()) ~worker_epoch ~base_path partition failure)
+        | Candidate.Judged judged ->
+          complete_and_signal
+            ~now:(now ())
+            ~worker_epoch
+            ~base_path
+            partition
+            judged.judgment
+        | Candidate.Consumed consumed ->
+          let* completed =
+            complete
+              ~now:(now ())
+              ~worker_epoch
+              ~base_path
+              partition
+              consumed.judgment
+          in
+          let* (_ : Partition.t) =
+            Partition.settle ~now:(now ()) ~base_path ~partition:completed
+          in
+          Ok (Candidate_already_consumed { candidate_id = candidate.candidate_id })))
+;;
+
+let process_next ~now ~worker_epoch ~base_path ~keeper_name ~judge =
+  let* candidates = Candidate.load_candidates ~base_path ~keeper_name in
+  let* (_ : int) = Partition.ensure_roots ~base_path ~keeper_name candidates in
+  let* claimed =
+    Partition.claim_next ~now:(now ()) ~worker_epoch ~base_path ~keeper_name
+  in
+  match claimed with
+  | None -> Ok Idle
+  | Some partition ->
+    (try
+       let* current_candidates = Candidate.load_candidates ~base_path ~keeper_name in
+       process_claimed
+         ~now
+         ~worker_epoch
+         ~base_path
+         ~judge
+         current_candidates
+         partition
+     with
+     | Eio.Cancel.Cancelled _ as exn ->
+       Eio.Cancel.protect (fun () ->
+         match
+           Partition.recover_claim_after_lane_abort
+             ~worker_epoch
+             ~base_path
+             ~partition
+         with
+         | Ok (Partition.Claim_released _ | Partition.Claim_already_transitioned _) -> ()
+         | Error detail ->
+           Log.Keeper.error
+             "Board attention cancellation claim recovery failed keeper=%s partition=%s: %s"
+             keeper_name
+             partition.partition_id
+             detail);
+       raise exn
+     | exn ->
+       recover_claim
+         ~worker_epoch
+         ~base_path
+         partition
+         ("Board attention worker step raised: " ^ Printexc.to_string exn))
+;;
+
+let completed_in_order ~base_path ~keeper_name =
+  let* completed = Partition.completed ~base_path ~keeper_name in
+  Ok
+    (List.sort
+       (fun left right ->
+          match Float.compare left.Partition.created_at right.Partition.created_at with
+          | 0 -> String.compare left.partition_id right.partition_id
+          | order -> order)
+       completed)
+;;
+
+let settle_one_completed ~base_path ~keeper_name =
+  let* completed = completed_in_order ~base_path ~keeper_name in
+  match completed with
+  | [] -> Ok No_completed_partition
+  | partition :: _ ->
+    (match partition.state with
+     | Partition.Completed { item; _ } ->
+       let* (_ : Candidate.candidate) =
+         Candidate.apply_judgment_and_deliver
+           ~base_path
+           ~keeper_name
+           ~candidate_id:item.candidate_id
+           ~judgment:item.judgment
+       in
+       let* settled =
+         Partition.settle
+           ~now:(Time_compat.now ())
+           ~base_path
+           ~partition
+       in
+       let* remaining = completed_in_order ~base_path ~keeper_name in
+       let continuation_wake =
+         match remaining with
+         | [] -> None
+         | _ :: _ -> Some (owner_wake ~base_path ~keeper_name)
+       in
+       Ok
+         (Partition_settled
+            { candidate_id = settled.candidate_id; continuation_wake })
+     | Partition.Ready
+     | Partition.Running _
+     | Partition.Deferred _
+     | Partition.Settled _
+     | Partition.Blocked _ ->
+       Error
+         ("completed partition query returned non-Completed state: "
+          ^ partition.partition_id))
+;;
+
+let recovered_mutex = Stdlib.Mutex.create ()
+let recovered_process_keys : (string, unit) Hashtbl.t = Hashtbl.create 16
+
+let claim_process_recovery ~base_path ~keeper_name =
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  Stdlib.Mutex.protect recovered_mutex (fun () ->
+    if Hashtbl.mem recovered_process_keys key
+    then false
+    else (
+      Hashtbl.add recovered_process_keys key ();
+      true))
+;;
+
+let release_process_recovery ~base_path ~keeper_name =
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  Stdlib.Mutex.protect recovered_mutex (fun () ->
+    Hashtbl.remove recovered_process_keys key)
+;;
+
+let observe_error ~base_path ~keeper_name detail =
+  (try Keeper_registry_error_recording.record ~base_path keeper_name detail with
+   | Eio.Cancel.Cancelled _ as exn -> raise exn
+   | exn ->
+     Log.Keeper.error
+       "Board attention worker failure observation also failed keeper=%s worker_error=%s observer_error=%s"
+       keeper_name
+       detail
+       (Printexc.to_string exn));
+  Log.Keeper.error "Board attention worker deferred keeper=%s: %s" keeper_name detail
+;;
+
+let run ~sw ~net ~base_path ~keeper_name =
+  match Wake.register ~sw ~base_path ~keeper_name with
+  | Error detail -> observe_error ~base_path ~keeper_name detail
+  | Ok registration ->
+    let worker_epoch = Partition.Worker_epoch.generate () in
+    let startup_ready =
+      if claim_process_recovery ~base_path ~keeper_name
+      then (
+        try
+          match Partition.recover_for_process_start ~base_path ~keeper_name with
+          | Ok _ -> true
+          | Error detail ->
+            release_process_recovery ~base_path ~keeper_name;
+            observe_error ~base_path ~keeper_name detail;
+            false
+        with
+        | Eio.Cancel.Cancelled _ as exn ->
+          release_process_recovery ~base_path ~keeper_name;
+          raise exn)
+      else true
+    in
+    let rec await () =
+      match Wake.await registration with
+      | Wake.Registration_closed -> ()
+      | Wake.Wake -> drain ()
+    and drain () =
+      match
+        process_next
+          ~now:Time_compat.now
+          ~worker_epoch
+          ~base_path
+          ~keeper_name
+          ~judge:(Candidate.judge_singleton ~sw ~net ~base_path)
+      with
+      | Ok Idle -> await ()
+      | Ok (Judgment_completed _ | Candidate_already_consumed _ | Partition_blocked _) ->
+        Eio.Fiber.yield ();
+        drain ()
+      | Ok (Judgment_deferred _) -> await ()
+      | Error detail ->
+        observe_error ~base_path ~keeper_name detail;
+        await ()
+    in
+    let rec supervise action =
+      try action () with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        observe_error
+          ~base_path
+          ~keeper_name
+          ("Board attention worker control loop raised: " ^ Printexc.to_string exn);
+        supervise await
+    in
+    supervise (if startup_ready then drain else await)
+;;
+
+module For_testing = struct
+  let process_next = process_next
+end
+;;

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -1,0 +1,58 @@
+(** Per-Keeper Board-attention judgment worker.
+
+    Provider work runs in this worker, never under Keeper turn admission. The
+    candidate and partition ledgers are authoritative; process-local wakes only
+    request another inspection. *)
+
+type step =
+  | Idle
+  | Judgment_completed of
+      { candidate_id : string
+      ; owner_wake : Keeper_registry.wakeup_outcome
+      }
+  | Judgment_deferred of
+      { candidate_id : string
+      ; failure : Keeper_board_attention_candidate.retryable_failure
+      }
+  | Candidate_already_consumed of { candidate_id : string }
+  | Partition_blocked of
+      { candidate_id : string
+      ; reason : Keeper_board_attention_partition.blocked_reason
+      }
+
+type settlement =
+  | No_completed_partition
+  | Partition_settled of
+      { candidate_id : string
+      ; continuation_wake : Keeper_registry.wakeup_outcome option
+      }
+
+val run :
+  sw:Eio.Switch.t ->
+  net:Eio_context.eio_net option ->
+  base_path:string ->
+  keeper_name:string ->
+  unit
+(** Register and run the transition-driven worker until [sw] is cancelled.
+    The first registration for this exact workspace/Keeper in the process owns
+    prior-process recovery. There is no timer polling or retry-count policy. *)
+
+val settle_one_completed :
+  base_path:string -> keeper_name:string -> (settlement, string) result
+(** Owner-admission boundary. Apply and deliver at most one completed judgment,
+    settle its partition, and request one continuation wake when more completed
+    results remain. This function never invokes a Provider. *)
+
+module For_testing : sig
+  val process_next :
+    now:(unit -> float) ->
+    worker_epoch:Keeper_board_attention_partition.Worker_epoch.t ->
+    base_path:string ->
+    keeper_name:string ->
+    judge:
+      (Keeper_board_attention_candidate.candidate ->
+       ( Keeper_board_attention_candidate.judgment
+       , Keeper_board_attention_candidate.retryable_failure )
+       result) ->
+    (step, string) result
+end

--- a/lib/keeper/keeper_board_attention_worker_wake.ml
+++ b/lib/keeper/keeper_board_attention_worker_wake.ml
@@ -1,0 +1,103 @@
+type registration_state =
+  | Open of { pending : bool }
+  | Closed
+
+type registration =
+  { key : string
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Eio.Condition.t
+  ; mutable state : registration_state
+  }
+
+type wake_result =
+  | Signaled
+  | Coalesced
+  | Not_registered
+
+type await_result =
+  | Wake
+  | Registration_closed
+
+let registry_mutex = Stdlib.Mutex.create ()
+let registrations : (string, registration) Hashtbl.t = Hashtbl.create 16
+let with_registry f = Stdlib.Mutex.protect registry_mutex f
+let with_registration registration f = Stdlib.Mutex.protect registration.mutex f
+
+let key ~base_path ~keeper_name =
+  try Ok (Keeper_registry_types.registry_key ~base_path keeper_name) with
+  | Invalid_argument detail -> Error detail
+;;
+
+let unregister registration =
+  let removed =
+    with_registry (fun () ->
+      match Hashtbl.find_opt registrations registration.key with
+      | Some current when current == registration ->
+        Hashtbl.remove registrations registration.key;
+        true
+      | Some _ | None -> false)
+  in
+  if removed
+  then (
+    with_registration registration (fun () -> registration.state <- Closed);
+    Eio.Condition.broadcast registration.condition)
+;;
+
+let register ~sw ~base_path ~keeper_name =
+  Eio.Switch.check sw;
+  match key ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok key ->
+    let registration =
+      { key
+      ; mutex = Stdlib.Mutex.create ()
+      ; condition = Eio.Condition.create ()
+      ; state = Open { pending = false }
+      }
+    in
+    let added =
+      with_registry (fun () ->
+        match Hashtbl.find_opt registrations key with
+        | Some _ -> false
+        | None ->
+          Hashtbl.add registrations key registration;
+          true)
+    in
+    if not added
+    then Error ("Board attention worker is already registered: " ^ key)
+    else (
+      Eio.Switch.on_release sw (fun () -> unregister registration);
+      Ok registration)
+;;
+
+let request ~base_path ~keeper_name =
+  match key ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok key ->
+    let result, notify =
+      with_registry (fun () ->
+        match Hashtbl.find_opt registrations key with
+        | None -> Not_registered, None
+        | Some registration ->
+          with_registration registration (fun () ->
+            match registration.state with
+            | Closed -> Not_registered, None
+            | Open { pending = true } -> Coalesced, None
+            | Open { pending = false } ->
+              registration.state <- Open { pending = true };
+              Signaled, Some registration.condition))
+    in
+    Option.iter Eio.Condition.broadcast notify;
+    Ok result
+;;
+
+let await registration =
+  Eio.Condition.loop_no_mutex registration.condition (fun () ->
+    with_registration registration (fun () ->
+      match registration.state with
+      | Closed -> Some Registration_closed
+      | Open { pending = false } -> None
+      | Open { pending = true } ->
+        registration.state <- Open { pending = false };
+        Some Wake))
+;;

--- a/lib/keeper/keeper_board_attention_worker_wake.mli
+++ b/lib/keeper/keeper_board_attention_worker_wake.mli
@@ -1,0 +1,34 @@
+(** Process-local wake hints for durable per-Keeper Board-attention workers.
+
+    Hints may coalesce because the candidate and partition ledgers are the work
+    authority. Registration is keyed by canonical BasePath plus Keeper name so
+    multiple workspaces cannot signal one another. *)
+
+type registration
+
+type wake_result =
+  | Signaled
+  | Coalesced
+  | Not_registered
+
+type await_result =
+  | Wake
+  | Registration_closed
+
+val register :
+  sw:Eio.Switch.t ->
+  base_path:string ->
+  keeper_name:string ->
+  (registration, string) result
+(** Register one worker for the exact workspace/Keeper identity. Duplicate
+    live registration is rejected. Switch release closes and unregisters the
+    exact registration. *)
+
+val request :
+  base_path:string -> keeper_name:string -> (wake_result, string) result
+(** Non-blockingly publish one coalescing hint. [Not_registered] is successful
+    durable deferral: startup drain remains responsible for already-persisted
+    work. *)
+
+val await : registration -> await_result
+(** Cancellably consume one hint or observe registration closure. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -121,10 +121,10 @@ type keepalive_turn_outcome = {
 
 exception Event_queue_settlement_failed of string
 
-type board_attention_drain_outcome =
-  | Board_attention_drained of
-      Keeper_board_attention_candidate.drain_report
-  | Board_attention_drain_deferred of
+type board_attention_settlement_outcome =
+  | Board_attention_settled of
+      Keeper_board_attention_worker.settlement
+  | Board_attention_settlement_deferred of
       Keeper_turn_admission.autonomous_block
 
 let connector_attention_event_ids_of_stimuli stimuli =
@@ -430,19 +430,19 @@ let turn_status_event ~turn_fail_count : Keeper_state_machine.event =
   else Keeper_state_machine.Turn_succeeded
 ;;
 
-let drain_board_attention_candidates_on_owner_lane ~base_path ~keeper_name =
+let settle_board_attention_on_owner_lane ~base_path ~keeper_name =
   match
     Keeper_turn_admission.run_if_free
       ~base_path
       ~keeper_name
       (fun () ->
-         Keeper_board_attention_candidate.drain_pending_on_owner_lane
+         Keeper_board_attention_worker.settle_one_completed
            ~base_path
            ~keeper_name)
   with
-  | `Ran (Ok report) -> Ok (Board_attention_drained report)
+  | `Ran (Ok settlement) -> Ok (Board_attention_settled settlement)
   | `Ran (Error detail) -> Error detail
-  | `Busy block -> Ok (Board_attention_drain_deferred block)
+  | `Busy block -> Ok (Board_attention_settlement_deferred block)
 ;;
 
 let run_keepalive_unified_turn
@@ -523,49 +523,46 @@ let run_keepalive_unified_turn
        | Ok () -> ()
        | Error message -> raise (Event_queue_settlement_failed message));
       (match
-         drain_board_attention_candidates_on_owner_lane
+         settle_board_attention_on_owner_lane
            ~base_path:ctx.config.base_path
            ~keeper_name:meta_after_triage.name
        with
        | Error detail ->
          raise (Keeper_board_attention_candidate.Candidate_unavailable detail)
+       | Ok (Board_attention_settled Keeper_board_attention_worker.No_completed_partition) ->
+         ()
        | Ok
-           (Board_attention_drained
-              ({ attempted; consumed; remaining }
-                : Keeper_board_attention_candidate.drain_report)) ->
-         if attempted > 0
-         then
-           Log.Keeper.info
-             "Board attention owner-lane drain keeper=%s attempted=%d consumed=%d \
-              remaining=%d"
-             meta_after_triage.name
-             attempted
-             consumed
-             remaining
+           (Board_attention_settled
+              (Keeper_board_attention_worker.Partition_settled
+                 { candidate_id; continuation_wake = _ })) ->
+         Log.Keeper.info
+           "Board attention completed judgment settled on owner lane keeper=%s candidate=%s"
+           meta_after_triage.name
+           candidate_id
        | Ok
-           (Board_attention_drain_deferred
+           (Board_attention_settlement_deferred
               (Keeper_turn_admission.Turn_busy in_flight)) ->
          Log.Keeper.debug
-           "Board attention owner-lane drain check deferred keeper=%s holder=%s"
+           "Board attention owner-lane settlement deferred keeper=%s holder=%s"
            meta_after_triage.name
            (match in_flight with
             | None -> "admission_in_progress"
             | Some { lane; _ } -> Keeper_turn_admission.lane_to_string lane)
        | Ok
-           (Board_attention_drain_deferred
+           (Board_attention_settlement_deferred
               (Keeper_turn_admission.Chat_backlog
                  { pending_count; inflight_count })) ->
          Log.Keeper.info
-           "Board attention owner-lane drain deferred to chat backlog \
+           "Board attention owner-lane settlement deferred to chat backlog \
             keeper=%s pending=%d inflight=%d"
            meta_after_triage.name
            pending_count
            inflight_count
        | Ok
-           (Board_attention_drain_deferred
+           (Board_attention_settlement_deferred
               (Keeper_turn_admission.Shutdown_requested operation_id)) ->
          Log.Keeper.info
-           "Board attention owner-lane drain check deferred by shutdown \
+           "Board attention owner-lane settlement deferred by shutdown \
             keeper=%s operation=%s"
            meta_after_triage.name
            (Keeper_shutdown_types.Operation_id.to_string operation_id));

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -369,6 +369,7 @@ type wakeup_intent =
   | Hitl_resolution
   | Broadcast_signal
   | Compaction_signal
+  | Attention_result
 
 let wakeup_intent_to_wire = function
   | Reactive_signal -> "reactive_signal"
@@ -378,6 +379,7 @@ let wakeup_intent_to_wire = function
   | Hitl_resolution -> "hitl_resolution"
   | Broadcast_signal -> "broadcast_signal"
   | Compaction_signal -> "compaction_signal"
+  | Attention_result -> "attention_result"
 ;;
 
 type wakeup_outcome =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -444,6 +444,7 @@ type wakeup_intent =
   | Hitl_resolution
   | Broadcast_signal
   | Compaction_signal
+  | Attention_result
 
 type wakeup_outcome =
   | Signaled

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -237,6 +237,16 @@ let launch_supervised_fiber_body
       Eio_guard.protect
         (fun () ->
            try
+             (* Ambient Board semantic judgment is a sibling worker on this
+                exact Keeper lifecycle switch. It owns Provider calls and
+                returns only durable completed partitions to the short owner
+                admission path; cancellation joins it with the Keeper lane. *)
+             Eio.Fiber.fork ~sw:lane_sw (fun () ->
+               Keeper_board_attention_worker.run
+                 ~sw:lane_sw
+                 ~net:ctx.net
+                 ~base_path
+                 ~keeper_name:meta.name);
              (* Keeper lifetime, idle duration, and progress age are
                 observations only. The supervisor runs the lane directly;
                 configured provider/tool boundaries and explicit operator

--- a/test/dune
+++ b/test/dune
@@ -187,6 +187,7 @@
   test_keeper_waiting_inventory
   test_keeper_board_attention_candidate
   test_keeper_board_attention_partition
+  test_keeper_board_attention_worker
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager
@@ -497,6 +498,7 @@
   test_keeper_waiting_inventory
   test_keeper_board_attention_candidate
   test_keeper_board_attention_partition
+  test_keeper_board_attention_worker
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -1,8 +1,6 @@
 module A = Masc.Keeper_board_attention_candidate
 module J = Masc.Keeper_board_attention_judgment
-module Event_queue = Keeper_event_queue
-module Event_queue_persistence = Keeper_event_queue_persistence
-module Registry = Masc.Keeper_registry
+module Wake = Masc.Keeper_board_attention_worker_wake
 
 let rec remove_tree path =
   if Sys.file_exists path
@@ -20,35 +18,12 @@ let with_temp_base name f =
   Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
 ;;
 
-let board_id parse label value =
-  match parse value with
-  | Ok id -> id
-  | Error error ->
-    Alcotest.failf "%s fixture id invalid: %s" label (Masc.Board.show_board_error error)
+let ok label = function
+  | Ok value -> value
+  | Error detail -> Alcotest.failf "%s: %s" label detail
 ;;
 
-let post_id value = board_id Masc.Board.Post_id.of_string "post" value
-let comment_id value = board_id Masc.Board.Comment_id.of_string "comment" value
-let agent_id value = board_id Masc.Board.Agent_id.of_string "agent" value
-
-let meta keeper_name =
-  let json =
-    `Assoc
-      [ "name", `String keeper_name
-      ; "agent_name", `String ("keeper-" ^ keeper_name ^ "-agent")
-      ; "trace_id", `String ("trace-" ^ keeper_name)
-      ; "instructions", `String "Use the lane context and complete the task"
-      ; "sandbox_profile", `String "local"
-      ; "network_mode", `String "inherit"
-      ; "mention_targets", `List [ `String keeper_name ]
-      ]
-  in
-  match Masc.Keeper_meta_json_parse.meta_of_json json with
-  | Ok meta -> { meta with active_goal_ids = [ "goal-board" ] }
-  | Error detail -> Alcotest.failf "keeper meta fixture invalid: %s" detail
-;;
-
-let signal ?(post_id = "post-1") ?(content = "A new Board observation") () :
+let signal ?(content = "Persisted Board evidence") post_id :
   Masc.Board_dispatch.board_signal
   =
   { kind = Masc.Board_dispatch.Board_post_created
@@ -61,1050 +36,260 @@ let signal ?(post_id = "post-1") ?(content = "A new Board observation") () :
   }
 ;;
 
-let post ?(id = "post-1") () : Masc.Board.post =
-  { id = post_id id
-  ; author = agent_id "external-author"
-  ; title = "Board update"
-  ; body = "Full persisted body"
-  ; content = "A new Board observation"
-  ; post_kind = Masc.Board.Human_post
-  ; meta_json = Some (`Assoc [ "source", `String "test" ])
-  ; visibility = Masc.Board.Public
-  ; created_at = 40.0
-  ; updated_at = 42.0
-  ; expires_at = 0.0
-  ; votes_up = 3
-  ; votes_down = 1
-  ; reply_count = 1
-  ; pinned = false
-  ; hearth = Some "hearth-1"
-  ; thread_id = Some "thread-1"
-  ; origin = None
+let candidate ?(context = `Assoc [ "instructions", `String "continue" ]) signal :
+  A.candidate
+  =
+  let keeper_name = "sangsu" in
+  let candidate_id =
+    `Assoc
+      [ "keeper_name", `String keeper_name
+      ; "signal", A.signal_to_yojson signal
+      ]
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  { candidate_id
+  ; keeper_name
+  ; signal
+  ; judgment_request =
+      `Assoc
+        [ "candidate_id", `String candidate_id
+        ; "signal", A.signal_to_yojson signal
+        ; "keeper_context", context
+        ]
+  ; recorded_at = 1.0
+  ; status = A.Pending { last_failure = None }
   }
-;;
-
-let comments () : Masc.Board.comment list =
-  [ { id = comment_id "comment-1"
-    ; post_id = post_id "post-1"
-    ; parent_id = None
-    ; author = agent_id "reviewer"
-    ; content = "Full persisted comment"
-    ; created_at = 41.0
-    ; expires_at = 0.0
-    ; votes_up = 1
-    ; votes_down = 0
-    }
-  ]
-;;
-
-let candidate ?(keeper_name = "sangsu") ?(signal = signal ()) () =
-  match
-    A.of_board_evidence
-      ~meta:(meta keeper_name)
-      ~recorded_at:100.0
-      ~signal
-      ~post:(post ~id:signal.post_id ())
-      ~comments:(comments ())
-  with
-  | Ok candidate -> candidate
-  | Error detail -> Alcotest.failf "candidate fixture invalid: %s" detail
 ;;
 
 let judgment decision : A.judgment =
-  { verdict = { J.decision = decision; rationale = "typed structured verdict" }
+  { verdict = { J.decision; rationale = "typed structured verdict" }
   ; runtime_id = "configured-structured-judge"
-  ; judged_at = 101.0
+  ; judged_at = 2.0
   }
 ;;
 
-let record_or_fail ~base_path candidate =
+let record ~base_path candidate =
   match A.record ~base_path candidate with
-  | A.Recorded persisted -> persisted
-  | A.Duplicate _ -> Alcotest.fail "first candidate record was a duplicate"
+  | A.Recorded candidate -> candidate
+  | A.Duplicate _ -> Alcotest.fail "first record was a duplicate"
   | A.Record_error detail -> Alcotest.failf "candidate record failed: %s" detail
 ;;
 
-let only_loaded ~base_path ~keeper_name =
-  match A.load_candidates ~base_path ~keeper_name with
-  | Ok [ candidate ] -> candidate
-  | Ok candidates ->
-    Alcotest.failf "expected one latest candidate, got %d" (List.length candidates)
-  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
+let load_one ~base_path =
+  match ok "load candidate" (A.load_candidates ~base_path ~keeper_name:"sangsu") with
+  | [ candidate ] -> candidate
+  | candidates -> Alcotest.failf "expected one candidate, got %d" (List.length candidates)
 ;;
 
-let test_roundtrip_preserves_full_evidence_and_pending_state () =
-  let candidate = candidate () in
-  (match candidate.status with
-   | A.Pending { last_failure = None } -> ()
-   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
-     Alcotest.fail "new candidate was not clean Pending");
-  let request_fields =
-    match candidate.judgment_request with
-    | `Assoc fields -> fields
-    | _ -> Alcotest.fail "judgment request must be an object"
+let test_codec_and_context_identity_are_strict () =
+  let original =
+    candidate
+      ~context:
+        (`Assoc
+           [ "instructions", `String "continue"
+           ; "goals", `List [ `String "g-1"; `String "g-2" ]
+           ])
+      (signal "post-codec")
   in
   Alcotest.(check bool)
-    "full post evidence"
+    "candidate roundtrip"
     true
-    (List.mem_assoc "post" request_fields);
-  (match List.assoc_opt "comments" request_fields with
-   | Some (`List [ `Assoc comment_fields ]) ->
-     Alcotest.(check bool)
-       "full comment content"
-       true
-       (List.mem_assoc "content" comment_fields)
-   | _ -> Alcotest.fail "full comment list missing");
-  Alcotest.(check bool)
-    "Keeper Goal Task lane context"
-    true
-    (List.mem_assoc "keeper_context" request_fields);
-  match A.candidate_of_json (A.candidate_to_json candidate) with
-  | Ok decoded -> Alcotest.(check bool) "strict roundtrip" true (decoded = candidate)
-  | Error detail -> Alcotest.failf "candidate decode failed: %s" detail
-;;
-
-let context_key_or_fail candidate =
-  match A.Context_key.of_candidate candidate with
-  | Ok key -> key
-  | Error detail -> Alcotest.failf "context key failed: %s" detail
-;;
-
-let candidate_with_context context =
-  { (candidate ()) with
-    judgment_request = `Assoc [ "keeper_context", context ]
-  }
-;;
-
-let test_context_key_is_exact_and_object_order_independent () =
-  let left =
-    candidate_with_context
-      (`Assoc
-         [ "instructions", `String "continue"
-         ; "goals", `List [ `String "g-1"; `String "g-2" ]
-         ; "runtime", `Assoc [ "model", `String "judge"; "tools", `Bool true ]
-         ])
-    |> context_key_or_fail
-  in
+    (ok "decode candidate" (A.candidate_of_json (A.candidate_to_json original)) = original);
+  let left = ok "left context" (A.Context_key.of_candidate original) in
   let reordered =
-    candidate_with_context
-      (`Assoc
-         [ "runtime", `Assoc [ "tools", `Bool true; "model", `String "judge" ]
-         ; "goals", `List [ `String "g-1"; `String "g-2" ]
-         ; "instructions", `String "continue"
-         ])
-    |> context_key_or_fail
-  in
-  let changed_list_order =
-    candidate_with_context
-      (`Assoc
-         [ "runtime", `Assoc [ "tools", `Bool true; "model", `String "judge" ]
-         ; "goals", `List [ `String "g-2"; `String "g-1" ]
-         ; "instructions", `String "continue"
-         ])
-    |> context_key_or_fail
+    candidate
+      ~context:
+        (`Assoc
+           [ "goals", `List [ `String "g-1"; `String "g-2" ]
+           ; "instructions", `String "continue"
+           ])
+      (signal "post-reordered")
+    |> A.Context_key.of_candidate
+    |> ok "reordered context"
   in
   Alcotest.(check bool)
-    "object field order is not identity"
+    "object field order is not context identity"
     true
     (A.Context_key.equal left reordered);
+  let changed_list =
+    candidate
+      ~context:
+        (`Assoc
+           [ "instructions", `String "continue"
+           ; "goals", `List [ `String "g-2"; `String "g-1" ]
+           ])
+      (signal "post-list-order")
+    |> A.Context_key.of_candidate
+    |> ok "changed list context"
+  in
   Alcotest.(check bool)
-    "list order remains identity"
+    "list order remains context identity"
     false
-    (A.Context_key.equal left changed_list_order);
-  let positive_zero =
-    candidate_with_context (`Assoc [ "offset", `Float 0.0 ])
-    |> context_key_or_fail
-  in
-  let negative_zero =
-    candidate_with_context (`Assoc [ "offset", `Float (-0.0) ])
-    |> context_key_or_fail
-  in
-  Alcotest.(check string)
-    "signed zero has one durable identity"
-    (A.Context_key.to_canonical_string positive_zero)
-    (A.Context_key.to_canonical_string negative_zero)
+    (A.Context_key.equal left changed_list);
+  (match
+     A.Context_key.of_candidate
+       { original with
+         judgment_request =
+           `Assoc
+             [ "keeper_context", `Assoc []
+             ; "keeper_context", `Assoc []
+             ]
+       }
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "duplicate keeper_context authority was accepted")
 ;;
 
-let test_context_key_rejects_ambiguous_authority () =
-  let expect_error label candidate =
-    match A.Context_key.of_candidate candidate with
-    | Error _ -> ()
-    | Ok _ -> Alcotest.failf "%s was accepted" label
+let test_record_dedupes_exact_identity_and_rejects_conflict () =
+  with_temp_base "board-attention-candidate-record" @@ fun base_path ->
+  let original = candidate (signal "post-record") in
+  let persisted = record ~base_path original in
+  (match A.record ~base_path original with
+   | A.Duplicate duplicate ->
+     Alcotest.(check bool) "exact duplicate" true (duplicate = persisted)
+   | A.Recorded _ | A.Record_error _ -> Alcotest.fail "exact duplicate was not deduped");
+  let conflicting =
+    { original with signal = signal ~content:"different evidence" "post-record" }
   in
-  expect_error
-    "missing keeper_context"
-    { (candidate ()) with judgment_request = `Assoc [] };
-  expect_error
-    "multiple keeper_context fields"
-    { (candidate ()) with
-      judgment_request =
-        `Assoc
-          [ "keeper_context", `Assoc [ "instructions", `String "first" ]
-          ; "keeper_context", `Assoc [ "instructions", `String "second" ]
-          ]
-    };
-  expect_error
-    "duplicate nested context key"
-    (candidate_with_context
-       (`Assoc
-          [ "instructions", `String "first"
-          ; "instructions", `String "second"
-          ]));
-  expect_error
-    "non-finite context number"
-    (candidate_with_context (`Assoc [ "temperature", `Float Float.nan ]))
-;;
-
-let test_record_dedupes_exact_candidate_identity () =
-  with_temp_base "keeper-board-attention-dedup" @@ fun base_path ->
-  let first = candidate () in
-  let duplicate = candidate () in
-  ignore (record_or_fail ~base_path first : A.candidate);
-  (match A.record ~base_path duplicate with
-   | A.Duplicate existing ->
-     Alcotest.(check string)
-       "same exact signal id"
-       first.candidate_id
-       existing.candidate_id
-   | A.Recorded _ -> Alcotest.fail "exact duplicate appended as a new candidate"
-   | A.Record_error detail -> Alcotest.failf "duplicate check failed: %s" detail);
-  ignore (only_loaded ~base_path ~keeper_name:first.keeper_name : A.candidate)
-;;
-
-let test_worker_record_wakes_then_owner_lane_drains () =
-  with_temp_base "keeper-board-attention-owner-lane" @@ fun base_path ->
-  let pending = candidate () in
-  let entry =
-    Registry.register
-      ~base_path
-      pending.keeper_name
-      (meta pending.keeper_name)
-  in
-  Fun.protect
-    ~finally:(fun () ->
-      Registry.unregister ~base_path pending.keeper_name)
-    (fun () ->
-       let accepted =
-         Domain.spawn (fun () -> A.record_and_wake ~base_path pending)
-         |> Domain.join
-       in
-       (match accepted with
-        | Ok
-            { A.candidate = persisted
-            ; persistence = A.Candidate_recorded
-            ; wake = A.Wake_requested Registry.Signaled
-            } ->
-          (match persisted.status with
-           | A.Pending { last_failure = None } -> ()
-           | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
-             Alcotest.fail "worker-side record invoked or mutated the judgment")
-        | Ok _ -> Alcotest.fail "worker-side record returned the wrong typed acceptance"
-        | Error detail -> Alcotest.failf "worker-side record failed: %s" detail);
-       Alcotest.(check bool)
-         "worker producer signaled the registered owner lane"
-         true
-         (Atomic.get entry.fiber_wakeup);
-       Atomic.set entry.fiber_wakeup false;
-       let report =
-         match
-           A.For_testing.drain_pending_with_judge
-             ~base_path
-             ~keeper_name:pending.keeper_name
-             ~judge:(fun _ -> Ok (judgment J.Relevant))
-         with
-         | Ok report -> report
-         | Error detail -> Alcotest.failf "owner-lane drain failed: %s" detail
-       in
-       Alcotest.(check int) "one candidate attempted" 1 report.attempted;
-       Alcotest.(check int) "one candidate consumed" 1 report.consumed;
-       Alcotest.(check int) "no candidate remains" 0 report.remaining;
-       Alcotest.(check bool)
-         "durable delivery signaled the owner lane"
-         true
-         (Atomic.get entry.fiber_wakeup);
-       match
-         Event_queue_persistence.load
-           ~base_path
-           ~keeper_name:pending.keeper_name
-         |> Event_queue.to_list
-       with
-       | [ { payload = Event_queue.Board_attention attention; _ } ] ->
-         Alcotest.(check string)
-           "owner drain delivered the exact candidate"
-           pending.candidate_id
-           attention.candidate_id
-       | _ -> Alcotest.fail "owner drain did not commit one Board_attention event")
-;;
-
-let test_retryable_judge_failure_remains_pending () =
-  with_temp_base "keeper-board-attention-retry" @@ fun base_path ->
-  let pending = record_or_fail ~base_path (candidate ()) in
-  let failure : A.retryable_failure =
-    { kind = A.Provider_unavailable
-    ; detail = "provider unavailable"
-    ; failed_at = 102.0
-    }
-  in
-  let current =
-    match
-      A.process_with_judge
-        ~base_path
-        ~judge:(fun _ -> Error failure)
-        pending
-    with
-    | Ok candidate -> candidate
-    | Error detail -> Alcotest.failf "retryable transition failed: %s" detail
-  in
-  match current.status with
-  | A.Pending { last_failure = Some observed } ->
-    Alcotest.(check string)
-      "typed failure preserved"
-      "provider_unavailable"
-      (A.retryable_failure_kind_to_string observed.kind)
-  | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
-    Alcotest.fail "retryable judge failure consumed the candidate"
-;;
-
-let test_not_relevant_transitions_directly_to_consumed () =
-  with_temp_base "keeper-board-attention-not-relevant" @@ fun base_path ->
-  let pending = record_or_fail ~base_path (candidate ()) in
-  let current =
-    match
-      A.process_with_judge
-        ~base_path
-        ~judge:(fun _ -> Ok (judgment J.Not_relevant))
-        pending
-    with
-    | Ok candidate -> candidate
-    | Error detail -> Alcotest.failf "not-relevant transition failed: %s" detail
-  in
-  (match current.status with
-   | A.Consumed { delivery = A.Not_relevant; _ } -> ()
-   | A.Consumed _ | A.Pending _ | A.Judged _ ->
-     Alcotest.fail "not-relevant verdict did not reach Consumed");
-  let queue =
-    Keeper_event_queue_persistence.load
-      ~base_path
-      ~keeper_name:current.keeper_name
-  in
-  Alcotest.(check int)
-    "not relevant does not enqueue"
-    0
-    (Keeper_event_queue.length queue)
-;;
-
-let test_relevant_consumes_only_after_exact_durable_enqueue () =
-  with_temp_base "keeper-board-attention-relevant" @@ fun base_path ->
-  let pending = record_or_fail ~base_path (candidate ()) in
-  let current =
-    match
-      A.process_with_judge
-        ~base_path
-        ~judge:(fun _ -> Ok (judgment J.Relevant))
-        pending
-    with
-    | Ok candidate -> candidate
-    | Error detail -> Alcotest.failf "relevant transition failed: %s" detail
-  in
-  (match current.status with
-   | A.Consumed { delivery = A.Enqueued_to_keeper_lane; _ } -> ()
-   | A.Consumed _ | A.Pending _ | A.Judged _ ->
-     Alcotest.fail "relevant verdict consumed before durable delivery");
-  let queue =
-    Keeper_event_queue_persistence.load
-      ~base_path
-      ~keeper_name:current.keeper_name
-    |> Keeper_event_queue.to_list
-  in
-  (match queue with
-   | [ { payload = Keeper_event_queue.Board_attention attention; _ } ] ->
-     Alcotest.(check string)
-       "opaque candidate identity persisted"
-       current.candidate_id
-       attention.candidate_id
-   | _ -> Alcotest.fail "relevant candidate did not persist one Board_attention event");
-  let replayed =
-    match
-      A.process_with_judge
-        ~base_path
-        ~judge:(fun _ -> Alcotest.fail "Consumed candidate invoked judge")
-        current
-    with
-    | Ok candidate -> candidate
-    | Error detail -> Alcotest.failf "Consumed replay failed: %s" detail
-  in
-  Alcotest.(check bool) "Consumed replay is idempotent" true (replayed = current)
-;;
-
-let test_delivery_storage_error_retains_judged_state () =
-  with_temp_base "keeper-board-attention-delivery-error" @@ fun base_path ->
-  let pending = record_or_fail ~base_path (candidate ()) in
-  let keepers_path =
-    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers"
-  in
-  let oc = open_out_bin keepers_path in
-  output_string oc "event queue directory blocker";
-  close_out oc;
-  let current =
-    match
-      A.process_with_judge
-        ~base_path
-        ~judge:(fun _ -> Ok (judgment J.Relevant))
-        pending
-    with
-    | Ok candidate -> candidate
-    | Error detail -> Alcotest.failf "delivery failure transition failed: %s" detail
-  in
-  match current.status with
-  | A.Judged
-      { last_failure = Some { kind = A.Durable_delivery_unavailable; _ }; _ } ->
-    ()
-  | A.Judged _ | A.Pending _ | A.Consumed _ ->
-    Alcotest.fail "durable delivery storage error did not retain Judged"
-;;
-
-let test_malformed_ledger_is_explicit_and_not_overwritten () =
-  with_temp_base "keeper-board-attention-malformed" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  let dir =
-    Filename.concat
-      (Common.masc_dir_from_base_path ~base_path)
-      "board_attention_candidates"
-  in
-  Fs_compat.mkdir_p dir;
-  let path = Filename.concat dir (keeper_name ^ ".jsonl") in
-  let malformed = "{not-json\n" in
-  let oc = open_out_bin path in
-  output_string oc malformed;
-  close_out oc;
-  (match A.load_candidates ~base_path ~keeper_name with
-   | Error detail -> Alcotest.(check bool) "error detail" true (String.length detail > 0)
-   | Ok _ -> Alcotest.fail "malformed ledger was silently skipped");
-  (match A.record ~base_path (candidate ~keeper_name ()) with
+  (match A.record ~base_path conflicting with
    | A.Record_error _ -> ()
-   | A.Recorded _ | A.Duplicate _ -> Alcotest.fail "malformed ledger was overwritten");
-  let ic = open_in_bin path in
-  let preserved = really_input_string ic (in_channel_length ic) in
-  close_in ic;
-  Alcotest.(check string) "malformed bytes preserved" malformed preserved
+   | A.Recorded _ | A.Duplicate _ -> Alcotest.fail "identity conflict was accepted");
+  Alcotest.(check bool) "conflict preserved original" true (load_one ~base_path = original)
 ;;
 
-let test_strict_judgment_contract_rejects_extra_fields () =
-  let invalid =
-    `Assoc
-      [ "decision", `String "relevant"
-      ; "rationale", `String "because"
-      ; "score", `Int 100
-      ]
+let test_record_requests_worker_without_invoking_judgment () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  with_temp_base "board-attention-candidate-wake" @@ fun base_path ->
+  let registration =
+    ok "register worker" (Wake.register ~sw ~base_path ~keeper_name:"sangsu")
   in
-  match J.of_yojson invalid with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "structured judgment accepted an undeclared score"
-;;
-
-let count_ledger_lines base_path =
-  let dir =
-    Filename.concat
-      (Filename.concat base_path ".masc")
-      "board_attention_candidates"
+  let original = candidate (signal "post-wake") in
+  let accepted =
+    Domain.spawn (fun () -> A.record_and_wake ~base_path original)
+    |> Domain.join
+    |> ok "record and wake"
   in
-  Sys.readdir dir
-  |> Array.to_list
-  |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
-  |> List.fold_left
-       (fun total name ->
-         let channel = open_in (Filename.concat dir name) in
-         Fun.protect
-           ~finally:(fun () -> close_in channel)
-           (fun () ->
-             let rec loop count =
-               match input_line channel with
-               | (_ : string) -> loop (count + 1)
-               | exception End_of_file -> count
-             in
-             total + loop 0))
-       0
+  (match accepted with
+   | { A.persistence = A.Candidate_recorded
+     ; wake = A.Judgment_worker_requested Wake.Signaled
+     ; candidate = persisted
+     } ->
+     (match persisted.status with
+      | A.Pending { last_failure = None } -> ()
+      | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
+        Alcotest.fail "producer performed judgment work")
+   | _ -> Alcotest.fail "candidate returned the wrong worker-wake acceptance");
+  match Wake.await registration with
+  | Wake.Wake -> ()
+  | Wake.Registration_closed -> Alcotest.fail "worker registration closed"
 ;;
 
-let test_update_ledger_compacts_to_distinct () =
-  with_temp_base "keeper-board-attention-compaction" @@ fun base_path ->
-  let pending = record_or_fail ~base_path (candidate ()) in
-  let keeper_name = pending.keeper_name in
-  (* Record several retryable failures against the same candidate id. Each is a
-     committed update; before compaction the ledger grew by one row per update
-     (and each update re-parsed the whole ledger, so writes were O(n^2)). *)
-  let transitions = 6 in
+let test_not_relevant_delivery_is_idempotent () =
+  with_temp_base "board-attention-candidate-not-relevant" @@ fun base_path ->
+  let persisted = record ~base_path (candidate (signal "post-not-relevant")) in
+  let verdict = judgment J.Not_relevant in
   ignore
-    (List.fold_left
-       (fun current index ->
-         let failure : A.retryable_failure =
-           { kind = A.Provider_unavailable
-           ; detail = Printf.sprintf "provider unavailable %d" index
-           ; failed_at = 102.0 +. float_of_int index
-           }
-         in
-         match A.record_retryable_failure ~base_path current failure with
-         | Ok candidate -> candidate
-         | Error detail -> Alcotest.failf "failure %d not recorded: %s" index detail)
-       pending
-       (List.init transitions Fun.id)
-     : A.candidate);
-  Alcotest.(check int)
-    "ledger holds one row per distinct candidate_id"
-    1
-    (count_ledger_lines base_path);
-  match A.load_candidates ~base_path ~keeper_name with
-  | Ok [ latest ] ->
-    (match latest.status with
-     | A.Pending { last_failure = Some observed } ->
-       Alcotest.(check string)
-         "latest failure wins after compaction"
-         "provider unavailable 5"
-         observed.detail
-     | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
-       Alcotest.fail "compaction dropped the latest pending failure")
-  | Ok candidates ->
-    Alcotest.failf "expected one compacted candidate, got %d" (List.length candidates)
-  | Error detail -> Alcotest.failf "load after compaction failed: %s" detail
-;;
-
-(* --- read-side stat memo (#25003) -------------------------------------
-   The memo key is (dev, ino, mtime, size). Production writes always go
-   through atomic temp+rename (new inode), so the only way to observe a
-   cache HIT deterministically is to mutate the file while preserving all
-   four key fields: an in-place same-length byte flip plus [Unix.utimes]
-   restore. A stale (pre-flip) result then proves the parse was skipped;
-   bumping mtime afterwards proves invalidation. *)
-
-let loaded_ids ~base_path ~keeper_name =
-  match A.load_candidates ~base_path ~keeper_name with
-  | Ok candidates -> List.map (fun (c : A.candidate) -> c.candidate_id) candidates
-  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
-;;
-
-(* µs-aligned so the utimes(float µs) -> stat(float ns) round trip is exact
-   and the memo key compares equal across the in-place mutation. *)
-let fixed_mtime = 1700000000.5
-let bumped_mtime = 1700000001.5
-
-let index_of_substring haystack needle =
-  let hay_len = String.length haystack
-  and needle_len = String.length needle in
-  let rec loop i =
-    if i + needle_len > hay_len
-    then None
-    else if String.equal (String.sub haystack i needle_len) needle
-    then Some i
-    else loop (i + 1)
+    (ok "record judgment" (A.record_judgment ~base_path persisted verdict)
+      : A.candidate);
+  (match
+     A.record_judgment
+       ~base_path
+       persisted
+       (judgment J.Relevant)
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "conflicting durable judgment was accepted");
+  let consumed =
+    ok
+      "apply judgment"
+      (A.apply_judgment_and_deliver
+         ~base_path
+         ~keeper_name:persisted.keeper_name
+         ~candidate_id:persisted.candidate_id
+         ~judgment:verdict)
   in
-  loop 0
-;;
-
-let rec find_file_named ~name path =
-  if Sys.file_exists path
-  then
-    if Sys.is_directory path
-    then
-      Array.fold_left
-        (fun found entry ->
-           match found with
-           | Some _ -> found
-           | None -> find_file_named ~name (Filename.concat path entry))
-        None
-        (Sys.readdir path)
-    else if String.equal (Filename.basename path) name
-    then Some path
-    else None
-  else None
-;;
-
-let ledger_path_or_fail ~base_path ~keeper_name =
-  match find_file_named ~name:(keeper_name ^ ".jsonl") base_path with
-  | Some path -> path
-  | None -> Alcotest.failf "ledger file for %s not found under %s" keeper_name base_path
-;;
-
-let flip_candidate_id_in_place path =
-  let ic = open_in_bin path in
-  let len = in_channel_length ic in
-  let content = really_input_string ic len in
-  close_in ic;
-  let marker = {|"candidate_id":"|} in
-  let start =
-    match index_of_substring content marker with
-    | Some index -> index + String.length marker
-    | None -> Alcotest.fail "candidate_id marker not found in ledger"
+  (match consumed.status with
+   | A.Consumed { delivery = A.Not_relevant; _ } -> ()
+   | A.Pending _ | A.Judged _ | A.Consumed _ ->
+     Alcotest.fail "not-relevant judgment did not reach Consumed");
+  let replayed =
+    ok
+      "replay judgment"
+      (A.apply_judgment_and_deliver
+         ~base_path
+         ~keeper_name:persisted.keeper_name
+         ~candidate_id:persisted.candidate_id
+         ~judgment:verdict)
   in
-  let original = content.[start] in
-  let flipped = if Char.equal original 'f' then '0' else 'f' in
-  let mutated =
-    String.mapi (fun i c -> if i = start then flipped else c) content
-  in
-  Alcotest.(check int) "in-place mutation keeps length" len (String.length mutated);
-  let fd = Unix.openfile path [ Unix.O_WRONLY ] 0o600 in
-  Fun.protect
-    ~finally:(fun () -> Unix.close fd)
-    (fun () ->
-      let written = Unix.write_substring fd mutated 0 len in
-      Alcotest.(check int) "in-place write is complete" len written)
-;;
-
-let test_load_memo_skips_reparse_when_stat_key_unchanged () =
-  with_temp_base "attention-read-memo-hit" (fun base_path ->
-    let keeper_name = "sangsu" in
-    let recorded = record_or_fail ~base_path (candidate ()) in
-    let path = ledger_path_or_fail ~base_path ~keeper_name in
-    Unix.utimes path fixed_mtime fixed_mtime;
-    (match loaded_ids ~base_path ~keeper_name with
-     | [ id ] ->
-       Alcotest.(check string) "first load parses the ledger" recorded.candidate_id id
-     | ids -> Alcotest.failf "expected one candidate, got %d" (List.length ids));
-    flip_candidate_id_in_place path;
-    Unix.utimes path fixed_mtime fixed_mtime;
-    (match loaded_ids ~base_path ~keeper_name with
-     | [ id ] ->
-       Alcotest.(check string)
-         "unchanged stat key serves the memoized parse"
-         recorded.candidate_id
-         id
-     | ids -> Alcotest.failf "expected one candidate, got %d" (List.length ids));
-    Unix.utimes path bumped_mtime bumped_mtime;
-    (* Invalidation proof: a re-read parses the mutated bytes, and the flipped
-       candidate_id no longer matches the content-identity digest, so the
-       loader must surface the integrity error. A stale cache hit would keep
-       returning [Ok] with the original id instead. *)
-    match A.load_candidates ~base_path ~keeper_name with
-    | Ok _ -> Alcotest.fail "mtime bump did not invalidate the memo (stale Ok served)"
-    | Error detail ->
-      (match index_of_substring detail "does not match" with
-       | Some _ -> ()
-       | None -> Alcotest.failf "unexpected load error after invalidation: %s" detail))
-;;
-
-let test_load_memo_invalidated_by_atomic_rewrite () =
-  with_temp_base "attention-read-memo-rewrite" (fun base_path ->
-    let keeper_name = "sangsu" in
-    let first = record_or_fail ~base_path (candidate ()) in
-    (match loaded_ids ~base_path ~keeper_name with
-     | [ id ] -> Alcotest.(check string) "first load" first.candidate_id id
-     | ids -> Alcotest.failf "expected one candidate, got %d" (List.length ids));
-    let second =
-      record_or_fail ~base_path (candidate ~signal:(signal ~post_id:"post-2" ()) ())
-    in
-    let ids = loaded_ids ~base_path ~keeper_name in
-    Alcotest.(check int) "rename-rewrite is observed" 2 (List.length ids);
-    if not (List.exists (String.equal second.candidate_id) ids)
-    then Alcotest.fail "second candidate missing after atomic rewrite")
-;;
-
-let all_not_relevant candidates =
-  Ok
-    (List.fold_left
-       (fun map (candidate : A.candidate) ->
-          A.Candidate_map.add candidate.candidate_id (judgment J.Not_relevant) map)
-       A.Candidate_map.empty
-       candidates)
-;;
-
-let test_pending_has_no_wall_clock_expiry () =
-  with_temp_base "board-attention-no-expiry" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  let _ = record_or_fail ~base_path (candidate ~keeper_name ()) in
-  let report =
-    match
-      A.For_testing.drain_pending_with_judge_batch
-        ~base_path
-        ~keeper_name
-        ~judge_batch:all_not_relevant
-    with
-    | Ok report -> report
-    | Error detail -> Alcotest.failf "pending drain failed: %s" detail
-  in
-  Alcotest.(check int) "pending row attempted" 1 report.attempted;
-  Alcotest.(check int) "pending row consumed" 1 report.consumed;
-  Alcotest.(check int) "nothing remains" 0 report.remaining;
-  match (only_loaded ~base_path ~keeper_name).status with
-  | A.Consumed { delivery = A.Not_relevant; _ } -> ()
-  | A.Consumed _ | A.Pending _ | A.Judged _ ->
-    Alcotest.fail "durable pending candidate did not reach judgment"
-;;
-
-let test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence () =
-  with_temp_base "board-attention-partial" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  let first = record_or_fail ~base_path (candidate ~keeper_name ()) in
-  let second =
-    record_or_fail
+  Alcotest.(check bool) "terminal replay is idempotent" true (replayed = consumed);
+  match
+    A.apply_judgment_and_deliver
       ~base_path
-      (candidate ~keeper_name ~signal:(signal ~post_id:"post-2" ()) ())
-  in
-  let report =
-    match
-      A.For_testing.drain_pending_with_judge_batch
-        ~base_path
-        ~keeper_name
-        ~judge_batch:(fun _ ->
-          Ok
-            (A.Candidate_map.add
-               first.candidate_id
-               (judgment J.Not_relevant)
-               A.Candidate_map.empty))
-    with
-    | Ok report -> report
-    | Error detail -> Alcotest.failf "partial drain failed: %s" detail
-  in
-  Alcotest.(check int) "both attempted" 2 report.attempted;
-  Alcotest.(check int) "partial response consumes nothing" 0 report.consumed;
-  Alcotest.(check int) "whole batch remains" 2 report.remaining;
-  match A.load_candidates ~base_path ~keeper_name with
-  | Ok candidates ->
-    List.iter
-      (fun (target : A.candidate) ->
-         match
-           List.find_opt
-             (fun (c : A.candidate) -> String.equal c.candidate_id target.candidate_id)
-             candidates
-         with
-         | Some
-             { status =
-                 A.Pending
-                   { last_failure =
-                       Some { kind = A.Response_contract_unavailable; _ }
-                   }
-             ; _
-             } ->
-           ()
-         | Some _ -> Alcotest.fail "partial response lacked contract-failure evidence"
-         | None -> Alcotest.fail "partial-response candidate vanished")
-      [ first; second ]
-  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
-;;
-
-let test_batch_failure_aborts_round_and_records_evidence () =
-  with_temp_base "board-attention-abort" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  let recorded =
-    List.map
-      (fun index ->
-         let post_id = Printf.sprintf "post-%d" index in
-         record_or_fail
-           ~base_path
-           (candidate ~keeper_name ~signal:(signal ~post_id ()) ()))
-      (List.init (A.batch_max_candidates + 1) (fun index -> index + 1))
-  in
-  let failure : A.retryable_failure =
-    { kind = A.Provider_unavailable; detail = "429 too many concurrent"; failed_at = 100.0 }
-  in
-  let report =
-    match
-      A.For_testing.drain_pending_with_judge_batch
-        ~base_path
-        ~keeper_name
-        ~judge_batch:(fun _ -> Error failure)
-    with
-    | Ok report -> report
-    | Error detail -> Alcotest.failf "abort drain failed: %s" detail
-  in
-  Alcotest.(check int)
-    "only the first batch was attempted"
-    A.batch_max_candidates
-    report.attempted;
-  Alcotest.(check int) "nothing consumed" 0 report.consumed;
-  Alcotest.(check int)
-    "failed batch and deferred batch remain"
-    (A.batch_max_candidates + 1)
-    report.remaining;
-  match A.load_candidates ~base_path ~keeper_name with
-  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
-  | Ok candidates ->
-    let by_id (target : A.candidate) =
-      List.find_opt
-        (fun (c : A.candidate) -> String.equal c.candidate_id target.candidate_id)
-        candidates
-    in
-    let attempted = List.filteri (fun index _ -> index < A.batch_max_candidates) recorded in
-    let deferred = List.nth recorded A.batch_max_candidates in
-    List.iter
-      (fun (target : A.candidate) ->
-         match by_id target with
-         | Some { status = A.Pending { last_failure = Some observed }; _ } ->
-           Alcotest.(check string)
-             "attempted candidate keeps the failure evidence"
-             "429 too many concurrent"
-             observed.detail
-         | Some _ -> Alcotest.fail "attempted candidate lost the failure evidence"
-         | None -> Alcotest.fail "attempted candidate vanished")
-      attempted;
-    (match by_id deferred with
-     | Some { status = A.Pending { last_failure = None }; _ } -> ()
-     | Some _ -> Alcotest.fail "deferred batch gained failure evidence"
-     | None -> Alcotest.fail "deferred candidate vanished")
-;;
-
-let test_batch_failure_evidence_write_error_propagates () =
-  with_temp_base "board-attention-failure-write" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  List.iter
-    (fun post_id ->
-       ignore
-         (record_or_fail
-            ~base_path
-            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())
-          : A.candidate))
-    [ "post-1"; "post-2" ];
-  let path = ledger_path_or_fail ~base_path ~keeper_name in
-  let backup = path ^ ".before-failure-evidence" in
-  let failure : A.retryable_failure =
-    { kind = A.Provider_unavailable
-    ; detail = "provider unavailable"
-    ; failed_at = 100.0
-    }
-  in
-  let result =
-    Fun.protect
-      ~finally:(fun () ->
-        if Sys.file_exists path && Sys.is_directory path then Unix.rmdir path;
-        if Sys.file_exists backup then Sys.rename backup path)
-      (fun () ->
-         A.For_testing.drain_pending_with_judge_batch
-           ~base_path
-           ~keeper_name
-           ~judge_batch:(fun _ ->
-             Sys.rename path backup;
-             Unix.mkdir path 0o700;
-             Error failure))
-  in
-  (match result with
-   | Error _ -> ()
-   | Ok _ -> Alcotest.fail "failure-evidence storage error was silently accepted");
-  match A.load_candidates ~base_path ~keeper_name with
-  | Error detail -> Alcotest.failf "candidate reload failed: %s" detail
-  | Ok candidates ->
-    Alcotest.(check int) "both candidates retained" 2 (List.length candidates);
-    List.iter
-      (fun (candidate : A.candidate) ->
-         match candidate.status with
-         | A.Pending { last_failure = None } -> ()
-         | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
-           Alcotest.fail "failed atomic evidence commit changed part of the batch")
-      candidates
-;;
-
-let test_atomic_judgment_commit_failure_preserves_all_pending () =
-  with_temp_base "board-attention-atomic-judgment-failure" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  List.iter
-    (fun post_id ->
-       ignore
-         (record_or_fail
-            ~base_path
-            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())
-          : A.candidate))
-    [ "post-1"; "post-2" ];
-  let path = ledger_path_or_fail ~base_path ~keeper_name in
-  let backup = path ^ ".before-atomic-commit" in
-  let result =
-    Fun.protect
-      ~finally:(fun () ->
-        if Sys.file_exists path && Sys.is_directory path then Unix.rmdir path;
-        if Sys.file_exists backup then Sys.rename backup path)
-      (fun () ->
-         A.For_testing.drain_pending_with_judge_batch
-           ~base_path
-           ~keeper_name
-           ~judge_batch:(fun candidates ->
-             Sys.rename path backup;
-             Unix.mkdir path 0o700;
-             all_not_relevant candidates))
-  in
-  (match result with
-   | Error _ -> ()
-   | Ok _ -> Alcotest.fail "atomic judgment storage failure was accepted");
-  match A.load_candidates ~base_path ~keeper_name with
-  | Error detail -> Alcotest.failf "candidate reload failed: %s" detail
-  | Ok candidates ->
-    Alcotest.(check int) "both candidates retained" 2 (List.length candidates);
-    List.iter
-      (fun (candidate : A.candidate) ->
-         match candidate.status with
-         | A.Pending { last_failure = None } -> ()
-         | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
-           Alcotest.fail "failed atomic commit changed part of the batch")
-      candidates
-;;
-
-let test_removed_expired_status_is_rejected () =
-  let fixture = A.candidate_to_json (candidate ()) in
-  let legacy =
-    match fixture with
-    | `Assoc fields ->
-      `Assoc
-        (List.map
-           (fun (key, value) ->
-              if String.equal key "status"
-              then
-                ( key
-                , `Assoc
-                    [ "kind", `String "expired"
-                    ; "expired_at", `Float 123.5
-                    ] )
-              else key, value)
-           fields)
-    | _ -> Alcotest.fail "candidate fixture must encode as an object"
-  in
-  match A.candidate_of_json legacy with
+      ~keeper_name:persisted.keeper_name
+      ~candidate_id:persisted.candidate_id
+      ~judgment:(judgment J.Relevant)
+  with
   | Error _ -> ()
-  | Ok _ -> Alcotest.fail "removed expired status was accepted"
+  | Ok _ -> Alcotest.fail "conflicting terminal judgment was accepted"
 ;;
 
-let test_batch_verdict_codec_roundtrip () =
-  let items : J.batch_item list =
-    [ { candidate_id = "c-1"; verdict = { decision = J.Relevant; rationale = "first" } }
-    ; { candidate_id = "c-2"; verdict = { decision = J.Not_relevant; rationale = "second" } }
-    ]
+let test_relevant_delivery_uses_exact_candidate_identity () =
+  with_temp_base "board-attention-candidate-relevant" @@ fun base_path ->
+  let persisted = record ~base_path (candidate (signal "post-relevant")) in
+  let consumed =
+    ok
+      "apply relevant judgment"
+      (A.apply_judgment_and_deliver
+         ~base_path
+         ~keeper_name:persisted.keeper_name
+         ~candidate_id:persisted.candidate_id
+         ~judgment:(judgment J.Relevant))
   in
-  match J.batch_of_yojson (J.batch_to_yojson items) with
-  | Ok [ first; second ] ->
-    Alcotest.(check string) "first id" "c-1" first.candidate_id;
-    Alcotest.(check string) "second id" "c-2" second.candidate_id;
-    (match first.verdict.decision with
-     | J.Relevant -> ()
-     | J.Not_relevant -> Alcotest.fail "first decision flipped")
-  | Ok _ -> Alcotest.fail "batch codec changed the item count"
-  | Error detail -> Alcotest.failf "batch codec failed: %s" detail
-;;
-
-let test_batch_verdict_codec_rejects_contract_violations () =
-  let expect_error label json =
-    match J.batch_of_yojson json with
-    | Error _ -> ()
-    | Ok _ -> Alcotest.failf "%s was accepted" label
-  in
-  expect_error
-    "missing verdicts field"
-    (`Assoc [ "items", `List [] ]);
-  expect_error
-    "unknown decision"
-    (`Assoc
-       [ ( "verdicts"
-         , `List
-             [ `Assoc
-                 [ "candidate_id", `String "c-1"
-                 ; "decision", `String "maybe"
-                 ; "rationale", `String "r"
-                 ]
-             ] )
-       ]);
-  expect_error
-    "empty rationale"
-    (`Assoc
-       [ ( "verdicts"
-         , `List
-             [ `Assoc
-                 [ "candidate_id", `String "c-1"
-                 ; "decision", `String "relevant"
-                 ; "rationale", `String "  "
-                 ]
-             ] )
-       ])
+  (match consumed.status with
+   | A.Consumed { delivery = A.Enqueued_to_keeper_lane; _ } -> ()
+   | A.Pending _ | A.Judged _ | A.Consumed _ ->
+     Alcotest.fail "relevant judgment consumed without durable enqueue");
+  match
+    Keeper_event_queue_persistence.load
+      ~base_path
+      ~keeper_name:persisted.keeper_name
+    |> Keeper_event_queue.to_list
+  with
+  | [ { payload = Keeper_event_queue.Board_attention attention; _ } ] ->
+    Alcotest.(check string)
+      "exact candidate delivery identity"
+      persisted.candidate_id
+      attention.candidate_id
+  | _ -> Alcotest.fail "relevant judgment did not enqueue one Board_attention event"
 ;;
 
 let () =
   Alcotest.run
     "keeper_board_attention_candidate"
-    [ ( "durable judgment"
+    [ ( "durable candidate"
       , [ Alcotest.test_case
-            "roundtrip preserves full evidence and Pending"
+            "codec and context identity are strict"
             `Quick
-            test_roundtrip_preserves_full_evidence_and_pending_state
+            test_codec_and_context_identity_are_strict
         ; Alcotest.test_case
-            "context identity is exact and object-order independent"
+            "record dedupes exact identity"
             `Quick
-            test_context_key_is_exact_and_object_order_independent
+            test_record_dedupes_exact_identity_and_rejects_conflict
         ; Alcotest.test_case
-            "context identity rejects ambiguous authority"
+            "record requests worker without judgment"
             `Quick
-            test_context_key_rejects_ambiguous_authority
+            test_record_requests_worker_without_invoking_judgment
         ; Alcotest.test_case
-            "record dedupes exact candidate identity"
+            "not relevant delivery is idempotent"
             `Quick
-            test_record_dedupes_exact_candidate_identity
+            test_not_relevant_delivery_is_idempotent
         ; Alcotest.test_case
-            "worker record wakes and owner lane drains"
+            "relevant delivery uses exact identity"
             `Quick
-            test_worker_record_wakes_then_owner_lane_drains
-        ; Alcotest.test_case
-            "retryable judge failure remains Pending"
-            `Quick
-            test_retryable_judge_failure_remains_pending
-        ; Alcotest.test_case
-            "not relevant transitions directly to Consumed"
-            `Quick
-            test_not_relevant_transitions_directly_to_consumed
-        ; Alcotest.test_case
-            "relevant consumes only after exact durable enqueue"
-            `Quick
-            test_relevant_consumes_only_after_exact_durable_enqueue
-        ; Alcotest.test_case
-            "delivery storage error retains Judged"
-            `Quick
-            test_delivery_storage_error_retains_judged_state
-        ; Alcotest.test_case
-            "malformed ledger is explicit and preserved"
-            `Quick
-            test_malformed_ledger_is_explicit_and_not_overwritten
-        ; Alcotest.test_case
-            "strict judgment rejects undeclared score"
-            `Quick
-            test_strict_judgment_contract_rejects_extra_fields
-        ; Alcotest.test_case
-            "update ledger compacts to distinct candidate count"
-            `Quick
-            test_update_ledger_compacts_to_distinct
-        ] )
-    ; ( "read memo"
-      , [ Alcotest.test_case
-            "unchanged stat key skips reparse"
-            `Quick
-            test_load_memo_skips_reparse_when_stat_key_unchanged
-        ; Alcotest.test_case
-            "atomic rewrite invalidates memo"
-            `Quick
-            test_load_memo_invalidated_by_atomic_rewrite
-        ] )
-    ; ( "batch drain"
-      , [ Alcotest.test_case
-            "pending work has no wall-clock expiry"
-            `Quick
-            test_pending_has_no_wall_clock_expiry
-        ; Alcotest.test_case
-            "missing verdict fails whole batch with evidence"
-            `Quick
-            test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence
-        ; Alcotest.test_case
-            "batch failure aborts round with evidence"
-            `Quick
-            test_batch_failure_aborts_round_and_records_evidence
-        ; Alcotest.test_case
-            "batch failure evidence write error propagates"
-            `Quick
-            test_batch_failure_evidence_write_error_propagates
-        ; Alcotest.test_case
-            "atomic judgment failure preserves all pending"
-            `Quick
-            test_atomic_judgment_commit_failure_preserves_all_pending
-        ; Alcotest.test_case
-            "removed expired status is rejected"
-            `Quick
-            test_removed_expired_status_is_rejected
-        ; Alcotest.test_case
-            "batch verdict codec roundtrip"
-            `Quick
-            test_batch_verdict_codec_roundtrip
-        ; Alcotest.test_case
-            "batch verdict codec rejects violations"
-            `Quick
-            test_batch_verdict_codec_rejects_contract_violations
+            test_relevant_delivery_uses_exact_candidate_identity
         ] )
     ]
 ;;

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -1,0 +1,311 @@
+module A = Masc.Keeper_board_attention_candidate
+module J = Masc.Keeper_board_attention_judgment
+module P = Masc.Keeper_board_attention_partition
+module W = Masc.Keeper_board_attention_worker
+module Wake = Masc.Keeper_board_attention_worker_wake
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_base name f =
+  let base_path = Filename.temp_dir name "" in
+  Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
+;;
+
+let ok label = function
+  | Ok value -> value
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
+let expect_error label = function
+  | Error _ -> ()
+  | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
+;;
+
+let candidate ?(id = "candidate-worker") () : A.candidate =
+  let keeper_name = "sangsu" in
+  let signal : Masc.Board_dispatch.board_signal =
+    { kind = Masc.Board_dispatch.Board_post_created
+    ; post_id = id
+    ; author = "external-author"
+    ; title = "Board update"
+    ; content = "Persisted Board evidence"
+    ; hearth = Some "hearth-1"
+    ; updated_at = Some 42.0
+    }
+  in
+  let candidate_id =
+    `Assoc
+      [ "keeper_name", `String keeper_name
+      ; "signal", A.signal_to_yojson signal
+      ]
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  { candidate_id
+  ; keeper_name
+  ; signal
+  ; judgment_request =
+      `Assoc
+        [ ( "keeper_context"
+          , `Assoc
+              [ "instructions", `String "continue"
+              ; "runtime", `Assoc [ "model", `String "configured-judge" ]
+              ] )
+        ]
+  ; recorded_at = 1.0
+  ; status = A.Pending { last_failure = None }
+  }
+;;
+
+let judgment decision : A.judgment =
+  { verdict = { J.decision; rationale = "typed structured verdict" }
+  ; runtime_id = "configured-structured-judge"
+  ; judged_at = 2.0
+  }
+;;
+
+let record ~base_path candidate =
+  match A.record ~base_path candidate with
+  | A.Recorded candidate -> candidate
+  | A.Duplicate _ -> Alcotest.fail "first record was a duplicate"
+  | A.Record_error detail -> Alcotest.failf "candidate record failed: %s" detail
+;;
+
+let load_one_candidate ~base_path =
+  match ok "load candidate" (A.load_candidates ~base_path ~keeper_name:"sangsu") with
+  | [ candidate ] -> candidate
+  | candidates -> Alcotest.failf "expected one candidate, got %d" (List.length candidates)
+;;
+
+let process_at ~now ~base_path ~judge =
+  W.For_testing.process_next
+    ~now
+    ~worker_epoch:(P.Worker_epoch.generate ())
+    ~base_path
+    ~keeper_name:"sangsu"
+    ~judge
+;;
+
+let process ~base_path ~judge =
+  process_at ~now:(fun () -> 3.0) ~base_path ~judge
+;;
+
+let test_provider_result_waits_for_owner_settlement () =
+  with_temp_base "board-attention-worker-boundary" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  let calls = ref 0 in
+  let observed_time = ref 3.0 in
+  (match
+     ok
+       "worker step"
+       (process_at ~base_path ~now:(fun () -> !observed_time) ~judge:(fun _ ->
+          incr calls;
+          observed_time := 9.0;
+          Ok (judgment J.Not_relevant)))
+   with
+   | W.Judgment_completed { candidate_id; _ }
+     when String.equal candidate_id persisted.candidate_id -> ()
+   | W.Judgment_completed _
+   | W.Idle
+   | W.Judgment_deferred _
+   | W.Candidate_already_consumed _
+   | W.Partition_blocked _ ->
+     Alcotest.fail "worker did not durably complete the exact judgment");
+  Alcotest.(check int) "one Provider judgment" 1 !calls;
+  (match (load_one_candidate ~base_path).status with
+   | A.Pending { last_failure = None } -> ()
+   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
+     Alcotest.fail "background worker mutated the candidate ledger");
+  (match ok "load completed partition" (P.completed ~base_path ~keeper_name:"sangsu") with
+   | [ { state = P.Completed { completed_at; _ }; _ } ] ->
+     Alcotest.(check (float 0.0))
+       "completion time is observed after Provider return"
+       9.0
+       completed_at
+   | _ -> Alcotest.fail "worker result was not Completed");
+  (match ok "owner settlement" (W.settle_one_completed ~base_path ~keeper_name:"sangsu") with
+   | W.Partition_settled { candidate_id; _ }
+     when String.equal candidate_id persisted.candidate_id -> ()
+   | W.Partition_settled _ -> Alcotest.fail "a different candidate was settled"
+   | W.No_completed_partition -> Alcotest.fail "completed judgment was not settled");
+  (match (load_one_candidate ~base_path).status with
+   | A.Consumed { delivery = A.Not_relevant; _ } -> ()
+   | A.Pending _ | A.Judged _ | A.Consumed _ ->
+     Alcotest.fail "owner settlement did not consume the exact judgment");
+  match ok "load partitions" (P.load ~base_path ~keeper_name:"sangsu") with
+  | [ { state = P.Settled _; _ } ] -> ()
+  | _ -> Alcotest.fail "owner settlement did not settle the partition"
+;;
+
+let test_provider_failure_is_durable_without_hot_retry () =
+  with_temp_base "board-attention-worker-deferred" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  let calls = ref 0 in
+  let failure : A.retryable_failure =
+    { kind = A.Provider_unavailable; detail = "typed provider failure"; failed_at = 3.0 }
+  in
+  (match
+     ok
+       "defer worker step"
+       (process ~base_path ~judge:(fun _ ->
+          incr calls;
+          Error failure))
+   with
+   | W.Judgment_deferred { candidate_id; failure = observed }
+     when String.equal candidate_id persisted.candidate_id && observed = failure -> ()
+   | _ -> Alcotest.fail "Provider failure was not durably deferred");
+  (match ok "no ordinary retry" (process ~base_path ~judge:(fun _ ->
+     incr calls;
+     Ok (judgment J.Not_relevant))) with
+   | W.Idle -> ()
+   | _ -> Alcotest.fail "Deferred partition was claimed without a retry authority");
+  Alcotest.(check int) "deferred work was not hot-looped" 1 !calls;
+  (match (load_one_candidate ~base_path).status with
+   | A.Pending { last_failure = None } -> ()
+   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
+     Alcotest.fail "partition failure leaked into the candidate SSOT")
+;;
+
+let test_existing_judgment_never_calls_provider () =
+  with_temp_base "board-attention-worker-existing-judgment" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  ignore
+    (ok
+       "record prior judgment"
+       (A.record_judgment ~base_path persisted (judgment J.Relevant))
+     : A.candidate);
+  match
+    ok
+      "worker step"
+      (process ~base_path ~judge:(fun _ -> Alcotest.fail "Provider was called"))
+  with
+  | W.Judgment_completed { candidate_id; _ }
+    when String.equal candidate_id persisted.candidate_id -> ()
+  | _ -> Alcotest.fail "prior judgment was not projected into a completed partition"
+;;
+
+let test_step_exception_releases_exact_claim () =
+  with_temp_base "board-attention-worker-claim-recovery" @@ fun base_path ->
+  ignore (record ~base_path (candidate ()) : A.candidate);
+  expect_error
+    "raised judge step"
+    (process ~base_path ~judge:(fun _ -> raise (Failure "injected judge crash")));
+  match ok "load recovered partition" (P.load ~base_path ~keeper_name:"sangsu") with
+  | [ { state = P.Ready; _ } ] -> ()
+  | _ -> Alcotest.fail "raised worker step stranded a Running claim"
+;;
+
+let test_step_cancellation_releases_exact_claim () =
+  Eio_main.run @@ fun _env ->
+  with_temp_base "board-attention-worker-cancel-recovery" @@ fun base_path ->
+  ignore (record ~base_path (candidate ()) : A.candidate);
+  let judge_entered, publish_judge_entered = Eio.Promise.create () in
+  let never, _resolve_never = Eio.Promise.create () in
+  Eio.Fiber.first
+    (fun () ->
+       ignore
+         (process ~base_path ~judge:(fun _ ->
+            Eio.Promise.resolve publish_judge_entered ();
+            Eio.Promise.await never)
+          : (W.step, string) result))
+    (fun () -> Eio.Promise.await judge_entered);
+  match ok "load cancellation-recovered partition" (P.load ~base_path ~keeper_name:"sangsu") with
+  | [ { state = P.Ready; _ } ] -> ()
+  | _ -> Alcotest.fail "cancelled worker step stranded a Running claim"
+;;
+
+let test_conflicting_owner_judgment_preserves_completed_partition () =
+  with_temp_base "board-attention-worker-conflict" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  ignore
+    (ok
+       "worker completion"
+       (process ~base_path ~judge:(fun _ -> Ok (judgment J.Relevant)))
+     : W.step);
+  ignore
+    (ok
+       "conflicting candidate judgment"
+       (A.record_judgment ~base_path persisted (judgment J.Not_relevant))
+     : A.candidate);
+  expect_error
+    "owner judgment conflict"
+    (W.settle_one_completed ~base_path ~keeper_name:"sangsu");
+  match ok "load preserved completion" (P.completed ~base_path ~keeper_name:"sangsu") with
+  | [ _ ] -> ()
+  | _ -> Alcotest.fail "conflicting owner settlement discarded the completed result"
+;;
+
+let test_cross_domain_wake_is_coalesced_and_rearmed () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  with_temp_base "board-attention-worker-wake" @@ fun base_path ->
+  (match ok "unregistered request" (Wake.request ~base_path ~keeper_name:"sangsu") with
+   | Wake.Not_registered -> ()
+   | Wake.Signaled | Wake.Coalesced -> Alcotest.fail "unregistered wake was accepted");
+  let registration =
+    ok "register worker wake" (Wake.register ~sw ~base_path ~keeper_name:"sangsu")
+  in
+  let first =
+    Domain.spawn (fun () -> Wake.request ~base_path ~keeper_name:"sangsu")
+    |> Domain.join
+    |> ok "cross-domain wake"
+  in
+  (match first with
+   | Wake.Signaled -> ()
+   | Wake.Coalesced | Wake.Not_registered -> Alcotest.fail "first wake was not signaled");
+  (match ok "coalesced wake" (Wake.request ~base_path ~keeper_name:"sangsu") with
+   | Wake.Coalesced -> ()
+   | Wake.Signaled | Wake.Not_registered -> Alcotest.fail "pending wake did not coalesce");
+  (match Wake.await registration with
+   | Wake.Wake -> ()
+   | Wake.Registration_closed -> Alcotest.fail "live registration closed");
+  match ok "rearmed wake" (Wake.request ~base_path ~keeper_name:"sangsu") with
+  | Wake.Signaled -> ()
+  | Wake.Coalesced | Wake.Not_registered -> Alcotest.fail "consumed wake did not rearm"
+;;
+
+let () =
+  Alcotest.run
+    "keeper_board_attention_worker"
+    [ ( "judgment plane"
+      , [ Alcotest.test_case
+            "Provider result waits for owner settlement"
+            `Quick
+            test_provider_result_waits_for_owner_settlement
+        ; Alcotest.test_case
+            "Provider failure is durable without hot retry"
+            `Quick
+            test_provider_failure_is_durable_without_hot_retry
+        ; Alcotest.test_case
+            "existing judgment skips Provider"
+            `Quick
+            test_existing_judgment_never_calls_provider
+        ; Alcotest.test_case
+            "step exception releases exact claim"
+            `Quick
+            test_step_exception_releases_exact_claim
+        ; Alcotest.test_case
+            "step cancellation releases exact claim"
+            `Quick
+            test_step_cancellation_releases_exact_claim
+        ; Alcotest.test_case
+            "conflicting owner judgment preserves completion"
+            `Quick
+            test_conflicting_owner_judgment_preserves_completed_partition
+        ; Alcotest.test_case
+            "cross-domain wake coalesces and rearms"
+            `Quick
+            test_cross_domain_wake_is_coalesced_and_rearmed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- run Board attention Provider judgment in one sibling Eio worker per Keeper lifecycle switch
- keep owner admission limited to one durable completed-result settlement
- use transition-driven process-local wake hints backed by the durable candidate/partition ledgers
- purge the fixed-size batch drain and its obsolete test surface
- reject conflicting judgment/consumption transitions explicitly

## Architecture
- Provider calls receive the exact Keeper lane switch and network capability
- cancellation releases the exact Running partition claim
- no timer polling, TTL, retry counter, batch cap, or inferred capacity authority
- Provider failures become durable Deferred partitions without a hot retry loop

## Focused verification
- scripts/dune-local.sh build for candidate, partition, worker, and registry-hardening targets
- candidate: 5/5
- partition: 5/5
- worker: 7/7
- registry hardening: 17/17
- ocamlformat --check
- git diff --check

Stacked on #25373.