### PR TITLE
fix(compaction): partition degrades gracefully on dangling/overlapping tool cycle instead of blocking all compaction

### DIFF
--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -41,6 +41,10 @@ type structural_error =
       { message_index : int
       ; tool_use_id : string
       }
+  (* Retained in the taxonomy for [show]/telemetry compatibility. No longer
+     produced by [partition]: a dangling ToolUse followed by a new ToolUse now
+     degrades gracefully into [protected_suffix] instead of aborting the whole
+     compaction (see [partition]). *)
   | Overlapping_tool_cycle of
       { message_index : int
       ; tool_use_id : string
@@ -162,8 +166,24 @@ let partition messages =
             Error (Non_assistant_tool_use { message_index = index; tool_use_id })
         | _ -> (
             match open_cycle, tool_ids, result_ids with
-            | Some _, tool_use_id :: _, _ ->
-                Error (Overlapping_tool_cycle { message_index = index; tool_use_id })
+            | Some cycle, _ :: _, _ ->
+                (* A dangling ToolUse never received its ToolResult, then a new
+                   ToolUse opens; the prior cycle can never close. [partition] is
+                   a total read-side function over histories produced by an
+                   external conversation owner (OAS) that masc cannot enforce at
+                   write time. Erroring here rejects the ENTIRE compaction and
+                   lets the keeper overflow. Preserve the unclosable region
+                   verbatim in [protected_suffix] (no drop, no repair), exactly
+                   as an open cycle at end-of-list is already protected by the
+                   [[]] case above; only the well-formed, fully-paired prefix in
+                   [units_rev] stays summarizable. Write-time prevention of the
+                   dangling ToolUse is RFC-0240 (tool-pair write-time
+                   enforcement), a separate boundary and follow-up. *)
+                Ok
+                  { closed_prefix = List.rev units_rev
+                  ; protected_suffix =
+                      List.rev_append cycle.messages_rev (message :: rest)
+                  }
             | None, _, _ -> (
                 match add_tool_ids ~message_index:index Id_set.empty tool_ids with
                 | Error _ as error -> error

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -45,6 +45,9 @@ type structural_error =
       { message_index : int
       ; tool_use_id : string
       }
+  (* Retained for [show]/telemetry compatibility. No longer produced by
+     {!partition}: a dangling ToolUse followed by a new ToolUse degrades into
+     [protected_suffix] rather than aborting the compaction. *)
   | Overlapping_tool_cycle of
       { message_index : int
       ; tool_use_id : string

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -25,6 +25,37 @@ let require_ok = function
   | Ok value -> value
   | Error _ -> Alcotest.fail "expected structural partition"
 
+let flatten_units units =
+  List.concat_map
+    (function
+      | U.Ordinary_message m -> [ m ]
+      | U.Closed_tool_cycle ms -> ms)
+    units
+
+(* Top-level ToolUse ids and ToolResult ids across a message list, so a test can
+   assert the two sets match (every ToolUse paired, no orphan either way). *)
+let top_level_tool_id_sets messages =
+  let uses, results =
+    List.fold_left
+      (fun acc (m : T.message) ->
+         List.fold_left
+           (fun (uses, results) -> function
+              | T.ToolUse { id; _ } -> id :: uses, results
+              | T.ToolResult { tool_use_id; _ } -> uses, tool_use_id :: results
+              | T.Text _
+              | T.Thinking _
+              | T.ReasoningDetails _
+              | T.RedactedThinking _
+              | T.Image _
+              | T.Document _
+              | T.Audio _ -> uses, results)
+           acc
+           m.content)
+      ([], [])
+      messages
+  in
+  List.sort compare uses, List.sort compare results
+
 let test_signed_parallel_cycle_is_atomic () =
   let assistant =
     message T.Assistant
@@ -271,6 +302,51 @@ let test_invalid_identity_prevents_plan_callback () =
   Alcotest.(check int) "plan callback count" 0 !plan_calls
 ;;
 
+let test_overlapping_dangling_cycle_degrades_to_suffix () =
+  (* Reproduces the live analyst/idealist compaction block: a well-formed cycle,
+     then a dangling ToolUse whose ToolResult never arrives, a next-turn
+     world-state injection, then a SECOND dangling ToolUse (provider
+     [call_function_<base>_<index>] ids). Historically the second ToolUse raised
+     [Overlapping_tool_cycle], rejecting the ENTIRE compaction. [partition] now
+     degrades: the paired prefix stays summarizable, the unclosable region is
+     protected verbatim. Reverting to [Error Overlapping_tool_cycle] fails this
+     test (require_ok raises). *)
+  let closed_use = message T.Assistant [ use "call_paired" ] in
+  let closed_result = message T.User [ result "call_paired" ] in
+  let dangling_first =
+    message T.Assistant [ T.Text "board?"; use "call_function_mzi85j82orkf_0" ]
+  in
+  let world_state = text T.User "## Current World State ..." in
+  let dangling_second =
+    message T.Assistant [ T.Text "retry"; use "call_function_mzi85j82orkf_1" ]
+  in
+  let tail = text T.User "later prose" in
+  let messages =
+    [ closed_use
+    ; closed_result
+    ; dangling_first
+    ; world_state
+    ; dangling_second
+    ; tail
+    ]
+  in
+  let output = U.partition messages |> require_ok in
+  (* Closed prefix stops before the first dangling ToolUse and holds only the
+     fully-paired cycle. *)
+  check_exact "closed prefix is the paired cycle only"
+    [ U.Closed_tool_cycle [ closed_use; closed_result ] ]
+    output.closed_prefix;
+  (* No orphaned pair in the closed prefix: ToolUse ids and ToolResult ids match. *)
+  let prefix_uses, prefix_results =
+    top_level_tool_id_sets (flatten_units output.closed_prefix)
+  in
+  check_exact "closed prefix tool pairs balanced" prefix_uses prefix_results;
+  (* Everything from the first anomaly onward is preserved byte-exact. *)
+  check_exact "protected suffix from first anomaly, verbatim"
+    [ dangling_first; world_state; dangling_second; tail ]
+    output.protected_suffix
+;;
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -313,5 +389,7 @@ let () =
             test_nonblank_tool_ids_remain_exact
         ; Alcotest.test_case "invalid identity stops plan callback" `Quick
             test_invalid_identity_prevents_plan_callback
+        ; Alcotest.test_case "overlapping dangling cycle degrades to suffix"
+            `Quick test_overlapping_dangling_cycle_degrades_to_suffix
         ] )
     ]


### PR DESCRIPTION
## Symptom (live, P0)

Two keepers (`analyst`, `idealist`) are permanently blocked from compacting. Every
manual compaction fails at both compaction gates:

```
compaction_rejected reason=invalid_structure:Keeper_compaction_unit.Overlapping_tool_cycle
  {message_index=1221; tool_use_id="call_function_mzi85j82orkf_1"}
compaction_failed(no_compaction:invalid_structural_source)
```

`analyst` retried at 02:41Z and 03:04Z — identical block. Because compaction is
rejected, these keepers cannot shrink context and will overflow.

## Root cause

From `analyst`'s OAS snapshot (`~/.masc/traces/.../oas-snapshot-*-g0.json`, 1420
messages): the history contains **8 dangling `ToolUse` blocks** — a `ToolUse`
with no matching `ToolResult` anywhere. They carry a provider id of the form
`call_function_<base>_<index>` (distinct from the 266 normally-paired
`call_<hex>` calls). Concretely `msg[1221]` is an `assistant` with
`text + ToolUse(keeper_board_list, id=call_function_mzi85j82orkf_1)` and
`msg[1222]` is a `user` next-turn **world-state injection** (not a `ToolResult`).
A turn emitted a `ToolUse` that was never executed/resulted, and the next turn
injected world-state — leaving the `ToolUse` dangling.

`Keeper_compaction_unit.partition` tracks an open tool cycle. A single dangling
`ToolUse` at end-of-list is already tolerated (flushed verbatim into
`protected_suffix` — see the existing `test_open_after_assistant_is_protected`).
But when a **second** `ToolUse` appears while a prior cycle is still open, the
`Some open_cycle, tool_use_id :: _` branch returned
`Error (Overlapping_tool_cycle ...)`, aborting the entire compaction.

Both compaction gates consume this contract, so both fail:

- **Gate 1 — `partition`** (`keeper_compact_policy.ml:271`,
  `requested_messages`) -> `Error (Invalid_structure ...)` ->
  `compaction_rejected invalid_structure:...Overlapping_tool_cycle`.
- **Gate 2 — `validate`** (`keeper_context_core.ml:71`,
  `checkpoint_for_persistence`) -> `Error` -> `Tool_history_invalid` ->
  `No_compaction { Invalid_structural_source }` ->
  `compaction_failed(no_compaction:invalid_structural_source)`
  (`keeper_post_turn.ml:631`). The compacted checkpoint's `protected_suffix`
  still contains the dangling `ToolUse`, so `validate` must also tolerate it or
  compaction fails at the persist step. `validate` = `partition` mapped to unit
  (shared contract by design, per the `.mli`), so the single fix degrades both.

## Fix

`partition` is a **total read-side function** over histories produced by an
external conversation owner (OAS) that masc cannot enforce at write time. On the
overlapping case it now stops the `closed_prefix` **before** the first dangling
`ToolUse` and moves the whole unclosable region (the open cycle's messages, the
current message, and the remaining tail) into `protected_suffix` **verbatim** —
exactly as an open cycle at end-of-list is already protected. Only well-formed,
fully-paired cycles are summarizable; the anomaly is preserved, not summarized.

Single-branch change in `lib/keeper/keeper_compaction_unit.ml`:

```
| Some cycle, _ :: _, _ ->
    Ok { closed_prefix = List.rev units_rev
       ; protected_suffix = List.rev_append cycle.messages_rev (message :: rest) }
```

(was `Error (Overlapping_tool_cycle ...)`). No other error path changes:
`Orphan_tool_result`, `Duplicate_tool_use_id`, `Duplicate_tool_result`,
`Unknown_tool_result`, `Non_assistant_tool_use`, `Tool_request_contains_result`,
`Non_result_tool_role`, `Empty_*`, and `Message_tool_call_id_mismatch` all still
error exactly as before. The `Overlapping_tool_cycle` variant is retained in the
taxonomy for `show`/telemetry compatibility but is no longer produced by
`partition`.

## Governance / spec verification

Compaction is a governed area — verified before implementing:

- **Layer A is permitted and required.** Protecting an open/dangling cycle in
  `protected_suffix` is the module's **existing sanctioned design** for the
  single-dangling case (`test_open_after_assistant_is_protected`); `validate`
  already returns `Ok` for one dangling `ToolUse`. The overlapping case is the
  multi-dangling extension of the same behavior, removing an arbitrary
  inconsistency (accept 1, reject 2). Both gates share the contract by design,
  and both must degrade for compaction to complete end-to-end.
- **Not lossy.** Checkpoint persistence is byte-exact (no drop, no repair, no
  mutation, no reorder). Protecting the anomaly is faithful storage — this is
  NOT the repair-then-save (`Repair / Sanitize`) pattern that RFC-0240 targets.
- **RFC-0240 (tool-pair write-time enforcement, Draft)** is the separate root
  boundary that should *prevent* the dangling `ToolUse` at write time so future
  histories never carry it. That is upstream prevention (Layer B) and does not
  unblock the already-corrupted `analyst`/`idealist` histories. This PR is the
  read/compaction-side total-function fix; RFC-0240 remains the follow-up.
- specs `docs/spec/02-types-and-invariants.md` and `12-memory-systems.md` do not
  require rejecting a reachable history at compaction time.

## Why this is a correctness fix, not a workaround

Total function over all reachable histories; no data loss; no repair, drop,
mutation, or reorder; no string/substring classifier; no counter-as-fix; no
cap/cooldown/dedup. The anomaly is preserved verbatim (`protected_suffix`), the
well-formed prefix stays summarizable. Erroring-entirely was the brittleness.

## Test + revert-red

Added `test_overlapping_dangling_cycle_degrades_to_suffix` in
`test/test_keeper_compaction_unit.ml`: a paired cycle, then a dangling `ToolUse`,
a world-state injection, then a **second** dangling `ToolUse` (reproducing
`Overlapping_tool_cycle`). Asserts `partition` returns `Ok` with the paired
cycle in `closed_prefix` (ToolUse/ToolResult id sets balanced — no orphan) and
the anomaly-onward region verbatim in `protected_suffix`. Reverting to
`Error (Overlapping_tool_cycle ...)` makes `require_ok` raise -> test fails
(revert-red). All existing `partition` tests remain green (well-formed histories
partition identically).

## Build

`scripts/dune-local.sh build lib/keeper test/test_keeper_compaction_unit.exe`
built clean (exit 0). `test_keeper_compaction_unit.exe`: **22/22 pass**
(21 pre-existing green — well-formed histories partition identically — plus the
new case). Revert-red verified: reverting the branch to
`Error (Overlapping_tool_cycle ...)` fails **only** test 21
(`ASSERT expected structural partition`), all others green.

## pr-rfc-check

`bash ~/me/scripts/pr-rfc-check.sh --pr-body <body>` → PASS (exit 0).
`--workaround-gate-only` → PASS (exit 0). No RFC gate and no workaround
signature triggered.

RFC-WAIVED: read/compaction-side total-function correctness fix. Governing RFC
for the upstream write-time prevention is RFC-0240 (Draft), cited above as the
separate follow-up boundary; no code path in the RFC-gated subsystems
(credential/identity/operator/sandbox/hooks/workflow) is touched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
