### PR TITLE
fix(keeper)!: move world-state frame to per-turn dynamic context (#25193)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -136,8 +136,9 @@ let keeper_config_json (config : Workspace.config) (name : string)
       in
       (* Preview the actual unified prompt the keeper turn uses.
          We build the observation from the current workspace state so the
-         system message and the "Current World State" user message both
-         match what a turn would see right now.
+         effective per-turn system side (identity + "Current World State"
+         dynamic context) and the persisted user message both match what a
+         turn would see right now.
 
          Board events are collected WITHOUT advancing the keeper's board
          cursor: passing [~pending_board_events:None] would route through
@@ -156,8 +157,17 @@ let keeper_config_json (config : Workspace.config) (name : string)
           Keeper_world_observation.observe
             ~pending_board_events:(Some pending_board_events) ~config ~meta:m
         in
-        Keeper_unified_prompt.build_prompt ~meta:m ~base_path:config.base_path
-          ~profile_defaults:defaults ~observation ()
+        let parts =
+          Keeper_unified_prompt.build_prompt ~meta:m ~base_path:config.base_path
+            ~profile_defaults:defaults ~observation ()
+        in
+        (* Match what a turn actually sends: the observation frame rides the
+           per-turn dynamic context (system side), and the persisted user
+           message is the wake marker / utterances only. *)
+        ( parts.Keeper_unified_prompt.system_prompt
+          ^ "\n\n"
+          ^ parts.Keeper_unified_prompt.world_state,
+          parts.Keeper_unified_prompt.user_message )
       in
       let prompt =
         `Assoc [

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -515,7 +515,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     ?(current_task : Masc_domain.task option)
     ?(active_goal_summaries : (string * string) list option)
     ~(observation : Keeper_world_observation.world_observation)
-    () : string * string
+    () : turn_prompt_parts
     =
   ignore base_path;
   (* Total deterministic resolution between two known instruction sources

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -10,6 +10,20 @@
 
     @since Unified Keeper Loop *)
 
+type turn_prompt_parts = {
+  system_prompt : string;
+  world_state : string;
+  user_message : string;
+}
+
+(* Persisted user-turn content for autonomous wake turns. The observation
+   frame is carried in [world_state] (per-turn dynamic context) — persisting
+   it re-feeds the model its own observations and starves compaction
+   (#25193: 943/945 user messages were identical frames). *)
+let autonomous_wake_marker =
+  "(autonomous wake — the current observation frame is provided per-turn in \
+   system context)"
+
 let format_pending_messages
       (messages : Keeper_world_observation_message_scope.pending_message list)
   : string
@@ -808,9 +822,10 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         Some (Buffer.contents ubuf))
       else None
   in
-  let user_message =
+  let world_state =
     "## Current World State\n\n" ^ Keeper_context_layers.assemble ~content_of
   in
+  let user_message = autonomous_wake_marker in
   (* Tool names and availability come exclusively from the typed schemas sent
      with this turn. Prompt markdown describes behaviour rather than attempting
      to mirror that catalog. World-state observations remain byte-for-byte
@@ -827,6 +842,10 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     (Float.of_int (String.length system_prompt));
   Otel_metric_store.set_gauge
     (Keeper_metrics.to_string PromptSegmentBytes)
+    ~labels:[("keeper", meta.name); ("segment", "world_state")]
+    (Float.of_int (String.length world_state));
+  Otel_metric_store.set_gauge
+    (Keeper_metrics.to_string PromptSegmentBytes)
     ~labels:[("keeper", meta.name); ("segment", "user_message")]
     (Float.of_int (String.length user_message));
   (* Instruction hash: emit a stable numeric fingerprint of the full prompt
@@ -834,7 +853,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
      changes between turns without storing the prompt content itself.
      Uses first 8 hex chars of SHA-256 as an integer (32-bit). *)
   let prompt_hash =
-    let combined = system_prompt ^ user_message in
+    let combined = system_prompt ^ world_state ^ user_message in
     let hex =
       Digestif.SHA256.(to_hex (digest_string combined))
     in
@@ -844,4 +863,4 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     (Keeper_metrics.to_string KeeperTurnInstructionHash)
     ~labels:[("keeper", meta.name)]
     prompt_hash;
-  system_prompt, user_message
+  { system_prompt; world_state; user_message }

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -11,11 +11,35 @@ val format_board_event_text : Keeper_world_observation.pending_board_event -> st
     RFC-0320 W3(a) verifies that an [External_attention] event steers the woken
     keeper to reply into the originating conversation via keeper_surface_post. *)
 
-(** Build unified system prompt and user message from keeper state.
+(** Three-channel turn prompt. The observation frame is separated from the
+    persisted user message so it can be injected per-turn (via
+    [dynamic_context]) instead of accumulating in the OAS conversation.
 
-    Returns [(system_prompt, user_message)] where:
-    - [system_prompt] contains keeper identity, instructions, and turn intent
-    - [user_message] contains reactive triggers + resource state only
+    Feedback-loop invariant (#25193, RFC PR #25246, operator decision
+    2026-07-20): [world_state] must never be persisted as a conversation
+    message. A live audit found 943/945 user messages in one keeper's
+    checkpoint were byte-identical world-state frames (59% of payload),
+    which starved compaction and re-fed the model its own observations. *)
+type turn_prompt_parts = {
+  system_prompt : string;
+      (** Keeper identity, instructions, and turn intent. Stable across
+          turns of a generation. *)
+  world_state : string;
+      (** The "## Current World State" observation frame, rebuilt fresh
+          every turn. Inject as per-turn [dynamic_context]; never append
+          to the persisted message history. *)
+  user_message : string;
+      (** Persisted user-turn content: genuine utterances only. For
+          autonomous wake turns this is {!autonomous_wake_marker}; HITL
+          resolutions are appended by the turn driver. *)
+}
+
+val autonomous_wake_marker : string
+(** Persisted user-turn content for autonomous wake turns. Constant and
+    tiny by design: the observation frame lives in
+    {!turn_prompt_parts.world_state}, not in the message history. *)
+
+(** Build the three-channel unified prompt from keeper state.
 
     @param meta Keeper metadata (identity, soul, goals, instructions)
     @param observation Current world snapshot *)
@@ -28,7 +52,7 @@ val build_prompt :
   ?active_goal_summaries:(string * string) list ->
   observation:Keeper_world_observation.world_observation ->
   unit ->
-  string * string
+  turn_prompt_parts
 (** When [?profile_defaults] is omitted, [instructions] falls back to
     [meta.instructions]. Production hot path supplies profile defaults;
     tests can keep the bare call.

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -634,7 +634,7 @@ let run_keeper_cycle
                      | None -> (goal_id, ""))
                    meta.active_goal_ids
                in
-               let system_prompt, user_message =
+               let { Keeper_unified_prompt.system_prompt; world_state; user_message } =
                  Keeper_unified_prompt.build_prompt
                    ~meta
                    ~base_path:config.base_path
@@ -679,10 +679,14 @@ let run_keeper_cycle
                let build_turn_prompt ~base_system_prompt:_ ~messages:_
                  : Keeper_agent_run.turn_prompt
                  =
-                 (* Unified path already places soft context (continuity, worktree)
-           in the user_message via Keeper_unified_prompt.build_prompt.
-           No dynamic_context needed here. *)
-                 { system_prompt; dynamic_context = "" }
+                 (* The observation frame rides [dynamic_context]: rebuilt fresh
+                    every turn and composed into the per-turn system prompt, so
+                    it never enters the persisted OAS conversation. Persisting
+                    it as a user message re-fed the model its own observations
+                    (943/945 identical frames in one live checkpoint, #25193)
+                    and starved compaction. Persisted user content is utterances
+                    only (wake marker + HITL resolutions). *)
+                 { system_prompt; dynamic_context = world_state }
                in
                (* 5. Run via OAS Agent.run() with transient-error retry.
                   The turn-local OAS Event_bus preserves factual
@@ -999,7 +1003,9 @@ let run_keeper_cycle
                      with
                      | Some requested -> string_of_int requested
                      | None -> "none")
-                    (String.length system_prompt + String.length user_message)
+                    (String.length system_prompt
+                     + String.length world_state
+                     + String.length user_message)
                     latency_ms
                     (if is_server_parse_rejection
                      then " (server parse rejection, auto-recoverable)"

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -131,13 +131,13 @@ let init_prompt_config_for_tests () =
       Masc.Keeper_prompt_external.reset_cache ()
 
 let user_message observation =
-  let _system, user =
+  let { Prompt.world_state = user; _ } =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~observation ()
   in
   user
 
 let system_prompt ?profile_defaults observation =
-  let system, _user =
+  let { Prompt.system_prompt = system; _ } =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?profile_defaults
       ~observation ()
   in

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -116,7 +116,7 @@ let test_persona_reaches_unified_system_prompt () =
   write_file
     (Filename.concat persona_dir "AGENT.md")
     "집요하고 직설적. 근본 원인을 잡을 때까지 <blame>을 판다.";
-  let system_prompt, _user =
+  let { Masc.Keeper_unified_prompt.system_prompt; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:(make_meta "test-keeper")
       ~base_path:"/tmp" ~observation:base_observation ()
   in
@@ -131,7 +131,7 @@ let test_persona_reaches_unified_system_prompt () =
 
 let test_no_persona_file_means_no_block () =
   with_config_dir @@ fun ~config_dir:_ ->
-  let system_prompt, _user =
+  let { Masc.Keeper_unified_prompt.system_prompt; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:(make_meta "test-keeper")
       ~base_path:"/tmp" ~observation:base_observation ()
   in
@@ -145,7 +145,7 @@ let test_persona_sits_between_identity_and_shared_body () =
   let persona_dir = Filename.concat config_dir "personas/test-keeper" in
   mkdir_p persona_dir;
   write_file (Filename.concat persona_dir "AGENT.md") "차분하고 꼼꼼함.";
-  let system_prompt, _user =
+  let { Masc.Keeper_unified_prompt.system_prompt; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:(make_meta "test-keeper")
       ~base_path:"/tmp" ~observation:base_observation ()
   in

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -164,11 +164,11 @@ let test_board_authors_share_one_neutral_observation_boundary () =
   let human_event = { sample_board_event with post_id = "human-1" } in
   let obs_peer = { base_observation with pending_board_events = [ peer_event ] } in
   let obs_human = { base_observation with pending_board_events = [ human_event ] } in
-  let _, peer_msg =
+  let { Masc.Keeper_unified_prompt.world_state = peer_msg; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
       ~observation:obs_peer ()
   in
-  let _, human_msg =
+  let { Masc.Keeper_unified_prompt.world_state = human_msg; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
       ~observation:obs_human ()
   in
@@ -213,7 +213,7 @@ let test_board_reaction_event_renders_reaction_context () =
     }
   in
   let obs = { base_observation with pending_board_events = [ reaction_event ] } in
-  let _, user_msg =
+  let { Masc.Keeper_unified_prompt.world_state = user_msg; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
       ~observation:obs ()
   in
@@ -240,7 +240,7 @@ let test_observation_tool_names_are_preserved () =
     }
   in
   let obs = { base_observation with pending_board_events = [ event ] } in
-  let _, user_msg =
+  let { Masc.Keeper_unified_prompt.world_state = user_msg; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
       ~observation:obs ()
   in
@@ -319,7 +319,7 @@ let test_scheduled_automation_prompt_section () =
   let obs =
     { base_observation with scheduled_automation = scheduled_automation_observation }
   in
-  let _, user_msg =
+  let { Masc.Keeper_unified_prompt.world_state = user_msg; _ } =
     Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
       ~observation:obs ()
   in
@@ -331,6 +331,28 @@ let test_scheduled_automation_prompt_section () =
     (contains_sub "masc_schedule_get" user_msg);
   check bool "prompt includes ready next action" true
     (contains_sub "do not create a duplicate schedule" user_msg)
+
+(* Feedback-loop invariant (#25193): the observation frame must ride the
+   ephemeral [world_state] channel, never the persisted [user_message].
+   Under the pre-split behaviour (frame concatenated into the user message)
+   both checks below go red: the marker check because the user message
+   started with "## Current World State", and the containment check because
+   the frame text was present in the persisted channel. *)
+let test_world_state_never_in_persisted_user_message () =
+  let obs = { base_observation with pending_board_events = [ sample_board_event ] } in
+  let { Masc.Keeper_unified_prompt.world_state; user_message; _ } =
+    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
+      ~observation:obs ()
+  in
+  check bool "world_state carries the frame header" true
+    (contains_sub "## Current World State" world_state);
+  check bool "persisted user message is the wake marker" true
+    (String.equal user_message
+       Masc.Keeper_unified_prompt.autonomous_wake_marker);
+  check bool "persisted user message carries no frame header" false
+    (contains_sub "## Current World State" user_message);
+  check bool "persisted user message carries no board observation" false
+    (contains_sub "### Board Activity" user_message)
 
 let () =
   run "keeper_unified_verification_surface"
@@ -375,5 +397,8 @@ let () =
           test_case
             "prompt: scheduled automation section renders attention items"
             `Quick test_scheduled_automation_prompt_section;
+          test_case
+            "invariant: world-state frame never enters the persisted user message"
+            `Quick test_world_state_never_in_persisted_user_message;
         ] );
     ]

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -165,7 +165,7 @@ let make_task ?(handoff_context = None) ~task_status () : Masc_domain.task =
   }
 
 let user_message ?turn_decision ?current_task ?active_goal_summaries observation =
-  let _system, user =
+  let { Prompt.world_state = user; _ } =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?turn_decision
       ?current_task ?active_goal_summaries ~observation ()
   in
@@ -298,7 +298,7 @@ let test_goal_holder_gets_self_direction_directive () =
           ("active_goal_ids", `List [ `String "goal-x" ]);
         ])
   in
-  let system, _user =
+  let { Prompt.system_prompt = system; _ } =
     Prompt.build_prompt ~meta:meta_with_goal ~base_path:"/tmp/unused"
       ~observation:base_observation ()
   in
@@ -306,7 +306,7 @@ let test_goal_holder_gets_self_direction_directive () =
     (contains ~needle:"advance one of your active" system);
   check bool "defer is stated as valid" true
     (contains ~needle:"Deferring is a valid choice" system);
-  let no_goal_system, _user =
+  let { Prompt.system_prompt = no_goal_system; _ } =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused"
       ~observation:base_observation ()
   in


### PR DESCRIPTION
## 문제 (라이브 실측, 2026-07-20)

analyst keeper 체크포인트: user 메시지 945건 중 **943건이 byte-identical `## Current World State` 프레임** (2.21MB 페이로드의 59%, 473k 토큰 vs 262k 창). 통합 턴이 매 사이클 관찰 프레임을 영속 user 메시지로 append → 모델이 자기 관찰을 되먹임 + 컴팩션 요약이 들어갈 창이 있는 provider가 소멸 → 수동 컴팩트 포함 컴팩션 전면 불능. #25193의 실측 확장판(당시 50.8% → 이번 99.8%).

## 수리 (3-채널 typed 분리)

- `Keeper_unified_prompt.build_prompt` → `turn_prompt_parts` 레코드: `system_prompt` / `world_state` / `user_message`
- `world_state`(관찰 프레임)는 **`Keeper_agent_run.turn_prompt.dynamic_context`로 주입** — 매 턴 신선하게 재구성, 영속 대화에 절대 미기록. 기존 배선(`dynamic_context`)이 이미 존재했고 통합 경로만 `""`로 비워두고 있었음(해당 주석이 버그).
- 영속 `user_message`는 발화 전용: 상수 wake marker + HITL resolution(드라이버가 append)
- dashboard 프리뷰는 system+world_state 합성으로 턴 실제 전송과 일치 유지
- `PromptSegmentBytes`에 `world_state` 세그먼트 추가, instruction hash는 3채널 전체

## 검증

- invariant 테스트 추가: 프레임이 영속 user 메시지에 절대 미포함 (pre-split 동작이면 red — counterfactual)
- 기존 관찰-렌더링 테스트 8곳은 `world_state` 채널을 읽도록 이동 (렌더링 계약 불변)
- ocamlformat 통과, dune 빌드/테스트는 CI

## 후속 (별도 실행)

- 운영자 승인 하의 일회성 오프라인 purge: 누적 프레임을 라이브 스냅샷에서 제거 (백업 후)
- RFC PR #25246 (observation/utterance 채널 분리)의 축적-차단 코어를 본 PR이 구현; 전체 채널 분리는 RFC 트랙 유지

breaking(!): `build_prompt` 반환 타입 변경 (tuple → typed record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
