### PR TITLE
fix(keeper): keeper-scoped prune store 목록 SSOT 통합 (#25603)

### DIFF
--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -657,24 +657,16 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                      (Server_runtime_startup_maintenance
                       .prune_flat_jsonl_older_than ~days)
                    (Filename.concat masc "trajectories")
-               (* execution-receipts canonical layout is
-                  keepers/<name>/execution-receipts (dated) — no top-level
-                  writer exists, so prune keeper-scoped only. *)
-               + (let keepers = Filename.concat masc "keepers" in
-                  if not (Sys.file_exists keepers)
-                  then 0
-                  else
-                    Array.fold_left
-                      (fun acc name ->
-                        let keeper_dir = Filename.concat keepers name in
-                        if Sys.is_directory keeper_dir
-                        then
-                          acc
-                          + prune_dir
-                              (Filename.concat keeper_dir "execution-receipts")
-                        else acc)
-                      0
-                      (Sys.readdir keepers))
+               (* Keeper-scoped stores (metrics, crash-events,
+                  execution-receipts) live only under keepers/<name>/ — no
+                  top-level writer exists, so prune keeper-scoped only. The
+                  store list is the SSOT shared with the startup pass; the
+                  inline execution-receipts-only fold this replaced had
+                  already drifted, letting metrics/crash-events accumulate
+                  until restart. *)
+               + Server_runtime_startup_maintenance.prune_keeper_scoped_stores
+                   ~prune_dir
+                   ~masc_root:masc
              in
              if total > 0
              then

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -19,6 +19,26 @@ let prune_children_dirs ~prune_dir root =
       0
       (Sys.readdir root)
 
+(* Keeper-scoped dated-JSONL stores pruned by BOTH the startup pass and the
+   24h periodic pass. SSOT: both loops fold this exact list via
+   [prune_keeper_scoped_stores] — never reintroduce an inline store list in
+   either caller (the periodic pass once pruned only execution-receipts,
+   letting metrics/crash-events accumulate until restart). *)
+let keeper_scoped_dated_stores = [ "metrics"; "crash-events"; "execution-receipts" ]
+
+(* Fold [prune_dir] over every keeper-scoped dated store
+   ([keepers/<name>/<store>] for each store in [keeper_scoped_dated_stores]).
+   Built on [prune_children_dirs], so a missing keepers root counts 0 and
+   stray files under it are skipped. *)
+let prune_keeper_scoped_stores ~prune_dir ~masc_root =
+  prune_children_dirs
+    ~prune_dir:(fun keeper_dir ->
+      List.fold_left
+        (fun acc store -> acc + prune_dir (Filename.concat keeper_dir store))
+        0
+        keeper_scoped_dated_stores)
+    (Filename.concat masc_root "keepers")
+
 (* Trajectory stores are flat [<trace_id>.jsonl] files under
    [trajectories/<keeper>/] — no [YYYY-MM] month dirs — so
    [Dated_jsonl.prune] is a provable no-op on them.  Prune by file mtime
@@ -85,21 +105,14 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        + prune_recall_injections ()
        + prune_dir (Filename.concat masc "voice_sessions")
        (* trajectories: flat <trace_id>.jsonl under trajectories/<keeper>/ —
-          Dated_jsonl.prune is a no-op there, prune by mtime keeper-scoped.
-          Top-level masc/"execution-receipts" has no writer (canonical layout
-          is keepers/<name>/execution-receipts), so it is not pruned here. *)
+          Dated_jsonl.prune is a no-op there, prune by mtime keeper-scoped. *)
        + prune_children_dirs
            ~prune_dir:(prune_flat_jsonl_older_than ~days)
            (Filename.concat masc "trajectories")
-       + (let keepers = Filename.concat masc "keepers" in
-          if not (Sys.file_exists keepers) then 0
-          else
-            Array.fold_left (fun acc name ->
-              acc
-              + prune_dir (Filename.concat (Filename.concat keepers name) "metrics")
-              + prune_dir (Filename.concat (Filename.concat keepers name) "crash-events")
-              + prune_dir (Filename.concat (Filename.concat keepers name) "execution-receipts")
-            ) 0 (Sys.readdir keepers))
+       (* Top-level masc/"execution-receipts" has no writer (canonical layout
+          is keepers/<name>/<store>), so keeper-scoped stores are pruned via
+          the SSOT fold shared with the 24h periodic pass. *)
+       + prune_keeper_scoped_stores ~prune_dir ~masc_root:masc
        + prune_children_dirs ~prune_dir (Filename.concat masc "resilience_audit")
      in
      if total > 0 then

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -3,6 +3,19 @@ val prune_children_dirs : prune_dir:(string -> int) -> string -> int
     root path. Missing root counts 0; stray files are skipped.
     Exposed for unit tests. *)
 
+val keeper_scoped_dated_stores : string list
+(** Dated-JSONL stores pruned keeper-scoped ([keepers/<name>/<store>]) by
+    BOTH the startup pass and the 24h periodic pass. SSOT for both loops —
+    never reintroduce an inline store list in either caller. *)
+
+val prune_keeper_scoped_stores :
+  prune_dir:(string -> int) -> masc_root:string -> int
+(** Fold [prune_dir] over every [keepers/<name>/<store>] path, for each store
+    in [keeper_scoped_dated_stores] and each keeper dir under
+    [masc_root/keepers]. Missing keepers root counts 0. Shared by the startup
+    pass and the 24h periodic pass so both prune the same store set.
+    Exposed for unit tests. *)
+
 val prune_flat_jsonl_older_than : days:int -> string -> int
 (** Delete regular [*.jsonl] files directly under the given directory whose
     mtime is older than [days]; returns the number of files removed.

--- a/test/test_server_runtime_startup_maintenance.ml
+++ b/test/test_server_runtime_startup_maintenance.ml
@@ -1,4 +1,4 @@
-(** Unit tests for [Server_runtime_startup_maintenance.prune_children_dirs]. *)
+(** Unit tests for [Server_runtime_startup_maintenance] prune folds. *)
 
 module SM = Server_runtime_startup_maintenance
 
@@ -70,6 +70,59 @@ let test_prune_flat_jsonl_removes_old_files () =
   Alcotest.(check bool) "recent file kept" true (Sys.file_exists recent_file);
   Alcotest.(check bool) "non-jsonl file kept" true (Sys.file_exists stray)
 
+let visited = ref []
+
+let record_visit dir =
+  visited := dir :: !visited;
+  0
+
+let test_keeper_scoped_store_list_is_ssot () =
+  (* Drift guard: the 24h periodic pass used to prune execution-receipts
+     only while startup pruned all three. Pin the shared list so neither
+     loop can silently drop a store again. *)
+  Alcotest.(check (list string))
+    "keeper-scoped stores = metrics + crash-events + execution-receipts"
+    [ "crash-events"; "execution-receipts"; "metrics" ]
+    (List.sort String.compare SM.keeper_scoped_dated_stores)
+
+let test_prune_keeper_scoped_stores_visits_all_stores () =
+  (* Regression for the 24h loop drift: both loops call this function, so
+     every keeper must see prune_dir invoked for all three stores. *)
+  visited := [];
+  let masc_root = fresh_dir "masc_keeper_scoped" in
+  let keepers = Filename.concat masc_root "keepers" in
+  List.iter
+    (fun name -> Fs_compat.mkdir_p (Filename.concat keepers name))
+    [ "keeper-a"; "keeper-b" ];
+  let stray = Filename.concat keepers "stray.txt" in
+  let oc = open_out stray in
+  output_string oc "x";
+  close_out oc;
+  let n = SM.prune_keeper_scoped_stores ~prune_dir:record_visit ~masc_root in
+  Alcotest.(check int) "returns summed prune counts" 0 n;
+  let expected =
+    List.concat_map
+      (fun keeper ->
+        List.map
+          (fun store -> Filename.concat (Filename.concat keepers keeper) store)
+          SM.keeper_scoped_dated_stores)
+      [ "keeper-a"; "keeper-b" ]
+  in
+  Alcotest.(check (list string))
+    "all three stores pruned for every keeper"
+    (List.sort String.compare expected)
+    (List.sort String.compare !visited)
+
+let test_prune_keeper_scoped_stores_missing_root () =
+  visited := [];
+  let n =
+    SM.prune_keeper_scoped_stores
+      ~prune_dir:record_visit
+      ~masc_root:"/nonexistent/masc-keeper-scoped"
+  in
+  Alcotest.(check int) "missing keepers root counts 0" 0 n;
+  Alcotest.(check int) "prune_dir never called" 0 (List.length !visited)
+
 let () =
   Alcotest.run "server_runtime_startup_maintenance"
     [
@@ -84,5 +137,14 @@ let () =
         [
           Alcotest.test_case "populated trajectories dir prunes old files" `Quick
             test_prune_flat_jsonl_removes_old_files;
+        ] );
+      ( "prune_keeper_scoped_stores",
+        [
+          Alcotest.test_case "store list is SSOT (3 stores)" `Quick
+            test_keeper_scoped_store_list_is_ssot;
+          Alcotest.test_case "visits all three stores per keeper" `Quick
+            test_prune_keeper_scoped_stores_visits_all_stores;
+          Alcotest.test_case "missing keepers root counts zero" `Quick
+            test_prune_keeper_scoped_stores_missing_root;
         ] );
     ]


### PR DESCRIPTION
## 문제

`lib/server/server_bootstrap_maintenance.ml`의 24h 주기 prune 루프가 keeper-scoped store fold의 inline 3번째 사본을 들고 있었고, drift가 이미 실재했습니다:

- startup 루프(`server_runtime_startup_maintenance.ml`): `metrics` + `crash-events` + `execution-receipts` 3개 store를 keeper별로 prune
- 24h 루프: `execution-receipts`만 prune

그 결과 장기 실행 서버는 재시작 전까지 `.masc/keepers/<name>/metrics`, `crash-events`의 dated JSONL day-file이 무한 축적됐습니다.

Closes #25603

## 수정 내용

- `Server_runtime_startup_maintenance`에 SSOT 추가:
  - `keeper_scoped_dated_stores` — 두 루프가 공유하는 store 목록 상수 (`metrics`, `crash-events`, `execution-receipts`)
  - `prune_keeper_scoped_stores ~prune_dir ~masc_root` — `prune_children_dirs` 위에 구성된 공통 fold (keepers root 부재 시 0, stray file skip 가드 포함)
- startup 루프의 inline keeper fold(94-102행)를 공통 함수 호출로 교체
- 24h 루프의 inline keeper fold(663-677행)를 공통 함수 호출로 교체 → 3개 store 모두 prune
- 회귀 테스트 3건 추가 (`test/test_server_runtime_startup_maintenance.ml`):
  - SSOT 목록이 정확히 3개 store임을 pin (drift 가드)
  - keeper 2개 + stray file 환경에서 keeper당 3개 store 모두에 `prune_dir` 호출됨을 단언
  - keepers root 부재 시 0 반환 단언

## 근본 원인 분석

keeper-scoped prune 대상 store 목록이 타입/상수가 아닌 각 루프의 inline 리터럴로 존재했습니다. startup 루프에 `metrics`/`crash-events`가 추가될 때 24h 루프 사본은 갱신되지 않았고, 컴파일러가 잡아낼 수 있는 구조(공유 상수/공통 함수)가 없어 drift가 조용히 방치됐습니다. 목록을 SSOT 상수로 올리고 두 루프 모두 공통 fold를 호출하게 해 구조적으로 재발을 막았습니다.

### #25448와의 양립성

#25448(`fix/startup-prune-symlink-follow`, do-not-merge)이 같은 두 파일을 건드립니다. 이 PR은 main 기준으로만 작성됐으며, `prune_keeper_scoped_stores`는 `prune_children_dirs` + leaf `prune_dir` 조합이라 #25448의 가드 구조(`prune_children_dirs`의 lstat 가드, leaf의 `prune_store_dir`)와 같은 레이어에 정확히 대응됩니다. #25448이 먼저 머지되면 leaf 호출을 `prune_store_dir`로 바꾸는 1줄 리베이스, 이 PR이 먼저 머지되면 #25448 쪽이 공통 함수 안에서 가드를 적용하면 됩니다. 어느 순서든 충돌 지점은 공통 함수 본문 한 곳입니다.

## 검증

- `scripts/dune-local.sh build lib/server/` — PASS
- `scripts/dune-local.sh build test/test_server_runtime_startup_maintenance.exe` 후 실행 — 6/6 PASS (신규 3건 포함)
- `test_server_bootstrap_maintenance_memory_os.exe` — 3/3 PASS
- `bash scripts/ci/check-determinism-contract.sh` — PASS (DET/NDT gate)
- `bash scripts/ci/check-telemetry-coverage.sh` — PASS (TEL gate)
- `bash scripts/lint-ignore-without-comment.sh` — exit 0
- `bash scripts/check-pr-hygiene.sh --base origin/main` — PASS

dashboard TS 변경 없음 (`tsc`/vitest 해당 없음).
