### PR TITLE
fix(config): ollama_cloud.deepseek-v4-flash exact-output target 추가 — main CI 복구

### DIFF
--- a/config/oas-models-overlay.toml
+++ b/config/oas-models-overlay.toml
@@ -232,3 +232,14 @@ model_id = "GLM-5-Turbo"
 id = "deepseek.deepseek-v4-pro"
 provider_ref = "deepseek"
 model_id = "deepseek-v4-pro"
+
+# Fleet default runtime id (config/runtime.toml `default` and the release
+# evidence smoke fixture in scripts/release-evidence.sh). #25648's
+# ensure_hitl_auto_judge_lane synthesizes the hitl_auto_judge exact-output
+# lane with this id as slot 1; without the target binding the frozen-catalog
+# publish rejects it and the server FATALs at boot (main CI Build and Test
+# red, run 30057220649).
+[[targets]]
+id = "ollama_cloud.deepseek-v4-flash"
+provider_ref = "ollama_cloud"
+model_id = "deepseek-v4-flash"


### PR DESCRIPTION
## 문제

main CI Build and Test 연속 실패 (run 30057220649, 30056397672): release evidence smoke 부팅이 FATAL —

```
exact-output lane "hitl_auto_judge" slot 1 ("ollama_cloud.deepseek-v4-flash"): target is not in the frozen catalog
```

## 원인

머지된 #25648의 `ensure_hitl_auto_judge_lane`이 fleet default runtime id(`ollama_cloud.deepseek-v4-flash` — repo seed와 `scripts/release-evidence.sh` smoke fixture 양쪽에서 사용)로 hitl_auto_judge lane을 자동 합성하는데, frozen catalog overlay(`config/oas-models-overlay.toml`)에는 `glm-coding.glm-5-turbo`와 `deepseek.deepseek-v4-pro` target만 있음. publish이 lane slot을 frozen catalog와 대조해 기동 거부.

overlay에는 provider(`ollama_cloud`)와 model(`deepseek-v4-flash`)이 이미 있고 opaque slot binding만 부재였음.

## 수정

`[[targets]] id = "ollama_cloud.deepseek-v4-flash"` 1건 추가 (기존 패턴 동일).

## 검증

- TOML 파싱 (python tomllib) ✅
- provider_ref/model_id가 overlay 기존 엔트리와 정합 ✅
- 실패 로그의 target id와 정확히 일치 ✅
- 전체 검증은 이 PR의 CI(Build and Test의 release evidence 단계)가 수행

## 연관

- #25648 (lane 자동 합성 도입), #25659 (harness target 선언 — smoke/release-evidence 경로는 미커버), #25623 리뷰에서 지적했던 "무조건 lane require → 기동 파괴" 클래스가 release-evidence 경로에서 실현된 케이스