### PR TITLE
feat(mcp): expose masc_keeper_compact on the public MCP surface

### DIFF
--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -88,6 +88,13 @@ let public_mcp_surface_tools =
   ; "masc_keeper_waiting_inventory"
   ; "masc_keeper_up"
   ; "masc_keeper_down"
+  ; (* Compaction is the operator's escape hatch for a keeper whose context has
+       outgrown its provider window. It was reachable only from the keeper tool
+       surface, so an operator observing the overflow could not act on it from
+       the MCP front door. [masc_keeper_clear] stays off this surface on
+       purpose: it wipes transcript messages, which is a different decision
+       from asking a keeper to compact. *)
+    "masc_keeper_compact"
   ; (* Persona authoring is operator-visible. *)
     "masc_persona_list"
   ; "masc_persona_create"

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -812,6 +812,31 @@ let test_property_types_valid () =
   ) schema_inventory
 
 (* ============================================================ *)
+(* Keeper runtime front door                                     *)
+(* ============================================================ *)
+
+(* A keeper whose context outgrows its provider window cannot shrink it on its
+   own, so an explicit compaction request is the operator's escape hatch. It
+   must therefore be reachable from the MCP front door, not only from the
+   keeper-internal tool surface. *)
+let test_keeper_compact_is_public_mcp () =
+  Alcotest.(check bool)
+    "masc_keeper_compact is on the public MCP surface"
+    true
+    (Masc.Tool_catalog.is_public_mcp "masc_keeper_compact")
+;;
+
+(* Pin the deliberate scope boundary: [masc_keeper_clear] wipes transcript
+   messages, which is a different operator decision from asking a keeper to
+   compact. Opening the escape hatch must not also expose the destructive one. *)
+let test_keeper_clear_stays_internal () =
+  Alcotest.(check bool)
+    "masc_keeper_clear stays off the public MCP surface"
+    false
+    (Masc.Tool_catalog.is_public_mcp "masc_keeper_clear")
+;;
+
+(* ============================================================ *)
 (* Test Runner                                                   *)
 (* ============================================================ *)
 
@@ -913,5 +938,11 @@ let () =
       Alcotest.test_case "description_not_long" `Quick test_description_not_too_long;
       Alcotest.test_case "no_duplicate_props" `Quick test_no_duplicate_properties;
       Alcotest.test_case "valid_prop_types" `Quick test_property_types_valid;
+    ];
+    "keeper_front_door", [
+      Alcotest.test_case "compact_is_public_mcp" `Quick
+        test_keeper_compact_is_public_mcp;
+      Alcotest.test_case "clear_stays_internal" `Quick
+        test_keeper_clear_stays_internal;
     ];
   ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -823,7 +823,7 @@ let test_keeper_compact_is_public_mcp () =
   Alcotest.(check bool)
     "masc_keeper_compact is on the public MCP surface"
     true
-    (Masc.Tool_catalog.is_public_mcp "masc_keeper_compact")
+    (Tool_catalog.is_public_mcp "masc_keeper_compact")
 ;;
 
 (* Pin the deliberate scope boundary: [masc_keeper_clear] wipes transcript
@@ -833,7 +833,7 @@ let test_keeper_clear_stays_internal () =
   Alcotest.(check bool)
     "masc_keeper_clear stays off the public MCP surface"
     false
-    (Masc.Tool_catalog.is_public_mcp "masc_keeper_clear")
+    (Tool_catalog.is_public_mcp "masc_keeper_clear")
 ;;
 
 (* ============================================================ *)


### PR DESCRIPTION
## 목표

`masc_keeper_compact`를 **공개 MCP 표면에 노출**해요. 운영자가 컨텍스트 오버플로를 보고도 손쓸 수단이 없던 문제를 해소합니다.

## 문제

keeper의 컨텍스트가 프로바이더 윈도우를 넘으면 **스스로 줄일 수 없어요**. 명시적 컴팩션 요청이 유일한 탈출구인데, 그 도구가 `public_mcp_surface_tools`에 없어서 `tools/list`에 뜨지 않았어요.

라이브 사례: 한 keeper가 선언된 윈도우 **203,000에 대해 입력 276,173 토큰**(136% 초과) 상태인데, MCP front door에서 컴팩션을 요청할 방법이 없었어요.

## 왜 한 줄이면 되는가

도구는 **이미 MCP로 호출 가능**했어요 — `Mcp_server_eio_execute`가 구동하는 `Keeper_dispatch_ref.dispatch` 훅에 등록돼 있고(`keeper_tool_surface.ml`), 스키마(`keeper_schema.ml`)와 descriptor(`keeper_tool_descriptor.ml`)도 갖춰져 있어요. **발견(discovery)만 빠져 있던 상태**라, SSOT인 `Tool_catalog_surfaces.public_mcp_surface_tools`의 "Keeper runtime front door" 그룹에 이름 하나를 추가하면 돼요. 새 dispatch도, 새 스키마도 필요 없어요.

## 범위를 하나로 좁힌 이유

바로 아래 `masc_keeper_clear`는 **함께 노출하지 않았어요**. 그건 transcript 메시지를 지우는 도구라, "keeper에게 압축을 요청한다"와는 **다른 운영 결정**이에요. 탈출구를 여는 것이 파괴 버튼까지 노출하는 일이 되면 안 돼요.

## 테스트

두 방향을 모두 고정했어요:
- `masc_keeper_compact`가 공개 표면에 **있음**
- `masc_keeper_clear`는 공개 표면에 **없음** (의도적 경계가 나중에 조용히 무너지지 않도록)

## 검증

- 로컬 dune 빌드 미실행 — CI가 빌드 권위예요.
- 표면 카운트 테스트는 하한(`>= 50`)이라 항목 추가로 깨지지 않고, tool matrix는 `| _ -> []` catch-all이라 케이스 추가가 불필요해요(확인함).

## 관련

RFC-0346(#25405)이 **자동** admission 복구를 다뤄요. 이 PR은 그와 독립적으로 **운영자 수동 경로**를 여는 것이고, 자동화가 서기 전까지의 유일한 실무 수단이에요.

RFC-WAIVED: tool 표면 노출 한 줄 + 테스트. credential/identity/operator-control/sandbox/hooks/workflow subsystem 무관.
