### PR TITLE
fix(keeper): split the post-turn memory lane so a librarian call cannot drop the deterministic write

### DIFF
--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -133,6 +133,7 @@ let run
     Keeper_memory_lane.submit
       ~base_path:config.base_path
       ~keeper_name:meta.name
+      ~lane:Keeper_memory_lane.Deterministic
       det_write_series
   in
   (match memory_extraction_record with
@@ -141,6 +142,7 @@ let run
        Keeper_memory_lane.submit
          ~base_path:config.base_path
          ~keeper_name:meta.name
+         ~lane:Keeper_memory_lane.Librarian
          librarian_series
      in
      ()

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -1,10 +1,36 @@
 (** Per-keeper memory execution lane. See keeper_memory_lane.mli (RFC-0257). *)
 
+(* Post-turn memory work splits into two kinds that write different stores
+   under their own locks ([Keeper_memory_bank.with_memory_bank_lock] vs
+   [Keeper_memory_os_io.with_facts_lock] / [with_episode_bundle_lock]), so they
+   never needed to serialize against each other. Sharing one lane made them
+   compete for one reservation budget anyway, and the librarian holds its
+   mutex across a provider round trip (seconds) while the deterministic write
+   is a local append. A turn submits one of each, so a librarian still in
+   flight from the previous turn left room for only one of them — and the
+   deterministic write is one-shot with no retry, while the librarian unit is
+   re-tried by its own cadence. Measured live on 2026-07-20: 220 drops against
+   375 librarian writes, keeper `analyst` at 144 drops / 136 writes, 52 of
+   those turns losing both units.
+
+   Each kind therefore gets its own entry: its own mutex (so a provider round
+   trip cannot block a local append) and its own reservation budget (so neither
+   kind can evict the other). Serialization *within* a kind is preserved. *)
+type lane =
+  | Deterministic
+  | Librarian
+
+let lane_label = function
+  | Deterministic -> "deterministic"
+  | Librarian -> "librarian"
+;;
+
 type entry =
   { mem_mu : Eio.Mutex.t
-    (* Serializes memory work within one keeper; held across a provider round
-       trip (seconds), hence the fiber-cooperative Eio.Mutex. Raw lock/unlock,
-       not [use_rw]: a raising unit must not poison the lane. *)
+    (* Serializes memory work within one keeper and lane; the librarian lane
+       holds it across a provider round trip (seconds), hence the
+       fiber-cooperative Eio.Mutex. Raw lock/unlock, not [use_rw]: a raising
+       unit must not poison the lane. *)
   ; state_mu : Stdlib.Mutex.t
     (* Guards [pending]. Critical sections never yield. *)
   ; mutable pending : int
@@ -48,8 +74,10 @@ let init ~sw =
 
 let current_sw () = Stdlib.Mutex.protect registry_mu (fun () -> !executor_sw)
 
-let entry_for ~base_path ~keeper_name =
-  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+let entry_for ~base_path ~keeper_name ~lane =
+  let key =
+    Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label lane
+  in
   Stdlib.Mutex.protect registry_mu (fun () ->
     match Hashtbl.find_opt entries key with
     | Some e -> e
@@ -66,56 +94,56 @@ let entry_for ~base_path ~keeper_name =
 
 let metric_name m = Keeper_metrics.(to_string m)
 
-let record_counter ~keeper_name metric =
+let record_counter ~keeper_name ~lane metric =
   Otel_metric_store.inc_counter
     (metric_name metric)
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
     ()
 ;;
 
-let inc_pending ~keeper_name () =
+let inc_pending ~keeper_name ~lane () =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLanePending)
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
     ()
 ;;
 
-let dec_pending ~keeper_name () =
+let dec_pending ~keeper_name ~lane () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLanePending)
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
     ()
 ;;
 
-let inc_in_flight ~keeper_name () =
+let inc_in_flight ~keeper_name ~lane () =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLaneInFlight)
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
     ()
 ;;
 
-let dec_in_flight ~keeper_name () =
+let dec_in_flight ~keeper_name ~lane () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLaneInFlight)
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
     ()
 ;;
 
-let try_reserve ~keeper_name entry =
+let try_reserve ~keeper_name ~lane entry =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     let bound = max_pending () in
     if entry.pending >= bound
     then None
     else (
       entry.pending <- entry.pending + 1;
-      inc_pending ~keeper_name ();
+      inc_pending ~keeper_name ~lane ();
       Some bound))
 ;;
 
-let release_reservation ~keeper_name entry =
+let release_reservation ~keeper_name ~lane entry =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     entry.pending <- entry.pending - 1;
-    dec_pending ~keeper_name ())
+    dec_pending ~keeper_name ~lane ())
 ;;
 
 let make_reservation () =
@@ -126,7 +154,7 @@ let reservation_released reservation =
   Stdlib.Mutex.protect reservation.release_mu (fun () -> reservation.released)
 ;;
 
-let release_reservation_once ~keeper_name entry reservation =
+let release_reservation_once ~keeper_name ~lane entry reservation =
   let should_release =
     Stdlib.Mutex.protect reservation.release_mu (fun () ->
       if reservation.released
@@ -135,7 +163,7 @@ let release_reservation_once ~keeper_name entry reservation =
         reservation.released <- true;
         true))
   in
-  if should_release then release_reservation ~keeper_name entry
+  if should_release then release_reservation ~keeper_name ~lane entry
 ;;
 
 let disarm_switch_hook reservation =
@@ -148,29 +176,32 @@ let disarm_switch_hook reservation =
   Option.iter (fun hook -> ignore (Eio.Switch.try_remove_hook hook)) hook
 ;;
 
-let protect_cleanup ~keeper_name label f =
+let protect_cleanup ~keeper_name ~lane label f =
   try f () with
   | exn ->
-    record_counter ~keeper_name MemoryLaneUnitFailures;
+    record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
     Log.Keeper.warn ~keeper_name
       "memory lane cleanup failed (%s): %s"
       label
       (Printexc.to_string exn)
 ;;
 
-let release_after_run ~keeper_name entry reservation ~acquired ~in_flight =
+let release_after_run ~keeper_name ~lane entry reservation ~acquired ~in_flight =
   if !in_flight
-  then protect_cleanup ~keeper_name "dec_in_flight" (fun () -> dec_in_flight ~keeper_name ());
+  then
+    protect_cleanup ~keeper_name ~lane "dec_in_flight" (fun () ->
+      dec_in_flight ~keeper_name ~lane ());
   if !acquired
-  then protect_cleanup ~keeper_name "unlock" (fun () -> Eio.Mutex.unlock entry.mem_mu);
-  protect_cleanup ~keeper_name "release_reservation" (fun () ->
-    release_reservation_once ~keeper_name entry reservation)
+  then
+    protect_cleanup ~keeper_name ~lane "unlock" (fun () -> Eio.Mutex.unlock entry.mem_mu);
+  protect_cleanup ~keeper_name ~lane "release_reservation" (fun () ->
+    release_reservation_once ~keeper_name ~lane entry reservation)
 ;;
 
-let arm_switch_release ~keeper_name entry reservation sw =
+let arm_switch_release ~keeper_name ~lane entry reservation sw =
   let release_from_switch () =
-    protect_cleanup ~keeper_name "executor_switch_release" (fun () ->
-      release_reservation_once ~keeper_name entry reservation)
+    protect_cleanup ~keeper_name ~lane "executor_switch_release" (fun () ->
+      release_reservation_once ~keeper_name ~lane entry reservation)
   in
   try
     let hook = Eio.Switch.on_release_cancellable sw release_from_switch in
@@ -190,31 +221,31 @@ let arm_switch_release ~keeper_name entry reservation sw =
    exit, including cancellation at shutdown. No exception escapes: a best-effort
    unit must never propagate into the executor switch — that would cancel the
    fleet. *)
-let run_unit ~keeper_name entry reservation sw f =
+let run_unit ~keeper_name ~lane entry reservation sw f =
   let acquired = ref false in
   let in_flight = ref false in
   Eio.Switch.run (fun cleanup_sw ->
     Eio.Switch.on_release cleanup_sw (fun () ->
-      release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
+      release_after_run ~keeper_name ~lane entry reservation ~acquired ~in_flight);
       disarm_switch_hook reservation;
       try
         Eio.Mutex.lock entry.mem_mu;
         (* No suspension point between [lock] returning and this assignment, so
            cancellation cannot strand a held mutex with [acquired = false]. *)
         acquired := true;
-        inc_in_flight ~keeper_name ();
+        inc_in_flight ~keeper_name ~lane ();
         in_flight := true;
         Eio_context.with_turn_switch sw f
       with
       | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
       | exn ->
-        record_counter ~keeper_name MemoryLaneUnitFailures;
+        record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
         Log.Keeper.warn ~keeper_name
           "memory lane unit failed: %s"
           (Printexc.to_string exn))
 ;;
 
-let submit ~base_path ~keeper_name f =
+let submit ~base_path ~keeper_name ~lane f =
   match current_sw () with
   | None ->
     (* Not initialized: run inline. The caller is still inside the per-keeper
@@ -223,48 +254,56 @@ let submit ~base_path ~keeper_name f =
     (try f () with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
-       record_counter ~keeper_name MemoryLaneUnitFailures;
+       record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
        Log.Keeper.warn ~keeper_name
          "memory lane unit failed (inline): %s"
          (Printexc.to_string exn));
-    record_counter ~keeper_name MemoryLaneRanInline;
+    record_counter ~keeper_name ~lane MemoryLaneRanInline;
     Ran_inline
   | Some sw ->
-    let entry = entry_for ~base_path ~keeper_name in
-    (match try_reserve ~keeper_name entry with
+    let entry = entry_for ~base_path ~keeper_name ~lane in
+    (match try_reserve ~keeper_name ~lane entry with
      | None ->
-       record_counter ~keeper_name MemoryLaneDropped;
+       record_counter ~keeper_name ~lane MemoryLaneDropped;
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string DispatchEventFailures)
-         ~labels:[ "keeper", keeper_name; "site", "memory_lane_saturated" ]
+         ~labels:
+           [ "keeper", keeper_name
+           ; "site", "memory_lane_saturated"
+           ; "lane", lane_label lane
+           ]
          ();
        Log.Keeper.warn ~keeper_name
-         "memory lane saturated (pending>=%d): dropping post-turn memory unit"
+         "memory lane saturated (lane=%s pending>=%d): dropping post-turn memory unit"
+         (lane_label lane)
          (max_pending ());
        Dropped
      | Some _bound ->
        let reservation = make_reservation () in
-       arm_switch_release ~keeper_name entry reservation sw;
+       arm_switch_release ~keeper_name ~lane entry reservation sw;
        if reservation_released reservation
        then (
-         record_counter ~keeper_name MemoryLaneDropped;
+         record_counter ~keeper_name ~lane MemoryLaneDropped;
          Log.Keeper.warn ~keeper_name
-           "memory lane executor switch unavailable: dropping post-turn memory unit";
+           "memory lane executor switch unavailable (lane=%s): dropping post-turn memory \
+            unit"
+           (lane_label lane);
          Dropped)
        else (
          try
-           record_counter ~keeper_name MemoryLaneSubmitted;
-           Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation sw f);
+           record_counter ~keeper_name ~lane MemoryLaneSubmitted;
+           Eio.Fiber.fork ~sw (fun () ->
+             run_unit ~keeper_name ~lane entry reservation sw f);
            Submitted
          with
          | Eio.Cancel.Cancelled _ as e ->
-           protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
+           protect_cleanup ~keeper_name ~lane "fork_cancel_release" (fun () ->
+             release_reservation_once ~keeper_name ~lane entry reservation);
            raise e
          | exn ->
-           protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           record_counter ~keeper_name MemoryLaneUnitFailures;
+           protect_cleanup ~keeper_name ~lane "fork_failure_release" (fun () ->
+             release_reservation_once ~keeper_name ~lane entry reservation);
+           record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
            Log.Keeper.warn ~keeper_name
              "memory lane fork failed: %s"
              (Printexc.to_string exn);
@@ -278,8 +317,10 @@ module For_testing = struct
       executor_sw := None)
   ;;
 
-  let pending ~base_path ~keeper_name =
-    let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  let pending ~base_path ~keeper_name ~lane =
+    let key =
+      Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label lane
+    in
     Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
     |> Option.map (fun e -> Stdlib.Mutex.protect e.state_mu (fun () -> e.pending))
   ;;

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -17,10 +17,26 @@
     (e.g. [Keeper_meta_contract.keeper_meta], [Workspace.config]) and never over
     mutable turn-local references.
 
-    The per-keeper reservation bound is controlled by
+    Work is split into two independent lanes per keeper ({!lane}). They write
+    different stores under their own locks, so serializing them against each
+    other bought nothing while making them share one reservation budget: a
+    librarian unit holding its mutex across a provider round trip left room for
+    only one of the next turn's two units, and the deterministic write has no
+    retry. Each lane now has its own mutex and its own budget; ordering within a
+    lane is unchanged.
+
+    The per-keeper, per-lane reservation bound is controlled by
     [MASC_KEEPER_MEMORY_LANE_MAX_PENDING] (default [2]). Submission outcomes
     are counted under [masc_keeper_memory_lane_*] and per-keeper pending /
-    in-flight gauges are exported. *)
+    in-flight gauges are exported, all labelled by [lane]. *)
+
+type lane =
+  | Deterministic
+      (** Local append to the keeper memory bank. One-shot: a drop here is
+          permanent, so it must not queue behind provider-backed work. *)
+  | Librarian
+      (** Provider-backed episode extraction. Holds its lane across the round
+          trip; a drop is retried on the next due turn by its own cadence. *)
 
 type outcome =
   | Submitted
@@ -41,9 +57,10 @@ val init : sw:Eio.Switch.t -> unit
 val submit
   :  base_path:string
   -> keeper_name:string
+  -> lane:lane
   -> (unit -> unit)
   -> outcome
-(** [submit ~base_path ~keeper_name f] runs [f] on [keeper_name]'s memory lane.
+(** [submit ~base_path ~keeper_name ~lane f] runs [f] on [keeper_name]'s [lane].
     When the executor switch is set, [f] is forked and serialized behind that
     keeper's mutex; over the pending bound it is dropped and counted. When the
     executor is not initialized, [f] runs inline and any exception is contained
@@ -54,6 +71,6 @@ module For_testing : sig
   val reset : unit -> unit
   (** Clear the lane registry and the executor switch. *)
 
-  val pending : base_path:string -> keeper_name:string -> int option
-  (** Current pending count for a keeper ([None] if the keeper has no entry). *)
+  val pending : base_path:string -> keeper_name:string -> lane:lane -> int option
+  (** Current pending count for a keeper's [lane] ([None] if it has no entry). *)
 end

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -16,7 +16,7 @@ let test_inline_when_uninitialized () =
   Lane.For_testing.reset ();
   let ran = ref false in
   let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran := true)
+    Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ran := true)
   in
   Alcotest.(check bool) "unit ran inline" true !ran;
   match outcome with
@@ -29,7 +29,7 @@ let test_inline_when_uninitialized () =
 let test_inline_contains_raise () =
   Lane.For_testing.reset ();
   let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
+    Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> raise Test_boom)
   in
   match outcome with
   | Lane.Ran_inline -> ()
@@ -49,7 +49,7 @@ let test_serializes_within_keeper () =
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
       let oa =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
           add "a-start";
           Eio.Promise.resolve set_started ();
           Eio.Promise.await p_release;
@@ -57,7 +57,7 @@ let test_serializes_within_keeper () =
       in
       Eio.Promise.await p_started;
       let ob =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> add "b")
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> add "b")
       in
       (* Let B attempt (and fail) to acquire the keeper mutex held by A. *)
       Eio.Fiber.yield ();
@@ -86,14 +86,14 @@ let test_independent_across_keepers () =
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
           Eio.Promise.resolve set_started ();
           Eio.Promise.await p_release;
           add "k1")
       in
       Eio.Promise.await p_started;
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k2" (fun () -> add "k2")
+        Lane.submit ~base_path ~keeper_name:"k2" ~lane:Lane.Librarian (fun () -> add "k2")
       in
       (* k2 runs to completion while k1 is still holding its own lane. *)
       Eio.Fiber.yield ();
@@ -111,11 +111,11 @@ let test_saturation_drops () =
       Lane.init ~sw;
       let p_release, set_release = Eio.Promise.create () in
       let o1 =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
           Eio.Promise.await p_release)
       in
-      let o2 = Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ()) in
-      let o3 = Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ()) in
+      let o2 = Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ()) in
+      let o3 = Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ()) in
       (match o1 with
        | Lane.Submitted -> ()
        | _ -> Alcotest.fail "o1 not submitted");
@@ -129,6 +129,56 @@ let test_saturation_drops () =
       Eio.Promise.resolve set_release ()))
 ;;
 
+(* The regression this split exists for: a saturated librarian lane must not
+   consume the deterministic lane's budget. A librarian unit parked in a
+   provider round trip plus one queued behind it fills the librarian lane, and
+   the deterministic write — one-shot, no retry — must still be admitted and
+   must run while the librarian is still blocked. Before the split both kinds
+   shared one budget, so this deterministic unit was dropped: measured live on
+   2026-07-20 at 220 drops fleet-wide, keeper `analyst` losing 144 of 280. *)
+let test_lanes_have_independent_budgets () =
+  Lane.For_testing.reset ();
+  let det_ran = ref false in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let p_release, set_release = Eio.Promise.create () in
+      let lib1 =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+          Eio.Promise.await p_release)
+      in
+      let lib2 =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ())
+      in
+      let lib3 =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ())
+      in
+      let det =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () ->
+          det_ran := true)
+      in
+      (match lib1, lib2 with
+       | Lane.Submitted, Lane.Submitted -> ()
+       | _ -> Alcotest.fail "librarian lane should admit two units");
+      (match lib3 with
+       | Lane.Dropped -> ()
+       | _ -> Alcotest.fail "librarian lane should be saturated at the bound");
+      (match det with
+       | Lane.Submitted -> ()
+       | Lane.Dropped ->
+         Alcotest.fail "deterministic unit dropped by a saturated librarian lane"
+       | Lane.Ran_inline -> Alcotest.fail "deterministic unit ran inline");
+      (* Still blocked on the librarian round trip; the deterministic write must
+         not be waiting behind it. *)
+      Eio.Fiber.yield ();
+      Eio.Fiber.yield ();
+      Alcotest.(check bool)
+        "deterministic write ran while librarian was in flight"
+        true
+        !det_ran;
+      Eio.Promise.resolve set_release ()))
+;;
+
 (* A unit that raises releases the mutex and the pending slot, so the lane
    recovers and later units run. *)
 let test_releases_on_raise () =
@@ -138,17 +188,17 @@ let test_releases_on_raise () =
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> raise Test_boom)
       in
       Eio.Fiber.yield ();
       Eio.Fiber.yield ();
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran_after := true)
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ran_after := true)
       in
       Eio.Fiber.yield ();
       Eio.Fiber.yield ()));
   Alcotest.(check bool) "lane recovered after raise" true !ran_after;
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked: %d" n
   | None -> Alcotest.fail "keeper entry missing"
@@ -164,7 +214,7 @@ let test_releases_on_cancel () =
          let started, set_started = Eio.Promise.create () in
          let never, _set_never = Eio.Promise.create () in
          let outcome =
-           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+           Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
              Eio.Promise.resolve set_started ();
              Eio.Promise.await never)
          in
@@ -176,7 +226,7 @@ let test_releases_on_cancel () =
          Eio.Switch.fail sw Cancel_lane_test))
    with
    | Cancel_lane_test -> ());
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after cancel: %d" n
   | None -> Alcotest.fail "keeper entry missing after cancel"
@@ -199,13 +249,13 @@ let test_finished_switch_drops_without_leak () =
   in
   Lane.init ~sw;
   let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
+    Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> raise Test_boom)
   in
   (match outcome with
    | Lane.Dropped -> ()
    | Lane.Submitted -> Alcotest.fail "expected Dropped, got Submitted"
    | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline");
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after finished switch submit: %d" n
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
@@ -232,6 +282,10 @@ let () =
             `Quick
             test_independent_across_keepers
         ; Alcotest.test_case "saturation drops" `Quick test_saturation_drops
+        ; Alcotest.test_case
+            "lanes have independent budgets"
+            `Quick
+            test_lanes_have_independent_budgets
         ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
         ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
         ; Alcotest.test_case


### PR DESCRIPTION
## 증상 (라이브 실측, 2026-07-20 fleet)

| 지표 | 값 |
|---|---|
| `memory lane saturated` 드롭 | **220건** |
| librarian 성공 기록 | 375건 |
| keeper `analyst` | 드롭 144 / 성공 136 = **51.4%** |
| analyst 중 같은 초에 2건 드롭(양 유닛 손실) | **52회** |

재현 명령 (`~/me/.masc/logs/system_log_2026-07-20.jsonl`):

```
rg -c "memory lane saturated" system_log_2026-07-20.jsonl      # 220
rg -c "librarian wrote episode" system_log_2026-07-20.jsonl    # 375
```

## 근본 원인

post-turn memory는 턴마다 유닛 **2개**를 제출한다 (`keeper_agent_run_post_turn_memory.ml:132,138`):

1. `det_write_series` — keeper memory bank에 로컬 append
2. `librarian_series` — provider 왕복 (수 초)

둘이 **같은 lane**을 쓰고, 예약 상한은 **2**다 (`keeper_memory_lane.ml:28`, `max_pending` 기본값). librarian은 provider 왕복 내내 lane mutex를 잡는다 (`:201`). 따라서 이전 턴 librarian이 아직 비행 중이면 이번 턴 2개 중 **1개만** 들어간다.

**두 유닛은 애초에 서로 직렬화될 이유가 없었다.** 서로 다른 저장소에 쓰고 각자 자체 락을 갖는다:

- det → `Keeper_memory_bank.with_memory_bank_lock`
- librarian → `Keeper_memory_os_io.with_facts_lock` / `with_episode_bundle_lock`

lane 공유는 상호 배제를 제공한 게 아니라 **하나의 예산을 놓고 경쟁하게 만들었을 뿐**이다.

**축출이 비대칭이다.** librarian 유닛은 드롭돼도 자체 cadence가 다음 due 턴에 재시도한다. `det_write_series`는 **one-shot, 재시도 없음** (`Memory.append_from_tool_results` → `Keeper_memory_bank.append_memory_notes_from_tool_results`). 누산기는 snapshot으로 전달되고 별도로 checkpoint working_context에 drain되므로 다음 턴에 다시 나타나지 않는다. 그 턴의 memory-bank `long_term` 기록은 **영구 손실**이다.

## 변경

종류별로 별도 entry를 준다 — 자체 mutex(provider 왕복이 로컬 append를 막지 못함)와 자체 예약 예산(어느 쪽도 상대를 축출하지 못함). **lane 내부의 직렬화는 그대로 유지**된다.

```ocaml
type lane =
  | Deterministic
  | Librarian
```

문자열이 아니라 typed variant로 둔 이유: 새 종류 추가가 컴파일 타임 결정이 된다.

부수 개선: `lane` 라벨을 lane counter / gauge / saturation WARN에 붙였다. 기존에는 드롭에 `keeper` 라벨만 있어서 **det 드롭과 librarian 드롭을 메트릭에서 구분할 수 없었다** — 위 실측도 로그 상관관계로 겨우 분리한 것이다.

## 검증

```
dune build lib/                       OK
test_keeper_memory_lane               9/9
```

**Counterfactual (핵심)**: `entry_for`에서 lane 키를 제거해 두 lane을 다시 하나로 합치면 (API는 유지) 새 테스트가 정확히 red가 된다:

```
> [FAIL] lane 5  lanes have independent budgets.
  [FAIL] lane 6  releases on raise.
  [FAIL] lane 7  releases on cancel.
  [FAIL] lane 8  finished switch drops without leak.
```

5번이 이 PR이 고치는 결함이고, 6~8번 연쇄 실패는 포화된 공유 entry가 해제되지 않는 수정 전 동작과 일치한다. 복원 후 다시 9/9.

새 테스트 `test_lanes_have_independent_budgets`가 고정하는 것: librarian lane이 (비행 1 + 대기 1로) 포화된 상태에서 deterministic 유닛이 **admit되어야 하고**, librarian이 아직 provider 왕복에 묶여 있는 동안 **실행까지 되어야 한다**.

ocamlformat 위반 없음.

## 검증되지 않은 항목

- 라이브 재기동 후 드롭 감소는 확인하지 않았다. 배포 후 `rg -c "memory lane saturated"`로 확인 필요.
- `max_pending` 기본값 2는 **건드리지 않았다**. 상향은 워크어라운드이고, 이 PR은 두 종류가 예산을 공유하던 구조 자체를 제거한다. 분리 후에도 단일 lane이 포화된다면 그건 별도 판단 사안이다.

## 범위 밖 (같은 감사에서 발견, 별도 처리)

- `Memory_fact_upsert_failed`가 backoff 집합에서 빠져 있어 매 턴 재시도 (`keeper_librarian_runtime.ml:277-288`)
- librarian 영구 스킵 3경로에 카운터 없음 (runtime 해석 실패 / 비-direct-completion provider / Eio 컨텍스트 부재)
- 에피소드 retention 경로 부재 — rondo 기준 460 파일, `render_context_exn`이 recall마다 전체 파싱

RFC-WAIVED: credential/identity/operator/sandbox/dashboard/hooks 어느 subsystem에도 해당하지 않는다. 동시성 구조 수정이며 저장소 포맷·API 계약 변경 없음.
