### PR TITLE
fix(keeper): stop recording bare autonomous wakes in the transcript (RFC-0351 S1, #25462)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -189,6 +189,7 @@ let run_turn
       ?world_observation
       ~(generation : int)
       ?(history_user_source = "direct_user")
+      ?(user_turn_record = Keeper_run_prompt.Record_user_turn)
       ?(history_assistant_source = "direct_assistant")
       ?temperature
       ?on_event
@@ -375,6 +376,7 @@ let run_turn
       ~config
       ~meta
       ~history_user_source
+      ~user_turn_record
       ~is_retry
       ~start_turn_count
   in

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -125,6 +125,7 @@ val run_turn
   -> ?world_observation:Keeper_world_observation.world_observation
   -> generation:int
   -> ?history_user_source:string
+  -> ?user_turn_record:Keeper_run_prompt.user_turn_record
   -> ?history_assistant_source:string
   -> ?temperature:float
   -> ?on_event:(Agent_sdk.Types.sse_event -> unit)

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -17,6 +17,31 @@ type turn_prompt_context =
   ; ctx_work : Keeper_context_runtime.working_context
   }
 
+(* RFC-0351 section 5 / #25462: an autonomous wake whose user turn is only the
+   [autonomous_wake_marker] constant carries nothing forward — the observation
+   frame it stands for rides [dynamic_context], rebuilt fresh every turn and
+   never persisted. Recording it anyway appends a byte-identical message per
+   wake, which is pure transcript duplication (analyst: the same 147B message
+   x359, part of a 25.7% exact-dup share). The distinction is typed here rather
+   than inferred from the message text. *)
+type user_turn_record =
+  | Record_user_turn
+      (** The user turn carries content later turns need: an operator message,
+          a HITL resolution, or chat-lane input. *)
+  | Skip_uninformative_wake
+      (** Autonomous wake marker alone. Neither appended to the working context
+          nor persisted to session history. *)
+
+(* The unified lane's user turn is the wake marker constant unless a HITL
+   resolution was appended to it, so the presence of that resolution is the
+   whole signal. Extracted from the lane call site to keep the mapping
+   unit-testable and to keep the decision out of the message text. *)
+let user_turn_record_of_hitl_resolution : _ option -> user_turn_record
+  = function
+  | None -> Skip_uninformative_wake
+  | Some _ -> Record_user_turn
+;;
+
 type extra_system_context_assembly =
   { extra_system_context : string option
   ; blocks : (Prompt_block_id.t * string) list
@@ -59,6 +84,7 @@ let build_turn_context
       ~config:(_ : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(history_user_source : string)
+      ~(user_turn_record : user_turn_record)
       ~(is_retry : bool)
       ~(start_turn_count : int)
   : turn_prompt_context
@@ -116,11 +142,18 @@ let build_turn_context
   let history_messages =
     Keeper_context_runtime.messages_of_context ctx_work
   in
-  let ctx_work = Keeper_context_runtime.append ctx_work user_msg in
-  if not is_retry
-  then
-    Keeper_context_runtime.persist_message
-      ~source:history_user_source session user_msg;
+  let ctx_work =
+    match user_turn_record with
+    | Record_user_turn -> Keeper_context_runtime.append ctx_work user_msg
+    | Skip_uninformative_wake -> ctx_work
+  in
+  (match user_turn_record, is_retry with
+   | Record_user_turn, false ->
+     Keeper_context_runtime.persist_message
+       ~source:history_user_source
+       session
+       user_msg
+   | Record_user_turn, true | Skip_uninformative_wake, _ -> ());
   { turn_system_prompt
   ; dynamic_context
   ; memory_context

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -17,6 +17,22 @@ type turn_prompt_context =
   ; ctx_work : Keeper_context_runtime.working_context
   }
 
+type user_turn_record =
+  | Record_user_turn
+  | Skip_uninformative_wake
+(** Whether this turn's user message belongs in the durable transcript.
+
+    [Skip_uninformative_wake] is the autonomous wake marker on its own: a
+    constant whose observation frame rides [dynamic_context], rebuilt fresh
+    every turn. Recording it appends a byte-identical message per wake and
+    becomes pure duplication — one keeper accumulated the same 147B message
+    x359 (RFC-0351 section 5, #25462). The distinction is typed, not inferred
+    from message text. *)
+
+val user_turn_record_of_hitl_resolution : _ option -> user_turn_record
+(** Map the unified lane's HITL resolution slot to a transcript decision.
+    Absent resolution means the user turn is the bare wake marker. *)
+
 type extra_system_context_assembly =
   { extra_system_context : string option
   ; blocks : (Prompt_block_id.t * string) list
@@ -46,6 +62,7 @@ val build_turn_context
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> history_user_source:string
+  -> user_turn_record:user_turn_record
   -> is_retry:bool
   -> start_turn_count:int
   -> turn_prompt_context

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -189,6 +189,14 @@ let run (ctx : ctx)
                  ~world_observation:observation
                  ~generation:run_generation
                  ~history_user_source:"world_state_prompt"
+                 (* RFC-0351 section 5 / #25462: on this lane the user turn is
+                    the wake marker constant unless a HITL resolution was
+                    appended to it. A bare marker carries nothing forward — the
+                    observation frame rides dynamic_context — so recording it
+                    only accumulates byte-identical duplicates. *)
+                 ~user_turn_record:
+                   (Keeper_run_prompt.user_turn_record_of_hitl_resolution
+                      hitl_resolution)
                  ~history_assistant_source:"internal_assistant"
                  ~degraded_retry_applied:
                    (Option.is_some turn_state.degraded_retry_info)

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -354,6 +354,20 @@ let test_world_state_never_in_persisted_user_message () =
   check bool "persisted user message carries no board observation" false
     (contains_sub "### Board Activity" user_message)
 
+(* RFC-0351 section 5 / #25462: splitting the frame out of the user message
+   (above) left the marker itself still being recorded once per wake, so the
+   duplication moved from bytes to message count — one keeper accumulated 359
+   copies of the same 147B constant, part of a 25.7% exact-dup transcript
+   share. A bare wake now skips the transcript entirely; only a turn carrying a
+   HITL resolution is recorded. *)
+let test_bare_autonomous_wake_is_not_recorded () =
+  check bool "bare autonomous wake skips the transcript" true
+    (Masc.Keeper_run_prompt.user_turn_record_of_hitl_resolution None
+     = Masc.Keeper_run_prompt.Skip_uninformative_wake);
+  check bool "a turn carrying a HITL resolution is recorded" true
+    (Masc.Keeper_run_prompt.user_turn_record_of_hitl_resolution (Some ())
+     = Masc.Keeper_run_prompt.Record_user_turn)
+
 let () =
   run "keeper_unified_verification_surface"
     [
@@ -400,5 +414,8 @@ let () =
           test_case
             "invariant: world-state frame never enters the persisted user message"
             `Quick test_world_state_never_in_persisted_user_message;
+          test_case
+            "invariant: a bare autonomous wake is not recorded in the transcript"
+            `Quick test_bare_autonomous_wake_is_not_recorded;
         ] );
     ]


### PR DESCRIPTION
## 목적

RFC-0351 §5 — 무정보 autonomous wake 가 영구 transcript 를 만들지 않게 한다. Closes #25462.

RFC: `docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md` §5 (Persistence 정책).

## 배경

unified lane 은 매 wake 마다 `autonomous_wake_marker` 상수를 user 메시지로 **working context 에 append 하고 session history 에 persist** 했다.

그런데 이 마커가 대표하는 관측 프레임은 `dynamic_context` 를 타고 가며, 매 턴 새로 만들어지고 영속되지 않는다. 즉 마커 자체는 **다음 턴에 아무것도 전달하지 않는다**.

- analyst: 동일한 147B 메시지 **×359** 축적
- 그 keeper transcript 의 exact-dup 비율 **25.7%** 중 최대 단일 기여자
- #25193 이 프레임을 user 메시지에서 분리해 **바이트** 문제는 줄였지만, **메시지 개수** 는 wake 당 1개씩 계속 늘었다 (RFC 가 "잔여 누수"로 지목)

## 변경

**typed 결정 도입** — `Keeper_run_prompt.user_turn_record`

```ocaml
type user_turn_record =
  | Record_user_turn        (* operator 메시지 / HITL resolution / chat lane 입력 *)
  | Skip_uninformative_wake (* wake marker 단독 *)
```

`Skip_uninformative_wake` 이면 `Keeper_context_runtime.append` 도, `persist_message` 도 하지 않는다.

**판단 근거는 HITL resolution 슬롯** — `user_turn_record_of_hitl_resolution` 로 추출해 단위 테스트 가능하게 했다. unified lane 의 user 메시지는 wake marker 이거나 거기에 HITL resolution 이 덧붙은 것뿐이므로, resolution 유무가 정보량의 전부다. **메시지 텍스트를 검사하지 않는다** (RFC §5: "문자열 검사·내용 판단 없음").

**기본값은 `Record_user_turn`** — `keeper_agent_run.run_turn` 의 optional 파라미터로 넣었으므로 chat lane 을 포함한 다른 호출부는 무변경.

## 로컬 검증

- `dune build --root . lib` — clean (`REAL_EXIT_CODE=0`)
- 신규 테스트 `invariant: a bare autonomous wake is not recorded in the transcript` 통과
  - resolution 없음 → `Skip_uninformative_wake`
  - resolution 있음 → `Record_user_turn`
- 기존 `test_world_state_never_in_persisted_user_message` 유지 — `build_prompt` 가 반환하는 user_message 자체는 여전히 마커이고 프레임을 포함하지 않는다 (이 PR 은 그 값을 *기록할지* 만 바꾼다)

## 남은 미검증

- 라이브 검증 미수행. RFC §6 S1 게이트는 "대상 keeper input −25%+ (E3 재현), wake-marker 신규 유입 0" 이며 배포 후 확인 필요.
- **기존에 쌓인 마커는 제거되지 않는다.** 이 PR 은 신규 유입만 차단한다. RFC S1 의 "플릿 1회 청소(결정론 dedup purge, 백업 필수)" 는 별도 작업.
- `dune build --root . @all` 미수행 (lib + 해당 테스트 타겟만).
- HITL resolution 이 없지만 정보가 있는 autonomous 턴이 존재하는지는 확인하지 않았다. 현재 lane 구조상 user 메시지는 마커 ± resolution 뿐이지만, 이 전제가 깨지면 판단 기준을 RFC §5 의 typed 3-신호(tool 사이클 / 가시 전달 / task·goal transition)로 넓혀야 한다.

## 관련

- RFC-0351 S0 (#25461, manual compaction 무한 재시도 종결): #25514
- 이 PR 은 S0 과 독립이며 `origin/main` 기준이다 (stacked 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
