### PR TITLE
feat(keeper): let a durable claim say how long it stays true (RFC-0351 S2)

### DIFF
--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -566,6 +566,14 @@ let keeper_context_status_json
 (* --- Explicit memory write (RFC-0035 P4 surface) ----------------- *)
 
 let keeper_memory_write_max_title_chars = 120
+let seconds_per_day = 86_400.
+
+(* An explicit lifetime is a claim about scope, so it has to be a real
+   boundary: a claim that expires today or a decade out is a producer mistake,
+   not a lifetime. Rejecting both ends keeps [valid_until] meaningful rather
+   than becoming a second way to say "forever". *)
+let keeper_memory_write_min_valid_days = 1
+let keeper_memory_write_max_valid_days = 365
 
 (** Pure validation result for a [keeper_memory_write] call. Splitting
     this from the persistence step lets tests pin the error_kind
@@ -575,6 +583,8 @@ type memory_write_error_kind =
   | Title_too_long
   | Content_empty
   | Content_rejected
+  | Invalid_valid_for_days
+  | Valid_for_days_on_turn_scoped_kind
   | Persistence_failed
   | No_memory_write_error
 
@@ -583,6 +593,8 @@ let memory_write_error_kind_to_string = function
   | Title_too_long -> "title_too_long"
   | Content_empty -> "content_empty"
   | Content_rejected -> "content_rejected"
+  | Invalid_valid_for_days -> "invalid_valid_for_days"
+  | Valid_for_days_on_turn_scoped_kind -> "valid_for_days_on_turn_scoped_kind"
   | Persistence_failed -> "persistence_failed"
   | No_memory_write_error -> ""
 ;;
@@ -591,6 +603,10 @@ type memory_write_validation =
   | Memory_write_ok of
       { kind : Keeper_memory_policy.memory_kind
       ; body : string
+      ; valid_for_days : int option
+        (** Producer-declared lifetime (RFC-0351 S2). [None] means the claim
+            carries no expiry, which is what every stored fact says today
+            because nothing has ever been able to say otherwise. *)
       }
   | Memory_write_invalid of
       { error_kind : memory_write_error_kind
@@ -601,6 +617,17 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
   let kind_wire = Safe_ops.json_string ~default:"" "kind" args in
   let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
   let content = Safe_ops.json_string ~default:"" "content" args |> String.trim in
+  (* [Safe_ops.json_int] cannot tell "absent" from "0", and 0 days is exactly
+     the mistake this field must reject, so read the raw member instead. *)
+  let valid_for_days =
+    match args with
+    | `Assoc fields ->
+      (match List.assoc_opt "valid_for_days" fields with
+       | None | Some `Null -> None
+       | Some (`Int n) -> Some n
+       | Some _ -> Some 0 (* wrong type falls into the range rejection below *))
+    | _ -> None
+  in
   match Keeper_memory_policy.memory_kind_of_wire kind_wire with
   | None ->
     Memory_write_invalid
@@ -626,12 +653,39 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
         }
     else if content = ""
     then Memory_write_invalid { error_kind = Content_empty; extras = [] }
+    else if
+      (match valid_for_days with
+       | None -> false
+       | Some d ->
+         d < keeper_memory_write_min_valid_days
+         || d > keeper_memory_write_max_valid_days)
+    then
+      Memory_write_invalid
+        { error_kind = Invalid_valid_for_days
+        ; extras =
+            [ "min_days", `Int keeper_memory_write_min_valid_days
+            ; "max_days", `Int keeper_memory_write_max_valid_days
+            ]
+        }
+    else if
+      Option.is_some valid_for_days
+      &&
+      match Keeper_memory_policy.memory_write_destination kind with
+      | Keeper_memory_policy.Turn_scoped_bank -> true
+      | Keeper_memory_policy.Durable_fact_store -> false
+    then
+      (* A turn-scoped note already dies with the run. Silently accepting a
+         lifetime for it would report a boundary the store does not keep. *)
+      Memory_write_invalid
+        { error_kind = Valid_for_days_on_turn_scoped_kind
+        ; extras = [ "kind", `String (Keeper_memory_policy.memory_kind_to_wire kind) ]
+        }
     else
       let body =
         if title = "" then content else Printf.sprintf "**%s** %s" title content
       in
       if Keeper_memory_bank.is_meaningful_memory_text body
-      then Memory_write_ok { kind; body }
+      then Memory_write_ok { kind; body; valid_for_days }
       else Memory_write_invalid { error_kind = Content_rejected; extras = [] }
 ;;
 
@@ -647,7 +701,10 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
    was just recall-injected is the model restating what it read, and must not
    advance the truth anchor recall's recency ranking reads. Writing through the
    same rule is the point — an explicit write is not a way around it. *)
-let append_durable_fact ~(meta : keeper_meta) ~(body : string)
+let append_durable_fact
+      ~(meta : keeper_meta)
+      ~(body : string)
+      ~(valid_for_days : int option)
   : Keeper_memory_os_io.fact_merge_stats
   =
   let keeper_id = meta.name in
@@ -663,7 +720,14 @@ let append_durable_fact ~(meta : keeper_meta) ~(body : string)
         }
     ; observed_by = []
     ; first_seen = now
-    ; valid_until = None
+    ; valid_until =
+        (* RFC-0351 S2. Recall has always dropped expired facts
+           ([Keeper_memory_os_types.fact_is_current]), but no producer could
+           ever set the boundary, so every stored fact reads as permanent —
+           747 of 747 across the live fleet. This is the first writer. The
+           lifetime is the producer's own claim about scope, not a rule
+           inferred from the text. *)
+        Option.map (fun days -> now +. (float_of_int days *. seconds_per_day)) valid_for_days
     ; last_verified_at = None
     ; schema_version = Keeper_memory_os_types.schema_version
     ; claim_id = None
@@ -713,11 +777,11 @@ let keeper_memory_write_with_outcome
   match validate_memory_write_args args with
   | Memory_write_invalid { error_kind; extras } ->
     respond ~ok:false ~error_kind extras
-  | Memory_write_ok { kind; body } ->
+  | Memory_write_ok { kind; body; valid_for_days } ->
     let kind_wire = Keeper_memory_policy.memory_kind_to_wire kind in
     (match Keeper_memory_policy.memory_write_destination kind with
      | Keeper_memory_policy.Durable_fact_store ->
-       (match append_durable_fact ~meta ~body with
+       (match append_durable_fact ~meta ~body ~valid_for_days with
         | stats ->
           let merged = stats.Keeper_memory_os_io.merged in
           respond

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -575,6 +575,37 @@ let seconds_per_day = 86_400.
 let keeper_memory_write_min_valid_days = 1
 let keeper_memory_write_max_valid_days = 365
 
+(* [Safe_ops.json_int] cannot tell "absent" from "0", and 0 days is exactly
+   the mistake this field must reject, so the member is read raw. A wrong JSON
+   type is its own producer error and keeps its own arm: collapsing it into a
+   number would answer a type mistake with a range complaint the caller already
+   satisfied. *)
+type valid_for_days_arg =
+  | Lifetime_absent
+  | Lifetime_days of int
+  | Lifetime_not_an_integer of string (* the JSON type actually supplied *)
+
+let json_type_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+;;
+
+let parse_valid_for_days (args : Yojson.Safe.t) : valid_for_days_arg =
+  match args with
+  | `Assoc fields ->
+    (match List.assoc_opt "valid_for_days" fields with
+     | None | Some `Null -> Lifetime_absent
+     | Some (`Int n) -> Lifetime_days n
+     | Some other -> Lifetime_not_an_integer (json_type_name other))
+  | _ -> Lifetime_absent
+;;
+
 (** Pure validation result for a [keeper_memory_write] call. Splitting
     this from the persistence step lets tests pin the error_kind
     taxonomy without constructing a [Workspace.config]. *)
@@ -613,21 +644,56 @@ type memory_write_validation =
       ; extras : (string * Yojson.Safe.t) list
       }
 
+(* Each way a lifetime can be wrong gets its own answer. A producer that sent
+   the wrong JSON type has not violated the range, and telling it the range is
+   1-365 sends it looking for a bug it does not have. *)
+let check_lifetime ~kind lifetime : (int option, memory_write_validation) result =
+  let out_of_range d =
+    d < keeper_memory_write_min_valid_days || d > keeper_memory_write_max_valid_days
+  in
+  let durable =
+    match Keeper_memory_policy.memory_write_destination kind with
+    | Keeper_memory_policy.Durable_fact_store -> true
+    | Keeper_memory_policy.Turn_scoped_bank -> false
+  in
+  match lifetime with
+  | Lifetime_absent -> Ok None
+  | Lifetime_not_an_integer provided_type ->
+    Error
+      (Memory_write_invalid
+         { error_kind = Invalid_valid_for_days
+         ; extras =
+             [ "reason", `String "not_an_integer"
+             ; "provided_type", `String provided_type
+             ]
+         })
+  | Lifetime_days d when out_of_range d ->
+    Error
+      (Memory_write_invalid
+         { error_kind = Invalid_valid_for_days
+         ; extras =
+             [ "reason", `String "out_of_range"
+             ; "provided_days", `Int d
+             ; "min_days", `Int keeper_memory_write_min_valid_days
+             ; "max_days", `Int keeper_memory_write_max_valid_days
+             ]
+         })
+  | Lifetime_days _ when not durable ->
+    (* A turn-scoped note already dies with the run. Silently accepting a
+       lifetime for it would report a boundary the store does not keep. *)
+    Error
+      (Memory_write_invalid
+         { error_kind = Valid_for_days_on_turn_scoped_kind
+         ; extras = [ "kind", `String (Keeper_memory_policy.memory_kind_to_wire kind) ]
+         })
+  | Lifetime_days d -> Ok (Some d)
+;;
+
 let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation =
   let kind_wire = Safe_ops.json_string ~default:"" "kind" args in
   let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
   let content = Safe_ops.json_string ~default:"" "content" args |> String.trim in
-  (* [Safe_ops.json_int] cannot tell "absent" from "0", and 0 days is exactly
-     the mistake this field must reject, so read the raw member instead. *)
-  let valid_for_days =
-    match args with
-    | `Assoc fields ->
-      (match List.assoc_opt "valid_for_days" fields with
-       | None | Some `Null -> None
-       | Some (`Int n) -> Some n
-       | Some _ -> Some 0 (* wrong type falls into the range rejection below *))
-    | _ -> None
-  in
+  let lifetime = parse_valid_for_days args in
   match Keeper_memory_policy.memory_kind_of_wire kind_wire with
   | None ->
     Memory_write_invalid
@@ -653,40 +719,16 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
         }
     else if content = ""
     then Memory_write_invalid { error_kind = Content_empty; extras = [] }
-    else if
-      (match valid_for_days with
-       | None -> false
-       | Some d ->
-         d < keeper_memory_write_min_valid_days
-         || d > keeper_memory_write_max_valid_days)
-    then
-      Memory_write_invalid
-        { error_kind = Invalid_valid_for_days
-        ; extras =
-            [ "min_days", `Int keeper_memory_write_min_valid_days
-            ; "max_days", `Int keeper_memory_write_max_valid_days
-            ]
-        }
-    else if
-      Option.is_some valid_for_days
-      &&
-      match Keeper_memory_policy.memory_write_destination kind with
-      | Keeper_memory_policy.Turn_scoped_bank -> true
-      | Keeper_memory_policy.Durable_fact_store -> false
-    then
-      (* A turn-scoped note already dies with the run. Silently accepting a
-         lifetime for it would report a boundary the store does not keep. *)
-      Memory_write_invalid
-        { error_kind = Valid_for_days_on_turn_scoped_kind
-        ; extras = [ "kind", `String (Keeper_memory_policy.memory_kind_to_wire kind) ]
-        }
-    else
-      let body =
-        if title = "" then content else Printf.sprintf "**%s** %s" title content
-      in
-      if Keeper_memory_bank.is_meaningful_memory_text body
-      then Memory_write_ok { kind; body; valid_for_days }
-      else Memory_write_invalid { error_kind = Content_rejected; extras = [] }
+    else (
+      match check_lifetime ~kind lifetime with
+      | Error invalid -> invalid
+      | Ok valid_for_days ->
+        let body =
+          if title = "" then content else Printf.sprintf "**%s** %s" title content
+        in
+        if Keeper_memory_bank.is_meaningful_memory_text body
+        then Memory_write_ok { kind; body; valid_for_days }
+        else Memory_write_invalid { error_kind = Content_rejected; extras = [] })
 ;;
 
 (* RFC-0351 L1. [Long_term] is the one kind a later turn reads back, so an

--- a/lib/keeper/keeper_tool_memory_runtime.mli
+++ b/lib/keeper/keeper_tool_memory_runtime.mli
@@ -78,6 +78,8 @@ type memory_write_error_kind =
   | Title_too_long
   | Content_empty
   | Content_rejected
+  | Invalid_valid_for_days
+  | Valid_for_days_on_turn_scoped_kind
   | Persistence_failed
   | No_memory_write_error
 
@@ -87,6 +89,7 @@ type memory_write_validation =
   | Memory_write_ok of
       { kind : Keeper_memory_policy.memory_kind
       ; body : string
+      ; valid_for_days : int option
       }
   | Memory_write_invalid of
       { error_kind : memory_write_error_kind

--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -136,6 +136,16 @@ let base_tools : Masc_domain.tool_schema list =
                             "Body. Required, must be non-empty. For decisions, lead with \
                              the decision then **Why** and **How to apply** lines." )
                       ] )
+                ; ( "valid_for_days"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; ( "description"
+                        , `String
+                            "Optional, long_term only: how many days this claim stays \
+                             true (1-365). Recall stops injecting it after that. Omit \
+                             when the claim has no expiry; do not omit it merely \
+                             because you are unsure how long it holds." )
+                      ] )
                 ] )
           ; "required", `List [ `String "kind"; `String "content" ]
           ]

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -11,6 +11,12 @@ let make_args ~kind ~title ~content =
     ]
 ;;
 
+let with_days args days =
+  match args with
+  | `Assoc fields -> `Assoc (fields @ [ "valid_for_days", `Int days ])
+  | other -> other
+;;
+
 let error_label = Runtime.memory_write_error_kind_to_string
 
 let assert_invalid ~expected = function
@@ -20,8 +26,9 @@ let assert_invalid ~expected = function
     Alcotest.failf "expected invalid memory write: %s" expected
 ;;
 
-let assert_ok ~kind ~body = function
+let assert_ok ?(valid_for_days = None) ~kind ~body = function
   | Runtime.Memory_write_ok valid ->
+    Alcotest.(check (option int)) "valid_for_days" valid_for_days valid.valid_for_days;
     Alcotest.(check string)
       "kind"
       kind
@@ -139,13 +146,27 @@ let test_validation_taxonomy () =
   |> assert_invalid ~expected:"title_too_long";
   Runtime.validate_memory_write_args
     (make_args ~kind:"goal" ~title:"" ~content:"none")
-  |> assert_invalid ~expected:"content_rejected"
+  |> assert_invalid ~expected:"content_rejected";
+  (* RFC-0351 S2: a lifetime is a claim about scope, so both ends are real
+     boundaries and a turn-scoped kind cannot carry one at all. *)
+  Runtime.validate_memory_write_args
+    (with_days (make_args ~kind:"long_term" ~title:"" ~content:"body") 0)
+  |> assert_invalid ~expected:"invalid_valid_for_days";
+  Runtime.validate_memory_write_args
+    (with_days (make_args ~kind:"long_term" ~title:"" ~content:"body") 366)
+  |> assert_invalid ~expected:"invalid_valid_for_days";
+  Runtime.validate_memory_write_args
+    (with_days (make_args ~kind:"goal" ~title:"" ~content:"body") 7)
+  |> assert_invalid ~expected:"valid_for_days_on_turn_scoped_kind"
 ;;
 
 let test_valid_body_has_no_intermediate_projection () =
   Runtime.validate_memory_write_args
     (make_args ~kind:"long_term" ~title:"" ~content:"body")
   |> assert_ok ~kind:"long_term" ~body:"body";
+  Runtime.validate_memory_write_args
+    (with_days (make_args ~kind:"long_term" ~title:"" ~content:"body") 30)
+  |> assert_ok ~valid_for_days:(Some 30) ~kind:"long_term" ~body:"body";
   Runtime.validate_memory_write_args
     (make_args ~kind:"decision" ~title:"hook" ~content:"body text")
   |> assert_ok ~kind:"decision" ~body:"**hook** body text";
@@ -231,7 +252,64 @@ let test_long_term_write_comes_back_through_recall () =
     Alcotest.(check bool)
       "no borrowed tool provenance"
       true
-      (fact.Masc.Keeper_memory_os_types.source.tool_call_id = None))
+      (fact.Masc.Keeper_memory_os_types.source.tool_call_id = None);
+    Alcotest.(check bool)
+      "a claim with no declared lifetime stays permanent"
+      true
+      (fact.Masc.Keeper_memory_os_types.valid_until = None))
+;;
+
+(* RFC-0351 S2. Recall has always dropped expired facts; until now nothing
+   could set the boundary, so all 747 facts in the live fleet read as
+   permanent. This pins the whole path: the declared lifetime reaches the
+   store, and the reader recall uses actually drops the claim past it. *)
+let test_declared_lifetime_expires () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "expiring-write" in
+  let keepers_dir = Filename.concat base_path "keepers" in
+  Masc.Keeper_memory_os_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+    let response =
+      Runtime.keeper_memory_write_json
+        ~config
+        ~meta
+        ~args:
+          (with_days
+             (make_args ~kind:"long_term" ~title:"" ~content:"task-2288 is blocked on the git-root gate")
+             7)
+      |> Yojson.Safe.from_string
+    in
+    Alcotest.(check bool)
+      "write succeeds"
+      true
+      (match json_field "ok" response with
+       | `Bool value -> value
+       | _ -> false);
+    let fact = List.hd (Masc.Keeper_memory_os_io.read_facts_all ~keeper_id:meta.name) in
+    let valid_until =
+      match fact.Masc.Keeper_memory_os_types.valid_until with
+      | Some ts -> ts
+      | None -> Alcotest.fail "declared lifetime did not reach the store"
+    in
+    let first_seen = fact.Masc.Keeper_memory_os_types.first_seen in
+    (* 7 days from the write, to the second. *)
+    Alcotest.(check (float 1.0))
+      "boundary is the declared span"
+      (7.0 *. 86_400.)
+      (valid_until -. first_seen);
+    Alcotest.(check bool)
+      "still current inside the window"
+      true
+      (Masc.Keeper_memory_os_types.fact_is_current
+         ~now:(valid_until -. 86_400.)
+         fact);
+    Alcotest.(check bool)
+      "recall drops it past the window"
+      false
+      (Masc.Keeper_memory_os_types.fact_is_current
+         ~now:(valid_until +. 1.0)
+         fact))
 ;;
 
 let test_tool_write_persists_typed_provenance () =
@@ -326,6 +404,10 @@ let () =
             "long-term write comes back through recall"
             `Quick
             test_long_term_write_comes_back_through_recall
+        ; Alcotest.test_case
+            "declared lifetime reaches the store and expires"
+            `Quick
+            test_declared_lifetime_expires
         ; Alcotest.test_case
             "tool write stores typed provenance"
             `Quick

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -157,7 +157,30 @@ let test_validation_taxonomy () =
   |> assert_invalid ~expected:"invalid_valid_for_days";
   Runtime.validate_memory_write_args
     (with_days (make_args ~kind:"goal" ~title:"" ~content:"body") 7)
-  |> assert_invalid ~expected:"valid_for_days_on_turn_scoped_kind"
+  |> assert_invalid ~expected:"valid_for_days_on_turn_scoped_kind";
+  (* A wrong JSON type is not a range violation. Answering it with the range
+     would send the producer looking for a bug it does not have. *)
+  (match
+     Runtime.validate_memory_write_args
+       (`Assoc
+         [ "kind", `String "long_term"
+         ; "title", `String ""
+         ; "content", `String "body"
+         ; "valid_for_days", `String "7"
+         ])
+   with
+   | Runtime.Memory_write_invalid { error_kind; extras } ->
+     Alcotest.(check string)
+       "error kind"
+       "invalid_valid_for_days"
+       (error_label error_kind);
+     Alcotest.(check (option string))
+       "reason names the type, not the range"
+       (Some "not_an_integer")
+       (match List.assoc_opt "reason" extras with
+        | Some (`String r) -> Some r
+        | _ -> None)
+   | Runtime.Memory_write_ok _ -> Alcotest.fail "a string lifetime must be rejected")
 ;;
 
 let test_valid_body_has_no_intermediate_projection () =


### PR DESCRIPTION
## 목적

`valid_until` 에 **첫 writer** 를 준다. 읽는 쪽은 이미 완성돼 있고 아무도 쓰지 않아 죽어 있던 필드다.

RFC-0351 S2 (`L1/L2 건강화 — consolidation fail-loud, **valid_until**, delivery accounting`).

## 근거 — 하네스가 측정한 것

RFC-0247 P-1 하네스(`test/memory_quality_eval.ml`, 이미 존재)를 라이브 스토어에 돌린 결과:

```
recall records: 293,285 turns · distinct fact_keys: 35,330 · total injections: 8,636,481
echo 분포: max=188,077  p99=3,193  p90=231  p50=23
top: g0234-loop-pattern 188,077 / board-post-get-needs-post-id 186,576
     board-post-get-requires-post-id 185,451 / issue-king-routing-pattern 179,850
recall churn: 턴당 fact_keys mean=29.4 max=381

FACT COMPOSITION: 747 facts · durable(valid_until=None) 747 (100%) · 중복행 0
```

**747개 전부가 영구 durable** 이다. 상위 4개는 각각 18만 회씩 재주입됐고, 그 내용은 "board_post_get 에 post_id 가 필요하다" 같은 운영 자잘한 사실이다.

## 왜 이게 코드 문제인가

`valid_until` 은 죽은 필드가 아니다. **읽는 쪽만 살아 있었다.**

| 층 | 상태 |
|---|---|
| 영속 포맷 (`keeper_memory_os_types.ml`) | 직렬화·파싱 **지원** |
| recall | `fact_is_current ~now` 로 **이미 만료 제거** |
| librarian 추출 | `valid_until = None` **하드코딩** (`keeper_librarian.ml:248,317`) |
| LLM 추출 스키마 | 필드 **없음** |
| 모델 쓰기 경로 (#25518) | `valid_until = None` **하드코딩** |

`rg 'valid_until = Some' lib/` → **0건**. 만료를 선언할 수 있는 producer 가 하나도 없어서, 만료 검사가 항상 참인 조건을 검사하고 있었다. #25517 과 같은 형태 — 메커니즘 있음, producer 없음.

## 변경

`keeper_memory_write` 에 optional `valid_for_days : integer` 를 추가한다.

- **long_term 전용.** turn-scoped kind 에 붙이면 `valid_for_days_on_turn_scoped_kind` 로 거부한다 — 그 노트는 어차피 런과 함께 죽으므로, 조용히 받아주면 스토어가 지키지 않는 경계를 보고하는 셈이 된다.
- **범위 1–365.** 양쪽 다 거부한다. 오늘 만료하는 클레임이나 10년짜리 클레임은 수명이 아니라 producer 의 실수이고, 상한이 없으면 `valid_for_days` 가 "영구"를 말하는 두 번째 방법이 된다.
- **판정은 producer 의 것이다.** 코드가 텍스트를 보고 수명을 추론하지 않는다. RFC-0247 §-1 이 금지하는 건 automatic confidence-cap-as-truth 이고, 모델이 "이건 7일간 참이다"라고 선언하는 것은 허용되는 producer judgment 다. 문자열 분류기를 추가하지 않는다 (CLAUDE.md 워크어라운드 시그니처 #2).
- 부재("absent")와 0 을 구분해야 해서 `Safe_ops.json_int` 대신 raw member 를 읽는다. `~default:0` 이면 미지정이 곧 거부 대상 값이 된다.

## 로컬 검증

- `dune build --root . lib` clean, `@fmt` 내 파일 diff 0
- **146 테스트 통과**: `test_keeper_memory_write` 8/8 · `test_keeper_memory_os` 112/112 · `test_memory_horizon_classifier` 4/4 · `test_tool_help_metadata_rfc_0195` 6/6 · `test_keeper_tool_resolution` 16/16
- 신규 `declared lifetime reaches the store and expires` — 선언한 수명이 스토어에 실리고(`valid_until - first_seen = 7일`), 창 안에서는 `fact_is_current = true`, 창 밖에서는 **`false`**. **recall 이 실제로 쓰는 리더**로 단언한다.
- 신규 거부 케이스 3종: 0일, 366일, turn-scoped kind 에 수명 부착

## 남은 미검증 / 하지 않은 것

- **기존 747개는 그대로 영구다.** 이 PR 은 새 클레임에 경계를 줄 뿐 스토어를 소급 정리하지 않는다. 그건 L2 consolidation 이고 별건이다.
- **librarian 추출 스키마는 건드리지 않았다.** LLM 이 추출하는 fact 에 수명을 싣게 하는 건 L2 Judge 범위다. 이 PR 은 모델 소유 쓰기(L1)만 덮는다.
- **모델이 이 필드를 쓸지는 모른다.** 도구를 열고 문구를 준 것이지, 사용은 배포 후 관측 대상이다. 하네스가 `durable(valid_until=None)` 비율을 이미 재고 있으므로 전후 비교는 가능하다.
- `dune build --root . @all` 미수행 (lib + 해당 테스트 타겟만).

## 관련

- RFC-0351 L1 개정 + S0: #25514 · S1: #25515 · L3 예산+게이지: #25516 · L1 쓰기측: #25518 (모두 머지됨)
- 이슈 #25517 (모델 메모리 쓰기 무효)
- L3 배포 실측: sangsu recall 222,384 B → 65,980 B (**−70.3%**, 226 표본)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
