### PR TITLE
fix(keeper): migrate retired transcript retry metadata

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -411,6 +411,10 @@ let retired_keeper_meta_key_names =
        this entry every read of every existing file would warn and increment
        MetaJsonFailures(site=unknown_keys) indefinitely. *)
   ; "last_turn_tool_calls"
+    (* Removed with the transcript-corruption retry latch. Existing dormant
+       Keeper metas still carry the codec-orphaned counter, so boot must
+       canonicalize it instead of warning on every later read. *)
+  ; "transcript_quarantine_consecutive_retries"
   ]
 ;;
 

--- a/test/test_keeper_meta_canonicalize.ml
+++ b/test/test_keeper_meta_canonicalize.ml
@@ -76,6 +76,7 @@ let inject_keys ?(extra = []) config name =
          @ [
              ("last_continuity_update_ts", `Float 1780000000.0);
              ("continuity_summary", `String "legacy continuity prose");
+             ("transcript_quarantine_consecutive_retries", `Int 3);
            ]
          @ extra)
     in
@@ -197,13 +198,18 @@ let test_unknown_keys_pure_function () =
   check (list string) "all-canonical object has no unknown keys" []
     (Keeper_meta_json.unknown_keeper_meta_keys canonical_only);
   check (list string) "retired keys are reported in order"
-    [ "last_continuity_update_ts"; "continuity_summary" ]
+    [
+      "last_continuity_update_ts";
+      "continuity_summary";
+      "transcript_quarantine_consecutive_retries";
+    ]
     (Keeper_meta_json.unknown_keeper_meta_keys
        (`Assoc
          [
            ("name", `String "x");
            ("last_continuity_update_ts", `Float 0.0);
            ("continuity_summary", `String "y");
+           ("transcript_quarantine_consecutive_retries", `Int 3);
          ]));
   check (list string) "non-object JSON has no unknown keys" []
     (Keeper_meta_json.unknown_keeper_meta_keys (`String "not an object"))


### PR DESCRIPTION
## Summary
- add `transcript_quarantine_consecutive_retries` to the explicit retired Keeper-meta key set
- remove it atomically during boot migration while preserving every surviving raw JSON field
- extend the canonicalization regression fixture

## Why
PR #25626 removed the retry counter from both Keeper meta codecs, but existing dormant `.masc/keepers/*.json` files still carry it. Every subsequent meta scan warns again because boot canonicalization did not know that exact retired key.

This remains fail-closed: arbitrary unknown keys are not dropped.

## Validation
- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_meta_store.ml test/test_keeper_meta_canonicalize.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_meta_store.ml`
- `ocamlc -stop-after parsing test/test_keeper_meta_canonicalize.ml`
- focused Dune wrapper attempted, but correctly refused because another bare `dune build lib` process owns the machine-wide build lane; CI is the build authority for this PR.