### PR TITLE
fix(keeper): quarantine structural breaks in compaction partition

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -268,7 +268,7 @@ let selected_message_count units selected =
     selected
 ;;
 let requested_messages (meta : keeper_meta) messages =
-  match Keeper_compaction_unit.partition messages with
+  match Keeper_compaction_unit.partition ~quarantine:true messages with
   | Error error -> Error (Invalid_structure error)
   | Ok { closed_prefix = []; _ } -> Error No_eligible_history
   | Ok { closed_prefix = units; protected_suffix } ->

--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -143,8 +143,21 @@ let is_result_role = function
   | T.User | T.Tool -> true
   | T.System | T.Assistant -> false
 
-let partition messages =
-  let ( let* ) = Result.bind in
+(* [stop_with_units] freezes the valid closed units accumulated so far and moves
+   the in-flight open tool cycle plus the offending message and everything after
+   it into the protected suffix. Used only when [partition] runs in quarantine
+   mode, so a single structural break compacts the valid prefix instead of
+   rejecting the whole history. *)
+let stop_with_units ~units_rev ~open_cycle ~message ~rest =
+  let open_prefix =
+    match open_cycle with None -> [] | Some cycle -> List.rev cycle.messages_rev
+  in
+  Ok
+    { closed_prefix = List.rev units_rev
+    ; protected_suffix = open_prefix @ (message :: rest)
+    }
+
+let partition ?(quarantine = false) messages =
   let rec loop index units_rev seen_tools seen_results open_cycle = function
     | [] ->
         let protected_suffix =
@@ -154,69 +167,90 @@ let partition messages =
         in
         Ok { closed_prefix = List.rev units_rev; protected_suffix }
     | (message : T.message) :: rest ->
-        let* tool_ids, result_ids =
-          validated_top_level_anchors ~message_index:index message
-        in
-        (match message.role, tool_ids with
-        | (T.System | T.User | T.Tool), tool_use_id :: _ ->
-            Error (Non_assistant_tool_use { message_index = index; tool_use_id })
-        | _ -> (
-            match open_cycle, tool_ids, result_ids with
-            | Some _, tool_use_id :: _, _ ->
-                Error (Overlapping_tool_cycle { message_index = index; tool_use_id })
-            | None, _, _ -> (
-                match add_tool_ids ~message_index:index Id_set.empty tool_ids with
-                | Error _ as error -> error
-                | Ok seen_tools -> (
-                    match tool_ids, result_ids with
-                    | [], tool_use_id :: _ ->
-                        if Id_set.mem tool_use_id seen_results then
-                          Error
-                            (Duplicate_tool_result
-                               { message_index = index; tool_use_id })
-                        else
-                          Error
-                            (Orphan_tool_result
-                               { message_index = index; tool_use_id })
-                    | [], [] ->
-                        loop (index + 1)
-                          (Ordinary_message message :: units_rev)
-                          seen_tools seen_results None rest
-                    | tool_use_id :: _, _ :: _ ->
-                        Error
-                          (Tool_request_contains_result
-                             { message_index = index; tool_use_id })
-                    | _ :: _, [] ->
-                        let expected = Id_set.of_list tool_ids in
-                        loop (index + 1) units_rev seen_tools seen_results
-                          (Some
-                             { expected
-                             ; pending = expected
-                             ; messages_rev = [ message ]
-                             })
-                          rest))
-            | Some cycle, [], [] ->
-                loop (index + 1) units_rev seen_tools seen_results
-                  (Some { cycle with messages_rev = message :: cycle.messages_rev })
-                  rest
-            | Some _, [], tool_use_id :: _ when not (is_result_role message.role) ->
-                Error (Non_result_tool_role { message_index = index; tool_use_id })
-            | Some cycle, [], _ :: _ -> (
-                match
-                  consume_results ~message_index:index ~expected:cycle.expected
-                    cycle.pending seen_results result_ids
-                with
-                | Error _ as error -> error
-                | Ok (pending, seen_results) ->
-                    let messages_rev = message :: cycle.messages_rev in
-                    if Id_set.is_empty pending then
-                      loop (index + 1)
-                        (Closed_tool_cycle (List.rev messages_rev) :: units_rev)
-                        Id_set.empty Id_set.empty None rest
-                    else
-                      loop (index + 1) units_rev seen_tools seen_results
-                        (Some { cycle with pending; messages_rev })
-                        rest)))
+        (match validated_top_level_anchors ~message_index:index message with
+         | Error _ when quarantine ->
+             stop_with_units ~units_rev ~open_cycle ~message ~rest
+         | Error _ as error -> error
+         | Ok (tool_ids, result_ids) ->
+             (match message.role, tool_ids with
+              | (T.System | T.User | T.Tool), tool_use_id :: _ ->
+                  if quarantine then
+                    stop_with_units ~units_rev ~open_cycle ~message ~rest
+                  else
+                    Error (Non_assistant_tool_use { message_index = index; tool_use_id })
+              | _ ->
+                  (match open_cycle, tool_ids, result_ids with
+                   | Some _, tool_use_id :: _, _ ->
+                       if quarantine then
+                         stop_with_units ~units_rev ~open_cycle ~message ~rest
+                       else
+                         Error
+                           (Overlapping_tool_cycle { message_index = index; tool_use_id })
+                   | None, _, _ ->
+                       (match add_tool_ids ~message_index:index Id_set.empty tool_ids with
+                        | Error _ when quarantine ->
+                            stop_with_units ~units_rev ~open_cycle ~message ~rest
+                        | Error _ as error -> error
+                        | Ok seen_tools ->
+                            (match tool_ids, result_ids with
+                             | [], tool_use_id :: _ ->
+                                 if quarantine then
+                                   stop_with_units ~units_rev ~open_cycle ~message ~rest
+                                 else if Id_set.mem tool_use_id seen_results then
+                                   Error
+                                     (Duplicate_tool_result
+                                        { message_index = index; tool_use_id })
+                                 else
+                                   Error
+                                     (Orphan_tool_result
+                                        { message_index = index; tool_use_id })
+                             | [], [] ->
+                                 loop (index + 1)
+                                   (Ordinary_message message :: units_rev)
+                                   seen_tools seen_results None rest
+                             | tool_use_id :: _, _ :: _ ->
+                                 if quarantine then
+                                   stop_with_units ~units_rev ~open_cycle ~message ~rest
+                                 else
+                                   Error
+                                     (Tool_request_contains_result
+                                        { message_index = index; tool_use_id })
+                             | _ :: _, [] ->
+                                 let expected = Id_set.of_list tool_ids in
+                                 loop (index + 1) units_rev seen_tools seen_results
+                                   (Some
+                                      { expected
+                                      ; pending = expected
+                                      ; messages_rev = [ message ]
+                                      })
+                                   rest))
+                   | Some cycle, [], [] ->
+                       loop (index + 1) units_rev seen_tools seen_results
+                         (Some { cycle with messages_rev = message :: cycle.messages_rev })
+                         rest
+                   | Some _, [], tool_use_id :: _ when not (is_result_role message.role) ->
+                       if quarantine then
+                         stop_with_units ~units_rev ~open_cycle ~message ~rest
+                       else
+                         Error (Non_result_tool_role { message_index = index; tool_use_id })
+                   | Some cycle, [], _ :: _ ->
+                       (match
+                          consume_results ~message_index:index ~expected:cycle.expected
+                            cycle.pending seen_results result_ids
+                        with
+                        | Error _ when quarantine ->
+                            stop_with_units ~units_rev ~open_cycle ~message ~rest
+                        | Error _ as error -> error
+                        | Ok (pending, seen_results) ->
+                            let messages_rev = message :: cycle.messages_rev in
+                            if Id_set.is_empty pending then
+                              loop (index + 1)
+                                (Closed_tool_cycle (List.rev messages_rev) :: units_rev)
+                                Id_set.empty Id_set.empty None rest
+                            else
+                              loop (index + 1) units_rev seen_tools seen_results
+                                (Some { cycle with pending; messages_rev })
+                                rest))))
   in
   loop 0 [] Id_set.empty Id_set.empty None messages
 

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -65,8 +65,15 @@ type partition =
   }
 
 val partition
-  :  Agent_sdk.Types.message list
+  :  ?quarantine:bool
+  -> Agent_sdk.Types.message list
   -> (partition, structural_error) result
+(** With [~quarantine:true] the first structural break freezes the valid
+    [closed_prefix] and moves the open cycle plus the offending message and its
+    successors into [protected_suffix] instead of returning [Error]. Compaction
+    callers use this so a single broken tool cycle compacts the valid prefix
+    rather than rejecting the whole history. [validate] and persistence callers
+    keep the default [false] to reject broken structures. *)
 
 (** Validate the same structural contract as {!partition} without exposing a
     partition to persistence callers that must preserve every message exactly. *)

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -271,6 +271,39 @@ let test_invalid_identity_prevents_plan_callback () =
   Alcotest.(check int) "plan callback count" 0 !plan_calls
 ;;
 
+let test_quarantine_overlapping_keeps_valid_prefix () =
+  let prefix = text T.User "valid prefix" in
+  let open_a = message T.Assistant [ use "a" ] in
+  let overlapping = message T.Assistant [ use "b" ] in
+  let history = [ prefix; open_a; overlapping ] in
+  (match U.partition history with
+   | Error (U.Overlapping_tool_cycle { message_index = 2; tool_use_id = "b" }) ->
+       ()
+   | _ -> Alcotest.fail "default partition must reject overlapping tool cycle");
+  let output = U.partition ~quarantine:true history |> require_ok in
+  check_exact "valid prefix compacted under quarantine"
+    [ U.Ordinary_message prefix ]
+    output.closed_prefix;
+  check_exact "open + overlapping protected under quarantine"
+    [ open_a; overlapping ]
+    output.protected_suffix
+;;
+
+let test_quarantine_orphan_keeps_valid_prefix () =
+  let prefix = text T.User "valid prefix" in
+  let orphan = message T.Tool [ result "x" ] in
+  let history = [ prefix; orphan ] in
+  (match U.partition history with
+   | Error (U.Orphan_tool_result _) ->
+       ()
+   | _ -> Alcotest.fail "default partition must reject orphan tool result");
+  let output = U.partition ~quarantine:true history |> require_ok in
+  check_exact "valid prefix compacted under quarantine"
+    [ U.Ordinary_message prefix ]
+    output.closed_prefix;
+  check_exact "orphan protected under quarantine" [ orphan ] output.protected_suffix
+;;
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -313,5 +346,9 @@ let () =
             test_nonblank_tool_ids_remain_exact
         ; Alcotest.test_case "invalid identity stops plan callback" `Quick
             test_invalid_identity_prevents_plan_callback
+        ; Alcotest.test_case "quarantine overlapping keeps valid prefix" `Quick
+            test_quarantine_overlapping_keeps_valid_prefix
+        ; Alcotest.test_case "quarantine orphan keeps valid prefix" `Quick
+            test_quarantine_orphan_keeps_valid_prefix
         ] )
     ]


### PR DESCRIPTION
## 무엇을

`Keeper_compaction_unit.partition`에 `~quarantine:bool` 옵션 추가. `~quarantine:true`에서 structural error(Overlapping_tool_cycle 등) 발생 시 전체 reject 대신 valid `closed_prefix`만 compaction, broken 이후는 `protected_suffix`로 보존(분할 반환). `keeper_compact_policy.requested_messages`는 `~quarantine:true`로 호출.

## 왜

라이브 사고(2026-07-20): analyst manual compaction이 `Overlapping_tool_cycle { message_index = 1221 }` 로 reject → compaction 실패 → context 안 줄어듦 → deepseek-v4-flash `Bad Request` 연쇄(system 116·rondo 1 동일 runtime 패턴). **broken tool cycle 하나가 keeper 전체를 막음.**

`validate`/persist는 기본 `quarantine=false`로 broken reject 유지(#25046 persist boundary 회귀 없음 — `validate` 경로 테스트로 확인). #25335 quarantine 패턴과 같은 방향.

## 검증

- `dune build --root .` 통과.
- `test_keeper_compaction_unit` **23/23 OK**(21 기존 회귀 없음 + quarantine 신규 2: Overlapping·Orphan → valid 보존).
- `ocamlformat --check` exit 0.

## 변경

- `lib/keeper/keeper_compaction_unit.ml` — `partition ?(quarantine=false)` + `stop_with_units` helper + 8-9 structural error 지점 분기.
- `lib/keeper/keeper_compaction_unit.mli` — partition signature + doc.
- `lib/keeper/keeper_compact_policy.ml` — line 271 `partition ~quarantine:true`.
- `test/test_keeper_compaction_unit.ml` — quarantine 2 케이스.

Co-Authored-By: Claude <noreply@anthropic.com>
