### PR TITLE
fix(C): 키퍼 런타임 변경이 우측 사이드바에 즉시 반영 (drift 배지 최대 30s stale 제거)

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -34,6 +34,7 @@ import {
   runtimeCatalogSnapshotFacts,
 } from '../lib/runtime-provider-summary'
 import { refreshKeeperRuntimeStatus } from '../store'
+import { bumpKeeperRuntimeTraceRefresh } from './keeper-runtime-trace-refresh'
 import { navigate } from '../router'
 import { SetupGuideCard } from './setup-guide-card'
 import { SectionHeader } from './common/section-header'
@@ -49,6 +50,11 @@ import {
 } from './keeper-config-state'
 
 async function refreshKeeperSurfacesAfterConfigSave(): Promise<void> {
+  // Re-fetch the right-rail runtime-trace evidence (drift badge) immediately;
+  // refreshKeeperRuntimeStatus below only updates the live-runtime slice, which
+  // does not change on save. Bump unconditionally so a failed status refresh
+  // still updates the assignment badge.
+  bumpKeeperRuntimeTraceRefresh()
   try {
     await refreshKeeperRuntimeStatus({ force: true })
   } catch (err) {

--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'preact/hooks'
+import { keeperRuntimeTraceRefreshNonce } from './keeper-runtime-trace-refresh'
 import { fetchKeeperComposite, fetchKeeperRuntimeTrace } from '../api/keeper'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
 import { DEFAULT_PANEL_REFRESH_MS, setupVisibleAutoRefresh } from '../lib/auto-refresh'
@@ -66,6 +67,9 @@ export function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot 
 
 export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailEvidenceState<KeeperRuntimeTraceResponse> {
   const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperRuntimeTraceResponse>>(loadingEvidence)
+  // Read the refresh nonce during render so the component subscribes to it;
+  // a config save bumps it, re-running the effect below to re-fetch the trace.
+  const refreshNonce = keeperRuntimeTraceRefreshNonce.value
   useEffect(() => {
     const controller = new AbortController()
     let cancelled = false
@@ -93,7 +97,7 @@ export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailE
       controller.abort()
       cleanup()
     }
-  }, [keeperName])
+  }, [keeperName, refreshNonce])
   return evidence
 }
 

--- a/dashboard/src/components/keeper-runtime-trace-refresh.test.ts
+++ b/dashboard/src/components/keeper-runtime-trace-refresh.test.ts
@@ -1,0 +1,42 @@
+import { h } from 'preact'
+import { cleanup, render, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+const { fetchKeeperRuntimeTrace, fetchKeeperComposite } = vi.hoisted(() => ({
+  fetchKeeperRuntimeTrace: vi.fn(),
+  fetchKeeperComposite: vi.fn(),
+}))
+vi.mock('../api/keeper', () => ({ fetchKeeperRuntimeTrace, fetchKeeperComposite }))
+// Silence the visible-auto-refresh timer so only explicit (initial + nonce) fetches occur.
+vi.mock('../lib/auto-refresh', () => ({
+  DEFAULT_PANEL_REFRESH_MS: 30_000,
+  setupVisibleAutoRefresh: () => () => {},
+}))
+
+import { useKeeperRuntimeTraceEvidence } from './keeper-detail-hooks'
+import { bumpKeeperRuntimeTraceRefresh } from './keeper-runtime-trace-refresh'
+
+function Probe({ name }: { name: string }): null {
+  useKeeperRuntimeTraceEvidence(name)
+  return null
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('useKeeperRuntimeTraceEvidence refresh nonce', () => {
+  it('re-fetches the runtime trace when the refresh nonce is bumped', async () => {
+    fetchKeeperRuntimeTrace.mockResolvedValue({ keeper_name: 'runtime-sync-keeper', lines: [] } as never)
+
+    render(h(Probe, { name: 'runtime-sync-keeper' }))
+    await waitFor(() => expect(fetchKeeperRuntimeTrace).toHaveBeenCalledTimes(1))
+
+    // A config save bumps the nonce; the effect (deps include the nonce) re-runs.
+    // Counterfactual: with deps [keeperName] only, this stays at 1 and the test fails.
+    bumpKeeperRuntimeTraceRefresh()
+    await waitFor(() => expect(fetchKeeperRuntimeTrace).toHaveBeenCalledTimes(2))
+  })
+})

--- a/dashboard/src/components/keeper-runtime-trace-refresh.ts
+++ b/dashboard/src/components/keeper-runtime-trace-refresh.ts
@@ -1,0 +1,19 @@
+import { signal } from '@preact/signals'
+
+/*
+ * Bumped whenever a keeper's runtime assignment is written (the config PATCH in
+ * keeper-config-panel). Hooks that read the keeper runtime-trace evidence — the
+ * right-rail "지정됨 X · 재시작 시 적용" drift badge — include this nonce in their
+ * effect deps so they re-fetch immediately after a save instead of waiting up to
+ * DEFAULT_PANEL_REFRESH_MS (30s) for the next visible-auto-refresh tick.
+ *
+ * refreshKeeperRuntimeStatus (store) only refreshes the LIVE runtime slice,
+ * which by design does not change on save (the assignment is adopted at the next
+ * turn-up); the drift badge is backed by the separate runtime-trace source,
+ * which nothing on the save path was invalidating.
+ */
+export const keeperRuntimeTraceRefreshNonce = signal(0)
+
+export function bumpKeeperRuntimeTraceRefresh(): void {
+  keeperRuntimeTraceRefreshNonce.value += 1
+}


### PR DESCRIPTION
## 무엇을 / 왜

키퍼 상세 패널에서 **런타임 배정을 변경해도 우측 사이드바의 "지정됨 X · 재시작 시 적용" drift 배지가 최대 30초간 stale**했습니다. `saveRuntimeConfig → refreshKeeperSurfacesAfterConfigSave`는 **live-runtime store 슬라이스만** 갱신하는데, 이건 저장 시 원래 안 바뀝니다(배정은 다음 turn-up에 채택). 배지는 별개의 **runtime-trace 소스**가 백킹하고, 그 hook(`useKeeperRuntimeTraceEvidence`)은 effect deps가 `[keeperName]`뿐 + 30s poll이라 저장 경로에서 재조회되지 않았습니다.

사용자 지적: *"런타임 정보를 키퍼 상세 설정에서 변경했는데 왜 우측 사이드바에선 업데이트가 안되는거지?"*

## 수정

module-level `@preact/signals` nonce(`keeper-runtime-trace-refresh.ts`) 추가. `useKeeperRuntimeTraceEvidence`가 render 중 이 nonce를 읽어 effect deps에 포함하고, `refreshKeeperSurfacesAfterConfigSave`가 저장 후 bump → **runtime-trace가 즉시 재조회**(다음 poll tick을 기다리지 않음).

## 검증
- `tsc --noEmit` clean, `eslint` clean
- `vitest` **1/1**: hook을 렌더하고 `fetchKeeperRuntimeTrace`를 mock해 **bump가 두 번째 fetch를 유발**함을 assert (counterfactual — deps `[keeperName]`만이면 1에 머물러 red).

## 대안 (미채택)
- config store의 `execution.selected_runtime_id`로 drift를 optimistic 계산해 서버 왕복 없이 즉시 표시 — 더 robust하나 사이드바 drift 계산부를 건드려 범위가 큼. nonce 재조회가 최소·정확.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
