### PR TITLE
fix(keeper): report persona drift only after registration commits

### DIFF
--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -80,9 +80,6 @@ let supervise_keepalive
     if Keeper_registry.is_registered ~base_path:ctx.config.base_path meta.name
     then ()
     else
-    let () =
-      Startup_helpers.log_persona_drift_if_missing ~base_path:ctx.config.base_path meta
-    in
     (* Register in Keeper_registry — single source of truth. *)
     match
       Keeper_registry.register_offline_if_admitted
@@ -111,6 +108,18 @@ let supervise_keepalive
          keeper_name
          detail
      | Ok reg ->
+    (* Persona drift is a property of a keeper that is actually joining the
+       fleet, so it is reported only once registration has committed. Reporting
+       it before [register_offline_if_admitted] meant every rejected
+       registration attempt also emitted a drift warning: when a shutdown
+       operation owns admission the supervisor retries roughly every 30s
+       forever, so a single blocked keeper produced ~120 drift warnings per
+       hour whose remediation ("add persona profile") cannot unblock it. The
+       drift condition itself is unchanged and still surfaces on the
+       registration that succeeds. *)
+    let () =
+      Startup_helpers.log_persona_drift_if_missing ~base_path:ctx.config.base_path meta
+    in
     (* Workspace initialization *)
     (try
        if not (Workspace_utils.is_initialized ctx.config)

--- a/test/dune
+++ b/test/dune
@@ -1906,6 +1906,7 @@
 (include stanzas/test_keeper_supervisor_observability_10125.inc)
 
 (include stanzas/test_keeper_supervisor_write_meta_source.inc)
+(include stanzas/test_keeper_supervisor_persona_drift_order.inc)
 
 (include stanzas/test_prompt_registry_dune_fallback.inc)
 

--- a/test/stanzas/test_keeper_supervisor_persona_drift_order.inc
+++ b/test/stanzas/test_keeper_supervisor_persona_drift_order.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_supervisor_persona_drift_order)
+ (modules test_keeper_supervisor_persona_drift_order)
+ (libraries alcotest unix str))

--- a/test/test_keeper_supervisor_persona_drift_order.ml
+++ b/test/test_keeper_supervisor_persona_drift_order.ml
@@ -1,0 +1,88 @@
+(** Structural guard for issue #25491.
+
+    [log_persona_drift_if_missing] used to run before
+    [register_offline_if_admitted] inside [supervise_keepalive]. Registration
+    can be rejected (a shutdown operation owning admission, a lifecycle
+    reservation, a validation error), and the supervisor retries roughly every
+    30s while the rejection persists. Every rejected attempt therefore emitted
+    a persona-drift warning whose stated remediation ("add persona profile if
+    persona assets are required") cannot lift the rejection: measured on a live
+    fleet on 2026-07-20, one blocked keeper produced ~120 such warnings per
+    hour against 20 server boots, while the drift condition itself was static.
+
+    This test pins the fix: the drift report must come after the registration
+    call, so it describes a keeper that actually joined the fleet.
+
+    Structural (source offsets) rather than behavioural, following the
+    precedent in [test_keeper_supervisor_write_meta_source.ml]: the call site
+    is inside [supervise_keepalive], which needs a full Workspace /
+    Keeper_registry fixture to exercise, and the repository has no log-capture
+    harness to assert on emitted lines. The risk guarded against is exactly
+    that a future refactor hoists the drift report back above the registration
+    call. *)
+
+open Alcotest
+
+let target_file = "lib/keeper/keeper_supervisor_supervise_keepalive.ml"
+
+let load_source rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root rel in
+  if not (Sys.file_exists path) then
+    failwith (Printf.sprintf "source file not found: %s" path)
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> In_channel.input_all ic)
+
+let find_offset haystack needle =
+  try Some (Str.search_forward (Str.regexp_string needle) haystack 0)
+  with Not_found -> None
+
+let count_occurrences haystack needle =
+  let re = Str.regexp_string needle in
+  let rec go from acc =
+    match Str.search_forward re haystack from with
+    | pos -> go (pos + 1) (acc + 1)
+    | exception Not_found -> acc
+  in
+  go 0 0
+
+let drift_call = "log_persona_drift_if_missing"
+let register_call = "register_offline_if_admitted"
+
+let test_drift_reported_once () =
+  let src = load_source target_file in
+  check int
+    "supervise_keepalive must call log_persona_drift_if_missing exactly once"
+    1
+    (count_occurrences src drift_call)
+
+let test_drift_follows_registration () =
+  let src = load_source target_file in
+  match find_offset src register_call, find_offset src drift_call with
+  | None, _ ->
+    fail (Printf.sprintf "%s not found in %s" register_call target_file)
+  | _, None ->
+    fail (Printf.sprintf "%s not found in %s" drift_call target_file)
+  | Some register_at, Some drift_at ->
+    check bool
+      "persona drift must be reported after register_offline_if_admitted, not \
+       before it (issue #25491: rejected registrations must not narrate an \
+       unrelated remediation)"
+      true
+      (drift_at > register_at)
+
+let () =
+  run "keeper_supervisor_persona_drift_order" [
+    "drift_report_ordering", [
+      test_case "drift reported exactly once" `Quick test_drift_reported_once;
+      test_case "drift reported after registration" `Quick
+        test_drift_follows_registration;
+    ];
+  ]


### PR DESCRIPTION
## 목표

기동이 차단된 keeper 가 무관한 조치를 안내하는 WARN 을 시간당 ~120건 내는 것을 멈춘다.

## 문제

`log_persona_drift_if_missing` 이 `register_offline_if_admitted` **이전**에 호출된다. 등록이 거부돼도 drift WARN 은 이미 나간 뒤다.

```ocaml
if is_registered then ()
else
let () = log_persona_drift_if_missing … in   (* ← 등록 시도 전 *)
match register_offline_if_admitted … with
| Error (Registration_shutdown_reserved op) -> Log.Keeper.info "supervisor launch skipped …"
```

shutdown operation 이 admission 을 소유하면 supervisor 는 약 30초 주기로 무기한 재시도하므로, 차단된 keeper 하나가 시간당 ~120건의 drift WARN 을 만든다. 그런데 그 WARN 이 안내하는 조치는 `operator action: add persona profile if persona assets are required` 로, **이 장애를 해소하지 못한다.**

## 실측 (라이브 fleet, 2026-07-20, keeper=rondo)

| 항목 | 값 |
|---|---|
| rondo 차단 시작 | 13:27:40Z (`Reconciliation_required` 가 admission 소유, #25491) |
| drift WARN | 하루 514건 / 최근 1시간 120건 |
| 서버 부팅 | 하루 20회 |
| `supervisor launch skipped` (실제 원인, INFO) | rondo·idealist 각 505건 |

시간대별로 13Z 이전은 시간당 1~3건(부팅 횟수와 일치), 13Z 이후 시간당 ~120건. **drift 조건은 정적인데 카운트는 등록 재시도 횟수를 추적하고 있었다.**

## 변경

호출을 `| Ok reg ->` 분기로 이동. 이유를 주석으로 남김.

drift 조건 자체는 그대로이며, 등록에 성공하는 시점에 여전히 보고된다. 등록에 성공하면 다음 tick 부터 `is_registered = true` 라 이 분기에 재진입하지 않으므로 등록당 1회다.

## 이것이 로그 억제가 아닌 이유

CLAUDE.md 의 "Log Dedup / Demote" 워크어라운드 시그니처를 자체 점검했다. 해당하지 않는다고 판단한다:

- 신호를 **줄이는** 것이 아니라 **잘못된 위치에서 나가던 것을 옳은 위치로 옮기는** 변경이다. persona profile 부재는 등록 성공 시 그대로 보고된다.
- 억제되는 것은 "등록이 거부된 keeper 에 대한 drift 보고" 뿐이고, 그 상황의 실제 원인은 별도 신호(`supervisor launch skipped`)가 이미 갖고 있다.
- 근본 원인(#25491, `Reconciliation_required` 흡수 상태)은 이 PR 이 건드리지 않으며 그대로 열려 있다. 이 PR 은 그 장애의 **오도 신호**만 제거한다.

## 검증

- `dune build --root . lib/keeper` 통과
- `dune exec --root . test/test_keeper_supervisor.exe` — **46 tests, 전부 통과**

## 미검증 (솔직히)

- 기존 persona_drift 테스트 3종은 헬퍼 함수(`persona_name_for_drift_check`, `persona_profile_path_for_drift_check`, `persona_drift_log_level_for_missing_profile`)만 덮고 **호출부 순서는 덮지 않는다.** 이 변경에 대한 회귀 테스트를 추가하지 못했다 — `supervise_keepalive` 내부의 제어 흐름 순서라 로그 캡처 하네스 없이는 단위 테스트가 어렵다. 필요하다면 하네스 도입을 별도로 다루는 편이 맞다고 본다.
- 라이브 검증은 배포 후에만 가능하다. 기대 결과는 rondo 차단이 지속되는 동안 drift WARN 이 0이 되고 `supervisor launch skipped` INFO 는 그대로 유지되는 것.

RFC-WAIVED: `lib/keeper/keeper_supervisor_supervise_keepalive.ml` 은 agent_delegation 의 RFC 필수 대상(credential/identity, repo_manager, operator_control, keeper_sandbox/shell, dashboard credential, hooks, workflow 문서)에 해당하지 않음. `pr-rfc-check.sh` 출력 없음(PASS).

Refs #25491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
