### PR TITLE
fix(keeper): stop persisting the autonomous wake marker on skipped-wake turns (RFC-0351 S1)

### DIFF
--- a/docs/CHECKPOINT-PURGE-RUNBOOK.md
+++ b/docs/CHECKPOINT-PURGE-RUNBOOK.md
@@ -1,0 +1,84 @@
+# Checkpoint Purge Runbook (RFC-0351 S1)
+
+RFC-0351:105 requires the operational cleanup procedure (backup included) to
+be documented before S2. This runbook covers `masc-checkpoint-purge`
+(#25537): the deterministic offline reduction of a keeper's canonical OAS
+checkpoint. No LLM is involved at any step.
+
+## What the tool does
+
+Three closed rules, applied in this order (the order is a correctness
+property — R2 before R1 is what makes a single pass a fixpoint):
+
+| Rule | Action | Never touches |
+|---|---|---|
+| R2 reasoning strip | removes unsigned `Thinking`/`ReasoningDetails` blocks from assistant messages without `ToolUse` | signed thinking, `RedactedThinking` (byte-exact replay contract) |
+| R3 tool-result clear | replaces `ToolResult` content in closed tool cycles with a fixed marker | `tool_use_id` pairing, typed outcome |
+| R1 duplicate collapse | byte-identical text-only messages repeated 3+ times keep first and last occurrence | tool cycles, message order |
+
+The last 20 messages (and the structural protected suffix) pass through
+byte-exact. Input and output both run `Keeper_compaction_unit.validate`;
+a structurally broken checkpoint is refused, never repaired (#25443 owns
+the write boundary). `session_id`/`turn_count` are unchanged, so the save
+lands as an equal-watermark re-save through the locked validated store.
+
+## Procedure
+
+1. **Confirm the keeper is stopped.** `masc_keeper_list` — the keeper must
+   not be `active`/`keepalive_running`. A live keeper's next save overwrites
+   the purge. (`masc_keeper_down <name>` if needed; restart is an operator
+   decision.)
+2. **Dry-run first.** Always. The report shows per-rule counts and the byte
+   delta; a second dry-run after an apply must show all zeros (fixpoint).
+
+   ```sh
+   masc-checkpoint-purge --trace <trace-id> --base ~/me/.masc
+   ```
+3. **Apply.** The tool writes a byte-exact backup before saving:
+
+   ```sh
+   masc-checkpoint-purge --trace <trace-id> --base ~/me/.masc --apply
+   # backup: {base}/backups-checkpoint-purge-<trace>-<ts>Z/<trace>.json
+   ```
+4. **Verify fixpoint.** Re-run the dry-run; expect `+0.0%` and zero rule
+   counts.
+5. **Keep the backup** until the keeper has completed at least one healthy
+   turn after restart. Rollback is a plain file copy over the canonical
+   checkpoint (server stopped).
+
+## What the tool refuses (and what to do)
+
+`checkpoint failed structural validation` (e.g. `Overlapping_tool_cycle`)
+means the write boundary admitted a broken history (#25443). Do not
+hand-edit the JSON and do not extend the tool to repair it — repair-on-read
+is the workaround class this system rejects. Record the trace and error in
+#25443 and leave the file untouched; such keepers likely cannot save new
+checkpoints under strict validation and need the #25443 fix, not a purge.
+
+## Fleet log
+
+| Date (UTC) | Trace / keeper | Result | Backup |
+|---|---|---|---|
+| 2026-07-21 | sangsu | 885→313 msgs, 631KB→202KB (−68%, two passes: pre-fixpoint binary then final) | `backups-checkpoint-purge-trace-1780648779957-00000-20260721T133717Z`, `…T134005Z` |
+| 2026-07-21 | taskmaster | −35.4% (1.0MB→650KB) | `…T155445Z` set |
+| 2026-07-21 | nick0cave | −42.0% (1.1MB→630KB) | 〃 |
+| 2026-07-21 | analyst | 1730→789 msgs, −38.6% | 〃 |
+| 2026-07-21 | ramarama | 824→434 msgs, −48.0% | 〃 |
+| 2026-07-21 | verifier | −27.1% | 〃 |
+| 2026-07-21 | base | −28.6% | 〃 |
+| 2026-07-21 | hitl-verifier | −4.1% | 〃 |
+| 2026-07-21 | executor, idealist, garnet, rondo, albini | **refused** — `Overlapping_tool_cycle` (recorded in #25443) | untouched |
+| 2026-07-21 | mad-improver (−48% available), issue_king, hitl-switch-verifier | skipped — keeper active at rollout time | — |
+
+Known open item: user-block base64 images are outside R1–R3 (garnet carries
+2.46MB of PNG payload, 77% of its checkpoint — #25542); an image rule needs
+a decision before it is added.
+
+## Relation to the sanctioned pipeline
+
+This tool is a one-shot operational lever, not a runtime mechanism: the
+runtime path stays compaction (until RFC-0351 S4 retires it) plus the S0
+settlement ceilings (#25536, #25541, #25544). If a purge is needed twice on
+the same keeper, that is a signal the inflow paths (#25462 wake markers,
+oversized tool results) are not closed — fix the inflow, do not schedule
+the purge.

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -49,10 +49,32 @@ let emit_wire_capture_response_suppressed_metrics ~keeper_name reasons =
     reasons
 ;;
 
+(* RFC-0351 S1 / #25462: a [Skip_uninformative_wake] turn records nothing in
+   the MASC-side stores (#25515), but the OAS run still receives the wake
+   marker as its goal and appends it to the transcript as a user message —
+   so every completed bare wake persisted one more byte-identical marker
+   into the checkpoint (343 measured in one keeper before the offline
+   purge). The typed turn record gates the drop; the exact sentinel
+   equality is a defence against the record ever being paired with a
+   different user message, not a classifier. *)
+let drop_leading_wake_marker ~user_turn_record current_suffix =
+  match user_turn_record, current_suffix with
+  | ( Keeper_run_prompt.Skip_uninformative_wake
+    , ({ Agent_sdk.Types.role = Agent_sdk.Types.User
+       ; content = [ Agent_sdk.Types.Text text ]
+       ; _
+       }
+       :: rest) )
+    when String.equal text Keeper_unified_prompt.autonomous_wake_marker -> rest
+  | (Keeper_run_prompt.Skip_uninformative_wake | Keeper_run_prompt.Record_user_turn), _
+    -> current_suffix
+;;
+
 let canonical_success_replay_checkpoint
       ~(history_messages : Agent_sdk.Types.message list)
       ~(session_id : string)
       ~(response_text : string)
+      ~(user_turn_record : Keeper_run_prompt.user_turn_record)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match
@@ -62,6 +84,9 @@ let canonical_success_replay_checkpoint
   with
   | Ok current_suffix ->
     let dropped_current_turn_replay = current_suffix <> [] in
+    let current_suffix =
+      drop_leading_wake_marker ~user_turn_record current_suffix
+    in
     let checkpoint =
       if String.trim response_text = ""
       then
@@ -71,15 +96,16 @@ let canonical_success_replay_checkpoint
         ; working_context = None
         }
       else
+        let base_messages = history_messages @ current_suffix in
         let messages =
           if
             List.exists
               (fun (msg : Agent_sdk.Types.message) ->
                  msg.role = Agent_sdk.Types.Assistant)
               current_suffix
-          then checkpoint.Agent_sdk.Checkpoint.messages
+          then base_messages
           else
-            checkpoint.Agent_sdk.Checkpoint.messages
+            base_messages
             @
             [ Agent_sdk.Types.make_message
                 ~role:Agent_sdk.Types.Assistant
@@ -130,6 +156,7 @@ let checkpoint_for_replay_persistence
       ~(session_id : string)
       ~(response_text : string)
       ?(stop_reason = Runtime_agent.Completed)
+      ?(user_turn_record = Keeper_run_prompt.Record_user_turn)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match stop_reason with
@@ -166,6 +193,7 @@ let checkpoint_for_replay_persistence
       ~history_messages
       ~session_id
       ~response_text
+      ~user_turn_record
       checkpoint
 ;;
 
@@ -268,6 +296,7 @@ let finalize
             (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~response_text
           ~stop_reason:result.stop_reason
+          ~user_turn_record
           checkpoint
       in
       (match checkpoint_for_save_result with

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -385,6 +385,119 @@ let test_media_degraded_projection_persists_canonical_checkpoint () =
         (persisted.messages = canonical_history @ [ current_assistant ]))
 ;;
 
+(* RFC-0351 S1 / #25462: a completed bare-wake turn must not persist the
+   autonomous wake marker the OAS run received as its goal — that was the
+   last accumulation path after #25515 (343 byte-identical markers measured
+   in one checkpoint). The typed [Skip_uninformative_wake] record gates the
+   drop; an identical-looking user message under [Record_user_turn] must
+   survive. *)
+let wake_marker_text = Masc.Keeper_unified_prompt.autonomous_wake_marker
+
+let wake_persistence ~user_turn_record ~response_text messages =
+  Finalize.checkpoint_for_replay_persistence
+    ~history_messages:
+      Agent_sdk.Types.
+        [ { role = User
+          ; content = [ Text "seed" ]
+          ; name = None
+          ; tool_call_id = None
+          ; metadata = []
+          }
+        ]
+    ~pre_turn_working_context:None
+    ~completion_contract_result:Receipt.Completion_no_visible_output
+    ~session_id:"new-session"
+    ~response_text
+    ~user_turn_record
+    (checkpoint messages)
+;;
+
+let history_seed = [ message Agent_sdk.Types.User [ Agent_sdk.Types.Text "seed" ] ]
+
+let test_skipped_wake_marker_is_not_persisted () =
+  let open Agent_sdk.Types in
+  let suffix =
+    [ message User [ Text wake_marker_text ]
+    ; message Assistant [ Text "observed, nothing to do" ]
+    ]
+  in
+  let patched, _ =
+    wake_persistence
+      ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+      ~response_text:"observed, nothing to do"
+      (history_seed @ suffix)
+    |> expect_ok
+  in
+  Alcotest.(check int)
+    "marker dropped, assistant reply retained"
+    2
+    (List.length patched.messages);
+  Alcotest.(check bool)
+    "no message carries the wake marker"
+    false
+    (List.exists
+       (fun (m : message) -> m.content = [ Text wake_marker_text ])
+       patched.messages)
+;;
+
+let test_recorded_turn_keeps_identical_marker_text () =
+  let open Agent_sdk.Types in
+  let suffix =
+    [ message User [ Text wake_marker_text ]
+    ; message Assistant [ Text "reply" ]
+    ]
+  in
+  let patched, _ =
+    wake_persistence
+      ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
+      ~response_text:"reply"
+      (history_seed @ suffix)
+    |> expect_ok
+  in
+  Alcotest.(check int)
+    "recorded turn persists the user message even with marker text"
+    3
+    (List.length patched.messages)
+;;
+
+let test_skipped_wake_leaves_non_marker_suffix_untouched () =
+  let open Agent_sdk.Types in
+  let suffix =
+    [ message User [ Text "an actual user question" ]
+    ; message Assistant [ Text "reply" ]
+    ]
+  in
+  let patched, _ =
+    wake_persistence
+      ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+      ~response_text:"reply"
+      (history_seed @ suffix)
+    |> expect_ok
+  in
+  Alcotest.(check int)
+    "a non-marker leading user message survives the skip record"
+    3
+    (List.length patched.messages)
+;;
+
+let test_skipped_wake_blank_response_still_drops_whole_suffix () =
+  let open Agent_sdk.Types in
+  let suffix =
+    [ message User [ Text wake_marker_text ]; message Assistant [ Text "" ] ]
+  in
+  let patched, _ =
+    wake_persistence
+      ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+      ~response_text:""
+      (history_seed @ suffix)
+    |> expect_ok
+  in
+  Alcotest.(check int)
+    "blank canonicalization keeps only the pre-turn history"
+    1
+    (List.length patched.messages)
+;;
+
 let () =
   Alcotest.run
     "keeper replay checkpoint"
@@ -421,6 +534,22 @@ let () =
             "media-degraded projection persists canonical checkpoint"
             `Quick
             test_media_degraded_projection_persists_canonical_checkpoint
+        ; Alcotest.test_case
+            "skipped wake marker is not persisted"
+            `Quick
+            test_skipped_wake_marker_is_not_persisted
+        ; Alcotest.test_case
+            "recorded turn keeps identical marker text"
+            `Quick
+            test_recorded_turn_keeps_identical_marker_text
+        ; Alcotest.test_case
+            "skipped wake leaves non-marker suffix untouched"
+            `Quick
+            test_skipped_wake_leaves_non_marker_suffix_untouched
+        ; Alcotest.test_case
+            "skipped wake blank response still drops whole suffix"
+            `Quick
+            test_skipped_wake_blank_response_still_drops_whole_suffix
         ] )
     ]
 ;;


### PR DESCRIPTION
## 마지막 축적 경로 (S1 게이트 "wake-marker 신규 유입 0"의 잔여 구멍)

#25515는 `Skip_uninformative_wake`가 MASC측 store 2개(history.jsonl, working context)를 스킵하게 했지만, OAS run은 여전히 wake marker를 goal로 받아 transcript에 user 메시지로 append한다 (`agent_input.ml` snoc). 완료된 bare wake마다 byte-identical marker가 checkpoint에 1개씩 영속 — **한 keeper에서 343개 실측** (#25537 purge R1이 제거). 이 경로를 닫지 않으면 플릿 purge 롤아웃이 재기동 후 첫 wake부터 재오염된다.

## 수정

`canonical_success_replay_checkpoint`(Completed 경로)가 finalize가 이미 들고 있는 typed `user_turn_record`를 받아, `Skip_uninformative_wake` 턴의 current-turn suffix에서 **선두 wake-marker user 메시지**를 제거한다.

- **이중 게이트**: typed record가 1차 (`Skip_uninformative_wake`일 때만), 정확 sentinel 동등성(`autonomous_wake_marker` 상수와 byte-equal + role=User + 단일 Text 블록)이 2차 — record가 다른 user 메시지와 짝지어지는 경우에 대한 방어이지 분류기가 아님. `Record_user_turn` 턴의 동일 텍스트 메시지는 생존 (테스트로 증명).
- `checkpoint_for_replay_persistence`는 `?user_turn_record` (기본 `Record_user_turn` — **보수 방향 기본값**: 명시 typed 신호에서만 제거).
- blank-response 정규화는 불변 (이미 suffix 전체 drop). InputRequired/Yielded checkpoint는 marker 유지 — 미완 턴의 재개 입력으로 필요하며, 잔존은 다음 Completed 턴에서 유한.

## 검증

- `test_keeper_replay_checkpoint` 12/12 green: 신규 4케이스(skip→marker 제거+assistant 유지 / recorded→동일 텍스트 생존 / skip+비marker 선두 user→불변 / skip+blank→기존 전체 drop) + **기존 8케이스 무수정 통과** (기본값이 구 계약 보존 증명).
- `dune build @check` PASS, DET/NDT gate 커밋 후 PASS.

검증 한계: 라이브 "신규 유입 0" 게이트는 keeper 재기동 후 24h 관측 (goal `keeper-restart-unblock-live-gate`) — 이 PR은 유일한 잔여 유입 경로의 코드 차단.

goal `s1-wake-marker-zero-fleet-purge`의 첫 슬라이스. 다음: 플릿 purge 롤아웃 + 운영 절차 문서화.

RFC-WAIVED: 게이트 대상 subsystem 미접촉 — RFC-0351 S1 (#25462) 명시 범위.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
