### PR TITLE
test(keeper): prove exact disposition crash boundaries

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -606,6 +606,7 @@ let exact_terminal_source = function
 
 let settle_claimed_lease
       ?(exact_execution = false)
+      ?(after_exact_disposition_prepare = fun () -> ())
       ~base_path
       ~keeper_name
       ~settled_at
@@ -680,6 +681,7 @@ let settle_claimed_lease
                 ("exact source disposition became visible with unconfirmed sync; restart reconciliation required: "
                  ^ detail)
             | Ok (disposition, Keeper_registry_event_queue.Fsync_completed) ->
+              after_exact_disposition_prepare ();
               Keeper_registry_event_queue.finalize_exact_source_disposition_result
                 ~base_path
                 keeper_name
@@ -863,6 +865,26 @@ module For_testing = struct
 
   let exact_execution_guard = exact_execution_guard
   let commit_transcript_corruption = commit_transcript_corruption
+
+  let settle_claimed_lease_exact
+        ~after_exact_disposition_prepare
+        ~base_path
+        ~keeper_name
+        ~settled_at
+        ~lease
+        ~settlement
+        ()
+    =
+    settle_claimed_lease
+      ~exact_execution:true
+      ~after_exact_disposition_prepare
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~settlement
+      ()
+  ;;
 
   let check_cancellation_after_exact_terminal_settlement =
     check_cancellation_after_exact_terminal_settlement

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -272,6 +272,16 @@ module For_testing : sig
     lease:Keeper_registry_event_queue.lease ->
     Keeper_compaction_llm_summarizer.exact_execution_guard
 
+  val settle_claimed_lease_exact :
+    after_exact_disposition_prepare:(unit -> unit) ->
+    base_path:string ->
+    keeper_name:string ->
+    settled_at:float ->
+    lease:Keeper_registry_event_queue.lease ->
+    settlement:Keeper_registry_event_queue.settlement ->
+    unit ->
+    (Keeper_registry_event_queue.settle_result, string) result
+
   val check_cancellation_after_exact_terminal_settlement :
     Keeper_registry_event_queue.settlement -> unit
 end

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -245,7 +245,7 @@ let save_json_atomic_with ~strict_parent_sync path json =
 let save_json_atomic = save_json_atomic_with ~strict_parent_sync:false
 let save_json_atomic_strict = save_json_atomic_with ~strict_parent_sync:true
 
-let save_json_atomic_strict_staged path json =
+let save_json_atomic_strict_staged_with ~save path json =
   match
     try Ok (Fs_compat.mkdir_p (Filename.dirname path)) with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -256,7 +256,7 @@ let save_json_atomic_strict_staged path json =
     let content =
       json |> Safe_ops.sanitize_json_utf8 |> Yojson.Safe.pretty_to_string
     in
-    (match Fs_compat.save_file_atomic_strict_staged path content with
+    (match save path content with
      | Ok () -> Ok Fsync_completed
      | Error (failure : Fs_compat.atomic_replace_failure) ->
        let detail = Fs_compat.atomic_replace_failure_to_string failure in
@@ -268,6 +268,10 @@ let save_json_atomic_strict_staged path json =
            | _ -> Error detail)
         | Fs_compat.After_rename ->
           Ok (Visible_sync_unconfirmed detail)))
+;;
+
+let save_json_atomic_strict_staged =
+  save_json_atomic_strict_staged_with ~save:Fs_compat.save_file_atomic_strict_staged
 ;;
 
 let save_state_unlocked_with ~strict_parent_sync owner state =
@@ -288,10 +292,10 @@ let save_state_unlocked_with ~strict_parent_sync owner state =
 let save_state_unlocked = save_state_unlocked_with ~strict_parent_sync:false
 let save_state_unlocked_strict = save_state_unlocked_with ~strict_parent_sync:true
 
-let save_state_unlocked_strict_staged owner state =
+let save_state_unlocked_strict_staged_with ~save owner state =
   let keeper_name = keeper_name_of_owner owner in
   let path = snapshot_path_of_owner owner in
-  match save_json_atomic_strict_staged path (State.to_yojson state) with
+  match save_json_atomic_strict_staged_with ~save path (State.to_yojson state) with
   | Ok outcome -> Ok outcome
   | Error message ->
     Error
@@ -300,6 +304,11 @@ let save_state_unlocked_strict_staged owner state =
          keeper_name
          path
          message)
+;;
+
+let save_state_unlocked_strict_staged =
+  save_state_unlocked_strict_staged_with
+    ~save:Fs_compat.save_file_atomic_strict_staged
 ;;
 
 type snapshot_read_error_kind =
@@ -787,7 +796,12 @@ let commit_transform
             (Printexc.to_string exn)))
 ;;
 
-let commit_exact_transform_unlocked owner ~after_commit transform =
+let commit_exact_transform_unlocked
+      ?(save_state = save_state_unlocked_strict_staged)
+      owner
+      ~after_commit
+      transform
+  =
   match load_state_unlocked owner with
   | Error _ as error -> error
   | Ok current ->
@@ -800,20 +814,26 @@ let commit_exact_transform_unlocked owner ~after_commit transform =
        (match next with
         | Error _ as error -> error
         | Ok next ->
-          (match save_state_unlocked_strict_staged owner next with
+          (match save_state owner next with
            | Error _ as error -> error
            | Ok outcome ->
              after_commit (State.pending next);
              Ok (value, outcome))))
 ;;
 
-let commit_exact_transform ~base_path ~keeper_name ~after_commit transform =
+let commit_exact_transform
+      ?save_state
+      ~base_path
+      ~keeper_name
+      ~after_commit
+      transform
+  =
   match resolve_owner ~base_path ~keeper_name with
   | Error _ as error -> error
   | Ok owner ->
     (try
        Owner_lock.with_durable_lock owner (fun () ->
-         commit_exact_transform_unlocked owner ~after_commit transform)
+         commit_exact_transform_unlocked ?save_state owner ~after_commit transform)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -1002,7 +1022,8 @@ let quarantine_exact_execution_result
   |> Result.map snd
 ;;
 
-let prepare_exact_source_disposition_result
+let prepare_exact_source_disposition_result_with
+      ?save_state
       ~base_path
       ~keeper_name
       ~lease
@@ -1013,6 +1034,7 @@ let prepare_exact_source_disposition_result
       ()
   =
   commit_exact_transform
+    ?save_state
     ~base_path
     ~keeper_name
     ~after_commit:(fun _ -> ())
@@ -1027,7 +1049,35 @@ let prepare_exact_source_disposition_result
        |> Result.map (fun (next, disposition) -> next, disposition))
 ;;
 
-let commit_settlement_transition_unlocked owner ~after_commit transition current =
+let prepare_exact_source_disposition_result
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source
+      ~terminal
+      ~semantic
+      ~prepared_at
+      ()
+  =
+  prepare_exact_source_disposition_result_with
+    ~base_path
+    ~keeper_name
+    ~lease
+    ~source
+    ~terminal
+    ~semantic
+    ~prepared_at
+    ()
+;;
+
+let commit_settlement_transition_unlocked_with
+      ~save_checkpoint
+      ~compact_wal
+      owner
+      ~after_commit
+      transition
+      current
+  =
   match transition current with
   | Error _ as error -> error
   | Ok (state, State.Already_settled receipt) ->
@@ -1042,14 +1092,14 @@ let commit_settlement_transition_unlocked owner ~after_commit transition current
        let path = settlement_wal_path_of_owner owner in
        let continue_after_commit () =
          let pending = State.pending checkpoint in
-         match save_state_unlocked owner checkpoint with
+         match save_checkpoint owner checkpoint with
          | Error detail ->
            Ok
              ( Committed_followup_failed
                  { receipt; stage = `Checkpoint; detail }
              , pending )
          | Ok () ->
-           (match compact_settlement_wal_unlocked owner with
+           (match compact_wal owner with
             | Error detail ->
               Ok
                 ( Committed_followup_failed
@@ -1108,6 +1158,12 @@ let commit_settlement_transition_unlocked owner ~after_commit transition current
           continue_after_commit ()))
      | [] | [ _ ] | _ :: _ :: _ ->
        Error "settlement transition did not produce its canonical outbox entry")
+;;
+
+let commit_settlement_transition_unlocked =
+  commit_settlement_transition_unlocked_with
+    ~save_checkpoint:save_state_unlocked
+    ~compact_wal:compact_settlement_wal_unlocked
 ;;
 
 let settle_result
@@ -1187,7 +1243,9 @@ let settle_bound_exact_nonterminal_result
             (Printexc.to_string exn)))
 ;;
 
-let finalize_exact_source_disposition_result
+let finalize_exact_source_disposition_result_with
+      ~save_checkpoint
+      ~compact_wal
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
@@ -1204,7 +1262,9 @@ let finalize_exact_source_disposition_result
          match load_state_unlocked owner with
          | Error _ as error -> error
          | Ok state ->
-           commit_settlement_transition_unlocked
+           commit_settlement_transition_unlocked_with
+             ~save_checkpoint
+             ~compact_wal
              owner
              ~after_commit
              (State.finalize_exact_source_disposition
@@ -1222,6 +1282,88 @@ let finalize_exact_source_disposition_result
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;
+
+let finalize_exact_source_disposition_result
+      ?after_commit
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~disposition_id
+      ()
+  =
+  finalize_exact_source_disposition_result_with
+    ~save_checkpoint:save_state_unlocked
+    ~compact_wal:compact_settlement_wal_unlocked
+    ?after_commit
+    ~base_path
+    ~keeper_name
+    ~settled_at
+    ~lease
+    ~disposition_id
+    ()
+;;
+
+module For_testing = struct
+  type settlement_followup_failure =
+    | Fail_checkpoint of string
+    | Fail_wal_compaction of string
+
+  let finalize_exact_source_disposition_with_followup_failure_result
+        ~failure
+        ~base_path
+        ~keeper_name
+        ~settled_at
+        ~lease
+        ~disposition_id
+        ()
+    =
+    let save_checkpoint, compact_wal =
+      match failure with
+      | Fail_checkpoint detail ->
+        ( (fun _owner _state -> Error detail)
+        , compact_settlement_wal_unlocked )
+      | Fail_wal_compaction detail ->
+        save_state_unlocked, (fun _owner -> Error detail)
+    in
+    finalize_exact_source_disposition_result_with
+      ~save_checkpoint
+      ~compact_wal
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~disposition_id
+      ()
+  ;;
+
+  let prepare_exact_source_disposition_with_sync_parent_result
+        ~sync_parent
+        ~base_path
+        ~keeper_name
+        ~lease
+        ~source
+        ~terminal
+        ~semantic
+        ~prepared_at
+        ()
+    =
+    let save =
+      Fs_compat.Atomic_replace_for_testing.save_file_atomic_strict_staged
+        ~sync_parent
+    in
+    prepare_exact_source_disposition_result_with
+      ~save_state:(save_state_unlocked_strict_staged_with ~save)
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~source
+      ~terminal
+      ~semantic
+      ~prepared_at
+      ()
+  ;;
+end
 
 let cancel_accepted_result
       ?(after_commit = fun _ -> ())

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -356,6 +356,34 @@ val finalize_exact_source_disposition_result :
   unit ->
   (settle_result, string) result
 
+module For_testing : sig
+  type settlement_followup_failure =
+    | Fail_checkpoint of string
+    | Fail_wal_compaction of string
+
+  val finalize_exact_source_disposition_with_followup_failure_result :
+    failure:settlement_followup_failure ->
+    base_path:string ->
+    keeper_name:string ->
+    settled_at:float ->
+    lease:lease ->
+    disposition_id:string ->
+    unit ->
+    (settle_result, string) result
+
+  val prepare_exact_source_disposition_with_sync_parent_result :
+    sync_parent:(string -> unit) ->
+    base_path:string ->
+    keeper_name:string ->
+    lease:lease ->
+    source:Keeper_checkpoint_ref.t ->
+    terminal:exact_execution_terminal ->
+    semantic:exact_settlement_semantic ->
+    prepared_at:float ->
+    unit ->
+    (exact_source_disposition * exact_write_outcome, string) result
+end
+
 val settle_bound_exact_nonterminal_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -8,10 +8,28 @@ let settlement_wal_path ~base_path ~keeper_name =
     "event-queue-settlements.jsonl"
 ;;
 
+let snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
+;;
+
 let read_file_or_fail label path =
   match Safe_ops.read_file_safe path with
   | Ok bytes -> bytes
   | Error detail -> Alcotest.failf "%s read failed: %s" label detail
+;;
+
+let decode_raw_snapshot label ~base_path ~keeper_name =
+  let path = snapshot_path ~base_path ~keeper_name in
+  let json =
+    try Yojson.Safe.from_string (read_file_or_fail label path) with
+    | Yojson.Json_error detail ->
+      Alcotest.failf "%s raw snapshot JSON failed: %s" label detail
+  in
+  match State.of_yojson json with
+  | Ok state -> state
+  | Error detail -> Alcotest.failf "%s raw current-state decode failed: %s" label detail
 ;;
 
 let require_loaded_state label ~base_path ~keeper_name =
@@ -22,6 +40,20 @@ let require_loaded_state label ~base_path ~keeper_name =
 
 let check_no_active_lease label state =
   Alcotest.(check bool) (label ^ " has no active lease") true (Option.is_none (State.active_lease state))
+;;
+
+let check_no_exact_binding label state =
+  Alcotest.(check bool)
+    (label ^ " has no exact binding")
+    true
+    (Option.is_none (State.exact_execution_binding state))
+;;
+
+let check_no_pending label state =
+  Alcotest.(check bool)
+    (label ^ " has no pending stimuli")
+    true
+    (Q.is_empty (State.pending state))
 ;;
 
 let state_json state = State.to_yojson state |> Yojson.Safe.to_string
@@ -447,6 +479,9 @@ let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
       ~terminal
       ~prepared_at:3.0
   in
+  let precommit =
+    decode_raw_snapshot (label ^ " precommit") ~base_path ~keeper_name
+  in
   (match
      P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
        ~failure
@@ -466,8 +501,44 @@ let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
    | Error detail -> Alcotest.failf "%s lost the durable WAL commit: %s" label detail);
   let wal_path = settlement_wal_path ~base_path ~keeper_name in
   check_single_v2_wal_row label (read_file_or_fail label wal_path);
+  let before_replay =
+    decode_raw_snapshot (label ^ " before replay") ~base_path ~keeper_name
+  in
+  (match failure with
+   | P.For_testing.Fail_checkpoint _ ->
+     Alcotest.(check string)
+       (label ^ " checkpoint failure preserves precommit revision")
+       (Int64.to_string (State.revision precommit))
+       (Int64.to_string (State.revision before_replay));
+     check_same_state
+       (label ^ " checkpoint failure preserves the prepared snapshot")
+       precommit
+       before_replay;
+     (match State.exact_execution_binding before_replay with
+      | Some { status = P.Disposition_prepared prepared; _ }
+        when String.equal prepared.disposition_id disposition.disposition_id ->
+        ()
+      | Some _ ->
+        Alcotest.failf "%s checkpoint failure lost the prepared disposition" label
+      | None ->
+        Alcotest.failf "%s checkpoint failure removed the exact binding" label)
+   | P.For_testing.Fail_wal_compaction _ ->
+     Alcotest.(check string)
+       (label ^ " compaction failure retains the committed revision")
+       (Int64.to_string (Int64.succ (State.revision precommit)))
+       (Int64.to_string (State.revision before_replay));
+     check_no_active_lease (label ^ " committed snapshot") before_replay;
+     check_no_exact_binding (label ^ " committed snapshot") before_replay;
+     check_no_pending (label ^ " committed snapshot") before_replay;
+     ignore
+       (require_single_exact_outbox
+          ~disposition_id:disposition.disposition_id
+          (label ^ " committed snapshot")
+          before_replay));
   let recovered = require_loaded_state (label ^ " first restart") ~base_path ~keeper_name in
   check_no_active_lease (label ^ " first restart") recovered;
+  check_no_exact_binding (label ^ " first restart") recovered;
+  check_no_pending (label ^ " first restart") recovered;
   let receipt =
     require_single_exact_outbox
       ~disposition_id:disposition.disposition_id
@@ -563,6 +634,8 @@ let test_visible_prepare_sync_failure_recovers_once () =
    | Error detail -> Alcotest.failf "visible prepare restart recovery failed: %s" detail);
   let recovered = require_loaded_state "visible prepare first restart" ~base_path ~keeper_name in
   check_no_active_lease "visible prepare first restart" recovered;
+  check_no_exact_binding "visible prepare first restart" recovered;
+  check_no_pending "visible prepare first restart" recovered;
   let receipt =
     require_single_exact_outbox
       ~disposition_id:disposition.disposition_id
@@ -649,12 +722,28 @@ let test_stale_finalize_preserves_active_successor () =
        ~transition_id:receipt.transition_id
    with
    | Ok () -> ()
-   | Error detail -> Alcotest.failf "stale-owner outbox projection failed: %s" detail);
+  | Error detail -> Alcotest.failf "stale-owner outbox projection failed: %s" detail);
   let successor = claim_manual_lease ~base_path ~keeper_name in
-  (match P.transition_outbox_result ~base_path ~keeper_name with
-   | Ok [] -> ()
-   | Ok _ -> Alcotest.fail "successor started with an unexpected outbox entry"
-   | Error detail -> Alcotest.failf "successor outbox load failed: %s" detail);
+  let before_retry =
+    require_loaded_state "stale finalize before retry" ~base_path ~keeper_name
+  in
+  (match State.active_lease before_retry with
+   | Some active ->
+     Alcotest.(check string)
+       "stale finalize starts with successor lease id"
+       successor.lease_id
+       active.lease_id;
+     Alcotest.(check string)
+       "stale finalize starts with successor lease sequence"
+       (Int64.to_string successor.sequence)
+       (Int64.to_string active.sequence)
+   | None -> Alcotest.fail "stale finalize setup lost the active successor lease");
+  check_no_exact_binding "stale finalize before retry" before_retry;
+  check_no_pending "stale finalize before retry" before_retry;
+  Alcotest.(check int)
+    "stale finalize starts without outbox work"
+    0
+    (List.length (State.transition_outbox before_retry));
   (match
      P.finalize_exact_source_disposition_result
        ~base_path
@@ -674,6 +763,14 @@ let test_stale_finalize_preserves_active_successor () =
   let after_retry =
     require_loaded_state "stale finalize post-retry" ~base_path ~keeper_name
   in
+  Alcotest.(check string)
+    "stale finalize preserves the successor revision"
+    (Int64.to_string (State.revision before_retry))
+    (Int64.to_string (State.revision after_retry));
+  check_same_state
+    "stale finalize leaves the adjacent full state unchanged"
+    before_retry
+    after_retry;
   (match State.active_lease after_retry with
    | Some active ->
      Alcotest.(check string)
@@ -685,6 +782,8 @@ let test_stale_finalize_preserves_active_successor () =
        (Int64.to_string successor.sequence)
        (Int64.to_string active.sequence)
    | None -> Alcotest.fail "stale finalize removed the active successor lease");
+  check_no_exact_binding "stale finalize after retry" after_retry;
+  check_no_pending "stale finalize after retry" after_retry;
   Alcotest.(check int)
     "stale finalize creates no successor outbox mutation"
     0
@@ -716,20 +815,30 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       ; reason = P.Exact_execution_terminal terminal
       }
   in
-  let context, resolve_context = Eio.Promise.create () in
-  let entered, resolve_entered = Eio.Promise.create () in
+  let progress, resolve_progress = Eio.Promise.create () in
   let release, resolve_release = Eio.Promise.create () in
   let result, resolve_result = Eio.Promise.create () in
   let finalized = Atomic.make false in
+  let prepare_entered = Atomic.make false in
+  let progress_resolved = Atomic.make false in
+  let release_resolved = Atomic.make false in
+  let resolve_progress_once progress =
+    if Atomic.compare_and_set progress_resolved false true
+    then Eio.Promise.resolve resolve_progress progress
+  in
+  let resolve_release_once () =
+    if Atomic.compare_and_set release_resolved false true
+    then Eio.Promise.resolve resolve_release ()
+  in
   Eio.Fiber.fork ~sw (fun () ->
     let outcome =
       try
         Eio.Cancel.sub (fun cancel_context ->
-          Eio.Promise.resolve resolve_context cancel_context;
           (match
              Masc.Keeper_heartbeat_loop.For_testing.settle_claimed_lease_exact
                ~after_exact_disposition_prepare:(fun () ->
-                 Eio.Promise.resolve resolve_entered ();
+                 Atomic.set prepare_entered true;
+                 resolve_progress_once (`Prepare_entered cancel_context);
                  Eio.Promise.await release)
                ~base_path
                ~keeper_name
@@ -752,17 +861,42 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       | Eio.Cancel.Cancelled _ -> Cancellation_observed
       | exn -> Raised (Printexc.to_string exn)
     in
+    if not (Atomic.get prepare_entered)
+    then resolve_progress_once (`Worker_finished outcome);
     Eio.Promise.resolve resolve_result outcome);
-  let cancel_context = Eio.Promise.await context in
-  Eio.Promise.await entered;
-  Eio.Cancel.cancel cancel_context Exit;
-  Eio.Fiber.yield ();
-  Alcotest.(check bool) "settlement is still protected" false (Atomic.get finalized);
-  (match P.exact_execution_binding_result ~base_path ~keeper_name with
-   | Ok (Some { status = P.Disposition_prepared _; _ }) -> ()
-   | Ok _ -> Alcotest.fail "cancellation barrier was not after durable prepare"
-   | Error detail -> Alcotest.failf "prepared cancellation binding load failed: %s" detail);
-  Eio.Promise.resolve resolve_release ();
+  let worker_finished_early =
+    Fun.protect
+      ~finally:resolve_release_once
+      (fun () ->
+         match Eio.Promise.await progress with
+         | `Worker_finished outcome -> Some outcome
+         | `Prepare_entered cancel_context ->
+           Eio.Cancel.cancel cancel_context Exit;
+           Alcotest.(check bool)
+             "settlement is still protected"
+             false
+             (Atomic.get finalized);
+           (match P.exact_execution_binding_result ~base_path ~keeper_name with
+            | Ok (Some { status = P.Disposition_prepared _; _ }) -> ()
+            | Ok _ ->
+              Alcotest.fail "cancellation barrier was not after durable prepare"
+            | Error detail ->
+              Alcotest.failf
+                "prepared cancellation binding load failed: %s"
+                detail);
+           None)
+  in
+  Alcotest.(check bool)
+    "release resolver settled exactly once"
+    true
+    (Atomic.get release_resolved);
+  (match worker_finished_early with
+   | None -> ()
+   | Some Cancellation_observed ->
+     Alcotest.fail "worker observed cancellation before durable prepare"
+   | Some Returned -> Alcotest.fail "worker returned before durable prepare"
+   | Some (Raised detail) ->
+     Alcotest.failf "worker failed before durable prepare: %s" detail);
   (match Eio.Promise.await result with
    | Cancellation_observed -> ()
    | Returned -> Alcotest.fail "post-settlement cancellation check did not propagate"
@@ -770,6 +904,8 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
   Alcotest.(check bool) "terminal settlement finalized first" true (Atomic.get finalized);
   let state = require_loaded_state "post-cancellation finalization" ~base_path ~keeper_name in
   check_no_active_lease "post-cancellation finalization" state;
+  check_no_exact_binding "post-cancellation finalization" state;
+  check_no_pending "post-cancellation finalization" state;
   ignore (require_single_exact_outbox "post-cancellation finalization" state);
   match P.prepare_registration_result ~base_path ~keeper_name ~settled_at:8.0 () with
   | Ok pending -> Alcotest.(check bool) "settled cancellation never requeues" true (Q.is_empty pending)

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -850,10 +850,10 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
                ()
            with
            | Ok
-               ( Keeper_registry_event_queue.Settled _
-               | Keeper_registry_event_queue.Already_settled _ ) ->
+               ( P.Settled _
+               | P.Already_settled _ ) ->
              Atomic.set finalized true
-           | Ok (Keeper_registry_event_queue.Committed_followup_failed { detail; _ }) ->
+           | Ok (P.Committed_followup_failed { detail; _ }) ->
              failwith detail
            | Error detail -> failwith detail);
           Masc.Keeper_heartbeat_loop.For_testing.check_cancellation_after_exact_terminal_settlement

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -1,5 +1,72 @@
 include Test_keeper_exact_execution_lease_guard_fixture
 
+module State = Keeper_event_queue_state
+
+let settlement_wal_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue-settlements.jsonl"
+;;
+
+let read_file_or_fail label path =
+  match Safe_ops.read_file_safe path with
+  | Ok bytes -> bytes
+  | Error detail -> Alcotest.failf "%s read failed: %s" label detail
+;;
+
+let require_loaded_state label ~base_path ~keeper_name =
+  match P.load_state_result ~base_path ~keeper_name with
+  | Ok state -> state
+  | Error detail -> Alcotest.failf "%s state load failed: %s" label detail
+;;
+
+let check_no_active_lease label state =
+  Alcotest.(check bool) (label ^ " has no active lease") true (Option.is_none (State.active_lease state))
+;;
+
+let state_json state = State.to_yojson state |> Yojson.Safe.to_string
+
+let check_same_state label expected actual =
+  Alcotest.(check string) label (state_json expected) (state_json actual)
+;;
+
+let require_single_exact_outbox ?disposition_id label state =
+  match State.transition_outbox state with
+  | [ entry ] ->
+    (match entry.receipt.settlement with
+     | P.Settle_exact disposition ->
+       (match disposition_id with
+        | None -> ()
+        | Some expected ->
+          Alcotest.(check string)
+            (label ^ " disposition")
+            expected
+            disposition.disposition_id);
+       entry.receipt
+     | _ -> Alcotest.failf "%s outbox settlement was not Settle_exact" label)
+  | entries ->
+    Alcotest.failf "%s expected one outbox entry, got %d" label (List.length entries)
+;;
+
+let check_single_v2_wal_row label bytes =
+  let rows =
+    String.split_on_char '\n' bytes
+    |> List.filter (fun row -> not (String.equal row ""))
+  in
+  match rows with
+  | [ row ] ->
+    let schema =
+      Yojson.Safe.from_string row
+      |> Yojson.Safe.Util.member "schema"
+      |> Yojson.Safe.Util.to_string
+    in
+    Alcotest.(check string)
+      (label ^ " WAL schema")
+      "masc.keeper_event_queue.settlement.v2"
+      schema
+  | _ -> Alcotest.failf "%s expected one durable WAL row, got %d" label (List.length rows)
+;;
+
 let test_bind_crash_restart_remains_blocked () =
   with_temp_dir "masc-exact-bind-crash" @@ fun base_path ->
   let keeper_name = "exact_bind_crash" in
@@ -355,6 +422,275 @@ let test_failure_judgment_settles_exact_execution_atomically () =
   check_settled_state "receipt replay"
 ;;
 
+let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
+  with_temp_dir ("masc-exact-wal-" ^ label) @@ fun base_path ->
+  let keeper_name = "exact_wal_" ^ label in
+  let slot_id = "slot-wal-" ^ label in
+  let call_id = "call-wal-" ^ label in
+  let plan_fingerprint = "plan-wal-" ^ label in
+  let request_body_sha256 = String.make 64 '2' in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Execution_failed_after_dispatch
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+  in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:3.0
+  in
+  (match
+     P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
+       ~failure
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Committed_followup_failed { stage; _ }) ->
+     Alcotest.(check bool)
+       (label ^ " reports the injected committed stage")
+       true
+       (stage = expected_stage)
+   | Ok _ -> Alcotest.failf "%s did not report a committed follow-up failure" label
+   | Error detail -> Alcotest.failf "%s lost the durable WAL commit: %s" label detail);
+  let wal_path = settlement_wal_path ~base_path ~keeper_name in
+  check_single_v2_wal_row label (read_file_or_fail label wal_path);
+  let recovered = require_loaded_state (label ^ " first restart") ~base_path ~keeper_name in
+  check_no_active_lease (label ^ " first restart") recovered;
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      (label ^ " first restart")
+      recovered
+  in
+  Alcotest.(check string)
+    (label ^ " WAL compacted after replay")
+    ""
+    (read_file_or_fail label wal_path);
+  let loaded_again =
+    require_loaded_state (label ^ " second restart") ~base_path ~keeper_name
+  in
+  check_same_state (label ^ " second load is idempotent") recovered loaded_again;
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       (label ^ " old finalize returns the canonical receipt")
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.failf "%s old finalize was not idempotent" label
+   | Error detail -> Alcotest.failf "%s old finalize retry failed: %s" label detail);
+  let after_retry =
+    require_loaded_state (label ^ " post-retry load") ~base_path ~keeper_name
+  in
+  check_same_state (label ^ " old retry leaves state unchanged") loaded_again after_retry
+;;
+
+let test_exact_wal_followup_failures_replay_once () =
+  run_exact_wal_followup_replay_case
+    ~label:"checkpoint"
+    ~failure:(P.For_testing.Fail_checkpoint "injected checkpoint failure")
+    ~expected_stage:`Checkpoint;
+  run_exact_wal_followup_replay_case
+    ~label:"compaction"
+    ~failure:(P.For_testing.Fail_wal_compaction "injected WAL compaction failure")
+    ~expected_stage:`Wal_compaction
+;;
+
+let test_visible_prepare_sync_failure_recovers_once () =
+  with_temp_dir "masc-exact-visible-prepare" @@ fun base_path ->
+  let keeper_name = "exact_visible_prepare" in
+  let slot_id = "slot-visible-prepare" in
+  let call_id = "call-visible-prepare" in
+  let plan_fingerprint = "plan-visible-prepare" in
+  let request_body_sha256 = String.make 64 '3' in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Execution_failed_after_dispatch
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+  in
+  let disposition =
+    match
+      P.For_testing.prepare_exact_source_disposition_with_sync_parent_result
+        ~sync_parent:(fun _ -> raise (Failure "injected parent sync failure"))
+        ~base_path
+        ~keeper_name
+        ~lease
+        ~source:(source_ref ())
+        ~terminal
+        ~semantic:P.Exact_no_compaction
+        ~prepared_at:3.0
+        ()
+    with
+    | Ok (disposition, P.Visible_sync_unconfirmed _) -> disposition
+    | Ok (_, P.Fsync_completed) ->
+      Alcotest.fail "injected post-rename parent sync failure was not observed"
+    | Error detail ->
+      Alcotest.failf "visible exact disposition was misclassified as absent: %s" detail
+  in
+  (match
+     P.prepare_registration_after_exact_recovery_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ()
+   with
+   | Ok pending ->
+     Alcotest.(check bool) "visible prepare recovery creates no replay" true (Q.is_empty pending)
+   | Error detail -> Alcotest.failf "visible prepare restart recovery failed: %s" detail);
+  let recovered = require_loaded_state "visible prepare first restart" ~base_path ~keeper_name in
+  check_no_active_lease "visible prepare first restart" recovered;
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      "visible prepare first restart"
+      recovered
+  in
+  (match
+     P.prepare_registration_after_exact_recovery_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ()
+   with
+   | Ok pending ->
+     Alcotest.(check bool) "second visible prepare recovery creates no replay" true (Q.is_empty pending)
+   | Error detail -> Alcotest.failf "second visible prepare recovery failed: %s" detail);
+  let loaded_again =
+    require_loaded_state "visible prepare second restart" ~base_path ~keeper_name
+  in
+  check_same_state "visible prepare recovery is idempotent" recovered loaded_again;
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:6.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       "visible prepare old retry returns canonical receipt"
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.fail "visible prepare old retry was not idempotent"
+   | Error detail -> Alcotest.failf "visible prepare old retry failed: %s" detail)
+;;
+
+let test_stale_finalize_preserves_active_successor () =
+  with_temp_dir "masc-exact-stale-finalize" @@ fun base_path ->
+  let keeper_name = "exact_stale_finalize" in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Execution_failed_after_dispatch
+      ~slot_id:"slot-stale"
+      ~call_id:"call-stale"
+      ~plan_fingerprint:"plan-stale"
+      ~request_body_sha256:(String.make 64 '4')
+  in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:3.0
+  in
+  (match
+     P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
+       ~failure:(P.For_testing.Fail_checkpoint "injected stale-owner checkpoint failure")
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Committed_followup_failed { stage = `Checkpoint; _ }) -> ()
+   | Ok _ -> Alcotest.fail "stale-owner setup did not stop after WAL commit"
+   | Error detail -> Alcotest.failf "stale-owner WAL commit failed: %s" detail);
+  let recovered = require_loaded_state "stale-owner restart" ~base_path ~keeper_name in
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      "stale-owner restart"
+      recovered
+  in
+  (match
+     P.mark_transition_projected_result
+       ~base_path
+       ~keeper_name
+       ~transition_id:receipt.transition_id
+   with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "stale-owner outbox projection failed: %s" detail);
+  let successor = claim_manual_lease ~base_path ~keeper_name in
+  (match P.transition_outbox_result ~base_path ~keeper_name with
+   | Ok [] -> ()
+   | Ok _ -> Alcotest.fail "successor started with an unexpected outbox entry"
+   | Error detail -> Alcotest.failf "successor outbox load failed: %s" detail);
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       "stale finalize retains the original receipt"
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.fail "stale finalize committed a second transition"
+   | Error detail -> Alcotest.failf "stale finalize retry failed: %s" detail);
+  let after_retry =
+    require_loaded_state "stale finalize post-retry" ~base_path ~keeper_name
+  in
+  (match State.active_lease after_retry with
+   | Some active ->
+     Alcotest.(check string)
+       "stale finalize preserves successor lease id"
+       successor.lease_id
+       active.lease_id;
+     Alcotest.(check string)
+       "stale finalize preserves successor lease sequence"
+       (Int64.to_string successor.sequence)
+       (Int64.to_string active.sequence)
+   | None -> Alcotest.fail "stale finalize removed the active successor lease");
+  Alcotest.(check int)
+    "stale finalize creates no successor outbox mutation"
+    0
+    (List.length (State.transition_outbox after_retry))
+;;
+
 let test_cancellation_surfaces_only_after_terminal_settlement () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -374,40 +710,41 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
       ~plan_fingerprint
       ~request_body_sha256
   in
-  let disposition =
-    prepare_terminal_disposition
-      ~base_path
-      ~keeper_name
-      ~lease
-      ~terminal
-      ~prepared_at:6.0
+  let settlement : P.settlement =
+    P.No_compaction
+      { source = source_ref ()
+      ; reason = P.Exact_execution_terminal terminal
+      }
   in
-  let settlement = P.Settle_exact disposition in
   let context, resolve_context = Eio.Promise.create () in
   let entered, resolve_entered = Eio.Promise.create () in
   let release, resolve_release = Eio.Promise.create () in
   let result, resolve_result = Eio.Promise.create () in
-  let committed = Atomic.make false in
+  let finalized = Atomic.make false in
   Eio.Fiber.fork ~sw (fun () ->
     let outcome =
       try
         Eio.Cancel.sub (fun cancel_context ->
           Eio.Promise.resolve resolve_context cancel_context;
-          Eio.Cancel.protect (fun () ->
-            Eio.Promise.resolve resolve_entered ();
-            Eio.Promise.await release;
-            match
-              P.finalize_exact_source_disposition_result
-                ~base_path
-                ~keeper_name
-                ~settled_at:7.0
-                ~lease
-                ~disposition_id:disposition.disposition_id
-                ()
-            with
-            | Ok (P.Settled _ | P.Already_settled _ | P.Committed_followup_failed _) ->
-              Atomic.set committed true
-            | Error detail -> failwith detail);
+          (match
+             Masc.Keeper_heartbeat_loop.For_testing.settle_claimed_lease_exact
+               ~after_exact_disposition_prepare:(fun () ->
+                 Eio.Promise.resolve resolve_entered ();
+                 Eio.Promise.await release)
+               ~base_path
+               ~keeper_name
+               ~settled_at:7.0
+               ~lease
+               ~settlement
+               ()
+           with
+           | Ok
+               ( Keeper_registry_event_queue.Settled _
+               | Keeper_registry_event_queue.Already_settled _ ) ->
+             Atomic.set finalized true
+           | Ok (Keeper_registry_event_queue.Committed_followup_failed { detail; _ }) ->
+             failwith detail
+           | Error detail -> failwith detail);
           Masc.Keeper_heartbeat_loop.For_testing.check_cancellation_after_exact_terminal_settlement
             settlement;
           Returned)
@@ -420,13 +757,20 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
   Eio.Promise.await entered;
   Eio.Cancel.cancel cancel_context Exit;
   Eio.Fiber.yield ();
-  Alcotest.(check bool) "settlement is still protected" false (Atomic.get committed);
+  Alcotest.(check bool) "settlement is still protected" false (Atomic.get finalized);
+  (match P.exact_execution_binding_result ~base_path ~keeper_name with
+   | Ok (Some { status = P.Disposition_prepared _; _ }) -> ()
+   | Ok _ -> Alcotest.fail "cancellation barrier was not after durable prepare"
+   | Error detail -> Alcotest.failf "prepared cancellation binding load failed: %s" detail);
   Eio.Promise.resolve resolve_release ();
   (match Eio.Promise.await result with
    | Cancellation_observed -> ()
    | Returned -> Alcotest.fail "post-settlement cancellation check did not propagate"
    | Raised detail -> Alcotest.failf "cancellation proof raised: %s" detail);
-  Alcotest.(check bool) "terminal settlement committed first" true (Atomic.get committed);
+  Alcotest.(check bool) "terminal settlement finalized first" true (Atomic.get finalized);
+  let state = require_loaded_state "post-cancellation finalization" ~base_path ~keeper_name in
+  check_no_active_lease "post-cancellation finalization" state;
+  ignore (require_single_exact_outbox "post-cancellation finalization" state);
   match P.prepare_registration_result ~base_path ~keeper_name ~settled_at:8.0 () with
   | Ok pending -> Alcotest.(check bool) "settled cancellation never requeues" true (Q.is_empty pending)
   | Error detail -> Alcotest.failf "post-terminal registration failed: %s" detail
@@ -458,6 +802,18 @@ let () =
             "failure judgment settles exact execution atomically"
             `Quick
             test_failure_judgment_settles_exact_execution_atomically
+        ; Alcotest.test_case
+            "Settle_exact WAL follow-up failures replay once"
+            `Quick
+            test_exact_wal_followup_failures_replay_once
+        ; Alcotest.test_case
+            "visible prepare sync failure recovers once"
+            `Quick
+            test_visible_prepare_sync_failure_recovers_once
+        ; Alcotest.test_case
+            "stale finalize preserves active successor"
+            `Quick
+            test_stale_finalize_preserves_active_successor
         ] )
     ; ( "cancellation"
       , [ Alcotest.test_case

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -821,12 +821,14 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
   let finalized = Atomic.make false in
   let prepare_entered = Atomic.make false in
   let progress_resolved = Atomic.make false in
+  let release_attempts = Atomic.make 0 in
   let release_resolved = Atomic.make false in
   let resolve_progress_once progress =
     if Atomic.compare_and_set progress_resolved false true
     then Eio.Promise.resolve resolve_progress progress
   in
   let resolve_release_once () =
+    ignore (Atomic.fetch_and_add release_attempts 1);
     if Atomic.compare_and_set release_resolved false true
     then Eio.Promise.resolve resolve_release ()
   in
@@ -890,6 +892,10 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
     "release resolver settled exactly once"
     true
     (Atomic.get release_resolved);
+  Alcotest.(check int)
+    "release resolver invoked exactly once"
+    1
+    (Atomic.get release_attempts);
   (match worker_finished_early with
    | None -> ()
    | Some Cancellation_observed ->


### PR DESCRIPTION
## Summary

- prove `Settle_exact` WAL v2 survives checkpoint and WAL-compaction follow-up failures, then replays exactly once
- decode the raw current-state snapshot before replay to distinguish prepared checkpoint failure from committed compaction failure
- prove an after-rename parent-sync failure returns `Visible_sync_unconfirmed` and restart recovery converges idempotently
- exercise the production `settle_claimed_lease ~exact_execution:true` cancellation boundary with a deterministic post-prepare/early-worker handshake and failure-safe single release
- prove a stale old-owner finalize retry preserves the active successor lease, revision, exact binding, outbox, pending state, and full adjacent state bytes

## Test seams

- settlement WAL append remains the production durable append; only checkpoint/compaction follow-ups receive scoped deterministic faults
- atomic prepare reuses `Fs_compat.Atomic_replace_for_testing` for the parent-sync fault
- heartbeat exposes a scoped post-prepare observer; production behavior and defaults are unchanged
- no global mutable hooks, WAL v1 compatibility, migration, or `owner_generation` fallback

## Lineage

This replaces #25635. GitHub automatically closed the stacked PR when #25633 merged, then refused to reopen it after the required restack force-push. The proof commits are rebased directly onto merged `main` commit `205948711fc7a97ba72c8021cecf69f4bd7296fe`.

## Validation

- `ocamlformat -i` on changed OCaml files
- local build/tests intentionally not run; PR CI is the execution authority
