### PR TITLE
fix(memory): accept JSON-mode librarian summaries

### DIFF
--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -57,11 +57,12 @@ let provider_for_summary (provider_cfg : Llm_provider.Provider_config.t) =
     tool_choice = None;
     disable_parallel_tool_use = true;
   }
-  |> Keeper_structured_output_schema.apply_to_provider_config
+  |> Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
+       ~log_label:"memory LLM summary"
        Keeper_structured_output_schema.memory_bank_summary_output_schema
 
-let summary_schema_supported provider_cfg =
-  Keeper_structured_output_schema.provider_config_accepts_schema
+let summary_json_guarantee_supported provider_cfg =
+  Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
     Keeper_structured_output_schema.memory_bank_summary_output_schema
     provider_cfg
 
@@ -266,10 +267,12 @@ let make
                provider_runtime_id err;
              None
          | Ok provider ->
-             let providers = [ provider ] |> List.filter summary_schema_supported in
+             let providers =
+               [ provider ] |> List.filter summary_json_guarantee_supported
+             in
              if providers = [] then begin
                Log.Keeper.warn ~keeper_name:keeper_name
-                 "memory LLM summary has no schema-capable direct completion providers runtime=%s"
+                 "memory LLM summary has no JSON-capable completion providers runtime=%s"
                  provider_runtime_id;
                None
              end else

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -8,9 +8,14 @@ val provider_for_summary :
   Llm_provider.Provider_config.t ->
   Llm_provider.Provider_config.t
 (** Tune the summary request while preserving the selected provider config's
-    exact temperature, including omission. *)
+    exact temperature, including omission. Native JSON Schema is preferred;
+    JSON-object mode is sufficient because the response is parsed and validated
+    locally before use. *)
 
-val summary_schema_supported : Llm_provider.Provider_config.t -> bool
+val summary_json_guarantee_supported :
+  Llm_provider.Provider_config.t -> bool
+(** Whether the provider can guarantee JSON syntax through native schema or
+    JSON-object mode. *)
 
 val messages_for_summary :
   trace_id:string -> texts:string list -> Agent_sdk.Types.message list

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -238,6 +238,20 @@ let invalid_schema_provider_cfg () =
     ()
 ;;
 
+let json_only_provider_cfg () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id:"json-only-memory-summary"
+    ~base_url:"https://json-only.invalid/v1"
+    ~max_tokens:4096
+    ~model_capabilities_override:
+      { Llm_provider.Capabilities.openai_compat_chat_extended_capabilities with
+        supports_structured_output = false
+      ; supports_response_format_json = true
+      }
+    ()
+;;
+
 let with_eio f =
   Eio_main.run
   @@ fun env ->
@@ -1424,11 +1438,33 @@ let test_memory_llm_summary_provider_requests_json_schema () =
        (Llm_provider.Provider_config.validate_output_schema_request provider_cfg))
 ;;
 
-let test_memory_llm_summary_rejects_invalid_schema_provider () =
+let test_memory_llm_summary_accepts_json_object_mode () =
+  let provider_cfg =
+    Memory_summary.provider_for_summary (json_only_provider_cfg ())
+  in
   Alcotest.(check bool)
-    "localhost OpenAI-compatible schema provider rejected"
+    "JSON-only provider is eligible"
+    true
+    (Memory_summary.summary_json_guarantee_supported
+       (json_only_provider_cfg ()));
+  Alcotest.(check bool)
+    "summary requests JSON-object mode"
+    true
+    (match provider_cfg.response_format with
+     | Agent_sdk.Types.JsonMode -> true
+     | Agent_sdk.Types.JsonSchema _ | Agent_sdk.Types.Off -> false);
+  Alcotest.(check (option bool))
+    "JSON-object mode carries no output schema"
+    None
+    (Option.map (fun _ -> true) provider_cfg.output_schema)
+;;
+
+let test_memory_llm_summary_rejects_provider_without_json_guarantee () =
+  Alcotest.(check bool)
+    "provider without a JSON guarantee rejected"
     false
-    (Memory_summary.summary_schema_supported (invalid_schema_provider_cfg ()))
+    (Memory_summary.summary_json_guarantee_supported
+       (invalid_schema_provider_cfg ()))
 ;;
 
 let test_memory_llm_summary_response_parser_accepts_only_summary_json () =
@@ -4608,9 +4644,13 @@ let () =
             `Quick
             test_memory_llm_summary_provider_requests_json_schema
         ; Alcotest.test_case
-            "memory llm summary rejects invalid schema provider"
+            "memory llm summary accepts json object mode"
             `Quick
-            test_memory_llm_summary_rejects_invalid_schema_provider
+            test_memory_llm_summary_accepts_json_object_mode
+        ; Alcotest.test_case
+            "memory llm summary rejects provider without json guarantee"
+            `Quick
+            test_memory_llm_summary_rejects_provider_without_json_guarantee
         ; Alcotest.test_case
             "memory llm summary accepts only summary json"
             `Quick


### PR DESCRIPTION
## Summary

- remove the native-JSON-Schema-only gate from the legacy memory-bank summary path
- accept either native schema or JSON-object mode based on typed OAS capabilities
- continue rejecting providers that cannot guarantee JSON syntax
- keep strict local `{ "summary": string }` parsing before the value is used

## Why

The memory summary prompt and parser already own the domain contract. Requiring `supports_structured_output` additionally excluded JSON-object-capable targets and made the overloaded Librarian route appear tied to a particular model/provider class.

The actual requirement is provider/model-free: JSON syntax guarantee plus local domain validation. OAS owns whether that guarantee is supplied through native JSON Schema or JSON-object mode. MASC does not branch on vendor/model literals.

Post-turn episode extraction already follows the same principle through `minimum_guarantee = Json_syntax`; this change aligns the remaining legacy memory-bank summary path.

## Verification

- `opam exec -- ocamlformat --check lib/keeper/keeper_memory_llm_summary.ml lib/keeper/keeper_memory_llm_summary.mli test/test_keeper_memory_os.ml`
- `scripts/dune-local.sh build ./test/test_keeper_memory_os.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_memory_os.exe` (108/108)
- regression coverage: schema-capable uses `JsonSchema`, JSON-only uses `JsonMode`, neither capability is rejected, malformed domain output remains rejected