### PR TITLE
fix(keeper): continue runtime lane walk past per-candidate context overflow

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -993,9 +993,14 @@ candidates = [
 # has no keeper assignments").
 # Do not assign general keeper lanes to Pro here. Pro is reserved for explicit
 # judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
+#
+# Assignment targets must be runtime ids (<provider>.<model>); a lane id here
+# is rejected at load. A keeper reaches a [runtime.lanes] failover group only
+# when the lane id shadows a runtime id (resolve_assignment prefers the lane
+# on collision).
 [runtime.assignments]
-# example: route a test keeper through the failover lane
-# canary = "default"
+# example: pin a test keeper to an explicit runtime
+# canary = "deepseek.deepseek-v4-pro"
 
 # ── Discord ──────────────────────────────────────────────────────────
 # Trigger policy controls which inbound Discord events the bot responds to.

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -114,6 +114,16 @@ let lane_should_retry
   else if Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next error
   then
     allow_accept_no_progress_retry
+  else if Keeper_turn_driver_try_runtime.context_overflow_should_try_next error
+  then
+    (* A typed ContextOverflow is a per-candidate capacity bound, not a request
+       defect: a later lane candidate with a larger context window can still
+       serve the same turn. [sdk_error_to_http_error] folds it into a generic
+       HTTP 400 which [Runtime_attempt_fsm.should_try_next] treats as terminal,
+       so the typed error must be read before that mapping. Overflow on the
+       last candidate still returns the typed error, keeping the reactive
+       compaction trigger ([context_overflow_event_of_error]) intact. *)
+    true
   else
     match Keeper_turn_driver_try_runtime.sdk_error_to_http_error error with
     | Some http_err -> Runtime_attempt_fsm.should_try_next http_err

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -20,3 +20,26 @@ let accept_no_progress_should_try_next error =
       internal_error
   | None -> false
 ;;
+
+(* Lives here rather than reusing [Keeper_error_classify.is_context_overflow]:
+   that module depends on [Keeper_turn_driver], so the walk predicate cannot
+   reach it without a module cycle. Api variants are enumerated so a new
+   variant forces a compile-time walk decision instead of a silent [false]. *)
+let context_overflow_should_try_next = function
+  | Agent_sdk.Error.Api (Agent_sdk.Retry.ContextOverflow _) -> true
+  | Agent_sdk.Error.Api
+      ( Agent_sdk.Retry.RateLimited _ | Agent_sdk.Retry.Overloaded _
+      | Agent_sdk.Retry.ServerError _ | Agent_sdk.Retry.AuthError _
+      | Agent_sdk.Retry.AuthorizationError _
+      | Agent_sdk.Retry.PaymentRequired _ | Agent_sdk.Retry.InvalidRequest _
+      | Agent_sdk.Retry.NotFound _ | Agent_sdk.Retry.NetworkError _
+      | Agent_sdk.Retry.Timeout _ )
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ -> false
+;;

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -393,6 +393,62 @@ let test_resolve_assignment_missing () =
     | `Single_runtime _ | `Lane _ ->
       Alcotest.fail "expected missing assignment")
 
+let runtime_toml_assignment_to_lane =
+  {|
+[runtime]
+default = "primary.test_model"
+
+[runtime.lanes.resilient]
+strategy = "ordered"
+candidates = [ "primary.test_model", "fallback.test_model" ]
+
+[runtime.assignments]
+canary = "resilient"
+
+[providers.primary]
+display-name = "Primary Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[providers.fallback]
+display-name = "Fallback Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:2"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[primary.test_model]
+is-default = true
+max-concurrent = 1
+
+[fallback.test_model]
+max-concurrent = 1
+|}
+
+(* Pins the current assignment contract: [runtime.assignments] targets must be
+   runtime ids, so a keeper can only reach a lane when the lane id shadows a
+   runtime id ([resolve_assignment] prefers lanes on collision). Direct lane
+   assignment also has no pre-dispatch context budget resolution
+   ([resolve_max_context_resolution_for_runtime_id] resolves runtime ids only),
+   so accepting it at load would just move this failure to every turn. *)
+let test_assignment_to_lane_id_rejected_at_load () =
+  let path = Filename.temp_file "runtime_failover_lane_assign_" ".toml" in
+  write_file path runtime_toml_assignment_to_lane;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> Alcotest.fail "expected load to fail on lane-targeted assignment"
+       | Error msg ->
+         Alcotest.(check bool)
+           "error names the assignment"
+           true
+           (contains ~needle:"[runtime.assignments].canary" msg))
+
 let test_unknown_lane_candidate_rejected_at_load () =
   let path = Filename.temp_file "runtime_failover_bad_" ".toml" in
   write_file path runtime_toml_unknown_lane_candidate;
@@ -878,6 +934,73 @@ let test_attempt_loop_preserves_last_sdk_error () =
        | _ -> false)
      |> List.map decision_runtime_id)
 
+let context_overflow_error message =
+  Agent_sdk.Error.Api
+    (Agent_sdk.Retry.ContextOverflow { message; limit = Some 32768 })
+
+(* A typed ContextOverflow is a per-candidate capacity bound: a later lane
+   candidate with a larger context window can still serve the same turn, so
+   the walk must continue instead of treating the 400 mapping as terminal. *)
+let test_attempt_loop_overflow_tries_next_candidate () =
+  let attempts = ref [] in
+  let events = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "small.test_model" ->
+          Error (context_overflow_error "prompt exceeds context window"), None
+        | "large.test_model" -> Ok runtime_id, None
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "small.test_model"; "large.test_model" ]
+  in
+  (match result with
+   | Ok runtime_id ->
+     Alcotest.(check string)
+       "larger-context candidate serves the turn"
+       "large.test_model"
+       runtime_id
+   | Error e ->
+     Alcotest.failf
+       "expected larger-context fallback success, got %s"
+       (Agent_sdk.Error.to_string e));
+  Alcotest.(check (list string))
+    "overflow continues the lane walk"
+    [ "small.test_model"; "large.test_model" ]
+    !attempts
+
+(* When every candidate overflows, the last typed ContextOverflow must be
+   preserved so the reactive compaction path
+   ([Keeper_turn_runtime_budget.context_overflow_event_of_error]) still fires. *)
+let test_attempt_loop_overflow_on_last_candidate_is_terminal () =
+  let attempts = ref [] in
+  let events = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        Error (context_overflow_error (runtime_id ^ " overflow")), None)
+      [ "small.test_model"; "smaller.test_model" ]
+  in
+  (match result with
+   | Ok _ -> Alcotest.fail "expected terminal overflow"
+   | Error err ->
+     Alcotest.(check bool)
+       "typed overflow preserved for reactive compaction"
+       true
+       (Masc.Keeper_error_classify.is_context_overflow err));
+  Alcotest.(check (list string))
+    "every candidate attempted before terminal overflow"
+    [ "small.test_model"; "smaller.test_model" ]
+    !attempts
+
 let () =
   Alcotest.run
     "keeper_turn_driver_failover"
@@ -908,6 +1031,10 @@ let () =
             "unknown lane candidate rejected at load"
             `Quick
             test_unknown_lane_candidate_rejected_at_load;
+          Alcotest.test_case
+            "assignment to lane id rejected at load"
+            `Quick
+            test_assignment_to_lane_id_rejected_at_load;
           Alcotest.test_case
             "lane media degrade uses first candidate runtime id"
             `Quick
@@ -952,5 +1079,13 @@ let () =
             "attempt loop preserves last SDK error"
             `Quick
             test_attempt_loop_preserves_last_sdk_error;
+          Alcotest.test_case
+            "context overflow tries next lane candidate"
+            `Quick
+            test_attempt_loop_overflow_tries_next_candidate;
+          Alcotest.test_case
+            "context overflow on last candidate stays terminal"
+            `Quick
+            test_attempt_loop_overflow_on_last_candidate_is_terminal;
         ] );
     ]


### PR DESCRIPTION
## 문제

runtime lane(ordered failover)의 walk 결정이 typed ContextOverflow를 보기 전에 sdk_error_to_http_error가 generic HTTP 400으로 접어버려, Runtime_attempt_fsm.should_try_next(408/409/429/5xx만 재시도)가 terminal로 판정했습니다. 혼합 컨텍스트 lane에서:

```
lane = [ big-262k, small-128k, big2-200k ]
big-262k  -> 429 (rate limited)      => try next (정상)
small-128k -> 400 ContextOverflow    => walk 즉시 종료
big2-200k -> 시도조차 안 됨
```

즉 lane에 살아있는 대형 컨텍스트 후보가 남아 있는데도 턴이 실패합니다. 8 keeper가 각기 다른 컨텍스트 윈도우 모델을 쓰는 fleet에서 lane 부족(고갈)이 실제보다 조기에 발생하는 구조적 결함입니다.

## 수리

- lane_should_retry가 HTTP 매핑 이전에 typed ContextOverflow를 읽고 walk를 계속합니다 (keeper_turn_driver.ml).
- 분류기는 Keeper_turn_driver_try_runtime.context_overflow_should_try_next로 배치 (Keeper_error_classify는 Keeper_turn_driver에 의존해 module cycle). Api variant 전수 나열로 새 variant 추가 시 컴파일 타임에 walk 결정을 강제합니다.
- 마지막 후보의 overflow는 기존과 동일하게 typed error로 반환되어 reactive compaction 트리거(context_overflow_event_of_error)가 그대로 발화합니다.
- checkpoint-stage 관찰 후의 same-run retry 유예(allow_retry 게이트)는 기존 그대로 상위에서 적용됩니다.

## 함께 포함

- pin 테스트: [runtime.assignments]가 lane id를 지정하면 로드에서 거부됨을 고정 (test_assignment_to_lane_id_rejected_at_load). 시드 config의 주석 예시(canary = "default")가 정확히 이 거부되는 형태를 제안하고 있어 주석을 실제 계약(runtime id만, lane은 shadow 충돌 시에만)으로 정정.
- lane-aware 예산/lane 배정 설계는 #25393, judge/HITL/librarian 바인딩 lane 수용은 #25394로 추적.

## 검증

- red->green counterfactual: test_attempt_loop_overflow_tries_next_candidate가 수리 전 FAIL(첫 후보에서 종료), 수리 후 OK.
- terminal 보존: test_attempt_loop_overflow_on_last_candidate_is_terminal (typed overflow가 마지막 에러로 보존).
- test_keeper_turn_driver_failover 20/20, test_runtime_config_validity 38/38, test_keeper_unified_context_overflow 2/2, test_pbt_context_overflow 2/2 green (worktree 격리 빌드, dune --root .).

## 미검증

- 라이브 fleet에서 혼합 컨텍스트 lane 구성은 현재 없음(시드 lane default는 deepseek 2종). 이 수리는 lane 구성이 혼합 컨텍스트로 갈 때의 선행 안전판.

RFC-WAIVED: 단일 walk-predicate 버그 수리 + 동작 pin 테스트. 아키텍처 결정(예산 계약, lane 배정 수용)은 #25393/#25394로 분리 추적하며 본 PR은 기존 lane walk 계약 내 typed-error 분류 수정만 포함.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
