### PR TITLE
test(ci): pin the keeper turn path as provider-agnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
             shell_ir=true
           fi
 
-          if has_match '^(lib/keeper/|scripts/keeper-cwd-leak-gate\.sh$|\.github/workflows/ci\.yml$)'; then
+          if has_match '^(lib/keeper/|scripts/keeper-cwd-leak-gate\.sh$|scripts/turn-path-provider-agnostic-gate\.sh$|\.github/workflows/ci\.yml$)'; then
             keeper_cwd=true
           fi
 
@@ -1071,6 +1071,15 @@ jobs:
       - name: Run keeper cwd leak gate
         if: needs.changes.outputs.keeper_cwd == 'true'
         run: scripts/keeper-cwd-leak-gate.sh
+
+      # Self-test first: a gate that cannot fail would pass silently forever.
+      - name: Run turn-path provider-agnostic gate self-test
+        if: needs.changes.outputs.keeper_cwd == 'true'
+        run: scripts/turn-path-provider-agnostic-gate.sh --self-test
+
+      - name: Run turn-path provider-agnostic gate
+        if: needs.changes.outputs.keeper_cwd == 'true'
+        run: scripts/turn-path-provider-agnostic-gate.sh
 
   shell-ir-ratchet:
     name: Shell IR Consumption Ratchet

--- a/scripts/turn-path-provider-agnostic-gate.sh
+++ b/scripts/turn-path-provider-agnostic-gate.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Keeper turn-path provider-agnostic gate.
+#
+# Rule: no provider or vendor name may appear in the keeper turn path.
+# The turn path decides what to send and how to recover; it must reach that
+# decision from typed values and spec numbers (max_context, budgets, typed
+# capability records), never from which vendor is on the other end.
+#
+# Background: the 2026-07-22 adversarial audit (masc#25550) applied one
+# question to every turn step — does this step need to know provider IDENTITY,
+# or does a spec number suffice? Every accusation against the masc turn path
+# was refuted: the path was already agnostic, and all identity reads lived at
+# the OAS serialization boundary, where they belong. That result is a property
+# worth keeping, not a snapshot. Serialization needs identity; deciding a turn
+# does not, and a single vendor branch here is how that separation erodes.
+#
+# The gate is deliberately a substring check rather than a typed-variant check.
+# A typed `Provider_config.Glm` match in this layer is exactly as much of a
+# violation as a "glm" string, and both carry the vendor name.
+#
+# Usage:
+#   scripts/turn-path-provider-agnostic-gate.sh              # check
+#   scripts/turn-path-provider-agnostic-gate.sh --self-test  # prove non-vacuous
+#
+# Exit codes:
+#   0  no vendor name in the turn path (or self-test passed)
+#   1  one or more hits (file:line printed for each), or self-test failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Vendor and provider names. Extend when a provider joins the roster — the
+# point is the name, not the spelling of any one vendor.
+#
+# Known limitation: this is a plain substring scan, so it reads comments as
+# well as code. That is mostly wanted — a comment naming a vendor in the turn
+# path usually marks logic nearby that depends on one. It also means the
+# pattern cannot include a name that appears in existing prose without the
+# gate failing on documentation. "claude" and "gpt-" are left out for exactly
+# that reason: keeper_agent_run.ml carries a comment about a past pricing
+# default that names them. If either ever appears in turn-path *logic*, the
+# typed-capability rule still applies, but this gate will not be what catches
+# it.
+VENDOR_PATTERN='glm|deepseek|kimi|anthropic|openai|gemini|ollama|minimax|mimo|qwen|dashscope|zai'
+
+# Turn-path surface. Globs, not a fixed file list, so a new file that joins the
+# turn path is covered the moment it is named like its siblings.
+TURN_PATH_GLOBS=(
+  'keeper_agent_run*.ml'
+  'keeper_run_prompt*.ml'
+  'keeper_run_context*.ml'
+  'keeper_unified_turn*.ml'
+  'keeper_turn_*.ml'
+  'keeper_post_turn*.ml'
+)
+
+collect_files() {
+  local root="$1"
+  local glob
+  for glob in "${TURN_PATH_GLOBS[@]}"; do
+    find "${root}/lib/keeper" -maxdepth 1 -name "${glob}" -type f 2>/dev/null || true
+  done
+}
+
+# bash 3.2 (the macOS default) has no `mapfile`, so the file list travels as a
+# NUL-delimited stream rather than an array.
+scan() {
+  local root="$1"
+  local list
+  list="$(collect_files "${root}" | sort -u)"
+  if [ -z "${list}" ]; then
+    echo "turn-path gate: no turn-path files found under ${root}/lib/keeper" >&2
+    echo "the globs no longer match anything, so the gate would pass vacuously" >&2
+    return 2
+  fi
+  printf '%s\n' "${list}" \
+    | tr '\n' '\0' \
+    | xargs -0 rg --ignore-case --line-number --with-filename "${VENDOR_PATTERN}" 2>/dev/null \
+    || true
+}
+
+self_test() {
+  # A gate that cannot fail is worth nothing. Plant a violation in a scratch
+  # copy of the surface and require the scan to report it.
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "${tmp}/lib/keeper"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks are
+  # OCaml polymorphic-variant syntax and must reach the file literally.
+  printf 'let route ~kind = match kind with Glm -> `Special | _ -> `Normal\n' \
+    >"${tmp}/lib/keeper/keeper_turn_selftest_fixture.ml"
+
+  local planted
+  planted="$(scan "${tmp}")"
+  if [ -z "${planted}" ]; then
+    rm -rf "${tmp}"
+    echo "turn-path gate self-test FAILED: planted violation was not detected" >&2
+    return 1
+  fi
+
+  # shellcheck disable=SC2016  # same: literal OCaml, no shell expansion wanted.
+  printf 'let route ~budget = if budget > 0 then `Normal else `Degrade\n' \
+    >"${tmp}/lib/keeper/keeper_turn_selftest_fixture.ml"
+  local clean
+  clean="$(scan "${tmp}")"
+  rm -rf "${tmp}"
+  if [ -n "${clean}" ]; then
+    echo "turn-path gate self-test FAILED: clean fixture reported a hit:" >&2
+    echo "${clean}" >&2
+    return 1
+  fi
+
+  echo "turn-path gate self-test passed (detects a planted vendor branch, ignores a clean one)"
+  return 0
+}
+
+main() {
+  if [ "${1:-}" = "--self-test" ]; then
+    self_test
+    return $?
+  fi
+
+  local hits
+  hits="$(scan "${REPO_ROOT}")"
+
+  if [ -n "${hits}" ]; then
+    echo "turn-path provider-agnostic gate: vendor name in the keeper turn path" >&2
+    echo "${hits}" >&2
+    echo >&2
+    echo "The turn path decides a turn from typed values and spec numbers." >&2
+    echo "If this step genuinely needs a per-provider fact, express it as a typed" >&2
+    echo "capability the provider config carries, and read that instead." >&2
+    echo "Serialization may know the vendor; deciding a turn may not." >&2
+    return 1
+  fi
+
+  local count
+  count="$(collect_files "${REPO_ROOT}" | sort -u | wc -l | tr -d ' ')"
+  echo "turn-path provider-agnostic gate: clean (${count} files scanned)"
+  return 0
+}
+
+main "$@"


### PR DESCRIPTION
## 목표

켈베로스 감사(#25550)의 **핵심 결론을 회귀 가드로 고정**한다 — masc keeper turn path 는 provider-agnostic 이며, provider identity 는 OAS 직렬화 경계에만 존재한다. 개선 P5.

## 왜 필요한가

감사는 turn 의 각 단계에 한 가지만 물었다: **"이 단계가 provider identity 를 알아야 하는가, 스펙 숫자로 충분한가?"** masc turn path 에 대한 고발은 **전부 REFUTED** 됐다 — 이미 typed 값과 스펙 숫자로만 턴을 결정하고 있었고, identity 참조는 전부 OAS 직렬화 경계(정당한 위치)에 있었다.

문제는 **그 성질을 지키는 장치가 없다**는 것이다. 여기에 vendor 분기 하나가 들어오면 그것이 다음 분기의 *합리적 선례*가 된다.

## 변경

`scripts/turn-path-provider-agnostic-gate.sh` 추가 + `keeper-cwd-leak-gate` 와 같은 CI job · 경로 필터에 배선.

- **대상 56파일**: `keeper_agent_run*` · `keeper_run_prompt*` · `keeper_run_context*` · `keeper_unified_turn*` · `keeper_turn_*` · `keeper_post_turn*`. 고정 목록이 아니라 **glob** 이라, 형제와 같은 이름으로 새 turn-path 파일이 생기면 즉시 포함된다.
- **오늘 실측**: 0 hits.
- 게이트는 substring 검사다 — 이 계층에서 typed `Provider_config.Glm` match 는 `"glm"` 문자열과 **똑같은 위반**이고, 둘 다 vendor 이름을 담는다.

## 비어있지 않음(non-vacuous) 증명

CI 는 스캔 **전에** self-test 를 돌린다. 실패할 수 없는 게이트는 영원히 조용히 통과하기 때문이다.

```
$ scripts/turn-path-provider-agnostic-gate.sh --self-test
turn-path gate self-test passed (detects a planted vendor branch, ignores a clean one)
```

self-test 는 scratch fixture 에 vendor 분기를 심어 **탐지를 요구**하고, 이어서 clean fixture 가 **아무것도 보고하지 않을 것을 요구**한다. 양방향이라 pattern 을 비워도 red 가 된다.

## 정직하게 밝히는 한계 (스크립트 안에 기재)

1. **substring 스캔이라 주석도 읽는다.** 대체로 의도한 바다 — turn path 의 주석이 vendor 를 부르면 대개 근처 로직이 그것에 의존한다는 신호다.
2. 그래서 **기존 산문에 등장하는 이름은 pattern 에 넣을 수 없다.** `claude` 와 `gpt-` 를 제외한 이유가 정확히 이것이다 — `keeper_agent_run.ml` 이 과거 pricing 기본값 사고를 설명하며 두 이름을 쓴다. 포함하면 로직이 아니라 **문서 때문에** CI 가 깨진다. 둘 중 하나가 turn-path *로직*에 등장하면 typed capability 규칙은 여전히 적용되지만, 그걸 잡는 것은 이 게이트가 아니다.

## 검증 (로컬)

| 항목 | 결과 |
|---|---|
| `--self-test` | 통과 (심은 위반 탐지 + clean fixture 무보고) |
| 실제 스캔 | `clean (56 files scanned)` |
| `shellcheck` | exit 0 (SC2016 2건은 사유 명시 후 억제 — 백틱은 OCaml variant 문법이라 리터럴 유지가 의도) |
| `actionlint` | 변경 라인에 지적 없음 (기존 SC2129 style 지적은 무관한 선행 항목) |
| YAML 파싱 | OK |

macOS bash 3.2 에 `mapfile` 이 없어 파일 목록은 NUL-구분 스트림으로 전달한다(로컬·CI 양쪽 동작).

## 검증하지 못한 것

- CI 에서의 실제 발화는 이 PR 의 CI 실행으로 확인된다(로컬에서는 스크립트 단위로만 검증).
- 게이트는 masc turn path 만 덮는다. OAS 쪽 identity 집중(감사 P2~P5)은 jeong-sik/masc#27872 에서 별도로 다룬다.

RFC-WAIVED: 테스트/CI 가드 추가이며 런타임 코드 변경이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
