### PR TITLE
fix(keeper): do not offer a keeper its own authored tasks as claimable

### DIFF
--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -30,6 +30,23 @@ let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta)
   scope.task_filter
 ;;
 
+(* A keeper must not treat a task it authored itself as work waiting for it.
+   Without this, a persona whose response to "an unclaimed task exists" is to
+   create a routing/report task produces a closed positive feedback loop: the
+   new task is itself an unclaimed Todo authored by the same keeper, so it
+   re-satisfies the trigger on the next observation. Live evidence: taskmaster
+   authored 367 of the active tasks, 272 of them the same four "Route g0700 #N"
+   templates re-emitted once per iteration (#28..#90), none ever claimed.
+
+   [created_by] carries the keeper handle ([meta.name], e.g. "taskmaster"), not
+   the agent name, so it is compared against [meta.name]. A task with no
+   [created_by] has no known author and is never excluded. *)
+let task_is_self_authored ~(meta : keeper_meta) (task : Masc_domain.task) =
+  match task.created_by with
+  | None -> false
+  | Some author -> String.equal author meta.name
+;;
+
 let actionable_verification_request_ids ~(config : Workspace.config) : string list =
   Verification.list_requests config.Workspace.base_path
   |> List.filter Verification.request_is_actionable
@@ -96,7 +113,11 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
         (List.filter
            (fun task ->
               Workspace_task_schedule.task_is_claim_pool_candidate task
-              && claim_scope_filter task)
+              && claim_scope_filter task
+              (* Self-authored tasks stay in [unclaimed] (the count stays an
+                 honest view of the backlog) but are not offered back to their
+                 author as claimable work — that edge is the feedback loop. *)
+              && not (task_is_self_authored ~meta task))
            unclaimed_tasks)
     in
     let failed =

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -14,6 +14,19 @@ val read_backlog_counts
   -> meta:keeper_meta
   -> int * int * int * int * bool
 
+(** [task_is_self_authored ~meta task] is true when [task.created_by] is the
+    keeper's own handle ([meta.name]).
+
+    A keeper that treats its own output as work waiting for it closes a
+    positive feedback loop: a persona whose response to "an unclaimed task
+    exists" is to create a routing or report task produces a new unclaimed Todo
+    authored by itself, which re-satisfies the trigger on the next observation.
+    Self-authored tasks therefore stay in the [unclaimed] count (an honest view
+    of the backlog) but are excluded from [claimable] in
+    {!read_backlog_counts}. A task with no [created_by] has no known author and
+    is never excluded. *)
+val task_is_self_authored : meta:keeper_meta -> Masc_domain.task -> bool
+
 val audit_tasks_without_actionable_verification_ids
   :  string list
   -> Masc_domain.task list

--- a/test/dune
+++ b/test/dune
@@ -816,6 +816,14 @@
  (modules test_runtime_modality_reroute)
  (libraries masc_test_deps))
 
+; A keeper must not be offered its own authored tasks as claimable work —
+; otherwise a routing/report persona re-triggers on its own output.
+
+(test
+ (name test_keeper_self_authored_task_exclusion)
+ (modules test_keeper_self_authored_task_exclusion)
+ (libraries masc_test_deps))
+
 ; RFC-0267 Phase 1: registry goal_id projection onto the /execution task wire.
 
 (test

--- a/test/test_keeper_self_authored_task_exclusion.ml
+++ b/test/test_keeper_self_authored_task_exclusion.ml
@@ -1,0 +1,105 @@
+(** A keeper must not be offered its own authored tasks as claimable work.
+
+    Without this exclusion the task board runs a closed positive feedback loop:
+    a persona whose response to "an unclaimed task exists" is to create a
+    routing or report task emits a new unclaimed Todo authored by itself, which
+    re-satisfies the same trigger on the next observation. Observed live on
+    2026-07-20: keeper "taskmaster" authored 367 of the active tasks, 272 of
+    them the same four "Route g0700 #N" templates re-emitted once per iteration
+    (#28..#90), none ever claimed since 2026-07-09. *)
+
+module WOI = Masc.Keeper_world_observation_inputs
+
+let make_meta name : Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+        ; "trace_id", `String ("trace-" ^ name)
+        ; "autoboot_enabled", `Bool false
+        ])
+  with
+  | Ok meta -> meta
+  | Error message -> Alcotest.fail ("meta fixture rejected: " ^ message)
+;;
+
+let task ?created_by id : Masc_domain.task =
+  { id
+  ; title = "Task " ^ id
+  ; description = ""
+  ; task_status = Todo
+  ; priority = 3
+  ; files = []
+  ; created_at = "2026-07-20T00:00:00Z"
+  ; created_by
+  ; predecessor_task_id = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+;;
+
+(* [created_by] carries the keeper handle ([meta.name]), which is what the live
+   backlog records ("taskmaster"), not the agent name. *)
+let test_own_task_is_self_authored () =
+  let meta = make_meta "taskmaster" in
+  Alcotest.(check bool)
+    "a task authored by this keeper is self-authored"
+    true
+    (WOI.task_is_self_authored ~meta (task ~created_by:"taskmaster" "task-1"))
+;;
+
+let test_other_keeper_task_is_not_self_authored () =
+  let meta = make_meta "taskmaster" in
+  Alcotest.(check bool)
+    "a task authored by another keeper is not self-authored"
+    false
+    (WOI.task_is_self_authored ~meta (task ~created_by:"executor" "task-2"))
+;;
+
+(* An unattributed task has no known author, so it must stay claimable rather
+   than being silently withheld from everyone. *)
+let test_unattributed_task_is_not_self_authored () =
+  let meta = make_meta "taskmaster" in
+  Alcotest.(check bool)
+    "a task with no created_by is never excluded"
+    false
+    (WOI.task_is_self_authored ~meta (task "task-3"))
+;;
+
+(* The agent name must not be mistaken for the author key: the live backlog
+   stores "taskmaster", never "keeper-taskmaster-agent". Matching on the agent
+   name would silently exclude nothing and leave the loop intact. *)
+let test_agent_name_is_not_the_author_key () =
+  let meta = make_meta "taskmaster" in
+  Alcotest.(check bool)
+    "agent-name-shaped author does not match the keeper handle"
+    false
+    (WOI.task_is_self_authored
+       ~meta
+       (task ~created_by:"keeper-taskmaster-agent" "task-4"))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_self_authored_task_exclusion"
+    [ ( "task_is_self_authored"
+      , [ Alcotest.test_case "own task" `Quick test_own_task_is_self_authored
+        ; Alcotest.test_case
+            "other keeper task"
+            `Quick
+            test_other_keeper_task_is_not_self_authored
+        ; Alcotest.test_case
+            "unattributed task"
+            `Quick
+            test_unattributed_task_is_not_self_authored
+        ; Alcotest.test_case
+            "agent name is not the author key"
+            `Quick
+            test_agent_name_is_not_the_author_key
+        ] )
+    ]
+;;

--- a/test/test_keeper_self_authored_task_exclusion.ml
+++ b/test/test_keeper_self_authored_task_exclusion.ml
@@ -10,7 +10,7 @@
 
 module WOI = Masc.Keeper_world_observation_inputs
 
-let make_meta name : Keeper_meta_contract.keeper_meta =
+let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1344,6 +1344,41 @@ let test_read_backlog_counts_falls_back_to_unscoped_claimable_task () =
       claimable
   )
 
+(* The self-authored exclusion must hold through [read_backlog_counts], not
+   only in [task_is_self_authored]: dropping the filter clause leaves every
+   predicate-level test green while the feedback loop stays open. Counts are
+   compared against a baseline because the fixture seeds its own tasks. *)
+let test_read_backlog_counts_excludes_self_authored_task () =
+  with_test_env (fun config ->
+    let meta = keeper_meta_for_self_filter "keeper-self-filter-agent" in
+    let _, claimable_before, _, _, _ =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    let _ =
+      Workspace.add_task config ~created_by:meta.name
+        ~title:"self-authored routing task" ~priority:3 ~description:""
+    in
+    let unclaimed_after_self, claimable_after_self, _, _, _ =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    Alcotest.(check int)
+      "a keeper's own task is not offered back to it as claimable"
+      claimable_before claimable_after_self;
+    let _ =
+      Workspace.add_task config ~created_by:"peer-keeper"
+        ~title:"peer authored task" ~priority:3 ~description:""
+    in
+    let unclaimed_after_peer, claimable_after_peer, _, _, _ =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    Alcotest.(check int)
+      "a peer-authored task is still claimable"
+      (claimable_before + 1) claimable_after_peer;
+    Alcotest.(check int)
+      "the unclaimed count still reports both tasks"
+      (unclaimed_after_self + 1) unclaimed_after_peer
+  )
+
 let test_keeper_tasks_audit_excludes_self_owned_orphan () =
   with_test_env (fun config ->
     let keeper = "keeper-task-audit-self-filter-agent" in
@@ -1753,6 +1788,9 @@ let () =
       Alcotest.test_case "read backlog counts falls back to unscoped claimable"
         `Quick
         test_read_backlog_counts_falls_back_to_unscoped_claimable_task;
+      Alcotest.test_case "read backlog counts excludes self-authored task"
+        `Quick
+        test_read_backlog_counts_excludes_self_authored_task;
       Alcotest.test_case "keeper tasks audit excludes self-owned orphan" `Quick
         test_keeper_tasks_audit_excludes_self_owned_orphan;
     ];


### PR DESCRIPTION
## 문제 — 태스크 보드의 닫힌 양성 피드백 루프

keeper가 "unclaimed 태스크가 있다"를 관측 → 라우팅/보고 페르소나가 **태스크를 생성**으로 응답 → 그 태스크가 **자기 자신이 작성한 unclaimed Todo** → 다음 관측에서 같은 트리거를 재충족. read 경로가 **status만** 필터링해서 이걸 막는 게 없어요.

## 라이브 증거 (2026-07-20)

- keeper `taskmaster`가 active 태스크 중 **367건 작성**
- 그 중 **272건이 동일한 4개 `Route g0700 #N` 템플릿**, iteration #28~#90(57회) 매번 재발행
- **2026-07-09 이후 단 한 건도 claim 안 됨**
- `task-2196`: *"Route task-1873 (Route task-1872 to executor) to keeper-executor-agent"* — **라우팅 태스크를 라우팅하는 태스크를 라우팅**

## 변경

`read_backlog_counts`는 이미 `~meta`를 받아 keeper 핸들을 알고 있어요. 자기 작성 태스크를 **`claimable`에서만 제외**하고 **`unclaimed`에는 남겨요**:

- `unclaimed` = 백로그의 정직한 뷰(그대로 유지)
- `claimable` = "내가 잡을 수 있는 일" → 자기 산출물은 제외

**루프의 간선은 정확히 이 지점**이에요. 옆의 `claim_goal_scope_filter`와 동일한 필터 합성 패턴을 따랐어요.

## 정확성 근거

`created_by`에는 **keeper 핸들(`meta.name`)**이 들어가요 — 라이브 백로그 실측이 `"taskmaster"`(367건)이고 `"keeper-taskmaster-agent"`가 아니에요. `created_by`가 없는 태스크는 작성자 미상이라 **절대 제외하지 않아요**(아무한테도 안 보이는 태스크가 생기면 안 되니까).

## 테스트 (4개)

- 자기 작성 → 제외됨
- 타 keeper 작성 → 제외 안 됨
- `created_by` 없음 → 제외 안 됨
- **agent name(`keeper-taskmaster-agent`)은 작성자 키가 아님** — 이걸로 매칭했다면 아무것도 제외 못 하고 루프가 그대로 남는다는 걸 고정

## 범위 — 이건 최소 결정적 가드지 전부가 아니에요

근본 규명 결과 세 층이 겹쳐 있어요:
1. **read**: unclaimed 필터가 status만 봄 → **이 PR이 닫음**
2. **write**: `workspace_task_create.ml`에 write-time dedup 부재 (docstring이 *"동일 title은 별개 task, dedup은 제출 전 LLM이 판단"*으로 **명시적 설계 결정** — 자율 keeper엔 그 단계가 없어서 가정이 깨짐)
3. **drain**: Todo TTL 없음, cancel은 수동·단방향 → 생성률 > claim률이면 무한 증가

후속(별도 RFC): write-time 멱등 키, typed `kind: Code | Coordination | Report`(Parse-don't-validate 근본), Todo 자동만료. **페르소나 수정만으로는 부족해요** — 코드가 output→trigger 간선을 여전히 허용하면 "루프 돌지 말아달라"는 부탁에 불과하니까요.

RFC-WAIVED: 단일 read 경로에 작성자 필터 추가 + 테스트. credential/identity/operator-control/sandbox/hooks/workflow subsystem 무관.
