### PR TITLE
fix(keeper): route Librarian through OAS exact output

### DIFF
--- a/config/oas-models-overlay.toml
+++ b/config/oas-models-overlay.toml
@@ -224,6 +224,11 @@ supports_native_streaming = true
 # Opaque exact-output slot bindings. MASC routes only by [id]; OAS owns the
 # provider/model join, capability admission, and wire materialization.
 [[targets]]
+id = "glm-coding.glm-5-turbo"
+provider_ref = "glm-coding"
+model_id = "GLM-5-Turbo"
+
+[[targets]]
 id = "deepseek.deepseek-v4-pro"
 provider_ref = "deepseek"
 model_id = "deepseek-v4-pro"

--- a/config/prompts/keeper.librarian.episode_extraction.md
+++ b/config/prompts/keeper.librarian.episode_extraction.md
@@ -29,9 +29,9 @@ Additional rules:
 3. Each claim must include an approximate source_turn from the conversation slice. Use source_tool_call_id only when a tool call id is explicitly visible.
 4. If you are unsure a claim is durable, prefer "ephemeral" over a durable category and state the uncertainty in the claim text. Do not emit a confidence number — the store no longer reads one; spend the words on a precise claim instead.
 5. open_items and constraints are episode-level summary arrays, separate from a claim's category. A claim already categorized as constraint does not need to be repeated in the constraints array.
-6. claim_id (optional): a short lowercase kebab-case slug identifying the CONCLUSION, not the wording — derive it deterministically from the subject and the asserted state (e.g. "pr-21249-verification-complete", "pr-123-open", "pr-123-merged"). Re-stating the same conclusion later MUST reuse the same slug; a changed conclusion (e.g. open -> merged) MUST use a new slug. Omit it if you cannot form a stable slug.
-7. claim_kind (optional): tag the claim's epistemic nature, orthogonal to category. Use "self_observation" for transient first-person agent state — you are idle, looping, blocked, or a tool is timing out (true now, false next turn). Use "external_state" for a claim about the world/PR/issue that is verifiable elsewhere. Use "durable_knowledge" for a timeless rule or lesson. A "lesson" category can still be a self_observation. Omit it when unclear — an omitted tag is treated as durable. Do NOT tag transient self-state as durable knowledge; that is the echo this field exists to stop.
-8. valid_for_days (optional integer, 1-365): YOUR judgment of how many days this claim stays worth re-reading — after that the store forgets it. A claim you labeled "ephemeral" or tagged "self_observation" MUST carry a small value (1-3: it is true today, not next week). Short-lived external_state (an open PR, a pending deploy) usually deserves 7-30. Omit it ONLY for genuinely durable knowledge — an omitted lifetime means the store keeps the claim forever, so leaving it off a transient claim immortalizes noise.
+6. claim_id (nullable): a short lowercase kebab-case slug identifying the CONCLUSION, not the wording — derive it deterministically from the subject and the asserted state (e.g. "pr-21249-verification-complete", "pr-123-open", "pr-123-merged"). Re-stating the same conclusion later MUST reuse the same slug; a changed conclusion (e.g. open -> merged) MUST use a new slug. Use null if you cannot form a stable slug.
+7. claim_kind (nullable): tag the claim's epistemic nature, orthogonal to category. Use "self_observation" for transient first-person agent state — you are idle, looping, blocked, or a tool is timing out (true now, false next turn). Use "external_state" for a claim about the world/PR/issue that is verifiable elsewhere. Use "durable_knowledge" for a timeless rule or lesson. A "lesson" category can still be a self_observation. Use null when unclear — a null tag is treated as durable. Do NOT tag transient self-state as durable knowledge; that is the echo this field exists to stop.
+8. valid_for_days (nullable integer, 1-365): YOUR judgment of how many days this claim stays worth re-reading — after that the store forgets it. A claim you labeled "ephemeral" or tagged "self_observation" MUST carry a small value (1-3: it is true today, not next week). Short-lived external_state (an open PR, a pending deploy) usually deserves 7-30. Use null ONLY for genuinely durable knowledge — null means the store keeps the claim forever, so using it for a transient claim immortalizes noise.
 
 Output schema:
 {
@@ -41,9 +41,9 @@ Output schema:
       "claim": "A single factual sentence.",
       "category": "code_change|fact|preference|blocker|goal|constraint|validated_approach|lesson|ephemeral",
       "source_turn": 12,
-      "source_tool_call_id": "call_abc",
+      "source_tool_call_id": null,
       "claim_id": "pr-123-open",
-      "claim_kind": "self_observation|external_state|durable_knowledge",
+      "claim_kind": "external_state",
       "valid_for_days": 7
     }
   ],

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -11,14 +11,14 @@
 
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
-# memory-os librarian (post-turn episode extraction) requests provider-native
-# structured output, so it is routed independently of keeper chat to the native
-# Ollama /api/chat binding whose `format` schema path was live-verified. The
-# OpenAI-compatible /v1 path accepts response_format but can still return fenced
-# prose, so do not point this lane at [providers.ollama_cloud]. Override per
-# process with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each
-# keeper's runtime (legacy).
+# Legacy Memory OS summary/consolidation helpers still consume this runtime
+# role. Post-turn Librarian episode extraction does not: it resolves only the
+# OAS [runtime.exact_output_lanes.librarian_exact] lane.
 librarian = "ollama_cloud_native.minimax-m3-native-structured"
+# Existing deployments must opt in explicitly after the exact-output registry
+# is available:
+# [runtime.exact_output_lanes.librarian_exact]
+# slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 # Provider-native structured-output judges must not inherit the fleet chat
 # default when that default lacks schema support. Keep this lane explicit so
 # structured judgment lanes fail at config load on typo/unsupported

--- a/docs/rfc/RFC-0243-memory-os-confidence-mutability-write-side-upsert.md
+++ b/docs/rfc/RFC-0243-memory-os-confidence-mutability-write-side-upsert.md
@@ -50,7 +50,7 @@ and failed to find one for each:
 The update-in-place machinery already exists in `Keeper_memory_os_gc.run_gc`
 (`lib/keeper/keeper_memory_os_gc.ml:76-94`: `read_facts_all → dedup → rewrite_facts_atomically`)
 but it too has **zero lib callers** — it is dead. The write path is blind
-append: `extract_and_append_with_provider` (`keeper_librarian_runtime.ml`)
+append: `extract_and_append_with_exact_output` (`keeper_librarian_runtime.ml`)
 calls `append_episode_bundle`, which fans out `List.iter append_fact`
 (`keeper_memory_os_io.ml:170`). A claim re-confirmed across N turns becomes N
 immortal rows, each frozen at its one-shot confidence.
@@ -114,7 +114,7 @@ and a race on `facts_path`.
 
 ### 2.4 Write path (`keeper_librarian_runtime.ml`)
 
-`extract_and_append_with_provider` now writes the episode log
+`extract_and_append_with_exact_output` now writes the episode log
 (`append_episode` + `append_event`, which retain the raw claims) and then upserts
 the facts via `merge_and_cap_facts ~merge:(reobserve_fact ~now)`. Because the
 episode log already records the claims, a fact-merge failure (logged and

--- a/docs/rfc/RFC-0247-purge-implementation-plan.md
+++ b/docs/rfc/RFC-0247-purge-implementation-plan.md
@@ -63,7 +63,7 @@ The field removals from the `fact` record (`types.ml:100-120`) and their codec h
 
 **Where it lives**: the always-on consolidation fiber, `server_bootstrap_maintenance.ml:90-118` (300s cadence, cross-keeper read + atomic `_shared.facts.jsonl` rewrite, per-tick failures caught). Keep the fiber skeleton; replace the arithmetic body in `keeper_memory_os_consolidator.ml`.
 
-**What it reads**: (orient) the keeper's current fact set + the shared store; (gather) facts written since the last consolidation tick. **What it writes**: the rewritten store(s). The LLM call reuses the existing librarian provider plumbing (`keeper_librarian_runtime.ml extract_with_provider`, `:245-255`).
+**What it reads**: (orient) the keeper's current fact set + the shared store; (gather) facts written since the last consolidation tick. **What it writes**: the rewritten store(s). The LLM call reuses the Librarian domain codec; provider admission and wire execution use the OAS exact-output surface (`keeper_librarian_runtime.ml extract_with_exact_output`).
 
 **4 phases ported from Claude Code §8** (Map Report 4):
 1. **Orient** — read existing facts so the pass *improves topic-facts rather than duplicating*. Anti-duplication read-before-write.

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -81,7 +81,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 246 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 280 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 258 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 268 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 268 | Legacy Memory OS summary runtime override; not used by exact extraction. @category Runtime @ops_class operator |
 | `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 222 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 215 unique knobs across 8 modules.
+**Total**: 214 unique knobs across 8 modules.
 
-**Typed getter classification**: 39/127 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 88).
+**Typed getter classification**: 38/126 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 88).
 
 ## Env_config_core (24 knobs; typed classification 2/5)
 
@@ -47,56 +47,55 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 430 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 289 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (46 knobs; typed classification 27/40)
+## Env_config_keeper (45 knobs; typed classification 26/39)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 657 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 603 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 643 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 589 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 65 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 623 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 343 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 369 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 359 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 379 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 349 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 609 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 329 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 355 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 345 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 365 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 335 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 143 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 151 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 528 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 466 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 455 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 477 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 636 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 489 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 510 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 317 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: true; invalid values fail closed to false.... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 327 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 306 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 236 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 248 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 294 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 260 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 272 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 282 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 224 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 514 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 452 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 441 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 463 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 622 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 475 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 496 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 303 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: true; invalid values fail closed to false.... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 313 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 292 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 234 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 246 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 280 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 258 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 268 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 222 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 552 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 538 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 154 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 646 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 563 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 416 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 426 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 406 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 632 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 549 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 402 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 412 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 392 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 88 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 114 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 103 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 504 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 490 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 
@@ -232,9 +231,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 452 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 456 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 458 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 448 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 452 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 454 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 150 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 220 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 222 |  |
@@ -242,8 +241,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 160 |  |
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 192 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 232 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 418 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 420 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 414 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 416 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 224 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 81 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
@@ -253,18 +252,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 341 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 504 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 530 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 538 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 478 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 480 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 482 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 484 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 490 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 500 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 526 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 534 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 474 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 476 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 478 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 480 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 486 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 520 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 522 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 516 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 518 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -169,7 +169,6 @@ module KeeperMemoryOs = struct
   let librarian_enabled_default = true
   let librarian_cadence_turns_default = 3
   let librarian_max_messages_default = 24
-  let librarian_max_tokens_default = 4096
   let librarian_runtime_id_default = None
   let librarian_global_slot_default = 1
   let gc_enabled_default = true
@@ -191,7 +190,6 @@ module KeeperMemoryOs = struct
   let librarian_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
   let librarian_cadence_turns_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
   let librarian_max_messages_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
-  let librarian_max_tokens_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS"
   let librarian_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
   let librarian_global_slot_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
   let gc_env_key = "MASC_KEEPER_MEMORY_OS_GC"
@@ -259,18 +257,6 @@ module KeeperMemoryOs = struct
       (get_int_logged
          librarian_max_messages_env_key
          ~default:librarian_max_messages_default)
-  ;;
-
-  (** Output token cap for librarian extraction, applied as min with the
-      provider max_tokens. Default: 4096, floored to 1.
-      @category Runtime
-      @ops_class operator *)
-  let librarian_max_tokens () =
-    max
-      1
-      (get_int_logged
-         librarian_max_tokens_env_key
-         ~default:librarian_max_tokens_default)
   ;;
 
   (** Optional runtime id override for librarian extraction.

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -259,7 +259,7 @@ module KeeperMemoryOs = struct
          ~default:librarian_max_messages_default)
   ;;
 
-  (** Optional runtime id override for librarian extraction.
+  (** Legacy Memory OS summary runtime override; not used by exact extraction.
       @category Runtime
       @ops_class operator *)
   let librarian_runtime_id () =

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -66,7 +66,6 @@ module KeeperMemoryOs : sig
   val librarian_env_key : string
   val librarian_cadence_turns_env_key : string
   val librarian_max_messages_env_key : string
-  val librarian_max_tokens_env_key : string
   val librarian_runtime_id_env_key : string
   val librarian_global_slot_env_key : string
   val gc_env_key : string
@@ -77,7 +76,6 @@ module KeeperMemoryOs : sig
   val librarian_enabled_default : bool
   val librarian_cadence_turns_default : int
   val librarian_max_messages_default : int
-  val librarian_max_tokens_default : int
   val librarian_runtime_id_default : string option
   val librarian_global_slot_default : int
   val gc_enabled_default : bool
@@ -88,10 +86,6 @@ module KeeperMemoryOs : sig
   val librarian_enabled : unit -> bool
   val librarian_cadence_turns : unit -> int
   val librarian_max_messages : unit -> int
-  val librarian_max_tokens : unit -> int
-  (** Output token cap for librarian extraction, applied as min with the
-      provider max_tokens. Default: 4096, floored to 1. *)
-
   val librarian_runtime_id : unit -> string option
   val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -377,10 +377,6 @@ let memory_entries =
       Memory_os_defaults.librarian_max_messages_env_key
       "Recent-message window for librarian extraction (floor 1)";
     entry
-      ~default:(string_of_int Memory_os_defaults.librarian_max_tokens_default)
-      Memory_os_defaults.librarian_max_tokens_env_key
-      "Output token cap for librarian extraction (applied as min with provider max_tokens, floor 1)";
-    entry
       ~default:
         (optional_default_to_display Memory_os_defaults.librarian_runtime_id_default)
       Memory_os_defaults.librarian_runtime_id_env_key

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -380,7 +380,7 @@ let memory_entries =
       ~default:
         (optional_default_to_display Memory_os_defaults.librarian_runtime_id_default)
       Memory_os_defaults.librarian_runtime_id_env_key
-      "Optional runtime id override for librarian extraction; (none) displays the empty default";
+      "Legacy runtime id override for Memory OS LLM summary generation; does not route post-turn Librarian exact-output extraction; (none) displays the empty default";
     entry
       ~default:(string_of_int Memory_os_defaults.librarian_global_slot_default)
       Memory_os_defaults.librarian_global_slot_env_key

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -401,7 +401,6 @@ let finalize
            ~user_turn_record
            ~tool_calls_made:(actual_keeper_tool_names <> []))
       ~post_turn_t0
-      ~runtime_id:runtime_id_string
       ~inference_telemetry:result.response.telemetry
       ();
     Ok

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -14,7 +14,6 @@ let run
   ~librarian_messages
   ~(memory_extraction_record : Keeper_run_prompt.memory_extraction_record)
   ~post_turn_t0
-  ~runtime_id
   ~inference_telemetry
   ?deliberation_execution
   ()
@@ -122,7 +121,6 @@ let run
       }
     in
     Keeper_librarian_runtime.run_best_effort
-      ~runtime_id
       ~keeper_id:meta.name
       librarian_input
   in

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -19,7 +19,6 @@ val run :
   librarian_messages:Agent_sdk.Types.message list ->
   memory_extraction_record:Keeper_run_prompt.memory_extraction_record ->
   post_turn_t0:float ->
-  runtime_id:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -198,14 +198,14 @@ let claim_source ~trace_id turn tool_call_id =
 
 let claim_kind_field fields =
   match List.assoc_opt wire_field_claim_kind fields with
-  | None -> Some None
+  | None | Some `Null -> Some None
   | Some (`String raw) -> Option.map (fun kind -> Some kind) (claim_kind_of_string raw)
   | Some _ -> None
 ;;
 
 let optional_string_field_strict key fields =
   match List.assoc_opt key fields with
-  | None -> Some None
+  | None | Some `Null -> Some None
   | Some (`String value) -> Some (Some value)
   | Some _ -> None
 ;;

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -1,16 +1,8 @@
 (** Runtime adapter for Memory OS librarian extraction. *)
 
-(* Cap on the librarian extraction output, applied as
-   [min provider_cfg.max_tokens (librarian_max_tokens ())] at the complete call
-   (see [extract] below). The previous fixed cap of 1024 truncated episode
-   JSON mid-object whenever the summary plus facts exceeded ~1024 output
-   tokens, surfacing as "invalid_json: Unexpected end of input" every turn.
-   4096 covers realistic episode payloads while staying well under the
-   JSON-capable model context budget; tunable via
-   [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS] (floor 1). *)
-let librarian_max_tokens () = Env_config.KeeperMemoryOs.librarian_max_tokens ()
+module Exact_output = Agent_sdk.Exact_output
 
-type complete_fn = Keeper_provider_subcall.complete_fn
+let exact_lane_id = "librarian_exact"
 
 (* RFC-0257 / P0-4 adversarial hardening: per-keeper librarian provider slot.
    The previous process-global slot allowed one slow keeper to starve the fleet.
@@ -30,6 +22,7 @@ type provider_slot =
 
 let provider_slots_mu = Eio.Mutex.create ()
 let provider_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 64
+let exact_flow_mutexes : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 64
 
 let provider_slot_for_keeper ~keeper_id capacity =
   Eio_guard.with_mutex provider_slots_mu (fun () ->
@@ -39,6 +32,16 @@ let provider_slot_for_keeper ~keeper_id capacity =
       let slot = { capacity; in_use = 0 } in
       Hashtbl.replace provider_slots keeper_id slot;
       slot)
+;;
+
+let exact_flow_mutex_for_keeper ~keeper_id =
+  Eio_guard.with_mutex provider_slots_mu (fun () ->
+    match Hashtbl.find_opt exact_flow_mutexes keeper_id with
+    | Some mutex -> mutex
+    | None ->
+      let mutex = Eio.Mutex.create () in
+      Hashtbl.replace exact_flow_mutexes keeper_id mutex;
+      mutex)
 ;;
 
 let with_provider_slot ~keeper_id ~clock:_ f =
@@ -195,10 +198,6 @@ let max_messages () =
 let prompt_max_messages () = max_messages () * cadence_turns ()
 ;;
 
-let runtime_id_for_librarian ~runtime_id =
-  Keeper_memory_runtime_resolution.runtime_id_for_librarian ~runtime_id
-;;
-
 let select_recent_messages ~max_messages messages =
   let max_messages = max 0 max_messages in
   let len = List.length messages in
@@ -214,42 +213,41 @@ let select_recent_messages ~max_messages messages =
   drop drop_count messages
 ;;
 
-let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
-  let configured_librarian_max_tokens = librarian_max_tokens () in
-  let max_tokens =
-    match provider_cfg.max_tokens with
-    | Some n when n > 0 -> Some (min n configured_librarian_max_tokens)
-    | Some _ -> Some configured_librarian_max_tokens
-    | None -> Some configured_librarian_max_tokens
-  in
-  let tuned_cfg =
-    Keeper_structured_output_schema.for_deterministic_subcall ~max_tokens provider_cfg
-  in
-  (* No wire response format. config/prompts/keeper.librarian.episode_extraction.md
-     states the object shape and both enums, and [Keeper_librarian.episode_of_json_result]
-     re-validates every field into a closed [parse_error]; a bad reply defers the
-     next attempt instead of writing.
-
-     Dropping the schema also closes a live disagreement between the two. The
-     schema marked every claim field [required] with nullable types, so a
-     schema-conforming provider emits ["claim_id": null] — which
-     [optional_string_field_strict] rejects, failing [traverse] all-or-nothing and
-     dropping the whole episode. The prompt tells the model to omit the key
-     instead, which the parser accepts. Prompt and parser agree; the schema was
-     the one that disagreed. *)
-  Keeper_structured_output_schema.without_response_format tuned_cfg
-;;
-
 let message role text =
   Agent_sdk.Types.make_message ~role [ Agent_sdk.Types.Text text ]
 ;;
 
+type exact_setup_error =
+  | Exact_registry_unavailable of Runtime_exact_output_registry.publication_error
+  | Exact_lane_unavailable of Runtime_exact_output_registry.lane_resolution_error
+  | Exact_candidate_invalid of
+      { position : int
+      ; slot_id : string
+      }
+  | Exact_journal_unavailable of string
+  | Exact_previous_attempt_unsettled of
+      { state : string
+      ; trace_id : string
+      ; generation : int
+      }
+  | Exact_flow_admission_failed of Exact_output.flow_admission_error
+  | Exact_flow_start_failed of Exact_output.flow_start_error
+
+type exact_execution_failure =
+  | Exact_attempt_already_started
+  | Exact_callback_persistence_failed of string
+  | Exact_provider_execution_failed of Exact_output.execution_error_cause
+
+type exact_execution_error =
+  { dispatched : bool
+  ; failure : exact_execution_failure
+  }
+
 type extraction_error =
   | Prompt_render_failed of string
   | Provider_clock_unavailable
-  | Provider_timeout
-  | Provider_transport_failed of string
-  | Provider_empty_response
+  | Exact_setup_failed of exact_setup_error
+  | Exact_execution_failed of exact_execution_error
   | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
 
@@ -257,25 +255,93 @@ let librarian_provider_clock_unavailable_error =
   "memory os librarian provider clock unavailable"
 ;;
 
+let execution_error_cause_to_string = function
+  | Exact_output.Attempt_already_started -> "attempt_already_started"
+  | Clock_required_for_timeout -> "clock_required_for_timeout"
+  | Frozen_request_mismatch -> "frozen_request_mismatch"
+  | Completion_failed -> "completion_failed"
+  | Incomplete_output -> "incomplete_output"
+  | Missing_output -> "missing_output"
+  | Ambiguous_output count -> Printf.sprintf "ambiguous_output(%d)" count
+  | Unexpected_output_content -> "unexpected_output_content"
+  | Invalid_json_output -> "invalid_json_output"
+  | Internal_non_json_output -> "internal_non_json_output"
+;;
+
+let exact_setup_error_to_string = function
+  | Exact_registry_unavailable error ->
+    "exact registry unavailable: "
+    ^ Runtime_exact_output_registry.publication_error_to_string error
+  | Exact_lane_unavailable error ->
+    Runtime_exact_output_registry.lane_resolution_error_to_string error
+  | Exact_candidate_invalid { position; slot_id } ->
+    Printf.sprintf
+      "exact lane candidate invalid position=%d slot=%S"
+      position
+      slot_id
+  | Exact_journal_unavailable detail ->
+    "exact receipt journal unavailable: " ^ detail
+  | Exact_previous_attempt_unsettled { state; trace_id; generation } ->
+    Printf.sprintf
+      "previous exact attempt is unsettled state=%s trace_id=%s generation=%d"
+      state
+      trace_id
+      generation
+  | Exact_flow_admission_failed
+      (Exact_output.Duplicate_flow_candidate_id
+         { candidate_id; first_position; duplicate_position }) ->
+    Printf.sprintf
+      "exact flow duplicate candidate id=%S first_position=%d duplicate_position=%d"
+      candidate_id
+      first_position
+      duplicate_position
+  | Exact_flow_admission_failed (No_admitted_flow_candidates admissions) ->
+    Printf.sprintf
+      "exact flow has no admitted candidates (candidates=%d)"
+      (List.length admissions)
+  | Exact_flow_start_failed
+      (Exact_output.Flow_candidate_attempt_start_failed
+         { identity; position; cause; admissions = _ }) ->
+    let detail =
+      match cause with
+      | Exact_output.Call_id_generation_failed detail -> detail
+    in
+    Printf.sprintf
+      "exact flow attempt start failed candidate=%S position=%d: %s"
+      identity.candidate_id
+      position
+      detail
+;;
+
 let extraction_error_to_string = function
   | Prompt_render_failed msg -> msg
   | Provider_clock_unavailable -> librarian_provider_clock_unavailable_error
-  | Provider_timeout -> "librarian provider timed out"
-  | Provider_transport_failed msg -> msg
-  | Provider_empty_response -> "librarian provider returned empty response"
+  | Exact_setup_failed error -> exact_setup_error_to_string error
+  | Exact_execution_failed { dispatched; failure } ->
+    let detail =
+      match failure with
+      | Exact_attempt_already_started -> "attempt_already_started"
+      | Exact_callback_persistence_failed detail ->
+        "callback_persistence_failed: " ^ detail
+      | Exact_provider_execution_failed cause ->
+        execution_error_cause_to_string cause
+    in
+    Printf.sprintf
+      "librarian exact execution failed dispatched=%b cause=%s"
+      dispatched
+      detail
   | Provider_unparseable_response msg ->
     "librarian provider returned unparseable structured response: " ^ msg
   | Memory_fact_upsert_failed msg -> "memory os fact upsert failed: " ^ msg
 ;;
 
 let should_record_cadence_backoff_after_error = function
-  | Provider_timeout
-  | Provider_transport_failed _
-  | Provider_empty_response
-  | Provider_unparseable_response _ ->
-    true
+  | Exact_execution_failed { dispatched; _ } -> dispatched
+  | Exact_setup_failed (Exact_previous_attempt_unsettled _) -> true
+  | Provider_unparseable_response _ -> true
   | Provider_clock_unavailable
   | Prompt_render_failed _
+  | Exact_setup_failed _
   | Memory_fact_upsert_failed _ ->
     false
 ;;
@@ -310,16 +376,187 @@ let messages_for_librarian (inp : Keeper_librarian.input) =
          ])
 ;;
 
-(* http_error_message moved to Provider_http_error.to_message (SSOT,
-   2026-06-24): four byte-for-output-identical copies unified. *)
+let effect_phase_to_string = function
+  | Exact_output.Not_started -> "not_started"
+  | Before_dispatch -> "before_dispatch"
+  | Dispatch_started -> "dispatch_started"
+  | Response_received -> "response_received"
+  | Terminal -> "terminal"
+;;
 
-let extract_with_provider_classified
-    ?complete
+let receipt_json (receipt : Exact_output.receipt) =
+  `Assoc
+    [ ( "call_id"
+      , `String
+          (Exact_output.call_id_to_string
+             (Exact_output.receipt_call_id receipt)) )
+    ; "phase", `String (effect_phase_to_string (Exact_output.receipt_phase receipt))
+    ; "dispatch_count", `Int (Exact_output.receipt_dispatch_count receipt)
+    ; ( "http_status"
+      , match Exact_output.receipt_http_status receipt with
+        | Some status -> `Int status
+        | None -> `Null )
+    ; "plan_fingerprint", `String (Exact_output.receipt_plan_fingerprint receipt)
+    ; "request_body_sha256", `String (Exact_output.receipt_request_body_sha256 receipt)
+    ; ( "catalog_generation"
+      , `String
+          (Exact_output.catalog_generation_fingerprint
+             (Exact_output.receipt_catalog_generation receipt)) )
+    ; ( "catalog_evidence_sha256"
+      , `String
+          (Exact_output.catalog_evidence_sha256
+             (Exact_output.receipt_catalog_evidence receipt)) )
+    ; ( "target_identity"
+      , `String
+          (Exact_output.target_identity_fingerprint
+             (Exact_output.receipt_target_identity receipt)) )
+    ]
+;;
+
+let attempt_receipt_json (attempt : Exact_output.flow_attempt_receipt) =
+  `Assoc
+    [ "candidate_id", `String attempt.identity.candidate_id
+    ; "receipt", receipt_json attempt.receipt
+    ]
+;;
+
+let exact_flow_state_dir ~keeper_id =
+  Keeper_memory_os_io.facts_path ~keeper_id
+  |> Filename.dirname
+  |> fun keepers_dir -> Filename.concat keepers_dir keeper_id
+  |> fun keeper_dir -> Filename.concat keeper_dir "exact-output"
+;;
+
+let exact_flow_state_path ~keeper_id =
+  Filename.concat
+    (exact_flow_state_dir ~keeper_id)
+    "librarian-exact-state.json"
+;;
+
+let persist_exact_flow_state ~keeper_id ~trace_id ~generation ~state fields =
+  let (_ : string) = Keeper_fs.ensure_dir (exact_flow_state_dir ~keeper_id) in
+  let payload =
+    `Assoc
+      ([ "schema_version", `Int 1
+       ; "trace_id", `String trace_id
+       ; "generation", `Int generation
+       ; "state", `String state
+       ]
+       @ fields)
+    |> Yojson.Safe.pretty_to_string
+  in
+  Fs_compat.save_file_atomic_strict
+    (exact_flow_state_path ~keeper_id)
+    payload
+;;
+
+type exact_journal_disposition =
+  | Journal_active
+  | Journal_terminal
+
+let exact_journal_disposition_of_state = function
+  | "candidate_bound"
+  | "candidate_advance_committed"
+  | "oas_success" ->
+    Ok Journal_active
+  | "domain_valid"
+  | "domain_invalid"
+  | "execution_terminal" ->
+    Ok Journal_terminal
+  | state -> Error state
+;;
+
+let preflight_exact_flow_state ~keeper_id =
+  let path = exact_flow_state_path ~keeper_id in
+  if not (Sys.file_exists path)
+  then Ok ()
+  else
+    try
+      let json =
+        In_channel.with_open_bin path In_channel.input_all
+        |> Yojson.Safe.from_string
+      in
+      let open Yojson.Safe.Util in
+      let state = json |> member "state" |> to_string in
+      match exact_journal_disposition_of_state state with
+      | Ok Journal_terminal -> Ok ()
+      | Ok Journal_active ->
+        Error
+          (Exact_previous_attempt_unsettled
+             { state
+             ; trace_id = json |> member "trace_id" |> to_string
+             ; generation = json |> member "generation" |> to_int
+             })
+      | Error state ->
+        Error (Exact_journal_unavailable ("unknown state " ^ state))
+    with
+    | Eio.Cancel.Cancelled _ as error -> raise error
+    | exn -> Error (Exact_journal_unavailable (Printexc.to_string exn))
+;;
+
+let flow_candidates selected_slots =
+  let rec loop position acc = function
+    | [] -> Ok (List.rev acc)
+    | (slot : Runtime_exact_output_registry.selected_slot) :: rest ->
+      (match Exact_output.make_flow_candidate ~id:slot.slot_id ~target:slot.target with
+       | Ok candidate -> loop (position + 1) (candidate :: acc) rest
+       | Error Exact_output.Blank_flow_candidate_id ->
+         Error
+           (Exact_candidate_invalid
+              { position
+              ; slot_id = slot.slot_id
+              }))
+  in
+  loop 0 [] selected_slots
+;;
+
+let exact_execution_error = function
+  | Exact_output.Flow_attempt_already_started _ ->
+    { dispatched = false; failure = Exact_attempt_already_started }
+  | Flow_before_dispatch_callback_failed { candidate; cause; evidence = _ } ->
+    { dispatched =
+        Exact_output.receipt_dispatch_count candidate.receipt > 0
+    ; failure = Exact_callback_persistence_failed cause
+    }
+  | Flow_before_advance_callback_failed
+      { failed; failure = _; next = _; cause; evidence = _ } ->
+    { dispatched =
+        Exact_output.receipt_dispatch_count failed.receipt > 0
+    ; failure = Exact_callback_persistence_failed cause
+    }
+  | Flow_exact_execution_failed { candidate = _; cause; evidence = _ } ->
+    { dispatched = Exact_output.receipt_dispatch_count cause.receipt > 0
+    ; failure = Exact_provider_execution_failed cause.cause
+    }
+;;
+
+let persist_exact_execution_terminal
+      ~keeper_id
+      ~trace_id
+      ~generation
+      error
+  =
+  match error with
+  | Exact_output.Flow_exact_execution_failed
+      { candidate; cause; evidence = _ } ->
+    persist_exact_flow_state
+      ~keeper_id
+      ~trace_id
+      ~generation
+      ~state:"execution_terminal"
+      [ "candidate", attempt_receipt_json candidate
+      ; "failure_cause", `String (execution_error_cause_to_string cause.cause)
+      ]
+  | Flow_attempt_already_started _ -> Ok ()
+  | Flow_before_dispatch_callback_failed { cause; _ }
+  | Flow_before_advance_callback_failed { cause; _ } ->
+    Error cause
+;;
+
+let extract_with_exact_output_classified_unlocked
     ?clock
-    ~sw
     ~net
-    ~runtime_id
-    ~provider_cfg
+    ~keeper_id
     ~generation
     (inp : Keeper_librarian.input)
   =
@@ -329,60 +566,196 @@ let extract_with_provider_classified
     (match messages_for_librarian inp with
      | Error msg -> Error (Prompt_render_failed msg)
      | Ok messages ->
-       let provider_cfg = provider_for_librarian provider_cfg in
-       (
-          let attempt messages =
-            match
-              Keeper_provider_subcall.complete ?override:complete ~sw ~net ~clock
-                ~config:provider_cfg ~messages ()
-            with
-            | Error (Llm_provider.Http_client.TimeoutError _) ->
-              Error Provider_timeout
-            | Error err ->
-              Error (Provider_transport_failed (Provider_http_error.to_message err))
-            | Ok response ->
-              (match
-                 Agent_sdk_response.structured_json_of_response
-                   ~schema_name:"keeper_librarian_episode"
-                   response
-               with
-               | Error detail ->
-                 Error
-                   (Provider_unparseable_response
-                      (Printf.sprintf
-                         "librarian provider returned invalid structured JSON (%s)"
-                         detail))
-               | Ok json ->
-                 (match Keeper_librarian.episode_of_json_result ~generation inp json with
-                  | Ok episode -> Ok episode
-                  | Error error ->
-                    Error
-                      (Provider_unparseable_response
-                         (Printf.sprintf
-                            "librarian provider returned invalid episode JSON (%s)"
-                            (Keeper_librarian.parse_error_to_string error)))))
-          in
-          attempt messages))
+       (match preflight_exact_flow_state ~keeper_id with
+        | Error error -> Error (Exact_setup_failed error)
+        | Ok () ->
+       (match Runtime_exact_output_registry.current () with
+        | Error error ->
+          Error (Exact_setup_failed (Exact_registry_unavailable error))
+        | Ok registry ->
+          (match
+             Runtime_exact_output_registry.resolve_lane registry ~lane_id:exact_lane_id
+           with
+           | Error error ->
+             Error (Exact_setup_failed (Exact_lane_unavailable error))
+           | Ok resolved ->
+             (match flow_candidates resolved.selected_slots with
+              | Error error -> Error (Exact_setup_failed error)
+              | Ok [] ->
+                Error
+                  (Exact_setup_failed
+                     (Exact_lane_unavailable
+                        (No_usable_lane_slots
+                           { lane_id = exact_lane_id
+                           ; unavailable_slots = resolved.unavailable_slots
+                           })))
+              | Ok (first :: rest) ->
+                let requirement =
+                  Exact_output.make_output_requirement
+                    ~schema:
+                      Keeper_structured_output_schema.librarian_episode_output_schema
+                    ~minimum_guarantee:Exact_output.Json_syntax
+                in
+                (match
+                   Exact_output.admit_flow
+                     ~first
+                     ~rest
+                     ~messages
+                     requirement
+                 with
+                 | Error error ->
+                   Error (Exact_setup_failed (Exact_flow_admission_failed error))
+                 | Ok ready_flow ->
+                   (match Exact_output.start_flow ready_flow with
+                    | Error error ->
+                      Error (Exact_setup_failed (Exact_flow_start_failed error))
+                    | Ok attempt ->
+                      (match
+                         Exact_output.execute_flow_once
+                           ~net
+                           ~clock
+                           ~before_dispatch:(fun candidate ->
+                             persist_exact_flow_state
+                               ~keeper_id
+                               ~trace_id:inp.trace_id
+                               ~generation
+                               ~state:"candidate_bound"
+                               [ "candidate", attempt_receipt_json candidate ])
+                           ~before_advance:(fun ~failed ~failure ~next ->
+                             persist_exact_flow_state
+                               ~keeper_id
+                               ~trace_id:inp.trace_id
+                               ~generation
+                               ~state:"candidate_advance_committed"
+                               [ "failed_candidate", attempt_receipt_json failed
+                               ; ( "failure_cause"
+                                 , `String
+                                     (execution_error_cause_to_string
+                                        failure.cause) )
+                               ; "next_candidate", attempt_receipt_json next
+                               ])
+                           attempt
+                       with
+                       | Error error ->
+                         let classified = exact_execution_error error in
+                         (match
+                            persist_exact_execution_terminal
+                              ~keeper_id
+                              ~trace_id:inp.trace_id
+                              ~generation
+                              error
+                          with
+                          | Ok () ->
+                            Error (Exact_execution_failed classified)
+                          | Error detail ->
+                            Error
+                              (Exact_execution_failed
+                                 { dispatched = classified.dispatched
+                                 ; failure =
+                                     Exact_callback_persistence_failed detail
+                                 }))
+                       | Ok success ->
+                         (match
+                            persist_exact_flow_state
+                              ~keeper_id
+                              ~trace_id:inp.trace_id
+                              ~generation
+                              ~state:"oas_success"
+                              [ "candidate", attempt_receipt_json success.candidate ]
+                          with
+                          | Error detail ->
+                            Error
+                              (Exact_execution_failed
+                                 { dispatched = true
+                                 ; failure =
+                                     Exact_callback_persistence_failed detail
+                                 })
+                          | Ok () ->
+                            (match
+                               Keeper_librarian.episode_of_json_result
+                                 ~generation
+                                 inp
+                                 success.success.output
+                             with
+                             | Ok episode ->
+                               (match
+                                  persist_exact_flow_state
+                                    ~keeper_id
+                                    ~trace_id:inp.trace_id
+                                    ~generation
+                                    ~state:"domain_valid"
+                                    [ ( "candidate"
+                                      , attempt_receipt_json success.candidate )
+                                    ]
+                                with
+                                | Ok () -> Ok episode
+                                | Error detail ->
+                                  Error
+                                    (Exact_execution_failed
+                                       { dispatched = true
+                                       ; failure =
+                                           Exact_callback_persistence_failed detail
+                                       }))
+                             | Error error ->
+                               let parse_error =
+                                 Keeper_librarian.parse_error_to_string error
+                               in
+                               (match
+                                  persist_exact_flow_state
+                                    ~keeper_id
+                                    ~trace_id:inp.trace_id
+                                    ~generation
+                                    ~state:"domain_invalid"
+                                    [ ( "candidate"
+                                      , attempt_receipt_json success.candidate )
+                                    ; "parse_error", `String parse_error
+                                    ]
+                                with
+                                | Error detail ->
+                                  Error
+                                    (Exact_execution_failed
+                                       { dispatched = true
+                                       ; failure =
+                                           Exact_callback_persistence_failed detail
+                                       })
+                                | Ok () ->
+                                  Error
+                                    (Provider_unparseable_response
+                                       (Printf.sprintf
+                                          "librarian provider returned invalid episode JSON (%s)"
+                                          parse_error)))))))))))))
 ;;
 
-let extract_with_provider
-    ?complete
+let extract_with_exact_output_classified
+      ?clock
+      ~net
+      ~keeper_id
+      ~generation
+      inp
+  =
+  Eio_guard.with_mutex
+    (exact_flow_mutex_for_keeper ~keeper_id)
+    (fun () ->
+      extract_with_exact_output_classified_unlocked
+        ?clock
+        ~net
+        ~keeper_id
+        ~generation
+        inp)
+;;
+
+let extract_with_exact_output
     ?clock
-    ~sw
     ~net
-    ~runtime_id
-    ~provider_cfg
+    ~keeper_id
     ~generation
     inp
   =
   match
-    extract_with_provider_classified
-      ?complete
+    extract_with_exact_output_classified
       ?clock
-      ~sw
       ~net
-      ~runtime_id
-      ~provider_cfg
+      ~keeper_id
       ~generation
       inp
   with
@@ -390,14 +763,10 @@ let extract_with_provider
   | Ok episode -> Ok episode
 ;;
 
-let extract_and_append_with_provider_classified
-    ?complete
+let extract_and_append_with_exact_output_classified
     ?clock
-    ~sw
     ~net
     ~keeper_id
-    ~runtime_id
-    ~provider_cfg
     inp
   =
   match clock with
@@ -410,13 +779,10 @@ let extract_and_append_with_provider_classified
         ~trace_id:inp.Keeper_librarian.trace_id
     in
     (match
-       extract_with_provider_classified
-         ?complete
+       extract_with_exact_output_classified
          ?clock
-         ~sw
          ~net
-         ~runtime_id
-         ~provider_cfg
+         ~keeper_id
          ~generation
          inp
      with
@@ -476,36 +842,24 @@ let extract_and_append_with_provider_classified
       | Error message -> Error (Memory_fact_upsert_failed message)))
 ;;
 
-let extract_and_append_with_provider
-    ?complete
+let extract_and_append_with_exact_output
     ?clock
-    ~sw
     ~net
     ~keeper_id
-    ~runtime_id
-    ~provider_cfg
     inp
   =
   match
-    extract_and_append_with_provider_classified
-      ?complete
+    extract_and_append_with_exact_output_classified
       ?clock
-      ~sw
       ~net
       ~keeper_id
-      ~runtime_id
-      ~provider_cfg
       inp
   with
   | Error err -> Error (extraction_error_to_string err)
   | Ok episode -> Ok episode
 ;;
 
-let provider_for_runtime ~runtime_id =
-  Keeper_memory_runtime_resolution.provider_for_runtime ~runtime_id
-;;
-
-let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.input) =
+let run_best_effort ~keeper_id (inp : Keeper_librarian.input) =
   (* [cadence_due] short-circuits after [enabled]: a disabled keeper never
      advances its cadence counter, and a not-due turn skips extraction entirely
      (the messages remain in the window for the next due turn). The cadence
@@ -514,49 +868,25 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
   if enabled () && cadence_due ~keeper_id ~trace_id:inp.trace_id
   then (
     try
-      match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-      | Some sw, Some net ->
-        let runtime_id = runtime_id_for_librarian ~runtime_id in
-        (match provider_for_runtime ~runtime_id with
-         | Error err ->
-           Log.Keeper.warn ~keeper_name:keeper_id
-             "memory os librarian skipped runtime=%s: %s"
-             runtime_id
-             err
-         | Ok provider_cfg -> (
-             let clock = Eio_context.get_clock_opt () in
-             match clock with
-             | None ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string EpisodeCreateFailures)
-                 ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
-                 ();
-               Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian failed runtime=%s: %s"
-                 runtime_id
-                 librarian_provider_clock_unavailable_error
-             | Some clock -> (
-             match
-               with_provider_slot ~keeper_id ~clock (fun () ->
-                 extract_and_append_with_provider_classified
-                   ?complete
-                   ~clock
-                   ~sw
-                   ~net
-                   ~keeper_id
-                   ~runtime_id
-                   ~provider_cfg
-                   inp)
-             with
+      match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with
+      | Some net, Some clock ->
+        (match
+           with_provider_slot ~keeper_id ~clock (fun () ->
+             extract_and_append_with_exact_output_classified
+               ~clock
+               ~net
+               ~keeper_id
+               inp)
+         with
              | None ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
                 ~labels:
                   [ "keeper", keeper_id; "site", memory_os_librarian_provider_slot_site ]
-                 ();
+               ();
                Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
-                 runtime_id
+                 "memory os librarian skipped lane=%s: per-keeper provider slot busy (capacity=%d)"
+                 exact_lane_id
                  (per_keeper_slot_capacity ())
              | Some (Ok episode) ->
                cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
@@ -573,14 +903,14 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
                if should_record_cadence_backoff_after_error err
                then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
                Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian failed runtime=%s: %s; cadence deferred=%b"
-                 runtime_id
+                 "memory os librarian failed lane=%s: %s; cadence deferred=%b"
+                 exact_lane_id
                  (extraction_error_to_string err)
-                 (should_record_cadence_backoff_after_error err))))
+                 (should_record_cadence_backoff_after_error err))
       | _ ->
         Log.Keeper.warn ~keeper_name:keeper_id
-          "memory os librarian skipped: Eio context unavailable runtime=%s"
-          runtime_id
+          "memory os librarian skipped: Eio net/clock context unavailable lane=%s"
+          exact_lane_id
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
@@ -589,7 +919,7 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
         ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
         ();
       Log.Keeper.warn ~keeper_name:keeper_id
-        "memory os librarian failed runtime=%s: %s"
-        runtime_id
+        "memory os librarian failed lane=%s: %s"
+        exact_lane_id
         (Printexc.to_string exn))
 ;;

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -456,9 +456,12 @@ type exact_journal_disposition =
 
 let exact_journal_disposition_of_state = function
   | "candidate_bound"
-  | "candidate_advance_committed"
-  | "oas_success" ->
+  | "candidate_advance_committed" ->
     Ok Journal_active
+  (* The provider response is not resumable because its body is deliberately
+     absent from the journal, but no Memory OS domain write has begun. A later
+     cadence may therefore start a fresh exact-output flow safely. *)
+  | "oas_success"
   | "domain_valid"
   | "domain_invalid"
   | "execution_terminal" ->

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -4,8 +4,6 @@
     owns the side-effect boundary: render external prompts, call a provider, and
     append accepted episodes to [Keeper_memory_os_io]. *)
 
-type complete_fn = Keeper_provider_subcall.complete_fn
-
 val enabled : unit -> bool
 (** Opt-in gate controlled by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
@@ -86,10 +84,6 @@ val max_messages : unit -> int
     effective prompt window is this value scaled by [cadence_turns] so skipped
     turns are not evicted before the next due extraction. *)
 
-val runtime_id_for_librarian : runtime_id:string -> string
-(** Runtime id after applying the optional
-    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] override. *)
-
 val select_recent_messages
   :  max_messages:int
   -> Agent_sdk.Types.message list
@@ -99,22 +93,40 @@ val messages_for_librarian
   :  Keeper_librarian.input
   -> (Agent_sdk.Types.message list, string) result
 
-val provider_for_librarian
-  :  Llm_provider.Provider_config.t
-  -> Llm_provider.Provider_config.t
-(** Provider config specialized for episode extraction. Caps [max_tokens] at
-    the librarian output budget (default 4096, overridable with
-    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS], floor 1) and requests the
-    structured episode output schema. The selected provider config's exact
-    temperature and [max_concurrent_requests] are preserved, including
-    omission. OAS [Complete] remains the single endpoint admission owner. *)
+val exact_lane_id : string
+(** OAS exact-output lane used by the Librarian. *)
+
+type exact_setup_error =
+  | Exact_registry_unavailable of Runtime_exact_output_registry.publication_error
+  | Exact_lane_unavailable of Runtime_exact_output_registry.lane_resolution_error
+  | Exact_candidate_invalid of
+      { position : int
+      ; slot_id : string
+      }
+  | Exact_journal_unavailable of string
+  | Exact_previous_attempt_unsettled of
+      { state : string
+      ; trace_id : string
+      ; generation : int
+      }
+  | Exact_flow_admission_failed of Agent_sdk.Exact_output.flow_admission_error
+  | Exact_flow_start_failed of Agent_sdk.Exact_output.flow_start_error
+
+type exact_execution_failure =
+  | Exact_attempt_already_started
+  | Exact_callback_persistence_failed of string
+  | Exact_provider_execution_failed of Agent_sdk.Exact_output.execution_error_cause
+
+type exact_execution_error =
+  { dispatched : bool
+  ; failure : exact_execution_failure
+  }
 
 type extraction_error =
   | Prompt_render_failed of string
   | Provider_clock_unavailable
-  | Provider_timeout
-  | Provider_transport_failed of string
-  | Provider_empty_response
+  | Exact_setup_failed of exact_setup_error
+  | Exact_execution_failed of exact_execution_error
   | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
 
@@ -122,8 +134,9 @@ val extraction_error_to_string : extraction_error -> string
 
 val should_record_cadence_backoff_after_error : extraction_error -> bool
 (** Whether an extraction error represents enough completed work to defer the
-    next attempt until the next cadence window. Only completed provider-attempt
-    failures should defer cadence; local deterministic failures stay due. *)
+    next attempt until the next cadence window. Completed provider attempts and
+    a durable unsettled prior-attempt guard defer cadence; local deterministic
+    setup failures stay due. *)
 
 val per_keeper_slot_capacity : unit -> int
 (** Per-keeper librarian provider slot capacity from
@@ -148,66 +161,51 @@ val librarian_provider_clock_unavailable_error : string
     extraction is called without a clock. Exposed so callers/tests do not
     classify the human diagnostic with substring matching. *)
 
-val extract_with_provider
-  :  ?complete:complete_fn
-  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> sw:Eio.Switch.t
+val extract_with_exact_output
+  :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> runtime_id:string
-  -> provider_cfg:Llm_provider.Provider_config.t
+  -> keeper_id:string
   -> generation:int
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
 
-val extract_with_provider_classified
-  :  ?complete:complete_fn
-  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> sw:Eio.Switch.t
+val extract_with_exact_output_classified
+  :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> runtime_id:string
-  -> provider_cfg:Llm_provider.Provider_config.t
+  -> keeper_id:string
   -> generation:int
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, extraction_error) result
-(** Provider-backed librarian extraction. [clock] stays optional at the API
+(** OAS exact-output Librarian extraction. Target resolution, capability
+    admission, wire materialization, and failover are owned by OAS. MASC
+    supplies only the immutable prompt, domain schema, minimum JSON guarantee,
+    post-success domain validation, and an fsync-backed receipt journal for
+    OAS's predetermined candidate transitions. An unsettled journal from a
+    prior process fails closed before dispatch. Calls are serialized per keeper
+    so the bounded journal remains a single affine flow. [clock] stays optional at the API
     boundary because [run_best_effort] may be called from contexts that cannot
     supply an Eio clock; [None] returns
-    {!librarian_provider_clock_unavailable_error} before provider I/O because
-    the provider call itself requires the clock. The extraction now runs to
-    completion: [timeout_sec] no longer force-kills a legitimate in-flight
-    provider call (that wall-clock kill produced kill -> retry churn; see
-    RFC-0156, Withdraw MASC turn-budget timeout policy). An inner-transport
-    (connect/idle/HTTP) timeout still surfaces as {!Provider_timeout}. *)
+    {!librarian_provider_clock_unavailable_error} before provider I/O. *)
 
-val extract_and_append_with_provider
-  :  ?complete:complete_fn
-  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> sw:Eio.Switch.t
+val extract_and_append_with_exact_output
+  :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> keeper_id:string
-  -> runtime_id:string
-  -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
 
-val extract_and_append_with_provider_classified
-  :  ?complete:complete_fn
-  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> sw:Eio.Switch.t
+val extract_and_append_with_exact_output_classified
+  :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> keeper_id:string
-  -> runtime_id:string
-  -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, extraction_error) result
 
 val run_best_effort
-  :  ?complete:complete_fn
-  -> runtime_id:string
-  -> keeper_id:string
+  :  keeper_id:string
   -> Keeper_librarian.input
   -> unit
 (** Run the opt-in post-turn librarian path.
 
     Non-cancel failures are logged and counted, never raised. Runtime dispatch
-    uses OAS endpoint admission; this path adds no runtime-wide MASC slot. *)
+    uses the immutable OAS exact-output registry and [librarian_exact] lane. *)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -207,11 +207,12 @@ val cross_verifier_runtime_id : unit -> string option
     Validated at load so a [Some] always resolves to a configured runtime. *)
 
 val librarian_runtime_id : unit -> string option
-(** [\[runtime\].librarian] runtime id for the memory-os librarian, or [None]
-    when unset (the librarian inherits each keeper's runtime). Validated at load
-    so a [Some] always resolves to a configured runtime.
-    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] overrides this at the librarian
-    call site. *)
+(** Legacy [\[runtime\].librarian] runtime id for Memory OS LLM summary
+    generation and the consolidation fallback, or [None] when summary generation
+    inherits each keeper's runtime. It does not route post-turn Librarian
+    exact-output extraction. Validated at load so a [Some] always resolves to a
+    configured runtime. [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] overrides
+    summary generation only. *)
 
 val structured_judge_runtime_id : unit -> string option
 (** [\[runtime\].structured_judge] runtime id for provider-native

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -240,13 +240,13 @@ type config =
   ; bindings : binding list
   ; default_runtime_id : string option
   ; librarian_runtime_id : string option
-    (** [\[runtime\].librarian] — runtime id ["provider.model"] for the memory-os
-        librarian (post-turn episode extraction). The librarian now requests
-        provider-native structured output at its call sites; this field is the
-        routing SSOT and load-time validation only rejects unknown ids. [None] =
-        the librarian inherits each keeper's runtime (legacy). An unknown id is
-        rejected at load like [\[runtime\].default]. The
-        [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] env var overrides this. *)
+    (** [\[runtime\].librarian] — legacy runtime id ["provider.model"] for
+        Memory OS LLM summary generation and the consolidation fallback. It
+        does not route post-turn Librarian exact-output extraction. [None] =
+        summary generation inherits each keeper's runtime. An unknown id is
+        rejected at load like [\[runtime\].default].
+        [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] overrides summary
+        generation only. *)
   ; structured_judge_runtime_id : string option
     (** [\[runtime\].structured_judge] — runtime id for provider-native
         structured-output judge calls such as dashboard operator

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -174,13 +174,12 @@ type config =
   ; bindings : binding list
   ; default_runtime_id : string option
   ; librarian_runtime_id : string option
-    (** [\[runtime\].librarian] — runtime id for the memory-os librarian
-        (post-turn episode extraction). The librarian now requests
-        provider-native structured output at its call sites; this field is the
-        routing SSOT and load-time validation only rejects unknown ids. [None] =
-        inherit each keeper's runtime. Unknown id rejected at load like
+    (** [\[runtime\].librarian] — legacy runtime id for Memory OS LLM summary
+        generation and the consolidation fallback. It does not route post-turn
+        Librarian exact-output extraction. [None] = summary generation inherits
+        each keeper's runtime. Unknown id rejected at load like
         [\[runtime\].default]; [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID]
-        overrides. *)
+        overrides summary generation only. *)
   ; structured_judge_runtime_id : string option
     (** [\[runtime\].structured_judge] — runtime id for provider-native
         structured-output judge calls. When set, the model must declare

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -81,10 +81,11 @@ let wake_enqueue_counts_of_dispatches dispatches =
 
 (* Resolve the runtime for the Memory OS per-keeper consolidation pass, keeping
    its identity paired with the provider config through the inference boundary.
-   Env var takes precedence; otherwise inherit the librarian runtime so the
-   consolidation LLM uses the same JSON-capable model the librarian uses.
-   An explicit but unknown runtime ID is logged and falls back to the default
-   so typos in operator config are not silently masked. *)
+   The dedicated consolidation env var takes precedence; otherwise inherit the
+   legacy [runtime].librarian summary runtime. Post-turn Librarian exact-output
+   extraction does not consume either setting. An explicit but unknown runtime
+   ID is logged and falls back to the default so typos in operator config are
+   not silently masked. *)
 let runtime_for_memory_os_consolidation () =
   let default_runtime () = Runtime.get_default_runtime () in
   let runtime_id =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -247,7 +247,16 @@ let configure_exact_output_registry ?config_root () =
               lanes)
        then
          Log.Server.warn
-           "exact_output: compaction is degraded until [runtime.exact_output_lanes.compaction_exact] is configured with OAS target refs")
+           "exact_output: compaction is degraded until [runtime.exact_output_lanes.compaction_exact] is configured with OAS target refs";
+       if
+         not
+           (List.exists
+              (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+                 String.equal lane.id "librarian_exact")
+              lanes)
+       then
+         Log.Server.warn
+           "exact_output: librarian is degraded until [runtime.exact_output_lanes.librarian_exact] is configured with OAS target refs")
 ;;
 
 (* GC tuning for long-running server with bursty allocation.

--- a/test/compaction_exact_output_fixture.ml
+++ b/test/compaction_exact_output_fixture.ml
@@ -77,7 +77,14 @@ let start_server ?on_request_before_reply ~sw ~net ~clock behavior =
   }
 ;;
 
-let target_fixture_toml ?connect_timeout_s ~api_key_env index fixture =
+let target_fixture_toml
+      ?connect_timeout_s
+      ~supports_response_format_json
+      ~supports_structured_output
+      ~api_key_env
+      index
+      fixture
+  =
   let provider_id = Printf.sprintf "masc-exact-fixture-provider-%d" index in
   let model_id = Printf.sprintf "masc-exact-fixture-model-%d" index in
   let timeout =
@@ -98,8 +105,8 @@ let target_fixture_toml ?connect_timeout_s ~api_key_env index fixture =
      provider_name = %S\n\
      max_context_tokens = 8192\n\
      max_output_tokens = 1024\n\
-     supports_response_format_json = true\n\
-     supports_structured_output = true\n\n\
+     supports_response_format_json = %b\n\
+     supports_structured_output = %b\n\n\
      [[targets]]\n\
      id = %S\n\
      provider_ref = %S\n\
@@ -110,6 +117,8 @@ let target_fixture_toml ?connect_timeout_s ~api_key_env index fixture =
     api_key_env
     model_id
     provider_id
+    supports_response_format_json
+    supports_structured_output
     fixture.id
     provider_id
     model_id
@@ -120,6 +129,8 @@ let resolver_snapshot
       ?(connect_timeouts = [])
       ?(api_key_env = "")
       ?(api_key_envs = [])
+      ?(supports_response_format_json = true)
+      ?(supports_structured_output = true)
       ~source
       fixtures
   =
@@ -134,6 +145,8 @@ let resolver_snapshot
         |> List.mapi (fun index fixture ->
             target_fixture_toml
               ?connect_timeout_s:(timeout_for fixture.id)
+              ~supports_response_format_json
+              ~supports_structured_output
               ~api_key_env:(api_key_env_for fixture.id)
             index
             fixture)

--- a/test/dune
+++ b/test/dune
@@ -1294,6 +1294,12 @@
   eio_main
   unix))
 
+; Provider-neutral Memory OS Librarian exact-output composition proof.
+(test
+ (name test_librarian_exact_output_conformance)
+ (modules test_librarian_exact_output_conformance)
+ (libraries alcotest compaction_exact_output_fixture masc_test_deps eio_main unix))
+
 ; Durable pre-dispatch fence and restart/cancellation fail-closed proof.
 (test
  (name test_keeper_exact_execution_lease_guard)

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -135,14 +135,28 @@ let test_cadence_record_attempt_defers () =
     (R.cadence_due ~keeper_id:kid ~trace_id:tid)
 
 let test_cadence_error_backoff_policy () =
-  check bool "empty provider response defers cadence" true
-    (R.should_record_cadence_backoff_after_error R.Provider_empty_response);
-  check bool "provider timeout defers cadence" true
-    (R.should_record_cadence_backoff_after_error R.Provider_timeout);
-  check bool "provider transport failure defers cadence" true
+  check bool "dispatched exact execution failure defers cadence" true
     (R.should_record_cadence_backoff_after_error
-       (R.Provider_transport_failed "http timeout"));
-  check bool "unparseable provider response defers cadence" true
+       (R.Exact_execution_failed
+          { dispatched = true
+          ; failure =
+              R.Exact_provider_execution_failed
+                Agent_sdk.Exact_output.Completion_failed
+          }));
+  check bool "zero-dispatch exact execution failure stays due" false
+    (R.should_record_cadence_backoff_after_error
+       (R.Exact_execution_failed
+          { dispatched = false
+          ; failure =
+              R.Exact_provider_execution_failed
+                Agent_sdk.Exact_output.Completion_failed
+          }));
+  check bool "durable unsettled prior attempt defers cadence" true
+    (R.should_record_cadence_backoff_after_error
+       (R.Exact_setup_failed
+          (R.Exact_previous_attempt_unsettled
+             { state = "candidate_bound"; trace_id = "trace"; generation = 1 })));
+  check bool "domain-invalid exact output defers cadence" true
     (R.should_record_cadence_backoff_after_error
        (R.Provider_unparseable_response "invalid_json"));
   check bool "prompt render failure stays due" false

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -787,6 +787,47 @@ let test_librarian_rejects_invalid_lifetime () =
     ]
 ;;
 
+let test_librarian_accepts_nullable_claim_fields () =
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-nullable-claim-fields"
+    ; generation = 3
+    ; messages = [ text_message "nullable structured output" ]
+    }
+  in
+  let json =
+    `Assoc
+      [ "episode_summary", `String "nullable fields follow the domain schema"
+      ; ( "claims"
+        , `List
+            [ `Assoc
+                [ "claim", `String "Nullable claim metadata is accepted."
+                ; "category", `String "fact"
+                ; "source_turn", `Int 0
+                ; "source_tool_call_id", `Null
+                ; "claim_id", `Null
+                ; "claim_kind", `Null
+                ; "valid_for_days", `Null
+                ]
+            ] )
+      ; "open_items", `List []
+      ; "constraints", `List []
+      ; "preserved_tool_refs", `List []
+      ]
+  in
+  match Librarian.episode_of_json_result ~now:1_000_000.0 ~generation:3 inp json with
+  | Error error ->
+    Alcotest.failf
+      "schema-valid nullable fields were rejected: %s"
+      (Librarian.parse_error_to_string error)
+  | Ok episode ->
+    (match episode.Types.claims with
+     | [ claim ] ->
+       Alcotest.(check (option string)) "tool call id" None claim.source.tool_call_id;
+       Alcotest.(check (option string)) "claim id" None claim.claim_id;
+       Alcotest.(check (option (float 0.0001))) "validity" None claim.valid_until
+     | claims -> Alcotest.failf "expected one claim, got %d" (List.length claims))
+;;
+
 let test_librarian_accepts_wrapped_json_output () =
   let inp : Librarian.input =
     { Librarian.trace_id = "trace-wrapped-json"
@@ -879,14 +920,14 @@ let test_librarian_runtime_override_env () =
        Alcotest.(check string)
          "empty override falls back"
          "keeper-runtime"
-         (Librarian_runtime.runtime_id_for_librarian ~runtime_id:"keeper-runtime");
+         (Runtime_resolution.runtime_id_for_librarian ~runtime_id:"keeper-runtime");
        Unix.putenv
          Env_config.KeeperMemoryOs.librarian_runtime_id_env_key
          " runpod_mtp.qwen36-35b-a3b-mtp ";
        Alcotest.(check string)
          "override trims"
          "runpod_mtp.qwen36-35b-a3b-mtp"
-         (Librarian_runtime.runtime_id_for_librarian ~runtime_id:"keeper-runtime"))
+         (Runtime_resolution.runtime_id_for_librarian ~runtime_id:"keeper-runtime"))
 ;;
 
 let memory_runtime_resolution_toml =
@@ -944,9 +985,6 @@ let test_memory_provider_configs_use_runtime_temperature () =
       let summary =
         Memory_summary.provider_for_summary runtime.Runtime.provider_config
       in
-      let librarian =
-        Librarian_runtime.provider_for_librarian runtime.Runtime.provider_config
-      in
       let consolidation =
         Consolidation_runtime.For_testing.provider_for_consolidation
           runtime.Runtime.provider_config
@@ -956,27 +994,9 @@ let test_memory_provider_configs_use_runtime_temperature () =
         (Some 1.0)
         summary.temperature;
       Alcotest.(check (option (float 0.0001)))
-        "librarian keeps runtime.toml temperature"
-        (Some 1.0)
-        librarian.temperature;
-      Alcotest.(check (option (float 0.0001)))
         "memory consolidation keeps runtime.toml temperature"
         (Some 1.0)
         consolidation.temperature)
-;;
-
-let test_librarian_provider_config_preserves_provider_admission () =
-  let projected max_concurrent_requests =
-    Librarian_runtime.provider_for_librarian
-      { (test_provider_cfg ()) with max_concurrent_requests }
-  in
-  List.iter
-    (fun expected ->
-       Alcotest.(check (option int))
-         "librarian projection preserves OAS provider admission"
-         expected
-         (projected expected).max_concurrent_requests)
-    [ None; Some 5 ]
 ;;
 
 let with_memory_os_env name value f =
@@ -1118,9 +1138,7 @@ let find_config_env env entries =
 (* Introspection-parity SSOT rows: one row per Memory OS knob pairing the
    exported env-key constant with a thunk exercising its compiled reader. A
    snapshot registry entry cannot be added to this list without a reader
-   existing (the phantom MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS
-   regression: registered + tested, zero readers, so setting it was a silent
-   no-op reported as source=env). *)
+   existing. *)
 let memory_os_knob_readers : (string * (unit -> unit)) list =
   [ ( Env_config.KeeperMemoryOs.recall_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.recall_enabled () : bool) )
@@ -1130,8 +1148,6 @@ let memory_os_knob_readers : (string * (unit -> unit)) list =
     , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_cadence_turns () : int) )
   ; ( Env_config.KeeperMemoryOs.librarian_max_messages_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_max_messages () : int) )
-  ; ( Env_config.KeeperMemoryOs.librarian_max_tokens_env_key
-    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_max_tokens () : int) )
   ; ( Env_config.KeeperMemoryOs.librarian_runtime_id_env_key
     , fun () ->
         ignore (Env_config.KeeperMemoryOs.librarian_runtime_id () : string option) )
@@ -1213,41 +1229,6 @@ let test_memory_os_config_snapshot_surfaces_effective_envs () =
     | None -> Alcotest.fail "recall entry value missing")
 ;;
 
-let test_librarian_max_tokens_override_env () =
-  let env = Env_config.KeeperMemoryOs.librarian_max_tokens_env_key in
-  let default = Env_config.KeeperMemoryOs.librarian_max_tokens_default in
-  (* Exercise the cap through [provider_for_librarian] (the consuming site):
-     before the knob was wired to a reader, setting the env var was a silent
-     no-op while the config snapshot reported source=env. *)
-  let effective_cap () =
-    (Librarian_runtime.provider_for_librarian
-       (test_provider_cfg ()))
-      .Llm_provider.Provider_config.max_tokens
-  in
-  Fun.protect
-    ~finally:(fun () -> Unix.putenv env "")
-    (fun () ->
-       Unix.putenv env "";
-       Alcotest.(check (option int))
-         "empty max tokens override falls back"
-         (Some default)
-         (effective_cap ());
-       Unix.putenv env "512";
-       Alcotest.(check (option int))
-         "max tokens override caps the librarian provider config"
-         (Some 512)
-         (effective_cap ());
-       Unix.putenv env "0";
-       Alcotest.(check int)
-         "non-positive max tokens override floors at 1"
-         1
-         (Env_config.KeeperMemoryOs.librarian_max_tokens ());
-       Unix.putenv env "bogus";
-       Alcotest.(check (option int))
-         "invalid max tokens override falls back"
-         (Some default)
-         (effective_cap ()))
-;;
 
 let test_librarian_preserves_admission_memory_text () =
   let inp : Librarian.input =
@@ -1532,390 +1513,6 @@ let json_episode_file_count ~keeper_id =
   |> List.filter (fun name -> Filename.check_suffix name ".json")
   |> List.length
 ;;
-
-let test_librarian_runtime_appends_episode_bundle () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
-      with_eio (fun ~sw ~net ~clock ->
-        let keeper_id = "runtime-librarian-keeper" in
-        let captured = ref None in
-        let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages () =
-          captured := Some (config, messages);
-          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
-        in
-        let private_msg : Agent_sdk.Types.message =
-          { role = Agent_sdk.Types.Assistant
-          ; content =
-              [ Agent_sdk.Types.Text "visible durable fact"
-              ; Agent_sdk.Types.Thinking
-                  { signature = None; content = "hidden chain of thought" }
-              ; Agent_sdk.Types.ToolResult
-                  { tool_use_id = "call_runtime"
-                  ; content = "secret tool payload"
-                  ; outcome = Agent_sdk.Types.Tool_succeeded
-                  ; json = None
-                  ; content_blocks = None
-                  }
-              ]
-          ; name = None
-          ; tool_call_id = None
-          ; metadata = []
-          }
-        in
-        let inp : Librarian.input =
-          { Librarian.trace_id = "trace-runtime"
-          ; generation = 7
-          ; messages =
-              [ text_message "older message"
-              ; text_message "Please remember the runtime boundary."
-              ; private_msg
-              ]
-          }
-        in
-        (match
-           Librarian_runtime.extract_and_append_with_provider
-             ~complete
-             ~clock
-             ~sw
-             ~net
-             ~keeper_id
-             ~runtime_id:unconfigured_runtime_id
-             ~provider_cfg:(test_provider_cfg ())
-             inp
-         with
-         | Error msg -> Alcotest.fail msg
-         | Ok episode ->
-           Alcotest.(check string) "trace id" "trace-runtime" episode.Types.trace_id;
-           Alcotest.(check int) "generation" 7 episode.Types.generation;
-           Alcotest.(check int) "claim persisted in result" 1 (List.length episode.Types.claims));
-        (match !captured with
-         | None -> Alcotest.fail "expected fake provider to be called"
-         | Some (provider_cfg, messages) ->
-           Alcotest.(check (option bool))
-             "thinking disabled"
-             (Some false)
-             provider_cfg.Llm_provider.Provider_config.enable_thinking;
-           Alcotest.(check (option bool))
-             "thinking preservation disabled"
-             (Some false)
-             provider_cfg.Llm_provider.Provider_config.preserve_thinking;
-           (* The contract lives in the prompt and in
-              [Keeper_librarian.episode_of_json_result], not in a wire format.
-              Reattaching the schema here would resurrect a concrete failure:
-              it marks every claim field required with nullable types, so a
-              conforming provider emits ["claim_id": null], which
-              [optional_string_field_strict] rejects — dropping the whole
-              episode — while the prompt tells the model to omit the key. *)
-           Alcotest.(check bool)
-             "librarian requests no response format"
-             true
-             (match provider_cfg.response_format with
-              | Agent_sdk.Types.Off -> true
-              | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
-           Alcotest.(check bool)
-             "librarian attaches no output schema"
-             true
-             (Option.is_none provider_cfg.Llm_provider.Provider_config.output_schema);
-           Alcotest.(check int) "system+user prompt" 2 (List.length messages);
-           let rendered_prompt = messages |> List.map message_text |> String.concat "\n" in
-           Alcotest.(check bool)
-             "contains visible prompt"
-             true
-             (contains "visible durable fact" rendered_prompt);
-           Alcotest.(check bool)
-             "scrubs state text"
-             false
-             (contains "runtime secret sentinel" rendered_prompt);
-           Alcotest.(check bool)
-             "scrubs thinking"
-             false
-             (contains "hidden chain of thought" rendered_prompt);
-           Alcotest.(check bool)
-             "scrubs tool payload"
-             false
-             (contains "secret tool payload" rendered_prompt));
-        Alcotest.(check int)
-          "episode file persisted"
-          1
-          (json_episode_file_count ~keeper_id);
-        (match Memory_io.read_events_tail ~keeper_id ~n:1 with
-         | [ episode ] ->
-          Alcotest.(check string)
-            "event persisted"
-            "Strict librarian output should persist"
-            episode.Types.episode_summary
-         | events -> Alcotest.failf "expected one event, got %d" (List.length events));
-        match Memory_io.read_facts_tail ~keeper_id ~n:1 with
-        | [ fact ] ->
-          Alcotest.(check string)
-            "fact persisted"
-            "Strict librarian claim survives parsing"
-            fact.Types.claim
-        | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
-;;
-
-let test_librarian_runtime_falls_back_when_schema_unavailable () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
-      with_eio (fun ~sw ~net ~clock ->
-        let called = ref false in
-        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          called := true;
-          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
-        in
-        let inp : Librarian.input =
-          { Librarian.trace_id = "trace-invalid-schema-provider"
-          ; generation = 1
-          ; messages = [ text_message "Please remember schema validation." ]
-          }
-        in
-        match
-          Librarian_runtime.extract_with_provider_classified
-            ~complete
-            ~clock
-            ~sw
-            ~net
-            ~runtime_id:unconfigured_runtime_id
-            ~provider_cfg:(invalid_schema_provider_cfg ())
-            ~generation:1
-            inp
-        with
-        | Ok _ ->
-          Alcotest.(check bool)
-            "complete called on the prompt-tier fallback path"
-            true
-            !called
-        | Error err ->
-          Alcotest.fail
-            (Printf.sprintf
-               "expected prompt-tier fallback to succeed, got %s"
-               (Librarian_runtime.extraction_error_to_string err)))))
-;;
-
-let test_librarian_runtime_requires_clock_for_provider_call () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
-      with_eio (fun ~sw ~net ~clock:_ ->
-        let keeper_id = "runtime-librarian-no-clock-keeper" in
-        let called = ref false in
-        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          called := true;
-          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
-        in
-        let inp : Librarian.input =
-          { Librarian.trace_id = "trace-runtime-no-clock"
-          ; generation = 7
-          ; messages = [ text_message "Please remember the timeout boundary." ]
-          }
-        in
-        let generation_counter =
-          Filename.concat
-            (Memory_io.episodes_dir ~keeper_id)
-            (Printf.sprintf "%s.generation" inp.Librarian.trace_id)
-        in
-        (match
-           Librarian_runtime.extract_and_append_with_provider_classified
-             ~complete
-             ~sw
-             ~net
-             ~keeper_id
-             ~runtime_id:unconfigured_runtime_id
-             ~provider_cfg:(test_provider_cfg ())
-             inp
-         with
-         | Ok _ -> Alcotest.fail "expected missing clock to fail closed"
-         | Error err ->
-           Alcotest.(check string)
-             "explicit missing clock error"
-             Librarian_runtime.librarian_provider_clock_unavailable_error
-             (Librarian_runtime.extraction_error_to_string err));
-        Alcotest.(check bool) "provider not called without clock" false !called;
-        Alcotest.(check bool)
-          "generation counter not created without clock"
-          false
-          (Sys.file_exists generation_counter);
-        Alcotest.(check int)
-          "no event persisted"
-          0
-          (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
-        Alcotest.(check int)
-          "no fact persisted"
-          0
-          (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
-;;
-
-let test_librarian_runtime_rejects_unstructured_fallback () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
-      with_eio (fun ~sw ~net ~clock ->
-        let keeper_id = "runtime-librarian-fallback-keeper" in
-        let calls = ref 0 in
-        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          incr calls;
-          Ok (fake_response "not json, but keep this observation")
-        in
-        let inp : Librarian.input =
-          { Librarian.trace_id = "trace-runtime-fallback"
-          ; generation = 9
-          ; messages = [ text_message "Please remember the fallback path." ]
-          }
-        in
-        Alcotest.(check bool)
-          "production cadence gate is due before provider attempt"
-          true
-          (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id);
-        let fallback_result =
-          Librarian_runtime.extract_and_append_with_provider_classified
-            ~complete
-            ~clock
-            ~sw
-            ~net
-            ~keeper_id
-            ~runtime_id:unconfigured_runtime_id
-            ~provider_cfg:(test_provider_cfg ())
-            inp
-        in
-        (match fallback_result with
-         | Ok _ -> Alcotest.fail "unstructured provider output must not persist"
-         | Error (Librarian_runtime.Provider_unparseable_response reason as err) ->
-           Alcotest.(check int) "single provider attempt" 1 !calls;
-           Alcotest.(check bool)
-             "typed provider error preserves parser reason"
-             true
-             (contains
-                "librarian provider returned invalid structured JSON"
-                reason);
-           Alcotest.(check bool)
-             "typed provider error preserves JSON parser detail"
-             true
-             (contains "JSON parse error" reason);
-           Alcotest.(check bool)
-             "unparseable provider error enters cadence backoff path"
-             true
-             (Librarian_runtime.should_record_cadence_backoff_after_error err);
-           Librarian_runtime.cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
-           Alcotest.(check bool)
-             "cadence attempt defers the next provider retry"
-             false
-             (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id)
-         | Error err ->
-           Alcotest.failf
-             "expected Provider_unparseable_response, got %s"
-             (Librarian_runtime.extraction_error_to_string err));
-        Alcotest.(check int)
-          "episode file not persisted"
-          0
-          (json_episode_file_count ~keeper_id);
-        Alcotest.(check int)
-          "event not persisted"
-          0
-          (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
-        Alcotest.(check int)
-          "fact not persisted"
-          0
-          (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
-;;
-
-let test_librarian_invalid_output_does_not_write_facts () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
-      with_eio (fun ~sw ~net ~clock ->
-        let keeper_id = "runtime-librarian-fallback-upsert-keeper" in
-        let inp : Librarian.input =
-          { Librarian.trace_id = "trace-runtime-fallback-upsert"
-          ; generation = 12
-          ; messages = [ text_message "Please remember repeated fallback shape." ]
-          }
-        in
-        let first_complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          Ok (fake_response "first invalid librarian payload")
-        in
-        let second_complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          Ok (fake_response "second invalid librarian payload with different text")
-        in
-        let run_once complete =
-          match
-            Librarian_runtime.extract_and_append_with_provider
-              ~complete
-              ~clock
-              ~sw
-              ~net
-              ~keeper_id
-              ~runtime_id:unconfigured_runtime_id
-              ~provider_cfg:(test_provider_cfg ())
-              inp
-          with
-          | Ok _ -> Alcotest.fail "unparseable provider output must not persist"
-          | Error msg -> msg
-        in
-        let first = run_once first_complete in
-        let second = run_once second_complete in
-        Alcotest.(check int)
-          "fallback events are not written"
-          0
-          (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
-        let facts = Memory_io.read_facts_all ~keeper_id in
-        Alcotest.(check int) "diagnostic facts are not written" 0 (List.length facts);
-        Alcotest.(check bool)
-          "first error keeps invalid-json reason"
-          true
-          (contains "invalid structured JSON" first);
-        Alcotest.(check bool)
-          "first error keeps JSON parser detail"
-          true
-          (contains "JSON parse error" first);
-        Alcotest.(check bool)
-          "second error keeps invalid-json reason"
-          true
-          (contains "invalid structured JSON" second);
-        Alcotest.(check bool)
-          "second error keeps JSON parser detail"
-          true
-          (contains "JSON parse error" second))))
-;;
-
-let test_librarian_runtime_reports_fact_upsert_failure () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
-      with_eio (fun ~sw ~net ~clock ->
-        let keeper_id = "runtime-librarian-keeper" in
-        Unix.mkdir (Memory_io.facts_path ~keeper_id) 0o755;
-        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
-        in
-        let inp : Librarian.input =
-          { Librarian.trace_id = "trace-runtime-upsert-failure"
-          ; generation = 8
-          ; messages = [ text_message "Please remember the runtime boundary." ]
-          }
-        in
-        match
-          Librarian_runtime.extract_and_append_with_provider
-            ~complete
-            ~clock
-            ~sw
-            ~net
-            ~keeper_id
-            ~runtime_id:unconfigured_runtime_id
-            ~provider_cfg:(test_provider_cfg ())
-            inp
-        with
-        | Ok _ -> Alcotest.fail "expected fact upsert failure"
-        | Error msg ->
-          Alcotest.(check bool)
-            "fact upsert error returned to caller"
-            true
-            (contains "memory os fact upsert failed" msg);
-          Alcotest.(check int)
-            "episode file not published on fact failure"
-            0
-            (json_episode_file_count ~keeper_id);
-          Alcotest.(check int)
-            "event not published on fact failure"
-            0
-            (List.length (Memory_io.read_events_tail ~keeper_id ~n:10)))))
-;;
-
 
 let test_reference_time_is_observation_only () =
   let now = 1_000_000.0 in
@@ -2570,6 +2167,7 @@ let test_episode_gc_corrupt_store_fails_loud_and_deletes_nothing () =
    from its very first turn. Short-circuiting to "" hid the L1 nudge from
    exactly the keepers that had never written anything. *)
 let test_recall_context_empty_store_renders_gauge () =
+  with_prompt_registry (fun () ->
   with_temp_keepers_dir (fun _keepers_dir ->
     let ctx =
       Recall.render_context
@@ -2586,7 +2184,7 @@ let test_recall_context_empty_store_renders_gauge () =
     Alcotest.(check bool)
       "empty-store recall context carries the zero gauge"
       true
-      (contains ~needle:"facts 0/0 injected, episodes 0/0 injected" ctx))
+      (contains ~needle:"facts 0/0 injected, episodes 0/0 injected" ctx)))
 ;;
 
 (* render_if_enabled — the extra_system_context gate wired into
@@ -2619,6 +2217,7 @@ let test_render_if_enabled_explicit_off () =
 ;;
 
 let test_render_if_enabled_empty_store_still_injects_gauge () =
+  with_prompt_registry (fun () ->
   with_recall_env "true" (fun () ->
     with_temp_keepers_dir (fun keepers_dir ->
       match
@@ -2639,7 +2238,7 @@ let test_render_if_enabled_empty_store_still_injects_gauge () =
            let rec scan i =
              i + nlen <= hlen && (String.sub block i nlen = needle || scan (i + 1))
            in
-           scan 0)))
+           scan 0))))
 ;;
 
 let test_render_if_enabled_surfaces_prompt_render_failure () =
@@ -4949,6 +4548,10 @@ let () =
             `Quick
             test_librarian_rejects_invalid_lifetime
         ; Alcotest.test_case
+            "librarian accepts schema-valid nullable claim fields"
+            `Quick
+            test_librarian_accepts_nullable_claim_fields
+        ; Alcotest.test_case
             "librarian accepts wrapped json output"
             `Quick
             test_librarian_accepts_wrapped_json_output
@@ -4989,10 +4592,6 @@ let () =
             `Quick
             test_memory_os_snapshot_registry_parity
         ; Alcotest.test_case
-            "librarian max tokens override env"
-            `Quick
-            test_librarian_max_tokens_override_env
-        ; Alcotest.test_case
             "librarian preserves admission memory text"
             `Quick
             test_librarian_preserves_admission_memory_text
@@ -5020,22 +4619,6 @@ let () =
             "memory llm summary does not invent clock requirement"
             `Quick
             test_memory_llm_summary_does_not_invent_clock_requirement
-        ; Alcotest.test_case
-            "librarian runtime appends episode bundle"
-            `Quick
-            test_librarian_runtime_appends_episode_bundle
-        ; Alcotest.test_case
-            "librarian runtime falls back when schema unavailable"
-            `Quick
-            test_librarian_runtime_falls_back_when_schema_unavailable
-        ; Alcotest.test_case
-            "librarian runtime requires clock for provider call"
-            `Quick
-            test_librarian_runtime_requires_clock_for_provider_call
-        ; Alcotest.test_case
-            "librarian runtime reports fact upsert failure"
-            `Quick
-            test_librarian_runtime_reports_fact_upsert_failure
         ; Alcotest.test_case
             "dashboard fact json omits deleted score keys (RFC-keeper-memory-panel-real-data §4a)"
             `Quick
@@ -5289,14 +4872,6 @@ let () =
         ] )
     ; ( "librarian runtime"
       , [ Alcotest.test_case
-            "unparseable output is rejected instead of persisted"
-            `Quick
-            test_librarian_runtime_rejects_unstructured_fallback
-        ; Alcotest.test_case
-            "unstructured fallback does not write facts"
-            `Quick
-            test_librarian_invalid_output_does_not_write_facts
-        ; Alcotest.test_case
             "provider slot gate caps concurrency at capacity (#21376/#21230)"
             `Quick
             test_librarian_provider_slot_gate_caps_at_capacity
@@ -5308,10 +4883,6 @@ let () =
             "provider slot gate isolates keepers (P0-4)"
             `Quick
             test_librarian_provider_slot_gate_is_per_keeper
-        ; Alcotest.test_case
-            "provider projection preserves OAS admission"
-            `Quick
-            test_librarian_provider_config_preserves_provider_admission
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -1,0 +1,470 @@
+open Masc
+
+module Fixture = Compaction_exact_output_fixture
+module Librarian = Keeper_librarian
+module Librarian_runtime = Keeper_librarian_runtime
+module Memory_io = Keeper_memory_os_io
+module Types = Keeper_memory_os_types
+
+let has_librarian_prompt_root path =
+  Sys.file_exists
+    (Filename.concat path "config/prompts/keeper.librarian.episode_extraction.md")
+;;
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_librarian_prompt_root root -> root
+  | _ ->
+    let rec ascend path =
+      if has_librarian_prompt_root path
+      then path
+      else (
+        let parent = Filename.dirname path in
+        if String.equal parent path then Sys.getcwd () else ascend parent)
+    in
+    ascend (Sys.getcwd ())
+;;
+
+let with_prompt_registry f =
+  Fun.protect
+    ~finally:Prompt_registry.clear
+    (fun () ->
+      Prompt_registry.clear ();
+      Prompt_registry.set_markdown_dir (Filename.concat (repo_root ()) "config/prompts");
+      Prompt_defaults.init ();
+      f ())
+;;
+
+let with_temp_keepers_dir f =
+  let marker = Filename.temp_file "librarian-exact-output-" ".tmp" in
+  Sys.remove marker;
+  Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+;;
+
+let text_message text =
+  Agent_sdk.Types.make_message
+    ~role:Agent_sdk.Types.User
+    [ Agent_sdk.Types.Text text ]
+;;
+
+let librarian_input trace_id =
+  { Librarian.trace_id
+  ; generation = 1
+  ; messages = [ text_message "Remember the exact-output boundary." ]
+  }
+;;
+
+let valid_output =
+  `Assoc
+    [ "episode_summary", `String "OAS exact output succeeded."
+    ; ( "claims"
+      , `List
+          [ `Assoc
+              [ "claim", `String "OAS owns exact-output provider admission."
+              ; "category", `String "constraint"
+              ; "source_turn", `Int 0
+              ; "source_tool_call_id", `Null
+              ; "claim_id", `String "oas-exact-output-owns-admission"
+              ; "claim_kind", `String "durable_knowledge"
+              ; "valid_for_days", `Null
+              ]
+          ] )
+    ; "open_items", `List []
+    ; "constraints", `List []
+    ; "preserved_tool_refs", `List []
+    ]
+;;
+
+let publish_lane
+      ?(supports_response_format_json = true)
+      ?(supports_structured_output = false)
+      fixtures
+  =
+  let snapshot =
+    Fixture.resolver_snapshot
+      ~supports_response_format_json
+      ~supports_structured_output
+      ~source:"librarian exact-output conformance"
+      fixtures
+  in
+  ignore
+    (Fixture.publish_registry
+       ~lane_id:Librarian_runtime.exact_lane_id
+       ~slot_ids:(List.map (fun (fixture : Fixture.target_fixture) -> fixture.id) fixtures)
+       snapshot
+      : Runtime_exact_output_registry.t)
+;;
+
+let json_object_response_format body =
+  match Yojson.Safe.from_string body with
+  | `Assoc fields ->
+    (match List.assoc_opt "response_format" fields with
+     | Some (`Assoc response_format) ->
+       (match List.assoc_opt "type" response_format with
+        | Some (`String "json_object") -> true
+        | _ -> false)
+     | _ -> false)
+  | _ -> false
+;;
+
+let exact_journal_state ~keeper_id =
+  let exact_output_dir =
+    Memory_io.episodes_dir ~keeper_id
+    |> Filename.dirname
+    |> fun keeper_dir -> Filename.concat keeper_dir "exact-output"
+  in
+  let journals =
+    exact_output_dir
+    |> Sys.readdir
+    |> Array.to_list
+    |> List.filter (String.equal "librarian-exact-state.json")
+  in
+  match journals with
+  | [ journal ] ->
+    let path = Filename.concat exact_output_dir journal in
+    let json =
+      In_channel.with_open_bin path In_channel.input_all
+      |> Yojson.Safe.from_string
+    in
+    Yojson.Safe.Util.(json |> member "state" |> to_string)
+  | _ -> Alcotest.failf "expected one exact journal, got %d" (List.length journals)
+;;
+
+let write_active_exact_journal ~keeper_id =
+  let exact_output_dir =
+    Memory_io.episodes_dir ~keeper_id
+    |> Filename.dirname
+    |> fun keeper_dir -> Filename.concat keeper_dir "exact-output"
+    |> Keeper_fs.ensure_dir
+  in
+  let path = Filename.concat exact_output_dir "librarian-exact-state.json" in
+  let payload =
+    `Assoc
+      [ "schema_version", `Int 1
+      ; "trace_id", `String "prior-trace"
+      ; "generation", `Int 41
+      ; "state", `String "candidate_bound"
+      ]
+    |> Yojson.Safe.to_string
+  in
+  Out_channel.with_open_bin path (fun channel -> output_string channel payload)
+;;
+
+let run_eio f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  f
+    ~sw
+    ~net:(Eio.Stdenv.net env)
+    ~clock:(Eio.Stdenv.clock env)
+;;
+
+let test_json_only_target_is_admitted_and_persisted () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _ ->
+      run_eio (fun ~sw ~net ~clock ->
+        let response = Fixture.openai_response valid_output in
+        let server = Fixture.start_server ~sw ~net ~clock (Fixture.Reply response) in
+        let slot : Fixture.target_fixture =
+          { id = "librarian-json-only"; base_url = server.base_url }
+        in
+        publish_lane [ slot ];
+        let keeper_id = "librarian-json-only-keeper" in
+        match
+          Librarian_runtime.extract_and_append_with_exact_output
+            ~clock
+            ~net
+            ~keeper_id
+            (librarian_input "trace-json-only")
+        with
+        | Error error -> Alcotest.fail error
+        | Ok episode ->
+          Alcotest.(check int) "one claim" 1 (List.length episode.Types.claims);
+          Alcotest.(check int) "one provider request" 1 (Fixture.post_count server);
+          (match Fixture.request_bodies server with
+           | [ body ] ->
+             Alcotest.(check bool)
+               "OAS selected json_object for a JSON-only target"
+               true
+               (json_object_response_format body)
+           | bodies ->
+             Alcotest.failf "expected one request body, got %d" (List.length bodies));
+          Alcotest.(check int)
+            "episode persisted"
+            1
+            (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
+          Alcotest.(check int)
+            "fact persisted"
+            1
+            (List.length (Memory_io.read_facts_tail ~keeper_id ~n:10));
+          Alcotest.(check string)
+            "exact receipt journal reached domain-valid terminal"
+            "domain_valid"
+            (exact_journal_state ~keeper_id))))
+;;
+
+let test_missing_json_capability_fails_before_dispatch () =
+  with_prompt_registry (fun () ->
+    run_eio (fun ~sw ~net ~clock ->
+      let response = Fixture.openai_response valid_output in
+      let server = Fixture.start_server ~sw ~net ~clock (Fixture.Reply response) in
+      let slot : Fixture.target_fixture =
+        { id = "librarian-no-json"; base_url = server.base_url }
+      in
+      publish_lane
+        ~supports_response_format_json:false
+        ~supports_structured_output:false
+        [ slot ];
+      match
+        Librarian_runtime.extract_with_exact_output_classified
+          ~clock
+          ~net
+          ~keeper_id:"librarian-no-json-keeper"
+          ~generation:1
+          (librarian_input "trace-no-json")
+      with
+      | Error (Librarian_runtime.Exact_setup_failed _) ->
+        Alcotest.(check int) "no provider request" 0 (Fixture.post_count server)
+      | Error error ->
+        Alcotest.failf
+          "expected typed exact setup failure, got %s"
+          (Librarian_runtime.extraction_error_to_string error)
+      | Ok _ -> Alcotest.fail "target without a JSON guarantee must fail closed"))
+;;
+
+let test_domain_invalid_output_does_not_fail_over () =
+  with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
+    run_eio (fun ~sw ~net ~clock ->
+      let invalid_server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply
+             (Fixture.openai_response
+                (`Assoc [ "episode_summary", `String "missing claims" ])))
+      in
+      let valid_server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply (Fixture.openai_response valid_output))
+      in
+      let slots : Fixture.target_fixture list =
+        [ { id = "librarian-domain-invalid"; base_url = invalid_server.base_url }
+        ; { id = "librarian-domain-valid"; base_url = valid_server.base_url }
+        ]
+      in
+      publish_lane slots;
+      match
+        Librarian_runtime.extract_with_exact_output_classified
+          ~clock
+          ~net
+          ~keeper_id:"librarian-domain-invalid-keeper"
+          ~generation:1
+          (librarian_input "trace-domain-invalid")
+      with
+      | Error (Librarian_runtime.Provider_unparseable_response _) ->
+        Alcotest.(check int)
+          "first exact candidate dispatched once"
+          1
+          (Fixture.post_count invalid_server);
+        Alcotest.(check int)
+          "domain validation is terminal"
+          0
+          (Fixture.post_count valid_server);
+        Alcotest.(check string)
+          "domain-invalid terminal is durable"
+          "domain_invalid"
+          (exact_journal_state ~keeper_id:"librarian-domain-invalid-keeper")
+      | Error error ->
+        Alcotest.failf
+          "expected domain validation failure, got %s"
+          (Librarian_runtime.extraction_error_to_string error)
+      | Ok _ -> Alcotest.fail "domain-invalid episode must not be accepted")))
+;;
+
+let test_unsettled_restart_state_fails_before_dispatch () =
+  with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
+    run_eio (fun ~sw ~net ~clock ->
+      let server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply (Fixture.openai_response valid_output))
+      in
+      let slot : Fixture.target_fixture =
+        { id = "librarian-restart-guard"; base_url = server.base_url }
+      in
+      publish_lane [ slot ];
+      let keeper_id = "librarian-restart-guard-keeper" in
+      write_active_exact_journal ~keeper_id;
+      match
+        Librarian_runtime.extract_with_exact_output_classified
+          ~clock
+          ~net
+          ~keeper_id
+          ~generation:42
+          (librarian_input "trace-after-restart")
+      with
+      | Error
+          (Librarian_runtime.Exact_setup_failed
+             (Librarian_runtime.Exact_previous_attempt_unsettled
+                { state = "candidate_bound"
+                ; trace_id = "prior-trace"
+                ; generation = 41
+                })) ->
+        Alcotest.(check int) "restart guard dispatched nothing" 0 (Fixture.post_count server)
+      | Error error ->
+        Alcotest.failf
+          "expected typed unsettled-attempt guard, got %s"
+          (Librarian_runtime.extraction_error_to_string error)
+      | Ok _ -> Alcotest.fail "unsettled prior exact attempt must fail closed")))
+;;
+
+let test_missing_clock_fails_before_dispatch () =
+  with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
+    run_eio (fun ~sw ~net ~clock ->
+      let server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply (Fixture.openai_response valid_output))
+      in
+      let slot : Fixture.target_fixture =
+        { id = "librarian-clock-guard"; base_url = server.base_url }
+      in
+      publish_lane [ slot ];
+      match
+        Librarian_runtime.extract_with_exact_output_classified
+          ~net
+          ~keeper_id:"librarian-clock-guard-keeper"
+          ~generation:1
+          (librarian_input "trace-clock-guard")
+      with
+      | Error Librarian_runtime.Provider_clock_unavailable ->
+        Alcotest.(check int) "missing clock dispatched nothing" 0 (Fixture.post_count server)
+      | Error error ->
+        Alcotest.failf
+          "expected typed missing-clock error, got %s"
+          (Librarian_runtime.extraction_error_to_string error)
+      | Ok _ -> Alcotest.fail "missing clock must fail closed")))
+;;
+
+let test_fact_upsert_failure_does_not_publish_episode () =
+  with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
+    run_eio (fun ~sw ~net ~clock ->
+      let server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply (Fixture.openai_response valid_output))
+      in
+      let slot : Fixture.target_fixture =
+        { id = "librarian-fact-write-failure"; base_url = server.base_url }
+      in
+      publish_lane [ slot ];
+      let keeper_id = "librarian-fact-write-failure-keeper" in
+      Unix.mkdir (Memory_io.facts_path ~keeper_id) 0o700;
+      match
+        Librarian_runtime.extract_and_append_with_exact_output
+          ~clock
+          ~net
+          ~keeper_id
+          (librarian_input "trace-fact-write-failure")
+      with
+      | Error error ->
+        Alcotest.(check bool)
+          "typed write error is returned"
+          true
+          (String.starts_with ~prefix:"memory os fact upsert failed:" error);
+        Alcotest.(check int)
+          "episode commit marker was not published"
+          0
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:10))
+      | Ok _ -> Alcotest.fail "fact upsert failure must block episode publication")))
+;;
+
+let test_zero_dispatch_failure_advances_to_next_candidate () =
+  with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
+    run_eio (fun ~sw ~net ~clock ->
+      let valid_server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply (Fixture.openai_response valid_output))
+      in
+      let slots : Fixture.target_fixture list =
+        [ { id = "librarian-unreachable"; base_url = "http://127.0.0.1:1" }
+        ; { id = "librarian-failover-success"; base_url = valid_server.base_url }
+        ]
+      in
+      publish_lane slots;
+      let keeper_id = "librarian-safe-failover-keeper" in
+      match
+        Librarian_runtime.extract_with_exact_output
+          ~clock
+          ~net
+          ~keeper_id
+          ~generation:1
+          (librarian_input "trace-safe-failover")
+      with
+      | Error error -> Alcotest.fail error
+      | Ok _ ->
+        Alcotest.(check int)
+          "next candidate received one request"
+          1
+          (Fixture.post_count valid_server);
+        Alcotest.(check string)
+          "failover receipt journal reached terminal"
+          "domain_valid"
+          (exact_journal_state ~keeper_id))))
+;;
+
+let () =
+  Alcotest.run
+    "librarian_exact_output_conformance"
+    [ ( "exact output"
+      , [ Alcotest.test_case
+            "JSON-only target is admitted and persisted"
+            `Quick
+            test_json_only_target_is_admitted_and_persisted
+        ; Alcotest.test_case
+            "missing JSON capability fails before dispatch"
+            `Quick
+            test_missing_json_capability_fails_before_dispatch
+        ; Alcotest.test_case
+            "domain-invalid output does not fail over"
+            `Quick
+            test_domain_invalid_output_does_not_fail_over
+        ; Alcotest.test_case
+            "unsettled restart state fails before dispatch"
+            `Quick
+            test_unsettled_restart_state_fails_before_dispatch
+        ; Alcotest.test_case
+            "missing clock fails before dispatch"
+            `Quick
+            test_missing_clock_fails_before_dispatch
+        ; Alcotest.test_case
+            "fact upsert failure does not publish episode"
+            `Quick
+            test_fact_upsert_failure_does_not_publish_episode
+        ; Alcotest.test_case
+            "zero-dispatch failure advances to next candidate"
+            `Quick
+            test_zero_dispatch_failure_advances_to_next_candidate
+        ] )
+    ]
+;;

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -130,7 +130,7 @@ let exact_journal_state ~keeper_id =
   | _ -> Alcotest.failf "expected one exact journal, got %d" (List.length journals)
 ;;
 
-let write_active_exact_journal ~keeper_id =
+let write_exact_journal ~keeper_id ~state =
   let exact_output_dir =
     Memory_io.episodes_dir ~keeper_id
     |> Filename.dirname
@@ -143,7 +143,7 @@ let write_active_exact_journal ~keeper_id =
       [ "schema_version", `Int 1
       ; "trace_id", `String "prior-trace"
       ; "generation", `Int 41
-      ; "state", `String "candidate_bound"
+      ; "state", `String state
       ]
     |> Yojson.Safe.to_string
   in
@@ -207,6 +207,7 @@ let test_json_only_target_is_admitted_and_persisted () =
 
 let test_missing_json_capability_fails_before_dispatch () =
   with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
     run_eio (fun ~sw ~net ~clock ->
       let response = Fixture.openai_response valid_output in
       let server = Fixture.start_server ~sw ~net ~clock (Fixture.Reply response) in
@@ -231,7 +232,7 @@ let test_missing_json_capability_fails_before_dispatch () =
         Alcotest.failf
           "expected typed exact setup failure, got %s"
           (Librarian_runtime.extraction_error_to_string error)
-      | Ok _ -> Alcotest.fail "target without a JSON guarantee must fail closed"))
+      | Ok _ -> Alcotest.fail "target without a JSON guarantee must fail closed")))
 ;;
 
 let test_domain_invalid_output_does_not_fail_over () =
@@ -304,7 +305,7 @@ let test_unsettled_restart_state_fails_before_dispatch () =
       in
       publish_lane [ slot ];
       let keeper_id = "librarian-restart-guard-keeper" in
-      write_active_exact_journal ~keeper_id;
+      write_exact_journal ~keeper_id ~state:"candidate_bound";
       match
         Librarian_runtime.extract_with_exact_output_classified
           ~clock
@@ -326,6 +327,46 @@ let test_unsettled_restart_state_fails_before_dispatch () =
           "expected typed unsettled-attempt guard, got %s"
           (Librarian_runtime.extraction_error_to_string error)
       | Ok _ -> Alcotest.fail "unsettled prior exact attempt must fail closed")))
+;;
+
+let test_oas_success_restart_state_starts_fresh_flow () =
+  with_prompt_registry (fun () ->
+  with_temp_keepers_dir (fun _ ->
+    run_eio (fun ~sw ~net ~clock ->
+      let server =
+        Fixture.start_server
+          ~sw
+          ~net
+          ~clock
+          (Fixture.Reply (Fixture.openai_response valid_output))
+      in
+      let slot : Fixture.target_fixture =
+        { id = "librarian-oas-success-restart"; base_url = server.base_url }
+      in
+      publish_lane [ slot ];
+      let keeper_id = "librarian-oas-success-restart-keeper" in
+      write_exact_journal ~keeper_id ~state:"oas_success";
+      match
+        Librarian_runtime.extract_with_exact_output_classified
+          ~clock
+          ~net
+          ~keeper_id
+          ~generation:42
+          (librarian_input "trace-after-oas-success")
+      with
+      | Error error ->
+        Alcotest.failf
+          "oas-success restart should start a fresh flow, got %s"
+          (Librarian_runtime.extraction_error_to_string error)
+      | Ok _ ->
+        Alcotest.(check int)
+          "fresh flow dispatched once"
+          1
+          (Fixture.post_count server);
+        Alcotest.(check string)
+          "fresh flow reached domain-valid terminal"
+          "domain_valid"
+          (exact_journal_state ~keeper_id))))
 ;;
 
 let test_missing_clock_fails_before_dispatch () =
@@ -453,6 +494,10 @@ let () =
             "unsettled restart state fails before dispatch"
             `Quick
             test_unsettled_restart_state_fails_before_dispatch
+        ; Alcotest.test_case
+            "OAS success restart state starts a fresh flow"
+            `Quick
+            test_oas_success_restart_state_starts_fresh_flow
         ; Alcotest.test_case
             "missing clock fails before dispatch"
             `Quick


### PR DESCRIPTION
## Summary
- remove the production Librarian Provider_config/response_format path and route extraction through the OAS `librarian_exact` flow
- persist fsync-backed candidate/receipt state, allow only OAS-proven zero-dispatch failover, and fail closed on ambiguous restart state
- treat durable `oas_success` as restart-safe because provider completion is known and no Memory OS domain write has begun
- align nullable claim fields across prompt, schema, and parser; remove the obsolete Librarian max-token env knob
- document `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` as a legacy Memory OS summary override, not an exact-extraction router
- add the GLM-5-Turbo exact target binding and focused conformance coverage

## Deployment migration
Existing runtime files are preserved. Before enabling Librarian extraction, add an explicit lane:

```toml
[runtime.exact_output_lanes.librarian_exact]
slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
```

Without the lane, bootstrap warns and Librarian fails closed before provider I/O.

The per-keeper journal is `<keepers_dir>/<keeper_id>/exact-output/librarian-exact-state.json`. `candidate_bound` and `candidate_advance_committed` remain fail-closed because their dispatch outcome cannot be reconstructed safely after restart. `oas_success` starts a fresh flow on the next cadence because the provider response completed and the journal is still before Memory OS domain writes.

## Verification
- `test_keeper_memory_os.exe`: 107 passed
- `test_keeper_structured_output_schema.exe`: 16 passed
- `test_librarian_exact_output_conformance.exe`: 8 passed
- `test_keeper_librarian_retry.exe`: 24 passed
- `test_runtime_config_validity.exe`: 44 passed
- focused build of `lib/masc.cma` and `test_server_runtime_bootstrap.exe`
- full local `@check`
- determinism, OAS-boundary, stringly-boundary, silent-failure, and MASC-domain-boundary ratchets passed

Local environment note: the installed `agent_sdk` is 0.208.22 while this head requires >=0.221.1, so focused local builds used `MASC_SKIP_PIN_CHECK=1`; PR CI remains the authoritative pin/build check.