### PR TITLE
fix(runtime): require explicit exact-output lanes

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -24,6 +24,8 @@ structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # this explicit smart lane.
 cross_verifier = "deepseek.deepseek-v4-pro"
 
+# Existing workspaces are not overwritten by this seed. Copy the required lane
+# declarations into the live runtime.toml before enabling their consumers.
 [runtime.exact_output_lanes.librarian_exact]
 slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -14,10 +14,6 @@ default = "ollama_cloud.deepseek-v4-flash"
 # Periodic Memory OS fact-survival consolidation is a separate task route from
 # post-turn Librarian extraction. Model/provider selection belongs only here.
 memory_os_consolidation = "ollama_cloud_native.minimax-m3-native-structured"
-# Existing deployments must opt in explicitly after the exact-output registry
-# is available:
-# [runtime.exact_output_lanes.librarian_exact]
-# slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 # Provider-native structured-output judges must not inherit the fleet chat
 # default when that default lacks schema support. Keep this lane explicit so
 # structured judgment lanes fail at config load on typo/unsupported
@@ -27,6 +23,15 @@ structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.
 cross_verifier = "deepseek.deepseek-v4-pro"
+
+[runtime.exact_output_lanes.librarian_exact]
+slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
+
+[runtime.exact_output_lanes.compaction_exact]
+slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
+
+[runtime.exact_output_lanes.hitl_auto_judge]
+slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -930,59 +930,6 @@ let degrade_loaded_for_missing_catalog
       , degradation )
 ;;
 
-let hitl_auto_judge_lane_id = "hitl_auto_judge"
-
-let ensure_hitl_auto_judge_lane
-    ~runtimes
-    ~default_runtime
-    ~structured_judge_runtime_id
-    ~lanes
-    exact_output_lane_decls
-  =
-  if
-    List.exists
-      (fun (lane : Runtime_schema.exact_output_lane_decl) ->
-         String.equal lane.id hitl_auto_judge_lane_id)
-      exact_output_lane_decls
-  then
-    Ok exact_output_lane_decls
-  else
-    let assignment_id =
-      match structured_judge_runtime_id with
-      | Some runtime_id -> runtime_id
-      | None -> default_runtime.id
-    in
-    let slot_ids =
-      match
-        List.find_opt
-          (fun (lane : Runtime_lane.t) ->
-             String.equal lane.id assignment_id)
-          lanes
-      with
-      | Some lane -> lane.candidates
-      | None ->
-        (match
-           List.find_opt
-             (fun (runtime : t) ->
-                String.equal runtime.id assignment_id)
-             runtimes
-         with
-         | Some runtime -> [ runtime.id ]
-         | None -> [])
-    in
-    (match slot_ids with
-     | [] ->
-       Error
-         (Printf.sprintf
-            "runtime exact-output lane %S cannot derive slots from structured-judge assignment %S"
-            hitl_auto_judge_lane_id
-            assignment_id)
-     | _ ->
-       Ok
-         (exact_output_lane_decls
-          @ [ { Runtime_schema.id = hitl_auto_judge_lane_id; slot_ids } ]))
-;;
-
 let materialize_config
     ?(validate_max_context = true)
     ~(config_path : string)
@@ -1070,15 +1017,7 @@ let materialize_config
     , cfg.media_failover
     , lanes )
   in
-  let* exact_output_lane_decls =
-    ensure_hitl_auto_judge_lane
-      ~runtimes
-      ~default_runtime:rt
-      ~structured_judge_runtime_id:cfg.structured_judge_runtime_id
-      ~lanes
-      cfg.exact_output_lane_decls
-  in
-  Ok (loaded, exact_output_lane_decls)
+  Ok (loaded, cfg.exact_output_lane_decls)
 ;;
 
 let load_list_internal ~(config_path : string) ~validate_max_context
@@ -1237,21 +1176,6 @@ let init_default_degraded_report ~config_path =
              Ok (Initialized_degraded degradation))))
 
 let runtime_state () = Atomic.get loaded_state_ref
-
-let effective_exact_output_lane_declarations exact_output_lane_decls =
-  let state = runtime_state () in
-  match state.default_runtime with
-  | None ->
-    Error
-      "runtime exact-output lanes: effective runtime state is not initialized"
-  | Some default_runtime ->
-    ensure_hitl_auto_judge_lane
-      ~runtimes:state.runtimes
-      ~default_runtime
-      ~structured_judge_runtime_id:state.structured_judge_runtime_id
-      ~lanes:state.lanes
-      exact_output_lane_decls
-;;
 
 let get_default_runtime () = (runtime_state ()).default_runtime
 let get_runtimes () = (runtime_state ()).runtimes

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -126,15 +126,6 @@ val load_list :
     keeper→runtime-id list; [media_failover] is the RFC-0265 ordered reroute
     list; [lanes] is the ordered failover candidate lists. *)
 
-val effective_exact_output_lane_declarations :
-  Runtime_schema.exact_output_lane_decl list ->
-  (Runtime_schema.exact_output_lane_decl list, string) result
-(** Materialize exact-output lanes from the initialized effective runtime state.
-    When [hitl_auto_judge] is not explicitly declared, its opaque slot ids are
-    derived from the effective structured-judge assignment through the same pure
-    path used by runtime config writes. This never reparses or revalidates
-    runtimes disabled by degraded startup. *)
-
 val runtime_ids : t list -> string list
 
 (** {1 Lazy default runtime singleton}

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -178,8 +178,17 @@ let read_exact_output_overlay path =
   | Sys_error detail -> Error detail
 ;;
 
-let load_exact_output_lane_declarations () =
-  match Runtime.config_path () with
+let load_exact_output_lane_declarations ?config_root () =
+  let runtime_config_path =
+    match config_root with
+    | Some config_root ->
+      let path =
+        Filename.concat config_root Config_dir_resolver.runtime_toml_filename
+      in
+      if Sys.file_exists path then Some path else None
+    | None -> Runtime.config_path ()
+  in
+  match runtime_config_path with
   | None ->
     raise
       (Env_config_core.Config_error
@@ -193,19 +202,7 @@ let load_exact_output_lane_declarations () =
                "exact-output registry: runtime config parse failed (%s): %d error(s)"
                config_path
                (List.length errors)))
-     | Ok (config : Runtime_schema.config) ->
-       (match
-          Runtime.effective_exact_output_lane_declarations
-            config.exact_output_lane_decls
-        with
-        | Ok lanes -> lanes
-        | Error detail ->
-          raise
-            (Env_config_core.Config_error
-               (Printf.sprintf
-                  "exact-output registry: effective runtime lane materialization failed (%s): %s"
-                  config_path
-                  detail))))
+     | Ok (config : Runtime_schema.config) -> config.exact_output_lane_decls)
 ;;
 
 let configure_exact_output_registry ?config_root () =
@@ -239,7 +236,7 @@ let configure_exact_output_registry ?config_root () =
          ("exact-output resolver snapshot: "
           ^ exact_output_snapshot_error_to_string error))
   | Ok resolver_snapshot ->
-    let lanes = load_exact_output_lane_declarations () in
+    let lanes = load_exact_output_lane_declarations ?config_root () in
     (match Runtime.publish_exact_output_registry ~lanes resolver_snapshot with
      | Error detail ->
        raise

--- a/test/test_exact_output_catalog_precedence.ml
+++ b/test/test_exact_output_catalog_precedence.ml
@@ -20,6 +20,18 @@ let require_lane_slots label ~lane_id ~expected registry =
          selected_slots)
 ;;
 
+let require_lane_unconfigured label ~lane_id registry =
+  match Registry.resolve_lane registry ~lane_id with
+  | Error (Registry.Exact_lane_unconfigured { lane_id = actual_lane_id }) ->
+    Alcotest.(check string) label lane_id actual_lane_id
+  | Error error ->
+    Alcotest.failf
+      "%s returned the wrong failure: %s"
+      label
+      (Registry.lane_resolution_error_to_string error)
+  | Ok _ -> Alcotest.failf "%s unexpectedly resolved" label
+;;
+
 let test_full_replacement_precedence ~clock ~mono_clock ~net ~proc_mgr ~fs () =
   with_temp_dir "exact-output-catalog-precedence" @@ fun root ->
   let config_root = Filename.concat root "config" in
@@ -41,7 +53,6 @@ let test_full_replacement_precedence ~clock ~mono_clock ~net ~proc_mgr ~fs () =
          { source = overlay_path; contents = overlay_catalog })
   in
   require_admitted overlay_snapshot overlay_target;
-  require_admitted overlay_snapshot embedded_target;
   let replacement_snapshot =
     load_control_snapshot
       (Exact_output.Full_replacement
@@ -49,7 +60,6 @@ let test_full_replacement_precedence ~clock ~mono_clock ~net ~proc_mgr ~fs () =
   in
   require_admitted replacement_snapshot replacement_target;
   require_not_admitted replacement_snapshot overlay_target;
-  require_not_admitted replacement_snapshot embedded_target;
 
   Unix.putenv "MASC_CONFIG_DIR" config_root;
   Unix.putenv "OAS_MODEL_CATALOG" replacement_path;
@@ -86,7 +96,6 @@ let test_full_replacement_precedence ~clock ~mono_clock ~net ~proc_mgr ~fs () =
   in
   require_registry_unpublished "fresh process";
   require_bootstrap_rejected "overlay target is suppressed" overlay_target;
-  require_bootstrap_rejected "embedded target is suppressed" embedded_target;
 
   write_file runtime_path (runtime_toml replacement_target);
   create_server_state ();
@@ -461,10 +470,9 @@ let test_hitl_auto_judge_lane_bootstrap ~clock ~mono_clock ~net ~proc_mgr ~fs ()
   write_file runtime_path (runtime_toml replacement_target);
   create_server_state ();
   let default_registry = current_registry "default HITL lane bootstrap" in
-  require_lane_slots
-    "missing HITL lane synthesizes the opaque structured-judge runtime"
+  require_lane_unconfigured
+    "missing HITL lane stays unconfigured"
     ~lane_id:"hitl_auto_judge"
-    ~expected:[ Runtime.runtime_id_for_structured_judge () ]
     default_registry;
   let structured_judge_candidates =
     [ replacement_structured_judge_target
@@ -477,10 +485,9 @@ let test_hitl_auto_judge_lane_bootstrap ~clock ~mono_clock ~net ~proc_mgr ~fs ()
        ~structured_judge_candidates
        replacement_target);
   create_server_state ();
-  require_lane_slots
-    "runtime-lane structured judge expands to ordered opaque candidates"
+  require_lane_unconfigured
+    "structured-judge route does not synthesize an exact-output lane"
     ~lane_id:"hitl_auto_judge"
-    ~expected:structured_judge_candidates
     (current_registry "runtime-lane HITL bootstrap");
   let explicit_slots = [ replacement_secondary_target; replacement_target ] in
   write_file
@@ -511,7 +518,7 @@ let () =
             `Quick
             test_offline_runtime_save_converges_by_write_stage
         ; Alcotest.test_case
-            "full replacement suppresses overlay and embedded targets"
+            "full replacement suppresses overlay targets"
             `Quick
             (test_full_replacement_precedence
                ~clock
@@ -520,7 +527,7 @@ let () =
                ~proc_mgr
                ~fs)
         ; Alcotest.test_case
-            "HITL lane synthesizes an opaque default and preserves explicit order"
+            "HITL lane stays explicit and preserves configured order"
             `Quick
             (test_hitl_auto_judge_lane_bootstrap
                ~clock

--- a/test/test_exact_output_catalog_precedence_fixture.ml
+++ b/test/test_exact_output_catalog_precedence_fixture.ml
@@ -41,7 +41,6 @@ let replacement_target = "replacement-only-target"
 let replacement_structured_judge_target = "replacement_provider.replacement"
 let replacement_secondary_runtime_target = "replacement_provider.secondary"
 let replacement_secondary_target = "replacement-secondary-target"
-let embedded_target = "ollama-cloud-minimax-m3-json"
 
 let catalog_toml
       ?(api_key_env = "")
@@ -59,6 +58,7 @@ kind = "openai_compat"
 base_url = "http://127.0.0.1:1"
 request_path = "/v1/chat/completions"
 api_key_env = %S
+capabilities_base = "openai_chat_extended"
 
 [[models]]
 id_prefix = %S

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1,6 +1,8 @@
 open Alcotest
 open Masc
 
+module Exact_output = Agent_sdk.Exact_output
+
 let empty_env _name = None
 
 let parse_or_fail content =
@@ -760,8 +762,27 @@ let test_repo_runtime_toml_loads () =
     (match Runtime_toml.parse_file path with
      | Error _ -> fail "repo runtime.toml exact-output lanes must parse"
      | Ok config ->
-       check int "public seed has no provider-bound exact-output lanes" 0
-         (List.length config.exact_output_lane_decls));
+       let lane_ids =
+         List.map
+           (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+              lane.id)
+           config.exact_output_lane_decls
+       in
+       check
+         (list string)
+         "public seed exact-output lanes"
+         [ "librarian_exact"
+         ; "compaction_exact"
+         ; "hitl_auto_judge"
+         ]
+         lane_ids;
+       List.iter
+         (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+            check bool
+              (Printf.sprintf "%s has at least one target" lane.id)
+              true
+              (not (List.is_empty lane.slot_ids)))
+         config.exact_output_lane_decls);
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
       default.provider_config.connect_timeout_s;
@@ -897,6 +918,45 @@ let test_repo_runtime_toml_loads () =
                caps.thinking_control_format
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.7 Code capabilities"))
+
+let test_deployment_exact_output_catalog_covers_seed_lanes () =
+  let root = repo_root () in
+  let runtime_path = Filename.concat root "config/runtime.toml" in
+  let overlay_path = Filename.concat root "config/oas-models-overlay.toml" in
+  let overlay_contents =
+    In_channel.with_open_bin overlay_path In_channel.input_all
+  in
+  let io : Exact_output.resolver_io =
+    { getenv = (fun _ -> Ok None) }
+  in
+  let snapshot =
+    match
+      Exact_output.load_resolver_snapshot
+        ~io
+        ~catalog:
+          (Exact_output.Embedded_with_overlay
+             { source = overlay_path; contents = overlay_contents })
+        ()
+    with
+    | Ok snapshot -> snapshot
+    | Error _ -> fail "deployment exact-output catalog should load"
+  in
+  match Runtime_toml.parse_file runtime_path with
+  | Error _ -> fail "repo runtime.toml exact-output lanes must parse"
+  | Ok config ->
+    List.iter
+      (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+         List.iter
+           (fun target_ref ->
+              match Exact_output.admit_target_ref snapshot target_ref with
+              | Ok _ -> ()
+              | Error _ ->
+                failf
+                  "exact-output lane %s target %s must exist in the frozen catalog"
+                  lane.id
+                  target_ref)
+           lane.slot_ids)
+      config.exact_output_lane_decls
 
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =
@@ -2669,6 +2729,10 @@ let () =
             test_exact_output_lane_rejects_unknown_key;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
+          test_case
+            "deployment exact-output catalog covers repo seed lanes"
+            `Quick
+            test_deployment_exact_output_catalog_covers_seed_lanes;
           test_case
             "[runtime].cross_verifier resolves, defaults to None, rejects unknown"
             `Quick test_cross_verifier_runtime_routing;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -919,15 +919,22 @@ let test_repo_runtime_toml_loads () =
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.7 Code capabilities"))
 
-let test_deployment_exact_output_catalog_covers_seed_lanes () =
+let test_deployment_exact_output_catalog_admits_seed_lanes () =
   let root = repo_root () in
   let runtime_path = Filename.concat root "config/runtime.toml" in
   let overlay_path = Filename.concat root "config/oas-models-overlay.toml" in
   let overlay_contents =
-    In_channel.with_open_bin overlay_path In_channel.input_all
+    try In_channel.with_open_bin overlay_path In_channel.input_all with
+    | Sys_error detail ->
+      failf "deployment exact-output catalog cannot be read: %s" detail
   in
   let io : Exact_output.resolver_io =
-    { getenv = (fun _ -> Ok None) }
+    { getenv =
+        (function
+          | "ZAI_CODING_API_KEY" | "DEEPSEEK_API_KEY" ->
+            Ok (Some "exact-output-seed-test")
+          | _ -> Ok None)
+    }
   in
   let snapshot =
     match
@@ -941,6 +948,22 @@ let test_deployment_exact_output_catalog_covers_seed_lanes () =
     | Ok snapshot -> snapshot
     | Error _ -> fail "deployment exact-output catalog should load"
   in
+  let output_requirement =
+    Exact_output.make_output_requirement
+      ~schema:
+        (`Assoc
+           [ "type", `String "object"
+           ; "properties", `Assoc []
+           ; "additionalProperties", `Bool false
+           ])
+      ~minimum_guarantee:Exact_output.Json_syntax
+  in
+  let messages =
+    [ Agent_sdk.Types.text_message
+        Agent_sdk.Types.User
+        "Return one JSON object."
+    ]
+  in
   match Runtime_toml.parse_file runtime_path with
   | Error _ -> fail "repo runtime.toml exact-output lanes must parse"
   | Ok config ->
@@ -949,7 +972,26 @@ let test_deployment_exact_output_catalog_covers_seed_lanes () =
          List.iter
            (fun target_ref ->
               match Exact_output.admit_target_ref snapshot target_ref with
-              | Ok _ -> ()
+              | Ok admitted_target ->
+                (match Exact_output.resolve_target admitted_target with
+                 | Error _ ->
+                   failf
+                     "exact-output lane %s target %s must resolve with fixture credentials"
+                     lane.id
+                     target_ref
+                 | Ok target ->
+                   (match
+                      Exact_output.admit
+                        ~target
+                        ~messages
+                        output_requirement
+                    with
+                    | Ok _ -> ()
+                    | Error _ ->
+                      failf
+                        "exact-output lane %s target %s must satisfy Json_syntax"
+                        lane.id
+                        target_ref))
               | Error _ ->
                 failf
                   "exact-output lane %s target %s must exist in the frozen catalog"
@@ -1748,22 +1790,6 @@ let test_server_degraded_init_disables_unreferenced_uncatalogued_runtimes () =
          check (list string) "active runtime ids"
            [ "ollama.good" ]
            (Runtime.get_runtime_ids ());
-         (match Runtime.effective_exact_output_lane_declarations [] with
-          | Error detail ->
-            failf
-              "effective exact-output lanes must use degraded runtime state: %s"
-              detail
-          | Ok [ lane ] ->
-            check string "synthesized HITL lane id"
-              "hitl_auto_judge"
-              lane.Runtime_schema.id;
-            check (list string) "synthesized HITL lane uses active default only"
-              [ "ollama.good" ]
-              lane.slot_ids
-          | Ok lanes ->
-            failf
-              "expected one synthesized HITL lane, got %d"
-              (List.length lanes));
          check (list string) "no dropped assignment"
            []
            (List.map
@@ -2401,6 +2427,14 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
         lane_id
         (Runtime_exact_output_registry.lane_resolution_error_to_string error)
   in
+  let lane_is_unconfigured ~lane_id registry =
+    match Runtime_exact_output_registry.resolve_lane registry ~lane_id with
+    | Error
+        (Runtime_exact_output_registry.Exact_lane_unconfigured
+           { lane_id = actual_lane_id }) ->
+      String.equal lane_id actual_lane_id
+    | Error _ | Ok _ -> false
+  in
   let baseline = content ~default:"local.chat" "slot-a" in
   with_temp_runtime_toml baseline (fun path ->
     (match Runtime.save_config_text ~runtime_config_path:path baseline with
@@ -2425,8 +2459,8 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
       (Runtime_exact_output_registry.generation after_invalid);
     check (list string) "invalid save preserves registry slots" [ "slot-a" ]
       (slots_exn ~lane_id:"compaction_exact" after_invalid);
-    check (list string) "invalid save preserves synthesized HITL lane" [ "local.chat" ]
-      (slots_exn ~lane_id:"hitl_auto_judge" after_invalid);
+    check bool "invalid save does not synthesize HITL lane" true
+      (lane_is_unconfigured ~lane_id:"hitl_auto_judge" after_invalid);
     let replacement = content ~default:"local.libr" "slot-b" in
     let failed_path = path ^ ".directory" in
     Unix.mkdir failed_path 0o755;
@@ -2445,11 +2479,8 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
            (Runtime_exact_output_registry.generation after_write_failure);
          check (list string) "write failure preserves registry slots" [ "slot-a" ]
            (slots_exn ~lane_id:"compaction_exact" after_write_failure);
-         check
-           (list string)
-           "write failure preserves synthesized HITL lane"
-           [ "local.chat" ]
-           (slots_exn ~lane_id:"hitl_auto_judge" after_write_failure));
+         check bool "write failure does not synthesize HITL lane" true
+           (lane_is_unconfigured ~lane_id:"hitl_auto_judge" after_write_failure));
     (match Runtime.save_config_text ~runtime_config_path:path replacement with
      | Error detail -> failf "valid exact replacement failed: %s" detail
      | Ok () -> ());
@@ -2464,8 +2495,8 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
        > 0);
     check (list string) "valid save commits registry slots" [ "slot-b" ]
       (slots_exn ~lane_id:"compaction_exact" replaced);
-    check (list string) "valid save refreshes synthesized HITL lane" [ "local.libr" ]
-      (slots_exn ~lane_id:"hitl_auto_judge" replaced))
+    check bool "valid save does not synthesize HITL lane" true
+      (lane_is_unconfigured ~lane_id:"hitl_auto_judge" replaced))
 
 let test_deprecated_capability_notice_warns_once_per_process () =
   (* runtime.toml is re-parsed on every keeper boot; a per-parse deprecation
@@ -2730,9 +2761,9 @@ let () =
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case
-            "deployment exact-output catalog covers repo seed lanes"
+            "deployment exact-output catalog admits repo seed lanes"
             `Quick
-            test_deployment_exact_output_catalog_covers_seed_lanes;
+            test_deployment_exact_output_catalog_admits_seed_lanes;
           test_case
             "[runtime].cross_verifier resolves, defaults to None, rejects unknown"
             `Quick test_cross_verifier_runtime_routing;


### PR DESCRIPTION
## Summary

- remove the `hitl_auto_judge` synthesis from `[runtime].structured_judge` or `[runtime].default`
- publish only exact-output lanes explicitly declared in the active `runtime.toml`
- seed `librarian_exact`, `compaction_exact`, and `hitl_auto_judge` with opaque OAS target refs
- keep provider/model identities in TOML catalog data; MASC policy code does not inspect them
- preserve the separate `[runtime].memory_os_consolidation` task route introduced by #25651

## Runtime contract

Exact-output lanes and ordinary MASC runtime routes are separate namespaces. A missing exact-output lane is not inferred from another role:

- manual/always-allow Gate mode can still start without `hitl_auto_judge`
- switching to auto-judge fails at the existing readiness boundary with typed `Exact_lane_unconfigured`
- Librarian and compaction likewise report their own unconfigured lane instead of borrowing a runtime
- existing workspaces are not overwritten by the repository seed and must copy the desired lane declarations into their live `runtime.toml`

The explicit `config_root` passed to exact-output bootstrap now owns both `runtime.toml` and the OAS catalog overlay lookup. This removes the previous split where the overlay used the supplied root but lane declarations could come from a cached global resolver root.

## Librarian contract

Librarian requires `minimum_guarantee = Json_syntax`, not provider-native JSON Schema. OAS may satisfy that with native structured output or JSON-object mode; MASC then performs strict local episode-domain validation before persistence.

## Verification

- rebased onto #25651 merge `a48d59f034`
- `ocamlformat --check` on all changed OCaml files
- focused build: `test_runtime_config_validity.exe`, `test_exact_output_catalog_precedence.exe`
- runtime config tests: 46/46
- exact-output bootstrap tests: 6/6
- seed slots resolve with fixture credentials and satisfy OAS `Json_syntax` admission
- regression proves omitted HITL lane stays unconfigured after boot and runtime config writes
- `git diff --check`

## OAS 0.222 fixture alignment

The exact-output bootstrap fixture now declares the OAS 0.222 provider `capabilities_base` field and no longer assumes the retired embedded target `ollama-cloud-minimax-m3-json` exists. This changes only the deterministic test catalog, not production routing.