### PR TITLE
fix(server): serialize memory-os consolidation tick provider calls

### DIFF
--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -177,10 +177,12 @@ let run_memory_os_consolidation_tick
         keeper_id
         (Printexc.to_string exn)
   in
-  Eio.Fiber.all
-    (List.map
-       (fun keeper_id () -> consolidate_one keeper_id ())
-       keeper_ids)
+  (* Sequential on purpose: every keeper's consolidation call lands on the
+     same runtime, so a concurrent fan-out is an N-keeper burst against one
+     endpoint admission FIFO, starving turn/judge/compaction traffic for the
+     whole burst (#25401). The tick cadence (600s) dwarfs a serial sweep, and
+     [consolidate_one] already contains per-keeper failures. *)
+  List.iter (fun keeper_id -> consolidate_one keeper_id ()) keeper_ids
 ;;
 
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -149,6 +149,57 @@ let test_skips_when_too_few () =
           Alcotest.(check int) "store unchanged when too few facts" 1 after_count))))
 ;;
 
+(* The tick must not fan out one provider call per keeper concurrently: every
+   call lands on the same runtime, so an N-keeper burst floods that endpoint's
+   admission FIFO and starves turn/judge/compaction traffic for the whole
+   burst (#25401). The fake yields inside the provider call so any concurrent
+   scheduling would be observed as in_flight > 1. *)
+let test_tick_serializes_provider_calls () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+        with_temp_keepers (fun () ->
+          let keeper_ids = [ "keeper-1"; "keeper-2"; "keeper-3" ] in
+          List.iter
+            (fun keeper_id ->
+               List.iter
+                 (Io.append_fact ~keeper_id)
+                 [ fact "deploy uses blue-green"
+                 ; fact "deployment is blue-green based"
+                 ; fact "build runs on dune 3.x"
+                 ; fact "tests live under test/"
+                 ; fact "ci runs on github actions"
+                 ])
+            keeper_ids;
+          let in_flight = ref 0 in
+          let max_in_flight = ref 0 in
+          let calls = ref 0 in
+          let observing_complete :
+                Masc.Keeper_memory_os_consolidation_runtime.complete_fn =
+            fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () ->
+              incr in_flight;
+              incr calls;
+              if !in_flight > !max_in_flight then max_in_flight := !in_flight;
+              Eio.Fiber.yield ();
+              decr in_flight;
+              Ok (fake_response {|{"groups":[],"drop_indices":[]}|})
+          in
+          Server_bootstrap_maintenance.run_memory_os_consolidation_tick
+            ~complete:observing_complete
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ();
+          Alcotest.(check int) "every keeper consolidated" 3 !calls;
+          Alcotest.(check int)
+            "provider calls never overlap"
+            1
+            !max_in_flight))))
+;;
+
 let () =
   Alcotest.run
     "server_bootstrap_maintenance_memory_os"
@@ -161,6 +212,10 @@ let () =
             "skips when too few facts"
             `Quick
             test_skips_when_too_few
+        ; Alcotest.test_case
+            "tick serializes provider calls"
+            `Quick
+            test_tick_serializes_provider_calls
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

run_memory_os_consolidation_tick이 keeper당 provider 호출 1건을 Eio.Fiber.all로 동시 fan-out했습니다. 모든 호출이 같은 runtime으로 해석되므로 N-keeper fleet에서 600초마다 단일 endpoint admission FIFO에 N-와이드 burst가 발생, burst 동안 turn/judge/compaction 트래픽을 기아시킵니다 (#25401 실측: 라이브 fleet 전 소비자가 glm 8-permit FIFO 공유).

## 수리

- 순차 스윕으로 교체: 틱당 in-flight consolidation 호출 1건. 600초 주기 대비 순차 스윕 소요는 무시 가능하고, consolidate_one의 per-keeper 실패 격리는 그대로입니다.
- 세마포어+knob 대신 순차를 선택한 이유: 이 경로는 지연 무관 백그라운드 유지보수라 동시성 상한의 튜닝 여지가 없고, 미검증 수치의 env knob 추가는 dead-knob 안티패턴입니다.

## 검증

- red→green counterfactual: fake complete_fn이 in-flight 최대치를 기록(호출 내 yield로 겹침 관측 가능). Fiber.all에서 max>=2로 FAIL, 순차 전환 후 max=1 OK.
- test_server_bootstrap_maintenance_memory_os 3/3 green, 변경 파일 ocamlformat clean.

관련: #25401, 감사 리포트 ~/me/reports/masc-lane-audit-2026-07-20.md

RFC-WAIVED: 단일 함수의 동시성 버그 수리(관측 가능한 동작 계약 불변, 스케줄링만 변경). per-lane 예약/우선순위 admission 설계는 #25401에서 추적.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
