### PR TITLE
refactor(board): fix audience at write boundary

### DIFF
--- a/lib/board/board.ml
+++ b/lib/board/board.ml
@@ -1,1 +1,7 @@
 include Board_votes
+
+let audience_for_post = Board_audience.audience_for_post
+let audience_for_comment = Board_audience.audience_for_comment
+let audience_for_reaction = Board_audience.audience_for_reaction
+let audience_label = Board_audience.audience_label
+let direct_targets_of_text = Board_audience.direct_targets_of_text

--- a/lib/board/board.mli
+++ b/lib/board/board.mli
@@ -22,3 +22,14 @@
 include module type of struct
   include Board_votes
 end
+
+val audience_for_post
+  :  visibility:visibility
+  -> title:string
+  -> content:string
+  -> (audience, board_error) result
+
+val audience_for_comment : content:string -> (audience, board_error) result
+val audience_for_reaction : audience
+val audience_label : audience -> string
+val direct_targets_of_text : string -> Agent_id.t list

--- a/lib/board/board_audience.ml
+++ b/lib/board/board_audience.ml
@@ -1,0 +1,147 @@
+include Board_types
+
+let trim_token_edges value =
+  let is_word = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '@' | '_' | '-' -> true
+    | _ -> false
+  in
+  let length = String.length value in
+  let first = ref 0 in
+  let last = ref (length - 1) in
+  while !first < length && not (is_word value.[!first]) do
+    incr first
+  done;
+  while !last >= !first && not (is_word value.[!last]) do
+    decr last
+  done;
+  if !last < !first then "" else String.sub value !first (!last - !first + 1)
+;;
+
+let normalized_tokens content =
+  content
+  |> String.map (function
+    | '\t' | '\n' | '\r' -> ' '
+    | character -> character)
+  |> String.split_on_char ' '
+  |> List.map trim_token_edges
+  |> List.filter (fun token -> not (String.equal token ""))
+;;
+
+type explicit_address =
+  | No_explicit_address
+  | Explicit_targets of Agent_id.t list
+  | Broadcast_all
+  | Unsupported_broadcast of string list
+  | Malformed_targets of string list
+
+let compare_agent_id left right =
+  String.compare (Agent_id.to_string left) (Agent_id.to_string right)
+;;
+
+let explicit_address_of_text content =
+  let tokens = normalized_tokens content in
+  let selectors =
+    tokens
+    |> List.filter_map (fun token ->
+      if String.length token >= 2 && String.starts_with ~prefix:"@@" token
+      then
+        Some
+          (String.sub token 2 (String.length token - 2)
+           |> String.lowercase_ascii)
+      else None)
+    |> List.sort_uniq String.compare
+  in
+  if selectors <> [] && List.for_all (String.equal "all") selectors
+  then Broadcast_all
+  else if selectors <> []
+  then Unsupported_broadcast selectors
+  else (
+    let targets, malformed =
+      List.fold_left
+        (fun (targets, malformed) token ->
+          if Char.equal token.[0] '@'
+             && not (String.starts_with ~prefix:"@@" token)
+          then
+            let candidate = String.sub token 1 (String.length token - 1) in
+            match Agent_id.of_string candidate with
+            | Ok target -> target :: targets, malformed
+            | Error _ -> targets, token :: malformed
+          else targets, malformed)
+        ([], [])
+        tokens
+    in
+    match List.sort_uniq String.compare malformed with
+    | _ :: _ as malformed -> Malformed_targets malformed
+    | [] ->
+      (match List.sort_uniq compare_agent_id targets with
+       | [] -> No_explicit_address
+       | _ :: _ as targets -> Explicit_targets targets))
+;;
+
+let direct_targets_of_text content =
+  match explicit_address_of_text content with
+  | Explicit_targets targets -> targets
+  | ( No_explicit_address
+    | Broadcast_all
+    | Unsupported_broadcast _
+    | Malformed_targets _ ) -> []
+;;
+
+let address_text ~title ~content =
+  String.concat
+    "\n"
+    (List.filter
+       (fun value -> not (String.equal (String.trim value) ""))
+       [ title; content ])
+;;
+
+let unsupported_broadcast_error selectors =
+  Validation_error
+    (Printf.sprintf
+       "unsupported Board broadcast selector(s): %s"
+       (String.concat ", " (List.map (Printf.sprintf "@@%s") selectors)))
+;;
+
+let malformed_targets_error targets =
+  Validation_error
+    (Printf.sprintf
+       "invalid Board target token(s): %s"
+       (String.concat ", " targets))
+;;
+
+let audience_of_address ~visibility ~unaddressed = function
+  | Explicit_targets targets -> Ok (Targets targets)
+  | Broadcast_all ->
+    (match visibility with
+     | Direct -> Error (Validation_error "Direct Board posts cannot broadcast")
+     | Public | Unlisted | Internal -> Ok Broadcast)
+  | Unsupported_broadcast selectors -> Error (unsupported_broadcast_error selectors)
+  | Malformed_targets targets -> Error (malformed_targets_error targets)
+  | No_explicit_address -> unaddressed ()
+;;
+
+let audience_for_post ~visibility ~title ~content =
+  explicit_address_of_text (address_text ~title ~content)
+  |> audience_of_address ~visibility ~unaddressed:(fun () ->
+    match visibility with
+    | Direct -> Error (Validation_error "Direct Board posts require explicit targets")
+    | Public | Unlisted | Internal -> Ok Discoverable)
+;;
+
+let audience_for_comment ~content =
+  match explicit_address_of_text content with
+  | Explicit_targets targets -> Ok (Targets targets)
+  | Broadcast_all -> Ok Broadcast
+  | Unsupported_broadcast selectors -> Error (unsupported_broadcast_error selectors)
+  | Malformed_targets targets -> Error (malformed_targets_error targets)
+  | No_explicit_address -> Ok Thread_participants
+;;
+
+let audience_for_reaction = Thread_participants
+
+let audience_label = function
+  | Targets _ -> "targets"
+  | Broadcast -> "broadcast"
+  | Thread_participants -> "thread_participants"
+  | Discoverable -> "discoverable"
+;;

--- a/lib/board/board_audience.mli
+++ b/lib/board/board_audience.mli
@@ -1,0 +1,26 @@
+(** Exact write-boundary Board audience parser. *)
+
+include module type of struct
+  include Board_types
+end
+
+val direct_targets_of_text : string -> Agent_id.t list
+(** Exact single-at target tokens, canonicalized and deduplicated. Broadcast
+    and unsupported double-at selectors are not direct targets. *)
+
+val audience_for_post
+  :  visibility:visibility
+  -> title:string
+  -> content:string
+  -> (audience, board_error) result
+(** Parse the immutable audience of a new post. A [Direct] post requires exact
+    targets; a targetless or broadcast Direct post is rejected before
+    persistence. Malformed target syntax also fails closed. *)
+
+val audience_for_comment : content:string -> (audience, board_error) result
+(** An unaddressed comment belongs to [Thread_participants]. *)
+
+val audience_for_reaction : audience
+(** Reactions are structural thread activity and carry no textual address. *)
+
+val audience_label : audience -> string

--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -209,7 +209,7 @@ let search_posts store ~predicate ~limit : post list =
 
 (** {1 Comment Operations} *)
 
-let add_comment
+let add_comment_with_audience
       store
       ~post_id
       ~author
@@ -217,7 +217,7 @@ let add_comment
       ?parent_id
       ?(ttl_hours = Limits.default_ttl_hours)
       ()
-  : (comment, board_error) Result.t
+  : (comment_creation, board_error) Result.t
   =
   maybe_sweep store;
   (* Validate all IDs first *)
@@ -243,7 +243,10 @@ let add_comment
           then Error (Validation_error "ttl_hours must be non-negative")
           else if String.length content = 0
           then Error (Validation_error "Content cannot be empty")
-          else (
+          else
+            match Board_audience.audience_for_comment ~content with
+            | Error _ as error -> error
+            | Ok audience ->
             let board_result =
               with_lock store (fun () ->
                 (* Verify post exists *)
@@ -313,11 +316,23 @@ let add_comment
                  with_lock store (fun () ->
                    mark_dirty_post store (Post_id.to_string comment.post_id);
                    mark_dirty_comment store (Comment_id.to_string comment.id));
-                 Ok comment
+                 Ok { comment; audience }
                | Error e ->
                  rollback_fresh_comment store ~comment ~previous_post;
                  Error e)
-            | Error _ as e -> e)))
+            | Error _ as e -> e))
+;;
+
+let add_comment store ~post_id ~author ~content ?parent_id ?ttl_hours () =
+  add_comment_with_audience
+    store
+    ~post_id
+    ~author
+    ~content
+    ?parent_id
+    ?ttl_hours
+    ()
+  |> Result.map (fun creation -> creation.comment)
 ;;
 
 let get_comments store ~post_id : (comment list, board_error) Result.t =

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -264,6 +264,24 @@ val create_post_once_by_fusion_run_id
 (** Exact typed-origin create. Replays return the existing normalized post;
     conflicting payloads return [Already_exists]. *)
 
+val create_post_with_audience
+  :  store
+  -> author:string
+  -> content:string
+  -> ?title:string
+  -> ?body:string
+  -> post_kind:post_kind
+  -> ?meta_json:Yojson.Safe.t
+  -> ?visibility:visibility
+  -> ?ttl_hours:int
+  -> ?hearth:string
+  -> ?thread_id:string
+  -> ?origin:post_origin
+  -> unit
+  -> (post_creation, board_error) Result.t
+(** Create a post only after its routing audience has been validated, and
+    return the exact audience admitted with the write. *)
+
 val get_post : store -> post_id:string -> (post, board_error) Result.t
 
 (** RFC-0233 §7: look up a post by the originating turn's join key
@@ -329,6 +347,18 @@ val add_comment
   -> ?ttl_hours:int
   -> unit
   -> (comment, board_error) Result.t
+
+val add_comment_with_audience
+  :  store
+  -> post_id:string
+  -> author:string
+  -> content:string
+  -> ?parent_id:string
+  -> ?ttl_hours:int
+  -> unit
+  -> (comment_creation, board_error) Result.t
+(** Validate and freeze comment routing before the Board mutation, returning
+    the same audience with the committed comment. *)
 
 (** Returns the comments for [post_id] sorted by
     [created_at] ascending. *)

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -553,7 +553,7 @@ let validate_sub_board_post_policy_unlocked store ~author_id ~hearth =
 ;;
 
 (** {1 Post Operations} *)
-let create_post
+let create_post_with_audience
       store
       ~author
       ~content
@@ -567,7 +567,7 @@ let create_post
   ?thread_id
   ?origin
   ()
-  : (post, board_error) Result.t
+  : (post_creation, board_error) Result.t
   =
   maybe_sweep store;
   match Agent_id.of_string author with
@@ -596,7 +596,15 @@ let create_post
       ->
     if String.length normalized_body = 0
     then Error (Validation_error "Content cannot be empty")
-    else (
+    else
+      match
+        Board_audience.audience_for_post
+          ~visibility
+          ~title:normalized_title
+          ~content:normalized_body
+      with
+      | Error _ as error -> error
+      | Ok audience ->
       let board_result =
         with_lock store (fun () ->
           match validate_sub_board_post_policy_unlocked store ~author_id ~hearth with
@@ -633,11 +641,31 @@ let create_post
       match board_result with
       | Ok post ->
         (match with_persist_lock store (fun () -> append_post post) with
-         | Ok () -> Ok post
+         | Ok () -> Ok { post; audience }
          | Error e ->
            rollback_fresh_post store post;
            Error e)
-      | Error _ as e -> e)
+      | Error _ as e -> e
+;;
+
+let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
+      ?visibility ?ttl_hours ?hearth ?thread_id ?origin ()
+  =
+  create_post_with_audience
+    store
+    ~author
+    ~content
+    ?title
+    ?body
+    ~post_kind
+    ?meta_json
+    ?visibility
+    ?ttl_hours
+    ?hearth
+    ?thread_id
+    ?origin
+    ()
+  |> Result.map (fun creation -> creation.post)
 ;;
 
 type create_post_once_result =

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -113,6 +113,24 @@ val create_post_once_by_fusion_run_id :
     the committed post instead of appending another row. A conflicting replay
     returns [Already_exists]. The regular create path remains unchanged. *)
 
+val create_post_with_audience :
+  store ->
+  author:string ->
+  content:string ->
+  ?title:string ->
+  ?body:string ->
+  post_kind:post_kind ->
+  ?meta_json:Yojson.Safe.t ->
+  ?visibility:visibility ->
+  ?ttl_hours:int ->
+  ?hearth:string ->
+  ?thread_id:string ->
+  ?origin:post_origin ->
+  unit ->
+  (post_creation, board_error) result
+(** Validate and freeze the post audience before mutating or persisting the
+    Board, returning that same authority with the committed post. *)
+
 (** Owner-gated in-place edit of an existing post's title/body.  Returns
     [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
     missing id, and [Validation_error] for empty/oversized content or invalid

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -95,6 +95,11 @@ type board_signal = {
   updated_at : float option;
 }
 
+type addressed_board_signal = {
+  signal : board_signal;
+  audience : Board.audience;
+}
+
 type board_sse_event =
   | Post_created of {
       post_id : string;
@@ -242,7 +247,8 @@ let ensure_flusher_actor store =
       loop flusher_start_cas_retries
 
 
-let board_signal_hook : (board_signal -> unit) option Atomic.t = Atomic.make None
+let board_signal_hook : (addressed_board_signal -> unit) option Atomic.t =
+  Atomic.make None
 
 let set_board_signal_hook hook =
   Atomic.set board_signal_hook (Some hook)
@@ -351,18 +357,20 @@ let matching_post_ids_for_comment_author_filter ~needle (comments : Board.commen
     comments;
   matches
 
-let emit_post_created (post : Board.post) =
+let emit_post_created ~(audience : Board.audience) (post : Board.post) =
   let pid = Board.Post_id.to_string post.id in
   let auth = Board.Agent_id.to_string post.author in
   emit_board_signal
-    {
-      kind = Board_post_created;
-      post_id = pid;
-      author = auth;
-      title = post.title;
-      content = post.content;
-      hearth = post.hearth;
-      updated_at = Some post.updated_at;
+    { signal =
+        { kind = Board_post_created
+        ; post_id = pid
+        ; author = auth
+        ; title = post.title
+        ; content = post.content
+        ; hearth = post.hearth
+        ; updated_at = Some post.updated_at
+        }
+    ; audience
     };
   emit_board_sse_event
     (Post_created
@@ -375,7 +383,7 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
   match backend () with
   | Jsonl store ->
     (match
-       Board.create_post
+       Board.create_post_with_audience
          store
          ~author
          ~content
@@ -390,9 +398,9 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
          ?origin
          ()
      with
-     | Ok post ->
-       emit_post_created post;
-       Ok post
+     | Ok creation ->
+       emit_post_created ~audience:creation.audience creation.post;
+       Ok creation.post
      | Error _ as error -> error)
 
 let create_post_once_by_fusion_run_id ~fusion_run_id ~author ~content ~post_kind
@@ -404,7 +412,20 @@ let create_post_once_by_fusion_run_id ~fusion_run_id ~author ~content ~post_kind
          ~content ~post_kind ?meta_json ~visibility ~ttl_hours ~origin ()
      with
      | Ok (Board.Post_created post as outcome) ->
-       emit_post_created post;
+       (match
+          Board.audience_for_post
+            ~visibility:post.visibility
+            ~title:post.title
+            ~content:post.content
+        with
+        | Ok audience -> emit_post_created ~audience post
+        | Error error ->
+          (* Unreachable: [create_post_once_by_fusion_run_id] commits through
+             [create_post], which validates this exact audience at the write
+             boundary before persisting. *)
+          Log.BoardLog.error
+            "post-created signal not emitted: audience re-derivation failed: %s"
+            (Board_types.show_board_error error));
        Ok outcome
      | Ok (Board.Post_already_present _ as outcome) -> Ok outcome
      | Error _ as error -> error)
@@ -518,23 +539,26 @@ let add_comment ~post_id ~author ~content ?parent_id
   match backend () with
   | Jsonl store ->
       (match
-         Board.add_comment store ~post_id ~author ~content ?parent_id
+         Board.add_comment_with_audience store ~post_id ~author ~content ?parent_id
            ~ttl_hours ()
        with
-      | Ok comment ->
+      | Ok creation ->
+          let comment = creation.comment in
           let cid = Board.Comment_id.to_string comment.id in
           let auth = Board.Agent_id.to_string comment.author in
           (match Board.get_post store ~post_id with
           | Ok post ->
               emit_board_signal
-                {
-                  kind = Board_comment_added;
-                  post_id;
-                  author = auth;
-                  title = post.title;
-                  content;
-                  hearth = post.hearth;
-                  updated_at = Some post.updated_at;
+                { signal =
+                    { kind = Board_comment_added
+                    ; post_id
+                    ; author = auth
+                    ; title = post.title
+                    ; content
+                    ; hearth = post.hearth
+                    ; updated_at = Some post.updated_at
+                    }
+                ; audience = creation.audience
                 }
           | Error e ->
               Log.BoardLog.warn "board signal skipped: get_post failed for %s: %s"
@@ -609,22 +633,23 @@ let emit_reaction_board_signal store (toggled : Board.reaction_toggle_result) =
   with
   | Ok post ->
       emit_board_signal
-        {
-          kind =
-            Board_reaction_changed
-              {
-                target_type = toggled.target_type;
-                target_id = toggled.target_id;
-                user_id = toggled.user_id;
-                emoji = toggled.emoji;
-                reacted = toggled.reacted;
-              };
-          post_id = Board.Post_id.to_string post.id;
-          author = toggled.user_id;
-          title = post.title;
-          content = post.content;
-          hearth = post.hearth;
-          updated_at = Some post.updated_at;
+        { signal =
+            { kind =
+                Board_reaction_changed
+                  { target_type = toggled.target_type
+                  ; target_id = toggled.target_id
+                  ; user_id = toggled.user_id
+                  ; emoji = toggled.emoji
+                  ; reacted = toggled.reacted
+                  }
+            ; post_id = Board.Post_id.to_string post.id
+            ; author = toggled.user_id
+            ; title = post.title
+            ; content = post.content
+            ; hearth = post.hearth
+            ; updated_at = Some post.updated_at
+            }
+        ; audience = Board.audience_for_reaction
         }
   | Error e ->
       Log.BoardLog.warn

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -56,6 +56,13 @@ type board_signal = {
   updated_at : float option;
 }
 
+type addressed_board_signal = {
+  signal : board_signal;
+  audience : Board.audience;
+}
+(** Signal payload paired with the audience fixed before the originating Board
+    mutation. The hook must consume this authority, not parse mutable text. *)
+
 type board_sse_event =
   | Post_created of {
       post_id : string;
@@ -88,7 +95,7 @@ type board_sse_event =
       reacted : bool;
     }
 
-val set_board_signal_hook : (board_signal -> unit) -> unit
+val set_board_signal_hook : (addressed_board_signal -> unit) -> unit
 (** Replace the in-process hook invoked from {!create_post}, {!add_comment},
     and {!toggle_reaction}. *)
 

--- a/lib/board/dune
+++ b/lib/board/dune
@@ -8,6 +8,7 @@
   board
   board_agent_effect_hooks
   board_attachment_meta
+  board_audience
   board_core
   board_core_classify
   board_core_json

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -126,6 +126,15 @@ type visibility =
   | Internal    (* This MASC instance only *)
   | Direct      (* Mentioned agents only *)
 
+type audience =
+  | Targets of Agent_id.t list
+  | Broadcast
+  | Thread_participants
+  | Discoverable
+(** Closed routing authority for Board mutations. [Targets] contains exact
+    typed Board identities, not Keeper identities; MASC may project those
+    identities into Keeper lanes without making Board depend on Keeper. *)
+
 type post_kind =
   | Human_post [@tla.symbol "human_post"]
   | Automation_post [@tla.symbol "automation_post"]
@@ -192,6 +201,16 @@ type comment = {
   expires_at: float;   (* MANDATORY *)
   votes_up: int;
   votes_down: int;
+}
+
+type post_creation = {
+  post: post;
+  audience: audience;
+}
+
+type comment_creation = {
+  comment: comment;
+  audience: audience;
 }
 
 type reaction_target_type =

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -71,6 +71,14 @@ type visibility =
   | Internal    (** This MASC instance only. *)
   | Direct      (** Mentioned agents only. *)
 
+type audience =
+  | Targets of Agent_id.t list
+  | Broadcast
+  | Thread_participants
+  | Discoverable
+(** Closed Board routing authority. Target identities remain Board-level
+    {!Agent_id.t}; no Keeper dependency crosses into this library. *)
+
 type post_kind =
   | Human_post
   | Automation_post
@@ -130,6 +138,19 @@ type comment = {
   votes_up : int;
   votes_down : int;
 }
+
+type post_creation = {
+  post : post;
+  audience : audience;
+}
+(** Successful post write together with the audience fixed at the same write
+    boundary. Consumers must not re-derive routing from mutable projections. *)
+
+type comment_creation = {
+  comment : comment;
+  audience : audience;
+}
+(** Successful comment write and its write-boundary routing authority. *)
 
 type reaction_target_type =
   | Reaction_post

--- a/lib/keeper/keeper_board_audience.ml
+++ b/lib/keeper/keeper_board_audience.ml
@@ -8,42 +8,53 @@ type t =
   | Discoverable
 
 type classification_error =
-  | Unsupported_broadcast of string list
-  | Direct_without_targets of string
-  | Broadcast_on_direct of string
+  | Invalid_board_audience of Board.board_error
+  | Invalid_board_target of string
 
 type route =
   | Deliver of Board_signal.wake_reason
   | Judge_discoverable
   | Ignore
 
+let keeper_targets_of_board targets =
+  List.fold_left
+    (fun result target ->
+      match result with
+      | Error _ as error -> error
+      | Ok targets ->
+        let raw = Board.Agent_id.to_string target in
+        (match Keeper_identity.Keeper_id.of_string raw with
+         | Some target -> Ok (target :: targets)
+         | None -> Error (Invalid_board_target raw)))
+    (Ok [])
+    targets
+  |> Result.map (List.sort_uniq Keeper_identity.Keeper_id.compare)
+;;
+
+let of_board_audience = function
+  | Board.Targets targets ->
+    keeper_targets_of_board targets |> Result.map (fun targets -> Targets targets)
+  | Board.Broadcast -> Ok Broadcast
+  | Board.Thread_participants -> Ok Thread_participants
+  | Board.Discoverable -> Ok Discoverable
+;;
+
 let classify ~visibility signal =
-  match
-    Keeper_lane_mentions.explicit_address_of_content
-      (Board_signal.address_text signal)
-  with
-  | Keeper_lane_mentions.Broadcast_all ->
-    (* [Direct] means "mentioned agents only" (Board_types.visibility), so a
-       fleet-wide [@@all] contradicts the visibility the author chose.  Fail
-       closed instead of promoting the signal to a fleet Broadcast: the
-       write boundary (#25379) rejects such posts, and routing must not
-       re-admit what the boundary refuses. *)
-    (match visibility with
-     | Board.Direct -> Error (Broadcast_on_direct signal.post_id)
-     | Board.Public | Board.Unlisted | Board.Internal -> Ok Broadcast)
-  | Keeper_lane_mentions.Targets targets -> Ok (Targets targets)
-  | Keeper_lane_mentions.Unsupported_broadcast selectors ->
-    Error (Unsupported_broadcast selectors)
-  | Keeper_lane_mentions.No_explicit_address ->
-    (match signal.Board_dispatch.kind, visibility with
-     | Board_dispatch.Board_post_created, Board.Direct ->
-       Error (Direct_without_targets signal.post_id)
-     | Board_dispatch.Board_post_created,
-       (Board.Public | Board.Unlisted | Board.Internal) -> Ok Discoverable
-     | ( Board_dispatch.Board_comment_added
-       | Board_dispatch.Board_reaction_changed _ ),
-       (Board.Public | Board.Unlisted | Board.Internal | Board.Direct) ->
-       Ok Thread_participants)
+  let board_audience =
+    match signal.Board_dispatch.kind with
+    | Board_dispatch.Board_post_created ->
+      Board.audience_for_post
+        ~visibility
+        ~title:signal.title
+        ~content:signal.content
+    | Board_dispatch.Board_comment_added ->
+      Board.audience_for_comment ~content:signal.content
+    | Board_dispatch.Board_reaction_changed _ ->
+      Ok Board.audience_for_reaction
+  in
+  match board_audience with
+  | Error error -> Error (Invalid_board_audience error)
+  | Ok audience -> of_board_audience audience
 ;;
 
 let keeper_target_ids (meta : Keeper_meta_contract.keeper_meta) =
@@ -80,14 +91,7 @@ let label = function
 ;;
 
 let classification_error_to_string = function
-  | Unsupported_broadcast selectors ->
-    Printf.sprintf
-      "unsupported Keeper Board broadcast selector(s): %s"
-      (String.concat ", " (List.map (Printf.sprintf "@@%s") selectors))
-  | Direct_without_targets post_id ->
-    Printf.sprintf "Direct Board post %s has no explicit Keeper targets" post_id
-  | Broadcast_on_direct post_id ->
-    Printf.sprintf
-      "Direct Board post %s cannot address the fleet with @@all"
-      post_id
+  | Invalid_board_audience error -> Board.show_board_error error
+  | Invalid_board_target target ->
+    Printf.sprintf "Board audience target cannot identify a Keeper lane: %s" target
 ;;

--- a/lib/keeper/keeper_board_audience.mli
+++ b/lib/keeper/keeper_board_audience.mli
@@ -9,9 +9,8 @@ type t =
     [Discoverable] may enter semantic attention judgment. *)
 
 type classification_error =
-  | Unsupported_broadcast of string list
-  | Direct_without_targets of string
-  | Broadcast_on_direct of string
+  | Invalid_board_audience of Board.board_error
+  | Invalid_board_target of string
 
 type route =
   | Deliver of Keeper_world_observation_board_signal.wake_reason
@@ -26,15 +25,20 @@ val classify
     to structural thread participants, while a newly-created unaddressed post
     is discoverable.
 
-    Fail-closed address/visibility contract:
-    - an unsupported [@@name] selector rejects the whole signal, even when
-      valid [@keeper] targets are mixed in (no partial routing);
-    - [@@all] on a [Direct] post is rejected ([Broadcast_on_direct]):
-      [Direct] means "mentioned agents only", so a fleet broadcast would
-      contradict the visibility the author chose.  [@@all] on
-      [Public]/[Unlisted]/[Internal] classifies as {!Broadcast};
-    - a [Direct] post-creation without any explicit address is rejected
-      ([Direct_without_targets]). *)
+    Fail-closed address/visibility contract (validated through the typed
+    {!Board.audience} write boundary, surfaced as [Invalid_board_audience]):
+    - an unsupported [@@name] selector or a malformed [@target] token rejects
+      the whole signal, even when valid [@keeper] targets are mixed in (no
+      partial routing);
+    - [@@all] on a [Direct] post is rejected: [Direct] means "mentioned
+      agents only", so a fleet broadcast would contradict the visibility the
+      author chose.  [@@all] on [Public]/[Unlisted]/[Internal] classifies as
+      {!Broadcast};
+    - a [Direct] post-creation without any explicit address is rejected. *)
+
+val of_board_audience : Board.audience -> (t, classification_error) result
+(** Project generic Board identities into canonical Keeper lane identities.
+    This is the only MASC-specific step; Board remains Keeper-independent. *)
 
 val route_for_keeper
   :  audience:t

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -68,7 +68,7 @@ val effective_keepalive_meta :
   keeper_meta
 
 val wakeup_relevant_keeper_for_board_signal :
-  config:Workspace.config -> Board_dispatch.board_signal -> unit
+  config:Workspace.config -> Board_dispatch.addressed_board_signal -> unit
 
 (** The heartbeat loop body, extracted for reuse by the supervisor.
     Runs synchronously in the calling fiber until [stop] becomes true. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -438,8 +438,9 @@ let deliver_addressed_board_signal
 
 let wakeup_relevant_keeper_for_board_signal
       ~(config : Workspace.config)
-      (signal : Board_dispatch.board_signal)
+      (addressed : Board_dispatch.addressed_board_signal)
   =
+  let signal = addressed.signal in
   let registry_entries =
     Keeper_registry.all ~base_path:config.base_path ()
     |> List.filter board_signal_entry_accepts_delivery
@@ -450,18 +451,7 @@ let wakeup_relevant_keeper_for_board_signal
     | Board_dispatch.Board_comment_added -> "comment_added"
     | Board_dispatch.Board_reaction_changed _ -> "reaction_changed"
   in
-  match Board_dispatch.get_post ~post_id:signal.post_id with
-  | Error error ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string KeepaliveSignalFailures)
-      ~labels:[ ("keeper", "routing"); ("phase", "board_audience_post_read") ]
-      ();
-    Log.Keeper.warn
-      "board signal audience post unavailable: post=%s error=%s"
-      signal.post_id
-      (Board.show_board_error error)
-  | Ok post ->
-  match Keeper_board_audience.classify ~visibility:post.visibility signal with
+  match Keeper_board_audience.of_board_audience addressed.audience with
   | Error error ->
     (* Fail closed: a classification error (unsupported [@@] selector,
        mixed direct+broadcast address, or a Direct post without targets)

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -125,7 +125,7 @@ val wakeup_keeper :
   string -> unit
 
 val wakeup_relevant_keeper_for_board_signal :
-  config:Workspace.config -> Board_dispatch.board_signal -> unit
+  config:Workspace.config -> Board_dispatch.addressed_board_signal -> unit
 
 (** Per-stage timing accumulator for Phase 0 profiling. *)
 type stage_timing = {

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -213,17 +213,21 @@ let text (signal : Board_dispatch.board_signal) =
 
 let address_text (signal : Board_dispatch.board_signal) =
   match signal.kind with
-  | Board_dispatch.Board_post_created -> text signal
+  | Board_dispatch.Board_post_created ->
+    String.concat
+      "\n"
+      (List.filter
+         (fun part -> not (String.equal (String.trim part) ""))
+         [ signal.title; signal.content ])
   | Board_dispatch.Board_comment_added -> signal.content
   | Board_dispatch.Board_reaction_changed _ -> ""
 ;;
 
 let mention_ids_of_signal signal =
-  (* Board dispatch still carries textual Board content. Convert that boundary
-     payload exactly once into canonical Keeper ids and compare only those typed
-     identities below. This deliberately replaces substring matching; tokens
-     such as [@foo-extra] and [email@foo.example] cannot address [foo]. *)
-  Keeper_lane_mentions.mention_ids_of_content (address_text signal)
+  Board.direct_targets_of_text (address_text signal)
+  |> List.filter_map (fun target ->
+    Board.Agent_id.to_string target |> Keeper_identity.Keeper_id.of_string)
+  |> List.sort_uniq Keeper_identity.Keeper_id.compare
 ;;
 
 let match_signal

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -65,7 +65,8 @@ val list_posts_after_cursor : float * string option -> Board.post list
 val text : Board_dispatch.board_signal -> string
 val address_text : Board_dispatch.board_signal -> string
 (** Text authored by the current signal producer and therefore allowed to
-    carry addressing authority. A post uses its title/content/hearth, a
+    carry addressing authority. A post uses its title/content (never the
+    category [hearth]), a
     comment uses only the new comment body, and a reaction carries no textual
     address. Inherited post display fields never re-address later events. *)
 val mention_ids_of_signal : Board_dispatch.board_signal -> Keeper_identity.Keeper_id.t list

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1448,7 +1448,8 @@ let test_board_signal_reaction_changed_resolves_comment_parent () =
    | Error e -> Alcotest.fail (Board.show_board_error e)
    | Ok _ -> ());
   match !seen with
-  | Some signal ->
+  | Some addressed ->
+    let signal = addressed.Board_dispatch.signal in
     (match signal.Board_dispatch.kind with
      | Board_dispatch.Board_reaction_changed
          { target_type; target_id; user_id; emoji; reacted } ->
@@ -1462,6 +1463,9 @@ let test_board_signal_reaction_changed_resolves_comment_parent () =
       Alcotest.(check bool) "reacted" true reacted;
       Alcotest.(check string) "parent title" "Reaction parent title" signal.title;
       Alcotest.(check string) "parent content" "reaction parent content @keeper-alpha" signal.content
+      ; (match addressed.audience with
+         | Board.Thread_participants -> ()
+         | _ -> Alcotest.fail "reaction audience must be thread participants")
      | _ -> Alcotest.fail "expected reaction_changed board signal")
   | None -> Alcotest.fail "expected reaction_changed board signal"
 
@@ -1604,6 +1608,65 @@ let test_invalid_author () =
   with
   | Ok _ -> Alcotest.fail "Expected validation error for empty author"
   | Error _ -> ()
+
+let expect_validation_error label = function
+  | Error (Board.Validation_error _) -> ()
+  | Error error -> Alcotest.failf "%s: %s" label (Board.show_board_error error)
+  | Ok _ -> Alcotest.failf "%s: expected Validation_error" label
+;;
+
+let test_direct_post_requires_exact_targets () =
+  expect_validation_error
+    "targetless Direct post"
+    (Board_dispatch.create_post
+       ~author:"validator"
+       ~content:"private but unaddressed"
+       ~visibility:Board.Direct
+       ~post_kind:Board.Human_post
+       ());
+  expect_validation_error
+    "Direct broadcast"
+    (Board_dispatch.create_post
+       ~author:"validator"
+       ~content:"@@all private broadcast is contradictory"
+       ~visibility:Board.Direct
+       ~post_kind:Board.Human_post
+       ())
+;;
+
+let test_malformed_target_fails_closed () =
+  expect_validation_error
+    "malformed target"
+    (Board_dispatch.create_post
+       ~author:"validator"
+       ~content:"please inspect @!"
+       ~post_kind:Board.Human_post
+       ())
+;;
+
+let test_write_boundary_emits_typed_audience () =
+  let seen = ref None in
+  Board_dispatch.set_board_signal_hook (fun addressed -> seen := Some addressed);
+  (match
+     Board_dispatch.create_post
+       ~author:"validator"
+       ~content:"@MiXeD-Agent inspect this"
+       ~post_kind:Board.Human_post
+       ()
+   with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Board.show_board_error error));
+  match !seen with
+  | None -> Alcotest.fail "typed Board signal was not emitted"
+  | Some addressed ->
+    (match addressed.Board_dispatch.audience with
+     | Board.Targets [ target ] ->
+       Alcotest.(check string)
+         "Board target retains the typed source identity"
+         "MiXeD-Agent"
+         (Board.Agent_id.to_string target)
+     | _ -> Alcotest.fail "expected one exact Board target")
+;;
 
 (** {1 SubBoard CRUD} *)
 
@@ -2044,6 +2107,12 @@ let () =
     "validation", [
       Alcotest.test_case "empty content" `Quick (with_eio test_empty_content);
       Alcotest.test_case "invalid author" `Quick (with_eio test_invalid_author);
+      Alcotest.test_case "Direct requires exact targets" `Quick
+        (with_eio test_direct_post_requires_exact_targets);
+      Alcotest.test_case "malformed target fails closed" `Quick
+        (with_eio test_malformed_target_fails_closed);
+      Alcotest.test_case "write emits typed audience" `Quick
+        (with_eio test_write_boundary_emits_typed_audience);
     ];
     "sub_boards", [
       Alcotest.test_case "create and get" `Quick (with_eio test_sub_board_create_and_get);

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -313,6 +313,30 @@ let test_closed_board_audience_routes_only_its_authority () =
     (match route ~audience:targeted_audience ~meta:beta targeted with
      | KBA.Ignore -> true
      | KBA.Deliver _ | KBA.Judge_discoverable -> false);
+  (* W1: a non-Keeper target mixed into the audience must not fail the whole
+     classification — the valid Keeper target keeps live routing, and both
+     audience consumers (routing [classify] and structural
+     [mention_ids_of_signal]) project the exact same Keeper id set.
+     [Keeper_id.of_string] mints a raw-fallback id for non-Keeper names
+     (RFC-0232 §3.4), so this also pins that behavior against regressions. *)
+  let mixed_audience =
+    audience_signal ~author:"external-author" "@alpha @human-b inspect"
+  in
+  let mixed_classified = classified mixed_audience in
+  check bool "mixed Keeper and non-Keeper targets still classify" true
+    (match mixed_classified with KBA.Targets _ -> true | _ -> false);
+  check bool "valid Keeper target keeps direct delivery with a mixed audience" true
+    (match route ~audience:mixed_classified ~meta:alpha mixed_audience with
+     | KBA.Deliver KWOBS.Explicit_mention -> true
+     | KBA.Deliver _ | KBA.Judge_discoverable | KBA.Ignore -> false);
+  check bool "both audience consumers project the same Keeper id set" true
+    (match mixed_classified with
+     | KBA.Targets targets ->
+       List.equal
+         Keeper_identity.Keeper_id.equal
+         targets
+         (KWOBS.mention_ids_of_signal mixed_audience)
+     | KBA.Broadcast | KBA.Thread_participants | KBA.Discoverable -> false);
   let discoverable = audience_signal ~author:"external-author" "new research" in
   let discoverable_audience = classified discoverable in
   check bool "new unaddressed post is discoverable" true
@@ -321,6 +345,11 @@ let test_closed_board_audience_routes_only_its_authority () =
     (match route ~audience:discoverable_audience ~meta:alpha discoverable with
      | KBA.Judge_discoverable -> true
      | KBA.Deliver _ | KBA.Ignore -> false);
+  let hearth_only = { discoverable with hearth = Some "@alpha" } in
+  check bool "Board category cannot become recipient authority" true
+    (match classified hearth_only with KBA.Discoverable -> true | _ -> false);
+  check bool "Board category is absent from mention metrics" false
+    (KWOBS.match_signal ~meta:alpha ~signal:hearth_only).explicit_mention;
   let self_authored = audience_signal ~author:"keeper-alpha" "new research" in
   check bool "author lane never judges its own post" true
     (match route ~audience:(classified self_authored) ~meta:alpha self_authored with
@@ -372,21 +401,21 @@ let test_closed_board_audience_routes_only_its_authority () =
   let unsupported = audience_signal ~author:"external-author" "@@analyst inspect" in
   check bool "unsupported broadcast fails closed" true
     (match KBA.classify ~visibility:Board.Internal unsupported with
-     | Error (KBA.Unsupported_broadcast [ "analyst" ]) -> true
+     | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
      | Error _ | Ok _ -> false);
   check bool "Direct without targets fails closed" true
     (match KBA.classify ~visibility:Board.Direct discoverable with
-     | Error (KBA.Direct_without_targets "post-audience") -> true
+     | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
      | Error _ | Ok _ -> false);
   let mixed = audience_signal ~author:"external-author" "@alpha @@analyst inspect" in
   check bool "mixed direct target and unsupported selector fails closed" true
     (match KBA.classify ~visibility:Board.Internal mixed with
-     | Error (KBA.Unsupported_broadcast [ "analyst" ]) -> true
+     | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
      | Error _ | Ok _ -> false);
   let direct_broadcast = audience_signal ~author:"external-author" "@@all inspect" in
   check bool "@@all on a Direct post fails closed" true
     (match KBA.classify ~visibility:Board.Direct direct_broadcast with
-     | Error (KBA.Broadcast_on_direct "post-audience") -> true
+     | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
      | Error _ | Ok _ -> false);
   check bool "@@all on a non-Direct post still broadcasts" true
     (match KBA.classify ~visibility:Board.Internal direct_broadcast with
@@ -434,7 +463,18 @@ let persist_board_signal (signal : Board_dispatch.board_signal) =
   with
   | Error error -> fail (Board.show_board_error error)
   | Ok post ->
-    { signal with post_id = Board.Post_id.to_string post.id }
+    let signal = { signal with post_id = Board.Post_id.to_string post.id } in
+    let audience =
+      match
+        Board.audience_for_post
+          ~visibility:post.visibility
+          ~title:post.title
+          ~content:post.content
+      with
+      | Ok audience -> audience
+      | Error error -> fail (Board.show_board_error error)
+    in
+    { Board_dispatch.signal; audience }
 ;;
 
 let overwrite_file path contents =
@@ -456,7 +496,7 @@ let test_exact_mentions_deliver_and_wake_each_lane_independently () =
        persist_and_register_board_lane config alpha;
        persist_and_register_board_lane config beta;
        persist_and_register_board_lane config gamma;
-       let signal : Board_dispatch.board_signal =
+       let signal : Board_dispatch.addressed_board_signal =
          { kind = Board_dispatch.Board_post_created
          ; post_id = "post-multi-lane"
          ; author = "external-author"
@@ -489,25 +529,27 @@ let test_mixed_address_signal_is_dropped_at_routing () =
   Fun.protect
     ~finally:Keeper_registry.For_testing.clear
     (fun () ->
-       (* Policy pin (P2-1): a signal mixing a valid [@keeper] target with an
-          unsupported [@@] selector is dropped whole at routing — the valid
-          target is NOT partially routed. *)
+       (* Policy pin (P2-1): a post mixing a valid [@keeper] target with an
+          unsupported [@@] selector is rejected whole — the valid target is
+          NOT partially routed.  #25378 pinned this at routing; the write
+          boundary now rejects the post before any signal exists, which is
+          the same fail-closed policy enforced one layer earlier. *)
        let alpha = make_board_resume_meta "alpha" in
        let beta = make_board_resume_meta "beta" in
        persist_and_register_board_lane config alpha;
        persist_and_register_board_lane config beta;
-       let signal : Board_dispatch.board_signal =
-         { kind = Board_dispatch.Board_post_created
-         ; post_id = "post-mixed-address"
-         ; author = "external-author"
-         ; title = "mixed address"
-         ; content = "@alpha @@analyst inspect"
-         ; hearth = None
-         ; updated_at = Some 125.0
-         }
-         |> persist_board_signal
-       in
-       KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
+       (match
+          Board_dispatch.create_post
+            ~author:"external-author"
+            ~content:"@alpha @@analyst inspect"
+            ~title:"mixed address"
+            ~post_kind:Board.Human_post
+            ~visibility:Board.Internal
+            ()
+        with
+        | Ok _ -> fail "mixed-address post must be rejected at the write boundary"
+        | Error (Board.Validation_error _) -> ()
+        | Error error -> fail (Board.show_board_error error));
        check int "mixed-address target durable queue" 0
          (board_queue_length config "alpha");
        check int "mixed-address non-target durable queue" 0
@@ -535,7 +577,7 @@ let test_paused_exact_mention_is_durable_without_wake () =
         with
         | Ok _ -> ()
         | Error _ -> fail "failed to pause Keeper fixture");
-       let signal : Board_dispatch.board_signal =
+       let signal : Board_dispatch.addressed_board_signal =
          { kind = Board_dispatch.Board_post_created
          ; post_id = "post-paused-lane"
          ; author = "external-author"
@@ -573,7 +615,7 @@ let test_restarting_exact_mention_is_durable_with_deferred_wake () =
         with
         | Ok _ -> ()
         | Error _ -> fail "failed to register Restarting Keeper fixture");
-       let signal : Board_dispatch.board_signal =
+       let signal : Board_dispatch.addressed_board_signal =
          { kind = Board_dispatch.Board_post_created
          ; post_id = "post-restarting-lane"
          ; author = "external-author"
@@ -611,7 +653,7 @@ let test_lane_meta_failure_does_not_block_next_durable_delivery () =
        overwrite_file
          (Keeper_types_profile.keeper_meta_path config broken.name)
          "{ malformed Keeper metadata";
-       let signal : Board_dispatch.board_signal =
+       let signal : Board_dispatch.addressed_board_signal =
          { kind = Board_dispatch.Board_post_created
          ; post_id = "post-lane-isolation"
          ; author = "external-author"


### PR DESCRIPTION
Stacks on #25378. Board now owns a closed typed audience at the mutation boundary; Direct posts require exact targets, malformed selectors fail closed, categories cannot become recipients, and Keeper live routing consumes the admitted audience without re-reading/re-parsing the post. Focused proof: board validation 5/5; keeper keepalive helpers 15/15; ocamlformat and diff checks pass. Full build remains CI authority. Deliberately not claimed here: durable Board outbox/cold replay, Direct read ACL, edit/vote attention signals, and reaction persistence error propagation.