### PR TITLE
fix(keeper): bound in-lane provider-overflow compaction retries (RFC-0351 S0)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -924,6 +924,14 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ( "last_compaction_decision",
                 Keeper_meta_contract.compaction_decision_json_or_null
                   m.runtime.compaction_rt.last_decision );
+              ( "compaction_consecutive_failures",
+                `Int m.runtime.compaction_rt.consecutive_failures );
+              (* RFC-0351 S0 / #25461: operator-visible marker that the
+                 settlement stopped retrying compaction for this keeper. *)
+              ( "compaction_retry_suspended",
+                `Bool
+                  (Keeper_meta_contract.compaction_retry_suspended
+                     m.runtime.compaction_rt) );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -264,33 +264,69 @@ let failure_judgment_successor
   }
 ;;
 
-let settlement_of_failure ~settled_at failure =
+let settlement_of_failure ~settled_at ~compaction_consecutive_failures failure =
+  let follow_route () =
+    match failure.Keeper_unified_turn.route with
+    | Keeper_runtime_failure_route.Retry_after_observed _ ->
+      Keeper_registry_event_queue.Requeue
+        Keeper_registry_event_queue.Retry_after_observed
+    | Keeper_runtime_failure_route.Rotate_now _ ->
+      Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Rotate_now
+    | Keeper_runtime_failure_route.Escalate_judgment
+        { judgment; provenance; detail } ->
+      Keeper_registry_event_queue.Escalate
+        { reason = Keeper_registry_event_queue.Failure_judgment_requested
+        ; successor =
+            Some
+              (failure_judgment_successor
+                 ~arrived_at:settled_at
+                 failure
+                 judgment
+                 provenance
+                 detail)
+        }
+  in
+  (* RFC-0351 S0 / #25461: this failure is the
+     [compaction_consecutive_failures + 1]-th compaction failure in a row when
+     the disposition carries an in-lane compaction outcome; the counter itself
+     is advanced by [compaction_outcome_of_cycle_outcome] on
+     [keeper_meta.runtime.compaction_rt] after the settlement is decided. *)
+  let attempts = compaction_consecutive_failures + 1 in
+  let escalate_exhausted detail =
+    Keeper_registry_event_queue.Escalate
+      { reason =
+          Keeper_registry_event_queue.Compaction_retry_exhausted
+            { attempts; detail }
+      ; successor = None
+      }
+  in
   match failure.Keeper_unified_turn.source_lease_disposition with
   | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
     Keeper_registry_event_queue.Ack
-  | Keeper_unified_turn.Requeue_after_context_compaction ->
+  | Keeper_unified_turn.Requeue_after_context_compaction
+      Keeper_unified_turn.Compaction_committed ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
-  | Keeper_unified_turn.Follow_failure_route ->
-    (match failure.Keeper_unified_turn.route with
-     | Keeper_runtime_failure_route.Retry_after_observed _ ->
-       Keeper_registry_event_queue.Requeue
-         Keeper_registry_event_queue.Retry_after_observed
-     | Keeper_runtime_failure_route.Rotate_now _ ->
-       Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Rotate_now
-     | Keeper_runtime_failure_route.Escalate_judgment
-         { judgment; provenance; detail } ->
-       Keeper_registry_event_queue.Escalate
-         { reason = Keeper_registry_event_queue.Failure_judgment_requested
-         ; successor =
-             Some
-               (failure_judgment_successor
-                  ~arrived_at:settled_at
-                  failure
-                  judgment
-                  provenance
-                  detail)
-         })
+  | Keeper_unified_turn.Requeue_after_context_compaction
+      (Keeper_unified_turn.Compaction_attempt_failed _) ->
+    if attempts >= Keeper_meta_contract.compaction_retry_escalation_threshold
+    then
+      escalate_exhausted
+        "in-lane provider-overflow compaction failed on consecutive attempts; \
+         retry suspended pending operator inspection"
+    else
+      Keeper_registry_event_queue.Requeue
+        Keeper_registry_event_queue.Context_compaction_retry
+  | Keeper_unified_turn.Follow_failure_route_after_no_compaction { reason } ->
+    if attempts >= Keeper_meta_contract.compaction_retry_escalation_threshold
+    then
+      escalate_exhausted
+        (Printf.sprintf
+           "in-lane provider-overflow compaction terminally declined (%s) on \
+            consecutive attempts; retry suspended pending operator inspection"
+           (Keeper_event_queue_state.no_compaction_reason_label reason))
+    else follow_route ()
+  | Keeper_unified_turn.Follow_failure_route -> follow_route ()
 ;;
 
 let single_approved_resolution lease =
@@ -303,13 +339,15 @@ let single_approved_resolution lease =
   | [] | [ _ ] | _ :: _ :: _ -> None
 ;;
 
-(* RFC-0351 S0 / #25461: consecutive manual-compaction failures tolerated before
-   the settlement escalates instead of requeuing. A requeue is not an ack, so
+(* RFC-0351 S0 / #25461: consecutive compaction failures tolerated before the
+   settlement escalates instead of requeuing. A requeue is not an ack, so
    without a ceiling the same stimulus re-enters on every heartbeat cycle —
    measured at 102 failures / 104 compaction LLM calls in 74 minutes after the
-   #25413 build went live. Three attempts keeps a transient CAS/source race
-   recoverable while bounding a structurally-stuck compaction. *)
-let compaction_retry_escalation_threshold = 3
+   #25413 build went live. The constant lives in [Keeper_meta_contract] next to
+   the [consecutive_failures] field it interprets, shared with the
+   status/dashboard projections. *)
+let compaction_retry_escalation_threshold =
+  Keeper_meta_contract.compaction_retry_escalation_threshold
 
 let settlement_of_cycle_outcome
       ~base_path
@@ -374,7 +412,7 @@ let settlement_of_cycle_outcome
   | Some (Cycle.Busy _) ->
     Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Cycle_busy
   | Some (Cycle.Failed { failure; _ }) ->
-    settlement_of_failure ~settled_at failure
+    settlement_of_failure ~settled_at ~compaction_consecutive_failures failure
   | Some (Cycle.Judgment_settled { outcome; _ }) ->
     (match outcome with
      | Cycle.Judgment_boundary_failed { detail } ->
@@ -420,6 +458,40 @@ let settlement_of_cycle_outcome
       Keeper_registry_event_queue.Requeue
         Keeper_registry_event_queue.Turn_not_scheduled
     )
+;;
+
+(* RFC-0351 S0 / #25461: pure mapping from a settled cycle outcome to the
+   compaction-streak stamp on [keeper_meta.runtime.compaction_rt]. The manual
+   lane counts [Manual_compaction_applied]/[Manual_compaction_failed]; the
+   in-lane provider-overflow recovery joins the same streak through the
+   failure's disposition so the settlement can bound its retries too. A
+   terminal in-lane no-compaction counts as a failure — unlike the manual
+   lane, where the terminal reason acks and consumes the compaction stimulus,
+   the in-lane source lease carries a product event that requeues, so the same
+   terminal reason re-fires on every retry. Dispositions with no in-lane
+   compaction involvement leave the streak untouched: a generic turn failure
+   proves nothing about compaction progress in either direction. *)
+let compaction_outcome_of_cycle_outcome = function
+  | Some (Cycle.Manual_compaction_applied _) -> Some `Committed
+  | Some (Cycle.Manual_compaction_failed _) -> Some `Failed
+  | Some (Cycle.Failed { failure; _ }) ->
+    (match failure.Keeper_unified_turn.source_lease_disposition with
+     | Keeper_unified_turn.Requeue_after_context_compaction
+         Keeper_unified_turn.Compaction_committed -> Some `Committed
+     | Keeper_unified_turn.Requeue_after_context_compaction
+         (Keeper_unified_turn.Compaction_attempt_failed _)
+     | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
+       Some `Failed
+     | Keeper_unified_turn.Follow_failure_route
+     | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> None)
+  | Some
+      ( Cycle.Completed _
+      | Cycle.Cancelled _
+      | Cycle.Skipped _
+      | Cycle.Busy _
+      | Cycle.Judgment_settled _
+      | Cycle.Manual_compaction_not_applied _ )
+  | None -> None
 ;;
 
 let project_transition_outbox ~base_path ~keeper_name =
@@ -841,9 +913,10 @@ let run_keepalive_unified_turn
          (match !cycle_outcome_ref with
           | Some (Cycle.Failed { failure; _ }) ->
             (match failure.Keeper_unified_turn.source_lease_disposition with
-             | Keeper_unified_turn.Requeue_after_context_compaction
+             | Keeper_unified_turn.Requeue_after_context_compaction _
              | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
-             | Keeper_unified_turn.Follow_failure_route ->
+             | Keeper_unified_turn.Follow_failure_route
+             | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
                (match failure.Keeper_unified_turn.route with
                 | Keeper_runtime_failure_route.Escalate_judgment
                     { judgment; provenance; detail } ->
@@ -907,18 +980,7 @@ let run_keepalive_unified_turn
             requeue-vs-escalate from the streak *before* this failure, and this
             stamp records the failure for the next cycle. *)
          (let compaction_outcome =
-            match !cycle_outcome_ref with
-            | Some (Cycle.Manual_compaction_applied _) -> Some `Committed
-            | Some (Cycle.Manual_compaction_failed _) -> Some `Failed
-            | Some
-                ( Cycle.Completed _
-                | Cycle.Cancelled _
-                | Cycle.Skipped _
-                | Cycle.Busy _
-                | Cycle.Failed _
-                | Cycle.Judgment_settled _
-                | Cycle.Manual_compaction_not_applied _ )
-            | None -> None
+            compaction_outcome_of_cycle_outcome !cycle_outcome_ref
           in
           match compaction_outcome with
           | None -> ()

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -122,13 +122,35 @@ val record_crashed_cycle_failure :
 
 val settlement_of_failure :
   settled_at:float ->
+  compaction_consecutive_failures:int ->
   Keeper_unified_turn.turn_failure ->
   Keeper_registry_event_queue.settlement
 (** Pure queue disposition for a failed cycle. Retry/rotation requeue and a
     deterministic failure creates one judgment successor. This mapping is
     identical when the source lease carried an earlier judgment: the failed
     action's new typed route remains authoritative rather than being collapsed
-    into a generic judgment failure. *)
+    into a generic judgment failure.
+
+    [compaction_consecutive_failures] is the keeper's persisted failure streak
+    from [keeper_meta.runtime.compaction_rt]. When the disposition carries an
+    in-lane provider-overflow compaction outcome that made no durable progress
+    ([Compaction_attempt_failed] or a terminal no-compaction), the settlement
+    escalates as [Compaction_retry_exhausted] once this failure would reach
+    [Keeper_meta_contract.compaction_retry_escalation_threshold] — without the
+    ceiling this lane requeues forever, one summarizer LLM call per heartbeat
+    cycle (RFC-0351 S0, #25461; 2026-07-21 storm: 284 provider-overflow
+    rejections over ~10h, ended only by operator keeper_down). A
+    [Compaction_committed] disposition always requeues: the retry reloads a
+    durably smaller checkpoint. *)
+
+val compaction_outcome_of_cycle_outcome :
+  Keeper_heartbeat_loop_cycle.cycle_outcome option ->
+  [ `Committed | `Failed ] option
+(** Pure mapping from a settled cycle outcome to the compaction-streak stamp
+    ([Keeper_meta_store.persist_compaction_outcome]). Manual-lane
+    applied/failed outcomes and in-lane provider-overflow dispositions join
+    the same per-keeper streak; outcomes with no compaction involvement return
+    [None] and leave the streak untouched. *)
 
 val settlement_of_cycle_outcome :
   base_path:string ->
@@ -142,12 +164,13 @@ val settlement_of_cycle_outcome :
     cancellation and non-executable-phase skips requeue.
 
     [compaction_consecutive_failures] is the keeper's current failure streak
-    from [keeper_meta.runtime.compaction_rt]. A manual-compaction failure
-    settles as [Escalate Compaction_retry_exhausted] once this failure would
-    reach the escalation threshold, and as
-    [Requeue Context_compaction_retry] below it — a requeue is not an ack, so
-    without the ceiling the same stimulus re-enters every cycle (RFC-0351 S0,
-    #25461). *)
+    from [keeper_meta.runtime.compaction_rt]. A manual-compaction failure — or
+    a failed cycle whose disposition carries a no-progress in-lane compaction
+    outcome (via {!settlement_of_failure}) — settles as
+    [Escalate Compaction_retry_exhausted] once this failure would reach
+    [Keeper_meta_contract.compaction_retry_escalation_threshold], and retries
+    below it — a requeue is not an ack, so without the ceiling the same
+    stimulus re-enters every cycle (RFC-0351 S0, #25461). *)
 
 val project_transition_outbox :
   base_path:string -> keeper_name:string -> (unit, string) result

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -47,13 +47,27 @@ type compaction_runtime =
   ; last_check_ts : float
   ; last_decision : compaction_runtime_decision
   ; consecutive_failures : int
-    (* RFC-0351 S0 / #25461: consecutive [Manual_compaction_failed] settlements
-       for this keeper. Incremented on failure, reset to 0 on a committed
-       compaction. The heartbeat settlement path escalates instead of requeuing
-       once this reaches [compaction_retry_escalation_threshold]; without it a
-       failing compaction requeues forever (measured: 102 failures / 104
-       compaction LLM calls in 74 minutes). *)
+    (* RFC-0351 S0 / #25461: consecutive compaction-failure settlements for
+       this keeper — manual-lane [Manual_compaction_failed] and in-lane
+       provider-overflow recoveries that made no durable progress. Incremented
+       on failure, reset to 0 on a committed compaction from either lane. The
+       heartbeat settlement path escalates instead of requeuing once this
+       reaches [compaction_retry_escalation_threshold]; without it a failing
+       compaction requeues forever (measured: 102 failures / 104 compaction
+       LLM calls in 74 minutes). *)
   }
+
+(* RFC-0351 S0 / #25461: consecutive compaction failures tolerated before the
+   settlement escalates instead of retrying. Defined next to
+   [consecutive_failures] so the heartbeat settlement (manual and in-lane
+   provider-overflow) and the status/dashboard projections that surface the
+   suspended state read one constant. Three attempts keeps a transient
+   CAS/source race recoverable while bounding a structurally-stuck
+   compaction. *)
+let compaction_retry_escalation_threshold = 3
+
+let compaction_retry_suspended rt =
+  rt.consecutive_failures >= compaction_retry_escalation_threshold
 
 type proactive_runtime =
   { count_total : int

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -64,10 +64,24 @@ type compaction_runtime = {
   last_check_ts : float;
   last_decision : compaction_runtime_decision;
   consecutive_failures : int;
-      (** RFC-0351 S0 / #25461: consecutive manual-compaction failures.  Reset to
-          0 on a committed compaction; the heartbeat settlement escalates instead
-          of requeuing once it reaches the escalation threshold. *)
+      (** RFC-0351 S0 / #25461: consecutive compaction failures across the
+          manual lane and the in-lane provider-overflow recovery.  Reset to 0
+          on a committed compaction from either lane; the heartbeat settlement
+          escalates instead of requeuing once it reaches
+          {!compaction_retry_escalation_threshold}. *)
 }
+
+val compaction_retry_escalation_threshold : int
+(** RFC-0351 S0 / #25461: consecutive compaction failures tolerated before the
+    settlement escalates ([Compaction_retry_exhausted]) instead of retrying.
+    Single definition shared by the heartbeat settlement and the
+    status/dashboard projections. *)
+
+val compaction_retry_suspended : compaction_runtime -> bool
+(** [true] once the persisted failure streak has reached
+    {!compaction_retry_escalation_threshold} — the settlement has stopped
+    retrying compaction for this keeper and each further stimulus escalates
+    after a single bounded attempt, pending operator inspection. *)
 
 type proactive_runtime = {
   count_total : int;

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -160,6 +160,12 @@ let handle_keeper_list ctx args : tool_result =
               ("handoff_count_total", `Int trace_history_count);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
+              ( "compaction_consecutive_failures",
+                `Int m.runtime.compaction_rt.consecutive_failures );
+              ( "compaction_retry_suspended",
+                `Bool
+                  (Keeper_meta_contract.compaction_retry_suspended
+                     m.runtime.compaction_rt) );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -19,9 +19,15 @@ include Keeper_unified_turn_types
 
 include Keeper_unified_turn_phase_plan
 
+type in_lane_compaction =
+  | Compaction_committed
+  | Compaction_attempt_failed of { reason : string }
+
 type source_lease_disposition =
   | Follow_failure_route
-  | Requeue_after_context_compaction
+  | Follow_failure_route_after_no_compaction of
+      { reason : Keeper_event_queue_state.no_compaction_reason }
+  | Requeue_after_context_compaction of in_lane_compaction
   | Acknowledge_after_in_turn_handling
 
 type turn_failure =
@@ -321,8 +327,13 @@ let append_provider_overflow_manifest
     (* [No_compaction] is terminal evidence for an explicit manual-compaction
        operation, not successful handling of the product event whose provider
        turn overflowed. Preserve the typed context-overflow route so the
-       owning source lease is escalated instead of silently consumed. *)
-    Follow_failure_route, turn_state
+       owning source lease is escalated instead of silently consumed — but
+       carry the terminal reason so the settlement can advance the
+       compaction-failure streak: a context that cannot shrink re-overflows
+       deterministically, so unbounded route retries burn one summarizer LLM
+       call per cycle (RFC-0351 S0, #25461). *)
+    Follow_failure_route_after_no_compaction { reason = no_compaction.reason },
+    turn_state
   | Provider_overflow_applied recovery ->
     let turn_state =
       append_recovery
@@ -331,7 +342,7 @@ let append_provider_overflow_manifest
         ~recovery
         turn_state
     in
-    Requeue_after_context_compaction, turn_state
+    Requeue_after_context_compaction Compaction_committed, turn_state
   | Provider_overflow_retry_with_checkpoint { reason; recovery } ->
     let turn_state =
       append_recovery
@@ -340,7 +351,10 @@ let append_provider_overflow_manifest
         ~recovery
         turn_state
     in
-    Requeue_after_context_compaction, turn_state
+    (* The checkpoint commit succeeded ([recovery] exists); only the lifecycle
+       completion dispatch failed. The retry reloads a durably smaller
+       checkpoint, so this counts as compaction progress for the streak. *)
+    Requeue_after_context_compaction Compaction_committed, turn_state
   | Provider_overflow_retry_without_checkpoint { trigger; reason } ->
     let turn_state =
       Keeper_unified_turn_manifest.append_manifest
@@ -362,7 +376,8 @@ let append_provider_overflow_manifest
                ]))
         Keeper_runtime_manifest.Context_compacted
     in
-    Requeue_after_context_compaction, turn_state
+    Requeue_after_context_compaction (Compaction_attempt_failed { reason }),
+    turn_state
 ;;
 
 let run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -137,11 +137,33 @@ val record_streaming_cancelled_observation
   -> unit
   -> unit
 
+type in_lane_compaction =
+  | Compaction_committed
+  | Compaction_attempt_failed of { reason : string }
+(** Typed outcome of the in-lane provider-overflow compaction behind a
+    [Requeue_after_context_compaction] disposition. [Compaction_committed]
+    proves the checkpoint durably shrank before the requeue, so the settlement
+    resets the keeper's compaction-failure streak and the retry reloads real
+    progress. [Compaction_attempt_failed] means the recovery made no durable
+    progress; the settlement advances the streak and escalates once it reaches
+    [Keeper_meta_contract.compaction_retry_escalation_threshold] (RFC-0351 S0,
+    #25461 — without the ceiling this lane requeued forever: 284 of 285
+    rejections in the 2026-07-21 storm carried trigger=provider_overflow and
+    only the operator's keeper_down ended it). *)
+
 type source_lease_disposition =
   | Follow_failure_route
-  | Requeue_after_context_compaction
+  | Follow_failure_route_after_no_compaction of
+      { reason : Keeper_event_queue_state.no_compaction_reason }
+  | Requeue_after_context_compaction of in_lane_compaction
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
+    [Follow_failure_route_after_no_compaction] follows the same route but
+    records that the in-lane provider-overflow compaction terminally declined
+    to act ([no_compaction_reason]); the settlement advances the
+    compaction-failure streak and replaces the route with
+    [Escalate Compaction_retry_exhausted] at the threshold, because a turn
+    whose context cannot shrink re-overflows deterministically on every retry.
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
     cycle reloads the durably compacted checkpoint.

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -958,6 +958,7 @@ let test_failed_cycle_route_mapping () =
   (match
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:2.0
+       ~compaction_consecutive_failures:0
        retry_failure
    with
    | Masc.Keeper_registry_event_queue.Requeue
@@ -975,6 +976,7 @@ let test_failed_cycle_route_mapping () =
   (match
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:3.0
+       ~compaction_consecutive_failures:0
        judgment_failure
    with
    | Masc.Keeper_registry_event_queue.Escalate
@@ -995,6 +997,7 @@ let test_failed_cycle_route_mapping () =
   (match
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:6.0
+       ~compaction_consecutive_failures:0
        handled_failure
    with
    | Masc.Keeper_registry_event_queue.Ack -> ()
@@ -1003,11 +1006,13 @@ let test_failed_cycle_route_mapping () =
     { judgment_failure with
       source_lease_disposition =
         Masc.Keeper_unified_turn.Requeue_after_context_compaction
+          Masc.Keeper_unified_turn.Compaction_committed
     }
   in
   match
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:7.0
+      ~compaction_consecutive_failures:0
       compacted_failure
   with
   | Masc.Keeper_registry_event_queue.Requeue
@@ -1076,6 +1081,7 @@ let test_manual_no_compaction_is_terminal_but_overflow_escalates () =
   match
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:3.0
+      ~compaction_consecutive_failures:0
       overflow_failure
   with
   | Masc.Keeper_registry_event_queue.Escalate
@@ -1182,6 +1188,158 @@ let test_compaction_retry_escalates_after_threshold () =
   | _ ->
     Alcotest.fail
       "third consecutive compaction failure requeued instead of escalating"
+;;
+
+(* RFC-0351 S0 / #25461: the in-lane provider-overflow recovery joins the same
+   ceiling. In the 2026-07-21 storm 284 of 285 rejections carried
+   trigger=provider_overflow and escalation never fired, because this lane
+   requeued unconditionally; the storm ran ~10h and ended only when the
+   operator issued keeper_down. *)
+let test_in_lane_compaction_streak_bounds_retries () =
+  let judgment_route =
+    Keeper_runtime_failure_route.Escalate_judgment
+      { judgment = Keeper_runtime_failure_route.Context_overflow
+      ; provenance = Keeper_runtime_failure_route.Oas_api_error
+      ; detail = "typed provider context overflow"
+      }
+  in
+  let failure disposition =
+    { (turn_failure judgment_route) with source_lease_disposition = disposition }
+  in
+  let settlement ~streak disposition =
+    Masc.Keeper_heartbeat_loop.settlement_of_failure
+      ~settled_at:4.0
+      ~compaction_consecutive_failures:streak
+      (failure disposition)
+  in
+  let attempt_failed =
+    Masc.Keeper_unified_turn.Requeue_after_context_compaction
+      (Masc.Keeper_unified_turn.Compaction_attempt_failed
+         { reason = "test-induced recovery failure" })
+  in
+  let committed =
+    Masc.Keeper_unified_turn.Requeue_after_context_compaction
+      Masc.Keeper_unified_turn.Compaction_committed
+  in
+  let terminal_no_compaction =
+    Masc.Keeper_unified_turn.Follow_failure_route_after_no_compaction
+      { reason = State.Checkpoint_not_reduced }
+  in
+  let expect_compaction_requeue label = function
+    | Masc.Keeper_registry_event_queue.Requeue
+        Masc.Keeper_registry_event_queue.Context_compaction_retry ->
+      ()
+    | _ -> Alcotest.fail label
+  in
+  let expect_exhausted ~attempts label = function
+    | Masc.Keeper_registry_event_queue.Escalate
+        { reason =
+            Masc.Keeper_registry_event_queue.Compaction_retry_exhausted
+              { attempts = reported; _ }
+        ; successor = None
+        } ->
+      Alcotest.(check int) (label ^ ": attempt count") attempts reported
+    | _ -> Alcotest.fail label
+  in
+  expect_compaction_requeue
+    "first in-lane recovery failure did not requeue"
+    (settlement ~streak:0 attempt_failed);
+  expect_compaction_requeue
+    "second in-lane recovery failure did not requeue"
+    (settlement ~streak:1 attempt_failed);
+  expect_exhausted
+    ~attempts:3
+    "third in-lane recovery failure requeued instead of escalating"
+    (settlement ~streak:2 attempt_failed);
+  (* A committed compaction is progress: the retry reloads a durably smaller
+     checkpoint and must never be replaced by exhaustion, whatever the prior
+     streak. *)
+  expect_compaction_requeue
+    "committed in-lane compaction was escalated despite durable progress"
+    (settlement ~streak:2 committed);
+  (* A terminal no-compaction below the ceiling keeps today's route (the
+     judgment successor); at the ceiling the settlement replaces the route,
+     because a context that cannot shrink re-overflows deterministically. *)
+  (match settlement ~streak:0 terminal_no_compaction with
+   | Masc.Keeper_registry_event_queue.Escalate
+       { reason = Masc.Keeper_registry_event_queue.Failure_judgment_requested
+       ; successor = Some { Queue.payload = Queue.Failure_judgment _; _ }
+       } ->
+     ()
+   | _ ->
+     Alcotest.fail
+       "terminal no-compaction below the ceiling lost its typed failure route");
+  expect_exhausted
+    ~attempts:3
+    "terminal no-compaction at the ceiling followed the route instead of \
+     escalating"
+    (settlement ~streak:2 terminal_no_compaction)
+;;
+
+(* RFC-0351 S0 / #25461: the settlement decides from the streak; this mapping
+   is what advances it. In-lane dispositions must join the manual lane's
+   counter, and outcomes with no compaction involvement must leave it
+   untouched. *)
+let test_compaction_outcome_mapping_covers_in_lane_dispositions () =
+  let meta = cycle_meta () in
+  let judgment_route =
+    Keeper_runtime_failure_route.Escalate_judgment
+      { judgment = Keeper_runtime_failure_route.Context_overflow
+      ; provenance = Keeper_runtime_failure_route.Oas_api_error
+      ; detail = "typed provider context overflow"
+      }
+  in
+  let failed disposition =
+    Some
+      (Masc.Keeper_heartbeat_loop_cycle.Failed
+         { meta
+         ; failure =
+             { (turn_failure judgment_route) with
+               source_lease_disposition = disposition
+             }
+         })
+  in
+  let check label expected outcome =
+    let actual =
+      match Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome outcome with
+      | Some `Committed -> "committed"
+      | Some `Failed -> "failed"
+      | None -> "none"
+    in
+    Alcotest.(check string) label expected actual
+  in
+  check
+    "in-lane committed compaction resets the streak"
+    "committed"
+    (failed
+       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
+          Masc.Keeper_unified_turn.Compaction_committed));
+  check
+    "in-lane failed recovery advances the streak"
+    "failed"
+    (failed
+       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
+          (Masc.Keeper_unified_turn.Compaction_attempt_failed
+             { reason = "test-induced recovery failure" })));
+  check
+    "in-lane terminal no-compaction advances the streak"
+    "failed"
+    (failed
+       (Masc.Keeper_unified_turn.Follow_failure_route_after_no_compaction
+          { reason = State.Checkpoint_not_reduced }));
+  check
+    "a generic turn failure leaves the streak untouched"
+    "none"
+    (failed Masc.Keeper_unified_turn.Follow_failure_route);
+  check
+    "an in-turn handled failure leaves the streak untouched"
+    "none"
+    (failed Masc.Keeper_unified_turn.Acknowledge_after_in_turn_handling);
+  check
+    "a completed cycle leaves the streak untouched"
+    "none"
+    (Some (Masc.Keeper_heartbeat_loop_cycle.Completed meta));
+  check "no outcome leaves the streak untouched" "none" None
 ;;
 
 let test_cancelled_and_skipped_cycles_requeue () =
@@ -2069,6 +2227,14 @@ let () =
             "compaction retry escalates after threshold"
             `Quick
             test_compaction_retry_escalates_after_threshold
+        ; Alcotest.test_case
+            "in-lane compaction streak bounds retries"
+            `Quick
+            test_in_lane_compaction_streak_bounds_retries
+        ; Alcotest.test_case
+            "compaction outcome mapping covers in-lane dispositions"
+            `Quick
+            test_compaction_outcome_mapping_covers_in_lane_dispositions
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick


### PR DESCRIPTION
## 무엇이 남아 있었나 (라이브 실측, 2026-07-21)

#25514가 넣은 3회 에스컬레이션 상한은 **manual compaction lane에만** 적용됐다. 오늘 sangsu 폭풍의 실측:

- compaction_rejected 285건 중 **284건이 trigger=provider_overflow** (in-lane reactive 경로)
- `Compaction_retry_exhausted` 발화 **0회** (~10시간)
- 사유 분포: checkpoint_not_reduced 161 / invalid_compaction_plan 90 / structurally_unchanged 34
- LLM candidate 생성 성공 201회 — 매 재시도가 summarizer LLM 호출을 지불하고 그대로 거부됨
- 폭풍의 종결자는 에스컬레이션이 아니라 10:14Z 오너의 `masc_keeper_down`

구조적 원인 두 가지:

1. in-lane retryable 실패(`invalid_compaction_plan` 등)는 `settlement_of_failure`가 streak을 읽지 않고 **무조건 `Requeue Context_compaction_retry`** — 상한이 아예 배선되지 않음.
2. in-lane terminal 거부(`checkpoint_not_reduced` 등)는 manual lane에선 stimulus를 소비(ack)하지만, in-lane에선 source lease가 **product 이벤트**라 requeue가 정당 — 그래서 같은 terminal 사유가 매 재시도마다 재발화. 줄어들 수 없는 컨텍스트는 재시도마다 결정론적으로 다시 overflow한다.

## 수정

디스포지션이 in-lane 컴팩션 결과를 타입으로 실어 나르게 하고, settlement가 manual lane과 **같은 streak/threshold**로 판단한다:

| 디스포지션 | streak | settlement |
|---|---|---|
| `Requeue_after_context_compaction Compaction_committed` | reset | 항상 requeue (durable 진전 — 재시도는 더 작은 checkpoint를 로드) |
| `Requeue_after_context_compaction (Compaction_attempt_failed _)` | +1 | threshold 미만 requeue / 도달 시 `Escalate Compaction_retry_exhausted` |
| `Follow_failure_route_after_no_compaction {reason}` (신규) | +1 | threshold 미만 기존 failure route 유지(judgment successor 등) / 도달 시 escalate |
| `Follow_failure_route` (일반 실패) | 불변 | 기존과 동일 — 일반 턴 실패는 컴팩션 진전에 대해 아무것도 증명하지 않음 |

- streak 전진/리셋은 pure 함수 `compaction_outcome_of_cycle_outcome`로 추출 — manual lane(`Manual_compaction_applied/Failed`)과 in-lane 디스포지션이 같은 `compaction_rt.consecutive_failures`에 합류. ordering은 기존 그대로 (settlement가 이전 streak을 읽고, stamp는 그 후).
- `compaction_retry_escalation_threshold`(3)를 `Keeper_meta_contract`로 이동 — 해석 대상 필드(`consecutive_failures`) 옆이 SSOT, settlement와 projection이 한 상수를 읽는다.
- **표면화 (#25461의 "Board/attention 표면화" 절반)**: `masc_keeper_status`와 dashboard keeper JSON에 `compaction_consecutive_failures` + `compaction_retry_suspended`(bool) 추가. 에스컬레이션은 기존대로 WARN + reaction ledger 카운터에 남고, 이제 status 표면에서 "이 keeper는 컴팩션 재시도가 정지된 상태"가 보인다.

에스컬레이션 이후 동작: streak이 threshold 이상으로 고착되면 새 stimulus는 **턴 1회 + 컴팩션 시도 1회 후 즉시 escalate** — 이벤트당 비용이 상수로 떨어진다. 컴팩션이 한 번이라도 commit되면 streak이 리셋되어 정상 재시도로 복귀.

## 검증

- `test_keeper_event_queue_state_v2` 신규 2케이스: in-lane streak bound(미만 requeue/도달 escalate/committed는 streak 무관 requeue/terminal no-compaction은 미만에서 기존 route 유지) + outcome 매핑 totality. 31 tests 중 신규 포함 30 pass.
- 잔여 1 실패 `test_legacy_settlement_wal_v1_remain`은 **main 베이스라인(a6ad60de5d)에서 동일 재현**되는 로컬 한정(pre-existing, CI green) 실패로 본 변경과 무관.
- `dune build --root . @check` PASS, DET/NDT gate 로컬 PASS, 코드 파일 fmt clean (dune 파일 fmt drift는 pre-existing이라 미포함).

검증 한계: 라이브 재현(overflow 상태 keeper로 3연속 실패 유도)은 로컬 하네스 부재로 미수행 — settlement/매핑은 pure 함수 단위로 검증했고, streak 전진의 라이브 경로는 기존 #25514의 persist 사이트를 그대로 공유한다.

## 남는 것 (범위 밖)

- `Compaction_retry_exhausted`의 board post/대시보드 전용 렌더링 — status JSON 필드까지가 이 PR. 대시보드 TS 렌더링은 후속.
- 근본원인(쓰기 경계가 깨진 tool_use/tool_result 히스토리 admit, #25443)과 eligible 협소 문제는 이 PR이 건드리지 않음 — 이 PR은 그 결함이 유발하는 무한 소각을 typed terminal로 막는 S0 단계.
- sangsu의 실제 복구는 S1 결정론 purge + 이후 L4 Flush (RFC-0351).

RFC-0351 S0 (#25467) 및 #25461 인용 — "연속 N회 실패 시 typed 정지 + 표면화"의 in-lane 완결.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
