### PR TITLE
fix(keeper): stop holding the admission slot mutex across a fiber suspension

### DIFF
--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -165,29 +165,43 @@ let decr_running_count_clamped () =
 
 (** Lock-free CAS loop for registry writes. Atomic.t used instead of Eio.Mutex for non-Eio context compatibility (#7011 pattern). *)
 
+(* Precondition: the caller already holds the per-keeper lifecycle key lock.
+   Every step below is non-suspending: [authorize] reads the process-local
+   reservation table, [validate_registry_entry] is pure, the metric store and
+   [Log] use stdlib I/O rather than Eio flows, and the install is a CAS loop.
+   That totality is what makes this body legal to run inside
+   [Keeper_turn_admission.commit_registration_if_open], whose critical section
+   is guarded by a scheduler-blocking [Stdlib.Mutex]: a fiber that suspends
+   there can never be resumed, because [Stdlib.Mutex.lock] blocks the very OS
+   thread that runs the Eio scheduler. Acquiring the key lock here instead
+   would reintroduce that suspension. *)
+let put_entry_key_locked ?lifecycle_token ~base_path name entry =
+  match
+    Keeper_lifecycle_reservation.authorize
+      ?token:lifecycle_token
+      ~base_path
+      ~keeper_name:name
+      ()
+  with
+  | Error owner -> Error (Lifecycle_transaction_reserved owner)
+  | Ok () ->
+    (match validate_registry_entry ~base_path name entry with
+     | Error err ->
+       record_invalid_registry_entry ~operation:"put" ~name err;
+       Error err
+     | Ok () ->
+       let key = registry_key ~base_path name in
+       let rec loop () =
+         let current = Atomic.get registry in
+         let updated = StringMap.add key entry current in
+         if Atomic.compare_and_set registry current updated then Ok () else loop ()
+       in
+       loop ())
+;;
+
 let put_entry_internal ?lifecycle_token ~base_path name entry =
   Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
-    match
-      Keeper_lifecycle_reservation.authorize
-        ?token:lifecycle_token
-        ~base_path
-        ~keeper_name:name
-        ()
-    with
-    | Error owner -> Error (Lifecycle_transaction_reserved owner)
-    | Ok () ->
-      (match validate_registry_entry ~base_path name entry with
-       | Error err ->
-         record_invalid_registry_entry ~operation:"put" ~name err;
-         Error err
-       | Ok () ->
-         let key = registry_key ~base_path name in
-         let rec loop () =
-           let current = Atomic.get registry in
-           let updated = StringMap.add key entry current in
-           if Atomic.compare_and_set registry current updated then Ok () else loop ()
-         in
-         loop ()))
+    put_entry_key_locked ?lifecycle_token ~base_path name entry)
 ;;
 
 let put_entry ~base_path name entry = put_entry_internal ~base_path name entry
@@ -502,7 +516,8 @@ let register_with_state_result
     ; compaction_stage = Packed Compaction_accumulating
     }
   in
-  let commit () =
+  (* Runs with the lifecycle key lock already held, so it never suspends. *)
+  let commit_key_locked () =
     (match StringMap.find_opt key (Atomic.get registry) with
      | Some prior when prior.phase = Running ->
        Otel_metric_store.inc_counter
@@ -512,31 +527,38 @@ let register_with_state_result
        Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
        decr_running_count_clamped ()
      | Some _ | None -> ());
-    put_entry_internal ?lifecycle_token ~base_path name entry
+    put_entry_key_locked ?lifecycle_token ~base_path name entry
   in
+  (* The key lock is taken OUTSIDE the admission fence. Nesting it inside
+     [commit_registration_if_open] would suspend the fiber while it owns the
+     admission slot's [Stdlib.Mutex], wedging the whole domain. The fence check
+     and the registry install still happen together under that mutex, so
+     shutdown reservation and same-name lane installation stay totally
+     ordered. *)
   let commit_result =
-    if respect_shutdown_fence
-    then
-      match
-        Keeper_turn_admission.commit_registration_if_open
-          ~base_path
-          ~keeper_name:name
-          commit
-      with
-      | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
-        Error (Registration_shutdown_reserved operation_id)
-      | Keeper_turn_admission.Registration_committed
-          (Error (Lifecycle_transaction_reserved owner)) ->
-        Error (Registration_lifecycle_reserved owner)
-      | Keeper_turn_admission.Registration_committed (Error validation_error) ->
-        Error (Registration_invalid validation_error)
-      | Keeper_turn_admission.Registration_committed (Ok ()) -> Ok ()
-    else
-      match commit () with
-      | Ok () -> Ok ()
-      | Error (Lifecycle_transaction_reserved owner) ->
-        Error (Registration_lifecycle_reserved owner)
-      | Error validation_error -> Error (Registration_invalid validation_error)
+    Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
+      if respect_shutdown_fence
+      then (
+        match
+          Keeper_turn_admission.commit_registration_if_open
+            ~base_path
+            ~keeper_name:name
+            commit_key_locked
+        with
+        | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+          Error (Registration_shutdown_reserved operation_id)
+        | Keeper_turn_admission.Registration_committed
+            (Error (Lifecycle_transaction_reserved owner)) ->
+          Error (Registration_lifecycle_reserved owner)
+        | Keeper_turn_admission.Registration_committed (Error validation_error) ->
+          Error (Registration_invalid validation_error)
+        | Keeper_turn_admission.Registration_committed (Ok ()) -> Ok ())
+      else (
+        match commit_key_locked () with
+        | Ok () -> Ok ()
+        | Error (Lifecycle_transaction_reserved owner) ->
+          Error (Registration_lifecycle_reserved owner)
+        | Error validation_error -> Error (Registration_invalid validation_error)))
   in
   match commit_result with
   | Error _ as error -> error
@@ -716,19 +738,20 @@ let register_restarting ~base_path name meta
     then Ok new_entry
     else loop ()
   in
-  let guarded_loop () =
-    Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
-      match
-        Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name ()
-      with
-      | Error owner -> Error (Restart_lifecycle_reserved owner)
-      | Ok () -> loop ())
+  (* Runs with the lifecycle key lock already held, so it never suspends. *)
+  let guarded_loop_key_locked () =
+    match Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name () with
+    | Error owner -> Error (Restart_lifecycle_reserved owner)
+    | Ok () -> loop ()
   in
+  (* Key lock outside the admission fence — see the register path for why
+     nesting it inside would wedge the domain. *)
   match
-    Keeper_turn_admission.commit_registration_if_open
-      ~base_path
-      ~keeper_name:name
-      guarded_loop
+    Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
+      Keeper_turn_admission.commit_registration_if_open
+        ~base_path
+        ~keeper_name:name
+        guarded_loop_key_locked)
   with
   | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
     Error (Restart_shutdown_reserved operation_id)

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -166,9 +166,12 @@ let decr_running_count_clamped () =
 (** Lock-free CAS loop for registry writes. Atomic.t used instead of Eio.Mutex for non-Eio context compatibility (#7011 pattern). *)
 
 (* Precondition: the caller already holds the per-keeper lifecycle key lock.
-   Every step below is non-suspending: [authorize] reads the process-local
-   reservation table, [validate_registry_entry] is pure, the metric store and
-   [Log] use stdlib I/O rather than Eio flows, and the install is a CAS loop.
+   Every step below is non-suspending: [authorize] is an [Atomic.get] on the
+   process-local reservation table (NOT [Keeper_lifecycle_reservation.acquire],
+   which takes the key lock and would suspend — the two differ by exactly that,
+   and the whole argument here rests on it), [validate_registry_entry] is pure,
+   the metric store and [Log] use stdlib I/O rather than Eio flows, and the
+   install is a CAS loop.
    That totality is what makes this body legal to run inside
    [Keeper_turn_admission.commit_registration_if_open], whose critical section
    is guarded by a scheduler-blocking [Stdlib.Mutex]: a fiber that suspends

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -259,9 +259,22 @@ val restore_shutdown :
   operation_id:Keeper_shutdown_types.Operation_id.t ->
   restore_shutdown_result
 
-(** Run the non-yielding registry [commit] only while no shutdown operation
-    owns the Keeper admission fence. Shutdown reservation and same-name lane
-    installation are therefore totally ordered. *)
+(** Run the registry [commit] only while no shutdown operation owns the Keeper
+    admission fence. Shutdown reservation and same-name lane installation are
+    therefore totally ordered.
+
+    PRECONDITION — [commit] must not suspend the calling fiber. It runs inside
+    a [Stdlib.Mutex] critical section, and [Stdlib.Mutex.lock] blocks the OS
+    thread that runs the Eio scheduler: a fiber that suspends here can never be
+    resumed, so any other fiber on the domain that touches this slot wedges the
+    entire domain with no timeout and no diagnostic. Concretely, [commit] must
+    not acquire the per-keeper lifecycle key lock
+    ([Keeper_lifecycle_reservation.with_key_lock] suspends via
+    [Cross_context_mutex]); acquire that lock around this call instead, as
+    [Keeper_registry_setup] does. The type cannot express this — OCaml has no
+    effect annotation for "does not suspend" — so the obligation is on the
+    caller and is covered by
+    [test/test_keeper_registry_admission_no_suspend.ml]. *)
 val commit_registration_if_open :
   base_path:string ->
   keeper_name:string ->

--- a/test/dune
+++ b/test/dune
@@ -1623,6 +1623,7 @@
 ; sorted alphabetically.
 
 (include stanzas/test_anti_rationalization_empty_reject.inc)
+(include stanzas/test_keeper_registry_admission_no_suspend.inc)
 
 (include stanzas/test_exec_policy_cwd_hint.inc)
 

--- a/test/stanzas/test_keeper_registry_admission_no_suspend.inc
+++ b/test/stanzas/test_keeper_registry_admission_no_suspend.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_registry_admission_no_suspend)
+ (modules test_keeper_registry_admission_no_suspend)
+ (libraries masc_test_deps unix))

--- a/test/test_keeper_registry_admission_no_suspend.ml
+++ b/test/test_keeper_registry_admission_no_suspend.ml
@@ -14,10 +14,20 @@
     [Cross_context_mutex.with_eio_lock] -> [Eio.Mutex.use_ro], a suspension
     point under contention). The fix hoists the key lock outside the fence.
 
-    A wedged scheduler cannot be observed from inside its own domain — an
-    [Eio.Time.with_timeout] fiber would never be scheduled either. The
-    watchdog therefore lives in a separate domain, which turns the pre-fix
-    behaviour into a clean non-zero exit instead of a hung test process. *)
+    Observed pre-fix failure (counterfactual run — this file kept,
+    [keeper_registry_setup.ml] reverted):
+
+      Fatal error: exception Sys_error("Mutex.lock: Resource deadlock avoided")
+
+    That is pthread EDEADLK, not a hang. Eio runs every fiber of a domain on
+    ONE OS thread, so the second [Stdlib.Mutex.lock] on [state_mu] is the same
+    thread re-locking a mutex it already owns, and macOS reports it
+    immediately. On a platform whose default mutex is not error-checking the
+    same interleaving is a silent hang instead, and across domains the wedge
+    described above is the failure mode. The watchdog therefore lives in a
+    separate domain so this test fails loudly on every platform rather than
+    hanging on some of them; on macOS the EDEADLK arrives first and the
+    watchdog never fires. *)
 
 module Reservation = Masc.Keeper_lifecycle_reservation
 module KR = Masc.Keeper_registry

--- a/test/test_keeper_registry_admission_no_suspend.ml
+++ b/test/test_keeper_registry_admission_no_suspend.ml
@@ -1,0 +1,119 @@
+(** Regression: the closure handed to
+    [Keeper_turn_admission.commit_registration_if_open] must not suspend.
+
+    That function evaluates its argument inside [Stdlib.Mutex.protect
+    slot.state_mu]. [Stdlib.Mutex.lock] blocks the OS thread that runs the Eio
+    scheduler, so a fiber that suspends while owning [state_mu] can never be
+    resumed: the next fiber on the same domain to touch that slot blocks the
+    scheduler thread and the whole domain stops. There is no timeout and no
+    diagnostic.
+
+    Before the fix, [Keeper_registry_setup] acquired the per-keeper lifecycle
+    key lock INSIDE that critical section
+    ([put_entry_internal] -> [Keeper_lifecycle_reservation.with_key_lock] ->
+    [Cross_context_mutex.with_eio_lock] -> [Eio.Mutex.use_ro], a suspension
+    point under contention). The fix hoists the key lock outside the fence.
+
+    A wedged scheduler cannot be observed from inside its own domain — an
+    [Eio.Time.with_timeout] fiber would never be scheduled either. The
+    watchdog therefore lives in a separate domain, which turns the pre-fix
+    behaviour into a clean non-zero exit instead of a hung test process. *)
+
+module Reservation = Masc.Keeper_lifecycle_reservation
+module KR = Masc.Keeper_registry
+module Admission = Masc.Keeper_turn_admission
+
+let base_path = "/tmp/test_keeper_registry_admission_no_suspend"
+let keeper_name = "wedgecheck"
+let watchdog_seconds = 30.0
+
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "agent_name", `String ("agent-" ^ name)
+        ; "trace_id", `String ("trace-" ^ name)
+        ; "allowed_paths", `List [ `String "*" ]
+        ; "autoboot_enabled", `Bool false
+        ])
+  with
+  | Ok m -> m
+  | Error e -> failwith ("make_meta failed: " ^ e)
+;;
+
+(* Fiber A holds the lifecycle key lock so that fiber B's acquisition of it is
+   guaranteed to suspend, then releases it. Fiber C reads the admission slot
+   while B is blocked; pre-fix that read blocks the scheduler thread forever,
+   because B is parked with state_mu held. *)
+let run_interleaving () =
+  Eio_main.run (fun _env ->
+    KR.clear ();
+    Admission.For_testing.reset ();
+    let key_lock_taken, set_key_lock_taken = Eio.Promise.create () in
+    let release_key_lock, do_release_key_lock = Eio.Promise.create () in
+    let registration_done, set_registration_done = Eio.Promise.create () in
+    Eio.Fiber.all
+      [ (fun () ->
+          (* A: own the key lock until the other two fibers have had their turn *)
+          Reservation.with_key_lock ~base_path ~keeper_name (fun () ->
+            Eio.Promise.resolve set_key_lock_taken ();
+            Eio.Promise.await release_key_lock))
+      ; (fun () ->
+          (* B: fenced registration — must park on the key lock WITHOUT
+             holding the admission slot's state_mu *)
+          Eio.Promise.await key_lock_taken;
+          let meta = make_meta keeper_name in
+          let result =
+            KR.register_offline_if_admitted ~base_path keeper_name meta
+          in
+          Eio.Promise.resolve set_registration_done result)
+      ; (fun () ->
+          (* C: touch the admission slot while B is parked. Pre-fix this call
+             blocks the scheduler thread and nothing below ever runs. *)
+          Eio.Promise.await key_lock_taken;
+          Eio.Fiber.yield ();
+          Eio.Fiber.yield ();
+          let snapshot = Admission.snapshot_for ~base_path ~keeper_name in
+          assert (String.equal snapshot.Admission.snapshot_keeper_name keeper_name);
+          (* The slot must be idle: no turn is in flight, only a registration
+             is in progress. *)
+          assert (Option.is_none snapshot.Admission.snapshot_in_flight);
+          Eio.Promise.resolve do_release_key_lock ())
+      ];
+    match Eio.Promise.await registration_done with
+    | Ok _ -> ()
+    | Error _ ->
+      failwith "fenced registration failed with no shutdown reserved")
+;;
+
+let () =
+  let finished = Atomic.make false in
+  let watchdog =
+    Domain.spawn (fun () ->
+      let deadline = Unix.gettimeofday () +. watchdog_seconds in
+      let rec wait () =
+        if Atomic.get finished
+        then ()
+        else if Unix.gettimeofday () > deadline
+        then (
+          prerr_endline
+            "FAIL: admission slot wedged — the registration commit suspended \
+             while holding state_mu (Stdlib.Mutex), so the Eio scheduler \
+             thread is blocked and the domain cannot make progress. Acquire \
+             the lifecycle key lock outside \
+             Keeper_turn_admission.commit_registration_if_open.";
+          exit 1)
+        else (
+          Unix.sleepf 0.05;
+          wait ())
+      in
+      wait ())
+  in
+  run_interleaving ();
+  Atomic.set finished true;
+  Domain.join watchdog;
+  print_endline
+    "PASS: fenced registration parks on the lifecycle key lock without holding \
+     the admission slot mutex"
+;;


### PR DESCRIPTION
## 증상 (P0, 잠재)

`Keeper_turn_admission.commit_registration_if_open`은 클로저를 `Stdlib.Mutex.protect slot.state_mu` 안에서 평가합니다. `Stdlib.Mutex.lock`은 **Eio 스케줄러가 도는 OS 스레드 자체를 블록**하므로, `state_mu`를 쥔 채 suspend한 fiber는 재개될 수 없습니다. Eio는 모든 fiber를 단일 스레드에서 돌리기 때문에, 같은 도메인의 다른 fiber가 그 슬롯을 건드리는 순간 도메인 전체가 멈춥니다. 타임아웃도 진단도 없습니다.

`.mli:262`는 "non-yielding registry commit"이라고 **산문으로** 규정하고, `.ml:91-92`는 "Critical sections never yield"라고 **주석으로** 단언합니다. 타입은 `(unit -> 'a)`이고 아무것도 강제하지 않습니다. **두 프로덕션 호출자 모두 이 계약을 위반하고 있었습니다.**

```
state_mu -> commit () -> put_entry_internal
  -> Keeper_lifecycle_reservation.with_key_lock   (keeper_lifecycle_reservation.ml:74-80)
  -> Cross_context_mutex.with_eio_lock            (cross_context_mutex.ml:37-41)
  -> Eio.Mutex.use_ro                             (cross_context_mutex.ml:24-25) ← suspend
   + lock_cooperatively / Eio.Fiber.yield 루프    (cross_context_mutex.ml:12-17) ← suspend
```

- `keeper_registry_setup.ml:521` — 일반 register 경로 (재시작 전용 아님)
- `keeper_registry_setup.ml:728` — 재시작 경로

## 근본 수리

`with_key_lock`을 fence **바깥으로 호이스트**했습니다. fence 검사와 레지스트리 설치는 여전히 `state_mu` 안에서 함께 일어나므로 "shutdown 예약과 동명 lane 설치의 전순서" 불변식은 그대로입니다. 밖으로 나간 건 suspending 락뿐입니다.

`put_entry_internal`을 둘로 나눴습니다:
- `put_entry_key_locked` — 본문, key lock 보유를 전제
- `put_entry_internal` — 락을 잡는 래퍼 (기존 호출자 영향 없음)

**수리 후 `state_mu`를 잡은 뒤 key lock을 잡는 경로가 0**이 되어, 순서 위험이 좁혀진 게 아니라 제거됐습니다.

### 호이스트 후 클로저가 정말 non-suspending인지 검증

호이스트가 suspension 소스를 하나만 제거하고 나머지를 남겼다면 의미가 없으므로 전수 확인했습니다:

| 클로저 내 호출 | 결과 |
|---|---|
| `validate_registry_entry` / `validate_runtime_fields` | 순수 문자열·정수 비교 |
| `Otel_metric_store.inc_counter` | `rg -c 'Eio\.'` → **0건** |
| `Log.Keeper.warn` | stdlib `output_string`, Eio flow 아님 |
| `Keeper_lifecycle_reservation.authorize` | key lock 미획득 (오늘도 `with_key_lock` 안에서 호출됨 — 잡았다면 non-reentrant 뮤텍스라 이미 교착) |

## 검증

`test/test_keeper_registry_admission_no_suspend.ml` 신규.

블록된 스케줄러는 **자기 도메인 안에서 관측 불가**합니다 — `Eio.Time.with_timeout` fiber도 스케줄되지 못합니다. 그래서 워치독을 별도 `Domain`에 두어, 수리 전 동작이 무한 정지가 아니라 명시적 실패로 떨어지게 했습니다.

Counterfactual (lib 수리만 되돌리고 테스트 유지):

```
Fatal error: exception Sys_error("Mutex.lock: Resource deadlock avoided")
EXIT=2
```

macOS의 error-checking 뮤텍스가 EDEADLK로 즉시 잡습니다. 기본 non-error-checking 뮤텍스를 쓰는 리눅스에서는 **조용한 무한 정지**가 됩니다 — 원 분석의 "진단 없는 wedge"와 일치합니다.

- 수리 적용: `PASS` (exit 0)
- `dune build @check`: 통과
- `test_keeper_turn_admission`: 전항목 통과 (fence 의미론 무변경 확인)
- `test_keeper_registry_hardening`: 17 tests, 통과

## 출처

2026-07-20 lane 큐 적대적 감사 (워크플로 `wf_be08aa4a-c34`, 35 에이전트). 이 항목은 전담 반증 에이전트를 통과했습니다 — *"Could not refute; all four refutation angles failed, and the defect is broader than claimed."* 원 주장은 재시작 경로만 지목했으나, 반증 과정에서 일반 register 경로도 같은 연쇄를 탄다는 사실이 드러났습니다.

같은 감사에서 나온 다른 후보 15건은 반증되어 제외했습니다.

리포트: `~/me/reports/masc-lane-queue-audit-2026-07-20.html`

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem도 건드리지 않음 (admission 슬롯의 락 순서 한정).
