### PR TITLE
fix(voice): surface broken voice config instead of silent model fallback

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -27,63 +27,78 @@ let audio_payload_fields ~audio_file ~audio_device =
   | _ -> []
 ;;
 
-let available_stt_endpoints () =
-  match load_voice_config () with
-  | Ok config ->
-    config.stt.endpoints |> List.filter (fun (ep : Voice_config.endpoint) -> ep.enabled)
-  | Error _ -> []
+let available_stt_endpoints (config : Voice_config.t) =
+  config.stt.endpoints |> List.filter (fun (ep : Voice_config.endpoint) -> ep.enabled)
 ;;
 
 let transcribe_audio ~audio_file ?language_code () =
-  let model =
-    match load_voice_config () with
-    | Ok config -> config.stt.default_model
-    | Error _ -> "scribe_v2"
-  in
-  let endpoints = available_stt_endpoints () in
-  let rec try_endpoints = function
-    | [] -> Error "no enabled STT endpoints configured"
-    | endpoint :: rest ->
-      (match transcribe_via_http_stt endpoint ~audio_file ~model with
-       | Ok json ->
-         let text =
-           Option.value
-             (Json_util.get_string json "text")
-             ~default:(Yojson.Safe.to_string json)
-         in
-         let lang =
-           match language_code with
-           | Some lc -> lc
-           | None ->
-             (match Json_util.get_string json "language_code" with
-              | Some lc -> lc
-              | None -> "unknown")
-         in
-         Ok
-           (`Assoc
-               [ "status", `String "transcribed"
-               ; "text", `String text
-               ; "language_code", `String lang
-               ; "endpoint_id", `String endpoint.id
-               ])
-       | Error _ when rest <> [] -> try_endpoints rest
-       | Error err -> Error err)
-  in
-  try_endpoints endpoints
+  match Voice_config.load_detailed () with
+  | Error (Voice_config.Invalid msg) ->
+    (* An explicit voice config exists but is broken: surface the
+       load failure instead of substituting a hardcoded model. *)
+    Error (Printf.sprintf "voice config load failed: %s" msg)
+  | Error Voice_config.Not_configured ->
+    (* Voice is not set up in this environment: STT is explicitly
+       disabled, which is not an error of the config itself. *)
+    Error "no enabled STT endpoints configured"
+  | Ok config ->
+    let model = config.stt.default_model in
+    let endpoints = available_stt_endpoints config in
+    let rec try_endpoints attempted = function
+      | [] ->
+        Error
+          (Printf.sprintf
+             "all enabled STT endpoints failed: %s"
+             (String.concat " | " (List.rev attempted)))
+      | endpoint :: rest ->
+        (match transcribe_via_http_stt endpoint ~audio_file ~model with
+         | Ok json ->
+           let text =
+             Option.value
+               (Json_util.get_string json "text")
+               ~default:(Yojson.Safe.to_string json)
+           in
+           let lang =
+             match language_code with
+             | Some lc -> lc
+             | None ->
+               (match Json_util.get_string json "language_code" with
+                | Some lc -> lc
+                | None -> "unknown")
+           in
+           Ok
+             (`Assoc
+                 [ "status", `String "transcribed"
+                 ; "text", `String text
+                 ; "language_code", `String lang
+                 ; "endpoint_id", `String endpoint.id
+                 ])
+         | Error error ->
+           let attempt = Printf.sprintf "%s: %s" endpoint.id error in
+           (if rest <> []
+            then
+              log_error
+                (Printf.sprintf
+                   "STT endpoint %s failed; trying next endpoint: %s"
+                   endpoint.id
+                   error));
+           try_endpoints (attempt :: attempted) rest)
+    in
+    if endpoints = []
+    then Error "no enabled STT endpoints configured"
+    else try_endpoints [] endpoints
 ;;
 
-let available_tts_endpoints ?provider () =
-  match load_voice_config () with
-  | Ok config -> Voice_runtime_overlay.select_endpoints ?provider config.tts.endpoints
-  | Error _ -> []
+let available_tts_endpoints ?provider (config : Voice_config.t) =
+  Voice_runtime_overlay.select_endpoints ?provider config.tts.endpoints
 ;;
 
 (** Synthesize a dashboard-playable MP3 via any HTTP TTS endpoint.
     This is used as a parallel fallback when the active transport is
     [Voice_mcp], which produces audio through a local/MCP path but does not
     write a browser-fetchable file. *)
-let try_http_tts_for_dashboard ~agent_id ~message ~voice ~model ~audio_device () =
-  let endpoints = available_tts_endpoints () in
+let try_http_tts_for_dashboard ~config ~agent_id ~message ~voice ~model ~audio_device () =
+  let endpoints = available_tts_endpoints config in
   let rec try_endpoint = function
     | [] -> None
     | endpoint :: rest ->
@@ -354,6 +369,7 @@ let attempt_tts_endpoint
       ~voice
       ~model
       ~priority
+      ~config
       ?audio_device
       endpoint
   =
@@ -472,6 +488,7 @@ let attempt_tts_endpoint
       let data =
         match
           try_http_tts_for_dashboard
+            ~config
             ~agent_id
             ~message
             ~voice
@@ -592,73 +609,87 @@ let agent_speak_json
       | _ -> None
     in
     cleanup_old_audio_files ();
-    let endpoints = available_tts_endpoints ?provider () in
-    let model =
-      match load_voice_config () with
-      | Ok config -> config.tts.default_model
-      | Error _ -> "eleven_multilingual_v2"
-    in
-    let rec try_endpoints attempted = function
-      | [] ->
-        Error
-          (Printf.sprintf
-             "all configured TTS endpoints failed: %s"
-             (String.concat " | " (List.rev attempted)))
-      | endpoint :: rest ->
-        (match
-           attempt_tts_endpoint
-             ~sw
-             ~clock
-             ~net
-             ~agent_id
-             ~message
-             ~voice
-             ~model
-             ~priority
-             ?audio_device
-             endpoint
-         with
-         | Ok _ as ok -> ok
-         | Error error ->
-           let attempt = Printf.sprintf "%s: %s" endpoint.id error in
-           try_endpoints (attempt :: attempted) rest)
-    in
-    if endpoints = []
-    then Error "no configured TTS endpoint"
-    else
-      match try_endpoints [] endpoints with
-      | Ok result when not (result_has_audio_file result) ->
-        (* The winning endpoint was [Voice_mcp]. Try a dashboard-playable
-           HTTP TTS clip in parallel so the dashboard has audio playback.
-           If no HTTP endpoint is available or all fail, the MCP result
-           still stands and the dashboard simply shows no audio player. *)
-        (match
-           try_http_tts_for_browser_audio
-             ~sw
-             ~clock
-             ~net
-             ~agent_id
-             ~message
-             ~voice
-             ~model
-             ~priority
-             ?audio_device
-             endpoints
-         with
-         | Some (audio_file, file_size) ->
-           log_info
-             (Printf.sprintf
-                "Voice MCP: synthesized parallel browser audio clip for agent=%s file=%s"
-                agent_id
-                audio_file);
-           Ok (merge_browser_audio_fields ~audio_file ~file_size ?audio_device result)
-         | None ->
-           log_info
-             (Printf.sprintf
-                "Voice MCP path used for agent=%s; no browser audio clip available (no HTTP TTS endpoint)."
-                agent_id);
-           Ok result)
-      | other -> other)
+    match Voice_config.load_detailed () with
+    | Error (Voice_config.Invalid msg) ->
+      (* An explicit voice config exists but is broken: surface the
+         load failure instead of substituting a hardcoded model. *)
+      Error (Printf.sprintf "voice config load failed: %s" msg)
+    | Error Voice_config.Not_configured ->
+      (* Voice is not set up in this environment: TTS is explicitly
+         disabled, which is not an error of the config itself. *)
+      Error "no configured TTS endpoint"
+    | Ok config ->
+      let endpoints = available_tts_endpoints ?provider config in
+      let model = config.tts.default_model in
+      let rec try_endpoints attempted = function
+        | [] ->
+          Error
+            (Printf.sprintf
+               "all configured TTS endpoints failed: %s"
+               (String.concat " | " (List.rev attempted)))
+        | endpoint :: rest ->
+          (match
+             attempt_tts_endpoint
+               ~sw
+               ~clock
+               ~net
+               ~agent_id
+               ~message
+               ~voice
+               ~model
+               ~priority
+               ~config
+               ?audio_device
+               endpoint
+           with
+           | Ok _ as ok -> ok
+           | Error error ->
+             let attempt = Printf.sprintf "%s: %s" endpoint.id error in
+             (if rest <> []
+              then
+                log_error
+                  (Printf.sprintf
+                     "TTS endpoint %s failed; trying next endpoint: %s"
+                     endpoint.id
+                     error));
+             try_endpoints (attempt :: attempted) rest)
+      in
+      if endpoints = []
+      then Error "no configured TTS endpoint"
+      else
+        match try_endpoints [] endpoints with
+        | Ok result when not (result_has_audio_file result) ->
+          (* The winning endpoint was [Voice_mcp]. Try a dashboard-playable
+             HTTP TTS clip in parallel so the dashboard has audio playback.
+             If no HTTP endpoint is available or all fail, the MCP result
+             still stands and the dashboard simply shows no audio player. *)
+          (match
+             try_http_tts_for_browser_audio
+               ~sw
+               ~clock
+               ~net
+               ~agent_id
+               ~message
+               ~voice
+               ~model
+               ~priority
+               ?audio_device
+               endpoints
+           with
+           | Some (audio_file, file_size) ->
+             log_info
+               (Printf.sprintf
+                  "Voice MCP: synthesized parallel browser audio clip for agent=%s file=%s"
+                  agent_id
+                  audio_file);
+             Ok (merge_browser_audio_fields ~audio_file ~file_size ?audio_device result)
+           | None ->
+             log_info
+               (Printf.sprintf
+                  "Voice MCP path used for agent=%s; no browser audio clip available (no HTTP TTS endpoint)."
+                  agent_id);
+             Ok result)
+        | other -> other)
 ;;
 
 let decode_agent_speak_result payload =

--- a/lib/voice/voice_bridge.mli
+++ b/lib/voice/voice_bridge.mli
@@ -41,6 +41,12 @@ val agent_speak :
     an invalid provider completion payload return [Error] so the caller — and
     the LLM driving it — sees the failure instead of a fake success.
 
+    Config-state semantics (no silent fallback): an explicit but broken
+    voice config surfaces its load error; when no voice config exists at
+    all, TTS is reported as explicitly disabled ([Error
+    "no configured TTS endpoint"]) instead of substituting a hardcoded
+    model name.
+
     This is the only speak path: the former fire-and-forget
     [enqueue_agent_speak] queue was removed after the 2026-06-10 voice
     repeat incident (schema promised blocking semantics while the
@@ -57,6 +63,12 @@ val transcribe_audio :
   ?language_code:string ->
   unit ->
   (Yojson.Safe.t, string) result
+(** Transcribe [audio_file] through the enabled STT endpoint chain.
+    A broken explicit voice config surfaces its load error; when no
+    voice config exists, STT is reported as explicitly disabled
+    ([Error "no enabled STT endpoints configured"]).  If every enabled
+    endpoint fails, the returned error names each attempted endpoint
+    and its failure. *)
 
 (** {1 Microphone record + transcribe} *)
 

--- a/lib/voice_config/dune
+++ b/lib/voice_config/dune
@@ -11,6 +11,7 @@
   yojson
   masc_log
   masc.config_dir_resolver
+  masc.fs_compat
   masc.masc_core
   masc.tool_types
   masc.config

--- a/lib/voice_config/voice_config.ml
+++ b/lib/voice_config/voice_config.ml
@@ -364,6 +364,10 @@ let parse_json json =
     TOML arrays-of-tables ([[\[voice.tts.endpoints\]]]) become JSON
     arrays of objects — matching what [parse_json] expects. *)
 
+type load_error =
+  | Not_configured
+  | Invalid of string
+
 let rec toml_to_json = function
   | Otoml.TomlInteger i -> `Int i
   | Otoml.TomlFloat f -> `Float f
@@ -393,60 +397,76 @@ let runtime_toml_path () : string option =
   else None
 
 (** Try loading voice config from the [\[voice\]] section of
-    runtime.toml.  Returns [Ok config] when the section exists
-    and parses cleanly.  Returns [Error _] when:
-    - no runtime.toml in config root (expected — fall back to JSON)
-    - no [\[voice\]] section (expected — fall back to JSON)
-    - TOML parse error in [\[voice\]] (unexpected — surfaced, NOT
-      silently swallowed, so the operator knows the TOML is broken) *)
+    runtime.toml.  Returns:
+    - [Ok (Some config)] when the section exists and parses cleanly;
+    - [Ok None] when runtime.toml or the [\[voice\]] section is
+      absent (expected — caller falls back to JSON);
+    - [Error _] when the section exists but is broken (TOML parse
+      error, read failure, or schema error) — surfaced to the
+      caller, NOT silently swallowed, so the operator knows the
+      TOML is broken. *)
 let load_from_runtime_toml () =
   match runtime_toml_path () with
-  | None -> Error "no runtime.toml in config root"
-  | Some path ->
+  | None -> Ok None
+  | Some path -> (
     try
       let toml = Otoml.Parser.from_file path in
-      (match Otoml.find_opt toml Fun.id [ "voice" ] with
-       | None -> Error "no [voice] section in runtime.toml"
-       | Some _ ->
-         (* Fun.id returns the raw Otoml.t value; toml_to_json
-            pattern-matches on its constructors. *)
-         let voice_value =
-           match Otoml.find_opt toml Fun.id [ "voice" ] with
-           | Some v -> v
-           | None -> Otoml.TomlTable []
-         in
-         let json = toml_to_json voice_value in
-         parse_json json)
+      match Otoml.find_opt toml Fun.id [ "voice" ] with
+      | None -> Ok None
+      | Some voice_value -> (
+        (* Fun.id returns the raw Otoml.t value; toml_to_json
+           pattern-matches on its constructors. *)
+        match parse_json (toml_to_json voice_value) with
+        | Ok config -> Ok (Some config)
+        | Error msg -> Error (Printf.sprintf "runtime.toml [voice]: %s" msg))
     with
     | Otoml.Parse_error (_, msg) ->
-        Error (Printf.sprintf "runtime.toml parse error: %s" msg)
+      Error (Printf.sprintf "runtime.toml parse error: %s" msg)
     | Sys_error msg ->
-        Error (Printf.sprintf "runtime.toml read failed: %s" msg)
+      Error (Printf.sprintf "runtime.toml read failed: %s" msg))
 
-let load () =
+let load_detailed () =
   (* Prefer runtime.toml [voice] section over standalone JSON.
      Only fall back when the file or section is absent — TOML
      parse errors are surfaced to the operator. *)
   match load_from_runtime_toml () with
-  | Ok config -> Ok config
-  | Error msg ->
-    Log.Runtime.info
-      "voice_config: falling back to JSON (%s)" msg;
+  | Ok (Some config) -> Ok config
+  | Error msg -> Error (Invalid msg)
+  | Ok None -> (
     let path = config_path () in
-    if not (Sys.file_exists path) then
-      Error (Printf.sprintf "voice config missing at %s" path)
+    if not (Sys.file_exists path)
+    then Error Not_configured
     else
-      try
-        let json = Safe_ops.read_json_eio path in
-        parse_json json
-      with
-      | Yojson.Json_error error ->
-          Error (Printf.sprintf "invalid voice config json: %s" error)
-      | Sys_error error ->
+      match
+        try Ok (Fs_compat.load_file path) with
+        | Sys_error error ->
           Error (Printf.sprintf "voice config read failed: %s" error)
-      | Eio.Io _ as exn ->
-          Error (Printf.sprintf "voice config Eio read failed: %s"
-                   (Printexc.to_string exn))
+        | Eio.Io _ as exn ->
+          Error
+            (Printf.sprintf
+               "voice config Eio read failed: %s"
+               (Printexc.to_string exn))
+      with
+      | Error msg -> Error (Invalid msg)
+      | Ok content -> (
+        (* parse via parse_json_safe (keeps the UTF-8 repair pass) but
+           keep the Error — read_json_eio would swallow a syntax error
+           into a warn-log plus an empty object that then fails schema
+           parsing with a misleading "must be object" message. *)
+        match Safe_ops.parse_json_safe ~context:path content with
+        | Error msg ->
+          Error (Invalid (Printf.sprintf "invalid voice config json: %s" msg))
+        | Ok json -> (
+          match parse_json json with
+          | Ok config -> Ok config
+          | Error msg -> Error (Invalid msg))))
+
+let load () =
+  match load_detailed () with
+  | Ok config -> Ok config
+  | Error Not_configured ->
+    Error (Printf.sprintf "voice config missing at %s" (config_path ()))
+  | Error (Invalid msg) -> Error msg
 
 let enabled_endpoints (endpoints : endpoint list) =
   List.filter (fun (endpoint : endpoint) -> endpoint.enabled) endpoints

--- a/lib/voice_config/voice_config.mli
+++ b/lib/voice_config/voice_config.mli
@@ -125,7 +125,35 @@ val load : unit -> (t, string) result
 
     Returns [Error _] when no candidate exists or JSON parsing
     fails.  Pinned at the contract seam — operators see one of
-    these 3 paths in the error message. *)
+    these 3 paths in the error message.
+
+    A broken [\[voice\]] section in runtime.toml is surfaced as an
+    error, not silently traded for the JSON fallback.  A syntactically
+    invalid [voice_config.json] reports the actual parse error
+    (["invalid voice config json: ..."]) instead of degrading to a
+    downstream schema error on an empty object.  Implemented on top
+    of {!load_detailed}; kept for callers that only need the legacy
+    string error. *)
+
+(** {1 Typed load status} *)
+
+type load_error =
+  | Not_configured
+      (** No [\[voice\]] section in runtime.toml and no
+          [voice_config.json] candidate exists: voice is simply not
+          set up in this environment.  Callers treat this as
+          "voice disabled", not as a failure. *)
+  | Invalid of string
+      (** A voice config source exists but could not be read or
+          parsed; the string names the source and the reason.
+          Callers must surface this to the operator instead of
+          substituting defaults. *)
+
+val load_detailed : unit -> (t, load_error) result
+(** [load_detailed ()] distinguishes "voice is not configured"
+    ({!Not_configured}) from "an explicit config exists but is
+    broken" ({!Invalid}), which {!load} conflates in a single
+    error string. *)
 
 (** {1 Endpoint selection} *)
 

--- a/test/test_voice_config.ml
+++ b/test/test_voice_config.ml
@@ -56,6 +56,102 @@ let parse json_str =
   let json = Yojson.Safe.from_string json_str in
   Vc.parse_json json
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 then true
+  else
+    let rec loop idx =
+      idx + needle_len <= haystack_len
+      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
+    in
+    loop 0
+
+let rec mkdir_p path =
+  if path <> "" && not (Sys.file_exists path) then begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+(** Point MASC_BASE_PATH at a fresh empty dir so no runtime.toml
+    [voice] section and no voice_config.json exist. *)
+let with_unconfigured_voice f =
+  with_temp_dir "voice-config-load-" @@ fun root ->
+  with_env "MASC_BASE_PATH" (Some root) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" (Some root) @@ f
+
+(** Like {!with_unconfigured_voice} but with [contents] written to the
+    resolved voice_config.json path (an explicit configuration). *)
+let with_explicit_voice_config contents f =
+  with_unconfigured_voice (fun () ->
+    let path = Vc.config_path () in
+    mkdir_p (Filename.dirname path);
+    write_file path contents;
+    f ())
+
+let test_load_detailed_not_configured () =
+  with_unconfigured_voice (fun () ->
+    match Vc.load_detailed () with
+    | Error Vc.Not_configured -> ()
+    | Error (Vc.Invalid msg) ->
+      fail (Printf.sprintf "expected Not_configured, got Invalid: %s" msg)
+    | Ok _ -> fail "expected Not_configured, got Ok")
+
+let test_load_detailed_invalid_json () =
+  with_explicit_voice_config "{ this is not json" (fun () ->
+    match Vc.load_detailed () with
+    | Error (Vc.Invalid msg) ->
+      check bool "json syntax error surfaced" true
+        (contains_substring ~needle:"invalid voice config json" msg)
+    | Error Vc.Not_configured ->
+      fail "expected Invalid, got Not_configured"
+    | Ok _ -> fail "expected Invalid, got Ok")
+
+let test_load_detailed_schema_error_is_invalid () =
+  with_explicit_voice_config {|{"tts": {"default_model": "m"}}|} (fun () ->
+    match Vc.load_detailed () with
+    | Error (Vc.Invalid msg) ->
+      check bool "schema error surfaced" true
+        (contains_substring ~needle:"required" msg)
+    | Error Vc.Not_configured ->
+      fail "expected Invalid, got Not_configured"
+    | Ok _ -> fail "expected Invalid, got Ok")
+
+let test_load_detailed_valid_config () =
+  with_explicit_voice_config (minimal_config_json ~session_endpoints:"[]")
+    (fun () ->
+      match Vc.load_detailed () with
+      | Ok config ->
+        check string "stt model from config" "scribe_v1"
+          config.stt.default_model
+      | Error Vc.Not_configured ->
+        fail "expected Ok, got Not_configured"
+      | Error (Vc.Invalid msg) ->
+        fail (Printf.sprintf "expected Ok, got Invalid: %s" msg))
+
+(* [load ()] keeps its legacy error strings on top of [load_detailed]:
+   unconfigured reads as "missing", a broken explicit config surfaces
+   the parse error instead of falling through to a default. *)
+let test_load_legacy_strings_preserved () =
+  with_unconfigured_voice (fun () ->
+    match Vc.load () with
+    | Error msg ->
+      check bool "missing reported" true
+        (contains_substring ~needle:"voice config missing at" msg)
+    | Ok _ -> fail "expected missing-config Error, got Ok");
+  with_explicit_voice_config "{ this is not json" (fun () ->
+    match Vc.load () with
+    | Error msg ->
+      check bool "json error surfaced" true
+        (contains_substring ~needle:"invalid voice config json" msg)
+    | Ok _ -> fail "expected invalid-config Error, got Ok")
+
 let test_session_empty_endpoints_ok () =
   let json = minimal_config_json ~session_endpoints:"[]" in
   match parse json with
@@ -133,6 +229,19 @@ let test_config_path_survives_deleted_cwd_without_base () =
 let () =
   Alcotest.run "voice_config"
     [
+      ( "load_detailed",
+        [
+          test_case "unconfigured is Not_configured"
+            `Quick test_load_detailed_not_configured;
+          test_case "broken json is Invalid"
+            `Quick test_load_detailed_invalid_json;
+          test_case "schema error is Invalid"
+            `Quick test_load_detailed_schema_error_is_invalid;
+          test_case "valid config loads"
+            `Quick test_load_detailed_valid_config;
+          test_case "legacy load strings preserved"
+            `Quick test_load_legacy_strings_preserved;
+        ] );
       ( "session_endpoints",
         [
           test_case "empty session endpoints parses ok"

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -840,6 +840,219 @@ let test_playback_timeout_parsers_and_budget () =
     (Voice_bridge_core.playback_timeout_sec_for ~duration_sec:None)
 ;;
 
+(* No-silent-fallback contract for voice config loading:
+   - an explicit but broken config surfaces a typed load failure
+     (never proceeds with a hardcoded model name);
+   - no config at all means voice is explicitly disabled, reported
+     through the pre-existing "no ... endpoint" terminals;
+   - endpoint failover keeps every attempt observable. *)
+let remove_voice_config_file () =
+  let path = Voice_config.config_path () in
+  if Sys.file_exists path then Sys.remove path
+;;
+
+let with_voice_config_file contents f =
+  let path = Voice_config.config_path () in
+  mkdir_if_missing (Filename.dirname path);
+  write_file path contents;
+  Fun.protect ~finally:remove_voice_config_file f
+;;
+
+let broken_config_json = "{ this is not json"
+
+(* Valid config whose TTS/STT endpoints all fail deterministically without
+   network: the API key env var is unset in the test process. *)
+let failover_config_json =
+  {|
+{
+  "tts": {
+    "default_model": "test-tts-model",
+    "default_voice": "test-voice",
+    "endpoints": [
+      { "id": "tts-a", "kind": "elevenlabs_direct",
+        "api_key_env": "MASC_VOICE_TEST_UNSET_KEY", "enabled": true },
+      { "id": "tts-b", "kind": "elevenlabs_direct",
+        "api_key_env": "MASC_VOICE_TEST_UNSET_KEY", "enabled": true }
+    ]
+  },
+  "stt": {
+    "default_model": "test-stt-model",
+    "endpoints": [
+      { "id": "stt-a", "kind": "elevenlabs_direct",
+        "api_key_env": "MASC_VOICE_TEST_UNSET_KEY", "enabled": true },
+      { "id": "stt-b", "kind": "elevenlabs_direct",
+        "api_key_env": "MASC_VOICE_TEST_UNSET_KEY", "enabled": true }
+    ]
+  },
+  "session": {
+    "endpoints": []
+  }
+}
+|}
+;;
+
+let test_transcribe_invalid_config_surfaces_load_failure () =
+  with_voice_config_file broken_config_json (fun () ->
+    match
+      Masc.Voice_bridge.transcribe_audio ~audio_file:"/tmp/masc-voice-noaudio.wav" ()
+    with
+    | Ok _ -> fail "expected typed config failure, got Ok"
+    | Error msg ->
+      check
+        bool
+        "broken config surfaces load failure"
+        true
+        (String_util.contains_substring msg "voice config load failed");
+      check
+        bool
+        "does not masquerade as unconfigured"
+        false
+        (String_util.contains_substring msg "no enabled STT endpoints configured");
+      check
+        bool
+        "does not proceed with hardcoded scribe model"
+        false
+        (String_util.contains_substring msg "scribe"))
+;;
+
+let test_transcribe_unconfigured_is_explicitly_disabled () =
+  remove_voice_config_file ();
+  match
+    Masc.Voice_bridge.transcribe_audio ~audio_file:"/tmp/masc-voice-noaudio.wav" ()
+  with
+  | Ok _ -> fail "expected explicit disabled error, got Ok"
+  | Error msg ->
+    check
+      string
+      "STT explicitly disabled when voice is not configured"
+      "no enabled STT endpoints configured"
+      msg
+;;
+
+let test_transcribe_endpoint_failover_surfaces_each_attempt () =
+  with_voice_config_file failover_config_json (fun () ->
+    with_env "MASC_VOICE_TEST_UNSET_KEY" None (fun () ->
+      match
+        Masc.Voice_bridge.transcribe_audio ~audio_file:"/tmp/masc-voice-noaudio.wav" ()
+      with
+      | Ok _ -> fail "expected aggregate endpoint failure, got Ok"
+      | Error msg ->
+        check
+          bool
+          "aggregate failure reported"
+          true
+          (String_util.contains_substring msg "all enabled STT endpoints failed");
+        check
+          bool
+          "first endpoint attempt visible"
+          true
+          (String_util.contains_substring msg "stt-a:");
+        check
+          bool
+          "second endpoint attempt visible"
+          true
+          (String_util.contains_substring msg "stt-b:")))
+;;
+
+let test_agent_speak_invalid_config_surfaces_load_failure () =
+  with_voice_config_file broken_config_json (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let clock = Eio.Stdenv.clock env in
+    (match
+       Masc.Voice_bridge.agent_speak
+         ~sw
+         ~clock
+         ~net
+         ~agent_id:"voice-config-test"
+         ~message:"invalid config must surface"
+         ()
+     with
+     | Ok _ -> fail "expected typed config failure, got Ok"
+     | Error msg ->
+       check
+         bool
+         "broken config surfaces load failure"
+         true
+         (String_util.contains_substring msg "voice config load failed");
+       check
+         bool
+         "does not masquerade as unconfigured"
+         false
+         (String_util.contains_substring msg "no configured TTS endpoint");
+       check
+         bool
+         "does not proceed with hardcoded elevenlabs model"
+         false
+         (String_util.contains_substring msg "eleven_multilingual")))
+;;
+
+let test_agent_speak_unconfigured_is_explicitly_disabled () =
+  remove_voice_config_file ();
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  match
+    Masc.Voice_bridge.agent_speak
+      ~sw
+      ~clock
+      ~net
+      ~agent_id:"voice-config-test"
+      ~message:"unconfigured voice is explicitly disabled"
+      ()
+  with
+  | Ok _ -> fail "expected explicit disabled error, got Ok"
+  | Error msg ->
+    check
+      string
+      "TTS explicitly disabled when voice is not configured"
+      "no configured TTS endpoint"
+      msg
+;;
+
+let test_agent_speak_endpoint_failover_surfaces_each_attempt () =
+  with_voice_config_file failover_config_json (fun () ->
+    with_env "MASC_VOICE_TEST_UNSET_KEY" None (fun () ->
+      Eio_main.run
+      @@ fun env ->
+      Eio.Switch.run
+      @@ fun sw ->
+      let net = Eio.Stdenv.net env in
+      let clock = Eio.Stdenv.clock env in
+      match
+        Masc.Voice_bridge.agent_speak
+          ~sw
+          ~clock
+          ~net
+          ~agent_id:"voice-config-test"
+          ~message:"failover attempts stay visible"
+          ()
+      with
+      | Ok _ -> fail "expected aggregate endpoint failure, got Ok"
+      | Error msg ->
+        check
+          bool
+          "aggregate failure reported"
+          true
+          (String_util.contains_substring msg "all configured TTS endpoints failed");
+        check
+          bool
+          "first endpoint attempt visible"
+          true
+          (String_util.contains_substring msg "tts-a:");
+        check
+          bool
+          "second endpoint attempt visible"
+          true
+          (String_util.contains_substring msg "tts-b:")))
+;;
+
 let write_local_playback_config () =
   let config_path = Voice_config.config_path () in
   mkdir_if_missing (Filename.dirname config_path);
@@ -955,6 +1168,32 @@ let () =
             "tts request elevenlabs rejects unknown name"
             `Quick
             test_tts_request_elevenlabs_rejects_unknown_name
+        ] )
+    ; ( "voice_config_state"
+      , [ test_case
+            "transcribe invalid config surfaces load failure"
+            `Quick
+            test_transcribe_invalid_config_surfaces_load_failure
+        ; test_case
+            "transcribe unconfigured is explicitly disabled"
+            `Quick
+            test_transcribe_unconfigured_is_explicitly_disabled
+        ; test_case
+            "transcribe failover surfaces each attempt"
+            `Quick
+            test_transcribe_endpoint_failover_surfaces_each_attempt
+        ; test_case
+            "agent_speak invalid config surfaces load failure"
+            `Quick
+            test_agent_speak_invalid_config_surfaces_load_failure
+        ; test_case
+            "agent_speak unconfigured is explicitly disabled"
+            `Quick
+            test_agent_speak_unconfigured_is_explicitly_disabled
+        ; test_case
+            "agent_speak failover surfaces each attempt"
+            `Quick
+            test_agent_speak_endpoint_failover_surfaces_each_attempt
         ] )
     ; ( "keeper_voice_speak"
       , [ test_case


### PR DESCRIPTION
## What

`Voice_bridge` used to swallow voice-config load failures and silently substitute hardcoded model names (`"scribe_v2"` in `transcribe_audio`, `"eleven_multilingual_v2"` in `agent_speak_json`). Because the endpoint list also collapsed to `[]` on the same swallowed `Error _`, a **broken** config was misreported as `no configured TTS endpoint` — a broken explicit config was indistinguishable from voice never having been set up, and STT endpoint failover dropped every intermediate error, surfacing only the last endpoint's failure.

This PR makes the config state explicit and keeps the failures observable:

- **`Voice_config.load_detailed`** (new, typed) classifies the load into `Not_configured` vs `Invalid of string` instead of conflating both into one error string.
- **Not configured** (no `[voice]` section in runtime.toml *and* no `voice_config.json`): voice is **explicitly disabled** — the pre-existing terminals `no configured TTS endpoint` / `no enabled STT endpoints configured` are kept byte-for-byte (the TTS one is pinned by `test_keeper_voice_speak_surfaces_tts_failure`, the STT one is documented in RFC-0236). This case is not an error.
- **Configured but broken**: the load failure is surfaced to the caller as `voice config load failed: <reason>`. The hardcoded model-name fallbacks are deleted — no silent proceed.
- **Endpoint failover**: the STT path now accumulates every attempt like the TTS path already did (`all enabled STT endpoints failed: id: err | ...`), and both paths log intermediate failures, so an all-endpoints failure names each endpoint and its error.

## Adjacent swallows fixed under the same principle

- A broken `[voice]` section in `runtime.toml` no longer falls back to JSON silently — the TOML error is surfaced, matching the contract already documented on `load ()` ("Only fall back when the file or section is absent"). `load ()` keeps its legacy error strings otherwise (implemented on top of `load_detailed`).
- A syntactically invalid `voice_config.json` now reports the actual parse error (`invalid voice config json: ...`, the message the old code intended but never reached) instead of degrading through `Safe_ops.read_json_eio`'s empty-object swallow into a misleading `root.tts must be object` schema error.

## How the unset/broken distinction was made

`load_from_runtime_toml` now returns `Ok None` (absent), `Ok (Some config)`, or `Error _` (broken); `load_detailed` maps JSON-file-missing to `Not_configured` and any read/parse/schema failure of an existing source to `Invalid`. The bridge matches on the typed constructors — no error-message string matching anywhere.

## Test plan

- `test/test_voice_config.ml` (+5): `load_detailed` state classification — unconfigured → `Not_configured`, broken JSON → `Invalid` with parse error, schema error → `Invalid`, valid → `Ok`, and legacy `load ()` strings preserved.
- `test/test_voice_runtime_overlay.ml` (+6, group `voice_config_state`): broken config surfaces `voice config load failed` for both `transcribe_audio` and `agent_speak` and does **not** masquerade as unconfigured or proceed with the hardcoded models; unconfigured → explicit disabled terminals; two always-failing endpoints (deterministic via unset `api_key_env`, no network) → aggregate error names **both** attempts.
- Deterministic endpoint failures use an unset API-key env var, so tests need no network and no real credentials.

## Verification (local, focused targets only)

- `scripts/dune-local.sh build test/test_voice_runtime_overlay.exe test/test_voice_config.exe test/test_env_config_voice_bridge_timeouts.exe` — clean
- `test_voice_config.exe` — 11/11 pass
- `test_voice_runtime_overlay.exe` — 28/28 pass (incl. pre-existing keeper_voice_speak / playback groups, no regressions)
- `test_env_config_voice_bridge_timeouts.exe` — 4/4 pass

Red evidence: against the old code, `transcribe invalid config` returned `no enabled STT endpoints configured` (masquerade) and STT failover returned only the last endpoint's error — both asserted-against behaviors; `load_detailed` did not exist (compile-red).

## Notes / follow-ups (out of scope, unchanged)

- `Voice_bridge_core.agent_voices` / `tuning_for_agent` / `default_voice` and `Voice_bridge.get_agent_voice` still fall back to overlay defaults / `"Sarah"` on config load failure (same anti-pattern, outside the audited call sites). Worth a follow-up issue.
