### PR TITLE
fix(keeper): fully apply bounded requeue convergence

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1006,6 +1006,7 @@ let rec converge_requeue_conflict
     ~keeper_name
     ~partition
     ~expected_quarantine_id
+    ()
   =
   let* candidates = Candidate.load_candidates ~base_path ~keeper_name in
   let* candidate =
@@ -1079,6 +1080,7 @@ let rec converge_requeue_conflict
            ~keeper_name
            ~partition
            ~expected_quarantine_id
+           ()
        | Partition.Generation_conflict detail ->
          Error ("partition target generation changed during requeue: " ^ detail))
   | Partition.Ready
@@ -1096,6 +1098,7 @@ let confirm_requeue_outcome
       ~keeper_name
       ~partition
       ~expected_quarantine_id
+      ()
   = function
   | Partition.Requeued transition ->
     confirm_requeue_transition ~base_path transition


### PR DESCRIPTION
## Summary

- add a final `unit` argument to `converge_requeue_conflict`
- fully apply both its recursive retry and external call sites
- remove warning 16 and the resulting partial-application type error from current `main`

## Context

#25672 merged the earlier record-label, typed-result test, and operator snapshot fixes. After rebasing onto that merge, this PR now contains only the remaining Board Attention compile blocker observed by both local `dune build .` and CI.

## Validation

- user local build on current `main` reproduced warning 16 at line 1004 and the partial application at lines 1103-1107
- local build was not rerun in this worktree; PR CI is the build authority for the three-line fix
