### PR TITLE
docs: use a base-path placeholder in the checkpoint purge runbook

### DIFF
--- a/docs/CHECKPOINT-PURGE-RUNBOOK.md
+++ b/docs/CHECKPOINT-PURGE-RUNBOOK.md
@@ -32,12 +32,12 @@ lands as an equal-watermark re-save through the locked validated store.
    delta; a second dry-run after an apply must show all zeros (fixpoint).
 
    ```sh
-   masc-checkpoint-purge --trace <trace-id> --base ~/me/.masc
+   masc-checkpoint-purge --trace <trace-id> --base <base-path>/.masc
    ```
 3. **Apply.** The tool writes a byte-exact backup before saving:
 
    ```sh
-   masc-checkpoint-purge --trace <trace-id> --base ~/me/.masc --apply
+   masc-checkpoint-purge --trace <trace-id> --base <base-path>/.masc --apply
    # backup: {base}/backups-checkpoint-purge-<trace>-<ts>Z/<trace>.json
    ```
 4. **Verify fixpoint.** Re-run the dry-run; expect `+0.0%` and zero rule


### PR DESCRIPTION
## 목표

`main` 의 Lint red 를 해소한다. 현재 **열린 masc PR 전부**가 이 실패로 막혀 있다.

## 증상

```
ERROR[R6-home-masc-root]: 5 occurrences (baseline 3) — SSOT bypass grew.
  Replace with: <base-path>/.masc with explicit MASC_BASE_PATH or --base-path
```

`scripts/check-ssot.sh` 가 main 에서 exit 1 → `Lint` job 실패 → `CI Gate` 실패. 코드 변경과 무관한 PR 들도 함께 red 가 된다.

## 원인

`docs/CHECKPOINT-PURGE-RUNBOOK.md:35,40` 의 예시 명령 2줄이 `--base` 에 operator home 리터럴 경로를 넘긴다. R6 가 그 패턴을 세고, 3 → 5 로 늘어난 상태였다.

```sh
masc-checkpoint-purge --trace <trace-id> --base ~/me/.masc
masc-checkpoint-purge --trace <trace-id> --base ~/me/.masc --apply
```

## 왜 baseline 상향이 아니라 문서 수정인가

이 2줄은 **가이드로서도 틀렸다.** 같은 저장소의 두 문서가 정확히 이 형태를 금지한다:

- `docs/KEEPER-USER-MANUAL.md:828` — "bare `~/.masc` 는 operator home 의 `.masc` 로 해석될 수 있으므로 runbook 에서는 `<base-path>/.masc` 또는 fully resolved path 를 쓴다."
- `docs/BOOT-ENV-STATE-INVENTORY.md:397,430` — "do not shorten this to `~/.masc`, which means `/Users/dancer/.masc` in a shell."

runbook 이 자기가 어기고 있던 규칙을 따르도록 고쳤다. 남는 3건은 위 두 문서(규칙을 **가르치는** 문장들)이며 추적된 baseline 이다.

## 변경

2줄, `~/me/.masc` → `<base-path>/.masc`.

## 검증 (로컬)

```
$ bash scripts/check-ssot.sh
OK[R6-home-masc-root]: 3 occurrences (baseline 3).
...
exit 0
```

## 범위

문서 2줄만 건드렸다. baseline 을 올리지 않았고 checker 도 수정하지 않았다 — 규칙은 옳고 위반이 실제였다.

RFC-WAIVED: 문서 문자열 수정이며 코드·설정 변경이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
