### PR TITLE
fix(fusion): route evidence_unavailable failure code through typed variant (#25602)

### DIFF
--- a/lib/fusion/fusion_delivery_projector.ml
+++ b/lib/fusion/fusion_delivery_projector.ml
@@ -28,6 +28,26 @@ let projection_error_to_string = function
   | Projection_failed detail -> "Fusion terminal projection failed: " ^ detail
 ;;
 
+(** Sink failure codes are derived from the typed error — never the other way
+    around. Only errors that are actually delivered through
+    [Fusion_sink.emit_failure] have a code; anything else is a programmer
+    error, so it fails fast instead of silently inventing a string. *)
+let projection_error_failure_code = function
+  | Evidence_unavailable -> "evidence_unavailable"
+  | ( Invalid_request_id _
+    | Obligation_unavailable _
+    | Identity_mismatch _
+    | Non_durable_settlement
+    | Ambiguous_settlement
+    | Nonterminal_status _
+    | Evidence_invalid _
+    | Projection_failed _
+    | Obligation_removal_failed _ ) as error ->
+    invalid_arg
+      ("projection error is not delivered as a sink failure: "
+       ^ projection_error_to_string error)
+;;
+
 let ( let* ) = Result.bind
 
 let request_id_of_entry (entry : Keeper_msg_async.entry) =
@@ -118,10 +138,11 @@ let project_entry ~base_path (entry : Keeper_msg_async.entry) =
          Remediate by delivering a typed failure through the same fail-closed
          sink and then clearing the obligation (a failed failure-projection
          still retains it). *)
+      let error = Evidence_unavailable in
       Fusion_sink.emit_failure ~base_dir:base_path ~keeper:payload.keeper_name
         ~run_id:entry.request_id ~channel:payload.channel
-        ~failure_code:"evidence_unavailable"
-        ~detail:"computation completed successfully without deliberation evidence"
+        ~failure_code:(projection_error_failure_code error)
+        ~detail:(projection_error_to_string error)
       |> Result.map_error (fun detail -> Projection_failed detail)
     | status ->
       (match failure_of_status status with

--- a/lib/fusion/fusion_delivery_projector.mli
+++ b/lib/fusion/fusion_delivery_projector.mli
@@ -15,6 +15,11 @@ type projection_error =
 
 val projection_error_to_string : projection_error -> string
 
+val projection_error_failure_code : projection_error -> string
+(** Sink failure code derived from the typed error. Only errors delivered
+    through [Fusion_sink.emit_failure] have a code (currently
+    [Evidence_unavailable]); any other error raises [Invalid_argument]. *)
+
 val on_worker_settled :
   base_path:string -> Keeper_msg_async.worker_settlement -> unit
 (** Project an exact durable settlement. Any ambiguity or delivery failure is

--- a/test/test_fusion_delivery_obligation.ml
+++ b/test/test_fusion_delivery_obligation.ml
@@ -358,6 +358,24 @@ let test_startup_recovery_remediates_missing_evidence () =
         | None -> fail "startup remediation did not durably queue a failure")))
 ;;
 
+let test_evidence_unavailable_typed_failure_code () =
+  (* The sink failure code is derived from the typed variant — the live path
+     must never bypass it with a raw string. *)
+  check string "failure code derives from typed variant" "evidence_unavailable"
+    (Fusion_delivery_projector.projection_error_failure_code
+       Fusion_delivery_projector.Evidence_unavailable);
+  check string "detail derives from typed variant"
+    "Fusion computation completed successfully without deliberation evidence"
+    (Fusion_delivery_projector.projection_error_to_string
+       Fusion_delivery_projector.Evidence_unavailable);
+  match
+    Fusion_delivery_projector.projection_error_failure_code
+      (Fusion_delivery_projector.Projection_failed "boom")
+  with
+  | _ -> fail "non-sink projection error must not have a failure code"
+  | exception Invalid_argument _ -> ()
+;;
+
 let () =
   run
     "fusion delivery obligation"
@@ -370,6 +388,8 @@ let () =
             test_startup_recovery_projects_canonical_terminal
         ; test_case "startup recovery remediates missing evidence" `Quick
             test_startup_recovery_remediates_missing_evidence
+        ; test_case "evidence_unavailable failure code is typed" `Quick
+            test_evidence_unavailable_typed_failure_code
         ; test_case "startup cleanup observes atomic orphans" `Quick
             test_startup_cleanup_observes_atomic_orphans
         ] )


### PR DESCRIPTION
## 문제

`lib/fusion/fusion_delivery_projector.ml`에 typed variant `Evidence_unavailable`이 선언되고 `to_string` arm까지 존재했으나 생성자 0건의 dead variant였습니다. live 경로(`Done{ok=true; data=None}` 처리)는 `Fusion_sink.emit_failure … ~failure_code:"evidence_unavailable"`로 raw string을 직접 전달해 typed variant를 bypass하고 있었습니다 — 'no string matching where typed variants exist' doctrine 위반 + dead code.

Closes #25602

## 수정 내용

- live 경로가 `Evidence_unavailable` typed variant를 생성(`let error = Evidence_unavailable`)하고 소비하도록 변경
- `projection_error_failure_code : projection_error -> string` 추가 — sink failure_code string은 이 함수(`"evidence_unavailable"`)를 경유해서만 생성. sink로 전달되지 않는 다른 variant에 대해서는 새 문자열을 지어내지 않고 `Invalid_argument`로 fail-fast (exhaustive match 유지, silent failure 금지)
- `detail`도 `projection_error_to_string` 경유로 생성해 문자열 SSOT를 typed variant에 통일 (기존 자유형식 문자열 `"computation completed successfully without deliberation evidence"` → typed variant의 `"Fusion computation completed successfully without deliberation evidence"`)
- `.mli`에 `projection_error_failure_code` 노출 + 계약 문서화
- 회귀 테스트 `evidence_unavailable failure code is typed` 추가: typed variant → failure_code/detail 파생 단언 + 비-sink 오류의 fail-fast 단언

주변 `emit_failure` 호출부(`failure_of_status` 경유)는 `Keeper_msg_async.request_status` 기반의 별도 분류이고 이 이슈 범위 밖이라 그대로 두었습니다. `Fusion_sink` 계약(`~failure_code:string`)은 변경 없음 — 문자열 값 `"evidence_unavailable"`이 유지되어 downstream(런 레지스트리, board JSON) 소비는 그대로입니다.

## 근본 원인 분석

#25355에서 `Done{ok=true; data=None}` P1 remediation을 추가할 때 typed variant(`Evidence_unavailable`)와 `to_string` arm은 함께 선언했지만, live 호출부는 당시 편의상 raw string 리터럴을 직접 `emit_failure`에 넘겼습니다. 적대적 리뷰에서 P3로 지적됐으나 미해결 상태로 머지되면서 선언-사용 불일치가 고착화됐습니다. sink 인터페이스가 `~failure_code:string`이라 타입 시스템이 raw string bypass를 잡아주지 못한 것도 원인입니다 — 이번 수정처럼 생성 지점에서 typed variant 경유를 강제하는 코드 구조가 보완책입니다.

## 검증

- `scripts/dune-local.sh build lib/fusion test/test_fusion_delivery_obligation.exe` — PASS
- `_build/default/test/test_fusion_delivery_obligation.exe` — 6 tests 전부 PASS (신규 typed 단언 테스트 + 기존 `startup recovery remediates missing evidence` 포함)
- `bash scripts/ci/check-determinism-contract.sh` — PASS
- `bash scripts/ci/check-telemetry-coverage.sh` — PASS
- `bash scripts/lint-ignore-without-comment.sh` — exit 0
- `bash scripts/check-pr-hygiene.sh --base origin/main` — PASS
- `ocamlformat --check` (touched 3개 파일) — PASS