### PR TITLE
refactor(runtime): 런타임을 지명하는 경로들의 수용 경로를 하나로

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -133,28 +133,6 @@ let validate_keeper_assignments ~(config_path : string)
             ~runtime_count:(List.length runtimes) runtime_id))
 ;;
 
-(* [runtime].memory_os_consolidation must resolve to a configured runtime when
-   set. [None] is the designed inheritance of [runtime].default; an unknown id
-   is an operator typo rejected at load, never a silent fallback. *)
-let validate_memory_os_consolidation_runtime
-    ~(config_path : string)
-    ~(dropped_bindings : (string * string) list)
-    (runtimes : t list)
-    (runtime_id : string option) : (unit, string) result =
-  match runtime_id with
-  | None -> Ok ()
-  | Some id ->
-    if List.exists (fun (r : t) -> String.equal r.id id) runtimes
-    then Ok ()
-    else
-      Error
-        (Printf.sprintf
-           "%s: [runtime].memory_os_consolidation = %S%s"
-           config_path
-           id
-           (unresolved_runtime_suffix ~dropped_bindings
-              ~runtime_count:(List.length runtimes) id))
-;;
 
 (* Route ids resolve with lane precedence ([resolve_assignment] prefers a lane
    over a same-named runtime), so route validation must judge the same target
@@ -209,105 +187,96 @@ let validate_lane_candidates_capability
   check (Runtime_lane.ordered_candidates lane)
 ;;
 
-(* [runtime].cross_verifier treats an unknown id as an operator typo rejected at
-   load, not a silent fallback
-   (Unknown→Permissive anti-pattern). [None] is the designed "inherit
-   [runtime].default" case. A lane id is accepted when every candidate
-   declares JSON mode (#25394). *)
-let validate_cross_verifier_runtime ~(config_path : string)
-    ~(dropped_bindings : (string * string) list) (runtimes : t list)
-    (lanes : Runtime_lane.t list)
-    (cross_verifier_id : string option) : (unit, string) result =
-  let supports_json (runtime : t) =
-    match runtime.model.capabilities with
-    | Some caps -> caps.supports_response_format_json
-    | None -> false
-  in
-  match cross_verifier_id with
-  | None -> Ok ()
-  | Some id ->
-    (match find_declared_lane lanes id with
-     | Some lane ->
-       validate_lane_candidates_capability
-         ~config_path
-         ~route_name:"cross_verifier"
-         ~capability_key:"supports-response-format-json"
-         ~runtime_supports:supports_json
-         runtimes
-         lane
-     | None ->
-    (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
-     | None ->
-      Error
-        (Printf.sprintf
-           "%s: [runtime].cross_verifier = %S%s"
-           config_path
-           id
-           (unresolved_runtime_suffix ~dropped_bindings
-              ~runtime_count:(List.length runtimes) id))
-     | Some runtime ->
-       if supports_json runtime
-       then Ok ()
-       else
-          Error
-            (Printf.sprintf
-               "%s: [runtime].cross_verifier = %S uses model %S, which does \
-                not declare supports-response-format-json"
-               config_path
-               id
-               runtime.model.id)))
+(* One admission path for the routes that name a runtime. Each route resolves an
+   id with lane precedence ([resolve_assignment] prefers a lane over a same-named
+   runtime), and some routes additionally require the resolved target to declare a
+   capability. The requirement is a closed variant rather than an optional
+   argument, so a route that needs no capability states that instead of relying on
+   a caller to omit a parameter that silently changes the outcome.
+
+   Merging the three per-route validators removed an asymmetry with no stated
+   reason: [runtime].memory_os_consolidation was validated before lanes were
+   materialised, so it alone could not name a lane while cross_verifier and
+   structured_judge could.
+
+   [None] stays the designed "inherit [runtime].default" case for every route, and
+   an unknown id remains an operator typo rejected at load rather than a silent
+   fallback (Unknown -> Permissive anti-pattern). *)
+type route_requirement =
+  | Resolves_only
+  | Declares_capability of
+      { key : string
+      ; supported_by : t -> bool
+      }
+
+(* Capability accessors preserve the existing [None -> false] reading: a model
+   with no declared capabilities does not satisfy the requirement. That denial on
+   unknown is carried over unchanged, not introduced here; whether an unknown
+   capability should order a candidate later rather than exclude it up front is
+   the separate question tracked against the format axis. *)
+let model_supports_response_format_json (runtime : t) =
+  match runtime.model.capabilities with
+  | Some caps -> caps.supports_response_format_json
+  | None -> false
 ;;
 
-(* [runtime].structured_judge is the explicit lane for provider-native schema
-   requests. It must declare structured output, not just JSON mode. [None]
-   remains a migration fallback for existing configs;
-   unsupported resolved runtimes are rejected by each caller's OAS schema
-   validation instead of silently dropping the schema. A [runtime.lanes] id is
-   accepted when every candidate declares structured output (#25394): every
-   consumer routes through [resolve_assignment]-aware paths
-   ([Keeper_turn_driver.run_named] or the compaction candidate expansion). *)
-let validate_structured_judge_runtime ~(config_path : string)
-    ~(dropped_bindings : (string * string) list) (runtimes : t list)
+let model_supports_structured_output (runtime : t) =
+  match runtime.model.capabilities with
+  | Some caps -> caps.supports_structured_output
+  | None -> false
+;;
+
+let validate_route_runtime
+    ~(config_path : string)
+    ~(dropped_bindings : (string * string) list)
+    ~(route_name : string)
+    ~(requirement : route_requirement)
+    (runtimes : t list)
     (lanes : Runtime_lane.t list)
-    (structured_judge_id : string option) : (unit, string) result =
-  let supports_structured (runtime : t) =
-    match runtime.model.capabilities with
-    | Some caps -> caps.supports_structured_output
-    | None -> false
-  in
-  match structured_judge_id with
+    (route_id : string option) : (unit, string) result =
+  match route_id with
   | None -> Ok ()
   | Some id ->
-    (match find_declared_lane lanes id with
-     | Some lane ->
+    (match find_declared_lane lanes id, requirement with
+     | Some _, Resolves_only ->
+       (* [validate_lanes] already guaranteed every candidate id resolves. *)
+       Ok ()
+     | Some lane, Declares_capability { key; supported_by } ->
        validate_lane_candidates_capability
          ~config_path
-         ~route_name:"structured_judge"
-         ~capability_key:"supports-structured-output"
-         ~runtime_supports:supports_structured
+         ~route_name
+         ~capability_key:key
+         ~runtime_supports:supported_by
          runtimes
          lane
-     | None ->
-    (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
-     | None ->
-       Error
-         (Printf.sprintf
-            "%s: [runtime].structured_judge = %S%s"
-            config_path
-            id
-            (unresolved_runtime_suffix ~dropped_bindings
-               ~runtime_count:(List.length runtimes) id))
-     | Some runtime ->
-       if supports_structured runtime
-       then Ok ()
-       else
+     | None, _ ->
+       (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
+        | None ->
           Error
             (Printf.sprintf
-               "%s: [runtime].structured_judge = %S uses model %S, which does \
-                not declare supports-structured-output"
+               "%s: [runtime].%s = %S%s"
                config_path
+               route_name
                id
-               runtime.model.id)))
+               (unresolved_runtime_suffix
+                  ~dropped_bindings
+                  ~runtime_count:(List.length runtimes)
+                  id))
+        | Some runtime ->
+          (match requirement with
+           | Resolves_only -> Ok ()
+           | Declares_capability { key; supported_by } ->
+             if supported_by runtime
+             then Ok ()
+             else
+               Error
+                 (Printf.sprintf
+                    "%s: [runtime].%s = %S uses model %S, which does not declare %s"
+                    config_path
+                    route_name
+                    id
+                    runtime.model.id
+                    key))))
 ;;
 
 (* [runtime].media_failover (RFC-0265) validates each id in the ordered list: an
@@ -971,26 +940,48 @@ let materialize_config
   let* () =
     validate_keeper_assignments ~config_path ~dropped_bindings runtimes assignments
   in
-  let* () =
-    validate_memory_os_consolidation_runtime
-      ~config_path
-      ~dropped_bindings
-      runtimes
-      cfg.memory_os_consolidation_runtime_id
-  in
-  (* Lanes are materialized before the judge/verifier route validations so a
-     route id can name a lane (#25394); candidate resolution is enforced by
-     [validate_lanes] inside [lanes_of_decls]. *)
+  (* Lanes are materialized before every route validation so any route id can
+     name a lane (#25394); candidate resolution is enforced by [validate_lanes]
+     inside [lanes_of_decls]. memory_os_consolidation used to be validated above
+     this point, which is the only reason it could not name a lane. *)
   let* lanes =
     lanes_of_decls ~config_path ~dropped_bindings runtimes cfg.lane_decls
   in
   let* () =
-    validate_structured_judge_runtime ~config_path ~dropped_bindings runtimes
+    validate_route_runtime
+      ~config_path
+      ~dropped_bindings
+      ~route_name:"memory_os_consolidation"
+      ~requirement:Resolves_only
+      runtimes
+      lanes
+      cfg.memory_os_consolidation_runtime_id
+  in
+  let* () =
+    validate_route_runtime
+      ~config_path
+      ~dropped_bindings
+      ~route_name:"structured_judge"
+      ~requirement:
+        (Declares_capability
+           { key = "supports-structured-output"
+           ; supported_by = model_supports_structured_output
+           })
+      runtimes
       lanes
       cfg.structured_judge_runtime_id
   in
   let* () =
-    validate_cross_verifier_runtime ~config_path ~dropped_bindings runtimes
+    validate_route_runtime
+      ~config_path
+      ~dropped_bindings
+      ~route_name:"cross_verifier"
+      ~requirement:
+        (Declares_capability
+           { key = "supports-response-format-json"
+           ; supported_by = model_supports_response_format_json
+           })
+      runtimes
       lanes
       cfg.cross_verifier_runtime_id
   in

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2266,6 +2266,42 @@ let test_structured_judge_lane_shadow_precedence () =
       check bool "error names the incapable shadow candidate" true
         (String_util.contains_substring msg "local.jsononly"))
 
+(* memory_os_consolidation was validated before lanes_of_decls ran, so it was the
+   one route that could not name a lane while structured_judge and cross_verifier
+   could. It is now validated after lanes are materialised, with the same
+   lane-over-runtime precedence [resolve_assignment] applies. Its requirement is
+   Resolves_only, so a candidate without declared capabilities is admissible —
+   that is the difference from the judge and verifier lanes. *)
+let test_memory_os_consolidation_lane_target () =
+  with_fake_runtime_model_catalog @@ fun () ->
+  let lane_target =
+    judge_lane_base
+    ^ "memory_os_consolidation = \"consolidators\"\n\
+       \n\
+       [runtime.lanes.consolidators]\n\
+       strategy = \"ordered\"\n\
+       candidates = [\"local.chat\", \"local.judge\"]\n"
+  in
+  with_temp_runtime_toml lane_target (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg ->
+      failf "lane-targeted memory_os_consolidation should load: %s" msg
+    | Ok (_, _, _, _, _, _, _, lanes) ->
+      check bool "consolidators lane is materialized" true
+        (List.exists
+           (fun lane -> String.equal (Runtime_lane.id lane) "consolidators")
+           lanes));
+  (* An unknown id stays an operator typo whether or not lanes exist. *)
+  with_temp_runtime_toml
+    (judge_lane_base ^ "memory_os_consolidation = \"local.absent\"\n")
+    (fun path ->
+      match Runtime.load_list ~config_path:path with
+      | Ok _ ->
+        failf "unknown [runtime].memory_os_consolidation id must still be rejected"
+      | Error msg ->
+        check bool "error names the route" true
+          (String_util.contains_substring msg "memory_os_consolidation"))
+
 let test_cross_verifier_lane_target () =
   with_fake_runtime_model_catalog @@ fun () ->
   let json_capable_lane =
@@ -2776,6 +2812,9 @@ let () =
           test_case
             "[runtime].cross_verifier accepts JSON-capable lanes"
             `Quick test_cross_verifier_lane_target;
+          test_case
+            "[runtime].memory_os_consolidation accepts a lane id"
+            `Quick test_memory_os_consolidation_lane_target;
           test_case
             "save_config_text validates and refreshes cross_verifier runtime"
             `Quick test_save_config_text_refreshes_cross_verifier_runtime;


### PR DESCRIPTION
## 왜

`runtime.ml` 이 `memory_os_consolidation`, `structured_judge`, `cross_verifier` 를 **거의 동일한 세 함수**로 검증했다. 차이는 경로 이름, capability key, capability 접근자 **세 값**뿐이고 능력 순회는 이미 `validate_lane_candidates_capability` 로 공유돼 있었다 — 중복된 것은 래퍼뿐이었다.

## 무엇을

셋을 `validate_route_runtime` 하나로 합치고 요구사항을 **닫힌 variant** 로 매개화했다:

```ocaml
type route_requirement =
  | Resolves_only
  | Declares_capability of { key : string; supported_by : t -> bool }
```

옵셔널 인자가 아니라 닫힌 variant 인 이유: 능력이 필요 없는 경로는 **그렇다고 말해야** 하고, 호출자가 파라미터를 생략했는지에 결과가 달라지면 안 된다. 이 실패 모드는 이 저장소에서 지금 라이브다 — `exact_execution_guard` 가 8개 층을 `?optional` 로 통과하는데 바닥에서는 필수이고, 부재가 일반 거부로만 드러난다 (#25713).

## 부수적으로 고친 비대칭

`memory_os_consolidation` 은 `lanes_of_decls` 가 실행되기 **전에** 검증됐다. 그래서 다른 두 경로는 lane id 를 지명할 수 있는데 이 경로만 불가능했다 — 근거가 코드에 없다. 이제 lane 이 materialize 된 뒤에 검증되므로 **모든 경로가 소비자와 같은 방식으로 id 를 해석**한다 (`resolve_assignment` 의 lane 우선).

## 동작 변화

- 에러 메시지가 `[runtime].<route> = ...` 로 통일된다. **이전 문구를 단정하는 테스트는 없다** — 기존 테스트는 `Ok`/`Error` 를 단정하고 그 단정은 그대로 성립한다: 미지 id 거부, `None` 은 `[runtime].default` 상속, 능력 미선언 런타임은 여전히 거부.
- `memory_os_consolidation` 이 lane id 를 지명할 수 있게 된다 (위 비대칭 제거).

## 이것이 무엇을 고치지 않는가

capability 접근자의 `| None -> false` 는 **그대로 옮겼다**. 능력 미선언을 거부로 압축하는 것이 옳은지 — 즉 배제가 아니라 정렬이어야 하는지 — 는 형식 축의 별개 질문이고, 이 PR 이후 **고칠 자리가 2곳에서 1곳으로** 줄어든다.

그 형식 축 변경에는 선행조건이 있다는 것도 함께 기록해 둔다: `lib/runtime/runtime_attempt_fsm.ml:20-28` 은 failover 를 `http_error` 만으로 판단하는데, OAS 는 형식 불일치를 `lib/llm_provider/exact_output.ml:384-387` 에서 HTTP 호출 **전에** 거부하고 `Json_syntax_unavailable` / `Output_requirement_rejected` 는 masc `lib/` 에 이름이 없다. 따라서 수용만 완화하면 배제는 사라지고 failover 는 생기지 않는다.

## 검증

- `lib/runtime/runtime.ml` `ocamlformat` 파싱 통과. 세 옛 이름의 잔여 참조 0건 (`rg` 확인, `lib/` + `test/`). `runtime.mli` 는 셋 중 어느 것도 노출하지 않았으므로 인터페이스 변경 없음.
- 변경 규모: 1파일, +110 −119.
- **로컬 타입체크 안 함**: 공유 opam 스위치가 `agent_sdk.0.223.1` 을 들고 있고 핀은 `45473aae` (= `0.222.2`) 다. `lib/runtime` 은 이 PR 이 건드리지 않은 `lib/runtime/runtime_exact_output_registry.ml:434` (`Unbound constructor Exact_output.Missing_target_credential`) 에서 먼저 실패한다. 타입체크 권위는 CI.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. 변경은 `lib/runtime` 의 설정 수용 검증 하나이며, 새 추상화를 만드는 대신 이미 공유돼 있던 `validate_lane_candidates_capability` 위에 래퍼를 하나로 접었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEwRSse6KzFf9MnVGkjbH
