### PR TITLE
fix(runtime): include detailed key path and message in TOML parse errors

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1028,10 +1028,17 @@ let load_list_internal ~(config_path : string) ~validate_max_context
   let* cfg =
     Runtime_toml.parse_file config_path
     |> Result.map_error (fun errs ->
+      let detail =
+        errs
+        |> List.map (fun (e : Runtime_toml.parse_error) ->
+          Printf.sprintf "  - %s: %s" e.path e.message)
+        |> String.concat "\n"
+      in
       Printf.sprintf
-        "runtime config parse failed (%s): %d error(s)"
+        "runtime config parse failed (%s): %d error(s):\n%s"
         config_path
-        (List.length errs))
+        (List.length errs)
+        detail)
   in
   materialize_config ~validate_max_context ~config_path cfg
 ;;


### PR DESCRIPTION
## Summary

- Format TOML parse errors in `Runtime.load_list_internal` to include each error's `path` and `message` instead of collapsing them into a generic count string (`N error(s)`).

## Problem

When a TOML configuration error occurred (e.g. an unrecognized or invalid key under `[runtime]`), `load_list_internal` emitted:
`runtime config parse failed (/path/to/runtime.toml): 1 error(s)`
without indicating which key or table caused the failure.

## Solution

Format each `Runtime_toml.parse_error` line item (`- <path>: <message>`) into the error string detail payload.

## Impact

Improves server boot diagnostics and troubleshooting when runtime config validation fails.