### PR TITLE
refactor(dashboard): schedule terminal status SSOT 중복 제거 (#25605)

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -18,6 +18,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { AgentAvatar } from './agent-avatar'
+import { SCHED_TERMINAL_NORMALIZED } from '../v2/schedule-constants'
 import { tasks, keepers, boardPosts, goals, fusionRuns } from '../../store'
 import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
 import type {
@@ -264,8 +265,6 @@ export interface OverviewScheduledAutomationDigest {
   tone: 'ok' | 'warn' | 'bad' | 'volt'
 }
 
-const SCHEDULE_TERMINAL_STATUS_KEY = new Set(['succeeded', 'failed', 'cancelled', 'expired'])
-
 function normalizeScheduleStatus(value: string | undefined): string {
   return value?.trim().toLowerCase() ?? ''
 }
@@ -306,7 +305,7 @@ function requestCountByProjectionCount(
 
 function sumTerminalCountFromProjection(counts: Record<string, number> | undefined): number {
   let sum = 0
-  for (const terminalStatus of SCHEDULE_TERMINAL_STATUS_KEY) {
+  for (const terminalStatus of SCHED_TERMINAL_NORMALIZED) {
     const n = counts?.[terminalStatus]
     if (typeof n === 'number' && Number.isFinite(n)) sum += n
   }


### PR DESCRIPTION
## 문제

`dashboard/src/components/overview/overview.ts`에 `SCHEDULE_TERMINAL_STATUS_KEY = new Set(['succeeded','failed','cancelled','expired'])`가 기존 SSOT `dashboard/src/components/v2/schedule-constants.ts`의 `SCHED_TERMINAL`/`SCHED_TERMINAL_NORMALIZED`와 정확히 중복 정의되어 있어 drift 가능성이 있었습니다 (#25513 적대적 리뷰 P2 미해결 머지).

Closes #25605

## 수정 내용

- `overview.ts`의 로컬 `SCHEDULE_TERMINAL_STATUS_KEY` 상수 삭제
- `sumTerminalCountFromProjection`에서 `../v2/schedule-constants`의 `SCHED_TERMINAL_NORMALIZED`를 import하여 사용
  - `SCHED_TERMINAL`(배열)이 아닌 `SCHED_TERMINAL_NORMALIZED`(Set)를 선택한 이유: 사용처는 projection counts의 키를 lowercase 정규화(`normalizeScheduleStatus`)하여 조회하므로, "lowercase 정규화된 형태"라는 semantics가 정확히 일치하는 쪽이 `SCHED_TERMINAL_NORMALIZED`입니다. 값 집합 자체는 동일하므로 동작 변화 없음.

## 근본 원인 분석

#25513에서 overview 화면의 schedule runner digest를 추가하면서 terminal status 집합이 필요했고, 이미 존재하는 `v2/schedule-constants.ts`의 SSOT를 import하지 않고 로컬에 같은 리터럴 Set을 재정의한 채 머지되었습니다. 적대적 리뷰에서 P2로 'import로 대체 권장'이 지적되었으나 해결 없이 머지되어 SSOT 중복이 잔존했습니다.

## 검증

- `cd dashboard && npx tsc --noEmit --pretty` — 통과 (에러 없음)
- `npx vitest run src/components/overview/overview.test.ts src/components/v2/schedule-constants.test.ts` — 2개 파일, 104 tests 전부 통과
- 변경이 dashboard TS 파일 1개뿐이라 OCaml 빌드/테스트 및 OCaml 대상 repo gate(determinism/telemetry/ignore lint)는 해당 없음