### PR TITLE
fix(keeper): accept current event queue snapshots

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -2825,8 +2825,10 @@ let of_yojson json =
       ; "last_settlement"
       ; "transition_outbox"
       ]
-      @ if String.equal schema_value schema then [ "accepted_transfer_projections" ] else []
-      @ if has_exact_execution_bindings then [ "exact_execution_bindings" ] else []
+      @ (if String.equal schema_value schema
+         then [ "accepted_transfer_projections" ]
+         else [])
+      @ (if has_exact_execution_bindings then [ "exact_execution_bindings" ] else [])
     in
     let* () = exact_fields ~context ~expected:expected_fields fields in
     let* revision = int64_field ~context "revision" fields in

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2765,7 +2765,16 @@ let test_unsupported_snapshots_fail_closed () =
     write_queue primary (queue [ stimulus "old-schema" 3.0 ]);
     (match Persistence.load_state_result ~base_path ~keeper_name with
      | Error _ -> ()
-     | Ok _ -> Alcotest.fail "old primary schema was migrated"))
+    | Ok _ -> Alcotest.fail "old primary schema was migrated"))
+;;
+
+let test_current_state_codec_reads_its_own_output () =
+  let encoded = State.to_yojson State.empty in
+  let decoded = State.of_yojson encoded |> require_ok "decode current state writer output" in
+  Alcotest.(check bool)
+    "current state round-trips"
+    true
+    (Yojson.Safe.equal encoded (State.to_yojson decoded))
 ;;
 
 let test_v3_snapshot_upgrades_only_without_active_lease () =
@@ -3099,6 +3108,10 @@ let () =
             "unconsumed approval yields FIFO"
             `Quick
             test_unconsumed_approval_requeues_behind_other_work
+        ; Alcotest.test_case
+            "current state codec reads its own output"
+            `Quick
+            test_current_state_codec_reads_its_own_output
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- parenthesize current-schema conditional field appends in the event-queue decoder
- add a focused writer-to-reader round-trip regression

## Root cause
The unparenthesized second `@ if` was parsed into the first conditional's `else` branch. Current v4 snapshots always written with `exact_execution_bindings` were therefore rejected as containing an unknown field.

## Validation
- `ocamlformat` applied
- local build/tests intentionally not run per operator direction

No legacy migration or live-state mutation is included.