### PR TITLE
chore(keeper): small dead-code cleanups and resilience audit retention

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -366,9 +366,6 @@ let heartbeat_event_intake
         | Keeper_event_queue_persistence.Board_batch, batch ->
           consume_board_stimulus_batch ~meta_after_triage batch
         | ( Keeper_event_queue_persistence.Single
-          | Keeper_event_queue_persistence.Legacy_inflight ), [ stimulus ] ->
-          consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stimulus
-        | ( Keeper_event_queue_persistence.Single
           | Keeper_event_queue_persistence.Legacy_inflight ), stimuli ->
           List.concat_map
             (consume_single_heartbeat_stimulus ~ctx ~meta_after_triage)

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -137,10 +137,9 @@ let derive_phase (c : conditions) : phase =
     || (not c.turn_healthy)
     || c.credential_archived
   then Failing (* 10. Healthy running *)
-  else if c.fiber_alive
-  then Running
-  (* 11. Initial / unreachable fallback *)
-  else Offline
+  (* [fiber_alive] is guaranteed here: branch 3 routes a dead fiber to
+     Crashed, so the fallthrough can only be Running. *)
+  else Running
 ;;
 
 (* ── Condition Updaters ────────────────────────────────── *)

--- a/lib/runtime/runtime_candidate.ml
+++ b/lib/runtime/runtime_candidate.ml
@@ -12,8 +12,6 @@
 
 type t = Llm_provider.Provider_config.t
 
-module Runtime_binding = Agent_sdk.Provider_runtime_binding
-
 let of_provider_config (cfg : Llm_provider.Provider_config.t) : t = cfg
 
 let of_provider_configs (cfgs : Llm_provider.Provider_config.t list) : t list = cfgs

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -532,12 +532,6 @@ let validate_dashboard_string_list_field key = function
       loop 0 items
   | other -> dashboard_field_type_error key "an array of strings" other
 
-let validate_dashboard_nonnegative_int key value =
-  if value >= 0 then Ok ()
-  else
-    Error
-      (Printf.sprintf "%s must be non-negative (received %d)" key value)
-
 let validate_dashboard_max_context_override = function
   | `Null -> Ok ()
   | `Int value ->

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -4,6 +4,21 @@
 
 (* ── Startup pruning ───────────────────────────────── *)
 
+(* Fold [prune_dir] over the immediate sub-directories of [root].
+   A missing [root] counts 0 and stray files under [root] are skipped —
+   [.masc/resilience_audit/<keeper>/] stores keep their day-files one
+   level below the keeper dir, so per-keeper traversal needs the same
+   guard the keepers loop gets for free from its nested path concat. *)
+let prune_children_dirs ~prune_dir root =
+  if not (Sys.file_exists root) then 0
+  else
+    Array.fold_left
+      (fun acc name ->
+        let dir = Filename.concat root name in
+        if Sys.is_directory dir then acc + prune_dir dir else acc)
+      0
+      (Sys.readdir root)
+
 let startup_prune_jsonl (state : Mcp_server.server_state) =
   (try
      let days =
@@ -48,6 +63,7 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
               + prune_dir (Filename.concat (Filename.concat keepers name) "metrics")
               + prune_dir (Filename.concat (Filename.concat keepers name) "crash-events")
             ) 0 (Sys.readdir keepers))
+       + prune_children_dirs ~prune_dir (Filename.concat masc "resilience_audit")
      in
      if total > 0 then
          Log.Misc.info "startup prune: pruned %d old JSONL day-files (retention=%dd)"

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -1,3 +1,8 @@
+val prune_children_dirs : prune_dir:(string -> int) -> string -> int
+(** Fold [prune_dir] over the immediate sub-directories of the given
+    root path. Missing root counts 0; stray files are skipped.
+    Exposed for unit tests. *)
+
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 
 (** Boot-time pass over [.masc/keepers/*.json]: remove only keys in the

--- a/test/dune
+++ b/test/dune
@@ -892,6 +892,7 @@
   test_dashboard_namespace_truth
   test_dashboard_snapshot
   test_server_runtime_bootstrap
+  test_server_runtime_startup_maintenance
   test_server_hibernation
   test_server_base_path_diagnostics
   test_server_base_path_guard
@@ -1055,6 +1056,7 @@
   test_dashboard_namespace_truth
   test_dashboard_snapshot
   test_server_runtime_bootstrap
+  test_server_runtime_startup_maintenance
   test_server_hibernation
   test_server_base_path_diagnostics
   test_server_base_path_guard

--- a/test/test_server_runtime_startup_maintenance.ml
+++ b/test/test_server_runtime_startup_maintenance.ml
@@ -1,0 +1,54 @@
+(** Unit tests for [Server_runtime_startup_maintenance.prune_children_dirs]. *)
+
+module SM = Server_runtime_startup_maintenance
+
+let counter = ref 0
+
+let fresh_dir prefix =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%.0f" prefix (Unix.getpid ()) (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
+
+let record_prune dir =
+  incr counter;
+  String.length dir
+
+let test_missing_root_counts_zero () =
+  counter := 0;
+  let n =
+    SM.prune_children_dirs ~prune_dir:record_prune "/nonexistent/masc-prune-children"
+  in
+  Alcotest.(check int) "missing root counts 0" 0 n;
+  Alcotest.(check int) "prune_dir never called" 0 !counter
+
+let test_subdirs_pruned_and_stray_files_skipped () =
+  counter := 0;
+  let root = fresh_dir "masc_prune_children" in
+  let keeper_a = Filename.concat root "keeper-a" in
+  let keeper_b = Filename.concat root "keeper-b" in
+  Fs_compat.mkdir_p keeper_a;
+  Fs_compat.mkdir_p keeper_b;
+  let stray = Filename.concat root "stray.txt" in
+  let oc = open_out stray in
+  output_string oc "x";
+  close_out oc;
+  let n = SM.prune_children_dirs ~prune_dir:record_prune root in
+  Alcotest.(check int) "prune called for both subdirs" 2 !counter;
+  Alcotest.(check bool)
+    "return sums prune_dir results" true (n = String.length keeper_a + String.length keeper_b)
+
+let () =
+  Alcotest.run "server_runtime_startup_maintenance"
+    [
+      ( "prune_children_dirs",
+        [
+          Alcotest.test_case "missing root counts zero" `Quick
+            test_missing_root_counts_zero;
+          Alcotest.test_case "subdirs pruned, stray files skipped" `Quick
+            test_subdirs_pruned_and_stray_files_skipped;
+        ] );
+    ]


### PR DESCRIPTION
## Problem

Small audit leftovers + one retention gap found while shipping #25404:

- `keeper_state_machine.ml`: the final `else Offline` is unreachable — `fiber_alive = true` is proven by the preceding branch. Offline's real producer (:117-118) is untouched; TLA correspondence still passes.
- `keeper_heartbeat_stimulus_intake.ml`: a singleton match arm fully subsumed by the following `concat_map` arm.
- `runtime_candidate`: unused `Runtime_binding` alias.
- `server_dashboard_http_keeper_api_post.ml`: zero-caller validation helper.
- `.masc/resilience_audit/<keeper>/` was not covered by JSONL retention pruning — the hash-chain store the audit-integrity surface verifies could grow unboundedly, making verification cost linear forever.

## Investigated, no change

- `health_of_entry`: still consumed by `get_with_health` — not dead.
- `inference_utils` None→zero: intentional — the `usage_reported` guard lane records unreported usage as `Null`, so the `agent_sdk_response.mli` "must not treat as zero" rule is honored.

## Verification

- `dune build lib/` ✓; keeper_state_machine 106, TLA correspondence 5, registry_hardening 17, wirein_order 5 ✓
- Determinism gate, keeper matrix, doc refs ✓