### PR TITLE
refactor(keeper): drop dead provider-kind gate from memory-os path

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -531,13 +531,7 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
              "memory os librarian skipped runtime=%s: %s"
              runtime_id
              err
-         | Ok provider_cfg ->
-           if not (Keeper_memory_llm_summary.is_direct_completion_provider provider_cfg)
-           then
-             Log.Keeper.warn ~keeper_name:keeper_id
-               "memory os librarian skipped runtime=%s: provider does not support direct completion"
-               runtime_id
-           else (
+         | Ok provider_cfg -> (
              let clock = Eio_context.get_clock_opt () in
              match clock with
              | None ->

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -46,11 +46,6 @@ let runtime_lane_label =
 
 type complete_fn = Keeper_provider_subcall.complete_fn
 
-let is_direct_completion_provider
-    (provider_cfg : Llm_provider.Provider_config.t) : bool =
-  match provider_cfg.kind with
-  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
-
 let provider_for_summary (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
@@ -271,11 +266,7 @@ let make
                provider_runtime_id err;
              None
          | Ok provider ->
-             let providers =
-               [ provider ]
-               |> List.filter is_direct_completion_provider
-               |> List.filter summary_schema_supported
-             in
+             let providers = [ provider ] |> List.filter summary_schema_supported in
              if providers = [] then begin
                Log.Keeper.warn ~keeper_name:keeper_name
                  "memory LLM summary has no schema-capable direct completion providers runtime=%s"

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -4,9 +4,6 @@ val summary_max_tokens : int
 
 type complete_fn = Keeper_provider_subcall.complete_fn
 
-val is_direct_completion_provider :
-  Llm_provider.Provider_config.t -> bool
-
 val provider_for_summary :
   Llm_provider.Provider_config.t ->
   Llm_provider.Provider_config.t


### PR DESCRIPTION
## 목표

memory-os write 경로를 provider roster 에 묶어두던 dead gate 를 제거한다. 켈베로스 감사(#25551) 개선 P6 항목.

## 근거

`is_direct_completion_provider` (`keeper_memory_llm_summary.ml`) 는 `Provider_kind` 를 exhaustive match 하지만 **모든 arm 이 `true`** 였다.

```ocaml
match provider_cfg.kind with
| Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
```

따라서 두 호출처가 모두 inert 였다:

| 호출처 | 실제 동작 |
|---|---|
| `keeper_librarian_runtime.ml:535` | `if not (...) then warn else (...)` — 절대 타지 않는 분기 |
| `keeper_memory_llm_summary.ml:276` | `List.filter is_direct_completion_provider` — 아무것도 제거하지 않는 filter |

유일한 실효는 **compile coupling** 이었다. match 가 exhaustive 라 provider variant 를 추가하면 memory-os write 경로 안을 수정해야 했는데, memory-os 는 provider roster 에 이해관계가 없다.

## 변경

- `is_direct_completion_provider` 및 `.mli` 선언 제거
- librarian 가드 제거 (내부 `match` 의 arm 이 바깥 `match` 에 흡수되지 않도록 괄호 그룹은 유지)
- summary provider 목록은 `summary_schema_supported` 단일 필터만 남음 — 이쪽은 실제로 원소를 거른다

3 files, +2 / -19.

## 검증 (로컬)

| 항목 | 결과 |
|---|---|
| `dune build --root . lib` | 통과 |
| `test_keeper_librarian_retry` | 24 tests 통과 |
| `test_keeper_memory_summary_label_redaction` | 1 test 통과 |
| 제거된 warn 문자열 참조 | 저장소 전체 0건 (테스트 의존 없음) |
| 잔여 심볼 참조 | 0건 |

## 검증하지 못한 것

- 라이브 fleet 재현은 하지 않았다. 동작 변화가 없어야 하는 변경(제거된 분기는 도달 불가)이므로 근거는 정적 분석과 단위 테스트다.
- 감사가 함께 지적한 `supports_document_input` typed 필드 부재(P6 나머지)와 memory-bank summary 의 json_schema fan-out 필터(P4)는 이 PR 범위 밖이며 #25551 에 남겨두었다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서 어디에도 해당하지 않는 dead code 제거이며, 관측 가능한 동작 변화가 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
