### PR TITLE
fix(keeper): refuse reactive compaction prepare while retries are suspended (RFC-0351 S0)

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -72,6 +72,7 @@ type compaction_recovery_error =
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
+  | Retry_suspended of { consecutive_failures : int }
 
 let compaction_recovery_error_to_tag = function
   | Checkpoint_ref_load_failed Keeper_checkpoint_store.Ref_not_found ->
@@ -98,6 +99,7 @@ let compaction_recovery_error_to_tag = function
     Keeper_compact_policy.compaction_rejection_to_tag reason
   | No_compaction { reason; _ } ->
     "no_compaction:" ^ Keeper_event_queue_state.no_compaction_reason_label reason
+  | Retry_suspended _ -> "retry_suspended"
 
 let checkpoint_load_error_detail = function
   | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
@@ -189,6 +191,12 @@ let compaction_recovery_error_to_string = function
       source.turn_count
       source.sha256
       (Keeper_event_queue_state.no_compaction_reason_label reason)
+  | Retry_suspended { consecutive_failures } ->
+    Printf.sprintf
+      "compaction retry suspended after %d consecutive failures; reactive \
+       prepare refused before the summarizer call — an operator-committed \
+       manual compaction resets the streak and lifts the suspension"
+      consecutive_failures
 
 (* ── Tier A6: resilience post-turn wire-in (Cycle 23) ──────────────
    Feature-flag-gated layer that runs before tool emission and
@@ -513,7 +521,7 @@ type prepared_compaction =
   ; evidence : Keeper_compaction_evidence.t
   }
 
-let prepare_compaction
+let prepare_compaction_admitted
       ~base_dir
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
@@ -606,6 +614,34 @@ let prepare_compaction
             (Printf.sprintf
                "compaction recovery reached a non-preparation decision: %s"
                (Keeper_compact_policy.compaction_decision_to_string decision))))
+;;
+
+(* RFC-0351 S0 / #25461: reactive admission gate in front of the prepare
+   phase. Once the persisted failure streak reaches the escalation threshold
+   the settlement already refuses to retry, but each *new* stimulus still paid
+   one full prepare — checkpoint load plus a summarizer LLM call — before its
+   escalation settled. Refusing the reactive trigger here, before any I/O,
+   drops that residual burn to zero. The manual trigger passes through on
+   purpose: an operator-committed compaction is the recovery lever — its
+   commit resets the streak and lifts the suspension. *)
+let prepare_compaction
+      ~base_dir
+      ~(meta : keeper_meta)
+      ~(trigger : Compaction_trigger.t)
+      ~projection_request
+  : (prepared_compaction, compaction_recovery_error) result =
+  let suspended =
+    Keeper_meta_contract.compaction_retry_suspended meta.runtime.compaction_rt
+  in
+  match trigger with
+  | Compaction_trigger.Provider_overflow _ when suspended ->
+    Error
+      (Retry_suspended
+         { consecutive_failures =
+             meta.runtime.compaction_rt.consecutive_failures
+         })
+  | Compaction_trigger.Provider_overflow _ | Compaction_trigger.Manual ->
+    prepare_compaction_admitted ~base_dir ~meta ~trigger ~projection_request
 ;;
 
 let commit_prepared_compaction (prepared : prepared_compaction)

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -47,6 +47,15 @@ type compaction_recovery_error =
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
+  | Retry_suspended of { consecutive_failures : int }
+      (** RFC-0351 S0 / #25461: the keeper's compaction failure streak reached
+          [Keeper_meta_contract.compaction_retry_escalation_threshold], so a
+          reactive ([Provider_overflow]) prepare is refused before the
+          checkpoint load and the summarizer LLM call — the settlement's
+          per-stimulus escalation already stops the retries, and this gate
+          stops the one bounded LLM attempt each new stimulus still paid.
+          [Manual] prepares bypass the gate: an operator-committed compaction
+          resets the streak and lifts the suspension. *)
 
 val compaction_recovery_error_to_tag : compaction_recovery_error -> string
 val compaction_recovery_error_to_string : compaction_recovery_error -> string

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -113,7 +113,11 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Checkpoint_cas_failed _
     | Checkpoint_candidate_failed _
     | Compaction_rejected _
-    | No_compaction _ ->
+    | No_compaction _
+    (* Manual prepares bypass the suspension gate, so this surface cannot
+       observe [Retry_suspended] today; the arm keeps the classification
+       total if that routing ever changes. *)
+    | Retry_suspended _ ->
       Not_installed, `Bool false
   in
   let recovery_code =
@@ -127,6 +131,7 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Compaction_rejected Checkpoint_not_reduced
     | No_compaction _ ->
       Precondition_failed
+    | Retry_suspended _ -> Precondition_failed
     | Compaction_rejected Summarizer_unavailable
     | Compaction_rejected Plan_provider_unavailable
     | Compaction_rejected Invalid_compaction_plan

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -763,6 +763,92 @@ let test_malformed_structure_preserves_checkpoint () =
          | Ok _ -> fail "stale prepared value committed past the source CAS"))
 ;;
 
+(* RFC-0351 S0 / #25461: once the persisted failure streak suspends
+   compaction retries, a reactive prepare must be refused before any
+   checkpoint I/O — each new stimulus used to pay one full prepare
+   (checkpoint load + summarizer LLM call) before its escalation settled.
+   The fixture base_dir holds no checkpoint, so any prepare that passes the
+   gate deterministically fails with [Checkpoint_ref_load_failed Ref_not_found];
+   returning [Retry_suspended] instead proves the refusal fired first. *)
+let test_suspended_streak_refuses_reactive_prepare () =
+  Eio_main.run @@ fun _env ->
+  let meta_with_streak streak =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String "prepare-admission"
+          ; "trace_id", `String "trace-prepare-admission"
+          ; "compaction_consecutive_failures", `Int streak
+          ])
+    with
+    | Ok meta -> meta
+    | Error detail -> failf "prepare-admission meta fixture: %s" detail
+  in
+  let base_dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-prepare-admission-%d" (Unix.getpid ()))
+  in
+  let projection_request =
+    Projection_target.request
+      ~assignment_id:""
+      ~resolve_context_window:(fun _ ->
+        Projection_target.Resolved_context_window 1)
+  in
+  let prepare ~streak ~trigger =
+    Post_turn.prepare_compaction
+      ~base_dir
+      ~meta:(meta_with_streak streak)
+      ~trigger
+      ~projection_request
+  in
+  let suspended = meta_with_streak 3 in
+  check bool
+    "fixture streak reaches the suspension threshold"
+    true
+    (Masc.Keeper_meta_contract.compaction_retry_suspended
+       suspended.runtime.compaction_rt);
+  (match
+     prepare
+       ~streak:3
+       ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+   with
+   | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
+     check int "refusal reports the persisted streak" 3 consecutive_failures
+   | Error error ->
+     failf
+       "suspended reactive prepare reached I/O instead of the admission gate: \
+        %s"
+       (Post_turn.compaction_recovery_error_to_string error)
+   | Ok _ -> fail "suspended reactive prepare produced a prepared compaction");
+  (match prepare ~streak:3 ~trigger:Compaction_trigger.Manual with
+   | Error
+       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
+     ->
+     (* Reached the checkpoint load: the operator lever bypasses the gate. *)
+     ()
+   | Error error ->
+     failf
+       "suspended manual prepare did not reach the checkpoint load: %s"
+       (Post_turn.compaction_recovery_error_to_string error)
+   | Ok _ -> fail "manual prepare on an empty store produced a compaction");
+  match
+    prepare
+      ~streak:2
+      ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+  with
+  | Error
+      (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
+    ->
+    (* Below the threshold the reactive path is admitted unchanged. *)
+    ()
+  | Error error ->
+    failf
+      "below-threshold reactive prepare did not reach the checkpoint load: %s"
+      (Post_turn.compaction_recovery_error_to_string error)
+  | Ok _ -> fail "reactive prepare on an empty store produced a compaction"
+;;
+
 let () =
   run "post-turn durability" [
     "durable compaction", [
@@ -778,5 +864,7 @@ let () =
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "malformed structure preserves checkpoint"
         `Quick test_malformed_structure_preserves_checkpoint;
+      test_case "suspended streak refuses reactive prepare"
+        `Quick test_suspended_streak_refuses_reactive_prepare;
     ];
   ]


### PR DESCRIPTION
## 무엇이 남아 있었나

#25536의 상한은 settlement의 **재시도 결정**을 멈추지만, 새 stimulus가 도착할 때마다 escalation이 정산되기 **전에** prepare 1회 — checkpoint 로드 + summarizer LLM 호출 — 를 여전히 지불한다. wake cadence 기준으로 이 잔여 burn은 원 폭풍(#25461: 74분간 LLM 104회)과 같은 자릿수가 될 수 있다. 시나리오 매트릭스 적대 평가(파괴자 5 + 완결성 비평 + 시퀀싱 판정)가 이 슬라이스를 게이트-결정 지출로 최우선 배치했다.

## 수정

`prepare_compaction` 진입부(모든 I/O 이전)에 admission 게이트:

| trigger | suspended (streak ≥ 3) | 미만 |
|---|---|---|
| `Provider_overflow` (reactive) | **typed `Retry_suspended` 거부 — LLM 0회** | 기존과 동일 통과 |
| `Manual` (operator) | **의도적 통과** — commit 성공 시 streak 리셋 = suspension 해제 레버 | 동일 통과 |

- 거부는 양 lane의 기존 에러 라우팅을 그대로 타고 settlement의 threshold 분기(이미 escalate)에 착지 — **신규 settlement arm 없음**. 이벤트당 비용: LLM 1회 → **0회**.
- `Retry_suspended`가 `compaction_recovery_error`에 합류 (tag `retry_suspended` + 진단 문자열에 해제 방법 명시). 컴파일러가 지목한 소비처 2곳(`keeper_tool_surface`)에 명시 arm — manual 우회로 현재 도달 불가지만 totality 유지 (catch-all 아님).
- Manual 우회가 없으면 오퍼레이터의 `masc_keeper_compact`까지 거부되어 suspension이 meta 파일 수술 없이는 풀 수 없는 wedge가 됨 — 우회가 복구 경로의 일부다.

## 검증

- 신규 테스트 `suspended streak refuses reactive prepare`: checkpoint가 없는 base_dir에서 실행 — 게이트를 통과한 prepare는 그 환경에서 결정론적으로 `Checkpoint_ref_load_failed`가 되므로, `Retry_suspended` 반환 자체가 **checkpoint I/O 이전(따라서 summarizer 이전)에 거부됐다는 증명**. Manual/미만-threshold reactive는 checkpoint 로드까지 도달 확인.
- `dune build @check` PASS, DET/NDT gate 커밋 후 PASS.
- 스위트 잔여 1 실패("malformed structure preserves checkpoint")는 main 베이스라인 947c98b68f 동일 재현되는 로컬 한정 pre-existing (CI green) — 본 변경 무관.

검증 한계: suspended keeper에 wake가 실제로 매 cadence 도달하는 잔여 burn rate는 라이브 실측 미수행 (적대 평가의 hidden_prereq로 기록됨) — 이 게이트는 rate와 무관하게 상한을 0으로 만든다.

## 맥락

goal `s0-storm-terminal-closure`의 첫 슬라이스. 다음: floor typed terminal (#25538 — generation 비교는 적대 평가에서 기각, streak 리셋 의미론 교체로 대체 예정).

RFC-WAIVED: 게이트 대상 subsystem 미접촉 — keeper compaction 경로의 admission 게이트이며 RFC-0351 S0 (#25461) 명시 범위.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
