### PR TITLE
refactor(keeper): hard-cut legacy exact attempts

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -190,8 +190,6 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let legacy_pending_store_version = 3
-let exact_attempt_pending_store_version = 4
 let pending_store_version = 5
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
@@ -567,7 +565,7 @@ let validate_entry_exact_attempt
     Error "non-completed exact attempt requires a pending summary"
 ;;
 
-let pending_entry_of_yojson ~base_path ~snapshot_version json =
+let pending_entry_of_yojson ~base_path json =
   match json with
   | `Assoc fields ->
     let ( let* ) = Result.bind in
@@ -575,28 +573,25 @@ let pending_entry_of_yojson ~base_path ~snapshot_version json =
     let* () =
       reject_unknown_fields
         ~surface
-          ~allowed:
-            ([ "id"
-             ; "keeper_name"
-             ; "tool_name"
-             ; "input_hash"
-             ; "input"
-             ; "sequence"
-             ; "requested_at"
-             ; "turn_id"
-             ; "request_context"
-             ; "request_context_version"
-             ; "task_id"
-             ; "goal_id"
-             ; "goal_ids"
-             ; "continuation_channel"
-             ; "summary_status"
-             ]
-             @
-             if snapshot_version >= exact_attempt_pending_store_version
-             then [ "exact_attempt" ]
-             else [])
-          fields
+        ~allowed:
+          [ "id"
+          ; "keeper_name"
+          ; "tool_name"
+          ; "input_hash"
+          ; "input"
+          ; "sequence"
+          ; "requested_at"
+          ; "turn_id"
+          ; "request_context"
+          ; "request_context_version"
+          ; "task_id"
+          ; "goal_id"
+          ; "goal_ids"
+          ; "continuation_channel"
+          ; "summary_status"
+          ; "exact_attempt"
+          ]
+        fields
     in
     let* id = required_string ~surface "id" fields in
     let* keeper_name = required_string ~surface "keeper_name" fields in
@@ -622,10 +617,7 @@ let pending_entry_of_yojson ~base_path ~snapshot_version json =
         when Int.equal version exact_request_context_version ->
         Ok (Some context)
       | Some _, (None | Some `Null) ->
-        (* Pre-version records contain the retired projection format. It is
-           intentionally not inspected or migrated: there is no exact causal
-           evidence to recover from a digest projection. *)
-        Ok None
+        Error (surface ^ ".request_context requires request_context_version")
       | (None | Some `Null), Some (`Int version) ->
         Error
           (Printf.sprintf
@@ -651,13 +643,8 @@ let pending_entry_of_yojson ~base_path ~snapshot_version json =
     let* continuation_channel = Keeper_continuation_channel.of_yojson continuation_json in
       let* summary_json = required_member ~surface "summary_status" fields in
       let* summary_status = summary_status_of_yojson_with_error summary_json in
-      let* exact_attempt =
-        if snapshot_version = legacy_pending_store_version
-        then Ok Exact_unbound
-        else
-          let* exact_attempt_json = required_member ~surface "exact_attempt" fields in
-          exact_attempt_state_of_yojson_with_error exact_attempt_json
-      in
+      let* exact_attempt_json = required_member ~surface "exact_attempt" fields in
+      let* exact_attempt = exact_attempt_state_of_yojson_with_error exact_attempt_json in
       let* () =
         validate_entry_exact_attempt
           ~id
@@ -723,7 +710,7 @@ let approval_decision_of_yojson json =
   | _ -> Error "gate_pending.decision must be a JSON object"
 ;;
 
-let persisted_delivery_of_yojson ~base_path ~snapshot_version json =
+let persisted_delivery_of_yojson ~base_path json =
   match json with
   | `Assoc fields ->
     let ( let* ) = Result.bind in
@@ -743,9 +730,7 @@ let persisted_delivery_of_yojson ~base_path ~snapshot_version json =
         fields
     in
     let* entry_json = required_member ~surface "entry" fields in
-      let* entry =
-        pending_entry_of_yojson ~base_path ~snapshot_version entry_json
-      in
+    let* entry = pending_entry_of_yojson ~base_path entry_json in
     let* decision_json = required_member ~surface "decision" fields in
     let* decision = approval_decision_of_yojson decision_json in
     let* source_raw = required_string ~surface "source" fields in
@@ -822,78 +807,6 @@ let parse_list ~surface parse = function
   | _ -> Error (surface ^ " must be an array")
 ;;
 
-type hard_cut_migration =
-  { source_version : int
-  ; target_version : int
-  ; removed_pending : int
-  ; removed_deliveries : int
-  }
-
-let hard_cut_removed_count migration =
-  migration.removed_pending + migration.removed_deliveries
-;;
-
-(* Retain malformed non-row values so the strict decoder still rejects the
-   snapshot. Historical object rows are retained only when their typed codec
-   proves a full exact binding; no retired state token is interpreted here. *)
-let hard_cut_pending_row_has_full_identity = function
-  | `Assoc fields ->
-    (match List.assoc_opt "exact_attempt" fields with
-     | Some exact_attempt_json ->
-       (match exact_attempt_state_of_yojson_with_error exact_attempt_json with
-        | Ok (Exact_bound _) -> true
-        | Ok Exact_unbound | Error _ -> false)
-     | None -> false)
-  | _ -> true
-;;
-
-let hard_cut_delivery_row_has_full_identity = function
-  | `Assoc fields ->
-    (match List.assoc_opt "entry" fields with
-     | Some (`Assoc _ as entry) -> hard_cut_pending_row_has_full_identity entry
-     | Some _ | None -> true)
-  | _ -> true
-;;
-
-let filter_hard_cut_rows ~has_full_identity = function
-  | `List rows ->
-    let retained, removed =
-      List.fold_left
-        (fun (retained, removed) row ->
-           if has_full_identity row
-           then row :: retained, removed
-           else retained, removed + 1)
-        ([], 0)
-        rows
-    in
-    `List (List.rev retained), removed
-  | json -> json, 0
-;;
-
-let hard_cut_snapshot_rows ~snapshot_version ~pending_json ~delivery_json =
-  if snapshot_version = pending_store_version
-  then pending_json, delivery_json, None
-  else
-    let pending_json, removed_pending =
-      filter_hard_cut_rows
-        ~has_full_identity:hard_cut_pending_row_has_full_identity
-        pending_json
-    in
-    let delivery_json, removed_deliveries =
-      filter_hard_cut_rows
-        ~has_full_identity:hard_cut_delivery_row_has_full_identity
-        delivery_json
-    in
-    ( pending_json
-    , delivery_json
-    , Some
-        { source_version = snapshot_version
-        ; target_version = pending_store_version
-        ; removed_pending
-        ; removed_deliveries
-        } )
-;;
-
 let validate_snapshot_sequences ~next_sequence pending_entries delivery_entries =
   let sequences =
     List.map (fun (entry : pending_approval) -> entry.sequence) pending_entries
@@ -928,34 +841,33 @@ let snapshot_of_yojson ~base_path json =
         ~allowed:[ "version"; "next_sequence"; "pending"; "deliveries" ]
         fields
     in
-      let* snapshot_version =
+    let* () =
         match List.assoc_opt "version" fields with
-        | Some (`Int version)
-          when version = legacy_pending_store_version
-               || version = exact_attempt_pending_store_version
-               || version = pending_store_version ->
-          Ok version
+        | Some (`Int version) when version = pending_store_version -> Ok ()
         | Some (`Int version) ->
-          Error (Printf.sprintf "%s.version %d is unsupported" surface version)
+          Error
+            (Printf.sprintf
+               "%s.version %d is unsupported (current %d); reset runtime state \
+                before restarting MASC"
+               surface
+               version
+               pending_store_version)
       | Some _ -> Error (surface ^ ".version must be an integer")
       | None -> Error (surface ^ ".version is required")
     in
     let* next_sequence = required_positive_int ~surface "next_sequence" fields in
     let* pending_json = required_member ~surface "pending" fields in
     let* delivery_json = required_member ~surface "deliveries" fields in
-    let pending_json, delivery_json, hard_cut_migration =
-      hard_cut_snapshot_rows ~snapshot_version ~pending_json ~delivery_json
-    in
-      let* pending_entries =
-        parse_list
-          ~surface:"gate_pending.pending"
-          (pending_entry_of_yojson ~base_path ~snapshot_version)
-          pending_json
+    let* pending_entries =
+      parse_list
+        ~surface:"gate_pending.pending"
+        (pending_entry_of_yojson ~base_path)
+        pending_json
     in
     let* delivery_entries =
       parse_list
           ~surface:"gate_pending.deliveries"
-          (persisted_delivery_of_yojson ~base_path ~snapshot_version)
+          (persisted_delivery_of_yojson ~base_path)
           delivery_json
     in
     let* pending_map =
@@ -978,21 +890,8 @@ let snapshot_of_yojson ~base_path json =
     let* () =
       validate_snapshot_sequences ~next_sequence pending_entries delivery_entries
     in
-      Ok
-        ( snapshot_version
-        , pending_map
-        , delivery_map
-        , next_sequence
-        , hard_cut_migration )
+    Ok (pending_map, delivery_map, next_sequence)
   | _ -> Error "gate_pending snapshot must be a JSON object"
-;;
-
-let snapshot_version_of_yojson = function
-  | `Assoc fields -> (
-    match List.assoc_opt "version" fields with
-    | Some (`Int version) -> Some version
-    | Some _ | None -> None)
-  | _ -> None
 ;;
 
 let quarantine_restarted_entry (entry : pending_approval) =
@@ -1036,53 +935,11 @@ let quarantine_restarted_deliveries map =
     (false, SMap.empty)
 ;;
 
-let quarantine_path ~path ~version =
-  let base = Printf.sprintf "%s.v%d.quarantine" path version in
-  let rec find_free k =
-    let candidate =
-      if k = 0 then base else Printf.sprintf "%s.%d" base k
-    in
-    if Sys.file_exists candidate then find_free (k + 1) else candidate
-  in
-  find_free 0
-;;
-
-(* An unsupported snapshot version is a generational boundary, not
-   corruption: the durable file is preserved verbatim at a visible
-   quarantine path and the store starts a fresh generation. Only a rename
-   failure keeps the old fail-closed behavior — starting fresh while the
-   old file is still in place would let the next [put] overwrite the very
-   evidence the quarantine exists to preserve. *)
-let quarantine_snapshot_unlocked ~path ~version =
-  let target = quarantine_path ~path ~version in
-  try
-    Sys.rename path target;
-    Log.Server.error
-      "gate_pending snapshot version %d is unsupported (current %d); \
-       quarantined to %s and starting a fresh store generation"
-      version pending_store_version target;
-    Ok (SMap.empty, SMap.empty, first_sequence)
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    let reason =
-      Printf.sprintf
-        "gate_pending snapshot version %d is unsupported and quarantine \
-         rename to %s failed: %s"
-        version target (Printexc.to_string exn)
-    in
-    report_pending_read_drop
-      ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
-      ~path
-      ~detail:reason;
-    Error { path; reason }
-;;
-
 let load_snapshot_unlocked ~base_path =
   let path = pending_store_path ~base_path in
   try
     if not (Sys.file_exists path)
-    then Ok (SMap.empty, SMap.empty, first_sequence, None)
+    then Ok (SMap.empty, SMap.empty, first_sequence)
     else (
       match Safe_ops.read_json_file_safe path with
       | Error reason ->
@@ -1092,81 +949,36 @@ let load_snapshot_unlocked ~base_path =
           ~detail:reason;
         Error { path; reason }
       | Ok json ->
-        (match snapshot_version_of_yojson json with
-           | Some version
-             when version <> legacy_pending_store_version
-                  && version <> exact_attempt_pending_store_version
-                  && version <> pending_store_version ->
-             (match quarantine_snapshot_unlocked ~path ~version with
+        (match snapshot_of_yojson ~base_path json with
+         | Ok (loaded_pending, loaded_deliveries, loaded_next_sequence) ->
+           let pending_changed, loaded_pending =
+             quarantine_restarted_pending loaded_pending
+           in
+           let deliveries_changed, loaded_deliveries =
+             quarantine_restarted_deliveries loaded_deliveries
+           in
+           if pending_changed || deliveries_changed
+           then
+             (match
+                save_snapshot_file_unlocked
+                  ~base_path
+                  ~next_sequence:loaded_next_sequence
+                  ~pending_map:loaded_pending
+                  ~delivery_map:loaded_deliveries
+              with
               | Error _ as error -> error
-              | Ok (pending_map, delivery_map, next_sequence) ->
-                Ok (pending_map, delivery_map, next_sequence, None))
-           | Some _ | None ->
-             (match snapshot_of_yojson ~base_path json with
-              | Ok
-                  ( snapshot_version
-                  , loaded_pending
-                  , loaded_deliveries
-                  , loaded_next_sequence
-                  , hard_cut_migration ) ->
-                let pending_changed, loaded_pending =
-                  quarantine_restarted_pending loaded_pending
-                in
-                let deliveries_changed, loaded_deliveries =
-                  quarantine_restarted_deliveries loaded_deliveries
-                in
-                if
-                  snapshot_version <> pending_store_version
-                  || pending_changed
-                  || deliveries_changed
-                then
-                  (match
-                     save_snapshot_file_unlocked
-                       ~base_path
-                       ~next_sequence:loaded_next_sequence
-                       ~pending_map:loaded_pending
-                       ~delivery_map:loaded_deliveries
-                   with
-                   | Error _ as error -> error
-                   | Ok () ->
-                     Log.Server.warn
-                       "gate_pending hard-cut migrated workspace=%s \
-                        version=%d->%d removed_pending=%d \
-                        removed_deliveries=%d removed_count=%d \
-                        restart_quarantine=%b"
-                       base_path
-                       snapshot_version
-                       pending_store_version
-                       (Option.fold
-                          ~none:0
-                          ~some:(fun migration -> migration.removed_pending)
-                          hard_cut_migration)
-                       (Option.fold
-                          ~none:0
-                          ~some:(fun migration -> migration.removed_deliveries)
-                          hard_cut_migration)
-                       (Option.fold
-                          ~none:0
-                          ~some:hard_cut_removed_count
-                          hard_cut_migration)
-                       (pending_changed || deliveries_changed);
-                     Ok
-                       ( loaded_pending
-                       , loaded_deliveries
-                       , loaded_next_sequence
-                       , hard_cut_migration ))
-                else
-                  Ok
-                    ( loaded_pending
-                    , loaded_deliveries
-                    , loaded_next_sequence
-                    , hard_cut_migration )
-              | Error reason ->
-              report_pending_read_drop
-                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-                ~path
-                ~detail:reason;
-              Error { path; reason })))
+              | Ok () ->
+                Log.Server.warn
+                  "gate_pending restart quarantine workspace=%s"
+                  base_path;
+                Ok (loaded_pending, loaded_deliveries, loaded_next_sequence))
+           else Ok (loaded_pending, loaded_deliveries, loaded_next_sequence)
+         | Error reason ->
+           report_pending_read_drop
+             ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+             ~path
+             ~detail:reason;
+           Error { path; reason }))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
@@ -1270,7 +1082,6 @@ let read_recent_audit_raw store limit =
 let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
 let approval_audit_summary_event = "summary_updated"
-let approval_audit_hard_cut_event = "legacy_exact_attempt_hard_cut_tombstone"
 let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
 let approval_sse_summary_event = "approval:summary_updated"
@@ -1343,23 +1154,6 @@ let get_audit_store ~base_path () =
   | exn -> report_failure exn
 ;;
 
-let append_approval_audit_json
-      ~store
-      ~keeper_name
-      ~site
-      ~id
-      ~event_type
-      json
-  =
-  Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
-    try
-      Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
-      invalidate_recent_audit_cache_for_store store
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn -> record_queue_failure ~keeper_name ~site ~id ~event_type exn)
-;;
-
 let audit_approval_event
       ~base_path
       ~event_type
@@ -1419,44 +1213,13 @@ let audit_approval_event
             | None -> [])
          )
     in
-    append_approval_audit_json
-      ~store
-      ~keeper_name
-      ~site:"audit_append"
-      ~id
-      ~event_type
-      json
-;;
-
-let audit_hard_cut_migration ~base_path migration =
-  match get_audit_store ~base_path () with
-  | None -> ()
-  | Some store ->
-    let id = "gate_pending" in
-    let keeper_name = "aggregate" in
-    let event_type = approval_audit_hard_cut_event in
-    let json =
-      `Assoc
-        [ "ts", `Float (Unix.gettimeofday ())
-        ; "event", `String event_type
-        ; "id", `String id
-        ; "keeper", `String keeper_name
-        ; "tool", `String "approval_queue_migration"
-        ; "source_version", `Int migration.source_version
-        ; "target_version", `Int migration.target_version
-        ; "removed_pending", `Int migration.removed_pending
-        ; "removed_deliveries", `Int migration.removed_deliveries
-        ; "removed_count", `Int (hard_cut_removed_count migration)
-        ; "reason", `String "missing_full_exact_attempt_identity"
-        ]
-    in
-    append_approval_audit_json
-      ~store
-      ~keeper_name
-      ~site:"audit_hard_cut_tombstone"
-      ~id
-      ~event_type
-      json
+    Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
+      try
+        Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
+        invalidate_recent_audit_cache_for_store store
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn -> record_queue_failure ~keeper_name ~site:"audit_append" ~id ~event_type exn)
 ;;
 
 let audit_rule_event ~base_path ~event_type (rule : approval_rule) =
@@ -3174,11 +2937,7 @@ let install_persistence_internal ~after_load ~base_path =
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;
         Error storage_error
-      | Ok
-          ( loaded_pending
-          , loaded_deliveries
-          , loaded_next_sequence
-          , hard_cut_migration ) ->
+      | Ok (loaded_pending, loaded_deliveries, loaded_next_sequence) ->
         let current_pending =
           remove_base_entries ~base_path (Atomic.get pending) Fun.id
         in
@@ -3238,13 +2997,11 @@ let install_persistence_internal ~after_load ~base_path =
                 , SMap.bindings loaded_deliveries
                   |> List.map snd
                   |> List.sort (fun left right ->
-                    compare_pending_order left.entry right.entry)
-                , hard_cut_migration ))))
+                    compare_pending_order left.entry right.entry) ))))
   in
   match installed with
   | Error storage_error -> Error (Install_storage_failed storage_error)
-  | Ok (loaded_pending, loaded_deliveries, hard_cut_migration) ->
-    Option.iter (audit_hard_cut_migration ~base_path) hard_cut_migration;
+  | Ok (loaded_pending, loaded_deliveries) ->
     let rec replay count failures = function
       | [] ->
         Ok

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -9,7 +9,6 @@ type storage_error =
 
 type summary_transition_rejection =
   | Summary_exact_attempt_bound of exact_attempt_binding
-  | Summary_legacy_execution_uncertain of string
 
 type summary_transition_error =
   | Summary_transition_storage_error of storage_error
@@ -25,7 +24,6 @@ type exact_attempt_rejection =
   | Exact_attempt_invalid_identity of string
   | Exact_attempt_summary_not_pending of string
   | Exact_attempt_unbound_state of string
-  | Exact_attempt_legacy_execution_uncertain of string
   | Exact_attempt_identity_conflict of exact_attempt_binding
   | Exact_attempt_status_conflict of exact_attempt_binding
   | Exact_attempt_provenance_mismatch of
@@ -131,10 +129,6 @@ let summary_transition_error_to_string = function
   | Summary_transition_rejected (Summary_exact_attempt_bound binding) ->
     "legacy summary transition rejected for exact attempt: "
     ^ exact_attempt_binding_to_string binding
-  | Summary_transition_rejected (Summary_legacy_execution_uncertain approval_id) ->
-    Printf.sprintf
-      "legacy summary transition rejected for execution-uncertain approval %s"
-      approval_id
 ;;
 
 let exact_attempt_error_to_string = function
@@ -154,10 +148,6 @@ let exact_attempt_error_to_string = function
     Printf.sprintf "exact attempt approval %s summary is not pending" approval_id
   | Exact_attempt_rejected (Exact_attempt_unbound_state approval_id) ->
     Printf.sprintf "exact attempt approval %s has no bound identity" approval_id
-  | Exact_attempt_rejected (Exact_attempt_legacy_execution_uncertain approval_id) ->
-    Printf.sprintf
-      "exact attempt approval %s is quarantined as legacy execution-uncertain"
-      approval_id
   | Exact_attempt_rejected (Exact_attempt_identity_conflict binding) ->
     "exact attempt identity conflicts with durable binding: "
     ^ exact_attempt_binding_to_string binding
@@ -201,7 +191,8 @@ let install_error_to_string = function
 ;;
 
 let legacy_pending_store_version = 3
-let pending_store_version = 4
+let exact_attempt_pending_store_version = 4
+let pending_store_version = 5
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
@@ -553,9 +544,6 @@ let validate_entry_exact_attempt
   =
   match exact_attempt, summary_status with
   | Exact_unbound, _ -> Ok ()
-  | Legacy_execution_uncertain, Summary_pending -> Ok ()
-  | Legacy_execution_uncertain, _ ->
-    Error "legacy execution-uncertain quarantine requires a pending summary"
   | Exact_bound binding, _
     when not
            (String.equal binding.approval_id id
@@ -605,7 +593,7 @@ let pending_entry_of_yojson ~base_path ~snapshot_version json =
              ; "summary_status"
              ]
              @
-             if snapshot_version = pending_store_version
+             if snapshot_version >= exact_attempt_pending_store_version
              then [ "exact_attempt" ]
              else [])
           fields
@@ -665,12 +653,7 @@ let pending_entry_of_yojson ~base_path ~snapshot_version json =
       let* summary_status = summary_status_of_yojson_with_error summary_json in
       let* exact_attempt =
         if snapshot_version = legacy_pending_store_version
-        then
-          Ok
-            (match summary_status with
-             | Summary_pending -> Legacy_execution_uncertain
-             | Summary_not_requested | Summary_available _ | Summary_failed _ ->
-               Exact_unbound)
+        then Ok Exact_unbound
         else
           let* exact_attempt_json = required_member ~surface "exact_attempt" fields in
           exact_attempt_state_of_yojson_with_error exact_attempt_json
@@ -839,6 +822,78 @@ let parse_list ~surface parse = function
   | _ -> Error (surface ^ " must be an array")
 ;;
 
+type hard_cut_migration =
+  { source_version : int
+  ; target_version : int
+  ; removed_pending : int
+  ; removed_deliveries : int
+  }
+
+let hard_cut_removed_count migration =
+  migration.removed_pending + migration.removed_deliveries
+;;
+
+(* Retain malformed non-row values so the strict decoder still rejects the
+   snapshot. Historical object rows are retained only when their typed codec
+   proves a full exact binding; no retired state token is interpreted here. *)
+let hard_cut_pending_row_has_full_identity = function
+  | `Assoc fields ->
+    (match List.assoc_opt "exact_attempt" fields with
+     | Some exact_attempt_json ->
+       (match exact_attempt_state_of_yojson_with_error exact_attempt_json with
+        | Ok (Exact_bound _) -> true
+        | Ok Exact_unbound | Error _ -> false)
+     | None -> false)
+  | _ -> true
+;;
+
+let hard_cut_delivery_row_has_full_identity = function
+  | `Assoc fields ->
+    (match List.assoc_opt "entry" fields with
+     | Some (`Assoc _ as entry) -> hard_cut_pending_row_has_full_identity entry
+     | Some _ | None -> true)
+  | _ -> true
+;;
+
+let filter_hard_cut_rows ~has_full_identity = function
+  | `List rows ->
+    let retained, removed =
+      List.fold_left
+        (fun (retained, removed) row ->
+           if has_full_identity row
+           then row :: retained, removed
+           else retained, removed + 1)
+        ([], 0)
+        rows
+    in
+    `List (List.rev retained), removed
+  | json -> json, 0
+;;
+
+let hard_cut_snapshot_rows ~snapshot_version ~pending_json ~delivery_json =
+  if snapshot_version = pending_store_version
+  then pending_json, delivery_json, None
+  else
+    let pending_json, removed_pending =
+      filter_hard_cut_rows
+        ~has_full_identity:hard_cut_pending_row_has_full_identity
+        pending_json
+    in
+    let delivery_json, removed_deliveries =
+      filter_hard_cut_rows
+        ~has_full_identity:hard_cut_delivery_row_has_full_identity
+        delivery_json
+    in
+    ( pending_json
+    , delivery_json
+    , Some
+        { source_version = snapshot_version
+        ; target_version = pending_store_version
+        ; removed_pending
+        ; removed_deliveries
+        } )
+;;
+
 let validate_snapshot_sequences ~next_sequence pending_entries delivery_entries =
   let sequences =
     List.map (fun (entry : pending_approval) -> entry.sequence) pending_entries
@@ -877,6 +932,7 @@ let snapshot_of_yojson ~base_path json =
         match List.assoc_opt "version" fields with
         | Some (`Int version)
           when version = legacy_pending_store_version
+               || version = exact_attempt_pending_store_version
                || version = pending_store_version ->
           Ok version
         | Some (`Int version) ->
@@ -886,13 +942,16 @@ let snapshot_of_yojson ~base_path json =
     in
     let* next_sequence = required_positive_int ~surface "next_sequence" fields in
     let* pending_json = required_member ~surface "pending" fields in
+    let* delivery_json = required_member ~surface "deliveries" fields in
+    let pending_json, delivery_json, hard_cut_migration =
+      hard_cut_snapshot_rows ~snapshot_version ~pending_json ~delivery_json
+    in
       let* pending_entries =
         parse_list
           ~surface:"gate_pending.pending"
           (pending_entry_of_yojson ~base_path ~snapshot_version)
           pending_json
     in
-    let* delivery_json = required_member ~surface "deliveries" fields in
     let* delivery_entries =
       parse_list
           ~surface:"gate_pending.deliveries"
@@ -919,7 +978,12 @@ let snapshot_of_yojson ~base_path json =
     let* () =
       validate_snapshot_sequences ~next_sequence pending_entries delivery_entries
     in
-      Ok (snapshot_version, pending_map, delivery_map, next_sequence)
+      Ok
+        ( snapshot_version
+        , pending_map
+        , delivery_map
+        , next_sequence
+        , hard_cut_migration )
   | _ -> Error "gate_pending snapshot must be a JSON object"
 ;;
 
@@ -943,7 +1007,6 @@ let quarantine_restarted_entry (entry : pending_approval) =
       }
     , true )
   | Exact_unbound
-  | Legacy_execution_uncertain
   | Exact_bound
       { status =
           ( Exact_released_before_dispatch
@@ -1019,7 +1082,7 @@ let load_snapshot_unlocked ~base_path =
   let path = pending_store_path ~base_path in
   try
     if not (Sys.file_exists path)
-    then Ok (SMap.empty, SMap.empty, first_sequence)
+    then Ok (SMap.empty, SMap.empty, first_sequence, None)
     else (
       match Safe_ops.read_json_file_safe path with
       | Error reason ->
@@ -1032,15 +1095,20 @@ let load_snapshot_unlocked ~base_path =
         (match snapshot_version_of_yojson json with
            | Some version
              when version <> legacy_pending_store_version
+                  && version <> exact_attempt_pending_store_version
                   && version <> pending_store_version ->
-             quarantine_snapshot_unlocked ~path ~version
+             (match quarantine_snapshot_unlocked ~path ~version with
+              | Error _ as error -> error
+              | Ok (pending_map, delivery_map, next_sequence) ->
+                Ok (pending_map, delivery_map, next_sequence, None))
            | Some _ | None ->
              (match snapshot_of_yojson ~base_path json with
               | Ok
                   ( snapshot_version
                   , loaded_pending
                   , loaded_deliveries
-                  , loaded_next_sequence ) ->
+                  , loaded_next_sequence
+                  , hard_cut_migration ) ->
                 let pending_changed, loaded_pending =
                   quarantine_restarted_pending loaded_pending
                 in
@@ -1048,7 +1116,7 @@ let load_snapshot_unlocked ~base_path =
                   quarantine_restarted_deliveries loaded_deliveries
                 in
                 if
-                  snapshot_version = legacy_pending_store_version
+                  snapshot_version <> pending_store_version
                   || pending_changed
                   || deliveries_changed
                 then
@@ -1062,21 +1130,37 @@ let load_snapshot_unlocked ~base_path =
                    | Error _ as error -> error
                    | Ok () ->
                      Log.Server.warn
-                       "gate_pending migrated workspace=%s version=%d->%d \
+                       "gate_pending hard-cut migrated workspace=%s \
+                        version=%d->%d removed_pending=%d \
+                        removed_deliveries=%d removed_count=%d \
                         restart_quarantine=%b"
                        base_path
                        snapshot_version
                        pending_store_version
+                       (Option.fold
+                          ~none:0
+                          ~some:(fun migration -> migration.removed_pending)
+                          hard_cut_migration)
+                       (Option.fold
+                          ~none:0
+                          ~some:(fun migration -> migration.removed_deliveries)
+                          hard_cut_migration)
+                       (Option.fold
+                          ~none:0
+                          ~some:hard_cut_removed_count
+                          hard_cut_migration)
                        (pending_changed || deliveries_changed);
                      Ok
                        ( loaded_pending
                        , loaded_deliveries
-                       , loaded_next_sequence ))
+                       , loaded_next_sequence
+                       , hard_cut_migration ))
                 else
                   Ok
                     ( loaded_pending
                     , loaded_deliveries
-                    , loaded_next_sequence )
+                    , loaded_next_sequence
+                    , hard_cut_migration )
               | Error reason ->
               report_pending_read_drop
                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -1186,6 +1270,7 @@ let read_recent_audit_raw store limit =
 let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
 let approval_audit_summary_event = "summary_updated"
+let approval_audit_hard_cut_event = "legacy_exact_attempt_hard_cut_tombstone"
 let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
 let approval_sse_summary_event = "approval:summary_updated"
@@ -1258,6 +1343,23 @@ let get_audit_store ~base_path () =
   | exn -> report_failure exn
 ;;
 
+let append_approval_audit_json
+      ~store
+      ~keeper_name
+      ~site
+      ~id
+      ~event_type
+      json
+  =
+  Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
+    try
+      Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
+      invalidate_recent_audit_cache_for_store store
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> record_queue_failure ~keeper_name ~site ~id ~event_type exn)
+;;
+
 let audit_approval_event
       ~base_path
       ~event_type
@@ -1317,13 +1419,44 @@ let audit_approval_event
             | None -> [])
          )
     in
-    Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
-      try
-        Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
-        invalidate_recent_audit_cache_for_store store
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn -> record_queue_failure ~keeper_name ~site:"audit_append" ~id ~event_type exn)
+    append_approval_audit_json
+      ~store
+      ~keeper_name
+      ~site:"audit_append"
+      ~id
+      ~event_type
+      json
+;;
+
+let audit_hard_cut_migration ~base_path migration =
+  match get_audit_store ~base_path () with
+  | None -> ()
+  | Some store ->
+    let id = "gate_pending" in
+    let keeper_name = "aggregate" in
+    let event_type = approval_audit_hard_cut_event in
+    let json =
+      `Assoc
+        [ "ts", `Float (Unix.gettimeofday ())
+        ; "event", `String event_type
+        ; "id", `String id
+        ; "keeper", `String keeper_name
+        ; "tool", `String "approval_queue_migration"
+        ; "source_version", `Int migration.source_version
+        ; "target_version", `Int migration.target_version
+        ; "removed_pending", `Int migration.removed_pending
+        ; "removed_deliveries", `Int migration.removed_deliveries
+        ; "removed_count", `Int (hard_cut_removed_count migration)
+        ; "reason", `String "missing_full_exact_attempt_identity"
+        ]
+    in
+    append_approval_audit_json
+      ~store
+      ~keeper_name
+      ~site:"audit_hard_cut_tombstone"
+      ~id
+      ~event_type
+      json
 ;;
 
 let audit_rule_event ~base_path ~event_type (rule : approval_rule) =
@@ -1780,8 +1913,6 @@ let summary_transition_rejection (entry : pending_approval) =
   match entry.exact_attempt with
   | Exact_unbound -> None
   | Exact_bound binding -> Some (Summary_exact_attempt_bound binding)
-  | Legacy_execution_uncertain ->
-    Some (Summary_legacy_execution_uncertain entry.id)
 ;;
 
 let persist_pending_entry_unlocked ~map ~(entry : pending_approval) updated_entry =
@@ -1977,10 +2108,6 @@ let bind_summary_exact_attempt_with
                    ~map
                    ~entry
                    { entry with exact_attempt = Exact_bound candidate }
-              | Legacy_execution_uncertain ->
-                Error
-                  (Exact_attempt_rejected
-                     (Exact_attempt_legacy_execution_uncertain entry.id))
                 | Exact_bound existing
                   when exact_attempt_identity_matches existing candidate ->
                   (match existing.status with
@@ -2051,10 +2178,6 @@ let release_summary_exact_attempt_before_dispatch_with
              Error
                (Exact_attempt_rejected
                   (Exact_attempt_unbound_state entry.id))
-           | Legacy_execution_uncertain ->
-             Error
-               (Exact_attempt_rejected
-                  (Exact_attempt_legacy_execution_uncertain entry.id))
            | Exact_bound existing
              when not (exact_attempt_identity_matches existing candidate) ->
              Error
@@ -2130,10 +2253,6 @@ let fail_summary_exact_attempt_before_dispatch_with
              Error
                (Exact_attempt_rejected
                   (Exact_attempt_unbound_state entry.id))
-           | Legacy_execution_uncertain ->
-             Error
-               (Exact_attempt_rejected
-                  (Exact_attempt_legacy_execution_uncertain entry.id))
            | Exact_bound existing
              when not (exact_attempt_identity_matches existing candidate) ->
              Error
@@ -2223,10 +2342,6 @@ let quarantine_summary_exact_attempt_with
              Error
                (Exact_attempt_rejected
                   (Exact_attempt_unbound_state entry.id))
-           | Legacy_execution_uncertain ->
-             Error
-               (Exact_attempt_rejected
-                  (Exact_attempt_legacy_execution_uncertain entry.id))
            | Exact_bound existing
              when not (exact_attempt_identity_matches existing candidate) ->
              Error
@@ -2316,10 +2431,6 @@ let complete_summary_exact_attempt_with
              Error
                (Exact_attempt_rejected
                   (Exact_attempt_unbound_state entry.id))
-           | Legacy_execution_uncertain ->
-             Error
-               (Exact_attempt_rejected
-                  (Exact_attempt_legacy_execution_uncertain entry.id))
            | Exact_bound existing
              when not (exact_attempt_identity_matches existing candidate) ->
              Error
@@ -3063,7 +3174,11 @@ let install_persistence_internal ~after_load ~base_path =
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;
         Error storage_error
-      | Ok (loaded_pending, loaded_deliveries, loaded_next_sequence) ->
+      | Ok
+          ( loaded_pending
+          , loaded_deliveries
+          , loaded_next_sequence
+          , hard_cut_migration ) ->
         let current_pending =
           remove_base_entries ~base_path (Atomic.get pending) Fun.id
         in
@@ -3123,11 +3238,13 @@ let install_persistence_internal ~after_load ~base_path =
                 , SMap.bindings loaded_deliveries
                   |> List.map snd
                   |> List.sort (fun left right ->
-                    compare_pending_order left.entry right.entry) ))))
+                    compare_pending_order left.entry right.entry)
+                , hard_cut_migration ))))
   in
   match installed with
   | Error storage_error -> Error (Install_storage_failed storage_error)
-  | Ok (loaded_pending, loaded_deliveries) ->
+  | Ok (loaded_pending, loaded_deliveries, hard_cut_migration) ->
+    Option.iter (audit_hard_cut_migration ~base_path) hard_cut_migration;
     let rec replay count failures = function
       | [] ->
         Ok

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -13,7 +13,6 @@ type storage_error =
 
 type summary_transition_rejection =
   | Summary_exact_attempt_bound of exact_attempt_binding
-  | Summary_legacy_execution_uncertain of string
 
 type summary_transition_error =
   | Summary_transition_storage_error of storage_error
@@ -29,7 +28,6 @@ type exact_attempt_rejection =
   | Exact_attempt_invalid_identity of string
   | Exact_attempt_summary_not_pending of string
   | Exact_attempt_unbound_state of string
-  | Exact_attempt_legacy_execution_uncertain of string
   | Exact_attempt_identity_conflict of exact_attempt_binding
   | Exact_attempt_status_conflict of exact_attempt_binding
   | Exact_attempt_provenance_mismatch of

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -360,9 +360,7 @@ let classify_auto_judge_entry
     Auto_judge_finalizable summary
   | Keeper_approval_queue.Exact_unbound,
     Keeper_approval_queue.Summary_failed _
-  | ( Keeper_approval_queue.Exact_bound _
-    | Keeper_approval_queue.Legacy_execution_uncertain ),
-    _ ->
+  | Keeper_approval_queue.Exact_bound _, _ ->
     Auto_judge_ineligible
 ;;
 
@@ -783,8 +781,7 @@ let finalize_recovered_judgment
          ("exact completion durability confirmation failed; Gate finalization \
            withheld: "
           ^ Keeper_approval_queue.exact_attempt_error_to_string error))
-  | Keeper_approval_queue.Exact_bound _
-  | Keeper_approval_queue.Legacy_execution_uncertain ->
+  | Keeper_approval_queue.Exact_bound _ ->
     Error
       "recovered Auto Judge entry is not an unbound or completed exact judgment"
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -75,7 +75,6 @@ let exact_attempt_binding_with_status binding status = { binding with status }
 type exact_attempt_state =
   | Exact_unbound
   | Exact_bound of exact_attempt_binding
-  | Legacy_execution_uncertain
 
 type pending_approval =
   { id : string
@@ -260,8 +259,6 @@ let exact_attempt_quarantine_cause_to_string = function
 
 let exact_attempt_state_to_yojson = function
   | Exact_unbound -> `Assoc [ "state", `String "unbound" ]
-  | Legacy_execution_uncertain ->
-    `Assoc [ "state", `String "legacy_execution_uncertain" ]
   | Exact_bound binding ->
     let quarantine_cause =
       match binding.status with
@@ -379,9 +376,6 @@ let exact_attempt_state_of_yojson_with_error json =
      | "unbound" ->
        let* () = reject_unknown_fields ~surface ~allowed:[ "state" ] fields in
        Ok Exact_unbound
-     | "legacy_execution_uncertain" ->
-       let* () = reject_unknown_fields ~surface ~allowed:[ "state" ] fields in
-       Ok Legacy_execution_uncertain
      | "bound" ->
        let* () =
          reject_unknown_fields

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -67,7 +67,6 @@ val exact_attempt_binding_with_status :
 type exact_attempt_state =
   | Exact_unbound
   | Exact_bound of exact_attempt_binding
-  | Legacy_execution_uncertain
 
 (** A pending request never owns or suspends a Keeper lane. [sequence] is the
     durable queue-issued order identity; [requested_at] is observation only. *)

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -429,6 +429,7 @@ let delivery_json ~entry ~remember_rule =
     ; "decision", `Assoc [ "kind", `String "approve" ]
     ; "source", `String "human_operator"
     ; "remember_rule", `Bool remember_rule
+    ; "rule_expires_at", `Null
     ; "created_by", `Null
     ; "grant_consumed", `Bool false
     ]
@@ -445,7 +446,7 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 3
+            [ "version", `Int 5
             ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
@@ -608,55 +609,6 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | None -> Alcotest.fail "pending request was not restored");
        reject_and_cleanup ~base_path first;
        reject_and_cleanup ~base_path changed)
-;;
-
-let test_unversioned_request_context_is_not_replayed_as_exact () =
-  let base_path = temp_dir () in
-  let keeper_name = "queue-legacy-context" in
-  Fun.protect
-    ~finally:(fun () ->
-      AQ.For_testing.reset_runtime_state ();
-      cleanup_dir base_path)
-    (fun () ->
-       AQ.For_testing.reset_runtime_state ();
-       ignore (install_exn ~base_path);
-       let id =
-         submit_with_context
-           ~request_context:(`Assoc [ "history_digest", `String "retired-projection" ])
-           ~base_path
-           ~keeper_name
-           ~input:(`String "legacy")
-           ()
-       in
-       let snapshot = read_pending_snapshot ~base_path in
-       let unversioned =
-         match snapshot with
-         | `Assoc fields ->
-           let pending =
-             match List.assoc_opt "pending" fields with
-             | Some (`List entries) ->
-               `List
-                 (List.map
-                    (function
-                      | `Assoc entry_fields ->
-                        `Assoc (List.remove_assoc "request_context_version" entry_fields)
-                      | entry -> entry)
-                    entries)
-             | Some pending -> pending
-             | None -> `List []
-           in
-           `Assoc (("pending", pending) :: List.remove_assoc "pending" fields)
-         | other -> other
-       in
-       AQ.For_testing.reset_runtime_state ();
-       write_pending_snapshot ~base_path unversioned;
-       ignore (install_exn ~base_path);
-       (match AQ.get_pending_entry ~id with
-        | Some { request_context = None; _ } -> ()
-        | Some { request_context = Some _; _ } ->
-          Alcotest.fail "unversioned projected context was treated as exact evidence"
-        | None -> Alcotest.fail "legacy pending request was not restored");
-       reject_and_cleanup ~base_path id)
 ;;
 
 let test_monotonic_sequence_survives_restart () =
@@ -1065,7 +1017,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
        drop_resolution ~base_path ~keeper_name resolution)
 ;;
 
-let test_v4_exact_binding_codec_validates_entry_identity () =
+let test_exact_binding_codec_validates_entry_identity () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -1077,7 +1029,7 @@ let test_v4_exact_binding_codec_validates_entry_identity () =
        let id =
          submit
            ~base_path
-           ~keeper_name:"queue-v4-exact-codec"
+           ~keeper_name:"queue-exact-codec"
            ~input:(`Assoc [ "request", `String "codec" ])
        in
        check_update "mark exact codec pending" true (AQ.mark_summary_pending ~id);
@@ -1105,12 +1057,12 @@ let test_v4_exact_binding_codec_validates_entry_identity () =
               Alcotest.failf "%s runtime hash was accepted" label)
          invalid_hashes;
        check_exact_update
-         "bind valid v4 identity"
+         "bind valid exact identity"
          true
          (run_exact_transition AQ.bind_summary_exact_attempt identity);
        let snapshot = read_pending_snapshot ~base_path in
        let open Yojson.Safe.Util in
-       Alcotest.(check int) "v4 snapshot" 4 (snapshot |> member "version" |> to_int);
+       Alcotest.(check int) "v5 snapshot" 5 (snapshot |> member "version" |> to_int);
        let exact_json =
          snapshot
          |> member "pending"
@@ -1132,7 +1084,7 @@ let test_v4_exact_binding_codec_validates_entry_identity () =
             "codec sequence identity"
             identity.sequence_arg
             binding.sequence
-        | Ok _ -> Alcotest.fail "v4 bound exact attempt decoded as another state"
+        | Ok _ -> Alcotest.fail "bound exact attempt decoded as another state"
         | Error reason -> Alcotest.fail reason);
        let replace_field field value = function
          | `Assoc fields ->
@@ -2479,131 +2431,6 @@ let test_decisive_summary_finalizes_after_restart () =
        drop_resolution ~base_path ~keeper_name resolution)
 ;;
 
-let test_legacy_exact_attempt_rows_are_hard_cut () =
-  let base_path = temp_dir () in
-  let keeper_name = "queue-legacy-hard-cut" in
-  Fun.protect
-    ~finally:(fun () ->
-      AQ.For_testing.reset_runtime_state ();
-      cleanup_dir base_path)
-    (fun () ->
-       AQ.For_testing.reset_runtime_state ();
-       ignore (install_exn ~base_path);
-       let pending_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "legacy-pending" ])
-       in
-       let delivery_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "legacy-delivery" ])
-       in
-       check_update
-         "legacy pending judge marked in flight"
-         true
-         (AQ.mark_summary_pending ~id:pending_id);
-       check_update
-         "legacy delivery judge marked in flight"
-         true
-         (AQ.mark_summary_pending ~id:delivery_id);
-       let current_snapshot = read_pending_snapshot ~base_path in
-       let legacy_entry id entries =
-         match
-           List.find_opt
-             (function
-               | `Assoc fields ->
-                 (match List.assoc_opt "id" fields with
-                  | Some (`String actual) -> String.equal actual id
-                  | Some _ | None -> false)
-               | _ -> false)
-             entries
-         with
-         | Some (`Assoc fields) ->
-           `Assoc
-             (("exact_attempt", `Assoc [ "state", `String "legacy_execution_uncertain" ])
-              :: List.remove_assoc "exact_attempt" fields)
-         | Some _ | None -> Alcotest.failf "snapshot entry %s not found" id
-       in
-       let v4_snapshot =
-         match current_snapshot with
-         | `Assoc fields ->
-           let entries =
-             match List.assoc_opt "pending" fields with
-             | Some (`List entries) -> entries
-             | _ -> Alcotest.fail "legacy pending list expected"
-           in
-           let pending_entry = legacy_entry pending_id entries in
-           let delivery_entry = legacy_entry delivery_id entries in
-           let delivery =
-             `Assoc
-               [ "entry", delivery_entry
-               ; "decision", `Assoc [ "kind", `String "approve" ]
-               ; "source", `String "human_operator"
-               ; "remember_rule", `Bool false
-               ; "rule_expires_at", `Null
-               ; "created_by", `Null
-               ; "grant_consumed", `Bool false
-               ]
-           in
-           `Assoc
-             (("version", `Int 4)
-              :: ("pending", `List [ pending_entry ])
-              :: ("deliveries", `List [ delivery ])
-              :: (fields
-                  |> List.remove_assoc "version"
-                  |> List.remove_assoc "pending"
-                  |> List.remove_assoc "deliveries"))
-         | _ -> Alcotest.fail "legacy snapshot object expected"
-       in
-       AQ.For_testing.reset_runtime_state ();
-       write_pending_snapshot ~base_path v4_snapshot;
-       Alcotest.(check int) "process state cleared" 0 (List.length (AQ.list_pending_entries ()));
-       let report = install_exn ~base_path in
-       Alcotest.(check int) "legacy pending removed" 0 report.loaded_pending;
-       Alcotest.(check int) "no delivery replay" 0 report.replayed_deliveries;
-       Alcotest.(check int)
-         "no delivery replay failure"
-         0
-         (List.length report.delivery_replay_failures);
-       Alcotest.(check bool)
-         "legacy pending absent"
-         true
-         (Option.is_none (AQ.get_pending_entry ~id:pending_id));
-       Alcotest.(check bool)
-         "legacy delivery absent"
-         true
-         (Option.is_none (AQ.get_pending_entry ~id:delivery_id));
-       let open Yojson.Safe.Util in
-       let persisted = read_pending_snapshot ~base_path in
-       Alcotest.(check int) "legacy snapshot migrated to v5" 5
-         (persisted |> member "version" |> to_int);
-       Alcotest.(check int) "persisted pending removed" 0
-         (persisted |> member "pending" |> to_list |> List.length);
-       Alcotest.(check int) "persisted delivery removed" 0
-         (persisted |> member "deliveries" |> to_list |> List.length);
-       let tombstone =
-         AQ.read_recent_audit ~base_path ~n:20 ()
-         |> List.find_opt (fun json ->
-           String.equal
-             "legacy_exact_attempt_hard_cut_tombstone"
-             (Safe_ops.json_string ~default:"" "event" json))
-         |> function
-         | Some json -> json
-         | None -> Alcotest.fail "hard-cut migration audit tombstone missing"
-       in
-       let check_tombstone_int label expected field =
-         Alcotest.(check int) label expected (tombstone |> member field |> to_int)
-       in
-       check_tombstone_int "source version" 4 "source_version";
-       check_tombstone_int "target version" 5 "target_version";
-       check_tombstone_int "one pending tombstoned" 1 "removed_pending";
-       check_tombstone_int "one delivery tombstoned" 1 "removed_deliveries";
-       check_tombstone_int "two rows tombstoned" 2 "removed_count")
-;;
-
 let test_malformed_snapshot_fails_install_and_is_observed () =
   let base_path = temp_dir () in
   Fun.protect
@@ -2615,7 +2442,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 3
+            [ "version", `Int 5
             ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
@@ -2646,7 +2473,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 3
+               [ "version", `Int 5
                ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
@@ -2660,7 +2487,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        Alcotest.(check bool) "malformed snapshot observed" true (after -. before >= 1.0))
 ;;
 
-let test_unsupported_version_snapshot_is_quarantined_and_store_starts_fresh () =
+let test_unsupported_version_snapshot_requires_runtime_reset () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -2676,16 +2503,23 @@ let test_unsupported_version_snapshot_is_quarantined_and_store_starts_fresh () =
             ; "deliveries", `List []
             ]);
        (match AQ.install_persistence ~base_path with
-        | Ok _ -> ()
-        | Error _ ->
-          Alcotest.fail "unsupported version must quarantine, not fail install");
+        | Ok _ -> Alcotest.fail "unsupported version must fail install"
+        | Error
+            (AQ.Install_storage_failed
+              { reason =
+                  "gate_pending.version 2 is unsupported (current 5); reset \
+                   runtime state before restarting MASC"
+              ; _
+              }) ->
+          ()
+        | Error error ->
+          Alcotest.failf
+            "unsupported version returned the wrong error: %s"
+            (AQ.install_error_to_string error));
        let store_path = AQ.For_testing.pending_store_path ~base_path in
-       Alcotest.(check bool) "original moved away" false
+       Alcotest.(check bool) "original remains for operator reset" true
          (Sys.file_exists store_path);
-       let quarantine_path = store_path ^ ".v2.quarantine" in
-       Alcotest.(check bool) "quarantine file exists" true
-         (Sys.file_exists quarantine_path);
-       let preserved = Yojson.Safe.from_file quarantine_path in
+       let preserved = Yojson.Safe.from_file store_path in
        Alcotest.(check bool) "content preserved verbatim" true
          (Yojson.Safe.equal
             preserved
@@ -2693,42 +2527,7 @@ let test_unsupported_version_snapshot_is_quarantined_and_store_starts_fresh () =
                [ "version", `Int 2
                ; "pending", `List []
                ; "deliveries", `List []
-               ]));
-       let id =
-         submit ~base_path ~keeper_name:"queue-quarantine"
-           ~input:(`Assoc [ "target", `String "after-quarantine" ])
-       in
-       Alcotest.(check int) "fresh generation starts at sequence 1" 1
-         (pending_entry_exn id).sequence)
-;;
-
-let test_quarantine_name_collision_uses_next_free_name () =
-  let base_path = temp_dir () in
-  Fun.protect
-    ~finally:(fun () ->
-      AQ.For_testing.reset_runtime_state ();
-      cleanup_dir base_path)
-    (fun () ->
-       AQ.For_testing.reset_runtime_state ();
-       let store_path = AQ.For_testing.pending_store_path ~base_path in
-       write_pending_snapshot
-         ~base_path
-         (`Assoc
-            [ "version", `Int 2
-            ; "pending", `List []
-            ; "deliveries", `List []
-            ]);
-       let occupied = store_path ^ ".v2.quarantine" in
-       ensure_dir (Filename.dirname occupied);
-       Out_channel.with_open_text occupied (fun channel ->
-         output_string channel "prior quarantine");
-       (match AQ.install_persistence ~base_path with
-        | Ok _ -> ()
-        | Error _ -> Alcotest.fail "install must quarantine");
-       Alcotest.(check bool) "prior quarantine kept" true
-         (Sys.file_exists occupied);
-       Alcotest.(check bool) "next free name used" true
-         (Sys.file_exists (store_path ^ ".v2.quarantine.1")))
+               ]))
 ;;
 
 let test_unreadable_json_snapshot_is_not_quarantined () =
@@ -2779,7 +2578,7 @@ let test_persisted_delivery_replays_before_origin_wake () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 3
+            [ "version", `Int 5
             ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
@@ -2873,7 +2672,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 3
+            [ "version", `Int 5
             ; "next_sequence", `Int 4
             ; "pending", `List []
             ; ( "deliveries"
@@ -3119,10 +2918,6 @@ let () =
             `Quick
             test_submit_is_nonblocking_and_exactly_deduplicated
         ; Alcotest.test_case
-            "unversioned context is never replayed as exact"
-            `Quick
-            test_unversioned_request_context_is_not_replayed_as_exact
-        ; Alcotest.test_case
             "durable sequence survives restart"
             `Quick
             test_monotonic_sequence_survives_restart
@@ -3157,7 +2952,7 @@ let () =
         ; Alcotest.test_case
             "exact binding codec validates entry identity"
             `Quick
-            test_v4_exact_binding_codec_validates_entry_identity
+            test_exact_binding_codec_validates_entry_identity
         ; Alcotest.test_case
             "exact binding release and conflicts"
             `Quick
@@ -3211,21 +3006,13 @@ let () =
               `Quick
               test_exact_completed_restart_requires_fsync_confirmation
         ; Alcotest.test_case
-            "legacy exact-attempt rows are hard-cut"
-            `Quick
-            test_legacy_exact_attempt_rows_are_hard_cut
-        ; Alcotest.test_case
             "malformed snapshot is explicit"
             `Quick
             test_malformed_snapshot_fails_install_and_is_observed
         ; Alcotest.test_case
-            "unsupported version quarantines and restarts fresh"
+            "unsupported version requires runtime reset"
             `Quick
-            test_unsupported_version_snapshot_is_quarantined_and_store_starts_fresh
-        ; Alcotest.test_case
-            "quarantine name collision uses next free name"
-            `Quick
-            test_quarantine_name_collision_uses_next_free_name
+            test_unsupported_version_snapshot_requires_runtime_reset
         ; Alcotest.test_case
             "unreadable json is not quarantined"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1143,7 +1143,7 @@ let test_exact_binding_codec_validates_entry_identity () =
             | Error _ -> ()
             | Ok _ ->
               Alcotest.failf
-                "v4 binding with mismatched %s installed"
+                "current binding with mismatched %s installed"
                 field)
          [ "approval_id", `String "different-approval"
          ; "input_hash", `String "different-input-hash"
@@ -2530,7 +2530,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
                ])))
 ;;
 
-let test_unreadable_json_snapshot_is_not_quarantined () =
+let test_unreadable_snapshot_fails_closed_and_is_preserved () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -2546,9 +2546,7 @@ let test_unreadable_json_snapshot_is_not_quarantined () =
         | Ok _ -> Alcotest.fail "unreadable snapshot must not install"
         | Error _ -> ());
        Alcotest.(check bool) "file left in place" true
-         (Sys.file_exists store_path);
-       Alcotest.(check bool) "no quarantine created" false
-         (Sys.file_exists (store_path ^ ".v2.quarantine")))
+         (Sys.file_exists store_path))
 ;;
 
 let test_persisted_delivery_replays_before_origin_wake () =
@@ -3014,9 +3012,9 @@ let () =
             `Quick
             test_unsupported_version_snapshot_requires_runtime_reset
         ; Alcotest.test_case
-            "unreadable json is not quarantined"
+            "unreadable current snapshot is preserved"
             `Quick
-            test_unreadable_json_snapshot_is_not_quarantined
+            test_unreadable_snapshot_fails_closed_and_is_preserved
         ; Alcotest.test_case
             "delivery journal replays"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -2527,7 +2527,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
                [ "version", `Int 2
                ; "pending", `List []
                ; "deliveries", `List []
-               ]))
+               ])))
 ;;
 
 let test_unreadable_json_snapshot_is_not_quarantined () =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -386,16 +386,10 @@ let check_visible_update label expected = function
   | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
 ;;
 
-let expect_summary_rejection label expected = function
+let expect_summary_rejection label = function
   | Error
       (AQ.Summary_transition_rejected
-        (AQ.Summary_exact_attempt_bound _))
-    when expected = `Bound ->
-    ()
-  | Error
-      (AQ.Summary_transition_rejected
-        (AQ.Summary_legacy_execution_uncertain _))
-    when expected = `Legacy ->
+        (AQ.Summary_exact_attempt_bound _)) ->
     ()
   | Error error ->
     Alcotest.failf
@@ -1272,18 +1266,15 @@ let test_exact_attempt_binding_release_and_conflicts () =
        let summary = exact_summary "bound-summary-rejection" in
        expect_summary_rejection
          "bound attach"
-         `Bound
          (AQ.attach_summary ~id summary);
        expect_summary_rejection
          "bound fail"
-         `Bound
          (AQ.mark_summary_failed
             ~id
             ~reason:"must remain exact"
             ~retryable:true);
        expect_summary_rejection
          "bound restart"
-         `Bound
          (AQ.restart_failed_summary ~id);
        let quarantine_cause = AQ.Exact_post_dispatch_failure in
        check_exact_update
@@ -2488,9 +2479,9 @@ let test_decisive_summary_finalizes_after_restart () =
        drop_resolution ~base_path ~keeper_name resolution)
 ;;
 
-let test_v3_inflight_auto_judge_becomes_legacy_quarantine () =
+let test_legacy_exact_attempt_rows_are_hard_cut () =
   let base_path = temp_dir () in
-  let keeper_name = "queue-v3-legacy-quarantine" in
+  let keeper_name = "queue-legacy-hard-cut" in
   Fun.protect
     ~finally:(fun () ->
       AQ.For_testing.reset_runtime_state ();
@@ -2498,104 +2489,119 @@ let test_v3_inflight_auto_judge_becomes_legacy_quarantine () =
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
        ignore (install_exn ~base_path);
-       let id =
+       let pending_id =
          submit
            ~base_path
            ~keeper_name
-           ~input:(`Assoc [ "target", `String "legacy-restart" ])
+           ~input:(`Assoc [ "target", `String "legacy-pending" ])
        in
-       check_update "legacy judge marked in flight" true (AQ.mark_summary_pending ~id);
-       let v4_snapshot = read_pending_snapshot ~base_path in
-       let v3_snapshot =
-         match v4_snapshot with
+       let delivery_id =
+         submit
+           ~base_path
+           ~keeper_name
+           ~input:(`Assoc [ "target", `String "legacy-delivery" ])
+       in
+       check_update
+         "legacy pending judge marked in flight"
+         true
+         (AQ.mark_summary_pending ~id:pending_id);
+       check_update
+         "legacy delivery judge marked in flight"
+         true
+         (AQ.mark_summary_pending ~id:delivery_id);
+       let current_snapshot = read_pending_snapshot ~base_path in
+       let legacy_entry id entries =
+         match
+           List.find_opt
+             (function
+               | `Assoc fields ->
+                 (match List.assoc_opt "id" fields with
+                  | Some (`String actual) -> String.equal actual id
+                  | Some _ | None -> false)
+               | _ -> false)
+             entries
+         with
+         | Some (`Assoc fields) ->
+           `Assoc
+             (("exact_attempt", `Assoc [ "state", `String "legacy_execution_uncertain" ])
+              :: List.remove_assoc "exact_attempt" fields)
+         | Some _ | None -> Alcotest.failf "snapshot entry %s not found" id
+       in
+       let v4_snapshot =
+         match current_snapshot with
          | `Assoc fields ->
-           let pending =
+           let entries =
              match List.assoc_opt "pending" fields with
-             | Some (`List entries) ->
-               `List
-                 (List.map
-                    (function
-                      | `Assoc entry_fields ->
-                        `Assoc (List.remove_assoc "exact_attempt" entry_fields)
-                      | _ -> Alcotest.fail "legacy pending entry object expected")
-                    entries)
+             | Some (`List entries) -> entries
              | _ -> Alcotest.fail "legacy pending list expected"
            in
+           let pending_entry = legacy_entry pending_id entries in
+           let delivery_entry = legacy_entry delivery_id entries in
+           let delivery =
+             `Assoc
+               [ "entry", delivery_entry
+               ; "decision", `Assoc [ "kind", `String "approve" ]
+               ; "source", `String "human_operator"
+               ; "remember_rule", `Bool false
+               ; "rule_expires_at", `Null
+               ; "created_by", `Null
+               ; "grant_consumed", `Bool false
+               ]
+           in
            `Assoc
-             (("version", `Int 3)
-              :: ("pending", pending)
+             (("version", `Int 4)
+              :: ("pending", `List [ pending_entry ])
+              :: ("deliveries", `List [ delivery ])
               :: (fields
                   |> List.remove_assoc "version"
-                  |> List.remove_assoc "pending"))
+                  |> List.remove_assoc "pending"
+                  |> List.remove_assoc "deliveries"))
          | _ -> Alcotest.fail "legacy snapshot object expected"
        in
        AQ.For_testing.reset_runtime_state ();
-       write_pending_snapshot ~base_path v3_snapshot;
+       write_pending_snapshot ~base_path v4_snapshot;
        Alcotest.(check int) "process state cleared" 0 (List.length (AQ.list_pending_entries ()));
        let report = install_exn ~base_path in
-       Alcotest.(check int) "one pending restored" 1 report.loaded_pending;
+       Alcotest.(check int) "legacy pending removed" 0 report.loaded_pending;
        Alcotest.(check int) "no delivery replay" 0 report.replayed_deliveries;
        Alcotest.(check int)
          "no delivery replay failure"
          0
          (List.length report.delivery_replay_failures);
-       (match AQ.get_pending_entry ~id with
-        | None -> Alcotest.fail "same approval id was not restored"
-        | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Legacy_execution_uncertain
-            ; _
-            } ->
-          ()
-        | Some _ ->
-          Alcotest.fail "v3 in-flight summary was not visibly quarantined");
+       Alcotest.(check bool)
+         "legacy pending absent"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id:pending_id));
+       Alcotest.(check bool)
+         "legacy delivery absent"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id:delivery_id));
        let open Yojson.Safe.Util in
        let persisted = read_pending_snapshot ~base_path in
-       Alcotest.(check int) "legacy snapshot migrated to v4" 4
+       Alcotest.(check int) "legacy snapshot migrated to v5" 5
          (persisted |> member "version" |> to_int);
-       Alcotest.(check string)
-         "legacy execution uncertainty is durable"
-         "legacy_execution_uncertain"
-         (persisted
-          |> member "pending"
-          |> to_list
-          |> List.hd
-          |> member "exact_attempt"
-          |> member "state"
-          |> to_string);
-       let summary = exact_summary "legacy-rejected-summary" in
-       expect_summary_rejection
-         "legacy attach"
-         `Legacy
-         (AQ.attach_summary ~id summary);
-       expect_summary_rejection
-         "legacy fail"
-         `Legacy
-         (AQ.mark_summary_failed
-            ~id
-            ~reason:"legacy execution uncertain"
-            ~retryable:true);
-       expect_summary_rejection
-         "legacy restart"
-         `Legacy
-         (AQ.restart_failed_summary ~id);
-       AQ.For_testing.reset_runtime_state ();
-       ignore (install_exn ~base_path);
-       let identity = exact_identity id in
-       (match pending_entry_exn id with
-        | { exact_attempt = AQ.Legacy_execution_uncertain; _ } -> ()
-        | _ -> Alcotest.fail "second restart changed legacy quarantine to unbound");
-       (match run_exact_transition AQ.bind_summary_exact_attempt identity with
-        | Error
-            (AQ.Exact_attempt_rejected
-              (AQ.Exact_attempt_legacy_execution_uncertain actual)) ->
-          Alcotest.(check string) "legacy bind rejection identity" id actual
-        | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
-        | Ok _ -> Alcotest.fail "legacy execution uncertainty rebound");
-       reject_and_cleanup ~base_path id;
-       (match durable_resolution_opt ~base_path ~keeper_name ~approval_id:id with
-        | Some resolution -> drop_resolution ~base_path ~keeper_name resolution
-        | None -> Alcotest.fail "cleanup resolution was not durable"))
+       Alcotest.(check int) "persisted pending removed" 0
+         (persisted |> member "pending" |> to_list |> List.length);
+       Alcotest.(check int) "persisted delivery removed" 0
+         (persisted |> member "deliveries" |> to_list |> List.length);
+       let tombstone =
+         AQ.read_recent_audit ~base_path ~n:20 ()
+         |> List.find_opt (fun json ->
+           String.equal
+             "legacy_exact_attempt_hard_cut_tombstone"
+             (Safe_ops.json_string ~default:"" "event" json))
+         |> function
+         | Some json -> json
+         | None -> Alcotest.fail "hard-cut migration audit tombstone missing"
+       in
+       let check_tombstone_int label expected field =
+         Alcotest.(check int) label expected (tombstone |> member field |> to_int)
+       in
+       check_tombstone_int "source version" 4 "source_version";
+       check_tombstone_int "target version" 5 "target_version";
+       check_tombstone_int "one pending tombstoned" 1 "removed_pending";
+       check_tombstone_int "one delivery tombstoned" 1 "removed_deliveries";
+       check_tombstone_int "two rows tombstoned" 2 "removed_count")
 ;;
 
 let test_malformed_snapshot_fails_install_and_is_observed () =
@@ -3149,7 +3155,7 @@ let () =
             `Quick
             test_summary_updates_never_resolve_pending_request
         ; Alcotest.test_case
-            "v4 exact binding codec validates entry identity"
+            "exact binding codec validates entry identity"
             `Quick
             test_v4_exact_binding_codec_validates_entry_identity
         ; Alcotest.test_case
@@ -3205,9 +3211,9 @@ let () =
               `Quick
               test_exact_completed_restart_requires_fsync_confirmation
         ; Alcotest.test_case
-            "v3 in-flight judge becomes legacy quarantine"
+            "legacy exact-attempt rows are hard-cut"
             `Quick
-            test_v3_inflight_auto_judge_becomes_legacy_quarantine
+            test_legacy_exact_attempt_rows_are_hard_cut
         ; Alcotest.test_case
             "malformed snapshot is explicit"
             `Quick

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -511,19 +511,12 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
                model_run_id = identity.call_id
              }))
   in
-  let legacy_source =
-    submit_eligibility_entry ~base_path ~keeper_name "legacy-uncertain"
-  in
-  let legacy =
-    { legacy_source with exact_attempt = AQ.Legacy_execution_uncertain }
-  in
   let check_ready label expected entry =
     check bool label expected (Gate.For_testing.auto_judge_entry_ready entry)
   in
   check_ready "new unbound judgment is startable" true not_requested;
   check_ready "pending unbound judgment is resumable" true pending;
   check_ready "available judgment does not start a provider worker" false available;
-  check_ready "legacy execution uncertainty is not worker-ready" false legacy;
   check_ready "dispatch-uncertain binding is not worker-ready" false dispatch_uncertain;
   check_ready
     "released-before-dispatch binding is not worker-ready"
@@ -535,7 +528,6 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
    | AQ.Exact_bound { status = AQ.Exact_quarantined AQ.Exact_post_dispatch_failure; _ } ->
      ()
    | AQ.Exact_unbound
-   | AQ.Legacy_execution_uncertain
    | AQ.Exact_bound _ ->
      fail "typed quarantine cause was not persisted");
   (match completed.exact_attempt, completed.summary_status with
@@ -551,7 +543,6 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
       (not_requested
        :: pending
        :: available
-       :: legacy
        :: other_owner
        :: [ dispatch_uncertain; released_before_dispatch; quarantined; completed ])
   in


### PR DESCRIPTION
## Summary
- remove the retired Legacy_execution_uncertain constructor, errors, codec token, gate branches, and test surface
- make approval queue persistence schema v5 current-only: fresh v5 state writes, reads, and restart recovery remain supported
- reject v3/v4 and every other stale schema fail-closed with an explicit runtime-reset instruction, without decoding, migrating, rewriting, renaming, or tombstoning old rows
- remove migration/filter/audit compatibility machinery and obsolete legacy fixtures; retain current v5 restart and delivery replay coverage

## Runtime policy
- runtime JSON is disposable across this boundary; operators reset stale runtime state before restarting MASC
- this PR does not modify the live .masc directory

## Validation
- ocamlformat on changed OCaml files
- local build/tests not run per operator request
