### PR TITLE
fix(keeper): approval wake settles on delivery, not consumption (RFC-0351 S0)

### DIFF
--- a/docs/rfc/RFC-keeper-conversation-hitl-flow.md
+++ b/docs/rfc/RFC-keeper-conversation-hitl-flow.md
@@ -1,7 +1,7 @@
 # RFC: Keeper conversation and non-blocking HITL
 
 - Status: Accepted
-- Updated: 2026-07-13
+- Updated: 2026-07-21 (approval-wake settlement: delivery, not consumption)
 
 Conversation, Gate request list, and request detail are projections of the same
 durable Gate journal. A deep link carries the opaque correlation id and exact
@@ -11,3 +11,28 @@ Pending HITL is shown as one request-local activity. The Keeper can continue
 other work, and unrelated Keepers remain active. Approve creates a one-shot
 grant and wakes only the origin lane. Reject/Edit stores typed rationale/input
 for the next LLM turn and does not grant execution.
+
+## Approval-wake settlement (2026-07-21 amendment, #25539)
+
+The approval wake's job is DELIVERY, not consumption. Whether the model spends
+the grant during the woken turn is the model's own non-deterministic decision
+and never a settlement condition.
+
+- A wake turn that completes settles as Ack regardless of grant state. The
+  original settlement requeued whenever the grant was still unconsumed, so a
+  keeper that kept doing other work re-fired on every heartbeat cycle —
+  measured: 8,349 requeue receipts across 8 keepers over ~42h, one grant
+  spinning 657 times. The same applies when the grant store cannot be read at
+  settlement time: the grant is durable either way and the completed turn is
+  the settlement authority.
+- A wake turn that does not complete (busy, cancelled, failed, skipped)
+  follows its ordinary typed settlement, so delivery itself is retried.
+- Ack does not spend or expire the authorization. The one-shot grant remains
+  durably spendable in the approval store, observable via
+  `approved_resolution_state` and the resolved surface; a later attempt whose
+  keeper, opaque operation identity, and canonical input match still consumes
+  it exactly once. An authorization the keeper never re-attempts stays
+  recorded rather than silently vanishing.
+- Retry ceilings or time-based cooldowns on the wake are rejected shapes for
+  this boundary: the root cause was the settlement condition (consumption)
+  belonging to the model, not an unbounded-retry defect in the queue.

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -379,29 +379,52 @@ let settlement_of_cycle_outcome
       ~lease
       outcome
   =
-  match single_approved_resolution lease with
-  | Some resolution ->
+  match single_approved_resolution lease, outcome with
+  | Some resolution, Some (Cycle.Completed _) ->
+    (* RFC-0351 S0 / #25539: the approval wake's job is DELIVERY, not
+       consumption. The old settlement requeued a completed turn whenever the
+       grant was still unconsumed — but whether the model spends the grant is
+       its own (non-deterministic) decision, so keepers that kept doing other
+       work re-fired on every heartbeat cycle: 8,349 requeue receipts across
+       8 keepers over ~42h, one idealist grant alone spinning 657 times. A
+       completed turn settles as Ack regardless of grant state. This does not
+       lose the operator's authorization: the grant remains durably spendable
+       in the approval store ([approved_resolution_state] observes it) and
+       visible on the resolved surface; a later matching attempt still
+       consumes it. *)
     (match
        Keeper_approval_queue.approved_resolution_state
          ~base_path
          ~id:resolution.approval_id
      with
-     | Ok Keeper_approval_queue.Resolution_consumed ->
-       (* The durable authorization was spent before the external effect. The
-          wake has completed its only job even if the later tool/cycle result
-          failed; replay must never recreate the grant. *)
-       Keeper_registry_event_queue.Ack
+     | Ok Keeper_approval_queue.Resolution_consumed -> ()
      | Ok Keeper_approval_queue.Resolution_unconsumed ->
-       Keeper_registry_event_queue.Requeue
-         Keeper_registry_event_queue.Approval_grant_unconsumed
+       Log.Keeper.warn
+         "approval grant delivered but not consumed this turn approval=%s \
+          keeper turn completed; grant remains durably spendable"
+         resolution.approval_id
      | Error error ->
        Log.Keeper.error
-         "approval resolution state unavailable approval=%s: %s"
+         "approval resolution state unavailable approval=%s: %s (grant \
+          remains durable; settlement follows the completed turn)"
          resolution.approval_id
-         (Keeper_approval_queue.grant_error_to_string error);
-       Keeper_registry_event_queue.Requeue
-         Keeper_registry_event_queue.Approval_grant_state_unavailable)
-  | None ->
+         (Keeper_approval_queue.grant_error_to_string error));
+    Keeper_registry_event_queue.Ack
+  | ( Some _
+    , ( Some
+          ( Cycle.Cancelled _
+          | Cycle.Skipped _
+          | Cycle.Busy _
+          | Cycle.Failed _
+          | Cycle.Judgment_settled _
+          | Cycle.Manual_compaction_applied _
+          | Cycle.Manual_compaction_failed _
+          | Cycle.Manual_compaction_not_applied _ )
+      | None ) )
+  (* A turn that did not complete has not delivered the wake; fall through to
+     the ordinary outcome settlement below (busy/cancelled/failed requeue
+     along their usual typed routes and the stimulus re-enters). *)
+  | None, _ ->
     (match outcome with
   | Some (Cycle.Manual_compaction_applied _ as applied) ->
     (match Cycle.manual_compaction_followup_failure applied with

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -14,6 +14,11 @@ type requeue_reason =
   | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
+    (* The two approval arms are no longer produced: the approval-wake
+       settlement follows the completed turn since the 2026-07-21
+       delivery-not-consumption amendment (#25539, RFC
+       keeper-conversation-hitl-flow). Kept for decoding persisted
+       receipts/WAL rows written before the amendment. *)
 
 type escalation_reason =
   | Failure_judgment_requested

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1458,6 +1458,126 @@ let with_temp_dir prefix f =
   Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
 ;;
 
+(* RFC-0351 S0 / #25539: the approval wake's job is delivery, not
+   consumption. A completed turn settles as Ack even while the grant is
+   durably unconsumed (8,349 requeue receipts measured across 8 keepers;
+   one idealist grant spun 657 times) — and the grant-store-unavailable
+   path, the second unbounded loop, also follows the completed turn. A
+   turn that did not complete keeps its ordinary typed settlement, so
+   delivery is still retried. *)
+let test_approved_wake_settles_on_delivery_not_consumption () =
+  with_temp_dir "approval-delivery-ack" @@ fun base_path ->
+  ignore (Masc.Keeper_approval_queue.install_persistence ~base_path);
+  let approval_id =
+    match
+      Masc.Keeper_approval_queue.submit_pending
+        ~keeper_name:"queue-outcome"
+        ~tool_name:"external-effect"
+        ~input:(`Assoc [ "op", `String "delivery-ack-test" ])
+        ~base_path
+        ()
+    with
+    | Ok id -> id
+    | Error error ->
+      Alcotest.failf
+        "approval fixture submit: %s"
+        (Masc.Keeper_approval_queue.storage_error_to_string error)
+  in
+  (match
+     Masc.Keeper_approval_queue.resolve
+       ~base_path
+       ~id:approval_id
+       ~decision:Masc.Keeper_approval_queue.Decision.Approve
+   with
+   | Ok () -> ()
+   | Error error ->
+     Alcotest.failf
+       "approval fixture resolve: %s"
+       (Masc.Keeper_approval_queue.resolve_error_to_string error));
+  (match
+     Masc.Keeper_approval_queue.approved_resolution_state
+       ~base_path
+       ~id:approval_id
+   with
+   | Ok Masc.Keeper_approval_queue.Resolution_unconsumed -> ()
+   | Ok Masc.Keeper_approval_queue.Resolution_consumed ->
+     Alcotest.fail "fixture grant is unexpectedly consumed"
+   | Error error ->
+     Alcotest.failf
+       "fixture grant state: %s"
+       (Masc.Keeper_approval_queue.grant_error_to_string error));
+  let resolution : Queue.hitl_resolution =
+    { approval_id
+    ; decision = Queue.Hitl_approved
+    ; channel = Keeper_continuation_channel.unrouted "delivery ack test"
+    }
+  in
+  let lease =
+    lease_for
+      (stimulus
+         ~payload:(Queue.Hitl_resolved resolution)
+         (Queue.hitl_resolution_post_id resolution)
+         1.0)
+  in
+  let settlement ~base_path outcome =
+    Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
+      ~base_path
+      ~settled_at:4.0
+      ~stop_requested:false
+      ~compaction_consecutive_failures:0
+      ~lease
+      outcome
+  in
+  let meta = cycle_meta () in
+  (match
+     settlement ~base_path (Some (Masc.Keeper_heartbeat_loop_cycle.Completed meta))
+   with
+   | Masc.Keeper_registry_event_queue.Ack -> ()
+   | _ ->
+     Alcotest.fail
+       "completed turn with an unconsumed grant did not settle as Ack");
+  (* Grant survives the Ack: the operator's authorization is not consumed
+     by settlement and remains durably spendable. *)
+  (match
+     Masc.Keeper_approval_queue.approved_resolution_state
+       ~base_path
+       ~id:approval_id
+   with
+   | Ok Masc.Keeper_approval_queue.Resolution_unconsumed -> ()
+   | Ok Masc.Keeper_approval_queue.Resolution_consumed ->
+     Alcotest.fail "settlement consumed the grant"
+   | Error error ->
+     Alcotest.failf
+       "grant state after ack: %s"
+       (Masc.Keeper_approval_queue.grant_error_to_string error));
+  (* The second unbounded loop: a completed turn whose grant store cannot
+     be read must also follow the completed turn instead of requeuing. *)
+  (match
+     settlement
+       ~base_path:(Filename.concat base_path "missing-grant-store")
+       (Some (Masc.Keeper_heartbeat_loop_cycle.Completed meta))
+   with
+   | Masc.Keeper_registry_event_queue.Ack -> ()
+   | _ ->
+     Alcotest.fail
+       "grant-store-unavailable completed turn did not settle as Ack");
+  (* An undelivered wake keeps re-entering: a busy cycle still requeues. *)
+  match
+    settlement
+      ~base_path
+      (Some
+         (Masc.Keeper_heartbeat_loop_cycle.Busy
+            { meta
+            ; block = Masc.Keeper_turn_admission.Turn_busy None
+            }))
+  with
+  | Masc.Keeper_registry_event_queue.Requeue
+      Masc.Keeper_registry_event_queue.Cycle_busy ->
+    ()
+  | _ -> Alcotest.fail "busy cycle released the undelivered approval wake"
+;;
+
+
 let keeper_dir ~base_path ~keeper_name =
   Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name
 ;;
@@ -2259,6 +2379,10 @@ let () =
             "compaction outcome mapping covers in-lane dispositions"
             `Quick
             test_compaction_outcome_mapping_covers_in_lane_dispositions
+        ; Alcotest.test_case
+            "approved wake settles on delivery not consumption"
+            `Quick
+            test_approved_wake_settles_on_delivery_not_consumption
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick


### PR DESCRIPTION
## 무엇이 고장이었나 (#25539 실측)

승인 wake의 정산이 **cycle outcome보다 grant 상태를 먼저** 봐서, 턴이 완료돼도 grant가 미소비면 `Requeue Approval_grant_unconsumed` — 상한 없음. grant 소비는 모델의 비결정론적 선택인데 그것을 정산 조건으로 삼은 것이 근본. grant-store 읽기 에러 arm(`Approval_grant_state_unavailable`)은 같은 모양의 제2 무한 루프.

**실측** (reaction-ledger v4, [#25539 코멘트](https://github.com/jeong-sik/masc/issues/25539#issuecomment-5035637159)): 8 keeper에서 **8,349건** 재큐 receipt, distinct grant 240개, ~42h, heartbeat cadence 33–95s. idealist는 **grant 1개가 657회** 스핀.

## 수정: delivery ≠ consumption

| lease + outcome | 이전 | 이후 |
|---|---|---|
| approved wake + `Completed` | grant 미소비면 무한 requeue | **Ack** (grant 상태 무관 — 미소비면 WARN 로그) |
| approved wake + `Completed`, grant store 읽기 에러 | 무한 requeue | **Ack** (ERROR 로그 — grant는 durable이라 정산 권위는 완료된 턴) |
| approved wake + busy/cancelled/failed/skipped | (도달 불가 — grant 검사가 선행) | **일반 typed 정산으로 fall-through** — delivery 자체는 재시도됨 |

**승인은 소멸하지 않습니다**: one-shot grant는 approval store에 durably spendable로 존속하고 (`approved_resolution_state` 문서: "remains **durably** unconsumed"), resolved 표면에 렌더되며, 이후 keeper/op-identity/canonical-input이 일치하는 시도가 정확히 1회 소비합니다. keeper가 영영 재시도하지 않는 승인은 사라지는 게 아니라 기록된 채 남습니다.

**counter/ceiling을 쓰지 않은 이유** (적대 평가 판정 반영): 컴팩션 lane(#25536/#25544)과 달리 여기의 근본은 큐의 무한 재시도 결함이 아니라 **모델 소유의 조건을 정산 조건으로 오배치**한 것 — cap은 워크어라운드 시그니처이고 RFC-0351 S0의 counter 승인 범위(#25461 컴팩션)를 벗어남.

`Approval_grant_unconsumed`/`Approval_grant_state_unavailable`은 생산처가 사라지지만 **개정 이전에 영속된 receipt/WAL 디코드 호환**을 위해 variant를 유지 (주석 명시).

## RFC 개정 동반

`docs/rfc/RFC-keeper-conversation-hitl-flow.md`에 "Approval-wake settlement" 절 추가 — delivery vs consumption, grant durability, 기각된 형태(cap/cooldown) 명문화. (goal 성공 기준 "HITL RFC 개정 머지" 충족.)

## 검증

- 신규 테스트 (`approved wake settles on delivery not consumption`): **실제 approval store**(submit→approve)로 unconsumed grant를 만들고 — ① Completed → Ack + **정산 후에도 grant가 unconsumed로 존속함을 단언** ② grant-store 부재 base_path + Completed → Ack (제2 루프 폐쇄) ③ Busy → `Requeue Cycle_busy` (delivery 재시도 유지). 기존 FIFO 공정성 테스트는 큐-레벨 계약이라 무수정 통과.
- `dune build @check` PASS, DET/NDT gate 커밋 후 PASS. 스위트 잔여 1 실패는 main 동일 재현 로컬 한정 pre-existing (legacy WAL).

검증 한계: TLA+ bug-model(정산 liveness invariant)은 fix 확정 후 regression guard로 별도 — 적대 평가가 "invariant는 fix 형태 확정 전 작성 불가"로 순서를 못박음. `Cycle.Judgment_settled`/`Manual_compaction_*` outcome과 approved lease의 조합은 fall-through(일반 정산)로 보수 처리했고 라이브에서 관측 시 재평가.

goal `s0-hitl-grant-settlement`. Refs #25539, #25488 인접(FSM sparse catch-all은 별도).

RFC-WAIVED: 게이트 대상 subsystem 미접촉 — event-queue 정산 의미론이며 동반 RFC(keeper-conversation-hitl-flow) 개정을 본 PR에 포함.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
