### PR TITLE
fix(dashboard): label transcript corruption reset state

### DIFF
--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -55,6 +55,7 @@ export const ATTENTION_REASONS = [
   'transient_runtime_retry',
   'internal_error',
   'cancelled',
+  'transcript_corruption',
   'unmapped_runtime_state',
 ] as const
 export type AttentionReason = typeof ATTENTION_REASONS[number]
@@ -74,6 +75,7 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   transient_runtime_retry: '일시적 런타임 재시도',
   internal_error: '내부 오류',
   cancelled: '취소됨',
+  transcript_corruption: '대화 기록 손상 - 초기화 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 


### PR DESCRIPTION
## Summary

- add the backend-emitted transcript_corruption reason to the closed dashboard attention union
- label it as 대화 기록 손상 - 초기화 필요 to preserve the typed operator-reset-required semantics
- keep the backend-derived drift guard strict and unchanged

## Evidence

- main CI run 30011248823
- Dashboard job 89219748222
- failing step: Run dashboard tests
- failure: execution receipt attention_reason code with no union arm: transcript_corruption

## Validation

- local build/tests not run per instruction; draft PR CI is the execution authority
