### PR TITLE
fix(hitl): close post-merge exact flow gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1049,7 +1049,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [pr-live-gate, changes]
-    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true' || needs.changes.outputs.keeper_cwd == 'true') }}
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true' || needs.changes.outputs.dashboard == 'true' || needs.changes.outputs.keeper_cwd == 'true') }}
 
     steps:
       - name: Checkout
@@ -1067,7 +1067,7 @@ jobs:
         run: scripts/stringly-boundary-ratchet.sh
 
       - name: Run OAS boundary ratchet
-        if: needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true'
+        if: needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true' || needs.changes.outputs.dashboard == 'true'
         run: |
           scripts/test_oas_boundary_ratchet.sh
           scripts/oas-boundary-ratchet.sh

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -478,6 +478,13 @@ let settle_current (entry : pending_approval) ~reason ~cause =
     Ok ()
   | Some { exact_attempt = Exact_unbound; _ } ->
     mark_unbound_failure entry reason
+  | Some
+      { exact_attempt =
+          Exact_bound { status = (Exact_completed | Exact_quarantined _); _ }
+      ; _
+      } ->
+    record_outcome "exact_source_resolved";
+    Ok ()
   | Some { exact_attempt = Exact_bound binding; _ } ->
     quarantine_identity_result entry (exact_identity_of_binding binding) cause
 ;;

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -106,6 +106,16 @@ let flow_candidates selected_slots =
   loop [] selected_slots
 ;;
 
+let admit_resolved_lane ~messages (resolved : Registry.resolved_lane) =
+  let* candidates = flow_candidates resolved.selected_slots in
+  match candidates with
+  | [] -> Error "HITL exact-output lane has no usable candidates"
+  | first :: rest ->
+    Exact_output.admit_flow ~first ~rest ~messages output_requirement
+    |> Result.map_error (fun _ ->
+      "HITL exact-output flow admitted no candidates")
+;;
+
 let prepare_flow ~(entry : pending_approval) =
   let* context_bundle =
     build_context_bundle ~entry
@@ -124,18 +134,10 @@ let prepare_flow ~(entry : pending_approval) =
     Registry.resolve_lane registry ~lane_id
     |> Result.map_error lane_error
   in
-  let* candidates = flow_candidates resolved.selected_slots in
   let* ready_flow =
-    match candidates with
-    | [] -> Error "HITL exact-output lane has no usable candidates"
-    | first :: rest ->
-      Exact_output.admit_flow
-        ~first
-        ~rest
-        ~messages:(messages_for_summary ~system_prompt ~context_bundle)
-        output_requirement
-      |> Result.map_error (fun _ ->
-        "HITL exact-output flow admitted no candidates")
+    admit_resolved_lane
+      ~messages:(messages_for_summary ~system_prompt ~context_bundle)
+      resolved
   in
   let* attempt =
     Exact_output.start_flow ready_flow
@@ -146,11 +148,17 @@ let prepare_flow ~(entry : pending_approval) =
 ;;
 
 let readiness () =
-  let* (_ : string) = system_prompt () in
+  let* system_prompt = system_prompt () in
   let* registry = Registry.current () |> Result.map_error registry_error in
-  let* (_ : Registry.resolved_lane) =
+  let* resolved =
     Registry.resolve_lane registry ~lane_id
     |> Result.map_error lane_error
+  in
+  let* _ready_flow =
+    admit_resolved_lane
+      ~messages:
+        (messages_for_summary ~system_prompt ~context_bundle:(`Assoc []))
+      resolved
   in
   Ok ()
 ;;

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -6,7 +6,8 @@
 
 val readiness : unit -> (unit, string) result
 (** Verify that the Gate prompt and the registry-owned [hitl_auto_judge] exact
-    lane are currently available. No provider/model/runtime scalar is read. *)
+    lane are currently available and that OAS admits at least one candidate for
+    the HITL output requirement. No provider/model/runtime scalar is read. *)
 
 exception Exact_terminalization_persistence_failed of string
 

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -2329,7 +2329,12 @@ let restart_failed_summaries ~base_path =
                    , Exact_bound
                        { status = Exact_released_recovery_required; _ } ) ->
                    true
-                 | Summary_failed _, _ -> true
+                 | Summary_failed _, Exact_unbound -> true
+                 | ( Summary_failed _
+                   , Exact_bound
+                       { status = Exact_released_before_dispatch; _ } ) ->
+                   true
+                 | Summary_failed _, Exact_bound _ -> false
                  | ( Summary_not_requested
                    | Summary_available _
                    | Summary_pending ),

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -489,7 +489,7 @@ let rec spawn_claimed_auto_judge_entry_with
            ()
        with
        | Ok () -> Ok Started
-       | Error reason -> fail_before_worker ~reason ~retryable:false
+       | Error reason -> fail_before_worker ~reason ~retryable:true
      with
      | Eio.Cancel.Cancelled _ as exn ->
        release_auto_judge entry;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1107,13 +1107,6 @@ let load_list_internal ~(config_path : string) ~validate_max_context
   materialize_config ~validate_max_context ~config_path cfg
 ;;
 
-let load_exact_output_lane_declarations ~config_path =
-  let* _, exact_output_lane_decls =
-    load_list_internal ~config_path ~validate_max_context:true
-  in
-  Ok exact_output_lane_decls
-;;
-
 let load_list ~config_path =
   load_list_internal ~config_path ~validate_max_context:true
   |> Result.map fst
@@ -1237,6 +1230,22 @@ let init_default_degraded_report ~config_path =
              Ok (Initialized_degraded degradation))))
 
 let runtime_state () = Atomic.get loaded_state_ref
+
+let effective_exact_output_lane_declarations exact_output_lane_decls =
+  let state = runtime_state () in
+  match state.default_runtime with
+  | None ->
+    Error
+      "runtime exact-output lanes: effective runtime state is not initialized"
+  | Some default_runtime ->
+    ensure_hitl_auto_judge_lane
+      ~runtimes:state.runtimes
+      ~default_runtime
+      ~librarian_runtime_id:state.librarian_runtime_id
+      ~structured_judge_runtime_id:state.structured_judge_runtime_id
+      ~lanes:state.lanes
+      exact_output_lane_decls
+;;
 
 let get_default_runtime () = (runtime_state ()).default_runtime
 let get_runtimes () = (runtime_state ()).runtimes

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -926,6 +926,60 @@ let degrade_loaded_for_missing_catalog
       , degradation )
 ;;
 
+let hitl_auto_judge_lane_id = "hitl_auto_judge"
+
+let ensure_hitl_auto_judge_lane
+    ~runtimes
+    ~default_runtime
+    ~librarian_runtime_id
+    ~structured_judge_runtime_id
+    ~lanes
+    exact_output_lane_decls
+  =
+  if
+    List.exists
+      (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+         String.equal lane.id hitl_auto_judge_lane_id)
+      exact_output_lane_decls
+  then
+    Ok exact_output_lane_decls
+  else
+    let assignment_id =
+      match structured_judge_runtime_id, librarian_runtime_id with
+      | Some runtime_id, _ | None, Some runtime_id -> runtime_id
+      | None, None -> default_runtime.id
+    in
+    let slot_ids =
+      match
+        List.find_opt
+          (fun (lane : Runtime_lane.t) ->
+             String.equal lane.id assignment_id)
+          lanes
+      with
+      | Some lane -> lane.candidates
+      | None ->
+        (match
+           List.find_opt
+             (fun (runtime : t) ->
+                String.equal runtime.id assignment_id)
+             runtimes
+         with
+         | Some runtime -> [ runtime.id ]
+         | None -> [])
+    in
+    (match slot_ids with
+     | [] ->
+       Error
+         (Printf.sprintf
+            "runtime exact-output lane %S cannot derive slots from structured-judge assignment %S"
+            hitl_auto_judge_lane_id
+            assignment_id)
+     | _ ->
+       Ok
+         (exact_output_lane_decls
+          @ [ { Runtime_schema.id = hitl_auto_judge_lane_id; slot_ids } ]))
+;;
+
 let materialize_config
     ?(validate_max_context = true)
     ~(config_path : string)
@@ -1000,16 +1054,26 @@ let materialize_config
      [load_list] stays a routing-validity parser for tests and config probes.
      Startup callers choose fail-closed [init_default_strict] or server-visible
      degraded boot [init_default_degraded_report]. *)
-  Ok
-    ( ( runtimes
-      , rt
-      , assignments
-      , cfg.librarian_runtime_id
-      , cfg.structured_judge_runtime_id
-      , cfg.cross_verifier_runtime_id
-      , cfg.media_failover
-      , lanes )
-    , cfg.exact_output_lane_decls )
+  let loaded =
+    ( runtimes
+    , rt
+    , assignments
+    , cfg.librarian_runtime_id
+    , cfg.structured_judge_runtime_id
+    , cfg.cross_verifier_runtime_id
+    , cfg.media_failover
+    , lanes )
+  in
+  let* exact_output_lane_decls =
+    ensure_hitl_auto_judge_lane
+      ~runtimes
+      ~default_runtime:rt
+      ~librarian_runtime_id:cfg.librarian_runtime_id
+      ~structured_judge_runtime_id:cfg.structured_judge_runtime_id
+      ~lanes
+      cfg.exact_output_lane_decls
+  in
+  Ok (loaded, exact_output_lane_decls)
 ;;
 
 let load_list_internal ~(config_path : string) ~validate_max_context
@@ -1041,6 +1105,13 @@ let load_list_internal ~(config_path : string) ~validate_max_context
         detail)
   in
   materialize_config ~validate_max_context ~config_path cfg
+;;
+
+let load_exact_output_lane_declarations ~config_path =
+  let* _, exact_output_lane_decls =
+    load_list_internal ~config_path ~validate_max_context:true
+  in
+  Ok exact_output_lane_decls
 ;;
 
 let load_list ~config_path =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -124,13 +124,14 @@ val load_list :
     keeper→runtime-id list; [media_failover] is the RFC-0265 ordered reroute
     list; [lanes] is the ordered failover candidate lists. *)
 
-val load_exact_output_lane_declarations :
-  config_path:string ->
+val effective_exact_output_lane_declarations :
+  Runtime_schema.exact_output_lane_decl list ->
   (Runtime_schema.exact_output_lane_decl list, string) result
-(** Parse and materialize the effective exact-output lanes from runtime.toml.
+(** Materialize exact-output lanes from the initialized effective runtime state.
     When [hitl_auto_judge] is not explicitly declared, its opaque slot ids are
-    derived from the structured-judge assignment through the same pure path used
-    by runtime config writes. *)
+    derived from the effective structured-judge assignment through the same pure
+    path used by runtime config writes. This never reparses or revalidates
+    runtimes disabled by degraded startup. *)
 
 val runtime_ids : t list -> string list
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -124,6 +124,14 @@ val load_list :
     keeper→runtime-id list; [media_failover] is the RFC-0265 ordered reroute
     list; [lanes] is the ordered failover candidate lists. *)
 
+val load_exact_output_lane_declarations :
+  config_path:string ->
+  (Runtime_schema.exact_output_lane_decl list, string) result
+(** Parse and materialize the effective exact-output lanes from runtime.toml.
+    When [hitl_auto_judge] is not explicitly declared, its opaque slot ids are
+    derived from the structured-judge assignment through the same pure path used
+    by runtime config writes. *)
+
 val runtime_ids : t list -> string list
 
 (** {1 Lazy default runtime singleton}

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -185,15 +185,27 @@ let load_exact_output_lane_declarations () =
       (Env_config_core.Config_error
          "exact-output registry: runtime.toml path is unavailable")
   | Some config_path ->
-    (match Runtime.load_exact_output_lane_declarations ~config_path with
-     | Ok lanes -> lanes
-     | Error detail ->
+    (match Runtime_toml.parse_file config_path with
+     | Error errors ->
        raise
          (Env_config_core.Config_error
             (Printf.sprintf
-               "exact-output registry: runtime config materialization failed (%s): %s"
+               "exact-output registry: runtime config parse failed (%s): %d error(s)"
                config_path
-               detail)))
+               (List.length errors)))
+     | Ok (config : Runtime_schema.config) ->
+       (match
+          Runtime.effective_exact_output_lane_declarations
+            config.exact_output_lane_decls
+        with
+        | Ok lanes -> lanes
+        | Error detail ->
+          raise
+            (Env_config_core.Config_error
+               (Printf.sprintf
+                  "exact-output registry: effective runtime lane materialization failed (%s): %s"
+                  config_path
+                  detail))))
 ;;
 
 let configure_exact_output_registry ?config_root () =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -185,47 +185,15 @@ let load_exact_output_lane_declarations () =
       (Env_config_core.Config_error
          "exact-output registry: runtime.toml path is unavailable")
   | Some config_path ->
-    (match Runtime_toml.parse_file config_path with
-     | Ok (config : Runtime_schema.config) -> config.exact_output_lane_decls
-     | Error errors ->
+    (match Runtime.load_exact_output_lane_declarations ~config_path with
+     | Ok lanes -> lanes
+     | Error detail ->
        raise
          (Env_config_core.Config_error
             (Printf.sprintf
-               "exact-output registry: runtime config parse failed (%s): %d error(s)"
+               "exact-output registry: runtime config materialization failed (%s): %s"
                config_path
-               (List.length errors))))
-;;
-
-let hitl_auto_judge_lane_id = "hitl_auto_judge"
-
-let structured_judge_exact_slot_ids () =
-  let assignment_id = Runtime.runtime_id_for_structured_judge () in
-  match Runtime.resolve_assignment assignment_id with
-  | `Single_runtime runtime -> [ runtime.Runtime.id ]
-  | `Lane lane -> lane.Runtime_lane.candidates
-  | `Missing ->
-    raise
-      (Env_config_core.Config_error
-         (Printf.sprintf
-            "exact-output registry: structured-judge assignment %S does not resolve \
-             to a runtime or lane"
-            assignment_id))
-;;
-
-let ensure_hitl_auto_judge_lane lanes =
-  if
-    List.exists
-      (fun (lane : Runtime_schema.exact_output_lane_decl) ->
-         String.equal lane.id hitl_auto_judge_lane_id)
-      lanes
-  then
-    lanes
-  else
-    lanes
-    @ [ { Runtime_schema.id = hitl_auto_judge_lane_id
-        ; slot_ids = structured_judge_exact_slot_ids ()
-        }
-      ]
+               detail)))
 ;;
 
 let configure_exact_output_registry ?config_root () =
@@ -259,9 +227,7 @@ let configure_exact_output_registry ?config_root () =
          ("exact-output resolver snapshot: "
           ^ exact_output_snapshot_error_to_string error))
   | Ok resolver_snapshot ->
-    let lanes =
-      load_exact_output_lane_declarations () |> ensure_hitl_auto_judge_lane
-    in
+    let lanes = load_exact_output_lane_declarations () in
     (match Runtime.publish_exact_output_registry ~lanes resolver_snapshot with
      | Error detail ->
        raise

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -431,7 +431,7 @@ let test_predispatch_failure_advances_only_to_oas_successor () =
          ~on_summary:(fun _ -> ())
          (prepare_exn entry);
        check int "OAS-selected successor posted once" 1 (F.post_count successor);
-       match Q.get_pending_entry ~id:entry.id with
+       (match Q.get_pending_entry ~id:entry.id with
        | Some
            { exact_attempt =
                Q.Exact_bound

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -862,14 +862,13 @@ let test_pre_worker_start_failure_is_retryable () =
            "retryable failure reason is durable"
            "no usable exact-output lane slots"
            reason
-       | _ -> fail "pre-worker failure was not durably retryable")
-       ;
+       | _ -> fail "pre-worker failure was not durably retryable");
        check
          bool
          "pre-worker failure releases the owner claim"
          true
          (Gate.For_testing.claim_auto_judge successor);
-       Gate.For_testing.release_auto_judge successor
+       Gate.For_testing.release_auto_judge successor)
 ;;
 
 let test_visible_uncertainty_withholds_production_drain () =

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -827,6 +827,43 @@ let test_cancellation_after_dispatch_is_terminal () =
        | _ -> fail "post-dispatch cancellation was not terminally quarantined")
 ;;
 
+let test_pre_worker_start_failure_is_retryable () =
+  run_eio @@ fun ~sw:_ ~net:_ ~clock:_ ->
+  with_temp_dir "hitl-pre-worker-start-failure" @@ fun base_path ->
+  Fun.protect
+    ~finally:Q.For_testing.reset_runtime_state
+    (fun () ->
+       install_queue base_path;
+       select_auto_judge_mode base_path;
+       let entry = pending_entry ~base_path () in
+       (match
+          Gate.For_testing.spawn_auto_judge_entry_with_worker
+            ~spawn_worker:
+              (fun ~sw:_ ~entry:_ ~on_summary:_ ~on_finish:_ () ->
+                 Error "no usable exact-output lane slots")
+            entry
+        with
+        | Error detail ->
+          check
+            string
+            "pre-worker failure is returned"
+            "no usable exact-output lane slots"
+            detail
+        | Ok _ -> fail "pre-worker failure was reported as a successful start");
+       match Q.get_pending_entry ~id:entry.id with
+       | Some
+           { exact_attempt = Q.Exact_unbound
+           ; summary_status = Q.Summary_failed { reason; retryable = true }
+           ; _
+           } ->
+         check
+           string
+           "retryable failure reason is durable"
+           "no usable exact-output lane slots"
+           reason
+       | _ -> fail "pre-worker failure was not durably retryable")
+;;
+
 let test_visible_uncertainty_withholds_production_drain () =
   run_eio_without_context @@ fun ~sw ~net ~clock ~mono_clock ->
   with_temp_dir "hitl-uncertain-lifecycle" @@ fun base_path ->
@@ -1059,6 +1096,10 @@ let () =
             "post-dispatch cancellation is terminal"
             `Quick
             test_cancellation_after_dispatch_is_terminal
+        ; test_case
+            "pre-worker start failure is retryable"
+            `Quick
+            test_pre_worker_start_failure_is_retryable
         ; test_case
             "visible uncertainty withholds production drain"
             `Quick

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -431,7 +431,7 @@ let test_predispatch_failure_advances_only_to_oas_successor () =
          ~on_summary:(fun _ -> ())
          (prepare_exn entry);
        check int "OAS-selected successor posted once" 1 (F.post_count successor);
-       (match Q.get_pending_entry ~id:entry.id with
+       match Q.get_pending_entry ~id:entry.id with
        | Some
            { exact_attempt =
                Q.Exact_bound
@@ -526,7 +526,7 @@ let test_visible_bind_blocks_dispatch () =
          ~on_summary:(fun _ -> fail "unconfirmed bind delivered a summary")
          (prepare_exn entry);
        check int "unconfirmed bind forbids POST" 0 (F.post_count server);
-       match Q.get_pending_entry ~id:entry.id with
+       (match Q.get_pending_entry ~id:entry.id with
        | Some
            { exact_attempt =
                Q.Exact_bound

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -526,7 +526,7 @@ let test_visible_bind_blocks_dispatch () =
          ~on_summary:(fun _ -> fail "unconfirmed bind delivered a summary")
          (prepare_exn entry);
        check int "unconfirmed bind forbids POST" 0 (F.post_count server);
-       (match Q.get_pending_entry ~id:entry.id with
+       match Q.get_pending_entry ~id:entry.id with
        | Some
            { exact_attempt =
                Q.Exact_bound
@@ -872,7 +872,7 @@ let test_pre_worker_start_failure_is_retryable () =
             "no usable exact-output lane slots"
             detail
         | Ok _ -> fail "pre-worker failure was reported as a successful start");
-       match Q.get_pending_entry ~id:entry.id with
+       (match Q.get_pending_entry ~id:entry.id with
        | Some
            { exact_attempt = Q.Exact_unbound
            ; summary_status = Q.Summary_failed { reason; retryable = true }

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -836,6 +836,7 @@ let test_pre_worker_start_failure_is_retryable () =
        install_queue base_path;
        select_auto_judge_mode base_path;
        let entry = pending_entry ~base_path () in
+       let successor = pending_entry ~input_tag:"successor" ~base_path () in
        (match
           Gate.For_testing.spawn_auto_judge_entry_with_worker
             ~spawn_worker:
@@ -862,6 +863,13 @@ let test_pre_worker_start_failure_is_retryable () =
            "no usable exact-output lane slots"
            reason
        | _ -> fail "pre-worker failure was not durably retryable")
+       ;
+       check
+         bool
+         "pre-worker failure releases the owner claim"
+         true
+         (Gate.For_testing.claim_auto_judge successor);
+       Gate.For_testing.release_auto_judge successor
 ;;
 
 let test_visible_uncertainty_withholds_production_drain () =

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -132,6 +132,27 @@ let prepare_exn entry =
   | Error detail -> fail detail
 ;;
 
+let test_readiness_rejects_lane_without_json_guarantee () =
+  Prompt_registry.set_markdown_dir
+    (Masc_test_deps.source_path "config/prompts");
+  let slot_id = "hitl-readiness-no-json" in
+  publish_lane
+    [ slot_id ]
+    (F.resolver_snapshot
+       ~supports_response_format_json:false
+       ~supports_structured_output:false
+       ~source:"hitl-readiness-no-json"
+       [ { id = slot_id; base_url = "http://127.0.0.1:9" } ]);
+  match Worker.readiness () with
+  | Ok () -> fail "readiness admitted a lane without the HITL output guarantee"
+  | Error detail ->
+    check
+      string
+      "readiness reports OAS admission rejection"
+      "HITL exact-output flow admitted no candidates"
+      detail
+;;
+
 let visible_after_rename_writer path body =
   match Fs_compat.save_file_atomic path body with
   | Error reason -> failf "visible writer could not replace %s: %s" path reason
@@ -1065,6 +1086,10 @@ let () =
             "prompt is registry-owned"
             `Quick
             test_gate_judgment_prompt_comes_from_registry
+        ; test_case
+            "readiness requires JSON admission"
+            `Quick
+            test_readiness_rejects_lane_without_json_guarantee
         ] )
     ; ( "production exact flow"
       , [ test_case

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -663,11 +663,10 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
            ~keeper_name:"fifo-owner"
            [ second; first ]
        with
-       | [ oldest; newest ] ->
-         Alcotest.(check string) "oldest sequence first" first.id oldest.id;
-         Alcotest.(check string) "next sequence second" second.id newest.id
+       | [ oldest ] ->
+         Alcotest.(check string) "only oldest sequence is ready" first.id oldest.id
        | entries ->
-         Alcotest.failf "two same-owner entries expected, got %d" (List.length entries))
+         Alcotest.failf "one oldest same-owner entry expected, got %d" (List.length entries))
 ;;
 
 let test_different_owners_claim_in_parallel () =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -2072,7 +2072,7 @@ let test_all_summary_failures_accept_explicit_restart () =
        reject_and_cleanup ~base_path terminal_id)
 ;;
 
-let test_operator_recovery_reopens_all_failed_summaries () =
+let test_operator_recovery_skips_terminal_exact_failures () =
   let base_path = temp_dir () in
   let keeper_name = "queue-summary-operator-recovery" in
   Fun.protect
@@ -2098,9 +2098,12 @@ let test_operator_recovery_reopens_all_failed_summaries () =
        let terminal_id =
          submit ~base_path ~keeper_name ~input:(`String "terminal")
        in
+       let quarantined_id =
+         submit ~base_path ~keeper_name ~input:(`String "quarantined")
+       in
        List.iter
          (fun id -> check_update "mark pending" true (AQ.mark_summary_pending ~id))
-         [ retryable_id; terminal_id ];
+         [ retryable_id; terminal_id; quarantined_id ];
        check_update
          "retryable failure"
          true
@@ -2109,6 +2112,24 @@ let test_operator_recovery_reopens_all_failed_summaries () =
          "terminal failure"
          true
          (AQ.mark_summary_failed ~id:terminal_id ~reason:"prompt" ~retryable:false);
+       let quarantined_identity =
+         exact_identity
+           ~slot_id:"slot-quarantined"
+           ~call_id:"call-quarantined"
+           quarantined_id
+       in
+       check_exact_update
+         "bind terminal exact failure"
+         true
+         (run_exact_transition
+            AQ.bind_summary_exact_attempt
+            quarantined_identity);
+       check_exact_update
+         "quarantine terminal exact failure"
+         true
+         (quarantine_exact
+            quarantined_identity
+            AQ.Exact_flow_execution_failed);
        let reopened =
          match AQ.restart_failed_summaries ~base_path with
          | Ok ids -> List.sort String.compare ids
@@ -2116,7 +2137,7 @@ let test_operator_recovery_reopens_all_failed_summaries () =
            Alcotest.fail (AQ.summary_transition_error_to_string error)
        in
        Alcotest.(check (list string))
-         "explicit operator action reopens both classes"
+         "explicit operator action reopens only restartable failures"
          (List.sort String.compare [ retryable_id; terminal_id ])
          reopened;
        List.iter
@@ -2133,8 +2154,23 @@ let test_operator_recovery_reopens_all_failed_summaries () =
             (Some request_context)
             entry.request_context
         | None -> Alcotest.fail "reopened summary disappeared");
+       (match AQ.get_pending_entry ~id:quarantined_id with
+        | Some
+            { summary_status = AQ.Summary_failed { retryable = false; _ }
+            ; exact_attempt =
+                AQ.Exact_bound
+                  { status =
+                      AQ.Exact_quarantined AQ.Exact_flow_execution_failed
+                  ; _
+                  }
+            ; _
+            } ->
+          ()
+        | Some _ | None ->
+          Alcotest.fail "bulk recovery changed a terminal exact quarantine");
        reject_and_cleanup ~base_path retryable_id;
-       reject_and_cleanup ~base_path terminal_id)
+       reject_and_cleanup ~base_path terminal_id;
+       reject_and_cleanup ~base_path quarantined_id)
 ;;
 
 let test_dashboard_retry_rejects_cross_workspace_approval () =
@@ -2919,9 +2955,9 @@ let () =
             `Quick
             test_lane_activity_does_not_retry_failed_auto_judge
         ; Alcotest.test_case
-            "operator recovery reopens terminal failures"
+            "operator recovery skips terminal exact failures"
             `Quick
-            test_operator_recovery_reopens_all_failed_summaries
+            test_operator_recovery_skips_terminal_exact_failures
           ; Alcotest.test_case
               "decisive summary finalizes after restart"
               `Quick

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -579,9 +579,9 @@ let with_exact_status (entry : AQ.pending_approval) status =
           ; completed
           ])
   in
-  check int "operator recovery queues only two worker-ready entries" 2 (List.length ready);
-  check (list string) "operator recovery predicate preserves owner FIFO"
-    [ not_requested.id; pending.id ]
+  check int "operator recovery exposes only the FIFO head" 1 (List.length ready);
+  check (list string) "operator recovery cannot skip the FIFO head"
+    [ not_requested.id ]
     (List.map (fun (entry : AQ.pending_approval) -> entry.id) ready)
 ;;
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2217,6 +2217,8 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
       ~source:"runtime raw-save exact replacement"
       [ { id = "slot-a"; base_url = "http://127.0.0.1:9" }
       ; { id = "slot-b"; base_url = "http://127.0.0.1:10" }
+      ; { id = "local.chat"; base_url = "http://127.0.0.1:11" }
+      ; { id = "local.libr"; base_url = "http://127.0.0.1:12" }
       ]
   in
   ignore
@@ -2262,9 +2264,9 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
         "exact-output registry must be published: %s"
         (Runtime_exact_output_registry.publication_error_to_string error)
   in
-  let slots_exn registry =
+  let slots_exn ~lane_id registry =
     match
-      Runtime_exact_output_registry.resolve_lane registry ~lane_id:"compaction_exact"
+      Runtime_exact_output_registry.resolve_lane registry ~lane_id
     with
     | Ok resolved ->
       (match resolved.unavailable_slots with
@@ -2274,7 +2276,8 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
            resolved.selected_slots
        | unavailable_slots ->
          failf
-           "compaction lane unexpectedly has unavailable slots: %s"
+           "exact-output lane %S unexpectedly has unavailable slots: %s"
+           lane_id
            (String.concat
               "; "
               (List.map
@@ -2282,7 +2285,8 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
                  unavailable_slots)))
     | Error error ->
       failf
-        "compaction lane must exist: %s"
+        "exact-output lane %S must exist: %s"
+        lane_id
         (Runtime_exact_output_registry.lane_resolution_error_to_string error)
   in
   let baseline = content ~default:"local.chat" "slot-a" in
@@ -2308,7 +2312,9 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
     check int64 "invalid save preserves registry generation" stable_generation
       (Runtime_exact_output_registry.generation after_invalid);
     check (list string) "invalid save preserves registry slots" [ "slot-a" ]
-      (slots_exn after_invalid);
+      (slots_exn ~lane_id:"compaction_exact" after_invalid);
+    check (list string) "invalid save preserves synthesized HITL lane" [ "local.chat" ]
+      (slots_exn ~lane_id:"hitl_auto_judge" after_invalid);
     let replacement = content ~default:"local.libr" "slot-b" in
     let failed_path = path ^ ".directory" in
     Unix.mkdir failed_path 0o755;
@@ -2326,7 +2332,12 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
          check int64 "write failure preserves registry generation" stable_generation
            (Runtime_exact_output_registry.generation after_write_failure);
          check (list string) "write failure preserves registry slots" [ "slot-a" ]
-           (slots_exn after_write_failure));
+           (slots_exn ~lane_id:"compaction_exact" after_write_failure);
+         check
+           (list string)
+           "write failure preserves synthesized HITL lane"
+           [ "local.chat" ]
+           (slots_exn ~lane_id:"hitl_auto_judge" after_write_failure));
     (match Runtime.save_config_text ~runtime_config_path:path replacement with
      | Error detail -> failf "valid exact replacement failed: %s" detail
      | Ok () -> ());
@@ -2340,7 +2351,9 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
          stable_generation
        > 0);
     check (list string) "valid save commits registry slots" [ "slot-b" ]
-      (slots_exn replaced))
+      (slots_exn ~lane_id:"compaction_exact" replaced);
+    check (list string) "valid save refreshes synthesized HITL lane" [ "local.libr" ]
+      (slots_exn ~lane_id:"hitl_auto_judge" replaced))
 
 let test_deprecated_capability_notice_warns_once_per_process () =
   (* runtime.toml is re-parsed on every keeper boot; a per-parse deprecation

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1667,6 +1667,22 @@ let test_server_degraded_init_disables_unreferenced_uncatalogued_runtimes () =
          check (list string) "active runtime ids"
            [ "ollama.good" ]
            (Runtime.get_runtime_ids ());
+         (match Runtime.effective_exact_output_lane_declarations [] with
+          | Error detail ->
+            failf
+              "effective exact-output lanes must use degraded runtime state: %s"
+              detail
+          | Ok [ lane ] ->
+            check string "synthesized HITL lane id"
+              "hitl_auto_judge"
+              lane.Runtime_schema.id;
+            check (list string) "synthesized HITL lane uses active default only"
+              [ "ollama.good" ]
+              lane.slot_ids
+          | Ok lanes ->
+            failf
+              "expected one synthesized HITL lane, got %d"
+              (List.length lanes));
          check (list string) "no dropped assignment"
            []
            (List.map


### PR DESCRIPTION
## Summary
- keep pre-worker exact-flow start failures operator-retryable
- preserve one-at-a-time owner FIFO and update stale list-contract assertions
- treat already-terminal completed/quarantined replay state as conclusive

## Review source
Follow-up for review `#pullrequestreview-4768809527` on merged #25648. The startup-order finding was already fixed in the merged head; this PR addresses the three remaining actionable findings.

## Boundary
- no provider/model/tier inspection
- no receipt phase/count branching
- no legacy runtime migration
- OAS remains sole attempt/failover authority

## Local checks
- `ocamlformat` on changed OCaml files
- `scripts/check-hitl-exact-flow-boundary.sh --check`
- `scripts/check-hitl-exact-flow-boundary.sh --self-test`
- `git diff --check`

Per operator instruction, no local Dune/npm build or test was run.