### PR TITLE
chore(deps): bump agent_sdk lower bound to 0.219.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.217.4))
+  (agent_sdk (>= 0.219.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {>= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.217.4"}
+  "agent_sdk" {>= "0.219.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Why

OAS released 0.219.0 (v0.218.0 + v0.219.0): runtime cluster 9-module redesign, test-only agent_sdk re-export drop (9 modules), legacy Api/Streaming/Provider_intf dispatch island retire, eval/harness purge, Internal zero-consumer purge, TTFT docstring fix, lifecycle event exception arm. The live opam pin is already `agent_sdk.0.219.0` — this raises the declared lower bound to match.

## Change
- masc.opam: `"agent_sdk" {>= "0.217.4"}` -> `{>= "0.219.0"}`
- dune-project: `(agent_sdk (>= 0.217.4))` -> `(>= 0.219.0)`

No code change; version contract only.

Co-Authored-By: Claude <noreply@anthropic.com>
