### PR TITLE
refactor(runtime): reject unrecognised modalities instead of admitting them

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -457,12 +457,41 @@ let supported_modalities_of_capabilities
   @ (if caps.supports_multimodal_inputs then [ "document" ] else [])
   @ (if caps.supports_audio_input then [ "audio" ] else [])
 
+(* The modality a content block demands of a runtime. The producers
+   ([block_required_modality], [required_modalities_of_content_blocks]) match
+   exhaustively over [content_block], so the set is closed — it travels as a
+   string only because the capability count list and the public
+   [strip_unsupported_modality_blocks] surface are keyed by string. Parsing it
+   back here keeps the decision below exhaustive: the catch-all lives at the
+   parse boundary, not in the capability logic. *)
+type required_modality =
+  | Modality_text
+  | Modality_image
+  | Modality_document
+  | Modality_audio
+
+let required_modality_of_string = function
+  | "text" -> Some Modality_text
+  | "image" -> Some Modality_image
+  | "document" -> Some Modality_document
+  | "audio" -> Some Modality_audio
+  | _ -> None
+
+(* An unrecognised modality reports unsupported rather than supported. The
+   previous [_ -> true] was the permissive-default shape: a string the
+   producers never emit could only arrive through producer/consumer drift, and
+   answering "supported" would send a block the runtime cannot handle to the
+   provider. Answering "unsupported" routes it into the media reroute and
+   degrade paths that already exist, so the drift is visible. Unreachable
+   today — every producer emits one of the four above. *)
 let supports_required_modality
-    (caps : Llm_provider.Capabilities.capabilities) = function
-  | "image" -> caps.supports_image_input
-  | "document" -> caps.supports_multimodal_inputs
-  | "audio" -> caps.supports_audio_input
-  | _ -> true
+    (caps : Llm_provider.Capabilities.capabilities) modality =
+  match required_modality_of_string modality with
+  | Some Modality_text -> true
+  | Some Modality_image -> caps.supports_image_input
+  | Some Modality_document -> caps.supports_multimodal_inputs
+  | Some Modality_audio -> caps.supports_audio_input
+  | None -> false
 
 let supported_non_text_capability_count
     (caps : Llm_provider.Capabilities.capabilities) =

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -253,7 +253,24 @@ let test_caps_admit_required_modalities () =
        (caps ~image:true ())
        [ "image"; "audio" ]);
   check bool "empty required is always admitted" true
-    (Runtime_agent.For_testing.caps_admit_required_modalities (caps ()) [])
+    (Runtime_agent.For_testing.caps_admit_required_modalities (caps ()) []);
+  (* text is a modality every runtime carries, and it is the one string in
+     [supported_modalities_of_capabilities] that no content block demands. *)
+  check bool "text is admitted by a text-only runtime" true
+    (Runtime_agent.For_testing.caps_admit_required_modalities (caps ()) [ "text" ]);
+  (* An unrecognised modality reports unsupported, not supported. The producers
+     match exhaustively over content_block, so such a string can only arrive
+     through producer/consumer drift; answering "supported" there would hand a
+     block the runtime cannot process to the provider, while answering
+     "unsupported" routes it into the reroute and degrade paths. *)
+  check bool "unrecognised modality is not admitted" false
+    (Runtime_agent.For_testing.caps_admit_required_modalities
+       (caps ~image:true ~audio:true ())
+       [ "hologram" ]);
+  check bool "unrecognised modality is not masked by a supported sibling" false
+    (Runtime_agent.For_testing.caps_admit_required_modalities
+       (caps ~image:true ())
+       [ "image"; "hologram" ])
 
 (* RFC-0265 follow-up — graceful media degrade. [strip_unsupported_modality_blocks]
    drops the top-level image/audio/document blocks a text-only runtime cannot


### PR DESCRIPTION
## 목표

`supports_required_modality` 의 허용 기본값(`| _ -> true`)을 제거하고, 닫힌 modality 집합을 typed variant 로 파싱해 판정 로직을 exhaustive 하게 만든다. 켈베로스 감사(#25550) 개선 P6 의 masc 절반.

## 근거

```ocaml
let supports_required_modality caps = function
  | "image" -> caps.supports_image_input
  | "document" -> caps.supports_multimodal_inputs
  | "audio" -> caps.supports_audio_input
  | _ -> true          (* ← 모르는 modality = 지원함 *)
```

이 함수를 먹이는 생산자 두 곳(`block_required_modality`, `required_modalities_of_content_blocks`)은 `content_block` 을 **exhaustive match** 해서 `"image" | "document" | "audio"` 만 방출한다. 즉 집합은 닫혀 있고 `_` arm 은 도달 불가다 — 그것이 인코딩한 것은 **허용 기본값**이다.

그리고 이 함수는 (a) 런타임이 요청을 서빙할 수 있는지, (b) 어떤 블록을 strip 할지를 결정하는 경로에 있다. 네 번째 modality 가 생산자/소비자 드리프트로 도달했다면, "지원함" 이라는 답은 런타임이 처리 못 하는 블록을 provider 로 보낸다. "지원 안 함" 은 이미 존재하는 media reroute · degrade 경로로 보내므로 드리프트가 **드러난다**.

## 변경

```ocaml
type required_modality =
  | Modality_text | Modality_image | Modality_document | Modality_audio

let required_modality_of_string = function
  | "text" -> Some Modality_text
  | "image" -> Some Modality_image
  | "document" -> Some Modality_document
  | "audio" -> Some Modality_audio
  | _ -> None

let supports_required_modality caps modality =
  match required_modality_of_string modality with
  | Some Modality_text -> true
  | Some Modality_image -> caps.supports_image_input
  | Some Modality_document -> caps.supports_multimodal_inputs
  | Some Modality_audio -> caps.supports_audio_input
  | None -> false
```

catch-all 이 **파싱 경계**로 이동했다 — 거기서 모델링되지 않은 문자열은 *파싱 실패*이지, capability 로직 안의 *답변*이 아니다.

## 하지 않은 것

modality 는 여전히 string 으로 이동한다. capability count 리스트와 공개 `strip_unsupported_modality_blocks` 표면이 string 키이기 때문이다(`runtime_agent.mli:202`, `keeper_turn_driver.ml:468`, 테스트). variant 를 그쪽까지 관통시키는 것은 더 큰 변경이며 여기서 시도하지 않았다.

또한 `Modality_document` 는 아직 `supports_multimodal_inputs` 포괄 필드를 읽는다. 전용 `supports_document_input` 은 OAS 쪽(jeong-sik/oas#2755)이 머지되고 pin 이 올라간 뒤에 교체 가능하다.

## 동작 변화

**오늘 기준 없음.** 모든 생산자가 모델링된 네 값 중 하나만 방출한다. `"text"` 는 명시적으로 모델링했고 계속 admit 된다.

## 검증 (로컬)

| 항목 | 결과 |
|---|---|
| `dune build --root . lib` | 통과 |
| `test_runtime_modality_reroute` | **22 tests** 통과 (신규 단언 4건) |
| `test_keeper_turn_outcome` | 11 tests 통과 |
| `test_keeper_raw_trace_sink` | 10 tests 통과 |
| `test_keeper_turn_driver_failover` | 20 tests 통과 |
| `@fmt` | 변경 파일에 지적 없음 |

신규 단언은 `For_testing.caps_admit_required_modalities` 를 통해 공개 표면에서 검증한다:
- `"text"` 는 text-only 런타임에서 admit
- **모르는 modality 는 admit 되지 않음** ← 옛 `_ -> true` 로 되돌리면 red
- 지원되는 형제 modality 가 있어도 모르는 것이 가려지지 않음

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서 어디에도 해당하지 않는다. 허용 기본값 제거다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
