### PR TITLE
refactor(server): resolve the runtime_info test-seam audit — one alias excised, the rest ratified

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1146,10 +1146,6 @@ let dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes =
     ]
 ;;
 
-let dashboard_runtime_probe_payload_json_for_tests ?default_id runtimes =
-  dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes
-;;
-
 let run_dashboard_runtime_probe () =
   match Atomic.get dashboard_runtime_probe_runner_hook with
   | Some hook -> hook ()

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -18,6 +18,7 @@
       ({!runtime_resolution_json},
       {!light_runtime_resolution_json},
       {!dashboard_runtime_probe_http_json},
+      {!dashboard_runtime_probe_payload_json_of_runtimes},
       {!runtime_inventory_json},
       {!dashboard_perf_http_json},
       {!scheduled_automation_dashboard_json},
@@ -25,7 +26,6 @@
     - {b runtime probe test seams}
       ({!set_dashboard_runtime_probe_runner_for_tests},
       {!clear_dashboard_runtime_probe_runner_for_tests},
-      {!dashboard_runtime_probe_payload_json_for_tests},
       {!set_dashboard_runtime_provider_http_get_for_tests},
       {!clear_dashboard_runtime_provider_http_get_for_tests},
       {!clear_dashboard_runtime_probe_cache_for_tests}).
@@ -111,11 +111,13 @@ val maybe_fork_dashboard_runtime_probe_refresh : unit -> unit
     the server boot path to warm the cache before the first dashboard request
     so the first response is not a [warming_up] placeholder. *)
 
-val dashboard_runtime_probe_payload_json_for_tests :
+val dashboard_runtime_probe_payload_json_of_runtimes :
   ?default_id:string -> Runtime.t list -> Yojson.Safe.t
-(** Test-only pure projection for the production runtime reachability payload.
-    HTTP execution is supplied through
-    {!set_dashboard_runtime_provider_http_get_for_tests}. *)
+(** Pure reachability-probe projection over an explicit [Runtime.t list].
+    [run_dashboard_runtime_probe] calls this with the live runtime fleet;
+    exposed directly (rather than via a [_for_tests] alias) so tests can drive
+    it with synthetic runtimes. HTTP execution is supplied by the production
+    GET path or, in tests, {!set_dashboard_runtime_provider_http_get_for_tests}. *)
 
 val gate_hitl_json : unit -> Yojson.Safe.t
 (** Returns the always-available, nonblocking human-decision handler state

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1030,7 +1030,7 @@ let assert_dashboard_runtime_probe_reachable runtime =
            , [ "content-type", "application/json" ]
            , {|{"data":[{"id":"qwen"}]}|} ))
       (fun () ->
-         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_for_tests
+         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_of_runtimes
            ~default_id:"runpod_mtp.qwen" [ runtime ])
   in
   let reachable_provider = first_provider_probe reachable_json in
@@ -1059,7 +1059,7 @@ let assert_dashboard_runtime_probe_missing_auth runtime =
       ~finally:(fun () ->
         Server_dashboard_http_runtime_info.clear_dashboard_runtime_provider_http_get_for_tests ())
       (fun () ->
-         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_for_tests
+         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_of_runtimes
            ~default_id:"runpod_mtp.qwen" [ runtime ])
   in
   let provider = first_provider_probe json in
@@ -1088,7 +1088,7 @@ let assert_dashboard_runtime_probe_redacts_url_credentials () =
     with_dashboard_probe_http_get
       (fun ~url:_ ~headers:_ ~timeout_sec:_ -> Ok (200, [], {|{"data":[]}|}))
       (fun () ->
-         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_for_tests
+         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_of_runtimes
            ~default_id:"runpod_mtp.qwen" [ runtime ])
   in
   let provider = first_provider_probe json in


### PR DESCRIPTION
godfile 시리즈 3호 — 의도적으로 기록하는 **부정 결과**입니다. 감사가 지목한 runtime_info 시임 21개 중 실제 절제 가능은 1개뿐이었습니다.

- **절제 1**: `dashboard_runtime_probe_payload_json_for_tests` = 순수 별칭 → 실제 production 이름을 직접 노출, 테스트 3곳 rename (단언 불변)
- **비준 19**: 나머지 전부가 impure/동시성 기계(Atomic TTL 캐시, single-flight CAS, subprocess, 백그라운드 fork 도메인)의 **유일한 결정론 제어점** — argv drift guard 포함. 제거는 동시성 회귀 커버리지의 손실
- **감사 증거 오류 정정 1**: `scheduled_automation_dashboard_json`은 test-only가 아님 — production이 `dashboard_tools_http_json`(bootstrap 실배선) 내부에서 직접 호출. 감사 콜러 목록이 이를 누락. 이후 스윕의 재론 방지를 위해 기록

검증: `@check` green + 영향 스위트 5종 전부 PASS (128 케이스, 동시성 스위트 포함). 집행: rtinfo-seam-excisor 에이전트(시임별 3분류 판정) + 제 스팟 검증.

RFC-WAIVED: dead-surface 감사 집행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
