### PR TITLE
refactor(keeper): move test-only Keeper_registry vals behind For_testing

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -357,10 +357,6 @@ let set_started_at_for_test ~base_path name started_at =
       (registry_entry_validation_error_to_string err)
 ;;
 
-module For_testing = struct
-  let unsafe_put_entry = unsafe_put_entry
-end
-
 type wakeup_intent =
   | Reactive_signal
   | Scheduled_signal
@@ -1232,3 +1228,15 @@ let get_phase ~base_path name =
 
 (* Event-queue access (enqueue_event / event_queue_snapshot / dequeue_event /
    drain_board_events) moved to Keeper_registry_event_queue. *)
+
+module For_testing = struct
+  let unsafe_put_entry = unsafe_put_entry
+  let register = register
+  let unregister = unregister
+  let clear = clear
+  let reload_meta_from_disk = reload_meta_from_disk
+  let record_restart = record_restart
+  let set_started_at_for_test = set_started_at_for_test
+  let crash_log_of = crash_log_of
+  let board_wakeup_allowed = board_wakeup_allowed
+end

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -27,10 +27,6 @@ val validate_turn_phase_transition
   -> unit
 
 
-(** Register a keeper with an already-live fiber. Primarily used by tests and
-    direct fixtures that want a keeper to begin in [Running]. *)
-val register : base_path:string -> string -> keeper_meta -> registry_entry
-
 (** Register a fresh keeper before its first keepalive fiber launch.
     The entry starts in [Offline] and must receive [Fiber_started] when the
     runtime actually launches the fiber. *)
@@ -88,9 +84,6 @@ val prepare_fiber_launch_for_lifecycle :
   Keeper_lifecycle_reservation.token ->
   registry_entry ->
   (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
-
-(** Unregister a keeper (removes from registry). *)
-val unregister : base_path:string -> string -> unit
 
 type unregister_exact_result =
   | Exact_unregistered
@@ -195,17 +188,8 @@ val update_entry_if_registered :
 (** Update the meta for a registered keeper. No-op if not found. *)
 val update_meta : base_path:string -> string -> keeper_meta -> unit
 
-(** Reload a registered keeper's meta from disk and replace the in-memory
-    registry copy. Returns [Ok None] when the keeper is not registered or has
-    no persisted meta. *)
-val reload_meta_from_disk :
-  base_path:string -> string -> (registry_entry option, string) result
-
 (* Runtime-attempt persistence + enrichment moved to
    Keeper_registry_runtime_attempt (record / enrich_fiber_unresolved_outcome). *)
-
-(** Record a restart. Increments restart_count and updates last_restart_ts. *)
-val record_restart : base_path:string -> string -> unit
 
 (* [record_error] moved to [Keeper_registry_error_recording.record]. *)
 
@@ -421,10 +405,6 @@ val mark_dead : base_path:string -> string -> at:float -> unit
 (** Return the started_at timestamp, or None if not registered. *)
 val started_at : base_path:string -> string -> float option
 
-(** Test-only: override [started_at] for registry fixtures that need to
-    model a long-running fiber without waiting for wall-clock time. *)
-val set_started_at_for_test : base_path:string -> string -> float -> unit
-
 (** Count keepers in Running state. *)
 val count_running : ?base_path:string -> unit -> int
 
@@ -433,6 +413,40 @@ module For_testing : sig
       corrupted registry state. *)
   val unsafe_put_entry :
     base_path:string -> string -> registry_entry -> unit
+
+  (** Register a keeper with an already-live fiber. Primarily used by tests and
+      direct fixtures that want a keeper to begin in [Running]. *)
+  val register : base_path:string -> string -> keeper_meta -> registry_entry
+
+  (** Unregister a keeper (removes from registry). *)
+  val unregister : base_path:string -> string -> unit
+
+  (** Clear the registry. For testing only. *)
+  val clear : unit -> unit
+
+  (** Reload a registered keeper's meta from disk and replace the in-memory
+      registry copy. Returns [Ok None] when the keeper is not registered or has
+      no persisted meta. *)
+  val reload_meta_from_disk :
+    base_path:string -> string -> (registry_entry option, string) result
+
+  (** Record a restart. Increments restart_count and updates last_restart_ts. *)
+  val record_restart : base_path:string -> string -> unit
+
+  (** Test-only: override [started_at] for registry fixtures that need to
+      model a long-running fiber without waiting for wall-clock time. *)
+  val set_started_at_for_test : base_path:string -> string -> float -> unit
+
+  (** Recent crash entries (up to 5) for a keeper. *)
+  val crash_log_of : base_path:string -> string -> (float * string) list
+
+  (** Check if a board-reactive wakeup is allowed (debounce). [dedup_key] is the
+      key under which the wake is deduped — RFC-0239 R4 passes a content
+      fingerprint rather than the raw post_id, so identical re-posts with fresh
+      post_ids collapse. Records timestamp if allowed. Returns true for
+      unregistered keepers. *)
+  val board_wakeup_allowed :
+    base_path:string -> string -> dedup_key:string -> debounce_sec:float -> bool
 
 end
 
@@ -485,31 +499,17 @@ val wakeup_all : intent:wakeup_intent -> ?base_path:string -> unit -> unit
     Returns Fiber_unknown if the keeper is not registered. *)
 val fiber_health_of : base_path:string -> string -> fiber_health
 
-(** Recent crash entries (up to 5) for a keeper. *)
-val crash_log_of : base_path:string -> string -> (float * string) list
-
 (** Restore supervisor state on a freshly registered entry (used by restart). *)
 val restore_supervisor_state :
   base_path:string -> string ->
   restart_count:int -> last_restart_ts:float ->
   crash_log:(float * string) list -> unit
 
-(** Check if a board-reactive wakeup is allowed (debounce). [dedup_key] is the
-    key under which the wake is deduped — RFC-0239 R4 passes a content
-    fingerprint rather than the raw post_id, so identical re-posts with fresh
-    post_ids collapse. Records timestamp if allowed. Returns true for
-    unregistered keepers. *)
-val board_wakeup_allowed :
-  base_path:string -> string -> dedup_key:string -> debounce_sec:float -> bool
-
 (** Reset tracking state (agent count + board wakeups) for a keeper. *)
 val cleanup_tracking : base_path:string -> string -> unit
 
 (** Reset tracking only if [entry]'s lane still owns its registry key. *)
 val cleanup_tracking_exact : registry_entry -> exact_update_result
-
-(** Clear the registry. For testing only. *)
-val clear : unit -> unit
 
 (** Get board event cursor token. Returns [(0.0, None)] if not found. *)
 val get_board_cursor : base_path:string -> string -> float * string option

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -502,9 +502,9 @@ let test_first_board_observation_starts_at_current_head () =
   let base_path = Sys.getenv "MASC_BASE_PATH" in
   let keeper_name = "cursor-bootstrap" in
   let meta = board_observation_meta keeper_name in
-  ignore (Keeper_registry.register ~base_path keeper_name meta);
+  ignore (Keeper_registry.For_testing.register ~base_path keeper_name meta);
   Fun.protect
-    ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+    ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
     (fun () ->
        let old_post =
          match
@@ -567,9 +567,9 @@ let test_dashboard_projection_does_not_produce_attention_candidate () =
   let base_path = Sys.getenv "MASC_BASE_PATH" in
   let keeper_name = "projection-read-only" in
   let meta = board_observation_meta keeper_name in
-  let entry = Keeper_registry.register ~base_path keeper_name meta in
+  let entry = Keeper_registry.For_testing.register ~base_path keeper_name meta in
   Fun.protect
-    ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+    ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
     (fun () ->
        ignore
          (Keeper_world_observation.collect_board_events ~base_path ~meta

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -87,10 +87,10 @@ let with_ws name fn =
       Eio.Switch.run @@ fun sw ->
       let config = Masc.Workspace.default_config dir in
       let meta = make_meta () in
-      ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
       Fun.protect
         ~finally:(fun () ->
-          Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+          Masc.Keeper_registry.For_testing.unregister ~base_path:config.base_path meta.name)
         (fun () ->
           Masc_test_deps.with_publication_recovery_registry
             ~sw

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -158,7 +158,7 @@ let make_test_meta name =
 
 let test_keepers_section_empty () =
   let now = Unix.gettimeofday () in
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   let section = Dashboard.keepers_section now in
   Alcotest.(check string) "title" "Keepers" section.title;
   Alcotest.(check string) "empty_msg" "(no keepers registered)" section.empty_msg;
@@ -168,9 +168,9 @@ let test_keepers_section_with_entry () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   ignore
-    (Lib.Keeper_registry.register ~base_path:dir "alpha"
+    (Lib.Keeper_registry.For_testing.register ~base_path:dir "alpha"
        (make_test_meta "alpha"));
   let now = Unix.gettimeofday () in
   let section = Dashboard.keepers_section now in
@@ -180,7 +180,7 @@ let test_keepers_section_with_entry () =
   Alcotest.(check bool) "contains keeper name" true (contains line "alpha");
   Alcotest.(check bool) "contains phase" true (contains line "running");
   Alcotest.(check bool) "contains seq" true (contains line "seq=");
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   cleanup_dir dir
 
 let test_generate_full_contains_keepers () =
@@ -207,9 +207,9 @@ let test_keepers_section_dead_phase () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   ignore
-    (Lib.Keeper_registry.register ~base_path:dir "delta"
+    (Lib.Keeper_registry.For_testing.register ~base_path:dir "delta"
        (make_test_meta "delta"));
   let now_mark = Unix.gettimeofday () in
   Lib.Keeper_registry.mark_dead ~base_path:dir "delta" ~at:now_mark;
@@ -220,16 +220,16 @@ let test_keepers_section_dead_phase () =
   Alcotest.(check bool) "contains delta" true (contains line "delta");
   Alcotest.(check bool) "contains dead phase" true (contains line "dead");
   Alcotest.(check bool) "contains since= marker" true (contains line "since=");
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   cleanup_dir dir
 
 let test_keepers_section_with_error_truncated () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   ignore
-    (Lib.Keeper_registry.register ~base_path:dir "echo"
+    (Lib.Keeper_registry.For_testing.register ~base_path:dir "echo"
        (make_test_meta "echo"));
   let long_err =
     "this is a long error message that should exceed the default display length of 35 chars and therefore be truncated with an ellipsis"
@@ -244,7 +244,7 @@ let test_keepers_section_with_error_truncated () =
      so the total line cannot contain the full 130-char error verbatim. *)
   Alcotest.(check bool) "long error body is not verbatim"
     false (contains line "ellipsis");
-  Lib.Keeper_registry.clear ();
+  Lib.Keeper_registry.For_testing.clear ();
   cleanup_dir dir
 
 (* ===== Test Suite ===== *)

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -871,17 +871,17 @@ let test_wake_fail_closed_preserves_route () =
 
 let test_completion_wake_does_not_signal_replacement_lane () =
   with_isolated_base_path "fusion-wake-exact-owner" (fun base_dir ->
-    Keeper_registry.clear ();
+    Keeper_registry.For_testing.clear ();
     Fun.protect
-      ~finally:Keeper_registry.clear
+      ~finally:Keeper_registry.For_testing.clear
       (fun () ->
          let keeper = Printf.sprintf "fusion-exact-%d" (Random.bits ()) in
          let run_id = Printf.sprintf "fus-exact-%d" (Random.bits ()) in
          let meta = make_meta ~name:keeper () in
-         let captured = Keeper_registry.register ~base_path:base_dir keeper meta in
+         let captured = Keeper_registry.For_testing.register ~base_path:base_dir keeper meta in
          Atomic.set captured.fiber_wakeup false;
          Fusion_wake_route.register ~base_path:base_dir ~keeper ~run_id None;
-         let replacement = Keeper_registry.register ~base_path:base_dir keeper meta in
+         let replacement = Keeper_registry.For_testing.register ~base_path:base_dir keeper meta in
          Atomic.set replacement.fiber_wakeup false;
          let result =
            Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -328,9 +328,9 @@ let base_observation : WO.world_observation =
     exception carries no payload (RFC-0002).
     Verifies: state = Crashed, failure_reason stored, done_p resolved. *)
 let test_crash_heartbeat_failure () =
-  R.clear ();
+  R.For_testing.clear ();
   let meta = make_meta "hb-crash" in
-  let reg = R.register ~base_path:bp "hb-crash" meta in
+  let reg = R.For_testing.register ~base_path:bp "hb-crash" meta in
   (* Simulate what launch_supervised_fiber does on Keeper_fiber_crash *)
   let reason = R.Heartbeat_consecutive_failures 5 in
   let reason_str = R.failure_reason_to_string reason in
@@ -360,9 +360,9 @@ let test_crash_heartbeat_failure () =
 
 (** Simulate the generic exception catch branch (lines 67-77). *)
 let test_crash_generic_exception () =
-  R.clear ();
+  R.For_testing.clear ();
   let meta = make_meta "exn-crash" in
-  let reg = R.register ~base_path:bp "exn-crash" meta in
+  let reg = R.For_testing.register ~base_path:bp "exn-crash" meta in
   let exn_str = "Sys_error(disk full)" in
   let fr = R.Exception exn_str in
   let reason_str = R.failure_reason_to_string fr in
@@ -383,9 +383,9 @@ let test_crash_generic_exception () =
 
 (** Simulate the fiber_unresolved fallback (finally block, lines 78-94). *)
 let test_crash_fiber_unresolved () =
-  R.clear ();
+  R.For_testing.clear ();
   let meta = make_meta "unresolved" in
-  let reg = R.register ~base_path:bp "unresolved" meta in
+  let reg = R.For_testing.register ~base_path:bp "unresolved" meta in
   (* Simulate: fiber exits without resolving done_r → finally fires.
      Issue #18901: Unexpected cause (not shutdown) — represents the
      genuine missed-resolution bug path the supervisor must restart. *)
@@ -413,9 +413,9 @@ let test_crash_fiber_unresolved () =
     Verifies: Dead is terminal, is_registered=true, Dead→Running blocked,
     only unregister can remove a Dead entry. *)
 let test_dead_tombstone_full_lifecycle () =
-  R.clear ();
+  R.For_testing.clear ();
   let meta = make_meta "mortal" in
-  let reg = R.register ~base_path:bp "mortal" meta in
+  let reg = R.For_testing.register ~base_path:bp "mortal" meta in
   check string "initially running" "running"
     (KSM.phase_to_string (Option.get (R.get ~base_path:bp "mortal")).phase);
   (* Crash *)
@@ -442,7 +442,7 @@ let test_dead_tombstone_full_lifecycle () =
        (KSM.phase_to_string e.phase)
    | None -> fail "expected mortal");
   (* Only unregister removes Dead entry *)
-  R.unregister ~base_path:bp "mortal";
+  R.For_testing.unregister ~base_path:bp "mortal";
   check bool "gone after unregister" false
     (R.is_registered ~base_path:bp "mortal")
 
@@ -455,9 +455,9 @@ let test_dead_tombstone_full_lifecycle () =
     Stopped with a resolved terminal and joined lane = reconcile-eligible.
     Stopped with an unjoined lane = sweep will handle. *)
 let test_reconcile_predicate_sweep_owned () =
-  R.clear ();
+  R.For_testing.clear ();
   (* Running = sweep-owned *)
-  let _e = R.register ~base_path:bp "r1" (make_meta "r1") in
+  let _e = R.For_testing.register ~base_path:bp "r1" (make_meta "r1") in
   (match R.get ~base_path:bp "r1" with
    | Some e ->
      check string "running" "running" (KSM.phase_to_string e.phase);
@@ -480,8 +480,8 @@ let test_reconcile_predicate_sweep_owned () =
    | None -> fail "expected r1")
 
 let test_reconcile_predicate_stopped_resolved () =
-  R.clear ();
-  let reg = R.register ~base_path:bp "s1" (make_meta "s1") in
+  R.For_testing.clear ();
+  let reg = R.For_testing.register ~base_path:bp "s1" (make_meta "s1") in
   ignore (R.dispatch_event ~base_path:bp "s1" KSM.Stop_requested);
   ignore (R.dispatch_event ~base_path:bp "s1" KSM.Drain_complete);
   resolve_done_for_test reg `Stopped;
@@ -503,8 +503,8 @@ let test_reconcile_predicate_stopped_resolved () =
    | None -> fail "expected s1")
 
 let test_reconcile_predicate_stopped_unresolved () =
-  R.clear ();
-  let _reg = R.register ~base_path:bp "s2" (make_meta "s2") in
+  R.For_testing.clear ();
+  let _reg = R.For_testing.register ~base_path:bp "s2" (make_meta "s2") in
   ignore (R.dispatch_event ~base_path:bp "s2" KSM.Stop_requested);
   ignore (R.dispatch_event ~base_path:bp "s2" KSM.Drain_complete);
   (* Stopped + unresolved done_p = sweep will handle *)
@@ -530,15 +530,15 @@ let test_reconcile_predicate_stopped_unresolved () =
 (** Simulate crash → re-register → restore_supervisor_state.
     Verifies restart_count and crash_log survive across re-registration. *)
 let test_restart_state_preservation () =
-  R.clear ();
+  R.For_testing.clear ();
   let meta = make_meta "restartable" in
-  let reg1 = R.register ~base_path:bp "restartable" meta in
+  let reg1 = R.For_testing.register ~base_path:bp "restartable" meta in
   resolve_done_for_test reg1 (`Crashed "first crash");
   ignore (R.dispatch_event ~base_path:bp "restartable"
     (KSM.Fiber_terminated { outcome = "first crash"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "restartable" 100.0 "first crash";
   (* Simulate sweep restart: re-register then restore state *)
-  let _reg2 = R.register ~base_path:bp "restartable" meta in
+  let _reg2 = R.For_testing.register ~base_path:bp "restartable" meta in
   R.restore_supervisor_state ~base_path:bp "restartable"
     ~restart_count:1 ~last_restart_ts:200.0
     ~crash_log:[(100.0, "first crash")];
@@ -562,9 +562,9 @@ let test_restart_state_preservation () =
 (** Simulate the turn failure crash path: supervisor catch sets
     Turn_consecutive_failures as failure_reason, state = Crashed. *)
 let test_crash_turn_failures () =
-  R.clear ();
+  R.For_testing.clear ();
   let meta = make_meta "turn-crash" in
-  let reg = R.register ~base_path:bp "turn-crash" meta in
+  let reg = R.For_testing.register ~base_path:bp "turn-crash" meta in
   let reason = R.Turn_consecutive_failures 10 in
   let reason_str = R.failure_reason_to_string reason in
   R.set_failure_reason ~base_path:bp "turn-crash" (Some reason);
@@ -597,11 +597,11 @@ let test_fresh_presence_preserves_turn_failures () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  R.clear ();
+  R.For_testing.clear ();
   let base_path = temp_dir "fresh-presence-turn-failure" in
   Fun.protect
     ~finally:(fun () ->
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_path)
     (fun () ->
       let config = Masc.Workspace.default_config base_path in
@@ -618,7 +618,7 @@ let test_fresh_presence_preserves_turn_failures () =
         }
       in
       let meta = make_meta "fresh-presence-turn-failure" in
-      ignore (R.register ~base_path:config.base_path meta.name meta);
+      ignore (R.For_testing.register ~base_path:config.base_path meta.name meta);
       R.increment_turn_failures ~base_path:config.base_path meta.name;
       ignore
         (R.dispatch_event
@@ -652,16 +652,16 @@ let test_fresh_presence_preserves_turn_failures () =
 let test_crashed_cycle_records_turn_failure () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  R.clear ();
+  R.For_testing.clear ();
   let base_path = temp_dir "crashed-cycle-turn-failure" in
   Fun.protect
     ~finally:(fun () ->
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_path)
     (fun () ->
       let config = Masc.Workspace.default_config base_path in
       let meta = make_meta "crashed-cycle" in
-      ignore (R.register ~base_path:config.base_path meta.name meta);
+      ignore (R.For_testing.register ~base_path:config.base_path meta.name meta);
       check int "no failures before crash" 0
         (R.get_turn_failures ~base_path:config.base_path meta.name);
       KHL.record_crashed_cycle_failure
@@ -695,7 +695,7 @@ let test_crashed_cycle_records_turn_failure () =
 let test_direct_start_keepalive_resolves_done_on_stop () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  R.clear ();
+  R.For_testing.clear ();
   let base_dir = temp_dir "direct-keepalive" in
   let keeper_name = "direct-lifecycle" in
   Fun.protect
@@ -2011,7 +2011,7 @@ let test_dashboard_purge_resolution_is_fail_closed () =
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2127,7 +2127,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
     ~finally:(fun () ->
       Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2139,7 +2139,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error detail -> fail detail);
-      let entry = R.register ~base_path:config.base_path name meta in
+      let entry = R.For_testing.register ~base_path:config.base_path name meta in
       let never_p, _never_r = Eio.Promise.create () in
       (match
          Lane.fork
@@ -2211,7 +2211,7 @@ let test_keeper_shutdown_prepare_joins_not_started_lane () =
     ~finally:(fun () ->
       Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2223,7 +2223,7 @@ let test_keeper_shutdown_prepare_joins_not_started_lane () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error detail -> fail detail);
-      let entry = R.register ~base_path:config.base_path name meta in
+      let entry = R.For_testing.register ~base_path:config.base_path name meta in
       let operation =
         match
           Shutdown_prepare_join.run
@@ -2263,7 +2263,7 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
     ~finally:(fun () ->
       Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2275,7 +2275,7 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error detail -> fail detail);
-      let entry = R.register ~base_path:config.base_path name meta in
+      let entry = R.For_testing.register ~base_path:config.base_path name meta in
       let probe_operation_id = Shutdown_types.Operation_id.generate () in
       let records_dir =
         match Shutdown_store.path ~config ~keeper_name:name probe_operation_id with
@@ -2328,7 +2328,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
       Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
       Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2444,7 +2444,7 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
       Lifecycle_hooks.reset_for_testing ();
       Subprocess_registry.reset_for_testing ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2460,7 +2460,7 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error detail -> fail detail);
-      let entry = R.register ~base_path:config.base_path meta.name meta in
+      let entry = R.For_testing.register ~base_path:config.base_path meta.name meta in
       let hook_deliveries = ref 0 in
       Subprocess_registry.register_default_cleanup_hook ();
       Lifecycle_hooks.register (fun ~keeper_id event ->
@@ -2696,7 +2696,7 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
       Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
       Shutdown_finalize.For_testing.reset_completion_handler ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -2943,7 +2943,7 @@ let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -3009,7 +3009,7 @@ let test_keeper_shutdown_recovers_committed_task_receipt () =
     ~finally:(fun () ->
       Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
       Masc.Keeper_turn_admission.For_testing.reset ();
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -3113,12 +3113,12 @@ let test_keeper_shutdown_recovers_committed_task_receipt () =
 let test_start_keepalive_denies_dead_tombstone_before_registration () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  R.clear ();
+  R.For_testing.clear ();
   let base_dir = temp_dir "dead-tombstone-keepalive-admission" in
   let keeper_name = "dead-tombstone-admission" in
   Fun.protect
     ~finally:(fun () ->
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
@@ -3152,19 +3152,19 @@ let test_start_keepalive_denies_dead_tombstone_before_registration () =
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  R.clear ();
+  R.For_testing.clear ();
   let base_dir = temp_dir "direct-keepalive-live-failing" in
   let keeper_name = "live-failing-entry" in
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_keepalive.stop_keepalive keeper_name;
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
       ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
       let meta = make_meta keeper_name in
-      let original = R.register ~base_path:config.base_path keeper_name meta in
+      let original = R.For_testing.register ~base_path:config.base_path keeper_name meta in
       ignore
         (R.dispatch_event
            ~base_path:config.base_path
@@ -3200,19 +3200,19 @@ let test_start_keepalive_preserves_unresolved_failing_entry () =
 let test_start_keepalive_reclaims_finished_failing_entry () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  R.clear ();
+  R.For_testing.clear ();
   let base_dir = temp_dir "direct-keepalive-stale-failing" in
   let keeper_name = "stale-failing-entry" in
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_keepalive.stop_keepalive keeper_name;
-      R.clear ();
+      R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
       ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
       let meta = make_meta keeper_name in
-      let original = R.register ~base_path:config.base_path keeper_name meta in
+      let original = R.For_testing.register ~base_path:config.base_path keeper_name meta in
       ignore
         (R.dispatch_event
            ~base_path:config.base_path
@@ -3248,9 +3248,9 @@ let test_start_keepalive_reclaims_finished_failing_entry () =
         Masc.Keeper_keepalive.stop_keepalive keeper_name)
 
 let test_stop_keepalive_only_requests_lane_stop () =
-  R.clear ();
+  R.For_testing.clear ();
   let keeper_name = "manual-stop-entry" in
-  let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
+  let reg = R.For_testing.register ~base_path:bp keeper_name (make_meta keeper_name) in
   Masc.Keeper_keepalive.stop_keepalive keeper_name;
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected manual-stop-entry in registry"
@@ -3271,9 +3271,9 @@ let test_stop_keepalive_only_requests_lane_stop () =
       (not (R.lane_has_exited entry))
 
 let test_stop_keepalive_preserves_existing_crash_outcome () =
-  R.clear ();
+  R.For_testing.clear ();
   let keeper_name = "crashed-before-stop" in
-  let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
+  let reg = R.For_testing.register ~base_path:bp keeper_name (make_meta keeper_name) in
   let reason = "already crashed" in
   ignore (R.dispatch_event ~base_path:bp keeper_name
     (KSM.Fiber_terminated { outcome = "already crashed"; provider_id = None; http_status = None }));
@@ -3292,9 +3292,9 @@ let test_stop_keepalive_preserves_existing_crash_outcome () =
      | None -> fail "expected crash promise to remain resolved")
 
 let test_resolve_done_reports_prior_outcome () =
-  R.clear ();
+  R.For_testing.clear ();
   let keeper_name = "double-resolve-contract" in
-  let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
+  let reg = R.For_testing.register ~base_path:bp keeper_name (make_meta keeper_name) in
   (match R.resolve_done reg ~source:"test_first" (`Crashed "first") with
    | R.Done_resolved { source } -> check string "first source" "test_first" source
    | R.Done_already_resolved _ -> fail "first resolve should succeed");
@@ -3361,13 +3361,13 @@ let test_pipeline_stage_detail_distinguishes_offline_projection () =
     a non-None mapping. This tests the production boundary:
     get_phase feeds into pipeline_stage_of_phase. *)
 let test_pipeline_stage_unregistered_is_offline () =
-  R.clear ();
+  R.For_testing.clear ();
   (* Unregistered: get_phase must return None *)
   check bool "unregistered → no phase"
     true (Option.is_none (R.get_phase ~base_path:bp "ghost"));
   (* Registered: get_phase returns real phase, of_phase gives deterministic stage *)
   let meta = make_meta "alive" in
-  let _reg = R.register ~base_path:bp "alive" meta in
+  let _reg = R.For_testing.register ~base_path:bp "alive" meta in
   (match R.get_phase ~base_path:bp "alive" with
    | Some phase ->
      let stage = ES.pipeline_stage_of_phase phase in

--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -35,7 +35,7 @@ let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
   let keeper_name = "compact-missing-checkpoint" in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.unregister ~base_path keeper_name;
+      Keeper_registry.For_testing.unregister ~base_path keeper_name;
       Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
       let config = Workspace.default_config base_path in
@@ -50,7 +50,7 @@ let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
        | Error detail -> failf "keeper meta write failed: %s" detail);
       let persisted_meta = persisted_meta_exn config keeper_name in
       ignore
-        (Keeper_registry.register
+        (Keeper_registry.For_testing.register
            ~base_path:config.base_path
            keeper_name
            persisted_meta);

--- a/test/test_keeper_composite_live_turn_surface.ml
+++ b/test/test_keeper_composite_live_turn_surface.ml
@@ -40,7 +40,7 @@ let make_meta name =
 (* Register a keeper and return the fresh entry after [setup] has run its
    registry mutations, so the observer sees the mutated SSOT. *)
 let observed_json ~base ~name ~setup () =
-  ignore (Keeper_registry.register ~base_path:base name (make_meta name));
+  ignore (Keeper_registry.For_testing.register ~base_path:base name (make_meta name));
   setup ();
   match Keeper_registry.get ~base_path:base name with
   | Some entry -> Observer.snapshot_to_json (Observer.observe entry)
@@ -123,10 +123,10 @@ let test_board_cursor_and_wakeups () =
         Keeper_registry.set_board_cursor ~base_path:base name 1234.5
           (Some "post-42");
         ignore
-          (Keeper_registry.board_wakeup_allowed ~base_path:base name
+          (Keeper_registry.For_testing.board_wakeup_allowed ~base_path:base name
              ~dedup_key:"fingerprint-a" ~debounce_sec:60.0);
         ignore
-          (Keeper_registry.board_wakeup_allowed ~base_path:base name
+          (Keeper_registry.For_testing.board_wakeup_allowed ~base_path:base name
              ~dedup_key:"fingerprint-b" ~debounce_sec:60.0))
       ()
   in

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -919,12 +919,12 @@ let test_status_reads_live_registry_each_call () =
     ~instructions:"live registry observation";
   let config = Workspace.default_config base in
   let meta = seed_runtime_meta config name in
-  Masc.Keeper_registry.clear ();
+  Masc.Keeper_registry.For_testing.clear ();
   Fun.protect
-    ~finally:Masc.Keeper_registry.clear
+    ~finally:Masc.Keeper_registry.For_testing.clear
     (fun () ->
       ignore
-        (Masc.Keeper_registry.register
+        (Masc.Keeper_registry.For_testing.register
            ~base_path:config.base_path
            name
            meta);
@@ -1038,10 +1038,10 @@ instructions = "missing sandbox profile"
 |};
   let config = Workspace.default_config base in
   let meta = seed_runtime_meta config name in
-  Masc.Keeper_registry.clear ();
-  ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+  Masc.Keeper_registry.For_testing.clear ();
+  ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
   Fun.protect
-    ~finally:Masc.Keeper_registry.clear
+    ~finally:Masc.Keeper_registry.For_testing.clear
     (fun () ->
       match Keeper_tool_surface_ops.keeper_list_row_json ~runtime_class:"keeper" config name with
       | None -> Alcotest.fail "expected error row for invalid effective meta"
@@ -1061,10 +1061,10 @@ instructions = "missing sandbox profile"
 |};
   let config = Workspace.default_config base in
   let meta = seed_runtime_meta config name in
-  Masc.Keeper_registry.clear ();
-  ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+  Masc.Keeper_registry.For_testing.clear ();
+  ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
   Fun.protect
-    ~finally:Masc.Keeper_registry.clear
+    ~finally:Masc.Keeper_registry.For_testing.clear
     (fun () ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
@@ -1139,9 +1139,9 @@ let test_reactive_overflow_stamps_compaction_decision () =
   let name = "overflow-observability" in
   let config = Workspace.default_config base in
   let meta = seed_runtime_meta config name in
-  Masc.Keeper_registry.clear ();
-  ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
-  Fun.protect ~finally:Masc.Keeper_registry.clear (fun () ->
+  Masc.Keeper_registry.For_testing.clear ();
+  ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
+  Fun.protect ~finally:Masc.Keeper_registry.For_testing.clear (fun () ->
       let reason = "plan_provider_unavailable" in
       Masc.Keeper_turn_runtime_budget.record_overflow_failure ~config ~meta ~reason;
       let latest =
@@ -1169,9 +1169,9 @@ let test_reactive_overflow_persists_compaction_decision_to_disk () =
   let name = "overflow-durable" in
   let config = Workspace.default_config base in
   let meta = seed_runtime_meta config name in
-  Masc.Keeper_registry.clear ();
-  ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
-  Fun.protect ~finally:Masc.Keeper_registry.clear (fun () ->
+  Masc.Keeper_registry.For_testing.clear ();
+  ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
+  Fun.protect ~finally:Masc.Keeper_registry.For_testing.clear (fun () ->
       let reason = "plan_provider_unavailable" in
       Masc.Keeper_turn_runtime_budget.record_overflow_failure ~config ~meta ~reason;
       match Store.read_meta config name with

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -998,19 +998,19 @@ let () =
   let base_path = temp_dir "keeper-event-queue-registry" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-registry-test" in
       let meta = meta_for_keeper keeper_name "trace-event-queue-registry-test" in
-      Masc.Keeper_registry.clear ();
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry.For_testing.clear ();
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       assert (length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
-      Masc.Keeper_registry.clear ();
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry.For_testing.clear ();
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
       assert (length restored = 1);
       (match
@@ -1049,7 +1049,7 @@ let () =
   let base_path = temp_dir "keeper-event-queue-registry-base-alias" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-registry-base-alias-test" in
@@ -1059,10 +1059,10 @@ let () =
         Keeper_event_queue.to_list queue
         |> List.map (fun (stimulus : Keeper_event_queue.stimulus) -> stimulus.post_id)
       in
-      Masc.Keeper_registry.clear ();
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry.For_testing.clear ();
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       ignore
-        (Masc.Keeper_registry.register
+        (Masc.Keeper_registry.For_testing.register
            ~base_path:base_path_masc
            keeper_name
            meta);
@@ -1112,9 +1112,9 @@ let () =
            ~keeper_name
          |> queue_post_ids);
 
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       ignore
-        (Masc.Keeper_registry.register
+        (Masc.Keeper_registry.For_testing.register
            ~base_path:base_path_masc
            keeper_name
            meta);
@@ -1134,13 +1134,13 @@ let () =
   let base_path = temp_dir "keeper-event-queue-turn-digest" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-turn-digest-test" in
       let meta = meta_for_keeper keeper_name "trace-event-queue-turn-digest-test" in
-      Masc.Keeper_registry.clear ();
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry.For_testing.clear ();
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       let digest_now = Unix.gettimeofday () in
       let board_at ~post_id ~urgency arrived_at =
         { post_id; urgency; arrived_at; payload = board_payload () }
@@ -1225,12 +1225,12 @@ let () =
   let base_path = temp_dir "keeper-event-queue-unregistered" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-unregistered-test" in
       let meta = meta_for_keeper keeper_name "trace-event-queue-unregistered-test" in
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name bootstrap_stim;
@@ -1241,7 +1241,7 @@ let () =
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
       let pending = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
       assert (length pending = 2);
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
       assert (length restored = 2);
       let claim_and_ack expected_post_id =
@@ -1323,18 +1323,18 @@ let () =
     let base_path = temp_dir "keeper-event-queue-autonomous-yield" in
     Fun.protect
       ~finally:(fun () ->
-        Masc.Keeper_registry.clear ();
+        Masc.Keeper_registry.For_testing.clear ();
         Masc.Keeper_chat_queue.For_testing.reset ();
         rm_rf base_path)
       (fun () ->
         let keeper_name = "keeper-event-queue-yield-test" in
         let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
-        Masc.Keeper_registry.clear ();
+        Masc.Keeper_registry.For_testing.clear ();
         Masc.Keeper_chat_queue.For_testing.reset ();
         ignore
           (Masc.Keeper_chat_queue.configure_persistence ~base_path
             : Masc.Keeper_chat_queue.configure_report);
-        ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+        ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
         (match
            Masc.Keeper_unified_turn_execution.autonomous_yield_request
              ~base_path
@@ -1370,12 +1370,12 @@ let () =
   let base_path = temp_dir "keeper-event-queue-durable-unregistered" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-durable-unregistered-test" in
       let meta = meta_for_keeper keeper_name "trace-durable-unregistered-test" in
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       (match
          Masc.Keeper_registry_event_queue.enqueue_durable_result
            ~base_path
@@ -1385,7 +1385,7 @@ let () =
        | Ok () -> ()
        | Error msg -> Alcotest.fail ("durable enqueue failed: " ^ msg));
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       let _lease, stimulus =
         claim_single
           ~base_path
@@ -1488,12 +1488,12 @@ let () =
   let base_path = temp_dir "keeper-event-queue-durable-offline" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-durable-offline-test" in
       let meta = meta_for_keeper keeper_name "trace-durable-offline-test" in
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       ignore (Masc.Keeper_registry.register_offline ~base_path keeper_name meta);
       (match
          Masc.Keeper_registry_event_queue.enqueue_durable_result
@@ -1546,13 +1546,13 @@ let () =
   let base_path = temp_dir "keeper-event-queue-requeue-front" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry.For_testing.clear ();
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-requeue-front-test" in
       let meta = meta_for_keeper keeper_name "trace-event-queue-requeue-front-test" in
-      Masc.Keeper_registry.clear ();
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry.For_testing.clear ();
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name bootstrap_stim;
       let consumed_lease, consumed =

--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -79,13 +79,13 @@ let setup f =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
-       Keeper_registry.clear ();
+       Keeper_registry.For_testing.clear ();
        let config = Workspace.default_config base in
        let meta = { (make_meta "tester") with always_allow = Some true } in
        let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
        ensure_dir playground;
        let (_registered : Keeper_registry.registry_entry) =
-         Keeper_registry.register ~base_path:base meta.name meta
+         Keeper_registry.For_testing.register ~base_path:base meta.name meta
        in
        Masc_test_deps.with_publication_recovery_registry
          ~sw

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -74,12 +74,12 @@ let setup ?(sandbox = Keeper_types_profile_sandbox.Local) f =
   let base = temp_dir () in
   ensure_dir (Filename.concat base Common.masc_dirname);
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let config = Workspace.default_config base in
   let meta = make_meta ~sandbox "tester" in
   let playground = Masc.Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
-  ignore (Keeper_registry.register ~base_path:base meta.name meta);
+  ignore (Keeper_registry.For_testing.register ~base_path:base meta.name meta);
   Masc_test_deps.with_publication_recovery_registry
     ~sw
     ~fs

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -331,9 +331,9 @@ let test_ollama_probe_allow_dispatches_exact_input () =
   Fun.protect ~finally:(fun () -> remove_tree base_path) @@ fun () ->
   let config = Workspace.default_config base_path in
   let meta = make_meta ~always_allow:true "ollama-gate-allow-keeper" in
-  ignore (Keeper_registry.register ~base_path meta.name meta);
+  ignore (Keeper_registry.For_testing.register ~base_path meta.name meta);
   Fun.protect
-    ~finally:(fun () -> Keeper_registry.unregister ~base_path meta.name)
+    ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path meta.name)
   @@ fun () ->
   let result =
     Keeper_tool_in_process_runtime.handle_masc_local_runtime_with_outcome

--- a/test/test_keeper_identity_drift_counter.ml
+++ b/test/test_keeper_identity_drift_counter.ml
@@ -60,7 +60,7 @@ let is_error_json raw =
 (* ── find_registry_meta tests ─────────────────────────────────────────── *)
 
 let test_find_registry_meta_missing () =
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let before = counter_value ~source_layer:"test_layer" ~field:"registry_missing" in
   let result =
     KES.find_registry_meta ~keeper_name:"nonexistent-keeper" ~source_layer:"test_layer"
@@ -72,7 +72,7 @@ let test_find_registry_meta_missing () =
 ;;
 
 let test_find_registry_meta_mismatch () =
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let base = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base)
@@ -84,7 +84,7 @@ let test_find_registry_meta_mismatch () =
        in
        (* Register under a different name than meta.name. The registry repairs
           this at insert time, so the lookup layer should not see live drift. *)
-       ignore (Keeper_registry.register ~base_path:base "alias-name" meta);
+       ignore (Keeper_registry.For_testing.register ~base_path:base "alias-name" meta);
        let before = counter_value ~source_layer:"test_layer" ~field:"name_mismatch" in
        let result =
          KES.find_registry_meta ~keeper_name:"alias-name" ~source_layer:"test_layer"
@@ -103,13 +103,13 @@ let test_find_registry_meta_mismatch () =
 ;;
 
 let test_find_registry_meta_match () =
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let base = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
        let meta = make_meta "matched-name" in
-       ignore (Keeper_registry.register ~base_path:base "matched-name" meta);
+       ignore (Keeper_registry.For_testing.register ~base_path:base "matched-name" meta);
        let before_missing =
          counter_value ~source_layer:"test_layer" ~field:"registry_missing"
        in
@@ -131,7 +131,7 @@ let test_find_registry_meta_match () =
 (* ── with_registry_meta tests ─────────────────────────────────────────── *)
 
 let test_with_registry_meta_missing () =
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let result =
     KES.with_registry_meta ~keeper_name:"missing-keeper" ~source_layer:"test_layer"
       (fun _meta -> {|{"ok":true}|})
@@ -140,13 +140,13 @@ let test_with_registry_meta_missing () =
 ;;
 
 let test_with_registry_meta_match () =
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let base = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
        let meta = make_meta "found-keeper" in
-       ignore (Keeper_registry.register ~base_path:base "found-keeper" meta);
+       ignore (Keeper_registry.For_testing.register ~base_path:base "found-keeper" meta);
        let result =
          KES.with_registry_meta ~keeper_name:"found-keeper" ~source_layer:"test_layer"
            (fun meta -> Printf.sprintf {|{"ok":true,"name":"%s"}|} meta.name)

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -75,13 +75,13 @@ let test_current_task_id_for_agent_reconciles_from_empty_registry_task () =
         version = 2;
       };
     ignore
-      (Keeper_registry.register
+      (Keeper_registry.For_testing.register
          ~base_path:config.Workspace.base_path
          keeper_name
          meta);
     Fun.protect
       ~finally:(fun () ->
-        Keeper_registry.unregister ~base_path:config.Workspace.base_path keeper_name)
+        Keeper_registry.For_testing.unregister ~base_path:config.Workspace.base_path keeper_name)
       (fun () ->
         check string "heartbeat task id" task_id
           (KK.current_task_id_for_agent ~config agent_name);
@@ -270,7 +270,7 @@ let persist_and_register_board_lane config meta =
    | Ok () -> ()
    | Error detail -> fail ("write_meta failed: " ^ detail));
   ignore
-    (Keeper_registry.register
+    (Keeper_registry.For_testing.register
        ~base_path:config.Workspace.base_path
        meta.Keeper_meta_contract.name
        meta)
@@ -293,7 +293,7 @@ let overwrite_file path contents =
 let test_exact_mentions_deliver_and_wake_each_lane_independently () =
   with_temp_workspace @@ fun config ->
   Fun.protect
-    ~finally:Keeper_registry.clear
+    ~finally:Keeper_registry.For_testing.clear
     (fun () ->
        let alpha = make_board_resume_meta "alpha" in
        let beta = make_board_resume_meta "beta" in
@@ -325,7 +325,7 @@ let test_exact_mentions_deliver_and_wake_each_lane_independently () =
 let test_paused_exact_mention_is_durable_without_wake () =
   with_temp_workspace @@ fun config ->
   Fun.protect
-    ~finally:Keeper_registry.clear
+    ~finally:Keeper_registry.For_testing.clear
     (fun () ->
        let meta = make_board_resume_meta "pausedlane" in
        persist_and_register_board_lane config meta;
@@ -359,7 +359,7 @@ let test_paused_exact_mention_is_durable_without_wake () =
 let test_restarting_exact_mention_is_durable_with_deferred_wake () =
   with_temp_workspace @@ fun config ->
   Fun.protect
-    ~finally:Keeper_registry.clear
+    ~finally:Keeper_registry.For_testing.clear
     (fun () ->
        let meta = make_board_resume_meta "restartlane" in
        (match Keeper_meta_store.write_meta config meta with
@@ -396,7 +396,7 @@ let test_restarting_exact_mention_is_durable_with_deferred_wake () =
 let test_lane_meta_failure_does_not_block_next_durable_delivery () =
   with_temp_workspace @@ fun config ->
   Fun.protect
-    ~finally:Keeper_registry.clear
+    ~finally:Keeper_registry.For_testing.clear
     (fun () ->
        let broken = make_board_resume_meta "zzzbroken" in
        let healthy = make_board_resume_meta "aaahealthy" in

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -180,15 +180,15 @@ let test_grpc_pause_directive_records_reason () =
   let base_path = Masc_test_deps.setup_test_workspace () in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
        let keeper_name = "grpc-directive-keeper" in
        let meta = make_meta keeper_name in
-       Keeper_registry.clear ();
-       ignore (Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       Keeper_registry.For_testing.clear ();
+       ignore (Keeper_registry.For_testing.register ~base_path:config.base_path keeper_name meta);
        Keeper_keepalive.process_directive
          ~agent_name:keeper_name
          Keeper_directive.Pause;

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -70,8 +70,8 @@ let dispatch_expect_rejected name event =
   | Error (KSM.Precondition_violation _) -> ()
 
 let setup name =
-  R.clear ();
-  ignore (R.register ~base_path:bp name (make_meta name))
+  R.For_testing.clear ();
+  ignore (R.For_testing.register ~base_path:bp name (make_meta name))
 
 (** Drives keeper from Running → Failing → Crashed via heartbeat failure + fiber death. *)
 let crash_keeper name =
@@ -211,10 +211,10 @@ let test_full_chaos_sequence () =
   check phase_t "final stopped" KSM.Stopped tr.new_phase
 
 let test_fleet_chaos () =
-  R.clear ();
+  R.For_testing.clear ();
   let keepers = ["fleet-a"; "fleet-b"; "fleet-c"; "fleet-d"] in
   List.iter (fun name ->
-    ignore (R.register ~base_path:bp name (make_meta name))
+    ignore (R.For_testing.register ~base_path:bp name (make_meta name))
   ) keepers;
 
   ignore (dispatch "fleet-a" KSM.Heartbeat_ok);

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -159,15 +159,15 @@ let test_registry_rejects_meta_name_mismatch_update () =
   let base_dir = temp_dir "keeper_lifecycle_registry_meta_mismatch" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-registry-meta-mismatch" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       let bad_meta = { meta with name = "wrong-keeper-name" } in
       KR.update_meta ~base_path:config.base_path meta.name bad_meta;
       match KR.get ~base_path:config.base_path meta.name with
@@ -179,18 +179,18 @@ let test_registry_canonicalizes_mismatched_meta_on_register () =
   let base_dir = temp_dir "keeper_lifecycle_registry_register_repair" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let registry_name = "keeper-registry-register-repair" in
       let bad_meta =
         { (make_keeper_meta ~name:"wrong-register-name" ()) with agent_name = "" }
       in
-      ignore (KR.register ~base_path:config.base_path registry_name bad_meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path registry_name bad_meta);
       match KR.get ~base_path:config.base_path registry_name with
       | Some entry ->
           check string "registry repairs meta name" registry_name entry.meta.name;
@@ -203,12 +203,12 @@ let test_registry_reload_meta_from_disk_repairs_stale_meta () =
   let base_dir = temp_dir "keeper_lifecycle_registry_meta_reload" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let name = "keeper-registry-meta-reload" in
       write_keeper_toml
@@ -220,9 +220,9 @@ let test_registry_reload_meta_from_disk_repairs_stale_meta () =
         ];
       let persisted_meta = make_keeper_meta ~name () in
       let stale_meta = { persisted_meta with instructions = "stale instructions" } in
-      ignore (KR.register ~base_path:config.base_path name stale_meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path name stale_meta);
       write_keeper_meta_json_for_name config name persisted_meta;
-      match KR.reload_meta_from_disk ~base_path:config.base_path name with
+      match KR.For_testing.reload_meta_from_disk ~base_path:config.base_path name with
       | Ok (Some entry) ->
           check string "reload applies base-path TOML instructions" "fresh instructions"
             entry.meta.instructions
@@ -236,10 +236,10 @@ let test_dispatch_keeper_phase_event_uses_workspace_base_path () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-phase-regression" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       KEC.dispatch_keeper_phase_event
         ~config
         ~origin:KR.Post_turn_lifecycle
@@ -258,10 +258,10 @@ let test_dispatch_compaction_completed_uses_workspace_base_path () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-outcome-regression" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       KEC.dispatch_keeper_phase_event
         ~config
         ~origin:KR.Post_turn_lifecycle
@@ -282,15 +282,15 @@ let test_compaction_runs_from_failing_health_lane () =
   let base_dir = temp_dir "keeper_lifecycle_registry_failing_compaction" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-failing-compaction" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       KEC.dispatch_keeper_phase_event
         ~config
         ~keeper_name:meta.name
@@ -325,15 +325,15 @@ let test_compaction_completion_without_started_is_nonfatal () =
   let base_dir = temp_dir "keeper_lifecycle_registry_missing_start" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-missing-compaction-start" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       let labels =
         [ ("keeper", meta.name); ("event", "compaction_completed") ]
       in
@@ -365,15 +365,15 @@ let test_compaction_restarts_after_done_stage () =
   let base_dir = temp_dir "keeper_lifecycle_registry_repeat_compaction" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-repeat-compaction" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       let run_compaction label =
         KEC.dispatch_keeper_phase_event
           ~config
@@ -403,15 +403,15 @@ let test_dispatch_keeper_phase_event_rejects_unscoped_lifecycle_event () =
   let base_dir = temp_dir "keeper_lifecycle_registry_origin_guard" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-origin-guard" () in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      ignore (KR.For_testing.register ~base_path:config.base_path meta.name meta);
       let labels =
         [ ("keeper", meta.name); ("event", "compaction_started") ]
       in
@@ -511,13 +511,13 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
   let base_dir = temp_dir "keeper_lifecycle_keepalive_rejection" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let ctx : _ Keeper_types_profile.context =
         {
@@ -558,14 +558,14 @@ let test_publication_recovery_turn_resolution_is_filesystem_idle () =
   let base_dir = temp_dir "keeper_publication_recovery_scope" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let keeper_name = "publication-scope-exact-lane" in
       let meta = make_keeper_meta ~name:keeper_name () in
-      let entry = KR.register ~base_path:config.base_path keeper_name meta in
+      let entry = KR.For_testing.register ~base_path:config.base_path keeper_name meta in
       let provider_reads = Atomic.make 0 in
       let provider () =
         Atomic.incr provider_reads;
@@ -596,10 +596,10 @@ let test_publication_recovery_scope_preserves_typed_lookup_failures () =
   let base_dir = temp_dir "keeper_publication_recovery_failures" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       let config = Masc.Workspace.default_config base_dir in
       let keeper_name = "publication-scope-failures" in
       let provider =
@@ -627,7 +627,7 @@ let test_publication_recovery_scope_preserves_typed_lookup_failures () =
            ~base_path:config.base_path
            ~keeper_name);
       let entry =
-        KR.register
+        KR.For_testing.register
           ~base_path:config.base_path
           keeper_name
           (make_keeper_meta ~name:keeper_name ())

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -188,8 +188,8 @@ let test_manual_compaction_serializes_owner_lane () =
     ~finally:(fun () ->
       Runtime.For_testing.restore runtime_snapshot;
       Admission.For_testing.reset ();
-      Masc.Keeper_registry.unregister ~base_path meta.name;
-      Masc.Keeper_registry.unregister ~base_path peer.name;
+      Masc.Keeper_registry.For_testing.unregister ~base_path meta.name;
+      Masc.Keeper_registry.For_testing.unregister ~base_path peer.name;
       Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
       let config = Masc.Workspace.default_config base_path in
@@ -201,8 +201,8 @@ let test_manual_compaction_serializes_owner_lane () =
        | Ok () -> ()
        | Error detail -> failf "runtime fixture initialization failed: %s" detail);
       Result.get_ok (Masc.Keeper_meta_store.write_meta config meta);
-      let owner_entry = Masc.Keeper_registry.register ~base_path meta.name meta in
-      let peer_entry = Masc.Keeper_registry.register ~base_path peer.name peer in
+      let owner_entry = Masc.Keeper_registry.For_testing.register ~base_path meta.name meta in
+      let peer_entry = Masc.Keeper_registry.For_testing.register ~base_path peer.name peer in
       Atomic.set owner_entry.fiber_wakeup false;
       Atomic.set peer_entry.fiber_wakeup false;
       let checkpoint =

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -33,13 +33,13 @@ let make_meta name =
 
 let register name =
   let meta = make_meta name in
-  KR.register ~base_path meta.name meta
+  KR.For_testing.register ~base_path meta.name meta
 ;;
 
 let health_to_string = KR.registry_entry_validation_error_to_string
 
 let test_put_entry_rejects_meta_name_mismatch () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let entry = register "alice" in
   let corrupted = { entry with meta = { entry.meta with name = "bob" } } in
   match KR.put_entry ~base_path "alice" corrupted with
@@ -51,7 +51,7 @@ let test_put_entry_rejects_meta_name_mismatch () =
 ;;
 
 let test_update_entry_rejects_corrupted_result () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let entry = register "alice" in
   let original_base_path = entry.base_path in
   (match
@@ -66,7 +66,7 @@ let test_update_entry_rejects_corrupted_result () =
 ;;
 
 let test_unregister_exact_preserves_replacement_lane () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let old_entry = register "alice" in
   let replacement = register "alice" in
   (match KR.unregister_exact old_entry with
@@ -88,7 +88,7 @@ let test_unregister_exact_preserves_replacement_lane () =
 ;;
 
 let test_unregister_exact_accepts_same_lane_record_update () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let observed = register "alice" in
   (match
      KR.update_entry ~base_path "alice" (fun entry ->
@@ -105,7 +105,7 @@ let test_unregister_exact_accepts_same_lane_record_update () =
 ;;
 
 let test_update_entry_exact_preserves_replacement_lane () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let old_entry = register "alice" in
   let replacement = register "alice" in
   (match
@@ -125,7 +125,7 @@ let test_update_entry_exact_preserves_replacement_lane () =
 ;;
 
 let test_dispatch_event_exact_preserves_replacement_lane () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let old_meta = make_meta "alice" in
   let old_entry = KR.register_offline ~base_path old_meta.name old_meta in
   let replacement = KR.register_offline ~base_path old_meta.name old_meta in
@@ -179,7 +179,7 @@ let test_lane_fork_rejects_cancelling_switch () =
 ;;
 
 let test_dispatch_write_failure_skips_phase_side_effects () =
-  KR.clear ();
+  KR.For_testing.clear ();
   KLH.reset_for_testing ();
   Fun.protect
     ~finally:(fun () -> KLH.reset_for_testing ())
@@ -200,7 +200,7 @@ let test_dispatch_write_failure_skips_phase_side_effects () =
 ;;
 
 let test_get_filters_corrupted_entry () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let entry = register "alice" in
   let corrupted =
     { entry with
@@ -223,7 +223,7 @@ let test_get_filters_corrupted_entry () =
 ;;
 
 let test_wakeup_running_reports_typed_outcome () =
-  KR.clear ();
+  KR.For_testing.clear ();
   (match
      KR.wakeup_running ~intent:KR.Hitl_resolution ~base_path "missing"
    with
@@ -253,7 +253,7 @@ let test_wakeup_running_reports_typed_outcome () =
 ;;
 
 let test_wakeup_running_exact_preserves_owner_lane () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let captured = register "exact-owner" in
   let peer = register "exact-peer" in
   Atomic.set captured.fiber_wakeup false;
@@ -306,9 +306,9 @@ let test_wakeup_running_exact_preserves_owner_lane () =
 ;;
 
 let test_wakeup_running_exact_reports_deferred_outcomes () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let removed = register "exact-missing" in
-  KR.clear ();
+  KR.For_testing.clear ();
   (match KR.wakeup_running_exact ~intent:KR.Reactive_signal removed with
    | KR.Exact_wake_missing -> ()
    | KR.Exact_wake_signaled
@@ -329,7 +329,7 @@ let test_wakeup_running_exact_reports_deferred_outcomes () =
    | KR.Exact_wake_lifecycle_reserved _ ->
      fail "offline exact owner did not report phase");
   let paused_meta = { (make_meta "exact-paused") with paused = true } in
-  let paused = KR.register ~base_path paused_meta.name paused_meta in
+  let paused = KR.For_testing.register ~base_path paused_meta.name paused_meta in
   (match KR.wakeup_running_exact ~intent:KR.Reactive_signal paused with
    | KR.Exact_wake_lifecycle_denied
        (Keeper_lifecycle_admission.Autonomous_paused _) -> ()
@@ -344,7 +344,7 @@ let test_wakeup_running_exact_reports_deferred_outcomes () =
 ;;
 
 let test_wakeup_running_exact_respects_lifecycle_owner_and_replacement () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let captured = register "exact-reserved" in
   Atomic.set captured.fiber_wakeup false;
   let token =
@@ -416,9 +416,9 @@ let test_wakeup_running_exact_respects_lifecycle_owner_and_replacement () =
 ;;
 
 let test_wakeup_denies_paused_and_dead_without_signaling () =
-  KR.clear ();
+  KR.For_testing.clear ();
   let paused_meta = { (make_meta "paused-wakeup") with paused = true } in
-  let paused_entry = KR.register ~base_path paused_meta.name paused_meta in
+  let paused_entry = KR.For_testing.register ~base_path paused_meta.name paused_meta in
   Atomic.set paused_entry.fiber_wakeup false;
   (match KR.wakeup_running ~intent:KR.Scheduled_signal ~base_path paused_meta.name with
    | KR.Deferred_lifecycle (Keeper_lifecycle_admission.Autonomous_paused _) -> ()
@@ -434,7 +434,7 @@ let test_wakeup_denies_paused_and_dead_without_signaling () =
     ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
     }
   in
-  let entry = KR.register ~base_path meta.name meta in
+  let entry = KR.For_testing.register ~base_path meta.name meta in
   Atomic.set entry.fiber_wakeup false;
   (match KR.wakeup_running ~intent:KR.Scheduled_signal ~base_path meta.name with
    | KR.Deferred_lifecycle
@@ -474,12 +474,12 @@ let test_reactive_wakeup_defers_offline_lane_after_queue_commit () =
   let dir = temp_dir "registry_reactive_offline_wakeup" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir dir)
     (fun () ->
        Eio_main.run @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
-       KR.clear ();
+       KR.For_testing.clear ();
        let meta = make_meta "reactive-offline" in
        let entry = KR.register_offline ~base_path:dir meta.name meta in
        let stimulus : Keeper_event_queue.stimulus =
@@ -509,12 +509,12 @@ let test_goal_assignment_defers_offline_lane_after_queue_commit () =
   let dir = temp_dir "registry_goal_offline_wakeup" in
   Fun.protect
     ~finally:(fun () ->
-      KR.clear ();
+      KR.For_testing.clear ();
       cleanup_dir dir)
     (fun () ->
        Eio_main.run @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
-       KR.clear ();
+       KR.For_testing.clear ();
        let config = Masc.Workspace.default_config dir in
        let meta = make_meta "goal-offline" in
        let entry =
@@ -576,10 +576,10 @@ let test_tool_dispatch_preserves_exact_meta_after_replacement () =
          Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
        in
        let _original_entry =
-         KR.register ~base_path:config.base_path meta.name meta
+         KR.For_testing.register ~base_path:config.base_path meta.name meta
        in
        Fun.protect
-         ~finally:(fun () -> KR.unregister ~base_path:config.base_path meta.name)
+         ~finally:(fun () -> KR.For_testing.unregister ~base_path:config.base_path meta.name)
          (fun () ->
             let provider_reads = Atomic.make 0 in
             let provider () =
@@ -605,7 +605,7 @@ let test_tool_dispatch_preserves_exact_meta_after_replacement () =
               }
             in
             let replacement =
-              KR.register
+              KR.For_testing.register
                 ~base_path:config.base_path
                 replacement_meta.name
                 replacement_meta

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -223,7 +223,7 @@ let setup ~sandbox f =
   ensure_dir config_dir;
   let config = Workspace.default_config base in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let meta = make_meta ~name:"minjae" ~sandbox () in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
@@ -249,7 +249,7 @@ let setup_with_sandbox ~sandbox f =
   ensure_dir config_dir;
   let config = Workspace.default_config base in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let meta = make_meta ~name:"minjae" ~sandbox () in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
@@ -279,11 +279,11 @@ let test_turn_sandbox_factory_uses_refreshed_registry_meta () =
     }
   in
   let factory = Keeper_sandbox_factory.create ~config ~meta () in
-  ignore (Keeper_registry.register ~base_path:config.Workspace.base_path meta.name docker_meta);
+  ignore (Keeper_registry.For_testing.register ~base_path:config.Workspace.base_path meta.name docker_meta);
   Fun.protect
     ~finally:(fun () ->
       Keeper_sandbox_factory.cleanup factory;
-      Keeper_registry.unregister ~base_path:config.Workspace.base_path meta.name)
+      Keeper_registry.For_testing.unregister ~base_path:config.Workspace.base_path meta.name)
   @@ fun () ->
   let docker_playground = Keeper_sandbox.host_root_abs_of_meta ~config docker_meta in
   match Keeper_sandbox_factory.resolve factory ~cwd:docker_playground with

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -173,23 +173,23 @@ let test_keep_last_n_over_limit () =
 (* ── Registry-based tests (replacing removed supervisor Hashtbl queries) *)
 
 let test_fiber_health_unknown () =
-  Reg.clear ();
+  Reg.For_testing.clear ();
   let health = Reg.fiber_health_of ~base_path:"/tmp" "nonexistent-keeper" in
   check bool "unknown for unregistered"
     true (health = KT.Fiber_unknown)
 
 let test_registry_count_initially_zero () =
-  Reg.clear ();
+  Reg.For_testing.clear ();
   check int "no keepers initially" 0 (Reg.count_running ())
 
 let test_crash_log_empty_for_unknown () =
-  Reg.clear ();
+  Reg.For_testing.clear ();
   check int "empty crash log" 0
-    (List.length (Reg.crash_log_of ~base_path:"/tmp" "nonexistent"))
+    (List.length (Reg.For_testing.crash_log_of ~base_path:"/tmp" "nonexistent"))
 
 let test_should_cleanup_dead_true () =
-  Reg.clear ();
-  let _entry = Reg.register ~base_path:"/tmp" "dead1"
+  Reg.For_testing.clear ();
+  let _entry = Reg.For_testing.register ~base_path:"/tmp" "dead1"
       (let json = `Assoc [
         ("name", `String "dead1");
         ("agent_name", `String "agent-dead1");
@@ -207,8 +207,8 @@ let test_should_cleanup_dead_true () =
     (Sup.should_cleanup_dead ~now:4000.0 ~dead_ttl_sec:3600.0 entry)
 
 let test_should_cleanup_dead_false_when_recent () =
-  Reg.clear ();
-  let _entry = Reg.register ~base_path:"/tmp" "dead2"
+  Reg.For_testing.clear ();
+  let _entry = Reg.For_testing.register ~base_path:"/tmp" "dead2"
       (let json = `Assoc [
         ("name", `String "dead2");
         ("agent_name", `String "agent-dead2");
@@ -556,7 +556,7 @@ let test_declarative_boot_materializes_instructions () =
   let instructions = "watch fleet safety and repair keeper bootstrap" in
   write_keeper_toml_with_instructions config_dir ~name ~instructions;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -584,7 +584,7 @@ let test_declarative_boot_allows_empty_goal_links () =
   let name = "empty-intent" in
   write_empty_keeper_toml config_dir ~name;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -614,7 +614,7 @@ let test_declarative_boot_records_typed_invalid_config_failure () =
   write_file keeper_path "[broken";
   Keeper_types_profile.invalidate_keeper_profile_defaults_cache name;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -651,7 +651,7 @@ let test_reconcile_materializes_configured_keeper_without_meta () =
   let name = "hot-restored" in
   write_keeper_toml config_dir ~name;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -687,7 +687,7 @@ let test_reconcile_does_not_double_start_materialized_keeper () =
   let name = "hot-registered" in
   write_keeper_toml config_dir ~name;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -727,7 +727,7 @@ let test_reconcile_does_not_double_start_materialized_keeper () =
   let name = "manual-paused-owner" in
   write_keeper_toml config_dir ~name;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -781,7 +781,7 @@ let test_reconcile_materialize_failure_continues_with_metric () =
   write_keeper_toml config_dir ~name:failing;
   write_keeper_toml config_dir ~name:healthy;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -821,7 +821,7 @@ let test_reconcile_supervise_exception_continues () =
   write_keeper_toml config_dir ~name:failing;
   write_keeper_toml config_dir ~name:healthy;
   Eio.Switch.on_release sw (fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
@@ -850,9 +850,9 @@ let test_reconcile_supervise_exception_continues () =
     (Masc.Otel_metric_store.metric_total metric)
 
 let registered_entries names =
-  Reg.clear ();
+  Reg.For_testing.clear ();
   List.map
-    (fun name -> Reg.register ~base_path:bp name (make_meta name))
+    (fun name -> Reg.For_testing.register ~base_path:bp name (make_meta name))
     names
 
 let test_supervision_cohorts_64_keepers_8x8 () =
@@ -915,8 +915,8 @@ let test_fresh_supervision_cohort_keepers_rereads_registry () =
     | [ cohort ] -> cohort
     | _ -> fail "expected one cohort"
   in
-  Reg.unregister ~base_path:bp "alpha";
-  Reg.unregister ~base_path:bp "bravo";
+  Reg.For_testing.unregister ~base_path:bp "alpha";
+  Reg.For_testing.unregister ~base_path:bp "bravo";
   let _entry = Reg.register_offline ~base_path:bp "bravo" (make_meta "bravo") in
   let fresh = Sup.fresh_supervision_cohort_keepers ~base_path:bp cohort in
   check (list string) "removed entries omitted"
@@ -962,7 +962,7 @@ let test_sweep_does_not_synthesize_gate_from_runtime_blocker () =
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_keepalive.stop_keepalive ~base_path:base_dir "paused-reconcile";
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1033,7 +1033,7 @@ let test_sweep_reports_pending_hitl_approval () =
                 ~id
                 ~decision:(AQ.Decision.Reject "test cleanup")))
         !approval_id;
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1096,7 +1096,7 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_keepalive.stop_keepalive ~base_path:base_dir name;
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1107,7 +1107,7 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       resolve_done_for_test reg (`Crashed "ordinary crash");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
@@ -1160,14 +1160,14 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
   let name = "restart-missing-meta-metric-keeper" in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
       let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
       let meta = make_meta name in
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       resolve_done_for_test reg (`Crashed "ordinary crash");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
@@ -1221,7 +1221,7 @@ let test_restart_denies_persisted_dead_tombstone () =
   let name = "restart-dead-tombstone-admission" in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1240,7 +1240,7 @@ let test_restart_denies_persisted_dead_tombstone () =
       (match Keeper_meta_store.write_meta config dead_meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name active_meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name active_meta in
       resolve_done_for_test reg (`Crashed "crash before terminal persist");
       Reg.restore_supervisor_state
         ~base_path:config.base_path
@@ -1311,7 +1311,7 @@ let with_reap_ready_dead_keeper name f =
       Subprocess_registry.reset_for_testing ();
       Masc.Keeper_process_switch.For_testing.clear ();
       KLH.reset_for_testing ();
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1321,7 +1321,7 @@ let with_reap_ready_dead_keeper name f =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      ignore (Reg.register ~base_path:config.base_path name meta);
+      ignore (Reg.For_testing.register ~base_path:config.base_path name meta);
       Reg.mark_dead ~base_path:config.base_path name ~at:0.0;
       let completion_bus = Agent_sdk.Event_bus.create () in
       Masc_event_bus.set completion_bus;
@@ -1417,7 +1417,7 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1428,7 +1428,7 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       Reg.mark_dead ~base_path:config.base_path name ~at:(Unix.gettimeofday ());
       let ctx : _ Keeper_types_profile.context =
         {
@@ -1478,7 +1478,7 @@ let test_launch_fork_rejection_does_not_announce_running () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1491,7 +1491,7 @@ let test_launch_fork_rejection_does_not_announce_running () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       (match
          Lane.reject_before_start reg.lane ~reason:(Failure "pre-claimed for test")
        with
@@ -1534,7 +1534,7 @@ let test_fork_rejection_preserves_replacement_lane () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1542,13 +1542,13 @@ let test_fork_rejection_preserves_replacement_lane () =
       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
       let name = "fork-reject-replacement" in
       let meta = make_meta name in
-      let rejected = Reg.register ~base_path:config.base_path name meta in
+      let rejected = Reg.For_testing.register ~base_path:config.base_path name meta in
       (match
          Lane.reject_before_start rejected.lane ~reason:(Failure "pre-claimed for test")
        with
        | Ok () -> ()
        | Error error -> fail (Lane.start_error_to_string error));
-      let replacement = Reg.register ~base_path:config.base_path name meta in
+      let replacement = Reg.For_testing.register ~base_path:config.base_path name meta in
       let ctx : _ Keeper_types_profile.context =
         { config
         ; agent_name = supervisor_agent_name
@@ -1587,7 +1587,7 @@ let test_fork_rejection_unregisters_non_terminalizable_owner () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1595,7 +1595,7 @@ let test_fork_rejection_unregisters_non_terminalizable_owner () =
       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
       let name = "fork-reject-terminal-owner" in
       let meta = make_meta name in
-      let rejected = Reg.register ~base_path:config.base_path name meta in
+      let rejected = Reg.For_testing.register ~base_path:config.base_path name meta in
       Reg.mark_dead ~base_path:config.base_path name ~at:(Unix.gettimeofday ());
       (match
          Lane.reject_before_start rejected.lane ~reason:(Failure "pre-claimed for test")
@@ -1632,7 +1632,7 @@ let test_sweep_waits_for_lane_join_before_unregister () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1640,7 +1640,7 @@ let test_sweep_waits_for_lane_join_before_unregister () =
       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
       let name = "joined-before-unregister" in
       let meta = make_meta name in
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       ignore (Reg.dispatch_event ~base_path:config.base_path name KSM.Stop_requested);
       ignore (Reg.dispatch_event ~base_path:config.base_path name KSM.Drain_complete);
       ignore (Reg.resolve_done reg ~source:"test_unjoined_terminal" `Stopped);
@@ -1682,7 +1682,7 @@ let test_idle_duration_never_stops_keeper () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1707,8 +1707,8 @@ let test_idle_duration_never_stops_keeper () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name meta in
-      Reg.set_started_at_for_test
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
+      Reg.For_testing.set_started_at_for_test
         ~base_path:config.base_path
         name
         (Unix.time () -. 3600.0);
@@ -1759,7 +1759,7 @@ let test_non_storm_crashed_restarts_normally () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1771,7 +1771,7 @@ let test_non_storm_crashed_restarts_normally () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       resolve_done_for_test reg (`Crashed "ordinary crash");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:50 ~last_restart_ts:0.0 ~crash_log:[];
@@ -1820,7 +1820,7 @@ let test_persisted_blocker_survives_unregister () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Reg.clear ();
+      Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1841,7 +1841,7 @@ let test_persisted_blocker_survives_unregister () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
       resolve_done_for_test reg (`Crashed "observed failure");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
@@ -1873,7 +1873,7 @@ let test_persisted_blocker_survives_unregister () =
        | Error err -> fail ("read_meta failed: " ^ err));
       
       (* Unregister the keeper *)
-      Reg.unregister ~base_path:config.base_path name;
+      Reg.For_testing.unregister ~base_path:config.base_path name;
       
       (* Read again and verify *)
       (match Keeper_meta_store.read_meta config name with

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -797,12 +797,12 @@ let () =
       keeper_name
       (Some stale_provider_failure)
   in
-  Masc.Keeper_registry.clear ();
+  Masc.Keeper_registry.For_testing.clear ();
   Fun.protect
-    ~finally:Masc.Keeper_registry.clear
+    ~finally:Masc.Keeper_registry.For_testing.clear
     (fun () ->
        ignore
-         (Masc.Keeper_registry.register
+         (Masc.Keeper_registry.For_testing.register
             ~base_path:config.base_path
             keeper_name
             meta);

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -99,10 +99,10 @@ let with_exec_fixture ?(process = false) ?(always_allow = false) name fn =
         let meta = { (make_meta ()) with allowed_paths = [ config.base_path ] } in
         if always_allow then { meta with always_allow = Some true } else meta
       in
-      ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
       Fun.protect
         ~finally:(fun () ->
-          Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+          Masc.Keeper_registry.For_testing.unregister ~base_path:config.base_path meta.name)
         (fun () ->
           Masc_test_deps.with_publication_recovery_registry
             ~sw
@@ -2318,7 +2318,7 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
       Eio_context.with_turn_switch turn_sw @@ fun () ->
       let config = Workspace.default_config dir in
       let meta = make_meta () in
-      ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      ignore (Masc.Keeper_registry.For_testing.register ~base_path:config.base_path meta.name meta);
       Masc_test_deps.with_publication_recovery_registry
         ~sw:root_sw
         ~fs:(Eio.Stdenv.fs env)
@@ -2342,7 +2342,7 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
       Fun.protect
         ~finally:(fun () ->
           Masc.Keeper_dispatch_ref.dispatch := previous_dispatch;
-          Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+          Masc.Keeper_registry.For_testing.unregister ~base_path:config.base_path meta.name)
         (fun () ->
           Masc.Keeper_dispatch_ref.dispatch :=
             (fun ~config:_ ~agent_name:_

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -179,9 +179,9 @@ let make_fixture
       (Agent_sdk.Types.user_msg "tool matrix memory needle")
   in
   let ctx_snapshot = ctx in
-  Masc.Keeper_registry.clear ();
-  ignore (Masc.Keeper_registry.register ~base_path meta.name meta);
-  ignore (Masc.Keeper_registry.register ~base_path "tool-matrix" meta);
+  Masc.Keeper_registry.For_testing.clear ();
+  ignore (Masc.Keeper_registry.For_testing.register ~base_path meta.name meta);
+  ignore (Masc.Keeper_registry.For_testing.register ~base_path "tool-matrix" meta);
   let tools =
     KTO.make_tools
       ~config

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -88,7 +88,7 @@ let setup ~keeper_name ~sandbox f =
   with_eio_fs @@ fun () ->
   let base, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let meta = make_meta ~name:keeper_name ~sandbox in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
@@ -403,7 +403,7 @@ let test_readonly_execute_omitted_cwd_does_not_create_playground () =
   with_eio_fs @@ fun () ->
   let base, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let meta = make_meta ~name:"readonly-executor" ~sandbox:Keeper_types_profile_sandbox.Docker in
   let playground = Keeper_sandbox_repo_path.playground_root_no_create ~config ~meta in
   Alcotest.(check bool) "playground starts absent" false (Sys.file_exists playground);

--- a/test/test_keeper_tool_search_files_via_field.ml
+++ b/test/test_keeper_tool_search_files_via_field.ml
@@ -57,7 +57,7 @@ let setup f =
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   ensure_dir (Filename.concat base Common.masc_dirname);
   let config = Workspace.default_config base in
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   let meta = make_meta ~name:"via-keeper" in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;

--- a/test/test_keeper_turn_attempt_observer.ml
+++ b/test/test_keeper_turn_attempt_observer.ml
@@ -22,7 +22,7 @@ let register_keeper keeper =
     | Error error -> Alcotest.failf "register_keeper %s: %s" keeper error
   in
   ignore
-    (Registry.register ~base_path:(base_path ()) keeper meta : Registry.registry_entry)
+    (Registry.For_testing.register ~base_path:(base_path ()) keeper meta : Registry.registry_entry)
 ;;
 
 let test_observations_never_gate () =

--- a/test/test_keeper_turn_interrupt.ml
+++ b/test/test_keeper_turn_interrupt.ml
@@ -56,7 +56,7 @@ let with_env body =
   Fun.protect
     ~finally:(fun () -> Fs_compat.remove_tree base)
     (fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       Keeper_turn_admission.For_testing.reset ();
       body ~base)
 ;;
@@ -70,7 +70,7 @@ let test_interrupt_cancels_turn () =
   @@ fun env ->
   Masc_test_deps.init_eio_clock env;
   let clock = Eio.Stdenv.clock env in
-  ignore (Keeper_registry.register ~base_path:base name (make_meta name));
+  ignore (Keeper_registry.For_testing.register ~base_path:base name (make_meta name));
   Keeper_registry.mark_turn_started
     ~base_path:base
     ~wake:Keeper_registry.Proactive_tick
@@ -116,7 +116,7 @@ let test_interrupt_no_turn_is_noop () =
   Eio_main.run
   @@ fun env ->
   Masc_test_deps.init_eio_clock env;
-  ignore (Keeper_registry.register ~base_path:base name (make_meta name));
+  ignore (Keeper_registry.For_testing.register ~base_path:base name (make_meta name));
   check
     "no in-flight turn"
     (match Keeper_registry.interrupt_current_turn ~base_path:base name with

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -85,12 +85,12 @@ let setup ?sandbox ?always_allow f =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
-       Keeper_registry.clear ();
+       Keeper_registry.For_testing.clear ();
        let config = Workspace.default_config base in
        let meta = make_meta ?sandbox ?always_allow "tester" in
        let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
        ensure_dir playground;
-       ignore (Keeper_registry.register ~base_path:base meta.name meta);
+       ignore (Keeper_registry.For_testing.register ~base_path:base meta.name meta);
        Masc_test_deps.with_publication_recovery_registry
          ~sw
          ~fs

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -665,12 +665,12 @@ let test_live_turn_keeper_is_busy_without_waiting_rows () =
   let keeper_name = "busy-keeper" in
   ensure_keeper config keeper_name;
   let meta = keeper_meta_exn config keeper_name in
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   Fun.protect
-    ~finally:(fun () -> Keeper_registry.clear ())
+    ~finally:(fun () -> Keeper_registry.For_testing.clear ())
     (fun () ->
       ignore
-        (Keeper_registry.register
+        (Keeper_registry.For_testing.register
            ~base_path:config.Workspace_utils_backend_setup.base_path
            keeper_name
            meta);

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2068,10 +2068,10 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  Keeper_registry.clear ();
+  Keeper_registry.For_testing.clear ();
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       cleanup_dir base_path)
     (fun () ->
       let keeper_name = "sangsu" in
@@ -2080,7 +2080,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
         make_keeper_meta ~agent_name:keeper_agent_name keeper_name
       in
       ignore
-        (Keeper_registry.register ~base_path keeper_name
+        (Keeper_registry.For_testing.register ~base_path keeper_name
            keeper_meta);
       let state = Mcp_eio.For_testing.create_state ~base_path () in
       ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
@@ -2121,8 +2121,8 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
             (persisted |> member "tools" |> index 0 |> member "tool" |> to_string);
           Alcotest.(check int) "persisted deferred count" 0
             (persisted |> member "tools" |> index 0 |> member "deferred" |> to_int);
-          Keeper_registry.unregister ~base_path keeper_name;
-          ignore (Keeper_registry.register ~base_path keeper_name keeper_meta);
+          Keeper_registry.For_testing.unregister ~base_path keeper_name;
+          ignore (Keeper_registry.For_testing.register ~base_path keeper_name keeper_meta);
           Masc.Keeper_registry_tool_usage_persistence.restore ~base_path keeper_name;
           let restored =
             List.assoc_opt
@@ -2144,8 +2144,8 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
                  ; "tools", `List []
                  ])
              ^ "\n");
-          Keeper_registry.unregister ~base_path keeper_name;
-          ignore (Keeper_registry.register ~base_path keeper_name keeper_meta);
+          Keeper_registry.For_testing.unregister ~base_path keeper_name;
+          ignore (Keeper_registry.For_testing.register ~base_path keeper_name keeper_meta);
           Masc.Keeper_registry_tool_usage_persistence.restore ~base_path keeper_name;
           Alcotest.(check (list string))
             "legacy schema is rejected without migration"
@@ -2251,14 +2251,14 @@ let test_handle_request_tools_call_internal_keeper_runtime_rejects_retired_execu
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       cleanup_dir base_path)
     (fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       let keeper_name = "sangsu" in
       let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
       ignore
-        (Keeper_registry.register ~base_path keeper_name
+        (Keeper_registry.For_testing.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
       let state = Mcp_eio.For_testing.create_state ~base_path () in
       let token = Masc.Auth.ensure_internal_keeper_token base_path in

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -533,7 +533,7 @@ let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
   in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.unregister ~base_path keeper_name;
+      Masc.Keeper_registry.For_testing.unregister ~base_path keeper_name;
       cleanup_dir base_path)
     (fun () ->
       ignore
@@ -595,7 +595,7 @@ let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
   in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_registry.unregister ~base_path keeper_name;
+      Masc.Keeper_registry.For_testing.unregister ~base_path keeper_name;
       cleanup_dir base_path)
     (fun () ->
       ignore
@@ -631,7 +631,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
   Fun.protect
     ~finally:(fun () ->
       Masc.Sse.unsubscribe_external subscriber_id;
-      Masc.Keeper_registry.unregister ~base_path keeper_name;
+      Masc.Keeper_registry.For_testing.unregister ~base_path keeper_name;
       Masc.Keeper_tool_call_log.reset_for_testing ();
       cleanup_dir base_path)
     (fun () ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -496,7 +496,7 @@ let test_keeper_up_clears_dead_tombstone_resume_state () =
   let keeper_name = "dead-tombstone-operator-resume" in
   Eio.Switch.on_release sw (fun () ->
     Keeper_keepalive.stop_keepalive ~base_path:base_dir keeper_name;
-    Keeper_registry.clear ();
+    Keeper_registry.For_testing.clear ();
     Keeper_runtime.reset_test_state base_dir;
     cleanup_dir base_dir);
   let config = Workspace.default_config base_dir in
@@ -752,7 +752,7 @@ let test_lifecycle_owner_gates_meta_and_registry_mutations () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Workspace.default_config base_dir in
@@ -862,7 +862,7 @@ let test_dead_revival_launch_failure_rolls_back_both_authorities () =
   Fun.protect
     ~finally:(fun () ->
       Keeper_keepalive.stop_keepalive ~base_path:base_dir keeper_name;
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
       let config = Workspace.default_config base_dir in
@@ -978,7 +978,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
   Fun.protect
     ~finally:(fun () ->
       Keeper_keepalive.stop_keepalive keeper_name;
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1114,7 +1114,7 @@ let test_digest_workspace_includes_keeper_runtime_attention () =
   Fun.protect
     ~finally:(fun () ->
       Keeper_keepalive.stop_keepalive keeper_name;
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1223,7 +1223,7 @@ let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
   Fun.protect
     ~finally:(fun () ->
       Keeper_keepalive.stop_keepalive keeper_name;
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1492,7 +1492,7 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
       Dashboard_cache.invalidate_all ();
       Eio_guard.disable ();
       Keeper_keepalive.stop_keepalive "lightweight-audit";
-      Keeper_registry.clear ();
+      Keeper_registry.For_testing.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -484,10 +484,10 @@ let test_acked_occurrence_recovery_does_not_enqueue_or_wake_again () =
   let keeper_name = "schedule-keeper" in
   let base_path = config.Workspace_utils.base_path in
   let entry =
-    Keeper_registry.register ~base_path keeper_name (keeper_meta_for_name keeper_name)
+    Keeper_registry.For_testing.register ~base_path keeper_name (keeper_meta_for_name keeper_name)
   in
   Fun.protect
-    ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+    ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
     (fun () ->
       let request = create_keeper_wake_schedule config in
       let signal =
@@ -805,11 +805,11 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
   let keeper_name = "schedule-keeper" in
   let meta = keeper_meta_for_name keeper_name in
   let (_entry : Keeper_registry.registry_entry) =
-    Keeper_registry.register ~base_path:config.Workspace_utils.base_path keeper_name meta
+    Keeper_registry.For_testing.register ~base_path:config.Workspace_utils.base_path keeper_name meta
   in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.unregister ~base_path:config.Workspace_utils.base_path keeper_name)
+      Keeper_registry.For_testing.unregister ~base_path:config.Workspace_utils.base_path keeper_name)
     (fun () ->
       let request = create_keeper_wake_schedule config in
       let result = tick_ok config ~now:201.0 in

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -568,10 +568,10 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_or_wake_again () =
   let keeper_name = "schedule-keeper" in
   let base_path = config.Workspace_utils.base_path in
   let entry =
-    Keeper_registry.register ~base_path keeper_name (keeper_meta_for_name keeper_name)
+    Keeper_registry.For_testing.register ~base_path keeper_name (keeper_meta_for_name keeper_name)
   in
   Fun.protect
-    ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+    ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
     (fun () ->
       let request = create_keeper_wake_schedule config in
       let signal =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1217,14 +1217,14 @@ let with_running_keeper_metas config metas f =
   let base_path = config.Workspace.base_path in
   List.iter
     (fun (meta : Keeper_meta_contract.keeper_meta) ->
-      Keeper_registry.unregister ~base_path meta.name;
-      ignore (Keeper_registry.register ~base_path meta.name meta))
+      Keeper_registry.For_testing.unregister ~base_path meta.name;
+      ignore (Keeper_registry.For_testing.register ~base_path meta.name meta))
     metas;
   Fun.protect
     ~finally:(fun () ->
       List.iter
         (fun (meta : Keeper_meta_contract.keeper_meta) ->
-          Keeper_registry.unregister ~base_path meta.name)
+          Keeper_registry.For_testing.unregister ~base_path meta.name)
         metas)
     f
 
@@ -1276,8 +1276,8 @@ let terminate_keeper_fiber config (meta : Keeper_meta_contract.keeper_meta) =
 let mark_keeper_dead_with_registry_cause config
     (meta : Keeper_meta_contract.keeper_meta) =
   let base_path = config.Workspace.base_path in
-  Keeper_registry.record_restart ~base_path meta.name;
-  Keeper_registry.record_restart ~base_path meta.name;
+  Keeper_registry.For_testing.record_restart ~base_path meta.name;
+  Keeper_registry.For_testing.record_restart ~base_path meta.name;
   Keeper_registry.set_failure_reason ~base_path meta.name
     (Some
        (Keeper_registry.Provider_runtime_error
@@ -3022,7 +3022,7 @@ let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
             restored.name
             ~restart_count:10
             ~last_restart_ts:1234.0
-            ~crash_log:(Keeper_registry.crash_log_of ~base_path restored.name);
+            ~crash_log:(Keeper_registry.For_testing.crash_log_of ~base_path restored.name);
           (match Keeper_registry.get ~base_path restored.name with
            | Some entry ->
              Alcotest.(check bool) "restore cleared typed failure reason" true

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -111,7 +111,7 @@ let with_temp_masc_dir ?(keeper_names = [ "operator" ]) f =
   Fun.protect
     ~finally:(fun () ->
       ignore (Workspace.reset config);
-      Reg.clear ();
+      Reg.For_testing.clear ();
       KR.reset_test_state base;
       restore_env "MASC_CONFIG_DIR" original_config_dir;
       Config_dir_resolver.reset ();


### PR DESCRIPTION
## Problem

`keeper_registry.mli` (~600 lines) exposed 8 vals with **zero production consumers** — test support living in the public signature: `register`, `unregister`, `clear`, `set_started_at_for_test`, `record_restart`, `crash_log_of`, `board_wakeup_allowed`, `reload_meta_from_disk`.

## Fix

Move them into the existing `Keeper_registry.For_testing` submodule so the interface shows the real contract. 37 test files updated mechanically (direct + aliased references; sibling registries untouched).

## Verification

- `dune build lib/` + `test/` + `bin/main_eio.exe` ✓
- registry_hardening 17, lifecycle_registry_dispatch 14, composite_live_turn_surface 9, keeper_supervisor 46, dashboard 15, effective_meta_overlay 24 ✓
- Determinism gate, keeper matrix, doc refs ✓

Found by adversarial wiring audit (2026-07-17).