### PR TITLE
refactor(keeper): delegate compaction failover to OAS

### DIFF
--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -9,7 +9,8 @@ type compaction_rejection =
   | Exact_admission_failed
   | Exact_attempt_start_failed
   | Exact_execution_context_unavailable
-  | Exact_execution_failed_before_dispatch
+  | Exact_execution_guard_failed
+  | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_event_queue_state.exact_execution_terminal
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error

--- a/lib/keeper/keeper_compact_rejection.ml
+++ b/lib/keeper/keeper_compact_rejection.ml
@@ -4,7 +4,8 @@ type compaction_rejection =
   | Exact_admission_failed
   | Exact_attempt_start_failed
   | Exact_execution_context_unavailable
-  | Exact_execution_failed_before_dispatch
+  | Exact_execution_guard_failed
+  | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_event_queue_state.exact_execution_terminal
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
@@ -21,7 +22,8 @@ let compaction_rejection_to_tag = function
   | Exact_admission_failed -> "exact_admission_failed"
   | Exact_attempt_start_failed -> "exact_attempt_start_failed"
   | Exact_execution_context_unavailable -> "exact_execution_context_unavailable"
-  | Exact_execution_failed_before_dispatch -> "exact_execution_failed_before_dispatch"
+  | Exact_execution_guard_failed -> "exact_execution_guard_failed"
+  | Exact_flow_already_started -> "exact_flow_already_started"
   | Exact_execution_terminal terminal ->
     Keeper_event_queue_state.exact_execution_terminal_cause_label terminal.cause
   | Invalid_compaction_plan -> "invalid_compaction_plan"
@@ -45,45 +47,20 @@ let compaction_rejection_to_string = function
   | reason -> compaction_rejection_to_tag reason
 ;;
 
-let exact_terminal_of_observation cause
-      (observation : Keeper_compaction_llm_summarizer.attempt_observation) =
-  Keeper_event_queue_state.
-    { cause
-    ; slot_id = observation.slot_id
-    ; call_id = observation.call_id
-    ; plan_fingerprint = observation.receipt_plan_fingerprint
-    ; request_body_sha256 = observation.receipt_request_body_sha256
-    }
-;;
-
 let summarization_rejection = function
   | Keeper_compaction_llm_summarizer.Exact_lane_unconfigured ->
     Exact_lane_unconfigured
   | Keeper_compaction_llm_summarizer.Exact_target_selection_failed ->
     Exact_target_selection_failed
   | Keeper_compaction_llm_summarizer.Exact_admission_failed -> Exact_admission_failed
-  | Keeper_compaction_llm_summarizer.Exact_attempt_start_failed _ ->
-    Exact_attempt_start_failed
+  | Keeper_compaction_llm_summarizer.Exact_attempt_start_failed -> Exact_attempt_start_failed
   | Keeper_compaction_llm_summarizer.Exact_execution_context_unavailable ->
     Exact_execution_context_unavailable
-  | Keeper_compaction_llm_summarizer.Exact_execution_failed_before_dispatch ->
-    Exact_execution_failed_before_dispatch
+  | Keeper_compaction_llm_summarizer.Exact_execution_guard_failed ->
+    Exact_execution_guard_failed
+  | Keeper_compaction_llm_summarizer.Exact_flow_already_started ->
+    Exact_flow_already_started
   | Keeper_compaction_llm_summarizer.Exact_execution_terminal terminal ->
     Exact_execution_terminal terminal
-  | Keeper_compaction_llm_summarizer.Exact_execution_failed_after_dispatch observation ->
-    Exact_execution_terminal
-      (exact_terminal_of_observation Execution_failed_after_dispatch observation)
-  | Keeper_compaction_llm_summarizer.Exact_attempt_already_started observation ->
-    Exact_execution_terminal
-      (exact_terminal_of_observation Attempt_already_started observation)
-  | Keeper_compaction_llm_summarizer.Exact_execution_cancelled_after_dispatch observation ->
-    Exact_execution_terminal
-      (exact_terminal_of_observation Execution_cancelled_after_dispatch observation)
-  | Keeper_compaction_llm_summarizer.Exact_execution_provenance_mismatch observation ->
-    Exact_execution_terminal
-      (exact_terminal_of_observation Execution_provenance_mismatch observation)
   | Keeper_compaction_llm_summarizer.Invalid_plan -> Invalid_compaction_plan
-  | Keeper_compaction_llm_summarizer.Invalid_plan_after_dispatch observation ->
-    Exact_execution_terminal
-      (exact_terminal_of_observation Domain_invalid_output observation)
 ;;

--- a/lib/keeper/keeper_compact_rejection.mli
+++ b/lib/keeper/keeper_compact_rejection.mli
@@ -4,7 +4,8 @@ type compaction_rejection =
   | Exact_admission_failed
   | Exact_attempt_start_failed
   | Exact_execution_context_unavailable
-  | Exact_execution_failed_before_dispatch
+  | Exact_execution_guard_failed
+  | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_event_queue_state.exact_execution_terminal
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -43,8 +43,6 @@ type exact_execution_evidence =
 type attempt_observation =
   { slot_id : string
   ; call_id : string
-  ; phase : Exact_output.effect_phase
-  ; dispatch_count : int
   ; catalog_generation_fingerprint : string
   ; receipt_plan_fingerprint : string
   ; receipt_request_body_sha256 : string
@@ -82,16 +80,12 @@ type summarization_failure =
   | Exact_lane_unconfigured
   | Exact_target_selection_failed
   | Exact_admission_failed
-  | Exact_attempt_start_failed of string
+  | Exact_attempt_start_failed
   | Exact_execution_context_unavailable
-  | Exact_execution_failed_before_dispatch
+  | Exact_execution_guard_failed
+  | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_event_queue_state.exact_execution_terminal
-  | Exact_execution_failed_after_dispatch of attempt_observation
-  | Exact_attempt_already_started of attempt_observation
-  | Exact_execution_cancelled_after_dispatch of attempt_observation
-  | Exact_execution_provenance_mismatch of attempt_observation
   | Invalid_plan
-  | Invalid_plan_after_dispatch of attempt_observation
 
 type summarizer =
   units:Keeper_compaction_unit.closed_unit list ->
@@ -381,42 +375,28 @@ let exact_output_requirement =
     ~minimum_guarantee:Exact_output.Json_syntax
 ;;
 
-type admitted_slot =
-  { slot_id : string
-  ; ready_plan : Exact_output.ready_plan
-  ; attempt : Exact_output.attempt
-  ; receipt : Exact_output.receipt
-  }
-
 type prepared_lane =
   { units : Keeper_compaction_unit.closed_unit list
-  ; admitted_slots : admitted_slot list
+  ; registry_generation : int64
+  ; ordered_slot_ids : string list
+  ; flow_attempt : Exact_output.flow_attempt
   }
 
 let call_id_to_string call_id = Exact_output.call_id_to_string call_id
 
-let observe_receipt ~slot_id receipt =
-  { slot_id
+let observe_flow_attempt_receipt
+      (candidate : Exact_output.flow_attempt_receipt)
+  =
+  let receipt = candidate.receipt in
+  { slot_id = candidate.identity.candidate_id
   ; call_id = receipt |> Exact_output.receipt_call_id |> call_id_to_string
-  ; phase = Exact_output.receipt_phase receipt
-  ; dispatch_count = Exact_output.receipt_dispatch_count receipt
   ; catalog_generation_fingerprint =
-      receipt
-      |> Exact_output.receipt_catalog_generation
+      candidate.identity.catalog_generation
       |> Exact_output.catalog_generation_fingerprint
   ; receipt_plan_fingerprint = Exact_output.receipt_plan_fingerprint receipt
   ; receipt_request_body_sha256 =
       Exact_output.receipt_request_body_sha256 receipt
   }
-;;
-
-let observe_attempt (slot : admitted_slot) =
-  observe_receipt ~slot_id:slot.slot_id slot.receipt
-;;
-
-let is_before_dispatch_zero observation =
-  observation.phase = Exact_output.Before_dispatch
-  && observation.dispatch_count = 0
 ;;
 
 let terminal_of_observation cause (observation : attempt_observation) =
@@ -427,42 +407,6 @@ let terminal_of_observation cause (observation : attempt_observation) =
     ; plan_fingerprint = observation.receipt_plan_fingerprint
     ; request_body_sha256 = observation.receipt_request_body_sha256
     }
-;;
-
-type exact_execution_release_result =
-  | Release_durable
-  | Release_failed
-  | Release_visible_terminal of Keeper_event_queue_state.exact_execution_terminal
-
-let release_exact_execution_before_dispatch
-      ~keeper_name
-      ~exact_execution_guard
-      observation
-  =
-  match exact_execution_guard with
-  | None -> Release_failed
-  | Some guard ->
-    (match guard.release_before_dispatch observation with
-     | Ok Fsync_completed -> Release_durable
-     | Ok (Visible_sync_unconfirmed detail) ->
-       Log.Keeper.error
-         ~keeper_name
-         "compaction exact pre-dispatch fence release is visible but sync is unconfirmed slot=%s call_id=%s: %s"
-         observation.slot_id
-         observation.call_id
-         detail;
-       Release_visible_terminal
-         (terminal_of_observation
-            Keeper_event_queue_state.Terminal_persistence_failed
-            observation)
-     | Error detail ->
-       Log.Keeper.error
-         ~keeper_name
-         "compaction exact pre-dispatch fence release failed slot=%s call_id=%s: %s"
-         observation.slot_id
-         observation.call_id
-         detail;
-       Release_failed)
 ;;
 
 let quarantine_exact_execution ~keeper_name ~exact_execution_guard ~cause observation =
@@ -489,11 +433,10 @@ let quarantine_exact_execution ~keeper_name ~exact_execution_guard ~cause observ
        Error detail)
 ;;
 
-let terminal_failure_after_quarantine
+let terminal_after_quarantine
       ~keeper_name
       ~exact_execution_guard
       ~cause
-      ~failure
       observation
   =
   ignore
@@ -503,7 +446,7 @@ let terminal_failure_after_quarantine
        ~cause
        observation
      : (exact_write_outcome, string) result);
-  Error failure
+  terminal_of_observation cause observation
 ;;
 
 let log_terminal_quarantine_failure
@@ -584,54 +527,38 @@ let terminalize_post_success terminalizer cause =
     terminal
 ;;
 
-let exact_execution_evidence ~slot_id ready_plan (success : Exact_output.success) =
+let exact_execution_evidence (flow_success : Exact_output.flow_success) =
+  let success = flow_success.success in
   let provenance = success.provenance in
   let identity = provenance.target_identity in
-  let receipt = success.receipt in
-  { slot_id
-  ; call_id = call_id_to_string success.call_id
+  let observation = observe_flow_attempt_receipt flow_success.candidate in
+  { slot_id = observation.slot_id
+  ; call_id = observation.call_id
   ; target_identity_fingerprint =
       Exact_output.target_identity_fingerprint identity
   ; catalog_generation_fingerprint =
       Exact_output.catalog_generation_fingerprint provenance.catalog_generation
   ; catalog_evidence_sha256 =
       Exact_output.catalog_evidence_sha256 provenance.catalog_evidence
-  ; plan_fingerprint = Exact_output.plan_fingerprint ready_plan
-  ; receipt_plan_fingerprint = Exact_output.receipt_plan_fingerprint receipt
+  ; plan_fingerprint = observation.receipt_plan_fingerprint
+  ; receipt_plan_fingerprint = observation.receipt_plan_fingerprint
   ; receipt_request_body_sha256 =
-      Exact_output.receipt_request_body_sha256 receipt
+      observation.receipt_request_body_sha256
   }
 ;;
 
-let admit_all ~keeper_name selected_slots ~messages =
-  let rec loop admitted = function
-    | [] -> Ok (List.rev admitted)
+let make_flow_candidates ~keeper_name selected_slots =
+  let rec loop candidates = function
+    | [] -> Ok (List.rev candidates)
     | (slot : Runtime_exact_output_registry.selected_slot) :: rest ->
-      (match
-         Exact_output.admit
-           ~target:slot.target
-           ~messages
-           exact_output_requirement
-       with
-       | Ok ready_plan ->
-         (match Exact_output.start_attempt ready_plan with
-          | Ok attempt ->
-            let receipt = Exact_output.attempt_receipt attempt in
-            loop
-              ({ slot_id = slot.slot_id; ready_plan; attempt; receipt } :: admitted)
-              rest
-          | Error (Exact_output.Call_id_generation_failed detail) ->
-            Log.Keeper.warn
-              ~keeper_name
-              "compaction exact attempt identity allocation failed slot=%s"
-              slot.slot_id;
-            Error (Exact_attempt_start_failed detail))
+      (match Exact_output.make_flow_candidate ~id:slot.slot_id ~target:slot.target with
+       | Ok candidate -> loop (candidate :: candidates) rest
        | Error _ ->
-         Log.Keeper.warn
+         Log.Keeper.error
            ~keeper_name
-           "compaction exact slot rejected before dispatch slot=%s"
+           "compaction exact flow candidate rejected opaque slot identity slot=%s"
            slot.slot_id;
-         loop admitted rest)
+         Error Exact_admission_failed)
   in
   loop [] selected_slots
 ;;
@@ -654,190 +581,262 @@ let prepare_lane ~keeper_name ~registry ~lane_id ~units =
     | Error
         (Runtime_exact_output_registry.No_usable_lane_slots
            { unavailable_slots; _ }) ->
-      List.iter
-        (fun unavailable ->
-           Log.Keeper.warn
-             ~keeper_name
-             "compaction exact slot unavailable generation=%Ld: %s"
-             registry_generation
-             (Runtime_exact_output_registry.unavailable_slot_to_string unavailable))
-        unavailable_slots;
+      Log.Keeper.warn
+        ~keeper_name
+        "compaction exact lane has no usable opaque slots generation=%Ld lane_id=%s unavailable_count=%d"
+        registry_generation
+        lane_id
+        (List.length unavailable_slots);
       Error Exact_target_selection_failed
     | Ok { selected_slots; unavailable_slots } ->
       List.iter
-        (fun unavailable ->
+        (fun (unavailable : Runtime_exact_output_registry.unavailable_slot) ->
            Log.Keeper.warn
              ~keeper_name
-             "compaction exact slot skipped generation=%Ld: %s"
+             "compaction exact opaque slot unavailable generation=%Ld lane_id=%s position=%d slot=%s"
              registry_generation
-             (Runtime_exact_output_registry.unavailable_slot_to_string unavailable))
+             lane_id
+             unavailable.position
+             unavailable.slot_id)
         unavailable_slots;
       let messages = messages_for_plan ~units in
-      (* Every usable candidate is admitted and starts exactly one independent
-         affine attempt before the first network effect. The attempt and its
-         receipt stay MASC-private and immutable for the lifetime of this lane. *)
-      (match admit_all ~keeper_name selected_slots ~messages with
-       | Error _ as error -> error
-       | Ok [] -> Error Exact_admission_failed
-       | Ok admitted_slots -> Ok { units; admitted_slots })
+      let* candidates = make_flow_candidates ~keeper_name selected_slots in
+      (match candidates with
+       | [] -> Error Exact_target_selection_failed
+       | first :: rest ->
+         (match
+            Exact_output.admit_flow
+              ~first
+              ~rest
+              ~messages
+              exact_output_requirement
+          with
+          | Error _ ->
+            Log.Keeper.warn
+              ~keeper_name
+              "compaction exact flow admission rejected generation=%Ld lane_id=%s candidate_count=%d"
+              registry_generation
+              lane_id
+              (List.length candidates);
+            Error Exact_admission_failed
+          | Ok ready_flow ->
+            (match Exact_output.start_flow ready_flow with
+             | Error _ ->
+               Log.Keeper.error
+                 ~keeper_name
+                 "compaction exact flow identity allocation failed generation=%Ld lane_id=%s"
+                 registry_generation
+                 lane_id;
+               Error Exact_attempt_start_failed
+             | Ok flow_attempt ->
+               Ok
+                 { units
+                 ; registry_generation
+                 ; ordered_slot_ids =
+                     List.map
+                       (fun (slot : Runtime_exact_output_registry.selected_slot) ->
+                          slot.slot_id)
+                       selected_slots
+                 ; flow_attempt
+                 })))
+;;
+
+type exact_flow_callback_failure =
+  | Bind_failed
+  | Bind_sync_unconfirmed of Keeper_event_queue_state.exact_execution_terminal
+  | Release_failed of Keeper_event_queue_state.exact_execution_terminal
+  | Release_sync_unconfirmed of Keeper_event_queue_state.exact_execution_terminal
+
+let bind_exact_execution
+      ~keeper_name
+      ~exact_execution_guard
+      observation
+  =
+  match exact_execution_guard with
+  | None ->
+    Log.Keeper.error
+      ~keeper_name
+      "compaction exact durable execution guard is unavailable slot=%s call_id=%s"
+      observation.slot_id
+      observation.call_id;
+    Error Bind_failed
+  | Some guard ->
+    (match guard.before_dispatch observation with
+     | Ok Fsync_completed -> Ok ()
+     | Error detail ->
+       Log.Keeper.error
+         ~keeper_name
+         "compaction exact durable bind failed slot=%s call_id=%s: %s"
+         observation.slot_id
+         observation.call_id
+         detail;
+       Error Bind_failed
+     | Ok (Visible_sync_unconfirmed detail) ->
+       Log.Keeper.error
+         ~keeper_name
+         "compaction exact durable bind is visible but sync is unconfirmed slot=%s call_id=%s: %s"
+         observation.slot_id
+         observation.call_id
+         detail;
+       Error
+         (Bind_sync_unconfirmed
+            (terminal_of_observation
+               Keeper_event_queue_state.Terminal_persistence_failed
+               observation)))
+;;
+
+let release_exact_execution
+      ~keeper_name
+      ~exact_execution_guard
+      observation
+  =
+  let terminal () =
+    terminal_of_observation
+      Keeper_event_queue_state.Terminal_persistence_failed
+      observation
+  in
+  match exact_execution_guard with
+  | None ->
+    Log.Keeper.error
+      ~keeper_name
+      "compaction exact durable release guard is unavailable slot=%s call_id=%s"
+      observation.slot_id
+      observation.call_id;
+    Error (Release_failed (terminal ()))
+  | Some guard ->
+    (match guard.release_before_dispatch observation with
+     | Ok Fsync_completed -> Ok ()
+     | Error detail ->
+       Log.Keeper.error
+         ~keeper_name
+         "compaction exact durable release failed slot=%s call_id=%s: %s"
+         observation.slot_id
+         observation.call_id
+         detail;
+       Error (Release_failed (terminal ()))
+     | Ok (Visible_sync_unconfirmed detail) ->
+       Log.Keeper.error
+         ~keeper_name
+         "compaction exact durable release is visible but sync is unconfirmed slot=%s call_id=%s: %s"
+         observation.slot_id
+         observation.call_id
+         detail;
+       Error (Release_sync_unconfirmed (terminal ())))
+;;
+
+let summarization_failure_of_callback = function
+  | Bind_failed -> Exact_execution_guard_failed
+  | Bind_sync_unconfirmed terminal
+  | Release_failed terminal
+  | Release_sync_unconfirmed terminal ->
+    Exact_execution_terminal terminal
 ;;
 
 let execute_prepared_lane ~keeper_name ~net ?clock ?exact_execution_guard prepared_lane =
-  let rec execute = function
-    | [] -> Error Exact_execution_failed_before_dispatch
-    | ({ slot_id; ready_plan; attempt; receipt = _ } as slot) :: rest ->
-      let handle_result = function
-        | Error
-            ({ cause = Exact_output.Attempt_already_started; receipt; _ } :
-              Exact_output.execution_error) ->
-          let observation = observe_receipt ~slot_id receipt in
-          Log.Keeper.warn
-            ~keeper_name
-            "compaction exact attempt already consumed slot=%s call_id=%s"
-            slot_id
-            observation.call_id;
-          terminal_failure_after_quarantine
-            ~keeper_name
-            ~exact_execution_guard
-            ~cause:Keeper_event_queue_state.Attempt_already_started
-            ~failure:(Exact_attempt_already_started observation)
-            observation
-        | Error ({ receipt; _ } : Exact_output.execution_error) ->
-          let observation = observe_receipt ~slot_id receipt in
-          if is_before_dispatch_zero observation
-          then (
-            Log.Keeper.warn
-              ~keeper_name
-              "compaction exact slot failed before dispatch slot=%s call_id=%s"
-              slot_id
-              observation.call_id;
-            match
-              release_exact_execution_before_dispatch
-                ~keeper_name
-                ~exact_execution_guard
-                observation
-            with
-            | Release_durable -> execute rest
-            | Release_visible_terminal terminal ->
-              Error (Exact_execution_terminal terminal)
-            | Release_failed -> Error Exact_execution_failed_before_dispatch)
-          else (
-            terminal_failure_after_quarantine
-              ~keeper_name
-              ~exact_execution_guard
-              ~cause:Keeper_event_queue_state.Execution_failed_after_dispatch
-              ~failure:(Exact_execution_failed_after_dispatch observation)
-              observation)
-        | Ok (success : Exact_output.success) ->
-          let observation = observe_attempt slot in
-          let success_call_id = call_id_to_string success.call_id in
-          let success_receipt_call_id =
-            success.receipt
-            |> Exact_output.receipt_call_id
-            |> call_id_to_string
-          in
-          if
-            not
-              (String.equal success_call_id success_receipt_call_id
-               && String.equal success_call_id observation.call_id)
-          then (
-            terminal_failure_after_quarantine
-              ~keeper_name
-              ~exact_execution_guard
-              ~cause:Keeper_event_queue_state.Execution_provenance_mismatch
-              ~failure:(Exact_execution_provenance_mismatch observation)
-              observation)
-          else
-            (match plan_of_json ~units:prepared_lane.units success.output with
-             | Error detail ->
-               Log.Keeper.warn
-                 ~keeper_name
-                 "compaction exact output violated domain plan slot=%s call_id=%s: %s"
-                 slot_id
-                 observation.call_id
-                 detail;
-               terminal_failure_after_quarantine
+  let bound_observation = ref None in
+  let before_dispatch candidate =
+    let observation = observe_flow_attempt_receipt candidate in
+    match bind_exact_execution ~keeper_name ~exact_execution_guard observation with
+    | Error _ as error -> error
+    | Ok () ->
+      bound_observation := Some observation;
+      Ok ()
+  in
+  let before_advance ~failed ~failure:_ ~next:_ =
+    let observation = observe_flow_attempt_receipt failed in
+    match release_exact_execution ~keeper_name ~exact_execution_guard observation with
+    | Error _ as error -> error
+    | Ok () ->
+      bound_observation := None;
+      Ok ()
+  in
+  let execution =
+    try
+      `Flow
+        (Exact_output.execute_flow_once
+           ~net
+           ?clock
+           ~before_dispatch
+           ~before_advance
+           prepared_lane.flow_attempt)
+    with
+    | Eio.Cancel.Cancelled _ as cancellation ->
+      Eio.Cancel.protect
+      @@ fun () ->
+      (match !bound_observation with
+       | None -> raise cancellation
+       | Some observation ->
+         Log.Keeper.warn
+           ~keeper_name
+           "compaction exact cancellation quarantines only the durably bound identity slot=%s call_id=%s"
+           observation.slot_id
+           observation.call_id;
+         `Failure
+           (Exact_execution_terminal
+              (terminal_after_quarantine
                  ~keeper_name
                  ~exact_execution_guard
-                 ~cause:Keeper_event_queue_state.Domain_invalid_output
-                 ~failure:(Invalid_plan_after_dispatch observation)
-                 observation
-             | Ok plan ->
-               (match exact_execution_guard with
-                | None -> Error Exact_execution_failed_before_dispatch
-                | Some exact_execution_guard ->
-                  Ok
-                    { plan
-                    ; exact_execution_evidence =
-                        exact_execution_evidence ~slot_id ready_plan success
-                    ; post_success_terminalizer =
-                        { keeper_name
-                        ; exact_execution_guard
-                        ; attempt_observation = observation
-                        ; terminalization_mutex = Eio.Mutex.create ()
-                        ; canonical_terminal = None
-                        }
-                    }))
-      in
-      let initial_observation = observe_attempt slot in
-      (match exact_execution_guard with
-       | Some guard ->
-         (match guard.before_dispatch initial_observation with
-          | Error detail ->
-            Log.Keeper.error
-              ~keeper_name
-              "compaction exact pre-dispatch fence commit failed slot=%s call_id=%s: %s"
-              slot_id
-              initial_observation.call_id
-              detail;
-            Error Exact_execution_failed_before_dispatch
-          | Ok (Visible_sync_unconfirmed detail) ->
-            Log.Keeper.error
-              ~keeper_name
-              "compaction exact pre-dispatch binding is visible but sync is unconfirmed; refusing POST and terminally settling the source slot=%s call_id=%s: %s"
-              slot_id
-              initial_observation.call_id
-              detail;
-            Error
-              (Exact_execution_terminal
-                 (terminal_of_observation
-                    Keeper_event_queue_state.Terminal_persistence_failed
-                    initial_observation))
-          | Ok Fsync_completed ->
-            (try handle_result (Exact_output.execute_once ~net ?clock attempt) with
-             | Eio.Cancel.Cancelled _ as cancellation ->
-               Eio.Cancel.protect
-               @@ fun () ->
-               let observation = observe_attempt slot in
-               if is_before_dispatch_zero observation
-               then (
-                 match
-                   release_exact_execution_before_dispatch
-                     ~keeper_name
-                     ~exact_execution_guard
-                     observation
-                 with
-                 | Release_visible_terminal terminal ->
-                   (* The binding removal is already visible. Consume
-                      cancellation only here so the original identity remains
-                      available for source-bound terminal settlement. *)
-                   Error (Exact_execution_terminal terminal)
-                 | Release_durable | Release_failed -> raise cancellation)
-               else (
-                 Log.Keeper.warn
-                   ~keeper_name
-                   "compaction exact cancellation became terminal slot=%s call_id=%s"
-                   slot_id
-                   observation.call_id;
-                 terminal_failure_after_quarantine
-                   ~keeper_name
-                   ~exact_execution_guard
-                   ~cause:Keeper_event_queue_state.Execution_cancelled_after_dispatch
-                   ~failure:(Exact_execution_cancelled_after_dispatch observation)
-                   observation)))
-       | None -> Error Exact_execution_failed_before_dispatch)
+                 ~cause:Keeper_event_queue_state.Exact_execution_cancelled
+                 observation)))
   in
-  execute prepared_lane.admitted_slots
+  match execution with
+  | `Failure failure -> Error failure
+  | `Flow (Error (Exact_output.Flow_attempt_already_started _)) ->
+    Error Exact_flow_already_started
+  | `Flow
+      (Error
+        (Exact_output.Flow_before_dispatch_callback_failed
+          { cause; _ })) ->
+    Error (summarization_failure_of_callback cause)
+  | `Flow
+      (Error
+        (Exact_output.Flow_before_advance_callback_failed
+          { cause; _ })) ->
+    Error (summarization_failure_of_callback cause)
+  | `Flow
+      (Error
+        (Exact_output.Flow_exact_execution_failed
+          { candidate; _ })) ->
+    let observation = observe_flow_attempt_receipt candidate in
+    Error
+      (Exact_execution_terminal
+         (terminal_after_quarantine
+            ~keeper_name
+            ~exact_execution_guard
+            ~cause:Keeper_event_queue_state.Exact_execution_failed
+            observation))
+  | `Flow (Ok (flow_success : Exact_output.flow_success)) ->
+    let observation = observe_flow_attempt_receipt flow_success.candidate in
+    (match plan_of_json ~units:prepared_lane.units flow_success.success.output with
+     | Error detail ->
+       Log.Keeper.warn
+         ~keeper_name
+         "compaction exact output violated MASC domain plan slot=%s call_id=%s: %s"
+         observation.slot_id
+         observation.call_id
+         detail;
+       Error
+         (Exact_execution_terminal
+            (terminal_after_quarantine
+               ~keeper_name
+               ~exact_execution_guard
+               ~cause:Keeper_event_queue_state.Domain_invalid_output
+               observation))
+     | Ok plan ->
+       (match exact_execution_guard with
+        | None -> Error Exact_execution_guard_failed
+        | Some exact_execution_guard ->
+          Ok
+            { plan
+            ; exact_execution_evidence = exact_execution_evidence flow_success
+            ; post_success_terminalizer =
+                { keeper_name
+                ; exact_execution_guard
+                ; attempt_observation = observation
+                ; terminalization_mutex = Eio.Mutex.create ()
+                ; canonical_terminal = None
+                }
+            }))
 ;;
 
 let run_exact ?exact_execution_guard ~keeper_name ~sw:_ ~net ~clock ~units () =
@@ -914,11 +913,13 @@ let exact_execution_evidence_receipt_request_body_sha256
 module For_testing = struct
   let messages_for_plan = messages_for_plan
 
-  let admitted_slot_ids prepared_lane =
-    List.map (fun (slot : admitted_slot) -> slot.slot_id) prepared_lane.admitted_slots
-  ;;
+  let flow_slot_ids prepared_lane = prepared_lane.ordered_slot_ids
+  let registry_generation prepared_lane = prepared_lane.registry_generation
 
   let attempt_observations prepared_lane =
-    List.map observe_attempt prepared_lane.admitted_slots
+    let evidence : Exact_output.flow_evidence =
+      Exact_output.flow_attempt_evidence prepared_lane.flow_attempt
+    in
+    List.map observe_flow_attempt_receipt evidence.attempts
   ;;
 end

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -763,6 +763,12 @@ let execute_prepared_lane ~keeper_name ~net ?clock ?exact_execution_guard prepar
     | Eio.Cancel.Cancelled _ as cancellation ->
       Eio.Cancel.protect
       @@ fun () ->
+      (* A durable bind is MASC's only ownership signal. MASC deliberately does
+         not inspect OAS receipt phase/count after cancellation. If OAS had
+         proved safe advancement it would first invoke [before_advance], whose
+         fsynced release clears [bound_observation]. Therefore a still-bound
+         identity is always source-terminal; a pre-bind cancellation is
+         re-raised. *)
       (match !bound_observation with
        | None -> raise cancellation
        | Some observation ->

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -15,8 +15,6 @@ type prepared_lane
 type attempt_observation =
   { slot_id : string
   ; call_id : string
-  ; phase : Agent_sdk.Exact_output.effect_phase
-  ; dispatch_count : int
   ; catalog_generation_fingerprint : string
   ; receipt_plan_fingerprint : string
   ; receipt_request_body_sha256 : string
@@ -39,36 +37,33 @@ type exact_execution_guard =
     payload and parent [Unix.fsync] returned and supports process-restart
     safety, not hardware/power-loss persistence or Darwin [F_FULLFSYNC].
     Visible uncertainty returns a source-bound terminal without POST.
-    [release_before_dispatch] permits the next slot only after
-    [Fsync_completed]; visible removal returns a terminal for the original
-    slot/call and does not fail over. A visible [quarantine] preserves the
-    original post-dispatch terminal cause for source-bound settlement. None of
-    these callbacks performs POST. *)
+    [release_before_dispatch] is invoked only for the failed identity selected
+    by OAS and permits OAS to advance only after [Fsync_completed]. Visible or
+    failed removal returns a terminal for that identity and cannot dispatch its
+    successor. A visible [quarantine] preserves the original terminal cause for
+    source-bound settlement. None of these callbacks selects a successor or
+    performs POST. *)
 
 type summarization_failure =
   | Exact_lane_unconfigured
   | Exact_target_selection_failed
   | Exact_admission_failed
-  | Exact_attempt_start_failed of string
+  | Exact_attempt_start_failed
   | Exact_execution_context_unavailable
-  | Exact_execution_failed_before_dispatch
+  | Exact_execution_guard_failed
+  | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_event_queue_state.exact_execution_terminal
-  | Exact_execution_failed_after_dispatch of attempt_observation
-  | Exact_attempt_already_started of attempt_observation
-  | Exact_execution_cancelled_after_dispatch of attempt_observation
-  | Exact_execution_provenance_mismatch of attempt_observation
   | Invalid_plan
-  | Invalid_plan_after_dispatch of attempt_observation
 
 type summarizer =
   units:Keeper_compaction_unit.closed_unit list ->
   (completed_plan, summarization_failure) result
 
-(** Pure lane lookup, selection, and admission against exactly one
-    caller-supplied immutable registry. Every candidate is considered in
-    declaration order, all admitted plans and their real receipts are retained
-    before any network effect, and the returned lane is abstract so callers
-    cannot replace ready plans. *)
+(** Pure lane lookup and construction of one immutable OAS exact flow against
+    exactly one caller-supplied registry generation. MASC supplies only ordered
+    opaque slot identities and domain messages/schema. OAS performs candidate
+    admission and allocates every non-shared affine attempt before any network
+    effect. *)
 val prepare_lane
   :  keeper_name:string
   -> registry:Runtime_exact_output_registry.t
@@ -76,11 +71,12 @@ val prepare_lane
   -> units:Keeper_compaction_unit.closed_unit list
   -> (prepared_lane, summarization_failure) result
 
-(** Execute each retained OAS attempt at most once. Only a real receipt at
-    [Before_dispatch] with dispatch count zero advances to the next slot.
-    Pre-dispatch cancellation is re-raised. Post-dispatch cancellation,
-    duplicate execution, provenance mismatch, dispatched failure, and a
-    MASC-invalid domain plan are typed terminal outcomes and never fail over. *)
+(** Execute the immutable OAS flow exactly once. OAS exclusively decides
+    whether an execution failure can advance and supplies the predetermined
+    successor. MASC only durably binds the supplied identity, durably releases
+    the failed identity, and quarantines source-bound terminal identities.
+    MASC never reads receipt phase/count or provider/admission failure causes.
+    Domain-invalid output is terminal and cannot enter OAS failover. *)
 val execute_prepared_lane
   :  keeper_name:string
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -89,12 +85,10 @@ val execute_prepared_lane
   -> prepared_lane
   -> (completed_plan, summarization_failure) result
 
-(** Resolve [compaction_exact] from one published immutable registry, admit all
-    resolved slots for valid JSON syntax before dispatch, then execute each
-    admitted plan at most once. OAS guarantees JSON syntax; [plan_of_json]
-    enforces the MASC-owned compaction schema and domain rules. Invalid domain
-    output is terminal and never advances to another slot. Only a receipt still
-    at [Before_dispatch] with dispatch count zero permits advancing. *)
+(** Resolve [compaction_exact] from one published immutable registry and hand
+    its ordered opaque slots to one OAS exact flow. OAS owns admission,
+    execute-once, advancement, and provenance. [plan_of_json] alone enforces the
+    MASC-owned compaction schema and domain rules after success. *)
 val make : ?exact_execution_guard:exact_execution_guard -> keeper_name:string -> unit -> summarizer option
 
 val has_eligible_units : Keeper_compaction_unit.closed_unit list -> bool
@@ -141,7 +135,8 @@ module For_testing : sig
     :  units:Keeper_compaction_unit.closed_unit list
     -> Agent_sdk.Types.message list
 
-  val admitted_slot_ids : prepared_lane -> string list
+  val flow_slot_ids : prepared_lane -> string list
+  val registry_generation : prepared_lane -> int64
 
   val attempt_observations : prepared_lane -> attempt_observation list
 end

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -76,6 +76,10 @@ val prepare_lane
     successor. MASC only durably binds the supplied identity, durably releases
     the failed identity, and quarantines source-bound terminal identities.
     MASC never reads receipt phase/count or provider/admission failure causes.
+    Cancellation before a durable bind is re-raised. Once a durable bind exists,
+    cancellation is a phase-neutral source-bound terminal unless OAS first
+    invokes [release_before_dispatch]; MASC never reconstructs dispatch state
+    from cancellation or receipt details.
     Domain-invalid output is terminal and cannot enter OAS failover. *)
 val execute_prepared_lane
   :  keeper_name:string

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -785,7 +785,7 @@ let settlement_is_exact_output_cancellation = function
       { reason =
           Keeper_event_queue_state.Exact_execution_terminal
             { cause =
-                ( Keeper_event_queue_state.Execution_cancelled_after_dispatch
+                ( Keeper_event_queue_state.Exact_execution_cancelled
                 | Keeper_event_queue_state.Terminal_persistence_failed )
             ; _
             }
@@ -796,7 +796,7 @@ let settlement_is_exact_output_cancellation = function
           Keeper_registry_event_queue.Compaction_exact_output_terminal
             { terminal =
                 { cause =
-                    ( Keeper_event_queue_state.Execution_cancelled_after_dispatch
+                    ( Keeper_event_queue_state.Exact_execution_cancelled
                     | Keeper_event_queue_state.Terminal_persistence_failed )
                 ; _
                 }
@@ -813,7 +813,7 @@ let settlement_is_exact_output_cancellation = function
   | Keeper_registry_event_queue.Settle_exact
       { outcome =
           Keeper_registry_event_queue.Terminal
-            ( Keeper_event_queue_state.Execution_cancelled_after_dispatch
+            ( Keeper_event_queue_state.Exact_execution_cancelled
             | Keeper_event_queue_state.Terminal_persistence_failed )
       ; _
       } ->

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -219,7 +219,7 @@ let no_compaction_after_prepared_cancellation prepared =
   Eio.Cancel.protect (fun () ->
     No_compaction
       (Keeper_post_turn.no_compaction_of_uncommitted_prepared
-         ~cause:Keeper_event_queue_state.Execution_cancelled_after_dispatch
+         ~cause:Keeper_event_queue_state.Exact_execution_cancelled
          prepared))
 ;;
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -508,7 +508,9 @@ let terminal_reason_of_rejection = function
   | Exact_admission_failed
   | Exact_attempt_start_failed
   | Exact_execution_context_unavailable
-  | Exact_execution_failed_before_dispatch -> None
+  | Exact_execution_guard_failed
+  | Exact_flow_already_started ->
+    None
 ;;
 
 type prepared_compaction =
@@ -761,7 +763,7 @@ let commit_prepared_compaction (prepared : prepared_compaction)
        terminal Keeper_event_queue_state.Invalid_structural_source_after_dispatch
    with
    | Eio.Cancel.Cancelled _ ->
-     terminal Keeper_event_queue_state.Execution_cancelled_after_dispatch
+     terminal Keeper_event_queue_state.Exact_execution_cancelled
    | exn ->
      let detail = Printexc.to_string exn in
      log_keeper_exn ~label:"compaction checkpoint save exception" exn;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -19,10 +19,8 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Context_compaction_retry
 
 type exact_execution_terminal_cause = Keeper_event_queue_persistence.exact_execution_terminal_cause =
-  | Execution_failed_after_dispatch
-  | Attempt_already_started
-  | Execution_cancelled_after_dispatch
-  | Execution_provenance_mismatch
+  | Exact_execution_failed
+  | Exact_execution_cancelled
   | Domain_invalid_output
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.ml
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.ml
@@ -3,10 +3,8 @@ module Make (Publish : sig
   end) =
 struct
   type exact_execution_terminal_cause = Keeper_event_queue_persistence.exact_execution_terminal_cause =
-    | Execution_failed_after_dispatch
-    | Attempt_already_started
-    | Execution_cancelled_after_dispatch
-    | Execution_provenance_mismatch
+    | Exact_execution_failed
+    | Exact_execution_cancelled
     | Domain_invalid_output
     | Invalid_structural_evidence
     | Invalid_structural_source_after_dispatch

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.mli
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.mli
@@ -3,10 +3,8 @@ module Make (Publish : sig
   end) : sig
   type exact_execution_terminal_cause =
     Keeper_event_queue_persistence.exact_execution_terminal_cause =
-    | Execution_failed_after_dispatch
-    | Attempt_already_started
-    | Execution_cancelled_after_dispatch
-    | Execution_provenance_mismatch
+    | Exact_execution_failed
+    | Exact_execution_cancelled
     | Domain_invalid_output
     | Invalid_structural_evidence
     | Invalid_structural_source_after_dispatch

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -136,7 +136,8 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Retry_suspended _ -> Precondition_failed
     | Compaction_rejected Exact_execution_context_unavailable
     | Compaction_rejected Exact_attempt_start_failed
-    | Compaction_rejected Exact_execution_failed_before_dispatch
+    | Compaction_rejected Exact_execution_guard_failed
+    | Compaction_rejected Exact_flow_already_started
     | Compaction_rejected (Exact_execution_terminal _)
     | Compaction_rejected Invalid_compaction_plan
     | Compaction_rejected (Invalid_structural_evidence _)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -16,10 +16,8 @@ type requeue_reason = State.requeue_reason =
   | Context_compaction_retry
 
 type exact_execution_terminal_cause = State.exact_execution_terminal_cause =
-  | Execution_failed_after_dispatch
-  | Attempt_already_started
-  | Execution_cancelled_after_dispatch
-  | Execution_provenance_mismatch
+  | Exact_execution_failed
+  | Exact_execution_cancelled
   | Domain_invalid_output
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -22,10 +22,8 @@ type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Context_compaction_retry
 
 type exact_execution_terminal_cause = Keeper_event_queue_state.exact_execution_terminal_cause =
-  | Execution_failed_after_dispatch
-  | Attempt_already_started
-  | Execution_cancelled_after_dispatch
-  | Execution_provenance_mismatch
+  | Exact_execution_failed
+  | Exact_execution_cancelled
   | Domain_invalid_output
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -13,10 +13,8 @@ type requeue_reason =
   | Context_compaction_retry
 
 type exact_execution_terminal_cause =
-  | Execution_failed_after_dispatch
-  | Attempt_already_started
-  | Execution_cancelled_after_dispatch
-  | Execution_provenance_mismatch
+  | Exact_execution_failed
+  | Exact_execution_cancelled
   | Domain_invalid_output
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
@@ -440,10 +438,8 @@ let requeue_reason_of_label = function
 let ( let* ) = Result.bind
 
 let exact_execution_terminal_cause_label = function
-  | Execution_failed_after_dispatch -> "execution_failed_after_dispatch"
-  | Attempt_already_started -> "attempt_already_started"
-  | Execution_cancelled_after_dispatch -> "execution_cancelled_after_dispatch"
-  | Execution_provenance_mismatch -> "execution_provenance_mismatch"
+  | Exact_execution_failed -> "exact_execution_failed"
+  | Exact_execution_cancelled -> "exact_execution_cancelled"
   | Domain_invalid_output -> "domain_invalid_output"
   | Invalid_structural_evidence -> "invalid_structural_evidence"
   | Invalid_structural_source_after_dispatch ->
@@ -457,11 +453,8 @@ let exact_execution_terminal_cause_label = function
 ;;
 
 let exact_execution_terminal_cause_of_label = function
-  | "execution_failed_after_dispatch" -> Ok Execution_failed_after_dispatch
-  | "attempt_already_started" -> Ok Attempt_already_started
-  | "execution_cancelled_after_dispatch" ->
-    Ok Execution_cancelled_after_dispatch
-  | "execution_provenance_mismatch" -> Ok Execution_provenance_mismatch
+  | "exact_execution_failed" -> Ok Exact_execution_failed
+  | "exact_execution_cancelled" -> Ok Exact_execution_cancelled
   | "domain_invalid_output" -> Ok Domain_invalid_output
   | "invalid_structural_evidence" -> Ok Invalid_structural_evidence
   | "invalid_structural_source_after_dispatch" ->

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -20,10 +20,8 @@ type requeue_reason =
   | Context_compaction_retry
 
 type exact_execution_terminal_cause =
-  | Execution_failed_after_dispatch
-  | Attempt_already_started
-  | Execution_cancelled_after_dispatch
-  | Execution_provenance_mismatch
+  | Exact_execution_failed
+  | Exact_execution_cancelled
   | Domain_invalid_output
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch

--- a/scripts/check-compaction-exact-flow-boundary.sh
+++ b/scripts/check-compaction-exact-flow-boundary.sh
@@ -52,8 +52,26 @@ check_boundary() {
   local provenance_label="execution_provenance_"'mismatch'
   local attempt_label="attempt_already_"'started'
   local old_pattern
+  local legacy_label_candidates
+  local legacy_label_targets=()
   old_pattern="${failed_after}|${failed_before}|${cancelled_after}|${lower_failed_after}|${lower_failed_before}|${lower_cancelled_after}|${attempt_constructor}|${exact_attempt_constructor}|${provenance_constructor}|${exact_provenance_constructor}|\"${provenance_label}\"|\"${attempt_label}\""
-  if rg -n "${old_pattern}" "${REPO_ROOT}/lib" "${REPO_ROOT}/test"; then
+  legacy_label_candidates=(
+    "${TARGET}"
+    "${REPO_ROOT}/lib/keeper/keeper_compaction_llm_summarizer.mli"
+    "${REPO_ROOT}/lib/keeper/keeper_registry_event_queue_exact_execution.ml"
+    "${REPO_ROOT}/lib/keeper/keeper_registry_event_queue_exact_execution.mli"
+    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_persistence.ml"
+    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_persistence.mli"
+    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_state.ml"
+    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_state.mli"
+    "${REPO_ROOT}/test/test_compaction_exact_output_conformance.ml"
+    "${REPO_ROOT}/test/test_keeper_event_queue_state_v2.ml"
+    "${REPO_ROOT}/test/test_keeper_exact_execution_lease_guard.ml"
+  )
+  for candidate in "${legacy_label_candidates[@]}"; do
+    [[ -f "${candidate}" ]] && legacy_label_targets+=("${candidate}")
+  done
+  if rg -n "${old_pattern}" "${legacy_label_targets[@]}"; then
     fail "retired receipt-phase or legacy durable terminal label remains"
   fi
 

--- a/scripts/check-compaction-exact-flow-boundary.sh
+++ b/scripts/check-compaction-exact-flow-boundary.sh
@@ -90,6 +90,9 @@ let _ = Exact_output.admit_flow
 let _ = Exact_output.start_flow
 let _ = Exact_output.execute_flow_once
 EOF
+  printf '%s\n' \
+    'let _ = Exact_attempt_already_started' \
+    >"${fixture}/lib/keeper/keeper_librarian_runtime.ml"
 
   MASC_COMPACTION_BOUNDARY_ROOT="${fixture}" \
     MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
@@ -103,7 +106,8 @@ EOF
   then
     fail "self-test forbidden receipt inspection unexpectedly passed"
   fi
-  echo "[compaction-exact-flow-boundary:self-test] clean=pass forbidden=fail"
+  echo \
+    "[compaction-exact-flow-boundary:self-test] clean=pass unrelated=pass forbidden=fail"
 }
 
 case "${1:-}" in

--- a/scripts/check-compaction-exact-flow-boundary.sh
+++ b/scripts/check-compaction-exact-flow-boundary.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${MASC_COMPACTION_BOUNDARY_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+TARGET="${MASC_COMPACTION_EXACT_FLOW_TARGET:-${REPO_ROOT}/lib/keeper/keeper_compaction_llm_summarizer.ml}"
+
+fail() {
+  echo "[compaction-exact-flow-boundary] $*" >&2
+  exit 1
+}
+
+count_fixed() {
+  local token="$1"
+  { rg -o --fixed-strings "${token}" "${TARGET}" 2>/dev/null || true; } \
+    | wc -l \
+    | tr -d ' '
+}
+
+require_once() {
+  local token="$1"
+  local count
+  count="$(count_fixed "${token}")"
+  [[ "${count}" == "1" ]] \
+    || fail "expected exactly one ${token} call in ${TARGET}, found ${count}"
+}
+
+check_boundary() {
+  [[ -f "${TARGET}" ]] || fail "target not found: ${TARGET}"
+
+  require_once "Exact_output.make_flow_candidate"
+  require_once "Exact_output.admit_flow"
+  require_once "Exact_output.start_flow"
+  require_once "Exact_output.execute_flow_once"
+
+  local forbidden_pattern
+  forbidden_pattern='Exact_output\.admit([^_[:alnum:]]|$)|Exact_output\.(start_attempt|execute_once|receipt_phase|receipt_dispatch_count)|Exact_output\.effect_phase|type admitted_slot|is_before_dispatch_zero|ready_plan'
+  if rg -n "${forbidden_pattern}" "${TARGET}"; then
+    fail "MASC-local exact admission/attempt/receipt control flow is forbidden"
+  fi
+
+  local failed_after="Execution_failed_"'after_dispatch'
+  local failed_before="Exact_execution_failed_"'before_dispatch'
+  local cancelled_after="Execution_cancelled_"'after_dispatch'
+  local lower_failed_after="execution_failed_"'after_dispatch'
+  local lower_failed_before="exact_execution_failed_"'before_dispatch'
+  local lower_cancelled_after="execution_cancelled_"'after_dispatch'
+  local attempt_constructor="Attempt_already_"'started'
+  local exact_attempt_constructor="Exact_attempt_already_"'started'
+  local provenance_constructor="Execution_provenance_"'mismatch'
+  local exact_provenance_constructor="Exact_execution_provenance_"'mismatch'
+  local provenance_label="execution_provenance_"'mismatch'
+  local attempt_label="attempt_already_"'started'
+  local old_pattern
+  old_pattern="${failed_after}|${failed_before}|${cancelled_after}|${lower_failed_after}|${lower_failed_before}|${lower_cancelled_after}|${attempt_constructor}|${exact_attempt_constructor}|${provenance_constructor}|${exact_provenance_constructor}|\"${provenance_label}\"|\"${attempt_label}\""
+  if rg -n "${old_pattern}" "${REPO_ROOT}/lib" "${REPO_ROOT}/test"; then
+    fail "retired receipt-phase or legacy durable terminal label remains"
+  fi
+
+  echo "[compaction-exact-flow-boundary] OK"
+}
+
+self_test() {
+  local fixture target
+  fixture="$(mktemp -d "${TMPDIR:-/tmp}/compaction-exact-flow-boundary.XXXXXX")"
+  trap "rm -rf '${fixture}'" EXIT
+  mkdir -p "${fixture}/lib/keeper" "${fixture}/test"
+  target="${fixture}/lib/keeper/keeper_compaction_llm_summarizer.ml"
+  cat >"${target}" <<'EOF'
+let _ = Exact_output.make_flow_candidate
+let _ = Exact_output.admit_flow
+let _ = Exact_output.start_flow
+let _ = Exact_output.execute_flow_once
+EOF
+
+  MASC_COMPACTION_BOUNDARY_ROOT="${fixture}" \
+    MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
+    "${BASH_SOURCE[0]}" --check-only >/dev/null
+
+  printf '%s\n' 'let _ = Exact_output.receipt_phase' >>"${target}"
+  if
+    MASC_COMPACTION_BOUNDARY_ROOT="${fixture}" \
+      MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
+      "${BASH_SOURCE[0]}" --check-only >/dev/null 2>&1
+  then
+    fail "self-test forbidden receipt inspection unexpectedly passed"
+  fi
+  echo "[compaction-exact-flow-boundary:self-test] clean=pass forbidden=fail"
+}
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    ;;
+  --check-only | "")
+    check_boundary
+    ;;
+  *)
+    fail "usage: $0 [--self-test|--check-only]"
+    ;;
+esac

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -51,6 +51,8 @@ blocking_lints() {
   run_lint "Tool substrate adapter surface" bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
   run_lint "Tool -> Keeper dependency-direction ratchet (RFC-0194)" bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
   run_lint "MASC domain ownership ratchet" bash scripts/lint/masc-domain-boundary-ratchet.sh --fail
+  run_lint "Compaction exact-flow boundary self-test" bash scripts/check-compaction-exact-flow-boundary.sh --self-test
+  run_lint "Compaction exact-flow boundary" bash scripts/check-compaction-exact-flow-boundary.sh
   run_lint "No Tool_result.error + Printexc (RFC-0148)" bash scripts/lint/no-tool-result-error-printexc.sh
   run_lint "Boundary redaction SSOT (RFC-0132 PR-3)" bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
   run_lint "No fabricated telemetry" bash scripts/lint/no-fabricated-telemetry.sh

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -430,6 +430,31 @@ let test_bind_failure_prevents_post () =
   Alcotest.(check int) "bind failure prevents POST" 0 (F.post_count server)
 ;;
 
+let test_missing_dispatch_guard_prevents_post () =
+  run_eio
+  @@ fun ~sw ~net ~clock ->
+  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let slot_id = "missing-dispatch-guard" in
+  let snapshot =
+    F.resolver_snapshot
+      ~source:"masc missing dispatch guard"
+      [ { id = slot_id; base_url = server.base_url } ]
+  in
+  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+  let prepared = prepare_exn ~keeper_name:"keeper-missing-guard" ~registry in
+  (match
+     C.execute_prepared_lane
+       ~keeper_name:"keeper-missing-guard"
+       ~net
+       ~clock
+       prepared
+   with
+   | Error C.Exact_execution_guard_failed -> ()
+   | Error _ -> Alcotest.fail "missing guard returned the wrong typed failure"
+   | Ok _ -> Alcotest.fail "missing guard unexpectedly executed");
+  Alcotest.(check int) "missing guard prevents POST" 0 (F.post_count server)
+;;
+
 let test_release_failure_blocks_successor () =
   run_eio
   @@ fun ~sw ~net ~clock ->
@@ -1486,6 +1511,10 @@ let () =
             "bind failure prevents POST"
             `Quick
             test_bind_failure_prevents_post
+        ; Alcotest.test_case
+            "missing guard prevents POST"
+            `Quick
+            test_missing_dispatch_guard_prevents_post
         ; Alcotest.test_case
             "release failure blocks successor"
             `Quick

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -1,19 +1,20 @@
-(** Composition-level conformance for the MASC compaction exact-output lane.
+(** MASC-owned composition proof for the compaction OAS exact-flow boundary.
 
-    These tests use real OAS resolver snapshots, ready plans, receipts, and
-    local HTTP effects. They intentionally do not repeat provider codec or
-    resolver validation coverage owned by OAS. *)
+    OAS owns admission, affine attempts, execute-once, advancement, and receipt
+    semantics. These tests observe only MASC-owned ordered opaque slot identity,
+    durable bind/release/quarantine callbacks, domain validation, registry
+    generation, and source terminalization. *)
 
 open Masc
+
 module C = Keeper_compaction_llm_summarizer
-module EO = Agent_sdk.Exact_output
+module F = Compaction_exact_output_fixture
+module P = Keeper_event_queue_persistence
+module Q = Keeper_event_queue
 module Registry = Runtime_exact_output_registry
 module S = Keeper_structured_output_schema
 module T = Agent_sdk.Types
 module U = Keeper_compaction_unit
-module F = Compaction_exact_output_fixture
-module P = Keeper_event_queue_persistence
-module Q = Keeper_event_queue
 
 exception Cancel_after_request_arrived
 
@@ -125,18 +126,11 @@ let settle_terminal_disposition_result
     ()
 ;;
 
-let permissive_exact_execution_guard : C.exact_execution_guard =
-  { before_dispatch = (fun _ -> Ok C.Fsync_completed)
-  ; release_before_dispatch = (fun _ -> Ok C.Fsync_completed)
-  ; quarantine = (fun _ _ -> Ok C.Fsync_completed)
-  }
-;;
-
 let execute_prepared_lane
       ~keeper_name
       ~net
       ?clock
-      ?(exact_execution_guard = permissive_exact_execution_guard)
+      ?(exact_execution_guard = F.permissive_exact_execution_guard)
       prepared_lane
   =
   C.execute_prepared_lane
@@ -205,12 +199,12 @@ let prepare_exn ~keeper_name ~registry =
       ~units
   with
   | Ok prepared -> prepared
-  | Error _ -> Alcotest.fail "compaction lane preparation failed"
+  | Error _ -> Alcotest.fail "compaction flow preparation failed"
 ;;
 
 let completed_exn = function
   | Ok completed -> completed
-  | Error _ -> Alcotest.fail "compaction lane execution failed"
+  | Error _ -> Alcotest.fail "compaction flow execution failed"
 ;;
 
 let observation_exn prepared slot_id =
@@ -219,44 +213,29 @@ let observation_exn prepared slot_id =
     String.equal observation.slot_id slot_id)
   |> function
   | Some observation -> observation
-  | None -> Alcotest.failf "missing retained receipt observation for %s" slot_id
+  | None -> Alcotest.failf "missing OAS flow attempt identity for %s" slot_id
 ;;
 
-let check_observation
-      ~label
-      ~phase
-      ~dispatch_count
-      ?catalog_generation_fingerprint
-      observation
-  =
+let check_identity label (observation : C.attempt_observation) =
   Alcotest.(check bool)
-    (label ^ " call id retained")
+    (label ^ " call id")
     true
-    (String.trim observation.C.call_id <> "");
+    (String.trim observation.call_id <> "");
   Alcotest.(check bool)
-    (label ^ " receipt plan fingerprint retained")
+    (label ^ " catalog generation")
+    true
+    (String.trim observation.catalog_generation_fingerprint <> "");
+  Alcotest.(check bool)
+    (label ^ " plan identity")
     true
     (String.trim observation.receipt_plan_fingerprint <> "");
   Alcotest.(check bool)
-    (label ^ " receipt request hash retained")
+    (label ^ " request identity")
     true
-    (String.trim observation.receipt_request_body_sha256 <> "");
-  Alcotest.(check bool)
-    (label ^ " phase")
-    true
-    (observation.C.phase = phase);
-  Alcotest.(check int)
-    (label ^ " dispatch count")
-    dispatch_count
-    observation.dispatch_count;
-  Option.iter
-    (fun expected ->
-      Alcotest.(check string)
-        (label ^ " catalog generation")
-        expected
-        observation.catalog_generation_fingerprint)
-    catalog_generation_fingerprint
+    (String.trim observation.receipt_request_body_sha256 <> "")
 ;;
+
+let push_event events event = events := !events @ [ event ]
 
 let test_missing_compaction_lane_is_explicit_degraded_state () =
   let snapshot =
@@ -265,12 +244,12 @@ let test_missing_compaction_lane_is_explicit_degraded_state () =
       [ { id = "configured-slot"; base_url = "http://127.0.0.1:9" } ]
   in
   let registry =
-    match Runtime_exact_output_registry.publish ~lanes:[] snapshot with
+    match Registry.publish ~lanes:[] snapshot with
     | Ok registry -> registry
     | Error error ->
       Alcotest.failf
         "empty exact-output registry must publish: %s"
-        (Runtime_exact_output_registry.publication_error_to_string error)
+        (Registry.publication_error_to_string error)
   in
   match
     C.prepare_lane
@@ -280,215 +259,48 @@ let test_missing_compaction_lane_is_explicit_degraded_state () =
       ~units
   with
   | Error C.Exact_lane_unconfigured -> ()
-  | Error _ -> Alcotest.fail "missing compaction lane returned the wrong typed failure"
-  | Ok _ -> Alcotest.fail "missing compaction lane must not be synthesized"
+  | Error _ -> Alcotest.fail "missing lane returned the wrong typed failure"
+  | Ok _ -> Alcotest.fail "missing lane must not be synthesized"
 ;;
 
-let test_missing_credential_is_deferred_past_registry_admission () =
-  let slot_id = "credential-gated-slot" in
-  let snapshot =
-    F.resolver_snapshot
-      ~api_key_env:"MASC_TEST_EXACT_OUTPUT_MISSING_CREDENTIAL"
-      ~source:"masc credential-free admission"
-      [ { id = slot_id; base_url = "http://127.0.0.1:9" } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  (match Registry.resolve_lane registry ~lane_id:conformance_lane_id with
-   | Error
-       (Registry.No_usable_lane_slots
-          { unavailable_slots =
-              [ { cause = EO.Missing_target_credential { environment_variable; _ }
-                ; _
-                }
-              ]
-          ; _
-          }) ->
-     Alcotest.(check string)
-       "missing credential cause remains typed"
-       "MASC_TEST_EXACT_OUTPUT_MISSING_CREDENTIAL"
-       environment_variable
-   | Ok _ -> Alcotest.fail "missing credential must fail target selection"
-   | Error _ ->
-     Alcotest.fail "missing credential returned the wrong lane-resolution failure");
-  match
-    C.prepare_lane
-      ~keeper_name:"keeper-missing-credential"
-      ~registry
-      ~lane_id:conformance_lane_id
-      ~units
-  with
-  | Error C.Exact_target_selection_failed -> ()
-  | Error _ -> Alcotest.fail "missing credential returned the wrong typed failure"
-  | Ok _ -> Alcotest.fail "missing credential must not produce a ready plan"
-;;
-
-let test_unknown_target_is_rejected_by_registry_publication () =
-  let unknown_target = "unknown-exact-target" in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc unknown-target admission"
-      [ { id = "configured-target"; base_url = "http://127.0.0.1:9" } ]
-  in
-  let lanes : Runtime_schema.exact_output_lane_decl list =
-    [ { id = conformance_lane_id; slot_ids = [ unknown_target ] } ]
-  in
-  match Registry.publish ~lanes snapshot with
-  | Error (Registry.Unknown_lane_slot { target_ref; _ }) ->
-    Alcotest.(check string) "unknown target identity" unknown_target target_ref
-  | Error _ -> Alcotest.fail "unknown target returned the wrong publication failure"
-  | Ok _ -> Alcotest.fail "unknown target must not publish in the MASC registry"
-;;
-
-let check_failure label expected = function
-  | Error actual when actual = expected -> ()
-  | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
-  | Error _ -> Alcotest.failf "%s returned the wrong failure class" label
-;;
-
-let test_unavailable_slots_are_skipped_in_both_orders () =
-  let check unavailable_first =
-    run_eio
-    @@ fun ~sw ~net ~clock ->
-    let usable = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-    let unavailable_id =
-      if unavailable_first then "unavailable-first" else "unavailable-last"
-    in
-    let usable_id = if unavailable_first then "usable-last" else "usable-first" in
-    let fixtures : F.target_fixture list =
-      [ { id = unavailable_id; base_url = "http://127.0.0.1:9" }
-      ; { id = usable_id; base_url = usable.base_url }
-      ]
-    in
-    let snapshot =
-      F.resolver_snapshot
-        ~api_key_envs:
-          [ unavailable_id, "MASC_TEST_EXACT_OUTPUT_UNAVAILABLE_MIXED" ]
-        ~source:"masc mixed availability"
-        fixtures
-    in
-    let slot_ids =
-      if unavailable_first
-      then [ unavailable_id; usable_id ]
-      else [ usable_id; unavailable_id ]
-    in
-    let registry = publish_exn ~slot_ids snapshot in
-    let expected_unavailable_position = if unavailable_first then 1 else 2 in
-    (match Registry.resolve_lane registry ~lane_id:conformance_lane_id with
-     | Ok
-         { selected_slots = [ selected ]
-         ; unavailable_slots = [ unavailable ]
-         } ->
-       Alcotest.(check string) "usable slot retained" usable_id selected.slot_id;
-       Alcotest.(check string)
-         "unavailable slot retained as diagnostics"
-         unavailable_id
-         unavailable.slot_id;
-       Alcotest.(check int)
-         "unavailable declaration position"
-         expected_unavailable_position
-         unavailable.position
-     | Ok _ -> Alcotest.fail "mixed lane returned the wrong partition"
-     | Error _ -> Alcotest.fail "mixed lane must retain its usable slot");
-    let prepared = prepare_exn ~keeper_name:"keeper-mixed" ~registry in
-    Alcotest.(check (list string))
-      "only usable slot is prepared"
-      [ usable_id ]
-      (C.For_testing.admitted_slot_ids prepared);
-    ignore
-      (execute_prepared_lane
-         ~keeper_name:"keeper-mixed"
-         ~net
-         ~clock
-         prepared
-       |> completed_exn
-        : C.completed_plan);
-    Alcotest.(check int) "usable slot dispatched once" 1 (F.post_count usable)
-  in
-  check true;
-  check false
-;;
-
-let test_all_unavailable_slots_are_typed () =
-  let first_id = "all-unavailable-first" in
-  let second_id = "all-unavailable-second" in
-  let snapshot =
-    F.resolver_snapshot
-      ~api_key_envs:
-        [ first_id, "MASC_TEST_EXACT_OUTPUT_MISSING_FIRST"
-        ; second_id, "MASC_TEST_EXACT_OUTPUT_MISSING_SECOND"
-        ]
-      ~source:"masc all unavailable"
-      [ { id = first_id; base_url = "http://127.0.0.1:9" }
-      ; { id = second_id; base_url = "http://127.0.0.1:9" }
-      ]
-  in
-  let registry = publish_exn ~slot_ids:[ first_id; second_id ] snapshot in
-  (match Registry.resolve_lane registry ~lane_id:conformance_lane_id with
-   | Error
-       (Registry.No_usable_lane_slots
-          { unavailable_slots = [ first; second ]; _ }) ->
-     Alcotest.(check string) "first unavailable slot" first_id first.slot_id;
-     Alcotest.(check string) "second unavailable slot" second_id second.slot_id
-   | Error _ -> Alcotest.fail "all-unavailable lane returned the wrong typed error"
-   | Ok _ -> Alcotest.fail "all-unavailable lane must not resolve");
-  match
-    C.prepare_lane
-      ~keeper_name:"keeper-all-unavailable"
-      ~registry
-      ~lane_id:conformance_lane_id
-      ~units
-  with
-  | Error C.Exact_target_selection_failed -> ()
-  | Error _ -> Alcotest.fail "all-unavailable preparation returned the wrong error"
-  | Ok _ -> Alcotest.fail "all-unavailable preparation must fail"
-;;
-
-let test_preparation_is_ordered_effect_free_and_single_generation () =
+let test_preparation_freezes_order_generation_and_unique_call_ids () =
   run_eio
   @@ fun ~sw ~net ~clock ->
   let first = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
   let second = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let fixtures : F.target_fixture list =
-    [ { id = "prepare-first"; base_url = first.base_url }
-    ; { id = "prepare-second"; base_url = second.base_url }
-    ]
+  let snapshot =
+    F.resolver_snapshot
+      ~source:"masc immutable preparation"
+      [ { id = "prepare-first"; base_url = first.base_url }
+      ; { id = "prepare-second"; base_url = second.base_url }
+      ]
   in
-  let snapshot = F.resolver_snapshot ~source:"masc preparation conformance" fixtures in
-  let generation = F.catalog_generation_fingerprint snapshot in
-  let registry = publish_exn ~slot_ids:[ "prepare-first"; "prepare-second" ] snapshot in
-  let prepared =
-    prepare_exn
-      ~keeper_name:"keeper-preparation"
-      ~registry
+  let registry =
+    publish_exn ~slot_ids:[ "prepare-first"; "prepare-second" ] snapshot
   in
+  let prepared = prepare_exn ~keeper_name:"keeper-preparation" ~registry in
   Alcotest.(check (list string))
-    "declaration order is retained"
+    "MASC opaque declaration order"
     [ "prepare-first"; "prepare-second" ]
-    (C.For_testing.admitted_slot_ids prepared);
-  Alcotest.(check int) "first target has no preparation effect" 0 (F.post_count first);
-  Alcotest.(check int) "second target has no preparation effect" 0 (F.post_count second);
-  let first_observations = C.For_testing.attempt_observations prepared in
-  let second_observations = C.For_testing.attempt_observations prepared in
-  List.iter2
-    (fun first second ->
-       Alcotest.(check string)
-         "preparation retains one stable call id per slot"
-         first.C.call_id
-         second.C.call_id)
-    first_observations
-    second_observations;
-  List.iter
-    (fun slot_id ->
-      check_observation
-        ~label:slot_id
-        ~phase:EO.Not_started
-        ~dispatch_count:0
-        ~catalog_generation_fingerprint:generation
-        (observation_exn prepared slot_id))
-    [ "prepare-first"; "prepare-second" ]
+    (C.For_testing.flow_slot_ids prepared);
+  Alcotest.(check int64)
+    "one immutable MASC registry generation"
+    (Registry.generation registry)
+    (C.For_testing.registry_generation prepared);
+  (match C.For_testing.attempt_observations prepared with
+   | [ first_observation; second_observation ] ->
+     check_identity "first attempt" first_observation;
+     check_identity "second attempt" second_observation;
+     Alcotest.(check bool)
+       "candidate call ids are unique"
+       true
+       (not (String.equal first_observation.call_id second_observation.call_id))
+   | _ -> Alcotest.fail "prepared OAS flow did not retain two candidate identities");
+  Alcotest.(check int) "preparation performs no first POST" 0 (F.post_count first);
+  Alcotest.(check int) "preparation performs no second POST" 0 (F.post_count second)
 ;;
 
-let test_published_snapshot_replacement_cannot_mix_prepared_lane () =
+let test_published_replacement_cannot_mix_prepared_generation () =
   run_eio
   @@ fun ~sw ~net ~clock ->
   let server_a = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
@@ -499,262 +311,293 @@ let test_published_snapshot_replacement_cannot_mix_prepared_lane () =
       [ { id = "frozen-slot"; base_url = server_a.base_url } ]
   in
   let registry_a = publish_exn ~slot_ids:[ "frozen-slot" ] snapshot_a in
-  let prepared =
-    prepare_exn
-      ~keeper_name:"keeper-frozen-a"
-      ~registry:registry_a
-  in
+  let prepared_a = prepare_exn ~keeper_name:"keeper-frozen-a" ~registry:registry_a in
   let snapshot_b =
     F.resolver_snapshot
-      ~source:"masc frozen registry B"
+      ~source:"masc replacement registry B"
       [ { id = "replacement-slot"; base_url = server_b.base_url } ]
   in
   let registry_b = publish_exn ~slot_ids:[ "replacement-slot" ] snapshot_b in
-  let prepared_b =
-    prepare_exn ~keeper_name:"keeper-frozen-b" ~registry:registry_b
-  in
   Alcotest.(check bool)
-    "MASC publication generation advances atomically"
+    "MASC publication generation advances"
     true
-    (Int64.compare
-       (Runtime_exact_output_registry.generation registry_a)
-       (Runtime_exact_output_registry.generation registry_b)
-     < 0);
-  Alcotest.(check (list string))
-    "replacement publication carries its own lane declaration"
-    [ "replacement-slot" ]
-    (C.For_testing.admitted_slot_ids prepared_b);
+    (Int64.compare (Registry.generation registry_a) (Registry.generation registry_b) < 0);
   let completed =
     execute_prepared_lane
       ~keeper_name:"keeper-frozen-a"
       ~net
       ~clock
-      prepared
+      prepared_a
     |> completed_exn
   in
   let evidence = C.completed_exact_execution_evidence completed in
-  let generation_a = F.catalog_generation_fingerprint snapshot_a in
-  let generation_b = F.catalog_generation_fingerprint snapshot_b in
-  Alcotest.(check bool)
-    "resolver snapshots have distinct OAS generations"
-    true
-    (not (String.equal generation_a generation_b));
   Alcotest.(check string)
-    "execution retains prepared snapshot generation"
-    generation_a
+    "execution retains prepared resolver generation"
+    (F.catalog_generation_fingerprint snapshot_a)
     (C.exact_execution_evidence_catalog_generation_fingerprint evidence);
   Alcotest.(check int) "prepared A dispatches to A" 1 (F.post_count server_a);
   Alcotest.(check int) "later publication B is not observed" 0 (F.post_count server_b)
 ;;
 
-let test_before_dispatch_zero_advances_exactly_once () =
+let test_durable_release_precedes_successor_bind_and_post () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  let first = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let second = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let events = ref [] in
+  let second =
+    F.start_server
+      ~on_request_before_reply:(fun () -> push_event events "post:second")
+      ~sw
+      ~net
+      ~clock
+      (F.Reply valid_response)
+  in
   let third = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
   let snapshot =
     F.resolver_snapshot
-      ~connect_timeouts:[ "before-dispatch", 1.0 ]
-      ~source:"masc before-dispatch failover"
-      [ { id = "before-dispatch"; base_url = first.base_url }
-      ; { id = "after-before-dispatch"; base_url = second.base_url }
-      ; { id = "must-remain-ready"; base_url = third.base_url }
+      ~source:"masc OAS advancement order"
+      [ { id = "unreachable-first"; base_url = "http://127.0.0.1:9" }
+      ; { id = "successful-second"; base_url = second.base_url }
+      ; { id = "forbidden-third"; base_url = third.base_url }
       ]
   in
   let registry =
     publish_exn
-      ~slot_ids:
-        [ "before-dispatch"; "after-before-dispatch"; "must-remain-ready" ]
+      ~slot_ids:[ "unreachable-first"; "successful-second"; "forbidden-third" ]
       snapshot
   in
-  let prepared =
-    prepare_exn
-      ~keeper_name:"keeper-before-dispatch"
-      ~registry
+  let prepared = prepare_exn ~keeper_name:"keeper-advance-order" ~registry in
+  let guard : C.exact_execution_guard =
+    { before_dispatch =
+        (fun observation ->
+           push_event events ("bind:" ^ observation.slot_id);
+           Ok C.Fsync_completed)
+    ; release_before_dispatch =
+        (fun observation ->
+           push_event events ("release:" ^ observation.slot_id);
+           Ok C.Fsync_completed)
+    ; quarantine = (fun _ _ -> Alcotest.fail "successful flow must not quarantine")
+    }
   in
   ignore
     (execute_prepared_lane
-       ~keeper_name:"keeper-before-dispatch"
+       ~keeper_name:"keeper-advance-order"
        ~net
+       ~clock
+       ~exact_execution_guard:guard
        prepared
      |> completed_exn
-     : C.completed_plan);
-  check_observation
-    ~label:"rejected transport"
-    ~phase:EO.Before_dispatch
-    ~dispatch_count:0
-    (observation_exn prepared "before-dispatch");
-  check_observation
-    ~label:"single successor"
-    ~phase:EO.Terminal
-    ~dispatch_count:1
-    (observation_exn prepared "after-before-dispatch");
-  check_observation
-    ~label:"slot after success"
-    ~phase:EO.Not_started
-    ~dispatch_count:0
-    (observation_exn prepared "must-remain-ready");
-  Alcotest.(check int) "pre-dispatch target has no POST" 0 (F.post_count first);
-  Alcotest.(check int) "one successor POST" 1 (F.post_count second);
-  Alcotest.(check int) "no POST after successor success" 0 (F.post_count third)
+      : C.completed_plan);
+  Alcotest.(check (list string))
+    "bind A, fsync release A, bind B, then POST B"
+    [ "bind:unreachable-first"
+    ; "release:unreachable-first"
+    ; "bind:successful-second"
+    ; "post:second"
+    ]
+    !events;
+  Alcotest.(check int) "successor dispatches once" 1 (F.post_count second);
+  Alcotest.(check int) "success prevents another candidate" 0 (F.post_count third)
 ;;
 
-let test_visible_release_uncertainty_is_source_bound_terminal () =
+let test_bind_failure_prevents_post () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  let first = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let second = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let first_slot = "visible-release-original" in
-  let second_slot = "visible-release-forbidden-successor" in
+  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
   let snapshot =
     F.resolver_snapshot
-      ~connect_timeouts:[ first_slot, 1.0 ]
-      ~source:"masc visible release terminal"
-      [ { id = first_slot; base_url = first.base_url }
-      ; { id = second_slot; base_url = second.base_url }
-      ]
+      ~source:"masc bind failure"
+      [ { id = "bind-failure"; base_url = server.base_url } ]
   in
-  let registry = publish_exn ~slot_ids:[ first_slot; second_slot ] snapshot in
-  let prepared = prepare_exn ~keeper_name:"keeper-visible-release" ~registry in
-  let release_calls = ref [] in
+  let registry = publish_exn ~slot_ids:[ "bind-failure" ] snapshot in
+  let prepared = prepare_exn ~keeper_name:"keeper-bind-failure" ~registry in
   let guard : C.exact_execution_guard =
-    { before_dispatch = (fun _ -> Ok C.Fsync_completed)
-    ; release_before_dispatch =
-        (fun observation ->
-           release_calls := observation :: !release_calls;
-           Ok (C.Visible_sync_unconfirmed "injected release after-rename failure"))
+    { before_dispatch = (fun _ -> Error "injected durable bind failure")
+    ; release_before_dispatch = (fun _ -> Alcotest.fail "release must not run")
     ; quarantine = (fun _ _ -> Alcotest.fail "quarantine must not run")
     }
   in
-  let terminal : P.exact_execution_terminal =
+  (match
+     execute_prepared_lane
+       ~keeper_name:"keeper-bind-failure"
+       ~net
+       ~clock
+       ~exact_execution_guard:guard
+       prepared
+   with
+   | Error C.Exact_execution_guard_failed -> ()
+   | Error _ -> Alcotest.fail "bind failure returned the wrong typed failure"
+   | Ok _ -> Alcotest.fail "bind failure unexpectedly executed");
+  Alcotest.(check int) "bind failure prevents POST" 0 (F.post_count server)
+;;
+
+let test_release_failure_blocks_successor () =
+  run_eio
+  @@ fun ~sw ~net ~clock ->
+  let successor = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let first_slot = "release-failure-first" in
+  let successor_slot = "release-failure-successor" in
+  let snapshot =
+    F.resolver_snapshot
+      ~source:"masc release failure"
+      [ { id = first_slot; base_url = "http://127.0.0.1:9" }
+      ; { id = successor_slot; base_url = successor.base_url }
+      ]
+  in
+  let registry = publish_exn ~slot_ids:[ first_slot; successor_slot ] snapshot in
+  let prepared = prepare_exn ~keeper_name:"keeper-release-failure" ~registry in
+  let events = ref [] in
+  let guard : C.exact_execution_guard =
+    { before_dispatch =
+        (fun observation ->
+           push_event events ("bind:" ^ observation.slot_id);
+           Ok C.Fsync_completed)
+    ; release_before_dispatch =
+        (fun observation ->
+           push_event events ("release:" ^ observation.slot_id);
+           Error "injected durable release failure")
+    ; quarantine = (fun _ _ -> Alcotest.fail "release failure must not relabel")
+    }
+  in
+  let terminal =
     match
       execute_prepared_lane
-        ~keeper_name:"keeper-visible-release"
+        ~keeper_name:"keeper-release-failure"
         ~net
         ~clock
         ~exact_execution_guard:guard
         prepared
     with
     | Error (C.Exact_execution_terminal terminal) -> terminal
-    | Error _ -> Alcotest.fail "visible release returned the wrong typed failure"
-    | Ok _ -> Alcotest.fail "visible release uncertainty incorrectly failed over"
+    | Error _ -> Alcotest.fail "release failure returned the wrong terminal"
+    | Ok _ -> Alcotest.fail "release failure incorrectly advanced"
   in
-  let original = observation_exn prepared first_slot in
   Alcotest.(check bool)
-    "visible release uses persistence terminal cause"
+    "release failure is a persistence terminal"
     true
     (terminal.cause = Keeper_event_queue_state.Terminal_persistence_failed);
-  Alcotest.(check string) "visible release retains slot" original.slot_id terminal.slot_id;
-  Alcotest.(check string) "visible release retains call" original.call_id terminal.call_id;
-  (match !release_calls with
-   | [ released ] ->
-     Alcotest.(check string) "release called for original slot" first_slot released.slot_id
-   | _ -> Alcotest.fail "visible release was not called exactly once");
-  Alcotest.(check int) "visible release original has no POST" 0 (F.post_count first);
-  Alcotest.(check int)
-    "visible release never dispatches successor"
-    0
-    (F.post_count second)
+  Alcotest.(check string) "release failure retains A" first_slot terminal.slot_id;
+  Alcotest.(check (list string))
+    "successor is never bound"
+    [ "bind:" ^ first_slot; "release:" ^ first_slot ]
+    !events;
+  Alcotest.(check int) "release failure prevents successor POST" 0 (F.post_count successor)
 ;;
 
-let test_post_dispatch_failure_is_terminal () =
+let test_domain_invalid_output_never_reenters_failover () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  let first = F.start_server ~sw ~net ~clock F.Abort_after_request in
-  let second = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let invalid = F.start_server ~sw ~net ~clock (F.Reply domain_invalid_response) in
+  let successor = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let first_slot = "domain-invalid" in
   let snapshot =
     F.resolver_snapshot
-      ~source:"masc post-dispatch terminal"
-      [ { id = "post-dispatch"; base_url = first.base_url }
-      ; { id = "forbidden-post-dispatch-failover"; base_url = second.base_url }
+      ~source:"masc domain validation terminal"
+      [ { id = first_slot; base_url = invalid.base_url }
+      ; { id = "forbidden-domain-successor"; base_url = successor.base_url }
       ]
   in
   let registry =
     publish_exn
-      ~slot_ids:[ "post-dispatch"; "forbidden-post-dispatch-failover" ]
+      ~slot_ids:[ first_slot; "forbidden-domain-successor" ]
       snapshot
   in
-  let prepared =
-    prepare_exn
-      ~keeper_name:"keeper-post-dispatch"
-      ~registry
+  let prepared = prepare_exn ~keeper_name:"keeper-domain-invalid" ~registry in
+  let quarantined = ref [] in
+  let guard : C.exact_execution_guard =
+    { before_dispatch = (fun _ -> Ok C.Fsync_completed)
+    ; release_before_dispatch =
+        (fun _ -> Alcotest.fail "domain validation is outside OAS advancement")
+    ; quarantine =
+        (fun cause observation ->
+           quarantined := (cause, observation.slot_id) :: !quarantined;
+           Ok C.Fsync_completed)
+    }
   in
-  (match execute_prepared_lane ~keeper_name:"keeper-post-dispatch" ~net prepared with
-   | Error (C.Exact_execution_failed_after_dispatch observation) ->
-     Alcotest.(check string)
-       "post-dispatch failure retains slot"
-       "post-dispatch"
-       observation.slot_id;
-     Alcotest.(check bool)
-       "post-dispatch failure retains call id"
-       true
-       (String.trim observation.call_id <> "")
-   | Error _ -> Alcotest.fail "post-dispatch failure returned the wrong class"
-   | Ok _ -> Alcotest.fail "post-dispatch failure unexpectedly succeeded");
-  check_observation
-    ~label:"post-dispatch failure"
-    ~phase:EO.Dispatch_started
-    ~dispatch_count:1
-    (observation_exn prepared "post-dispatch");
-  check_observation
-    ~label:"forbidden successor"
-    ~phase:EO.Not_started
-    ~dispatch_count:0
-    (observation_exn prepared "forbidden-post-dispatch-failover");
-  Alcotest.(check int) "failed request dispatched once" 1 (F.post_count first);
-  Alcotest.(check int) "post-dispatch failure does not fail over" 0 (F.post_count second)
+  let terminal =
+    match
+      execute_prepared_lane
+        ~keeper_name:"keeper-domain-invalid"
+        ~net
+        ~clock
+        ~exact_execution_guard:guard
+        prepared
+    with
+    | Error (C.Exact_execution_terminal terminal) -> terminal
+    | Error _ -> Alcotest.fail "domain invalidity returned the wrong failure"
+    | Ok _ -> Alcotest.fail "domain-invalid output unexpectedly succeeded"
+  in
+  Alcotest.(check bool)
+    "domain terminal cause"
+    true
+    (terminal.cause = Keeper_event_queue_state.Domain_invalid_output);
+  Alcotest.(check string) "domain terminal retains bound slot" first_slot terminal.slot_id;
+  Alcotest.(check int) "domain-invalid target posts once" 1 (F.post_count invalid);
+  Alcotest.(check int) "domain invalidity never fails over" 0 (F.post_count successor);
+  Alcotest.(check bool)
+    "only bound identity quarantined"
+    true
+    (List.rev !quarantined
+     = [ Keeper_event_queue_state.Domain_invalid_output, first_slot ])
 ;;
 
-let test_domain_invalid_json_is_terminal () =
+let test_final_oas_flow_failure_is_generic_source_terminal () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  let first = F.start_server ~sw ~net ~clock (F.Reply domain_invalid_response) in
-  let second = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let failed = F.start_server ~sw ~net ~clock F.Abort_after_request in
+  let successor = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let first_slot = "generic-flow-failure" in
   let snapshot =
     F.resolver_snapshot
-      ~source:"masc domain-invalid terminal"
-      [ { id = "domain-invalid"; base_url = first.base_url }
-      ; { id = "forbidden-domain-failover"; base_url = second.base_url }
+      ~source:"masc generic OAS flow failure"
+      [ { id = first_slot; base_url = failed.base_url }
+      ; { id = "forbidden-failure-successor"; base_url = successor.base_url }
       ]
   in
   let registry =
     publish_exn
-      ~slot_ids:[ "domain-invalid"; "forbidden-domain-failover" ]
+      ~slot_ids:[ first_slot; "forbidden-failure-successor" ]
       snapshot
   in
-  let prepared =
-    prepare_exn
-      ~keeper_name:"keeper-domain-invalid"
-      ~registry
+  let prepared = prepare_exn ~keeper_name:"keeper-flow-failure" ~registry in
+  let quarantined = ref [] in
+  let guard : C.exact_execution_guard =
+    { before_dispatch = (fun _ -> Ok C.Fsync_completed)
+    ; release_before_dispatch =
+        (fun _ -> Alcotest.fail "terminal OAS flow failure must not advance")
+    ; quarantine =
+        (fun cause observation ->
+           quarantined := (cause, observation.slot_id) :: !quarantined;
+           Ok C.Fsync_completed)
+    }
   in
-  (match execute_prepared_lane ~keeper_name:"keeper-domain-invalid" ~net prepared with
-   | Error (C.Invalid_plan_after_dispatch observation) ->
-     Alcotest.(check string)
-       "domain-invalid output retains slot"
-       "domain-invalid"
-       observation.slot_id;
-     Alcotest.(check bool)
-       "domain-invalid output retains call id"
-       true
-       (String.trim observation.call_id <> "")
-   | Error _ -> Alcotest.fail "domain-invalid output returned the wrong class"
-   | Ok _ -> Alcotest.fail "domain-invalid output unexpectedly succeeded");
-  check_observation
-    ~label:"domain-invalid response"
-    ~phase:EO.Terminal
-    ~dispatch_count:1
-    (observation_exn prepared "domain-invalid");
-  check_observation
-    ~label:"domain successor"
-    ~phase:EO.Not_started
-    ~dispatch_count:0
-    (observation_exn prepared "forbidden-domain-failover");
-  Alcotest.(check int) "domain-invalid target dispatched once" 1 (F.post_count first);
-  Alcotest.(check int) "domain invalidity does not fail over" 0 (F.post_count second)
+  let terminal =
+    match
+      execute_prepared_lane
+        ~keeper_name:"keeper-flow-failure"
+        ~net
+        ~clock
+        ~exact_execution_guard:guard
+        prepared
+    with
+    | Error (C.Exact_execution_terminal terminal) -> terminal
+    | Error _ -> Alcotest.fail "OAS flow failure returned the wrong failure"
+    | Ok _ -> Alcotest.fail "failed OAS flow unexpectedly succeeded"
+  in
+  Alcotest.(check bool)
+    "generic terminal does not claim receipt phase"
+    true
+    (terminal.cause = Keeper_event_queue_state.Exact_execution_failed);
+  Alcotest.(check string) "generic terminal retains bound slot" first_slot terminal.slot_id;
+  Alcotest.(check int) "failed request posts once" 1 (F.post_count failed);
+  Alcotest.(check int) "terminal flow failure never advances" 0 (F.post_count successor);
+  Alcotest.(check bool)
+    "generic terminal quarantines one identity"
+    true
+    (List.rev !quarantined
+     = [ Keeper_event_queue_state.Exact_execution_failed, first_slot ])
 ;;
 
-let test_post_dispatch_cancellation_is_typed_terminal () =
+let test_cancellation_quarantines_only_bound_identity () =
   run_eio
   @@ fun ~sw ~net ~clock ->
   let hold_response, _resolve_hold_response = Eio.Promise.create () in
@@ -766,23 +609,35 @@ let test_post_dispatch_cancellation_is_typed_terminal () =
       ~clock
       (F.Reply valid_response)
   in
-  let second = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let successor = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let first_slot = "cancelled-bound-slot" in
   let snapshot =
     F.resolver_snapshot
-      ~source:"masc cancellation terminal"
-      [ { id = "cancelled-dispatch"; base_url = first.base_url }
-      ; { id = "forbidden-cancel-failover"; base_url = second.base_url }
+      ~source:"masc bound cancellation"
+      [ { id = first_slot; base_url = first.base_url }
+      ; { id = "forbidden-cancel-successor"; base_url = successor.base_url }
       ]
   in
   let registry =
     publish_exn
-      ~slot_ids:[ "cancelled-dispatch"; "forbidden-cancel-failover" ]
+      ~slot_ids:[ first_slot; "forbidden-cancel-successor" ]
       snapshot
   in
-  let prepared =
-    prepare_exn
-      ~keeper_name:"keeper-cancelled"
-      ~registry
+  let prepared = prepare_exn ~keeper_name:"keeper-cancelled" ~registry in
+  let bound = ref [] in
+  let quarantined = ref [] in
+  let guard : C.exact_execution_guard =
+    { before_dispatch =
+        (fun observation ->
+           bound := observation.slot_id :: !bound;
+           Ok C.Fsync_completed)
+    ; release_before_dispatch =
+        (fun _ -> Alcotest.fail "cancelled bound identity must not advance")
+    ; quarantine =
+        (fun cause observation ->
+           quarantined := (cause, observation.slot_id) :: !quarantined;
+           Ok C.Fsync_completed)
+    }
   in
   let cancel_context, resolve_cancel_context = Eio.Promise.create () in
   let execution =
@@ -793,12 +648,10 @@ let test_post_dispatch_cancellation_is_typed_terminal () =
           ~keeper_name:"keeper-cancelled"
           ~net
           ~clock
+          ~exact_execution_guard:guard
           prepared))
   in
-  let retained_call_id =
-    (observation_exn prepared "cancelled-dispatch").call_id
-  in
-  let cancellation_result =
+  let result =
     try
       Eio.Time.with_timeout_exn clock 1.0 (fun () ->
         let context = Eio.Promise.await cancel_context in
@@ -806,279 +659,140 @@ let test_post_dispatch_cancellation_is_typed_terminal () =
         Eio.Cancel.cancel context Cancel_after_request_arrived;
         Eio.Promise.await_exn execution)
     with
-    | Eio.Time.Timeout ->
-      Alcotest.fail "request-arrival cancellation watchdog expired"
+    | Eio.Time.Timeout -> Alcotest.fail "cancellation watchdog expired"
   in
-  (match cancellation_result with
-   | Error (C.Exact_execution_cancelled_after_dispatch terminal) ->
-     Alcotest.(check string)
-       "terminal cancellation retains slot"
-       "cancelled-dispatch"
-       terminal.slot_id;
-     Alcotest.(check string)
-       "terminal cancellation retains OAS call id"
-       retained_call_id
-       terminal.call_id;
-     Alcotest.(check bool)
-       "terminal cancellation records dispatched phase"
-       true
-       (terminal.phase = EO.Dispatch_started);
-     Alcotest.(check int)
-       "terminal cancellation records one dispatch"
-       1
-       terminal.dispatch_count
-   | Error _ -> Alcotest.fail "post-dispatch cancellation returned the wrong error"
-   | Ok _ -> Alcotest.fail "post-dispatch cancellation unexpectedly succeeded");
-  check_observation
-    ~label:"cancelled real receipt"
-    ~phase:EO.Dispatch_started
-    ~dispatch_count:1
-    (observation_exn prepared "cancelled-dispatch");
-  check_observation
-    ~label:"cancel successor"
-    ~phase:EO.Not_started
-    ~dispatch_count:0
-    (observation_exn prepared "forbidden-cancel-failover");
-  Alcotest.(check int) "cancelled request dispatched once" 1 (F.post_count first);
-  Alcotest.(check int) "cancellation never fails over" 0 (F.post_count second)
+  let terminal =
+    match result with
+    | Error (C.Exact_execution_terminal terminal) -> terminal
+    | Error _ -> Alcotest.fail "cancellation returned the wrong terminal"
+    | Ok _ -> Alcotest.fail "cancelled flow unexpectedly succeeded"
+  in
+  Alcotest.(check bool)
+    "cancellation terminal is phase-neutral"
+    true
+    (terminal.cause = Keeper_event_queue_state.Exact_execution_cancelled);
+  Alcotest.(check (list string)) "only first identity was bound" [ first_slot ] (List.rev !bound);
+  Alcotest.(check bool)
+    "only the bound identity was quarantined"
+    true
+    (List.rev !quarantined
+     = [ Keeper_event_queue_state.Exact_execution_cancelled, first_slot ]);
+  Alcotest.(check int) "cancelled request posts once" 1 (F.post_count first);
+  Alcotest.(check int) "cancellation never dispatches successor" 0 (F.post_count successor)
 ;;
 
-let test_keeper_preparations_do_not_share_attempt_state () =
+let test_independent_preparations_do_not_share_call_identity () =
   run_eio
   @@ fun ~sw ~net ~clock ->
   let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let slot_id = "independent-flow-slot" in
   let snapshot =
     F.resolver_snapshot
-      ~source:"masc keeper ready-plan isolation"
-      [ { id = "keeper-private-ready"; base_url = server.base_url } ]
+      ~source:"masc flow non-sharing"
+      [ { id = slot_id; base_url = server.base_url } ]
   in
-  let registry = publish_exn ~slot_ids:[ "keeper-private-ready" ] snapshot in
-  let keeper_a =
-    prepare_exn
-      ~keeper_name:"keeper-a"
-      ~registry
-  in
-  let keeper_b =
-    prepare_exn
-      ~keeper_name:"keeper-b"
-      ~registry
-  in
-  let keeper_a_observation = observation_exn keeper_a "keeper-private-ready" in
-  let keeper_b_observation = observation_exn keeper_b "keeper-private-ready" in
+  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+  let keeper_a = prepare_exn ~keeper_name:"keeper-a" ~registry in
+  let keeper_b = prepare_exn ~keeper_name:"keeper-b" ~registry in
+  let a = observation_exn keeper_a slot_id in
+  let b = observation_exn keeper_b slot_id in
   Alcotest.(check bool)
-    "independent preparations own distinct OAS call ids"
+    "independent flows own distinct call ids"
     true
-    (not (String.equal keeper_a_observation.call_id keeper_b_observation.call_id));
+    (not (String.equal a.call_id b.call_id));
   let result_a, result_b =
     Eio.Fiber.pair
-      (fun () ->
-         execute_prepared_lane ~keeper_name:"keeper-a" ~net ~clock keeper_a)
-      (fun () ->
-         execute_prepared_lane ~keeper_name:"keeper-b" ~net ~clock keeper_b)
+      (fun () -> execute_prepared_lane ~keeper_name:"keeper-a" ~net ~clock keeper_a)
+      (fun () -> execute_prepared_lane ~keeper_name:"keeper-b" ~net ~clock keeper_b)
   in
   ignore (completed_exn result_a : C.completed_plan);
   ignore (completed_exn result_b : C.completed_plan);
-  check_observation
-    ~label:"keeper A"
-    ~phase:EO.Terminal
-    ~dispatch_count:1
-    (observation_exn keeper_a "keeper-private-ready");
-  check_observation
-    ~label:"keeper B"
-    ~phase:EO.Terminal
-    ~dispatch_count:1
-    (observation_exn keeper_b "keeper-private-ready");
-  Alcotest.(check int)
-    "two Keeper-owned ready plans dispatch independently"
-    2
-    (F.post_count server)
+  Alcotest.(check int) "independent flows post independently" 2 (F.post_count server)
 ;;
 
-let test_prepared_lane_replay_is_terminal_without_second_post () =
+let test_same_flow_concurrent_loser_mutates_no_queue () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let slot_id = "single-use-replay" in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc affine replay"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name:"keeper-affine-replay" ~registry in
-  let retained_call_id = (observation_exn prepared slot_id).call_id in
-  ignore
-    (execute_prepared_lane
-       ~keeper_name:"keeper-affine-replay"
-       ~net
-       ~clock
-       prepared
-     |> completed_exn
-      : C.completed_plan);
-  (match
-     execute_prepared_lane
-       ~keeper_name:"keeper-affine-replay"
-       ~net
-       ~clock
-       prepared
-   with
-   | Error (C.Exact_attempt_already_started observation) ->
-     Alcotest.(check string)
-       "replay reports retained call id"
-       retained_call_id
-       observation.call_id
-   | Error _ -> Alcotest.fail "replay returned the wrong typed terminal error"
-   | Ok _ -> Alcotest.fail "same prepared lane replay unexpectedly succeeded");
-  Alcotest.(check int) "replay cannot issue a second POST" 1 (F.post_count server)
-;;
-
-let test_prepared_lane_concurrency_is_affine () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
+  with_temp_dir "masc-same-flow-affinity"
+  @@ fun base_path ->
+  let keeper_name = "keeper-same-flow-affinity" in
+  let lease = claim_manual_lease ~base_path ~keeper_name in
   let server =
     F.start_server ~sw ~net ~clock (F.Delay_then_reply (0.05, valid_response))
   in
-  let slot_id = "single-use-concurrent" in
+  let slot_id = "same-flow-slot" in
   let snapshot =
     F.resolver_snapshot
-      ~source:"masc affine concurrency"
+      ~source:"masc same-flow affinity"
       [ { id = slot_id; base_url = server.base_url } ]
   in
   let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name:"keeper-affine-concurrent" ~registry in
-  let retained_call_id = (observation_exn prepared slot_id).call_id in
+  let prepared = prepare_exn ~keeper_name ~registry in
+  let durable_guard =
+    Keeper_heartbeat_loop.For_testing.exact_execution_guard
+      ~base_path
+      ~keeper_name
+      ~lease
+  in
+  let bind_mutations = Atomic.make 0 in
+  let release_mutations = Atomic.make 0 in
+  let quarantine_mutations = Atomic.make 0 in
+  let guard : C.exact_execution_guard =
+    { before_dispatch =
+        (fun observation ->
+           Atomic.incr bind_mutations;
+           durable_guard.before_dispatch observation)
+    ; release_before_dispatch =
+        (fun observation ->
+           Atomic.incr release_mutations;
+           durable_guard.release_before_dispatch observation)
+    ; quarantine =
+        (fun cause observation ->
+           Atomic.incr quarantine_mutations;
+           durable_guard.quarantine cause observation)
+    }
+  in
   let first, second =
     Eio.Fiber.pair
       (fun () ->
          execute_prepared_lane
-           ~keeper_name:"keeper-affine-concurrent-a"
+           ~keeper_name
            ~net
            ~clock
+           ~exact_execution_guard:guard
            prepared)
       (fun () ->
          execute_prepared_lane
-           ~keeper_name:"keeper-affine-concurrent-b"
+           ~keeper_name
            ~net
            ~clock
+           ~exact_execution_guard:guard
            prepared)
   in
   (match first, second with
-   | Ok _, Error (C.Exact_attempt_already_started observation)
-   | Error (C.Exact_attempt_already_started observation), Ok _ ->
-     Alcotest.(check string)
-       "concurrent rejection reports retained call id"
-       retained_call_id
-       observation.call_id
-   | _ ->
-     Alcotest.fail "concurrent execution must yield one success and one affine rejection");
+   | Ok _, Error C.Exact_flow_already_started
+   | Error C.Exact_flow_already_started, Ok _ ->
+     ()
+   | _ -> Alcotest.fail "same flow must have one owner and one affine loser");
+  Alcotest.(check int) "one owner performs one durable bind" 1 (Atomic.get bind_mutations);
+  Alcotest.(check int) "loser performs no release mutation" 0 (Atomic.get release_mutations);
   Alcotest.(check int)
-    "concurrent reuse cannot issue a second POST"
-    1
-    (F.post_count server)
-;;
-
-let test_before_rename_binding_failure_prevents_post () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let slot_id = "durable-guard-failure" in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc durable guard failure"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name:"keeper-durable-guard-failure" ~registry in
-  let guard : C.exact_execution_guard =
-    { before_dispatch = (fun _ -> Error "injected before-rename binding failure")
-    ; release_before_dispatch = (fun _ -> Alcotest.fail "release must not run")
-    ; quarantine = (fun _ _ -> Alcotest.fail "quarantine must not run")
-    }
-  in
-  (match
-     execute_prepared_lane
-       ~keeper_name:"keeper-durable-guard-failure"
-       ~net
-       ~clock
-       ~exact_execution_guard:guard
-       prepared
-   with
-   | Error C.Exact_execution_failed_before_dispatch -> ()
-   | Error _ -> Alcotest.fail "guard failure returned the wrong typed failure"
-   | Ok _ -> Alcotest.fail "guard failure must prevent exact-output execution");
-  Alcotest.(check int) "before-rename binding failure prevents POST" 0 (F.post_count server)
-;;
-
-let test_missing_dispatch_guard_prevents_post () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let slot_id = "missing-dispatch-guard" in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc missing durable dispatch guard"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name:"keeper-missing-dispatch-guard" ~registry in
-  (match
-     C.execute_prepared_lane
-       ~keeper_name:"keeper-missing-dispatch-guard"
-       ~net
-       ~clock
-       prepared
-   with
-   | Error C.Exact_execution_failed_before_dispatch -> ()
-   | Error _ -> Alcotest.fail "missing guard returned the wrong typed failure"
-   | Ok _ -> Alcotest.fail "missing guard must prevent exact-output execution");
-  Alcotest.(check int) "missing guard prevents POST" 0 (F.post_count server)
-;;
-
-let test_quarantine_persistence_failure_preserves_original_cause () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  let server = F.start_server ~sw ~net ~clock F.Abort_after_request in
-  let slot_id = "quarantine-persistence-failure" in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc terminal quarantine persistence failure"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name:"keeper-quarantine-persistence-failure" ~registry in
-  let quarantine_calls = ref [] in
-  let guard : C.exact_execution_guard =
-    { before_dispatch = (fun _ -> Ok C.Fsync_completed)
-    ; release_before_dispatch = (fun _ -> Alcotest.fail "release must not run")
-    ; quarantine =
-        (fun cause observation ->
-           quarantine_calls := (cause, observation) :: !quarantine_calls;
-           Error "injected terminal persistence failure")
-    }
-  in
-  (match
-     execute_prepared_lane
-       ~keeper_name:"keeper-quarantine-persistence-failure"
-       ~net
-       ~clock
-       ~exact_execution_guard:guard
-       prepared
-   with
-   | Error (C.Exact_execution_failed_after_dispatch observation) ->
-     Alcotest.(check string) "original failure slot" slot_id observation.slot_id
-   | Error _ -> Alcotest.fail "quarantine failure returned the wrong typed terminal"
-   | Ok _ -> Alcotest.fail "quarantine persistence failure unexpectedly succeeded");
-  (match !quarantine_calls with
-   | [ Keeper_event_queue_state.Execution_failed_after_dispatch, observation ] ->
-     Alcotest.(check string) "quarantine retained slot" slot_id observation.slot_id
-   | _ -> Alcotest.fail "quarantine did not receive the original terminal cause once");
-  Alcotest.(check int) "terminal persistence failure never retries" 1 (F.post_count server)
+    "loser performs no quarantine mutation"
+    0
+    (Atomic.get quarantine_mutations);
+  Alcotest.(check int) "same flow performs one POST" 1 (F.post_count server);
+  match P.exact_execution_binding_result ~base_path ~keeper_name with
+  | Ok (Some binding) ->
+    Alcotest.(check string) "durable binding retains winner slot" slot_id binding.slot_id
+  | Ok None -> Alcotest.fail "winner durable binding is missing"
+  | Error detail -> Alcotest.failf "winner binding reload failed: %s" detail
 ;;
 
 let test_heartbeat_guard_binds_before_post () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  with_temp_dir "masc-heartbeat-bind-before-post" @@ fun base_path ->
+  with_temp_dir "masc-heartbeat-bind-before-post"
+  @@ fun base_path ->
   let keeper_name = "keeper-heartbeat-bind-before-post" in
   let lease = claim_manual_lease ~base_path ~keeper_name in
   let slot_id = "heartbeat-bind-before-post" in
@@ -1133,218 +847,24 @@ let test_heartbeat_guard_binds_before_post () =
      |> completed_exn
       : C.completed_plan);
   Alcotest.(check bool)
-    "durable heartbeat binding exists when POST arrives"
+    "durable binding exists when POST arrives"
     true
     (Atomic.get durable_binding_seen);
-  Alcotest.(check int) "heartbeat guarded request posts once" 1 (F.post_count server)
+  Alcotest.(check int) "guarded flow posts once" 1 (F.post_count server)
 ;;
 
-let test_visible_unknown_binding_prevents_post_and_settles () =
+let test_post_success_terminalization_is_canonical_and_durable () =
   run_eio
   @@ fun ~sw ~net ~clock ->
-  with_temp_dir "masc-visible-unknown-binding" @@ fun base_path ->
-  let keeper_name = "keeper-visible-unknown-binding" in
-  let lease = claim_manual_lease ~base_path ~keeper_name in
-  let slot_id = "visible-unknown-binding" in
-  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc visible unknown binding"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name ~registry in
-  let observation = observation_exn prepared slot_id in
-  let durable_guard =
-    Keeper_heartbeat_loop.For_testing.exact_execution_guard
-      ~base_path
-      ~keeper_name
-      ~lease
-  in
-  let guard : C.exact_execution_guard =
-    { durable_guard with
-      before_dispatch =
-        (fun observation ->
-           match durable_guard.before_dispatch observation with
-           | Ok C.Fsync_completed ->
-             Ok (C.Visible_sync_unconfirmed "injected bind after-rename failure")
-           | Ok (C.Visible_sync_unconfirmed _ as outcome) -> Ok outcome
-           | Error _ as error -> error)
-    }
-  in
-  let terminal : P.exact_execution_terminal =
-    match
-      execute_prepared_lane
-        ~keeper_name
-        ~net
-        ~clock
-        ~exact_execution_guard:guard
-        prepared
-    with
-    | Error (C.Exact_execution_terminal terminal) -> terminal
-    | Error _ -> Alcotest.fail "visible bind outcome returned the wrong typed terminal"
-    | Ok _ -> Alcotest.fail "visible bind outcome must prevent exact-output execution"
-  in
-  Alcotest.(check bool)
-    "visible bind outcome uses persistence terminal cause"
-    true
-    (terminal.cause = Keeper_event_queue_state.Terminal_persistence_failed);
-  Alcotest.(check int) "visible bind outcome prevents POST" 0 (F.post_count server);
-  (match P.exact_execution_binding_result ~base_path ~keeper_name with
-   | Ok
-       (Some
-         { status = P.Dispatch_uncertain
-         ; slot_id = persisted_slot_id
-         ; call_id = persisted_call_id
-         ; plan_fingerprint
-         ; request_body_sha256
-         ; _
-         }) ->
-     Alcotest.(check string)
-       "visible bind retains slot identity"
-       observation.slot_id
-       persisted_slot_id;
-     Alcotest.(check string)
-       "visible bind retains call identity"
-       observation.call_id
-       persisted_call_id;
-     Alcotest.(check string)
-       "visible bind retains plan identity"
-       observation.receipt_plan_fingerprint
-       plan_fingerprint;
-     Alcotest.(check string)
-       "visible bind retains request identity"
-       observation.receipt_request_body_sha256
-       request_body_sha256
-   | Ok (Some _) -> Alcotest.fail "visible bind retained the wrong status"
-   | Ok None -> Alcotest.fail "visible bind was relabelled as unbound"
-   | Error detail -> Alcotest.failf "visible bind reload failed: %s" detail);
-  (match
-     settle_terminal_disposition_result
-       ~base_path
-       ~keeper_name
-       ~lease
-       ~source:(persisted_checkpoint_source_exn "trace-visible-unknown-binding")
-       ~terminal
-       ~settled_at:4.0
-   with
-   | Ok (P.Settled _) -> ()
-   | Ok _ -> Alcotest.fail "visible bind settlement was not fresh"
-   | Error detail -> Alcotest.failf "visible bind settlement failed: %s" detail);
-  match P.exact_execution_binding_result ~base_path ~keeper_name with
-  | Ok None -> ()
-  | Ok (Some _) -> Alcotest.fail "visible bind settlement retained the binding"
-  | Error detail -> Alcotest.failf "visible bind settlement reload failed: %s" detail
-;;
-
-let test_visible_unknown_quarantine_preserves_cause_and_settles () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  with_temp_dir "masc-visible-unknown-quarantine" @@ fun base_path ->
-  let keeper_name = "keeper-visible-unknown-quarantine" in
-  let lease = claim_manual_lease ~base_path ~keeper_name in
-  let slot_id = "visible-unknown-quarantine" in
-  let server = F.start_server ~sw ~net ~clock (F.Reply domain_invalid_response) in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc visible unknown quarantine"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name ~registry in
-  let durable_guard =
-    Keeper_heartbeat_loop.For_testing.exact_execution_guard
-      ~base_path
-      ~keeper_name
-      ~lease
-  in
-  let guard : C.exact_execution_guard =
-    { durable_guard with
-      quarantine =
-        (fun cause observation ->
-           match durable_guard.quarantine cause observation with
-           | Ok C.Fsync_completed ->
-             Ok (C.Visible_sync_unconfirmed "injected quarantine after-rename failure")
-           | Ok (C.Visible_sync_unconfirmed _ as outcome) -> Ok outcome
-           | Error _ as error -> error)
-    }
-  in
-  let observation : C.attempt_observation =
-    match
-      execute_prepared_lane
-        ~keeper_name
-        ~net
-        ~clock
-        ~exact_execution_guard:guard
-        prepared
-    with
-    | Error (C.Invalid_plan_after_dispatch observation) -> observation
-    | Error _ -> Alcotest.fail "visible quarantine returned the wrong typed failure"
-    | Ok _ -> Alcotest.fail "domain-invalid output unexpectedly succeeded"
-  in
-  let terminal : P.exact_execution_terminal =
-    { cause = Keeper_event_queue_state.Domain_invalid_output
-    ; slot_id = observation.slot_id
-    ; call_id = observation.call_id
-    ; plan_fingerprint = observation.receipt_plan_fingerprint
-    ; request_body_sha256 = observation.receipt_request_body_sha256
-    }
-  in
-  Alcotest.(check int) "visible quarantine follows one POST" 1 (F.post_count server);
-  (match P.exact_execution_binding_result ~base_path ~keeper_name with
-   | Ok
-       (Some
-         { status = P.Terminal_quarantined persisted_cause
-         ; slot_id = persisted_slot_id
-         ; call_id = persisted_call_id
-         ; _
-         }) ->
-     Alcotest.(check bool)
-       "visible quarantine preserves canonical cause"
-       true
-       (persisted_cause = terminal.cause);
-     Alcotest.(check string)
-       "visible quarantine preserves canonical slot"
-       terminal.slot_id
-       persisted_slot_id;
-     Alcotest.(check string)
-       "visible quarantine preserves canonical call"
-       terminal.call_id
-       persisted_call_id
-   | Ok (Some _) -> Alcotest.fail "visible quarantine retained the wrong status"
-   | Ok None -> Alcotest.fail "visible quarantine was relabelled as unbound"
-   | Error detail -> Alcotest.failf "visible quarantine reload failed: %s" detail);
-  (match
-     settle_terminal_disposition_result
-       ~base_path
-       ~keeper_name
-       ~lease
-       ~source:(persisted_checkpoint_source_exn "trace-visible-unknown-quarantine")
-       ~terminal
-       ~settled_at:5.0
-   with
-   | Ok (P.Settled _) -> ()
-   | Ok _ -> Alcotest.fail "visible quarantine settlement was not fresh"
-   | Error detail -> Alcotest.failf "visible quarantine settlement failed: %s" detail);
-  match P.exact_execution_binding_result ~base_path ~keeper_name with
-  | Ok None -> ()
-  | Ok (Some _) -> Alcotest.fail "visible quarantine settlement retained the binding"
-  | Error detail ->
-    Alcotest.failf "visible quarantine settlement reload failed: %s" detail
-;;
-
-let test_post_success_terminalization_is_affine () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  with_temp_dir "masc-post-success-terminal-affinity"
+  with_temp_dir "masc-post-success-terminal"
   @@ fun base_path ->
-  let keeper_name = "keeper-post-success-terminal-affinity" in
+  let keeper_name = "keeper-post-success-terminal" in
   let lease = claim_manual_lease ~base_path ~keeper_name in
-  let slot_id = "post-success-terminal-affinity" in
+  let slot_id = "post-success-terminal" in
   let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
   let snapshot =
     F.resolver_snapshot
-      ~source:"masc post-success terminal affinity"
+      ~source:"masc post-success terminal"
       [ { id = slot_id; base_url = server.base_url } ]
   in
   let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
@@ -1355,16 +875,12 @@ let test_post_success_terminalization_is_affine () =
       ~keeper_name
       ~lease
   in
-  let quarantine_entered, resolve_quarantine_entered = Eio.Promise.create () in
-  let release_quarantine, resolve_release_quarantine = Eio.Promise.create () in
   let quarantine_calls = ref 0 in
   let guard : C.exact_execution_guard =
     { durable_guard with
       quarantine =
         (fun cause observation ->
            incr quarantine_calls;
-           Eio.Promise.resolve resolve_quarantine_entered ();
-           Eio.Promise.await release_quarantine;
            durable_guard.quarantine cause observation)
     }
   in
@@ -1378,305 +894,132 @@ let test_post_success_terminalization_is_affine () =
     |> completed_exn
   in
   let terminalizer = C.completed_post_success_terminalizer completed in
-  let first_result, resolve_first_result = Eio.Promise.create () in
-  let second_started, resolve_second_started = Eio.Promise.create () in
-  let second_result, resolve_second_result = Eio.Promise.create () in
-  Eio.Fiber.fork ~sw (fun () ->
+  let first =
     C.terminalize_post_success
       terminalizer
       Keeper_event_queue_state.Invalid_structural_evidence
-    |> Eio.Promise.resolve resolve_first_result);
-  Eio.Promise.await quarantine_entered;
-  Eio.Fiber.fork ~sw (fun () ->
-    Eio.Promise.resolve resolve_second_started ();
+  in
+  let replay =
     C.terminalize_post_success
       terminalizer
       Keeper_event_queue_state.Checkpoint_persistence_failed
-    |> Eio.Promise.resolve resolve_second_result);
-  Eio.Promise.await second_started;
-  Eio.Fiber.yield ();
-  Eio.Promise.resolve resolve_release_quarantine ();
-  let first = Eio.Promise.await first_result in
-  let second = Eio.Promise.await second_result in
-  Alcotest.(check int) "post-success quarantine runs once" 1 !quarantine_calls;
-  Alcotest.(check bool)
-    "different causes retain the first canonical terminal"
-    true
-    (first = second);
-  Alcotest.(check bool)
-    "first cause remains canonical"
-    true
-    (first.cause = Keeper_event_queue_state.Invalid_structural_evidence);
-  let source =
-    match Keeper_id.Trace_id.of_string "trace-post-success-terminal-affinity" with
-    | Error detail -> Alcotest.failf "terminal source trace id failed: %s" detail
-    | Ok trace_id ->
-      (match
-         Keeper_checkpoint_ref.of_persisted
-           ~trace_id
-           ~generation:1
-           ~turn_count:1
-           ~sha256:(String.make 64 'a')
-       with
-       | Ok source -> source
-       | Error _ -> Alcotest.fail "terminal source checkpoint ref failed")
   in
-  match
-    settle_terminal_disposition_result
-      ~base_path
-      ~keeper_name
-      ~lease
-      ~source
-      ~terminal:second
-      ~settled_at:4.0
-  with
-  | Ok (P.Settled receipt) ->
-    (match P.exact_execution_binding_result ~base_path ~keeper_name with
-     | Ok None -> ()
-     | Ok (Some _) -> Alcotest.fail "settlement retained exact-execution binding"
-     | Error detail -> Alcotest.failf "settled binding reload failed: %s" detail);
-    (match P.active_lease_result ~base_path ~keeper_name with
-     | Ok None -> ()
-     | Ok (Some _) -> Alcotest.fail "settlement retained active lease"
-     | Error detail -> Alcotest.failf "settled lease reload failed: %s" detail);
-    let state =
-      match P.load_state_result ~base_path ~keeper_name with
-      | Ok state -> state
-      | Error detail ->
-        Alcotest.failf "reload canonical terminal state failed: %s" detail
-    in
-    Alcotest.(check int)
-      "reloaded state has no lease"
-      0
-      (List.length (Keeper_event_queue_state.leases state));
-    (match Keeper_event_queue_state.transition_outbox state with
-     | [ { receipt = durable_receipt; _ } ] ->
-       Alcotest.(check bool)
-         "canonical terminal receipt is durable"
-         true
-         (receipt = durable_receipt);
-       (match durable_receipt.settlement with
-        | P.Settle_exact
-            { outcome = P.Terminal cause
-            ; semantic = P.Exact_no_compaction
-            ; action = P.Consume_source
-            ; slot_id
-            ; call_id
-            ; _
-            } ->
-          Alcotest.(check bool)
-            "durable terminal retains canonical cause and identity"
-            true
-            (cause = first.cause
-             && String.equal slot_id first.slot_id
-             && String.equal call_id first.call_id)
-        | _ -> Alcotest.fail "durable receipt lost canonical exact terminal")
-     | _ -> Alcotest.fail "canonical terminal state has no exact durable receipt")
-  | Ok (P.Already_settled _) ->
-    Alcotest.fail "first canonical terminal settlement was already settled"
-  | Ok (P.Committed_followup_failed { detail; _ }) ->
-    Alcotest.failf "canonical terminal settlement follow-up failed: %s" detail
-  | Error detail -> Alcotest.failf "canonical terminal settlement failed: %s" detail
-;;
-
-let test_post_success_terminalization_failures_preserve_canonical () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  let cases =
-    [ "error", (fun _cause _observation -> Error "injected quarantine error")
-    ; "exception", (fun _cause _observation -> failwith "injected quarantine exception")
-    ]
-  in
-  List.iteri
-    (fun index (label, quarantine) ->
-       with_temp_dir ("masc-post-success-terminal-" ^ label)
-       @@ fun base_path ->
-       let keeper_name = "keeper-post-success-terminal-" ^ label in
-       let lease = claim_manual_lease ~base_path ~keeper_name in
-       let slot_id = Printf.sprintf "post-success-terminal-%s-%d" label index in
-       let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-       let snapshot =
-         F.resolver_snapshot
-           ~source:("masc post-success terminal " ^ label)
-           [ { id = slot_id; base_url = server.base_url } ]
-       in
-       let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-       let prepared = prepare_exn ~keeper_name ~registry in
-       let durable_guard =
-         Keeper_heartbeat_loop.For_testing.exact_execution_guard
-           ~base_path
-           ~keeper_name
-           ~lease
-       in
-       let quarantine_calls = ref 0 in
-       let guard : C.exact_execution_guard =
-         { durable_guard with
-           quarantine =
-             (fun cause observation ->
-                incr quarantine_calls;
-                quarantine cause observation)
-         }
-       in
-       let completed =
-         execute_prepared_lane
-           ~keeper_name
-           ~net
-           ~clock
-           ~exact_execution_guard:guard
-           prepared
-         |> completed_exn
-       in
-       let observation = C.completed_attempt_observation completed in
-       let terminalizer = C.completed_post_success_terminalizer completed in
-       let first =
-         C.terminalize_post_success
-           terminalizer
-           Keeper_event_queue_state.Invalid_structural_evidence
-       in
-       let replay =
-         C.terminalize_post_success
-           terminalizer
-           Keeper_event_queue_state.Checkpoint_persistence_failed
-       in
-       Alcotest.(check int) (label ^ " quarantine runs once") 1 !quarantine_calls;
-       Alcotest.(check bool)
-         (label ^ " preserves canonical terminal")
-         true
-         (first = replay);
-       match P.exact_execution_binding_result ~base_path ~keeper_name with
-       | Ok
-           (Some
-             { slot_id = durable_slot_id
-             ; call_id = durable_call_id
-             ; plan_fingerprint
-             ; request_body_sha256
-             ; status = P.Dispatch_uncertain
+  Alcotest.(check int) "terminalizer quarantines once" 1 !quarantine_calls;
+  Alcotest.(check bool) "terminalizer retains first canonical cause" true (first = replay);
+  let source = persisted_checkpoint_source_exn "trace-post-success-terminal" in
+  (match
+     settle_terminal_disposition_result
+       ~base_path
+       ~keeper_name
+       ~lease
+       ~source
+       ~terminal:replay
+       ~settled_at:4.0
+   with
+   | Ok (P.Settled receipt) ->
+     (match P.exact_execution_binding_result ~base_path ~keeper_name with
+      | Ok None -> ()
+      | Ok (Some _) -> Alcotest.fail "terminal settlement retained binding"
+      | Error detail -> Alcotest.failf "settled binding reload failed: %s" detail);
+     (match P.active_lease_result ~base_path ~keeper_name with
+      | Ok None -> ()
+      | Ok (Some _) -> Alcotest.fail "terminal settlement retained lease"
+      | Error detail -> Alcotest.failf "settled lease reload failed: %s" detail);
+     let state =
+       match P.load_state_result ~base_path ~keeper_name with
+       | Ok state -> state
+       | Error detail -> Alcotest.failf "canonical state reload failed: %s" detail
+     in
+     (match Keeper_event_queue_state.transition_outbox state with
+      | [ { receipt = durable_receipt; _ } ] ->
+        Alcotest.(check bool)
+          "canonical terminal receipt is durable"
+          true
+          (receipt = durable_receipt);
+        (match durable_receipt.settlement with
+         | P.Settle_exact
+             { outcome = P.Terminal cause
+             ; slot_id = durable_slot
+             ; call_id = durable_call
              ; _
-             }) ->
-         Alcotest.(check string)
-           (label ^ " retains slot identity")
-           observation.slot_id
-           durable_slot_id;
-         Alcotest.(check string)
-           (label ^ " retains call identity")
-           observation.call_id
-           durable_call_id;
-         Alcotest.(check string)
-           (label ^ " retains plan identity")
-           observation.receipt_plan_fingerprint
-           plan_fingerprint;
-         Alcotest.(check string)
-           (label ^ " retains request identity")
-           observation.receipt_request_body_sha256
-           request_body_sha256
-       | Ok (Some _) ->
-         Alcotest.failf "%s quarantine failure did not remain dispatch-uncertain" label
-       | Ok None -> Alcotest.failf "%s quarantine failure removed the binding" label
-       | Error detail ->
-         Alcotest.failf "%s quarantine failure binding reload failed: %s" label detail)
-    cases
+             } ->
+           Alcotest.(check bool)
+             "durable settlement retains canonical terminal identity"
+             true
+             (cause = first.cause
+              && String.equal durable_slot first.slot_id
+              && String.equal durable_call first.call_id)
+         | _ -> Alcotest.fail "durable receipt lost exact terminal")
+      | _ -> Alcotest.fail "canonical terminal outbox receipt is missing")
+   | Ok (P.Already_settled _) ->
+     Alcotest.fail "first terminal settlement was already settled"
+   | Ok (P.Committed_followup_failed { detail; _ }) ->
+     Alcotest.failf "terminal settlement follow-up failed: %s" detail
+   | Error detail -> Alcotest.failf "terminal settlement failed: %s" detail)
 ;;
 
 let () =
   Alcotest.run
-    "compaction exact-output conformance"
+    "compaction exact-flow conformance"
     [ ( "preparation"
       , [ Alcotest.test_case
-            "missing compaction lane is explicit degraded state"
+            "missing lane is explicit"
             `Quick
             test_missing_compaction_lane_is_explicit_degraded_state
         ; Alcotest.test_case
-            "ordered, effect-free, and one catalog generation"
+            "order, generation, and call ids are immutable"
             `Quick
-            test_preparation_is_ordered_effect_free_and_single_generation
+            test_preparation_freezes_order_generation_and_unique_call_ids
         ; Alcotest.test_case
-            "published snapshot replacement cannot mix"
+            "replacement cannot mix prepared generation"
             `Quick
-            test_published_snapshot_replacement_cannot_mix_prepared_lane
-        ; Alcotest.test_case
-            "missing credential is deferred past registry admission"
-            `Quick
-            test_missing_credential_is_deferred_past_registry_admission
-        ; Alcotest.test_case
-            "mixed unavailable slots are skipped in both orders"
-            `Quick
-            test_unavailable_slots_are_skipped_in_both_orders
-        ; Alcotest.test_case
-            "all unavailable slots return a typed error"
-            `Quick
-            test_all_unavailable_slots_are_typed
-        ; Alcotest.test_case
-            "unknown target is rejected by registry publication"
-            `Quick
-            test_unknown_target_is_rejected_by_registry_publication
+            test_published_replacement_cannot_mix_prepared_generation
         ] )
-    ; ( "effect boundary"
+    ; ( "durable flow callbacks"
       , [ Alcotest.test_case
-            "Before_dispatch/0 advances exactly once"
+            "release precedes successor bind and POST"
             `Quick
-            test_before_dispatch_zero_advances_exactly_once
+            test_durable_release_precedes_successor_bind_and_post
         ; Alcotest.test_case
-            "visible release uncertainty is source-bound terminal"
+            "bind failure prevents POST"
             `Quick
-            test_visible_release_uncertainty_is_source_bound_terminal
+            test_bind_failure_prevents_post
         ; Alcotest.test_case
-            "post-dispatch failure is terminal"
+            "release failure blocks successor"
             `Quick
-            test_post_dispatch_failure_is_terminal
+            test_release_failure_blocks_successor
         ; Alcotest.test_case
-            "domain-invalid JSON is terminal"
-            `Quick
-            test_domain_invalid_json_is_terminal
-        ; Alcotest.test_case
-            "post-dispatch cancellation is typed and terminal"
-            `Quick
-            test_post_dispatch_cancellation_is_typed_terminal
-        ; Alcotest.test_case
-            "durable dispatch guard failure prevents POST"
-            `Quick
-            test_before_rename_binding_failure_prevents_post
-        ; Alcotest.test_case
-            "missing dispatch guard prevents POST"
-            `Quick
-            test_missing_dispatch_guard_prevents_post
-        ; Alcotest.test_case
-            "quarantine persistence failure preserves original cause"
-            `Quick
-            test_quarantine_persistence_failure_preserves_original_cause
-        ; Alcotest.test_case
-            "heartbeat durable bind precedes POST"
+            "heartbeat guard binds before POST"
             `Quick
             test_heartbeat_guard_binds_before_post
-        ; Alcotest.test_case
-            "visible binding uncertainty prevents POST and settles"
-            `Quick
-            test_visible_unknown_binding_prevents_post_and_settles
-        ; Alcotest.test_case
-            "visible quarantine uncertainty preserves cause and settles"
-            `Quick
-            test_visible_unknown_quarantine_preserves_cause_and_settles
-        ; Alcotest.test_case
-            "post-success terminalization is affine"
-            `Quick
-            test_post_success_terminalization_is_affine
-        ; Alcotest.test_case
-            "post-success terminalization failures preserve canonical identity"
-            `Quick
-            test_post_success_terminalization_failures_preserve_canonical
         ] )
-    ; ( "Keeper isolation"
+    ; ( "terminal ownership"
       , [ Alcotest.test_case
-            "prepared attempts are not shared"
+            "domain invalidity never reenters failover"
             `Quick
-            test_keeper_preparations_do_not_share_attempt_state
+            test_domain_invalid_output_never_reenters_failover
         ; Alcotest.test_case
-            "prepared lane replay is affine"
+            "final OAS failure is generic terminal"
             `Quick
-            test_prepared_lane_replay_is_terminal_without_second_post
+            test_final_oas_flow_failure_is_generic_source_terminal
         ; Alcotest.test_case
-            "prepared lane concurrency is affine"
+            "cancellation quarantines bound identity"
             `Quick
-            test_prepared_lane_concurrency_is_affine
+            test_cancellation_quarantines_only_bound_identity
+        ; Alcotest.test_case
+            "terminalization is canonical and durable"
+            `Quick
+            test_post_success_terminalization_is_canonical_and_durable
+        ] )
+    ; ( "affinity and non-sharing"
+      , [ Alcotest.test_case
+            "independent flows do not share call identity"
+            `Quick
+            test_independent_preparations_do_not_share_call_identity
+        ; Alcotest.test_case
+            "same-flow loser mutates no queue"
+            `Quick
+            test_same_flow_concurrent_loser_mutates_no_queue
         ] )
     ]
 ;;

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -958,6 +958,508 @@ let test_post_success_terminalization_is_canonical_and_durable () =
    | Error detail -> Alcotest.failf "terminal settlement failed: %s" detail)
 ;;
 
+let test_post_success_terminalization_overlap_is_affine_and_durable () =
+  run_eio
+  @@ fun ~sw ~net ~clock ->
+  with_temp_dir "masc-post-success-terminal-overlap"
+  @@ fun base_path ->
+  let keeper_name = "keeper-post-success-terminal-overlap" in
+  let lease = claim_manual_lease ~base_path ~keeper_name in
+  let slot_id = "post-success-terminal-overlap" in
+  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+  let snapshot =
+    F.resolver_snapshot
+      ~source:"masc post-success terminal overlap"
+      [ { id = slot_id; base_url = server.base_url } ]
+  in
+  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+  let prepared = prepare_exn ~keeper_name ~registry in
+  let durable_guard =
+    Keeper_heartbeat_loop.For_testing.exact_execution_guard
+      ~base_path
+      ~keeper_name
+      ~lease
+  in
+  let quarantine_entered, resolve_quarantine_entered = Eio.Promise.create () in
+  let release_quarantine, resolve_release_quarantine = Eio.Promise.create () in
+  let quarantine_calls = ref 0 in
+  let guard : C.exact_execution_guard =
+    { durable_guard with
+      quarantine =
+        (fun cause observation ->
+           incr quarantine_calls;
+           Eio.Promise.resolve resolve_quarantine_entered ();
+           Eio.Promise.await release_quarantine;
+           durable_guard.quarantine cause observation)
+    }
+  in
+  let completed =
+    execute_prepared_lane
+      ~keeper_name
+      ~net
+      ~clock
+      ~exact_execution_guard:guard
+      prepared
+    |> completed_exn
+  in
+  let terminalizer = C.completed_post_success_terminalizer completed in
+  let first_result, resolve_first_result = Eio.Promise.create () in
+  let second_started, resolve_second_started = Eio.Promise.create () in
+  let second_result, resolve_second_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    C.terminalize_post_success
+      terminalizer
+      Keeper_event_queue_state.Invalid_structural_evidence
+    |> Eio.Promise.resolve resolve_first_result);
+  Eio.Promise.await quarantine_entered;
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Promise.resolve resolve_second_started ();
+    C.terminalize_post_success
+      terminalizer
+      Keeper_event_queue_state.Checkpoint_persistence_failed
+    |> Eio.Promise.resolve resolve_second_result);
+  Eio.Promise.await second_started;
+  Eio.Fiber.yield ();
+  Eio.Promise.resolve resolve_release_quarantine ();
+  let first = Eio.Promise.await first_result in
+  let second = Eio.Promise.await second_result in
+  Alcotest.(check int) "overlap performs one quarantine" 1 !quarantine_calls;
+  Alcotest.(check bool)
+    "overlap returns one canonical terminal"
+    true
+    (first = second);
+  Alcotest.(check bool)
+    "first concurrent cause remains canonical"
+    true
+    (first.cause = Keeper_event_queue_state.Invalid_structural_evidence);
+  let source = persisted_checkpoint_source_exn "trace-post-success-terminal-overlap" in
+  (match
+     settle_terminal_disposition_result
+       ~base_path
+       ~keeper_name
+       ~lease
+       ~source
+       ~terminal:second
+       ~settled_at:5.0
+   with
+   | Ok (P.Settled _) -> ()
+   | Ok (P.Already_settled _) ->
+     Alcotest.fail "first overlap settlement was already settled"
+   | Ok (P.Committed_followup_failed { detail; _ }) ->
+     Alcotest.failf "overlap settlement follow-up failed: %s" detail
+   | Error detail -> Alcotest.failf "overlap settlement failed: %s" detail);
+  (match P.exact_execution_binding_result ~base_path ~keeper_name with
+   | Ok None -> ()
+   | Ok (Some _) -> Alcotest.fail "overlap settlement retained exact binding"
+   | Error detail -> Alcotest.failf "overlap binding reload failed: %s" detail);
+  match P.transition_outbox_result ~base_path ~keeper_name with
+  | Ok [ _ ] -> ()
+  | Ok _ -> Alcotest.fail "overlap produced other than one durable settlement"
+  | Error detail -> Alcotest.failf "overlap outbox reload failed: %s" detail
+;;
+
+let test_post_success_terminalization_failures_preserve_full_binding () =
+  run_eio
+  @@ fun ~sw ~net ~clock ->
+  let cases =
+    [ "error", (fun _cause _observation -> Error "injected quarantine error")
+    ; "exception", (fun _cause _observation -> failwith "injected quarantine exception")
+    ]
+  in
+  List.iteri
+    (fun index (label, quarantine) ->
+       with_temp_dir ("masc-post-success-terminal-" ^ label)
+       @@ fun base_path ->
+       let keeper_name = "keeper-post-success-terminal-" ^ label in
+       let lease = claim_manual_lease ~base_path ~keeper_name in
+       let slot_id = Printf.sprintf "post-success-terminal-%s-%d" label index in
+       let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+       let snapshot =
+         F.resolver_snapshot
+           ~source:("masc post-success terminal " ^ label)
+           [ { id = slot_id; base_url = server.base_url } ]
+       in
+       let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+       let prepared = prepare_exn ~keeper_name ~registry in
+       let durable_guard =
+         Keeper_heartbeat_loop.For_testing.exact_execution_guard
+           ~base_path
+           ~keeper_name
+           ~lease
+       in
+       let quarantine_calls = ref 0 in
+       let guard : C.exact_execution_guard =
+         { durable_guard with
+           quarantine =
+             (fun cause observation ->
+                incr quarantine_calls;
+                quarantine cause observation)
+         }
+       in
+       let completed =
+         execute_prepared_lane
+           ~keeper_name
+           ~net
+           ~clock
+           ~exact_execution_guard:guard
+           prepared
+         |> completed_exn
+       in
+       let observation = C.completed_attempt_observation completed in
+       let terminalizer = C.completed_post_success_terminalizer completed in
+       let first =
+         C.terminalize_post_success
+           terminalizer
+           Keeper_event_queue_state.Invalid_structural_evidence
+       in
+       let replay =
+         C.terminalize_post_success
+           terminalizer
+           Keeper_event_queue_state.Checkpoint_persistence_failed
+       in
+       Alcotest.(check int) (label ^ " quarantine runs once") 1 !quarantine_calls;
+       Alcotest.(check bool)
+         (label ^ " replay returns canonical terminal")
+         true
+         (first = replay);
+       Alcotest.(check bool)
+         (label ^ " first cause remains canonical")
+         true
+         (first.cause = Keeper_event_queue_state.Invalid_structural_evidence);
+       match P.exact_execution_binding_result ~base_path ~keeper_name with
+       | Ok
+           (Some
+             { slot_id = durable_slot_id
+             ; call_id = durable_call_id
+             ; plan_fingerprint
+             ; request_body_sha256
+             ; status = P.Dispatch_uncertain
+             ; _
+             }) ->
+         Alcotest.(check string)
+           (label ^ " retains slot identity")
+           observation.slot_id
+           durable_slot_id;
+         Alcotest.(check string)
+           (label ^ " retains call identity")
+           observation.call_id
+           durable_call_id;
+         Alcotest.(check string)
+           (label ^ " retains plan identity")
+           observation.receipt_plan_fingerprint
+           plan_fingerprint;
+         Alcotest.(check string)
+           (label ^ " retains request identity")
+           observation.receipt_request_body_sha256
+           request_body_sha256
+       | Ok (Some _) ->
+         Alcotest.failf "%s quarantine failure did not remain dispatch-uncertain" label
+       | Ok None -> Alcotest.failf "%s quarantine failure removed the binding" label
+       | Error detail ->
+         Alcotest.failf "%s quarantine failure binding reload failed: %s" label detail)
+    cases
+;;
+
+let test_visible_sync_uncertainty_seams () =
+  run_eio
+  @@ fun ~sw ~net ~clock ->
+  let bind_visibility () =
+    with_temp_dir "masc-visible-bind"
+    @@ fun base_path ->
+    let keeper_name = "keeper-visible-bind" in
+    let lease = claim_manual_lease ~base_path ~keeper_name in
+    let slot_id = "visible-bind" in
+    let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+    let snapshot =
+      F.resolver_snapshot
+        ~source:"masc visible bind"
+        [ { id = slot_id; base_url = server.base_url } ]
+    in
+    let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+    let prepared = prepare_exn ~keeper_name ~registry in
+    let observation = observation_exn prepared slot_id in
+    let durable_guard =
+      Keeper_heartbeat_loop.For_testing.exact_execution_guard
+        ~base_path
+        ~keeper_name
+        ~lease
+    in
+    let bind_calls = ref 0 in
+    let guard : C.exact_execution_guard =
+      { durable_guard with
+        before_dispatch =
+          (fun candidate ->
+             incr bind_calls;
+             match durable_guard.before_dispatch candidate with
+             | Ok C.Fsync_completed ->
+               Ok (C.Visible_sync_unconfirmed "injected bind visibility uncertainty")
+             | Ok (C.Visible_sync_unconfirmed _ as outcome) -> Ok outcome
+             | Error _ as error -> error)
+      }
+    in
+    let terminal =
+      match
+        execute_prepared_lane
+          ~keeper_name
+          ~net
+          ~clock
+          ~exact_execution_guard:guard
+          prepared
+      with
+      | Error (C.Exact_execution_terminal terminal) -> terminal
+      | Error _ -> Alcotest.fail "visible bind returned the wrong terminal"
+      | Ok _ -> Alcotest.fail "visible bind unexpectedly dispatched"
+    in
+    Alcotest.(check int) "visible bind callback runs once" 1 !bind_calls;
+    Alcotest.(check int) "visible bind prevents POST" 0 (F.post_count server);
+    Alcotest.(check bool)
+      "visible bind uses persistence terminal"
+      true
+      (terminal.cause = Keeper_event_queue_state.Terminal_persistence_failed);
+    Alcotest.(check string) "visible bind terminal slot" observation.slot_id terminal.slot_id;
+    Alcotest.(check string) "visible bind terminal call" observation.call_id terminal.call_id;
+    Alcotest.(check string)
+      "visible bind terminal plan"
+      observation.receipt_plan_fingerprint
+      terminal.plan_fingerprint;
+    Alcotest.(check string)
+      "visible bind terminal request"
+      observation.receipt_request_body_sha256
+      terminal.request_body_sha256;
+    match P.exact_execution_binding_result ~base_path ~keeper_name with
+    | Ok
+        (Some
+          { status = P.Dispatch_uncertain
+          ; slot_id = durable_slot_id
+          ; call_id = durable_call_id
+          ; plan_fingerprint
+          ; request_body_sha256
+          ; _
+          }) ->
+      Alcotest.(check string) "visible bind durable slot" observation.slot_id durable_slot_id;
+      Alcotest.(check string) "visible bind durable call" observation.call_id durable_call_id;
+      Alcotest.(check string)
+        "visible bind durable plan"
+        observation.receipt_plan_fingerprint
+        plan_fingerprint;
+      Alcotest.(check string)
+        "visible bind durable request"
+        observation.receipt_request_body_sha256
+        request_body_sha256
+    | Ok (Some _) -> Alcotest.fail "visible bind retained the wrong durable status"
+    | Ok None -> Alcotest.fail "visible bind lost durable identity"
+    | Error detail -> Alcotest.failf "visible bind reload failed: %s" detail
+  in
+  let release_visibility () =
+    with_temp_dir "masc-visible-release"
+    @@ fun base_path ->
+    let keeper_name = "keeper-visible-release" in
+    let lease = claim_manual_lease ~base_path ~keeper_name in
+    let first_slot = "visible-release-first" in
+    let successor_slot = "visible-release-successor" in
+    let successor = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
+    let snapshot =
+      F.resolver_snapshot
+        ~source:"masc visible release"
+        [ { id = first_slot; base_url = "http://127.0.0.1:9" }
+        ; { id = successor_slot; base_url = successor.base_url }
+        ]
+    in
+    let registry = publish_exn ~slot_ids:[ first_slot; successor_slot ] snapshot in
+    let prepared = prepare_exn ~keeper_name ~registry in
+    let first_observation = observation_exn prepared first_slot in
+    let durable_guard =
+      Keeper_heartbeat_loop.For_testing.exact_execution_guard
+        ~base_path
+        ~keeper_name
+        ~lease
+    in
+    let bound_slots = ref [] in
+    let release_calls = ref 0 in
+    let guard : C.exact_execution_guard =
+      { before_dispatch =
+          (fun candidate ->
+             bound_slots := candidate.slot_id :: !bound_slots;
+             durable_guard.before_dispatch candidate)
+      ; release_before_dispatch =
+          (fun candidate ->
+             incr release_calls;
+             match durable_guard.release_before_dispatch candidate with
+             | Ok C.Fsync_completed ->
+               Ok (C.Visible_sync_unconfirmed "injected release visibility uncertainty")
+             | Ok (C.Visible_sync_unconfirmed _ as outcome) -> Ok outcome
+             | Error _ as error -> error)
+      ; quarantine = durable_guard.quarantine
+      }
+    in
+    let terminal =
+      match
+        execute_prepared_lane
+          ~keeper_name
+          ~net
+          ~clock
+          ~exact_execution_guard:guard
+          prepared
+      with
+      | Error (C.Exact_execution_terminal terminal) -> terminal
+      | Error _ -> Alcotest.fail "visible release returned the wrong terminal"
+      | Ok _ -> Alcotest.fail "visible release incorrectly advanced"
+    in
+    Alcotest.(check (list string))
+      "visible release never binds successor"
+      [ first_slot ]
+      (List.rev !bound_slots);
+    Alcotest.(check int) "visible release callback runs once" 1 !release_calls;
+    Alcotest.(check int)
+      "visible release prevents successor POST"
+      0
+      (F.post_count successor);
+    Alcotest.(check bool)
+      "visible release uses persistence terminal"
+      true
+      (terminal.cause = Keeper_event_queue_state.Terminal_persistence_failed);
+    Alcotest.(check string)
+      "visible release stays on A slot"
+      first_observation.slot_id
+      terminal.slot_id;
+    Alcotest.(check string)
+      "visible release stays on A call"
+      first_observation.call_id
+      terminal.call_id;
+    Alcotest.(check string)
+      "visible release stays on A plan"
+      first_observation.receipt_plan_fingerprint
+      terminal.plan_fingerprint;
+    Alcotest.(check string)
+      "visible release stays on A request"
+      first_observation.receipt_request_body_sha256
+      terminal.request_body_sha256
+  in
+  let quarantine_visibility () =
+    with_temp_dir "masc-visible-quarantine"
+    @@ fun base_path ->
+    let keeper_name = "keeper-visible-quarantine" in
+    let lease = claim_manual_lease ~base_path ~keeper_name in
+    let slot_id = "visible-quarantine" in
+    let server =
+      F.start_server ~sw ~net ~clock (F.Reply domain_invalid_response)
+    in
+    let snapshot =
+      F.resolver_snapshot
+        ~source:"masc visible quarantine"
+        [ { id = slot_id; base_url = server.base_url } ]
+    in
+    let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+    let prepared = prepare_exn ~keeper_name ~registry in
+    let observation = observation_exn prepared slot_id in
+    let durable_guard =
+      Keeper_heartbeat_loop.For_testing.exact_execution_guard
+        ~base_path
+        ~keeper_name
+        ~lease
+    in
+    let quarantine_calls = ref 0 in
+    let guard : C.exact_execution_guard =
+      { durable_guard with
+        quarantine =
+          (fun cause candidate ->
+             incr quarantine_calls;
+             match durable_guard.quarantine cause candidate with
+             | Ok C.Fsync_completed ->
+               Ok (C.Visible_sync_unconfirmed "injected quarantine visibility uncertainty")
+             | Ok (C.Visible_sync_unconfirmed _ as outcome) -> Ok outcome
+             | Error _ as error -> error)
+      }
+    in
+    let terminal =
+      match
+        execute_prepared_lane
+          ~keeper_name
+          ~net
+          ~clock
+          ~exact_execution_guard:guard
+          prepared
+      with
+      | Error (C.Exact_execution_terminal terminal) -> terminal
+      | Error _ -> Alcotest.fail "visible quarantine returned the wrong terminal"
+      | Ok _ -> Alcotest.fail "domain-invalid output unexpectedly succeeded"
+    in
+    Alcotest.(check int) "visible quarantine callback runs once" 1 !quarantine_calls;
+    Alcotest.(check int) "visible quarantine follows one POST" 1 (F.post_count server);
+    Alcotest.(check bool)
+      "visible quarantine preserves original cause"
+      true
+      (terminal.cause = Keeper_event_queue_state.Domain_invalid_output);
+    Alcotest.(check string)
+      "visible quarantine preserves slot"
+      observation.slot_id
+      terminal.slot_id;
+    Alcotest.(check string)
+      "visible quarantine preserves call"
+      observation.call_id
+      terminal.call_id;
+    Alcotest.(check string)
+      "visible quarantine preserves plan"
+      observation.receipt_plan_fingerprint
+      terminal.plan_fingerprint;
+    Alcotest.(check string)
+      "visible quarantine preserves request"
+      observation.receipt_request_body_sha256
+      terminal.request_body_sha256;
+    let source = persisted_checkpoint_source_exn "trace-visible-quarantine" in
+    let receipt =
+      match
+        settle_terminal_disposition_result
+          ~base_path
+          ~keeper_name
+          ~lease
+          ~source
+          ~terminal
+          ~settled_at:6.0
+      with
+      | Ok (P.Settled receipt) -> receipt
+      | Ok (P.Already_settled _) ->
+        Alcotest.fail "first visible quarantine settlement was already settled"
+      | Ok (P.Committed_followup_failed { detail; _ }) ->
+        Alcotest.failf "visible quarantine settlement follow-up failed: %s" detail
+      | Error detail -> Alcotest.failf "visible quarantine settlement failed: %s" detail
+    in
+    (match P.exact_execution_binding_result ~base_path ~keeper_name with
+     | Ok None -> ()
+     | Ok (Some _) -> Alcotest.fail "visible quarantine settlement retained binding"
+     | Error detail ->
+       Alcotest.failf "visible quarantine binding reload failed: %s" detail);
+    match P.transition_outbox_result ~base_path ~keeper_name with
+    | Ok [ { receipt = durable_receipt; _ } ] ->
+      Alcotest.(check bool)
+        "visible quarantine has exactly one durable settlement"
+        true
+        (receipt = durable_receipt);
+      (match durable_receipt.settlement with
+       | P.Settle_exact
+           { outcome = P.Terminal cause
+           ; slot_id = durable_slot
+           ; call_id = durable_call
+           ; _
+           } ->
+         Alcotest.(check bool)
+           "visible quarantine settlement preserves cause and identity"
+           true
+           (cause = terminal.cause
+            && String.equal durable_slot terminal.slot_id
+            && String.equal durable_call terminal.call_id)
+       | _ -> Alcotest.fail "visible quarantine lost exact terminal settlement")
+    | Ok _ -> Alcotest.fail "visible quarantine produced multiple settlements"
+    | Error detail -> Alcotest.failf "visible quarantine outbox reload failed: %s" detail
+  in
+  List.iter
+    (fun (_label, run) -> run ())
+    [ "bind", bind_visibility
+    ; "release", release_visibility
+    ; "quarantine", quarantine_visibility
+    ]
+;;
+
 let () =
   Alcotest.run
     "compaction exact-flow conformance"
@@ -992,6 +1494,10 @@ let () =
             "heartbeat guard binds before POST"
             `Quick
             test_heartbeat_guard_binds_before_post
+        ; Alcotest.test_case
+            "visible sync uncertainty seams fail closed"
+            `Quick
+            test_visible_sync_uncertainty_seams
         ] )
     ; ( "terminal ownership"
       , [ Alcotest.test_case
@@ -1010,6 +1516,14 @@ let () =
             "terminalization is canonical and durable"
             `Quick
             test_post_success_terminalization_is_canonical_and_durable
+        ; Alcotest.test_case
+            "terminalization overlap is affine and durable"
+            `Quick
+            test_post_success_terminalization_overlap_is_affine_and_durable
+        ; Alcotest.test_case
+            "terminalization failures preserve full binding"
+            `Quick
+            test_post_success_terminalization_failures_preserve_full_binding
         ] )
     ; ( "affinity and non-sharing"
       , [ Alcotest.test_case

--- a/test/test_compaction_exact_output_entrypoint_clockless.ml
+++ b/test/test_compaction_exact_output_entrypoint_clockless.ml
@@ -112,10 +112,11 @@ let with_clockless_eio_context env sw f =
     | Some _ -> fail "clock was installed inside the clockless exact-output scope")
 ;;
 
-let test_invalid_plan_is_distinct_from_before_dispatch_failure () =
-  (* Both typed failures cross the real production composition boundary:
-     domain-invalid output dispatches once, while a timeout requiring an absent
-     clock is rejected before dispatch and performs no POST. *)
+let test_domain_invalid_and_clockless_flow_failure_are_terminal () =
+  (* Both typed failures cross the real production composition boundary.
+     MASC never reads receipt phase/count: domain-invalid output remains a
+     domain terminal, while the opaque OAS flow failure becomes a generic
+     source-bound execution terminal. *)
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
@@ -148,8 +149,12 @@ let test_invalid_plan_is_distinct_from_before_dispatch_failure () =
         ~source:"post-turn domain-invalid plan"
         invalid_server;
       (match decision () with
-       | Compact_policy.Rejected (Manual, Invalid_compaction_plan) -> ()
-       | _ -> fail "invalid provider plan was not a typed source terminal");
+       | Compact_policy.Rejected
+           ( Manual
+           , Exact_execution_terminal
+               { cause = Keeper_event_queue_state.Domain_invalid_output; _ } ) ->
+         ()
+       | _ -> fail "invalid domain plan was not a typed source terminal");
       check int
         "domain-invalid plan dispatches exactly once"
         1
@@ -166,8 +171,12 @@ let test_invalid_plan_is_distinct_from_before_dispatch_failure () =
         ~source:"post-turn before-dispatch rejection"
         before_dispatch_server;
       (match decision () with
-       | Compact_policy.Rejected (Manual, Exact_execution_failed_before_dispatch) -> ()
-       | _ -> fail "pre-dispatch execution failure was collapsed into an invalid plan");
+       | Compact_policy.Rejected
+           ( Manual
+           , Exact_execution_terminal
+               { cause = Keeper_event_queue_state.Exact_execution_failed; _ } ) ->
+         ()
+       | _ -> fail "clockless OAS flow failure was not a generic source terminal");
       check int
         "before-dispatch lane performs no HTTP request"
         0
@@ -179,9 +188,9 @@ let () =
     "compaction exact-output clockless entrypoint"
     [ ( "production entrypoint"
       , [ test_case
-            "invalid plan is distinct from before-dispatch failure"
+            "domain invalid and clockless flow failure are terminal"
             `Quick
-            test_invalid_plan_is_distinct_from_before_dispatch_failure
+            test_domain_invalid_and_clockless_flow_failure_are_terminal
         ] )
     ]
 ;;

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -156,10 +156,8 @@ let test_exact_output_terminal_reasons_round_trip () =
          "exact terminal receipt retains call provenance"
          true
          (State.transition_receipt_equal receipt restored))
-    [ State.Execution_failed_after_dispatch
-    ; State.Attempt_already_started
-    ; State.Execution_cancelled_after_dispatch
-    ; State.Execution_provenance_mismatch
+    [ State.Exact_execution_failed
+    ; State.Exact_execution_cancelled
     ; State.Domain_invalid_output
     ; State.Invalid_structural_evidence
     ; State.Invalid_structural_source_after_dispatch
@@ -204,7 +202,7 @@ let test_exact_terminal_codec_rejects_missing_or_blank_call_identity () =
         (State.No_compaction
            (no_compaction
               ~turn_count:7
-              (exact_terminal State.Execution_cancelled_after_dispatch)))
+              (exact_terminal State.Exact_execution_cancelled)))
       claimed
     |> require_ok "settle closed exact terminal"
   in
@@ -285,7 +283,7 @@ let test_cancelled_exact_terminal_consumes_queue_durably () =
               (exact_terminal
                  ~slot_id:"cancelled-slot"
                  ~call_id:"cancelled-call"
-                 State.Execution_cancelled_after_dispatch)))
+                 State.Exact_execution_cancelled)))
       claimed
     |> require_ok "settle cancelled exact terminal"
   in
@@ -1570,14 +1568,14 @@ let test_in_lane_compaction_streak_bounds_retries () =
          })
       (no_compaction
          ~turn_count:14
-         (exact_terminal State.Execution_failed_after_dispatch))
+         (exact_terminal State.Exact_execution_failed))
   in
   (match dispatch_terminal with
    | Masc.Keeper_registry_event_queue.Escalate
        { reason =
            Masc.Keeper_registry_event_queue.Compaction_exact_output_terminal
              { terminal =
-                 { cause = State.Execution_failed_after_dispatch; _ }
+                 { cause = State.Exact_execution_failed; _ }
              ; _
              }
        ; successor = None
@@ -1752,7 +1750,7 @@ let test_compaction_outcome_mapping_covers_in_lane_dispositions () =
        (Masc.Keeper_unified_turn.source_lease_disposition_after_no_compaction
           (no_compaction
              ~turn_count:18
-             (exact_terminal State.Execution_failed_after_dispatch))));
+             (exact_terminal State.Exact_execution_failed))));
   check
     "domain-invalid terminal records failure without retry"
     "failed"

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -184,7 +184,7 @@ let test_before_dispatch_release_allows_registration_requeue () =
    | Ok (Some _) -> Alcotest.fail "before-dispatch release retained the binding"
    | Error detail -> Alcotest.failf "released binding load failed: %s" detail);
   let terminal : P.exact_execution_terminal =
-    { cause = P.Execution_failed_after_dispatch
+    { cause = P.Exact_execution_failed
     ; slot_id
     ; call_id
     ; plan_fingerprint
@@ -276,7 +276,7 @@ let test_restart_recovery_never_requeues_bound_lease () =
     bind_and_quarantine
       ~base_path
       ~keeper_name
-      ~cause:P.Execution_failed_after_dispatch
+      ~cause:P.Exact_execution_failed
       ~slot_id
       ~call_id
       ~plan_fingerprint
@@ -465,7 +465,7 @@ let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
     bind_and_quarantine
       ~base_path
       ~keeper_name
-      ~cause:P.Execution_failed_after_dispatch
+      ~cause:P.Exact_execution_failed
       ~slot_id
       ~call_id
       ~plan_fingerprint
@@ -597,7 +597,7 @@ let test_visible_prepare_sync_failure_recovers_once () =
     bind_and_quarantine
       ~base_path
       ~keeper_name
-      ~cause:P.Execution_failed_after_dispatch
+      ~cause:P.Exact_execution_failed
       ~slot_id
       ~call_id
       ~plan_fingerprint
@@ -681,7 +681,7 @@ let test_stale_finalize_preserves_active_successor () =
     bind_and_quarantine
       ~base_path
       ~keeper_name
-      ~cause:P.Execution_failed_after_dispatch
+      ~cause:P.Exact_execution_failed
       ~slot_id:"slot-stale"
       ~call_id:"call-stale"
       ~plan_fingerprint:"plan-stale"
@@ -803,7 +803,7 @@ let test_cancellation_surfaces_only_after_terminal_settlement () =
     bind_and_quarantine
       ~base_path
       ~keeper_name
-      ~cause:P.Execution_cancelled_after_dispatch
+      ~cause:P.Exact_execution_cancelled
       ~slot_id
       ~call_id
       ~plan_fingerprint

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -146,7 +146,7 @@ let test_final_admission_busy_requeues_only_pre_dispatch_no_compaction () =
     true
     (preserves
        (Keeper_event_queue_state.Exact_execution_terminal
-          (exact_terminal Keeper_event_queue_state.Execution_failed_after_dispatch)))
+          (exact_terminal Keeper_event_queue_state.Exact_execution_failed)))
 ;;
 
 let test_empty_projection_target_is_typed () =


### PR DESCRIPTION
## Summary

- replace MASC-local compaction candidate admission/attempt loop with one OAS `Exact_output` flow: `make_flow_candidate` -> `admit_flow` -> `start_flow` -> `execute_flow_once`
- keep only MASC-owned ordered opaque slot identity, domain Input/Output validation, and durable bind/release/quarantine callbacks
- let OAS exclusively own admission, affine attempts, execute-once, receipt semantics, advancement, and failover
- remove receipt phase/count inspection, local recursive failover, ready-plan retention, provider/admission cause interpretation, and provenance revalidation

## Durable boundary

- bind candidate A before its effect
- only OAS may nominate B; MASC must fsync release A before OAS can bind and dispatch B
- missing guard or bind failure performs no POST
- release failure cannot bind or POST a successor
- final OAS flow failure becomes one generic source-bound `Exact_execution_failed` terminal/quarantine
- cancellation before durable bind is re-raised
- once callback-confirmed durable bind exists, cancellation is a phase-neutral source-bound terminal unless OAS first invokes the release callback; MASC never infers dispatch state from receipt phase/count or cancellation
- domain-invalid MASC output is terminal outside OAS failover
- same-flow concurrent loser executes no queue callback and cannot issue a second POST

## Breaking current-schema hard cut

Pre-1.0 runtime JSON compatibility is intentionally not preserved.

- replace phase-asserting terminal labels with `exact_execution_failed` and `exact_execution_cancelled`
- remove durable `attempt_already_started` and `execution_provenance_mismatch` terminal variants
- remove the retry label `exact_execution_failed_before_dispatch`; durable callback failure is now `exact_execution_guard_failed`
- old persisted state containing removed labels is rejected by the current decoder; operators start from fresh pre-1.0 state
- no compatibility decoder, migration, fallback, silent reinterpretation, or reconciliation path is included

## Tests and ratchet

- replace OAS-internal receipt/credential/ready-plan duplication with MASC seam proofs for ordering, non-sharing, concurrency, durable callback order, guard/bind no-POST fences, no domain failover, bound cancellation, immutable generation, and terminal settlement
- add `scripts/check-compaction-exact-flow-boundary.sh` plus blocking lint self-test/check

## Local validation

- changed-file `ocamlformat -i`
- `scripts/check-compaction-exact-flow-boundary.sh --self-test`
- `scripts/check-compaction-exact-flow-boundary.sh`
- `git diff --check`

Per operator instruction, no local Dune build or test suite was run; CI is the build authority.
