### PR TITLE
fix(keeper): budget-source provenance on status + librarian-declared claim lifetimes (RFC-0351 follow-ups)

### DIFF
--- a/config/prompts/keeper.librarian.episode_extraction.md
+++ b/config/prompts/keeper.librarian.episode_extraction.md
@@ -31,6 +31,7 @@ Additional rules:
 5. open_items and constraints are episode-level summary arrays, separate from a claim's category. A claim already categorized as constraint does not need to be repeated in the constraints array.
 6. claim_id (optional): a short lowercase kebab-case slug identifying the CONCLUSION, not the wording — derive it deterministically from the subject and the asserted state (e.g. "pr-21249-verification-complete", "pr-123-open", "pr-123-merged"). Re-stating the same conclusion later MUST reuse the same slug; a changed conclusion (e.g. open -> merged) MUST use a new slug. Omit it if you cannot form a stable slug.
 7. claim_kind (optional): tag the claim's epistemic nature, orthogonal to category. Use "self_observation" for transient first-person agent state — you are idle, looping, blocked, or a tool is timing out (true now, false next turn). Use "external_state" for a claim about the world/PR/issue that is verifiable elsewhere. Use "durable_knowledge" for a timeless rule or lesson. A "lesson" category can still be a self_observation. Omit it when unclear — an omitted tag is treated as durable. Do NOT tag transient self-state as durable knowledge; that is the echo this field exists to stop.
+8. valid_for_days (optional integer, 1-365): YOUR judgment of how many days this claim stays worth re-reading — after that the store forgets it. A claim you labeled "ephemeral" or tagged "self_observation" MUST carry a small value (1-3: it is true today, not next week). Short-lived external_state (an open PR, a pending deploy) usually deserves 7-30. Omit it ONLY for genuinely durable knowledge — an omitted lifetime means the store keeps the claim forever, so leaving it off a transient claim immortalizes noise.
 
 Output schema:
 {
@@ -42,7 +43,8 @@ Output schema:
       "source_turn": 12,
       "source_tool_call_id": "call_abc",
       "claim_id": "pr-123-open",
-      "claim_kind": "self_observation|external_state|durable_knowledge"
+      "claim_kind": "self_observation|external_state|durable_knowledge",
+      "valid_for_days": 7
     }
   ],
   "open_items": ["Tasks or questions left unresolved."],

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -100,6 +100,13 @@ type max_context_resolution = {
   requested_override : int option;
   primary_budget : int;
   runtime_budget : int;
+  (* Where [runtime_budget] came from: the OAS capability catalog, a
+     runtime.toml override, or that override clamped by the capability.
+     [None] only on the legacy ordered-label path when no label resolved and
+     the precomputed default budget filled in. Dropping this rendered a
+     runtime.toml override as "runtime_provider_cap" in keeper status JSON,
+     disguising the #25463 config drift as a provider fact. *)
+  runtime_budget_source : Runtime.max_context_source option;
   requested_context_window : int;
   effective_budget : int;
 }
@@ -144,10 +151,22 @@ let context_budget_json_of_resolution
     |> context_budget_source_of_resolution
     |> context_budget_source_to_string
   in
+  (* [budget_source] states which side won (runtime budget vs keeper-meta
+     requested override); [runtime_budget_source] states where the runtime
+     budget itself came from. Without the second field a runtime.toml
+     override rendered as budget_source=runtime_provider_cap under the JSON
+     key provider_context_window, which disguised the #25463 262144 config
+     drift as a provider fact for weeks. *)
+  let runtime_budget_source =
+    match resolution.runtime_budget_source with
+    | Some source -> Runtime.max_context_source_to_string source
+    | None -> "default_fallback"
+  in
   `Assoc
     [ ("runtime_id", `String runtime_id)
     ; ("provider_context_window", `Int resolution.primary_budget)
     ; ("budget_source", `String context_budget_source)
+    ; ("runtime_budget_source", `String runtime_budget_source)
     ; ("requested_override", Json_util.int_opt_to_json resolution.requested_override)
     ; ("primary_budget", `Int resolution.primary_budget)
     ; ("runtime_budget", `Int resolution.runtime_budget)
@@ -316,16 +335,19 @@ let effective_model_labels_for_turn (m : keeper_meta) : string list =
 let resolve_max_context_resolution ~requested_override (labels : string list)
     : max_context_resolution =
   let default_budget = Runtime.default_max_context () in
-  let runtime_budget =
-    labels
-    |> List.find_map (fun label ->
-           String.trim label
-           |> Runtime.max_context_of_runtime_id)
+  let runtime_budget, runtime_budget_source =
+    match
+      labels
+      |> List.find_map (fun label ->
+             String.trim label
+             |> Runtime.resolve_max_context_of_runtime_id)
+    with
+    | Some (budget, source) -> budget, Some source
     (* Labels are an ordered runtime-budget preference list. If none resolve,
        the precomputed default runtime budget preserves config-less tests.
        DET-OK: dispatch still fail-fast validates the selected runtime id before
        provider execution. *)
-    |> Option.value ~default:default_budget
+    | None -> default_budget, None
   in
   (* RFC-0207: budget against the same per-keeper runtime id that dispatch uses. *)
   let primary_budget = runtime_budget in
@@ -338,6 +360,7 @@ let resolve_max_context_resolution ~requested_override (labels : string list)
   { requested_override
   ; primary_budget
   ; runtime_budget
+  ; runtime_budget_source
   ; requested_context_window
   ; effective_budget
   }
@@ -353,7 +376,7 @@ let resolve_max_context_resolution_for_runtime
     (match Runtime.resolve_max_context_of_runtime runtime with
      | None ->
        Error (Runtime_context_window_unavailable { runtime_id = runtime.id })
-     | Some (runtime_budget, _) ->
+     | Some (runtime_budget, runtime_budget_source) ->
        let requested_context_window =
          match requested_override with
          | None -> runtime_budget
@@ -364,6 +387,7 @@ let resolve_max_context_resolution_for_runtime
          { requested_override
          ; primary_budget = runtime_budget
          ; runtime_budget
+         ; runtime_budget_source = Some runtime_budget_source
          ; requested_context_window
          ; effective_budget
          })

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -83,6 +83,10 @@ type max_context_resolution =
   { requested_override : int option
   ; primary_budget : int
   ; runtime_budget : int
+  ; runtime_budget_source : Runtime.max_context_source option
+    (** Where [runtime_budget] came from (capability catalog, runtime.toml
+        override, or override clamped by capability). [None] only when the
+        legacy ordered-label path fell back to the precomputed default. *)
   ; requested_context_window : int
   ; effective_budget : int
   }

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -21,6 +21,7 @@ let wire_field_source_turn = Keeper_memory_os_types.wire_field_source_turn
 let wire_field_source_tool_call_id = Keeper_memory_os_types.wire_field_source_tool_call_id
 let wire_field_claim_id = Keeper_memory_os_types.wire_field_claim_id
 let wire_field_claim_kind = Keeper_memory_os_types.wire_field_claim_kind
+let wire_field_valid_for_days = Keeper_memory_os_types.wire_field_valid_for_days
 let wire_field_schema_version = Keeper_memory_os_types.wire_field_schema_version
 let wire_episode_fields = Keeper_memory_os_types.wire_librarian_episode_fields
 let wire_claim_fields = Keeper_memory_os_types.wire_librarian_claim_fields
@@ -215,6 +216,21 @@ let claim_id_field fields =
   | value -> value
 ;;
 
+(* Producer-declared lifetime in whole days, same contract as the explicit
+   keeper_memory_write surface (RFC-0351 S2). Absent/null = durable. A
+   present value outside [1, max_valid_for_days] or of the wrong JSON type
+   rejects the claim (strict, like every other field here): a malformed
+   lifetime silently stored as "forever" is exactly the ephemeral-immortality
+   drift this field closes. *)
+let valid_for_days_field fields =
+  match List.assoc_opt wire_field_valid_for_days fields with
+  | None | Some `Null -> Some None
+  | Some (`Int days)
+    when days >= 1 && days <= Keeper_memory_os_types.max_valid_for_days ->
+    Some (Some days)
+  | Some _ -> None
+;;
+
 let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
   match json with
   | `Assoc fields ->
@@ -225,13 +241,15 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
        , claim_kind_field fields
        , claim_id_field fields
        , optional_string_field_strict wire_field_source_tool_call_id fields
+       , valid_for_days_field fields
      with
      | ( Some claim
        , Some category_str
        , Some turn
        , Some claim_kind
        , Some claim_id
-       , Some tool_call_id )
+       , Some tool_call_id
+       , Some valid_for_days )
        when turn >= 0 ->
       (* Parse the provider's category once at the producer boundary. It remains
          context and never creates a validity horizon. *)
@@ -245,15 +263,23 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
             the consolidator populates observed_by only on promotion (RFC-0244). *)
          ; observed_by = []
          ; first_seen = now
-         ; valid_until = None
+         ; valid_until =
+             (* RFC-0351 S2: the extracting model's own lifetime judgment for
+                the claim; absent = durable. Closes the librarian half of the
+                "ephemeral is kept briefly and forgotten" prompt promise —
+                the read side (fact_is_current + expiry GC) has been waiting
+                on a producer since #25519. *)
+             Option.map
+               (Keeper_memory_os_types.valid_until_of_days ~now)
+               valid_for_days
          ; last_verified_at = None (* RFC-0285 §3.3 / RFC-0259 P7: re-extraction must not advance last_verified_at *)
          ; schema_version
          ; claim_id
          }
-     | (Some _, Some _, Some _, _, _, _)
-     | (Some _, Some _, None, _, _, _)
-     | (Some _, None, _, _, _, _)
-     | (None, _, _, _, _, _) -> None)
+     | (Some _, Some _, Some _, _, _, _, _)
+     | (Some _, Some _, None, _, _, _, _)
+     | (Some _, None, _, _, _, _, _)
+     | (None, _, _, _, _, _, _) -> None)
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
 ;;
 

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -24,6 +24,12 @@ val wire_field_source_tool_call_id : string
 val wire_field_claim_id : string
 val wire_field_claim_kind : string
 
+val wire_field_valid_for_days : string
+(** Producer-declared lifetime in whole days (1..
+    {!Keeper_memory_os_types.max_valid_for_days}); absent = durable. The
+    extracting model's own judgment — categories never infer a validity
+    horizon (RFC-0351 S2). *)
+
 val wire_episode_fields : string list
 (** Canonical episode-object wire field names accepted by the parser and used by
     retry prompt rendering. *)

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -52,6 +52,8 @@ let wire_librarian_episode_fields =
   ]
 ;;
 
+let wire_field_valid_for_days = "valid_for_days"
+
 let wire_librarian_claim_fields =
   [ wire_field_claim
   ; wire_field_category
@@ -59,6 +61,7 @@ let wire_librarian_claim_fields =
   ; wire_field_source_tool_call_id
   ; wire_field_claim_id
   ; wire_field_claim_kind
+  ; wire_field_valid_for_days
   ]
 ;;
 
@@ -211,6 +214,16 @@ let fact_is_current ~now (fact : fact) =
   | None -> true
   | Some ts -> ts >= now
 ;;
+
+let seconds_per_day = 86_400.
+let max_valid_for_days = 365
+
+(* RFC-0351 S2: a producer-declared lifetime in whole days becomes the exact
+   [valid_until] boundary that [fact_is_current] and expiry GC already honor.
+   The number is the producer's own claim about the claim's scope — judged by
+   the model that wrote it, never inferred from the text by a fixed
+   write-side TTL (#24332 removed exactly those). *)
+let valid_until_of_days ~now days = now +. (float_of_int days *. seconds_per_day)
 
 (* Split facts only on the exact stored [valid_until] boundary. No category,
    claim-kind, or timestamp-derived fallback participates. *)

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -27,6 +27,10 @@ val wire_field_last_verified_at : string
 val wire_field_observed_by : string
 val wire_field_claim_id : string
 val wire_field_claim_kind : string
+
+val wire_field_valid_for_days : string
+(** Producer-declared lifetime in whole days on the librarian claim wire —
+    same vocabulary as the explicit keeper_memory_write argument. *)
 val wire_field_schema_version : string
 val wire_field_generation : string
 val wire_field_episode_summary : string
@@ -145,6 +149,18 @@ val fact_effective_valid_until : fact -> float option
 (** Whether a fact's hard-expiry horizon still admits it at [now]. Facts with no
     effective [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
+
+val seconds_per_day : float
+
+val max_valid_for_days : int
+(** Upper bound on a producer-declared lifetime in whole days (365). Shared by
+    every [valid_for_days] producer surface. *)
+
+val valid_until_of_days : now:float -> int -> float
+(** [valid_until_of_days ~now days] is the exact expiry boundary that
+    {!fact_is_current} and expiry GC honor for a producer-declared lifetime of
+    [days] whole days. The lifetime is the writing model's own judgment about
+    the claim's scope — no fixed write-side TTL infers it from text. *)
 
 (** Partition facts into [(live, expired)] at [now] using only the exact stored
     [valid_until]. Facts with [None] are always in [live]. *)

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -54,6 +54,7 @@ let librarian_claim_schema =
     ; Keeper_librarian.wire_field_source_tool_call_id, nullable_string_schema
     ; Keeper_librarian.wire_field_claim_id, nullable_string_schema
     ; Keeper_librarian.wire_field_claim_kind, nullable_enum_schema librarian_claim_kind_tokens
+    ; Keeper_librarian.wire_field_valid_for_days, nullable_integer_schema
     ]
   in
   object_schema ~required:(List.map fst fields) fields

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -566,14 +566,15 @@ let keeper_context_status_json
 (* --- Explicit memory write (RFC-0035 P4 surface) ----------------- *)
 
 let keeper_memory_write_max_title_chars = 120
-let seconds_per_day = 86_400.
 
 (* An explicit lifetime is a claim about scope, so it has to be a real
    boundary: a claim that expires today or a decade out is a producer mistake,
    not a lifetime. Rejecting both ends keeps [valid_until] meaningful rather
-   than becoming a second way to say "forever". *)
+   than becoming a second way to say "forever". Bound and day arithmetic are
+   the shared producer SSOT in [Keeper_memory_os_types] (the librarian
+   extraction path declares lifetimes through the same contract). *)
 let keeper_memory_write_min_valid_days = 1
-let keeper_memory_write_max_valid_days = 365
+let keeper_memory_write_max_valid_days = Keeper_memory_os_types.max_valid_for_days
 
 (* [Safe_ops.json_int] cannot tell "absent" from "0", and 0 days is exactly
    the mistake this field must reject, so the member is read raw. A wrong JSON
@@ -769,7 +770,7 @@ let append_durable_fact
            747 of 747 across the live fleet. This is the first writer. The
            lifetime is the producer's own claim about scope, not a rule
            inferred from the text. *)
-        Option.map (fun days -> now +. (float_of_int days *. seconds_per_day)) valid_for_days
+        Option.map (Keeper_memory_os_types.valid_until_of_days ~now) valid_for_days
     ; last_verified_at = None
     ; schema_version = Keeper_memory_os_types.schema_version
     ; claim_id = None

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1301,6 +1301,14 @@ let resolve_assignment (assigned_id : string) =
      | None -> `Missing)
 ;;
 
+let resolve_max_context_of_runtime_id (id : string)
+  : (int * max_context_source) option
+  =
+  match get_runtime_by_id id with
+  | Some rt -> resolve_max_context_of_runtime rt
+  | None -> None
+;;
+
 let max_context_of_runtime_id (id : string) : int option =
   match get_runtime_by_id id with
   | Some rt -> Some (max_context_of_runtime rt)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -287,6 +287,14 @@ val max_context_of_runtime : t -> int
     context cannot be resolved at load time (no silent default —
     RFC-0206 §2.1). *)
 
+val resolve_max_context_of_runtime_id : string -> (int * max_context_source) option
+(** {!resolve_max_context_of_runtime} looked up by runtime id: the effective
+    input context window together with the source that produced it, or [None]
+    when the id is not configured. Budget surfaces must carry the source —
+    dropping it rendered a runtime.toml override as ["runtime_provider_cap"]
+    in keeper status JSON, which disguised the #25463 config drift as a
+    provider fact. *)
+
 val max_context_of_runtime_id : string -> int option
 (** Effective input context window for the materialized runtime [id], or [None]
     when the id is not configured.  Budgeting callers use this to size a

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -676,6 +676,117 @@ let test_librarian_does_not_infer_validity () =
   | None -> Alcotest.fail "expected librarian output to parse"
 ;;
 
+(* RFC-0351 S2: the extracting model may declare a lifetime per claim; the
+   parser stamps the exact valid_until boundary the recall filter and expiry
+   GC already honor. Declaration only — categories still never infer one
+   (locked by test_librarian_does_not_infer_validity above). *)
+let test_librarian_stamps_declared_lifetime () =
+  let now = 1_000_000.0 in
+  let output =
+    `Assoc
+      [ "episode_summary", `String "declared lifetime claims"
+      ; ( "claims"
+        , `List
+            [ `Assoc
+                [ "claim", `String "the agent is blocked on a sandbox limit today"
+                ; "category", `String "ephemeral"
+                ; "claim_kind", `String "self_observation"
+                ; "source_turn", `Int 0
+                ; "valid_for_days", `Int 2
+                ]
+            ; `Assoc
+                [ "claim", `String "parse boundaries own validation"
+                ; "category", `String "lesson"
+                ; "source_turn", `Int 1
+                ]
+            ] )
+      ; "open_items", `List []
+      ; "constraints", `List []
+      ; "preserved_tool_refs", `List []
+      ]
+    |> Yojson.Safe.to_string
+  in
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-declared-lifetime"
+    ; generation = 0
+    ; messages = [ text_message "x" ]
+    }
+  in
+  match Librarian.episode_of_output ~now ~generation:inp.generation inp output with
+  | Some episode ->
+    let find cat = List.find (fun f -> f.Types.category = cat) episode.Types.claims in
+    let declared = find Types.Ephemeral in
+    let durable = find Types.Lesson in
+    Alcotest.(check (option (float 0.001)))
+      "declared lifetime becomes the exact expiry boundary"
+      (Some (now +. (2. *. 86_400.)))
+      declared.Types.valid_until;
+    Alcotest.(check (option (float 0.001)))
+      "undeclared lifetime stays durable"
+      None
+      durable.Types.valid_until;
+    Alcotest.(check bool)
+      "declared-lifetime claim is current before its boundary"
+      true
+      (Types.fact_is_current ~now:(now +. 86_400.) declared);
+    Alcotest.(check bool)
+      "declared-lifetime claim expires after its boundary"
+      false
+      (Types.fact_is_current ~now:(now +. (3. *. 86_400.)) declared)
+  | None -> Alcotest.fail "expected librarian output to parse"
+;;
+
+let test_librarian_rejects_invalid_lifetime () =
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-invalid-lifetime"
+    ; generation = 0
+    ; messages = [ text_message "x" ]
+    }
+  in
+  List.iter
+    (fun (label, value) ->
+       let raw =
+         `Assoc
+           [ "episode_summary", `String "summary"
+           ; ( "claims"
+             , `List
+                 [ `Assoc
+                     [ "claim", `String "claim with a malformed lifetime"
+                     ; "category", `String "ephemeral"
+                     ; "source_turn", `Int 0
+                     ; "valid_for_days", value
+                     ]
+                 ] )
+           ; "open_items", `List []
+           ; "constraints", `List []
+           ; "preserved_tool_refs", `List []
+           ]
+         |> Yojson.Safe.to_string
+       in
+       match
+         Librarian.episode_of_output_result
+           ~now:1_000_000.0
+           ~generation:inp.generation
+           inp
+           raw
+       with
+       | Error Librarian.Claim_schema_mismatch -> ()
+       | Error error ->
+         Alcotest.failf
+           "%s: expected Claim_schema_mismatch, got %s"
+           label
+           (Librarian.parse_error_to_string error)
+       | Ok _ ->
+         Alcotest.failf
+           "%s: a malformed lifetime must not be stored as forever"
+           label)
+    [ "zero days", `Int 0
+    ; "negative days", `Int (-3)
+    ; "beyond the shared bound", `Int 999
+    ; "wrong JSON type", `String "7"
+    ]
+;;
+
 let test_librarian_accepts_wrapped_json_output () =
   let inp : Librarian.input =
     { Librarian.trace_id = "trace-wrapped-json"
@@ -4829,6 +4940,14 @@ let () =
             "librarian does not infer validity"
             `Quick
             test_librarian_does_not_infer_validity
+        ; Alcotest.test_case
+            "librarian stamps a declared lifetime"
+            `Quick
+            test_librarian_stamps_declared_lifetime
+        ; Alcotest.test_case
+            "librarian rejects a malformed lifetime"
+            `Quick
+            test_librarian_rejects_invalid_lifetime
         ; Alcotest.test_case
             "librarian accepts wrapped json output"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -843,6 +843,7 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
       { requested_override = None
       ; primary_budget = 4096
       ; runtime_budget = 4096
+      ; runtime_budget_source = Some Runtime.Capability
       ; requested_context_window = 4096
       ; effective_budget = 4096
       }

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1007,6 +1007,48 @@ let test_context_budget_source_is_shared_ssot () =
       (source (Some 1_000_000)))
 ;;
 
+(* The runtime budget's own provenance must survive to the status surface.
+   Collapsing it rendered a runtime.toml [model.max-context] override as
+   budget_source=runtime_provider_cap under the provider_context_window JSON
+   key, which disguised the #25463 live config drift (deepseek-v4-flash
+   262144 vs catalog 1048576) as a provider fact. The fixture's [openai.gpt]
+   declares max-context in runtime.toml, so its budget is an override. *)
+let test_runtime_budget_source_survives_to_status_json () =
+  with_runtime_initialized (fun () ->
+    match
+      Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+        ~requested_override:None
+        ~runtime_id:"openai.gpt"
+    with
+    | Error error ->
+      Alcotest.failf
+        "openai.gpt must resolve: %s"
+        (Keeper_context_runtime.max_context_resolution_error_to_string error)
+    | Ok resolution ->
+      (match resolution.Keeper_context_runtime.runtime_budget_source with
+       | Some Runtime.Override -> ()
+       | Some other ->
+         Alcotest.failf
+           "expected the runtime.toml override source, got %s"
+           (Runtime.max_context_source_to_string other)
+       | None -> Alcotest.fail "runtime budget source dropped on the strict path");
+      let json =
+        Keeper_context_runtime.context_budget_json_of_resolution
+          ~runtime_id:"openai.gpt"
+          resolution
+      in
+      (match json with
+       | `Assoc fields ->
+         (match List.assoc_opt "runtime_budget_source" fields with
+          | Some (`String "override") -> ()
+          | Some other ->
+            Alcotest.failf
+              "runtime_budget_source rendered %s"
+              (Yojson.Safe.to_string other)
+          | None -> Alcotest.fail "runtime_budget_source missing from budget JSON")
+       | _ -> Alcotest.fail "context budget JSON must be an object"))
+;;
+
 (* Remaining projection path: [resolve_max_context_resolution_of_meta] must
    prefer the keeper's routed runtime (openai.gpt = 64000), NOT
    [runtime].default (runpod_mtp.qwen = 128000). Actual turn admission is
@@ -1910,6 +1952,10 @@ let () =
             "context budget source uses shared SSOT"
             `Quick
             test_context_budget_source_is_shared_ssot
+        ; Alcotest.test_case
+            "runtime budget source survives to status JSON"
+            `Quick
+            test_runtime_budget_source_survives_to_status_json
         ; Alcotest.test_case
             "strict context budget rejects unavailable capacity and invalid override"
             `Quick


### PR DESCRIPTION
## 배경

PR #25522 (RFC-0351 라이브 고장 수리)의 후속 2건. 37-agent 적대 감사(wf_19b24c6a-1f8)에서 확정된 결함 중 본 PR과 독립적으로 착륙 가능한 것들입니다.

## 커밋 1 — budget_source 라벨 위장 수리 (#25463 잔여)

`runtime.toml`의 `[model.max-context]` 오버라이드가 keeper status JSON에서 `budget_source=runtime_provider_cap` + JSON 키 `provider_context_window`로 **위장 렌더링**되던 결함. `Runtime.resolve_max_context_of_runtime`이 만든 typed source(Override | Capability | Override_clamped_by_capability)를 두 budget resolver가 전부 버리고 있었음 — 이 위장이 deepseek-v4-flash 262144 드리프트를 몇 주간 provider 사실처럼 보이게 했습니다.

- `Runtime.resolve_max_context_of_runtime_id` 신설 (id-lookup 경로에서 source 보존).
- `max_context_resolution`에 `runtime_budget_source` 필드 추가 (legacy label 경로의 default fallback만 None), budget JSON에 `runtime_budget_source` 키 추가. 기존 키는 불변 — 리더 호환.
- 테스트: fixture의 오버라이드 runtime이 JSON까지 `"override"`로 관통.

## 커밋 2 — librarian 수명 선언 (RFC-0351 S2, #25526)

추출 프롬프트는 "ephemeral로 라벨하면 짧게 보관 후 망각"을 약속하지만 구현이 없었습니다: read side(`fact_is_current` + expiry GC)는 #25519부터 `valid_until`을 존중하는데 librarian은 전 claim에 `None`을 스탬프 — idle self-observation("all N backlog tasks are blocked")이 영구 fact로 축적·매턴 재주입되는 증폭 루프의 재료 (감사 finding l1-[6]).

- librarian claim wire에 optional `valid_for_days`(1–365) 추가 — **추출 모델이 수명을 판단**해 선언, 부재 = durable. 카테고리로부터의 추론은 없음 (#24332가 걷어낸 고정 write-side TTL을 되살리지 않음; 기존 does-not-infer-validity 테스트 불변).
- 존재하되 잘못된 수명(0/음수/365 초과/타입 오류)은 claim 거부 — 잘못된 수명이 "영원히"로 침묵 저장되는 드리프트 차단 (다른 필드와 동일한 strict 계약).
- 일수 산술과 365 상한을 `Keeper_memory_os_types`로 이동 (explicit `keeper_memory_write`와 공유 SSOT).
- 프롬프트: ephemeral/self_observation은 작은 값 필수, durable만 생략.

## 검증

- `dune build @check` green. 신규/개정 테스트: memory_os 114/114, routing 41/41, schema 12/12, librarian_retry 24/24.
- 라이브 검증: 배포 후 librarian이 쓰는 신규 claim에 `valid_until` 스탬프 발생 여부 + 만료 GC 발화를 실측.

## 범위 밖

episode(비-fact) 스토어의 성장/망각은 #25526에 남음 — claim 수명은 그 절반(facts 쪽)을 닫습니다.

Refs #25463, #25526, RFC-0351 S2. Base: #25522 머지 후 그 위로 리베이스됨 (`keeper_structured_output_schema.ml`, `test_keeper_memory_os.ml` 2파일 겹침 — 병합 트리에서 @check 재검증 완료).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
