### PR TITLE
feat(keeper): deterministic offline checkpoint purge tool (RFC-0351 S1)

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -145,6 +145,17 @@
  (package masc)
  (libraries masc masc_core masc.config_dir_resolver unix eio eio_main))
 
+;; Offline deterministic checkpoint purge CLI (RFC-0351 S1): duplicate
+;; collapse, unsigned reasoning strip, tool-result content clear. Dry-run by
+;; default; --apply backs up then saves through the locked validated store.
+
+(executable
+ (name masc_checkpoint_purge)
+ (modules masc_checkpoint_purge)
+ (public_name masc-checkpoint-purge)
+ (package masc)
+ (libraries masc masc_core masc.config_dir_resolver agent_sdk unix))
+
 ;; Read-only keeper feature proof CLI: renders the same JSON as
 ;; /api/v1/dashboard/keeper-feature-proof without starting a server.
 

--- a/bin/masc_checkpoint_purge.ml
+++ b/bin/masc_checkpoint_purge.ml
@@ -1,0 +1,212 @@
+(** [masc_checkpoint_purge] — offline deterministic checkpoint purge
+    (RFC-0351 S1).
+
+    Loads the canonical OAS checkpoint for one trace, applies
+    {!Masc.Keeper_checkpoint_purge.purge} (duplicate collapse, unsigned
+    reasoning strip, tool-result content clear — no LLM involved), and prints
+    a per-rule report. Dry-run by default; [--apply] backs the original file
+    up byte-exact and saves the purged checkpoint through
+    [Keeper_checkpoint_store.save_oas_classified] (locked, structure-validated,
+    watermark-checked; [turn_count] is unchanged so the save lands as an
+    equal-watermark re-save).
+
+    Run [--apply] only while the keeper is stopped ([masc_keeper_down]): a
+    live keeper holds the conversation in memory and its next save overwrites
+    the purge. *)
+
+let usage =
+  {|Usage: masc_checkpoint_purge --trace TRACE_ID [OPTIONS]
+
+Deterministic offline checkpoint purge (RFC-0351 S1). Dry-run by default.
+
+Options:
+  --trace ID               trace/session id (directory under {base}/traces/)
+  --base DIR               masc base dir (default: MASC_BASE_PATH or cwd)
+  --apply                  back up, then write the purged checkpoint
+  --keep-recent N          protected tail length in messages (default 20)
+  --dup-threshold N        duplicate collapse threshold (default 3, >= 2)
+  --no-strip-thinking      keep unsigned Thinking/ReasoningDetails blocks
+  --no-clear-tool-results  keep ToolResult payloads
+  -h, --help               print this help
+
+--apply requires the keeper to be stopped (masc_keeper_down); a live keeper
+overwrites the purge on its next save.
+
+Exit codes:
+  0  report printed (dry-run) or purge applied
+  1  invalid argument / load / structural / save error
+|}
+
+module Purge = Masc.Keeper_checkpoint_purge
+module Store = Masc.Keeper_checkpoint_store
+
+let error msg =
+  prerr_endline msg;
+  exit 1
+
+let parse_positive_int_arg name raw =
+  match int_of_string_opt (String.trim raw) with
+  | Some n when n >= 0 -> n
+  | _ -> error (Printf.sprintf "invalid %s: %S (expected an integer >= 0)" name raw)
+
+let structural_error_text structural =
+  Masc.Keeper_compaction_unit.show_structural_error structural
+
+let purge_error_text = function
+  | Purge.Invalid_config detail -> "invalid config: " ^ detail
+  | Purge.Invalid_input_structure structural ->
+    Printf.sprintf
+      "checkpoint failed structural validation and was not modified: %s\n\
+       (a broken history has to be repaired at the write boundary that \
+       admitted it, not by this tool — see #25443)"
+      (structural_error_text structural)
+  | Purge.Invalid_output_structure structural ->
+    Printf.sprintf
+      "purge produced an invalid structure — this is a bug in \
+       keeper_checkpoint_purge, nothing was written: %s"
+      (structural_error_text structural)
+
+let load_error_text = function
+  | Store.Not_found -> "canonical checkpoint file not found"
+  | Store.Store_error detail -> "store error: " ^ detail
+  | Store.Parse_error detail -> "parse error: " ^ detail
+  | Store.Io_error detail -> "io error: " ^ detail
+  | Store.Sdk_other_error detail -> "sdk error: " ^ detail
+
+let read_file_bytes path =
+  match In_channel.with_open_bin path In_channel.input_all with
+  | bytes -> bytes
+  | exception Sys_error detail -> error ("cannot read " ^ path ^ ": " ^ detail)
+
+let write_file_bytes path bytes =
+  match Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc bytes) with
+  | () -> ()
+  | exception Sys_error detail -> error ("cannot write " ^ path ^ ": " ^ detail)
+
+let timestamp_utc () =
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  Printf.sprintf
+    "%04d%02d%02dT%02d%02d%02dZ"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+    tm.tm_hour tm.tm_min tm.tm_sec
+
+let () =
+  let trace = ref None in
+  let base = ref None in
+  let apply = ref false in
+  let config = ref Purge.default_config in
+  let rec parse = function
+    | [] -> ()
+    | "-h" :: _ | "--help" :: _ ->
+      print_string usage;
+      exit 0
+    | "--trace" :: value :: rest ->
+      trace := Some value;
+      parse rest
+    | "--base" :: value :: rest ->
+      base := Some value;
+      parse rest
+    | "--apply" :: rest ->
+      apply := true;
+      parse rest
+    | "--keep-recent" :: value :: rest ->
+      config
+      := { !config with
+           Purge.keep_recent_messages = parse_positive_int_arg "--keep-recent" value
+         };
+      parse rest
+    | "--dup-threshold" :: value :: rest ->
+      config
+      := { !config with
+           Purge.dup_threshold = parse_positive_int_arg "--dup-threshold" value
+         };
+      parse rest
+    | "--no-strip-thinking" :: rest ->
+      config := { !config with Purge.strip_thinking = false };
+      parse rest
+    | "--no-clear-tool-results" :: rest ->
+      config := { !config with Purge.clear_tool_results = false };
+      parse rest
+    | unknown :: _ -> error (Printf.sprintf "unknown argument: %S\n%s" unknown usage)
+  in
+  parse (List.tl (Array.to_list Sys.argv));
+  let trace =
+    match !trace with
+    | Some value when String.trim value <> "" -> value
+    | Some _ | None -> error ("--trace is required\n" ^ usage)
+  in
+  let base_path =
+    match !base with
+    | Some value -> Config_dir_resolver.absolute_path value
+    | None -> Config_dir_resolver.base_path_or_cwd ()
+  in
+  let session_dir = Filename.concat (Filename.concat base_path "traces") trace in
+  let checkpoint_path = Store.oas_checkpoint_path ~session_dir ~session_id:trace in
+  if not (Sys.file_exists checkpoint_path)
+  then error ("no canonical checkpoint at " ^ checkpoint_path);
+  let original_bytes = read_file_bytes checkpoint_path in
+  match Store.load_oas ~session_dir ~session_id:trace with
+  | Error load_error -> error (load_error_text load_error)
+  | Ok checkpoint ->
+    (match Purge.purge ~config:!config checkpoint with
+     | Error purge_error -> error (purge_error_text purge_error)
+     | Ok (purged, report) ->
+       let purged_bytes = Agent_sdk.Checkpoint.to_string purged in
+       let before_len = String.length original_bytes in
+       let after_len = String.length purged_bytes in
+       Printf.printf "trace: %s\n" trace;
+       Printf.printf "checkpoint: %s\n" checkpoint_path;
+       Printf.printf
+         "messages: %d -> %d\n"
+         report.Purge.messages_before
+         report.Purge.messages_after;
+       Printf.printf
+         "bytes (canonical): %d -> %d (%+.1f%%)\n"
+         before_len
+         after_len
+         (if before_len = 0
+          then 0.0
+          else
+            100.0
+            *. (float_of_int after_len -. float_of_int before_len)
+            /. float_of_int before_len);
+       Printf.printf
+         "R1 duplicate messages dropped: %d\n"
+         report.Purge.duplicates_dropped;
+       Printf.printf
+         "R2 reasoning blocks stripped: %d (messages dropped when emptied: %d)\n"
+         report.Purge.reasoning_blocks_stripped
+         report.Purge.reasoning_messages_dropped;
+       Printf.printf
+         "R3 tool results cleared: %d\n"
+         report.Purge.tool_results_cleared;
+       if not !apply
+       then print_endline "dry-run: nothing written (pass --apply to persist)"
+       else (
+         let backup_dir =
+           Filename.concat
+             base_path
+             (Printf.sprintf "backups-checkpoint-purge-%s-%s" trace (timestamp_utc ()))
+         in
+         (match Sys.is_directory backup_dir with
+          | true -> ()
+          | false -> error (backup_dir ^ " exists and is not a directory")
+          | exception Sys_error _ -> Unix.mkdir backup_dir 0o755);
+         let backup_path = Filename.concat backup_dir (trace ^ ".json") in
+         write_file_bytes backup_path original_bytes;
+         Printf.printf "backup: %s (%d bytes)\n" backup_path before_len;
+         (match Store.save_oas_classified ~session_dir purged with
+          | Error detail -> error ("save failed (backup retained): " ^ detail)
+          | Ok (Store.Stale_noop { incoming_turn_count; known_turn_count }) ->
+            error
+              (Printf.sprintf
+                 "save refused as stale (incoming turn %d < known turn %d) — \
+                  the checkpoint changed underneath the purge; re-run against \
+                  the current file (backup retained)"
+                 incoming_turn_count
+                 known_turn_count)
+          | Ok (Store.Saved { relation = _; turn_count }) ->
+            Printf.printf
+              "applied: purged checkpoint saved at turn_count %d\n"
+              turn_count))
+     )

--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -114,22 +114,28 @@ let clear_tool_result_blocks (message : Agent_sdk.Types.message) =
   { message with Agent_sdk.Types.content }, !cleared_count
 ;;
 
-(* R1 bookkeeping: positions (item indices) of every unprotected text-only
-   ordinary message, grouped by the message's full derived representation. *)
-let duplicate_positions_to_drop ~dup_threshold ~protected items =
+(* An item after R2/R3: its surviving messages ([] when R2 emptied and
+   dropped it) and, when it is an unprotected text-only ordinary message, the
+   R1 grouping key over its full derived representation. *)
+type transformed_item =
+  { messages : Agent_sdk.Types.message list
+  ; dedup_key : string option
+  }
+
+(* R1 bookkeeping: positions (item indices) of duplicate-eligible items,
+   grouped by their transformed representation. *)
+let duplicate_positions_to_drop ~dup_threshold transformed_items =
   let groups : (string, int list) Hashtbl.t = Hashtbl.create 64 in
   List.iteri
-    (fun position item ->
-       match item.unit_ with
-       | Keeper_compaction_unit.Ordinary_message message
-         when (not (protected item)) && is_text_only message ->
-         let key = Agent_sdk.Types.show_message message in
+    (fun position transformed ->
+       match transformed.dedup_key with
+       | Some key ->
          let positions =
            Option.value ~default:[] (Hashtbl.find_opt groups key)
          in
          Hashtbl.replace groups key (position :: positions)
-       | _ -> ())
-    items;
+       | None -> ())
+    transformed_items;
   let dropped = Hashtbl.create 64 in
   Hashtbl.iter
     (fun _key positions ->
@@ -182,19 +188,23 @@ let purge_messages ~config messages =
       in
       let protected_from = messages_before - config.keep_recent_messages in
       let protected item = item.flat_last >= protected_from in
-      let dropped_positions =
-        duplicate_positions_to_drop
-          ~dup_threshold:config.dup_threshold
-          ~protected
-          items
-      in
-      let duplicates_dropped = Hashtbl.length dropped_positions in
       let reasoning_blocks_stripped = ref 0 in
       let reasoning_messages_dropped = ref 0 in
       let tool_results_cleared = ref 0 in
+      (* R2/R3 run before R1: stripping reasoning can turn previously
+         distinct assistant messages byte-identical, and only the stripped
+         form participates in duplicate grouping. This ordering is what makes
+         a single pass a fixpoint (verified by the idempotence test; measured
+         on the sangsu checkpoint, R1-first left 229 duplicates for a second
+         pass to find). *)
+      let dedup_key_of message =
+        if is_text_only message
+        then Some (Agent_sdk.Types.show_message message)
+        else None
+      in
       let purge_item item =
         if protected item
-        then messages_of_unit item.unit_
+        then { messages = messages_of_unit item.unit_; dedup_key = None }
         else (
           match item.unit_ with
           | Keeper_compaction_unit.Ordinary_message message ->
@@ -211,28 +221,41 @@ let purge_messages ~config messages =
               match stripped_message.Agent_sdk.Types.content with
               | [] ->
                 incr reasoning_messages_dropped;
-                []
-              | _ :: _ -> [ stripped_message ])
-            else [ message ]
+                { messages = []; dedup_key = None }
+              | _ :: _ ->
+                { messages = [ stripped_message ]
+                ; dedup_key = dedup_key_of stripped_message
+                })
+            else { messages = [ message ]; dedup_key = dedup_key_of message }
           | Keeper_compaction_unit.Closed_tool_cycle cycle_messages ->
-            if config.clear_tool_results
-            then
-              List.map
-                (fun message ->
-                   let cleared_message, cleared =
-                     clear_tool_result_blocks message
-                   in
-                   tool_results_cleared := !tool_results_cleared + cleared;
-                   cleared_message)
-                cycle_messages
-            else cycle_messages)
+            let cycle_messages =
+              if config.clear_tool_results
+              then
+                List.map
+                  (fun message ->
+                     let cleared_message, cleared =
+                       clear_tool_result_blocks message
+                     in
+                     tool_results_cleared := !tool_results_cleared + cleared;
+                     cleared_message)
+                  cycle_messages
+              else cycle_messages
+            in
+            { messages = cycle_messages; dedup_key = None })
       in
+      let transformed_items = List.map purge_item items in
+      let dropped_positions =
+        duplicate_positions_to_drop
+          ~dup_threshold:config.dup_threshold
+          transformed_items
+      in
+      let duplicates_dropped = Hashtbl.length dropped_positions in
       let purged_prefix =
         List.concat
           (List.filteri
              (fun position _item -> not (Hashtbl.mem dropped_positions position))
-             items
-           |> List.map purge_item)
+             transformed_items
+           |> List.map (fun transformed -> transformed.messages))
       in
       let purged = purged_prefix @ protected_suffix in
       (match Keeper_compaction_unit.validate purged with

--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -131,6 +131,8 @@ let duplicate_positions_to_drop ~dup_threshold transformed_items =
        match transformed.dedup_key with
        | Some key ->
          let positions =
+           (* DET-OK: Hashtbl accumulator — an absent key is the empty group
+              by construction, not unknown input collapsed to a default. *)
            Option.value ~default:[] (Hashtbl.find_opt groups key)
          in
          Hashtbl.replace groups key (position :: positions)

--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -1,0 +1,257 @@
+(* Deterministic offline checkpoint purge (RFC-0351 S1). See the .mli for the
+   rule contract. The implementation works on the closed units produced by
+   [Keeper_compaction_unit.partition] so a tool cycle is one indivisible item
+   from the first line to the last. *)
+
+type config =
+  { dup_threshold : int
+  ; keep_recent_messages : int
+  ; strip_thinking : bool
+  ; clear_tool_results : bool
+  }
+
+let default_config =
+  { dup_threshold = 3
+  ; keep_recent_messages = 20
+  ; strip_thinking = true
+  ; clear_tool_results = true
+  }
+;;
+
+let cleared_tool_result_content =
+  "[old tool result content cleared by keeper checkpoint purge]"
+;;
+
+type report =
+  { messages_before : int
+  ; messages_after : int
+  ; duplicates_dropped : int
+  ; reasoning_blocks_stripped : int
+  ; reasoning_messages_dropped : int
+  ; tool_results_cleared : int
+  }
+
+type purge_error =
+  | Invalid_config of string
+  | Invalid_input_structure of Keeper_compaction_unit.structural_error
+  | Invalid_output_structure of Keeper_compaction_unit.structural_error
+
+(* One purge work item: an ordinary message or a whole closed tool cycle.
+   [flat_last] is the index of the item's last message in the original list,
+   used for the count-based protected tail. *)
+type item =
+  { unit_ : Keeper_compaction_unit.closed_unit
+  ; flat_last : int
+  }
+
+let messages_of_unit = function
+  | Keeper_compaction_unit.Ordinary_message message -> [ message ]
+  | Keeper_compaction_unit.Closed_tool_cycle messages -> messages
+;;
+
+let is_text_only (message : Agent_sdk.Types.message) =
+  (match message.role with
+   | Agent_sdk.Types.User | Agent_sdk.Types.Assistant -> true
+   | Agent_sdk.Types.System | Agent_sdk.Types.Tool -> false)
+  && Option.is_none message.tool_call_id
+  && message.content <> []
+  && List.for_all
+       (function
+         | Agent_sdk.Types.Text _ -> true
+         | _ -> false)
+       message.content
+;;
+
+let has_tool_use (message : Agent_sdk.Types.message) =
+  List.exists
+    (function
+      | Agent_sdk.Types.ToolUse _ -> true
+      | _ -> false)
+    message.content
+;;
+
+(* R2: remove unsigned reasoning blocks. Signed thinking and
+   [RedactedThinking] replay byte-exact on tool turns and are kept. *)
+let strip_reasoning_blocks (message : Agent_sdk.Types.message) =
+  let kept, stripped =
+    List.fold_left
+      (fun (kept, stripped) block ->
+         match block with
+         | Agent_sdk.Types.Thinking { signature = None; _ }
+         | Agent_sdk.Types.ReasoningDetails _ -> kept, stripped + 1
+         | _ -> block :: kept, stripped)
+      ([], 0)
+      message.content
+  in
+  { message with Agent_sdk.Types.content = List.rev kept }, stripped
+;;
+
+(* R3: replace a tool result's payload with the fixed marker while keeping the
+   [tool_use_id] pairing and the typed delivery outcome. *)
+let clear_tool_result_blocks (message : Agent_sdk.Types.message) =
+  let cleared_count = ref 0 in
+  let content =
+    List.map
+      (fun block ->
+         match block with
+         | Agent_sdk.Types.ToolResult
+             ({ content; json; content_blocks; _ } as result) ->
+           if String.equal content cleared_tool_result_content
+              && Option.is_none json
+              && Option.is_none content_blocks
+           then block
+           else (
+             incr cleared_count;
+             Agent_sdk.Types.ToolResult
+               { result with
+                 content = cleared_tool_result_content
+               ; json = None
+               ; content_blocks = None
+               })
+         | _ -> block)
+      message.content
+  in
+  { message with Agent_sdk.Types.content }, !cleared_count
+;;
+
+(* R1 bookkeeping: positions (item indices) of every unprotected text-only
+   ordinary message, grouped by the message's full derived representation. *)
+let duplicate_positions_to_drop ~dup_threshold ~protected items =
+  let groups : (string, int list) Hashtbl.t = Hashtbl.create 64 in
+  List.iteri
+    (fun position item ->
+       match item.unit_ with
+       | Keeper_compaction_unit.Ordinary_message message
+         when (not (protected item)) && is_text_only message ->
+         let key = Agent_sdk.Types.show_message message in
+         let positions =
+           Option.value ~default:[] (Hashtbl.find_opt groups key)
+         in
+         Hashtbl.replace groups key (position :: positions)
+       | _ -> ())
+    items;
+  let dropped = Hashtbl.create 64 in
+  Hashtbl.iter
+    (fun _key positions ->
+       if List.length positions >= dup_threshold
+       then (
+         (* [positions] is in reverse traversal order: the head is the last
+            occurrence. Keep the first and last occurrence; drop the middle. *)
+         match positions with
+         | _last :: rest ->
+           (match List.rev rest with
+            | _first :: middle ->
+              List.iter
+                (fun position -> Hashtbl.replace dropped position ())
+                middle
+            | [] -> ())
+         | [] -> ()))
+    groups;
+  dropped
+;;
+
+let purge_messages ~config messages =
+  if config.dup_threshold < 2
+  then
+    Error
+      (Invalid_config
+         (Printf.sprintf
+            "dup_threshold must be >= 2 (got %d): every group keeps its first \
+             and last occurrence"
+            config.dup_threshold))
+  else if config.keep_recent_messages < 0
+  then
+    Error
+      (Invalid_config
+         (Printf.sprintf
+            "keep_recent_messages must be >= 0 (got %d)"
+            config.keep_recent_messages))
+  else (
+    match Keeper_compaction_unit.partition messages with
+    | Error structural -> Error (Invalid_input_structure structural)
+    | Ok { closed_prefix; protected_suffix } ->
+      let messages_before = List.length messages in
+      let items =
+        let flat_index = ref (-1) in
+        List.map
+          (fun unit_ ->
+             let unit_messages = messages_of_unit unit_ in
+             flat_index := !flat_index + List.length unit_messages;
+             { unit_; flat_last = !flat_index })
+          closed_prefix
+      in
+      let protected_from = messages_before - config.keep_recent_messages in
+      let protected item = item.flat_last >= protected_from in
+      let dropped_positions =
+        duplicate_positions_to_drop
+          ~dup_threshold:config.dup_threshold
+          ~protected
+          items
+      in
+      let duplicates_dropped = Hashtbl.length dropped_positions in
+      let reasoning_blocks_stripped = ref 0 in
+      let reasoning_messages_dropped = ref 0 in
+      let tool_results_cleared = ref 0 in
+      let purge_item item =
+        if protected item
+        then messages_of_unit item.unit_
+        else (
+          match item.unit_ with
+          | Keeper_compaction_unit.Ordinary_message message ->
+            if config.strip_thinking
+               && (match message.role with
+                   | Agent_sdk.Types.Assistant -> true
+                   | Agent_sdk.Types.User
+                   | Agent_sdk.Types.System
+                   | Agent_sdk.Types.Tool -> false)
+               && not (has_tool_use message)
+            then (
+              let stripped_message, stripped = strip_reasoning_blocks message in
+              reasoning_blocks_stripped := !reasoning_blocks_stripped + stripped;
+              match stripped_message.Agent_sdk.Types.content with
+              | [] ->
+                incr reasoning_messages_dropped;
+                []
+              | _ :: _ -> [ stripped_message ])
+            else [ message ]
+          | Keeper_compaction_unit.Closed_tool_cycle cycle_messages ->
+            if config.clear_tool_results
+            then
+              List.map
+                (fun message ->
+                   let cleared_message, cleared =
+                     clear_tool_result_blocks message
+                   in
+                   tool_results_cleared := !tool_results_cleared + cleared;
+                   cleared_message)
+                cycle_messages
+            else cycle_messages)
+      in
+      let purged_prefix =
+        List.concat
+          (List.filteri
+             (fun position _item -> not (Hashtbl.mem dropped_positions position))
+             items
+           |> List.map purge_item)
+      in
+      let purged = purged_prefix @ protected_suffix in
+      (match Keeper_compaction_unit.validate purged with
+       | Error structural -> Error (Invalid_output_structure structural)
+       | Ok () ->
+         Ok
+           ( purged
+           , { messages_before
+             ; messages_after = List.length purged
+             ; duplicates_dropped
+             ; reasoning_blocks_stripped = !reasoning_blocks_stripped
+             ; reasoning_messages_dropped = !reasoning_messages_dropped
+             ; tool_results_cleared = !tool_results_cleared
+             } )))
+;;
+
+let purge ~config (ckpt : Agent_sdk.Checkpoint.t) =
+  match purge_messages ~config ckpt.messages with
+  | Error error -> Error error
+  | Ok (messages, report) ->
+    Ok ({ ckpt with Agent_sdk.Checkpoint.messages }, report)
+;;

--- a/lib/keeper/keeper_checkpoint_purge.mli
+++ b/lib/keeper/keeper_checkpoint_purge.mli
@@ -12,6 +12,10 @@
       their content replaced by {!cleared_tool_result_content}, preserving the
       [tool_use_id]/[ToolUse] pairing (the cycle stays a valid closed unit).
 
+    R2 and R3 run before R1: stripping reasoning can make previously distinct
+    assistant messages byte-identical, and duplicate grouping sees only the
+    stripped form — this ordering is what makes a single pass a fixpoint.
+
     Tool protocol cycles are never split, reordered, or dropped. The last
     [keep_recent_messages] messages — and the structurally protected suffix
     from {!Keeper_compaction_unit.partition} — are returned byte-exact.

--- a/lib/keeper/keeper_checkpoint_purge.mli
+++ b/lib/keeper/keeper_checkpoint_purge.mli
@@ -1,0 +1,79 @@
+(** Deterministic offline checkpoint purge (RFC-0351 S1).
+
+    Reduces a persisted OAS checkpoint with three closed rules, none of which
+    involves an LLM:
+
+    - R1 duplicate collapse: byte-identical text-only messages repeated at
+      least [dup_threshold] times keep their first and last occurrence.
+    - R2 reasoning strip: unsigned [Thinking] and [ReasoningDetails] blocks are
+      removed from assistant messages that carry no [ToolUse] block; a message
+      left with no content is dropped.
+    - R3 tool-result clear: [ToolResult] blocks in closed tool cycles have
+      their content replaced by {!cleared_tool_result_content}, preserving the
+      [tool_use_id]/[ToolUse] pairing (the cycle stays a valid closed unit).
+
+    Tool protocol cycles are never split, reordered, or dropped. The last
+    [keep_recent_messages] messages — and the structurally protected suffix
+    from {!Keeper_compaction_unit.partition} — are returned byte-exact.
+    Signed thinking ([Thinking] with a signature and [RedactedThinking]) is
+    never removed: providers replay it byte-exact on tool turns.
+
+    Input and output are both validated with
+    {!Keeper_compaction_unit.validate}; a checkpoint that fails input
+    validation is refused rather than repaired, because a structurally broken
+    history has to be prevented at the write boundary that admitted it
+    (#25443). [session_id], [turn_count], and every other checkpoint field
+    outside [messages] pass through unchanged, so
+    [Keeper_checkpoint_store.save_oas_classified] accepts the result as an
+    equal-watermark re-save.
+
+    Applying the purge twice with the same config returns the first result
+    unchanged (verified by test): survivors of R1 number below
+    [dup_threshold], R2 leaves nothing further to strip, and R3 is a fixed
+    substitution. *)
+
+type config =
+  { dup_threshold : int (** minimum occurrences before R1 collapses, >= 2 *)
+  ; keep_recent_messages : int (** byte-exact protected tail length, >= 0 *)
+  ; strip_thinking : bool (** apply R2 *)
+  ; clear_tool_results : bool (** apply R3 *)
+  }
+
+val default_config : config
+(** [{ dup_threshold = 3; keep_recent_messages = 20; strip_thinking = true;
+      clear_tool_results = true }] — the rule set measured on the analyst
+    checkpoint (1,315 -> 579 messages, -28.0% bytes, next-turn input
+    -26.0%). *)
+
+val cleared_tool_result_content : string
+(** Replacement content for R3-cleared [ToolResult] blocks. A fixed marker,
+    not a classifier: nothing reads it back. *)
+
+type report =
+  { messages_before : int
+  ; messages_after : int
+  ; duplicates_dropped : int (** R1: middle occurrences removed *)
+  ; reasoning_blocks_stripped : int (** R2: blocks removed from survivors *)
+  ; reasoning_messages_dropped : int (** R2: messages left empty and dropped *)
+  ; tool_results_cleared : int (** R3: blocks whose content was replaced *)
+  }
+
+type purge_error =
+  | Invalid_config of string
+  | Invalid_input_structure of Keeper_compaction_unit.structural_error
+  | Invalid_output_structure of Keeper_compaction_unit.structural_error
+      (** Defensive re-validation of our own output; reaching this is a bug in
+          the transform, never a property of the input. *)
+
+val purge_messages
+  :  config:config
+  -> Agent_sdk.Types.message list
+  -> (Agent_sdk.Types.message list * report, purge_error) result
+(** Pure message-list transform behind {!purge}. Exposed for tests. *)
+
+val purge
+  :  config:config
+  -> Agent_sdk.Checkpoint.t
+  -> (Agent_sdk.Checkpoint.t * report, purge_error) result
+(** Apply {!purge_messages} to [ckpt.messages], leaving every other field
+    unchanged. *)

--- a/test/dune
+++ b/test/dune
@@ -668,6 +668,12 @@
  (libraries alcotest masc_test_deps masc.keeper_checkpoint_ref))
 
 (test
+ (name test_keeper_checkpoint_purge)
+ (modules test_keeper_checkpoint_purge)
+ (libraries alcotest masc_test_deps))
+
+
+(test
  (name test_keeper_paused_work_cancellation_transaction)
  (modules test_keeper_paused_work_cancellation_transaction)
  (libraries alcotest masc_test_deps eio_main))

--- a/test/test_keeper_checkpoint_purge.ml
+++ b/test/test_keeper_checkpoint_purge.ml
@@ -168,12 +168,39 @@ let test_cycle_overlapping_protected_tail_is_untouched () =
   let _purged, report = run ~config messages in
   Alcotest.(check int) "overlapping cycle not cleared" 0 report.tool_results_cleared
 
+let test_strip_revealed_duplicates_collapse_in_one_pass () =
+  (* Three assistant replies that differ only in their reasoning become
+     byte-identical once R2 strips them; R1 must see the stripped form in the
+     same pass (measured on the sangsu checkpoint: the reverse ordering left
+     229 duplicates for a second run to find). *)
+  let reply thinking =
+    block_message Types.Assistant [ unsigned_thinking thinking; Types.Text "same answer" ]
+  in
+  let messages =
+    [ reply "t1"
+    ; text_message Types.User "q1"
+    ; reply "t2"
+    ; text_message Types.User "q2"
+    ; reply "t3"
+    ]
+  in
+  let purged, report = run messages in
+  Alcotest.(check int) "three blocks stripped" 3 report.reasoning_blocks_stripped;
+  Alcotest.(check int) "middle stripped duplicate dropped" 1 report.duplicates_dropped;
+  Alcotest.(check (list string))
+    "first and last stripped occurrence survive"
+    [ "same answer"; "q1"; "q2"; "same answer" ]
+    (message_texts purged)
+
 let test_purge_is_idempotent () =
   let wake = text_message Types.User "(autonomous wake)" in
+  let reply thinking =
+    block_message Types.Assistant [ unsigned_thinking thinking; Types.Text "same answer" ]
+  in
   let messages =
     [ wake; wake; wake ]
     @ cycle "a"
-    @ [ block_message Types.Assistant [ unsigned_thinking "t"; Types.Text "x" ] ]
+    @ [ reply "t1"; reply "t2"; reply "t3" ]
     @ [ wake ]
   in
   let once, _ = run messages in
@@ -288,6 +315,10 @@ let () =
             "tool result clear preserves pairing"
             `Quick
             test_tool_result_clear_preserves_pairing
+        ; Alcotest.test_case
+            "strip-revealed duplicates collapse in one pass"
+            `Quick
+            test_strip_revealed_duplicates_collapse_in_one_pass
         ] )
     ; ( "boundaries"
       , [ Alcotest.test_case

--- a/test/test_keeper_checkpoint_purge.ml
+++ b/test/test_keeper_checkpoint_purge.ml
@@ -1,0 +1,315 @@
+(* RFC-0351 S1: deterministic offline checkpoint purge. The rules were
+   measured live on the analyst checkpoint (1,315 -> 579 messages, -28.0%
+   bytes); these tests pin the rule contract so the checked-in tool cannot
+   drift from what was validated. *)
+
+module Purge = Masc.Keeper_checkpoint_purge
+module Types = Agent_sdk.Types
+
+let text_message role text : Types.message =
+  { role; content = [ Types.Text text ]; name = None; tool_call_id = None; metadata = [] }
+
+let block_message role content : Types.message =
+  { role; content; name = None; tool_call_id = None; metadata = [] }
+
+let tool_use id : Types.content_block =
+  Types.ToolUse { id; name = "test_tool"; input = `Assoc [ "id", `String id ] }
+
+let tool_result ?(content = "raw tool output") id : Types.content_block =
+  Types.ToolResult
+    { tool_use_id = id
+    ; content
+    ; outcome = Types.Tool_succeeded
+    ; json = Some (`Assoc [ "ok", `Bool true ])
+    ; content_blocks = None
+    }
+
+let cycle id =
+  [ block_message Types.Assistant [ tool_use id ]
+  ; { (block_message Types.Tool [ tool_result id ]) with tool_call_id = Some id }
+  ]
+
+let unsigned_thinking text : Types.content_block =
+  Types.Thinking { content = text; signature = None }
+
+let signed_thinking text : Types.content_block =
+  Types.Thinking { content = text; signature = Some "sig" }
+
+(* Trailing distinct filler so the interesting prefix sits outside the
+   protected tail without disabling the tail protection itself. *)
+let filler n =
+  List.init n (fun i -> text_message Types.User (Printf.sprintf "filler-%d" i))
+
+let no_tail_config = { Purge.default_config with keep_recent_messages = 0 }
+
+let run ?(config = no_tail_config) messages =
+  match Purge.purge_messages ~config messages with
+  | Ok result -> result
+  | Error _ -> Alcotest.fail "purge rejected a structurally valid fixture"
+
+let message_texts messages =
+  List.map
+    (fun (m : Types.message) ->
+       String.concat
+         "|"
+         (List.map
+            (function
+              | Types.Text t -> t
+              | Types.Thinking _ -> "<thinking>"
+              | Types.ToolUse { id; _ } -> "use:" ^ id
+              | Types.ToolResult { tool_use_id; content; _ } ->
+                "result:" ^ tool_use_id ^ ":" ^ content
+              | _ -> "<other>")
+            m.content))
+    messages
+
+let test_duplicate_collapse_keeps_first_and_last () =
+  let wake = text_message Types.User "(autonomous wake)" in
+  let messages =
+    [ wake
+    ; text_message Types.Assistant "reply-a"
+    ; wake
+    ; text_message Types.Assistant "reply-b"
+    ; wake
+    ; wake
+    ]
+  in
+  let purged, report = run messages in
+  Alcotest.(check int) "two middles dropped" 2 report.duplicates_dropped;
+  Alcotest.(check (list string))
+    "first and last occurrence survive in order"
+    [ "(autonomous wake)"; "reply-a"; "reply-b"; "(autonomous wake)" ]
+    (message_texts purged)
+
+let test_duplicates_below_threshold_survive () =
+  let wake = text_message Types.User "(autonomous wake)" in
+  let messages = [ wake; text_message Types.Assistant "reply"; wake ] in
+  let _purged, report = run messages in
+  Alcotest.(check int) "pair is under the threshold" 0 report.duplicates_dropped
+
+let test_duplicate_tool_cycles_are_never_collapsed () =
+  (* Byte-identical cycles differ only in tool_use_id here — but even truly
+     repeated payloads must stay: R1 is scoped to text-only ordinary
+     messages. *)
+  let messages = cycle "a" @ cycle "b" @ cycle "c" in
+  let purged, report = run messages in
+  Alcotest.(check int) "no cycle collapsed" 0 report.duplicates_dropped;
+  Alcotest.(check int) "all cycle messages survive" 6 (List.length purged)
+
+let test_reasoning_strip_scope () =
+  let messages =
+    [ block_message Types.Assistant [ unsigned_thinking "t1"; Types.Text "answer" ]
+    ; block_message Types.Assistant [ unsigned_thinking "t2" ]
+    ; block_message Types.Assistant [ signed_thinking "t3"; Types.Text "signed" ]
+    ]
+  in
+  let purged, report = run messages in
+  Alcotest.(check int) "unsigned blocks stripped" 2 report.reasoning_blocks_stripped;
+  Alcotest.(check int) "thinking-only message dropped" 1 report.reasoning_messages_dropped;
+  Alcotest.(check (list string))
+    "text survives; signed thinking is untouched"
+    [ "answer"; "<thinking>|signed" ]
+    (message_texts purged)
+
+let test_reasoning_inside_tool_cycle_is_kept () =
+  let messages =
+    [ block_message Types.Assistant [ unsigned_thinking "pre-tool"; tool_use "a" ]
+    ; { (block_message Types.Tool [ tool_result "a" ]) with tool_call_id = Some "a" }
+    ]
+  in
+  let _purged, report = run messages in
+  Alcotest.(check int)
+    "a tool-use message keeps its reasoning"
+    0
+    report.reasoning_blocks_stripped
+
+let test_tool_result_clear_preserves_pairing () =
+  let messages = cycle "a" @ [ text_message Types.User "after" ] in
+  let purged, report = run messages in
+  Alcotest.(check int) "one result cleared" 1 report.tool_results_cleared;
+  (match List.nth purged 1 with
+   | { Types.content = [ Types.ToolResult { tool_use_id; content; json; content_blocks; outcome } ]; _ } ->
+     Alcotest.(check string) "pairing id kept" "a" tool_use_id;
+     Alcotest.(check string)
+       "content replaced by the marker"
+       Purge.cleared_tool_result_content
+       content;
+     Alcotest.(check bool) "json dropped" true (Option.is_none json);
+     Alcotest.(check bool) "blocks dropped" true (Option.is_none content_blocks);
+     (match outcome with
+      | Types.Tool_succeeded -> ()
+      | _ -> Alcotest.fail "typed outcome must survive the clear")
+   | _ -> Alcotest.fail "cleared cycle lost its ToolResult block");
+  match Masc.Keeper_compaction_unit.validate purged with
+  | Ok () -> ()
+  | Error _ -> Alcotest.fail "cleared cycle no longer validates"
+
+let test_protected_tail_is_byte_exact () =
+  let wake = text_message Types.User "(autonomous wake)" in
+  let config = { Purge.default_config with keep_recent_messages = 4 } in
+  let tail =
+    [ wake
+    ; wake
+    ; wake
+    ; block_message Types.Assistant [ unsigned_thinking "tail"; Types.Text "t" ]
+    ]
+  in
+  let messages = filler 3 @ tail in
+  let purged, report = run ~config messages in
+  Alcotest.(check int) "tail duplicates survive" 0 report.duplicates_dropped;
+  Alcotest.(check int) "tail reasoning survives" 0 report.reasoning_blocks_stripped;
+  Alcotest.(check int) "nothing dropped" 7 (List.length purged)
+
+let test_cycle_overlapping_protected_tail_is_untouched () =
+  let config = { Purge.default_config with keep_recent_messages = 1 } in
+  (* The cycle's final message falls inside the protected tail; the whole
+     cycle must be exempt from R3. *)
+  let messages = [ text_message Types.User "head" ] @ cycle "a" in
+  let _purged, report = run ~config messages in
+  Alcotest.(check int) "overlapping cycle not cleared" 0 report.tool_results_cleared
+
+let test_purge_is_idempotent () =
+  let wake = text_message Types.User "(autonomous wake)" in
+  let messages =
+    [ wake; wake; wake ]
+    @ cycle "a"
+    @ [ block_message Types.Assistant [ unsigned_thinking "t"; Types.Text "x" ] ]
+    @ [ wake ]
+  in
+  let once, _ = run messages in
+  let twice, second_report = run once in
+  Alcotest.(check (list string))
+    "second purge is the identity"
+    (message_texts once)
+    (message_texts twice);
+  Alcotest.(check int) "no further duplicates" 0 second_report.duplicates_dropped;
+  Alcotest.(check int)
+    "no further reasoning"
+    0
+    second_report.reasoning_blocks_stripped;
+  Alcotest.(check int) "no further clears" 0 second_report.tool_results_cleared
+
+let test_broken_structure_is_refused () =
+  let orphan =
+    { (block_message Types.Tool [ tool_result "ghost" ]) with
+      tool_call_id = Some "ghost"
+    }
+  in
+  match Purge.purge_messages ~config:no_tail_config [ orphan ] with
+  | Error (Purge.Invalid_input_structure _) -> ()
+  | Ok _ -> Alcotest.fail "orphan tool_result was accepted"
+  | Error _ -> Alcotest.fail "orphan tool_result misclassified"
+
+let test_config_bounds_are_enforced () =
+  (match
+     Purge.purge_messages
+       ~config:{ no_tail_config with dup_threshold = 1 }
+       [ text_message Types.User "x" ]
+   with
+   | Error (Purge.Invalid_config _) -> ()
+   | _ -> Alcotest.fail "dup_threshold 1 was accepted");
+  match
+    Purge.purge_messages
+      ~config:{ no_tail_config with keep_recent_messages = -1 }
+      [ text_message Types.User "x" ]
+  with
+  | Error (Purge.Invalid_config _) -> ()
+  | _ -> Alcotest.fail "negative keep_recent_messages was accepted"
+
+let test_checkpoint_fields_pass_through () =
+  let checkpoint =
+    Agent_sdk.Checkpoint.
+      { version = checkpoint_version
+      ; session_id = "trace-purge-fixture"
+      ; agent_name = "purge-fixture"
+      ; model = "test-model"
+      ; system_prompt = None
+      ; messages =
+          [ text_message Types.User "(autonomous wake)"
+          ; text_message Types.User "(autonomous wake)"
+          ; text_message Types.User "(autonomous wake)"
+          ]
+      ; usage = Types.empty_usage
+      ; turn_count = 41
+      ; created_at = 1_700_000_000.0
+      ; tools = []
+      ; tool_choice = None
+      ; disable_parallel_tool_use = false
+      ; temperature = None
+      ; top_p = None
+      ; top_k = None
+      ; min_p = None
+      ; enable_thinking = None
+      ; preserve_thinking = None
+      ; response_format = Types.Off
+      ; thinking_budget = None
+      ; reasoning_effort = None
+      ; cache_system_prompt = false
+      ; context = Agent_sdk.Context.create_sync ()
+      ; mcp_sessions = []
+      ; working_context = None
+      }
+  in
+  match Purge.purge ~config:no_tail_config checkpoint with
+  | Error _ -> Alcotest.fail "checkpoint purge failed"
+  | Ok (purged, report) ->
+    Alcotest.(check int) "one middle dropped" 1 report.duplicates_dropped;
+    Alcotest.(check string)
+      "session identity unchanged"
+      checkpoint.session_id
+      purged.Agent_sdk.Checkpoint.session_id;
+    Alcotest.(check int)
+      "turn watermark unchanged"
+      checkpoint.turn_count
+      purged.Agent_sdk.Checkpoint.turn_count
+
+let () =
+  Alcotest.run
+    "keeper checkpoint purge"
+    [ ( "rules"
+      , [ Alcotest.test_case
+            "duplicate collapse keeps first and last"
+            `Quick
+            test_duplicate_collapse_keeps_first_and_last
+        ; Alcotest.test_case
+            "duplicates below threshold survive"
+            `Quick
+            test_duplicates_below_threshold_survive
+        ; Alcotest.test_case
+            "tool cycles are never collapsed"
+            `Quick
+            test_duplicate_tool_cycles_are_never_collapsed
+        ; Alcotest.test_case "reasoning strip scope" `Quick test_reasoning_strip_scope
+        ; Alcotest.test_case
+            "reasoning inside a tool cycle is kept"
+            `Quick
+            test_reasoning_inside_tool_cycle_is_kept
+        ; Alcotest.test_case
+            "tool result clear preserves pairing"
+            `Quick
+            test_tool_result_clear_preserves_pairing
+        ] )
+    ; ( "boundaries"
+      , [ Alcotest.test_case
+            "protected tail is byte exact"
+            `Quick
+            test_protected_tail_is_byte_exact
+        ; Alcotest.test_case
+            "cycle overlapping the tail is untouched"
+            `Quick
+            test_cycle_overlapping_protected_tail_is_untouched
+        ; Alcotest.test_case "purge is idempotent" `Quick test_purge_is_idempotent
+        ; Alcotest.test_case
+            "broken structure is refused"
+            `Quick
+            test_broken_structure_is_refused
+        ; Alcotest.test_case
+            "config bounds are enforced"
+            `Quick
+            test_config_bounds_are_enforced
+        ; Alcotest.test_case
+            "checkpoint fields pass through"
+            `Quick
+            test_checkpoint_fields_pass_through
+        ] )
+    ]


### PR DESCRIPTION
## 왜

RFC-0351 S1(플릿 결정론 청소)은 지금까지 세션 scratchpad의 ad-hoc 스크립트로만 수행됐다 (analyst E2/E3: 1,315→579 msgs, −28.0% bytes, 다음 턴 input −26.0% — 어디에도 체크인 안 됨). sangsu는 #25532의 overflow livelock으로 keeper_down 상태이며, sanctioned 컴팩션은 eligible 0.1% 문제로 이 체크포인트를 줄일 수 없다. 복구 수단을 **타입 검증을 통과하는 체크인된 도구**로 만든다.

## 무엇

**`lib/keeper/keeper_checkpoint_purge`** (pure, LLM 무관, 12 테스트):

| 규칙 | 동작 | 보존 |
|---|---|---|
| R1 dup collapse | byte-identical text-only 메시지 3회+ → 첫/끝만 유지 | tool cycle 제외, 순서 보존 |
| R2 reasoning strip | ToolUse 없는 assistant의 unsigned `Thinking`/`ReasoningDetails` 제거 | signed thinking·`RedactedThinking`은 항상 보존 (byte-exact replay 계약) |
| R3 tool-result clear | closed cycle의 `ToolResult` content를 고정 마커로 교체 | `tool_use_id` 쌍·typed outcome 보존 |

- tool cycle은 `Keeper_compaction_unit.partition`의 closed unit 단위로 불가침. 마지막 `keep_recent_messages`(기본 20) + 구조적 protected suffix는 byte-exact 통과.
- 입력·출력 모두 `Keeper_compaction_unit.validate` — 깨진 입력은 수리하지 않고 거부 (#25443이 write boundary의 주인).
- 멱등 (테스트로 증명): 2회 적용 = 1회 적용.
- `session_id`/`turn_count` 불변 → `save_oas_classified`의 equal-watermark re-save로 착지.

**`bin/masc_checkpoint_purge`**: dry-run 기본, `--apply`는 byte-exact 백업 후 locked/validated 저장. keeper 정지 상태에서만 적용 (help에 명시).

## 실측 (sangsu, keeper_down 상태, dry-run)

```
messages: 885 -> 542
bytes (canonical): 645684 -> 229680 (-64.4%)
R1 duplicate messages dropped: 343   (autonomous wake marker ×347 그룹)
R2 reasoning blocks stripped: 325
R3 tool results cleared: 89
```

224KB ≈ GLM 실측 2.0 B/tok 기준 ~115K 토큰 — 관측된 최대 성공 input 137K 아래로 복귀.

## 참조 설계와의 수렴 (요청받은 교차 검토)

- **Claude Code** `microCompact`: 오래된 tool_result의 content-clear + 쌍 보존 + keep-recent-N — R3와 동일한 모양.
- **OpenClaw** `session-management-compaction.md`: chunk 경계를 tool call/result 쌍을 가르지 않게 이동, successor transcript가 "짧은 retry window의 exact duplicate user turn을 drop" — R1과 동일한 모양. `MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3`은 S0(#25536)의 임계값 3과 독립 수렴.
- **Hermes Agent**: 컨텍스트 방어(промptware 3 chokepoints)는 있으나 체크포인트 감량은 세션 회전 위주 — 직접 대응물 없음.

## 검증

- `test_keeper_checkpoint_purge` 12/12 green (규칙 범위, 쌍 보존, protected tail byte-exact, 멱등성, 깨진 구조 거부, config 경계, checkpoint 필드 통과).
- `dune build @check` PASS, DET/NDT gate PASS. fmt drift는 pre-existing dune 파일들만 (미포함).
- 검증 한계: `--apply` 경로는 저장 API(`save_oas_classified`)의 기존 계약(락·strict validate·watermark)에 의존하며 라이브 적용은 이 PR 머지와 별개로 오너 운영 절차로 수행.

RFC-0351 S1. Refs #25532, #25461.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
