### PR TITLE
fix(keeper): preserve process_next polymorphism

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1309,9 +1309,15 @@ let process_next_with_claim_ready_exact
     claim_selected 3
 ;;
 
-let process_next =
+let process_next ~now ~worker_epoch ~base_path ~keeper_name ~prepare ~execute =
   process_next_with_claim_ready_exact
     ~claim_ready_exact:Partition.claim_ready_exact
+    ~now
+    ~worker_epoch
+    ~base_path
+    ~keeper_name
+    ~prepare
+    ~execute
 ;;
 
 let completed_in_order ~base_path ~keeper_name =


### PR DESCRIPTION
## What changed

Eta-expand `process_next` so it remains polymorphic over the injected prepared value while binding the production `claim_ready_exact` implementation.

## Root cause

The partial application assigned by `let process_next = ...` is expansive under OCaml's value restriction. Its weak prepared type was subsequently fixed to `Exact_flow.prepared` by the production drain path, so the implementation could not satisfy the polymorphic `For_testing.process_next` interface.

The interface is intentionally left unchanged: test callers inject non-production prepared values, so narrowing it to `Exact_flow.prepared` would break the seam instead of fixing the implementation.

## Impact

Restores compilation of `keeper_board_attention_worker.ml` after #25682 without changing runtime behavior.

## Validation

- `scripts/dune-local.sh build lib/masc.cmxa` — pass
- `scripts/dune-local.sh build .` — pass
- `ocamlformat --check lib/keeper/keeper_board_attention_worker.ml` — pass
- `git diff --check` — pass
- The focused worker executable compiles. Running it exposes four separate state-transition assertion failures that were hidden behind the compile blocker; tracked in #25684.