### PR TITLE
fix(dashboard): expose boot for dead paused keepers

### DIFF
--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -30,6 +30,9 @@ function makeKeeper(overrides: Partial<Keeper>): Keeper {
     status: 'active',
     phase: 'Running',
     paused: false,
+    // A keeper with its fiber alive is the normal case; tests that exercise
+    // the dead-paused boot path override this to false explicitly.
+    keepalive_running: true,
     ...overrides,
   } as unknown as Keeper
 }
@@ -96,6 +99,27 @@ describe('keeperActionVisibility', () => {
       const v = keeperActionVisibility(k)
       expect(v.canResume).toBe(true)
       expect(v.canWake).toBe(false)
+    })
+  })
+
+  describe('paused keeper whose fiber died (keepalive_running=false)', () => {
+    it('exposes boot instead of resume — resume needs a live owner_generation', () => {
+      const k = makeKeeper({ status: 'active', phase: 'Paused', paused: true, keepalive_running: false })
+      const v = keeperActionVisibility(k)
+      expect(v.canResume).toBe(false)
+      expect(v.canBoot).toBe(true)
+      expect(v.canPause).toBe(false)
+      expect(v.canShutdown).toBe(true)
+    })
+
+    it('still exposes boot when phase is null but the paused flag lingers', () => {
+      // Reproduces the live incident: paused directive persisted after the
+      // process died, phase never repopulated — resume errored with
+      // "current owner generation is unavailable" while boot stayed hidden.
+      const k = makeKeeper({ status: 'active', phase: null, paused: true, keepalive_running: false })
+      const v = keeperActionVisibility(k)
+      expect(v.canResume).toBe(false)
+      expect(v.canBoot).toBe(true)
     })
   })
 

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -14,6 +14,9 @@ function keeper(overrides: Partial<Keeper> = {}): Keeper {
   return {
     name: 'quiet-keeper',
     status: 'active',
+    // Live fiber is the normal case; tests that exercise the dead-paused
+    // boot path override this to false explicitly.
+    keepalive_running: true,
     ...overrides,
   }
 }

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -174,12 +174,19 @@ export function keeperActionVisibility(keeper: Keeper): KeeperActionVisibility {
   const isPaused = isKeeperPaused(keeper)
   const isOffline = isKeeperOffline(keeper)
   const isRunning = isKeeperRunningExcludingRestarting(keeper)
+  // A paused directive can outlive its process: the persisted `paused` flag
+  // stays set after the keeper fiber dies, but only a live fiber can be
+  // resumed — resume needs a live owner_generation as its fencing token, and
+  // a dead keeper has none. Treat paused-but-not-live as needing boot, so
+  // the boot verb surfaces for a dead paused keeper and resume stays hidden
+  // instead of returning "current owner generation is unavailable".
+  const live = keeper.keepalive_running === true
 
   return {
     canPause:    isRunning && !isPaused,
-    canResume:   isPaused,
+    canResume:   isPaused && live,
     canWake:     keeperCanWakeup(keeper),
-    canBoot:     isOffline,
+    canBoot:     isOffline || (isPaused && !live),
     canShutdown: isRunning || isPaused,
   }
 }


### PR DESCRIPTION
## Why

`keeperActionVisibility` treated any paused keeper as resumable (`canResume = isPaused`). A paused directive persists in meta after the keeper fiber dies, but resume needs a live `owner_generation` fencing token a dead keeper no longer has. Live incident: clicking resume on a paused keeper whose process had died returned `Cannot resume sangsu: current owner generation is unavailable`, while the boot verb stayed hidden because `canBoot = isOffline` and the backend had not repopulated phase as offline.

## Change

Gate resume on a live fiber and surface boot when paused-but-not-live, inside `keeperActionVisibility` only:

- `live = keeper.keepalive_running === true`
- `canResume = isPaused && live`
- `canBoot = isOffline || (isPaused && !live)`

Scope is the visibility predicate only. `isKeeperOffline` (consumed by 5 other surfaces: store-normalize, runtime-projection, operational-state, tool-audit, workspace-shared) is untouched to keep blast radius narrow.

`keepalive_running === true` (not `!== false`) is deliberate — an unknown signal does not default to live, so a deployment that fails to populate the field falls back to boot rather than silently re-enabling resume.

## Verification

- `pnpm typecheck` — pass
- `pnpm test` (full dashboard suite) — 8740/8741 pass. The single failure this surfaced was a `keeper-detail-alert-strip` paused case whose `keeper()` fixture omitted `keepalive_running`; fixed by defaulting that fixture factory to `keepalive_running: true` (live is the normal case; dead-paused tests override to `false`).
- New tests in `keeper-action-panel.test.ts`: a paused keeper with `keepalive_running: false` exposes `canBoot=true, canResume=false`, including a phase=null variant that reproduces the live incident exactly.

## Out of scope

- `dashboard/src/keeper-actions.ts:1008` has a pre-existing `no-nested-ternary` lint error. This PR does not touch that file; the error exists on `origin/main`.
- Backend phase model: this fix reads `keepalive_running`, which the backend already populates (`keeper-state.ts:816`, consumed by `live-store.ts:162`). A deployment that does not populate it leaves the dead-paused case falling back to resume.

## Manual verification not done

The fix is unit-tested at the predicate level only. Confirming the end-to-end "boot button appears for a dead paused keeper → POST /boot succeeds" path needs a running dashboard against a dead paused keeper, which I did not exercise here.
