### PR TITLE
fix(keeper): enforce typed Board audiences

### DIFF
--- a/lib/keeper/keeper_board_audience.ml
+++ b/lib/keeper/keeper_board_audience.ml
@@ -1,0 +1,80 @@
+module Board_signal = Keeper_world_observation_board_signal
+module Message_scope = Keeper_world_observation_message_scope
+
+type t =
+  | Targets of Keeper_identity.Keeper_id.t list
+  | Broadcast
+  | Thread_participants
+  | Discoverable
+
+type classification_error =
+  | Unsupported_broadcast of string list
+  | Direct_without_targets of string
+
+type route =
+  | Deliver of Board_signal.wake_reason
+  | Judge_discoverable
+  | Ignore
+
+let classify ~visibility signal =
+  match
+    Keeper_lane_mentions.explicit_address_of_content
+      (Board_signal.address_text signal)
+  with
+  | Keeper_lane_mentions.Broadcast_all -> Ok Broadcast
+  | Keeper_lane_mentions.Targets targets -> Ok (Targets targets)
+  | Keeper_lane_mentions.Unsupported_broadcast selectors ->
+    Error (Unsupported_broadcast selectors)
+  | Keeper_lane_mentions.No_explicit_address ->
+    (match signal.Board_dispatch.kind, visibility with
+     | Board_dispatch.Board_post_created, Board.Direct ->
+       Error (Direct_without_targets signal.post_id)
+     | Board_dispatch.Board_post_created,
+       (Board.Public | Board.Unlisted | Board.Internal) -> Ok Discoverable
+     | ( Board_dispatch.Board_comment_added
+       | Board_dispatch.Board_reaction_changed _ ),
+       (Board.Public | Board.Unlisted | Board.Internal | Board.Direct) ->
+       Ok Thread_participants)
+;;
+
+let keeper_target_ids (meta : Keeper_meta_contract.keeper_meta) =
+  let targets =
+    if meta.mention_targets = [] then [ meta.name ] else meta.mention_targets
+  in
+  Keeper_lane_mentions.target_ids_of targets
+;;
+
+let route_for_keeper ~audience ~(meta : Keeper_meta_contract.keeper_meta) ~signal =
+  let self_ids = Message_scope.self_ids meta in
+  if Message_scope.is_self_author ~self_ids signal.Board_dispatch.author
+  then Board_signal.Available Ignore
+  else
+    match audience with
+    | Targets targets ->
+      if Keeper_lane_mentions.ids_match ~target_ids:(keeper_target_ids meta) targets
+      then Board_signal.Available (Deliver Board_signal.Explicit_mention)
+      else Board_signal.Available Ignore
+    | Broadcast -> Board_signal.Available (Deliver Board_signal.Broadcast)
+    | Thread_participants ->
+      (match Board_signal.wake_reason ~meta ~signal with
+       | Board_signal.Unavailable _ as unavailable -> unavailable
+       | Board_signal.Available (Some reason) -> Board_signal.Available (Deliver reason)
+       | Board_signal.Available None -> Board_signal.Available Ignore)
+    | Discoverable -> Board_signal.Available Judge_discoverable
+;;
+
+let label = function
+  | Targets _ -> "targets"
+  | Broadcast -> "broadcast"
+  | Thread_participants -> "thread_participants"
+  | Discoverable -> "discoverable"
+;;
+
+let classification_error_to_string = function
+  | Unsupported_broadcast selectors ->
+    Printf.sprintf
+      "unsupported Keeper Board broadcast selector(s): %s"
+      (String.concat ", " (List.map (Printf.sprintf "@@%s") selectors))
+  | Direct_without_targets post_id ->
+    Printf.sprintf "Direct Board post %s has no explicit Keeper targets" post_id
+;;

--- a/lib/keeper/keeper_board_audience.ml
+++ b/lib/keeper/keeper_board_audience.ml
@@ -10,6 +10,7 @@ type t =
 type classification_error =
   | Unsupported_broadcast of string list
   | Direct_without_targets of string
+  | Broadcast_on_direct of string
 
 type route =
   | Deliver of Board_signal.wake_reason
@@ -21,7 +22,15 @@ let classify ~visibility signal =
     Keeper_lane_mentions.explicit_address_of_content
       (Board_signal.address_text signal)
   with
-  | Keeper_lane_mentions.Broadcast_all -> Ok Broadcast
+  | Keeper_lane_mentions.Broadcast_all ->
+    (* [Direct] means "mentioned agents only" (Board_types.visibility), so a
+       fleet-wide [@@all] contradicts the visibility the author chose.  Fail
+       closed instead of promoting the signal to a fleet Broadcast: the
+       write boundary (#25379) rejects such posts, and routing must not
+       re-admit what the boundary refuses. *)
+    (match visibility with
+     | Board.Direct -> Error (Broadcast_on_direct signal.post_id)
+     | Board.Public | Board.Unlisted | Board.Internal -> Ok Broadcast)
   | Keeper_lane_mentions.Targets targets -> Ok (Targets targets)
   | Keeper_lane_mentions.Unsupported_broadcast selectors ->
     Error (Unsupported_broadcast selectors)
@@ -77,4 +86,8 @@ let classification_error_to_string = function
       (String.concat ", " (List.map (Printf.sprintf "@@%s") selectors))
   | Direct_without_targets post_id ->
     Printf.sprintf "Direct Board post %s has no explicit Keeper targets" post_id
+  | Broadcast_on_direct post_id ->
+    Printf.sprintf
+      "Direct Board post %s cannot address the fleet with @@all"
+      post_id
 ;;

--- a/lib/keeper/keeper_board_audience.mli
+++ b/lib/keeper/keeper_board_audience.mli
@@ -11,6 +11,7 @@ type t =
 type classification_error =
   | Unsupported_broadcast of string list
   | Direct_without_targets of string
+  | Broadcast_on_direct of string
 
 type route =
   | Deliver of Keeper_world_observation_board_signal.wake_reason
@@ -23,7 +24,17 @@ val classify
   -> (t, classification_error) result
 (** Exact explicit address wins. Otherwise comments and reactions are scoped
     to structural thread participants, while a newly-created unaddressed post
-    is discoverable. *)
+    is discoverable.
+
+    Fail-closed address/visibility contract:
+    - an unsupported [@@name] selector rejects the whole signal, even when
+      valid [@keeper] targets are mixed in (no partial routing);
+    - [@@all] on a [Direct] post is rejected ([Broadcast_on_direct]):
+      [Direct] means "mentioned agents only", so a fleet broadcast would
+      contradict the visibility the author chose.  [@@all] on
+      [Public]/[Unlisted]/[Internal] classifies as {!Broadcast};
+    - a [Direct] post-creation without any explicit address is rejected
+      ([Direct_without_targets]). *)
 
 val route_for_keeper
   :  audience:t

--- a/lib/keeper/keeper_board_audience.mli
+++ b/lib/keeper/keeper_board_audience.mli
@@ -1,0 +1,35 @@
+(** Signal-centric Board routing authority for Keeper lanes. *)
+
+type t =
+  | Targets of Keeper_identity.Keeper_id.t list
+  | Broadcast
+  | Thread_participants
+  | Discoverable
+(** Closed audience sum from the mixed-workload operation contract. Only
+    [Discoverable] may enter semantic attention judgment. *)
+
+type classification_error =
+  | Unsupported_broadcast of string list
+  | Direct_without_targets of string
+
+type route =
+  | Deliver of Keeper_world_observation_board_signal.wake_reason
+  | Judge_discoverable
+  | Ignore
+
+val classify
+  :  visibility:Board.visibility
+  -> Board_dispatch.board_signal
+  -> (t, classification_error) result
+(** Exact explicit address wins. Otherwise comments and reactions are scoped
+    to structural thread participants, while a newly-created unaddressed post
+    is discoverable. *)
+
+val route_for_keeper
+  :  audience:t
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> signal:Board_dispatch.board_signal
+  -> route Keeper_world_observation_board_signal.board_read
+
+val label : t -> string
+val classification_error_to_string : classification_error -> string

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -32,10 +32,6 @@ val wakeup_keeper :
   ?stimulus:Keeper_event_queue.stimulus ->
   string -> unit
 
-(** Wake up all running keepers. Used for @@all broadcast mentions
-    or system-wide events. *)
-val wakeup_all_keepers : ?base_path:string -> unit -> unit
-
 val not_in_registry_warn_cooldown_s : float
 val not_in_registry_warn_max_entries : int
 

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -463,6 +463,12 @@ let wakeup_relevant_keeper_for_board_signal
   | Ok post ->
   match Keeper_board_audience.classify ~visibility:post.visibility signal with
   | Error error ->
+    (* Fail closed: a classification error (unsupported [@@] selector,
+       mixed direct+broadcast address, or a Direct post without targets)
+       drops the ENTIRE signal.  There is no partial routing to the
+       otherwise-valid [@keeper] targets of a mixed address — accepting
+       them would silently reinterpret an ambiguous address.  The drop is
+       observable via the metric and warning below. *)
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string KeepaliveSignalFailures)
       ~labels:[ ("keeper", "routing"); ("phase", "board_audience_classify") ]

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -310,21 +310,9 @@ let wakeup_keeper ?base_path ?stimulus name =
     entries
 ;;
 
-(** Wake up all running keepers — used when a broadcast mentions @@all
-    or when a system-wide event requires immediate attention.
-    [None] preserves the legacy global wakeup behavior. *)
-let wakeup_all_keepers ?base_path () =
-  match base_path with
-  | None -> Keeper_registry.wakeup_all ~intent:Keeper_registry.Broadcast_signal ()
-  | Some expected ->
-    Keeper_registry.wakeup_all
-      ~intent:Keeper_registry.Broadcast_signal
-      ~base_path:expected
-      ()
-
 (* RFC-0020: enqueue the board signal as a typed [stimulus_payload] (PR-1).
    [reason] is the typed {!Board_wake.wake_reason} that selected this keeper;
-   here it only picks urgency (explicit mentions are [Immediate]). It is not
+   here it only picks urgency (explicit targets and broadcasts are [Immediate]). It is not
    carried in the payload — the next prompt re-derives board context from the
    typed [Board_signal] payload, not from a wake-reason string. *)
 let queue_reaction_target_of_board = function
@@ -366,7 +354,8 @@ let board_signal_stimulus
   { Keeper_event_queue.post_id = signal.post_id
   ; urgency =
       (match reason with
-       | Board_wake.Explicit_mention -> Keeper_event_queue.Immediate
+       | Board_wake.Explicit_mention | Board_wake.Broadcast ->
+         Keeper_event_queue.Immediate
        | Board_wake.Thread_reply_after_self_comment
        | Board_wake.Reaction_after_self_activity ->
          Keeper_event_queue.Normal)
@@ -410,7 +399,11 @@ let record_board_attention_candidate
      | Ok _ ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string BoardSignalAttentionCandidateTotal)
-         ~labels:[ ("keeper", meta.name); ("kind", signal_kind_label) ]
+         ~labels:
+           [ ("keeper", meta.name)
+           ; ("kind", signal_kind_label)
+           ; ("audience", Keeper_board_audience.label Keeper_board_audience.Discoverable)
+           ]
          ()
      | Error err ->
        Otel_metric_store.inc_counter
@@ -457,13 +450,42 @@ let wakeup_relevant_keeper_for_board_signal
     | Board_dispatch.Board_comment_added -> "comment_added"
     | Board_dispatch.Board_reaction_changed _ -> "reaction_changed"
   in
-  (* Every lane is independent: persist and signal each addressed Keeper
-     without a fleet-wide cap, ordering dependency, or content debounce. *)
-  let board_ym = Eio_guard.create_yield_meter () in
-  List.iter
-    (fun (entry : Keeper_registry.registry_entry) ->
-       (try
-          match read_meta config entry.name with
+  match Board_dispatch.get_post ~post_id:signal.post_id with
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string KeepaliveSignalFailures)
+      ~labels:[ ("keeper", "routing"); ("phase", "board_audience_post_read") ]
+      ();
+    Log.Keeper.warn
+      "board signal audience post unavailable: post=%s error=%s"
+      signal.post_id
+      (Board.show_board_error error)
+  | Ok post ->
+  match Keeper_board_audience.classify ~visibility:post.visibility signal with
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string KeepaliveSignalFailures)
+      ~labels:[ ("keeper", "routing"); ("phase", "board_audience_classify") ]
+      ();
+    Log.Keeper.warn
+      "board signal audience rejected: post=%s error=%s"
+      signal.post_id
+      (Keeper_board_audience.classification_error_to_string error)
+  | Ok audience ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string BoardSignalRoutedTotal)
+      ~labels:
+        [ ("kind", signal_kind_label)
+        ; ("audience", Keeper_board_audience.label audience)
+        ]
+      ();
+    (* Every lane is independent: persist and signal each addressed Keeper
+       without a fleet-wide cap, ordering dependency, or content debounce. *)
+    let board_ym = Eio_guard.create_yield_meter () in
+    List.iter
+      (fun (entry : Keeper_registry.registry_entry) ->
+         (try
+            match read_meta config entry.name with
         | Error detail ->
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string KeepaliveSignalFailures)
@@ -483,7 +505,8 @@ let wakeup_relevant_keeper_for_board_signal
             entry.name
         | Ok (Some meta) ->
           (match
-             Keeper_world_observation.board_signal_wake_reason
+             Keeper_board_audience.route_for_keeper
+               ~audience
                ~meta
                ~signal
            with
@@ -497,17 +520,38 @@ let wakeup_relevant_keeper_for_board_signal
                meta.name
                signal.post_id
                (Keeper_world_observation_board_signal.unavailable_to_string unavailable)
-           | Keeper_world_observation_board_signal.Available None ->
+           | Keeper_world_observation_board_signal.Available
+               Keeper_board_audience.Ignore ->
              Otel_metric_store.inc_counter
                Keeper_metrics.(to_string BoardSignalNoWakeTotal)
-               ~labels:[ ("keeper", meta.name); ("kind", signal_kind_label) ]
+               ~labels:
+                 [ ("keeper", meta.name)
+                 ; ("kind", signal_kind_label)
+                 ; ("audience", Keeper_board_audience.label audience)
+                 ]
+               ()
+           | Keeper_world_observation_board_signal.Available
+               Keeper_board_audience.Judge_discoverable ->
+             (* Intentionally counted under [BoardSignalNoWakeTotal]:
+                [Judge_discoverable] issues no wake for this keeper — the
+                signal is recorded as an attention candidate below
+                instead. The [audience] label keeps this distinguishable
+                from the [Ignore] branch, which shares the counter. *)
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string BoardSignalNoWakeTotal)
+               ~labels:
+                 [ ("keeper", meta.name)
+                 ; ("kind", signal_kind_label)
+                 ; ("audience", Keeper_board_audience.label audience)
+                 ]
                ();
              record_board_attention_candidate
                ~config
                ~signal_kind_label
                ~meta
                signal
-           | Keeper_world_observation_board_signal.Available (Some reason) ->
+           | Keeper_world_observation_board_signal.Available
+               (Keeper_board_audience.Deliver reason) ->
              (match deliver_addressed_board_signal ~config ~reason ~signal meta with
               | Error detail ->
                 Otel_metric_store.inc_counter
@@ -522,6 +566,14 @@ let wakeup_relevant_keeper_for_board_signal
                   signal.post_id
                   detail
               | Ok () ->
+                Otel_metric_store.inc_counter
+                  Keeper_metrics.(to_string BoardSignalDeliveryTotal)
+                  ~labels:
+                    [ ("keeper", meta.name)
+                    ; ("kind", signal_kind_label)
+                    ; ("audience", Keeper_board_audience.label audience)
+                    ]
+                  ();
                 if meta.paused || entry.phase = Keeper_state_machine.Paused
                 then
                   Log.Keeper.info
@@ -531,8 +583,16 @@ let wakeup_relevant_keeper_for_board_signal
                     signal.post_id
                 else (
                   let outcome =
+                    let intent =
+                      match reason with
+                      | Board_wake.Broadcast -> Keeper_registry.Broadcast_signal
+                      | Board_wake.Explicit_mention
+                      | Board_wake.Thread_reply_after_self_comment
+                      | Board_wake.Reaction_after_self_activity ->
+                        Keeper_registry.Reactive_signal
+                    in
                     Keeper_registry.wakeup_running
-                      ~intent:Keeper_registry.Reactive_signal
+                      ~intent
                       ~base_path:config.base_path
                       meta.name
                   in
@@ -551,20 +611,20 @@ let wakeup_relevant_keeper_for_board_signal
                       meta.name
                       (Board_wake.wake_reason_label reason)
                       signal.post_id)))
-        with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string KeepaliveSignalFailures)
-            ~labels:[ ("keeper", entry.name); ("phase", "board_lane_failure") ]
-            ();
-          Log.Keeper.warn
-            "board signal lane failed independently: keeper=%s post=%s error=%s"
-            entry.name
-            signal.post_id
-            (Printexc.to_string exn));
-       Eio_guard.yield_step board_ym)
-    registry_entries
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string KeepaliveSignalFailures)
+              ~labels:[ ("keeper", entry.name); ("phase", "board_lane_failure") ]
+              ();
+            Log.Keeper.warn
+              "board signal lane failed independently: keeper=%s post=%s error=%s"
+              entry.name
+              signal.post_id
+              (Printexc.to_string exn));
+         Eio_guard.yield_step board_ym)
+      registry_entries
 ;;
 
 (* Per-stage timing accumulator for Phase 0 profiling.

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -124,9 +124,6 @@ val wakeup_keeper :
   ?stimulus:Keeper_event_queue.stimulus ->
   string -> unit
 
-(** Wake up all running keepers. [None] preserves legacy global wakeup. *)
-val wakeup_all_keepers : ?base_path:string -> unit -> unit
-
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.board_signal -> unit
 

--- a/lib/keeper/keeper_lane_mentions.ml
+++ b/lib/keeper/keeper_lane_mentions.ml
@@ -28,9 +28,7 @@ let trim_token_edges s =
   if !j < !i then "" else String.sub s !i (!j - !i + 1)
 ;;
 
-let mention_ids_of_content (content : string) :
-  Keeper_identity.Keeper_id.t list
-  =
+let normalized_tokens content =
   let normalized =
     String.map
       (fun c ->
@@ -40,13 +38,55 @@ let mention_ids_of_content (content : string) :
       (String.lowercase_ascii content)
   in
   String.split_on_char ' ' normalized
-  |> List.filter_map (fun token ->
-    let trimmed = trim_token_edges token in
-    if String.length trimmed >= 2 && trimmed.[0] = '@' then
-      Keeper_identity.Keeper_id.of_string
-        (String.sub trimmed 1 (String.length trimmed - 1))
-    else None)
-  |> List.sort_uniq Keeper_identity.Keeper_id.compare
+  |> List.map trim_token_edges
+  |> List.filter (fun token -> not (String.equal token ""))
+;;
+
+type explicit_address =
+  | No_explicit_address
+  | Targets of Keeper_identity.Keeper_id.t list
+  | Broadcast_all
+  | Unsupported_broadcast of string list
+
+let explicit_address_of_content content =
+  let tokens = normalized_tokens content in
+  let broadcast_selectors =
+    tokens
+    |> List.filter_map (fun token ->
+      if String.length token >= 2 && String.starts_with ~prefix:"@@" token
+      then Some (String.sub token 2 (String.length token - 2))
+      else None)
+    |> List.sort_uniq String.compare
+  in
+  if
+    broadcast_selectors <> []
+    && List.for_all (String.equal "all") broadcast_selectors
+  then Broadcast_all
+  else if broadcast_selectors <> []
+  then Unsupported_broadcast broadcast_selectors
+  else (
+    let targets =
+      tokens
+      |> List.filter_map (fun token ->
+        if
+          String.length token >= 2
+          && token.[0] = '@'
+          && not (String.starts_with ~prefix:"@@" token)
+        then
+          Keeper_identity.Keeper_id.of_string
+            (String.sub token 1 (String.length token - 1))
+        else None)
+      |> List.sort_uniq Keeper_identity.Keeper_id.compare
+    in
+    match targets with
+    | [] -> No_explicit_address
+    | _ :: _ -> Targets targets)
+;;
+
+let mention_ids_of_content content =
+  match explicit_address_of_content content with
+  | Targets targets -> targets
+  | No_explicit_address | Broadcast_all | Unsupported_broadcast _ -> []
 ;;
 
 let target_ids_of (targets : string list) :

--- a/lib/keeper/keeper_lane_mentions.ml
+++ b/lib/keeper/keeper_lane_mentions.ml
@@ -50,6 +50,13 @@ type explicit_address =
 
 let explicit_address_of_content content =
   let tokens = normalized_tokens content in
+  (* Broadcast selectors win over direct targets: a line that mixes valid
+     [@keeper] targets with any [@@] selector is treated as a broadcast
+     address, never as a partial direct address.  When the selector is not
+     [@@all] the result is [Unsupported_broadcast] and the caller fails
+     closed, dropping the whole signal — the otherwise-valid direct targets
+     are deliberately NOT routed, because partially routing an ambiguous
+     address would silently reinterpret the author's intent. *)
   let broadcast_selectors =
     tokens
     |> List.filter_map (fun token ->

--- a/lib/keeper/keeper_lane_mentions.mli
+++ b/lib/keeper/keeper_lane_mentions.mli
@@ -21,6 +21,22 @@ val mention_ids_of_content : string -> Keeper_identity.Keeper_id.t list
 (** Every ["@name"] token of the content, edge-trimmed, minted to a
     canonical id, deduplicated.  [[]] when the line mentions nobody. *)
 
+type explicit_address =
+  | No_explicit_address
+  | Targets of Keeper_identity.Keeper_id.t list
+  | Broadcast_all
+  | Unsupported_broadcast of string list
+(** Closed write-boundary interpretation of address tokens. [@@all] is the
+    only Keeper-wide broadcast selector. Other [@@name] forms belong to the
+    generic workspace agent-type router, whose type catalog is not a Keeper
+    routing authority; they are retained as an explicit error instead of
+    being downgraded to ambient content. *)
+
+val explicit_address_of_content : string -> explicit_address
+(** Parse the exact whitespace-token contract once. Broadcast takes
+    precedence over direct targets, matching the existing workspace mention
+    grammar. Unsupported broadcast selectors fail closed at the caller. *)
+
 val target_ids_of : string list -> Keeper_identity.Keeper_id.t list
 (** Mint a keeper's mention-target names (e.g.
     [message_feed_targets meta]) into comparable ids. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -460,22 +460,6 @@ let wakeup_running_exact ~intent (expected : registry_entry) =
           | Deferred_lifecycle denial -> Exact_wake_lifecycle_denied denial)))
 ;;
 
-let wakeup_all ~intent ?base_path () =
-  let base_path = Option.map canonical_base_path_exn base_path in
-  StringMap.iter
-    (fun _k entry ->
-       match base_path with
-       | Some expected when not (String.equal expected entry.base_path) -> ()
-       | _ ->
-         if entry.phase = Running
-         then
-           let (_ : wakeup_outcome) =
-             wakeup_running_entry ~intent entry
-           in
-           ())
-    (Atomic.get registry)
-;;
-
 let fiber_health_of ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> Fiber_unknown

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -492,9 +492,6 @@ val wakeup_running_exact :
     ownership check and signal are serialized with lifecycle transactions for
     this Keeper key; an unowned wake returns [Exact_wake_lifecycle_reserved]. *)
 
-(** Set fiber_wakeup for all running keepers. *)
-val wakeup_all : intent:wakeup_intent -> ?base_path:string -> unit -> unit
-
 (** Fiber-level health based on Promise resolution state.
     Returns Fiber_unknown if the keeper is not registered. *)
 val fiber_health_of : base_path:string -> string -> fiber_health

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -148,6 +148,7 @@ type keeper_cycle_decision =
   }
 
 module Board_signal = Keeper_world_observation_board_signal
+module Board_audience = Keeper_board_audience
 
 type board_signal_match = Board_signal.match_result =
   { explicit_mention : bool
@@ -166,7 +167,6 @@ let count_running_keeper_fibers = Inputs.count_running_keeper_fibers
 let compute_idle_seconds = Inputs.compute_idle_seconds
 let board_signal_match = Board_signal.match_signal
 let check_self_comment_status = Board_signal.check_self_comment_status
-let board_signal_wake_reason = Board_signal.wake_reason
 let compare_board_cursor_token = Board_signal.compare_cursor_token
 let board_cursor_token_of_post = Board_signal.cursor_token_of_post
 let list_board_posts_after_cursor = Board_signal.list_posts_after_cursor
@@ -864,59 +864,94 @@ let collect_board_events_with_cursor_policy
              }
            in
            let matched = board_signal_match ~meta ~signal in
-           if not matched.explicit_mention
-           then
-             (* Only the live Keeper collector owns durable candidate
-                production. Dashboard prompt preview uses
-                [advance_cursor:false] and must remain a read-only projection:
-                observing the page cannot schedule a model judgment or wake a
-                Keeper lane. *)
-             if not advance_cursor
-             then consume_posts (Some next_cursor) acc rest
-             else (
-               match
-                 Keeper_board_attention_candidate.of_board_signal
-                   ~meta
-                   ~recorded_at:(Time_compat.now ())
-                   signal
-               with
+           (match Board_audience.classify ~visibility:p.visibility signal with
+            | Error error ->
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string ObservationQueryFailures)
+                ~labels:
+                  [ ( "operation"
+                    , Runtime_observation_query_operation.(to_label Board_events) )
+                  ]
+                ();
+              Log.Keeper.warn
+                "board replay audience rejected: keeper=%s post=%s error=%s"
+                meta.name
+                post_id
+                (Board_audience.classification_error_to_string error);
+              consume_posts (Some next_cursor) acc rest
+            | Ok audience ->
+              (match Board_audience.route_for_keeper ~audience ~meta ~signal with
                | Board_signal.Unavailable unavailable ->
-                 (match log_and_count_unavailable ~context:"candidate" unavailable with
-                  | Board_signal.Permanent -> consume_posts (Some next_cursor) acc rest
-                  | Board_signal.Transient -> List.rev acc, last_cursor)
-               | Board_signal.Available candidate ->
                  (match
-                    Keeper_board_attention_candidate.record_and_wake
-                      ~base_path
-                      candidate
+                    log_and_count_unavailable ~context:"audience" unavailable
                   with
-                  | Ok _ -> ()
-                  | Error detail ->
-                    raise
-                      (Keeper_board_attention_candidate.Candidate_unavailable
-                         detail));
-                 consume_posts (Some next_cursor) acc rest)
-           else
-             consume_posts
-               
-               (Some next_cursor)
-               ({ event_kind = Board_post_created
-                ; post_id
-                ; author = Board.Agent_id.to_string p.author
-                ; title = p.title
-                ; preview = short_preview ~max_len:80 p.content
-                ; hearth = p.hearth
-                ; post_kind = p.post_kind
-                ; updated_at = p.updated_at
-                ; explicit_mention = matched.explicit_mention
-                ; matched_targets = matched.matched_targets
-                ; self_commented = false
-                ; new_external_since = 0
-                ; latest_external_author = None
-                ; latest_external_preview = None
-                }
-                :: acc)
-               rest
+                  | Board_signal.Permanent ->
+                    consume_posts (Some next_cursor) acc rest
+                  | Board_signal.Transient -> List.rev acc, last_cursor)
+               | Board_signal.Available Board_audience.Ignore ->
+                 consume_posts (Some next_cursor) acc rest
+               | Board_signal.Available Board_audience.Judge_discoverable ->
+                 (* Only the live Keeper collector owns durable candidate
+                    production. Dashboard prompt preview uses
+                    [advance_cursor:false] and must remain a read-only projection:
+                    observing the page cannot schedule a model judgment or wake a
+                    Keeper lane. *)
+                 if not advance_cursor
+                 then consume_posts (Some next_cursor) acc rest
+                 else (
+                   match
+                     Keeper_board_attention_candidate.of_board_signal
+                       ~meta
+                       ~recorded_at:(Time_compat.now ())
+                       signal
+                   with
+                   | Board_signal.Unavailable unavailable ->
+                     (match
+                        log_and_count_unavailable ~context:"candidate" unavailable
+                      with
+                      | Board_signal.Permanent ->
+                        consume_posts (Some next_cursor) acc rest
+                      | Board_signal.Transient -> List.rev acc, last_cursor)
+                   | Board_signal.Available candidate ->
+                     (match
+                        Keeper_board_attention_candidate.record_and_wake
+                          ~base_path
+                          candidate
+                      with
+                      | Ok _ -> ()
+                      | Error detail ->
+                        raise
+                          (Keeper_board_attention_candidate.Candidate_unavailable
+                             detail));
+                     consume_posts (Some next_cursor) acc rest)
+               | Board_signal.Available (Board_audience.Deliver _) ->
+                 (* [explicit_mention] mirrors mention parsing only:
+                    Broadcast-routed deliveries (e.g. [@@all]) record
+                    [false] because a broadcast has no per-keeper mention
+                    target. The event's presence in this Deliver branch
+                    already marks it as addressed; downstream
+                    ([Keeper_unified_prompt.format_board_event_text])
+                    uses the field solely to render a "[mentions ...]"
+                    note. *)
+                 consume_posts
+                   (Some next_cursor)
+                   ({ event_kind = Board_post_created
+                    ; post_id
+                    ; author = Board.Agent_id.to_string p.author
+                    ; title = p.title
+                    ; preview = short_preview ~max_len:80 p.content
+                    ; hearth = p.hearth
+                    ; post_kind = p.post_kind
+                    ; updated_at = p.updated_at
+                    ; explicit_mention = matched.explicit_mention
+                    ; matched_targets = matched.matched_targets
+                    ; self_commented = false
+                    ; new_external_since = 0
+                    ; latest_external_author = None
+                    ; latest_external_preview = None
+                    }
+                    :: acc)
+                   rest))
          | Board_signal.Available (`New_external (count, ext_author, ext_preview)) ->
            (
              let signal : Board_dispatch.board_signal =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -226,12 +226,6 @@ val board_signal_match :
   signal:Board_dispatch.board_signal ->
   board_signal_match
 
-val board_signal_wake_reason :
-  meta:Keeper_meta_contract.keeper_meta ->
-  signal:Board_dispatch.board_signal ->
-  Keeper_world_observation_board_signal.wake_reason option
-  Keeper_world_observation_board_signal.board_read
-
 (** RFC-0266: build the actionable [pending_board_event] for a completed async
     [masc_fusion] deliberation. Surfaces the sink's board result as a just-arrived
     event so the woken turn can inspect it as neutral Board context.

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -211,12 +211,19 @@ let text (signal : Board_dispatch.board_signal) =
        ])
 ;;
 
+let address_text (signal : Board_dispatch.board_signal) =
+  match signal.kind with
+  | Board_dispatch.Board_post_created -> text signal
+  | Board_dispatch.Board_comment_added -> signal.content
+  | Board_dispatch.Board_reaction_changed _ -> ""
+;;
+
 let mention_ids_of_signal signal =
   (* Board dispatch still carries textual Board content. Convert that boundary
      payload exactly once into canonical Keeper ids and compare only those typed
      identities below. This deliberately replaces substring matching; tokens
      such as [@foo-extra] and [email@foo.example] cannot address [foo]. *)
-  Keeper_lane_mentions.mention_ids_of_content (text signal)
+  Keeper_lane_mentions.mention_ids_of_content (address_text signal)
 ;;
 
 let match_signal
@@ -313,6 +320,9 @@ let check_self_comment_status ~self_ids ~(post_id : string) : comment_status =
 type wake_reason =
   | Explicit_mention
       (** The signal mentions one of the keeper's identity targets. *)
+  | Broadcast
+      (** The exact [@@all] Keeper Board address selected every non-author
+          lane. *)
   | Thread_reply_after_self_comment
       (** A new external comment arrived on a post the keeper had commented on. *)
   | Reaction_after_self_activity
@@ -321,6 +331,7 @@ type wake_reason =
 
 let wake_reason_label = function
   | Explicit_mention -> "explicit_mention"
+  | Broadcast -> "broadcast"
   | Thread_reply_after_self_comment -> "thread_reply_after_self_comment"
   | Reaction_after_self_activity -> "reaction_after_self_activity"
 ;;

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -63,6 +63,11 @@ val compare_cursor_token : float * string -> float * string -> int
 val cursor_token_of_post : Board.post -> float * string
 val list_posts_after_cursor : float * string option -> Board.post list
 val text : Board_dispatch.board_signal -> string
+val address_text : Board_dispatch.board_signal -> string
+(** Text authored by the current signal producer and therefore allowed to
+    carry addressing authority. A post uses its title/content/hearth, a
+    comment uses only the new comment body, and a reaction carries no textual
+    address. Inherited post display fields never re-address later events. *)
 val mention_ids_of_signal : Board_dispatch.board_signal -> Keeper_identity.Keeper_id.t list
 
 val match_signal
@@ -77,6 +82,7 @@ val check_self_comment_status
 
 type wake_reason =
   | Explicit_mention
+  | Broadcast
   | Thread_reply_after_self_comment
   | Reaction_after_self_activity
 (** Closed set of reasons a keeper wakes for a board signal (RFC-0020).

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -74,6 +74,8 @@ type t =
   | CrashPersistenceFailures
   | GenerationLineageFailures
   | KeepaliveSignalFailures
+  | BoardSignalRoutedTotal
+  | BoardSignalDeliveryTotal
   | BoardSignalNoWakeTotal
   | BoardSignalAttentionCandidateTotal
   | MetaJsonFailures
@@ -292,6 +294,8 @@ let to_string = function
   | CrashPersistenceFailures -> "masc_keeper_crash_persistence_failures_total"
   | GenerationLineageFailures -> "masc_keeper_generation_lineage_failures_total"
   | KeepaliveSignalFailures -> "masc_keeper_keepalive_signal_failures_total"
+  | BoardSignalRoutedTotal -> "masc_keeper_board_signal_routed_total"
+  | BoardSignalDeliveryTotal -> "masc_keeper_board_signal_delivery_total"
   | BoardSignalNoWakeTotal -> "masc_keeper_board_signal_no_wake_total"
   | BoardSignalAttentionCandidateTotal ->
     "masc_keeper_board_signal_attention_candidate_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -65,6 +65,8 @@ type t =
   | CrashPersistenceFailures
   | GenerationLineageFailures
   | KeepaliveSignalFailures
+  | BoardSignalRoutedTotal
+  | BoardSignalDeliveryTotal
   | BoardSignalNoWakeTotal
   | BoardSignalAttentionCandidateTotal
   | MetaJsonFailures

--- a/lib/otel_metric_store/otel_metric_names.mli
+++ b/lib/otel_metric_store/otel_metric_names.mli
@@ -203,12 +203,14 @@ val metric_tool_keeper_cache_ttl_parse_failures : string
 val metric_write_meta_cas_retry_total : string
 
 (** Total board signals that did not produce a wake decision for a
-    running keeper. Increments per (keeper, kind) when
-    [Keeper_world_observation.board_signal_wake_reason] returns
-    [None] — no explicit_mention, scope feed disabled, and no
-    external reply after a self-comment. Discoverability for the
-    REPO_WAKE_UP audit finding: keepers with narrow mention targets
-    can silently drop board posts. Labels: keeper, kind=post_created|comment_added. *)
+    running keeper ([masc_keeper_board_signal_no_wake_total]).
+    Increments per (keeper, kind, audience) when typed-audience routing
+    ([Keeper_board_audience.route_for_keeper]) returns [Ignore], or
+    [Judge_discoverable] — the latter issues no wake and records a board
+    attention candidate instead, so the [audience] label distinguishes
+    the two. Discoverability for the REPO_WAKE_UP audit finding:
+    keepers with narrow mention targets can silently drop board posts.
+    Labels: keeper, kind=post_created|comment_added, audience. *)
 
 val metric_cache_desync_cleared : string
 

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -377,6 +377,20 @@ let test_closed_board_audience_routes_only_its_authority () =
   check bool "Direct without targets fails closed" true
     (match KBA.classify ~visibility:Board.Direct discoverable with
      | Error (KBA.Direct_without_targets "post-audience") -> true
+     | Error _ | Ok _ -> false);
+  let mixed = audience_signal ~author:"external-author" "@alpha @@analyst inspect" in
+  check bool "mixed direct target and unsupported selector fails closed" true
+    (match KBA.classify ~visibility:Board.Internal mixed with
+     | Error (KBA.Unsupported_broadcast [ "analyst" ]) -> true
+     | Error _ | Ok _ -> false);
+  let direct_broadcast = audience_signal ~author:"external-author" "@@all inspect" in
+  check bool "@@all on a Direct post fails closed" true
+    (match KBA.classify ~visibility:Board.Direct direct_broadcast with
+     | Error (KBA.Broadcast_on_direct "post-audience") -> true
+     | Error _ | Ok _ -> false);
+  check bool "@@all on a non-Direct post still broadcasts" true
+    (match KBA.classify ~visibility:Board.Internal direct_broadcast with
+     | Ok KBA.Broadcast -> true
      | Error _ | Ok _ -> false)
 
 let persist_and_register_board_lane config meta =
@@ -467,6 +481,42 @@ let test_exact_mentions_deliver_and_wake_each_lane_independently () =
                 (Atomic.get entry.fiber_wakeup)
             | None -> fail (keeper_name ^ " registry entry missing"))
          [ "alpha"; "beta" ])
+;;
+
+let test_mixed_address_signal_is_dropped_at_routing () =
+  Eio_main.run @@ fun _env ->
+  with_temp_workspace @@ fun config ->
+  Fun.protect
+    ~finally:Keeper_registry.For_testing.clear
+    (fun () ->
+       (* Policy pin (P2-1): a signal mixing a valid [@keeper] target with an
+          unsupported [@@] selector is dropped whole at routing — the valid
+          target is NOT partially routed. *)
+       let alpha = make_board_resume_meta "alpha" in
+       let beta = make_board_resume_meta "beta" in
+       persist_and_register_board_lane config alpha;
+       persist_and_register_board_lane config beta;
+       let signal : Board_dispatch.board_signal =
+         { kind = Board_dispatch.Board_post_created
+         ; post_id = "post-mixed-address"
+         ; author = "external-author"
+         ; title = "mixed address"
+         ; content = "@alpha @@analyst inspect"
+         ; hearth = None
+         ; updated_at = Some 125.0
+         }
+         |> persist_board_signal
+       in
+       KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
+       check int "mixed-address target durable queue" 0
+         (board_queue_length config "alpha");
+       check int "mixed-address non-target durable queue" 0
+         (board_queue_length config "beta");
+       match Keeper_registry.get ~base_path:config.base_path "alpha" with
+       | Some entry ->
+         check bool "mixed-address target not woken" false
+           (Atomic.get entry.fiber_wakeup)
+       | None -> fail "alpha registry entry missing")
 ;;
 
 let test_paused_exact_mention_is_durable_without_wake () =
@@ -611,6 +661,8 @@ let () =
             test_closed_board_audience_routes_only_its_authority
         ; test_case "exact mentions deliver and wake every lane" `Quick
             test_exact_mentions_deliver_and_wake_each_lane_independently
+        ; test_case "mixed address signal is dropped at routing" `Quick
+            test_mixed_address_signal_is_dropped_at_routing
         ; test_case "paused exact mention is durable without wake" `Quick
             test_paused_exact_mention_is_durable_without_wake
         ; test_case "Restarting exact mention is durable with deferred wake" `Quick

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -20,9 +20,14 @@ let with_temp_workspace f =
   let base_path = Filename.temp_dir "keeper-heartbeat-current-task" "" in
   let config = Workspace.default_config base_path in
   Fun.protect
-    ~finally:(fun () -> rm_rf base_path)
+    ~finally:(fun () ->
+      Board_dispatch.reset_for_test ();
+      Board.reset_global_for_test ();
+      rm_rf base_path)
     (fun () ->
       ignore (Workspace.init config ~agent_name:None : string);
+      Board_dispatch.reset_for_test ();
+      Board.reset_global_for_test ();
       f config)
 
 let make_keepalive_meta ~name ~agent_name =
@@ -175,6 +180,8 @@ let test_not_in_registry_warn_state_is_bounded () =
 
 module KKS = Masc.Keeper_keepalive_signal
 module KWOBS = Masc.Keeper_world_observation_board_signal
+module KBA = Masc.Keeper_board_audience
+module KBAC = Masc.Keeper_board_attention_candidate
 
 let make_board_resume_meta name =
   let json =
@@ -265,6 +272,113 @@ let test_board_mentions_use_exact_typed_keeper_ids () =
   check_exact_board_mention ~content:"@foobar is a different lane" ~expected:false;
   check_exact_board_mention ~content:"mail foo@example.com" ~expected:false
 
+let audience_signal ?(kind = Board_dispatch.Board_post_created) ~author content :
+  Board_dispatch.board_signal
+  =
+  { kind
+  ; post_id = "post-audience"
+  ; author
+  ; title = "audience"
+  ; content
+  ; hearth = None
+  ; updated_at = Some 123.0
+  }
+;;
+
+let classified ?(visibility = Board.Internal) signal =
+  match KBA.classify ~visibility signal with
+  | Ok audience -> audience
+  | Error error -> fail (KBA.classification_error_to_string error)
+;;
+
+let route ~audience ~meta signal =
+  match KBA.route_for_keeper ~audience ~meta ~signal with
+  | KWOBS.Available route -> route
+  | KWOBS.Unavailable unavailable ->
+    fail (KWOBS.unavailable_to_string unavailable)
+;;
+
+let test_closed_board_audience_routes_only_its_authority () =
+  let alpha = make_board_resume_meta "alpha" in
+  let beta = make_board_resume_meta "beta" in
+  let targeted = audience_signal ~author:"external-author" "@alpha inspect" in
+  let targeted_audience = classified targeted in
+  check bool "explicit address classifies as Targets" true
+    (match targeted_audience with KBA.Targets _ -> true | _ -> false);
+  check bool "target receives direct delivery" true
+    (match route ~audience:targeted_audience ~meta:alpha targeted with
+     | KBA.Deliver KWOBS.Explicit_mention -> true
+     | KBA.Deliver _ | KBA.Judge_discoverable | KBA.Ignore -> false);
+  check bool "non-target is retired, not judged" true
+    (match route ~audience:targeted_audience ~meta:beta targeted with
+     | KBA.Ignore -> true
+     | KBA.Deliver _ | KBA.Judge_discoverable -> false);
+  let discoverable = audience_signal ~author:"external-author" "new research" in
+  let discoverable_audience = classified discoverable in
+  check bool "new unaddressed post is discoverable" true
+    (match discoverable_audience with KBA.Discoverable -> true | _ -> false);
+  check bool "discoverable enters judgment only for non-author" true
+    (match route ~audience:discoverable_audience ~meta:alpha discoverable with
+     | KBA.Judge_discoverable -> true
+     | KBA.Deliver _ | KBA.Ignore -> false);
+  let self_authored = audience_signal ~author:"keeper-alpha" "new research" in
+  check bool "author lane never judges its own post" true
+    (match route ~audience:(classified self_authored) ~meta:alpha self_authored with
+     | KBA.Ignore -> true
+     | KBA.Deliver _ | KBA.Judge_discoverable -> false);
+  let broadcast = audience_signal ~author:"external-author" "@@all inspect" in
+  check bool "exact Keeper broadcast is direct delivery" true
+    (match route ~audience:(classified broadcast) ~meta:beta broadcast with
+     | KBA.Deliver KWOBS.Broadcast -> true
+     | KBA.Deliver _ | KBA.Judge_discoverable | KBA.Ignore -> false);
+  let comment =
+    audience_signal
+      ~kind:Board_dispatch.Board_comment_added
+      ~author:"external-author"
+      "thread update"
+  in
+  check bool "unaddressed comment is thread-scoped" true
+    (match classified comment with KBA.Thread_participants -> true | _ -> false);
+  check bool "Direct thread follow-up stays participant-scoped" true
+    (match classified ~visibility:Board.Direct comment with
+     | KBA.Thread_participants -> true
+     | _ -> false);
+  let inherited_title =
+    { comment with title = "original post for @alpha"; content = "plain follow-up" }
+  in
+  check bool "inherited post title cannot re-address a comment" true
+    (match classified inherited_title with
+     | KBA.Thread_participants -> true
+     | _ -> false);
+  check bool "structural matcher ignores inherited title address" false
+    (KWOBS.match_signal ~meta:alpha ~signal:inherited_title).explicit_mention;
+  let inherited_reaction =
+    audience_signal
+      ~kind:
+        (Board_dispatch.Board_reaction_changed
+           { target_type = Board.Reaction_post
+           ; target_id = "post-audience"
+           ; user_id = "external-author"
+           ; emoji = "eyes"
+           ; reacted = true
+           })
+      ~author:"external-author"
+      "original post body for @alpha"
+  in
+  check bool "inherited post body cannot re-address a reaction" true
+    (match classified inherited_reaction with
+     | KBA.Thread_participants -> true
+     | _ -> false);
+  let unsupported = audience_signal ~author:"external-author" "@@analyst inspect" in
+  check bool "unsupported broadcast fails closed" true
+    (match KBA.classify ~visibility:Board.Internal unsupported with
+     | Error (KBA.Unsupported_broadcast [ "analyst" ]) -> true
+     | Error _ | Ok _ -> false);
+  check bool "Direct without targets fails closed" true
+    (match KBA.classify ~visibility:Board.Direct discoverable with
+     | Error (KBA.Direct_without_targets "post-audience") -> true
+     | Error _ | Ok _ -> false)
+
 let persist_and_register_board_lane config meta =
   (match Keeper_meta_store.write_meta config meta with
    | Ok () -> ()
@@ -283,6 +397,32 @@ let board_queue_length config keeper_name =
   |> Keeper_event_queue.length
 ;;
 
+let board_attention_count config keeper_name =
+  match
+    KBAC.load_candidates
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+  with
+  | Ok candidates -> List.length candidates
+  | Error detail -> fail ("load_candidates failed: " ^ detail)
+;;
+
+let persist_board_signal (signal : Board_dispatch.board_signal) =
+  match
+    Board_dispatch.create_post
+      ~author:signal.author
+      ~content:signal.content
+      ~title:signal.title
+      ~post_kind:Board.Human_post
+      ~visibility:Board.Internal
+      ?hearth:signal.hearth
+      ()
+  with
+  | Error error -> fail (Board.show_board_error error)
+  | Ok post ->
+    { signal with post_id = Board.Post_id.to_string post.id }
+;;
+
 let overwrite_file path contents =
   let channel = open_out_bin path in
   Fun.protect
@@ -291,14 +431,17 @@ let overwrite_file path contents =
 ;;
 
 let test_exact_mentions_deliver_and_wake_each_lane_independently () =
+  Eio_main.run @@ fun _env ->
   with_temp_workspace @@ fun config ->
   Fun.protect
     ~finally:Keeper_registry.For_testing.clear
     (fun () ->
        let alpha = make_board_resume_meta "alpha" in
        let beta = make_board_resume_meta "beta" in
+       let gamma = make_board_resume_meta "gamma" in
        persist_and_register_board_lane config alpha;
        persist_and_register_board_lane config beta;
+       persist_and_register_board_lane config gamma;
        let signal : Board_dispatch.board_signal =
          { kind = Board_dispatch.Board_post_created
          ; post_id = "post-multi-lane"
@@ -308,10 +451,14 @@ let test_exact_mentions_deliver_and_wake_each_lane_independently () =
          ; hearth = None
          ; updated_at = Some 123.0
          }
+         |> persist_board_signal
        in
        KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
        check int "alpha durable queue" 1 (board_queue_length config "alpha");
        check int "beta durable queue" 1 (board_queue_length config "beta");
+       check int "non-target durable queue" 0 (board_queue_length config "gamma");
+       check int "non-target attention fan-out" 0
+         (board_attention_count config "gamma");
        List.iter
          (fun keeper_name ->
             match Keeper_registry.get ~base_path:config.base_path keeper_name with
@@ -323,6 +470,7 @@ let test_exact_mentions_deliver_and_wake_each_lane_independently () =
 ;;
 
 let test_paused_exact_mention_is_durable_without_wake () =
+  Eio_main.run @@ fun _env ->
   with_temp_workspace @@ fun config ->
   Fun.protect
     ~finally:Keeper_registry.For_testing.clear
@@ -346,6 +494,7 @@ let test_paused_exact_mention_is_durable_without_wake () =
          ; hearth = None
          ; updated_at = Some 124.0
          }
+         |> persist_board_signal
        in
        KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
        check int "paused durable queue" 1 (board_queue_length config meta.name);
@@ -357,6 +506,7 @@ let test_paused_exact_mention_is_durable_without_wake () =
 ;;
 
 let test_restarting_exact_mention_is_durable_with_deferred_wake () =
+  Eio_main.run @@ fun _env ->
   with_temp_workspace @@ fun config ->
   Fun.protect
     ~finally:Keeper_registry.For_testing.clear
@@ -382,6 +532,7 @@ let test_restarting_exact_mention_is_durable_with_deferred_wake () =
          ; hearth = None
          ; updated_at = Some 124.5
          }
+         |> persist_board_signal
        in
        KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
        check int "Restarting durable queue" 1
@@ -394,6 +545,7 @@ let test_restarting_exact_mention_is_durable_with_deferred_wake () =
 ;;
 
 let test_lane_meta_failure_does_not_block_next_durable_delivery () =
+  Eio_main.run @@ fun _env ->
   with_temp_workspace @@ fun config ->
   Fun.protect
     ~finally:Keeper_registry.For_testing.clear
@@ -418,6 +570,7 @@ let test_lane_meta_failure_does_not_block_next_durable_delivery () =
          ; hearth = None
          ; updated_at = Some 125.0
          }
+         |> persist_board_signal
        in
        KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
        check int "unreadable lane has no queued signal" 0
@@ -454,6 +607,8 @@ let () =
             test_board_goal_keyword_overlap_is_not_wake_reason
         ; test_case "mentions use exact typed Keeper ids" `Quick
             test_board_mentions_use_exact_typed_keeper_ids
+        ; test_case "closed audience routes only its authority" `Quick
+            test_closed_board_audience_routes_only_its_authority
         ; test_case "exact mentions deliver and wake every lane" `Quick
             test_exact_mentions_deliver_and_wake_each_lane_independently
         ; test_case "paused exact mention is durable without wake" `Quick

--- a/test/test_keeper_lane_mentions.ml
+++ b/test/test_keeper_lane_mentions.ml
@@ -48,6 +48,36 @@ let test_parser_goldens () =
      token and never reaches "sangsu"; same as the legacy tokenizer. *)
   check ids "possessive stays distinct" [ "sangsu's" ] (parse "@sangsu's note")
 
+let test_explicit_address_is_closed () =
+  let check_address label expected content =
+    let actual =
+      match Lane.explicit_address_of_content content with
+      | Lane.No_explicit_address -> "none"
+      | Lane.Broadcast_all -> "broadcast"
+      | Lane.Targets targets ->
+        "targets:" ^ String.concat "," (List.map Kid.to_string targets)
+      | Lane.Unsupported_broadcast selectors ->
+        "unsupported:" ^ String.concat "," selectors
+    in
+    check string label expected actual
+  in
+  check_address "unaddressed" "none" "plain Board update";
+  check_address "targets" "targets:alpha,beta" "@beta and @alpha";
+  check_address "exact broadcast" "broadcast" "release note @@all";
+  check_address
+    "generic agent-type broadcast is not Keeper authority"
+    "unsupported:analyst"
+    "release note @@analyst";
+  check_address "empty broadcast selector fails closed" "unsupported:" "release @@";
+  check_address
+    "mixed valid and unsupported broadcast fails closed"
+    "unsupported:all,analyst"
+    "@@all @@analyst";
+  check_address
+    "broadcast precedence"
+    "broadcast"
+    "@@all and @alpha"
+
 (* ── 2. Legacy decision equivalence ── *)
 
 (* Verbatim replica of the deleted read-time tokenizer + decision. *)
@@ -267,7 +297,11 @@ let () =
   Random.self_init ();
   run "keeper_lane_mentions"
     [
-      ("parser", [ test_case "goldens" `Quick test_parser_goldens ]);
+      ( "parser",
+        [ test_case "goldens" `Quick test_parser_goldens;
+          test_case "closed explicit address" `Quick
+            test_explicit_address_is_closed;
+        ] );
       ( "legacy_equivalence",
         [ test_case "corpus matrix" `Quick test_legacy_equivalence ] );
       ( "store_roundtrip",


### PR DESCRIPTION
## Summary

- add the closed Keeper Board audience authority: `Targets | Broadcast | Thread_participants | Discoverable`
- retire non-target lanes before candidate creation; only `Discoverable` enters the attention judge
- preserve the same authority in live hook delivery and Board cursor replay
- reject unsupported `@@type` broadcasts and `Direct` posts without targets explicitly
- prevent inherited post title/body mentions from re-addressing later comments or reactions
- remove the inert fleet-wide wake API; broadcast now durably admits each independent lane
- expose routed/delivered/candidate counters by typed audience

Stacked on #25377. Refs #23925 item 60.

## Focused verification

- `test_keeper_lane_mentions`: 8/8
- `test_keeper_keepalive_helpers`: 15/15
- `test_keeper_board_attention_candidate`: 5/5
- `test_keeper_board_attention_failure`: 5/5
- `test_keeper_board_attention_partition`: 5/5
- `test_keeper_board_attention_worker`: 8/8
- `test_keeper_runtime_failure_route`: 14/14
- `test_keeper_registry_hardening`: 17/17

Total: 77/77 focused tests.

Local focused builds used `scripts/dune-local.sh`; full build/test remains CI authority. The initial wrapper pin guard reported the machine-wide OAS pin at `64525619...` while this stack expects `9d8c54b...`; verification used the wrapper-provided `MASC_SKIP_PIN_CHECK=1` without mutating the global pin.