### PR TITLE
fix(keeper): Read limit means lines, not bytes — line-window contract with next_offset

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -328,9 +328,17 @@ let read_file_schema =
          repos/masc. This is explicit only; Read never inherits the previous \
          Execute cwd."
     ; property
+        "offset"
+        "integer"
+        "1-based line number to start reading from (default 1). To continue a \
+         truncated read, pass the next_offset value from the previous response."
+    ; property
         "limit"
         "integer"
-        "Approximate maximum bytes to return. Line offsets are not supported."
+        "Maximum number of LINES to return, counted from offset. The response \
+         is additionally bounded by a byte budget; when more content remains, \
+         the payload sets truncated=true and next_offset for the follow-up \
+         call."
     ]
 ;;
 
@@ -450,6 +458,10 @@ let fetch_web_schema =
 
 let translate_identity input = input
 
+(* [offset]/[limit] pass through as LINE coordinates — the runtime owns the
+   line-window contract (keeper_tool_filesystem_runtime.slice_read_window).
+   [limit] used to be renamed to [max_bytes] here, which silently turned "200
+   lines" into "512 bytes" (the min byte clamp) and starved every code read. *)
 let translate_read_file input =
   match input with
   | `Assoc fields ->
@@ -458,7 +470,6 @@ let translate_read_file input =
       (fun (k, v) ->
          match k with
          | "file_path" -> out := ("path", v) :: !out
-         | "limit" -> out := ("max_bytes", v) :: !out
          | _ -> out := (k, v) :: !out)
       fields;
     `Assoc (List.rev !out)

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -61,9 +61,13 @@ type read_line_window =
   ; max_lines : int option (* cap on returned lines; None = to EOF *)
   }
 
-let read_window_is_whole_prefix = function
-  | { start_line = 1; max_lines = None } -> true
-  | _ -> false
+(* A window that starts at line 1 can only ever return bytes from the first
+   [max_bytes] of the file (the response is byte-budgeted), so its fetch stays
+   at [max_bytes]; only a window that starts deeper needs to scan further to
+   locate its lines. *)
+let read_window_fetch_bytes ~max_bytes = function
+  | { start_line = 1; max_lines = _ } -> max_bytes
+  | _ -> read_file_max_max_bytes
 ;;
 
 (* Range violations are rejected loudly instead of being defaulted: a model
@@ -324,15 +328,7 @@ let handle_read_file_with_outcome
            let timeout_sec =
              Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ()
            in
-           (* A line window that starts past line 1 (or caps lines) needs
-              bytes beyond the response budget to locate its lines, so the
-              fetch runs to the scan ceiling; the response stays bounded by
-              [max_bytes] either way. *)
-           let fetch_bytes =
-             if read_window_is_whole_prefix window
-             then max_bytes
-             else read_file_max_max_bytes
-           in
+           let fetch_bytes = read_window_fetch_bytes ~max_bytes window in
            let+ body =
              Keeper_sandbox_read_runner.read_file
                ?turn_sandbox_factory

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -84,6 +84,9 @@ let read_line_window_of_args args =
           read up to the byte budget."
          limit)
   | offset, max_lines ->
+    (* DET-OK: absent offset resolves to the schema-declared default (line 1,
+       "start of file"); out-of-range values are rejected above, so this is
+       documented-default resolution, not permissive unknown handling. *)
     Ok { start_line = Option.value ~default:1 offset; max_lines }
 ;;
 

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -47,6 +47,136 @@ let read_file_default_max_bytes = Tool_shard_limits.read_file_default_max_bytes
 let read_file_min_max_bytes = 512
 let read_file_max_max_bytes = 200_000
 
+(** Read line window. The Read descriptor (agent.read_file) exposes
+    [offset]/[limit] as LINE coordinates — the shape mainstream Read tools
+    train models on: [offset] is the 1-based first line, [limit] caps
+    returned lines. [max_bytes] stays a byte budget on the returned content.
+    The descriptor used to translate [limit] straight into [max_bytes], so a
+    model asking for 200 lines received max(512, 200) = 512 bytes with
+    [truncated=true] and could never read past the file head — live keepers
+    re-issued the byte-identical Read for 200+ calls inside a single turn.
+    [next_offset] in the payload is what makes forward progress expressible. *)
+type read_line_window =
+  { start_line : int (* 1-based first line to return *)
+  ; max_lines : int option (* cap on returned lines; None = to EOF *)
+  }
+
+let read_window_is_whole_prefix = function
+  | { start_line = 1; max_lines = None } -> true
+  | _ -> false
+;;
+
+(* Range violations are rejected loudly instead of being defaulted: a model
+   that sent [limit=0] or [offset=-3] gets a payload naming the contract, so
+   the next attempt can self-correct. *)
+let read_line_window_of_args args =
+  match Safe_ops.json_int_opt "offset" args, Safe_ops.json_int_opt "limit" args with
+  | Some offset, _ when offset < 1 ->
+    Error
+      (Printf.sprintf
+         "offset must be a 1-based line number (got %d). Read returns lines; \
+          use next_offset from the previous response to continue."
+         offset)
+  | _, Some limit when limit < 1 ->
+    Error
+      (Printf.sprintf
+         "limit must be a positive number of lines (got %d). Omit limit to \
+          read up to the byte budget."
+         limit)
+  | offset, max_lines ->
+    Ok { start_line = Option.value ~default:1 offset; max_lines }
+;;
+
+type read_window_slice =
+  { window_content : string
+  ; returned_lines : int
+  ; next_offset : int option (* set iff content remains past the window *)
+  ; window_truncated : bool
+  ; last_line_partial : bool
+    (* the byte budget cut inside the final returned line; [next_offset]
+       already points past that line so retrying cannot loop on it *)
+  }
+
+(* Byte index where 1-based [line] starts in [content], or None when the
+   scanned content ends before that line begins. *)
+let rec line_start_index content len idx line =
+  if line <= 1
+  then Some idx
+  else if idx >= len
+  then None
+  else (
+    match String.index_from_opt content idx '\n' with
+    | None -> None
+    | Some nl -> line_start_index content len (nl + 1) (line - 1))
+;;
+
+let count_returned_lines capped =
+  let len = String.length capped in
+  if len = 0
+  then 0
+  else (
+    let newlines = String.fold_left (fun n c -> if c = '\n' then n + 1 else n) 0 capped in
+    if capped.[len - 1] = '\n' then newlines else newlines + 1)
+;;
+
+(* [scan_complete=false] means [content] is a byte-budgeted prefix of the
+   file (sandbox fetch cut), so exhausting [content] does not prove EOF and
+   line numbers past the scan horizon cannot be mapped. *)
+let slice_read_window ~(window : read_line_window) ~max_bytes ~scan_complete content =
+  let len = String.length content in
+  match line_start_index content len 0 window.start_line with
+  | None ->
+    if scan_complete
+    then
+      Ok
+        { window_content = ""
+        ; returned_lines = 0
+        ; next_offset = None
+        ; window_truncated = false
+        ; last_line_partial = false
+        }
+    else Error `Offset_beyond_scan
+  | Some start ->
+    let stop =
+      match window.max_lines with
+      | None -> len
+      | Some lines ->
+        let rec advance idx remaining =
+          if remaining = 0 || idx >= len
+          then idx
+          else (
+            match String.index_from_opt content idx '\n' with
+            | None -> len
+            | Some nl -> advance (nl + 1) (remaining - 1))
+        in
+        advance start lines
+    in
+    let raw = String.sub content start (stop - start) in
+    let capped, last_line_partial =
+      if String.length raw <= max_bytes
+      then raw, false
+      else (
+        match String.rindex_from_opt raw (max_bytes - 1) '\n' with
+        | Some nl -> String.sub raw 0 (nl + 1), false
+        | None -> String.sub raw 0 max_bytes, true)
+    in
+    let returned_lines = count_returned_lines capped in
+    let consumed_to = start + String.length capped in
+    let more_in_scan = consumed_to < len in
+    let more_beyond_scan = (not scan_complete) && consumed_to >= len in
+    let window_truncated = more_in_scan || more_beyond_scan || last_line_partial in
+    let next_offset =
+      if window_truncated then Some (window.start_line + returned_lines) else None
+    in
+    Ok
+      { window_content = capped
+      ; returned_lines
+      ; next_offset
+      ; window_truncated
+      ; last_line_partial
+      }
+;;
+
 type read_file_resolution_error = Read_path_error of string
 
 let string_opt_nonempty name json =
@@ -124,9 +254,57 @@ let handle_read_file_with_outcome
     |> fun n -> max read_file_min_max_bytes (min read_file_max_max_bytes n)
   in
   let cwd = string_opt_nonempty "cwd" args in
-  match resolve_read_file_target ~config ~meta ~args ~raw_path:path with
-  | Error (Read_path_error e) -> Keeper_tool_execution.failure (error_json e)
-  | Ok target ->
+  match read_line_window_of_args args, resolve_read_file_target ~config ~meta ~args ~raw_path:path with
+  | Error window_error, _ -> Keeper_tool_execution.failure (error_json window_error)
+  | Ok _, Error (Read_path_error e) -> Keeper_tool_execution.failure (error_json e)
+  | Ok window, Ok target ->
+    let payload_of_slice ~via ~file_bytes ~scan_complete body =
+      match slice_read_window ~window ~max_bytes ~scan_complete body with
+      | Error `Offset_beyond_scan ->
+        Read_failed_payload
+          (error_json
+             ~fields:
+               [ "path", `String target
+               ; "offset", `Int window.start_line
+               ; "scanned_bytes", `Int (String.length body)
+               ]
+             (Printf.sprintf
+                "offset %d is beyond the scanned window (%d bytes; the file \
+                 continues past the scan budget). Read line ranges within the \
+                 first %d bytes, or narrow the file another way (e.g. Grep)."
+                window.start_line
+                (String.length body)
+                read_file_max_max_bytes))
+      | Ok slice ->
+        let optional_fields =
+          List.concat
+            [ (match slice.next_offset with
+               | Some next -> [ "next_offset", `Int next ]
+               | None -> [])
+            ; (if slice.last_line_partial
+               then [ "last_line_partial", `Bool true ]
+               else [])
+            ; (match file_bytes with
+               | Some total -> [ "file_bytes", `Int total ]
+               | None -> [])
+            ; (match via with
+               | Some via -> [ "via", `String via ]
+               | None -> [])
+            ]
+        in
+        Read_succeeded
+          (Yojson.Safe.to_string
+             (`Assoc
+                 ([ "ok", `Bool true
+                  ; "path", `String target
+                  ; "bytes", `Int (String.length slice.window_content)
+                  ; "truncated", `Bool slice.window_truncated
+                  ; "offset", `Int window.start_line
+                  ; "returned_lines", `Int slice.returned_lines
+                  ; "content", `String slice.window_content
+                  ]
+                  @ optional_fields)))
+    in
     let run_read () =
          (* RFC-0006 Phase B-1: Docker keepers are always contained to their
             playground bundle on the host before any read-side I/O proceeds.
@@ -143,28 +321,31 @@ let handle_read_file_with_outcome
            let timeout_sec =
              Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ()
            in
+           (* A line window that starts past line 1 (or caps lines) needs
+              bytes beyond the response budget to locate its lines, so the
+              fetch runs to the scan ceiling; the response stays bounded by
+              [max_bytes] either way. *)
+           let fetch_bytes =
+             if read_window_is_whole_prefix window
+             then max_bytes
+             else read_file_max_max_bytes
+           in
            let+ body =
              Keeper_sandbox_read_runner.read_file
                ?turn_sandbox_factory
                ~config
                ~meta
                ~host_path:target
-               ~max_bytes
+               ~max_bytes:fetch_bytes
                ~timeout_sec
                ()
            in
-           let total = String.length body in
-           let truncated = total >= max_bytes in
-           Read_succeeded
-             (Yojson.Safe.to_string
-                (`Assoc
-                    [ "ok", `Bool true
-                    ; "path", `String target
-                    ; "bytes", `Int total
-                    ; "truncated", `Bool truncated
-                    ; "content", `String body
-                    ; "via", `String Keeper_sandbox_read_runner.backend_via
-                    ])))
+           let scan_complete = String.length body < fetch_bytes in
+           payload_of_slice
+             ~via:(Some Keeper_sandbox_read_runner.backend_via)
+             ~file_bytes:None
+             ~scan_complete
+             body)
          else (
            match Safe_ops.read_file_safe target with
            | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
@@ -177,21 +358,12 @@ let handle_read_file_with_outcome
                      ~error:e))
            | Error e -> Ok (Read_failed_message e)
            | Ok content ->
-             let total = String.length content in
-             let truncated = total > max_bytes in
-             let body =
-               if truncated then String.sub content 0 max_bytes else content
-             in
              Ok
-               (Read_succeeded
-                  (Yojson.Safe.to_string
-                     (`Assoc
-                          [ "ok", `Bool true
-                          ; "path", `String target
-                          ; "bytes", `Int total
-                          ; "truncated", `Bool truncated
-                          ; "content", `String body
-                          ]))))
+               (payload_of_slice
+                  ~via:None
+                  ~file_bytes:(Some (String.length content))
+                  ~scan_complete:true
+                  content))
     in
     (match run_read () with
      | Ok (Read_succeeded json) -> Keeper_tool_execution.success json

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -88,9 +88,8 @@ let read_line_window_of_args args =
           read up to the byte budget."
          limit)
   | offset, max_lines ->
-    (* DET-OK: absent offset resolves to the schema-declared default (line 1,
-       "start of file"); out-of-range values are rejected above, so this is
-       documented-default resolution, not permissive unknown handling. *)
+    (* DET-OK: absent offset = the schema-declared default (line 1); range
+       violations are rejected above — documented-default resolution. *)
     Ok { start_line = Option.value ~default:1 offset; max_lines }
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -2470,6 +2470,11 @@
  (modules test_keeper_visible_path_projection)
  (libraries masc_test_deps))
 
+(test
+ (name test_keeper_tool_read_window)
+ (modules test_keeper_tool_read_window)
+ (libraries masc_test_deps))
+
 ; Event-bus concurrency regression tests (S1–S3).
 
 (test

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -724,7 +724,8 @@ let test_read_public_validation_translates_supported_fields () =
     `Assoc
       [ "file_path", `String "lib/keeper/keeper_transition_audit.ml"
       ; "cwd", `String "repos/masc"
-      ; "limit", `Int 4096
+      ; "offset", `Int 100
+      ; "limit", `Int 200
       ]
   in
   match
@@ -749,12 +750,26 @@ let test_read_public_validation_translates_supported_fields () =
       (match List.assoc_opt "cwd" fields with
        | Some (`String cwd) -> Some cwd
        | _ -> None);
+    (* The line window passes through untouched: the runtime owns line
+       semantics. Renaming limit to max_bytes here is what turned "200
+       lines" into "512 bytes" and starved every code read (2026-07-21
+       executor loop). *)
     Alcotest.(check (option int))
-      "limit translates to max_bytes"
-      (Some 4096)
-      (match List.assoc_opt "max_bytes" fields with
-       | Some (`Int max_bytes) -> Some max_bytes
-       | _ -> None)
+      "limit passes through as a line cap"
+      (Some 200)
+      (match List.assoc_opt "limit" fields with
+       | Some (`Int limit) -> Some limit
+       | _ -> None);
+    Alcotest.(check (option int))
+      "offset passes through as a line offset"
+      (Some 100)
+      (match List.assoc_opt "offset" fields with
+       | Some (`Int offset) -> Some offset
+       | _ -> None);
+    Alcotest.(check bool)
+      "no max_bytes is synthesized from limit"
+      true
+      (List.assoc_opt "max_bytes" fields = None)
   | Some (Ok (_, other)) ->
     Alcotest.failf "Read translated input is not an object: %s" (Yojson.Safe.to_string other)
   | Some (Error validation_result) ->

--- a/test/test_keeper_tool_read_window.ml
+++ b/test/test_keeper_tool_read_window.ml
@@ -1,0 +1,364 @@
+(* Read tool line-window contract (agent.read_file / tool_read_file).
+
+   Locks the fix for the live parrot loop of 2026-07-21: the Read descriptor
+   translated [limit] into [max_bytes], so a model asking for 200 LINES
+   received max(512, 200) = 512 BYTES with truncated=true, could never read
+   past the file head, and re-issued the byte-identical Read for 200+ calls
+   inside one turn. The contract now treats [offset]/[limit] as line
+   coordinates, keeps [max_bytes] as the byte budget, and reports
+   [next_offset] so a follow-up call can make forward progress. *)
+
+module Workspace = Masc.Workspace
+module Json = Yojson.Safe.Util
+module Keeper_registry = Masc.Keeper_registry
+module Keeper_sandbox = Masc.Keeper_sandbox
+module Keeper_tool_filesystem_runtime = Masc.Keeper_tool_filesystem_runtime
+module Keeper_tool_descriptor = Masc.Keeper_tool_descriptor
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper-read-window-" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+;;
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/"
+  then ()
+  else if Sys.file_exists path
+  then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+;;
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("agent-" ^ name)
+      ; "trace_id", `String ("trace-" ^ name)
+      ; ( "sandbox_profile"
+        , `String
+            (Keeper_types_profile_sandbox.sandbox_profile_to_string
+               Keeper_types_profile_sandbox.Local) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+;;
+
+let with_eio_fs f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  f ~fs ~sw ()
+;;
+
+let allow_repo ~config ~(meta : Masc.Keeper_meta_contract.keeper_meta) repo_id =
+  let repo_path =
+    Filename.concat
+      (Keeper_sandbox.host_root_abs_of_meta ~config meta)
+      (Filename.concat "repos" repo_id)
+  in
+  let repo : Repo_manager_types.repository =
+    { id = repo_id
+    ; name = repo_id
+    ; url = Printf.sprintf "https://example.invalid/%s.git" repo_id
+    ; local_path = repo_path
+    ; aliases = []
+    ; default_branch = "main"
+    ; keepers = []
+    ; status = Repo_manager_types.Active
+    ; auto_sync = false
+    ; sync_interval = 0
+    ; created_at = Int64.zero
+    ; updated_at = Int64.zero
+    }
+  in
+  (match Repo_store.save_all ~base_path:config.Workspace.base_path [ repo ] with
+   | Ok () -> ()
+   | Error e -> Alcotest.fail ("failed to seed repository catalog: " ^ e));
+  let mapping : Repo_manager_types.keeper_repo_mapping =
+    Repo_manager_types.make_keeper_repo_mapping
+      ~keeper_id:meta.name
+      ~repository_ids:[ repo_id ]
+  in
+  match
+    Keeper_repo_mapping.save_mapping ~base_path:config.Workspace.base_path mapping
+  with
+  | Ok () -> ()
+  | Error e -> Alcotest.fail ("failed to seed keeper repo mapping: " ^ e)
+;;
+
+let setup f =
+  with_eio_fs
+  @@ fun ~fs ~sw () ->
+  let base = temp_dir () in
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       Keeper_registry.For_testing.clear ();
+       let config = Workspace.default_config base in
+       let meta = make_meta "reader" in
+       let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+       ensure_dir playground;
+       ignore (Keeper_registry.For_testing.register ~base_path:base meta.name meta);
+       allow_repo ~config ~meta "masc";
+       Masc_test_deps.with_publication_recovery_registry
+         ~sw
+         ~fs
+         ~registry_root:(Workspace.masc_root_dir config)
+       @@ fun _registry -> f ~config ~meta ~playground)
+;;
+
+let parse raw = Yojson.Safe.from_string raw
+
+let parse_ok raw =
+  parse raw |> Json.member "ok" |> Json.to_bool_option |> Option.value ~default:false
+;;
+
+let parse_string key raw = parse raw |> Json.member key |> Json.to_string_option
+let parse_int key raw = parse raw |> Json.member key |> Json.to_int_option
+
+let parse_bool key raw =
+  parse raw |> Json.member key |> Json.to_bool_option |> Option.value ~default:false
+;;
+
+let numbered_lines n =
+  let buffer = Buffer.create (n * 9) in
+  for i = 1 to n do
+    Buffer.add_string buffer (Printf.sprintf "line-%03d\n" i)
+  done;
+  Buffer.contents buffer
+;;
+
+let read ~config ~meta args =
+  Keeper_tool_filesystem_runtime.handle_read_file
+    ~turn_sandbox_factory:None
+    ~config
+    ~meta
+    ~args
+;;
+
+(* The live regression, end to end through the descriptor wire contract: a
+   model sends Read {file_path, limit:200} meaning 200 lines. Before the fix
+   the translation produced max_bytes=200 -> clamp 512 bytes. *)
+let test_wire_limit_means_lines () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 300);
+  let translated =
+    Keeper_tool_descriptor.translate_input
+      ~public:"Read"
+      (`Assoc
+          [ "file_path", `String "repos/masc/sample.ml"; "limit", `Int 200 ])
+  in
+  let raw = read ~config ~meta translated in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option int)) "returned_lines" (Some 200) (parse_int "returned_lines" raw);
+  Alcotest.(check (option int)) "next_offset" (Some 201) (parse_int "next_offset" raw);
+  Alcotest.(check bool) "truncated" true (parse_bool "truncated" raw);
+  let content = parse_string "content" raw |> Option.value ~default:"" in
+  Alcotest.(check int) "content bytes exceed the old 512-byte clamp" 1800 (String.length content);
+  Alcotest.(check bool)
+    "starts at line 1"
+    true
+    (String.length content >= 9 && String.sub content 0 9 = "line-001\n")
+;;
+
+let test_offset_window_mid_file () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 300);
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc
+          [ "path", `String "repos/masc/sample.ml"
+          ; "offset", `Int 100
+          ; "limit", `Int 5
+          ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option string))
+    "window content"
+    (Some "line-100\nline-101\nline-102\nline-103\nline-104\n")
+    (parse_string "content" raw);
+  Alcotest.(check (option int)) "next_offset" (Some 105) (parse_int "next_offset" raw)
+;;
+
+let test_tail_window_reaches_eof () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 300);
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc [ "path", `String "repos/masc/sample.ml"; "offset", `Int 201 ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option int)) "returned_lines" (Some 100) (parse_int "returned_lines" raw);
+  Alcotest.(check bool) "not truncated at EOF" false (parse_bool "truncated" raw);
+  Alcotest.(check (option int)) "no next_offset at EOF" None (parse_int "next_offset" raw)
+;;
+
+let test_byte_budget_cuts_at_line_boundary () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 300);
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc [ "path", `String "repos/masc/sample.ml"; "max_bytes", `Int 512 ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  let content = parse_string "content" raw |> Option.value ~default:"" in
+  (* 9-byte lines: 56 lines = 504 bytes fit inside 512. *)
+  Alcotest.(check int) "content is whole lines within budget" 504 (String.length content);
+  Alcotest.(check bool)
+    "ends on a line boundary"
+    true
+    (content <> "" && content.[String.length content - 1] = '\n');
+  Alcotest.(check (option int)) "returned_lines" (Some 56) (parse_int "returned_lines" raw);
+  Alcotest.(check (option int)) "next_offset" (Some 57) (parse_int "next_offset" raw);
+  Alcotest.(check bool) "truncated" true (parse_bool "truncated" raw);
+  Alcotest.(check bool) "no partial line" false (parse_bool "last_line_partial" raw)
+;;
+
+let test_single_long_line_stays_partial_but_advances () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file
+    (Filename.concat playground "repos/masc/wide.txt")
+    (String.make 2000 'x' ^ "\nline-2\n");
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc [ "path", `String "repos/masc/wide.txt"; "max_bytes", `Int 512 ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option int)) "bytes capped" (Some 512) (parse_int "bytes" raw);
+  Alcotest.(check bool) "partial line flagged" true (parse_bool "last_line_partial" raw);
+  Alcotest.(check (option int))
+    "next_offset advances past the partial line"
+    (Some 2)
+    (parse_int "next_offset" raw)
+;;
+
+let test_zero_limit_is_rejected () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 10);
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc [ "path", `String "repos/masc/sample.ml"; "limit", `Int 0 ])
+  in
+  if parse_ok raw then Alcotest.failf "expected Read failure, got ok: %s" raw;
+  let message = parse_string "error" raw |> Option.value ~default:"" in
+  Alcotest.(check bool)
+    "error names the limit contract"
+    true
+    (Astring.String.is_infix ~affix:"limit" message)
+;;
+
+let test_offset_past_eof_returns_empty () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 10);
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc [ "path", `String "repos/masc/sample.ml"; "offset", `Int 1000 ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option string)) "empty content" (Some "") (parse_string "content" raw);
+  Alcotest.(check (option int)) "returned_lines" (Some 0) (parse_int "returned_lines" raw);
+  Alcotest.(check bool) "not truncated" false (parse_bool "truncated" raw);
+  Alcotest.(check (option int)) "no next_offset" None (parse_int "next_offset" raw)
+;;
+
+let test_legacy_max_bytes_args_unchanged () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  write_file (Filename.concat playground "repos/masc/sample.ml") (numbered_lines 10);
+  let raw =
+    read
+      ~config
+      ~meta
+      (`Assoc [ "path", `String "repos/masc/sample.ml"; "max_bytes", `Int 4096 ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option string))
+    "whole file"
+    (Some (numbered_lines 10))
+    (parse_string "content" raw);
+  Alcotest.(check bool) "not truncated" false (parse_bool "truncated" raw);
+  Alcotest.(check (option int)) "returned_lines" (Some 10) (parse_int "returned_lines" raw)
+;;
+
+let () =
+  Alcotest.run
+    "keeper_tool_read_window"
+    [ ( "read-line-window"
+      , [ Alcotest.test_case "wire limit means lines" `Quick test_wire_limit_means_lines
+        ; Alcotest.test_case "offset window mid file" `Quick test_offset_window_mid_file
+        ; Alcotest.test_case "tail window reaches EOF" `Quick test_tail_window_reaches_eof
+        ; Alcotest.test_case
+            "byte budget cuts at line boundary"
+            `Quick
+            test_byte_budget_cuts_at_line_boundary
+        ; Alcotest.test_case
+            "single long line stays partial but advances"
+            `Quick
+            test_single_long_line_stays_partial_but_advances
+        ; Alcotest.test_case "zero limit is rejected" `Quick test_zero_limit_is_rejected
+        ; Alcotest.test_case
+            "offset past EOF returns empty"
+            `Quick
+            test_offset_past_eof_returns_empty
+        ; Alcotest.test_case
+            "legacy max_bytes args unchanged"
+            `Quick
+            test_legacy_max_bytes_args_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇이 고장이었나 (라이브 실측, 2026-07-21)

오너가 executor 채팅에 "실제 코드 보고 확인해"를 보내자, 한 keeper 턴 안에서 deepseek가 **동일한 Read 2건을 8–9초 간격으로 100회 이상 반복**했다 (raw trace `turn-1784627661201-6bc3-000031.jsonl`: 1,544 레코드, tool 실행 201회, assistant 블록 301개, `run_finished` 없음). 그 결과:

- 턴이 끝나지 않아 keeper turn 레코드가 09:50 이후 중단 (tool_exec 스팸만 지속)
- event queue가 `requeue, reason=cycle_busy`로 기아 — 대시보드의 `manual_compaction_requested` 블록이 몇 시간째 pending인 이유 (dashboard "requested" vs runtime meta "not_requested"는 둘 다 진실)
- 채팅 메시지가 완결 턴에 연결되지 못함 (turnRef provenance는 턴 종료 시 생성)

## 근본 원인

`agent.read_file` descriptor가 `limit`을 `max_bytes`로 1:1 번역했다 (`keeper_tool_descriptor.ml` `translate_read_file`). 도구 이름(`Read`)과 시그니처(`file_path`, `limit`)는 업계 표준 Read 도구의 형태를 그대로 빌렸는데, 그 계보에서 `limit`은 **줄 수**다. 모델이 `limit: 200`(200줄 의도)을 보내면:

```
max_bytes = max(512, min(200000, 200)) = 512 바이트
```

512바이트 + `truncated: true`만 돌아오고 이어읽을 수단(`offset`)은 "지원 안 함"이 계약이었다. "코드를 확인하라"는 지시를 **수행할 수 없는** 도구 표면 + 진전 불가 상태에서 같은 입력이 같은 출력을 낳는 결정론이 앵무새 루프의 정체다. (턴 자체에 상한이 없는 것은 OAS 쪽 별도 결함 — 아래 후속 참조.)

실사용 검증: 루프 내 distinct tool 입력은 7개뿐, 최다 반복 70회, 전부 `limit: 200`/`limit: 300` (줄 수 의도).

## 수정

계약을 이름이 약속하는 의미로 정렬:

| 파라미터 | 이전 | 이후 |
|---|---|---|
| `limit` | 바이트로 오번역 (min 512 클램프) | **줄 수** (offset부터 최대 N줄) |
| `offset` | 미지원 ("Line offsets are not supported") | **1-based 시작 줄** |
| `max_bytes` | limit이 덮어씀 | 응답 바이트 예산으로 유지 (기본 20,000, 512–200,000) |

응답 페이로드에 진전을 표현하는 필드 추가: `offset`, `returned_lines`, **`next_offset`**(남은 내용이 있을 때만), `last_line_partial`(단일 줄이 바이트 예산을 넘어 잘린 경우 — next_offset은 그 줄을 넘겨 전진). 바이트 예산 절단은 줄 경계에서 수행.

- 범위 위반(`limit<=0`, `offset<1`)은 조용한 기본값 대신 계약을 설명하는 실패로 반환 (Unknown → Permissive Default 안티패턴 회피)
- sandbox 경로: 줄 윈도우가 응답 예산 밖 줄을 요구하면 스캔 상한(200,000B)까지 fetch, 스캔 지평 밖 offset은 typed 실패로 안내
- legacy `path`/`max_bytes` 호출은 동작 불변 (기존 테스트 green)

## 검증

- 신규 `test/test_keeper_tool_read_window.ml` 8케이스 green — 핵심 회귀 케이스는 **descriptor wire 계약 끝단부터**(`translate_input ~public:"Read"` 경유) `limit:200` → 200줄/`next_offset:201` 확인. 그 외: 중간 윈도우, EOF, 줄 경계 절단, 초장문 줄 partial+전진, `limit:0` 거부, EOF 밖 offset, legacy 인자.
- `test_keeper_tool_descriptor_registry_integrity` 41/41 green — 구 결함을 잠그고 있던 drift-guard("limit translates to max_bytes")를 새 계약("limit passes through as a line cap", "no max_bytes is synthesized")으로 반전.
- `dune build @check` PASS. `test_keeper_tool_matrix`는 main 베이스라인과 동일한 환경 의존 실패(115/120)로 본 변경과 무관.

검증 한계: docker sandbox 경로의 fetch 예산 분기(`read_window_fetch_bytes`)는 컴파일 + 코드 리뷰만 수행 (로컬 도커 read 하네스 부재). 줄 슬라이스 로직 자체는 host 경로와 공유되어 위 테스트가 커버한다.

## 후속 (이 PR 범위 밖)

- **OAS run 루프 턴 상한 부재**: 진전 없는 도구 반복이 무한히 허용됨 (`agent.ml` `run_loop_turns_detailed` 무조건 재귀). typed turn budget은 OAS 쪽 이슈로 분리.
- sangsu overflow→compaction livelock: #25532.
- executor는 배포 전까지 down 유지 권장 — durable chat replay가 같은 채팅을 재전달해 구 바이너리에서 루프 재진입.

RFC-WAIVED: 게이트 대상 subsystem(credential/repo_manager/operator/hooks/workflow) 미접촉 — keeper tool 표면의 단위 오번역 버그 수정이며 신규 메커니즘 도입 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
