### PR TITLE
feat(keeper-memory): sweep expired episodes in retention GC

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1178,9 +1178,10 @@ let memory_os_gc_dry_run_cmd_exit base_path keeper_ids as_json =
 
 let memory_os_gc_dry_run_cmd =
   let doc =
-    "Run the Memory OS fact-store GC in dry-run mode and print the TTL/dedup \
-     report without rewriting stores. The scan still takes each keeper fact-store \
-     lock; contended stores are reported as per-keeper errors."
+    "Run the Memory OS GC (fact store and episode store) in dry-run mode and \
+     print the TTL report without rewriting or deleting anything. The scan \
+     still takes each keeper store lock; contended stores are reported as \
+     per-keeper errors."
   in
   let info = Cmd.info "memory-os-gc-dry-run" ~doc in
   Cmd.v info

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -38,10 +38,12 @@ let keeper_status_fast_default () : bool =
    Keeper_memory_os_recall.render_context_exn injected the keeper's ENTIRE
    current fact/episode store into every turn's prompt -- no selection
    contract existed, so a keeper that accumulated facts/episodes without
-   bound (no retention existed either -- see the episode retention wired
-   into Keeper_memory_os_gc below) grew its per-turn prompt injection
-   without limit. These three knobs are the boundary: how many facts, how
-   many episodes, and how many rendered bytes recall may inject per turn.
+   bound grew its per-turn prompt injection without limit. (Retention for
+   both stores lives in Keeper_memory_os_gc: run_gc deletes facts and
+   run_episode_gc deletes episode files, each only past the exact
+   producer-declared valid_until, default-on from the maintenance fiber.)
+   These three knobs are the boundary: how many facts, how many episodes,
+   and how many rendered bytes recall may inject per turn.
 
    Defaults are set at/above the largest volume observed in the 2026-07-17
    lane analysis that diagnosed this (~300 facts, ~380 episode summaries,

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -1,4 +1,5 @@
-(** Keeper_memory_os_gc — exact explicit-expiry cleanup for facts. *)
+(** Keeper_memory_os_gc — exact explicit-expiry cleanup for facts and episode
+    files. *)
 
 open Keeper_memory_os_types
 
@@ -133,6 +134,95 @@ let run_gc_for_keepers_dir ~keepers_dir ?dry_run ~keeper_id ~now () =
       Io.read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id)
     ~rewrite_facts_atomically:(fun facts ->
       Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts)
+    ?dry_run
+    ~keeper_id
+    ~now
+    ()
+;;
+
+(** {1 Episode-store retention sweep} *)
+
+type episode_gc_report =
+  { episodes_total : int
+  ; episodes_expired : int
+  ; episodes_deleted : int
+  ; dry_run : bool
+  }
+
+exception Episode_store_corrupt of string
+
+(* Same exact producer validity boundary as [ttl_expired]: [ts >= now] is
+   current, anything strictly past expires, and an absent [valid_until] never
+   expires. No created_at- or age-derived fallback participates. *)
+let episode_ttl_expired ~now (episode : episode) =
+  match episode.valid_until with
+  | None -> false
+  | Some ts -> not (ts >= now)
+;;
+
+(* The episode store is one [trace-generation-timestamp].json file per episode
+   under [keeper_id/episodes/], so the sweep classifies-then-deletes per file
+   instead of the facts read-modify-rewrite. Both phases run under the same
+   per-keeper episode-bundle lock the librarian write path
+   (Keeper_librarian_runtime, via [Io.with_episode_bundle_lock]) holds when it
+   publishes an episode, so the sweep cannot remove a file a concurrent writer
+   is mid-publish on. Same discipline as the facts sweep: strict read, and one
+   malformed episode file aborts the sweep with every file — expired or not —
+   left on disk and the error raised (preserve over delete). A failed
+   [Sys.remove] is equally loud. Must run inside an Eio context, like
+   [run_gc]. *)
+let run_episode_gc_with_store
+      ~lock_path
+      ~read_episode_files_all_strict
+      ~delete_episode_file
+      ?(dry_run = false)
+      ~keeper_id
+      ~now
+      ()
+  =
+  File_lock_eio.with_lock lock_path (fun () ->
+    match read_episode_files_all_strict () with
+    | Error message ->
+      raise (Episode_store_corrupt ("memory os gc episode store read failed: " ^ message))
+    | Ok stored ->
+      let expired =
+        List.filter (fun (_path, episode) -> episode_ttl_expired ~now episode) stored
+      in
+      let expired_count = List.length expired in
+      if not dry_run
+      then (
+        List.iter (fun (path, _episode) -> delete_episode_file path) expired;
+        if expired_count > 0
+        then
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string MemoryOsEpisodeRetentionPruned)
+            ~labels:[ "keeper", keeper_id ]
+            ~delta:(float_of_int expired_count)
+            ());
+      { episodes_total = List.length stored
+      ; episodes_expired = expired_count
+      ; episodes_deleted = (if dry_run then 0 else expired_count)
+      ; dry_run
+      })
+;;
+
+let run_episode_gc ?dry_run ~keeper_id ~now () =
+  run_episode_gc_with_store
+    ~lock_path:(Io.episode_bundle_lock_path ~keeper_id)
+    ~read_episode_files_all_strict:(fun () -> Io.read_episode_files_all_strict ~keeper_id)
+    ~delete_episode_file:Sys.remove
+    ?dry_run
+    ~keeper_id
+    ~now
+    ()
+;;
+
+let run_episode_gc_for_keepers_dir ~keepers_dir ?dry_run ~keeper_id ~now () =
+  run_episode_gc_with_store
+    ~lock_path:(Io.episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~read_episode_files_all_strict:(fun () ->
+      Io.read_episode_files_all_strict_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~delete_episode_file:Sys.remove
     ?dry_run
     ~keeper_id
     ~now

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -1,4 +1,4 @@
-(** Deterministic garbage collection for Memory OS facts. *)
+(** Deterministic garbage collection for Memory OS facts and episode files. *)
 
 open Keeper_memory_os_types
 
@@ -42,3 +42,47 @@ val run_gc_for_keepers_dir
   -> now:float
   -> unit
   -> gc_report
+
+(** Outcome of the episode-store retention sweep. [episodes_expired] counts
+    files past their explicit [valid_until] (what a [dry_run] would delete);
+    [episodes_deleted] is the number actually removed — always 0 on a dry run. *)
+type episode_gc_report =
+  { episodes_total : int
+  ; episodes_expired : int
+  ; episodes_deleted : int
+  ; dry_run : bool
+  }
+
+exception Episode_store_corrupt of string
+
+(** [episode_ttl_expired ~now episode] uses only the exact producer-supplied
+    [valid_until], with the same boundary as {!ttl_expired}: [ts >= now] is
+    current; an absent [valid_until] never expires. *)
+val episode_ttl_expired : now:float -> episode -> bool
+
+(** Run the deterministic explicit-expiry sweep over one keeper's episode
+    files. Unless [dry_run], deletes each episode file past its exact
+    [valid_until] (counted in
+    [Keeper_metrics.MemoryOsEpisodeRetentionPruned] with the [keeper] label);
+    every other file stays byte-identical.
+
+    The episode store is one JSON file per episode, so the sweep is
+    classify-then-delete per file rather than the facts read-modify-rewrite.
+    Both phases run under the same per-keeper episode-bundle lock the librarian
+    write path holds when publishing an episode — must be called inside an Eio
+    context. Reads strictly: a malformed episode file raises
+    [Episode_store_corrupt] and leaves every file, expired or not, on disk. *)
+val run_episode_gc
+  :  ?dry_run:bool
+  -> keeper_id:string
+  -> now:float
+  -> unit
+  -> episode_gc_report
+
+val run_episode_gc_for_keepers_dir
+  :  keepers_dir:string
+  -> ?dry_run:bool
+  -> keeper_id:string
+  -> now:float
+  -> unit
+  -> episode_gc_report

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -1,8 +1,10 @@
-(** Read-only operator report for Memory OS fact-store GC dry-runs. *)
+(** Read-only operator report for Memory OS GC dry-runs (fact store + episode
+    store). *)
 
 type keeper_error =
   | Missing_fact_store of { facts_path : string }
   | Corrupt_fact_store of { message : string }
+  | Corrupt_episode_store of { message : string }
   | Fact_store_access_error of { message : string }
   | Fact_store_locked of
       { caller : string
@@ -19,6 +21,8 @@ type keeper_result =
       ; ttl_expired_non_ephemeral : int
       ; ttl_expired_by_category : (string * int) list
       ; written : int
+      ; episodes_total : int
+      ; episodes_expired : int
       }
   | Keeper_error of
       { keeper_id : string
@@ -34,6 +38,8 @@ type t =
   ; ttl_expired_non_ephemeral : int
   ; ttl_expired_by_category : (string * int) list
   ; written : int
+  ; episodes_total : int
+  ; episodes_expired : int
   ; error_count : int
   }
 
@@ -59,7 +65,9 @@ let access_error_message = function
 
 let keeper_error_message = function
   | Missing_fact_store { facts_path } -> Printf.sprintf "fact store not found: %s" facts_path
-  | Corrupt_fact_store { message } | Fact_store_access_error { message } -> message
+  | Corrupt_fact_store { message }
+  | Corrupt_episode_store { message }
+  | Fact_store_access_error { message } -> message
   | Fact_store_locked { caller; lock_path; attempts } ->
     Printf.sprintf
       "fact store lock timeout: caller=%s lock_path=%s attempts=%d"
@@ -71,6 +79,7 @@ let keeper_error_message = function
 let keeper_error_code = function
   | Missing_fact_store _ -> "fact_store_missing"
   | Corrupt_fact_store _ -> "fact_store_corrupt"
+  | Corrupt_episode_store _ -> "episode_store_corrupt"
   | Fact_store_access_error _ -> "fact_store_access_error"
   | Fact_store_locked _ -> "fact_store_locked"
 ;;
@@ -98,16 +107,45 @@ let default_run_gc_for_keepers_dir ~keepers_dir ~dry_run ~keeper_id ~now () =
     ()
 ;;
 
-let run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now =
+let default_run_episode_gc_for_keepers_dir ~keepers_dir ~dry_run ~keeper_id ~now () =
+  Keeper_memory_os_gc.run_episode_gc_for_keepers_dir
+    ~keepers_dir
+    ~dry_run
+    ~keeper_id
+    ~now
+    ()
+;;
+
+let run_one
+      ~keepers_dir
+      ~run_gc_for_keepers_dir
+      ~run_episode_gc_for_keepers_dir
+      ~explicit
+      ~keeper_id
+      ~now
+  =
   let facts_path =
     Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id
   in
-  if explicit && not (Sys.file_exists facts_path)
+  (* A keeper with an episode store but no [*.facts.jsonl] (episodes whose
+     claims were all empty) is still a scannable store — only a keeper with
+     neither store is missing. *)
+  if explicit
+     && (not (Sys.file_exists facts_path))
+     && not (Keeper_memory_os_io.has_episode_store_for_keepers_dir ~keepers_dir ~keeper_id)
   then fact_store_missing_error ~keepers_dir ~keeper_id
   else (
     try
       let (report : Keeper_memory_os_gc.gc_report) =
         run_gc_for_keepers_dir
+          ~keepers_dir
+          ~dry_run:true
+          ~keeper_id
+          ~now
+          ()
+      in
+      let (episode_report : Keeper_memory_os_gc.episode_gc_report) =
+        run_episode_gc_for_keepers_dir
           ~keepers_dir
           ~dry_run:true
           ~keeper_id
@@ -122,6 +160,8 @@ let run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now =
         ; ttl_expired_non_ephemeral = report.ttl_expired_non_ephemeral
         ; ttl_expired_by_category = report.ttl_expired_by_category
         ; written = report.written
+        ; episodes_total = episode_report.episodes_total
+        ; episodes_expired = episode_report.episodes_expired
         }
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -130,6 +170,8 @@ let run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now =
         { keeper_id; error = Fact_store_locked { caller; lock_path = path; attempts } }
     | Keeper_memory_os_gc.Fact_store_corrupt message ->
       Keeper_error { keeper_id; error = Corrupt_fact_store { message } }
+    | Keeper_memory_os_gc.Episode_store_corrupt message ->
+      Keeper_error { keeper_id; error = Corrupt_episode_store { message } }
     | exn ->
       (match access_error_message exn with
        | Some message -> Keeper_error { keeper_id; error = Fact_store_access_error { message } }
@@ -139,6 +181,7 @@ let run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now =
 let run_for_keepers_dir_with_runner
       ~keepers_dir
       ~run_gc_for_keepers_dir
+      ~run_episode_gc_for_keepers_dir
       ?keeper_ids
       ~now
       ()
@@ -148,12 +191,22 @@ let run_for_keepers_dir_with_runner
     | Some ids -> true, unique_sorted ids
     | None ->
       ( false
-      , Keeper_memory_os_io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir )
+      , List.sort_uniq
+          String.compare
+          (Keeper_memory_os_io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir
+           @ Keeper_memory_os_io.list_episode_store_keeper_ids_for_keepers_dir ~keepers_dir)
+      )
   in
   let results =
     List.map
       (fun keeper_id ->
-         run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now)
+         run_one
+           ~keepers_dir
+           ~run_gc_for_keepers_dir
+           ~run_episode_gc_for_keepers_dir
+           ~explicit
+           ~keeper_id
+           ~now)
       keeper_ids
   in
   let
@@ -163,6 +216,8 @@ let run_for_keepers_dir_with_runner
     ttl_expired_non_ephemeral,
     ttl_expired_by_category,
     written,
+    episodes_total,
+    episodes_expired,
     error_count
     =
     List.fold_left
@@ -173,6 +228,8 @@ let run_for_keepers_dir_with_runner
         , ttl_expired_non_ephemeral
         , ttl_expired_by_category
         , written
+        , episodes_total
+        , episodes_expired
         , error_count )
         -> function
          | Keeper_ok row ->
@@ -182,6 +239,8 @@ let run_for_keepers_dir_with_runner
            , ttl_expired_non_ephemeral + row.ttl_expired_non_ephemeral
            , merge_category_counts ttl_expired_by_category row.ttl_expired_by_category
            , written + row.written
+           , episodes_total + row.episodes_total
+           , episodes_expired + row.episodes_expired
            , error_count )
          | Keeper_error _ ->
            ( total_input
@@ -190,8 +249,10 @@ let run_for_keepers_dir_with_runner
            , ttl_expired_non_ephemeral
            , ttl_expired_by_category
            , written
+           , episodes_total
+           , episodes_expired
            , error_count + 1 ))
-      (0, 0, 0, 0, [], 0, 0)
+      (0, 0, 0, 0, [], 0, 0, 0, 0)
       results
   in
   { keepers_dir
@@ -202,6 +263,8 @@ let run_for_keepers_dir_with_runner
   ; ttl_expired_non_ephemeral
   ; ttl_expired_by_category
   ; written
+  ; episodes_total
+  ; episodes_expired
   ; error_count
   }
 ;;
@@ -210,16 +273,25 @@ let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
   run_for_keepers_dir_with_runner
     ~keepers_dir
     ~run_gc_for_keepers_dir:default_run_gc_for_keepers_dir
+    ~run_episode_gc_for_keepers_dir:default_run_episode_gc_for_keepers_dir
     ?keeper_ids
     ~now
     ()
 ;;
 
 module For_testing = struct
-  let run_for_keepers_dir ~keepers_dir ~run_gc_for_keepers_dir ?keeper_ids ~now () =
+  let run_for_keepers_dir
+        ~keepers_dir
+        ~run_gc_for_keepers_dir
+        ~run_episode_gc_for_keepers_dir
+        ?keeper_ids
+        ~now
+        ()
+    =
     run_for_keepers_dir_with_runner
       ~keepers_dir
       ~run_gc_for_keepers_dir
+      ~run_episode_gc_for_keepers_dir
       ?keeper_ids
       ~now
       ()
@@ -241,6 +313,8 @@ let result_to_json = function
       ; "ttl_expired_non_ephemeral", `Int row.ttl_expired_non_ephemeral
       ; "ttl_expired_by_category", category_counts_to_json row.ttl_expired_by_category
       ; "written", `Int row.written
+      ; "episodes_total", `Int row.episodes_total
+      ; "episodes_expired", `Int row.episodes_expired
       ]
   | Keeper_error row ->
     Tool_args.error_assoc
@@ -263,6 +337,8 @@ let to_json report =
     ; "ttl_expired_non_ephemeral", `Int report.ttl_expired_non_ephemeral
     ; "ttl_expired_by_category", category_counts_to_json report.ttl_expired_by_category
     ; "written", `Int report.written
+    ; "episodes_total", `Int report.episodes_total
+    ; "episodes_expired", `Int report.episodes_expired
     ; "keepers", `List (List.map result_to_json report.results)
     ]
 ;;
@@ -270,13 +346,15 @@ let to_json report =
 let render_result = function
   | Keeper_ok row ->
     Printf.sprintf
-      "%s\tok\ttotal=%d\tttl_expired=%d\tephemeral_expired=%d\tnon_ephemeral_expired=%d\twould_write=%d\n"
+      "%s\tok\ttotal=%d\tttl_expired=%d\tephemeral_expired=%d\tnon_ephemeral_expired=%d\twould_write=%d\tepisodes_total=%d\tepisodes_expired=%d\n"
       row.keeper_id
       row.total_input
       row.ttl_expired
       row.ttl_expired_ephemeral
       row.ttl_expired_non_ephemeral
       row.written
+      row.episodes_total
+      row.episodes_expired
   | Keeper_error row ->
     Printf.sprintf
       "%s\t%s\t%s\n"
@@ -288,14 +366,14 @@ let render_result = function
 let render_text report =
   let body =
     match report.results with
-    | [] -> "no keeper fact stores found\n"
+    | [] -> "no keeper memory stores found\n"
     | rows -> rows |> List.map render_result |> String.concat ""
   in
   Printf.sprintf
     "Memory OS GC dry-run\n\
      keepers_dir: %s\n\
      keepers: %d, errors: %d\n\
-     totals: total=%d ttl_expired=%d ephemeral_expired=%d non_ephemeral_expired=%d would_write=%d\n\
+     totals: total=%d ttl_expired=%d ephemeral_expired=%d non_ephemeral_expired=%d would_write=%d episodes_total=%d episodes_expired=%d\n\
      %s"
     report.keepers_dir
     (List.length report.results)
@@ -305,5 +383,7 @@ let render_text report =
     report.ttl_expired_ephemeral
     report.ttl_expired_non_ephemeral
     report.written
+    report.episodes_total
+    report.episodes_expired
     body
 ;;

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
@@ -1,8 +1,10 @@
-(** Read-only operator report for Memory OS fact-store GC dry-runs. *)
+(** Read-only operator report for Memory OS GC dry-runs (fact store + episode
+    store). *)
 
 type keeper_error =
   | Missing_fact_store of { facts_path : string }
   | Corrupt_fact_store of { message : string }
+  | Corrupt_episode_store of { message : string }
   | Fact_store_access_error of { message : string }
   | Fact_store_locked of
       { caller : string
@@ -19,6 +21,8 @@ type keeper_result =
       ; ttl_expired_non_ephemeral : int
       ; ttl_expired_by_category : (string * int) list
       ; written : int
+      ; episodes_total : int
+      ; episodes_expired : int
       }
   | Keeper_error of
       { keeper_id : string
@@ -34,6 +38,8 @@ type t =
   ; ttl_expired_non_ephemeral : int
   ; ttl_expired_by_category : (string * int) list
   ; written : int
+  ; episodes_total : int
+  ; episodes_expired : int
   ; error_count : int
   }
 
@@ -43,12 +49,14 @@ val run_for_keepers_dir
   -> now:float
   -> unit
   -> t
-(** Scan keeper fact stores and run {!Keeper_memory_os_gc.run_gc_for_keepers_dir}
-    with [dry_run:true]. Must be called inside an Eio context because the GC
-    path takes the per-keeper facts lock. If [keeper_ids] is omitted, every
-    existing non-shared [*.facts.jsonl] store in [keepers_dir] is scanned. If it
-    is provided, missing stores are reported as per-keeper errors instead of
-    silently returning an empty report. *)
+(** Scan keeper memory stores and run
+    {!Keeper_memory_os_gc.run_gc_for_keepers_dir} and
+    {!Keeper_memory_os_gc.run_episode_gc_for_keepers_dir} with [dry_run:true].
+    Must be called inside an Eio context because the GC paths take the
+    per-keeper store locks. If [keeper_ids] is omitted, every existing
+    non-shared fact store or episode store in [keepers_dir] is scanned. If it
+    is provided, keepers with neither store are reported as per-keeper errors
+    instead of silently returning an empty report. *)
 
 module For_testing : sig
   val run_for_keepers_dir
@@ -60,6 +68,13 @@ module For_testing : sig
           -> now:float
           -> unit
           -> Keeper_memory_os_gc.gc_report)
+    -> run_episode_gc_for_keepers_dir:
+         (keepers_dir:string
+          -> dry_run:bool
+          -> keeper_id:string
+          -> now:float
+          -> unit
+          -> Keeper_memory_os_gc.episode_gc_report)
     -> ?keeper_ids:string list
     -> now:float
     -> unit

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -74,6 +74,35 @@ let list_fact_store_keeper_ids () =
   list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir:(keepers_dir ())
 ;;
 
+(* Read-only existence check — unlike [episodes_dir_for_keepers_dir] it never
+   creates the directory. *)
+let has_episode_store_for_keepers_dir ~keepers_dir ~keeper_id =
+  let dir = Filename.concat keepers_dir (Filename.concat keeper_id "episodes") in
+  Sys.file_exists dir && Sys.is_directory dir
+;;
+
+(* Keeper ids with an on-disk episode store ([<id>/episodes/]), for the episode
+   retention sweep. A keeper whose extracted episodes all carried zero claims
+   has no [*.facts.jsonl] but still accumulates episode files, so the sweep
+   cannot enumerate from fact stores alone. The reserved shared id is excluded;
+   sorted for deterministic sweep order. *)
+let list_episode_store_keeper_ids_for_keepers_dir ~keepers_dir =
+  let dir = keepers_dir in
+  if not (Sys.file_exists dir && Sys.is_directory dir)
+  then []
+  else
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter (fun name ->
+      (not (String.equal name shared_store_id))
+      && has_episode_store_for_keepers_dir ~keepers_dir ~keeper_id:name)
+    |> List.sort String.compare
+;;
+
+let list_episode_store_keeper_ids () =
+  list_episode_store_keeper_ids_for_keepers_dir ~keepers_dir:(keepers_dir ())
+;;
+
 let list_fact_store_keeper_ids_for_base_path ~base_path =
   list_fact_store_keeper_ids_for_keepers_dir
     ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
@@ -111,8 +140,12 @@ let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
+let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat keepers_dir (keeper_id ^ ".episode-bundle")
+;;
+
 let episode_bundle_lock_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".episode-bundle")
+  episode_bundle_lock_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
@@ -640,6 +673,58 @@ let read_episode_file path =
        let len = in_channel_length ic in
        let buf = really_input_string ic len in
        parse_json_line episode_of_json buf)
+;;
+
+(* Strict counterpart of [read_episode_file]: a malformed episode file is an
+   [Error], not a silently dropped [None] — a destructive sweep must classify
+   the whole store before deleting anything (same preserve-over-delete rule as
+   [read_facts_all_strict]). *)
+let parse_episode_file_strict ~path buf =
+  try
+    match episode_of_json (Yojson.Safe.from_string buf) with
+    | Some episode -> Ok (path, episode)
+    | None -> Error (Printf.sprintf "%s: invalid episode JSON shape" path)
+  with
+  | Yojson.Json_error message ->
+    Error (Printf.sprintf "%s: invalid episode JSON: %s" path message)
+;;
+
+let read_episode_file_strict path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       let buf = really_input_string ic len in
+       parse_episode_file_strict ~path buf)
+;;
+
+(* Every [<keeper_id>/episodes/*.json] file as [(path, episode)] in filename
+   order. Never creates the directory: a keeper with no episode store is
+   [Ok []], not a side effect. *)
+let read_episode_files_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+  let dir = Filename.concat keepers_dir (Filename.concat keeper_id "episodes") in
+  if not (Sys.file_exists dir && Sys.is_directory dir)
+  then Ok []
+  else (
+    let paths =
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (fun name -> Filename.check_suffix name ".json")
+      |> List.sort String.compare
+      |> List.map (fun name -> Filename.concat dir name)
+    in
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | path :: rest ->
+        let* parsed = read_episode_file_strict path in
+        loop (parsed :: acc) rest
+    in
+    loop [] paths)
+;;
+
+let read_episode_files_all_strict ~keeper_id =
+  read_episode_files_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
 let compare_episode_recency a b =

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -15,6 +15,16 @@ val facts_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> strin
 val list_fact_store_keeper_ids : unit -> string list
 val list_fact_store_keeper_ids_for_keepers_dir : keepers_dir:string -> string list
 
+(** Keeper ids that currently have an on-disk episode store ([<id>/episodes/]).
+    A keeper whose episodes all carried zero claims has no [*.facts.jsonl] but
+    still accumulates episode files, so episode sweeps cannot enumerate from
+    fact stores alone. Excludes the reserved shared id; sorted. *)
+val list_episode_store_keeper_ids : unit -> string list
+val list_episode_store_keeper_ids_for_keepers_dir : keepers_dir:string -> string list
+
+(** Read-only check for an on-disk episode store; never creates the directory. *)
+val has_episode_store_for_keepers_dir : keepers_dir:string -> keeper_id:string -> bool
+
 (** Base-path-scoped variant of {!list_fact_store_keeper_ids}; avoids ambient
     config-dir reads in multi-workspace dashboard routes. *)
 val list_fact_store_keeper_ids_for_base_path : base_path:string -> string list
@@ -71,6 +81,12 @@ val with_out_channel : out_channel -> f:(out_channel -> unit) -> unit
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
+
+(** Lock path used by {!with_episode_bundle_lock}; the episode retention sweep
+    serializes against episode writers on the same lock. *)
+val episode_bundle_lock_path : keeper_id:string -> string
+val episode_bundle_lock_path_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> string
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
@@ -130,6 +146,15 @@ val read_episodes_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_all : keeper_id:string -> episode list
 (** Read every persisted episode in source order. Any malformed row/file raises;
     no child episode is silently dropped. *)
+
+(** Strict episode-file read for destructive sweeps: every
+    [<keeper_id>/episodes/*.json] file as [(path, episode)] in filename order,
+    or [Error] on the first malformed file. Never creates the episodes
+    directory — a keeper with no episode store is [Ok []]. *)
+val read_episode_files_all_strict :
+  keeper_id:string -> ((string * episode) list, string) result
+val read_episode_files_all_strict_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> ((string * episode) list, string) result
 
 (** Read and parse every fact in the store. *)
 val read_all_facts : keeper_id:string -> fact list

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -306,9 +306,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       loop ());
   (* RFC-0247 §2.3: memory-os expiry sweep. Off the keeper hot path — every
      [interval]s it runs the deterministic per-keeper GC: facts whose explicit
-     [valid_until] has passed are removed and every other row is preserved.
-     Default ON; env var [MASC_KEEPER_MEMORY_OS_GC] is the kill switch. Per-keeper
-     fibers run in parallel. *)
+     [valid_until] has passed are removed and every other row is preserved, and
+     episode files past their explicit [valid_until] are deleted under the
+     episode-bundle lock. Default ON; env var [MASC_KEEPER_MEMORY_OS_GC] is the
+     kill switch. Per-keeper fibers run in parallel. *)
   if Env_config.KeeperMemoryOs.gc_enabled () then
     fork_logged_fiber
       ~sw
@@ -337,15 +338,46 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
             keeper_id
             (Printexc.to_string exn)
       in
+      (* Episode-store sweep, same discipline as [gc_one]: only episodes past
+         their explicit [valid_until] are deleted; a corrupt episode store
+         fails loud here and is left untouched. *)
+      let gc_episodes_one keeper_id () =
+        try
+          let report =
+            Keeper_memory_os_gc.run_episode_gc ~keeper_id ~now:(Time_compat.now ()) ()
+          in
+          if report.Keeper_memory_os_gc.episodes_expired > 0
+          then
+            Log.Server.info
+              "memory_os_gc: keeper=%s episodes_expired=%d episodes_deleted=%d"
+              keeper_id
+              report.episodes_expired
+              report.episodes_deleted
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Server.warn
+            "memory_os_gc: keeper=%s episode sweep crashed: %s"
+            keeper_id
+            (Printexc.to_string exn)
+      in
       let rec loop () =
+        (* Union of fact-store ids and episode-store ids: a keeper whose
+           episodes all carried zero claims has no [*.facts.jsonl] but still
+           accumulates episode files. *)
         let keeper_ids =
           List.filter
             (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
-            (Keeper_memory_os_io.list_fact_store_keeper_ids ())
+            (List.sort_uniq
+               String.compare
+               (Keeper_memory_os_io.list_fact_store_keeper_ids ()
+                @ Keeper_memory_os_io.list_episode_store_keeper_ids ()))
         in
         Eio.Fiber.all
           (List.map
-             (fun keeper_id () -> gc_one keeper_id ())
+             (fun keeper_id () ->
+                gc_one keeper_id ();
+                gc_episodes_one keeper_id ())
              keeper_ids);
         Eio.Time.sleep clock interval;
         loop ()

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2277,6 +2277,179 @@ let test_gc_waits_for_fact_writer_lock () =
          survivors))))
 ;;
 
+(* Episode-store retention sweep: the per-file episode store
+   ([keeper_id/episodes/*.json]) expires only episodes whose explicit
+   [valid_until] has passed — the same exact producer boundary the facts sweep
+   uses. Survivors stay byte-identical; a corrupt store aborts the sweep with
+   every file (even expired ones) left on disk. *)
+let episode_file_snapshot ~keeper_id =
+  let dir = Memory_io.episodes_dir ~keeper_id in
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.sort String.compare
+  |> List.map (fun name ->
+    name, In_channel.with_open_bin (Filename.concat dir name) In_channel.input_all)
+;;
+
+let snapshot_entry_with_summary snapshot summary =
+  match List.find_opt (fun (_name, bytes) -> contains summary bytes) snapshot with
+  | Some entry -> entry
+  | None -> Alcotest.fail ("missing episode file containing summary: " ^ summary)
+;;
+
+let episode_retention_metric_value keeper_id =
+  Metrics.metric_value_or_zero
+    Keeper_metrics.(to_string MemoryOsEpisodeRetentionPruned)
+    ~labels:[ "keeper", keeper_id ]
+    ()
+;;
+
+let test_episode_gc_deletes_only_expired () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-gc-keeper" in
+    let now = 1_000_000.0 in
+    let expired_a =
+      { (episode_fixture
+           ~now
+           ~trace_id:"trace-expired-a"
+           ~generation:0
+           ~summary:"expired episode a")
+        with
+        Types.valid_until = Some (now -. 1.0)
+      }
+    in
+    let expired_b =
+      { (episode_fixture
+           ~now
+           ~trace_id:"trace-expired-b"
+           ~generation:0
+           ~summary:"expired episode b")
+        with
+        Types.valid_until = Some (now -. 2.0)
+      }
+    in
+    let current =
+      { (episode_fixture ~now ~trace_id:"trace-current" ~generation:0 ~summary:"current episode") with
+        Types.valid_until = Some (now +. 60.0)
+      }
+    in
+    let boundary =
+      { (episode_fixture ~now ~trace_id:"trace-boundary" ~generation:0 ~summary:"boundary episode") with
+        Types.valid_until = Some now
+      }
+    in
+    let indefinite =
+      episode_fixture ~now ~trace_id:"trace-indefinite" ~generation:0 ~summary:"indefinite episode"
+    in
+    List.iter
+      (Memory_io.append_episode ~keeper_id)
+      [ expired_a; expired_b; current; boundary; indefinite ];
+    let before = episode_file_snapshot ~keeper_id in
+    Alcotest.(check int) "five episode files on disk" 5 (List.length before);
+    let report = GC.run_episode_gc ~keeper_id ~now () in
+    Alcotest.(check int) "episodes total" 5 report.GC.episodes_total;
+    Alcotest.(check int) "episodes expired" 2 report.GC.episodes_expired;
+    Alcotest.(check int) "episodes deleted" 2 report.GC.episodes_deleted;
+    Alcotest.(check bool) "real sweep, not dry-run" false report.GC.dry_run;
+    let after = episode_file_snapshot ~keeper_id in
+    Alcotest.(check int) "three episode files survive" 3 (List.length after);
+    List.iter
+      (fun summary ->
+         let survivor = snapshot_entry_with_summary before summary in
+         Alcotest.(check bool)
+           (summary ^ " survives byte-identical")
+           true
+           (List.mem survivor after))
+      [ "current episode"; "boundary episode"; "indefinite episode" ];
+    Alcotest.(check (float 0.001))
+      "pruned metric counts exactly the deleted files"
+      2.0
+      (episode_retention_metric_value keeper_id)))
+;;
+
+let test_episode_gc_dry_run_reports_without_deleting () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-gc-dry-run-keeper" in
+    let now = 1_000_000.0 in
+    let expired =
+      { (episode_fixture
+           ~now
+           ~trace_id:"trace-expired"
+           ~generation:0
+           ~summary:"dry-run expired episode")
+        with
+        Types.valid_until = Some (now -. 1.0)
+      }
+    in
+    let live =
+      episode_fixture ~now ~trace_id:"trace-live" ~generation:0 ~summary:"dry-run live episode"
+    in
+    List.iter (Memory_io.append_episode ~keeper_id) [ expired; live ];
+    let before = episode_file_snapshot ~keeper_id in
+    let report = GC.run_episode_gc ~dry_run:true ~keeper_id ~now () in
+    Alcotest.(check bool) "dry-run flag" true report.GC.dry_run;
+    Alcotest.(check int) "episodes total" 2 report.GC.episodes_total;
+    Alcotest.(check int) "episodes expired reported" 1 report.GC.episodes_expired;
+    Alcotest.(check int) "dry-run deletes nothing" 0 report.GC.episodes_deleted;
+    Alcotest.(check (list (pair string string)))
+      "dry-run leaves every file byte-identical"
+      before
+      (episode_file_snapshot ~keeper_id);
+    Alcotest.(check (float 0.001))
+      "dry-run does not count prunes"
+      0.0
+      (episode_retention_metric_value keeper_id)))
+;;
+
+(* Preserve over delete, same rule as the facts sweep: one malformed episode
+   file aborts the sweep and even expired files stay on disk — the error
+   surfaces instead of a corrupt store being silently pruned around. *)
+let test_episode_gc_corrupt_store_fails_loud_and_deletes_nothing () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-gc-corrupt-keeper" in
+    let now = 1_000_000.0 in
+    let expired =
+      { (episode_fixture
+           ~now
+           ~trace_id:"trace-expired"
+           ~generation:0
+           ~summary:"corrupt-store expired episode")
+        with
+        Types.valid_until = Some (now -. 1.0)
+      }
+    in
+    let live =
+      episode_fixture
+        ~now
+        ~trace_id:"trace-live"
+        ~generation:0
+        ~summary:"corrupt-store live episode"
+    in
+    List.iter (Memory_io.append_episode ~keeper_id) [ expired; live ];
+    (* A torn write, as a crash mid-publish or disk corruption would leave
+       behind. *)
+    write_text_file
+      (Filename.concat (Memory_io.episodes_dir ~keeper_id) "torn-g0000-t0000000000001.json")
+      "{ broken json";
+    let before = episode_file_snapshot ~keeper_id in
+    Alcotest.(check int) "three episode files on disk" 3 (List.length before);
+    (match GC.run_episode_gc ~keeper_id ~now () with
+     | _report -> Alcotest.fail "expected run_episode_gc to raise on a corrupt store"
+     | exception GC.Episode_store_corrupt _ -> ());
+    Alcotest.(check (list (pair string string)))
+      "corrupt store left untouched — even expired episodes survive"
+      before
+      (episode_file_snapshot ~keeper_id);
+    Alcotest.(check (float 0.001))
+      "no prune counted for the aborted sweep"
+      0.0
+      (episode_retention_metric_value keeper_id)))
+;;
+
 let test_recall_context_empty_without_memory () =
   with_temp_keepers_dir (fun _keepers_dir ->
     let ctx =
@@ -4759,6 +4932,18 @@ let () =
             "gc waits for fact writer lock"
             `Quick
             test_gc_waits_for_fact_writer_lock
+        ; Alcotest.test_case
+            "episode gc deletes only expired episodes"
+            `Quick
+            test_episode_gc_deletes_only_expired
+        ; Alcotest.test_case
+            "episode gc dry-run reports without deleting"
+            `Quick
+            test_episode_gc_dry_run_reports_without_deleting
+        ; Alcotest.test_case
+            "episode gc fails loud on a corrupt store"
+            `Quick
+            test_episode_gc_corrupt_store_fails_loud_and_deletes_nothing
         ] )
     ; ( "recall"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os_gc_dry_run_report.ml
+++ b/test/test_keeper_memory_os_gc_dry_run_report.ml
@@ -17,6 +17,22 @@ let fact_fixture ~now ~claim =
   }
 ;;
 
+let episode_fixture ~now ~trace_id ~summary =
+  { Types.trace_id
+  ; generation = 0
+  ; episode_summary = summary
+  ; claims = []
+  ; open_items = []
+  ; constraints = []
+  ; preserved_tool_refs = []
+  ; source_turn_range = None
+  ; created_at = now
+  ; valid_until = None
+  ; terminal_marker = None
+  ; schema_version = Types.schema_version
+  }
+;;
+
 let with_temp_keepers_dir f =
   let marker = Filename.temp_file "keeper-memory-os-gc-dry-run-" ".tmp" in
   Sys.remove marker;
@@ -46,6 +62,14 @@ let test_report_summarizes_dry_run_without_rewrite () =
       in
       List.iter (Memory_io.append_fact ~keeper_id:"alpha") [ live; expired ];
       Memory_io.append_fact ~keeper_id:"beta" (fact_fixture ~now ~claim:"beta fact");
+      Memory_io.append_episode
+        ~keeper_id:"alpha"
+        { (episode_fixture ~now ~trace_id:"trace-alpha-expired" ~summary:"alpha expired episode") with
+          Types.valid_until = Some (now -. 1.0)
+        };
+      Memory_io.append_episode
+        ~keeper_id:"alpha"
+        (episode_fixture ~now ~trace_id:"trace-alpha-live" ~summary:"alpha live episode");
       let report = Report.run_for_keepers_dir ~keepers_dir ~now () in
       Alcotest.(check int) "keeper count" 2 (List.length report.results);
       Alcotest.(check int) "total input" 3 report.total_input;
@@ -54,11 +78,17 @@ let test_report_summarizes_dry_run_without_rewrite () =
         "non-ephemeral expired is a migration candidate"
         1
         report.ttl_expired_non_ephemeral;
+      Alcotest.(check int) "episodes total" 2 report.episodes_total;
+      Alcotest.(check int) "episodes expired" 1 report.episodes_expired;
       Alcotest.(check int) "error count" 0 report.error_count;
       Alcotest.(check int)
         "alpha file unchanged by dry-run"
         2
         (List.length (Memory_io.read_facts_all ~keeper_id:"alpha"));
+      Alcotest.(check int)
+        "alpha episode files unchanged by dry-run"
+        2
+        (Array.length (Sys.readdir (Memory_io.episodes_dir ~keeper_id:"alpha")));
       match result_for "alpha" report with
       | Some (Report.Keeper_ok row) ->
         Alcotest.(check int) "alpha ttl expired" 1 row.ttl_expired;
@@ -70,7 +100,9 @@ let test_report_summarizes_dry_run_without_rewrite () =
           "alpha expired by category"
           [ "fact", 1 ]
           row.ttl_expired_by_category;
-        Alcotest.(check int) "alpha would write" 1 row.written
+        Alcotest.(check int) "alpha would write" 1 row.written;
+        Alcotest.(check int) "alpha episodes total" 2 row.episodes_total;
+        Alcotest.(check int) "alpha episodes expired" 1 row.episodes_expired
       | Some (Report.Keeper_error row) ->
         Alcotest.failf
           "unexpected alpha error: %s"
@@ -78,6 +110,7 @@ let test_report_summarizes_dry_run_without_rewrite () =
            | Report.Missing_fact_store { facts_path } ->
              Printf.sprintf "missing %s" facts_path
            | Report.Corrupt_fact_store { message }
+           | Report.Corrupt_episode_store { message }
            | Report.Fact_store_access_error { message } -> message
            | Report.Fact_store_locked { lock_path; _ } ->
              Printf.sprintf "locked %s" lock_path)
@@ -105,6 +138,7 @@ let test_explicit_missing_keeper_is_error () =
          | Report.Missing_fact_store { facts_path } ->
            Alcotest.(check string) "missing fact store path" expected_path facts_path
          | Report.Corrupt_fact_store _
+         | Report.Corrupt_episode_store _
          | Report.Fact_store_access_error _
          | Report.Fact_store_locked _ ->
            Alcotest.fail "expected structured missing fact store error");
@@ -141,6 +175,18 @@ let fake_gc_report ?(total_input = 1) ?(ttl_expired = 0) ?(written = 1) () =
   }
 ;;
 
+let fake_episode_gc_report ?(episodes_total = 0) ?(episodes_expired = 0) () =
+  { GC.episodes_total
+  ; episodes_expired
+  ; episodes_deleted = 0
+  ; dry_run = true
+  }
+;;
+
+let noop_run_episode_gc_for_keepers_dir ~keepers_dir:_ ~dry_run:_ ~keeper_id:_ ~now:_ () =
+  fake_episode_gc_report ()
+;;
+
 let seed_keeper ~now keeper_id =
   Memory_io.append_fact ~keeper_id (fact_fixture ~now ~claim:(keeper_id ^ " fact"))
 ;;
@@ -159,6 +205,7 @@ let test_lock_timeout_is_per_keeper_error () =
         Report.For_testing.run_for_keepers_dir
           ~keepers_dir
           ~run_gc_for_keepers_dir
+          ~run_episode_gc_for_keepers_dir:noop_run_episode_gc_for_keepers_dir
           ~keeper_ids:[ "locked" ]
           ~now
           ()
@@ -185,6 +232,7 @@ let test_corrupt_store_is_per_keeper_error () =
         Report.For_testing.run_for_keepers_dir
           ~keepers_dir
           ~run_gc_for_keepers_dir
+          ~run_episode_gc_for_keepers_dir:noop_run_episode_gc_for_keepers_dir
           ~keeper_ids:[ "corrupt" ]
           ~now
           ()
@@ -196,6 +244,60 @@ let test_corrupt_store_is_per_keeper_error () =
       | Some (Report.Keeper_error _) -> Alcotest.fail "expected corrupt store error"
       | Some (Report.Keeper_ok _) -> Alcotest.fail "expected corrupt keeper error"
       | None -> Alcotest.fail "missing corrupt result"))
+;;
+
+let test_corrupt_episode_store_is_per_keeper_error () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let now = 1_000.0 in
+      seed_keeper ~now "corrupt-episode";
+      let run_gc_for_keepers_dir ~keepers_dir:_ ~dry_run:_ ~keeper_id:_ ~now:_ () =
+        fake_gc_report ()
+      in
+      let run_episode_gc_for_keepers_dir ~keepers_dir:_ ~dry_run:_ ~keeper_id:_ ~now:_ () =
+        raise (GC.Episode_store_corrupt "bad episode")
+      in
+      let report =
+        Report.For_testing.run_for_keepers_dir
+          ~keepers_dir
+          ~run_gc_for_keepers_dir
+          ~run_episode_gc_for_keepers_dir
+          ~keeper_ids:[ "corrupt-episode" ]
+          ~now
+          ()
+      in
+      Alcotest.(check int) "one corrupt episode error" 1 report.error_count;
+      match result_for "corrupt-episode" report with
+      | Some (Report.Keeper_error { error = Report.Corrupt_episode_store { message }; _ }) ->
+        Alcotest.(check string) "message" "bad episode" message
+      | Some (Report.Keeper_error _) -> Alcotest.fail "expected corrupt episode store error"
+      | Some (Report.Keeper_ok _) -> Alcotest.fail "expected corrupt episode keeper error"
+      | None -> Alcotest.fail "missing corrupt episode result"))
+;;
+
+(* A keeper with an episode store but no [*.facts.jsonl] (e.g. every extracted
+   episode carried zero claims) must still be discovered and swept — the scan
+   unions fact-store ids and episode-store ids. *)
+let test_episode_only_keeper_is_scanned () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let now = 1_000.0 in
+      Memory_io.append_episode
+        ~keeper_id:"gamma"
+        { (episode_fixture ~now ~trace_id:"trace-gamma-expired" ~summary:"gamma expired episode") with
+          Types.valid_until = Some (now -. 1.0)
+        };
+      let report = Report.run_for_keepers_dir ~keepers_dir ~now () in
+      Alcotest.(check int) "episode-only keeper discovered" 1 (List.length report.results);
+      Alcotest.(check int) "error count" 0 report.error_count;
+      Alcotest.(check int) "episodes total" 1 report.episodes_total;
+      Alcotest.(check int) "episodes expired" 1 report.episodes_expired;
+      match result_for "gamma" report with
+      | Some (Report.Keeper_ok row) ->
+        Alcotest.(check int) "gamma has no fact store rows" 0 row.total_input;
+        Alcotest.(check int) "gamma episodes expired" 1 row.episodes_expired
+      | Some (Report.Keeper_error _) -> Alcotest.fail "unexpected gamma error"
+      | None -> Alcotest.fail "missing gamma result"))
 ;;
 
 let test_mixed_results_keep_ok_totals_and_errors () =
@@ -212,6 +314,7 @@ let test_mixed_results_keep_ok_totals_and_errors () =
         Report.For_testing.run_for_keepers_dir
           ~keepers_dir
           ~run_gc_for_keepers_dir
+          ~run_episode_gc_for_keepers_dir:noop_run_episode_gc_for_keepers_dir
           ~keeper_ids:[ "alpha"; "broken" ]
           ~now
           ()
@@ -277,6 +380,14 @@ let () =
             "corrupt store is per-keeper error"
             `Quick
             test_corrupt_store_is_per_keeper_error
+        ; Alcotest.test_case
+            "corrupt episode store is per-keeper error"
+            `Quick
+            test_corrupt_episode_store_is_per_keeper_error
+        ; Alcotest.test_case
+            "episode-only keeper is scanned"
+            `Quick
+            test_episode_only_keeper_is_scanned
         ; Alcotest.test_case
             "mixed results keep ok totals and errors"
             `Quick


### PR DESCRIPTION
## 문제 (감사 증거)

두 차례 독립 감사로 확정된 사실:

- keeper 메모리는 raw `episode`와 derived claim(`fact`)이 distinct type이다 (`lib/keeper/keeper_memory_os_types.ml`). facts용 GC(`Keeper_memory_os_gc.run_gc`)는 존재하지만 **episode 쪽은 sweep/prune 코드가 0건**이었다 — `episode.valid_until` 필드가 있음에도 episode 파일이 무한 축적된다 (라이브 실측 keeper당 303–380 파일, 1.7–2.2MB).
- `Keeper_metrics.MemoryOsEpisodeRetentionPruned`가 선언만 있고 inc site 0건 (dead metric).
- `keeper_config.ml` 주석이 "episode retention wired into Keeper_memory_os_gc"라 주장하나 코드와 모순 (stale 주석).

## 설계 선택

- **경계 조건**: facts GC와 정확히 같은 producer 선언 경계 — `valid_until`이 과거인 episode만 삭제한다. `valid_until` 미설정 또는 미래인 episode는 절대 삭제하지 않는다 (blind TTL 금지). `ts >= now` ⇔ current, 경계 등호 의미도 facts와 동일.
- **레이아웃 차이 반영**: episode store는 facts(single JSONL + atomic rewrite)와 달리 episode당 1파일(`<keeper>/episodes/*.json`)이므로 read-modify-rewrite 대신 **classify-then-delete per file**. `Sys.remove` 실패도 예외로 표면화 (silent skip 없음).
- **잠금**: facts GC가 facts lock을 잡는 것과 같은 규율로, episode write path(librarian이 episode publish 시 잡는 `with_episode_bundle_lock`)와 **같은 per-keeper episode-bundle lock** 아래서 분류+삭제. lock 순서(bundle → facts)와 무충돌 — episode GC는 bundle lock만 잡는다.
- **실패 분류**: facts GC의 preserve-over-delete 규칙 그대로 — strict read에서 손상 episode 파일 1개라도 있으면 `Episode_store_corrupt`를 raise하고 (만료 파일 포함) 아무것도 삭제하지 않는다.
- **메트릭**: 실삭제 시에만 `MemoryOsEpisodeRetentionPruned`를 삭제 수만큼 inc (`~delta`, `keeper` 라벨). dry-run은 보고만 하고 inc하지 않는다.
- **배선**: maintenance fiber의 기존 default-ON GC 패스에 같은 규율로 연결. keeper 열거는 fact-store ids ∪ episode-store ids — claims가 전부 비어 facts 파일이 없는 keeper도 episode 파일은 축적되기 때문. `memory-os-gc-dry-run` CLI 리포트에 keeper별/합계 episode 카운트와 `episode_store_corrupt` 구조화 에러를 포함.
- `keeper_config.ml` 주석을 최종 구현과 일치시킴.

## 기계 판정 기준 (테스트 이름 + 결과)

TDD: 구현 전 테스트 먼저 작성 → 빌드 red (`Unbound value GC.run_episode_gc`) 확인 후 구현.

`test/test_keeper_memory_os.exe` (110 tests, 전부 OK):
- `io / episode gc deletes only expired episodes` — 만료 2개만 삭제, 미만료/경계(`valid_until = now`)/무기한 3개는 byte-identity 생존, 메트릭 정확히 2.0 inc
- `io / episode gc dry-run reports without deleting` — dry-run은 전 파일 byte-identical, `episodes_deleted = 0`, 메트릭 0
- `io / episode gc fails loud on a corrupt store` — 손상 store는 `Episode_store_corrupt` raise + 만료 파일조차 byte-identical 생존, 메트릭 0

`test/test_keeper_memory_os_gc_dry_run_report.exe` (9 tests, 전부 OK):
- `report / summarizes dry-run without rewrite` — 리포트 row/합계에 episode 카운트 포함, dry-run 후 episode 파일 불변
- `report / corrupt episode store is per-keeper error` — `Corrupt_episode_store` 구조화 에러
- `report / episode-only keeper is scanned` — facts 파일 없는 episode-only keeper도 발견/스캔

실행 증거 (repo 로컬 규율: touched target만 `scripts/dune-local.sh`로 빌드):
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe test/test_keeper_memory_os_gc_dry_run_report.exe` → green, 두 exe 직접 실행 `Test Successful` (110 + 9 tests)
- `scripts/dune-local.sh build lib/server bin/main_eio.exe` → green (exit 0)
- 인접 타겟 `test_server_bootstrap_maintenance_memory_os.exe` (2 tests) / `test_keeper_memory_os_sanity_sweep.exe` (3 tests) 빌드+실행 green

## 영향 범위

- `lib/keeper/keeper_memory_os_gc.{ml,mli}` — episode sweep 추가 (facts 경로 무변경)
- `lib/keeper/keeper_memory_os_io.{ml,mli}` — strict episode reader, episode-store 열거/존재 확인, bundle lock path의 `_for_keepers_dir` variant (기존 함수는 위임으로 동치)
- `lib/keeper/keeper_memory_os_gc_dry_run_report.{ml,mli}` — episode 카운트/에러 variant 추가. JSON 출력에 `episodes_total`/`episodes_expired` 필드 추가 (기존 필드 불변, additive)
- `lib/server/server_bootstrap_maintenance.ml` — 기존 GC 파이버에 episode sweep 연결 (facts 로그 문자열 무변경)
- `lib/keeper/keeper_config.ml` — stale 주석을 코드와 일치
- `bin/main_eio.ml` — `memory-os-gc-dry-run` doc 문자열 갱신

## 범위 밖 (후속 후보)

- `<keeper>.events.jsonl` (episode의 append-only 이벤트 로그)는 별도 아티팩트로 이번 sweep 대상이 아니다. RFC-0272(Draft)가 설계한 count-based bounded-append(`cap_events`/`cap_episode_files`)와 이번 TTL sweep은 직교 — RFC-0272의 count cap은 미구현으로 남는다.
- dashboard memory-health (`server_dashboard_http_keeper_memory_health.ml`)와 `memory-os-sanity-sweep`는 facts-only 경로로 유지 (무수정).
