### PR TITLE
fix(build): enforce exact OCaml 5.5.0 toolchain

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -3,7 +3,7 @@ description: Shared OCaml toolchain bootstrap with Linux local-opam pinning and 
 
 inputs:
   ocaml-compiler:
-    description: OCaml compiler version
+    description: OCaml compiler version (MASC supports exactly 5.5.0)
     required: false
     default: "5.5.0"
   dune-cache:
@@ -22,6 +22,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate OCaml compiler contract
+      shell: bash
+      env:
+        OCAML_COMPILER_INPUT: ${{ inputs.ocaml-compiler }}
+      run: |
+        if [[ "${OCAML_COMPILER_INPUT}" != "5.5.0" ]]; then
+          echo "Unsupported ocaml-compiler input: ${OCAML_COMPILER_INPUT}; MASC requires exactly 5.5.0" >&2
+          exit 1
+        fi
+
     - name: Setup OCaml (macOS)
       if: runner.os == 'macOS'
       uses: ocaml/setup-ocaml@v3.6.0
@@ -102,21 +112,7 @@ runs:
       run: |
         set -euo pipefail
 
-        case "${OCAML_COMPILER_INPUT}" in
-          5.5|5.5.x)
-            compiler_pkg="ocaml-base-compiler.5.5.0"
-            ;;
-          [0-9]*.[0-9]*.[0-9]*)
-            compiler_pkg="ocaml-base-compiler.${OCAML_COMPILER_INPUT}"
-            ;;
-          ocaml-base-compiler.*)
-            compiler_pkg="${OCAML_COMPILER_INPUT}"
-            ;;
-          *)
-            echo "Unsupported ocaml-compiler input: ${OCAML_COMPILER_INPUT}" >&2
-            exit 1
-            ;;
-        esac
+        compiler_pkg="ocaml-base-compiler.5.5.0"
 
         switch_name="ci-${OCAML_COMPILER_INPUT//[^A-Za-z0-9]/-}"
 

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -101,15 +101,15 @@ jobs:
           path: |
             ~/.opam
             ~/.local/share/opam
-          key: opam-ocamlformat-${{ steps.pin.outputs.ocamlformat_version }}-ocaml-5.2-${{ runner.os }}-v1
+          key: opam-ocamlformat-${{ steps.pin.outputs.ocamlformat_version }}-ocaml-5.5.0-${{ runner.os }}-v1
           restore-keys: |
-            opam-ocamlformat-${{ steps.pin.outputs.ocamlformat_version }}-ocaml-5.2-${{ runner.os }}-
+            opam-ocamlformat-${{ steps.pin.outputs.ocamlformat_version }}-ocaml-5.5.0-${{ runner.os }}-
 
       - name: Set up OCaml
         if: steps.changed.outputs.no_files != 'true'
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: '5.2'
+          ocaml-compiler: '5.5.0'
 
       - name: Install ocamlformat
         if: steps.changed.outputs.no_files != 'true'

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@
  (synopsis "Multi-Agent Shared Context MCP Server in OCaml")
  (description "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents")
  (depends
-  (ocaml (>= 5.5))
+  (ocaml (= 5.5.0))
   ; [dune] dependency is implicit from [(lang dune 3.22)] above —
   ; declaring it again here makes the generated .opam emit
   ; [{>= "3.22" & >= "3.22"}] (audited continuous-loop iter #10).
@@ -53,7 +53,7 @@
   ; brew openssl@3 + CPATH=/opt/homebrew/opt/openssl@3/include
   ; LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib environment overrides
   ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
-  (piaf (>= 0.2.0))
+  (piaf (= 0.2.0))
   (eio-ssl (>= 0.3.0))
   ;; The exact OAS release pin carries typed recovery, response-shape, and
   ;; ordered multimodal delivery contracts;
@@ -79,6 +79,7 @@
   (zstd (>= 0.4))
   (httpun (>= 0.2))
   (httpun-eio (>= 0.2))
+  (httpun-ws (= 0.2.0))
   (bigstringaf (>= 0.10))
   (eio (>= 1.0))
   (eio_main (>= 1.0))
@@ -118,8 +119,10 @@
   ; continuous-loop iter #12 audit (2026-05-15).  Same shape as
   ; pbrt_services (iter #11): declared but never imported.  Re-add
   ; when Neo4j Bolt support resumes.
-  ; OpenTelemetry observability + OTLP exporter
-  (opentelemetry (>= 0.13))
+  ; OpenTelemetry observability + OTLP exporter.  MASC consumes the
+  ; [opentelemetry.client] findlib library exposed by 0.13; newer package
+  ; families use a different public library layout.
+  (opentelemetry (= 0.13))
   (ambient-context-eio (>= 0.2))
   ; Build-time embedder for default config seeds (init subcommand)
   (crunch (and :build (>= 4.0)))))

--- a/masc.opam
+++ b/masc.opam
@@ -12,7 +12,7 @@ doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
   "dune" {>= "3.22"}
-  "ocaml" {>= "5.5"}
+  "ocaml" {= "5.5.0"}
   "mcp_protocol" {>= "1.3.0"}
   "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}
@@ -28,7 +28,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "piaf" {>= "0.2.0"}
+  "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
   "agent_sdk" {>= "0.222.0"}
   "uri" {>= "4.4"}
@@ -50,6 +50,7 @@ depends: [
   "zstd" {>= "0.4"}
   "httpun" {>= "0.2"}
   "httpun-eio" {>= "0.2"}
+  "httpun-ws" {= "0.2.0"}
   "bigstringaf" {>= "0.10"}
   "eio" {>= "1.0"}
   "eio_main" {>= "1.0"}
@@ -69,7 +70,7 @@ depends: [
   "atdgen" {build & >= "4.2.0"}
   "atdgen-runtime" {>= "4.2.0"}
   "atdts" {build & >= "4.2.0"}
-  "opentelemetry" {>= "0.13"}
+  "opentelemetry" {= "0.13"}
   "ambient-context-eio" {>= "0.2"}
   "crunch" {build & >= "4.0"}
   "odoc" {with-doc}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -43,6 +43,7 @@ depends: [
   "cmdliner" {= "2.1.1"}
   "cohttp" {= "6.2.1"}
   "cohttp-eio" {= "6.2.1"}
+  "compiler-cloning" {= "enabled"}
   "conduit" {= "8.0.0"}
   "conf-gmp" {= "5"}
   "conf-gmp-powm-sec" {= "4"}
@@ -92,12 +93,13 @@ depends: [
   "httpun" {= "0.2.0"}
   "httpun-eio" {= "0.2.0"}
   "httpun-types" {= "0.2.0"}
+  "httpun-ws" {= "0.2.0"}
   "integers" {= "0.7.0"}
   "iomux" {= "0.4"}
   "ipaddr" {= "5.6.2"}
   "ipaddr-sexp" {= "5.6.2"}
   "jane-street-headers" {= "v0.17.0"}
-  "js_of_ocaml-compiler" {= "6.3.2"}
+  "js_of_ocaml-compiler" {= "6.4.1"}
   "jsonm" {= "1.0.2"}
   "jst-config" {= "v0.17.0"}
   "kdf" {= "1.0.0"}
@@ -119,11 +121,10 @@ depends: [
   "mirage-crypto-rng-eio" {= "1.2.0"}
   "mtime" {= "2.1.0"}
   "num" {= "1.6"}
-  "ocaml" {= "5.4.1"}
-  "ocaml-base-compiler" {= "5.4.1"}
-  "ocaml-compiler" {= "5.4.1"}
+  "ocaml" {= "5.5.0"}
+  "ocaml-base-compiler" {= "5.5.0"}
+  "ocaml-compiler" {= "5.5.0"}
   "ocaml-compiler-libs" {= "v0.17.0"}
-  "ocaml-config" {= "3"}
   "ocaml-options-vanilla" {= "1"}
   "ocaml-protoc-plugin" {= "6.2.0"}
   "ocaml-syntax-shims" {= "1.0.0"}

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -16,8 +16,9 @@ Local Dune wrapper for multi-agent development:
   - disables the shared Dune artifact cache by default for local builds
   - injects --root <repo-root> unless --root is already present
   - asserts agent_sdk opam pin matches the repo SSOT before each build
-  - asserts core opam dependencies are installed in the active switch
-  - asserts OCaml is at or above the repo floor declared in dune-project
+  - asserts the shell and opam resolve one coherent toolchain
+  - asserts required findlib libraries are installed in the active switch
+  - asserts OCaml exactly matches the repo version declared in dune-project
 
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_DUNE_CACHE=enabled or enabled-except-user-rules to opt into the shared Dune cache.
@@ -29,8 +30,8 @@ Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
 Set MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 to wait behind a live _build/.lock holder.
 Set MASC_DUNE_ALLOW_BARE_DUNE=1 to run despite a live Dune process outside this wrapper.
 Set MASC_SKIP_PIN_CHECK=1 to skip the agent_sdk pin guard.
-Set MASC_SKIP_DEPS_CHECK=1 to skip the core-deps installed guard.
-Set MASC_SKIP_OCAML_VERSION_CHECK=1 to skip the OCaml minimum version guard.
+Set MASC_SKIP_DEPS_CHECK=1 to skip the required-findlib guard.
+Set MASC_SKIP_OCAML_VERSION_CHECK=1 to skip the exact OCaml toolchain guard.
 USAGE
 }
 
@@ -471,6 +472,75 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
 fi
 # -----------------------------------------------------------------------
 
+# --- exact OCaml toolchain guard ---------------------------------------
+# MASC supports one compiler version.  Verify both the version and the
+# identity of the active opam prefix before any findlib or pin inspection.
+# This catches split-brain shells where `opam switch show` names one switch
+# while PATH/OPAM_SWITCH_PREFIX still point at another.
+if [[ "${GITHUB_ACTIONS:-}" != "true" \
+      && "${MASC_SKIP_OCAML_VERSION_CHECK:-0}" != "1" \
+      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
+      && "${_subcommand}" != "clean" ]]; then
+  _required_version="$(sed -nE '/^[[:space:]]*\(ocaml[[:space:]]+\(=[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)\)\).*$/ { s//\1/; p; q; }' \
+    "${repo_root}/dune-project")"
+  if [[ -z "${_required_version}" ]]; then
+    printf '[dune-local] unable to read exact OCaml version from %s\n' \
+      "${repo_root}/dune-project" >&2
+    exit 1
+  fi
+
+  if ! command -v opam >/dev/null 2>&1; then
+    printf '[dune-local] opam is unavailable; MASC requires an opam-managed OCaml %s switch\n' \
+      "${_required_version}" >&2
+    exit 1
+  fi
+  _opam_switch="$(opam switch show 2>/dev/null || true)"
+  _opam_prefix="$(opam var prefix 2>/dev/null || true)"
+  if [[ -z "${_opam_switch}" || -z "${_opam_prefix}" ]]; then
+    printf '[dune-local] unable to resolve the active opam switch and prefix\n' >&2
+    exit 1
+  fi
+  if [[ -n "${OPAM_SWITCH_PREFIX:-}" \
+        && "${OPAM_SWITCH_PREFIX%/}" != "${_opam_prefix%/}" ]]; then
+    printf '[dune-local] split opam environment: switch %s uses %s but OPAM_SWITCH_PREFIX=%s\n' \
+      "${_opam_switch}" "${_opam_prefix}" "${OPAM_SWITCH_PREFIX}" >&2
+    printf '%s\n' \
+      "[dune-local] repair: eval \"\$(opam env --switch=${_required_version} --set-switch)\"" >&2
+    exit 1
+  fi
+  for _tool in ocamlc dune ocamlfind; do
+    _tool_path="$(command -v "${_tool}" 2>/dev/null || true)"
+    if [[ -z "${_tool_path}" || "${_tool_path}" != "${_opam_prefix%/}/bin/"* ]]; then
+      printf '[dune-local] split opam environment: %s resolves to %s, expected %s/bin/%s\n' \
+        "${_tool}" "${_tool_path:-<missing>}" "${_opam_prefix%/}" "${_tool}" >&2
+      printf '%s\n' \
+        "[dune-local] repair: eval \"\$(opam env --switch=${_required_version} --set-switch)\"" >&2
+      exit 1
+    fi
+  done
+
+  if ! command -v ocamlc >/dev/null 2>&1; then
+    printf '[dune-local] ocamlc is unavailable; this repo requires OCaml %s\n' \
+      "${_required_version}" >&2
+    exit 1
+  fi
+  _ocaml_v="$(ocamlc -version 2>/dev/null || true)"
+  if [[ "${_ocaml_v}" != "${_required_version}" ]]; then
+    printf '[dune-local] OCaml %s detected; this repo requires exactly %s (dune-project)\n' \
+      "${_ocaml_v:-unknown}" "${_required_version}" >&2
+    printf '[dune-local] repair (run each line in turn):\n' >&2
+    printf '[dune-local]   opam switch create %s ocaml-base-compiler.%s\n' \
+      "${_required_version}" "${_required_version}" >&2
+    printf '%s\n' \
+      "[dune-local]   eval \"\$(opam env --switch=${_required_version} --set-switch)\"" >&2
+    printf '[dune-local]   bash scripts/opam-pin-external-deps.sh --install\n' >&2
+    printf '[dune-local]   opam install . --deps-only --with-test -y\n' >&2
+    printf '[dune-local] set MASC_SKIP_OCAML_VERSION_CHECK=1 to bypass this guard\n' >&2
+    exit 1
+  fi
+fi
+# -----------------------------------------------------------------------
+
 # --- agent_sdk pin guard -----------------------------------------------
 # Assert the local opam switch is pinned to the SSOT SHA before each local
 # build.  Multiple concurrent sessions that share one opam switch can
@@ -628,20 +698,20 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
 fi
 # -----------------------------------------------------------------------
 
-# --- core opam-deps installed guard ------------------------------------
-# Catch the "deps declared but not installed" failure mode before Dune
-# emits a wall of cryptic abstract-cmi errors:
+# --- required findlib libraries guard ----------------------------------
+# Catch absent packages and incompatible package API layouts before Dune
+# emits a wall of cryptic library-resolution or abstract-cmi errors:
 #
+#   Error: Library "opentelemetry.client" not found
+#   Error: Library "piaf.stream" not found
 #   Error: Unbound module Httpun
 #   Type Httpun.Method.t is abstract because no corresponding cmi file
 #   was found in path.
 #
-# Pin guard above checks that agent_sdk *would resolve to* the right
-# SHA, but does not catch the case where the operator added a new opam
-# switch and forgot `opam install . --deps-only -y`.  Hardcoded list
-# covers the four packages whose absence produces the worst error
-# spew; full validation belongs to opam itself (the wrapper deliberately
-# stays cheap).
+# Query the actual findlib names consumed by Dune instead of only checking
+# opam package names.  Package existence alone did not catch
+# opentelemetry.0.91.1, which is installed successfully but does not expose
+# the [opentelemetry.client] library consumed by MASC.
 #
 # Skipped under the same envelope as the pin guard plus
 # MASC_SKIP_DEPS_CHECK=1.
@@ -650,66 +720,33 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
       && "${_subcommand}" != "clean" ]]; then
   if command -v opam >/dev/null 2>&1; then
-    _core_deps=(httpun httpun-eio httpun-ws agent_sdk)
+    _required_findlib=(
+      httpun
+      httpun-eio
+      httpun-ws
+      agent_sdk
+      piaf
+      piaf.stream
+      opentelemetry.client
+    )
     _missing=()
-    for _pkg in "${_core_deps[@]}"; do
-      if ! opam list --installed --short "${_pkg}" 2>/dev/null \
-           | grep -qx "${_pkg}"; then
-        _missing+=("${_pkg}")
+    for _library in "${_required_findlib[@]}"; do
+      _library_path="$(opam exec -- ocamlfind query "${_library}" 2>/dev/null || true)"
+      if [[ -z "${_library_path}" ]]; then
+        _missing+=("${_library}")
       fi
     done
     if [[ ${#_missing[@]} -gt 0 ]]; then
-      printf '[dune-local] missing opam packages in switch %s: %s\n' \
+      printf '[dune-local] missing or incompatible findlib libraries in switch %s: %s\n' \
         "$(opam switch show 2>/dev/null || echo '?')" \
         "${_missing[*]}" >&2
       printf '[dune-local] symptom you would otherwise see:\n' >&2
-      printf '[dune-local]   Error: Unbound module <Pkg>\n' >&2
-      printf '[dune-local]   Type <Pkg>.<T>.t is abstract because no corresponding cmi file...\n' >&2
-      printf '[dune-local] repair: opam install . --deps-only -y\n' >&2
+      printf '[dune-local]   Error: Library "<name>" not found\n' >&2
+      printf '[dune-local] repair (run each line in turn):\n' >&2
+      printf '[dune-local]   bash scripts/opam-pin-external-deps.sh --install\n' >&2
+      printf '[dune-local]   opam install . --deps-only --with-test -y\n' >&2
       printf '[dune-local] set MASC_SKIP_DEPS_CHECK=1 to bypass this guard\n' >&2
       exit 1
-    fi
-  fi
-fi
-# -----------------------------------------------------------------------
-
-# --- OCaml minimum version guard ---------------------------------------
-# dune-project declares the OCaml floor and masc.opam is generated from it.
-# Older switches build the early lib/ deps fine but fail later during opam
-# dependency resolution or in stdlib calls added by the declared floor.  Catch
-# the mismatch up-front so the error mentions the real floor rather than the
-# trailing symptom (e.g. an "Unbound value" from a newer stdlib API).
-if [[ "${GITHUB_ACTIONS:-}" != "true" \
-      && "${MASC_SKIP_OCAML_VERSION_CHECK:-0}" != "1" \
-      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
-      && "${_subcommand}" != "clean" ]]; then
-  if command -v ocaml >/dev/null 2>&1; then
-    _ocaml_v="$(ocaml -version 2>/dev/null \
-                | sed -nE 's/.*version ([0-9]+\.[0-9]+).*/\1/p')"
-    if [[ -n "${_ocaml_v}" ]]; then
-      _required_version="$(sed -nE '/^[[:space:]]*\(ocaml[[:space:]]+\(>=[[:space:]]+([0-9]+)\.([0-9]+)\)\).*$/ { s//\1.\2/; p; q; }' \
-        "${repo_root}/dune-project")"
-      if [[ -z "${_required_version}" ]]; then
-        printf '[dune-local] unable to read OCaml floor from %s\n' \
-          "${repo_root}/dune-project" >&2
-        exit 1
-      fi
-      _required_major="${_required_version%%.*}"
-      _required_minor="${_required_version##*.}"
-      _major="${_ocaml_v%%.*}"
-      _minor="${_ocaml_v##*.}"
-      if [[ "${_major}" -lt "${_required_major}" \
-            || ( "${_major}" -eq "${_required_major}" && "${_minor}" -lt "${_required_minor}" ) ]]; then
-        printf '[dune-local] OCaml %s detected; this repo requires >= %s (dune-project)\n' \
-          "${_ocaml_v}" "${_required_version}" >&2
-        printf '[dune-local] symptom under older switch: opam dep resolution fails or stdlib API missing\n' >&2
-        printf '[dune-local] repair (run each line in turn):\n' >&2
-        printf '[dune-local]   opam switch create %s.0\n' "${_required_version}" >&2
-        printf '[dune-local]   eval $%s\n' '(opam env)' >&2
-        printf '[dune-local]   opam install . --deps-only -y\n' >&2
-        printf '[dune-local] set MASC_SKIP_OCAML_VERSION_CHECK=1 to bypass this guard\n' >&2
-        exit 1
-      fi
     fi
   fi
 fi

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -57,6 +57,39 @@ if [[ "${MASC_SKIP_OPAM_LOCK:-0}" != "1" \
   fi
 fi
 
+# Refuse to mutate a different or unsupported switch.  This script is the
+# documented repair path for local OAS pin drift, so it must not silently
+# repair the switch named by opam while the caller's shell still executes
+# tools from another prefix.
+required_ocaml_version="$(sed -nE '/^[[:space:]]*\(ocaml[[:space:]]+\(=[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)\)\).*$/ { s//\1/; p; q; }' \
+  "${REPO_ROOT}/dune-project")"
+if [[ -z "${required_ocaml_version}" ]]; then
+  echo "[opam-pin] ERROR: unable to read exact OCaml version from ${REPO_ROOT}/dune-project" >&2
+  exit 1
+fi
+if ! command -v opam >/dev/null 2>&1; then
+  echo "[opam-pin] ERROR: opam is unavailable; MASC requires OCaml ${required_ocaml_version}" >&2
+  exit 1
+fi
+active_opam_switch="$(opam switch show 2>/dev/null || true)"
+active_opam_prefix="$(opam var prefix 2>/dev/null || true)"
+active_ocaml_version="$(opam exec -- ocamlc -version 2>/dev/null || true)"
+if [[ -z "${active_opam_switch}" || -z "${active_opam_prefix}" ]]; then
+  echo "[opam-pin] ERROR: unable to resolve the active opam switch and prefix" >&2
+  exit 1
+fi
+if [[ -n "${OPAM_SWITCH_PREFIX:-}" \
+      && "${OPAM_SWITCH_PREFIX%/}" != "${active_opam_prefix%/}" ]]; then
+  echo "[opam-pin] ERROR: split opam environment: switch ${active_opam_switch} uses ${active_opam_prefix} but OPAM_SWITCH_PREFIX=${OPAM_SWITCH_PREFIX}" >&2
+  echo "[opam-pin] repair: eval \"\$(opam env --switch=${required_ocaml_version} --set-switch)\"" >&2
+  exit 1
+fi
+if [[ "${active_ocaml_version}" != "${required_ocaml_version}" ]]; then
+  echo "[opam-pin] ERROR: OCaml ${active_ocaml_version:-unknown} detected; MASC requires exactly ${required_ocaml_version}" >&2
+  echo "[opam-pin] repair: eval \"\$(opam env --switch=${required_ocaml_version} --set-switch)\"" >&2
+  exit 1
+fi
+
 # --- Pin SHAs (bump these when upstream changes are needed) ---
 readonly WEBRTC_SHA="1b7993605b293f45169369d488f970ba15132a9f"
 readonly GRPC_DIRECT_SHA="d7269ebebf9e4688486cc6591c66e794607e7b0f"
@@ -203,7 +236,7 @@ guard_agent_sdk_downgrade() {
   if [[ -r "${agent_sdk_floor_path}" ]]; then
     recorded_floor="$(head -n 1 "${agent_sdk_floor_path}" 2>/dev/null || true)"
     if [[ -n "${recorded_floor}" ]] && version_gt "${recorded_floor}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
-      echo "[opam-pin] ERROR: refusing to downgrade shared agent_sdk pin below recorded floor ${recorded_floor}; branch floor is ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+      echo "[opam-pin] ERROR: refusing to downgrade agent_sdk below recorded floor ${recorded_floor}; branch floor is ${OAS_AGENT_SDK_MIN_VERSION}" >&2
       echo "[opam-pin] worktree: ${REPO_ROOT}" >&2
       echo "[opam-pin] recorded floor: ${agent_sdk_floor_path}" >&2
       echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
@@ -235,9 +268,10 @@ guard_agent_sdk_downgrade() {
   fi
 
   if version_gt "${installed_version}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
-    echo "[opam-pin] ERROR: refusing to downgrade shared agent_sdk pin" >&2
+    echo "[opam-pin] ERROR: refusing to downgrade installed agent_sdk ${installed_version}" >&2
     echo "[opam-pin] worktree: ${REPO_ROOT}" >&2
-    echo "[opam-pin] requested: agent_sdk >= ${OAS_AGENT_SDK_MIN_VERSION} at ${agent_sdk_pin_source}" >&2
+    echo "[opam-pin] requested floor: agent_sdk >= ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+    echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
     echo "[opam-pin] installed: agent_sdk ${installed_version}" >&2
     echo "[opam-pin] lock path: ${opam_lock_path}" >&2
     print_opam_lock_holder

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -120,7 +120,7 @@ let run_process ?(env = []) ?(unset_env = []) ~cwd prog argv =
     - bin/opam  (fake: exists, exits 0)
 
     Returns [(bin_dir, dune_log)] where [dune_log] records each dune call. *)
-let setup_fake_repo ?(ocaml_floor = "5.5") base ~pin_check_exit_code
+let setup_fake_repo ?(ocaml_version = "5.5.0") base ~pin_check_exit_code
     ~pin_check_stderr_msg =
   let scripts_dir = Filename.concat base "scripts" in
   let bin_dir = Filename.concat base "bin" in
@@ -132,9 +132,9 @@ let setup_fake_repo ?(ocaml_floor = "5.5") base ~pin_check_exit_code
 (package
  (name masc)
  (depends
-  (ocaml (>= %s))))
+  (ocaml (= %s))))
 |}
-       ocaml_floor);
+       ocaml_version);
   (* Real dune-local.sh *)
   write_executable
     (Filename.concat scripts_dir "dune-local.sh")
@@ -244,6 +244,11 @@ let run_dune_local base bin_dir ?(env = []) ?(unset_env = []) subcommand =
     then []
     else [ ("MASC_DUNE_ALLOW_BARE_DUNE", "1") ]
   in
+  let default_skip_env name =
+    if List.exists (String.equal name) unset_env || List.mem_assoc name env
+    then []
+    else [ (name, "1") ]
+  in
   let full_env =
     [
       ("PATH", path);
@@ -255,6 +260,8 @@ let run_dune_local base bin_dir ?(env = []) ?(unset_env = []) subcommand =
       ("MASC_OPAM_LOCK_HELD", "0");
     ]
     @ allow_bare_dune_env
+    @ default_skip_env "MASC_SKIP_DEPS_CHECK"
+    @ default_skip_env "MASC_SKIP_OCAML_VERSION_CHECK"
     @ List.filter
         (fun (k, _) ->
           k <> "PATH" && k <> "GIT_CEILING_DIRECTORIES" && k <> "DUNE_LOCAL_LOCK")
@@ -385,17 +392,24 @@ let test_github_actions_bypasses_pin_guard () =
       check int "exits zero when GITHUB_ACTIONS=true" 0 code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
-let test_opam_absent_skips_pin_guard () =
+let test_opam_absent_aborts_before_pin_guard () =
   with_temp_dir "dune-local-no-opam" (fun dir ->
       (* Set up repo with failing pin check but no fake opam in PATH *)
       let scripts_dir = Filename.concat dir "scripts" in
       let bin_dir = Filename.concat dir "bin" in
       mkdir_p scripts_dir;
       mkdir_p bin_dir;
+      write_file (Filename.concat dir "dune-project")
+        {|(lang dune 3.22)
+(package
+ (name masc)
+ (depends
+  (ocaml (= 5.5.0))))
+|};
       write_executable
         (Filename.concat scripts_dir "dune-local.sh")
         (read_file (dune_local_script_path ()));
-      (* Failing pin check: should never be called when opam is absent *)
+      (* Failing pin check: should never be called when opam is absent. *)
       write_executable
         (Filename.concat scripts_dir "check-oas-pin.sh")
         "#!/bin/sh\necho 'pin mismatch' >&2\nexit 1\n";
@@ -437,7 +451,7 @@ exec "$@"
       let minimal_path = Printf.sprintf "%s:/usr/bin:/bin" bin_dir in
       let lock_path = Filename.concat dir "dune-local.lock" in
       let script = Filename.concat scripts_dir "dune-local.sh" in
-      let code, _stdout, _stderr =
+      let code, _stdout, stderr =
         run_process ~cwd:dir "/bin/bash"
           ~env:
             [
@@ -450,13 +464,15 @@ exec "$@"
           ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
           [| "/bin/bash"; script; "build" |]
       in
-      check int "exits zero when opam absent" 0 code;
+      check int "exits non-zero when opam absent" 1 code;
+      check_contains "opam requirement is explicit" stderr
+        "opam is unavailable; MASC requires an opam-managed OCaml 5.5.0 switch";
       let lock_log =
         if Sys.file_exists lockf_log then read_file lockf_log else ""
       in
       check bool "opam lockf not invoked" false
         (contains_substring lock_log opam_lock_path);
-      check bool "dune was invoked" true (Sys.file_exists dune_log))
+      check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
 let test_dune_lock_wait_reports_holder () =
   with_temp_dir "dune-local-lock-diag" (fun dir ->
@@ -1210,11 +1226,10 @@ let test_dry_run_skips_pin_check () =
       check int "exits zero for dry run" 0 code;
       check bool "dune not actually invoked" false (Sys.file_exists dune_log))
 
-(* --- deps guard tests (#13117 review) ---------------------------------
-   Helper: fake a missing-deps environment by overriding [opam] in PATH
-   with one that responds to [list --installed --short <pkg>] with an
-   empty body (the case the guard is supposed to catch).  pin check
-   passes so the test isolates the deps-guard branch. *)
+(* --- required findlib guard tests -------------------------------------
+   Helper: fake a dependency environment where opam package installation
+   may have succeeded but [ocamlfind query] resolves no public libraries.
+   The pin check passes so the test isolates the findlib guard. *)
 
 let setup_repo_with_missing_deps base =
   let bin_dir, dune_log = setup_fake_repo base ~pin_check_exit_code:0
@@ -1246,9 +1261,12 @@ let test_missing_deps_aborts_build () =
     in
     check int "exits non-zero on missing deps" 1 code;
     check bool "missing deps message present" true
-      (contains_substring stderr "missing opam packages");
+      (contains_substring stderr "missing or incompatible findlib libraries");
+    check_contains "piaf stream is checked" stderr "piaf.stream";
+    check_contains "OpenTelemetry API layout is checked" stderr
+      "opentelemetry.client";
     check bool "repair hint present" true
-      (contains_substring stderr "opam install . --deps-only");
+      (contains_substring stderr "opam-pin-external-deps.sh --install");
     check bool "skip hint present" true
       (contains_substring stderr "MASC_SKIP_DEPS_CHECK=1");
     check bool "dune not invoked" false (Sys.file_exists dune_log))
@@ -1265,87 +1283,109 @@ let test_skip_deps_check_env_bypasses_guard () =
     check int "exits zero when MASC_SKIP_DEPS_CHECK=1" 0 code;
     check bool "dune was invoked" true (Sys.file_exists dune_log))
 
-(* --- OCaml minimum version guard tests (#13117 review) ---------------- *)
+(* --- exact OCaml toolchain guard tests -------------------------------- *)
 
-let setup_repo_with_old_ocaml ?(ocaml_floor = "5.5")
+let setup_repo_with_ocaml ?(required_version = "5.5.0")
     ?(ocaml_version = "5.4.0") base =
   let bin_dir, dune_log =
-    setup_fake_repo base ~ocaml_floor ~pin_check_exit_code:0
+    setup_fake_repo base ~ocaml_version:required_version ~pin_check_exit_code:0
       ~pin_check_stderr_msg:""
   in
-  (* opam list --installed --short returns the dep so deps-guard passes;
-     we test the OCaml branch in isolation. *)
+  (* The exact-toolchain tests exercise opam prefix identity before any
+     dependency checks, so provide one coherent fake switch and prefix. *)
   let opam_path = Filename.concat bin_dir "opam" in
   let opam_script =
-    {|#!/bin/sh
-# Echo back the requested package name for `opam list --installed --short PKG`
-# (args: $1=list $2=--installed $3=--short $4=PKG) so the deps-installed
-# guard sees every package as present and we can isolate the OCaml-version
-# branch in this fixture.
-if [ "$1" = "list" ] && [ "$2" = "--installed" ] && [ -n "$4" ]; then
-  printf '%s\n' "$4"; exit 0
+    Printf.sprintf
+      {|#!/bin/sh
+if [ "$1" = "switch" ] && [ "$2" = "show" ]; then
+  printf 'fake-switch\n'; exit 0
 fi
-if [ "$1" = "switch" ] && [ "$2" = "show" ]; then printf 'fake-switch\n'; exit 0; fi
+if [ "$1" = "var" ] && [ "$2" = "prefix" ]; then
+  printf '%%s\n' %s; exit 0
+fi
 exit 0
 |}
+      (quote base)
   in
   write_executable opam_path opam_script;
-  (* Fake ocaml that reports an old version. *)
-  let ocaml_path = Filename.concat bin_dir "ocaml" in
-  write_executable ocaml_path
+  (* Fake compiler that reports the requested exact version. *)
+  let ocamlc_path = Filename.concat bin_dir "ocamlc" in
+  write_executable ocamlc_path
     (Printf.sprintf
-       "#!/bin/sh\nif [ \"$1\" = \"-version\" ]; then printf 'The OCaml \
-        toplevel, version %s\\n'; fi\nexit 0\n"
+       "#!/bin/sh\nif [ \"$1\" = \"-version\" ]; then printf '%s\\n'; fi\nexit 0\n"
        ocaml_version);
   (bin_dir, dune_log)
 
 let test_old_ocaml_aborts_build () =
   with_temp_dir "dune-local-old-ocaml" (fun dir ->
-    let bin_dir, dune_log = setup_repo_with_old_ocaml dir in
+    let bin_dir, dune_log = setup_repo_with_ocaml dir in
     let code, _stdout, stderr =
       run_dune_local dir bin_dir
+        ~env:[ ("OPAM_SWITCH_PREFIX", dir) ]
         ~unset_env:
           [ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"
           ; "MASC_SKIP_DEPS_CHECK"; "MASC_SKIP_OCAML_VERSION_CHECK" ]
         "build"
     in
     check int "exits non-zero on old OCaml" 1 code;
-    check_contains "OCaml version message present" stderr "OCaml 5.4 detected";
-    check_contains "minimum 5.5 mentioned" stderr ">= 5.5";
+    check_contains "OCaml version message present" stderr "OCaml 5.4.0 detected";
+    check_contains "exact 5.5.0 mentioned" stderr "exactly 5.5.0";
     check_contains "skip hint present" stderr
       "MASC_SKIP_OCAML_VERSION_CHECK=1";
     check bool "dune not invoked" false (Sys.file_exists dune_log))
 
 let test_skip_ocaml_version_env_bypasses_guard () =
   with_temp_dir "dune-local-skip-ocaml" (fun dir ->
-    let bin_dir, dune_log = setup_repo_with_old_ocaml dir in
+    let bin_dir, dune_log = setup_repo_with_ocaml dir in
     let code, _stdout, _stderr =
       run_dune_local dir bin_dir
         ~env:[ ("MASC_SKIP_OCAML_VERSION_CHECK", "1") ]
-        ~unset_env:
-          [ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"; "MASC_SKIP_DEPS_CHECK" ]
+        ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
         "build"
     in
     check int "exits zero when MASC_SKIP_OCAML_VERSION_CHECK=1" 0 code;
     check bool "dune was invoked" true (Sys.file_exists dune_log))
 
-let test_ocaml_floor_comes_from_dune_project () =
-  with_temp_dir "dune-local-ocaml-floor-ssot" (fun dir ->
+let test_ocaml_version_comes_from_dune_project () =
+  with_temp_dir "dune-local-ocaml-version-ssot" (fun dir ->
     let bin_dir, dune_log =
-      setup_repo_with_old_ocaml dir ~ocaml_floor:"5.6" ~ocaml_version:"5.5.0"
+      setup_repo_with_ocaml dir ~required_version:"5.6.0"
+        ~ocaml_version:"5.5.0"
     in
     let code, _stdout, stderr =
       run_dune_local dir bin_dir
+        ~env:[ ("OPAM_SWITCH_PREFIX", dir) ]
         ~unset_env:
           [ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"
           ; "MASC_SKIP_DEPS_CHECK"; "MASC_SKIP_OCAML_VERSION_CHECK" ]
         "build"
     in
-    check int "exits non-zero below dune-project floor" 1 code;
+    check int "exits non-zero on dune-project version mismatch" 1 code;
     check bool "live OCaml version message present" true
-      (contains_substring stderr "OCaml 5.5 detected");
-    check bool "dune-project floor mentioned" true
-      (contains_substring stderr ">= 5.6");
+      (contains_substring stderr "OCaml 5.5.0 detected");
+    check bool "dune-project exact version mentioned" true
+      (contains_substring stderr "exactly 5.6.0");
+    check bool "dune not invoked" false (Sys.file_exists dune_log))
+
+let test_split_opam_prefix_aborts_build () =
+  with_temp_dir "dune-local-split-opam-prefix" (fun dir ->
+    let bin_dir, dune_log = setup_repo_with_ocaml dir ~ocaml_version:"5.5.0" in
+    let wrong_prefix = Filename.concat dir "other-switch" in
+    let code, _stdout, stderr =
+      run_dune_local dir bin_dir
+        ~env:[ ("OPAM_SWITCH_PREFIX", wrong_prefix) ]
+        ~unset_env:
+          [ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"
+          ; "MASC_SKIP_OCAML_VERSION_CHECK" ]
+        "build"
+    in
+    check int "exits non-zero on split opam prefix" 1 code;
+    check_contains "split environment message present" stderr
+      "split opam environment";
+    check_contains "selected prefix present" stderr dir;
+    check_contains "stale prefix present" stderr wrong_prefix;
+    check_contains "repair command present" stderr
+      "opam env --switch=5.5.0 --set-switch";
     check bool "dune not invoked" false (Sys.file_exists dune_log))
 
 let () =
@@ -1367,8 +1407,8 @@ let () =
             test_skip_pin_check_still_cleans_on_provider_kind_crc_change;
           test_case "GITHUB_ACTIONS=true bypasses pin guard" `Quick
             test_github_actions_bypasses_pin_guard;
-          test_case "opam absent skips pin guard" `Quick
-            test_opam_absent_skips_pin_guard;
+          test_case "opam absent aborts before pin guard" `Quick
+            test_opam_absent_aborts_before_pin_guard;
           test_case "Dune lock wait reports holder" `Quick
             test_dune_lock_wait_reports_holder;
           test_case "live build-dir lock aborts before Dune" `Quick
@@ -1441,7 +1481,9 @@ let () =
             test_old_ocaml_aborts_build;
           test_case "MASC_SKIP_OCAML_VERSION_CHECK=1 bypasses ocaml guard"
             `Quick test_skip_ocaml_version_env_bypasses_guard;
-          test_case "OCaml floor is read from dune-project" `Quick
-            test_ocaml_floor_comes_from_dune_project;
+          test_case "exact OCaml version is read from dune-project" `Quick
+            test_ocaml_version_comes_from_dune_project;
+          test_case "split opam prefix aborts with repair command" `Quick
+            test_split_opam_prefix_aborts_build;
         ] );
     ]

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -24,6 +24,22 @@ cat > "${FAKE_BIN}/opam" <<'FAKE_OPAM'
 set -euo pipefail
 
 case "$1" in
+  switch)
+    [[ "${2:-}" == "show" ]] || exit 2
+    printf '%s\n' "${FAKE_OPAM_SWITCH:-5.5.0}"
+    ;;
+  var)
+    [[ "${2:-}" == "prefix" ]] || exit 2
+    printf '%s\n' "${FAKE_OPAM_PREFIX:?}"
+    ;;
+  exec)
+    if [[ "${2:-}" == "--" && "${3:-}" == "ocamlc" && "${4:-}" == "-version" ]]; then
+      printf '%s\n' "${FAKE_OCAML_VERSION:-5.5.0}"
+      exit 0
+    fi
+    echo "unexpected fake opam exec command: $*" >&2
+    exit 2
+    ;;
   list)
     for arg in "$@"; do
       if [[ "${arg}" == "--short" ]]; then
@@ -80,6 +96,8 @@ run_pin_script() {
   env \
     PATH="${FAKE_BIN}:${PATH}" \
     OPAM_FAKE_CALLS="${CALLS_FILE}" \
+    FAKE_OPAM_PREFIX="${TMP}/switch" \
+    OPAM_SWITCH_PREFIX="${TMP}/switch" \
     MASC_AGENT_SDK_FLOOR_PATH="${FLOOR_FILE}" \
     MASC_SKIP_OPAM_LOCK=1 \
     "$@"
@@ -231,5 +249,32 @@ if [[ "${recorded_floor}" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
 fi
 echo "ok case 10 - fresh switch without installed agent_sdk permits initial pinning"
 
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script \
+  OPAM_SWITCH_PREFIX="${TMP}/other-switch" \
+  FAKE_AGENT_SDK_VERSION="${OAS_AGENT_SDK_MIN_VERSION}" \
+  bash "${PIN_SCRIPT}" >"${TMP}/case11.out" 2>"${TMP}/case11.err"; then
+  echo "FAIL case 11: split opam prefix should be rejected" >&2
+  exit 1
+fi
+assert_contains "${TMP}/case11.err" "split opam environment"
+assert_contains "${TMP}/case11.err" "opam env --switch=5.5.0 --set-switch"
+assert_not_contains "${CALLS_FILE}" "pin add"
+echo "ok case 11 - split opam prefix fails before pin mutation"
+
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script \
+  FAKE_OCAML_VERSION=5.4.1 \
+  FAKE_AGENT_SDK_VERSION="${OAS_AGENT_SDK_MIN_VERSION}" \
+  bash "${PIN_SCRIPT}" >"${TMP}/case12.out" 2>"${TMP}/case12.err"; then
+  echo "FAIL case 12: unsupported OCaml should be rejected" >&2
+  exit 1
+fi
+assert_contains "${TMP}/case12.err" "OCaml 5.4.1 detected; MASC requires exactly 5.5.0"
+assert_not_contains "${CALLS_FILE}" "pin add"
+echo "ok case 12 - unsupported OCaml fails before pin mutation"
+
 echo ""
-echo "[opam-pin-downgrade-guard test] PASS - 10/10 cases"
+echo "[opam-pin-downgrade-guard test] PASS - 12/12 cases"


### PR DESCRIPTION
## Summary

- hard-cut MASC manifests, lockfile, shared CI setup, and formatter CI to OCaml `5.5.0`
- pin the consumed Piaf/OpenTelemetry API families and declare `httpun-ws` directly
- fail before Dune when the opam-selected prefix and shell tool paths disagree
- query the exact findlib libraries consumed by Dune, including `piaf.stream` and `opentelemetry.client`
- refuse to mutate external pins from a split or non-5.5.0 switch

## Why

A shell could report opam switch `5.4.1` while resolving `dune`/`ocamlfind` from `5.5.0`. Pinning OAS HEAD then mutated the wrong switch, and Dune later emitted a wall of missing-library errors. Package-name checks also accepted OpenTelemetry `0.91.1`, although MASC consumes the `opentelemetry.client` findlib layout from `0.13`.

## Verification

- `bash scripts/check-oas-pin.sh --local-only` — OAS `0.222.0` / `f4432204...` verified
- focused `test_dune_local_script.exe` — 35/35 passed
- `bash test/test_opam_pin_downgrade_guard.sh` — 12/12 passed
- rejected the live split `5.4.1`/`5.5.0` environment without changing its `agent_sdk` pin
- `opam install . --deps-only --with-test --locked --dry-run --yes` on switch `5.5.0` — solved
- `opam lint masc.opam masc.opam.locked`
- `shellcheck --severity=warning ...`
- `actionlint .github/workflows/ocamlformat.yml` and YAML parse of the composite action

Fixes #25652
