### PR TITLE
fix(keeper): 무위 턴에서 librarian 추출 중단 — 키퍼가 자기 게으름을 기억으로 만들던 루프 차단

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -708,6 +708,7 @@ let run_turn
                           ~session ~append_manifest ~model
                           ~acc
                           ~actual_keeper_tool_names
+                          ~user_turn_record
                           ~result ~checkpoint_persistence_error
                           ~post_turn_t0 ~runtime_id_string
                           ~history_messages

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -197,6 +197,7 @@ let finalize
     ~model
     ~(acc : Keeper_run_tools.hook_accumulator)
     ~actual_keeper_tool_names
+    ~(user_turn_record : Keeper_run_prompt.user_turn_record)
     ~(result : Runtime_agent.run_result)
     ~checkpoint_persistence_error
     ~post_turn_t0
@@ -366,6 +367,10 @@ let finalize
       ~response_text
       ~actual_tools:actual_keeper_tool_names
       ~librarian_messages
+      ~memory_extraction_record:
+        (Keeper_run_prompt.memory_extraction_record_of_turn
+           ~user_turn_record
+           ~tool_calls_made:(actual_keeper_tool_names <> []))
       ~post_turn_t0
       ~runtime_id:runtime_id_string
       ~inference_telemetry:result.response.telemetry

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -12,6 +12,7 @@ let run
   ~response_text
   ~actual_tools
   ~librarian_messages
+  ~(memory_extraction_record : Keeper_run_prompt.memory_extraction_record)
   ~post_turn_t0
   ~runtime_id
   ~inference_telemetry
@@ -134,12 +135,23 @@ let run
       ~keeper_name:meta.name
       det_write_series
   in
-  let (_ : Keeper_memory_lane.outcome) =
-    Keeper_memory_lane.submit
-      ~base_path:config.base_path
-      ~keeper_name:meta.name
-      librarian_series
-  in
+  (match memory_extraction_record with
+   | Keeper_run_prompt.Extract_turn ->
+     let (_ : Keeper_memory_lane.outcome) =
+       Keeper_memory_lane.submit
+         ~base_path:config.base_path
+         ~keeper_name:meta.name
+         librarian_series
+     in
+     ()
+   | Keeper_run_prompt.Skip_inert_turn ->
+     (* Not submitted at all, so the cadence counter does not advance either:
+        an idle stretch leaves the extraction budget untouched instead of
+        spending it on prose about the idleness. *)
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string MemoryOsInertTurnExtractionSkipped)
+       ~labels:[ "keeper", meta.name ]
+       ());
   (* Post-turn memory recall evidence is logged to decisions.jsonl. *)
   (try
      let used_search =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -17,6 +17,7 @@ val run :
   response_text:string ->
   actual_tools:string list ->
   librarian_messages:Agent_sdk.Types.message list ->
+  memory_extraction_record:Keeper_run_prompt.memory_extraction_record ->
   post_turn_t0:float ->
   runtime_id:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
@@ -34,4 +35,11 @@ val run :
 
     [deliberation_execution], when available, is persisted as advisory
     delegation request artifacts on this post-turn memory lane rather than on
-    the decision-record append path. *)
+    the decision-record append path.
+
+    [memory_extraction_record] gates only the librarian sub-stage. On
+    [Skip_inert_turn] the librarian unit is never submitted, so its cadence
+    counter does not advance and an idle stretch spends no extraction budget.
+    The deterministic write series runs either way: a model-owned
+    [keeper_memory_write] on an otherwise inert turn is an explicit decision to
+    remember, not an extraction from prose. *)

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -42,6 +42,34 @@ let user_turn_record_of_hitl_resolution : _ option -> user_turn_record
   | Some _ -> Record_user_turn
 ;;
 
+type memory_extraction_record =
+  | Extract_turn
+  | Skip_inert_turn
+
+(* The librarian fires on a turn cadence, not on activity, so an idle stretch
+   keeps extracting. What it extracts from a bare wake that called no tool is
+   the model's prose about its own idleness, which lands in the fact store as
+   [ephemeral] claims and is recalled on the next turn. Live: 8 of one
+   keeper's 10 most recent claims were "Agent idle across N consecutive
+   autonomous wake cycles", re-injected at 66KB against 3.8KB of world state
+   that reported 122 claimable tasks on the same prompt.
+
+   Both arms are required. A wake that ran a tool changed something; a turn
+   carrying operator or HITL input can hold a durable fact with no tool call.
+   Every pair is listed so a new [user_turn_record] variant fails to compile
+   here rather than defaulting into one side. *)
+let memory_extraction_record_of_turn
+      ~(user_turn_record : user_turn_record)
+      ~(tool_calls_made : bool)
+  : memory_extraction_record
+  =
+  match user_turn_record, tool_calls_made with
+  | Skip_uninformative_wake, false -> Skip_inert_turn
+  | Skip_uninformative_wake, true -> Extract_turn
+  | Record_user_turn, false -> Extract_turn
+  | Record_user_turn, true -> Extract_turn
+;;
+
 type extra_system_context_assembly =
   { extra_system_context : string option
   ; blocks : (Prompt_block_id.t * string) list

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -33,6 +33,32 @@ val user_turn_record_of_hitl_resolution : _ option -> user_turn_record
 (** Map the unified lane's HITL resolution slot to a transcript decision.
     Absent resolution means the user turn is the bare wake marker. *)
 
+type memory_extraction_record =
+  | Extract_turn
+  | Skip_inert_turn
+(** Whether this turn is worth running librarian extraction over.
+
+    [Skip_inert_turn] is a bare autonomous wake that also called no tool: the
+    input carried nothing forward ({!Skip_uninformative_wake}) and the turn
+    changed nothing observable. The librarian fires on a turn cadence rather
+    than on activity, so an idle stretch keeps extracting, and what it can
+    extract from such a turn is the model's prose about its own idleness.
+    Those land in the fact store as [ephemeral] claims ("Agent idle across 72
+    consecutive autonomous wake cycles"), are recalled the next turn, and are
+    read back as evidence that there is nothing to do — a loop that runs while
+    the world observation on the same prompt reports claimable tasks.
+
+    The distinction is typed and derived from the wake decision plus the
+    turn's tool-call list, never from response text. *)
+
+val memory_extraction_record_of_turn
+  :  user_turn_record:user_turn_record
+  -> tool_calls_made:bool
+  -> memory_extraction_record
+(** [Skip_inert_turn] only when the wake was bare {b and} no tool ran. A wake
+    that called a tool did something worth recording; a turn carrying operator
+    or HITL input can hold a durable fact even with no tool call. *)
+
 type extra_system_context_assembly =
   { extra_system_context : string option
   ; blocks : (Prompt_block_id.t * string) list

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -191,6 +191,7 @@ type t =
   | MemoryOsRecallUnavailable
   | MemoryOsReobserveEchoSuppressed
   | MemoryOsExplicitFactWrite
+  | MemoryOsInertTurnExtractionSkipped
   | MemoryOsRecallFactsTruncated
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
@@ -416,6 +417,8 @@ let to_string = function
       "masc_keeper_memory_os_reobserve_echo_suppressed_total"
   | MemoryOsExplicitFactWrite ->
       "masc_keeper_memory_os_explicit_fact_write_total"
+  | MemoryOsInertTurnExtractionSkipped ->
+      "masc_keeper_memory_os_inert_turn_extraction_skipped_total"
   | MemoryOsRecallFactsTruncated ->
       "masc_keeper_memory_os_recall_facts_truncated_total"
   | MemoryOsRecallEpisodesTruncated ->

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -182,6 +182,7 @@ type t =
   | MemoryOsRecallUnavailable
   | MemoryOsReobserveEchoSuppressed
   | MemoryOsExplicitFactWrite
+  | MemoryOsInertTurnExtractionSkipped
   | MemoryOsRecallFactsTruncated
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -368,6 +368,39 @@ let test_bare_autonomous_wake_is_not_recorded () =
     (Masc.Keeper_run_prompt.user_turn_record_of_hitl_resolution (Some ())
      = Masc.Keeper_run_prompt.Record_user_turn)
 
+(* The transcript fix above stopped the wake marker from accumulating, but the
+   librarian reads the checkpoint window on a turn cadence, so an idle stretch
+   kept extracting and kept storing the idleness. Live: 8 of one keeper's 10
+   most recent claims were "Agent idle across N consecutive autonomous wake
+   cycles", recalled at 66KB against 3.8KB of world state reporting 122
+   claimable tasks on the same prompt. Only the bare-wake-and-no-tool pair is
+   inert; the other three carry something a later turn can use. *)
+let test_inert_turn_skips_librarian_extraction () =
+  let decide ~user_turn_record ~tool_calls_made =
+    Masc.Keeper_run_prompt.memory_extraction_record_of_turn
+      ~user_turn_record ~tool_calls_made
+  in
+  check bool "bare wake with no tool call is inert" true
+    (decide
+       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+       ~tool_calls_made:false
+     = Masc.Keeper_run_prompt.Skip_inert_turn);
+  check bool "bare wake that ran a tool still extracts" true
+    (decide
+       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+       ~tool_calls_made:true
+     = Masc.Keeper_run_prompt.Extract_turn);
+  check bool "operator/HITL input extracts even with no tool call" true
+    (decide
+       ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
+       ~tool_calls_made:false
+     = Masc.Keeper_run_prompt.Extract_turn);
+  check bool "operator/HITL input with a tool call extracts" true
+    (decide
+       ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
+       ~tool_calls_made:true
+     = Masc.Keeper_run_prompt.Extract_turn)
+
 let () =
   run "keeper_unified_verification_surface"
     [
@@ -417,5 +450,8 @@ let () =
           test_case
             "invariant: a bare autonomous wake is not recorded in the transcript"
             `Quick test_bare_autonomous_wake_is_not_recorded;
+          test_case
+            "invariant: an inert turn does not feed the librarian"
+            `Quick test_inert_turn_skips_librarian_extraction;
         ] );
     ]


### PR DESCRIPTION
## 목적

무위 턴(bare autonomous wake + 도구 호출 0회)에서 librarian 추출을 건너뛴다. 그 턴에서 추출할 수 있는 것은 모델이 자기 무위에 대해 쓴 산문뿐이고, 그게 fact 스토어에 쌓여 다음 턴에 회상된다.

RFC-0351 §5. #25515 가 같은 교환의 user 쪽(transcript)에 한 것을 fact 쪽에 적용한다.

## 라이브 근거

sangsu 의 최근 저장 claim 10건 중 8건:

```
[ephemeral] Agent idle across 72 consecutive autonomous wake cycles with no tasks claimed.
[ephemeral] Agent reported no-work across 36 consecutive autonomous wake cycles...
[ephemeral] Keeper idle across 36 consecutive wake cycles with no tasks claimed or performed.
[ephemeral] Keeper found no work to do across many consecutive autonomous wake cycles.
```

episode 요약도 같다: *"The keeper cycled through 36 consecutive autonomous wake-ups with no tasks, reporting 'No-work' each time."*

같은 턴의 프롬프트 구성:

```
memory_os_recall   65,954 B  (78%)   "너는 72번 연속 놀았다"
persona            15,069 B  (18%)
dynamic_context     3,849 B  ( 4%)   "Claimable tasks for this keeper: 122"
```

**무위의 기억이 현재 세계 상태의 17배다.** 그리고 그 세계 상태는 백로그에 todo 122건이 있다고 보고하고 있다 (`~/.masc/tasks/backlog.json`: todo 122 / in_progress 3 / done 171).

루프: `"No-work."` → librarian 이 "agent was idle" 을 fact 로 추출 → 다음 턴 회상 → `"No-work."`.

## 왜 이 지점인가

librarian 은 **활동이 아니라 턴 cadence** 로 발화한다 (`keeper_librarian_runtime.cadence_turns`). 그래서 무위 구간에서도 계속 돌면서 그 무위를 요약해 저장한다. 무위 턴에서 제출 자체를 건너뛰면 cadence 카운터도 안 올라가므로, 유휴 구간은 추출 예산을 쓰지 않는다.

## 변경

`Keeper_run_prompt` 에 #25515 의 `user_turn_record` 와 대칭인 순수 판별식 추가:

```ocaml
type memory_extraction_record =
  | Extract_turn
  | Skip_inert_turn

let memory_extraction_record_of_turn ~user_turn_record ~tool_calls_made =
  match user_turn_record, tool_calls_made with
  | Skip_uninformative_wake, false -> Skip_inert_turn
  | Skip_uninformative_wake, true  -> Extract_turn
  | Record_user_turn,        false -> Extract_turn
  | Record_user_turn,        true  -> Extract_turn
```

- **두 조건 모두 필요하다.** 도구를 부른 wake 는 뭔가를 바꿨고, operator/HITL 입력을 실은 턴은 도구 없이도 durable fact 를 담을 수 있다.
- **네 쌍을 전부 나열**한다. catch-all 없음 — `user_turn_record` 에 변형이 추가되면 여기서 컴파일 에러가 난다.
- **응답 텍스트를 보지 않는다.** 판정은 wake 결정과 tool_calls 리스트라는 구조적 신호에서만 나온다 (CLAUDE.md 워크어라운드 시그니처 #2: string/substring 분류기 금지).

`Skip_inert_turn` 일 때 librarian 유닛을 `Keeper_memory_lane` 에 **제출하지 않는다**. 결정론적 write series 는 그대로 돈다 — 무위 턴의 모델 소유 `keeper_memory_write` 는 산문 추출이 아니라 명시적 기억 결정이므로 막지 않는다.

## 로컬 검증

```
dune build --root . @all                        exit 0
test_keeper_unified_verification_surface       19/19  (신규 1건)
test_keeper_wire_capture                       15/15
test_keeper_memory_os                         112/112
test_keeper_memory_write                        8/8
```

신규 테스트는 네 쌍을 전부 단언한다 — 무위 1건, 추출 3건.

## 남은 미검증 / 하지 않은 것

- **기존 fact 는 그대로다.** 이 PR 은 새 추출만 막는다. sangsu 의 ephemeral 12건은 남아 있고 계속 회상된다. 소급 정리는 L2 consolidation 이고 별건이다.
- **`"No-work."` 가 실제로 줄어드는지는 모른다.** 배포 후 관측 대상이다. 새 카운터 `masc_keeper_memory_os_inert_turn_extraction_skipped_total` 로 스킵 발생량은 셀 수 있고, fact 스토어의 `ephemeral` 증가율로 효과를 비교할 수 있다.
- **librarian 윈도우는 여전히 과거 메시지를 포함한다.** 활동 턴이 오면 그 윈도우에 옛 무위 메시지가 섞여 있다. 이 PR 이 막는 것은 "무위 구간 중에 발화해서 무위만 요약하는" 경로다 — 관측된 패턴이 정확히 그것이다.
- 무위 턴의 assistant 메시지는 여전히 체크포인트에 쌓인다. transcript 측 대칭 수정은 별도 판단이 필요하다 (#25515 는 user 측만 다뤘다).

## 관련

- #25515 — 같은 교환의 user 측(transcript). 이 PR 은 fact 측
- #25516 — recall 출력 바이트 예산 (222 KB → 66 KB). 크기를 줄였지 내용을 바꾸지 않았다
- RFC-0351 §5

RFC-WAIVED: 변경 파일이 credential/identity/operator-control/sandbox/hooks 경계 밖(`keeper_agent_run*`, `keeper_run_prompt*`, `keeper_metrics`)이고, RFC-0351 §5 가 이미 이 작업의 설계 근거다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
