### PR TITLE
fix(keeper): error-classify 불변 주석을 실제 회계 장치와 일치 + InvalidRequest SDK shape drift guard (#25606)

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -717,7 +717,19 @@ let degraded_rotation_after_recoverable_error
 (** [true] for API-side 400 rejections ([Api (InvalidRequest _)]): the
     provider refused the request body itself (malformed payload, orphan
     tool-call residues), so same-turn retry is futile.  Also matches legacy
-    string-rendered ["Invalid request"] / ["Bad Request"] messages. *)
+    string-rendered ["Invalid request"] / ["Bad Request"] messages.
+
+    Drift boundary: the typed arm is authoritative.  The string arms exist
+    for string-rendered shapes of the same condition; the only rendering the
+    pinned SDK (oas 5851df2e) produces with one of these prefixes is
+    [Llm_provider.Retry.error_message (InvalidRequest _)] =
+    ["Invalid request (%s): %s"] (oas lib/llm_provider/retry.ml), whose
+    classification shape is produced by [Llm_provider.Retry.classify_error]
+    for HTTP 400/422.  At the pin no [sdk_error] rendering starts with
+    ["Bad Request"] or ["oas-ollama_cloud"] — those arms are defensive
+    legacy shapes.  [test_keeper_invalid_request_auto_recover.ml] pins the
+    SDK classification+rendering shape so an SDK drift fails the test
+    instead of silently deadening the matcher. *)
 let is_invalid_request_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (InvalidRequest _) -> true
@@ -755,14 +767,30 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
        contains_substring msg "model_context_window_exceeded"
        || contains_substring msg "Context overflow")
 
-(* Invariant for this predicate: every class listed here is exempted from the
-   crash threshold ([Keeper_unified_turn_failure.record_failure_observation]
-   skips [increment_turn_failures] entirely), so each class must carry its own
-   compensating accounting. Without one, "not counted toward crash" means the
-   keeper retries the same failure forever with [consecutive] pinned at 0.
+(* Invariant for this predicate: the exemption gate is
+   [Keeper_unified_turn_failure.account_failure_counting].  When it returns
+   [false], [record_failure_observation] skips [increment_turn_failures], so
+   every exempted class must carry its own compensating accounting.  Without
+   one, "not counted toward crash" means the keeper retries the same failure
+   forever with [consecutive] pinned at 0.
 
-   - transient network / runtime-exhausted: bounded by the runtime rotation and
-     exhaustion paths.
+   - runtime-exhausted ([Runtime_exhausted _] / [Resumable_cli_session _]):
+     NOT exempt.  [account_failure_counting] counts them toward the crash
+     threshold via its [is_runtime_exhausted_error] override, so the ordinary
+     consecutive-failure threshold bounds them.
+   - capacity backpressure: exempt; bounded by the runtime-rotation path —
+     [recoverable_runtime_failure_reason] maps it to [Capacity_backpressure]
+     and [degraded_rotation_after_recoverable_error] walks the untried
+     runtime catalog once, then stops (it never invents a timed retry cycle).
+   - transient network: exempt with NO compensating counter.  Rotation
+     deliberately does not apply ([recoverable_runtime_failure_reason]
+     returns [None] for network/timeout errors and the failure route is
+     [Retry_after_observed Network_transient]), and no per-keeper counter
+     advances.  A persistently failing transport therefore retries once per
+     keeper cycle with [consecutive] pinned at 0; only the per-turn attempt
+     count is bounded (by the runtime candidate list).  If this class ever
+     needs a bound, add a real counter — do not claim one here without the
+     device.
    - context overflow: accounted at the point of detection by
      [Keeper_turn_runtime_budget.record_overflow_failure], and its in-lane
      compaction retries are bounded (#25536).

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -45,7 +45,9 @@ val is_model_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
 (** [true] for API-side 400 rejections ([Api (InvalidRequest _)]): the
     provider refused the request body itself (malformed payload, orphan
     tool-call residues), so same-turn retry is futile.  Also matches legacy
-    string-rendered ["Invalid request"] / ["Bad Request"] messages. *)
+    string-rendered ["Invalid request"] / ["Bad Request"] messages.  The
+    typed arm is authoritative; the string arms are pinned against the SDK
+    rendering shape by a drift test (see the .ml doc comment). *)
 val is_invalid_request_error : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] for a 0-byte empty completion: the provider ended the turn with a

--- a/test/test_keeper_invalid_request_auto_recover.ml
+++ b/test/test_keeper_invalid_request_auto_recover.ml
@@ -103,6 +103,40 @@ let test_counters_are_per_keeper () =
   KUF.reset_invalid_request_failures ~keeper_name:keeper_b
 ;;
 
+(* Drift guard for the legacy string arms in [EC.is_invalid_request_error]
+   (#25606).  The classification shape and the rendered prefix are both
+   produced by the pinned OAS SDK (oas 5851df2e, lib/llm_provider/retry.ml):
+   [Retry.classify_error] maps HTTP 400/422 to
+   [InvalidRequest { reason = Unknown_invalid_request; message = body }] and
+   [Retry.error_message] renders it as ["Invalid request (%s): %s"] — the
+   prefix the legacy string arm matches.  This test generates the real SDK
+   product and asserts the predicate catches it and the rendering keeps the
+   matched prefix, so an SDK-side shape change fails here instead of
+   silently deadening the matcher.  At the pin no [sdk_error] rendering
+   starts with ["Bad Request"] or ["oas-ollama_cloud"]; those string arms
+   are defensive legacy shapes with no SDK producer to pin. *)
+let test_sdk_invalid_request_shape_drift_guard () =
+  let api_error =
+    Llm_provider.Retry.classify_error
+      ~retry_after_header:None
+      ~status:400
+      ~body:"Bad Request"
+  in
+  let err = Agent_sdk.Error.Api api_error in
+  check
+    bool
+    "SDK-classified 400 is caught by the predicate"
+    true
+    (EC.is_invalid_request_error err);
+  check
+    bool
+    "SDK rendering keeps the Invalid request prefix the string arm matches"
+    true
+    (String.starts_with
+       ~prefix:"Invalid request"
+       (Agent_sdk.Error.to_string err))
+;;
+
 let () =
   run
     "keeper_invalid_request_auto_recover"
@@ -123,6 +157,10 @@ let () =
             "consecutive counters are per-keeper"
             `Quick
             test_counters_are_per_keeper
+        ; test_case
+            "SDK 400 classification/rendering shape drift guard"
+            `Quick
+            test_sdk_invalid_request_shape_drift_guard
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

Closes #25606

1. `is_invalid_request_error`(lib/keeper/keeper_error_classify.ml)가 typed variant 대신 에러 문자열 prefix 매칭(`"Invalid request"` / `"Bad Request"` / `"oas-ollama_cloud"`)에 의존 — SDK 에러 텍스트 변경 시 조용히 묠력화되는 cross-repo 결합인데 drift guard가 없었음.
2. 같은 파일의 불변식 주석이 실제 회계 장치와 불일치 — "transient network / runtime-exhausted: bounded by the runtime rotation and exhaustion paths"라고 주장했으나, 실제로는 runtime-exhausted는 면제 대상이 아니고(`account_failure_counting`의 `is_runtime_exhausted_error` override로 crash 카운터에 그대로 계수), transient network는 보상 카운터도 rotation 이유(`recoverable_runtime_failure_reason` → `None`)도 없이 면제만 되어 있었음.

## 수정 내용

- **불변식 주석 전수 감사 및 정정** (lib/keeper/keeper_error_classify.ml):
  - 면제 게이트가 `record_failure_observation`이 아니라 `Keeper_unified_turn_failure.account_failure_counting`임을 명시.
  - runtime-exhausted(`Runtime_exhausted _` / `Resumable_cli_session _`)는 면제가 아니라 crash threshold에 계수됨을 정정.
  - capacity backpressure는 runtime rotation 경로(`Some Capacity_backpressure` → `degraded_rotation_after_recoverable_error`)가 실재하는 bound임을 명시.
  - transient network는 보상 카운터가 없음을 명시적으로 기록(turn당 시도 횟수만 runtime candidate list로 bound). 허구의 bound 주장 제거.
  - 실재 확인된 장치는 유지: `record_overflow_failure`(context overflow), `empty_completion_exemption_budget`(empty completion), `note_invalid_request_failure` / `max_consecutive_invalid_request_failures`(invalid request).
- **drift guard 테스트 추가** (test/test_keeper_invalid_request_auto_recover.ml):
  - 문자열 shape의 실제 SDK 생산 위치 특정(pin 5851df2e): `Llm_provider.Retry.classify_error`(HTTP 400/422 → `InvalidRequest { reason = Unknown_invalid_request }`)와 `Llm_provider.Retry.error_message`(렌더링 `"Invalid request (%s): %s"`, oas `lib/llm_provider/retry.ml`).
  - 테스트가 SDK의 실제 `classify_error ~status:400 ~body:"Bad Request"` 결과를 생성해 (a) predicate가 잡는지, (b) 렌더링이 string arm이 매칭하는 `"Invalid request"` prefix를 유지하는지 단언. SDK가 shape를 바꾸면 predicate가 조용히 죽는 대신 이 테스트가 실패.
  - pin 기준 `"Bad Request"` / `"oas-ollama_cloud"` prefix로 시작하는 `sdk_error` 렌더링 생산자는 존재하지 않음을 확인 — 해당 string arm은 defensive legacy shape임을 주석에 명시(제거는 동작 변경이므로 범위 밖).
- `is_invalid_request_error` doc comment(.ml/.mli)에 drift boundary와 생산자 위치 기록.

## 근본 원인 분석

- #25592/#25593이 400 분류를 문자열 매칭으로 도입할 때 SDK 렌더링 shape를 고정하는 테스트가 없었고, #25582/#25583이 보상 카운터를 추가하면서 불변식 주석을 고쳤지만 기존에 있던 "transient network / runtime-exhausted" 항목은 실제 코드(`account_failure_counting`의 override 구조)와 대조하지 않은 채 잔존. 주석이 코드 진화를 따라가지 못한 전형적인 comment drift.

## 범위 밖 (경계 제안)

- typed variant로의 전환: OAS가 `Api (InvalidRequest _)` 외 경로(Provider flatten 등)에서도 typed 400을 제공하도록 OAS 변경이 필요하므로 이 PR 범위 밖. string arm 제거도 그 전제 위에서만 안전.
- transient network 면제에 보상 카운터가 없는 것은 실재하는 gap이나, 새 카운터 추가는 동작 변경이므로 별도 이슈/PR 제안.

## 검증

- `scripts/dune-local.sh build lib/keeper/keeper_error_classify.ml test/test_keeper_invalid_request_auto_recover.exe` — 성공
- `test/test_keeper_invalid_request_auto_recover.exe` — 5/5 통과(신규 drift guard 포함)
- `test/test_keeper_runtime_observation_boundaries.exe` — 10/10 통과
- `bash scripts/ci/check-determinism-contract.sh` — PASS
- `bash scripts/ci/check-telemetry-coverage.sh` — PASS
- `bash scripts/lint-ignore-without-comment.sh` — exit 0
- `bash scripts/check-pr-hygiene.sh --base origin/main --head HEAD` — PASS
- OAS pin 5851df2e 기준 생산자 확인: `git show 5851df2e:lib/llm_provider/retry.ml`(`classify_error`, `error_message`), `lib/base/error.ml`(`to_string`), `lib/llm_provider/error.ml`(`of_http_error`)
