### PR TITLE
fix(runtime): make consolidation routing a single SSOT

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3358,6 +3358,10 @@ describe('fetchRuntimeDefaults', () => {
         { id: 'openai.gpt-4o', provider: 'OpenAI', model: 'gpt-4o', max_context: 128000, is_default: true },
       ],
       model_routing: {
+        memory_os_consolidation_runtime_id: null,
+        memory_os_consolidation_effective_runtime_id: 'openai.gpt-4o',
+        memory_os_consolidation_status: 'inherited',
+        memory_os_consolidation_error: null,
         structured_judge_runtime_id: null,
         cross_verifier_runtime_id: null,
         media_failover: [],
@@ -3377,5 +3381,7 @@ describe('fetchRuntimeDefaults', () => {
     expect(result.default_runtime_id).toBe('openai.gpt-4o')
     expect(result.default_model).toBe('gpt-4o')
     expect(result.runtimes[0]?.is_default).toBe(true)
+    expect(result.model_routing.memory_os_consolidation_status).toBe('inherited')
+    expect(result.model_routing.memory_os_consolidation_effective_runtime_id).toBe('openai.gpt-4o')
   })
 })

--- a/dashboard/src/api/schemas/runtime-defaults.test.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.test.ts
@@ -5,6 +5,19 @@ import {
   parseRuntimeDefaultsResponse,
 } from './runtime-defaults'
 
+function validModelRouting(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    memory_os_consolidation_runtime_id: 'anthropic.sonnet',
+    memory_os_consolidation_effective_runtime_id: 'anthropic.sonnet',
+    memory_os_consolidation_status: 'resolved',
+    memory_os_consolidation_error: null,
+    structured_judge_runtime_id: 'openai.gpt-4o',
+    cross_verifier_runtime_id: null,
+    media_failover: ['openai.gpt-4o'],
+    ...overrides,
+  }
+}
+
 function validResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     generated_at_iso: '2026-06-21T00:00:00Z',
@@ -18,11 +31,7 @@ function validResponse(overrides: Record<string, unknown> = {}): Record<string, 
       { id: 'openai.gpt-4o', provider: 'OpenAI', model: 'gpt-4o', max_context: 128000, is_default: true },
       { id: 'anthropic.sonnet', provider: 'Anthropic', model: 'claude-sonnet-4', max_context: 200000, is_default: false },
     ],
-    model_routing: {
-      structured_judge_runtime_id: 'openai.gpt-4o',
-      cross_verifier_runtime_id: null,
-      media_failover: ['openai.gpt-4o'],
-    },
+    model_routing: validModelRouting(),
     ...overrides,
   }
 }
@@ -34,6 +43,9 @@ describe('parseRuntimeDefaultsResponse', () => {
     expect(out.default_model).toBe('gpt-4o')
     expect(out.runtimes).toHaveLength(2)
     expect(out.runtimes[0]!.is_default).toBe(true)
+    expect(out.model_routing.memory_os_consolidation_status).toBe('resolved')
+    expect(out.model_routing.memory_os_consolidation_runtime_id).toBe('anthropic.sonnet')
+    expect(out.model_routing.memory_os_consolidation_effective_runtime_id).toBe('anthropic.sonnet')
     expect(out.model_routing.structured_judge_runtime_id).toBe('openai.gpt-4o')
     expect(out.model_routing.cross_verifier_runtime_id).toBeNull()
   })
@@ -47,6 +59,10 @@ describe('parseRuntimeDefaultsResponse', () => {
         default_max_context: null,
         runtimes: [],
         model_routing: {
+          memory_os_consolidation_runtime_id: null,
+          memory_os_consolidation_effective_runtime_id: null,
+          memory_os_consolidation_status: 'error',
+          memory_os_consolidation_error: 'runtime state is not initialized',
           structured_judge_runtime_id: null,
           cross_verifier_runtime_id: null,
           media_failover: [],
@@ -56,6 +72,69 @@ describe('parseRuntimeDefaultsResponse', () => {
     expect(out.default_runtime_id).toBeNull()
     expect(out.default_model).toBeNull()
     expect(out.runtimes).toHaveLength(0)
+    expect(out.model_routing.memory_os_consolidation_status).toBe('error')
+    expect(out.model_routing.memory_os_consolidation_runtime_id).toBeNull()
+    expect(out.model_routing.memory_os_consolidation_effective_runtime_id).toBeNull()
+  })
+
+  it('preserves inherited consolidation routing without rewriting the configured selector', () => {
+    const out = parseRuntimeDefaultsResponse(
+      validResponse({
+        model_routing: {
+          memory_os_consolidation_runtime_id: null,
+          memory_os_consolidation_effective_runtime_id: 'openai.gpt-4o',
+          memory_os_consolidation_status: 'inherited',
+          memory_os_consolidation_error: null,
+          structured_judge_runtime_id: 'openai.gpt-4o',
+          cross_verifier_runtime_id: null,
+          media_failover: ['openai.gpt-4o'],
+        },
+      }),
+    )
+    expect(out.model_routing.memory_os_consolidation_status).toBe('inherited')
+    expect(out.model_routing.memory_os_consolidation_runtime_id).toBeNull()
+    expect(out.model_routing.memory_os_consolidation_effective_runtime_id).toBe('openai.gpt-4o')
+  })
+
+  it('rejects resolved status without an effective runtime', () => {
+    expect(() =>
+      parseRuntimeDefaultsResponse(
+        validResponse({
+          model_routing: validModelRouting({
+            memory_os_consolidation_effective_runtime_id: null,
+          }),
+        }),
+      ),
+    ).toThrow(RuntimeDefaultsSchemaDriftError)
+  })
+
+  it('rejects error status without an error string', () => {
+    expect(() =>
+      parseRuntimeDefaultsResponse(
+        validResponse({
+          model_routing: validModelRouting({
+            memory_os_consolidation_status: 'error',
+            memory_os_consolidation_effective_runtime_id: null,
+            memory_os_consolidation_error: null,
+          }),
+        }),
+      ),
+    ).toThrow(RuntimeDefaultsSchemaDriftError)
+  })
+
+  it('rejects inherited status with a non-null error', () => {
+    expect(() =>
+      parseRuntimeDefaultsResponse(
+        validResponse({
+          model_routing: validModelRouting({
+            memory_os_consolidation_runtime_id: null,
+            memory_os_consolidation_effective_runtime_id: 'openai.gpt-4o',
+            memory_os_consolidation_status: 'inherited',
+            memory_os_consolidation_error: 'contradictory inherited error',
+          }),
+        }),
+      ),
+    ).toThrow(RuntimeDefaultsSchemaDriftError)
   })
 
   it('throws schema drift when a runtime entry is missing a required field', () => {

--- a/dashboard/src/api/schemas/runtime-defaults.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.ts
@@ -11,11 +11,14 @@
 import {
   array,
   boolean,
+  literal,
   nullable,
+  null_,
   number,
   object,
   optional,
   string,
+  variant,
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
@@ -29,11 +32,35 @@ const RuntimeEntrySchema = object({
   is_default: boolean(),
 })
 
-const ModelRoutingSchema = object({
-  structured_judge_runtime_id: nullable(string()),
-  cross_verifier_runtime_id: nullable(string()),
-  media_failover: array(string()),
-})
+const ModelRoutingSchema = variant('memory_os_consolidation_status', [
+  object({
+    memory_os_consolidation_runtime_id: string(),
+    memory_os_consolidation_effective_runtime_id: string(),
+    memory_os_consolidation_status: literal('resolved'),
+    memory_os_consolidation_error: null_(),
+    structured_judge_runtime_id: nullable(string()),
+    cross_verifier_runtime_id: nullable(string()),
+    media_failover: array(string()),
+  }),
+  object({
+    memory_os_consolidation_runtime_id: null_(),
+    memory_os_consolidation_effective_runtime_id: string(),
+    memory_os_consolidation_status: literal('inherited'),
+    memory_os_consolidation_error: null_(),
+    structured_judge_runtime_id: nullable(string()),
+    cross_verifier_runtime_id: nullable(string()),
+    media_failover: array(string()),
+  }),
+  object({
+    memory_os_consolidation_runtime_id: nullable(string()),
+    memory_os_consolidation_effective_runtime_id: null_(),
+    memory_os_consolidation_status: literal('error'),
+    memory_os_consolidation_error: string(),
+    structured_judge_runtime_id: nullable(string()),
+    cross_verifier_runtime_id: nullable(string()),
+    media_failover: array(string()),
+  }),
+])
 
 const RuntimeDefaultsResponseSchema = object({
   generated_at_iso: optional(string()),

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -150,6 +150,25 @@ function makeToolItem(overrides: Partial<DashboardToolInventoryItem> = {}): Dash
   }
 }
 
+function makeModelRouting(
+  overrides: {
+    structured_judge_runtime_id?: string | null
+    cross_verifier_runtime_id?: string | null
+    media_failover?: string[]
+  } = {},
+): RuntimeDefaultsResponse['model_routing'] {
+  return {
+    memory_os_consolidation_runtime_id: 'rt-a',
+    memory_os_consolidation_effective_runtime_id: 'rt-a',
+    memory_os_consolidation_status: 'resolved',
+    memory_os_consolidation_error: null,
+    structured_judge_runtime_id: null,
+    cross_verifier_runtime_id: null,
+    media_failover: [],
+    ...overrides,
+  }
+}
+
 function makeRuntimeDefaults(
   overrides: Partial<RuntimeDefaultsResponse> = {},
 ): RuntimeDefaultsResponse {
@@ -166,11 +185,7 @@ function makeRuntimeDefaults(
       { id: 'rt-b', provider: 'P', model: 'm2', max_context: 128000, is_default: false },
       { id: 'rt-c', provider: 'P', model: 'm3', max_context: 128000, is_default: false },
     ],
-    model_routing: {
-      structured_judge_runtime_id: null,
-      cross_verifier_runtime_id: null,
-      media_failover: [],
-    },
+    model_routing: makeModelRouting(),
     ...overrides,
   }
 }
@@ -1276,11 +1291,11 @@ describe('SettingsSurface', () => {
   it('routing section shows resolved model routing controls', async () => {
     stubRuntimeDefaults(
       makeRuntimeDefaults({
-        model_routing: {
+        model_routing: makeModelRouting({
           structured_judge_runtime_id: 'rt-c',
           cross_verifier_runtime_id: 'rt-a',
           media_failover: [],
-        },
+        }),
       }),
     )
     stubRuntimeResolved(makeRuntimeResolved())
@@ -1310,11 +1325,11 @@ describe('SettingsSurface', () => {
     apiMock.fetchRuntimeDefaults
       .mockResolvedValueOnce(makeRuntimeDefaults())
       .mockResolvedValueOnce(makeRuntimeDefaults({
-        model_routing: {
+        model_routing: makeModelRouting({
           structured_judge_runtime_id: 'rt-b',
           cross_verifier_runtime_id: null,
           media_failover: [],
-        },
+        }),
       }))
     render(html`<${SettingsSurface} />`, container)
 
@@ -1397,18 +1412,18 @@ describe('SettingsSurface', () => {
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeDefaults
       .mockResolvedValueOnce(makeRuntimeDefaults({
-        model_routing: {
+        model_routing: makeModelRouting({
           structured_judge_runtime_id: null,
           cross_verifier_runtime_id: null,
           media_failover: ['rt-b'],
-        },
+        }),
       }))
       .mockResolvedValueOnce(makeRuntimeDefaults({
-        model_routing: {
+        model_routing: makeModelRouting({
           structured_judge_runtime_id: null,
           cross_verifier_runtime_id: null,
           media_failover: ['rt-b', 'rt-c'],
-        },
+        }),
       }))
     render(html`<${SettingsSurface} />`, container)
 

--- a/docs/audit/2026-06-25-memory-os-adversarial-audit.md
+++ b/docs/audit/2026-06-25-memory-os-adversarial-audit.md
@@ -209,7 +209,6 @@ The env surface is broad but named and centralized enough to audit:
 - `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT`: default 1.
 - `MASC_KEEPER_MEMORY_OS_GC`: default false.
 - `MASC_KEEPER_MEMORY_OS_CONSOLIDATION`: default false.
-- `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID`: optional runtime override.
 
 The fixed-size constants are hardcoded operational policy, not hidden path
 state: recall 8 facts and 2 episodes, shared facts 4, episode tail scan 32,

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 213 unique knobs across 8 modules.
+**Total**: 212 unique knobs across 8 modules.
 
-**Typed getter classification**: 37/125 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 88).
+**Typed getter classification**: 36/124 tagged (`operator`: 36, `algorithm`: 0, `unclassified`: 88).
 
 ## Env_config_core (24 knobs; typed classification 2/5)
 
@@ -47,54 +47,53 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 430 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 289 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (44 knobs; typed classification 25/38)
+## Env_config_keeper (43 knobs; typed classification 24/37)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 632 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 578 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 612 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 558 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 65 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 598 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 318 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 344 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 334 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 354 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 324 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 578 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 298 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 324 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 314 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 334 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 304 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 143 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 151 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 503 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 441 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 430 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 452 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 611 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 464 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 485 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 292 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: true; invalid values fail closed to false.... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 302 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 281 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 233 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 245 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 269 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 257 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 221 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 483 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 421 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 410 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 432 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 591 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 444 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 465 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 282 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: true; invalid values fail closed to false.... |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 271 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 223 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 235 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 259 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 247 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 211 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 527 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 507 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 154 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 621 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 538 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 391 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 401 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 381 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 601 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 518 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 371 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 381 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 361 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 88 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 114 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 103 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 479 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 459 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 
@@ -230,9 +229,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 443 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 447 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 449 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 432 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 436 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 438 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 150 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 220 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 222 |  |
@@ -240,8 +239,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 160 |  |
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 192 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 232 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 409 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 411 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 398 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 400 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 224 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 81 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
@@ -251,18 +250,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 341 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 495 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 521 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 529 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 469 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 471 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 473 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 475 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 481 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 484 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 510 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 518 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 458 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 460 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 462 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 464 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 470 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 511 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 513 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 500 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 502 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -177,10 +177,9 @@ module KeeperMemoryOs = struct
      TTL/cap retention was removed (RFC-0259 supersession), so with this pass off
      the Tier-1 fact store only grows (idealist: 449 rows, 0 with valid_until).
      Failures are graceful no-ops (transport/parse errors never mutate the store).
-     Runtime selection uses the dedicated consolidation override when set, then
-     the default runtime. Set the env false to disable. *)
+     Runtime selection belongs to [runtime.toml]; set the env false to disable
+     the pass. *)
   let consolidation_enabled_default = true
-  let consolidation_runtime_id_default = None
 
   (* Env-key SSOT: the config-introspection registry
      (env_config_snapshot.ml memory_entries) and the tests reference these
@@ -193,21 +192,12 @@ module KeeperMemoryOs = struct
   let librarian_global_slot_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
   let gc_env_key = "MASC_KEEPER_MEMORY_OS_GC"
   let consolidation_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
-  let consolidation_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
-
-  let optional_string_default value = Option.value value ~default:""
-  ;;
 
   let get_bool_logged ?(invalid = Env_config_memory.Default) name ~default =
     Env_config_memory.get_bool_logged
       ~invalid
       name
       ~default
-  ;;
-
-  let nonempty_string value =
-    let value = String.trim value in
-    if String.equal value "" then None else Some value
   ;;
 
   (** Memory OS recall prompt injection kill switch. Default: true; invalid
@@ -291,16 +281,6 @@ module KeeperMemoryOs = struct
       ~invalid:Env_config_memory.Fail_closed
       consolidation_env_key
       ~default:consolidation_enabled_default
-  ;;
-
-  (** Optional runtime id override for Memory OS consolidation.
-      @category Runtime
-      @ops_class operator *)
-  let consolidation_runtime_id () =
-    get_string
-      ~default:(optional_string_default consolidation_runtime_id_default)
-      consolidation_runtime_id_env_key
-    |> nonempty_string
   ;;
 end
 

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -69,7 +69,6 @@ module KeeperMemoryOs : sig
   val librarian_global_slot_env_key : string
   val gc_env_key : string
   val consolidation_env_key : string
-  val consolidation_runtime_id_env_key : string
 
   val recall_enabled_default : bool
   val librarian_enabled_default : bool
@@ -78,7 +77,6 @@ module KeeperMemoryOs : sig
   val librarian_global_slot_default : int
   val gc_enabled_default : bool
   val consolidation_enabled_default : bool
-  val consolidation_runtime_id_default : string option
 
   val recall_enabled : unit -> bool
   val librarian_enabled : unit -> bool
@@ -87,7 +85,6 @@ module KeeperMemoryOs : sig
   val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool
   val consolidation_enabled : unit -> bool
-  val consolidation_runtime_id : unit -> string option
 end
 
 (** {1 Keeper dashboard compaction snapshots} *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -350,11 +350,6 @@ let local_runtime_entries =
 
 module Memory_os_defaults = Env_config_keeper.KeeperMemoryOs
 
-let optional_default_to_display = function
-  | None -> "(none)"
-  | Some value -> value
-;;
-
 (* Env-var names come from Env_config_keeper.KeeperMemoryOs (the reader
    module), never from re-spelled literals: a registry entry whose env var
    nothing reads is a silent no-op reported as source=env. *)
@@ -388,12 +383,6 @@ let memory_entries =
       ~default:(string_of_bool Memory_os_defaults.consolidation_enabled_default)
       Memory_os_defaults.consolidation_env_key
       "Per-keeper Memory OS consolidation maintenance fiber kill switch; invalid values fail closed";
-    entry
-      ~default:
-        (optional_default_to_display
-           Memory_os_defaults.consolidation_runtime_id_default)
-      Memory_os_defaults.consolidation_runtime_id_env_key
-      "Optional runtime id override for Memory OS consolidation; (none) displays the empty default";
   ]
 
 let message_gc_entries =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1209,10 +1209,77 @@ let runtime_id_for_keeper (keeper_name : string) : string option =
 
 let keeper_assignments () = (runtime_state ()).keeper_assignments
 
-(* Dedicated Memory OS consolidation routing. [None] means the periodic pass
-   inherits [runtime].default. *)
-let memory_os_consolidation_runtime_id () =
-  (runtime_state ()).memory_os_consolidation_runtime_id
+type memory_os_consolidation_source =
+  | Consolidation_configured
+  | Consolidation_inherited_default
+
+type effective_memory_os_consolidation =
+  { effective_runtime : t
+  ; resolution_source : memory_os_consolidation_source
+  }
+
+type dashboard_runtime_defaults_snapshot =
+  { default_runtime : t option
+  ; runtimes : t list
+  ; memory_os_consolidation_runtime_id : string option
+  ; memory_os_consolidation : (effective_memory_os_consolidation, string) result
+  ; structured_judge_runtime_id : string option
+  ; cross_verifier_runtime_id : string option
+  ; media_failover : string list
+  ; config_path : string option
+  }
+
+(* Resolve the effective Memory OS consolidation runtime from the supplied
+   immutable loaded-state snapshot. Only an absent task route inherits the
+   default. A configured id missing from the same snapshot is an invariant
+   violation, never permission to execute on a different runtime. *)
+let resolve_memory_os_consolidation_from_state (state : loaded_state) =
+  match state.default_runtime, state.memory_os_consolidation_runtime_id with
+  | None, _ ->
+    Error
+      "Memory OS consolidation runtime cannot resolve before runtime initialization"
+  | Some default_runtime, None ->
+    Ok
+      { effective_runtime = default_runtime
+      ; resolution_source = Consolidation_inherited_default
+      }
+  | Some _, Some runtime_id ->
+    (match
+       List.find_opt
+         (fun (runtime : t) -> String.equal runtime.id runtime_id)
+         state.runtimes
+     with
+     | Some runtime ->
+       Ok
+         { effective_runtime = runtime
+         ; resolution_source = Consolidation_configured
+         }
+     | None ->
+       Error
+         (Printf.sprintf
+            "configured [runtime].memory_os_consolidation id %S is absent from \
+             the loaded runtime snapshot"
+            runtime_id))
+;;
+
+let resolve_memory_os_consolidation_runtime () =
+  resolve_memory_os_consolidation_from_state (runtime_state ())
+  |> Result.map (fun resolution -> resolution.effective_runtime)
+;;
+
+let dashboard_runtime_defaults_snapshot () =
+  let state = runtime_state () in
+  { default_runtime = state.default_runtime
+  ; runtimes = state.runtimes
+  ; memory_os_consolidation_runtime_id =
+      state.memory_os_consolidation_runtime_id
+  ; memory_os_consolidation =
+      resolve_memory_os_consolidation_from_state state
+  ; structured_judge_runtime_id = state.structured_judge_runtime_id
+  ; cross_verifier_runtime_id = state.cross_verifier_runtime_id
+  ; media_failover = state.media_failover
+  ; config_path = state.config_path
+  }
 ;;
 
 (* [runtime].structured_judge is the explicit runtime.toml SSOT for

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -209,11 +209,37 @@ val keeper_assignments : unit -> (string * string) list
     Dashboard/operator surfaces use this to expose assignment blast radius
     without parsing TOML independently. *)
 
-val memory_os_consolidation_runtime_id : unit -> string option
-(** [\[runtime\].memory_os_consolidation] runtime id for the periodic Memory OS
-    fact-survival consolidation pass, or [None] when it inherits
-    [\[runtime\].default]. Validated at load so [Some] always resolves to a
-    configured runtime. *)
+val resolve_memory_os_consolidation_runtime : unit -> (t, string) result
+(** Resolve the effective runtime for the periodic Memory OS fact-survival
+    consolidation pass from one immutable loaded-state snapshot. An absent
+    [\[runtime\].memory_os_consolidation] inherits [\[runtime\].default].
+    An uninitialized state or an explicit id missing from the same snapshot is
+    [Error], never a fallback to another runtime. *)
+
+type memory_os_consolidation_source =
+  | Consolidation_configured
+  | Consolidation_inherited_default
+
+type effective_memory_os_consolidation =
+  { effective_runtime : t
+  ; resolution_source : memory_os_consolidation_source
+  }
+
+type dashboard_runtime_defaults_snapshot =
+  { default_runtime : t option
+  ; runtimes : t list
+  ; memory_os_consolidation_runtime_id : string option
+  ; memory_os_consolidation : (effective_memory_os_consolidation, string) result
+  ; structured_judge_runtime_id : string option
+  ; cross_verifier_runtime_id : string option
+  ; media_failover : string list
+  ; config_path : string option
+  }
+
+val dashboard_runtime_defaults_snapshot : unit -> dashboard_runtime_defaults_snapshot
+(** Capture every value consumed by the dashboard runtime-defaults endpoint from
+    one immutable loaded-state snapshot. The consolidation resolution retains
+    configured-vs-inherited provenance and any invariant error. *)
 
 val cross_verifier_runtime_id : unit -> string option
 (** [\[runtime\].cross_verifier] runtime id for the anti-rationalization

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -993,14 +993,6 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
                   }
                 , errs )
               | Error e -> section, errs @ e)
-           | "librarian" ->
-             ( section
-             , errs
-               @ error
-                   "runtime.librarian"
-                   "retired [runtime].librarian key; remove it and use \
-                    [runtime].memory_os_consolidation only when the Memory OS \
-                    consolidation pass must not inherit [runtime].default" )
            | "structured_judge" ->
              (match
                 parse_runtime_string_leaf ~path:"runtime.structured_judge" ~key value

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -79,33 +79,6 @@ let wake_enqueue_counts_of_dispatches dispatches =
     dispatches
 ;;
 
-(* Resolve the runtime for the Memory OS per-keeper consolidation pass, keeping
-   its identity paired with the provider config through the inference boundary.
-   The dedicated consolidation env var takes precedence over the typed TOML
-   route; when neither is set, inherit the default runtime. Post-turn Librarian
-   exact-output extraction does not consume this setting. An explicit but
-   unknown env runtime ID is logged and falls back to the default so typos are
-   not silently masked; TOML ids are validated at config load. *)
-let runtime_for_memory_os_consolidation () =
-  let default_runtime () = Runtime.get_default_runtime () in
-  let runtime_id =
-    match Env_config.KeeperMemoryOs.consolidation_runtime_id () with
-    | Some id -> Some id
-    | None -> Runtime.memory_os_consolidation_runtime_id ()
-  in
-  match runtime_id with
-  | None -> default_runtime ()
-  | Some id ->
-    (match Runtime.get_runtime_by_id id with
-     | Some rt -> Some rt
-     | None ->
-       Log.Server.warn
-         "memory_os_keeper_consolidation: requested runtime %s not found; \
-          falling back to default"
-         id;
-       default_runtime ())
-;;
-
 (* Run one consolidation pass over every keeper that currently has a fact store.
    The optional [complete] injection lets tests drive the loop with a fake model.
    Provider transport owns the only LLM timeout boundary. The output contract is
@@ -422,11 +395,12 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            so a 10-minute cadence bounds cost while still shrinking stores. *)
         let interval = 600.0 in
         let rec loop () =
-          (match runtime_for_memory_os_consolidation () with
-           | None ->
+          (match Runtime.resolve_memory_os_consolidation_runtime () with
+           | Error msg ->
              Log.Server.warn
-               "memory_os_keeper_consolidation: no runtime configured; skipping tick"
-           | Some runtime ->
+               "memory_os_keeper_consolidation: %s; skipping tick"
+               msg
+           | Ok runtime ->
              run_memory_os_consolidation_tick
                ~sw
                ~net:env#net

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -2,10 +2,6 @@ val fork_logged_fiber :
   sw:Eio.Switch.t -> on_error:(exn -> unit) -> (unit -> unit) -> unit
 val log_server_fiber_crash : string -> exn -> unit
 
-val runtime_for_memory_os_consolidation : unit -> Runtime.t option
-(** Resolve the selected consolidation runtime without discarding its identity;
-    an unknown explicit selection is logged before falling back to the default. *)
-
 val run_memory_os_consolidation_tick :
   ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
   sw:Eio.Switch.t ->

--- a/lib/server/server_dashboard_runtime_defaults_json.ml
+++ b/lib/server/server_dashboard_runtime_defaults_json.ml
@@ -25,12 +25,18 @@ type runtime_entry =
   ; is_default : bool
   }
 
+type memory_os_consolidation_resolution =
+  | Consolidation_resolved of string
+  | Consolidation_inherited of string
+  | Consolidation_error of string
+
 type resolved =
   { default_runtime_id : string option
   ; default_model : string option
   ; default_max_context : int option
   ; runtimes : runtime_entry list
   ; memory_os_consolidation_runtime_id : string option
+  ; memory_os_consolidation : memory_os_consolidation_resolution
   ; structured_judge_runtime_id : string option
   ; cross_verifier_runtime_id : string option
   ; media_failover : string list
@@ -57,6 +63,30 @@ let runtime_entry_json (e : runtime_entry) : Yojson.Safe.t =
     ]
 ;;
 
+let memory_os_consolidation_fields ~configured_runtime_id = function
+  | Consolidation_resolved runtime_id ->
+    [ "memory_os_consolidation_status", `String "resolved"
+    ; ( "memory_os_consolidation_runtime_id"
+      , string_opt_json configured_runtime_id )
+    ; "memory_os_consolidation_effective_runtime_id", `String runtime_id
+    ; "memory_os_consolidation_error", `Null
+    ]
+  | Consolidation_inherited runtime_id ->
+    [ "memory_os_consolidation_status", `String "inherited"
+    ; ( "memory_os_consolidation_runtime_id"
+      , string_opt_json configured_runtime_id )
+    ; "memory_os_consolidation_effective_runtime_id", `String runtime_id
+    ; "memory_os_consolidation_error", `Null
+    ]
+  | Consolidation_error error ->
+    [ "memory_os_consolidation_status", `String "error"
+    ; ( "memory_os_consolidation_runtime_id"
+      , string_opt_json configured_runtime_id )
+    ; "memory_os_consolidation_effective_runtime_id", `Null
+    ; "memory_os_consolidation_error", `String error
+    ]
+;;
+
 let build ~generated_at_iso (r : resolved) : Yojson.Safe.t =
   `Assoc
     [ "generated_at_iso", `String generated_at_iso
@@ -69,18 +99,20 @@ let build ~generated_at_iso (r : resolved) : Yojson.Safe.t =
     ; "runtimes", `List (List.map runtime_entry_json r.runtimes)
     ; ( "model_routing"
       , `Assoc
-          [ ( "memory_os_consolidation_runtime_id"
-            , string_opt_json r.memory_os_consolidation_runtime_id )
-          ; ( "structured_judge_runtime_id"
-            , string_opt_json r.structured_judge_runtime_id )
-          ; "cross_verifier_runtime_id", string_opt_json r.cross_verifier_runtime_id
-          ; "media_failover", `List (List.map (fun s -> `String s) r.media_failover)
-          ] )
+          (memory_os_consolidation_fields
+             ~configured_runtime_id:r.memory_os_consolidation_runtime_id
+             r.memory_os_consolidation
+           @ [ ( "structured_judge_runtime_id"
+               , string_opt_json r.structured_judge_runtime_id )
+             ; "cross_verifier_runtime_id", string_opt_json r.cross_verifier_runtime_id
+             ; "media_failover", `List (List.map (fun s -> `String s) r.media_failover)
+             ]) )
     ]
 ;;
 
-let resolved_of_runtime () : resolved =
-  let default = Runtime.get_default_runtime () in
+let resolved_of_snapshot
+    (snapshot : Runtime.dashboard_runtime_defaults_snapshot) : resolved =
+  let default = snapshot.default_runtime in
   let entry (rt : Runtime.t) : runtime_entry =
     { id = rt.id
     ; provider = rt.provider.display_name
@@ -89,18 +121,38 @@ let resolved_of_runtime () : resolved =
     ; is_default = rt.binding.is_default
     }
   in
+  let memory_os_consolidation =
+    match snapshot.memory_os_consolidation with
+    | Error error -> Consolidation_error error
+    | Ok
+        { Runtime.effective_runtime
+        ; resolution_source = Runtime.Consolidation_configured
+        } ->
+      Consolidation_resolved effective_runtime.id
+    | Ok
+        { Runtime.effective_runtime
+        ; resolution_source = Runtime.Consolidation_inherited_default
+        } ->
+      Consolidation_inherited effective_runtime.id
+  in
   { default_runtime_id = Option.map (fun (rt : Runtime.t) -> rt.id) default
   ; default_model = Option.map (fun (rt : Runtime.t) -> rt.model.api_name) default
   ; default_max_context =
       Option.map Runtime.max_context_of_runtime default
-  ; runtimes = List.map entry (Runtime.get_runtimes ())
+  ; runtimes = List.map entry snapshot.runtimes
   ; memory_os_consolidation_runtime_id =
-      Runtime.memory_os_consolidation_runtime_id ()
-  ; structured_judge_runtime_id = Runtime.structured_judge_runtime_id ()
-  ; cross_verifier_runtime_id = Runtime.cross_verifier_runtime_id ()
-  ; media_failover = Runtime.media_failover ()
-  ; config_path = Runtime.config_path ()
+      snapshot.memory_os_consolidation_runtime_id
+  ; memory_os_consolidation
+  ; structured_judge_runtime_id = snapshot.structured_judge_runtime_id
+  ; cross_verifier_runtime_id = snapshot.cross_verifier_runtime_id
+  ; media_failover = snapshot.media_failover
+  ; config_path = snapshot.config_path
   }
+;;
+
+let resolved_of_runtime () : resolved =
+  Runtime.dashboard_runtime_defaults_snapshot ()
+  |> resolved_of_snapshot
 ;;
 
 let current ~generated_at_iso () : Yojson.Safe.t =

--- a/lib/server/server_dashboard_runtime_defaults_json.mli
+++ b/lib/server/server_dashboard_runtime_defaults_json.mli
@@ -12,12 +12,18 @@ type runtime_entry =
   ; is_default : bool
   }
 
+type memory_os_consolidation_resolution =
+  | Consolidation_resolved of string
+  | Consolidation_inherited of string
+  | Consolidation_error of string
+
 type resolved =
   { default_runtime_id : string option
   ; default_model : string option
   ; default_max_context : int option
   ; runtimes : runtime_entry list
   ; memory_os_consolidation_runtime_id : string option
+  ; memory_os_consolidation : memory_os_consolidation_resolution
   ; structured_judge_runtime_id : string option
   ; cross_verifier_runtime_id : string option
   ; media_failover : string list
@@ -27,9 +33,12 @@ type resolved =
 val build : generated_at_iso:string -> resolved -> Yojson.Safe.t
 (** Pure JSON encoder over the resolved structure. *)
 
+val resolved_of_snapshot : Runtime.dashboard_runtime_defaults_snapshot -> resolved
+(** Project one typed Runtime snapshot into the dashboard wire structure without
+    rereading mutable runtime state. *)
+
 val resolved_of_runtime : unit -> resolved
-(** Snapshot the runtime config singletons. Uses only option-returning
-    accessors, so it never raises on an uninitialized default. *)
+(** Capture one typed Runtime snapshot and project it. *)
 
 val current : generated_at_iso:string -> unit -> Yojson.Safe.t
 (** [build] applied to {!resolved_of_runtime}. *)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1081,10 +1081,6 @@ let memory_os_knob_readers : (string * (unit -> unit)) list =
     , fun () -> ignore (Env_config.KeeperMemoryOs.gc_enabled () : bool) )
   ; ( Env_config.KeeperMemoryOs.consolidation_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.consolidation_enabled () : bool) )
-  ; ( Env_config.KeeperMemoryOs.consolidation_runtime_id_env_key
-    , fun () ->
-        ignore (Env_config.KeeperMemoryOs.consolidation_runtime_id () : string option)
-    )
   ]
 ;;
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1119,26 +1119,6 @@ let test_runtime_toml_rejects_unknown_runtime_key () =
     check bool "error explains unknown runtime key" true
       (String_util.contains_substring rendered "unknown [runtime] key")
 
-let test_runtime_toml_rejects_retired_librarian_key () =
-  let content =
-    "[runtime]\n\
-     default = \"local.sample\"\n\
-     librarian = \"local.sample\"\n"
-  in
-  match Runtime_toml.parse_string content with
-  | Ok _ -> failf "retired [runtime].librarian key should fail parse"
-  | Error errs ->
-    let rendered =
-      errs
-      |> List.map (fun (err : Runtime_toml.parse_error) ->
-        Printf.sprintf "%s: %s" err.path err.message)
-      |> String.concat "\n"
-    in
-    check bool "error names retired key" true
-      (String_util.contains_substring rendered "runtime.librarian");
-    check bool "error names replacement route" true
-      (String_util.contains_substring rendered "runtime].memory_os_consolidation")
-
 let test_runtime_toml_allows_runtime_profile_tables () =
   let content =
     "[providers.local]\n\
@@ -2798,8 +2778,6 @@ let () =
             test_runtime_toml_reserves_web_search_namespace;
           test_case "runtime table rejects unknown keys" `Quick
             test_runtime_toml_rejects_unknown_runtime_key;
-          test_case "runtime table rejects retired librarian key" `Quick
-            test_runtime_toml_rejects_retired_librarian_key;
           test_case "runtime table allows profile tables" `Quick
             test_runtime_toml_allows_runtime_profile_tables;
           test_case "runtime table rejects wrong-type media_failover" `Quick

--- a/test/test_runtime_defaults_json.ml
+++ b/test/test_runtime_defaults_json.ml
@@ -22,6 +22,7 @@ let test_build_resolved_serializes_defaults_and_routing () =
           }
         ]
     ; memory_os_consolidation_runtime_id = Some "anthropic.sonnet"
+    ; memory_os_consolidation = J.Consolidation_resolved "anthropic.sonnet"
     ; structured_judge_runtime_id = Some "openai.gpt-4o"
     ; cross_verifier_runtime_id = None
     ; media_failover = [ "openai.gpt-4o" ]
@@ -50,9 +51,21 @@ let test_build_resolved_serializes_defaults_and_routing () =
     (member "is_default" first |> Yojson.Safe.Util.to_bool);
   let routing = member "model_routing" json in
   Alcotest.(check string)
-    "Memory OS consolidation routing" "anthropic.sonnet"
+    "Memory OS consolidation status" "resolved"
+    (member "memory_os_consolidation_status" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "Memory OS consolidation configured selector" "anthropic.sonnet"
     (member "memory_os_consolidation_runtime_id" routing
      |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "Memory OS consolidation effective runtime" "anthropic.sonnet"
+    (member "memory_os_consolidation_effective_runtime_id" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool)
+    "Memory OS consolidation error is null"
+    true
+    (member "memory_os_consolidation_error" routing = `Null);
   Alcotest.(check string) "structured judge routing" "openai.gpt-4o"
     (member "structured_judge_runtime_id" routing |> Yojson.Safe.Util.to_string)
 let test_build_uninitialized_emits_null_not_fabricated_default () =
@@ -64,6 +77,8 @@ let test_build_uninitialized_emits_null_not_fabricated_default () =
     ; default_max_context = None
     ; runtimes = []
     ; memory_os_consolidation_runtime_id = None
+    ; memory_os_consolidation =
+        J.Consolidation_error "runtime state is not initialized"
     ; structured_judge_runtime_id = None
     ; cross_verifier_runtime_id = None
     ; media_failover = []
@@ -78,12 +93,113 @@ let test_build_uninitialized_emits_null_not_fabricated_default () =
   Alcotest.(check int) "runtimes empty" 0
     (member "runtimes" json |> Yojson.Safe.Util.to_list |> List.length);
   let routing = member "model_routing" json in
-  Alcotest.(check bool) "Memory OS consolidation null" true
+  Alcotest.(check string)
+    "Memory OS consolidation status" "error"
+    (member "memory_os_consolidation_status" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool) "Memory OS consolidation runtime is null" true
     (member "memory_os_consolidation_runtime_id" routing = `Null);
+  Alcotest.(check bool) "Memory OS consolidation effective runtime is null" true
+    (member "memory_os_consolidation_effective_runtime_id" routing = `Null);
+  Alcotest.(check string)
+    "Memory OS consolidation error"
+    "runtime state is not initialized"
+    (member "memory_os_consolidation_error" routing
+     |> Yojson.Safe.Util.to_string);
   Alcotest.(check bool) "cross_verifier null" true
     (member "cross_verifier_runtime_id" routing = `Null);
   Alcotest.(check bool) "structured_judge null" true
     (member "structured_judge_runtime_id" routing = `Null)
+
+let test_build_inherited_consolidation_route () =
+  let resolved : J.resolved =
+    { default_runtime_id = Some "local.chat"
+    ; default_model = Some "chat"
+    ; default_max_context = Some 1024
+    ; runtimes = []
+    ; memory_os_consolidation_runtime_id = None
+    ; memory_os_consolidation = J.Consolidation_inherited "local.chat"
+    ; structured_judge_runtime_id = None
+    ; cross_verifier_runtime_id = None
+    ; media_failover = []
+    ; config_path = Some "/cfg/runtime.toml"
+    }
+  in
+  let routing =
+    J.build ~generated_at_iso:"2026-07-24T00:00:00Z" resolved
+    |> member "model_routing"
+  in
+  Alcotest.(check string)
+    "inherited status"
+    "inherited"
+    (member "memory_os_consolidation_status" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool)
+    "inherited selector remains null"
+    true
+    (member "memory_os_consolidation_runtime_id" routing = `Null);
+  Alcotest.(check string)
+    "inherited effective runtime"
+    "local.chat"
+    (member "memory_os_consolidation_effective_runtime_id" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool)
+    "inherited error is null"
+    true
+    (member "memory_os_consolidation_error" routing = `Null)
+
+let test_build_missing_configured_consolidation_route () =
+  let error = "configured consolidation runtime is absent" in
+  let resolved : J.resolved =
+    { default_runtime_id = Some "local.chat"
+    ; default_model = Some "chat"
+    ; default_max_context = Some 1024
+    ; runtimes = []
+    ; memory_os_consolidation_runtime_id = Some "local.missing"
+    ; memory_os_consolidation = J.Consolidation_error error
+    ; structured_judge_runtime_id = None
+    ; cross_verifier_runtime_id = None
+    ; media_failover = []
+    ; config_path = Some "/cfg/runtime.toml"
+    }
+  in
+  let routing =
+    J.build ~generated_at_iso:"2026-07-24T00:00:00Z" resolved
+    |> member "model_routing"
+  in
+  Alcotest.(check string)
+    "missing configured status"
+    "error"
+    (member "memory_os_consolidation_status" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "missing configured selector preserved"
+    "local.missing"
+    (member "memory_os_consolidation_runtime_id" routing
+     |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool)
+    "missing configured effective runtime is null"
+    true
+    (member "memory_os_consolidation_effective_runtime_id" routing = `Null);
+  Alcotest.(check string)
+    "missing configured error"
+    error
+    (member "memory_os_consolidation_error" routing
+     |> Yojson.Safe.Util.to_string)
+
+let test_uninitialized_runtime_snapshot_surfaces_error () =
+  let snapshot = Runtime.dashboard_runtime_defaults_snapshot () in
+  let resolved = J.resolved_of_snapshot snapshot in
+  match snapshot.memory_os_consolidation, resolved.memory_os_consolidation with
+  | Error expected, J.Consolidation_error actual ->
+    Alcotest.(check string) "snapshot error preserved" expected actual;
+    Alcotest.(check (option string))
+      "uninitialized configured selector remains absent"
+      None
+      resolved.memory_os_consolidation_runtime_id
+  | Ok _, _ -> Alcotest.fail "uninitialized Runtime snapshot unexpectedly resolved"
+  | Error _, _ -> Alcotest.fail "dashboard projection discarded Runtime snapshot error"
+
 let () =
   Alcotest.run "runtime_defaults_json"
     [ ( "build",
@@ -91,5 +207,11 @@ let () =
             test_build_resolved_serializes_defaults_and_routing;
           Alcotest.test_case "uninitialized emits null (no fabrication)" `Quick
             test_build_uninitialized_emits_null_not_fabricated_default;
+          Alcotest.test_case "serializes inherited consolidation route" `Quick
+            test_build_inherited_consolidation_route;
+          Alcotest.test_case "preserves missing configured selector" `Quick
+            test_build_missing_configured_consolidation_route;
+          Alcotest.test_case "preserves uninitialized snapshot error" `Quick
+            test_uninitialized_runtime_snapshot_surfaces_error;
         ] );
     ]

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -50,18 +50,6 @@ let provider_cfg () =
     ()
 ;;
 
-let with_env name value f =
-  let previous = Sys.getenv_opt name in
-  Fun.protect
-    ~finally:(fun () ->
-      match previous with
-      | Some old -> Unix.putenv name old
-      | None -> Unix.putenv name "")
-    (fun () ->
-      Unix.putenv name value;
-      f ())
-;;
-
 let with_runtime_config content f =
   let path = Filename.temp_file "memory-os-consolidation-runtime-" ".toml" in
   let snapshot = Runtime.For_testing.snapshot () in
@@ -252,15 +240,91 @@ default = "local.chat"
 memory_os_consolidation = "local.consolidation"
 |}
   in
-  with_env Env_config.KeeperMemoryOs.consolidation_runtime_id_env_key "" (fun () ->
-    with_runtime_config config (fun () ->
-      match Server_bootstrap_maintenance.runtime_for_memory_os_consolidation () with
-      | None -> Alcotest.fail "typed consolidation runtime should resolve"
-      | Some runtime ->
+  with_runtime_config config (fun () ->
+    let snapshot = Runtime.dashboard_runtime_defaults_snapshot () in
+    Alcotest.(check (option string))
+      "snapshot preserves configured selector"
+      (Some "local.consolidation")
+      snapshot.memory_os_consolidation_runtime_id;
+    match snapshot.memory_os_consolidation with
+    | Error msg -> Alcotest.failf "typed consolidation runtime should resolve: %s" msg
+    | Ok resolution ->
+      Alcotest.(check string)
+        "typed task route wins over default"
+        "local.consolidation"
+        resolution.effective_runtime.Runtime.id;
+      Alcotest.(check bool)
+        "snapshot records configured source"
+        true
+        (resolution.resolution_source = Runtime.Consolidation_configured);
+      let dashboard =
+        Server_dashboard_runtime_defaults_json.resolved_of_snapshot snapshot
+      in
+      Alcotest.(check (option string))
+        "dashboard preserves configured selector"
+        (Some "local.consolidation")
+        dashboard.memory_os_consolidation_runtime_id;
+      (match dashboard.memory_os_consolidation
+       with
+       | Server_dashboard_runtime_defaults_json.Consolidation_resolved runtime_id ->
+         Alcotest.(check string)
+           "dashboard preserves configured snapshot route"
+           "local.consolidation"
+           runtime_id
+       | _ -> Alcotest.fail "dashboard changed configured snapshot resolution"))
+;;
+
+let test_consolidation_runtime_inherits_default () =
+  let config =
+    {|
+[providers.local]
+display-name = "Local"
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.chat]
+api-name = "chat"
+max-context = 1024
+
+[local.chat]
+
+[runtime]
+default = "local.chat"
+|}
+  in
+  with_runtime_config config (fun () ->
+    let snapshot = Runtime.dashboard_runtime_defaults_snapshot () in
+    Alcotest.(check (option string))
+      "snapshot preserves absent selector"
+      None
+      snapshot.memory_os_consolidation_runtime_id;
+    match snapshot.memory_os_consolidation with
+    | Error msg -> Alcotest.failf "default consolidation runtime should resolve: %s" msg
+    | Ok resolution ->
         Alcotest.(check string)
-          "typed task route wins over default"
-          "local.consolidation"
-          runtime.Runtime.id))
+          "absent task route inherits default"
+          "local.chat"
+          resolution.effective_runtime.Runtime.id;
+        Alcotest.(check bool)
+          "snapshot records inherited source"
+          true
+          (resolution.resolution_source
+           = Runtime.Consolidation_inherited_default);
+        let dashboard =
+          Server_dashboard_runtime_defaults_json.resolved_of_snapshot snapshot
+        in
+        Alcotest.(check (option string))
+          "dashboard preserves absent selector"
+          None
+          dashboard.memory_os_consolidation_runtime_id;
+        (match dashboard.memory_os_consolidation
+         with
+         | Server_dashboard_runtime_defaults_json.Consolidation_inherited runtime_id ->
+           Alcotest.(check string)
+             "dashboard preserves inherited snapshot route"
+             "local.chat"
+             runtime_id
+         | _ -> Alcotest.fail "dashboard changed inherited snapshot resolution"))
 ;;
 
 let () =
@@ -283,6 +347,10 @@ let () =
             "typed route selects consolidation runtime"
             `Quick
             test_consolidation_runtime_uses_typed_route
+        ; Alcotest.test_case
+            "absent route inherits default runtime"
+            `Quick
+            test_consolidation_runtime_inherits_default
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- remove the retired consolidation runtime env selector and use runtime TOML as the only routing authority
- derive bootstrap execution and dashboard projection from one immutable Runtime snapshot
- preserve the configured selector wire key while exposing effective runtime, source status, and explicit resolution errors
- remove the pre-1.0 `[runtime].librarian` compatibility branch and regenerate the operator knob catalog
- align dashboard component and API fixtures with the new typed consolidation projection

## Boundary
- MASC still receives only runtime IDs/configuration; no provider, model, tier, pricing, retry, or fallback policy is introduced
- invalid configured runtime IDs fail closed instead of silently inheriting the default

## Breaking change / migration
This is an intentional pre-1.0 hard cut, not a compatibility migration:

- remove `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` from deployment environments
- configure consolidation only through `[runtime].memory_os_consolidation` in `runtime.toml`
- `[runtime].librarian` is retired and is rejected by the generic unknown-key validation; no compatibility reader or fallback remains

## Evidence
- rebased onto main after #25661 and #25667; PR Axis Cross-Check passes
- CI root cause: dashboard fixtures omitted the four required `memory_os_consolidation_*` fields introduced by the typed variant
- `npx tsc --noEmit --pretty` — pass
- `npx vitest run src/api/dashboard.test.ts src/components/settings-surface.test.ts` — 138/138 pass
- `scripts/dune-local.sh build @check` — pass
- generated `docs/runtime-tunables.md` with the existing catalog generator (212 entries)
- updated-head CI is the merge authority

## Follow-up
This is the corrective follow-up to the consolidation routing added after #25651.
