### PR TITLE
fix(dashboard): 큐잉된 컴팩션을 "완료" 아닌 "예약됨"으로 표시

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -6,6 +6,7 @@ import { navigate } from '../../router'
 import { callMcpTool } from '../../api/mcp'
 import { fetchKeeperCompactionSnapshots, fetchKeeperTurnRecords, fetchRuntimeProviders } from '../../api/dashboard'
 import { requestConfirm } from '../common/confirm-dialog'
+import { showToast } from '../common/toast'
 import { KeeperWorkspaceRail, runtimeRawSpecOpen } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
 import type { KeeperRuntimeLensConfigDriftAxis } from '../../api/keeper-runtime-trace'
@@ -135,6 +136,11 @@ vi.mock('../../api/mcp', () => ({
 
 vi.mock('../common/confirm-dialog', () => ({
   requestConfirm: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+  showActionToast: vi.fn(),
 }))
 
 function mkKeeper(partial: Partial<Keeper>): Keeper {
@@ -827,6 +833,55 @@ describe('KeeperWorkspaceRail', () => {
 
     await waitFor(() => expect(requestConfirm).toHaveBeenCalled())
     expect(callMcpTool).not.toHaveBeenCalled()
+  })
+
+  it('shows a pending (not complete) toast when compaction is only enqueued', async () => {
+    // The real masc_keeper_compact ENQUEUES the request and returns
+    // {queued, queue_outcome}; it does NOT return before/after tokens. Enqueue is
+    // not completion — a queue stuck behind an unrecovered inflight turn stays
+    // pending, so the toast must say pending, never "완료".
+    vi.mocked(callMcpTool).mockResolvedValueOnce(
+      '{"name":"masc-improver","queued":true,"queue_outcome":"enqueued","stimulus":"manual_compaction_requested"}',
+    )
+    shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, lifecycle_phase: 'Overflowed' })} />`)
+    fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
+
+    // The compaction toast names the keeper; a later refresh toast does not, so
+    // filter by name to avoid asserting on the unrelated refresh notification.
+    await waitFor(() =>
+      expect(
+        vi.mocked(showToast).mock.calls.some(([msg]) => typeof msg === 'string' && msg.includes('masc-improver')),
+      ).toBe(true),
+    )
+    const compactCall = vi.mocked(showToast).mock.calls.find(
+      ([msg]) => typeof msg === 'string' && msg.includes('masc-improver'),
+    )
+    expect(compactCall?.[0]).toContain('예약됨')
+    expect(compactCall?.[0]).not.toContain('완료')
+    expect(compactCall?.[1]).toBe('warning')
+    // A request that only queued must not leave a phantom (null-token) snapshot.
+    expect(compactionSnapshots.value['masc-improver']).toBeUndefined()
+  })
+
+  it('reports completion only when the tool returns measured before/after tokens', async () => {
+    vi.mocked(callMcpTool).mockResolvedValueOnce('{"before_tokens":1000,"after_tokens":800}')
+    shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, lifecycle_phase: 'Overflowed' })} />`)
+    fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(showToast).mock.calls.some(([msg]) => typeof msg === 'string' && msg.includes('masc-improver')),
+      ).toBe(true),
+    )
+    const compactCall = vi.mocked(showToast).mock.calls.find(
+      ([msg]) => typeof msg === 'string' && msg.includes('masc-improver'),
+    )
+    expect(compactCall?.[0]).toContain('완료')
+    expect(compactCall?.[1]).toBe('success')
+    // A measured compaction is recorded as a durable snapshot.
+    expect(compactionSnapshots.value['masc-improver']).toBeDefined()
   })
 
   it('opens the compaction inspector overlay from the context rail and hydrates durable snapshots', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -414,19 +414,41 @@ function ContextSection({
       setCompacting(true)
       try {
         const raw = await callMcpTool('masc_keeper_compact', { name: keeper.name, force })
-        const parsed = JSON.parse(raw) as { before_tokens?: number; after_tokens?: number; phase_after?: string }
+        const parsed = JSON.parse(raw) as {
+          before_tokens?: number
+          after_tokens?: number
+          phase_after?: string
+          queued?: boolean
+          queue_outcome?: string
+        }
         const before = formatK(parsed.before_tokens)
         const after = formatK(parsed.after_tokens)
-        recordManualCompaction(
-          keeper.name,
-          parsed.before_tokens,
-          parsed.after_tokens,
-          keeperRuntimeLabel(keeper) ?? '—',
-        )
-        showToast(
-          before && after ? `${keeper.name} compact 완료: ${before} -> ${after}` : `${keeper.name} compact 완료`,
-          'success',
-        )
+        if (before && after) {
+          // Measured before/after present: a compaction actually ran and reduced tokens.
+          recordManualCompaction(
+            keeper.name,
+            parsed.before_tokens,
+            parsed.after_tokens,
+            keeperRuntimeLabel(keeper) ?? '—',
+          )
+          showToast(`${keeper.name} compact 완료: ${before} -> ${after}`, 'success')
+        } else if (parsed.queued) {
+          // masc_keeper_compact only ENQUEUES the request; the compaction runs later on the
+          // keeper's owning lane. Queuing is not completion: a queue stuck behind an
+          // unrecovered inflight turn stays pending indefinitely, so rendering it as "완료"
+          // is a false success. Surface the pending state, and do not record a phantom
+          // (null-token) compaction snapshot for a request that has not run.
+          const alreadyQueued = parsed.queue_outcome === 'already_present'
+          showToast(
+            alreadyQueued
+              ? `${keeper.name} compaction 이미 예약됨 — 대기열에서 실행 대기 중`
+              : `${keeper.name} compaction 예약됨 — 대기열에서 실행 대기 중`,
+            'warning',
+          )
+        } else {
+          // Unrecognized response shape: acknowledge receipt without claiming completion.
+          showToast(`${keeper.name} compaction 요청 접수됨 (상태 미확인)`, 'warning')
+        }
         await refreshAfterRuntimeAction()
       } catch (err) {
         showToast(`compact 실패: ${errorToString(err)}`, 'error', 8000)


### PR DESCRIPTION
## 무엇을

키퍼 상세의 "지금 컴팩트" 버튼이 **큐잉을 완료로 오표시**하던 것을 수정. `masc_keeper_compact`는 compaction을 **큐에 넣기만** 하고(`{queued, queue_outcome}` 반환) 실행/완료를 기다리지 않는데, 대시보드가 호출 직후 무조건 `compact 완료` success 토스트 + null-token 스냅샷을 남겨서, **큐에 물렸을 뿐인 요청이 "완료"로 보였습니다**.

## 왜 (라이브 근거)

2026-07-20 라이브: analyst가 **339.1k / 262.1k (100% 초과)** 상태에서 compaction이 안 돎. 원인 체인:
- 턴이 `TRANSPORT FAILURE`로 실패 → event queue가 "recover inflight turn"에서 대기 → 뒤에 큐된 `manual_compaction_requested`가 **영구 대기**(`queue_outcome:"already_present"`).
- 그런데 대시보드는 `masc_keeper_compact -> {"queued":true}`를 받자마자 **"compact 완료" 토스트**를 띄움 → 운영자는 "됐다"고 오인, 실제론 큐에서 안 돎.

`keeper-workspace-rail.ts`는 `{before_tokens, after_tokens}`(동기 결과)를 기대하나 tool은 그걸 **절대 반환 안 함** → 항상 `before/after` undefined → 항상 plain "완료". "compaction 예정(pending)" 상태가 통째로 사라짐.

## 변경

`callMcpTool` 응답을 실제 형태로 분기:
- **measured before/after 존재** → `완료` (success) + 스냅샷 기록 (실제 compaction 실행된 경우).
- **`queued:true`** → `예약됨 — 대기열에서 실행 대기 중` (warning), phantom 스냅샷 미기록. `already_present`는 `이미 예약됨`.
- **미상 형태** → `요청 접수됨 (상태 미확인)` (warning), 완료 주장 안 함.

## false-green 동반 수정

기존 rail 테스트는 `callMcpTool` mock이 `{before_tokens:1000, after_tokens:800}` — **tool이 절대 안 주는 동기 형태**를 반환해서 "완료" 경로만 검증(실제 `{queued:true}` 비동기 계약 미검증). 실제 queued 응답 + measured-완료 경로 테스트 2종 추가.

## 검증

- `keeper-workspace-rail.test.ts` **37/37 통과** (기존 35 + 신규 2).
- 신규 pending 테스트는 구코드(항상 "완료 success")에서 반드시 실패 = 회귀 가드.
- `tsc --noEmit` exit 0.

## 경계

- 대시보드(TS)만. backend `masc_keeper_compact` 계약(비동기 enqueue) 불변.
- 이번 PR은 **false "완료" 토스트**만 고침. 근본 데드락(compaction stimulus가 복구 안 되는 inflight turn 뒤에 starve)은 별도 backend 트랙으로 분리(이슈 기록 예정).

RFC-WAIVED: dashboard rail toast 렌더 수정 — credential/identity/keeper-repo-mapping 등 RFC-gated 컴포넌트 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
