### PR TITLE
feat(runtime): accept lane ids for structured_judge and cross_verifier routes

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -155,16 +155,86 @@ let validate_librarian_runtime ~(config_path : string)
               ~runtime_count:(List.length runtimes) id))
 ;;
 
+(* Route ids resolve with lane precedence ([resolve_assignment] prefers a lane
+   over a same-named runtime), so route validation must judge the same target
+   the consumer will actually get: lane first, runtime second. *)
+let find_declared_lane (lanes : Runtime_lane.t list) (id : string) =
+  List.find_opt (fun lane -> String.equal (Runtime_lane.id lane) id) lanes
+;;
+
+(* Every lane candidate must satisfy the route's capability contract: the
+   turn-driver lane walk attempts candidates without re-filtering by
+   capability, so one incapable candidate would silently downgrade the
+   contract mid-failover. [validate_lanes] already guarantees candidate ids
+   resolve; the [None] arm stays total for the error message anyway. *)
+let validate_lane_candidates_capability
+    ~(config_path : string)
+    ~(route_name : string)
+    ~(capability_key : string)
+    ~(runtime_supports : t -> bool)
+    (runtimes : t list)
+    (lane : Runtime_lane.t) : (unit, string) result =
+  let lane_id = Runtime_lane.id lane in
+  let rec check = function
+    | [] -> Ok ()
+    | candidate_id :: rest ->
+      (match
+         List.find_opt (fun (r : t) -> String.equal r.id candidate_id) runtimes
+       with
+       | None ->
+         Error
+           (Printf.sprintf
+              "%s: [runtime].%s = %S lane candidate %S is not a configured \
+               runtime"
+              config_path
+              route_name
+              lane_id
+              candidate_id)
+       | Some runtime ->
+         if runtime_supports runtime
+         then check rest
+         else
+           Error
+             (Printf.sprintf
+                "%s: [runtime].%s = %S lane candidate %S uses model %S, which \
+                 does not declare %s"
+                config_path
+                route_name
+                lane_id
+                candidate_id
+                runtime.model.id
+                capability_key))
+  in
+  check (Runtime_lane.ordered_candidates lane)
+;;
+
 (* [runtime].cross_verifier mirrors [runtime].librarian validation: an unknown
    id is an operator typo rejected at load, not a silent fallback
    (Unknown→Permissive anti-pattern). [None] is the designed "inherit
-   [runtime].default" case. *)
+   [runtime].default" case. A lane id is accepted when every candidate
+   declares JSON mode (#25394). *)
 let validate_cross_verifier_runtime ~(config_path : string)
     ~(dropped_bindings : (string * string) list) (runtimes : t list)
+    (lanes : Runtime_lane.t list)
     (cross_verifier_id : string option) : (unit, string) result =
+  let supports_json (runtime : t) =
+    match runtime.model.capabilities with
+    | Some caps -> caps.supports_response_format_json
+    | None -> false
+  in
   match cross_verifier_id with
   | None -> Ok ()
   | Some id ->
+    (match find_declared_lane lanes id with
+     | Some lane ->
+       validate_lane_candidates_capability
+         ~config_path
+         ~route_name:"cross_verifier"
+         ~capability_key:"supports-response-format-json"
+         ~runtime_supports:supports_json
+         runtimes
+         lane
+     | None ->
     (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
      | None ->
       Error
@@ -175,9 +245,9 @@ let validate_cross_verifier_runtime ~(config_path : string)
            (unresolved_runtime_suffix ~dropped_bindings
               ~runtime_count:(List.length runtimes) id))
      | Some runtime ->
-       (match runtime.model.capabilities with
-        | Some caps when caps.supports_response_format_json -> Ok ()
-        | _ ->
+       if supports_json runtime
+       then Ok ()
+       else
           Error
             (Printf.sprintf
                "%s: [runtime].cross_verifier = %S uses model %S, which does \
@@ -191,13 +261,32 @@ let validate_cross_verifier_runtime ~(config_path : string)
    requests. Unlike the librarian lane, this lane must declare structured output,
    not just JSON mode. [None] remains a migration fallback for existing configs;
    unsupported resolved runtimes are rejected by each caller's OAS schema
-   validation instead of silently dropping the schema. *)
+   validation instead of silently dropping the schema. A [runtime.lanes] id is
+   accepted when every candidate declares structured output (#25394): every
+   consumer routes through [resolve_assignment]-aware paths
+   ([Keeper_turn_driver.run_named] or the compaction candidate expansion). *)
 let validate_structured_judge_runtime ~(config_path : string)
     ~(dropped_bindings : (string * string) list) (runtimes : t list)
+    (lanes : Runtime_lane.t list)
     (structured_judge_id : string option) : (unit, string) result =
+  let supports_structured (runtime : t) =
+    match runtime.model.capabilities with
+    | Some caps -> caps.supports_structured_output
+    | None -> false
+  in
   match structured_judge_id with
   | None -> Ok ()
   | Some id ->
+    (match find_declared_lane lanes id with
+     | Some lane ->
+       validate_lane_candidates_capability
+         ~config_path
+         ~route_name:"structured_judge"
+         ~capability_key:"supports-structured-output"
+         ~runtime_supports:supports_structured
+         runtimes
+         lane
+     | None ->
     (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
      | None ->
        Error
@@ -208,9 +297,9 @@ let validate_structured_judge_runtime ~(config_path : string)
             (unresolved_runtime_suffix ~dropped_bindings
                ~runtime_count:(List.length runtimes) id))
      | Some runtime ->
-       (match runtime.model.capabilities with
-        | Some caps when caps.supports_structured_output -> Ok ()
-        | _ ->
+       if supports_structured runtime
+       then Ok ()
+       else
           Error
             (Printf.sprintf
                "%s: [runtime].structured_judge = %S uses model %S, which does \
@@ -728,39 +817,6 @@ let degrade_loaded_for_missing_catalog
     then Some { route_name = runtime_default_route_name; runtime_id = configured_default.id }
     else None
   in
-  let drop_route route_name = function
-    | None -> None, None
-    | Some runtime_id when is_missing runtime_id -> None, Some { route_name; runtime_id }
-    | Some _ as value -> value, None
-  in
-  let librarian_id, librarian_drop = drop_route "[runtime].librarian" librarian_id in
-  let structured_judge_id, structured_judge_drop =
-    drop_route "[runtime].structured_judge" structured_judge_id
-  in
-  let hitl_summary_id, hitl_summary_drop =
-    drop_route "[runtime].hitl_summary" hitl_summary_id
-  in
-  let cross_verifier_id, cross_verifier_drop =
-    drop_route "[runtime].cross_verifier" cross_verifier_id
-  in
-  let dropped_routes =
-    [ default_drop
-    ; librarian_drop
-    ; structured_judge_drop
-    ; hitl_summary_drop
-    ; cross_verifier_drop
-    ]
-    |> List.filter_map Fun.id
-  in
-  let kept_media_failover, dropped_media_failover =
-    List.fold_right
-      (fun runtime_id (kept, dropped) ->
-         if is_missing runtime_id
-         then kept, runtime_id :: dropped
-         else runtime_id :: kept, dropped)
-      media_failover
-      ([], [])
-  in
   let kept_lanes, dropped_lane_candidates, dropped_lanes =
     List.fold_right
       (fun (lane : Runtime_lane.t) (kept, dropped_candidates, dropped_lanes) ->
@@ -797,6 +853,55 @@ let degrade_loaded_for_missing_catalog
            , dropped_lanes ))
       lanes
       ([], [], [])
+  in
+  (* A route id may name a lane (#25394). A lane-targeted route stays live
+     while any candidate survives (the lane itself degrades), and drops only
+     when the whole lane dropped; a runtime-targeted route drops when that
+     runtime is missing. Mirrors [resolve_assignment]'s lane precedence. *)
+  let is_declared_lane id =
+    List.exists (fun lane -> String.equal (Runtime_lane.id lane) id) lanes
+  in
+  let lane_fully_dropped id =
+    List.exists
+      (fun (entry : dropped_runtime_lane) -> String.equal entry.lane_id id)
+      dropped_lanes
+  in
+  let route_unavailable id =
+    if is_declared_lane id then lane_fully_dropped id else is_missing id
+  in
+  let drop_route route_name = function
+    | None -> None, None
+    | Some runtime_id when route_unavailable runtime_id ->
+      None, Some { route_name; runtime_id }
+    | Some _ as value -> value, None
+  in
+  let librarian_id, librarian_drop = drop_route "[runtime].librarian" librarian_id in
+  let structured_judge_id, structured_judge_drop =
+    drop_route "[runtime].structured_judge" structured_judge_id
+  in
+  let hitl_summary_id, hitl_summary_drop =
+    drop_route "[runtime].hitl_summary" hitl_summary_id
+  in
+  let cross_verifier_id, cross_verifier_drop =
+    drop_route "[runtime].cross_verifier" cross_verifier_id
+  in
+  let dropped_routes =
+    [ default_drop
+    ; librarian_drop
+    ; structured_judge_drop
+    ; hitl_summary_drop
+    ; cross_verifier_drop
+    ]
+    |> List.filter_map Fun.id
+  in
+  let kept_media_failover, dropped_media_failover =
+    List.fold_right
+      (fun runtime_id (kept, dropped) ->
+         if is_missing runtime_id
+         then kept, runtime_id :: dropped
+         else runtime_id :: kept, dropped)
+      media_failover
+      ([], [])
   in
   let has_routing_references =
     (not (List.is_empty dropped_assignments))
@@ -894,8 +999,15 @@ let materialize_config
     validate_librarian_runtime ~config_path ~dropped_bindings runtimes
       cfg.librarian_runtime_id
   in
+  (* Lanes are materialized before the judge/verifier route validations so a
+     route id can name a lane (#25394); candidate resolution is enforced by
+     [validate_lanes] inside [lanes_of_decls]. *)
+  let* lanes =
+    lanes_of_decls ~config_path ~dropped_bindings runtimes cfg.lane_decls
+  in
   let* () =
     validate_structured_judge_runtime ~config_path ~dropped_bindings runtimes
+      lanes
       cfg.structured_judge_runtime_id
   in
   let* () =
@@ -904,6 +1016,7 @@ let materialize_config
   in
   let* () =
     validate_cross_verifier_runtime ~config_path ~dropped_bindings runtimes
+      lanes
       cfg.cross_verifier_runtime_id
   in
   let* () =
@@ -914,9 +1027,6 @@ let materialize_config
     if validate_max_context
     then validate_runtime_max_context ~config_path runtimes
     else Ok ()
-  in
-  let* lanes =
-    lanes_of_decls ~config_path ~dropped_bindings runtimes cfg.lane_decls
   in
   (* The OAS catalog membership gate is intentionally not called here:
      [load_list] stays a routing-validity parser for tests and config probes.

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1983,6 +1983,164 @@ let test_structured_judge_runtime_routing () =
            (Fs_compat.load_file path)
            "structured_judge"))
 
+(* #25394 slice 1: [runtime].structured_judge / .cross_verifier accept a
+   [runtime.lanes] id. The capability contract extends to every candidate
+   (the turn-driver lane walk does not re-filter by capability), and
+   validation follows [resolve_assignment]'s lane-over-runtime precedence. *)
+let judge_lane_base =
+  "[providers.local]\n\
+   display-name = \"Local\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11434\"\n\
+   \n\
+   [models.chat]\n\
+   api-name = \"chat\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.judge]\n\
+   api-name = \"judge\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.judge.capabilities]\n\
+   supports-response-format-json = true\n\
+   supports-structured-output = true\n\
+   \n\
+   [models.judge2]\n\
+   api-name = \"judge2\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.judge2.capabilities]\n\
+   supports-response-format-json = true\n\
+   supports-structured-output = true\n\
+   \n\
+   [models.jsononly]\n\
+   api-name = \"jsononly\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.jsononly.capabilities]\n\
+   supports-response-format-json = true\n\
+   supports-structured-output = false\n\
+   \n\
+   [local.chat]\n\
+   \n\
+   [local.judge]\n\
+   \n\
+   [local.judge2]\n\
+   \n\
+   [local.jsononly]\n\
+   \n\
+   [runtime]\n\
+   default = \"local.chat\"\n"
+
+let test_structured_judge_lane_target () =
+  with_fake_runtime_model_catalog @@ fun () ->
+  let capable_lane =
+    judge_lane_base
+    ^ "structured_judge = \"judges\"\n\
+       \n\
+       [runtime.lanes.judges]\n\
+       strategy = \"ordered\"\n\
+       candidates = [\"local.judge\", \"local.judge2\"]\n"
+  in
+  with_temp_runtime_toml capable_lane (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "lane-targeted structured_judge should load: %s" msg
+    | Ok (_, _, _, _, structured_judge, _, _, _, lanes) ->
+      check
+        (option string)
+        "structured_judge keeps the lane id"
+        (Some "judges")
+        structured_judge;
+      check bool "judges lane is materialized" true
+        (List.exists
+           (fun lane -> String.equal (Runtime_lane.id lane) "judges")
+           lanes));
+  let incapable_candidate_lane =
+    judge_lane_base
+    ^ "structured_judge = \"judges\"\n\
+       \n\
+       [runtime.lanes.judges]\n\
+       strategy = \"ordered\"\n\
+       candidates = [\"local.judge\", \"local.jsononly\"]\n"
+  in
+  with_temp_runtime_toml incapable_candidate_lane (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ ->
+      failf
+        "structured_judge lane with a candidate lacking structured output must \
+         be rejected"
+    | Error msg ->
+      check bool "error names the route" true
+        (String_util.contains_substring msg "structured_judge");
+      check bool "error names the incapable candidate" true
+        (String_util.contains_substring msg "local.jsononly");
+      check bool "error names the missing capability" true
+        (String_util.contains_substring msg "supports-structured-output"))
+
+(* A lane that shadows a capable runtime id must be validated as the lane:
+   [resolve_assignment] hands consumers the lane, so validating the shadowed
+   runtime would approve a target the consumer never uses. *)
+let test_structured_judge_lane_shadow_precedence () =
+  with_fake_runtime_model_catalog @@ fun () ->
+  let shadowing_lane =
+    judge_lane_base
+    ^ "structured_judge = \"local.judge\"\n\
+       \n\
+       [runtime.lanes.\"local.judge\"]\n\
+       strategy = \"ordered\"\n\
+       candidates = [\"local.jsononly\"]\n"
+  in
+  with_temp_runtime_toml shadowing_lane (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ ->
+      failf
+        "structured_judge naming a lane that shadows a capable runtime must \
+         be judged as the lane (incapable candidate rejected)"
+    | Error msg ->
+      check bool "error names the incapable shadow candidate" true
+        (String_util.contains_substring msg "local.jsononly"))
+
+let test_cross_verifier_lane_target () =
+  with_fake_runtime_model_catalog @@ fun () ->
+  let json_capable_lane =
+    judge_lane_base
+    ^ "cross_verifier = \"verifiers\"\n\
+       \n\
+       [runtime.lanes.verifiers]\n\
+       strategy = \"ordered\"\n\
+       candidates = [\"local.judge\", \"local.jsononly\"]\n"
+  in
+  with_temp_runtime_toml json_capable_lane (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "lane-targeted cross_verifier should load: %s" msg
+    | Ok (_, _, _, _, _, _, cross_verifier, _, _) ->
+      check
+        (option string)
+        "cross_verifier keeps the lane id"
+        (Some "verifiers")
+        cross_verifier);
+  let json_incapable_lane =
+    judge_lane_base
+    ^ "cross_verifier = \"verifiers\"\n\
+       \n\
+       [runtime.lanes.verifiers]\n\
+       strategy = \"ordered\"\n\
+       candidates = [\"local.judge\", \"local.chat\"]\n"
+  in
+  with_temp_runtime_toml json_incapable_lane (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ ->
+      failf
+        "cross_verifier lane with a candidate lacking JSON mode must be \
+         rejected"
+    | Error msg ->
+      check bool "error names the route" true
+        (String_util.contains_substring msg "cross_verifier");
+      check bool "error names the incapable candidate" true
+        (String_util.contains_substring msg "local.chat");
+      check bool "error names the missing capability" true
+        (String_util.contains_substring msg "supports-response-format-json"))
+
 let test_hitl_summary_runtime_routing () =
   let base =
     "[providers.local]\n\
@@ -2364,6 +2522,15 @@ let () =
           test_case
             "[runtime].structured_judge resolves and rejects unsupported models"
             `Quick test_structured_judge_runtime_routing;
+          test_case
+            "[runtime].structured_judge accepts capability-complete lanes"
+            `Quick test_structured_judge_lane_target;
+          test_case
+            "[runtime].structured_judge validates shadowing lanes as lanes"
+            `Quick test_structured_judge_lane_shadow_precedence;
+          test_case
+            "[runtime].cross_verifier accepts JSON-capable lanes"
+            `Quick test_cross_verifier_lane_target;
           test_case
             "[runtime].hitl_summary resolves, refreshes, and rejects unknown ids"
             `Quick test_hitl_summary_runtime_routing;


### PR DESCRIPTION
## 문제 (#25394 slice 1)

[runtime].structured_judge / cross_verifier가 단일 runtime id만 수용해, 단일 provider quota 장애가 failure judge / board attention judge / done-verification을 동시 정지시켰습니다(07-19 minimax weekly limit 실측 선례). compaction만 lane-capable인 비대칭.

## 변경

- 두 route가 [runtime.lanes] id도 수용. 검증은 resolve_assignment의 lane-over-runtime 우선순위를 따르며(lane 먼저), **모든 lane 후보**가 해당 route의 capability(structured output / JSON mode)를 선언해야 로드 통과 — turn driver lane walk는 capability 재필터링을 하지 않으므로 후보 하나라도 미달이면 failover 중 계약이 조용히 강등되기 때문(fail-closed 유지).
- catalog degradation: lane 대상 route는 후보가 하나라도 생존하면 유지(lane 자체가 내부 degrade), 전체 소실 시에만 route drop.
- 소비자 변경 0: failure judge(keeper_failure_judge.ml:82)·board attention judge(keeper_board_attention_candidate.ml:1007)·anti-rationalization evaluator(workspace_metric_hooks→run_named)는 lane-aware run_named 경유, compaction은 이미 resolve_assignment로 확장(candidates_for_assignment).

## 잠재 버그 동시 수리

기존 검증은 shadow 케이스(lane id == runtime id)에서 **runtime을 검증하고 소비자는 lane을 해석**하는 불일치 — 무능한 후보로 구성된 shadowing lane이 로드를 통과했습니다. shadow-precedence 테스트로 pin.

## 검증

- counterfactual: 신규 테스트 3건이 수정 전 runtime.ml에서 전부 FAIL(lane id 거부 + shadow 오승인), 수정 후 41/41 green.
- 인접 스위트: test_keeper_turn_driver_failover 17/17, test_runtime_per_keeper_routing 40/40 green. 변경 파일 ocamlformat clean.

## 미포함(후속)

- librarian/hitl_summary는 run_named를 경유하지 않는 직접 provider_config 경로라 이번 slice에서 제외(#25394 본문 참조).
- [runtime.assignments]→lane은 예산 계약 설계 필요(#25393).

관련: #25394, #25401, 감사 리포트 ~/me/reports/masc-lane-audit-2026-07-20.md

RFC-WAIVED: 기존 lane/route 검증 계약의 표면 확장 + 잠재 검증 불일치 수리. 아키텍처 신설 없음(lane 메커니즘·capability 게이트 재사용). 예산/배정 등 설계 결정 항목은 #25393/#25394로 분리.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
