### PR TITLE
fix(test): migrate the last KR.clear call site missed by #25420 (main build @all red)

### DIFF
--- a/test/test_keeper_registry_admission_no_suspend.ml
+++ b/test/test_keeper_registry_admission_no_suspend.ml
@@ -58,7 +58,7 @@ let make_meta name =
    because B is parked with state_mu held. *)
 let run_interleaving () =
   Eio_main.run (fun _env ->
-    KR.clear ();
+    KR.For_testing.clear ();
     Admission.For_testing.reset ();
     let key_lock_taken, set_key_lock_taken = Eio.Promise.create () in
     let release_key_lock, do_release_key_lock = Eio.Promise.create () in


### PR DESCRIPTION
## 문제

`main` 에서 `dune build @all` 이 실패한다.

```
File "test/test_keeper_registry_admission_no_suspend.ml", line 61, characters 4-12:
61 |     KR.clear ();
Error: Unbound value KR.clear
```

#25420 (`refactor(keeper): move test-only Keeper_registry vals behind For_testing`) 이 `clear` 를 포함한 8개 val 을 `For_testing` 서브모듈로 옮기고 테스트 호출 사이트 ~36개를 갱신했는데, **이 파일 하나가 PR 변경 목록에 없었다**. `test/test_keeper_registry_admission_no_suspend.ml:33` 은 `module KR = Masc.Keeper_registry` 로 별칭을 만들고 `:61` 에서 `KR.clear ()` 를 호출한다.

## 왜 CI 가 잡지 못했나

이 저장소의 required check (`CI Gate`) 경로는 `dune build @default @check` 를 돈다. `@default` 는 테스트 실행파일을 전부 포함하지 않으므로, 테스트 전용 소스의 컴파일 에러가 통과한다. `@all` 에서만 드러난다.

해당 테스트는 `test/stanzas/test_keeper_registry_admission_no_suspend.inc` 로 기본 빌드에 배선된 평범한 `(test ...)` 스탠자이며 `enabled_if` 제외가 없다 — dead target 이 아니다.

## 수정

`KR.clear ()` → `KR.For_testing.clear ()` 한 줄. `For_testing.clear` 는 `lib/keeper/keeper_registry.mli:425` 에 존재하고, `.ml:1236` 에서 `let clear = clear` 로 동일 구현을 별칭한다 — 동작 변화 없음.

미마이그레이션 호출 사이트가 이 한 곳뿐임을 확인:

```
git grep -n -E '(KR|Keeper_registry)\.(clear|register|unregister|reload_meta_from_disk|record_restart|set_started_at_for_test|crash_log_of|board_wakeup_allowed) ' origin/main -- test/ lib/ bin/ | rg -v 'For_testing|register_offline|register_keeper'
→ test/test_keeper_registry_admission_no_suspend.ml:61 만 매칭
```

## 후속

`CI Gate` 가 `@all` 을 포함하지 않아 테스트 소스 컴파일 에러가 통과하는 구조 자체는 별도 이슈로 다룬다. 이 PR 은 main 복구만 한다.

RFC-WAIVED: 테스트 호출 사이트 1줄 수정(빌드 복구). 설계 변경 없음.
