### PR TITLE
fix(keeper): retry transient board read before dropping keepalive signal (#25600)

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -436,6 +436,85 @@ let deliver_addressed_board_signal
   | Keeper_registry_event_queue.Stimulus_storage_error detail -> Error detail
 ;;
 
+(* #25600 — a transient board-store read failure must not silently drop the
+   whole signal for a lane.
+
+   [Keeper_board_audience.route_for_keeper] only touches the board store on
+   the [Thread_participants] route ([Board_signal.wake_reason] re-reads the
+   post/comment stream); the [Targets]/[Broadcast] routes are payload-only
+   and can never return [Unavailable].  The issue's alternative (a) —
+   falling back to the explicit [@keeper] target in the payload — is
+   therefore dead code here: any lane with an explicit target is routed by
+   the typed [Targets] audience before any store read happens.  The fitting
+   policy is the one the cursor-based replay path
+   ([Keeper_world_observation.collect_board_events]) already uses:
+   [Transient] failures retain the cursor for a later retry while
+   [Permanent] ones are skipped immediately.  This push path has no cursor
+   to retain, so the structural analog is a bounded in-place retry of the
+   relevance read (a pure, idempotent store read).  Exhaustion stays
+   observable: the [Unavailable] branch below logs and counts the drop. *)
+let board_signal_relevance_max_attempts = 3
+
+(* Test hook mirroring
+   [Board_dispatch.force_flusher_start_cas_conflicts_for_test]: forces the
+   next N relevance computations to report a transient board read failure so
+   the bounded-retry path is exercisable without a real store outage. *)
+let forced_transient_relevance_failures_for_test : int Atomic.t = Atomic.make 0
+
+let force_transient_relevance_failures_for_test count =
+  Atomic.set forced_transient_relevance_failures_for_test (Int.max 0 count)
+;;
+
+let consume_forced_transient_relevance_failure_for_test () =
+  let rec loop () =
+    let remaining = Atomic.get forced_transient_relevance_failures_for_test in
+    if remaining <= 0
+    then false
+    else
+      Atomic.compare_and_set
+        forced_transient_relevance_failures_for_test
+        remaining
+        (remaining - 1)
+      || loop ()
+  in
+  loop ()
+;;
+
+let board_signal_relevance_route ~audience ~meta (signal : Board_dispatch.board_signal) =
+  if consume_forced_transient_relevance_failure_for_test ()
+  then
+    Keeper_world_observation_board_signal.Unavailable
+      { operation = Keeper_world_observation_board_signal.Get_post
+      ; post_id = signal.post_id
+      ; error = Board.Io_error "forced transient relevance read failure (test hook)"
+      }
+  else Keeper_board_audience.route_for_keeper ~audience ~meta ~signal
+;;
+
+let route_for_keeper_with_bounded_retry
+      ~audience
+      ~meta
+      (signal : Board_dispatch.board_signal)
+  =
+  let rec attempt attempts_left =
+    match board_signal_relevance_route ~audience ~meta signal with
+    | Keeper_world_observation_board_signal.Unavailable unavailable
+      when Keeper_world_observation_board_signal.(
+             disposition_of_unavailable unavailable = Transient)
+           && attempts_left > 1 ->
+      Log.Keeper.warn
+        "board signal relevance read transiently unavailable, retrying: keeper=%s \
+         post=%s attempts_left=%d error=%s"
+        meta.Keeper_meta_contract.name
+        signal.post_id
+        (attempts_left - 1)
+        (Keeper_world_observation_board_signal.unavailable_to_string unavailable);
+      attempt (attempts_left - 1)
+    | result -> result
+  in
+  attempt board_signal_relevance_max_attempts
+;;
+
 let wakeup_relevant_keeper_for_board_signal
       ~(config : Workspace.config)
       (addressed : Board_dispatch.addressed_board_signal)
@@ -500,22 +579,40 @@ let wakeup_relevant_keeper_for_board_signal
             "board signal Keeper metadata missing: keeper=%s"
             entry.name
         | Ok (Some meta) ->
-          (match
-             Keeper_board_audience.route_for_keeper
-               ~audience
-               ~meta
-               ~signal
-           with
+          (match route_for_keeper_with_bounded_retry ~audience ~meta signal with
            | Keeper_world_observation_board_signal.Unavailable unavailable ->
              Otel_metric_store.inc_counter
                Keeper_metrics.(to_string KeepaliveSignalFailures)
                ~labels:[ ("keeper", meta.name); ("phase", "board_signal_read") ]
                ();
-             Log.Keeper.warn
-               "board signal relevance read unavailable: keeper=%s post=%s error=%s"
-               meta.name
-               signal.post_id
-               (Keeper_world_observation_board_signal.unavailable_to_string unavailable)
+             (match
+                Keeper_world_observation_board_signal.disposition_of_unavailable
+                  unavailable
+              with
+              | Keeper_world_observation_board_signal.Permanent ->
+                (* Mirrors the replay path: a permanently unavailable read
+                   (e.g. the post was swept from the store) can never resolve,
+                   so the lane is dropped without consuming retry attempts. *)
+                Log.Keeper.warn
+                  "board signal relevance read permanently unavailable, lane dropped: \
+                   keeper=%s post=%s error=%s"
+                  meta.name
+                  signal.post_id
+                  (Keeper_world_observation_board_signal.unavailable_to_string
+                     unavailable)
+              | Keeper_world_observation_board_signal.Transient ->
+                (* Explicit policy (#25600): the signal is dropped for this
+                   lane only after [board_signal_relevance_max_attempts]
+                   attempts; the keeper's own cursor-based replay scan
+                   remains the next-cycle safety net. *)
+                Log.Keeper.error
+                  "board signal relevance read still unavailable after %d attempt(s), \
+                   lane dropped: keeper=%s post=%s error=%s"
+                  board_signal_relevance_max_attempts
+                  meta.name
+                  signal.post_id
+                  (Keeper_world_observation_board_signal.unavailable_to_string
+                     unavailable))
            | Keeper_world_observation_board_signal.Available
                Keeper_board_audience.Ignore ->
              Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -127,6 +127,11 @@ val wakeup_keeper :
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.addressed_board_signal -> unit
 
+(** Test hook (#25600): force the next [count] board-signal relevance
+    computations to report a transient store read failure, exercising the
+    bounded-retry path without a real store outage. *)
+val force_transient_relevance_failures_for_test : int -> unit
+
 (** Per-stage timing accumulator for Phase 0 profiling. *)
 type stage_timing = {
   presence_ms : float;

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -671,6 +671,97 @@ let test_lane_meta_failure_does_not_block_next_durable_delivery () =
          (board_queue_length config healthy.name))
 ;;
 
+(* #25600 fixture: a [Thread_participants]-audience comment signal is the
+   only route that re-reads the board store at signal time
+   ([check_self_comment_status]).  The keeper authored an earlier comment on
+   the post, so a newer external comment addresses it as
+   [Thread_reply_after_self_comment] — but only if the store read succeeds. *)
+let create_thread_fixture config ~keeper_name =
+  let meta = make_board_resume_meta keeper_name in
+  persist_and_register_board_lane config meta;
+  let post =
+    match
+      Board_dispatch.create_post
+        ~author:"external-author"
+        ~content:"thread topic"
+        ~title:"thread"
+        ~post_kind:Board.Human_post
+        ~visibility:Board.Internal
+        ()
+    with
+    | Error error -> fail (Board.show_board_error error)
+    | Ok post -> post
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let add_comment ~author ~content =
+    match Board_dispatch.add_comment ~post_id ~author ~content () with
+    | Error error -> fail (Board.show_board_error error)
+    | Ok _comment -> ()
+  in
+  add_comment ~author:meta.Keeper_meta_contract.agent_name ~content:"keeper was here";
+  add_comment ~author:"external-author" ~content:"follow up";
+  let signal : Board_dispatch.addressed_board_signal =
+    { signal =
+        { kind = Board_dispatch.Board_comment_added
+        ; post_id
+        ; author = "external-author"
+        ; title = "thread"
+        ; content = "follow up"
+        ; hearth = None
+        ; updated_at = Some 125.5
+        }
+    ; audience = Board.Thread_participants
+    }
+  in
+  meta, signal
+;;
+
+(* #25600 regression: a transient store read failure on the
+   [Thread_participants] route must not silently drop the signal — the
+   bounded retry re-reads and the addressed keeper still wakes. *)
+let test_thread_participant_wakes_after_transient_store_read_failure () =
+  Eio_main.run @@ fun _env ->
+  with_temp_workspace @@ fun config ->
+  Fun.protect
+    ~finally:(fun () ->
+      KKS.force_transient_relevance_failures_for_test 0;
+      Keeper_registry.For_testing.clear ())
+    (fun () ->
+       let meta, signal = create_thread_fixture config ~keeper_name:"threadlane" in
+       KKS.force_transient_relevance_failures_for_test 1;
+       KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
+       check int "addressed lane durable queue after transient failure" 1
+         (board_queue_length config meta.name);
+       match Keeper_registry.get ~base_path:config.base_path meta.name with
+       | Some entry ->
+         check bool "addressed lane woken after transient failure" true
+           (Atomic.get entry.fiber_wakeup)
+       | None -> fail "threadlane registry entry missing")
+;;
+
+(* #25600 bound pin: the retry is bounded — a store that keeps failing past
+   [board_signal_relevance_max_attempts] still drops the lane (loudly), it
+   does not retry forever. *)
+let test_thread_participant_drop_is_bounded_under_persistent_failure () =
+  Eio_main.run @@ fun _env ->
+  with_temp_workspace @@ fun config ->
+  Fun.protect
+    ~finally:(fun () ->
+      KKS.force_transient_relevance_failures_for_test 0;
+      Keeper_registry.For_testing.clear ())
+    (fun () ->
+       let meta, signal = create_thread_fixture config ~keeper_name:"boundlane" in
+       KKS.force_transient_relevance_failures_for_test 100;
+       KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
+       check int "persistently failing lane stays undelivered" 0
+         (board_queue_length config meta.name);
+       match Keeper_registry.get ~base_path:config.base_path meta.name with
+       | Some entry ->
+         check bool "persistently failing lane not woken" false
+           (Atomic.get entry.fiber_wakeup)
+       | None -> fail "boundlane registry entry missing")
+;;
+
 (* ── Test runner ─── *)
 
 let () =
@@ -711,6 +802,10 @@ let () =
             test_restarting_exact_mention_is_durable_with_deferred_wake
         ; test_case "lane metadata failure does not block next durable delivery" `Quick
             test_lane_meta_failure_does_not_block_next_durable_delivery
+        ; test_case "thread participant wakes after transient store read failure" `Quick
+            test_thread_participant_wakes_after_transient_store_read_failure
+        ; test_case "thread participant drop is bounded under persistent failure" `Quick
+            test_thread_participant_drop_is_bounded_under_persistent_failure
         ] )
     ; ( "interruptible_cadence"
       , [ test_case "directed wake cuts configured sleep" `Quick


### PR DESCRIPTION
## 문제

이슈 #25600 (#25378 follow-up): board signal routing 중 store read(`get_post`/`get_comments`)가 transient 실패를 반환하면 해당 keeper lane의 signal이 warn + counter만 남기고 drop됐다. retry도, payload 기반 fallback routing도 없어서, thread에 묶인 keeper가 새 외부 댓글에 영영 wake하지 못할 수 있는 경로 — doctrine 'No Silent Failure' 위반.

Closes #25600

## 수정 내용

`lib/keeper/keeper_keepalive_signal.ml`:

- `route_for_keeper_with_bounded_retry` 추가: per-lane relevance 판정(`Keeper_board_audience.route_for_keeper`)을 `board_signal_relevance_max_attempts`(=3, named constant)까지 재시도. 재시도는 `Keeper_world_observation_board_signal.disposition_of_unavailable = Transient`(typed variant, string 매칭 아님)인 경우에만 적용하고, `Permanent`(예: swept post)는 재시도 없이 즉시 drop — replay 경로(`collect_board_events`의 Permanent-skip / Transient-cursor-retain)와 동일한 정책.
- 재시도 소진 후에도 실패하면 `Log.Keeper.error` + `KeepaliveSignalFailures` counter로 drop을 명시적으로 관측 가능하게 유지(조용한 drop 아님).
- 테스트 훅 `force_transient_relevance_failures_for_test` 추가(`Board_dispatch.force_flusher_start_cas_conflicts_for_test`와 같은 패턴).

`test/test_keeper_keepalive_helpers.ml`:

- 회귀 테스트 `thread participant wakes after transient store read failure`: `Thread_participants` audience signal + keeper의 기존 댓글이 있는 post fixture에서 store read 1회 transient 실패를 강제필 때, addressed keeper가 여전히 durable queue + wake 됨을 검증.
- bound pin 테스트 `thread participant drop is bounded under persistent failure`: 지속 실패 시 bounded retry 후 drop됨(무한 재시도 아님)을 검증.

## 옵션 선택 근거 (a) vs (b)

이슈가 제안한 두 옵션 중 **(b) bounded retry**를 선택:

- 현재 origin/main 구조에서 store read가 필요한 경로는 `Thread_participants` audience뿐이다. `Targets`/`Broadcast` 경로는 typed audience가 write 시점에 계산되어 payload-only로 routing되므로 store read 없이 항상 delivery된다.
- 따라서 (a) "payload의 explicit @keeper target으로 fallback routing"은 구조적으로 dead code가 된다: explicit target이 있는 lane은 이미 store read 이전에 `Targets` audience로 routing되며, `Unavailable`에 도달하는 lane(`Thread_participants`)의 payload에는 fallback할 explicit target이 존재하지 않는다.
- replay 경로(List.rev acc, last_cursor 유지)의 철학 — Transient은 나중에 재시도, Permanent은 즉시 skip — 을 push 경로에 맞게 옮기면 cursor가 없으므로 bounded in-place retry가 구조적 대응물이다. 이 근거는 코드 주석(`keeper_keepalive_signal.ml` `board_signal_relevance_max_attempts` 위)에도 기록했다.

## 근본 원인 분석

#25378이 store read를 routing의 필수 선행 의존으로 만들면서 실패 경로 정책이 설계되지 않았다. 이후 audience 계산이 write 시점으로 이동(`addressed_board_signal`)하면서 routing-level 전체 drop은 해소됐지만, `Thread_participants` per-lane relevance read의 `Unavailable` 분기에는 여전히 warn+counter 후 drop만 남아 있었다. 실패가 결과를 바꾸는 경로(addressed keeper가 wake하지 못함)에서 재시도/유지 정책 없이 drop한 것이 위반의 본질.

## 검증

- `bash scripts/dune-local.sh build lib/keeper/keeper_keepalive_signal.ml test/test_keeper_keepalive_helpers.exe` — 성공
- `_build/default/test/test_keeper_keepalive_helpers.exe` — 18/18 통과(신규 2개 포함: transient 실패 후 wake 회귀 테스트, bounded drop pin 테스트)
- `bash scripts/ci/check-determinism-contract.sh` — PASS
- `bash scripts/ci/check-telemetry-coverage.sh` — PASS
- `bash scripts/lint-ignore-without-comment.sh` — exit 0
- `bash scripts/check-pr-hygiene.sh --base origin/main` — PASS
- Dashboard TS 변경 없음 (tsc/vitest 해당 없음)
