### PR TITLE
fix(dashboard): 레인이 잘린 개수를 총계로 표시하지 않도록

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import type { DashboardKeeperWaitingInventory } from '../../api'
+import type { DashboardKeeperWaitingInventory, DashboardKeeperWaitingRow } from '../../api'
 import type { Keeper } from '../../types'
 import { KeeperLaneStrip } from './keeper-lane-strip'
 
@@ -59,6 +59,57 @@ function inventoryFixture(): DashboardKeeperWaitingInventory {
   }
 }
 
+/** Mirrors the live shape that produced the "레인 64" report: the server capped
+ *  external attention at `external_attention_row_limit` and said so, so every
+ *  count folded over the surviving rows is a lower bound. The cap and the
+ *  external-attention row count are the observed values (sangsu, 2026-07-21,
+ *  265 pending in the store, 64 served); the uncapped chat rows are added so
+ *  the fixture covers a mixed entry where only one source is bounded. */
+function truncatedInventoryFixture(): DashboardKeeperWaitingInventory {
+  const externalRows: DashboardKeeperWaitingRow[] = Array.from({ length: 64 }, (_, i) => ({
+    keeper_name: 'sangsu',
+    source: 'external_attention',
+    waiting_on: 'external_attention',
+    wake_producer: 'keeper_process_external_attention',
+    since_iso: '2026-06-12T03:20:00Z',
+    next_action: 'keeper_process_external_attention',
+    detail: { event_id: `evt-${i}` },
+  }))
+  const chatRows: DashboardKeeperWaitingRow[] = Array.from({ length: 5 }, (_, i) => ({
+    keeper_name: 'sangsu',
+    source: 'chat_queue_pending',
+    waiting_on: 'dashboard_chat',
+    wake_producer: 'keeper_chat_queue',
+    since_iso: '2026-07-21T07:30:00Z',
+    next_action: 'keeper_drain_chat_queue',
+    detail: { receipt_id: `chatq_${i}` },
+  }))
+  return {
+    schema: 'masc.dashboard.keeper_waiting_inventory.v2',
+    source: 'server_keeper_waiting_inventory',
+    generated_at: '2026-07-21T07:38:06Z',
+    supported_states: ['idle', 'busy', 'waiting', 'deferred'],
+    keeper_count_known: true,
+    keeper_count: 1,
+    waiting_keeper_count: 1,
+    row_count: 69,
+    row_count_truncated: true,
+    external_attention_row_limit: 64,
+    keepers: [
+      {
+        keeper_name: 'sangsu',
+        state: 'waiting',
+        waiting_count: 69,
+        waiting_count_truncated: true,
+        truncated_sources: { external_attention: true },
+        sources: { external_attention: 64, chat_queue_pending: 5 },
+        next_action: 'keeper_process_external_attention',
+        waiting_on: [...externalRows, ...chatRows],
+      },
+    ],
+  }
+}
+
 describe('KeeperLaneStrip', () => {
   let host: HTMLDivElement | null = null
 
@@ -94,6 +145,71 @@ describe('KeeperLaneStrip', () => {
     expect(text).toContain('chat_lane')
     expect(text).toContain('keeper finish in flight turn')
     expect(el.querySelector('[data-missing="keeper-lane"]')).toBeNull()
+  })
+
+  it('marks a server-capped count as a lower bound instead of a total', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${truncatedInventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    const text = el.textContent ?? ''
+    expect(text).toContain('≥69')
+    // the bare integer would assert a total the server never computed
+    expect(text).not.toMatch(/레인\s*69(?!\d)/)
+    expect(el.querySelector('[data-testid="keeper-lane-more"]')?.textContent ?? '')
+      .toContain('of at least 69')
+  })
+
+  it('attributes the truncation to the capped source and the server limit', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${truncatedInventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    const note = el.querySelector('[data-testid="keeper-lane-truncation"]')?.textContent ?? ''
+    expect(note).toContain('external attention')
+    expect(note).toContain('64')
+    expect(note).toContain('실제 대기 건수는 더 많습니다')
+  })
+
+  it('bounds only the sources the server reported as capped', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${truncatedInventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    const sources = el.querySelector('[data-testid="keeper-lane-sources"]')?.textContent ?? ''
+    expect(sources).toContain('external attention ≥64')
+    // chat_queue_pending was not capped, so it is an exact count
+    expect(sources).toContain('chat queue pending 5')
+    expect(sources).not.toContain('chat queue pending ≥5')
+  })
+
+  it('renders an exact count and no truncation note when nothing was capped', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${inventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    expect(el.textContent ?? '').not.toContain('≥')
+    expect(el.querySelector('[data-testid="keeper-lane-truncation"]')).toBeNull()
   })
 
   it('shows the auto-refresh cadence beside the snapshot time when polling', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -5,6 +5,14 @@
 // the waiting rows behind it. State strings and rows render exactly as the
 // server sent them — no client-side judgement — and a keeper absent from
 // the inventory renders an explicit data gap instead of a guessed "idle".
+//
+// Counts are the one place that rule cuts the other way. `waiting_count` and
+// `sources` are both folds over a list the server already capped
+// (`server_keeper_waiting_inventory.ml:529` takes 64 external-attention rows,
+// then `:870`/`:877` measure what survived), so rendering either as a bare
+// integer states a total the server never computed. When the server sets
+// `waiting_count_truncated` the same numbers are lower bounds and must render
+// as such.
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
@@ -65,6 +73,29 @@ function LaneGap({ children }: { children: VNode | string }): VNode {
   `
 }
 
+/** A count the server folded over a possibly-capped row list. `truncated`
+ *  carries the server's own `waiting_count_truncated` / `truncated_sources`
+ *  verdict, so a capped count never renders as an exact total. */
+function boundedCount(value: number, truncated: boolean): string {
+  return truncated ? `≥${value}` : `${value}`
+}
+
+/** Per-source counts, each marked with the server's own per-source truncation
+ *  verdict. Sorted by count so the source driving the lane reads first. */
+function sourceBreakdown(entry: DashboardKeeperWaitingKeeper): string[] {
+  const truncated = entry.truncated_sources ?? {}
+  return Object.entries(entry.sources ?? {})
+    .sort(([, a], [, b]) => b - a)
+    .map(([source, count]) => `${enumLabel(source)} ${boundedCount(count, truncated[source] === true)}`)
+}
+
+/** Sources the server reported as capped, for the attribution line. */
+function truncatedSourceLabels(entry: DashboardKeeperWaitingKeeper): string[] {
+  return Object.entries(entry.truncated_sources ?? {})
+    .filter(([, isTruncated]) => isTruncated)
+    .map(([source]) => enumLabel(source))
+}
+
 function LaneWaitingRow({ row }: { row: DashboardKeeperWaitingRow }): VNode {
   return html`
     <div class="grid gap-0.5 border-t border-[var(--color-border-subtle)] py-1.5 first:border-t-0">
@@ -104,11 +135,17 @@ export function KeeperLaneStrip({
   const entry = inventoryEntry(inventory, keeper)
   const rows = (entry?.waiting_on ?? []).slice(0, LANE_ROW_LIMIT)
   const waitingCount = entry?.waiting_count ?? 0
+  const countTruncated = entry?.waiting_count_truncated === true
+  const truncatedSources = entry ? truncatedSourceLabels(entry) : []
+  const breakdown = entry ? sourceBreakdown(entry) : []
+  const rowLimit = inventory?.external_attention_row_limit
   return html`
     <div class="ctx-sec" data-testid="keeper-lane-section">
       <h4 style=${{ display: 'flex', alignItems: 'center', gap: '7px' }}>
         레인
-        ${waitingCount > 0 ? html`<${CountBadge}>${waitingCount}<//>` : null}
+        ${waitingCount > 0
+          ? html`<${CountBadge}>${boundedCount(waitingCount, countTruncated)}<//>`
+          : null}
       </h4>
       ${entry
         ? html`
@@ -126,10 +163,22 @@ export function KeeperLaneStrip({
                         <${LaneWaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />
                       `)}
                       ${waitingCount > rows.length
-                        ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]">+${waitingCount - rows.length} more</div>`
+                        ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-more">
+                            +${waitingCount - rows.length} more${countTruncated ? ` of at least ${waitingCount}` : ''}
+                          </div>`
                         : null}
                     </div>
                   `
+                : null}
+              ${countTruncated
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-truncation">
+                    서버 상한${rowLimit != null ? ` ${rowLimit}` : ''}에서 잘림${truncatedSources.length > 0 ? ` — ${truncatedSources.join(', ')}` : ''}. 실제 대기 건수는 더 많습니다.
+                  </div>`
+                : null}
+              ${breakdown.length > 0
+                ? html`<div class="font-mono text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-sources">
+                    ${breakdown.join(' · ')}
+                  </div>`
                 : null}
               ${inventory?.generated_at
                 ? html`<div class="text-2xs text-[var(--color-fg-muted)]">기준 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatAutoRefreshLabel(autoRefreshMs)}` : null}</div>`


### PR DESCRIPTION
## 목표

레인이 **잘린 개수를 총계로 표시하는 것**을 멈춥니다. 표시 계층만 바꾸며 서버와 동작은 그대로입니다.

## 배경 (실측)

사용자가 대시보드 레인에서 `64 waiting`을 보고 "왜 64개나 대기인가"를 물었습니다. 64는 개수가 아니라 서버 상한입니다.

| 값 | 출처 |
|---|---|
| `external_attention_dashboard_row_limit = 64` | `lib/server_keeper_waiting_inventory.ml:54` |
| 응답의 `external_attention` 카운트 = **64** | 상한과 정확히 일치 = 포화 |
| `external_attention_truncated_keeper_count = 1` | 잘렸음을 서버가 이미 보고 |
| 스토어 실제 pending = **265** | `~/.masc/external_attention/sangsu.jsonl` 761줄 접기: recorded 509 − terminal 244 |

`waiting_count`는 `keeper_json`(`:870`)에서 **이미 잘린 리스트**의 `List.length`로 계산됩니다. 이 시점 이후 265라는 값은 시스템 어디에도 없습니다. 같은 페이로드가 `masc_keeper_waiting_inventory` MCP 도구로도 나가므로 사람과 LLM 오퍼레이터 양쪽이 상한을 개수로 읽고 있었습니다.

## 변경 파일

- `dashboard/src/components/keeper-workspace/keeper-lane-strip.ts`
- `dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts`

서버가 이미 보내고 클라이언트 타입에도 선언되어 있으나 레인이 **하나도 읽지 않던** 필드를 소비합니다: `waiting_count_truncated`(`:871`), `truncated_sources`(`:872`), `sources`(`:877`), `external_attention_row_limit`(`:987`). 클라이언트 타입은 `dashboard/src/api/dashboard-tools-prompts.ts:328-329`.

- 잘림 보고 시 카운트를 `≥n`으로 표기
- 잔여 표기를 `+n more of at least m`로 변경
- 잘린 소스와 서버 상한을 명시하는 줄 추가
- 소스별 카운트 분리 표기. `sources`도 같은 잘린 rows에서 접힌 값(`:877`)이므로 **각 소스가 자기 bound를 따로** 가집니다. 집계에만 표시하면 같은 과장을 한 단계 아래에서 반복하게 됩니다.

## 로컬 검증

| 검사 | 결과 |
|---|---|
| `vitest run … keeper-lane-strip.test.ts` | 11 passed (기존 7 + 신규 4), exit 0 |
| `tsc --noEmit` | exit 0 |
| 회귀 게이트(positive control) | 소스 변경만 stash 후 재실행 → 신규 4건 중 **3건 실패** 확인 |

4번째 신규 테스트는 비잘림 경로 가드(`≥` 미출현, 안내줄 없음)라 구 코드에서도 통과하는 것이 정상입니다.

신규 fixture는 실측 형상을 그대로 씁니다: external attention 64행 + `truncated_sources: { external_attention: true }`, 여기에 잘리지 않은 chat 5행을 섞어 **한 소스만 bound되는 경우**를 덮습니다.

## 미검증 / 범위 밖

- **ESLint 미적용**: `dashboard/eslint.config.mjs`는 89개 파일 opt-in 허용목록이고 `keeper-lane-strip.ts`는 목록에 없습니다. 시험 삼아 추가하니 **기존 코드**의 `no-nested-ternary` 4건(`:150`, `:183`, `:190`, `:192` — 전부 이 PR 이전부터 존재)이 나와, 범위를 지키려 되돌렸습니다. 별도 정리 대상입니다.
- **진짜 총계는 여전히 미계산**: 서버에 총계 진입점이 없어(`pending_for_keeper`는 `limit:int`만, `limit<=0`은 빈 리스트) 클라이언트가 265를 알 방법이 없습니다. 그래서 이 PR의 정직한 표기는 `265`가 아니라 `≥64`입니다. 서버 총계 방출은 후속.
- **265건이 왜 안 줄어드는지는 이 PR이 고치지 않습니다.** 별도 조사에서 `record`와 `enqueue`가 독립된 두 문장이라 `MASC_CONNECTOR_AMBIENT_WAKE_ENABLED`(기본 false)가 그 사이를 갈랐고, 2026-07-13 이전 ambient-route 246건이 종료 호출자 없이 고착된 것으로 확인했습니다. 근본 수정은 `RFC-0241` 개정 대상입니다.
- 확대 컨트롤/딥링크는 넣지 않았습니다. 라우팅 확인이 필요해 범위를 넘습니다.

RFC-WAIVED: 표시 계층 단독 변경. mandatory-RFC subsystem(credential/identity, repo_manager, operator_control, keeper sandbox, hooks, workflow 문서) 어디에도 해당하지 않으며 서버·스토어·프로토콜 무수정.
