### PR TITLE
test(keeper): prove exact disposition crash boundaries

### DIFF
--- a/lib/keeper/keeper_compact_rejection.ml
+++ b/lib/keeper/keeper_compact_rejection.ml
@@ -48,7 +48,12 @@ let compaction_rejection_to_string = function
 let exact_terminal_of_observation cause
       (observation : Keeper_compaction_llm_summarizer.attempt_observation) =
   Keeper_event_queue_state.
-    { cause; slot_id = observation.slot_id; call_id = observation.call_id }
+    { cause
+    ; slot_id = observation.slot_id
+    ; call_id = observation.call_id
+    ; plan_fingerprint = observation.receipt_plan_fingerprint
+    ; request_body_sha256 = observation.receipt_request_body_sha256
+    }
 ;;
 
 let summarization_rejection = function

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -421,7 +421,12 @@ let is_before_dispatch_zero observation =
 
 let terminal_of_observation cause (observation : attempt_observation) =
   Keeper_event_queue_state.
-    { cause; slot_id = observation.slot_id; call_id = observation.call_id }
+    { cause
+    ; slot_id = observation.slot_id
+    ; call_id = observation.call_id
+    ; plan_fingerprint = observation.receipt_plan_fingerprint
+    ; request_body_sha256 = observation.receipt_request_body_sha256
+    }
 ;;
 
 type exact_execution_release_result =
@@ -533,6 +538,10 @@ let terminalize_post_success terminalizer cause =
             { cause
             ; slot_id = terminalizer.attempt_observation.slot_id
             ; call_id = terminalizer.attempt_observation.call_id
+            ; plan_fingerprint =
+                terminalizer.attempt_observation.receipt_plan_fingerprint
+            ; request_body_sha256 =
+                terminalizer.attempt_observation.receipt_request_body_sha256
             }
         in
         let completion, resolve_completion = Eio.Promise.create () in

--- a/lib/keeper/keeper_exact_disposition_recovery.ml
+++ b/lib/keeper/keeper_exact_disposition_recovery.ml
@@ -1,0 +1,11 @@
+let prepare_registration_result
+      ~base_path
+      ~keeper_name
+      ~settled_at
+  =
+  Keeper_event_queue_persistence.prepare_registration_after_exact_recovery_result
+    ~base_path
+    ~keeper_name
+    ~settled_at
+    ()
+;;

--- a/lib/keeper/keeper_exact_disposition_recovery.mli
+++ b/lib/keeper/keeper_exact_disposition_recovery.mli
@@ -1,0 +1,11 @@
+(** Restart composition root for exact source dispositions.
+
+    The persistence boundary performs WAL replay, terminal exact disposition
+    finalization, and generic registration recovery in that order under the
+    queue owner's durable lock. *)
+
+val prepare_registration_result :
+  base_path:string ->
+  keeper_name:string ->
+  settled_at:float ->
+  (Keeper_event_queue.t, string) result

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -580,6 +580,30 @@ let project_transition_outbox ~base_path ~keeper_name =
     ~keeper_name
 ;;
 
+let exact_terminal_source = function
+  | Keeper_registry_event_queue.No_compaction
+      { source
+      ; reason = Keeper_event_queue_state.Exact_execution_terminal terminal
+      } ->
+    Some (source, terminal)
+  | Keeper_registry_event_queue.Escalate
+      { reason =
+          Keeper_registry_event_queue.Compaction_exact_output_terminal
+            { source; terminal }
+      ; successor = None
+      } ->
+    Some (source, terminal)
+  | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.No_compaction _
+  | Keeper_registry_event_queue.Cancel_accepted _
+  | Keeper_registry_event_queue.Transfer_accepted _
+  | Keeper_registry_event_queue.Settle_from_source_terminal _
+  | Keeper_registry_event_queue.Settle_exact _
+  | Keeper_registry_event_queue.Requeue _
+  | Keeper_registry_event_queue.Escalate _ ->
+    None
+;;
+
 let settle_claimed_lease
       ?(exact_execution = false)
       ~base_path
@@ -602,20 +626,66 @@ let settle_claimed_lease
       match Keeper_registry_event_queue.exact_execution_binding_result ~base_path keeper_name with
       | Error _ as error -> error
       | Ok None ->
-        Keeper_registry_event_queue.settle_result
-          ~base_path
-          keeper_name
-          ~settled_at
-          ~lease
-          ~settlement
+        (match exact_terminal_source settlement with
+         | Some _ ->
+           Error "exact terminal settlement has no durable exact execution binding"
+         | None ->
+           Keeper_registry_event_queue.settle_result
+             ~base_path
+             keeper_name
+             ~settled_at
+             ~lease
+             ~settlement)
       | Ok (Some binding) ->
-        Keeper_registry_event_queue.settle_exact_execution_result
-          ~base_path
-          keeper_name
-          ~settled_at
-          ~lease
-          ~binding
-          ~settlement)
+        (match exact_terminal_source settlement with
+         | None ->
+           Keeper_registry_event_queue.settle_bound_exact_nonterminal_result
+             ~base_path
+             keeper_name
+             ~settled_at
+             ~lease
+             ~binding
+             ~settlement
+         | Some (source, terminal) ->
+           let semantic =
+             match settlement with
+             | Keeper_registry_event_queue.No_compaction _ ->
+               Keeper_registry_event_queue.Exact_no_compaction
+             | Keeper_registry_event_queue.Escalate _ ->
+               Keeper_registry_event_queue.Exact_escalate
+             | Keeper_registry_event_queue.Ack
+             | Keeper_registry_event_queue.Cancel_accepted _
+             | Keeper_registry_event_queue.Transfer_accepted _
+             | Keeper_registry_event_queue.Settle_from_source_terminal _
+             | Keeper_registry_event_queue.Settle_exact _
+             | Keeper_registry_event_queue.Requeue _ ->
+               assert false
+           in
+           (match
+              Keeper_registry_event_queue.prepare_exact_source_disposition_result
+                ~base_path
+                keeper_name
+                ~lease
+                ~source
+                ~terminal
+                ~semantic
+                ~prepared_at:settled_at
+            with
+            | Error _ as error -> error
+            | Ok
+                ( _
+                , Keeper_registry_event_queue.Visible_sync_unconfirmed detail )
+              ->
+              Error
+                ("exact source disposition became visible with unconfirmed sync; restart reconciliation required: "
+                 ^ detail)
+            | Ok (disposition, Keeper_registry_event_queue.Fsync_completed) ->
+              Keeper_registry_event_queue.finalize_exact_source_disposition_result
+                ~base_path
+                keeper_name
+                ~settled_at
+                ~lease
+                ~disposition_id:disposition.disposition_id)))
 ;;
 
 let exact_execution_guard ~base_path ~keeper_name ~lease =
@@ -658,15 +728,18 @@ let exact_execution_guard ~base_path ~keeper_name ~lease =
       binding_arguments observation
     in
     let terminal : Keeper_registry_event_queue.exact_execution_terminal =
-      { cause; slot_id; call_id }
+      { cause
+      ; slot_id
+      ; call_id
+      ; plan_fingerprint
+      ; request_body_sha256
+      }
     in
     Keeper_registry_event_queue.quarantine_exact_execution_result
       ~base_path
       keeper_name
       ~lease
       ~terminal
-      ~plan_fingerprint
-      ~request_body_sha256
   in
   Keeper_compaction_llm_summarizer.
     { before_dispatch; release_before_dispatch; quarantine }
@@ -678,6 +751,7 @@ let settlement_is_ack = function
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _ -> true
   | Keeper_registry_event_queue.Settle_from_source_terminal _ -> true
+  | Keeper_registry_event_queue.Settle_exact _ -> true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false
@@ -696,6 +770,9 @@ let settlement_is_exact_output_terminal = function
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _
   | Keeper_registry_event_queue.Settle_from_source_terminal _
+  | Keeper_registry_event_queue.Settle_exact
+      { outcome = Keeper_registry_event_queue.Terminal _; _ } ->
+    true
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false
@@ -731,6 +808,15 @@ let settlement_is_exact_output_cancellation = function
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _
   | Keeper_registry_event_queue.Settle_from_source_terminal _
+  | Keeper_registry_event_queue.Settle_exact
+      { outcome =
+          Keeper_registry_event_queue.Terminal
+            ( Keeper_event_queue_state.Execution_cancelled_after_dispatch
+            | Keeper_event_queue_state.Terminal_persistence_failed )
+      ; _
+      } ->
+    true
+  | Keeper_registry_event_queue.Settle_exact _
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -606,6 +606,7 @@ let exact_terminal_source = function
 
 let settle_claimed_lease
       ?(exact_execution = false)
+      ?(after_exact_disposition_prepare = fun () -> ())
       ~base_path
       ~keeper_name
       ~settled_at
@@ -680,6 +681,7 @@ let settle_claimed_lease
                 ("exact source disposition became visible with unconfirmed sync; restart reconciliation required: "
                  ^ detail)
             | Ok (disposition, Keeper_registry_event_queue.Fsync_completed) ->
+              after_exact_disposition_prepare ();
               Keeper_registry_event_queue.finalize_exact_source_disposition_result
                 ~base_path
                 keeper_name
@@ -863,6 +865,26 @@ module For_testing = struct
 
   let exact_execution_guard = exact_execution_guard
   let commit_transcript_corruption = commit_transcript_corruption
+
+  let settle_claimed_lease_exact
+        ~after_exact_disposition_prepare
+        ~base_path
+        ~keeper_name
+        ~settled_at
+        ~lease
+        ~settlement
+        ()
+    =
+    settle_claimed_lease
+      ~exact_execution:true
+      ~after_exact_disposition_prepare
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~settlement
+      ()
+  ;;
 
   let check_cancellation_after_exact_terminal_settlement =
     check_cancellation_after_exact_terminal_settlement

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -272,6 +272,16 @@ module For_testing : sig
     lease:Keeper_registry_event_queue.lease ->
     Keeper_compaction_llm_summarizer.exact_execution_guard
 
+  val settle_claimed_lease_exact :
+    after_exact_disposition_prepare:(unit -> unit) ->
+    base_path:string ->
+    keeper_name:string ->
+    settled_at:float ->
+    lease:Keeper_registry_event_queue.lease ->
+    settlement:Keeper_registry_event_queue.settlement ->
+    unit ->
+    (Keeper_registry_event_queue.settle_result, string) result
+
   val check_cancellation_after_exact_terminal_settlement :
     Keeper_registry_event_queue.settlement -> unit
 end

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -301,6 +301,11 @@ let reaction_kind_of_settlement = function
   | Keeper_event_queue_state.Cancel_accepted _ -> Event_queue_cancelled
   | Keeper_event_queue_state.Transfer_accepted _ -> Event_queue_ack
   | Keeper_event_queue_state.Settle_from_source_terminal _ -> Event_queue_ack
+  | Keeper_event_queue_state.Settle_exact
+      { semantic = Exact_no_compaction; _ } ->
+    Event_queue_no_compaction
+  | Keeper_event_queue_state.Settle_exact { semantic = Exact_escalate; _ } ->
+    Event_queue_escalated
   | Keeper_event_queue_state.Requeue _ -> Event_queue_requeued
   | Keeper_event_queue_state.Escalate _ -> Event_queue_escalated
 ;;
@@ -676,14 +681,22 @@ let reaction_kind_matches_settlement reaction_kind settlement =
   | Event_queue_ack, Keeper_event_queue_state.Transfer_accepted _ -> true
   | Event_queue_ack, Keeper_event_queue_state.Settle_from_source_terminal _ -> true
   | Event_queue_no_compaction, Keeper_event_queue_state.No_compaction _ -> true
+  | Event_queue_no_compaction,
+    Keeper_event_queue_state.Settle_exact
+      { semantic = Exact_no_compaction; _ } ->
+    true
   | Event_queue_cancelled, Keeper_event_queue_state.Cancel_accepted _ -> true
   | Event_queue_requeued, Keeper_event_queue_state.Requeue _ -> true
   | Event_queue_escalated, Keeper_event_queue_state.Escalate _ -> true
+  | Event_queue_escalated,
+    Keeper_event_queue_state.Settle_exact { semantic = Exact_escalate; _ } ->
+    true
   | Turn_started, _
   | Cursor_ack, _
   | Event_queue_ack,
     ( Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
+    | Keeper_event_queue_state.Settle_exact _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_no_compaction,
@@ -691,6 +704,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Settle_from_source_terminal _
+    | Keeper_event_queue_state.Settle_exact _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_cancelled,
@@ -698,6 +712,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Settle_from_source_terminal _
+    | Keeper_event_queue_state.Settle_exact _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_requeued,
@@ -706,6 +721,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Settle_from_source_terminal _
+    | Keeper_event_queue_state.Settle_exact _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_escalated,
     ( Keeper_event_queue_state.Ack
@@ -713,6 +729,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Settle_from_source_terminal _
+    | Keeper_event_queue_state.Settle_exact _
     | Keeper_event_queue_state.Requeue _ ) -> false
 ;;
 
@@ -1425,6 +1442,7 @@ let summarize_rows ~keeper_name ~limit rows =
        | Keeper_event_queue_state.Cancel_accepted _
        | Keeper_event_queue_state.Transfer_accepted _
        | Keeper_event_queue_state.Settle_from_source_terminal _
+       | Keeper_event_queue_state.Settle_exact _
        | Keeper_event_queue_state.Requeue _ -> ())
     | Cursor_ack, None -> incr cursor_ack_count
     | Turn_started, Some _

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -102,6 +102,7 @@ type settlement = Keeper_event_queue_persistence.settlement =
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
   | Settle_from_source_terminal of accepted_source_terminal
+  | Settle_exact of exact_source_disposition
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -18,8 +18,6 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Approval_grant_unconsumed
-  | Approval_grant_state_unavailable
 
 let publish_pending ~base_path name pending =
   match Keeper_registry.get ~base_path name with

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -38,11 +38,26 @@ type exact_execution_terminal = Keeper_event_queue_persistence.exact_execution_t
   { cause : exact_execution_terminal_cause
   ; slot_id : string
   ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
   }
+
+type exact_source_action = Keeper_event_queue_persistence.exact_source_action =
+  | Consume_source
+
+type exact_settlement_semantic = Keeper_event_queue_persistence.exact_settlement_semantic =
+  | Exact_no_compaction
+  | Exact_escalate
+
+type exact_source_outcome = Keeper_event_queue_persistence.exact_source_outcome =
+  | Terminal of exact_execution_terminal_cause
+
+type exact_source_disposition = Keeper_event_queue_persistence.exact_source_disposition
 
 type exact_execution_lease_status = Keeper_event_queue_persistence.exact_execution_lease_status =
   | Dispatch_uncertain
   | Terminal_quarantined of exact_execution_terminal_cause
+  | Disposition_prepared of exact_source_disposition
 
 type exact_execution_binding = Keeper_event_queue_persistence.exact_execution_binding =
   { lease_id : string
@@ -129,6 +144,7 @@ type settlement = Keeper_event_queue_persistence.settlement =
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
   | Settle_from_source_terminal of accepted_source_terminal
+  | Settle_exact of exact_source_disposition
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -180,7 +196,7 @@ val settle_result :
   settlement:settlement ->
   (settle_result, string) result
 
-val settle_exact_execution_result :
+val settle_bound_exact_nonterminal_result :
   base_path:string ->
   string ->
   settled_at:float ->
@@ -214,9 +230,25 @@ val quarantine_exact_execution_result :
   string ->
   lease:lease ->
   terminal:exact_execution_terminal ->
-  plan_fingerprint:string ->
-  request_body_sha256:string ->
   (exact_write_outcome, string) result
+
+val prepare_exact_source_disposition_result :
+  base_path:string ->
+  string ->
+  lease:lease ->
+  source:Keeper_checkpoint_ref.t ->
+  terminal:exact_execution_terminal ->
+  semantic:exact_settlement_semantic ->
+  prepared_at:float ->
+  (exact_source_disposition * exact_write_outcome, string) result
+
+val finalize_exact_source_disposition_result :
+  base_path:string ->
+  string ->
+  settled_at:float ->
+  lease:lease ->
+  disposition_id:string ->
+  (settle_result, string) result
 
 val cancel_accepted_result :
   base_path:string ->

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -17,8 +17,6 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Approval_grant_unconsumed
-  | Approval_grant_state_unavailable
 
 type exact_execution_terminal_cause = Keeper_event_queue_persistence.exact_execution_terminal_cause =
   | Execution_failed_after_dispatch

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.ml
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.ml
@@ -20,11 +20,27 @@ struct
     { cause : exact_execution_terminal_cause
     ; slot_id : string
     ; call_id : string
+    ; plan_fingerprint : string
+    ; request_body_sha256 : string
     }
-  
+
+  type exact_source_action = Keeper_event_queue_persistence.exact_source_action =
+    | Consume_source
+
+  type exact_settlement_semantic =
+    Keeper_event_queue_persistence.exact_settlement_semantic =
+    | Exact_no_compaction
+    | Exact_escalate
+
+  type exact_source_outcome = Keeper_event_queue_persistence.exact_source_outcome =
+    | Terminal of exact_execution_terminal_cause
+
+  type exact_source_disposition = Keeper_event_queue_persistence.exact_source_disposition
+
   type exact_execution_lease_status = Keeper_event_queue_persistence.exact_execution_lease_status =
     | Dispatch_uncertain
     | Terminal_quarantined of exact_execution_terminal_cause
+    | Disposition_prepared of exact_source_disposition
   
   type exact_execution_binding = Keeper_event_queue_persistence.exact_execution_binding =
     { lease_id : string
@@ -87,16 +103,49 @@ struct
         name
         ~lease
         ~terminal
-        ~plan_fingerprint
-        ~request_body_sha256
     =
     Keeper_event_queue_persistence.quarantine_exact_execution_result
       ~base_path
       ~keeper_name:name
       ~lease
       ~terminal
-      ~plan_fingerprint
-      ~request_body_sha256
+      ()
+  ;;
+
+  let prepare_exact_source_disposition_result
+        ~base_path
+        name
+        ~lease
+        ~source
+        ~terminal
+        ~semantic
+        ~prepared_at
+    =
+    Keeper_event_queue_persistence.prepare_exact_source_disposition_result
+      ~base_path
+      ~keeper_name:name
+      ~lease
+      ~source
+      ~terminal
+      ~semantic
+      ~prepared_at
+      ()
+  ;;
+
+  let finalize_exact_source_disposition_result
+        ~base_path
+        name
+        ~settled_at
+        ~lease
+        ~disposition_id
+    =
+    Keeper_event_queue_persistence.finalize_exact_source_disposition_result
+      ~base_path
+      ~keeper_name:name
+      ~settled_at
+      ~lease
+      ~disposition_id
+      ~after_commit:(Publish.publish_pending ~base_path name)
       ()
   ;;
   
@@ -128,7 +177,7 @@ struct
       ~transition_id
   ;;
   
-  let settle_exact_execution_result
+  let settle_bound_exact_nonterminal_result
         ~base_path
         name
         ~settled_at
@@ -136,7 +185,7 @@ struct
         ~binding
         ~settlement
     =
-    Keeper_event_queue_persistence.settle_exact_execution_result
+    Keeper_event_queue_persistence.settle_bound_exact_nonterminal_result
       ~base_path
       ~keeper_name:name
       ~settled_at

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.mli
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.mli
@@ -20,12 +20,28 @@ module Make (Publish : sig
     { cause : exact_execution_terminal_cause
     ; slot_id : string
     ; call_id : string
+    ; plan_fingerprint : string
+    ; request_body_sha256 : string
     }
+
+  type exact_source_action = Keeper_event_queue_persistence.exact_source_action =
+    | Consume_source
+
+  type exact_settlement_semantic =
+    Keeper_event_queue_persistence.exact_settlement_semantic =
+    | Exact_no_compaction
+    | Exact_escalate
+
+  type exact_source_outcome = Keeper_event_queue_persistence.exact_source_outcome =
+    | Terminal of exact_execution_terminal_cause
+
+  type exact_source_disposition = Keeper_event_queue_persistence.exact_source_disposition
 
   type exact_execution_lease_status =
     Keeper_event_queue_persistence.exact_execution_lease_status =
     | Dispatch_uncertain
     | Terminal_quarantined of exact_execution_terminal_cause
+    | Disposition_prepared of exact_source_disposition
 
   type exact_execution_binding = Keeper_event_queue_persistence.exact_execution_binding =
     { lease_id : string
@@ -66,9 +82,25 @@ module Make (Publish : sig
     string ->
     lease:Keeper_event_queue_persistence.lease ->
     terminal:exact_execution_terminal ->
-    plan_fingerprint:string ->
-    request_body_sha256:string ->
     (exact_write_outcome, string) result
+
+  val prepare_exact_source_disposition_result :
+    base_path:string ->
+    string ->
+    lease:Keeper_event_queue_persistence.lease ->
+    source:Keeper_checkpoint_ref.t ->
+    terminal:exact_execution_terminal ->
+    semantic:exact_settlement_semantic ->
+    prepared_at:float ->
+    (exact_source_disposition * exact_write_outcome, string) result
+
+  val finalize_exact_source_disposition_result :
+    base_path:string ->
+    string ->
+    settled_at:float ->
+    lease:Keeper_event_queue_persistence.lease ->
+    disposition_id:string ->
+    (Keeper_event_queue_persistence.settle_result, string) result
 
   val active_lease_result :
     base_path:string ->
@@ -86,7 +118,7 @@ module Make (Publish : sig
   val mark_transition_projected_result :
     base_path:string -> string -> transition_id:string -> (unit, string) result
 
-  val settle_exact_execution_result :
+  val settle_bound_exact_nonterminal_result :
     base_path:string ->
     string ->
     settled_at:float ->

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -473,11 +473,10 @@ let register_with_state_result
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   match
-    Keeper_event_queue_persistence.prepare_registration_result
+    Keeper_exact_disposition_recovery.prepare_registration_result
       ~base_path
       ~keeper_name:name
       ~settled_at:(Time_compat.now ())
-      ()
   with
   | Error detail -> Error (Registration_event_queue_unavailable { keeper_name = name; detail })
   | Ok initial_event_queue ->
@@ -688,11 +687,10 @@ let register_restarting ~base_path name meta
      queue snapshot instead of being reset across restart. *)
   let done_p, done_r = Eio.Promise.create () in
   match
-    Keeper_event_queue_persistence.prepare_registration_result
+    Keeper_exact_disposition_recovery.prepare_registration_result
       ~base_path
       ~keeper_name:name
       ~settled_at:(Time_compat.now ())
-      ()
   with
   | Error detail -> Error (Restart_event_queue_unavailable { keeper_name = name; detail })
   | Ok initial_event_queue ->

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -45,6 +45,7 @@
   masc_config
   masc_log
   masc_process
+  digestif
   str
   time_compat
   uri

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -35,11 +35,36 @@ type exact_execution_terminal = State.exact_execution_terminal =
   { cause : exact_execution_terminal_cause
   ; slot_id : string
   ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  }
+
+type exact_source_action = State.exact_source_action = Consume_source
+
+type exact_settlement_semantic = State.exact_settlement_semantic =
+  | Exact_no_compaction
+  | Exact_escalate
+
+type exact_source_outcome = State.exact_source_outcome =
+  | Terminal of exact_execution_terminal_cause
+
+type exact_source_disposition = State.exact_source_disposition =
+  { disposition_id : string
+  ; source : Keeper_checkpoint_ref.t
+  ; slot_id : string
+  ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; outcome : exact_source_outcome
+  ; action : exact_source_action
+  ; semantic : exact_settlement_semantic
+  ; prepared_at : float
   }
 
 type exact_execution_lease_status = State.exact_execution_lease_status =
   | Dispatch_uncertain
   | Terminal_quarantined of exact_execution_terminal_cause
+  | Disposition_prepared of exact_source_disposition
 
 type exact_execution_binding = State.exact_execution_binding =
   { lease_id : string
@@ -126,6 +151,7 @@ type settlement = State.settlement =
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
   | Settle_from_source_terminal of accepted_source_terminal
+  | Settle_exact of exact_source_disposition
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -963,8 +989,6 @@ let quarantine_exact_execution_result
       ~keeper_name
       ~lease
       ~terminal
-      ~plan_fingerprint
-      ~request_body_sha256
       ()
   =
   commit_exact_transform
@@ -975,11 +999,34 @@ let quarantine_exact_execution_result
        State.quarantine_exact_execution
          ~lease
          ~terminal
-         ~plan_fingerprint
-         ~request_body_sha256
          state
        |> Result.map (fun next -> next, ()))
   |> Result.map snd
+;;
+
+let prepare_exact_source_disposition_result
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source
+      ~terminal
+      ~semantic
+      ~prepared_at
+      ()
+  =
+  commit_exact_transform
+    ~base_path
+    ~keeper_name
+    ~after_commit:(fun _ -> ())
+    (fun state ->
+       State.prepare_exact_source_disposition
+         ~lease
+         ~source
+         ~terminal
+         ~semantic
+         ~prepared_at
+         state
+       |> Result.map (fun (next, disposition) -> next, disposition))
 ;;
 
 let commit_settlement_transition_unlocked owner ~after_commit transition current =
@@ -1098,7 +1145,7 @@ let settle_result
             (Printexc.to_string exn)))
 ;;
 
-let settle_exact_execution_result
+let settle_bound_exact_nonterminal_result
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
@@ -1122,7 +1169,7 @@ let settle_exact_execution_result
            commit_settlement_transition_unlocked
              owner
              ~after_commit
-             (State.settle_exact_execution
+             (State.settle_bound_exact_nonterminal
                 ~settled_at
                 ~lease
                 ~slot_id
@@ -1137,7 +1184,43 @@ let settle_exact_execution_result
      | exn ->
        Error
          (Printf.sprintf
-            "exact execution settlement raised keeper=%s: %s"
+            "bound exact nonterminal settlement raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let finalize_exact_source_disposition_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~disposition_id
+      ()
+  =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           commit_settlement_transition_unlocked
+             owner
+             ~after_commit
+             (State.finalize_exact_source_disposition
+                ~settled_at
+                ~lease
+                ~disposition_id)
+             state
+           |> Result.map fst)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "exact source disposition settlement raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;
@@ -1288,7 +1371,7 @@ let settle_pending_from_source_terminal_result
             (Printexc.to_string exn)))
 ;;
 
-let prepare_registration_result
+let prepare_registration_after_exact_recovery_result
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
@@ -1303,9 +1386,25 @@ let prepare_registration_result
          match load_state_unlocked owner with
          | Error _ as error -> error
          | Ok state ->
-           (match State.active_lease state with
-            | None -> Ok (State.pending state)
-            | Some lease ->
+           let finish_exact lease disposition state =
+             match
+               commit_settlement_transition_unlocked
+                 owner
+                 ~after_commit
+                 (State.finalize_exact_source_disposition
+                    ~settled_at
+                    ~lease
+                    ~disposition_id:disposition.disposition_id)
+                 state
+             with
+             | Error _ as error -> error
+             | Ok ((Settled _ | Already_settled _), pending) -> Ok pending
+             | Ok (Committed_followup_failed { detail; _ }, _) ->
+               Error
+                 ("exact registration settlement committed with follow-up failure: "
+                  ^ detail)
+           in
+           let recover_generic lease =
               (match
                  commit_settlement_transition_unlocked
                    owner
@@ -1319,7 +1418,26 @@ let prepare_registration_result
                | Error _ as error -> error
                | Ok ((Settled _ | Already_settled _), pending) -> Ok pending
                | Ok (Committed_followup_failed { detail; _ }, _) ->
-                 Error ("registration settlement committed with follow-up failure: " ^ detail))))
+                 Error ("registration settlement committed with follow-up failure: " ^ detail))
+           in
+           (match State.active_lease state, State.exact_execution_binding state with
+            | None, None -> Ok (State.pending state)
+            | Some lease, None -> recover_generic lease
+            | None, Some _ ->
+              Error "exact execution binding has no matching active lease"
+            | Some lease, Some { status = Dispatch_uncertain; _ } ->
+              Error
+                (Printf.sprintf
+                   "dispatch-uncertain exact execution remains fail-closed at registration: %s"
+                   lease.lease_id)
+            | Some lease, Some { status = Terminal_quarantined _; _ } ->
+              Error
+                (Printf.sprintf
+                   "source-less terminal quarantine has no source disposition: %s"
+                   lease.lease_id)
+            | Some lease, Some { status = Disposition_prepared disposition; _ } ->
+              (match disposition.outcome with
+               | Terminal _ -> finish_exact lease disposition state)))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -1328,6 +1446,21 @@ let prepare_registration_result
             "event queue registration settlement raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
+;;
+
+let prepare_registration_result
+      ?after_commit
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ()
+  =
+  prepare_registration_after_exact_recovery_result
+    ?after_commit
+    ~base_path
+    ~keeper_name
+    ~settled_at
+    ()
 ;;
 
 let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -245,7 +245,7 @@ let save_json_atomic_with ~strict_parent_sync path json =
 let save_json_atomic = save_json_atomic_with ~strict_parent_sync:false
 let save_json_atomic_strict = save_json_atomic_with ~strict_parent_sync:true
 
-let save_json_atomic_strict_staged path json =
+let save_json_atomic_strict_staged_with ~save path json =
   match
     try Ok (Fs_compat.mkdir_p (Filename.dirname path)) with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -256,7 +256,7 @@ let save_json_atomic_strict_staged path json =
     let content =
       json |> Safe_ops.sanitize_json_utf8 |> Yojson.Safe.pretty_to_string
     in
-    (match Fs_compat.save_file_atomic_strict_staged path content with
+    (match save path content with
      | Ok () -> Ok Fsync_completed
      | Error (failure : Fs_compat.atomic_replace_failure) ->
        let detail = Fs_compat.atomic_replace_failure_to_string failure in
@@ -268,6 +268,10 @@ let save_json_atomic_strict_staged path json =
            | _ -> Error detail)
         | Fs_compat.After_rename ->
           Ok (Visible_sync_unconfirmed detail)))
+;;
+
+let save_json_atomic_strict_staged =
+  save_json_atomic_strict_staged_with ~save:Fs_compat.save_file_atomic_strict_staged
 ;;
 
 let save_state_unlocked_with ~strict_parent_sync owner state =
@@ -288,10 +292,10 @@ let save_state_unlocked_with ~strict_parent_sync owner state =
 let save_state_unlocked = save_state_unlocked_with ~strict_parent_sync:false
 let save_state_unlocked_strict = save_state_unlocked_with ~strict_parent_sync:true
 
-let save_state_unlocked_strict_staged owner state =
+let save_state_unlocked_strict_staged_with ~save owner state =
   let keeper_name = keeper_name_of_owner owner in
   let path = snapshot_path_of_owner owner in
-  match save_json_atomic_strict_staged path (State.to_yojson state) with
+  match save_json_atomic_strict_staged_with ~save path (State.to_yojson state) with
   | Ok outcome -> Ok outcome
   | Error message ->
     Error
@@ -300,6 +304,11 @@ let save_state_unlocked_strict_staged owner state =
          keeper_name
          path
          message)
+;;
+
+let save_state_unlocked_strict_staged =
+  save_state_unlocked_strict_staged_with
+    ~save:Fs_compat.save_file_atomic_strict_staged
 ;;
 
 type snapshot_read_error_kind =
@@ -787,7 +796,12 @@ let commit_transform
             (Printexc.to_string exn)))
 ;;
 
-let commit_exact_transform_unlocked owner ~after_commit transform =
+let commit_exact_transform_unlocked
+      ?(save_state = save_state_unlocked_strict_staged)
+      owner
+      ~after_commit
+      transform
+  =
   match load_state_unlocked owner with
   | Error _ as error -> error
   | Ok current ->
@@ -800,20 +814,26 @@ let commit_exact_transform_unlocked owner ~after_commit transform =
        (match next with
         | Error _ as error -> error
         | Ok next ->
-          (match save_state_unlocked_strict_staged owner next with
+          (match save_state owner next with
            | Error _ as error -> error
            | Ok outcome ->
              after_commit (State.pending next);
              Ok (value, outcome))))
 ;;
 
-let commit_exact_transform ~base_path ~keeper_name ~after_commit transform =
+let commit_exact_transform
+      ?save_state
+      ~base_path
+      ~keeper_name
+      ~after_commit
+      transform
+  =
   match resolve_owner ~base_path ~keeper_name with
   | Error _ as error -> error
   | Ok owner ->
     (try
        Owner_lock.with_durable_lock owner (fun () ->
-         commit_exact_transform_unlocked owner ~after_commit transform)
+         commit_exact_transform_unlocked ?save_state owner ~after_commit transform)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -1002,7 +1022,8 @@ let quarantine_exact_execution_result
   |> Result.map snd
 ;;
 
-let prepare_exact_source_disposition_result
+let prepare_exact_source_disposition_result_with
+      ?save_state
       ~base_path
       ~keeper_name
       ~lease
@@ -1013,6 +1034,7 @@ let prepare_exact_source_disposition_result
       ()
   =
   commit_exact_transform
+    ?save_state
     ~base_path
     ~keeper_name
     ~after_commit:(fun _ -> ())
@@ -1027,7 +1049,35 @@ let prepare_exact_source_disposition_result
        |> Result.map (fun (next, disposition) -> next, disposition))
 ;;
 
-let commit_settlement_transition_unlocked owner ~after_commit transition current =
+let prepare_exact_source_disposition_result
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source
+      ~terminal
+      ~semantic
+      ~prepared_at
+      ()
+  =
+  prepare_exact_source_disposition_result_with
+    ~base_path
+    ~keeper_name
+    ~lease
+    ~source
+    ~terminal
+    ~semantic
+    ~prepared_at
+    ()
+;;
+
+let commit_settlement_transition_unlocked_with
+      ~save_checkpoint
+      ~compact_wal
+      owner
+      ~after_commit
+      transition
+      current
+  =
   match transition current with
   | Error _ as error -> error
   | Ok (state, State.Already_settled receipt) ->
@@ -1042,14 +1092,14 @@ let commit_settlement_transition_unlocked owner ~after_commit transition current
        let path = settlement_wal_path_of_owner owner in
        let continue_after_commit () =
          let pending = State.pending checkpoint in
-         match save_state_unlocked owner checkpoint with
+         match save_checkpoint owner checkpoint with
          | Error detail ->
            Ok
              ( Committed_followup_failed
                  { receipt; stage = `Checkpoint; detail }
              , pending )
          | Ok () ->
-           (match compact_settlement_wal_unlocked owner with
+           (match compact_wal owner with
             | Error detail ->
               Ok
                 ( Committed_followup_failed
@@ -1108,6 +1158,12 @@ let commit_settlement_transition_unlocked owner ~after_commit transition current
           continue_after_commit ()))
      | [] | [ _ ] | _ :: _ :: _ ->
        Error "settlement transition did not produce its canonical outbox entry")
+;;
+
+let commit_settlement_transition_unlocked =
+  commit_settlement_transition_unlocked_with
+    ~save_checkpoint:save_state_unlocked
+    ~compact_wal:compact_settlement_wal_unlocked
 ;;
 
 let settle_result
@@ -1187,7 +1243,9 @@ let settle_bound_exact_nonterminal_result
             (Printexc.to_string exn)))
 ;;
 
-let finalize_exact_source_disposition_result
+let finalize_exact_source_disposition_result_with
+      ~save_checkpoint
+      ~compact_wal
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
@@ -1204,7 +1262,9 @@ let finalize_exact_source_disposition_result
          match load_state_unlocked owner with
          | Error _ as error -> error
          | Ok state ->
-           commit_settlement_transition_unlocked
+           commit_settlement_transition_unlocked_with
+             ~save_checkpoint
+             ~compact_wal
              owner
              ~after_commit
              (State.finalize_exact_source_disposition
@@ -1222,6 +1282,88 @@ let finalize_exact_source_disposition_result
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;
+
+let finalize_exact_source_disposition_result
+      ?after_commit
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~disposition_id
+      ()
+  =
+  finalize_exact_source_disposition_result_with
+    ~save_checkpoint:save_state_unlocked
+    ~compact_wal:compact_settlement_wal_unlocked
+    ?after_commit
+    ~base_path
+    ~keeper_name
+    ~settled_at
+    ~lease
+    ~disposition_id
+    ()
+;;
+
+module For_testing = struct
+  type settlement_followup_failure =
+    | Fail_checkpoint of string
+    | Fail_wal_compaction of string
+
+  let finalize_exact_source_disposition_with_followup_failure_result
+        ~failure
+        ~base_path
+        ~keeper_name
+        ~settled_at
+        ~lease
+        ~disposition_id
+        ()
+    =
+    let save_checkpoint, compact_wal =
+      match failure with
+      | Fail_checkpoint detail ->
+        ( (fun _owner _state -> Error detail)
+        , compact_settlement_wal_unlocked )
+      | Fail_wal_compaction detail ->
+        save_state_unlocked, (fun _owner -> Error detail)
+    in
+    finalize_exact_source_disposition_result_with
+      ~save_checkpoint
+      ~compact_wal
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~disposition_id
+      ()
+  ;;
+
+  let prepare_exact_source_disposition_with_sync_parent_result
+        ~sync_parent
+        ~base_path
+        ~keeper_name
+        ~lease
+        ~source
+        ~terminal
+        ~semantic
+        ~prepared_at
+        ()
+    =
+    let save =
+      Fs_compat.Atomic_replace_for_testing.save_file_atomic_strict_staged
+        ~sync_parent
+    in
+    prepare_exact_source_disposition_result_with
+      ~save_state:(save_state_unlocked_strict_staged_with ~save)
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source
+      ~terminal
+      ~semantic
+      ~prepared_at
+      ()
+  ;;
+end
 
 let cancel_accepted_result
       ?(after_commit = fun _ -> ())

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -14,8 +14,6 @@ type requeue_reason = State.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Approval_grant_unconsumed
-  | Approval_grant_state_unavailable
 
 type exact_execution_terminal_cause = State.exact_execution_terminal_cause =
   | Execution_failed_after_dispatch

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -356,6 +356,34 @@ val finalize_exact_source_disposition_result :
   unit ->
   (settle_result, string) result
 
+module For_testing : sig
+  type settlement_followup_failure =
+    | Fail_checkpoint of string
+    | Fail_wal_compaction of string
+
+  val finalize_exact_source_disposition_with_followup_failure_result :
+    failure:settlement_followup_failure ->
+    base_path:string ->
+    keeper_name:string ->
+    settled_at:float ->
+    lease:lease ->
+    disposition_id:string ->
+    unit ->
+    (settle_result, string) result
+
+  val prepare_exact_source_disposition_with_sync_parent_result :
+    sync_parent:(string -> unit) ->
+    base_path:string ->
+    keeper_name:string ->
+    lease:lease ->
+    source:Keeper_checkpoint_ref.t ->
+    terminal:exact_execution_terminal ->
+    semantic:exact_settlement_semantic ->
+    prepared_at:float ->
+    unit ->
+    (exact_source_disposition * exact_write_outcome, string) result
+end
+
 val settle_bound_exact_nonterminal_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,10 +1,11 @@
 (** Durable per-Keeper Event Layer state.
 
-    [event-queue.json] keeps the current v4 envelope containing pending stimuli, active
+    [event-queue.json] keeps the v5 envelope containing pending stimuli, active
     typed leases, exact-execution dispatch fences, the monotonic lease
-    sequence, transition outbox, and durable accepted-transfer target accounting.
-    Stale schemas and [event-queue-inflight.json] fail closed rather than being
-    migrated or treated as a second authority. *)
+    sequence, transition outbox, and durable accepted-transfer target
+    accounting. Only the current schema is accepted; stale or unknown state
+    fails closed and requires reset. [event-queue-inflight.json] is rejected
+    explicitly rather than migrated or treated as a second authority. *)
 
 type lease_kind = Keeper_event_queue_state.lease_kind =
   | Single
@@ -40,11 +41,37 @@ type exact_execution_terminal = Keeper_event_queue_state.exact_execution_termina
   { cause : exact_execution_terminal_cause
   ; slot_id : string
   ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  }
+
+type exact_source_action = Keeper_event_queue_state.exact_source_action =
+  | Consume_source
+
+type exact_settlement_semantic = Keeper_event_queue_state.exact_settlement_semantic =
+  | Exact_no_compaction
+  | Exact_escalate
+
+type exact_source_outcome = Keeper_event_queue_state.exact_source_outcome =
+  | Terminal of exact_execution_terminal_cause
+
+type exact_source_disposition = Keeper_event_queue_state.exact_source_disposition =
+  { disposition_id : string
+  ; source : Keeper_checkpoint_ref.t
+  ; slot_id : string
+  ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; outcome : exact_source_outcome
+  ; action : exact_source_action
+  ; semantic : exact_settlement_semantic
+  ; prepared_at : float
   }
 
 type exact_execution_lease_status = Keeper_event_queue_state.exact_execution_lease_status =
   | Dispatch_uncertain
   | Terminal_quarantined of exact_execution_terminal_cause
+  | Disposition_prepared of exact_source_disposition
 
 type exact_execution_binding = Keeper_event_queue_state.exact_execution_binding =
   { lease_id : string
@@ -136,6 +163,7 @@ type settlement = Keeper_event_queue_state.settlement =
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
   | Settle_from_source_terminal of accepted_source_terminal
+  | Settle_exact of exact_source_disposition
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -226,10 +254,11 @@ val load_snapshot_pair_with_errors :
 
 val load_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
-(** Strict state read used by tests and operator projection. A malformed v3
-    envelope or v3-plus-legacy residue is an [Error], never an empty queue.
-    Committed WAL rows are replayed idempotently, checkpointed, and then
-    compacted to the exact empty suffix before the state is returned. *)
+(** Strict state read used by tests and operator projection. A malformed
+    current envelope or stale/unknown schema is an [Error], never an empty
+    queue. Committed current-schema WAL rows are replayed idempotently,
+    checkpointed, and then compacted to the exact empty suffix before the state
+    is returned. *)
 
 val claim_when_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -302,15 +331,34 @@ val quarantine_exact_execution_result :
   keeper_name:string ->
   lease:lease ->
   terminal:exact_execution_terminal ->
-  plan_fingerprint:string ->
-  request_body_sha256:string ->
   unit ->
   (exact_write_outcome, string) result
 (** Persist the canonical post-dispatch terminal cause. A visible replacement
     with unconfirmed directory sync keeps that original cause and remains
     eligible for matching source-bound settlement. *)
 
-val settle_exact_execution_result :
+val prepare_exact_source_disposition_result :
+  base_path:string ->
+  keeper_name:string ->
+  lease:lease ->
+  source:Keeper_checkpoint_ref.t ->
+  terminal:exact_execution_terminal ->
+  semantic:exact_settlement_semantic ->
+  prepared_at:float ->
+  unit ->
+  (exact_source_disposition * exact_write_outcome, string) result
+
+val finalize_exact_source_disposition_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  settled_at:float ->
+  lease:lease ->
+  disposition_id:string ->
+  unit ->
+  (settle_result, string) result
+
+val settle_bound_exact_nonterminal_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
   keeper_name:string ->
@@ -323,6 +371,9 @@ val settle_exact_execution_result :
   settlement:settlement ->
   unit ->
   (settle_result, string) result
+(** Commit only the identity-bound nonterminal Ack/retry/floor/failure-judgment
+    cases. Exact terminal outcomes require durable source preparation and
+    [finalize_exact_source_disposition_result]. *)
 
 val cancel_accepted_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -386,6 +437,18 @@ val prepare_registration_result :
     resulting pending projection from the same durable transaction. A malformed
     state is an [Error]; registration must not substitute an empty queue.
     Post-commit [Error] names that fact; retry replays the exact WAL cursor. *)
+
+val prepare_registration_after_exact_recovery_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  settled_at:float ->
+  unit ->
+  (Keeper_event_queue.t, string) result
+(** Under one owner durable lock, replay the settlement WAL, finalize a
+    validated terminal v5 exact disposition, then and only then apply ordinary
+    registration recovery. Dispatch-uncertain bindings and source-less terminal
+    quarantines remain fail-closed. *)
 
 val mark_transition_projected_result :
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -20,8 +20,6 @@ type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Approval_grant_unconsumed
-  | Approval_grant_state_unavailable
 
 type exact_execution_terminal_cause = Keeper_event_queue_state.exact_execution_terminal_cause =
   | Execution_failed_after_dispatch

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -37,11 +37,35 @@ type exact_execution_terminal =
   { cause : exact_execution_terminal_cause
   ; slot_id : string
   ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  }
+
+type exact_source_action = Consume_source
+
+type exact_settlement_semantic =
+  | Exact_no_compaction
+  | Exact_escalate
+
+type exact_source_outcome = Terminal of exact_execution_terminal_cause
+
+type exact_source_disposition =
+  { disposition_id : string
+  ; source : Keeper_checkpoint_ref.t
+  ; slot_id : string
+  ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; outcome : exact_source_outcome
+  ; action : exact_source_action
+  ; semantic : exact_settlement_semantic
+  ; prepared_at : float
   }
 
 type exact_execution_lease_status =
   | Dispatch_uncertain
   | Terminal_quarantined of exact_execution_terminal_cause
+  | Disposition_prepared of exact_source_disposition
 
 type exact_execution_binding =
   { lease_id : string
@@ -152,6 +176,7 @@ type settlement =
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
   | Settle_from_source_terminal of accepted_source_terminal
+  | Settle_exact of exact_source_disposition
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -199,7 +224,7 @@ type transfer_projection_result =
   | Transfer_projected
   | Transfer_already_projected
 
-let schema = "keeper.event_queue.state.v4"
+let schema = "keeper.event_queue.state.v5"
 
 let empty =
   { revision = 0L
@@ -471,15 +496,19 @@ let validate_exact_execution_terminal (terminal : exact_execution_terminal) =
     else Ok ()
   in
   let* () = validate_identity "slot_id" terminal.slot_id in
-  validate_identity "call_id" terminal.call_id
+  let* () = validate_identity "call_id" terminal.call_id in
+  let* () = validate_identity "plan_fingerprint" terminal.plan_fingerprint in
+  validate_identity "request_body_sha256" terminal.request_body_sha256
 ;;
 
 let exact_execution_terminal_to_string terminal =
   Printf.sprintf
-    "%s:slot_id=%s:call_id=%s"
+    "%s:slot_id=%s:call_id=%s:plan_fingerprint=%s:request_body_sha256=%s"
     (exact_execution_terminal_cause_label terminal.cause)
     terminal.slot_id
     terminal.call_id
+    terminal.plan_fingerprint
+    terminal.request_body_sha256
 ;;
 
 let checkpoint_source_reason_detail_to_yojson (source : Keeper_checkpoint_ref.t) =
@@ -522,6 +551,8 @@ let escalation_reason_detail_to_yojson = function
       ; "cause", `String (exact_execution_terminal_cause_label terminal.cause)
       ; "slot_id", `String terminal.slot_id
       ; "call_id", `String terminal.call_id
+      ; "plan_fingerprint", `String terminal.plan_fingerprint
+      ; "request_body_sha256", `String terminal.request_body_sha256
       ]
   | Compaction_retry_exhausted { attempts; detail } ->
     `Assoc [ "attempts", `Int attempts; "detail", `String detail ]
@@ -596,7 +627,13 @@ let escalation_reason_of_wire ~label ~detail_json =
     let* () =
       exact_reason_fields
         ~context
-        [ "source"; "cause"; "slot_id"; "call_id" ]
+        [ "source"
+        ; "cause"
+        ; "slot_id"
+        ; "call_id"
+        ; "plan_fingerprint"
+        ; "request_body_sha256"
+        ]
         fields
     in
     let* source_json =
@@ -618,7 +655,15 @@ let escalation_reason_of_wire ~label ~detail_json =
     let* cause = exact_execution_terminal_cause_of_label cause_label in
     let* slot_id = required_nonempty_reason_string ~context "slot_id" fields in
     let* call_id = required_nonempty_reason_string ~context "call_id" fields in
-    let terminal = { cause; slot_id; call_id } in
+    let* plan_fingerprint =
+      required_nonempty_reason_string ~context "plan_fingerprint" fields
+    in
+    let* request_body_sha256 =
+      required_nonempty_reason_string ~context "request_body_sha256" fields
+    in
+    let terminal =
+      { cause; slot_id; call_id; plan_fingerprint; request_body_sha256 }
+    in
     let* () = validate_exact_execution_terminal terminal in
     Ok (Compaction_exact_output_terminal { source; terminal })
   | "compaction_exact_lane_unconfigured", `Assoc fields ->
@@ -738,12 +783,23 @@ let settlement_kind_label = function
   | Cancel_accepted _ -> "cancel_accepted"
   | Transfer_accepted _ -> "transfer_accepted"
   | Settle_from_source_terminal _ -> "settle_from_source_terminal"
+  | Settle_exact _ -> "settle_exact"
   | Requeue _ -> "requeue"
   | Escalate _ -> "escalate"
 ;;
 
 let transition_id (lease : lease) settlement =
-  Printf.sprintf "%s:%s" lease.lease_id (settlement_kind_label settlement)
+  match settlement with
+  | Settle_exact disposition ->
+    Printf.sprintf "%s:settle_exact:%s" lease.lease_id disposition.disposition_id
+  | Ack
+  | No_compaction _
+  | Cancel_accepted _
+  | Transfer_accepted _
+  | Settle_from_source_terminal _
+  | Requeue _
+  | Escalate _ ->
+    Printf.sprintf "%s:%s" lease.lease_id (settlement_kind_label settlement)
 ;;
 
 let event_id_of_transition transition_id =
@@ -768,19 +824,13 @@ let settlement_equal left right =
   | Transfer_accepted left, Transfer_accepted right -> left = right
   | Settle_from_source_terminal left, Settle_from_source_terminal right ->
     left = right
+  | Settle_exact left, Settle_exact right -> left = right
   | Requeue left, Requeue right -> left = right
   | ( Escalate { reason = left_reason; successor = left_successor }
     , Escalate { reason = right_reason; successor = right_successor } ) ->
     left_reason = right_reason
     && successor_equal left_successor right_successor
-  | Ack, (No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
-  | No_compaction _, (Ack | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
-  | Cancel_accepted _, (Ack | No_compaction _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
-  | Transfer_accepted _, (Ack | No_compaction _ | Cancel_accepted _ | Settle_from_source_terminal _ | Requeue _ | Escalate _)
-  | Settle_from_source_terminal _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Requeue _ | Escalate _)
-  | Requeue _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Escalate _)
-  | Escalate _, (Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ | Requeue _) ->
-    false
+  | _ -> false
 ;;
 
 let transition_receipt_equal left right =
@@ -858,6 +908,91 @@ let validate_accepted_source_terminal source_terminal =
     else Error "source-terminal settlement receipt does not match source payload"
 ;;
 
+let checkpoint_ref_identity (reference : Keeper_checkpoint_ref.t) =
+  String.concat
+    "\000"
+    [ Keeper_id.Trace_id.to_string reference.trace_id
+    ; string_of_int reference.generation
+    ; string_of_int reference.turn_count
+    ; reference.sha256
+    ]
+;;
+
+let exact_source_outcome_identity = function
+  | Terminal cause ->
+    "terminal\000" ^ exact_execution_terminal_cause_label cause
+;;
+
+let exact_source_action_identity Consume_source = "consume_source"
+
+let exact_settlement_semantic_label = function
+  | Exact_no_compaction -> "no_compaction"
+  | Exact_escalate -> "escalate"
+;;
+
+let exact_source_disposition_id_of_fields
+      ~source
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+      ~outcome
+      ~action
+      ~semantic
+      ~prepared_at:_
+  =
+  String.concat
+    "\000"
+    [ "keeper.exact_source_disposition.v1"
+    ; checkpoint_ref_identity source
+    ; slot_id
+    ; call_id
+    ; plan_fingerprint
+    ; request_body_sha256
+    ; exact_source_outcome_identity outcome
+    ; exact_source_action_identity action
+    ; exact_settlement_semantic_label semantic
+    ]
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let validate_exact_source_disposition
+      (disposition : exact_source_disposition)
+  =
+  let terminal =
+    match disposition.outcome with
+    | Terminal cause ->
+      { cause
+      ; slot_id = disposition.slot_id
+      ; call_id = disposition.call_id
+      ; plan_fingerprint = disposition.plan_fingerprint
+      ; request_body_sha256 = disposition.request_body_sha256
+      }
+  in
+  let* () = validate_exact_execution_terminal terminal in
+  let expected_id =
+    exact_source_disposition_id_of_fields
+      ~source:disposition.source
+      ~slot_id:disposition.slot_id
+      ~call_id:disposition.call_id
+      ~plan_fingerprint:disposition.plan_fingerprint
+      ~request_body_sha256:disposition.request_body_sha256
+      ~outcome:disposition.outcome
+      ~action:disposition.action
+      ~semantic:disposition.semantic
+      ~prepared_at:disposition.prepared_at
+  in
+  if not (Float.is_finite disposition.prepared_at)
+  then Error "exact source disposition preparation time must be finite"
+  else if not (String.equal disposition.disposition_id expected_id)
+  then Error "exact source disposition id does not match its immutable fields"
+  else
+    match disposition.semantic, disposition.action with
+    | (Exact_no_compaction | Exact_escalate), Consume_source ->
+      Ok ()
+;;
+
 let validate_settlement = function
   | Ack | Requeue _ -> Ok ()
   | No_compaction { reason = Exact_execution_terminal terminal; _ } ->
@@ -876,6 +1011,7 @@ let validate_settlement = function
   | Transfer_accepted transfer -> validate_accepted_transfer transfer
   | Settle_from_source_terminal source_terminal ->
     validate_accepted_source_terminal source_terminal
+  | Settle_exact disposition -> validate_exact_source_disposition disposition
   | Escalate
       { reason = Failure_judgment_requested
       ; successor =
@@ -987,7 +1123,7 @@ let validate_settlement_for_stimuli settlement stimuli =
     Error "source-terminal receipt does not match its exact event stimulus"
   | Settle_from_source_terminal _, _ ->
     Error "source-terminal settlement requires exactly one accepted event stimulus"
-  | (Ack | Requeue _ | Escalate _), _ -> Ok ()
+  | (Ack | Settle_exact _ | Requeue _ | Escalate _), _ -> Ok ()
 ;;
 
 let validate_settlement_for_lease settlement (lease : lease) =
@@ -1059,22 +1195,11 @@ let binding_identity_equal
   && String.equal binding.request_body_sha256 request_body_sha256
 ;;
 
-let validate_bound_settlement binding settlement =
-  let terminal_matches ?cause (terminal : exact_execution_terminal) =
-    binding_call_identity_equal binding ~slot_id:terminal.slot_id ~call_id:terminal.call_id
-    &&
-    match cause with
-    | None -> true
-    | Some cause -> cause = terminal.cause
-  in
-  match binding.status, settlement with
-  | Dispatch_uncertain, Ack -> Ok ()
-  | Dispatch_uncertain, Requeue Context_compaction_retry -> Ok ()
-  | Dispatch_uncertain,
-    Escalate { reason = Compaction_floor_exceeded _; successor = None } ->
-    Ok ()
-  | Dispatch_uncertain,
-    Escalate
+let identity_bound_nonterminal_settlement = function
+  | Ack -> true
+  | Requeue Context_compaction_retry -> true
+  | Escalate { reason = Compaction_floor_exceeded _; successor = None } -> true
+  | Escalate
       { reason = Failure_judgment_requested
       ; successor =
           Some
@@ -1082,29 +1207,41 @@ let validate_bound_settlement binding settlement =
             ; _
             }
       } ->
-    Ok ()
-  | Dispatch_uncertain, No_compaction { reason = Exact_execution_terminal terminal; _ }
-    when terminal_matches terminal -> Ok ()
-  | Dispatch_uncertain,
-    Escalate
-      { reason = Compaction_exact_output_terminal { terminal; _ }; successor = None }
-    when terminal_matches terminal -> Ok ()
-  | Terminal_quarantined cause, No_compaction { reason = Exact_execution_terminal terminal; _ }
-    when terminal_matches ~cause terminal -> Ok ()
-  | Terminal_quarantined cause,
-    Escalate
-      { reason = Compaction_exact_output_terminal { terminal; _ }; successor = None }
-    when terminal_matches ~cause terminal -> Ok ()
+    true
+  | No_compaction _
+  | Cancel_accepted _
+  | Transfer_accepted _
+  | Settle_from_source_terminal _
+  | Settle_exact _
+  | Requeue _
+  | Escalate _ ->
+    false
+;;
+
+let validate_bound_settlement binding settlement =
+  match binding.status, settlement with
+  | Disposition_prepared disposition, Settle_exact requested
+    when disposition = requested -> Ok ()
+  | Disposition_prepared _, Settle_exact _ ->
+    Error "exact source disposition proof conflicts with its durable binding"
+  | Dispatch_uncertain, settlement
+    when identity_bound_nonterminal_settlement settlement -> Ok ()
   | Dispatch_uncertain, _ ->
     Error
       (Printf.sprintf
-         "exact execution lease %s call %s requires an identity-bound terminal or ack settlement"
+         "exact execution lease %s call %s requires an identity-bound nonterminal settlement or a prepared full source disposition"
          binding.lease_id
          binding.call_id)
   | Terminal_quarantined _, _ ->
     Error
       (Printf.sprintf
-         "quarantined exact execution lease %s call %s requires its matching terminal settlement"
+         "quarantined exact execution lease %s call %s requires a prepared full source disposition"
+         binding.lease_id
+         binding.call_id)
+  | Disposition_prepared _, _ ->
+    Error
+      (Printf.sprintf
+         "exact execution lease %s call %s requires Settle_exact with its full durable proof"
          binding.lease_id
          binding.call_id)
 ;;
@@ -1184,6 +1321,12 @@ let bind_exact_execution
          (Printf.sprintf
             "exact execution lease %s call %s is already terminally quarantined"
             lease.lease_id
+            call_id)
+     | Disposition_prepared _ ->
+       Error
+         (Printf.sprintf
+            "exact execution lease %s call %s already owns a source disposition"
+            lease.lease_id
             call_id))
   | [ binding ] ->
     Error
@@ -1228,6 +1371,12 @@ let release_exact_execution_before_dispatch
       (Printf.sprintf
          "terminally quarantined exact execution lease cannot be released: %s"
          lease.lease_id)
+  | Some
+      { status = Disposition_prepared _; _ } ->
+    Error
+      (Printf.sprintf
+         "source-disposition exact execution lease cannot be released: %s"
+         lease.lease_id)
   | Some { status = Dispatch_uncertain; _ } ->
     Ok { state with exact_execution_bindings = [] }
 ;;
@@ -1235,8 +1384,6 @@ let release_exact_execution_before_dispatch
 let quarantine_exact_execution
       ~(lease : lease)
       ~(terminal : exact_execution_terminal)
-      ~plan_fingerprint
-      ~request_body_sha256
       state
   =
   let* () =
@@ -1244,8 +1391,8 @@ let quarantine_exact_execution
       ~lease
       ~slot_id:terminal.slot_id
       ~call_id:terminal.call_id
-      ~plan_fingerprint
-      ~request_body_sha256
+      ~plan_fingerprint:terminal.plan_fingerprint
+      ~request_body_sha256:terminal.request_body_sha256
   in
   let* () = validate_exact_execution_terminal terminal in
   match binding_for_lease lease state with
@@ -1256,8 +1403,8 @@ let quarantine_exact_execution
               binding
               ~slot_id:terminal.slot_id
               ~call_id:terminal.call_id
-              ~plan_fingerprint
-              ~request_body_sha256) ->
+              ~plan_fingerprint:terminal.plan_fingerprint
+              ~request_body_sha256:terminal.request_body_sha256) ->
     Error (Printf.sprintf "exact execution binding identity conflict: %s" lease.lease_id)
   | Some ({ status = Dispatch_uncertain; _ } as binding) ->
     Ok
@@ -1268,6 +1415,117 @@ let quarantine_exact_execution
   | Some { status = Terminal_quarantined cause; _ } when cause = terminal.cause -> Ok state
   | Some { status = Terminal_quarantined _; _ } ->
     Error (Printf.sprintf "exact execution terminal cause conflict: %s" lease.lease_id)
+  | Some
+      { status = Disposition_prepared disposition; _ } ->
+    (match disposition.outcome with
+     | Terminal cause when cause = terminal.cause -> Ok state
+     | Terminal _ ->
+       Error (Printf.sprintf "exact execution terminal cause conflict: %s" lease.lease_id))
+;;
+
+let prepare_exact_source_disposition
+      ~(lease : lease)
+      ~source
+      ~(terminal : exact_execution_terminal)
+      ~semantic
+      ~prepared_at
+      state
+  =
+  let slot_id = terminal.slot_id in
+  let call_id = terminal.call_id in
+  let plan_fingerprint = terminal.plan_fingerprint in
+  let request_body_sha256 = terminal.request_body_sha256 in
+  let outcome = Terminal terminal.cause in
+  let action = Consume_source in
+  let* () = validate_exact_execution_terminal terminal in
+  let* () =
+    validate_binding_arguments
+      ~lease
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+  in
+  let* () =
+    if Float.is_finite prepared_at
+    then Ok ()
+    else Error "exact source disposition preparation time must be finite"
+  in
+  let* () =
+    match committed_lease lease state with
+    | Some committed when lease_equal committed lease -> Ok ()
+    | Some _ -> Error (Printf.sprintf "event queue lease payload conflict: %s" lease.lease_id)
+    | None -> Error (Printf.sprintf "event queue lease not found: %s" lease.lease_id)
+  in
+  match binding_for_lease lease state with
+  | None -> Error (Printf.sprintf "exact execution lease is not bound: %s" lease.lease_id)
+  | Some binding
+    when not
+           (binding_identity_equal
+              binding
+              ~slot_id
+              ~call_id
+              ~plan_fingerprint
+              ~request_body_sha256) ->
+    Error (Printf.sprintf "exact execution binding identity conflict: %s" lease.lease_id)
+  | Some binding ->
+    let disposition_id =
+      exact_source_disposition_id_of_fields
+        ~source
+        ~slot_id
+        ~call_id
+        ~plan_fingerprint
+        ~request_body_sha256
+        ~outcome
+        ~action
+        ~semantic
+        ~prepared_at
+    in
+    let disposition =
+      { disposition_id
+      ; source
+      ; slot_id
+      ; call_id
+      ; plan_fingerprint
+      ; request_body_sha256
+      ; outcome
+      ; action
+      ; semantic
+      ; prepared_at
+      }
+    in
+    let* () = validate_exact_source_disposition disposition in
+    let prepared_status = Disposition_prepared disposition in
+    (match binding.status with
+     | Dispatch_uncertain ->
+       Ok
+         ( { state with
+             exact_execution_bindings =
+               [ { binding with status = prepared_status } ]
+           }
+         , disposition )
+     | Terminal_quarantined cause ->
+       (match outcome with
+        | Terminal requested when requested = cause ->
+          Ok
+            ( { state with
+                exact_execution_bindings =
+                  [ { binding with status = prepared_status } ]
+              }
+            , disposition )
+        | Terminal _ ->
+          Error
+            (Printf.sprintf
+               "exact execution terminal cause conflict: %s"
+               lease.lease_id))
+     | Disposition_prepared existing ->
+       if String.equal existing.disposition_id disposition.disposition_id
+       then Ok (state, existing)
+       else
+         Error
+           (Printf.sprintf
+              "exact source disposition conflict: %s"
+              lease.lease_id))
 ;;
 
 let settle_committed ~settled_at ~lease ~settlement state =
@@ -1303,6 +1561,7 @@ let settle_committed ~settled_at ~lease ~settlement state =
       match settlement with
       | Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _
       | Settle_from_source_terminal _ -> state.pending
+      | Settle_exact { action = Consume_source; _ } -> state.pending
       | Requeue
           ( Retry_after_observed
           | Context_compaction_retry
@@ -1347,13 +1606,14 @@ let settle ~settled_at ~lease ~settlement state =
          binding.call_id)
   | None ->
     (match settlement with
-     | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _ ->
+     | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _
+     | Settle_exact _ ->
        Error "accepted disposition requires its owner-fenced boundary"
      | Ack | No_compaction _ | Requeue _ | Escalate _ ->
        settle_committed ~settled_at ~lease ~settlement state)
 ;;
 
-let settle_exact_execution
+let settle_bound_exact_nonterminal
       ~settled_at
       ~lease
       ~slot_id
@@ -1363,6 +1623,11 @@ let settle_exact_execution
       ~settlement
       state
   =
+  let* () =
+    if identity_bound_nonterminal_settlement settlement
+    then Ok ()
+    else Error "bound exact terminal settlement requires a prepared full source disposition"
+  in
   let* () =
     validate_binding_arguments
       ~lease
@@ -1389,6 +1654,36 @@ let settle_exact_execution
             "active exact execution lease is not durably bound: %s"
             lease.lease_id)
      | None -> settle_committed ~settled_at ~lease ~settlement state)
+;;
+
+let finalize_exact_source_disposition
+      ~settled_at
+      ~(lease : lease)
+      ~disposition_id
+      state
+  =
+  match binding_for_lease lease state with
+  | Some { status = Disposition_prepared disposition; _ } ->
+    if not (String.equal disposition.disposition_id disposition_id)
+    then Error (Printf.sprintf "exact source disposition identity conflict: %s" lease.lease_id)
+    else
+      settle_committed
+        ~settled_at
+        ~lease
+        ~settlement:(Settle_exact disposition)
+        state
+  | Some { status = Dispatch_uncertain; _ } ->
+    Error "dispatch-uncertain exact execution has no source disposition"
+  | Some { status = Terminal_quarantined _; _ } ->
+    Error "source-less terminal quarantine has no source disposition"
+  | None ->
+    (match find_prior_receipt lease.lease_id state with
+     | Some ({ settlement = Settle_exact disposition; _ } as receipt)
+       when String.equal disposition.disposition_id disposition_id ->
+       Ok (state, Already_settled receipt)
+     | Some _ ->
+       Error (Printf.sprintf "exact source disposition replay conflict: %s" lease.lease_id)
+     | None -> Error (Printf.sprintf "exact execution lease is not bound: %s" lease.lease_id))
 ;;
 
 let cancel_accepted
@@ -1431,7 +1726,7 @@ let disposition_operation_id = function
   | Transfer_accepted transfer -> Some transfer.operator_operation_id
   | Settle_from_source_terminal source_terminal ->
     Some source_terminal.operator_operation_id
-  | Ack | No_compaction _ | Requeue _ | Escalate _ -> None
+  | Ack | No_compaction _ | Settle_exact _ | Requeue _ | Escalate _ -> None
 ;;
 
 let prior_disposition_by_operation_id operation_id state =
@@ -1715,11 +2010,32 @@ let replay_transition_receipt receipt state =
   with
   | Some lease ->
     let* state, result =
-      settle_committed
-        ~settled_at:receipt.settled_at
-        ~lease
-        ~settlement:receipt.settlement
-        state
+      match receipt.settlement with
+      | Settle_exact disposition ->
+        finalize_exact_source_disposition
+          ~settled_at:receipt.settled_at
+          ~lease
+          ~disposition_id:disposition.disposition_id
+          state
+      | Ack
+      | No_compaction _
+      | Cancel_accepted _
+      | Transfer_accepted _
+      | Settle_from_source_terminal _
+      | Requeue _
+      | Escalate _ ->
+        (match binding_for_lease lease state with
+         | Some _ ->
+           Error
+             (Printf.sprintf
+                "generic WAL receipt cannot settle exact execution lease: %s"
+                lease.lease_id)
+         | None ->
+           settle_committed
+             ~settled_at:receipt.settled_at
+             ~lease
+             ~settlement:receipt.settlement
+             state)
     in
     let actual =
       match result with
@@ -1878,7 +2194,7 @@ let replay_transition_outbox_entry entry state =
              Error "pending source-terminal WAL source conflicts with its receipt"
            | Settle_from_source_terminal _, ([] | _ :: _ :: _) ->
              Error "pending source-terminal WAL must carry exactly one source"
-           | (Ack | No_compaction _ | Requeue _ | Escalate _), _ ->
+           | (Ack | No_compaction _ | Settle_exact _ | Requeue _ | Escalate _), _ ->
              Error
                (Printf.sprintf
                   "event queue WAL receipt has no matching active lease: %s"
@@ -2088,6 +2404,8 @@ let exact_execution_terminal_to_yojson terminal =
     [ "cause", `String (exact_execution_terminal_cause_label terminal.cause)
     ; "slot_id", `String terminal.slot_id
     ; "call_id", `String terminal.call_id
+    ; "plan_fingerprint", `String terminal.plan_fingerprint
+    ; "request_body_sha256", `String terminal.request_body_sha256
     ]
 ;;
 
@@ -2095,13 +2413,28 @@ let exact_execution_terminal_of_yojson json =
   let context = "exact execution terminal" in
   let* fields = assoc_fields ~context json in
   let* () =
-    exact_fields ~context ~expected:[ "cause"; "slot_id"; "call_id" ] fields
+    exact_fields
+      ~context
+      ~expected:
+        [ "cause"
+        ; "slot_id"
+        ; "call_id"
+        ; "plan_fingerprint"
+        ; "request_body_sha256"
+        ]
+      fields
   in
   let* cause_label = string_field ~context "cause" fields in
   let* cause = exact_execution_terminal_cause_of_label cause_label in
   let* slot_id = string_field ~context "slot_id" fields in
   let* call_id = string_field ~context "call_id" fields in
-  let terminal = { cause; slot_id; call_id } in
+  let* plan_fingerprint = string_field ~context "plan_fingerprint" fields in
+  let* request_body_sha256 =
+    string_field ~context "request_body_sha256" fields
+  in
+  let terminal =
+    { cause; slot_id; call_id; plan_fingerprint; request_body_sha256 }
+  in
   let* () = validate_exact_execution_terminal terminal in
   Ok terminal
 ;;
@@ -2137,6 +2470,104 @@ let checkpoint_source_of_yojson json =
       Printf.sprintf "no-compaction checkpoint turn count is negative: %d" value
     | Invalid_sha256 value ->
       Printf.sprintf "no-compaction checkpoint digest is invalid: %s" value)
+;;
+
+let exact_source_disposition_to_yojson disposition =
+  let terminal_cause =
+    match disposition.outcome with
+    | Terminal cause ->
+      `String (exact_execution_terminal_cause_label cause)
+  in
+  let action_kind =
+    match disposition.action with
+    | Consume_source -> "consume_source"
+  in
+  `Assoc
+    [ "disposition_id", `String disposition.disposition_id
+    ; "source", checkpoint_source_to_yojson disposition.source
+    ; "slot_id", `String disposition.slot_id
+    ; "call_id", `String disposition.call_id
+    ; "plan_fingerprint", `String disposition.plan_fingerprint
+    ; "request_body_sha256", `String disposition.request_body_sha256
+    ; "terminal_cause", terminal_cause
+    ; "action_kind", `String action_kind
+    ; ( "settlement_semantic"
+      , `String (exact_settlement_semantic_label disposition.semantic) )
+    ; "prepared_at_unix", `Float disposition.prepared_at
+    ]
+;;
+
+let exact_source_disposition_of_yojson json =
+  let context = "exact source disposition" in
+  let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:
+        [ "disposition_id"
+        ; "source"
+        ; "slot_id"
+        ; "call_id"
+        ; "plan_fingerprint"
+        ; "request_body_sha256"
+        ; "terminal_cause"
+        ; "action_kind"
+        ; "settlement_semantic"
+        ; "prepared_at_unix"
+        ]
+      fields
+  in
+  let* disposition_id = string_field ~context "disposition_id" fields in
+  let* source_json = required_field ~context "source" fields in
+  let* source = checkpoint_source_of_yojson source_json in
+  let* slot_id = string_field ~context "slot_id" fields in
+  let* call_id = string_field ~context "call_id" fields in
+  let* plan_fingerprint = string_field ~context "plan_fingerprint" fields in
+  let* request_body_sha256 = string_field ~context "request_body_sha256" fields in
+  let* terminal_cause_json = required_field ~context "terminal_cause" fields in
+  let* outcome =
+    match terminal_cause_json with
+    | `String cause ->
+      let* cause = exact_execution_terminal_cause_of_label cause in
+      Ok (Terminal cause)
+    | _ -> Error "terminal exact source disposition requires one terminal cause"
+  in
+  let* action_kind = string_field ~context "action_kind" fields in
+  let* action =
+    match action_kind with
+    | "consume_source" -> Ok Consume_source
+    | unknown ->
+      Error (Printf.sprintf "unknown exact source disposition action: %s" unknown)
+  in
+  let* semantic_label =
+    string_field ~context "settlement_semantic" fields
+  in
+  let* semantic =
+    match semantic_label with
+    | "no_compaction" -> Ok Exact_no_compaction
+    | "escalate" -> Ok Exact_escalate
+    | unknown ->
+      Error
+        (Printf.sprintf
+           "unknown exact source disposition settlement semantic: %s"
+           unknown)
+  in
+  let* prepared_at = float_field ~context "prepared_at_unix" fields in
+  let disposition =
+    { disposition_id
+    ; source
+    ; slot_id
+    ; call_id
+    ; plan_fingerprint
+    ; request_body_sha256
+    ; outcome
+    ; action
+    ; semantic
+    ; prepared_at
+    }
+  in
+  let* () = validate_exact_source_disposition disposition in
+  Ok disposition
 ;;
 
 let settlement_to_yojson = function
@@ -2192,7 +2623,12 @@ let settlement_to_yojson = function
       ; "source_revision", int64_json source_terminal.source_revision
       ; "owner_nonce", `Int source_terminal.owner_nonce
       ; "operator_operation_id", `String source_terminal.operator_operation_id
-      ; "source_receipt_kind", `String receipt_kind
+       ; "source_receipt_kind", `String receipt_kind
+       ]
+  | Settle_exact disposition ->
+    `Assoc
+      [ "kind", `String "settle_exact"
+      ; "disposition", exact_source_disposition_to_yojson disposition
       ]
   | Requeue reason ->
     `Assoc
@@ -2355,6 +2791,13 @@ let settlement_of_yojson json =
     in
     let* () = validate_accepted_source_terminal source_terminal in
     Ok (Settle_from_source_terminal source_terminal)
+  | "settle_exact" ->
+    let* () =
+      exact_fields ~context ~expected:[ "kind"; "disposition" ] fields
+    in
+    let* disposition_json = required_field ~context "disposition" fields in
+    let* disposition = exact_source_disposition_of_yojson disposition_json in
+    Ok (Settle_exact disposition)
   | "requeue" ->
     let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in
@@ -2396,6 +2839,7 @@ let accepted_transfer_projection_of_yojson json =
   | No_compaction _
   | Cancel_accepted _
   | Settle_from_source_terminal _
+  | Settle_exact _
   | Requeue _
   | Escalate _ -> Error "target transfer projection must contain transfer_accepted"
 ;;
@@ -2436,7 +2880,20 @@ let transition_receipt_of_yojson json =
   let* settlement = settlement_of_yojson settlement_json in
   let expected_lease_id = lease_id_of_sequence lease_sequence in
   let expected_transition_id =
-    Printf.sprintf "%s:%s" expected_lease_id (settlement_kind_label settlement)
+    match settlement with
+    | Settle_exact disposition ->
+      Printf.sprintf
+        "%s:settle_exact:%s"
+        expected_lease_id
+        disposition.disposition_id
+    | Ack
+    | No_compaction _
+    | Cancel_accepted _
+    | Transfer_accepted _
+    | Settle_from_source_terminal _
+    | Requeue _
+    | Escalate _ ->
+      Printf.sprintf "%s:%s" expected_lease_id (settlement_kind_label settlement)
   in
   let expected_event_id = event_id_of_transition expected_transition_id in
   if Int64.compare lease_sequence 1L < 0
@@ -2482,11 +2939,15 @@ let outbox_entry_of_yojson json =
 ;;
 
 let exact_execution_binding_to_yojson binding =
-  let status, terminal_cause =
+  let status, terminal_cause, disposition =
     match binding.status with
-    | Dispatch_uncertain -> "dispatch_uncertain", `Null
+    | Dispatch_uncertain -> "dispatch_uncertain", `Null, `Null
     | Terminal_quarantined cause ->
-      "terminal_quarantined", `String (exact_execution_terminal_cause_label cause)
+      ( "terminal_quarantined"
+      , `String (exact_execution_terminal_cause_label cause)
+      , `Null )
+    | Disposition_prepared disposition ->
+      "disposition_prepared", `Null, exact_source_disposition_to_yojson disposition
   in
   `Assoc
     [ "lease_id", `String binding.lease_id
@@ -2497,25 +2958,28 @@ let exact_execution_binding_to_yojson binding =
     ; "request_body_sha256", `String binding.request_body_sha256
     ; "status", `String status
     ; "terminal_cause", terminal_cause
+    ; "disposition", disposition
     ]
 ;;
 
 let exact_execution_binding_of_yojson json =
   let context = "exact execution lease binding" in
   let* fields = assoc_fields ~context json in
+  let has_disposition = List.mem_assoc "disposition" fields in
   let* () =
     exact_fields
       ~context
       ~expected:
-        [ "lease_id"
-        ; "lease_sequence"
-        ; "slot_id"
-        ; "call_id"
-        ; "plan_fingerprint"
-        ; "request_body_sha256"
-        ; "status"
-        ; "terminal_cause"
-        ]
+        ([ "lease_id"
+         ; "lease_sequence"
+         ; "slot_id"
+         ; "call_id"
+         ; "plan_fingerprint"
+         ; "request_body_sha256"
+         ; "status"
+         ; "terminal_cause"
+         ]
+         @ if has_disposition then [ "disposition" ] else [])
       fields
   in
   let* lease_id = string_field ~context "lease_id" fields in
@@ -2526,17 +2990,25 @@ let exact_execution_binding_of_yojson json =
   let* request_body_sha256 = string_field ~context "request_body_sha256" fields in
   let* status_label = string_field ~context "status" fields in
   let* terminal_cause_json = required_field ~context "terminal_cause" fields in
+  let disposition_json = List.assoc_opt "disposition" fields in
   let* status =
-    match status_label, terminal_cause_json with
-    | "dispatch_uncertain", `Null -> Ok Dispatch_uncertain
-    | "terminal_quarantined", `String cause ->
+    match status_label, terminal_cause_json, disposition_json with
+    | "dispatch_uncertain", `Null, (None | Some `Null) -> Ok Dispatch_uncertain
+    | "terminal_quarantined", `String cause, (None | Some `Null) ->
       let* cause = exact_execution_terminal_cause_of_label cause in
       Ok (Terminal_quarantined cause)
-    | "dispatch_uncertain", _ ->
+    | "disposition_prepared", `Null, Some disposition_json ->
+      let* disposition = exact_source_disposition_of_yojson disposition_json in
+      (match disposition.outcome with
+       | Terminal _ -> Ok (Disposition_prepared disposition))
+    | "dispatch_uncertain", _, _ ->
       Error "dispatch-uncertain exact execution binding must not carry a terminal cause"
-    | "terminal_quarantined", _ ->
+    | "terminal_quarantined", _, _ ->
       Error "terminally quarantined exact execution binding requires a terminal cause"
-    | status, _ -> Error (Printf.sprintf "unknown exact execution binding status: %s" status)
+    | "disposition_prepared", _, _ ->
+      Error "v5 exact execution binding status requires one source disposition"
+    | status, _, _ ->
+      Error (Printf.sprintf "unknown exact execution binding status: %s" status)
   in
   if Int64.compare lease_sequence 1L < 0
   then Error "exact execution binding lease sequence must be positive"
@@ -2550,6 +3022,16 @@ let exact_execution_binding_of_yojson json =
   then Error "exact execution binding plan fingerprint must not be empty"
   else if String.trim request_body_sha256 = ""
   then Error "exact execution binding request body sha256 must not be empty"
+  else if
+    match status with
+    | Dispatch_uncertain | Terminal_quarantined _ -> false
+    | Disposition_prepared disposition ->
+      not
+        (String.equal disposition.slot_id slot_id
+         && String.equal disposition.call_id call_id
+         && String.equal disposition.plan_fingerprint plan_fingerprint
+         && String.equal disposition.request_body_sha256 request_body_sha256)
+  then Error "exact source disposition does not match its full execution binding"
   else
     Ok
       { lease_id
@@ -2636,6 +3118,27 @@ let validate_state state =
          || String.trim binding.request_body_sha256 = "")
       state.exact_execution_bindings
   then Error "event queue state contains an invalid exact execution binding"
+  else if
+    List.exists
+      (fun (binding : exact_execution_binding) ->
+         match binding.status with
+         | Dispatch_uncertain | Terminal_quarantined _ -> false
+         | Disposition_prepared disposition ->
+           Result.is_error (validate_exact_source_disposition disposition)
+           || not
+                (String.equal binding.slot_id disposition.slot_id
+                 && String.equal binding.call_id disposition.call_id
+                 && String.equal
+                      binding.plan_fingerprint
+                      disposition.plan_fingerprint
+                 && String.equal
+                      binding.request_body_sha256
+                      disposition.request_body_sha256)
+           ||
+           match disposition.outcome with
+           | Terminal _ -> false)
+      state.exact_execution_bindings
+  then Error "event queue state contains an invalid exact source disposition"
   else if
     List.exists
       (fun (binding : exact_execution_binding) ->
@@ -2748,13 +3251,31 @@ let of_yojson json =
         accepted_transfer_projection_of_yojson
         fields
     in
-    let* exact_execution_bindings =
-      list_field
-        ~context
-        "exact_execution_bindings"
-        exact_execution_binding_of_yojson
-        fields
+    let* bindings_json =
+      match List.assoc_opt "exact_execution_bindings" fields with
+      | Some (`List bindings) -> Ok bindings
+      | Some _ ->
+        Error "keeper event queue state exact_execution_bindings must be a list"
+      | None ->
+        Error "keeper event queue state missing exact_execution_bindings"
     in
+    let* () =
+      if
+        List.exists
+          (function
+            | `Assoc fields -> not (List.mem_assoc "disposition" fields)
+            | _ -> true)
+          bindings_json
+      then Error "v5 exact execution binding requires disposition evidence field"
+      else Ok ()
+    in
+    let rec decode_bindings acc = function
+      | [] -> Ok (List.rev acc)
+      | binding_json :: rest ->
+        let* binding = exact_execution_binding_of_yojson binding_json in
+        decode_bindings (binding :: acc) rest
+    in
+    let* exact_execution_bindings = decode_bindings [] bindings_json in
     validate_state
       { revision
       ; next_lease_sequence

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -11,13 +11,6 @@ type requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Approval_grant_unconsumed
-  | Approval_grant_state_unavailable
-    (* The two approval arms are no longer produced: the approval-wake
-       settlement follows the completed turn since the 2026-07-21
-       delivery-not-consumption amendment (#25539, RFC
-       keeper-conversation-hitl-flow). Kept for decoding persisted
-       receipts/WAL rows written before the amendment. *)
 
 type exact_execution_terminal_cause =
   | Execution_failed_after_dispatch
@@ -430,8 +423,6 @@ let requeue_reason_label = function
   | Registration_recovery -> "registration_recovery"
   | Retry_after_observed -> "retry_after_observed"
   | Context_compaction_retry -> "context_compaction_retry"
-  | Approval_grant_unconsumed -> "approval_grant_unconsumed"
-  | Approval_grant_state_unavailable -> "approval_grant_state_unavailable"
 ;;
 
 let requeue_reason_of_label = function
@@ -443,8 +434,6 @@ let requeue_reason_of_label = function
   | "registration_recovery" -> Ok Registration_recovery
   | "retry_after_observed" -> Ok Retry_after_observed
   | "context_compaction_retry" -> Ok Context_compaction_retry
-  | "approval_grant_unconsumed" -> Ok Approval_grant_unconsumed
-  | "approval_grant_state_unavailable" -> Ok Approval_grant_state_unavailable
   | label -> Error (Printf.sprintf "unknown event queue requeue reason: %s" label)
 ;;
 
@@ -1563,13 +1552,9 @@ let settle_committed ~settled_at ~lease ~settlement state =
       | Settle_from_source_terminal _ -> state.pending
       | Settle_exact { action = Consume_source; _ } -> state.pending
       | Requeue
-          ( Retry_after_observed
-          | Context_compaction_retry
-          | Approval_grant_unconsumed
-          | Approval_grant_state_unavailable ) ->
-        (* Retryable provider work, context repair handoffs, and a durable
-           one-shot grant retain the exact leased stimuli without monopolizing
-           the FIFO front. *)
+          (Retry_after_observed | Context_compaction_retry) ->
+        (* Retryable provider work and context repair handoffs retain the exact
+           leased stimuli without monopolizing the FIFO front. *)
         append_missing committed.stimuli state.pending
       | Requeue _ -> prepend_missing committed.stimuli state.pending
       | Escalate { successor = None; _ } -> state.pending

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -39,14 +39,44 @@ type exact_execution_terminal =
   { cause : exact_execution_terminal_cause
   ; slot_id : string
   ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
   }
 (** One OAS-owned affine call that crossed, or can no longer safely be assumed
-    not to have crossed, the dispatch boundary. Both identities are mandatory
-    and survive the queue receipt/WAL codec. *)
+    not to have crossed, the dispatch boundary. The complete producer proof is
+    mandatory and survives the queue receipt/WAL codec. *)
+
+type exact_source_action = Consume_source
+
+type exact_settlement_semantic =
+  | Exact_no_compaction
+  | Exact_escalate
+
+type exact_source_outcome = Terminal of exact_execution_terminal_cause
+
+type exact_source_disposition =
+  { disposition_id : string
+  ; source : Keeper_checkpoint_ref.t
+  ; slot_id : string
+  ; call_id : string
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; outcome : exact_source_outcome
+  ; action : exact_source_action
+  ; semantic : exact_settlement_semantic
+  ; prepared_at : float
+  }
+(** Immutable terminal source disposition for one exact call. The ID is the
+    SHA-256 of its stable proof, outcome, semantic, and action fields.
+    [prepared_at] is observational and excluded from identity. *)
 
 type exact_execution_lease_status =
   | Dispatch_uncertain
   | Terminal_quarantined of exact_execution_terminal_cause
+      (** Current-schema terminal quarantine before a source disposition is
+          prepared. It has no source authority and can never be finalized or
+          registration-requeued. *)
+  | Disposition_prepared of exact_source_disposition
 
 type exact_execution_binding =
   { lease_id : string
@@ -180,6 +210,7 @@ type settlement =
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
   | Settle_from_source_terminal of accepted_source_terminal
+  | Settle_exact of exact_source_disposition
   | Requeue of requeue_reason
   | Escalate of
       { reason : escalation_reason
@@ -288,14 +319,35 @@ val release_exact_execution_before_dispatch :
 val quarantine_exact_execution :
   lease:lease ->
   terminal:exact_execution_terminal ->
-  plan_fingerprint:string ->
-  request_body_sha256:string ->
   t ->
   (t, string) result
 (** Advance a matching dispatch-uncertain binding to a typed terminal
     quarantine without releasing the lease for replay. *)
 
-val settle_exact_execution :
+val prepare_exact_source_disposition :
+  lease:lease ->
+  source:Keeper_checkpoint_ref.t ->
+  terminal:exact_execution_terminal ->
+  semantic:exact_settlement_semantic ->
+  prepared_at:float ->
+  t ->
+  (t * exact_source_disposition, string) result
+(** Atomically replace a matching dispatch fence or source-less terminal
+    quarantine with one immutable terminal source disposition, after matching
+    the opaque producer proof against the durable binding. Repeating the same
+    stable proof adopts the first durable preparation timestamp. *)
+
+val finalize_exact_source_disposition :
+  settled_at:float ->
+  lease:lease ->
+  disposition_id:string ->
+  t ->
+  (t * settle_result, string) result
+(** Finalize only a validated terminal disposition through [Settle_exact].
+    Its source action is applied exactly once by the canonical receipt
+    transition. *)
+
+val settle_bound_exact_nonterminal :
   settled_at:float ->
   lease:lease ->
   slot_id:string ->
@@ -305,8 +357,10 @@ val settle_exact_execution :
   settlement:settlement ->
   t ->
   (t * settle_result, string) result
-(** Finalize a bound lease through its exact OAS identity. Generic {!settle}
-    rejects bound leases. *)
+(** Settle only the identity-bound nonterminal Ack/retry/floor/failure-judgment
+    cases. Exact terminal outcomes require
+    {!prepare_exact_source_disposition} followed by
+    {!finalize_exact_source_disposition}. *)
 
 val cancel_accepted :
   current_owner_nonce:int ->
@@ -429,5 +483,5 @@ val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
 val schema : string
-(** ["keeper.event_queue.state.v4"]. Only this current schema is accepted.
+(** ["keeper.event_queue.state.v5"]. Only this current schema is accepted.
     Stale or unknown persisted state fails closed and requires a runtime reset. *)

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -18,8 +18,6 @@ type requeue_reason =
   | Registration_recovery
   | Retry_after_observed
   | Context_compaction_retry
-  | Approval_grant_unconsumed
-  | Approval_grant_state_unavailable
 
 type exact_execution_terminal_cause =
   | Execution_failed_after_dispatch

--- a/test/dune
+++ b/test/dune
@@ -1302,6 +1302,12 @@
   test_keeper_exact_execution_lease_guard_fixture)
  (libraries alcotest masc masc_test_deps masc.keeper_checkpoint_ref eio_main unix))
 
+; Source-bound exact disposition schema, WAL replay, and restart reconciliation.
+(test
+ (name test_keeper_exact_disposition_recovery)
+ (modules test_keeper_exact_disposition_recovery)
+ (libraries alcotest masc masc_test_deps masc.keeper_checkpoint_ref unix))
+
 ; Process-isolated proof that exact-output bootstrap honors full catalog
 ; replacement precedence over deployment overlays and OAS embedded targets.
 (test

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -91,6 +91,40 @@ let persisted_checkpoint_source_exn trace_id =
      | Error _ -> Alcotest.fail "persisted checkpoint source ref failed")
 ;;
 
+let settle_terminal_disposition_result
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source
+      ~(terminal : P.exact_execution_terminal)
+      ~settled_at
+  =
+  let disposition =
+    match
+      P.prepare_exact_source_disposition_result
+        ~base_path
+        ~keeper_name
+        ~lease
+        ~source
+        ~terminal
+        ~semantic:P.Exact_no_compaction
+        ~prepared_at:settled_at
+        ()
+    with
+    | Error detail -> Alcotest.failf "terminal disposition preparation failed: %s" detail
+    | Ok (_, P.Visible_sync_unconfirmed detail) ->
+      Alcotest.failf "terminal disposition preparation durability unknown: %s" detail
+    | Ok (disposition, P.Fsync_completed) -> disposition
+  in
+  P.finalize_exact_source_disposition_result
+    ~base_path
+    ~keeper_name
+    ~settled_at
+    ~lease
+    ~disposition_id:disposition.disposition_id
+    ()
+;;
+
 let permissive_exact_execution_guard : C.exact_execution_guard =
   { before_dispatch = (fun _ -> Ok C.Fsync_completed)
   ; release_before_dispatch = (fun _ -> Ok C.Fsync_completed)
@@ -1185,24 +1219,14 @@ let test_visible_unknown_binding_prevents_post_and_settles () =
    | Ok (Some _) -> Alcotest.fail "visible bind retained the wrong status"
    | Ok None -> Alcotest.fail "visible bind was relabelled as unbound"
    | Error detail -> Alcotest.failf "visible bind reload failed: %s" detail);
-  let settlement : P.settlement =
-    P.No_compaction
-      { source = persisted_checkpoint_source_exn "trace-visible-unknown-binding"
-      ; reason = P.Exact_execution_terminal terminal
-      }
-  in
   (match
-     P.settle_exact_execution_result
+     settle_terminal_disposition_result
        ~base_path
        ~keeper_name
-       ~settled_at:4.0
        ~lease
-       ~slot_id:observation.slot_id
-       ~call_id:observation.call_id
-       ~plan_fingerprint:observation.receipt_plan_fingerprint
-       ~request_body_sha256:observation.receipt_request_body_sha256
-       ~settlement
-       ()
+       ~source:(persisted_checkpoint_source_exn "trace-visible-unknown-binding")
+       ~terminal
+       ~settled_at:4.0
    with
    | Ok (P.Settled _) -> ()
    | Ok _ -> Alcotest.fail "visible bind settlement was not fresh"
@@ -1262,6 +1286,8 @@ let test_visible_unknown_quarantine_preserves_cause_and_settles () =
     { cause = Keeper_event_queue_state.Domain_invalid_output
     ; slot_id = observation.slot_id
     ; call_id = observation.call_id
+    ; plan_fingerprint = observation.receipt_plan_fingerprint
+    ; request_body_sha256 = observation.receipt_request_body_sha256
     }
   in
   Alcotest.(check int) "visible quarantine follows one POST" 1 (F.post_count server);
@@ -1288,24 +1314,14 @@ let test_visible_unknown_quarantine_preserves_cause_and_settles () =
    | Ok (Some _) -> Alcotest.fail "visible quarantine retained the wrong status"
    | Ok None -> Alcotest.fail "visible quarantine was relabelled as unbound"
    | Error detail -> Alcotest.failf "visible quarantine reload failed: %s" detail);
-  let settlement : P.settlement =
-    P.No_compaction
-      { source = persisted_checkpoint_source_exn "trace-visible-unknown-quarantine"
-      ; reason = P.Exact_execution_terminal terminal
-      }
-  in
   (match
-     P.settle_exact_execution_result
+     settle_terminal_disposition_result
        ~base_path
        ~keeper_name
-       ~settled_at:5.0
        ~lease
-       ~slot_id:observation.slot_id
-       ~call_id:observation.call_id
-       ~plan_fingerprint:observation.receipt_plan_fingerprint
-       ~request_body_sha256:observation.receipt_request_body_sha256
-       ~settlement
-       ()
+       ~source:(persisted_checkpoint_source_exn "trace-visible-unknown-quarantine")
+       ~terminal
+       ~settled_at:5.0
    with
    | Ok (P.Settled _) -> ()
    | Ok _ -> Alcotest.fail "visible quarantine settlement was not fresh"
@@ -1361,7 +1377,6 @@ let test_post_success_terminalization_is_affine () =
       prepared
     |> completed_exn
   in
-  let observation = C.completed_attempt_observation completed in
   let terminalizer = C.completed_post_success_terminalizer completed in
   let first_result, resolve_first_result = Eio.Promise.create () in
   let second_started, resolve_second_started = Eio.Promise.create () in
@@ -1406,24 +1421,14 @@ let test_post_success_terminalization_is_affine () =
        | Ok source -> source
        | Error _ -> Alcotest.fail "terminal source checkpoint ref failed")
   in
-  let settlement : P.settlement =
-    P.No_compaction
-      { source
-      ; reason = P.Exact_execution_terminal second
-      }
-  in
   match
-    P.settle_exact_execution_result
+    settle_terminal_disposition_result
       ~base_path
       ~keeper_name
-      ~settled_at:4.0
       ~lease
-      ~slot_id:observation.slot_id
-      ~call_id:observation.call_id
-      ~plan_fingerprint:observation.receipt_plan_fingerprint
-      ~request_body_sha256:observation.receipt_request_body_sha256
-      ~settlement
-      ()
+      ~source
+      ~terminal:second
+      ~settled_at:4.0
   with
   | Ok (P.Settled receipt) ->
     (match P.exact_execution_binding_result ~base_path ~keeper_name with
@@ -1451,12 +1456,20 @@ let test_post_success_terminalization_is_affine () =
          true
          (receipt = durable_receipt);
        (match durable_receipt.settlement with
-        | P.No_compaction
-            { reason = P.Exact_execution_terminal durable_terminal; _ } ->
+        | P.Settle_exact
+            { outcome = P.Terminal cause
+            ; semantic = P.Exact_no_compaction
+            ; action = P.Consume_source
+            ; slot_id
+            ; call_id
+            ; _
+            } ->
           Alcotest.(check bool)
             "durable terminal retains canonical cause and identity"
             true
-            (durable_terminal = first)
+            (cause = first.cause
+             && String.equal slot_id first.slot_id
+             && String.equal call_id first.call_id)
         | _ -> Alcotest.fail "durable receipt lost canonical exact terminal")
      | _ -> Alcotest.fail "canonical terminal state has no exact durable receipt")
   | Ok (P.Already_settled _) ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -930,9 +930,9 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
             None
         with
         | Masc.Keeper_registry_event_queue.Requeue
-            Masc.Keeper_registry_event_queue.Approval_grant_unconsumed ->
+            Masc.Keeper_registry_event_queue.Turn_not_scheduled ->
           ()
-        | _ -> Alcotest.fail "unconsumed grant wake was acknowledged");
+        | _ -> Alcotest.fail "unscheduled grant wake was not requeued");
        let request ~input ~task_id ~goal_ids : Gate.request =
          { keeper_name
          ; operation = "external-effect"
@@ -1003,8 +1003,10 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
             ~lease
             None
         with
-        | Masc.Keeper_registry_event_queue.Ack -> ()
-        | _ -> Alcotest.fail "consumed grant wake was not acknowledged");
+        | Masc.Keeper_registry_event_queue.Requeue
+            Masc.Keeper_registry_event_queue.Turn_not_scheduled ->
+          ()
+        | _ -> Alcotest.fail "unscheduled consumed grant wake was not requeued");
        AQ.For_testing.reset_runtime_state ();
        let _ = install_exn ~base_path in
        (match AQ.approved_resolution_state ~base_path ~id:approval_id with

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -54,7 +54,13 @@ let no_compaction ~turn_count reason : State.no_compaction =
 ;;
 
 let exact_terminal ?(slot_id = "slot-terminal") ?(call_id = "call-terminal") cause =
-  State.Exact_execution_terminal { cause; slot_id; call_id }
+  State.Exact_execution_terminal
+    { cause
+    ; slot_id
+    ; call_id
+    ; plan_fingerprint = "plan-terminal"
+    ; request_body_sha256 = String.make 64 'b'
+    }
 ;;
 
 let test_exact_output_terminal_reasons_round_trip () =

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1836,60 +1836,6 @@ let test_cancelled_and_skipped_cycles_requeue () =
   | _ -> Alcotest.fail "non-executable phase acknowledged leased work"
 ;;
 
-let test_unconsumed_approval_requeues_behind_other_work () =
-  List.iter
-    (fun reason ->
-       let resolution : Queue.hitl_resolution =
-         { approval_id = "approval-tail"
-         ; decision = Queue.Hitl_approved
-         ; channel = Keeper_continuation_channel.unrouted "queue fairness test"
-         }
-       in
-       let approval =
-         stimulus
-           ~payload:(Queue.Hitl_resolved resolution)
-           (Queue.hitl_resolution_post_id resolution)
-           1.0
-       in
-       let board = stimulus "board-next" 2.0 in
-       let state = State.with_pending (queue [ approval; board ]) State.empty in
-       let state, lease = claim_head state in
-       let lease = require_some "approval lease" lease in
-       let state, _ =
-         State.settle
-           ~settled_at:3.0
-           ~lease
-           ~settlement:(State.Requeue reason)
-           state
-         |> require_ok "tail requeue approval"
-       in
-       Alcotest.(check (list string))
-         "approval remains durable at the FIFO tail"
-         [ "board-next"; Queue.hitl_resolution_post_id resolution ]
-         (post_ids (State.pending state));
-       let receipt =
-         match State.transition_outbox state with
-         | [ entry ] -> entry.receipt
-         | _ -> Alcotest.fail "approval requeue must create one receipt"
-       in
-       let state =
-         State.mark_transition_projected ~transition_id:receipt.transition_id state
-         |> require_ok "project approval requeue"
-       in
-       let _state, next = claim_head state in
-       let next = require_some "next fair lease" next in
-       match next.stimuli with
-       | [ next ] ->
-         Alcotest.(check string)
-           "unrelated work leases before the retained approval"
-           "board-next"
-           next.post_id
-       | _ -> Alcotest.fail "fairness fixture expected one leased stimulus")
-    [ State.Approval_grant_unconsumed
-    ; State.Approval_grant_state_unavailable
-    ]
-;;
-
 let rec remove_tree path =
   if Sys.file_exists path
   then if Sys.is_directory path
@@ -2827,10 +2773,6 @@ let () =
             "approved wake settles on delivery not consumption"
             `Quick
             test_approved_wake_settles_on_delivery_not_consumption
-        ; Alcotest.test_case
-            "unconsumed approval yields FIFO"
-            `Quick
-            test_unconsumed_approval_requeues_behind_other_work
         ; Alcotest.test_case
             "current state codec reads its own output"
             `Quick

--- a/test/test_keeper_exact_disposition_recovery.ml
+++ b/test/test_keeper_exact_disposition_recovery.ml
@@ -1,0 +1,315 @@
+module State = Keeper_event_queue_state
+module Persistence = Keeper_event_queue_persistence
+module Queue = Keeper_event_queue
+
+let require_ok = function
+  | Ok value -> value
+  | Error detail -> Alcotest.fail detail
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let with_temp_dir prefix f =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let require_fsync = function
+  | Persistence.Fsync_completed -> ()
+  | Persistence.Visible_sync_unconfirmed detail ->
+    Alcotest.failf "durability unknown: %s" detail
+;;
+
+let checkpoint_ref ~sha =
+  let trace_id =
+    Keeper_id.Trace_id.of_string "exact-disposition-recovery-trace"
+    |> require_ok
+  in
+  match
+    Keeper_checkpoint_ref.of_persisted
+      ~trace_id
+      ~generation:4
+      ~turn_count:12
+      ~sha256:sha
+  with
+  | Ok reference -> reference
+  | Error _ -> Alcotest.fail "invalid checkpoint fixture"
+;;
+
+let source_ref = checkpoint_ref ~sha:(String.make 64 '0')
+
+let stimulus post_id arrived_at =
+  { Keeper_event_queue.post_id
+  ; urgency = Keeper_event_queue.Immediate
+  ; arrived_at
+  ; payload = Keeper_event_queue.Manual_compaction_requested
+  }
+;;
+
+let claimed_state ?(post_id = "manual-exact") () =
+  let pending =
+    Keeper_event_queue.enqueue
+      Keeper_event_queue.empty
+      (stimulus post_id 1.0)
+  in
+  let state = State.with_pending pending State.empty in
+  let state, lease =
+    State.claim_when ~claimed_at:2.0 ~ready:(fun _ -> true) state
+    |> require_ok
+  in
+  match lease with
+  | Some lease -> state, lease
+  | None -> Alcotest.fail "fixture lease was not claimed"
+;;
+
+let bound_state ?post_id () =
+  let state, lease = claimed_state ?post_id () in
+  let state =
+    State.bind_exact_execution
+      ~lease
+      ~slot_id:"slot-a"
+      ~call_id:"call-a"
+      ~plan_fingerprint:"plan-a"
+      ~request_body_sha256:(String.make 64 'a')
+      state
+    |> require_ok
+  in
+  state, lease
+;;
+
+let exact_terminal
+      ?(slot_id = "slot-a")
+      ?(call_id = "call-a")
+      ?(plan_fingerprint = "plan-a")
+      ?(request_body_sha256 = String.make 64 'a')
+      cause
+  : State.exact_execution_terminal
+  =
+  { cause; slot_id; call_id; plan_fingerprint; request_body_sha256 }
+;;
+
+let prepare_terminal ?(prepared_at = 3.0) state lease =
+  State.prepare_exact_source_disposition
+    ~lease
+    ~source:source_ref
+    ~terminal:(exact_terminal State.Domain_invalid_output)
+    ~semantic:State.Exact_no_compaction
+    ~prepared_at
+    state
+  |> require_ok
+;;
+
+let test_terminal_persistence_recovery_retains_full_proof () =
+  with_temp_dir "masc-exact-disposition-recovery" @@ fun base_path ->
+  let keeper_name = "exact_disposition_recovery" in
+  (match
+     Persistence.update_checked_result
+       ~base_path
+       ~keeper_name
+       (fun pending -> Ok (Queue.enqueue pending (stimulus "persisted-exact" 1.0)))
+   with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "source persist failed: %s" detail);
+  let lease =
+    match
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:2.0
+        ~ready:(fun _ -> true)
+        ()
+    with
+    | Ok (Some lease) -> lease
+    | Ok None -> Alcotest.fail "persisted source was not claimed"
+    | Error detail -> Alcotest.failf "persisted claim failed: %s" detail
+  in
+  Persistence.bind_exact_execution_result
+    ~base_path
+    ~keeper_name
+    ~lease
+    ~slot_id:"slot-a"
+    ~call_id:"call-a"
+    ~plan_fingerprint:"plan-a"
+    ~request_body_sha256:(String.make 64 'a')
+    ()
+  |> require_ok
+  |> require_fsync;
+  let terminal = exact_terminal State.Domain_invalid_output in
+  let disposition, durability =
+    Persistence.prepare_exact_source_disposition_result
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source:source_ref
+      ~terminal
+      ~semantic:Persistence.Exact_no_compaction
+      ~prepared_at:3.0
+      ()
+    |> require_ok
+  in
+  require_fsync durability;
+  let pending =
+    Persistence.prepare_registration_after_exact_recovery_result
+      ~base_path
+      ~keeper_name
+      ~settled_at:4.0
+      ()
+    |> require_ok
+  in
+  Alcotest.(check bool) "recovery consumed source" true (Queue.is_empty pending);
+  let recovered =
+    Persistence.load_state_result ~base_path ~keeper_name |> require_ok
+  in
+  Alcotest.(check int)
+    "recovery consumed lease"
+    0
+    (List.length (State.leases recovered));
+  let entry =
+    match State.transition_outbox recovered with
+    | [ entry ] -> entry
+    | [] | _ :: _ :: _ -> Alcotest.fail "durable exact outbox is not singular"
+  in
+  Alcotest.(check string)
+    "deterministic exact transition"
+    (lease.lease_id ^ ":settle_exact:" ^ disposition.disposition_id)
+    entry.receipt.transition_id;
+  (match entry.receipt.settlement with
+   | State.Settle_exact proof ->
+     Alcotest.(check string)
+       "request proof retained"
+       disposition.request_body_sha256
+       proof.request_body_sha256;
+     Alcotest.(check string)
+       "plan proof retained"
+       disposition.plan_fingerprint
+       proof.plan_fingerprint
+   | _ -> Alcotest.fail "durable WAL receipt did not carry Settle_exact");
+  let replay_pending =
+    Persistence.prepare_registration_after_exact_recovery_result
+      ~base_path
+      ~keeper_name
+      ~settled_at:5.0
+      ()
+    |> require_ok
+  in
+  Alcotest.(check bool)
+    "restart replay remains consumed"
+    true
+    (Queue.is_empty replay_pending)
+;;
+
+let replace_assoc key value fields =
+  (key, value) :: List.remove_assoc key fields
+;;
+
+let corrupt_disposition_proof = function
+  | `Assoc state_fields ->
+    let bindings =
+      match List.assoc "exact_execution_bindings" state_fields with
+      | `List [ `Assoc binding_fields ] ->
+        let disposition =
+          match List.assoc "disposition" binding_fields with
+          | `Assoc fields ->
+            `Assoc
+              (replace_assoc
+                 "request_body_sha256"
+                 (`String (String.make 64 'f'))
+                 fields)
+          | _ -> Alcotest.fail "fixture disposition missing"
+        in
+        `List
+          [ `Assoc
+              (replace_assoc "disposition" disposition binding_fields)
+          ]
+      | _ -> Alcotest.fail "fixture binding missing"
+    in
+    `Assoc
+      (replace_assoc "exact_execution_bindings" bindings state_fields)
+  | _ -> Alcotest.fail "fixture state is not an object"
+;;
+
+let test_wrong_full_proof_is_rejected () =
+  let state, lease = bound_state () in
+  let prepared, _ = prepare_terminal state lease in
+  match State.of_yojson (corrupt_disposition_proof (State.to_yojson prepared)) with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "changed request proof retained the disposition id"
+;;
+
+let test_producer_proof_mismatches_are_rejected () =
+  let state, lease = bound_state ~post_id:"bad-proof" () in
+  let canonical = exact_terminal State.Domain_invalid_output in
+  let rejects label terminal =
+    match
+      State.prepare_exact_source_disposition
+        ~lease
+        ~source:source_ref
+        ~terminal
+        ~semantic:State.Exact_no_compaction
+        ~prepared_at:6.0
+        state
+    with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s producer proof mismatch was accepted" label
+  in
+  rejects "slot_id" { canonical with slot_id = "slot-b" };
+  rejects "call_id" { canonical with call_id = "call-b" };
+  rejects
+    "plan_fingerprint"
+    { canonical with plan_fingerprint = "plan-b" };
+  rejects
+    "request_body_sha256"
+    { canonical with request_body_sha256 = String.make 64 'b' };
+  match State.exact_execution_binding state with
+  | Some { status = State.Dispatch_uncertain; _ } -> ()
+  | Some _ -> Alcotest.fail "proof mismatch changed the durable binding"
+  | None -> Alcotest.fail "proof mismatch removed the durable binding"
+;;
+
+let test_retry_adopts_stored_prepared_at () =
+  let state, lease = bound_state ~post_id:"stable-retry" () in
+  let prepared, original = prepare_terminal state lease in
+  let _, retried = prepare_terminal ~prepared_at:99.0 prepared lease in
+  Alcotest.(check string)
+    "stable disposition id"
+    original.disposition_id
+    retried.disposition_id;
+  Alcotest.(check (float 0.0))
+    "stored observation retained"
+    original.prepared_at
+    retried.prepared_at
+;;
+
+let () =
+  Alcotest.run
+    "keeper exact disposition recovery"
+    [ ( "recovery"
+      , [ Alcotest.test_case
+            "terminal persistence recovery retains full proof"
+            `Quick
+            test_terminal_persistence_recovery_retains_full_proof
+        ; Alcotest.test_case
+            "wrong full proof is rejected"
+            `Quick
+            test_wrong_full_proof_is_rejected
+        ; Alcotest.test_case
+            "producer proof mismatches are rejected"
+            `Quick
+            test_producer_proof_mismatches_are_rejected
+        ; Alcotest.test_case
+            "retry adopts stored prepared_at"
+            `Quick
+            test_retry_adopts_stored_prepared_at
+        ] )
+    ]
+;;

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -8,10 +8,28 @@ let settlement_wal_path ~base_path ~keeper_name =
     "event-queue-settlements.jsonl"
 ;;
 
+let snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
+;;
+
 let read_file_or_fail label path =
   match Safe_ops.read_file_safe path with
   | Ok bytes -> bytes
   | Error detail -> Alcotest.failf "%s read failed: %s" label detail
+;;
+
+let decode_raw_snapshot label ~base_path ~keeper_name =
+  let path = snapshot_path ~base_path ~keeper_name in
+  let json =
+    try Yojson.Safe.from_string (read_file_or_fail label path) with
+    | Yojson.Json_error detail ->
+      Alcotest.failf "%s raw snapshot JSON failed: %s" label detail
+  in
+  match State.of_yojson json with
+  | Ok state -> state
+  | Error detail -> Alcotest.failf "%s raw current-state decode failed: %s" label detail
 ;;
 
 let require_loaded_state label ~base_path ~keeper_name =
@@ -22,6 +40,20 @@ let require_loaded_state label ~base_path ~keeper_name =
 
 let check_no_active_lease label state =
   Alcotest.(check bool) (label ^ " has no active lease") true (Option.is_none (State.active_lease state))
+;;
+
+let check_no_exact_binding label state =
+  Alcotest.(check bool)
+    (label ^ " has no exact binding")
+    true
+    (Option.is_none (State.exact_execution_binding state))
+;;
+
+let check_no_pending label state =
+  Alcotest.(check bool)
+    (label ^ " has no pending stimuli")
+    true
+    (Q.is_empty (State.pending state))
 ;;
 
 let state_json state = State.to_yojson state |> Yojson.Safe.to_string
@@ -447,6 +479,9 @@ let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
       ~terminal
       ~prepared_at:3.0
   in
+  let precommit =
+    decode_raw_snapshot (label ^ " precommit") ~base_path ~keeper_name
+  in
   (match
      P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
        ~failure
@@ -466,8 +501,44 @@ let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
    | Error detail -> Alcotest.failf "%s lost the durable WAL commit: %s" label detail);
   let wal_path = settlement_wal_path ~base_path ~keeper_name in
   check_single_v2_wal_row label (read_file_or_fail label wal_path);
+  let before_replay =
+    decode_raw_snapshot (label ^ " before replay") ~base_path ~keeper_name
+  in
+  (match failure with
+   | P.For_testing.Fail_checkpoint _ ->
+     Alcotest.(check string)
+       (label ^ " checkpoint failure preserves precommit revision")
+       (Int64.to_string (State.revision precommit))
+       (Int64.to_string (State.revision before_replay));
+     check_same_state
+       (label ^ " checkpoint failure preserves the prepared snapshot")
+       precommit
+       before_replay;
+     (match State.exact_execution_binding before_replay with
+      | Some { status = P.Disposition_prepared prepared; _ }
+        when String.equal prepared.disposition_id disposition.disposition_id ->
+        ()
+      | Some _ ->
+        Alcotest.failf "%s checkpoint failure lost the prepared disposition" label
+      | None ->
+        Alcotest.failf "%s checkpoint failure removed the exact binding" label)
+   | P.For_testing.Fail_wal_compaction _ ->
+     Alcotest.(check string)
+       (label ^ " compaction failure retains the committed revision")
+       (Int64.to_string (Int64.succ (State.revision precommit)))
+       (Int64.to_string (State.revision before_replay));
+     check_no_active_lease (label ^ " committed snapshot") before_replay;
+     check_no_exact_binding (label ^ " committed snapshot") before_replay;
+     check_no_pending (label ^ " committed snapshot") before_replay;
+     ignore
+       (require_single_exact_outbox
+          ~disposition_id:disposition.disposition_id
+          (label ^ " committed snapshot")
+          before_replay));
   let recovered = require_loaded_state (label ^ " first restart") ~base_path ~keeper_name in
   check_no_active_lease (label ^ " first restart") recovered;
+  check_no_exact_binding (label ^ " first restart") recovered;
+  check_no_pending (label ^ " first restart") recovered;
   let receipt =
     require_single_exact_outbox
       ~disposition_id:disposition.disposition_id
@@ -563,6 +634,8 @@ let test_visible_prepare_sync_failure_recovers_once () =
    | Error detail -> Alcotest.failf "visible prepare restart recovery failed: %s" detail);
   let recovered = require_loaded_state "visible prepare first restart" ~base_path ~keeper_name in
   check_no_active_lease "visible prepare first restart" recovered;
+  check_no_exact_binding "visible prepare first restart" recovered;
+  check_no_pending "visible prepare first restart" recovered;
   let receipt =
     require_single_exact_outbox
       ~disposition_id:disposition.disposition_id
@@ -649,12 +722,28 @@ let test_stale_finalize_preserves_active_successor () =
        ~transition_id:receipt.transition_id
    with
    | Ok () -> ()
-   | Error detail -> Alcotest.failf "stale-owner outbox projection failed: %s" detail);
+  | Error detail -> Alcotest.failf "stale-owner outbox projection failed: %s" detail);
   let successor = claim_manual_lease ~base_path ~keeper_name in
-  (match P.transition_outbox_result ~base_path ~keeper_name with
-   | Ok [] -> ()
-   | Ok _ -> Alcotest.fail "successor started with an unexpected outbox entry"
-   | Error detail -> Alcotest.failf "successor outbox load failed: %s" detail);
+  let before_retry =
+    require_loaded_state "stale finalize before retry" ~base_path ~keeper_name
+  in
+  (match State.active_lease before_retry with
+   | Some active ->
+     Alcotest.(check string)
+       "stale finalize starts with successor lease id"
+       successor.lease_id
+       active.lease_id;
+     Alcotest.(check string)
+       "stale finalize starts with successor lease sequence"
+       (Int64.to_string successor.sequence)
+       (Int64.to_string active.sequence)
+   | None -> Alcotest.fail "stale finalize setup lost the active successor lease");
+  check_no_exact_binding "stale finalize before retry" before_retry;
+  check_no_pending "stale finalize before retry" before_retry;
+  Alcotest.(check int)
+    "stale finalize starts without outbox work"
+    0
+    (List.length (State.transition_outbox before_retry));
   (match
      P.finalize_exact_source_disposition_result
        ~base_path
@@ -674,6 +763,14 @@ let test_stale_finalize_preserves_active_successor () =
   let after_retry =
     require_loaded_state "stale finalize post-retry" ~base_path ~keeper_name
   in
+  Alcotest.(check string)
+    "stale finalize preserves the successor revision"
+    (Int64.to_string (State.revision before_retry))
+    (Int64.to_string (State.revision after_retry));
+  check_same_state
+    "stale finalize leaves the adjacent full state unchanged"
+    before_retry
+    after_retry;
   (match State.active_lease after_retry with
    | Some active ->
      Alcotest.(check string)
@@ -685,6 +782,8 @@ let test_stale_finalize_preserves_active_successor () =
        (Int64.to_string successor.sequence)
        (Int64.to_string active.sequence)
    | None -> Alcotest.fail "stale finalize removed the active successor lease");
+  check_no_exact_binding "stale finalize after retry" after_retry;
+  check_no_pending "stale finalize after retry" after_retry;
   Alcotest.(check int)
     "stale finalize creates no successor outbox mutation"
     0
@@ -716,20 +815,30 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       ; reason = P.Exact_execution_terminal terminal
       }
   in
-  let context, resolve_context = Eio.Promise.create () in
-  let entered, resolve_entered = Eio.Promise.create () in
+  let progress, resolve_progress = Eio.Promise.create () in
   let release, resolve_release = Eio.Promise.create () in
   let result, resolve_result = Eio.Promise.create () in
   let finalized = Atomic.make false in
+  let prepare_entered = Atomic.make false in
+  let progress_resolved = Atomic.make false in
+  let release_resolved = Atomic.make false in
+  let resolve_progress_once progress =
+    if Atomic.compare_and_set progress_resolved false true
+    then Eio.Promise.resolve resolve_progress progress
+  in
+  let resolve_release_once () =
+    if Atomic.compare_and_set release_resolved false true
+    then Eio.Promise.resolve resolve_release ()
+  in
   Eio.Fiber.fork ~sw (fun () ->
     let outcome =
       try
         Eio.Cancel.sub (fun cancel_context ->
-          Eio.Promise.resolve resolve_context cancel_context;
           (match
              Masc.Keeper_heartbeat_loop.For_testing.settle_claimed_lease_exact
                ~after_exact_disposition_prepare:(fun () ->
-                 Eio.Promise.resolve resolve_entered ();
+                 Atomic.set prepare_entered true;
+                 resolve_progress_once (`Prepare_entered cancel_context);
                  Eio.Promise.await release)
                ~base_path
                ~keeper_name
@@ -752,17 +861,42 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       | Eio.Cancel.Cancelled _ -> Cancellation_observed
       | exn -> Raised (Printexc.to_string exn)
     in
+    if not (Atomic.get prepare_entered)
+    then resolve_progress_once (`Worker_finished outcome);
     Eio.Promise.resolve resolve_result outcome);
-  let cancel_context = Eio.Promise.await context in
-  Eio.Promise.await entered;
-  Eio.Cancel.cancel cancel_context Exit;
-  Eio.Fiber.yield ();
-  Alcotest.(check bool) "settlement is still protected" false (Atomic.get finalized);
-  (match P.exact_execution_binding_result ~base_path ~keeper_name with
-   | Ok (Some { status = P.Disposition_prepared _; _ }) -> ()
-   | Ok _ -> Alcotest.fail "cancellation barrier was not after durable prepare"
-   | Error detail -> Alcotest.failf "prepared cancellation binding load failed: %s" detail);
-  Eio.Promise.resolve resolve_release ();
+  let worker_finished_early =
+    Fun.protect
+      ~finally:resolve_release_once
+      (fun () ->
+         match Eio.Promise.await progress with
+         | `Worker_finished outcome -> Some outcome
+         | `Prepare_entered cancel_context ->
+           Eio.Cancel.cancel cancel_context Exit;
+           Alcotest.(check bool)
+             "settlement is still protected"
+             false
+             (Atomic.get finalized);
+           (match P.exact_execution_binding_result ~base_path ~keeper_name with
+            | Ok (Some { status = P.Disposition_prepared _; _ }) -> ()
+            | Ok _ ->
+              Alcotest.fail "cancellation barrier was not after durable prepare"
+            | Error detail ->
+              Alcotest.failf
+                "prepared cancellation binding load failed: %s"
+                detail);
+           None)
+  in
+  Alcotest.(check bool)
+    "release resolver settled exactly once"
+    true
+    (Atomic.get release_resolved);
+  (match worker_finished_early with
+   | None -> ()
+   | Some Cancellation_observed ->
+     Alcotest.fail "worker observed cancellation before durable prepare"
+   | Some Returned -> Alcotest.fail "worker returned before durable prepare"
+   | Some (Raised detail) ->
+     Alcotest.failf "worker failed before durable prepare: %s" detail);
   (match Eio.Promise.await result with
    | Cancellation_observed -> ()
    | Returned -> Alcotest.fail "post-settlement cancellation check did not propagate"
@@ -770,6 +904,8 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
   Alcotest.(check bool) "terminal settlement finalized first" true (Atomic.get finalized);
   let state = require_loaded_state "post-cancellation finalization" ~base_path ~keeper_name in
   check_no_active_lease "post-cancellation finalization" state;
+  check_no_exact_binding "post-cancellation finalization" state;
+  check_no_pending "post-cancellation finalization" state;
   ignore (require_single_exact_outbox "post-cancellation finalization" state);
   match P.prepare_registration_result ~base_path ~keeper_name ~settled_at:8.0 () with
   | Ok pending -> Alcotest.(check bool) "settled cancellation never requeues" true (Q.is_empty pending)

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -1,5 +1,72 @@
 include Test_keeper_exact_execution_lease_guard_fixture
 
+module State = Keeper_event_queue_state
+
+let settlement_wal_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue-settlements.jsonl"
+;;
+
+let read_file_or_fail label path =
+  match Safe_ops.read_file_safe path with
+  | Ok bytes -> bytes
+  | Error detail -> Alcotest.failf "%s read failed: %s" label detail
+;;
+
+let require_loaded_state label ~base_path ~keeper_name =
+  match P.load_state_result ~base_path ~keeper_name with
+  | Ok state -> state
+  | Error detail -> Alcotest.failf "%s state load failed: %s" label detail
+;;
+
+let check_no_active_lease label state =
+  Alcotest.(check bool) (label ^ " has no active lease") true (Option.is_none (State.active_lease state))
+;;
+
+let state_json state = State.to_yojson state |> Yojson.Safe.to_string
+
+let check_same_state label expected actual =
+  Alcotest.(check string) label (state_json expected) (state_json actual)
+;;
+
+let require_single_exact_outbox ?disposition_id label state =
+  match State.transition_outbox state with
+  | [ entry ] ->
+    (match entry.receipt.settlement with
+     | P.Settle_exact disposition ->
+       (match disposition_id with
+        | None -> ()
+        | Some expected ->
+          Alcotest.(check string)
+            (label ^ " disposition")
+            expected
+            disposition.disposition_id);
+       entry.receipt
+     | _ -> Alcotest.failf "%s outbox settlement was not Settle_exact" label)
+  | entries ->
+    Alcotest.failf "%s expected one outbox entry, got %d" label (List.length entries)
+;;
+
+let check_single_v2_wal_row label bytes =
+  let rows =
+    String.split_on_char '\n' bytes
+    |> List.filter (fun row -> not (String.equal row ""))
+  in
+  match rows with
+  | [ row ] ->
+    let schema =
+      Yojson.Safe.from_string row
+      |> Yojson.Safe.Util.member "schema"
+      |> Yojson.Safe.Util.to_string
+    in
+    Alcotest.(check string)
+      (label ^ " WAL schema")
+      "masc.keeper_event_queue.settlement.v2"
+      schema
+  | _ -> Alcotest.failf "%s expected one durable WAL row, got %d" label (List.length rows)
+;;
+
 let test_bind_crash_restart_remains_blocked () =
   with_temp_dir "masc-exact-bind-crash" @@ fun base_path ->
   let keeper_name = "exact_bind_crash" in
@@ -355,6 +422,275 @@ let test_failure_judgment_settles_exact_execution_atomically () =
   check_settled_state "receipt replay"
 ;;
 
+let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
+  with_temp_dir ("masc-exact-wal-" ^ label) @@ fun base_path ->
+  let keeper_name = "exact_wal_" ^ label in
+  let slot_id = "slot-wal-" ^ label in
+  let call_id = "call-wal-" ^ label in
+  let plan_fingerprint = "plan-wal-" ^ label in
+  let request_body_sha256 = String.make 64 '2' in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Execution_failed_after_dispatch
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+  in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:3.0
+  in
+  (match
+     P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
+       ~failure
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Committed_followup_failed { stage; _ }) ->
+     Alcotest.(check bool)
+       (label ^ " reports the injected committed stage")
+       true
+       (stage = expected_stage)
+   | Ok _ -> Alcotest.failf "%s did not report a committed follow-up failure" label
+   | Error detail -> Alcotest.failf "%s lost the durable WAL commit: %s" label detail);
+  let wal_path = settlement_wal_path ~base_path ~keeper_name in
+  check_single_v2_wal_row label (read_file_or_fail label wal_path);
+  let recovered = require_loaded_state (label ^ " first restart") ~base_path ~keeper_name in
+  check_no_active_lease (label ^ " first restart") recovered;
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      (label ^ " first restart")
+      recovered
+  in
+  Alcotest.(check string)
+    (label ^ " WAL compacted after replay")
+    ""
+    (read_file_or_fail label wal_path);
+  let loaded_again =
+    require_loaded_state (label ^ " second restart") ~base_path ~keeper_name
+  in
+  check_same_state (label ^ " second load is idempotent") recovered loaded_again;
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       (label ^ " old finalize returns the canonical receipt")
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.failf "%s old finalize was not idempotent" label
+   | Error detail -> Alcotest.failf "%s old finalize retry failed: %s" label detail);
+  let after_retry =
+    require_loaded_state (label ^ " post-retry load") ~base_path ~keeper_name
+  in
+  check_same_state (label ^ " old retry leaves state unchanged") loaded_again after_retry
+;;
+
+let test_exact_wal_followup_failures_replay_once () =
+  run_exact_wal_followup_replay_case
+    ~label:"checkpoint"
+    ~failure:(P.For_testing.Fail_checkpoint "injected checkpoint failure")
+    ~expected_stage:`Checkpoint;
+  run_exact_wal_followup_replay_case
+    ~label:"compaction"
+    ~failure:(P.For_testing.Fail_wal_compaction "injected WAL compaction failure")
+    ~expected_stage:`Wal_compaction
+;;
+
+let test_visible_prepare_sync_failure_recovers_once () =
+  with_temp_dir "masc-exact-visible-prepare" @@ fun base_path ->
+  let keeper_name = "exact_visible_prepare" in
+  let slot_id = "slot-visible-prepare" in
+  let call_id = "call-visible-prepare" in
+  let plan_fingerprint = "plan-visible-prepare" in
+  let request_body_sha256 = String.make 64 '3' in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Execution_failed_after_dispatch
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+  in
+  let disposition =
+    match
+      P.For_testing.prepare_exact_source_disposition_with_sync_parent_result
+        ~sync_parent:(fun _ -> raise (Failure "injected parent sync failure"))
+        ~base_path
+        ~keeper_name
+        ~lease
+        ~source:(source_ref ())
+        ~terminal
+        ~semantic:P.Exact_no_compaction
+        ~prepared_at:3.0
+        ()
+    with
+    | Ok (disposition, P.Visible_sync_unconfirmed _) -> disposition
+    | Ok (_, P.Fsync_completed) ->
+      Alcotest.fail "injected post-rename parent sync failure was not observed"
+    | Error detail ->
+      Alcotest.failf "visible exact disposition was misclassified as absent: %s" detail
+  in
+  (match
+     P.prepare_registration_after_exact_recovery_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ()
+   with
+   | Ok pending ->
+     Alcotest.(check bool) "visible prepare recovery creates no replay" true (Q.is_empty pending)
+   | Error detail -> Alcotest.failf "visible prepare restart recovery failed: %s" detail);
+  let recovered = require_loaded_state "visible prepare first restart" ~base_path ~keeper_name in
+  check_no_active_lease "visible prepare first restart" recovered;
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      "visible prepare first restart"
+      recovered
+  in
+  (match
+     P.prepare_registration_after_exact_recovery_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ()
+   with
+   | Ok pending ->
+     Alcotest.(check bool) "second visible prepare recovery creates no replay" true (Q.is_empty pending)
+   | Error detail -> Alcotest.failf "second visible prepare recovery failed: %s" detail);
+  let loaded_again =
+    require_loaded_state "visible prepare second restart" ~base_path ~keeper_name
+  in
+  check_same_state "visible prepare recovery is idempotent" recovered loaded_again;
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:6.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       "visible prepare old retry returns canonical receipt"
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.fail "visible prepare old retry was not idempotent"
+   | Error detail -> Alcotest.failf "visible prepare old retry failed: %s" detail)
+;;
+
+let test_stale_finalize_preserves_active_successor () =
+  with_temp_dir "masc-exact-stale-finalize" @@ fun base_path ->
+  let keeper_name = "exact_stale_finalize" in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Execution_failed_after_dispatch
+      ~slot_id:"slot-stale"
+      ~call_id:"call-stale"
+      ~plan_fingerprint:"plan-stale"
+      ~request_body_sha256:(String.make 64 '4')
+  in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:3.0
+  in
+  (match
+     P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
+       ~failure:(P.For_testing.Fail_checkpoint "injected stale-owner checkpoint failure")
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Committed_followup_failed { stage = `Checkpoint; _ }) -> ()
+   | Ok _ -> Alcotest.fail "stale-owner setup did not stop after WAL commit"
+   | Error detail -> Alcotest.failf "stale-owner WAL commit failed: %s" detail);
+  let recovered = require_loaded_state "stale-owner restart" ~base_path ~keeper_name in
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      "stale-owner restart"
+      recovered
+  in
+  (match
+     P.mark_transition_projected_result
+       ~base_path
+       ~keeper_name
+       ~transition_id:receipt.transition_id
+   with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "stale-owner outbox projection failed: %s" detail);
+  let successor = claim_manual_lease ~base_path ~keeper_name in
+  (match P.transition_outbox_result ~base_path ~keeper_name with
+   | Ok [] -> ()
+   | Ok _ -> Alcotest.fail "successor started with an unexpected outbox entry"
+   | Error detail -> Alcotest.failf "successor outbox load failed: %s" detail);
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       "stale finalize retains the original receipt"
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.fail "stale finalize committed a second transition"
+   | Error detail -> Alcotest.failf "stale finalize retry failed: %s" detail);
+  let after_retry =
+    require_loaded_state "stale finalize post-retry" ~base_path ~keeper_name
+  in
+  (match State.active_lease after_retry with
+   | Some active ->
+     Alcotest.(check string)
+       "stale finalize preserves successor lease id"
+       successor.lease_id
+       active.lease_id;
+     Alcotest.(check string)
+       "stale finalize preserves successor lease sequence"
+       (Int64.to_string successor.sequence)
+       (Int64.to_string active.sequence)
+   | None -> Alcotest.fail "stale finalize removed the active successor lease");
+  Alcotest.(check int)
+    "stale finalize creates no successor outbox mutation"
+    0
+    (List.length (State.transition_outbox after_retry))
+;;
+
 let test_cancellation_surfaces_only_after_terminal_settlement () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -374,40 +710,41 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       ~plan_fingerprint
       ~request_body_sha256
   in
-  let disposition =
-    prepare_terminal_disposition
-      ~base_path
-      ~keeper_name
-      ~lease
-      ~terminal
-      ~prepared_at:6.0
+  let settlement : P.settlement =
+    P.No_compaction
+      { source = source_ref ()
+      ; reason = P.Exact_execution_terminal terminal
+      }
   in
-  let settlement = P.Settle_exact disposition in
   let context, resolve_context = Eio.Promise.create () in
   let entered, resolve_entered = Eio.Promise.create () in
   let release, resolve_release = Eio.Promise.create () in
   let result, resolve_result = Eio.Promise.create () in
-  let committed = Atomic.make false in
+  let finalized = Atomic.make false in
   Eio.Fiber.fork ~sw (fun () ->
     let outcome =
       try
         Eio.Cancel.sub (fun cancel_context ->
           Eio.Promise.resolve resolve_context cancel_context;
-          Eio.Cancel.protect (fun () ->
-            Eio.Promise.resolve resolve_entered ();
-            Eio.Promise.await release;
-            match
-              P.finalize_exact_source_disposition_result
-                ~base_path
-                ~keeper_name
-                ~settled_at:7.0
-                ~lease
-                ~disposition_id:disposition.disposition_id
-                ()
-            with
-            | Ok (P.Settled _ | P.Already_settled _ | P.Committed_followup_failed _) ->
-              Atomic.set committed true
-            | Error detail -> failwith detail);
+          (match
+             Masc.Keeper_heartbeat_loop.For_testing.settle_claimed_lease_exact
+               ~after_exact_disposition_prepare:(fun () ->
+                 Eio.Promise.resolve resolve_entered ();
+                 Eio.Promise.await release)
+               ~base_path
+               ~keeper_name
+               ~settled_at:7.0
+               ~lease
+               ~settlement
+               ()
+           with
+           | Ok
+               ( Keeper_registry_event_queue.Settled _
+               | Keeper_registry_event_queue.Already_settled _ ) ->
+             Atomic.set finalized true
+           | Ok (Keeper_registry_event_queue.Committed_followup_failed { detail; _ }) ->
+             failwith detail
+           | Error detail -> failwith detail);
           Masc.Keeper_heartbeat_loop.For_testing.check_cancellation_after_exact_terminal_settlement
             settlement;
           Returned)
@@ -420,13 +757,20 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
   Eio.Promise.await entered;
   Eio.Cancel.cancel cancel_context Exit;
   Eio.Fiber.yield ();
-  Alcotest.(check bool) "settlement is still protected" false (Atomic.get committed);
+  Alcotest.(check bool) "settlement is still protected" false (Atomic.get finalized);
+  (match P.exact_execution_binding_result ~base_path ~keeper_name with
+   | Ok (Some { status = P.Disposition_prepared _; _ }) -> ()
+   | Ok _ -> Alcotest.fail "cancellation barrier was not after durable prepare"
+   | Error detail -> Alcotest.failf "prepared cancellation binding load failed: %s" detail);
   Eio.Promise.resolve resolve_release ();
   (match Eio.Promise.await result with
    | Cancellation_observed -> ()
    | Returned -> Alcotest.fail "post-settlement cancellation check did not propagate"
    | Raised detail -> Alcotest.failf "cancellation proof raised: %s" detail);
-  Alcotest.(check bool) "terminal settlement committed first" true (Atomic.get committed);
+  Alcotest.(check bool) "terminal settlement finalized first" true (Atomic.get finalized);
+  let state = require_loaded_state "post-cancellation finalization" ~base_path ~keeper_name in
+  check_no_active_lease "post-cancellation finalization" state;
+  ignore (require_single_exact_outbox "post-cancellation finalization" state);
   match P.prepare_registration_result ~base_path ~keeper_name ~settled_at:8.0 () with
   | Ok pending -> Alcotest.(check bool) "settled cancellation never requeues" true (Q.is_empty pending)
   | Error detail -> Alcotest.failf "post-terminal registration failed: %s" detail
@@ -458,6 +802,18 @@ let () =
             "failure judgment settles exact execution atomically"
             `Quick
             test_failure_judgment_settles_exact_execution_atomically
+        ; Alcotest.test_case
+            "Settle_exact WAL follow-up failures replay once"
+            `Quick
+            test_exact_wal_followup_failures_replay_once
+        ; Alcotest.test_case
+            "visible prepare sync failure recovers once"
+            `Quick
+            test_visible_prepare_sync_failure_recovers_once
+        ; Alcotest.test_case
+            "stale finalize preserves active successor"
+            `Quick
+            test_stale_finalize_preserves_active_successor
         ] )
     ; ( "cancellation"
       , [ Alcotest.test_case

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -85,19 +85,22 @@ let test_before_dispatch_release_allows_registration_requeue () =
    | Ok (Some _) -> Alcotest.fail "before-dispatch release retained the binding"
    | Error detail -> Alcotest.failf "released binding load failed: %s" detail);
   let terminal : P.exact_execution_terminal =
-    { cause = P.Execution_failed_after_dispatch; slot_id; call_id }
+    { cause = P.Execution_failed_after_dispatch
+    ; slot_id
+    ; call_id
+    ; plan_fingerprint
+    ; request_body_sha256
+    }
   in
   (match
-     P.settle_exact_execution_result
+     P.prepare_exact_source_disposition_result
        ~base_path
        ~keeper_name
-       ~settled_at:3.0
        ~lease
-       ~slot_id
-       ~call_id
-       ~plan_fingerprint
-       ~request_body_sha256
-       ~settlement:(terminal_settlement (source_ref ()) terminal)
+       ~source:(source_ref ())
+       ~terminal
+       ~semantic:P.Exact_no_compaction
+       ~prepared_at:3.0
        ()
    with
    | Error _ -> ()
@@ -181,7 +184,14 @@ let test_restart_recovery_never_requeues_bound_lease () =
       ~request_body_sha256
   in
   check_binding ~base_path ~keeper_name ~call_id ~plan_fingerprint;
-  let settlement = terminal_settlement (source_ref ()) terminal in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:3.0
+  in
   let wal_path =
     Filename.concat
       (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
@@ -189,74 +199,61 @@ let test_restart_recovery_never_requeues_bound_lease () =
   in
   Unix.mkdir wal_path 0o700;
   (match
-     P.settle_exact_execution_result
+     P.finalize_exact_source_disposition_result
        ~base_path
        ~keeper_name
-       ~settled_at:3.0
+       ~settled_at:4.0
        ~lease
-       ~slot_id
-       ~call_id
-       ~plan_fingerprint
-       ~request_body_sha256
-       ~settlement
+       ~disposition_id:disposition.disposition_id
        ()
    with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "poisoned WAL unexpectedly committed settlement");
   Unix.rmdir wal_path;
-  (match P.prepare_registration_result ~base_path ~keeper_name ~settled_at:4.0 () with
-   | Error _ -> ()
-   | Ok _ -> Alcotest.fail "registration recovery requeued a bound exact execution");
-  check_binding ~base_path ~keeper_name ~call_id ~plan_fingerprint;
+  check_prepared_binding
+    ~base_path
+    ~keeper_name
+    ~disposition_id:disposition.disposition_id;
+  (match
+     P.prepare_registration_after_exact_recovery_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ()
+   with
+   | Ok pending ->
+     Alcotest.(check bool) "terminal recovery created no replay" true (Q.is_empty pending)
+   | Error detail -> Alcotest.failf "prepared terminal recovery failed: %s" detail);
+  (match P.exact_execution_binding_result ~base_path ~keeper_name with
+   | Ok None -> ()
+   | Ok (Some _) -> Alcotest.fail "terminal recovery retained the exact binding"
+   | Error detail -> Alcotest.failf "recovered binding load failed: %s" detail);
   (match P.load_pending_result ~base_path ~keeper_name with
    | Ok pending -> Alcotest.(check bool) "no generic recovery pending row" true (Q.is_empty pending)
    | Error detail -> Alcotest.failf "pending load failed: %s" detail);
   (match
-     P.settle_exact_execution_result
+     P.finalize_exact_source_disposition_result
        ~base_path
        ~keeper_name
-       ~settled_at:5.0
+       ~settled_at:6.0
        ~lease
-       ~slot_id
-       ~call_id:"different-call"
-       ~plan_fingerprint
-       ~request_body_sha256
-       ~settlement
+       ~disposition_id:"different-disposition"
        ()
    with
    | Error _ -> ()
-   | Ok _ -> Alcotest.fail "mismatched call id finalized a quarantined lease");
+   | Ok _ -> Alcotest.fail "mismatched disposition replay was accepted");
   (match
-    P.settle_exact_execution_result
-      ~base_path
-      ~keeper_name
-      ~settled_at:6.0
-      ~lease
-      ~slot_id
-      ~call_id
-      ~plan_fingerprint
-      ~request_body_sha256
-      ~settlement
-      ()
-   with
-   | Ok (P.Settled _ | P.Already_settled _ | P.Committed_followup_failed _) -> ()
-   | Error detail -> Alcotest.failf "matching terminal finalization failed: %s" detail);
-  match
-    P.settle_exact_execution_result
+    P.finalize_exact_source_disposition_result
       ~base_path
       ~keeper_name
       ~settled_at:7.0
       ~lease
-      ~slot_id
-      ~call_id
-      ~plan_fingerprint
-      ~request_body_sha256
-      ~settlement
+      ~disposition_id:disposition.disposition_id
       ()
-  with
-  | Ok (P.Already_settled _) -> ()
-  | Ok _ -> Alcotest.fail "matching receipt replay was not idempotent"
-  | Error detail -> Alcotest.failf "matching receipt replay failed: %s" detail
+   with
+   | Ok (P.Already_settled _) -> ()
+   | Ok _ -> Alcotest.fail "matching receipt replay was not idempotent"
+   | Error detail -> Alcotest.failf "matching receipt replay failed: %s" detail)
 ;;
 
 let test_failure_judgment_settles_exact_execution_atomically () =
@@ -323,7 +320,7 @@ let test_failure_judgment_settles_exact_execution_atomically () =
     | Error detail -> Alcotest.failf "%s pending load failed: %s" label detail
   in
   (match
-     P.settle_exact_execution_result
+     P.settle_bound_exact_nonterminal_result
        ~base_path
        ~keeper_name
        ~settled_at:3.0
@@ -340,7 +337,7 @@ let test_failure_judgment_settles_exact_execution_atomically () =
    | Error detail -> Alcotest.failf "failure judgment settlement failed: %s" detail);
   check_settled_state "first settlement";
   (match
-     P.settle_exact_execution_result
+     P.settle_bound_exact_nonterminal_result
        ~base_path
        ~keeper_name
        ~settled_at:4.0
@@ -377,7 +374,15 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       ~plan_fingerprint
       ~request_body_sha256
   in
-  let settlement = terminal_settlement (source_ref ()) terminal in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:6.0
+  in
+  let settlement = P.Settle_exact disposition in
   let context, resolve_context = Eio.Promise.create () in
   let entered, resolve_entered = Eio.Promise.create () in
   let release, resolve_release = Eio.Promise.create () in
@@ -392,16 +397,12 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
             Eio.Promise.resolve resolve_entered ();
             Eio.Promise.await release;
             match
-              P.settle_exact_execution_result
+              P.finalize_exact_source_disposition_result
                 ~base_path
                 ~keeper_name
                 ~settled_at:7.0
                 ~lease
-                ~slot_id
-                ~call_id
-                ~plan_fingerprint
-                ~request_body_sha256
-                ~settlement
+                ~disposition_id:disposition.disposition_id
                 ()
             with
             | Ok (P.Settled _ | P.Already_settled _ | P.Committed_followup_failed _) ->

--- a/test/test_keeper_exact_execution_lease_guard_fixture.ml
+++ b/test/test_keeper_exact_execution_lease_guard_fixture.ml
@@ -69,6 +69,12 @@ let claim_manual_lease ~base_path ~keeper_name =
   | Error detail -> Alcotest.failf "manual lease claim failed: %s" detail
 ;;
 
+let require_fsync label = function
+  | P.Fsync_completed -> ()
+  | P.Visible_sync_unconfirmed detail ->
+    Alcotest.failf "%s durability unknown: %s" label detail
+;;
+
 let bind_and_quarantine
       ~base_path
       ~keeper_name
@@ -94,15 +100,15 @@ let bind_and_quarantine
    | Ok (P.Visible_sync_unconfirmed detail) ->
      Alcotest.failf "exact execution bind durability unknown: %s" detail
    | Error detail -> Alcotest.failf "exact execution bind failed: %s" detail);
-  let terminal : P.exact_execution_terminal = { cause; slot_id; call_id } in
+  let terminal : P.exact_execution_terminal =
+    { cause; slot_id; call_id; plan_fingerprint; request_body_sha256 }
+  in
   (match
      P.quarantine_exact_execution_result
        ~base_path
        ~keeper_name
        ~lease
        ~terminal
-       ~plan_fingerprint
-       ~request_body_sha256
        ()
    with
    | Ok P.Fsync_completed -> ()
@@ -112,8 +118,28 @@ let bind_and_quarantine
   lease, terminal
 ;;
 
-let terminal_settlement source terminal : P.settlement =
-  P.No_compaction { source; reason = P.Exact_execution_terminal terminal }
+let prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at
+  =
+  match
+    P.prepare_exact_source_disposition_result
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source:(source_ref ())
+      ~terminal
+      ~semantic:P.Exact_no_compaction
+      ~prepared_at
+      ()
+  with
+  | Error detail -> Alcotest.failf "terminal disposition preparation failed: %s" detail
+  | Ok (disposition, durability) ->
+    require_fsync "terminal disposition preparation" durability;
+    disposition
 ;;
 
 let check_binding ~base_path ~keeper_name ~call_id ~plan_fingerprint =
@@ -133,6 +159,19 @@ let check_binding ~base_path ~keeper_name ~call_id ~plan_fingerprint =
   | Ok (Some _) -> Alcotest.fail "binding was not terminally quarantined"
   | Ok None -> Alcotest.fail "durable exact execution binding disappeared"
   | Error detail -> Alcotest.failf "binding load failed: %s" detail
+;;
+
+let check_prepared_binding ~base_path ~keeper_name ~disposition_id =
+  match P.exact_execution_binding_result ~base_path ~keeper_name with
+  | Ok
+      (Some
+        { status = P.Disposition_prepared disposition
+        ; _
+        })
+    when String.equal disposition.disposition_id disposition_id -> ()
+  | Ok (Some _) -> Alcotest.fail "binding did not retain the prepared disposition"
+  | Ok None -> Alcotest.fail "prepared exact execution binding disappeared"
+  | Error detail -> Alcotest.failf "prepared binding load failed: %s" detail
 ;;
 
 let bind_exact_execution

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -15,7 +15,13 @@ module Schema = Masc.Keeper_structured_output_schema
 module Summarizer = Masc.Keeper_compaction_llm_summarizer
 
 let exact_terminal ?(slot_id = "compaction-slot") ?(call_id = "call-compaction") cause =
-  Keeper_event_queue_state.{ cause; slot_id; call_id }
+  Keeper_event_queue_state.
+    { cause
+    ; slot_id
+    ; call_id
+    ; plan_fingerprint = "compaction-plan"
+    ; request_body_sha256 = String.make 64 'c'
+    }
 ;;
 
 let compaction_decision ?summary unit_index action =
@@ -736,6 +742,7 @@ let test_manual_compaction_serializes_owner_lane () =
        | Registry_queue.Cancel_accepted _
        | Registry_queue.Transfer_accepted _
        | Registry_queue.Settle_from_source_terminal _
+       | Registry_queue.Settle_exact _
        | Registry_queue.Escalate _ ->
          fail "post-dispatch final admission lost source-bound terminal evidence");
       Registry_queue.settle_result


### PR DESCRIPTION
## Summary

- prove `Settle_exact` WAL v2 survives checkpoint and WAL-compaction follow-up failures, then replays exactly once
- prove an after-rename parent-sync failure returns `Visible_sync_unconfirmed` and restart recovery converges idempotently
- exercise the production `settle_claimed_lease ~exact_execution:true` cancellation boundary with a deterministic post-prepare barrier inside its existing `Eio.Cancel.protect`
- prove a stale old-owner finalize retry cannot mutate an active successor lease or create a new outbox effect

## Test seams

- settlement WAL append remains the production durable append; only checkpoint/compaction follow-ups receive scoped deterministic faults
- atomic prepare reuses `Fs_compat.Atomic_replace_for_testing` for the parent-sync fault
- heartbeat exposes a scoped post-prepare observer; production behavior and defaults are unchanged
- no global mutable hooks, WAL v1 compatibility, migration, or `owner_generation` fallback

## Stack

This PR is intentionally stacked on #25633 at `536b519ba1c7671119d4e3f8a662b11a90fbbfc8`. Retarget it to `main` after #25633 merges.

## Validation

- `ocamlformat -i` on the five changed OCaml files
- local build/tests intentionally not run; PR CI is the execution authority
