### PR TITLE
fix(keeper): escalate manual compaction after consecutive failures (RFC-0351 S0, #25461)

### DIFF
--- a/docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md
+++ b/docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md
@@ -40,7 +40,7 @@ evidence: knowledge/research/2026-07-20-memory-first-context-management-adversar
 ## 3. 목표 아키텍처 (5층 ordering)
 
 ```
-L1 Write   librarian 상시 추출 + delivery accounting (drop-not-block → due-backlog)
+L1 Write   모델이 memory tool 로 직접 기록(주 경로) + 예산 게이지 노출; librarian 추출은 보조
 L2 Judge   consolidation = LLM-judged merge/forget (중복 병합의 유일 결정자, RFC-0332 준수)
 L3 Select  검색 기반 recall 주입 (bulk 500/500 전량 주입 은퇴; RFC-0244 계열/pgvector)
 L4 Flush   예산 근접 시 memory flush silent turn (openclaw shape) — 떨어져 나갈 내용의 durable 저장 유도
@@ -48,6 +48,9 @@ L5 Budget  매턴 조립 예산: persona + dynamic + Select 결과 + 최근 창(
            초과 시 결정론적 축소 순서(Select 주입분 → 오래된 최근 창)로 재조립. history 재작성 없음.
 ```
 
+- **L1의 주체는 모델이다 (2026-07-21 개정).** 기록은 `keeper_memory_write` 계열 tool call로 모델이 직접 수행하고, 시스템은 예산 게이지(현재 조립 크기 / 예산)를 프롬프트에 노출한다. librarian의 turn-후 추출은 모델이 놓친 것을 메우는 **보조** 경로로 강등한다. 근거: (a) tool call은 동기 실행이고 결과가 `tool_result`로 모델에 돌아오므로 **드롭이 구조적으로 불가능** — 현행 `Keeper_memory_lane`의 `max_pending`(in-flight 1 + queued 1) 초과 드롭과, 호출부(`keeper_agent_run_post_turn_memory.ml:131,137`)가 `outcome`을 `_`로 폐기하는 조용한 유실 경로가 함께 사라진다. (b) 선례: Letta/MemGPT는 "agents self-edit their memory", Hermes는 게이지를 모델에게 보여주고 메모리 탱크 관리를 맡긴다. (c) §2.1 "판단은 LLM 경계"의 직접 실행 — 무엇을 기억할지의 판단이 LLM 쪽에 놓인다.
+- 게이지 노출은 §2.2가 금지한 "중요도 점수·문자열 분류·휴리스틱 임계값"이 아니라 허용된 **예산 산술(정수 비교)**이다. 시스템은 숫자만 제시하고 임계 판단을 하지 않는다. 게이지가 없으면 모델은 자기 상태를 환각한다 — analyst가 "Memory OS가 턴마다 1500개+ 에피소드 덤프"라고 진단했으나 실측은 268~500(cap)이었고, 그 오진이 fact로 저장돼 매 턴 재주입되며 고착했다(2026-07-21 감사).
+- 모델이 기록을 게을리할 위험은 **L4 Flush가 흡수한다**: 평소 모델 자율, 예산 근접 시 시스템이 flush 턴을 강제. (Hermes 게이지 + openclaw pre-compaction flush 조합)
 - L5의 "최근 창"은 recency 구조이지 중요도 판단이 아니다. keeper는 일직선 타임라인이므로 최근성은 타임라인의 구조 자체다. 의미 보존은 L1-L4가 이미 수행했다.
 - typed provider overflow(`Error.Api (ContextOverflow _)`)는 여전히 도착할 수 있다(GLM/Kimi/DeepSeek 토큰 카운팅 typed-Unsupported → 예산은 직전 턴 api_usage 반응형). 대응은 **더 작은 재조립**(결정론적 degrade)이지 checkpoint 수술이 아니다.
 
@@ -92,6 +95,7 @@ S4 전까지 typed trigger(`Provider_overflow | Manual`)와 partition/evidence/C
 - LLM bulk-summarize의 개선/재작성 (동결 대상에 투자 금지)
 - 결정론적 floor(#25281)의 신규 완성 (assembly가 대체; 열린 PR 처분은 S3 시점 재평가)
 - write-side jaccard/문자열 dedup (RFC-0332 기각 유지)
+- **memory lane 의 delivery accounting / due-backlog 인프라** — L1이 모델 tool call 주도로 바뀌면서 불필요해진다. 배달 보증 계층을 만드는 대신 드롭이 발생할 수 있는 구조 자체를 없앤다. `Keeper_memory_lane`은 librarian 보조 추출 전용으로 축소 유지하되, 그 경로의 유실은 계측(counter)만 하고 인프라 투자는 하지 않는다.
 - OAS에 MASC 개념 유입 (replay 교정은 provider capability 데이터 정정일 뿐)
 
 ## 9. 리스크

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -303,7 +303,22 @@ let single_approved_resolution lease =
   | [] | [ _ ] | _ :: _ :: _ -> None
 ;;
 
-let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease outcome =
+(* RFC-0351 S0 / #25461: consecutive manual-compaction failures tolerated before
+   the settlement escalates instead of requeuing. A requeue is not an ack, so
+   without a ceiling the same stimulus re-enters on every heartbeat cycle —
+   measured at 102 failures / 104 compaction LLM calls in 74 minutes after the
+   #25413 build went live. Three attempts keeps a transient CAS/source race
+   recoverable while bounding a structurally-stuck compaction. *)
+let compaction_retry_escalation_threshold = 3
+
+let settlement_of_cycle_outcome
+      ~base_path
+      ~settled_at
+      ~stop_requested
+      ~compaction_consecutive_failures
+      ~lease
+      outcome
+  =
   match single_approved_resolution lease with
   | Some resolution ->
     (match
@@ -377,8 +392,25 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
          ; successor = None
          })
   | Some (Cycle.Manual_compaction_failed _) ->
-    Keeper_registry_event_queue.Requeue
-      Keeper_registry_event_queue.Context_compaction_retry
+    (* This failure is the [compaction_consecutive_failures + 1]-th in a row for
+       this keeper; the counter itself is advanced by the compaction commit path
+       on [keeper_meta.runtime.compaction_rt]. *)
+    let attempts = compaction_consecutive_failures + 1 in
+    if attempts >= compaction_retry_escalation_threshold
+    then
+      Keeper_registry_event_queue.Escalate
+        { reason =
+            Keeper_registry_event_queue.Compaction_retry_exhausted
+              { attempts
+              ; detail =
+                  "manual compaction failed on consecutive attempts; retry \
+                   suspended pending operator inspection"
+              }
+        ; successor = None
+        }
+    else
+      Keeper_registry_event_queue.Requeue
+        Keeper_registry_event_queue.Context_compaction_retry
   | Some (Cycle.Manual_compaction_not_applied { no_compaction = { source; reason }; _ }) ->
     Keeper_registry_event_queue.No_compaction { source; reason }
   | None ->
@@ -863,9 +895,44 @@ let run_keepalive_unified_turn
              ~base_path:ctx.config.base_path
              ~settled_at
              ~stop_requested:(Atomic.get stop)
+             ~compaction_consecutive_failures:
+               meta_after_triage.runtime.compaction_rt.consecutive_failures
              ~lease
              !cycle_outcome_ref
          in
+         (* RFC-0351 S0 / #25461: advance the compaction streak the settlement
+            above just read. Ordering matters — the settlement decides
+            requeue-vs-escalate from the streak *before* this failure, and this
+            stamp records the failure for the next cycle. *)
+         (let compaction_outcome =
+            match !cycle_outcome_ref with
+            | Some (Cycle.Manual_compaction_applied _) -> Some `Committed
+            | Some (Cycle.Manual_compaction_failed _) -> Some `Failed
+            | Some
+                ( Cycle.Completed _
+                | Cycle.Cancelled _
+                | Cycle.Skipped _
+                | Cycle.Busy _
+                | Cycle.Failed _
+                | Cycle.Judgment_settled _
+                | Cycle.Manual_compaction_not_applied _ )
+            | None -> None
+          in
+          match compaction_outcome with
+          | None -> ()
+          | Some outcome ->
+            (match
+               Keeper_meta_store.persist_compaction_outcome
+                 ctx.config
+                 ~keeper_name:meta_after_triage.name
+                 ~outcome
+             with
+             | Ok (`Persisted | `No_durable_meta) -> ()
+             | Error message ->
+               Log.Keeper.warn
+                 "compaction outcome counter not persisted keeper=%s: %s"
+                 meta_after_triage.name
+                 message));
          (match
             settle_claimed_lease
               ~base_path:ctx.config.base_path

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -134,11 +134,20 @@ val settlement_of_cycle_outcome :
   base_path:string ->
   settled_at:float ->
   stop_requested:bool ->
+  compaction_consecutive_failures:int ->
   lease:Keeper_registry_event_queue.lease ->
   Keeper_heartbeat_loop_cycle.cycle_outcome option ->
   Keeper_registry_event_queue.settlement
 (** Pure lease settlement boundary. Completed work acknowledges; typed
-    cancellation and non-executable-phase skips requeue. *)
+    cancellation and non-executable-phase skips requeue.
+
+    [compaction_consecutive_failures] is the keeper's current failure streak
+    from [keeper_meta.runtime.compaction_rt]. A manual-compaction failure
+    settles as [Escalate Compaction_retry_exhausted] once this failure would
+    reach the escalation threshold, and as
+    [Requeue Context_compaction_retry] below it — a requeue is not an ack, so
+    without the ceiling the same stimulus re-enters every cycle (RFC-0351 S0,
+    #25461). *)
 
 val project_transition_outbox :
   base_path:string -> keeper_name:string -> (unit, string) result

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -46,6 +46,13 @@ type compaction_runtime =
   ; last_after_tokens : int
   ; last_check_ts : float
   ; last_decision : compaction_runtime_decision
+  ; consecutive_failures : int
+    (* RFC-0351 S0 / #25461: consecutive [Manual_compaction_failed] settlements
+       for this keeper. Incremented on failure, reset to 0 on a committed
+       compaction. The heartbeat settlement path escalates instead of requeuing
+       once this reaches [compaction_retry_escalation_threshold]; without it a
+       failing compaction requeues forever (measured: 102 failures / 104
+       compaction LLM calls in 74 minutes). *)
   }
 
 type proactive_runtime =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -63,6 +63,10 @@ type compaction_runtime = {
   last_after_tokens : int;
   last_check_ts : float;
   last_decision : compaction_runtime_decision;
+  consecutive_failures : int;
+      (** RFC-0351 S0 / #25461: consecutive manual-compaction failures.  Reset to
+          0 on a committed compaction; the heartbeat settlement escalates instead
+          of requeuing once it reaches the escalation threshold. *)
 }
 
 type proactive_runtime = {

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -43,6 +43,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "last_compaction_ts", `Float rt.compaction_rt.last_ts
     ; "last_compaction_before_tokens", `Int rt.compaction_rt.last_before_tokens
     ; "last_compaction_after_tokens", `Int rt.compaction_rt.last_after_tokens
+    ; ( "compaction_consecutive_failures"
+      , `Int rt.compaction_rt.consecutive_failures )
     ; "proactive_count_total", `Int rt.proactive_rt.count_total
     ; "last_proactive_ts", `Float rt.proactive_rt.last_ts
     ; "proactive_visible_count_total", `Int rt.proactive_rt.visible_count_total

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -160,6 +160,8 @@ let parse_compaction_runtime (json : Yojson.Safe.t) : compaction_runtime =
   ; last_decision =
       Safe_ops.json_string ~default:"uninitialized" "last_compaction_decision" json
       |> compaction_runtime_decision_of_string
+  ; consecutive_failures =
+      Safe_ops.json_int ~default:0 "compaction_consecutive_failures" json
   }
 ;;
 

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -554,6 +554,38 @@ let persist_compaction_decision config ~keeper_name ~decision
     |> Result.map (fun () -> `Persisted)
 ;;
 
+(* RFC-0351 S0 / #25461: advance the consecutive-failure streak that the
+   heartbeat settlement reads to choose requeue-vs-escalate.  Same
+   read/stamp/merge shape as [persist_compaction_decision] so a concurrent CAS
+   re-applies the stamp instead of dropping it.
+
+   [`Committed] also advances [count].  That field had no writer: it was
+   serialized to meta and rendered by the dashboard while nothing incremented
+   it, so a keeper whose compaction pipeline was committing normally still
+   reported compaction_count=0 — one keeper carried 88 committed
+   [context_compacted] runtime-manifest records against a meta reading 0. *)
+let persist_compaction_outcome config ~keeper_name ~outcome
+  : ([ `Persisted | `No_durable_meta ], string) result
+  =
+  let stamp (m : Keeper_meta_contract.keeper_meta) =
+    Keeper_meta_contract.map_compaction_rt
+      (fun rt ->
+        match outcome with
+        | `Committed -> { rt with count = rt.count + 1; consecutive_failures = 0 }
+        | `Failed -> { rt with consecutive_failures = rt.consecutive_failures + 1 })
+      m
+  in
+  match read_meta config keeper_name with
+  | Error msg -> Error msg
+  | Ok None -> Ok `No_durable_meta
+  | Ok (Some disk_meta) ->
+    write_meta_with_merge
+      ~merge:(fun ~latest ~caller:_ -> stamp latest)
+      config
+      (stamp disk_meta)
+    |> Result.map (fun () -> `Persisted)
+;;
+
 type identity_update_error =
   | Identity_missing
   | Identity_changed

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -250,3 +250,17 @@ val persist_compaction_decision :
   keeper_name:string ->
   decision:Keeper_meta_contract.compaction_runtime_decision ->
   ([ `Persisted | `No_durable_meta ], string) result
+
+val persist_compaction_outcome :
+  Workspace.config ->
+  keeper_name:string ->
+  outcome:[ `Committed | `Failed ] ->
+  ([ `Persisted | `No_durable_meta ], string) result
+(** Advance the compaction outcome counters on [compaction_rt] using the same
+    read/stamp/merge shape as {!persist_compaction_decision}.
+
+    [`Committed] increments [count] and resets [consecutive_failures] to 0;
+    [`Failed] increments [consecutive_failures]. The streak is what
+    {!settlement_of_cycle_outcome} reads to escalate instead of requeuing a
+    failing compaction (RFC-0351 S0, #25461); [count] had no writer before this
+    despite being serialized and rendered. *)

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -28,6 +28,10 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       { judge_runtime_id : string
       ; rationale : string
       }
+  | Compaction_retry_exhausted of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -27,6 +27,10 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       { judge_runtime_id : string
       ; rationale : string
       }
+  | Compaction_retry_exhausted of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -243,6 +243,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_after_tokens = 0;
             last_check_ts = now_ts;
             last_decision = compaction_runtime_decision_of_string "initialized";
+            consecutive_failures = 0;
           };
           proactive_rt = {
             count_total = 0;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -25,6 +25,10 @@ type escalation_reason = State.escalation_reason =
       { judge_runtime_id : string
       ; rationale : string
       }
+  | Compaction_retry_exhausted of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = State.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -29,6 +29,10 @@ type escalation_reason = Keeper_event_queue_state.escalation_reason =
       { judge_runtime_id : string
       ; rationale : string
       }
+  | Compaction_retry_exhausted of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = Keeper_event_queue_state.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -22,6 +22,17 @@ type escalation_reason =
       { judge_runtime_id : string
       ; rationale : string
       }
+  | Compaction_retry_exhausted of
+      { attempts : int
+      ; detail : string
+      }
+    (* RFC-0351 S0 / #25461: a failing manual compaction previously settled as
+       [Requeue Context_compaction_retry] with no attempt counter, so the same
+       stimulus re-entered on every heartbeat cycle (measured: 102 failures /
+       104 compaction LLM calls in 74 minutes). After
+       [compaction_retry_escalation_threshold] consecutive failures the
+       settlement escalates instead, surfacing the blocker rather than
+       re-firing. *)
 
 type no_compaction_reason =
   | No_eligible_history
@@ -45,7 +56,8 @@ type accepted_cancellation =
 let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
-  | Failure_judgment_boundary_failed _ -> false
+  | Failure_judgment_boundary_failed _
+  | Compaction_retry_exhausted _ -> false
 ;;
 
 type settlement =
@@ -288,6 +300,7 @@ let escalation_reason_label = function
   | Failure_judgment_boundary_failed _ -> "failure_judgment_boundary_failed"
   | Failure_judgment_external_input_requested _ ->
     "failure_judgment_external_input_requested"
+  | Compaction_retry_exhausted _ -> "compaction_retry_exhausted"
 ;;
 
 let escalation_reason_detail_to_yojson = function
@@ -299,6 +312,8 @@ let escalation_reason_detail_to_yojson = function
       [ "judge_runtime_id", `String judge_runtime_id
       ; "rationale", `String rationale
       ]
+  | Compaction_retry_exhausted { attempts; detail } ->
+    `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
 ;;
 
 let required_nonempty_reason_string ~context name fields =
@@ -343,6 +358,28 @@ let escalation_reason_of_wire ~label ~detail_json =
         fields
     in
     Ok (Failure_judgment_boundary_failed { detail })
+  | "compaction_retry_exhausted", `Assoc fields ->
+    let* () =
+      exact_reason_fields
+        ~context:"compaction_retry_exhausted"
+        [ "attempts"; "detail" ]
+        fields
+    in
+    let* attempts =
+      match List.assoc_opt "attempts" fields with
+      | Some (`Int value) when value > 0 -> Ok value
+      | Some (`Int _) ->
+        Error "compaction_retry_exhausted.attempts must be positive"
+      | Some _ -> Error "compaction_retry_exhausted.attempts must be an int"
+      | None -> Error "compaction_retry_exhausted.attempts is required"
+    in
+    let* detail =
+      required_nonempty_reason_string
+        ~context:"compaction_retry_exhausted"
+        "detail"
+        fields
+    in
+    Ok (Compaction_retry_exhausted { attempts; detail })
   | "failure_judgment_external_input_requested", `Assoc fields ->
     let* () =
       exact_reason_fields
@@ -485,6 +522,9 @@ let validate_settlement = function
       { reason = Failure_judgment_external_input_requested _; successor = Some _ }
     ->
     Error "external-input failure judgment must not enqueue a successor"
+  | Escalate { reason = Compaction_retry_exhausted _; successor = None } -> Ok ()
+  | Escalate { reason = Compaction_retry_exhausted _; successor = Some _ } ->
+    Error "compaction retry exhaustion must not enqueue a successor"
 ;;
 
 (* Pure receipt-vs-stimuli invariant. Kept in ONE place so the live settle

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -29,6 +29,15 @@ type escalation_reason =
       { judge_runtime_id : string
       ; rationale : string
       }
+  | Compaction_retry_exhausted of
+      { attempts : int
+      ; detail : string
+      }
+      (** RFC-0351 S0 / #25461: settled instead of
+          [Requeue Context_compaction_retry] once consecutive manual-compaction
+          failures reach the escalation threshold.  A requeue is not an ack, so
+          without this ceiling the same stimulus re-enters every heartbeat
+          cycle. *)
 
 type no_compaction_reason =
   | No_eligible_history

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -791,6 +791,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
             ~base_path
             ~settled_at:3.0
             ~stop_requested:false
+            ~compaction_consecutive_failures:0
             ~lease
             None
         with
@@ -864,6 +865,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
             ~base_path
             ~settled_at:4.0
             ~stop_requested:false
+            ~compaction_consecutive_failures:0
             ~lease
             None
         with

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1058,6 +1058,7 @@ let test_manual_no_compaction_is_terminal_but_overflow_escalates () =
        ~base_path:"/tmp/no-compaction-manual"
        ~settled_at:2.0
        ~stop_requested:false
+       ~compaction_consecutive_failures:0
        ~lease
        (Some
           (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_not_applied
@@ -1099,6 +1100,7 @@ let test_applied_compaction_settles_followup_atomically () =
       ~base_path:(Sys.getcwd ())
       ~settled_at:8.0
       ~stop_requested:false
+      ~compaction_consecutive_failures:0
       ~lease
       (Some
          (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_applied
@@ -1134,6 +1136,54 @@ let test_applied_compaction_settles_followup_atomically () =
   | _ -> Alcotest.fail "follow-up retry replayed an already-applied compaction"
 ;;
 
+(* RFC-0351 S0 / #25461: a manual-compaction failure requeues while the streak
+   is under the ceiling and settles terminally at it. Without the ceiling the
+   stimulus re-enters on every heartbeat cycle, because [Requeue] is not an ack
+   (measured: 102 failures / 104 compaction LLM calls in 74 minutes). *)
+let test_compaction_retry_escalates_after_threshold () =
+  let lease = lease_for (stimulus "compaction-retry" 1.0) in
+  let meta = cycle_meta () in
+  let failed =
+    Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_failed
+      { meta
+      ; failure =
+          Masc.Keeper_manual_compaction.Recovery
+            ( Masc.Keeper_post_turn.Checkpoint_candidate_failed
+                "test-induced candidate failure"
+            , Ok () )
+      }
+  in
+  let settlement ~streak =
+    Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
+      ~base_path:"/tmp/compaction-retry-ceiling"
+      ~settled_at:2.0
+      ~stop_requested:false
+      ~compaction_consecutive_failures:streak
+      ~lease
+      (Some failed)
+  in
+  let expect_requeue ~streak label =
+    match settlement ~streak with
+    | Masc.Keeper_registry_event_queue.Requeue
+        Masc.Keeper_registry_event_queue.Context_compaction_retry ->
+      ()
+    | _ -> Alcotest.fail label
+  in
+  expect_requeue ~streak:0 "first compaction failure did not requeue";
+  expect_requeue ~streak:1 "second compaction failure did not requeue";
+  match settlement ~streak:2 with
+  | Masc.Keeper_registry_event_queue.Escalate
+      { reason =
+          Masc.Keeper_registry_event_queue.Compaction_retry_exhausted
+            { attempts; _ }
+      ; successor = None
+      } ->
+    Alcotest.(check int) "escalation reports the attempt count" 3 attempts
+  | _ ->
+    Alcotest.fail
+      "third consecutive compaction failure requeued instead of escalating"
+;;
+
 let test_cancelled_and_skipped_cycles_requeue () =
   let lease = lease_for (stimulus "phase-gated" 1.0) in
   let meta = cycle_meta () in
@@ -1142,6 +1192,7 @@ let test_cancelled_and_skipped_cycles_requeue () =
       ~base_path:"/tmp/non-approval-cycle"
       ~settled_at:2.0
       ~stop_requested:false
+      ~compaction_consecutive_failures:0
       ~lease
       (Some outcome)
   in
@@ -1973,6 +2024,10 @@ let () =
             "cancelled and skipped cycles requeue"
             `Quick
             test_cancelled_and_skipped_cycles_requeue
+        ; Alcotest.test_case
+            "compaction retry escalates after threshold"
+            `Quick
+            test_compaction_retry_escalates_after_threshold
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick


### PR DESCRIPTION
## 목적

RFC-0351 S0 — 실패한 manual compaction 이 무한 재시도하는 경로를 typed terminal settlement 로 종결시킨다. Closes #25461 의 재시도 폭풍 부분.

RFC: `docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md` (S0 단계). 같은 RFC 의 L1 정의도 이 PR 에서 개정한다.

## 배경 — 왜 무한 루프였나

`Manual_compaction_failed` 는 `Requeue Context_compaction_retry` 로 settle 되는데, 재시도 횟수를 세는 곳이 **경로 어디에도 없다**:

- `lease` 레코드(`lease_id` / `sequence` / `kind` / `claimed_at` / `stimuli`)에 requeue 카운터 없음
- event queue 도 같은 stimulus 가 몇 번 되돌아왔는지 추적하지 않음
- `settlement_is_ack` 기준으로 `Requeue` 는 ack 가 아니므로 다음 heartbeat cycle 에 그대로 재진입

즉 구조적으로 막힌 compaction 은 영원히 재발화한다. `keeper_compact_policy.ml:298-300` 주석이 실사고를 인용한다 — **#25413 빌드 배포 후 74분간 102 failures / 104 compaction LLM calls**.

## 변경

**1. `compaction_rt.consecutive_failures` 추가** (`keeper_meta_contract`)
- 파싱 기본값 0, 직렬화 키 `compaction_consecutive_failures`
- 신규 keeper 초기값 0

**2. `Keeper_meta_store.persist_compaction_outcome` 신설**
- `persist_compaction_decision` 과 동일한 read → `map_compaction_rt` stamp → `write_meta_with_merge` (CAS 경합 시 재적용) 형태
- `` `Committed `` → `count + 1`, `consecutive_failures = 0`
- `` `Failed `` → `consecutive_failures + 1`

**3. `Compaction_retry_exhausted` escalation variant 추가**
- `keeper_event_queue_state` → `keeper_event_queue_persistence` → `keeper_registry_event_queue` 3계층 재노출
- wire label `compaction_retry_exhausted`, detail `{attempts, detail}`
- successor 를 동반하면 거부하는 불변식 추가 (기존 escalation 들과 동일 취급)

**4. `settlement_of_cycle_outcome` 에 `~compaction_consecutive_failures` 배선**
- 3회 연속 실패에 도달하면 `Requeue` 대신 `Escalate Compaction_retry_exhausted`
- 임계값은 named constant (`compaction_retry_escalation_threshold = 3`), 근거 주석 포함
- heartbeat loop 이 settlement 계산 **뒤에** 카운터를 stamp 한다 — settlement 은 이번 실패 *이전* 의 streak 로 판단하고, stamp 는 다음 cycle 용

**5. `compaction_rt.count` 에 최초 writer 배선**
- 이 필드는 meta 에 직렬화되고 대시보드가 렌더하는데 **증가시키는 코드가 리포에 0건**이었다
- 그래서 compaction 이 정상 커밋되는 keeper 도 `compaction_count: 0` 으로 보였다 — 한 keeper 는 `context_compacted` runtime-manifest 레코드 88건을 갖고도 meta 는 0
- S0 게이트("재시도 폭풍 0건/24h")를 관측하려면 이 카운터가 살아있어야 한다

## 로컬 검증

- `dune build --root . lib` — clean (`REAL_EXIT_CODE=0`)
- 신규 테스트 `compaction retry escalates after threshold` — **[OK]** (state 그룹 16번)
  - streak 0, 1 → `Requeue Context_compaction_retry`
  - streak 2 (즉 3번째 연속 실패) → `Escalate Compaction_retry_exhausted { attempts = 3 }`
- 기존 `settlement_of_cycle_outcome` 호출부 5곳(`test_keeper_event_queue_state_v2` 3, `test_keeper_approval_queue` 2)에 새 인자 배선

## 남은 미검증

- **`test_keeper_event_queue_state_v2` 에 pre-existing 실패 1건**: `persistence 4 — legacy settlement WAL v1 remains replayable` (`settlement WAL row owner does not match its Keeper lane`). `origin/main` 을 detached worktree 로 따로 빌드해 **동일하게 재현** 확인 — 이 PR 과 무관하며 별도 이슈 대상.
- 라이브 검증(24h 재시도 폭풍 0건) 미수행. 배포 후 `compaction_consecutive_failures` 와 `compaction_count` 가 실제로 진행하는지 확인 필요.
- `dune build --root . @all` 미수행 (lib + 해당 테스트 타겟만 빌드).
- 임계값 3 은 "transient CAS/source race 는 회복 가능하게, 구조적 정체는 조기 차단" 근거의 판단값이며 라이브 데이터로 조정되지 않았다.

## RFC-0351 L1 개정 (동봉)

L1 이 `librarian 상시 추출 + delivery accounting (drop-not-block → due-backlog)` 로 규정돼 있었다. 이를 **모델이 `keeper_memory_write` tool call 로 직접 기록 + 예산 게이지 노출**로 바꾸고 librarian 추출을 보조로 강등한다.

tool call 은 동기 실행이고 결과가 `tool_result` 로 모델에 돌아오므로 드롭이 구조적으로 불가능하다 — `Keeper_memory_lane` 의 `max_pending`(in-flight 1 + queued 1) 초과 드롭과, 호출부(`keeper_agent_run_post_turn_memory.ml:131,137`)가 `outcome` 을 `_` 로 폐기하는 조용한 유실 경로가 함께 사라진다. 따라서 L1 이 요구하던 delivery-accounting 인프라는 Non-goals 로 이동한다.

선례: Letta/MemGPT("agents self-edit their memory"), Hermes(모델에게 메모리 게이지를 보여주고 탱크 관리를 맡김). 게이지 노출은 §2.2 가 금지한 휴리스틱 임계값이 아니라 허용된 예산 산술이며, §2.1 "판단은 LLM 경계" 의 직접 실행이다.

게이지가 없으면 모델이 자기 상태를 환각한다: 한 keeper 가 "Memory OS 가 턴마다 1500개+ 에피소드를 덤프한다" 고 진단했으나 실측은 268–500(cap) 이었고, 그 오진이 fact 로 저장돼 매 턴 재주입되며 고착했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
