### PR TITLE
fix(keeper): use flow-neutral exact terminal causes

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -190,7 +190,7 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 5
+let pending_store_version = 6
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
@@ -896,7 +896,11 @@ let snapshot_of_yojson ~base_path json =
 
 let quarantine_restarted_entry (entry : pending_approval) =
   match entry.exact_attempt with
-  | Exact_bound ({ status = Exact_dispatch_uncertain; _ } as binding) ->
+  | Exact_bound
+      ( { status =
+            (Exact_dispatch_uncertain | Exact_released_before_dispatch)
+        ; _
+        } as binding ) ->
     ( { entry with
         exact_attempt =
           Exact_bound
@@ -908,9 +912,7 @@ let quarantine_restarted_entry (entry : pending_approval) =
   | Exact_unbound
   | Exact_bound
       { status =
-          ( Exact_released_before_dispatch
-          | Exact_quarantined _
-          | Exact_completed )
+          (Exact_quarantined _ | Exact_completed)
       ; _
       } ->
     entry, false
@@ -2133,7 +2135,9 @@ let quarantine_summary_exact_attempt_with
                     ~entry
                     entry
                 | Exact_released_before_dispatch
-                  when cause = Exact_terminal_persistence_failure ->
+                  when cause = Exact_terminal_persistence_failure
+                       || cause = Exact_cancellation
+                       || cause = Exact_flow_execution_failed ->
                   let quarantined =
                     exact_attempt_binding_with_status
                       existing

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -2073,6 +2073,15 @@ let fail_summary_exact_attempt_before_dispatch =
     ~save_file_atomic_strict_staged:Fs_compat.save_file_atomic_strict_staged
 ;;
 
+let exact_attempt_quarantine_cause_is_public = function
+  | Exact_restart_uncertainty -> false
+  | Exact_flow_execution_failed
+  | Exact_cancellation
+  | Exact_attempt_replay
+  | Exact_domain_invalid_output
+  | Exact_terminal_persistence_failure -> true
+;;
+
 let quarantine_summary_exact_attempt_with
       ~save_file_atomic_strict_staged
       ~id
@@ -2113,7 +2122,12 @@ let quarantine_summary_exact_attempt_with
                (Exact_attempt_rejected
                   (Exact_attempt_identity_conflict existing))
            | Exact_bound existing ->
-             (match existing.status with
+             if not (exact_attempt_quarantine_cause_is_public cause) then
+               Error
+                 (Exact_attempt_rejected
+                    (Exact_attempt_status_conflict existing))
+             else
+               (match existing.status with
               | Exact_dispatch_uncertain ->
                 let quarantined =
                   exact_attempt_binding_with_status

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -898,7 +898,7 @@ let quarantine_restarted_entry (entry : pending_approval) =
   match entry.exact_attempt with
   | Exact_bound
       ( { status =
-            (Exact_dispatch_uncertain | Exact_released_before_dispatch)
+            Exact_dispatch_uncertain
         ; _
         } as binding ) ->
     ( { entry with
@@ -912,7 +912,7 @@ let quarantine_restarted_entry (entry : pending_approval) =
   | Exact_unbound
   | Exact_bound
       { status =
-          (Exact_quarantined _ | Exact_completed)
+          (Exact_released_before_dispatch | Exact_quarantined _ | Exact_completed)
       ; _
       } ->
     entry, false

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -406,11 +406,12 @@ val quarantine_summary_exact_attempt :
   cause:exact_attempt_quarantine_cause ->
   (exact_attempt_transition, exact_attempt_error) result
 
-(** Terminally quarantine a matching dispatch-uncertain binding with one closed
-    typed cause. A released binding accepts only
-    [Exact_terminal_persistence_failure]. The same identity and cause is
-    idempotently strict-rewritten. It can never return to the legacy summary
-    mutation path. *)
+(** Terminally quarantine a matching exact binding with one closed typed cause.
+    A dispatch-uncertain binding accepts any current exact cause. A released
+    binding accepts only [Exact_terminal_persistence_failure],
+    [Exact_cancellation], or [Exact_flow_execution_failed]. The same identity
+    and cause is idempotently strict-rewritten. It can never return to the
+    legacy summary mutation path. *)
 
 val complete_summary_exact_attempt :
   id:string ->

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -375,8 +375,9 @@ val release_summary_exact_attempt_before_dispatch :
 (** Mark the matching binding released only after OAS proves the attempt stayed
     before dispatch. Only [Fsync_completed] permits failover. A visible
     unconfirmed release retains the original identity, forbids a successor, and
-    may be terminalized only with [Exact_terminal_persistence_failure]. The same
-    release is idempotently strict-rewritten. *)
+    may be terminalized only with [Exact_terminal_persistence_failure],
+    [Exact_cancellation], or [Exact_flow_execution_failed]. The same release is
+    idempotently strict-rewritten. *)
 
 val fail_summary_exact_attempt_before_dispatch :
   id:string ->

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -24,11 +24,10 @@ and summary_status =
   | Summary_failed of { reason : string; retryable : bool }
 
 type exact_attempt_quarantine_cause =
-  | Exact_post_dispatch_failure
+  | Exact_flow_execution_failed
   | Exact_cancellation
   | Exact_attempt_replay
   | Exact_domain_invalid_output
-  | Exact_provenance_mismatch
   | Exact_terminal_persistence_failure
   | Exact_restart_uncertainty
 
@@ -248,11 +247,10 @@ let exact_attempt_status_to_string = function
 ;;
 
 let exact_attempt_quarantine_cause_to_string = function
-  | Exact_post_dispatch_failure -> "post_dispatch_failure"
+  | Exact_flow_execution_failed -> "flow_execution_failed"
   | Exact_cancellation -> "cancellation"
   | Exact_attempt_replay -> "attempt_replay"
   | Exact_domain_invalid_output -> "domain_invalid_output"
-  | Exact_provenance_mismatch -> "provenance_mismatch"
   | Exact_terminal_persistence_failure -> "terminal_persistence_failure"
   | Exact_restart_uncertainty -> "restart_uncertainty"
 ;;
@@ -338,11 +336,10 @@ let required_string_list ~surface field fields =
 ;;
 
 let exact_attempt_quarantine_cause_of_string = function
-  | "post_dispatch_failure" -> Ok Exact_post_dispatch_failure
+  | "flow_execution_failed" -> Ok Exact_flow_execution_failed
   | "cancellation" -> Ok Exact_cancellation
   | "attempt_replay" -> Ok Exact_attempt_replay
   | "domain_invalid_output" -> Ok Exact_domain_invalid_output
-  | "provenance_mismatch" -> Ok Exact_provenance_mismatch
   | "terminal_persistence_failure" -> Ok Exact_terminal_persistence_failure
   | "restart_uncertainty" -> Ok Exact_restart_uncertainty
   | cause ->

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -25,11 +25,10 @@ and summary_status =
   | Summary_failed of { reason : string; retryable : bool }
 
 type exact_attempt_quarantine_cause =
-  | Exact_post_dispatch_failure
+  | Exact_flow_execution_failed
   | Exact_cancellation
   | Exact_attempt_replay
   | Exact_domain_invalid_output
-  | Exact_provenance_mismatch
   | Exact_terminal_persistence_failure
   | Exact_restart_uncertainty
 

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1519,76 +1519,97 @@ let test_dispatch_uncertain_restart_is_durably_quarantined () =
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
        ignore (install_exn ~base_path);
-       let id =
-         submit
-           ~base_path
-           ~keeper_name:"queue-exact-restart"
-           ~input:(`Assoc [ "request", `String "restart" ])
+       let prepare label =
+         let id =
+           submit
+             ~base_path
+             ~keeper_name:("queue-exact-restart-" ^ label)
+             ~input:(`Assoc [ "request", `String label ])
+         in
+         check_update
+           ("mark " ^ label ^ " pending")
+           true
+           (AQ.mark_summary_pending ~id);
+         let identity = exact_identity id in
+         check_exact_update
+           ("bind " ^ label ^ " attempt")
+           true
+           (run_exact_transition AQ.bind_summary_exact_attempt identity);
+         id, identity
        in
-       check_update "mark exact restart pending" true (AQ.mark_summary_pending ~id);
-       let identity = exact_identity id in
+       let uncertain_id, uncertain_identity = prepare "uncertain" in
+       let released_id, released_identity = prepare "released" in
        check_exact_update
-         "bind dispatch-uncertain attempt"
+         "release no-dispatch proof"
          true
-         (run_exact_transition AQ.bind_summary_exact_attempt identity);
+         (run_exact_transition
+            AQ.release_summary_exact_attempt_before_dispatch
+            released_identity);
+       let assert_restart_states label =
+         (match pending_entry_exn uncertain_id with
+          | { exact_attempt =
+                AQ.Exact_bound
+                  { status =
+                      AQ.Exact_quarantined AQ.Exact_restart_uncertainty
+                  ; slot_id
+                  ; call_id
+                  ; _
+                  }
+            ; _
+            } ->
+            Alcotest.(check string)
+              (label ^ " uncertain slot")
+              uncertain_identity.slot_id_arg
+              slot_id;
+            Alcotest.(check string)
+              (label ^ " uncertain call")
+              uncertain_identity.call_id_arg
+              call_id
+          | _ ->
+            Alcotest.fail
+              (label ^ " did not quarantine dispatch-uncertain attempt"));
+         match pending_entry_exn released_id with
+         | { exact_attempt =
+               AQ.Exact_bound
+                 { status = AQ.Exact_released_before_dispatch
+                 ; slot_id
+                 ; call_id
+                 ; _
+                 }
+           ; _
+           } ->
+           Alcotest.(check string)
+             (label ^ " released slot")
+             released_identity.slot_id_arg
+             slot_id;
+           Alcotest.(check string)
+             (label ^ " released call")
+             released_identity.call_id_arg
+             call_id
+         | _ ->
+           Alcotest.fail
+             (label ^ " did not preserve released no-dispatch proof")
+       in
        AQ.For_testing.reset_runtime_state ();
        ignore (install_exn ~base_path);
-       (match pending_entry_exn id with
-        | { exact_attempt =
-              AQ.Exact_bound
-                { status =
-                    AQ.Exact_quarantined
-                      AQ.Exact_restart_uncertainty
-                ; slot_id
-                ; call_id
-                ; _
-                }
-          ; _
-          } ->
-          Alcotest.(check string)
-            "restart keeps slot identity"
-            identity.slot_id_arg
-            slot_id;
-          Alcotest.(check string)
-            "restart keeps call identity"
-            identity.call_id_arg
-            call_id
-        | _ -> Alcotest.fail "dispatch-uncertain restart was not quarantined");
-       let open Yojson.Safe.Util in
+       assert_restart_states "first install";
+       let first_snapshot =
+         read_pending_snapshot ~base_path |> Yojson.Safe.to_string
+       in
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       assert_restart_states "second install";
+       let second_snapshot =
+         read_pending_snapshot ~base_path |> Yojson.Safe.to_string
+       in
        Alcotest.(check string)
-         "restart quarantine is persisted"
-         "quarantined"
-         (read_pending_snapshot ~base_path
-          |> member "pending"
-          |> to_list
-          |> List.hd
-          |> member "exact_attempt"
-          |> member "status"
-          |> to_string);
-       Alcotest.(check string)
-         "restart quarantine cause is persisted"
-         "restart_uncertainty"
-         (read_pending_snapshot ~base_path
-          |> member "pending"
-          |> to_list
-          |> List.hd
-          |> member "exact_attempt"
-          |> member "quarantine_cause"
-          |> to_string);
-       (match
-          run_exact_transition
-            AQ.release_summary_exact_attempt_before_dispatch
-            identity
-        with
-        | Error
-            (AQ.Exact_attempt_rejected
-              (AQ.Exact_attempt_status_conflict _)) ->
-          ()
-        | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
-        | Ok _ -> Alcotest.fail "restart-quarantined attempt was released"))
+         "second install does not rewrite stable exact states"
+         first_snapshot
+         second_snapshot)
 ;;
 
 let test_exact_attempt_completion_is_atomic () =
+
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -1949,6 +1970,24 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          "bind quarantine fixture"
          true
          (run_exact_transition AQ.bind_summary_exact_attempt quarantine_identity);
+(match
+   quarantine_exact
+     quarantine_identity
+     AQ.Exact_restart_uncertainty
+ with
+ | Error
+     (AQ.Exact_attempt_rejected
+       (AQ.Exact_attempt_status_conflict _)) ->
+   ()
+ | Error error ->
+   Alcotest.fail (AQ.exact_attempt_error_to_string error)
+ | Ok _ ->
+   Alcotest.fail
+     "public quarantine accepted restart uncertainty");
+assert_status
+  "public restart rejection preserves dispatch uncertainty"
+  quarantine_id
+  "dispatch_uncertain";
        check_visible_update
          "visible quarantine"
          true
@@ -3054,7 +3093,7 @@ let () =
             `Quick
             test_exact_attempt_final_predispatch_failure_requires_operator_restart
         ; Alcotest.test_case
-            "dispatch-uncertain restart is quarantined"
+            "restart quarantines only dispatch-uncertain and is stable"
             `Quick
             test_dispatch_uncertain_restart_is_durably_quarantined
         ; Alcotest.test_case

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1062,7 +1062,7 @@ let test_exact_binding_codec_validates_entry_identity () =
          (run_exact_transition AQ.bind_summary_exact_attempt identity);
        let snapshot = read_pending_snapshot ~base_path in
        let open Yojson.Safe.Util in
-       Alcotest.(check int) "v5 snapshot" 5 (snapshot |> member "version" |> to_int);
+       Alcotest.(check int) "v6 snapshot" 6 (snapshot |> member "version" |> to_int);
        let exact_json =
          snapshot
          |> member "pending"
@@ -1091,6 +1091,53 @@ let test_exact_binding_codec_validates_entry_identity () =
            `Assoc ((field, value) :: List.remove_assoc field fields)
          | _ -> Alcotest.fail "exact attempt object expected"
        in
+       check_exact_update
+         "quarantine exact codec fixture"
+         true
+         (quarantine_exact identity AQ.Exact_flow_execution_failed);
+       let quarantined_exact_json =
+         read_pending_snapshot ~base_path
+         |> member "pending"
+         |> to_list
+         |> List.hd
+         |> member "exact_attempt"
+       in
+       Alcotest.(check string)
+         "flow execution failure is encoded"
+         "flow_execution_failed"
+         (quarantined_exact_json
+          |> member "quarantine_cause"
+          |> to_string);
+       (match
+          AQ.exact_attempt_state_of_yojson_with_error quarantined_exact_json
+        with
+        | Ok
+            (AQ.Exact_bound
+              { status =
+                  AQ.Exact_quarantined
+                    AQ.Exact_flow_execution_failed
+              ; _
+              }) ->
+          ()
+        | Ok _ ->
+          Alcotest.fail
+            "flow execution failure decoded as another exact state"
+        | Error reason -> Alcotest.fail reason);
+       List.iter
+         (fun removed_cause ->
+            match
+              AQ.exact_attempt_state_of_yojson_with_error
+                (replace_field
+                   "quarantine_cause"
+                   (`String removed_cause)
+                   quarantined_exact_json)
+            with
+            | Error _ -> ()
+            | Ok _ ->
+              Alcotest.failf
+                "removed quarantine cause %s was decoded"
+                removed_cause)
+         [ "post_dispatch_failure"; "provenance_mismatch" ];
        (match
           AQ.exact_attempt_state_of_yojson_with_error
             (replace_field "call_id" (`String " ") exact_json)
@@ -1228,7 +1275,7 @@ let test_exact_attempt_binding_release_and_conflicts () =
        expect_summary_rejection
          "bound restart"
          (AQ.restart_failed_summary ~id);
-       let quarantine_cause = AQ.Exact_post_dispatch_failure in
+       let quarantine_cause = AQ.Exact_flow_execution_failed in
        check_exact_update
          "quarantine replacement"
          true
@@ -1238,7 +1285,7 @@ let test_exact_attempt_binding_release_and_conflicts () =
               AQ.Exact_bound
                 { status =
                     AQ.Exact_quarantined
-                      AQ.Exact_post_dispatch_failure
+                      AQ.Exact_flow_execution_failed
                 ; _
                 }
           ; _
@@ -1541,6 +1588,83 @@ let test_dispatch_uncertain_restart_is_durably_quarantined () =
         | Ok _ -> Alcotest.fail "restart-quarantined attempt was released"))
 ;;
 
+let test_released_before_dispatch_restart_is_durably_quarantined () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let id =
+         submit
+           ~base_path
+           ~keeper_name:"queue-exact-released-restart"
+           ~input:(`Assoc [ "request", `String "released-restart" ])
+       in
+       check_update
+         "mark released restart pending"
+         true
+         (AQ.mark_summary_pending ~id);
+       let identity = exact_identity id in
+       check_exact_update
+         "bind released restart attempt"
+         true
+         (run_exact_transition
+            AQ.bind_summary_exact_attempt
+            identity);
+       check_exact_update
+         "release restart attempt"
+         true
+         (run_exact_transition
+            AQ.release_summary_exact_attempt_before_dispatch
+            identity);
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       (match pending_entry_exn id with
+        | { exact_attempt =
+              AQ.Exact_bound
+                { status =
+                    AQ.Exact_quarantined
+                      AQ.Exact_restart_uncertainty
+                ; slot_id
+                ; call_id
+                ; _
+                }
+          ; _
+          } ->
+          Alcotest.(check string)
+            "released restart keeps slot identity"
+            identity.slot_id_arg
+            slot_id;
+          Alcotest.(check string)
+            "released restart keeps call identity"
+            identity.call_id_arg
+            call_id
+        | _ ->
+          Alcotest.fail
+            "released-before-dispatch restart was not quarantined");
+       let open Yojson.Safe.Util in
+       let exact_attempt =
+         read_pending_snapshot ~base_path
+         |> member "pending"
+         |> to_list
+         |> List.hd
+         |> member "exact_attempt"
+       in
+       Alcotest.(check string)
+         "released restart quarantine is persisted"
+         "quarantined"
+         (exact_attempt |> member "status" |> to_string);
+       Alcotest.(check string)
+         "released restart cause is persisted"
+         "restart_uncertainty"
+         (exact_attempt
+          |> member "quarantine_cause"
+          |> to_string))
+;;
+
 let test_exact_attempt_completion_is_atomic () =
   let base_path = temp_dir () in
   Fun.protect
@@ -1798,17 +1922,27 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          (run_exact_transition
             AQ.release_summary_exact_attempt_before_dispatch
             release_identity);
-       (match
-          quarantine_exact release_identity AQ.Exact_post_dispatch_failure
-        with
-        | Error
-            (AQ.Exact_attempt_rejected
-              (AQ.Exact_attempt_status_conflict _)) ->
-          ()
-        | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
-        | Ok _ ->
-          Alcotest.fail
-            "released binding accepted an untyped terminalization cause");
+       List.iter
+         (fun (label, cause) ->
+            match quarantine_exact release_identity cause with
+            | Error
+                (AQ.Exact_attempt_rejected
+                  (AQ.Exact_attempt_status_conflict _)) ->
+              ()
+            | Error error ->
+              Alcotest.fail
+                (AQ.exact_attempt_error_to_string error)
+            | Ok _ ->
+              Alcotest.failf
+                "released binding accepted %s"
+                label)
+         [ "domain-invalid output", AQ.Exact_domain_invalid_output
+         ; "attempt replay", AQ.Exact_attempt_replay
+         ];
+       assert_status
+         "rejected causes preserve release"
+         release_id
+         "released_before_dispatch";
        check_exact_update
          "typed release uncertainty terminalization"
          true
@@ -1816,6 +1950,42 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             release_identity
             AQ.Exact_terminal_persistence_failure);
        assert_status "release terminal memory" release_id "quarantined";
+       let terminalize_released label cause =
+         let id, identity = prepare label in
+         check_exact_update
+           ("bind " ^ label)
+           true
+           (run_exact_transition
+              AQ.bind_summary_exact_attempt
+              identity);
+         check_exact_update
+           ("release " ^ label)
+           true
+           (run_exact_transition
+              AQ.release_summary_exact_attempt_before_dispatch
+              identity);
+         check_exact_update
+           ("quarantine " ^ label)
+           true
+           (quarantine_exact identity cause);
+         match pending_entry_exn id with
+         | { exact_attempt =
+               AQ.Exact_bound
+                 { status = AQ.Exact_quarantined actual; _ }
+           ; _
+           } when actual = cause ->
+           ()
+         | _ ->
+           Alcotest.failf
+             "%s did not retain its exact quarantine cause"
+             label
+       in
+       terminalize_released
+         "release-cancellation"
+         AQ.Exact_cancellation;
+       terminalize_released
+         "release-flow-execution-failed"
+         AQ.Exact_flow_execution_failed;
        let fail_id, fail_identity = prepare "fail" in
        check_exact_update
          "bind failure fixture"
@@ -1867,7 +2037,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             ~call_id:quarantine_identity.call_id_arg
             ~plan_fingerprint:quarantine_identity.plan_fingerprint_arg
             ~request_body_sha256:quarantine_identity.request_body_sha256_arg
-            ~cause:AQ.Exact_post_dispatch_failure);
+            ~cause:AQ.Exact_flow_execution_failed);
        assert_status
          "visible quarantine memory"
          quarantine_id
@@ -1877,7 +2047,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          false
          (quarantine_exact
             quarantine_identity
-            AQ.Exact_post_dispatch_failure);
+            AQ.Exact_flow_execution_failed);
        let complete_id, complete_identity = prepare "complete" in
        check_exact_update
          "bind completion fixture"
@@ -2442,7 +2612,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 5
+            [ "version", `Int 6
             ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
@@ -2473,7 +2643,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 5
+               [ "version", `Int 6
                ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
@@ -2507,7 +2677,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
         | Error
             (AQ.Install_storage_failed
               { reason =
-                  "gate_pending.version 2 is unsupported (current 5); reset \
+                  "gate_pending.version 2 is unsupported (current 6); reset \
                    runtime state before restarting MASC"
               ; _
               }) ->
@@ -2948,7 +3118,7 @@ let () =
             `Quick
             test_summary_updates_never_resolve_pending_request
         ; Alcotest.test_case
-            "exact binding codec validates entry identity"
+            "exact binding codec validates identity and current causes"
             `Quick
             test_exact_binding_codec_validates_entry_identity
         ; Alcotest.test_case
@@ -2963,6 +3133,10 @@ let () =
             "dispatch-uncertain restart is quarantined"
             `Quick
             test_dispatch_uncertain_restart_is_durably_quarantined
+        ; Alcotest.test_case
+            "released-before-dispatch restart is quarantined"
+            `Quick
+            test_released_before_dispatch_restart_is_durably_quarantined
         ; Alcotest.test_case
             "exact completion is atomic"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1588,83 +1588,6 @@ let test_dispatch_uncertain_restart_is_durably_quarantined () =
         | Ok _ -> Alcotest.fail "restart-quarantined attempt was released"))
 ;;
 
-let test_released_before_dispatch_restart_is_durably_quarantined () =
-  let base_path = temp_dir () in
-  Fun.protect
-    ~finally:(fun () ->
-      AQ.For_testing.reset_runtime_state ();
-      cleanup_dir base_path)
-    (fun () ->
-       AQ.For_testing.reset_runtime_state ();
-       ignore (install_exn ~base_path);
-       let id =
-         submit
-           ~base_path
-           ~keeper_name:"queue-exact-released-restart"
-           ~input:(`Assoc [ "request", `String "released-restart" ])
-       in
-       check_update
-         "mark released restart pending"
-         true
-         (AQ.mark_summary_pending ~id);
-       let identity = exact_identity id in
-       check_exact_update
-         "bind released restart attempt"
-         true
-         (run_exact_transition
-            AQ.bind_summary_exact_attempt
-            identity);
-       check_exact_update
-         "release restart attempt"
-         true
-         (run_exact_transition
-            AQ.release_summary_exact_attempt_before_dispatch
-            identity);
-       AQ.For_testing.reset_runtime_state ();
-       ignore (install_exn ~base_path);
-       (match pending_entry_exn id with
-        | { exact_attempt =
-              AQ.Exact_bound
-                { status =
-                    AQ.Exact_quarantined
-                      AQ.Exact_restart_uncertainty
-                ; slot_id
-                ; call_id
-                ; _
-                }
-          ; _
-          } ->
-          Alcotest.(check string)
-            "released restart keeps slot identity"
-            identity.slot_id_arg
-            slot_id;
-          Alcotest.(check string)
-            "released restart keeps call identity"
-            identity.call_id_arg
-            call_id
-        | _ ->
-          Alcotest.fail
-            "released-before-dispatch restart was not quarantined");
-       let open Yojson.Safe.Util in
-       let exact_attempt =
-         read_pending_snapshot ~base_path
-         |> member "pending"
-         |> to_list
-         |> List.hd
-         |> member "exact_attempt"
-       in
-       Alcotest.(check string)
-         "released restart quarantine is persisted"
-         "quarantined"
-         (exact_attempt |> member "status" |> to_string);
-       Alcotest.(check string)
-         "released restart cause is persisted"
-         "restart_uncertainty"
-         (exact_attempt
-          |> member "quarantine_cause"
-          |> to_string))
-;;
-
 let test_exact_attempt_completion_is_atomic () =
   let base_path = temp_dir () in
   Fun.protect
@@ -1938,6 +1861,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
                 label)
          [ "domain-invalid output", AQ.Exact_domain_invalid_output
          ; "attempt replay", AQ.Exact_attempt_replay
+         ; "restart uncertainty", AQ.Exact_restart_uncertainty
          ];
        assert_status
          "rejected causes preserve release"
@@ -3133,10 +3057,6 @@ let () =
             "dispatch-uncertain restart is quarantined"
             `Quick
             test_dispatch_uncertain_restart_is_durably_quarantined
-        ; Alcotest.test_case
-            "released-before-dispatch restart is quarantined"
-            `Quick
-            test_released_before_dispatch_restart_is_durably_quarantined
         ; Alcotest.test_case
             "exact completion is atomic"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -446,7 +446,7 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 5
+             [ "version", `Int 6
             ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
@@ -2746,7 +2746,7 @@ let test_persisted_delivery_replays_before_origin_wake () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 5
+             [ "version", `Int 6
             ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
@@ -2840,7 +2840,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 5
+             [ "version", `Int 6
             ; "next_sequence", `Int 4
             ; "pending", `List []
             ; ( "deliveries"

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -492,7 +492,7 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
            ~call_id:identity.call_id
            ~plan_fingerprint:identity.plan_fingerprint
            ~request_body_sha256:identity.request_body_sha256
-           ~cause:AQ.Exact_post_dispatch_failure))
+           ~cause:AQ.Exact_flow_execution_failed))
   in
   let completed =
     make_bound "completed" (fun entry identity ->
@@ -525,7 +525,7 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
   check_ready "quarantined binding is not worker-ready" false quarantined;
   check_ready "completed binding is finalize-only" false completed;
   (match quarantined.exact_attempt with
-   | AQ.Exact_bound { status = AQ.Exact_quarantined AQ.Exact_post_dispatch_failure; _ } ->
+   | AQ.Exact_bound { status = AQ.Exact_quarantined AQ.Exact_flow_execution_failed; _ } ->
      ()
    | AQ.Exact_unbound
    | AQ.Exact_bound _ ->


### PR DESCRIPTION
## Summary
- replace provider/receipt-shaped exact quarantine causes with `Exact_flow_execution_failed`
- allow released exact bindings to terminalize only for persistence failure, cancellation, or generic flow execution failure
- bump the current-only pending snapshot to v6 without a v5 reader, migration, or rewrite path

## Exact restart invariants
- install-internal recovery converts only `Exact_dispatch_uncertain` to `Exact_quarantined Exact_restart_uncertainty`
- `Exact_released_before_dispatch` preserves its fsynced no-dispatch proof across restart and remains on the existing explicit operator recovery/reopen path
- the public quarantine API rejects `Exact_restart_uncertainty` for every exact-attempt status; this cause is reserved for install-internal restart closure
- no production candidate recovery, automatic failover, bulk recovery, migration, or compatibility path is added

## Coverage
- prove the new cause snapshot roundtrip and reject removed cause strings
- cover released fsync terminalization and invalid, replay, and public restart-cause rejection
- directly install a dispatch-uncertain and a released entry twice, proving only the uncertain entry is quarantined and the second install does not rewrite stable exact states
- updated focused fixtures; no build or test run per coordination request, `ocamlformat` only

## Merge ordering
Rebase this PR onto the latest `main` after #25638 before merge. The branch was created on current `main` after #25638 merged, but the ordering requirement remains explicit for any later update.