### PR TITLE
fix(keeper): count provider parse rejections toward the crash threshold

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -686,14 +686,29 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.Internal _ -> false
 
+(* Invariant for this predicate: every class listed here is exempted from the
+   crash threshold ([Keeper_unified_turn_failure.record_failure_observation]
+   skips [increment_turn_failures] entirely), so each class must carry its own
+   compensating accounting. Without one, "not counted toward crash" means the
+   keeper retries the same failure forever with [consecutive] pinned at 0.
+
+   - transient network / runtime-exhausted: bounded by the runtime rotation and
+     exhaustion paths.
+   - context overflow: accounted at the point of detection by
+     [Keeper_turn_runtime_budget.record_overflow_failure], and its in-lane
+     compaction retries are bounded (#25536).
+
+   Provider parse rejections used to be listed here and had no such accounting.
+   A provider that keeps emitting a malformed stream (for example a tool_call
+   delta with a blank id, which the OAS SSE parser rejects) produced an
+   unbounded retry loop: 923 rejections across five keepers in 1h41m on
+   2026-07-21, each attempt costing up to 70s, with no escalation because the
+   counter never advanced. They are no longer exempt, so the ordinary
+   consecutive-failure threshold bounds them; an isolated malformed response
+   still costs nothing, because a later success resets the counter. *)
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   is_transient_network_error err
-  || is_server_rejected_parse_error err
   || is_auto_recoverable_runtime_exhausted_error err
-  (* Context overflow is handled explicitly by
-     [Keeper_turn_runtime_budget.record_overflow_failure] at the point of
-     detection rather than being duplicated in the ordinary turn-failure
-     observation stream. *)
   || is_context_overflow err
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1025,7 +1025,7 @@ let run_keeper_cycle
                      + String.length user_message)
                     latency_ms
                     (if is_server_parse_rejection
-                     then " (server parse rejection, auto-recoverable)"
+                     then " (server parse rejection, counts toward crash threshold)"
                      else if is_transient
                      then " (transient, cooldown preserved)"
                      else if EC.should_warn_keeper_cycle_failed err

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -74,6 +74,25 @@ let test_tls_handshake_internal_error_is_transient () =
     true
     (EC.is_auto_recoverable_turn_error err)
 
+(* A provider parse rejection stays a parse rejection, but it must not be
+   exempt from the crash threshold: the exemption skips [increment_turn_failures]
+   entirely, so a provider emitting a persistently malformed stream retried
+   forever with [consecutive] pinned at 0. *)
+let test_provider_parse_rejection_counts_toward_crash () =
+  let err =
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.ParseError
+         { detail = "sse: SSE parse failed: malformed_delta_tool_call" })
+  in
+  Alcotest.(check bool)
+    "provider parse rejection is still classified as a server parse rejection"
+    true
+    (EC.is_server_rejected_parse_error err);
+  Alcotest.(check bool)
+    "provider parse rejection is not exempt from the crash threshold"
+    false
+    (EC.is_auto_recoverable_turn_error err)
+
 let test_extra_system_context_preserves_typed_blocks () =
   let blocks =
     [ Prompt_block_id.Dynamic_context, "dynamic"
@@ -103,6 +122,8 @@ let () =
           test_raw_oas_api_timeout_preserves_typed_observation;
         Alcotest.test_case "TLS handshake internal error is transient" `Quick
           test_tls_handshake_internal_error_is_transient;
+        Alcotest.test_case "provider parse rejection counts toward crash" `Quick
+          test_provider_parse_rejection_counts_toward_crash;
         Alcotest.test_case "extra system context preserves typed blocks" `Quick
           test_extra_system_context_preserves_typed_blocks;
       ] );


### PR DESCRIPTION
## 목표

auto-recoverable 로 분류된 오류 부류 중 **보상 회계가 없는 유일한 부류**(provider parse rejection)를 제거해, 무한 재시도 좀비를 정상 crash threshold 로 되돌린다. #25551 후속.

## 근거 — 회계 비대칭

`keeper_unified_turn_failure.ml:13-26`

```ocaml
let counts_toward_crash = (not is_auto_recoverable) || EC.is_runtime_exhausted_error err in
if counts_toward_crash
then (Keeper_registry.increment_turn_failures ...; Health.record_failure ...)
else Log.Keeper.info "auto-recoverable turn failure (not counted toward crash threshold)"
```

auto-recoverable 이면 **카운터가 아예 증가하지 않는다**. 따라서 여기 나열된 모든 부류는 자기 회계를 가져야 한다.

| 부류 | 보상 회계 |
|---|---|
| transient network / runtime exhausted | rotation · exhaustion 경로가 bound |
| context overflow | 탐지 시점에 `record_overflow_failure` 로 회계, in-lane compaction 재시도는 #25536 이 bound |
| **provider parse rejection** | **없음** ← 무한 재시도 |

`is_server_rejected_parse_error` → `is_provider_rejected_parse_error` → `Agent_sdk.Error.Provider (ParseError _) -> true`.

## 라이브 정량 (`system_log_2026-07-21.jsonl`)

| | |
|---|---|
| SSE parse 거부 | **923건** |
| 범위 | 15:24:19Z → 17:05:45Z (**1시간 41분**, 약 분당 9건) |
| keeper | albini 78 · issue_king 74 · nick0cave 70 · base 38 · garnet 2 (+ system 661 = pipeline 레벨 중복) |
| 시도당 소요 | 최대 70초 (`turn_duration_sec=70.405`) |
| `consecutive` | 전 구간 **0** — escalate 없음 |

## 변경

- `is_auto_recoverable_turn_error` 에서 parse-rejection arm 제거. 남은 세 부류에는 각각 보상 회계가 있고, 그 사실을 주석으로 명시했다.
- cycle-failure 로그 접미사 `" (server parse rejection, auto-recoverable)"` → `" (server parse rejection, counts toward crash threshold)"`. 변경 후 전자는 거짓이 된다.
- **분류 자체는 그대로**다. OAS 파서가 빈 `id` 의 tool_call delta 를 거부하는 것은 정당하고(provider-agnostic typed 검증), `is_server_rejected_parse_error` 는 여전히 그 조건을 보고한다. 제거된 것은 **crash 면제**뿐이다.

## 동작 변화 (의도된 것, 오너 판단 필요)

parse 오류를 반복하는 keeper 는 이제 **연속 실패 임계값에서 escalate** 한다. 현재 5개 keeper 가 이 상태다. 단발 malformed 응답은 이후 성공이 카운터를 리셋하므로 비용이 없다.

무한 스핀보다 escalate 가 낫다는 판단이지만, 임계값 자체를 parse 오류에 더 관대하게 두는 선택지도 있다(별도 튜닝 사안). 그 경우 이 PR 대신 parse 전용 카운터 + 상한을 두는 형태가 된다.

## 검증 (로컬)

| 항목 | 결과 |
|---|---|
| `dune build --root . lib` | 통과 |
| `test_keeper_runtime_observation_boundaries` | 5 tests 통과 (신규 1건) |
| `test_keeper_sdk_error_typed_bridge` | 18 tests 통과 |
| `test_keeper_unified_context_overflow` | 2 tests 통과 |
| 변경한 로그 문구 의존 테스트 | 0건 |

신규 테스트: provider `ParseError` 가 (a) 여전히 server parse rejection 으로 분류되고 (b) crash 면제 대상이 **아님**을 고정.

## 검증하지 못한 것

- 라이브 fleet 에서의 escalate 동작은 미검증. 근거는 코드 경로와 단위 테스트다.
- raw delta 가 `index:0` 에 빈 id/name + arguments 만 담고 있는 원인(GLM 출력 quirk vs OAS streaming accumulator 상태)은 별개 조사 대상이며 이 PR 범위 밖이다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서 어디에도 해당하지 않는다. 오류 분류 회계의 대칭 복원이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
