### PR TITLE
fix(keeper): 채팅 턴 정합을 requestId 기반으로 — 도구 타임라인 중복 표시 근본 수정

### DIFF
--- a/dashboard/docs/API_CONTRACT.md
+++ b/dashboard/docs/API_CONTRACT.md
@@ -99,9 +99,12 @@ Each migration PR:
   `{"kind":"direct_request","request_id":"kmsg-..."}` (other `kind` values:
   `async_request` with `request_id`, `queue_receipts` with `receipt_ids`).
   Rows written by the plain append paths omit the field entirely. The
-  dashboard uses `delivery_key.request_id` as the turn reconciliation key
-  between optimistic rows and a history reload. Consumers MUST treat the
-  field as optional (absent on legacy and plain-append rows).
+  dashboard reconciles optimistic rows using exact typed identity:
+  `request_id` for direct/async delivery, or an intersecting `receipt_ids`
+  value for queue delivery. If neither side carries a delivery key, an exact
+  non-empty `turn_ref` match is the final fallback. It never reconciles by
+  role/text. Consumers MUST treat `delivery_key` as optional (absent on
+  legacy and plain-append rows).
 
 ## Non-goals
 

--- a/dashboard/docs/API_CONTRACT.md
+++ b/dashboard/docs/API_CONTRACT.md
@@ -91,6 +91,18 @@ Each migration PR:
    to the relevant integration test file.
 5. States the bundle size delta in the PR description.
 
+## Endpoint notes
+
+- `GET /api/v1/keepers/:name/chat/history` — each message object may carry
+  an optional `delivery_key` field: the exact delivery identity persisted by
+  the idempotent append-once write paths, e.g.
+  `{"kind":"direct_request","request_id":"kmsg-..."}` (other `kind` values:
+  `async_request` with `request_id`, `queue_receipts` with `receipt_ids`).
+  Rows written by the plain append paths omit the field entirely. The
+  dashboard uses `delivery_key.request_id` as the turn reconciliation key
+  between optimistic rows and a history reload. Consumers MUST treat the
+  field as optional (absent on legacy and plain-append rows).
+
 ## Non-goals
 
 - OCaml → TypeScript codegen. Evaluated separately; parity with a

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -158,6 +158,25 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.turn_ref).toBeUndefined()
   })
 
+  it('passes delivery_key through without dropping the row, whatever its shape', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({ delivery_key: { kind: 'direct_request', request_id: 'kmsg-1' } }),
+    )
+    expect(out).not.toBeNull()
+    expect(out?.delivery_key).toEqual({ kind: 'direct_request', request_id: 'kmsg-1' })
+    // Malformed / unexpected shapes are tolerated too: the consumer extracts
+    // request_id tolerantly, so the row must survive.
+    expect(
+      safeParseKeeperChatHistoryMessage(validMessage({ delivery_key: 'kmsg-1' })),
+    ).not.toBeNull()
+    expect(
+      safeParseKeeperChatHistoryMessage(validMessage({ delivery_key: 42 })),
+    ).not.toBeNull()
+    expect(
+      safeParseKeeperChatHistoryMessage(validMessage())?.delivery_key,
+    ).toBeUndefined()
+  })
+
   it('returns null when turn_ref has the wrong type', () => {
     expect(
       safeParseKeeperChatHistoryMessage(validMessage({ turn_ref: 4071 })),

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -285,6 +285,12 @@ export const KeeperChatHistoryMessageSchema = object({
   // :848-861). Without decoding these, a user's upload appears live but
   // vanishes on reload even though it is on disk.
   attachments: optional(array(KeeperChatHistoryAttachmentSchema)),
+  // Turn identity stamped by the backend on every dashboard-originated row
+  // (keeper_chat_store.ml delivery_key, e.g.
+  // `{"kind":"direct_request","request_id":"kmsg-..."}`). Accepted as
+  // `unknown` so a shape drift never drops the row; the consumer extracts
+  // `request_id` tolerantly (absent/malformed -> undefined).
+  delivery_key: optional(unknown()),
   // RFC-0235 P3: server-parsed rich chat blocks. Carried on history rows so
   // reloads preserve the structured render instead of re-parsing plain text.
   blocks: optional(array(KeeperChatBlockSchema)),

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2256,7 +2256,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       // Server already persisted the user turn, but the assistant reply is
       // still queued and has not been written yet.
       fetchKeeperChatHistory.mockResolvedValue([
-        { role: 'user', content: '진행 상황?', ts: 1_780_000_000 },
+        { role: 'user', content: '진행 상황?', ts: 1_780_000_000, delivery_key: { kind: 'direct_request', request_id: 'kmsg_echo_1' } },
       ])
 
       // First poll says queued; second poll completes so the test can finish.

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1672,7 +1672,12 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
     await sendKeeperThreadMessage('echo', '진행 상황?')
 
-    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    const thread = keeperThreads.value.echo ?? []
+    const user = thread.find(entry => entry.role === 'user')
+    const reply = thread.find(entry => entry.role === 'assistant')
+    expect(user?.details?.queueReceiptId).toBe(
+      'chatq_00000000-0000-4000-8000-000000000001',
+    )
     expect(reply?.delivery).toBe('queued')
     expect(reply?.text).toContain('message is queued')
     expect(reply?.details).toMatchObject({

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -513,6 +513,29 @@ function stampPlaceholderRequestId(keeperName: string, entryIds: string[], reque
   }
 }
 
+// A busy Keeper can persist history under queue_receipts rather than the
+// request id. Stamp the validated durable receipt onto both optimistic rows
+// so either role can converge with its canonical history row.
+function stampPlaceholderQueueReceiptId(
+  keeperName: string,
+  entryIds: string[],
+  queueReceiptId: string,
+): void {
+  for (const entryId of entryIds) {
+    updateThreadEntry(keeperName, entryId, entry => (
+      entry.details?.queueReceiptId === queueReceiptId
+        ? entry
+        : {
+            ...entry,
+            details: {
+              ...entry.details,
+              queueReceiptId,
+            },
+          }
+    ))
+  }
+}
+
 function isMissingQueuedKeeperRequestError(err: unknown): boolean {
   const record = isRecord(err) ? err : null
   const method = asString(record?.method, '').trim().toUpperCase()
@@ -1367,6 +1390,16 @@ export async function sendKeeperThreadMessage(
         const error = applyKeeperStreamEvent(keeperName, assistantId, event)
         if (error) {
           throw new Error(error)
+        }
+        if (event.type === 'CUSTOM' && event.name === 'KEEPER_CHAT_QUEUED' && isRecord(event.value)) {
+          const queueReceiptId = asString(event.value.receipt_id, '').trim()
+          if (queueReceiptId) {
+            stampPlaceholderQueueReceiptId(
+              keeperName,
+              [localId, assistantId],
+              queueReceiptId,
+            )
+          }
         }
         persistPendingAssistantDraft(keeperName, requestId, assistantId)
         if (event.type === 'TOOL_CALL_END') {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -66,6 +66,7 @@ import {
   setActiveStreamRequestId,
   setRecordValue,
   setStatusDetail,
+  updateThreadEntry,
 } from './keeper-state'
 import {
   abortKeeperThreadMessage,
@@ -500,6 +501,18 @@ function pendingAssistantEntryId(requestId: string): string {
   return `pending-assistant-${requestId}`
 }
 
+// The live-send placeholders are appended before the server mints the
+// request id; once KEEPER_QUEUE_REQUEST arrives, stamp it onto both rows so
+// a later history merge can reconcile the turn by requestId even when the
+// stream dies before the reply text lands.
+function stampPlaceholderRequestId(keeperName: string, entryIds: string[], requestId: string): void {
+  for (const entryId of entryIds) {
+    updateThreadEntry(keeperName, entryId, entry => (
+      entry.requestId === requestId ? entry : { ...entry, requestId }
+    ))
+  }
+}
+
 function isMissingQueuedKeeperRequestError(err: unknown): boolean {
   const record = isRecord(err) ? err : null
   const method = asString(record?.method, '').trim().toUpperCase()
@@ -528,6 +541,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       timestamp: new Date(request.submittedAt).toISOString(),
       delivery: 'delivered',
       streamState: null,
+      requestId: request.requestId,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
         deliveryReceipt: 'no_delivery_receipt',
@@ -548,6 +562,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       timestamp: assistantDraft?.timestamp ?? null,
       delivery: assistantDraft?.delivery ?? 'queued',
       streamState: assistantDraft ? assistantDraft.streamState : 'opening',
+      requestId: request.requestId,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
         deliveryReceipt: 'no_delivery_receipt',
@@ -1306,6 +1321,7 @@ export async function sendKeeperThreadMessage(
             setRecordValue(keeperActionErrors, keeperName, message)
           } else if (controller.signal.aborted) {
             requestId = nextRequestId
+            stampPlaceholderRequestId(keeperName, [localId, assistantId], nextRequestId)
             const pendingRequest = withCurrentPendingAssistantDraft({
               requestId: nextRequestId,
               keeperName,
@@ -1325,6 +1341,7 @@ export async function sendKeeperThreadMessage(
             })
           } else {
             requestId = nextRequestId
+            stampPlaceholderRequestId(keeperName, [localId, assistantId], nextRequestId)
             // This live send now owns the request; resume must defer to it
             // (and not mint a duplicate pending entry) until handoff/finally.
             setActiveStreamRequestId(keeperName, requestId)

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -307,7 +307,7 @@ describe('thread history merge & persistence', () => {
     // placeholder keeps text='' with only the accumulated tool trace and
     // never received REPLY_DETAILS (turnRef stays null). The real reply
     // arrives later as a REST history row. The backend stamps
-    // delivery_key.request_id ('kmsg-...') on every row of the turn, so
+    // delivery_key.request_id ('kmsg-...') on user/assistant rows, so
     // history convergence must fold the placeholder into the history row
     // instead of leaving a second "턴 타임라인" behind.
     const R = 'kmsg_turn_1'
@@ -357,8 +357,8 @@ describe('thread history merge & persistence', () => {
 
     const history = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: '질문', ts: 1_780_000_001, delivery_key: { kind: 'direct_request', request_id: R } },
-      { role: 'tool', content: '{"path":"a"}', ts: 1_780_000_002, tool_call_id: 'call-1', tool_call_name: 'read_file', delivery_key: { kind: 'direct_request', request_id: R } },
-      { role: 'tool', content: '{"path":"b"}', ts: 1_780_000_003, tool_call_id: 'call-2', tool_call_name: 'write_file', delivery_key: { kind: 'direct_request', request_id: R } },
+      { role: 'tool', content: '{"path":"a"}', ts: 1_780_000_002, tool_call_id: 'call-1', tool_call_name: 'read_file' },
+      { role: 'tool', content: '{"path":"b"}', ts: 1_780_000_003, tool_call_id: 'call-2', tool_call_name: 'write_file' },
       { role: 'assistant', content: '답변', ts: 1_780_000_004, turn_ref: 'trace-x#1', delivery_key: { kind: 'direct_request', request_id: R } },
     ])
     mergeServerHistoryEntries('echo', history)
@@ -402,6 +402,96 @@ describe('thread history merge & persistence', () => {
     expect(thread.map(e => e.id)).toEqual(['local-legacy', 'hist-legacy'])
   })
 
+  it('converges queue-lane user rows through an exact durable receipt', () => {
+    const receiptId = 'chatq_00000000-0000-4000-8000-000000000001'
+    appendThreadEntry('echo', entry({
+      id: 'local-queued-user',
+      role: 'user',
+      text: 'same queued message',
+      rawText: 'same queued message',
+      delivery: 'delivered',
+      details: { queueReceiptId: receiptId },
+    }))
+
+    const history = chatHistoryEntriesFromRest('echo', [{
+      id: 'history-queued-user',
+      role: 'user',
+      content: 'same queued message',
+      ts: 1_780_000_001,
+      delivery_key: {
+        kind: 'queue_receipts',
+        receipt_ids: [receiptId],
+      },
+    }])
+    expect(history[0]?.requestId).toBeNull()
+    expect(history[0]?.queueReceiptIds).toEqual([receiptId])
+
+    mergeServerHistoryEntries('echo', history)
+
+    const users = (keeperThreads.value.echo ?? []).filter(candidate => candidate.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0]?.id).toBe('history-queued-user')
+    expect(users[0]?.delivery).toBe('history')
+  })
+
+  it('rejects a malformed queue receipt list instead of falling back to role/text', () => {
+    const receiptId = 'chatq_00000000-0000-4000-8000-000000000001'
+    appendThreadEntry('echo', entry({
+      id: 'local-malformed-receipt',
+      role: 'user',
+      text: 'same queued message',
+      rawText: 'same queued message',
+      delivery: 'delivered',
+      details: { queueReceiptId: receiptId },
+    }))
+
+    const history = chatHistoryEntriesFromRest('echo', [{
+      id: 'history-malformed-receipt',
+      role: 'user',
+      content: 'same queued message',
+      ts: 1_780_000_001,
+      delivery_key: {
+        kind: 'queue_receipts',
+        receipt_ids: [receiptId, 7],
+      },
+    }])
+    expect(history[0]?.queueReceiptIds).toEqual([])
+
+    mergeServerHistoryEntries('echo', history)
+
+    expect((keeperThreads.value.echo ?? []).map(candidate => candidate.id).sort()).toEqual([
+      'history-malformed-receipt',
+      'local-malformed-receipt',
+    ])
+  })
+
+  it('converges rows through exact turnRef only when delivery keys are absent', () => {
+    appendThreadEntry('echo', entry({
+      id: 'local-turn-ref',
+      role: 'assistant',
+      text: 'live wording',
+      rawText: 'live wording',
+      delivery: 'delivered',
+      turnRef: 'trace-exact#7',
+    }))
+
+    mergeServerHistoryEntries('echo', [
+      entry({
+        id: 'history-turn-ref',
+        role: 'assistant',
+        text: 'canonical wording',
+        rawText: 'canonical wording',
+        delivery: 'history',
+        turnRef: 'trace-exact#7',
+      }),
+    ])
+
+    const assistants = (keeperThreads.value.echo ?? [])
+      .filter(candidate => candidate.role === 'assistant')
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0]?.id).toBe('history-turn-ref')
+  })
+
   it('does not merge same-text rows that carry different requestIds', () => {
     // Identical reply text across two distinct turns: requestId is the turn
     // identity, so the history row of one request must not claim the local
@@ -414,10 +504,11 @@ describe('thread history merge & persistence', () => {
       delivery: 'delivered',
       timestamp: '2026-06-10T00:00:01.000Z',
       requestId: 'kmsg_1',
+      turnRef: 'trace-shared#1',
     }))
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z', requestId: 'kmsg_2' }),
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z', requestId: 'kmsg_2', turnRef: 'trace-shared#1' }),
     ])
 
     const ids = (keeperThreads.value.echo ?? []).map(e => e.id)

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -167,10 +167,10 @@ describe('thread history merge & persistence', () => {
   })
 
   it('does not duplicate a local message when server history arrives with a different timestamp', () => {
-    appendThreadEntry('echo', entry({ id: 'local-1', text: 'gg', rawText: 'gg', timestamp: '2026-06-10T00:00:01.000Z' }))
+    appendThreadEntry('echo', entry({ id: 'local-1', text: 'gg', rawText: 'gg', requestId: 'kmsg-r1', timestamp: '2026-06-10T00:00:01.000Z' }))
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-1', text: 'gg', rawText: 'gg', delivery: 'history', timestamp: '2026-06-10T00:00:05.000Z' }),
+      entry({ id: 'hist-1', text: 'gg', rawText: 'gg', requestId: 'kmsg-r1', delivery: 'history', timestamp: '2026-06-10T00:00:05.000Z' }),
     ])
 
     const matches = (keeperThreads.value.echo ?? []).filter(e => e.text === 'gg')
@@ -184,6 +184,7 @@ describe('thread history merge & persistence', () => {
       role: 'assistant',
       text: 'final answer',
       rawText: 'final answer',
+      requestId: 'kmsg-r1',
       delivery: 'streaming',
       streamState: 'streaming',
     }))
@@ -200,6 +201,7 @@ describe('thread history merge & persistence', () => {
         role: 'assistant',
         text: 'final answer',
         rawText: 'final answer',
+        requestId: 'kmsg-r1',
         delivery: 'history',
         timestamp: '2026-06-10T00:00:05.000Z',
       }),
@@ -216,14 +218,14 @@ describe('thread history merge & persistence', () => {
 
   it('distributes identical-text assistant turns trace 1:1 across history rows (#21748)', () => {
     // Two local optimistic assistants with the SAME reply text but distinct
-    // thinking traces. Before the fix, both history rows matched the FIRST
-    // local source via the role+text fallback, so the second row inherited the
-    // first turn's trace.
+    // thinking traces and distinct requestIds. Each history row must inherit
+    // its OWN turn's trace via the requestId join, never the other's.
     appendThreadEntry('echo', entry({
       id: 'local-a',
       role: 'assistant',
       text: 'done',
       rawText: 'done',
+      requestId: 'kmsg-ra',
       delivery: 'delivered',
       streamState: null,
       timestamp: '2026-06-10T00:00:01.000Z',
@@ -233,6 +235,7 @@ describe('thread history merge & persistence', () => {
       role: 'assistant',
       text: 'done',
       rawText: 'done',
+      requestId: 'kmsg-rb',
       delivery: 'delivered',
       streamState: null,
       timestamp: '2026-06-10T00:00:02.000Z',
@@ -241,8 +244,8 @@ describe('thread history merge & persistence', () => {
     appendAssistantThinkingDelta('echo', 'local-b', 'second turn reasoning')
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
-      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
+      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', requestId: 'kmsg-ra', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', requestId: 'kmsg-rb', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
     ])
 
     const thread = keeperThreads.value.echo ?? []
@@ -378,13 +381,17 @@ describe('thread history merge & persistence', () => {
     expect(thread.filter(e => e.role === 'tool')).toHaveLength(2)
   })
 
-  it('keeps the role+text fallback for legacy local entries without requestId', () => {
+  it('never merges a legacy local entry that carries no requestId (role+text fallback hard-cut)', () => {
+    // The legacy role+text heuristic was removed: without a requestId the
+    // local row and the history row are distinct rows, even with identical
+    // text. A text-less placeholder can no longer be reconciled by text.
     appendThreadEntry('echo', entry({
       id: 'local-legacy',
       role: 'assistant',
       text: 'done',
       rawText: 'done',
       delivery: 'delivered',
+      timestamp: '2026-06-10T00:00:01.000Z',
     }))
 
     mergeServerHistoryEntries('echo', [
@@ -392,8 +399,7 @@ describe('thread history merge & persistence', () => {
     ])
 
     const thread = keeperThreads.value.echo ?? []
-    expect(thread).toHaveLength(1)
-    expect(thread[0]?.id).toBe('hist-legacy')
+    expect(thread.map(e => e.id)).toEqual(['local-legacy', 'hist-legacy'])
   })
 
   it('does not merge same-text rows that carry different requestIds', () => {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -21,7 +21,7 @@ import {
   removeThreadEntries,
   setStatusDetail,
 } from './keeper-state'
-import type { ChatBlock, KeeperConversationEntry } from './types'
+import type { ChatBlock, ChatTraceStep, KeeperConversationEntry } from './types'
 
 describe('normalizeStatusDetail', () => {
   it('infers and hides internal keeper history from direct comms', () => {
@@ -297,6 +297,125 @@ describe('thread history merge & persistence', () => {
     expect(traceTextOf('hist-a')).not.toBe(traceTextOf('hist-b'))
     expect(traceTextOf('hist-a')).toBe('turn-a reasoning')
     expect(traceTextOf('hist-b')).toBe('turn-b reasoning')
+  })
+
+  it('converges a stream-interrupted placeholder turn to a single assistant row via requestId', () => {
+    // Live stream died right after the tool events: the local assistant
+    // placeholder keeps text='' with only the accumulated tool trace and
+    // never received REPLY_DETAILS (turnRef stays null). The real reply
+    // arrives later as a REST history row. The backend stamps
+    // delivery_key.request_id ('kmsg-...') on every row of the turn, so
+    // history convergence must fold the placeholder into the history row
+    // instead of leaving a second "턴 타임라인" behind.
+    const R = 'kmsg_turn_1'
+    const traceSteps: ChatTraceStep[] = [
+      { kind: 'tool', name: 'read_file', toolCallId: 'call-1', status: 'ok' },
+      { kind: 'tool', name: 'write_file', toolCallId: 'call-2', status: 'ok' },
+    ]
+    appendThreadEntry('echo', entry({
+      id: `pending-user-${R}`,
+      role: 'user',
+      text: '질문',
+      rawText: '질문',
+      delivery: 'delivered',
+      timestamp: '2026-06-10T00:00:01.000Z',
+      requestId: R,
+    }))
+    appendThreadEntry('echo', entry({
+      id: 'tool-call-1',
+      role: 'tool',
+      source: 'tool_result',
+      label: 'read_file',
+      text: '{"path":"a"}',
+      rawText: '{"path":"a"}',
+      delivery: 'delivered',
+      timestamp: '2026-06-10T00:00:02.000Z',
+    }))
+    appendThreadEntry('echo', entry({
+      id: 'tool-call-2',
+      role: 'tool',
+      source: 'tool_result',
+      label: 'write_file',
+      text: '{"path":"b"}',
+      rawText: '{"path":"b"}',
+      delivery: 'delivered',
+      timestamp: '2026-06-10T00:00:03.000Z',
+    }))
+    appendThreadEntry('echo', entry({
+      id: `pending-assistant-${R}`,
+      role: 'assistant',
+      text: '',
+      rawText: '',
+      delivery: 'error',
+      timestamp: '2026-06-10T00:00:04.000Z',
+      requestId: R,
+      traceSteps,
+    }))
+
+    const history = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: '질문', ts: 1_780_000_001, delivery_key: { kind: 'direct_request', request_id: R } },
+      { role: 'tool', content: '{"path":"a"}', ts: 1_780_000_002, tool_call_id: 'call-1', tool_call_name: 'read_file', delivery_key: { kind: 'direct_request', request_id: R } },
+      { role: 'tool', content: '{"path":"b"}', ts: 1_780_000_003, tool_call_id: 'call-2', tool_call_name: 'write_file', delivery_key: { kind: 'direct_request', request_id: R } },
+      { role: 'assistant', content: '답변', ts: 1_780_000_004, turn_ref: 'trace-x#1', delivery_key: { kind: 'direct_request', request_id: R } },
+    ])
+    mergeServerHistoryEntries('echo', history)
+
+    const thread = keeperThreads.value.echo ?? []
+    // Exactly one assistant row survives: the canonical history row.
+    const assistants = thread.filter(e => e.role === 'assistant')
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0]?.text).toBe('답변')
+    expect(assistants[0]?.delivery).toBe('history')
+    expect(assistants[0]?.requestId).toBe(R)
+    // The interrupted placeholder's live tool trace is inherited.
+    expect(assistants[0]?.traceSteps).toEqual(traceSteps)
+    // The optimistic user row converges to the history row too.
+    const users = thread.filter(e => e.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0]?.delivery).toBe('history')
+    expect(users[0]?.requestId).toBe(R)
+    // Tool rows stay single (dedup by the tool-<tool_call_id> id shape).
+    expect(thread.filter(e => e.role === 'tool')).toHaveLength(2)
+  })
+
+  it('keeps the role+text fallback for legacy local entries without requestId', () => {
+    appendThreadEntry('echo', entry({
+      id: 'local-legacy',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'delivered',
+    }))
+
+    mergeServerHistoryEntries('echo', [
+      entry({ id: 'hist-legacy', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:05.000Z' }),
+    ])
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread).toHaveLength(1)
+    expect(thread[0]?.id).toBe('hist-legacy')
+  })
+
+  it('does not merge same-text rows that carry different requestIds', () => {
+    // Identical reply text across two distinct turns: requestId is the turn
+    // identity, so the history row of one request must not claim the local
+    // row of another even when role+text coincide.
+    appendThreadEntry('echo', entry({
+      id: 'local-a',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'delivered',
+      timestamp: '2026-06-10T00:00:01.000Z',
+      requestId: 'kmsg_1',
+    }))
+
+    mergeServerHistoryEntries('echo', [
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z', requestId: 'kmsg_2' }),
+    ])
+
+    const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
+    expect(ids).toEqual(['local-a', 'hist-b'])
   })
 
   it('keeps local entries the server has not persisted yet', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -855,6 +855,15 @@ function fallbackHistoryEntryId(
   return `${role}-${timestamp ?? 'entry'}-${(hash >>> 0).toString(36)}`
 }
 
+// Turn identity carried on persisted history rows as
+// `delivery_key: {"kind":"direct_request","request_id":"kmsg-..."}`. `kind`
+// may take other values, so only the `request_id` string is extracted; any
+// other shape yields null (the row itself is never dropped for this).
+function requestIdFromDeliveryKey(raw: unknown): string | null {
+  if (!isRecord(raw)) return null
+  return asString(raw.request_id) ?? null
+}
+
 function normalizeHistoryEntry(
   raw: unknown,
   keeperName?: string,
@@ -884,6 +893,7 @@ function normalizeHistoryEntry(
   const speakerAuthority = asString(raw.speaker_authority) ?? null
   // RFC-0233 §7: asString rejects malformed join keys instead of repairing them.
   const turnRef = asString(raw.turn_ref) ?? null
+  const requestId = requestIdFromDeliveryKey(raw.delivery_key)
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
   // apart from a real reply. Preserve that writer-declared provenance as its
@@ -912,6 +922,7 @@ function normalizeHistoryEntry(
     rawText,
     timestamp,
     turnRef,
+    requestId,
     delivery,
     error: delivery === 'transport_failure' ? rawText : null,
     streamState: null,
@@ -1331,6 +1342,17 @@ function sameConversationEntry(
 ): boolean {
   if (left.id === right.id) return true
   if (left.role === 'tool' || right.role === 'tool') return false
+  // requestId (delivery_key.request_id) is the backend-stamped turn identity:
+  // it joins a local placeholder to its history row even when the placeholder
+  // has no text yet (stream interrupted before the reply arrived). Two rows
+  // that both carry a requestId belong to the same turn iff the ids match —
+  // a mismatch must NOT fall through to the role+text heuristic, or two
+  // distinct same-text turns would collapse into one.
+  const leftRequestId = left.requestId?.trim()
+  const rightRequestId = right.requestId?.trim()
+  if (leftRequestId && rightRequestId) {
+    return left.role === right.role && leftRequestId === rightRequestId
+  }
   return left.role === right.role && left.text === right.text
 }
 
@@ -1347,14 +1369,34 @@ function mergeLocalAssistantTraceSteps(
   historyEntry: KeeperConversationEntry,
   localEntries: KeeperConversationEntry[],
   // Tracks local trace sources already claimed by an earlier history row.
-  // When OAS/MASC provides turn_ref on both the live reply details and the
-  // persisted history row, that value is the exact join key. The role+text
-  // fallback remains only for legacy rows without turn_ref; `consumed` keeps
-  // those fallback matches 1:1 instead of letting duplicate assistant text reuse
-  // the first local trace source (#21748).
+  // Join order: requestId (backend-stamped turn identity) first, then
+  // turn_ref when OAS/MASC provides it on both the live reply details and
+  // the persisted history row. The role+text fallback remains only for
+  // legacy rows without either key; `consumed` keeps every match 1:1 instead
+  // of letting duplicate assistant text reuse the first local trace source
+  // (#21748).
   consumed: Set<string>,
 ): KeeperConversationEntry {
   if (historyEntry.role !== 'assistant') return historyEntry
+  // requestId join first: a placeholder whose stream died before REPLY_DETAILS
+  // has no turnRef and possibly no text, but it does carry the request id.
+  const historyRequestId = historyEntry.requestId?.trim()
+  const localTraceSourceByRequestId = historyRequestId
+    ? localEntries.find(
+        entry =>
+          entry.role === 'assistant'
+          && (entry.traceSteps?.length ?? 0) > 0
+          && !consumed.has(entry.id)
+          && entry.requestId?.trim() === historyRequestId,
+      )
+    : undefined
+  if (localTraceSourceByRequestId?.traceSteps?.length) {
+    consumed.add(localTraceSourceByRequestId.id)
+    return {
+      ...historyEntry,
+      traceSteps: localTraceSourceByRequestId.traceSteps,
+    }
+  }
   const historyTurnRef = historyEntry.turnRef?.trim()
   const localTraceSourceByTurnRef = historyTurnRef
     ? localEntries.find(
@@ -1471,6 +1513,10 @@ interface RestChatHistoryMessage {
   speaker_authority?: string
   // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" turn join key.
   turn_ref?: string | null
+  // Backend-stamped turn identity (e.g.
+  // `{"kind":"direct_request","request_id":"kmsg-..."}`); extracted
+  // tolerantly — only the request_id string is read.
+  delivery_key?: unknown
   audio?: unknown
   // Persisted upload rows (snake_case from keeper_chat_store) — normalized to
   // KeeperConversationAttachment at consume time so reload keeps the cards.
@@ -1522,6 +1568,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     // Tool rows share the same untrusted REST boundary; reject malformed
     // turn_ref values here too so this path matches normalizeHistoryEntry.
     turnRef: asString(message.turn_ref) ?? null,
+    requestId: requestIdFromDeliveryKey(message.delivery_key),
   }
 }
 
@@ -1559,6 +1606,7 @@ export function chatHistoryEntriesFromRest(
         kind: message.kind,
         blocks: message.blocks,
         turn_ref: message.turn_ref,
+        delivery_key: message.delivery_key,
         stream_contract: message.stream_contract,
       },
       keeperName,

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -855,13 +855,28 @@ function fallbackHistoryEntryId(
   return `${role}-${timestamp ?? 'entry'}-${(hash >>> 0).toString(36)}`
 }
 
-// Turn identity carried on persisted history rows as
-// `delivery_key: {"kind":"direct_request","request_id":"kmsg-..."}`. `kind`
-// may take other values, so only the `request_id` string is extracted; any
-// other shape yields null (the row itself is never dropped for this).
-function requestIdFromDeliveryKey(raw: unknown): string | null {
-  if (!isRecord(raw)) return null
-  return asString(raw.request_id) ?? null
+interface DeliveryIdentity {
+  requestId: string | null
+  queueReceiptIds: string[]
+}
+
+// Typed delivery identity carried on persisted history rows. Unknown or
+// malformed shapes fail closed for reconciliation without dropping the row.
+function deliveryIdentityFromKey(raw: unknown): DeliveryIdentity {
+  if (!isRecord(raw)) return { requestId: null, queueReceiptIds: [] }
+  const kind = asString(raw.kind)
+  if (kind === 'direct_request' || kind === 'async_request') {
+    const requestId = asString(raw.request_id)?.trim() ?? ''
+    return { requestId: requestId || null, queueReceiptIds: [] }
+  }
+  const rawReceiptIds = normalizeStringArray(raw.receipt_ids)
+  if (kind === 'queue_receipts' && rawReceiptIds !== null) {
+    const queueReceiptIds = rawReceiptIds
+      .map(receiptId => receiptId.trim())
+      .filter((receiptId): receiptId is string => receiptId.length > 0)
+    return { requestId: null, queueReceiptIds: [...new Set(queueReceiptIds)] }
+  }
+  return { requestId: null, queueReceiptIds: [] }
 }
 
 function normalizeHistoryEntry(
@@ -893,7 +908,7 @@ function normalizeHistoryEntry(
   const speakerAuthority = asString(raw.speaker_authority) ?? null
   // RFC-0233 §7: asString rejects malformed join keys instead of repairing them.
   const turnRef = asString(raw.turn_ref) ?? null
-  const requestId = requestIdFromDeliveryKey(raw.delivery_key)
+  const deliveryIdentity = deliveryIdentityFromKey(raw.delivery_key)
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
   // apart from a real reply. Preserve that writer-declared provenance as its
@@ -922,7 +937,8 @@ function normalizeHistoryEntry(
     rawText,
     timestamp,
     turnRef,
-    requestId,
+    requestId: deliveryIdentity.requestId,
+    queueReceiptIds: deliveryIdentity.queueReceiptIds,
     delivery,
     error: delivery === 'transport_failure' ? rawText : null,
     streamState: null,
@@ -1332,26 +1348,46 @@ export function finalizeAssistantEntry(
 
 // Dedup key for merging server history with locally-appended entries.
 // Server ids win when both sides have already converged. User/assistant
-// rows converge only through delivery_key.request_id — the backend-stamped
-// turn identity that joins a local placeholder to its history row even when
-// the placeholder has no text yet (stream interrupted before the reply
-// arrived). Two rows that both carry a requestId belong to the same turn
-// iff the ids match; a row without a requestId (pre-delivery_key history,
-// connector-originated) never merges with a local row — the legacy
-// role+text heuristic was hard-cut because it collapsed distinct same-text
-// turns and could never reconcile a text-less placeholder. Tool rows are
-// execution facts and can share argument/output text across separate
-// calls, so they only dedup by the explicit `tool-<tool_call_id>` id shape.
+// rows converge through exact producer identities only: request id first,
+// then a shared queue receipt, then turn_ref when neither side carries a
+// delivery key. Conflicting delivery identities fail closed. The legacy
+// role+text heuristic stays hard-cut because it collapsed distinct same-text
+// turns. Tool rows only dedup by their explicit `tool-<tool_call_id>` id.
+function queueReceiptIds(entry: KeeperConversationEntry): string[] {
+  const receiptIds = new Set(
+    (entry.queueReceiptIds ?? [])
+      .map(receiptId => receiptId.trim())
+      .filter(receiptId => receiptId.length > 0),
+  )
+  const localReceiptId = entry.details?.queueReceiptId?.trim()
+  if (localReceiptId) receiptIds.add(localReceiptId)
+  return [...receiptIds]
+}
+
 function sameConversationEntry(
   left: KeeperConversationEntry,
   right: KeeperConversationEntry,
 ): boolean {
   if (left.id === right.id) return true
   if (left.role === 'tool' || right.role === 'tool') return false
+  if (left.role !== right.role) return false
   const leftRequestId = left.requestId?.trim()
   const rightRequestId = right.requestId?.trim()
-  if (!leftRequestId || !rightRequestId) return false
-  return left.role === right.role && leftRequestId === rightRequestId
+  if (leftRequestId && rightRequestId) return leftRequestId === rightRequestId
+
+  const leftReceiptIds = queueReceiptIds(left)
+  const rightReceiptIds = queueReceiptIds(right)
+  if (leftReceiptIds.length > 0 && rightReceiptIds.length > 0) {
+    const rightReceipts = new Set(rightReceiptIds)
+    return leftReceiptIds.some(receiptId => rightReceipts.has(receiptId))
+  }
+  if (leftRequestId || rightRequestId || leftReceiptIds.length > 0 || rightReceiptIds.length > 0) {
+    return false
+  }
+
+  const leftTurnRef = left.turnRef?.trim()
+  const rightTurnRef = right.turnRef?.trim()
+  return Boolean(leftTurnRef && rightTurnRef && leftTurnRef === rightTurnRef)
 }
 
 // Entries with no parseable timestamp (live placeholders, still-streaming
@@ -1439,13 +1475,12 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
       // later flip to delivered and leave a duplicate "작업 과정" card behind.
       const isCoveredToolRow = entry.role === 'tool' && coveredByHistory
       // In-flight (sending/streaming/queued) entries represent live state and
-      // must survive history merges until they finalize. Otherwise a queued
-      // assistant with empty text can be mistaken for an older empty-text
-      // history row and dropped, making the queued reply look like an error.
+      // must survive history merges until they finalize.
       // A terminal durable-receipt observation is also operator evidence, not
       // a duplicate assistant reply: keep it alongside the canonical history
       // row so its Pending/Inflight/Delivered/Failed lifecycle remains visible.
-      const isReceiptObservation = Boolean(entry.details?.queueReceiptId)
+      const isReceiptObservation =
+        entry.role === 'assistant' && Boolean(entry.details?.queueReceiptId)
       const shouldKeepLocalEntry = isInFlightDelivery(entry.delivery)
         || isReceiptObservation
         || !coveredByHistory
@@ -1500,9 +1535,8 @@ interface RestChatHistoryMessage {
   speaker_authority?: string
   // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" turn join key.
   turn_ref?: string | null
-  // Backend-stamped turn identity (e.g.
-  // `{"kind":"direct_request","request_id":"kmsg-..."}`); extracted
-  // tolerantly — only the request_id string is read.
+  // Backend-stamped delivery identity: direct/async request id or queue
+  // receipt ids. Unknown shapes are ignored without dropping the row.
   delivery_key?: unknown
   audio?: unknown
   // Persisted upload rows (snake_case from keeper_chat_store) — normalized to
@@ -1555,7 +1589,6 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     // Tool rows share the same untrusted REST boundary; reject malformed
     // turn_ref values here too so this path matches normalizeHistoryEntry.
     turnRef: asString(message.turn_ref) ?? null,
-    requestId: requestIdFromDeliveryKey(message.delivery_key),
   }
 }
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1332,28 +1332,26 @@ export function finalizeAssistantEntry(
 
 // Dedup key for merging server history with locally-appended entries.
 // Server ids win when both sides have already converged. User/assistant
-// optimistic rows still fall back to role + text because the POST can create
-// the local row before the server-minted id is known. Tool rows are execution
-// facts and can share argument/output text across separate calls, so they only
-// dedup by the explicit `tool-<tool_call_id>` id shape.
+// rows converge only through delivery_key.request_id — the backend-stamped
+// turn identity that joins a local placeholder to its history row even when
+// the placeholder has no text yet (stream interrupted before the reply
+// arrived). Two rows that both carry a requestId belong to the same turn
+// iff the ids match; a row without a requestId (pre-delivery_key history,
+// connector-originated) never merges with a local row — the legacy
+// role+text heuristic was hard-cut because it collapsed distinct same-text
+// turns and could never reconcile a text-less placeholder. Tool rows are
+// execution facts and can share argument/output text across separate
+// calls, so they only dedup by the explicit `tool-<tool_call_id>` id shape.
 function sameConversationEntry(
   left: KeeperConversationEntry,
   right: KeeperConversationEntry,
 ): boolean {
   if (left.id === right.id) return true
   if (left.role === 'tool' || right.role === 'tool') return false
-  // requestId (delivery_key.request_id) is the backend-stamped turn identity:
-  // it joins a local placeholder to its history row even when the placeholder
-  // has no text yet (stream interrupted before the reply arrived). Two rows
-  // that both carry a requestId belong to the same turn iff the ids match —
-  // a mismatch must NOT fall through to the role+text heuristic, or two
-  // distinct same-text turns would collapse into one.
   const leftRequestId = left.requestId?.trim()
   const rightRequestId = right.requestId?.trim()
-  if (leftRequestId && rightRequestId) {
-    return left.role === right.role && leftRequestId === rightRequestId
-  }
-  return left.role === right.role && left.text === right.text
+  if (!leftRequestId || !rightRequestId) return false
+  return left.role === right.role && leftRequestId === rightRequestId
 }
 
 // Entries with no parseable timestamp (live placeholders, still-streaming
@@ -1371,9 +1369,11 @@ function mergeLocalAssistantTraceSteps(
   // Tracks local trace sources already claimed by an earlier history row.
   // Join order: requestId (backend-stamped turn identity) first, then
   // turn_ref when OAS/MASC provides it on both the live reply details and
-  // the persisted history row. The role+text fallback remains only for
-  // legacy rows without either key; `consumed` keeps every match 1:1 instead
-  // of letting duplicate assistant text reuse the first local trace source
+  // the persisted history row. There is no text-based fallback: a local
+  // trace source that shares neither key with the history row stays
+  // unmerged (and is dropped by the same requestId rule in replaceThread
+  // once its turn converges). `consumed` keeps every match 1:1 instead of
+  // letting duplicate assistant text reuse the first local trace source
   // (#21748).
   consumed: Set<string>,
 ): KeeperConversationEntry {
@@ -1414,20 +1414,7 @@ function mergeLocalAssistantTraceSteps(
       traceSteps: localTraceSourceByTurnRef.traceSteps,
     }
   }
-  const localTraceSource = localEntries.find(
-    entry =>
-      entry.role === 'assistant'
-      && (entry.traceSteps?.length ?? 0) > 0
-      && !(entry.turnRef?.trim())
-      && !consumed.has(entry.id)
-      && sameConversationEntry(entry, historyEntry),
-  )
-  if (!localTraceSource?.traceSteps?.length) return historyEntry
-  consumed.add(localTraceSource.id)
-  return {
-    ...historyEntry,
-    traceSteps: localTraceSource.traceSteps,
-  }
+  return historyEntry
 }
 
 function replaceThread(name: string, entries: KeeperConversationEntry[]): void {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -978,6 +978,12 @@ export interface KeeperConversationEntry {
   // chat message's originating turn so turn consumers can prefer exact matching
   // over timestamp-window fallback.
   turnRef?: string | null
+  // Turn identity for history reconciliation: the backend persists
+  // `delivery_key.request_id` ('kmsg-...') on every dashboard-originated row
+  // of a turn. Local placeholders carry the same id from send time, so a
+  // history merge can converge a turn even when the text/turnRef join keys
+  // are unavailable (e.g. a stream interrupted before the reply arrived).
+  requestId?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
   streamContract?: KeeperConversationStreamContract | null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -978,12 +978,12 @@ export interface KeeperConversationEntry {
   // chat message's originating turn so turn consumers can prefer exact matching
   // over timestamp-window fallback.
   turnRef?: string | null
-  // Turn identity for history reconciliation: the backend persists
-  // `delivery_key.request_id` ('kmsg-...') on every dashboard-originated row
-  // of a turn. Local placeholders carry the same id from send time, so a
-  // history merge can converge a turn even when the text/turnRef join keys
-  // are unavailable (e.g. a stream interrupted before the reply arrived).
+  // Direct/async delivery identity for history reconciliation. Local
+  // placeholders carry the backend-minted request id once it is observed.
   requestId?: string | null
+  // Queue-lane delivery identity. Persisted history can reference one or more
+  // durable queue receipts instead of a request id.
+  queueReceiptIds?: string[]
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
   streamContract?: KeeperConversationStreamContract | null

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -232,6 +232,12 @@ type chat_message = {
          stream response represented by this row. [None] means pre-K1f row or
          no lifecycle proof. Malformed persisted values are reported and read
          as [None], keeping the row valid. *)
+  delivery_key : Keeper_chat_delivery_identity.delivery_key option;
+      (* The exact delivery identity persisted by the idempotent append-once
+         paths.  [None] on rows written by the plain append paths and on rows
+         written before this field existed.  A malformed persisted value is
+         reported as a persistence read drop and reads as [None]; the row
+         stays valid. *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -1243,6 +1249,24 @@ let parse_line ~file_path (line : string) : chat_message option =
       | Some stream_lifecycle_json ->
           parse_stream_lifecycle ~path:file_path stream_lifecycle_json
     in
+    let delivery_key =
+      (* Same read-drop convention as [turn_ref]: a malformed persisted
+         value is surfaced and reads as [None] — the row stays valid. *)
+      match Json_util.assoc_member_opt "delivery_key" json with
+      | None -> None
+      | Some delivery_key_json -> (
+          match
+            Keeper_chat_delivery_identity.delivery_key_of_yojson
+              delivery_key_json
+          with
+          | Ok key -> Some key
+          | Error detail ->
+              report_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path:file_path
+                ~detail:(Printf.sprintf "invalid delivery_key: %s" detail);
+              None)
+    in
     if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -1276,7 +1300,8 @@ let parse_line ~file_path (line : string) : chat_message option =
             { id; role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id;
               workspace_id; speaker;
-              audio; blocks; mentions; kind; turn_ref; stream_lifecycle }
+              audio; blocks; mentions; kind; turn_ref; stream_lifecycle;
+              delivery_key }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -1636,7 +1661,16 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                 ]
               @ blocks_fields_of_list (blocks_with_trace_block ~trace_block m)
               @ opt_string_field "turn_ref"
-                  (Option.map Ids.Turn_ref.to_string m.turn_ref)))
+                  (Option.map Ids.Turn_ref.to_string m.turn_ref)
+              (* Expose the persisted delivery identity so the dashboard can
+                 reconcile a history reload against its optimistic turn rows
+                 on the exact [delivery_key.request_id]. *)
+              @ (match m.delivery_key with
+                 | None -> []
+                 | Some key ->
+                     [ ( "delivery_key"
+                       , Keeper_chat_delivery_identity.delivery_key_to_yojson
+                           key ) ])))
        messages)
 
 (* RFC-0233 §7: a turn's transcript derived by an exact join on the

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -207,6 +207,13 @@ type chat_message = {
           the writer could not prove lifecycle events. Malformed persisted
           values are reported as persistence read drops and read as [None];
           the row stays valid. *)
+  delivery_key : Keeper_chat_delivery_identity.delivery_key option;
+      (** The exact delivery identity persisted by the idempotent append-once
+          paths ({!append_user_message_once} /
+          {!append_assistant_message_once}).  [None] on rows written by the
+          plain append paths and on rows written before this field existed.
+          A malformed persisted value is reported as a persistence read drop
+          and reads as [None]; the row stays valid. *)
 }
 
 (** {1 I/O} *)
@@ -391,8 +398,11 @@ val load_page :
     [ts] field; [tool_call_id] / [tool_call_name] / [source] /
     [conversation_id] / [external_message_id] / [workspace_id] /
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
-    when present. When [base_dir] is supplied, the history endpoint marks
-    audio clips as [expired] when the underlying MP3 file is gone. *)
+    when present. [delivery_key] appears only on rows persisted by the
+    idempotent append-once paths, verbatim as the typed delivery
+    identity object. When [base_dir] is supplied, the history endpoint
+    marks audio clips as [expired] when the underlying MP3 file is
+    gone. *)
 val to_json_array :
   ?base_dir:string ->
   ?trace_block_by_turn_ref:(Ids.Turn_ref.t -> chat_block option) ->

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1785,10 +1785,121 @@ let test_turn_ref_malformed_reads_none () =
       | messages ->
           Alcotest.failf "expected 1 message, got %d" (List.length messages))
 
-(* RFC-0233 §7: transcript_of_messages joins persisted rows on the exact
-   turn_ref, partitions operator/keeper lines, and excludes rows of other
-   turns. turn_transcript_to_json reports found=true and surfaces the
-   content. *)
+(* The idempotent append-once paths persist the exact delivery identity on
+   the row; load decodes it back and to_json_array exposes it verbatim so the
+   dashboard can reconcile a history reload against its optimistic turn rows
+   on the exact [delivery_key.request_id]. *)
+let test_delivery_key_round_trip_to_json_array () =
+  let base_dir = temp_base_path "keeper-chat-store-delivery-key" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-delivery-key" in
+      let request_id =
+        match
+          Keeper_chat_delivery_identity.Request_id.of_string
+            "kmsg-turn-identity-1"
+        with
+        | Ok request_id -> request_id
+        | Error detail -> Alcotest.fail detail
+      in
+      let delivery_key =
+        Keeper_chat_delivery_identity.Direct_request request_id
+      in
+      (match
+         K.append_user_message_once ~base_dir ~keeper_name ~delivery_key
+           ~content:"hello" ()
+       with
+       | Ok (K.Appended _) -> ()
+       | Ok (K.Already_present _) ->
+           Alcotest.fail "user row unexpectedly already present"
+       | Error detail -> Alcotest.fail detail);
+      (match
+         K.append_assistant_message_once ~base_dir ~keeper_name ~delivery_key
+           ~content:"hi" ()
+       with
+       | Ok (K.Appended _) -> ()
+       | Ok (K.Already_present _) ->
+           Alcotest.fail "assistant row unexpectedly already present"
+       | Error detail -> Alcotest.fail detail);
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check int) "two rows loaded" 2 (List.length messages);
+      List.iter
+        (fun (m : K.chat_message) ->
+          match m.delivery_key with
+          | Some key ->
+              Alcotest.(check bool)
+                (Printf.sprintf "delivery_key on %s row"
+                   (K.Role.to_label m.role))
+                true
+                (Keeper_chat_delivery_identity.delivery_key_equal key
+                   delivery_key)
+          | None -> Alcotest.fail "missing delivery_key on append-once row")
+        messages;
+      let open Yojson.Safe.Util in
+      match K.to_json_array messages with
+      | `List rows ->
+          List.iter
+            (fun row ->
+              let key_json = row |> member "delivery_key" in
+              Alcotest.(check string) "delivery_key kind" "direct_request"
+                (key_json |> member "kind" |> to_string);
+              Alcotest.(check string) "delivery_key request_id"
+                "kmsg-turn-identity-1"
+                (key_json |> member "request_id" |> to_string))
+            rows
+      | _ -> Alcotest.fail "to_json_array must return a list")
+
+(* Rows written by the plain append paths carry no delivery identity; the
+   history payload omits the field entirely (shape unchanged for them). *)
+let test_delivery_key_absent_on_plain_append () =
+  let base_dir = temp_base_path "keeper-chat-store-delivery-key-absent" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-delivery-key-absent" in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"hi"
+        ~user_attachments:[] ~assistant_content:"hello" ();
+      let messages = K.load ~base_dir ~keeper_name in
+      List.iter
+        (fun (m : K.chat_message) ->
+          Alcotest.(check bool) "plain append row has no delivery_key" true
+            (m.delivery_key = None))
+        messages;
+      let open Yojson.Safe.Util in
+      match K.to_json_array messages with
+      | `List rows ->
+          List.iter
+            (fun row ->
+              Alcotest.(check bool) "delivery_key field omitted" true
+                (row |> member "delivery_key" |> ( = ) `Null))
+            rows
+      | _ -> Alcotest.fail "to_json_array must return a list")
+
+(* A malformed persisted delivery_key is surfaced as a read drop and reads
+   as [None] — the row itself stays valid, same convention as turn_ref. *)
+let test_delivery_key_malformed_reads_none () =
+  let base_dir = temp_base_path "keeper-chat-store-delivery-key-bad" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-delivery-key-bad" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let invalid_payload =
+        Safe_ops.persistence_read_drop_reason_invalid_payload
+      in
+      let before = drop_value invalid_payload in
+      write_file path
+        ({|{"role":"user","content":"x","ts":1.0,"delivery_key":{"kind":"not_a_kind","request_id":"kmsg-1"}}|}
+        ^ "\n");
+      (match K.load ~base_dir ~keeper_name with
+       | [ m ] ->
+           Alcotest.(check bool) "malformed delivery_key reads as None" true
+             (m.delivery_key = None)
+       | messages ->
+           Alcotest.failf "expected 1 message, got %d" (List.length messages));
+      Alcotest.(check (float 0.001)) "drop counted as invalid payload" 1.0
+        (drop_value invalid_payload -. before))
 let test_transcript_of_messages_joins_turn_ref () =
   let base_dir = temp_base_path "keeper-chat-store-transcript" in
   Fun.protect
@@ -1972,6 +2083,12 @@ let () =
             `Quick test_turn_ref_persisted_on_turn_rows;
           Alcotest.test_case "malformed turn_ref reads as None (RFC-0233 §7)"
             `Quick test_turn_ref_malformed_reads_none;
+          Alcotest.test_case "delivery_key round-trips to history json" `Quick
+            test_delivery_key_round_trip_to_json_array;
+          Alcotest.test_case "delivery_key omitted on plain append rows"
+            `Quick test_delivery_key_absent_on_plain_append;
+          Alcotest.test_case "malformed delivery_key reads as None" `Quick
+            test_delivery_key_malformed_reads_none;
           Alcotest.test_case
             "transcript_of_messages joins turn_ref (RFC-0233 §7)" `Quick
             test_transcript_of_messages_joins_turn_ref;

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -67,6 +67,7 @@ let msg ~role ?(id = "test-msg") ?(ts = Some 1.0) ?(source = None) ?(speaker = N
   ; kind
   ; turn_ref
   ; stream_lifecycle = None
+  ; delivery_key = None
   }
 ;;
 
@@ -217,6 +218,7 @@ let tool_line : Store.chat_message =
   ; kind = Store.Row_kind.Utterance
   ; turn_ref = None
   ; stream_lifecycle = None
+  ; delivery_key = None
   }
 ;;
 

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -31,6 +31,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     kind = Store.Row_kind.Utterance;
     turn_ref = None;
     stream_lifecycle = None;
+    delivery_key = None;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## 요약

keeper 채팅에서 스트림이 도구 실행 도중 끊기면, 같은 도구 호출이 "턴 타임라인" 두 블록에 중복 표시되던 버그의 근본 수정. 턴 정합(reconciliation) 키를 `role+text` 휴리스틱에서 **`delivery_key.request_id`**로 교체하고, 레거시 폴터는 hard-cut.

## 근본 원인

- 라이브 스트림이 도구 이벤트까지만 받고 끊기면 로컬에 placeholder(text='', traceSteps=[도구…])가 남는다.
- 실제 답변은 REST 히스토리로 도착하지만, dedup이 id 또는 `role+text`만 보기 때문에 빈 텍스트 placeholder는 영원히 매칭되지 않고 매 hydration마다 살아남아 자기 타임라인을 렌더링 → 도구가 2번 표시.
- 백엔드는 대시보드발 모든 채팅 행에 `delivery_key.request_id`를 영속화하지만 read-serve(`to_json_array`)에서 버리고 있었고, 프론트도 파싱하지 않았다.

## 변경

**백엔드 (OCaml)**
- `keeper_chat_store.chat_message`에 `delivery_key` 필드 추가, `parse_line`에서 디코드(malformed는 persistence read-drop 관례로 None, 행 유지), `to_json_array`가 있을 때만 emit
- wire shape: `{"kind":"direct_request","request_id":"kmsg-..."}` (kind는 `async_request`/`queue_receipts`도 가능, absent 가능 — 소비자는 optional로 취급, API_CONTRACT.md 명시)

**프론트엔드**
- `KeeperConversationEntry.requestId` 추가, chat-history 스키마가 `delivery_key`를 관대하게 파싱
- `sameConversationEntry`: user/assistant 수렴은 **requestId 전용** — `role+text` 레거시 휴리스틱 hard-cut (같은 텍스트의 다른 턴을 합치는 역방향 버그와 빈 텍스트 placeholder 정합 불가 문제를 동시에 제거). tool 행은 기존 `tool-<tool_call_id>` id 규칙 유지
- `mergeLocalAssistantTraceSteps`: requestId → turnRef 순 조인만 남기고 텍스트 폴터 제거 → 끊긴 placeholder의 trace가 히스토리 행에 흡수된 뒤 placeholder는 drop
- send/restore 경로 placeholder에 requestId 스탬프

## 검증

- 회귀 테스트(스크린샷 시나리오): 수정 전 2 failed → 수정 후 통과. assistant 1개 수렴 + trace 상속 + tool 중복 없음 확인
- hard-cut 계약 테스트: requestId 없는 레거시 로컬 행은 텍스트가 같아도 병합되지 않음 / requestId가 다른 같은-텍스트 행은 병합되지 않음
- 대시보드: `tsc --noEmit` 에러 0, **vitest 639파일 / 8753 테스트 전부 통과**
- 백엔드: `scripts/dune-local.sh`로 touched 타겟 빌드 + `test_keeper_chat_store`(52), `test_keeper_surface_read`(9), `test_keeper_mention_scope`(24) 전부 통과 (full runtest는 CI에 위임)

## 비목표

- tool 행의 서버 영속화 확장, 라이브 이중 기록(traceSteps + tool 엔트리) 구조 자체(렌더에서 join되는 설계), SSE→WS 컷오버