### PR TITLE
refactor(board,keeper): addressing grammar 공유 리프 추출 + case 정책 통일 (#25601)

### DIFF
--- a/lib/board/board_audience.ml
+++ b/lib/board/board_audience.ml
@@ -1,31 +1,11 @@
 include Board_types
 
-let trim_token_edges value =
-  let is_word = function
-    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '@' | '_' | '-' -> true
-    | _ -> false
-  in
-  let length = String.length value in
-  let first = ref 0 in
-  let last = ref (length - 1) in
-  while !first < length && not (is_word value.[!first]) do
-    incr first
-  done;
-  while !last >= !first && not (is_word value.[!last]) do
-    decr last
-  done;
-  if !last < !first then "" else String.sub value !first (!last - !first + 1)
-;;
-
-let normalized_tokens content =
-  content
-  |> String.map (function
-    | '\t' | '\n' | '\r' -> ' '
-    | character -> character)
-  |> String.split_on_char ' '
-  |> List.map trim_token_edges
-  |> List.filter (fun token -> not (String.equal token ""))
-;;
+(* The tokenization grammar (edge trimming, whitespace splitting, [@@]
+   selectors, [@] target candidates) is shared with the Keeper write
+   boundary through [Board_addressing] (issue #25601).  This module owns
+   only the Board identity policy: candidates are validated through
+   [Agent_id.of_string], which is case-sensitive, and invalid candidates
+   fail closed as [Malformed_targets]. *)
 
 type explicit_address =
   | No_explicit_address
@@ -39,43 +19,30 @@ let compare_agent_id left right =
 ;;
 
 let explicit_address_of_text content =
-  let tokens = normalized_tokens content in
-  let selectors =
-    tokens
-    |> List.filter_map (fun token ->
-      if String.length token >= 2 && String.starts_with ~prefix:"@@" token
-      then
-        Some
-          (String.sub token 2 (String.length token - 2)
-           |> String.lowercase_ascii)
-      else None)
-    |> List.sort_uniq String.compare
-  in
-  if selectors <> [] && List.for_all (String.equal "all") selectors
-  then Broadcast_all
-  else if selectors <> []
-  then Unsupported_broadcast selectors
-  else (
+  match Board_addressing.parse content with
+  | Board_addressing.Broadcast_all -> Broadcast_all
+  | Board_addressing.Unsupported_broadcast selectors ->
+    Unsupported_broadcast selectors
+  | Board_addressing.No_explicit_address -> No_explicit_address
+  | Board_addressing.Raw_targets candidates ->
     let targets, malformed =
       List.fold_left
-        (fun (targets, malformed) token ->
-          if Char.equal token.[0] '@'
-             && not (String.starts_with ~prefix:"@@" token)
-          then
-            let candidate = String.sub token 1 (String.length token - 1) in
-            match Agent_id.of_string candidate with
-            | Ok target -> target :: targets, malformed
-            | Error _ -> targets, token :: malformed
-          else targets, malformed)
+        (fun (targets, malformed) candidate ->
+          match Agent_id.of_string candidate with
+          | Ok target -> target :: targets, malformed
+          | Error _ ->
+            (* Report the original [@]-prefixed token so the error message
+               shows what the author typed. *)
+            targets, (Board_addressing.target_prefix ^ candidate) :: malformed)
         ([], [])
-        tokens
+        candidates
     in
-    match List.sort_uniq String.compare malformed with
-    | _ :: _ as malformed -> Malformed_targets malformed
-    | [] ->
-      (match List.sort_uniq compare_agent_id targets with
-       | [] -> No_explicit_address
-       | _ :: _ as targets -> Explicit_targets targets))
+    (match List.sort_uniq String.compare malformed with
+     | _ :: _ as malformed -> Malformed_targets malformed
+     | [] ->
+       (match List.sort_uniq compare_agent_id targets with
+        | [] -> No_explicit_address
+        | _ :: _ as targets -> Explicit_targets targets))
 ;;
 
 let direct_targets_of_text content =

--- a/lib/board/dune
+++ b/lib/board/dune
@@ -39,6 +39,9 @@
   masc_random_id
   masc.config
   masc.masc_board
+  ;; Shared @-mention addressing grammar (issue #25601) — also used by the
+  ;; Keeper write boundary via the masc umbrella.
+  masc.board_addressing
   masc_types
   masc_core
   masc_log

--- a/lib/board_addressing/board_addressing.ml
+++ b/lib/board_addressing/board_addressing.ml
@@ -1,0 +1,81 @@
+(** Shared @-mention addressing grammar — see the interface.  The
+    tokenization is the case-preserving superset of the two legacy clones
+    ([keeper_lane_mentions] pre-folded case, [board_audience] preserved
+    it); equivalence against both legacy decision procedures is pinned by
+    test_keeper_lane_mentions, test_board_dispatch, and
+    test_board_addressing. *)
+
+let target_prefix = "@"
+let broadcast_selector_prefix = "@@"
+let broadcast_all_selector = "all"
+
+let trim_token_edges value =
+  let is_word = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '@' | '_' | '-' -> true
+    | _ -> false
+  in
+  let length = String.length value in
+  let first = ref 0 in
+  let last = ref (length - 1) in
+  while !first < length && not (is_word value.[!first]) do
+    incr first
+  done;
+  while !last >= !first && not (is_word value.[!last]) do
+    decr last
+  done;
+  if !last < !first then "" else String.sub value !first (!last - !first + 1)
+;;
+
+let tokens_of_text text =
+  text
+  |> String.map (function
+    | '\t' | '\n' | '\r' -> ' '
+    | character -> character)
+  |> String.split_on_char ' '
+  |> List.map trim_token_edges
+  |> List.filter (fun token -> not (String.equal token ""))
+;;
+
+type raw_address =
+  | No_explicit_address
+  | Raw_targets of string list
+  | Broadcast_all
+  | Unsupported_broadcast of string list
+
+let parse text =
+  let tokens = tokens_of_text text in
+  let prefix_length = String.length broadcast_selector_prefix in
+  let selectors =
+    tokens
+    |> List.filter_map (fun token ->
+      if
+        String.length token >= prefix_length
+        && String.starts_with ~prefix:broadcast_selector_prefix token
+      then
+        Some
+          (String.sub token prefix_length (String.length token - prefix_length)
+           |> String.lowercase_ascii)
+      else None)
+    |> List.sort_uniq String.compare
+  in
+  if selectors <> [] && List.for_all (String.equal broadcast_all_selector) selectors
+  then Broadcast_all
+  else if selectors <> []
+  then Unsupported_broadcast selectors
+  else (
+    let targets =
+      tokens
+      |> List.filter_map (fun token ->
+        (* [tokens_of_text] never yields empty tokens, so the [String.sub]
+           below is safe; a bare ["@"] reaches the caller as the empty
+           candidate. *)
+        if
+          String.starts_with ~prefix:target_prefix token
+          && not (String.starts_with ~prefix:broadcast_selector_prefix token)
+        then Some (String.sub token 1 (String.length token - 1))
+        else None)
+    in
+    match targets with
+    | [] -> No_explicit_address
+    | _ :: _ -> Raw_targets targets)
+;;

--- a/lib/board_addressing/board_addressing.mli
+++ b/lib/board_addressing/board_addressing.mli
@@ -1,0 +1,66 @@
+(** Board_addressing — the shared @-mention addressing grammar parsed at
+    the Board and Keeper write boundaries (issue #25601).
+
+    This leaf owns exactly one thing: turning free text into raw address
+    tokens.  It exists because [board_audience] and
+    [keeper_lane_mentions] each carried a private clone of the same
+    grammar (token edge trimming, whitespace splitting, [@@] broadcast
+    selectors, [@] direct targets) and the clones had already drifted —
+    the Keeper copy case-folded the whole content before tokenizing while
+    the Board copy preserved target case.
+
+    Case policy (the unification): the grammar is case-preserving.
+    Content is NOT lowercased before tokenization, and target candidates
+    keep the author's casing.  Case normalization is an identity concern
+    owned by each caller's id type:
+    - Keeper mints candidates through [Keeper_identity.Keeper_id.of_string],
+      whose documented contract case-folds and canonicalizes
+      (["@ALPHA"] and ["@alpha"] mint the same keeper id).
+    - Board validates candidates through [Board_types.Agent_id.of_string],
+      which is case-sensitive (["@MiXeD-Agent"] stays ["MiXeD-Agent"]).
+    Only [@@] selector {e comparison} is case-insensitive here
+    (["@@ALL"] is [Broadcast_all] on both sides, as both legacy copies
+    already behaved), and unsupported selectors are reported lowercased,
+    matching both legacy copies. *)
+
+val target_prefix : string
+(** ["@"] — the single-at direct-target prefix. *)
+
+val broadcast_selector_prefix : string
+(** ["@@"] — the double-at broadcast selector prefix. *)
+
+val broadcast_all_selector : string
+(** ["all"] — the only universally supported broadcast selector. *)
+
+val trim_token_edges : string -> string
+(** Trim non-word characters from both ends of a token, keeping internal
+    ones.  Word chars are [A-Za-z0-9@_-]; ['.'] is NOT a word char, so
+    ["@alice."] trims to ["@alice"] while the internal ['.'] in
+    ["email@alice.com"] is preserved (the whole token stays
+    ["email@alice.com"] and never equals ["@alice"]). *)
+
+val tokens_of_text : string -> string list
+(** Whitespace-split (['\t'], ['\n'], ['\r'] fold to [' ']) and edge-trim
+    the text into non-empty tokens.  Case is preserved. *)
+
+type raw_address =
+  | No_explicit_address  (** No [@]- or [@@]-tokens at all. *)
+  | Raw_targets of string list
+      (** Direct-address candidate names (leading ['@'] stripped), in
+          token order, case preserved, not yet validated or deduplicated.
+          A bare ["@"] yields the empty candidate; whether that is
+          malformed or simply not an id is the caller id type's call. *)
+  | Broadcast_all  (** Every [@@] selector was [all] (case-insensitive). *)
+  | Unsupported_broadcast of string list
+      (** At least one [@@] selector was not [all].  Selectors are
+          lowercased, sorted, and deduplicated. *)
+
+val parse : string -> raw_address
+(** Classify the address tokens of a text.  Broadcast selectors win over
+    direct targets: a line that mixes valid [@name] targets with any
+    [@@] selector is treated as a broadcast address, never as a partial
+    direct address.  When the selector is not [@@all] the result is
+    [Unsupported_broadcast] and the caller fails closed, dropping the
+    whole signal — the otherwise-valid direct targets are deliberately
+    NOT surfaced, because partially routing an ambiguous address would
+    silently reinterpret the author's intent. *)

--- a/lib/board_addressing/dune
+++ b/lib/board_addressing/dune
@@ -1,0 +1,16 @@
+; Board_addressing — shared @-mention addressing grammar (issue #25601).
+; Single source of truth for the tokenization + @@-selector grammar that
+; Board (board_audience) and Keeper (keeper_lane_mentions) both parse at
+; their write boundaries.  Stdlib-only so board_handlers (which cannot
+; import keeper modules) and the flat masc umbrella can both depend on it.
+; Identity minting stays with each caller's id type — this leaf returns
+; raw, case-preserved candidate names only.
+
+(include_subdirs no)
+
+(library
+ (name masc_board_addressing)
+ (public_name masc.board_addressing)
+ (wrapped false)
+ (modules board_addressing)
+ (libraries))

--- a/lib/dune
+++ b/lib/dune
@@ -255,6 +255,10 @@
   masc.masc_exec_command_gate
   ;; Board types (extracted sub-library — first step toward board isolation)
   masc_board
+  ;; Shared @-mention addressing grammar for Board + Keeper write
+  ;; boundaries (issue #25601). stdlib-only leaf; board_audience and
+  ;; keeper_lane_mentions both parse through it.
+  masc.board_addressing
   ;; Decoupled board handlers
   masc.board_handlers
   ;; Board MCP adapter: joins Board domain with neutral Tool substrate.

--- a/lib/keeper/keeper_lane_mentions.ml
+++ b/lib/keeper/keeper_lane_mentions.ml
@@ -1,46 +1,10 @@
-(** Boundary mention parser — see the interface.  The tokenization is a
-    verbatim relocation of the legacy read-time tokenizer
-    ([trim_token_edges] + whitespace split); equivalence against the
-    legacy decision procedure is pinned by test_keeper_lane_mentions. *)
-
-(* Trim non-word characters from both ends of a token, keeping internal
-   ones.  Word chars are [a-z0-9@_-]; '.' is NOT a word char, so
-   "@alice." trims to "@alice" while the internal '.' in
-   "email@alice.com" is preserved (the whole token stays
-   "email@alice.com" and never equals "@alice"). *)
-let trim_token_edges s =
-  let is_word c =
-    (c >= 'a' && c <= 'z')
-    || (c >= '0' && c <= '9')
-    || c = '@'
-    || c = '_'
-    || c = '-'
-  in
-  let n = String.length s in
-  let i = ref 0 in
-  let j = ref (n - 1) in
-  while !i < n && not (is_word s.[!i]) do
-    incr i
-  done;
-  while !j >= !i && not (is_word s.[!j]) do
-    decr j
-  done;
-  if !j < !i then "" else String.sub s !i (!j - !i + 1)
-;;
-
-let normalized_tokens content =
-  let normalized =
-    String.map
-      (fun c ->
-        match c with
-        | '\t' | '\n' | '\r' -> ' '
-        | _ -> c)
-      (String.lowercase_ascii content)
-  in
-  String.split_on_char ' ' normalized
-  |> List.map trim_token_edges
-  |> List.filter (fun token -> not (String.equal token ""))
-;;
+(** Boundary mention parser — see the interface.  The tokenization grammar
+    is shared with the Board write boundary through [Board_addressing]
+    (issue #25601); this module only mints the grammar's raw, case-preserved
+    target candidates through [Keeper_identity.Keeper_id.of_string], whose
+    documented contract case-folds and canonicalizes.  Equivalence against
+    the legacy (pre-folded) decision procedure is pinned by
+    test_keeper_lane_mentions. *)
 
 type explicit_address =
   | No_explicit_address
@@ -49,45 +13,18 @@ type explicit_address =
   | Unsupported_broadcast of string list
 
 let explicit_address_of_content content =
-  let tokens = normalized_tokens content in
-  (* Broadcast selectors win over direct targets: a line that mixes valid
-     [@keeper] targets with any [@@] selector is treated as a broadcast
-     address, never as a partial direct address.  When the selector is not
-     [@@all] the result is [Unsupported_broadcast] and the caller fails
-     closed, dropping the whole signal — the otherwise-valid direct targets
-     are deliberately NOT routed, because partially routing an ambiguous
-     address would silently reinterpret the author's intent. *)
-  let broadcast_selectors =
-    tokens
-    |> List.filter_map (fun token ->
-      if String.length token >= 2 && String.starts_with ~prefix:"@@" token
-      then Some (String.sub token 2 (String.length token - 2))
-      else None)
-    |> List.sort_uniq String.compare
-  in
-  if
-    broadcast_selectors <> []
-    && List.for_all (String.equal "all") broadcast_selectors
-  then Broadcast_all
-  else if broadcast_selectors <> []
-  then Unsupported_broadcast broadcast_selectors
-  else (
-    let targets =
-      tokens
-      |> List.filter_map (fun token ->
-        if
-          String.length token >= 2
-          && token.[0] = '@'
-          && not (String.starts_with ~prefix:"@@" token)
-        then
-          Keeper_identity.Keeper_id.of_string
-            (String.sub token 1 (String.length token - 1))
-        else None)
-      |> List.sort_uniq Keeper_identity.Keeper_id.compare
-    in
-    match targets with
-    | [] -> No_explicit_address
-    | _ :: _ -> Targets targets)
+  match Board_addressing.parse content with
+  | Board_addressing.Broadcast_all -> Broadcast_all
+  | Board_addressing.Unsupported_broadcast selectors ->
+    Unsupported_broadcast selectors
+  | Board_addressing.No_explicit_address -> No_explicit_address
+  | Board_addressing.Raw_targets candidates ->
+    (match
+       List.filter_map Keeper_identity.Keeper_id.of_string candidates
+       |> List.sort_uniq Keeper_identity.Keeper_id.compare
+     with
+     | [] -> No_explicit_address
+     | _ :: _ as targets -> Targets targets)
 ;;
 
 let mention_ids_of_content content =

--- a/lib/keeper/keeper_lane_mentions.mli
+++ b/lib/keeper/keeper_lane_mentions.mli
@@ -12,7 +12,9 @@
     mentions [x] when some whitespace-separated token equals ["@" ^ x]
     after trimming non-word edge characters.  Token equality, not
     substring — ["@alicex"] and ["email@alice.com"] do not mention
-    ["alice"].  On top of the legacy contract, extracted names are
+    ["alice"].  The grammar itself (edge trimming, whitespace splitting,
+    [@@] selectors) is shared with the Board write boundary via
+    [Board_addressing] (issue #25601); on top of it, extracted names are
     minted through {!Keeper_identity.Keeper_id.of_string}, so
     keeper-shaped forms (["@keeper-alice"]) canonicalize to the same
     id as the bare name. *)

--- a/test/board_addressing/dune
+++ b/test/board_addressing/dune
@@ -1,0 +1,6 @@
+; Standalone alcotest for the shared stdlib-only addressing grammar
+; (issue #25601).
+
+(tests
+ (names test_board_addressing)
+ (libraries alcotest masc.board_addressing))

--- a/test/board_addressing/test_board_addressing.ml
+++ b/test/board_addressing/test_board_addressing.ml
@@ -1,0 +1,87 @@
+(* Issue #25601: regression pins for the shared @-mention addressing
+   grammar extracted from the drifted keeper_lane_mentions /
+   board_audience clones.
+
+   Pinned here:
+   1. Tokenization goldens — edge trimming + whitespace splitting, with
+      case PRESERVED (the unification: case normalization is an identity
+      concern owned by each caller's id type, not by the grammar).
+   2. Address classification — [@@all] (any casing) is the only broadcast;
+      other [@@] selectors fail closed as [Unsupported_broadcast];
+      broadcast selectors win over direct targets.
+   3. Raw target candidates keep the author's casing and are neither
+      validated nor deduplicated — that is the identity layer's job
+      ([Keeper_id] folds case, [Agent_id] preserves it; both pinned by
+      their own boundary tests). *)
+
+open Alcotest
+
+let strings = list string
+
+let test_trim_token_edges () =
+  check string "trailing punctuation" "@alice" (Board_addressing.trim_token_edges "@alice,");
+  check string "wrapping parens" "@alice" (Board_addressing.trim_token_edges "(@alice)");
+  check string "email keeps internal dot" "email@alice.com"
+    (Board_addressing.trim_token_edges "email@alice.com");
+  check string "possessive apostrophe kept" "@sangsu's"
+    (Board_addressing.trim_token_edges "@sangsu's");
+  check string "all non-word" "" (Board_addressing.trim_token_edges "...")
+
+let test_tokens_of_text () =
+  check strings "whitespace variants split"
+    [ "hey"; "@alice"; "look" ]
+    (Board_addressing.tokens_of_text "hey\t@alice\nlook");
+  check strings "case is preserved"
+    [ "PING"; "@ALICE"; "NOW" ]
+    (Board_addressing.tokens_of_text "PING @ALICE NOW");
+  check strings "empty tokens dropped" [ "@alice" ]
+    (Board_addressing.tokens_of_text "   @alice   ")
+
+let raw_address_to_string = function
+  | Board_addressing.No_explicit_address -> "none"
+  | Board_addressing.Broadcast_all -> "broadcast"
+  | Board_addressing.Raw_targets targets ->
+    "targets:" ^ String.concat "," targets
+  | Board_addressing.Unsupported_broadcast selectors ->
+    "unsupported:" ^ String.concat "," selectors
+
+let check_parse label expected content =
+  check string label expected (raw_address_to_string (Board_addressing.parse content))
+
+let test_parse_targets () =
+  check_parse "unaddressed" "none" "plain Board update";
+  check_parse "single target" "targets:alpha" "hey @alpha look";
+  check_parse "target case preserved" "targets:MiXeD-Agent"
+    "@MiXeD-Agent inspect this";
+  check_parse "duplicate casings not deduplicated (identity-level concern)"
+    "targets:ALPHA,alpha" "@ALPHA and @alpha";
+  check_parse "token order preserved" "targets:beta,alpha" "@beta and @alpha";
+  check_parse "email is one token" "none" "send to email@alice.com";
+  check_parse "mid-token at is not a target" "none" "mid@alice token";
+  check_parse "bare at is the empty candidate" "targets:" "@ bare at";
+  check_parse "trailing punctuation trimmed" "targets:alice" "ok @alice, thanks";
+  check_parse "possessive stays distinct" "targets:sangsu's" "@sangsu's note"
+
+let test_parse_broadcast () =
+  check_parse "exact broadcast" "broadcast" "release note @@all";
+  check_parse "broadcast selector compare is case-insensitive" "broadcast"
+    "release note @@ALL";
+  check_parse "unsupported selector" "unsupported:analyst" "release note @@analyst";
+  check_parse "unsupported selectors lowercased" "unsupported:analyst"
+    "release note @@Analyst";
+  check_parse "empty broadcast selector fails closed" "unsupported:" "release @@";
+  check_parse "mixed all and unsupported fails closed" "unsupported:all,analyst"
+    "@@all @@analyst";
+  check_parse "broadcast precedence over direct targets" "broadcast"
+    "@@all and @alpha";
+  check_parse "unsupported broadcast hides direct targets" "unsupported:analyst"
+    "@@analyst and @alpha"
+
+let () =
+  run "board_addressing"
+    [ ( "tokenization",
+        [ test_case "trim_token_edges" `Quick test_trim_token_edges;
+          test_case "tokens_of_text" `Quick test_tokens_of_text ] );
+      ( "parse",
+        [ test_case "targets" `Quick test_parse_targets;
+          test_case "broadcast" `Quick test_parse_broadcast ] ) ]

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1714,6 +1714,25 @@ let test_write_boundary_emits_typed_audience () =
      | _ -> Alcotest.fail "expected one exact Board target")
 ;;
 
+let test_target_case_is_identity_level () =
+  (* #25601: the shared grammar (Board_addressing) preserves target case;
+     case normalization is an identity-level concern.  Board agent ids are
+     case-sensitive, so differently-cased targets stay DISTINCT here —
+     while the Keeper boundary folds them into one canonical id (pinned in
+     test_keeper_lane_mentions). *)
+  match
+    Board.audience_for_post ~visibility:Board.Public ~title:""
+      ~content:"@MiXeD-Agent and @mixed-agent"
+  with
+  | Ok (Board.Targets targets) ->
+    Alcotest.(check (list string))
+      "Board targets keep distinct casings"
+      [ "MiXeD-Agent"; "mixed-agent" ]
+      (List.map Board.Agent_id.to_string targets)
+  | Ok _ -> Alcotest.fail "expected exact targets"
+  | Error error -> Alcotest.fail (Board.show_board_error error)
+;;
+
 (** {1 SubBoard CRUD} *)
 
 let test_sub_board_create_and_get () =
@@ -2161,6 +2180,8 @@ let () =
         (with_eio test_malformed_target_fails_closed);
       Alcotest.test_case "write emits typed audience" `Quick
         (with_eio test_write_boundary_emits_typed_audience);
+      Alcotest.test_case "target case is identity-level" `Quick
+        (with_eio test_target_case_is_identity_level);
     ];
     "sub_boards", [
       Alcotest.test_case "create and get" `Quick (with_eio test_sub_board_create_and_get);

--- a/test/test_keeper_lane_mentions.ml
+++ b/test/test_keeper_lane_mentions.ml
@@ -34,6 +34,11 @@ let test_parser_goldens () =
   check ids "different token" [ "alicex" ] (parse "ping @alicex now");
   check ids "email is one token" [] (parse "send to email@alice.com");
   check ids "case folded" [ "alice" ] (parse "PING @ALICE NOW");
+  (* #25601: the shared grammar preserves case; the case-fold now happens
+     only inside [Keeper_id.of_string], so duplicate casings of the same
+     mention still mint ONE canonical id. *)
+  check ids "duplicate casings mint one id" [ "alice" ]
+    (parse "@ALICE and @alice");
   check ids "trailing punctuation" [ "alice" ] (parse "ok @alice, thanks");
   check ids "no mention" [] (parse "just chatting here");
   check ids "newline separated" [ "alice" ] (parse "line one\n@alice two");


### PR DESCRIPTION
## 문제

`lib/board/board_audience.ml`이 `lib/keeper/keeper_lane_mentions.ml`의 addressing grammar(trim_token_edges, whitespace tokenization, `@@`-selector/`@@all` 분류, explicit_address variant)를 복제했고 이미 drift 발생: Keeper copy는 content 전체를 lowercase, Board copy는 target case 보존. 결과적으로 `@ALPHA`가 어느 파서를 타느냐에 따라 다른 identity로 해석됐다.

Closes #25601

## 수정 내용

- **신규 공유 리프 `lib/board_addressing/` (`masc.board_addressing`, stdlib-only, wrapped false)**: addressing grammar의 SSOT. `trim_token_edges`, `tokens_of_text`, `parse`(→ `No_explicit_address` / `Raw_targets` / `Broadcast_all` / `Unsupported_broadcast`)를 소유. 경계 규칙(rule 8: Board→Keeper import 부적절)상 `board_handlers`와 flat `masc` umbrella 양쪽이 의존 가능한 가장 낮은 레이어에 배치.
- **case 정책 통일**: grammar는 case를 보존하고, case 정규화는 identity 레이어(각 id 타입)의 책임으로 이동.
  - 근거: `Keeper_identity.Keeper_id.of_string`(lib/keeper/keeper_identity.ml:136)은 lowercase fold + canonicalize가 문서화된 계약 → `@ALPHA`/`@alpha`는 동일 keeper id로 mint(회귀 핀 추가).
  - `Board_types.Agent_id`(lib/board_types/board_types.ml:83)는 검증 패턴이 대소문자 혼용을 허용하고 case-sensitive → `@MiXeD-Agent`는 그대로 유지(기존 핀 유지 + case-distinct target 구분 핀 추가).
  - `@@` selector 비교만 case-insensitive(`@@ALL` = `@@all`) — 두 legacy copy 모두 이미 그렇게 동작.
- **`keeper_lane_mentions.ml` / `board_audience.ml`**: 복제된 grammar를 삭제하고 `Board_addressing.parse` 위임으로 교체. 각 모듈은 자기 id 타입으로의 mint/검증(Keeper: `Keeper_id.of_string` filter_map, Board: `Agent_id.of_string` + `Malformed_targets` fail-closed)만 유지. 공개 인터페이스(.mli) 변경 없음.

## 근본 원인 분석

Board↔Keeper 경계상 Board가 Keeper 모듈을 import할 수 없어 grammar가 필요한 쪽(Board)이 Keeper 구현을 클론했다. 공유 하위 라이브러리가 없으니 클론 이후 한쪽(Keeper의 legacy tokenizer 이전)만 lowercase 정책을 물고 왔고 다른 쪽은 case 보존으로 새 테스트가 핀되면서 조용히 drift. "문법"과 "identity 해석"이라는 서로 다른 관심사가 한 함수에 섞여 있었던 것이 drift가 테스트로도 잡히지 않은 이유 — 이번에 문법(case-preserving)과 identity(id 타입별 정규화)를 분리해 각각 핀했다.

## 검증

- `scripts/dune-local.sh build lib/board_addressing lib/board` → OK
- `scripts/dune-local.sh build lib test/board_addressing test/test_keeper_lane_mentions.exe test/test_board_dispatch.exe` → OK
- `test/board_addressing/test_board_addressing.exe` → 4/4 OK (신규 리프 골든: trim/tokenize/parse + case 보존 + broadcast precedence)
- `test/test_keeper_lane_mentions.exe` → 8/8 OK (기존 골든 + legacy 결정 절차 동치 코퍼스 + 신규 "duplicate casings mint one id" 핀)
- `test/test_board_dispatch.exe` → 78/80 OK. 실패 2건(`posts.12 dedup hit does not fan out`, `posts.20 dashboard projection`)은 addressing과 무관하며 **clean `origin/main`(5f643ec24b) 별도 worktree에서도 동일하게 실패 확인** — pre-existing.
- Repo gates: `check-pr-hygiene.sh` PASS, `check-determinism-contract.sh` PASS, `check-telemetry-coverage.sh` PASS(신규 순수 파서 모듈에 대한 WARN만), `lint-ignore-without-comment.sh` PASS(신규 ignore 없음)
