### PR TITLE
fix(keeper): publish durable checkpoint commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1087,6 +1087,10 @@ jobs:
         if: needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true'
         run: scripts/silent-failure-ratchet.sh
 
+      - name: Run checkpoint installation legacy purge ratchet
+        if: needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true'
+        run: scripts/check-checkpoint-installation-legacy-purge.sh
+
       - name: Run keeper cwd leak gate
         if: needs.changes.outputs.keeper_cwd == 'true'
         run: scripts/keeper-cwd-leak-gate.sh

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -845,11 +845,18 @@ module For_testing = struct
       ~expected_source_ref
       candidate =
     let with_release_failure ~session_dir f =
-      with_checkpoint_cas_lock ~session_dir f
-      |> fun installation ->
-      append_installation_auxiliary
-        installation
-        (Release_process_lock_failed release_failure)
+      match canonical_session_location session_dir with
+      | Error error ->
+        not_installed
+          (Source_unavailable
+             (Ref_lock_failed (save_oas_error_to_string error)))
+      | Ok session_dir ->
+        let lock_path = session_dir ^ ".checkpoint.lock" in
+        File_lock_eio.For_testing.with_durable_lock_observed_with_release_failure
+          ~release_failure
+          ~lock_path
+          (fun () -> f session_dir)
+        |> installation_of_lock_observation
     in
     save_oas_if_source_with
       ~with_checkpoint_cas_lock:with_release_failure

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -540,21 +540,18 @@ type checkpoint_cas_error =
       { expected : int
       ; candidate : int
       }
-  | Candidate_turn_regressed of
-      { source_turn : int
-      ; candidate_turn : int
-      }
-  | Commit_not_installed of Keeper_fs.durable_write_error
-  | Commit_durability_unknown of
-      { installed_ref : Keeper_checkpoint_ref.t
-      ; error : Keeper_fs.durable_write_error
-      }
-  | Transaction_outcome_unknown of
-      { possible_installed_ref : Keeper_checkpoint_ref.t
-      ; error : File_lock_eio.durable_lock_error
-      }
+   | Candidate_turn_regressed of
+       { source_turn : int
+       ; candidate_turn : int
+       }
+   | Commit_not_installed of Keeper_fs.durable_write_error
+   | Transaction_outcome_unknown of
+       { possible_installed_ref : Keeper_checkpoint_ref.t
+       ; error : File_lock_eio.durable_lock_error
+       }
 
 type checkpoint_installation_auxiliary =
+  | Commit_durability_unknown of Keeper_fs.durable_write_error
   | Commit_observer_failed of Eio.Exn.with_bt
   | Release_process_lock_failed of File_lock_eio.durable_lock_error
   | Post_commit_unwind_interrupted of Eio.Exn.with_bt
@@ -677,6 +674,7 @@ let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
 
 let save_oas_if_source_with
     ~with_checkpoint_cas_lock
+    ~write_checkpoint_bytes
     ~(on_checkpoint_commit_observer : Keeper_checkpoint_ref.t -> unit)
     ~session_dir
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
@@ -743,16 +741,14 @@ let save_oas_if_source_with
            in
            let ownership_root = Filename.dirname session_dir in
            (match
-              Keeper_fs.save_bytes_durable_atomic_observed
+              write_checkpoint_bytes
                 ~on_durable_commit:observe_commit
                 ~ownership_root
-                canonical_path
-                candidate_bytes
+                ~path:canonical_path
+                ~bytes:candidate_bytes
             with
             | Error error when error.Keeper_fs.renamed ->
-              Not_installed
-                (Commit_durability_unknown
-                   { installed_ref = candidate_ref; error })
+              publish [ Commit_durability_unknown error ]
             | Error error -> Not_installed (Commit_not_installed error)
             | Ok Keeper_fs.Committed ->
               (* The durable writer installs [candidate_bytes] verbatim - the
@@ -775,14 +771,19 @@ let save_oas_if_source_with
       | Some installed -> installed
       | None -> { installed_ref; auxiliary = [] }
     in
+    let known_installed_ref () =
+      match !committed_installation with
+      | Some installed -> Some installed.installed_ref
+      | None -> !observed_ref
+    in
     (match outcome with
      | `Returned
          (Not_installed
             (Transaction_outcome_unknown
                { possible_installed_ref; error }))
-       when (match !observed_ref with
-             | Some observed_ref ->
-               Keeper_checkpoint_ref.equal observed_ref possible_installed_ref
+       when (match known_installed_ref () with
+             | Some installed_ref ->
+               Keeper_checkpoint_ref.equal installed_ref possible_installed_ref
              | None -> false) ->
        Installed
          (append_auxiliary
@@ -790,7 +791,7 @@ let save_oas_if_source_with
             (Release_process_lock_failed error))
      | `Returned installation -> installation
      | `Raised (exn, backtrace) ->
-       (match !observed_ref with
+       (match known_installed_ref () with
         | Some installed_ref ->
           Installed
             (append_auxiliary
@@ -798,9 +799,22 @@ let save_oas_if_source_with
                (Post_commit_unwind_interrupted (exn, backtrace)))
         | None -> Printexc.raise_with_backtrace exn backtrace))
 
+let write_checkpoint_bytes
+    ~on_durable_commit
+    ~ownership_root
+    ~path
+    ~bytes =
+  Keeper_fs.save_bytes_durable_atomic_observed
+    ~on_durable_commit
+    ~ownership_root
+    path
+    bytes
+;;
+
 let save_oas_if_source ~session_dir ~expected_source_ref candidate =
   save_oas_if_source_with
     ~with_checkpoint_cas_lock
+    ~write_checkpoint_bytes
     ~on_checkpoint_commit_observer:(fun _ -> ())
     ~session_dir
     ~expected_source_ref
@@ -815,6 +829,7 @@ module For_testing = struct
       candidate =
     save_oas_if_source_with
       ~with_checkpoint_cas_lock
+      ~write_checkpoint_bytes
       ~on_checkpoint_commit_observer
       ~session_dir
       ~expected_source_ref
@@ -839,6 +854,44 @@ module For_testing = struct
     in
     save_oas_if_source_with
       ~with_checkpoint_cas_lock:with_release_failure
+      ~write_checkpoint_bytes
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate
+  ;;
+
+  let save_oas_if_source_with_writer
+      ~write_checkpoint_bytes
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate =
+    save_oas_if_source_with
+      ~with_checkpoint_cas_lock
+      ~write_checkpoint_bytes
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate
+  ;;
+
+  let save_oas_if_source_with_post_commit_unwind
+      ~post_commit_unwind
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate =
+    let with_post_commit_unwind ~session_dir ~candidate_ref f =
+      match with_checkpoint_cas_lock ~session_dir ~candidate_ref f with
+      | Installed _ as installation ->
+        post_commit_unwind ();
+        installation
+      | Not_installed _ as outcome -> outcome
+    in
+    save_oas_if_source_with
+      ~with_checkpoint_cas_lock:with_post_commit_unwind
+      ~write_checkpoint_bytes
       ~on_checkpoint_commit_observer
       ~session_dir
       ~expected_source_ref

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -554,6 +554,11 @@ type checkpoint_cas_error =
       ; error : File_lock_eio.durable_lock_error
       }
 
+type checkpoint_installation =
+  { installed_ref : Keeper_checkpoint_ref.t
+  ; hint_failure : Eio.Exn.with_bt option
+  }
+
 let checkpoint_generation_strict (checkpoint : Agent_sdk.Checkpoint.t) =
   match
     Agent_sdk.Context.get_scoped checkpoint.Agent_sdk.Checkpoint.context
@@ -661,7 +666,7 @@ let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
                   (File_lock_eio.durable_lock_error_to_string error)))))
 
 let save_oas_if_source
-    ~(on_checkpoint_committed : unit -> unit)
+    ~(on_checkpoint_commit_hint : Keeper_checkpoint_ref.t -> unit)
     ~session_dir
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
     (candidate : Agent_sdk.Checkpoint.t) =
@@ -696,55 +701,58 @@ let save_oas_if_source
          })
   | Ok candidate_ref ->
     let expected_session_id = expected_source_ref.trace_id in
-    let committed = ref false in
-    let outcome =
-      try
-        `Returned
-          (with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
-             match load_ref_locked ~session_dir ~expected_session_id with
-             | Error error -> Error (Source_unavailable error)
-             | Ok snapshot
-               when not
-                      (Keeper_checkpoint_ref.equal
-                         expected_source_ref
-                         (exact_snapshot_reference snapshot)) ->
-               Error (Source_changed (exact_snapshot_reference snapshot))
-             | Ok _ ->
-                  let canonical_path =
-                    oas_checkpoint_path
-                      ~session_dir
-                      ~session_id:
-                        (Keeper_id.Trace_id.to_string expected_session_id)
-                  in
-                  let ownership_root = Filename.dirname session_dir in
-                  (match
-                     Keeper_fs.save_bytes_durable_atomic_observed
-                       ~on_durable_commit:(fun () -> committed := true)
-                       ~ownership_root
-                       canonical_path
-                       candidate_bytes
-                   with
-                   | Error error when error.Keeper_fs.renamed ->
-                     Error
-                       (Commit_durability_unknown
-                          { installed_ref = candidate_ref; error })
-                   | Error error -> Error (Commit_not_installed error)
-                   | Ok () ->
-                     (* The durable writer installs [candidate_bytes] verbatim —
-                        the exact bytes [candidate_ref] was derived from — so the
-                        published file and the returned ref agree by construction,
-                        not by an encoding contract. Once the writer returns [Ok],
-                        rename and both durability fsyncs have completed; a
-                        post-commit read cannot downgrade that committed outcome
-                        to a retryable failure. *)
-                     Ok candidate_ref)))
-      with
-      | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+    let observed_ref = ref None in
+    let installation ?hint_failure () =
+      { installed_ref = candidate_ref; hint_failure }
     in
-    Keeper_fs.finish_durable_commit_observation
-      ~commit_observed:committed
-      ~on_durable_commit:on_checkpoint_committed
-      outcome
+    let observe_commit () =
+      observed_ref := Some candidate_ref;
+      on_checkpoint_commit_hint candidate_ref
+    in
+    (try
+       with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
+         match load_ref_locked ~session_dir ~expected_session_id with
+         | Error error -> Error (Source_unavailable error)
+         | Ok snapshot
+           when not
+                  (Keeper_checkpoint_ref.equal
+                     expected_source_ref
+                     (exact_snapshot_reference snapshot)) ->
+           Error (Source_changed (exact_snapshot_reference snapshot))
+         | Ok _ ->
+           let canonical_path =
+             oas_checkpoint_path
+               ~session_dir
+               ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
+           in
+           let ownership_root = Filename.dirname session_dir in
+           (match
+              Keeper_fs.save_bytes_durable_atomic_observed
+                ~on_durable_commit:observe_commit
+                ~ownership_root
+                canonical_path
+                candidate_bytes
+            with
+            | Error error when error.Keeper_fs.renamed ->
+              Error
+                (Commit_durability_unknown
+                   { installed_ref = candidate_ref; error })
+            | Error error -> Error (Commit_not_installed error)
+            | Ok Keeper_fs.Committed ->
+              (* The durable writer installs [candidate_bytes] verbatim - the
+                 exact bytes [candidate_ref] was derived from - so the
+                 published file and the returned ref agree by construction.
+                 The hint is auxiliary and cannot downgrade that fact. *)
+              Ok (installation ())
+            | Ok (Keeper_fs.Committed_but_observer_failed failure) ->
+              Ok (installation ~hint_failure:failure ())))
+     with
+     | exn ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       (match !observed_ref with
+        | Some installed_ref ->
+          Ok { installed_ref; hint_failure = Some (exn, backtrace) }
+        | None -> Printexc.raise_with_backtrace exn backtrace))
 
 let save_oas_classified_typed
     ~(session_dir : string)

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -545,10 +545,6 @@ type checkpoint_cas_error =
        ; candidate_turn : int
        }
    | Commit_not_installed of Keeper_fs.durable_write_error
-   | Transaction_outcome_unknown of
-       { possible_installed_ref : Keeper_checkpoint_ref.t
-       ; error : File_lock_eio.durable_lock_error
-       }
 
 type checkpoint_installation_auxiliary =
   | Commit_durability_unknown of Keeper_fs.durable_write_error
@@ -557,14 +553,35 @@ type checkpoint_installation_auxiliary =
   | Post_commit_unwind_interrupted of Eio.Exn.with_bt
   | History_write_failed of Eio.Exn.with_bt
 
+type not_installed_checkpoint =
+  { cause : checkpoint_cas_error
+  ; auxiliary : checkpoint_installation_auxiliary list
+  }
+
 type installed_checkpoint =
   { installed_ref : Keeper_checkpoint_ref.t
   ; auxiliary : checkpoint_installation_auxiliary list
   }
 
 type checkpoint_installation =
-  | Not_installed of checkpoint_cas_error
+  | Not_installed of not_installed_checkpoint
   | Installed of installed_checkpoint
+
+let not_installed cause = Not_installed { cause; auxiliary = [] }
+
+let append_installation_auxiliary installation auxiliary =
+  match installation with
+  | Not_installed outcome ->
+    Not_installed
+      { outcome with
+        auxiliary = outcome.auxiliary @ [ auxiliary ]
+      }
+  | Installed outcome ->
+    Installed
+      { outcome with
+        auxiliary = outcome.auxiliary @ [ auxiliary ]
+      }
+;;
 
 let checkpoint_generation_strict (checkpoint : Agent_sdk.Checkpoint.t) =
   match
@@ -649,28 +666,31 @@ let load_oas_with_ref ~session_dir ~session_id =
     exact_snapshot_checkpoint snapshot, exact_snapshot_reference snapshot)
 ;;
 
-let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
+let lock_failure_not_installed error =
+  not_installed
+    (Source_unavailable
+       (Ref_lock_failed (File_lock_eio.durable_lock_error_to_string error)))
+;;
+
+let installation_of_lock_observation = function
+  | File_lock_eio.Lock_not_acquired error -> lock_failure_not_installed error
+  | File_lock_eio.Body_completed { value; release_error = None } -> value
+  | File_lock_eio.Body_completed { value; release_error = Some error } ->
+    append_installation_auxiliary value (Release_process_lock_failed error)
+;;
+
+let with_checkpoint_cas_lock ~session_dir f =
   match canonical_session_location session_dir with
   | Error error ->
-    Not_installed
+    not_installed
       (Source_unavailable
          (Ref_lock_failed (save_oas_error_to_string error)))
   | Ok session_dir ->
     let lock_path = session_dir ^ ".checkpoint.lock" in
-    (match File_lock_eio.with_durable_lock ~lock_path (fun () -> f session_dir) with
-     | Ok result -> result
-     | Error error ->
-       (match error.File_lock_eio.phase with
-        | File_lock_eio.Release_process_lock ->
-          Not_installed
-            (Transaction_outcome_unknown
-               { possible_installed_ref = candidate_ref; error })
-        | File_lock_eio.Open_lock_file
-        | File_lock_eio.Acquire_process_lock ->
-          Not_installed
-            (Source_unavailable
-               (Ref_lock_failed
-                  (File_lock_eio.durable_lock_error_to_string error)))))
+    File_lock_eio.with_durable_lock_observed
+      ~lock_path
+      (fun () -> f session_dir)
+    |> installation_of_lock_observation
 
 let save_oas_if_source_with
     ~with_checkpoint_cas_lock
@@ -684,26 +704,26 @@ let save_oas_if_source_with
       Yojson.Safe.to_string (Agent_sdk.Checkpoint.to_json candidate))
   in
   match checkpoint_ref_of_canonical_bytes candidate_bytes candidate with
-  | Error error -> Not_installed (Candidate_identity_invalid error)
+  | Error error -> not_installed (Candidate_identity_invalid error)
   | Ok candidate_ref
     when not
            (Keeper_id.Trace_id.equal
               expected_source_ref.trace_id candidate_ref.trace_id) ->
-    Not_installed
+    not_installed
       (Candidate_session_mismatch
          { expected = expected_source_ref.trace_id
          ; candidate = candidate_ref.trace_id
          })
   | Ok candidate_ref
     when not (Int.equal expected_source_ref.generation candidate_ref.generation) ->
-    Not_installed
+    not_installed
       (Candidate_generation_mismatch
          { expected = expected_source_ref.generation
          ; candidate = candidate_ref.generation
          })
   | Ok candidate_ref
     when candidate_ref.turn_count < expected_source_ref.turn_count ->
-    Not_installed
+    not_installed
       (Candidate_turn_regressed
          { source_turn = expected_source_ref.turn_count
          ; candidate_turn = candidate_ref.turn_count
@@ -724,15 +744,15 @@ let save_oas_if_source_with
     let outcome =
       try
         `Returned
-          (with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
+          (with_checkpoint_cas_lock ~session_dir (fun session_dir ->
          match load_ref_locked ~session_dir ~expected_session_id with
-         | Error error -> Not_installed (Source_unavailable error)
+         | Error error -> not_installed (Source_unavailable error)
          | Ok snapshot
            when not
                   (Keeper_checkpoint_ref.equal
                      expected_source_ref
                      (exact_snapshot_reference snapshot)) ->
-           Not_installed (Source_changed (exact_snapshot_reference snapshot))
+           not_installed (Source_changed (exact_snapshot_reference snapshot))
          | Ok _ ->
            let canonical_path =
              oas_checkpoint_path
@@ -749,7 +769,7 @@ let save_oas_if_source_with
             with
             | Error error when error.Keeper_fs.renamed ->
               publish [ Commit_durability_unknown error ]
-            | Error error -> Not_installed (Commit_not_installed error)
+            | Error error -> not_installed (Commit_not_installed error)
             | Ok Keeper_fs.Committed ->
               (* The durable writer installs [candidate_bytes] verbatim - the
                  exact bytes [candidate_ref] was derived from - so the
@@ -760,11 +780,6 @@ let save_oas_if_source_with
               publish [ Commit_observer_failed failure ])))
       with
       | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
-    in
-    let append_auxiliary installed auxiliary =
-      { installed with
-        auxiliary = installed.auxiliary @ [ auxiliary ]
-      }
     in
     let observed_installation installed_ref =
       match !committed_installation with
@@ -777,26 +792,13 @@ let save_oas_if_source_with
       | None -> !observed_ref
     in
     (match outcome with
-     | `Returned
-         (Not_installed
-            (Transaction_outcome_unknown
-               { possible_installed_ref; error }))
-       when (match known_installed_ref () with
-             | Some installed_ref ->
-               Keeper_checkpoint_ref.equal installed_ref possible_installed_ref
-             | None -> false) ->
-       Installed
-         (append_auxiliary
-            (observed_installation possible_installed_ref)
-            (Release_process_lock_failed error))
      | `Returned installation -> installation
      | `Raised (exn, backtrace) ->
        (match known_installed_ref () with
         | Some installed_ref ->
-          Installed
-            (append_auxiliary
-               (observed_installation installed_ref)
-               (Post_commit_unwind_interrupted (exn, backtrace)))
+          append_installation_auxiliary
+            (Installed (observed_installation installed_ref))
+            (Post_commit_unwind_interrupted (exn, backtrace))
         | None -> Printexc.raise_with_backtrace exn backtrace))
 
 let write_checkpoint_bytes
@@ -842,18 +844,34 @@ module For_testing = struct
       ~session_dir
       ~expected_source_ref
       candidate =
-    let with_release_failure ~session_dir ~candidate_ref f =
-      match with_checkpoint_cas_lock ~session_dir ~candidate_ref f with
-      | Installed _ ->
-        Not_installed
-          (Transaction_outcome_unknown
-             { possible_installed_ref = candidate_ref
-             ; error = release_failure
-             })
-      | Not_installed _ as outcome -> outcome
+    let with_release_failure ~session_dir f =
+      with_checkpoint_cas_lock ~session_dir f
+      |> fun installation ->
+      append_installation_auxiliary
+        installation
+        (Release_process_lock_failed release_failure)
     in
     save_oas_if_source_with
       ~with_checkpoint_cas_lock:with_release_failure
+      ~write_checkpoint_bytes
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate
+  ;;
+
+  let save_oas_if_source_with_acquire_failure
+      ~acquire_failure
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate =
+    let with_acquire_failure ~session_dir:_ _f =
+      installation_of_lock_observation
+        (File_lock_eio.Lock_not_acquired acquire_failure)
+    in
+    save_oas_if_source_with
+      ~with_checkpoint_cas_lock:with_acquire_failure
       ~write_checkpoint_bytes
       ~on_checkpoint_commit_observer
       ~session_dir
@@ -882,8 +900,8 @@ module For_testing = struct
       ~session_dir
       ~expected_source_ref
       candidate =
-    let with_post_commit_unwind ~session_dir ~candidate_ref f =
-      match with_checkpoint_cas_lock ~session_dir ~candidate_ref f with
+    let with_post_commit_unwind ~session_dir f =
+      match with_checkpoint_cas_lock ~session_dir f with
       | Installed _ as installation ->
         post_commit_unwind ();
         installation

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -554,10 +554,20 @@ type checkpoint_cas_error =
       ; error : File_lock_eio.durable_lock_error
       }
 
-type checkpoint_installation =
+type checkpoint_installation_auxiliary =
+  | Commit_observer_failed of Eio.Exn.with_bt
+  | Release_process_lock_failed of File_lock_eio.durable_lock_error
+  | Post_commit_unwind_interrupted of Eio.Exn.with_bt
+  | History_write_failed of Eio.Exn.with_bt
+
+type installed_checkpoint =
   { installed_ref : Keeper_checkpoint_ref.t
-  ; hint_failure : Eio.Exn.with_bt option
+  ; auxiliary : checkpoint_installation_auxiliary list
   }
+
+type checkpoint_installation =
+  | Not_installed of checkpoint_cas_error
+  | Installed of installed_checkpoint
 
 let checkpoint_generation_strict (checkpoint : Agent_sdk.Checkpoint.t) =
   match
@@ -645,7 +655,7 @@ let load_oas_with_ref ~session_dir ~session_id =
 let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
   match canonical_session_location session_dir with
   | Error error ->
-    Error
+    Not_installed
       (Source_unavailable
          (Ref_lock_failed (save_oas_error_to_string error)))
   | Ok session_dir ->
@@ -655,18 +665,19 @@ let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
      | Error error ->
        (match error.File_lock_eio.phase with
         | File_lock_eio.Release_process_lock ->
-          Error
+          Not_installed
             (Transaction_outcome_unknown
                { possible_installed_ref = candidate_ref; error })
         | File_lock_eio.Open_lock_file
         | File_lock_eio.Acquire_process_lock ->
-          Error
+          Not_installed
             (Source_unavailable
                (Ref_lock_failed
                   (File_lock_eio.durable_lock_error_to_string error)))))
 
-let save_oas_if_source
-    ~(on_checkpoint_commit_hint : Keeper_checkpoint_ref.t -> unit)
+let save_oas_if_source_with
+    ~with_checkpoint_cas_lock
+    ~(on_checkpoint_commit_observer : Keeper_checkpoint_ref.t -> unit)
     ~session_dir
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
     (candidate : Agent_sdk.Checkpoint.t) =
@@ -675,26 +686,26 @@ let save_oas_if_source
       Yojson.Safe.to_string (Agent_sdk.Checkpoint.to_json candidate))
   in
   match checkpoint_ref_of_canonical_bytes candidate_bytes candidate with
-  | Error error -> Error (Candidate_identity_invalid error)
+  | Error error -> Not_installed (Candidate_identity_invalid error)
   | Ok candidate_ref
     when not
            (Keeper_id.Trace_id.equal
               expected_source_ref.trace_id candidate_ref.trace_id) ->
-    Error
+    Not_installed
       (Candidate_session_mismatch
          { expected = expected_source_ref.trace_id
          ; candidate = candidate_ref.trace_id
          })
   | Ok candidate_ref
     when not (Int.equal expected_source_ref.generation candidate_ref.generation) ->
-    Error
+    Not_installed
       (Candidate_generation_mismatch
          { expected = expected_source_ref.generation
          ; candidate = candidate_ref.generation
          })
   | Ok candidate_ref
     when candidate_ref.turn_count < expected_source_ref.turn_count ->
-    Error
+    Not_installed
       (Candidate_turn_regressed
          { source_turn = expected_source_ref.turn_count
          ; candidate_turn = candidate_ref.turn_count
@@ -702,23 +713,28 @@ let save_oas_if_source
   | Ok candidate_ref ->
     let expected_session_id = expected_source_ref.trace_id in
     let observed_ref = ref None in
-    let installation ?hint_failure () =
-      { installed_ref = candidate_ref; hint_failure }
+    let committed_installation = ref None in
+    let publish auxiliary =
+      let installed = { installed_ref = candidate_ref; auxiliary } in
+      committed_installation := Some installed;
+      Installed installed
     in
     let observe_commit () =
       observed_ref := Some candidate_ref;
-      on_checkpoint_commit_hint candidate_ref
+      on_checkpoint_commit_observer candidate_ref
     in
-    (try
-       with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
+    let outcome =
+      try
+        `Returned
+          (with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
          match load_ref_locked ~session_dir ~expected_session_id with
-         | Error error -> Error (Source_unavailable error)
+         | Error error -> Not_installed (Source_unavailable error)
          | Ok snapshot
            when not
                   (Keeper_checkpoint_ref.equal
                      expected_source_ref
                      (exact_snapshot_reference snapshot)) ->
-           Error (Source_changed (exact_snapshot_reference snapshot))
+           Not_installed (Source_changed (exact_snapshot_reference snapshot))
          | Ok _ ->
            let canonical_path =
              oas_checkpoint_path
@@ -734,25 +750,101 @@ let save_oas_if_source
                 candidate_bytes
             with
             | Error error when error.Keeper_fs.renamed ->
-              Error
+              Not_installed
                 (Commit_durability_unknown
                    { installed_ref = candidate_ref; error })
-            | Error error -> Error (Commit_not_installed error)
+            | Error error -> Not_installed (Commit_not_installed error)
             | Ok Keeper_fs.Committed ->
               (* The durable writer installs [candidate_bytes] verbatim - the
                  exact bytes [candidate_ref] was derived from - so the
                  published file and the returned ref agree by construction.
                  The hint is auxiliary and cannot downgrade that fact. *)
-              Ok (installation ())
+              publish []
             | Ok (Keeper_fs.Committed_but_observer_failed failure) ->
-              Ok (installation ~hint_failure:failure ())))
-     with
-     | exn ->
-       let backtrace = Printexc.get_raw_backtrace () in
+              publish [ Commit_observer_failed failure ])))
+      with
+      | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+    in
+    let append_auxiliary installed auxiliary =
+      { installed with
+        auxiliary = installed.auxiliary @ [ auxiliary ]
+      }
+    in
+    let observed_installation installed_ref =
+      match !committed_installation with
+      | Some installed -> installed
+      | None -> { installed_ref; auxiliary = [] }
+    in
+    (match outcome with
+     | `Returned
+         (Not_installed
+            (Transaction_outcome_unknown
+               { possible_installed_ref; error }))
+       when (match !observed_ref with
+             | Some observed_ref ->
+               Keeper_checkpoint_ref.equal observed_ref possible_installed_ref
+             | None -> false) ->
+       Installed
+         (append_auxiliary
+            (observed_installation possible_installed_ref)
+            (Release_process_lock_failed error))
+     | `Returned installation -> installation
+     | `Raised (exn, backtrace) ->
        (match !observed_ref with
         | Some installed_ref ->
-          Ok { installed_ref; hint_failure = Some (exn, backtrace) }
+          Installed
+            (append_auxiliary
+               (observed_installation installed_ref)
+               (Post_commit_unwind_interrupted (exn, backtrace)))
         | None -> Printexc.raise_with_backtrace exn backtrace))
+
+let save_oas_if_source ~session_dir ~expected_source_ref candidate =
+  save_oas_if_source_with
+    ~with_checkpoint_cas_lock
+    ~on_checkpoint_commit_observer:(fun _ -> ())
+    ~session_dir
+    ~expected_source_ref
+    candidate
+;;
+
+module For_testing = struct
+  let save_oas_if_source_with_observer
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate =
+    save_oas_if_source_with
+      ~with_checkpoint_cas_lock
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate
+  ;;
+
+  let save_oas_if_source_with_release_failure
+      ~release_failure
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate =
+    let with_release_failure ~session_dir ~candidate_ref f =
+      match with_checkpoint_cas_lock ~session_dir ~candidate_ref f with
+      | Installed _ ->
+        Not_installed
+          (Transaction_outcome_unknown
+             { possible_installed_ref = candidate_ref
+             ; error = release_failure
+             })
+      | Not_installed _ as outcome -> outcome
+    in
+    save_oas_if_source_with
+      ~with_checkpoint_cas_lock:with_release_failure
+      ~on_checkpoint_commit_observer
+      ~session_dir
+      ~expected_source_ref
+      candidate
+  ;;
+end
 
 let save_oas_classified_typed
     ~(session_dir : string)

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -661,6 +661,7 @@ let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
                   (File_lock_eio.durable_lock_error_to_string error)))))
 
 let save_oas_if_source
+    ~(on_checkpoint_committed : unit -> unit)
     ~session_dir
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
     (candidate : Agent_sdk.Checkpoint.t) =
@@ -695,42 +696,55 @@ let save_oas_if_source
          })
   | Ok candidate_ref ->
     let expected_session_id = expected_source_ref.trace_id in
-    with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
-      match load_ref_locked ~session_dir ~expected_session_id with
-      | Error error -> Error (Source_unavailable error)
-      | Ok snapshot
-        when not
-               (Keeper_checkpoint_ref.equal
-                  expected_source_ref
-                  (exact_snapshot_reference snapshot)) ->
-        Error (Source_changed (exact_snapshot_reference snapshot))
-      | Ok _ ->
-           let canonical_path =
-             oas_checkpoint_path
-               ~session_dir
-               ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
-           in
-           let ownership_root = Filename.dirname session_dir in
-           (match
-              Keeper_fs.save_bytes_durable_atomic
-                ~ownership_root
-                canonical_path
-                candidate_bytes
-            with
-            | Error error when error.Keeper_fs.renamed ->
-              Error
-                (Commit_durability_unknown
-                   { installed_ref = candidate_ref; error })
-            | Error error -> Error (Commit_not_installed error)
-            | Ok () ->
-              (* The durable writer installs [candidate_bytes] verbatim — the
-                 exact bytes [candidate_ref] was derived from — so the
-                 published file and the returned ref agree by construction,
-                 not by an encoding contract. Once the writer returns [Ok],
-                 rename and both durability fsyncs have completed; a
-                 post-commit read cannot downgrade that committed outcome to
-                 a retryable failure. *)
-              Ok candidate_ref))
+    let committed = ref false in
+    let outcome =
+      try
+        `Returned
+          (with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
+             match load_ref_locked ~session_dir ~expected_session_id with
+             | Error error -> Error (Source_unavailable error)
+             | Ok snapshot
+               when not
+                      (Keeper_checkpoint_ref.equal
+                         expected_source_ref
+                         (exact_snapshot_reference snapshot)) ->
+               Error (Source_changed (exact_snapshot_reference snapshot))
+             | Ok _ ->
+                  let canonical_path =
+                    oas_checkpoint_path
+                      ~session_dir
+                      ~session_id:
+                        (Keeper_id.Trace_id.to_string expected_session_id)
+                  in
+                  let ownership_root = Filename.dirname session_dir in
+                  (match
+                     Keeper_fs.save_bytes_durable_atomic_observed
+                       ~on_durable_commit:(fun () -> committed := true)
+                       ~ownership_root
+                       canonical_path
+                       candidate_bytes
+                   with
+                   | Error error when error.Keeper_fs.renamed ->
+                     Error
+                       (Commit_durability_unknown
+                          { installed_ref = candidate_ref; error })
+                   | Error error -> Error (Commit_not_installed error)
+                   | Ok () ->
+                     (* The durable writer installs [candidate_bytes] verbatim —
+                        the exact bytes [candidate_ref] was derived from — so the
+                        published file and the returned ref agree by construction,
+                        not by an encoding contract. Once the writer returns [Ok],
+                        rename and both durability fsyncs have completed; a
+                        post-commit read cannot downgrade that committed outcome
+                        to a retryable failure. *)
+                     Ok candidate_ref)))
+      with
+      | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+    in
+    Keeper_fs.finish_durable_commit_observation
+      ~commit_observed:committed
+      ~on_durable_commit:on_checkpoint_committed
+      outcome
 
 let save_oas_classified_typed
     ~(session_dir : string)

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -214,11 +214,17 @@ type checkpoint_cas_error =
     ref is derived from the exact compact bytes passed to the durable atomic
     JSON writer. A writer error after atomic rename is
     [Commit_durability_unknown], never a retryable not-installed failure. This
-    same rule applies when releasing the stable lock fails after the body:
-    [Transaction_outcome_unknown] requires reconciliation rather than retry. The
-    payload-store commit is not an operation terminal fact; the Keeper operation
-    journal owns that authority. *)
+     same rule applies when releasing the stable lock fails after the body:
+     [Transaction_outcome_unknown] requires reconciliation rather than retry. The
+     payload-store commit is not an operation terminal fact; the Keeper operation
+     journal owns that authority. [on_checkpoint_committed] runs exactly once
+     after the CAS lock scope has unwound when durable commit was observed. It
+     runs without [Eio.Cancel.protect] and must not perform I/O, suspend, or
+     raise. If it violates that contract while a prior operation exception or
+     cancellation is already unwinding, the prior exception and its raw
+     backtrace take precedence; the observer failure is logged. *)
 val save_oas_if_source :
+  on_checkpoint_committed:(unit -> unit) ->
   session_dir:string ->
   expected_source_ref:Keeper_checkpoint_ref.t ->
   Agent_sdk.Checkpoint.t ->

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -198,10 +198,6 @@ type checkpoint_cas_error =
        ; candidate_turn : int
        }
    | Commit_not_installed of Keeper_fs.durable_write_error
-   | Transaction_outcome_unknown of
-       { possible_installed_ref : Keeper_checkpoint_ref.t
-       ; error : File_lock_eio.durable_lock_error
-       }
 
 type checkpoint_installation_auxiliary =
   | Commit_durability_unknown of Keeper_fs.durable_write_error
@@ -210,13 +206,18 @@ type checkpoint_installation_auxiliary =
   | Post_commit_unwind_interrupted of Eio.Exn.with_bt
   | History_write_failed of Eio.Exn.with_bt
 
+type not_installed_checkpoint =
+  { cause : checkpoint_cas_error
+  ; auxiliary : checkpoint_installation_auxiliary list
+  }
+
 type installed_checkpoint =
   { installed_ref : Keeper_checkpoint_ref.t
   ; auxiliary : checkpoint_installation_auxiliary list
   }
 
 type checkpoint_installation =
-  | Not_installed of checkpoint_cas_error
+  | Not_installed of not_installed_checkpoint
   | Installed of installed_checkpoint
 
 (** Conditionally publish [candidate] only when the canonical bytes still
@@ -226,9 +227,10 @@ type checkpoint_installation =
     ref is derived from the exact compact bytes passed to the durable atomic
     JSON writer. A writer error after atomic rename is an [Installed] result
     carrying [Commit_durability_unknown], never a retryable not-installed
-    failure. This same rule applies when releasing the stable lock fails after
-    the body:
-    [Transaction_outcome_unknown] requires reconciliation rather than retry.
+    failure. Releasing the stable lock cannot replace the already-computed body
+    result: [Not_installed] retains its exact cause and [Installed] retains its
+    exact reference, with [Release_process_lock_failed] appended as auxiliary
+    evidence in either case.
     The payload-store commit is not an operation terminal fact; the Keeper
     operation journal owns that authority.
 
@@ -253,6 +255,14 @@ module For_testing : sig
 
   val save_oas_if_source_with_release_failure :
     release_failure:File_lock_eio.durable_lock_error ->
+    on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    session_dir:string ->
+    expected_source_ref:Keeper_checkpoint_ref.t ->
+    Agent_sdk.Checkpoint.t ->
+    checkpoint_installation
+
+  val save_oas_if_source_with_acquire_failure :
+    acquire_failure:File_lock_eio.durable_lock_error ->
     on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
     session_dir:string ->
     expected_source_ref:Keeper_checkpoint_ref.t ->

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -207,10 +207,20 @@ type checkpoint_cas_error =
       ; error : File_lock_eio.durable_lock_error
       }
 
-type checkpoint_installation =
+type checkpoint_installation_auxiliary =
+  | Commit_observer_failed of Eio.Exn.with_bt
+  | Release_process_lock_failed of File_lock_eio.durable_lock_error
+  | Post_commit_unwind_interrupted of Eio.Exn.with_bt
+  | History_write_failed of Eio.Exn.with_bt
+
+type installed_checkpoint =
   { installed_ref : Keeper_checkpoint_ref.t
-  ; hint_failure : Eio.Exn.with_bt option
+  ; auxiliary : checkpoint_installation_auxiliary list
   }
+
+type checkpoint_installation =
+  | Not_installed of checkpoint_cas_error
+  | Installed of installed_checkpoint
 
 (** Conditionally publish [candidate] only when the canonical bytes still
     have exactly [expected_source_ref]. The stable session lock is reacquired,
@@ -224,17 +234,30 @@ type checkpoint_installation =
     The payload-store commit is not an operation terminal fact; the Keeper
     operation journal owns that authority.
 
-    [on_checkpoint_commit_hint] receives the exact installed reference in the
-    caller fiber when this invocation observes durable commit. It is a lossy,
-    best-effort hint, may run before the CAS lock is released, and must not be
-    used as an acknowledgement or restart authority. A callback failure or
-    cooperative cancellation observed after durable commit is returned in
-    [hint_failure] alongside the installed reference; it never becomes an
-    install failure or retry signal. An exception before commit is re-raised
-    with its original raw backtrace. *)
+    The closed result distinguishes [Not_installed] from [Installed].
+    Observer, release-lock, unwind, and history failures after durable commit
+    remain typed [auxiliary] facts beside the exact installed reference; they
+    never become install failures or retry signals. An exception before commit
+    is re-raised with its original raw backtrace. *)
 val save_oas_if_source :
-  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
   session_dir:string ->
   expected_source_ref:Keeper_checkpoint_ref.t ->
   Agent_sdk.Checkpoint.t ->
-  (checkpoint_installation, checkpoint_cas_error) result
+  checkpoint_installation
+
+module For_testing : sig
+  val save_oas_if_source_with_observer :
+    on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    session_dir:string ->
+    expected_source_ref:Keeper_checkpoint_ref.t ->
+    Agent_sdk.Checkpoint.t ->
+    checkpoint_installation
+
+  val save_oas_if_source_with_release_failure :
+    release_failure:File_lock_eio.durable_lock_error ->
+    on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    session_dir:string ->
+    expected_source_ref:Keeper_checkpoint_ref.t ->
+    Agent_sdk.Checkpoint.t ->
+    checkpoint_installation
+end

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -207,6 +207,11 @@ type checkpoint_cas_error =
       ; error : File_lock_eio.durable_lock_error
       }
 
+type checkpoint_installation =
+  { installed_ref : Keeper_checkpoint_ref.t
+  ; hint_failure : Eio.Exn.with_bt option
+  }
+
 (** Conditionally publish [candidate] only when the canonical bytes still
     have exactly [expected_source_ref]. The stable session lock is reacquired,
     current bytes are re-read and hashed, and an equal-turn checkpoint with
@@ -214,18 +219,22 @@ type checkpoint_cas_error =
     ref is derived from the exact compact bytes passed to the durable atomic
     JSON writer. A writer error after atomic rename is
     [Commit_durability_unknown], never a retryable not-installed failure. This
-     same rule applies when releasing the stable lock fails after the body:
-     [Transaction_outcome_unknown] requires reconciliation rather than retry. The
-     payload-store commit is not an operation terminal fact; the Keeper operation
-     journal owns that authority. [on_checkpoint_committed] runs exactly once
-     after the CAS lock scope has unwound when durable commit was observed. It
-     runs without [Eio.Cancel.protect] and must not perform I/O, suspend, or
-     raise. If it violates that contract while a prior operation exception or
-     cancellation is already unwinding, the prior exception and its raw
-     backtrace take precedence; the observer failure is logged. *)
+    same rule applies when releasing the stable lock fails after the body:
+    [Transaction_outcome_unknown] requires reconciliation rather than retry.
+    The payload-store commit is not an operation terminal fact; the Keeper
+    operation journal owns that authority.
+
+    [on_checkpoint_commit_hint] receives the exact installed reference in the
+    caller fiber when this invocation observes durable commit. It is a lossy,
+    best-effort hint, may run before the CAS lock is released, and must not be
+    used as an acknowledgement or restart authority. A callback failure or
+    cooperative cancellation observed after durable commit is returned in
+    [hint_failure] alongside the installed reference; it never becomes an
+    install failure or retry signal. An exception before commit is re-raised
+    with its original raw backtrace. *)
 val save_oas_if_source :
-  on_checkpoint_committed:(unit -> unit) ->
+  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
   session_dir:string ->
   expected_source_ref:Keeper_checkpoint_ref.t ->
   Agent_sdk.Checkpoint.t ->
-  (Keeper_checkpoint_ref.t, checkpoint_cas_error) result
+  (checkpoint_installation, checkpoint_cas_error) result

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -193,21 +193,18 @@ type checkpoint_cas_error =
       { expected : int
       ; candidate : int
       }
-  | Candidate_turn_regressed of
-      { source_turn : int
-      ; candidate_turn : int
-      }
-  | Commit_not_installed of Keeper_fs.durable_write_error
-  | Commit_durability_unknown of
-      { installed_ref : Keeper_checkpoint_ref.t
-      ; error : Keeper_fs.durable_write_error
-      }
-  | Transaction_outcome_unknown of
-      { possible_installed_ref : Keeper_checkpoint_ref.t
-      ; error : File_lock_eio.durable_lock_error
-      }
+   | Candidate_turn_regressed of
+       { source_turn : int
+       ; candidate_turn : int
+       }
+   | Commit_not_installed of Keeper_fs.durable_write_error
+   | Transaction_outcome_unknown of
+       { possible_installed_ref : Keeper_checkpoint_ref.t
+       ; error : File_lock_eio.durable_lock_error
+       }
 
 type checkpoint_installation_auxiliary =
+  | Commit_durability_unknown of Keeper_fs.durable_write_error
   | Commit_observer_failed of Eio.Exn.with_bt
   | Release_process_lock_failed of File_lock_eio.durable_lock_error
   | Post_commit_unwind_interrupted of Eio.Exn.with_bt
@@ -227,9 +224,10 @@ type checkpoint_installation =
     current bytes are re-read and hashed, and an equal-turn checkpoint with
     different content is rejected as [Source_changed]. On success the returned
     ref is derived from the exact compact bytes passed to the durable atomic
-    JSON writer. A writer error after atomic rename is
-    [Commit_durability_unknown], never a retryable not-installed failure. This
-    same rule applies when releasing the stable lock fails after the body:
+    JSON writer. A writer error after atomic rename is an [Installed] result
+    carrying [Commit_durability_unknown], never a retryable not-installed
+    failure. This same rule applies when releasing the stable lock fails after
+    the body:
     [Transaction_outcome_unknown] requires reconciliation rather than retry.
     The payload-store commit is not an operation terminal fact; the Keeper
     operation journal owns that authority.
@@ -255,6 +253,27 @@ module For_testing : sig
 
   val save_oas_if_source_with_release_failure :
     release_failure:File_lock_eio.durable_lock_error ->
+    on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    session_dir:string ->
+    expected_source_ref:Keeper_checkpoint_ref.t ->
+    Agent_sdk.Checkpoint.t ->
+    checkpoint_installation
+
+  val save_oas_if_source_with_writer :
+    write_checkpoint_bytes:
+      (on_durable_commit:(unit -> unit) ->
+       ownership_root:string ->
+       path:string ->
+       bytes:string ->
+       (Keeper_fs.durable_commit_outcome, Keeper_fs.durable_write_error) result) ->
+    on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    session_dir:string ->
+    expected_source_ref:Keeper_checkpoint_ref.t ->
+    Agent_sdk.Checkpoint.t ->
+    checkpoint_installation
+
+  val save_oas_if_source_with_post_commit_unwind :
+    post_commit_unwind:(unit -> unit) ->
     on_checkpoint_commit_observer:(Keeper_checkpoint_ref.t -> unit) ->
     session_dir:string ->
     expected_source_ref:Keeper_checkpoint_ref.t ->

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -112,6 +112,7 @@ let save_oas_checkpoint_classified
      | Error error -> Error (Persistence_error error))
 
 let save_oas_checkpoint_if_source
+    ~on_checkpoint_committed
     ~multimodal_policy
     ~keeper_name
     ~session
@@ -133,6 +134,7 @@ let save_oas_checkpoint_if_source
   | Ok checkpoint ->
     (match
        Keeper_checkpoint_store.save_oas_if_source
+         ~on_checkpoint_committed
          ~session_dir:session.session_dir
          ~expected_source_ref
          checkpoint

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -112,7 +112,7 @@ let save_oas_checkpoint_classified
      | Error error -> Error (Persistence_error error))
 
 let save_oas_checkpoint_if_source
-    ~on_checkpoint_committed
+    ~on_checkpoint_commit_hint
     ~multimodal_policy
     ~keeper_name
     ~session
@@ -134,17 +134,17 @@ let save_oas_checkpoint_if_source
   | Ok checkpoint ->
     (match
        Keeper_checkpoint_store.save_oas_if_source
-         ~on_checkpoint_committed
+         ~on_checkpoint_commit_hint
          ~session_dir:session.session_dir
          ~expected_source_ref
          checkpoint
      with
      | Error error -> Error (Persistence_error error)
-     | Ok installed_ref ->
+     | Ok installation ->
        Keeper_checkpoint_store.save_oas_history
          ~session_dir:session.session_dir
          checkpoint;
-       Ok (checkpoint, installed_ref))
+       Ok (checkpoint, installation))
 
 let save_oas_checkpoint
     ~multimodal_policy

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -111,8 +111,8 @@ let save_oas_checkpoint_classified
      | Ok outcome -> Ok (checkpoint, outcome)
      | Error error -> Error (Persistence_error error))
 
-let save_oas_checkpoint_if_source
-    ~on_checkpoint_commit_hint
+let save_oas_checkpoint_if_source_with
+    ~save_oas_history
     ~multimodal_policy
     ~keeper_name
     ~session
@@ -134,17 +134,41 @@ let save_oas_checkpoint_if_source
   | Ok checkpoint ->
     (match
        Keeper_checkpoint_store.save_oas_if_source
-         ~on_checkpoint_commit_hint
          ~session_dir:session.session_dir
          ~expected_source_ref
          checkpoint
      with
-     | Error error -> Error (Persistence_error error)
-     | Ok installation ->
-       Keeper_checkpoint_store.save_oas_history
-         ~session_dir:session.session_dir
-         checkpoint;
+     | Keeper_checkpoint_store.Not_installed _ as installation ->
+       Ok (checkpoint, installation)
+     | Keeper_checkpoint_store.Installed installed ->
+       let installation =
+         match
+           save_oas_history
+             ~session_dir:session.session_dir
+             checkpoint
+         with
+         | () -> Keeper_checkpoint_store.Installed installed
+         | exception exn ->
+           let failure = exn, Printexc.get_raw_backtrace () in
+           Keeper_checkpoint_store.Installed
+             { installed with
+               auxiliary =
+                 installed.auxiliary
+                 @ [ Keeper_checkpoint_store.History_write_failed failure ]
+             }
+       in
        Ok (checkpoint, installation))
+
+let save_oas_checkpoint_if_source =
+  save_oas_checkpoint_if_source_with
+    ~save_oas_history:Keeper_checkpoint_store.save_oas_history
+;;
+
+module For_testing = struct
+  let save_oas_checkpoint_if_source_with_history ~save_oas_history =
+    save_oas_checkpoint_if_source_with ~save_oas_history
+  ;;
+end
 
 let save_oas_checkpoint
     ~multimodal_policy

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -150,7 +150,6 @@ val save_oas_checkpoint_classified :
     has [expected_source_ref]. Equal-turn content changes are rejected by the
     checkpoint store's exact byte-identity CAS. *)
 val save_oas_checkpoint_if_source :
-  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
   multimodal_policy:Keeper_types_profile.multimodal_policy ->
   keeper_name:string ->
   session:session_context ->
@@ -161,6 +160,22 @@ val save_oas_checkpoint_if_source :
   ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.checkpoint_installation
   , Keeper_checkpoint_store.checkpoint_cas_error checkpoint_write_error )
   result
+
+module For_testing : sig
+  val save_oas_checkpoint_if_source_with_history :
+    save_oas_history:
+      (session_dir:string -> Agent_sdk.Checkpoint.t -> unit) ->
+    multimodal_policy:Keeper_types_profile.multimodal_policy ->
+    keeper_name:string ->
+    session:session_context ->
+    agent_name:string ->
+    ctx:working_context ->
+    generation:int ->
+    expected_source_ref:Keeper_checkpoint_ref.t ->
+    ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.checkpoint_installation
+    , Keeper_checkpoint_store.checkpoint_cas_error checkpoint_write_error )
+    result
+end
 
 (** {1 OAS checkpoint inspection} *)
 

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -150,6 +150,7 @@ val save_oas_checkpoint_classified :
     has [expected_source_ref]. Equal-turn content changes are rejected by the
     checkpoint store's exact byte-identity CAS. *)
 val save_oas_checkpoint_if_source :
+  on_checkpoint_committed:(unit -> unit) ->
   multimodal_policy:Keeper_types_profile.multimodal_policy ->
   keeper_name:string ->
   session:session_context ->

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -150,7 +150,7 @@ val save_oas_checkpoint_classified :
     has [expected_source_ref]. Equal-turn content changes are rejected by the
     checkpoint store's exact byte-identity CAS. *)
 val save_oas_checkpoint_if_source :
-  on_checkpoint_committed:(unit -> unit) ->
+  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
   multimodal_policy:Keeper_types_profile.multimodal_policy ->
   keeper_name:string ->
   session:session_context ->
@@ -158,7 +158,7 @@ val save_oas_checkpoint_if_source :
   ctx:working_context ->
   generation:int ->
   expected_source_ref:Keeper_checkpoint_ref.t ->
-  ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_ref.t
+  ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.checkpoint_installation
   , Keeper_checkpoint_store.checkpoint_cas_error checkpoint_write_error )
   result
 

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -90,6 +90,7 @@ type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
 
 type compaction_recovery = Keeper_post_turn.compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
+  checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation;
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -189,7 +189,7 @@ val prepare_compaction
   -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
 
 val commit_prepared_compaction
-  :  on_checkpoint_committed:(unit -> unit)
+  :  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit)
   -> Keeper_post_turn.prepared_compaction
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -102,6 +102,7 @@ type context_budget_source =
 
 type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
+  ; checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
@@ -189,8 +190,7 @@ val prepare_compaction
   -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
 
 val commit_prepared_compaction
-  :  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit)
-  -> Keeper_post_turn.prepared_compaction
+  :  Keeper_post_turn.prepared_compaction
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -189,7 +189,8 @@ val prepare_compaction
   -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
 
 val commit_prepared_compaction
-  :  Keeper_post_turn.prepared_compaction
+  :  on_checkpoint_committed:(unit -> unit)
+  -> Keeper_post_turn.prepared_compaction
   -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -451,6 +451,37 @@ let observe_durable_write_success ~on_durable_commit = function
        Ok (Committed_but_observer_failed (exn, backtrace)))
 ;;
 
+let finish_durable_commit_observation
+      ~(commit_observed : bool ref)
+      ~on_durable_commit
+      outcome
+  =
+  let notify () =
+    if !commit_observed
+    then (
+      commit_observed := false;
+      on_durable_commit ())
+  in
+  match outcome with
+  | `Returned value ->
+    notify ();
+    value
+  | `Raised (exn, backtrace) ->
+    (try notify () with
+     | observer_exn ->
+       (* The observer contract forbids raising. If it is violated while an
+          earlier operation exception is already in flight, preserve that
+          operation exception and its exact backtrace rather than masking the
+          cause that forced cleanup/unwinding. *)
+       (try
+          Log.Keeper.error
+            "durable commit observer raised while preserving an earlier exception: %s"
+            (Printexc.to_string observer_exn)
+        with
+        | _ -> ()));
+    Printexc.raise_with_backtrace exn backtrace
+;;
+
 let save_bytes_durable_atomic_observed_with
       ~on_durable_commit
       ~before_stage

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -451,37 +451,6 @@ let observe_durable_write_success ~on_durable_commit = function
        Ok (Committed_but_observer_failed (exn, backtrace)))
 ;;
 
-let finish_durable_commit_observation
-      ~(commit_observed : bool ref)
-      ~on_durable_commit
-      outcome
-  =
-  let notify () =
-    if !commit_observed
-    then (
-      commit_observed := false;
-      on_durable_commit ())
-  in
-  match outcome with
-  | `Returned value ->
-    notify ();
-    value
-  | `Raised (exn, backtrace) ->
-    (try notify () with
-     | observer_exn ->
-       (* The observer contract forbids raising. If it is violated while an
-          earlier operation exception is already in flight, preserve that
-          operation exception and its exact backtrace rather than masking the
-          cause that forced cleanup/unwinding. *)
-       (try
-          Log.Keeper.error
-            "durable commit observer raised while preserving an earlier exception: %s"
-            (Printexc.to_string observer_exn)
-        with
-        | _ -> ()));
-    Printexc.raise_with_backtrace exn backtrace
-;;
-
 let save_bytes_durable_atomic_observed_with
       ~on_durable_commit
       ~before_stage

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -83,6 +83,19 @@ val save_bytes_durable_atomic_observed
   -> string
   -> (durable_commit_outcome, durable_write_error) result
 
+(** Deliver a deferred durable-commit observation and finish a captured
+    operation outcome. [commit_observed] is cleared before the observer runs,
+    making delivery affine even when the observer raises. For [`Returned], an
+    observer exception propagates. For [`Raised], an observer exception is
+    logged but the original exception is re-raised with its captured raw
+    backtrace, so cleanup failure cannot mask the operation failure. Call only
+    after every lock or serialized admission owning the operation has unwound. *)
+val finish_durable_commit_observation
+  :  commit_observed:bool ref
+  -> on_durable_commit:(unit -> unit)
+  -> [ `Returned of 'a | `Raised of exn * Printexc.raw_backtrace ]
+  -> 'a
+
 (** Strict durable atomic write of the supplied immutable byte string.
     The payload is written exactly, without parsing or re-encoding. It provides
     equivalent semantics through the same core transaction and completion

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -83,19 +83,6 @@ val save_bytes_durable_atomic_observed
   -> string
   -> (durable_commit_outcome, durable_write_error) result
 
-(** Deliver a deferred durable-commit observation and finish a captured
-    operation outcome. [commit_observed] is cleared before the observer runs,
-    making delivery affine even when the observer raises. For [`Returned], an
-    observer exception propagates. For [`Raised], an observer exception is
-    logged but the original exception is re-raised with its captured raw
-    backtrace, so cleanup failure cannot mask the operation failure. Call only
-    after every lock or serialized admission owning the operation has unwound. *)
-val finish_durable_commit_observation
-  :  commit_observed:bool ref
-  -> on_durable_commit:(unit -> unit)
-  -> [ `Returned of 'a | `Raised of exn * Printexc.raw_backtrace ]
-  -> 'a
-
 (** Strict durable atomic write of the supplied immutable byte string.
     The payload is written exactly, without parsing or re-encoding. It provides
     equivalent semantics through the same core transaction and completion

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -464,7 +464,8 @@ let settlement_of_cycle_outcome
      along their usual typed routes and the stimulus re-enters). *)
   | None, _ ->
     (match outcome with
-  | Some (Cycle.Manual_compaction_applied _ as applied) ->
+  | Some (Cycle.Manual_compaction_applied { receipt; _ } as applied) ->
+    let commit = Keeper_manual_compaction.queue_commit_of_applied_receipt receipt in
     (match Cycle.manual_compaction_followup_failure applied with
      | Some
          ({ Keeper_unified_turn.source_lease_disposition =
@@ -474,10 +475,10 @@ let settlement_of_cycle_outcome
                 { judgment; provenance; detail }
           ; _
           } as failure) ->
-       Keeper_registry_event_queue.Escalate
-         { reason = Keeper_registry_event_queue.Failure_judgment_requested
-         ; successor =
-             Some
+       Keeper_registry_event_queue.Manual_compaction_committed
+         { commit
+         ; followup =
+             Keeper_event_queue_state.Compaction_commit_failure_judgment
                (failure_judgment_successor
                   ~arrived_at:settled_at
                   failure
@@ -485,7 +486,11 @@ let settlement_of_cycle_outcome
                   provenance
                   detail)
          }
-     | Some _ | None -> Keeper_registry_event_queue.Ack)
+     | Some _ | None ->
+       Keeper_registry_event_queue.Manual_compaction_committed
+         { commit
+         ; followup = Keeper_event_queue_state.Compaction_commit_ack
+         })
   | Some (Cycle.Completed _) -> Keeper_registry_event_queue.Ack
   | Some (Cycle.Cancelled _) ->
     Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Cancelled
@@ -616,6 +621,7 @@ let exact_terminal_source = function
       } ->
     Some (source, terminal)
   | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.Manual_compaction_committed _
   | Keeper_registry_event_queue.No_compaction _
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _
@@ -677,6 +683,7 @@ let settle_claimed_lease
              | Keeper_registry_event_queue.Escalate _ ->
                Keeper_registry_event_queue.Exact_escalate
              | Keeper_registry_event_queue.Ack
+             | Keeper_registry_event_queue.Manual_compaction_committed _
              | Keeper_registry_event_queue.Cancel_accepted _
              | Keeper_registry_event_queue.Transfer_accepted _
              | Keeper_registry_event_queue.Settle_from_source_terminal _
@@ -771,11 +778,18 @@ let exact_execution_guard ~base_path ~keeper_name ~lease =
 
 let settlement_is_ack = function
   | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.Manual_compaction_committed
+      { followup = Keeper_event_queue_state.Compaction_commit_ack; _ }
   | Keeper_registry_event_queue.No_compaction _
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _ -> true
   | Keeper_registry_event_queue.Settle_from_source_terminal _ -> true
   | Keeper_registry_event_queue.Settle_exact _ -> true
+  | Keeper_registry_event_queue.Manual_compaction_committed
+      { followup =
+          Keeper_event_queue_state.Compaction_commit_failure_judgment _
+      ; _
+      }
   | Keeper_registry_event_queue.Requeue _
   | Keeper_registry_event_queue.Escalate _ ->
     false
@@ -790,6 +804,7 @@ let settlement_is_exact_output_terminal = function
       } ->
     true
   | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.Manual_compaction_committed _
   | Keeper_registry_event_queue.No_compaction _
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _
@@ -828,6 +843,7 @@ let settlement_is_exact_output_cancellation = function
       } ->
     true
   | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.Manual_compaction_committed _
   | Keeper_registry_event_queue.No_compaction _
   | Keeper_registry_event_queue.Cancel_accepted _
   | Keeper_registry_event_queue.Transfer_accepted _

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -424,7 +424,7 @@ let run_keeper_cycle_with
          "manual compaction reached typed terminal: %s"
          (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
        Manual_compaction_not_applied { meta = meta_after_triage; no_compaction }
-     | `Applied success ->
+     | `Applied (success : Keeper_manual_compaction.success) ->
        Manual_compaction_applied
          { receipt = success.receipt; followup = run_standard_cycle () })
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -440,7 +440,9 @@ let run_keeper_cycle
       ()
   =
   run_keeper_cycle_with
-    ~run_manual_compaction:Keeper_manual_compaction.run_admitted
+    ~run_manual_compaction:
+      (Keeper_manual_compaction.run_admitted
+         ~on_checkpoint_committed:(fun () -> ()))
     ?exact_execution_guard
     ?event_bus
     ?hitl_resolution

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -59,7 +59,10 @@ type cycle_outcome =
       { meta : keeper_meta
       ; no_compaction : Keeper_post_turn.no_compaction
       }
-  | Manual_compaction_applied of cycle_outcome
+  | Manual_compaction_applied of
+      { receipt : Keeper_manual_compaction.applied_receipt
+      ; followup : cycle_outcome
+      }
 
 and failure_judgment_terminal =
   | Judgment_boundary_failed of { detail : string }
@@ -78,19 +81,19 @@ let rec meta = function
   | Manual_compaction_failed { meta; _ }
   | Manual_compaction_not_applied { meta; _ } ->
     meta
-  | Manual_compaction_applied outcome -> meta outcome
+  | Manual_compaction_applied { followup; _ } -> meta followup
 ;;
 
 let rec turn_failure = function
   | Failed { failure; _ } -> Some failure
-  | Manual_compaction_applied outcome -> turn_failure outcome
+  | Manual_compaction_applied { followup; _ } -> turn_failure followup
   | Completed _ | Cancelled _ | Skipped _ | Busy _
   | Judgment_settled _ | Manual_compaction_failed _
   | Manual_compaction_not_applied _ -> None
 ;;
 
 let manual_compaction_followup_failure = function
-  | Manual_compaction_applied outcome -> turn_failure outcome
+  | Manual_compaction_applied { followup; _ } -> turn_failure followup
   | Completed _ | Cancelled _ | Skipped _ | Failed _ | Busy _
   | Judgment_settled _ | Manual_compaction_failed _
   | Manual_compaction_not_applied _ -> None
@@ -398,7 +401,8 @@ let run_keeper_cycle_with
        [run_admitted]) and releases the slot the moment the checkpoint
        commits. The follow-up turn then re-enters the standard lane below,
        where a chat backlog wins — the remedy may cut the line, an arbitrary
-       LLM turn may not. [Manual_compaction_applied (Busy _)] settles the
+       LLM turn may not. [Manual_compaction_applied { followup = Busy _; _ }]
+       settles the
        stimulus as Ack, so a yielded follow-up does not replay compaction. *)
     (match
        run_manual_compaction
@@ -420,7 +424,9 @@ let run_keeper_cycle_with
          "manual compaction reached typed terminal: %s"
          (Keeper_event_queue_state.no_compaction_reason_label no_compaction.reason);
        Manual_compaction_not_applied { meta = meta_after_triage; no_compaction }
-     | `Applied _success -> Manual_compaction_applied (run_standard_cycle ()))
+     | `Applied success ->
+       Manual_compaction_applied
+         { receipt = success.receipt; followup = run_standard_cycle () })
 ;;
 
 let run_keeper_cycle

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -445,18 +445,14 @@ let run_keeper_cycle
       ?manual_compaction_requested
       ()
   =
-  run_keeper_cycle_with
-    ~run_manual_compaction:
-      (fun ?exact_execution_guard ~config ~meta () ->
-         let result =
-           Keeper_manual_compaction.run_admitted
-             ?exact_execution_guard
-             ~on_checkpoint_commit_hint:(fun _ -> ())
-             ~config
-             ~meta
-             ()
-         in
-         result.operation)
+run_keeper_cycle_with
+  ~run_manual_compaction:
+    (fun ?exact_execution_guard ~config ~meta () ->
+       Keeper_manual_compaction.run_admitted
+         ?exact_execution_guard
+         ~config
+         ~meta
+         ())
     ?exact_execution_guard
     ?event_bus
     ?hitl_resolution

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -441,8 +441,16 @@ let run_keeper_cycle
   =
   run_keeper_cycle_with
     ~run_manual_compaction:
-      (Keeper_manual_compaction.run_admitted
-         ~on_checkpoint_committed:(fun () -> ()))
+      (fun ?exact_execution_guard ~config ~meta () ->
+         let result =
+           Keeper_manual_compaction.run_admitted
+             ?exact_execution_guard
+             ~on_checkpoint_commit_hint:(fun _ -> ())
+             ~config
+             ~meta
+             ()
+         in
+         result.operation)
     ?exact_execution_guard
     ?event_bus
     ?hitl_resolution

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -24,7 +24,10 @@ type cycle_outcome =
       { meta : Keeper_meta_contract.keeper_meta
       ; no_compaction : Keeper_post_turn.no_compaction
       }
-  | Manual_compaction_applied of cycle_outcome
+  | Manual_compaction_applied of
+      { receipt : Keeper_manual_compaction.applied_receipt
+      ; followup : cycle_outcome
+      }
 
 and failure_judgment_terminal =
   | Judgment_boundary_failed of { detail : string }

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -17,20 +17,23 @@ type operation_outcome =
   | Compacted of success
   | No_compaction of Keeper_post_turn.no_compaction
 
-type lifecycle_stage =
+type pre_install_lifecycle_stage =
   | Operator_request
   | Compaction_started
-  | Compaction_completed
 
 type failure =
-  | Lifecycle of
-      { stage : lifecycle_stage
-      ; checkpoint_applied : bool
+  | Lifecycle_before_install of
+      { stage : pre_install_lifecycle_stage
       ; error : Keeper_context_runtime.lifecycle_dispatch_error
       }
-  | Lifecycle_with_failure_dispatch of
-      { stage : lifecycle_stage
-      ; checkpoint_applied : bool
+  | Lifecycle_before_install_with_failure_dispatch of
+      { stage : pre_install_lifecycle_stage
+      ; error : Keeper_context_runtime.lifecycle_dispatch_error
+      ; failure_dispatch :
+          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+      }
+  | Lifecycle_after_install_with_failure_dispatch of
+      { installed_ref : Keeper_checkpoint_ref.t
       ; error : Keeper_context_runtime.lifecycle_dispatch_error
       ; failure_dispatch :
           (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
@@ -120,15 +123,14 @@ let observe_terminal_dispatch_failure ~meta = function
 let run_start_lifecycle ~config ~meta =
   match dispatch_event ~config ~meta Keeper_state_machine.Operator_compact_requested with
   | Error error ->
-    Error (Lifecycle { stage = Operator_request; checkpoint_applied = false; error })
+    Error (Lifecycle_before_install { stage = Operator_request; error })
   | Ok () ->
     (match dispatch_event ~config ~meta Keeper_state_machine.Compaction_started with
      | Error error ->
        let failure_dispatch = dispatch_failed ~config ~meta "compaction_start_rejected" in
        Error
-         (Lifecycle_with_failure_dispatch
+         (Lifecycle_before_install_with_failure_dispatch
             { stage = Compaction_started
-            ; checkpoint_applied = false
             ; error
             ; failure_dispatch
             })
@@ -150,8 +152,8 @@ let run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared =
     Error (Recovery (error, failure_dispatch))
   | Ok recovery ->
     (match recovery.checkpoint_installation with
-     | Keeper_checkpoint_store.Not_installed cas_error ->
-       let error = Keeper_post_turn.Checkpoint_cas_failed cas_error in
+     | Keeper_checkpoint_store.Not_installed not_installed ->
+       let error = Keeper_post_turn.Checkpoint_cas_failed not_installed.cause in
        let failure_dispatch =
          dispatch_failed
            ~config
@@ -188,9 +190,8 @@ let run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared =
           Ok (Compacted { recovery; manifest })
         | Error _ ->
           Error
-            (Lifecycle_with_failure_dispatch
-               { stage = Compaction_completed
-               ; checkpoint_applied = true
+            (Lifecycle_after_install_with_failure_dispatch
+               { installed_ref = installed.installed_ref
                ; error
                ; failure_dispatch
                }))
@@ -375,10 +376,9 @@ let run_admitted
   { operation; checkpoint_commit_hint }
 ;;
 
-let lifecycle_stage_to_string = function
+let pre_install_lifecycle_stage_to_string = function
   | Operator_request -> "operator_request"
   | Compaction_started -> "compaction_started"
-  | Compaction_completed -> "compaction_completed"
 ;;
 
 let failure_dispatch_to_string = function
@@ -388,18 +388,28 @@ let failure_dispatch_to_string = function
 ;;
 
 let failure_to_string = function
-  | Lifecycle { stage; checkpoint_applied; error } ->
+  | Lifecycle_before_install { stage; error } ->
     Printf.sprintf
-      "stage=%s checkpoint_applied=%b error=%s"
-      (lifecycle_stage_to_string stage)
-      checkpoint_applied
+      "stage=%s installation=not_installed error=%s"
+      (pre_install_lifecycle_stage_to_string stage)
       (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
-  | Lifecycle_with_failure_dispatch
-      { stage; checkpoint_applied; error; failure_dispatch } ->
+  | Lifecycle_before_install_with_failure_dispatch
+      { stage; error; failure_dispatch } ->
     Printf.sprintf
-      "stage=%s checkpoint_applied=%b error=%s failure_dispatch=%s"
-      (lifecycle_stage_to_string stage)
-      checkpoint_applied
+      "stage=%s installation=not_installed error=%s failure_dispatch=%s"
+      (pre_install_lifecycle_stage_to_string stage)
+      (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
+      (failure_dispatch_to_string failure_dispatch)
+  | Lifecycle_after_install_with_failure_dispatch
+      { installed_ref; error; failure_dispatch } ->
+    Printf.sprintf
+      "stage=compaction_completed installation=installed \
+       trace_id=%s generation=%d turn_count=%d sha256=%s error=%s \
+       failure_dispatch=%s"
+      (Keeper_id.Trace_id.to_string installed_ref.trace_id)
+      installed_ref.generation
+      installed_ref.turn_count
+      installed_ref.sha256
       (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
       (failure_dispatch_to_string failure_dispatch)
   | Recovery (error, failure_dispatch) ->

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -8,13 +8,34 @@ type checkpoint_commit_hint_outcome =
       ; failure : Eio.Exn.with_bt
       }
 
-type success =
-  { recovery : Keeper_context_runtime.compaction_recovery
+type post_install_lifecycle =
+  | Completion_applied
+  | Completion_rejected_failure_dispatched of
+      { completion_error : Keeper_context_runtime.lifecycle_dispatch_error }
+  | Completion_rejected_failure_dispatch_failed of
+      { completion_error : Keeper_context_runtime.lifecycle_dispatch_error
+      ; failure_dispatch_error : Keeper_context_runtime.lifecycle_dispatch_error
+      }
+
+type applied_receipt =
+  { installation : Keeper_checkpoint_store.installed_checkpoint
+  ; lifecycle : post_install_lifecycle
   ; manifest : (unit, string) result
   }
 
+type success =
+  { recovery : Keeper_context_runtime.compaction_recovery
+  ; receipt : applied_receipt
+  }
+
+type committed =
+  { recovery : Keeper_context_runtime.compaction_recovery
+  ; installation : Keeper_checkpoint_store.installed_checkpoint
+  ; lifecycle : post_install_lifecycle
+  }
+
 type operation_outcome =
-  | Compacted of success
+  | Compacted of committed
   | No_compaction of Keeper_post_turn.no_compaction
 
 type pre_install_lifecycle_stage =
@@ -28,12 +49,6 @@ type failure =
       }
   | Lifecycle_before_install_with_failure_dispatch of
       { stage : pre_install_lifecycle_stage
-      ; error : Keeper_context_runtime.lifecycle_dispatch_error
-      ; failure_dispatch :
-          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
-      }
-  | Lifecycle_after_install_with_failure_dispatch of
-      { installed_ref : Keeper_checkpoint_ref.t
       ; error : Keeper_context_runtime.lifecycle_dispatch_error
       ; failure_dispatch :
           (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
@@ -54,47 +69,157 @@ type admitted_result =
   ; checkpoint_commit_hint : checkpoint_commit_hint_outcome
   }
 
-let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
+let checkpoint_ref_to_json (reference : Keeper_checkpoint_ref.t) =
+  `Assoc
+    [ "trace_id", `String (Keeper_id.Trace_id.to_string reference.trace_id)
+    ; "generation", `Int reference.generation
+    ; "turn_count", `Int reference.turn_count
+    ; "sha256", `String reference.sha256
+    ]
+;;
+
+let exception_auxiliary_json kind (exn, backtrace) =
+  `Assoc
+    [ "kind", `String kind
+    ; "detail", `String (Printexc.to_string exn)
+    ; ( "backtrace_present"
+      , `Bool (Printexc.raw_backtrace_length backtrace > 0) )
+    ; "operator_action_required", `Bool true
+    ]
+;;
+
+let checkpoint_installation_auxiliary_to_json = function
+  | Keeper_checkpoint_store.Commit_durability_unknown error ->
+    `Assoc
+      [ "kind", `String "commit_durability_unknown"
+      ; "detail", `String (Keeper_fs.durable_write_error_to_string error)
+      ; "backtrace_present", `Bool false
+      ; "operator_action_required", `Bool true
+      ]
+  | Keeper_checkpoint_store.Commit_observer_failed failure ->
+    exception_auxiliary_json "commit_observer_failed" failure
+  | Keeper_checkpoint_store.Release_process_lock_failed error ->
+    `Assoc
+      [ "kind", `String "release_process_lock_failed"
+      ; "detail", `String (File_lock_eio.durable_lock_error_to_string error)
+      ; "backtrace_present", `Bool false
+      ; "operator_action_required", `Bool true
+      ]
+  | Keeper_checkpoint_store.Post_commit_unwind_interrupted failure ->
+    exception_auxiliary_json "post_commit_unwind_interrupted" failure
+  | Keeper_checkpoint_store.History_write_failed failure ->
+    exception_auxiliary_json "history_write_failed" failure
+;;
+
+let post_install_lifecycle_to_json = function
+  | Completion_applied ->
+    `Assoc
+      [ "kind", `String "completion_applied"
+      ; "completion_error", `Null
+      ; "failure_dispatch", `String "not_needed"
+      ; "failure_dispatch_error", `Null
+      ; "operator_action_required", `Bool false
+      ]
+  | Completion_rejected_failure_dispatched { completion_error } ->
+    `Assoc
+      [ "kind", `String "completion_rejected_failure_dispatched"
+      ; ( "completion_error"
+        , `String
+            (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+               completion_error) )
+      ; "failure_dispatch", `String "applied"
+      ; "failure_dispatch_error", `Null
+      ; "operator_action_required", `Bool true
+      ]
+  | Completion_rejected_failure_dispatch_failed
+      { completion_error; failure_dispatch_error } ->
+    `Assoc
+      [ "kind", `String "completion_rejected_failure_dispatch_failed"
+      ; ( "completion_error"
+        , `String
+            (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+               completion_error) )
+      ; "failure_dispatch", `String "rejected"
+      ; ( "failure_dispatch_error"
+        , `String
+            (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+               failure_dispatch_error) )
+      ; "operator_action_required", `Bool true
+      ]
+;;
+
+let post_install_lifecycle_requires_operator_action = function
+  | Completion_applied -> false
+  | Completion_rejected_failure_dispatched _
+  | Completion_rejected_failure_dispatch_failed _ ->
+    true
+;;
+
+let append_manifest
+    ~config
+    ~base_dir
+    ~(meta : keeper_meta)
+    ~(installation : Keeper_checkpoint_store.installed_checkpoint)
+    ~lifecycle
+    recovery =
   let trigger = recovery.Keeper_context_runtime.trigger in
-    let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let context : Keeper_runtime_manifest.turn_context =
-      { manifest_keeper_name = meta.name
-      ; manifest_agent_name = Some meta.agent_name
-      ; manifest_trace_id = trace_id
-      ; manifest_generation = Some recovery.turn_generation
-      ; manifest_keeper_turn_id = Some recovery.checkpoint.turn_count
-      }
-    in
-    let checkpoint_path =
-      Keeper_checkpoint_store.oas_checkpoint_path
-        ~session_dir:(Filename.concat base_dir recovery.checkpoint.session_id)
-        ~session_id:recovery.checkpoint.session_id
-    in
-    let clock_refs =
-      Keeper_runtime_manifest.clock_refs_for_context
-        context
-        ~event:Keeper_runtime_manifest.Context_compacted
-        ~compaction_source:"operator_manual"
-        ()
-    in
-    Keeper_runtime_manifest.make_for_context
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let context : Keeper_runtime_manifest.turn_context =
+    { manifest_keeper_name = meta.name
+    ; manifest_agent_name = Some meta.agent_name
+    ; manifest_trace_id = trace_id
+    ; manifest_generation = Some recovery.turn_generation
+    ; manifest_keeper_turn_id = Some recovery.checkpoint.turn_count
+    }
+  in
+  let checkpoint_path =
+    Keeper_checkpoint_store.oas_checkpoint_path
+      ~session_dir:(Filename.concat base_dir recovery.checkpoint.session_id)
+      ~session_id:recovery.checkpoint.session_id
+  in
+  let clock_refs =
+    Keeper_runtime_manifest.clock_refs_for_context
       context
       ~event:Keeper_runtime_manifest.Context_compacted
-      ~status:"compacted"
-      ~decision:
-        (Keeper_runtime_manifest.with_clock_refs
-           ~clock_refs
-           (Keeper_runtime_manifest.with_payload_role
-              ~payload_role:Keeper_runtime_manifest.Checkpoint
-              (`Assoc
-                [ "trigger", `String (Compaction_trigger.to_label trigger)
-                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-                ; ( Keeper_compaction_evidence.exact_evidence_key
-                  , Keeper_compaction_evidence.to_json recovery.evidence )
-                ])))
-      ~checkpoint_path
+      ~compaction_source:"operator_manual"
       ()
-    |> Keeper_runtime_manifest.append config
+  in
+  let operator_action_required =
+    installation.auxiliary <> []
+    || post_install_lifecycle_requires_operator_action lifecycle
+  in
+  Keeper_runtime_manifest.make_for_context
+    context
+    ~event:Keeper_runtime_manifest.Context_compacted
+    ~status:(if operator_action_required then "degraded" else "compacted")
+    ~decision:
+      (Keeper_runtime_manifest.with_clock_refs
+         ~clock_refs
+         (Keeper_runtime_manifest.with_payload_role
+            ~payload_role:Keeper_runtime_manifest.Checkpoint
+            (`Assoc
+              [ "trigger", `String (Compaction_trigger.to_label trigger)
+              ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+              ; ( Keeper_compaction_evidence.exact_evidence_key
+                , Keeper_compaction_evidence.to_json recovery.evidence )
+              ; ( "checkpoint_installation_schema"
+                , `String "keeper.checkpoint_installation.v1" )
+              ; "checkpoint_installation_state", `String "installed"
+              ; ( "checkpoint_installed_ref"
+                , checkpoint_ref_to_json installation.installed_ref )
+              ; ( "checkpoint_installation_auxiliary"
+                , `List
+                    (List.map
+                       checkpoint_installation_auxiliary_to_json
+                       installation.auxiliary) )
+              ; ( "compaction_post_install_schema"
+                , `String "keeper.compaction.post_install.v1" )
+              ; "compaction_lifecycle", post_install_lifecycle_to_json lifecycle
+              ; "operator_action_required", `Bool operator_action_required
+              ])))
+    ~checkpoint_path
+    ()
+  |> Keeper_runtime_manifest.append config
 ;;
 let dispatch_event ~config ~meta event =
   Keeper_context_runtime.dispatch_keeper_phase_event_result
@@ -137,7 +262,7 @@ let run_start_lifecycle ~config ~meta =
      | Ok () -> Ok ())
 ;;
 
-let run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared =
+let run_commit ~on_checkpoint_installed ~config ~meta prepared =
   match Keeper_context_runtime.commit_prepared_compaction prepared with
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
@@ -163,46 +288,39 @@ let run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared =
        Error (Recovery (error, failure_dispatch))
      | Keeper_checkpoint_store.Installed installed ->
        on_checkpoint_installed installed.installed_ref;
-       let manifest = append_manifest ~config ~base_dir ~meta recovery in
-       (match
-       Keeper_context_runtime.dispatch_compaction_completed
-         ~config
-         ~keeper_name:meta.name
-         ~origin:Keeper_registry.Operator_compact
-     with
-     | Error error ->
-       Log.Keeper.error
-         ~keeper_name:meta.name
-         "manual compaction completion lifecycle dispatch failed after durable commit; closing the lifecycle with an explicit failure: %s"
-         (Keeper_context_runtime.lifecycle_dispatch_error_to_string error);
-       Keeper_unified_metrics.broadcast_compaction ~name:meta.name recovery;
-       let failure_dispatch =
-         dispatch_failed
-           ~config
-           ~meta
-           "compaction_completed_rejected_after_checkpoint"
+       let lifecycle =
+         match
+           Keeper_context_runtime.dispatch_compaction_completed
+             ~config
+             ~keeper_name:meta.name
+             ~origin:Keeper_registry.Operator_compact
+         with
+         | Ok () -> Completion_applied
+         | Error completion_error ->
+           Log.Keeper.error
+             ~keeper_name:meta.name
+             "manual compaction completion lifecycle dispatch failed after durable commit; preserving the committed checkpoint and dispatching typed failure cleanup: %s"
+             (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+                completion_error);
+           (match
+              dispatch_failed
+                ~config
+                ~meta
+                "compaction_completed_rejected_after_checkpoint"
+            with
+            | Ok () ->
+              Completion_rejected_failure_dispatched { completion_error }
+            | Error failure_dispatch_error ->
+              Completion_rejected_failure_dispatch_failed
+                { completion_error; failure_dispatch_error })
        in
-       (match failure_dispatch with
-        | Ok () ->
-          Log.Keeper.warn
-            ~keeper_name:meta.name
-            "manual compaction checkpoint remains applied after completion rejection; failure cleanup released the compaction lifecycle";
-          Ok (Compacted { recovery; manifest })
-        | Error _ ->
-          Error
-            (Lifecycle_after_install_with_failure_dispatch
-               { installed_ref = installed.installed_ref
-               ; error
-               ; failure_dispatch
-               }))
-     | Ok () ->
        Keeper_unified_metrics.broadcast_compaction
          ~name:meta.name
          recovery;
-       Ok (Compacted { recovery; manifest })))
+       Ok (Compacted { recovery; installation = installed; lifecycle }))
 ;;
 
-let finish_preparation ~on_checkpoint_installed ~config ~base_dir ~meta = function
+let finish_preparation ~on_checkpoint_installed ~config ~meta = function
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed
@@ -221,7 +339,7 @@ let finish_preparation ~on_checkpoint_installed ~config ~base_dir ~meta = functi
     in
     Error (Recovery (error, failure_dispatch))
   | Ok prepared ->
-    run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared
+    run_commit ~on_checkpoint_installed ~config ~meta prepared
 ;;
 
 let prepare_with ~prepare_compaction ~config ~meta =
@@ -315,7 +433,6 @@ let run_admitted_with
             finish_preparation
               ~on_checkpoint_installed
               ~config
-              ~base_dir
               ~meta
               preparation)
     in
@@ -332,15 +449,31 @@ let run_admitted_with
           `No_compaction no_compaction
         | Error _ -> `Busy block)
      | `Ran (Error failure) -> `Compaction_failed failure
-     | `Ran (Ok (Compacted success)) ->
-       observe_manifest ~keeper_name:meta.name success.manifest;
-       `Applied success
+     | `Ran (Ok (Compacted committed)) ->
+       let manifest =
+         append_manifest
+           ~config
+           ~base_dir
+           ~meta
+           ~installation:committed.installation
+           ~lifecycle:committed.lifecycle
+           committed.recovery
+       in
+       observe_manifest ~keeper_name:meta.name manifest;
+       `Applied
+         { recovery = committed.recovery
+         ; receipt =
+             { installation = committed.installation
+             ; lifecycle = committed.lifecycle
+             ; manifest
+             }
+         }
      | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction)
 ;;
 
-
-let run_admitted
+let run_admitted_with_install_observer
     ?exact_execution_guard
+    ~on_checkpoint_installed_observer
     ~on_checkpoint_commit_hint
     ~config
     ~meta
@@ -357,7 +490,8 @@ let run_admitted
           ~projection_request
           ())
       ~on_checkpoint_installed:(fun installed_ref ->
-        committed_ref := Some installed_ref)
+        committed_ref := Some installed_ref;
+        on_checkpoint_installed_observer installed_ref)
       ~config
       ~meta
   in
@@ -374,6 +508,21 @@ let run_admitted
            })
   in
   { operation; checkpoint_commit_hint }
+;;
+
+let run_admitted
+    ?exact_execution_guard
+    ~on_checkpoint_commit_hint
+    ~config
+    ~meta
+    () =
+  run_admitted_with_install_observer
+    ?exact_execution_guard
+    ~on_checkpoint_installed_observer:(fun _ -> ())
+    ~on_checkpoint_commit_hint
+    ~config
+    ~meta
+    ()
 ;;
 
 let pre_install_lifecycle_stage_to_string = function
@@ -400,18 +549,6 @@ let failure_to_string = function
       (pre_install_lifecycle_stage_to_string stage)
       (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
       (failure_dispatch_to_string failure_dispatch)
-  | Lifecycle_after_install_with_failure_dispatch
-      { installed_ref; error; failure_dispatch } ->
-    Printf.sprintf
-      "stage=compaction_completed installation=installed \
-       trace_id=%s generation=%d turn_count=%d sha256=%s error=%s \
-       failure_dispatch=%s"
-      (Keeper_id.Trace_id.to_string installed_ref.trace_id)
-      installed_ref.generation
-      installed_ref.turn_count
-      installed_ref.sha256
-      (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
-      (failure_dispatch_to_string failure_dispatch)
   | Recovery (error, failure_dispatch) ->
     Printf.sprintf
       "recovery_error=%s failure_dispatch=%s"
@@ -422,5 +559,13 @@ let failure_to_string = function
 module For_testing = struct
   let preserve_no_compaction_after_final_admission_busy =
     preserve_no_compaction_after_final_admission_busy
+  ;;
+
+  let run_admitted_with_install_observer =
+    run_admitted_with_install_observer
+  ;;
+
+  let checkpoint_installation_auxiliary_to_json =
+    checkpoint_installation_auxiliary_to_json
   ;;
 end

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -135,12 +135,8 @@ let run_start_lifecycle ~config ~meta =
      | Ok () -> Ok ())
 ;;
 
-let run_commit ~on_checkpoint_commit_hint ~config ~base_dir ~meta prepared =
-  match
-    Keeper_context_runtime.commit_prepared_compaction
-      ~on_checkpoint_commit_hint
-      prepared
-  with
+let run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared =
+  match Keeper_context_runtime.commit_prepared_compaction prepared with
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
@@ -153,8 +149,20 @@ let run_commit ~on_checkpoint_commit_hint ~config ~base_dir ~meta prepared =
     in
     Error (Recovery (error, failure_dispatch))
   | Ok recovery ->
-    let manifest = append_manifest ~config ~base_dir ~meta recovery in
-    (match
+    (match recovery.checkpoint_installation with
+     | Keeper_checkpoint_store.Not_installed cas_error ->
+       let error = Keeper_post_turn.Checkpoint_cas_failed cas_error in
+       let failure_dispatch =
+         dispatch_failed
+           ~config
+           ~meta
+           (Keeper_post_turn.compaction_recovery_error_to_tag error)
+       in
+       Error (Recovery (error, failure_dispatch))
+     | Keeper_checkpoint_store.Installed installed ->
+       on_checkpoint_installed installed.installed_ref;
+       let manifest = append_manifest ~config ~base_dir ~meta recovery in
+       (match
        Keeper_context_runtime.dispatch_compaction_completed
          ~config
          ~keeper_name:meta.name
@@ -190,10 +198,10 @@ let run_commit ~on_checkpoint_commit_hint ~config ~base_dir ~meta prepared =
        Keeper_unified_metrics.broadcast_compaction
          ~name:meta.name
          recovery;
-       Ok (Compacted { recovery; manifest }))
+       Ok (Compacted { recovery; manifest })))
 ;;
 
-let finish_preparation ~on_checkpoint_commit_hint ~config ~base_dir ~meta = function
+let finish_preparation ~on_checkpoint_installed ~config ~base_dir ~meta = function
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed
@@ -212,7 +220,7 @@ let finish_preparation ~on_checkpoint_commit_hint ~config ~base_dir ~meta = func
     in
     Error (Recovery (error, failure_dispatch))
   | Ok prepared ->
-    run_commit ~on_checkpoint_commit_hint ~config ~base_dir ~meta prepared
+    run_commit ~on_checkpoint_installed ~config ~base_dir ~meta prepared
 ;;
 
 let prepare_with ~prepare_compaction ~config ~meta =
@@ -267,7 +275,7 @@ let preserve_no_compaction_after_final_admission_busy = function
 
 let run_admitted_with
       ~prepare_compaction
-      ~on_checkpoint_commit_hint
+      ~on_checkpoint_installed
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
   =
@@ -304,7 +312,7 @@ let run_admitted_with
              | Error _ -> Error failure)
           | Ok () ->
             finish_preparation
-              ~on_checkpoint_commit_hint
+              ~on_checkpoint_installed
               ~config
               ~base_dir
               ~meta
@@ -347,7 +355,7 @@ let run_admitted
           ~trigger
           ~projection_request
           ())
-      ~on_checkpoint_commit_hint:(fun installed_ref ->
+      ~on_checkpoint_installed:(fun installed_ref ->
         committed_ref := Some installed_ref)
       ~config
       ~meta

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -155,6 +155,66 @@ let post_install_lifecycle_requires_operator_action = function
     true
 ;;
 
+let queue_auxiliary_of_checkpoint_auxiliary = function
+  | Keeper_checkpoint_store.Commit_durability_unknown error ->
+    Keeper_event_queue_state.Compaction_commit_durability_unknown
+      { detail = Keeper_fs.durable_write_error_to_string error }
+  | Keeper_checkpoint_store.Commit_observer_failed (exn, backtrace) ->
+    Keeper_event_queue_state.Compaction_commit_observer_failed
+      { detail = Printexc.to_string exn
+      ; backtrace_present = Printexc.raw_backtrace_length backtrace > 0
+      }
+  | Keeper_checkpoint_store.Release_process_lock_failed error ->
+    Keeper_event_queue_state.Compaction_release_process_lock_failed
+      { detail = File_lock_eio.durable_lock_error_to_string error }
+  | Keeper_checkpoint_store.Post_commit_unwind_interrupted (exn, backtrace) ->
+    Keeper_event_queue_state.Compaction_post_commit_unwind_interrupted
+      { detail = Printexc.to_string exn
+      ; backtrace_present = Printexc.raw_backtrace_length backtrace > 0
+      }
+  | Keeper_checkpoint_store.History_write_failed (exn, backtrace) ->
+    Keeper_event_queue_state.Compaction_history_write_failed
+      { detail = Printexc.to_string exn
+      ; backtrace_present = Printexc.raw_backtrace_length backtrace > 0
+      }
+;;
+
+let queue_lifecycle_of_post_install_lifecycle = function
+  | Completion_applied ->
+    Keeper_event_queue_state.Compaction_completion_applied
+  | Completion_rejected_failure_dispatched { completion_error } ->
+    Keeper_event_queue_state.Compaction_completion_rejected_failure_dispatched
+      { completion_error =
+          Keeper_context_runtime.lifecycle_dispatch_error_to_string
+            completion_error
+      }
+  | Completion_rejected_failure_dispatch_failed
+      { completion_error; failure_dispatch_error } ->
+    Keeper_event_queue_state.
+      Compaction_completion_rejected_failure_dispatch_failed
+        { completion_error =
+            Keeper_context_runtime.lifecycle_dispatch_error_to_string
+              completion_error
+        ; failure_dispatch_error =
+            Keeper_context_runtime.lifecycle_dispatch_error_to_string
+              failure_dispatch_error
+        }
+;;
+
+let queue_commit_of_applied_receipt (receipt : applied_receipt) =
+  { Keeper_event_queue_state.installed_ref = receipt.installation.installed_ref
+  ; auxiliary =
+      List.map
+        queue_auxiliary_of_checkpoint_auxiliary
+        receipt.installation.auxiliary
+  ; lifecycle = queue_lifecycle_of_post_install_lifecycle receipt.lifecycle
+  ; manifest_error =
+      (match receipt.manifest with
+       | Ok () -> None
+       | Error detail -> Some detail)
+  }
+;;
+
 let append_manifest
     ~config
     ~base_dir
@@ -393,6 +453,7 @@ let preserve_no_compaction_after_final_admission_busy = function
 ;;
 
 let run_admitted_with
+      ~append_compaction_manifest
       ~prepare_compaction
       ~on_checkpoint_installed
       ~(config : Workspace.config)
@@ -451,7 +512,7 @@ let run_admitted_with
      | `Ran (Error failure) -> `Compaction_failed failure
      | `Ran (Ok (Compacted committed)) ->
        let manifest =
-         append_manifest
+         append_compaction_manifest
            ~config
            ~base_dir
            ~meta
@@ -471,7 +532,8 @@ let run_admitted_with
      | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction)
 ;;
 
-let run_admitted_with_install_observer
+let run_admitted_with_install_observer_with
+    ~append_compaction_manifest
     ?exact_execution_guard
     ~on_checkpoint_installed_observer
     ~on_checkpoint_commit_hint
@@ -481,6 +543,7 @@ let run_admitted_with_install_observer
   let committed_ref = ref None in
   let operation =
     run_admitted_with
+      ~append_compaction_manifest
       ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
         Keeper_context_runtime.prepare_compaction
           ?exact_execution_guard
@@ -508,6 +571,23 @@ let run_admitted_with_install_observer
            })
   in
   { operation; checkpoint_commit_hint }
+;;
+
+let run_admitted_with_install_observer
+    ?exact_execution_guard
+    ~on_checkpoint_installed_observer
+    ~on_checkpoint_commit_hint
+    ~config
+    ~meta
+    () =
+  run_admitted_with_install_observer_with
+    ~append_compaction_manifest:append_manifest
+    ?exact_execution_guard
+    ~on_checkpoint_installed_observer
+    ~on_checkpoint_commit_hint
+    ~config
+    ~meta
+    ()
 ;;
 
 let run_admitted
@@ -563,6 +643,26 @@ module For_testing = struct
 
   let run_admitted_with_install_observer =
     run_admitted_with_install_observer
+  ;;
+
+  let run_admitted_with_install_observer_and_manifest_failure
+      ?exact_execution_guard
+      ~manifest_error
+      ~on_checkpoint_installed_observer
+      ~on_checkpoint_commit_hint
+      ~config
+      ~meta
+      () =
+    run_admitted_with_install_observer_with
+      ~append_compaction_manifest:
+        (fun ~config:_ ~base_dir:_ ~meta:_ ~installation:_ ~lifecycle:_ _ ->
+           Error manifest_error)
+      ?exact_execution_guard
+      ~on_checkpoint_installed_observer
+      ~on_checkpoint_commit_hint
+      ~config
+      ~meta
+      ()
   ;;
 
   let checkpoint_installation_auxiliary_to_json =

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -1,4 +1,13 @@
 open Keeper_meta_contract
+
+type checkpoint_commit_hint_outcome =
+  | Hint_not_emitted
+  | Hint_delivered of Keeper_checkpoint_ref.t
+  | Hint_failed of
+      { installed_ref : Keeper_checkpoint_ref.t
+      ; failure : Eio.Exn.with_bt
+      }
+
 type success =
   { recovery : Keeper_context_runtime.compaction_recovery
   ; manifest : (unit, string) result
@@ -29,6 +38,19 @@ type failure =
   | Recovery of
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+
+type admitted_operation =
+  [ `Applied of success
+  | `No_compaction of Keeper_post_turn.no_compaction
+  | `Compaction_failed of failure
+  | `Busy of Keeper_turn_admission.autonomous_block
+  ]
+
+type admitted_result =
+  { operation : admitted_operation
+  ; checkpoint_commit_hint : checkpoint_commit_hint_outcome
+  }
+
 let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
   let trigger = recovery.Keeper_context_runtime.trigger in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
@@ -113,10 +135,10 @@ let run_start_lifecycle ~config ~meta =
      | Ok () -> Ok ())
 ;;
 
-let run_commit ~on_checkpoint_committed ~config ~base_dir ~meta prepared =
+let run_commit ~on_checkpoint_commit_hint ~config ~base_dir ~meta prepared =
   match
     Keeper_context_runtime.commit_prepared_compaction
-      ~on_checkpoint_committed
+      ~on_checkpoint_commit_hint
       prepared
   with
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
@@ -171,7 +193,7 @@ let run_commit ~on_checkpoint_committed ~config ~base_dir ~meta prepared =
        Ok (Compacted { recovery; manifest }))
 ;;
 
-let finish_preparation ~on_checkpoint_committed ~config ~base_dir ~meta = function
+let finish_preparation ~on_checkpoint_commit_hint ~config ~base_dir ~meta = function
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed
@@ -190,7 +212,7 @@ let finish_preparation ~on_checkpoint_committed ~config ~base_dir ~meta = functi
     in
     Error (Recovery (error, failure_dispatch))
   | Ok prepared ->
-    run_commit ~on_checkpoint_committed ~config ~base_dir ~meta prepared
+    run_commit ~on_checkpoint_commit_hint ~config ~base_dir ~meta prepared
 ;;
 
 let prepare_with ~prepare_compaction ~config ~meta =
@@ -220,14 +242,6 @@ let prepare_with ~prepare_compaction ~config ~meta =
       ~projection_request )
 ;;
 
-let no_compaction_after_prepared_cancellation prepared =
-  Eio.Cancel.protect (fun () ->
-    No_compaction
-      (Keeper_post_turn.no_compaction_of_uncommitted_prepared
-         ~cause:Keeper_event_queue_state.Exact_execution_cancelled
-         prepared))
-;;
-
 let observe_manifest ~keeper_name = function
   | Ok () -> ()
   | Error detail ->
@@ -253,7 +267,7 @@ let preserve_no_compaction_after_final_admission_busy = function
 
 let run_admitted_with
       ~prepare_compaction
-      ~on_checkpoint_committed
+      ~on_checkpoint_commit_hint
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
   =
@@ -290,21 +304,13 @@ let run_admitted_with
              | Error _ -> Error failure)
           | Ok () ->
             finish_preparation
-              ~on_checkpoint_committed
+              ~on_checkpoint_commit_hint
               ~config
               ~base_dir
               ~meta
               preparation)
     in
-    let admitted =
-      match preparation with
-      | Ok prepared ->
-        (try final_admission () with
-         | Eio.Cancel.Cancelled _ ->
-           Eio.Cancel.protect (fun () ->
-             `Ran (Ok (no_compaction_after_prepared_cancellation prepared))))
-      | Error _ -> final_admission ()
-    in
+    let admitted = final_admission () in
     (match admitted
      with
      | `Busy block ->
@@ -326,33 +332,39 @@ let run_admitted_with
 
 let run_admitted
     ?exact_execution_guard
-    ~on_checkpoint_committed
+    ~on_checkpoint_commit_hint
     ~config
     ~meta
     () =
-  let committed = ref false in
-  let outcome =
-    try
-      `Returned
-        (run_admitted_with
-           ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
-             Keeper_context_runtime.prepare_compaction
-               ?exact_execution_guard
-               ~base_dir
-               ~meta
-               ~trigger
-               ~projection_request
-               ())
-           ~on_checkpoint_committed:(fun () -> committed := true)
-           ~config
-           ~meta)
-    with
-    | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+  let committed_ref = ref None in
+  let operation =
+    run_admitted_with
+      ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
+        Keeper_context_runtime.prepare_compaction
+          ?exact_execution_guard
+          ~base_dir
+          ~meta
+          ~trigger
+          ~projection_request
+          ())
+      ~on_checkpoint_commit_hint:(fun installed_ref ->
+        committed_ref := Some installed_ref)
+      ~config
+      ~meta
   in
-  Keeper_fs.finish_durable_commit_observation
-    ~commit_observed:committed
-    ~on_durable_commit:on_checkpoint_committed
-    outcome
+  let checkpoint_commit_hint =
+    match !committed_ref with
+    | None -> Hint_not_emitted
+    | Some installed_ref ->
+      (match on_checkpoint_commit_hint installed_ref with
+       | () -> Hint_delivered installed_ref
+       | exception exn ->
+         Hint_failed
+           { installed_ref
+           ; failure = exn, Printexc.get_raw_backtrace ()
+           })
+  in
+  { operation; checkpoint_commit_hint }
 ;;
 
 let lifecycle_stage_to_string = function

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -1,13 +1,5 @@
 open Keeper_meta_contract
 
-type checkpoint_commit_hint_outcome =
-  | Hint_not_emitted
-  | Hint_delivered of Keeper_checkpoint_ref.t
-  | Hint_failed of
-      { installed_ref : Keeper_checkpoint_ref.t
-      ; failure : Eio.Exn.with_bt
-      }
-
 type post_install_lifecycle =
   | Completion_applied
   | Completion_rejected_failure_dispatched of
@@ -63,11 +55,6 @@ type admitted_operation =
   | `Compaction_failed of failure
   | `Busy of Keeper_turn_admission.autonomous_block
   ]
-
-type admitted_result =
-  { operation : admitted_operation
-  ; checkpoint_commit_hint : checkpoint_commit_hint_outcome
-  }
 
 let checkpoint_ref_to_json (reference : Keeper_checkpoint_ref.t) =
   `Assoc
@@ -532,77 +519,24 @@ let run_admitted_with
      | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction)
 ;;
 
-let run_admitted_with_install_observer_with
-    ~append_compaction_manifest
-    ?exact_execution_guard
-    ~on_checkpoint_installed_observer
-    ~on_checkpoint_commit_hint
-    ~config
-    ~meta
-    () =
-  let committed_ref = ref None in
-  let operation =
-    run_admitted_with
-      ~append_compaction_manifest
-      ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
-        Keeper_context_runtime.prepare_compaction
-          ?exact_execution_guard
-          ~base_dir
-          ~meta
-          ~trigger
-          ~projection_request
-          ())
-      ~on_checkpoint_installed:(fun installed_ref ->
-        committed_ref := Some installed_ref;
-        on_checkpoint_installed_observer installed_ref)
-      ~config
-      ~meta
-  in
-  let checkpoint_commit_hint =
-    match !committed_ref with
-    | None -> Hint_not_emitted
-    | Some installed_ref ->
-      (match on_checkpoint_commit_hint installed_ref with
-       | () -> Hint_delivered installed_ref
-       | exception exn ->
-         Hint_failed
-           { installed_ref
-           ; failure = exn, Printexc.get_raw_backtrace ()
-           })
-  in
-  { operation; checkpoint_commit_hint }
-;;
-
-let run_admitted_with_install_observer
-    ?exact_execution_guard
-    ~on_checkpoint_installed_observer
-    ~on_checkpoint_commit_hint
-    ~config
-    ~meta
-    () =
-  run_admitted_with_install_observer_with
-    ~append_compaction_manifest:append_manifest
-    ?exact_execution_guard
-    ~on_checkpoint_installed_observer
-    ~on_checkpoint_commit_hint
-    ~config
-    ~meta
-    ()
-;;
-
 let run_admitted
     ?exact_execution_guard
-    ~on_checkpoint_commit_hint
     ~config
     ~meta
     () =
-  run_admitted_with_install_observer
-    ?exact_execution_guard
-    ~on_checkpoint_installed_observer:(fun _ -> ())
-    ~on_checkpoint_commit_hint
+  run_admitted_with
+    ~append_compaction_manifest:append_manifest
+    ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
+      Keeper_context_runtime.prepare_compaction
+        ?exact_execution_guard
+        ~base_dir
+        ~meta
+        ~trigger
+        ~projection_request
+        ())
+    ~on_checkpoint_installed:(fun _ -> ())
     ~config
     ~meta
-    ()
 ;;
 
 let pre_install_lifecycle_stage_to_string = function
@@ -639,30 +573,6 @@ let failure_to_string = function
 module For_testing = struct
   let preserve_no_compaction_after_final_admission_busy =
     preserve_no_compaction_after_final_admission_busy
-  ;;
-
-  let run_admitted_with_install_observer =
-    run_admitted_with_install_observer
-  ;;
-
-  let run_admitted_with_install_observer_and_manifest_failure
-      ?exact_execution_guard
-      ~manifest_error
-      ~on_checkpoint_installed_observer
-      ~on_checkpoint_commit_hint
-      ~config
-      ~meta
-      () =
-    run_admitted_with_install_observer_with
-      ~append_compaction_manifest:
-        (fun ~config:_ ~base_dir:_ ~meta:_ ~installation:_ ~lifecycle:_ _ ->
-           Error manifest_error)
-      ?exact_execution_guard
-      ~on_checkpoint_installed_observer
-      ~on_checkpoint_commit_hint
-      ~config
-      ~meta
-      ()
   ;;
 
   let checkpoint_installation_auxiliary_to_json =

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -309,7 +309,7 @@ let run_start_lifecycle ~config ~meta =
      | Ok () -> Ok ())
 ;;
 
-let run_commit ~on_checkpoint_installed ~config ~meta prepared =
+let run_commit ~config ~meta prepared =
   match Keeper_context_runtime.commit_prepared_compaction prepared with
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
@@ -334,7 +334,6 @@ let run_commit ~on_checkpoint_installed ~config ~meta prepared =
        in
        Error (Recovery (error, failure_dispatch))
      | Keeper_checkpoint_store.Installed installed ->
-       on_checkpoint_installed installed.installed_ref;
        let lifecycle =
          match
            Keeper_context_runtime.dispatch_compaction_completed
@@ -367,7 +366,7 @@ let run_commit ~on_checkpoint_installed ~config ~meta prepared =
        Ok (Compacted { recovery; installation = installed; lifecycle }))
 ;;
 
-let finish_preparation ~on_checkpoint_installed ~config ~meta = function
+let finish_preparation ~config ~meta = function
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed
@@ -386,7 +385,7 @@ let finish_preparation ~on_checkpoint_installed ~config ~meta = function
     in
     Error (Recovery (error, failure_dispatch))
   | Ok prepared ->
-    run_commit ~on_checkpoint_installed ~config ~meta prepared
+    run_commit ~config ~meta prepared
 ;;
 
 let prepare_with ~prepare_compaction ~config ~meta =
@@ -442,7 +441,6 @@ let preserve_no_compaction_after_final_admission_busy = function
 let run_admitted_with
       ~append_compaction_manifest
       ~prepare_compaction
-      ~on_checkpoint_installed
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
   =
@@ -479,7 +477,6 @@ let run_admitted_with
              | Error _ -> Error failure)
           | Ok () ->
             finish_preparation
-              ~on_checkpoint_installed
               ~config
               ~meta
               preparation)
@@ -534,7 +531,6 @@ let run_admitted
         ~trigger
         ~projection_request
         ())
-    ~on_checkpoint_installed:(fun _ -> ())
     ~config
     ~meta
 ;;

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -113,8 +113,12 @@ let run_start_lifecycle ~config ~meta =
      | Ok () -> Ok ())
 ;;
 
-let run_commit ~config ~base_dir ~meta prepared =
-  match Keeper_context_runtime.commit_prepared_compaction prepared with
+let run_commit ~on_checkpoint_committed ~config ~base_dir ~meta prepared =
+  match
+    Keeper_context_runtime.commit_prepared_compaction
+      ~on_checkpoint_committed
+      prepared
+  with
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed ~config ~meta (Keeper_post_turn.compaction_recovery_error_to_tag error)
@@ -167,7 +171,7 @@ let run_commit ~config ~base_dir ~meta prepared =
        Ok (Compacted { recovery; manifest }))
 ;;
 
-let finish_preparation ~config ~base_dir ~meta = function
+let finish_preparation ~on_checkpoint_committed ~config ~base_dir ~meta = function
   | Error (Keeper_post_turn.No_compaction no_compaction as error) ->
     let failure_dispatch =
       dispatch_failed
@@ -185,7 +189,8 @@ let finish_preparation ~config ~base_dir ~meta = function
         (Keeper_post_turn.compaction_recovery_error_to_tag error)
     in
     Error (Recovery (error, failure_dispatch))
-  | Ok prepared -> run_commit ~config ~base_dir ~meta prepared
+  | Ok prepared ->
+    run_commit ~on_checkpoint_committed ~config ~base_dir ~meta prepared
 ;;
 
 let prepare_with ~prepare_compaction ~config ~meta =
@@ -248,6 +253,7 @@ let preserve_no_compaction_after_final_admission_busy = function
 
 let run_admitted_with
       ~prepare_compaction
+      ~on_checkpoint_committed
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
   =
@@ -282,7 +288,13 @@ let run_admitted_with
              | Error (Keeper_post_turn.No_compaction no_compaction) ->
                Ok (No_compaction no_compaction)
              | Error _ -> Error failure)
-          | Ok () -> finish_preparation ~config ~base_dir ~meta preparation)
+          | Ok () ->
+            finish_preparation
+              ~on_checkpoint_committed
+              ~config
+              ~base_dir
+              ~meta
+              preparation)
     in
     let admitted =
       match preparation with
@@ -312,18 +324,35 @@ let run_admitted_with
 ;;
 
 
-let run_admitted ?exact_execution_guard ~config ~meta () =
-  run_admitted_with
-    ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
-      Keeper_context_runtime.prepare_compaction
-        ?exact_execution_guard
-        ~base_dir
-        ~meta
-        ~trigger
-        ~projection_request
-        ())
+let run_admitted
+    ?exact_execution_guard
+    ~on_checkpoint_committed
     ~config
     ~meta
+    () =
+  let committed = ref false in
+  let outcome =
+    try
+      `Returned
+        (run_admitted_with
+           ~prepare_compaction:(fun ~base_dir ~meta ~trigger ~projection_request ->
+             Keeper_context_runtime.prepare_compaction
+               ?exact_execution_guard
+               ~base_dir
+               ~meta
+               ~trigger
+               ~projection_request
+               ())
+           ~on_checkpoint_committed:(fun () -> committed := true)
+           ~config
+           ~meta)
+    with
+    | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+  in
+  Keeper_fs.finish_durable_commit_observation
+    ~commit_observed:committed
+    ~on_durable_commit:on_checkpoint_committed
+    outcome
 ;;
 
 let lifecycle_stage_to_string = function

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -1,3 +1,11 @@
+type checkpoint_commit_hint_outcome =
+  | Hint_not_emitted
+  | Hint_delivered of Keeper_checkpoint_ref.t
+  | Hint_failed of
+      { installed_ref : Keeper_checkpoint_ref.t
+      ; failure : Eio.Exn.with_bt
+      }
+
 type success =
   { recovery : Keeper_context_runtime.compaction_recovery
   ; manifest : (unit, string) result
@@ -29,17 +37,25 @@ type failure =
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
 
+type admitted_operation =
+  [ `Applied of success
+  | `No_compaction of Keeper_post_turn.no_compaction
+  | `Compaction_failed of failure
+  | `Busy of Keeper_turn_admission.autonomous_block
+  ]
+
+type admitted_result =
+  { operation : admitted_operation
+  ; checkpoint_commit_hint : checkpoint_commit_hint_outcome
+  }
+
 val run_admitted
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
-  -> on_checkpoint_committed:(unit -> unit)
+  -> on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit)
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> unit
-  -> [ `Applied of success
-     | `No_compaction of Keeper_post_turn.no_compaction
-     | `Compaction_failed of failure
-     | `Busy of Keeper_turn_admission.autonomous_block
-     ]
+  -> admitted_result
 (** The provider call runs OUTSIDE the keeper admission: [run_admitted]
     first performs a state-free availability preflight, then splits into
     [prepare_compaction] (durable load + policy + LLM plan, no slot held and no
@@ -47,13 +63,13 @@ val run_admitted
     start + source-CAS commit + completion/failure. The lane stays runnable
     while the LLM works; a failed final admission cannot strand
     [compaction_active], and interleaved checkpoint changes fail the exact
-    source CAS. [on_checkpoint_committed] runs only when that source-CAS
-    checkpoint becomes durably committed, and only after final compaction
-    admission has been released. It runs without [Eio.Cancel.protect] and must
-    not perform I/O, suspend, or raise. If it violates that contract while a
-    prior operation exception or cancellation is already unwinding, the prior
-    exception and its raw backtrace take precedence; the observer failure is
-    logged. A rejected completion after the checkpoint commit dispatches an
+    source CAS. [on_checkpoint_commit_hint] receives the exact installed
+    checkpoint reference only after final compaction admission has been
+    released. It is a lossy same-invocation hint, not an acknowledgement,
+    durable event, or restart authority. Process death may drop it. Its
+    delivery result is returned separately in [checkpoint_commit_hint], so a
+    callback exception cannot change [operation] from [`Applied] to failure.
+    A rejected completion after the checkpoint commit dispatches an
     explicit lifecycle failure cleanup before reporting the checkpoint as
     applied; if that cleanup is also rejected, the typed failure reports
     [checkpoint_applied = true]. This is the single sanctioned caller of that

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -99,6 +99,9 @@ val run_admitted
 
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit
+val queue_commit_of_applied_receipt
+  :  applied_receipt
+  -> Keeper_event_queue_state.manual_compaction_commit
 
 module For_testing : sig
   val preserve_no_compaction_after_final_admission_busy
@@ -107,6 +110,16 @@ module For_testing : sig
 
   val run_admitted_with_install_observer :
     ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard ->
+    on_checkpoint_installed_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
+    config:Workspace.config ->
+    meta:Keeper_meta_contract.keeper_meta ->
+    unit ->
+    admitted_result
+
+  val run_admitted_with_install_observer_and_manifest_failure :
+    ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard ->
+    manifest_error:string ->
     on_checkpoint_installed_observer:(Keeper_checkpoint_ref.t -> unit) ->
     on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
     config:Workspace.config ->

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -31,6 +31,7 @@ type failure =
 
 val run_admitted
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> on_checkpoint_committed:(unit -> unit)
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> unit
@@ -46,8 +47,14 @@ val run_admitted
     start + source-CAS commit + completion/failure. The lane stays runnable
     while the LLM works; a failed final admission cannot strand
     [compaction_active], and interleaved checkpoint changes fail the exact
-    source CAS. A rejected completion after the checkpoint commit dispatches
-    an explicit lifecycle failure cleanup before reporting the checkpoint as
+    source CAS. [on_checkpoint_committed] runs only when that source-CAS
+    checkpoint becomes durably committed, and only after final compaction
+    admission has been released. It runs without [Eio.Cancel.protect] and must
+    not perform I/O, suspend, or raise. If it violates that contract while a
+    prior operation exception or cancellation is already unwinding, the prior
+    exception and its raw backtrace take precedence; the observer failure is
+    logged. A rejected completion after the checkpoint commit dispatches an
+    explicit lifecycle failure cleanup before reporting the checkpoint as
     applied; if that cleanup is also rejected, the typed failure reports
     [checkpoint_applied = true]. This is the single sanctioned caller of that
     admission variant. *)

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -15,20 +15,23 @@ type operation_outcome =
   | Compacted of success
   | No_compaction of Keeper_post_turn.no_compaction
 
-type lifecycle_stage =
+type pre_install_lifecycle_stage =
   | Operator_request
   | Compaction_started
-  | Compaction_completed
 
 type failure =
-  | Lifecycle of
-      { stage : lifecycle_stage
-      ; checkpoint_applied : bool
+  | Lifecycle_before_install of
+      { stage : pre_install_lifecycle_stage
       ; error : Keeper_context_runtime.lifecycle_dispatch_error
       }
-  | Lifecycle_with_failure_dispatch of
-      { stage : lifecycle_stage
-      ; checkpoint_applied : bool
+  | Lifecycle_before_install_with_failure_dispatch of
+      { stage : pre_install_lifecycle_stage
+      ; error : Keeper_context_runtime.lifecycle_dispatch_error
+      ; failure_dispatch :
+          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+      }
+  | Lifecycle_after_install_with_failure_dispatch of
+      { installed_ref : Keeper_checkpoint_ref.t
       ; error : Keeper_context_runtime.lifecycle_dispatch_error
       ; failure_dispatch :
           (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
@@ -71,9 +74,10 @@ val run_admitted
     callback exception cannot change [operation] from [`Applied] to failure.
     A rejected completion after the checkpoint commit dispatches an
     explicit lifecycle failure cleanup before reporting the checkpoint as
-    applied; if that cleanup is also rejected, the typed failure reports
-    [checkpoint_applied = true]. This is the single sanctioned caller of that
-    admission variant. *)
+    applied; if that cleanup is also rejected, the typed post-install failure
+    preserves the exact installed checkpoint reference. Pre-install lifecycle
+    failures use separate constructors whose stages cannot represent
+    completion. *)
 
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -6,13 +6,34 @@ type checkpoint_commit_hint_outcome =
       ; failure : Eio.Exn.with_bt
       }
 
-type success =
-  { recovery : Keeper_context_runtime.compaction_recovery
+type post_install_lifecycle =
+  | Completion_applied
+  | Completion_rejected_failure_dispatched of
+      { completion_error : Keeper_context_runtime.lifecycle_dispatch_error }
+  | Completion_rejected_failure_dispatch_failed of
+      { completion_error : Keeper_context_runtime.lifecycle_dispatch_error
+      ; failure_dispatch_error : Keeper_context_runtime.lifecycle_dispatch_error
+      }
+
+type applied_receipt =
+  { installation : Keeper_checkpoint_store.installed_checkpoint
+  ; lifecycle : post_install_lifecycle
   ; manifest : (unit, string) result
   }
 
+type success =
+  { recovery : Keeper_context_runtime.compaction_recovery
+  ; receipt : applied_receipt
+  }
+
+type committed =
+  { recovery : Keeper_context_runtime.compaction_recovery
+  ; installation : Keeper_checkpoint_store.installed_checkpoint
+  ; lifecycle : post_install_lifecycle
+  }
+
 type operation_outcome =
-  | Compacted of success
+  | Compacted of committed
   | No_compaction of Keeper_post_turn.no_compaction
 
 type pre_install_lifecycle_stage =
@@ -26,12 +47,6 @@ type failure =
       }
   | Lifecycle_before_install_with_failure_dispatch of
       { stage : pre_install_lifecycle_stage
-      ; error : Keeper_context_runtime.lifecycle_dispatch_error
-      ; failure_dispatch :
-          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
-      }
-  | Lifecycle_after_install_with_failure_dispatch of
-      { installed_ref : Keeper_checkpoint_ref.t
       ; error : Keeper_context_runtime.lifecycle_dispatch_error
       ; failure_dispatch :
           (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
@@ -72,12 +87,15 @@ val run_admitted
     durable event, or restart authority. Process death may drop it. Its
     delivery result is returned separately in [checkpoint_commit_hint], so a
     callback exception cannot change [operation] from [`Applied] to failure.
-    A rejected completion after the checkpoint commit dispatches an
-    explicit lifecycle failure cleanup before reporting the checkpoint as
-    applied; if that cleanup is also rejected, the typed post-install failure
-    preserves the exact installed checkpoint reference. Pre-install lifecycle
-    failures use separate constructors whose stages cannot represent
-    completion. *)
+    A rejected completion after the checkpoint commit dispatches an explicit
+    lifecycle failure cleanup, but neither rejection can turn the installed
+    checkpoint into [`Compaction_failed] or a retry. The closed
+    [post_install_lifecycle] fact, exact installed reference, Store auxiliary
+    evidence, and manifest append result remain in the [`Applied] receipt.
+    The structured manifest is appended after admission release with
+    [status=degraded] and [operator_action_required=true] for every post-install
+    anomaly. Pre-install lifecycle failures use separate constructors whose
+    stages cannot represent completion. *)
 
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit
@@ -86,4 +104,17 @@ module For_testing : sig
   val preserve_no_compaction_after_final_admission_busy
     :  Keeper_event_queue_state.no_compaction_reason
     -> bool
+
+  val run_admitted_with_install_observer :
+    ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard ->
+    on_checkpoint_installed_observer:(Keeper_checkpoint_ref.t -> unit) ->
+    on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
+    config:Workspace.config ->
+    meta:Keeper_meta_contract.keeper_meta ->
+    unit ->
+    admitted_result
+
+  val checkpoint_installation_auxiliary_to_json :
+    Keeper_checkpoint_store.checkpoint_installation_auxiliary ->
+    Yojson.Safe.t
 end

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -1,11 +1,3 @@
-type checkpoint_commit_hint_outcome =
-  | Hint_not_emitted
-  | Hint_delivered of Keeper_checkpoint_ref.t
-  | Hint_failed of
-      { installed_ref : Keeper_checkpoint_ref.t
-      ; failure : Eio.Exn.with_bt
-      }
-
 type post_install_lifecycle =
   | Completion_applied
   | Completion_rejected_failure_dispatched of
@@ -62,18 +54,12 @@ type admitted_operation =
   | `Busy of Keeper_turn_admission.autonomous_block
   ]
 
-type admitted_result =
-  { operation : admitted_operation
-  ; checkpoint_commit_hint : checkpoint_commit_hint_outcome
-  }
-
 val run_admitted
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
-  -> on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit)
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> unit
-  -> admitted_result
+  -> admitted_operation
 (** The provider call runs OUTSIDE the keeper admission: [run_admitted]
     first performs a state-free availability preflight, then splits into
     [prepare_compaction] (durable load + policy + LLM plan, no slot held and no
@@ -81,12 +67,7 @@ val run_admitted
     start + source-CAS commit + completion/failure. The lane stays runnable
     while the LLM works; a failed final admission cannot strand
     [compaction_active], and interleaved checkpoint changes fail the exact
-    source CAS. [on_checkpoint_commit_hint] receives the exact installed
-    checkpoint reference only after final compaction admission has been
-    released. It is a lossy same-invocation hint, not an acknowledgement,
-    durable event, or restart authority. Process death may drop it. Its
-    delivery result is returned separately in [checkpoint_commit_hint], so a
-    callback exception cannot change [operation] from [`Applied] to failure.
+    source CAS.
     A rejected completion after the checkpoint commit dispatches an explicit
     lifecycle failure cleanup, but neither rejection can turn the installed
     checkpoint into [`Compaction_failed] or a retry. The closed
@@ -107,25 +88,6 @@ module For_testing : sig
   val preserve_no_compaction_after_final_admission_busy
     :  Keeper_event_queue_state.no_compaction_reason
     -> bool
-
-  val run_admitted_with_install_observer :
-    ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard ->
-    on_checkpoint_installed_observer:(Keeper_checkpoint_ref.t -> unit) ->
-    on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
-    config:Workspace.config ->
-    meta:Keeper_meta_contract.keeper_meta ->
-    unit ->
-    admitted_result
-
-  val run_admitted_with_install_observer_and_manifest_failure :
-    ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard ->
-    manifest_error:string ->
-    on_checkpoint_installed_observer:(Keeper_checkpoint_ref.t -> unit) ->
-    on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
-    config:Workspace.config ->
-    meta:Keeper_meta_contract.keeper_meta ->
-    unit ->
-    admitted_result
 
   val checkpoint_installation_auxiliary_to_json :
     Keeper_checkpoint_store.checkpoint_installation_auxiliary ->

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -694,7 +694,9 @@ let prepare_compaction
     ~projection_request
 ;;
 
-let commit_prepared_compaction (prepared : prepared_compaction)
+let commit_prepared_compaction
+    ~on_checkpoint_committed
+    (prepared : prepared_compaction)
   : (compaction_recovery, compaction_recovery_error) result =
   (* Source-CAS commit.  The caller decides which admission (if any) guards
      this phase; correctness against interleaved state change is enforced
@@ -719,6 +721,7 @@ let commit_prepared_compaction (prepared : prepared_compaction)
   (try
      match
        save_oas_checkpoint_if_source
+         ~on_checkpoint_committed
          ~multimodal_policy:retry_meta.multimodal_policy
          ~keeper_name:retry_meta.name
          ~session
@@ -789,5 +792,8 @@ let recover_latest_checkpoint_for_compaction
       ()
   with
   | Error _ as error -> error
-  | Ok prepared -> commit_prepared_compaction prepared
+  | Ok prepared ->
+    commit_prepared_compaction
+      ~on_checkpoint_committed:(fun () -> ())
+      prepared
 ;;

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -55,8 +55,7 @@ type post_turn_lifecycle = {
 
 type compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
-  installed_ref : Keeper_checkpoint_ref.t;
-  checkpoint_commit_hint_failure : Eio.Exn.with_bt option;
+  checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation;
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
@@ -696,8 +695,8 @@ let prepare_compaction
     ~projection_request
 ;;
 
-let commit_prepared_compaction
-    ~on_checkpoint_commit_hint
+let commit_prepared_compaction_with
+    ~save_oas_checkpoint_if_source
     (prepared : prepared_compaction)
   : (compaction_recovery, compaction_recovery_error) result =
   (* Source-CAS commit.  The caller decides which admission (if any) guards
@@ -723,7 +722,6 @@ let commit_prepared_compaction
   (try
      match
        save_oas_checkpoint_if_source
-         ~on_checkpoint_commit_hint
          ~multimodal_policy:retry_meta.multimodal_policy
          ~keeper_name:retry_meta.name
          ~session
@@ -732,28 +730,33 @@ let commit_prepared_compaction
          ~generation:turn_generation
          ~expected_source_ref:source_ref
      with
-     | Ok (saved_checkpoint, installation) ->
+     | Ok
+         ( saved_checkpoint
+         , (Keeper_checkpoint_store.Installed installed as installation) ) ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string Compactions)
          ~labels:[ "keeper", retry_meta.name ]
          ();
        Ok
          { checkpoint = saved_checkpoint
-         ; installed_ref = installation.installed_ref
-         ; checkpoint_commit_hint_failure = installation.hint_failure
+         ; checkpoint_installation = installation
          ; trigger = prepared_trigger
          ; evidence
          ; turn_generation
          ; projection_target =
              Keeper_compaction_projection_target.bind_committed_checkpoint
-               installation.installed_ref
+               installed.installed_ref
                projection_target
          }
-     | Error (Persistence_error (Keeper_checkpoint_store.Source_changed actual)) ->
+     | Ok
+         ( _
+         , Keeper_checkpoint_store.Not_installed
+             (Keeper_checkpoint_store.Source_changed actual) ) ->
        Log.Keeper.warn
          "compaction checkpoint source changed: %s"
          (checkpoint_ref_detail actual);
        terminal Keeper_event_queue_state.Checkpoint_source_changed
+     | Ok (_, Keeper_checkpoint_store.Not_installed cas_error)
      | Error (Persistence_error cas_error) ->
        let detail = checkpoint_cas_error_detail cas_error in
        Log.Keeper.error "compaction checkpoint save failed: %s" detail;
@@ -778,6 +781,20 @@ let commit_prepared_compaction
      terminal Keeper_event_queue_state.Checkpoint_persistence_failed)
 ;;
 
+let commit_prepared_compaction =
+  commit_prepared_compaction_with ~save_oas_checkpoint_if_source
+;;
+
+module For_testing = struct
+  let commit_prepared_compaction_with_history ~save_oas_history prepared =
+    commit_prepared_compaction_with
+      ~save_oas_checkpoint_if_source:
+        (Keeper_context_core.For_testing.save_oas_checkpoint_if_source_with_history
+           ~save_oas_history)
+      prepared
+  ;;
+end
+
 let recover_latest_checkpoint_for_compaction
     ?exact_execution_guard
     ~(base_dir : string)
@@ -796,8 +813,5 @@ let recover_latest_checkpoint_for_compaction
       ()
   with
   | Error _ as error -> error
-  | Ok prepared ->
-    commit_prepared_compaction
-      ~on_checkpoint_commit_hint:(fun _ -> ())
-      prepared
+  | Ok prepared -> commit_prepared_compaction prepared
 ;;

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -91,8 +91,6 @@ let compaction_recovery_error_to_tag = function
     "checkpoint_candidate_invalid"
   | Checkpoint_cas_failed (Commit_not_installed _) ->
     "checkpoint_commit_not_installed"
-  | Checkpoint_cas_failed (Transaction_outcome_unknown _) ->
-    "checkpoint_transaction_outcome_unknown"
   | Checkpoint_candidate_failed _ -> "checkpoint_candidate_failed"
   | Compaction_rejected reason ->
     Keeper_compact_policy.compaction_rejection_to_tag reason
@@ -164,11 +162,6 @@ let checkpoint_cas_error_detail = function
   | Commit_not_installed error ->
     "checkpoint commit not installed: "
     ^ Keeper_fs.durable_write_error_to_string error
-  | Transaction_outcome_unknown { possible_installed_ref; error } ->
-    Printf.sprintf
-      "checkpoint transaction outcome unknown: %s error=%s"
-      (checkpoint_ref_detail possible_installed_ref)
-      (File_lock_eio.durable_lock_error_to_string error)
 
 let compaction_recovery_error_to_string = function
   | Checkpoint_ref_load_failed error -> checkpoint_ref_load_error_detail error
@@ -744,12 +737,13 @@ let commit_prepared_compaction_with
      | Ok
          ( _
          , Keeper_checkpoint_store.Not_installed
-             (Keeper_checkpoint_store.Source_changed actual) ) ->
+             { cause = Keeper_checkpoint_store.Source_changed actual; _ } ) ->
        Log.Keeper.warn
          "compaction checkpoint source changed: %s"
          (checkpoint_ref_detail actual);
        terminal Keeper_event_queue_state.Checkpoint_source_changed
-     | Ok (_, Keeper_checkpoint_store.Not_installed cas_error)
+     | Ok
+         (_, Keeper_checkpoint_store.Not_installed { cause = cas_error; _ })
      | Error (Persistence_error cas_error) ->
        let detail = checkpoint_cas_error_detail cas_error in
        Log.Keeper.error "compaction checkpoint save failed: %s" detail;

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -55,6 +55,8 @@ type post_turn_lifecycle = {
 
 type compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
+  installed_ref : Keeper_checkpoint_ref.t;
+  checkpoint_commit_hint_failure : Eio.Exn.with_bt option;
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
@@ -695,7 +697,7 @@ let prepare_compaction
 ;;
 
 let commit_prepared_compaction
-    ~on_checkpoint_committed
+    ~on_checkpoint_commit_hint
     (prepared : prepared_compaction)
   : (compaction_recovery, compaction_recovery_error) result =
   (* Source-CAS commit.  The caller decides which admission (if any) guards
@@ -721,7 +723,7 @@ let commit_prepared_compaction
   (try
      match
        save_oas_checkpoint_if_source
-         ~on_checkpoint_committed
+         ~on_checkpoint_commit_hint
          ~multimodal_policy:retry_meta.multimodal_policy
          ~keeper_name:retry_meta.name
          ~session
@@ -730,19 +732,21 @@ let commit_prepared_compaction
          ~generation:turn_generation
          ~expected_source_ref:source_ref
      with
-     | Ok (saved_checkpoint, installed_ref) ->
+     | Ok (saved_checkpoint, installation) ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string Compactions)
          ~labels:[ "keeper", retry_meta.name ]
          ();
        Ok
          { checkpoint = saved_checkpoint
+         ; installed_ref = installation.installed_ref
+         ; checkpoint_commit_hint_failure = installation.hint_failure
          ; trigger = prepared_trigger
          ; evidence
          ; turn_generation
          ; projection_target =
              Keeper_compaction_projection_target.bind_committed_checkpoint
-               installed_ref
+               installation.installed_ref
                projection_target
          }
      | Error (Persistence_error (Keeper_checkpoint_store.Source_changed actual)) ->
@@ -794,6 +798,6 @@ let recover_latest_checkpoint_for_compaction
   | Error _ as error -> error
   | Ok prepared ->
     commit_prepared_compaction
-      ~on_checkpoint_committed:(fun () -> ())
+      ~on_checkpoint_commit_hint:(fun _ -> ())
       prepared
 ;;

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -91,8 +91,6 @@ let compaction_recovery_error_to_tag = function
     "checkpoint_candidate_invalid"
   | Checkpoint_cas_failed (Commit_not_installed _) ->
     "checkpoint_commit_not_installed"
-  | Checkpoint_cas_failed (Commit_durability_unknown _) ->
-    "checkpoint_commit_durability_unknown"
   | Checkpoint_cas_failed (Transaction_outcome_unknown _) ->
     "checkpoint_transaction_outcome_unknown"
   | Checkpoint_candidate_failed _ -> "checkpoint_candidate_failed"
@@ -166,11 +164,6 @@ let checkpoint_cas_error_detail = function
   | Commit_not_installed error ->
     "checkpoint commit not installed: "
     ^ Keeper_fs.durable_write_error_to_string error
-  | Commit_durability_unknown { installed_ref; error } ->
-    Printf.sprintf
-      "checkpoint commit durability unknown: %s error=%s"
-      (checkpoint_ref_detail installed_ref)
-      (Keeper_fs.durable_write_error_to_string error)
   | Transaction_outcome_unknown { possible_installed_ref; error } ->
     Printf.sprintf
       "checkpoint transaction outcome unknown: %s error=%s"

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -119,6 +119,7 @@ val prepare_compaction :
 (** Phase 2: source-CAS commit of a fully-planned compaction.  The caller
     decides which admission (if any) guards this phase. *)
 val commit_prepared_compaction :
+  on_checkpoint_committed:(unit -> unit) ->
   prepared_compaction ->
   (compaction_recovery, compaction_recovery_error) result
 

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -30,8 +30,7 @@ type post_turn_lifecycle =
     Manual and provider-overflow callers consume the same result. *)
 type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
-  ; installed_ref : Keeper_checkpoint_ref.t
-  ; checkpoint_commit_hint_failure : Eio.Exn.with_bt option
+  ; checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
@@ -121,9 +120,16 @@ val prepare_compaction :
 (** Phase 2: source-CAS commit of a fully-planned compaction.  The caller
     decides which admission (if any) guards this phase. *)
 val commit_prepared_compaction :
-  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
   prepared_compaction ->
   (compaction_recovery, compaction_recovery_error) result
+
+module For_testing : sig
+  val commit_prepared_compaction_with_history :
+    save_oas_history:
+      (session_dir:string -> Agent_sdk.Checkpoint.t -> unit) ->
+    prepared_compaction ->
+    (compaction_recovery, compaction_recovery_error) result
+end
 
 (** Terminal source-bound disposition for a prepared exact-output result that
     cannot enter its commit admission. The provider execution has completed,

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -30,6 +30,8 @@ type post_turn_lifecycle =
     Manual and provider-overflow callers consume the same result. *)
 type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
+  ; installed_ref : Keeper_checkpoint_ref.t
+  ; checkpoint_commit_hint_failure : Eio.Exn.with_bt option
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
@@ -119,7 +121,7 @@ val prepare_compaction :
 (** Phase 2: source-CAS commit of a fully-planned compaction.  The caller
     decides which admission (if any) guards this phase. *)
 val commit_prepared_compaction :
-  on_checkpoint_committed:(unit -> unit) ->
+  on_checkpoint_commit_hint:(Keeper_checkpoint_ref.t -> unit) ->
   prepared_compaction ->
   (compaction_recovery, compaction_recovery_error) result
 

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -297,6 +297,15 @@ let record_event_queue_turn_started ~base_path ~keeper_name stimulus =
 
 let reaction_kind_of_settlement = function
   | Keeper_event_queue_state.Ack -> Event_queue_ack
+  | Keeper_event_queue_state.Manual_compaction_committed
+      { followup = Keeper_event_queue_state.Compaction_commit_ack; _ } ->
+    Event_queue_ack
+  | Keeper_event_queue_state.Manual_compaction_committed
+      { followup =
+          Keeper_event_queue_state.Compaction_commit_failure_judgment _
+      ; _
+      } ->
+    Event_queue_escalated
   | Keeper_event_queue_state.No_compaction _ -> Event_queue_no_compaction
   | Keeper_event_queue_state.Cancel_accepted _ -> Event_queue_cancelled
   | Keeper_event_queue_state.Transfer_accepted _ -> Event_queue_ack
@@ -679,6 +688,10 @@ let require_finite_float ~missing ~non_finite field json =
 let reaction_kind_matches_settlement reaction_kind settlement =
   match reaction_kind, settlement with
   | Event_queue_ack, Keeper_event_queue_state.Ack -> true
+  | Event_queue_ack,
+    Keeper_event_queue_state.Manual_compaction_committed
+      { followup = Keeper_event_queue_state.Compaction_commit_ack; _ } ->
+    true
   | Event_queue_ack, Keeper_event_queue_state.Transfer_accepted _ -> true
   | Event_queue_ack, Keeper_event_queue_state.Settle_from_source_terminal _ -> true
   | Event_queue_no_compaction, Keeper_event_queue_state.No_compaction _ -> true
@@ -690,18 +703,27 @@ let reaction_kind_matches_settlement reaction_kind settlement =
   | Event_queue_requeued, Keeper_event_queue_state.Requeue _ -> true
   | Event_queue_escalated, Keeper_event_queue_state.Escalate _ -> true
   | Event_queue_escalated,
+    Keeper_event_queue_state.Manual_compaction_committed
+      { followup =
+          Keeper_event_queue_state.Compaction_commit_failure_judgment _
+      ; _
+      } ->
+    true
+  | Event_queue_escalated,
     Keeper_event_queue_state.Settle_exact { semantic = Exact_escalate; _ } ->
     true
   | Turn_started, _
   | Cursor_ack, _
   | Event_queue_ack,
-    ( Keeper_event_queue_state.No_compaction _
+    ( Keeper_event_queue_state.Manual_compaction_committed _
+    | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Settle_exact _
     | Keeper_event_queue_state.Requeue _
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_no_compaction,
     ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.Manual_compaction_committed _
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Settle_from_source_terminal _
@@ -710,6 +732,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_cancelled,
     ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.Manual_compaction_committed _
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Transfer_accepted _
     | Keeper_event_queue_state.Settle_from_source_terminal _
@@ -718,6 +741,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_requeued,
     ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.Manual_compaction_committed _
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
@@ -726,6 +750,7 @@ let reaction_kind_matches_settlement reaction_kind settlement =
     | Keeper_event_queue_state.Escalate _ )
   | Event_queue_escalated,
     ( Keeper_event_queue_state.Ack
+    | Keeper_event_queue_state.Manual_compaction_committed _
     | Keeper_event_queue_state.No_compaction _
     | Keeper_event_queue_state.Cancel_accepted _
     | Keeper_event_queue_state.Transfer_accepted _
@@ -1439,6 +1464,7 @@ let summarize_rows ~keeper_name ~limit rows =
          if Keeper_event_queue_state.escalation_reason_requests_external_input reason
          then incr event_queue_external_input_count
        | Keeper_event_queue_state.Ack
+       | Keeper_event_queue_state.Manual_compaction_committed _
        | Keeper_event_queue_state.No_compaction _
        | Keeper_event_queue_state.Cancel_accepted _
        | Keeper_event_queue_state.Transfer_accepted _

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -96,6 +96,10 @@ type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_t
 
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
+  | Manual_compaction_committed of
+      { commit : Keeper_event_queue_state.manual_compaction_commit
+      ; followup : Keeper_event_queue_state.manual_compaction_followup
+      }
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -136,6 +136,10 @@ type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_t
 
 type settlement = Keeper_event_queue_persistence.settlement =
   | Ack
+  | Manual_compaction_committed of
+      { commit : Keeper_event_queue_state.manual_compaction_commit
+      ; followup : Keeper_event_queue_state.manual_compaction_followup
+      }
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -383,6 +383,12 @@ let decision_public_allowlist =
     ; "ratio"; "threshold"; "count"
     ; "source_requeued"; Keeper_compaction_evidence.exact_evidence_key
     ; "clock_refs"
+    ; "checkpoint_installation_schema"; "checkpoint_installation_state"
+    ; "checkpoint_installed_ref"; "checkpoint_installation_auxiliary"
+    ; "compaction_post_install_schema"; "compaction_lifecycle"
+    ; "operator_action_required"; "trace_id"; "generation"; "turn_count"
+    ; "sha256"; "kind"; "detail"; "backtrace_present"; "completion_error"
+    ; "failure_dispatch"; "failure_dispatch_error"
     ]
 
 let compaction_evidence_public_allowlist =

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -91,12 +91,10 @@ let compaction_dispatch_error_data ~stage ~checkpoint_applied error =
 
 type compaction_checkpoint_commit_state =
   | Not_installed
-  | Installed_durability_unknown
   | Outcome_unknown
 
 let compaction_checkpoint_commit_state_to_string = function
   | Not_installed -> "not_installed"
-  | Installed_durability_unknown -> "installed_durability_unknown"
   | Outcome_unknown -> "transaction_outcome_unknown"
 
 let compaction_recovery_error_data ?dispatch_error error =
@@ -104,9 +102,6 @@ let compaction_recovery_error_data ?dispatch_error error =
   let detail = Keeper_post_turn.compaction_recovery_error_to_string error in
   let checkpoint_commit_state, checkpoint_applied =
     match error with
-    | Keeper_post_turn.Checkpoint_cas_failed
-        (Keeper_checkpoint_store.Commit_durability_unknown _) ->
-      Installed_durability_unknown, `Bool true
     | Checkpoint_cas_failed (Transaction_outcome_unknown _) ->
       Outcome_unknown, `Null
     | Checkpoint_ref_load_failed _
@@ -150,7 +145,6 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Checkpoint_cas_failed (Commit_not_installed _)
     | Checkpoint_candidate_failed _ -> Internal_error
     | Checkpoint_cas_failed (Source_changed _)
-    | Checkpoint_cas_failed (Commit_durability_unknown _)
     | Checkpoint_cas_failed (Transaction_outcome_unknown _) -> Conflict
   in
   let code =

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -79,63 +79,6 @@ let validation_error_data message =
     ; "message", `String message
     ]
 
-type compaction_checkpoint_commit_state = Not_installed
-
-let compaction_checkpoint_commit_state_to_string = function
-  | Not_installed -> "not_installed"
-
-let compaction_recovery_error_data ?dispatch_error error =
-  let tag = Keeper_post_turn.compaction_recovery_error_to_tag error in
-  let detail = Keeper_post_turn.compaction_recovery_error_to_string error in
-  let checkpoint_commit_state = Not_installed in
-  let recovery_code =
-    match error with
-    | Keeper_post_turn.Checkpoint_ref_load_failed
-        Keeper_checkpoint_store.Ref_not_found -> Not_found
-    | Compaction_rejected Exact_lane_unconfigured
-    | Compaction_rejected Exact_target_selection_failed
-    | Compaction_rejected Exact_admission_failed
-    | Compaction_rejected (Invalid_structure _)
-    | Compaction_rejected No_eligible_history
-    | Compaction_rejected Structurally_unchanged
-    | Compaction_rejected Checkpoint_not_reduced
-    | No_compaction _ ->
-      Precondition_failed
-    | Retry_suspended _ -> Precondition_failed
-    | Compaction_rejected Exact_execution_context_unavailable
-    | Compaction_rejected Exact_attempt_start_failed
-    | Compaction_rejected Exact_execution_guard_failed
-    | Compaction_rejected Exact_flow_already_started
-    | Compaction_rejected (Exact_execution_terminal _)
-    | Compaction_rejected Invalid_compaction_plan
-    | Compaction_rejected (Invalid_structural_evidence _)
-    | Checkpoint_ref_load_failed _
-    | Checkpoint_candidate_failed _ -> Internal_error
-    | Checkpoint_cas_failed (Source_changed _) -> Conflict
-    | Checkpoint_cas_failed _ -> Internal_error
-  in
-  let code =
-    match dispatch_error with
-    | None -> recovery_code
-    | Some _ -> Conflict
-  in
-  error_assoc
-    ([ "error_code", `String (error_code_to_string code)
-     ; "message", `String detail
-     ; "compaction_error", `String tag
-     ; ( "checkpoint_commit_state"
-       , `String
-           (compaction_checkpoint_commit_state_to_string checkpoint_commit_state) )
-     ]
-     @
-     match dispatch_error with
-     | None -> []
-     | Some error ->
-       [ "recovery_error_code", `String (error_code_to_string recovery_code)
-       ; ( "lifecycle_dispatch_error"
-         , `String
-             (Keeper_context_runtime.lifecycle_dispatch_error_to_string error) ) ])
-
 let keeper_sandbox_status_fleet_names ctx =
   let registry_names =
     Keeper_registry.all ~base_path:ctx.config.base_path ()

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -79,42 +79,15 @@ let validation_error_data message =
     ; "message", `String message
     ]
 
-let compaction_dispatch_error_data ~stage ~checkpoint_applied error =
-  let detail = Keeper_context_runtime.lifecycle_dispatch_error_to_string error in
-  error_assoc
-    [ "error_code", `String (error_code_to_string Conflict)
-    ; "message", `String (Printf.sprintf "compaction lifecycle dispatch failed: %s" detail)
-    ; "lifecycle_stage", `String stage
-    ; "checkpoint_applied", `Bool checkpoint_applied
-    ; "dispatch_error", `String detail
-    ]
-
-type compaction_checkpoint_commit_state =
-  | Not_installed
-  | Outcome_unknown
+type compaction_checkpoint_commit_state = Not_installed
 
 let compaction_checkpoint_commit_state_to_string = function
   | Not_installed -> "not_installed"
-  | Outcome_unknown -> "transaction_outcome_unknown"
 
 let compaction_recovery_error_data ?dispatch_error error =
   let tag = Keeper_post_turn.compaction_recovery_error_to_tag error in
   let detail = Keeper_post_turn.compaction_recovery_error_to_string error in
-  let checkpoint_commit_state, checkpoint_applied =
-    match error with
-    | Checkpoint_cas_failed (Transaction_outcome_unknown _) ->
-      Outcome_unknown, `Null
-    | Checkpoint_ref_load_failed _
-    | Checkpoint_cas_failed _
-    | Checkpoint_candidate_failed _
-    | Compaction_rejected _
-    | No_compaction _
-    (* Manual prepares bypass the suspension gate, so this surface cannot
-       observe [Retry_suspended] today; the arm keeps the classification
-       total if that routing ever changes. *)
-    | Retry_suspended _ ->
-      Not_installed, `Bool false
-  in
+  let checkpoint_commit_state = Not_installed in
   let recovery_code =
     match error with
     | Keeper_post_turn.Checkpoint_ref_load_failed
@@ -137,15 +110,9 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Compaction_rejected Invalid_compaction_plan
     | Compaction_rejected (Invalid_structural_evidence _)
     | Checkpoint_ref_load_failed _
-    | Checkpoint_cas_failed (Source_unavailable _)
-    | Checkpoint_cas_failed (Candidate_identity_invalid _)
-    | Checkpoint_cas_failed (Candidate_session_mismatch _)
-    | Checkpoint_cas_failed (Candidate_generation_mismatch _)
-    | Checkpoint_cas_failed (Candidate_turn_regressed _)
-    | Checkpoint_cas_failed (Commit_not_installed _)
     | Checkpoint_candidate_failed _ -> Internal_error
-    | Checkpoint_cas_failed (Source_changed _)
-    | Checkpoint_cas_failed (Transaction_outcome_unknown _) -> Conflict
+    | Checkpoint_cas_failed (Source_changed _) -> Conflict
+    | Checkpoint_cas_failed _ -> Internal_error
   in
   let code =
     match dispatch_error with
@@ -159,7 +126,6 @@ let compaction_recovery_error_data ?dispatch_error error =
      ; ( "checkpoint_commit_state"
        , `String
            (compaction_checkpoint_commit_state_to_string checkpoint_commit_state) )
-     ; "checkpoint_applied", checkpoint_applied
      ]
      @
      match dispatch_error with

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -162,6 +162,10 @@ type accepted_source_terminal = State.accepted_source_terminal =
 
 type settlement = State.settlement =
   | Ack
+  | Manual_compaction_committed of
+      { commit : State.manual_compaction_commit
+      ; followup : State.manual_compaction_followup
+      }
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -172,6 +172,10 @@ type accepted_source_terminal = Keeper_event_queue_state.accepted_source_termina
 
 type settlement = Keeper_event_queue_state.settlement =
   | Ack
+  | Manual_compaction_committed of
+      { commit : Keeper_event_queue_state.manual_compaction_commit
+      ; followup : Keeper_event_queue_state.manual_compaction_followup
+      }
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -838,11 +838,27 @@ let successor_equal left right =
   | None, Some _ | Some _, None -> false
 ;;
 
+let manual_compaction_committed_equal
+    ~(left_commit : manual_compaction_commit)
+    ~(left_followup : manual_compaction_followup)
+    ~(right_commit : manual_compaction_commit)
+    ~(right_followup : manual_compaction_followup)
+  =
+  left_commit = right_commit && left_followup = right_followup
+;;
+
 let settlement_equal left right =
   match left, right with
   | Ack, Ack -> true
-  | Manual_compaction_committed left, Manual_compaction_committed right ->
-    left = right
+  | ( Manual_compaction_committed
+        { commit = left_commit; followup = left_followup }
+    , Manual_compaction_committed
+        { commit = right_commit; followup = right_followup } ) ->
+    manual_compaction_committed_equal
+      ~left_commit
+      ~left_followup
+      ~right_commit
+      ~right_followup
   | No_compaction left, No_compaction right ->
     Keeper_checkpoint_ref.equal left.source right.source
     && left.reason = right.reason

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -150,6 +150,42 @@ type accepted_source_terminal =
   ; source_receipt : source_terminal_receipt
   }
 
+type manual_compaction_auxiliary =
+  | Compaction_commit_durability_unknown of { detail : string }
+  | Compaction_commit_observer_failed of
+      { detail : string
+      ; backtrace_present : bool
+      }
+  | Compaction_release_process_lock_failed of { detail : string }
+  | Compaction_post_commit_unwind_interrupted of
+      { detail : string
+      ; backtrace_present : bool
+      }
+  | Compaction_history_write_failed of
+      { detail : string
+      ; backtrace_present : bool
+      }
+
+type manual_compaction_lifecycle =
+  | Compaction_completion_applied
+  | Compaction_completion_rejected_failure_dispatched of
+      { completion_error : string }
+  | Compaction_completion_rejected_failure_dispatch_failed of
+      { completion_error : string
+      ; failure_dispatch_error : string
+      }
+
+type manual_compaction_commit =
+  { installed_ref : Keeper_checkpoint_ref.t
+  ; auxiliary : manual_compaction_auxiliary list
+  ; lifecycle : manual_compaction_lifecycle
+  ; manifest_error : string option
+  }
+
+type manual_compaction_followup =
+  | Compaction_commit_ack
+  | Compaction_commit_failure_judgment of Keeper_event_queue.stimulus
+
 let escalation_reason_requests_external_input = function
   | Failure_judgment_external_input_requested _ -> true
   | Failure_judgment_requested
@@ -163,6 +199,10 @@ let escalation_reason_requests_external_input = function
 
 type settlement =
   | Ack
+  | Manual_compaction_committed of
+      { commit : manual_compaction_commit
+      ; followup : manual_compaction_followup
+      }
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer
@@ -761,6 +801,7 @@ let escalation_reason_of_wire ~label ~detail_json =
 
 let settlement_kind_label = function
   | Ack -> "ack"
+  | Manual_compaction_committed _ -> "manual_compaction_committed"
   | No_compaction _ -> "no_compaction"
   | Cancel_accepted _ -> "cancel_accepted"
   | Transfer_accepted _ -> "transfer_accepted"
@@ -775,6 +816,7 @@ let transition_id (lease : lease) settlement =
   | Settle_exact disposition ->
     Printf.sprintf "%s:settle_exact:%s" lease.lease_id disposition.disposition_id
   | Ack
+  | Manual_compaction_committed _
   | No_compaction _
   | Cancel_accepted _
   | Transfer_accepted _
@@ -799,6 +841,8 @@ let successor_equal left right =
 let settlement_equal left right =
   match left, right with
   | Ack, Ack -> true
+  | Manual_compaction_committed left, Manual_compaction_committed right ->
+    left = right
   | No_compaction left, No_compaction right ->
     Keeper_checkpoint_ref.equal left.source right.source
     && left.reason = right.reason
@@ -975,8 +1019,87 @@ let validate_exact_source_disposition
       Ok ()
 ;;
 
+let manual_compaction_commit_requires_operator_action commit =
+  commit.auxiliary <> []
+  || commit.lifecycle <> Compaction_completion_applied
+  || Option.is_some commit.manifest_error
+;;
+
+let validate_nonempty_manual_compaction_detail field detail =
+  if String.equal (String.trim detail) ""
+  then Error ("manual compaction commit " ^ field ^ " must not be empty")
+  else Ok ()
+;;
+
+let validate_manual_compaction_auxiliary = function
+  | Compaction_commit_durability_unknown { detail }
+  | Compaction_release_process_lock_failed { detail }
+  | Compaction_commit_observer_failed { detail; _ }
+  | Compaction_post_commit_unwind_interrupted { detail; _ }
+  | Compaction_history_write_failed { detail; _ } ->
+    validate_nonempty_manual_compaction_detail "auxiliary detail" detail
+;;
+
+let validate_manual_compaction_lifecycle = function
+  | Compaction_completion_applied -> Ok ()
+  | Compaction_completion_rejected_failure_dispatched { completion_error } ->
+    validate_nonempty_manual_compaction_detail
+      "completion error"
+      completion_error
+  | Compaction_completion_rejected_failure_dispatch_failed
+      { completion_error; failure_dispatch_error } ->
+    let* () =
+      validate_nonempty_manual_compaction_detail
+        "completion error"
+        completion_error
+    in
+    validate_nonempty_manual_compaction_detail
+      "failure dispatch error"
+      failure_dispatch_error
+;;
+
+let validate_manual_compaction_commit commit =
+  let* () =
+    match
+      Keeper_checkpoint_ref.of_persisted
+        ~trace_id:commit.installed_ref.trace_id
+        ~generation:commit.installed_ref.generation
+        ~turn_count:commit.installed_ref.turn_count
+        ~sha256:commit.installed_ref.sha256
+    with
+    | Ok reference when Keeper_checkpoint_ref.equal reference commit.installed_ref ->
+      Ok ()
+    | Ok _ | Error _ -> Error "manual compaction installed ref is invalid"
+  in
+  let* () =
+    List.fold_left
+      (fun result auxiliary ->
+         let* () = result in
+         validate_manual_compaction_auxiliary auxiliary)
+      (Ok ())
+      commit.auxiliary
+  in
+  let* () = validate_manual_compaction_lifecycle commit.lifecycle in
+  match commit.manifest_error with
+  | None -> Ok ()
+  | Some detail ->
+    validate_nonempty_manual_compaction_detail "manifest error" detail
+;;
+
+let validate_manual_compaction_followup = function
+  | Compaction_commit_ack -> Ok ()
+  | Compaction_commit_failure_judgment
+      { Keeper_event_queue.payload = Keeper_event_queue.Failure_judgment _; _ } ->
+    Ok ()
+  | Compaction_commit_failure_judgment _ ->
+    Error "manual compaction failure-judgment follow-up has the wrong payload"
+;;
+
 let validate_settlement = function
   | Ack | Requeue _ -> Ok ()
+  | Manual_compaction_committed { commit; followup } ->
+    let* () = validate_manual_compaction_commit commit in
+    validate_manual_compaction_followup followup
   | No_compaction { reason = Exact_execution_terminal terminal; _ } ->
     validate_exact_execution_terminal terminal
   | No_compaction
@@ -1079,6 +1202,15 @@ let validate_settlement = function
    rules. *)
 let validate_settlement_for_stimuli settlement stimuli =
   match settlement, stimuli with
+  | Manual_compaction_committed _,
+    [ { Keeper_event_queue.payload =
+          Keeper_event_queue.Manual_compaction_requested
+      ; _
+      } ] ->
+    Ok ()
+  | Manual_compaction_committed _, _ ->
+    Error
+      "manual-compaction commit settlement requires one manual-compaction request stimulus"
   | No_compaction _,
     [ { Keeper_event_queue.payload =
           Keeper_event_queue.Manual_compaction_requested
@@ -1179,6 +1311,7 @@ let binding_identity_equal
 
 let identity_bound_nonterminal_settlement = function
   | Ack -> true
+  | Manual_compaction_committed _ -> true
   | Requeue Context_compaction_retry -> true
   | Escalate { reason = Compaction_floor_exceeded _; successor = None } -> true
   | Escalate
@@ -1541,8 +1674,13 @@ let settle_committed ~settled_at ~lease ~settlement state =
     let* () = validate_settlement_for_lease settlement committed in
     let pending =
       match settlement with
-      | Ack | No_compaction _ | Cancel_accepted _ | Transfer_accepted _
+      | Ack
+      | Manual_compaction_committed { followup = Compaction_commit_ack; _ }
+      | No_compaction _ | Cancel_accepted _ | Transfer_accepted _
       | Settle_from_source_terminal _ -> state.pending
+      | Manual_compaction_committed
+          { followup = Compaction_commit_failure_judgment successor; _ } ->
+        enqueue_if_missing state.pending successor
       | Settle_exact { action = Consume_source; _ } -> state.pending
       | Requeue
           (Retry_after_observed | Context_compaction_retry) ->
@@ -1587,7 +1725,8 @@ let settle ~settled_at ~lease ~settlement state =
      | Cancel_accepted _ | Transfer_accepted _ | Settle_from_source_terminal _
      | Settle_exact _ ->
        Error "accepted disposition requires its owner-fenced boundary"
-     | Ack | No_compaction _ | Requeue _ | Escalate _ ->
+     | Ack | Manual_compaction_committed _ | No_compaction _ | Requeue _
+     | Escalate _ ->
        settle_committed ~settled_at ~lease ~settlement state)
 ;;
 
@@ -1704,7 +1843,9 @@ let disposition_operation_id = function
   | Transfer_accepted transfer -> Some transfer.operator_operation_id
   | Settle_from_source_terminal source_terminal ->
     Some source_terminal.operator_operation_id
-  | Ack | No_compaction _ | Settle_exact _ | Requeue _ | Escalate _ -> None
+  | Ack | Manual_compaction_committed _ | No_compaction _ | Settle_exact _
+  | Requeue _ | Escalate _ ->
+    None
 ;;
 
 let prior_disposition_by_operation_id operation_id state =
@@ -1996,6 +2137,7 @@ let replay_transition_receipt receipt state =
           ~disposition_id:disposition.disposition_id
           state
       | Ack
+      | Manual_compaction_committed _
       | No_compaction _
       | Cancel_accepted _
       | Transfer_accepted _
@@ -2172,7 +2314,12 @@ let replay_transition_outbox_entry entry state =
              Error "pending source-terminal WAL source conflicts with its receipt"
            | Settle_from_source_terminal _, ([] | _ :: _ :: _) ->
              Error "pending source-terminal WAL must carry exactly one source"
-           | (Ack | No_compaction _ | Settle_exact _ | Requeue _ | Escalate _), _ ->
+           | ( Ack
+             | Manual_compaction_committed _
+             | No_compaction _
+             | Settle_exact _
+             | Requeue _
+             | Escalate _ ), _ ->
              Error
                (Printf.sprintf
                   "event queue WAL receipt has no matching active lease: %s"
@@ -2548,8 +2695,275 @@ let exact_source_disposition_of_yojson json =
   Ok disposition
 ;;
 
+let manual_compaction_auxiliary_to_yojson auxiliary =
+  let kind, detail, backtrace_present =
+    match auxiliary with
+    | Compaction_commit_durability_unknown { detail } ->
+      "commit_durability_unknown", detail, false
+    | Compaction_commit_observer_failed { detail; backtrace_present } ->
+      "commit_observer_failed", detail, backtrace_present
+    | Compaction_release_process_lock_failed { detail } ->
+      "release_process_lock_failed", detail, false
+    | Compaction_post_commit_unwind_interrupted { detail; backtrace_present } ->
+      "post_commit_unwind_interrupted", detail, backtrace_present
+    | Compaction_history_write_failed { detail; backtrace_present } ->
+      "history_write_failed", detail, backtrace_present
+  in
+  `Assoc
+    [ "kind", `String kind
+    ; "detail", `String detail
+    ; "backtrace_present", `Bool backtrace_present
+    ; "operator_action_required", `Bool true
+    ]
+;;
+
+let manual_compaction_auxiliary_of_yojson json =
+  let context = "manual compaction installation auxiliary" in
+  let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:
+        [ "kind"; "detail"; "backtrace_present"; "operator_action_required" ]
+      fields
+  in
+  let* kind = string_field ~context "kind" fields in
+  let* detail = string_field ~context "detail" fields in
+  let* backtrace_present =
+    match List.assoc_opt "backtrace_present" fields with
+    | Some (`Bool value) -> Ok value
+    | Some _ | None ->
+      Error "manual compaction auxiliary backtrace_present must be boolean"
+  in
+  let* () =
+    match List.assoc_opt "operator_action_required" fields with
+    | Some (`Bool true) -> Ok ()
+    | Some _ | None ->
+      Error "manual compaction auxiliary must require operator action"
+  in
+  let* auxiliary =
+    match kind, backtrace_present with
+    | "commit_durability_unknown", false ->
+      Ok (Compaction_commit_durability_unknown { detail })
+    | "commit_observer_failed", backtrace_present ->
+      Ok (Compaction_commit_observer_failed { detail; backtrace_present })
+    | "release_process_lock_failed", false ->
+      Ok (Compaction_release_process_lock_failed { detail })
+    | "post_commit_unwind_interrupted", backtrace_present ->
+      Ok
+        (Compaction_post_commit_unwind_interrupted
+           { detail; backtrace_present })
+    | "history_write_failed", backtrace_present ->
+      Ok (Compaction_history_write_failed { detail; backtrace_present })
+    | ("commit_durability_unknown" | "release_process_lock_failed"), true ->
+      Error "manual compaction non-exception auxiliary cannot carry a backtrace"
+    | unknown, _ ->
+      Error
+        (Printf.sprintf
+           "unknown manual compaction installation auxiliary: %s"
+           unknown)
+  in
+  let* () = validate_manual_compaction_auxiliary auxiliary in
+  Ok auxiliary
+;;
+
+let manual_compaction_lifecycle_to_yojson = function
+  | Compaction_completion_applied ->
+    `Assoc
+      [ "kind", `String "completion_applied"
+      ; "completion_error", `Null
+      ; "failure_dispatch", `String "not_needed"
+      ; "failure_dispatch_error", `Null
+      ; "operator_action_required", `Bool false
+      ]
+  | Compaction_completion_rejected_failure_dispatched { completion_error } ->
+    `Assoc
+      [ "kind", `String "completion_rejected_failure_dispatched"
+      ; "completion_error", `String completion_error
+      ; "failure_dispatch", `String "applied"
+      ; "failure_dispatch_error", `Null
+      ; "operator_action_required", `Bool true
+      ]
+  | Compaction_completion_rejected_failure_dispatch_failed
+      { completion_error; failure_dispatch_error } ->
+    `Assoc
+      [ "kind", `String "completion_rejected_failure_dispatch_failed"
+      ; "completion_error", `String completion_error
+      ; "failure_dispatch", `String "rejected"
+      ; "failure_dispatch_error", `String failure_dispatch_error
+      ; "operator_action_required", `Bool true
+      ]
+;;
+
+let manual_compaction_lifecycle_of_yojson json =
+  let context = "manual compaction post-install lifecycle" in
+  let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:
+        [ "kind"
+        ; "completion_error"
+        ; "failure_dispatch"
+        ; "failure_dispatch_error"
+        ; "operator_action_required"
+        ]
+      fields
+  in
+  let* kind = string_field ~context "kind" fields in
+  let lifecycle =
+    match
+      kind,
+      List.assoc_opt "completion_error" fields,
+      List.assoc_opt "failure_dispatch" fields,
+      List.assoc_opt "failure_dispatch_error" fields,
+      List.assoc_opt "operator_action_required" fields
+    with
+    | "completion_applied", Some `Null, Some (`String "not_needed"),
+      Some `Null, Some (`Bool false) ->
+      Ok Compaction_completion_applied
+    | "completion_rejected_failure_dispatched",
+      Some (`String completion_error), Some (`String "applied"), Some `Null,
+      Some (`Bool true) ->
+      Ok
+        (Compaction_completion_rejected_failure_dispatched
+           { completion_error })
+    | "completion_rejected_failure_dispatch_failed",
+      Some (`String completion_error), Some (`String "rejected"),
+      Some (`String failure_dispatch_error), Some (`Bool true) ->
+      Ok
+        (Compaction_completion_rejected_failure_dispatch_failed
+           { completion_error; failure_dispatch_error })
+    | _ -> Error "manual compaction lifecycle fields are inconsistent"
+  in
+  let* lifecycle = lifecycle in
+  let* () = validate_manual_compaction_lifecycle lifecycle in
+  Ok lifecycle
+;;
+
+let manual_compaction_commit_to_yojson commit =
+  `Assoc
+    [ "schema", `String "keeper.manual_compaction_commit.v1"
+    ; "checkpoint_installed_ref", checkpoint_source_to_yojson commit.installed_ref
+    ; ( "checkpoint_installation_auxiliary"
+      , `List
+          (List.map
+             manual_compaction_auxiliary_to_yojson
+             commit.auxiliary) )
+    ; "compaction_lifecycle", manual_compaction_lifecycle_to_yojson commit.lifecycle
+    ; ( "manifest_error"
+      , match commit.manifest_error with
+        | None -> `Null
+        | Some detail -> `String detail )
+    ; ( "operator_action_required"
+      , `Bool (manual_compaction_commit_requires_operator_action commit) )
+    ]
+;;
+
+let manual_compaction_commit_of_yojson json =
+  let context = "manual compaction commit receipt" in
+  let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:
+        [ "schema"
+        ; "checkpoint_installed_ref"
+        ; "checkpoint_installation_auxiliary"
+        ; "compaction_lifecycle"
+        ; "manifest_error"
+        ; "operator_action_required"
+        ]
+      fields
+  in
+  let* schema = string_field ~context "schema" fields in
+  let* () =
+    if String.equal schema "keeper.manual_compaction_commit.v1"
+    then Ok ()
+    else Error ("unsupported manual compaction commit schema: " ^ schema)
+  in
+  let* installed_ref_json =
+    required_field ~context "checkpoint_installed_ref" fields
+  in
+  let* installed_ref = checkpoint_source_of_yojson installed_ref_json in
+  let* auxiliary =
+    match List.assoc_opt "checkpoint_installation_auxiliary" fields with
+    | Some (`List values) ->
+      List.fold_right
+        (fun value result ->
+           let* auxiliary = manual_compaction_auxiliary_of_yojson value in
+           let* rest = result in
+           Ok (auxiliary :: rest))
+        values
+        (Ok [])
+    | Some _ | None ->
+      Error "manual compaction installation auxiliary must be a list"
+  in
+  let* lifecycle_json = required_field ~context "compaction_lifecycle" fields in
+  let* lifecycle = manual_compaction_lifecycle_of_yojson lifecycle_json in
+  let* manifest_error =
+    match List.assoc_opt "manifest_error" fields with
+    | Some `Null -> Ok None
+    | Some (`String detail) -> Ok (Some detail)
+    | Some _ | None ->
+      Error "manual compaction manifest_error must be string or null"
+  in
+  let commit = { installed_ref; auxiliary; lifecycle; manifest_error } in
+  let* () = validate_manual_compaction_commit commit in
+  let* operator_action_required =
+    match List.assoc_opt "operator_action_required" fields with
+    | Some (`Bool value) -> Ok value
+    | Some _ | None ->
+      Error "manual compaction operator_action_required must be boolean"
+  in
+  if
+    Bool.equal
+      operator_action_required
+      (manual_compaction_commit_requires_operator_action commit)
+  then Ok commit
+  else Error "manual compaction operator action fact does not match receipt"
+;;
+
+let manual_compaction_followup_to_yojson = function
+  | Compaction_commit_ack -> `Assoc [ "kind", `String "ack" ]
+  | Compaction_commit_failure_judgment successor ->
+    `Assoc
+      [ "kind", `String "failure_judgment_requested"
+      ; "successor", Keeper_event_queue.stimulus_to_yojson successor
+      ]
+;;
+
+let manual_compaction_followup_of_yojson json =
+  let context = "manual compaction commit follow-up" in
+  let* fields = assoc_fields ~context json in
+  let* kind = string_field ~context "kind" fields in
+  let* followup =
+    match kind with
+    | "ack" ->
+      let* () = exact_fields ~context ~expected:[ "kind" ] fields in
+      Ok Compaction_commit_ack
+    | "failure_judgment_requested" ->
+      let* () =
+        exact_fields ~context ~expected:[ "kind"; "successor" ] fields
+      in
+      let* successor_json = required_field ~context "successor" fields in
+      let* successor = Keeper_event_queue.stimulus_of_yojson successor_json in
+      Ok (Compaction_commit_failure_judgment successor)
+    | unknown ->
+      Error (Printf.sprintf "unknown manual compaction follow-up: %s" unknown)
+  in
+  let* () = validate_manual_compaction_followup followup in
+  Ok followup
+;;
+
 let settlement_to_yojson = function
   | Ack -> `Assoc [ "kind", `String "ack" ]
+  | Manual_compaction_committed { commit; followup } ->
+    `Assoc
+      [ "kind", `String "manual_compaction_committed"
+      ; "receipt", manual_compaction_commit_to_yojson commit
+      ; "followup", manual_compaction_followup_to_yojson followup
+      ]
   | No_compaction { source; reason } ->
     let fields =
       [ "kind", `String "no_compaction"
@@ -2633,6 +3047,17 @@ let settlement_of_yojson json =
   | "ack" ->
     let* () = exact_fields ~context ~expected:[ "kind" ] fields in
     Ok Ack
+  | "manual_compaction_committed" ->
+    let* () =
+      exact_fields ~context ~expected:[ "kind"; "receipt"; "followup" ] fields
+    in
+    let* receipt_json = required_field ~context "receipt" fields in
+    let* commit = manual_compaction_commit_of_yojson receipt_json in
+    let* followup_json = required_field ~context "followup" fields in
+    let* followup = manual_compaction_followup_of_yojson followup_json in
+    let settlement = Manual_compaction_committed { commit; followup } in
+    let* () = validate_settlement settlement in
+    Ok settlement
   | "no_compaction" ->
     let* reason_label = string_field ~context "reason" fields in
     let* source_json = required_field ~context "source" fields in
@@ -2814,6 +3239,7 @@ let accepted_transfer_projection_of_yojson json =
   match settlement with
   | Transfer_accepted transfer -> Ok transfer
   | Ack
+  | Manual_compaction_committed _
   | No_compaction _
   | Cancel_accepted _
   | Settle_from_source_terminal _
@@ -2865,6 +3291,7 @@ let transition_receipt_of_yojson json =
         expected_lease_id
         disposition.disposition_id
     | Ack
+    | Manual_compaction_committed _
     | No_compaction _
     | Cancel_accepted _
     | Transfer_accepted _

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -186,6 +186,46 @@ type accepted_source_terminal =
   ; source_receipt : source_terminal_receipt
   }
 
+type manual_compaction_auxiliary =
+  | Compaction_commit_durability_unknown of { detail : string }
+  | Compaction_commit_observer_failed of
+      { detail : string
+      ; backtrace_present : bool
+      }
+  | Compaction_release_process_lock_failed of { detail : string }
+  | Compaction_post_commit_unwind_interrupted of
+      { detail : string
+      ; backtrace_present : bool
+      }
+  | Compaction_history_write_failed of
+      { detail : string
+      ; backtrace_present : bool
+      }
+
+type manual_compaction_lifecycle =
+  | Compaction_completion_applied
+  | Compaction_completion_rejected_failure_dispatched of
+      { completion_error : string }
+  | Compaction_completion_rejected_failure_dispatch_failed of
+      { completion_error : string
+      ; failure_dispatch_error : string
+      }
+
+type manual_compaction_commit =
+  { installed_ref : Keeper_checkpoint_ref.t
+  ; auxiliary : manual_compaction_auxiliary list
+  ; lifecycle : manual_compaction_lifecycle
+  ; manifest_error : string option
+  }
+
+type manual_compaction_followup =
+  | Compaction_commit_ack
+  | Compaction_commit_failure_judgment of Keeper_event_queue.stimulus
+
+val manual_compaction_commit_requires_operator_action
+  :  manual_compaction_commit
+  -> bool
+
 val no_compaction_reason_label : no_compaction_reason -> string
 val no_compaction_reason_of_label : string -> (no_compaction_reason, string) result
 val no_compaction_reason_to_string : no_compaction_reason -> string
@@ -202,6 +242,10 @@ val escalation_reason_requests_external_input : escalation_reason -> bool
 
 type settlement =
   | Ack
+  | Manual_compaction_committed of
+      { commit : manual_compaction_commit
+      ; followup : manual_compaction_followup
+      }
   | No_compaction of no_compaction
   | Cancel_accepted of accepted_cancellation
   | Transfer_accepted of accepted_transfer

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -481,7 +481,19 @@ type 'a durable_lock_observation =
       ; release_error : durable_lock_error option
       }
 
-let with_durable_lock_observed ~lock_path f =
+let release_durable_lock_result ~lock_path fd =
+  match release_durable_fd_result fd with
+  | Ok () -> Ok ()
+  | Error (cause, cleanup_failure) ->
+    Error
+      (durable_lock_error
+         ?cleanup_failure
+         ~lock_path
+         ~phase:Release_process_lock
+         cause)
+;;
+
+let with_durable_lock_observed_with ~release_fd ~lock_path f =
   with_mutex lock_path (fun () ->
     let execution_context = Eio_guard.execution_context () in
     match acquire_durable_flock ~execution_context lock_path with
@@ -493,29 +505,24 @@ let with_durable_lock_observed ~lock_path f =
           | value -> `Returned value
           | exception exn -> `Raised (exn, Printexc.get_raw_backtrace ())
         in
-        let release = release_durable_fd_result fd in
+        let release = release_fd fd in
         match body, release with
         | `Returned value, Ok () ->
           Body_completed { value; release_error = None }
-        | `Returned value, Error (cause, cleanup_failure) ->
+        | `Returned value, Error error ->
           Body_completed
             { value
-            ; release_error =
-                Some
-                  (durable_lock_error
-                     ?cleanup_failure
-                     ~lock_path
-                     ~phase:Release_process_lock
-                     cause)
+            ; release_error = Some error
             }
         | `Raised (exn, backtrace), Ok () ->
           Printexc.raise_with_backtrace exn backtrace
-        | `Raised (exn, backtrace), Error (release_failure, cleanup_failure) ->
+        | `Raised (exn, backtrace), Error error ->
+          let release_failure = error.cause in
           Log.Misc.error
             "file_lock_eio: release failed during body exception lock_path=%s operation=%s argument=%s error=%s%s"
             lock_path release_failure.operation release_failure.argument
             (Unix.error_message release_failure.error)
-            (match cleanup_failure with
+            (match error.cleanup_failure with
              | None -> ""
              | Some cleanup ->
                Printf.sprintf
@@ -526,12 +533,33 @@ let with_durable_lock_observed ~lock_path f =
       in
       protect_cleanup execution_context admitted)
 
+let with_durable_lock_observed ~lock_path f =
+  with_durable_lock_observed_with
+    ~release_fd:(release_durable_lock_result ~lock_path)
+    ~lock_path
+    f
+;;
+
 let with_durable_lock ~lock_path f =
   match with_durable_lock_observed ~lock_path f with
   | Lock_not_acquired error -> Error error
   | Body_completed { value; release_error = None } -> Ok value
   | Body_completed { release_error = Some error; _ } -> Error error
 ;;
+
+module For_testing = struct
+  let with_durable_lock_observed_with_release_failure
+      ~release_failure
+      ~lock_path
+      f =
+    let release_fd fd =
+      match release_durable_lock_result ~lock_path fd with
+      | Error error -> Error error
+      | Ok () -> Error release_failure
+    in
+    with_durable_lock_observed_with ~release_fd ~lock_path f
+  ;;
+end
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -474,11 +474,18 @@ let acquire_durable_flock ~execution_context lock_path =
             ~phase:Acquire_process_lock
             cause))
 
-let with_durable_lock ~lock_path f =
+type 'a durable_lock_observation =
+  | Lock_not_acquired of durable_lock_error
+  | Body_completed of
+      { value : 'a
+      ; release_error : durable_lock_error option
+      }
+
+let with_durable_lock_observed ~lock_path f =
   with_mutex lock_path (fun () ->
     let execution_context = Eio_guard.execution_context () in
     match acquire_durable_flock ~execution_context lock_path with
-    | Error _ as error -> error
+    | Error error -> Lock_not_acquired error
     | Ok fd ->
       let admitted () =
         let body =
@@ -488,14 +495,19 @@ let with_durable_lock ~lock_path f =
         in
         let release = release_durable_fd_result fd in
         match body, release with
-        | `Returned value, Ok () -> Ok value
-        | `Returned _, Error (cause, cleanup_failure) ->
-          Error
-            (durable_lock_error
-               ?cleanup_failure
-               ~lock_path
-               ~phase:Release_process_lock
-               cause)
+        | `Returned value, Ok () ->
+          Body_completed { value; release_error = None }
+        | `Returned value, Error (cause, cleanup_failure) ->
+          Body_completed
+            { value
+            ; release_error =
+                Some
+                  (durable_lock_error
+                     ?cleanup_failure
+                     ~lock_path
+                     ~phase:Release_process_lock
+                     cause)
+            }
         | `Raised (exn, backtrace), Ok () ->
           Printexc.raise_with_backtrace exn backtrace
         | `Raised (exn, backtrace), Error (release_failure, cleanup_failure) ->
@@ -513,6 +525,13 @@ let with_durable_lock ~lock_path f =
           Printexc.raise_with_backtrace exn backtrace
       in
       protect_cleanup execution_context admitted)
+
+let with_durable_lock ~lock_path f =
+  match with_durable_lock_observed ~lock_path f with
+  | Lock_not_acquired error -> Error error
+  | Body_completed { value; release_error = None } -> Ok value
+  | Body_completed { release_error = Some error; _ } -> Error error
+;;
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -131,6 +131,18 @@ val with_durable_lock :
     failure remains [Error] here; transaction owners that distinguish their
     completed body result must use the observed surface. *)
 
+module For_testing : sig
+  val with_durable_lock_observed_with_release_failure :
+    release_failure:durable_lock_error ->
+    lock_path:string ->
+    (unit -> 'a) ->
+    'a durable_lock_observation
+  (** Acquire and release the real durable lock, then deterministically report
+      [release_failure] through the same [Body_completed] path used by a real
+      release error. The file descriptor is released before the injected
+      observation is returned. *)
+end
+
 (** {1 Observability hook} *)
 
 (** Fires after every {!acquire_flock_retry} / {!acquire_flock_retry_cooperative}

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -112,8 +112,24 @@ val with_lock :
     masked only after the OS lock is held, through body execution and release.
     The parent directory must exist. I/O failures are typed and body exceptions
     survive cleanup errors. *)
+type 'a durable_lock_observation =
+  | Lock_not_acquired of durable_lock_error
+  | Body_completed of
+      { value : 'a
+      ; release_error : durable_lock_error option
+      }
+
+val with_durable_lock_observed :
+  lock_path:string -> (unit -> 'a) -> 'a durable_lock_observation
+(** Preserve a completed body value even when releasing the process lock
+    fails. Open/acquire failures return [Lock_not_acquired] without running the
+    body. Body exceptions retain their original exception and raw backtrace. *)
+
 val with_durable_lock :
   lock_path:string -> (unit -> 'a) -> ('a, durable_lock_error) result
+(** Compatibility projection of {!with_durable_lock_observed}. A release
+    failure remains [Error] here; transaction owners that distinguish their
+    completed body result must use the observed surface. *)
 
 (** {1 Observability hook} *)
 

--- a/scripts/check-checkpoint-installation-legacy-purge.sh
+++ b/scripts/check-checkpoint-installation-legacy-purge.sh
@@ -18,6 +18,18 @@ if matches="$(
   fi
 fi
 
+if matches="$(
+  rg -n \
+    'checkpoint_commit_hint|Hint_not_emitted|Hint_delivered|Hint_failed|admitted_result|run_admitted_with_install_observer' \
+    "${roots[@]}" || true
+)"; then
+  if [[ -n "${matches}" ]]; then
+    echo "[checkpoint-installation-legacy-purge] forbidden manual-compaction legacy surface:" >&2
+    echo "${matches}" >&2
+    exit 1
+  fi
+fi
+
 checkpoint_surface_files=(
   lib/keeper/keeper_checkpoint_store.ml
   lib/keeper/keeper_checkpoint_store.mli
@@ -41,6 +53,22 @@ if matches="$(
 )"; then
   if [[ -n "${matches}" ]]; then
     echo "[checkpoint-installation-legacy-purge] forbidden checkpoint outcome residue:" >&2
+    echo "${matches}" >&2
+    exit 1
+  fi
+fi
+
+manual_compaction_surface_files=(
+  lib/keeper/keeper_manual_compaction.ml
+  lib/keeper/keeper_manual_compaction.mli
+)
+if matches="$(
+  rg -n \
+    'on_checkpoint_installed' \
+    "${manual_compaction_surface_files[@]}" || true
+)"; then
+  if [[ -n "${matches}" ]]; then
+    echo "[checkpoint-installation-legacy-purge] forbidden manual-compaction callback residue:" >&2
     echo "${matches}" >&2
     exit 1
   fi

--- a/scripts/check-checkpoint-installation-legacy-purge.sh
+++ b/scripts/check-checkpoint-installation-legacy-purge.sh
@@ -18,4 +18,32 @@ if matches="$(
   fi
 fi
 
+checkpoint_surface_files=(
+  lib/keeper/keeper_checkpoint_store.ml
+  lib/keeper/keeper_checkpoint_store.mli
+  lib/keeper/keeper_context_core.ml
+  lib/keeper/keeper_context_core.mli
+  lib/keeper/keeper_context_runtime.ml
+  lib/keeper/keeper_context_runtime.mli
+  lib/keeper/keeper_post_turn.ml
+  lib/keeper/keeper_post_turn.mli
+  lib/keeper/keeper_manual_compaction.ml
+  lib/keeper/keeper_manual_compaction.mli
+  lib/keeper/keeper_heartbeat_loop.ml
+  lib/keeper/keeper_heartbeat_loop_cycle.ml
+  lib/keeper/keeper_heartbeat_loop_cycle.mli
+  lib/keeper/keeper_tool_surface.ml
+)
+if matches="$(
+  rg -n \
+    'Outcome_unknown' \
+    "${checkpoint_surface_files[@]}" test proto || true
+)"; then
+  if [[ -n "${matches}" ]]; then
+    echo "[checkpoint-installation-legacy-purge] forbidden checkpoint outcome residue:" >&2
+    echo "${matches}" >&2
+    exit 1
+  fi
+fi
+
 echo "[checkpoint-installation-legacy-purge] OK"

--- a/scripts/check-checkpoint-installation-legacy-purge.sh
+++ b/scripts/check-checkpoint-installation-legacy-purge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+roots=(lib test proto docs .github)
+if matches="$(
+  rg -n \
+    'Transaction_outcome_unknown|checkpoint_applied' \
+    "${roots[@]}" || true
+)"; then
+  if [[ -n "${matches}" ]]; then
+    echo "[checkpoint-installation-legacy-purge] forbidden legacy surface:" >&2
+    echo "${matches}" >&2
+    exit 1
+  fi
+fi
+
+echo "[checkpoint-installation-legacy-purge] OK"

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -77,9 +77,16 @@ let test_with_lock_inside_eio () =
 let test_durable_lock_open_failure_is_typed () =
   with_temp_path @@ fun path ->
   let path = Filename.concat path "missing/target" in
-  match File_lock_eio.with_durable_lock ~lock_path:path (fun () -> ()) with
-  | Ok () -> fail "durable lock unexpectedly created a missing parent tree"
-  | Error error ->
+  let body_ran = ref false in
+  match
+    File_lock_eio.with_durable_lock_observed
+      ~lock_path:path
+      (fun () -> body_ran := true)
+  with
+  | File_lock_eio.Body_completed _ ->
+    fail "durable lock unexpectedly created a missing parent tree"
+  | File_lock_eio.Lock_not_acquired error ->
+    check bool "lock body did not run before acquisition" false !body_ran;
     check bool "failure phase is lock-file open" true
       (match error.File_lock_eio.phase with
        | File_lock_eio.Open_lock_file -> true

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -92,6 +92,37 @@ let test_durable_lock_open_failure_is_typed () =
        | File_lock_eio.Open_lock_file -> true
        | Acquire_process_lock | Release_process_lock -> false)
 
+let test_durable_lock_release_failure_preserves_completed_value () =
+  with_temp_path @@ fun lock_path ->
+  let release_failure =
+    { File_lock_eio.lock_path
+    ; phase = File_lock_eio.Release_process_lock
+    ; cause =
+        { File_lock_eio.error = Unix.EIO
+        ; operation = "injected_release_after_body"
+        ; argument = lock_path
+        }
+    ; cleanup_failure = None
+    }
+  in
+  match
+    File_lock_eio.For_testing.with_durable_lock_observed_with_release_failure
+      ~release_failure
+      ~lock_path
+      (fun () -> "completed")
+  with
+  | File_lock_eio.Lock_not_acquired error ->
+    fail
+      ("durable lock was not acquired: "
+       ^ File_lock_eio.durable_lock_error_to_string error)
+  | File_lock_eio.Body_completed { value; release_error } ->
+    check string "completed body value survives release failure" "completed" value;
+    check bool
+      "release failure is exact"
+      true
+      (release_error = Some release_failure)
+;;
+
 let with_external_lock_holder lock_path f =
   let ready_read, ready_write = Unix.pipe () in
   let release_read, release_write = Unix.pipe () in
@@ -168,6 +199,8 @@ let () =
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
           test_case "durable lock open failure is typed" `Quick
             test_durable_lock_open_failure_is_typed;
+          test_case "durable lock release failure preserves body value" `Quick
+            test_durable_lock_release_failure_preserves_completed_value;
           test_case "durable cross-process wait is cancellable" `Quick
             test_durable_lock_wait_is_cancellable;
         ] );

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -495,35 +495,66 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS source load failed"
     in
-    let writer marker =
-      Keeper_checkpoint_store.save_oas_if_source
-        ~on_checkpoint_commit_hint:(fun _ -> ())
+    let left_observed = Atomic.make 0 in
+    let right_observed = Atomic.make 0 in
+    let left_ref = Atomic.make None in
+    let right_ref = Atomic.make None in
+    let writer marker observed observed_ref =
+      Keeper_checkpoint_store.For_testing.save_oas_if_source_with_observer
+        ~on_checkpoint_commit_observer:(fun installed_ref ->
+          Atomic.incr observed;
+          Atomic.set observed_ref (Some installed_ref))
         ~session_dir
         ~expected_source_ref:source_ref
         (make_checkpoint ~session_id ~turn_count:8 ~marker
          |> with_generation 3)
     in
-    let left = Domain.spawn (fun () -> "left", writer "left") in
-    let right = Domain.spawn (fun () -> "right", writer "right") in
+    let left =
+      Domain.spawn (fun () -> "left", writer "left" left_observed left_ref)
+    in
+    let right =
+      Domain.spawn (fun () -> "right", writer "right" right_observed right_ref)
+    in
     let committed, changed =
       [ Domain.join left; Domain.join right ]
       |> List.fold_left
            (fun (committed, changed) (marker, outcome) ->
              match outcome with
-             | Ok reference -> (marker, reference) :: committed, changed
-             | Error (Keeper_checkpoint_store.Source_changed _) ->
+             | Keeper_checkpoint_store.Installed installed ->
+               (marker, installed) :: committed, changed
+             | Keeper_checkpoint_store.Not_installed
+                 (Keeper_checkpoint_store.Source_changed _) ->
                committed, changed + 1
-             | Error _ -> fail "CAS writer returned an unexpected error")
+             | Keeper_checkpoint_store.Not_installed _ ->
+               fail "CAS writer returned an unexpected error")
            ([], 0)
     in
     check int "exactly one writer commits" 1 (List.length committed);
     check int "the competing source is rejected" 1 changed;
+    check int
+      "competing observer is emitted once for the winner"
+      1
+      (Atomic.get left_observed + Atomic.get right_observed);
     match committed,
       Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
     with
     | [ (winner, committed_ref) ], Ok (checkpoint, disk_ref) ->
+      let winner_observed, loser_observed, winner_ref =
+        if String.equal winner "left"
+        then Atomic.get left_observed, Atomic.get right_observed, Atomic.get left_ref
+        else Atomic.get right_observed, Atomic.get left_observed, Atomic.get right_ref
+      in
+      check int "winning writer observer count" 1 winner_observed;
+      check int "stale writer observer count" 0 loser_observed;
       check bool "committed ref identifies installed canonical bytes" true
         (Keeper_checkpoint_ref.equal committed_ref.installed_ref disk_ref);
+      check bool
+        "observer receives the exact installed ref"
+        true
+        (match winner_ref with
+         | Some observed_ref ->
+           Keeper_checkpoint_ref.equal observed_ref committed_ref.installed_ref
+         | None -> false);
       check bool "installed payload belongs to the winning writer" true
         (List.exists
            (fun (message : Agent_sdk.Types.message) ->
@@ -546,16 +577,40 @@ let test_exact_source_cas_updates_canonical_watermark () =
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS watermark source load failed"
     in
+    let release_failure =
+      { File_lock_eio.lock_path = session_dir ^ ".checkpoint.lock"
+      ; phase = File_lock_eio.Release_process_lock
+      ; cause =
+          { File_lock_eio.error = Unix.EIO
+          ; operation = "injected_release"
+          ; argument = session_dir
+          }
+      ; cleanup_failure = None
+      }
+    in
+    let observer_count = ref 0 in
     (match
-       Keeper_checkpoint_store.save_oas_if_source
-         ~on_checkpoint_commit_hint:(fun _ -> ())
+       Keeper_checkpoint_store.For_testing.save_oas_if_source_with_release_failure
+         ~release_failure
+         ~on_checkpoint_commit_observer:(fun _ -> incr observer_count)
          ~session_dir
          ~expected_source_ref:source_ref
          (make_checkpoint ~session_id ~turn_count:9 ~marker:"target"
           |> with_generation 3)
      with
-     | Ok _ -> ()
-     | Error _ -> fail "CAS watermark candidate did not commit");
+     | Keeper_checkpoint_store.Installed installed ->
+       check int "release-failure observer remains at-most-once" 1 !observer_count;
+       check bool
+         "release failure remains auxiliary to installed"
+         true
+         (List.exists
+            (function
+              | Keeper_checkpoint_store.Release_process_lock_failed error ->
+                error = release_failure
+              | _ -> false)
+            installed.auxiliary)
+     | Keeper_checkpoint_store.Not_installed _ ->
+       fail "release failure downgraded the installed checkpoint");
     match
       Keeper_checkpoint_store.save_oas_classified ~session_dir
         (make_checkpoint ~session_id ~turn_count:8 ~marker:"stale!")

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -480,6 +480,31 @@ let test_ready_runtime_raw_domain_save () =
   | Error _ -> fail "raw-domain checkpoint did not round-trip"
   | Ok checkpoint -> check int "raw-domain turn persisted" 11 checkpoint.turn_count
 
+let with_recorded_backtraces f =
+  let was_recording = Printexc.backtrace_status () in
+  Printexc.record_backtrace true;
+  Fun.protect
+    ~finally:(fun () -> Printexc.record_backtrace was_recording)
+    f
+;;
+
+let with_exact_source_fixture ~session_id f =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:8 ~marker:"source"
+       |> with_generation 3)
+      "exact source seed save";
+    let source_ref =
+      match
+        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+      with
+      | Ok (_, reference) -> reference
+      | Error _ -> fail "exact source load failed"
+    in
+    f ~session_dir ~source_ref)
+;;
+
 let test_exact_source_cas_allows_one_equal_turn_writer () =
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
@@ -625,6 +650,133 @@ let test_exact_source_cas_updates_canonical_watermark () =
       fail "stale save ignored the canonical checkpoint installed by CAS"
     | Error error -> fail ("post-CAS stale classification failed: " ^ error))
 
+let test_post_rename_durability_unknown_is_installed () =
+  let session_id = "sess-cas-post-rename" in
+  with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
+    let candidate =
+      make_checkpoint ~session_id ~turn_count:9 ~marker:"post-rename"
+      |> with_generation 3
+    in
+    let durability_error =
+      { Keeper_fs.renamed = true
+      ; stage = Keeper_fs.Parent_directory_fsync_after_rename
+      ; failure =
+          Keeper_fs.Operation_failed "injected post-rename durability failure"
+      }
+    in
+    match
+      Keeper_checkpoint_store.For_testing.save_oas_if_source_with_writer
+        ~write_checkpoint_bytes:
+          (fun ~on_durable_commit:_ ~ownership_root:_ ~path ~bytes ->
+             Fs_compat.save_file path bytes;
+             Error durability_error)
+        ~on_checkpoint_commit_observer:(fun _ -> ())
+        ~session_dir
+        ~expected_source_ref:source_ref
+        candidate
+    with
+    | Keeper_checkpoint_store.Not_installed _ ->
+      fail "post-rename durability uncertainty became Not_installed"
+    | Keeper_checkpoint_store.Installed installed ->
+      (match installed.auxiliary with
+       | [ Keeper_checkpoint_store.Commit_durability_unknown error ] ->
+         check bool
+           "post-rename durability cause is preserved"
+           true
+           (error = durability_error)
+       | _ -> fail "post-rename durability auxiliary was not preserved");
+      let disk_ref =
+        match
+          Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+        with
+        | Ok (_, reference) -> reference
+        | Error _ -> fail "post-rename candidate was not externally installed"
+      in
+      check bool
+        "post-rename outcome carries the exact installed ref"
+        true
+        (Keeper_checkpoint_ref.equal installed.installed_ref disk_ref);
+      match
+        Keeper_checkpoint_store.save_oas_if_source
+          ~session_dir
+          ~expected_source_ref:source_ref
+          candidate
+      with
+      | Keeper_checkpoint_store.Not_installed
+          (Keeper_checkpoint_store.Source_changed actual) ->
+        check bool
+          "same-process retry is fenced by the installed ref"
+          true
+          (Keeper_checkpoint_ref.equal actual installed.installed_ref)
+      | Keeper_checkpoint_store.Installed _ ->
+        fail "post-rename candidate was installed twice"
+      | Keeper_checkpoint_store.Not_installed _ ->
+        fail "post-rename retry failed without exact source evidence")
+;;
+
+let test_commit_observer_failure_is_installed () =
+  let session_id = "sess-cas-observer-failure" in
+  with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
+    let outcome =
+      with_recorded_backtraces (fun () ->
+        Keeper_checkpoint_store.For_testing.save_oas_if_source_with_observer
+          ~on_checkpoint_commit_observer:(fun _ ->
+            failwith "injected commit observer failure")
+          ~session_dir
+          ~expected_source_ref:source_ref
+          (make_checkpoint ~session_id ~turn_count:9 ~marker:"observer-failure"
+           |> with_generation 3))
+    in
+    match outcome with
+    | Keeper_checkpoint_store.Not_installed _ ->
+      fail "commit observer failure downgraded the installed checkpoint"
+    | Keeper_checkpoint_store.Installed installed ->
+      match installed.auxiliary with
+      | [ Keeper_checkpoint_store.Commit_observer_failed
+            (Failure detail, backtrace) ] ->
+        check string
+          "commit observer failure cause"
+          "injected commit observer failure"
+          detail;
+        check bool
+          "commit observer failure preserves its raw backtrace"
+          true
+          (Printexc.raw_backtrace_length backtrace > 0)
+      | _ -> fail "commit observer failure was not preserved as auxiliary")
+;;
+
+let test_post_commit_unwind_is_installed () =
+  let session_id = "sess-cas-post-commit-unwind" in
+  with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
+    let outcome =
+      with_recorded_backtraces (fun () ->
+        Keeper_checkpoint_store.For_testing.save_oas_if_source_with_post_commit_unwind
+          ~post_commit_unwind:(fun () ->
+            failwith "injected post-commit unwind")
+          ~on_checkpoint_commit_observer:(fun _ -> ())
+          ~session_dir
+          ~expected_source_ref:source_ref
+          (make_checkpoint ~session_id ~turn_count:9 ~marker:"post-commit-unwind"
+           |> with_generation 3))
+    in
+    match outcome with
+    | Keeper_checkpoint_store.Not_installed _ ->
+      fail "post-commit unwind downgraded the installed checkpoint"
+    | Keeper_checkpoint_store.Installed installed ->
+      match installed.auxiliary with
+      | [ Keeper_checkpoint_store.Post_commit_unwind_interrupted
+            (Failure detail, backtrace) ] ->
+        check string
+          "post-commit unwind cause"
+          "injected post-commit unwind"
+          detail;
+        check bool
+          "post-commit unwind preserves its raw backtrace"
+          true
+          (Printexc.raw_backtrace_length backtrace > 0)
+      | _ -> fail "post-commit unwind was not preserved as auxiliary")
+;;
+
 let test_checkpoint_ref_requires_generation () =
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
@@ -710,6 +862,12 @@ let () =
             test_exact_source_cas_allows_one_equal_turn_writer;
           test_case "exact source CAS updates the canonical watermark" `Quick
             test_exact_source_cas_updates_canonical_watermark;
+          test_case "post-rename durability uncertainty stays installed" `Quick
+            test_post_rename_durability_unknown_is_installed;
+          test_case "commit observer failure stays installed" `Quick
+            test_commit_observer_failure_is_installed;
+          test_case "post-commit unwind stays installed" `Quick
+            test_post_commit_unwind_is_installed;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
           test_case "exact snapshot preserves canonical bytes" `Quick

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -548,7 +548,7 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
              | Keeper_checkpoint_store.Installed installed ->
                (marker, installed) :: committed, changed
              | Keeper_checkpoint_store.Not_installed
-                 (Keeper_checkpoint_store.Source_changed _) ->
+                 { cause = Keeper_checkpoint_store.Source_changed _; _ } ->
                committed, changed + 1
              | Keeper_checkpoint_store.Not_installed _ ->
                fail "CAS writer returned an unexpected error")
@@ -634,6 +634,18 @@ let test_exact_source_cas_updates_canonical_watermark () =
                 error = release_failure
               | _ -> false)
             installed.auxiliary)
+       ;
+       let disk_ref =
+         match
+           Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+         with
+         | Ok (_, reference) -> reference
+         | Error _ -> fail "release-failure installed checkpoint was not readable"
+       in
+       check bool
+         "release failure preserves the exact installed ref"
+         true
+         (Keeper_checkpoint_ref.equal installed.installed_ref disk_ref)
      | Keeper_checkpoint_store.Not_installed _ ->
        fail "release failure downgraded the installed checkpoint");
     match
@@ -703,7 +715,7 @@ let test_post_rename_durability_unknown_is_installed () =
           candidate
       with
       | Keeper_checkpoint_store.Not_installed
-          (Keeper_checkpoint_store.Source_changed actual) ->
+          { cause = Keeper_checkpoint_store.Source_changed actual; _ } ->
         check bool
           "same-process retry is fenced by the installed ref"
           true
@@ -741,7 +753,7 @@ let test_pre_rename_write_failure_is_not_installed_and_retryable () =
     | Keeper_checkpoint_store.Installed _ ->
       fail "pre-rename write failure became Installed"
     | Keeper_checkpoint_store.Not_installed
-        (Keeper_checkpoint_store.Commit_not_installed error) ->
+        { cause = Keeper_checkpoint_store.Commit_not_installed error; _ } ->
       check bool
         "pre-rename write failure preserves its exact cause"
         true
@@ -771,6 +783,102 @@ let test_pre_rename_write_failure_is_not_installed_and_retryable () =
          fail "pre-rename failure consumed the exact-source retry")
     | Keeper_checkpoint_store.Not_installed _ ->
       fail "pre-rename write failure lost its Commit_not_installed cause")
+;;
+
+let test_release_failure_preserves_not_installed_cause () =
+  let session_id = "sess-cas-not-installed-release" in
+  with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
+    let advanced =
+      match
+        Keeper_checkpoint_store.save_oas_if_source
+          ~session_dir
+          ~expected_source_ref:source_ref
+          (make_checkpoint ~session_id ~turn_count:9 ~marker:"advanced"
+           |> with_generation 3)
+      with
+      | Keeper_checkpoint_store.Installed installed -> installed.installed_ref
+      | Keeper_checkpoint_store.Not_installed _ ->
+        fail "failed to advance the source before release-failure proof"
+    in
+    let release_failure =
+      { File_lock_eio.lock_path = session_dir ^ ".checkpoint.lock"
+      ; phase = File_lock_eio.Release_process_lock
+      ; cause =
+          { File_lock_eio.error = Unix.EIO
+          ; operation = "injected_release_after_not_installed"
+          ; argument = session_dir
+          }
+      ; cleanup_failure = None
+      }
+    in
+    let observer_count = ref 0 in
+    match
+      Keeper_checkpoint_store.For_testing.save_oas_if_source_with_release_failure
+        ~release_failure
+        ~on_checkpoint_commit_observer:(fun _ -> incr observer_count)
+        ~session_dir
+        ~expected_source_ref:source_ref
+        (make_checkpoint ~session_id ~turn_count:10 ~marker:"stale-source"
+         |> with_generation 3)
+    with
+    | Keeper_checkpoint_store.Installed _ ->
+      fail "release failure changed a source mismatch into Installed"
+    | Keeper_checkpoint_store.Not_installed outcome ->
+      (match outcome.cause with
+       | Keeper_checkpoint_store.Source_changed actual ->
+         check bool
+           "Not_installed retains the exact changed source"
+           true
+           (Keeper_checkpoint_ref.equal actual advanced)
+       | _ -> fail "release failure replaced the original non-install cause");
+      check int "non-install path emits no commit observer" 0 !observer_count;
+      match outcome.auxiliary with
+      | [ Keeper_checkpoint_store.Release_process_lock_failed error ] ->
+        check bool
+          "Not_installed retains the release failure"
+          true
+          (error = release_failure)
+  | _ -> fail "Not_installed release failure was not preserved"
+;;
+
+let test_acquire_failure_prevents_lock_body () =
+  let session_id = "sess-cas-acquire-failure" in
+  with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
+    let acquire_failure =
+      { File_lock_eio.lock_path = session_dir ^ ".checkpoint.lock"
+      ; phase = File_lock_eio.Open_lock_file
+      ; cause =
+          { File_lock_eio.error = Unix.EACCES
+          ; operation = "injected_open_before_body"
+          ; argument = session_dir
+          }
+      ; cleanup_failure = None
+      }
+    in
+    let observer_count = ref 0 in
+    match
+      Keeper_checkpoint_store.For_testing.save_oas_if_source_with_acquire_failure
+        ~acquire_failure
+        ~on_checkpoint_commit_observer:(fun _ -> incr observer_count)
+        ~session_dir
+        ~expected_source_ref:source_ref
+        (make_checkpoint ~session_id ~turn_count:9 ~marker:"not-admitted"
+         |> with_generation 3)
+    with
+    | Keeper_checkpoint_store.Installed _ ->
+      fail "lock acquisition failure admitted the checkpoint body"
+    | Keeper_checkpoint_store.Not_installed outcome ->
+      check int "acquire failure runs no commit observer" 0 !observer_count;
+      check bool "acquire failure has no release auxiliary" true
+        (outcome.auxiliary = []);
+      match outcome.cause with
+      | Keeper_checkpoint_store.Source_unavailable
+          (Keeper_checkpoint_store.Ref_lock_failed detail) ->
+        check bool
+          "acquire failure preserves its exact lock cause"
+          true
+          (Astring.String.is_infix ~affix:"injected_open_before_body" detail)
+      | _ -> fail "acquire failure changed its non-install cause")
 ;;
 
 let test_commit_observer_failure_is_installed () =
@@ -921,6 +1029,10 @@ let () =
             test_exact_source_cas_allows_one_equal_turn_writer;
           test_case "exact source CAS updates the canonical watermark" `Quick
             test_exact_source_cas_updates_canonical_watermark;
+          test_case "release failure preserves Not_installed cause" `Quick
+            test_release_failure_preserves_not_installed_cause;
+          test_case "acquire failure prevents the lock body" `Quick
+            test_acquire_failure_prevents_lock_body;
           test_case "post-rename durability uncertainty stays installed" `Quick
             test_post_rename_durability_unknown_is_installed;
           test_case "pre-rename write failure stays retryable" `Quick

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -838,7 +838,7 @@ let test_release_failure_preserves_not_installed_cause () =
           "Not_installed retains the release failure"
           true
           (error = release_failure)
-  | _ -> fail "Not_installed release failure was not preserved"
+      | _ -> fail "Not_installed release failure was not preserved")
 ;;
 
 let test_acquire_failure_prevents_lock_body () =

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -495,15 +495,18 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS source load failed"
     in
-    let writer marker =
+    let left_observed = Atomic.make 0 in
+    let right_observed = Atomic.make 0 in
+    let writer marker observed =
       Keeper_checkpoint_store.save_oas_if_source
+        ~on_checkpoint_committed:(fun () -> Atomic.incr observed)
         ~session_dir
         ~expected_source_ref:source_ref
         (make_checkpoint ~session_id ~turn_count:8 ~marker
          |> with_generation 3)
     in
-    let left = Domain.spawn (fun () -> "left", writer "left") in
-    let right = Domain.spawn (fun () -> "right", writer "right") in
+    let left = Domain.spawn (fun () -> "left", writer "left" left_observed) in
+    let right = Domain.spawn (fun () -> "right", writer "right" right_observed) in
     let committed, changed =
       [ Domain.join left; Domain.join right ]
       |> List.fold_left
@@ -517,10 +520,19 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
     in
     check int "exactly one writer commits" 1 (List.length committed);
     check int "the competing source is rejected" 1 changed;
+    check int "durable commit is observed exactly once across writers" 1
+      (Atomic.get left_observed + Atomic.get right_observed);
     match committed,
       Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
     with
     | [ (winner, committed_ref) ], Ok (checkpoint, disk_ref) ->
+      let winner_observed, loser_observed =
+        if String.equal winner "left"
+        then Atomic.get left_observed, Atomic.get right_observed
+        else Atomic.get right_observed, Atomic.get left_observed
+      in
+      check int "winning writer observes its durable commit" 1 winner_observed;
+      check int "Source_changed writer observes no durable commit" 0 loser_observed;
       check bool "committed ref identifies installed canonical bytes" true
         (Keeper_checkpoint_ref.equal committed_ref disk_ref);
       check bool "installed payload belongs to the winning writer" true
@@ -545,8 +557,10 @@ let test_exact_source_cas_updates_canonical_watermark () =
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS watermark source load failed"
     in
+    let checkpoint_commits = ref 0 in
     (match
        Keeper_checkpoint_store.save_oas_if_source
+         ~on_checkpoint_committed:(fun () -> incr checkpoint_commits)
          ~session_dir
          ~expected_source_ref:source_ref
          (make_checkpoint ~session_id ~turn_count:9 ~marker:"target"
@@ -554,6 +568,7 @@ let test_exact_source_cas_updates_canonical_watermark () =
      with
      | Ok _ -> ()
      | Error _ -> fail "CAS watermark candidate did not commit");
+    check int "CAS watermark commit is observed once" 1 !checkpoint_commits;
     match
       Keeper_checkpoint_store.save_oas_classified ~session_dir
         (make_checkpoint ~session_id ~turn_count:8 ~marker:"stale!")

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -495,18 +495,16 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS source load failed"
     in
-    let left_observed = Atomic.make 0 in
-    let right_observed = Atomic.make 0 in
-    let writer marker observed =
+    let writer marker =
       Keeper_checkpoint_store.save_oas_if_source
-        ~on_checkpoint_committed:(fun () -> Atomic.incr observed)
+        ~on_checkpoint_commit_hint:(fun _ -> ())
         ~session_dir
         ~expected_source_ref:source_ref
         (make_checkpoint ~session_id ~turn_count:8 ~marker
          |> with_generation 3)
     in
-    let left = Domain.spawn (fun () -> "left", writer "left" left_observed) in
-    let right = Domain.spawn (fun () -> "right", writer "right" right_observed) in
+    let left = Domain.spawn (fun () -> "left", writer "left") in
+    let right = Domain.spawn (fun () -> "right", writer "right") in
     let committed, changed =
       [ Domain.join left; Domain.join right ]
       |> List.fold_left
@@ -520,21 +518,12 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
     in
     check int "exactly one writer commits" 1 (List.length committed);
     check int "the competing source is rejected" 1 changed;
-    check int "durable commit is observed exactly once across writers" 1
-      (Atomic.get left_observed + Atomic.get right_observed);
     match committed,
       Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
     with
     | [ (winner, committed_ref) ], Ok (checkpoint, disk_ref) ->
-      let winner_observed, loser_observed =
-        if String.equal winner "left"
-        then Atomic.get left_observed, Atomic.get right_observed
-        else Atomic.get right_observed, Atomic.get left_observed
-      in
-      check int "winning writer observes its durable commit" 1 winner_observed;
-      check int "Source_changed writer observes no durable commit" 0 loser_observed;
       check bool "committed ref identifies installed canonical bytes" true
-        (Keeper_checkpoint_ref.equal committed_ref disk_ref);
+        (Keeper_checkpoint_ref.equal committed_ref.installed_ref disk_ref);
       check bool "installed payload belongs to the winning writer" true
         (List.exists
            (fun (message : Agent_sdk.Types.message) ->
@@ -557,10 +546,9 @@ let test_exact_source_cas_updates_canonical_watermark () =
       | Ok (_, reference) -> reference
       | Error _ -> fail "CAS watermark source load failed"
     in
-    let checkpoint_commits = ref 0 in
     (match
        Keeper_checkpoint_store.save_oas_if_source
-         ~on_checkpoint_committed:(fun () -> incr checkpoint_commits)
+         ~on_checkpoint_commit_hint:(fun _ -> ())
          ~session_dir
          ~expected_source_ref:source_ref
          (make_checkpoint ~session_id ~turn_count:9 ~marker:"target"
@@ -568,7 +556,6 @@ let test_exact_source_cas_updates_canonical_watermark () =
      with
      | Ok _ -> ()
      | Error _ -> fail "CAS watermark candidate did not commit");
-    check int "CAS watermark commit is observed once" 1 !checkpoint_commits;
     match
       Keeper_checkpoint_store.save_oas_classified ~session_dir
         (make_checkpoint ~session_id ~turn_count:8 ~marker:"stale!")

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -714,6 +714,65 @@ let test_post_rename_durability_unknown_is_installed () =
         fail "post-rename retry failed without exact source evidence")
 ;;
 
+let test_pre_rename_write_failure_is_not_installed_and_retryable () =
+  let session_id = "sess-cas-pre-rename" in
+  with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
+    let candidate =
+      make_checkpoint ~session_id ~turn_count:9 ~marker:"pre-rename"
+      |> with_generation 3
+    in
+    let write_error =
+      { Keeper_fs.renamed = false
+      ; stage = Keeper_fs.Payload_write
+      ; failure = Keeper_fs.Operation_failed "injected pre-rename write failure"
+      }
+    in
+    let observer_count = ref 0 in
+    match
+      Keeper_checkpoint_store.For_testing.save_oas_if_source_with_writer
+        ~write_checkpoint_bytes:
+          (fun ~on_durable_commit:_ ~ownership_root:_ ~path:_ ~bytes:_ ->
+             Error write_error)
+        ~on_checkpoint_commit_observer:(fun _ -> incr observer_count)
+        ~session_dir
+        ~expected_source_ref:source_ref
+        candidate
+    with
+    | Keeper_checkpoint_store.Installed _ ->
+      fail "pre-rename write failure became Installed"
+    | Keeper_checkpoint_store.Not_installed
+        (Keeper_checkpoint_store.Commit_not_installed error) ->
+      check bool
+        "pre-rename write failure preserves its exact cause"
+        true
+        (error = write_error);
+      check int "pre-rename failure emits no commit observer" 0 !observer_count;
+      (match
+         Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+       with
+       | Ok (_, disk_ref) ->
+         check bool
+           "pre-rename failure leaves the canonical ref unchanged"
+           true
+           (Keeper_checkpoint_ref.equal source_ref disk_ref)
+       | Error _ -> fail "pre-rename failure removed the canonical checkpoint");
+      (match
+         Keeper_checkpoint_store.save_oas_if_source
+           ~session_dir
+           ~expected_source_ref:source_ref
+           candidate
+       with
+       | Keeper_checkpoint_store.Installed installed ->
+         check bool
+           "pre-rename failure remains retryable from the same source"
+           false
+           (Keeper_checkpoint_ref.equal source_ref installed.installed_ref)
+       | Keeper_checkpoint_store.Not_installed _ ->
+         fail "pre-rename failure consumed the exact-source retry")
+    | Keeper_checkpoint_store.Not_installed _ ->
+      fail "pre-rename write failure lost its Commit_not_installed cause")
+;;
+
 let test_commit_observer_failure_is_installed () =
   let session_id = "sess-cas-observer-failure" in
   with_exact_source_fixture ~session_id (fun ~session_dir ~source_ref ->
@@ -864,6 +923,8 @@ let () =
             test_exact_source_cas_updates_canonical_watermark;
           test_case "post-rename durability uncertainty stays installed" `Quick
             test_post_rename_durability_unknown_is_installed;
+          test_case "pre-rename write failure stays retryable" `Quick
+            test_pre_rename_write_failure_is_not_installed_and_retryable;
           test_case "commit observer failure stays installed" `Quick
             test_commit_observer_failure_is_installed;
           test_case "post-commit unwind stays installed" `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -55,13 +55,14 @@ let no_compaction ~turn_count reason : State.no_compaction =
 
 let applied_compaction_receipt
     ?(lifecycle = Masc.Keeper_manual_compaction.Completion_applied)
+    ?(manifest = Ok ())
     () =
   let installation : Masc.Keeper_checkpoint_store.installed_checkpoint =
     { installed_ref = checkpoint_source ~turn_count:9; auxiliary = [] }
   in
   { Masc.Keeper_manual_compaction.installation = installation
   ; lifecycle
-  ; manifest = Ok ()
+  ; manifest
   }
 ;;
 
@@ -1461,6 +1462,85 @@ let test_applied_compaction_settles_followup_atomically () =
        Masc.Keeper_registry_event_queue.Context_compaction_retry ->
      Alcotest.fail "post-install lifecycle failure replayed provider compaction"
    | _ -> Alcotest.fail "post-install lifecycle failure was not acknowledged");
+let manifest_error = "injected post-install manifest failure" in
+let manifest_settlement =
+  settlement
+    ~receipt:
+      (applied_compaction_receipt
+         ~manifest:(Error manifest_error)
+         ())
+    retry_failure
+in
+let manifest_commit =
+  match manifest_settlement with
+  | Masc.Keeper_registry_event_queue.Manual_compaction_committed
+      { commit
+      ; followup = Keeper_event_queue_state.Compaction_commit_ack
+      } ->
+    Alcotest.(check (option string))
+      "committed receipt preserves manifest error"
+      (Some manifest_error)
+      commit.manifest_error;
+    Alcotest.(check bool)
+      "manifest error requires operator action"
+      true
+      (Keeper_event_queue_state.manual_compaction_commit_requires_operator_action
+         commit);
+    commit
+  | _ -> Alcotest.fail "manifest failure was not committed as an applied receipt"
+in
+let manifest_source =
+  stimulus
+    ~payload:Queue.Manual_compaction_requested
+    Queue.manual_compaction_post_id
+    1.0
+in
+let manifest_state =
+  State.with_pending (queue [ manifest_source ]) State.empty
+in
+let manifest_state, manifest_lease = claim_head manifest_state in
+let manifest_lease = require_some "manifest receipt lease" manifest_lease in
+let _, manifest_result =
+  State.settle
+    ~settled_at:9.0
+    ~lease:manifest_lease
+    ~settlement:manifest_settlement
+    manifest_state
+  |> require_ok "settle manifest failure receipt"
+in
+let manifest_receipt =
+  match manifest_result with
+  | State.Settled receipt -> receipt
+  | State.Already_settled _ ->
+    Alcotest.fail "manifest failure receipt unexpectedly replayed"
+in
+let public_manifest_receipt =
+  State.transition_receipt_to_yojson manifest_receipt
+  |> Yojson.Safe.Util.member "settlement"
+  |> Yojson.Safe.Util.member "receipt"
+in
+Alcotest.(check string)
+  "public receipt preserves manifest error"
+  manifest_error
+  Yojson.Safe.Util.(public_manifest_receipt |> member "manifest_error" |> to_string);
+Alcotest.(check bool)
+  "public receipt preserves operator action"
+  true
+  Yojson.Safe.Util.(
+    public_manifest_receipt |> member "operator_action_required" |> to_bool);
+let restored_manifest_receipt =
+  State.transition_receipt_to_yojson manifest_receipt
+  |> State.transition_receipt_of_yojson
+  |> require_ok "decode manifest failure receipt"
+in
+Alcotest.(check bool)
+  "manifest failure receipt round-trips"
+  true
+  (State.transition_receipt_equal manifest_receipt restored_manifest_receipt);
+Alcotest.(check (option string))
+  "round-tripped committed receipt preserves manifest error"
+  (Some manifest_error)
+  manifest_commit.manifest_error;
   match
     Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome
       (Some committed)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1395,9 +1395,11 @@ let test_applied_compaction_settles_followup_atomically () =
          })
   in
   (match settlement judgment_failure with
-   | Masc.Keeper_registry_event_queue.Escalate
-       { reason = Masc.Keeper_registry_event_queue.Failure_judgment_requested
-       ; successor = Some { Queue.payload = Queue.Failure_judgment successor; _ }
+   | Masc.Keeper_registry_event_queue.Manual_compaction_committed
+       { followup =
+           Keeper_event_queue_state.Compaction_commit_failure_judgment
+             { Queue.payload = Queue.Failure_judgment successor; _ }
+       ; _
        } ->
      Alcotest.(check string)
        "atomic successor keeps exact final runtime"
@@ -1412,7 +1414,9 @@ let test_applied_compaction_settles_followup_atomically () =
          })
   in
   (match settlement retry_failure with
-   | Masc.Keeper_registry_event_queue.Ack -> ()
+   | Masc.Keeper_registry_event_queue.Manual_compaction_committed
+       { followup = Keeper_event_queue_state.Compaction_commit_ack; _ } ->
+     ()
    | _ -> Alcotest.fail "follow-up retry replayed an already-applied compaction");
   let completion_error =
     Masc.Keeper_context_runtime.Transition_rejected
@@ -1444,7 +1448,15 @@ let test_applied_compaction_settles_followup_atomically () =
        ~lease
        (Some committed)
    with
-   | Masc.Keeper_registry_event_queue.Ack -> ()
+   | Masc.Keeper_registry_event_queue.Manual_compaction_committed
+       { commit
+       ; followup = Keeper_event_queue_state.Compaction_commit_ack
+       } ->
+     Alcotest.(check bool)
+       "post-install lifecycle receipt requires operator action"
+       true
+       (Keeper_event_queue_state.manual_compaction_commit_requires_operator_action
+          commit)
    | Masc.Keeper_registry_event_queue.Requeue
        Masc.Keeper_registry_event_queue.Context_compaction_retry ->
      Alcotest.fail "post-install lifecycle failure replayed provider compaction"

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1415,12 +1415,12 @@ let test_applied_compaction_settles_followup_atomically () =
    | Masc.Keeper_registry_event_queue.Ack -> ()
    | _ -> Alcotest.fail "follow-up retry replayed an already-applied compaction");
   let completion_error =
-    Keeper_context_runtime.Transition_rejected
+    Masc.Keeper_context_runtime.Transition_rejected
       (Keeper_state_machine.Precondition_violation
          { event = "compaction_completed"; reason = "injected completion rejection" })
   in
   let failure_dispatch_error =
-    Keeper_context_runtime.Transition_rejected
+    Masc.Keeper_context_runtime.Transition_rejected
       (Keeper_state_machine.Precondition_violation
          { event = "compaction_failed"; reason = "injected cleanup rejection" })
   in

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -53,6 +53,18 @@ let no_compaction ~turn_count reason : State.no_compaction =
   { source = checkpoint_source ~turn_count; reason }
 ;;
 
+let applied_compaction_receipt
+    ?(lifecycle = Masc.Keeper_manual_compaction.Completion_applied)
+    () =
+  let installation : Masc.Keeper_checkpoint_store.installed_checkpoint =
+    { installed_ref = checkpoint_source ~turn_count:9; auxiliary = [] }
+  in
+  { Masc.Keeper_manual_compaction.installation = installation
+  ; lifecycle
+  ; manifest = Ok ()
+  }
+;;
+
 let exact_terminal ?(slot_id = "slot-terminal") ?(call_id = "call-terminal") cause =
   State.Exact_execution_terminal
     { cause
@@ -1360,7 +1372,7 @@ let test_applied_compaction_settles_followup_atomically () =
          1.0)
   in
   let meta = cycle_meta () in
-  let settlement failure =
+  let settlement ?(receipt = applied_compaction_receipt ()) failure =
     Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
       ~base_path:(Sys.getcwd ())
       ~settled_at:8.0
@@ -1369,7 +1381,10 @@ let test_applied_compaction_settles_followup_atomically () =
       ~lease
       (Some
          (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_applied
-            (Masc.Keeper_heartbeat_loop_cycle.Failed { meta; failure })))
+            { receipt
+            ; followup =
+                Masc.Keeper_heartbeat_loop_cycle.Failed { meta; failure }
+            }))
   in
   let judgment_failure =
     turn_failure
@@ -1396,9 +1411,50 @@ let test_applied_compaction_settles_followup_atomically () =
          ; retry_after = None
          })
   in
-  match settlement retry_failure with
-  | Masc.Keeper_registry_event_queue.Ack -> ()
-  | _ -> Alcotest.fail "follow-up retry replayed an already-applied compaction"
+  (match settlement retry_failure with
+   | Masc.Keeper_registry_event_queue.Ack -> ()
+   | _ -> Alcotest.fail "follow-up retry replayed an already-applied compaction");
+  let completion_error =
+    Keeper_context_runtime.Transition_rejected
+      (Keeper_state_machine.Precondition_violation
+         { event = "compaction_completed"; reason = "injected completion rejection" })
+  in
+  let failure_dispatch_error =
+    Keeper_context_runtime.Transition_rejected
+      (Keeper_state_machine.Precondition_violation
+         { event = "compaction_failed"; reason = "injected cleanup rejection" })
+  in
+  let receipt =
+    applied_compaction_receipt
+      ~lifecycle:
+        (Masc.Keeper_manual_compaction.Completion_rejected_failure_dispatch_failed
+           { completion_error; failure_dispatch_error })
+      ()
+  in
+  let committed =
+    Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_applied
+      { receipt; followup = Masc.Keeper_heartbeat_loop_cycle.Completed meta }
+  in
+  (match
+     Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
+       ~base_path:(Sys.getcwd ())
+       ~settled_at:8.0
+       ~stop_requested:false
+       ~compaction_consecutive_failures:0
+       ~lease
+       (Some committed)
+   with
+   | Masc.Keeper_registry_event_queue.Ack -> ()
+   | Masc.Keeper_registry_event_queue.Requeue
+       Masc.Keeper_registry_event_queue.Context_compaction_retry ->
+     Alcotest.fail "post-install lifecycle failure replayed provider compaction"
+   | _ -> Alcotest.fail "post-install lifecycle failure was not acknowledged");
+  match
+    Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome
+      (Some committed)
+  with
+  | Some `Committed -> ()
+  | _ -> Alcotest.fail "post-install lifecycle failure was not stamped committed"
 ;;
 
 (* RFC-0351 S0 / #25461: a manual-compaction failure requeues while the streak

--- a/test/test_keeper_fs_systhread_cancellation.ml
+++ b/test/test_keeper_fs_systhread_cancellation.ml
@@ -3,6 +3,8 @@ open Alcotest
 module KF = Masc.Keeper_fs
 
 exception Requested_cancel
+exception Underlying_failure
+exception Observer_failure
 
 type blocking_hook =
   { entered : unit Eio.Promise.t
@@ -109,6 +111,7 @@ let test_write_context_cancellation_is_not_swallowed () =
        let path = Filename.concat base "record.json" in
        require_write_ok "seed write" (KF.save_json_durable_atomic path (`Assoc []));
        let hook = blocking_hook () in
+       let observed_commits = Atomic.make 0 in
        let context, resolve_context = Eio.Promise.create () in
        let result, resolve_result = Eio.Promise.create () in
        Eio.Switch.run
@@ -121,12 +124,13 @@ let test_write_context_cancellation_is_not_swallowed () =
              Eio.Cancel.sub (fun cancel_context ->
                Eio.Promise.resolve resolve_context cancel_context;
                match
-                 KF.For_testing.save_json_durable_atomic
+                 KF.For_testing.save_bytes_durable_atomic_observed
+                   ~on_durable_commit:(fun () -> Atomic.incr observed_commits)
                    ~before_stage:(function
                      | KF.Payload_write -> block_once hook
                      | _ -> ())
                    path
-                   (`Assoc [ "version", `Int 2 ])
+                   {|{"version":2}|}
                with
                | Ok () -> Returned_ok
                | Error error -> Returned_error (KF.durable_write_error_to_string error))
@@ -140,7 +144,93 @@ let test_write_context_cancellation_is_not_swallowed () =
        Eio.Cancel.cancel cancel_context Requested_cancel;
        release hook;
        expect_cancelled (Eio.Promise.await result);
+       check int
+         "durably committed cancelled write is observed exactly once"
+         1
+         (Atomic.get observed_commits);
        check bool "completed write remains visible" true (Sys.file_exists path))
+;;
+
+let with_recorded_backtraces f =
+  let was_recording = Printexc.backtrace_status () in
+  Printexc.record_backtrace true;
+  Fun.protect
+    ~finally:(fun () -> Printexc.record_backtrace was_recording)
+    f
+;;
+
+let test_deferred_observer_preserves_cancellation_backtrace () =
+  Eio_main.run
+  @@ fun _env ->
+  with_recorded_backtraces
+  @@ fun () ->
+  let cancelled_exn, cancelled_backtrace =
+    try
+      Eio.Cancel.sub (fun cancel_context ->
+        Eio.Cancel.cancel cancel_context Requested_cancel;
+        Eio.Fiber.yield ();
+        fail "cancelled context returned")
+    with
+    | Eio.Cancel.Cancelled _ as exn ->
+      exn, Printexc.get_raw_backtrace ()
+  in
+  let expected_backtrace =
+    Printexc.raw_backtrace_to_string cancelled_backtrace
+  in
+  let commit_observed = ref true in
+  let observer_calls = ref 0 in
+  let reraised_backtrace =
+    try
+      ignore
+        (KF.finish_durable_commit_observation
+           ~commit_observed
+           ~on_durable_commit:(fun () -> incr observer_calls)
+           (`Raised (cancelled_exn, cancelled_backtrace)));
+      fail "captured cancellation returned"
+    with
+    | Eio.Cancel.Cancelled _ -> Printexc.get_raw_backtrace ()
+  in
+  check int "cancelled durable commit observer runs once" 1 !observer_calls;
+  check bool "cancelled durable commit latch is consumed" false !commit_observed;
+  check string
+    "cancelled durable commit preserves raw backtrace"
+    expected_backtrace
+    (Printexc.raw_backtrace_to_string reraised_backtrace)
+;;
+
+let test_raising_observer_does_not_mask_underlying_backtrace () =
+  with_recorded_backtraces
+  @@ fun () ->
+  let underlying_exn, underlying_backtrace =
+    try raise Underlying_failure with
+    | Underlying_failure as exn ->
+      exn, Printexc.get_raw_backtrace ()
+  in
+  let expected_backtrace =
+    Printexc.raw_backtrace_to_string underlying_backtrace
+  in
+  let commit_observed = ref true in
+  let observer_calls = ref 0 in
+  let reraised_backtrace =
+    try
+      ignore
+        (KF.finish_durable_commit_observation
+           ~commit_observed
+           ~on_durable_commit:(fun () ->
+             incr observer_calls;
+             raise Observer_failure)
+           (`Raised (underlying_exn, underlying_backtrace)));
+      fail "captured operation failure returned"
+    with
+    | Underlying_failure -> Printexc.get_raw_backtrace ()
+    | Observer_failure -> fail "observer failure masked the operation failure"
+  in
+  check int "raising durable commit observer runs once" 1 !observer_calls;
+  check bool "raising durable commit observer consumes latch" false !commit_observed;
+  check string
+    "raising observer preserves the underlying raw backtrace"
+    expected_backtrace
+    (Printexc.raw_backtrace_to_string reraised_backtrace)
 ;;
 
 let test_remove_context_cancellation_is_not_swallowed () =
@@ -208,9 +298,17 @@ let () =
     "Keeper_fs systhread cancellation"
     [ ( "durability",
         [ test_case
-            "write context cancellation propagates"
+            "observed write context cancellation propagates"
             `Quick
             test_write_context_cancellation_is_not_swallowed
+        ; test_case
+            "deferred observer preserves cancellation backtrace"
+            `Quick
+            test_deferred_observer_preserves_cancellation_backtrace
+        ; test_case
+            "raising observer preserves underlying backtrace"
+            `Quick
+            test_raising_observer_does_not_mask_underlying_backtrace
         ; test_case
             "remove context cancellation propagates"
             `Quick

--- a/test/test_keeper_fs_systhread_cancellation.ml
+++ b/test/test_keeper_fs_systhread_cancellation.ml
@@ -3,8 +3,6 @@ open Alcotest
 module KF = Masc.Keeper_fs
 
 exception Requested_cancel
-exception Underlying_failure
-exception Observer_failure
 
 type blocking_hook =
   { entered : unit Eio.Promise.t
@@ -111,7 +109,6 @@ let test_write_context_cancellation_is_not_swallowed () =
        let path = Filename.concat base "record.json" in
        require_write_ok "seed write" (KF.save_json_durable_atomic path (`Assoc []));
        let hook = blocking_hook () in
-       let observed_commits = Atomic.make 0 in
        let context, resolve_context = Eio.Promise.create () in
        let result, resolve_result = Eio.Promise.create () in
        Eio.Switch.run
@@ -124,13 +121,12 @@ let test_write_context_cancellation_is_not_swallowed () =
              Eio.Cancel.sub (fun cancel_context ->
                Eio.Promise.resolve resolve_context cancel_context;
                match
-                 KF.For_testing.save_bytes_durable_atomic_observed
-                   ~on_durable_commit:(fun () -> Atomic.incr observed_commits)
+                 KF.For_testing.save_json_durable_atomic
                    ~before_stage:(function
                      | KF.Payload_write -> block_once hook
                      | _ -> ())
                    path
-                   {|{"version":2}|}
+                   (`Assoc [ "version", `Int 2 ])
                with
                | Ok () -> Returned_ok
                | Error error -> Returned_error (KF.durable_write_error_to_string error))
@@ -144,93 +140,7 @@ let test_write_context_cancellation_is_not_swallowed () =
        Eio.Cancel.cancel cancel_context Requested_cancel;
        release hook;
        expect_cancelled (Eio.Promise.await result);
-       check int
-         "durably committed cancelled write is observed exactly once"
-         1
-         (Atomic.get observed_commits);
        check bool "completed write remains visible" true (Sys.file_exists path))
-;;
-
-let with_recorded_backtraces f =
-  let was_recording = Printexc.backtrace_status () in
-  Printexc.record_backtrace true;
-  Fun.protect
-    ~finally:(fun () -> Printexc.record_backtrace was_recording)
-    f
-;;
-
-let test_deferred_observer_preserves_cancellation_backtrace () =
-  Eio_main.run
-  @@ fun _env ->
-  with_recorded_backtraces
-  @@ fun () ->
-  let cancelled_exn, cancelled_backtrace =
-    try
-      Eio.Cancel.sub (fun cancel_context ->
-        Eio.Cancel.cancel cancel_context Requested_cancel;
-        Eio.Fiber.yield ();
-        fail "cancelled context returned")
-    with
-    | Eio.Cancel.Cancelled _ as exn ->
-      exn, Printexc.get_raw_backtrace ()
-  in
-  let expected_backtrace =
-    Printexc.raw_backtrace_to_string cancelled_backtrace
-  in
-  let commit_observed = ref true in
-  let observer_calls = ref 0 in
-  let reraised_backtrace =
-    try
-      ignore
-        (KF.finish_durable_commit_observation
-           ~commit_observed
-           ~on_durable_commit:(fun () -> incr observer_calls)
-           (`Raised (cancelled_exn, cancelled_backtrace)));
-      fail "captured cancellation returned"
-    with
-    | Eio.Cancel.Cancelled _ -> Printexc.get_raw_backtrace ()
-  in
-  check int "cancelled durable commit observer runs once" 1 !observer_calls;
-  check bool "cancelled durable commit latch is consumed" false !commit_observed;
-  check string
-    "cancelled durable commit preserves raw backtrace"
-    expected_backtrace
-    (Printexc.raw_backtrace_to_string reraised_backtrace)
-;;
-
-let test_raising_observer_does_not_mask_underlying_backtrace () =
-  with_recorded_backtraces
-  @@ fun () ->
-  let underlying_exn, underlying_backtrace =
-    try raise Underlying_failure with
-    | Underlying_failure as exn ->
-      exn, Printexc.get_raw_backtrace ()
-  in
-  let expected_backtrace =
-    Printexc.raw_backtrace_to_string underlying_backtrace
-  in
-  let commit_observed = ref true in
-  let observer_calls = ref 0 in
-  let reraised_backtrace =
-    try
-      ignore
-        (KF.finish_durable_commit_observation
-           ~commit_observed
-           ~on_durable_commit:(fun () ->
-             incr observer_calls;
-             raise Observer_failure)
-           (`Raised (underlying_exn, underlying_backtrace)));
-      fail "captured operation failure returned"
-    with
-    | Underlying_failure -> Printexc.get_raw_backtrace ()
-    | Observer_failure -> fail "observer failure masked the operation failure"
-  in
-  check int "raising durable commit observer runs once" 1 !observer_calls;
-  check bool "raising durable commit observer consumes latch" false !commit_observed;
-  check string
-    "raising observer preserves the underlying raw backtrace"
-    expected_backtrace
-    (Printexc.raw_backtrace_to_string reraised_backtrace)
 ;;
 
 let test_remove_context_cancellation_is_not_swallowed () =
@@ -298,17 +208,9 @@ let () =
     "Keeper_fs systhread cancellation"
     [ ( "durability",
         [ test_case
-            "observed write context cancellation propagates"
+            "write context cancellation propagates"
             `Quick
             test_write_context_cancellation_is_not_swallowed
-        ; test_case
-            "deferred observer preserves cancellation backtrace"
-            `Quick
-            test_deferred_observer_preserves_cancellation_backtrace
-        ; test_case
-            "raising observer preserves underlying backtrace"
-            `Quick
-            test_raising_observer_does_not_mask_underlying_backtrace
         ; test_case
             "remove context cancellation propagates"
             `Quick

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -485,9 +485,8 @@ let test_manual_compaction_preserves_failed_failure_dispatch () =
          { event = "compaction_failed"; reason = "failure dispatch rejection" })
   in
   let failure =
-    KMC.Lifecycle_with_failure_dispatch
+    KMC.Lifecycle_before_install_with_failure_dispatch
       { stage = KMC.Compaction_started
-      ; checkpoint_applied = false
       ; error = primary
       ; failure_dispatch = Error failure_dispatch
       }

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1217,9 +1217,7 @@ let test_manual_applied_hint_failure () =
             check bool
               "durable queue receipt carries exact installed ref"
               true
-              (Masc.Keeper_checkpoint_ref.equal
-                 success.receipt.installation.installed_ref
-                 commit.installed_ref);
+              (success.receipt.installation.installed_ref = commit.installed_ref);
             check bool
               "durable queue receipt carries observer auxiliary"
               true

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -750,9 +750,10 @@ let test_manual_compaction_serializes_owner_lane () =
         | Error detail ->
           failf "race manual compaction claim failed: %s" detail
       in
+      let race_hints = ref 0 in
       let busy_after_prepare =
         Masc.Keeper_manual_compaction.run_admitted
-          ~on_checkpoint_commit_hint:(fun _ -> ())
+          ~on_checkpoint_commit_hint:(fun _ -> incr race_hints)
           ~config
           ~meta
           ~exact_execution_guard:
@@ -767,6 +768,7 @@ let test_manual_compaction_serializes_owner_lane () =
         "planning-admission race performs one exact dispatch"
         1
         (Exact_fixture.post_count race_server);
+      check int "noncommit path emits no hint" 0 !race_hints;
       let no_compaction =
         match busy_after_prepare with
         | `No_compaction
@@ -1080,9 +1082,11 @@ let test_manual_applied_hint_failure () =
                ~persistence_error_to_string:Fun.id
                detail));
        let callback_saw_released_admission = ref false in
+       let hint_calls = ref 0 in
        let result =
          Masc.Keeper_manual_compaction.run_admitted
            ~on_checkpoint_commit_hint:(fun _installed_ref ->
+             incr hint_calls;
              callback_saw_released_admission :=
                Option.is_none
                  (Admission.in_flight
@@ -1095,11 +1099,27 @@ let test_manual_applied_hint_failure () =
            ()
        in
        (match result.operation with
-       | `Applied _ ->
+       | `Applied success ->
          check bool
            "manual hint runs after compaction admission release"
            true
-           !callback_saw_released_admission
+           !callback_saw_released_admission;
+         check int "manual hint is attempted at-most-once" 1 !hint_calls;
+         (match
+            success.recovery.checkpoint_installation,
+            result.checkpoint_commit_hint
+          with
+          | Masc.Keeper_checkpoint_store.Installed installed,
+            Masc.Keeper_manual_compaction.Hint_failed { installed_ref; _ } ->
+            check bool
+              "manual hint carries exact installed ref"
+              true
+              (Keeper_checkpoint_ref.equal
+                 installed_ref
+                 installed.installed_ref)
+          | Masc.Keeper_checkpoint_store.Not_installed _, _ ->
+            fail "Applied manual compaction carried Not_installed"
+          | _ -> fail "raising manual hint lost its typed failure")
        | `No_compaction no_compaction ->
          failf
            "manual observer did not apply: %s"
@@ -1194,22 +1214,39 @@ let test_prepare_commit_source_cas () =
       "prepare performs one real exact dispatch"
       1
       (Exact_fixture.post_count exact_server);
-    (match
-       Post_turn.commit_prepared_compaction
-         ~on_checkpoint_commit_hint:(fun _ -> ())
-         prepared
-     with
-     | Ok _ -> ()
+    let recovery =
+      match
+        Post_turn.For_testing.commit_prepared_compaction_with_history
+          ~save_oas_history:(fun ~session_dir:_ _ ->
+            raise
+              (Eio.Cancel.Cancelled
+                 (Failure "injected history cancellation")))
+          prepared
+      with
+      | Ok recovery -> recovery
      | Error error ->
        failf
          "commit of a fresh prepared plan failed: %s"
-         (Post_turn.compaction_recovery_error_to_string error));
+         (Post_turn.compaction_recovery_error_to_string error)
+    in
+    (match recovery.checkpoint_installation with
+     | Masc.Keeper_checkpoint_store.Installed installed ->
+       check bool
+         "history cancellation remains typed after install"
+         true
+         (List.exists
+            (function
+              | Masc.Keeper_checkpoint_store.History_write_failed
+                  (Eio.Cancel.Cancelled _, _) ->
+                true
+              | _ -> false)
+            installed.auxiliary)
+     | Masc.Keeper_checkpoint_store.Not_installed _ ->
+       fail "history cancellation downgraded the installed checkpoint");
     (* The first commit advanced the durable source; the same
        prepared value is now stale and must be CAS-rejected. *)
     (match
-       Post_turn.commit_prepared_compaction
-         ~on_checkpoint_commit_hint:(fun _ -> ())
-         prepared
+       Post_turn.commit_prepared_compaction prepared
      with
      | Error
          (Post_turn.No_compaction

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1199,14 +1199,22 @@ let test_manual_applied_hint_failure () =
           | Ok (Registry_queue.Committed_followup_failed { detail; _ })
           | Error detail ->
             failf "manual compaction receipt settlement failed: %s" detail);
+         let projected_entries = ref [] in
+         Registry_queue.project_transition_outbox_result
+           ~append_before_retire:(fun entry ->
+             projected_entries := entry :: !projected_entries;
+             Ok ())
+           ~base_path
+           ~keeper_name:meta.name
+         |> Result.map_error (fun detail ->
+              "manual compaction receipt projection failed: " ^ detail)
+         |> Result.get_ok;
          let entry =
-           Registry_queue.transition_outbox_result ~base_path meta.name
-           |> Result.get_ok
-           |> function
+           match List.rev !projected_entries with
            | [ entry ] -> entry
            | entries ->
              failf
-               "manual compaction durable outbox count=%d"
+               "manual compaction projected receipt count=%d"
                (List.length entries)
          in
          (match entry.receipt.settlement with

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -301,7 +301,6 @@ let test_manual_compaction_serializes_owner_lane () =
   Eio.Switch.run @@ fun sw ->
   with_eio_context env sw @@ fun () ->
   let base_path = Masc_test_deps.setup_test_workspace () in
-  let manifest_error = "injected post-install manifest append failure" in
   let meta = make_meta ~name:"compaction-owner" ~trace_id:"trace-compaction-owner" () in
   let peer = make_meta ~name:"compaction-peer" ~trace_id:"trace-compaction-peer" () in
   let runtime_snapshot = Runtime.For_testing.snapshot () in
@@ -827,6 +826,7 @@ let test_manual_compaction_serializes_owner_lane () =
        | Registry_queue.No_compaction _ ->
          fail "post-dispatch final admission changed its terminal cause"
        | Registry_queue.Ack
+       | Registry_queue.Manual_compaction_committed _
        | Registry_queue.Cancel_accepted _
        | Registry_queue.Transfer_accepted _
        | Registry_queue.Settle_from_source_terminal _
@@ -1082,6 +1082,7 @@ let test_manual_applied_hint_failure () =
             (Masc.Keeper_context_core.checkpoint_write_error_to_string
                ~persistence_error_to_string:Fun.id
                detail));
+       let manifest_error = "injected post-install manifest append failure" in
        let callback_saw_released_admission = ref false in
        let hint_calls = ref 0 in
        let result =

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1217,7 +1217,7 @@ let test_manual_applied_hint_failure () =
             check bool
               "durable queue receipt carries exact installed ref"
               true
-              (Keeper_checkpoint_ref.equal
+              (Masc.Keeper_checkpoint_ref.equal
                  success.receipt.installation.installed_ref
                  commit.installed_ref);
             check bool

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1114,7 +1114,7 @@ let test_manual_applied_hint_failure () =
             check bool
               "manual hint carries exact installed ref"
               true
-              (Keeper_checkpoint_ref.equal
+              (Masc.Keeper_checkpoint_ref.equal
                  installed_ref
                  installed.installed_ref)
           | Masc.Keeper_checkpoint_store.Not_installed _, _ ->
@@ -1214,20 +1214,25 @@ let test_prepare_commit_source_cas () =
       "prepare performs one real exact dispatch"
       1
       (Exact_fixture.post_count exact_server);
+    let was_recording = Printexc.backtrace_status () in
+    Printexc.record_backtrace true;
     let recovery =
-      match
-        Post_turn.For_testing.commit_prepared_compaction_with_history
-          ~save_oas_history:(fun ~session_dir:_ _ ->
-            raise
-              (Eio.Cancel.Cancelled
-                 (Failure "injected history cancellation")))
-          prepared
-      with
-      | Ok recovery -> recovery
-     | Error error ->
-       failf
-         "commit of a fresh prepared plan failed: %s"
-         (Post_turn.compaction_recovery_error_to_string error)
+      Fun.protect
+        ~finally:(fun () -> Printexc.record_backtrace was_recording)
+        (fun () ->
+           match
+             Post_turn.For_testing.commit_prepared_compaction_with_history
+               ~save_oas_history:(fun ~session_dir:_ _ ->
+                 raise
+                   (Eio.Cancel.Cancelled
+                      (Failure "injected history cancellation")))
+               prepared
+           with
+           | Ok recovery -> recovery
+           | Error error ->
+             failf
+               "commit of a fresh prepared plan failed: %s"
+               (Post_turn.compaction_recovery_error_to_string error))
     in
     (match recovery.checkpoint_installation with
      | Masc.Keeper_checkpoint_store.Installed installed ->
@@ -1237,8 +1242,8 @@ let test_prepare_commit_source_cas () =
          (List.exists
             (function
               | Masc.Keeper_checkpoint_store.History_write_failed
-                  (Eio.Cancel.Cancelled _, _) ->
-                true
+                  (Eio.Cancel.Cancelled _, backtrace) ->
+                Printexc.raw_backtrace_length backtrace > 0
               | _ -> false)
             installed.auxiliary)
      | Masc.Keeper_checkpoint_store.Not_installed _ ->

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1084,7 +1084,11 @@ let test_manual_applied_hint_failure () =
        let callback_saw_released_admission = ref false in
        let hint_calls = ref 0 in
        let result =
-         Masc.Keeper_manual_compaction.run_admitted
+         Masc.Keeper_manual_compaction.For_testing.run_admitted_with_install_observer
+           ~on_checkpoint_installed_observer:(fun _ ->
+             Masc.Keeper_registry.For_testing.unregister
+               ~base_path
+               meta.name)
            ~on_checkpoint_commit_hint:(fun _installed_ref ->
              incr hint_calls;
              callback_saw_released_admission :=
@@ -1107,17 +1111,89 @@ let test_manual_applied_hint_failure () =
          check int "manual hint is attempted at-most-once" 1 !hint_calls;
          (match
             success.recovery.checkpoint_installation,
+            success.receipt.installation,
             result.checkpoint_commit_hint
           with
           | Masc.Keeper_checkpoint_store.Installed installed,
+            receipt_installation,
             Masc.Keeper_manual_compaction.Hint_failed { installed_ref; _ } ->
             check bool
               "manual hint carries exact installed ref"
               true
-              (installed_ref = installed.installed_ref)
-          | Masc.Keeper_checkpoint_store.Not_installed _, _ ->
+              (installed_ref = installed.installed_ref);
+            check bool
+              "cycle receipt carries exact installed ref"
+              true
+              (installed_ref = receipt_installation.installed_ref)
+          | Masc.Keeper_checkpoint_store.Not_installed _, _, _ ->
             fail "Applied manual compaction carried Not_installed"
-          | _ -> fail "raising manual hint lost its typed failure")
+          | _ -> fail "raising manual hint lost its typed failure");
+         (match success.receipt.lifecycle with
+          | Masc.Keeper_manual_compaction.Completion_rejected_failure_dispatch_failed
+              _ ->
+            ()
+          | _ ->
+            fail
+              "post-install completion and cleanup rejection did not stay Applied");
+         (match success.receipt.manifest with
+          | Ok () -> ()
+          | Error detail ->
+            failf "post-install degraded manifest was not durable: %s" detail);
+         check int
+           "post-install lifecycle rejection performs one provider POST"
+           1
+           (Exact_fixture.post_count exact_server);
+         let manifest_path =
+           Masc.Keeper_runtime_manifest.path_for_trace
+             config
+             ~keeper_name:meta.name
+             ~trace_id:
+               (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+         in
+         let manifest =
+           Fs_compat.load_file manifest_path
+           |> String.split_on_char '\n'
+           |> List.filter (fun line -> String.trim line <> "")
+           |> List.rev
+           |> function
+           | line :: _ -> Yojson.Safe.from_string line
+           | [] -> fail "post-install degraded manifest row is missing"
+         in
+         let open Yojson.Safe.Util in
+         let decision = manifest |> member "decision" in
+         let public_decision =
+           Masc.Keeper_runtime_manifest.public_projection_of_decision decision
+         in
+         check string
+           "post-install anomaly degrades manifest health"
+           "degraded"
+           (manifest |> member "status" |> to_string);
+         check bool
+           "post-install anomaly requires operator action"
+           true
+           (public_decision
+            |> member "operator_action_required"
+            |> to_bool);
+         check string
+           "durable receipt states installed"
+           "installed"
+           (public_decision
+            |> member "checkpoint_installation_state"
+            |> to_string);
+         check string
+           "durable receipt carries exact sha"
+           success.receipt.installation.installed_ref.sha256
+           (public_decision
+            |> member "checkpoint_installed_ref"
+            |> member "sha256"
+            |> to_string);
+         check string
+           "durable receipt carries lifecycle failure"
+           "completion_rejected_failure_dispatch_failed"
+           (public_decision
+            |> member "compaction_lifecycle"
+            |> member "kind"
+            |> to_string)
        | `No_compaction no_compaction ->
          failf
            "manual observer did not apply: %s"
@@ -1138,6 +1214,62 @@ let test_manual_applied_hint_failure () =
          fail "raising manual hint was reported delivered"
        | Masc.Keeper_manual_compaction.Hint_not_emitted ->
          fail "Applied manual compaction emitted no hint")
+;;
+
+let test_checkpoint_installation_auxiliary_manifest_tags () =
+  let write_error =
+    { Keeper_fs.renamed = true
+    ; stage = Keeper_fs.Parent_directory_fsync_after_rename
+    ; failure = Keeper_fs.Operation_failed "injected durability uncertainty"
+    }
+  in
+  let lock_error =
+    { File_lock_eio.lock_path = "/tmp/checkpoint-installation-auxiliary.lock"
+    ; phase = File_lock_eio.Release_process_lock
+    ; cause =
+        { File_lock_eio.error = Unix.EIO
+        ; operation = "injected_release"
+        ; argument = "/tmp/checkpoint-installation-auxiliary.lock"
+        }
+    ; cleanup_failure = None
+    }
+  in
+  let failure detail = Failure detail, Printexc.get_callstack 1 in
+  let auxiliaries =
+    [ Masc.Keeper_checkpoint_store.Commit_durability_unknown write_error
+    ; Masc.Keeper_checkpoint_store.Commit_observer_failed (failure "observer")
+    ; Masc.Keeper_checkpoint_store.Release_process_lock_failed lock_error
+    ; Masc.Keeper_checkpoint_store.Post_commit_unwind_interrupted
+        (failure "unwind")
+    ; Masc.Keeper_checkpoint_store.History_write_failed (failure "history")
+    ]
+  in
+  let kinds =
+    auxiliaries
+    |> List.map
+         Masc.Keeper_manual_compaction.For_testing.checkpoint_installation_auxiliary_to_json
+    |> List.map (fun json ->
+      let open Yojson.Safe.Util in
+      check bool
+        "every installation auxiliary requires operator action"
+        true
+        (json |> member "operator_action_required" |> to_bool);
+      check bool
+        "every installation auxiliary has detail"
+        true
+        (json |> member "detail" |> to_string |> String.trim |> fun detail ->
+         detail <> "");
+      json |> member "kind" |> to_string)
+  in
+  check (list string)
+    "all installation auxiliary constructors have stable manifest tags"
+    [ "commit_durability_unknown"
+    ; "commit_observer_failed"
+    ; "release_process_lock_failed"
+    ; "post_commit_unwind_interrupted"
+    ; "history_write_failed"
+    ]
+    kinds
 ;;
 
 let test_prepare_commit_source_cas () =
@@ -1517,6 +1649,8 @@ let () =
         `Quick test_manual_compaction_serializes_owner_lane;
       test_case "manual Applied preserves hint failure"
         `Quick test_manual_applied_hint_failure;
+      test_case "checkpoint installation auxiliary manifest tags"
+        `Quick test_checkpoint_installation_auxiliary_manifest_tags;
       test_case "malformed structure preserves checkpoint"
         `Quick test_malformed_structure_preserves_checkpoint;
       test_case "prepare/commit source CAS"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -301,6 +301,7 @@ let test_manual_compaction_serializes_owner_lane () =
   Eio.Switch.run @@ fun sw ->
   with_eio_context env sw @@ fun () ->
   let base_path = Masc_test_deps.setup_test_workspace () in
+  let manifest_error = "injected post-install manifest append failure" in
   let meta = make_meta ~name:"compaction-owner" ~trace_id:"trace-compaction-owner" () in
   let peer = make_meta ~name:"compaction-peer" ~trace_id:"trace-compaction-peer" () in
   let runtime_snapshot = Runtime.For_testing.snapshot () in
@@ -1084,11 +1085,14 @@ let test_manual_applied_hint_failure () =
        let callback_saw_released_admission = ref false in
        let hint_calls = ref 0 in
        let result =
-         Masc.Keeper_manual_compaction.For_testing.run_admitted_with_install_observer
+         Masc.Keeper_manual_compaction.For_testing.
+           run_admitted_with_install_observer_and_manifest_failure
+           ~manifest_error
            ~on_checkpoint_installed_observer:(fun _ ->
              Masc.Keeper_registry.For_testing.unregister
                ~base_path
-               meta.name)
+               meta.name;
+             raise (Failure "injected checkpoint commit observer failure"))
            ~on_checkpoint_commit_hint:(fun _installed_ref ->
              incr hint_calls;
              callback_saw_released_admission :=
@@ -1136,64 +1140,135 @@ let test_manual_applied_hint_failure () =
             fail
               "post-install completion and cleanup rejection did not stay Applied");
          (match success.receipt.manifest with
-          | Ok () -> ()
           | Error detail ->
-            failf "post-install degraded manifest was not durable: %s" detail);
+            check string "manifest failure is exact" manifest_error detail
+          | Ok () -> fail "injected manifest append unexpectedly succeeded");
          check int
            "post-install lifecycle rejection performs one provider POST"
            1
            (Exact_fixture.post_count exact_server);
-         let manifest_path =
-           Masc.Keeper_runtime_manifest.path_for_trace
-             config
-             ~keeper_name:meta.name
-             ~trace_id:
-               (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+         let stimulus : Queue.stimulus =
+           { post_id = Queue.manual_compaction_post_id
+           ; urgency = Queue.Normal
+           ; arrived_at = 1.0
+           ; payload = Queue.Manual_compaction_requested
+           }
          in
-         let manifest =
-           Fs_compat.load_file manifest_path
-           |> String.split_on_char '\n'
-           |> List.filter (fun line -> String.trim line <> "")
-           |> List.rev
+         Result.get_ok
+           (Registry_queue.enqueue_durable_result
+              ~base_path
+              meta.name
+              stimulus);
+         let lease =
+           Registry_queue.claim_when_result
+             ~base_path
+             meta.name
+             ~claimed_at:2.0
+             ~ready:(fun _ -> true)
+           |> Result.get_ok
            |> function
-           | line :: _ -> Yojson.Safe.from_string line
-           | [] -> fail "post-install degraded manifest row is missing"
+           | Some lease -> lease
+           | None -> fail "manual compaction receipt fixture was not leased"
          in
+         let settlement =
+           Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
+             ~base_path
+             ~settled_at:3.0
+             ~stop_requested:false
+             ~compaction_consecutive_failures:0
+             ~lease
+             (Some
+                (Cycle.Manual_compaction_applied
+                   { receipt = success.receipt
+                   ; followup = Cycle.Completed meta
+                   }))
+         in
+         (match
+            Registry_queue.settle_result
+              ~base_path
+              meta.name
+              ~settled_at:3.0
+              ~lease
+              ~settlement
+          with
+          | Ok
+              ( Registry_queue.Settled _
+              | Registry_queue.Already_settled _ ) ->
+            ()
+          | Ok (Registry_queue.Committed_followup_failed { detail; _ })
+          | Error detail ->
+            failf "manual compaction receipt settlement failed: %s" detail);
+         let entry =
+           Registry_queue.transition_outbox_result ~base_path meta.name
+           |> Result.get_ok
+           |> function
+           | [ entry ] -> entry
+           | entries ->
+             failf
+               "manual compaction durable outbox count=%d"
+               (List.length entries)
+         in
+         (match entry.receipt.settlement with
+          | Registry_queue.Manual_compaction_committed
+              { commit
+              ; followup = Keeper_event_queue_state.Compaction_commit_ack
+              } ->
+            check bool
+              "durable queue receipt carries exact installed ref"
+              true
+              (Keeper_checkpoint_ref.equal
+                 success.receipt.installation.installed_ref
+                 commit.installed_ref);
+            check bool
+              "durable queue receipt carries observer auxiliary"
+              true
+              (List.exists
+                 (function
+                   | Keeper_event_queue_state.Compaction_commit_observer_failed _
+                     -> true
+                   | _ -> false)
+                 commit.auxiliary);
+            (match commit.lifecycle with
+             | Keeper_event_queue_state.
+                 Compaction_completion_rejected_failure_dispatch_failed _ ->
+               ()
+             | _ -> fail "durable queue receipt lost lifecycle failure");
+            check (option string)
+              "durable queue receipt carries manifest error"
+              (Some manifest_error)
+              commit.manifest_error;
+            check bool
+              "durable queue receipt requires operator action"
+              true
+              (Keeper_event_queue_state.
+                 manual_compaction_commit_requires_operator_action
+                 commit)
+          | _ -> fail "manual compaction durable settlement was not committed");
          let open Yojson.Safe.Util in
-         let decision = manifest |> member "decision" in
-         let public_decision =
-           Masc.Keeper_runtime_manifest.public_projection_of_decision decision
+         let public_receipt =
+           Keeper_event_queue_state.transition_receipt_to_yojson entry.receipt
+           |> member "settlement"
+           |> member "receipt"
          in
-         check string
-           "post-install anomaly degrades manifest health"
-           "degraded"
-           (manifest |> member "status" |> to_string);
          check bool
-           "post-install anomaly requires operator action"
+           "public durable receipt requires operator action"
            true
-           (public_decision
-            |> member "operator_action_required"
-            |> to_bool);
+           (public_receipt |> member "operator_action_required" |> to_bool);
          check string
-           "durable receipt states installed"
-           "installed"
-           (public_decision
-            |> member "checkpoint_installation_state"
-            |> to_string);
-         check string
-           "durable receipt carries exact sha"
+           "public durable receipt carries exact sha"
            success.receipt.installation.installed_ref.sha256
-           (public_decision
+           (public_receipt
             |> member "checkpoint_installed_ref"
             |> member "sha256"
             |> to_string);
          check string
-           "durable receipt carries lifecycle failure"
-           "completion_rejected_failure_dispatch_failed"
-           (public_decision
-            |> member "compaction_lifecycle"
-            |> member "kind"
-            |> to_string)
+           "public durable receipt carries manifest failure"
+           manifest_error
+           (public_receipt |> member "manifest_error" |> to_string);
+         check int
+           "durable receipt path never redispatches provider"
+           1
+           (Exact_fixture.post_count exact_server)
        | `No_compaction no_compaction ->
          failf
            "manual observer did not apply: %s"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1218,9 +1218,9 @@ let test_manual_applied_hint_failure () =
 
 let test_checkpoint_installation_auxiliary_manifest_tags () =
   let write_error =
-    { Keeper_fs.renamed = true
-    ; stage = Keeper_fs.Parent_directory_fsync_after_rename
-    ; failure = Keeper_fs.Operation_failed "injected durability uncertainty"
+    { Masc.Keeper_fs.renamed = true
+    ; stage = Masc.Keeper_fs.Parent_directory_fsync_after_rename
+    ; failure = Masc.Keeper_fs.Operation_failed "injected durability uncertainty"
     }
   in
   let lock_error =

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -14,7 +14,6 @@ module Exact_fixture = Compaction_exact_output_fixture
 module Schema = Masc.Keeper_structured_output_schema
 module Summarizer = Masc.Keeper_compaction_llm_summarizer
 
-exception Checkpoint_commit_hint_failure
 
 let exact_terminal ?(slot_id = "compaction-slot") ?(call_id = "call-compaction") cause =
   Keeper_event_queue_state.
@@ -750,10 +749,8 @@ let test_manual_compaction_serializes_owner_lane () =
         | Error detail ->
           failf "race manual compaction claim failed: %s" detail
       in
-      let race_hints = ref 0 in
       let busy_after_prepare =
         Masc.Keeper_manual_compaction.run_admitted
-          ~on_checkpoint_commit_hint:(fun _ -> incr race_hints)
           ~config
           ~meta
           ~exact_execution_guard:
@@ -762,13 +759,11 @@ let test_manual_compaction_serializes_owner_lane () =
                ~keeper_name:meta.name
                ~lease:race_lease)
           ()
-        |> fun result -> result.operation
       in
       check int
         "planning-admission race performs one exact dispatch"
         1
         (Exact_fixture.post_count race_server);
-      check int "noncommit path emits no hint" 0 !race_hints;
       let no_compaction =
         match busy_after_prepare with
         | `No_compaction
@@ -1017,285 +1012,6 @@ let test_malformed_structure_preserves_checkpoint () =
             { message_index = 0; tool_use_id = "orphan" }) ) ->
     ()
   | _ -> fail "malformed compaction was not rejected with typed structure")
-;;
-
-let test_manual_applied_hint_failure () =
-  Eio_main.run @@ fun env ->
-  Masc_test_deps.init_eio_clock env;
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Eio.Switch.run @@ fun sw ->
-  with_eio_context env sw @@ fun () ->
-  let base_path = Masc_test_deps.setup_test_workspace () in
-  let meta =
-    make_meta
-      ~name:"manual-commit-observer"
-      ~trace_id:"trace-manual-commit-observer"
-      ()
-  in
-  let runtime_snapshot = Runtime.For_testing.snapshot () in
-  Fun.protect
-    ~finally:(fun () ->
-      Runtime.For_testing.restore runtime_snapshot;
-      Admission.For_testing.reset ();
-      Masc.Keeper_registry.For_testing.unregister ~base_path meta.name;
-      Masc_test_deps.cleanup_test_workspace base_path)
-    (fun () ->
-       let config = Masc.Workspace.default_config base_path in
-       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       init_runtime_fixture ();
-       let exact_server =
-         Exact_fixture.start_server
-           ~sw
-           ~net:(Eio.Stdenv.net env)
-           ~clock:(Eio.Stdenv.clock env)
-           (Exact_fixture.Reply (summarize_response "manual observer compacted"))
-       in
-       publish_exact_fixture ~source:"manual commit observer" exact_server;
-       Result.get_ok (Masc.Keeper_meta_store.write_meta config meta);
-       ignore
-         (Masc.Keeper_registry.For_testing.register ~base_path meta.name meta);
-       let checkpoint =
-         { (make_checkpoint ()) with
-           session_id = "trace-manual-commit-observer"
-         ; agent_name = meta.agent_name
-         }
-       in
-       let session =
-         Masc.Keeper_context_core.create_session
-           ~session_id:checkpoint.session_id
-           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
-       in
-       (match
-          Masc.Keeper_context_core.save_oas_checkpoint_classified
-            ~multimodal_policy:meta.multimodal_policy
-            ~keeper_name:meta.name
-            ~session
-            ~agent_name:meta.agent_name
-            ~ctx:(Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint)
-            ~generation:meta.runtime.nonce
-        with
-        | Ok (_, Masc.Keeper_checkpoint_store.Saved _) -> ()
-        | Ok (_, Stale_noop _) -> fail "manual observer fixture save was stale"
-        | Error detail ->
-          failf
-            "manual observer fixture save failed: %s"
-            (Masc.Keeper_context_core.checkpoint_write_error_to_string
-               ~persistence_error_to_string:Fun.id
-               detail));
-       let manifest_error = "injected post-install manifest append failure" in
-       let callback_saw_released_admission = ref false in
-       let hint_calls = ref 0 in
-       let result =
-         Masc.Keeper_manual_compaction.For_testing.
-           run_admitted_with_install_observer_and_manifest_failure
-           ~manifest_error
-           ~on_checkpoint_installed_observer:(fun _ ->
-             Masc.Keeper_registry.For_testing.unregister
-               ~base_path
-               meta.name;
-             raise (Failure "injected checkpoint commit observer failure"))
-           ~on_checkpoint_commit_hint:(fun _installed_ref ->
-             incr hint_calls;
-             callback_saw_released_admission :=
-               Option.is_none
-                 (Admission.in_flight
-                    ~base_path
-                    ~keeper_name:meta.name);
-             raise Checkpoint_commit_hint_failure)
-           ~config
-           ~meta
-           ~exact_execution_guard:Exact_fixture.permissive_exact_execution_guard
-           ()
-       in
-       (match result.operation with
-       | `Applied success ->
-         check bool
-           "manual hint runs after compaction admission release"
-           true
-           !callback_saw_released_admission;
-         check int "manual hint is attempted at-most-once" 1 !hint_calls;
-         (match
-            success.recovery.checkpoint_installation,
-            success.receipt.installation,
-            result.checkpoint_commit_hint
-          with
-          | Masc.Keeper_checkpoint_store.Installed installed,
-            receipt_installation,
-            Masc.Keeper_manual_compaction.Hint_failed { installed_ref; _ } ->
-            check bool
-              "manual hint carries exact installed ref"
-              true
-              (installed_ref = installed.installed_ref);
-            check bool
-              "cycle receipt carries exact installed ref"
-              true
-              (installed_ref = receipt_installation.installed_ref)
-          | Masc.Keeper_checkpoint_store.Not_installed _, _, _ ->
-            fail "Applied manual compaction carried Not_installed"
-          | _ -> fail "raising manual hint lost its typed failure");
-         (match success.receipt.lifecycle with
-          | Masc.Keeper_manual_compaction.Completion_rejected_failure_dispatch_failed
-              _ ->
-            ()
-          | _ ->
-            fail
-              "post-install completion and cleanup rejection did not stay Applied");
-         (match success.receipt.manifest with
-          | Error detail ->
-            check string "manifest failure is exact" manifest_error detail
-          | Ok () -> fail "injected manifest append unexpectedly succeeded");
-         check int
-           "post-install lifecycle rejection performs one provider POST"
-           1
-           (Exact_fixture.post_count exact_server);
-         let stimulus : Queue.stimulus =
-           { post_id = Queue.manual_compaction_post_id
-           ; urgency = Queue.Normal
-           ; arrived_at = 1.0
-           ; payload = Queue.Manual_compaction_requested
-           }
-         in
-         Result.get_ok
-           (Registry_queue.enqueue_durable_result
-              ~base_path
-              meta.name
-              stimulus);
-         let lease =
-           Registry_queue.claim_when_result
-             ~base_path
-             meta.name
-             ~claimed_at:2.0
-             ~ready:(fun _ -> true)
-           |> Result.get_ok
-           |> function
-           | Some lease -> lease
-           | None -> fail "manual compaction receipt fixture was not leased"
-         in
-         let settlement =
-           Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
-             ~base_path
-             ~settled_at:3.0
-             ~stop_requested:false
-             ~compaction_consecutive_failures:0
-             ~lease
-             (Some
-                (Cycle.Manual_compaction_applied
-                   { receipt = success.receipt
-                   ; followup = Cycle.Completed meta
-                   }))
-         in
-         (match
-            Registry_queue.settle_result
-              ~base_path
-              meta.name
-              ~settled_at:3.0
-              ~lease
-              ~settlement
-          with
-          | Ok
-              ( Registry_queue.Settled _
-              | Registry_queue.Already_settled _ ) ->
-            ()
-          | Ok (Registry_queue.Committed_followup_failed { detail; _ })
-          | Error detail ->
-            failf "manual compaction receipt settlement failed: %s" detail);
-         let projected_entries = ref [] in
-         Registry_queue.project_transition_outbox_result
-           ~append_before_retire:(fun entry ->
-             projected_entries := entry :: !projected_entries;
-             Ok ())
-           ~base_path
-           ~keeper_name:meta.name
-         |> Result.map_error (fun detail ->
-              "manual compaction receipt projection failed: " ^ detail)
-         |> Result.get_ok;
-         let entry =
-           match List.rev !projected_entries with
-           | [ entry ] -> entry
-           | entries ->
-             failf
-               "manual compaction projected receipt count=%d"
-               (List.length entries)
-         in
-         (match entry.receipt.settlement with
-          | Registry_queue.Manual_compaction_committed
-              { commit
-              ; followup = Keeper_event_queue_state.Compaction_commit_ack
-              } ->
-            check bool
-              "durable queue receipt carries exact installed ref"
-              true
-              (success.receipt.installation.installed_ref = commit.installed_ref);
-            check bool
-              "durable queue receipt carries observer auxiliary"
-              true
-              (List.exists
-                 (function
-                   | Keeper_event_queue_state.Compaction_commit_observer_failed _
-                     -> true
-                   | _ -> false)
-                 commit.auxiliary);
-            (match commit.lifecycle with
-             | Keeper_event_queue_state.
-                 Compaction_completion_rejected_failure_dispatch_failed _ ->
-               ()
-             | _ -> fail "durable queue receipt lost lifecycle failure");
-            check (option string)
-              "durable queue receipt carries manifest error"
-              (Some manifest_error)
-              commit.manifest_error;
-            check bool
-              "durable queue receipt requires operator action"
-              true
-              (Keeper_event_queue_state.
-                 manual_compaction_commit_requires_operator_action
-                 commit)
-          | _ -> fail "manual compaction durable settlement was not committed");
-         let open Yojson.Safe.Util in
-         let public_receipt =
-           Keeper_event_queue_state.transition_receipt_to_yojson entry.receipt
-           |> member "settlement"
-           |> member "receipt"
-         in
-         check bool
-           "public durable receipt requires operator action"
-           true
-           (public_receipt |> member "operator_action_required" |> to_bool);
-         check string
-           "public durable receipt carries exact sha"
-           success.receipt.installation.installed_ref.sha256
-           (public_receipt
-            |> member "checkpoint_installed_ref"
-            |> member "sha256"
-            |> to_string);
-         check string
-           "public durable receipt carries manifest failure"
-           manifest_error
-           (public_receipt |> member "manifest_error" |> to_string);
-         check int
-           "durable receipt path never redispatches provider"
-           1
-           (Exact_fixture.post_count exact_server)
-       | `No_compaction no_compaction ->
-         failf
-           "manual observer did not apply: %s"
-           (Keeper_event_queue_state.no_compaction_reason_label
-              no_compaction.reason)
-       | `Compaction_failed failure ->
-         failf
-           "manual observer compaction failed: %s"
-           (Masc.Keeper_manual_compaction.failure_to_string failure)
-       | `Busy _ -> fail "manual hint compaction was unexpectedly busy");
-       match result.checkpoint_commit_hint with
-       | Masc.Keeper_manual_compaction.Hint_failed
-           { failure = Checkpoint_commit_hint_failure, _; _ } ->
-         ()
-       | Masc.Keeper_manual_compaction.Hint_failed { failure = exn, _; _ } ->
-         failf "manual hint failed with the wrong exception: %s" (Printexc.to_string exn)
-       | Masc.Keeper_manual_compaction.Hint_delivered _ ->
-         fail "raising manual hint was reported delivered"
-       | Masc.Keeper_manual_compaction.Hint_not_emitted ->
-         fail "Applied manual compaction emitted no hint")
 ;;
 
 let test_checkpoint_installation_auxiliary_manifest_tags () =
@@ -1729,8 +1445,6 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
-      test_case "manual Applied preserves hint failure"
-        `Quick test_manual_applied_hint_failure;
       test_case "checkpoint installation auxiliary manifest tags"
         `Quick test_checkpoint_installation_auxiliary_manifest_tags;
       test_case "malformed structure preserves checkpoint"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -748,8 +748,10 @@ let test_manual_compaction_serializes_owner_lane () =
         | Error detail ->
           failf "race manual compaction claim failed: %s" detail
       in
+      let checkpoint_commits = ref 0 in
       let busy_after_prepare =
         Masc.Keeper_manual_compaction.run_admitted
+          ~on_checkpoint_committed:(fun () -> incr checkpoint_commits)
           ~config
           ~meta
           ~exact_execution_guard:
@@ -763,6 +765,10 @@ let test_manual_compaction_serializes_owner_lane () =
         "planning-admission race performs one exact dispatch"
         1
         (Exact_fixture.post_count race_server);
+      check int
+        "provider success without final commit observes no checkpoint"
+        0
+        !checkpoint_commits;
       let no_compaction =
         match busy_after_prepare with
         | `No_compaction
@@ -1012,6 +1018,106 @@ let test_malformed_structure_preserves_checkpoint () =
   | _ -> fail "malformed compaction was not rejected with typed structure")
 ;;
 
+let test_manual_applied_observer () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let meta =
+    make_meta
+      ~name:"manual-commit-observer"
+      ~trace_id:"trace-manual-commit-observer"
+      ()
+  in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      Admission.For_testing.reset ();
+      Masc.Keeper_registry.For_testing.unregister ~base_path meta.name;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       init_runtime_fixture ();
+       let exact_server =
+         Exact_fixture.start_server
+           ~sw
+           ~net:(Eio.Stdenv.net env)
+           ~clock:(Eio.Stdenv.clock env)
+           (Exact_fixture.Reply (summarize_response "manual observer compacted"))
+       in
+       publish_exact_fixture ~source:"manual commit observer" exact_server;
+       Result.get_ok (Masc.Keeper_meta_store.write_meta config meta);
+       ignore
+         (Masc.Keeper_registry.For_testing.register ~base_path meta.name meta);
+       let checkpoint =
+         { (make_checkpoint ()) with
+           session_id = "trace-manual-commit-observer"
+         ; agent_name = meta.agent_name
+         }
+       in
+       let session =
+         Masc.Keeper_context_core.create_session
+           ~session_id:checkpoint.session_id
+           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+       in
+       (match
+          Masc.Keeper_context_core.save_oas_checkpoint_classified
+            ~multimodal_policy:meta.multimodal_policy
+            ~keeper_name:meta.name
+            ~session
+            ~agent_name:meta.agent_name
+            ~ctx:(Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint)
+            ~generation:meta.runtime.nonce
+        with
+        | Ok (_, Masc.Keeper_checkpoint_store.Saved _) -> ()
+        | Ok (_, Stale_noop _) -> fail "manual observer fixture save was stale"
+        | Error detail ->
+          failf
+            "manual observer fixture save failed: %s"
+            (Masc.Keeper_context_core.checkpoint_write_error_to_string
+               ~persistence_error_to_string:Fun.id
+               detail));
+       let checkpoint_commits = ref 0 in
+       let callback_saw_released_admission = ref false in
+       match
+         Masc.Keeper_manual_compaction.run_admitted
+           ~on_checkpoint_committed:(fun () ->
+             incr checkpoint_commits;
+             callback_saw_released_admission :=
+               Option.is_none
+                 (Admission.in_flight
+                    ~base_path
+                    ~keeper_name:meta.name))
+           ~config
+           ~meta
+           ~exact_execution_guard:Exact_fixture.permissive_exact_execution_guard
+           ()
+       with
+       | `Applied _ ->
+         check int
+           "manual Applied observes one durable checkpoint commit"
+           1
+           !checkpoint_commits;
+         check bool
+           "manual observer runs after compaction admission release"
+           true
+           !callback_saw_released_admission
+       | `No_compaction no_compaction ->
+         failf
+           "manual observer did not apply: %s"
+           (Keeper_event_queue_state.no_compaction_reason_label
+              no_compaction.reason)
+       | `Compaction_failed failure ->
+         failf
+           "manual observer compaction failed: %s"
+           (Masc.Keeper_manual_compaction.failure_to_string failure)
+       | `Busy _ -> fail "manual observer compaction was unexpectedly busy")
+;;
+
 let test_prepare_commit_source_cas () =
   (* The prepare/commit split exists so the provider call can run outside
      the keeper admission; the source CAS — not the slot — is the
@@ -1084,15 +1190,27 @@ let test_prepare_commit_source_cas () =
       "prepare performs one real exact dispatch"
       1
       (Exact_fixture.post_count exact_server);
-    (match Post_turn.commit_prepared_compaction prepared with
+    let checkpoint_commits = ref 0 in
+    let on_checkpoint_committed () = incr checkpoint_commits in
+    (match
+       Post_turn.commit_prepared_compaction
+         ~on_checkpoint_committed
+         prepared
+     with
      | Ok _ -> ()
      | Error error ->
        failf
          "commit of a fresh prepared plan failed: %s"
          (Post_turn.compaction_recovery_error_to_string error));
+    check int "fresh prepared commit is observed once" 1 !checkpoint_commits;
     (* The first commit advanced the durable source; the same
        prepared value is now stale and must be CAS-rejected. *)
-    (match Post_turn.commit_prepared_compaction prepared with
+    let commits_before_stale = !checkpoint_commits in
+    (match
+       Post_turn.commit_prepared_compaction
+         ~on_checkpoint_committed
+         prepared
+     with
      | Error
          (Post_turn.No_compaction
             { reason =
@@ -1109,7 +1227,11 @@ let test_prepare_commit_source_cas () =
        failf
          "stale prepared value failed with the wrong error: %s"
          (Post_turn.compaction_recovery_error_to_string error)
-     | Ok _ -> fail "stale prepared value committed past the source CAS"))
+     | Ok _ -> fail "stale prepared value committed past the source CAS");
+    check int
+      "stale prepared commit observes no durable checkpoint"
+      0
+      (!checkpoint_commits - commits_before_stale))
 ;;
 
 let test_invalid_structural_evidence_after_dispatch_is_terminal () =
@@ -1357,6 +1479,8 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
+      test_case "manual Applied observes its checkpoint commit"
+        `Quick test_manual_applied_observer;
       test_case "malformed structure preserves checkpoint"
         `Quick test_malformed_structure_preserves_checkpoint;
       test_case "prepare/commit source CAS"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -14,6 +14,8 @@ module Exact_fixture = Compaction_exact_output_fixture
 module Schema = Masc.Keeper_structured_output_schema
 module Summarizer = Masc.Keeper_compaction_llm_summarizer
 
+exception Checkpoint_commit_hint_failure
+
 let exact_terminal ?(slot_id = "compaction-slot") ?(call_id = "call-compaction") cause =
   Keeper_event_queue_state.
     { cause
@@ -748,10 +750,9 @@ let test_manual_compaction_serializes_owner_lane () =
         | Error detail ->
           failf "race manual compaction claim failed: %s" detail
       in
-      let checkpoint_commits = ref 0 in
       let busy_after_prepare =
         Masc.Keeper_manual_compaction.run_admitted
-          ~on_checkpoint_committed:(fun () -> incr checkpoint_commits)
+          ~on_checkpoint_commit_hint:(fun _ -> ())
           ~config
           ~meta
           ~exact_execution_guard:
@@ -760,15 +761,12 @@ let test_manual_compaction_serializes_owner_lane () =
                ~keeper_name:meta.name
                ~lease:race_lease)
           ()
+        |> fun result -> result.operation
       in
       check int
         "planning-admission race performs one exact dispatch"
         1
         (Exact_fixture.post_count race_server);
-      check int
-        "provider success without final commit observes no checkpoint"
-        0
-        !checkpoint_commits;
       let no_compaction =
         match busy_after_prepare with
         | `No_compaction
@@ -1018,7 +1016,7 @@ let test_malformed_structure_preserves_checkpoint () =
   | _ -> fail "malformed compaction was not rejected with typed structure")
 ;;
 
-let test_manual_applied_observer () =
+let test_manual_applied_hint_failure () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1081,29 +1079,25 @@ let test_manual_applied_observer () =
             (Masc.Keeper_context_core.checkpoint_write_error_to_string
                ~persistence_error_to_string:Fun.id
                detail));
-       let checkpoint_commits = ref 0 in
        let callback_saw_released_admission = ref false in
-       match
+       let result =
          Masc.Keeper_manual_compaction.run_admitted
-           ~on_checkpoint_committed:(fun () ->
-             incr checkpoint_commits;
+           ~on_checkpoint_commit_hint:(fun _installed_ref ->
              callback_saw_released_admission :=
                Option.is_none
                  (Admission.in_flight
                     ~base_path
-                    ~keeper_name:meta.name))
+                    ~keeper_name:meta.name);
+             raise Checkpoint_commit_hint_failure)
            ~config
            ~meta
            ~exact_execution_guard:Exact_fixture.permissive_exact_execution_guard
            ()
-       with
+       in
+       (match result.operation with
        | `Applied _ ->
-         check int
-           "manual Applied observes one durable checkpoint commit"
-           1
-           !checkpoint_commits;
          check bool
-           "manual observer runs after compaction admission release"
+           "manual hint runs after compaction admission release"
            true
            !callback_saw_released_admission
        | `No_compaction no_compaction ->
@@ -1115,7 +1109,17 @@ let test_manual_applied_observer () =
          failf
            "manual observer compaction failed: %s"
            (Masc.Keeper_manual_compaction.failure_to_string failure)
-       | `Busy _ -> fail "manual observer compaction was unexpectedly busy")
+       | `Busy _ -> fail "manual hint compaction was unexpectedly busy");
+       match result.checkpoint_commit_hint with
+       | Masc.Keeper_manual_compaction.Hint_failed
+           { failure = Checkpoint_commit_hint_failure, _; _ } ->
+         ()
+       | Masc.Keeper_manual_compaction.Hint_failed { failure = exn, _; _ } ->
+         failf "manual hint failed with the wrong exception: %s" (Printexc.to_string exn)
+       | Masc.Keeper_manual_compaction.Hint_delivered _ ->
+         fail "raising manual hint was reported delivered"
+       | Masc.Keeper_manual_compaction.Hint_not_emitted ->
+         fail "Applied manual compaction emitted no hint")
 ;;
 
 let test_prepare_commit_source_cas () =
@@ -1190,11 +1194,9 @@ let test_prepare_commit_source_cas () =
       "prepare performs one real exact dispatch"
       1
       (Exact_fixture.post_count exact_server);
-    let checkpoint_commits = ref 0 in
-    let on_checkpoint_committed () = incr checkpoint_commits in
     (match
        Post_turn.commit_prepared_compaction
-         ~on_checkpoint_committed
+         ~on_checkpoint_commit_hint:(fun _ -> ())
          prepared
      with
      | Ok _ -> ()
@@ -1202,13 +1204,11 @@ let test_prepare_commit_source_cas () =
        failf
          "commit of a fresh prepared plan failed: %s"
          (Post_turn.compaction_recovery_error_to_string error));
-    check int "fresh prepared commit is observed once" 1 !checkpoint_commits;
     (* The first commit advanced the durable source; the same
        prepared value is now stale and must be CAS-rejected. *)
-    let commits_before_stale = !checkpoint_commits in
     (match
        Post_turn.commit_prepared_compaction
-         ~on_checkpoint_committed
+         ~on_checkpoint_commit_hint:(fun _ -> ())
          prepared
      with
      | Error
@@ -1227,11 +1227,7 @@ let test_prepare_commit_source_cas () =
        failf
          "stale prepared value failed with the wrong error: %s"
          (Post_turn.compaction_recovery_error_to_string error)
-     | Ok _ -> fail "stale prepared value committed past the source CAS");
-    check int
-      "stale prepared commit observes no durable checkpoint"
-      0
-      (!checkpoint_commits - commits_before_stale))
+     | Ok _ -> fail "stale prepared value committed past the source CAS"))
 ;;
 
 let test_invalid_structural_evidence_after_dispatch_is_terminal () =
@@ -1479,8 +1475,8 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
-      test_case "manual Applied observes its checkpoint commit"
-        `Quick test_manual_applied_observer;
+      test_case "manual Applied preserves hint failure"
+        `Quick test_manual_applied_hint_failure;
       test_case "malformed structure preserves checkpoint"
         `Quick test_malformed_structure_preserves_checkpoint;
       test_case "prepare/commit source CAS"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1114,9 +1114,7 @@ let test_manual_applied_hint_failure () =
             check bool
               "manual hint carries exact installed ref"
               true
-              (Masc.Keeper_checkpoint_ref.equal
-                 installed_ref
-                 installed.installed_ref)
+              (installed_ref = installed.installed_ref)
           | Masc.Keeper_checkpoint_store.Not_installed _, _ ->
             fail "Applied manual compaction carried Not_installed"
           | _ -> fail "raising manual hint lost its typed failure")


### PR DESCRIPTION
## Summary

- propagate a required `on_checkpoint_committed` observer from manual compaction through the context/post-turn/checkpoint-store chain
- deliver the public observer exactly once only after the durable checkpoint CAS lock and manual-compaction admission scope have unwound
- centralize durable-commit observation settlement in `Keeper_fs.finish_durable_commit_observation`
- preserve the original exception/cancellation and raw backtrace when a post-commit observer violates its non-raising contract
- keep heartbeat and synchronous non-manual recovery call sites explicit with no-op observers

## Boundary

This is the A1 durable checkpoint-commit signal needed by the later `AckPending -> AckConfirmed` settlement layer.

- MASC owns domain checkpoint/compaction truth
- no provider, model, tier, pricing, credential, or wire policy is introduced
- no historical runtime JSON migration or compatibility alias is added
- the observer runs in the caller domain, outside the checkpoint CAS lock and outside manual-compaction admission
- existing durable quarantine I/O under `Eio.Cancel.protect` is intentionally not expanded here; A2 owns that cancellation-fence cleanup

## Proof added

- competing writers: durable winner observer 1, stale loser 0
- fresh checkpoint 1, stale checkpoint 0
- manual applied 1; non-commit outcomes 0
- durable write followed by cancellation: committed file remains and observer fires once
- underlying `Raised` plus raising observer: original exception and raw backtrace win
- callback latch is consumed before invocation, preventing retry after callback failure

Local build/test/format was intentionally not run; PR CI is the build authority for this stack.

## Stack

Depends on #25699 and intentionally targets `fix/durable-commit-observer-20260724`.
