### PR TITLE
fix(ci): declare exact-output harness targets

### DIFF
--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -103,6 +103,11 @@ supports_named_tool_choice = true
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = false
+
+[[targets]]
+id = "contract_verifier.smoke"
+provider_ref = "contract_verifier"
+model_id = "contract-verifier"
 EOF
 }
 

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -170,8 +170,8 @@ max_context_tokens = 32768
 max_output_tokens = 1024
 supports_tools = true
 supports_tool_choice = true
-supports_response_format_json = true
-supports_structured_output = true
+supports_response_format_json = false
+supports_structured_output = false
 supports_native_streaming = true
 
 [[targets]]

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -149,6 +149,35 @@ is-default = true
 max-concurrent = 1
 EOF
   fi
+
+  if [[ ! -f "$config_dir/oas-models-overlay.toml" ]]; then
+    cat >"$config_dir/oas-models-overlay.toml" <<'EOF'
+[[providers]]
+id = "deepseek"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:9/v1"
+request_path = "/chat/completions"
+api_key_env = ""
+capabilities_base = "openai_chat"
+
+[[models]]
+id_prefix = "transport-harness-smoke"
+provider_name = "deepseek"
+base = "openai_chat"
+max_context_tokens = 32768
+max_output_tokens = 1024
+supports_tools = true
+supports_tool_choice = true
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+
+[[targets]]
+id = "deepseek.smoke"
+provider_ref = "deepseek"
+model_id = "transport-harness-smoke"
+EOF
+  fi
 }
 
 harness_wait_for_health() {

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -116,6 +116,7 @@ harness_seed_server_config() {
   local repo_root="$1"
   local base_path="$2"
   local config_dir="${base_path%/}/.masc/config"
+  local seeded_runtime=0
 
   mkdir -p \
     "$config_dir" \
@@ -148,9 +149,10 @@ supports-tool-choice = true
 is-default = true
 max-concurrent = 1
 EOF
+    seeded_runtime=1
   fi
 
-  if [[ ! -f "$config_dir/oas-models-overlay.toml" ]]; then
+  if [[ "$seeded_runtime" == "1" && ! -f "$config_dir/oas-models-overlay.toml" ]]; then
     cat >"$config_dir/oas-models-overlay.toml" <<'EOF'
 [[providers]]
 id = "deepseek"

--- a/scripts/harness/perf/keeper_load_gate.sh
+++ b/scripts/harness/perf/keeper_load_gate.sh
@@ -249,6 +249,34 @@ is-default = true
 max-concurrent = 64
 EOF
 
+cat > "$BASE_PATH/.masc/config/oas-models-overlay.toml" <<EOF
+[[providers]]
+id = "mock"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:$MOCK_PORT"
+request_path = "/chat/completions"
+api_key_env = ""
+default_model = "$BORROW_MODEL"
+capabilities_base = "openai_chat"
+
+[[models]]
+id_prefix = "$BORROW_MODEL"
+provider_name = "mock"
+base = "openai_chat"
+max_context_tokens = 131072
+max_output_tokens = 4096
+supports_tools = true
+supports_tool_choice = true
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+
+[[targets]]
+id = "mock.mockmodel"
+provider_ref = "mock"
+model_id = "$BORROW_MODEL"
+EOF
+
 for ((k=1;k<=KEEPERS;k++)); do
   cat > "$BASE_PATH/.masc/config/keepers/perf_keeper_${k}.toml" <<EOF
 [keeper]

--- a/scripts/harness/perf/keeper_load_gate.sh
+++ b/scripts/harness/perf/keeper_load_gate.sh
@@ -267,8 +267,8 @@ max_context_tokens = 131072
 max_output_tokens = 4096
 supports_tools = true
 supports_tool_choice = true
-supports_response_format_json = true
-supports_structured_output = true
+supports_response_format_json = false
+supports_structured_output = false
 supports_native_streaming = true
 
 [[targets]]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -340,6 +340,34 @@ is-default = true
 max-concurrent = 1
 |}
 
+let catalog_overlay_seed =
+  {|
+[[providers]]
+id = "deepseek"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:9/v1"
+request_path = "/chat/completions"
+api_key_env = ""
+capabilities_base = "openai_chat"
+
+[[models]]
+id_prefix = "deepseek-v4-flash"
+provider_name = "deepseek"
+base = "openai_chat"
+max_context_tokens = 32768
+max_output_tokens = 1024
+supports_tools = true
+supports_tool_choice = true
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+
+[[targets]]
+id = "deepseek.smoke"
+provider_ref = "deepseek"
+model_id = "deepseek-v4-flash"
+|}
+
 let seed_server_config ~base_path =
   let masc_dir = Filename.concat base_path ".masc" in
   let config_dir = Filename.concat masc_dir "config" in
@@ -353,7 +381,13 @@ let seed_server_config ~base_path =
     let oc = open_out runtime_dst in
     Fun.protect
       ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc runtime_seed)
+      (fun () -> output_string oc runtime_seed);
+  let overlay_dst = Filename.concat config_dir "oas-models-overlay.toml" in
+  if not (Sys.file_exists overlay_dst) then
+    let oc = open_out overlay_dst in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc catalog_overlay_seed)
 
 let with_server f =
   let exe = find_main_eio_exe () in

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -358,8 +358,8 @@ max_context_tokens = 32768
 max_output_tokens = 1024
 supports_tools = true
 supports_tool_choice = true
-supports_response_format_json = true
-supports_structured_output = true
+supports_response_format_json = false
+supports_structured_output = false
 supports_native_streaming = true
 
 [[targets]]


### PR DESCRIPTION
## What changed

- seed explicit OAS provider/model/target rows for shared transport harnesses
- seed the same typed catalog contract for the SSE reconnect E2E fixture
- add the missing exact-output target binding to the contract verifier fixture
- keep shared bootstrap overlay ownership paired with the runtime it creates
- give the keeper-load mock runtime its own explicit catalog target

## Root cause

After the OAS 0.222.0 pin, exact-output lanes are admitted against a frozen catalog. The harness runtime aliases (`deepseek.smoke` and `contract_verifier.smoke`) existed only in `runtime.toml`; they had no explicit `[[targets]]` binding, so server startup failed closed before the harnesses could run.

This keeps the runtime fail-closed behavior intact. It does not add model-name branching, string matching, or an unknown-target fallback.

## Impact

Fresh CI harness workspaces now declare their synthetic targets through the same typed OAS catalog contract used by production, allowing SSE, transport, and contract suites to boot under OAS 0.222.0.

## Validation

- `bash -n scripts/harness/lib/server_bootstrap.sh scripts/harness/contract/run_all.sh`
- `opam exec -- ocamlformat --check test/test_sse_storm_e2e.ml`
- `scripts/dune-local.sh build ./test/test_sse_storm_e2e.exe`
- `MASC_E2E_TESTS=true scripts/dune-local.sh exec ./test/test_sse_storm_e2e.exe` (2/2)
- `SERVER_EXE=... PUBLIC_TOOL_MANIFEST_EXE=... scripts/harness/contract/run_all.sh` (pass)
- `SERVER_EXE=... bash scripts/harness/transport/run_all.sh` (7/7)
- `scripts/dune-local.sh exec ./test/test_contract_harness_auth_script.exe` (4/4)
- bootstrap seed ownership checks for fresh and caller-owned runtime configs

Post-merge failure evidence:

- main CI run `30054317628`
- same failure already present on OAS pin run `30053450210`
