### PR TITLE
feat(keeper): add expiry to exact Always Allowed HITL rules

### DIFF
--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -144,12 +144,14 @@ export function resolveGateApproval(
   decision: 'approve' | 'reject',
   rememberRule?: boolean,
   reason?: string,
+  ruleExpiresAt?: number,
 ): Promise<{ ok: boolean; id: string; decision: 'approve' | 'reject'; rule_id?: string | null }> {
   return post('/api/v1/dashboard/gate/resolve', {
     id,
     decision,
     remember_rule: rememberRule,
     reason,
+    rule_expires_at: ruleExpiresAt,
   })
 }
 

--- a/docs/security/approval-rules.md
+++ b/docs/security/approval-rules.md
@@ -2,10 +2,10 @@
 
 Keeper approval rules are persisted allow rules. The authoritative path is
 `Keeper_approval_queue_rules.rules_path`, which resolves beneath
-`Workspace_utils.masc_dir_from_base_path`. They are only loaded when each rule
-entry parses as a complete rule. Malformed entries are ignored, reported as
-persistence read drops, and cannot match a future request or auto-approve a tool
-call.
+`Workspace_utils.masc_dir_from_base_path`. They are only loaded when every rule
+entry parses as a complete rule. A malformed entry fails the whole load, is
+reported as a persistence read drop, and cannot match a future request or
+auto-approve a tool call.
 
 ## Critical Approval Timeout Policy
 
@@ -42,28 +42,36 @@ required fields:
 - `keeper_name`: non-blank string
 - `tool_name`: non-blank string
 - `request_fingerprint`: non-blank string
-- `max_risk`: one of `low`, `medium`, `high`, or `critical`
 - `created_at`: number
-- `match_count`: non-negative integer
 
-Optional fields such as `sandbox_profile`, `backend`, `created_by`,
-`last_matched_at`, and `source_approval_id` remain optional. A missing
-`request_fingerprint_preview` is derived from a valid fingerprint.
+`created_by`, `source_approval_id`, and `expires_at` are optional and may be
+absent or null. `expires_at` is an absolute Unix timestamp: at and after that
+time the rule no longer authorizes. A malformed non-null `expires_at` fails
+the entry rather than silently becoming a permanent rule.
 
-No malformed required field receives a permissive default. In particular,
-invalid or missing `max_risk` does not default to `high`.
+No malformed required field receives a permissive default, and any unsupported
+or duplicate field rejects the whole file with `explicit re-approval is
+required`.
+
+## Rule Expiry
+
+An exact Always Allowed rule with `expires_at` set stops matching at that
+timestamp. `find_matching_rule` then reports `Rule_match_expired` instead of
+applying the rule; the Gate logs the exclusion and appends a
+`gate_exact_rule_expired` audit event carrying the rule id, then falls back to
+the configured Gate mode. Expiry never deletes the rule: it stays in the store
+and dashboard listing until an operator removes it through the existing delete
+path. Rules without `expires_at` never expire, so pre-expiry persisted files
+keep their previous behavior.
 
 ## Rejection Proof
 
-`test/test_keeper_approval_queue_rules.ml` writes a persisted rule whose keeper,
-tool, and request fingerprint would otherwise match a low-risk request, but whose
-`max_risk` is malformed. The test verifies that:
+`test/test_keeper_approval_queue_rules.ml` writes a persisted rule entry with
+an unsupported field. The test verifies that:
 
-- `list_rules` skips the malformed rule during load
-- `find_matching_rule` returns `None` for the matching request
-- the skipped malformed entry increments the `keeper_approval_rules`
+- `list_rules` rejects the whole rules file
+- the rejected entry increments the `keeper_approval_rules`
   `invalid_payload` persistence-read-drop counter
-- rewriting the same persisted shape with a valid `max_risk` loads and matches
 
 This pins the operational behavior: malformed persisted approval rules are not
 silently allowed or silently erased.

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -51,6 +51,7 @@ type persisted_delivery =
   ; decision : decision
   ; source : decision_source
   ; remember_rule : bool
+  ; rule_expires_at : float option
   ; created_by : string option
   ; grant_consumed : bool
   }
@@ -173,6 +174,7 @@ let persisted_delivery_to_yojson delivery =
     ; "decision", approval_decision_to_yojson delivery.decision
     ; "source", `String (decision_source_to_string delivery.source)
     ; "remember_rule", `Bool delivery.remember_rule
+    ; "rule_expires_at", Json_util.float_opt_to_json delivery.rule_expires_at
     ; "created_by", Json_util.string_opt_to_json delivery.created_by
     ; "grant_consumed", `Bool delivery.grant_consumed
     ]
@@ -300,6 +302,14 @@ let optional_nonnegative_int ~surface field fields =
   | Some (`Int value) when value >= 0 -> Ok (Some value)
   | Some _ ->
     Error (Printf.sprintf "%s.%s must be a non-negative integer or null" surface field)
+;;
+
+let optional_float ~surface field fields =
+  match List.assoc_opt field fields with
+  | None | Some `Null -> Ok None
+  | Some (`Float value) -> Ok (Some value)
+  | Some (`Int value) -> Ok (Some (Float.of_int value))
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a number or null" surface field)
 ;;
 
 let required_positive_int ~surface field fields =
@@ -480,6 +490,7 @@ let persisted_delivery_of_yojson ~base_path json =
           ; "decision"
           ; "source"
           ; "remember_rule"
+          ; "rule_expires_at"
           ; "created_by"
           ; "grant_consumed"
           ]
@@ -501,6 +512,7 @@ let persisted_delivery_of_yojson ~base_path json =
       | Some _ -> Error (surface ^ ".remember_rule must be a boolean")
       | None -> Error (surface ^ ".remember_rule is required")
     in
+    let* rule_expires_at = optional_float ~surface "rule_expires_at" fields in
     let* created_by = optional_string ~surface "created_by" fields in
     let* grant_consumed =
       match List.assoc_opt "grant_consumed" fields with
@@ -515,7 +527,15 @@ let persisted_delivery_of_yojson ~base_path json =
       | (Decision.Reject _ | Decision.Edit _), true ->
         Error (surface ^ ".grant_consumed is valid only for approve")
     in
-    Ok { entry; decision; source; remember_rule; created_by; grant_consumed }
+    Ok
+      { entry
+      ; decision
+      ; source
+      ; remember_rule
+      ; rule_expires_at
+      ; created_by
+      ; grant_consumed
+      }
   | _ -> Error "gate_pending.delivery must be a JSON object"
 ;;
 
@@ -1903,7 +1923,7 @@ type journal_error =
   | Journal_not_found
   | Journal_storage of storage_error
 
-let journal_resolution ~id ~decision ~source ~remember_rule ~created_by =
+let journal_resolution ~id ~decision ~source ~remember_rule ~rule_expires_at ~created_by =
   with_pending_store_lock (fun () ->
     let pending_map = Atomic.get pending in
     match SMap.find_opt id pending_map with
@@ -1914,6 +1934,7 @@ let journal_resolution ~id ~decision ~source ~remember_rule ~created_by =
         ; decision
         ; source
         ; remember_rule
+        ; rule_expires_at
         ; created_by
         ; grant_consumed = false
         }
@@ -1959,7 +1980,7 @@ let approval_decision_equal left right =
     false
 ;;
 
-let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
+let remember_rule_for_entry ~base_path ?created_by ?rule_expires_at (entry : pending_approval) =
   try
     match
       upsert_rule
@@ -1969,6 +1990,7 @@ let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
         ~input:entry.input
         ?created_by
         ~source_approval_id:entry.id
+        ?expires_at:rule_expires_at
         ()
     with
     | Ok (rule, created) ->
@@ -2004,6 +2026,7 @@ let remember_rule_for_delivery delivery =
        remember_rule_for_entry
          ~base_path:delivery.entry.audit_base_path
          ?created_by:delivery.created_by
+         ?rule_expires_at:delivery.rule_expires_at
          delivery.entry
      with
      | Ok rule -> Ok (Some rule)
@@ -2203,6 +2226,7 @@ let resolve_with_policy
       ~(decision : decision)
       ?(source = Human_operator)
       ?(remember_rule = false)
+      ?rule_expires_at
       ?created_by
       ()
   : (resolution_result, resolve_error) result
@@ -2232,12 +2256,16 @@ let resolve_with_policy
              | Decision.Approve -> remember_rule
              | Decision.Reject _ | Decision.Edit _ -> false
            in
+           let rule_expires_at =
+             if remember_rule then rule_expires_at else None
+           in
            (match
               journal_resolution
                 ~id
                 ~decision
                 ~source
                 ~remember_rule
+                ~rule_expires_at
                 ~created_by
             with
             | Error Journal_not_found -> Error (Not_found id)
@@ -2252,6 +2280,7 @@ let resolve_with_policy
                 approval_decision_equal decision delivery.decision
                 && source = delivery.source
                 && remember_rule = delivery.remember_rule
+                && rule_expires_at = delivery.rule_expires_at
                 && created_by = delivery.created_by
               in
               if same_request

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -98,7 +98,9 @@ val list_rules_dashboard_json :
   base_path:string -> unit -> (Yojson.Safe.t, rule_store_error) result
 
 (** Insert or fetch the rule for the exact
-    [(keeper_name, tool_name, canonical complete input)] identity. *)
+    [(keeper_name, tool_name, canonical complete input)] identity.
+    [expires_at] is an optional absolute Unix expiry; the identity match
+    ignores it, so an existing rule is returned unchanged. *)
 val upsert_rule :
   base_path:string ->
   keeper_name:string ->
@@ -106,20 +108,25 @@ val upsert_rule :
   input:Yojson.Safe.t ->
   ?created_by:string ->
   ?source_approval_id:string ->
+  ?expires_at:float ->
   unit ->
   (approval_rule * bool, rule_store_error) result
 
 val delete_rule :
   base_path:string -> id:string -> unit -> (approval_rule, rule_store_error) result
 
-(** Find the exact remembered request and atomically update its match audit. *)
+(** Find the exact remembered request and report whether it authorizes at
+    [now] (defaults to the wall clock; inject for deterministic evaluation).
+    An expired rule is reported as [Rule_match_expired], never applied, and
+    never deleted. *)
 val find_matching_rule :
   base_path:string ->
   keeper_name:string ->
   tool_name:string ->
   input:Yojson.Safe.t ->
+  ?now:float ->
   unit ->
-  (rule_match option, rule_store_error) result
+  (rule_lookup, rule_store_error) result
 
 (** {1 Audit log} *)
 
@@ -202,13 +209,16 @@ type resolve_error =
 val resolve_error_to_string : resolve_error -> string
 
 (** Commit a resolution, optionally persist an exact Always Allowed rule for
-    [Decision.Approve], then wake only the Keeper captured by the pending entry. *)
+    [Decision.Approve], then wake only the Keeper captured by the pending entry.
+    [rule_expires_at] is an absolute Unix expiry applied to the remembered
+    rule; it is ignored unless [remember_rule] is [true]. *)
 val resolve_with_policy :
   base_path:string ->
   id:string ->
   decision:decision ->
   ?source:decision_source ->
   ?remember_rule:bool ->
+  ?rule_expires_at:float ->
   ?created_by:string ->
   unit ->
   (resolution_result, resolve_error) result

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -218,6 +218,7 @@ let upsert_rule
       ~input
       ?created_by
       ?source_approval_id
+      ?expires_at
       ()
   =
   with_rules_write_lock (fun () ->
@@ -233,6 +234,7 @@ let upsert_rule
         ; created_at = Unix.gettimeofday ()
         ; created_by
         ; source_approval_id
+        ; expires_at
         }
       in
       (match List.find_opt (fun rule -> rule_identity_matches rule candidate) rules with
@@ -275,6 +277,8 @@ let find_matching_rule
       ~keeper_name
       ~tool_name
       ~input
+      (* NDT-OK: wall-clock default at this store I/O boundary; callers inject ~now. *)
+      ?(now = Unix.gettimeofday ())
       ()
   =
   with_rules_read_lock (fun () ->
@@ -290,6 +294,10 @@ let find_matching_rule
               && String.equal rule.request_fingerprint request_fingerprint)
            rules
        with
-       | None -> Ok None
-       | Some rule -> Ok (Some { rule_id = rule.id })))
+       | None -> Ok Rule_match_absent
+       | Some rule ->
+         let matched = { rule_id = rule.id } in
+         if rule_expired ~now rule
+         then Ok (Rule_match_expired matched)
+         else Ok (Rule_match_active matched)))
 ;;

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -829,6 +829,25 @@ let observe_exact_rule_store_degraded request error =
     ()
 ;;
 
+let observe_exact_rule_expired request (rule_match : Keeper_approval_queue.rule_match) =
+  Log.Keeper.warn
+    ~keeper_name:request.keeper_name
+    "exact Always Allowed rule %s expired operation=%s; continuing configured Gate mode"
+    rule_match.rule_id
+    request.operation;
+  Keeper_approval_queue.audit_approval_event
+    ~base_path:request.base_path
+    ~event_type:"gate_exact_rule_expired"
+    ~id:(Keeper_approval_queue.generate_id ())
+    ~keeper_name:request.keeper_name
+    ~tool_name:request.operation
+    ?turn_id:(request_turn_id request)
+    ?task_id:request.task_id
+    ~goal_ids:request.goal_ids
+    ~rule_match
+    ()
+;;
+
 let decide_from_selected_mode request = function
   | Error detail -> defer request (Mode_state_invalid detail)
   | Ok Keeper_gate_mode.Manual -> defer request Human_requested
@@ -873,7 +892,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
         | Error error ->
           observe_exact_rule_store_degraded request error;
           decide_from_selected_mode request mode
-        | Ok (Some rule_match) ->
+        | Ok (Keeper_approval_queue.Rule_match_active rule_match) ->
           let source = Exact_always_rule rule_match.rule_id in
           audit_allow
             request
@@ -881,7 +900,11 @@ let decide_without_cycle_grant ~keeper_always_allow request =
             ~decision_source:Keeper_approval_queue.Always_allowed
             source;
           Allow { source }
-        | Ok None -> decide_from_selected_mode request mode))
+        | Ok (Keeper_approval_queue.Rule_match_expired rule_match) ->
+          observe_exact_rule_expired request rule_match;
+          decide_from_selected_mode request mode
+        | Ok Keeper_approval_queue.Rule_match_absent ->
+          decide_from_selected_mode request mode))
 ;;
 
 let decide ?cycle_grant ~keeper_always_allow request =

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -63,9 +63,17 @@ type approval_rule =
   ; created_at : float
   ; created_by : string option
   ; source_approval_id : string option
+  ; expires_at : float option
   }
 
 type rule_match = { rule_id : string }
+
+(** Exact rule lookup outcome. An expired rule never authorizes; it stays
+    stored and observable until an operator deletes it. *)
+type rule_lookup =
+  | Rule_match_active of rule_match
+  | Rule_match_expired of rule_match
+  | Rule_match_absent
 
 type rule_store_error =
   { path : string
@@ -131,6 +139,12 @@ let rule_store_error_to_string error =
   Printf.sprintf "%s: %s" error.path error.reason
 ;;
 
+let rule_expired ~now (rule : approval_rule) =
+  match rule.expires_at with
+  | None -> false
+  | Some expires_at -> expires_at <= now
+;;
+
 let approval_rule_to_yojson (rule : approval_rule) =
   `Assoc
     [ "id", `String rule.id
@@ -140,6 +154,7 @@ let approval_rule_to_yojson (rule : approval_rule) =
     ; "created_at", `Float rule.created_at
     ; "created_by", Json_util.string_opt_to_json rule.created_by
     ; "source_approval_id", Json_util.string_opt_to_json rule.source_approval_id
+    ; "expires_at", Json_util.float_opt_to_json rule.expires_at
     ]
 ;;
 
@@ -326,6 +341,7 @@ let approval_rule_of_yojson_with_error json =
             ; "created_at"
             ; "created_by"
             ; "source_approval_id"
+            ; "expires_at"
             ]
           fields
       with
@@ -348,6 +364,13 @@ let approval_rule_of_yojson_with_error json =
     in
     let created_by = Json_util.get_string json "created_by" in
     let source_approval_id = Json_util.get_string json "source_approval_id" in
+    let* expires_at =
+      match List.assoc_opt "expires_at" fields with
+      | None | Some `Null -> Ok None
+      | Some (`Float value) -> Ok (Some value)
+      | Some (`Int value) -> Ok (Some (Float.of_int value))
+      | Some _ -> Error "expires_at must be a number or null"
+    in
     Ok
       { id
       ; keeper_name
@@ -356,6 +379,7 @@ let approval_rule_of_yojson_with_error json =
       ; created_at
       ; created_by
       ; source_approval_id
+      ; expires_at
       }
   | _ -> Error "approval rule must be a JSON object"
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -63,7 +63,10 @@ type decision_source =
 (** An immutable exact Always Allowed rule. Its identity is the workspace-local
     Keeper, opaque operation identity, and complete normalized effect input;
     only JSON object-field order is canonicalized. Match observations belong in
-    the append-only Gate audit log, so reading a rule never rewrites it. *)
+    the append-only Gate audit log, so reading a rule never rewrites it.
+    [expires_at] is an optional absolute Unix expiry: at and after that time
+    the rule no longer authorizes. Expiry never deletes the rule; an operator
+    removes it through the existing delete path. *)
 type approval_rule =
   { id : string
   ; keeper_name : string
@@ -72,9 +75,17 @@ type approval_rule =
   ; created_at : float
   ; created_by : string option
   ; source_approval_id : string option
+  ; expires_at : float option
   }
 
 type rule_match = { rule_id : string }
+
+(** Exact rule lookup outcome. [Rule_match_expired] keeps the expired rule
+    identity observable instead of collapsing it into an absent match. *)
+type rule_lookup =
+  | Rule_match_active of rule_match
+  | Rule_match_expired of rule_match
+  | Rule_match_absent
 
 type rule_store_error =
   { path : string
@@ -92,6 +103,11 @@ val decision_source_of_string : string -> decision_source option
 val string_opt_of_json : Yojson.Safe.t -> string option
 val bool_member : string -> Yojson.Safe.t -> default:bool -> bool
 val rule_match_to_yojson : rule_match -> Yojson.Safe.t
+
+val rule_expired : now:float -> approval_rule -> bool
+(** [rule_expired ~now rule] is [true] when [rule.expires_at] is set and lies
+    at or before [now]. Pure and deterministic; [now] is injected. *)
+
 val rule_store_error_to_string : rule_store_error -> string
 val approval_rule_to_yojson : approval_rule -> Yojson.Safe.t
 val hitl_context_summary_to_yojson : hitl_context_summary -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -372,6 +372,7 @@ let dashboard_gate_resolve_http_json ~base_path ~created_by ~(args : Yojson.Safe
     let remember_rule =
       Safe_ops.json_bool_opt "remember_rule" args |> Option.value ~default:false
     in
+    let rule_expires_at = Safe_ops.json_float_opt "rule_expires_at" args in
     (* RFC-0305: a missing [decision] field must not default to approve — this
        resolves a pending HITL approval, so an omitted/malformed decision is a
        bad request, not a silent grant. Mirrors the [id]-required check above. *)
@@ -389,6 +390,7 @@ let dashboard_gate_resolve_http_json ~base_path ~created_by ~(args : Yojson.Safe
             ~id
             ~decision
             ~remember_rule
+            ?rule_expires_at
             ~created_by
             ()
         with

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -649,7 +649,8 @@ let test_resolution_is_durable_and_origin_scoped () =
               ~input
               ()
           with
-          | Ok matched -> Option.is_some matched
+          | Ok (AQ.Rule_match_active _) -> true
+          | Ok (AQ.Rule_match_expired _ | AQ.Rule_match_absent) -> false
           | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error));
        (match
           AQ.consume_approved_resolution
@@ -676,6 +677,62 @@ let test_resolution_is_durable_and_origin_scoped () =
           Alcotest.fail "exact request did not consume its grant"
         | Error error -> Alcotest.fail (AQ.grant_error_to_string error));
        drop_resolution ~base_path ~keeper_name resolution)
+;;
+
+let test_remembered_rule_carries_requested_expiry () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-expiry-origin" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       ignore (install_exn ~base_path);
+       let input = `Assoc [ "target", `String "document" ] in
+       let id = submit ~base_path ~keeper_name ~input in
+       let expires_at = Unix.gettimeofday () +. 600.0 in
+       let result =
+         AQ.resolve_with_policy
+           ~base_path
+           ~id
+           ~decision:AQ.Decision.Approve
+           ~remember_rule:true
+           ~rule_expires_at:expires_at
+           ~created_by:"operator"
+           ()
+       in
+       (match result with
+        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
+        | Ok { remembered_rule = None } ->
+          Alcotest.fail "approved remember_rule resolution must persist a rule"
+        | Ok { remembered_rule = Some rule } ->
+          Alcotest.(check (option (float 0.0)))
+            "rule carries requested expiry"
+            (Some expires_at)
+            rule.expires_at);
+       (* A same-request replay stays idempotent only when the expiry matches. *)
+       (match
+          AQ.resolve_with_policy
+            ~base_path
+            ~id
+            ~decision:AQ.Decision.Approve
+            ~remember_rule:true
+            ~rule_expires_at:expires_at
+            ~created_by:"operator"
+            ()
+        with
+        | Ok _ -> ()
+        | Error error ->
+          Alcotest.fail
+            ("identical expiry re-resolution must be idempotent: "
+             ^ AQ.resolve_error_to_string error));
+       match AQ.list_rules ~base_path () with
+       | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error)
+       | Ok [ rule ] ->
+         Alcotest.(check (option (float 0.0)))
+           "persisted rule carries requested expiry"
+           (Some expires_at)
+           rule.expires_at
+       | Ok rules ->
+         Alcotest.failf "one remembered rule expected, got %d" (List.length rules))
 ;;
 
 let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
@@ -1797,6 +1854,10 @@ let () =
             "resolution wakes only origin"
             `Quick
             test_resolution_is_durable_and_origin_scoped
+        ; Alcotest.test_case
+            "remembered rule carries requested expiry"
+            `Quick
+            test_remembered_rule_carries_requested_expiry
         ; Alcotest.test_case
             "cycle grant binds origin and is consumed once"
             `Quick

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -60,8 +60,14 @@ let find ~base_path ~input =
       ~input
       ()
   with
-  | Ok matched -> matched
+  | Ok lookup -> lookup
   | Error error -> fail (AQ.rule_store_error_to_string error)
+;;
+
+let find_active_opt ~base_path ~input =
+  match find ~base_path ~input with
+  | AQ.Rule_match_active matched -> Some matched
+  | AQ.Rule_match_expired _ | AQ.Rule_match_absent -> None
 ;;
 
 let test_rule_matches_only_complete_exact_request () =
@@ -84,7 +90,7 @@ let test_rule_matches_only_complete_exact_request () =
            ]
        in
        check bool "object field order is canonical" true
-         (Option.is_some (find ~base_path ~input:reordered));
+         (Option.is_some (find_active_opt ~base_path ~input:reordered));
        let changed_nonce =
          `Assoc
            [ "target", `String "/workspace/readme.md"
@@ -92,19 +98,19 @@ let test_rule_matches_only_complete_exact_request () =
            ]
        in
        check bool "no request field is discarded" true
-         (Option.is_none (find ~base_path ~input:changed_nonce));
+         (Option.is_none (find_active_opt ~base_path ~input:changed_nonce));
        check bool "different operation identity cannot match" true
-         (Option.is_none
-            (match
-               AQ.find_matching_rule
-                 ~base_path
-                 ~keeper_name:"keeper"
-                 ~tool_name:"another-effect"
-                 ~input
-                 ()
-             with
-             | Ok matched -> matched
-             | Error error -> fail (AQ.rule_store_error_to_string error))))
+         (match
+            AQ.find_matching_rule
+              ~base_path
+              ~keeper_name:"keeper"
+              ~tool_name:"another-effect"
+              ~input
+              ()
+          with
+          | Ok AQ.Rule_match_absent -> true
+          | Ok (AQ.Rule_match_active _ | AQ.Rule_match_expired _) -> false
+          | Error error -> fail (AQ.rule_store_error_to_string error)))
 ;;
 
 let test_equivalent_upsert_is_idempotent () =
@@ -150,6 +156,96 @@ let test_gate_allows_only_the_exact_persisted_rule () =
        | Gate.Deferred _ -> fail "exact Always Allowed rule unexpectedly deferred"
        | Gate.Unavailable reason ->
          fail (Gate.unavailable_reason_to_string reason))
+;;
+
+let upsert_with_expiry_exn ~base_path ~input ~expires_at =
+  match
+    AQ.upsert_rule
+      ~base_path
+      ~keeper_name:"keeper"
+      ~tool_name:"external-effect"
+      ~input
+      ~expires_at
+      ()
+  with
+  | Ok result -> result
+  | Error error -> fail (AQ.rule_store_error_to_string error)
+;;
+
+let find_at ~base_path ~input ~now =
+  match
+    AQ.find_matching_rule
+      ~base_path
+      ~keeper_name:"keeper"
+      ~tool_name:"external-effect"
+      ~input
+      ~now
+      ()
+  with
+  | Ok lookup -> lookup
+  | Error error -> fail (AQ.rule_store_error_to_string error)
+;;
+
+let test_unexpired_rule_matches_with_injected_now () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "request", `String "exact" ] in
+       let rule, created =
+         upsert_with_expiry_exn ~base_path ~input ~expires_at:2000.0
+       in
+       check bool "created" true created;
+       check (option (float 0.0)) "expiry persisted on rule" (Some 2000.0)
+         rule.expires_at;
+       match find_at ~base_path ~input ~now:1999.0 with
+       | AQ.Rule_match_active matched ->
+         check string "unexpired rule matches" rule.id matched.rule_id
+       | AQ.Rule_match_expired _ -> fail "unexpired rule reported as expired"
+       | AQ.Rule_match_absent -> fail "unexpired rule did not match")
+;;
+
+let test_expired_rule_is_reported_and_retained () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "request", `String "exact" ] in
+       let rule, _ = upsert_with_expiry_exn ~base_path ~input ~expires_at:2000.0 in
+       (match find_at ~base_path ~input ~now:2000.0 with
+        | AQ.Rule_match_expired matched ->
+          check string "expiry boundary is expired" rule.id matched.rule_id
+        | AQ.Rule_match_active _ -> fail "expired rule still matched"
+        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+       (match find_at ~base_path ~input ~now:2001.0 with
+        | AQ.Rule_match_expired matched ->
+          check string "after expiry is expired" rule.id matched.rule_id
+        | AQ.Rule_match_active _ -> fail "expired rule still matched"
+        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+       let stored =
+         match AQ.list_rules ~base_path () with
+         | Ok rules -> rules
+         | Error error -> fail (AQ.rule_store_error_to_string error)
+       in
+       check bool "expired rule is retained for operator cleanup" true
+         (List.exists (fun (stored : AQ.approval_rule) ->
+            String.equal stored.id rule.id && stored.expires_at = Some 2000.0)
+            stored))
+;;
+
+let test_rule_without_expiry_matches_at_any_now () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "request", `String "exact" ] in
+       let rule, _ = upsert_exn ~base_path ~input in
+       check (option (float 0.0)) "no expiry by default" None rule.expires_at;
+       match find_at ~base_path ~input ~now:1e12 with
+       | AQ.Rule_match_active matched ->
+         check string "rule without expiry stays active" rule.id matched.rule_id
+       | AQ.Rule_match_expired _ -> fail "rule without expiry reported as expired"
+       | AQ.Rule_match_absent -> fail "rule without expiry did not match")
 ;;
 
 let test_unknown_persisted_shape_is_reported_and_rejected () =
@@ -329,6 +425,64 @@ let test_invalid_mode_continues_to_explicit_defer_when_rule_store_is_unavailable
        ^ Gate.unavailable_reason_to_string reason)
 ;;
 
+let test_gate_allows_unexpired_exact_rule () =
+  with_gate_fixture @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  (match Gate_mode.set config ~actor:"test" Gate_mode.Manual with
+   | Ok _ -> ()
+   | Error reason -> fail reason);
+  let input = `Assoc [ "target", `String "exact" ] in
+  let rule, _ =
+    upsert_with_expiry_exn
+      ~base_path
+      ~input
+      ~expires_at:(Unix.gettimeofday () +. 3600.0)
+  in
+  match Gate.decide ~keeper_always_allow:false (gate_request ~base_path) with
+  | Gate.Allow { source = Gate.Exact_always_rule rule_id } ->
+    check string "unexpired exact rule id" rule.id rule_id
+  | Gate.Allow _ -> fail "Gate used a broader Always Allowed source"
+  | Gate.Deferred _ -> fail "unexpired exact rule unexpectedly deferred"
+  | Gate.Unavailable reason -> fail (Gate.unavailable_reason_to_string reason)
+;;
+
+(** An expired exact rule must not authorize: the Gate falls back to the
+    configured mode and the exclusion is audited. *)
+let test_gate_defers_and_observes_expired_exact_rule () =
+  with_gate_fixture @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  (match Gate_mode.set config ~actor:"test" Gate_mode.Manual with
+   | Ok _ -> ()
+   | Error reason -> fail reason);
+  let input = `Assoc [ "target", `String "exact" ] in
+  let rule, _ =
+    upsert_with_expiry_exn
+      ~base_path
+      ~input
+      ~expires_at:(Unix.gettimeofday () -. 60.0)
+  in
+  (match Gate.decide ~keeper_always_allow:false (gate_request ~base_path) with
+   | Gate.Deferred { reason = Gate.Human_requested; _ } -> ()
+   | Gate.Deferred _ -> fail "expired exact rule used the wrong deferred reason"
+   | Gate.Allow _ -> fail "expired exact rule still authorized the request"
+   | Gate.Unavailable reason ->
+     fail
+       ("expired exact rule blocked Manual HITL: "
+        ^ Gate.unavailable_reason_to_string reason));
+  let audited =
+    AQ.read_recent_audit ~base_path ~keeper_name:"keeper" ~n:20 ()
+    |> List.exists (fun json ->
+      String.equal
+        "gate_exact_rule_expired"
+        (Safe_ops.json_string ~default:"" "event" json)
+      &&
+      match Yojson.Safe.Util.member "rule_match" json with
+      | `Assoc [ "rule_id", `String rule_id ] -> String.equal rule.id rule_id
+      | _ -> false)
+  in
+  check bool "expired rule exclusion is audited" true audited
+;;
+
 let test_keeper_always_allow_does_not_depend_on_rule_store () =
   let base_path = temp_dir () in
   Fun.protect
@@ -372,6 +526,26 @@ let () =
             "Gate consumes exact persisted rule"
             `Quick
             test_gate_allows_only_the_exact_persisted_rule
+        ; test_case
+            "unexpired rule matches with injected now"
+            `Quick
+            test_unexpired_rule_matches_with_injected_now
+        ; test_case
+            "expired rule is reported and retained"
+            `Quick
+            test_expired_rule_is_reported_and_retained
+        ; test_case
+            "rule without expiry matches at any now"
+            `Quick
+            test_rule_without_expiry_matches_at_any_now
+        ; test_case
+            "Gate allows unexpired exact rule"
+            `Quick
+            test_gate_allows_unexpired_exact_rule
+        ; test_case
+            "Gate defers and audits expired exact rule"
+            `Quick
+            test_gate_defers_and_observes_expired_exact_rule
         ; test_case
             "unsupported persisted shape is explicit"
             `Quick

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -12,6 +12,7 @@ let sample_rule =
   ; created_at = 1780587600.0
   ; created_by = Some "operator"
   ; source_approval_id = Some "approval-1"
+  ; expires_at = None
   }
 ;;
 
@@ -52,6 +53,11 @@ let test_summary_json_is_nonhierarchical () =
     fail "available summary did not round trip"
 ;;
 
+let without_field field = function
+  | `Assoc fields -> `Assoc (List.remove_assoc field fields)
+  | json -> json
+;;
+
 let test_approval_rule_json_round_trip () =
   match Q.approval_rule_of_yojson (Q.approval_rule_to_yojson sample_rule) with
   | None -> fail "expected exact approval rule to parse"
@@ -60,9 +66,48 @@ let test_approval_rule_json_round_trip () =
     check string "fingerprint" sample_rule.request_fingerprint parsed.request_fingerprint
 ;;
 
-let without_field field = function
-  | `Assoc fields -> `Assoc (List.remove_assoc field fields)
-  | json -> json
+let test_approval_rule_expiry_round_trip () =
+  let rule = { sample_rule with Q.expires_at = Some 1780591200.0 } in
+  let json = Q.approval_rule_to_yojson rule in
+  check yojson "expires_at persisted" (`Float 1780591200.0)
+    (Yojson.Safe.Util.member "expires_at" json);
+  match Q.approval_rule_of_yojson json with
+  | None -> fail "expected expiring approval rule to parse"
+  | Some parsed ->
+    check (option (float 0.0)) "expires_at round trip" rule.expires_at parsed.expires_at
+;;
+
+let test_approval_rule_without_expiry_round_trip () =
+  let json = Q.approval_rule_to_yojson sample_rule in
+  check yojson "expires_at serialized as null" `Null
+    (Yojson.Safe.Util.member "expires_at" json);
+  let legacy = without_field "expires_at" json in
+  match Q.approval_rule_of_yojson legacy with
+  | None -> fail "pre-expiry persisted rule must still parse"
+  | Some parsed ->
+    check (option (float 0.0)) "missing expires_at is no expiry" None parsed.expires_at
+;;
+
+let test_rule_parser_rejects_malformed_expiry () =
+  let malformed =
+    match Q.approval_rule_to_yojson sample_rule with
+    | `Assoc fields ->
+      `Assoc (("expires_at", `String "soon") :: List.remove_assoc "expires_at" fields)
+    | json -> json
+  in
+  match Q.approval_rule_of_yojson_with_error malformed with
+  | Ok _ -> fail "malformed expires_at must not silently become a permanent rule"
+  | Error reason ->
+    check string "failure names expires_at" "expires_at must be a number or null"
+      reason
+;;
+
+let test_rule_expired_is_deterministic () =
+  let expiring = { sample_rule with Q.expires_at = Some 1000.0 } in
+  check bool "no expiry never expires" false (Q.rule_expired ~now:1e12 sample_rule);
+  check bool "before expiry is active" false (Q.rule_expired ~now:999.0 expiring);
+  check bool "expiry boundary is expired" true (Q.rule_expired ~now:1000.0 expiring);
+  check bool "after expiry is expired" true (Q.rule_expired ~now:1000.5 expiring)
 ;;
 
 let test_rule_parser_is_closed_and_explicit () =
@@ -112,6 +157,16 @@ let () =
         ] )
     ; ( "exact rule"
       , [ test_case "JSON round trip" `Quick test_approval_rule_json_round_trip
+        ; test_case "expiry JSON round trip" `Quick test_approval_rule_expiry_round_trip
+        ; test_case
+            "missing expiry parses as no expiry"
+            `Quick
+            test_approval_rule_without_expiry_round_trip
+        ; test_case
+            "malformed expiry rejected"
+            `Quick
+            test_rule_parser_rejects_malformed_expiry
+        ; test_case "expiry check is deterministic" `Quick test_rule_expired_is_deterministic
         ; test_case "closed explicit parser" `Quick test_rule_parser_is_closed_and_explicit
         ; test_case
             "duplicate fields rejected"


### PR DESCRIPTION
## 갭 증거

RFC-0000 acceptance는 operator-recorded Always Allowed rule이 typed **expiry**를 가져야 한다고 요구한다 (`docs/rfc/RFC-0000-MASTER-ROADMAP.md:466`, `:489`). 그러나 `approval_rule` (`lib/keeper_contract/keeper_approval_queue_rules_types.mli`)에는 expiry 필드가 없었고, revocation은 `delete_rule`뿐이었다 — 한번 remember된 rule은 수동 삭제 전까지 해당 exact request를 무기한 auto-approve했다.

## 설계

- **필드**: `approval_rule.expires_at : float option` — absolute Unix timestamp (`created_at`과 동일 표현). 단순 additive optional: 기존 영속 파일(필드 없음)은 그대로 파싱되고, dual-read/compat 분기는 없다. malformed non-null `expires_at`는 entry를 fail-close로 reject한다 (영구 rule로의 silent 승격 방지).
- **평가**: `find_matching_rule ?now`(default wall clock, repo의 `?now:float` 패턴)이 tri-state `rule_lookup = Rule_match_active | Rule_match_expired | Rule_match_absent`를 반환. 판정은 pure `rule_expired ~now` — `expires_at <= now`이면 만료 (schedule domain의 `expires_at` 컨벤션과 동일, 경계값=만료).
- **관측 (LAW 3)**: Gate는 만료 rule을 절대 적용하지 않고, `observe_exact_rule_store_degraded`와 같은 패턴으로 `Log.Keeper.warn` + `gate_exact_rule_expired` audit event(rule_id 포함)를 남긴 뒤 configured mode(Manual/Auto Judge)로 fall through한다.
- **자동 삭제 없음**: 만료 rule은 store와 dashboard listing에 남는다. 정리는 기존 `delete_rule` 경로의 operator 몫.
- **생성 surface**: `upsert_rule ?expires_at` + `resolve_with_policy ?rule_expires_at` → `persisted_delivery.rule_expires_at`(backward-compatible optional snapshot 필드) → `remember_rule` 체인 threading. Dashboard resolve endpoint(`rule_expires_at` JSON 인자)와 TS client(`resolveGateApproval` optional 5th param)까지 연결.

## 테스트 결과

- `test_keeper_approval_queue_rules_types`: **9/9** — expiry roundtrip, 필드 없는 legacy JSON → None, malformed expiry reject, 경계 결정론
- `test_keeper_approval_queue_rules`: **15/15** — (a) 미만료 적용 (b) 만료 미적용+보고+retained (c) expiry 없는 rule 불변 (d) Gate allow/defer+audit
- `test_keeper_approval_queue`: **29/29** — resolve 시 expiry가 rule에 실리고 동일 재해석 idempotent, delivery snapshot replay 호환
- `dune build @lib/server/check` ✓, dashboard `tsc --noEmit` ✓

로컬 검증은 `scripts/dune-local.sh build <test exe>` + 변경 타겟 직접 실행만 사용 (full dune build/runtest 미실행 — CI 위임).

## 판단 지점

- 만료는 실패가 아니므로 `ApprovalQueueFailures` 카운터를 재사용하지 않고 log+audit만 남김 (새 metric constructor 추가 대신 최소 diff 선택).
- `upsert_rule`의 identity match는 expiry를 무시 — 동일 identity의 기존 rule이 있으면 expiry가 달라도 갱신하지 않고 기존 것을 반환 (기존 upsert 의미론 유지; 갱신은 delete+recreate).
- `docs/security/approval-rules.md`의 parse-policy/rejection-proof 절이 현재 parser와 어긋난 pre-existing drift를 이 PR에서 함께 정정.
- Dashboard rules 목록 UI의 `expires_at` 표시는 후속 (이 PR은 생성/평가/감사 경로만).

🤖 Generated with Kimi Code