### PR TITLE
chore(telemetry): drop the write-only harness-telemetry JSONL store

### DIFF
--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -1,16 +1,19 @@
 (** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
     Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
-    filters [Custom("telemetry_event", json)] payloads, persists each
-    event to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
-    {!Dated_jsonl}, and increments an OTel counter for dashboard
-    visibility.
+    filters [Custom("telemetry_event", json)] payloads, and increments
+    an OTel counter for dashboard visibility.
+
+    Payloads are intentionally not persisted here: the same bus is fully
+    persisted by {!Keeper_event_bridge} into [.masc/oas-events/] (the
+    store {!Telemetry_unified} actually reads), so a second write-only
+    copy under [data/harness-telemetry/] was removed (2026-07-20).
 
     MASC deliberately does not deserialize provider/model-bearing OAS
     telemetry; concrete runtime identity belongs to OAS.
 
-    State is purely internal: the subscription handle, the fiber, and the
-    {!Dated_jsonl.t} store are all bound to the caller's [Eio.Switch.t]. *)
+    State is purely internal: the subscription handle and the fiber are
+    bound to the caller's [Eio.Switch.t]. *)
 
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 
@@ -18,12 +21,7 @@ let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
    starves co-located fibers (HTTP handlers, lazy startup tasks). *)
 let drain_interval_s = 0.1
 
-let spawn_subscriber ~sw ~clock ~base_path ~bus =
-  let store =
-    Dated_jsonl.create
-      ~base_dir:(Filename.concat base_path "data/harness-telemetry")
-      ()
-  in
+let spawn_subscriber ~sw ~clock ~bus =
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~capacity:256
@@ -41,12 +39,11 @@ let spawn_subscriber ~sw ~clock ~base_path ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", json) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", _json) ->
                   Otel_metric_store.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]
-                    ();
-                  Dated_jsonl.append store json
+                    ()
               | _ -> ())
            events
        with

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -2,18 +2,16 @@
 
     Spawns a fiber that drains [Custom("telemetry_event", json)]
     payloads from the OAS event bus without deserializing provider/model
-    identity.  Each event is persisted to
-    [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
-    {!Dated_jsonl}. *)
+    identity, incrementing an OTel counter per event. Payloads are not
+    persisted here — the same bus is fully persisted by
+    {!Keeper_event_bridge} into [.masc/oas-events/]. *)
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
-  -> base_path:string
   -> bus:Agent_sdk.Event_bus.t
   -> unit
-(** [spawn_subscriber ~sw ~clock ~base_path ~bus] forks a fiber that
-    drains [Custom("telemetry_event", json)] payloads from [bus],
-    persists each one to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl],
-    and increments an OTel counter.  The fiber yields every 100 ms so
+(** [spawn_subscriber ~sw ~clock ~bus] forks a fiber that drains
+    [Custom("telemetry_event", json)] payloads from [bus] and increments
+    an OTel counter for each. The fiber yields every 100 ms so
     co-located fibers are not starved. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1086,8 +1086,7 @@ let start_keeper_loops_owned
   Keeper_event_bridge.start ~sw ~clock ~config:(Mcp_server.workspace_config state) ~bus:masc_event_bus;
   (* Telemetry feedback loop: observe OAS per-turn signals without
      deserializing provider/model-bearing payloads. *)
-  Keeper_telemetry_consumer.spawn_subscriber
-    ~sw ~clock ~base_path:(Env_config.base_path ()) ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~capacity:256

--- a/test/test_keeper_telemetry_consumer.ml
+++ b/test/test_keeper_telemetry_consumer.ml
@@ -23,18 +23,6 @@ module KTC = Masc.Keeper_telemetry_consumer
 let target_iters = 5
 let inter_sleep_s = 0.02
 let total_expected_wall_clock_s = float_of_int target_iters *. inter_sleep_s
-let temp_counter = ref 0
-
-let temp_base_path prefix =
-  incr temp_counter;
-  let dir =
-    Filename.concat
-      (Filename.get_temp_dir_name ())
-      (Printf.sprintf "%s_%d_%d_%.0f" prefix !temp_counter (Unix.getpid ())
-         (Unix.gettimeofday ()))
-  in
-  Fs_compat.mkdir_p dir;
-  dir
 
 (* Marker used to break out of [Switch.run] once the assertion data is
    collected. Using [Switch.fail] would propagate as the switch's
@@ -47,10 +35,9 @@ let test_drain_loop_yields_to_co_located_fiber () =
   Eio_main.run @@ fun env ->
     let clock = Eio.Stdenv.clock env in
     let bus = Agent_sdk.Event_bus.create () in
-    let base_path = temp_base_path "keeper_telemetry_consumer" in
     (try
       Eio.Switch.run (fun sw ->
-        KTC.spawn_subscriber ~sw ~clock ~base_path ~bus;
+        KTC.spawn_subscriber ~sw ~clock ~bus;
         for _ = 1 to target_iters do
           Eio.Time.sleep clock inter_sleep_s;
           incr counter
@@ -64,61 +51,6 @@ let test_drain_loop_yields_to_co_located_fiber () =
        target_iters total_expected_wall_clock_s)
     target_iters !counter
 
-(* Walk [dir] recursively and return every regular file ending in
-   ".jsonl". Stdlib-only so the test does not need a [dated_jsonl] dune
-   dependency just to read the store back. *)
-let rec find_jsonl dir =
-  if not (Sys.file_exists dir) then []
-  else if Sys.is_directory dir then
-    Sys.readdir dir |> Array.to_list
-    |> List.concat_map (fun name -> find_jsonl (Filename.concat dir name))
-  else if Filename.check_suffix dir ".jsonl" then [ dir ]
-  else []
-
-let contains_substring haystack needle =
-  let hl = String.length haystack and nl = String.length needle in
-  let rec loop i =
-    if i + nl > hl then false
-    else if String.sub haystack i nl = needle then true
-    else loop (i + 1)
-  in
-  nl = 0 || loop 0
-
-(* Regression for the silent telemetry drop: the consumer must persist
-   each [Custom ("telemetry_event", json)] payload to
-   [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl], not merely
-   increment a counter. A counter-only consumer (the state #20853 fixed
-   and 6f5bfdeb2 reverted) drops the payload — this test fails on it. *)
-let test_persists_telemetry_event_to_jsonl () =
-  let base_path = temp_base_path "keeper_telemetry_persist" in
-  let marker = "persist_probe_3f9c1" in
-  let payload =
-    `Assoc [ ("kind", `String "turn_observation"); ("marker", `String marker) ]
-  in
-  Eio_main.run @@ fun env ->
-    let clock = Eio.Stdenv.clock env in
-    let bus = Agent_sdk.Event_bus.create () in
-    (try
-      Eio.Switch.run (fun sw ->
-        KTC.spawn_subscriber ~sw ~clock ~base_path ~bus;
-        Agent_sdk.Event_bus.publish bus
-          (Agent_sdk.Event_bus.mk_event
-             (Agent_sdk.Event_bus.Custom ("telemetry_event", payload)));
-        (* Let several drain intervals (0.1s each) flush to disk. *)
-        Eio.Time.sleep clock 0.35;
-        raise Test_done)
-    with Test_done -> ());
-  let store_dir = Filename.concat base_path "data/harness-telemetry" in
-  let files = find_jsonl store_dir in
-  let persisted =
-    List.exists
-      (fun path -> contains_substring (Fs_compat.load_file path) marker)
-      files
-  in
-  Alcotest.(check bool)
-    "telemetry_event payload persisted to harness-telemetry JSONL"
-    true persisted
-
 let () =
   Alcotest.run "keeper_telemetry_consumer"
     [
@@ -128,12 +60,5 @@ let () =
             "drain loop yields to co-located fiber"
             `Quick
             test_drain_loop_yields_to_co_located_fiber;
-        ] );
-      ( "persistence",
-        [
-          Alcotest.test_case
-            "telemetry_event persisted to dated JSONL"
-            `Quick
-            test_persists_telemetry_event_to_jsonl;
         ] );
     ]


### PR DESCRIPTION
## Problem

`Keeper_telemetry_consumer` persisted every OAS `telemetry_event` to `data/harness-telemetry/YYYY-MM/DD.jsonl` — a store with **zero readers** (repo-wide verified: no dashboard, tool, doc, or telemetry_unified source references it). The same bus is already fully persisted by `Keeper_event_bridge` into `.masc/oas-events/`, which `Telemetry_unified` actually reads. The second copy was pure disk growth.

## Fix

Remove the JSONL persistence (and the now-unused `base_path` parameter); keep the live parts — the subscription and the `masc_keeper_telemetry_events_consumed_total` counter. The payload-persistence intent of #20853 is preserved by the event bridge's durable, actually-read store.

## Verification

- `dune build lib/` ✓
- `test_keeper_telemetry_consumer` (cooperative-scheduling regression) ✓
- Determinism gate PASS ✓

Found by adversarial wiring audit (2026-07-17).