### PR TITLE
fix(keeper): publish durable commit before cancellation

### DIFF
--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -318,7 +318,7 @@ let save_bytes_durable_atomic_core
         temp_dir
   in
   let result =
-    run_in_systhread_cancel_checked (fun () ->
+    Eio_guard.run_in_systhread (fun () ->
     let temp_path = ref None in
     let channel = ref None in
     let renamed = ref false in
@@ -390,7 +390,7 @@ let save_bytes_durable_atomic_core
           ?ownership_root
           dir
       in
-      run_in_systhread_cancel_checked (fun () ->
+      Eio_guard.run_in_systhread (fun () ->
         run_durable_write_stage
           ~renamed:true
           ~before_stage
@@ -413,7 +413,7 @@ let save_bytes_durable_atomic_core
           ?ownership_root
           temp_dir
       in
-      run_in_systhread_cancel_checked (fun () ->
+      Eio_guard.run_in_systhread (fun () ->
         run_durable_write_stage
           ~renamed:true
           ~before_stage
@@ -424,7 +424,22 @@ let save_bytes_durable_atomic_core
   confirm_temp_directory_lease temp_directory_lease
 ;;
 
-let save_bytes_durable_atomic_with
+let observe_durable_write_success ~on_durable_commit = function
+  | Error _ as error ->
+    Eio_guard.check_if_ready ();
+    error
+  | Ok () as success ->
+    (* The blocking transaction and both final directory-lease confirmations
+       are complete. This pure caller-fiber publication must precede the
+       cooperative cancellation check: a systhread cannot stop once running,
+       so cancellation may already be pending after a fully durable commit. *)
+    on_durable_commit ();
+    Eio_guard.check_if_ready ();
+    success
+;;
+
+let save_bytes_durable_atomic_observed_with
+      ~on_durable_commit
       ~before_stage
       ?before_directory_fsync
       ?ownership_root
@@ -440,6 +455,25 @@ let save_bytes_durable_atomic_with
       ?temp_dir
       path
       bytes)
+  |> observe_durable_write_success ~on_durable_commit
+;;
+
+let save_bytes_durable_atomic_with
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes
+  =
+  save_bytes_durable_atomic_observed_with
+    ~on_durable_commit:(fun () -> ())
+    ~before_stage
+    ?before_directory_fsync
+    ?ownership_root
+    ?temp_dir
+    path
+    bytes
 ;;
 
 let save_json_durable_atomic_from_with
@@ -476,6 +510,7 @@ let save_json_durable_atomic_from_with
       ?temp_dir
       path
       bytes)
+  |> observe_durable_write_success ~on_durable_commit:(fun () -> ())
 ;;
 
 let save_json_durable_atomic_with
@@ -498,7 +533,24 @@ let save_json_durable_atomic_with
 ;;
 
 let save_bytes_durable_atomic ?ownership_root ?temp_dir path bytes =
-  save_bytes_durable_atomic_with
+  save_bytes_durable_atomic_observed_with
+    ~on_durable_commit:(fun () -> ())
+    ~before_stage:(fun _ -> ())
+    ?ownership_root
+    ?temp_dir
+    path
+    bytes
+;;
+
+let save_bytes_durable_atomic_observed
+      ~on_durable_commit
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes
+  =
+  save_bytes_durable_atomic_observed_with
+    ~on_durable_commit
     ~before_stage:(fun _ -> ())
     ?ownership_root
     ?temp_dir
@@ -603,6 +655,25 @@ let remove_file_durable ?ownership_root path =
 ;;
 
 module For_testing = struct
+  let save_bytes_durable_atomic_observed
+        ~on_durable_commit
+        ~before_stage
+        ?before_directory_fsync
+        ?ownership_root
+        ?temp_dir
+        path
+        bytes
+    =
+    save_bytes_durable_atomic_observed_with
+      ~on_durable_commit
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes
+  ;;
+
   let save_bytes_durable_atomic
         ~before_stage
         ?before_directory_fsync
@@ -611,7 +682,8 @@ module For_testing = struct
         path
         bytes
     =
-    save_bytes_durable_atomic_with
+    save_bytes_durable_atomic_observed
+      ~on_durable_commit:(fun () -> ())
       ~before_stage
       ?before_directory_fsync
       ?ownership_root

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -424,18 +424,31 @@ let save_bytes_durable_atomic_core
   confirm_temp_directory_lease temp_directory_lease
 ;;
 
+type durable_commit_outcome =
+  | Committed
+  | Committed_but_observer_failed of Eio.Exn.with_bt
+
+let check_durable_write_completion result =
+  Eio_guard.check_if_ready ();
+  result
+;;
+
 let observe_durable_write_success ~on_durable_commit = function
   | Error _ as error ->
     Eio_guard.check_if_ready ();
     error
-  | Ok () as success ->
+  | Ok () ->
     (* The blocking transaction and both final directory-lease confirmations
        are complete. This pure caller-fiber publication must precede the
        cooperative cancellation check: a systhread cannot stop once running,
        so cancellation may already be pending after a fully durable commit. *)
-    on_durable_commit ();
-    Eio_guard.check_if_ready ();
-    success
+    (match on_durable_commit () with
+     | () ->
+       Eio_guard.check_if_ready ();
+       Ok Committed
+     | exception exn ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       Ok (Committed_but_observer_failed (exn, backtrace)))
 ;;
 
 let save_bytes_durable_atomic_observed_with
@@ -466,14 +479,15 @@ let save_bytes_durable_atomic_with
       path
       bytes
   =
-  save_bytes_durable_atomic_observed_with
-    ~on_durable_commit:(fun () -> ())
-    ~before_stage
-    ?before_directory_fsync
-    ?ownership_root
-    ?temp_dir
-    path
-    bytes
+  protect_durable_write (fun () ->
+    save_bytes_durable_atomic_core
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes)
+  |> check_durable_write_completion
 ;;
 
 let save_json_durable_atomic_from_with
@@ -510,7 +524,7 @@ let save_json_durable_atomic_from_with
       ?temp_dir
       path
       bytes)
-  |> observe_durable_write_success ~on_durable_commit:(fun () -> ())
+  |> check_durable_write_completion
 ;;
 
 let save_json_durable_atomic_with
@@ -533,8 +547,7 @@ let save_json_durable_atomic_with
 ;;
 
 let save_bytes_durable_atomic ?ownership_root ?temp_dir path bytes =
-  save_bytes_durable_atomic_observed_with
-    ~on_durable_commit:(fun () -> ())
+  save_bytes_durable_atomic_with
     ~before_stage:(fun _ -> ())
     ?ownership_root
     ?temp_dir
@@ -682,8 +695,7 @@ module For_testing = struct
         path
         bytes
     =
-    save_bytes_durable_atomic_observed
-      ~on_durable_commit:(fun () -> ())
+    save_bytes_durable_atomic_with
       ~before_stage
       ?before_directory_fsync
       ?ownership_root

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -58,8 +58,24 @@ type durable_write_error =
   ; failure : durable_write_failure
   }
 
+(** Strict durable atomic write with a required terminal observer.
+    [on_durable_commit] runs exactly once in the caller fiber after the payload,
+    rename, required directory fsyncs, and final directory-lease confirmations
+    have all succeeded, but before pending cooperative cancellation is checked.
+    It is not called on an error. The callback must be synchronous,
+    non-blocking, perform no I/O or Eio operation, and must not raise. *)
+val save_bytes_durable_atomic_observed
+  :  on_durable_commit:(unit -> unit)
+  -> ?ownership_root:string
+  -> ?temp_dir:string
+  -> string
+  -> string
+  -> (unit, durable_write_error) result
+
 (** Strict durable atomic write of the supplied immutable byte string.
-    The payload is written exactly, without parsing or re-encoding. *)
+    The payload is written exactly, without parsing or re-encoding. This
+    delegates to {!save_bytes_durable_atomic_observed} with an explicit
+    no-op observer. *)
 val save_bytes_durable_atomic
   :  ?ownership_root:string
   -> ?temp_dir:string
@@ -126,6 +142,16 @@ module For_testing : sig
       named filesystem operation. [before_directory_fsync] runs immediately
       before anchoring one directory component in the durability systhread.
       Either may raise to verify the typed contract and retry behavior. *)
+  val save_bytes_durable_atomic_observed
+    :  on_durable_commit:(unit -> unit)
+    -> before_stage:(durable_write_stage -> unit)
+    -> ?before_directory_fsync:(string -> unit)
+    -> ?ownership_root:string
+    -> ?temp_dir:string
+    -> string
+    -> string
+    -> (unit, durable_write_error) result
+
   val save_bytes_durable_atomic
     :  before_stage:(durable_write_stage -> unit)
     -> ?before_directory_fsync:(string -> unit)

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -84,9 +84,9 @@ val save_bytes_durable_atomic_observed
   -> (durable_commit_outcome, durable_write_error) result
 
 (** Strict durable atomic write of the supplied immutable byte string.
-    The payload is written exactly, without parsing or re-encoding. This
-    delegates to {!save_bytes_durable_atomic_observed} with an explicit
-    no-op observer. *)
+    The payload is written exactly, without parsing or re-encoding. It provides
+    equivalent semantics through the same core transaction and completion
+    check without installing an observer. *)
 val save_bytes_durable_atomic
   :  ?ownership_root:string
   -> ?temp_dir:string

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -58,19 +58,30 @@ type durable_write_error =
   ; failure : durable_write_failure
   }
 
+type durable_commit_outcome =
+  | Committed
+  | Committed_but_observer_failed of Eio.Exn.with_bt
+
 (** Strict durable atomic write with a required terminal observer.
     [on_durable_commit] runs exactly once in the caller fiber after the payload,
     rename, required directory fsyncs, and final directory-lease confirmations
     have all succeeded, but before pending cooperative cancellation is checked.
     It is not called on an error. The callback must be synchronous,
-    non-blocking, perform no I/O or Eio operation, and must not raise. *)
+    non-blocking, and perform no I/O or Eio operation.
+
+    A normally returning callback produces [Committed], after which pending
+    cooperative cancellation is checked as usual. An observer exception,
+    including [Eio.Cancel.Cancelled], produces
+    [Committed_but_observer_failed] with its raw backtrace instead of escaping
+    through the pre-commit write-failure channel. The caller owns any
+    identity-bound reconciliation required by that outcome. *)
 val save_bytes_durable_atomic_observed
   :  on_durable_commit:(unit -> unit)
   -> ?ownership_root:string
   -> ?temp_dir:string
   -> string
   -> string
-  -> (unit, durable_write_error) result
+  -> (durable_commit_outcome, durable_write_error) result
 
 (** Strict durable atomic write of the supplied immutable byte string.
     The payload is written exactly, without parsing or re-encoding. This
@@ -150,7 +161,7 @@ module For_testing : sig
     -> ?temp_dir:string
     -> string
     -> string
-    -> (unit, durable_write_error) result
+    -> (durable_commit_outcome, durable_write_error) result
 
   val save_bytes_durable_atomic
     :  before_stage:(durable_write_stage -> unit)

--- a/test/test_keeper_fs_directory_durability.ml
+++ b/test/test_keeper_fs_directory_durability.ml
@@ -103,6 +103,13 @@ let require_durable_ok label = function
   | Error detail -> failf "%s: %s" label (KF.durable_write_error_to_string detail)
 ;;
 
+let require_observed_commit label = function
+  | Ok KF.Committed -> ()
+  | Ok (KF.Committed_but_observer_failed (exn, _)) ->
+    failf "%s: durable observer failed: %s" label (Printexc.to_string exn)
+  | Error detail -> failf "%s: %s" label (KF.durable_write_error_to_string detail)
+;;
+
 let require_directory_lease label = function
   | Ok _ -> ()
   | Error _ -> failf "%s: directory lease preparation failed" label
@@ -154,7 +161,7 @@ let test_non_directory_ancestor_does_not_poison_preparation () =
        let sibling_path = Filename.concat base "sibling/request.json" in
        match KF.save_json_durable_atomic sibling_path (`Assoc []) with
        | Ok () -> ()
-       | Error error ->
+        | Error error ->
          failf
            "directory prepare failure poisoned the next write: %s"
            (KF.durable_write_error_to_string error))
@@ -828,7 +835,7 @@ let test_durable_commit_observer_cardinality () =
     (fun () ->
        let committed = ref 0 in
        let committed_path = Filename.concat base "committed.bin" in
-       require_durable_ok
+       require_observed_commit
          "observed durable write"
          (KF.For_testing.save_bytes_durable_atomic_observed
             ~on_durable_commit:(fun () -> incr committed)
@@ -848,11 +855,15 @@ let test_durable_commit_observer_cardinality () =
             "rejected"
         with
         | Error { renamed = false; stage = KF.Payload_fsync; _ } -> ()
-        | Error error ->
+       | Error error ->
           failf
             "unexpected observed write error: %s"
             (KF.durable_write_error_to_string error)
-       | Ok () -> fail "injected precommit failure unexpectedly succeeded");
+        | Ok KF.Committed -> fail "injected precommit failure unexpectedly committed"
+        | Ok (KF.Committed_but_observer_failed (exn, _)) ->
+          failf
+            "injected precommit failure reached observer: %s"
+            (Printexc.to_string exn));
        check int "failed write does not publish" 0 !rejected;
        let post_rename = ref 0 in
        let post_rename_path = Filename.concat base "post-rename.bin" in
@@ -876,8 +887,67 @@ let test_durable_commit_observer_cardinality () =
           failf
             "unexpected post-rename observed write error: %s"
             (KF.durable_write_error_to_string error)
-        | Ok () -> fail "injected parent directory fsync failure unexpectedly succeeded");
+        | Ok KF.Committed ->
+          fail "injected parent directory fsync failure unexpectedly committed"
+        | Ok (KF.Committed_but_observer_failed (exn, _)) ->
+          failf
+            "injected parent directory fsync failure reached observer: %s"
+            (Printexc.to_string exn));
        check int "post-rename fsync failure does not publish" 0 !post_rename)
+;;
+
+let test_durable_commit_observer_failure_is_typed () =
+  KF.clear_dir_cache ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let assert_typed_failure ~label ~filename ~payload exception_ backtrace =
+         let path = Filename.concat base filename in
+         let observer_count = ref 0 in
+         (match
+            KF.For_testing.save_bytes_durable_atomic_observed
+              ~on_durable_commit:(fun () ->
+                incr observer_count;
+                Printexc.raise_with_backtrace exception_ backtrace)
+              ~before_stage:(fun _ -> ())
+              path
+              payload
+          with
+          | Ok (KF.Committed_but_observer_failed (observed_exn, observed_backtrace)) ->
+            check bool (label ^ " exception identity") true (observed_exn == exception_);
+            check
+              string
+              (label ^ " raw backtrace")
+              (Printexc.raw_backtrace_to_string backtrace)
+              (Printexc.raw_backtrace_to_string observed_backtrace)
+          | Ok KF.Committed -> failf "%s observer failure was lost" label
+          | Error error ->
+            failf
+              "%s durable write failed before observer: %s"
+              label
+              (KF.durable_write_error_to_string error));
+         check int (label ^ " observer cardinality") 1 !observer_count;
+         check
+           string
+           (label ^ " payload remains committed")
+           payload
+           (In_channel.with_open_bin path In_channel.input_all)
+       in
+       let ordinary_exception = Failure "injected durable observer failure" in
+       assert_typed_failure
+         ~label:"ordinary observer exception"
+         ~filename:"observer-failed.bin"
+         ~payload:"committed-before-observer-failure"
+         ordinary_exception
+         (Printexc.get_callstack 32);
+       let cancellation = Eio.Cancel.Cancelled Synthetic_observer_cancel in
+       assert_typed_failure
+         ~label:"observer cancellation"
+         ~filename:"observer-cancelled.bin"
+         ~payload:"committed-before-observer-cancellation"
+         cancellation
+         (Printexc.get_callstack 32))
 ;;
 
 let test_durable_commit_observer_precedes_pending_cancellation () =
@@ -924,7 +994,11 @@ let test_durable_commit_observer_precedes_pending_cancellation () =
                    path
                    "committed-before-cancel"
                with
-               | Ok () -> `Returned
+               | Ok KF.Committed -> `Returned
+               | Ok (KF.Committed_but_observer_failed (exn, _)) ->
+                 failf
+                   "pending-cancellation observer failed: %s"
+                   (Printexc.to_string exn)
                | Error error ->
                  failf
                    "pending-cancellation write failed: %s"
@@ -988,7 +1062,11 @@ let test_durable_commit_observer_error_preserves_pending_cancellation () =
                    path
                    "must-not-commit"
                with
-               | Ok () -> `Returned_ok
+               | Ok KF.Committed -> `Returned_ok
+               | Ok (KF.Committed_but_observer_failed (exn, _)) ->
+                 failf
+                   "precommit error unexpectedly reached observer: %s"
+                   (Printexc.to_string exn)
                | Error _ -> `Returned_error)
            with
            | Eio.Cancel.Cancelled _ -> `Cancelled
@@ -1061,7 +1139,9 @@ let test_durable_commit_observer_waits_for_reanchor () =
        check int "observer remains absent before re-anchor fsync" 0
          (Atomic.get publish_count);
        release_blocking_hook reanchor_fsync;
-       require_durable_ok "re-anchored observed write" (Eio.Promise.await outcome);
+       require_observed_commit
+         "re-anchored observed write"
+         (Eio.Promise.await outcome);
        check int "main write and re-anchor both fsync" 2
          (Atomic.get fsync_count);
        check int "observer publishes once after re-anchor" 1
@@ -1118,6 +1198,10 @@ let () =
             "success publishes once and error never publishes"
             `Quick
             test_durable_commit_observer_cardinality
+        ; test_case
+            "observer exception and cancellation return committed evidence"
+            `Quick
+            test_durable_commit_observer_failure_is_typed
         ; test_case
             "publication precedes pending cancellation"
             `Quick

--- a/test/test_keeper_fs_directory_durability.ml
+++ b/test/test_keeper_fs_directory_durability.ml
@@ -4,6 +4,7 @@ module KF = Masc.Keeper_fs
 module KDD = Masc.Keeper_fs_durable_directory
 
 exception Synthetic_owner_failure
+exception Synthetic_observer_cancel
 
 (* This is a test-runner watchdog, not a production scheduling policy. It
    localizes a coordination liveness regression instead of consuming the
@@ -819,6 +820,254 @@ let test_invalidate_reaps_resolved_ticket () =
          (Atomic.get reclaimed_before_release))
 ;;
 
+let test_durable_commit_observer_cardinality () =
+  KF.clear_dir_cache ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let committed = ref 0 in
+       let committed_path = Filename.concat base "committed.bin" in
+       require_durable_ok
+         "observed durable write"
+         (KF.For_testing.save_bytes_durable_atomic_observed
+            ~on_durable_commit:(fun () -> incr committed)
+            ~before_stage:(fun _ -> ())
+            committed_path
+            "committed");
+       check int "successful write publishes once" 1 !committed;
+       let rejected = ref 0 in
+       let rejected_path = Filename.concat base "rejected.bin" in
+       (match
+          KF.For_testing.save_bytes_durable_atomic_observed
+            ~on_durable_commit:(fun () -> incr rejected)
+            ~before_stage:(function
+              | KF.Payload_fsync -> failwith "injected precommit failure"
+              | _ -> ())
+            rejected_path
+            "rejected"
+        with
+        | Error { renamed = false; stage = KF.Payload_fsync; _ } -> ()
+        | Error error ->
+          failf
+            "unexpected observed write error: %s"
+            (KF.durable_write_error_to_string error)
+       | Ok () -> fail "injected precommit failure unexpectedly succeeded");
+       check int "failed write does not publish" 0 !rejected;
+       let post_rename = ref 0 in
+       let post_rename_path = Filename.concat base "post-rename.bin" in
+       (match
+          KF.For_testing.save_bytes_durable_atomic_observed
+            ~on_durable_commit:(fun () -> incr post_rename)
+            ~before_stage:(function
+              | KF.Parent_directory_fsync_after_rename ->
+                failwith "injected parent directory fsync failure"
+              | _ -> ())
+            post_rename_path
+            "renamed-not-durable"
+        with
+        | Error
+            { renamed = true
+            ; stage = KF.Parent_directory_fsync_after_rename
+            ; _
+            } ->
+          ()
+        | Error error ->
+          failf
+            "unexpected post-rename observed write error: %s"
+            (KF.durable_write_error_to_string error)
+        | Ok () -> fail "injected parent directory fsync failure unexpectedly succeeded");
+       check int "post-rename fsync failure does not publish" 0 !post_rename)
+;;
+
+let test_durable_commit_observer_precedes_pending_cancellation () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Time.with_timeout_exn
+    (Eio.Stdenv.clock env)
+    coordination_watchdog_seconds
+  @@ fun () ->
+  with_eio_guard
+  @@ fun () ->
+  KF.clear_dir_cache ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let path = Filename.concat base "cancelled-after-commit.bin" in
+       let hook = blocking_hook base in
+       let context, resolve_context = Eio.Promise.create () in
+       let outcome, resolve_outcome = Eio.Promise.create () in
+       let publish_count = Atomic.make 0 in
+       let published_on_caller_thread = Atomic.make false in
+       Eio.Switch.run
+       @@ fun sw ->
+       with_blocking_hook_release hook
+       @@ fun () ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let caller_thread_id = Thread.id (Thread.self ()) in
+         let outcome =
+           try
+             Eio.Cancel.sub (fun cancel_context ->
+               Eio.Promise.resolve resolve_context cancel_context;
+               match
+                 KF.For_testing.save_bytes_durable_atomic_observed
+                   ~on_durable_commit:(fun () ->
+                     Atomic.set
+                       published_on_caller_thread
+                       (Thread.id (Thread.self ()) = caller_thread_id);
+                     ignore (Atomic.fetch_and_add publish_count 1))
+                   ~before_stage:(function
+                     | KF.Parent_directory_fsync_after_rename ->
+                       block_once hook (fun () -> ()) base
+                     | _ -> ())
+                   path
+                   "committed-before-cancel"
+               with
+               | Ok () -> `Returned
+               | Error error ->
+                 failf
+                   "pending-cancellation write failed: %s"
+                   (KF.durable_write_error_to_string error))
+           with
+           | Eio.Cancel.Cancelled _ -> `Cancelled
+         in
+         Eio.Promise.resolve resolve_outcome outcome);
+       let cancel_context = Eio.Promise.await context in
+       Eio.Promise.await hook.entered;
+       Eio.Cancel.cancel cancel_context Synthetic_observer_cancel;
+       release_blocking_hook hook;
+       (match Eio.Promise.await outcome with
+        | `Cancelled -> ()
+        | `Returned -> fail "pending cancellation was not propagated");
+       check int "publication precedes pending cancellation" 1
+         (Atomic.get publish_count);
+       check bool "observer ran on caller thread" true
+         (Atomic.get published_on_caller_thread))
+;;
+
+let test_durable_commit_observer_error_preserves_pending_cancellation () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Time.with_timeout_exn
+    (Eio.Stdenv.clock env)
+    coordination_watchdog_seconds
+  @@ fun () ->
+  with_eio_guard
+  @@ fun () ->
+  KF.clear_dir_cache ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let path = Filename.concat base "cancelled-with-error.bin" in
+       let hook = blocking_hook base in
+       let context, resolve_context = Eio.Promise.create () in
+       let outcome, resolve_outcome = Eio.Promise.create () in
+       let publish_count = Atomic.make 0 in
+       Eio.Switch.run
+       @@ fun sw ->
+       with_blocking_hook_release hook
+       @@ fun () ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let outcome =
+           try
+             Eio.Cancel.sub (fun cancel_context ->
+               Eio.Promise.resolve resolve_context cancel_context;
+               match
+                 KF.For_testing.save_bytes_durable_atomic_observed
+                   ~on_durable_commit:(fun () ->
+                     ignore (Atomic.fetch_and_add publish_count 1))
+                   ~before_stage:(function
+                     | KF.Payload_fsync ->
+                       block_once
+                         hook
+                         (fun () -> failwith "injected operation error")
+                         base
+                     | _ -> ())
+                   path
+                   "must-not-commit"
+               with
+               | Ok () -> `Returned_ok
+               | Error _ -> `Returned_error)
+           with
+           | Eio.Cancel.Cancelled _ -> `Cancelled
+         in
+         Eio.Promise.resolve resolve_outcome outcome);
+       let cancel_context = Eio.Promise.await context in
+       Eio.Promise.await hook.entered;
+       Eio.Cancel.cancel cancel_context Synthetic_observer_cancel;
+       release_blocking_hook hook;
+       (match Eio.Promise.await outcome with
+        | `Cancelled -> ()
+        | `Returned_ok -> fail "faulted write unexpectedly succeeded"
+        | `Returned_error ->
+          fail "pending cancellation was hidden by the operation error");
+       check int "cancelled error path does not publish" 0
+         (Atomic.get publish_count))
+;;
+
+let test_durable_commit_observer_waits_for_reanchor () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Time.with_timeout_exn
+    (Eio.Stdenv.clock env)
+    coordination_watchdog_seconds
+  @@ fun () ->
+  with_eio_guard
+  @@ fun () ->
+  KF.clear_dir_cache ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let dir = Filename.concat base "owned" in
+       let path = Filename.concat dir "request.bin" in
+       require_durable_ok
+         "seed directory lease"
+         (KF.save_bytes_durable_atomic path "seed");
+       let initial_fsync = blocking_hook dir in
+       let reanchor_fsync = blocking_hook dir in
+       let fsync_count = Atomic.make 0 in
+       let publish_count = Atomic.make 0 in
+       let outcome, resolve_outcome = Eio.Promise.create () in
+       Eio.Switch.run
+       @@ fun sw ->
+       with_blocking_hook_release initial_fsync
+       @@ fun () ->
+       with_blocking_hook_release reanchor_fsync
+       @@ fun () ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let result =
+           KF.For_testing.save_bytes_durable_atomic_observed
+             ~on_durable_commit:(fun () ->
+               ignore (Atomic.fetch_and_add publish_count 1))
+             ~before_stage:(function
+               | KF.Parent_directory_fsync_after_rename ->
+                 let occurrence = Atomic.fetch_and_add fsync_count 1 in
+                 if occurrence = 0
+                 then block_once initial_fsync (fun () -> ()) dir
+                 else if occurrence = 1
+                 then block_once reanchor_fsync (fun () -> ()) dir
+               | _ -> ())
+             path
+             "replacement"
+         in
+         Eio.Promise.resolve resolve_outcome result);
+       Eio.Promise.await initial_fsync.entered;
+       KF.invalidate_dir dir;
+       release_blocking_hook initial_fsync;
+       Eio.Promise.await reanchor_fsync.entered;
+       check int "observer remains absent before re-anchor fsync" 0
+         (Atomic.get publish_count);
+       release_blocking_hook reanchor_fsync;
+       require_durable_ok "re-anchored observed write" (Eio.Promise.await outcome);
+       check int "main write and re-anchor both fsync" 2
+         (Atomic.get fsync_count);
+       check int "observer publishes once after re-anchor" 1
+         (Atomic.get publish_count))
+;;
+
 let () =
   run
     "Keeper_fs directory durability"
@@ -863,6 +1112,24 @@ let () =
             "pressure observer preserves post-unlink error"
             `Quick
             test_pressure_observer_failure_preserves_post_unlink_error
+        ] )
+    ; ( "durable commit observer"
+      , [ test_case
+            "success publishes once and error never publishes"
+            `Quick
+            test_durable_commit_observer_cardinality
+        ; test_case
+            "publication precedes pending cancellation"
+            `Quick
+            test_durable_commit_observer_precedes_pending_cancellation
+        ; test_case
+            "pending cancellation wins over operation error"
+            `Quick
+            test_durable_commit_observer_error_preserves_pending_cancellation
+        ; test_case
+            "publication waits for directory lease re-anchor"
+            `Quick
+            test_durable_commit_observer_waits_for_reanchor
         ] )
     ; ( "coordination"
       , [ test_case

--- a/test/test_keeper_fs_directory_durability.ml
+++ b/test/test_keeper_fs_directory_durability.ml
@@ -905,7 +905,7 @@ let test_durable_commit_observer_precedes_pending_cancellation () =
        with_blocking_hook_release hook
        @@ fun () ->
        Eio.Fiber.fork ~sw (fun () ->
-         let caller_thread_id = Thread.id (Thread.self ()) in
+         let caller_domain_id = Domain.self () in
          let outcome =
            try
              Eio.Cancel.sub (fun cancel_context ->
@@ -915,7 +915,7 @@ let test_durable_commit_observer_precedes_pending_cancellation () =
                    ~on_durable_commit:(fun () ->
                      Atomic.set
                        published_on_caller_thread
-                       (Thread.id (Thread.self ()) = caller_thread_id);
+                       (Domain.self () = caller_domain_id);
                      ignore (Atomic.fetch_and_add publish_count 1))
                    ~before_stage:(function
                      | KF.Parent_directory_fsync_after_rename ->


### PR DESCRIPTION
## What

Add one required observed durable-write surface so checkpoint owners can publish an in-process commit fact before pending cancellation is re-raised.

- `save_bytes_durable_atomic_observed` requires a nonblocking/no-I/O/no-raise `on_durable_commit` callback;
- the callback runs on the caller fiber exactly once only after the final semantic durable result, including directory-lease re-anchor;
- the callback runs before `Eio_guard.check_if_ready`, while rename/fsync I/O remains cancellable and outside `Eio.Cancel.protect`;
- error/precommit paths publish zero observations and still re-raise pending cancellation;
- existing generic byte/JSON writers delegate through the same implementation with an explicit noop, not an optional callback or dual writer.

## Proof scope

- success publishes once; injected write failures publish zero;
- pending cancellation is surfaced only after durable publication on success;
- pending cancellation still wins over a simultaneous write error without publication;
- callback stays on the caller thread;
- rename followed by parent-directory fsync failure publishes zero;
- directory-lease invalidation publishes only after re-anchor completes.

Two independent static reviews found no remaining P0/P1. Per current workflow, local build/test/formatter were not run; GitHub CI is the build authority.

## Follow-up

This PR is the lower primitive only. A separate PR will thread the required observer through checkpoint/manual-compaction ownership and publish identity-bound `AckPending`; restart durability remains a later operation-journal PR.
