### PR TITLE
docs(rfc-0284): annotate all ten deleted goal-loop scripts, not one

### DIFF
--- a/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
+++ b/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
@@ -51,12 +51,25 @@ fetch should be push/`useQuery`, not effect-on-mount).
 
 ## §2 Boundary — the worker is out-of-process (Python)
 
-The goal-loop worker is **not** an in-process OCaml fiber. It is a set of Python
-scripts implementing the OODA loop (`scripts/goal_loop_scheduler.py` — deleted 2026-07-21 per RFC-0000:781 KILL,
-`scripts/observe_goal_loop_logs.py`, `scripts/orient_goal_loop_logs.py`,
-`scripts/decide_goal_loop_findings.py`, `scripts/verify_goal_loop_logs.py`,
-`scripts/goal_loop_status.py`, `scripts/goal_loop_anti_stagnation.py`). They run
-out-of-band and write `status.json`; the OCaml SSE server only **reads** it.
+The goal-loop worker was **not** an in-process OCaml fiber. It was a set of Python
+scripts implementing the OODA loop, which ran out-of-band and wrote `status.json`;
+the OCaml SSE server only **read** it.
+
+**All of those scripts were deleted on 2026-07-21** (#25477, per RFC-0000:781
+KILL): `goal_loop_scheduler.py`, `observe_goal_loop_logs.py`,
+`orient_goal_loop_logs.py`, `decide_goal_loop_findings.py`,
+`verify_goal_loop_logs.py`, `goal_loop_status.py`,
+`goal_loop_anti_stagnation.py`, `goal_loop_live_replay.py`,
+`validate_goal_loop_act_map.py`, `validate_goal_loop_recovery_slo.py`. Nothing
+writes `status.json` any more, so the broadcast loop below fires only if a
+pre-existing file changes on disk. The fate of the remaining read side
+(`lib/server/server_dashboard_http_goal_loop_broadcast.ml` and the dashboard
+panel) is RFC-0352 Path-decision scope — it was deliberately left in place rather
+than removed alongside the writer.
+
+The boundary argument below is kept because it is the reason the broadcast
+trigger lives on the server, and it still constrains any future re-introduction
+of an out-of-process writer.
 
 Consequence: the worker cannot call the in-process `Sse.broadcast`. The
 status-file is the boundary between the non-deterministic Python OODA worker and


### PR DESCRIPTION
## 문제

#25477 이 goal-loop OODA Python 스크립트 10 개를 삭제했는데, `RFC-0284-goal-loop-sse-liveness.md` §2 는 그중 **1 개(`goal_loop_scheduler.py`)에만** "deleted 2026-07-21" 주석을 달았습니다. 같은 문장이 나머지 6 개를 살아있는 것처럼 나열하고, 주변 서술도 현재형입니다:

> They run out-of-band and write `status.json`

지금은 `status.json` 을 쓰는 주체가 없습니다.

## 왜 고치는가

이 저장소는 "코드를 제거하면서 그 코드를 설명하는 문서를 안 고쳐 다음 작업자가 회귀로 알고 되돌린" 이력이 있습니다. RFC 가 삭제된 스크립트를 현재형으로 서술하면 정확히 그 유인을 만듭니다.

## 변경

§2 를 과거형으로 정정하고, 삭제된 10 개를 **전부** 명시했습니다 (`goal_loop_scheduler`, `observe_goal_loop_logs`, `orient_goal_loop_logs`, `decide_goal_loop_findings`, `verify_goal_loop_logs`, `goal_loop_status`, `goal_loop_anti_stagnation`, `goal_loop_live_replay`, `validate_goal_loop_act_map`, `validate_goal_loop_recovery_slo`). 열 개 모두 현재 트리에 존재하지 않음을 확인했습니다.

읽기 측(`lib/server/server_dashboard_http_goal_loop_broadcast.ml`, 대시보드 패널)이 **의도적으로 남아 있고 RFC-0352 Path 결정 스코프**라는 점도 명시했습니다 — #25477 이 그 파일의 주석에 적어 둔 내용과 일치시킨 것입니다.

§2 의 경계 논증 자체는 유지했습니다. broadcast trigger 가 서버에 있는 이유이고, 나중에 out-of-process writer 를 다시 도입할 때도 그대로 제약으로 작동합니다.

문서 전용 변경입니다.

RFC-WAIVED: 기존 RFC 의 현재 상태 기술 정정(docs-only). 설계 변경 없음.
