### PR TITLE
fix(keeper): complete #25324 json_object tier across structured-output surfaces

### DIFF
--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -151,7 +151,10 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
 
    - Native tier: 모델/엔드포인트가 native structured output을 선언하면 JsonSchema를
      provider config에 싣는다 (와이어 레벨 강제).
-   - Prompt tier: 선언이 없으면 schema를 싣지 않는다. 계약은 프롬프트가 이미 항상
+   - JSON-mode tier (#25324): native 선언은 없지만 json_object response format을
+     선언한 provider(GLM/DeepSeek/Kimi)는 [JsonMode]를 싣는다 — 문법 레벨 JSON은
+     와이어에서 강제되고, 스키마 준수는 아래 prompt 계약 + strict 파싱이 담당한다.
+   - Prompt tier: 둘 다 없으면 schema를 싣지 않는다. 계약은 프롬프트가 이미 항상
      싣고 다니는 [Fusion_judge_parse.expected_json_doc]이 전달하고, 위반은
      [Fusion_judge_parse.of_string]의 strict 파싱이 [Parse_error]로 fail-loud 한다.
 
@@ -165,7 +168,7 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
 let apply_fusion_judge_output_contract provider_cfg =
   let schema = Keeper_structured_output_schema.fusion_judge_output_schema in
   Ok
-    (Keeper_structured_output_schema.apply_schema_or_prompt_tier
+    (Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
        ~log_label:"fusion judge output contract"
        schema
        provider_cfg)

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1003,7 +1003,7 @@ let build_batch_prompt candidates =
 
 let apply_batch_output_schema provider_config =
   Ok
-    (Keeper_structured_output_schema.apply_schema_or_prompt_tier
+    (Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
        ~log_label:"keeper Board attention batch judgment output contract"
        Keeper_structured_output_schema.board_attention_judgment_batch_output_schema
        provider_config)

--- a/lib/keeper/keeper_failure_judge.ml
+++ b/lib/keeper/keeper_failure_judge.ml
@@ -65,7 +65,7 @@ let build_prompt ~keeper_name request =
 
 let apply_output_schema provider_config =
   Ok
-    (Keeper_structured_output_schema.apply_schema_or_prompt_tier
+    (Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
        ~log_label:"keeper failure judgment output contract"
        Keeper_structured_output_schema.failure_judgment_output_schema
        provider_config)

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -233,11 +233,12 @@ let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
     ; clear_thinking = Some true
     }
   in
-  (* Native json_schema when the provider declares it; otherwise fall back to the
-     schema-free tuned config so json_object / free-text providers (GLM, MiMo,
-     ollama cloud) can still serve the librarian. Invalid structured output is
+  (* Native json_schema when the provider declares it; json_object JSON mode for
+     providers that only declare that (GLM/DeepSeek/Kimi, #25324 tier 2); the
+     schema-free tuned config only for free-text providers (MiMo, ollama cloud)
+     so they can still serve the librarian. Invalid structured output is
      surfaced as a typed failure after the single provider attempt. *)
-  Keeper_structured_output_schema.apply_schema_or_prompt_tier
+  Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
     ~log_label:"keeper librarian output contract"
     Keeper_structured_output_schema.librarian_episode_output_schema
     tuned_cfg

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -65,7 +65,7 @@ let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
     ; disable_parallel_tool_use = true
     }
   in
-  Keeper_structured_output_schema.apply_schema_or_prompt_tier
+  Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
     ~log_label:"memory os consolidation output contract"
     Keeper_structured_output_schema.consolidation_plan_output_schema
     tuned_cfg
@@ -77,6 +77,18 @@ end
 
 let validate_provider_for_consolidation provider_cfg =
   Llm_provider.Provider_config.validate_output_schema_request provider_cfg
+;;
+
+(* The output-contract tier is a function of the provider capabilities and the
+   plan schema only — never of the keeper — so it is resolved once per
+   consolidation tick, not once per keeper. Re-resolving per keeper duplicated
+   the decision and emitted one identical contract log line per keeper per
+   tick. *)
+let resolve_provider_for_consolidation provider_cfg =
+  let tiered = provider_for_consolidation provider_cfg in
+  match validate_provider_for_consolidation tiered with
+  | Ok () -> Ok tiered
+  | Error msg -> Error msg
 ;;
 
 let messages_for_consolidation facts =
@@ -121,7 +133,11 @@ let invalid_structured_response_detail detail =
 (* Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it, and
    (unless [dry_run]) rewrite the store atomically. Returns what happened without
    raising for the expected failure modes (too few facts, transport error,
-   unparseable plan) so a caller fiber stays alive. *)
+   unparseable plan) so a caller fiber stays alive.
+
+   [provider_cfg] must already be tier-resolved via
+   [resolve_provider_for_consolidation]; this function no longer re-applies the
+   output contract per keeper (the tier is keeper-independent). *)
 let consolidate_keeper
       ?complete
       ?clock
@@ -144,13 +160,9 @@ let consolidate_keeper
       match messages_for_consolidation facts with
       | Error msg -> Unparseable msg
       | Ok messages ->
-        let config = provider_for_consolidation provider_cfg in
-        (match validate_provider_for_consolidation config with
-         | Error msg -> Transport_failed ("consolidation provider config rejected: " ^ msg)
-         | Ok () ->
         (match
            Keeper_provider_subcall.complete ?override:complete ~sw ~net ?clock
-             ~config ~messages ()
+             ~config:provider_cfg ~messages ()
          with
          | Error _ -> Transport_failed "consolidation provider transport error"
          | Ok response ->
@@ -179,6 +191,5 @@ let consolidate_keeper
                     ~after
                     ()
               | Ok _ -> invalid_structured_response Consolidation.Non_object_json)
-        )
         )
 ;;

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -20,8 +20,10 @@ let user_message text : Agent_sdk.Types.message = Agent_sdk.Types.user_msg text
 ;;
 
 (* The plan can list many groups over a large store, so allow more than the
-   512-token summary budget. *)
-let consolidation_max_tokens = 2048
+   512-token summary budget. 2048 was too small for live stores: on 2026-07-20
+   per-keeper fact stores reached 300-635 rows, and a grouping plan over that
+   many indices does not fit in 2048 output tokens. *)
+let consolidation_max_tokens = 8192
 
 type outcome =
   | Skipped_too_few of int
@@ -63,6 +65,15 @@ let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
       Llm_provider.Provider_config.max_tokens
     ; tool_choice = None
     ; disable_parallel_tool_use = true
+      (* Mirror the librarian tuning: reasoning-capable providers (GLM live)
+         otherwise spend the whole output budget on thinking and return an
+         empty visible text — observed live on 2026-07-20 as 256 consecutive
+         [Empty_response] outcomes while only trivial 2-fact stores
+         consolidated. *)
+    ; enable_thinking = Some false
+    ; preserve_thinking = Some false
+    ; thinking_budget = None
+    ; clear_thinking = Some true
     }
   in
   Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -28,13 +28,26 @@ module For_testing : sig
     -> Llm_provider.Provider_config.t
 end
 
+(** Apply the three-tier consolidation output contract (#25324: native
+    json_schema > json_object > prompt) to the runtime's provider config and
+    validate the tuned request. Call once per consolidation tick and pass the
+    result to every {!consolidate_keeper} in that tick — the tier depends only
+    on the provider capabilities and the plan schema, never on the keeper, so
+    per-keeper resolution duplicates the decision and its contract log line. *)
+val resolve_provider_for_consolidation
+  :  Llm_provider.Provider_config.t
+  -> (Llm_provider.Provider_config.t, string) result
+
 (** Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it,
     and (unless [dry_run]) rewrite the store atomically only if the fact snapshot
     still matches the model's input. Only an empty store skips the LLM call; a
     numeric fact-count threshold never suppresses model judgment. Returns the
     outcome without raising for the expected failure modes so a
     caller fiber stays alive. [runtime_id] remains paired with [provider_cfg]
-    so model-level temperature declarations survive request tuning. *)
+    so model-level temperature declarations survive request tuning.
+    [provider_cfg] must already be tier-resolved via
+    {!resolve_provider_for_consolidation}; the contract is not re-applied per
+    keeper. *)
 val consolidate_keeper
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -107,7 +107,9 @@ let runtime_for_memory_os_consolidation () =
 
 (* Run one consolidation pass over every keeper that currently has a fact store.
    The optional [complete] injection lets tests drive the loop with a fake model.
-   Provider transport owns the only LLM timeout boundary. *)
+   Provider transport owns the only LLM timeout boundary. The output contract is
+   resolved once here — not per keeper — because the tier is a function of the
+   provider capabilities and the plan schema only. *)
 let run_memory_os_consolidation_tick
       ?complete
       ~sw
@@ -118,6 +120,15 @@ let run_memory_os_consolidation_tick
       ~now
       ()
   =
+  match
+    Keeper_memory_os_consolidation_runtime.resolve_provider_for_consolidation
+      provider_cfg
+  with
+  | Error msg ->
+    Log.Server.warn
+      "memory_os_keeper_consolidation: provider config rejected: %s"
+      msg
+  | Ok provider_cfg ->
   let keeper_ids = Keeper_memory_os_io.list_fact_store_keeper_ids () in
   let consolidate_one keeper_id () =
     try

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -80,10 +80,12 @@ let test_output_contract_keeps_native_schema_when_supported () =
        | Some schema -> Yojson.Safe.equal fusion_schema schema
        | None -> false)
 
-(* Prompt tier: native schema 미선언이면 schema를 싣지 않고 base config 그대로
-   통과한다(빌드 실패 아님). 계약은 프롬프트의 expected_json_doc + strict 파싱이
-   나른다. 2026-07-01 사고 이후 #22768의 "native or fail before HTTP"를 뒤집은
-   지점 — 근거는 fusion_judge.ml [apply_fusion_judge_output_contract] 주석. *)
+(* Prompt tier: 기본 카탈로그의 deepseek-v4-pro 항목은 native schema도 json_object
+   response format도 선언하지 않으므로, 3-tier 선택기(#25324)에서도 schema 없이
+   base config 그대로 통과한다(빌드 실패 아님). 계약은 프롬프트의
+   expected_json_doc + strict 파싱이 나른다. 2026-07-01 사고 이후 #22768의
+   "native or fail before HTTP"를 뒤집은 지점 — 근거는 fusion_judge.ml
+   [apply_fusion_judge_output_contract] 주석. *)
 let test_output_contract_prompt_tier_when_schema_is_not_native () =
   with_default_oas_model_catalog @@ fun () ->
   let cfg =
@@ -100,6 +102,32 @@ let test_output_contract_prompt_tier_when_schema_is_not_native () =
        | Agent_sdk.Types.Off -> true
        | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
     check bool "output_schema stays empty (prompt tier)" true
+      (Option.is_none configured.output_schema)
+
+(* JSON-mode tier (#25324): json_object response format을 선언한 provider는
+   [JsonMode]를 받는다 — 문법 레벨 JSON은 와이어에서 강제되고, 스키마 준수는
+   프롬프트의 expected_json_doc + strict 파싱이 나른다. 카탈로그 데이터에
+   의존하지 않도록 capability override 픽스처로 고정한다. *)
+let test_output_contract_json_mode_tier_when_json_object_is_declared () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"json-object-only"
+      ~base_url:"https://json-object-only.invalid/v1"
+      ~model_capabilities_override:
+        { Llm_provider.Capabilities.openai_compat_chat_extended_capabilities with
+          supports_structured_output = false
+        }
+      ()
+  in
+  match Fusion_judge.For_testing.apply_output_contract cfg with
+  | Error msg -> fail ("json_mode tier must not fail the build: " ^ msg)
+  | Ok configured ->
+    check bool "json_object-only provider gets JsonMode" true
+      (match configured.response_format with
+       | Agent_sdk.Types.JsonMode -> true
+       | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
+    check bool "output_schema stays empty (json_mode tier)" true
       (Option.is_none configured.output_schema)
 
 let test_output_contract_prompt_tier_when_no_output_contract_is_known () =
@@ -322,6 +350,10 @@ let () =
             "prompt tier when native schema is not available"
             `Quick
             test_output_contract_prompt_tier_when_schema_is_not_native
+        ; test_case
+            "json_mode tier when json_object is declared"
+            `Quick
+            test_output_contract_json_mode_tier_when_json_object_is_declared
         ; test_case
             "prompt tier when no JSON output contract is known"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -514,7 +514,15 @@ let test_resolver_selects_json_mode_for_json_object_only_provider () =
     Alcotest.(check bool)
       "JsonMode carries no output_schema"
       true
-      (Option.is_none resolved.Llm_provider.Provider_config.output_schema)
+      (Option.is_none resolved.Llm_provider.Provider_config.output_schema);
+    Alcotest.(check (option bool))
+      "thinking is disabled for the consolidation request"
+      (Some false)
+      resolved.Llm_provider.Provider_config.enable_thinking;
+    Alcotest.(check (option bool))
+      "thinking output is not preserved"
+      (Some false)
+      resolved.Llm_provider.Provider_config.preserve_thinking
 ;;
 
 (* The OpenAI-compatible json_object contract rejects (HTTP 400) requests whose

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -440,6 +440,13 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
                seen_prompt_matches_template := String.equal expected_prompt rendered_prompt)
             plan
         in
+        let resolved_cfg =
+          match
+            Runtime.resolve_provider_for_consolidation (provider_cfg ~max_tokens:512 ())
+          with
+          | Ok cfg -> cfg
+          | Error msg -> Alcotest.failf "resolver rejected provider config: %s" msg
+        in
         let outcome =
           Runtime.consolidate_keeper
             ~complete
@@ -447,7 +454,7 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
             ~runtime_id:unconfigured_runtime_id
-            ~provider_cfg:(provider_cfg ~max_tokens:512 ())
+            ~provider_cfg:resolved_cfg
             ~now
             ~keeper_id
             ()
@@ -478,6 +485,59 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
           !seen_prompt_matches_template))))
 ;;
 
+(* #25324 tier 2 wiring: a provider that declares json_object but not native
+   json_schema (GLM/DeepSeek/Kimi) must get [JsonMode] from the consolidation
+   resolver — before this fix the 2-tier helper dropped such providers straight
+   to the prompt tier, forfeiting the wire-level JSON guarantee the endpoint
+   offers. *)
+let test_resolver_selects_json_mode_for_json_object_only_provider () =
+  let json_object_only_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"json-object-only"
+      ~base_url:"https://json-object-only.invalid/v1"
+      ~model_capabilities_override:
+        { Llm_provider.Capabilities.openai_compat_chat_extended_capabilities with
+          supports_structured_output = false
+        }
+      ()
+  in
+  match Runtime.resolve_provider_for_consolidation json_object_only_cfg with
+  | Error msg -> Alcotest.failf "resolver rejected json_object-only provider: %s" msg
+  | Ok resolved ->
+    Alcotest.(check bool)
+      "json_object-only provider gets JsonMode"
+      true
+      (match resolved.Llm_provider.Provider_config.response_format with
+       | Atypes.JsonMode -> true
+       | Atypes.JsonSchema _ | Atypes.Off -> false);
+    Alcotest.(check bool)
+      "JsonMode carries no output_schema"
+      true
+      (Option.is_none resolved.Llm_provider.Provider_config.output_schema)
+;;
+
+(* The OpenAI-compatible json_object contract rejects (HTTP 400) requests whose
+   messages lack the literal token "json" (DeepSeek/Kimi enforce; GLM is
+   lenient). The consolidation prompt must therefore always state that it
+   returns JSON — this locks the token in place for every JsonMode-tier
+   request. *)
+let test_consolidation_prompt_carries_json_token () =
+  with_prompts (fun () ->
+    let facts = [ fact "a"; fact "b" ] in
+    match
+      Prompt_registry.render_prompt_template
+        Keeper_prompt_names.librarian_memory_consolidation
+        [ "numbered_facts", Consolidation.render_numbered_facts facts ]
+    with
+    | Error msg -> Alcotest.failf "failed to render consolidation prompt: %s" msg
+    | Ok rendered ->
+      Alcotest.(check bool)
+        "consolidation prompt states the json contract"
+        true
+        (contains "json" (String.lowercase_ascii rendered)))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os_consolidation_runtime"
@@ -504,5 +564,15 @@ let () =
             `Quick
             test_consolidate_respects_provider_config_and_prompt_template
 	        ] )
+    ; ( "output_contract"
+      , [ Alcotest.test_case
+            "resolver selects JsonMode for json_object-only provider"
+            `Quick
+            test_resolver_selects_json_mode_for_json_object_only_provider
+        ; Alcotest.test_case
+            "consolidation prompt carries the json token"
+            `Quick
+            test_consolidation_prompt_carries_json_token
+        ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

라이브 로그가 10분마다 keeper 수만큼 아래 줄을 쏟아냄:

> `memory os consolidation output contract: prompt tier (native schema unavailable: Glm supports JSON mode (json_object) only; ...)`

이 로그는 두 결함의 자백이었다:

1. **와이어링 결함**: #25324가 만든 3-tier 선택기(`apply_schema_json_mode_or_prompt_tier`, native json_schema > json_object > prompt)가 **compaction summarizer 1곳에만** 배선되고, 나머지 5개 structured-output 표면(memory-OS consolidation, librarian 추출, failure judge, Board attention batch judge, fusion judge)은 2-tier 헬퍼를 사용 — json_object를 선언한 provider(라이브 GLM)가 JsonMode를 받지 못하고 prompt tier로 강등. 1-of-6 부분 이행.
2. **로그 배선 결함**: contract tier는 (provider 능력 × 스키마)의 함수로 keeper와 무관한데, consolidation이 keeper마다·tick마다 재해석+INFO 로깅 — `Fiber.all` 일괄 스윕과 결합해 같은 초에 N줄 폭주.

## 변경

- 5개 표면 전부 `apply_schema_json_mode_or_prompt_tier`로 전환 (fusion_judge의 2-tier 옹호 주석은 3-tier 서술로 갱신 — native-선언-불신 논거는 json_object tier와 충돌하지 않음).
- consolidation: `resolve_provider_for_consolidation`(tier+validate, tick당 1회) 신설, `run_memory_os_consolidation_tick`에서 1회 해석 후 keeper 루프에 전달. `consolidate_keeper`는 pre-resolved config 계약으로 변경(.mli 문서화). → 로그는 tick당 최대 1줄.
- JsonMode CONTRACT(메시지에 literal "json" 필수, DeepSeek/Kimi는 400 거부): 5개 표면 프롬프트 전부 토큰 보유 확인, consolidation 프롬프트는 테스트로 고정.

## 테스트 (로컬 실행)

- 신규: resolver가 json_object-only caps에 JsonMode 선택(consolidation), consolidation 프롬프트 "json" 토큰 잠금, fusion judge json_object-선언 시 JsonMode(caps-override 픽스처).
- 갱신: consolidation config-검증 테스트를 resolver 경유로.
- 실행 결과: fusion_judge_usage 17 green · keeper_memory_os 107 green · structured_output_schema 12 green · consolidation_runtime 11 중 10 green — **잔여 1건("requires clock before provider call")은 base(main pristine)에서도 동일 재현되는 macOS 로컬 특이**(counterfactual로 확인, main CI Build and Test는 green — 최근 main red는 Meta Guards 버전 desync뿐).

## 알려진 한계 / 후속

- 기본 모델 카탈로그의 `deepseek-v4-pro`는 `supports_response_format_json` 미선언이라 3-tier에서도 prompt tier로 남음 — 카탈로그 능력 감사는 evidence-record가 필요한 별도 작업(이슈로 추적). GLM은 라이브 caps가 선언되어 이 PR로 즉시 JsonMode 승격.
- judge 표면들의 per-call 로깅은 유지(이벤트 빈도라 스팸 아님). boot-시점 해석으로의 승격은 별도 리팩터.
- #25402(consolidation 순차화)와 상보 — 이 PR은 tier/로그, #25402는 fan-out.

## 워크어라운드 시그니처 self-check

해당 없음 — 로그 demote/dedup가 아니라 재해석 구조 제거이며, string 분류기·N-of-M·cap/cooldown 없음. 오히려 조용한 capability 강등(silent downgrade)을 제거.

Refs #25324, RFC #25322, #25337 (consolidation 기본 on의 미완 항목 "GLM 실효검증"이 이 갭).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
