### PR TITLE
fix(D): 키퍼 컨텍스트 축소 시 컴팩션 확인 요구 (silent shrink → next-turn overflow 차단)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -405,8 +405,15 @@ let dashboard_config_string_list_fields =
     "allowed_paths";
   ]
 
+(* Control field (not persisted): explicit acknowledgement that reducing
+   [max_context_override] may force a compaction. Stripped before the config is
+   parsed/applied. RFC context: reactive Provider_overflow death-spiral
+   (#25062/#25268) — a silent shrink converts a settings edit into a next-turn
+   overflow. *)
+let confirm_context_shrink_field = "confirm_context_shrink"
+
 let dashboard_config_patch_allowed_fields =
-  [ "name"; "max_context_override" ]
+  [ "name"; "max_context_override"; confirm_context_shrink_field ]
   @
   dashboard_config_string_fields
   @ dashboard_config_bool_fields
@@ -544,6 +551,10 @@ let validate_dashboard_config_field key value =
     | other -> dashboard_field_type_error key "a string" other
   else if key = "max_context_override" then
     validate_dashboard_max_context_override value
+  else if key = confirm_context_shrink_field then
+    (match value with
+     | `Bool _ -> Ok ()
+     | other -> dashboard_field_type_error key "a boolean" other)
   else if List.mem key dashboard_config_string_fields then
     match value with
     | `String _ -> Ok ()
@@ -586,6 +597,21 @@ let validate_dashboard_config_patch ~meta:_ fields =
          | Error msg -> Error msg
          | Ok () -> Ok ())
 
+(* [Some (previous_display, new_value)] when the patch reduces the keeper's
+   context window below its current setting — introducing a cap where there was
+   none (full model window -> capped), or lowering an existing cap. [None] when
+   the field is absent, set to Null (removing the cap = expand), or raised.
+   Compares the persisted override only; a stricter check against the live
+   checkpoint token size is a follow-up. *)
+let context_shrink_of_patch ~(meta : Keeper_meta_contract.keeper_meta) fields =
+  match List.assoc_opt "max_context_override" fields with
+  | Some (`Int new_v) ->
+    (match meta.Keeper_meta_contract.max_context_override with
+     | None -> Some ("unset (full model window)", new_v)
+     | Some old_v when new_v < old_v -> Some (string_of_int old_v, new_v)
+     | Some _ -> None)
+  | _ -> None
+
 let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_config in
@@ -627,6 +653,27 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                  (match validate_dashboard_config_patch ~meta:meta0 fields with
                   | Error msg -> respond_error reqd msg
                   | Ok () ->
+                      let confirm_context_shrink =
+                        match
+                          List.assoc_opt confirm_context_shrink_field fields
+                        with
+                        | Some (`Bool b) -> b
+                        | _ -> false
+                      in
+                      (* Control field: consumed here, never persisted. *)
+                      let fields =
+                        List.remove_assoc confirm_context_shrink_field fields
+                      in
+                      (match context_shrink_of_patch ~meta:meta0 fields with
+                       | Some (previous, new_v) when not confirm_context_shrink ->
+                           respond_error reqd
+                             (Printf.sprintf
+                                "reducing max_context_override (%s -> %d) can push \
+                                 this keeper's existing context past the new window \
+                                 and force a compaction on its next turn. Re-send \
+                                 with %S: true to apply."
+                                previous new_v confirm_context_shrink_field)
+                       | _ ->
                       let args_with_name =
                         `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
                       in
@@ -675,7 +722,7 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                                  name
                              in
                              Http.Response.json_value ~compress:true
-                               ~request:req json reqd)))
+                               ~request:req json reqd))))
            | None ->
                respond_error reqd "request body must be a JSON object"
          with Yojson.Json_error e ->

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -69,6 +69,16 @@ val refresh_keeper_execution_surfaces :
 val invalidate_keeper_execution_surfaces :
   config:Workspace_utils.config -> unit -> unit
 
+(** [context_shrink_of_patch ~meta fields] is [Some (previous_display, new_value)]
+    when the config patch reduces the keeper's context window below its current
+    setting (introduces a cap where there was none, or lowers an existing cap),
+    else [None]. Used by {!handle_keeper_config_post} to require an explicit
+    [confirm_context_shrink] acknowledgement before applying a shrink. *)
+val context_shrink_of_patch :
+  meta:Keeper_meta_contract.keeper_meta ->
+  (string * Yojson.Safe.t) list ->
+  (string * int) option
+
 val handle_keeper_config_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1933,6 +1933,45 @@ let test_composite_blocked_uses_terminal_contract_not_observational_metadata () 
           ~terminal_reason_code:"opaque_terminal_failure"
           ~operator_disposition_reason:"success"))
 
+(* Context-window shrink guard (#25062/#25268): reducing max_context_override
+   must be detected so the config POST can require an explicit
+   confirm_context_shrink, instead of silently applying a window smaller than the
+   live context and triggering a reactive Provider_overflow on the next turn. *)
+module Keeper_config_post = Server_dashboard_http_keeper_api_post
+
+let shrink_base_meta () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc [ ("name", `String "shrink-fixture"); ("trace_id", `String "shrink-t") ])
+  with
+  | Ok m -> m
+  | Error e -> Alcotest.fail ("shrink meta fixture: " ^ e)
+
+let with_max_override meta o =
+  { meta with Masc.Keeper_meta_contract.max_context_override = o }
+
+let shrink_result = Alcotest.(option (pair string int))
+
+let test_context_shrink_detection () =
+  let base = shrink_base_meta () in
+  let shrink meta fields = Keeper_config_post.context_shrink_of_patch ~meta fields in
+  check shrink_result "cap introduced where there was none is a shrink"
+    (Some ("unset (full model window)", 1000))
+    (shrink (with_max_override base None) [ ("max_context_override", `Int 1000) ]);
+  check shrink_result "lowering an existing cap is a shrink"
+    (Some ("2000", 1000))
+    (shrink (with_max_override base (Some 2000)) [ ("max_context_override", `Int 1000) ]);
+  check shrink_result "raising the cap is not a shrink"
+    None
+    (shrink (with_max_override base (Some 1000)) [ ("max_context_override", `Int 2000) ]);
+  check shrink_result "removing the cap (Null) is not a shrink"
+    None
+    (shrink (with_max_override base (Some 1000)) [ ("max_context_override", `Null) ]);
+  check shrink_result "a patch without the field is not a shrink"
+    None
+    (shrink (with_max_override base (Some 1000)) [ ("name", `String "shrink-fixture") ])
+;;
+
 let () =
   run "dashboard_http_core"
     [
@@ -2048,5 +2087,9 @@ let () =
             test_lifecycle_event_cache_patcher_coverage;
           test_case "cache patchers pin byte-identical values" `Quick
             test_lifecycle_event_display_values;
+        ] );
+      ( "context-window shrink guard (#25062/#25268)",
+        [ test_case "shrink of max_context_override is detected" `Quick
+            test_context_shrink_detection;
         ] );
     ]


### PR DESCRIPTION
## 무엇을 / 왜

키퍼 상세 설정에서 **context window(`max_context_override`)를 줄이면 조용히 적용**됩니다 — 검증은 양수 체크뿐이고, 새 (작은) window를 기존 컨텍스트 크기와 비교하지 않습니다. 다음 턴에 작은 예산이 admission 체크 없이 적용 → over-limit 컨텍스트가 **reactive `Provider_overflow` = fleet이 싸워온 죽음의 나선**(#25062/#25268)을 유발합니다.

사용자 지적: *"컨텍스트 큰거→작은거 변경할 때는 컴팩션 여부를 물어봐야 하는 거 아닌가?"* — 맞습니다. 지금은 안 묻습니다.

## 수정

`handle_keeper_config_post`가 `max_context_override` **축소**(없던 cap 도입 또는 기존 cap 하향)를 순수 함수 `context_shrink_of_patch`로 감지하고, 요청에 `"confirm_context_shrink": true`(consume되고 persist 안 되는 control 필드)가 없으면 **typed 경고로 거부**합니다. 조용한 적용 → 명시적 확인으로 바뀌어, 대시보드가 적용 전에 프롬프트할 수 있습니다.

실제 컴팩션은 키퍼 자신의 **admission-gated 경로**(`Keeper_manual_compaction.run_admitted`가 유일 sanctioned caller)가 담당하며, HTTP 핸들러는 이를 우회하지 않습니다(concurrency 계약 준수).

## 검증
- `dune build` green
- `test_dashboard_http_core` **55/55** (신규 "context-window shrink guard": 감지 매트릭스 — cap 도입/하향/상향/제거/부재 counterfactual)

## 후속 (별도)
- 프론트: 이 거부를 받아 "축소 시 컴팩션 필요, 확인?" 프롬프트 UX (C 사이드바 PR과 함께 대시보드 작업).
- 정밀화: 축소를 persisted override가 아니라 **라이브 checkpoint 토큰 크기**와 비교(축소해도 현재 컨텍스트가 여전히 맞으면 확인 불필요).

RFC: #25062/#25268 (reactive overflow death-spiral) 계열의 write-boundary 예방.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
