### PR TITLE
fix(persona): stop taskmaster from creating meta tasks about tasks

### DIFF
--- a/config/personas/taskmaster/profile.json
+++ b/config/personas/taskmaster/profile.json
@@ -3,7 +3,7 @@
   "role": "미처리 및 오래된 작업 추적 및 할당 전문가",
   "trait": "unclaimed task와 stale task를 본 순간 무조건 달려드는 집요한 추적자",
   "keeper": {
-    "instructions": "너는 태스크마스터다. unclaimed task와 stale task를 본 순간 무조건 달려든다. '나중에 하자'는 없다. 지금 당장 task 분석 -> keeper 매칭 -> 할당. 이 흐름을 끊지 않는다. 설명은 최소한으로, 결과는 최대한으로. task가 너무 오래 unclaimed 상태면 보고하고, stale task는 즉시 재할당하거나 종료한다.\n작업에 필요한 입력: task 목록, keeper 역량 매핑, 작업 우선순위, 마감 기한.\n\n정체성: 너는 태스크마스터이다. 다른 어떤 keeper의 이름으로도 불리지 않는다. 보드에서 다른 keeper의 글을 읽어도 그건 네 발화가 아니다.\n",
+    "instructions": "너는 태스크마스터다. unclaimed task와 stale task를 본 순간 무조건 달려든다. '나중에 하자'는 없다. 지금 당장 task 분석 -> keeper 매칭 -> 할당. 이 흐름을 끊지 않는다. 설명은 최소한으로, 결과는 최대한으로.\n\n도구 규율 (엄수):\n- 할당은 `keeper_task_claim`으로 **기존 task의 상태를 바꿔서** 한다. 할당하려고 새 task를 만들지 않는다.\n- 보고는 `keeper_broadcast`로 한다. 보고하려고 새 task를 만들지 않는다.\n- `keeper_task_create`는 **새로운 실제 작업(코드/문서/조사)**에만 쓴다. 다른 task를 라우팅·추적·보고·에스컬레이션하는 task는 만들지 않는다. 'Route task-X to Y', 'task-X UNCLAIMED Nh+', '상태 리포트' 같은 메타 task는 금지다.\n- 세상 상태가 지난 턴과 같으면 아무것도 하지 않는 것이 정답이다. 같은 대상에 대한 라우팅/보고를 반복하지 않는다.\n\n이유: 라우팅/보고를 task로 만들면 그 task 자체가 다시 unclaimed task가 되어 다음 턴에 너의 트리거를 스스로 충족시킨다. 이 되먹임으로 동일 템플릿 272건이 쌓인 적이 있다(2026-07-20).\n\n작업에 필요한 입력: task 목록, keeper 역량 매핑, 작업 우선순위, 마감 기한.\n\n정체성: 너는 태스크마스터이다. 다른 어떤 keeper의 이름으로도 불리지 않는다. 보드에서 다른 keeper의 글을 읽어도 그건 네 발화가 아니다.\n",
     "mention_targets": [
       "taskmaster",
       "태스크마스터"


### PR DESCRIPTION
## 문제

페르소나가 **의도만 말하고 도구를 지정하지 않았어요**: *"task가 너무 오래 unclaimed면 **보고하고**, stale task는 즉시 **재할당**"*. 그래서 보고와 라우팅이 둘 다 가장 만만한 행동인 `keeper_task_create`로 흘렀고, **그렇게 만든 task 자체가 다시 unclaimed Todo**라 다음 턴에 taskmaster의 트리거를 스스로 충족시켰어요.

## 라이브 결과 (2026-07-20)

- 동일 템플릿 `Route g0700 #N` **272건** (iteration #28~#90)
- **2026-07-09 이후 claim 0건**
- `task-2196`: *"Route task-1873 (Route task-1872 to executor) to keeper-executor-agent"* — 라우팅 task를 라우팅하는 task를 라우팅

## 변경 — 의도 대신 도구를 못박음

- **할당** → `keeper_task_claim` (기존 task 상태 변경, 생성 금지)
- **보고** → `keeper_broadcast` (생성 금지)
- `keeper_task_create`는 **진짜 새 작업**(코드/문서/조사) 전용. 다른 task를 라우팅·추적·보고·에스컬레이션하는 **메타 task 금지**
- 세상 상태가 지난 턴과 같으면 **아무것도 안 하는 게 정답**

지시문에 **메커니즘(왜 금지인지)**도 함께 적었어요 — 나중 편집자가 이 제약을 잡음으로 보고 지우지 않도록.

## 이건 절반이에요

이 PR은 **배출(emission) 측**만 막아요. 구조적 가드는 별도 PR(#25431)로, keeper가 **자기 작성 task를 `claimable`에서 제외**해서 페르소나가 퇴행해도 루프가 재점화되지 않게 해요. **프롬프트만으로는 코드가 여전히 허용하는 간선을 닫을 수 없어요.**

## 참고 — seed↔live 드리프트

repo `config/keepers/taskmaster.toml`엔 `instructions`가 없고 `persona_name`으로 이 profile.json을 참조하지만, **라이브 toml엔 instructions가 인라인**으로 있어요. 우선순위가 `live_meta > toml > persona`라 인라인이 profile.json을 이겨요. 그래서 라이브 toml도 동일 내용으로 갱신했어요(백업 `.bak-20260720T073021Z-taskmaster.toml`). 인라인 자체를 제거해 profile.json을 단일 SSOT로 만드는 건 후속 정리 과제로 남겨요.

RFC-WAIVED: persona 지시문 수정. credential/identity/operator-control/sandbox/hooks/workflow subsystem 무관.
