### PR TITLE
fix(keeper): accept legacy owner_generation wire key on read paths (#25599)

### DIFF
--- a/lib/keeper/keeper_paused_work_operator_request.ml
+++ b/lib/keeper/keeper_paused_work_operator_request.ml
@@ -225,9 +225,27 @@ let parse_source_terminal = function
   | _ -> Error "settle_from_source_terminal request fields are not exact"
 ;;
 
+(* Wire-compat (#25599): pre-rename clients send the fencing counter as
+   ["owner_generation"]. During the deprecation window both keys are accepted;
+   the new ["owner_nonce"] key wins when a request carries both. Normalising to
+   the new key keeps the exact-field parsers below as the single authority on
+   request shape. *)
+let normalize_legacy_owner_generation_key fields =
+  if List.mem_assoc "owner_nonce" fields
+  then
+    List.filter
+      (fun (name, _) -> not (String.equal name "owner_generation"))
+      fields
+  else
+    List.map
+      (fun (name, value) ->
+        if String.equal name "owner_generation" then "owner_nonce", value else name, value)
+      fields
+;;
+
 let of_yojson = function
   | `Assoc fields ->
-    let fields = sorted fields in
+    let fields = sorted (normalize_legacy_owner_generation_key fields) in
     (match List.assoc_opt "operation" fields, List.assoc_opt "source_state" fields with
      | Some (`String "resume_owner"), _ -> parse_resume fields
      | Some (`String "cancel_accepted"), Some (`String "pending") ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -1545,6 +1545,29 @@ let int_field ~context name fields =
   | _ -> Error (Printf.sprintf "%s.%s must be an int" context name)
 ;;
 
+(* Wire-compat (#25599): pre-rename persisted rows (snapshot "last_settlement",
+   "transition_outbox", "accepted_transfer_projections" and every settlement
+   WAL entry) carry the fencing counter under ["owner_generation"]; post-rename
+   rows use ["owner_nonce"]. Read both — the new key wins when a row carries
+   both — so replay of pre-rename state survives the rename boundary. The
+   writer keeps emitting only ["owner_nonce"]. *)
+let owner_nonce_field ~context fields =
+  let parse name = function
+    | `Int value -> Ok value
+    | _ -> Error (Printf.sprintf "%s.%s must be an int" context name)
+  in
+  match List.assoc_opt "owner_nonce" fields with
+  | Some value -> parse "owner_nonce" value
+  | None ->
+    (match List.assoc_opt "owner_generation" fields with
+     | Some value -> parse "owner_generation" value
+     | None ->
+       Error
+         (Printf.sprintf
+            "%s missing required field owner_nonce (or legacy owner_generation)"
+            context))
+;;
+
 let int64_field ~context name fields =
   let* value = required_field ~context name fields in
   match value with
@@ -1758,6 +1781,7 @@ let settlement_of_yojson json =
           ; "source"
           ; "source_revision"
           ; "owner_nonce"
+          ; "owner_generation"
           ; "operator_operation_id"
           ; "reason"
           ]
@@ -1766,7 +1790,7 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
     let* source_revision = int64_field ~context "source_revision" fields in
-    let* owner_nonce = int_field ~context "owner_nonce" fields in
+    let* owner_nonce = owner_nonce_field ~context fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in
@@ -1785,6 +1809,7 @@ let settlement_of_yojson json =
           ; "source"
           ; "source_revision"
           ; "owner_nonce"
+          ; "owner_generation"
           ; "operator_operation_id"
           ; "from_keeper"
           ; "to_keeper"
@@ -1794,7 +1819,7 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
     let* source_revision = int64_field ~context "source_revision" fields in
-    let* owner_nonce = int_field ~context "owner_nonce" fields in
+    let* owner_nonce = owner_nonce_field ~context fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in
@@ -1820,6 +1845,7 @@ let settlement_of_yojson json =
           ; "source"
           ; "source_revision"
           ; "owner_nonce"
+          ; "owner_generation"
           ; "operator_operation_id"
           ; "source_receipt_kind"
           ]
@@ -1828,7 +1854,7 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
     let* source_revision = int64_field ~context "source_revision" fields in
-    let* owner_nonce = int_field ~context "owner_nonce" fields in
+    let* owner_nonce = owner_nonce_field ~context fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -884,16 +884,27 @@ type parsed_bulk_directive =
       }
   | Bulk_resume_owner of bulk_resume_target list
 
+let resume_owner_nonce json =
+  (* Wire-compat (#25599): pre-rename dashboard/operator clients send the
+     fencing counter as ["owner_generation"]. During the deprecation window
+     both keys are accepted; the new ["owner_nonce"] key wins when a request
+     carries both. *)
+  match Safe_ops.json_int_opt "owner_nonce" json with
+  | Some _ as nonce -> nonce
+  | None -> Safe_ops.json_int_opt "owner_generation" json
+
 let required_resume_owner_request json =
   match
-    Safe_ops.json_int_opt "owner_nonce" json,
+    resume_owner_nonce json,
     Safe_ops.json_string_opt "operator_operation_id" json
   with
   | Some owner_nonce, Some operator_operation_id ->
     Ok
       Keeper_paused_work_resume_transaction.
         { owner_nonce; operator_operation_id }
-  | None, _ -> Error "resume requires integer \"owner_nonce\""
+  | None, _ ->
+    Error
+      "resume requires integer \"owner_nonce\" (or legacy \"owner_generation\")"
   | _, None -> Error "resume requires string \"operator_operation_id\""
 
 let parse_keeper_directive_json json =

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2190,6 +2190,182 @@ let test_legacy_settlement_wal_v1_remains_replayable () =
       (Fs_compat.load_file wal_path))
 ;;
 
+(* Regression (#25599): #25535 renamed the persisted fencing-counter wire key
+   ["owner_generation"] -> ["owner_nonce"] with no reader fallback, so replay
+   of any pre-rename snapshot / settlement WAL row carrying a source-bearing
+   settlement failed with "row fields are not exact". The reader must accept
+   the legacy key (new key wins when both are present) while the writer keeps
+   emitting only ["owner_nonce"]. *)
+let rec rename_owner_nonce_to_legacy = function
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (name, value) ->
+           ( (if String.equal name "owner_nonce" then "owner_generation" else name)
+           , rename_owner_nonce_to_legacy value ))
+         fields)
+  | `List items -> `List (List.map rename_owner_nonce_to_legacy items)
+  | other -> other
+;;
+
+let test_legacy_owner_generation_wire_key_replays () =
+  let accepted = stimulus "legacy-owner-key-source" 1.0 in
+  let claimed, lease =
+    State.empty
+    |> State.with_pending (queue [ accepted ])
+    |> State.with_revision 7L
+    |> State.claim_when ~claimed_at:3.0 ~ready:(fun _ -> true)
+    |> require_ok "claim legacy owner-key fixture"
+  in
+  let lease = require_some "legacy owner-key lease" lease in
+  let cancellation =
+    accepted_cancellation
+      ~source:accepted
+      ~source_revision:7L
+      ~owner_nonce:4
+      "op-legacy-owner-key"
+  in
+  let settled, receipt =
+    match
+      State.cancel_accepted
+        ~current_owner_nonce:4
+        ~settled_at:4.0
+        ~lease
+        ~cancellation
+        claimed
+      |> require_ok "cancel legacy owner-key source"
+    with
+    | state, State.Settled receipt -> state, receipt
+    | _, State.Already_settled _ ->
+      Alcotest.fail "legacy owner-key fixture replayed early"
+  in
+  (* 1) Receipt codec: a pre-rename receipt decodes to the same value. *)
+  let legacy_receipt_json =
+    rename_owner_nonce_to_legacy (State.transition_receipt_to_yojson receipt)
+  in
+  let decoded =
+    State.transition_receipt_of_yojson legacy_receipt_json
+    |> require_ok "legacy owner_generation receipt decode"
+  in
+  Alcotest.(check bool)
+    "legacy-key receipt roundtrips"
+    true
+    (State.transition_receipt_equal receipt decoded);
+  (* 2) Snapshot codec: a pre-rename snapshot (last_settlement + outbox carry
+     the settlement) loads. *)
+  let legacy_snapshot = rename_owner_nonce_to_legacy (State.to_yojson settled) in
+  let restored =
+    State.of_yojson legacy_snapshot
+    |> require_ok "legacy owner_generation snapshot decode"
+  in
+  Alcotest.(check int)
+    "legacy snapshot keeps the outbox transition"
+    1
+    (List.length (State.transition_outbox restored));
+  (* 3) New key wins when a row carries both keys. *)
+  let both_keys_json =
+    match State.transition_receipt_to_yojson receipt with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (name, value) ->
+             match name, value with
+             | "settlement", `Assoc settlement_fields ->
+               name, `Assoc (("owner_generation", `Int 99) :: settlement_fields)
+             | _ -> name, value)
+           fields)
+    | other -> other
+  in
+  let decoded_both =
+    State.transition_receipt_of_yojson both_keys_json
+    |> require_ok "both-keys receipt decode"
+  in
+  (match decoded_both.State.settlement with
+   | State.Cancel_accepted decoded_cancellation ->
+     Alcotest.(check int)
+       "owner_nonce wins over legacy owner_generation"
+       4
+       decoded_cancellation.owner_nonce
+   | _ -> Alcotest.fail "both-keys decode changed the settlement kind");
+  (* 4) WAL replay: a pre-rename settlement row replays through persistence. *)
+  with_temp_dir "keeper-event-queue-legacy-owner-key" (fun base_path ->
+    let keeper_name = "legacy_owner_key_owner" in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending (stimulus "legacy-owner-key-wal-source" 1.0))
+    |> require_ok "seed legacy owner-key WAL owner";
+    let lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:2.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim legacy owner-key WAL source"
+      |> require_some "legacy owner-key WAL lease"
+    in
+    let claimed =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load legacy owner-key WAL pre-settlement state"
+    in
+    let source =
+      match Persistence.lease_stimuli lease with
+      | [ source ] -> source
+      | _ -> Alcotest.fail "legacy owner-key WAL lease lost its source"
+    in
+    let cancellation =
+      accepted_cancellation
+        ~source
+        ~source_revision:(State.revision claimed)
+        ~owner_nonce:4
+        "op-legacy-owner-key-wal"
+    in
+    let receipt =
+      match
+        State.cancel_accepted
+          ~current_owner_nonce:4
+          ~settled_at:3.0
+          ~lease
+          ~cancellation
+          claimed
+        |> require_ok "construct legacy owner-key WAL receipt"
+      with
+      | _, State.Settled receipt -> receipt
+      | _, State.Already_settled _ ->
+        Alcotest.fail "legacy owner-key WAL fixture replayed early"
+    in
+    let wal_path =
+      Filename.concat
+        (keeper_dir ~base_path ~keeper_name)
+        "event-queue-settlements.jsonl"
+    in
+    let row =
+      `Assoc
+        [ "schema", `String "masc.keeper_event_queue.settlement.v1"
+        ; "base_path", `String (Unix.realpath base_path)
+        ; "keeper_name", `String keeper_name
+        ; ( "receipt"
+          , rename_owner_nonce_to_legacy
+              (State.transition_receipt_to_yojson receipt) )
+        ]
+      |> Yojson.Safe.to_string
+      |> fun row -> row ^ "\n"
+    in
+    Fs_compat.save_file_atomic wal_path row
+    |> require_ok "write legacy owner-key WAL row";
+    let replayed =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "replay legacy owner-key WAL row"
+    in
+    Alcotest.(check int)
+      "legacy owner-key WAL settles active lease"
+      0
+      (List.length (State.leases replayed));
+    Alcotest.(check int)
+      "legacy owner-key WAL recreates transition outbox"
+      1
+      (List.length (State.transition_outbox replayed)))
+;;
+
 let test_context_compaction_retry_is_durable_and_lane_local () =
   with_temp_dir "keeper-event-queue-v2-retry-tail" (fun base_path ->
     let keeper_name = "retry_tail_keeper" in
@@ -2686,6 +2862,10 @@ let () =
             "legacy settlement WAL v1 remains replayable"
             `Quick
             test_legacy_settlement_wal_v1_remains_replayable
+        ; Alcotest.test_case
+            "legacy owner_generation wire key replays"
+            `Quick
+            test_legacy_owner_generation_wire_key_replays
         ; Alcotest.test_case
             "unsupported snapshots fail closed"
             `Quick

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -168,6 +168,59 @@ let test_strict_request_codec () =
    | Ok _ -> Alcotest.fail "source-terminal request accepted a mismatched receipt")
 ;;
 
+(* Regression (#25599): pre-rename clients send the fencing counter as
+   ["owner_generation"]. During the deprecation window the operator request
+   codec accepts the legacy key; the new ["owner_nonce"] key wins when a
+   request carries both. *)
+let test_legacy_owner_generation_key_is_accepted () =
+  let legacy_resume =
+    common
+      "resume_owner"
+      [ "owner_generation", `Int 7
+      ; "operator_operation_id", `String "operator-resume-legacy"
+      ]
+  in
+  (match Operator.request_of_yojson legacy_resume with
+   | Ok
+       (Operator.Resume_owner
+         { owner_nonce = 7; operator_operation_id = "operator-resume-legacy" }) ->
+     ()
+   | Ok _ -> Alcotest.fail "legacy resume request decoded to the wrong operation"
+   | Error detail -> Alcotest.fail detail);
+  let both_keys =
+    common
+      "resume_owner"
+      [ "owner_generation", `Int 99
+      ; "owner_nonce", `Int 7
+      ; "operator_operation_id", `String "operator-resume-both"
+      ]
+  in
+  (match Operator.request_of_yojson both_keys with
+   | Ok
+       (Operator.Resume_owner
+         { owner_nonce = 7; operator_operation_id = "operator-resume-both" }) ->
+     ()
+   | Ok _ -> Alcotest.fail "both-keys resume request decoded to the wrong operation"
+   | Error detail -> Alcotest.fail detail);
+  let legacy_cancel =
+    common
+      "cancel_accepted"
+      [ "source_state", `String "pending"
+      ; "source", Queue.stimulus_to_yojson board_source
+      ; "source_revision", int64_json 11L
+      ; "owner_generation", `Int 7
+      ; "operator_operation_id", `String "operator-cancel-legacy"
+      ; "reason", `String "operator rejected retained work"
+      ; "settled_at", `Float 3.0
+      ]
+  in
+  match Operator.request_of_yojson legacy_cancel with
+  | Ok (Operator.Cancel_pending request) ->
+    Alcotest.(check int) "legacy cancel nonce" 7 request.owner_nonce
+  | Ok _ -> Alcotest.fail "legacy cancellation decoded to the wrong operation"
+  | Error detail -> Alcotest.fail detail
+;;
+
 let test_inventory_exposes_exact_durable_fences () =
   let base_path = Filename.temp_dir "keeper-paused-work-operator" "" in
   Fun.protect
@@ -268,7 +321,12 @@ let () =
   Alcotest.run
     "keeper paused-work operator"
     [ ( "codec"
-      , [ Alcotest.test_case "strict four-way request codec" `Quick test_strict_request_codec ] )
+      , [ Alcotest.test_case "strict four-way request codec" `Quick test_strict_request_codec
+        ; Alcotest.test_case
+            "legacy owner_generation key is accepted"
+            `Quick
+            test_legacy_owner_generation_key_is_accepted
+        ] )
     ; ( "inventory"
       , [ Alcotest.test_case
             "durable exact identity and revision"

--- a/test/test_keeper_paused_work_resume_surface.ml
+++ b/test/test_keeper_paused_work_resume_surface.ml
@@ -62,6 +62,37 @@ let test_bulk_resume_requires_per_owner_targets () =
     parsed
 ;;
 
+let test_legacy_owner_generation_key_is_accepted () =
+  (* Regression (#25599): pre-rename dashboard clients send the fencing counter
+     as ["owner_generation"]. During the deprecation window both keys are
+     accepted; the new ["owner_nonce"] key wins when a request carries both. *)
+  let legacy =
+    Surface.parse_resume_request
+      (`Assoc
+         [ "action", `String "resume"
+         ; "owner_generation", `Int 7
+         ; "operator_operation_id", `String "dashboard-resume-legacy-7"
+         ])
+    |> require_ok "parse legacy-key Resume_owner"
+  in
+  check (pair int string) "legacy key fences" (7, "dashboard-resume-legacy-7") legacy;
+  let both_keys =
+    Surface.parse_resume_request
+      (`Assoc
+         [ "action", `String "resume"
+         ; "owner_generation", `Int 99
+         ; "owner_nonce", `Int 7
+         ; "operator_operation_id", `String "dashboard-resume-both-7"
+         ])
+    |> require_ok "parse both-keys Resume_owner"
+  in
+  check
+    (pair int string)
+    "owner_nonce wins over legacy owner_generation"
+    (7, "dashboard-resume-both-7")
+    both_keys
+;;
+
 let () =
   run
     "keeper paused-work resume surface"
@@ -74,6 +105,10 @@ let () =
             "bulk requires per-owner targets"
             `Quick
             test_bulk_resume_requires_per_owner_targets
+        ; test_case
+            "legacy owner_generation key is accepted"
+            `Quick
+            test_legacy_owner_generation_key_is_accepted
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

#25535(머지됨)가 영속 JSON wire 키를 `owner_generation` → `owner_nonce`로 fallback 없이 rename하면서, rename 이전에 기록된 event-queue snapshot / settlement WAL row가 upgrade 후 replay 시 실패("row fields are not exact") — paused-work settlement 상태가 restart를 넘지 못해 Keeper durability spec 위반. operator/dashboard 외부 API 표멸도 구 클라이언트를 전부 reject.

Closes #25599

## 수정 내용

- `lib/keeper_runtime/keeper_event_queue_state.ml`: 영속 settlement reader(`cancel_accepted` / `transfer_accepted` / `settle_from_source_terminal`)가 `owner_nonce` → `owner_generation` 순으로 fallback 조회. 두 키가 동시에 있으면 새 키 우선. writer는 새 키만 유지(변경 없음).
- `lib/keeper/keeper_paused_work_operator_request.ml`: operator request codec이 deprecation 기간 동안 양쪽 키 수용 — exact-field parse 전에 legacy 키를 새 키로 정규화(새 키 있으면 legacy 키 drop, 새 키 우선)하여 request shape 판정은 기존 parser가 단일 권위로 유지.
- `lib/server/server_dashboard_http_keeper_api_post.ml`: dashboard resume fence(`required_resume_owner_request`, single/bulk 공용)가 양쪽 키 수용, 새 키 우선. 에러 메시지에 legacy 키 명시.
- 회귀 테스트:
  - `test_keeper_event_queue_state_v2.ml`: 구 포맷(`owner_generation` 키만 있는) receipt codec / snapshot decode / settlement WAL v1 row replay + both-keys 시 새 키 우선.
  - `test_keeper_paused_work_operator.ml`: legacy 키 resume/cancel decode + both-keys 우선순위.
  - `test_keeper_paused_work_resume_surface.ml`: dashboard resume surface legacy 키 수용 + both-keys 우선순위.

## 근본 원인 분석

#25535가 meta 파일에서는 동일 클래스 버그를 인지해 수정('would load as nonce = 0' 커밋으로 `generation` 키 복원)했으나, event-queue 영속 JSON과 API 표면에는 동일 수정이 적용되지 않음. 첫 적대적 리뷰가 P1로 명시했으나 delta 리뷰가 meta 표멧만 재검증하고 승인하면서 누락. wire 키 rename 시 reader fallback(또는 키 유지)이 모든 영속/외부 표면에 일괄 적용됐는지 검증하는 체크가 없었던 것이 구조적 원인.

## 검증

- `scripts/dune-local.sh build lib/keeper_runtime/ lib/keeper/ lib/server/ test/test_keeper_event_queue_state_v2.exe test/test_keeper_paused_work_operator.exe test/test_keeper_paused_work_resume_surface.exe` — 성공
- `test_keeper_event_queue_state_v2.exe` — 35/35 통과 (신규 "legacy owner_generation wire key replays" 포함)
- `test_keeper_paused_work_operator.exe` — codec 2/2 통과. inventory 1건 실패는 base commit(5f643ec2)에서도 동일하게 재현되는 기존 실패(`to_int` on intlit, 본 변경과 무관)임을 base worktree에서 확인
- `test_keeper_paused_work_resume_surface.exe` — 3/3 통과
- `dune build @fmt` — 변경 .ml 파일 포맷 diff 없음 (dune 파일 drift는 main 기존 상태)
- `scripts/ci/check-determinism-contract.sh` — PASS
- `scripts/ci/check-telemetry-coverage.sh` — PASS
- `scripts/lint-ignore-without-comment.sh` — exit 0 (신규 ignore() 없음)
- `scripts/check-pr-hygiene.sh --base 5f643ec2...` — PASS

로컬 환경 참고: macOS `/var` → `/private/var` 심볼릭링크 때문에 TMPDIR를 canonical 경로로 설정하지 않으면 WAL owner-lane 매칭 테스트(기존 `legacy settlement WAL v1 remains replayable` 포함)가 실패함 — 본 변경과 무관한 환경 이슈.