### PR TITLE
fix(fusion): enforce min_answered quorum before judge

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -300,15 +300,17 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                         ] )))
           in
           let judge_full, judge_nodes =
-            match Fusion_types.answered_of panel with
-            | [] ->
-              let reason = Fusion_types.No_panel_answers { total = List.length panel } in
+            match
+              Fusion_types.judge_skip_reason ~panel
+                ~min_answered:preset.Fusion_policy.min_answered
+            with
+            | Some reason ->
               (* typed 그대로 propagate — 문자열로 렌더해 [Internal_error]에 압축하면
-                 패널 전멸이 "judge failed"/failure_code=internal_error로 오귀속된다
-                 (2026-07-01 사고: 8 run 전부 이 경로였는데 keeper 표면은 judge
-                 메커니즘 고장으로 보고했다). 렌더는 sink/텍스트 경계에서 한다. *)
+                 패널 전멸/정족수 미달이 "judge failed"/failure_code=internal_error로
+                 오귀속된다 (2026-07-01 사고: 8 run 전부 이 경로였는데 keeper 표면은
+                 judge 메커니즘 고장으로 보고했다). 렌더는 sink/텍스트 경계에서 한다. *)
               (Error (Fusion_types.Panels_unavailable reason, Fusion_types.zero_usage), [])
-            | _ :: _ ->
+            | None ->
             match topology with
             | Fusion_types.Simple ->
               (match run_single_judge () with

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -21,6 +21,11 @@ type outcome =
     + [Fusion_policy.decide]로 정책 판정 → [Deny]면 [Denied] 반환(부작용 없음).
     + [Allow]면 preset의 패널 모델로 [Fusion_panel.run], judge 모델로 [Fusion_judge.run].
       패널/심판 system prompt는 preset(=config)에서 온다 — 코드 default 없음.
+    + judge 실행 전에 응답 패널 수가 preset.min_answered(런타임 quorum) 미만이면
+      심판을 실행하지 않고 judge = [Error (Panels_unavailable _)]로 완료한다
+      (전멸이면 [No_panel_answers], 부분 미달이면 [Quorum_shortfall] — 미달 응답을
+      judge에 넘기는 silent degrade는 하지 않는다). 기본값 1은 "응답 0일 때만
+      skip"으로 종전 동작과 동일하다.
     + [topology]에 따라 reduce 위상을 고른다: [Simple]은 panel→judge→sink(현행),
       [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink, [Conditional]은 1차 판정이
       [Insufficient]일 때만 refine하고 그 외엔 [Simple]처럼 1차 종합 그대로

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -111,11 +111,35 @@ let answered_of outcomes =
 
 type skip_reason =
   | No_panel_answers of { total : int }
+  | Quorum_shortfall of
+      { answered : int
+      ; required : int
+      }
 [@@deriving yojson, show, eq]
 
 let render_skip_reason = function
   | No_panel_answers { total } ->
     Printf.sprintf "fusion aborted: none of %d panels returned an answer" total
+  | Quorum_shortfall { answered; required } ->
+    Printf.sprintf "fusion aborted: panel quorum not met (%d of %d required answers)"
+      answered required
+
+(* judge 실행 전 panel 입력 계약 검사 (런타임 quorum = preset.min_answered).
+   응답 0이면 [No_panel_answers](objective input absence), 0 < 응답 < [min_answered]면
+   [Quorum_shortfall](N-of-M 정책 미달), 응답 >= [min_answered]면 [None] = judge 진행.
+   미달 응답을 judge에 넘기는 silent degrade는 금지다 — quorum은 RFC-0252 §5.1 (a)의
+   meta-degrade(실행 후 첫 성공으로 폭빽)와 다른 축(실행 전 입력 계약)이다.
+   [min_answered] 기본값(1)에서는 "응답 0일 때만 skip"으로 강제 전 동작과 정확히 동일.
+   [Validated_preset]가 1..패널 총합 범위를 증명하므로 여기선 범위 재검증을 하지 않는다.
+   순수 — 테스트 가능. *)
+let judge_skip_reason ~panel ~min_answered : skip_reason option =
+  match answered_of panel with
+  | [] -> Some (No_panel_answers { total = List.length panel })
+  | _ :: _ as answered ->
+    let answered_count = List.length answered in
+    if answered_count < min_answered
+    then Some (Quorum_shortfall { answered = answered_count; required = min_answered })
+    else None
 
 let no_panel_answers_error =
   "all panels failed: no answered panel to synthesize"

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -113,10 +113,24 @@ val answered_of : panel_outcome list -> panel_answer list
 (** 심판을 실행하지 않는 typed 사유. *)
 type skip_reason =
   | No_panel_answers of { total : int }
+  | Quorum_shortfall of
+      { answered : int  (** 실제로 응답한 패널 수 *)
+      ; required : int  (** preset.min_answered 요구치 *)
+      }
+      (** 응답은 있으나 런타임 quorum(min_answered) 미달 — N-of-M 정책.
+          전멸([No_panel_answers])과 구분되는 사유다. *)
 [@@deriving yojson, show, eq]
 
 val render_skip_reason : skip_reason -> string
 (** Operator/log boundary renderer for {!skip_reason}. *)
+
+(** judge 실행 전 panel 입력 계약 검사 (런타임 quorum = preset.min_answered).
+    응답 0이면 [Some (No_panel_answers _)], 0 < 응답 < [min_answered]면
+    [Some (Quorum_shortfall _)], 응답 >= [min_answered]면 [None] = judge 진행.
+    [min_answered] 기본값(1)에서는 "응답 0일 때만 skip"으로 강제 전 동작과 동일.
+    순수 — 테스트 가능. *)
+val judge_skip_reason :
+  panel:panel_outcome list -> min_answered:int -> skip_reason option
 
 val no_panel_answers_error : string
 (** Legacy canonical string for callers that still need the pre-quorum

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1325,6 +1325,67 @@ let test_panels_unavailable_failure () =
     (judge_failure_text failure);
   Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure)
 
+(* --- min_answered 런타임 quorum 강제: judge 실행 전 panel 입력 계약 검사 ---
+   orchestrator는 judge dispatch 전에 [judge_skip_reason]을 호출해 미달 시 typed
+   [Panels_unavailable]로 skip한다 (미달 응답을 judge에 넘기는 silent degrade 금지 —
+   quorum은 입력 계약이다). 판정은 순수 함수로 분리해 여기서 exhaustive하게 핀다. *)
+
+let quorum_answered model : panel_outcome =
+  Answered { model; answer = "a"; usage = zero_usage }
+
+let quorum_failed model : panel_outcome =
+  Failed { failed_model = model; reason = Provider_error "boom" }
+
+let skip_reason_t = Alcotest.testable pp_skip_reason equal_skip_reason
+
+(* (a) min_answered=2인데 응답 1개 → typed skip (judge 미실행). *)
+let test_quorum_shortfall () =
+  let panel = [ quorum_answered "a"; quorum_failed "b"; quorum_failed "c" ] in
+  Alcotest.(check (option skip_reason_t)) "answered 1 < min_answered 2"
+    (Some (Quorum_shortfall { answered = 1; required = 2 }))
+    (judge_skip_reason ~panel ~min_answered:2)
+
+(* (b) min_answered=2, 응답 2개 → judge 진행 (skip 사유 없음). *)
+let test_quorum_met () =
+  let panel = [ quorum_answered "a"; quorum_answered "b"; quorum_failed "c" ] in
+  Alcotest.(check (option skip_reason_t)) "answered 2 >= min_answered 2" None
+    (judge_skip_reason ~panel ~min_answered:2)
+
+(* (c) 기본값(default_min_answered=1)은 강제 전과 정확히 같은 동작:
+   응답 1개면 judge 실행, 0개면 No_panel_answers. *)
+let test_quorum_default_preserves_current_behavior () =
+  Alcotest.(check (option skip_reason_t)) "1 answered, default -> judge runs" None
+    (judge_skip_reason
+       ~panel:[ quorum_answered "a"; quorum_failed "b" ]
+       ~min_answered:Fusion_policy.default_min_answered);
+  Alcotest.(check (option skip_reason_t)) "0 answered, default -> No_panel_answers"
+    (Some (No_panel_answers { total = 2 }))
+    (judge_skip_reason
+       ~panel:[ quorum_failed "a"; quorum_failed "b" ]
+       ~min_answered:Fusion_policy.default_min_answered)
+
+(* (d) min_answered=패널 수(3)인데 전원 실패 → 응답 0 = 입력 부재 typed skip.
+   전멸은 정족수 정책이 아니라 objective input absence라 No_panel_answers를 유지한다
+   (위 test_panels_unavailable_failure의 구분과 동일). *)
+let test_quorum_full_panel_all_failed () =
+  let panel = [ quorum_failed "a"; quorum_failed "b"; quorum_failed "c" ] in
+  Alcotest.(check (option skip_reason_t)) "min_answered 3, all failed -> typed skip"
+    (Some (No_panel_answers { total = 3 }))
+    (judge_skip_reason ~panel ~min_answered:3)
+
+(* quorum 미달도 패널-측 사유로 분류된다 — judge 메커니즘 실패로 오귀속하지 않게
+   failure_code는 panels_unavailable을 유지하고 텍스트에 도달/요구 수를 노출한다. *)
+let test_quorum_shortfall_failure_surface () =
+  let failure : judge_failure =
+    Panels_unavailable (Quorum_shortfall { answered = 1; required = 2 })
+  in
+  Alcotest.(check string) "failure_code tag" "panels_unavailable"
+    (judge_failure_tag failure);
+  Alcotest.(check string) "failure text = rendered skip reason"
+    "fusion aborted: panel quorum not met (1 of 2 required answers)"
+    (judge_failure_text failure);
+  Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure)
+
 (* min_answered must be in the policy range 1..total panels (inclusive).
    base_group has 3 models, so 0 and 4 are rejected; full-panel quorum (3) is allowed. *)
 let test_validated_bad_min_answered () =
@@ -1494,5 +1555,13 @@ let () =
         ; Alcotest.test_case "min_answered_constants" `Quick test_min_answered_constants
         ; Alcotest.test_case "panels_unavailable_failure" `Quick
             test_panels_unavailable_failure
+        ; Alcotest.test_case "quorum_shortfall" `Quick test_quorum_shortfall
+        ; Alcotest.test_case "quorum_met" `Quick test_quorum_met
+        ; Alcotest.test_case "quorum_default_preserves_current_behavior" `Quick
+            test_quorum_default_preserves_current_behavior
+        ; Alcotest.test_case "quorum_full_panel_all_failed" `Quick
+            test_quorum_full_panel_all_failed
+        ; Alcotest.test_case "quorum_shortfall_failure_surface" `Quick
+            test_quorum_shortfall_failure_surface
         ] )
     ]


### PR DESCRIPTION
## 문제

`min_answered`(패널 응답 quorum)는 TOML 파싱(`lib/fusion_core/fusion_config.ml:58`)과 범위 검증(`lib/fusion_core/fusion_policy.ml:266` — `Validated_preset`이 1..패널 총합 범위 증명)만 존재하고 **실행 시 읽는 코드가 0건**이었다. `lib/fusion/fusion_orchestrator.ml`의 judge dispatch는 `answered_of panel = []`만 검사해서, preset에 `min_answered = 2`를 설정필도 응답 1개로 judge가 실행됐다 — dead knob / silent failure.

## 수정

judge 실행 전(panel 수집 후, topology dispatch 전)에 quorum을 강제한다.

- `Fusion_types.judge_skip_reason ~panel ~min_answered` (pure, `lib/fusion_core/fusion_types.ml`): judge 실행 전 입력 계약 판정.
  - 응답 0 → `No_panel_answers` (기존, objective input absence — 2026-07-01 사고의 전멸 구분 유지)
  - 0 < 응답 < min_answered → 새 `skip_reason` variant `Quorum_shortfall { answered; required }` (N-of-M 정책 미달)
  - 응답 >= min_answered → `None` = judge 진행
- orchestrator는 결과를 기존 `Panels_unavailable` typed error로 그대로 propagate — 미달 응답을 judge에 넘기는 silent degrade 없음. `failure_code=panels_unavailable` 유지로 judge 메커니즘 실패로 오귀속되지 않는다.
- RFC-0252 §5.1 (a)의 meta-실패 degrade(실행 후 첫 성공 폭빽)와는 다른 축이다 — quorum은 실행 전 입력 계약이라 judge를 아예 실행하지 않는다.

## 기계 판정 기준

`test/fusion_core/test_fusion.ml` `panel_guard` 그룹에 5개 추가, 전체 **78 tests pass** (`_build/default/test/fusion_core/test_fusion.exe`):

- `quorum_shortfall` — min_answered=2, 응답 1 → `Some (Quorum_shortfall {answered=1; required=2})`
- `quorum_met` — min_answered=2, 응답 2 → `None` (judge 진행)
- `quorum_default_preserves_current_behavior` — 기본값(1): 응답 1 → `None`, 응답 0 → `No_panel_answers` (강제 전 동작과 동일)
- `quorum_full_panel_all_failed` — min_answered=3(패널 수), 전원 실패 → typed skip (`No_panel_answers`: 전멸은 정족수가 아니라 입력 부재)
- `quorum_shortfall_failure_surface` — `Panels_unavailable (Quorum_shortfall _)`의 failure_code/text/timeout 분류 핀

TDD red 증거: 구현(`lib/`)을 제외하고 테스트만 적용하면 `test_fusion.exe` 빌드가 `There is no constructor Quorum_shortfall within type skip_reason`으로 실패. 로컬 검증: `scripts/dune-local.sh build test/fusion_core/test_fusion.exe` + 실행, `scripts/dune-local.sh build lib/` (orchestrator 포함 main lib) 통과.

## 영향 범위

- **기본값 byte-identical**: `min_answered` 기본값 1에서는 "응답 0일 때만 skip"으로 강제 전과 정확히 동일. shipped `config/runtime.toml`은 `min_answered`를 설정하지 않으므로(전 preset 기본값) shipped 동작 변화 없음 — council pin 테스트(`shipped_runtime_council_staged_eligible`) 포함 전체 그린.
- `skip_reason` closed sum에 variant 1개 추가: exhaustive match는 `render_skip_reason` 한 곳뿐이며 갱신 완료. `judge_failure` 계열(tag/text)은 `Panels_unavailable` 재사용으로 무 변경.
- 미설정(기본 1) 외에 `min_answered >= 2`를 실제로 설정한 배포만 동작이 바뀐다: 응답 미달 run이 judge를 태우던 것(silent) → `Panels_unavailable` typed 실패(명시).