### PR TITLE
fix(keeper): terminate turns after surface delivery

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -549,29 +549,36 @@ let run_turn
        (* Section 3: Dispatch — call Keeper_turn_driver.run_named / Agent.run. *)
        let turn_result =
          let cooperative_yield_probe =
-                match autonomous_yield_requested with
-                | None -> None
-                | Some requested ->
-                  Some
-                    (fun (_ : Agent_sdk.Agent.Advanced.tool_boundary) ->
-                       try
-                         match requested () with
-                         | Ok (Some request) ->
-                           Ok (Runtime_agent.Yield (runtime_yield_reason request))
-                         | Ok None -> Ok Runtime_agent.Continue
-                         | Error detail ->
-                           Error
-                             (Agent_sdk.Error.Internal
-                                ("keeper cooperative-yield snapshot failed: "
-                                 ^ detail))
-                       with
-                       | Eio.Cancel.Cancelled _ as exn -> raise exn
-                       | exn ->
+           Some
+             (fun (_ : Agent_sdk.Agent.Advanced.tool_boundary) ->
+                try
+                  (* [terminal_effect_completed] is set only by a successful
+                     descriptor-typed terminal effect. OAS invokes this probe
+                     after tool results and the checkpoint have persisted, so
+                     settlement cannot race ahead of the reply effect. *)
+                  if s.terminal_effect_completed ()
+                  then Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
+                  else
+                    match autonomous_yield_requested with
+                    | None -> Ok Runtime_agent.Continue
+                    | Some requested ->
+                      (match requested () with
+                       | Ok (Some request) ->
+                         Ok (Runtime_agent.Yield (runtime_yield_reason request))
+                       | Ok None -> Ok Runtime_agent.Continue
+                       | Error detail ->
                          Error
                            (Agent_sdk.Error.Internal
-                              (Printf.sprintf
-                                 "keeper cooperative-yield probe failed: %s"
-                                 (Printexc.to_string exn))))
+                              ("keeper cooperative-yield snapshot failed: "
+                               ^ detail)))
+                with
+                | Eio.Cancel.Cancelled _ as exn -> raise exn
+                | exn ->
+                  Error
+                    (Agent_sdk.Error.Internal
+                       (Printf.sprintf
+                          "keeper cooperative-yield probe failed: %s"
+                          (Printexc.to_string exn))))
          in
          let checkpoint_sidecar =
                 ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -57,6 +57,7 @@ let task_id_scope_of_tool_call = Keeper_run_tools_task_scope.task_id_scope_of_to
 type agent_setup = Keeper_run_tools_hooks.agent_setup =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
+  ; terminal_effect_completed : unit -> bool
   ; hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection :
       Agent_sdk.Types.message list -> Agent_sdk.Types.message list

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -53,6 +53,7 @@ val freeze : hook_accumulator -> hook_outputs
 type agent_setup =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
+  ; terminal_effect_completed : unit -> bool
   ; hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection :
       Agent_sdk.Types.message list -> Agent_sdk.Types.message list

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -13,6 +13,7 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator
 type agent_setup =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
+  ; terminal_effect_completed : unit -> bool
   ; hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection :
       Agent_sdk.Types.message list -> Agent_sdk.Types.message list
@@ -36,6 +37,7 @@ type ctx =
       turn:int -> tool_list:string list -> lane:turn_lane -> unit
   ; config : Workspace.config
   ; keeper_tools_cleanup : unit -> unit
+  ; terminal_effect_completed : unit -> bool
   ; manifest_keeper_turn_id : int option
   ; meta : Keeper_meta_contract.keeper_meta
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
@@ -143,6 +145,7 @@ let assemble_hooks
   let record_tool_assignment = ctx.record_tool_assignment in
   let config = ctx.config in
   let keeper_tools_cleanup = ctx.keeper_tools_cleanup in
+  let terminal_effect_completed = ctx.terminal_effect_completed in
   let manifest_keeper_turn_id = ctx.manifest_keeper_turn_id in
   let meta = ctx.meta in
   let turn_ctx_cell = ctx.turn_ctx_cell in
@@ -558,6 +561,7 @@ let assemble_hooks
     Ok
       { tools
       ; cleanup = keeper_tools_cleanup
+      ; terminal_effect_completed
       ; hooks
       ; model_input_projection
       ; acc

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -86,7 +86,12 @@ let prepare_agent_setup
       Keeper_tool_execution.success
         (Yojson.Safe.to_string (`Assoc [ "results", `List [] ])))
   in
-  let { Keeper_tools_oas.tools = keeper_tools; cleanup = keeper_tools_cleanup } =
+  let
+    { Keeper_tools_oas.tools = keeper_tools
+    ; cleanup = keeper_tools_cleanup
+    ; terminal_effect_completed
+    }
+    =
     Keeper_tools_oas_bundle.make_tool_bundle
       ~config
       ~meta
@@ -249,6 +254,7 @@ let prepare_agent_setup
     ; record_tool_assignment
     ; config
     ; keeper_tools_cleanup
+    ; terminal_effect_completed
     ; manifest_keeper_turn_id
     ; meta
     ; turn_ctx_cell

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -12,6 +12,7 @@
 type tool_bundle =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
+  ; terminal_effect_completed : unit -> bool
   }
 
 (** Tool usage now lives in Keeper_registry (per-entry tool_usage Hashtbl).

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -14,6 +14,7 @@
 type tool_bundle =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
+  ; terminal_effect_completed : unit -> bool
   }
 
 (** Per-keeper tool usage view from [Keeper_registry]. *)

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -9,6 +9,18 @@
 
 open Keeper_tools_oas
 
+type completion_boundary =
+  | Continue_after_success
+  | Terminal_effect
+
+(* A connected-surface post is the reply deliverable for this Keeper turn.
+   Classify it from the closed runtime-handler ADT: no tool-name comparison,
+   payload inspection, retry count, or elapsed-time threshold participates. *)
+let completion_boundary_of_runtime_handler = function
+  | Keeper_tool_descriptor.Tool_surface_post -> Terminal_effect
+  | _ -> Continue_after_success
+;;
+
 let task_state_hint ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) : string =
   let meta = Keeper_current_task_reconcile.sync_current_task_id_from_backlog ~config meta in
   match meta.current_task_id with
@@ -68,6 +80,10 @@ let make_tool_bundle
   (* Every descriptor-declared model tool is materialized. The turn hook sends
      this exact list to OAS without per-Keeper or per-turn reduction. *)
   let model_visible_descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
+  (* The bundle lives for exactly one Agent run. A successful terminal effect
+     flips this turn-local latch; the OAS tool-boundary probe observes it only
+     after the whole tool batch and checkpoint sink have completed. *)
+  let terminal_effect_completed = ref false in
   (* The handler dispatches with
      [~name:descriptor.internal_name] so all telemetry SSOT remains internal;
      exactly one projected Tool.schema.name is model-visible.
@@ -77,6 +93,12 @@ let make_tool_bundle
     List.concat_map
       (fun (descriptor : Keeper_tool_descriptor.t) ->
          let internal = descriptor.internal_name in
+         let on_completed =
+           match completion_boundary_of_runtime_handler descriptor.runtime_handler with
+           | Terminal_effect ->
+             Some (fun () -> terminal_effect_completed := true)
+           | Continue_after_success -> None
+         in
          Keeper_tool_descriptor.keeper_model_names descriptor
          |> List.map (fun model_name ->
              let h =
@@ -94,6 +116,7 @@ let make_tool_bundle
                  ?gate_context:gate_context_provider
                  ?gate_grant
                  ?record_gate_result
+                 ?on_completed
                  ~pre_validate_input:(fun input ->
                    match
                      Keeper_tool_descriptor_resolution.validate_public_input_for_tool_call
@@ -127,6 +150,7 @@ let make_tool_bundle
   ; cleanup =
       (fun () ->
         Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory)
+  ; terminal_effect_completed = (fun () -> !terminal_effect_completed)
   }
 ;;
 
@@ -151,3 +175,11 @@ let make_tools
      ())
     .tools
 ;;
+
+module For_testing = struct
+  let is_terminal_effect_handler handler =
+    match completion_boundary_of_runtime_handler handler with
+    | Terminal_effect -> true
+    | Continue_after_success -> false
+  ;;
+end

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -29,3 +29,7 @@ val make_tools
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> unit
   -> Agent_sdk.Tool.t list
+
+module For_testing : sig
+  val is_terminal_effect_handler : Keeper_tool_descriptor.runtime_handler -> bool
+end

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -23,6 +23,7 @@ let make_keeper_tool_handler
       ?gate_context
       ?gate_grant
       ?record_gate_result
+      ?on_completed
       ?(pre_validate_input = fun input -> Ok input)
       ?(translate_input = fun j -> j)
       ?(validate_translated_input = true)
@@ -117,25 +118,32 @@ let make_keeper_tool_handler
               | Ok proc_mgr -> Some proc_mgr
               | Error _ -> None
             in
-            Keeper_tools_oas_handler_exec.execute_with_observers
-              ~name
-              ~config
-              ~meta
-              ~publication_recovery
-              ~ctx_snapshot
-              ?turn_sandbox_factory
-              ?search_fn
-              ?sw
-              ?clock
-              ?proc_mgr
-              ?net
-              ?continuation_channel
-              ?gate_context
-              ?gate_grant
-              ?oas_invocation
-              ~input
-              ()
-            |> record_result ~input
+            let result =
+              Keeper_tools_oas_handler_exec.execute_with_observers
+                ~name
+                ~config
+                ~meta
+                ~publication_recovery
+                ~ctx_snapshot
+                ?turn_sandbox_factory
+                ?search_fn
+                ?sw
+                ?clock
+                ?proc_mgr
+                ?net
+                ?continuation_channel
+                ?gate_context
+                ?gate_grant
+                ?oas_invocation
+                ~input
+                ()
+              |> record_result ~input
+            in
+            (match result with
+             | Tool_result.Completed _ ->
+               Option.iter (fun completed -> completed ()) on_completed
+             | Tool_result.Deferred _ | Tool_result.Failed _ -> ());
+            result
           in
           run_with_current_eio_context ?clock:current_clock ())
 ;;

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -33,6 +33,7 @@ val make_keeper_tool_handler
   -> ?gate_grant:Keeper_gate.cycle_grant
   -> ?record_gate_result:
        (operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit)
+  -> ?on_completed:(unit -> unit)
   -> ?pre_validate_input:
        (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -72,6 +72,7 @@ type stop_reason =
 type cooperative_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | Terminal_tool_completed
 
 type cooperative_yield_decision =
   | Continue
@@ -770,6 +771,16 @@ let select_agent_result ~checkpoint ~resume ~build =
   | Some checkpoint -> resume checkpoint
   | None -> build ()
 
+let stop_reason_of_cooperative_yield ~turns_used = function
+  | Chat_waiting -> Yielded_to_chat_waiting { turns_used }
+  | Durable_stimulus_waiting ->
+    Yielded_to_durable_stimulus { turns_used }
+  (* The provider loop yielded at OAS's durable post-tool boundary because
+     the typed reply effect already completed. This is successful completion,
+     not a continuation checkpoint that should replay on the next cycle. *)
+  | Terminal_tool_completed -> Completed
+;;
+
 module For_testing = struct
   let provider_http_observation_transport = provider_http_observation_transport
   let runtime_id_of_config = runtime_id_of_config
@@ -798,6 +809,7 @@ module For_testing = struct
   let apply_runtime_model_input_capabilities =
     apply_runtime_model_input_capabilities
   let select_agent_result = select_agent_result
+  let stop_reason_of_cooperative_yield = stop_reason_of_cooperative_yield
 end
 
 (* ================================================================ *)
@@ -1278,11 +1290,9 @@ let run_blocks
     | Ok (`Yielded (decision, yielded, response)) ->
       close_after_success ();
       let stop_reason =
-        match decision with
-        | Chat_waiting ->
-          Yielded_to_chat_waiting { turns_used = yielded.turn }
-        | Durable_stimulus_waiting ->
-          Yielded_to_durable_stimulus { turns_used = yielded.turn }
+        stop_reason_of_cooperative_yield
+          ~turns_used:yielded.turn
+          decision
       in
       record_dashboard_oas_response
         ~config

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -31,6 +31,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
 type cooperative_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | Terminal_tool_completed
 
 type cooperative_yield_decision =
   | Continue
@@ -229,6 +230,9 @@ module For_testing : sig
     Llm_provider.Llm_transport.t -> Llm_provider.Llm_transport.t
 
   val runtime_id_of_config : config -> string
+
+  val stop_reason_of_cooperative_yield :
+    turns_used:int -> cooperative_yield_reason -> stop_reason
 
   (* RFC-OAS-026 §4.6 fail-fast (pure decision; raises [Failure] when an idle
      deadline is configured but no clock resolves). *)

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -77,12 +77,35 @@ let test_autonomous_yield_boundary_contract () =
   in
   (match F.runtime_yield_reason chat with
    | Runtime_agent.Chat_waiting -> ()
-   | Runtime_agent.Durable_stimulus_waiting ->
+   | Runtime_agent.Durable_stimulus_waiting
+   | Runtime_agent.Terminal_tool_completed ->
      fail "chat request mapped to the durable reason");
-  match F.runtime_yield_reason durable_stimulus with
-  | Runtime_agent.Durable_stimulus_waiting -> ()
-  | Runtime_agent.Chat_waiting ->
-    fail "durable request mapped to the chat reason"
+  (match F.runtime_yield_reason durable_stimulus with
+   | Runtime_agent.Durable_stimulus_waiting -> ()
+   | Runtime_agent.Chat_waiting
+   | Runtime_agent.Terminal_tool_completed ->
+     fail "durable request mapped to the chat reason");
+  check bool "terminal tool yield settles as completion" true
+    (match
+       Runtime_agent.For_testing.stop_reason_of_cooperative_yield
+         ~turns_used:3
+         Runtime_agent.Terminal_tool_completed
+     with
+     | Runtime_agent.Completed -> true
+     | Runtime_agent.Yielded_to_chat_waiting _
+     | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.InputRequired _ -> false)
+
+let test_terminal_effect_handler_contract () =
+  let is_terminal =
+    Masc.Keeper_tools_oas_bundle.For_testing.is_terminal_effect_handler
+  in
+  check bool "surface post is a terminal effect" true
+    (is_terminal Masc.Keeper_tool_descriptor.Tool_surface_post);
+  check bool "surface read is not a terminal effect" false
+    (is_terminal Masc.Keeper_tool_descriptor.Tool_surface_read);
+  check bool "filesystem write is not a reply terminal" false
+    (is_terminal Masc.Keeper_tool_descriptor.Tool_write_file)
 
 let payload fields = Some (`Assoc fields)
 
@@ -266,6 +289,8 @@ let () =
           test_case "of_result_surface" `Quick test_of_result_surface;
           test_case "autonomous yield boundary contract" `Quick
             test_autonomous_yield_boundary_contract;
+          test_case "terminal effect handler contract" `Quick
+            test_terminal_effect_handler_contract;
         ] );
       ( "payload_decode",
         [


### PR DESCRIPTION
## What

- classify `Tool_surface_post` success as a typed terminal effect from the descriptor runtime-handler ADT
- use the existing OAS post-tool cooperative boundary to persist the checkpoint and stop the provider loop after delivery
- settle that boundary as successful completion, not a replayable continuation checkpoint
- keep failed/deferred surface posts non-terminal

## Why

Live `sangsu` recovery reproduced #24198: after an independent failure judgment admitted a fresh action turn, the main runtime successfully called `keeper_surface_post` six times with the same reply and would continue unbounded. The delivery effect itself was already complete after the first success.

No tool-name string comparison, payload-text matching, retry count, turn cap, token estimate, or elapsed-time threshold is introduced.

## Validation

- `git diff --check`
- `ocamlformat --check` on all changed `.ml`/`.mli`
- OCaml parser pass on all changed `.ml`/`.mli`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/silent-failure-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`
- `scripts/ci/check-enum-string-safety.sh`
- `scripts/ci/check-masc-oas-boundary.sh`
- `scripts/ocaml-structure-ratchet.sh`

Focused local Dune was requested through `scripts/dune-local.sh`, but the wrapper correctly refused while unrelated bare `dune build lib` PID 43628 holds the machine-wide build lane. PR CI is the build/test authority.

Refs #24198.