### PR TITLE
DO NOT MERGE (unsound, 적대검증 실패) fix(keeper): bound keeper lane acquisition (#25398)

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -298,6 +298,14 @@ let delegate_submission_error_to_json request = function
     `Assoc [ "error", `String "invalid_target"; "message", `String reason ]
   | Keeper_msg_async.Initial_persistence_failed { reason } ->
     `Assoc [ "error", `String "invocation_persistence_failed"; "message", `String reason ]
+  | Keeper_msg_async.Submit_lane_unavailable lane ->
+    (* Not [Publication_uncertain]: acquisition failed before any write, so the
+       invocation is definitively not published. *)
+    `Assoc
+      [ "error", `String "keeper_lane_unavailable"
+      ; "result_contract", `String (result_contract_to_string Failed)
+      ; "message", `String (Keeper_msg_async.lane_unavailable_to_string lane)
+      ]
   | Keeper_msg_async.Acceptance_persistence_failed { request_id; reason } ->
     `Assoc
       [ "error", `String "invocation_acceptance_uncertain"

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -490,7 +490,7 @@ let with_lane_gate ~on_wait ?(floor_s = lane_acquire_floor_seconds) mutex f =
       acquire ())
 ;;
 
-let with_keeper_lane_lock observation table ~base_path ~keeper_name f =
+let with_keeper_lane_lock observation table ?floor_s ~base_path ~keeper_name f =
   let key : Keeper_lane_key.t = { base_path; keeper_name } in
   let lock =
     Eio.Mutex.use_rw ~protect:true mu (fun () ->
@@ -522,7 +522,7 @@ let with_keeper_lane_lock observation table ~base_path ~keeper_name f =
   in
   let run () =
     match
-      with_lane_gate ~on_wait lock.mutex (fun () ->
+      with_lane_gate ~on_wait ?floor_s lock.mutex (fun () ->
         leave_pending ();
         match observation with
         | Unobserved_lane -> `Unobserved (f ())
@@ -571,19 +571,21 @@ let with_keeper_lane_lock observation table ~base_path ~keeper_name f =
     run
 ;;
 
-let with_keeper_submission_lock ~base_path ~keeper_name f =
+let with_keeper_submission_lock ?floor_s ~base_path ~keeper_name f =
   with_keeper_lane_lock
     Unobserved_lane
     keeper_submission_locks
+    ?floor_s
     ~base_path
     ~keeper_name
     f
 ;;
 
-let with_keeper_persistence_lock ~base_path ~keeper_name f =
+let with_keeper_persistence_lock ?floor_s ~base_path ~keeper_name f =
   with_keeper_lane_lock
     Persistence_lane
     keeper_persistence_locks
+    ?floor_s
     ~base_path
     ~keeper_name
     f
@@ -2992,6 +2994,14 @@ module For_testing = struct
 
   let bounded_lane_gate ~floor_s mutex f =
     with_lane_gate ~on_wait:(fun () -> ()) ~floor_s mutex f
+  ;;
+
+  let keeper_persistence_lane ~floor_s ~base_path ~keeper_name f =
+    with_keeper_persistence_lock ~floor_s ~base_path ~keeper_name f
+  ;;
+
+  let keeper_submission_lane ~floor_s ~base_path ~keeper_name f =
+    with_keeper_submission_lock ~floor_s ~base_path ~keeper_name f
   ;;
 
   let lane_acquire_floor_seconds = lane_acquire_floor_seconds

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -144,10 +144,28 @@ and recovery_record_error_kind =
   | Recovery_source_cleanup_failed
   | Recovery_entry_exception of string
 
+type lane_unavailable =
+  { waited_s : float
+  ; floor_s : float
+  }
+
+let lane_unavailable_to_string { waited_s; floor_s } =
+  Printf.sprintf
+    "keeper lane unavailable after %.1fs (floor %.1fs); a durable write for \
+     this keeper is still in flight"
+    waited_s
+    floor_s
+;;
+
 type submit_error =
   | Submit_rejected of access_rejection
   | Submit_invalid_keeper_name of { reason : string }
   | Initial_persistence_failed of { reason : string }
+  (* A keeper lane stayed held past the liveness floor because a durable write
+     for that keeper is still in flight. Kept separate from
+     [Initial_persistence_failed] so operators can tell a wedged lane from a
+     disk error: nothing was written, so there is nothing to reconcile. *)
+  | Submit_lane_unavailable of lane_unavailable
   | Acceptance_persistence_failed of
       { request_id : string
       ; reason : string
@@ -410,21 +428,66 @@ let elapsed_seconds started =
   Mtime.Span.to_float_ns (Mtime.span started (Mtime_clock.now ())) /. 1e9
 ;;
 
-let with_lane_gate ~on_wait mutex f =
-  let acquired_without_wait = Eio.Mutex.try_lock mutex in
-  if not acquired_without_wait
-  then (
-    on_wait ();
-    Eio.Mutex.lock mutex);
+(* A hung durable write keeps its lane until the write returns. That is the
+   exclusion invariant the lane exists to provide, not a defect to fix: the lane
+   mutex is the only serialiser of writes to a record path (no generation, CAS,
+   or version comparison runs before [Unix.rename]), so releasing it while a
+   write is in flight would let a write that started earlier and finished later
+   rename over a newer record. What must not be unbounded is every *later*
+   caller's wait for that lane. RFC-0348 §2 records the rejected alternative. *)
+let lane_acquire_floor_seconds = 60.0
+
+(* Bounded acquisition polls instead of racing [Eio.Mutex.lock] under
+   [Fiber.first]. [Fiber.first] cancels the loser, and [Eio.Mutex] offers no way
+   to observe whether a cancelled waiter had already taken the lock — that race
+   would leak the very lane this bound protects. Polling carries no such
+   ambiguity: the lock is either held by this fiber or it is not. *)
+let lane_acquire_poll_interval_seconds = 0.05
+
+let hold_lane_gate mutex f =
   (* A started durable systhread cannot be cancelled. Keep the lane held until
      its transaction and lock release finish. Deliberately do not re-check the
      parent cancellation here: the caller must first settle the committed
      receipt/status, matching [Keeper_event_queue_owner_lock.with_durable_lock]. *)
   (* fun-protect-finally-ok: [Eio.Mutex.unlock] is non-suspending and releases
-     only the lane gate acquired immediately above. *)
+     only the lane gate acquired by the caller. *)
   Fun.protect
     ~finally:(fun () -> Eio.Mutex.unlock mutex)
     (fun () -> Eio.Cancel.protect f)
+;;
+
+let with_lane_gate ~on_wait ?(floor_s = lane_acquire_floor_seconds) mutex f =
+  if Eio.Mutex.try_lock mutex
+  then Ok (hold_lane_gate mutex f)
+  else (
+    on_wait ();
+    match Eio_context.get_clock_opt () with
+    | None ->
+      (* No ambient clock, so the wait cannot be bounded here. Server bootstrap
+         installs one via [Eio_context.set_clock]; reaching this branch means
+         some other embedding (a tool, or a test that skipped the context) is
+         driving keeper lanes, and for those the pre-existing blocking
+         behaviour is kept rather than rejecting a caller that would otherwise
+         have succeeded. Logged rather than silent: this is the one path where
+         the liveness floor does not apply. *)
+      Log.Keeper.warn
+        "keeper_msg_async: lane acquisition unbounded, no Eio clock in context";
+      Eio.Mutex.lock mutex;
+      Ok (hold_lane_gate mutex f)
+    | Some clock ->
+      let started = Mtime_clock.now () in
+      let rec acquire () =
+        if Eio.Mutex.try_lock mutex
+        then Ok (hold_lane_gate mutex f)
+        else (
+          let waited_s = elapsed_seconds started in
+          if Float.compare waited_s floor_s >= 0
+          then Error { waited_s; floor_s }
+          else (
+            Eio.Time.sleep clock lane_acquire_poll_interval_seconds;
+            acquire ()))
+      in
+      acquire ())
 ;;
 
 let with_keeper_lane_lock observation table ~base_path ~keeper_name f =
@@ -474,8 +537,9 @@ let with_keeper_lane_lock observation table ~base_path ~keeper_name f =
           in
           `Persistence (outcome, elapsed_seconds started))
     with
-    | `Unobserved value -> value
-    | `Persistence (outcome, elapsed) ->
+    | Error _ as unavailable -> unavailable
+    | Ok (`Unobserved value) -> Ok value
+    | Ok (`Persistence (outcome, elapsed)) ->
       (* Keep blocking metrics-store work outside the per-Keeper persistence
          gate. The transaction outcome and elapsed time were captured while
          holding the gate, and [with_lane_gate] has released it before this
@@ -485,7 +549,7 @@ let with_keeper_lane_lock observation table ~base_path ~keeper_name f =
         let (_ : int) = Atomic.fetch_and_add persistence_lane_in_flight (-1) in
         Otel_metric_store.observe_histogram persistence_lane_duration_metric elapsed);
       (match outcome with
-       | Lane_lock_returned value -> value
+       | Lane_lock_returned value -> Ok value
        | Lane_lock_raised (exn, backtrace) ->
          Printexc.raise_with_backtrace exn backtrace)
   in
@@ -697,6 +761,13 @@ let submit_error_to_json = function
     `Assoc
       [ "error", `String "request_persistence_failed"
       ; "message", `String reason
+      ]
+  | Submit_lane_unavailable ({ waited_s; floor_s } as lane) ->
+    `Assoc
+      [ "error", `String "keeper_lane_unavailable"
+      ; "message", `String (lane_unavailable_to_string lane)
+      ; "waited_s", `Float waited_s
+      ; "floor_s", `Float floor_s
       ]
   | Acceptance_persistence_failed { request_id; reason } ->
     `Assoc
@@ -1131,6 +1202,11 @@ type write_failure =
 type persist_error =
   | Write_failed of write_failure
   | Integrity_failed of persist_integrity_error
+  (* The persistence lane could not be acquired within the liveness floor: a
+     durable write for this keeper is still in flight. Nothing was written on
+     this path — no temp file, no rename — so this is unambiguously
+     unpublished and must never be reconciled or rolled back. *)
+  | Lane_unavailable of lane_unavailable
 
 let persist_integrity_error_to_string = function
   | Unsafe_request_id -> "request_id is unsafe for persistence"
@@ -1149,12 +1225,15 @@ let persist_error_to_string = function
   | Write_failed (Not_published error | Published_uncertain error) ->
     Keeper_fs.durable_write_error_to_string error
   | Integrity_failed error -> persist_integrity_error_to_string error
+  | Lane_unavailable lane -> lane_unavailable_to_string lane
 ;;
 
 let persist_error_published = function
   | Write_failed (Not_published _) -> false
   | Write_failed (Published_uncertain _) -> true
   | Integrity_failed _ -> false
+  (* Acquisition failed before any write was attempted. *)
+  | Lane_unavailable _ -> false
 ;;
 
 let save_entry_durable ~ops path (entry : entry) =
@@ -1234,10 +1313,11 @@ let with_entry_persistence_transaction (entry : entry) f =
   match Keeper_id.Keeper_name.of_string entry.keeper_name with
   | Error reason -> Error (Integrity_failed (Invalid_keeper_name reason))
   | Ok keeper_name ->
-    with_keeper_persistence_lock
-      ~base_path:entry.base_path
-      ~keeper_name
-      f
+    (match
+       with_keeper_persistence_lock ~base_path:entry.base_path ~keeper_name f
+     with
+     | Ok result -> result
+     | Error lane -> Error (Lane_unavailable lane))
 ;;
 
 let persist_entry ~ops ?source_path (entry : entry) =
@@ -2031,11 +2111,13 @@ let persist_failure_locked ~ops key transition_lock (attempted_entry : entry) re
       ; durability = Volatile_persistence_failure
       ; origin = Transition_commit
       }
-  | Error (Write_failed (Not_published _)) ->
+  | Error (Write_failed (Not_published _)) | Error (Lane_unavailable _) ->
     (* The durable row still contains the previous non-terminal status. Keep
        an explicit volatile terminal overlay in this process so polling cannot
        hang indefinitely; restart recovery later converts the stale durable
-       row to typed [Lost]. *)
+       row to typed [Lost]. [Lane_unavailable] shares this arm because it
+       leaves the same on-disk state: acquisition failed before any temp file
+       or rename, so nothing was published. *)
     publish_if_owned key transition_lock failure_entry;
     Status_settlement
       { entry = failure_entry
@@ -2116,6 +2198,17 @@ let set_status ~ops ?(preserve_terminal = false) key status =
                 transition_lock
                 updated
                 (Keeper_fs.durable_write_error_to_string error))
+         | Error (Lane_unavailable lane) ->
+           (* Same on-disk state as [Not_published] — acquisition failed before
+              any write — so it takes the same settlement path, carrying a
+              reason that names the wedged lane rather than a disk error. *)
+           Some
+             (persist_failure_locked
+                ~ops
+                key
+                transition_lock
+                updated
+                (lane_unavailable_to_string lane))
          | Error (Integrity_failed _) ->
            Some
              (project_canonical_integrity_failure_locked
@@ -2170,7 +2263,8 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
      | Error reason -> Error (Submit_invalid_keeper_name { reason })
      | Ok keeper_name_id ->
     let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_id in
-    with_keeper_submission_lock ~base_path ~keeper_name:keeper_name_id (fun () ->
+    (match
+       with_keeper_submission_lock ~base_path ~keeper_name:keeper_name_id (fun () ->
     match reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name with
     | Error rejection -> Error (Submit_rejected rejection)
     | Ok (request_id, entry, key, transition_lock) ->
@@ -2181,6 +2275,7 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
         }
     in
     let initial_persistence =
+      match
       with_keeper_persistence_lock
         ~base_path
         ~keeper_name:keeper_name_id
@@ -2225,9 +2320,19 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
                               reason
                               (Keeper_fs.durable_remove_error_to_string
                                  rollback_error)))))
-              | Write_failed (Not_published _) | Integrity_failed _ ->
+              | Write_failed (Not_published _)
+              | Integrity_failed _
+              | Lane_unavailable _ ->
                 remove_runtime_if_owned key transition_lock;
                 `Settled (Error (Initial_persistence_failed { reason }))))
+      with
+      | Ok outcome -> outcome
+      | Error { waited_s; floor_s } ->
+        (* Acquisition failed, so no temp file was created and no rename ran:
+           there is nothing to roll back and no uncertain publication. Drop the
+           reservation and reject, the same shape as [Not_published]. *)
+        remove_runtime_if_owned key transition_lock;
+        `Settled (Error (Submit_lane_unavailable { waited_s; floor_s }))
     in
     (match initial_persistence with
      | `Settled result -> result
@@ -2456,7 +2561,14 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
               Ok { request_id; acceptance = Durably_accepted }
             | Some cause -> background_start_failed (Printexc.to_string cause))
         | exception exn ->
-          background_start_failed (Printexc.to_string exn))))))
+          background_start_failed (Printexc.to_string exn)))))
+     with
+     | Ok result -> result
+     | Error { waited_s; floor_s } ->
+       (* The submission lane is still held by an in-flight durable write for
+          this keeper. No reservation was taken and nothing was written on this
+          path, so the caller is rejected outright with no reconciliation. *)
+       Error (Submit_lane_unavailable { waited_s; floor_s })))
 ;;
 
 let submit_with_request_id = submit_with_ops production_request_ops
@@ -2878,4 +2990,9 @@ module For_testing = struct
   ;;
   let persistence_lane_samples = persistence_lane_samples
 
+  let bounded_lane_gate ~floor_s mutex f =
+    with_lane_gate ~on_wait:(fun () -> ()) ~floor_s mutex f
+  ;;
+
+  let lane_acquire_floor_seconds = lane_acquire_floor_seconds
 end

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -164,10 +164,28 @@ and recovery_record_error_kind =
   | Recovery_source_cleanup_failed
   | Recovery_entry_exception of string
 
+(** A keeper lane could not be acquired within the liveness floor. The lane is
+    still held by an in-flight durable write, which keeps it deliberately: the
+    lane mutex is the only serialiser of writes to a record path, so releasing
+    it mid-write would let a stale write rename over a newer record (RFC-0348
+    §2). Acquisition failure itself wrote nothing. *)
+type lane_unavailable =
+  { waited_s : float
+  ; floor_s : float
+  }
+
+val lane_unavailable_to_string : lane_unavailable -> string
+
 type submit_error =
   | Submit_rejected of access_rejection
   | Submit_invalid_keeper_name of { reason : string }
   | Initial_persistence_failed of { reason : string }
+  | Submit_lane_unavailable of lane_unavailable
+      (** A keeper lane stayed held past the liveness floor because a durable
+          write for that keeper is still in flight. Distinct from
+          {!Initial_persistence_failed}: nothing was written on this path, so
+          the request is unambiguously unpublished and needs no
+          reconciliation. *)
   | Acceptance_persistence_failed of
       { request_id : string
       ; reason : string
@@ -461,4 +479,15 @@ module For_testing : sig
   val active_switch_count : unit -> int
   val persistence_lane_observation : unit -> int * int * int
   val persistence_lane_samples : unit -> Otel_metrics.sample list
+
+  val bounded_lane_gate
+    :  floor_s:float
+    -> Eio.Mutex.t
+    -> (unit -> 'a)
+    -> ('a, lane_unavailable) result
+  (** The bounded lane acquisition used by every keeper lane, exposed so the
+      floor can be exercised without a 60 s wait. Pure with respect to module
+      state: it takes the mutex it is given and installs no overrides. *)
+
+  val lane_acquire_floor_seconds : float
 end

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -490,4 +490,23 @@ module For_testing : sig
       state: it takes the mutex it is given and installs no overrides. *)
 
   val lane_acquire_floor_seconds : float
+
+  val keeper_persistence_lane
+    :  floor_s:float
+    -> base_path:string
+    -> keeper_name:Keeper_id.Keeper_name.t
+    -> (unit -> 'a)
+    -> ('a, lane_unavailable) result
+  (** The real per-keeper persistence lane, keyed on [{base_path;
+      keeper_name}], so lane isolation can be exercised against the lane table
+      rather than a standalone mutex. *)
+
+  val keeper_submission_lane
+    :  floor_s:float
+    -> base_path:string
+    -> keeper_name:Keeper_id.Keeper_name.t
+    -> (unit -> 'a)
+    -> ('a, lane_unavailable) result
+  (** The real per-keeper submission lane. Held in a table separate from the
+      persistence lanes. *)
 end

--- a/test/dune
+++ b/test/dune
@@ -1847,6 +1847,8 @@
 
 (include stanzas/test_keeper_msg_async_durable_active_inventory.inc)
 
+(include stanzas/test_keeper_msg_async_lane_floor.inc)
+
 (include stanzas/test_turn_record.inc)
 
 (include stanzas/test_keeper_chat_coalescing.inc)

--- a/test/stanzas/test_keeper_msg_async_lane_floor.inc
+++ b/test/stanzas/test_keeper_msg_async_lane_floor.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_msg_async_lane_floor)
+ (modules test_keeper_msg_async_lane_floor)
+ (libraries masc_test_deps))

--- a/test/test_keeper_msg_async_lane_floor.ml
+++ b/test/test_keeper_msg_async_lane_floor.ml
@@ -1,0 +1,128 @@
+(** Bounded lane acquisition (#25398, RFC-0348).
+
+    A hung durable write keeps its lane on purpose — the lane mutex is the only
+    serialiser of writes to a record path, so releasing it mid-write would let a
+    stale write rename over a newer record (RFC-0348 §2). What these tests pin
+    is the other half: a caller that cannot acquire the lane must give up at the
+    floor with a typed rejection instead of waiting forever, and that rejection
+    must never be treated as published or reconcilable. *)
+
+open Alcotest
+module Keeper_msg_async = Masc.Keeper_msg_async
+
+let gate = Keeper_msg_async.For_testing.bounded_lane_gate
+
+(* Short enough to keep the suite fast, long enough that a loaded CI machine
+   still completes several poll iterations before the floor. *)
+let test_floor_s = 0.3
+
+(* The floor needs an ambient clock, which server bootstrap installs via
+   [Eio_context.set_clock]. Without it the gate deliberately falls back to the
+   pre-existing unbounded wait, so a test that skipped this setup would exercise
+   the fallback rather than the bound. *)
+let with_eio f =
+  Eio_main.run (fun env ->
+    Eio_context.set_clock (Eio.Stdenv.clock env);
+    f env)
+;;
+
+let test_free_lane_runs_body () =
+  with_eio (fun _env ->
+    let mutex = Eio.Mutex.create () in
+    let ran = ref false in
+    match gate ~floor_s:test_floor_s mutex (fun () -> ran := true; 42) with
+    | Ok value ->
+      check int "body result" 42 value;
+      check bool "body ran" true !ran;
+      check bool "lane released" true (Eio.Mutex.try_lock mutex)
+    | Error _ -> fail "free lane must be acquired")
+;;
+
+let test_held_lane_rejects_at_floor () =
+  with_eio (fun env ->
+    let clock = Eio.Stdenv.clock env in
+    let mutex = Eio.Mutex.create () in
+    Eio.Mutex.lock mutex;
+    let body_ran = ref false in
+    let started = Eio.Time.now clock in
+    match gate ~floor_s:test_floor_s mutex (fun () -> body_ran := true) with
+    | Ok () -> fail "a held lane must not be acquired"
+    | Error { waited_s; floor_s } ->
+      let elapsed = Eio.Time.now clock -. started in
+      check (float 0.001) "reported floor" test_floor_s floor_s;
+      check bool "waited at least the floor" true (waited_s >= test_floor_s);
+      (* The counterfactual: before this change the call blocked forever. An
+         upper bound is what proves the wait is bounded at all. *)
+      check bool "returned near the floor" true (elapsed < test_floor_s *. 10.);
+      check bool "body never ran" false !body_ran;
+      (* The holder still owns the lane. Releasing it early is the rejected
+         design; this assertion is the executable form of that invariant. *)
+      check bool "lane still held by the holder" false (Eio.Mutex.try_lock mutex))
+;;
+
+let test_lane_released_by_holder_is_acquirable () =
+  with_eio (fun _env ->
+    let mutex = Eio.Mutex.create () in
+    Eio.Mutex.lock mutex;
+    Eio.Mutex.unlock mutex;
+    match gate ~floor_s:test_floor_s mutex (fun () -> "acquired") with
+    | Ok value -> check string "body result" "acquired" value
+    | Error _ -> fail "a released lane must be acquirable")
+;;
+
+let test_body_exception_releases_lane () =
+  with_eio (fun _env ->
+    let mutex = Eio.Mutex.create () in
+    (match gate ~floor_s:test_floor_s mutex (fun () -> failwith "boom") with
+     | Ok () -> fail "exception must propagate"
+     | Error _ -> fail "exception must propagate, not become a lane rejection"
+     | exception Failure _ -> ());
+    check bool "lane released after exception" true (Eio.Mutex.try_lock mutex))
+;;
+
+(* Wiring: a lane rejection must not be mistaken for a published write. This is
+   what routes the caller to plain rejection instead of the reconciliation path
+   that deletes record files (RFC-0348 §2.2). *)
+let test_lane_rejection_is_not_published () =
+  let json =
+    Keeper_msg_async.submit_error_to_json
+      (Keeper_msg_async.Submit_lane_unavailable { waited_s = 61.0; floor_s = 60.0 })
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "error" fields with
+     | Some (`String code) -> check string "error code" "keeper_lane_unavailable" code
+     | Some _ | None -> fail "submit error json must carry a string error code")
+  | _ -> fail "submit error json must be an object"
+;;
+
+let test_floor_default_is_within_documented_bounds () =
+  let floor = Keeper_msg_async.For_testing.lane_acquire_floor_seconds in
+  check bool "floor at or above the documented minimum" true (floor >= 10.0);
+  check bool "floor at or below the documented maximum" true (floor <= 600.0)
+;;
+
+let () =
+  run
+    "keeper_msg_async lane floor"
+    [ ( "bounded acquisition"
+      , [ test_case "free lane runs body" `Quick test_free_lane_runs_body
+        ; test_case "held lane rejects at floor" `Quick test_held_lane_rejects_at_floor
+        ; test_case
+            "released lane is acquirable"
+            `Quick
+            test_lane_released_by_holder_is_acquirable
+        ; test_case "body exception releases lane" `Quick test_body_exception_releases_lane
+        ] )
+    ; ( "rejection wiring"
+      , [ test_case
+            "lane rejection is not published"
+            `Quick
+            test_lane_rejection_is_not_published
+        ; test_case
+            "floor default within documented bounds"
+            `Quick
+            test_floor_default_is_within_documented_bounds
+        ] )
+    ]
+;;

--- a/test/test_keeper_msg_async_lane_floor.ml
+++ b/test/test_keeper_msg_async_lane_floor.ml
@@ -80,6 +80,138 @@ let test_body_exception_releases_lane () =
     check bool "lane released after exception" true (Eio.Mutex.try_lock mutex))
 ;;
 
+(* --- Real lane table -------------------------------------------------------
+
+   The tests above use a standalone mutex, which proves the bound but says
+   nothing about whether keepers actually get *separate* lanes. The whole
+   premise of #25398 — that a hung durable write wedges one keeper and not the
+   fleet — rests on the lane key being [{base_path; keeper_name}]. These
+   exercise the real lane tables. *)
+
+let keeper_name_exn name =
+  match Keeper_id.Keeper_name.of_string name with
+  | Ok keeper_name -> keeper_name
+  | Error reason -> failwith reason
+;;
+
+let persistence_lane = Keeper_msg_async.For_testing.keeper_persistence_lane
+let submission_lane = Keeper_msg_async.For_testing.keeper_submission_lane
+let base_path = "/tmp/masc-lane-floor-test"
+
+(* Runs [hold] holding a lane while [probe] executes, then releases. The held
+   fiber parks on a promise so the lane stays taken for exactly as long as the
+   probe needs, with no sleep-based racing. *)
+let while_lane_held ~lane ~keeper ~probe =
+  let release, resolve_release = Eio.Promise.create () in
+  let probe_result = ref None in
+  Eio.Fiber.both
+    (fun () ->
+       let held =
+         lane ~floor_s:test_floor_s ~base_path ~keeper_name:(keeper_name_exn keeper)
+           (fun () -> Eio.Promise.await release)
+       in
+       match held with
+       | Ok () -> ()
+       | Error _ -> fail "the holder must acquire a free lane")
+    (fun () ->
+       probe_result := Some (probe ());
+       Eio.Promise.resolve resolve_release ());
+  match !probe_result with
+  | Some result -> result
+  | None -> fail "probe did not run"
+;;
+
+let test_other_keeper_lane_is_unaffected () =
+  with_eio (fun _env ->
+    let acquired =
+      while_lane_held ~lane:persistence_lane ~keeper:"keeper-alpha" ~probe:(fun () ->
+        persistence_lane
+          ~floor_s:test_floor_s
+          ~base_path
+          ~keeper_name:(keeper_name_exn "keeper-beta")
+          (fun () -> "beta ran"))
+    in
+    match acquired with
+    | Ok value -> check string "beta acquired while alpha is wedged" "beta ran" value
+    | Error _ ->
+      fail "a wedged lane on one keeper must not block a different keeper")
+;;
+
+let test_same_keeper_other_base_path_is_unaffected () =
+  with_eio (fun _env ->
+    let acquired =
+      while_lane_held ~lane:persistence_lane ~keeper:"keeper-alpha" ~probe:(fun () ->
+        persistence_lane
+          ~floor_s:test_floor_s
+          ~base_path:(base_path ^ "-other")
+          ~keeper_name:(keeper_name_exn "keeper-alpha")
+          (fun () -> "other store ran"))
+    in
+    match acquired with
+    | Ok value -> check string "other base_path acquired" "other store ran" value
+    | Error _ -> fail "the lane key includes base_path, so this must not block")
+;;
+
+let test_same_keeper_same_lane_hits_the_floor () =
+  with_eio (fun _env ->
+    let acquired =
+      while_lane_held ~lane:persistence_lane ~keeper:"keeper-alpha" ~probe:(fun () ->
+        persistence_lane
+          ~floor_s:test_floor_s
+          ~base_path
+          ~keeper_name:(keeper_name_exn "keeper-alpha")
+          (fun () -> fail "body must not run on a wedged lane"))
+    in
+    match acquired with
+    | Ok () -> fail "the same keeper's held lane must not be acquired"
+    | Error { floor_s; waited_s } ->
+      check (float 0.001) "reported floor" test_floor_s floor_s;
+      check bool "waited at least the floor" true (waited_s >= test_floor_s))
+;;
+
+let test_submission_and_persistence_lanes_are_separate () =
+  with_eio (fun _env ->
+    let acquired =
+      while_lane_held ~lane:persistence_lane ~keeper:"keeper-alpha" ~probe:(fun () ->
+        submission_lane
+          ~floor_s:test_floor_s
+          ~base_path
+          ~keeper_name:(keeper_name_exn "keeper-alpha")
+          (fun () -> "submission ran"))
+    in
+    match acquired with
+    | Ok value ->
+      check string "submission lane is a separate table" "submission ran" value
+    | Error _ ->
+      fail "persistence and submission lanes must not share a table")
+;;
+
+(* The rejection is a new exit path out of the lane gate. If it skipped the
+   pending-counter cleanup, the gauge would drift upward on every wedged lane
+   and mislead exactly the operator trying to diagnose the hang. *)
+let test_rejection_does_not_leak_pending_gauge () =
+  with_eio (fun _env ->
+    let pending () =
+      let _waits, pending, _in_flight =
+        Keeper_msg_async.For_testing.persistence_lane_observation ()
+      in
+      pending
+    in
+    let before = pending () in
+    let rejected =
+      while_lane_held ~lane:persistence_lane ~keeper:"keeper-gauge" ~probe:(fun () ->
+        persistence_lane
+          ~floor_s:test_floor_s
+          ~base_path
+          ~keeper_name:(keeper_name_exn "keeper-gauge")
+          (fun () -> ()))
+    in
+    (match rejected with
+     | Ok () -> fail "expected the probe to be rejected"
+     | Error _ -> ());
+    check int "pending gauge returned to its starting value" before (pending ()))
+;;
+
 (* Wiring: a lane rejection must not be mistaken for a published write. This is
    what routes the caller to plain rejection instead of the reconciliation path
    that deletes record files (RFC-0348 §2.2). *)
@@ -113,6 +245,28 @@ let () =
             `Quick
             test_lane_released_by_holder_is_acquirable
         ; test_case "body exception releases lane" `Quick test_body_exception_releases_lane
+        ] )
+    ; ( "lane isolation"
+      , [ test_case
+            "another keeper is unaffected"
+            `Quick
+            test_other_keeper_lane_is_unaffected
+        ; test_case
+            "same keeper in another store is unaffected"
+            `Quick
+            test_same_keeper_other_base_path_is_unaffected
+        ; test_case
+            "same keeper same lane hits the floor"
+            `Quick
+            test_same_keeper_same_lane_hits_the_floor
+        ; test_case
+            "submission and persistence lanes are separate"
+            `Quick
+            test_submission_and_persistence_lanes_are_separate
+        ; test_case
+            "rejection does not leak the pending gauge"
+            `Quick
+            test_rejection_does_not_leak_pending_gauge
         ] )
     ; ( "rejection wiring"
       , [ test_case


### PR DESCRIPTION
RFC-0348 PR-1. Fixes the P0 in #25398.

## 문제

durable persist가 멈추면(디스크 stall, 블록된 `fsync`/`rename`) 해당 keeper의 lane을 영구히 붙들고, 이후 모든 호출자가 상한 없이 그 뒤에 쌓입니다. 한 번 멈춘 write가 그 keeper의 `keeper_msg` 파이프라인 전체를 프로세스 재시작까지 wedge합니다.

## 무엇을 고치지 *않는지* 가 핵심입니다

진행 중인 write는 lane을 계속 쥡니다. 이건 결함이 아니라 지켜야 할 불변식입니다 — lane mutex가 해당 record 경로 쓰기의 **유일한** 직렬화 장치이고(`Unix.rename` 앞에 generation·CAS·version 비교가 하나도 없습니다), lane을 놓으면 먼저 시작해 늦게 끝난 write가 새 레코드를 덮습니다. 상한을 두는 대상은 **뒤에 쌓이는 호출자의 대기**입니다.

RFC-0348의 초안은 정확히 반대(대기 포기 → lane 해제 → systhread detached)를 제안했고, 그건 unsound였습니다. 폐기 근거는 RFC §2에 인용과 함께 보존했습니다(#25408).

## 왜 새 상태가 단순한가

획득 실패는 **모호하지 않습니다**: temp 파일도 rename도 없었으므로 아무것도 published되지 않았습니다. 따라서 기존 `Not_published`와 같은 정착 경로를 타되, 운영자가 "wedge된 lane"과 "디스크 오류"를 구분할 수 있도록 별도 typed 에러를 씁니다. `Published_uncertain`으로는 **절대** 보내지 않습니다 — 그 아암의 롤백(`keeper_msg_async.ml` 파일 삭제)이 아직 달리는 holder와 경합하기 때문입니다.

## 변경

- `with_lane_gate` — 무한 블로킹 fallback을 bounded 획득으로 교체. `Fiber.first` + `Eio.Mutex.lock` 경주가 아니라 폴링입니다: `Fiber.first`는 패자를 취소하는데 `Eio.Mutex`는 취소된 대기자가 이미 락을 잡았는지 관측할 방법이 없어, 그 경합이 이 상한이 지키려는 lane을 그대로 누수시킵니다.
- `lane_unavailable` 타입 + `Lane_unavailable` (`persist_error`) + `Submit_lane_unavailable` (`submit_error`).
- exhaustive match가 소비자 4곳에서 새 상태의 의미를 **컴파일 타임에 결정하도록 강제**했습니다(조용한 기본값 상속 없음).

## 검증

새 스위트 6건 통과(0.32초): 자유 lane 획득 / 점유된 lane이 floor에서 typed 거부 + **holder가 lane을 계속 보유** / 해제된 lane 재획득 / 예외 시 lane 해제 / 거부가 published로 분류되지 않음 / floor 기본값이 문서 범위 내.

"holder가 lane을 계속 보유"는 폐기된 설계가 깼던 불변식의 실행 가능한 형태입니다.

counterfactual: 구 코드에서는 이 테스트가 **컴파일되지 않습니다**(`with_lane_gate`가 `'a`를 반환했고 대기가 무한이었음).

## 미검증 / 알려진 한계

- **end-to-end 미커버**: "wedge된 lane 상태에서 `submit`이 `Submit_lane_unavailable`을 반환한다"는 통합 테스트는 floor를 `request_ops`로 주입하는 배선이 필요해 후속입니다. 지금은 원시함수 + 에러 매핑 배선만 고정돼 있습니다. 배선 누락은 제가 이 저장소에서 반복해 데인 실패 모드라 명시합니다.
- floor는 ambient Eio clock이 필요합니다(서버 bootstrap이 설치). clock이 없는 embedding은 기존 무한 대기를 유지하며, 이제 그 사실을 로그로 남깁니다.
- floor는 현재 named constant(60.0)입니다. RFC가 명시한 `MASC_KEEPER_LANE_ACQUIRE_FLOOR_SEC` env knob은 catalog 동기화가 필요해 분리했습니다.
- 로컬에서 `test_keeper_msg_async_terminal_event` 1건이 실패하나 macOS `$TMPDIR` 심볼릭 링크(`/var` vs `/private/var`) 문제로 본 변경과 무관합니다.

RFC-WAIVED: RFC-0348 (#25408) 이 PR의 설계 문서이며 본 PR이 그 PR-1입니다.
