### PR TITLE
fix(prompt): manage batch attention judgment asset

### DIFF
--- a/config/prompts/managed-assets.json
+++ b/config/prompts/managed-assets.json
@@ -13,6 +13,7 @@
     "governance.deliberation.md",
     "governance.dry_run.md",
     "keeper.board_attention_judgment.md",
+    "keeper.board_attention_judgment_batch.md",
     "keeper.capabilities.md",
     "keeper.claimed_task_nudge.md",
     "keeper.connected_surfaces_guidance.md",


### PR DESCRIPTION
## What changed

- add `keeper.board_attention_judgment_batch.md` to `config/prompts/managed-assets.json`

## Why

The prompt file is embedded in the binary but absent from the managed manifest. Startup therefore fails closed for prompt asset synchronization with:

`current embedded prompt assets missing from managed manifest: keeper.board_attention_judgment_batch.md`

Adding the existing asset to the manifest restores complete coverage and allows runtime prompt synchronization to converge.

## Validation

- `jq empty config/prompts/managed-assets.json`
- `git diff --check`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_prompt_asset_sync.exe`
- `_build/default/test/test_prompt_asset_sync.exe` — 12/12 passed

The pin check was skipped only because the shared local opam switch currently points at the same OAS repository without the expected exact commit fragment; this focused test does not exercise OAS behavior. PR CI remains the authoritative clean-environment check.