### PR TITLE
feat(keeper): let a keeper write memory that a later turn actually reads (RFC-0351 L1)

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -28,7 +28,8 @@ Use the smallest visible capability that fits the current signal:
 - use task capabilities only when taking, advancing, verifying, or closing work;
 - use connected-surface capabilities for the current dashboard or connector lane;
 - use fleet capabilities for discovery, status, direct delegation, and broadcast;
-- use memory and library capabilities before repeating past work;
+- use memory and library capabilities before repeating past work, and to record
+  what this turn learned that the next one will need;
 - use planning and scheduling capabilities only for durable workspace state;
 - use deliberation for bounded high-impact ambiguity, not cheap status checks;
 - use repository inspection and execution capabilities for code and forge work;
@@ -102,8 +103,12 @@ be read only through a visible capability that explicitly accepts them.
 
 ## Continuity and failure handling
 
-Your context resets between turns, but OAS checkpoints and typed MASC records
-persist. Record only durable facts and decisions that future turns should reuse.
+Your context resets between turns. Typed MASC records persist as written; the
+turn history behind them is compacted to fit, so a conclusion you leave only in
+that history may not survive to your next turn. Record the facts and decisions a
+future turn must reuse while you still hold them, using the durable memory kind
+rather than a working note, and record few enough that reading them back stays
+worth the space they take.
 Long-running work should be left with an observable receipt and resumed by its
 completion wake; do not block the Keeper lane with polling when completion is
 already asynchronous.

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -792,7 +792,13 @@ let append_explicit_memory_note
     : (memory_write_outcome, explicit_memory_write_error) result
   =
   let text = String.trim text in
-  if not (memory_kind_is_writable kind)
+  (* The bank holds turn-scoped working notes. A durable kind belongs to the
+     Memory OS fact store (RFC-0351 L1) and callers route on
+     [memory_write_destination]; this guard keeps the bank's own invariant so a
+     future caller cannot land a durable claim in a store no prompt reads. *)
+  if (match memory_write_destination kind with
+      | Turn_scoped_bank -> false
+      | Durable_fact_store -> true)
   then Error (Explicit_memory_kind_not_writable kind)
   else if not (is_meaningful_memory_text text)
   then Error Rejected_explicit_memory_text

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -64,10 +64,14 @@ type memory_kind =
 val memory_kind_to_wire : memory_kind -> string
 val memory_kind_of_wire : string -> memory_kind option
 val all_memory_kinds : memory_kind list
-val memory_kind_is_writable : memory_kind -> bool
-val writable_memory_kinds : memory_kind list
+type memory_write_destination = Keeper_memory_policy.memory_write_destination =
+  | Turn_scoped_bank
+  | Durable_fact_store
+
+val memory_write_destination : memory_kind -> memory_write_destination
+val bank_writable_memory_kinds : memory_kind list
 val valid_memory_kind_strings : string list
-val writable_memory_kind_strings : string list
+val bank_writable_memory_kind_strings : string list
 val memory_horizon_of_kind : memory_kind -> string
 val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
 val priority_for_kind : kind:memory_kind -> int

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -65,10 +65,14 @@ type memory_kind =
 val memory_kind_to_wire : memory_kind -> string
 val memory_kind_of_wire : string -> memory_kind option
 val all_memory_kinds : memory_kind list
-val memory_kind_is_writable : memory_kind -> bool
-val writable_memory_kinds : memory_kind list
+type memory_write_destination = Keeper_memory_policy.memory_write_destination =
+  | Turn_scoped_bank
+  | Durable_fact_store
+
+val memory_write_destination : memory_kind -> memory_write_destination
+val bank_writable_memory_kinds : memory_kind list
 val valid_memory_kind_strings : string list
-val writable_memory_kind_strings : string list
+val bank_writable_memory_kind_strings : string list
 val memory_horizon_of_kind : memory_kind -> string
 val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
 val priority_for_kind : kind:memory_kind -> int

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -103,14 +103,33 @@ let memory_kind_of_wire = function
 
 let all_memory_kinds = [ Decision; Goal; Progress; Open_question; Long_term ]
 
-let memory_kind_is_writable = function
-  | Long_term -> false
-  | Goal | Progress | Decision | Open_question -> true
+type memory_write_destination =
+  | Turn_scoped_bank
+  | Durable_fact_store
+
+(* RFC-0351 L1. A kind does not say whether it can be written, it says which
+   store holds it. The four turn-scoped kinds are working notes for the run in
+   progress; [Long_term] is the durable claim recall reads back on later turns.
+   Total and exhaustive: a new kind is a compile error here, so no kind reaches
+   a store by default. *)
+let memory_write_destination = function
+  | Goal | Progress | Decision | Open_question -> Turn_scoped_bank
+  | Long_term -> Durable_fact_store
 ;;
 
-let writable_memory_kinds = List.filter memory_kind_is_writable all_memory_kinds
+let bank_writable_memory_kinds =
+  List.filter
+    (fun kind ->
+      match memory_write_destination kind with
+      | Turn_scoped_bank -> true
+      | Durable_fact_store -> false)
+    all_memory_kinds
+;;
+
 let valid_memory_kind_strings = List.map memory_kind_to_wire all_memory_kinds
-let writable_memory_kind_strings = List.map memory_kind_to_wire writable_memory_kinds
+
+let bank_writable_memory_kind_strings =
+  List.map memory_kind_to_wire bank_writable_memory_kinds
 
 let memory_horizon_of_kind = function
   | Open_question | Progress -> short_term_horizon

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -60,10 +60,30 @@ type memory_kind =
 val memory_kind_to_wire : memory_kind -> string
 val memory_kind_of_wire : string -> memory_kind option
 val all_memory_kinds : memory_kind list
-val memory_kind_is_writable : memory_kind -> bool
-val writable_memory_kinds : memory_kind list
+
+(** Which store holds an explicitly written memory of a given kind (RFC-0351 L1).
+
+    [Turn_scoped_bank] is the working note bank for the run in progress. It is
+    shown on status and dashboard surfaces and is not read back into any prompt.
+
+    [Durable_fact_store] is the Memory OS fact store that
+    [Keeper_memory_os_recall] renders into later turns. A claim written there is
+    what the keeper actually carries forward. *)
+type memory_write_destination =
+  | Turn_scoped_bank
+  | Durable_fact_store
+
+val memory_write_destination : memory_kind -> memory_write_destination
+(** Total. Every kind has exactly one destination; there is no kind the model
+    may name and no store may accept. *)
+
+val bank_writable_memory_kinds : memory_kind list
+(** Kinds whose destination is [Turn_scoped_bank]. This is a property of the
+    bank, not the tool surface: the memory write tool accepts every kind (see
+    [valid_memory_kind_strings]) and routes on the destination. *)
+
 val valid_memory_kind_strings : string list
-val writable_memory_kind_strings : string list
+val bank_writable_memory_kind_strings : string list
 val memory_horizon_of_kind : memory_kind -> string
 val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
 val priority_for_kind : kind:memory_kind -> int

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -575,7 +575,6 @@ type memory_write_error_kind =
   | Title_too_long
   | Content_empty
   | Content_rejected
-  | Long_term_via_explicit_write_not_yet_supported
   | Persistence_failed
   | No_memory_write_error
 
@@ -584,8 +583,6 @@ let memory_write_error_kind_to_string = function
   | Title_too_long -> "title_too_long"
   | Content_empty -> "content_empty"
   | Content_rejected -> "content_rejected"
-  | Long_term_via_explicit_write_not_yet_supported ->
-    "long_term_via_explicit_write_not_yet_supported"
   | Persistence_failed -> "persistence_failed"
   | No_memory_write_error -> ""
 ;;
@@ -614,7 +611,7 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
             , `List
                 (List.map
                    (fun k -> `String k)
-                   Keeper_memory_policy.writable_memory_kind_strings) )
+                   Keeper_memory_policy.valid_memory_kind_strings) )
           ]
       }
   | Some kind ->
@@ -629,10 +626,6 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
         }
     else if content = ""
     then Memory_write_invalid { error_kind = Content_empty; extras = [] }
-    else if not (Keeper_memory_policy.memory_kind_is_writable kind)
-    then
-      Memory_write_invalid
-        { error_kind = Long_term_via_explicit_write_not_yet_supported; extras = [] }
     else
       let body =
         if title = "" then content else Printf.sprintf "**%s** %s" title content
@@ -640,6 +633,65 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
       if Keeper_memory_bank.is_meaningful_memory_text body
       then Memory_write_ok { kind; body }
       else Memory_write_invalid { error_kind = Content_rejected; extras = [] }
+;;
+
+(* RFC-0351 L1. [Long_term] is the one kind a later turn reads back, so an
+   explicit long-term write goes to the Memory OS fact store rather than the
+   turn-scoped bank, which no prompt block reads (masc#25517).
+
+   Provenance is this turn and [tool_call_id] is [None]: the claim is the
+   model's own assertion, not an observation carried out of some other tool's
+   result, and that field records where an observation came from.
+
+   The fold is the librarian's (RFC-0285 §8), unchanged: a claim whose identity
+   was just recall-injected is the model restating what it read, and must not
+   advance the truth anchor recall's recency ranking reads. Writing through the
+   same rule is the point — an explicit write is not a way around it. *)
+let append_durable_fact ~(meta : keeper_meta) ~(body : string)
+  : Keeper_memory_os_io.fact_merge_stats
+  =
+  let keeper_id = meta.name in
+  let now = Time_compat.now () in
+  let fact : Keeper_memory_os_types.fact =
+    { claim = body
+    ; category = Keeper_memory_os_types.Fact
+    ; claim_kind = Some Keeper_memory_os_types.Durable_knowledge
+    ; source =
+        { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
+        ; turn = meta.runtime.usage.total_turns
+        ; tool_call_id = None
+        }
+    ; observed_by = []
+    ; first_seen = now
+    ; valid_until = None
+    ; last_verified_at = None
+    ; schema_version = Keeper_memory_os_types.schema_version
+    ; claim_id = None
+    }
+  in
+  let merge ~existing ~incoming =
+    let provenance =
+      let key = Keeper_memory_os_types.claim_identity incoming in
+      if Keeper_recall_injection_window.recently_injected ~keeper_id ~key
+      then (
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string MemoryOsReobserveEchoSuppressed)
+          ~labels:[ "keeper", keeper_id ]
+          ();
+        Keeper_memory_os_policy.Recalled_echo)
+      else Keeper_memory_os_policy.Independent_observation
+    in
+    Keeper_memory_os_policy.reobserve_fact ~now ~provenance ~existing ~incoming
+  in
+  let stats =
+    File_lock_eio.with_lock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
+      Keeper_memory_os_io.merge_facts ~keeper_id ~merge ~incoming:[ fact ])
+  in
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string MemoryOsExplicitFactWrite)
+    ~labels:[ "keeper", keeper_id ]
+    ();
+  stats
 ;;
 
 let keeper_memory_write_with_outcome
@@ -662,49 +714,82 @@ let keeper_memory_write_with_outcome
   | Memory_write_invalid { error_kind; extras } ->
     respond ~ok:false ~error_kind extras
   | Memory_write_ok { kind; body } ->
-    (match
-       Keeper_memory_bank.append_explicit_memory_note
-         config
-         meta
-         ~turn:meta.runtime.usage.total_turns
-         ~kind
-         ~text:body
-     with
-     | Error (Keeper_memory_bank.Explicit_memory_kind_not_writable provided_kind) ->
-      respond
-        ~ok:false
-        ~error_kind:Long_term_via_explicit_write_not_yet_supported
-        [ ( "provided_kind"
-          , `String (Keeper_memory_policy.memory_kind_to_wire provided_kind) ) ]
-     | Error Keeper_memory_bank.Rejected_explicit_memory_text ->
-       respond ~ok:false ~error_kind:Content_rejected []
-     | Error (Keeper_memory_bank.Explicit_memory_write_failed detail) ->
-       respond
-         ~ok:false
-         ~error_kind:Persistence_failed
-         [ "detail", `String detail ]
-     | Ok Keeper_memory_bank.Persisted ->
-      let kind_wire = Keeper_memory_policy.memory_kind_to_wire kind in
-      respond
-        ~ok:true
-        ~error_kind:No_memory_write_error
-        [ "rows_written", `Int 1
-        ; "outcome", `String "persisted"
-        ; "kinds_written", `List [ `String kind_wire ]
-        ; "kind", `String kind_wire
-        ]
-     | Ok Keeper_memory_bank.Skipped_bank_writes_disabled ->
-      (* The memory-bank write kill-switch is off. Report accurately (0 rows,
-         not saved) rather than presenting the note as persisted — the caller
-         must not treat a skipped write as saved (spec/12 §Write Contract). *)
-      let kind_wire = Keeper_memory_policy.memory_kind_to_wire kind in
-      respond
-        ~ok:true
-        ~error_kind:No_memory_write_error
-        [ "rows_written", `Int 0
-        ; "outcome", `String "skipped_bank_writes_disabled"
-        ; "kind", `String kind_wire
-        ])
+    let kind_wire = Keeper_memory_policy.memory_kind_to_wire kind in
+    (match Keeper_memory_policy.memory_write_destination kind with
+     | Keeper_memory_policy.Durable_fact_store ->
+       (match append_durable_fact ~meta ~body with
+        | stats ->
+          let merged = stats.Keeper_memory_os_io.merged in
+          respond
+            ~ok:true
+            ~error_kind:No_memory_write_error
+            [ "rows_written", `Int 1
+            ; ( "outcome"
+              , `String (if merged > 0 then "merged_into_existing_claim" else "persisted")
+              )
+            ; "kinds_written", `List [ `String kind_wire ]
+            ; "kind", `String kind_wire
+            ; "store", `String "durable_fact_store"
+            ]
+        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+        | exception exn ->
+          (* The store is the only place a long-term claim survives, so a
+             failed write is reported as failed. Presenting it as saved would
+             lose the claim silently. *)
+          let detail = Printexc.to_string exn in
+          Log.Keeper.warn
+            "explicit durable fact write failed keeper=%s: %s"
+            meta.name
+            detail;
+          respond ~ok:false ~error_kind:Persistence_failed [ "detail", `String detail ])
+     | Keeper_memory_policy.Turn_scoped_bank ->
+       (match
+          Keeper_memory_bank.append_explicit_memory_note
+            config
+            meta
+            ~turn:meta.runtime.usage.total_turns
+            ~kind
+            ~text:body
+        with
+        | Error (Keeper_memory_bank.Explicit_memory_kind_not_writable provided_kind) ->
+          (* Unreachable through this tool: the routing above sends every
+             durable kind to the fact store, so the bank only ever sees kinds
+             it accepts. Kept because the bank guards its own invariant. *)
+          respond
+            ~ok:false
+            ~error_kind:Persistence_failed
+            [ ( "detail"
+              , `String
+                  (Printf.sprintf
+                     "memory bank refused kind %s"
+                     (Keeper_memory_policy.memory_kind_to_wire provided_kind)) )
+            ]
+        | Error Keeper_memory_bank.Rejected_explicit_memory_text ->
+          respond ~ok:false ~error_kind:Content_rejected []
+        | Error (Keeper_memory_bank.Explicit_memory_write_failed detail) ->
+          respond ~ok:false ~error_kind:Persistence_failed [ "detail", `String detail ]
+        | Ok Keeper_memory_bank.Persisted ->
+          respond
+            ~ok:true
+            ~error_kind:No_memory_write_error
+            [ "rows_written", `Int 1
+            ; "outcome", `String "persisted"
+            ; "kinds_written", `List [ `String kind_wire ]
+            ; "kind", `String kind_wire
+            ; "store", `String "turn_scoped_bank"
+            ]
+        | Ok Keeper_memory_bank.Skipped_bank_writes_disabled ->
+          (* The memory-bank write kill-switch is off. Report accurately (0 rows,
+             not saved) rather than presenting the note as persisted — the caller
+             must not treat a skipped write as saved (spec/12 §Write Contract). *)
+          respond
+            ~ok:true
+            ~error_kind:No_memory_write_error
+            [ "rows_written", `Int 0
+            ; "outcome", `String "skipped_bank_writes_disabled"
+            ; "kind", `String kind_wire
+            ; "store", `String "turn_scoped_bank"
+            ]))
 ;;
 
 let keeper_memory_write_json ~config ~meta ~args =

--- a/lib/keeper/keeper_tool_memory_runtime.mli
+++ b/lib/keeper/keeper_tool_memory_runtime.mli
@@ -78,7 +78,6 @@ type memory_write_error_kind =
   | Title_too_long
   | Content_empty
   | Content_rejected
-  | Long_term_via_explicit_write_not_yet_supported
   | Persistence_failed
   | No_memory_write_error
 

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -190,6 +190,7 @@ type t =
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
   | MemoryOsReobserveEchoSuppressed
+  | MemoryOsExplicitFactWrite
   | MemoryOsRecallFactsTruncated
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
@@ -413,6 +414,8 @@ let to_string = function
       "masc_keeper_memory_os_recall_unavailable_total"
   | MemoryOsReobserveEchoSuppressed ->
       "masc_keeper_memory_os_reobserve_echo_suppressed_total"
+  | MemoryOsExplicitFactWrite ->
+      "masc_keeper_memory_os_explicit_fact_write_total"
   | MemoryOsRecallFactsTruncated ->
       "masc_keeper_memory_os_recall_facts_truncated_total"
   | MemoryOsRecallEpisodesTruncated ->

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -181,6 +181,7 @@ type t =
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
   | MemoryOsReobserveEchoSuppressed
+  | MemoryOsExplicitFactWrite
   | MemoryOsRecallFactsTruncated
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -6,7 +6,6 @@
 val sort_order_enum_strings : string list
 val memory_search_source_enum_strings : string list
 val memory_kind_enum_strings : string list
-val writable_memory_kind_enum_strings : string list
 val fs_write_mode_enum_strings : string list
 val vote_direction_enum_strings : string list
 

--- a/lib/tool_surface/tool_help_registry.ml
+++ b/lib/tool_surface/tool_help_registry.ml
@@ -196,14 +196,14 @@ let manual_help_entry name =
           name;
           short_description = "Persist a structured keeper memory entry.";
           when_to_use =
-            "Use when an explicit decision, open question, goal, or progress note should be searchable on later turns.";
+            "Use when something from this turn must outlive it: long_term for a claim later turns should read back, the other kinds for working notes searchable within the run.";
           key_constraints =
             [
-              "kind must be one of the callable keeper memory kinds.";
+              "kind selects the store: long_term is durable, the rest are turn-scoped.";
               "Do not use for transient scratch notes.";
             ];
           details_markdown =
-            "Writes a bounded structured memory note. The long_term kind is reserved for tool-result emission and is not accepted here.";
+            "Writes a bounded structured memory note. long_term lands in the Memory OS fact store that recall renders into later turns; goal/progress/decision/open_question land in the turn-scoped memory bank.";
           doc_refs = [];
           prompt_hints = [];
           examples =

--- a/lib/tool_surface/tool_shard_types.mli
+++ b/lib/tool_surface/tool_shard_types.mli
@@ -11,9 +11,6 @@ val memory_kind_enum_strings : string list
 (** Hand-mirrored from [Keeper_memory_policy.valid_memory_kind_strings]
     (#8527). *)
 
-val writable_memory_kind_enum_strings : string list
-(** Hand-mirrored from [Keeper_memory_policy.writable_memory_kind_strings]. *)
-
 val fs_write_mode_enum_strings : string list
 (** Hand-mirrored from [Keeper_tool_filesystem_runtime.valid_fs_write_mode_strings]
     (#8490). *)

--- a/lib/tool_surface/tool_shard_types_enum_mirrors.ml
+++ b/lib/tool_surface/tool_shard_types_enum_mirrors.ml
@@ -14,8 +14,6 @@
           mirrors [Keeper_tool_memory_runtime.valid_memory_search_source_strings] (#8484)
       - [memory_kind_enum_strings]
           mirrors [Keeper_memory_policy.valid_memory_kind_strings] (#8527)
-      - [writable_memory_kind_enum_strings]
-          mirrors [Keeper_memory_policy.writable_memory_kind_strings]
       - [fs_write_mode_enum_strings]
           mirrors [Keeper_tool_filesystem_runtime.valid_fs_write_mode_strings] (#8490)
       - [vote_direction_enum_strings]
@@ -38,10 +36,6 @@ let memory_kind_enum_strings =
   ; "open_question"
   ; "long_term"
   ]
-;;
-
-let writable_memory_kind_enum_strings =
-  [ "decision"; "goal"; "progress"; "open_question" ]
 ;;
 
 let fs_write_mode_enum_strings = [ "overwrite"; "append"; "patch" ]

--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -28,11 +28,12 @@ let base_tools : Masc_domain.tool_schema list =
   ; (* Memory *)
     { name = "keeper_memory_search"
     ; description =
-        "Search memory for explicit durable notes or conversation history. \
+        "Search this run's working notes or conversation history. \
          Returns results with provenance metadata. Default searches the structured memory \
          bank. Use 'kind' to filter the typed note categories exposed by the runtime. \
          Use source='history' for raw user messages, \
-         source='all' for both."
+         source='all' for both. Durable long_term claims are not searched here; they \
+         are rendered into your context automatically."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -89,17 +90,19 @@ let base_tools : Masc_domain.tool_schema list =
           ]
     }
   ; (* RFC-0035 P4: explicit memory write surface.
-     Symmetric to the memory search tool; promotes a structured note
-     (kind/title/content) into the memory bank, queryable on later
-     turns. long_term kind is reserved for tool-result emission and
-     is rejected here. *)
+     Symmetric to the memory search tool; takes a structured note
+     (kind/title/content). RFC-0351 L1: the kind picks the store —
+     long_term writes the durable claim recall reads back on later
+     turns, the rest write turn-scoped working notes. *)
     { name = "keeper_memory_write"
     ; description =
-        "Promote an explicit decision, question, goal, or progress note into the memory \
-         bank for later search. Task sequencing and operating constraints belong to \
-         their typed domain stores, not memory prose. The runtime records explicit \
-         typed provenance and returns validation or persistence failures directly. \
-         'long_term' kind is reserved for tool-result emission and is not callable here."
+        "Record something you want to keep. 'long_term' writes a durable claim that \
+         later turns read back; the other kinds write a working note for the run in \
+         progress, searchable but not carried forward on its own. Your context resets \
+         between turns, so a conclusion you leave only in this turn's reasoning is \
+         gone. Task sequencing and operating constraints belong to their typed domain \
+         stores, not memory prose. The runtime records explicit typed provenance and \
+         returns validation or persistence failures directly."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -112,12 +115,12 @@ let base_tools : Masc_domain.tool_schema list =
                         , `List
                             (List.map
                                (fun s -> `String s)
-                               writable_memory_kind_enum_strings) )
+                               memory_kind_enum_strings) )
                       ; ( "description"
                         , `String
-                            "Memory kind. One of \
-                             goal/progress/decision/open_question. long_term not \
-                             supported." )
+                            "Memory kind. 'long_term' is the durable store later \
+                             turns read back; goal/progress/decision/open_question \
+                             are working notes for the run in progress." )
                       ] )
                 ; ( "title"
                   , `Assoc

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -132,9 +132,6 @@ let test_validation_taxonomy () =
     (make_args ~kind:" goal " ~title:"" ~content:"body")
   |> assert_invalid ~expected:"invalid_memory_kind";
   Runtime.validate_memory_write_args
-    (make_args ~kind:"long_term" ~title:"" ~content:"body")
-  |> assert_invalid ~expected:"long_term_via_explicit_write_not_yet_supported";
-  Runtime.validate_memory_write_args
     (make_args ~kind:"goal" ~title:"" ~content:"")
   |> assert_invalid ~expected:"content_empty";
   Runtime.validate_memory_write_args
@@ -146,6 +143,9 @@ let test_validation_taxonomy () =
 ;;
 
 let test_valid_body_has_no_intermediate_projection () =
+  Runtime.validate_memory_write_args
+    (make_args ~kind:"long_term" ~title:"" ~content:"body")
+  |> assert_ok ~kind:"long_term" ~body:"body";
   Runtime.validate_memory_write_args
     (make_args ~kind:"decision" ~title:"hook" ~content:"body text")
   |> assert_ok ~kind:"decision" ~body:"**hook** body text";
@@ -179,6 +179,59 @@ let test_bank_rejects_nonwritable_kind () =
   with
   | Error Bank.Rejected_explicit_memory_text -> ()
   | _ -> Alcotest.fail "filtered content must return a typed rejection"
+;;
+
+(* RFC-0351 L1 / masc#25517. The loop the model actually depends on: a
+   long-term write must reach the store recall reads back, not the turn-scoped
+   bank that no prompt block renders. The assertion goes through
+   [read_facts_all] — the same reader [Keeper_memory_os_recall] calls — rather
+   than through the rendered block, because routing is what this test is about
+   and rendering is covered in test_keeper_memory_os. *)
+let test_long_term_write_comes_back_through_recall () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "durable-write" in
+  let keepers_dir = Filename.concat base_path "keepers" in
+  Masc.Keeper_memory_os_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+    let response =
+      Runtime.keeper_memory_write_json
+        ~config
+        ~meta
+        ~args:
+          (make_args
+             ~kind:"long_term"
+             ~title:""
+             ~content:"reasoning_content must be replayed unmodified")
+      |> Yojson.Safe.from_string
+    in
+    Alcotest.(check bool)
+      "write succeeds"
+      true
+      (match json_field "ok" response with
+       | `Bool value -> value
+       | _ -> false);
+    Alcotest.(check string)
+      "routed to the durable store"
+      "durable_fact_store"
+      (string_field "store" response);
+    let facts = Masc.Keeper_memory_os_io.read_facts_all ~keeper_id:meta.name in
+    Alcotest.(check int) "one durable claim" 1 (List.length facts);
+    let fact = List.hd facts in
+    Alcotest.(check string)
+      "the claim reaches a later turn"
+      "reasoning_content must be replayed unmodified"
+      fact.Masc.Keeper_memory_os_types.claim;
+    Alcotest.(check int)
+      "provenance carries this turn"
+      7
+      fact.Masc.Keeper_memory_os_types.source.turn;
+    (* The model asserted this itself; it did not carry it out of another
+       tool's result, and the field says where an observation came from. *)
+    Alcotest.(check bool)
+      "no borrowed tool provenance"
+      true
+      (fact.Masc.Keeper_memory_os_types.source.tool_call_id = None))
 ;;
 
 let test_tool_write_persists_typed_provenance () =
@@ -269,6 +322,10 @@ let () =
             "bank rejects nonwritable kinds"
             `Quick
             test_bank_rejects_nonwritable_kind
+        ; Alcotest.test_case
+            "long-term write comes back through recall"
+            `Quick
+            test_long_term_write_comes_back_through_recall
         ; Alcotest.test_case
             "tool write stores typed provenance"
             `Quick

--- a/test/test_memory_horizon_classifier.ml
+++ b/test/test_memory_horizon_classifier.ml
@@ -68,22 +68,33 @@ let test_typed_policy () =
     "long-term cap"
     4
     (Policy.cap_for_kind (Policy.kind_caps ()) Policy.Long_term);
+  (* RFC-0351 L1: a kind names its store, not its writability. [Long_term] is
+     the durable claim recall reads back on later turns; the rest are working
+     notes for the run in progress. *)
   check bool
-    "long-term is not writable"
-    false
-    (Policy.memory_kind_is_writable Policy.Long_term);
+    "long-term goes to the durable fact store"
+    true
+    (match Policy.memory_write_destination Policy.Long_term with
+     | Policy.Durable_fact_store -> true
+     | Policy.Turn_scoped_bank -> false);
+  List.iter
+    (fun kind ->
+      check bool
+        (Printf.sprintf "%s is a turn-scoped note" (Policy.memory_kind_to_wire kind))
+        true
+        (match Policy.memory_write_destination kind with
+         | Policy.Turn_scoped_bank -> true
+         | Policy.Durable_fact_store -> false))
+    [ Policy.Decision; Policy.Goal; Policy.Progress; Policy.Open_question ];
   check (list string)
-    "writable wire kinds"
+    "bank wire kinds"
     [ "decision"; "goal"; "progress"; "open_question" ]
-    Policy.writable_memory_kind_strings;
-  check (list string)
-    "search schema mirror"
-    Policy.valid_memory_kind_strings
-    Masc.Tool_shard.memory_kind_enum_strings;
+    Policy.bank_writable_memory_kind_strings;
+  (* The write tool now offers every kind: each one has a store. *)
   check (list string)
     "write schema mirror"
-    Policy.writable_memory_kind_strings
-    Masc.Tool_shard.writable_memory_kind_enum_strings
+    Policy.valid_memory_kind_strings
+    Masc.Tool_shard.memory_kind_enum_strings
 ;;
 
 let test_json_strict_classifier () =


### PR DESCRIPTION
## 목적

`keeper_memory_write` 로 기록한 메모리가 미래 턴에 도달하게 만든다. 지금은 도달하지 않는다.

Closes #25517. RFC-0351 L1 (`docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md`).

## 배경 — 모델의 메모리 쓰기는 전부 무효였다

```
memory_kind = Goal | Progress | Decision | Open_question | Long_term
memory_kind_is_writable: Long_term -> false, 나머지 -> true
```

- 쓸 수 있는 4종 → memory bank
- `Long_term` → 거부 (`long_term_via_explicit_write_not_yet_supported`)

그리고 **memory bank 를 읽는 프롬프트 블록이 없다.** 조립 지점은 닫힌 합타입이다 (`lib/types/prompt_block_id.mli`):

```
Persona | Continuity | Dynamic_context | Temporal_summary
| Claimed_task_nudge | Retry_nudge | Memory_os_recall | Connected_surface | Other
```

> "Adding a new injection site without extending this variant is a compile-time error at the TurnRecord write site."

메모리 성격의 블록은 `Memory_os_recall` 하나이고 그것은 Memory OS fact/episode 스토어에서 렌더된다. `keeper_run_tools_hooks.ml` 주석이 직접 말한다 — *"read side; **the write side is the librarian**"*. fact 쓰기 호출자는 `keeper_librarian_runtime.ml:467` 하나뿐이었다.

**결과**: 모델은 무엇이 자기 기억에 남을지 결정할 수 없었다. 라이브 자국 — `taskmaster` keeper 가 2026-07-08 자기 턴에 `5 NEW tool failure memory (critical long_term_via_explicit_write_not_yet_supported 신규)` 라고 적었다. 모델이 시도했고, 거부당했고, critical 로 분류했다.

## 변경

**1. kind 는 쓰기 가능 여부가 아니라 목적지를 말한다**

```ocaml
type memory_write_destination =
  | Turn_scoped_bank    (* Goal | Progress | Decision | Open_question *)
  | Durable_fact_store  (* Long_term *)

val memory_write_destination : memory_kind -> memory_write_destination
```

`memory_kind_is_writable : memory_kind -> bool` 을 **삭제**했다. 그 불리언은 틀린 질문에 답했다 — 실제 질문은 "쓸 수 있는가"가 아니라 "어디에 가는가"였고, 호출자마다 다르게 해석될 여지를 남겼다. 전수 함수 하나로 대체하면 새 kind 를 추가할 때 라우팅을 강제로 결정하게 된다.

컴파일러가 영향 지점 8곳을 지목했다(재export 3, bank 가드 1, 스키마 미러 1, 테스트 3). `keeper_memory_bank_selection.ml` 은 그 이름을 한 번도 쓰지 않으면서 인터페이스로 요구하고 있었다 — grep 으로는 못 찾았을 지점이다.

**2. `Long_term` 은 Memory OS fact 스토어로 간다**

`append_durable_fact` 가 librarian 과 **같은 fold** 를 쓴다:

- `File_lock_eio.with_lock (facts_path ~keeper_id)` → `merge_facts` (RFC-0243 upsert)
- echo 판정도 같은 규칙 — `Keeper_recall_injection_window.recently_injected` → `Recalled_echo` (RFC-0285 §8). **명시적 쓰기가 truth anchor 를 우회하는 통로가 되면 안 되기 때문이다.** 방금 recall 로 읽은 것을 모델이 되풀이해 적는 것은 새 관측이 아니다.
- `claim_kind = Durable_knowledge`, `source = {trace_id; turn; tool_call_id = None}`

`tool_call_id` 가 `None` 인 것은 사실 그대로다. 그 필드는 *관측이 어디서 왔는가*를 기록하는데(librarian 은 LLM 추출물의 `source_tool_call_id` 를 그대로 싣는다), 이 클레임은 모델 자신의 주장이지 다른 도구 결과에서 나온 것이 아니다.

쓰기 실패는 실패로 보고한다. 이 스토어가 장기 클레임이 살아남는 유일한 곳이므로, 저장됐다고 응답하면 클레임이 조용히 사라진다.

**3. 도구 표면이 `long_term` 을 실제로 제공한다**

스키마의 `kind` enum 은 `writable_memory_kind_strings`(4종)에서 만들어졌으므로 모델은 `long_term` 을 **고를 수조차 없었다**. 이제 `memory_kind_enum_strings`(5종)를 쓴다. 4종짜리 미러(`writable_memory_kind_enum_strings`)는 삭제했다 — 남은 사용처가 없다.

**4. 모델이 읽는 문구를 사실로 되돌린다**

세 곳이 `long_term ... is not accepted here` / `not supported` 라고 말하고 있었다 (도구 description, `kind` description, `tool_help_registry`). 이 문구가 남아 있으면 라우팅을 고쳐도 모델은 시도하지 않는다.

`keeper_memory_search` 의 description 도 고쳤다 — "durable notes 를 검색한다"고 약속했지만 실제로는 bank 만 읽는다(아래 미검증 참조).

**5. 시스템 프롬프트가 "네 컨텍스트는 보존된다"고 말하는 것을 멈춘다** (두 번째 커밋)

`keeper.unified.system.md` 의 continuity 절은 이렇게 시작했다:

> "Your context resets between turns, but **OAS checkpoints and typed MASC records persist**. Record only durable facts and decisions that future turns should reuse."

읽는 순서대로 보면 **첫 문장이 두 번째 문장의 이유를 없앤다.** 컨텍스트가 보존된다고 들은 keeper 는 그것을 보존하려고 도구 호출을 쓸 이유가 없다. 스토어를 열어도 스토어가 필요없다고 믿는 keeper 는 쓰지 않는다.

실제로 살아남는 것으로 바꿨다 — typed record 는 쓴 그대로 남지만 그 뒤의 턴 히스토리는 압축되어 맞춰지므로, 거기에만 남긴 결론은 다음 턴에 도달하지 않을 수 있다. 그리고 **양을 제한한다**: 여기 기록한 것은 전부 나중 턴의 컨텍스트로 렌더되어 그 턴의 작업과 자리를 다툰다. 쓰기를 열면서 상한을 말하지 않으면 지금 죽이려는 222 KB 블록을 다시 만든다.

capability 목록도 읽기 전용 형태(`use memory ... before repeating past work`)였고 기록을 함께 명시했다. 두 줄 모두 **도구 이름을 쓰지 않는다** — 같은 프롬프트의 tool-authority 규칙이 "callable name 은 typed schema 만이 권위"라고 못 박기 때문이다.

**6. 카운터**

`masc_keeper_memory_os_explicit_fact_write_total` — 모델 소유 쓰기와 librarian 추출을 구분해 세는 유일한 수단이다. RFC-0351 S2 게이트가 "librarian 을 보조로 강등"을 판정하려면 이 분모가 필요하다.

## 로컬 검증

- `dune build --root . lib` — clean
- `dune build --root . @fmt` — 내 파일 diff 0 (루트 `dune` 의 기존 드리프트만 남음, 이 PR 은 dune 파일을 건드리지 않음)
- 테스트 **153개 통과**:
  - `test_keeper_memory_write` 7/7 — 신규 `long-term write comes back through recall` 포함
  - `test_memory_horizon_classifier` 4/4 — `is_writable` 단언을 목적지 단언으로 교체
  - `test_keeper_memory_os` 110/110
  - `test_tool_help_metadata_rfc_0195` 6/6, `test_keeper_tool_resolution` 16/16
  - 프롬프트 변경 후: `test_prompt_no_silent_reply_contract` 2/2, `test_keeper_wake_turn_context` 8/8

신규 테스트는 `read_facts_all` — **recall 이 실제로 부르는 리더** — 로 검증한다. 렌더된 블록이 아니라 리더로 단언하는 이유는 이 테스트의 고유 주장이 라우팅이고 렌더링은 `test_keeper_memory_os` 가 덮기 때문이다. (처음엔 렌더 텍스트로 단언했는데, 이 테스트 바이너리에 프롬프트 템플릿이 등록돼 있지 않아 실패했다. 그 실패 로그가 `ASSERT routed to the durable store` 는 이미 통과했음을 보여줬다.)

## 남은 미검증 / 알려진 간극

- **`keeper_memory_search` 는 fact 스토어를 검색하지 않는다** (`keeper_tool_memory_runtime.ml:78` 이 bank 경로만 읽는다). long_term 클레임은 recall 로 자동 복귀하지만 모델이 질의할 수는 없다. 이 PR 은 description 을 사실로 맞추는 선에서 멈췄다 — 검색 통합은 별도 작업이다.
- **라이브 검증 미수행.** 모델이 실제로 `long_term` 을 쓰기 시작하는지는 배포 후 `masc_keeper_memory_os_explicit_fact_write_total` 로 관측해야 안다. 도구를 열고 문구를 고쳤을 뿐, 모델이 그것을 쓸지는 별개다.
- **fact 스토어 성장 압력.** 모델 쓰기가 늘면 recall 주입 바이트가 늘어난다. 그 상한은 #25516(L3 바이트 예산)이 담당하며 이 PR 과 독립적으로 필요하다.
- `dune build --root . @all` 미수행 (lib + 관련 테스트 타겟만).

## 관련

- 이슈: #25517
- RFC-0351 L1 개정 + S0: #25514
- RFC-0351 S1: #25515
- RFC-0351 L3 (recall 바이트 예산 + 스토어 게이지): #25516 — 이 PR 이 그 게이지에 대응하는 **쓰기 측**이다. 게이지를 보여줘도 쓸 수단이 없으면 게이지는 장식이다.

네 PR 모두 `origin/main` 기준이며 stacked 가 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
