### PR TITLE
fix(keeper): restore main compile — candidate_id qualification + warning-10 + test error map

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -762,7 +762,7 @@ let complete_existing_judgment
       judgment
   =
   let item : Partition.completed_item =
-    { Partition.candidate_id = (!latest_partition).candidate_id; judgment }
+    { Partition.candidate_id = (!latest_partition).Partition.candidate_id; judgment }
   in
   match
     Partition.complete_existing_judgment
@@ -804,7 +804,7 @@ let settle_existing_consumed
       judgment
   =
   let item : Partition.completed_item =
-    { Partition.candidate_id = (!latest_partition).candidate_id; judgment }
+    { Partition.candidate_id = (!latest_partition).Partition.candidate_id; judgment }
   in
   match
     Partition.complete_existing_judgment

--- a/lib/server/server_dashboard_http_core_operator.ml
+++ b/lib/server/server_dashboard_http_core_operator.ml
@@ -196,7 +196,7 @@ let publish_operator_snapshot_invalidation_if_current ~generation =
 let begin_operator_snapshot_compute () =
   Dashboard_projection_cache.with_snapshot_publication_generation (fun generation ->
     Stdlib.Mutex.protect operator_snapshot_cache_mu (fun () ->
-      synchronize_operator_snapshot_generation generation;
+      ignore (synchronize_operator_snapshot_generation generation);
       mark_cached_surface_attempt operator_snapshot_cache;
       let sequence =
         Atomic.fetch_and_add operator_snapshot_compute_sequence 1 + 1

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -1762,8 +1762,10 @@ let test_same_quarantine_command_cas_loser_converges () =
   let report =
     ok
       "same command CAS loser converges"
-      (Q.For_testing.execute_with_before_partition_commit
-         ~before_partition_commit:(fun observed ->
+      (Result.map_error
+         Q.execution_error_label
+         (Q.For_testing.execute_with_before_partition_commit
+            ~before_partition_commit:(fun observed ->
            let competing =
              match
                ok
@@ -1782,7 +1784,7 @@ let test_same_quarantine_command_cas_loser_converges () =
              Alcotest.failf "competing Ready was not durable: %s" detail)
          ~now:20.0
          ~base_path
-         command)
+         command))
   in
   match report.partition.state with
   | P.Ready -> ()


### PR DESCRIPTION
## 문제

#25671 머지 이후 main red (run 30085869883, 30086771862). #25675는 test만 수리해 3개 에러가 잔존:

1. `keeper_board_attention_worker.ml:765,807` — `(!latest_partition).candidate_id` unqualified 필드 읽기가 타입 미제약 ref 파라미터 위에서 "Unbound record field" (동일 파일 :557의 qualified 패턴과 동일하게 수정)
2. `server_dashboard_http_core_operator.ml:199` — warning 10 non-unit-statement → `ignore` 래핑
3. `test_keeper_board_attention_worker.ml:1764` — `(Q.report, Q.execution_error) result`를 `(_, string) result` 기대하는 `ok` 헬퍼에 전달 → `Q.execution_error_label`로 map

## 검증

- ocamlformat --check 3개 파일 클린 ✅
- 전체 빌드 검증은 repo 정책대로 CI에 위임 — 로컬 스위치가 main pin(f448e518)보다 새로운 agent_sdk(InputCapacity 포함)라 `keeper_runtime_attempt.ml`에 main에서는 존재하지 않는 warning-8이 끼어들어 로컬 전체 빌드가 무의미함 (CI는 main pin이라 해당 없음)

## 연관

- #25671 (원인 머지), #25675 (불완전 픽스 — test만 수리), 리뷰에서 지적한 컴파일 결함이 그대로 실현된 케이스