### PR TITLE
fix(keeper): recover torn append tail at process start (#25604)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1820,6 +1820,8 @@ type private_jsonl_transaction_operation =
   | Sync_rewrite_parent
   | Inspect_rewritten_data
   | Remove_rewrite_stage
+  | Truncate_transaction_data
+  | Sync_transaction_data
 
 type private_jsonl_operation_failure =
   { operation : private_jsonl_transaction_operation
@@ -1961,6 +1963,8 @@ let private_jsonl_operation_to_string = function
   | Sync_rewrite_parent -> "sync rewrite parent"
   | Inspect_rewritten_data -> "inspect rewritten data"
   | Remove_rewrite_stage -> "remove rewrite stage"
+  | Truncate_transaction_data -> "truncate transaction data"
+  | Sync_transaction_data -> "sync transaction data"
 ;;
 
 let private_jsonl_operation_failure_to_string failure =
@@ -2544,6 +2548,95 @@ let read_private_jsonl_durable_locked_result path ~after =
     ~io:private_jsonl_transaction_unix_io
     path
     ~after
+;;
+
+let private_jsonl_last_complete_row_length bytes =
+  match String.rindex_opt bytes '\n' with
+  | Some index -> index + 1
+  | None -> 0
+;;
+
+(* Process-start recovery entry point: a torn tail left by a mid-append crash
+   is truncated to the last complete row under the stable lock, then reading
+   resumes. General reads keep hard-failing on [Incomplete_transaction_tail];
+   only recovery callers may opt into truncation. *)
+let recover_private_jsonl_durable_locked_with_io ~io path =
+  let success snapshot = Snapshot_succeeded snapshot in
+  with_private_jsonl_stable_lock ~io ~success path @@ fun ~dir:_ ~path ->
+  match private_jsonl_open_existing ~close_fd:io.close_fd path [ Unix.O_RDWR ] with
+  | Error _ as error -> error
+  | Ok None -> Ok { bytes = ""; cursor = Private_jsonl_cursor.Missing }
+  | Ok (Some fd) ->
+    private_jsonl_with_fd
+      ~close_operation:Close_transaction_data
+      ~close_fd:io.close_fd
+      ~success
+      fd
+      (fun () ->
+         match private_jsonl_capture Inspect_transaction_data (fun () -> Unix.fstat fd) with
+         | Error failure -> Error (Private_jsonl_operation_failed failure)
+         | Ok stats ->
+           (match private_jsonl_cursor_of_stats stats with
+            | Error _ as error -> error
+            | Ok actual ->
+              (match private_jsonl_validate_complete_tail fd stats.Unix.st_size with
+               | Ok () ->
+                 private_jsonl_read_exact fd ~from:0 ~end_offset:stats.Unix.st_size
+                 |> Result.map (fun bytes -> { bytes; cursor = actual })
+               | Error (Incomplete_transaction_tail { end_offset }) ->
+                 (match private_jsonl_read_exact fd ~from:0 ~end_offset with
+                  | Error _ as error -> error
+                  | Ok bytes ->
+                    let complete_length = private_jsonl_last_complete_row_length bytes in
+                    (match
+                       private_jsonl_capture Truncate_transaction_data (fun () ->
+                         Unix.ftruncate fd complete_length)
+                     with
+                     | Error failure -> Error (Private_jsonl_operation_failed failure)
+                     | Ok () ->
+                       (match
+                          private_jsonl_capture Sync_transaction_data (fun () ->
+                            Unix.fsync fd)
+                        with
+                        | Error failure -> Error (Private_jsonl_operation_failed failure)
+                        | Ok () ->
+                          (match
+                             private_jsonl_capture Inspect_transaction_data (fun () ->
+                               Unix.fstat fd)
+                           with
+                           | Error failure ->
+                             Error (Private_jsonl_operation_failed failure)
+                           | Ok truncated_stats ->
+                             (match private_jsonl_cursor_of_stats truncated_stats with
+                              | Error _ as error -> error
+                              | Ok cursor ->
+                                Ok
+                                  { bytes = String.sub bytes 0 complete_length
+                                  ; cursor
+                                  })))))
+               (* Recovery is scoped to [Incomplete_transaction_tail]; every
+                  other typed failure propagates exactly as the general read
+                  path surfaces it. *)
+               | Error
+                   ( Stable_lock_contended _
+                   | Unexpected_stable_lock_permissions _
+                   | Invalid_stable_lock_state _
+                   | Cursor_mismatch _
+                   | Unexpected_transaction_file_kind _
+                   | Ambiguous_transaction_file_identity _
+                   | Transaction_path_binding_changed _
+                   | Invalid_transaction_suffix
+                   | Private_jsonl_operation_failed _
+                   | Rewrite_stage_failed _
+                   | Rewrite_published_durability_unknown _
+                   | Transaction_settlement_failed _
+                   | Transaction_append_failed _ ) as error -> error)))
+;;
+
+let recover_private_jsonl_durable_locked_result path =
+  recover_private_jsonl_durable_locked_with_io
+    ~io:private_jsonl_transaction_unix_io
+    path
 ;;
 
 let read_private_jsonl_durable_locked_with_io_for_testing ~io path ~after =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -803,6 +803,8 @@ type private_jsonl_transaction_operation =
   | Sync_rewrite_parent
   | Inspect_rewritten_data
   | Remove_rewrite_stage
+  | Truncate_transaction_data
+  | Sync_transaction_data
 
 type private_jsonl_operation_failure =
   { operation : private_jsonl_transaction_operation
@@ -926,6 +928,18 @@ val private_jsonl_lock_path : string -> string
 val read_private_jsonl_durable_locked_result :
   string ->
   after:Private_jsonl_cursor.t option ->
+  (private_jsonl_snapshot, private_jsonl_transaction_error) result
+
+(** Process-start recovery read of a private JSONL store under its stable
+    sibling lock. Behaves like {!read_private_jsonl_durable_locked_result} with
+    [after = None], except that a torn tail (an incomplete final row left by a
+    mid-append crash) is truncated to the last complete row and fsynced while
+    the lock is held, after which reading resumes with the truncated cursor.
+    Every other failure propagates unchanged. Only process-start recovery may
+    use this entry point; general reads keep hard-failing on
+    [Incomplete_transaction_tail]. *)
+val recover_private_jsonl_durable_locked_result :
+  string ->
   (private_jsonl_snapshot, private_jsonl_transaction_error) result
 
 type private_jsonl_transaction_io_for_testing =

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -790,7 +790,9 @@ let recover_for_process_start ~base_path ~keeper_name =
     let entry = cache_entry ledger_path in
     Stdlib.Mutex.protect entry.mutation_mutex (fun () ->
       match
-        Fs_compat.read_private_jsonl_durable_locked_result ledger_path ~after:None
+        (* Process-start recovery only: a torn tail from a mid-append crash is
+           truncated to the last complete row; general reads keep hard-failing. *)
+        Fs_compat.recover_private_jsonl_durable_locked_result ledger_path
         |> snapshot_result ~ledger_path
       with
       | Error error -> Error error

--- a/lib/keeper/keeper_board_attention_partition.mli
+++ b/lib/keeper/keeper_board_attention_partition.mli
@@ -88,7 +88,10 @@ val recover_for_process_start :
   base_path:string -> keeper_name:string -> (int, string) result
 (** Release prior-process [Running] rows to [Ready] and canonically compact
     the append ledger to one latest row per partition. [Deferred] rows retain
-    their exact retry requirement; process restart is not retry authority. *)
+    their exact retry requirement; process restart is not retry authority. A
+    torn tail left by a mid-append crash is truncated to the last complete row
+    under the ledger lock before recovery; general reads keep hard-failing on
+    it. *)
 
 val release_due_provider_retries :
   now:float -> base_path:string -> keeper_name:string -> (int, string) result

--- a/test/test_keeper_board_attention_partition.ml
+++ b/test/test_keeper_board_attention_partition.ml
@@ -376,6 +376,68 @@ let test_strict_codec_and_ledger_identity_validation () =
   expect_error "duplicate live candidate membership" (P.load ~base_path ~keeper_name:"sangsu")
 ;;
 
+let inject_torn_tail ledger_path =
+  (* Simulates SIGKILL mid-append: partial row bytes without trailing newline. *)
+  let output = open_out_gen [ Open_wronly; Open_append; Open_binary ] 0o600 ledger_path in
+  output_string output "{\"schema_version\":2,\"partition_id\":\"torn-partial";
+  close_out output
+;;
+
+let test_torn_tail_truncates_to_last_complete_row () =
+  with_temp_base "board-attention-partition-torn-tail" @@ fun base_path ->
+  let pending = candidate ~id:"candidate-torn" ~recorded_at:1.0 () in
+  ignore (roots ~base_path [ pending ] : P.t list);
+  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  let durable = Fs_compat.load_file ledger_path in
+  inject_torn_tail ledger_path;
+  expect_error
+    "torn tail still hard-fails general reads"
+    (P.load ~base_path ~keeper_name:"sangsu");
+  Alcotest.(check int)
+    "torn tail without claims recovers nothing"
+    0
+    (ok
+       "torn-tail process-start recovery"
+       (P.recover_for_process_start ~base_path ~keeper_name:"sangsu"));
+  Alcotest.(check string)
+    "torn tail truncated to last complete row"
+    durable
+    (Fs_compat.load_file ledger_path);
+  (match ok "load after torn-tail recovery" (P.load ~base_path ~keeper_name:"sangsu") with
+   | [ { P.state = P.Ready; candidate_id; _ } ] ->
+     Alcotest.(check string) "durable partition survives" pending.candidate_id candidate_id
+   | _ -> Alcotest.fail "torn-tail recovery lost the durable partition");
+  Alcotest.(check int)
+    "process start after truncation is stable"
+    0
+    (ok
+       "repeat process-start recovery"
+       (P.recover_for_process_start ~base_path ~keeper_name:"sangsu"))
+;;
+
+let test_torn_tail_recovery_releases_prior_running () =
+  with_temp_base "board-attention-partition-torn-claim" @@ fun base_path ->
+  let pending = candidate ~id:"candidate-torn-claim" ~recorded_at:1.0 () in
+  ignore (roots ~base_path [ pending ] : P.t list);
+  let owner = P.Worker_epoch.generate () in
+  ignore (claim ~base_path ~worker_epoch:owner ~now:10.0 : P.t);
+  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  inject_torn_tail ledger_path;
+  expect_error
+    "torn tail still hard-fails general reads"
+    (P.load ~base_path ~keeper_name:"sangsu");
+  Alcotest.(check int)
+    "torn tail no longer wedges Running recovery"
+    1
+    (ok
+       "torn-tail process-start recovery"
+       (P.recover_for_process_start ~base_path ~keeper_name:"sangsu"));
+  match ok "load after torn-tail recovery" (P.load ~base_path ~keeper_name:"sangsu") with
+  | [ { P.state = P.Ready; candidate_id; _ } ] ->
+    Alcotest.(check string) "prior Running released to Ready" pending.candidate_id candidate_id
+  | _ -> Alcotest.fail "torn-tail recovery lost the durable partition"
+;;
+
 let test_invalid_observation_values_never_rewrite () =
   with_temp_base "board-attention-partition-invalid" @@ fun base_path ->
   expect_error
@@ -425,6 +487,14 @@ let () =
             "lane abort and process-start recovery"
             `Quick
             test_lane_abort_and_process_start_recovery_are_explicit
+        ; Alcotest.test_case
+            "torn tail truncates to last complete row"
+            `Quick
+            test_torn_tail_truncates_to_last_complete_row
+        ; Alcotest.test_case
+            "torn tail recovery releases prior Running"
+            `Quick
+            test_torn_tail_recovery_releases_prior_running
         ; Alcotest.test_case
             "strict codec and ledger identity"
             `Quick


### PR DESCRIPTION
## 문제

Closes #25604

SIGKILL이 append 도중 발생해 torn tail(개행 없이 끊긴 마지막 행)이 생기면, `lib/fs_compat/fs_compat.ml`의 `private_jsonl_validate_complete_tail`이 read와 append 모두를 `Incomplete_transaction_tail`로 hard-fail시킨다. 그런데 `recover_for_process_start`(`lib/keeper/keeper_board_attention_partition.ml:787`)도 같은 read 경로를 사용해, 해당 keeper의 board attention이 수동 파일 수술 전까지 영구 wedge 상태에 빠졌다. Keeper '무한 생존' spec과 충돌하는 새 실패 모드.

## 수정 내용

- `Fs_compat.recover_private_jsonl_durable_locked_result` 신설 (`lib/fs_compat/fs_compat.ml`, `.mli`): 프로세스 시작(recovery) 전용 read 진입점. stable sibling lock을 보유한 채로 torn tail을 감지하면 마지막 완전 행 경계(마지막 `\n` 직후, 완전 행이 하나도 없으면 0)까지 `ftruncate`하고 `fsync`한 뒤, 절단된 cursor로 정상 read를 재개한다. 절단 실패는 typed operation(`Truncate_transaction_data`/`Sync_transaction_data` 신설)으로 노출되며 silent fallback이 없다.
- `recover_for_process_start`가 이 진입점을 사용하도록 교체. 일반 read 경로(`load`, `read_view`, append/rewrite의 cursor 검증)는 기존 `Incomplete_transaction_tail` hard-fail을 그대로 유지한다 — 복구는 recovery 진입점에서만 일어난다.
- 회귀 테스트 2건 추가 (`test/test_keeper_board_attention_partition.ml`): append 도중 크래시(partial row, trailing newline 없음)를 파일에 직접 주입해 (1) torn tail이 마지막 완전 행까지 바이트 단위로 정확히 절단되고 일반 read는 계속 hard-fail하며 recovery 후 정상 재개되는 것, (2) torn tail이 있어도 기존 Running claim이 wedge 없이 Ready로 복구되는 것을 검증.

## 근본 원인 분석

`#25383`(append 인덱스 모델)에서 temp+rename 원자 교체가 in-place append로 바뀌면서 "부분 append가 디스크에 남는" 실패 모드가 새로 생겼다. temp+rename 모델에서는 크래시가 나면 staged 파일이 orphan으로 남을 뿐 published 파일은 항상 완전했지만, in-place append에서는 파일 자체가 torn 상태가 된다. 당시 `Incomplete_transaction_tail` hard-fail은 정합성 관점에서 올바른 방어였으나, recovery 경로가 일반 read와 같은 진입점을 공유하면서 "방어가 복구 자체를 차단하는" wedge가 됐다. 즉 실패 감지(typed hard-fail)와 실패 복구(truncate-and-resume)의 책임이 한 경로에 섞여 있던 것이 원인이다. 이번 수정은 감지는 일반 경로에 유지하고, 복구 권한은 프로세스 시작 recovery에만 명시적으로 부여해 분리한다.

## 검증

- `scripts/dune-local.sh build test/test_keeper_board_attention_partition.exe` — 빌드 성공 (경고 0, fragile-match는 모든 `private_jsonl_transaction_error` 생성자 명시로 해소)
- `test/test_keeper_board_attention_partition.exe` — 8/8 통과 (신규 torn tail 회귀 2건 포함)
- 회귀 스위트: `test_fs_compat.exe` 17/17, `test_fs_compat_durable_append.exe` 36/36, `test_fs_compat_append_jsonl_atomicity.exe` 2/2, `test_keeper_board_attention_worker.exe` 10/10 — 전부 통과
- `bash scripts/ci/check-determinism-contract.sh` — PASS
- `bash scripts/ci/check-telemetry-coverage.sh` — PASS
- `bash scripts/lint-ignore-without-comment.sh` — exit 0
- `bash scripts/check-pr-hygiene.sh --base origin/main` — PASS

Dashboard TS 변경 없음 (OCaml-only).
