### PR TITLE
fix(keeper): refuse a consolidation plan that empties the fact store

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -39,6 +39,7 @@ type outcome =
       { before : int
       ; after : int
       }
+  | Plan_rejected_total_deletion of { before : int }
 
 (* Serialize only the final snapshot validation + rewrite against the per-keeper
    facts file. The provider call runs without this lock, then the locked rewrite
@@ -190,7 +191,19 @@ let consolidate_keeper
                 let plan = Consolidation.plan_of_json json in
                 let survivors = Consolidation.apply_plan ~now ~facts plan in
                 let after = List.length survivors in
-                if dry_run
+                (* [before > 0] is guaranteed by the [Skipped_too_few] guard above,
+                   so [after = 0] here means the plan asked to erase the store. A
+                   plan that keeps nothing is treated as a malformed response, not
+                   as judgement: the store is the keeper's only durable memory and
+                   [rewrite_facts_atomically] renames over the sole copy, so the
+                   rows are unrecoverable. A truncated response that loses its
+                   [groups] array while retaining [drop_indices] produces exactly
+                   this shape. Only total erasure is refused — a large deletion
+                   over a mostly redundant store is a legitimate outcome, so no
+                   ratio or floor is imposed on [after > 0]. *)
+                if after = 0
+                then Plan_rejected_total_deletion { before }
+                else if dry_run
                 then Consolidated { before; after }
                 else
                   rewrite_if_snapshot_current

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -21,6 +21,13 @@ type outcome =
       { before : int
       ; after : int
       }
+  | Plan_rejected_total_deletion of { before : int }
+      (** The plan retained no survivor from a non-empty store. Emptying a
+          keeper's whole long-term memory is not a consolidation judgement the
+          model is asked to make, so the plan is discarded and the store is left
+          untouched. Deliberately narrower than a ratio guard: a store whose rows
+          are mostly redundant has a legitimately large deletion, and only total
+          erasure is refused. *)
 
 module For_testing : sig
   val provider_for_consolidation

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -150,6 +150,15 @@ let run_memory_os_consolidation_tick
           keeper_id
           before
           after
+      | Plan_rejected_total_deletion { before } ->
+        (* Warn, not info: the store survived, but the model asked to erase it.
+           A recurring rejection for one keeper means its plans are malformed
+           (truncation is the likely cause), which info-level volume would bury. *)
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s plan_rejected_total_deletion \
+           before=%d"
+          keeper_id
+          before
       | Skipped_too_few n ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s skipped_too_few=%d"

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -145,6 +145,89 @@ let test_consolidate_applies_plan () =
           claims))))
 ;;
 
+(* A plan whose drop_indices cover every row is refused and the store is left
+   byte-for-byte intact. This is the shape a truncated response takes when its
+   groups array is lost but drop_indices survives. *)
+let test_consolidate_rejects_total_deletion () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "deploy uses blue-green"
+          ; fact "build runs on dune 3.x"
+          ; fact "tests live under test/"
+          ];
+        let plan = {|{"groups":[],"drop_indices":[0,1,2]}|} in
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete plan)
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        (match outcome with
+         | Runtime.Plan_rejected_total_deletion { before } ->
+           Alcotest.(check int) "before" 3 before
+         | _ -> Alcotest.fail "expected Plan_rejected_total_deletion");
+        let claims =
+          Io.read_facts_all ~keeper_id
+          |> List.map (fun f -> f.Types.claim)
+          |> List.sort String.compare
+        in
+        Alcotest.(check (list string))
+          "store untouched"
+          [ "build runs on dune 3.x"; "deploy uses blue-green"; "tests live under test/" ]
+          claims))))
+;;
+
+(* Counterpart to the guard: dropping all but one row is a legitimate outcome for
+   a store of near-duplicates and must still be applied. The guard refuses total
+   erasure only — it is not a ratio floor. *)
+let test_consolidate_allows_large_deletion () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "keeper is idle"
+          ; fact "keeper is idle this turn"
+          ; fact "no actionable signal"
+          ; fact "nothing actionable detected"
+          ];
+        let plan = {|{"groups":[],"drop_indices":[1,2,3]}|} in
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete plan)
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        (match outcome with
+         | Runtime.Consolidated { before; after } ->
+           Alcotest.(check int) "before" 4 before;
+           Alcotest.(check int) "after (3 of 4 dropped)" 1 after
+         | _ -> Alcotest.fail "expected Consolidated");
+        Alcotest.(check (list string))
+          "sole survivor persisted"
+          [ "keeper is idle" ]
+          (Io.read_facts_all ~keeper_id |> List.map (fun f -> f.Types.claim))))))
+;;
+
 let test_consolidate_judges_single_fact () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -552,6 +635,14 @@ let () =
     [ ( "loop"
       , [ Alcotest.test_case "applies the model's plan" `Quick test_consolidate_applies_plan
         ; Alcotest.test_case "judges a single fact" `Quick test_consolidate_judges_single_fact
+        ; Alcotest.test_case
+            "rejects a plan that deletes every fact"
+            `Quick
+            test_consolidate_rejects_total_deletion
+        ; Alcotest.test_case
+            "applies a large but partial deletion"
+            `Quick
+            test_consolidate_allows_large_deletion
 	        ; Alcotest.test_case "dry-run preserves the store" `Quick test_consolidate_dry_run_preserves_store
         ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
         ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store


### PR DESCRIPTION
## 무엇이 고장이었나

`drop_indices`가 모든 행을 덮는 컨솔리데이션 계획이 keeper의 fact store를 **빈 파일로 덮어썼습니다.**

```ocaml
let survivors = Consolidation.apply_plan ~now ~facts plan in
let after = List.length survivors in   (* = 0 *)
if dry_run then Consolidated { before; after }
else rewrite_if_snapshot_current ... (* 빈 리스트를 그대로 기록 *)
```

`rewrite_facts_atomically`는 유일한 사본 위로 rename하고, fact 레코드에는 병합 출처(`merged_from`)가 없습니다. 행은 **복구 불가**합니다. 그런데 결과는:

```
Log.Server.info "memory_os_keeper_consolidation: keeper=%s before=449 after=0"
```

정상 실행과 **같은 심각도**입니다.

`consolidation_enabled_default = true`(#25337, 2026-07-20)이므로 이 경로는 라이브에서 매 600초 돕니다.

### 이 형태가 어떻게 나오나

적대적 모델이 필요 없습니다. 잘린 응답이 `groups` 배열을 잃고 `drop_indices`만 남기면 정확히 이 모양입니다. 프롬프트는 "make the set smaller and sharper"를 요구하고, 라이브 store는 300–697행입니다.

GC는 안전망이 아닙니다 — `fact_is_current`는 명시적 `valid_until`이 있는 행만 만료시키는데, 레포 자신의 측정이 `idealist: 449 rows, **0 with valid_until**`입니다 (`env_config_keeper.ml:180`). `keeper_librarian.ml`이 유일한 write 경로이고 `valid_until = None`을 하드코딩합니다.

## 변경

계획이 아무것도 남기지 않으면 **판단이 아니라 malformed 응답**으로 취급합니다:

- `Plan_rejected_total_deletion of { before : int }` 결과 변형 추가
- store 미변경, `Log.Server.warn`으로 로깅

`before = 0`은 위쪽 `Skipped_too_few` 가드가 보장하므로, 여기서 `after = 0`은 "비어 있던 store"가 아니라 "지우라는 계획"입니다.

### 비율 floor가 아닙니다

**의도적으로 전량 소거만 거부합니다.** 라이브 실측(2026-07-20):

| keeper | 총 행 | idle 계열 (키워드 추정) |
|---|---|---|
| rondo | 697 | 225 (32%) |
| analyst | 295 | 123 (41%) |

```
"Keeper is idle with no actionable tasks this turn."
"No new actionable signals detected this cycle; keeper is idle."
"Idle loop with no actionable signals detected across multiple consecutive keepalive turns."
```

중복률이 이만큼인 store에서는 **대량 삭제가 정당한 컨솔리데이션**입니다. `after < before * k` 같은 비율 가드는 그 정상 동작을 막습니다. `after > 0`인 한 아무 제약도 걸지 않습니다.

### Only-LLM 정책과의 관계

`env_config_keeper.ml:176-183`이 선언하는 계약 — *"LLM-judged per-keeper consolidation is the only sanctioned decider of which facts survive"* 그리고 *"transport/parse errors **never mutate the store**"* — 을 위반하지 않습니다. 오히려 후자를 집행합니다. 이 가드는 LLM의 *판단*에 반대표를 던지지 않고, **판단으로 볼 수 없는 응답**을 파싱 실패와 같은 층에서 거부합니다. `structured_json_of_response`가 깨진 JSON을 거부하는 것과 동일한 경계입니다.

선례: #25268(컴팩션 deterministic structural floor) — 같은 계열의 "LLM 경로 실패 시 결정론적 안전 동작".

## 테스트

`test/test_keeper_memory_os_consolidation_runtime.ml`:

- `rejects a plan that deletes every fact` — `{"groups":[],"drop_indices":[0,1,2]}` → `Plan_rejected_total_deletion { before = 3 }`, store가 byte-identical
- `applies a large but partial deletion` — `{"groups":[],"drop_indices":[1,2,3]}` → `Consolidated { before = 4; after = 1 }`, 유일 생존자 영속. **가드가 과잉 차단하지 않음을 증명**

## 로컬 검증

```
scripts/dune-local.sh build test/test_keeper_memory_os_consolidation_runtime.exe   # EXIT=0
./_build/default/test/test_keeper_memory_os_consolidation_runtime.exe
  → 13 tests, 신규 2건 포함 12 [OK], 1 failure
```

**남은 1건은 이 PR과 무관합니다.** `test_consolidate_requires_clock_before_provider_call`은 `?clock` 생략 시 provider 미호출을 요구하는데, 이 가드는 provider 호출 *이후* 경로입니다.

`origin/main`(bd85f786b6) pristine worktree에서 재현 확인 — 동일하게 `11 tests run, 1 failure`.

## 미검증

- 라이브 재기동 후 실제 warn 발생 여부 (이 형태는 드물게 발생)
- `Plan_rejected_total_deletion` 빈도 계측 없음 — 반복 발생 시 원인(truncation)을 좁히려면 후속 작업 필요

## 발견 경위

Memory OS 컨솔리데이션 적대적 검증 중 독립 리뷰어(fresh context)가 P0로 보고, 코드 재확인으로 CONFIRMED. 같은 검증에서 확인된 별건(recall Select 부재, 판단자 이중화, librarian 비-이벤트 32~41%)은 이 PR 범위 밖이며 별도 RFC로 정리 예정.

RFC-WAIVED: memory_os는 `agent_delegation` RFC 게이트 대상 subsystem(credential/identity/operator/sandbox/dashboard-credential/hooks/workflow)이 아님. 단일 결과 변형 추가로 기존 계약(`env_config_keeper.ml:176-183`)을 집행하는 변경이며 새 아키텍처를 도입하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
