### PR TITLE
refactor(keeper): append indexed singleton attention transitions

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -2231,6 +2231,7 @@ let private_jsonl_read_stable_lock_state path fd =
     else
       (match private_jsonl_capture Read_stable_lock_state (fun () ->
          let bytes = Bytes.create observed_length in
+         (* fire-and-forget: seek target is fixed at 0; a failed lseek surfaces as a short/garbage read below *)
          ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
          let rec read_all offset =
            if offset = observed_length
@@ -2267,6 +2268,7 @@ let private_jsonl_initialize_stable_lock ~io ~dir fd =
   in
   let* () =
     private_jsonl_capture Write_stable_lock_state (fun () ->
+      (* fire-and-forget: seek target is fixed at 0; a failed lseek surfaces as a short write below *)
       ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
       private_jsonl_write_substring_all
         fd

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1734,6 +1734,1068 @@ let run_blocking_private_file_transaction ~label ~path:_ f =
   | Eio_fiber -> Eio_unix.run_in_systhread ~label f
 ;;
 
+module Private_jsonl_cursor = struct
+  type t =
+    | Missing
+    | Present of
+        { device : int
+        ; inode : int
+        ; end_offset : int
+        }
+
+  let equal left right =
+    match left, right with
+    | Missing, Missing -> true
+    | ( Present
+          { device = left_device
+          ; inode = left_inode
+          ; end_offset = left_end_offset
+          }
+      , Present
+          { device = right_device
+          ; inode = right_inode
+          ; end_offset = right_end_offset
+          } ) ->
+      Int.equal left_device right_device
+      && Int.equal left_inode right_inode
+      && Int.equal left_end_offset right_end_offset
+    | Missing, Present _ | Present _, Missing -> false
+  ;;
+
+  let to_string = function
+    | Missing -> "missing"
+    | Present { device; inode; end_offset } ->
+      Printf.sprintf
+        "present(device=%d,inode=%d,end_offset=%d)"
+        device
+        inode
+        end_offset
+  ;;
+
+  let prefix_end_offset cursor ~device ~inode ~file_length =
+    match cursor with
+    | Missing -> None
+    | Present
+        { device = expected_device
+        ; inode = expected_inode
+        ; end_offset
+        } ->
+      if Int.equal expected_device device
+         && Int.equal expected_inode inode
+         && end_offset <= file_length
+      then Some end_offset
+      else None
+  ;;
+end
+
+type private_jsonl_snapshot =
+  { bytes : string
+  ; cursor : Private_jsonl_cursor.t
+  }
+
+type private_jsonl_transaction_operation =
+  | Create_parent_directory
+  | Canonicalize_parent_directory
+  | Inspect_stable_lock
+  | Open_stable_lock
+  | Set_stable_lock_permissions
+  | Sync_stable_lock_parent
+  | Acquire_stable_lock
+  | Read_stable_lock_state
+  | Write_stable_lock_state
+  | Sync_stable_lock
+  | Close_stable_lock
+  | Open_transaction_data
+  | Set_transaction_data_permissions
+  | Inspect_transaction_data
+  | Inspect_transaction_path
+  | Read_transaction_data
+  | Close_transaction_data
+  | Create_rewrite_stage
+  | Set_rewrite_stage_permissions
+  | Write_rewrite_stage
+  | Sync_rewrite_stage
+  | Close_rewrite_stage
+  | Rename_rewrite_stage
+  | Sync_rewrite_parent
+  | Inspect_rewritten_data
+  | Remove_rewrite_stage
+
+type private_jsonl_operation_failure =
+  { operation : private_jsonl_transaction_operation
+  ; exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type ('value, 'error) private_file_transaction_outcome =
+  | Private_file_succeeded of 'value
+  | Private_file_succeeded_with_cleanup_failure of
+      { value : 'value
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+  | Private_file_failed of 'error
+  | Private_file_failed_with_cleanup_failure of
+      { error : 'error
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+
+type private_jsonl_transaction_success =
+  | Snapshot_succeeded of private_jsonl_snapshot
+  | Cursor_succeeded of Private_jsonl_cursor.t
+  | Cursor_precondition_succeeded of Private_jsonl_cursor.t
+
+type private_jsonl_transaction_primary =
+  | Transaction_succeeded of private_jsonl_transaction_success
+  | Transaction_failed of private_jsonl_transaction_error
+
+and private_jsonl_transaction_error =
+  | Stable_lock_contended of { lock_path : string }
+  | Unexpected_stable_lock_permissions of
+      { path : string
+      ; actual : int
+      }
+  | Invalid_stable_lock_state of
+      { path : string
+      ; observed_length : int
+      }
+  | Cursor_mismatch of
+      { expected : Private_jsonl_cursor.t
+      ; actual : Private_jsonl_cursor.t
+      }
+  | Unexpected_transaction_file_kind of Unix.file_kind
+  | Ambiguous_transaction_file_identity of
+      { path : string
+      ; link_count : int
+      }
+  | Transaction_path_binding_changed of { path : string }
+  | Incomplete_transaction_tail of { end_offset : int }
+  | Invalid_transaction_suffix
+  | Private_jsonl_operation_failed of private_jsonl_operation_failure
+  | Rewrite_stage_failed of
+      { failure : private_jsonl_operation_failure
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
+  | Rewrite_published_durability_unknown of
+      { cursor : Private_jsonl_cursor.t option
+      ; failure : private_jsonl_operation_failure
+      }
+  | Transaction_settlement_failed of
+      { primary : private_jsonl_transaction_primary
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
+  | Transaction_append_failed of durable_append_error
+
+type 'a private_jsonl_success_receipt =
+  { value : 'a
+  ; settlement_error : private_jsonl_transaction_error option
+  }
+
+let private_jsonl_settlement_success = function
+  | (Transaction_settlement_failed
+      { primary = Transaction_succeeded success; _ } as error) ->
+    Some (success, error)
+  | Transaction_settlement_failed { primary = Transaction_failed _; _ }
+  | Stable_lock_contended _
+  | Unexpected_stable_lock_permissions _
+  | Invalid_stable_lock_state _
+  | Cursor_mismatch _
+  | Unexpected_transaction_file_kind _
+  | Ambiguous_transaction_file_identity _
+  | Transaction_path_binding_changed _
+  | Incomplete_transaction_tail _
+  | Invalid_transaction_suffix
+  | Private_jsonl_operation_failed _
+  | Rewrite_stage_failed _
+  | Rewrite_published_durability_unknown _
+  | Transaction_append_failed _ -> None
+;;
+
+let private_jsonl_snapshot_success_receipt = function
+  | Ok value -> Ok { value; settlement_error = None }
+  | Error error ->
+    (match private_jsonl_settlement_success error with
+     | Some (Snapshot_succeeded value, settlement_error) ->
+       Ok { value; settlement_error = Some settlement_error }
+     | Some
+         ( (Cursor_succeeded _ | Cursor_precondition_succeeded _)
+         , _ )
+     | None -> Error error)
+;;
+
+let private_jsonl_cursor_success_receipt = function
+  | Ok value -> Ok { value; settlement_error = None }
+  | Error error ->
+    (match private_jsonl_settlement_success error with
+     | Some (Cursor_succeeded value, settlement_error) ->
+       Ok { value; settlement_error = Some settlement_error }
+     | Some
+         ( (Snapshot_succeeded _ | Cursor_precondition_succeeded _)
+         , _ )
+     | None -> Error error)
+;;
+
+let private_jsonl_operation_to_string = function
+  | Create_parent_directory -> "create parent directory"
+  | Canonicalize_parent_directory -> "canonicalize parent directory"
+  | Inspect_stable_lock -> "inspect stable lock"
+  | Open_stable_lock -> "open stable lock"
+  | Set_stable_lock_permissions -> "set stable lock permissions"
+  | Sync_stable_lock_parent -> "sync stable lock parent"
+  | Acquire_stable_lock -> "acquire stable lock"
+  | Read_stable_lock_state -> "read stable lock state"
+  | Write_stable_lock_state -> "write stable lock state"
+  | Sync_stable_lock -> "sync stable lock"
+  | Close_stable_lock -> "close stable lock"
+  | Open_transaction_data -> "open transaction data"
+  | Set_transaction_data_permissions -> "set transaction data permissions"
+  | Inspect_transaction_data -> "inspect transaction data"
+  | Inspect_transaction_path -> "inspect transaction path"
+  | Read_transaction_data -> "read transaction data"
+  | Close_transaction_data -> "close transaction data"
+  | Create_rewrite_stage -> "create rewrite stage"
+  | Set_rewrite_stage_permissions -> "set rewrite stage permissions"
+  | Write_rewrite_stage -> "write rewrite stage"
+  | Sync_rewrite_stage -> "sync rewrite stage"
+  | Close_rewrite_stage -> "close rewrite stage"
+  | Rename_rewrite_stage -> "rename rewrite stage"
+  | Sync_rewrite_parent -> "sync rewrite parent"
+  | Inspect_rewritten_data -> "inspect rewritten data"
+  | Remove_rewrite_stage -> "remove rewrite stage"
+;;
+
+let private_jsonl_operation_failure_to_string failure =
+  Printf.sprintf
+    "%s failed: %s"
+    (private_jsonl_operation_to_string failure.operation)
+    (Printexc.to_string failure.exception_)
+;;
+
+let private_jsonl_cleanup_failures_to_string cleanup_failures =
+  cleanup_failures
+  |> List.map private_jsonl_operation_failure_to_string
+  |> String.concat "; "
+;;
+
+let rec private_jsonl_transaction_error_to_string = function
+  | Stable_lock_contended { lock_path } ->
+    Printf.sprintf "private JSONL stable lock is contended: %s" lock_path
+  | Unexpected_stable_lock_permissions { path; actual } ->
+    Printf.sprintf
+      "private JSONL stable lock permissions are %04o, expected 0600: %s"
+      actual
+      path
+  | Invalid_stable_lock_state { path; observed_length } ->
+    Printf.sprintf
+      "private JSONL stable lock has invalid durable state: %s (%d bytes)"
+      path
+      observed_length
+  | Cursor_mismatch { expected; actual } ->
+    Printf.sprintf
+      "private JSONL cursor mismatch: expected %s, observed %s"
+      (Private_jsonl_cursor.to_string expected)
+      (Private_jsonl_cursor.to_string actual)
+  | Unexpected_transaction_file_kind kind ->
+    Printf.sprintf
+      "private JSONL transaction target has unexpected file kind: %s"
+      (match kind with
+       | Unix.S_REG -> "regular"
+       | Unix.S_DIR -> "directory"
+       | Unix.S_CHR -> "character-device"
+       | Unix.S_BLK -> "block-device"
+       | Unix.S_LNK -> "symbolic-link"
+       | Unix.S_FIFO -> "fifo"
+       | Unix.S_SOCK -> "socket")
+  | Ambiguous_transaction_file_identity { path; link_count } ->
+    Printf.sprintf
+      "private JSONL transaction path has ambiguous hard-link identity: %s (links=%d)"
+      path
+      link_count
+  | Transaction_path_binding_changed { path } ->
+    Printf.sprintf
+      "private JSONL transaction path binding changed during operation: %s"
+      path
+  | Incomplete_transaction_tail { end_offset } ->
+    Printf.sprintf
+      "private JSONL transaction target has an incomplete tail at end %d"
+      end_offset
+  | Invalid_transaction_suffix ->
+    "private JSONL transaction payload must be empty or newline-terminated"
+  | Private_jsonl_operation_failed failure ->
+    private_jsonl_operation_failure_to_string failure
+  | Rewrite_stage_failed { failure; cleanup_failures } ->
+    let cleanup =
+      match cleanup_failures with
+      | [] -> ""
+      | cleanup_failures ->
+        Printf.sprintf
+          "; cleanup also failed: %s"
+          (private_jsonl_cleanup_failures_to_string cleanup_failures)
+    in
+    private_jsonl_operation_failure_to_string failure ^ cleanup
+  | Rewrite_published_durability_unknown { cursor; failure } ->
+    Printf.sprintf
+      "private JSONL rewrite was published but durability is unknown (cursor=%s): %s"
+      (match cursor with
+       | None -> "unknown"
+       | Some cursor -> Private_jsonl_cursor.to_string cursor)
+      (private_jsonl_operation_failure_to_string failure)
+  | Transaction_settlement_failed { primary; cleanup_failures } ->
+    let primary =
+      match primary with
+      | Transaction_succeeded (Snapshot_succeeded snapshot) ->
+        Printf.sprintf
+          "private JSONL snapshot read succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string snapshot.cursor)
+      | Transaction_succeeded (Cursor_succeeded cursor) ->
+        Printf.sprintf
+          "private JSONL cursor operation succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string cursor)
+      | Transaction_succeeded (Cursor_precondition_succeeded cursor) ->
+        Printf.sprintf
+          "private JSONL cursor precondition read succeeded (cursor=%s)"
+          (Private_jsonl_cursor.to_string cursor)
+      | Transaction_failed primary ->
+        private_jsonl_transaction_error_to_string primary
+    in
+    Printf.sprintf
+      "%s; descriptor settlement failed: %s"
+      primary
+      (private_jsonl_cleanup_failures_to_string cleanup_failures)
+  | Transaction_append_failed append_error ->
+    durable_append_error_to_string append_error
+;;
+
+let private_jsonl_failure operation exception_ =
+  { operation; exception_; backtrace = Printexc.get_raw_backtrace () }
+;;
+
+let private_jsonl_capture operation f =
+  match f () with
+  | value -> Ok value
+  | exception (Eio.Cancel.Cancelled _ as cancellation) -> raise cancellation
+  | exception exception_ -> Error (private_jsonl_failure operation exception_)
+;;
+
+let private_file_transaction_map f = function
+  | Private_file_succeeded value -> Private_file_succeeded (f value)
+  | Private_file_succeeded_with_cleanup_failure
+      { value; cleanup_failure } ->
+    Private_file_succeeded_with_cleanup_failure
+      { value = f value; cleanup_failure }
+  | Private_file_failed error -> Private_file_failed error
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Private_file_failed_with_cleanup_failure { error; cleanup_failure }
+;;
+
+let private_jsonl_with_fd_outcome ~close_operation ~close_fd fd f =
+  match f () with
+  | Ok value ->
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Private_file_succeeded value
+     | Error cleanup_failure ->
+       Private_file_succeeded_with_cleanup_failure
+         { value; cleanup_failure })
+  | Error error ->
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Private_file_failed error
+     | Error cleanup_failure ->
+       Private_file_failed_with_cleanup_failure
+         { error; cleanup_failure })
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match private_jsonl_capture close_operation (fun () -> close_fd fd) with
+     | Ok () -> Printexc.raise_with_backtrace exception_ backtrace
+     | Error cleanup_failure ->
+       let combined, combined_backtrace =
+         Eio.Exn.combine
+           (exception_, backtrace)
+           (cleanup_failure.exception_, cleanup_failure.backtrace)
+       in
+       Printexc.raise_with_backtrace combined combined_backtrace)
+;;
+
+let private_jsonl_add_cleanup_failure error cleanup_failure =
+  match error with
+  | Transaction_settlement_failed { primary; cleanup_failures } ->
+    Transaction_settlement_failed
+      { primary; cleanup_failures = cleanup_failures @ [ cleanup_failure ] }
+  | (Stable_lock_contended _
+    | Unexpected_stable_lock_permissions _
+    | Invalid_stable_lock_state _
+    | Cursor_mismatch _
+    | Unexpected_transaction_file_kind _
+    | Ambiguous_transaction_file_identity _
+    | Transaction_path_binding_changed _
+    | Incomplete_transaction_tail _
+    | Invalid_transaction_suffix
+    | Private_jsonl_operation_failed _
+    | Rewrite_stage_failed _
+    | Rewrite_published_durability_unknown _
+    | Transaction_append_failed _) as primary ->
+    Transaction_settlement_failed
+      { primary = Transaction_failed primary
+      ; cleanup_failures = [ cleanup_failure ]
+      }
+;;
+
+let private_jsonl_settlement_failed ~success result cleanup_failure =
+  match result with
+  | Ok value ->
+    Error
+      (Transaction_settlement_failed
+         { primary = Transaction_succeeded (success value)
+         ; cleanup_failures = [ cleanup_failure ]
+         })
+  | Error error -> Error (private_jsonl_add_cleanup_failure error cleanup_failure)
+;;
+
+let private_jsonl_with_fd ~close_operation ~close_fd ~success fd f =
+  match private_jsonl_with_fd_outcome ~close_operation ~close_fd fd f with
+  | Private_file_succeeded value -> Ok value
+  | Private_file_failed error -> Error error
+  | Private_file_succeeded_with_cleanup_failure
+      { value; cleanup_failure } ->
+    private_jsonl_settlement_failed ~success (Ok value) cleanup_failure
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error (private_jsonl_add_cleanup_failure error cleanup_failure)
+;;
+
+let private_jsonl_lock_path path = path ^ ".lock"
+
+type private_jsonl_transaction_io_for_testing =
+  { before_sync_parent : string -> unit
+  ; close_fd : Unix.file_descr -> unit
+  }
+
+let private_jsonl_transaction_unix_io =
+  { before_sync_parent = (fun _dir -> ()); close_fd = Unix.close }
+;;
+
+let private_jsonl_stable_lock_ready_marker = "\xA5"
+
+type private_jsonl_stable_lock_state =
+  | Stable_lock_initializing
+  | Stable_lock_ready
+
+type private_jsonl_stable_lock_creation =
+  | Stable_lock_created
+  | Stable_lock_existing
+
+type private_jsonl_stable_lock =
+  { fd : Unix.file_descr
+  ; creation : private_jsonl_stable_lock_creation
+  }
+
+let private_jsonl_open_stable_lock lock_path =
+  match
+    private_jsonl_capture Open_stable_lock (fun () ->
+      Unix.openfile
+        lock_path
+        [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_EXCL; Unix.O_CLOEXEC ]
+        0o600)
+  with
+  | Ok fd -> Ok { fd; creation = Stable_lock_created }
+  | Error failure ->
+    (match failure.exception_ with
+     | Unix.Unix_error (error, _, _) when error = Unix.EEXIST ->
+       private_jsonl_capture Open_stable_lock (fun () ->
+         Unix.openfile lock_path [ Unix.O_RDWR; Unix.O_CLOEXEC ] 0)
+       |> Result.map (fun fd -> { fd; creation = Stable_lock_existing })
+       |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+     (* DET-OK: [exn] is open. Every non-EEXIST open failure remains typed. *)
+     | _ -> Error (Private_jsonl_operation_failed failure))
+;;
+
+let rec private_jsonl_write_substring_all fd value offset =
+  if offset < String.length value
+  then
+    match Unix.write_substring fd value offset (String.length value - offset) with
+    | 0 ->
+      raise
+        (Unix.Unix_error
+           (Unix.EIO, "write", "private JSONL stable lock made no progress"))
+    | count -> private_jsonl_write_substring_all fd value (offset + count)
+    | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+      private_jsonl_write_substring_all fd value offset
+;;
+
+let private_jsonl_read_stable_lock_state path fd =
+  match private_jsonl_capture Read_stable_lock_state (fun () -> Unix.fstat fd) with
+  | Error failure -> Error (Private_jsonl_operation_failed failure)
+  | Ok stats ->
+    let observed_length = stats.Unix.st_size in
+    if observed_length = 0
+    then Ok Stable_lock_initializing
+    else if observed_length <> String.length private_jsonl_stable_lock_ready_marker
+    then Error (Invalid_stable_lock_state { path; observed_length })
+    else
+      (match private_jsonl_capture Read_stable_lock_state (fun () ->
+         let bytes = Bytes.create observed_length in
+         ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+         let rec read_all offset =
+           if offset = observed_length
+           then ()
+           else
+             match Unix.read fd bytes offset (observed_length - offset) with
+             | 0 -> raise End_of_file
+             | count -> read_all (offset + count)
+             | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_all offset
+         in
+         read_all 0;
+         Bytes.unsafe_to_string bytes)
+       with
+       | Error failure -> Error (Private_jsonl_operation_failed failure)
+       | Ok marker ->
+         if String.equal marker private_jsonl_stable_lock_ready_marker
+         then Ok Stable_lock_ready
+         else Error (Invalid_stable_lock_state { path; observed_length }))
+;;
+
+let private_jsonl_sync_stable_lock fd =
+  private_jsonl_capture Sync_stable_lock (fun () -> Unix.fsync fd)
+  |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+;;
+
+let private_jsonl_initialize_stable_lock ~io ~dir fd =
+  let ( let* ) = Result.bind in
+  let* () = private_jsonl_sync_stable_lock fd in
+  let* () =
+    private_jsonl_capture Sync_stable_lock_parent (fun () ->
+      io.before_sync_parent dir;
+      fsync_parent_directory dir)
+    |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+  in
+  let* () =
+    private_jsonl_capture Write_stable_lock_state (fun () ->
+      ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+      private_jsonl_write_substring_all
+        fd
+        private_jsonl_stable_lock_ready_marker
+        0)
+    |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+  in
+  private_jsonl_sync_stable_lock fd
+;;
+
+let private_jsonl_prepare_stable_lock ~io ~dir ~path stable_lock =
+  let ( let* ) = Result.bind in
+  let* () =
+    match stable_lock.creation with
+    | Stable_lock_created ->
+      private_jsonl_capture Set_stable_lock_permissions (fun () ->
+        Unix.fchmod stable_lock.fd 0o600)
+      |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+    | Stable_lock_existing -> Ok ()
+  in
+  let* permissions =
+    private_jsonl_capture Inspect_stable_lock (fun () ->
+      (Unix.fstat stable_lock.fd).Unix.st_perm land 0o7777)
+    |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+  in
+  if permissions <> 0o600
+  then Error (Unexpected_stable_lock_permissions { path; actual = permissions })
+  else
+    let* state = private_jsonl_read_stable_lock_state path stable_lock.fd in
+    match state with
+    | Stable_lock_initializing ->
+      private_jsonl_initialize_stable_lock ~io ~dir stable_lock.fd
+    | Stable_lock_ready -> Ok ()
+;;
+
+let private_jsonl_same_identity left right =
+  Int.equal left.Unix.st_dev right.Unix.st_dev
+  && Int.equal left.Unix.st_ino right.Unix.st_ino
+;;
+
+let private_jsonl_validate_unique_regular_binding ~path ~path_stats ~fd_stats =
+  if path_stats.Unix.st_kind <> Unix.S_REG
+  then Error (Unexpected_transaction_file_kind path_stats.Unix.st_kind)
+  else if fd_stats.Unix.st_kind <> Unix.S_REG
+  then Error (Unexpected_transaction_file_kind fd_stats.Unix.st_kind)
+  else if path_stats.Unix.st_nlink <> 1
+  then
+    Error
+      (Ambiguous_transaction_file_identity
+         { path; link_count = path_stats.Unix.st_nlink })
+  else if fd_stats.Unix.st_nlink <> 1
+  then
+    Error
+      (Ambiguous_transaction_file_identity
+         { path; link_count = fd_stats.Unix.st_nlink })
+  else if not (private_jsonl_same_identity path_stats fd_stats)
+  then Error (Transaction_path_binding_changed { path })
+  else Ok ()
+;;
+
+let private_jsonl_validate_open_binding ~operation ~path fd =
+  match private_jsonl_capture operation (fun () -> Unix.lstat path, Unix.fstat fd) with
+  | Error failure -> Error (Private_jsonl_operation_failed failure)
+  | Ok (path_stats, fd_stats) ->
+    private_jsonl_validate_unique_regular_binding ~path ~path_stats ~fd_stats
+;;
+
+let rec try_lock_whole_file fd =
+  match Unix.lockf fd Unix.F_TLOCK 0 with
+  | () -> true
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> try_lock_whole_file fd
+  | exception Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> false
+;;
+
+let with_private_jsonl_stable_lock ~io ~success requested_path f =
+  let requested_dir = Filename.dirname requested_path in
+  run_blocking_private_file_transaction
+    ~label:"fs-compat-private-jsonl-transaction"
+    ~path:requested_path
+    (fun () ->
+       match private_jsonl_capture Create_parent_directory (fun () ->
+         test_exec_home_guard ~op:"private_jsonl_transaction" requested_path;
+         mkdir_p_unix requested_dir)
+       with
+       | Error failure -> Error (Private_jsonl_operation_failed failure)
+       | Ok () ->
+         (match private_jsonl_capture Canonicalize_parent_directory (fun () ->
+            Unix.realpath requested_dir)
+          with
+          | Error failure -> Error (Private_jsonl_operation_failed failure)
+          | Ok dir ->
+            let path = Filename.concat dir (Filename.basename requested_path) in
+            let lock_path = private_jsonl_lock_path path in
+            let path_mu = get_append_path_mutex path in
+            Stdlib.Mutex.protect path_mu (fun () ->
+              match private_jsonl_open_stable_lock lock_path with
+              | Error _ as error -> error
+              | Ok stable_lock ->
+                private_jsonl_with_fd
+                  ~close_operation:Close_stable_lock
+                  ~close_fd:io.close_fd
+                  ~success
+                  stable_lock.fd
+                  (fun () ->
+                     let ( let* ) = Result.bind in
+                     let* () =
+                       private_jsonl_validate_open_binding
+                         ~operation:Inspect_stable_lock
+                         ~path:lock_path
+                         stable_lock.fd
+                     in
+                     let* acquired =
+                       private_jsonl_capture Acquire_stable_lock (fun () ->
+                         try_lock_whole_file stable_lock.fd)
+                       |> Result.map_error (fun failure ->
+                         Private_jsonl_operation_failed failure)
+                     in
+                     if not acquired
+                     then Error (Stable_lock_contended { lock_path })
+                     else
+                       let* () =
+                         private_jsonl_validate_open_binding
+                           ~operation:Inspect_stable_lock
+                           ~path:lock_path
+                           stable_lock.fd
+                       in
+                       let* () =
+                         private_jsonl_prepare_stable_lock
+                           ~io
+                           ~dir
+                           ~path:lock_path
+                           stable_lock
+                       in
+                       f ~dir ~path))))
+;;
+
+let private_jsonl_cursor_of_stats stats =
+  if stats.Unix.st_kind <> Unix.S_REG
+  then Error (Unexpected_transaction_file_kind stats.Unix.st_kind)
+  else
+    Ok
+      (Private_jsonl_cursor.Present
+         { device = stats.Unix.st_dev
+         ; inode = stats.Unix.st_ino
+         ; end_offset = stats.Unix.st_size
+         })
+;;
+
+let private_jsonl_open_existing ~close_fd path flags =
+  match Unix.openfile path (Unix.O_CLOEXEC :: flags) 0 with
+  | fd ->
+    (match
+       private_jsonl_validate_open_binding
+         ~operation:Inspect_transaction_path
+         ~path
+         fd
+     with
+     | Ok () -> Ok (Some fd)
+     | Error error ->
+       (match private_jsonl_capture Close_transaction_data (fun () -> close_fd fd) with
+        | Ok () -> Error error
+        | Error cleanup_failure ->
+          Error (private_jsonl_add_cleanup_failure error cleanup_failure)))
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+  | exception (Eio.Cancel.Cancelled _ as cancellation) -> raise cancellation
+  | exception exception_ ->
+    Error
+      (Private_jsonl_operation_failed
+         (private_jsonl_failure Open_transaction_data exception_))
+;;
+
+let rec private_jsonl_read_byte fd byte offset =
+  (* See POSIX lseek: no exception confirms the requested absolute offset. *)
+  ignore (Unix.lseek fd offset Unix.SEEK_SET : int);
+  match Unix.read fd byte 0 1 with
+  | 1 -> Bytes.get byte 0
+  | 0 -> raise End_of_file
+  | count ->
+    invalid_arg (Printf.sprintf "single-byte JSONL read returned %d bytes" count)
+  | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+    private_jsonl_read_byte fd byte offset
+;;
+
+let private_jsonl_validate_complete_tail fd end_offset =
+  if end_offset = 0
+  then Ok ()
+  else
+    match private_jsonl_capture Read_transaction_data (fun () ->
+      let byte = Bytes.create 1 in
+      Char.equal (private_jsonl_read_byte fd byte (end_offset - 1)) '\n')
+    with
+    | Error failure -> Error (Private_jsonl_operation_failed failure)
+    | Ok true -> Ok ()
+    | Ok false -> Error (Incomplete_transaction_tail { end_offset })
+;;
+
+let private_jsonl_read_exact fd ~from ~end_offset =
+  private_jsonl_capture Read_transaction_data (fun () ->
+    let length = end_offset - from in
+    let bytes = Bytes.create length in
+    (* See POSIX lseek: no exception confirms the requested absolute cursor. *)
+    ignore (Unix.lseek fd from Unix.SEEK_SET : int);
+    let rec read_all offset =
+      if offset = length
+      then ()
+      else
+        match Unix.read fd bytes offset (length - offset) with
+        | 0 -> raise End_of_file
+        | count -> read_all (offset + count)
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_all offset
+    in
+    read_all 0;
+    Bytes.unsafe_to_string bytes)
+  |> Result.map_error (fun failure -> Private_jsonl_operation_failed failure)
+;;
+
+let read_private_jsonl_durable_locked_with_io ~io path ~after =
+  let success snapshot = Snapshot_succeeded snapshot in
+  with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir:_ ~path ->
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
+  | Error _ as error -> error
+  | Ok None ->
+    let actual = Private_jsonl_cursor.Missing in
+    (match after with
+     | None -> Ok { bytes = ""; cursor = actual }
+     | Some expected ->
+       if Private_jsonl_cursor.equal expected actual
+       then Ok { bytes = ""; cursor = actual }
+       else Error (Cursor_mismatch { expected; actual }))
+  | Ok (Some fd) ->
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
+      (fun () ->
+         match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
+         with
+         | Error failure -> Error (Private_jsonl_operation_failed failure)
+         | Ok stats ->
+           (match private_jsonl_cursor_of_stats stats with
+            | Error _ as error -> error
+            | Ok actual ->
+              (match private_jsonl_validate_complete_tail fd stats.Unix.st_size with
+               | Error _ as error -> error
+               | Ok () ->
+                 let from =
+                   match after with
+                   | None -> Ok 0
+                   | Some expected ->
+                     (match
+                        Private_jsonl_cursor.prefix_end_offset
+                          expected
+                          ~device:stats.Unix.st_dev
+                          ~inode:stats.Unix.st_ino
+                          ~file_length:stats.Unix.st_size
+                      with
+                      | Some end_offset -> Ok end_offset
+                      | None -> Error (Cursor_mismatch { expected; actual }))
+                 in
+                 (match from with
+                  | Error _ as error -> error
+                  | Ok from ->
+                    private_jsonl_read_exact
+                      fd
+                      ~from
+                      ~end_offset:stats.Unix.st_size
+                    |> Result.map (fun bytes -> { bytes; cursor = actual })))))
+;;
+
+let read_private_jsonl_durable_locked_result path ~after =
+  read_private_jsonl_durable_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~after
+;;
+
+let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =
+  read_private_jsonl_durable_locked_with_io ~io path ~after
+;;
+
+let private_jsonl_current_cursor ~io path =
+  let success cursor = Cursor_precondition_succeeded cursor in
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDONLY ] with
+  | Error _ as error -> error
+  | Ok None -> Ok Private_jsonl_cursor.Missing
+  | Ok (Some fd) ->
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
+      (fun () ->
+         match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
+         with
+         | Error failure -> Error (Private_jsonl_operation_failed failure)
+         | Ok stats ->
+           (match private_jsonl_cursor_of_stats stats with
+            | Error _ as error -> error
+            | Ok cursor ->
+              private_jsonl_validate_complete_tail fd stats.Unix.st_size
+              |> Result.map (fun () -> cursor)))
+;;
+
+let private_jsonl_remove_rewrite_stage temp_path =
+  match private_jsonl_capture Remove_rewrite_stage (fun () -> Unix.unlink temp_path) with
+  | Ok () -> None
+  | Error failure ->
+    (match failure.exception_ with
+     | Unix.Unix_error (error, _, _) when error = Unix.ENOENT -> None
+     (* DET-OK: [exn] is open. Every non-ENOENT cleanup exception is preserved
+        as typed failure evidence; this arm never chooses a permissive default. *)
+     | _ -> Some failure)
+;;
+
+let private_jsonl_replace_locked ~dir path content =
+  match private_jsonl_capture Create_rewrite_stage (fun () ->
+    Filename.open_temp_file ~temp_dir:dir ".private_jsonl_" ".stage")
+  with
+  | Error failure -> Error (Private_jsonl_operation_failed failure)
+  | Ok (temp_path, output) ->
+    let descriptor = Unix.descr_of_out_channel output in
+    let first_failure = ref None in
+    let run_until_failure operation f =
+      match !first_failure with
+      | Some _ -> ()
+      | None ->
+        (match private_jsonl_capture operation f with
+         | Ok () -> ()
+         | Error failure -> first_failure := Some failure)
+    in
+    run_until_failure Set_rewrite_stage_permissions (fun () ->
+      Unix.fchmod descriptor 0o600);
+    run_until_failure Write_rewrite_stage (fun () ->
+      output_string output content;
+      flush output);
+    run_until_failure Sync_rewrite_stage (fun () -> Unix.fsync descriptor);
+    let operation_failure = !first_failure in
+    let close_failure =
+      match private_jsonl_capture Close_rewrite_stage (fun () -> close_out output) with
+      | Ok () -> None
+      | Error failure -> Some failure
+    in
+    (match operation_failure, close_failure with
+     | Some failure, close_failure ->
+       let cleanup_failures =
+         [ close_failure; private_jsonl_remove_rewrite_stage temp_path ]
+         |> List.filter_map Fun.id
+       in
+       Error (Rewrite_stage_failed { failure; cleanup_failures })
+     | None, Some failure ->
+       let cleanup_failures =
+         private_jsonl_remove_rewrite_stage temp_path |> Option.to_list
+       in
+       Error (Rewrite_stage_failed { failure; cleanup_failures })
+     | None, None ->
+       (match private_jsonl_capture Rename_rewrite_stage (fun () ->
+          Unix.rename temp_path path)
+        with
+        | Error failure ->
+          let cleanup_failures =
+            private_jsonl_remove_rewrite_stage temp_path |> Option.to_list
+          in
+          Error (Rewrite_stage_failed { failure; cleanup_failures })
+        | Ok () ->
+          (match private_jsonl_capture Inspect_rewritten_data (fun () ->
+             Unix.lstat path)
+           with
+           | Error failure ->
+             Error
+               (Rewrite_published_durability_unknown
+                  { cursor = None; failure })
+           | Ok stats ->
+             (match private_jsonl_cursor_of_stats stats with
+              | Error error ->
+                let failure =
+                  private_jsonl_failure
+                    Inspect_rewritten_data
+                    (Failure (private_jsonl_transaction_error_to_string error))
+                in
+                Error
+                  (Rewrite_published_durability_unknown
+                     { cursor = None; failure })
+              | Ok cursor ->
+                (match private_jsonl_capture Sync_rewrite_parent (fun () ->
+                   fsync_parent_directory dir)
+                 with
+                 | Ok () -> Ok cursor
+                 | Error failure ->
+                   Error
+                     (Rewrite_published_durability_unknown
+                        { cursor = Some cursor; failure }))))))
+;;
+
+let append_private_jsonl_durable_locked_at_cursor_with_io ~io path ~expected suffix =
+  if String.equal suffix ""
+     || not (Char.equal suffix.[String.length suffix - 1] '\n')
+  then Error Invalid_transaction_suffix
+  else
+    let success cursor = Cursor_succeeded cursor in
+    with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir ~path ->
+    match
+      private_jsonl_open_existing
+        ~close_fd:io.close_fd
+        path
+        [ Unix.O_RDWR; Unix.O_APPEND ]
+    with
+    | Error _ as error -> error
+    | Ok None ->
+      let actual = Private_jsonl_cursor.Missing in
+      if not (Private_jsonl_cursor.equal expected actual)
+      then Error (Cursor_mismatch { expected; actual })
+      else private_jsonl_replace_locked ~dir path suffix
+    | Ok (Some fd) ->
+      private_jsonl_with_fd
+        ~close_operation:Close_transaction_data
+        ~close_fd:io.close_fd
+        ~success
+        fd
+        (fun () ->
+           match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd)
+           with
+           | Error failure -> Error (Private_jsonl_operation_failed failure)
+           | Ok stats ->
+             (match private_jsonl_cursor_of_stats stats with
+              | Error _ as error -> error
+              | Ok actual ->
+                if not (Private_jsonl_cursor.equal expected actual)
+                then Error (Cursor_mismatch { expected; actual })
+                else (
+                  match private_jsonl_validate_complete_tail fd stats.Unix.st_size with
+                  | Error _ as error -> error
+                  | Ok () ->
+                    (match private_jsonl_capture Set_transaction_data_permissions (fun () ->
+                       Unix.fchmod fd 0o600)
+                     with
+                     | Error failure ->
+                       Error (Private_jsonl_operation_failed failure)
+                     | Ok () ->
+                       (* See POSIX lseek: O_APPEND owns writes; this resets reads. *)
+                       ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
+                       (match
+                          append_fd_durable
+                            ~io:durable_append_unix_io
+                            ~fd
+                            ~original_length:stats.Unix.st_size
+                            suffix
+                        with
+                        | Error append_error ->
+                          Error (Transaction_append_failed append_error)
+                        | Ok () ->
+                          (match private_jsonl_capture Inspect_transaction_data (fun () ->
+                             Unix.fstat fd)
+                           with
+                           | Error failure ->
+                             Error (Private_jsonl_operation_failed failure)
+                           | Ok committed_stats ->
+                             private_jsonl_cursor_of_stats committed_stats))))))
+;;
+
+let append_private_jsonl_durable_locked_at_cursor_result path ~expected suffix =
+  append_private_jsonl_durable_locked_at_cursor_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    suffix
+;;
+
+let append_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected
+      suffix
+  =
+  append_private_jsonl_durable_locked_at_cursor_with_io
+    ~io
+    path
+    ~expected
+    suffix
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_with_io
+      ~io
+      path
+      ~expected
+      content
+  =
+  if not (String.equal content "")
+     && not (Char.equal content.[String.length content - 1] '\n')
+  then Error Invalid_transaction_suffix
+  else
+    with_private_jsonl_stable_lock
+      ~io
+      ~success:(fun cursor -> Cursor_succeeded cursor)
+      path
+    @@ fun ~dir ~path ->
+    match private_jsonl_current_cursor ~io path with
+    | Error _ as error -> error
+    | Ok actual ->
+      if not (Private_jsonl_cursor.equal expected actual)
+      then Error (Cursor_mismatch { expected; actual })
+      else private_jsonl_replace_locked ~dir path content
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_result
+      path
+      ~expected
+      content
+  =
+  rewrite_private_jsonl_durable_locked_at_cursor_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected
+    content
+;;
+
+let rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected
+      content
+  =
+  rewrite_private_jsonl_durable_locked_at_cursor_with_io
+    ~io
+    path
+    ~expected
+    content
+;;
+
 module Private_jsonl_slice = struct
   type t =
     { bytes : string
@@ -1765,10 +2827,10 @@ module Private_jsonl_slice = struct
   ;;
 end
 
-let read_private_jsonl_slice_locked_result path ~from =
+let read_private_jsonl_slice_locked_with_io ~io path ~from =
   let open Private_jsonl_slice in
   if from < 0
-  then Error (Negative_offset from)
+  then Private_file_failed (Negative_offset from)
   else
     try
       test_exec_home_guard ~op:"read_private_jsonl_slice_locked" path;
@@ -1781,63 +2843,85 @@ let read_private_jsonl_slice_locked_result path ~from =
              match Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 with
              | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
                if from = 0
-               then Ok { bytes = ""; end_offset = 0 }
-               else Error (Missing_file_after_offset from)
+               then Private_file_succeeded { bytes = ""; end_offset = 0 }
+               else Private_file_failed (Missing_file_after_offset from)
              | fd ->
-               Fun.protect
-                 ~finally:(fun () -> Unix.close fd)
+               private_jsonl_with_fd_outcome
+                 ~close_operation:Close_transaction_data
+                 ~close_fd:io.close_fd
+                 fd
                  (fun () ->
-                    lock_whole_file_shared fd;
-                    let end_offset = Unix.lseek fd 0 Unix.SEEK_END in
-                    if from > end_offset
-                    then Error (Offset_beyond_end { offset = from; end_offset })
-                    else (
-                      let byte_at offset =
-                        (* See Unix.lseek: only the file-position side effect is required. *)
-                        ignore (Unix.lseek fd offset Unix.SEEK_SET : int);
-                        let byte = Bytes.create 1 in
-                        let rec read () =
-                          match Unix.read fd byte 0 1 with
-                          | 1 -> Bytes.get byte 0
-                          | 0 -> raise End_of_file
-                          | count ->
-                            invalid_arg
-                              (Printf.sprintf
-                                 "single-byte JSONL read returned %d bytes"
-                                 count)
-                          | exception Unix.Unix_error (Unix.EINTR, _, _) -> read ()
-                        in
-                        read ()
-                      in
-                      if from > 0 && not (Char.equal (byte_at (from - 1)) '\n')
-                      then Error (Offset_not_at_row_boundary from)
-                      else if
-                        end_offset > 0
-                        && not (Char.equal (byte_at (end_offset - 1)) '\n')
-                      then Error (Incomplete_tail end_offset)
+                    try
+                      lock_whole_file_shared fd;
+                      let end_offset = Unix.lseek fd 0 Unix.SEEK_END in
+                      if from > end_offset
+                      then Error (Offset_beyond_end { offset = from; end_offset })
                       else (
-                        let length = end_offset - from in
-                        (* See Unix.lseek: only the file-position side effect is required. *)
-                        ignore (Unix.lseek fd from Unix.SEEK_SET : int);
-                        let bytes = Bytes.create length in
-                        let rec read_all offset =
-                          if offset = length
-                          then ()
-                          else
-                            match Unix.read fd bytes offset (length - offset) with
+                        let byte_at offset =
+                          (* See Unix.lseek: only the file-position side effect is required. *)
+                          ignore (Unix.lseek fd offset Unix.SEEK_SET : int);
+                          let byte = Bytes.create 1 in
+                          let rec read () =
+                            match Unix.read fd byte 0 1 with
+                            | 1 -> Bytes.get byte 0
                             | 0 -> raise End_of_file
-                            | count -> read_all (offset + count)
+                            | count ->
+                              invalid_arg
+                                (Printf.sprintf
+                                   "single-byte JSONL read returned %d bytes"
+                                   count)
                             | exception Unix.Unix_error (Unix.EINTR, _, _) ->
-                              read_all offset
+                              read ()
+                          in
+                          read ()
                         in
-                        read_all 0;
-                        Ok { bytes = Bytes.unsafe_to_string bytes; end_offset })))))
+                        if from > 0
+                           && not (Char.equal (byte_at (from - 1)) '\n')
+                        then Error (Offset_not_at_row_boundary from)
+                        else if
+                          end_offset > 0
+                          && not (Char.equal (byte_at (end_offset - 1)) '\n')
+                        then Error (Incomplete_tail end_offset)
+                        else (
+                          let length = end_offset - from in
+                          (* See Unix.lseek: only the file-position side effect is required. *)
+                          ignore (Unix.lseek fd from Unix.SEEK_SET : int);
+                          let bytes = Bytes.create length in
+                          let rec read_all offset =
+                            if offset = length
+                            then ()
+                            else
+                              match Unix.read fd bytes offset (length - offset) with
+                              | 0 -> raise End_of_file
+                              | count -> read_all (offset + count)
+                              | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+                                read_all offset
+                          in
+                          read_all 0;
+                          Ok
+                            { bytes = Bytes.unsafe_to_string bytes
+                            ; end_offset
+                            }))
+                    with
+                    | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+                    | exn -> Error (Io_failed exn))))
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Io_failed exn)
+    | exn -> Private_file_failed (Io_failed exn)
 ;;
 
-let update_private_file_durable_locked_result path decide =
+let read_private_jsonl_slice_locked_result path ~from =
+  read_private_jsonl_slice_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~from
+;;
+
+let read_private_jsonl_slice_locked_with_io_for_testing ~io path ~from =
+  read_private_jsonl_slice_locked_with_io ~io path ~from
+;;
+
+let update_private_file_durable_locked_with_io ~io path decide =
   test_exec_home_guard ~op:"update_private_file_durable_locked" path;
   let dir = Filename.dirname path in
   mkdir_p_memoized dir;
@@ -1852,8 +2936,10 @@ let update_private_file_durable_locked_result path decide =
           [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
           0o600
       in
-      Fun.protect
-        ~finally:(fun () -> Unix.close fd)
+      private_jsonl_with_fd_outcome
+        ~close_operation:Close_transaction_data
+        ~close_fd:io.close_fd
+        fd
         (fun () ->
            Unix.fchmod fd 0o600;
            fsync_parent_directory dir;
@@ -1875,6 +2961,17 @@ let update_private_file_durable_locked_result path decide =
                 ~original_length
                 suffix
               |> Result.map (fun () -> result))))
+;;
+
+let update_private_file_durable_locked_result path decide =
+  update_private_file_durable_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    decide
+;;
+
+let update_private_file_durable_locked_with_io_for_testing ~io path decide =
+  update_private_file_durable_locked_with_io ~io path decide
 ;;
 
 let rewrite_private_file_durable_locked_result path decide =
@@ -1922,17 +3019,19 @@ let private_jsonl_append_error_to_string = function
   | Durable_jsonl_append_failed error -> durable_append_error_to_string error
 ;;
 
-let append_private_jsonl_durable_locked_with_expected_end_offset_result
+let append_private_jsonl_durable_locked_with_expected_end_offset_with_io
+      ~io
       path
       ~expected_end_offset
       suffix
   =
   if String.equal suffix ""
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
-  then Error Invalid_jsonl_suffix
+  then Private_file_failed Invalid_jsonl_suffix
   else
     match expected_end_offset with
-    | Some offset when offset < 0 -> Error (Negative_expected_end_offset offset)
+    | Some offset when offset < 0 ->
+      Private_file_failed (Negative_expected_end_offset offset)
     | _ ->
       run_blocking_private_file_transaction
         ~label:"fs-compat-durable-append"
@@ -1952,8 +3051,10 @@ let append_private_jsonl_durable_locked_with_expected_end_offset_result
                  [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
                  0o600
              in
-             Fun.protect
-               ~finally:(fun () -> Unix.close fd)
+             private_jsonl_with_fd_outcome
+               ~close_operation:Close_transaction_data
+               ~close_fd:io.close_fd
+               fd
                (fun () ->
                   Unix.fchmod fd 0o600;
                   fsync_parent_directory dir;
@@ -1999,6 +3100,18 @@ let append_private_jsonl_durable_locked_with_expected_end_offset_result
                         original_length + String.length suffix)))))
 ;;
 
+let append_private_jsonl_durable_locked_with_expected_end_offset_result
+      path
+      ~expected_end_offset
+      suffix
+  =
+  append_private_jsonl_durable_locked_with_expected_end_offset_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
+    ~expected_end_offset
+    suffix
+;;
+
 let append_private_jsonl_durable_locked_with_end_offset_result path suffix =
   append_private_jsonl_durable_locked_with_expected_end_offset_result
     path
@@ -2019,7 +3132,20 @@ let append_private_jsonl_durable_locked_at_end_offset_result
 
 let append_private_jsonl_durable_locked_result path suffix =
   append_private_jsonl_durable_locked_with_end_offset_result path suffix
-  |> Result.map ignore
+  |> private_file_transaction_map ignore
+;;
+
+let append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing
+      ~io
+      path
+      ~expected_end_offset
+      suffix
+  =
+  append_private_jsonl_durable_locked_with_expected_end_offset_with_io
+    ~io
+    path
+    ~expected_end_offset:(Some expected_end_offset)
+    suffix
 ;;
 
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -741,13 +741,6 @@ module Private_jsonl_slice : sig
   val error_to_string : error -> string
 end
 
-(** Read the exact complete JSONL bytes in [[from, end_offset)] while holding
-    the same per-path in-process mutex and a cross-process read lock used by
-    durable private JSONL writers. A missing file at offset zero is the empty
-    stream; every other cursor mismatch is explicit. *)
-val read_private_jsonl_slice_locked_result :
-  string -> from:int -> (Private_jsonl_slice.t, Private_jsonl_slice.error) result
-
 type durable_append_operation =
   | Write
   | Append_fsync
@@ -768,6 +761,239 @@ type durable_append_error =
   ; rollback_failures : durable_append_failure list
   }
 
+module Private_jsonl_cursor : sig
+  (** Durable identity of a private JSONL store. The file identity is part of
+      the cursor so an atomic rewrite cannot be mistaken for an append-only
+      continuation at the same byte offset. *)
+  type t
+
+  val equal : t -> t -> bool
+  val to_string : t -> string
+end
+
+type private_jsonl_snapshot =
+  { bytes : string
+  ; cursor : Private_jsonl_cursor.t
+  }
+
+type private_jsonl_transaction_operation =
+  | Create_parent_directory
+  | Canonicalize_parent_directory
+  | Inspect_stable_lock
+  | Open_stable_lock
+  | Set_stable_lock_permissions
+  | Sync_stable_lock_parent
+  | Acquire_stable_lock
+  | Read_stable_lock_state
+  | Write_stable_lock_state
+  | Sync_stable_lock
+  | Close_stable_lock
+  | Open_transaction_data
+  | Set_transaction_data_permissions
+  | Inspect_transaction_data
+  | Inspect_transaction_path
+  | Read_transaction_data
+  | Close_transaction_data
+  | Create_rewrite_stage
+  | Set_rewrite_stage_permissions
+  | Write_rewrite_stage
+  | Sync_rewrite_stage
+  | Close_rewrite_stage
+  | Rename_rewrite_stage
+  | Sync_rewrite_parent
+  | Inspect_rewritten_data
+  | Remove_rewrite_stage
+
+type private_jsonl_operation_failure =
+  { operation : private_jsonl_transaction_operation
+  ; exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type ('value, 'error) private_file_transaction_outcome =
+  | Private_file_succeeded of 'value
+  | Private_file_succeeded_with_cleanup_failure of
+      { value : 'value
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+  | Private_file_failed of 'error
+  | Private_file_failed_with_cleanup_failure of
+      { error : 'error
+      ; cleanup_failure : private_jsonl_operation_failure
+      }
+(** Result and descriptor-settlement outcome of a blocking private-file
+    transaction. A cleanup failure never replaces the primary value/error, and
+    a successful durable effect remains distinguishable from a primary failure
+    so callers cannot retry it accidentally. Exceptions documented by the
+    underlying operation still propagate. *)
+
+val private_jsonl_operation_failure_to_string :
+  private_jsonl_operation_failure -> string
+
+(** Read the exact complete JSONL bytes in [[from, end_offset)] while holding
+    the same per-path in-process mutex and a cross-process read lock used by
+    durable private JSONL writers. A missing file at offset zero is the empty
+    stream; every other cursor mismatch is explicit. Descriptor-close failure
+    preserves the successful slice or primary read error. *)
+val read_private_jsonl_slice_locked_result :
+  string ->
+  from:int ->
+  ( Private_jsonl_slice.t
+  , Private_jsonl_slice.error )
+  private_file_transaction_outcome
+
+type private_jsonl_transaction_success =
+  | Snapshot_succeeded of private_jsonl_snapshot
+  | Cursor_succeeded of Private_jsonl_cursor.t
+  | Cursor_precondition_succeeded of Private_jsonl_cursor.t
+
+type private_jsonl_transaction_primary =
+  | Transaction_succeeded of private_jsonl_transaction_success
+  | Transaction_failed of private_jsonl_transaction_error
+
+and private_jsonl_transaction_error =
+  | Stable_lock_contended of { lock_path : string }
+  | Unexpected_stable_lock_permissions of
+      { path : string
+      ; actual : int
+      }
+  | Invalid_stable_lock_state of
+      { path : string
+      ; observed_length : int
+      }
+  | Cursor_mismatch of
+      { expected : Private_jsonl_cursor.t
+      ; actual : Private_jsonl_cursor.t
+      }
+  | Unexpected_transaction_file_kind of Unix.file_kind
+  | Ambiguous_transaction_file_identity of
+      { path : string
+      ; link_count : int
+      }
+  | Transaction_path_binding_changed of { path : string }
+  | Incomplete_transaction_tail of { end_offset : int }
+  | Invalid_transaction_suffix
+  | Private_jsonl_operation_failed of private_jsonl_operation_failure
+  | Rewrite_stage_failed of
+      { failure : private_jsonl_operation_failure
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
+  | Rewrite_published_durability_unknown of
+      { cursor : Private_jsonl_cursor.t option
+      ; failure : private_jsonl_operation_failure
+      }
+  | Transaction_settlement_failed of
+      { primary : private_jsonl_transaction_primary
+      ; cleanup_failures : private_jsonl_operation_failure list
+      }
+  | Transaction_append_failed of durable_append_error
+
+type 'a private_jsonl_success_receipt =
+  { value : 'a
+  ; settlement_error : private_jsonl_transaction_error option
+  }
+(** A completed transaction value together with exact evidence that descriptor
+    settlement remained incomplete. Consumers may advance from [value], but
+    must observe [settlement_error]. Primary failures and mismatched success
+    kinds are never converted to receipts. *)
+
+val private_jsonl_snapshot_success_receipt :
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result ->
+  ( private_jsonl_snapshot private_jsonl_success_receipt
+  , private_jsonl_transaction_error )
+  result
+
+val private_jsonl_cursor_success_receipt :
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result ->
+  ( Private_jsonl_cursor.t private_jsonl_success_receipt
+  , private_jsonl_transaction_error )
+  result
+
+val private_jsonl_transaction_error_to_string :
+  private_jsonl_transaction_error -> string
+
+(** Stable sibling lock owned by the private JSONL transaction protocol. It is
+    created with mode [0600] and must never be renamed or removed while the
+    store may be in use. *)
+val private_jsonl_lock_path : string -> string
+
+(** Read a private JSONL store under its stable sibling lock. [after = None]
+    returns the full store. [after = Some cursor] returns only bytes appended
+    after that exact file identity and offset. A replacement, truncation, or
+    disappearance is a typed [Cursor_mismatch], never an implicit full rescan.
+    The returned cursor distinguishes a missing store from a present empty
+    store. *)
+val read_private_jsonl_durable_locked_result :
+  string ->
+  after:Private_jsonl_cursor.t option ->
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result
+
+type private_jsonl_transaction_io_for_testing =
+  { before_sync_parent : string -> unit
+  ; close_fd : Unix.file_descr -> unit
+  }
+
+val read_private_jsonl_slice_locked_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  from:int ->
+  ( Private_jsonl_slice.t
+  , Private_jsonl_slice.error )
+  private_file_transaction_outcome
+
+val update_private_file_durable_locked_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  (string -> string option * 'a) ->
+  ('a, durable_append_error) private_file_transaction_outcome
+
+(** Production-path seam for deterministic stable-lock creation and descriptor
+    settlement tests. *)
+val read_private_jsonl_durable_locked_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  after:Private_jsonl_cursor.t option ->
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result
+
+(** Append complete newline-terminated JSONL rows iff [expected] still names
+    the exact store identity and end offset observed by the caller. All
+    participants must use this stable-lock transaction family for [path]; the
+    sibling lock is never renamed, so atomic rewrites cannot strand an appender
+    on the old inode. Lock contention and stale cursors fail explicitly without
+    timeout, retry, or backoff policy. *)
+val append_private_jsonl_durable_locked_at_cursor_result :
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Production-path seam for cancellation during descriptor settlement. *)
+val append_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Atomically replace a complete private JSONL store iff [expected] still
+    names the exact current store. The staged payload and parent directory are
+    fsynced; no directory-fsync failure is suppressed. The stable sibling lock
+    remains the serialization authority across the inode replacement. *)
+val rewrite_private_jsonl_durable_locked_at_cursor_result :
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
+(** Production-path seam proving that a descriptor settlement failure while
+    reading the rewrite precondition is not classified as a committed rewrite. *)
+val rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  expected:Private_jsonl_cursor.t ->
+  string ->
+  (Private_jsonl_cursor.t, private_jsonl_transaction_error) result
+
 val durable_append_failure_to_string : durable_append_failure -> string
 
 (** Render a structured durable-append failure without discarding the original
@@ -777,21 +1003,25 @@ val durable_append_error_to_string : durable_append_error -> string
 (** [update_private_file_durable_locked_result path decide] serializes in-process
     callers with the shared per-path append mutex, takes a cross-process file
     lock, reads the exact existing bytes, and calls [decide]. [Some suffix]
-    appends the complete suffix and fsyncs it before returning [Ok]; [None]
-    performs no write. If writing or the append fsync fails, the file is
-    truncated to its original length and that rollback is fsynced. [Error]
-    preserves the append failure and every rollback failure. Setup, read, and
-    [decide] exceptions still propagate. The file is created with mode [0600],
-    and every transaction fsyncs its parent directory before touching payload
-    bytes so a failed creation can be retried without silently skipping that
-    durability boundary. Filesystems that reject directory fsync fail
-    explicitly. The shared path mutex serializes this operation with cached
-    JSONL writers without closing their already-flushed descriptors. When the
-    Eio filesystem is active, the transaction and [decide] run in a system
-    thread so a contended file cannot stop unrelated fibers; [decide] therefore
-    must not perform Eio effects. *)
+    appends the complete suffix and fsyncs it before returning a successful
+    outcome; [None] performs no write. If writing or the append fsync fails,
+    the file is truncated to its original length and that rollback is fsynced.
+    A failed outcome preserves the append failure and every rollback failure.
+    Descriptor-close failure is returned together with the primary value or
+    error, so a committed append is never misclassified as retryable. Setup,
+    read, and [decide] exceptions still propagate. The file is created with
+    mode [0600], and every transaction fsyncs its parent directory before
+    touching payload bytes so a failed creation can be retried without silently
+    skipping that durability boundary. Filesystems that reject directory fsync
+    fail explicitly. The shared path mutex serializes this operation with
+    cached JSONL writers without closing their already-flushed descriptors.
+    When the Eio filesystem is active, the transaction and [decide] run in a
+    system thread so a contended file cannot stop unrelated fibers; [decide]
+    therefore must not perform Eio effects. *)
 val update_private_file_durable_locked_result :
-  string -> (string -> string option * 'a) -> ('a, durable_append_error) result
+  string ->
+  (string -> string option * 'a) ->
+  ('a, durable_append_error) private_file_transaction_outcome
 
 (** [rewrite_private_file_durable_locked_result path decide] is the whole-file
     replacement sibling of {!update_private_file_durable_locked_result}. It takes
@@ -828,9 +1058,12 @@ type private_jsonl_append_error =
     fiber, the entire blocking lock/write/fsync transaction runs in a system
     thread, including directory creation and in-process mutex acquisition, so
     one contended file cannot stop unrelated fibers. Non-Eio callers execute
-    the same transaction directly. *)
+    the same transaction directly. Descriptor-close failure is returned with
+    the primary commit or rejection. *)
 val append_private_jsonl_durable_locked_with_end_offset_result :
-  string -> string -> (int, private_jsonl_append_error) result
+  string ->
+  string ->
+  (int, private_jsonl_append_error) private_file_transaction_outcome
 
 (** Append only when the file's locked byte length is exactly
     [expected_end_offset]. A stale writer receives [End_offset_mismatch] and
@@ -840,12 +1073,21 @@ val append_private_jsonl_durable_locked_at_end_offset_result :
   string ->
   expected_end_offset:int ->
   string ->
-  (int, private_jsonl_append_error) result
+  (int, private_jsonl_append_error) private_file_transaction_outcome
 
 (** As {!append_private_jsonl_durable_locked_with_end_offset_result}, discarding
     the committed newline-end byte offset. *)
 val append_private_jsonl_durable_locked_result :
-  string -> string -> (unit, private_jsonl_append_error) result
+  string ->
+  string ->
+  (unit, private_jsonl_append_error) private_file_transaction_outcome
+
+val append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing :
+  io:private_jsonl_transaction_io_for_testing ->
+  string ->
+  expected_end_offset:int ->
+  string ->
+  (int, private_jsonl_append_error) private_file_transaction_outcome
 
 val private_jsonl_append_error_to_string : private_jsonl_append_error -> string
 

--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -60,6 +60,10 @@ type binding_store_error =
 
 type audit_append_error =
   | Audit_append_failed of Fs_compat.private_jsonl_append_error
+  | Audit_append_failed_with_cleanup of {
+      error : Fs_compat.private_jsonl_append_error;
+      cleanup_failure : Fs_compat.private_jsonl_operation_failure;
+    }
   | Audit_io_failed of string
 
 type mutation_error =
@@ -95,6 +99,11 @@ let binding_store_error_to_string = function
 
 let audit_append_error_to_string = function
   | Audit_append_failed error -> Fs_compat.private_jsonl_append_error_to_string error
+  | Audit_append_failed_with_cleanup { error; cleanup_failure } ->
+    Printf.sprintf
+      "%s; descriptor settlement failed: %s"
+      (Fs_compat.private_jsonl_append_error_to_string error)
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure)
   | Audit_io_failed detail -> detail
 
 let mutation_error_to_string = function
@@ -274,8 +283,18 @@ let append_audit_event_result store event =
   let path = store.binding_audit_path () in
   let suffix = Yojson.Safe.to_string (audit_event_json store event) ^ "\n" in
   try
-    Fs_compat.append_private_jsonl_durable_locked_result path suffix
-    |> Result.map_error (fun error -> Audit_append_failed error)
+    match Fs_compat.append_private_jsonl_durable_locked_result path suffix with
+    | Private_file_succeeded () -> Ok ()
+    | Private_file_succeeded_with_cleanup_failure
+        { value = (); cleanup_failure } ->
+      Log.Gate.error
+        "binding audit append succeeded with descriptor settlement failure path=%s: %s"
+        path
+        (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+      Ok ()
+    | Private_file_failed error -> Error (Audit_append_failed error)
+    | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+      Error (Audit_append_failed_with_cleanup { error; cleanup_failure })
   with
   | Sys_error detail -> Error (Audit_io_failed detail)
   | Unix.Unix_error (code, fn, arg) ->

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -45,6 +45,10 @@ type binding_store_error =
 
 type audit_append_error =
   | Audit_append_failed of Fs_compat.private_jsonl_append_error
+  | Audit_append_failed_with_cleanup of {
+      error : Fs_compat.private_jsonl_append_error;
+      cleanup_failure : Fs_compat.private_jsonl_operation_failure;
+    }
   | Audit_io_failed of string
 
 type mutation_error =

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -691,8 +691,21 @@ let read_locked path parse =
     Fs_compat.update_private_file_durable_locked_result path (fun content ->
       None, parse content)
   with
-  | Error error -> Error (durable_error_to_string error)
-  | Ok result -> result
+  | Private_file_failed error -> Error (durable_error_to_string error)
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "%s; descriptor settlement failed: %s"
+         (durable_error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
+  | Private_file_succeeded result -> result
+  | Private_file_succeeded_with_cleanup_failure
+      { value = result; cleanup_failure } ->
+    Log.Keeper.error
+      "board attention candidate read succeeded with descriptor settlement failure path=%s: %s"
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    result
 ;;
 
 (* Read-side stat memo. Owner-lane drains call [load_candidates] far more often

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -608,10 +608,12 @@ let cursor_result ~ledger_path result =
 ;;
 
 let invalidate_cached entry observed =
+  (* fire-and-forget: false means a concurrent writer won; the loser simply keeps no stale cache *)
   ignore (Atomic.compare_and_set entry.cached observed None : bool)
 ;;
 
 let publish_cached entry observed view =
+  (* fire-and-forget: false means a concurrent writer won; readers fall back to recomputing *)
   ignore (Atomic.compare_and_set entry.cached observed (Some view) : bool)
 ;;
 

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -429,8 +429,22 @@ let load ~base_path ~keeper_name =
       Fs_compat.update_private_file_durable_locked_result ledger_path (fun content ->
         None, Result.bind (parse content) (validate_ledger keeper_name))
     with
-    | Ok result -> result
-    | Error error -> Error (Fs_compat.durable_append_error_to_string error)
+    | Private_file_failed error ->
+      Error (Fs_compat.durable_append_error_to_string error)
+    | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+      Error
+        (Printf.sprintf
+           "%s; descriptor settlement failed: %s"
+           (Fs_compat.durable_append_error_to_string error)
+           (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
+    | Private_file_succeeded result -> result
+    | Private_file_succeeded_with_cleanup_failure
+        { value = result; cleanup_failure } ->
+      Log.Keeper.error
+        "board attention partition read succeeded with descriptor settlement failure path=%s: %s"
+        ledger_path
+        (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+      result
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -374,112 +374,324 @@ let root_id ~keeper_name ~context_key ~candidate_id =
   "ba-root-" ^ Digestif.SHA256.(digest_string payload |> to_hex)
 ;;
 
+module Ready_order = struct
+  type nonrec t =
+    { created_at : float
+    ; partition_id : string
+    }
+
+  let compare left right =
+    match Float.compare left.created_at right.created_at with
+    | 0 -> String.compare left.partition_id right.partition_id
+    | ordering -> ordering
+  ;;
+end
+
+module Ready_set = Set.Make (Ready_order)
+
+type view =
+  { cursor : Fs_compat.Private_jsonl_cursor.t
+  ; by_id : t Id_map.t
+  ; ready : Ready_set.t
+  ; completed : Id_set.t
+  ; live_candidate_owner : string Id_map.t
+  }
+
+let empty_view cursor =
+  { cursor
+  ; by_id = Id_map.empty
+  ; ready = Ready_set.empty
+  ; completed = Id_set.empty
+  ; live_candidate_owner = Id_map.empty
+  }
+;;
+
 let is_live = function
   | Ready | Running _ | Deferred _ | Completed _ | Blocked _ -> true
   | Settled _ -> false
 ;;
 
-let validate_ledger keeper_name rows =
-  let* (_ : Id_set.t * Id_set.t) =
-    List.fold_left
-      (fun result row ->
-         let* partition_ids, live_candidate_ids = result in
-         if not (String.equal row.keeper_name keeper_name)
-         then
-           Error
-             (Printf.sprintf
-                "Board attention partition keeper mismatch expected=%s actual=%s partition=%s"
-                keeper_name
-                row.keeper_name
-                row.partition_id)
-         else
-           let expected_id =
-             root_id
-               ~keeper_name:row.keeper_name
-               ~context_key:row.context_key
-               ~candidate_id:row.candidate_id
-           in
-           if not (String.equal row.partition_id expected_id)
-           then
-             Error
-               (Printf.sprintf
-                  "Board attention partition identity mismatch expected=%s actual=%s"
-                  expected_id
-                  row.partition_id)
-           else if Id_set.mem row.partition_id partition_ids
-           then Error ("duplicate Board attention partition id: " ^ row.partition_id)
-           else if is_live row.state && Id_set.mem row.candidate_id live_candidate_ids
-           then Error ("duplicate live Board attention candidate membership: " ^ row.candidate_id)
-           else
-             Ok
-               ( Id_set.add row.partition_id partition_ids
-               , if is_live row.state
-                 then Id_set.add row.candidate_id live_candidate_ids
-                 else live_candidate_ids ))
-      (Ok (Id_set.empty, Id_set.empty))
-      rows
+let compare_partition left right =
+  match Float.compare left.created_at right.created_at with
+  | 0 -> String.compare left.partition_id right.partition_id
+  | ordering -> ordering
+;;
+
+let ready_order partition : Ready_order.t =
+  { created_at = partition.created_at; partition_id = partition.partition_id }
+;;
+
+let remove_partition_indexes view partition =
+  let ready =
+    match partition.state with
+    | Ready -> Ready_set.remove (ready_order partition) view.ready
+    | Running _ | Deferred _ | Completed _ | Settled _ | Blocked _ -> view.ready
   in
-  Ok rows
+  let completed =
+    match partition.state with
+    | Completed _ -> Id_set.remove partition.partition_id view.completed
+    | Ready | Running _ | Deferred _ | Settled _ | Blocked _ -> view.completed
+  in
+  let live_candidate_owner =
+    if is_live partition.state
+    then Id_map.remove partition.candidate_id view.live_candidate_owner
+    else view.live_candidate_owner
+  in
+  { view with ready; completed; live_candidate_owner }
+;;
+
+let add_partition_indexes view partition =
+  let* live_candidate_owner =
+    if not (is_live partition.state)
+    then Ok view.live_candidate_owner
+    else
+      match Id_map.find_opt partition.candidate_id view.live_candidate_owner with
+      | None ->
+        Ok
+          (Id_map.add
+             partition.candidate_id
+             partition.partition_id
+             view.live_candidate_owner)
+      | Some existing ->
+        Error
+          (Printf.sprintf
+             "candidate %s belongs to live partitions %s and %s"
+             partition.candidate_id
+             existing
+             partition.partition_id)
+  in
+  let ready =
+    match partition.state with
+    | Ready -> Ready_set.add (ready_order partition) view.ready
+    | Running _ | Deferred _ | Completed _ | Settled _ | Blocked _ -> view.ready
+  in
+  let completed =
+    match partition.state with
+    | Completed _ -> Id_set.add partition.partition_id view.completed
+    | Ready | Running _ | Deferred _ | Settled _ | Blocked _ -> view.completed
+  in
+  Ok
+    { view with
+      by_id = Id_map.add partition.partition_id partition view.by_id
+    ; ready
+    ; completed
+    ; live_candidate_owner
+    }
+;;
+
+let same_partition_identity left right =
+  String.equal left.partition_id right.partition_id
+  && String.equal left.keeper_name right.keeper_name
+  && Candidate.Context_key.equal left.context_key right.context_key
+  && String.equal left.candidate_id right.candidate_id
+  && Float.equal left.created_at right.created_at
+;;
+
+let legal_transition previous next =
+  match previous, next with
+  | Ready, Running _ -> true
+  | Running _, (Ready | Deferred _ | Completed _ | Blocked _) -> true
+  | Deferred _, Ready -> true
+  | Completed _, Settled _ -> true
+  | Ready, (Ready | Deferred _ | Completed _ | Settled _ | Blocked _)
+  | Running _, (Running _ | Settled _)
+  | Deferred _, (Running _ | Deferred _ | Completed _ | Settled _ | Blocked _)
+  | Completed _, (Ready | Running _ | Deferred _ | Completed _ | Blocked _)
+  | Settled _, (Ready | Running _ | Deferred _ | Completed _ | Settled _ | Blocked _)
+  | Blocked _, (Ready | Running _ | Deferred _ | Completed _ | Settled _ | Blocked _) ->
+    false
+;;
+
+let validate_root_identity partition =
+  let expected =
+    root_id
+      ~keeper_name:partition.keeper_name
+      ~context_key:partition.context_key
+      ~candidate_id:partition.candidate_id
+  in
+  if String.equal expected partition.partition_id
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "partition root identity mismatch expected=%s observed=%s"
+         expected
+         partition.partition_id)
+;;
+
+let apply_row view partition =
+  let* () = validate_root_identity partition in
+  match Id_map.find_opt partition.partition_id view.by_id with
+  | None -> add_partition_indexes view partition
+  | Some previous ->
+    if not (same_partition_identity previous partition)
+    then Error ("partition changed immutable identity: " ^ partition.partition_id)
+    else if previous = partition
+    then Ok view
+    else if not (legal_transition previous.state partition.state)
+    then
+      Error
+        (Printf.sprintf
+           "partition %s illegal transition %s -> %s"
+           partition.partition_id
+           (state_to_string previous.state)
+           (state_to_string partition.state))
+    else
+      add_partition_indexes (remove_partition_indexes view previous) partition
+;;
+
+let apply_rows view rows =
+  List.fold_left
+    (fun result partition ->
+       let* view = result in
+       apply_row view partition)
+    (Ok view)
+    rows
+;;
+
+let view_partitions view =
+  view.by_id
+  |> Id_map.bindings
+  |> List.map snd
+  |> List.sort compare_partition
+;;
+
+type cache_entry =
+  { cached : view option Atomic.t
+  ; mutation_mutex : Stdlib.Mutex.t
+  }
+
+let cache_registry : (string, cache_entry) Hashtbl.t = Hashtbl.create 32
+let cache_registry_mutex = Stdlib.Mutex.create ()
+
+let cache_entry ledger_path =
+  Stdlib.Mutex.protect cache_registry_mutex (fun () ->
+    match Hashtbl.find_opt cache_registry ledger_path with
+    | Some entry -> entry
+    | None ->
+      let entry =
+        { cached = Atomic.make None; mutation_mutex = Stdlib.Mutex.create () }
+      in
+      Hashtbl.add cache_registry ledger_path entry;
+      entry)
+;;
+
+let run_blocking label operation =
+  match Eio.Fiber.is_cancelled () with
+  | true | false -> Eio_unix.run_in_systhread ~label operation
+  | exception Effect.Unhandled _ -> operation ()
+;;
+
+let store_error = Fs_compat.private_jsonl_transaction_error_to_string
+
+let observe_settlement_warning ~ledger_path error =
+  Log.Keeper.error
+    "board_attention_partition: descriptor settlement incomplete ledger=%s detail=%s"
+    ledger_path
+    (store_error error)
+;;
+
+let snapshot_result ~ledger_path result =
+  match Fs_compat.private_jsonl_snapshot_success_receipt result with
+  | Error error -> Error (store_error error)
+  | Ok { value; settlement_error } ->
+    Option.iter (observe_settlement_warning ~ledger_path) settlement_error;
+    Ok value
+;;
+
+let cursor_result ~ledger_path result =
+  match Fs_compat.private_jsonl_cursor_success_receipt result with
+  | Error error -> Error (store_error error)
+  | Ok { value; settlement_error } ->
+    Option.iter (observe_settlement_warning ~ledger_path) settlement_error;
+    Ok value
+;;
+
+let invalidate_cached entry observed =
+  ignore (Atomic.compare_and_set entry.cached observed None : bool)
+;;
+
+let publish_cached entry observed view =
+  ignore (Atomic.compare_and_set entry.cached observed (Some view) : bool)
+;;
+
+let read_view_blocking ledger_path =
+  let entry = cache_entry ledger_path in
+  let observed = Atomic.get entry.cached in
+  let after = Option.map (fun view -> view.cursor) observed in
+  match
+    Fs_compat.read_private_jsonl_durable_locked_result ledger_path ~after
+    |> snapshot_result ~ledger_path
+  with
+  | Error error ->
+    invalidate_cached entry observed;
+    Error error
+  | Ok snapshot ->
+    let* rows = parse snapshot.bytes in
+    let base =
+      match observed with
+      | Some view -> view
+      | None -> empty_view snapshot.cursor
+    in
+    let* view = apply_rows base rows in
+    let view = { view with cursor = snapshot.cursor } in
+    publish_cached entry observed view;
+    Ok view
+;;
+
+let read_view ledger_path =
+  run_blocking "board-attention-partition-read" (fun () ->
+    let entry = cache_entry ledger_path in
+    Stdlib.Mutex.protect entry.mutation_mutex (fun () -> read_view_blocking ledger_path))
+;;
+
+let validate_keeper_identity ~keeper_name view =
+  Id_map.fold
+    (fun _ partition result ->
+       let* () = result in
+       if String.equal partition.keeper_name keeper_name
+       then Ok ()
+       else
+         Error
+           (Printf.sprintf
+              "Board attention partition keeper mismatch expected=%s actual=%s partition=%s"
+              keeper_name
+              partition.keeper_name
+              partition.partition_id))
+    view.by_id
+    (Ok ())
 ;;
 
 let load ~base_path ~keeper_name =
-  let ledger_path = path ~base_path ~keeper_name in
-  try
-    match
-      Fs_compat.update_private_file_durable_locked_result ledger_path (fun content ->
-        None, Result.bind (parse content) (validate_ledger keeper_name))
-    with
-    | Private_file_failed error ->
-      Error (Fs_compat.durable_append_error_to_string error)
-    | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
-      Error
-        (Printf.sprintf
-           "%s; descriptor settlement failed: %s"
-           (Fs_compat.durable_append_error_to_string error)
-           (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
-    | Private_file_succeeded result -> result
-    | Private_file_succeeded_with_cleanup_failure
-        { value = result; cleanup_failure } ->
-      Log.Keeper.error
-        "board attention partition read succeeded with descriptor settlement failure path=%s: %s"
-        ledger_path
-        (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
-      result
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Error
-      (Printf.sprintf
-         "Board attention partition load failed path=%s: %s"
-         ledger_path
-         (Printexc.to_string exn))
+  let* view = read_view (path ~base_path ~keeper_name) in
+  let* () = validate_keeper_identity ~keeper_name view in
+  Ok (view_partitions view)
 ;;
 
 let update ~base_path ~keeper_name decide =
   let ledger_path = path ~base_path ~keeper_name in
-  try
-    match
-      Fs_compat.rewrite_private_file_durable_locked_result ledger_path (fun content ->
-        let result =
-          let* rows = parse content in
-          let* rows = validate_ledger keeper_name rows in
-          decide rows
-        in
-        match result with
-        | Error _ as error -> None, error
-        | Ok (changed, rows, value) ->
-          (if changed then Some (serialize rows) else None), Ok value)
-    with
-    | Ok result -> result
-    | Error detail -> Error detail
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Error
-      (Printf.sprintf
-         "Board attention partition update failed path=%s: %s"
-         ledger_path
-         (Printexc.to_string exn))
+  run_blocking "board-attention-partition-update" (fun () ->
+    let entry = cache_entry ledger_path in
+    Stdlib.Mutex.protect entry.mutation_mutex (fun () ->
+      let* view = read_view_blocking ledger_path in
+      let* () = validate_keeper_identity ~keeper_name view in
+      let* rows, result = decide view in
+      match rows with
+      | [] -> Ok result
+      | _ :: _ ->
+        let* updated = apply_rows view rows in
+        let suffix = serialize rows in
+        (match
+           Fs_compat.append_private_jsonl_durable_locked_at_cursor_result
+             ledger_path
+             ~expected:view.cursor
+             suffix
+           |> cursor_result ~ledger_path
+         with
+         | Error error -> Error error
+         | Ok cursor ->
+           Atomic.set entry.cached (Some { updated with cursor });
+           Ok result)))
 ;;
 
 let compare_candidate left right =
@@ -490,183 +702,6 @@ let compare_candidate left right =
 
 let valid_time label value =
   if Float.is_finite value then Ok () else Error (label ^ " must be finite")
-;;
-
-let ensure_roots ~base_path ~keeper_name candidates =
-  update ~base_path ~keeper_name (fun current ->
-    let owners =
-      List.fold_left
-        (fun owners partition ->
-           if is_live partition.state
-           then Id_map.add partition.candidate_id partition owners
-           else owners)
-        Id_map.empty
-        current
-    in
-    let existing_by_id =
-      List.fold_left
-        (fun map partition -> Id_map.add partition.partition_id partition map)
-        Id_map.empty
-        current
-    in
-    let* roots =
-      candidates
-      |> List.sort compare_candidate
-      |> List.fold_left
-           (fun result (candidate : Candidate.candidate) ->
-              let* roots = result in
-              if not (String.equal candidate.keeper_name keeper_name)
-              then Error "candidate Keeper differs from partition ledger Keeper"
-              else
-                let* () = valid_time "candidate recorded_at" candidate.recorded_at in
-                match candidate.status with
-                | Candidate.Consumed _ -> Ok roots
-                | Candidate.Pending _ | Candidate.Judged _ ->
-                  let* context_key = Candidate.Context_key.of_candidate candidate in
-                  (match Id_map.find_opt candidate.candidate_id owners with
-                   | Some owner
-                     when Candidate.Context_key.equal owner.context_key context_key
-                          && Float.equal owner.created_at candidate.recorded_at -> Ok roots
-                   | Some owner ->
-                     Error
-                       (Printf.sprintf
-                          "candidate %s authority differs from live partition %s"
-                          candidate.candidate_id
-                          owner.partition_id)
-                   | None ->
-                     let partition_id =
-                       root_id ~keeper_name ~context_key ~candidate_id:candidate.candidate_id
-                     in
-                     (match Id_map.find_opt partition_id existing_by_id with
-                      | None ->
-                        Ok
-                          ({ partition_id
-                           ; keeper_name
-                           ; context_key
-                           ; candidate_id = candidate.candidate_id
-                           ; created_at = candidate.recorded_at
-                           ; state = Ready
-                           }
-                           :: roots)
-                      | Some historical
-                        when String.equal historical.candidate_id candidate.candidate_id
-                             && Candidate.Context_key.equal historical.context_key context_key
-                             && Float.equal historical.created_at candidate.recorded_at -> Ok roots
-                      | Some _ -> Error ("partition identity collision: " ^ partition_id))))
-           (Ok [])
-      |> Result.map List.rev
-    in
-    match roots with
-    | [] -> Ok (false, current, 0)
-    | _ ->
-      let rows = current @ roots in
-      Ok (true, rows, List.length roots))
-;;
-
-let compare_partition left right =
-  match Float.compare left.created_at right.created_at with
-  | 0 -> String.compare left.partition_id right.partition_id
-  | ordering -> ordering
-;;
-
-let replace_partition selected replacement rows =
-  List.map
-    (fun row ->
-       if String.equal row.partition_id selected.partition_id then replacement else row)
-    rows
-;;
-
-let claim_next ~now ~worker_epoch ~base_path ~keeper_name =
-  let* () = valid_time "partition claim time" now in
-  update ~base_path ~keeper_name (fun rows ->
-    match
-      rows
-      |> List.filter (fun row -> match row.state with Ready -> true | _ -> false)
-      |> List.sort compare_partition
-    with
-    | [] -> Ok (false, rows, None)
-    | selected :: _ ->
-      let claimed = { selected with state = Running { worker_epoch; started_at = now } } in
-      Ok (true, replace_partition selected claimed rows, Some claimed))
-;;
-
-let recover_for_process_start ~base_path ~keeper_name =
-  update ~base_path ~keeper_name (fun rows ->
-    let count, changed, recovered =
-      List.fold_left
-        (fun (count, changed, acc) row ->
-           match row.state with
-           | Running _ -> count + 1, true, { row with state = Ready } :: acc
-           | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
-             count, changed, row :: acc)
-        (0, false, [])
-        rows
-    in
-    Ok (changed, List.rev recovered, count))
-;;
-
-let release_due_provider_retries ~now ~base_path ~keeper_name =
-  let* () = valid_time "Provider retry release time" now in
-  update ~base_path ~keeper_name (fun rows ->
-    let released, changed, updated =
-      List.fold_left
-        (fun (released, changed, acc) row ->
-           match row.state with
-           | Deferred { failure; _ } ->
-             (match Failure.retry_deadline failure with
-              | Some deadline when Float.compare now deadline >= 0 ->
-                released + 1, true, { row with state = Ready } :: acc
-              | Some _ | None -> released, changed, row :: acc)
-           | Ready | Running _ | Completed _ | Settled _ | Blocked _ ->
-             released, changed, row :: acc)
-        (0, false, [])
-        rows
-    in
-    Ok (changed, List.rev updated, released))
-;;
-
-let next_provider_retry_deadline ~base_path ~keeper_name =
-  let* rows = load ~base_path ~keeper_name in
-  Ok
-    (List.fold_left
-       (fun earliest row ->
-          match row.state with
-          | Deferred { failure; _ } ->
-            (match earliest, Failure.retry_deadline failure with
-             | None, deadline -> deadline
-             | Some current, Some candidate
-               when Float.compare candidate current < 0 -> Some candidate
-             | Some _, Some _ | Some _, None -> earliest)
-          | Ready | Running _ | Completed _ | Settled _ | Blocked _ -> earliest)
-       None
-       rows)
-;;
-
-let find_persisted partition rows =
-  match List.find_opt (fun row -> String.equal row.partition_id partition.partition_id) rows with
-  | Some row -> Ok row
-  | None -> Error ("Board attention partition not found: " ^ partition.partition_id)
-;;
-
-let running_owned ~worker_epoch partition =
-  match partition.state with
-  | Running running when Worker_epoch.equal running.worker_epoch worker_epoch -> Ok ()
-  | Running running ->
-    Error
-      (Printf.sprintf
-         "partition %s is owned by worker %s"
-         partition.partition_id
-         (Worker_epoch.to_string running.worker_epoch))
-  | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
-    Error ("partition is not Running: " ^ partition.partition_id)
-;;
-
-let transition_running ~base_path ~partition ~worker_epoch state wrap =
-  update ~base_path ~keeper_name:partition.keeper_name (fun rows ->
-    let* current = find_persisted partition rows in
-    let* () = running_owned ~worker_epoch current in
-    let updated = { current with state } in
-    Ok (true, replace_partition current updated rows, wrap updated))
 ;;
 
 let nonempty label value =
@@ -692,23 +727,195 @@ let validate_blocked_reason = function
   | Judgment_blocked failure -> Failure.validate_blocked failure
 ;;
 
+let ensure_roots ~base_path ~keeper_name candidates =
+  update ~base_path ~keeper_name (fun view ->
+    let* roots =
+      candidates
+      |> List.sort compare_candidate
+      |> List.fold_left
+           (fun result (candidate : Candidate.candidate) ->
+              let* roots = result in
+              if not (String.equal candidate.keeper_name keeper_name)
+              then Error "candidate Keeper differs from partition ledger Keeper"
+              else
+                let* () = valid_time "candidate recorded_at" candidate.recorded_at in
+                match candidate.status with
+                | Candidate.Consumed _ -> Ok roots
+                | Candidate.Pending _ | Candidate.Judged _ ->
+                  let* context_key = Candidate.Context_key.of_candidate candidate in
+                  (match Id_map.find_opt candidate.candidate_id view.live_candidate_owner with
+                   | Some owner_id ->
+                     (match Id_map.find_opt owner_id view.by_id with
+                      | Some owner
+                        when Candidate.Context_key.equal owner.context_key context_key
+                             && Float.equal owner.created_at candidate.recorded_at -> Ok roots
+                      | Some owner ->
+                        Error
+                          (Printf.sprintf
+                             "candidate %s authority differs from live partition %s"
+                             candidate.candidate_id
+                             owner.partition_id)
+                      | None -> Error ("live owner index lost partition " ^ owner_id))
+                   | None ->
+                     let partition_id =
+                       root_id ~keeper_name ~context_key ~candidate_id:candidate.candidate_id
+                     in
+                     (match Id_map.find_opt partition_id view.by_id with
+                      | None ->
+                        Ok
+                          ({ partition_id
+                           ; keeper_name
+                           ; context_key
+                           ; candidate_id = candidate.candidate_id
+                           ; created_at = candidate.recorded_at
+                           ; state = Ready
+                           }
+                           :: roots)
+                      | Some historical
+                        when String.equal historical.candidate_id candidate.candidate_id
+                             && Candidate.Context_key.equal historical.context_key context_key
+                             && Float.equal historical.created_at candidate.recorded_at -> Ok roots
+                      | Some _ -> Error ("partition identity collision: " ^ partition_id))))
+           (Ok [])
+      |> Result.map List.rev
+    in
+    Ok (roots, List.length roots))
+;;
+
+let recover_for_process_start ~base_path ~keeper_name =
+  let ledger_path = path ~base_path ~keeper_name in
+  run_blocking "board-attention-partition-process-start" (fun () ->
+    let entry = cache_entry ledger_path in
+    Stdlib.Mutex.protect entry.mutation_mutex (fun () ->
+      match
+        Fs_compat.read_private_jsonl_durable_locked_result ledger_path ~after:None
+        |> snapshot_result ~ledger_path
+      with
+      | Error error -> Error error
+      | Ok snapshot ->
+        let* rows = parse snapshot.bytes in
+        let* current = apply_rows (empty_view snapshot.cursor) rows in
+        let* () = validate_keeper_identity ~keeper_name current in
+        let recovered, latest =
+          view_partitions current
+          |> List.fold_left
+               (fun (recovered, latest) partition ->
+                  match partition.state with
+                  | Running _ ->
+                    recovered + 1, { partition with state = Ready } :: latest
+                  | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
+                    recovered, partition :: latest)
+               (0, [])
+        in
+        let latest = List.rev latest in
+        let canonical = serialize latest in
+        if String.equal canonical snapshot.bytes
+        then (
+          Atomic.set entry.cached (Some current);
+          Ok recovered)
+        else
+          (match
+             Fs_compat.rewrite_private_jsonl_durable_locked_at_cursor_result
+               ledger_path
+               ~expected:snapshot.cursor
+               canonical
+             |> cursor_result ~ledger_path
+           with
+           | Error error -> Error error
+           | Ok cursor ->
+             let* compacted = apply_rows (empty_view cursor) latest in
+             Atomic.set entry.cached (Some compacted);
+             Ok recovered)))
+;;
+
+let release_due_provider_retries ~now ~base_path ~keeper_name =
+  let* () = valid_time "Provider retry release time" now in
+  update ~base_path ~keeper_name (fun view ->
+    let released =
+      view_partitions view
+      |> List.fold_left
+           (fun acc partition ->
+              match partition.state with
+              | Deferred { failure; _ } ->
+                (match Failure.retry_deadline failure with
+                 | Some deadline when Float.compare now deadline >= 0 ->
+                   { partition with state = Ready } :: acc
+                 | Some _ | None -> acc)
+              | Ready | Running _ | Completed _ | Settled _ | Blocked _ -> acc)
+           []
+      |> List.rev
+    in
+    Ok (released, List.length released))
+;;
+
+let next_provider_retry_deadline ~base_path ~keeper_name =
+  let* view = read_view (path ~base_path ~keeper_name) in
+  let* () = validate_keeper_identity ~keeper_name view in
+  Ok
+    (Id_map.fold
+       (fun _ partition earliest ->
+          match partition.state with
+          | Deferred { failure; _ } ->
+            (match earliest, Failure.retry_deadline failure with
+             | None, deadline -> deadline
+             | Some current, Some candidate
+               when Float.compare candidate current < 0 -> Some candidate
+             | Some _, Some _ | Some _, None -> earliest)
+          | Ready | Running _ | Completed _ | Settled _ | Blocked _ -> earliest)
+       view.by_id
+       None)
+;;
+
+let claim_next ~now ~worker_epoch ~base_path ~keeper_name =
+  let* () = valid_time "partition claim time" now in
+  update ~base_path ~keeper_name (fun view ->
+    match Ready_set.min_elt_opt view.ready with
+    | None -> Ok ([], None)
+    | Some selected_order ->
+      (match Id_map.find_opt selected_order.partition_id view.by_id with
+       | None -> Error ("ready index lost partition " ^ selected_order.partition_id)
+       | Some selected ->
+         let claimed =
+           { selected with state = Running { worker_epoch; started_at = now } }
+         in
+         Ok ([ claimed ], Some claimed)))
+;;
+
 let recover_claim_after_lane_abort ~worker_epoch ~base_path ~partition =
-  update ~base_path ~keeper_name:partition.keeper_name (fun rows ->
-    let* current = find_persisted partition rows in
-    match current.state with
-    | Running running when Worker_epoch.equal running.worker_epoch worker_epoch ->
-      let released = { current with state = Ready } in
-      Ok
-        ( true
-        , replace_partition current released rows
-        , Claim_released released )
-    | Running running ->
-      Error
-        (Printf.sprintf
-           "claim recovery cannot revoke worker %s"
-           (Worker_epoch.to_string running.worker_epoch))
-    | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
-      Ok (false, rows, Claim_already_transitioned current))
+  update ~base_path ~keeper_name:partition.keeper_name (fun view ->
+    match Id_map.find_opt partition.partition_id view.by_id with
+    | None -> Error ("partition not found during claim recovery: " ^ partition.partition_id)
+    | Some current ->
+      (match current.state with
+       | Running running when Worker_epoch.equal running.worker_epoch worker_epoch ->
+         let released = { current with state = Ready } in
+         Ok ([ released ], Claim_released released)
+       | Running running ->
+         Error
+           (Printf.sprintf
+              "claim recovery cannot revoke worker %s"
+              (Worker_epoch.to_string running.worker_epoch))
+       | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
+         Ok ([], Claim_already_transitioned current)))
+;;
+
+let transition_running ~base_path ~partition ~worker_epoch state wrap =
+  update ~base_path ~keeper_name:partition.keeper_name (fun view ->
+    match Id_map.find_opt partition.partition_id view.by_id with
+    | None -> Error ("Board attention partition not found: " ^ partition.partition_id)
+    | Some current ->
+      (match current.state with
+       | Running running when Worker_epoch.equal running.worker_epoch worker_epoch ->
+         let updated = { current with state } in
+         Ok ([ updated ], wrap updated)
+       | Running running ->
+         Error
+           (Printf.sprintf
+              "partition %s is owned by worker %s"
+              partition.partition_id
+              (Worker_epoch.to_string running.worker_epoch))
+       | Ready | Deferred _ | Completed _ | Settled _ | Blocked _ ->
+         Error ("partition is not Running: " ^ partition.partition_id)))
 ;;
 
 let complete ~now ~worker_epoch ~base_path ~partition ~item =
@@ -748,20 +955,29 @@ let block ~now ~worker_epoch ~base_path ~partition reason =
 ;;
 
 let completed ~base_path ~keeper_name =
-  let* rows = load ~base_path ~keeper_name in
-  Ok (List.filter (fun row -> match row.state with Completed _ -> true | _ -> false) rows)
+  let* view = read_view (path ~base_path ~keeper_name) in
+  let* () = validate_keeper_identity ~keeper_name view in
+  Id_set.fold
+    (fun partition_id result ->
+       let* completed = result in
+       match Id_map.find_opt partition_id view.by_id with
+       | Some partition -> Ok (partition :: completed)
+       | None -> Error ("completed index lost partition " ^ partition_id))
+    view.completed
+    (Ok [])
+  |> Result.map (List.sort compare_partition)
 ;;
 
 let settle ~now ~base_path ~partition =
   let* () = valid_time "partition settlement time" now in
-  update ~base_path ~keeper_name:partition.keeper_name (fun rows ->
-    let* current = find_persisted partition rows in
-    match current.state with
-    | Settled _ -> Ok (false, rows, current)
-    | Completed _ ->
+  update ~base_path ~keeper_name:partition.keeper_name (fun view ->
+    match Id_map.find_opt partition.partition_id view.by_id with
+    | None -> Error ("partition settlement target not found: " ^ partition.partition_id)
+    | Some ({ state = Settled _; _ } as current) -> Ok ([], current)
+    | Some ({ state = Completed _; _ } as current) ->
       let settled = { current with state = Settled { settled_at = now } } in
-      Ok (true, replace_partition current settled rows, settled)
-    | Ready | Running _ | Deferred _ | Blocked _ ->
+      Ok ([ settled ], settled)
+    | Some current ->
       Error ("only Completed partition can settle: " ^ current.partition_id))
 ;;
 

--- a/lib/keeper/keeper_board_attention_partition.mli
+++ b/lib/keeper/keeper_board_attention_partition.mli
@@ -4,7 +4,9 @@
     A candidate is the irreducible work identity until the dispatched Provider
     exposes typed actual-wire split authority. No byte count, token estimate,
     wall-clock expiry, retry counter, or configured batch cap chooses
-    membership. *)
+    membership. Runtime transitions append one cursor-fenced row and update
+    process-local indexes; only process-start recovery canonically compacts the
+    history to one latest row per partition. *)
 
 module Candidate = Keeper_board_attention_candidate
 module Failure = Keeper_board_attention_failure
@@ -79,13 +81,14 @@ val ensure_roots :
 (** Persist one deterministic singleton root for each unassigned [Pending] or
     [Judged]
     candidate and return the number created by this transaction. Existing live
-    membership is validated as one-to-one. *)
+    membership is validated as one-to-one. New roots are appended without
+    rewriting historical transition rows. *)
 
 val recover_for_process_start :
   base_path:string -> keeper_name:string -> (int, string) result
-(** Release prior-process [Running] rows to [Ready] in one rewrite. [Deferred]
-    rows retain their exact retry requirement; process restart is not retry
-    authority. *)
+(** Release prior-process [Running] rows to [Ready] and canonically compact
+    the append ledger to one latest row per partition. [Deferred] rows retain
+    their exact retry requirement; process restart is not retry authority. *)
 
 val release_due_provider_retries :
   now:float -> base_path:string -> keeper_name:string -> (int, string) result

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -701,20 +701,49 @@ let append_line_once path ~delivery_key ~transcript_slot ~row_id line =
         None, Ok (Already_present { row_id = existing_row_id })
       | Ok None -> Some (line ^ "\n"), Ok (Appended { row_id }))
   with
-  | Ok result -> result
-  | Error error -> Error (Fs_compat.durable_append_error_to_string error)
+  | Private_file_succeeded result -> result
+  | Private_file_succeeded_with_cleanup_failure
+      { value = result; cleanup_failure } ->
+    Log.Keeper.error
+      "keeper_chat_store: provenance update succeeded with descriptor settlement failure path=%s: %s"
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    result
+  | Private_file_failed error ->
+    Error (Fs_compat.durable_append_error_to_string error)
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "%s; descriptor settlement failed: %s"
+         (Fs_compat.durable_append_error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
 ;;
 
 let append_chat_payload_durable path payload =
   match Fs_compat.append_private_jsonl_durable_locked_result path payload with
-  | Ok () -> ()
-  | Error error ->
+  | Private_file_succeeded () -> ()
+  | Private_file_succeeded_with_cleanup_failure
+      { value = (); cleanup_failure } ->
+    Log.Keeper.error
+      "keeper_chat_store: payload append succeeded with descriptor settlement failure path=%s: %s"
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure)
+  | Private_file_failed error ->
     raise
       (Sys_error
          (Printf.sprintf
             "%s: %s"
             path
             (Fs_compat.private_jsonl_append_error_to_string error)))
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    raise
+      (Sys_error
+         (Printf.sprintf
+            "%s: %s; descriptor settlement failed: %s"
+            path
+            (Fs_compat.private_jsonl_append_error_to_string error)
+            (Fs_compat.private_jsonl_operation_failure_to_string
+               cleanup_failure)))
 ;;
 
 (* Tool calls with empty accumulated arguments are normalised to "{}" so

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -350,35 +350,56 @@ let replay_settlement_wal_bytes owner state bytes =
 
 let replay_settlement_wal_unlocked owner state =
   let path = settlement_wal_path_of_owner owner in
+  let replay_slice slice =
+    match slice.Fs_compat.Private_jsonl_slice.bytes with
+    | "" -> Ok state
+    | bytes ->
+      (match replay_settlement_wal_bytes owner state bytes with
+       | Error detail ->
+         Error (Printf.sprintf "failed to replay %s: %s" path detail)
+       | Ok replayed ->
+         (match bump_revision replayed with
+          | Error _ as error -> error
+          | Ok replayed ->
+            (match save_state_unlocked owner replayed with
+             | Ok () ->
+               (match compact_settlement_wal_unlocked owner with
+                | Ok () -> Ok replayed
+                | Error detail ->
+                  Error
+                    ("settlement WAL checkpoint recovered but compaction failed: "
+                     ^ detail))
+             | Error detail ->
+               Error
+                 (Printf.sprintf
+                    "settlement WAL is committed but checkpoint replay failed: %s"
+                    detail))))
+  in
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
-  | Error error ->
+  | Private_file_failed error ->
     Error
       (Printf.sprintf
          "failed to read settlement WAL keeper=%s path=%s: %s"
          (keeper_name_of_owner owner)
          path
          (Fs_compat.Private_jsonl_slice.error_to_string error))
-  | Ok { bytes = ""; _ } -> Ok state
-  | Ok slice ->
-    (match replay_settlement_wal_bytes owner state slice.bytes with
-     | Error detail -> Error (Printf.sprintf "failed to replay %s: %s" path detail)
-     | Ok replayed ->
-       (match bump_revision replayed with
-        | Error _ as error -> error
-        | Ok replayed ->
-          (match save_state_unlocked owner replayed with
-           | Ok () ->
-             (match compact_settlement_wal_unlocked owner with
-              | Ok () -> Ok replayed
-              | Error detail ->
-                Error
-                  ("settlement WAL checkpoint recovered but compaction failed: "
-                   ^ detail))
-           | Error detail ->
-             Error
-               (Printf.sprintf
-                  "settlement WAL is committed but checkpoint replay failed: %s"
-                  detail))))
+  | Private_file_failed_with_cleanup_failure { error; cleanup_failure } ->
+    Error
+      (Printf.sprintf
+         "failed to read settlement WAL keeper=%s path=%s: %s; descriptor settlement failed: %s"
+         (keeper_name_of_owner owner)
+         path
+         (Fs_compat.Private_jsonl_slice.error_to_string error)
+         (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure))
+  | Private_file_succeeded slice -> replay_slice slice
+  | Private_file_succeeded_with_cleanup_failure
+      { value = slice; cleanup_failure } ->
+    Log.Keeper.error
+      "settlement WAL read succeeded with descriptor settlement failure keeper=%s path=%s: %s"
+      (keeper_name_of_owner owner)
+      path
+      (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+    replay_slice slice
 ;;
 
 let load_state_unlocked owner =
@@ -745,52 +766,72 @@ let commit_settlement_transition_unlocked owner ~after_commit transition current
      | Ok checkpoint ->
        let suffix = settlement_wal_entry_to_line owner entry in
        let path = settlement_wal_path_of_owner owner in
+       let continue_after_commit () =
+         let pending = State.pending checkpoint in
+         match save_state_unlocked owner checkpoint with
+         | Error detail ->
+           Ok
+             ( Committed_followup_failed
+                 { receipt; stage = `Checkpoint; detail }
+             , pending )
+         | Ok () ->
+           (match compact_settlement_wal_unlocked owner with
+            | Error detail ->
+              Ok
+                ( Committed_followup_failed
+                    { receipt; stage = `Wal_compaction; detail }
+                , pending )
+            | Ok () ->
+              (match
+                 try
+                   after_commit pending;
+                   Ok ()
+                 with
+                 | Eio.Cancel.Cancelled _ as exn ->
+                   Error
+                     ("pending projection cancelled after settlement commit: "
+                      ^ Printexc.to_string exn)
+                 | exn -> Error (Printexc.to_string exn)
+               with
+               | Ok () -> Ok (Settled receipt, pending)
+               | Error detail ->
+                 Ok
+                   ( Committed_followup_failed
+                       { receipt; stage = `Projection; detail }
+                   , pending )))
+       in
        (match
           Fs_compat.append_private_jsonl_durable_locked_at_end_offset_result
             path
             ~expected_end_offset:0
             suffix
         with
-        | Error error ->
+        | Private_file_failed error ->
           Error
             (Printf.sprintf
                "settlement WAL commit failed keeper=%s path=%s: %s"
                (keeper_name_of_owner owner)
                path
                (Fs_compat.private_jsonl_append_error_to_string error))
-        | Ok _committed_end_offset ->
-          let pending = State.pending checkpoint in
-          (match save_state_unlocked owner checkpoint with
-           | Error detail ->
-             Ok
-               ( Committed_followup_failed
-                   { receipt; stage = `Checkpoint; detail }
-               , pending )
-           | Ok () ->
-             (match compact_settlement_wal_unlocked owner with
-              | Error detail ->
-                Ok
-                  ( Committed_followup_failed
-                      { receipt; stage = `Wal_compaction; detail }
-                  , pending )
-              | Ok () ->
-                (match
-                   try
-                     after_commit pending;
-                     Ok ()
-                   with
-                   | Eio.Cancel.Cancelled _ as exn ->
-                     Error
-                       ("pending projection cancelled after settlement commit: "
-                        ^ Printexc.to_string exn)
-                   | exn -> Error (Printexc.to_string exn)
-                 with
-                 | Ok () -> Ok (Settled receipt, pending)
-                 | Error detail ->
-                   Ok
-                     ( Committed_followup_failed
-                         { receipt; stage = `Projection; detail }
-                     , pending ))))))
+        | Private_file_failed_with_cleanup_failure
+            { error; cleanup_failure } ->
+          Error
+            (Printf.sprintf
+               "settlement WAL commit failed keeper=%s path=%s: %s; descriptor settlement failed: %s"
+               (keeper_name_of_owner owner)
+               path
+               (Fs_compat.private_jsonl_append_error_to_string error)
+               (Fs_compat.private_jsonl_operation_failure_to_string
+                  cleanup_failure))
+        | Private_file_succeeded _committed_end_offset -> continue_after_commit ()
+        | Private_file_succeeded_with_cleanup_failure
+            { value = _committed_end_offset; cleanup_failure } ->
+          Log.Keeper.error
+            "settlement WAL commit succeeded with descriptor settlement failure keeper=%s path=%s: %s"
+            (keeper_name_of_owner owner)
+            path
+            (Fs_compat.private_jsonl_operation_failure_to_string cleanup_failure);
+          continue_after_commit ()))
      | [] | [ _ ] | _ :: _ :: _ ->
        Error "settlement transition did not produce its canonical outbox entry")
 ;;

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -231,8 +231,12 @@ let test_private_jsonl_append_preserves_complete_history () =
        path
        "{\"row\":2}\n{\"row\":3}\n"
    with
-   | Ok () -> ()
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+   | Fs_compat.Private_file_succeeded () -> ()
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "unexpected descriptor settlement failure");
   check string
     "complete rows appended"
     "{\"row\":1}\n{\"row\":2}\n{\"row\":3}\n"
@@ -248,12 +252,16 @@ let test_private_jsonl_append_returns_committed_end_offset () =
        path
        suffix
    with
-   | Ok end_offset ->
+   | Fs_compat.Private_file_succeeded end_offset ->
      check int
        "committed newline-end byte offset"
        (String.length original + String.length suffix)
        end_offset
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error))
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "unexpected descriptor settlement failure")
 ;;
 
 let test_private_jsonl_append_at_exact_end_offset () =
@@ -266,12 +274,16 @@ let test_private_jsonl_append_at_exact_end_offset () =
        ~expected_end_offset:(String.length original)
        suffix
    with
-   | Ok end_offset ->
+   | Fs_compat.Private_file_succeeded end_offset ->
      check int
        "committed newline-end byte offset"
        (String.length original + String.length suffix)
        end_offset
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "unexpected descriptor settlement failure");
   check string "exact append bytes" (original ^ suffix) (Fs_compat.load_file path)
 ;;
 
@@ -284,12 +296,16 @@ let test_private_jsonl_append_rejects_stale_end_offset () =
        ~expected_end_offset:0
        "{\"row\":2}\n"
    with
-   | Error
+   | Fs_compat.Private_file_failed
        (Fs_compat.End_offset_mismatch
           { expected = 0; actual }) ->
      check int "locked actual byte offset" (String.length original) actual
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
-   | Ok _ -> fail "stale cursor unexpectedly appended");
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded _
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "stale cursor unexpectedly appended");
   check string "stale append writes no bytes" original (Fs_compat.load_file path)
 ;;
 
@@ -303,25 +319,32 @@ let test_private_jsonl_slice_reads_exact_cursor_suffix () =
       path
       ~from:(String.length row1)
   with
-  | Ok slice ->
+  | Fs_compat.Private_file_succeeded slice ->
     check string "exact suffix" (row2 ^ row3) slice.bytes;
     check int
       "locked end offset"
       (String.length row1 + String.length row2 + String.length row3)
       slice.end_offset
-  | Error _ -> fail "complete cursor slice was rejected"
+  | Fs_compat.Private_file_failed _ -> fail "complete cursor slice was rejected"
+  | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+  | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+    fail "unexpected descriptor settlement failure"
 ;;
 
 let test_private_jsonl_slice_rejects_invalid_cursors () =
   with_temp_jsonl "{\"row\":1}\n" @@ fun path ->
   (match Fs_compat.read_private_jsonl_slice_locked_result path ~from:(-1) with
-   | Error (Fs_compat.Private_jsonl_slice.Negative_offset (-1)) -> ()
+   | Fs_compat.Private_file_failed
+       (Fs_compat.Private_jsonl_slice.Negative_offset (-1)) ->
+     ()
    | _ -> fail "negative cursor was not rejected");
   (match Fs_compat.read_private_jsonl_slice_locked_result path ~from:1 with
-   | Error (Fs_compat.Private_jsonl_slice.Offset_not_at_row_boundary 1) -> ()
+   | Fs_compat.Private_file_failed
+       (Fs_compat.Private_jsonl_slice.Offset_not_at_row_boundary 1) ->
+     ()
    | _ -> fail "mid-row cursor was not rejected");
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:1024 with
-  | Error
+  | Fs_compat.Private_file_failed
       (Fs_compat.Private_jsonl_slice.Offset_beyond_end
         { offset = 1024; end_offset = 10 }) ->
     ()
@@ -332,17 +355,21 @@ let test_private_jsonl_slice_missing_store_contract () =
   let path = Filename.temp_file "masc_private_jsonl_missing_" ".jsonl" in
   Sys.remove path;
   (match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
-   | Ok { bytes = ""; end_offset = 0 } -> ()
+   | Fs_compat.Private_file_succeeded { bytes = ""; end_offset = 0 } -> ()
    | _ -> fail "missing origin was not treated as an empty stream");
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:1 with
-  | Error (Fs_compat.Private_jsonl_slice.Missing_file_after_offset 1) -> ()
+  | Fs_compat.Private_file_failed
+      (Fs_compat.Private_jsonl_slice.Missing_file_after_offset 1) ->
+    ()
   | _ -> fail "missing non-origin cursor was not rejected"
 ;;
 
 let test_private_jsonl_slice_rejects_incomplete_tail () =
   with_temp_jsonl "{\"row\":1}" @@ fun path ->
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
-  | Error (Fs_compat.Private_jsonl_slice.Incomplete_tail 9) -> ()
+  | Fs_compat.Private_file_failed
+      (Fs_compat.Private_jsonl_slice.Incomplete_tail 9) ->
+    ()
   | _ -> fail "incomplete JSONL tail was not rejected"
 ;;
 
@@ -351,18 +378,26 @@ let test_private_jsonl_append_rejects_incomplete_tail () =
   (match
      Fs_compat.append_private_jsonl_durable_locked_result path "{\"row\":2}\n"
    with
-   | Error Fs_compat.Incomplete_jsonl_tail -> ()
-   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
-   | Ok () -> fail "append accepted an incomplete existing JSONL row");
+   | Fs_compat.Private_file_failed Fs_compat.Incomplete_jsonl_tail -> ()
+   | Fs_compat.Private_file_failed error ->
+     fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Fs_compat.Private_file_succeeded _
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+   | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+     fail "append accepted an incomplete existing JSONL row");
   check string "incomplete bytes unchanged" "{\"row\":1}" (Fs_compat.load_file path)
 ;;
 
 let test_private_jsonl_append_rejects_incomplete_suffix () =
   with_temp_jsonl "" @@ fun path ->
   match Fs_compat.append_private_jsonl_durable_locked_result path "{\"row\":1}" with
-  | Error Fs_compat.Invalid_jsonl_suffix -> ()
-  | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
-  | Ok () -> fail "append accepted a non-terminated JSONL suffix"
+  | Fs_compat.Private_file_failed Fs_compat.Invalid_jsonl_suffix -> ()
+  | Fs_compat.Private_file_failed error ->
+    fail (Fs_compat.private_jsonl_append_error_to_string error)
+  | Fs_compat.Private_file_succeeded _
+  | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+  | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+    fail "append accepted a non-terminated JSONL suffix"
 ;;
 
 let test_private_jsonl_append_respects_execution_context () =
@@ -375,20 +410,677 @@ let test_private_jsonl_append_respects_execution_context () =
        (match
           Fs_compat.append_private_jsonl_durable_locked_result path "{\"fiber\":1}\n"
         with
-        | Ok () -> ()
-        | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+        | Fs_compat.Private_file_succeeded () -> ()
+        | Fs_compat.Private_file_failed error ->
+          fail (Fs_compat.private_jsonl_append_error_to_string error)
+        | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+        | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+          fail "unexpected descriptor settlement failure");
        let raw_domain_result =
          Domain.spawn (fun () ->
            Fs_compat.append_private_jsonl_durable_locked_result path "{\"domain\":2}\n")
          |> Domain.join
        in
        (match raw_domain_result with
-        | Ok () -> ()
-        | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+        | Fs_compat.Private_file_succeeded () -> ()
+        | Fs_compat.Private_file_failed error ->
+          fail (Fs_compat.private_jsonl_append_error_to_string error)
+        | Fs_compat.Private_file_succeeded_with_cleanup_failure _
+        | Fs_compat.Private_file_failed_with_cleanup_failure _ ->
+          fail "unexpected descriptor settlement failure");
        check string
          "Eio fiber and raw Domain append once"
          "{\"fiber\":1}\n{\"domain\":2}\n"
          (Fs_compat.load_file path))
+;;
+
+let remove_if_present path =
+  match Unix.unlink path with
+  | () -> ()
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+;;
+
+let with_transaction_jsonl initial f =
+  let path = Filename.temp_file "masc_private_jsonl_transaction_" ".jsonl" in
+  (match initial with
+   | Some content ->
+     let output = open_out_bin path in
+     output_string output content;
+     close_out output
+   | None -> remove_if_present path);
+  Fun.protect
+    ~finally:(fun () ->
+      remove_if_present path;
+      remove_if_present (Fs_compat.private_jsonl_lock_path path))
+    (fun () -> f path)
+;;
+
+let transaction_snapshot path ~after =
+  match Fs_compat.read_private_jsonl_durable_locked_result path ~after with
+  | Ok snapshot -> snapshot
+  | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+;;
+
+let transaction_snapshot_with_io ~io path ~after =
+  match
+    Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+      ~io
+      path
+      ~after
+  with
+  | Ok snapshot -> snapshot
+  | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+;;
+
+let write_stable_lock_fixture path contents permissions =
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  let output = open_out_bin lock_path in
+  output_string output contents;
+  close_out output;
+  Unix.chmod lock_path permissions
+;;
+
+let transaction_append path ~expected suffix =
+  match
+    Fs_compat.append_private_jsonl_durable_locked_at_cursor_result
+      path
+      ~expected
+      suffix
+  with
+  | Ok cursor -> cursor
+  | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+;;
+
+let injected_close_io ~fail_calls =
+  let calls = ref 0 in
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> ())
+    ; close_fd =
+        (fun fd ->
+          incr calls;
+          Unix.close fd;
+          if List.mem !calls fail_calls
+          then
+            raise
+              (Unix.Unix_error
+                 (Unix.EIO, "injected_private_jsonl_close", string_of_int !calls)))
+    }
+  in
+  io, calls
+;;
+
+let check_transaction_close_failure
+      ~label
+      ~operation
+      (failure : Fs_compat.private_jsonl_operation_failure)
+  =
+  check bool (label ^ " operation") true (failure.operation = operation);
+  match failure.exception_ with
+  | Unix.Unix_error (Unix.EIO, "injected_private_jsonl_close", _) -> ()
+  | exception_ ->
+    fail
+      (Printf.sprintf
+         "%s lost injected close failure: %s"
+         label
+         (Printexc.to_string exception_))
+;;
+
+let test_private_jsonl_slice_returns_value_with_close_failure () =
+  with_temp_jsonl "{\"row\":1}\n" @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.read_private_jsonl_slice_locked_with_io_for_testing
+       ~io
+       path
+       ~from:0
+   with
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure
+       { value = slice; cleanup_failure } ->
+     check string "read value preserved" "{\"row\":1}\n" slice.bytes;
+     check_transaction_close_failure
+       ~label:"offset read descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "offset read did not preserve its value and close failure");
+  check int "offset read descriptor closed once" 1 !calls
+;;
+
+let test_private_jsonl_append_returns_commit_with_close_failure () =
+  let original = "{\"row\":1}\n" in
+  let suffix = "{\"row\":2}\n" in
+  with_temp_jsonl original @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing
+       ~io
+       path
+       ~expected_end_offset:(String.length original)
+       suffix
+   with
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure
+       { value = end_offset; cleanup_failure } ->
+     check int
+       "committed offset preserved"
+       (String.length original + String.length suffix)
+       end_offset;
+     check_transaction_close_failure
+       ~label:"offset append descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "offset append did not preserve its commit and close failure");
+  check int "offset append descriptor closed once" 1 !calls;
+  check string "offset append commits once" (original ^ suffix) (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_append_preserves_rejection_with_close_failure () =
+  let original = "{\"row\":1}\n" in
+  with_temp_jsonl original @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_end_offset_with_io_for_testing
+       ~io
+       path
+       ~expected_end_offset:0
+       "{\"row\":2}\n"
+   with
+   | Fs_compat.Private_file_failed_with_cleanup_failure
+       { error = Fs_compat.End_offset_mismatch { expected = 0; actual }
+       ; cleanup_failure
+       } ->
+     check int "rejection actual offset" (String.length original) actual;
+     check_transaction_close_failure
+       ~label:"rejected offset append descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "offset append did not preserve its rejection and close failure");
+  check int "rejected append descriptor closed once" 1 !calls;
+  check string "rejected append writes nothing" original (Fs_compat.load_file path)
+;;
+
+let test_private_file_update_returns_value_with_close_failure () =
+  let original = "{\"row\":1}\n" in
+  let suffix = "{\"row\":2}\n" in
+  with_temp_jsonl original @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.update_private_file_durable_locked_with_io_for_testing
+       ~io
+       path
+       (fun _existing -> Some suffix, `Committed)
+   with
+   | Fs_compat.Private_file_succeeded_with_cleanup_failure
+       { value = `Committed; cleanup_failure } ->
+     check_transaction_close_failure
+       ~label:"private update descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | _ -> fail "private update did not preserve its value and close failure");
+  check int "private update descriptor closed once" 1 !calls;
+  check string "private update commits once" (original ^ suffix) (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_transaction_preserves_primary_when_data_close_fails () =
+  with_transaction_jsonl (Some "incomplete") @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_failed
+               (Fs_compat.Incomplete_transaction_tail _)
+         ; cleanup_failures = [ cleanup_failure ]
+         }) ->
+     check_transaction_close_failure
+       ~label:"data descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "data close failure was silently accepted");
+  check int "data and stable lock descriptors closed" 2 !calls
+;;
+
+let test_private_jsonl_transaction_accumulates_nested_close_failures () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let io, calls = injected_close_io ~fail_calls:[ 1; 2 ] in
+  let result =
+    Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+      ~io
+      path
+      ~after:None
+  in
+  (match result with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Snapshot_succeeded snapshot)
+         ; cleanup_failures = [ data_failure; lock_failure ]
+         }) ->
+     check string "successful snapshot receipt" "{\"row\":1}\n" snapshot.bytes;
+     check_transaction_close_failure
+       ~label:"data descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       data_failure;
+     check_transaction_close_failure
+       ~label:"stable lock descriptor cleanup"
+       ~operation:Fs_compat.Close_stable_lock
+       lock_failure;
+     (match Fs_compat.private_jsonl_snapshot_success_receipt result with
+      | Ok { value; settlement_error = Some _ } ->
+        check string "classified snapshot receipt" snapshot.bytes value.bytes
+      | Ok { settlement_error = None; _ } ->
+        fail "snapshot classifier discarded settlement evidence"
+      | Error error ->
+        fail (Fs_compat.private_jsonl_transaction_error_to_string error));
+     let cursor_settlement_error =
+       Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Cursor_succeeded snapshot.cursor)
+         ; cleanup_failures = [ data_failure; lock_failure ]
+         }
+     in
+     (match
+        Fs_compat.private_jsonl_cursor_success_receipt
+          (Error cursor_settlement_error)
+      with
+      | Ok { value; settlement_error = Some _ } ->
+        check bool
+          "classified cursor receipt"
+          true
+          (Fs_compat.Private_jsonl_cursor.equal snapshot.cursor value)
+      | Ok { settlement_error = None; _ } ->
+        fail "cursor classifier discarded settlement evidence"
+      | Error error ->
+        fail (Fs_compat.private_jsonl_transaction_error_to_string error));
+     (match
+        Fs_compat.private_jsonl_snapshot_success_receipt
+          (Error cursor_settlement_error)
+      with
+      | Error _ -> ()
+      | Ok _ -> fail "snapshot classifier accepted a cursor success receipt")
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "nested close failures were silently accepted");
+  check int "both nested descriptors closed" 2 !calls
+;;
+
+let test_private_jsonl_rewrite_rejects_precondition_close_as_commit () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let origin = transaction_snapshot path ~after:None in
+  let io, calls = injected_close_io ~fail_calls:[ 1 ] in
+  let result =
+    Fs_compat.rewrite_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+      ~io
+      path
+      ~expected:origin.cursor
+      "{\"row\":2}\n"
+  in
+  (match result with
+   | Error
+       (Fs_compat.Transaction_settlement_failed
+         { primary =
+             Fs_compat.Transaction_succeeded
+               (Fs_compat.Cursor_precondition_succeeded observed)
+         ; cleanup_failures = [ cleanup_failure ]
+         }) ->
+     check bool
+       "precondition cursor preserved"
+       true
+       (Fs_compat.Private_jsonl_cursor.equal origin.cursor observed);
+     check_transaction_close_failure
+       ~label:"rewrite precondition descriptor cleanup"
+       ~operation:Fs_compat.Close_transaction_data
+       cleanup_failure;
+     (match Fs_compat.private_jsonl_cursor_success_receipt result with
+      | Error _ -> ()
+      | Ok _ -> fail "precondition cursor was classified as a committed rewrite")
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "rewrite continued after precondition descriptor settlement failed");
+  check int "precondition and stable lock descriptors closed" 2 !calls;
+  check string
+    "failed precondition leaves target unchanged"
+    "{\"row\":1}\n"
+    (Fs_compat.load_file path)
+;;
+
+exception Requested_private_jsonl_cancellation
+
+type private_jsonl_append_cancellation_outcome =
+  | Append_returned of
+      ( Fs_compat.Private_jsonl_cursor.t
+        , Fs_compat.private_jsonl_transaction_error )
+        result
+  | Append_cancelled
+
+type private_jsonl_close_barrier =
+  { entered : unit Eio.Promise.t
+  ; resolve_entered : unit Eio.Promise.u
+  ; first_close : bool Atomic.t
+  ; close_calls : int Atomic.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Stdlib.Condition.t
+  ; mutable released : bool
+  }
+
+let private_jsonl_close_barrier () =
+  let entered, resolve_entered = Eio.Promise.create () in
+  { entered
+  ; resolve_entered
+  ; first_close = Atomic.make true
+  ; close_calls = Atomic.make 0
+  ; mutex = Stdlib.Mutex.create ()
+  ; condition = Stdlib.Condition.create ()
+  ; released = false
+  }
+;;
+
+let release_private_jsonl_close barrier =
+  Stdlib.Mutex.protect barrier.mutex (fun () ->
+    if not barrier.released
+    then (
+      barrier.released <- true;
+      Stdlib.Condition.broadcast barrier.condition))
+;;
+
+let private_jsonl_blocking_close_io barrier =
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> ())
+    ; close_fd =
+        (fun fd ->
+          ignore (Atomic.fetch_and_add barrier.close_calls 1 : int);
+          if Atomic.compare_and_set barrier.first_close true false
+          then (
+            Eio.Promise.resolve barrier.resolve_entered ();
+            Stdlib.Mutex.protect barrier.mutex (fun () ->
+              while not barrier.released do
+                Stdlib.Condition.wait barrier.condition barrier.mutex
+              done));
+          Unix.close fd)
+    }
+  in
+  io
+;;
+
+let test_private_jsonl_append_cancellation_settles_once_with_receipt () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  Eio_main.run @@ fun _env ->
+  let origin = transaction_snapshot path ~after:None in
+  let barrier = private_jsonl_close_barrier () in
+  let context, resolve_context = Eio.Promise.create () in
+  let outcome, resolve_outcome = Eio.Promise.create () in
+  Fun.protect
+    ~finally:(fun () -> release_private_jsonl_close barrier)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let outcome =
+           try
+             Eio.Cancel.sub @@ fun context ->
+             Eio.Promise.resolve resolve_context context;
+             Append_returned
+               (Fs_compat.append_private_jsonl_durable_locked_at_cursor_with_io_for_testing
+                  ~io:(private_jsonl_blocking_close_io barrier)
+                  path
+                  ~expected:origin.cursor
+                  "{\"row\":2}\n")
+           with
+           | Eio.Cancel.Cancelled _ -> Append_cancelled
+         in
+         Eio.Promise.resolve resolve_outcome outcome);
+       let context = Eio.Promise.await context in
+       Eio.Promise.await barrier.entered;
+       Eio.Cancel.cancel context Requested_private_jsonl_cancellation;
+       release_private_jsonl_close barrier;
+       match Eio.Promise.await outcome with
+       | Append_cancelled ->
+         fail "committed append lost its terminal receipt to cancellation"
+       | Append_returned (Error error) ->
+         fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+       | Append_returned (Ok committed) ->
+         check bool
+           "cancellation path returns committed cursor"
+           false
+           (Fs_compat.Private_jsonl_cursor.equal origin.cursor committed));
+  check int "cancellation path closes both descriptors" 2 (Atomic.get barrier.close_calls);
+  check string
+    "cancellation path commits suffix exactly once"
+    "{\"row\":1}\n{\"row\":2}\n"
+    (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_transaction_missing_and_delta_contract () =
+  with_transaction_jsonl None @@ fun path ->
+  let origin = transaction_snapshot path ~after:None in
+  let committed = transaction_append path ~expected:origin.cursor "{\"row\":1}\n" in
+  let delta = transaction_snapshot path ~after:(Some committed) in
+  check string "no bytes after committed cursor" "" delta.bytes;
+  let next = transaction_append path ~expected:committed "{\"row\":2}\n" in
+  let delta = transaction_snapshot path ~after:(Some committed) in
+  check string "exact appended delta" "{\"row\":2}\n" delta.bytes;
+  check bool
+    "delta advances durable cursor"
+    true
+    (Fs_compat.Private_jsonl_cursor.equal next delta.cursor)
+;;
+
+let test_private_jsonl_transaction_rejects_second_writer_cursor () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let snapshot = transaction_snapshot path ~after:None in
+  ignore (transaction_append path ~expected:snapshot.cursor "{\"winner\":1}\n");
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_cursor_result
+       path
+       ~expected:snapshot.cursor
+       "{\"loser\":1}\n"
+   with
+   | Error (Fs_compat.Cursor_mismatch _) -> ()
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "second writer committed from a stale cursor");
+  check string
+    "stale writer writes zero bytes"
+    "{\"row\":1}\n{\"winner\":1}\n"
+    (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_transaction_rejects_same_length_rewrite_aba () =
+  let before = "{\"row\":1}\n" in
+  let after = "{\"row\":2}\n" in
+  check int "fixture lengths match" (String.length before) (String.length after);
+  with_transaction_jsonl (Some before) @@ fun path ->
+  let snapshot = transaction_snapshot path ~after:None in
+  let rewritten =
+    match
+      Fs_compat.rewrite_private_jsonl_durable_locked_at_cursor_result
+        path
+        ~expected:snapshot.cursor
+        after
+    with
+    | Ok cursor -> cursor
+    | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+  in
+  check bool
+    "same-length rewrite changes durable identity"
+    false
+    (Fs_compat.Private_jsonl_cursor.equal snapshot.cursor rewritten);
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_cursor_result
+       path
+       ~expected:snapshot.cursor
+       "{\"stale\":1}\n"
+   with
+   | Error (Fs_compat.Cursor_mismatch _) -> ()
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "stale pre-rewrite cursor passed a same-length ABA");
+  check string "rewrite remains authoritative" after (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_transaction_lock_is_private () =
+  with_transaction_jsonl None @@ fun path ->
+  ignore (transaction_snapshot path ~after:None);
+  let permissions =
+    (Unix.stat (Fs_compat.private_jsonl_lock_path path)).Unix.st_perm land 0o777
+  in
+  check int "stable lock permissions" 0o600 permissions
+;;
+
+let test_private_jsonl_stable_lock_parent_sync_is_one_shot () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let parent_syncs = ref 0 in
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent = (fun _dir -> incr parent_syncs)
+    ; close_fd = Unix.close
+    }
+  in
+  let snapshot = transaction_snapshot_with_io ~io path ~after:None in
+  ignore (transaction_snapshot_with_io ~io path ~after:(Some snapshot.cursor));
+  ignore (transaction_snapshot_with_io ~io path ~after:(Some snapshot.cursor));
+  check int "stable lock parent sync count" 1 !parent_syncs
+;;
+
+let test_private_jsonl_stable_lock_parent_sync_failure_retries () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let io : Fs_compat.private_jsonl_transaction_io_for_testing =
+    { before_sync_parent =
+        (fun dir ->
+          raise (Unix.Unix_error (Unix.EIO, "injected_parent_fsync", dir)))
+    ; close_fd = Unix.close
+    }
+  in
+  (match
+     Fs_compat.read_private_jsonl_durable_locked_with_io_for_testing
+       ~io
+       path
+       ~after:None
+   with
+   | Error
+       (Fs_compat.Private_jsonl_operation_failed
+         { operation = Fs_compat.Sync_stable_lock_parent; _ }) ->
+     ()
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "stable lock parent-sync failure was silently accepted");
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  check string "failed initialization remains preparing" "" (Fs_compat.load_file lock_path);
+  ignore (transaction_snapshot path ~after:None);
+  check bool
+    "successful retry publishes ready state"
+    true
+    (String.length (Fs_compat.load_file lock_path) > 0)
+;;
+
+let test_private_jsonl_stable_lock_invalid_state_fails_closed () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let invalid = "invalid-ready-state" in
+  write_stable_lock_fixture path invalid 0o600;
+  match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+  | Error (Fs_compat.Invalid_stable_lock_state { observed_length; _ }) ->
+    check int "invalid stable lock length" (String.length invalid) observed_length
+  | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+  | Ok _ -> fail "invalid stable lock state was accepted"
+;;
+
+let test_private_jsonl_stable_lock_permission_drift_fails_closed () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  write_stable_lock_fixture path "" 0o640;
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  (match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+   | Error (Fs_compat.Unexpected_stable_lock_permissions { actual; _ }) ->
+     check int "observed stable lock permissions" 0o640 actual
+   | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+   | Ok _ -> fail "stable lock permission drift was silently repaired");
+  check int
+    "permission drift remains untouched"
+    0o640
+    ((Unix.stat lock_path).Unix.st_perm land 0o7777)
+;;
+
+let test_private_jsonl_transaction_rejects_data_aliases () =
+  with_transaction_jsonl (Some "{\"row\":1}\n") @@ fun path ->
+  let hardlink = path ^ ".hardlink" in
+  Fun.protect
+    ~finally:(fun () -> remove_if_present hardlink)
+    (fun () ->
+       Unix.link path hardlink;
+       match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+       | Error (Fs_compat.Ambiguous_transaction_file_identity { link_count; _ }) ->
+         check int "hard-link count" 2 link_count
+       | Error error -> fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+       | Ok _ -> fail "hard-linked transaction data was accepted")
+;;
+
+let test_private_jsonl_transaction_rejects_symlink_lock_without_chmod () =
+  with_transaction_jsonl None @@ fun path ->
+  let lock_path = Fs_compat.private_jsonl_lock_path path in
+  let external_path =
+    Filename.temp_file "masc_private_jsonl_external_lock_" ".lock"
+  in
+  Fun.protect
+    ~finally:(fun () -> remove_if_present external_path)
+    (fun () ->
+       Unix.chmod external_path 0o644;
+       Unix.symlink external_path lock_path;
+       (match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+        | Error (Fs_compat.Unexpected_transaction_file_kind Unix.S_LNK) -> ()
+        | Error error ->
+          fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+        | Ok _ -> fail "symbolic-link stable lock was accepted");
+       let permissions = (Unix.stat external_path).Unix.st_perm land 0o777 in
+       check int "external target permissions unchanged" 0o644 permissions)
+;;
+
+let test_private_jsonl_transaction_lock_contention_is_typed () =
+  with_transaction_jsonl None @@ fun path ->
+  ignore (transaction_snapshot path ~after:None);
+  let ready_read, ready_write = Unix.pipe ~cloexec:true () in
+  let release_read, release_write = Unix.pipe ~cloexec:true () in
+  match Unix.fork () with
+  | 0 ->
+    Unix.close ready_read;
+    Unix.close release_write;
+    (try
+       let lock_fd =
+         Unix.openfile
+           (Fs_compat.private_jsonl_lock_path path)
+           [ Unix.O_RDWR; Unix.O_CLOEXEC ]
+           0
+       in
+       Unix.lockf lock_fd Unix.F_LOCK 0;
+       ignore (Unix.write_substring ready_write "x" 0 1 : int);
+       let release = Bytes.create 1 in
+       ignore (Unix.read release_read release 0 1 : int);
+       Unix.close lock_fd;
+       Unix._exit 0
+     with _ -> Unix._exit 2)
+  | child ->
+    Unix.close ready_write;
+    Unix.close release_read;
+    let ready = Bytes.create 1 in
+    ignore (Unix.read ready_read ready 0 1 : int);
+    Fun.protect
+      ~finally:(fun () ->
+        ignore (Unix.write_substring release_write "x" 0 1 : int);
+        Unix.close ready_read;
+        Unix.close release_write;
+        match Unix.waitpid [] child with
+        | _, Unix.WEXITED 0 -> ()
+        | _, status ->
+          fail
+            (Printf.sprintf
+               "stable-lock child failed: %s"
+               (match status with
+                | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+                | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+                | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal)))
+      (fun () ->
+         match Fs_compat.read_private_jsonl_durable_locked_result path ~after:None with
+         | Error (Fs_compat.Stable_lock_contended _) -> ()
+         | Error error ->
+           fail (Fs_compat.private_jsonl_transaction_error_to_string error)
+         | Ok _ -> fail "cross-process stable-lock contention was accepted")
 ;;
 
 let () =
@@ -457,9 +1149,85 @@ let () =
             `Quick
             test_private_jsonl_append_rejects_incomplete_suffix
         ; test_case
+            "private JSONL stable lock contention is typed"
+            `Quick
+            test_private_jsonl_transaction_lock_contention_is_typed
+        ; test_case
             "private JSONL append respects execution context"
             `Quick
             test_private_jsonl_append_respects_execution_context
+        ; test_case
+            "private JSONL transaction handles missing stores and deltas"
+            `Quick
+            test_private_jsonl_transaction_missing_and_delta_contract
+        ; test_case
+            "private JSONL transaction rejects a second writer cursor"
+            `Quick
+            test_private_jsonl_transaction_rejects_second_writer_cursor
+        ; test_case
+            "private JSONL transaction rejects same-length rewrite ABA"
+            `Quick
+            test_private_jsonl_transaction_rejects_same_length_rewrite_aba
+        ; test_case
+            "private JSONL stable lock is private"
+            `Quick
+            test_private_jsonl_transaction_lock_is_private
+        ; test_case
+            "private JSONL stable lock parent sync is one-shot"
+            `Quick
+            test_private_jsonl_stable_lock_parent_sync_is_one_shot
+        ; test_case
+            "private JSONL stable lock retries failed parent sync"
+            `Quick
+            test_private_jsonl_stable_lock_parent_sync_failure_retries
+        ; test_case
+            "private JSONL stable lock invalid state fails closed"
+            `Quick
+            test_private_jsonl_stable_lock_invalid_state_fails_closed
+        ; test_case
+            "private JSONL stable lock permission drift fails closed"
+            `Quick
+            test_private_jsonl_stable_lock_permission_drift_fails_closed
+        ; test_case
+            "private JSONL transaction rejects data aliases"
+            `Quick
+            test_private_jsonl_transaction_rejects_data_aliases
+        ; test_case
+            "private JSONL stable lock rejects symlink aliases"
+            `Quick
+            test_private_jsonl_transaction_rejects_symlink_lock_without_chmod
+        ; test_case
+            "private JSONL data close preserves primary error"
+            `Quick
+            test_private_jsonl_transaction_preserves_primary_when_data_close_fails
+        ; test_case
+            "private JSONL offset read preserves close failure"
+            `Quick
+            test_private_jsonl_slice_returns_value_with_close_failure
+        ; test_case
+            "private JSONL offset append preserves committed close failure"
+            `Quick
+            test_private_jsonl_append_returns_commit_with_close_failure
+        ; test_case
+            "private JSONL offset append preserves rejected close failure"
+            `Quick
+            test_private_jsonl_append_preserves_rejection_with_close_failure
+        ; test_case
+            "private file update preserves committed close failure"
+            `Quick
+            test_private_file_update_returns_value_with_close_failure
+        ; test_case
+            "private JSONL nested close failures accumulate"
+            `Quick
+            test_private_jsonl_transaction_accumulates_nested_close_failures
+        ; test_case
+            "private JSONL rewrite precondition close is not a commit"
+            `Quick
+            test_private_jsonl_rewrite_rejects_precondition_close_as_commit
+        ; test_case
+            "private JSONL append cancellation settles once with receipt"
+            `Quick
+            test_private_jsonl_append_cancellation_settles_once_with_receipt
         ] )
     ]
 ;;

--- a/test/test_keeper_board_attention_partition.ml
+++ b/test/test_keeper_board_attention_partition.ml
@@ -29,6 +29,12 @@ let expect_error label = function
   | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
 ;;
 
+let ledger_lines path =
+  Fs_compat.load_file path
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> not (String.equal line ""))
+;;
+
 let signal post_id : Masc.Board_dispatch.board_signal =
   { kind = Masc.Board_dispatch.Board_post_created
   ; post_id
@@ -177,6 +183,67 @@ let test_claim_ownership_completion_and_settlement () =
   Alcotest.(check bool) "settlement is idempotent" true (settled = settled_again);
   let next = claim ~base_path ~worker_epoch:owner ~now:13.0 in
   Alcotest.(check string) "next singleton remains independent" late.candidate_id next.candidate_id
+;;
+
+let test_runtime_transitions_append_then_startup_compacts () =
+  with_temp_base "board-attention-partition-append-index" @@ fun base_path ->
+  let pending = candidate ~id:"candidate-append" ~recorded_at:1.0 () in
+  ignore (roots ~base_path [ pending ] : P.t list);
+  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  let ready_bytes = Fs_compat.load_file ledger_path in
+  let owner = P.Worker_epoch.generate () in
+  let claimed = claim ~base_path ~worker_epoch:owner ~now:10.0 in
+  let running_bytes = Fs_compat.load_file ledger_path in
+  Alcotest.(check bool)
+    "claim preserves Ready prefix"
+    true
+    (String.starts_with running_bytes ~prefix:ready_bytes);
+  let item : P.completed_item =
+    { candidate_id = claimed.candidate_id; judgment = judgment () }
+  in
+  let completed =
+    match
+      ok
+        "complete append"
+        (P.complete ~now:11.0 ~worker_epoch:owner ~base_path ~partition:claimed ~item)
+    with
+    | P.Partition_completed partition -> partition
+    | P.Partition_deferred _ | P.Partition_blocked _ ->
+      Alcotest.fail "append fixture did not complete"
+  in
+  let completed_bytes = Fs_compat.load_file ledger_path in
+  Alcotest.(check bool)
+    "completion preserves Running prefix"
+    true
+    (String.starts_with completed_bytes ~prefix:running_bytes);
+  let settled = ok "settle append" (P.settle ~now:12.0 ~base_path ~partition:completed) in
+  let settled_bytes = Fs_compat.load_file ledger_path in
+  Alcotest.(check bool)
+    "settlement preserves Completed prefix"
+    true
+    (String.starts_with settled_bytes ~prefix:completed_bytes);
+  Alcotest.(check int)
+    "one row per runtime transition"
+    4
+    (List.length (ledger_lines ledger_path));
+  ignore (ok "idempotent settlement" (P.settle ~now:13.0 ~base_path ~partition:settled) : P.t);
+  Alcotest.(check string)
+    "idempotent settlement appends nothing"
+    settled_bytes
+    (Fs_compat.load_file ledger_path);
+  Alcotest.(check int)
+    "settled history recovers no claims"
+    0
+    (ok
+       "startup compaction"
+       (P.recover_for_process_start ~base_path ~keeper_name:"sangsu"));
+  Alcotest.(check int)
+    "startup compacts to one latest row"
+    1
+    (List.length (ledger_lines ledger_path));
+  match ok "load compacted ledger" (P.load ~base_path ~keeper_name:"sangsu") with
+  | [ { P.state = P.Settled _; _ } ] -> ()
+  | _ -> Alcotest.fail "startup compaction lost the Settled receipt"
 ;;
 
 let test_lane_abort_and_process_start_recovery_are_explicit () =
@@ -350,6 +417,10 @@ let () =
             "claim ownership completion and settlement"
             `Quick
             test_claim_ownership_completion_and_settlement
+        ; Alcotest.test_case
+            "runtime transitions append then startup compacts"
+            `Quick
+            test_runtime_transitions_append_then_startup_compacts
         ; Alcotest.test_case
             "lane abort and process-start recovery"
             `Quick


### PR DESCRIPTION
## Summary
- replace whole-file singleton partition rewrites with cursor-fenced append transitions
- maintain process-local latest-row, Ready-order, Completed, and live-candidate ownership indexes
- reject immutable identity changes, illegal FSM transitions, duplicate live membership, and stale cursors
- reserve canonical latest-row compaction and Running/Deferred recovery for process start

## Correctness
- membership remains exact-context singleton
- no TTL, retry counter, token estimate, split heuristic, or inferred capacity
- runtime mutations append exactly one transition row
- idempotent settlement appends no duplicate row
- process-start compaction preserves the latest durable Settled receipt

## Static verification
- ocamlc -stop-after parsing on changed ml/mli and focused fixture
- ocamlformat --check
- git diff --check
- local build/tests intentionally not run per operator instruction

Stacked on #25381. This is the current-contract replacement for the partition portion of #25198.