### PR TITLE
feat(runtime): 운영자가 요청 본문 상한을 선언할 수 있게 한다

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -345,6 +345,7 @@ let model_capabilities_override_of_model_spec
 
 (* --- provider × model spec → Provider_config.t --- *)
 let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_requests
+    ?max_request_body_bytes
     (provider : Runtime_schema.provider) (spec : Runtime_schema.model_spec)
   : (Llm_provider.Provider_config.t, string) result =
   let registry_entry = find_registry_entry provider.id in
@@ -406,6 +407,7 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
             ?num_ctx
             ?connect_timeout_s:provider.connect_timeout_s
             ?max_concurrent_requests
+            ?max_request_body_bytes
             ())
      | Error reason -> Error reason)
   | Cli _ ->
@@ -431,6 +433,7 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
             ?num_ctx
             ?connect_timeout_s:provider.connect_timeout_s
             ?max_concurrent_requests
+            ?max_request_body_bytes
             ())
      | Error reason -> Error reason)
 ;;
@@ -457,6 +460,7 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
          ?keep_alive:binding.keep_alive
          ?num_ctx:binding.num_ctx
          ?max_concurrent_requests:binding.max_concurrent
+         ?max_request_body_bytes:binding.max_request_body_bytes
          provider
          spec)
 ;;

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -200,6 +200,7 @@ type binding =
   ; is_default : bool
   ; wizard_default : bool
   ; max_concurrent : int option
+  ; max_request_body_bytes : int option
   ; price_input : float option
   ; price_output : float option
   ; keep_alive : string option

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -137,6 +137,18 @@ type binding =
   ; is_default : bool
   ; wizard_default : bool
   ; max_concurrent : int option
+  ; max_request_body_bytes : int option
+        (** Serialized request-body ceiling for this binding, in bytes.
+
+            OAS validates this knob and [max_concurrent] together in one function
+            ([Llm_provider] admission declaration) and enforces this one before
+            POST: it serializes the body, measures it, and returns a typed
+            [Request_body_too_large] when the declared ceiling is exceeded. That
+            rejection is pre-dispatch, so it is failover-eligible.
+
+            Undeclared means the gate passes every size, and the ceiling is then
+            discovered only as a gateway 400 after the bytes are already on the
+            wire — post-dispatch, where neither retry nor failover applies. *)
   ; price_input : float option
   ; price_output : float option
   ; keep_alive : string option

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -799,6 +799,26 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
               n))
     | Error _ as e -> e
   in
+  (* Paired with max-concurrent on purpose: OAS validates both in one admission
+     declaration and enforces this one before POST by serializing, measuring and
+     returning a typed Request_body_too_large. Only max-concurrent was declarable
+     here, so the byte ceiling could not be expressed at all and the OAS gate
+     passed every size. Same shape as its sibling, including the >= 1 rule OAS
+     already enforces on the declaration. *)
+  let max_request_body_bytes_result =
+    match typed_find "an integer" path tbl "max-request-body-bytes" Otoml.get_integer with
+    | Ok None -> Ok None
+    | Ok (Some n) when n > 0 -> Ok (Some n)
+    | Ok (Some n) ->
+      Error
+        (error
+           (path ^ ".max-request-body-bytes")
+           (Printf.sprintf
+              "max-request-body-bytes must be a positive integer or omitted for no \
+               declared ceiling; got %d"
+              n))
+    | Error _ as e -> e
+  in
   let price_input_result = typed_find "a float" path tbl "price-input" Otoml.get_float in
   let price_output_result = typed_find "a float" path tbl "price-output" Otoml.get_float in
   let keep_alive_result = typed_find "a string" path tbl "keep-alive" Otoml.get_string in
@@ -812,6 +832,7 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
     (* DET-OK: omitted means not selected for install wizard. *)
   in
   let* max_concurrent = max_concurrent_result in
+  let* max_request_body_bytes = max_request_body_bytes_result in
   let* price_input = price_input_result in
   let* price_output = price_output_result in
   let* keep_alive = keep_alive_result in
@@ -822,6 +843,7 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
     ; is_default
     ; wizard_default
     ; max_concurrent
+    ; max_request_body_bytes
     ; price_input
     ; price_output
     ; keep_alive

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1287,6 +1287,96 @@ let test_runtime_toml_parses_optional_max_concurrent () =
          binding.Runtime_schema.max_concurrent
      | bindings -> failf "expected one binding, got %d" (List.length bindings))
 
+let test_runtime_toml_parses_optional_max_request_body_bytes () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     max-request-body-bytes = 1048576\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (err : Runtime_toml.parse_error) ->
+        Printf.sprintf "%s: %s" err.path err.message)
+      |> String.concat "\n"
+    in
+    failf "runtime TOML should parse optional max-request-body-bytes:\n%s" rendered
+  | Ok cfg ->
+    (match cfg.Runtime_schema.bindings with
+     | [ binding ] ->
+       check (option int) "explicit max-request-body-bytes opt-in" (Some 1048576)
+         binding.Runtime_schema.max_request_body_bytes
+     | bindings -> failf "expected one binding, got %d" (List.length bindings))
+
+let test_runtime_toml_omitted_max_request_body_bytes_is_none () =
+  (* Undeclared must stay None rather than acquiring a default. OAS reads None as
+     "no ceiling declared" and passes every size; a default here would silently
+     become a product-wide cap nobody chose. *)
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Error _ -> failf "runtime TOML without the knob should still parse"
+  | Ok cfg ->
+    (match cfg.Runtime_schema.bindings with
+     | [ binding ] ->
+       check (option int) "omitted max-request-body-bytes stays None" None
+         binding.Runtime_schema.max_request_body_bytes
+     | bindings -> failf "expected one binding, got %d" (List.length bindings))
+
+let test_runtime_toml_rejects_non_positive_max_request_body_bytes () =
+  let template n =
+    Printf.sprintf
+      "[providers.local]\n\
+       protocol = \"openai-compatible-http\"\n\
+       endpoint = \"http://127.0.0.1:1/v1\"\n\
+       \n\
+       [models.sample]\n\
+       api-name = \"sample\"\n\
+       max-context = 1024\n\
+       \n\
+       [local.sample]\n\
+       max-request-body-bytes = %d\n\
+       \n\
+       [runtime]\n\
+       default = \"local.sample\"\n"
+      n
+  in
+  List.iter
+    (fun n ->
+       match Runtime_toml.parse_string (template n) with
+       | Ok _ -> failf "max-request-body-bytes = %d should be rejected" n
+       | Error errs ->
+         let rendered =
+           errs
+           |> List.map (fun (err : Runtime_toml.parse_error) ->
+             Printf.sprintf "%s: %s" err.path err.message)
+           |> String.concat "\n"
+         in
+         check bool (Printf.sprintf "error mentions the knob for %d" n) true
+           (String_util.contains_substring rendered "max-request-body-bytes"))
+    [ 0; -1 ]
+
 let test_runtime_toml_separates_wizard_default_from_runtime_default_marker () =
   let content =
     "[providers.local]\n\
@@ -2831,6 +2921,12 @@ let () =
             test_runtime_toml_rejects_non_positive_max_concurrent;
           test_case "max-concurrent flows from binding to provider config" `Quick
             test_runtime_toml_max_concurrent_flows_to_provider_config;
+          test_case "max-request-body-bytes is optional opt-in" `Quick
+            test_runtime_toml_parses_optional_max_request_body_bytes;
+          test_case "omitted max-request-body-bytes stays None" `Quick
+            test_runtime_toml_omitted_max_request_body_bytes_is_none;
+          test_case "non-positive max-request-body-bytes is rejected" `Quick
+            test_runtime_toml_rejects_non_positive_max_request_body_bytes;
           test_case
             "deprecated capability notice warns once per process, not per parse"
             `Quick test_deprecated_capability_notice_warns_once_per_process;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1332,6 +1332,8 @@ let test_runtime_toml_omitted_max_request_body_bytes_is_none () =
      api-name = \"sample\"\n\
      max-context = 1024\n\
      \n\
+     [local.sample]\n\
+     \n\
      [runtime]\n\
      default = \"local.sample\"\n"
   in

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -65,6 +65,7 @@ let runpod_binding =
   ; is_default = true
   ; wizard_default = false
   ; max_concurrent = None
+  ; max_request_body_bytes = None
   ; price_input = None
   ; price_output = None
   ; keep_alive = None


### PR DESCRIPTION
## 왜

OAS 는 이 상한을 **dispatch 전에 이미 강제한다**. `lib/llm_provider/complete_common.ml:682-687` 이 요청을 직렬화하고 크기를 재서 선언된 상한을 넘으면 typed `Request_body_too_large` 를 반환한다. 이 거부는 pre-dispatch 이므로 **failover 적격**이다 — 바이트가 이미 와이어에 올라간 뒤 도착하는 게이트웨이 400 과 다르다.

**masc 에는 이것을 선언할 방법이 없었다.** `max_request_body_bytes` 가 `lib/` 에 0 hits 라서 `Provider_config` 는 항상 `None` 을 받았고, OAS 의 게이트는 모든 크기를 통과시켰다.

라이브에서 보이는 결과 (`masc_keeper_status` 전수 20기, 2026-07-25T06:2x):

| 모드 | 키퍼 |
|---|---|
| `compaction_count > 0` (한 번이라도 닫힘) | 3 |
| `not_requested` | 14 |
| `exact_execution_guard_failed` | 2 |
| `compaction retry suspended` | 2 |
| `no compaction for ...` | 2 |

막힌 두 키퍼는 `checkpoint_bytes: 453515` 로 실패하는데, 비교할 상한은 아무도 선언하지 않았다 (`~/me/.masc/logs/system_log_2026-07-25.jsonl` seq 46292).

## 무엇을

**형제 노브는 이미 배선돼 있었다.** OAS 는 `max_request_body_bytes` 와 `max_concurrent_requests` 를 **한 admission declaration 에서 함께 검증**하는데(`complete_common.ml:568-585`), masc 에서는 동시성 절반만 표현 가능했다. 이 PR 은 형제가 지나가는 **정확히 같은 경로**로 쌍의 나머지를 완성한다:

`runtime.toml` → `Runtime_schema.binding` → `runtime_adapter` → `Provider_config`

- `lib/runtime/runtime_schema.ml` / `.mli` — `max_request_body_bytes : int option` 필드
- `lib/runtime/runtime_toml.ml` — `max-request-body-bytes` 파싱, OAS 가 선언에 요구하는 `>= 1` 규칙 동일 적용
- `lib/runtime/runtime_adapter.ml` — `?max_request_body_bytes` 를 형제와 같은 4개 지점에서 전달
- `test/test_runtime_config_validity.ml` — 테스트 3건: opt-in 파싱 / **생략 시 `None` 유지** / 비양수 거부

**생략은 `None` 으로 남는다.** 여기서 기본값을 주면 아무도 선택하지 않은 제품 전역 cap 이 되므로, 그것을 테스트로 고정했다.

## 검증

- 편집한 6개 파일 전부 `ocamlformat` 파싱 통과.
- **로컬 타입체크 안 함**: 공유 opam 스위치가 `agent_sdk.0.223.1` 을 들고 있고 `scripts/oas-agent-sdk-pin.sh` 의 핀은 `45473aae` (= `0.222.2`) 다. `lib/runtime` 은 **이 PR 이 건드리지 않은 파일**에서 먼저 실패한다 — `lib/runtime/runtime_exact_output_registry.ml:434`, `Unbound constructor Exact_output.Missing_target_credential`. 따라서 이 브랜치의 타입체크 권위는 CI 다.

## 이것이 무엇을 고치지 않는가

상한을 **선언 가능**하게 만들 뿐, 값을 정하지 않는다. 값은 카탈로그/운영자 설정의 몫이다 (런타임 무관심 원칙: 대상 선택과 용량은 role 코드가 아니라 카탈로그 + 운영자 순서가 정한다).

`not_requested` 14기는 이 PR 로 움직이지 않는다 — 그들은 애초에 compaction 을 요청하지 않으며 `lib/keeper/keeper_post_turn.ml:438` 이 조건 없이 `Not_requested` 를 기록한다. 별도 변경이다.

`exact_execution_guard_failed` 2기도 움직이지 않는다 — #25713 (`keeper_heartbeat_loop.ml:1363-1371` 이 stimulus lease 없이는 guard 를 만들지 않는다). 별도 변경이다.

## Done 지표

테스트 green 이 아니라 라이브 숫자로 본다. 상한이 선언된 뒤 `Request_body_too_large` 가 **pre-dispatch** 로 관측되는지, 그리고 그 키퍼의 실패가 400 (post-dispatch, failover 불가) 에서 typed 거부 (failover 가능) 로 바뀌는지. 하네스 게이트 G-6 (`~/me/.worktrees/masc-liveness-program/scripts/apc/selftest.py`) 가 매 실행마다 모드별 분포를 출력하므로 기준선 `3/20` 대비 변화를 추적할 수 있다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. 변경 범위는 `lib/runtime` 설정 파싱과 그 테스트이며, 기존에 배선된 형제 노브의 경로를 그대로 따른다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEwRSse6KzFf9MnVGkjbH
