### PR TITLE
feat(runtime): sticky lane failover — start turns from the last-good candidate

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 214 unique knobs across 8 modules.
+**Total**: 215 unique knobs across 8 modules.
 
-**Typed getter classification**: 38/126 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 88).
+**Typed getter classification**: 39/127 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 88).
 
 ## Env_config_core (24 knobs; typed classification 2/5)
 
@@ -106,7 +106,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Historical keeper Domain_pool pilot flag. The supervisor still reads this for observability, but keepalive fibers rem... |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 17 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
-## Env_config_runtime (71 knobs; typed classification 4/56)
+## Env_config_runtime (72 knobs; typed classification 5/57)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -115,40 +115,41 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 227 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
 | `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 278 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
 | `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 269 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 535 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 549 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 41 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 37 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 386 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 382 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 384 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 425 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 439 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 377 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 449 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 482 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 469 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 414 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 409 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 458 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 373 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 369 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 365 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 400 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 396 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 398 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 439 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 453 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 391 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 463 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 496 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 483 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 428 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 423 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 472 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 387 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 383 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 379 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 53 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 512 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 500 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 526 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 514 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
 | `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 202 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
 | `MASC_GRPC_PORT` | string_literal | n/a | n/a | 198 | gRPC server port. Default: 8936. |
 | `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 206 | gRPC client target address. Derived from grpc_port when unset. |
 | `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 232 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 551 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 527 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 531 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 565 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 541 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 545 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 368 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
 | `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 291 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
 | `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 342 | Local runtime cooldown (seconds). |
 | `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 338 | Enable local runtime debug logging. Default: false. |
 | `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 345 | Local worker heartbeat interval (seconds). Default: 60. |
 | `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 144 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 523 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 537 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
 | `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 353 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 67 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 63 | Orchestrator check interval (seconds) |
@@ -156,15 +157,15 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 296 | Extra public tools (comma-separated names). |
 | `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 324 | Burst capacity. Default: 150. |
 | `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 321 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 565 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 557 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 579 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 571 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 8 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 13 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 591 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 579 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 607 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 539 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 543 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 605 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 593 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 621 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 553 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 557 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
 | `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 243 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 29 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 25 | Maximum polling interval (seconds) - for idle tempo |
@@ -177,8 +178,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 299 |  |
 | `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 302 |  |
 | `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 308 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 652 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 642 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 666 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 656 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 213 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 209 | WebSocket server port. Default: 8937. |
 
@@ -231,9 +232,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 450 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 454 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 456 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 452 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 456 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 458 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 150 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 220 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 222 |  |
@@ -252,18 +253,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 341 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 502 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 528 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 536 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 476 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 478 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 480 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 482 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 488 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 504 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 530 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 538 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 478 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 480 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 482 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 484 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 490 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 518 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 520 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 520 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 522 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -354,6 +354,20 @@ module Oas_sse = struct
     if v < 0.1 then 2.0 else v
 end
 
+(** {1 Lane failover} *)
+
+module Lane = struct
+  (** Sticky lane-candidate preference TTL (seconds). After a lane candidate
+      succeeds, later turns on the same lane try it first instead of
+      re-attempting candidates declared before it; [0] disables stickiness.
+      Default: 3600 (1 hour), matching common hourly provider rate-limit
+      windows.
+      @category Timeouts
+      @ops_class operator *)
+  let preference_ttl_s () =
+    get_float_nonneg ~default:3600.0 "MASC_LANE_PREFERENCE_TTL_S"
+end
+
 (** {1 Dashboard Signal Thresholds} *)
 
 module Dashboard = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -167,6 +167,16 @@ module Oas_sse : sig
   val drain_interval_sec : float
 end
 
+(** {1 Lane failover} *)
+
+module Lane : sig
+  val preference_ttl_s : unit -> float
+  (** Sticky lane-candidate preference TTL in seconds
+      ([MASC_LANE_PREFERENCE_TTL_S], default [3600.0]).  Re-read per call so
+      tests and operators can flip it without a restart; [0] disables
+      stickiness. *)
+end
+
 (** {1 Dashboard signal thresholds + render budgets} *)
 
 module Dashboard : sig

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -419,6 +419,8 @@ let model_routing_entries =
       "Default model id; None when unset";
     entry ~default:"(none)" "MASC_DEFAULT_PROVIDER"
       "Default provider name; None when unset";
+    entry ~default:"3600.0" "MASC_LANE_PREFERENCE_TTL_S"
+      "Sticky lane failover preference TTL (seconds, 1 hour); 0 disables";
   ]
 
 let oas_sse_entries =

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -387,10 +387,11 @@ let run_plan
 
 type candidate =
   { runtime_id : string
+  ; lane_id : string option
   ; provider_cfg : Llm_provider.Provider_config.t
   }
 
-let eligible_candidate ~keeper_name (runtime : Runtime.t) =
+let eligible_candidate ~keeper_name ~lane_id (runtime : Runtime.t) =
   let runtime_id = runtime.Runtime.id in
   let provider_cfg = runtime.Runtime.provider_config in
   (* #25266: a provider is eligible when it can enforce the schema (strict
@@ -409,10 +410,10 @@ let eligible_candidate ~keeper_name (runtime : Runtime.t) =
        the compaction plan schema nor json mode"
       runtime_id;
     None)
-  else Some { runtime_id; provider_cfg }
+  else Some { runtime_id; lane_id; provider_cfg }
 
 let candidates_for_assignment ~keeper_name assignment_id =
-  let rec resolve_lane acc = function
+  let rec resolve_lane ~lane_id acc = function
     | [] -> Some (List.rev acc)
     | runtime_id :: rest ->
       (match Runtime.get_runtime_by_id runtime_id with
@@ -423,11 +424,11 @@ let candidates_for_assignment ~keeper_name assignment_id =
          None
        | Some runtime ->
          let acc =
-           match eligible_candidate ~keeper_name runtime with
+           match eligible_candidate ~keeper_name ~lane_id:(Some lane_id) runtime with
            | None -> acc
            | Some candidate -> candidate :: acc
          in
-         resolve_lane acc rest)
+         resolve_lane ~lane_id acc rest)
   in
   match Runtime.resolve_assignment assignment_id with
   | `Missing ->
@@ -436,9 +437,14 @@ let candidates_for_assignment ~keeper_name assignment_id =
       assignment_id;
     None
   | `Single_runtime runtime ->
-    Some (Option.to_list (eligible_candidate ~keeper_name runtime))
+    Some (Option.to_list (eligible_candidate ~keeper_name ~lane_id:None runtime))
   | `Lane lane ->
-    resolve_lane [] (Runtime_lane.ordered_candidates lane)
+    (* Sticky failover: start from the last-good lane candidate when one is
+       remembered, keeping the declared order for the rest. *)
+    let lane_id = Runtime_lane.id lane in
+    resolve_lane ~lane_id []
+      (Runtime_lane_preference.prefer_order ~lane_id
+         (Runtime_lane.ordered_candidates lane))
 
 (* Collapse duplicate runtime ids while keeping the first (highest-priority)
    occurrence, so a seed assignment that resolves to the same runtime as a
@@ -506,6 +512,13 @@ let make_resolved ?complete ~(runtime_ids : string list) ~(keeper_name : string)
                     ~provider_cfg:candidate.provider_cfg ~units ()
                 with
                 | Ok _ as plan ->
+                  (* Sticky failover: remember the winning candidate for the
+                     lane it came from, if any. *)
+                  (match candidate.lane_id with
+                   | Some lane_id ->
+                     Runtime_lane_preference.note_success ~lane_id
+                       ~candidate:candidate.runtime_id
+                   | None -> ());
                   Log.Keeper.info ~keeper_name
                     "compaction LLM candidate succeeded assignments=%s runtime=%s"
                     assignments_label candidate.runtime_id;

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -25,12 +25,14 @@ type complete_fn = Keeper_provider_subcall.complete_fn
 (** [make ~runtime_ids ~keeper_name ()] resolves each id in [runtime_ids],
     most-preferred first, exactly as a single {!candidate_runtime_ids_for_assignment}
     would: a Runtime contributes its exact provider config, a Lane tries its
-    configured Runtime candidates in declared order. Every eligible candidate
-    across every seed id is tried, seed order first and then per-seed lane
-    order, with candidates that resolve to the same Runtime id collapsed to
-    their first (highest-priority) occurrence. Missing, ineligible, and failed
-    candidates are logged with their Runtime id. No default Runtime is
-    substituted. [complete] overrides the Provider boundary in tests.
+    configured Runtime candidates in declared order adjusted by the sticky
+    last-good lane preference ({!Runtime_lane_preference}). Every eligible
+    candidate across every seed id is tried, seed order first and then
+    per-seed lane order, with candidates that resolve to the same Runtime id
+    collapsed to their first (highest-priority) occurrence. Missing,
+    ineligible, and failed candidates are logged with their Runtime id. No
+    default Runtime is substituted. [complete] overrides the Provider boundary
+    in tests.
 
     The compaction owner imposes no wall-clock deadline. Cancellation belongs
     to the owning Keeper lane or to the Provider transport boundary. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -133,6 +133,7 @@ let attempt_runtime_candidates
     ?(allow_retry = fun ~runtime_id:_ ~attempt:_ _error -> true)
     ?(allow_accept_no_progress_retry = fun ~runtime_id:_ ~attempt:_ _error ->
       true)
+    ?lane_id
     ~runtime_id ~runtime_id_of
     ~(emit_runtime_manifest :
        ?status:string ->
@@ -159,6 +160,13 @@ let attempt_runtime_candidates
            ~status:"completed"
            ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
            Keeper_runtime_manifest.Runtime_completed;
+         (* Sticky failover: remember the winning candidate so later turns on
+            this lane start from it (idx 0 or a failover success alike). *)
+         (match lane_id with
+          | Some lane_id ->
+            Runtime_lane_preference.note_success ~lane_id
+              ~candidate:attempt_runtime_id
+          | None -> ());
          Ok value
        | Error error, _checkpoint_after ->
          emit_runtime_manifest
@@ -356,13 +364,19 @@ let run_named
     | _ -> ()
   in
   (* Lanes shadow runtimes: a lane id takes precedence over a runtime id so
-     operators can route through explicit failover groups. *)
+     operators can route through explicit failover groups.  Lane candidate
+     order passes through the sticky last-good preference so a known-healthy
+     failover candidate is tried before re-hitting a dead head candidate. *)
   let lane_resolution = Runtime.resolve_assignment runtime_id in
-  let lane_candidate_ids =
+  let lane_id_opt, lane_candidate_ids =
     match lane_resolution with
-    | `Missing -> []
-    | `Single_runtime runtime -> [ runtime.Runtime.id ]
-    | `Lane lane -> Runtime_lane.ordered_candidates lane
+    | `Missing -> None, []
+    | `Single_runtime runtime -> None, [ runtime.Runtime.id ]
+    | `Lane lane ->
+      let lane_id = Runtime_lane.id lane in
+      ( Some lane_id
+      , Runtime_lane_preference.prefer_order ~lane_id
+          (Runtime_lane.ordered_candidates lane) )
   in
   if lane_candidate_ids = []
   then
@@ -512,6 +526,7 @@ let run_named
   (* Sequential candidate attempt loop. On failure we record a manifest row and
      move to the next candidate; on success we record completion and return. *)
   attempt_runtime_candidates
+    ?lane_id:lane_id_opt
     ~allow_retry:(fun ~runtime_id:attempt_runtime_id ~attempt error ->
       let allowed =
         Keeper_turn_driver_try_provider.same_run_retry_allowed

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -180,6 +180,7 @@ module For_testing : sig
       (runtime_id:string -> attempt:int -> Agent_sdk.Error.sdk_error -> bool) ->
     ?allow_accept_no_progress_retry:
       (runtime_id:string -> attempt:int -> Agent_sdk.Error.sdk_error -> bool) ->
+    ?lane_id:string ->
     runtime_id:string ->
     runtime_id_of:('candidate -> string) ->
     emit_runtime_manifest:

--- a/lib/runtime/runtime_lane_preference.ml
+++ b/lib/runtime/runtime_lane_preference.ml
@@ -1,0 +1,48 @@
+(** Process-local sticky candidate preference for runtime lane failover.
+
+    See the [.mli] for the contract.  Implementation notes:
+
+    - State is a small [Hashtbl] guarded by [Stdlib.Mutex], matching the
+      {!Dashboard_oas_bridge} convention in this library (record/read may be
+      called from outside Eio fibers, so [Eio.Mutex] is not required).
+    - Expiry is lazy: [prefer_order] compares the entry age against
+      {!ttl_s} at call time and drops stale entries on read. *)
+
+type entry =
+  { candidate : string
+  ; noted_at : float
+  }
+
+let entries : (string, entry) Hashtbl.t = Hashtbl.create 8
+let mu = Stdlib.Mutex.create ()
+
+let ttl_s = Env_config_runtime.Lane.preference_ttl_s
+
+(* NDT-OK: the wall clock is the explicit time boundary for TTL expiry; no
+   deterministic replay logic branches on these timestamps. *)
+let now () = Unix.gettimeofday ()
+
+let prefer_order ~lane_id candidates =
+  let preferred =
+    Stdlib.Mutex.protect mu (fun () ->
+      match Hashtbl.find_opt entries lane_id with
+      | None -> None
+      | Some entry ->
+        if Float.compare (now () -. entry.noted_at) (ttl_s ()) < 0
+        then Some entry.candidate
+        else begin
+          Hashtbl.remove entries lane_id;
+          None
+        end)
+  in
+  match preferred with
+  | Some candidate when List.exists (String.equal candidate) candidates ->
+    candidate :: List.filter (fun id -> not (String.equal id candidate)) candidates
+  | _ -> candidates
+
+let note_success ~lane_id ~candidate =
+  Stdlib.Mutex.protect mu (fun () ->
+    Hashtbl.replace entries lane_id { candidate; noted_at = now () })
+
+let reset_for_testing () =
+  Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset entries)

--- a/lib/runtime/runtime_lane_preference.mli
+++ b/lib/runtime/runtime_lane_preference.mli
@@ -1,0 +1,29 @@
+(** Process-local sticky candidate preference for runtime lane failover.
+
+    Lane failover walks candidates in declared order every turn, so a dead
+    head candidate (e.g. an hourly provider rate-limit window) is hit on
+    every turn before the lane fails over.  This module remembers the last
+    successful candidate per lane so later turns start from it instead.
+
+    The table is keyed by lane id and shared across keepers on purpose:
+    provider rate limits are account-scoped, so one keeper's failover
+    discovery benefits every keeper routed through the same lane.  Entries
+    expire lazily on read against {!ttl_s}; there is no background sweeper. *)
+
+val prefer_order : lane_id:string -> string list -> string list
+(** Reorder [candidates] so the remembered last-good candidate for [lane_id]
+    comes first, keeping the declared relative order of the rest.  Returns
+    the input unchanged when no entry is remembered, the entry expired, or
+    the remembered candidate is not a member of [candidates]. *)
+
+val note_success : lane_id:string -> candidate:string -> unit
+(** Remember [candidate] as the last-good candidate for [lane_id], stamped
+    with the current time.  Called on every successful attempt, whether the
+    head candidate or a failover candidate succeeded. *)
+
+val ttl_s : unit -> float
+(** Sticky preference TTL in seconds ([MASC_LANE_PREFERENCE_TTL_S], default
+    [3600.0]; [0] disables stickiness). *)
+
+val reset_for_testing : unit -> unit
+(** Drop every remembered entry.  Test-only. *)

--- a/test/dune
+++ b/test/dune
@@ -119,6 +119,7 @@
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm
+  test_runtime_lane_preference
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
   test_domain_pool
@@ -432,6 +433,7 @@
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm
+  test_runtime_lane_preference
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
   test_domain_pool

--- a/test/test_runtime_lane_preference.ml
+++ b/test/test_runtime_lane_preference.ml
@@ -1,0 +1,73 @@
+(** Unit tests for Runtime_lane_preference — sticky lane candidate ordering.
+
+    Each case resets the process-local table first; the TTL case shrinks
+    [MASC_LANE_PREFERENCE_TTL_S] via env (re-read per call) instead of
+    injecting a clock. *)
+
+let candidates = [ "alpha"; "beta"; "gamma" ]
+
+let test_identity_without_state () =
+  Runtime_lane_preference.reset_for_testing ();
+  Alcotest.(check (list string)) "no state keeps declared order" candidates
+    (Runtime_lane_preference.prefer_order ~lane_id:"lane-1" candidates)
+
+let test_preferred_first_after_success () =
+  Runtime_lane_preference.reset_for_testing ();
+  Runtime_lane_preference.note_success ~lane_id:"lane-1" ~candidate:"beta";
+  Alcotest.(check (list string)) "remembered candidate leads"
+    [ "beta"; "alpha"; "gamma" ]
+    (Runtime_lane_preference.prefer_order ~lane_id:"lane-1" candidates)
+
+let test_success_on_head_is_harmless () =
+  Runtime_lane_preference.reset_for_testing ();
+  Runtime_lane_preference.note_success ~lane_id:"lane-1" ~candidate:"alpha";
+  Alcotest.(check (list string)) "head success keeps declared order"
+    candidates
+    (Runtime_lane_preference.prefer_order ~lane_id:"lane-1" candidates)
+
+let test_lane_isolation () =
+  Runtime_lane_preference.reset_for_testing ();
+  Runtime_lane_preference.note_success ~lane_id:"lane-1" ~candidate:"beta";
+  Alcotest.(check (list string)) "other lane unaffected" candidates
+    (Runtime_lane_preference.prefer_order ~lane_id:"lane-2" candidates)
+
+let test_non_member_ignored () =
+  Runtime_lane_preference.reset_for_testing ();
+  Runtime_lane_preference.note_success ~lane_id:"lane-1" ~candidate:"gone";
+  Alcotest.(check (list string)) "non-member remembered id keeps order"
+    candidates
+    (Runtime_lane_preference.prefer_order ~lane_id:"lane-1" candidates)
+
+let test_ttl_expiry_restores_order () =
+  Runtime_lane_preference.reset_for_testing ();
+  Unix.putenv "MASC_LANE_PREFERENCE_TTL_S" "0.05";
+  Fun.protect
+    ~finally:(fun () -> Unix.putenv "MASC_LANE_PREFERENCE_TTL_S" "")
+    (fun () ->
+      Alcotest.(check (float 0.001)) "env ttl applies" 0.05
+        (Runtime_lane_preference.ttl_s ());
+      Runtime_lane_preference.note_success ~lane_id:"lane-1" ~candidate:"beta";
+      Alcotest.(check (list string)) "fresh entry leads"
+        [ "beta"; "alpha"; "gamma" ]
+        (Runtime_lane_preference.prefer_order ~lane_id:"lane-1" candidates);
+      Unix.sleepf 0.1;
+      Alcotest.(check (list string)) "expired entry restores declared order"
+        candidates
+        (Runtime_lane_preference.prefer_order ~lane_id:"lane-1" candidates))
+
+let () =
+  Alcotest.run "runtime_lane_preference"
+    [
+      ( "prefer_order"
+      , [ Alcotest.test_case "identity without state" `Quick
+            test_identity_without_state
+        ; Alcotest.test_case "remembered candidate first" `Quick
+            test_preferred_first_after_success
+        ; Alcotest.test_case "head success harmless" `Quick
+            test_success_on_head_is_harmless
+        ; Alcotest.test_case "lane isolation" `Quick test_lane_isolation
+        ; Alcotest.test_case "non-member ignored" `Quick test_non_member_ignored
+        ; Alcotest.test_case "ttl expiry restores order" `Quick
+            test_ttl_expiry_restores_order
+        ] )
+    ]


### PR DESCRIPTION
## Problem

Lanes (`[runtime.lanes.<id>]`) already give per-turn ordered failover, but every turn restarts from candidate[0]. With a dead primary — e.g. the weekly rate-limit window currently killing `ollama_cloud_native.minimax-m3` — every turn pays one slow failed call (observed 17–76s in production logs) before failing over, thousands of times a day.

## Fix

New `Runtime_lane_preference`: remembers the last **successful** candidate per lane and `prefer_order` puts it first next turn.

- Process-local, **lane-shared** state — rate limits are account-scoped, so one keeper's failover discovery benefits every keeper on the lane
- `MASC_LANE_PREFERENCE_TTL_S` (default 3600s, `0` = disabled): lazy expiry on read, so declared order resumes once the limit window passes
- Failures are never recorded: a dead remembered head costs one probe, then the next success re-sticks (self-healing)
- Applied in `keeper_turn_driver` and shared by `keeper_compaction_llm_summarizer`; single-runtime assignments untouched

## Operator usage

```toml
[runtime.lanes.default]
strategy = ordered
candidates = [ kimi_code.kimi-for-coding, glm-coding.glm-5-turbo ]

[runtime.assignments]
garnet = default   # lane id shadows the runtime id
```

## Verification

- `dune build lib/` ✓
- `test_runtime_lane_preference` 6/6 ✓ (identity, reorder, lane isolation, non-member, TTL expiry, head-success no-op)
- `test_keeper_turn_driver_failover` 17, `runtime_attempt_fsm` 23, `compaction_llm_summarizer` 21, `boundary_redaction_runtime_lane` 3 ✓
- Determinism gate PASS ✓, runtime-tunables regenerated ✓

Note: `test_keeper_turn_driver_accept` has one pre-existing failure at branch base (stale source-shape assertion after a rename in 6ea111f3ed) — unrelated; issue filing pending (GitHub API rate-limited at the time).