### PR TITLE
feat(dashboard): audit integrity surface — verify resilience hash chains on demand

### DIFF
--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -192,6 +192,36 @@ export function fetchKeeperMemoryHealth(): Promise<KeeperMemoryHealthResponse> {
   return get<KeeperMemoryHealthResponse>('/api/v1/dashboard/keeper-memory-health')
 }
 
+// --- Audit Integrity ---
+// Backend: lib/server/server_dashboard_http_audit_integrity.ml
+// Route:   GET /api/v1/dashboard/audit-integrity
+// Read-only snapshot of the Shared_audit hash-chain verification over the
+// per-keeper resilience audit logs.
+
+export interface AuditIntegrityKeeperEntry {
+  keeper_id: string
+  entries: number
+  ok: boolean
+  broken_at: number | null
+  detail: string | null
+}
+
+export interface AuditIntegrityResponse {
+  generated_at: number
+  resilience_enabled: boolean
+  keepers: AuditIntegrityKeeperEntry[]
+  totals: {
+    keepers: number
+    entries: number
+    ok: number
+    failed: number
+  }
+}
+
+export function fetchAuditIntegrity(): Promise<AuditIntegrityResponse> {
+  return get<AuditIntegrityResponse>('/api/v1/dashboard/audit-integrity')
+}
+
 // --- Verification requests (Mission detail table) ---
 // Backend: lib/dashboard/dashboard_verification.ml
 // Route:   GET /api/v1/verification/requests?task_id=&limit=

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -336,6 +336,8 @@ export type {
   KeeperMemoryHealthAlertTarget,
   KeeperMemoryHealthKeeperEntry,
   KeeperMemoryHealthResponse,
+  AuditIntegrityKeeperEntry,
+  AuditIntegrityResponse,
   VerificationRequestStatus,
   VerificationRequestVerdict,
   VerificationRequest,
@@ -353,6 +355,7 @@ export type {
 export {
   fetchMemorySubsystems,
   fetchKeeperMemoryHealth,
+  fetchAuditIntegrity,
   fetchVerificationRequests,
   resolveVerificationRequest,
   fetchTlaSpecs,

--- a/dashboard/src/components/lab.test.ts
+++ b/dashboard/src/components/lab.test.ts
@@ -26,6 +26,9 @@ async function loadLab() {
   vi.doMock('./memory/keeper-memory-health', () => ({
     KeeperMemoryHealth: () => html`<div data-testid="lab-keeper-memory-health">KeeperMemoryHealth</div>`,
   }))
+  vi.doMock('./memory/audit-integrity', () => ({
+    AuditIntegrity: () => html`<div data-testid="lab-audit-integrity">AuditIntegrity</div>`,
+  }))
   vi.doMock('./common/surface-header', () => ({
     SurfaceHeader: () => html`<header data-testid="surface-header">Lab</header>`,
   }))
@@ -51,6 +54,7 @@ describe('Lab', () => {
     vi.doUnmock('./harness-health')
     vi.doUnmock('./lab-perf')
     vi.doUnmock('./memory/keeper-memory-health')
+    vi.doUnmock('./memory/audit-integrity')
     vi.doUnmock('./memory-subsystems')
     vi.doUnmock('./common/surface-header')
   })
@@ -86,6 +90,14 @@ describe('Lab', () => {
 
     render(html`<${Lab} />`, container)
     expect(container.querySelector('[data-testid="lab-keeper-memory-health"]')).not.toBeNull()
+  })
+
+  it('renders audit integrity section', async () => {
+    route.value.params = { section: 'audit-integrity' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-audit-integrity"]')).not.toBeNull()
   })
 
   it('renders the live Memory OS subsystem section and passes through focus', async () => {

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -4,6 +4,7 @@ import { Tools } from './tools/tools-main'
 import { HarnessHealth } from './harness-health'
 import { LabPerf } from './lab-perf'
 import { KeeperMemoryHealth } from './memory/keeper-memory-health'
+import { AuditIntegrity } from './memory/audit-integrity'
 import { SurfaceHeader } from './common/surface-header'
 import { MemorySubsystems } from './memory-subsystems'
 
@@ -13,6 +14,7 @@ type LabSection =
   | 'performance'
   | 'memory-subsystems'
   | 'keeper-memory-health'
+  | 'audit-integrity'
 
 function currentSection(): LabSection {
   const section = route.value.params.section
@@ -21,6 +23,7 @@ function currentSection(): LabSection {
     || section === 'performance'
     || section === 'memory-subsystems'
     || section === 'keeper-memory-health'
+    || section === 'audit-integrity'
   ) {
     return section
   }
@@ -51,6 +54,10 @@ export function Lab() {
 
       ${section === 'keeper-memory-health' ? html`
         <${KeeperMemoryHealth} />
+      ` : null}
+
+      ${section === 'audit-integrity' ? html`
+        <${AuditIntegrity} />
       ` : null}
     </div>
   `

--- a/dashboard/src/components/memory/audit-integrity.test.ts
+++ b/dashboard/src/components/memory/audit-integrity.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  AuditIntegrityKeeperEntry,
+  AuditIntegrityResponse,
+} from '../../api/dashboard'
+
+// ── Mock API ──────────────────────────────────────────
+// AuditIntegrity fetches via fetchAuditIntegrity() inside useEffect.
+// Mocking the module lets us drive every render branch without a real HTTP call.
+
+const mockFetch = vi.fn<() => Promise<AuditIntegrityResponse>>()
+
+vi.mock('../../api/dashboard', () => ({
+  fetchAuditIntegrity: () => mockFetch(),
+}))
+
+// ── Import after mocks ────────────────────────────────
+
+import { AuditIntegrity } from './audit-integrity'
+
+function makeEntry(
+  overrides: Partial<AuditIntegrityKeeperEntry> = {},
+): AuditIntegrityKeeperEntry {
+  return {
+    keeper_id: 'alpha',
+    entries: 12,
+    ok: true,
+    broken_at: null,
+    detail: null,
+    ...overrides,
+  }
+}
+
+function makeResponse(
+  keepers: AuditIntegrityKeeperEntry[],
+  totalsOverrides: Partial<AuditIntegrityResponse['totals']> = {},
+  enabled = true,
+): AuditIntegrityResponse {
+  return {
+    generated_at: 1_700_000_000,
+    resilience_enabled: enabled,
+    keepers,
+    totals: {
+      keepers: keepers.length,
+      entries: keepers.reduce((acc, k) => acc + k.entries, 0),
+      ok: keepers.filter(k => k.ok).length,
+      failed: keepers.filter(k => !k.ok).length,
+      ...totalsOverrides,
+    },
+  }
+}
+
+function statValue(container: Element, key: string): string | undefined {
+  const stat = container.querySelector(`.ai-totals-strip .ai-stat[data-stat-key="${key}"]`)
+  return stat?.querySelector('.ai-stat-value')?.textContent ?? undefined
+}
+
+describe('AuditIntegrity', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+  afterEach(() => cleanup())
+
+  describe('chain status rendering', () => {
+    it('renders an ok badge and no failure detail for an intact chain', async () => {
+      mockFetch.mockResolvedValue(makeResponse([makeEntry({ keeper_id: 'alpha' })]))
+      const { container } = render(html`<${AuditIntegrity} />`)
+      await waitFor(() => expect(screen.getByText('alpha')).not.toBeNull())
+
+      expect(container.querySelector('.ai-badge--ok')).not.toBeNull()
+      expect(container.querySelector('.ai-row--fail')).toBeNull()
+    })
+
+    it('flags a failed chain with broken index and detail', async () => {
+      mockFetch.mockResolvedValue(
+        makeResponse([
+          makeEntry({
+            keeper_id: 'tampered',
+            ok: false,
+            broken_at: 2,
+            detail: 'prev_hash mismatch at index 2',
+          }),
+        ]),
+      )
+      const { container } = render(html`<${AuditIntegrity} />`)
+      await waitFor(() => expect(screen.getByText('tampered')).not.toBeNull())
+
+      expect(container.querySelector('.ai-row--fail')).not.toBeNull()
+      expect(container.querySelector('.ai-badge--fail')).not.toBeNull()
+      expect(screen.getByText('2')).not.toBeNull()
+      expect(screen.getByText('prev_hash mismatch at index 2')).not.toBeNull()
+    })
+
+    it('surfaces the failed count in the totals strip', async () => {
+      mockFetch.mockResolvedValue(
+        makeResponse([
+          makeEntry({ keeper_id: 'broken', ok: false, broken_at: 1, detail: 'boom' }),
+          makeEntry({ keeper_id: 'healthy' }),
+        ]),
+      )
+      const { container } = render(html`<${AuditIntegrity} />`)
+      await waitFor(() => expect(screen.getByText('broken')).not.toBeNull())
+
+      expect(statValue(container, 'failed')).toBe('1')
+      expect(statValue(container, 'ok')).toBe('1')
+      expect(statValue(container, 'keepers')).toBe('2')
+      expect(container.querySelector('[data-stat-key="failed"] .ai-stat-value--fail')).not.toBeNull()
+    })
+  })
+
+  describe('render states', () => {
+    it('shows the loading state before the fetch resolves', () => {
+      // Never-resolving promise keeps the component in its initial loading branch.
+      mockFetch.mockReturnValue(new Promise<AuditIntegrityResponse>(() => {}))
+      render(html`<${AuditIntegrity} />`)
+      expect(screen.getByText('로딩중...')).not.toBeNull()
+    })
+
+    it('shows the error state when the fetch rejects', async () => {
+      mockFetch.mockRejectedValue(new Error('boom'))
+      render(html`<${AuditIntegrity} />`)
+      await waitFor(() => expect(screen.getByText('데이터 로드 실패: boom')).not.toBeNull())
+    })
+
+    it('shows the empty-keepers message when the response has no keepers', async () => {
+      mockFetch.mockResolvedValue(makeResponse([]))
+      render(html`<${AuditIntegrity} />`)
+      await waitFor(() => expect(screen.getByText('검증할 감사 로그 없음 (resilience audit 기록 없음).')).not.toBeNull())
+    })
+
+    it('renders one table row per keeper and the resilience flag', async () => {
+      mockFetch.mockResolvedValue(
+        makeResponse([makeEntry({ keeper_id: 'alpha' }), makeEntry({ keeper_id: 'beta' })]),
+      )
+      const { container } = render(html`<${AuditIntegrity} />`)
+      await waitFor(() => expect(screen.getByText('alpha')).not.toBeNull())
+
+      const rows = container.querySelectorAll('tbody tr')
+      expect(rows.length).toBe(2)
+      expect(screen.getByText('beta')).not.toBeNull()
+      expect(statValue(container, 'resilience-enabled')).toBe('활성')
+    })
+
+    it('shows the resilience flag as inactive when the feature is off', async () => {
+      mockFetch.mockResolvedValue(makeResponse([], {}, false))
+      const { container } = render(html`<${AuditIntegrity} />`)
+      await waitFor(() =>
+        expect(container.querySelector('[data-stat-key="resilience-enabled"]')).not.toBeNull(),
+      )
+      expect(statValue(container, 'resilience-enabled')).toBe('비활성')
+    })
+  })
+})

--- a/dashboard/src/components/memory/audit-integrity.ts
+++ b/dashboard/src/components/memory/audit-integrity.ts
@@ -1,0 +1,149 @@
+// AuditIntegrity — per-keeper resilience audit hash-chain verification panel.
+//
+// Read-only diagnostic surface for Lab > 감사 무결성.
+// Runs Shared_audit.Store.verify server-side and shows the result:
+// last verification time, entries checked, OK/failed, and the first
+// broken-link index so operators can spot tamper evidence.
+
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import {
+  fetchAuditIntegrity,
+  type AuditIntegrityKeeperEntry,
+  type AuditIntegrityResponse,
+} from '../../api/dashboard'
+import { DEFAULT_PANEL_REFRESH_MS, formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../../lib/auto-refresh'
+
+function KeeperRow({ entry }: { entry: AuditIntegrityKeeperEntry }) {
+  return html`
+    <tr class=${entry.ok ? '' : 'ai-row--fail'}>
+      <td>${entry.keeper_id}</td>
+      <td>${entry.entries.toLocaleString()}</td>
+      <td>
+        ${entry.ok
+          ? html`<span class="ai-badge ai-badge--ok">정상</span>`
+          : html`<span class="ai-badge ai-badge--fail">실패</span>`}
+      </td>
+      <td>${entry.broken_at !== null ? String(entry.broken_at) : '—'}</td>
+      <td class="ai-cell-detail">${entry.detail ?? '—'}</td>
+    </tr>
+  `
+}
+
+export function AuditIntegrity() {
+  const [data, setData] = useState<AuditIntegrityResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    // useEffect is appropriate here: this is external-system synchronization
+    // (periodic HTTP fetch from the MASC API), not derived state or event response.
+    const controller = new AbortController()
+
+    const refresh = async () => {
+      try {
+        const result = await fetchAuditIntegrity()
+        if (controller.signal.aborted) return
+        setData(result)
+        setError(null)
+      } catch (err) {
+        if (controller.signal.aborted) return
+        setError(err instanceof Error ? err.message : 'audit-integrity fetch failed')
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }
+
+    setLoading(true)
+    void refresh()
+    const cleanup = setupVisibleAutoRefresh(() => { void refresh() }, DEFAULT_PANEL_REFRESH_MS)
+
+    return () => {
+      controller.abort()
+      cleanup()
+    }
+  }, [])
+
+  if (loading && data === null) {
+    return html`
+      <div class="ai-panel">
+        <p class="ai-empty">로딩중...</p>
+      </div>
+    `
+  }
+
+  if (error !== null && data === null) {
+    return html`
+      <div class="ai-panel">
+        <p class="ai-empty">데이터 로드 실패: ${error}</p>
+      </div>
+    `
+  }
+
+  if (data === null) {
+    return html`
+      <div class="ai-panel">
+        <p class="ai-empty">데이터 없음.</p>
+      </div>
+    `
+  }
+
+  const generatedAt = new Date(data.generated_at * 1000).toLocaleTimeString()
+  const hasFailures = data.totals.failed > 0
+
+  return html`
+    <div class="ai-panel">
+      <div class="ai-header">
+        <div class="ai-title">감사 무결성</div>
+        <div class="ai-totals-strip">
+          <div class="ai-stat" data-stat-key="keepers">
+            <span class="ai-stat-label">검증 키퍼</span>
+            <span class="ai-stat-value">${data.totals.keepers}</span>
+          </div>
+          <div class="ai-stat" data-stat-key="entries">
+            <span class="ai-stat-label">검증 엔트리</span>
+            <span class="ai-stat-value">${data.totals.entries.toLocaleString()}</span>
+          </div>
+          <div class="ai-stat" data-stat-key="ok">
+            <span class="ai-stat-label">정상</span>
+            <span class="ai-stat-value">${data.totals.ok}</span>
+          </div>
+          <div class="ai-stat" data-stat-key="failed">
+            <span class="ai-stat-label">실패</span>
+            <span class=${`ai-stat-value${hasFailures ? ' ai-stat-value--fail' : ''}`}>
+              ${data.totals.failed}
+            </span>
+          </div>
+          <div class="ai-stat" data-stat-key="resilience-enabled">
+            <span class="ai-stat-label">Resilience 감사</span>
+            <span class="ai-stat-value">${data.resilience_enabled ? '활성' : '비활성'}</span>
+          </div>
+        </div>
+        <div class="ai-refresh-label">
+          ${formatAutoRefreshLabel(DEFAULT_PANEL_REFRESH_MS)} — 기준 ${generatedAt}
+        </div>
+      </div>
+
+      ${data.keepers.length === 0
+        ? html`<p class="ai-empty">검증할 감사 로그 없음 (resilience audit 기록 없음).</p>`
+        : html`
+          <div class="ai-table-wrap">
+            <table class="ai-table">
+              <thead>
+                <tr>
+                  <th>키퍼</th>
+                  <th>검증 엔트리</th>
+                  <th>체인 상태</th>
+                  <th>실패 지점</th>
+                  <th>상세</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${data.keepers.map(entry => html`<${KeeperRow} key=${entry.keeper_id} entry=${entry} />`)}
+              </tbody>
+            </table>
+          </div>
+        `}
+    </div>
+  `
+}

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -156,6 +156,7 @@ describe('lab navigation', () => {
       'performance',
       'memory-subsystems',
       'keeper-memory-health',
+      'audit-integrity',
     ])
 
     expect(labSections.map(item => item.label)).toEqual([
@@ -164,6 +165,7 @@ describe('lab navigation', () => {
       'Performance',
       'Memory OS',
       '키퍼 메모리 상태',
+      '감사 무결성',
     ])
     expect(labSections.find(item => item.id === 'memory-subsystems')?.description).toBe(
       'Live episodes, user model projection, Hebbian synapses, and gated memory entries.',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -79,6 +79,7 @@ type SurfaceSectionId =
   | 'performance'
   | 'memory-subsystems'
   | 'keeper-memory-health'
+  | 'audit-integrity'
   // code (Stage 5 IDE plane — shell only in PR-1, 4-pane content in PR-2+)
   | 'ide-shell'
 
@@ -474,6 +475,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '키퍼 메모리 상태',
       description: 'Per-keeper fact-store size, GC statistics, and cadence counter.',
       params: { section: 'keeper-memory-health' },
+    },
+    {
+      id: 'audit-integrity',
+      label: '감사 무결성',
+      description: 'Per-keeper resilience audit hash-chain verification result.',
+      params: { section: 'audit-integrity' },
     },
   ],
   code: [

--- a/dashboard/src/styles/audit-integrity-v2.css
+++ b/dashboard/src/styles/audit-integrity-v2.css
@@ -1,0 +1,143 @@
+/* ════════════════════════════════════════════════════════════════
+   AUDIT INTEGRITY — per-keeper resilience audit chain verification panel (Lab)
+   Read-only diagnostic panel for the Shared_audit hash-chain verify result.
+   Auto-imported via the *-v2.css glob in main.ts — do not add an import line.
+   ════════════════════════════════════════════════════════════════ */
+
+.ai-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+
+.ai-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ai-title {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ai-totals-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.ai-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ai-stat-label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ai-stat-value {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.ai-stat-value--fail {
+  color: var(--status-bad, #e05252);
+}
+
+.ai-table-wrap {
+  overflow-x: auto;
+}
+
+.ai-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.ai-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border-subtle);
+  white-space: nowrap;
+}
+
+.ai-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.ai-table tr:last-child td {
+  border-bottom: none;
+}
+
+.ai-table tr:hover td {
+  background: var(--surface-hovered);
+}
+
+/* Rows whose chain verification failed — tamper evidence. */
+.ai-row--fail td {
+  background: color-mix(in srgb, var(--status-bad, #e05252) 6%, transparent);
+}
+
+.ai-row--fail:hover td {
+  background: color-mix(in srgb, var(--status-bad, #e05252) 10%, transparent);
+}
+
+.ai-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.ai-badge--fail {
+  background: color-mix(in srgb, var(--status-bad, #e05252) 20%, transparent);
+  color: var(--status-bad, #e05252);
+}
+
+.ai-badge--ok {
+  background: color-mix(in srgb, var(--status-ok) 15%, transparent);
+  color: var(--status-ok);
+}
+
+.ai-cell-detail {
+  max-width: 32rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ai-refresh-label {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  margin-top: var(--space-1);
+}
+
+.ai-empty {
+  padding: var(--space-8);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -47,7 +47,7 @@ let valid_sections =
   ; ( "workspace"
     , [ "board"; "sub-boards"; "moderation"; "planning"; "repositories"; "verification"; "work" ] )
   ; ( "lab"
-    , [ "tools"; "harness"; "performance"; "memory-subsystems"; "keeper-memory-health" ]
+    , [ "tools"; "harness"; "performance"; "memory-subsystems"; "keeper-memory-health"; "audit-integrity" ]
     )
   ; "code", [ "ide-shell" ]
   ; ( "settings"

--- a/lib/server/server_dashboard_http_audit_integrity.ml
+++ b/lib/server/server_dashboard_http_audit_integrity.ml
@@ -1,0 +1,126 @@
+(** Audit-integrity dashboard HTTP JSON helper.
+
+    Runs [Shared_audit.Store.verify] over the per-keeper resilience audit
+    logs and produces a read-only snapshot for the
+    /api/v1/dashboard/audit-integrity endpoint.
+
+    Data sources:
+    - [<base_path>/.masc/resilience_audit/<keeper>/] — the write path is
+      owned by [Keeper_turn_runtime_budget.resilience_audit_dir]; this
+      module only reads that layout.
+    - [Resilience.Keeper_bridge.masc_resilience_enabled] for the feature
+      flag state, so operators can distinguish "feature off" from
+      "no broken chains".
+
+    A keeper whose log cannot be read or parsed is reported as a failed
+    verification (not skipped): unreadable audit evidence is itself an
+    integrity signal. *)
+
+type keeper_report =
+  { keeper_id : string
+  ; entries : int
+  ; ok : bool
+  ; broken_at : int option
+  ; detail : string option
+  }
+
+let audit_root ~base_path =
+  Filename.concat (Config_dir_resolver.masc_root ~base_path) "resilience_audit"
+;;
+
+let list_keeper_ids root =
+  if not (Sys.file_exists root)
+  then []
+  else if not (Sys.is_directory root)
+  then []
+  else
+    Sys.readdir root
+    |> Array.to_list
+    |> List.filter (fun name -> Sys.is_directory (Filename.concat root name))
+    |> List.sort String.compare
+;;
+
+let verify_keeper ~root keeper_id =
+  let base_dir = Filename.concat root keeper_id in
+  try
+    let store = Shared_audit.Store.create ~base_dir in
+    let report = Shared_audit.Store.verify store in
+    match report.failure with
+    | None ->
+      { keeper_id
+      ; entries = report.entries_checked
+      ; ok = true
+      ; broken_at = None
+      ; detail = None
+      }
+    | Some (idx, reason) ->
+      { keeper_id
+      ; entries = report.entries_checked
+      ; ok = false
+      ; broken_at = Some idx
+      ; detail = Some reason
+      }
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Shared_audit.Store.Corrupt_jsonl { path; line_number; detail } ->
+    { keeper_id
+    ; entries = 0
+    ; ok = false
+    ; broken_at = None
+    ; detail =
+        Some (Printf.sprintf "corrupt audit JSONL %s:%d: %s" path line_number detail)
+    }
+  | exn ->
+    Log.Dashboard.warn
+      "[audit_integrity] verify failed for keeper %s: %s"
+      keeper_id
+      (Printexc.to_string exn);
+    { keeper_id
+    ; entries = 0
+    ; ok = false
+    ; broken_at = None
+    ; detail = Some (Printexc.to_string exn)
+    }
+;;
+
+let keeper_report_to_json r =
+  `Assoc
+    [ "keeper_id", `String r.keeper_id
+    ; "entries", `Int r.entries
+    ; "ok", `Bool r.ok
+    ; "broken_at", Option.fold ~none:`Null ~some:(fun idx -> `Int idx) r.broken_at
+    ; "detail", Option.fold ~none:`Null ~some:(fun d -> `String d) r.detail
+    ]
+;;
+
+let audit_integrity_http_json ~base_path : Yojson.Safe.t =
+  (* NDT-OK: diagnostic snapshot timestamp only; verification never
+     branches on the wall clock. *)
+  let now = Unix.gettimeofday () in
+  let root = audit_root ~base_path in
+  let reports =
+    list_keeper_ids root
+    |> List.map (verify_keeper ~root)
+    (* Failures first so broken chains surface at the top. *)
+    |> List.sort (fun a b ->
+      match a.ok, b.ok with
+      | false, true -> -1
+      | true, false -> 1
+      | _ -> String.compare a.keeper_id b.keeper_id)
+  in
+  let failed = List.filter (fun r -> not r.ok) reports in
+  `Assoc
+    [ "generated_at", `Float now
+    ; ( "resilience_enabled"
+      , `Bool (Resilience.Keeper_bridge.masc_resilience_enabled ()) )
+    ; "keepers", `List (List.map keeper_report_to_json reports)
+    ; ( "totals"
+      , `Assoc
+          [ "keepers", `Int (List.length reports)
+          ; ( "entries"
+            , `Int (List.fold_left (fun acc r -> acc + r.entries) 0 reports) )
+          ; "ok", `Int (List.length reports - List.length failed)
+          ; "failed", `Int (List.length failed)
+          ] )
+    ]
+;;

--- a/lib/server/server_dashboard_http_audit_integrity.mli
+++ b/lib/server/server_dashboard_http_audit_integrity.mli
@@ -1,0 +1,7 @@
+(** Audit-integrity dashboard HTTP JSON helper.
+
+    Runs [Shared_audit.Store.verify] over the per-keeper resilience audit
+    logs and produces a read-only snapshot for the
+    /api/v1/dashboard/audit-integrity endpoint. *)
+
+val audit_integrity_http_json : base_path:string -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1182,6 +1182,18 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/audit-integrity" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = (Mcp_server.workspace_config state).base_path in
+         let cache_key = Printf.sprintf "audit_integrity:%s" base_path in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               Server_dashboard_http_audit_integrity.audit_integrity_http_json
+                 ~base_path))
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/gate" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = (Mcp_server.workspace_config state).base_path in

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -9,6 +9,11 @@ exception Corrupt_jsonl of {
   detail : string;
 }
 
+type verify_report = {
+  entries_checked : int;
+  failure : (int * string) option;
+}
+
 let parse_jsonl_line line =
   try Yojson.Safe.from_string line |> Envelope.of_json with
   | Yojson.Json_error msg -> Error msg
@@ -140,3 +145,11 @@ let verify_chain entries =
         check (idx + 1) (Some h) rest
   in
   check 0 None entries
+
+let verify t =
+  let entries = read_all_entries t in
+  match verify_chain entries with
+  | Ok () ->
+    { entries_checked = List.length entries; failure = None }
+  | Error (idx, reason) ->
+    { entries_checked = idx; failure = Some (idx, reason) }

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -59,5 +59,21 @@ val verify_chain : Envelope.t list -> (unit, int * string) result
     [Error (idx, reason)] at the first broken link. The first entry
     must have [prev_hash = None]. *)
 
+type verify_report = {
+  entries_checked : int;
+  (** Entries whose chain link verified before the first failure; equals
+      the total on-disk entry count when the chain is intact. *)
+  failure : (int * string) option;
+  (** [Some (idx, reason)] at the first broken link; [None] when intact. *)
+}
+
+val verify : t -> verify_report
+(** Read the full on-disk log and verify the [prev_hash] chain with
+    {!verify_chain}. This is the runtime entry point that makes the chain
+    more than a write-only cost: callers (e.g. the audit-integrity
+    dashboard surface) run it against the persisted log and surface the
+    result. Raises {!Corrupt_jsonl} when persisted audit evidence is
+    malformed. *)
+
 val base_dir : t -> string
 (** Inspector for the base directory (mainly for tests). *)

--- a/test/dune
+++ b/test/dune
@@ -140,6 +140,7 @@
   test_dashboard_nav_event
   test_server_dashboard_http_memory_subsystems
   test_server_dashboard_http_keeper_memory_health
+  test_server_dashboard_http_audit_integrity
   test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview
@@ -449,6 +450,7 @@
   test_dashboard_nav_event
   test_server_dashboard_http_memory_subsystems
   test_server_dashboard_http_keeper_memory_health
+  test_server_dashboard_http_audit_integrity
   test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -201,6 +201,50 @@ let test_store_verify_chain_detects_tampering () =
          because its prev_hash no longer matches. *)
       check bool "broken link reported" true (idx >= 2))
 
+let test_store_verify_empty_log () =
+  let dir = unique_temp_dir "audit_verify_empty" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let report = Store.verify store in
+    check int "no entries checked" 0 report.entries_checked;
+    check bool "no failure on empty log" true (report.failure = None))
+
+let test_store_verify_reports_intact_chain () =
+  let dir = unique_temp_dir "audit_verify_report_ok" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    for i = 1 to 4 do
+      let _ = Store.append store ~category:"V" ~payload:(`Int i) in ()
+    done;
+    let report = Store.verify store in
+    check int "all entries checked" 4 report.entries_checked;
+    check bool "no failure" true (report.failure = None))
+
+let test_store_verify_reports_on_disk_tampering () =
+  let dir = unique_temp_dir "audit_verify_report_broken" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let _ = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let e2 = Store.append store ~category:"X" ~payload:(`Int 2) in
+    (* Forge a third line whose prev_hash does not chain to e2. The line
+       lands in the same day-file as e2 so it is read after it. *)
+    let forged =
+      Env.make ~category:"X" ~payload:(`Int 3)
+        ~prev_hash:(Some (String.make 64 '0'))
+    in
+    let path = audit_path ~base_dir:dir ~ts:e2.ts in
+    let oc = open_out_gen [ Open_append; Open_wronly ] 0o644 path in
+    output_string oc (Yojson.Safe.to_string (Env.to_json forged));
+    output_char oc '\n';
+    close_out oc;
+    let report = Store.verify store in
+    check int "two links checked before break" 2 report.entries_checked;
+    match report.failure with
+    | Some (idx, reason) ->
+      check int "break at forged index" 2 idx;
+      check bool "reason non-empty" true (String.trim reason <> "")
+    | None -> fail "expected broken chain report")
+
 let test_store_resume_continues_chain () =
   let dir = unique_temp_dir "audit_resume" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
@@ -276,6 +320,9 @@ let () =
       test_case "since filters by timestamp" `Quick test_store_since_filters;
       test_case "verify_chain intact" `Quick test_store_verify_chain_intact;
       test_case "verify_chain detects tampering" `Quick test_store_verify_chain_detects_tampering;
+      test_case "verify empty log" `Quick test_store_verify_empty_log;
+      test_case "verify reports intact chain" `Quick test_store_verify_reports_intact_chain;
+      test_case "verify reports on-disk tampering" `Quick test_store_verify_reports_on_disk_tampering;
       test_case "resume continues chain" `Quick test_store_resume_continues_chain;
       test_case "rejects malformed JSONL lines" `Quick test_store_rejects_malformed_jsonl_lines;
       test_case "rejects invalid envelope JSONL lines" `Quick test_store_rejects_invalid_envelope_jsonl_lines;

--- a/test/test_server_dashboard_http_audit_integrity.ml
+++ b/test/test_server_dashboard_http_audit_integrity.ml
@@ -1,0 +1,175 @@
+(** Regression tests for the audit-integrity dashboard helper. *)
+
+module Integrity = Server_dashboard_http_audit_integrity
+module Env = Shared_audit.Envelope
+module Store = Shared_audit.Store
+
+(* [Filename.temp_dir] creates the directory atomically. *)
+let fresh_dir prefix = Filename.temp_dir prefix ""
+
+let audit_path ~base_dir ~ts =
+  let tm = Unix.gmtime ts in
+  let yyyy_mm =
+    Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)
+  in
+  let dd = Printf.sprintf "%02d" tm.Unix.tm_mday in
+  Filename.concat (Filename.concat base_dir yyyy_mm) (dd ^ ".jsonl")
+;;
+
+let keeper_dir ~base keeper_id =
+  Filename.concat
+    (Filename.concat (Filename.concat base ".masc") "resilience_audit")
+    keeper_id
+;;
+
+let append_entries ~base keeper_id payloads =
+  let store = Store.create ~base_dir:(keeper_dir ~base keeper_id) in
+  List.map (fun i -> Store.append store ~category:"Test" ~payload:(`Int i)) payloads
+;;
+
+(* Append a forged line whose prev_hash does not chain to the latest entry,
+   landing in the same day-file so it is read after it. *)
+let forge_line ~base keeper_id ~after =
+  let forged =
+    Env.make ~category:"Test" ~payload:(`Int 999)
+      ~prev_hash:(Some (String.make 64 '0'))
+  in
+  let path = audit_path ~base_dir:(keeper_dir ~base keeper_id) ~ts:after.Env.ts in
+  let oc = open_out_gen [ Open_append; Open_wronly ] 0o644 path in
+  output_string oc (Yojson.Safe.to_string (Env.to_json forged));
+  output_char oc '\n';
+  close_out oc
+;;
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let int_field name json =
+  match assoc_field name json with
+  | Some (`Int n) -> n
+  | _ -> Alcotest.failf "expected int field %S" name
+;;
+
+let bool_field name json =
+  match assoc_field name json with
+  | Some (`Bool b) -> b
+  | _ -> Alcotest.failf "expected bool field %S" name
+;;
+
+let list_field name json =
+  match assoc_field name json with
+  | Some (`List xs) -> xs
+  | _ -> Alcotest.failf "expected list field %S" name
+;;
+
+let keeper_ids json =
+  list_field "keepers" json
+  |> List.filter_map (fun k ->
+    match assoc_field "keeper_id" k with
+    | Some (`String s) -> Some s
+    | _ -> None)
+;;
+
+let keeper_obj id json =
+  match
+    List.find_opt
+      (fun k ->
+        match assoc_field "keeper_id" k with
+        | Some (`String s) -> String.equal s id
+        | _ -> false)
+      (list_field "keepers" json)
+  with
+  | Some k -> k
+  | None -> Alcotest.failf "keeper %S not present in snapshot" id
+;;
+
+let totals json =
+  match assoc_field "totals" json with
+  | Some t -> t
+  | None -> Alcotest.fail "expected totals object"
+;;
+
+let test_missing_audit_root_yields_empty_snapshot () =
+  let base = fresh_dir "masc-audit-integrity-empty" in
+  let json = Integrity.audit_integrity_http_json ~base_path:base in
+  Alcotest.(check (list string)) "no keepers" [] (keeper_ids json);
+  Alcotest.(check int) "totals.keepers 0" 0 (int_field "keepers" (totals json));
+  Alcotest.(check int) "totals.entries 0" 0 (int_field "entries" (totals json));
+  Alcotest.(check int) "totals.failed 0" 0 (int_field "failed" (totals json));
+  Alcotest.(check bool)
+    "resilience_enabled is a bool"
+    true
+    (match assoc_field "resilience_enabled" json with
+     | Some (`Bool _) -> true
+     | _ -> false)
+;;
+
+let test_reports_intact_chain () =
+  let base = fresh_dir "masc-audit-integrity-ok" in
+  ignore (append_entries ~base "solo" [ 1; 2; 3 ]);
+  let json = Integrity.audit_integrity_http_json ~base_path:base in
+  let k = keeper_obj "solo" json in
+  Alcotest.(check bool) "chain ok" true (bool_field "ok" k);
+  Alcotest.(check int) "entries counted" 3 (int_field "entries" k);
+  Alcotest.(check bool)
+    "broken_at null"
+    true
+    (match assoc_field "broken_at" k with
+     | Some `Null -> true
+     | _ -> false);
+  Alcotest.(check int) "totals.ok 1" 1 (int_field "ok" (totals json));
+  Alcotest.(check int) "totals.failed 0" 0 (int_field "failed" (totals json));
+  Alcotest.(check int) "totals.entries 3" 3 (int_field "entries" (totals json))
+;;
+
+let test_reports_broken_chain_and_sorts_failures_first () =
+  let base = fresh_dir "masc-audit-integrity-broken" in
+  ignore (append_entries ~base "healthy" [ 1; 2 ]);
+  let appended = append_entries ~base "tampered" [ 1; 2 ] in
+  (match List.rev appended with
+   | last :: _ -> forge_line ~base "tampered" ~after:last
+   | [] -> Alcotest.fail "expected appended entries");
+  let json = Integrity.audit_integrity_http_json ~base_path:base in
+  let k = keeper_obj "tampered" json in
+  Alcotest.(check bool) "chain not ok" false (bool_field "ok" k);
+  Alcotest.(check int) "entries before break" 2 (int_field "entries" k);
+  Alcotest.(check bool)
+    "broken_at = forged index 2"
+    true
+    (match assoc_field "broken_at" k with
+     | Some (`Int 2) -> true
+     | _ -> false);
+  Alcotest.(check bool)
+    "detail present"
+    true
+    (match assoc_field "detail" k with
+     | Some (`String s) -> String.trim s <> ""
+     | _ -> false);
+  Alcotest.(check (list string))
+    "failed keeper sorts first"
+    [ "tampered"; "healthy" ]
+    (keeper_ids json);
+  Alcotest.(check int) "totals.failed 1" 1 (int_field "failed" (totals json));
+  Alcotest.(check int) "totals.ok 1" 1 (int_field "ok" (totals json))
+;;
+
+let () =
+  Alcotest.run
+    "server_dashboard_http_audit_integrity"
+    [ ( "snapshot"
+      , [ Alcotest.test_case
+            "missing audit root yields empty snapshot"
+            `Quick
+            test_missing_audit_root_yields_empty_snapshot
+        ; Alcotest.test_case
+            "reports intact chain"
+            `Quick
+            test_reports_intact_chain
+        ; Alcotest.test_case
+            "reports broken chain and sorts failures first"
+            `Quick
+            test_reports_broken_chain_and_sorts_failures_first
+        ] )
+    ]


### PR DESCRIPTION
## Problem

`Shared_audit` writes a tamper-evident hash chain (resilience audit), but nothing ever verified it — `verify_chain` was test-only. A tamper-evidence chain nobody checks is decoration.

## Fix

- `Store.verify`: full-chain verification report (entries checked, first broken link + reason). Full chain is required — the chain root is the genesis entry, so partial verification cannot detect tampering.
- `GET /api/v1/dashboard/audit-integrity`: per-keeper chain status, first broken index, totals. 60s cached, blocking IO offloaded to Domain_pool; unreadable/corrupt logs are reported as failures (fail-closed — unverifiable evidence is itself a tamper signal).
- Lab panel "audit-integrity": totals strip + per-keeper table, distinguishing resilience-disabled (`MASC_RESILIENCE` off) from no-data.

## Verification

- `dune build lib/` ✓
- `test_shared_audit` 20/20 (incl. tamper-injection detection) ✓
- `test_server_dashboard_http_audit_integrity` 3/3 ✓
- `tsc --noEmit` ✓, vitest 69/69 ✓
- Determinism gate PASS ✓

Found by adversarial wiring audit (2026-07-17). Follow-up noted: `resilience_audit` is not covered by JSONL retention pruning.