### PR TITLE
fix(compaction): run the persist structural gate before paying the summarizer

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -284,12 +284,38 @@ let requested_messages (meta : keeper_meta) messages =
        [protected_suffix], that break is carried into the compacted checkpoint
        and rejected there — after the summarizer call has already been paid
        for. [validate messages] failing therefore implies the compacted result
-       fails too, so rejecting here loses no reachable compaction and returns
-       the identical typed terminal the persist boundary would have produced.
+       fails too, so rejecting here refuses no compaction that could have
+       persisted.
 
-       This bounds cost only. It does not make a structurally broken history
-       compactable: the break has to be prevented at the write boundary that
-       admitted a tool_use with no matching tool_result. *)
+       The observable outcome is deliberately NOT identical to the late
+       failure, and the difference is the point:
+
+       - Late: [commit_prepared_compaction] returns [Error], which
+         [Keeper_manual_compaction.run_commit] folds into its catch-all
+         [Error (Recovery _)] -> [Manual_compaction_failed] -> [Requeue
+         Context_compaction_retry]. That settlement is not an ack
+         (keeper_heartbeat_loop.ml), so the same doomed request is re-driven
+         every cycle — one summarizer call each time. This is the live
+         livelock: 102 failures and 104 compaction LLM calls in the 74 minutes
+         after the #25413 build went live.
+       - Early: the typed [No_compaction] arm of
+         [Keeper_manual_compaction.finish_preparation] acks and settles
+         terminally, with a ledger row and a [compaction_rejected] log line.
+
+       Terminating is correct here because [validate] rejection is monotone
+       under append: appending messages never repairs an existing structural
+       break, so retrying the identical source cannot succeed.
+
+       Because this gate precedes summarizer selection, a keeper with BOTH a
+       broken history and an unavailable summarizer now reports
+       [Invalid_structure] (terminal) rather than [Summarizer_unavailable]
+       (retryable). That ordering is intended: the structural break is the
+       condition that no retry can clear.
+
+       Scope: this stops the retry loop and its cost. It does not make a
+       structurally broken history compactable — the break has to be prevented
+       at the write boundary that admitted a tool_use with no matching
+       tool_result (#25443). *)
     (match Keeper_compaction_unit.validate messages with
      | Error error -> Error (Invalid_structure error)
      | Ok () ->

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -272,6 +272,27 @@ let requested_messages (meta : keeper_meta) messages =
   | Error error -> Error (Invalid_structure error)
   | Ok { closed_prefix = []; _ } -> Error No_eligible_history
   | Ok { closed_prefix = units; protected_suffix } ->
+    (* Persistence-gate precondition, checked BEFORE the summarizer runs.
+
+       [partition ~quarantine:true] tolerates a structural break by freezing
+       the valid prefix and moving the break plus its successors into
+       [protected_suffix]. The persist boundary does not tolerate it: a
+       checkpoint must preserve every message exactly, so it runs
+       [Keeper_compaction_unit.validate] with quarantine off
+       (keeper_context_core.ml:71 -> Tool_history_invalid ->
+       Invalid_structural_source). Because quarantine PRESERVES the break in
+       [protected_suffix], that break is carried into the compacted checkpoint
+       and rejected there — after the summarizer call has already been paid
+       for. [validate messages] failing therefore implies the compacted result
+       fails too, so rejecting here loses no reachable compaction and returns
+       the identical typed terminal the persist boundary would have produced.
+
+       This bounds cost only. It does not make a structurally broken history
+       compactable: the break has to be prevented at the write boundary that
+       admitted a tool_use with no matching tool_result. *)
+    (match Keeper_compaction_unit.validate messages with
+     | Error error -> Error (Invalid_structure error)
+     | Ok () ->
     if not (Keeper_compaction_llm_summarizer.has_eligible_units units)
     then Error No_eligible_history
     else
@@ -309,7 +330,7 @@ let requested_messages (meta : keeper_meta) messages =
                        selected_message_count
                          units
                          (Keeper_compaction_llm_summarizer.dropped_indices plan)
-                   })))
+                   }))))
 ;;
 
 let tool_block_counts messages =

--- a/test/dune
+++ b/test/dune
@@ -654,17 +654,12 @@
   test_board_rest_routes
   test_board_context_inference_resolution)
  (libraries
-  masc_test_deps
-  masc.keeper_chat_delivery_identity
-  masc_schedule
-  multimodal
-  bigstringaf
-  masc.keeper_checkpoint_ref))
+  masc_test_deps masc.keeper_chat_delivery_identity masc_schedule multimodal
+  bigstringaf masc.keeper_checkpoint_ref))
 
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test
 ; group above.
-
 (test
  (name test_keeper_event_queue_state_v2)
  (modules test_keeper_event_queue_state_v2)
@@ -709,11 +704,7 @@
  (name test_keeper_memory_os_generation_base_path)
  (modules test_keeper_memory_os_generation_base_path)
  (libraries masc_test_deps)
- (action
-  (setenv
-   MASC_CONFIG_DIR
-   ""
-   (run %{test}))))
+ (action (setenv MASC_CONFIG_DIR "" (run %{test}))))
 
 (test
  (name test_oas_canonical_delegation)
@@ -744,12 +735,7 @@
 (test
  (name test_fusion_delivery_obligation)
  (modules test_fusion_delivery_obligation)
- (libraries
-  alcotest
-  masc_test_deps
-  masc
-  masc.fusion_core
-  masc.keeper_runtime))
+ (libraries alcotest masc_test_deps masc masc.fusion_core masc.keeper_runtime))
 
 ; Board-unavailable-result: keeper_world_observation_board_signal's
 ; Board_unavailable exception -> (_, board_unavailable) result conversion.
@@ -1269,15 +1255,7 @@
 (test
  (name test_server_auth_dashboard_actor_resolution)
  (modules test_server_auth_dashboard_actor_resolution)
- (libraries
-  alcotest
-  masc
-  masc.auth
-  masc.masc_types
-  masc_server
-  eio_main
-  httpun
-  unix))
+ (libraries alcotest masc masc.auth masc.masc_types masc_server eio_main httpun unix))
 
 ; RFC-0301 item 6: the turn-local generated-media accumulator turns stream media
 ; into reload chat blocks (image / voice / attach) via the content-addressed store.
@@ -1646,7 +1624,6 @@
 
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_keeper_registry_admission_no_suspend.inc)
-
 (include stanzas/test_keeper_compaction_persist_gate.inc)
 
 (include stanzas/test_exec_policy_cwd_hint.inc)
@@ -1812,17 +1789,24 @@
 
 (include stanzas/test_goal_phase_all.inc)
 
+
+
+
 (include stanzas/test_heartbeat_integration.inc)
 
 (include stanzas/test_http_pages_asset_read.inc)
 
+
 (include stanzas/test_bind_required_guard_counter.inc)
+
 
 (include stanzas/test_k2_pipeline_e2e.inc)
 
 (include stanzas/test_k3_tool_pipeline_e2e.inc)
 
+
 (include stanzas/test_keepers_runtime_dir_ssot.inc)
+
 
 (include stanzas/test_keeper_latched_reason_wiring.inc)
 
@@ -1836,6 +1820,8 @@
 
 (include stanzas/test_keeper_checkpoint_stale_guard.inc)
 
+
+
 (include stanzas/test_keeper_context_isolation.inc)
 
 (include stanzas/test_keeper_turn_up_args.inc)
@@ -1847,6 +1833,7 @@
 (include stanzas/test_keeper_tool_name.inc)
 
 (include stanzas/test_keeper_tool_command_runtime_cwd_response.inc)
+
 
 (include stanzas/test_keeper_tool_dispatch_runtime.inc)
 
@@ -1896,6 +1883,8 @@
 
 (include stanzas/test_keeper_mutex_coverage.inc)
 
+
+
 (include stanzas/test_keeper_personality_round_trip.inc)
 
 (include stanzas/test_keeper_post_turn_wirein_order.inc)
@@ -1928,16 +1917,19 @@
 
 (include stanzas/test_keeper_tool_matrix.inc)
 
+
 (include stanzas/test_keeper_unified_tool_event_order_source.inc)
 
+
 (include stanzas/test_keeper_task_outcomes.inc)
+
+
 
 (include stanzas/test_keeper_turn_helpers_side_effect_metric.inc)
 
 (include stanzas/test_keeper_transition_audit_types.inc)
 
 (include stanzas/test_keeper_path_rejection.inc)
-
 (include stanzas/test_keeper_path_containment_objective.inc)
 
 (include stanzas/test_keeper_approval_queue_rules_types.inc)
@@ -1962,6 +1954,7 @@
 
 (include stanzas/test_runtime_oas_eio_context_classify.inc)
 
+
 (include stanzas/test_runtime_model_temperature_toml.inc)
 
 (include stanzas/test_keeper_response_feedback.inc)
@@ -1972,7 +1965,9 @@
 
 (include stanzas/test_mcp_tool_matrix.inc)
 
+
 (include stanzas/test_normalized_actor.inc)
+
 
 (include stanzas/test_keeper_runtime_observation_boundaries.inc)
 
@@ -2008,7 +2003,9 @@
 
 (include stanzas/test_pr_open_script.inc)
 
+
 (include stanzas/test_release_train_guard_script.inc)
+
 
 (include stanzas/test_server_state_product.inc)
 
@@ -2438,6 +2435,7 @@
    (run %{test})))
  (libraries masc_test_deps))
 
+
 (include stanzas/test_keeper_wire_capture_suppression.inc)
 
 (include stanzas/test_keeper_meta_canonicalize.inc)
@@ -2497,15 +2495,9 @@
  (deps
   (source_tree ../lib)
   (source_tree ../bin)))
-
 (include stanzas/test_keeper_turn_attempt_observer.inc)
-
 (include stanzas/test_keeper_gate_effect_coverage.inc)
-
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)
-
 (include stanzas/test_fs_compat_capability_write.inc)
-
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
-
 (include stanzas/test_eio_resource_scope.inc)

--- a/test/dune
+++ b/test/dune
@@ -654,12 +654,17 @@
   test_board_rest_routes
   test_board_context_inference_resolution)
  (libraries
-  masc_test_deps masc.keeper_chat_delivery_identity masc_schedule multimodal
-  bigstringaf masc.keeper_checkpoint_ref))
+  masc_test_deps
+  masc.keeper_chat_delivery_identity
+  masc_schedule
+  multimodal
+  bigstringaf
+  masc.keeper_checkpoint_ref))
 
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test
 ; group above.
+
 (test
  (name test_keeper_event_queue_state_v2)
  (modules test_keeper_event_queue_state_v2)
@@ -704,7 +709,11 @@
  (name test_keeper_memory_os_generation_base_path)
  (modules test_keeper_memory_os_generation_base_path)
  (libraries masc_test_deps)
- (action (setenv MASC_CONFIG_DIR "" (run %{test}))))
+ (action
+  (setenv
+   MASC_CONFIG_DIR
+   ""
+   (run %{test}))))
 
 (test
  (name test_oas_canonical_delegation)
@@ -735,7 +744,12 @@
 (test
  (name test_fusion_delivery_obligation)
  (modules test_fusion_delivery_obligation)
- (libraries alcotest masc_test_deps masc masc.fusion_core masc.keeper_runtime))
+ (libraries
+  alcotest
+  masc_test_deps
+  masc
+  masc.fusion_core
+  masc.keeper_runtime))
 
 ; Board-unavailable-result: keeper_world_observation_board_signal's
 ; Board_unavailable exception -> (_, board_unavailable) result conversion.
@@ -1255,7 +1269,15 @@
 (test
  (name test_server_auth_dashboard_actor_resolution)
  (modules test_server_auth_dashboard_actor_resolution)
- (libraries alcotest masc masc.auth masc.masc_types masc_server eio_main httpun unix))
+ (libraries
+  alcotest
+  masc
+  masc.auth
+  masc.masc_types
+  masc_server
+  eio_main
+  httpun
+  unix))
 
 ; RFC-0301 item 6: the turn-local generated-media accumulator turns stream media
 ; into reload chat blocks (image / voice / attach) via the content-addressed store.
@@ -1625,6 +1647,8 @@
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_keeper_registry_admission_no_suspend.inc)
 
+(include stanzas/test_keeper_compaction_persist_gate.inc)
+
 (include stanzas/test_exec_policy_cwd_hint.inc)
 
 (include stanzas/test_auth_bearer_mismatch_9786.inc)
@@ -1788,24 +1812,17 @@
 
 (include stanzas/test_goal_phase_all.inc)
 
-
-
-
 (include stanzas/test_heartbeat_integration.inc)
 
 (include stanzas/test_http_pages_asset_read.inc)
 
-
 (include stanzas/test_bind_required_guard_counter.inc)
-
 
 (include stanzas/test_k2_pipeline_e2e.inc)
 
 (include stanzas/test_k3_tool_pipeline_e2e.inc)
 
-
 (include stanzas/test_keepers_runtime_dir_ssot.inc)
-
 
 (include stanzas/test_keeper_latched_reason_wiring.inc)
 
@@ -1819,8 +1836,6 @@
 
 (include stanzas/test_keeper_checkpoint_stale_guard.inc)
 
-
-
 (include stanzas/test_keeper_context_isolation.inc)
 
 (include stanzas/test_keeper_turn_up_args.inc)
@@ -1832,7 +1847,6 @@
 (include stanzas/test_keeper_tool_name.inc)
 
 (include stanzas/test_keeper_tool_command_runtime_cwd_response.inc)
-
 
 (include stanzas/test_keeper_tool_dispatch_runtime.inc)
 
@@ -1882,8 +1896,6 @@
 
 (include stanzas/test_keeper_mutex_coverage.inc)
 
-
-
 (include stanzas/test_keeper_personality_round_trip.inc)
 
 (include stanzas/test_keeper_post_turn_wirein_order.inc)
@@ -1916,19 +1928,16 @@
 
 (include stanzas/test_keeper_tool_matrix.inc)
 
-
 (include stanzas/test_keeper_unified_tool_event_order_source.inc)
 
-
 (include stanzas/test_keeper_task_outcomes.inc)
-
-
 
 (include stanzas/test_keeper_turn_helpers_side_effect_metric.inc)
 
 (include stanzas/test_keeper_transition_audit_types.inc)
 
 (include stanzas/test_keeper_path_rejection.inc)
+
 (include stanzas/test_keeper_path_containment_objective.inc)
 
 (include stanzas/test_keeper_approval_queue_rules_types.inc)
@@ -1953,7 +1962,6 @@
 
 (include stanzas/test_runtime_oas_eio_context_classify.inc)
 
-
 (include stanzas/test_runtime_model_temperature_toml.inc)
 
 (include stanzas/test_keeper_response_feedback.inc)
@@ -1964,9 +1972,7 @@
 
 (include stanzas/test_mcp_tool_matrix.inc)
 
-
 (include stanzas/test_normalized_actor.inc)
-
 
 (include stanzas/test_keeper_runtime_observation_boundaries.inc)
 
@@ -2002,9 +2008,7 @@
 
 (include stanzas/test_pr_open_script.inc)
 
-
 (include stanzas/test_release_train_guard_script.inc)
-
 
 (include stanzas/test_server_state_product.inc)
 
@@ -2434,7 +2438,6 @@
    (run %{test})))
  (libraries masc_test_deps))
 
-
 (include stanzas/test_keeper_wire_capture_suppression.inc)
 
 (include stanzas/test_keeper_meta_canonicalize.inc)
@@ -2494,9 +2497,15 @@
  (deps
   (source_tree ../lib)
   (source_tree ../bin)))
+
 (include stanzas/test_keeper_turn_attempt_observer.inc)
+
 (include stanzas/test_keeper_gate_effect_coverage.inc)
+
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)
+
 (include stanzas/test_fs_compat_capability_write.inc)
+
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
+
 (include stanzas/test_eio_resource_scope.inc)

--- a/test/stanzas/test_keeper_compaction_persist_gate.inc
+++ b/test/stanzas/test_keeper_compaction_persist_gate.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_compaction_persist_gate)
+ (modules test_keeper_compaction_persist_gate)
+ (libraries masc_test_deps))

--- a/test/test_keeper_compaction_persist_gate.ml
+++ b/test/test_keeper_compaction_persist_gate.ml
@@ -1,0 +1,152 @@
+(** The compaction plan gate and the checkpoint persist gate disagree, and the
+    persist gate runs last.
+
+    [Keeper_compaction_unit.partition ~quarantine:true] tolerates a structural
+    break: it freezes the valid prefix and moves the break plus its successors
+    into [protected_suffix] (#25413). The persist boundary does not tolerate
+    it — a checkpoint must preserve every message exactly, so
+    [Keeper_context_core.checkpoint_for_persistence] runs
+    [Keeper_compaction_unit.validate] with quarantine off and maps a failure to
+    [Tool_history_invalid] -> [Invalid_structural_source].
+
+    Because quarantine PRESERVES the break rather than removing it, the break
+    is carried into the compacted checkpoint and rejected there — after the
+    summarizer has already been paid for. These tests pin that implication,
+    which is what makes it safe to run the persist check BEFORE the summarizer
+    call in [Keeper_compact_policy.requested_messages]:
+
+      validate source = Error  ==>  validate (summary :: protected_suffix) = Error
+
+    If this implication ever stops holding, the early rejection would start
+    refusing compactions that could actually have persisted, and the gate in
+    [requested_messages] must be revisited. *)
+
+module U = Masc.Keeper_compaction_unit
+module T = Agent_sdk.Types
+
+let message ?tool_call_id role content : T.message =
+  { role; content; name = None; tool_call_id; metadata = [] }
+;;
+
+let text role value = message role [ T.Text value ]
+
+let use id =
+  T.ToolUse { id; name = "test_tool"; input = `Assoc [ "id", `String id ] }
+;;
+
+let result id =
+  T.ToolResult
+    { tool_use_id = id
+    ; content = "result:" ^ id
+    ; outcome = T.Tool_succeeded
+    ; json = Some (`Assoc [ "id", `String id ])
+    ; content_blocks = None
+    }
+;;
+
+(* One complete tool cycle, then an assistant turn that opens a cycle and a
+   second assistant turn that opens another before the first is answered. That
+   overlap is the shape observed live on analyst and idealist:
+
+     compaction_rejected reason=invalid_structure:
+       Keeper_compaction_unit.Overlapping_tool_cycle
+         {message_index = 1221; tool_use_id = "call_function_mzi85j82orkf_1"}
+
+   A merely dangling ToolUse is NOT enough — [validate] accepts a trailing open
+   cycle. The rejection needs a second cycle opened while one is still open. *)
+let history_with_overlapping_tool_cycle =
+  [ text T.System "system preamble"
+  ; text T.User "first question"
+  ; message T.Assistant [ use "call-closed" ]
+  ; message T.Tool [ result "call-closed" ]
+  ; text T.Assistant "answered"
+  ; text T.User "second question"
+  ; message T.Assistant [ use "call-open" ]
+  ; message T.Assistant [ use "call-overlapping" ]
+  ; message T.Tool [ result "call-overlapping" ]
+  ]
+;;
+
+let test_persist_gate_rejects_what_quarantine_admits () =
+  (* Gate 1 (compaction planning) admits it. *)
+  let partitioned =
+    match U.partition ~quarantine:true history_with_overlapping_tool_cycle with
+    | Ok partitioned -> partitioned
+    | Error _ ->
+      Alcotest.fail "quarantine partition must admit an overlapping tool cycle (#25413)"
+  in
+  Alcotest.(check bool)
+    "quarantine produced a compactable prefix"
+    true
+    (partitioned.closed_prefix <> []);
+  (* Gate 2 (persistence) refuses the same history. *)
+  Alcotest.(check bool)
+    "persist gate rejects the source history"
+    true
+    (Result.is_error (U.validate history_with_overlapping_tool_cycle))
+;;
+
+let test_break_survives_into_the_compacted_checkpoint () =
+  let partitioned =
+    match U.partition ~quarantine:true history_with_overlapping_tool_cycle with
+    | Ok partitioned -> partitioned
+    | Error _ -> Alcotest.fail "quarantine partition must admit an overlapping tool cycle"
+  in
+  Alcotest.(check bool)
+    "the break was preserved in protected_suffix, not removed"
+    true
+    (partitioned.protected_suffix <> []);
+  (* What compaction would persist: the summary replacing closed_prefix,
+     followed by the untouched protected_suffix. *)
+  let compacted =
+    text T.Assistant "<<compaction summary>>" :: partitioned.protected_suffix
+  in
+  Alcotest.(check bool)
+    "persist gate still rejects the compacted result"
+    true
+    (Result.is_error (U.validate compacted))
+;;
+
+let test_clean_history_passes_both_gates () =
+  (* Guard against over-rejection: a well-formed history must still compact. *)
+  let clean =
+    [ text T.System "system preamble"
+    ; text T.User "first question"
+    ; message T.Assistant [ use "call-a" ]
+    ; message T.Tool [ result "call-a" ]
+    ; text T.Assistant "answered"
+    ; text T.User "second question"
+    ]
+  in
+  Alcotest.(check bool)
+    "persist gate accepts a clean history"
+    true
+    (Result.is_ok (U.validate clean));
+  match U.partition ~quarantine:true clean with
+  | Ok partitioned ->
+    Alcotest.(check bool)
+      "clean history still yields a compactable prefix"
+      true
+      (partitioned.closed_prefix <> [])
+  | Error _ -> Alcotest.fail "clean history must partition"
+;;
+
+let () =
+  Alcotest.run
+    "keeper_compaction_persist_gate"
+    [ ( "gate_disagreement"
+      , [ Alcotest.test_case
+            "persist gate rejects what quarantine admits"
+            `Quick
+            test_persist_gate_rejects_what_quarantine_admits
+        ; Alcotest.test_case
+            "break survives into the compacted checkpoint"
+            `Quick
+            test_break_survives_into_the_compacted_checkpoint
+        ; Alcotest.test_case
+            "clean history passes both gates"
+            `Quick
+            test_clean_history_passes_both_gates
+        ] )
+    ]
+;;

--- a/test/test_keeper_compaction_persist_gate.ml
+++ b/test/test_keeper_compaction_persist_gate.ml
@@ -131,6 +131,38 @@ let test_clean_history_passes_both_gates () =
   | Error _ -> Alcotest.fail "clean history must partition"
 ;;
 
+(* The over-rejection guard. A turn that has issued a tool_use and not yet
+   received its result is the NORMAL mid-turn shape, not a break: [validate]
+   accepts a trailing open cycle (partition's [| [] ->] arm returns [Ok]
+   regardless of an open cycle). If that ever changed, the gate added to
+   [Keeper_compact_policy.requested_messages] would start refusing ordinary
+   histories and compaction would stop fleet-wide — a far worse failure than
+   the cost bleed the gate exists to stop. This is the single most important
+   case in this file. *)
+let test_trailing_open_cycle_is_not_a_break () =
+  let trailing_open =
+    [ text T.System "system preamble"
+    ; text T.User "first question"
+    ; message T.Assistant [ use "call-closed" ]
+    ; message T.Tool [ result "call-closed" ]
+    ; text T.Assistant "answered"
+    ; text T.User "second question"
+    ; message T.Assistant [ use "call-still-open" ]
+    ]
+  in
+  Alcotest.(check bool)
+    "persist gate accepts a history whose last tool cycle is still open"
+    true
+    (Result.is_ok (U.validate trailing_open));
+  match U.partition ~quarantine:true trailing_open with
+  | Ok partitioned ->
+    Alcotest.(check bool)
+      "an in-flight turn still yields a compactable prefix"
+      true
+      (partitioned.closed_prefix <> [])
+  | Error _ -> Alcotest.fail "a trailing open cycle must not fail partition"
+;;
+
 let () =
   Alcotest.run
     "keeper_compaction_persist_gate"
@@ -147,6 +179,10 @@ let () =
             "clean history passes both gates"
             `Quick
             test_clean_history_passes_both_gates
+        ; Alcotest.test_case
+            "trailing open cycle is not a break"
+            `Quick
+            test_trailing_open_cycle_is_not_a_break
         ] )
     ]
 ;;


### PR DESCRIPTION
Closes part of #25443 (cost bleed only — see Scope).

## 문제

compaction에 구조 게이트가 **2개** 있고 계약이 서로 양립 불가하며, 엄격한 쪽이 나중에 돕니다.

| | 게이트 | 계약 |
|---|---|---|
| 1 | `keeper_compact_policy.ml:271` `partition ~quarantine:true` | 파손 **관용** — 유효 prefix를 얼리고 파손+후속을 `protected_suffix`로 이동 (#25413) |
| 2 | `keeper_context_core.ml:71` `validate` | 파손 **거부** — 체크포인트는 모든 메시지를 정확히 보존해야 함 (`.mli`에 명시) |

quarantine은 파손을 **제거하지 않고 보존**합니다. 그 `protected_suffix`가 압축 결과 체크포인트에 그대로 실려 게이트 2에서 거부됩니다 — **summarizer 호출을 이미 지불한 뒤에**.

### 라이브 실측 (`~/me/.masc/logs/system_log_2026-07-20.jsonl`)

| 시점 | `invalid_structural_source` | compaction LLM 호출 |
|---|---|---|
| #25413 빌드 이전 (02Z/03Z/06Z) | 3 / 3 / 1 시간당 | **0** |
| #25413 빌드 이후 (08:14Z~09:04Z) | **70** | **71** |

`saved_checkpoint_bytes`: 910 → 909 → 560. 재기동 이후 `compaction_rejected`는 **0건** — 게이트 1은 통과하고 있고, 실패는 전부 게이트 2입니다.

## 수리

게이트 2의 전제조건을 summarizer **이전에** 검사합니다.

`validate(source)`가 실패하면 `validate(summary :: protected_suffix)`도 반드시 실패합니다(quarantine이 파손을 보존하므로). 따라서 조기 거부는 **성공 가능했던 compaction을 하나도 잃지 않고**, persist 경계가 냈을 것과 **동일한 typed terminal**(`Invalid_structure` → `Invalid_structural_source`)을 반환합니다.

## Scope (중요)

이 PR은 **비용만 막습니다.** 구조가 깨진 히스토리를 압축 가능하게 만들지 않습니다 — analyst/idealist는 여전히 compaction 불가입니다. 근본은 `tool_use`에 대응하는 `tool_result` 없이 기록을 허용한 **write 경계**이고, #25443에 별도로 남겨두었습니다.

워크어라운드 아님 판정: 텔레메트리-as-fix / 문자열 분류기 / N-of-M / catch-all 추가 / cap·cooldown·dedup·repair / test backdoor 전부 비해당. 기존 검사를 **비싼 연산 앞이라는 올바른 위치로 옮기는 순서 수정**입니다.

## 검증

`test/test_keeper_compaction_persist_gate.ml` 신규 — 조기 게이트가 의존하는 함의를 고정합니다.

1. quarantine은 통과시키지만 persist는 같은 히스토리를 거부한다
2. 파손이 `protected_suffix`에 **보존되어** 압축 결과도 거부된다
3. 정상 히스토리는 양쪽 게이트를 통과한다 (과잉 거부 방지)

**테스트 작성 중 제 가정 하나가 틀린 것이 드러나 교정했습니다**: 단순 dangling `ToolUse`는 `validate`가 거부하지 **않습니다**(끝에 열린 사이클은 허용). 라이브 실패는 `Overlapping_tool_cycle` — 열린 사이클이 있는 상태에서 새 사이클이 열리는 모양이라, 픽스처를 그 모양으로 재작성했습니다. 첫 픽스처였다면 통과해버려 아무것도 증명 못 했을 것입니다.

- `dune build @check`: 통과
- 신규 테스트: 3/3 통과
- `@fmt`: 신규/수정 파일 drift 없음

## #25392 관련

#25392는 *"compaction 게이트가 2개(partition + persist)"*라고 주장했으나, *"두 PR은 같은 함수를 고치므로 런타임 동작이 동일"*이라는 근거로 #25413에 흡수되며 close됐습니다. 라이브 증거와 이 PR의 테스트는 **#25392의 2-게이트 분석이 옳았음**을 확인합니다.

출처: lane 큐 적대적 감사 2026-07-20. 리포트 `~/me/reports/masc-lane-queue-audit-2026-07-20.html`

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem도 건드리지 않음 (compaction 계획 경로의 게이트 순서 한정).
