### PR TITLE
fix(keeper): halt on transcript corruption

### DIFF
--- a/lib/keeper/keeper_activation_readiness.ml
+++ b/lib/keeper/keeper_activation_readiness.ml
@@ -8,6 +8,7 @@ type pause_kind =
   | Operator_paused
   | Unclassified_paused
   | Dead_tombstone
+  | Transcript_corruption_reset_required
 
 let pause_kind (meta : Keeper_meta_contract.keeper_meta) =
   match
@@ -23,6 +24,9 @@ let pause_kind (meta : Keeper_meta_contract.keeper_meta) =
          (Keeper_latched_reason.Operator_paused _) -> Operator_paused
      | Keeper_lifecycle_admission.Classified Keeper_latched_reason.Dead_tombstone ->
        Dead_tombstone
+     | Keeper_lifecycle_admission.Classified
+         Keeper_latched_reason.Transcript_corruption_reset_required ->
+       Transcript_corruption_reset_required
      | Keeper_lifecycle_admission.Unclassified -> Unclassified_paused)
 ;;
 
@@ -31,6 +35,8 @@ let pause_kind_to_wire = function
   | Operator_paused -> "operator_paused"
   | Unclassified_paused -> "unclassified_paused"
   | Dead_tombstone -> "dead_tombstone"
+  | Transcript_corruption_reset_required ->
+    "transcript_corruption_reset_required"
 ;;
 
 type autonomous_activation =
@@ -78,6 +84,14 @@ let autonomous_blocker_to_wire = function
    from a per-keeper flag without parsing the boundary string projection. *)
 let autonomous_hint (meta : Keeper_meta_contract.keeper_meta) = function
   | None -> None
+  | Some
+      (Lifecycle_denied
+        (Keeper_lifecycle_admission.Autonomous_paused
+          (Keeper_lifecycle_admission.Classified
+            Keeper_latched_reason.Transcript_corruption_reset_required))) ->
+    Some
+      "reset the corrupted Keeper checkpoint before starting a new lane; \
+       generic resume is intentionally denied"
   | Some
       (Lifecycle_denied (Keeper_lifecycle_admission.Autonomous_paused _)) ->
     Some "resume keeper before expecting autonomous keepalive or PR fan-out"

--- a/lib/keeper/keeper_activation_readiness.mli
+++ b/lib/keeper/keeper_activation_readiness.mli
@@ -16,6 +16,7 @@ type pause_kind =
   | Operator_paused
   | Unclassified_paused
   | Dead_tombstone
+  | Transcript_corruption_reset_required
 
 val pause_kind : Keeper_meta_contract.keeper_meta -> pause_kind
 val pause_kind_to_wire : pause_kind -> string

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -59,6 +59,7 @@ type operator_disposition_kind =
   | Disp_pass_next_model
   | Disp_user_cancelled
   | Disp_skipped
+  | Disp_operator_reset_required
   | Disp_unknown
 
 let operator_disposition_kind_to_string = function
@@ -67,6 +68,7 @@ let operator_disposition_kind_to_string = function
   | Disp_pass_next_model -> "pass_next_model"
   | Disp_user_cancelled -> "user_cancelled"
   | Disp_skipped -> "skipped"
+  | Disp_operator_reset_required -> "operator_reset_required"
   | Disp_unknown -> "unknown"
 ;;
 
@@ -76,6 +78,7 @@ let operator_disposition_kind_of_string = function
   | "pass_next_model" -> Some Disp_pass_next_model
   | "user_cancelled" -> Some Disp_user_cancelled
   | "skipped" -> Some Disp_skipped
+  | "operator_reset_required" -> Some Disp_operator_reset_required
   | "unknown" -> Some Disp_unknown
   | _ -> None
 ;;
@@ -93,6 +96,7 @@ type operator_disposition_reason =
   | Reason_input_required
   | Reason_cancelled
   | Reason_phase_skipped
+  | Reason_transcript_corruption
   | Reason_unmapped_runtime_state
 
 let operator_disposition_reason_to_string = function
@@ -108,6 +112,7 @@ let operator_disposition_reason_to_string = function
   | Reason_input_required -> "input_required"
   | Reason_cancelled -> "cancelled"
   | Reason_phase_skipped -> "phase_skipped"
+  | Reason_transcript_corruption -> "transcript_corruption"
   | Reason_unmapped_runtime_state -> "unmapped_runtime_state"
 ;;
 
@@ -151,6 +156,8 @@ let operator_disposition (receipt : t)
      branch via [terminal_reason="runtime_exhausted"]. *)
   match terminal_reason with
   | _ when input_required -> Disp_pass, Reason_input_required
+  | Keeper_terminal_reason.Transcript_corruption _ ->
+    Disp_operator_reset_required, Reason_transcript_corruption
   | Keeper_terminal_reason.Runtime_exhausted _ ->
     Disp_fail_open_next_runtime, Reason_runtime_exhausted
   | Keeper_terminal_reason.Capacity_backpressure _ ->
@@ -217,6 +224,7 @@ let operator_disposition (receipt : t)
        | Capacity_backpressure _
        | Config_or_auth _
        | Provider_runtime_failure _
+       | Transcript_corruption _
        | Internal_error _
        | Unknown _ -> false)
     then Disp_pass, Reason_healthy
@@ -445,6 +453,7 @@ let to_json receipt =
    (StaleRunning watchdog + emit_stale_keeper_broadcast) is deferred to
    a separate cycle. *)
 let needs_operator_broadcast = function
+  | Disp_operator_reset_required
   | Disp_unknown -> true
   | Disp_pass
   | Disp_fail_open_next_runtime

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -191,6 +191,7 @@ type operator_disposition_kind =
   | Disp_pass_next_model
   | Disp_user_cancelled
   | Disp_skipped
+  | Disp_operator_reset_required
   | Disp_unknown
 
 val operator_disposition_kind_to_string : operator_disposition_kind -> string
@@ -220,6 +221,7 @@ type operator_disposition_reason =
   | Reason_input_required
   | Reason_cancelled
   | Reason_phase_skipped
+  | Reason_transcript_corruption
   | Reason_unmapped_runtime_state
 
 val operator_disposition_reason_to_string : operator_disposition_reason -> string

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -740,8 +740,43 @@ let check_cancellation_after_exact_terminal_settlement settlement =
   if settlement_is_exact_output_cancellation settlement then Eio.Fiber.check ()
 ;;
 
+type transcript_corruption_commit =
+  | Transcript_pause_persisted
+  | Transcript_pause_and_settlement_persisted
+  | Transcript_pause_persistence_failed of string
+  | Transcript_pause_settlement_failed of string
+
+let commit_transcript_corruption ~stop ~persist_pause ?settle () =
+  Atomic.set stop true;
+  Eio.Cancel.protect (fun () ->
+    let guarded_call ~site call =
+      try call () with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> Error (Printf.sprintf "%s raised: %s" site (Printexc.to_string exn))
+    in
+    match guarded_call ~site:"transcript corruption pause CAS" persist_pause with
+    | Error detail -> Transcript_pause_persistence_failed detail
+    | Ok `No_durable_meta ->
+      Transcript_pause_persistence_failed
+        "transcript corruption pause has no durable Keeper metadata"
+    | Ok `Persisted ->
+      (match settle with
+       | None -> Transcript_pause_persisted
+       | Some settle ->
+         (match guarded_call ~site:"transcript corruption settlement" settle with
+          | Ok () -> Transcript_pause_and_settlement_persisted
+          | Error detail -> Transcript_pause_settlement_failed detail)))
+;;
+
 module For_testing = struct
+  type nonrec transcript_corruption_commit = transcript_corruption_commit =
+    | Transcript_pause_persisted
+    | Transcript_pause_and_settlement_persisted
+    | Transcript_pause_persistence_failed of string
+    | Transcript_pause_settlement_failed of string
+
   let exact_execution_guard = exact_execution_guard
+  let commit_transcript_corruption = commit_transcript_corruption
 
   let check_cancellation_after_exact_terminal_settlement =
     check_cancellation_after_exact_terminal_settlement
@@ -790,6 +825,7 @@ let run_keepalive_unified_turn
     let cycle_outcome_ref = ref None in
     let lease_settled = ref false in
     let settlement_failed = ref false in
+    let transcript_corruption_detected = ref false in
     let record_settlement_failure message =
       settlement_failed := true;
       match !cycle_outcome_ref with
@@ -1185,48 +1221,83 @@ let run_keepalive_unified_turn
           Cycle.meta cycle_outcome)
         else meta_after_triage
       in
-      let meta_after_cycle =
+      let transcript_corruption_commit =
         match !cycle_outcome_ref with
         | Some (Cycle.Failed { failure; _ }) ->
           (match failure.Keeper_unified_turn.source_lease_disposition with
            | Keeper_unified_turn.Pause_after_transcript_corruption _ ->
-             (* Set the in-process stop before storage I/O so an unexpected
-                persistence exception still cannot spin this corrupted
-                checkpoint in the current process. The CAS writer below owns
-                the restart-safe pause boundary. *)
-             Atomic.set stop true;
-             (match
-                Keeper_meta_store.persist_transcript_corruption_pause
-                  ctx.config
-                  ~keeper_name:meta_after_triage.name
-              with
-              | Ok `Persisted -> ()
-              | Ok `No_durable_meta ->
-                let message =
-                  "transcript corruption pause has no durable keeper metadata"
-                in
-                Log.Keeper.error
-                  ~keeper_name:meta_after_triage.name
-                  "%s"
-                  message;
-                record_settlement_failure message
-              | Error message ->
+             transcript_corruption_detected := true;
+             let settle =
+               match !claimed_lease with
+               | None -> None
+               | Some lease ->
+                 Some
+                   (fun () ->
+                      let settled_at = Time_compat.now () in
+                      let settlement =
+                        settlement_of_failure
+                          ~settled_at
+                          ~compaction_consecutive_failures:
+                            meta_after_triage.runtime.compaction_rt.consecutive_failures
+                          failure
+                      in
+                      match
+                        settle_claimed_lease
+                          ~exact_execution:true
+                          ~base_path:ctx.config.base_path
+                          ~keeper_name:meta_after_triage.name
+                          ~settled_at
+                          ~lease
+                          ~settlement
+                          ()
+                      with
+                      | Error detail -> Error detail
+                      | Ok
+                          ( Keeper_registry_event_queue.Settled _
+                          | Keeper_registry_event_queue.Already_settled _ ) ->
+                        lease_settled := true;
+                        project_transition_outbox
+                          ~base_path:ctx.config.base_path
+                          ~keeper_name:meta_after_triage.name
+                      | Ok
+                          (Keeper_registry_event_queue.Committed_followup_failed
+                            { detail; _ }) ->
+                        lease_settled := true;
+                        Error detail)
+             in
+             let committed =
+               commit_transcript_corruption
+                 ~stop
+                 ~persist_pause:(fun () ->
+                   Keeper_meta_store.persist_transcript_corruption_pause
+                     ctx.config
+                     ~keeper_name:meta_after_triage.name)
+                 ?settle
+                 ()
+             in
+             (match committed with
+              | Transcript_pause_persisted
+              | Transcript_pause_and_settlement_persisted ->
+                ()
+              | Transcript_pause_persistence_failed message ->
                 Log.Keeper.error
                   ~keeper_name:meta_after_triage.name
                   "transcript corruption pause persistence failed: %s"
                   message;
+                record_settlement_failure message
+              | Transcript_pause_settlement_failed message ->
+                Log.Keeper.error
+                  ~keeper_name:meta_after_triage.name
+                  "transcript corruption terminal settlement failed: %s"
+                  message;
                 record_settlement_failure message);
-             { meta_after_cycle with
-               paused = true
-             ; latched_reason = None
-             ; updated_at = Keeper_meta_contract.now_iso ()
-             }
+             Some committed
            | Keeper_unified_turn.Follow_failure_route
            | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
            | Keeper_unified_turn.Requeue_after_context_compaction _
            | Keeper_unified_turn.Escalate_after_exact_output_terminal _
            | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
-             meta_after_cycle)
+             None)
         | Some
             ( Cycle.Completed _
             | Cycle.Cancelled _
@@ -1237,12 +1308,21 @@ let run_keepalive_unified_turn
             | Cycle.Manual_compaction_failed _
             | Cycle.Manual_compaction_not_applied _ )
         | None ->
-          meta_after_cycle
+          None
+      in
+      let meta_after_cycle =
+        match transcript_corruption_commit with
+        | None -> meta_after_cycle
+        | Some _ ->
+          Keeper_meta_contract.mark_transcript_corruption_reset_required
+            meta_after_cycle
       in
       (* Queue ownership follows the typed cycle outcome.  Pending removal,
          lease removal, an optional judgment successor, and the transition
          outbox receipt commit in one event-queue.json rename. *)
-      (match !claimed_lease with
+      (if Option.is_none transcript_corruption_commit
+       then
+         match !claimed_lease with
        | None ->
          (match !cycle_outcome_ref with
           | Some (Cycle.Failed { failure; _ }) ->
@@ -1394,15 +1474,19 @@ let run_keepalive_unified_turn
     with
     | Eio.Cancel.Cancelled _ as e ->
       let backtrace = Printexc.get_raw_backtrace () in
-      if not (settle_exact_terminal_after_cancellation ())
+      if
+        (not !transcript_corruption_detected)
+        && not (settle_exact_terminal_after_cancellation ())
       then requeue_unsettled Keeper_registry_event_queue.Cancelled;
       Printexc.raise_with_backtrace e backtrace
     | Keeper_registry.Keeper_fiber_crash as e ->
       let backtrace = Printexc.get_raw_backtrace () in
-      requeue_unsettled Keeper_registry_event_queue.Cycle_crashed;
+      if not !transcript_corruption_detected
+      then requeue_unsettled Keeper_registry_event_queue.Cycle_crashed;
       Printexc.raise_with_backtrace e backtrace
     | exn ->
-      requeue_unsettled Keeper_registry_event_queue.Cycle_crashed;
+      if not !transcript_corruption_detected
+      then requeue_unsettled Keeper_registry_event_queue.Cycle_crashed;
       (* T6 audit: keep the fiber alive, but surface the crash as a
          turn failure so the caller does not dispatch
          [Turn_succeeded] for a cycle that never completed. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -267,7 +267,6 @@ let failure_judgment_successor
 let settlement_of_failure
       ~settled_at
       ~compaction_consecutive_failures
-      ~transcript_quarantine_consecutive_retries
       failure
   =
   let follow_route () =
@@ -358,36 +357,13 @@ let settlement_of_failure
     else
       Keeper_registry_event_queue.Requeue
         Keeper_registry_event_queue.Context_compaction_retry
-  | Keeper_unified_turn.Requeue_after_transcript_quarantine ->
-    (* #25296: the poisoned checkpoint is preserved unmodified by design, so
-       every re-lease reloads the same incomplete transcript and the admission
-       rejects it again — an unbounded requeue would re-fire the full turn
-       pipeline on every heartbeat. This failure is the
-       [transcript_quarantine_consecutive_retries + 1]-th quarantine in a row;
-       the counter itself is advanced by
-       [transcript_quarantine_outcome_of_cycle_outcome] on
-       [keeper_meta.runtime] after the settlement is decided. Same ceiling
-       shape as the compaction streak (2026-07-21 lesson: every exempt class
-       needs its own accounting). *)
-    let quarantine_attempts = transcript_quarantine_consecutive_retries + 1 in
-    if
-      quarantine_attempts
-      >= Keeper_meta_contract.transcript_quarantine_retry_escalation_threshold
-    then
-      Keeper_registry_event_queue.Escalate
-        { reason =
-            Keeper_registry_event_queue.Transcript_quarantine_retry_exhausted
-              { attempts = quarantine_attempts
-              ; detail =
-                  "transcript quarantine rejected the same preserved checkpoint \
-                   on consecutive attempts; retry suspended pending operator \
-                   inspection (recover or compact the checkpoint to clear)"
-              }
-        ; successor = None
-        }
-    else
-      Keeper_registry_event_queue.Requeue
-        Keeper_registry_event_queue.Transcript_quarantine_retry
+  | Keeper_unified_turn.Pause_after_transcript_corruption { detail } ->
+    Keeper_registry_event_queue.Escalate
+      { reason =
+          Keeper_registry_event_queue.Transcript_corruption_requires_reset
+            { detail }
+      ; successor = None
+      }
   | Keeper_unified_turn.Follow_failure_route_after_no_compaction { reason } ->
     if attempts >= Keeper_meta_contract.compaction_retry_escalation_threshold
     then
@@ -425,7 +401,6 @@ let settlement_of_cycle_outcome
       ~settled_at
       ~stop_requested
       ~compaction_consecutive_failures
-      ~transcript_quarantine_consecutive_retries
       ~lease
       outcome
   =
@@ -510,7 +485,6 @@ let settlement_of_cycle_outcome
     settlement_of_failure
       ~settled_at
       ~compaction_consecutive_failures
-      ~transcript_quarantine_consecutive_retries
       failure
   | Some (Cycle.Judgment_settled { outcome; _ }) ->
     (match outcome with
@@ -589,44 +563,13 @@ let compaction_outcome_of_cycle_outcome = function
      | Keeper_unified_turn.Escalate_after_exact_output_terminal _ -> Some `Failed
      | Keeper_unified_turn.Follow_failure_route
      | Keeper_unified_turn.Acknowledge_after_in_turn_handling
-     | Keeper_unified_turn.Requeue_after_transcript_quarantine -> None)
+     | Keeper_unified_turn.Pause_after_transcript_corruption _ -> None)
   | Some (Cycle.Completed _) -> Some `Recovered
   | Some
       ( Cycle.Cancelled _
       | Cycle.Skipped _
       | Cycle.Busy _
       | Cycle.Judgment_settled _
-      | Cycle.Manual_compaction_not_applied _ )
-  | None -> None
-;;
-
-(* #25296: pure mapping from a settled cycle outcome to the
-   transcript-quarantine streak stamp on
-   [keeper_meta.runtime.transcript_quarantine_consecutive_retries]. A failed
-   turn whose disposition is [Requeue_after_transcript_quarantine] advances
-   the streak — the settlement above reads it to escalate instead of
-   requeuing once it reaches
-   [Keeper_meta_contract.transcript_quarantine_retry_escalation_threshold].
-   Any completed turn resets: the keeper is no longer pinned to the poisoned
-   transcript. Other outcomes prove nothing about quarantine progress in
-   either direction. *)
-let transcript_quarantine_outcome_of_cycle_outcome = function
-  | Some (Cycle.Failed { failure; _ }) ->
-    (match failure.Keeper_unified_turn.source_lease_disposition with
-     | Keeper_unified_turn.Requeue_after_transcript_quarantine -> Some `Retried
-     | Keeper_unified_turn.Follow_failure_route
-     | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
-     | Keeper_unified_turn.Requeue_after_context_compaction _
-     | Keeper_unified_turn.Escalate_after_exact_output_terminal _
-     | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> None)
-  | Some (Cycle.Completed _) -> Some `Recovered
-  | Some
-      ( Cycle.Cancelled _
-      | Cycle.Skipped _
-      | Cycle.Busy _
-      | Cycle.Judgment_settled _
-      | Cycle.Manual_compaction_applied _
-      | Cycle.Manual_compaction_failed _
       | Cycle.Manual_compaction_not_applied _ )
   | None -> None
 ;;
@@ -910,8 +853,6 @@ let run_keepalive_unified_turn
             ~stop_requested:(Atomic.get stop)
             ~compaction_consecutive_failures:
               meta_after_triage.runtime.compaction_rt.consecutive_failures
-            ~transcript_quarantine_consecutive_retries:
-              meta_after_triage.runtime.transcript_quarantine_consecutive_retries
             ~lease
             (Some outcome)
         in
@@ -1244,6 +1185,60 @@ let run_keepalive_unified_turn
           Cycle.meta cycle_outcome)
         else meta_after_triage
       in
+      let meta_after_cycle =
+        match !cycle_outcome_ref with
+        | Some (Cycle.Failed { failure; _ }) ->
+          (match failure.Keeper_unified_turn.source_lease_disposition with
+           | Keeper_unified_turn.Pause_after_transcript_corruption _ ->
+             (* Set the in-process stop before storage I/O so an unexpected
+                persistence exception still cannot spin this corrupted
+                checkpoint in the current process. The CAS writer below owns
+                the restart-safe pause boundary. *)
+             Atomic.set stop true;
+             (match
+                Keeper_meta_store.persist_transcript_corruption_pause
+                  ctx.config
+                  ~keeper_name:meta_after_triage.name
+              with
+              | Ok `Persisted -> ()
+              | Ok `No_durable_meta ->
+                let message =
+                  "transcript corruption pause has no durable keeper metadata"
+                in
+                Log.Keeper.error
+                  ~keeper_name:meta_after_triage.name
+                  "%s"
+                  message;
+                record_settlement_failure message
+              | Error message ->
+                Log.Keeper.error
+                  ~keeper_name:meta_after_triage.name
+                  "transcript corruption pause persistence failed: %s"
+                  message;
+                record_settlement_failure message);
+             { meta_after_cycle with
+               paused = true
+             ; latched_reason = None
+             ; updated_at = Keeper_meta_contract.now_iso ()
+             }
+           | Keeper_unified_turn.Follow_failure_route
+           | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
+           | Keeper_unified_turn.Requeue_after_context_compaction _
+           | Keeper_unified_turn.Escalate_after_exact_output_terminal _
+           | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
+             meta_after_cycle)
+        | Some
+            ( Cycle.Completed _
+            | Cycle.Cancelled _
+            | Cycle.Skipped _
+            | Cycle.Busy _
+            | Cycle.Judgment_settled _
+            | Cycle.Manual_compaction_applied _
+            | Cycle.Manual_compaction_failed _
+            | Cycle.Manual_compaction_not_applied _ )
+        | None ->
+          meta_after_cycle
+      in
       (* Queue ownership follows the typed cycle outcome.  Pending removal,
          lease removal, an optional judgment successor, and the transition
          outbox receipt commit in one event-queue.json rename. *)
@@ -1254,7 +1249,7 @@ let run_keepalive_unified_turn
             (match failure.Keeper_unified_turn.source_lease_disposition with
              | Keeper_unified_turn.Requeue_after_context_compaction _
              | Keeper_unified_turn.Escalate_after_exact_output_terminal _
-             | Keeper_unified_turn.Requeue_after_transcript_quarantine
+             | Keeper_unified_turn.Pause_after_transcript_corruption _
              | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
                (* Intentionally a no-op, consistent with the context-compaction
                   arm above: these dispositions only requeue/acknowledge the
@@ -1322,9 +1317,6 @@ let run_keepalive_unified_turn
              ~stop_requested:(Atomic.get stop)
              ~compaction_consecutive_failures:
                meta_after_triage.runtime.compaction_rt.consecutive_failures
-             ~transcript_quarantine_consecutive_retries:
-               meta_after_triage.runtime
-                 .transcript_quarantine_consecutive_retries
              ~lease
              !cycle_outcome_ref
          in
@@ -1354,33 +1346,6 @@ let run_keepalive_unified_turn
              | Error message ->
                Log.Keeper.warn
                  "compaction outcome counter not persisted keeper=%s: %s"
-                 meta_after_triage.name
-                 message));
-         (* #25296: advance the transcript-quarantine streak the settlement
-            above just read — same ordering rule as the compaction streak. *)
-         (let quarantine_outcome =
-            transcript_quarantine_outcome_of_cycle_outcome !cycle_outcome_ref
-          in
-          match quarantine_outcome with
-          | None -> ()
-          | Some `Recovered
-            when meta_after_triage.runtime
-                   .transcript_quarantine_consecutive_retries
-                 = 0 ->
-            (* Streak already clear: skip the read-modify-write that every
-               healthy completed turn would otherwise pay. *)
-            ()
-          | Some outcome ->
-            (match
-               Keeper_meta_store.persist_transcript_quarantine_outcome
-                 ctx.config
-                 ~keeper_name:meta_after_triage.name
-                 ~outcome
-             with
-             | Ok (`Persisted | `No_durable_meta) -> ()
-             | Error message ->
-               Log.Keeper.warn
-                 "transcript quarantine outcome counter not persisted keeper=%s: %s"
                  meta_after_triage.name
                  message));
          (match

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -252,6 +252,20 @@ val run_heartbeat_loop :
   wakeup:bool Atomic.t -> unit
 
 module For_testing : sig
+  type transcript_corruption_commit =
+    | Transcript_pause_persisted
+    | Transcript_pause_and_settlement_persisted
+    | Transcript_pause_persistence_failed of string
+    | Transcript_pause_settlement_failed of string
+
+  val commit_transcript_corruption :
+    stop:bool Atomic.t ->
+    persist_pause:
+      (unit -> ([ `Persisted | `No_durable_meta ], string) result) ->
+    ?settle:(unit -> (unit, string) result) ->
+    unit ->
+    transcript_corruption_commit
+
   val exact_execution_guard :
     base_path:string ->
     keeper_name:string ->

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -123,7 +123,6 @@ val record_crashed_cycle_failure :
 val settlement_of_failure :
   settled_at:float ->
   compaction_consecutive_failures:int ->
-  transcript_quarantine_consecutive_retries:int ->
   Keeper_unified_turn.turn_failure ->
   Keeper_registry_event_queue.settlement
 (** Pure queue disposition for a failed cycle. Retry/rotation requeue and a
@@ -147,15 +146,9 @@ val settlement_of_failure :
     the ordinary route and immediately settles as a typed escalation with no
     successor.
 
-    [transcript_quarantine_consecutive_retries] is the keeper's persisted
-    quarantine streak from
-    [keeper_meta.runtime.transcript_quarantine_consecutive_retries]. A
-    [Requeue_after_transcript_quarantine] disposition requeues below
-    [Keeper_meta_contract.transcript_quarantine_retry_escalation_threshold]
-    and escalates as [Transcript_quarantine_retry_exhausted] at it — the
-    poisoned checkpoint is preserved unmodified by design, so without the
-    ceiling the same stimulus loops through the full turn pipeline on every
-    heartbeat (#25296). *)
+    [Pause_after_transcript_corruption] never follows the ordinary route: the
+    first structural rejection pauses the Keeper and settles as
+    [Transcript_corruption_requires_reset] with no retry successor. *)
 
 val compaction_outcome_of_cycle_outcome :
   Keeper_heartbeat_loop_cycle.cycle_outcome option ->
@@ -171,26 +164,11 @@ val compaction_outcome_of_cycle_outcome :
     operator's manual commit maps to [`Committed] (count + reset).
     Outcomes with no compaction involvement return [None]. *)
 
-val transcript_quarantine_outcome_of_cycle_outcome :
-  Keeper_heartbeat_loop_cycle.cycle_outcome option ->
-  [ `Retried | `Recovered ] option
-(** Pure mapping from a settled cycle outcome to the transcript-quarantine
-    streak stamp
-    ({!Keeper_meta_store.persist_transcript_quarantine_outcome}). A failed
-    turn with a [Requeue_after_transcript_quarantine] disposition maps to
-    [`Retried] (advances the streak — the settlement reads it to escalate
-    instead of requeuing at
-    [Keeper_meta_contract.transcript_quarantine_retry_escalation_threshold]);
-    a completed turn maps to [`Recovered] (resets it — the keeper is no
-    longer pinned to the poisoned transcript). Outcomes with no quarantine
-    involvement return [None] (#25296). *)
-
 val settlement_of_cycle_outcome :
   base_path:string ->
   settled_at:float ->
   stop_requested:bool ->
   compaction_consecutive_failures:int ->
-  transcript_quarantine_consecutive_retries:int ->
   lease:Keeper_registry_event_queue.lease ->
   Keeper_heartbeat_loop_cycle.cycle_outcome option ->
   Keeper_registry_event_queue.settlement

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -123,23 +123,35 @@ let persist_directive_meta_update
 ;;
 
 let directive_paused_meta (meta : keeper_meta) paused =
-  {
-    meta with
-    paused;
-    (* A gRPC pause directive is an operator/control-plane pause; record it
-       so the status bridge can name it. Resume/wakeup (paused=false) clears
-       the reason together with the pause bit. Observability only — the
-       pause/resume decision is carried by [paused] as before. *)
-    latched_reason =
-      (if paused
-       then
-         Some
-           (Keeper_latched_reason.Operator_paused
-              { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive })
-       else None);
-    runtime = { meta.runtime with last_blocker = None };
-    updated_at = now_iso ();
-  }
+  if paused
+  then
+    { meta with
+      paused = true
+    ; latched_reason =
+        Some
+          (Keeper_latched_reason.Operator_paused
+             { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive })
+    ; runtime = { meta.runtime with last_blocker = None }
+    ; updated_at = now_iso ()
+    }
+  else
+    { (Keeper_meta_contract.mark_resumed meta) with updated_at = now_iso () }
+;;
+
+let transcript_corruption_reset_required (meta : keeper_meta) =
+  match
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  with
+  | Keeper_lifecycle_admission.Paused
+      (Keeper_lifecycle_admission.Classified
+        Keeper_latched_reason.Transcript_corruption_reset_required) ->
+    true
+  | Keeper_lifecycle_admission.Active
+  | Keeper_lifecycle_admission.Paused _
+  | Keeper_lifecycle_admission.Dead_tombstone ->
+    false
 ;;
 
 (* Unknown-keeper directives can repeat while boot/crash truth is still
@@ -269,39 +281,51 @@ let set_keeper_paused_state ~agent_name paused =
         ();
       log_directive_agent_not_in_registry ~agent_name ~action)
     (fun entry ->
-       let previous_failure_reason = entry.last_failure_reason in
-       let updated_meta = directive_paused_meta entry.meta paused in
-       (match persist_directive_meta_update entry ~updated_meta with
-        | Error err ->
-          Keeper_registry.set_failure_reason
-            ~base_path:entry.base_path
-            entry.name
-            previous_failure_reason;
+       if (not paused) && transcript_corruption_reset_required entry.meta
+       then (
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string DirectiveFailures)
             ~labels:
-              [ "keeper", entry.name; "site", "pause_resume_persist" ]
+              [ "keeper", entry.name; "site", "resume_reset_required" ]
             ();
           Log.Keeper.error
-            "directive %s: meta persist failed for %s: %s"
-            (if paused then "pause" else "resume")
-            entry.name
-            err
-        | Ok () ->
-          Keeper_registry.dispatch_event_unit
-            ~base_path:entry.base_path
-            entry.name
-            (if paused
-             then Keeper_state_machine.Operator_pause
-             else Keeper_state_machine.Operator_resume);
-          if not paused
-          then (
-            (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
-            Atomic.set entry.fiber_wakeup true;
-            (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition.
-               The [@@fsm_guard] PPX routes the assertion through
-               [wrap_unit ~stage:"guard"] automatically. *)
-            post_wakeup_signal ~wakeup:entry.fiber_wakeup)))
+            "directive resume denied for %s: transcript corruption requires \
+             checkpoint reset"
+            entry.name)
+       else (
+         let previous_failure_reason = entry.last_failure_reason in
+         let updated_meta = directive_paused_meta entry.meta paused in
+         match persist_directive_meta_update entry ~updated_meta with
+         | Error err ->
+           Keeper_registry.set_failure_reason
+             ~base_path:entry.base_path
+             entry.name
+             previous_failure_reason;
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string DirectiveFailures)
+             ~labels:
+               [ "keeper", entry.name; "site", "pause_resume_persist" ]
+             ();
+           Log.Keeper.error
+             "directive %s: meta persist failed for %s: %s"
+             (if paused then "pause" else "resume")
+             entry.name
+             err
+         | Ok () ->
+           Keeper_registry.dispatch_event_unit
+             ~base_path:entry.base_path
+             entry.name
+             (if paused
+              then Keeper_state_machine.Operator_pause
+              else Keeper_state_machine.Operator_resume);
+           if not paused
+           then (
+             (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
+             Atomic.set entry.fiber_wakeup true;
+             (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition.
+                The [@@fsm_guard] PPX routes the assertion through
+                [wrap_unit ~stage:"guard"] automatically. *)
+             post_wakeup_signal ~wakeup:entry.fiber_wakeup)))
 ;;
 
 let wakeup_keeper_by_agent_name ~agent_name =

--- a/lib/keeper/keeper_lifecycle_admission.ml
+++ b/lib/keeper/keeper_lifecycle_admission.ml
@@ -10,6 +10,8 @@ type state =
 let state ~paused ~latched_reason =
   match latched_reason with
   | Some Keeper_latched_reason.Dead_tombstone -> Dead_tombstone
+  | Some (Keeper_latched_reason.Transcript_corruption_reset_required as reason) ->
+    Paused (Classified reason)
   | Some reason when paused -> Paused (Classified reason)
   | None when paused -> Paused Unclassified
   | Some _ | None -> Active
@@ -19,9 +21,13 @@ type manual_one_shot_admission =
   | Manual_admitted_active
   | Manual_admitted_paused_recovery of paused_latch
   | Manual_denied_dead_tombstone
+  | Manual_denied_transcript_reset_required
 
 let admit_manual_one_shot = function
   | Active -> Manual_admitted_active
+  | Paused
+      (Classified Keeper_latched_reason.Transcript_corruption_reset_required) ->
+    Manual_denied_transcript_reset_required
   | Paused latch -> Manual_admitted_paused_recovery latch
   | Dead_tombstone -> Manual_denied_dead_tombstone
 ;;

--- a/lib/keeper/keeper_lifecycle_admission.mli
+++ b/lib/keeper/keeper_lifecycle_admission.mli
@@ -1,9 +1,11 @@
 (** Pure lifecycle admission for keeper execution boundaries.
 
     The persisted [paused] bit remains the pause authority.  A typed
-    [Dead_tombstone] latch refines that state into a terminal lifecycle state,
-    even if a racing/stale writer cleared [paused].  Missing or malformed latch
-    detail while [paused = true] is fail-closed as an unclassified pause. *)
+    [Dead_tombstone] latch refines that state into a terminal lifecycle state.
+    [Transcript_corruption_reset_required] refines it into a pause that generic
+    resume cannot clear. Both remain fail-closed even if a racing/stale writer
+    cleared [paused]. Missing latch detail while [paused = true] is fail-closed
+    as an unclassified pause. *)
 
 type paused_latch = private
   | Classified of Keeper_latched_reason.t
@@ -23,6 +25,7 @@ type manual_one_shot_admission =
   | Manual_admitted_active
   | Manual_admitted_paused_recovery of paused_latch
   | Manual_denied_dead_tombstone
+  | Manual_denied_transcript_reset_required
 
 val admit_manual_one_shot : state -> manual_one_shot_admission
 

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -407,44 +407,53 @@ type keeper_meta =
   ; meta_version : int
   }
 
-(* Sanctioned unpause transform: the coupled way to set [paused = false].
-   Clears the typed latch (including the terminal [Dead_tombstone]) and the
-   last blocker together with the pause bit, so [paused = false &&
-   latched_reason <> None] cannot be constructed through the resume path.
-   Terminal dead-tombstone revival additionally runs the crash-recoverable
-   [Keeper_dead_revival_transaction] at its call site; [mark_resumed] only
-   normalizes the meta fields. Callers set [updated_at] themselves. *)
-let mark_resumed (m : keeper_meta) : keeper_meta =
+let mark_transcript_corruption_reset_required (m : keeper_meta) : keeper_meta =
   { m with
-    paused = false
-  ; latched_reason = None
-  ; runtime = { m.runtime with last_blocker = None }
+    paused = true
+  ; latched_reason = Some Keeper_latched_reason.Transcript_corruption_reset_required
+  ; updated_at = now_iso ()
   }
 ;;
 
-(* Write-boundary invariant: a terminal [Dead_tombstone] latch must co-occur
-   with [paused = true]. The canonical setter ([dead_tombstone_meta]) pairs
-   them, and every sanctioned clear runs through [mark_resumed] / dead
-   revival which nulls the latch. [paused = false] while [Dead_tombstone] is
-   latched is un-recoverable: lifecycle admission denies by the latch alone
-   (paused-independent), yet the split can only be produced by a writer that
-   cleared [paused] without clearing the latch. Returns [Some detail] when the
-   split is present so the store can reject the write fail-closed rather than
-   persist an unrepresentable state. Non-terminal latches with [paused = false]
-   are left alone (admission treats them as [Active], so they are recoverable). *)
-let dead_tombstone_pause_violation (m : keeper_meta) : string option =
+(* Sanctioned generic unpause transform. The reset-required transcript latch
+   is deliberately immutable here: only checkpoint reset/replacement may
+   remove it. Other latches are cleared together with the pause bit and last
+   blocker. Terminal dead-tombstone revival additionally runs the
+   crash-recoverable [Keeper_dead_revival_transaction] at its call site. *)
+let mark_resumed (m : keeper_meta) : keeper_meta =
+  match m.latched_reason with
+  | Some Keeper_latched_reason.Transcript_corruption_reset_required -> m
+  | Some
+      ( Keeper_latched_reason.Operator_paused _
+      | Keeper_latched_reason.Dead_tombstone )
+  | None ->
+    { m with
+      paused = false
+    ; latched_reason = None
+    ; runtime = { m.runtime with last_blocker = None }
+    }
+;;
+
+(* Write-boundary invariant: terminal/reset-required latches must co-occur
+   with [paused = true]. Admission denies them by latch identity even if a
+   stale writer cleared [paused], so reject that split instead of repairing it
+   silently. *)
+let terminal_latch_pause_violation (m : keeper_meta) : string option =
   (* Exhaustive on [latched_reason] for the [paused = false] rows (no [_]
      catch-all): a future terminal latch variant must force a decision here
      rather than silently escaping the write-boundary guard. A non-terminal
      latch with [paused = false] is admission-[Active] (recoverable), so it is
      not a violation. [paused = true] is always consistent with any latch. *)
   match m.paused, m.latched_reason with
-  | false, Some Keeper_latched_reason.Dead_tombstone ->
+  | false,
+    Some
+      (( Keeper_latched_reason.Dead_tombstone
+       | Keeper_latched_reason.Transcript_corruption_reset_required ) as reason) ->
     Some
       (Printf.sprintf
-         "keeper %s: paused=false with Dead_tombstone latch (resume must clear \
-          the latch via mark_resumed / dead revival)"
-         m.name)
+         "keeper %s: paused=false with terminal/reset-required latch %s"
+         m.name
+         (Keeper_latched_reason.to_wire reason))
   | false, (Some (Keeper_latched_reason.Operator_paused _) | None) -> None
   | true, _ -> None
 ;;

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -388,9 +388,10 @@ type keeper_meta =
     active_goal_ids : string list
   ; paused : bool
   ; latched_reason : Keeper_latched_reason.t option
-    (** Typed companion to [paused]. Only explicit operator pause and terminal
-        dead-tombstone paths may write it. [None] while paused is a fail-closed
-        unclassified legacy state that requires an operator resume. *)
+    (** Typed companion to [paused]. Explicit operator pause, terminal
+        dead-tombstone, and transcript-corruption reset-required paths may write
+        it. [None] while paused is a fail-closed unclassified state that
+        requires operator action. *)
   ; autoboot_enabled : bool
   ; current_task_id : Keeper_id.Task_id.t option
     (** Currently claimed task ID for cost attribution.

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -69,15 +69,6 @@ let compaction_retry_escalation_threshold = 3
 let compaction_retry_suspended rt =
   rt.consecutive_failures >= compaction_retry_escalation_threshold
 
-(* #25296: consecutive transcript-quarantine requeues tolerated before the
-   settlement escalates instead of retrying. Defined next to
-   [compaction_retry_escalation_threshold] so the heartbeat settlement reads
-   one family of retry ceilings. Three attempts keeps a transient
-   checkpoint-write race recoverable while bounding a structurally poisoned
-   transcript, which the admission rejects deterministically on every
-   re-lease. *)
-let transcript_quarantine_retry_escalation_threshold = 3
-
 type proactive_runtime =
   { count_total : int
   ; last_ts : float
@@ -371,16 +362,6 @@ type agent_runtime_state =
   ; message_scope_ack_id : string option
     (** Stable chat-row id of the newest message-scope row actually injected
         into a completed Keeper turn. Rows after this id remain pending. *)
-  ; transcript_quarantine_consecutive_retries : int
-    (* #25296: consecutive transcript-quarantine requeue settlements for this
-       keeper. Incremented each time a failed turn settles as
-       [Requeue Transcript_quarantine_retry], reset to 0 on a completed turn.
-       The heartbeat settlement escalates
-       ([Transcript_quarantine_retry_exhausted]) instead of requeuing once
-       this reaches [transcript_quarantine_retry_escalation_threshold];
-       without it a poisoned checkpoint — preserved unmodified by design —
-       loops the same source stimulus through the full turn pipeline on every
-       heartbeat. *)
   }
 
 type keeper_meta =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -299,18 +299,18 @@ type keeper_meta = {
   meta_version : int;
 }
 
-(** Sanctioned unpause transform: sets [paused = false] while clearing the
-    typed latch ([Dead_tombstone] included) and [runtime.last_blocker], so a
-    resumed keeper can never retain a terminal latch. Callers set [updated_at]
-    themselves. Dead-tombstone revival still runs the crash-recoverable
-    transaction at its call site; this only normalizes the meta fields. *)
+(** Stamp the current Keeper state as structurally corrupted and requiring
+    checkpoint reset. This is current-state persistence, not a migration. *)
+val mark_transcript_corruption_reset_required : keeper_meta -> keeper_meta
+
+(** Sanctioned generic unpause transform. Clears ordinary/operator/dead
+    latches with the pause bit and [runtime.last_blocker]. A
+    [Transcript_corruption_reset_required] latch is returned unchanged, so
+    generic resume cannot replay a poisoned checkpoint. *)
 val mark_resumed : keeper_meta -> keeper_meta
 
-(** [dead_tombstone_pause_violation m] is [Some detail] when [m] has
-    [paused = false] together with a [Dead_tombstone] latch — the
-    un-recoverable, out-of-invariant state. Used by the meta store to reject
-    such writes at the boundary. [None] when the meta is consistent. *)
-val dead_tombstone_pause_violation : keeper_meta -> string option
+(** Reject [paused = false] paired with a terminal or reset-required latch. *)
+val terminal_latch_pause_violation : keeper_meta -> string option
 
 (** Overlay TOML/persona defaults onto persisted runtime meta for
     status-facing reads. Persisted runtime JSON intentionally omits

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -279,9 +279,10 @@ type keeper_meta = {
   active_goal_ids : string list;
   paused : bool;
   latched_reason : Keeper_latched_reason.t option;
-      (** Typed companion to [paused]. Only explicit operator pause and terminal
-          dead-tombstone paths may write it. [None] while paused is an
-          unclassified legacy state requiring operator action. *)
+      (** Typed companion to [paused]. Explicit operator pause, terminal
+          dead-tombstone, and transcript-corruption reset-required paths may
+          write it. [None] while paused is a fail-closed unclassified state
+          requiring operator action. *)
   autoboot_enabled : bool;
   current_task_id : Keeper_id.Task_id.t option;
       (** Currently claimed task ID for cost attribution.  Set

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -83,12 +83,6 @@ val compaction_retry_suspended : compaction_runtime -> bool
     retrying compaction for this keeper and each further stimulus escalates
     after a single bounded attempt, pending operator inspection. *)
 
-val transcript_quarantine_retry_escalation_threshold : int
-(** #25296: consecutive transcript-quarantine requeues tolerated before the
-    settlement escalates ([Transcript_quarantine_retry_exhausted]) instead of
-    retrying.  Single definition shared by the heartbeat settlement and
-    tests. *)
-
 type proactive_runtime = {
   count_total : int;
   last_ts : float;
@@ -257,11 +251,6 @@ type agent_runtime_state = {
   message_scope_ack_id : string option;
   (** Stable chat-row id of the newest message-scope row injected into a
       completed Keeper turn. *)
-  transcript_quarantine_consecutive_retries : int;
-  (** #25296: consecutive transcript-quarantine requeue settlements for this
-      keeper.  Reset to 0 on a completed turn; the heartbeat settlement
-      escalates instead of requeuing once it reaches
-      {!transcript_quarantine_retry_escalation_threshold}. *)
 }
 
 (** {1 Keeper meta record} *)

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -71,8 +71,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       , match rt.message_scope_ack_id with
         | Some id -> `String id
         | None -> `Null )
-    ; ( "transcript_quarantine_consecutive_retries"
-      , `Int rt.transcript_quarantine_consecutive_retries )
     ; ( "last_blocker"
       , match rt.last_blocker with
         | Some info -> blocker_info_to_json info

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -330,11 +330,6 @@ let parse_keeper_state
       ; mention_reactive_turn_count
       ; noop_turn_count
       ; message_scope_ack_id
-      ; transcript_quarantine_consecutive_retries =
-          Safe_ops.json_int
-            ~default:0
-            "transcript_quarantine_consecutive_retries"
-            json
 	      ; last_blocker
 	      ; last_runtime_attempt
 	      }

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -606,29 +606,28 @@ let persist_compaction_outcome config ~keeper_name ~outcome
     |> Result.map (fun () -> `Persisted)
 ;;
 
-(* #25296: advance the transcript-quarantine retry streak on
-   [agent_runtime_state.transcript_quarantine_consecutive_retries] using the
-   same read/stamp/merge shape as {!persist_compaction_outcome}.
-
-   [`Retried] increments the streak each time a failed turn settles as
-   [Requeue Transcript_quarantine_retry] — including the escalated terminal
-   attempt, so an operator inspecting the meta sees the streak at the
-   ceiling. [`Recovered] resets it on a completed turn: any successful turn
-   proves the keeper is no longer pinned to the poisoned transcript. *)
-let persist_transcript_quarantine_outcome config ~keeper_name ~outcome
+(* Structural transcript corruption is deterministic current-state damage, not
+   a retry class. Persist the existing fail-closed pause surface before the
+   owning lease is terminally settled. The merge preserves any stronger pause
+   or dead-tombstone latch won by a concurrent operator/lifecycle writer. *)
+let persist_transcript_corruption_pause config ~keeper_name
   : ([ `Persisted | `No_durable_meta ], string) result
   =
   let stamp (m : Keeper_meta_contract.keeper_meta) =
-    let rt = m.runtime in
-    { m with
-      runtime =
-        { rt with
-          transcript_quarantine_consecutive_retries =
-            (match outcome with
-             | `Retried -> rt.transcript_quarantine_consecutive_retries + 1
-             | `Recovered -> 0)
-        }
-    }
+    match
+      Keeper_lifecycle_admission.state
+        ~paused:m.paused
+        ~latched_reason:m.latched_reason
+    with
+    | Keeper_lifecycle_admission.Active ->
+      { m with
+        paused = true
+      ; latched_reason = None
+      ; updated_at = Keeper_meta_contract.now_iso ()
+      }
+    | Keeper_lifecycle_admission.Paused _
+    | Keeper_lifecycle_admission.Dead_tombstone ->
+      m
   in
   match read_meta config keeper_name with
   | Error msg -> Error msg

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -322,12 +322,8 @@ let write_meta_error_to_string = function
 let write_meta_typed ?lifecycle_token config (m : Keeper_meta_contract.keeper_meta) =
   let path = keeper_meta_path config m.name in
   (* Write-boundary invariant (fail-closed): never persist [paused=false] with
-     a terminal [Dead_tombstone] latch. That split is un-recoverable (lifecycle
-     admission denies by the latch alone) and is only produced by a writer that
-     cleared [paused] without clearing the latch. Rejecting here — rather than
-     silently repairing — forces resume writers through [mark_resumed] / dead
-     revival, keeping the illegal state unrepresentable on disk. *)
-  match Keeper_meta_contract.dead_tombstone_pause_violation m with
+     a terminal or reset-required latch. *)
+  match Keeper_meta_contract.terminal_latch_pause_violation m with
   | Some detail -> Error (Invariant_violation { keeper_name = m.name; detail })
   | None ->
   Keeper_lifecycle_reservation.with_key_lock
@@ -607,9 +603,9 @@ let persist_compaction_outcome config ~keeper_name ~outcome
 ;;
 
 (* Structural transcript corruption is deterministic current-state damage, not
-   a retry class. Persist the existing fail-closed pause surface before the
-   owning lease is terminally settled. The merge preserves any stronger pause
-   or dead-tombstone latch won by a concurrent operator/lifecycle writer. *)
+   a retry class. Persist the typed reset-required latch before the owning
+   lease is terminally settled. A concurrent dead tombstone remains stronger;
+   an ordinary operator/unclassified pause is upgraded to reset-required. *)
 let persist_transcript_corruption_pause config ~keeper_name
   : ([ `Persisted | `No_durable_meta ], string) result
   =
@@ -619,15 +615,10 @@ let persist_transcript_corruption_pause config ~keeper_name
         ~paused:m.paused
         ~latched_reason:m.latched_reason
     with
-    | Keeper_lifecycle_admission.Active ->
-      { m with
-        paused = true
-      ; latched_reason = None
-      ; updated_at = Keeper_meta_contract.now_iso ()
-      }
-    | Keeper_lifecycle_admission.Paused _
-    | Keeper_lifecycle_admission.Dead_tombstone ->
-      m
+    | Keeper_lifecycle_admission.Dead_tombstone -> m
+    | Keeper_lifecycle_admission.Active
+    | Keeper_lifecycle_admission.Paused _ ->
+      Keeper_meta_contract.mark_transcript_corruption_reset_required m
   in
   match read_meta config keeper_name with
   | Error msg -> Error msg

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -277,5 +277,6 @@ val persist_transcript_corruption_pause :
   keeper_name:string ->
   ([ `Persisted | `No_durable_meta ], string) result
 (** CAS-merge the existing fail-closed pause surface after structural
-    transcript corruption. Concurrent operator/dead-tombstone latches win;
-    no automatic retry counter or migration state is created. *)
+    transcript corruption. A dead tombstone remains stronger and every other
+    live/pause state becomes typed reset-required state. No decoder, migration,
+    or automatic retry state is created. *)

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -272,17 +272,10 @@ val persist_compaction_outcome :
     failing compaction (RFC-0351 S0, #25461); [count] had no writer before this
     despite being serialized and rendered. *)
 
-val persist_transcript_quarantine_outcome :
+val persist_transcript_corruption_pause :
   Workspace.config ->
   keeper_name:string ->
-  outcome:[ `Retried | `Recovered ] ->
   ([ `Persisted | `No_durable_meta ], string) result
-(** Advance the transcript-quarantine retry streak on
-    [agent_runtime_state.transcript_quarantine_consecutive_retries] using the
-    same read/stamp/merge shape as {!persist_compaction_outcome}.
-
-    [`Retried] increments the streak — including the escalated terminal
-    attempt, so the persisted meta shows the streak at the ceiling.
-    [`Recovered] (a completed turn) resets it; callers skip the write when the
-    streak is already 0.  The streak is what the heartbeat settlement reads to
-    escalate instead of requeuing a poisoned transcript quarantine (#25296). *)
+(** CAS-merge the existing fail-closed pause surface after structural
+    transcript corruption. Concurrent operator/dead-tombstone latches win;
+    no automatic retry counter or migration state is created. *)

--- a/lib/keeper/keeper_operator_disposition_display.ml
+++ b/lib/keeper/keeper_operator_disposition_display.ml
@@ -12,6 +12,9 @@ let of_kind ~operator_disposition_reason = function
     ("Pass", reason_or_default ~operator_disposition_reason "continue_next_cycle")
   | Keeper_execution_receipt.Disp_user_cancelled ->
     ("Blocked", reason_or_default ~operator_disposition_reason "cancelled")
+  | Keeper_execution_receipt.Disp_operator_reset_required ->
+    ( "Pause",
+      reason_or_default ~operator_disposition_reason "transcript_corruption" )
   | Keeper_execution_receipt.Disp_unknown ->
     ( "Alert",
       reason_or_default ~operator_disposition_reason "unmapped_runtime_state" )

--- a/lib/keeper/keeper_paused_work_operator.ml
+++ b/lib/keeper/keeper_paused_work_operator.ml
@@ -239,6 +239,7 @@ let error_class = function
           | Resume.Durable_owner_identity_changed
           | Resume.Durable_owner_not_paused
           | Resume.Durable_owner_dead_tombstone
+          | Resume.Durable_owner_transcript_reset_required
           | Resume.Registry_owner_nonce_changed _
           | Resume.Registry_owner_identity_changed
           | Resume.Registry_owner_not_paused _ )

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -24,6 +24,7 @@ type failure =
   | Durable_owner_identity_changed
   | Durable_owner_not_paused
   | Durable_owner_dead_tombstone
+  | Durable_owner_transcript_reset_required
   | Registry_owner_missing
   | Registry_owner_nonce_changed of
       { expected : int
@@ -89,6 +90,9 @@ let failure_to_string = function
   | Durable_owner_not_paused -> "Resume_owner requires a durably paused Keeper"
   | Durable_owner_dead_tombstone ->
     "Resume_owner cannot revive a Dead tombstone; use the dead-revival transaction"
+  | Durable_owner_transcript_reset_required ->
+    "Resume_owner cannot replay a structurally corrupted checkpoint; reset the \
+     Keeper checkpoint first"
   | Registry_owner_missing -> "Resume_owner requires the exact registered Keeper lane"
   | Registry_owner_nonce_changed { expected; actual } ->
     Printf.sprintf
@@ -162,6 +166,10 @@ let paused_meta receipt (meta : Keeper_meta_contract.keeper_meta) =
   with
   | Keeper_lifecycle_admission.Dead_tombstone -> Error Durable_owner_dead_tombstone
   | Keeper_lifecycle_admission.Active -> Error Durable_owner_not_paused
+  | Keeper_lifecycle_admission.Paused
+      (Keeper_lifecycle_admission.Classified
+        Keeper_latched_reason.Transcript_corruption_reset_required) ->
+    Error Durable_owner_transcript_reset_required
   | Keeper_lifecycle_admission.Paused _ ->
     let* () = validate_identity receipt meta in
     Ok meta

--- a/lib/keeper/keeper_paused_work_resume_transaction.mli
+++ b/lib/keeper/keeper_paused_work_resume_transaction.mli
@@ -26,6 +26,7 @@ type failure =
   | Durable_owner_identity_changed
   | Durable_owner_not_paused
   | Durable_owner_dead_tombstone
+  | Durable_owner_transcript_reset_required
   | Registry_owner_missing
   | Registry_owner_nonce_changed of
       { expected : int

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -18,7 +18,6 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Transcript_quarantine_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -52,10 +51,7 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       { attempts : int
       ; detail : string
       }
-  | Transcript_quarantine_retry_exhausted of
-      { attempts : int
-      ; detail : string
-      }
+  | Transcript_corruption_requires_reset of { detail : string }
 
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -17,7 +17,6 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Transcript_quarantine_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -79,10 +78,7 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
       { attempts : int
       ; detail : string
       }
-  | Transcript_quarantine_retry_exhausted of
-      { attempts : int
-      ; detail : string
-      }
+  | Transcript_corruption_requires_reset of { detail : string }
 
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -268,7 +268,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           mention_reactive_turn_count = 0;
           noop_turn_count = 0;
           message_scope_ack_id = None;
-          transcript_quarantine_consecutive_retries = 0;
 	          last_blocker = None;
 	          last_runtime_attempt = None;
 	        };

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -42,7 +42,11 @@ let revival_decision ~(latched_reason : Keeper_latched_reason.t option)
   let dead_revival_requested =
     match latched_reason with
     | Some Keeper_latched_reason.Dead_tombstone -> true
-    | Some (Keeper_latched_reason.Operator_paused _) | None -> false
+    | Some
+        ( Keeper_latched_reason.Operator_paused _
+        | Keeper_latched_reason.Transcript_corruption_reset_required )
+    | None ->
+      false
   in
   {
     dead_revival_requested;

--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -36,7 +36,7 @@ type revival_decision = {
     [Dead_tombstone] with [paused = true], but a resume writer that clears
     [paused] without clearing the latch can strand a keeper at
     [paused = false] + [Dead_tombstone] (see
-    [Keeper_meta_contract.dead_tombstone_pause_violation]). Lifecycle
+    [Keeper_meta_contract.terminal_latch_pause_violation]). Lifecycle
     admission denies by the latch regardless of [paused], so a stranded
     keeper needs a revival path that does not require [paused = true].
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -36,7 +36,7 @@ type source_lease_disposition =
       { reason : Keeper_event_queue_state.no_compaction_reason }
   | Escalate_after_exact_output_terminal of exact_output_terminal_reason
   | Requeue_after_context_compaction of in_lane_compaction
-  | Requeue_after_transcript_quarantine
+  | Pause_after_transcript_corruption of { detail : string }
   | Acknowledge_after_in_turn_handling
 
 let source_lease_disposition_after_no_compaction
@@ -62,9 +62,10 @@ type turn_failure =
   ; source_lease_disposition : source_lease_disposition
   }
 
-let is_incomplete_tool_transcript_error error =
+let transcript_corruption error =
   match Keeper_internal_error.classify_masc_internal_error error with
-  | Some (Keeper_internal_error.Incomplete_tool_transcript _) -> true
+  | Some (Keeper_internal_error.Incomplete_tool_transcript { detail; _ }) ->
+    Some detail
   | Some
       ( Keeper_internal_error.Runtime_exhausted _
       | Keeper_internal_error.Capacity_backpressure _
@@ -75,7 +76,7 @@ let is_incomplete_tool_transcript_error error =
       | Keeper_internal_error.Internal_contract_rejected _
       | Keeper_internal_error.Receipt_persistence_failed _ )
   | None ->
-    false
+    None
 ;;
 
 type turn_success =
@@ -1173,18 +1174,20 @@ dominant source of the observed CAS race exhaustion after
                      the heartbeat settles the current lease and, for
                      [Escalate_judgment], enqueues its typed successor in the
                      same durable event-queue transaction. *)
+                  let transcript_corruption = transcript_corruption err in
                   let failure_route =
                     Keeper_runtime_failure_route.route_of_error
                       ~boundary:
-                        (if is_incomplete_tool_transcript_error err
+                        (if Option.is_some transcript_corruption
                          then Keeper_runtime_failure_route.Masc_execution
                          else Keeper_runtime_failure_route.Oas_execution)
                       err
                   in
                   let source_lease_disposition, turn_state =
-                    if is_incomplete_tool_transcript_error err
-                    then Requeue_after_transcript_quarantine, turn_state
-                    else (
+                    match transcript_corruption with
+                    | Some detail ->
+                      Pause_after_transcript_corruption { detail }, turn_state
+                    | None ->
                       (* The checkpoint helper reports [Ok] only after the
                          compacted checkpoint is durably saved. The heartbeat
                          settles the owning lease after this cycle returns, so
@@ -1209,7 +1212,7 @@ dominant source of the observed CAS race exhaustion after
                         ~turn_start
                         ~turn_state
                         ~base_dir
-                        overflow_recovery)
+                        overflow_recovery
                   in
                   exact_failure_execution :=
                     Some

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -166,7 +166,7 @@ type source_lease_disposition =
       { reason : Keeper_event_queue_state.no_compaction_reason }
   | Escalate_after_exact_output_terminal of exact_output_terminal_reason
   | Requeue_after_context_compaction of in_lane_compaction
-  | Requeue_after_transcript_quarantine
+  | Pause_after_transcript_corruption of { detail : string }
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
     [Follow_failure_route_after_no_compaction] follows the same route but
@@ -183,9 +183,10 @@ type source_lease_disposition =
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
     cycle reloads the durably compacted checkpoint.
-    [Requeue_after_transcript_quarantine] preserves an unprocessed source
-    stimulus after typed transcript admission rejected provider dispatch; an
-    operator or recovery path can repair the checkpoint without losing work.
+    [Pause_after_transcript_corruption] is terminal for automatic execution:
+    typed transcript admission rejected before provider dispatch, so the
+    heartbeat durably pauses the Keeper and consumes any owning lease into an
+    operator-reset-required escalation with no retry successor.
     [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -14,7 +14,6 @@ type requeue_reason = State.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Transcript_quarantine_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -76,10 +75,7 @@ type escalation_reason = State.escalation_reason =
       { attempts : int
       ; detail : string
       }
-  | Transcript_quarantine_retry_exhausted of
-      { attempts : int
-      ; detail : string
-      }
+  | Transcript_corruption_requires_reset of { detail : string }
 
 type no_compaction_reason = State.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -19,7 +19,6 @@ type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Transcript_quarantine_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -86,10 +85,7 @@ type escalation_reason = Keeper_event_queue_state.escalation_reason =
       { attempts : int
       ; detail : string
       }
-  | Transcript_quarantine_retry_exhausted of
-      { attempts : int
-      ; detail : string
-      }
+  | Transcript_corruption_requires_reset of { detail : string }
 
 type no_compaction_reason = Keeper_event_queue_state.no_compaction_reason =
   | No_eligible_history

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -11,7 +11,6 @@ type requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Transcript_quarantine_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
     (* The two approval arms are no longer produced: the approval-wake
@@ -88,18 +87,10 @@ type escalation_reason =
        the checkpoint, reset the streak forever). Distinct from
        [Compaction_retry_exhausted] so the operator can tell "compaction keeps
        failing" from "compaction succeeds but cannot help". *)
-  | Transcript_quarantine_retry_exhausted of
-      { attempts : int
-      ; detail : string
-      }
-    (* #25296: a quarantined poisoned checkpoint is preserved unmodified by
-       design, so every re-lease reloads the same incomplete transcript and
-       the admission rejects it again — an unbounded
-       [Requeue Transcript_quarantine_retry] loop. After
-       [transcript_quarantine_retry_escalation_threshold] consecutive
-       quarantine settlements the settlement escalates instead, surfacing the
-       suspended lane to the operator rather than re-firing the full turn
-       pipeline on every heartbeat. *)
+  | Transcript_corruption_requires_reset of { detail : string }
+    (* Structural transcript corruption is deterministic and rejected before
+       provider dispatch. The first failure pauses the Keeper and terminally
+       consumes the source lease without a successor. *)
 
 type no_compaction_reason =
   | No_eligible_history
@@ -152,7 +143,7 @@ let escalation_reason_requests_external_input = function
   | Compaction_exact_output_terminal _
   | Compaction_retry_exhausted _
   | Compaction_floor_exceeded _
-  | Transcript_quarantine_retry_exhausted _ -> false
+  | Transcript_corruption_requires_reset _ -> false
 ;;
 
 type settlement =
@@ -414,7 +405,6 @@ let requeue_reason_label = function
   | Registration_recovery -> "registration_recovery"
   | Retry_after_observed -> "retry_after_observed"
   | Context_compaction_retry -> "context_compaction_retry"
-  | Transcript_quarantine_retry -> "transcript_quarantine_retry"
   | Approval_grant_unconsumed -> "approval_grant_unconsumed"
   | Approval_grant_state_unavailable -> "approval_grant_state_unavailable"
 ;;
@@ -428,7 +418,6 @@ let requeue_reason_of_label = function
   | "registration_recovery" -> Ok Registration_recovery
   | "retry_after_observed" -> Ok Retry_after_observed
   | "context_compaction_retry" -> Ok Context_compaction_retry
-  | "transcript_quarantine_retry" -> Ok Transcript_quarantine_retry
   | "approval_grant_unconsumed" -> Ok Approval_grant_unconsumed
   | "approval_grant_state_unavailable" -> Ok Approval_grant_state_unavailable
   | label -> Error (Printf.sprintf "unknown event queue requeue reason: %s" label)
@@ -512,8 +501,8 @@ let escalation_reason_label = function
   | Compaction_exact_output_terminal _ -> "compaction_exact_output_terminal"
   | Compaction_retry_exhausted _ -> "compaction_retry_exhausted"
   | Compaction_floor_exceeded _ -> "compaction_floor_exceeded"
-  | Transcript_quarantine_retry_exhausted _ ->
-    "transcript_quarantine_retry_exhausted"
+  | Transcript_corruption_requires_reset _ ->
+    "transcript_corruption_requires_reset"
 ;;
 
 let escalation_reason_detail_to_yojson = function
@@ -538,8 +527,8 @@ let escalation_reason_detail_to_yojson = function
     `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
   | Compaction_floor_exceeded { attempts; detail } ->
     `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
-  | Transcript_quarantine_retry_exhausted { attempts; detail } ->
-    `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
+  | Transcript_corruption_requires_reset { detail } ->
+    `Assoc [ "detail", `String detail ]
 ;;
 
 let required_nonempty_reason_string ~context name fields =
@@ -697,30 +686,20 @@ let escalation_reason_of_wire ~label ~detail_json =
         fields
     in
     Ok (Compaction_floor_exceeded { attempts; detail })
-  | "transcript_quarantine_retry_exhausted", `Assoc fields ->
+  | "transcript_corruption_requires_reset", `Assoc fields ->
     let* () =
       exact_reason_fields
-        ~context:"transcript_quarantine_retry_exhausted"
-        [ "attempts"; "detail" ]
+        ~context:"transcript_corruption_requires_reset"
+        [ "detail" ]
         fields
-    in
-    let* attempts =
-      match List.assoc_opt "attempts" fields with
-      | Some (`Int value) when value > 0 -> Ok value
-      | Some (`Int _) ->
-        Error "transcript_quarantine_retry_exhausted.attempts must be positive"
-      | Some _ ->
-        Error "transcript_quarantine_retry_exhausted.attempts must be an int"
-      | None ->
-        Error "transcript_quarantine_retry_exhausted.attempts is required"
     in
     let* detail =
       required_nonempty_reason_string
-        ~context:"transcript_quarantine_retry_exhausted"
+        ~context:"transcript_corruption_requires_reset"
         "detail"
         fields
     in
-    Ok (Transcript_quarantine_retry_exhausted { attempts; detail })
+    Ok (Transcript_corruption_requires_reset { detail })
   | "failure_judgment_external_input_requested", `Assoc fields ->
     let* () =
       exact_reason_fields
@@ -968,12 +947,12 @@ let validate_settlement = function
   | Escalate
       { reason = Compaction_exact_output_terminal _; successor = Some _ } ->
     Error "terminal exact-output compaction must not enqueue a successor"
-  | Escalate { reason = Transcript_quarantine_retry_exhausted _; successor = None }
+  | Escalate { reason = Transcript_corruption_requires_reset _; successor = None }
     ->
     Ok ()
   | Escalate
-      { reason = Transcript_quarantine_retry_exhausted _; successor = Some _ } ->
-    Error "transcript quarantine retry exhaustion must not enqueue a successor"
+      { reason = Transcript_corruption_requires_reset _; successor = Some _ } ->
+    Error "transcript corruption reset requirement must not enqueue a successor"
 ;;
 
 (* Pure receipt-vs-stimuli invariant. Kept in ONE place so the live settle
@@ -1327,7 +1306,6 @@ let settle_committed ~settled_at ~lease ~settlement state =
       | Requeue
           ( Retry_after_observed
           | Context_compaction_retry
-          | Transcript_quarantine_retry
           | Approval_grant_unconsumed
           | Approval_grant_state_unavailable ) ->
         (* Retryable provider work, context repair handoffs, and a durable

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -18,7 +18,6 @@ type requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Transcript_quarantine_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -99,16 +98,10 @@ type escalation_reason =
           window (an incompressible floor).  Distinct from
           [Compaction_retry_exhausted] so "compaction keeps failing" and
           "compaction succeeds but cannot help" stay operator-distinguishable. *)
-  | Transcript_quarantine_retry_exhausted of
-      { attempts : int
-      ; detail : string
-      }
-      (** #25296: settled instead of [Requeue Transcript_quarantine_retry]
-          once consecutive transcript-quarantine settlements reach the
-          escalation threshold.  The poisoned checkpoint is preserved
-          unmodified by design, so every re-lease rejects the same transcript
-          again — without this ceiling the source stimulus loops through the
-          full turn pipeline on every heartbeat. *)
+  | Transcript_corruption_requires_reset of { detail : string }
+      (** Structural transcript corruption is terminal for automatic
+          execution. The first failure pauses the Keeper and consumes the
+          source lease without a successor until explicit operator reset. *)
 
 type no_compaction_reason =
   | No_eligible_history
@@ -261,8 +254,8 @@ val settle :
     same semantic settlement returns [Already_settled]; a different settlement
     for an already-settled lease is an explicit conflict.
 
-    [Retry_after_observed], [Context_compaction_retry], and
-    [Transcript_quarantine_retry] retain the exact leased stimuli at the
+    [Retry_after_observed] and [Context_compaction_retry] retain the exact
+    leased stimuli at the
     pending FIFO tail so unrelated work in the same lane can proceed before
     another provider attempt. [No_compaction] is accepted
     only for a lease containing exactly one typed

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -23,6 +23,7 @@ let runtime_id_to_string (s : string) = s
    producer codec, receipt terminal projection, and consumer decoder share
    this value so recoverability cannot drift through duplicated literals. *)
 let capacity_backpressure_kind = "capacity_backpressure"
+let incomplete_tool_transcript_kind = "incomplete_tool_transcript"
 
 type provider_rejection = {
   provider_label : string;
@@ -450,7 +451,7 @@ let masc_internal_error_to_json = function
   | Incomplete_tool_transcript { reason; detail; tool_use_ids } ->
     `Assoc
       [
-        ("kind", `String "incomplete_tool_transcript");
+        ("kind", `String incomplete_tool_transcript_kind);
         ("reason", `String (transcript_quarantine_reason_to_string reason));
         ("detail", `String detail);
         ("tool_use_ids", `List (List.map (fun id -> `String id) tool_use_ids));
@@ -589,7 +590,7 @@ let kind_of_masc_internal_error = function
   | Internal_unhandled_exception _ -> "internal_unhandled_exception"
   | Internal_bridge_exception _ -> "internal_bridge_exception"
   | Internal_contract_rejected _ -> "internal_contract_rejected"
-  | Incomplete_tool_transcript _ -> "incomplete_tool_transcript"
+  | Incomplete_tool_transcript _ -> incomplete_tool_transcript_kind
   | Receipt_persistence_failed _ -> "receipt_persistence_failed"
 
 let runtime_id_of_masc_internal_error = function

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -4,6 +4,9 @@
 (** Canonical wire kind emitted for {!Capacity_backpressure}.  Receipt
     terminal projection and decoding consume this same value. *)
 val capacity_backpressure_kind : string
+val incomplete_tool_transcript_kind : string
+(** Canonical wire kind for structural transcript corruption rejected before
+    provider dispatch. *)
 
 type provider_rejection = {
   provider_label : string;

--- a/lib/keeper_runtime/keeper_latched_reason.ml
+++ b/lib/keeper_runtime/keeper_latched_reason.ml
@@ -1,8 +1,9 @@
 (** Typed persisted lifecycle latch.
 
-    Only explicit operator pause and terminal dead tombstones own the durable
-    paused axis. Turn/provider/task failures remain observations and cannot
-    manufacture a lifecycle state. *)
+    Explicit operator pauses, terminal dead tombstones, and structural
+    transcript corruption own the durable paused axis. Ordinary
+    turn/provider/task failures remain observations and cannot manufacture a
+    lifecycle state. *)
 
 type operator_actor =
   | Grpc_directive
@@ -11,6 +12,7 @@ type operator_actor =
 type t =
   | Operator_paused of { operator_actor : operator_actor }
   | Dead_tombstone
+  | Transcript_corruption_reset_required
 
 let operator_actor_grpc_directive = Grpc_directive
 let operator_actor_keeper_down = Keeper_down
@@ -33,14 +35,18 @@ let equal left right =
     Operator_paused { operator_actor = Grpc_directive }
   | Operator_paused { operator_actor = Keeper_down },
     Operator_paused { operator_actor = Keeper_down }
-  | Dead_tombstone, Dead_tombstone -> true
-  | (Operator_paused _ | Dead_tombstone), _ -> false
+  | Dead_tombstone, Dead_tombstone
+  | Transcript_corruption_reset_required, Transcript_corruption_reset_required ->
+    true
+  | (Operator_paused _ | Dead_tombstone | Transcript_corruption_reset_required), _ ->
+    false
 ;;
 
 let hash = function
   | Operator_paused { operator_actor = Grpc_directive } -> 0
   | Operator_paused { operator_actor = Keeper_down } -> 1
   | Dead_tombstone -> 2
+  | Transcript_corruption_reset_required -> 3
 ;;
 
 let pp formatter = function
@@ -50,12 +56,16 @@ let pp formatter = function
       "Operator_paused{actor=%s}"
       (operator_actor_to_wire operator_actor)
   | Dead_tombstone -> Format.pp_print_string formatter "Dead_tombstone"
+  | Transcript_corruption_reset_required ->
+    Format.pp_print_string formatter "Transcript_corruption_reset_required"
 ;;
 
 let to_wire = function
   | Operator_paused { operator_actor } ->
     "operator_paused:actor=" ^ operator_actor_to_wire operator_actor
   | Dead_tombstone -> "dead_tombstone"
+  | Transcript_corruption_reset_required ->
+    "transcript_corruption_reset_required"
 ;;
 
 let of_wire = function
@@ -64,6 +74,8 @@ let of_wire = function
   | "operator_paused:actor=keeper_down" ->
     Ok (Operator_paused { operator_actor = Keeper_down })
   | "dead_tombstone" -> Ok Dead_tombstone
+  | "transcript_corruption_reset_required" ->
+    Ok Transcript_corruption_reset_required
   | wire ->
     Error
       (Printf.sprintf
@@ -79,6 +91,8 @@ module Stable = struct
         ; "actor", `String (operator_actor_to_wire operator_actor)
         ]
     | Dead_tombstone -> `Assoc [ "kind", `String "dead_tombstone" ]
+    | Transcript_corruption_reset_required ->
+      `Assoc [ "kind", `String "transcript_corruption_reset_required" ]
   ;;
 
   let of_yojson = function
@@ -88,6 +102,8 @@ module Stable = struct
         (fun operator_actor -> Operator_paused { operator_actor })
         (operator_actor_of_wire actor)
     | `Assoc [ "kind", `String "dead_tombstone" ] -> Ok Dead_tombstone
+    | `Assoc [ "kind", `String "transcript_corruption_reset_required" ] ->
+      Ok Transcript_corruption_reset_required
     | json ->
       Error
         (Printf.sprintf

--- a/lib/keeper_runtime/keeper_latched_reason.mli
+++ b/lib/keeper_runtime/keeper_latched_reason.mli
@@ -1,12 +1,14 @@
 (** Typed SSOT for a durable Keeper lifecycle latch.
 
-    Failure observations never inhabit this type. A persisted retired failure
-    latch is rejected explicitly and is surfaced by the metadata reader as an
-    unclassified paused state until an operator resumes it. *)
+    Ordinary failure observations never inhabit this type. Structural
+    transcript corruption is a reset-required lifecycle latch because replaying
+    the same checkpoint is unsafe. Retired or unknown latches are rejected
+    explicitly. *)
 
 type t =
   | Operator_paused of { operator_actor : operator_actor }
   | Dead_tombstone
+  | Transcript_corruption_reset_required
 
 and operator_actor =
   | Grpc_directive

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -28,6 +28,7 @@ type t =
   | Capacity_backpressure of string
   | Config_or_auth of string
   | Provider_runtime_failure of string
+  | Transcript_corruption of string
   | Internal_error of string
   | Pre_dispatch_success of string
   | Unknown of string
@@ -64,6 +65,9 @@ let of_wire wire =
     || String.equal wire "provider_error"
     || String.starts_with ~prefix:"provider_error_" wire
   then Provider_runtime_failure wire
+  else if
+    String.equal wire Keeper_internal_error.incomplete_tool_transcript_kind
+  then Transcript_corruption wire
   else if String.equal wire "internal_error"
   then Internal_error wire
   else if String.equal wire "pre_dispatch_success"
@@ -80,6 +84,7 @@ let to_wire = function
   | Capacity_backpressure wire -> wire
   | Config_or_auth wire -> wire
   | Provider_runtime_failure wire -> wire
+  | Transcript_corruption wire -> wire
   | Internal_error wire -> wire
   | Pre_dispatch_success wire -> wire
   | Unknown wire -> wire
@@ -107,6 +112,7 @@ let is_transient_provider_runtime_failure = function
   | Runtime_exhausted _
   | Capacity_backpressure _
   | Config_or_auth _
+  | Transcript_corruption _
   | Internal_error _
   | Pre_dispatch_success _
   | Unknown _ -> false

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -64,6 +64,11 @@ type t =
           [String.starts_with ~prefix:"provider_error_"]. Config/auth-like
           provider codes still land in [Config_or_auth] because that bucket
           is ranked earlier. Payload is the original string. *)
+  | Transcript_corruption of string
+  (** Exact canonical wire
+      {!Keeper_internal_error.incomplete_tool_transcript_kind}. Provider
+      dispatch did not occur; automatic retry is forbidden until an operator
+      resets the corrupted checkpoint. *)
   | Internal_error of string
   (** Exact wire ["internal_error"]. Payload is the original
           string, carried only for [to_wire] round-trip fidelity. *)

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -1021,6 +1021,7 @@ let resume_error_status (error : Keeper_paused_work_resume_transaction.error) =
   | Durable_owner_identity_changed
   | Durable_owner_not_paused
   | Durable_owner_dead_tombstone
+  | Durable_owner_transcript_reset_required
   | Registry_owner_nonce_changed _
   | Registry_owner_identity_changed
   | Registry_owner_not_paused _ -> `Conflict

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -40,6 +40,7 @@ type pause_kind = Keeper_activation_readiness.pause_kind =
   | Operator_paused
   | Unclassified_paused
   | Dead_tombstone
+  | Transcript_corruption_reset_required
 
 let pause_kind = Keeper_activation_readiness.pause_kind
 let pause_kind_to_wire = Keeper_activation_readiness.pause_kind_to_wire

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -18,6 +18,7 @@ type pause_kind = Keeper_activation_readiness.pause_kind =
   | Operator_paused
   | Unclassified_paused
   | Dead_tombstone
+  | Transcript_corruption_reset_required
 
 val pause_kind : Keeper_meta_contract.keeper_meta -> pause_kind
 val pause_kind_to_wire : pause_kind -> string

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -169,7 +169,10 @@ let keeper_event_queue_health_json () =
       | Ok (Some meta) ->
         (match pause_kind meta with
          | Active -> Keeper_event_queue_persistence.Runnable
-         | Operator_paused | Unclassified_paused | Dead_tombstone ->
+         | Operator_paused
+         | Unclassified_paused
+         | Dead_tombstone
+         | Transcript_corruption_reset_required ->
            Keeper_event_queue_persistence.Paused_retained)
       | Ok None ->
         Keeper_event_queue_persistence.Lifecycle_unknown "durable keeper metadata missing"

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -926,7 +926,6 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
             ~settled_at:3.0
             ~stop_requested:false
             ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
             ~lease
             None
         with
@@ -1001,7 +1000,6 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
             ~settled_at:4.0
             ~stop_requested:false
             ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
             ~lease
             None
         with

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1190,7 +1190,6 @@ let test_failed_cycle_route_mapping () =
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:2.0
        ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
        retry_failure
    with
    | Masc.Keeper_registry_event_queue.Requeue
@@ -1209,7 +1208,6 @@ let test_failed_cycle_route_mapping () =
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:3.0
        ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
        judgment_failure
    with
    | Masc.Keeper_registry_event_queue.Escalate
@@ -1231,7 +1229,6 @@ let test_failed_cycle_route_mapping () =
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:6.0
        ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
        handled_failure
    with
    | Masc.Keeper_registry_event_queue.Ack -> ()
@@ -1247,7 +1244,6 @@ let test_failed_cycle_route_mapping () =
      Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:7.0
        ~compaction_consecutive_failures:0
-       ~transcript_quarantine_consecutive_retries:0
        compacted_failure
    with
    | Masc.Keeper_registry_event_queue.Requeue
@@ -1257,20 +1253,27 @@ let test_failed_cycle_route_mapping () =
   let quarantined_failure =
     { judgment_failure with
       source_lease_disposition =
-        Masc.Keeper_unified_turn.Requeue_after_transcript_quarantine
+        Masc.Keeper_unified_turn.Pause_after_transcript_corruption
+          { detail = "fixture transcript corruption" }
     }
   in
   match
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:8.0
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
       quarantined_failure
   with
-  | Masc.Keeper_registry_event_queue.Requeue
-      Masc.Keeper_registry_event_queue.Transcript_quarantine_retry ->
-    ()
-  | _ -> Alcotest.fail "unprocessed source stimulus was acknowledged after quarantine"
+  | Masc.Keeper_registry_event_queue.Escalate
+      { reason =
+          Masc.Keeper_registry_event_queue.Transcript_corruption_requires_reset
+            { detail }
+      ; successor = None
+      } ->
+    Alcotest.(check string)
+      "terminal corruption detail"
+      "fixture transcript corruption"
+      detail
+  | _ -> Alcotest.fail "transcript corruption did not require operator reset"
 ;;
 
 let cycle_meta () =
@@ -1316,7 +1319,6 @@ let test_manual_no_compaction_is_terminal_but_overflow_escalates () =
        ~settled_at:2.0
        ~stop_requested:false
        ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
        ~lease
        (Some
           (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_not_applied
@@ -1335,7 +1337,6 @@ let test_manual_no_compaction_is_terminal_but_overflow_escalates () =
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:3.0
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
       overflow_failure
   with
   | Masc.Keeper_registry_event_queue.Escalate
@@ -1361,7 +1362,6 @@ let test_applied_compaction_settles_followup_atomically () =
       ~settled_at:8.0
       ~stop_requested:false
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
       ~lease
       (Some
          (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_applied
@@ -1420,7 +1420,6 @@ let test_compaction_retry_escalates_after_threshold () =
       ~settled_at:2.0
       ~stop_requested:false
       ~compaction_consecutive_failures:streak
-      ~transcript_quarantine_consecutive_retries:0
       ~lease
       (Some failed)
   in
@@ -1466,7 +1465,6 @@ let test_in_lane_compaction_streak_bounds_retries () =
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:4.0
       ~compaction_consecutive_failures:streak
-      ~transcript_quarantine_consecutive_retries:0
       (failure disposition)
   in
   let attempt_failed =
@@ -1552,7 +1550,6 @@ let test_in_lane_compaction_streak_bounds_retries () =
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:5.0
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
       { (turn_failure route) with
         source_lease_disposition =
           Masc.Keeper_unified_turn.source_lease_disposition_after_no_compaction
@@ -1773,13 +1770,7 @@ let test_compaction_outcome_mapping_covers_in_lane_dispositions () =
   check "no outcome leaves the streak untouched" "none" None
 ;;
 
-(* #25296: a transcript-quarantine disposition requeues while the streak is
-   under the ceiling and settles terminally at it. The poisoned checkpoint is
-   preserved unmodified by design, so every re-lease rejects the same
-   transcript again — without the ceiling the same stimulus re-enters the full
-   turn pipeline on every heartbeat cycle, because [Requeue] is not an ack
-   (2026-07-21 lesson: every exempt retry class needs its own accounting). *)
-let test_transcript_quarantine_retry_escalates_after_threshold () =
+let test_transcript_corruption_requires_reset_immediately () =
   let judgment_route =
     Keeper_runtime_failure_route.Escalate_judgment
       { judgment = Keeper_runtime_failure_route.Contract_violation
@@ -1790,86 +1781,29 @@ let test_transcript_quarantine_retry_escalates_after_threshold () =
   let quarantined_failure =
     { (turn_failure judgment_route) with
       source_lease_disposition =
-        Masc.Keeper_unified_turn.Requeue_after_transcript_quarantine
+        Masc.Keeper_unified_turn.Pause_after_transcript_corruption
+          { detail = "overlapping tool cycle" }
     }
   in
-  let settlement ~streak =
+  match
     Masc.Keeper_heartbeat_loop.settlement_of_failure
       ~settled_at:5.0
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:streak
       quarantined_failure
-  in
-  let expect_requeue ~streak label =
-    match settlement ~streak with
-    | Masc.Keeper_registry_event_queue.Requeue
-        Masc.Keeper_registry_event_queue.Transcript_quarantine_retry ->
-      ()
-    | _ -> Alcotest.fail label
-  in
-  expect_requeue ~streak:0 "first transcript quarantine did not requeue";
-  expect_requeue ~streak:1 "second transcript quarantine did not requeue";
-  match settlement ~streak:2 with
+  with
   | Masc.Keeper_registry_event_queue.Escalate
       { reason =
-          Masc.Keeper_registry_event_queue.Transcript_quarantine_retry_exhausted
-            { attempts; _ }
+          Masc.Keeper_registry_event_queue.Transcript_corruption_requires_reset
+            { detail }
       ; successor = None
       } ->
-    Alcotest.(check int) "escalation reports the attempt count" 3 attempts
+    Alcotest.(check string)
+      "first rejection preserves typed detail"
+      "overlapping tool cycle"
+      detail
   | _ ->
     Alcotest.fail
-      "third consecutive transcript quarantine requeued instead of escalating"
-;;
-
-(* #25296: the settlement decides from the streak; this mapping is what
-   advances and resets it. A quarantine disposition must count, a completed
-   turn must reset, and outcomes with no quarantine involvement must leave the
-   streak untouched. *)
-let test_transcript_quarantine_outcome_mapping () =
-  let meta = cycle_meta () in
-  let judgment_route =
-    Keeper_runtime_failure_route.Escalate_judgment
-      { judgment = Keeper_runtime_failure_route.Contract_violation
-      ; provenance = Keeper_runtime_failure_route.Oas_agent_error
-      ; detail = "typed transcript quarantine"
-      }
-  in
-  let failed disposition =
-    Some
-      (Masc.Keeper_heartbeat_loop_cycle.Failed
-         { meta
-         ; failure =
-             { (turn_failure judgment_route) with
-               source_lease_disposition = disposition
-             }
-         })
-  in
-  let check label expected outcome =
-    let actual =
-      match
-        Masc.Keeper_heartbeat_loop.transcript_quarantine_outcome_of_cycle_outcome
-          outcome
-      with
-      | Some `Retried -> "retried"
-      | Some `Recovered -> "recovered"
-      | None -> "none"
-    in
-    Alcotest.(check string) label expected actual
-  in
-  check
-    "a quarantine disposition advances the streak"
-    "retried"
-    (failed Masc.Keeper_unified_turn.Requeue_after_transcript_quarantine);
-  check
-    "a generic turn failure leaves the streak untouched"
-    "none"
-    (failed Masc.Keeper_unified_turn.Follow_failure_route);
-  check
-    "a completed turn resets the streak"
-    "recovered"
-    (Some (Masc.Keeper_heartbeat_loop_cycle.Completed meta));
-  check "no outcome leaves the streak untouched" "none" None
+      "first transcript corruption did not settle terminally without successor"
 ;;
 
 let test_cancelled_and_skipped_cycles_requeue () =
@@ -1881,7 +1815,6 @@ let test_cancelled_and_skipped_cycles_requeue () =
       ~settled_at:2.0
       ~stop_requested:false
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
       ~lease
       (Some outcome)
   in
@@ -2032,7 +1965,6 @@ let test_approved_wake_settles_on_delivery_not_consumption () =
       ~settled_at:4.0
       ~stop_requested:false
       ~compaction_consecutive_failures:0
-      ~transcript_quarantine_consecutive_retries:0
       ~lease
       outcome
   in
@@ -2882,13 +2814,9 @@ let () =
             `Quick
             test_compaction_outcome_mapping_covers_in_lane_dispositions
         ; Alcotest.test_case
-            "transcript quarantine retry escalates after threshold"
+            "transcript corruption requires immediate reset"
             `Quick
-            test_transcript_quarantine_retry_escalates_after_threshold
-        ; Alcotest.test_case
-            "transcript quarantine outcome mapping"
-            `Quick
-            test_transcript_quarantine_outcome_mapping
+            test_transcript_corruption_requires_reset_immediately
         ; Alcotest.test_case
             "approved wake settles on delivery not consumption"
             `Quick

--- a/test/test_keeper_latched_reason.ml
+++ b/test/test_keeper_latched_reason.ml
@@ -7,6 +7,7 @@ let reasons =
   ; ( "keeper_down operator pause"
     , R.Operator_paused { operator_actor = R.operator_actor_keeper_down } )
   ; "dead tombstone", R.Dead_tombstone
+  ; "transcript corruption reset required", R.Transcript_corruption_reset_required
   ]
 ;;
 

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -255,7 +255,8 @@ let test_active_admission () =
     (match Admission.admit_manual_one_shot state with
      | Admission.Manual_admitted_active -> true
      | Admission.Manual_admitted_paused_recovery _
-     | Admission.Manual_denied_dead_tombstone -> false);
+     | Admission.Manual_denied_dead_tombstone
+     | Admission.Manual_denied_transcript_reset_required -> false);
   check bool "autonomous admitted" true
     (match Admission.admit_autonomous state with
      | Admission.Autonomous_admitted -> true
@@ -278,7 +279,8 @@ let test_classified_pause_admission () =
        Keeper_latched_reason.equal reason operator_pause
      | Admission.Manual_admitted_active
      | Admission.Manual_admitted_paused_recovery Admission.Unclassified
-     | Admission.Manual_denied_dead_tombstone -> false);
+     | Admission.Manual_denied_dead_tombstone
+     | Admission.Manual_denied_transcript_reset_required -> false);
   check bool "autonomous execution is denied" true
     (match Admission.admit_autonomous state with
      | Admission.Autonomous_denied
@@ -321,7 +323,8 @@ let test_dead_tombstone_dominates_stale_paused_bit () =
     (match Admission.admit_manual_one_shot state with
      | Admission.Manual_denied_dead_tombstone -> true
      | Admission.Manual_admitted_active
-     | Admission.Manual_admitted_paused_recovery _ -> false);
+     | Admission.Manual_admitted_paused_recovery _
+     | Admission.Manual_denied_transcript_reset_required -> false);
   check bool "autonomous execution denied as terminal" true
     (match Admission.admit_autonomous state with
      | Admission.Autonomous_denied Admission.Autonomous_dead_tombstone -> true
@@ -352,6 +355,43 @@ let test_readiness_projects_dead_tombstone () =
     (Readiness.autonomous_check_value activation)
 ;;
 
+let test_transcript_corruption_requires_reset () =
+  without_overrides @@ fun () ->
+  let reason = Keeper_latched_reason.Transcript_corruption_reset_required in
+  let state =
+    lifecycle_state ~paused:false ~latched_reason:(Some reason)
+  in
+  check bool "reset-required latch dominates stale pause bit" true
+    (match state with
+     | Admission.Paused (Admission.Classified actual) ->
+       Keeper_latched_reason.equal actual reason
+     | Admission.Active
+     | Admission.Paused Admission.Unclassified
+     | Admission.Dead_tombstone ->
+       false);
+  check bool "generic manual resume is denied" true
+    (match Admission.admit_manual_one_shot state with
+     | Admission.Manual_denied_transcript_reset_required -> true
+     | Admission.Manual_admitted_active
+     | Admission.Manual_admitted_paused_recovery _
+     | Admission.Manual_denied_dead_tombstone ->
+       false);
+  let meta =
+    { (ready_meta ()) with paused = false; latched_reason = Some reason }
+  in
+  let readiness = Readiness.of_meta meta in
+  check bool "reset-required Keeper is not ready" false
+    readiness.autonomous_activation.ok;
+  check bool "health projects reset-required identity" true
+    (match Readiness.pause_kind meta with
+     | Readiness.Transcript_corruption_reset_required -> true
+     | Readiness.Active
+     | Readiness.Operator_paused
+     | Readiness.Unclassified_paused
+     | Readiness.Dead_tombstone ->
+       false)
+;;
+
 let test_health_projection_uses_typed_lifecycle () =
   let dead_meta =
     { (ready_meta ()) with
@@ -367,13 +407,15 @@ let test_health_projection_uses_typed_lifecycle () =
      | Readiness.Dead_tombstone -> true
      | Readiness.Active
      | Readiness.Operator_paused
-     | Readiness.Unclassified_paused -> false);
+     | Readiness.Unclassified_paused
+     | Readiness.Transcript_corruption_reset_required -> false);
   check bool "health does not mislabel missing reason as operator pause" true
     (match Readiness.pause_kind unclassified_meta with
      | Readiness.Unclassified_paused -> true
      | Readiness.Active
      | Readiness.Operator_paused
-     | Readiness.Dead_tombstone -> false)
+     | Readiness.Dead_tombstone
+     | Readiness.Transcript_corruption_reset_required -> false)
 ;;
 
 let () = init_runtime_default_for_tests ()
@@ -406,6 +448,8 @@ let () =
             test_dead_tombstone_dominates_stale_paused_bit
         ; test_case "readiness projects dead tombstone" `Quick
             test_readiness_projects_dead_tombstone
+        ; test_case "transcript corruption requires reset" `Quick
+            test_transcript_corruption_requires_reset
         ; test_case "health projects typed lifecycle" `Quick
             test_health_projection_uses_typed_lifecycle
         ] )

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -382,7 +382,7 @@ let test_mark_resumed_clears_dead_tombstone_and_persists () =
         updated_at = Keeper_meta_contract.now_iso () }
     in
     check (option string) "mark_resumed leaves no invariant violation"
-      None (Keeper_meta_contract.dead_tombstone_pause_violation resumed);
+      None (Keeper_meta_contract.terminal_latch_pause_violation resumed);
     (match Keeper_meta_store.write_meta config resumed with
      | Ok () -> () | Error e -> fail ("resumed write should succeed: " ^ e));
     let after = match Keeper_meta_store.read_meta config "resume-dead" with
@@ -402,11 +402,11 @@ let test_dead_tombstone_pause_violation_classifies () =
       latched_reason = Some Keeper_latched_reason.Dead_tombstone } in
   let unpaused_none = { base with paused = false; latched_reason = None } in
   check bool "paused+dead is valid (no violation)" true
-    (Option.is_none (Keeper_meta_contract.dead_tombstone_pause_violation paused_dead));
+    (Option.is_none (Keeper_meta_contract.terminal_latch_pause_violation paused_dead));
   check bool "unpaused+dead is a violation" true
-    (Option.is_some (Keeper_meta_contract.dead_tombstone_pause_violation unpaused_dead));
+    (Option.is_some (Keeper_meta_contract.terminal_latch_pause_violation unpaused_dead));
   check bool "unpaused+no-latch is valid" true
-    (Option.is_none (Keeper_meta_contract.dead_tombstone_pause_violation unpaused_none))
+    (Option.is_none (Keeper_meta_contract.terminal_latch_pause_violation unpaused_none))
 
 (* PR #24351 review (P1): [Keeper_turn_up_update.revival_decision] is the
    extracted decision that used to be inlined in [update_keeper]. Before

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -7,6 +7,7 @@ module State = Keeper_event_queue_state
 module Transaction = Keeper_paused_work_cancellation_transaction
 module Disposition_receipt = Keeper_paused_work_disposition_receipt
 module Resume_transaction = Keeper_paused_work_resume_transaction
+module Heartbeat_testing = Keeper_heartbeat_loop.For_testing
 
 let require_ok label = function
   | Ok value -> value
@@ -662,6 +663,113 @@ let test_resume_owner_rejects_dead_tombstone_without_receipt () =
        | Error detail -> Alcotest.fail detail)
 ;;
 
+let test_resume_owner_rejects_transcript_reset_without_receipt () =
+  with_seeded_owner
+    ~registered:false
+    ~latched_reason:Keeper_latched_reason.Transcript_corruption_reset_required
+    ~paused:true
+    ~generation:24
+    (fun config keeper_name _source ->
+       let request = resume_request 24 "operator-resume-corrupted" in
+       (match Resume_transaction.resume config ~keeper_name request with
+        | Error
+            { Resume_transaction.cause =
+                Resume_transaction.Durable_owner_transcript_reset_required
+            ; reservation_release = Some release
+            } ->
+          check_resume_released release
+        | Error error -> Alcotest.fail (Resume_transaction.error_to_string error)
+        | Ok _ ->
+          Alcotest.fail "Resume_owner replayed a structurally corrupted checkpoint");
+       match
+         Disposition_receipt.load
+           config
+           ~keeper_name
+           ~operator_operation_id:request.operator_operation_id
+       with
+       | Ok None -> ()
+       | Ok (Some _) ->
+         Alcotest.fail "reset-required Resume_owner persisted a receipt"
+       | Error detail -> Alcotest.fail detail)
+;;
+
+let test_transcript_corruption_pause_precedes_settlement () =
+  let stop = Atomic.make false in
+  let calls = ref [] in
+  let result =
+    Heartbeat_testing.commit_transcript_corruption
+      ~stop
+      ~persist_pause:(fun () ->
+        calls := "pause" :: !calls;
+        Ok `Persisted)
+      ~settle:(fun () ->
+        calls := "settle" :: !calls;
+        Ok ())
+      ()
+  in
+  Alcotest.(check bool) "corrupted fiber is stopped" true (Atomic.get stop);
+  Alcotest.(check (list string))
+    "durable pause commits before terminal settlement"
+    [ "pause"; "settle" ]
+    (List.rev !calls);
+  Alcotest.(check bool)
+    "both commits are reported"
+    true
+    (match result with
+     | Heartbeat_testing.Transcript_pause_and_settlement_persisted -> true
+     | Heartbeat_testing.Transcript_pause_persisted
+     | Heartbeat_testing.Transcript_pause_persistence_failed _
+     | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
+       false)
+;;
+
+let test_transcript_corruption_pause_failure_preserves_lease () =
+  let stop = Atomic.make false in
+  let settlement_called = ref false in
+  let result =
+    Heartbeat_testing.commit_transcript_corruption
+      ~stop
+      ~persist_pause:(fun () -> Ok `No_durable_meta)
+      ~settle:(fun () ->
+        settlement_called := true;
+        Ok ())
+      ()
+  in
+  Alcotest.(check bool) "corrupted fiber remains stopped" true (Atomic.get stop);
+  Alcotest.(check bool)
+    "terminal settlement stays locked"
+    false
+    !settlement_called;
+  Alcotest.(check bool)
+    "pause failure is typed"
+    true
+    (match result with
+     | Heartbeat_testing.Transcript_pause_persistence_failed _ -> true
+     | Heartbeat_testing.Transcript_pause_persisted
+     | Heartbeat_testing.Transcript_pause_and_settlement_persisted
+     | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
+       false)
+;;
+
+let test_unleased_transcript_corruption_only_persists_pause () =
+  let stop = Atomic.make false in
+  let result =
+    Heartbeat_testing.commit_transcript_corruption
+      ~stop
+      ~persist_pause:(fun () -> Ok `Persisted)
+      ()
+  in
+  Alcotest.(check bool)
+    "unleased corruption commits only durable pause"
+    true
+    (match result with
+     | Heartbeat_testing.Transcript_pause_persisted -> true
+     | Heartbeat_testing.Transcript_pause_and_settlement_persisted
+     | Heartbeat_testing.Transcript_pause_persistence_failed _
+     | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
+       false)
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -712,6 +820,22 @@ let () =
             "Resume_owner rejects Dead tombstone without receipt"
             `Quick
             test_resume_owner_rejects_dead_tombstone_without_receipt
+        ; Alcotest.test_case
+            "Resume_owner rejects transcript reset without receipt"
+            `Quick
+            test_resume_owner_rejects_transcript_reset_without_receipt
+        ; Alcotest.test_case
+            "transcript pause precedes settlement"
+            `Quick
+            test_transcript_corruption_pause_precedes_settlement
+        ; Alcotest.test_case
+            "transcript pause failure preserves lease"
+            `Quick
+            test_transcript_corruption_pause_failure_preserves_lease
+        ; Alcotest.test_case
+            "unleased transcript only persists pause"
+            `Quick
+            test_unleased_transcript_corruption_only_persists_pause
         ] )
     ]
 ;;

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -723,15 +723,17 @@ let test_transcript_corruption_pause_precedes_settlement () =
        false)
 ;;
 
-let test_transcript_corruption_pause_failure_preserves_lease () =
+let assert_transcript_corruption_pause_failure_preserves_lease ~persist_pause =
   with_lane ~registered:false ~paused:false ~generation:24
     (fun config keeper_name request ->
        let stop = Atomic.make false in
+       let settlement_called = ref false in
        let result =
          Heartbeat_testing.commit_transcript_corruption
            ~stop
-           ~persist_pause:(fun () -> Error "injected pause CAS failure")
+           ~persist_pause
            ~settle:(fun () ->
+             settlement_called := true;
              Registry_queue.settle_result
                ~base_path:config.Workspace.base_path
                keeper_name
@@ -751,6 +753,10 @@ let test_transcript_corruption_pause_failure_preserves_lease () =
          "corrupted fiber remains stopped"
          true
          (Atomic.get stop);
+       Alcotest.(check bool)
+         "pause failure never enters terminal settlement"
+         false
+         !settlement_called;
        Alcotest.(check bool)
          "pause CAS failure is typed"
          true
@@ -780,6 +786,16 @@ let test_transcript_corruption_pause_failure_preserves_lease () =
          "pause CAS failure creates no terminal outbox receipt"
          0
          (List.length (State.transition_outbox state)))
+;;
+
+let test_transcript_corruption_pause_failure_preserves_lease () =
+  assert_transcript_corruption_pause_failure_preserves_lease
+    ~persist_pause:(fun () -> Error "injected pause CAS failure")
+;;
+
+let test_transcript_corruption_pause_exception_preserves_lease () =
+  assert_transcript_corruption_pause_failure_preserves_lease
+    ~persist_pause:(fun () -> failwith "injected pause persistence exception")
 ;;
 
 let test_unleased_transcript_corruption_only_persists_pause () =
@@ -863,6 +879,10 @@ let () =
             "transcript pause failure preserves lease"
             `Quick
             test_transcript_corruption_pause_failure_preserves_lease
+        ; Alcotest.test_case
+            "transcript pause exception preserves lease"
+            `Quick
+            test_transcript_corruption_pause_exception_preserves_lease
         ; Alcotest.test_case
             "unleased transcript only persists pause"
             `Quick

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -724,31 +724,62 @@ let test_transcript_corruption_pause_precedes_settlement () =
 ;;
 
 let test_transcript_corruption_pause_failure_preserves_lease () =
-  let stop = Atomic.make false in
-  let settlement_called = ref false in
-  let result =
-    Heartbeat_testing.commit_transcript_corruption
-      ~stop
-      ~persist_pause:(fun () -> Ok `No_durable_meta)
-      ~settle:(fun () ->
-        settlement_called := true;
-        Ok ())
-      ()
-  in
-  Alcotest.(check bool) "corrupted fiber remains stopped" true (Atomic.get stop);
-  Alcotest.(check bool)
-    "terminal settlement stays locked"
-    false
-    !settlement_called;
-  Alcotest.(check bool)
-    "pause failure is typed"
-    true
-    (match result with
-     | Heartbeat_testing.Transcript_pause_persistence_failed _ -> true
-     | Heartbeat_testing.Transcript_pause_persisted
-     | Heartbeat_testing.Transcript_pause_and_settlement_persisted
-     | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
-       false)
+  with_lane ~registered:false ~paused:false ~generation:24
+    (fun config keeper_name request ->
+       let stop = Atomic.make false in
+       let result =
+         Heartbeat_testing.commit_transcript_corruption
+           ~stop
+           ~persist_pause:(fun () -> Error "injected pause CAS failure")
+           ~settle:(fun () ->
+             Registry_queue.settle_result
+               ~base_path:config.Workspace.base_path
+               keeper_name
+               ~settled_at:4.0
+               ~lease:request.lease
+               ~settlement:
+                 (Registry_queue.Escalate
+                    { reason =
+                        Registry_queue.Transcript_corruption_requires_reset
+                          { detail = "fixture transcript corruption" }
+                    ; successor = None
+                    })
+             |> Result.map (fun _ -> ()))
+           ()
+       in
+       Alcotest.(check bool)
+         "corrupted fiber remains stopped"
+         true
+         (Atomic.get stop);
+       Alcotest.(check bool)
+         "pause CAS failure is typed"
+         true
+         (match result with
+          | Heartbeat_testing.Transcript_pause_persistence_failed _ -> true
+          | Heartbeat_testing.Transcript_pause_persisted
+          | Heartbeat_testing.Transcript_pause_and_settlement_persisted
+          | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
+            false);
+       let state =
+         Persistence.load_state_result
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+         |> require_ok "load lease after pause CAS failure"
+       in
+       (match State.leases state with
+        | [ lease ] ->
+          Alcotest.(check string)
+            "pause CAS failure preserves the exact durable lease"
+            request.lease.lease_id
+            lease.lease_id
+        | leases ->
+          Alcotest.failf
+            "pause CAS failure changed durable lease count: expected 1, got %d"
+            (List.length leases));
+       Alcotest.(check int)
+         "pause CAS failure creates no terminal outbox receipt"
+         0
+         (List.length (State.transition_outbox state)))
 ;;
 
 let test_unleased_transcript_corruption_only_persists_pause () =

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -473,8 +473,6 @@ let test_manual_compaction_serializes_owner_lane () =
            ~stop_requested:false
            ~compaction_consecutive_failures:
              meta.runtime.compaction_rt.consecutive_failures
-           ~transcript_quarantine_consecutive_retries:
-             meta.runtime.transcript_quarantine_consecutive_retries
            ~lease
            (Some busy_outcome)
        with
@@ -715,8 +713,6 @@ let test_manual_compaction_serializes_owner_lane () =
           ~stop_requested:false
           ~compaction_consecutive_failures:
             meta.runtime.compaction_rt.consecutive_failures
-          ~transcript_quarantine_consecutive_retries:
-            meta.runtime.transcript_quarantine_consecutive_retries
           ~lease
           (Some
              (Cycle.Manual_compaction_not_applied

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -73,6 +73,7 @@ let roundtrip_corpus =
   [ (* exact-match buckets *)
     "runtime_exhausted"
   ; Keeper_internal_error.capacity_backpressure_kind
+  ; Keeper_internal_error.incomplete_tool_transcript_kind
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -159,6 +160,9 @@ let frozen_operator_disposition (receipt : R.t)
   else if
     String.equal terminal_reason Keeper_internal_error.capacity_backpressure_kind
   then R.Disp_fail_open_next_runtime, R.Reason_capacity_backpressure
+  else if
+    String.equal terminal_reason Keeper_internal_error.incomplete_tool_transcript_kind
+  then R.Disp_operator_reset_required, R.Reason_transcript_corruption
   else if preflight_config_failure
   then R.Disp_fail_open_next_runtime, R.Reason_preflight_config_error
   else if
@@ -279,6 +283,20 @@ let () =
   check
     "canonical typed config wire keeps its explicit route"
     (canonical = (R.Disp_fail_open_next_runtime, R.Reason_preflight_config_error))
+  ;
+  let transcript_corruption =
+    R.operator_disposition
+      { base_receipt with
+        terminal_reason_code = Keeper_internal_error.incomplete_tool_transcript_kind
+      }
+  in
+  check
+    "transcript corruption requires operator reset"
+    (transcript_corruption
+     = (R.Disp_operator_reset_required, R.Reason_transcript_corruption));
+  check
+    "transcript corruption emits operator broadcast"
+    (R.needs_operator_broadcast (fst transcript_corruption))
 ;;
 
 let () =
@@ -307,6 +325,36 @@ let () =
   check
     "runtime completion ignores missing visible-output observation"
     (disposition = R.Disp_pass)
+;;
+
+let () =
+  with_temp_dir "transcript-corruption-pause" (fun base_path ->
+    let config = Workspace.default_config base_path in
+    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let meta =
+      meta_fixture_exn
+        (`Assoc
+          [ "name", `String "corrupted-transcript"
+          ; "agent_name", `String "agent-corrupted-transcript"
+          ; "trace_id", `String "trace-corrupted-transcript"
+          ])
+    in
+    write_meta_exn config meta;
+    (match
+       KMS.persist_transcript_corruption_pause
+         config
+         ~keeper_name:meta.name
+     with
+     | Ok `Persisted -> ()
+     | Ok `No_durable_meta ->
+       check "transcript corruption pause found durable meta" false
+     | Error error ->
+       check ("transcript corruption pause persisted: " ^ error) false);
+    let paused = read_meta_exn config meta.name in
+    check "transcript corruption pauses durable keeper" paused.paused;
+    check
+      "transcript corruption uses existing unclassified pause surface"
+      (Option.is_none paused.latched_reason))
 ;;
 
 let () =
@@ -375,6 +423,7 @@ let operator_disposition_kinds =
   ; R.Disp_pass_next_model
   ; R.Disp_user_cancelled
   ; R.Disp_skipped
+  ; R.Disp_operator_reset_required
   ; R.Disp_unknown
   ]
 ;;

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -353,8 +353,19 @@ let () =
     let paused = read_meta_exn config meta.name in
     check "transcript corruption pauses durable keeper" paused.paused;
     check
-      "transcript corruption uses existing unclassified pause surface"
-      (Option.is_none paused.latched_reason))
+      "transcript corruption persists typed reset-required latch"
+      (match paused.latched_reason with
+       | Some Keeper_latched_reason.Transcript_corruption_reset_required -> true
+       | Some
+           ( Keeper_latched_reason.Operator_paused _
+           | Keeper_latched_reason.Dead_tombstone )
+       | None ->
+         false);
+    let generic_resume = Keeper_meta_contract.mark_resumed paused in
+    check
+      "generic resume cannot clear transcript reset-required latch"
+      (generic_resume.paused
+       && generic_resume.latched_reason = paused.latched_reason))
 ;;
 
 let () =

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -329,8 +329,8 @@ let () =
 
 let () =
   with_temp_dir "transcript-corruption-pause" (fun base_path ->
-    let config = Workspace.default_config base_path in
-    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let config = Masc.Workspace.default_config base_path in
+    ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
     let meta =
       meta_fixture_exn
         (`Assoc
@@ -361,7 +361,7 @@ let () =
            | Keeper_latched_reason.Dead_tombstone )
        | None ->
          false);
-    let generic_resume = Keeper_meta_contract.mark_resumed paused in
+    let generic_resume = KMC.mark_resumed paused in
     check
       "generic resume cannot clear transcript reset-required latch"
       (generic_resume.paused


### PR DESCRIPTION
## Summary
- hard-cut transcript corruption from the automatic retry surface
- persist the existing fail-closed keeper pause on the first typed admission rejection, including unleased proactive cycles
- terminally settle an owning lease as `Transcript_corruption_requires_reset` with no successor
- emit `operator_reset_required` / `transcript_corruption` receipts instead of `unknown` / `unmapped_runtime_state`
- delete the obsolete quarantine retry counter, threshold, API, wire decoder, and retry tests

## Boundary
- MASC validates transcript structure before provider dispatch
- no provider/model/tier/Pricing policy added
- no legacy JSON migration or compatibility decoder added
- old runtime JSON is intentionally disposable before launch

## Validation
- `ocamlformat -i` on touched OCaml files
- local build/tests not run per operator instruction; CI is the build authority