### PR TITLE
fix(keeper): require typed attention retry authority

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -2,6 +2,7 @@
 
 module Board_signal = Keeper_world_observation_board_signal
 module Candidate_map = Map.Make (String)
+module Judgment_failure = Keeper_board_attention_failure
 
 type retryable_failure_kind =
   | Runtime_configuration_unavailable
@@ -1110,15 +1111,20 @@ let judge_singleton ~sw ~net ~base_path candidate =
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn ->
       Error
-        (failure
-           ~kind:Runtime_configuration_unavailable
-           (Printexc.to_string exn))
+        (Judgment_failure.runtime_configuration_change
+           ~failed_at:(Time_compat.now ())
+           ~detail:(Printexc.to_string exn))
   in
   match runtime_id_result with
   | Error _ as error -> error
   | Ok runtime_id ->
     (match build_singleton_prompt candidate with
-     | Error detail -> Error (failure ~kind:Prompt_contract_unavailable detail)
+     | Error detail ->
+       Error
+         (Judgment_failure.blocked
+            ~blocked_at:(Time_compat.now ())
+            ~kind:Judgment_failure.Prompt_contract_unavailable
+            ~detail)
      | Ok prompt ->
        let provider_result =
          try
@@ -1138,12 +1144,17 @@ let judge_singleton ~sw ~net ~base_path candidate =
            | Ok result -> Ok result
            | Error error ->
              Error
-               (failure
-                  ~kind:Provider_unavailable
-                  (Agent_sdk.Error.to_string error))
+               (Judgment_failure.of_sdk_error
+                  ~observed_at:(Time_compat.now ())
+                  error)
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn -> Error (failure ~kind:Provider_unavailable (Printexc.to_string exn))
+         | exn ->
+           Error
+             (Judgment_failure.blocked
+                ~blocked_at:(Time_compat.now ())
+                ~kind:Judgment_failure.Unexpected_judgment_exception
+                ~detail:(Printexc.to_string exn))
        in
        (match provider_result with
         | Error _ as error -> error
@@ -1153,11 +1164,20 @@ let judge_singleton ~sw ~net ~base_path candidate =
                ~schema_name:Keeper_board_attention_judgment.batch_schema_name
                result.response
            with
-           | Error detail -> Error (failure ~kind:Response_contract_unavailable detail)
+           | Error detail ->
+             Error
+               (Judgment_failure.blocked
+                  ~blocked_at:(Time_compat.now ())
+                  ~kind:Judgment_failure.Response_contract_unavailable
+                  ~detail)
            | Ok json ->
              (match Keeper_board_attention_judgment.batch_of_yojson json with
               | Error detail ->
-                Error (failure ~kind:Response_contract_unavailable detail)
+                Error
+                  (Judgment_failure.blocked
+                     ~blocked_at:(Time_compat.now ())
+                     ~kind:Judgment_failure.Response_contract_unavailable
+                     ~detail)
               | Ok [ item ] when String.equal item.candidate_id candidate.candidate_id ->
                 Ok
                   { verdict = item.verdict
@@ -1166,19 +1186,23 @@ let judge_singleton ~sw ~net ~base_path candidate =
                   }
               | Ok [ item ] ->
                 Error
-                  (failure
-                     ~kind:Response_contract_unavailable
-                     (Printf.sprintf
-                        "singleton verdict identity mismatch expected=%S actual=%S"
-                        candidate.candidate_id
-                        item.candidate_id))
+                  (Judgment_failure.blocked
+                     ~blocked_at:(Time_compat.now ())
+                     ~kind:Judgment_failure.Response_contract_unavailable
+                     ~detail:
+                       (Printf.sprintf
+                          "singleton verdict identity mismatch expected=%S actual=%S"
+                          candidate.candidate_id
+                          item.candidate_id))
               | Ok items ->
                 Error
-                  (failure
-                     ~kind:Response_contract_unavailable
-                     (Printf.sprintf
-                        "singleton verdict count must be exactly one, got %d"
-                        (List.length items)))))))
+                  (Judgment_failure.blocked
+                     ~blocked_at:(Time_compat.now ())
+                     ~kind:Judgment_failure.Response_contract_unavailable
+                     ~detail:
+                       (Printf.sprintf
+                          "singleton verdict count must be exactly one, got %d"
+                          (List.length items)))))))
 ;;
 
 let apply_judgment_and_deliver ~base_path ~keeper_name ~candidate_id ~judgment =

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -141,7 +141,7 @@ val judge_singleton :
   net:Eio_context.eio_net option ->
   base_path:string ->
   candidate ->
-  (judgment, retryable_failure) result
+  (judgment, Keeper_board_attention_failure.attempt_failure) result
 (** Invoke the configured structured judge for exactly one immutable
     candidate. The response must cover that exact candidate identity. This is
     Provider work and must never run under Keeper turn admission. *)

--- a/lib/keeper/keeper_board_attention_failure.ml
+++ b/lib/keeper/keeper_board_attention_failure.ml
@@ -1,0 +1,344 @@
+module Route = Keeper_runtime_failure_route
+
+type retry_requirement =
+  | Provider_retry_after of
+      { retry_class : Route.retry_class
+      ; delay_seconds : float
+      }
+  | Provider_recovery of Route.retry_class
+  | Runtime_catalog_change of Route.rotate_class
+  | Runtime_configuration_change
+
+type retryable =
+  { requirement : retry_requirement
+  ; detail : string
+  ; failed_at : float
+  }
+
+type blocked_kind =
+  | Prompt_contract_unavailable
+  | Response_contract_unavailable
+  | Provider_judgment_required of
+      { judgment : Route.judgment_class
+      ; provenance : Route.judgment_provenance
+      }
+  | Invalid_provider_retry_authority
+  | Unexpected_judgment_exception
+
+type blocked =
+  { kind : blocked_kind
+  ; detail : string
+  ; blocked_at : float
+  }
+
+type attempt_failure =
+  | Retryable of retryable
+  | Blocked of blocked
+
+let ( let* ) = Result.bind
+
+let nonempty label value =
+  if String.equal (String.trim value) ""
+  then Error (label ^ " must not be empty")
+  else Ok ()
+;;
+
+let finite_nonnegative label value =
+  if not (Float.is_finite value)
+  then Error (label ^ " must be finite")
+  else if Float.compare value 0.0 < 0
+  then Error (label ^ " must not be negative")
+  else Ok ()
+;;
+
+let finite_time label value =
+  if Float.is_finite value then Ok () else Error (label ^ " must be finite")
+;;
+
+let retry_deadline (failure : retryable) =
+  match failure.requirement with
+  | Provider_retry_after { delay_seconds; _ } ->
+    Some (failure.failed_at +. delay_seconds)
+  | Provider_recovery _
+  | Runtime_catalog_change _
+  | Runtime_configuration_change -> None
+;;
+
+let retry_requirement_label = function
+  | Provider_retry_after _ -> "provider_retry_after"
+  | Provider_recovery _ -> "provider_recovery"
+  | Runtime_catalog_change _ -> "runtime_catalog_change"
+  | Runtime_configuration_change -> "runtime_configuration_change"
+;;
+
+let blocked_kind_label = function
+  | Prompt_contract_unavailable -> "prompt_contract_unavailable"
+  | Response_contract_unavailable -> "response_contract_unavailable"
+  | Provider_judgment_required _ -> "provider_judgment_required"
+  | Invalid_provider_retry_authority -> "invalid_provider_retry_authority"
+  | Unexpected_judgment_exception -> "unexpected_judgment_exception"
+;;
+
+let validate_retryable (failure : retryable) =
+  let* () = nonempty "attention retry detail" failure.detail in
+  let* () = finite_time "attention retry failed_at" failure.failed_at in
+  match failure.requirement with
+  | Provider_retry_after { delay_seconds; _ } ->
+    let* () = finite_nonnegative "Provider retry-after" delay_seconds in
+    (match retry_deadline failure with
+     | Some deadline -> finite_time "Provider retry deadline" deadline
+     | None -> Error "Provider retry-after did not produce a deadline")
+  | Provider_recovery _
+  | Runtime_catalog_change _
+  | Runtime_configuration_change -> Ok ()
+;;
+
+let validate_blocked (failure : blocked) =
+  let* () = nonempty "attention blocked detail" failure.detail in
+  finite_time "attention blocked_at" failure.blocked_at
+;;
+
+let display_detail error =
+  Keeper_internal_error.cap_blocker_detail (Agent_sdk.Error.to_string error)
+;;
+
+let blocked ~blocked_at ~kind ~detail =
+  Blocked { kind; detail; blocked_at }
+;;
+
+let runtime_configuration_change ~failed_at ~detail =
+  Retryable { requirement = Runtime_configuration_change; detail; failed_at }
+;;
+
+let of_sdk_error ~observed_at error =
+  let detail = display_detail error in
+  match Route.route_of_error ~boundary:Route.Oas_execution error with
+  | Route.Retry_after_observed { retry_class; retry_after = None } ->
+    Retryable
+      { requirement = Provider_recovery retry_class
+      ; detail
+      ; failed_at = observed_at
+      }
+  | Route.Retry_after_observed
+      { retry_class; retry_after = Some delay_seconds } ->
+    let retryable =
+      { requirement = Provider_retry_after { retry_class; delay_seconds }
+      ; detail
+      ; failed_at = observed_at
+      }
+    in
+    (match validate_retryable retryable with
+     | Ok () -> Retryable retryable
+     | Error authority_error ->
+       blocked
+         ~blocked_at:observed_at
+         ~kind:Invalid_provider_retry_authority
+         ~detail:(detail ^ "; " ^ authority_error))
+  | Route.Rotate_now { rotate } ->
+    Retryable
+      { requirement = Runtime_catalog_change rotate
+      ; detail
+      ; failed_at = observed_at
+      }
+  | Route.Escalate_judgment { judgment; provenance; detail } ->
+    blocked
+      ~blocked_at:observed_at
+      ~kind:(Provider_judgment_required { judgment; provenance })
+      ~detail
+;;
+
+let retry_requirement_to_yojson = function
+  | Provider_retry_after { retry_class; delay_seconds } ->
+    `Assoc
+      [ "kind", `String "provider_retry_after"
+      ; "retry_class", `String (Route.retry_class_label retry_class)
+      ; "delay_seconds", `Float delay_seconds
+      ]
+  | Provider_recovery retry_class ->
+    `Assoc
+      [ "kind", `String "provider_recovery"
+      ; "retry_class", `String (Route.retry_class_label retry_class)
+      ]
+  | Runtime_catalog_change rotate_class ->
+    `Assoc
+      [ "kind", `String "runtime_catalog_change"
+      ; "rotate_class", `String (Route.rotate_class_label rotate_class)
+      ]
+  | Runtime_configuration_change ->
+    `Assoc [ "kind", `String "runtime_configuration_change" ]
+;;
+
+let blocked_kind_to_yojson = function
+  | Prompt_contract_unavailable ->
+    `Assoc [ "kind", `String "prompt_contract_unavailable" ]
+  | Response_contract_unavailable ->
+    `Assoc [ "kind", `String "response_contract_unavailable" ]
+  | Invalid_provider_retry_authority ->
+    `Assoc [ "kind", `String "invalid_provider_retry_authority" ]
+  | Unexpected_judgment_exception ->
+    `Assoc [ "kind", `String "unexpected_judgment_exception" ]
+  | Provider_judgment_required { judgment; provenance } ->
+    `Assoc
+      [ "kind", `String "provider_judgment_required"
+      ; "judgment", `String (Route.judgment_class_label judgment)
+      ; "provenance", Route.judgment_provenance_to_yojson provenance
+      ]
+;;
+
+let retryable_to_yojson (failure : retryable) =
+  `Assoc
+    [ "requirement", retry_requirement_to_yojson failure.requirement
+    ; "detail", `String failure.detail
+    ; "failed_at", `Float failure.failed_at
+    ]
+;;
+
+let blocked_to_yojson (failure : blocked) =
+  `Assoc
+    [ "kind", blocked_kind_to_yojson failure.kind
+    ; "detail", `String failure.detail
+    ; "blocked_at", `Float failure.blocked_at
+    ]
+;;
+
+let assoc ~context = function
+  | `Assoc fields -> Ok fields
+  | _ -> Error (context ^ " must be an object")
+;;
+
+let exact_fields ~context expected fields =
+  let actual = List.map fst fields in
+  if List.length actual = List.length expected
+     && List.for_all (fun key -> List.mem key actual) expected
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "%s fields must be exactly [%s], got [%s]"
+         context
+         (String.concat "," expected)
+         (String.concat "," actual))
+;;
+
+let field ~context key fields =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s missing field %s" context key)
+;;
+
+let string_json ~context = function
+  | `String value -> Ok value
+  | _ -> Error (context ^ " must be a string")
+;;
+
+let float_json ~context = function
+  | `Float value -> Ok value
+  | `Int value -> Ok (float_of_int value)
+  | _ -> Error (context ^ " must be a number")
+;;
+
+let retry_class_json ~context json =
+  let* label = string_json ~context json in
+  match Route.retry_class_of_label label with
+  | Some retry_class -> Ok retry_class
+  | None -> Error (Printf.sprintf "unknown retry class %S" label)
+;;
+
+let rotate_class_json ~context json =
+  let* label = string_json ~context json in
+  match Route.rotate_class_of_label label with
+  | Some rotate_class -> Ok rotate_class
+  | None -> Error (Printf.sprintf "unknown rotate class %S" label)
+;;
+
+let retry_requirement_of_yojson json =
+  let context = "attention retry requirement" in
+  let* fields = assoc ~context json in
+  let* kind_json = field ~context "kind" fields in
+  let* kind = string_json ~context:(context ^ ".kind") kind_json in
+  match kind with
+  | "provider_retry_after" ->
+    let* () = exact_fields ~context [ "kind"; "retry_class"; "delay_seconds" ] fields in
+    let* retry_json = field ~context "retry_class" fields in
+    let* retry_class = retry_class_json ~context:(context ^ ".retry_class") retry_json in
+    let* delay_json = field ~context "delay_seconds" fields in
+    let* delay_seconds = float_json ~context:(context ^ ".delay_seconds") delay_json in
+    Ok (Provider_retry_after { retry_class; delay_seconds })
+  | "provider_recovery" ->
+    let* () = exact_fields ~context [ "kind"; "retry_class" ] fields in
+    let* retry_json = field ~context "retry_class" fields in
+    let* retry_class = retry_class_json ~context:(context ^ ".retry_class") retry_json in
+    Ok (Provider_recovery retry_class)
+  | "runtime_catalog_change" ->
+    let* () = exact_fields ~context [ "kind"; "rotate_class" ] fields in
+    let* rotate_json = field ~context "rotate_class" fields in
+    let* rotate_class = rotate_class_json ~context:(context ^ ".rotate_class") rotate_json in
+    Ok (Runtime_catalog_change rotate_class)
+  | "runtime_configuration_change" ->
+    let* () = exact_fields ~context [ "kind" ] fields in
+    Ok Runtime_configuration_change
+  | value -> Error (Printf.sprintf "unknown attention retry requirement %S" value)
+;;
+
+let blocked_kind_of_yojson json =
+  let context = "attention blocked kind" in
+  let* fields = assoc ~context json in
+  let* kind_json = field ~context "kind" fields in
+  let* kind = string_json ~context:(context ^ ".kind") kind_json in
+  match kind with
+  | "prompt_contract_unavailable" ->
+    let* () = exact_fields ~context [ "kind" ] fields in
+    Ok Prompt_contract_unavailable
+  | "response_contract_unavailable" ->
+    let* () = exact_fields ~context [ "kind" ] fields in
+    Ok Response_contract_unavailable
+  | "invalid_provider_retry_authority" ->
+    let* () = exact_fields ~context [ "kind" ] fields in
+    Ok Invalid_provider_retry_authority
+  | "unexpected_judgment_exception" ->
+    let* () = exact_fields ~context [ "kind" ] fields in
+    Ok Unexpected_judgment_exception
+  | "provider_judgment_required" ->
+    let* () = exact_fields ~context [ "kind"; "judgment"; "provenance" ] fields in
+    let* judgment_json = field ~context "judgment" fields in
+    let* judgment_label = string_json ~context:(context ^ ".judgment") judgment_json in
+    let* judgment =
+      match Route.judgment_class_of_label judgment_label with
+      | Some judgment -> Ok judgment
+      | None -> Error (Printf.sprintf "unknown judgment class %S" judgment_label)
+    in
+    let* provenance_json = field ~context "provenance" fields in
+    let* provenance = Route.judgment_provenance_of_yojson provenance_json in
+    Ok (Provider_judgment_required { judgment; provenance })
+  | value -> Error (Printf.sprintf "unknown attention blocked kind %S" value)
+;;
+
+let retryable_of_yojson json =
+  let context = "attention retryable failure" in
+  let* fields = assoc ~context json in
+  let* () = exact_fields ~context [ "requirement"; "detail"; "failed_at" ] fields in
+  let* requirement_json = field ~context "requirement" fields in
+  let* requirement = retry_requirement_of_yojson requirement_json in
+  let* detail_json = field ~context "detail" fields in
+  let* detail = string_json ~context:(context ^ ".detail") detail_json in
+  let* failed_json = field ~context "failed_at" fields in
+  let* failed_at = float_json ~context:(context ^ ".failed_at") failed_json in
+  let failure = { requirement; detail; failed_at } in
+  let* () = validate_retryable failure in
+  Ok failure
+;;
+
+let blocked_of_yojson json =
+  let context = "attention blocked failure" in
+  let* fields = assoc ~context json in
+  let* () = exact_fields ~context [ "kind"; "detail"; "blocked_at" ] fields in
+  let* kind_json = field ~context "kind" fields in
+  let* kind = blocked_kind_of_yojson kind_json in
+  let* detail_json = field ~context "detail" fields in
+  let* detail = string_json ~context:(context ^ ".detail") detail_json in
+  let* blocked_json = field ~context "blocked_at" fields in
+  let* blocked_at = float_json ~context:(context ^ ".blocked_at") blocked_json in
+  let failure = { kind; detail; blocked_at } in
+  let* () = validate_blocked failure in
+  Ok failure
+;;

--- a/lib/keeper/keeper_board_attention_failure.mli
+++ b/lib/keeper/keeper_board_attention_failure.mli
@@ -1,0 +1,67 @@
+(** Typed failure evidence for the Board-attention judgment plane.
+
+    Retry authority is never inferred from elapsed time, message text, or a
+    local retry counter. A deadline exists only when the Provider supplied an
+    exact typed retry-after hint. Other retryable states require the named
+    external state transition. Deterministic failures are blocked rather than
+    mechanically retried. *)
+
+type retry_requirement =
+  | Provider_retry_after of
+      { retry_class : Keeper_runtime_failure_route.retry_class
+      ; delay_seconds : float
+      }
+  | Provider_recovery of Keeper_runtime_failure_route.retry_class
+  | Runtime_catalog_change of Keeper_runtime_failure_route.rotate_class
+  | Runtime_configuration_change
+
+type retryable =
+  { requirement : retry_requirement
+  ; detail : string
+  ; failed_at : float
+  }
+
+type blocked_kind =
+  | Prompt_contract_unavailable
+  | Response_contract_unavailable
+  | Provider_judgment_required of
+      { judgment : Keeper_runtime_failure_route.judgment_class
+      ; provenance : Keeper_runtime_failure_route.judgment_provenance
+      }
+  | Invalid_provider_retry_authority
+  | Unexpected_judgment_exception
+
+type blocked =
+  { kind : blocked_kind
+  ; detail : string
+  ; blocked_at : float
+  }
+
+type attempt_failure =
+  | Retryable of retryable
+  | Blocked of blocked
+
+val runtime_configuration_change : failed_at:float -> detail:string -> attempt_failure
+
+val blocked : blocked_at:float -> kind:blocked_kind -> detail:string -> attempt_failure
+
+val of_sdk_error : observed_at:float -> Agent_sdk.Error.sdk_error -> attempt_failure
+(** Classify one OAS execution failure through the shared typed runtime route.
+    Free-form error text is retained for display only and is never matched. *)
+
+val retry_deadline : retryable -> float option
+(** Exact wall-clock deadline derived only from a typed Provider retry-after
+    hint. [None] means an external typed state-change signal is required. *)
+
+val retry_requirement_label : retry_requirement -> string
+val blocked_kind_label : blocked_kind -> string
+(** Stable observability labels. They are projections only and are never parsed
+    to make scheduling decisions. *)
+
+val retryable_to_yojson : retryable -> Yojson.Safe.t
+val retryable_of_yojson : Yojson.Safe.t -> (retryable, string) result
+val blocked_to_yojson : blocked -> Yojson.Safe.t
+val blocked_of_yojson : Yojson.Safe.t -> (blocked, string) result
+
+val validate_retryable : retryable -> (unit, string) result
+val validate_blocked : blocked -> (unit, string) result

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -1,6 +1,7 @@
 (* See .mli. *)
 
 module Candidate = Keeper_board_attention_candidate
+module Failure = Keeper_board_attention_failure
 module Id_map = Map.Make (String)
 module Id_set = Set.Make (String)
 
@@ -41,6 +42,7 @@ type completed_item =
 type blocked_reason =
   | Candidate_membership_conflict of string
   | Durable_partition_invariant of string
+  | Judgment_blocked of Failure.blocked
 
 type state =
   | Ready
@@ -49,7 +51,7 @@ type state =
       ; started_at : float
       }
   | Deferred of
-      { failure : Candidate.retryable_failure
+      { failure : Failure.retryable
       ; deferred_at : float
       }
   | Completed of
@@ -81,7 +83,7 @@ type claim_recovery =
   | Claim_already_transitioned of t
 
 let ( let* ) = Result.bind
-let schema_version = 1
+let schema_version = 2
 
 let state_to_string = function
   | Ready -> "ready"
@@ -97,6 +99,11 @@ let blocked_reason_to_yojson = function
     `Assoc [ "kind", `String "candidate_membership_conflict"; "detail", `String detail ]
   | Durable_partition_invariant detail ->
     `Assoc [ "kind", `String "durable_partition_invariant"; "detail", `String detail ]
+  | Judgment_blocked failure ->
+    `Assoc
+      [ "kind", `String "judgment_blocked"
+      ; "failure", Failure.blocked_to_yojson failure
+      ]
 ;;
 
 let completed_item_to_yojson (item : completed_item) =
@@ -117,7 +124,7 @@ let state_to_yojson = function
   | Deferred { failure; deferred_at } ->
     `Assoc
       [ "kind", `String "deferred"
-      ; "failure", Candidate.retryable_failure_to_yojson failure
+      ; "failure", Failure.retryable_to_yojson failure
       ; "deferred_at", `Float deferred_at
       ]
   | Completed { item; completed_at } ->
@@ -189,14 +196,24 @@ let float_json ~context = function
 let blocked_reason_of_yojson json =
   let context = "Board attention blocked reason" in
   let* fields = assoc ~context json in
-  let* () = exact_fields ~context [ "kind"; "detail" ] fields in
   let* kind_json = field ~context "kind" fields in
   let* kind = string_json ~context:(context ^ ".kind") kind_json in
-  let* detail_json = field ~context "detail" fields in
-  let* detail = string_json ~context:(context ^ ".detail") detail_json in
   match kind with
-  | "candidate_membership_conflict" -> Ok (Candidate_membership_conflict detail)
-  | "durable_partition_invariant" -> Ok (Durable_partition_invariant detail)
+  | "candidate_membership_conflict" ->
+    let* () = exact_fields ~context [ "kind"; "detail" ] fields in
+    let* detail_json = field ~context "detail" fields in
+    let* detail = string_json ~context:(context ^ ".detail") detail_json in
+    Ok (Candidate_membership_conflict detail)
+  | "durable_partition_invariant" ->
+    let* () = exact_fields ~context [ "kind"; "detail" ] fields in
+    let* detail_json = field ~context "detail" fields in
+    let* detail = string_json ~context:(context ^ ".detail") detail_json in
+    Ok (Durable_partition_invariant detail)
+  | "judgment_blocked" ->
+    let* () = exact_fields ~context [ "kind"; "failure" ] fields in
+    let* failure_json = field ~context "failure" fields in
+    let* failure = Failure.blocked_of_yojson failure_json in
+    Ok (Judgment_blocked failure)
   | value -> Error (Printf.sprintf "unknown Board attention blocked reason %S" value)
 ;;
 
@@ -231,7 +248,7 @@ let state_of_yojson json =
   | "deferred" ->
     let* () = exact_fields ~context [ "kind"; "failure"; "deferred_at" ] fields in
     let* failure_json = field ~context "failure" fields in
-    let* failure = Candidate.retryable_failure_of_yojson failure_json in
+    let* failure = Failure.retryable_of_yojson failure_json in
     let* deferred_json = field ~context "deferred_at" fields in
     let* deferred_at = float_json ~context:(context ^ ".deferred_at") deferred_json in
     Ok (Deferred { failure; deferred_at })
@@ -565,12 +582,50 @@ let recover_for_process_start ~base_path ~keeper_name =
       List.fold_left
         (fun (count, changed, acc) row ->
            match row.state with
-           | Running _ | Deferred _ -> count + 1, true, { row with state = Ready } :: acc
-           | Ready | Completed _ | Settled _ | Blocked _ -> count, changed, row :: acc)
+           | Running _ -> count + 1, true, { row with state = Ready } :: acc
+           | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
+             count, changed, row :: acc)
         (0, false, [])
         rows
     in
     Ok (changed, List.rev recovered, count))
+;;
+
+let release_due_provider_retries ~now ~base_path ~keeper_name =
+  let* () = valid_time "Provider retry release time" now in
+  update ~base_path ~keeper_name (fun rows ->
+    let released, changed, updated =
+      List.fold_left
+        (fun (released, changed, acc) row ->
+           match row.state with
+           | Deferred { failure; _ } ->
+             (match Failure.retry_deadline failure with
+              | Some deadline when Float.compare now deadline >= 0 ->
+                released + 1, true, { row with state = Ready } :: acc
+              | Some _ | None -> released, changed, row :: acc)
+           | Ready | Running _ | Completed _ | Settled _ | Blocked _ ->
+             released, changed, row :: acc)
+        (0, false, [])
+        rows
+    in
+    Ok (changed, List.rev updated, released))
+;;
+
+let next_provider_retry_deadline ~base_path ~keeper_name =
+  let* rows = load ~base_path ~keeper_name in
+  Ok
+    (List.fold_left
+       (fun earliest row ->
+          match row.state with
+          | Deferred { failure; _ } ->
+            (match earliest, Failure.retry_deadline failure with
+             | None, deadline -> deadline
+             | Some current, Some candidate
+               when Float.compare candidate current < 0 -> Some candidate
+             | Some _, Some _ | Some _, None -> earliest)
+          | Ready | Running _ | Completed _ | Settled _ | Blocked _ -> earliest)
+       None
+       rows)
 ;;
 
 let find_persisted partition rows =
@@ -612,9 +667,7 @@ let validate_judgment (judgment : Candidate.judgment) =
   |> Result.map ignore
 ;;
 
-let validate_failure (failure : Candidate.retryable_failure) =
-  let* () = nonempty "partition failure detail" failure.detail in
-  valid_time "partition failure failed_at" failure.failed_at
+let validate_failure = Failure.validate_retryable
 ;;
 
 let validate_blocked_reason = function
@@ -622,6 +675,7 @@ let validate_blocked_reason = function
     nonempty "candidate membership conflict detail" detail
   | Durable_partition_invariant detail ->
     nonempty "durable partition invariant detail" detail
+  | Judgment_blocked failure -> Failure.validate_blocked failure
 ;;
 
 let recover_claim_after_lane_abort ~worker_epoch ~base_path ~partition =

--- a/lib/keeper/keeper_board_attention_partition.mli
+++ b/lib/keeper/keeper_board_attention_partition.mli
@@ -7,6 +7,7 @@
     membership. *)
 
 module Candidate = Keeper_board_attention_candidate
+module Failure = Keeper_board_attention_failure
 
 module Worker_epoch : sig
   type t
@@ -25,6 +26,7 @@ type completed_item =
 type blocked_reason =
   | Candidate_membership_conflict of string
   | Durable_partition_invariant of string
+  | Judgment_blocked of Failure.blocked
 
 type state =
   | Ready
@@ -33,7 +35,7 @@ type state =
       ; started_at : float
       }
   | Deferred of
-      { failure : Candidate.retryable_failure
+      { failure : Failure.retryable
       ; deferred_at : float
       }
   | Completed of
@@ -81,9 +83,19 @@ val ensure_roots :
 
 val recover_for_process_start :
   base_path:string -> keeper_name:string -> (int, string) result
-(** Release every prior-process [Running] and [Deferred] row to [Ready] in one
-    rewrite. This operation is process-start authority and must not be used as
-    an ordinary retry signal. *)
+(** Release prior-process [Running] rows to [Ready] in one rewrite. [Deferred]
+    rows retain their exact retry requirement; process restart is not retry
+    authority. *)
+
+val release_due_provider_retries :
+  now:float -> base_path:string -> keeper_name:string -> (int, string) result
+(** Release only [Deferred] rows whose typed Provider retry-after deadline has
+    been reached. No local delay or retry counter is synthesized. *)
+
+val next_provider_retry_deadline :
+  base_path:string -> keeper_name:string -> (float option, string) result
+(** Earliest exact Provider-authored retry deadline, if any. Deferred rows
+    requiring another typed state change are intentionally absent. *)
 
 val claim_next :
   now:float ->
@@ -114,7 +126,7 @@ val defer :
   worker_epoch:Worker_epoch.t ->
   base_path:string ->
   partition:t ->
-  Candidate.retryable_failure ->
+  Failure.retryable ->
   (completion, string) result
 
 val block :

--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1,4 +1,5 @@
 module Candidate = Keeper_board_attention_candidate
+module Failure = Keeper_board_attention_failure
 module Partition = Keeper_board_attention_partition
 module Wake = Keeper_board_attention_worker_wake
 
@@ -10,7 +11,7 @@ type step =
       }
   | Judgment_deferred of
       { candidate_id : string
-      ; failure : Candidate.retryable_failure
+      ; failure : Failure.retryable
       }
   | Candidate_already_consumed of { candidate_id : string }
   | Partition_blocked of
@@ -156,8 +157,15 @@ let process_claimed ~now ~worker_epoch ~base_path ~judge candidates partition =
                ~base_path
                partition
                judgment
-           | Error failure ->
-             defer ~now:(now ()) ~worker_epoch ~base_path partition failure)
+           | Error (Failure.Retryable failure) ->
+             defer ~now:(now ()) ~worker_epoch ~base_path partition failure
+           | Error (Failure.Blocked failure) ->
+             block
+               ~now:(now ())
+               ~worker_epoch
+               ~base_path
+               partition
+               (Partition.Judgment_blocked failure))
         | Candidate.Judged judged ->
           complete_and_signal
             ~now:(now ())
@@ -304,7 +312,13 @@ let observe_error ~base_path ~keeper_name detail =
   Log.Keeper.error "Board attention worker deferred keeper=%s: %s" keeper_name detail
 ;;
 
-let run ~sw ~net ~base_path ~keeper_name =
+let run
+      ~sw
+      ~(clock : [> float Eio.Time.clock_ty ] Eio.Resource.t)
+      ~net
+      ~base_path
+      ~keeper_name
+  =
   match Wake.register ~sw ~base_path ~keeper_name with
   | Error detail -> observe_error ~base_path ~keeper_name detail
   | Ok registration ->
@@ -325,27 +339,88 @@ let run ~sw ~net ~base_path ~keeper_name =
           raise exn)
       else true
     in
-    let rec await () =
+    let rec await_wake () =
       match Wake.await registration with
       | Wake.Registration_closed -> ()
       | Wake.Wake -> drain ()
-    and drain () =
-      match
-        process_next
-          ~now:Time_compat.now
-          ~worker_epoch
-          ~base_path
-          ~keeper_name
-          ~judge:(Candidate.judge_singleton ~sw ~net ~base_path)
-      with
-      | Ok Idle -> await ()
-      | Ok (Judgment_completed _ | Candidate_already_consumed _ | Partition_blocked _) ->
-        Eio.Fiber.yield ();
-        drain ()
-      | Ok (Judgment_deferred _) -> await ()
+    and await () =
+      match Partition.next_provider_retry_deadline ~base_path ~keeper_name with
       | Error detail ->
         observe_error ~base_path ~keeper_name detail;
-        await ()
+        await_wake ()
+      | Ok None -> await_wake ()
+      | Ok (Some deadline) ->
+        let observed_at = Time_compat.now () in
+        if Float.compare observed_at deadline >= 0
+        then drain ()
+        else (
+          let delay = deadline -. observed_at in
+          match
+            Eio.Fiber.first
+              (fun () -> `Wake (Wake.await registration))
+              (fun () ->
+                 Eio.Time.sleep clock delay;
+                 `Provider_retry_deadline)
+          with
+          | `Provider_retry_deadline -> drain ()
+          | `Wake Wake.Registration_closed -> ()
+          | `Wake Wake.Wake -> drain ())
+    and drain () =
+      match
+        Partition.release_due_provider_retries
+          ~now:(Time_compat.now ())
+          ~base_path
+          ~keeper_name
+      with
+      | Error detail ->
+        observe_error ~base_path ~keeper_name detail;
+        await_wake ()
+      | Ok released ->
+        if released > 0
+        then
+          Log.Keeper.info
+            "Board attention Provider-authored retry deadline released keeper=%s count=%d"
+            keeper_name
+            released;
+        (match
+           process_next
+             ~now:Time_compat.now
+             ~worker_epoch
+             ~base_path
+             ~keeper_name
+             ~judge:(Candidate.judge_singleton ~sw ~net ~base_path)
+         with
+         | Ok Idle -> await ()
+         | Ok (Judgment_completed _ | Candidate_already_consumed _) ->
+           Eio.Fiber.yield ();
+           drain ()
+         | Ok (Judgment_deferred { candidate_id; failure }) ->
+           Log.Keeper.info
+             "Board attention judgment durably deferred keeper=%s candidate=%s requirement=%s"
+             keeper_name
+             candidate_id
+             (Failure.retry_requirement_label failure.requirement);
+           await ()
+         | Ok (Partition_blocked { candidate_id; reason }) ->
+           let reason_label =
+             match reason with
+             | Partition.Candidate_membership_conflict _ ->
+               "candidate_membership_conflict"
+             | Partition.Durable_partition_invariant _ ->
+               "durable_partition_invariant"
+             | Partition.Judgment_blocked blocked ->
+               Failure.blocked_kind_label blocked.kind
+           in
+           Log.Keeper.warn
+             "Board attention judgment durably blocked keeper=%s candidate=%s reason=%s"
+             keeper_name
+             candidate_id
+             reason_label;
+           Eio.Fiber.yield ();
+           drain ()
+         | Error detail ->
+           observe_error ~base_path ~keeper_name detail;
+           await ())
     in
     let rec supervise action =
       try action () with

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -12,7 +12,7 @@ type step =
       }
   | Judgment_deferred of
       { candidate_id : string
-      ; failure : Keeper_board_attention_candidate.retryable_failure
+      ; failure : Keeper_board_attention_failure.retryable
       }
   | Candidate_already_consumed of { candidate_id : string }
   | Partition_blocked of
@@ -29,6 +29,7 @@ type settlement =
 
 val run :
   sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   net:Eio_context.eio_net option ->
   base_path:string ->
   keeper_name:string ->
@@ -52,7 +53,7 @@ module For_testing : sig
     judge:
       (Keeper_board_attention_candidate.candidate ->
        ( Keeper_board_attention_candidate.judgment
-       , Keeper_board_attention_candidate.retryable_failure )
+       , Keeper_board_attention_failure.attempt_failure )
        result) ->
     (step, string) result
 end

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -244,6 +244,7 @@ let launch_supervised_fiber_body
              Eio.Fiber.fork ~sw:lane_sw (fun () ->
                Keeper_board_attention_worker.run
                  ~sw:lane_sw
+                 ~clock:ctx.clock
                  ~net:ctx.net
                  ~base_path
                  ~keeper_name:meta.name);

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -236,6 +236,15 @@ let retry_class_label = function
   | Network_transient -> "network_transient"
   | Provider_timeout -> "provider_timeout"
 
+let retry_class_of_label = function
+  | "rate_limited" -> Some Rate_limited
+  | "hard_quota" -> Some Hard_quota
+  | "capacity_backpressure" -> Some Capacity_backpressure
+  | "server_error" -> Some Server_error
+  | "network_transient" -> Some Network_transient
+  | "provider_timeout" -> Some Provider_timeout
+  | _ -> None
+
 let rotate_class_label = function
   | Auth_failed -> "auth_failed"
   | Model_unavailable -> "model_unavailable"
@@ -244,6 +253,16 @@ let rotate_class_label = function
   | Runtime_exhausted -> "runtime_exhausted"
   | No_progress_empty -> "no_progress_empty"
   | No_progress_thinking_only -> "no_progress_thinking_only"
+
+let rotate_class_of_label = function
+  | "auth_failed" -> Some Auth_failed
+  | "model_unavailable" -> Some Model_unavailable
+  | "resumable_cli_session" -> Some Resumable_cli_session
+  | "candidates_filtered" -> Some Candidates_filtered
+  | "runtime_exhausted" -> Some Runtime_exhausted
+  | "no_progress_empty" -> Some No_progress_empty
+  | "no_progress_thinking_only" -> Some No_progress_thinking_only
+  | _ -> None
 
 let judgment_class_label = function
   | Deterministic_request -> "deterministic_request"

--- a/lib/keeper_runtime/keeper_runtime_failure_route.mli
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.mli
@@ -124,7 +124,9 @@ val route_kind_label : route -> string
     "escalate_judgment"]. *)
 
 val retry_class_label : retry_class -> string
+val retry_class_of_label : string -> retry_class option
 val rotate_class_label : rotate_class -> string
+val rotate_class_of_label : string -> rotate_class option
 val judgment_class_label : judgment_class -> string
 
 val judgment_provenance_label : judgment_provenance -> string

--- a/test/dune
+++ b/test/dune
@@ -187,6 +187,7 @@
   test_keeper_external_attention
   test_keeper_waiting_inventory
   test_keeper_board_attention_candidate
+  test_keeper_board_attention_failure
   test_keeper_board_attention_partition
   test_keeper_board_attention_worker
   test_keeper_runtime_trust_snapshot
@@ -499,6 +500,7 @@
   test_keeper_external_attention
   test_keeper_waiting_inventory
   test_keeper_board_attention_candidate
+  test_keeper_board_attention_failure
   test_keeper_board_attention_partition
   test_keeper_board_attention_worker
   test_keeper_runtime_trust_snapshot

--- a/test/test_keeper_board_attention_failure.ml
+++ b/test/test_keeper_board_attention_failure.ml
@@ -1,0 +1,145 @@
+module F = Masc.Keeper_board_attention_failure
+module Route = Keeper_runtime_failure_route
+
+let ok label = function
+  | Ok value -> value
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
+let expect_error label = function
+  | Error _ -> ()
+  | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
+;;
+
+let test_provider_retry_after_is_exact_authority () =
+  let failure =
+    F.of_sdk_error
+      ~observed_at:100.0
+      (Agent_sdk.Error.Api
+         (Llm_provider.Retry.RateLimited
+            { retry_after = Some 30.0; message = "typed throttle" }))
+  in
+  match failure with
+  | F.Retryable retryable ->
+    (match retryable.requirement with
+     | F.Provider_retry_after { retry_class = Route.Rate_limited; delay_seconds } ->
+       Alcotest.(check (float 0.0)) "exact Provider delay" 30.0 delay_seconds
+     | F.Provider_retry_after _
+     | F.Provider_recovery _
+     | F.Runtime_catalog_change _
+     | F.Runtime_configuration_change ->
+       Alcotest.fail "typed rate limit lost its retry-after authority");
+    Alcotest.(check (option (float 0.0)))
+      "exact derived deadline"
+      (Some 130.0)
+      (F.retry_deadline retryable);
+    Alcotest.(check bool)
+      "retry evidence roundtrip"
+      true
+      (ok
+         "decode retry evidence"
+         (F.retryable_of_yojson (F.retryable_to_yojson retryable))
+       = retryable)
+  | F.Blocked _ -> Alcotest.fail "valid Provider retry-after was blocked"
+;;
+
+let test_missing_provider_hint_requires_recovery_signal () =
+  match
+    F.of_sdk_error
+      ~observed_at:100.0
+      (Agent_sdk.Error.Provider
+         (Llm_provider.Error.ProviderUnavailable
+            { provider = "typed-provider"; detail = "upstream unavailable" }))
+  with
+  | F.Retryable
+      { requirement = F.Provider_recovery Route.Server_error
+      ; failed_at
+      ; _
+      } ->
+    Alcotest.(check (float 0.0)) "observation time" 100.0 failed_at
+  | F.Retryable _ | F.Blocked _ ->
+    Alcotest.fail "hintless Provider outage invented a retry deadline"
+;;
+
+let test_deterministic_sdk_failure_is_blocked () =
+  let failure =
+    F.of_sdk_error
+      ~observed_at:100.0
+      (Agent_sdk.Error.Api
+         (Llm_provider.Retry.InvalidRequest
+            { message = "invalid schema"
+            ; reason = Llm_provider.Retry.Unknown_invalid_request
+            }))
+  in
+  match failure with
+  | F.Blocked
+      ({ kind =
+           F.Provider_judgment_required
+             { judgment = Route.Deterministic_request
+             ; provenance = Route.Oas_api_error
+             }
+       ; _
+       } as blocked) ->
+    Alcotest.(check bool)
+      "blocked evidence roundtrip"
+      true
+      (ok
+         "decode blocked evidence"
+         (F.blocked_of_yojson (F.blocked_to_yojson blocked))
+       = blocked)
+  | F.Blocked _ | F.Retryable _ ->
+    Alcotest.fail "deterministic SDK failure was not typed as blocked"
+;;
+
+let test_invalid_provider_hint_fails_closed () =
+  match
+    F.of_sdk_error
+      ~observed_at:100.0
+      (Agent_sdk.Error.Api
+         (Llm_provider.Retry.RateLimited
+            { retry_after = Some (-1.0); message = "invalid typed hint" }))
+  with
+  | F.Blocked { kind = F.Invalid_provider_retry_authority; _ } -> ()
+  | F.Blocked _ | F.Retryable _ ->
+    Alcotest.fail "invalid Provider retry authority did not fail closed"
+;;
+
+let test_retry_codec_rejects_unknown_requirement () =
+  let malformed =
+    `Assoc
+      [ ( "requirement"
+        , `Assoc [ "kind", `String "elapsed_time_guess" ] )
+      ; "detail", `String "must not decode"
+      ; "failed_at", `Float 1.0
+      ]
+  in
+  expect_error "unknown retry requirement" (F.retryable_of_yojson malformed)
+;;
+
+let () =
+  Alcotest.run
+    "keeper_board_attention_failure"
+    [ ( "typed retry authority"
+      , [ Alcotest.test_case
+            "Provider retry-after is exact authority"
+            `Quick
+            test_provider_retry_after_is_exact_authority
+        ; Alcotest.test_case
+            "missing hint requires Provider recovery"
+            `Quick
+            test_missing_provider_hint_requires_recovery_signal
+        ; Alcotest.test_case
+            "deterministic SDK failure is blocked"
+            `Quick
+            test_deterministic_sdk_failure_is_blocked
+        ; Alcotest.test_case
+            "invalid Provider hint fails closed"
+            `Quick
+            test_invalid_provider_hint_fails_closed
+        ; Alcotest.test_case
+            "unknown retry requirement is rejected"
+            `Quick
+            test_retry_codec_rejects_unknown_requirement
+        ] )
+    ]
+;;

--- a/test/test_keeper_board_attention_partition.ml
+++ b/test/test_keeper_board_attention_partition.ml
@@ -1,5 +1,6 @@
 module P = Masc.Keeper_board_attention_partition
 module A = P.Candidate
+module F = P.Failure
 module J = Masc.Keeper_board_attention_judgment
 
 let rec remove_tree path =
@@ -200,8 +201,15 @@ let test_lane_abort_and_process_start_recovery_are_explicit () =
       | _ -> Alcotest.fail "released claim was not Ready")
    | P.Claim_already_transitioned _ -> Alcotest.fail "live owner claim was not released");
   let first_claim = claim ~base_path ~worker_epoch:owner ~now:11.0 in
-  let failure : A.retryable_failure =
-    { kind = A.Provider_unavailable; detail = "typed Provider failure"; failed_at = 12.0 }
+  let failure : F.retryable =
+    { requirement =
+        F.Provider_retry_after
+          { retry_class = Keeper_runtime_failure_route.Server_error
+          ; delay_seconds = 5.0
+          }
+    ; detail = "typed Provider failure"
+    ; failed_at = 12.0
+    }
   in
   ignore
     (ok
@@ -214,10 +222,34 @@ let test_lane_abort_and_process_start_recovery_are_explicit () =
     second.candidate_id
     second_claim.candidate_id;
   Alcotest.(check int)
-    "process start recovers prior Running and Deferred"
-    2
+    "process start recovers only prior Running"
+    1
     (ok "process-start recovery" (P.recover_for_process_start ~base_path ~keeper_name:"sangsu"));
-  let recovered = claim ~base_path ~worker_epoch:owner ~now:14.0 in
+  Alcotest.(check (option (float 0.0)))
+    "Provider deadline remains durable"
+    (Some 17.0)
+    (ok
+       "next Provider retry deadline"
+       (P.next_provider_retry_deadline ~base_path ~keeper_name:"sangsu"));
+  Alcotest.(check int)
+    "deadline cannot release early"
+    0
+    (ok
+       "early Provider retry release"
+       (P.release_due_provider_retries
+          ~now:16.0
+          ~base_path
+          ~keeper_name:"sangsu"));
+  Alcotest.(check int)
+    "exact Provider deadline releases deferred root"
+    1
+    (ok
+       "due Provider retry release"
+       (P.release_due_provider_retries
+          ~now:17.0
+          ~base_path
+          ~keeper_name:"sangsu"));
+  let recovered = claim ~base_path ~worker_epoch:owner ~now:18.0 in
   Alcotest.(check string)
     "recovery restores durable oldest order"
     first.candidate_id
@@ -247,7 +279,7 @@ let test_strict_codec_and_ledger_identity_validation () =
     (ok "decode" (P.of_yojson encoded) = created);
   expect_error
     "unknown schema version"
-    (P.of_yojson (replace_field "schema_version" (`Int 2) encoded));
+    (P.of_yojson (replace_field "schema_version" (`Int 3) encoded));
   let malformed = replace_field "partition_id" (`String "forged-root") encoded in
   let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
   ok

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -1,4 +1,5 @@
 module A = Masc.Keeper_board_attention_candidate
+module F = Masc.Keeper_board_attention_failure
 module J = Masc.Keeper_board_attention_judgment
 module P = Masc.Keeper_board_attention_partition
 module W = Masc.Keeper_board_attention_worker
@@ -151,15 +152,19 @@ let test_provider_failure_is_durable_without_hot_retry () =
   with_temp_base "board-attention-worker-deferred" @@ fun base_path ->
   let persisted = record ~base_path (candidate ()) in
   let calls = ref 0 in
-  let failure : A.retryable_failure =
-    { kind = A.Provider_unavailable; detail = "typed provider failure"; failed_at = 3.0 }
+  let failure : F.retryable =
+    { requirement =
+        F.Provider_recovery Keeper_runtime_failure_route.Server_error
+    ; detail = "typed provider failure"
+    ; failed_at = 3.0
+    }
   in
   (match
      ok
        "defer worker step"
        (process ~base_path ~judge:(fun _ ->
           incr calls;
-          Error failure))
+          Error (F.Retryable failure)))
    with
    | W.Judgment_deferred { candidate_id; failure = observed }
      when String.equal candidate_id persisted.candidate_id && observed = failure -> ()
@@ -174,6 +179,35 @@ let test_provider_failure_is_durable_without_hot_retry () =
    | A.Pending { last_failure = None } -> ()
    | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
      Alcotest.fail "partition failure leaked into the candidate SSOT")
+;;
+
+let test_deterministic_failure_is_blocked_without_retry () =
+  with_temp_base "board-attention-worker-blocked" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  let blocked : F.blocked =
+    { kind = F.Response_contract_unavailable
+    ; detail = "structured response did not cover the singleton identity"
+    ; blocked_at = 3.0
+    }
+  in
+  (match
+     ok
+       "block worker step"
+       (process ~base_path ~judge:(fun _ -> Error (F.Blocked blocked)))
+   with
+   | W.Partition_blocked
+       { candidate_id
+       ; reason = P.Judgment_blocked observed
+       }
+     when String.equal candidate_id persisted.candidate_id && observed = blocked -> ()
+   | _ -> Alcotest.fail "deterministic judgment failure was not durably blocked");
+  (match
+     ok
+       "blocked partition is not retried"
+       (process ~base_path ~judge:(fun _ -> Alcotest.fail "blocked work was retried"))
+   with
+   | W.Idle -> ()
+   | _ -> Alcotest.fail "blocked partition became claimable")
 ;;
 
 let test_existing_judgment_never_calls_provider () =
@@ -286,6 +320,10 @@ let () =
             "Provider failure is durable without hot retry"
             `Quick
             test_provider_failure_is_durable_without_hot_retry
+        ; Alcotest.test_case
+            "deterministic failure is blocked"
+            `Quick
+            test_deterministic_failure_is_blocked_without_retry
         ; Alcotest.test_case
             "existing judgment skips Provider"
             `Quick


### PR DESCRIPTION
## Summary
- preserve OAS SDK failures as typed attention retry or blocked evidence
- derive autonomous retry deadlines only from exact Provider retry-after hints
- stop treating process restart as authority to retry every Deferred partition
- persist deterministic request/response failures as Blocked instead of retrying them mechanically
- make the per-Keeper worker wait on either a durable wake or the earliest Provider-authored deadline

## Invariants
- no error-string matching controls retry
- no TTL, local retry count, fixed delay, or process restart invents retry authority
- hintless Provider recovery and runtime configuration changes remain distinct typed requirements
- deterministic failures remain observable and non-claimable

## Focused verification
- candidate 5/5
- typed failure authority 5/5
- singleton partition 5/5
- judgment worker 8/8
- runtime failure route 14/14
- registry hardening 17/17
- ocamlformat --check
- git diff --check

Stacked on #25375.