### PR TITLE
fix(scripts): restore OAS_AGENT_SDK_TRACK_REF removed by #25579 (#25584)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -62,5 +62,8 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.219.0"
 # reports the public-surface delta at pin-bump time.
 # Pinned to main (c8b355d2). Absorbs oas#2771 & oas#2772: release v0.220.4 with immutable resolver snapshot.
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.220.4"
+# Upstream ref the pin tracks. Consumed by check-oas-pin.sh (drift +
+# reachability guard), oas-drift-check.sh, and sync-oas-pin-docs.sh.
+readonly OAS_AGENT_SDK_TRACK_REF="main"
 readonly OAS_AGENT_SDK_SHA="c8b355d2ed99c73f939d2771826e5197399a81af"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.219.0"

--- a/scripts/sync-oas-pin-docs.sh
+++ b/scripts/sync-oas-pin-docs.sh
@@ -143,7 +143,7 @@ sync_readme_badge() {
 manual_doc="${REPO_ROOT}/docs/KEEPER-USER-MANUAL.md"
 
 printf -v manual_body '%s' \
-  "OAS pin metadata is generated from \`scripts/oas-agent-sdk-pin.sh\`. Current dependency floor: \`agent_sdk >= ${OAS_AGENT_SDK_MIN_VERSION}\`, runtime pin: \`${OAS_AGENT_SDK_TRACK_REF}@${OAS_AGENT_SDK_SHA}\`, declared base version: \`${OAS_AGENT_SDK_BASE_VERSION}\`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 \`dune-project\`와 pin script를 우선 truth source로 본다."
+  "OAS pin metadata is generated from \`scripts/oas-agent-sdk-pin.sh\`. Current dependency floor: \`agent_sdk >= ${OAS_AGENT_SDK_MIN_VERSION}\`, runtime pin: \`${OAS_AGENT_SDK_TRACK_REF}@${OAS_AGENT_SDK_SHA}\`, declared base version: \`v${OAS_AGENT_SDK_DECLARED_VERSION}\`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 \`dune-project\`와 pin script를 우선 truth source로 본다."
 
 replace_generated_block "${manual_doc}" "oas-pin-manual" <<<"${manual_body}"
 sync_readme_badge


### PR DESCRIPTION
## 문제 (#25584)

#25579 (3a2d4e7999) 가 pin script에서 `OAS_AGENT_SDK_TRACK_REF` 를 삭제했으나 소비자 3곳이 여전히 참조해 `set -u` 하에서 로컬 빌드 가드가 전부 abort:

- `scripts/check-oas-pin.sh` (drift 조회 + ref-reachability guard + verified 메시지)
- `scripts/oas-drift-check.sh` (fetch 대상 ref)
- `scripts/sync-oas-pin-docs.sh:146` (manual 생성 문구)

증상: `scripts/dune-local.sh build <target>` 실행 시 pin guard 단계에서 `OAS_AGENT_SDK_TRACK_REF: unbound variable` → abort. 리뷰 대응 작업들이 `MASC_SKIP_PIN_CHECK=1` 우회를 강제당함.

## 수정

1. `oas-agent-sdk-pin.sh`: `readonly OAS_AGENT_SDK_TRACK_REF="main"` 복원 (pin이 main을 track한다는 기존 계약 그대로).
2. `sync-oas-pin-docs.sh:146`: `declared base version` 슬롯이 floor 버전(`OAS_AGENT_SDK_BASE_VERSION=v0.219.0`)을 찍던 것을 `OAS_AGENT_SDK_DECLARED_VERSION` (0.220.4) 기반으로 수정 — 기존 생성 문서(`v0.220.4`)와 일치하므로 문서 diff는 0.

## 검증

- `bash scripts/sync-oas-pin-docs.sh` 재생성 → docs diff 0 (기존 `v0.220.4` 문구와 일치 확인)
- `bash scripts/sync-oas-pin-manifests.sh --check` → MANIFESTS-OK
- `bash scripts/check-oas-pin.sh --local-only` → `unbound variable` / TRACK_REF 에러 소멸 (로컬 opam pin drift 경고는 #25584와 무관한 기존 환경 이슈로 잔존)

Closes #25584