### PR TITLE
fix(keeper): drop the wire response_format demand from five structured-output surfaces

### DIFF
--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -146,32 +146,24 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
     Provider_error
       (prefix ^ Fusion_oas.provider_error_detail ~runtime_id (sdk_error_detail e))
 
-(* 심판 출력 계약은 typed 2-tier다. tier는 OAS capability facts(
-   [validate_output_schema_request])로만 결정하며 provider-name 특례는 없다:
+(* 심판 출력 계약은 프롬프트와 파서가 진다. 요청은 wire response format을 싣지
+   않는다: 계약은 프롬프트가 항상 싣고 다니는
+   [Fusion_judge_parse.expected_json_doc]이 전달하고(객체 형태, 닫힌
+   [decision.kind] 합, 빈 배열 허용 규칙까지 전부 명시), 위반은
+   [Fusion_judge_parse.of_string]의 strict 파싱이 [Parse_error]로 fail-loud 한다.
+   프롬프트가 쓰는 필드명 상수는 schema builder가 쓰던 것과 동일한
+   [Fusion_judge_parse.wire_field_*]이므로 계약이 갈라질 수 없다.
 
-   - Native tier: 모델/엔드포인트가 native structured output을 선언하면 JsonSchema를
-     provider config에 싣는다 (와이어 레벨 강제).
-   - JSON-mode tier (#25324): native 선언은 없지만 json_object response format을
-     선언한 provider(GLM/DeepSeek/Kimi)는 [JsonMode]를 싣는다 — 문법 레벨 JSON은
-     와이어에서 강제되고, 스키마 준수는 아래 prompt 계약 + strict 파싱이 담당한다.
-   - Prompt tier: 둘 다 없으면 schema를 싣지 않는다. 계약은 프롬프트가 이미 항상
-     싣고 다니는 [Fusion_judge_parse.expected_json_doc]이 전달하고, 위반은
-     [Fusion_judge_parse.of_string]의 strict 파싱이 [Parse_error]로 fail-loud 한다.
-
-   #22768("native schema or fail before HTTP")은 native 미선언을 빌드 실패로
-   만들었는데, 이는 두 가지 이유로 뒤집는다: (1) capability 사실이 거짓일 수 있음이
-   실측됨(ollama.com cloud는 declared인데 json_schema를 조용히 무시 — 2026-07-02
-   probe), (2) 사실이 참(미지원)일 때 빌드 실패는 해당 preset의 fusion 자체를
-   영구 불능으로 만든다(2026-06-17~06-30 prompt 계약만으로 성공한 run 다수).
-   Prompt tier는 silent downgrade가 아니다 — 결정 시점에 로그로 관측되고, 파싱은
-   여전히 strict다. *)
+   tier 선택을 걷어내는 근거는 이 파일이 이미 기록해둔 두 사실이다:
+   (1) capability 사실이 거짓일 수 있다 — ollama.com cloud는 declared인데
+   json_schema를 조용히 무시한다(2026-07-02 probe). 현재 심판 런타임이 가리키는
+   엔드포인트가 정확히 그것이므로, native tier가 선택되어도 와이어 강제는 실제로
+   일어나지 않는다. 계약을 지켜온 것은 내내 프롬프트와 파서다.
+   (2) #22768("native schema or fail before HTTP")이 native 미선언을 빌드 실패로
+   만들었다가 뒤집힌 이력이 있다 — 미지원 preset의 fusion을 영구 불능으로 만들기
+   때문이며, 2026-06-17~06-30 prompt 계약만으로 성공한 run이 다수다. *)
 let apply_fusion_judge_output_contract provider_cfg =
-  let schema = Keeper_structured_output_schema.fusion_judge_output_schema in
-  Ok
-    (Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-       ~log_label:"fusion judge output contract"
-       schema
-       provider_cfg)
+  Ok (Keeper_structured_output_schema.without_response_format provider_cfg)
 
 (* 합성된 프롬프트를 받아 심판 에이전트를 빌드·실행·파싱한다. [run]/[run_refine]가
    서로 다른 [compose_*]로 만든 프롬프트를 넘기는 공유 본체 — 프롬프트 구성만 다르고

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1096,12 +1096,14 @@ let build_singleton_prompt candidate =
     [ "batch_request_json", Yojson.Safe.to_string json ]
 ;;
 
+(* Batch integrity does not come from the wire format. Verdicts are matched by
+   [candidate_id], and a reply is accepted only when its id set equals the
+   requested set exactly ([validate_batch_coverage]); unknown or duplicated ids
+   fail the whole batch back to Pending. A provider honouring the schema
+   perfectly can still answer for the wrong ids, so the schema never covered
+   the failure mode that matters here. *)
 let apply_batch_output_schema provider_config =
-  Ok
-    (Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-       ~log_label:"keeper Board attention batch judgment output contract"
-       Keeper_structured_output_schema.board_attention_judgment_batch_output_schema
-       provider_config)
+  Ok (Keeper_structured_output_schema.without_response_format provider_config)
 ;;
 
 let judge_singleton ~sw ~net ~base_path candidate =

--- a/lib/keeper/keeper_failure_judge.ml
+++ b/lib/keeper/keeper_failure_judge.ml
@@ -63,12 +63,13 @@ let build_prompt ~keeper_name request =
     [ "failure_request_json", Yojson.Safe.to_string (request_json ~keeper_name request) ]
 ;;
 
+(* config/prompts/keeper.failure_judgment.md states the contract more tightly
+   than the schema can: it fixes the exact field set and couples decision to
+   guidance (null for await_external_input, non-empty otherwise), which JSON
+   Schema cannot express without oneOf. Keeper_failure_judgment_contract
+   re-checks every one of those on the way in. *)
 let apply_output_schema provider_config =
-  Ok
-    (Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-       ~log_label:"keeper failure judgment output contract"
-       Keeper_structured_output_schema.failure_judgment_output_schema
-       provider_config)
+  Ok (Keeper_structured_output_schema.without_response_format provider_config)
 ;;
 
 let reject_unregistered_tool ~name ~args:_ =

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -233,15 +233,19 @@ let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
     ; clear_thinking = Some true
     }
   in
-  (* Native json_schema when the provider declares it; json_object JSON mode for
-     providers that only declare that (GLM/DeepSeek/Kimi, #25324 tier 2); the
-     schema-free tuned config only for free-text providers (MiMo, ollama cloud)
-     so they can still serve the librarian. Invalid structured output is
-     surfaced as a typed failure after the single provider attempt. *)
-  Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-    ~log_label:"keeper librarian output contract"
-    Keeper_structured_output_schema.librarian_episode_output_schema
-    tuned_cfg
+  (* No wire response format. config/prompts/keeper.librarian.episode_extraction.md
+     states the object shape and both enums, and [Keeper_librarian.episode_of_json_result]
+     re-validates every field into a closed [parse_error]; a bad reply defers the
+     next attempt instead of writing.
+
+     Dropping the schema also closes a live disagreement between the two. The
+     schema marked every claim field [required] with nullable types, so a
+     schema-conforming provider emits ["claim_id": null] — which
+     [optional_string_field_strict] rejects, failing [traverse] all-or-nothing and
+     dropping the whole episode. The prompt tells the model to omit the key
+     instead, which the parser accepts. Prompt and parser agree; the schema was
+     the one that disagreed. *)
+  Keeper_structured_output_schema.without_response_format tuned_cfg
 ;;
 
 let message role text =
@@ -251,7 +255,6 @@ let message role text =
 type extraction_error =
   | Prompt_render_failed of string
   | Provider_clock_unavailable
-  | Provider_config_rejected of string
   | Provider_timeout
   | Provider_transport_failed of string
   | Provider_empty_response
@@ -265,7 +268,6 @@ let librarian_provider_clock_unavailable_error =
 let extraction_error_to_string = function
   | Prompt_render_failed msg -> msg
   | Provider_clock_unavailable -> librarian_provider_clock_unavailable_error
-  | Provider_config_rejected msg -> "librarian provider config rejected: " ^ msg
   | Provider_timeout -> "librarian provider timed out"
   | Provider_transport_failed msg -> msg
   | Provider_empty_response -> "librarian provider returned empty response"
@@ -281,7 +283,6 @@ let should_record_cadence_backoff_after_error = function
   | Provider_unparseable_response _ ->
     true
   | Provider_clock_unavailable
-  | Provider_config_rejected _
   | Prompt_render_failed _
   | Memory_fact_upsert_failed _ ->
     false
@@ -337,11 +338,7 @@ let extract_with_provider_classified
      | Error msg -> Error (Prompt_render_failed msg)
      | Ok messages ->
        let provider_cfg = provider_for_librarian provider_cfg in
-       (match
-          Llm_provider.Provider_config.validate_output_schema_request provider_cfg
-        with
-        | Error msg -> Error (Provider_config_rejected msg)
-        | Ok () ->
+       (
           let attempt messages =
             match
               Keeper_provider_subcall.complete ?override:complete ~sw ~net ~clock

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -112,7 +112,6 @@ val provider_for_librarian
 type extraction_error =
   | Prompt_render_failed of string
   | Provider_clock_unavailable
-  | Provider_config_rejected of string
   | Provider_timeout
   | Provider_transport_failed of string
   | Provider_empty_response

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -83,9 +83,8 @@ let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
   ; preserve_thinking = Some false
   ; thinking_budget = None
   ; clear_thinking = Some true
-  ; response_format = Agent_sdk.Types.Off
-  ; output_schema = None
   }
+  |> Keeper_structured_output_schema.without_response_format
 ;;
 
 module For_testing = struct
@@ -97,6 +96,8 @@ end
    No Result: with no schema requested there is nothing left that can reject
    the config. *)
 let resolve_provider_for_consolidation = provider_for_consolidation
+;;
+
 let messages_for_consolidation facts =
   let numbered = Consolidation.render_numbered_facts facts in
   match

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -54,54 +54,49 @@ let with_facts_lock ?clock ~keeper_id f =
     f
 ;;
 
+(* The consolidation request carries no wire [response_format]: the prompt
+   states the output contract (config/prompts/keeper.librarian.memory_consolidation.md
+   spells out the object, its fields, and the empty-plan reply) and
+   [Consolidation.plan_of_json] is total, so a malformed reply becomes
+   [Unparseable] / [Invalid_structured_response] instead of a bad write. A
+   schema on top of that added no guarantee the parser did not already provide,
+   only a capability branch: [validate_output_schema_request] rejects
+   json_schema on every json_object-only endpoint, and the parse path never
+   read a provider-side field anyway — [structured_json_of_response] extracts
+   JSON from the response's visible text. *)
 let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some n
     | Some _ | None -> Some consolidation_max_tokens
   in
-  let tuned_cfg =
-    { provider_cfg with
-      Llm_provider.Provider_config.max_tokens
-    ; tool_choice = None
-    ; disable_parallel_tool_use = true
-      (* Mirror the librarian tuning: reasoning-capable providers (GLM live)
-         otherwise spend the whole output budget on thinking and return an
-         empty visible text — observed live on 2026-07-20 as 256 consecutive
-         [Empty_response] outcomes while only trivial 2-fact stores
-         consolidated. *)
-    ; enable_thinking = Some false
-    ; preserve_thinking = Some false
-    ; thinking_budget = None
-    ; clear_thinking = Some true
-    }
-  in
-  Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-    ~log_label:"memory os consolidation output contract"
-    Keeper_structured_output_schema.consolidation_plan_output_schema
-    tuned_cfg
+  { provider_cfg with
+    Llm_provider.Provider_config.max_tokens
+  ; tool_choice = None
+  ; disable_parallel_tool_use = true
+    (* Mirror the librarian tuning: reasoning-capable providers (GLM live)
+       otherwise spend the whole output budget on thinking and return an
+       empty visible text — observed live on 2026-07-20 as 256 consecutive
+       [Empty_response] outcomes while only trivial 2-fact stores
+       consolidated. *)
+  ; enable_thinking = Some false
+  ; preserve_thinking = Some false
+  ; thinking_budget = None
+  ; clear_thinking = Some true
+  ; response_format = Agent_sdk.Types.Off
+  ; output_schema = None
+  }
 ;;
 
 module For_testing = struct
   let provider_for_consolidation = provider_for_consolidation
 end
 
-let validate_provider_for_consolidation provider_cfg =
-  Llm_provider.Provider_config.validate_output_schema_request provider_cfg
-;;
-
-(* The output-contract tier is a function of the provider capabilities and the
-   plan schema only — never of the keeper — so it is resolved once per
-   consolidation tick, not once per keeper. Re-resolving per keeper duplicated
-   the decision and emitted one identical contract log line per keeper per
-   tick. *)
-let resolve_provider_for_consolidation provider_cfg =
-  let tiered = provider_for_consolidation provider_cfg in
-  match validate_provider_for_consolidation tiered with
-  | Ok () -> Ok tiered
-  | Error msg -> Error msg
-;;
-
+(* Request tuning is a function of the provider config alone — never of the
+   keeper — so it is resolved once per consolidation tick, not once per keeper.
+   No Result: with no schema requested there is nothing left that can reject
+   the config. *)
+let resolve_provider_for_consolidation = provider_for_consolidation
 let messages_for_consolidation facts =
   let numbered = Consolidation.render_numbered_facts facts in
   match

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -28,15 +28,15 @@ module For_testing : sig
     -> Llm_provider.Provider_config.t
 end
 
-(** Apply the three-tier consolidation output contract (#25324: native
-    json_schema > json_object > prompt) to the runtime's provider config and
-    validate the tuned request. Call once per consolidation tick and pass the
-    result to every {!consolidate_keeper} in that tick — the tier depends only
-    on the provider capabilities and the plan schema, never on the keeper, so
-    per-keeper resolution duplicates the decision and its contract log line. *)
+(** Tune the runtime's provider config for the consolidation request: output
+    budget, no tool use, thinking disabled, and no wire response format. Call
+    once per consolidation tick and pass the result to every
+    {!consolidate_keeper} in that tick — the tuning depends only on the provider
+    config, never on the keeper. Total: the request asks for no output schema,
+    so no provider capability can reject it. *)
 val resolve_provider_for_consolidation
   :  Llm_provider.Provider_config.t
-  -> (Llm_provider.Provider_config.t, string) result
+  -> Llm_provider.Provider_config.t
 
 (** Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it,
     and (unless [dry_run]) rewrite the store atomically only if the fact snapshot

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -282,16 +282,30 @@ let apply_hitl_summary_schema_to_config config =
   apply_to_provider_config hitl_context_summary_schema config
 ;;
 
-let apply_schema_or_prompt_tier ~log_label schema provider_cfg =
-  let native_cfg = apply_to_provider_config schema provider_cfg in
-  match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
-  | Ok () -> native_cfg
-  | Error detail ->
-    Log.Keeper.info
-      "%s: prompt tier (native schema unavailable: %s)"
-      log_label
-      detail;
-    provider_cfg
+(* Ask the provider for no wire response format. The call sites that use this
+   state their output contract in the prompt and re-validate it in a total
+   parser, so a native schema added no guarantee the parser did not already
+   provide. What it did add was a capability branch:
+   [validate_output_schema_request] rejects json_schema on every
+   json_object-only endpoint (GLM/DeepSeek/Kimi), so those lanes fell back to
+   the same prompt path anyway while logging one INFO line per keeper per tick.
+
+   Two failure modes traced to that branch are closed by not taking it. The
+   librarian schema marks every claim field [required] with nullable types, so
+   a schema-conforming provider emits ["claim_id": null] — which
+   [Keeper_librarian.optional_string_field_strict] rejects, dropping the whole
+   episode, while the prompt tells the model to omit the key instead. And the
+   json_object tier only 400s because a response_format was set at all.
+
+   Note the parse path never read a provider-side structured field:
+   [Agent_sdk_response.structured_json_of_response] extracts JSON from the
+   response's visible text, so native and prompt tiers converge on the same
+   parser byte for byte. *)
+let without_response_format (provider_cfg : Llm_provider.Provider_config.t) =
+  { provider_cfg with
+    response_format = Agent_sdk.Types.Off
+  ; output_schema = None
+  }
 ;;
 
 (* Capability-aware three-tier response-format selection for a request whose

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -60,15 +60,15 @@ val apply_hitl_summary_schema_to_config
   -> Llm_provider.Provider_config.t
 (** Set both OAS structured-output fields for {!hitl_context_summary_schema}. *)
 
-val apply_schema_or_prompt_tier
-  :  log_label:string
-  -> Yojson.Safe.t
+val without_response_format
+  :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
-  -> Llm_provider.Provider_config.t
-(** Set [schema] only when the provider accepts native structured output.
-    Otherwise return the original provider config and log the prompt-tier
-    downgrade with the validation detail. Use only for keeper operation paths
-    whose parser remains fail-loud after the provider response. *)
+(** Clear both OAS structured-output fields: the request states its output
+    contract in its prompt and validates the parse downstream, so it asks the
+    provider for no wire format at all. Use for call sites whose prompt spells
+    out the object shape and whose parser is total — a malformed reply must
+    already become a typed error rather than a bad write. Every provider then
+    takes one identical request path with no capability branch. *)
 
 val apply_schema_json_mode_or_prompt_tier
   :  log_label:string

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -120,15 +120,10 @@ let run_memory_os_consolidation_tick
       ~now
       ()
   =
-  match
+  let provider_cfg =
     Keeper_memory_os_consolidation_runtime.resolve_provider_for_consolidation
       provider_cfg
-  with
-  | Error msg ->
-    Log.Server.warn
-      "memory_os_keeper_consolidation: provider config rejected: %s"
-      msg
-  | Ok provider_cfg ->
+  in
   let keeper_ids = Keeper_memory_os_io.list_fact_store_keeper_ids () in
   let consolidate_one keeper_id () =
     try

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1488,19 +1488,23 @@ let test_librarian_runtime_appends_episode_bundle () =
              "thinking preservation disabled"
              (Some false)
              provider_cfg.Llm_provider.Provider_config.preserve_thinking;
-           let expected_schema = Structured_schema.librarian_episode_output_schema in
+           (* The contract lives in the prompt and in
+              [Keeper_librarian.episode_of_json_result], not in a wire format.
+              Reattaching the schema here would resurrect a concrete failure:
+              it marks every claim field required with nullable types, so a
+              conforming provider emits ["claim_id": null], which
+              [optional_string_field_strict] rejects — dropping the whole
+              episode — while the prompt tells the model to omit the key. *)
            Alcotest.(check bool)
-             "librarian json schema response format"
+             "librarian requests no response format"
              true
              (match provider_cfg.response_format with
-              | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal schema expected_schema
-              | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
-           Alcotest.(check (option bool))
-             "librarian output schema mirrors response format"
-             (Some true)
-             (Option.map
-                (Yojson.Safe.equal expected_schema)
-                provider_cfg.Llm_provider.Provider_config.output_schema);
+              | Agent_sdk.Types.Off -> true
+              | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
+           Alcotest.(check bool)
+             "librarian attaches no output schema"
+             true
+             (Option.is_none provider_cfg.Llm_provider.Provider_config.output_schema);
            Alcotest.(check int) "system+user prompt" 2 (List.length messages);
            let rendered_prompt = messages |> List.map message_text |> String.concat "\n" in
            Alcotest.(check bool)

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -440,12 +440,10 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
                seen_prompt_matches_template := String.equal expected_prompt rendered_prompt)
             plan
         in
+        (* Total: with no output schema requested there is nothing a provider
+           capability can reject, so the resolver returns a config directly. *)
         let resolved_cfg =
-          match
-            Runtime.resolve_provider_for_consolidation (provider_cfg ~max_tokens:512 ())
-          with
-          | Ok cfg -> cfg
-          | Error msg -> Alcotest.failf "resolver rejected provider config: %s" msg
+          Runtime.resolve_provider_for_consolidation (provider_cfg ~max_tokens:512 ())
         in
         let outcome =
           Runtime.consolidate_keeper
@@ -489,12 +487,13 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
           !seen_prompt_matches_template))))
 ;;
 
-(* #25324 tier 2 wiring: a provider that declares json_object but not native
-   json_schema (GLM/DeepSeek/Kimi) must get [JsonMode] from the consolidation
-   resolver — before this fix the 2-tier helper dropped such providers straight
-   to the prompt tier, forfeiting the wire-level JSON guarantee the endpoint
-   offers. *)
-let test_resolver_selects_json_mode_for_json_object_only_provider () =
+(* Capability independence: a provider that declares json_object but not native
+   json_schema (GLM/DeepSeek/Kimi) gets exactly the request every other provider
+   gets. Tier selection existed only to decide how to ask for a schema; with no
+   schema requested, a declared capability — which this repo has recorded as
+   sometimes false (ollama.com cloud, 2026-07-02 probe) — can no longer change
+   what goes on the wire. The tuning that does matter is still asserted below. *)
+let test_resolver_is_capability_independent () =
   let json_object_only_cfg =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -506,34 +505,33 @@ let test_resolver_selects_json_mode_for_json_object_only_provider () =
         }
       ()
   in
-  match Runtime.resolve_provider_for_consolidation json_object_only_cfg with
-  | Error msg -> Alcotest.failf "resolver rejected json_object-only provider: %s" msg
-  | Ok resolved ->
-    Alcotest.(check bool)
-      "json_object-only provider gets JsonMode"
-      true
-      (match resolved.Llm_provider.Provider_config.response_format with
-       | Atypes.JsonMode -> true
-       | Atypes.JsonSchema _ | Atypes.Off -> false);
-    Alcotest.(check bool)
-      "JsonMode carries no output_schema"
-      true
-      (Option.is_none resolved.Llm_provider.Provider_config.output_schema);
-    Alcotest.(check (option bool))
-      "thinking is disabled for the consolidation request"
-      (Some false)
-      resolved.Llm_provider.Provider_config.enable_thinking;
-    Alcotest.(check (option bool))
-      "thinking output is not preserved"
-      (Some false)
-      resolved.Llm_provider.Provider_config.preserve_thinking
+  let resolved = Runtime.resolve_provider_for_consolidation json_object_only_cfg in
+  Alcotest.(check bool)
+    "json_object-only provider still gets no response format"
+    true
+    (match resolved.Llm_provider.Provider_config.response_format with
+     | Atypes.Off -> true
+     | Atypes.JsonMode | Atypes.JsonSchema _ -> false);
+  Alcotest.(check bool)
+    "no output_schema is attached"
+    true
+    (Option.is_none resolved.Llm_provider.Provider_config.output_schema);
+  Alcotest.(check (option bool))
+    "thinking is disabled for the consolidation request"
+    (Some false)
+    resolved.Llm_provider.Provider_config.enable_thinking;
+  Alcotest.(check (option bool))
+    "thinking output is not preserved"
+    (Some false)
+    resolved.Llm_provider.Provider_config.preserve_thinking
 ;;
 
-(* The OpenAI-compatible json_object contract rejects (HTTP 400) requests whose
-   messages lack the literal token "json" (DeepSeek/Kimi enforce; GLM is
-   lenient). The consolidation prompt must therefore always state that it
-   returns JSON — this locks the token in place for every JsonMode-tier
-   request. *)
+(* With no wire response format, the prompt is the only place the output
+   contract is stated, so it must keep saying the reply is JSON — a prompt that
+   stopped asking for JSON would leave [plan_of_json] rejecting every reply.
+   (This assertion previously existed for a different reason: the
+   OpenAI-compatible json_object tier 400s when the messages lack a literal
+   "json" token. That tier is gone; the contract reason outlives it.) *)
 let test_consolidation_prompt_carries_json_token () =
   with_prompts (fun () ->
     let facts = [ fact "a"; fact "b" ] in
@@ -578,9 +576,9 @@ let () =
 	        ] )
     ; ( "output_contract"
       , [ Alcotest.test_case
-            "resolver selects JsonMode for json_object-only provider"
+            "resolver output does not depend on provider capability"
             `Quick
-            test_resolver_selects_json_mode_for_json_object_only_provider
+            test_resolver_is_capability_independent
         ; Alcotest.test_case
             "consolidation prompt carries the json token"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -466,19 +466,23 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
           "configured max_tokens cap is preserved"
           (Some 512)
           !seen_max_tokens;
-        let expected_schema = Structured_schema.consolidation_plan_output_schema in
+        (* The contract lives in the prompt and the parser, not in a wire
+           response_format. Pinning [Off] keeps the request identical across
+           providers: reintroducing a schema demand would make every
+           json_object-only endpoint (GLM/DeepSeek/Kimi) fail capability
+           validation and silently fall back to this same prompt path. *)
         Alcotest.(check (option bool))
-          "json schema response format requested"
+          "no response format is requested"
           (Some true)
           (Option.map
              (function
-               | Atypes.JsonSchema schema -> Yojson.Safe.equal schema expected_schema
-               | Atypes.JsonMode | Atypes.Off -> false)
+               | Atypes.Off -> true
+               | Atypes.JsonMode | Atypes.JsonSchema _ -> false)
              !seen_response_format);
-        Alcotest.(check (option bool))
-          "output schema mirrors response format"
-          (Some true)
-          (Option.map (Yojson.Safe.equal expected_schema) !seen_output_schema);
+        Alcotest.(check bool)
+          "no output schema is attached"
+          true
+          (Option.is_none !seen_output_schema);
         Alcotest.(check bool)
           "prompt registry output is passed through verbatim"
           true

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -123,49 +123,55 @@ let has_json_schema_response_format schema provider_cfg =
   | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false
 ;;
 
-let test_apply_schema_or_prompt_tier_uses_native_when_supported () =
-  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
-  let base = schema_capable_oas_provider_config () in
-  let configured =
-    Keeper_structured_output_schema.apply_schema_or_prompt_tier
-      ~log_label:"test native"
-      schema
-      base
-  in
-  check bool "native schema is attached" true
-    (has_json_schema_response_format schema configured);
-  check (option bool) "output_schema mirrors native schema" (Some true)
-    (Option.map
-       (Yojson.Safe.equal schema)
-       configured.Llm_provider.Provider_config.output_schema)
+let has_no_response_format provider_cfg =
+  match provider_cfg.Llm_provider.Provider_config.response_format with
+  | Agent_sdk.Types.Off ->
+    Option.is_none provider_cfg.Llm_provider.Provider_config.output_schema
+  | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false
 ;;
 
-let test_apply_schema_or_prompt_tier_keeps_prompt_config_when_native_rejected () =
-  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
-  let base = prompt_tier_oas_provider_config () in
-  let native_cfg = Keeper_structured_output_schema.apply_to_provider_config schema base in
-  (match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
-   | Ok () -> fail "prompt-tier provider unexpectedly accepted native schema"
-   | Error _ -> ());
-  let configured =
-    Keeper_structured_output_schema.apply_schema_or_prompt_tier
-      ~log_label:"test prompt"
-      schema
-      base
+(* A schema-capable provider gets no response format either: capability is not
+   consulted. Without this the helper could silently regrow a native tier for
+   the one provider class that accepts it, which is the split these call sites
+   were changed to remove. *)
+let test_without_response_format_clears_schema_capable_provider () =
+  let base =
+    Keeper_structured_output_schema.apply_to_provider_config
+      Keeper_structured_output_schema.librarian_episode_output_schema
+      (schema_capable_oas_provider_config ())
   in
-  check bool "prompt tier has no native schema" false
-    (has_json_schema_response_format schema configured);
-  check (option bool) "prompt tier leaves output_schema empty" None
-    (Option.map
-       (Yojson.Safe.equal schema)
-       configured.Llm_provider.Provider_config.output_schema);
-  check
-    bool
-    "prompt-tier config still validates without native schema"
-    true
-    (match Llm_provider.Provider_config.validate_output_schema_request configured with
-     | Ok () -> true
-     | Error _ -> false)
+  check bool "schema-capable provider starts with a native schema attached" true
+    (has_json_schema_response_format
+       Keeper_structured_output_schema.librarian_episode_output_schema
+       base);
+  check bool "helper clears it anyway" true
+    (has_no_response_format (Keeper_structured_output_schema.without_response_format base))
+;;
+
+(* The point of the helper is that the request is byte-identical regardless of
+   what the provider advertises, so a capability fact that turns out to be a lie
+   (ollama.com cloud declared json_schema and ignored it — 2026-07-02 probe)
+   cannot change the request that was sent. *)
+let test_without_response_format_is_capability_independent () =
+  let schema_capable =
+    Keeper_structured_output_schema.without_response_format
+      (schema_capable_oas_provider_config ())
+  in
+  let json_object_only =
+    Keeper_structured_output_schema.without_response_format
+      (prompt_tier_oas_provider_config ())
+  in
+  check bool "schema-capable provider asks for no format" true
+    (has_no_response_format schema_capable);
+  check bool "json_object-only provider asks for no format" true
+    (has_no_response_format json_object_only);
+  check bool "both configs pass output-schema validation" true
+    (List.for_all
+       (fun cfg ->
+          match Llm_provider.Provider_config.validate_output_schema_request cfg with
+          | Ok () -> true
+          | Error _ -> false)
+       [ schema_capable; json_object_only ])
 ;;
 
 (* #25266: a json_object-only provider (structured_output=false,
@@ -405,13 +411,13 @@ let () =
             `Quick
             test_all_schemas_apply_as_oas_native_json_schema
         ; test_case
-            "schema-or-prompt helper uses native schema when supported"
+            "without_response_format clears a schema-capable provider too"
             `Quick
-            test_apply_schema_or_prompt_tier_uses_native_when_supported
+            test_without_response_format_clears_schema_capable_provider
         ; test_case
-            "schema-or-prompt helper keeps prompt tier when native rejected"
+            "without_response_format is capability-independent"
             `Quick
-            test_apply_schema_or_prompt_tier_keeps_prompt_config_when_native_rejected
+            test_without_response_format_is_capability_independent
         ; test_case
             "json_mode tier selects JsonMode for json_object-only provider"
             `Quick


### PR DESCRIPTION
## 목표

structured-output 호출부 5곳에서 wire `response_format` 요구를 제거한다. 계약은 프롬프트가 말하고 파서가 검증하므로, provider에게 형식을 강제하는 층은 중복이었다.

## 판정 기준

호출부마다 두 가지만 물었다. 둘 다 참일 때만 제거했다.

1. 프롬프트가 출력 계약(객체 형태, 필드명, 빈 응답)을 완전히 서술하는가
2. 파서가 총함수인가 — 잘못된 응답이 typed error가 되고 잘못된 쓰기가 되지 않는가

| 호출부 | 프롬프트 | 파서 | 결정적 근거 |
|---|---|---|---|
| memory OS consolidation | 완전 | 총함수 | `plan_of_json` → `Unparseable`/`Invalid_structured_response` |
| keeper failure judgment | **스키마보다 엄격** | 총함수 | 프롬프트가 `decision`↔`guidance` 조건부 null 결합을 강제 — JSON Schema는 oneOf 없이 표현 불가 |
| Board attention batch | 완전 | 총함수 | 무결성은 `candidate_id` 집합 일치(`validate_batch_coverage`)가 지킴 |
| fusion judge | 완전 | 총함수 | 필드명 상수가 schema builder와 동일해 계약이 갈라질 수 없음 |
| Memory OS librarian | 완전 | 총함수 | `episode_of_json_result` → 닫힌 `parse_error` |

`keeper_compaction_llm_summarizer`는 **제외**했다. 그 호출부는 `plan_schema_supported` 후보 필터와 얽혀 있고, 라이브 컴팩션이 #25275/#25324로 막 복구된 상태라 회귀 시 원인 분리가 어렵다.

## 근거

**파싱 경로가 애초에 provider 필드를 읽지 않았다.** `Agent_sdk_response.structured_json_of_response`는 응답의 **visible text**에서 JSON을 추출한다. native tier와 prompt tier가 같은 파서로 바이트 단위 수렴한다. 스키마는 형식 위반 확률만 낮췄고, 그건 프롬프트가 이미 하던 일이다.

**대신 capability 분기를 만들었다.** `validate_output_schema_request`가 json_object-only 엔드포인트를 거절하므로 그 lane은 같은 prompt 경로로 떨어지면서 로그만 남겼다.

**분기를 타지 않음으로써 닫히는 실제 결함 2건:**

1. **librarian 데이터 손실** — `librarian_claim_schema`는 모든 claim 필드를 `required` + nullable로 선언한다. 스키마를 준수하는 provider는 `"claim_id": null`을 보내고, `optional_string_field_strict`는 `` `Null ``을 거부하며, `traverse`가 all-or-nothing이라 **에피소드 전체가 드롭**된다. 반면 프롬프트는 키를 생략하라고 지시하고 파서는 그걸 받아들인다. 프롬프트와 파서는 일치했고, 어긋난 건 스키마였다.

2. **fusion judge의 무의미한 강제** — 현재 judge 런타임이 가리키는 엔드포인트는 json_schema 지원을 **선언하고 무시한다**(2026-07-02 probe, `fusion_judge.ml`에 기록). native tier가 와이어에서 선택되지만 강제되지 않는다. 계약을 지켜온 건 내내 프롬프트와 파서다. #22768이 native 부재를 hard failure로 만들었다가 되돌린 것도 같은 이유다.

## 변경

- `apply_schema_or_prompt_tier` → `without_response_format` (`response_format = Off`, `output_schema = None`)
- vacuous해진 검증 제거: consolidation과 librarian의 provider-config 검증은 스키마를 요구하지 않으면 실패할 수 없다. librarian의 도달 불가능한 `Provider_config_rejected` 생성자도 함께 제거.
- `resolve_provider_for_consolidation`의 `Result` 제거 — 같은 이유로 총함수가 된다.
- `apply_to_provider_config`는 **유지**한다. 본 감사 범위 밖의 4곳(vision_tool, hitl_summary, memory_llm_summary, metric_hooks)이 쓴다.

**upstream 보존**: #25423이 consolidation에 넣은 `max_tokens = 8192`와 thinking-off 4필드(라이브 `Empty_response` 256건 수정), 그리고 tick당 1회 호이스트 구조는 그대로 유지했다.

## 로컬 검증

| 스위트 | 결과 |
|---|---|
| `test_keeper_structured_output_schema` | 12/12 |
| `test_keeper_memory_os` | 107/107 |
| `test_keeper_board_attention_candidate` | 5/5 |
| `test_fusion` | 79/79 |
| `test_keeper_memory_os_consolidation_runtime` | 10/11 |

`dune build lib/` 통과.

유일한 실패는 `loop.007 requires clock before provider call`이다. **변경 전 트리에서 동일하게 재현**되며(lib/test를 모두 되돌려 확인), 알려진 macOS 로컬 실패다. 본 변경과 무관하다.

새 테스트가 실제로 무언가를 고정하는지도 counterfactual로 확인했다 — 변경 전 lib에 새 테스트를 물리면 `loop.008`이 red가 된다(2 failures).

## 검증되지 않은 항목

- 라이브 재기동 후 동작은 확인하지 않았다.
- librarian의 `"claim_id": null` 드롭은 **코드 리딩 기반**이며 실행으로 재현하지 않았다. 스키마 준수 페이로드를 파서에 직접 먹이는 테스트로 확정할 값어치가 있다.
- compaction 호출부는 남아 있다. 필터 재설계와 함께 별도로 다룬다.

RFC-WAIVED: credential/identity/operator/sandbox/dashboard/hooks 어느 subsystem에도 해당하지 않는다. 동작 축소가 아니라 중복 제거이며, 각 호출부의 파서 계약은 불변이다.
