### PR TITLE
fix(gate): persist connector workspace identity through typed delivery

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -6,6 +6,7 @@ type connector_delivery =
   ; surface : Surface_ref.t
   ; conversation_id : string option
   ; external_message_id : string option
+  ; workspace_id : string option
   }
 
 (* ── Keeper response parsing ─────────────────────────────────── *)
@@ -391,6 +392,36 @@ let reconcile_delivery_metadata key expected metadata =
     Error (Printf.sprintf "connector metadata contains duplicate %s fields" key)
 ;;
 
+(* The untyped gate-message [channel_workspace_id] string and the typed
+   [delivery.workspace_id] describe the same workspace at two layers; the
+   stringly layer encodes absence as "". Any disagreement between them is a
+   wiring defect, so intake fails closed instead of silently picking one —
+   the same discipline as {!reconcile_delivery_metadata}. *)
+let reconcile_gate_workspace_id ~channel_workspace_id ~workspace_id =
+  match non_empty_opt channel_workspace_id, workspace_id with
+  | None, None -> Ok ()
+  | Some gate, Some typed when String.equal gate typed -> Ok ()
+  | Some gate, Some typed ->
+    Error
+      (Printf.sprintf
+         "connector gate workspace_id conflicts with typed delivery \
+          (gate=%S delivery=%S)"
+         gate
+         typed)
+  | Some gate, None ->
+    Error
+      (Printf.sprintf
+         "connector gate supplied workspace_id %S but the typed delivery \
+          omitted it"
+         gate)
+  | None, Some typed ->
+    Error
+      (Printf.sprintf
+         "connector typed delivery supplied workspace_id %S but the gate \
+          context omitted it"
+         typed)
+;;
+
 let delivery_key_of_receipt receipt_id =
   match Keeper_chat_delivery_identity.Receipt_ids.of_list [ receipt_id ] with
   | Ok receipt_ids ->
@@ -458,7 +489,6 @@ let terminal_connector_reply ~redact_text ~channel ~channel_user_id
 let accept_connector ~delivery ~clock ~config ~channel ~channel_user_id
     ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
     ~metadata ~content =
-  ignore channel_workspace_id;
   let keeper_name = String.trim keeper_name in
   let redaction =
     Keeper_secret_redaction.snapshot
@@ -468,16 +498,27 @@ let accept_connector ~delivery ~clock ~config ~channel ~channel_user_id
   let redact_text = Keeper_secret_redaction.redact_text redaction in
   let conversation_id = delivery.conversation_id in
   let external_message_id = delivery.external_message_id in
+  let workspace_id = delivery.workspace_id in
   let metadata =
     match
       reconcile_delivery_metadata "conversation_id" conversation_id metadata
     with
     | Error _ as error -> error
     | Ok metadata ->
-      reconcile_delivery_metadata
-        "external_message_id"
-        external_message_id
-        metadata
+      (match
+         reconcile_delivery_metadata
+           "external_message_id"
+           external_message_id
+           metadata
+       with
+       | Error _ as error -> error
+       | Ok metadata ->
+         reconcile_delivery_metadata "workspace_id" workspace_id metadata)
+  in
+  let metadata =
+    match reconcile_gate_workspace_id ~channel_workspace_id ~workspace_id with
+    | Error _ as error -> error
+    | Ok () -> metadata
   in
   match metadata with
   | Error detail -> Gate_protocol.Keeper_error_result (redact_text detail)
@@ -504,7 +545,7 @@ let accept_connector ~delivery ~clock ~config ~channel ~channel_user_id
              Keeper_chat_store.append_user_message_once
                ~base_dir:config.Workspace.base_path ~keeper_name ~delivery_key
                ~content:(String.trim content) ~surface ?conversation_id
-               ?external_message_id
+               ?external_message_id ?workspace_id
                ~speaker:
                  { Keeper_chat_store.speaker_id = opt channel_user_id
                  ; speaker_name = opt channel_user_name

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -17,10 +17,14 @@ type connector_delivery =
   ; surface : Surface_ref.t
   ; conversation_id : string option
   ; external_message_id : string option
+  ; workspace_id : string option
   }
 (** Immutable projection of the connector-owned delivery coordinates. The leaf
     parses its own protocol and supplies this value; the Keeper adapter treats
-    every field as typed opaque input and does not inspect product metadata. *)
+    every field as typed opaque input and does not inspect product metadata.
+    [workspace_id] is the connector workspace identity (Discord guild / Slack
+    team); [None] is the explicit typed absence (e.g. a Discord DM), never an
+    empty string. *)
 
 val accept_connector :
   delivery:connector_delivery ->
@@ -40,7 +44,10 @@ val accept_connector :
     this adapter neither identifies products nor derives routes from
     product-specific metadata. The producer's typed request identity is the
     queue receipt and transcript delivery key; retries converge without a
-    derived hash namespace. *)
+    derived hash namespace. The typed [delivery.workspace_id] is persisted on
+    the durable user row like the speaker identity; any disagreement between
+    the typed delivery, the gate [channel_workspace_id], or the connector
+    metadata fails closed instead of guessing a workspace. *)
 
 val dispatch :
   submitted_by:string ->

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -201,6 +201,7 @@ type chat_message = {
          [surface] field.  [None] on rows written before P5. *)
   conversation_id : string option;
   external_message_id : string option;
+  workspace_id : string option;
   speaker : speaker option;
   audio : audio_clip option;
   blocks : Keeper_chat_blocks.chat_block list option;
@@ -517,7 +518,8 @@ let legacy_message_id ~ts ~content =
     (String.sub (Digest.to_hex (Digest.string content)) 0 12)
 
 let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_call_id
-    ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
+    ?tool_call_name ?surface ?conversation_id ?external_message_id ?workspace_id
+    ?speaker
     ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref
     ?stream_lifecycle ?delivery_key ?transcript_slot ()
     : string =
@@ -599,6 +601,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_cal
     @ surface_field
     @ opt_string_field "conversation_id" conversation_id
     @ opt_string_field "external_message_id" external_message_id
+    @ opt_string_field "workspace_id" workspace_id
     @ speaker_fields speaker
     @ audio_fields audio
     @ blocks_fields blocks
@@ -953,6 +956,7 @@ let append_user_message_once
       ?surface
       ?conversation_id
       ?external_message_id
+      ?workspace_id
       ?speaker
       ?(extra_mentions = [])
       ()
@@ -977,6 +981,7 @@ let append_user_message_once
         ?surface
         ?conversation_id
         ?external_message_id
+        ?workspace_id
         ?speaker
         ~mentions:(user_line_mentions ~extra_mentions content)
         ~delivery_key
@@ -1034,6 +1039,7 @@ let parse_line ~file_path (line : string) : chat_message option =
     in
     let conversation_id = opt_string "conversation_id" in
     let external_message_id = opt_string "external_message_id" in
+    let workspace_id = opt_string "workspace_id" in
     let speaker =
       let speaker_id = opt_string "speaker_id" in
       let speaker_name = opt_string "speaker_name" in
@@ -1239,7 +1245,8 @@ let parse_line ~file_path (line : string) : chat_message option =
           in
           Some
             { id; role; content; ts; attachments; tool_call_id; tool_call_name;
-              source; surface; conversation_id; external_message_id; speaker;
+              source; surface; conversation_id; external_message_id;
+              workspace_id; speaker;
               audio; blocks; mentions; kind; turn_ref; stream_lifecycle }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
@@ -1576,6 +1583,7 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                  | Some s -> [ ("surface", Surface_ref.to_json s) ])
               @ opt_string_field "conversation_id" m.conversation_id
               @ opt_string_field "external_message_id" m.external_message_id
+              @ opt_string_field "workspace_id" m.workspace_id
               @ speaker_fields m.speaker
               @ (match m.attachments with
                  | None | Some [] -> []

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -161,6 +161,11 @@ type chat_message = {
           to decode (reported as a persistence read drop, row kept). *)
   conversation_id : string option;
   external_message_id : string option;
+  workspace_id : string option;
+      (** The connector workspace (guild/team) identity from the typed
+          delivery. Written on connector-intake user lines; [None] on
+          workspace-less deliveries (e.g. Discord DM), rows written before
+          this field existed, and non-connector lines. *)
   speaker : speaker option;
       (** Present on user lines written since RFC-0223 P1; [None] on
           older lines, tool/assistant lines, and lines whose persisted
@@ -341,6 +346,7 @@ val append_user_message_once :
   ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?external_message_id:string ->
+  ?workspace_id:string ->
   ?speaker:speaker ->
   ?extra_mentions:Keeper_identity.Keeper_id.t list ->
   unit ->
@@ -383,7 +389,7 @@ val load_page :
 
 (** JSON array of messages. Entries without a timestamp omit the
     [ts] field; [tool_call_id] / [tool_call_name] / [source] /
-    [conversation_id] / [external_message_id] /
+    [conversation_id] / [external_message_id] / [workspace_id] /
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
     when present. When [base_dir] is supplied, the history endpoint marks
     audio clips as [expired] when the underlying MP3 file is gone. *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -156,6 +156,9 @@ let discord_delivery ~guild_id ~channel_id ~message_id ~author_id :
         { guild_id; channel_id; parent_channel_id; thread_id }
   ; conversation_id = Some (discord_conversation_id ~guild_id ~channel_id)
   ; external_message_id = Some message_id
+    (* The guild IS the workspace identity; a DM has none, which rides the
+       typed delivery as explicit absence ([None]), never an empty string. *)
+  ; workspace_id = guild_id
   }
 
 let record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
@@ -308,7 +311,11 @@ let accept_message_create ~resolved_binding ~dispatch_for_delivery
            P1); the snowflake stands in only for malformed payloads
            missing both — the gate contract requires a non-empty name,
            and the id fallback preserves the pre-P1 behavior. *)
-      ; channel_workspace_id = channel_id
+      ; channel_workspace_id = Option.value guild_id ~default:""
+        (* sound-partial: allow — [guild_id]=None is a DM (a known state,
+           not a parse failure), so the "" default at the stringly gate
+           layer is total, not permissive; the typed
+           [delivery.workspace_id] carries the explicit absence ([None]). *)
       ; keeper_name
       ; content
       ; idempotency_key = Printf.sprintf "discord-msg-%s" message_id

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -152,6 +152,10 @@ let slack_delivery ~team_id ~channel_id ~thread_ts ~reply_to_thread_ts ~user_id
   ; surface = Surface_ref.Slack { team_id; channel_id; thread_ts }
   ; conversation_id = Some (slack_conversation_id ~channel_id)
   ; external_message_id = Some ts
+    (* The team IS the workspace identity; when auth.test could not resolve
+       it, the typed delivery carries explicit absence ([None]), never an
+       empty string. *)
+  ; workspace_id = team_id
   }
 
 (* ---------------------------------------------------------------- *)
@@ -273,7 +277,12 @@ let accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id ~
            valid fallback when Slack omits [user_name] (a known case, mirroring
            the Discord gateway's id fallback). sound-partial: allow *)
       ; channel_user_name = Option.value user_name ~default:user_id
-      ; channel_workspace_id = channel_id
+      ; channel_workspace_id = Option.value team_id ~default:""
+        (* sound-partial: allow — [team_id]=None means auth.test could not
+           resolve the team (a known state, not a parse failure), so the ""
+           default at the stringly gate layer is total, not permissive; the
+           typed [delivery.workspace_id] carries the explicit absence
+           ([None]). *)
       ; keeper_name
       ; content = text
       ; idempotency_key = Printf.sprintf "slack-msg-%s" ts

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -71,13 +71,17 @@ let test_exact_source_identity_converges () =
                    }
              ; conversation_id = Some "discord:dm:channel:channel-exact"
              ; external_message_id = Some "source-123"
+               (* DM fixture: no guild, so the typed workspace identity is
+                  explicitly absent and the gate layer carries "" (the
+                  gateways wire [Option.value guild_id ~default:""]). *)
+             ; workspace_id = None
              }
            ~clock
            ~config
            ~channel:"discord"
            ~channel_user_id:"user-exact"
            ~channel_user_name:"Exact User"
-           ~channel_workspace_id:"channel-exact"
+           ~channel_workspace_id:""
            ~keeper_name
            ~idempotency_key:"discord-msg-source-123"
            ~metadata
@@ -139,8 +143,198 @@ let test_exact_source_identity_converges () =
          (snapshot.pending = [] && Int64.equal snapshot.terminal_count 1L))
 ;;
 
+let user_rows ~base ~keeper_name =
+  Keeper_chat_store.load ~base_dir:base ~keeper_name
+  |> List.filter (fun (message : Keeper_chat_store.chat_message) ->
+    match message.role with
+    | Keeper_chat_store.Role.User -> true
+    | Keeper_chat_store.Role.Assistant | Keeper_chat_store.Role.Tool -> false)
+;;
+
+let with_connector_env ~keeper_name f =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-connector-workspace-%d-%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let clock = Eio.Stdenv.clock env in
+       let config = Workspace.default_config base in
+       ignore (Workspace.init config ~agent_name:(Some keeper_name));
+       configure_queue ~base;
+       f ~base ~config ~clock)
+;;
+
+(* Mirrors the Discord leaf projection: guild messages carry the guild as the
+   typed workspace identity; DMs carry [None] (explicit typed absence). *)
+let connector_delivery ~message_id ~guild_id
+    : Gate_keeper_backend.connector_delivery =
+  { source =
+      Keeper_chat_queue.Discord { channel_id = "channel-ws"; user_id = "user-ws" }
+  ; surface =
+      Surface_ref.Discord
+        { guild_id
+        ; channel_id = "channel-ws"
+        ; parent_channel_id = None
+        ; thread_id = None
+        }
+  ; conversation_id =
+      Some
+        (match guild_id with
+         | Some guild -> Printf.sprintf "discord:%s:channel:channel-ws" guild
+         | None -> "discord:dm:channel:channel-ws")
+  ; external_message_id = Some message_id
+  ; workspace_id = guild_id
+  }
+;;
+
+let test_workspace_id_persists_roundtrip () =
+  Printf.printf
+    "Test: connector workspace identity persists on the durable chat row\n%!";
+  let keeper_name = "connector-workspace-roundtrip" in
+  with_connector_env ~keeper_name (fun ~base ~config ~clock ->
+    (match
+       Gate_keeper_backend.accept_connector
+         ~delivery:(connector_delivery ~message_id:"ws-1" ~guild_id:(Some "guild-7"))
+         ~clock
+         ~config
+         ~channel:"discord"
+         ~channel_user_id:"user-ws"
+         ~channel_user_name:"Workspace User"
+         ~channel_workspace_id:"guild-7"
+         ~keeper_name
+         ~idempotency_key:"discord-msg-ws-1"
+         ~metadata:[]
+         ~content:"workspace identity must persist"
+     with
+     | Gate_protocol.Reply _ -> check "guild delivery accepted" true
+     | Gate_protocol.Keeper_error_result detail ->
+       check (Printf.sprintf "guild delivery accepted (%s)" detail) false
+     | Gate_protocol.Unavailable_result ->
+       check "guild delivery accepted" false);
+    match user_rows ~base ~keeper_name with
+    | [ row ] ->
+      check
+        "persisted user row carries the typed workspace identity"
+        (row.Keeper_chat_store.workspace_id = Some "guild-7");
+      (match Keeper_chat_store.to_json_array [ row ] with
+       | `List [ `Assoc fields ] ->
+         check
+           "history projection carries workspace_id"
+           (List.assoc_opt "workspace_id" fields = Some (`String "guild-7"))
+       | _ -> check "history projection carries workspace_id" false)
+    | _ -> check "exactly one user row persisted" false)
+;;
+
+let test_workspace_id_conflict_fails_closed () =
+  Printf.printf
+    "Test: conflicting connector workspace identity fails closed\n%!";
+  let keeper_name = "connector-workspace-conflict" in
+  with_connector_env ~keeper_name (fun ~base ~config ~clock ->
+    let accept ~channel_workspace_id ~metadata ~idempotency_key =
+      Gate_keeper_backend.accept_connector
+        ~delivery:
+          (connector_delivery ~message_id:idempotency_key
+             ~guild_id:(Some "guild-7"))
+        ~clock
+        ~config
+        ~channel:"discord"
+        ~channel_user_id:"user-ws"
+        ~channel_user_name:"Workspace User"
+        ~channel_workspace_id
+        ~keeper_name
+        ~idempotency_key
+        ~metadata
+        ~content:"conflicting workspace must be rejected"
+    in
+    (match
+       accept
+         ~channel_workspace_id:"guild-7"
+         ~metadata:[ "workspace_id", "guild-9" ]
+         ~idempotency_key:"discord-msg-ws-conflict-meta"
+     with
+     | Gate_protocol.Keeper_error_result detail ->
+       check
+         "metadata workspace conflict fails closed"
+         (contains ~affix:"conflicts with metadata" detail)
+     | Gate_protocol.Reply _ | Gate_protocol.Unavailable_result ->
+       check "metadata workspace conflict fails closed" false);
+    (match
+       accept
+         ~channel_workspace_id:"guild-9"
+         ~metadata:[]
+         ~idempotency_key:"discord-msg-ws-conflict-gate"
+     with
+     | Gate_protocol.Keeper_error_result detail ->
+       check
+         "gate workspace conflict fails closed"
+         (contains ~affix:"workspace_id" detail)
+     | Gate_protocol.Reply _ | Gate_protocol.Unavailable_result ->
+       check "gate workspace conflict fails closed" false);
+    (match
+       accept
+         ~channel_workspace_id:""
+         ~metadata:[]
+         ~idempotency_key:"discord-msg-ws-conflict-omitted"
+     with
+     | Gate_protocol.Keeper_error_result detail ->
+       check
+         "gate omission with typed workspace fails closed"
+         (contains ~affix:"workspace_id" detail)
+     | Gate_protocol.Reply _ | Gate_protocol.Unavailable_result ->
+       check "gate omission with typed workspace fails closed" false);
+    check "no conflicting row persisted" (count_user_lines ~base = 0))
+;;
+
+let test_workspace_id_absent_is_explicit () =
+  Printf.printf
+    "Test: absent connector workspace identity persists as absent\n%!";
+  let keeper_name = "connector-workspace-absent" in
+  with_connector_env ~keeper_name (fun ~base ~config ~clock ->
+    (match
+       Gate_keeper_backend.accept_connector
+         ~delivery:(connector_delivery ~message_id:"dm-1" ~guild_id:None)
+         ~clock
+         ~config
+         ~channel:"discord"
+         ~channel_user_id:"user-ws"
+         ~channel_user_name:"Workspace User"
+         ~channel_workspace_id:""
+         ~keeper_name
+         ~idempotency_key:"discord-msg-dm-1"
+         ~metadata:[]
+         ~content:"dm without guild stays workspace-less"
+     with
+     | Gate_protocol.Reply _ -> check "workspace-less delivery accepted" true
+     | Gate_protocol.Keeper_error_result detail ->
+       check
+         (Printf.sprintf "workspace-less delivery accepted (%s)" detail)
+         false
+     | Gate_protocol.Unavailable_result ->
+       check "workspace-less delivery accepted" false);
+    match user_rows ~base ~keeper_name with
+    | [ row ] ->
+      check
+        "persisted row keeps the workspace explicitly absent"
+        (row.Keeper_chat_store.workspace_id = None)
+    | _ -> check "exactly one user row persisted" false)
+;;
+
 let () =
   test_exact_source_identity_converges ();
+  test_workspace_id_persists_roundtrip ();
+  test_workspace_id_conflict_fails_closed ();
+  test_workspace_id_absent_is_explicit ();
   (* For_testing.reset now requires an Eio context (main's idiom runs it via
      Switch.on_release inside the test); at process exit it is moot, so the
      toplevel call is dropped rather than leaking the effect. *)

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -59,6 +59,7 @@ let msg ~role ?(id = "test-msg") ?(ts = Some 1.0) ?(source = None) ?(speaker = N
   ; surface = None
   ; conversation_id = None
   ; external_message_id = None
+  ; workspace_id = None
   ; speaker
   ; audio
   ; blocks = None
@@ -208,6 +209,7 @@ let tool_line : Store.chat_message =
   ; surface = None
   ; conversation_id = None
   ; external_message_id = None
+  ; workspace_id = None
   ; speaker = None
   ; audio = None
   ; blocks = None

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -23,6 +23,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     surface = None;
     conversation_id = None;
     external_message_id = None;
+    workspace_id = None;
     speaker;
     audio = None;
     blocks = None;

--- a/test/test_server_discord_trigger_policy.ml
+++ b/test/test_server_discord_trigger_policy.ml
@@ -258,6 +258,7 @@ let test_durable_accept_precedes_delivery_handoff () =
              ; thread_id }
        ; conversation_id
        ; external_message_id
+       ; workspace_id
        } ->
      check string "Discord delivery channel" "C123" channel_id;
      check string "Discord delivery actor" "U123" user_id;
@@ -268,7 +269,9 @@ let test_durable_accept_precedes_delivery_handoff () =
      check (option string) "Discord conversation identity"
        (Some "discord:G123:channel:C123") conversation_id;
      check (option string) "Discord external event identity"
-       (Some "discord-exact-123") external_message_id
+       (Some "discord-exact-123") external_message_id;
+     check (option string) "Discord delivery workspace identity"
+       (Some "G123") workspace_id
    | Some _ -> fail "Discord leaf emitted another connector projection"
    | None -> fail "Discord leaf did not emit a delivery projection");
   let failure = Eio.Promise.await observed in

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -273,11 +273,14 @@ let test_bound_message_queues_exact_slack_ts () =
                  }
            ; conversation_id
            ; external_message_id
+           ; workspace_id
            } ->
          check string "Slack delivery channel" "C123" channel_id;
          check string "Slack delivery actor" "U123" user_id;
          check string "Slack delivery actor name" "operator" user_name;
          check (option string) "Slack delivery team" (Some "T123") team_id;
+         check (option string) "Slack delivery workspace identity"
+           (Some "T123") workspace_id;
          check (option string) "Slack reply thread"
            (Some "1710000000.123456") thread_ts;
          check string "Slack surface channel" "C123" surface_channel_id;


### PR DESCRIPTION
## 배경

Connector intake(`Gate_keeper_backend.accept_connector`)가 `channel_workspace_id`를 `ignore`로 버리고 있어 Discord guild / Slack team 정체성이 keeper chat 맥락에 도달하지 않았다. workspace는 공간 분리의 핵심 키다("각 공간은 분리해서 개념지어야 함").

## 변경

- **typed delivery**: `connector_delivery`에 `workspace_id : string option` 추가. Discord leaf는 `guild_id`, Slack leaf는 `team_id`를 싣는다. DM / auth.test 미해소 경로는 empty string이 아니라 명시적 typed 부재(`None`)로 흐른다.
- **intake fail-closed**: `accept_connector`가 typed workspace를 (1) gate-message `channel_workspace_id`(untyped, 부재="")와 (2) connector metadata `workspace_id`와 reconcile한다. 어느 한쪽이라도 불일치하면 `Keeper_error_result`로 명시 거부 — 기존 `conversation_id`/`external_message_id` metadata 충돌 규율(`reconcile_delivery_metadata`)과 동일한 discipline.
- **durable persist**: `Keeper_chat_store.chat_message`에 `workspace_id : string option` 추가 — JSONL encode/decode, `load` 왕복, history `to_json_array` projection까지 speaker와 같은 수준으로 보존. `append_user_message_once ?workspace_id`로 기록.
- **gateway 배선**: 두 leaf의 gate-message `channel_workspace_id`도 실제 guild/team을 싣도록 정정(기존에는 channel_id가 들어가 있었음 — accept_connector 경로에서는 ignore되어 영향 없었고, 이제 typed delivery와 fail-closed로 정합).

## 테스트 (TDD)

- `test_keeper_busy_connector_deferred.ml`: (a) guild workspace가 intake→durable row→history projection으로 왕복, (b) metadata 충돌 / gate-layer 충돌 / gate 부재+typed 존재 3종 fail-closed + 미기록 확인, (c) DM(typed 부재) 경로가 수용되고 row에 `None`으로 유지.
- `test_server_{discord,slack}_trigger_policy.ml`: leaf가 emit하는 delivery에 실제 guild/team이 workspace로 실리는지 어서션 추가.

## 검증

```
scripts/dune-local.sh build test/test_keeper_busy_connector_deferred.exe test/test_server_discord_trigger_policy.exe test/test_server_slack_trigger_policy.exe test/test_gate_keeper_backend.exe
```

- test_keeper_busy_connector_deferred: 20 checks 전부 ✓
- test_server_discord_trigger_policy: 12 tests OK
- test_server_slack_trigger_policy: 17 tests OK
- test_gate_keeper_backend: 98 tests OK
- (리베이스 후 재검증 동일)

## 발견 기록 (수정 범위 밖)

- `test_keeper_busy_dashboard_deferred.exe`의 "delegate failure carries the typed tool name" 실패는 origin/main pristine에서도 재현되는 선행 실패 → #25450으로 기록.
- 참고: gate-message `channel_workspace_id`가 실제 workspace로 바뀌면서 `Channel_gate_metrics`의 `workspace_id` 라벨 값이 channel_id → guild/team으로 정정된다(DM은 "").