### PR TITLE
fix(keeper): #25585 후속 — Codex 리뷰 R2/R3 대응 (post-dispatch terminality, save-path backfill)

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -416,45 +416,60 @@ let prepare_lane ~keeper_name ~registry ~lane_id ~units =
         (Runtime_exact_output_registry.error_to_string error);
       Error Exact_target_selection_failed
     | Ok slot_ids ->
-      let selected_slots_result =
+      (* Optional failover credentials are intentionally not mandatory:
+         publication defers credential admission, so an unavailable slot must
+         not veto the resolvable ones. Selection fails only when no slot can
+         be resolved at all. *)
+      let selected_slots =
         Runtime_exact_output_registry.resolve_slots registry slot_ids
-        |> List.fold_left
-             (fun selected_slots_result outcome ->
-                match selected_slots_result, outcome with
-                | (Error _ as error), _ -> error
-                | Ok selected_slots, Ok selected -> Ok (selected :: selected_slots)
-                | Ok _, Error error ->
-                  Log.Keeper.warn
-                    ~keeper_name
-                    "compaction exact registry readiness violated generation=%Ld: %s"
-                    registry_generation
-                    (Runtime_exact_output_registry.error_to_string error);
-                  Error Exact_target_selection_failed)
-             (Ok [])
+        |> List.filter_map (function
+          | Ok selected -> Some selected
+          | Error error ->
+            Log.Keeper.warn
+              ~keeper_name
+              "compaction exact slot unavailable generation=%Ld: %s"
+              registry_generation
+              (Runtime_exact_output_registry.error_to_string error);
+            None)
       in
-      (match selected_slots_result with
-       | Error _ as error -> error
-       | Ok selected_slots ->
-         let selected_slots = List.rev selected_slots in
-         if selected_slots = []
-         then Error Exact_target_selection_failed
-         else
-           let messages = messages_for_plan ~units in
-           (* Every candidate is admitted against the same immutable registry before
-              the first network effect. Each admitted plan's real receipt is retained
-              before execution enters a cancellation scope. *)
-           let admitted_slots = admit_all ~keeper_name selected_slots ~messages in
-           if admitted_slots = []
-           then Error Exact_admission_failed
-           else Ok { units; admitted_slots })
+      (match selected_slots with
+       | [] -> Error Exact_target_selection_failed
+       | selected_slots ->
+         let messages = messages_for_plan ~units in
+         (* Every candidate is admitted against the same immutable registry before
+            the first network effect. Each admitted plan's real receipt is retained
+            before execution enters a cancellation scope. *)
+         let admitted_slots = admit_all ~keeper_name selected_slots ~messages in
+         if admitted_slots = []
+         then Error Exact_admission_failed
+         else Ok { units; admitted_slots })
 ;;
 
 let execute_prepared_lane ~keeper_name ~net ?clock prepared_lane =
   let rec execute = function
     | [] -> Error Exact_execution_failed_before_dispatch
     | { slot_id; ready_plan; receipt } :: rest ->
-      (match Exact_output.execute_once ~net ?clock ready_plan with
-       | Error _
+      let result =
+        (* A cancellation that arrives after the request crossed the provider
+           boundary must not escape as an unsettled [Cancelled]: the heartbeat
+           exception handler would requeue the lease and dispatch the same
+           compaction again. The receipt's dispatch count is pure local state,
+           so inspecting it cannot block; once the boundary was crossed, settle
+           the source as post-dispatch terminal instead. *)
+        try Ok (Exact_output.execute_once ~net ?clock ready_plan) with
+        | Eio.Cancel.Cancelled _ as exn ->
+          if Exact_output.receipt_dispatch_count receipt > 0
+          then Error `Cancelled_after_dispatch
+          else raise exn
+      in
+      (match result with
+       | Error `Cancelled_after_dispatch ->
+         Log.Keeper.warn
+           ~keeper_name
+           "compaction exact slot cancelled after dispatch slot=%s"
+           slot_id;
+         Error Exact_execution_failed_after_dispatch
+       | Ok (Error _)
          when Exact_output.receipt_phase receipt = Exact_output.Before_dispatch
               && Exact_output.receipt_dispatch_count receipt = 0 ->
          Log.Keeper.warn
@@ -462,8 +477,8 @@ let execute_prepared_lane ~keeper_name ~net ?clock prepared_lane =
            "compaction exact slot failed before dispatch slot=%s"
            slot_id;
          execute rest
-       | Error _ -> Error Exact_execution_failed_after_dispatch
-       | Ok success ->
+       | Ok (Error _) -> Error Exact_execution_failed_after_dispatch
+       | Ok (Ok success) ->
          (match plan_of_json ~units:prepared_lane.units success.output with
           | Error detail ->
             Log.Keeper.warn

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -43,8 +43,10 @@ val prepare_lane
 
 (** Execute each admitted ready plan at most once. Only a real receipt at
     [Before_dispatch] with dispatch count zero advances to the next slot.
-    Cancellation is not caught, and a dispatched failure or MASC-invalid domain
-    plan is terminal. *)
+    Cancellation before the dispatch boundary propagates; a cancellation whose
+    receipt shows the request already crossed the provider boundary settles as
+    [Exact_execution_failed_after_dispatch] (terminal), and a dispatched
+    failure or MASC-invalid domain plan is terminal. *)
 val execute_prepared_lane
   :  keeper_name:string
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -244,7 +244,21 @@ let run_admitted_with
         | Error (Keeper_post_turn.No_compaction no_compaction) ->
           `No_compaction no_compaction
         | Error _ -> `Busy block)
-     | `Ran (Error failure) -> `Compaction_failed failure
+     | `Ran (Error failure) ->
+       (match preparation, failure with
+        | ( Ok prepared
+          , Recovery
+              ( Keeper_post_turn.Checkpoint_cas_failed
+                  (Keeper_checkpoint_store.Source_changed _)
+              , _ ) ) ->
+          (* Another turn advanced the checkpoint while the exact-output
+             request was already dispatched against the old source. Re-driving
+             the same stale source would pay a second provider request, so
+             settle the source-bound terminal used for the final-admission
+             race instead of the replayable [Compaction_failed] arm. *)
+          `No_compaction
+            (Keeper_post_turn.no_compaction_of_uncommitted_prepared prepared)
+        | _ -> `Compaction_failed failure)
      | `Ran (Ok (Compacted success)) ->
        observe_manifest ~keeper_name:meta.name success.manifest;
        `Applied success

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -506,7 +506,13 @@ let terminal_reason_of_rejection = function
   | Invalid_compaction_plan -> Some Domain_invalid_output
   | Exact_execution_failed_after_dispatch ->
     Some Execution_may_have_dispatched
-  | Invalid_structural_evidence _
+  | Invalid_structural_evidence _ ->
+    (* Evidence is constructed only after the summarizer returned a completed
+       plan, which for the exact-output path means [execute_once] already
+       crossed the provider boundary. Retrying would dispatch a second
+       request for the same source, so this settles as the same post-dispatch
+       terminal as a failed-after-dispatch execution. *)
+    Some Execution_may_have_dispatched
   | Exact_target_selection_failed
   | Exact_admission_failed
   | Exact_execution_context_unavailable
@@ -752,3 +758,7 @@ let recover_latest_checkpoint_for_compaction
   | Error _ as error -> error
   | Ok prepared -> commit_prepared_compaction prepared
 ;;
+
+module For_testing = struct
+  let terminal_reason_of_rejection = terminal_reason_of_rejection
+end

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -136,3 +136,15 @@ val recover_latest_checkpoint_for_compaction :
   trigger:Compaction_trigger.t ->
   projection_request:Keeper_compaction_projection_target.request ->
   (compaction_recovery, compaction_recovery_error) result
+
+(** {1 Test hooks} *)
+
+module For_testing : sig
+  val terminal_reason_of_rejection
+    :  Keeper_compact_policy.compaction_rejection
+    -> Keeper_event_queue_state.no_compaction_reason option
+  (** Terminal-settlement mapping for compaction rejections. Post-dispatch
+      failures (failed-after-dispatch execution, structural-evidence
+      invalidity) map to [Execution_may_have_dispatched]; pre-dispatch
+      exact-output rejections stay retryable ([None]). *)
+end

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -27,6 +27,9 @@
   masc.masc_tool_dispatch
   masc.config
   masc.config_dir_resolver
+  ;; runtime_exact_output_lanes reads the required-lane seed declarations
+  ;; from the binary-embedded seed runtime.toml (RFC: exact-output backfill).
+  masc.embedded_config
   masc.event_bus_slots
   masc.provider_tool_support
   masc.keeper_runtime

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1701,23 +1701,27 @@ let validate_runtime_config_text ~config_path content =
 let save_config_text ?runtime_config_path content =
   let* path = runtime_config_path_result ?runtime_config_path () in
   let* exact_output_lane_decls = validate_runtime_config_text ~config_path:path content in
+  (* Upgraded workspaces keep a persisted runtime.toml that predates
+     [runtime.exact_output_lanes]; startup backfills [compaction_exact] only
+     in memory. Apply the same required-lane backfill when deriving the
+     effective lanes for a save, so an unrelated raw save does not strip the
+     lane the compaction summarizer resolves by name. *)
+  let effective_lanes =
+    Runtime_exact_output_lanes.with_required_backfill exact_output_lane_decls
+  in
   (* Raw config edits may rewrite [runtime.exact_output_lanes]. Validate the
-     new declarations against the live resolver snapshot and republish so the
-     active exact-output registry tracks the save instead of going stale
-     until the next restart. Republishing precedes the atomic write so an
-     invalid lane set is rejected before it reaches disk; if the write itself
-     fails, the registry still holds a valid lane set and the next successful
-     save or restart reconverges. Without a published registry (pre-bootstrap
-     or non-server contexts) there is no snapshot to validate against —
-     bootstrap publishes from the saved file. *)
+     new declarations against the live resolver snapshot WITHOUT publishing;
+     the registry is republished only after the durable write commits, so a
+     failed write never leaves active routing ahead of both the on-disk
+     config and what the caller believes was applied. Without a published
+     registry (pre-bootstrap or non-server contexts) there is no snapshot to
+     validate against — bootstrap publishes from the saved file. *)
   let* () =
     match Runtime_exact_output_registry.current () with
     | Error _ -> Ok ()
     | Ok _registry ->
-      (match
-         Runtime_exact_output_registry.republish ~lanes:exact_output_lane_decls
-       with
-       | Ok _registry -> Ok ()
+      (match Runtime_exact_output_registry.validate ~lanes:effective_lanes with
+       | Ok () -> Ok ()
        | Error error ->
          Error
            (Printf.sprintf
@@ -1726,6 +1730,20 @@ let save_config_text ?runtime_config_path content =
   in
   let* () = Fs_compat.save_file_atomic path content in
   let* () = init_default ~config_path:path in
+  (* The write committed: republish so the active registry tracks the saved
+     lanes instead of going stale until the next restart. Validation above
+     already succeeded against the same immutable snapshot, so a failure here
+     is unexpected — log it rather than misreporting the committed save as
+     failed. *)
+  (match Runtime_exact_output_registry.current () with
+   | Error _ -> ()
+   | Ok _registry ->
+     (match Runtime_exact_output_registry.republish ~lanes:effective_lanes with
+      | Ok _registry -> ()
+      | Error error ->
+        Log.Misc.error
+          "exact-output registry republish failed after committed config save: %s"
+          (Runtime_exact_output_registry.error_to_string error)));
   Ok ()
 ;;
 

--- a/lib/runtime/runtime_exact_output_lanes.ml
+++ b/lib/runtime/runtime_exact_output_lanes.ml
@@ -1,0 +1,43 @@
+(* The compaction summarizer resolves this lane by name; it must exist in
+   every published registry for manual/provider-overflow compaction to run. *)
+let compaction_exact_lane_id = "compaction_exact"
+
+(* Upgraded workspaces keep their operator-owned runtime.toml, which predates
+   [runtime.exact_output_lanes]. Without a backfill a published registry would
+   carry zero lanes and every compaction would fail at execution with
+   [Exact_target_selection_failed]. The seed declaration comes from the
+   binary-embedded seed config so repo config and backfill share one source;
+   operator declarations always win. *)
+let seed_lane_declarations () =
+  match Embedded_config.read "runtime.toml" with
+  | None ->
+    Log.Misc.warn
+      "exact_output: embedded seed runtime.toml is unavailable; cannot backfill the %S lane"
+      compaction_exact_lane_id;
+    []
+  | Some contents ->
+    (match Runtime_toml.parse_string contents with
+     | Ok (config : Runtime_schema.config) -> config.exact_output_lane_decls
+     | Error errors ->
+       Log.Misc.warn
+         "exact_output: embedded seed runtime.toml parse failed (%d error(s)); cannot backfill the %S lane"
+         (List.length errors)
+         compaction_exact_lane_id;
+       [])
+;;
+
+let backfill_required ~seed_lanes lanes =
+  let has_compaction_exact (lane : Runtime_schema.exact_output_lane_decl) =
+    String.equal lane.id compaction_exact_lane_id
+  in
+  if List.exists has_compaction_exact lanes
+  then lanes, false
+  else
+    match List.find_opt has_compaction_exact seed_lanes with
+    | None -> lanes, false
+    | Some seed_lane -> lanes @ [ seed_lane ], true
+;;
+
+let with_required_backfill lanes =
+  fst (backfill_required ~seed_lanes:(seed_lane_declarations ()) lanes)
+;;

--- a/lib/runtime/runtime_exact_output_lanes.mli
+++ b/lib/runtime/runtime_exact_output_lanes.mli
@@ -1,0 +1,25 @@
+(** Required exact-output lane backfill, shared by the server bootstrap
+    publish path and the runtime.toml save path. *)
+
+val compaction_exact_lane_id : string
+(** Lane id the compaction summarizer resolves by name; every published
+    exact-output registry must carry it. *)
+
+val seed_lane_declarations : unit -> Runtime_schema.exact_output_lane_decl list
+(** Exact-output lane declarations from the binary-embedded seed runtime.toml.
+    Returns [] (with a WARN) when the embedded seed is unavailable or invalid. *)
+
+val backfill_required
+  :  seed_lanes:Runtime_schema.exact_output_lane_decl list
+  -> Runtime_schema.exact_output_lane_decl list
+  -> Runtime_schema.exact_output_lane_decl list * bool
+(** Append the seed {!compaction_exact_lane_id} declaration when the given
+    lane list does not declare the lane (legacy runtime.toml from before
+    [runtime.exact_output_lanes] existed). Returns the effective lane list and
+    whether a backfill happened. Operator declarations always win. *)
+
+val with_required_backfill
+  :  Runtime_schema.exact_output_lane_decl list
+  -> Runtime_schema.exact_output_lane_decl list
+(** [backfill_required] with the embedded seed declarations, returning only
+    the effective lane list. *)

--- a/lib/runtime/runtime_exact_output_registry.ml
+++ b/lib/runtime/runtime_exact_output_registry.ml
@@ -145,6 +145,12 @@ let republish ~lanes =
   | Some registry -> publish ~lanes registry.resolver_snapshot
 ;;
 
+let validate ~lanes =
+  match Atomic.get published with
+  | None -> Error Registry_not_published
+  | Some registry -> validate_lanes registry.resolver_snapshot lanes
+;;
+
 let generation registry = registry.generation
 
 let lane_slots registry ~lane_id =

--- a/lib/runtime/runtime_exact_output_registry.mli
+++ b/lib/runtime/runtime_exact_output_registry.mli
@@ -33,6 +33,15 @@ val republish
     Returns [Registry_not_published] when no registry has been published yet
     (pre-bootstrap or non-server contexts). *)
 
+val validate
+  :  lanes:Runtime_schema.exact_output_lane_decl list
+  -> (unit, error) result
+(** Validate [lanes] against the currently published resolver snapshot WITHOUT
+    mutating the Atomic. Save paths run this before the durable write and call
+    {!republish} only after the write commits, so a failed write never leaves
+    routing ahead of the on-disk config. Returns [Registry_not_published] when
+    no registry has been published yet. *)
+
 val current : unit -> (t, error) result
 (** Return the currently published registry, or a typed error before bootstrap
     has published one. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -199,44 +199,14 @@ let load_exact_output_lane_declarations () =
                (List.length errors))))
 ;;
 
-(* The compaction summarizer resolves this lane by name; it must exist in
-   every published registry for manual/provider-overflow compaction to run. *)
-let compaction_exact_lane_id = "compaction_exact"
-
-(* Upgraded workspaces keep their operator-owned runtime.toml
-   ([Config_root_bootstrap] preserves existing roots), which predates
-   [runtime.exact_output_lanes]. Without a backfill the bootstrap would
-   publish a valid registry with zero lanes and every compaction would fail at
-   execution with [Exact_target_selection_failed]. The seed declaration comes
-   from the binary-embedded seed config so repo config and backfill share one
-   source; operator declarations always win. *)
-let seed_exact_output_lane_declarations () =
-  match Embedded_config.read "runtime.toml" with
-  | None ->
-    Log.Misc.warn
-      "exact_output: embedded seed runtime.toml is unavailable; cannot backfill the %S lane"
-      compaction_exact_lane_id;
-    []
-  | Some contents ->
-    (match Runtime_toml.parse_string contents with
-     | Ok (config : Runtime_schema.config) -> config.exact_output_lane_decls
-     | Error errors ->
-       Log.Misc.warn
-         "exact_output: embedded seed runtime.toml parse failed (%d error(s)); cannot backfill the %S lane"
-         (List.length errors)
-         compaction_exact_lane_id;
-       [])
-
-let backfill_required_exact_output_lanes ~seed_lanes lanes =
-  let has_compaction_exact (lane : Runtime_schema.exact_output_lane_decl) =
-    String.equal lane.id compaction_exact_lane_id
-  in
-  if List.exists has_compaction_exact lanes
-  then lanes, false
-  else
-    match List.find_opt has_compaction_exact seed_lanes with
-    | None -> lanes, false
-    | Some seed_lane -> lanes @ [ seed_lane ], true
+(* Required-lane backfill is owned by [Runtime_exact_output_lanes] so the
+   runtime.toml save path applies the same rule; these aliases keep the
+   bootstrap call sites (and the exported test surface) stable. *)
+let compaction_exact_lane_id = Runtime_exact_output_lanes.compaction_exact_lane_id
+let seed_exact_output_lane_declarations =
+  Runtime_exact_output_lanes.seed_lane_declarations
+let backfill_required_exact_output_lanes =
+  Runtime_exact_output_lanes.backfill_required
 ;;
 
 (* Row identity for catalog table arrays, mirroring [Model_catalog] merge

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -40,7 +40,8 @@ val configure_oas_model_catalog_overlay :
 
 val compaction_exact_lane_id : string
 (** Lane id the compaction summarizer resolves by name; every published
-    exact-output registry must carry it. *)
+    exact-output registry must carry it. Alias of
+    [Runtime_exact_output_lanes.compaction_exact_lane_id]. *)
 
 val backfill_required_exact_output_lanes
   :  seed_lanes:Runtime_schema.exact_output_lane_decl list
@@ -49,7 +50,9 @@ val backfill_required_exact_output_lanes
 (** Append the seed {!compaction_exact_lane_id} declaration when the operator
     config does not declare the lane (legacy runtime.toml from before
     [runtime.exact_output_lanes] existed). Returns the effective lane list and
-    whether a backfill happened. Operator declarations always win. *)
+    whether a backfill happened. Operator declarations always win. Alias of
+    [Runtime_exact_output_lanes.backfill_required], shared with the
+    runtime.toml save path. *)
 
 val merge_catalog_overlay_toml
   :  base_contents:string

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -355,7 +355,87 @@ let test_domain_invalid_json_is_terminal () =
   Alcotest.(check int) "domain invalidity does not fail over" 0 (F.post_count second)
 ;;
 
-let test_timeout_cancellation_escapes_without_failover () =
+(* A lane mixing one fully usable target with one target whose credential is
+   absent: publication intentionally accepts the missing credential, and slot
+   selection must keep the resolvable slot instead of vetoing the whole lane. *)
+let optional_credential_snapshot ~usable_base_url =
+  let overlay : EO.catalog_overlay =
+    { source = "masc optional credential"
+    ; contents =
+        Printf.sprintf
+          "[[providers]]\n\
+           id = \"masc-exact-usable\"\n\
+           kind = \"openai_compat\"\n\
+           base_url = %S\n\
+           request_path = \"/v1/chat/completions\"\n\
+           api_key_env = \"\"\n\
+           \n\
+           [[providers]]\n\
+           id = \"masc-exact-needs-key\"\n\
+           kind = \"openai_compat\"\n\
+           base_url = \"http://127.0.0.1:9\"\n\
+           request_path = \"/v1/chat/completions\"\n\
+           api_key_env = \"MASC_CONFORMANCE_UNSET_KEY\"\n\
+           \n\
+           [[models]]\n\
+           id_prefix = \"usable-model\"\n\
+           provider_name = \"masc-exact-usable\"\n\
+           max_context_tokens = 8192\n\
+           max_output_tokens = 1024\n\
+           supports_response_format_json = true\n\
+           supports_structured_output = true\n\
+           \n\
+           [[models]]\n\
+           id_prefix = \"keyed-model\"\n\
+           provider_name = \"masc-exact-needs-key\"\n\
+           max_context_tokens = 8192\n\
+           max_output_tokens = 1024\n\
+           supports_response_format_json = true\n\
+           supports_structured_output = true\n\
+           \n\
+           [[targets]]\n\
+           id = \"masc-exact-usable.usable-model\"\n\
+           provider_ref = \"masc-exact-usable\"\n\
+           model_id = \"usable-model\"\n\
+           \n\
+           [[targets]]\n\
+           id = \"masc-exact-needs-key.keyed-model\"\n\
+           provider_ref = \"masc-exact-needs-key\"\n\
+           model_id = \"keyed-model\"\n"
+          usable_base_url
+    }
+  in
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  match EO.load_resolver_snapshot ~io ~overlay () with
+  | Ok snapshot -> snapshot
+  | Error _ -> Alcotest.fail "optional-credential resolver fixture did not load"
+;;
+
+let test_unavailable_credential_slot_does_not_veto_usable_slot () =
+  run_eio
+  @@ fun ~sw ~net ~clock ->
+  let first = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let snapshot =
+    optional_credential_snapshot ~usable_base_url:first.base_url
+  in
+  let registry =
+    publish_exn
+      ~slot_ids:
+        [ "masc-exact-usable.usable-model"; "masc-exact-needs-key.keyed-model" ]
+      snapshot
+  in
+  let prepared =
+    prepare_exn ~keeper_name:"keeper-optional-credential" ~registry
+  in
+  ignore (completed_exn (C.execute_prepared_lane
+    ~keeper_name:"keeper-optional-credential" ~net ~clock prepared));
+  Alcotest.(check int)
+    "usable slot dispatched exactly once"
+    1
+    (F.post_count first)
+;;
+
+let test_post_dispatch_cancellation_settles_terminal_without_failover () =
   run_eio
   @@ fun ~sw ~net ~clock ->
   let hold_response, _resolve_hold_response = Eio.Promise.create () in
@@ -396,27 +476,19 @@ let test_timeout_cancellation_escapes_without_failover () =
           ~clock
           prepared))
   in
-  let cancellation_propagated =
-    try
-      Eio.Time.with_timeout_exn clock 1.0 (fun () ->
-        let context = Eio.Promise.await cancel_context in
-        F.await_first_request first;
-        Eio.Cancel.cancel context Cancel_after_request_arrived;
-        try
-          ignore
-            (Eio.Promise.await_exn execution
-              : (C.completed_plan, C.summarization_failure) result);
-          false
-        with
-        | Eio.Cancel.Cancelled Cancel_after_request_arrived -> true)
-    with
-    | Eio.Time.Timeout ->
-      Alcotest.fail "request-arrival cancellation watchdog expired"
+  let settlement =
+    Eio.Time.with_timeout_exn clock 1.0 (fun () ->
+      let context = Eio.Promise.await cancel_context in
+      F.await_first_request first;
+      Eio.Cancel.cancel context Cancel_after_request_arrived;
+      Eio.Promise.await_exn execution)
   in
-  Alcotest.(check bool)
-    "caller cancellation escapes compaction"
-    true
-    cancellation_propagated;
+  (match settlement with
+   | Error C.Exact_execution_failed_after_dispatch -> ()
+   | Error _ ->
+     Alcotest.fail
+       "post-dispatch cancellation must settle as Exact_execution_failed_after_dispatch"
+   | Ok _ -> Alcotest.fail "post-dispatch cancellation must not succeed");
   check_observation
     ~label:"cancelled real receipt"
     ~phase:EO.Dispatch_started
@@ -503,9 +575,13 @@ let () =
             `Quick
             test_domain_invalid_json_is_terminal
         ; Alcotest.test_case
-            "timeout cancellation escapes without failover"
+            "unavailable credential slot does not veto usable slot"
             `Quick
-            test_timeout_cancellation_escapes_without_failover
+            test_unavailable_credential_slot_does_not_veto_usable_slot
+        ; Alcotest.test_case
+            "post-dispatch cancellation settles terminal without failover"
+            `Quick
+            test_post_dispatch_cancellation_settles_terminal_without_failover
         ] )
     ; ( "Keeper isolation"
       , [ Alcotest.test_case

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -696,6 +696,162 @@ let test_manual_compaction_serializes_owner_lane () =
         (Exact_fixture.post_count race_server))
 ;;
 
+let test_evidence_failure_maps_to_post_dispatch_terminal () =
+  (match
+     Post_turn.For_testing.terminal_reason_of_rejection
+       (Compact_policy.Invalid_structural_evidence
+          Keeper_compaction_evidence.Expected_object)
+   with
+   | Some Keeper_event_queue_state.Execution_may_have_dispatched -> ()
+   | _ ->
+     fail
+       "post-dispatch evidence failure must settle as Execution_may_have_dispatched");
+  (match
+     Post_turn.For_testing.terminal_reason_of_rejection
+       Compact_policy.Exact_execution_failed_after_dispatch
+   with
+   | Some Keeper_event_queue_state.Execution_may_have_dispatched -> ()
+   | _ -> fail "failed-after-dispatch execution must stay a post-dispatch terminal");
+  match
+    Post_turn.For_testing.terminal_reason_of_rejection
+      Compact_policy.Exact_target_selection_failed
+  with
+  | None -> ()
+  | Some _ -> fail "pre-dispatch selection failure must stay retryable"
+;;
+
+let test_manual_compaction_stale_source_commit_settles_terminal () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let meta =
+    make_meta
+      ~name:"compaction-stale-source"
+      ~trace_id:"trace-compaction-stale-source"
+      ()
+  in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      Admission.For_testing.reset ();
+      Masc.Keeper_registry.For_testing.unregister ~base_path meta.name;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_path in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      init_runtime_fixture ();
+      Result.get_ok (Masc.Keeper_meta_store.write_meta config meta);
+      let owner_entry =
+        Masc.Keeper_registry.For_testing.register ~base_path meta.name meta
+      in
+      Atomic.set owner_entry.fiber_wakeup false;
+      let checkpoint =
+        { (make_checkpoint ()) with
+          session_id = "trace-compaction-stale-source"
+        ; agent_name = meta.agent_name
+        }
+      in
+      let session =
+        Masc.Keeper_context_core.create_session
+          ~session_id:checkpoint.session_id
+          ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+      in
+      (match
+         Masc.Keeper_context_core.save_oas_checkpoint_classified
+           ~multimodal_policy:meta.multimodal_policy
+           ~keeper_name:meta.name
+           ~session
+           ~agent_name:meta.agent_name
+           ~ctx:(Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint)
+           ~generation:meta.runtime.generation
+       with
+       | Ok (_, Masc.Keeper_checkpoint_store.Saved _) -> ()
+       | Ok (_, Stale_noop _) -> fail "initial checkpoint save was stale"
+       | Error detail ->
+         failf
+           "initial checkpoint save failed: %s"
+           (Masc.Keeper_context_core.checkpoint_write_error_to_string
+              ~persistence_error_to_string:Fun.id
+              detail));
+      (* The loaded checkpoint carries the injected keeper generation in its
+         context, which the raw interleaved save below needs for the source
+         ref. *)
+      let saved_checkpoint =
+        Result.get_ok
+          (Masc.Keeper_checkpoint_store.load_oas
+             ~session_dir:session.session_dir
+             ~session_id:checkpoint.session_id)
+      in
+      (* Another turn advances the durable source while the exact-output
+         request is in flight, so the prepared plan's commit CAS-misses. *)
+      let race_server =
+        Exact_fixture.start_server
+          ~on_request_before_reply:(fun () ->
+            let advanced =
+              { saved_checkpoint with
+                turn_count = saved_checkpoint.turn_count + 1
+              ; messages =
+                  saved_checkpoint.messages
+                  @ [ Agent_sdk.Types.text_message
+                        Agent_sdk.Types.User
+                        "interleaved turn"
+                    ]
+              }
+            in
+            match
+              Masc.Keeper_checkpoint_store.save_oas_classified
+                ~session_dir:session.session_dir
+                advanced
+            with
+            | Ok (Masc.Keeper_checkpoint_store.Saved _) -> ()
+            | Ok (Stale_noop _) -> fail "interleaved checkpoint save was stale"
+            | Error detail ->
+              failf "interleaved checkpoint save failed: %s" detail)
+          ~sw
+          ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env)
+          (Exact_fixture.Reply
+             (summarize_response "stale source must not commit"))
+      in
+      publish_exact_fixture ~source:"post-turn stale-source commit" race_server;
+      let outcome =
+        Masc.Keeper_manual_compaction.run_admitted ~config ~meta
+      in
+      check int
+        "stale-source commit performs one exact dispatch"
+        1
+        (Exact_fixture.post_count race_server);
+      (match outcome with
+       | `No_compaction
+           { reason =
+               Keeper_event_queue_state.Execution_may_have_dispatched
+           ; _
+           } ->
+         ()
+       | `Busy _ -> fail "stale-source commit collapsed to replayable Busy"
+       | `Applied _ -> fail "stale-source commit applied past the source CAS"
+       | `No_compaction _ ->
+         fail "stale-source commit lost its post-dispatch terminal reason"
+       | `Compaction_failed failure ->
+         failf
+           "stale-source commit stayed a replayable Compaction_failed: %s"
+           (Masc.Keeper_manual_compaction.failure_to_string failure));
+      let retained =
+        Result.get_ok
+          (Masc.Keeper_checkpoint_store.load_oas
+             ~session_dir:session.session_dir
+             ~session_id:checkpoint.session_id)
+      in
+      check int
+        "interleaved checkpoint is retained exactly"
+        (List.length checkpoint.messages + 1)
+        (List.length retained.messages))
+;;
+
 let test_malformed_structure_preserves_checkpoint () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
@@ -927,6 +1083,10 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
+      test_case "stale-source commit settles post-dispatch terminal"
+        `Quick test_manual_compaction_stale_source_commit_settles_terminal;
+      test_case "evidence failure maps to post-dispatch terminal"
+        `Quick test_evidence_failure_maps_to_post_dispatch_terminal;
       test_case "malformed structure preserves checkpoint"
         `Quick test_malformed_structure_preserves_checkpoint;
       test_case "prepare/commit source CAS"

--- a/test/test_runtime_exact_output_registry.ml
+++ b/test/test_runtime_exact_output_registry.ml
@@ -12,6 +12,13 @@ let fixture_provider_id = "masc-exact-registry-provider"
 let fixture_model_id = "masc-exact-registry-model"
 let fixture_target_id = "masc-exact-registry-provider.masc-exact-registry-model"
 
+(* The embedded-catalog provider/model pair the seed runtime.toml's required
+   [compaction_exact] lane references. Declaring the target here lets the
+   backfilled seed lane validate against the fixture snapshot; its credential
+   (DEEPSEEK_API_KEY, absent under the fixture getenv) is deferred at publish
+   by design. *)
+let seed_target_id = "deepseek.deepseek-v4-pro"
+
 let fixture_catalog_toml ~api_key_env =
   Printf.sprintf
     "[[providers]]\n\
@@ -32,7 +39,12 @@ let fixture_catalog_toml ~api_key_env =
      [[targets]]\n\
      id = %S\n\
      provider_ref = %S\n\
-     model_id = %S\n"
+     model_id = %S\n\
+     \n\
+     [[targets]]\n\
+     id = %S\n\
+     provider_ref = \"deepseek\"\n\
+     model_id = \"deepseek-v4-pro\"\n"
     fixture_provider_id
     api_key_env
     fixture_model_id
@@ -40,6 +52,7 @@ let fixture_catalog_toml ~api_key_env =
     fixture_target_id
     fixture_provider_id
     fixture_model_id
+    seed_target_id
 ;;
 
 let load_snapshot ~api_key_env =
@@ -232,6 +245,104 @@ let test_save_config_text_republishes_exact_output_lanes () =
                   && not (contains_substring on_disk "no.such-target"))))
 ;;
 
+let test_save_config_text_backfills_required_lane () =
+  let snapshot = load_snapshot ~api_key_env:"" in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       match
+         Registry.publish
+           ~lanes:[ lane "compaction_exact" [ fixture_target_id ] ]
+           snapshot
+       with
+       | Error error ->
+         failf "fixture publish failed: %s" (Registry.error_to_string error)
+       | Ok _published ->
+         (* A legacy runtime.toml without [runtime.exact_output_lanes]: the
+            save must keep the required lane (backfilled from the embedded
+            seed), not republish an empty lane set. *)
+         let path = Filename.temp_file "runtime-exact-output" ".toml" in
+         Fun.protect
+           ~finally:(fun () ->
+             try Sys.remove path with
+             | Sys_error _ -> ())
+           (fun () ->
+              match Runtime.save_config_text ~runtime_config_path:path (runtime_config_text ~extra:"") with
+              | Error msg -> failf "lane-less config save failed: %s" msg
+              | Ok () ->
+                (match Registry.current () with
+                 | Error _ -> fail "registry must stay published after a save"
+                 | Ok current ->
+                   (match Registry.lane_slots current ~lane_id:"compaction_exact" with
+                    | Error error ->
+                      failf
+                        "required lane missing after lane-less save: %s"
+                        (Registry.error_to_string error)
+                    | Ok slot_ids ->
+                      check
+                        (list string)
+                        "lane-less save backfills the seed lane"
+                        [ seed_target_id ]
+                        slot_ids))))
+;;
+
+let test_failed_write_does_not_republish () =
+  let snapshot = load_snapshot ~api_key_env:"" in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       match
+         Registry.publish
+           ~lanes:[ lane "compaction_exact" [ fixture_target_id ] ]
+           snapshot
+       with
+       | Error error ->
+         failf "fixture publish failed: %s" (Registry.error_to_string error)
+       | Ok published ->
+         let content =
+           runtime_config_text
+             ~extra:
+               (Printf.sprintf
+                  "[runtime.exact_output_lanes.compaction_exact]\n\
+                   slots = [ %S ]\n\
+                   [runtime.exact_output_lanes.extra_lane]\n\
+                   slots = [ %S ]\n"
+                  fixture_target_id
+                  fixture_target_id)
+         in
+         let missing_dir_path =
+           Filename.concat
+             (Filename.get_temp_dir_name ())
+             "masc-exact-output-no-such-dir/runtime.toml"
+         in
+         (match Runtime.save_config_text ~runtime_config_path:missing_dir_path content with
+          | Ok () -> fail "save into a missing directory must fail"
+          | Error _ -> ());
+         (match Registry.current () with
+          | Error _ -> fail "registry must stay published after a failed write"
+          | Ok current ->
+            check bool
+              "failed write does not advance the generation"
+              true
+              (Int64.equal (Registry.generation current) (Registry.generation published));
+            (match Registry.lane_slots current ~lane_id:"extra_lane" with
+             | Ok _ -> fail "failed write must not publish the rejected lanes"
+             | Error _ -> ());
+            match Registry.lane_slots current ~lane_id:"compaction_exact" with
+            | Error error ->
+              failf
+                "previously published lane lost after failed write: %s"
+                (Registry.error_to_string error)
+            | Ok slot_ids ->
+              check
+                (list string)
+                "previously published lanes survive the failed write"
+                [ fixture_target_id ]
+                slot_ids))
+;;
+
 let () =
   Alcotest.run
     "Runtime_exact_output_registry"
@@ -244,6 +355,10 @@ let () =
             test_republish_revalidates_against_current_snapshot
         ; test_case "config save republishes lanes" `Quick
             test_save_config_text_republishes_exact_output_lanes
+        ; test_case "lane-less config save backfills required lane" `Quick
+            test_save_config_text_backfills_required_lane
+        ; test_case "failed write does not republish" `Quick
+            test_failed_write_does_not_republish
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

#25585 머지(23:59 KST) 전후로 달린 Codex 리뷰 라운드 2/3(#4756689176, #4757012224) 대응입니다. 수정 커밋이 완성되기 전에 #25585가 머지되어, 후속 PR로 분리합니다 (원 커밋 `ae6616879a`를 최신 main에 cherry-pick — 머지 시점 이후 달린 리뷰라 main 기준으로는 미반영).

## 대응 내용

**Round 2 (#4756689176)**
- R2-1 (P1): `Invalid_structural_evidence`는 `execute_once` 성공 이후에만 생성되므로 정의상 post-dispatch — retryable `None` arm 대신 `Execution_may_have_dispatched` terminal로 매핑해 증거 검증 실패 시 재dispatch 차단.
- R2-2 (P2): dispatch 이후 stale-source CAS miss(`Checkpoint_cas_failed Source_changed`)를 replayable `Compaction_failed` 대신 source-bound `No_compaction` terminal로 settle.

**Round 3 (#4757012224)**
- R3-1 (P1): `execute_prepared_lane`이 `Eio.Cancel.Cancelled`를 잡아 receipt `dispatch_count > 0`이면 `Exact_execution_failed_after_dispatch` terminal로 settle (heartbeat requeue 경로 차단).
- R3-2 (P1): 필수 lane backfill을 공유 모듈 `runtime_exact_output_lanes`로 승격하고 `Runtime.save_config_text`에도 적용 — lane 없는 legacy runtime.toml의 무관한 raw save가 `compaction_exact`를 지우지 않음.
- R3-3 (P2): `prepare_lane`이 resolve 가능한 slot만 유지 — optional failover credential 부재가 usable target까지 무효화하지 않음.
- R3-4 (P2): `save_config_text`가 mutation 없는 `validate` → atomic write → `republish` 순서로 변경 — write 실패 시 registry가 디스크와 어긋나지 않음.

## 검증

- `scripts/dune-local.sh build lib/keeper lib/runtime` (최신 main 기준) ✅
- 로컬 (cherry-pick 전 동일 내용): conformance 8/8, registry 6/6, wirein_order +2, config_validity 43/43, server_runtime_bootstrap 89 pass ✅
- 참고: `test_keeper_post_turn_wirein_order`의 "malformed structure preserves checkpoint" 1건은 #25585 브랜치 시절부터의 기존 실패 (compaction-policy ordering 이슈, 본 PR 범위 밖).

Related: #25585, reviews #4756689176 / #4757012224
