### PR TITLE
refactor(keeper): hard-cut pre-1.0 event queue compatibility

### DIFF
--- a/dashboard/src/api/keeper-bulk.test.ts
+++ b/dashboard/src/api/keeper-bulk.test.ts
@@ -52,12 +52,12 @@ describe('bulkKeeperDirective', () => {
       targets: [
         {
           name: 'rondo',
-          owner_generation: 3,
+          owner_nonce: 3,
           operator_operation_id: 'resume-rondo-1',
         },
         {
           name: 'qa-king',
-          owner_generation: 5,
+          owner_nonce: 5,
           operator_operation_id: 'resume-qa-1',
         },
       ],

--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -308,7 +308,7 @@ export async function resumeKeeper(
     `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
     {
       action: 'resume',
-      owner_generation: intent.ownerGeneration,
+      owner_nonce: intent.ownerGeneration,
       operator_operation_id: intent.operatorOperationId,
     },
     `Failed to resume ${name}`,
@@ -404,7 +404,7 @@ export async function bulkKeeperDirective(
         action,
         targets: resumeIntents.map(({ name, intent }) => ({
           name,
-          owner_generation: intent.ownerGeneration,
+          owner_nonce: intent.ownerGeneration,
           operator_operation_id: intent.operatorOperationId,
         })),
       }

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1312,7 +1312,7 @@ describe('keeper lifecycle', () => {
     expect(url).toBe('/api/v1/keepers/janitor/directive')
     expect(JSON.parse(init.body)).toEqual({
       action: 'resume',
-      owner_generation: 7,
+      owner_nonce: 7,
       operator_operation_id: 'dashboard-resume-test-1',
     })
   })

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -103,7 +103,7 @@ describe('keeperActionVisibility', () => {
   })
 
   describe('paused keeper whose fiber died (keepalive_running=false)', () => {
-    it('exposes boot instead of resume — resume needs a live owner_generation', () => {
+    it('exposes boot instead of resume — resume needs a live owner nonce', () => {
       const k = makeKeeper({ status: 'active', phase: 'Paused', paused: true, keepalive_running: false })
       const v = keeperActionVisibility(k)
       expect(v.canResume).toBe(false)

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -7,7 +7,7 @@
 // Actions available per keeper:
 //   pause     → POST /api/v1/keepers/:name/directive  { action: "pause" }
 //   resume    → POST /api/v1/keepers/:name/directive
-//               { action: "resume", owner_generation, operator_operation_id }
+//               { action: "resume", owner_nonce, operator_operation_id }
 //   wakeup    → POST /api/v1/keepers/:name/directive  { action: "wakeup" }
 //   boot      → POST /api/v1/keepers/:name/boot
 //   shutdown  → POST /api/v1/keepers/:name/shutdown

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -176,7 +176,7 @@ export function keeperActionVisibility(keeper: Keeper): KeeperActionVisibility {
   const isRunning = isKeeperRunningExcludingRestarting(keeper)
   // A paused directive can outlive its process: the persisted `paused` flag
   // stays set after the keeper fiber dies, but only a live fiber can be
-  // resumed — resume needs a live owner_generation as its fencing token, and
+  // resumed — resume needs a live owner nonce as its fencing token, and
   // a dead keeper has none. Treat paused-but-not-live as needing boot, so
   // the boot verb surfaces for a dead paused keeper and resume stays hidden
   // instead of returning "current owner generation is unavailable".

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -365,8 +365,7 @@ let heartbeat_event_intake
         match Keeper_registry_event_queue.lease_kind lease, stimuli with
         | Keeper_event_queue_persistence.Board_batch, batch ->
           consume_board_stimulus_batch ~meta_after_triage batch
-        | ( Keeper_event_queue_persistence.Single
-          | Keeper_event_queue_persistence.Legacy_inflight ), stimuli ->
+        | Keeper_event_queue_persistence.Single, stimuli ->
           List.concat_map
             (consume_single_heartbeat_stimulus ~ctx ~meta_after_triage)
             stimuli

--- a/lib/keeper/keeper_paused_work_operator_request.ml
+++ b/lib/keeper/keeper_paused_work_operator_request.ml
@@ -225,27 +225,9 @@ let parse_source_terminal = function
   | _ -> Error "settle_from_source_terminal request fields are not exact"
 ;;
 
-(* Wire-compat (#25599): pre-rename clients send the fencing counter as
-   ["owner_generation"]. During the deprecation window both keys are accepted;
-   the new ["owner_nonce"] key wins when a request carries both. Normalising to
-   the new key keeps the exact-field parsers below as the single authority on
-   request shape. *)
-let normalize_legacy_owner_generation_key fields =
-  if List.mem_assoc "owner_nonce" fields
-  then
-    List.filter
-      (fun (name, _) -> not (String.equal name "owner_generation"))
-      fields
-  else
-    List.map
-      (fun (name, value) ->
-        if String.equal name "owner_generation" then "owner_nonce", value else name, value)
-      fields
-;;
-
 let of_yojson = function
   | `Assoc fields ->
-    let fields = sorted (normalize_legacy_owner_generation_key fields) in
+    let fields = sorted fields in
     (match List.assoc_opt "operation" fields, List.assoc_opt "source_state" fields with
      | Some (`String "resume_owner"), _ -> parse_resume fields
      | Some (`String "cancel_accepted"), Some (`String "pending") ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -4,7 +4,6 @@ module State = Keeper_event_queue_state
 type lease_kind = State.lease_kind =
   | Single
   | Board_batch
-  | Legacy_inflight
 
 type requeue_reason = State.requeue_reason =
   | Cycle_busy
@@ -375,26 +374,9 @@ let settlement_wal_entry_to_line owner entry =
   |> fun row -> row ^ "\n"
 ;;
 
-type settlement_wal_transition =
-  | Legacy_receipt of transition_receipt
-  | Source_entry of outbox_entry
-
-let settlement_wal_transition_of_json owner = function
+let settlement_wal_entry_of_json owner = function
   | `Assoc fields ->
     (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
-     | [ ("base_path", `String base_path)
-       ; ("keeper_name", `String keeper_name)
-       ; ("receipt", receipt)
-       ; ("schema", `String schema)
-       ] ->
-       if not (String.equal schema "masc.keeper_event_queue.settlement.v1")
-       then Error (Printf.sprintf "unsupported settlement WAL schema: %s" schema)
-       else if
-         not
-           (String.equal base_path (Owner_lock.base_path owner)
-            && String.equal keeper_name (keeper_name_of_owner owner))
-       then Error "settlement WAL row owner does not match its Keeper lane"
-       else State.transition_receipt_of_yojson receipt |> Result.map (fun receipt -> Legacy_receipt receipt)
      | [ ("base_path", `String base_path)
        ; ("keeper_name", `String keeper_name)
        ; ("outbox_entry", entry)
@@ -407,7 +389,7 @@ let settlement_wal_transition_of_json owner = function
            (String.equal base_path (Owner_lock.base_path owner)
             && String.equal keeper_name (keeper_name_of_owner owner))
        then Error "settlement WAL row owner does not match its Keeper lane"
-       else State.outbox_entry_of_yojson entry |> Result.map (fun entry -> Source_entry entry)
+       else State.outbox_entry_of_yojson entry
      | _ -> Error "settlement WAL row fields are not exact")
   | _ -> Error "settlement WAL row must be a JSON object"
 ;;
@@ -423,13 +405,9 @@ let replay_settlement_wal_bytes owner state bytes =
        with
        | Error detail -> Error ("invalid settlement WAL JSON: " ^ detail)
        | Ok json ->
-         (match settlement_wal_transition_of_json owner json with
+         (match settlement_wal_entry_of_json owner json with
           | Error _ as error -> error
-          | Ok (Legacy_receipt receipt) ->
-            (match State.replay_transition_receipt receipt state with
-             | Error _ as error -> error
-             | Ok state -> replay state rest)
-          | Ok (Source_entry entry) ->
+          | Ok entry ->
             (match State.replay_transition_outbox_entry entry state with
              | Error _ as error -> error
              | Ok state -> replay state rest)))
@@ -1337,42 +1315,6 @@ let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =
        match State.mark_transition_projected ~transition_id state with
        | Error _ as error -> error
        | Ok state -> Ok (state, ()))
-;;
-
-let record_inflight ~base_path ~keeper_name stimuli =
-  match stimuli with
-  | [] -> ()
-  | _ ->
-    (match
-       commit_transform
-         ~base_path
-         ~keeper_name
-         ~after_commit:(fun _ -> ())
-         (fun state ->
-            match State.add_legacy_inflight stimuli state with
-            | Error _ as error -> error
-            | Ok (state, _lease) -> Ok (state, ()))
-     with
-     | Ok () -> ()
-     | Error message ->
-       Log.Keeper.error
-         "event_queue_snapshot: record legacy inflight failed keeper=%s: %s"
-         keeper_name
-         message)
-;;
-
-let ack_inflight ~base_path ~keeper_name stimuli =
-  match
-    commit_transform
-      ~base_path
-      ~keeper_name
-      ~after_commit:(fun _ -> ())
-      (fun state ->
-         Ok (State.release_legacy_inflight stimuli state, ()))
-  with
-  | Ok () -> ()
-  | Error message ->
-    Log.Keeper.error "event_queue_snapshot: ack_inflight failed keeper=%s: %s" keeper_name message
 ;;
 
 let remove_post_ids stimuli state =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -400,10 +400,7 @@ let settlement_wal_entry_of_json owner = function
     (match List.assoc_opt "schema" fields with
      | Some (`String schema)
        when not (String.equal schema "masc.keeper_event_queue.settlement.v2") ->
-       Error
-         (Printf.sprintf
-            "unsupported settlement WAL schema (reset required): %s"
-            schema)
+       Error (Printf.sprintf "unsupported settlement WAL schema: %s" schema)
      | _ ->
        (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
         | [ ("base_path", `String base_path)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -299,14 +299,25 @@ let snapshot_read_error_kind_to_string = function
   | Parse_failed -> "parse_failed"
 ;;
 
+let reset_required_message ~path ~surface detail =
+  Printf.sprintf "%s at %s is incompatible (reset required): %s" surface path detail
+;;
+
 let read_json_if_present path =
   try
     if Sys.file_exists path
     then
-      (match Safe_ops.read_json_file_safe path with
-       | Ok json -> Ok (Some json)
+      (match Safe_ops.read_file_safe path with
        | Error message ->
-         Error (Printf.sprintf "failed to read %s: %s" path message))
+         Error (Printf.sprintf "failed to read %s: %s" path message)
+       | Ok bytes ->
+         (try Ok (Some (Yojson.Safe.from_string bytes)) with
+          | Yojson.Json_error detail ->
+            Error
+              (reset_required_message
+                 ~path
+                 ~surface:"event queue snapshot"
+                 ("invalid JSON: " ^ detail))))
     else Ok None
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -334,11 +345,21 @@ let read_primary_unlocked owner =
   | Ok None -> Ok Primary_missing
   | Ok (Some json) ->
     (match schema_field json with
-     | Error message -> Error (Printf.sprintf "%s: %s" path message)
+     | Error message ->
+       Error
+         (reset_required_message
+            ~path
+            ~surface:"event queue snapshot"
+            message)
      | Ok _ ->
        (match State.of_yojson json with
         | Ok state -> Ok (Primary_current state)
-        | Error message -> Error (Printf.sprintf "%s: %s" path message)))
+        | Error message ->
+          Error
+            (reset_required_message
+               ~path
+               ~surface:"event queue snapshot"
+               message)))
 ;;
 
 let reject_unsupported_inflight owner =
@@ -376,21 +397,27 @@ let settlement_wal_entry_to_line owner entry =
 
 let settlement_wal_entry_of_json owner = function
   | `Assoc fields ->
-    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
-     | [ ("base_path", `String base_path)
-       ; ("keeper_name", `String keeper_name)
-       ; ("outbox_entry", entry)
-       ; ("schema", `String schema)
-       ] ->
-       if not (String.equal schema "masc.keeper_event_queue.settlement.v2")
-       then Error (Printf.sprintf "unsupported settlement WAL schema: %s" schema)
-       else if
-         not
-           (String.equal base_path (Owner_lock.base_path owner)
-            && String.equal keeper_name (keeper_name_of_owner owner))
-       then Error "settlement WAL row owner does not match its Keeper lane"
-       else State.outbox_entry_of_yojson entry
-     | _ -> Error "settlement WAL row fields are not exact")
+    (match List.assoc_opt "schema" fields with
+     | Some (`String schema)
+       when not (String.equal schema "masc.keeper_event_queue.settlement.v2") ->
+       Error
+         (Printf.sprintf
+            "unsupported settlement WAL schema (reset required): %s"
+            schema)
+     | _ ->
+       (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+        | [ ("base_path", `String base_path)
+          ; ("keeper_name", `String keeper_name)
+          ; ("outbox_entry", entry)
+          ; ("schema", `String "masc.keeper_event_queue.settlement.v2")
+          ] ->
+          if
+            not
+              (String.equal base_path (Owner_lock.base_path owner)
+               && String.equal keeper_name (keeper_name_of_owner owner))
+          then Error "settlement WAL row owner does not match its Keeper lane"
+          else State.outbox_entry_of_yojson entry
+        | _ -> Error "settlement WAL row fields are not exact"))
   | _ -> Error "settlement WAL row must be a JSON object"
 ;;
 
@@ -421,10 +448,14 @@ let replay_settlement_wal_unlocked owner state =
     match slice.Fs_compat.Private_jsonl_slice.bytes with
     | "" -> Ok state
     | bytes ->
-      (match replay_settlement_wal_bytes owner state bytes with
-       | Error detail ->
-         Error (Printf.sprintf "failed to replay %s: %s" path detail)
-       | Ok replayed ->
+       (match replay_settlement_wal_bytes owner state bytes with
+        | Error detail ->
+          Error
+            (reset_required_message
+               ~path
+               ~surface:"settlement WAL"
+               detail)
+        | Ok replayed ->
          (match bump_revision replayed with
           | Error _ as error -> error
           | Ok replayed ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,15 +1,14 @@
 (** Durable per-Keeper Event Layer state.
 
-    [event-queue.json] keeps the v4 envelope containing pending stimuli, active
+    [event-queue.json] keeps the current v4 envelope containing pending stimuli, active
     typed leases, exact-execution dispatch fences, the monotonic lease
-    sequence, transition outbox, and durable accepted-transfer target accounting. Strict v3 is the only supported
-    predecessor. [event-queue-inflight.json] is rejected explicitly rather
-    than migrated or treated as a second authority. *)
+    sequence, transition outbox, and durable accepted-transfer target accounting.
+    Stale schemas and [event-queue-inflight.json] fail closed rather than being
+    migrated or treated as a second authority. *)
 
 type lease_kind = Keeper_event_queue_state.lease_kind =
   | Single
   | Board_batch
-  | Legacy_inflight
 
 type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Cycle_busy
@@ -443,14 +442,6 @@ val project_accepted_transfer_result :
 
 val persist_snapshot :
   base_path:string -> keeper_name:string -> (unit -> Keeper_event_queue.t) -> unit
-
-val record_inflight :
-  base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
-(** Legacy source/test adapter. Writes a typed [Legacy_inflight] lease into the
-    v4 envelope; it never creates [event-queue-inflight.json]. *)
-
-val ack_inflight :
-  base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
 
 val ack_consumed :
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -2734,11 +2734,7 @@ let of_yojson json =
   let* fields = assoc_fields ~context json in
   let* schema_value = string_field ~context "schema" fields in
   if not (String.equal schema_value schema)
-  then
-    Error
-      (Printf.sprintf
-         "unsupported keeper event queue state schema (reset required): %s"
-         schema_value)
+  then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
   else
     let expected_fields =
       [ "schema"

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -1,7 +1,6 @@
 type lease_kind =
   | Single
   | Board_batch
-  | Legacy_inflight
 
 type requeue_reason =
   | Cycle_busy
@@ -210,7 +209,6 @@ type transfer_projection_result =
   | Transfer_already_projected
 
 let schema = "keeper.event_queue.state.v4"
-let predecessor_schema = "keeper.event_queue.state.v3"
 
 let empty =
   { revision = 0L
@@ -342,18 +340,6 @@ let append_missing stimuli queue =
     stimuli
 ;;
 
-let remove_stimuli queue stimuli =
-  let should_remove stimulus =
-    List.exists
-      (Keeper_event_queue.stimulus_identity_equal stimulus)
-      stimuli
-  in
-  queue
-  |> Keeper_event_queue.to_list
-  |> List.filter (fun stimulus -> not (should_remove stimulus))
-  |> List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty
-;;
-
 let lease_id_of_sequence sequence = Printf.sprintf "lease:%Ld" sequence
 
 let make_lease ~kind ~claimed_at stimuli state =
@@ -408,25 +394,14 @@ let claim_board ~claimed_at state =
     make_lease ~kind:Board_batch ~claimed_at:(Some claimed_at) stimuli { state with pending })
 ;;
 
-let add_legacy_inflight stimuli state =
-  if lease_admission_blocked state
-  then Error "event queue cannot migrate legacy inflight work while a lease or outbox exists"
-  else (
-    let stimuli = Keeper_event_queue.uniq_stimuli stimuli in
-    let pending = remove_stimuli state.pending stimuli in
-    make_lease ~kind:Legacy_inflight ~claimed_at:None stimuli { state with pending })
-;;
-
 let lease_kind_label = function
   | Single -> "single"
   | Board_batch -> "board_batch"
-  | Legacy_inflight -> "legacy_inflight"
 ;;
 
 let lease_kind_of_label = function
   | "single" -> Ok Single
   | "board_batch" -> Ok Board_batch
-  | "legacy_inflight" -> Ok Legacy_inflight
   | label -> Error (Printf.sprintf "unknown event queue lease kind: %s" label)
 ;;
 
@@ -1977,29 +1952,6 @@ let remove_by_post_id post_id state =
   , { state with pending; leases } )
 ;;
 
-let release_legacy_inflight stimuli state =
-  let should_release stimulus =
-    List.exists
-      (Keeper_event_queue.stimulus_identity_equal stimulus)
-      stimuli
-  in
-  let leases =
-    List.filter_map
-      (fun (lease : lease) ->
-         match binding_for_lease lease state with
-         | Some _ -> Some lease
-         | None ->
-           let remaining =
-             List.filter (fun stimulus -> not (should_release stimulus)) lease.stimuli
-           in
-           (match remaining with
-            | [] -> None
-            | _ :: _ -> Some { lease with stimuli = remaining }))
-      state.leases
-  in
-  { state with leases }
-;;
-
 let assoc_fields ~context = function
   | `Assoc fields -> Ok fields
   | _ -> Error (context ^ " must be a JSON object")
@@ -2044,29 +1996,6 @@ let int_field ~context name fields =
   match value with
   | `Int value -> Ok value
   | _ -> Error (Printf.sprintf "%s.%s must be an int" context name)
-;;
-
-(* Wire-compat (#25599): pre-rename persisted rows (snapshot "last_settlement",
-   "transition_outbox", "accepted_transfer_projections" and every settlement
-   WAL entry) carry the fencing counter under ["owner_generation"]; post-rename
-   rows use ["owner_nonce"]. Read both — the new key wins when a row carries
-   both — so replay of pre-rename state survives the rename boundary. The
-   writer keeps emitting only ["owner_nonce"]. *)
-let owner_nonce_field ~context fields =
-  let parse name = function
-    | `Int value -> Ok value
-    | _ -> Error (Printf.sprintf "%s.%s must be an int" context name)
-  in
-  match List.assoc_opt "owner_nonce" fields with
-  | Some value -> parse "owner_nonce" value
-  | None ->
-    (match List.assoc_opt "owner_generation" fields with
-     | Some value -> parse "owner_generation" value
-     | None ->
-       Error
-         (Printf.sprintf
-            "%s missing required field owner_nonce (or legacy owner_generation)"
-            context))
 ;;
 
 let int64_field ~context name fields =
@@ -2349,7 +2278,6 @@ let settlement_of_yojson json =
           ; "source"
           ; "source_revision"
           ; "owner_nonce"
-          ; "owner_generation"
           ; "operator_operation_id"
           ; "reason"
           ]
@@ -2358,7 +2286,7 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
     let* source_revision = int64_field ~context "source_revision" fields in
-    let* owner_nonce = owner_nonce_field ~context fields in
+    let* owner_nonce = int_field ~context "owner_nonce" fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in
@@ -2377,7 +2305,6 @@ let settlement_of_yojson json =
           ; "source"
           ; "source_revision"
           ; "owner_nonce"
-          ; "owner_generation"
           ; "operator_operation_id"
           ; "from_keeper"
           ; "to_keeper"
@@ -2387,7 +2314,7 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
     let* source_revision = int64_field ~context "source_revision" fields in
-    let* owner_nonce = owner_nonce_field ~context fields in
+    let* owner_nonce = int_field ~context "owner_nonce" fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in
@@ -2413,7 +2340,6 @@ let settlement_of_yojson json =
           ; "source"
           ; "source_revision"
           ; "owner_nonce"
-          ; "owner_generation"
           ; "operator_operation_id"
           ; "source_receipt_kind"
           ]
@@ -2422,7 +2348,7 @@ let settlement_of_yojson json =
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
     let* source_revision = int64_field ~context "source_revision" fields in
-    let* owner_nonce = owner_nonce_field ~context fields in
+    let* owner_nonce = int_field ~context "owner_nonce" fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in
@@ -2807,15 +2733,13 @@ let of_yojson json =
   let context = "keeper event queue state" in
   let* fields = assoc_fields ~context json in
   let* schema_value = string_field ~context "schema" fields in
-  if
-    not
-      (String.equal schema_value schema
-       || String.equal schema_value predecessor_schema)
-  then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
+  if not (String.equal schema_value schema)
+  then
+    Error
+      (Printf.sprintf
+         "unsupported keeper event queue state schema (reset required): %s"
+         schema_value)
   else
-    let has_exact_execution_bindings =
-      String.equal schema_value schema && List.mem_assoc "exact_execution_bindings" fields
-    in
     let expected_fields =
       [ "schema"
       ; "revision"
@@ -2824,11 +2748,9 @@ let of_yojson json =
       ; "leases"
       ; "last_settlement"
       ; "transition_outbox"
+      ; "accepted_transfer_projections"
+      ; "exact_execution_bindings"
       ]
-      @ (if String.equal schema_value schema
-         then [ "accepted_transfer_projections" ]
-         else [])
-      @ (if has_exact_execution_bindings then [ "exact_execution_bindings" ] else [])
     in
     let* () = exact_fields ~context ~expected:expected_fields fields in
     let* revision = int64_field ~context "revision" fields in
@@ -2846,37 +2768,18 @@ let of_yojson json =
       list_field ~context "transition_outbox" outbox_entry_of_yojson fields
     in
     let* accepted_transfer_projections =
-      if String.equal schema_value predecessor_schema
-      then Ok []
-      else
-        list_field
-          ~context
-          "accepted_transfer_projections"
-          accepted_transfer_projection_of_yojson
-          fields
-    in
-    let* () =
-      if has_exact_execution_bindings || leases = []
-      then Ok ()
-      else
-        Error
-          "legacy keeper event queue state with active leases cannot be upgraded without exact execution bindings"
+      list_field
+        ~context
+        "accepted_transfer_projections"
+        accepted_transfer_projection_of_yojson
+        fields
     in
     let* exact_execution_bindings =
-      if has_exact_execution_bindings
-      then
-        list_field
-          ~context
-          "exact_execution_bindings"
-          exact_execution_binding_of_yojson
-          fields
-      else
-        match leases with
-        | [] -> Ok []
-        | _ :: _ ->
-          Error
-            "legacy keeper event queue state has active leases without exact \
-             execution bindings; refusing replay-unsafe promotion"
+      list_field
+        ~context
+        "exact_execution_bindings"
+        exact_execution_binding_of_yojson
+        fields
     in
     validate_state
       { revision

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -8,7 +8,6 @@
 type lease_kind =
   | Single
   | Board_batch
-  | Legacy_inflight
 
 type requeue_reason =
   | Cycle_busy
@@ -252,11 +251,6 @@ val claim_when :
 val claim_board : claimed_at:float -> t -> (t * lease option, string) result
 (** Lease every pending board stimulus as one ordered digest. *)
 
-val add_legacy_inflight :
-  Keeper_event_queue.stimulus list -> t -> (t * lease option, string) result
-(** Migration/test compatibility boundary.  Adds one lease for legacy
-    [event-queue-inflight.json] rows and removes matching pending identities. *)
-
 val settle :
   settled_at:float ->
   lease:lease ->
@@ -427,12 +421,6 @@ val mark_transition_projected : transition_id:string -> t -> (t, string) result
 val remove_by_post_id :
   Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t
 
-val release_legacy_inflight :
-  Keeper_event_queue.stimulus list -> t -> t
-(** Compatibility-only projection for the retired split-file API.  Removes
-    matching identities from active leases while leaving pending untouched.
-    New runtime code must settle the opaque lease instead. *)
-
 val lease_to_yojson : lease -> Yojson.Safe.t
 val lease_of_yojson : Yojson.Safe.t -> (lease, string) result
 val transition_receipt_equal : transition_receipt -> transition_receipt -> bool
@@ -448,5 +436,5 @@ val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
 val schema : string
-(** ["keeper.event_queue.state.v4"]. Strict v3 snapshots are read as the sole
-    supported predecessor and upgraded on their next durable mutation. *)
+(** ["keeper.event_queue.state.v4"]. Only this current schema is accepted.
+    Stale or unknown persisted state fails closed and requires a runtime reset. *)

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -884,27 +884,16 @@ type parsed_bulk_directive =
       }
   | Bulk_resume_owner of bulk_resume_target list
 
-let resume_owner_nonce json =
-  (* Wire-compat (#25599): pre-rename dashboard/operator clients send the
-     fencing counter as ["owner_generation"]. During the deprecation window
-     both keys are accepted; the new ["owner_nonce"] key wins when a request
-     carries both. *)
-  match Safe_ops.json_int_opt "owner_nonce" json with
-  | Some _ as nonce -> nonce
-  | None -> Safe_ops.json_int_opt "owner_generation" json
-
 let required_resume_owner_request json =
   match
-    resume_owner_nonce json,
+    Safe_ops.json_int_opt "owner_nonce" json,
     Safe_ops.json_string_opt "operator_operation_id" json
   with
   | Some owner_nonce, Some operator_operation_id ->
     Ok
       Keeper_paused_work_resume_transaction.
         { owner_nonce; operator_operation_id }
-  | None, _ ->
-    Error
-      "resume requires integer \"owner_nonce\" (or legacy \"owner_generation\")"
+  | None, _ -> Error "resume requires integer \"owner_nonce\""
   | _, None -> Error "resume requires string \"operator_operation_id\""
 
 let parse_keeper_directive_json json =

--- a/scripts/harness/perf/paused_work_disposition_soak.sh
+++ b/scripts/harness/perf/paused_work_disposition_soak.sh
@@ -403,7 +403,7 @@ resume_cleanup() {
   local keeper="$1" generation="$2" operation_id="$3" request
   request="$(jq -cn --arg schema "$REQUEST_SCHEMA" --arg op "$operation_id" \
     --argjson generation "$generation" \
-    '{schema:$schema,operation:"resume_owner",owner_generation:$generation,operator_operation_id:$op}')"
+    '{schema:$schema,operation:"resume_owner",owner_nonce:$generation,operator_operation_id:$op}')"
   post_disposition "$keeper" "$request" "cleanup resume $keeper"
   jq -e '.ok == true and .operation == "resume_owner"' <<<"$HTTP_LAST_BODY" >/dev/null ||
     die "cleanup resume projection incomplete for $keeper: $HTTP_LAST_BODY"
@@ -461,7 +461,7 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
     resume)
       request="$(jq -cn --arg schema "$REQUEST_SCHEMA" --arg op "$operation_id" \
         --argjson generation "$source_generation" \
-        '{schema:$schema,operation:"resume_owner",owner_generation:$generation,operator_operation_id:$op}')"
+        '{schema:$schema,operation:"resume_owner",owner_nonce:$generation,operator_operation_id:$op}')"
       RESUME_CASES=$((RESUME_CASES + 1))
       ;;
     transfer)
@@ -470,7 +470,7 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
         --argjson generation "$source_generation" --argjson target_generation "$target_generation" \
         --arg target "$target_keeper" --argjson binding "$binding" --argjson settled_at "$settled_at" \
         '{schema:$schema,operation:"transfer_owner",source:$source,source_revision:$revision,
-          owner_generation:$generation,target_generation:$target_generation,to_keeper:$target,
+          owner_nonce:$generation,target_generation:$target_generation,to_keeper:$target,
           continuation_binding:$binding,operator_operation_id:$op,settled_at:$settled_at}')"
       target_queue_path="$(queue_path "$target_keeper")"
       if [[ -f "$target_queue_path" ]]; then
@@ -487,7 +487,7 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
         --argjson source "$source" --arg revision "$source_revision" \
         --argjson generation "$source_generation" --argjson settled_at "$settled_at" \
         '{schema:$schema,operation:"cancel_accepted",source_state:"pending",source:$source,
-          source_revision:$revision,owner_generation:$generation,operator_operation_id:$op,
+          source_revision:$revision,owner_nonce:$generation,operator_operation_id:$op,
           reason:"paused-work soak accepted cancellation",settled_at:$settled_at}')"
       CANCEL_CASES=$((CANCEL_CASES + 1))
       ;;
@@ -558,12 +558,12 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
     --argjson iteration "$ITERATIONS" --arg action "$action" --arg source_keeper "$source_keeper" \
     --arg target_keeper "$( [[ "$action" == "transfer" ]] && printf '%s' "$target_keeper" || printf '')" \
     --arg post_id "$post_id" --arg operation_id "$operation_id" --argjson source "$source" \
-    --argjson source_revision "$source_revision" --argjson owner_generation "$source_generation" \
+    --argjson source_revision "$source_revision" --argjson owner_nonce "$source_generation" \
     --argjson restarted "$restarted" --argjson receipt "$first_receipt" \
     '{schema:$schema,run_id:$run_id,iteration:$iteration,action:$action,
       source_keeper:$source_keeper,target_keeper:(if $target_keeper == "" then null else $target_keeper end),
       post_id:$post_id,operation_id:$operation_id,source:$source,source_revision:$source_revision,
-      owner_generation:$owner_generation,restarted:$restarted,receipt:$receipt,
+      owner_nonce:$owner_nonce,restarted:$restarted,receipt:$receipt,
       duplicate_terminal_effects:0,silent_losses:0}' >>"$LEDGER_FILE"
 
   if [[ "$action" != "resume" ]]; then

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -784,36 +784,9 @@ let () =
       assert (String.equal only.post_id "bootstrap");
       assert (is_empty rest));
 
-  (* --- durable in-flight store: ack removes only consumed stimuli --- *)
-  let base_path = temp_dir "keeper-event-queue-inflight-partial-ack" in
-  Fun.protect
-    ~finally:(fun () -> rm_rf base_path)
-    (fun () ->
-      let keeper_name = "keeper-event-queue-inflight-partial-ack-test" in
-      Keeper_event_queue_persistence.record_inflight
-        ~base_path
-        ~keeper_name
-        [ board_stim; bootstrap_stim ];
-      Keeper_event_queue_persistence.ack_inflight
-        ~base_path
-        ~keeper_name
-        [ board_stim ];
-      let restored = Keeper_event_queue_persistence.load ~base_path ~keeper_name in
-      assert (length restored = 1);
-      let remaining, rest =
-        match dequeue restored with
-        | Some item -> item
-        | None -> Alcotest.fail "partial ack should leave unrelated in-flight stimulus"
-      in
-      assert (String.equal remaining.post_id "bootstrap");
-      assert (is_empty rest));
-
   (* --- A-fix (RFC: keeper-orphan-stimulus-persistence): a consumed stimulus
-         is drained from pending and inflight snapshots on the genuine-ack path.
-         [ack_inflight] clears the inflight file only (it is shared with
-         [requeue_front], which must leave the requeued stimulus in pending -
-         covered by the requeue-front test below). Here the stimulus lives in
-         the pending snapshot (event-queue.json), mirroring a bootstrap enqueued
+         is drained from the current queue state on the genuine-ack path. Here
+         the stimulus lives in event-queue.json, mirroring a bootstrap enqueued
          by supervisor launch; after ack, [load] must be empty. Without the
          A-fix this returns length 1 and accumulates across restarts. --- *)
   let base_path = temp_dir "keeper-event-queue-ack-drains-pending" in
@@ -854,10 +827,17 @@ let () =
         |> fun q -> enqueue q board_stim
       in
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name pending;
-      Keeper_event_queue_persistence.record_inflight
-        ~base_path
-        ~keeper_name
-        [ board_stim; bootstrap_stim ];
+      (match
+         Keeper_event_queue_persistence.claim_when_result
+           ~base_path
+           ~keeper_name
+           ~claimed_at:3.0
+           ~ready:(fun stimulus -> stimulus_identity_equal stimulus board_stim)
+           ()
+       with
+       | Ok (Some _) -> ()
+       | Ok None -> Alcotest.fail "current queue fixture did not claim board stimulus"
+       | Error detail -> Alcotest.fail detail);
       (match
          Keeper_event_queue_persistence.ack_consumed
            ~base_path
@@ -894,10 +874,21 @@ let () =
         ~base_path
         ~keeper_name:pending_keeper
         (empty |> fun q -> enqueue q old_pending |> fun q -> enqueue q newer_pending);
-      Keeper_event_queue_persistence.record_inflight
+      Keeper_event_queue_persistence.persist
         ~base_path
         ~keeper_name:inflight_keeper
-        [ inflight ];
+        (enqueue empty inflight);
+      (match
+         Keeper_event_queue_persistence.claim_when_result
+           ~base_path
+           ~keeper_name:inflight_keeper
+           ~claimed_at:6.0
+           ~ready:(fun _ -> true)
+           ()
+       with
+       | Ok (Some _) -> ()
+       | Ok None -> Alcotest.fail "current queue fixture did not claim inflight stimulus"
+       | Error detail -> Alcotest.fail detail);
       let noise_keeper_dir =
         Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) "snapshotless"
       in

--- a/test/test_keeper_event_queue_owner_lock.ml
+++ b/test/test_keeper_event_queue_owner_lock.ml
@@ -307,8 +307,16 @@ let test_fleet_summary_serializes_with_owner_commit () =
     Persistence.persist
       ~base_path
       ~keeper_name
-      (Queue.enqueue Queue.empty pending);
-    Persistence.record_inflight ~base_path ~keeper_name [ inflight ];
+      (Queue.empty |> fun queue -> Queue.enqueue queue inflight |> fun queue -> Queue.enqueue queue pending);
+    ignore
+      (Persistence.claim_when_result
+         ~base_path
+         ~keeper_name
+         ~claimed_at:11.0
+         ~ready:(fun stimulus -> String.equal stimulus.Queue.post_id inflight.post_id)
+         ()
+       |> require_ok "claim current inflight summary fixture"
+       |> require_some "current inflight summary lease");
     let transform_entered = Atomic.make false in
     let release = Atomic.make false in
     let writer_result = ref None in

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2381,7 +2381,12 @@ let test_incompatible_settlement_wal_requires_reset_without_rewrite () =
         (keeper_dir ~base_path ~keeper_name)
         "event-queue-settlements.jsonl"
     in
-    let incompatible_wal_bytes = "{}\n" in
+    let incompatible_wal_schema = "masc.keeper_event_queue.settlement.incompatible" in
+    let incompatible_wal_bytes =
+      `Assoc [ "schema", `String incompatible_wal_schema ]
+      |> Yojson.Safe.to_string
+      |> fun row -> row ^ "\n"
+    in
     Fs_compat.save_file_atomic wal_path incompatible_wal_bytes
     |> require_ok "write incompatible WAL";
     (match Persistence.load_state_result ~base_path ~keeper_name with
@@ -2389,9 +2394,10 @@ let test_incompatible_settlement_wal_requires_reset_without_rewrite () =
        Alcotest.(check string)
          "incompatible WAL requires an explicit reset"
          (Printf.sprintf
-            "settlement WAL at %s is incompatible (reset required): settlement WAL row \
-             fields are not exact"
-            wal_path)
+            "settlement WAL at %s is incompatible (reset required): unsupported settlement \
+             WAL schema: %s"
+            wal_path
+            incompatible_wal_schema)
          message
      | Ok _ -> Alcotest.fail "incompatible settlement WAL was replayed");
     Alcotest.(check string)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2370,6 +2370,36 @@ let test_pending_cancellation_wal_replays_before_removal () =
     | Error detail -> Alcotest.failf "committed pending cancellation did not replay: %s" detail)
 ;;
 
+let test_incompatible_settlement_wal_requires_reset_without_rewrite () =
+  with_temp_dir "keeper-event-queue-incompatible-settlement-wal-hardcut" (fun base_path ->
+    let keeper_name = "incompatible_wal_hardcut_owner" in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending (stimulus "incompatible-wal-source" 1.0))
+    |> require_ok "seed current primary for incompatible WAL hard cut";
+    let wal_path =
+      Filename.concat
+        (keeper_dir ~base_path ~keeper_name)
+        "event-queue-settlements.jsonl"
+    in
+    let incompatible_wal_bytes = "{}\n" in
+    Fs_compat.save_file_atomic wal_path incompatible_wal_bytes
+    |> require_ok "write incompatible WAL";
+    (match Persistence.load_state_result ~base_path ~keeper_name with
+     | Error message ->
+       Alcotest.(check string)
+         "incompatible WAL requires an explicit reset"
+         (Printf.sprintf
+            "settlement WAL at %s is incompatible (reset required): settlement WAL row \
+             fields are not exact"
+            wal_path)
+         message
+     | Ok _ -> Alcotest.fail "incompatible settlement WAL was replayed");
+    Alcotest.(check string)
+      "hard cut does not rewrite incompatible WAL"
+      incompatible_wal_bytes
+      (Fs_compat.load_file wal_path))
+;;
+
 let test_context_compaction_retry_is_durable_and_lane_local () =
   with_temp_dir "keeper-event-queue-v2-retry-tail" (fun base_path ->
     let keeper_name = "retry_tail_keeper" in
@@ -2530,7 +2560,14 @@ let test_unsupported_snapshots_fail_closed () =
     write_queue primary (queue [ stimulus "old-schema" 3.0 ]);
     let unsupported_bytes = Fs_compat.load_file primary in
     (match Persistence.load_state_result ~base_path ~keeper_name with
-     | Error _ -> ()
+     | Error message ->
+       Alcotest.(check string)
+         "incompatible snapshot requires an explicit reset"
+         (Printf.sprintf
+            "event queue snapshot at %s is incompatible (reset required): snapshot missing \
+             required field schema"
+            primary)
+         message
      | Ok _ -> Alcotest.fail "old primary schema was migrated");
     Alcotest.(check string)
       "hard cut does not rewrite unsupported state"
@@ -2876,6 +2913,10 @@ let () =
             "pending cancellation WAL replays before removal"
             `Quick
             test_pending_cancellation_wal_replays_before_removal
+        ; Alcotest.test_case
+            "incompatible settlement WAL requires reset without rewrite"
+            `Quick
+            test_incompatible_settlement_wal_requires_reset_without_rewrite
         ; Alcotest.test_case
             "unsupported snapshots fail closed"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2370,241 +2370,6 @@ let test_pending_cancellation_wal_replays_before_removal () =
     | Error detail -> Alcotest.failf "committed pending cancellation did not replay: %s" detail)
 ;;
 
-let test_legacy_settlement_wal_v1_remains_replayable () =
-  with_temp_dir "keeper-event-queue-legacy-settlement-wal" (fun base_path ->
-    let keeper_name = "legacy_wal_owner" in
-    Persistence.update_result ~base_path ~keeper_name (fun pending ->
-      Queue.enqueue pending (stimulus "legacy-wal-source" 1.0))
-    |> require_ok "seed legacy WAL owner";
-    let lease =
-      Persistence.claim_when_result
-        ~base_path
-        ~keeper_name
-        ~claimed_at:2.0
-        ~ready:(fun _ -> true)
-        ()
-      |> require_ok "claim legacy WAL source"
-      |> require_some "legacy WAL lease"
-    in
-    let claimed =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "load legacy WAL pre-settlement state"
-    in
-    let receipt =
-      match
-        State.settle ~settled_at:3.0 ~lease ~settlement:State.Ack claimed
-        |> require_ok "construct legacy WAL receipt"
-      with
-      | _, State.Settled receipt -> receipt
-      | _, State.Already_settled _ -> Alcotest.fail "legacy WAL fixture replayed early"
-    in
-    let wal_path =
-      Filename.concat
-        (keeper_dir ~base_path ~keeper_name)
-        "event-queue-settlements.jsonl"
-    in
-    let row =
-      `Assoc
-        [ "schema", `String "masc.keeper_event_queue.settlement.v1"
-        ; "base_path", `String (Unix.realpath base_path)
-        ; "keeper_name", `String keeper_name
-        ; "receipt", State.transition_receipt_to_yojson receipt
-        ]
-      |> Yojson.Safe.to_string
-      |> fun row -> row ^ "\n"
-    in
-    Fs_compat.save_file_atomic wal_path row |> require_ok "write legacy WAL row";
-    let replayed =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "replay legacy WAL row"
-    in
-    Alcotest.(check int) "legacy WAL settles active lease" 0 (List.length (State.leases replayed));
-    Alcotest.(check int)
-      "legacy WAL recreates transition outbox"
-      1
-      (List.length (State.transition_outbox replayed));
-    Alcotest.(check string)
-      "legacy WAL is compacted after checkpoint"
-      ""
-      (Fs_compat.load_file wal_path))
-;;
-
-(* Regression (#25599): #25535 renamed the persisted fencing-counter wire key
-   ["owner_generation"] -> ["owner_nonce"] with no reader fallback, so replay
-   of any pre-rename snapshot / settlement WAL row carrying a source-bearing
-   settlement failed with "row fields are not exact". The reader must accept
-   the legacy key (new key wins when both are present) while the writer keeps
-   emitting only ["owner_nonce"]. *)
-let rec rename_owner_nonce_to_legacy = function
-  | `Assoc fields ->
-    `Assoc
-      (List.map
-         (fun (name, value) ->
-           ( (if String.equal name "owner_nonce" then "owner_generation" else name)
-           , rename_owner_nonce_to_legacy value ))
-         fields)
-  | `List items -> `List (List.map rename_owner_nonce_to_legacy items)
-  | other -> other
-;;
-
-let test_legacy_owner_generation_wire_key_replays () =
-  let accepted = stimulus "legacy-owner-key-source" 1.0 in
-  let claimed, lease =
-    State.empty
-    |> State.with_pending (queue [ accepted ])
-    |> State.with_revision 7L
-    |> State.claim_when ~claimed_at:3.0 ~ready:(fun _ -> true)
-    |> require_ok "claim legacy owner-key fixture"
-  in
-  let lease = require_some "legacy owner-key lease" lease in
-  let cancellation =
-    accepted_cancellation
-      ~source:accepted
-      ~source_revision:7L
-      ~owner_nonce:4
-      "op-legacy-owner-key"
-  in
-  let settled, receipt =
-    match
-      State.cancel_accepted
-        ~current_owner_nonce:4
-        ~settled_at:4.0
-        ~lease
-        ~cancellation
-        claimed
-      |> require_ok "cancel legacy owner-key source"
-    with
-    | state, State.Settled receipt -> state, receipt
-    | _, State.Already_settled _ ->
-      Alcotest.fail "legacy owner-key fixture replayed early"
-  in
-  (* 1) Receipt codec: a pre-rename receipt decodes to the same value. *)
-  let legacy_receipt_json =
-    rename_owner_nonce_to_legacy (State.transition_receipt_to_yojson receipt)
-  in
-  let decoded =
-    State.transition_receipt_of_yojson legacy_receipt_json
-    |> require_ok "legacy owner_generation receipt decode"
-  in
-  Alcotest.(check bool)
-    "legacy-key receipt roundtrips"
-    true
-    (State.transition_receipt_equal receipt decoded);
-  (* 2) Snapshot codec: a pre-rename snapshot (last_settlement + outbox carry
-     the settlement) loads. *)
-  let legacy_snapshot = rename_owner_nonce_to_legacy (State.to_yojson settled) in
-  let restored =
-    State.of_yojson legacy_snapshot
-    |> require_ok "legacy owner_generation snapshot decode"
-  in
-  Alcotest.(check int)
-    "legacy snapshot keeps the outbox transition"
-    1
-    (List.length (State.transition_outbox restored));
-  (* 3) New key wins when a row carries both keys. *)
-  let both_keys_json =
-    match State.transition_receipt_to_yojson receipt with
-    | `Assoc fields ->
-      `Assoc
-        (List.map
-           (fun (name, value) ->
-             match name, value with
-             | "settlement", `Assoc settlement_fields ->
-               name, `Assoc (("owner_generation", `Int 99) :: settlement_fields)
-             | _ -> name, value)
-           fields)
-    | other -> other
-  in
-  let decoded_both =
-    State.transition_receipt_of_yojson both_keys_json
-    |> require_ok "both-keys receipt decode"
-  in
-  (match decoded_both.State.settlement with
-   | State.Cancel_accepted decoded_cancellation ->
-     Alcotest.(check int)
-       "owner_nonce wins over legacy owner_generation"
-       4
-       decoded_cancellation.owner_nonce
-   | _ -> Alcotest.fail "both-keys decode changed the settlement kind");
-  (* 4) WAL replay: a pre-rename settlement row replays through persistence. *)
-  with_temp_dir "keeper-event-queue-legacy-owner-key" (fun base_path ->
-    let keeper_name = "legacy_owner_key_owner" in
-    Persistence.update_result ~base_path ~keeper_name (fun pending ->
-      Queue.enqueue pending (stimulus "legacy-owner-key-wal-source" 1.0))
-    |> require_ok "seed legacy owner-key WAL owner";
-    let lease =
-      Persistence.claim_when_result
-        ~base_path
-        ~keeper_name
-        ~claimed_at:2.0
-        ~ready:(fun _ -> true)
-        ()
-      |> require_ok "claim legacy owner-key WAL source"
-      |> require_some "legacy owner-key WAL lease"
-    in
-    let claimed =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "load legacy owner-key WAL pre-settlement state"
-    in
-    let source =
-      match Persistence.lease_stimuli lease with
-      | [ source ] -> source
-      | _ -> Alcotest.fail "legacy owner-key WAL lease lost its source"
-    in
-    let cancellation =
-      accepted_cancellation
-        ~source
-        ~source_revision:(State.revision claimed)
-        ~owner_nonce:4
-        "op-legacy-owner-key-wal"
-    in
-    let receipt =
-      match
-        State.cancel_accepted
-          ~current_owner_nonce:4
-          ~settled_at:3.0
-          ~lease
-          ~cancellation
-          claimed
-        |> require_ok "construct legacy owner-key WAL receipt"
-      with
-      | _, State.Settled receipt -> receipt
-      | _, State.Already_settled _ ->
-        Alcotest.fail "legacy owner-key WAL fixture replayed early"
-    in
-    let wal_path =
-      Filename.concat
-        (keeper_dir ~base_path ~keeper_name)
-        "event-queue-settlements.jsonl"
-    in
-    let row =
-      `Assoc
-        [ "schema", `String "masc.keeper_event_queue.settlement.v1"
-        ; "base_path", `String (Unix.realpath base_path)
-        ; "keeper_name", `String keeper_name
-        ; ( "receipt"
-          , rename_owner_nonce_to_legacy
-              (State.transition_receipt_to_yojson receipt) )
-        ]
-      |> Yojson.Safe.to_string
-      |> fun row -> row ^ "\n"
-    in
-    Fs_compat.save_file_atomic wal_path row
-    |> require_ok "write legacy owner-key WAL row";
-    let replayed =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "replay legacy owner-key WAL row"
-    in
-    Alcotest.(check int)
-      "legacy owner-key WAL settles active lease"
-      0
-      (List.length (State.leases replayed));
-    Alcotest.(check int)
-      "legacy owner-key WAL recreates transition outbox"
-      1
-      (List.length (State.transition_outbox replayed)))
-;;
-
 let test_context_compaction_retry_is_durable_and_lane_local () =
   with_temp_dir "keeper-event-queue-v2-retry-tail" (fun base_path ->
     let keeper_name = "retry_tail_keeper" in
@@ -2741,7 +2506,7 @@ let test_context_compaction_retry_is_durable_and_lane_local () =
 ;;
 
 let test_unsupported_snapshots_fail_closed () =
-  with_temp_dir "keeper-event-queue-v3-hardcut" (fun base_path ->
+  with_temp_dir "keeper-event-queue-schema-hardcut" (fun base_path ->
     let keeper_name = "hardcut_keeper" in
     let dir = keeper_dir ~base_path ~keeper_name in
     let primary = Filename.concat dir "event-queue.json" in
@@ -2763,9 +2528,14 @@ let test_unsupported_snapshots_fail_closed () =
       (Sys.file_exists unsupported);
     Sys.remove unsupported;
     write_queue primary (queue [ stimulus "old-schema" 3.0 ]);
+    let unsupported_bytes = Fs_compat.load_file primary in
     (match Persistence.load_state_result ~base_path ~keeper_name with
      | Error _ -> ()
-    | Ok _ -> Alcotest.fail "old primary schema was migrated"))
+     | Ok _ -> Alcotest.fail "old primary schema was migrated");
+    Alcotest.(check string)
+      "hard cut does not rewrite unsupported state"
+      unsupported_bytes
+      (Fs_compat.load_file primary))
 ;;
 
 let test_current_state_codec_reads_its_own_output () =
@@ -2777,57 +2547,33 @@ let test_current_state_codec_reads_its_own_output () =
     (Yojson.Safe.equal encoded (State.to_yojson decoded))
 ;;
 
-let test_v3_snapshot_upgrades_only_without_active_lease () =
-  with_temp_dir "keeper-event-queue-v3-upgrade" (fun base_path ->
-    let keeper_name = "v3_upgrade_keeper" in
-    let path = Filename.concat (keeper_dir ~base_path ~keeper_name) "event-queue.json" in
-    let v3_of_state state =
-      match State.to_yojson state with
-      | `Assoc fields ->
-        `Assoc
-          (("schema", `String "keeper.event_queue.state.v3")
-           :: List.filter
-                (fun (name, _) ->
-                   not
-                     (String.equal name "schema"
-                      || String.equal name "accepted_transfer_projections"
-                      || String.equal name "exact_execution_bindings"))
-                fields)
-      | _ -> Alcotest.fail "current event queue state codec is not an object"
-    in
-    let v3 = v3_of_state State.empty in
-    Fs_compat.mkdir_p (Filename.dirname path);
-    Fs_compat.save_file_atomic path (Yojson.Safe.to_string v3)
-    |> require_ok "write strict v3 predecessor";
-    let upgraded =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "load strict v3 predecessor"
-    in
-    Alcotest.(check int)
-      "v3 starts with no target transfer accounting"
-      0
-      (List.length (State.accepted_transfer_projections upgraded));
+let test_current_state_fresh_write_read_restart () =
+  with_temp_dir "keeper-event-queue-current-restart" (fun base_path ->
+    let keeper_name = "current_restart_keeper" in
+    let source = stimulus "current-restart-source" 1.0 in
     Persistence.update_result ~base_path ~keeper_name (fun pending ->
-      Queue.enqueue pending (stimulus "upgrade" 1.0))
-    |> require_ok "mutate upgraded queue";
+      Queue.enqueue pending source)
+    |> require_ok "write fresh current queue";
+    let first =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "read fresh current queue"
+    in
+    let path = Filename.concat (keeper_dir ~base_path ~keeper_name) "event-queue.json" in
     let persisted =
-      Safe_ops.read_json_file_safe path |> require_ok "read upgraded queue"
+      Safe_ops.read_json_file_safe path |> require_ok "read current queue envelope"
     in
-    let open Yojson.Safe.Util in
     Alcotest.(check string)
-      "next durable write uses v4"
-      "keeper.event_queue.state.v4"
-      (persisted |> member "schema" |> to_string);
-    let claimed, lease =
-      State.with_pending (queue [ stimulus "possibly-dispatched" 2.0 ]) State.empty
-      |> claim_head
+      "fresh writer emits only current schema"
+      State.schema
+      Yojson.Safe.Util.(persisted |> member "schema" |> to_string);
+    let restarted =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "reload current queue after restart"
     in
-    ignore (require_some "legacy active lease" lease : State.lease);
-    match State.of_yojson (v3_of_state claimed) with
-    | Error _ -> ()
-    | Ok _ ->
-      Alcotest.fail
-        "legacy active lease was promoted without exact execution bindings")
+    Alcotest.(check bool)
+      "fresh current state survives write/read/restart"
+      true
+      (Yojson.Safe.equal (State.to_yojson first) (State.to_yojson restarted)))
 ;;
 
 let test_transition_outbox_projects_with_stable_identity () =
@@ -3131,21 +2877,13 @@ let () =
             `Quick
             test_pending_cancellation_wal_replays_before_removal
         ; Alcotest.test_case
-            "legacy settlement WAL v1 remains replayable"
-            `Quick
-            test_legacy_settlement_wal_v1_remains_replayable
-        ; Alcotest.test_case
-            "legacy owner_generation wire key replays"
-            `Quick
-            test_legacy_owner_generation_wire_key_replays
-        ; Alcotest.test_case
             "unsupported snapshots fail closed"
             `Quick
             test_unsupported_snapshots_fail_closed
         ; Alcotest.test_case
-            "v3 upgrades only without an active lease"
+            "current state fresh write/read/restart"
             `Quick
-            test_v3_snapshot_upgrades_only_without_active_lease
+            test_current_state_fresh_write_read_restart
         ; Alcotest.test_case
             "transition outbox projection"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2564,8 +2564,8 @@ let test_unsupported_snapshots_fail_closed () =
        Alcotest.(check string)
          "incompatible snapshot requires an explicit reset"
          (Printf.sprintf
-            "event queue snapshot at %s is incompatible (reset required): snapshot missing \
-             required field schema"
+            "event queue snapshot at %s is incompatible (reset required): unsupported keeper \
+             event queue state schema: keeper.event_queue.v2"
             primary)
          message
      | Ok _ -> Alcotest.fail "old primary schema was migrated");

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -168,59 +168,6 @@ let test_strict_request_codec () =
    | Ok _ -> Alcotest.fail "source-terminal request accepted a mismatched receipt")
 ;;
 
-(* Regression (#25599): pre-rename clients send the fencing counter as
-   ["owner_generation"]. During the deprecation window the operator request
-   codec accepts the legacy key; the new ["owner_nonce"] key wins when a
-   request carries both. *)
-let test_legacy_owner_generation_key_is_accepted () =
-  let legacy_resume =
-    common
-      "resume_owner"
-      [ "owner_generation", `Int 7
-      ; "operator_operation_id", `String "operator-resume-legacy"
-      ]
-  in
-  (match Operator.request_of_yojson legacy_resume with
-   | Ok
-       (Operator.Resume_owner
-         { owner_nonce = 7; operator_operation_id = "operator-resume-legacy" }) ->
-     ()
-   | Ok _ -> Alcotest.fail "legacy resume request decoded to the wrong operation"
-   | Error detail -> Alcotest.fail detail);
-  let both_keys =
-    common
-      "resume_owner"
-      [ "owner_generation", `Int 99
-      ; "owner_nonce", `Int 7
-      ; "operator_operation_id", `String "operator-resume-both"
-      ]
-  in
-  (match Operator.request_of_yojson both_keys with
-   | Ok
-       (Operator.Resume_owner
-         { owner_nonce = 7; operator_operation_id = "operator-resume-both" }) ->
-     ()
-   | Ok _ -> Alcotest.fail "both-keys resume request decoded to the wrong operation"
-   | Error detail -> Alcotest.fail detail);
-  let legacy_cancel =
-    common
-      "cancel_accepted"
-      [ "source_state", `String "pending"
-      ; "source", Queue.stimulus_to_yojson board_source
-      ; "source_revision", int64_json 11L
-      ; "owner_generation", `Int 7
-      ; "operator_operation_id", `String "operator-cancel-legacy"
-      ; "reason", `String "operator rejected retained work"
-      ; "settled_at", `Float 3.0
-      ]
-  in
-  match Operator.request_of_yojson legacy_cancel with
-  | Ok (Operator.Cancel_pending request) ->
-    Alcotest.(check int) "legacy cancel nonce" 7 request.owner_nonce
-  | Ok _ -> Alcotest.fail "legacy cancellation decoded to the wrong operation"
-  | Error detail -> Alcotest.fail detail
-;;
-
 let test_inventory_exposes_exact_durable_fences () =
   let base_path = Filename.temp_dir "keeper-paused-work-operator" "" in
   Fun.protect
@@ -321,12 +268,7 @@ let () =
   Alcotest.run
     "keeper paused-work operator"
     [ ( "codec"
-      , [ Alcotest.test_case "strict four-way request codec" `Quick test_strict_request_codec
-        ; Alcotest.test_case
-            "legacy owner_generation key is accepted"
-            `Quick
-            test_legacy_owner_generation_key_is_accepted
-        ] )
+      , [ Alcotest.test_case "strict four-way request codec" `Quick test_strict_request_codec ] )
     ; ( "inventory"
       , [ Alcotest.test_case
             "durable exact identity and revision"

--- a/test/test_keeper_paused_work_resume_surface.ml
+++ b/test/test_keeper_paused_work_resume_surface.ml
@@ -62,37 +62,6 @@ let test_bulk_resume_requires_per_owner_targets () =
     parsed
 ;;
 
-let test_legacy_owner_generation_key_is_accepted () =
-  (* Regression (#25599): pre-rename dashboard clients send the fencing counter
-     as ["owner_generation"]. During the deprecation window both keys are
-     accepted; the new ["owner_nonce"] key wins when a request carries both. *)
-  let legacy =
-    Surface.parse_resume_request
-      (`Assoc
-         [ "action", `String "resume"
-         ; "owner_generation", `Int 7
-         ; "operator_operation_id", `String "dashboard-resume-legacy-7"
-         ])
-    |> require_ok "parse legacy-key Resume_owner"
-  in
-  check (pair int string) "legacy key fences" (7, "dashboard-resume-legacy-7") legacy;
-  let both_keys =
-    Surface.parse_resume_request
-      (`Assoc
-         [ "action", `String "resume"
-         ; "owner_generation", `Int 99
-         ; "owner_nonce", `Int 7
-         ; "operator_operation_id", `String "dashboard-resume-both-7"
-         ])
-    |> require_ok "parse both-keys Resume_owner"
-  in
-  check
-    (pair int string)
-    "owner_nonce wins over legacy owner_generation"
-    (7, "dashboard-resume-both-7")
-    both_keys
-;;
-
 let () =
   run
     "keeper paused-work resume surface"
@@ -105,10 +74,6 @@ let () =
             "bulk requires per-owner targets"
             `Quick
             test_bulk_resume_requires_per_owner_targets
-        ; test_case
-            "legacy owner_generation key is accepted"
-            `Quick
-            test_legacy_owner_generation_key_is_accepted
         ] )
     ]
 ;;

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -746,10 +746,20 @@ let test_summary_cursor_ack_respects_post_id_tiebreaker () =
     ~base_path
     keeper_name
     (board_stimulus ~post_id:"post-live-backlog-2" ());
-  Keeper_event_queue_persistence.record_inflight
-    ~base_path
-    ~keeper_name
-    [ fusion_completed_stimulus () ];
+  let inflight = fusion_completed_stimulus () in
+  Keeper_registry_event_queue.enqueue ~base_path keeper_name inflight;
+  (match
+     Keeper_event_queue_persistence.claim_when_result
+       ~base_path
+       ~keeper_name
+       ~claimed_at:1235.0
+       ~ready:(fun stimulus ->
+         Keeper_event_queue.stimulus_identity_equal stimulus inflight)
+       ()
+   with
+   | Ok (Some _) -> ()
+   | Ok None -> fail "current queue fixture did not claim fusion stimulus"
+   | Error detail -> fail detail);
   let fleet =
     Keeper_reaction_ledger.fleet_summary_json
       ~base_path

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -195,10 +195,18 @@ let test_event_queue_pending_and_inflight_are_visible () =
   Keeper_event_queue_persistence.persist
     ~base_path:config.Workspace_utils_backend_setup.base_path
     ~keeper_name
-    (queue_of_list [ pending ]);
-  Keeper_event_queue_persistence.record_inflight
-    ~base_path:config.Workspace_utils_backend_setup.base_path
-    ~keeper_name [ inflight ];
+    (queue_of_list [ inflight; pending ]);
+  (match
+     Keeper_event_queue_persistence.claim_when_result
+       ~base_path:config.Workspace_utils_backend_setup.base_path
+       ~keeper_name
+       ~claimed_at:120.0
+       ~ready:(fun stimulus -> String.equal stimulus.Keeper_event_queue.post_id inflight.post_id)
+       ()
+   with
+   | Ok (Some _) -> ()
+   | Ok None -> fail "current queue fixture did not claim inflight stimulus"
+   | Error detail -> fail detail);
   let json = Server_keeper_waiting_inventory.dashboard_json config in
   check_metric_float "event pending metric"
     Otel_metric_store.metric_keeper_waiting_count


### PR DESCRIPTION
## Summary

- base this hard cut directly on merged #25622 (`4a3549237d2`)
- remove the public `Legacy_inflight` lease shape and split-file test adapters
- accept only current event-queue state v4, current settlement WAL v2, and `owner_nonce`
- update current dashboard and soak-harness clients to emit `owner_nonce`
- retain focused clean write/read/restart and fail-closed/no-rewrite evidence

## Hard cut

- deleted `Legacy_inflight`, `add_legacy_inflight`, `release_legacy_inflight`,
  `record_inflight`, and `ack_inflight`
- deleted settlement WAL v1 receipt decoding/replay
- deleted `owner_generation` normalization/fallback from durable state and
  paused-work HTTP/operator request codecs
- deleted state v3 predecessor upgrade logic and compatibility fixtures
- stale/unknown state now returns an explicit reset-required error
- unsupported split sidecars and state remain untouched on failure

## Non-goals

- no migration, reconciliation, rewrite, quarantine, or tombstone path
- no replay of pre-1.0 runtime assets
- no #25624 terminal-disposition semantics in this PR
- no full local Dune suite; CI remains the broad build authority

## Validation

- `scripts/dune-local.sh build` for seven touched test executables: pass
- `test_keeper_event_queue_state_v2.exe`: 36/36 pass, including current v4
  fresh write/read/restart and unsupported-state no-rewrite
- `test_keeper_event_queue_owner_lock.exe`: pass
- `test_keeper_waiting_inventory.exe`: 16/16 pass
- `test_keeper_reaction_ledger.exe`: 26/26 pass
- `test_keeper_paused_work_resume_surface.exe`: 2/2 pass
- dashboard `tsc --noEmit`: pass
- focused dashboard Vitest: 3 files, 65 tests pass
- `ocamlformat --check`, `bash -n`, `git diff --check`: pass
- repository hard-cut ratchet for removed symbols/schemas: 0 hits

Two unrelated main-head assertions still fail identically before this diff's
changed paths:

- `test_keeper_event_queue.exe`: existing fusion post-id assertion at line 248
- `test_keeper_paused_work_operator.exe`: existing JSON `int`/`intlit`
  inventory assertion

Both were reproduced with the main checkout's pre-existing executables.

## Restack order

Merge this hard cut first, then restack #25624 onto the resulting main. During
the overlap resolution, keep this PR's deleted compatibility surfaces and
reapply only #25624's current-v5 terminal-disposition semantics.

## Self-audit

- P0: 0
- P1: 0
- P2: 0
- P3: 0
