### PR TITLE
fix(keeper): count overflow episodes, not commit resets — Compaction_floor_exceeded typed terminal (RFC-0351 S0)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -305,8 +305,30 @@ let settlement_of_failure ~settled_at ~compaction_consecutive_failures failure =
     Keeper_registry_event_queue.Ack
   | Keeper_unified_turn.Requeue_after_context_compaction
       Keeper_unified_turn.Compaction_committed ->
-    Keeper_registry_event_queue.Requeue
-      Keeper_registry_event_queue.Context_compaction_retry
+    (* RFC-0351 S0 / #25538: a committed in-lane compaction is normally
+       progress — but the streak now counts overflow episodes and only an
+       overflow-free turn resets it, so reaching the ceiling *through
+       commits* proves the committed savings cannot bring the context under
+       the provider window (incompressible floor; measured: an LLM plan
+       committing 920B, 0.07%, looped forever under the old
+       reset-on-commit semantics). *)
+    if attempts >= Keeper_meta_contract.compaction_retry_escalation_threshold
+    then
+      Keeper_registry_event_queue.Escalate
+        { reason =
+            Keeper_registry_event_queue.Compaction_floor_exceeded
+              { attempts
+              ; detail =
+                  "compactions keep committing but the context re-overflows \
+                   on consecutive attempts; the committed savings cannot \
+                   bring the context under the provider window — retry \
+                   suspended pending operator inspection"
+              }
+        ; successor = None
+        }
+    else
+      Keeper_registry_event_queue.Requeue
+        Keeper_registry_event_queue.Context_compaction_retry
   | Keeper_unified_turn.Requeue_after_context_compaction
       (Keeper_unified_turn.Compaction_attempt_failed _) ->
     if attempts >= Keeper_meta_contract.compaction_retry_escalation_threshold
@@ -477,16 +499,21 @@ let compaction_outcome_of_cycle_outcome = function
   | Some (Cycle.Failed { failure; _ }) ->
     (match failure.Keeper_unified_turn.source_lease_disposition with
      | Keeper_unified_turn.Requeue_after_context_compaction
-         Keeper_unified_turn.Compaction_committed -> Some `Committed
+         Keeper_unified_turn.Compaction_committed ->
+       (* #25538: an in-lane commit is still one provider-overflow episode.
+          Advancing (not resetting) the streak is what lets an
+          incompressible floor reach the ceiling; only an overflow-free
+          completed turn — or the operator's manual commit — resets. *)
+       Some `Overflow_episode_committed
      | Keeper_unified_turn.Requeue_after_context_compaction
          (Keeper_unified_turn.Compaction_attempt_failed _)
      | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
        Some `Failed
      | Keeper_unified_turn.Follow_failure_route
      | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> None)
+  | Some (Cycle.Completed _) -> Some `Recovered
   | Some
-      ( Cycle.Completed _
-      | Cycle.Cancelled _
+      ( Cycle.Cancelled _
       | Cycle.Skipped _
       | Cycle.Busy _
       | Cycle.Judgment_settled _
@@ -984,6 +1011,12 @@ let run_keepalive_unified_turn
           in
           match compaction_outcome with
           | None -> ()
+          | Some `Recovered
+            when meta_after_triage.runtime.compaction_rt.consecutive_failures
+                 = 0 ->
+            (* Streak already clear: skip the read-modify-write that every
+               healthy completed turn would otherwise pay. *)
+            ()
           | Some outcome ->
             (match
                Keeper_meta_store.persist_compaction_outcome

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -145,12 +145,17 @@ val settlement_of_failure :
 
 val compaction_outcome_of_cycle_outcome :
   Keeper_heartbeat_loop_cycle.cycle_outcome option ->
-  [ `Committed | `Failed ] option
+  [ `Committed | `Overflow_episode_committed | `Failed | `Recovered ] option
 (** Pure mapping from a settled cycle outcome to the compaction-streak stamp
     ([Keeper_meta_store.persist_compaction_outcome]). Manual-lane
     applied/failed outcomes and in-lane provider-overflow dispositions join
-    the same per-keeper streak; outcomes with no compaction involvement return
-    [None] and leave the streak untouched. *)
+    the same per-keeper streak. The streak counts consecutive
+    provider-overflow episodes (#25538): an in-lane commit maps to
+    [`Overflow_episode_committed] (advances the streak — committed savings
+    under an incompressible floor must still reach the ceiling), a completed
+    overflow-free turn maps to [`Recovered] (resets it), and only the
+    operator's manual commit maps to [`Committed] (count + reset).
+    Outcomes with no compaction involvement return [None]. *)
 
 val settlement_of_cycle_outcome :
   base_path:string ->

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -554,16 +554,25 @@ let persist_compaction_decision config ~keeper_name ~decision
     |> Result.map (fun () -> `Persisted)
 ;;
 
-(* RFC-0351 S0 / #25461: advance the consecutive-failure streak that the
-   heartbeat settlement reads to choose requeue-vs-escalate.  Same
-   read/stamp/merge shape as [persist_compaction_decision] so a concurrent CAS
-   re-applies the stamp instead of dropping it.
+(* RFC-0351 S0 / #25461, #25538: advance the streak that the heartbeat
+   settlement reads to choose requeue-vs-escalate.  Same read/stamp/merge
+   shape as [persist_compaction_decision] so a concurrent CAS re-applies the
+   stamp instead of dropping it.
 
-   [`Committed] also advances [count].  That field had no writer: it was
-   serialized to meta and rendered by the dashboard while nothing incremented
-   it, so a keeper whose compaction pipeline was committing normally still
-   reported compaction_count=0 — one keeper carried 88 committed
-   [context_compacted] runtime-manifest records against a meta reading 0. *)
+   Reset semantics (#25538): the streak counts consecutive provider-overflow
+   episodes, and only a turn that completes without overflow — or an
+   operator-committed manual compaction — resets it.  An in-lane (reactive)
+   commit advances the streak instead of resetting it: a committed plan that
+   saves 920B of a checkpoint (0.07%, live measurement) used to reset the
+   counter on every loop iteration, so an incompressible floor never reached
+   the ceiling.
+
+   [`Committed]/[`Overflow_episode_committed] also advance [count].  That
+   field had no writer: it was serialized to meta and rendered by the
+   dashboard while nothing incremented it, so a keeper whose compaction
+   pipeline was committing normally still reported compaction_count=0 — one
+   keeper carried 88 committed [context_compacted] runtime-manifest records
+   against a meta reading 0. *)
 let persist_compaction_outcome config ~keeper_name ~outcome
   : ([ `Persisted | `No_durable_meta ], string) result
   =
@@ -572,7 +581,13 @@ let persist_compaction_outcome config ~keeper_name ~outcome
       (fun rt ->
         match outcome with
         | `Committed -> { rt with count = rt.count + 1; consecutive_failures = 0 }
-        | `Failed -> { rt with consecutive_failures = rt.consecutive_failures + 1 })
+        | `Overflow_episode_committed ->
+          { rt with
+            count = rt.count + 1
+          ; consecutive_failures = rt.consecutive_failures + 1
+          }
+        | `Failed -> { rt with consecutive_failures = rt.consecutive_failures + 1 }
+        | `Recovered -> { rt with consecutive_failures = 0 })
       m
   in
   match read_meta config keeper_name with

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -254,10 +254,17 @@ val persist_compaction_decision :
 val persist_compaction_outcome :
   Workspace.config ->
   keeper_name:string ->
-  outcome:[ `Committed | `Failed ] ->
+  outcome:
+    [ `Committed | `Overflow_episode_committed | `Failed | `Recovered ] ->
   ([ `Persisted | `No_durable_meta ], string) result
 (** Advance the compaction outcome counters on [compaction_rt] using the same
     read/stamp/merge shape as {!persist_compaction_decision}.
+
+    [`Overflow_episode_committed] (an in-lane reactive commit) increments
+    [count] AND the streak — committed savings under an incompressible floor
+    must still count toward the ceiling (#25538). [`Recovered] (a turn
+    completed without provider overflow) resets the streak; callers skip the
+    write when the streak is already 0.
 
     [`Committed] increments [count] and resets [consecutive_failures] to 0;
     [`Failed] increments [consecutive_failures]. The streak is what

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -32,6 +32,10 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       { attempts : int
       ; detail : string
       }
+  | Compaction_floor_exceeded of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -31,6 +31,10 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       { attempts : int
       ; detail : string
       }
+  | Compaction_floor_exceeded of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -29,6 +29,10 @@ type escalation_reason = State.escalation_reason =
       { attempts : int
       ; detail : string
       }
+  | Compaction_floor_exceeded of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = State.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -34,6 +34,10 @@ type escalation_reason = Keeper_event_queue_state.escalation_reason =
       { attempts : int
       ; detail : string
       }
+  | Compaction_floor_exceeded of
+      { attempts : int
+      ; detail : string
+      }
 
 type no_compaction_reason = Keeper_event_queue_state.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -33,6 +33,17 @@ type escalation_reason =
        [compaction_retry_escalation_threshold] consecutive failures the
        settlement escalates instead, surfacing the blocker rather than
        re-firing. *)
+  | Compaction_floor_exceeded of
+      { attempts : int
+      ; detail : string
+      }
+    (* RFC-0351 S0 / #25538: consecutive provider-overflow episodes reached
+       the threshold even though compactions were committing — the committed
+       savings cannot bring the context under the provider window (an
+       incompressible floor; measured: an LLM plan committing 920B, 0.07% of
+       the checkpoint, reset the streak forever). Distinct from
+       [Compaction_retry_exhausted] so the operator can tell "compaction keeps
+       failing" from "compaction succeeds but cannot help". *)
 
 type no_compaction_reason =
   | No_eligible_history
@@ -79,7 +90,8 @@ let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
   | Failure_judgment_boundary_failed _
-  | Compaction_retry_exhausted _ -> false
+  | Compaction_retry_exhausted _
+  | Compaction_floor_exceeded _ -> false
 ;;
 
 type settlement =
@@ -384,6 +396,7 @@ let escalation_reason_label = function
   | Failure_judgment_external_input_requested _ ->
     "failure_judgment_external_input_requested"
   | Compaction_retry_exhausted _ -> "compaction_retry_exhausted"
+  | Compaction_floor_exceeded _ -> "compaction_floor_exceeded"
 ;;
 
 let escalation_reason_detail_to_yojson = function
@@ -396,6 +409,8 @@ let escalation_reason_detail_to_yojson = function
       ; "rationale", `String rationale
       ]
   | Compaction_retry_exhausted { attempts; detail } ->
+    `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
+  | Compaction_floor_exceeded { attempts; detail } ->
     `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
 ;;
 
@@ -463,6 +478,28 @@ let escalation_reason_of_wire ~label ~detail_json =
         fields
     in
     Ok (Compaction_retry_exhausted { attempts; detail })
+  | "compaction_floor_exceeded", `Assoc fields ->
+    let* () =
+      exact_reason_fields
+        ~context:"compaction_floor_exceeded"
+        [ "attempts"; "detail" ]
+        fields
+    in
+    let* attempts =
+      match List.assoc_opt "attempts" fields with
+      | Some (`Int value) when value > 0 -> Ok value
+      | Some (`Int _) ->
+        Error "compaction_floor_exceeded.attempts must be positive"
+      | Some _ -> Error "compaction_floor_exceeded.attempts must be an int"
+      | None -> Error "compaction_floor_exceeded.attempts is required"
+    in
+    let* detail =
+      required_nonempty_reason_string
+        ~context:"compaction_floor_exceeded"
+        "detail"
+        fields
+    in
+    Ok (Compaction_floor_exceeded { attempts; detail })
   | "failure_judgment_external_input_requested", `Assoc fields ->
     let* () =
       exact_reason_fields
@@ -670,6 +707,9 @@ let validate_settlement = function
   | Escalate { reason = Compaction_retry_exhausted _; successor = None } -> Ok ()
   | Escalate { reason = Compaction_retry_exhausted _; successor = Some _ } ->
     Error "compaction retry exhaustion must not enqueue a successor"
+  | Escalate { reason = Compaction_floor_exceeded _; successor = None } -> Ok ()
+  | Escalate { reason = Compaction_floor_exceeded _; successor = Some _ } ->
+    Error "compaction floor exhaustion must not enqueue a successor"
 ;;
 
 (* Pure receipt-vs-stimuli invariant. Kept in ONE place so the live settle

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -38,6 +38,16 @@ type escalation_reason =
           failures reach the escalation threshold.  A requeue is not an ack, so
           without this ceiling the same stimulus re-enters every heartbeat
           cycle. *)
+  | Compaction_floor_exceeded of
+      { attempts : int
+      ; detail : string
+      }
+      (** RFC-0351 S0 / #25538: consecutive provider-overflow episodes reached
+          the threshold even though compactions were committing — the
+          committed savings cannot bring the context under the provider
+          window (an incompressible floor).  Distinct from
+          [Compaction_retry_exhausted] so "compaction keeps failing" and
+          "compaction succeeds but cannot help" stay operator-distinguishable. *)
 
 type no_compaction_reason =
   | No_eligible_history

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1251,12 +1251,29 @@ let test_in_lane_compaction_streak_bounds_retries () =
     ~attempts:3
     "third in-lane recovery failure requeued instead of escalating"
     (settlement ~streak:2 attempt_failed);
-  (* A committed compaction is progress: the retry reloads a durably smaller
-     checkpoint and must never be replaced by exhaustion, whatever the prior
-     streak. *)
+  (* Below the ceiling a committed compaction requeues: the retry reloads a
+     durably smaller checkpoint. *)
   expect_compaction_requeue
-    "committed in-lane compaction was escalated despite durable progress"
-    (settlement ~streak:2 committed);
+    "committed in-lane compaction below the ceiling did not requeue"
+    (settlement ~streak:0 committed);
+  expect_compaction_requeue
+    "second committed episode below the ceiling did not requeue"
+    (settlement ~streak:1 committed);
+  (* #25538: at the ceiling a commit proves the floor — the savings keep
+     committing yet the context re-overflows every episode, so the settlement
+     escalates with the commit-distinguishing reason instead of looping. *)
+  (match settlement ~streak:2 committed with
+   | Masc.Keeper_registry_event_queue.Escalate
+       { reason =
+           Masc.Keeper_registry_event_queue.Compaction_floor_exceeded
+             { attempts; _ }
+       ; successor = None
+       } ->
+     Alcotest.(check int) "floor escalation reports the attempt count" 3 attempts
+   | _ ->
+     Alcotest.fail
+       "committed episode at the ceiling requeued instead of escalating as \
+        a floor");
   (* A terminal no-compaction below the ceiling keeps today's route (the
      judgment successor); at the ceiling the settlement replaces the route,
      because a context that cannot shrink re-overflows deterministically. *)
@@ -1303,14 +1320,21 @@ let test_compaction_outcome_mapping_covers_in_lane_dispositions () =
     let actual =
       match Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome outcome with
       | Some `Committed -> "committed"
+      | Some `Overflow_episode_committed -> "overflow_episode_committed"
       | Some `Failed -> "failed"
+      | Some `Recovered -> "recovered"
       | None -> "none"
     in
     Alcotest.(check string) label expected actual
   in
+  (* #25538: an in-lane commit is one provider-overflow episode — it advances
+     the streak instead of resetting it, so an incompressible floor whose
+     commits keep "succeeding" still reaches the ceiling. The old
+     reset-on-commit expectation was the blind spot (measured: a committed
+     920B/0.07% plan reset the streak forever). *)
   check
-    "in-lane committed compaction resets the streak"
-    "committed"
+    "in-lane committed compaction counts the overflow episode"
+    "overflow_episode_committed"
     (failed
        (Masc.Keeper_unified_turn.Requeue_after_context_compaction
           Masc.Keeper_unified_turn.Compaction_committed));
@@ -1336,8 +1360,8 @@ let test_compaction_outcome_mapping_covers_in_lane_dispositions () =
     "none"
     (failed Masc.Keeper_unified_turn.Acknowledge_after_in_turn_handling);
   check
-    "a completed cycle leaves the streak untouched"
-    "none"
+    "a completed overflow-free turn resets the streak"
+    "recovered"
     (Some (Masc.Keeper_heartbeat_loop_cycle.Completed meta));
   check "no outcome leaves the streak untouched" "none" None
 ;;


### PR DESCRIPTION
## S0 사각지대 (#25538): 성공이 무한 루프의 연료

streak 리셋이 "컴팩션 commit"에 걸려 있어, checkpoint를 provider 창 아래로 줄일 수 없는 keeper(incompressible floor)는 overflow → commit(실측: **920B, 0.07% 절약**) → 재-overflow를 무한 반복하며 매 "성공"이 카운터를 리셋했다 — #25536의 상한도, #25541의 suspended-skip도 영영 발화하지 않는 구조.

이슈 원안의 generation 비교 판별식은 적대 평가에서 **기각**됐다 (generation은 재수육 카운터라 한 생애 내 상수 → 건강한 keeper의 정상 재-overflow까지 오탐 wedge — [#25538 정정 코멘트](https://github.com/jeong-sik/masc/issues/25538#issuecomment-5035641361)). 수리는 신규 판별 필드 없이 **리셋 의미론 교체**.

## 새 의미론: streak = 연속 provider-overflow 에피소드

| 이벤트 | 이전 | 이후 |
|---|---|---|
| in-lane(reactive) commit | count+1, **streak 리셋** ← 사각지대 | `Overflow_episode_committed`: count+1, **streak+1** |
| overflow 없이 완료된 턴 | 불변 | `Recovered`: **streak 리셋** (streak 0이면 write 스킵 — 건강 턴 추가 I/O 없음) |
| Manual(오퍼레이터) commit | count+1, 리셋 | 불변 — #25541의 복구 레버 계약 유지 |
| 실패 | streak+1 | 불변 |

settlement: in-lane commit 디스포지션이 임계(3) 도달 시 신규 typed reason **`Compaction_floor_exceeded`**로 escalate — `Compaction_retry_exhausted`("컴팩션이 계속 실패")와 구별되는 "컴팩션이 성공해도 소용없음". 임계 미만 commit은 기존대로 requeue (더 작은 checkpoint 재로드).

**오탐 불가 논증**: 건강한 keeper는 에피소드 사이에 overflow 없는 완료 턴이 반드시 끼고 그때 리셋되므로, "commit → 수백 턴 생산 작업 → 재-overflow"는 streak 0에서 시작한다. 연속 3 에피소드에 무-overflow 턴이 하나도 없는 경우만 floor.

## 변경 범위

- `Compaction_floor_exceeded`를 escalation reason 3중 정의(state/persistence/registry)에 추가 — label, encode/decode(왕복), settle validation(successor 금지), external-input 술어. `Compaction_retry_exhausted`와 동형.
- `persist_compaction_outcome` outcome 4-arm으로 확장 (`Committed | `Overflow_episode_committed | `Failed | `Recovered).
- `compaction_outcome_of_cycle_outcome`: in-lane commit → episode, `Completed` → recovered.
- `settlement_of_failure`: committed 분기에 floor ceiling.

## 검증

- #25536의 reset-on-commit을 잠그던 guard 2건을 **의도적으로 반전** (구 기대가 사각지대 그 자체 — Read 도구 사건의 "drift-guard가 결함의 공범" 교훈 재적용) + floor escalate/Recovered 매핑 신규 케이스. 반전·신규 전부 green.
- `dune build @check` PASS, DET/NDT gate 커밋 후 PASS.
- 스위트 잔여 실패 2건(legacy WAL, malformed structure)은 main 베이스라인 `9184a31aca` 동일 재현 로컬 한정 pre-existing (CI green) — 무관.

검증 한계: 성공-루프 라이브 재현(tiny-savings commit 반복 하네스)은 미구축 — settlement/매핑/persist는 pure 단위로 증명했고, 라이브 발화는 keeper 재기동 후 S0 24h 관측(goal `keeper-restart-unblock-live-gate`)에서 확인된다. #25538 본문의 "L4 flush 라우팅" 꼬리는 S2 게이트 위반이라 배제 — floor-terminal keeper는 오퍼레이터 대기 wedge이며 해제 레버는 Manual commit(#25541) 또는 S1 purge 도구(#25537).

RFC-WAIVED: 게이트 대상 subsystem 미접촉 — RFC-0351 S0 (#25461, #25538) 명시 범위의 settlement 의미론 수리.

goal `s0-storm-terminal-closure`의 두 번째 슬라이스. Follows #25536, #25541.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
