### PR TITLE
refactor(keeper): drop 26 unreferenced constants, and teach the audit about facade re-exports

### DIFF
--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
@@ -21,22 +21,16 @@ let label_callback = "callback"
 let label_tool = "tool"
 let label_source = "source"
 let label_alias = "alias"
-let label_surface = "surface"
 let label_shape = "shape"
 let label_model = "model"
 let label_provider = "provider"
-let label_provider_kind = "provider_kind"
 let label_status = "status"
 let label_site = "site"
 let label_reason = "reason"
 let label_outcome = "outcome"
 let label_stop_reason = "stop_reason"
 let label_keeper_name = "keeper_name"
-let label_channel = "channel"
-
-(** JSON field-key constants used across keeper_hooks_oas.ml. *)
 let key_agent = "agent"
-let key_task_id = "task_id"
 let key_input_tokens = "input_tokens"
 let key_output_tokens = "output_tokens"
 let key_cost_usd = "cost_usd"
@@ -45,15 +39,6 @@ let key_cost_status_reason = "cost_status_reason"
 let key_cost_usd_source = "cost_usd_source"
 let key_usage_missing = "usage_missing"
 let key_timestamp = "timestamp"
-let key_reasoning_tokens = "reasoning_tokens"
-let key_cache_n = "cache_n"
-let key_prompt_per_second = "prompt_per_second"
-let key_provider_tokens_per_second = "provider_tokens_per_second"
-let key_hw_decode_tokens_per_second = "hw_decode_tokens_per_second"
-let key_peak_memory_gb = "peak_memory_gb"
-let key_request_latency_ms = "request_latency_ms"
-let key_tokens_per_second = "tokens_per_second"
-let key_status = "status"
 let key_reason = "reason"
 let key_provider = "provider"
 let key_model = "model"
@@ -71,17 +56,7 @@ let key_name = "name"
 let key_generation = "generation"
 let key_active = "active"
 let key_via = "via"
-let key_route_via = "route_via"
-let key_metric_event = "metric_event"
-let key_agent_name = "agent_name"
-let key_tool_name = "tool_name"
 let key_tool_call_count = "tool_call_count"
-let key_tools_used = "tools_used"
-let key_duration_ms = "duration_ms"
-let key_channel = "channel"
-let key_error = "error"
-
-(** Callback name labels used as Otel_metric_store + log identifiers. *)
 let callback_label_after_turn_sse_broadcast = "after_turn_sse_broadcast"
 let callback_label_post_tool_log_write = "post_tool_log_write"
 let callback_label_on_tool_executed = "on_tool_executed"
@@ -241,17 +216,6 @@ let current_keeper_model _meta =
   runtime_lane_label
 
 let stop_reason_to_label = Agent_sdk.Types.stop_reason_to_metric_label
-let stop_reason_label_end_turn = stop_reason_to_label Agent_sdk.Types.EndTurn
-let stop_reason_label_tool_use = stop_reason_to_label Agent_sdk.Types.StopToolUse
-let stop_reason_label_max_tokens = stop_reason_to_label Agent_sdk.Types.MaxTokens
-let stop_reason_label_stop_sequence =
-  stop_reason_to_label Agent_sdk.Types.StopSequence
-
-let stop_reason_label_unknown =
-  stop_reason_to_label (Agent_sdk.Types.Unknown "")
-
-(* F4 canonical projection consumption: delegate to OAS instead of re-spelling
-   the api_usage record literal (SSOT — OAS owns the zero marker). *)
 let zero_usage = Agent_sdk.Types.zero_api_usage
 
 let telemetry_has_canonical_model_id

--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.mli
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.mli
@@ -13,22 +13,18 @@ val label_callback : string
 val label_tool : string
 val label_source : string
 val label_alias : string
-val label_surface : string
 val label_shape : string
 val label_model : string
 val label_provider : string
-val label_provider_kind : string
 val label_status : string
 val label_site : string
 val label_reason : string
 val label_outcome : string
 val label_stop_reason : string
 val label_keeper_name : string
-val label_channel : string
 
 (** JSON field-key string constants used across keeper_hooks_oas.ml. *)
 val key_agent : string
-val key_task_id : string
 val key_input_tokens : string
 val key_output_tokens : string
 val key_cost_usd : string
@@ -37,15 +33,6 @@ val key_cost_status_reason : string
 val key_cost_usd_source : string
 val key_usage_missing : string
 val key_timestamp : string
-val key_reasoning_tokens : string
-val key_cache_n : string
-val key_prompt_per_second : string
-val key_provider_tokens_per_second : string
-val key_hw_decode_tokens_per_second : string
-val key_peak_memory_gb : string
-val key_request_latency_ms : string
-val key_tokens_per_second : string
-val key_status : string
 val key_reason : string
 val key_provider : string
 val key_model : string
@@ -62,15 +49,7 @@ val key_name : string
 val key_generation : string
 val key_active : string
 val key_via : string
-val key_route_via : string
-val key_metric_event : string
-val key_agent_name : string
-val key_tool_name : string
 val key_tool_call_count : string
-val key_tools_used : string
-val key_duration_ms : string
-val key_channel : string
-val key_error : string
 val key_ts : string
 
 (** Callback name labels used as Otel_metric_store + log identifiers. *)
@@ -165,14 +144,6 @@ val usage_has_tokens : Agent_sdk.Types.api_usage -> bool
 val current_keeper_model : 'a -> string
 (** Neutral runtime lane used for keeper-facing tool-call telemetry.
     Concrete provider/model identity is OAS-owned. *)
-
-(** Internal: stop-reason string labels exposed for keeper_hooks_oas.ml
-    consumers that emit them across multiple call sites. *)
-val stop_reason_label_end_turn : string
-val stop_reason_label_tool_use : string
-val stop_reason_label_max_tokens : string
-val stop_reason_label_stop_sequence : string
-val stop_reason_label_unknown : string
 
 val stop_reason_to_label : Agent_sdk.Types.stop_reason -> string
 (** Canonical telemetry/metric label for an OAS stop reason.  Delegates to

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -69,6 +69,8 @@ class DeadExport(TypedDict):
     name: str
     module: str
     mli: str
+    # Facades republishing this module's whole signature; empty when none do.
+    reexported_by: list[str]
 
 
 def is_skipped(rel: Path) -> bool:
@@ -184,6 +186,7 @@ def find_dead_exports(root: Path, min_name_len: int) -> list[DeadExport]:
         for token in set(TOKEN_RE.findall(text)) & wanted:
             seen[token].add(path)
 
+    republished = reexporting_modules(root)
     dead: list[DeadExport] = []
     for name, declared in owners.items():
         if len(declared) > 1:
@@ -194,8 +197,54 @@ def find_dead_exports(root: Path, min_name_len: int) -> list[DeadExport]:
         pair = {mli, mli.with_suffix(".ml")}
         if seen.get(name, set()) - pair:
             continue
-        dead.append({"name": name, "module": module, "mli": str(mli.relative_to(root))})
+        dead.append({
+            "name": name,
+            "module": module,
+            "mli": str(mli.relative_to(root)),
+            "reexported_by": sorted(republished.get(module, [])),
+        })
     return sorted(dead, key=lambda d: (d["module"], d["name"]))
+
+
+def reexporting_modules(root: Path) -> dict[str, list[str]]:
+    """Module -> the modules that republish its whole signature.
+
+    Three shapes republish a module wholesale without ever naming the values
+    they carry, so a token scan cannot see them:
+
+        include module type of Foo          (in a .mli)
+        module Bar = Foo                    (in a .mli -- a signature alias)
+        include Foo                         (in a .ml, when the .mli also
+                                             republishes the signature)
+
+    Adversarial review of an earlier run of this audit found every one of its
+    28 false positives here: values with no call site anywhere, still exposed
+    through a facade's published signature. Deleting one of those means editing
+    the facade too, which makes it a different change from deleting a value
+    nothing can reach.
+    """
+    by_source: dict[str, list[str]] = defaultdict(list)
+    patterns = (
+        re.compile(r"include\s+module\s+type\s+of\s+(?:struct\s+include\s+)?([A-Z][A-Za-z0-9_]*)"),
+        re.compile(r"^\s*module\s+[A-Z][A-Za-z0-9_]*\s*=\s*([A-Z][A-Za-z0-9_]*)\s*$", re.M),
+        re.compile(r"^\s*include\s+([A-Z][A-Za-z0-9_]*)\s*$", re.M),
+    )
+    for base in SOURCE_ROOTS:
+        directory = root / base
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.ml*")):
+            if path.suffix not in (".ml", ".mli") or is_skipped(path.relative_to(root)):
+                continue
+            text = read_text(path)
+            facade = path.stem
+            for pattern in patterns:
+                for match in pattern.finditer(text):
+                    source = match.group(1)
+                    source_module = source[0].lower() + source[1:]
+                    if source_module != facade and facade not in by_source[source_module]:
+                        by_source[source_module].append(facade)
+    return dict(by_source)
 
 
 def find_orphan_stanzas(root: Path) -> list[str]:
@@ -258,6 +307,21 @@ def run_self_test() -> int:
         if "used_entry_helper" in dead_exports:
             failures.append("token reference from a test not counted")
 
+        # A value republished through a facade's signature must be flagged as
+        # such: nothing calls it, but deleting it means editing the facade.
+        (root / "lib" / "leaf_surface.mli").write_text("val republished_helper : unit -> int\n")
+        (root / "lib" / "leaf_surface.ml").write_text("let republished_helper () = 0\n")
+        (root / "lib" / "facade_surface.ml").write_text("include Leaf_surface\n")
+        (root / "lib" / "facade_surface.mli").write_text(
+            "include module type of Leaf_surface\n"
+        )
+        entries = {d["name"]: d for d in find_dead_exports(root, DEFAULT_MIN_NAME_LEN)}
+        republished = entries.get("republished_helper")
+        if republished is None:
+            failures.append("value behind a facade not reported at all")
+        elif not republished.get("reexported_by"):
+            failures.append("facade re-export not recorded on the finding")
+
     for failure in failures:
         print(f"self-test FAIL: {failure}", file=sys.stderr)
     if failures:
@@ -304,10 +368,14 @@ def main(argv: list[str]) -> int:
         for entry in dead_exports:
             per_module[entry["module"]] += 1
         payload["dead_exports"] = dead_exports
+        behind_facade = [d for d in dead_exports if d.get("reexported_by")]
         if not args.json:
             print(f"dead exports: {len(dead_exports)} "
                   f"across {len(per_module)} modules "
                   f"(names >= {args.min_name_len} chars)")
+            print(f"  directly removable: {len(dead_exports) - len(behind_facade)}")
+            print(f"  behind a facade re-export (needs the facade edited too): "
+                  f"{len(behind_facade)}")
             for module, count in sorted(per_module.items(), key=lambda kv: (-kv[1], kv[0]))[:40]:
                 print(f"  {count:4d}  {module}")
     if args.stanzas:


### PR DESCRIPTION
First deletion slice from the audit landed in #25439. Removes 26 constants from
`keeper_hooks_oas_types` — the `val` declarations, the implementations behind them, and the
doc block describing the deleted stop-reason labels: 65 lines.

The values are JSON field keys and metric labels: `key_agent_name`, `key_task_id`,
`label_surface`, `stop_reason_label_max_tokens` and 22 siblings. Nothing reads them.

## Why the deletion is safe

Three independent checks, each able to falsify the others:

**1. The compiler names exactly these 26.** The repo's root `dune` sets
`(flags (:standard -warn-error +8))`, so warning 32 (unused value) is off and this class of
dead code accumulates silently. Building with it forced on:

```
OCAMLPARAM='_,w=+32' dune build @check
```

reports `unused value` for 26 values in this module — the same 26 the audit script proposed
from token scanning, with no additions and no omissions. Two methods that share no code
agreed on the list.

**2. Removing the `val` declarations does not break any consumer.** `dune build @check`
passes with the narrowed `.mli`. That gate was itself verified rather than assumed: inserting
`let _x : int = "not an int"` into the same module makes `@check` fail with
`This constant has type string but an expression was expected of type int`, so a passing build
is evidence and not a no-op.

**3. Adversarial review found no reachability route.** An independent pass searched for what a
token scan cannot see — `include` re-export, module aliasing, functor arguments, first-class
modules, ppx, dune rules, runtime string dispatch, out-of-tree consumers — and reported none
for these 26. It did correct a premise of mine: `keeper_hooks_oas.ml:14` does
`include Keeper_hooks_oas_types` and `keeper_hooks_oas.mli:63` does
`include module type of Keeper_hooks_oas_types`. Those re-exports carry the `.mli` signature,
so removing a `val` removes it from the facade too rather than leaving a dangling reference.

After the deletion, `warning 32` reports nothing further in this module.

## Scope

26 of the 311 fully-dead candidates the audit found. The rest are deliberately not in this PR:

- **190 verified deletable** — same treatment, one module or small group per PR so each stays
  reviewable.
- **28 held back.** Adversarial review refuted these: they are re-exported wholesale into a
  facade's published signature, either by `include M` + `include module type of M`
  (`Backend`/`Backend_types`, `Voice_bridge`/`Voice_bridge_core`,
  `Keeper_memory`/`Keeper_memory_recall`, `Workspace_utils`/`Workspace_utils_ops`) or by a
  `module Core = M` alias inside a `.mli` (`Capability_recovery_reconciler.Core`). They have no
  call sites, but deleting them means editing the facade's signature too, which is a different
  change. The audit script cannot see these — the value name never appears at the re-export
  site. The second commit below closes that gap.
- **93 not yet verified.** Untouched.

## Pre-existing dead code this surfaced

Building with warning 32 on reports **at least 93 unused values across 46 files**, unrelated to
this change. It is a lower bound: these surface as errors, so dune stops before compiling
anything downstream of a failing file. The compiler has known about them all along;
`-warn-error +8` hides them. Four examples:

| Location | Value |
|---|---|
| `lib/keeper_runtime/keeper_event_queue.ml:483` | `string_list_field` |
| `lib/runtime/runtime_observation.ml:145` | `strip_latest_suffix` |
| `lib/runtime/runtime.ml:659` | `validate_runtime_model_capabilities` |
| `lib/prompt_defaults.mli:65` | `init` |

(The third is a thin wrapper over `decide_capability_gate`, which is exported at
`runtime.mli:31` and covered by tests — so it is a redundant wrapper, not a validation that
stopped running.)

Filed as #25455 rather than bundled here.

## Second commit: closing the audit's blind spot

The adversarial pass refuted 28 of 218 candidates (12.8%), and every refutation had one cause:
the value is republished wholesale into a facade's signature. Three shapes do that without ever
naming the values they carry, which is why a token scan cannot see them:

```
include module type of Foo     (in a .mli)
module Bar = Foo               (a signature alias in a .mli)
include Foo                    (in a .ml whose .mli republishes the type)
```

`scripts/audit-dead-surface.py` now builds that re-export graph and reports the two groups
separately. Measured against the adversarial verdicts it recovers **28 of 28 refutations with
none missed** — the same safety the review pass provided, without the review pass. It also
flags 74 that the review cleared; those keep their finding but route through the slower path of
checking the facade, which is the safe direction for an error.

Current tree: 1015 dead exports — **436 directly removable, 579 behind a facade re-export**.

The self-test gains a case pinning that recall, since losing it would silently return the audit
to proposing unsafe deletions.

## Separately filed

#25455: warning 32 is off repo-wide (`-warn-error +8`), so unused implementations accumulate
with no signal. Forcing it on reports at least 93 across 46 files. Clearing those and then
adding 32 to the error set would let the compiler prevent this class permanently — a better
answer to the ratchet request on #25439 than ratcheting the Python script.

## Verification

- `OCAMLPARAM='_,w=+32' dune build @check` — 26 unused-value reports before, 0 in this module after
- `dune build @check` (CI-equivalent flags) — passes
- positive control confirming the gate fails on a real type error

RFC-WAIVED: deletes unused JSON-key and metric-label constants from a leaf types module; no
credential, operator-control, sandbox, hooks or workflow surface.
