### PR TITLE
fix(A-masc): rotation retry를 Warn→Info 강등 (self-healing을 실패로 과다로깅)

### DIFF
--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -437,7 +437,14 @@ let run (ctx : ctx)
              let turn_state =
                { turn_state with degraded_retry_info = Some degraded_retry }
              in
-             Log.Keeper.warn
+             (* A rotation retry was scheduled: the runtime failed but the lane
+                stays usable and recovers on the next runtime. This is a
+                recovering, receipted event (Rotation_retry_scheduled above), not
+                a failure that stalled the lane — Info per
+                docs/spec/18-log-severity-taxonomy.md. WARN is reserved for the
+                terminal setup-failed arm above, so WARN tracks failures that did
+                not self-heal instead of narrating every rotation. *)
+             Log.Keeper.info
                "%s: recoverable runtime failure in %s; rotation \
                retry on runtime=%s reason=%s max_context=%d \
                 context_budget=%d primary_budget=%d \


### PR DESCRIPTION
## 무엇을 / 왜 (4-concern 감사 A의 masc 부분)

라이브 로그의 주요 WARN 중 `"recoverable runtime failure in <runtime>; rotation retry on ..."`(~450/일)는 **복구 중인 이벤트를 실패로 과다로깅**합니다: 런타임 호출은 실패했지만 lane은 usable하고 다음 런타임으로 rotation 재시도합니다(`Rotation_retry_scheduled`가 이미 turn receipt에 기록됨). `docs/spec/18-log-severity-taxonomy.md`상 Warn은 lane을 멈춘 명시적 실패용이고, self-healing rotation은 Info입니다.

사용자 지적: *"이 로그들 애초에 이상한 논리에서 만들어진 건 아닌지 의심"* — 이 케이스는 확정입니다.

## 수정

`Degraded_retry_step_prepared` arm만 `Log.Keeper.info`로 강등. 형제 `Rotation_setup_failed` arm(retry setup 자체 실패 → `mark_terminal_error`)은 **Warn 유지** — 이제 Warn은 self-heal 안 된 실패만 추적합니다. **동작 변화 없음**: rotation receipt/metric 불변, 로그 severity만 이동.

## 검증
`dune build` green. log-level 변경은 기능 단위 표면이 없어(RFC-keeper-memory-consolidation §5.2 "단위 격리 불가" 선례) compile로 검증.

## 관련 (별도)
같은 감사의 나머지 A: `reasoning_replay_dropped`(~973/일)와 `pipeline stage failed`(483/일)는 **OAS repo** 발신(`reasoning_history_projection.ml:361`, `pipeline.ml:494`) — 별도 OAS PR + masc pin bump로 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
