### PR TITLE
refactor(server): excise three dead surfaces from the keeper-stream godfile

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -3089,7 +3089,6 @@ module For_testing = struct
   let chat_speaker_of_request = chat_speaker_of_request
   let turn_instructions_for_request = turn_instructions_for_request
   let args_of_request = args_of_request
-  let modalities_for_request = modalities_for_request
   let defer_dashboard_payload_if_busy_evidence
         ~base_path
         ~clock
@@ -3121,8 +3120,6 @@ module For_testing = struct
   let committed_delivery_outcome = committed_delivery_outcome
   let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
-  let empty_stream_bridge_state = empty_keeper_stream_bridge_state
-  let translate_oas_stream_event = translate_oas_stream_event
   let keeper_tool_failure_log_details = keeper_tool_failure_log_details
   let keeper_chat_stream_headers = keeper_chat_stream_headers
   let worker_settlement_terminal_body ~staged_body settlement =

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -264,7 +264,6 @@ module For_testing : sig
   val chat_speaker_of_request : keeper_chat_stream_request -> Keeper_chat_store.speaker
   val turn_instructions_for_request : keeper_chat_stream_request -> string option
   val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
-  val modalities_for_request : keeper_chat_stream_request -> string list
   val keeper_chat_stream_headers : string -> Httpun.Headers.t
   val defer_dashboard_payload_if_busy :
     base_path:string ->
@@ -296,13 +295,6 @@ module For_testing : sig
     (queued_turn_outcome option, string) result
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
-  val empty_stream_bridge_state : keeper_stream_bridge_state
-  val translate_oas_stream_event :
-    redact_text:(string -> string) ->
-    base_dir:string ->
-    keeper_stream_bridge_state ->
-    Agent_sdk.Types.sse_event ->
-    translated_keeper_stream_event
   val keeper_tool_failure_log_details :
     tool_name:string ->
     agent_name:string ->

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -10,7 +10,6 @@ module Server_activity_http = Server_activity_http
 module Common = Server_routes_http_common
 module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
-module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api_types = Server_dashboard_http_keeper_api_types
 
 let activity_result_json ~ok ~message =

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -8,7 +8,6 @@ module Http = Http_server_eio
 module Mcp_eio = Mcp_server_eio
 module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
-module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
 
 (* Dashboard /logs JSON builder extracted to

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -9,7 +9,6 @@ module Http = Http_server_eio
 module Common = Server_routes_http_common
 module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
-module Keeper_stream = Server_routes_http_keeper_stream
 
 let respond_redirect ~location reqd =
   let response =


### PR DESCRIPTION
godfile 시리즈 2호 — `server_routes_http_keeper_stream.ml` 분할 전 죽은 표면 절제 (fresh 재검증 완료).

| 제거 | 근거 |
|---|---|
| sister 모듈 3곳의 `module Keeper_stream = ...` alias | `Keeper_stream.` 콜사이트 0 (옛 라우트 분할 잔재) |
| `For_testing.empty_stream_bridge_state`/`translate_oas_stream_event` | 콜러 0 — gate-backend 테스트는 `Keeper_chat_oas_stream_bridge`를 직접 구동. production 바인딩·콜사이트는 유지 |
| `For_testing.modalities_for_request` | 콜러 0 재수출. production 함수·사용처 유지 |

검증: `@check` green. RFC-WAIVED: dead-surface 감사 집행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
