### PR TITLE
docs(rfc): define scheduled occurrence lifecycle authority

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -344,7 +344,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | elim | Withdrawn command-policy classification experiment | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | a48d59f034 2026-07-24 | - |
 | runt | Per-runtime note field & dashboard surfacing | Draft | f3e073c3c9 2026-06-25 | - |
-| sche | Separate schedule definitions, occurrence delivery, and work outcomes | Draft | ee2f49fe0a 2026-07-24 | - |
+| sche | Separate schedule definitions, occurrence delivery, and work outcomes | Draft | e190805cc8 2026-07-24 | - |
 | type | Withdraw product-specific egress effect classification | Withdrawn | 7b62a87d44 2026-07-13 | - |
 
 ### 신규 RFC

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -46,92 +46,92 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 
 | # | Title | Status | Last activity | Sub-docs |
 |---|---|---|---|---|
-| 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | b07a069c5c 2026-07-17 | - |
+| 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | 8c6f0e9742 2026-07-24 | - |
 | 0001 | Withdraw heuristic uncertainty governance | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0002 | Keeper 11-State Machine + Det/NonDet Boundary Formalization | reference | 7b62a87d44 2026-07-13 | - |
 | 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | 03d5feaf25 2026-07-08 | - |
+| 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | 0ee897eca1 2026-06-03 | - |
 | 0005 | Withdraw the typed command-policy substrate | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0006 | Keeper Surface And Sandbox | Draft | 03d5feaf25 2026-07-08 | - |
-| 0008 | Keeper Credential Provider | Draft | 03d5feaf25 2026-07-08 | - |
-| 0009 | Runtime Trust Phase 2: Operator Recommendations + Opt-in Persist | Draft | 03d5feaf25 2026-07-08 | - |
-| 0010 | ocamlformat config reconciliation | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0012 | Mid-Turn Progress Probe | Draft | 03d5feaf25 2026-07-08 | - |
-| 0019 | Keeper Credential Unification | Draft | 03d5feaf25 2026-07-08 | - |
+| 0006 | Keeper Surface And Sandbox | Draft | 6ce9619607 2026-05-27 | - |
+| 0008 | Keeper Credential Provider | Draft | 478c943e39 2026-06-02 | - |
+| 0009 | Runtime Trust Phase 2: Operator Recommendations + Opt-in Persist | Draft | 70ac2a7930 2026-06-03 | - |
+| 0010 | ocamlformat config reconciliation | Implemented | a7b9f1f8d0 2026-05-31 | - |
+| 0012 | Mid-Turn Progress Probe | Draft | 00a9aa0dd1 2026-06-06 | - |
+| 0019 | Keeper Credential Unification | Draft | 478c943e39 2026-06-02 | - |
 | 0022 | Withdraw MASC attempt budgets and provider demotion | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0024 | Ollama Runtime Integration + KV Cache Optimization | Draft | 03d5feaf25 2026-07-08 | - |
-| 0025 | Tiered Small-Model Runtime (4B → 9B → 70B+) | Draft | 03d5feaf25 2026-07-08 | - |
+| 0024 | Ollama Runtime Integration + KV Cache Optimization | Draft | 0ee897eca1 2026-06-03 | - |
+| 0025 | Tiered Small-Model Runtime (4B → 9B → 70B+) | Draft | 70ac2a7930 2026-06-03 | - |
 | 0027 | Retired tension and meta-cognition draft | Superseded | 434a7f5a76 2026-07-10 | - |
-| 0029 | Dashboard Fiber-Batched Aggregation | Active | 03d5feaf25 2026-07-08 | - |
-| 0032 | Environment Knob Unification | Draft | 03d5feaf25 2026-07-08 | - |
-| 0034 | d — release_stale_claims agent-side sync | Draft | 03d5feaf25 2026-07-08 | - |
-| 0035 | Cognitive IDE Master Plan Integration | Draft | 03d5feaf25 2026-07-08 | - |
-| 0036 | oas Cognitive Mapping (companion to RFC-0035) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0037 | Local-first Keeper Enablement: Harness/User Boundary | Draft | 03d5feaf25 2026-07-08 | - |
+| 0029 | Dashboard Fiber-Batched Aggregation | Active | a7b9f1f8d0 2026-05-31 | - |
+| 0032 | Environment Knob Unification | Draft | a7296801a7 2026-06-01 | - |
+| 0034 | d — release_stale_claims agent-side sync | Draft | 00a9aa0dd1 2026-06-06 | - |
+| 0035 | Cognitive IDE Master Plan Integration | Draft | 0ee897eca1 2026-06-03 | - |
+| 0036 | oas Cognitive Mapping (companion to RFC-0035) | Draft | 0ee897eca1 2026-06-03 | - |
+| 0037 | Local-first Keeper Enablement: Harness/User Boundary | Draft | 0ee897eca1 2026-06-03 | - |
 | 0038 | Withdraw MASC capability-routing plan | Withdrawn | 7b62a87d44 2026-07-13 | RFC-0038-phase-2-keeper-identity-canonical.md |
 | 0041 | Withdraw runtime group/item hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0042 | Withdraw Keeper terminal-reason hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0043 | Distribute legacy metrics backend metric ownership to domain modules | Active | 03d5feaf25 2026-07-08 | - |
-| 0044 | Typed persistence read-drop reason + Result-based reads | Active | 03d5feaf25 2026-07-08 | - |
-| 0045 | SDK turn boundary alignment with MASC keeper FSM | Draft | 03d5feaf25 2026-07-08 | - |
-| 0046 | Keeper Detail FSM Hub as SSOT | Active | 03d5feaf25 2026-07-08 | - |
-| 0047 | `oas_*` adapter family decomposition (consumer-only OAS boundary) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0049 | Dashboard Surface Telemetry Foundation | Draft | 03d5feaf25 2026-07-08 | - |
-| 0050 | Dashboard Component Ownership Decomposition | Active | 03d5feaf25 2026-07-08 | - |
-| 0051 | run_named closure decomposition | Active | 03d5feaf25 2026-07-08 | - |
-| 0052 | Boot-time Required Invariants (typed) | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0053 | Tool Dispatch Session-Local Handles | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0043 | Distribute legacy metrics backend metric ownership to domain modules | Active | d498dd810a 2026-06-06 | - |
+| 0044 | Typed persistence read-drop reason + Result-based reads | Active | 00a9aa0dd1 2026-06-06 | - |
+| 0045 | SDK turn boundary alignment with MASC keeper FSM | Draft | 00a9aa0dd1 2026-06-06 | - |
+| 0046 | Keeper Detail FSM Hub as SSOT | Active | a7b9f1f8d0 2026-05-31 | - |
+| 0047 | `oas_*` adapter family decomposition (consumer-only OAS boundary) | Draft | 00a9aa0dd1 2026-06-06 | - |
+| 0049 | Dashboard Surface Telemetry Foundation | Draft | d498dd810a 2026-06-06 | - |
+| 0050 | Dashboard Component Ownership Decomposition | Active | 00a9aa0dd1 2026-06-06 | - |
+| 0051 | run_named closure decomposition | Active | 9d7d80804a 2026-06-06 | - |
+| 0052 | Boot-time Required Invariants (typed) | Implemented | 00a9aa0dd1 2026-06-06 | - |
+| 0053 | Tool Dispatch Session-Local Handles | Implemented | 0ee897eca1 2026-06-03 | - |
 | 0054 | Withdraw code generation for command-policy GADTs | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0056 | Incremental Sub-Library Extraction from Flat masc Library | Active | 03d5feaf25 2026-07-08 | - |
+| 0056 | Incremental Sub-Library Extraction from Flat masc Library | Active | 00a9aa0dd1 2026-06-06 | - |
 | 0057 | Tool Descriptor Codegen — `[@@deriving tool]` via Build-Time Generation | Draft | 7b62a87d44 2026-07-13 | - |
 | 0058 | Withdraw terminal capability hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | RFC-0058-phase-5-erase-provider-variant.md |
-| 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class (Reverse-Engineered Initi... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0063 | Telemetry Feedback Loop & Cooperative Scheduling Safety | Draft | 03d5feaf25 2026-07-08 | - |
-| 0064 | Descriptor-Owned Tool Surface | Superseded | 03d5feaf25 2026-07-08 | - |
+| 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class (Reverse-Engineered Initi... | Draft | 00a9aa0dd1 2026-06-06 | - |
+| 0063 | Telemetry Feedback Loop & Cooperative Scheduling Safety | Draft | 00a9aa0dd1 2026-06-06 | - |
+| 0064 | Descriptor-Owned Tool Surface | Superseded | 6ce9619607 2026-05-27 | - |
 | 0065 | Withdraw policy-bearing tool-selection model | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0067 | Goal-Scope Observation→Claim Atomicity | Draft | 03d5feaf25 2026-07-08 | - |
+| 0067 | Goal-Scope Observation→Claim Atomicity | Draft | 00a9aa0dd1 2026-06-06 | - |
 | 0068 | Withdraw operator disposition hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0069 | Awareness Channel Split | Active | 361bf75eb5 2026-07-17 | - |
 | 0070 | Keeper Sandbox Runtime — Pure/Edge Separation | Active | 7b62a87d44 2026-07-13 | - |
-| 0071 | Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0072 | Type-encoded keeper sub-FSM transitions (runtime + turn_phase) | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0071 | Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern | Implemented | a7b9f1f8d0 2026-05-31 | - |
+| 0072 | Type-encoded keeper sub-FSM transitions (runtime + turn_phase) | Implemented | a7b9f1f8d0 2026-05-31 | - |
 | 0073 | Withdraw pre-turn tool readiness filtering | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0074 | Sandbox Credential Auto-provision | Retired | 03d5feaf25 2026-07-08 | - |
-| 0075 | Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0076 | Tool Readiness Notification Channel | Retired | 03d5feaf25 2026-07-08 | - |
-| 0077 | Write-side silent failure — typed propagation | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0079 | Log row typed encoder + silent-drop removal | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0074 | Sandbox Credential Auto-provision | Retired | 478c943e39 2026-06-02 | - |
+| 0075 | Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate | Implemented | 0ee897eca1 2026-06-03 | - |
+| 0076 | Tool Readiness Notification Channel | Retired | 478c943e39 2026-06-02 | - |
+| 0077 | Write-side silent failure — typed propagation | Implemented | 00a9aa0dd1 2026-06-06 | - |
+| 0079 | Log row typed encoder + silent-drop removal | Implemented | a7296801a7 2026-06-01 | - |
 | 0080 | Registered descriptors are the tool-surface SSOT | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0081 | OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0081 | OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | 1f2a526520 2026-06-09 | - |
 | 0082 | Withdraw automatic blocker escalation and recovery | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0083 | Dashboard system-actor convention typed unification | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0083 | Dashboard system-actor convention typed unification | Implemented | dac9946522 2026-05-23 | - |
 | 0084 | Tool dispatch handler and observation unification | Implemented | 7b62a87d44 2026-07-13 | - |
 | 0086 | Keeper namespace bulk promotion to sub-library | Implemented | 1fe1daf0e5 2026-07-16 | - |
-| 0087 | Tool Dispatch Path Unification + Legacy Purge | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0088 | Counter-as-Fix → Result Propagation (umbrella scoping) | Active | 03d5feaf25 2026-07-08 | - |
+| 0087 | Tool Dispatch Path Unification + Legacy Purge | Implemented | 00a9aa0dd1 2026-06-06 | - |
+| 0088 | Counter-as-Fix → Result Propagation (umbrella scoping) | Active | 00a9aa0dd1 2026-06-06 | - |
 | 0089 | String Classifier to Typed Variant — direct replacement, no lint | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0090 | Write-side success-model attribution — finish N-of-M migration | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0091 | Execute tool: cmd string → typed Argv schema (lexer/validator 박멸) | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0090 | Write-side success-model attribution — finish N-of-M migration | Implemented | d498dd810a 2026-06-06 | - |
+| 0091 | Execute tool: cmd string → typed Argv schema (lexer/validator 박멸) | Implemented | 23dcea3303 2026-06-04 | - |
 | 0093 | Board persistence identity and atomic snapshot | Implemented | 7b62a87d44 2026-07-13 | - |
 | 0094 | Compact cooldown semantics split decision record | Superseded | 434a7f5a76 2026-07-10 | - |
-| 0095 | Provider-D-compat provider streaming wire-up | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0096 | Keeper Turn Contract — multi-turn reasoning + runtime SPOF root-fix | Withdrawn | 03d5feaf25 2026-07-08 | - |
+| 0095 | Provider-D-compat provider streaming wire-up | Implemented | d498dd810a 2026-06-06 | - |
+| 0096 | Keeper Turn Contract — multi-turn reasoning + runtime SPOF root-fix | Withdrawn | 6c5095e528 2026-06-03 | - |
 | 0097 | Keeper sandbox container reuse (long-running sandbox per keeper) | Active | 7b62a87d44 2026-07-13 | - |
 | 0098 | Typed JSON-RPC error envelope & production-code silent-failure lint | Implemented | 434a7f5a76 2026-07-10 | - |
 | 0099 | Session lifecycle — typed events, explicit eviction, resume backpressure | Active | 63c38bf628 2026-07-17 | - |
-| 0100 | Streamable HTTP as default transport (MCP 2025-03-26) | Active | 03d5feaf25 2026-07-08 | - |
+| 0100 | Streamable HTTP as default transport (MCP 2025-03-26) | Active | 0ee897eca1 2026-06-03 | - |
 | 0101 | FD accountant — observation across process resource classes | Active | 7b62a87d44 2026-07-13 | - |
 | 0102 | Pre-turn runtime availability gate — reuse, not new surface | Superseded | df319a9896 2026-07-11 | - |
-| 0103 | Log retention opt-in + JSONL volume root reduction | Draft | 03d5feaf25 2026-07-08 | - |
+| 0103 | Log retention opt-in + JSONL volume root reduction | Draft | a7b9f1f8d0 2026-05-31 | - |
 | 0104 | Withdraw Task-to-repository authorization | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0105 | OpenAI-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | 03d5feaf25 2026-07-08 | - |
+| 0105 | OpenAI-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope | Implemented | 0ee897eca1 2026-06-03 | - |
+| 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | 0ee897eca1 2026-06-03 | - |
 | 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... | Active | 7b62a87d44 2026-07-13 | - |
-| 0108 | PR / Worktree Operation Safety Gates | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0108 | PR / Worktree Operation Safety Gates | Implemented | 0ee897eca1 2026-06-03 | - |
 | 0109 | CDAL x Goal Integration Contract | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0110 | Tool-pair atomicity at write boundary — sunset compaction repair fabrication | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0110 | Tool-pair atomicity at write boundary — sunset compaction repair fabrication | Implemented | fed12810ef 2026-06-13 | - |
 | 0111 | Goal mint atomicity — auto-goal uniqueness invariant at write boundary | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0112 | Typed JSON parse boundary — eliminate silent-drop fallback across read sites | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0112 | Typed JSON parse boundary — eliminate silent-drop fallback across read sites | Implemented | a7b9f1f8d0 2026-05-31 | - |
 | 0113 | Withdraw KeeperReactionLiveness runtime hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0114 | Withdraw compact-retry and lifecycle guard model | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0116 | Withdraw fallback-count cap | Withdrawn | 7b62a87d44 2026-07-13 | - |
@@ -139,163 +139,163 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0118 | Withdraw terminal runtime projection contract | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0119 | Withdraw lifecycle projection mapping hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0120 | Cross-spec set-name divergence — 3-class classification framework (STALE / DE... | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0121 | Config-dir resolution — single active root, no implicit fallback | Active | 03d5feaf25 2026-07-08 | - |
-| 0122 | Keeper disk pressure — process-local fleet failure mode beyond FD | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0123 | Briefing last_event fabrication — option-typed write boundary | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0121 | Config-dir resolution — single active root, no implicit fallback | Active | a7296801a7 2026-06-01 | - |
+| 0122 | Keeper disk pressure — process-local fleet failure mode beyond FD | Implemented | 7abc844904 2026-06-01 | - |
+| 0123 | Briefing last_event fabrication — option-typed write boundary | Implemented | 00a9aa0dd1 2026-06-06 | - |
 | 0124 | Withdraw fleet resource admission denial | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0125 | Withdraw Keeper watchdog and force-release discipline | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0126 | Silent fallback discipline (typed split for option/result wildcard arms) | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0127 | Runtime Fast-Fail (Provider Health Phase 3) + Fiber Termination Provenance | Active | 03d5feaf25 2026-07-08 | - |
-| 0129 | Runtime attempt idle-cap: kill the reserve_fraction band-aid | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0126 | Silent fallback discipline (typed split for option/result wildcard arms) | Implemented | a48d59f034 2026-07-24 | - |
+| 0127 | Runtime Fast-Fail (Provider Health Phase 3) + Fiber Termination Provenance | Active | 00a9aa0dd1 2026-06-06 | - |
+| 0129 | Runtime attempt idle-cap: kill the reserve_fraction band-aid | Implemented | a41c953ae8 2026-06-06 | - |
 | 0131 | Withdraw policy-bearing shell command facade | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | 5cbe0f454e 2026-07-06 | - |
 | 0134 | Persistence read-drop root fix (recovery story for RFC-0044) | Active | 7b62a87d44 2026-07-13 | - |
 | 0135 | Supersede dashboard-derived Keeper disposition | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | 0418bdc838 2026-06-15 | - |
 | 0137 | Host FD pressure observation — retired Keeper-pause proposal | Retired | 7b62a87d44 2026-07-13 | - |
-| 0138 | Dashboard Snapshot Lock-Free Immutable Architecture | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0138 | Dashboard Snapshot Lock-Free Immutable Architecture | Implemented | fdbf1c08d6 2026-07-19 | - |
 | 0139 | Withdraw parallel agent and judge status hierarchies | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0140 | Dashboard wire codec for source observations | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0141 | TOML Field Resolution Typed Variant for repo_manager | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0142 | runtime_error_classify Decomposition + Typed JSON-Extraction Variant | Active | 03d5feaf25 2026-07-08 | - |
-| 0143 | keeper_runtime_profile Typed Catalog Query Result | Active | 03d5feaf25 2026-07-08 | - |
+| 0141 | TOML Field Resolution Typed Variant for repo_manager | Implemented | 478c943e39 2026-06-02 | - |
+| 0142 | runtime_error_classify Decomposition + Typed JSON-Extraction Variant | Active | 0ee897eca1 2026-06-03 | - |
+| 0143 | keeper_runtime_profile Typed Catalog Query Result | Active | d943a4f3b8 2026-06-05 | - |
 | 0144 | Withdraw recording-error dedup and metric sunset gates | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0145 | Permissive-Silent-Fallback Elimination | Active | 03d5feaf25 2026-07-08 | - |
+| 0145 | Permissive-Silent-Fallback Elimination | Active | 00a9aa0dd1 2026-06-06 | - |
 | 0147 | Withdraw decomposition around deleted Keeper policy stages | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0148 | Typed `tool_error` Variant for LLM-Facing Tool Failure Surface | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0149 | Audit-Driven Telemetry-as-Fix Sunset | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0148 | Typed `tool_error` Variant for LLM-Facing Tool Failure Surface | Implemented | 799c1a7331 2026-06-05 | - |
+| 0149 | Audit-Driven Telemetry-as-Fix Sunset | Implemented | 00a9aa0dd1 2026-06-06 | - |
 | 0150 | Keeper Attention Signal — backend 단일 typed wire envelope | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0151 | 4-metric monotone-decrease ratchet for code-smell metrics | Withdrawn | 03d5feaf25 2026-07-08 | - |
+| 0151 | 4-metric monotone-decrease ratchet for code-smell metrics | Withdrawn | 9d7d80804a 2026-06-06 | - |
 | 0153 | Withdraw runtime tier admission | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0154 | System_error_class typed SSOT — close substring-classifier loop across backen... | Implemented | 03d5feaf25 2026-07-08 | - |
+| 0154 | System_error_class typed SSOT — close substring-classifier loop across backen... | Implemented | 0ee897eca1 2026-06-03 | - |
 | 0155 | Withdraw centralized operational policy log taxonomy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0156 | Withdraw MASC turn-budget timeout policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0157 | Withdraw MASC pre-dispatch provider capability filtering | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0158 | Withdraw MASC retry-admission denial | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0159 | Reason_internal_error typed split — close string-classifier catch-all | Draft | 03d5feaf25 2026-07-08 | - |
+| 0159 | Reason_internal_error typed split — close string-classifier catch-all | Draft | 00a9aa0dd1 2026-06-06 | - |
 | 0160 | Withdrawn Shell IR decision-substrate plan | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0161 | Tool Error Hint Symmetry Enforcement | Draft | 03d5feaf25 2026-07-08 | - |
-| 0162 | JSONL Write-Path FD Pressure Root-Fix | Draft | 03d5feaf25 2026-07-08 | - |
-| 0163 | Tier-group capability profile route canonicalization — typed dedup and bypass... | Withdrawn | 03d5feaf25 2026-07-08 | - |
+| 0161 | Tool Error Hint Symmetry Enforcement | Draft | da3eb7d5c3 2026-05-26 | - |
+| 0162 | JSONL Write-Path FD Pressure Root-Fix | Draft | 0ee897eca1 2026-06-03 | - |
+| 0163 | Tier-group capability profile route canonicalization — typed dedup and bypass... | Withdrawn | 00a9aa0dd1 2026-06-06 | - |
 | 0164 | Withdraw voice exceptions to provider capability filtering | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0167 | Withdrawn product-specific runtime authorization cleanup | Draft | 7b62a87d44 2026-07-13 | - |
-| 0168 | Dashboard upstream-LLM-provider color palette purge | Draft | 03d5feaf25 2026-07-08 | - |
-| 0169 | Dashboard common/* MCP-client attribution header purge | Draft | 03d5feaf25 2026-07-08 | - |
-| 0170 | Dashboard provider-b palette closure (RFC-0168 N-of-M follow-up) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0171 | Design-canvas + ui_kits mock data vendor purge | Draft | 03d5feaf25 2026-07-08 | - |
-| 0172 | Big-bang vendor purge across docs, audits, RFCs, design-system, tests | Draft | 03d5feaf25 2026-07-08 | - |
-| 0173 | OCaml lib/bin/test vendor purge (identifier + string literal) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0174 | Dashboard substring classifier to typed — TypeScript | Draft | 03d5feaf25 2026-07-08 | - |
-| 0175 | Godfile decomposition Wave D — keeper core 5-file split | Draft | 03d5feaf25 2026-07-08 | - |
-| 0176 | OAS vendor-purge migration — consume agent_sdk 0.198.0 | Implemented | 03d5feaf25 2026-07-08 | - |
-| 0177 | Phonebook internal vendor-coupled enum purge | Draft | 03d5feaf25 2026-07-08 | - |
-| 0178 | Types Sub-library Extraction with `_intf.ml` mli-only Surface (typed-SSOT) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0179 | ToolDescriptor Ecosystem Coverage Extension to Workspace Tools | Draft | 03d5feaf25 2026-07-08 | - |
-| 0180 | 24h Runtime ERROR 7-Pattern Sweep Roadmap | Draft | 03d5feaf25 2026-07-08 | - |
+| 0168 | Dashboard upstream-LLM-provider color palette purge | Draft | 685aa5fbb7 2026-06-12 | - |
+| 0169 | Dashboard common/* MCP-client attribution header purge | Draft | 0ee897eca1 2026-06-03 | - |
+| 0170 | Dashboard provider-b palette closure (RFC-0168 N-of-M follow-up) | Draft | 05c74824a2 2026-06-12 | - |
+| 0171 | Design-canvas + ui_kits mock data vendor purge | Draft | 05c74824a2 2026-06-12 | - |
+| 0172 | Big-bang vendor purge across docs, audits, RFCs, design-system, tests | Draft | 6a489efe99 2026-06-16 | - |
+| 0173 | OCaml lib/bin/test vendor purge (identifier + string literal) | Draft | 05c74824a2 2026-06-12 | - |
+| 0174 | Dashboard substring classifier to typed — TypeScript | Draft | e7924e8cdf 2026-05-24 | - |
+| 0175 | Godfile decomposition Wave D — keeper core 5-file split | Draft | 71c70f2806 2026-07-18 | - |
+| 0176 | OAS vendor-purge migration — consume agent_sdk 0.198.0 | Implemented | 0ee897eca1 2026-06-03 | - |
+| 0177 | Phonebook internal vendor-coupled enum purge | Draft | 05c74824a2 2026-06-12 | - |
+| 0178 | Types Sub-library Extraction with `_intf.ml` mli-only Surface (typed-SSOT) | Draft | 0ee897eca1 2026-06-03 | - |
+| 0179 | ToolDescriptor Ecosystem Coverage Extension to Workspace Tools | Draft | d45f4b8b02 2026-06-03 | - |
+| 0180 | 24h Runtime ERROR 7-Pattern Sweep Roadmap | Draft | 0ee897eca1 2026-06-03 | - |
 | 0181 | Withdraw MASC capability-intent routing | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0182 | masc_* Workspace Tool Descriptor Projection + Tool_spec SSOT Consolidation | Draft | 7b62a87d44 2026-07-13 | - |
-| 0184 | Runtime phonebook typed roundtrip for protocol/flavor/provider identifiers | Draft (Deferred) | 03d5feaf25 2026-07-08 | - |
-| 0189 | Typed Tool_result.result variant — eliminating boolean blindness in tool disp... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0190 | Descriptor as Visibility/Metadata SSOT — Surface Projection from descriptor.p... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0184 | Runtime phonebook typed roundtrip for protocol/flavor/provider identifiers | Draft (Deferred) | 05c74824a2 2026-06-12 | - |
+| 0189 | Typed Tool_result.result variant — eliminating boolean blindness in tool disp... | Draft | 799c1a7331 2026-06-05 | - |
+| 0190 | Descriptor as Visibility/Metadata SSOT — Surface Projection from descriptor.p... | Draft | e6b16cb275 2026-06-05 | - |
 | 0191 | Withdraw descriptor authorization policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0192 | Runtime deadline propagation — retired admission-wait proposal | Retired | 7b62a87d44 2026-07-13 | - |
 | 0194 | Withdraw tool semantics as an authorization SSOT | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0197 | Runtime Attempt Watchdog — Per-Candidate Wrap + Shared Deadline | Draft | 03d5feaf25 2026-07-08 | - |
+| 0197 | Runtime Attempt Watchdog — Per-Candidate Wrap + Shared Deadline | Draft | 44966887a6 2026-07-18 | - |
 | 0198 | Execute Typed Redirection (Shell IR Syntax Leakage Closure) | Draft | 214eec8f6c 2026-07-14 | - |
 | 0199 | Withdraw deterministic task-completion auto approval | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0200 | Time constants 를 leaf library 로 분리 | Draft | 03d5feaf25 2026-07-08 | - |
-| 0201 | Activity Events Wait-Free Snapshot | Draft | 03d5feaf25 2026-07-08 | - |
-| 0203 | In-process Discord connector | Implemented (Phase 3 cutover landed 2026-05-29) | 03d5feaf25 2026-07-08 | - |
+| 0200 | Time constants 를 leaf library 로 분리 | Draft | 0ee897eca1 2026-06-03 | - |
+| 0201 | Activity Events Wait-Free Snapshot | Draft | fdbf1c08d6 2026-07-19 | - |
+| 0203 | In-process Discord connector | Implemented (Phase 3 cutover landed 2026-05-29) | 8a8a90a2f0 2026-07-18 | - |
 | 0204 | Dashboard Read Serving Isolation from Fleet Compute | Draft | 7b62a87d44 2026-07-13 | - |
-| 0205 | Keeper Module Consolidation — Eliminate Facade Anti-Pattern | Draft | 03d5feaf25 2026-07-08 | - |
-| 0206 | Runtime 개념 — runtime→Runtime 재탄생 | Draft | 03d5feaf25 2026-07-08 | - |
-| 0207 | Per-keeper LLM runtime routing | Draft | 03d5feaf25 2026-07-08 | - |
+| 0205 | Keeper Module Consolidation — Eliminate Facade Anti-Pattern | Draft | ec50013248 2026-07-19 | - |
+| 0206 | Runtime 개념 — runtime→Runtime 재탄생 | Draft | c7757f9721 2026-07-07 | - |
+| 0207 | Per-keeper LLM runtime routing | Draft | 70ac2a7930 2026-06-03 | - |
 | 0208 | Withdrawn compositional Shell IR policy algebra | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0210 | Keeper Playground Repo Currency (fetch + fast-forward, work-preserving) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0211 | Persona ⊥ {model, runtime}, opaque runtime id, runtime.toml keeper-assignment... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0210 | Keeper Playground Repo Currency (fetch + fast-forward, work-preserving) | Draft | 679471d525 2026-06-04 | - |
+| 0211 | Persona ⊥ {model, runtime}, opaque runtime id, runtime.toml keeper-assignment... | Draft | bf66513f1b 2026-06-02 | - |
 | 0212 | Withdraw Keeper exposure policy axis | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0213 | Keeper sandbox/playground isolation model (fix sandbox_repo_not_ready + macOS... | Draft | 7b62a87d44 2026-07-13 | - |
-| 0214 | OTel GenAI Semantic Convention Migration | Draft | 03d5feaf25 2026-07-08 | - |
+| 0214 | OTel GenAI Semantic Convention Migration | Draft | b8c26aa41a 2026-06-06 | - |
 | 0215 | Keeper sub-library extraction campaign — sequence and per-PR gates | Draft | 0ed4982f58 2026-07-15 | - |
-| 0216 | Per-Keeper Decline Memory (orphan-task churn root fix) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0217 | Telemetry Backend Otel 단일화 (Retired Backend Purge) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0218 | Keeper tool-surface coherence + web-tooling roadmap — phases and per-phase gates | Draft | 03d5feaf25 2026-07-08 | - |
-| 0219 | Remove Sandbox Repo Patrol Gates | Draft | 03d5feaf25 2026-07-08 | - |
-| 0220 | Decouple keeper liveness from verification state + guaranteed satisfier for e... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0221 | Atomic verification submission — task_status as the sole outcome authority | Implemented (steps 1-3 merged #20613/#20617; steps 4-5 measured then dropped, §3.3/§3.4) | 03d5feaf25 2026-07-08 | - |
+| 0216 | Per-Keeper Decline Memory (orphan-task churn root fix) | Draft | f765863658 2026-06-23 | - |
+| 0217 | Telemetry Backend Otel 단일화 (Retired Backend Purge) | Draft | d498dd810a 2026-06-06 | - |
+| 0218 | Keeper tool-surface coherence + web-tooling roadmap — phases and per-phase gates | Draft | ec5d329844 2026-06-06 | - |
+| 0219 | Remove Sandbox Repo Patrol Gates | Draft | 7e800d1231 2026-06-06 | - |
+| 0220 | Decouple keeper liveness from verification state + guaranteed satisfier for e... | Draft | 6c9029bcbf 2026-06-25 | - |
+| 0221 | Atomic verification submission — task_status as the sole outcome authority | Implemented (steps 1-3 merged #20613/#20617; steps 4-5 measured then dropped, §3.3/§3.4) | 310e140640 2026-06-09 | - |
 | 0222 | Withdraw harness-owned Task completion | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0223 | Typed connector surfaces: presence in world prompt, pull-based lane context, ... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0223 | Typed connector surfaces: presence in world prompt, pull-based lane context, ... | Draft | c8eb1078d2 2026-06-10 | - |
 | 0224 | Withdraw the mandatory structured completion checklist | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0225 | Per-keeper turn single-flight admission | Draft | 03d5feaf25 2026-07-08 | - |
-| 0226 | Ambient lane recording: record-vs-trigger decouple for connector surfaces | Draft | 03d5feaf25 2026-07-08 | - |
-| 0228 | Paged lane pull + fact-retention harness: digest without a summarizer | Draft | 03d5feaf25 2026-07-08 | - |
+| 0225 | Per-keeper turn single-flight admission | Draft | 534e9549ed 2026-06-10 | - |
+| 0226 | Ambient lane recording: record-vs-trigger decouple for connector surfaces | Draft | 759814d603 2026-06-11 | - |
+| 0228 | Paged lane pull + fact-retention harness: digest without a summarizer | Draft | 18706b0500 2026-06-11 | - |
 | 0229 | Keeper person notes: deliberate per-speaker memory beyond the log window | Draft | 7b62a87d44 2026-07-13 | - |
-| 0230 | Keeper mention/scope reactivity: cursor-free salience to complement pull-base... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0232 | Typed lane event model: parse at the write boundary, never re-derive by strin... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0230 | Keeper mention/scope reactivity: cursor-free salience to complement pull-base... | Draft | c8790d6aaf 2026-06-11 | - |
+| 0232 | Typed lane event model: parse at the write boundary, never re-derive by strin... | Draft | f8ee031835 2026-06-12 | - |
 | 0233 | Typed turn observability: TurnRecord prompt-block provenance + canonical tool... | Draft | 434a7f5a76 2026-07-10 | - |
 | 0234 | Withdraw schedule-specific approval hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0235 | Voice output transport: browser-addressed audio delivery with device-routed p... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0235 | Voice output transport: browser-addressed audio delivery with device-routed p... | Draft | 29e585aec9 2026-06-14 | - |
+| 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | 12435886d0 2026-06-14 | - |
 | 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Draft | 434a7f5a76 2026-07-10 | - |
 | 0239 | Supersede no-progress pause and semantic debounce guards | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0240 | Tool-pair invariant enforced at write-time (eliminate repair-on-read) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0241 | external-attention store lifecycle: read-side bound, retention, and typed tai... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0240 | Tool-pair invariant enforced at write-time (eliminate repair-on-read) | Draft | dee099a0dd 2026-06-15 | - |
+| 0241 | external-attention store lifecycle: read-side bound, retention, and typed tai... | Draft | db70697a12 2026-06-15 | - |
 | 0242 | Retired continuity prose-filter draft | Superseded | 434a7f5a76 2026-07-10 | - |
-| 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | 03d5feaf25 2026-07-08 | - |
-| 0244 | Memory OS recall: turn-seeded deterministic lexical retrieval, with provenanc... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0245 | Exempt goalless tasks from the per-goal WIP claim cap | Withdrawn | 03d5feaf25 2026-07-08 | - |
-| 0247 | Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) | Draft | 03d5feaf25 2026-07-08 | - |
+| 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | d1a7fa9756 2026-07-24 | - |
+| 0244 | Memory OS recall: turn-seeded deterministic lexical retrieval, with provenanc... | Draft | 0cbd738d42 2026-06-15 | - |
+| 0245 | Exempt goalless tasks from the per-goal WIP claim cap | Withdrawn | 59c024c890 2026-07-04 | - |
+| 0247 | Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) | Draft | d1a7fa9756 2026-07-24 | - |
 | 0248 | Board context without local authority classification | Draft | 7b62a87d44 2026-07-13 | - |
-| 0249 | Remove the dead `stale_factor` field (execute RFC-0239/0243/0244/0247) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0251 | Memory OS: record well, do not value — remove the scoring layer | Draft | 03d5feaf25 2026-07-08 | - |
+| 0249 | Remove the dead `stale_factor` field (execute RFC-0239/0243/0244/0247) | Draft | 6ac33d752e 2026-06-16 | - |
+| 0251 | Memory OS: record well, do not value — remove the scoring layer | Draft | 36bebccdfe 2026-06-17 | - |
 | 0252 | Fusion: 패널+심판(panel+judge) 심의 루프 (MASC 내장) | Draft | ba354b7bb0 2026-07-17 | - |
-| 0253 | Dashboard keeper-v2 surfaces: canonical spacing/radius token scale + off-scal... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0253 | Dashboard keeper-v2 surfaces: canonical spacing/radius token scale + off-scal... | Draft | ae523ba6d1 2026-06-17 | - |
 | 0254 | Shell IR Approval Gate — Autonomous Production Policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0255 | Withdraw inferred argv path policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0256 | Migrate hand-rolled Mutex lock/protect/unlock to Mutex.protect | Draft | 727a060579 2026-07-16 | - |
 | 0257 | Per-Keeper memory execution lane | Draft | 7b62a87d44 2026-07-13 | - |
-| 0259 | Memory OS — Volatile Claim Grounding, Retraction & Decay | Draft | 03d5feaf25 2026-07-08 | - |
+| 0259 | Memory OS — Volatile Claim Grounding, Retraction & Decay | Draft | afb089a3a4 2026-07-01 | - |
 | 0260 | Withdraw MASC provider-health gate | Draft | 7b62a87d44 2026-07-13 | - |
-| 0261 | gRPC LSP failed-initialize FD/process teardown | Draft | 03d5feaf25 2026-07-08 | - |
+| 0261 | gRPC LSP failed-initialize FD/process teardown | Draft | f126d7751e 2026-06-19 | - |
 | 0262 | Withdraw hierarchical Task-completion authority | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0263 | Withdraw actor-priority turn preemption | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0264 | Memory OS recall outcome-anchored eval harness | Draft | 03d5feaf25 2026-07-08 | - |
+| 0264 | Memory OS recall outcome-anchored eval harness | Draft | a616cd9947 2026-06-19 | - |
 | 0265 | Withdraw MASC modality capability rerouting | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0266 | Fusion async-completion wake + in-progress 가시성 | Draft | 03d5feaf25 2026-07-08 | - |
-| 0267 | Make task↔goal links visible and explicitly assignable | Draft | 03d5feaf25 2026-07-08 | - |
-| 0269 | Process Critic Loop for Keeper Work Traces | Draft | 03d5feaf25 2026-07-08 | - |
-| 0270 | CI Gate merge guard: block merges on a non-success CI Gate and trip on red main | Draft | 03d5feaf25 2026-07-08 | - |
+| 0266 | Fusion async-completion wake + in-progress 가시성 | Draft | 217be11d24 2026-06-20 | - |
+| 0267 | Make task↔goal links visible and explicitly assignable | Draft | 6c9029bcbf 2026-06-25 | - |
+| 0269 | Process Critic Loop for Keeper Work Traces | Draft | fae5c47f35 2026-06-20 | - |
+| 0270 | CI Gate merge guard: block merges on a non-success CI Gate and trip on red main | Draft | 61cb9cfe8f 2026-06-20 | - |
 | 0271 | Withdraw progress-based turn rejection and pause | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0272 | Memory OS — Episode Log Retention (bounded append for events.jsonl / episodes) | Draft | 03d5feaf25 2026-07-08 | - |
+| 0272 | Memory OS — Episode Log Retention (bounded append for events.jsonl / episodes) | Draft | f09d3015ed 2026-06-21 | - |
 | 0273 | Withdraw policy-bearing Keeper configuration tiers | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0274 | Workspace base_path SSOT — retire env runtime read, thread Workspace.config | Draft | 03d5feaf25 2026-07-08 | - |
+| 0274 | Workspace base_path SSOT — retire env runtime read, thread Workspace.config | Draft | 115a872077 2026-06-21 | - |
 | 0275 | Retired cognitive-triple removal record | Implemented | 434a7f5a76 2026-07-10 | - |
 | 0276 | Remove Keeper social-model self-report protocol | Implemented | 434a7f5a76 2026-07-10 | - |
 | 0277 | Fusion: 이종 패널 그룹(heterogeneous panel groups) + 발동 예산 제거 | Draft | 27c5da70fc 2026-07-16 | - |
-| 0278 | Fusion: 같은 model을 다른 prompt로 (same-model panels via panel labels) | Draft | 03d5feaf25 2026-07-08 | - |
+| 0278 | Fusion: 같은 model을 다른 prompt로 (same-model panels via panel labels) | Draft | 9052e25e02 2026-06-22 | - |
 | 0279 | Withdraw completion-contract result taxonomy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0280 | Fusion: validated preset type (Parse, don't validate) | Draft | 03d5feaf25 2026-07-08 | - |
-| 0281 | WebSocket transport SSOT — separate upgrade-attachment from session-protocol,... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0280 | Fusion: validated preset type (Parse, don't validate) | Draft | 60cca2c35e 2026-06-22 | - |
+| 0281 | WebSocket transport SSOT — separate upgrade-attachment from session-protocol,... | Draft | 7eaba002d2 2026-06-22 | - |
 | 0282 | Reduce Keeper persona to ordinary instructions | Implemented | 434a7f5a76 2026-07-10 | - |
 | 0283 | Fusion: judge-of-judges 위상 (flat/staged reducer) | Draft | ba354b7bb0 2026-07-17 | - |
 | 0284 | Supersede command-semantics guidance guards | Superseded | 7b62a87d44 2026-07-13 | - |
 | 0285 | Memory OS — Self-Observation Claim Volatility (closing RFC-0259's internal-st... | Draft | 434a7f5a76 2026-07-10 | - |
 | 0286 | Superseded exec and Keeper boundary diagnosis | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0287 | ws-direct — a single masc-owned WebSocket stack for server and client | Draft | 03d5feaf25 2026-07-08 | - |
+| 0287 | ws-direct — a single masc-owned WebSocket stack for server and client | Draft | 78f1c2fcf4 2026-06-23 | - |
 | 0288 | Remove per-Keeper goal-horizon fields | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0289 | Extract progress-classification into its own library for a single substantive... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0289 | Extract progress-classification into its own library for a single substantive... | Draft | 88996d4d8b 2026-06-24 | - |
 | 0290 | Generic keeper background-work tool (spawn → wake-on-completion) | Draft | ba354b7bb0 2026-07-17 | - |
-| 0291 | Closed SSE event-type sum + typed broadcast — RFC-0004 Phase A0 Wave 2 increment | Draft | 7b62a87d44 2026-07-13 | - |
+| 0291 | Closed SSE event-type sum + typed broadcast — RFC-0004 Phase A0 Wave 2 increment | Draft | 9144909e70 2026-07-21 | - |
 | 0292 | Complete lib/auth de-duplication — remove drifted Masc.Auth* test copies | Draft | b568e023bf 2026-07-16 | - |
 | 0293 | Withdraw policy-bearing execution endpoints | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0294 | Remove workspace Goal horizon | Implemented | 434a7f5a76 2026-07-10 | - |
 | 0295 | Withdraw derived fleet runtime bands | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0296 | CI skip-gate main-push safety-net: always run Build and Test on non-PR events | Draft | 03d5feaf25 2026-07-08 | - |
-| 0298 | fusion judge pool — judge 모델을 preset에서 분리 | Draft | 03d5feaf25 2026-07-08 | - |
+| 0296 | CI skip-gate main-push safety-net: always run Build and Test on non-PR events | Draft | bd0df6dad0 2026-06-28 | - |
+| 0298 | fusion judge pool — judge 모델을 preset에서 분리 | Draft | 5bdaa1b714 2026-06-29 | - |
 | 0299 | RFC-0299 — Typed-Boundary Sweep (string-classifier → closed-sum, dead SSOT re... | Draft | 7b62a87d44 2026-07-13 | - |
-| 0300 | RFC-0300 — Dashboard design-token scope consolidation (radius / shadow / type... | Draft | 03d5feaf25 2026-07-08 | - |
-| 0301 | Keeper 생성 미디어(이미지/오디오) 대시보드 노출 | Draft | 03d5feaf25 2026-07-08 | - |
-| 0302 | Keeper 메모리 파일 I/O off-main-domain 오프로드 (HOL fix) | Draft | 03d5feaf25 2026-07-08 | - |
+| 0300 | RFC-0300 — Dashboard design-token scope consolidation (radius / shadow / type... | Draft | 345224b01e 2026-06-30 | - |
+| 0301 | Keeper 생성 미디어(이미지/오디오) 대시보드 노출 | Draft | fa7bd52db2 2026-07-02 | - |
+| 0302 | Keeper 메모리 파일 I/O off-main-domain 오프로드 (HOL fix) | Draft | c4faea4305 2026-07-03 | - |
 | 0303 | Keeper wake without progress heuristics | Draft | 7b62a87d44 2026-07-13 | - |
 | 0304 | Withdraw Critical-class HITL escalation | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0305 | Withdraw global fail-closed governance policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
@@ -304,9 +304,9 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0308 | Withdraw verifier-required Task routing | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0309 | Withdrawn product-specific capability hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0311 | Withdraw deterministic evidence floors | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0312 | Keeper repo mappings are advisory default scope, not access caps | Accepted | 03d5feaf25 2026-07-08 | - |
+| 0312 | Keeper repo mappings are advisory default scope, not access caps | Accepted | c96f29136a 2026-07-07 | - |
 | 0315 | Typed wake-turn context and self-directed work lane | Active | 434a7f5a76 2026-07-10 | - |
-| 0316 | Merge gating convergence: enforce_admins=true + live Branch Protection Watchdog | Draft | 03d5feaf25 2026-07-08 | - |
+| 0316 | Merge gating convergence: enforce_admins=true + live Branch Protection Watchdog | Draft | 43b7c1110a 2026-07-07 | - |
 | 0317 | In-process Slack connector (Socket Mode) | In progress (PR-1/PR-2 landed; PR-3 implemented; PR-4 sidecar removal pending) | c8b5216a15 2026-07-18 | - |
 | 0318 | Replace risk-tier auto approval with request-local Auto Judge | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0319 | Replace hierarchical approval modes with Keeper Gate choices | Withdrawn | 7b62a87d44 2026-07-13 | - |
@@ -328,11 +328,23 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0341 | Keeper lifecycle projection SSOT | Draft | 7b62a87d44 2026-07-13 | - |
 | 0342 | Capability catalog overlay, deployment capability declarations, and boot posture | Draft | 25a1c593b5 2026-07-16 | - |
 | 0343 | Repo location SSOT (collapse dual-authority, attribute by git-remote) | Draft | f463ec7b82 2026-07-15 | - |
-| 0347 | Typed EffectIntent + capability floor at the Keeper Gate | Draft | 354027d3ae 2026-07-20 | - |
+| 0345 | Streaming idle-timeout fail-safe floor (#25128) | Draft | 5805c199d6 2026-07-20 | - |
+| 0346 | Gateway redelivery dedup: transcript single-authority, attention as wake-hint | Draft | f1d21b989d 2026-07-21 | - |
+| 0347 | Typed EffectIntent + capability floor at the Keeper Gate | Draft | 92c23f85a5 2026-07-21 | - |
+| 0348 | Bounded lane acquisition for durable keeper_msg writes (#25398) | Draft | dce1ab3b71 2026-07-21 | - |
+| 0349 | Restore a reachable compaction admission path | Draft | a48d59f034 2026-07-24 | - |
+| 0350 | Unbounded request-fiber admission (durable queue + lifecycle-sibling worker +... | Draft | 8c6f0e9742 2026-07-24 | - |
+| 0351 | Memory-first context management and compaction sunset | Draft | ee6e9bb8ca 2026-07-21 | - |
+| 0352 | Legacy Goal: RFC-0000 §3.2 ↔ §3.15 자기모순 해소 (결정 요청) | Draft | 6952c01917 2026-07-21 | - |
+| 0353 | 실패 분류가 모듈 경계에서 소실되는 결함 (결정 요청) | Draft | 25993cb494 2026-07-21 | - |
+| asyn | Offload the structured-log durable append off the emitting fiber | Draft | 3ec8a423be 2026-07-21 | - |
+| chec | Immutable boot-pinned root capability for checkpoint containment | Draft | 810be9566e 2026-07-18 | - |
+| comp | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | ca5652a705 2026-07-21 | - |
 | conn | Durable Keeper chat receipts and connector delivery settlement | Active | 9d59e83655 2026-07-14 | - |
 | elim | Withdrawn command-policy classification experiment | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | 7b62a87d44 2026-07-13 | - |
-| runt | Per-runtime note field & dashboard surfacing | Draft | 03d5feaf25 2026-07-08 | - |
+| keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | a48d59f034 2026-07-24 | - |
+| runt | Per-runtime note field & dashboard surfacing | Draft | f3e073c3c9 2026-06-25 | - |
+| sche | Separate schedule definitions, occurrence delivery, and work outcomes | Draft | ee2f49fe0a 2026-07-24 | - |
 | type | Withdraw product-specific egress effect classification | Withdrawn | 7b62a87d44 2026-07-13 | - |
 
 ### 신규 RFC

--- a/docs/rfc/RFC-scheduled-occurrence-lifecycle.md
+++ b/docs/rfc/RFC-scheduled-occurrence-lifecycle.md
@@ -1,0 +1,1328 @@
+---
+rfc: "scheduled-occurrence-lifecycle"
+title: "Separate schedule definitions, occurrence delivery, and work outcomes"
+status: Draft
+created: 2026-07-24
+updated: 2026-07-24
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0234", "0290", "0315", "connector-ambient-attention-wake"]
+implementation_prs: []
+---
+
+# RFC: Scheduled occurrence lifecycle and terminal evidence authority
+
+## 0. Summary
+
+MASC currently closes a scheduled execution as `Succeeded` when the synchronous
+schedule consumer returns `Ok` after durable Keeper queue enqueue. The actual
+Keeper lifecycle continues asynchronously: the target may be unregistered or
+not running, the stimulus may wait in the queue, a turn may start much later,
+and the turn may ACK, requeue, escalate, or be cancelled. Those later facts are
+durably recorded, but they do not flow back into the schedule execution state.
+
+This is not a collection of unrelated bugs. It is one ownership error:
+
+> A schedule occurrence is an asynchronous delivery saga, but the schedule
+> runner models it as a synchronous consumer call and declares terminal success
+> at the first durable handoff.
+
+This RFC preserves the surviving boundary decision from withdrawn RFC-0234:
+
+1. the Scheduler persists future intent and due conditions;
+2. the Scheduler wakes the owning Keeper lane when an occurrence becomes due;
+3. the consumer owns payload interpretation;
+4. every external effect still crosses the ordinary Keeper Gate at execution
+   time.
+
+The RFC adds the missing lifecycle model:
+
+- `ScheduleDefinition` owns recurrence and future intent;
+- `ScheduleOccurrence` owns one exact due instant and its delivery lifecycle;
+- `DeliveryAttempt` owns queue and wake admission evidence;
+- `WorkOutcome` is optional evidence owned by a typed executor, never inferred
+  from a natural-language Keeper wake.
+
+An append-only, per-schedule occurrence ledger becomes the authority for
+operator truth. The existing Keeper event queue remains the authority for
+leases and settlements. Its durable outbox commits exact transition rows to the
+reaction ledger, and a non-blocking projector carries schedule rows back to the
+occurrence ledger. Dashboard and health surfaces derive from the occurrence
+ledger rather than reconstructing completion from queue absence and partial
+reaction evidence.
+
+The central invariant is:
+
+> No terminal status exists without exact, durable terminal evidence for the
+> same occurrence identity.
+
+For `masc.keeper_wake`, terminal delivery ACK means that the Keeper event
+queue's settlement policy accepted the exact source as handled. It does **not**
+mean that the model performed the natural-language request. Only a future typed
+job contract with a source-owned terminal receipt may claim business work
+success.
+
+## 1. Problem
+
+### 1.1 The synchronous consumer boundary closes asynchronous work
+
+`Schedule_runner.consumer.dispatch` returns:
+
+```ocaml
+(Yojson.Safe.t, consumer_dispatch_error) result
+```
+
+The production Keeper-wake consumer:
+
+1. validates enough of the payload to build `Schedule_due`;
+2. durably enqueues the stimulus;
+3. records stimulus evidence;
+4. calls `Keeper_registry.wakeup_running`;
+5. logs the wake admission outcome;
+6. returns `Ok receipt`.
+
+`Schedule_runner.dispatch_candidate` interprets that `Ok` as completion and
+calls `Schedule_store.complete_running`. The store marks the matching execution
+`Execution_succeeded`; a one-shot definition becomes `Succeeded`, and a
+recurring definition advances immediately to its next `Scheduled` due time.
+
+The returned receipt says `occurrence_status=awaiting_ack`, which is itself
+proof that the occurrence has not reached a terminal queue settlement. The
+schedule status nevertheless says succeeded.
+
+The type cannot express the real result:
+
+```text
+accepted asynchronously, queue durable, wake deferred, terminal pending
+```
+
+That missing variant is the first corrupted boundary.
+
+### 1.2 One mutable request row represents two different entities
+
+`Schedule_domain.schedule_request` contains:
+
+- durable definition facts: actors, recurrence, payload, source;
+- the next mutable `due_at`;
+- a `status` sum containing both definition states and occurrence states:
+  `Scheduled | Due | Running | Succeeded | Failed | Cancelled | Expired`.
+
+For a recurring schedule, the same row moves back to `Scheduled` as soon as the
+consumer accepts one occurrence, even while that occurrence remains pending or
+inflight in the Keeper event queue. The row therefore cannot answer:
+
+- how many occurrences are outstanding;
+- which occurrence is deferred, leased, requeued, or escalated;
+- whether cancellation applies to future due instants or already accepted
+  occurrences;
+- whether expiry still applies after queue acceptance;
+- whether another occurrence may overlap the current one.
+
+`execution_record` does not repair this mismatch. It records the short runner
+dispatch attempt and stores the consumer receipt, but it is named and projected
+as execution history. Its `Execution_succeeded` does not represent Keeper work
+terminal success.
+
+### 1.3 There is no owner for the cross-store saga
+
+The production path crosses these durable authorities:
+
+```text
+schedules.json snapshot
+  -> schedule wake-signal JSONL
+  -> signal_keys.json fence
+  -> Keeper durable event queue
+  -> Keeper transition outbox
+  -> Keeper reaction ledger
+  -> Keeper turn/provider/tool evidence
+```
+
+Each subsystem contains useful local safety mechanisms. The event queue has
+exact stimulus identity, durable leases, typed settlements, and a transition
+outbox. The reaction ledger has deterministic event ids and replay-safe
+projection. The occurrence id is derived from stable persisted facts.
+
+What is missing is an aggregate that owns the transition between those stores.
+Consequences include:
+
+- signal JSONL append and `signal_keys.json` commit are not failure-atomic;
+- a wake admission outcome is reduced to a log line;
+- a startup `Running` recovery failure can be attempted only once and then
+  disappear behind green idle ticks;
+- recurring definitions advance while old occurrences remain outstanding;
+- Dashboard must join mutable snapshots and several ledgers heuristically;
+- one global schedule snapshot grows and rewrites with all execution history.
+
+This is a distributed transaction implemented as unrelated local writes rather
+than an explicit idempotent saga.
+
+### 1.4 A Keeper wake cannot prove business work success
+
+`masc.keeper_wake` carries a natural-language `message`. The event queue ACKs a
+claimed source when the Keeper cycle reaches the queue settlement policy's
+acknowledged outcome. A completed turn can ACK even if the model read the
+message and chose another action. This is intentional for other stimulus
+families: delivery of an approval resolution, for example, is distinct from
+whether the model consumes the durable grant in that turn.
+
+Therefore these claims have different strength:
+
+| Evidence | What it proves | What it does not prove |
+|---|---|---|
+| signal persisted | an occurrence was durably materialized | queue acceptance |
+| queue accepted | the exact stimulus is durable or already present | runnable Keeper |
+| wake signaled | a running Keeper sleep was interrupted | turn start |
+| wake deferred | the queue preserved the stimulus | delivery failure |
+| turn started | a cycle leased the stimulus | completed cycle |
+| queue ACK | event-queue settlement accepted the source as handled | requested business action |
+| typed work receipt | the owning executor reached a stated terminal | unrelated effects |
+
+The current vocabulary collapses the first two rows into `Succeeded`, and the
+Dashboard may label even `stimulus recorded` or `turn started` as `완료`.
+
+### 1.5 Exact reaction evidence discards negative settlement meaning
+
+The reaction ledger stores closed settlement kinds:
+
+- `Event_queue_ack`
+- `Event_queue_cancelled`
+- `Event_queue_requeued`
+- `Event_queue_escalated`
+- `Event_queue_no_compaction`
+
+The exact evidence projection exposed to scheduled automation retains ACK and
+cancellation booleans, but it does not retain requeue or escalation as an
+occurrence result. The Dashboard then treats `matched_stimulus`,
+`matched_turn_started`, and `matched_consumed_ack` as the same healthy drained
+state.
+
+The projection is not merely missing presentation detail. It removes precisely
+the evidence needed to distinguish a successful delivery from retry or
+terminal escalation.
+
+### 1.6 Payload, ownership, and time invariants are validated too late
+
+The schedule core intentionally treats the payload as an opaque typed envelope.
+That does not require accepting unvalidated future intent.
+
+Current `masc.keeper_wake` behavior has three authorities for one target:
+
+- `scheduled_by.id` controls pre-due Keeper visibility;
+- `payload.body.keeper_name` controls actual dispatch;
+- the authenticated dispatch context identifies the producer.
+
+They may disagree. Unknown body fields may be persisted and then silently
+dropped by the consumer. The full message is durable in the queue, but the
+prompt renders only a bounded preview and points to no deterministic
+schedule-occurrence detail surface.
+
+Timestamp fields also accept non-finite or unsupported epoch values. A value can
+be committed before ISO presentation fails, leaving one malformed input in the
+global snapshot's failure domain.
+
+Opaque scheduling and closed producer contracts are compatible: the schedule
+core need not understand consumer fields, but the producer/consumer schema
+authority must validate the complete envelope before persistence.
+
+### 1.7 Live evidence
+
+The 2026-07-24 runtime audit on
+`3691462b32b97c4082b557d6a45d82de280d13a3` observed:
+
+- one hourly Keeper schedule with 17 pending `Schedule_due` stimuli;
+- deferred dispatches logged as unregistered while runner dispatch recorded
+  `succeeded`;
+- one occurrence enqueued at `02:00:05Z`, delivered at `03:08:49Z`, and
+  escalated at `03:08:54Z`, while its schedule execution remained `succeeded`;
+- 27 observed v4 schedule stimuli conserved as 18 pending, 7 ACK, and
+  2 escalation records;
+- no duplicate occurrence in the observed signal sample, but no crash-window
+  proof for signal append versus fence persistence.
+
+The substrate is real and usually conserves work. The operator semantics are
+what fail.
+
+## 2. Goals
+
+1. Give every due instant one exact, durable `ScheduleOccurrence` identity.
+2. Preserve queue acceptance, wake admission, lease, requeue, escalation,
+   cancellation, expiry, and ACK as distinct typed facts.
+3. Make occurrence projection monotonic and replayable from append-only events.
+4. Keep schedule definition state separate from occurrence delivery state.
+5. Keep business work outcome separate from Keeper wake delivery.
+6. Apply recurrence misfire and overlap policy identically whether the
+   Scheduler, Keeper, or provider was unavailable.
+7. Preserve owning-Keeper lane independence: one corrupt schedule cannot block
+   unrelated schedules or Keeper lanes.
+8. Validate target, payload schema, actors, and timestamps before durable
+   admission.
+9. Make Dashboard, API, health, and telemetry consume the same typed occurrence
+   projection.
+10. Reuse the existing event queue, transition outbox, reaction ledger, and
+    occurrence identity rather than creating a second delivery engine.
+
+## 3. Non-goals
+
+- The Scheduler does not authorize external effects. Keeper Gate remains the
+  only effect authorization boundary.
+- This RFC does not infer business success from model text, tool-name matching,
+  turn completion, or queue ACK.
+- This RFC does not make a natural-language Keeper wake into a deterministic
+  job.
+- This RFC does not unify every Keeper stimulus family under the schedule
+  domain. It reuses their common event-queue settlement substrate.
+- This RFC does not promise distributed exactly-once execution. It requires
+  durable at-least-once handoff with idempotent, exact-id transitions.
+- This RFC does not add an external database. Existing workspace-local durable
+  primitives are sufficient.
+- This RFC does not retain parallel legacy and new authorities after cutover.
+
+## 4. Terminology and semantic contract
+
+### 4.1 ScheduleDefinition
+
+Future intent owned by one Keeper lane:
+
+```ocaml
+type definition_state =
+  | Active
+  | Paused
+  | Exhausted
+  | Cancelled
+  | Expired
+
+type schedule_definition =
+  { schedule_id : Schedule_id.t
+  ; owner_lane : Keeper_name.t
+  ; requested_by : Schedule_actor.t
+  ; scheduled_by : Schedule_actor.t
+  ; created_at : Finite_timestamp.t
+  ; first_due_at : Finite_timestamp.t
+  ; payload : Schedule_payload.t
+  ; recurrence : Schedule_recurrence.t
+  ; backlog_policy : Schedule_backlog_policy.t
+  ; definition_state : definition_state
+  ; definition_version : int
+  }
+```
+
+Definition state never becomes `Running`, `Succeeded`, or `Failed`. Those words
+describe an occurrence or work result, not future intent.
+
+`Exhausted` means the definition has no future due instant. A one-shot
+definition becomes exhausted when its only occurrence is materialized,
+regardless of that occurrence's later delivery result.
+
+`owner_lane` is outside the opaque payload and is the only target used by
+pre-due visibility, dispatch, cancellation authorization, and queue routing.
+
+`next_due_at` is a rebuildable projection from `first_due_at`, recurrence, and
+the last materialized/skipped occurrence evidence. It is not an independently
+mutable definition fact.
+
+### 4.2 ScheduleOccurrence
+
+One exact due instant:
+
+```ocaml
+type occurrence_key =
+  { occurrence_id : Schedule_occurrence_id.t
+  ; schedule_id : Schedule_id.t
+  ; definition_version : int
+  ; due_at : Finite_timestamp.t
+  ; payload_digest : Payload_digest.t
+  }
+```
+
+The existing occurrence-id derivation from `schedule_id`, `due_at`, and
+`payload_digest` remains valid. `definition_version` is persisted as evidence
+and must be covered by the digest or the occurrence-id derivation if it can
+change dispatch meaning.
+
+An occurrence owns delivery, not future recurrence.
+
+### 4.3 DeliveryAttempt
+
+A retryable handoff attempt for one occurrence:
+
+```ocaml
+type wake_admission =
+  | Signaled
+  | Deferred_unregistered
+  | Deferred_not_running of Keeper_phase.t
+  | Deferred_lifecycle of Keeper_lifecycle_admission.denial
+
+type delivery_settlement =
+  | Acknowledged
+  | Cancelled of cancellation_evidence
+  | Escalated of Keeper_event_queue.escalation_reason
+  | Expired_before_lease
+  | Superseded of Schedule_occurrence_id.t
+
+type delivery_attempt =
+  { occurrence_id : Schedule_occurrence_id.t
+  ; attempt : int
+  ; queue_acceptance : queue_acceptance option
+  ; wake_admission : wake_admission option
+  ; lease_id : Keeper_event_queue.Lease_id.t option
+  ; settlement : delivery_settlement option
+  }
+```
+
+`Requeue` is an attempt transition, not an occurrence terminal. It closes the
+current lease attempt, increments the delivery attempt ordinal, and returns the
+same occurrence identity to ready/pending state.
+
+### 4.4 WorkOutcome
+
+Optional evidence from an executor that owns a typed job:
+
+```ocaml
+type completion_contract =
+  | Delivery_only
+  | Typed_source_terminal of
+      { source_kind : string
+      ; schema_version : int
+      }
+```
+
+`masc.keeper_wake` is always `Delivery_only`. Its strongest success is
+`delivery_settlement=Acknowledged`.
+
+A future typed scheduled job may use `Typed_source_terminal`, but only if:
+
+- the payload schema identifies the executor;
+- the executor preserves `occurrence_id`;
+- its terminal receipt has a closed success/failure/cancelled sum;
+- its external effects still cross Keeper Gate;
+- the occurrence ledger records the source receipt without reinterpreting it.
+
+The schedule subsystem may display such a receipt but does not manufacture it.
+
+### 4.5 Identity chain
+
+The E2E chain preserves distinct identities rather than renaming one id at each
+boundary:
+
+| Identity | Meaning | Relationship |
+|---|---|---|
+| `schedule_id` | future-intent definition | parent of occurrences |
+| `occurrence_id` | one exact due instant | stable across every delivery retry |
+| `stimulus_id` | event-queue source identity | exactly `occurrence_id` for `Schedule_due` |
+| `delivery_attempt_id` | one lease/retry attempt | derived from occurrence id + ordinal |
+| `lease_id` | event-queue lease authority | referenced by attempt evidence |
+| `turn_id` | Keeper cycle correlation | optional link from lease/turn evidence |
+| `execution_id` | actual provider/tool execution | optional work correlation, never occurrence identity |
+
+The legacy schedule `execution_id` is imported as a legacy dispatch-attempt
+reference. New schedule delivery does not mint a second generic execution id.
+
+## 5. Authority model
+
+| Fact | Authoritative owner | Projections/consumers |
+|---|---|---|
+| definition and recurrence | append-only definition event ledger | definition projection, tools, Dashboard, runner |
+| due occurrence identity | occurrence ledger | runner, Dashboard, telemetry |
+| queue pending/inflight | Keeper event queue | occurrence settlement projector |
+| wake admission | Keeper registry typed outcome recorded as occurrence event | health, Dashboard |
+| lease settlement | Keeper event queue transition/outbox | reaction ledger; occurrence projector consumes its exact rows |
+| Keeper turn/provider/tool result | Keeper turn/execution stores | optional typed work receipt |
+| operator view | occurrence projection | Dashboard/API only |
+
+No Dashboard code, health counter, or log parser may become a lifecycle
+authority.
+
+The reaction ledger remains the durable, replayable fan-out journal for
+Keeper-runtime transitions. The schedule occurrence ledger is the schedule
+product authority. The occurrence settlement projector consumes the exact
+transition receipt already preserved in reaction-ledger rows and uses that
+source event id as its idempotency identity. It never infers a settlement from
+reaction-ledger absence.
+
+## 6. Definition and occurrence event algebra
+
+### 6.1 Definition events
+
+Definition mutation is append-only and actor-bearing:
+
+```ocaml
+type definition_event =
+  | Created of created_definition
+  | Updated of
+      { previous_version : int
+      ; next_version : int
+      ; changed_fields : definition_change list
+      }
+  | Paused of actor_reason
+  | Resumed of actor_reason
+  | Cancelled of
+      { actor_reason : actor_reason
+      ; scope : cancellation_scope
+      }
+  | Definition_expired of expiry_evidence
+  | Due_window_skipped of
+      { first_due_at : Finite_timestamp.t
+      ; last_due_at : Finite_timestamp.t
+      ; count : int
+      ; policy : misfire_policy
+      ; reason : skip_reason
+      }
+  | Latest_due_coalesced of
+      { previous_watermark : Finite_timestamp.t option
+      ; latest_due_at : Finite_timestamp.t
+      ; coalesced_count : int
+      ; blocked_by : Schedule_occurrence_id.t
+      }
+  | Legacy_definition_imported of legacy_definition_evidence
+  | Definition_evidence_quarantined of quarantine_evidence
+```
+
+Every mutation carries authenticated actor, source surface, timestamp, reason,
+previous definition version, and next definition version. The JSON definition
+record is a rebuildable materialized projection, not a lifecycle audit
+authority.
+
+There are no schedule-specific `Approved` or `Rejected` definition events.
+Those labels in the historical #21955 proposal belonged to the approval
+hierarchy withdrawn by RFC-0234. External-effect Gate decisions remain in the
+ordinary Gate/effect evidence, not the schedule lifecycle.
+
+### 6.2 Occurrence events
+
+The append-only ledger uses a closed event sum. Names below are semantic; exact
+OCaml module names are implementation detail.
+
+```ocaml
+type occurrence_event =
+  | Materialized of materialized
+  | Queue_accepted of queue_receipt
+  | Wake_admission_recorded of wake_admission
+  | Lease_started of lease_receipt
+  | Turn_started of turn_receipt
+  | Requeued of requeue_receipt
+  | Delivery_acknowledged of ack_receipt
+  | Delivery_cancelled of cancellation_receipt
+  | Delivery_escalated of escalation_receipt
+  | Expired_before_lease of expiry_receipt
+  | Superseded of supersession_receipt
+  | Work_terminal_recorded of typed_work_receipt
+  | Legacy_evidence_imported of legacy_evidence
+  | Evidence_quarantined of quarantine_evidence
+```
+
+Every row contains:
+
+- `schema`;
+- deterministic `event_id`;
+- `occurrence_id`;
+- `schedule_id`;
+- `owner_lane`;
+- `recorded_at`;
+- event payload;
+- source authority and source event id;
+- actor/reason where applicable.
+
+### 6.3 Projection states
+
+The event stream projects to:
+
+```ocaml
+type delivery_phase =
+  | Materialized
+  | Queue_pending
+  | Leased
+  | Turn_in_progress
+  | Retry_wait of requeue_reason
+  | Settled of delivery_settlement
+  | Evidence_invalid of quarantine_reason
+
+type occurrence_projection =
+  { phase : delivery_phase
+  ; latest_wake_admission : wake_admission option
+  ; attempts : delivery_attempt list
+  ; work_outcome : typed_work_receipt option
+  }
+```
+
+Wake admission is an evidence axis, not a delivery phase. `Signaled` means a
+currently running Keeper's sleep was interrupted; a deferred value explains why
+that hint was not applied. The durable queue may still be leased later through
+registration recovery or a periodic cycle, so neither outcome controls the
+phase transition.
+
+`Turn_started` does not imply ACK. `Delivery_acknowledged` requires an exact
+event-queue settlement receipt. Escalation and cancellation are terminal and
+cannot be overwritten by later ACK. Conflicting terminal events quarantine the
+occurrence and degrade schedule health.
+
+```text
+Materialized
+  -> Queue_pending
+       |    `-- wake admission evidence: Signaled | Deferred_*
+       `-> Leased -> Turn_in_progress
+                       |-> Requeued -> Queue_pending
+                       |-> Delivery_acknowledged
+                       |-> Delivery_escalated
+                       `-> Delivery_cancelled
+
+Materialized/Queue_pending -> Expired_before_lease
+Materialized/Queue_pending -> Superseded
+```
+
+### 6.4 Transition invariants
+
+1. `Materialized` is the first event.
+2. An event for another `schedule_id` or payload digest cannot join the
+   occurrence.
+3. `Queue_accepted` is idempotent for one occurrence.
+4. `Wake_admission_recorded` cannot precede queue acceptance, but lease and
+   settlement do not require a `Signaled` wake event.
+5. Each lease start has one exact lease/attempt ordinal.
+6. Requeue closes only its matching attempt and preserves occurrence identity.
+7. ACK, cancellation, escalation, expiry, and supersession are mutually
+   exclusive occurrence delivery terminals.
+8. `Work_terminal_recorded` cannot change delivery settlement.
+9. `Delivery_acknowledged` cannot manufacture `Work_terminal_recorded`.
+10. Duplicate deterministic event ids are replay, not additional transitions.
+11. Unknown event variants or impossible transitions produce typed quarantine;
+    they never become permissive success.
+12. Projection is deterministic and independent of filesystem enumeration
+    order.
+13. Definition update never mutates an already materialized occurrence; the
+    occurrence retains its immutable owner, due time, payload snapshot/digest,
+    deadline, and definition version.
+14. `owner_lane` is immutable. Moving future intent to another lane creates a
+    new definition with explicit provenance.
+
+## 7. Storage layout and isolation
+
+The current global `schedules.json` combines every definition and execution
+record in one rewrite and decode failure domain. Replace it with a versioned,
+owner- and schedule-partitioned namespace:
+
+```text
+.masc/schedules/occurrence-v1/
+  owners/<owner-lane>/
+    definitions/<schedule-id>/projection.json
+    definitions/<schedule-id>/events/YYYY-MM/DD.jsonl
+    occurrences/<schedule-id>/YYYY-MM/DD.jsonl
+    occurrence-index/<schedule-id>.json
+    outbox/<occurrence-id>.json
+  migration.json
+```
+
+Exact filenames may change during implementation, but these properties are
+required:
+
+- one malformed definition cannot prevent decoding unrelated definitions;
+- one malformed occurrence row is quarantined with schedule and row identity;
+- history pagination for one schedule does not materialize or sort global
+  history;
+- mutation does not rewrite all historical execution events;
+- outbox projections are exact-occurrence scoped and rebuildable from
+  nonterminal `Materialized` events;
+- paths derive from `Workspace_utils.config`; no ambient global root;
+- owner and schedule path components use existing validated typed names/ids;
+- append uses the existing atomic JSONL substrate;
+- index writes are bounded per schedule and are rebuildable from the ledger.
+
+The occurrence ledger event id is the logical idempotency fence. Replayed
+physical rows with the same deterministic event id collapse to one transition.
+The separate `signal_keys.json` authority is retired. An unchanged idle tick
+performs no durable rewrite.
+
+Definition mutation and occurrence materialization for one schedule are
+serialized under its existing workspace file-lock discipline. The runner
+re-reads the latest definition version after acquiring that lock. Concurrent
+update or cancellation either commits before materialization and changes the
+future occurrence, or commits after materialization and affects only later
+occurrences; it cannot rewrite an occurrence already in the event queue.
+Occurrence outbox and settlement projectors use the same per-schedule event
+append lock, so they may repair causal prerequisites before appending a later
+fact without racing another projector.
+
+## 8. Failure-atomic handoff protocol
+
+### 8.1 Materialization
+
+For each due instant selected by recurrence policy, the sole authoritative
+commit is one append of `Materialized`. The event contains:
+
+- the complete occurrence key;
+- the owner lane and immutable definition-version/payload-digest reference;
+- the recurrence decision and next due cursor;
+- the backlog-policy evidence;
+- the enqueue intent.
+
+Only after that append succeeds may projectors update the rebuildable
+per-schedule index, definition due projection, and exact occurrence outbox
+file. A crash between those projections is repaired by replaying nonterminal
+`Materialized` events. The occurrence event is therefore the durable outbox
+intent; the outbox file is an efficient projection, not a second authority.
+
+If the event append fails, no queue side effect is allowed. On retry, the same
+due facts derive the same occurrence id.
+
+### 8.2 Queue handoff
+
+The occurrence outbox projector:
+
+1. reads the exact outbox entry and exact reaction evidence;
+2. if an exact terminal settlement already exists, backfills any missing
+   `Queue_accepted` evidence from that receipt, appends the terminal, and does
+   not recreate the stimulus;
+3. otherwise calls durable Keeper queue enqueue with `occurrence_id` as the
+   idempotency identity;
+4. receives `Enqueued | Already_present | Storage_error`;
+5. appends `Queue_accepted` for either successful acceptance result;
+6. records the typed `wakeup_running` outcome as
+   `Wake_admission_recorded`;
+7. retires the occurrence outbox only after both events are durable.
+
+Crash cases are safe:
+
+- crash before queue enqueue: outbox retries;
+- crash after enqueue but before `Queue_accepted`: retry gets
+  `Already_present`, or finds exact stimulus/settlement evidence after a fast
+  drain, then appends the missing acceptance event;
+- crash after event append but before outbox retirement: deterministic event id
+  makes replay idempotent;
+- wake signal lost with process death: the durable queue remains authoritative,
+  and registration/recovery reloads it.
+
+The wake outcome is never allowed to change queue acceptance into failure. A
+deferred wake is a truthful nonterminal state with durable work preserved.
+
+### 8.3 Queue settlement return
+
+The existing Keeper event queue transition outbox remains single-purpose and
+does not wait on schedule storage:
+
+1. commit the queue transition and transition outbox entry;
+2. append the complete typed transition receipt to the reaction ledger; for
+   `Schedule_due`, the row preserves a typed source reference containing
+   `occurrence_id`, `schedule_id`, `due_at`, and `payload_digest`;
+3. retire the event-queue outbox under its existing idempotent contract;
+4. let a separate occurrence settlement projector consume reaction-ledger rows
+   whose stimulus kind is `Schedule_due`;
+5. append the matching occurrence event using
+   `stimulus_id=occurrence_id` and the reaction row's deterministic event id;
+6. advance a per-owner settlement projection cursor only after durable
+   occurrence append.
+
+Before appending lease or settlement evidence, the projector verifies that
+`Materialized` exists. If `Queue_accepted` is missing because the process died
+after enqueue, the exact transition receipt is sufficient causal proof to
+append a typed recovered acceptance before the later event. Recovery may
+backfill evidence; it may not invent a wake admission outcome.
+
+A lost cursor only causes replay; the deterministic source event id makes the
+occurrence append idempotent. A schedule-store failure leaves reaction evidence
+available for retry and degrades schedule health, but does not hold the Keeper
+event queue's sole transition outbox or block unrelated stimuli in that lane.
+The projector routes by the typed source reference; it must not parse a
+human-readable stimulus summary or scan every schedule to discover ownership.
+
+Reaction-ledger retention may not delete an unprojected schedule settlement
+row. The per-owner occurrence projection cursor is therefore a retention fence.
+Malformed rows that cannot carry an identity are recorded as shard-level
+quarantine and advance by physical row position so one bad row cannot create an
+infinite replay loop.
+
+The projector maps:
+
+| Event queue settlement | Occurrence event |
+|---|---|
+| `Ack` / accepted source terminal delivery | `Delivery_acknowledged` |
+| `Cancel_accepted` | `Delivery_cancelled` |
+| `Requeue reason` | `Requeued` |
+| `Escalate reason` | `Delivery_escalated` |
+
+An occurrence projection failure leaves schedule health degraded. It does not
+roll back an already committed queue transition or block queue settlement for
+another schedule, stimulus family, or Keeper lane.
+
+### 8.4 Startup reconciliation
+
+Startup no longer performs a best-effort one-shot mutation of all `Running`
+schedule rows.
+
+Before new materialization for an owner lane, a bounded reconciler:
+
+1. rebuilds/drains occurrence outbox projections;
+2. lets the existing event-queue projector drain transition outboxes to the
+   reaction ledger;
+3. replays the schedule settlement cursor over exact reaction rows;
+4. replays nonterminal occurrence projections;
+5. compares queue exact-id presence/lease state for unresolved handoffs;
+6. repairs missing idempotent projection events;
+7. records typed quarantine for contradictory evidence.
+
+The owner lane remains `degraded_reconciling` until reconciliation succeeds or
+reaches a typed operator-action terminal. Other owner lanes continue.
+
+There is no process-local `Running` definition state to steal. Lease ownership
+remains inside the Keeper event queue, which already owns process/restart
+recovery.
+
+## 9. Recurrence, overlap, expiry, and cancellation
+
+### 9.1 Backlog policy
+
+Every recurring definition carries a closed policy:
+
+```ocaml
+type misfire_policy =
+  | Skip_missed of { grace_sec : int }
+  | Fire_latest
+  | Catch_up of
+      { max_occurrences : int
+      ; max_age_sec : int
+      ; max_materialized_per_tick : int
+      }
+
+type overlap_policy =
+  | Forbid_overlap
+  | Keep_latest_pending
+  | Allow_up_to of { max_outstanding : int }
+```
+
+The default for recurring `masc.keeper_wake` is:
+
+```text
+misfire = Fire_latest
+overlap = Keep_latest_pending
+```
+
+Rationale: a natural-language wake is usually current-attention intent, not a
+financial/event log that must replay every missed hour. The current unbounded
+offline backlog is unsafe. Producers that require every occurrence must opt
+into bounded `Catch_up`.
+
+`Keep_latest_pending` means:
+
+- at most one nonterminal occurrence exists for the definition;
+- if a newer due instant arrives while an occurrence is pending, append a
+  durable latest-due watermark, settle the pending occurrence as superseded,
+  and materialize the watermark only after that terminal is durable;
+- if an occurrence is leased, retain only the newest due instant as a durable
+  coalesced watermark and materialize it after the lease terminal;
+- each skipped/superseded due window is recorded with reason, first/last due
+  instant, and count;
+- no occurrence disappears silently.
+
+Large missed windows are summarized as bounded range evidence. The runner must
+not allocate or append one row for every theoretical due instant merely to
+record that policy skipped or coalesced them. `Catch_up` is the only policy that
+materializes multiple missed occurrences, and its count, age, outstanding, and
+per-tick bounds are mandatory.
+
+The same algorithm runs after Scheduler downtime and while a Keeper is
+unregistered, paused, lifecycle-deferred, or provider-failing. Component
+availability does not change recurrence semantics.
+
+Outstanding counts come from nonterminal occurrence projections, not from a
+best-effort queue snapshot. A forward wall-clock jump is handled as misfire;
+a backward jump cannot rematerialize an already committed due instant because
+its occurrence identity and due cursor are durable.
+
+### 9.2 Expiry
+
+Definition expiry prevents future occurrence materialization.
+
+Each materialized occurrence also carries an immutable delivery deadline:
+
+- expiry before queue acceptance: settle `Expired_before_lease`;
+- expiry while pending: exact-id queue cancellation settles
+  `Expired_before_lease`;
+- expiry after lease start does not asynchronously kill a running Keeper turn;
+  the lease reaches its normal settlement and records that the deadline passed
+  during delivery.
+
+No `Schedule_due` stimulus may outlive its occurrence deadline without an
+explicit projected state.
+
+### 9.3 Cancellation
+
+Definition cancellation and occurrence cancellation are different commands.
+
+The public API requires a typed scope:
+
+```ocaml
+type cancellation_scope =
+  | Future_occurrences_only
+  | Future_and_pending_occurrences
+```
+
+- both scopes stop future materialization;
+- `Future_and_pending_occurrences` requests exact-id cancellation for all
+  non-leased queue occurrences;
+- an active lease is not physically deleted; cancellation races are resolved
+  by the event queue's owner-fenced accepted-cancellation contract;
+- actor, reason, requested scope, affected occurrence ids, and race outcome are
+  append-only evidence.
+
+There is no silent default that lets the tool response claim a broad cancel
+while only mutating a definition snapshot.
+
+## 10. Payload, ownership, and admission
+
+### 10.1 One owner/target authority
+
+For Keeper-owned schedule tools:
+
+- `owner_lane` is derived from authenticated dispatch context;
+- `keeper_name` is removed from the consumer payload body;
+- visibility, dispatch, cancellation, recurrence, and storage partition use
+  `owner_lane`.
+
+For an operator creating a cross-Keeper schedule:
+
+- the target Keeper is an explicit top-level typed `owner_lane`;
+- the route requires the appropriate operator capability;
+- requested actor, authenticated scheduling actor, owner lane, and reason are
+  immutable definition events.
+
+A payload cannot redirect work to another lane.
+
+### 10.2 Closed producer schema
+
+`masc.keeper_wake` v1 admits only:
+
+- `message`;
+- optional `title`;
+- optional typed `urgency`.
+
+Unknown fields are rejected before persistence. If a new field such as
+connector channel routing is required, it receives a new schema version and an
+end-to-end DTO, prompt, retrieval, and test contract.
+
+The definition event for each immutable version owns the full validated
+payload. An occurrence stores that version and payload digest, and the event
+queue carries a delivery copy rather than becoming the content SSOT. The full
+message remains retrievable by exact occurrence id from a typed schedule
+occurrence detail tool/surface, which resolves the immutable definition version
+and verifies the digest. Prompt truncation is presentation only and must include
+that valid pointer. It must not point to a Board post that does not exist.
+
+Occurrence detail requires either owner-lane identity or operator read
+capability. Append-only payload history does not widen message visibility.
+
+### 10.3 Time validation
+
+One domain validator admits all schedule timestamps:
+
+- finite only;
+- within the supported ISO/`Unix.gmtime` range;
+- consistent ordering for requested, due, expiry, and update times;
+- stable typed rejection before persistence.
+
+Persisted invalid rows are quarantined individually. List and Dashboard
+surfaces show the affected schedule id and typed reason rather than failing the
+whole fleet projection.
+
+## 11. API and Dashboard semantics
+
+### 11.1 API vocabulary
+
+Remove unqualified `Succeeded` and `Failed` from schedule definition output.
+
+Definition output uses:
+
+- `active`
+- `paused`
+- `exhausted`
+- `cancelled`
+- `expired`
+
+Occurrence delivery output uses:
+
+- `materialized`
+- `queue_pending`
+- `leased`
+- `turn_in_progress`
+- `retry_wait`
+- `delivery_acknowledged`
+- `delivery_cancelled`
+- `delivery_escalated`
+- `expired_before_lease`
+- `superseded`
+- `evidence_invalid`
+
+It exposes `wake_admission` separately as
+`signaled | deferred_unregistered | deferred_not_running |
+deferred_lifecycle | null`.
+
+If a typed source terminal exists, it is a separate `work_outcome` object.
+
+### 11.2 Dashboard labels
+
+The Dashboard may display:
+
+| Typed state | Korean operator label |
+|---|---|
+| `queue_pending` | 큐 대기 |
+| `leased` / `turn_in_progress` | 처리 중 |
+| `retry_wait` | 재시도 대기 |
+| `delivery_acknowledged` | 전달 완료 |
+| `delivery_cancelled` | 전달 취소 |
+| `delivery_escalated` | 에스컬레이션 |
+| `expired_before_lease` | 전달 전 만료 |
+| `evidence_invalid` | 증거 격리 |
+
+`wake_admission` may appear as a secondary `Wake 신호` or `Wake 보류` badge
+beside a nonterminal phase. It is never the completion label.
+
+It must not display generic `완료` for `stimulus_seen`, `turn_started`, queue
+absence, or schedule definition state.
+
+Queue snapshots remain useful live evidence, but absence is not a terminal
+proof. The occurrence ledger terminal event is authoritative.
+
+### 11.3 Health and telemetry
+
+Health counters are derived from occurrence events/projections, not independently
+incremented process-local structs:
+
+- open occurrences by phase and bounded age bucket;
+- wake admissions by closed outcome;
+- requeue and escalation counts by bounded typed reason;
+- pending occurrence/settlement outboxes;
+- reconciliation status and oldest unresolved age;
+- quarantined occurrence rows;
+- recurrence skipped/coalesced counts.
+
+Occurrence ids remain in logs/traces and detail APIs, not unbounded metric
+labels.
+
+Dead counters with no production event source are removed.
+
+## 12. Crash and recovery matrix
+
+| Crash/failure point | Durable fact before crash | Recovery action | Forbidden result |
+|---|---|---|---|
+| before materialization commit | none | recompute same due id | phantom queue item |
+| after `Materialized`, before outbox projection | occurrence event | rebuild outbox, retry enqueue | lose due intent |
+| after outbox projection, before queue enqueue | occurrence event + outbox projection | retry enqueue | mark delivery complete |
+| after queue enqueue, before `Queue_accepted` | queue exact id | `Already_present`, append event | duplicate stimulus |
+| after `Queue_accepted`, before wake event | queue + occurrence | retry wake hint or record current deferred outcome | erase queue acceptance |
+| after wake signal, before turn | queue pending | registration/heartbeat drains | claim task success |
+| after lease start, before turn record | queue lease | event queue lease recovery/requeue | second concurrent lease |
+| after turn failure, before settlement projection | transition outbox | replay exact settlement event | green ACK |
+| after occurrence settlement append, before cursor advance | deterministic event id | replay as duplicate | second terminal |
+| occurrence row malformed | isolated row identity | quarantine one occurrence | fail every schedule |
+| definition row malformed | isolated schedule identity | quarantine one definition | block another owner lane |
+| migration interrupted | migration phase/commit marker | resume or refuse runner admission | partial dual authority |
+
+Every row in this table requires a deterministic test using the production
+write/projector path. Tests that inject already-aggregated health structs are
+not proof of lifecycle wiring.
+
+## 13. Migration and hard cut
+
+This RFC rejects permanent dual-read or dual-write compatibility. The cutover
+uses a versioned, one-time migration while schedule runner admission is closed.
+
+### 13.1 Cutover fence
+
+Migration does not stop unrelated Keeper work:
+
+1. acquire a schedule-subsystem migration epoch;
+2. stop the legacy runner from materializing/enqueuing new schedule stimuli;
+3. make create/update/cancel return a typed `schedule_migrating` result;
+4. leave existing Keeper event queues and turns running;
+5. record a physical high-watermark for each owner reaction ledger;
+6. import legacy snapshots/signals/queue state through those watermarks;
+7. start the new occurrence settlement projector at the recorded cursors so
+   rows appended while migration runs are tailed exactly once logically;
+8. open new runner/tool admission only after the manifest and cursor handoff
+   commit together.
+
+An old pending schedule stimulus may therefore settle during migration without
+being lost or requiring a fleet stop. The migration manifest records the epoch,
+per-owner high-watermarks, imported counts, and new projector cursors.
+
+### 13.2 Migration inputs
+
+- current schedule definitions in `schedules.json`;
+- current embedded execution records;
+- schedule signal JSONL;
+- Keeper event queue pending/inflight `Schedule_due` stimuli;
+- reaction-ledger schedule occurrence evidence.
+
+### 13.3 Migration rules
+
+1. Active definitions are copied to isolated definition records with an exact
+   count and digest manifest.
+   For a legacy Keeper wake, `owner_lane` is taken from the validated dispatch
+   target because that is the lane holding any queue/reaction evidence;
+   `scheduled_by` remains actor provenance. A missing or invalid target
+   quarantines the definition instead of guessing.
+   Every distinct legacy payload version is preserved in an immutable
+   definition event; occurrences reference its digest rather than duplicating
+   content.
+2. Existing execution `succeeded` is imported as
+   `Legacy_evidence_imported { semantic = dispatch_acceptance_unknown }`, never
+   as business success.
+   Every imported occurrence first receives a synthetic `Materialized` event
+   with `origin=legacy_migration`; later evidence cannot appear without an
+   occurrence root.
+3. A parseable Keeper-wake receipt may produce `Queue_accepted`.
+4. Exact pending/inflight queue rows produce current nonterminal occurrence
+   evidence.
+5. Exact reaction settlements produce ACK, cancellation, requeue, or escalation
+   events.
+6. Missing or contradictory joins become `legacy_indeterminate` or quarantine;
+   they are not silently dropped.
+7. Actor/reason fields absent from legacy snapshots remain explicitly unknown.
+8. Counts by definition, legacy execution, signal, queue, and settlement are
+   written to the migration manifest.
+9. Only a verified manifest writes the migration commit marker and opens runner
+   admission.
+
+After commit:
+
+- legacy files remain read-only archive evidence;
+- runtime paths read and write only the new namespace;
+- no fallback to stale `.last-good` may silently replace newer occurrence
+  truth;
+- migration failure degrades the schedule subsystem without blocking unrelated
+  Keeper lanes.
+
+## 14. Implementation phases
+
+Each phase is independently reviewable but must preserve the final vocabulary.
+No phase may introduce a second terminal authority.
+
+### Phase 0 — Operator-truth correction
+
+Related: #24199, #25691.
+
+- rename current execution output to dispatch/queue acceptance semantics;
+- preserve typed wake admission in the receipt;
+- project requeue and escalation as first-class evidence;
+- remove `matched_stimulus` and `matched_turn_started` from completed UI states;
+- remove or wire every runner health counter from a real typed production event.
+
+This phase does not claim to solve occurrence persistence. It immediately stops
+false-green operator output.
+
+### Phase 1 — Definition and occurrence types
+
+Related: #21955, #24199, #25687, #25689.
+
+- add closed definition, occurrence event, projection, actor, target, timestamp,
+  and backlog policy types;
+- create isolated definition and append-only occurrence stores;
+- add per-schedule cursor/index contract;
+- validate closed payload and owner before persistence;
+- prove event/projector state-machine properties.
+
+### Phase 2 — Failure-atomic occurrence outbox
+
+Related: #25690.
+
+- make `Materialized` the sole durable enqueue intent;
+- rebuild the exact outbox projection from nonterminal occurrence events;
+- enqueue by exact occurrence id;
+- append queue acceptance and wake admission;
+- retire `signal_keys.json` and idle rewrites;
+- add crash-boundary tests.
+
+### Phase 3 — Settlement bridge and reconciler
+
+Related: #25688, #25691.
+
+- project exact schedule settlement rows from the reaction ledger to the
+  occurrence ledger without blocking the event queue outbox;
+- preserve ACK/requeue/escalation/cancellation exact receipts;
+- add per-owner startup reconciliation and degraded health;
+- replace one-shot schedule `Running` recovery.
+
+### Phase 4 — Recurrence, cancellation, and expiry
+
+Related: #25692.
+
+- implement closed misfire and overlap policy;
+- default Keeper wake to bounded latest delivery;
+- implement explicit cancel scope and exact pending cancellation;
+- carry occurrence deadline into queue admission;
+- prove scheduler-down and Keeper-down policy equivalence.
+
+### Phase 5 — Migration, cutover, and legacy removal
+
+- run versioned one-time migration;
+- verify evidence manifest;
+- switch API/Dashboard/health to occurrence projection;
+- remove embedded execution history and legacy runtime readers/writers;
+- retain legacy files as read-only archive;
+- complete production soak and RFC closeout.
+
+## 15. Verification plan
+
+### 15.1 Model/property tests
+
+- every accepted event sequence projects deterministically;
+- impossible transition order is rejected;
+- duplicate event ids are idempotent;
+- no two mutually exclusive terminals project as success;
+- requeue preserves occurrence id and increments attempt;
+- update/materialization and cancel/materialization races preserve one
+  definition version and immutable occurrence facts;
+- definition cancellation never rewrites historical occurrence evidence;
+- one corrupt schedule/row cannot prevent another schedule projection;
+- cursor pagination has no duplicate or omitted event under concurrent append.
+
+### 15.2 End-to-end scenarios
+
+1. registered, running Keeper: queue acceptance → signaled → lease → ACK;
+2. unregistered Keeper: queue acceptance → deferred → later registration →
+   lease → ACK;
+3. paused/lifecycle-deferred Keeper with exact denial evidence;
+4. provider retry: turn started → requeue → later ACK;
+5. provider terminal: turn started → escalation, never completion;
+6. cancellation before enqueue, while pending, and racing active lease;
+7. expiry before enqueue, while pending, and after lease start;
+8. restart at every crash-matrix boundary;
+9. duplicate tick/projector invocation with exactly one occurrence/stimulus;
+10. Scheduler downtime versus Keeper downtime under each backlog policy;
+11. long downtime with bounded catch-up and rate;
+12. owner mismatch, unknown payload field, oversized message retrieval pointer;
+13. NaN, infinity, huge epoch, and supported timestamp boundaries;
+14. malformed occurrence row isolated from another owner lane;
+15. legacy migration with pending, ACK, escalation, and missing evidence rows.
+
+The scenarios must call production adapters. Serialization-only tests over
+synthetic status values do not satisfy the contract.
+
+### 15.3 Runtime acceptance
+
+- zero schedule executions labelled business success for `Delivery_only`;
+- zero open occurrence absent from both an outbox and the Keeper queue without
+  typed quarantine;
+- zero dead health counters;
+- bounded outstanding occurrence count matches each definition's policy;
+- one deferred Keeper lane does not delay another lane's occurrence;
+- restart reconciliation reaches a terminal state or remains visibly degraded;
+- Dashboard occurrence detail can explain every visible label with exact event
+  ids and timestamps.
+
+## 16. Alternatives rejected
+
+### 16.1 Rename `Succeeded` only
+
+Truthful vocabulary is necessary as Phase 0, but it does not solve non-atomic
+handoff, global history rewrite, recurrence backlog, cancellation, or recovery.
+
+### 16.2 Make the Scheduler own Keeper work
+
+Rejected. It violates the RFC-0234 boundary, duplicates Keeper Gate, and still
+cannot prove fulfillment of an open-ended model instruction.
+
+### 16.3 Join queue and reaction stores only at Dashboard read time
+
+Rejected. That preserves multiple authorities, makes absence meaningful, loses
+settlement reasons, and cannot drive deterministic recovery.
+
+### 16.4 Treat turn start as success
+
+Rejected. Start is not terminal and the live escalation counterexample disproves
+the inference.
+
+### 16.5 Treat queue ACK as business success
+
+Rejected for `masc.keeper_wake`. ACK proves stimulus delivery through a completed
+event-queue settlement, not execution of the natural-language request.
+
+### 16.6 Keep signal JSONL plus a repaired `signal_keys.json`
+
+Rejected as the final architecture. A repaired two-store fence would still
+duplicate occurrence identity and leave settlement outside the schedule
+authority. The occurrence event ledger is the fence.
+
+### 16.7 Introduce a database transaction
+
+Rejected for this scope. Exact-id enqueue, append-only stores, and durable
+outboxes already provide the required idempotent saga substrate. A database
+would not fix semantic ownership by itself.
+
+## 17. Issue mapping
+
+| Issue | RFC responsibility |
+|---|---|
+| #21955 | append-only definition/occurrence lifecycle and actor/reason evidence |
+| #24199 | separate definition from occurrence history; truthful async lifecycle |
+| #25687 | finite/range timestamp admission and row-level quarantine |
+| #25688 | per-owner reconciler replacing one-shot `Running` recovery |
+| #25689 | lossless closed payload, exact detail pointer, owner-lane authority |
+| #25690 | occurrence ledger/outbox replacing non-atomic signal fence |
+| #25691 | durable typed wake admission and production-derived health |
+| #25692 | explicit misfire, overlap, expiry, cancellation, and backpressure |
+
+These remain implementation issues under this RFC. Closing one does not imply
+the RFC is implemented.
+
+## 18. Closed decisions
+
+- The Scheduler owns future intent and occurrence delivery, not external-effect
+  authorization.
+- `masc.keeper_wake` is delivery-only.
+- Definition, occurrence delivery, and work outcome are separate types.
+- The append-only occurrence ledger is schedule operator-truth authority.
+- Keeper event queue remains lease/settlement authority.
+- Settlement returns through the existing transition outbox → reaction ledger
+  pattern and a non-blocking occurrence projector.
+- Target Keeper is a top-level owner-lane fact, never duplicated in payload.
+- Unknown v1 payload fields are rejected.
+- Timestamp validation precedes persistence.
+- Recurring Keeper wake defaults to latest bounded delivery, not unbounded
+  catch-up.
+- Dashboard never infers completion from stimulus, turn start, or queue absence.
+- Cutover has no permanent dual authority or silent legacy fallback.
+
+## 19. Open decisions before activation
+
+These do not change the semantic model but must be fixed before Phase 5:
+
+1. occurrence ledger retention duration and archive compaction;
+2. exact bounded defaults for `grace_sec`, catch-up count/age, and materialize
+   rate;
+3. whether active-lease cancellation remains request-only or integrates a
+   provider cancellation token for specific typed jobs;
+4. operator capability required for cross-Keeper definition creation;
+5. whether a true typed scheduled-job family receives a separate RFC.
+
+No implementation may substitute heuristics for these decisions.
+
+## 20. Workaround rejection self-check
+
+- Telemetry-as-fix: rejected; events drive real recovery and projection.
+- String matching: rejected; all lifecycle, wake, settlement, and policy values
+  are closed typed sums.
+- Silent fallback: rejected; corrupt/unknown evidence is quarantined.
+- Retry without bound: rejected; catch-up and outstanding work are bounded.
+- Queue cap without policy: rejected; bounds are part of explicit recurrence
+  semantics and skipped/coalesced evidence remains visible.
+- Dual authority migration: rejected; one verified hard cut.
+- UI-only repair: rejected; Dashboard consumes authoritative occurrence events.
+- Fake job success: rejected; delivery and work outcomes remain distinct.
+
+## 21. Acceptance and closeout
+
+This RFC may move to `Implemented` only when:
+
+1. all Phase 0–5 implementation PRs are merged;
+2. old production readers/writers for embedded execution history and
+   `signal_keys.json` are removed;
+3. the migration manifest is verified on a representative live workspace;
+4. every crash-matrix row has a production-path deterministic test;
+5. Dashboard and APIs expose no unqualified schedule `Succeeded` for
+   `Delivery_only`;
+6. deferred, requeued, escalated, cancelled, expired, and quarantined
+   occurrences are individually explainable;
+7. recurrence backlog remains within declared policy during Scheduler and
+   Keeper downtime;
+8. CI and an operator-observed restart soak are green;
+9. #21955, #24199, and #25687–#25692 are either closed by implementation or
+   explicitly superseded with evidence.


### PR DESCRIPTION
## Summary

- define one authoritative lifecycle for scheduled Keeper-wake occurrences;
- separate `ScheduleDefinition`, `ScheduleOccurrence`, delivery attempts, and optional typed work outcomes;
- preserve the surviving RFC-0234 boundary: Scheduler owns future intent and Keeper delivery, while actual effects remain behind Keeper Gate;
- make the append-only occurrence ledger the schedule operator-truth authority;
- return exact queue settlements through the existing event-queue outbox → reaction-ledger path without blocking unrelated Keeper work;
- define recurrence misfire/overlap, cancellation, expiry, migration, crash recovery, and Dashboard semantics.

The central invariant is:

> No terminal status exists without exact, durable terminal evidence for the same occurrence identity.

For `masc.keeper_wake`, queue ACK proves delivery settlement only. It never claims that the model performed the natural-language request.

## Root cause addressed

The current synchronous `consumer.dispatch : (..., error) result` returns after durable enqueue, and the runner immediately records `Execution_succeeded`. The actual queue → wake → lease → turn → ACK/Requeue/Escalate lifecycle continues in other ledgers with no return path to schedule state.

The RFC treats that path as an explicit idempotent saga instead of a synchronous execution.

## Key decisions

- wake admission is an orthogonal evidence axis, not a delivery phase;
- definition state never becomes `Running`, `Succeeded`, or `Failed`;
- occurrence identity remains stable through every delivery retry;
- `stimulus_id = occurrence_id` for `Schedule_due`;
- natural-language Keeper wake is `Delivery_only`;
- event-queue settlement remains authoritative and fans out through exact reaction rows;
- recurring Keeper wake defaults to bounded latest delivery, not unbounded catch-up;
- owner lane is a top-level immutable fact, never duplicated in payload;
- unknown v1 payload fields and unsafe timestamps are rejected before persistence;
- cutover uses a verified hard migration with no permanent dual authority.

## Issue mapping

Relates #21955, #24199, #25687, #25688, #25689, #25690, #25691, and #25692.

These remain implementation issues; this RFC does not close them.

## Scope

Documentation only. No runtime, queue, ledger, Keeper, or Dashboard code changes.

`docs/rfc/README.md` was regenerated using the repository-required generator. Besides adding this slug RFC, it refreshes stale generated `Last activity` rows and recently added RFC entries.

## Verification

- `python3 scripts/rfc_enforcer.py --check docs/rfc/ --files RFC-scheduled-occurrence-lifecycle.md --ignore-missing-section1`
- `python3 scripts/rfc-generate-index.py --check`
- `git diff --check`

All passed.
