### PR TITLE
fix(keeper): apply requeue convergence at the call site

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1098,7 +1098,6 @@ let confirm_requeue_outcome
       ~keeper_name
       ~partition
       ~expected_quarantine_id
-      ()
   = function
   | Partition.Requeued transition ->
     confirm_requeue_transition ~base_path transition
@@ -1108,6 +1107,7 @@ let confirm_requeue_outcome
       ~keeper_name
       ~partition
       ~expected_quarantine_id
+      ()
   | Partition.Generation_conflict detail ->
     Error ("partition target generation changed during requeue: " ^ detail)
 ;;


### PR DESCRIPTION
## Summary

- remove the accidental final `unit` argument from `confirm_requeue_outcome`
- fully apply the optional-argument `converge_requeue_conflict` call inside its `Cursor_conflict` branch
- leave the two existing `confirm_requeue_outcome ... outcome` callers unchanged

## Context

#25678 merged before its corrective follow-up commit reached the PR. Current `main` therefore still returns a partially-applied `converge_requeue_conflict` function at lines 1106-1110. This PR moves the already-intended `()` to the actual callee.

## Validation

- user local `dune build .` on current `main` reproduced the partial-application error
- local build was not rerun in this worktree; PR CI is the build authority
