### PR TITLE
refactor(keeper): excise five dead exports from the chat-queue godfile

### DIFF
--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -35,7 +35,6 @@ type failure_kind =
   | Delivery_failed
   | Cancelled
   | Internal_error
-  | Recovery_interrupted
 
 type failure = {
   completed_at : float;
@@ -513,8 +512,6 @@ let commit_failure_for_testing : commit_failure option Atomic.t = Atomic.make No
 let transaction_observer_for_testing :
     (transaction_stage -> unit) option Atomic.t =
   Atomic.make None
-let before_entry_lock_observer_for_testing : (string -> unit) option Atomic.t =
-  Atomic.make None
 let inventory_classified_observer_for_testing : (unit -> unit) option Atomic.t =
   Atomic.make None
 let transition_observer : transition_observer option Atomic.t = Atomic.make None
@@ -855,7 +852,6 @@ let failure_kind_to_string = function
   | Delivery_failed -> "delivery_failed"
   | Cancelled -> "cancelled"
   | Internal_error -> "internal_error"
-  | Recovery_interrupted -> "recovery_interrupted"
 
 let failure_kind_of_string = function
   | "turn_failed" -> Ok Turn_failed
@@ -865,7 +861,6 @@ let failure_kind_of_string = function
   | "delivery_failed" -> Ok Delivery_failed
   | "cancelled" -> Ok Cancelled
   | "internal_error" -> Ok Internal_error
-  | "recovery_interrupted" -> Ok Recovery_interrupted
   | value -> Error (Printf.sprintf "unknown chat queue failure kind: %s" value)
 
 let completion_fields (completion : completion) =
@@ -2178,8 +2173,6 @@ let get_or_create_entry keeper_name =
    the lock normally, and re-raise outside. Any other exception still
    poisons — protected state may genuinely be torn there. *)
 let with_entry_lock keeper_name entry f =
-  Option.iter (fun observer -> observer keeper_name)
-    (Atomic.get before_entry_lock_observer_for_testing);
   let outcome =
     Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
       match f () with
@@ -2806,26 +2799,6 @@ let nack ~keeper_name ~lease_id =
        notify_indeterminate ~keeper_name (Error error);
        `Error error
      | `Unknown_lease -> `Unknown_lease)
-
-let pending_count ~keeper_name =
-  match mutation_context ~keeper_name ~create:false with
-  | Error _ as error -> error
-  | Ok (_, _, None) -> Ok 0
-  | Ok (_, _, Some entry) ->
-    with_entry_lock keeper_name entry (fun () ->
-        match first_blocking_error entry with
-        | Some error -> Error (Snapshot_unavailable error)
-        | None -> Ok entry.pending_count)
-
-let inflight_count ~keeper_name =
-  match mutation_context ~keeper_name ~create:false with
-  | Error _ as error -> error
-  | Ok (_, _, None) -> Ok 0
-  | Ok (_, _, Some entry) ->
-    with_entry_lock keeper_name entry (fun () ->
-        match first_blocking_error entry with
-        | Some error -> Error (Snapshot_unavailable error)
-        | None -> Ok (if Option.is_some entry.inflight then 1 else 0))
 
 let has_active_receipts ~keeper_name =
   match mutation_context ~keeper_name ~create:false with
@@ -3895,7 +3868,6 @@ module For_testing = struct
     Atomic.set transaction_failures_for_testing [];
     Atomic.set commit_failure_for_testing None;
     Atomic.set transaction_observer_for_testing None;
-    Atomic.set before_entry_lock_observer_for_testing None;
     Atomic.set inventory_classified_observer_for_testing None;
     Atomic.set persistence_configuration Unconfigured;
     Atomic.set global_load_errors [];
@@ -3911,13 +3883,9 @@ module For_testing = struct
   let set_transaction_stage_observer observer =
     Atomic.set transaction_observer_for_testing observer
 
-  let set_before_entry_lock_observer observer =
-    Atomic.set before_entry_lock_observer_for_testing observer
-
   let set_inventory_classified_observer observer =
     Atomic.set inventory_classified_observer_for_testing observer
 
-  let failure_kind_of_string = failure_kind_of_string
   let finalize_statement = sqlite_finalize
   let snapshot_path = snapshot_path
 

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -49,7 +49,6 @@ type failure_kind =
   | Delivery_failed
   | Cancelled
   | Internal_error
-  | Recovery_interrupted
 
 val failure_kind_to_string : failure_kind -> string
 
@@ -276,8 +275,6 @@ val nack :
   | `Error of mutation_error
   ]
 
-val pending_count : keeper_name:string -> (int, mutation_error) result
-val inflight_count : keeper_name:string -> (int, mutation_error) result
 val has_active_receipts : keeper_name:string -> (bool, mutation_error) result
 
 type lane_health =
@@ -377,9 +374,7 @@ module For_testing : sig
   val fail_next_commit_with : commit_failure -> unit
   val set_transaction_stage_observer :
     (transaction_stage -> unit) option -> unit
-  val set_before_entry_lock_observer : (string -> unit) option -> unit
   val set_inventory_classified_observer : (unit -> unit) option -> unit
-  val failure_kind_of_string : string -> (failure_kind, string) result
 
   val finalize_statement : Sqlite3.db -> Sqlite3.stmt -> (unit, string) result
   (** Total statement finalize: folds both the rc channel and the

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -425,7 +425,10 @@ let test_transition_observer_outside_lock_exactly_once () =
   Keeper_chat_queue.set_transition_observer
     (Some (fun ~keeper_name ~revision:_ ->
        incr calls;
-       match Keeper_chat_queue.pending_count ~keeper_name with
+       (* has_active_receipts takes the same entry lock the removed
+          pending_count probe took — the re-entrancy invariant is what
+          this test pins, not the count itself. *)
+       match Keeper_chat_queue.has_active_receipts ~keeper_name with
        | Ok _ -> nested_read_succeeded := true
        | Error _ -> ()));
   let receipt_id = Keeper_chat_queue.Receipt_id.generate () in


### PR DESCRIPTION
## 요약

godfile 분해 시리즈 1호 — `keeper_chat_queue.ml`(3,930 LoC) 분할 전 죽은 표면 절제. 분할이 라이브 코드만 옮기도록 선행합니다.

| 제거 | 근거 (fresh 재검증) |
|---|---|
| `val inflight_count` | 콜러 0. 대시보드의 `inflight_count` wire 필드는 **다른 서브시스템**(keeper_event_queue_persistence) 생산 — 함수와 무관 확인 |
| `val pending_count` | production 0; 유일 소비자였던 coalescing 테스트의 재진입 probe는 동일 락 경로의 라이브 `has_active_receipts`로 재배선 (불변식 보존) |
| `For_testing.set_before_entry_lock_observer` + Atomic + hook | 아무도 등록하지 않는 옵저버 |
| `For_testing.failure_kind_of_string` | 콜러 0 |
| variant `Recovery_interrupted` | 생성자 0 + **라이브 sqlite 실측**: 전 keeper store에서 행 0건, DDL에도 부재 → persisted decode 리스크 없음 |

검증: `@check` green, coalescing 테스트 PASS. RFC-0071 inventory 라인 핀은 advisory(Phase 1, 비차단) — 분할 PR에서 재생성 예정.

RFC-WAIVED: dead-surface 감사 집행 (감사 리포트가 설계 문서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
