### PR TITLE
fix(keeper): lease 없는 compaction 실패가 재시도 예산을 소모하지 않았다

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1593,34 +1593,6 @@ let run_keepalive_unified_turn
              ~lease
              !cycle_outcome_ref
          in
-         (* RFC-0351 S0 / #25461: advance the compaction streak the settlement
-            above just read. Ordering matters — the settlement decides
-            requeue-vs-escalate from the streak *before* this failure, and this
-            stamp records the failure for the next cycle. *)
-         (let compaction_outcome =
-            compaction_outcome_of_cycle_outcome !cycle_outcome_ref
-          in
-          match compaction_outcome with
-          | None -> ()
-          | Some `Recovered
-            when meta_after_triage.runtime.compaction_rt.consecutive_failures
-                 = 0 ->
-            (* Streak already clear: skip the read-modify-write that every
-               healthy completed turn would otherwise pay. *)
-            ()
-          | Some outcome ->
-            (match
-               Keeper_meta_store.persist_compaction_outcome
-                 ctx.config
-                 ~keeper_name:meta_after_triage.name
-                 ~outcome
-             with
-             | Ok (`Persisted | `No_durable_meta) -> ()
-             | Error message ->
-               Log.Keeper.warn
-                 "compaction outcome counter not persisted keeper=%s: %s"
-                 meta_after_triage.name
-                 message));
          (match
             settle_claimed_lease
               ~exact_execution:true
@@ -1670,6 +1642,45 @@ let run_keepalive_unified_turn
               detail;
             record_settlement_failure detail;
             check_cancellation_after_exact_terminal_settlement settlement));
+      (* RFC-0351 S0 / #25461: advance the compaction streak the settlement above
+         just read. Ordering still holds — [settlement_of_cycle_outcome] reads the
+         streak from [meta_after_triage] before this stamp, so requeue-vs-escalate
+         still decides on the count before this failure.
+
+         Hoisted out of the [Some lease] branch. A failure has to consume retry
+         budget whether or not the cycle happened to own an event-queue lease.
+         While this ran inside that branch, a keeper that claimed no lease could
+         neither compact — [dispatch_guard] is [None] without a lease, so the
+         summarizer rejects with an absent exact-execution guard — nor accumulate
+         the streak that would eventually suspend it. Measured 2026-07-25: two
+         keepers at 306 and 368 failed context_compacted attempts with
+         consecutive_failures = 0, retrying without bound, while keepers that did
+         hold a lease reached the ceiling at 21 and 3 and settled. Compaction
+         failures already map to [`Failed] (keeper_unified_turn.ml:448 ->
+         compaction_outcome_of_cycle_outcome), so nothing else was suppressing it. *)
+      (let compaction_outcome =
+         compaction_outcome_of_cycle_outcome !cycle_outcome_ref
+       in
+       match compaction_outcome with
+       | None -> ()
+       | Some `Recovered
+         when meta_after_triage.runtime.compaction_rt.consecutive_failures = 0 ->
+         (* Streak already clear: skip the read-modify-write that every healthy
+            completed turn would otherwise pay. *)
+         ()
+       | Some outcome ->
+         (match
+            Keeper_meta_store.persist_compaction_outcome
+              ctx.config
+              ~keeper_name:meta_after_triage.name
+              ~outcome
+          with
+          | Ok (`Persisted | `No_durable_meta) -> ()
+          | Error message ->
+            Log.Keeper.warn
+              "compaction outcome counter not persisted keeper=%s: %s"
+              meta_after_triage.name
+              message));
       { meta = meta_after_cycle
       ; cycle_status =
           if !settlement_failed then Turn_cycle_crashed else Turn_cycle_completed

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2019,6 +2019,38 @@ let with_temp_dir prefix f =
    path, the second unbounded loop, also follows the completed turn. A
    turn that did not complete keeps its ordinary typed settlement, so
    delivery is still retried. *)
+(* A compaction failure has to consume retry budget whether or not the cycle owned
+   an event-queue lease. keeper_heartbeat_loop.ml advances the streak after the
+   lease match rather than inside its [Some lease] branch, and
+   persist_compaction_outcome is the mechanism — which had no test.
+
+   Measured 2026-07-25: two keepers sat at 306 and 368 failed context_compacted
+   attempts with consecutive_failures = 0 and retried without bound, because the
+   advance was unreachable without a lease, while keepers that held one reached the
+   ceiling at 21 and 3 and settled. *)
+let test_compaction_failure_advances_streak_without_lease () =
+  with_temp_dir "compaction-streak-no-lease" @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  ignore (Masc.Workspace.init config ~agent_name:None : string);
+  let meta = cycle_meta () in
+  Result.get_ok (Masc.Keeper_meta_store.write_meta config meta);
+  (match
+     Masc.Keeper_meta_store.persist_compaction_outcome
+       config
+       ~keeper_name:meta.name
+       ~outcome:`Failed
+   with
+   | Ok (`Persisted | `No_durable_meta) -> ()
+   | Error message -> Alcotest.failf "persist compaction outcome: %s" message);
+  match Masc.Keeper_meta_store.read_meta config meta.name with
+  | Error message -> Alcotest.failf "read meta back: %s" message
+  | Ok None -> Alcotest.fail "meta disappeared after persisting the outcome"
+  | Ok (Some stored) ->
+    Alcotest.(check int)
+      "a compaction failure advances the streak"
+      1
+      stored.runtime.compaction_rt.consecutive_failures
+
 let test_approved_wake_settles_on_delivery_not_consumption () =
   with_temp_dir "approval-delivery-ack" @@ fun base_path ->
   ignore (Masc.Keeper_approval_queue.install_persistence ~base_path);
@@ -3454,6 +3486,10 @@ let () =
             "approved wake settles on delivery not consumption"
             `Quick
             test_approved_wake_settles_on_delivery_not_consumption
+        ; Alcotest.test_case
+            "a compaction failure advances the streak without a lease"
+            `Quick
+            test_compaction_failure_advances_streak_without_lease
         ; Alcotest.test_case
             "current state codec reads its own output"
             `Quick


### PR DESCRIPTION
## 증상

라이브 실측 (2026-07-25, `masc_keeper_status` + runtime-manifest 전수):

| keeper | 실패 시도 | `consecutive_failures` | 결과 |
|---|---|---|---|
| `apc-alpha` | 306 | **0** | 무한 재시도 |
| `apc-beta` | 368 | **0** | 무한 재시도 |
| `garnet` | — | 21 | 서스펜드 |
| `taskmaster` | — | 3 | 서스펜드 |

전 키퍼 `context_compacted` 이벤트 **881 시도, 성공 0** (전부 `retryable_failure`).

## 원인

스트릭을 전진시키는 블록이 `lib/keeper/keeper_heartbeat_loop.ml` 의 lease match 중 **`| Some lease ->` 분기 안**에 있었다. lease 를 잡지 못한 사이클은 그 블록에 **구문상 도달할 수 없다**.

그리고 그것은 compaction 이 불가능해지는 **같은 조건**이다: lease 가 없으면 `dispatch_guard = None` (`:1363-1371`) 이므로 summarizer 가 exact-execution guard 부재로 거부한다 (`keeper_compaction_llm_summarizer.ml:836-838`). 즉 **하나의 조건이 무관한 두 성질을 게이팅**했다 — 압축 가능 여부와, 실패가 서스펜션으로 집계되는지 여부.

lease 는 `keeper_heartbeat_stimulus_intake.ml:347-361` 에서 `claim_when_result ~ready:stimulus_ready_for_intake` 로만 획득된다. 오버플로로 매 턴 실패하는 키퍼는 stimulus 를 만들지 못하므로 lease 를 얻지 못한다 — **압축이 가장 필요한 집합이 압축도 못 하고 멈추지도 않는다.**

## 수정

전진 블록을 lease match **전체 뒤**로 옮겼다. 호출 지점은 여전히 한 곳이다.

**순서 계약 유지**: `settlement_of_cycle_outcome` 가 `meta_after_triage` 에서 스트릭을 읽어 requeue-vs-escalate 를 정하고, 그 읽기는 이 스탬프보다 앞선다. 원래 주석이 요구한 "settlement decides … from the streak *before* this failure" 가 그대로 성립한다.

**다른 억제 요인은 없다**: `keeper_unified_turn.ml:448` 이 압축 시도 실패를 `Requeue_after_context_compaction (Compaction_attempt_failed _)` 로 분류하고, `compaction_outcome_of_cycle_outcome` (`:577-580`) 이 그것을 `Some \`Failed` 로 매핑한다. `None` 으로 가는 세 disposition (`Follow_failure_route`, `Acknowledge_after_in_turn_handling`, `Pause_after_transcript_corruption`) 은 압축과 무관한 턴 실패이며 그 제외는 의도다.

## 이것이 무엇을 고치지 않는가

**압축이 성공하게 되지는 않는다.** 실패가 **유한**해질 뿐이다 — 압축할 수 없는 키퍼가 영원히 재시도하지 않고 서스펜드된다. 나머지 절반(압축의 지속성 권한을 stimulus lease 에서 분리)은 #25713 이다.

검증 지표: 하네스 게이트 G-6 이 `<성공>/<시도> manifest attempts` 를 출력한다 (현재 `0/881`, 3분마다 100건 이상 증가). 이 PR 이 들어가면 **분모 증가가 멈춰야** 한다. 분자는 #25713 이 필요하다.

## 테스트

`persist_compaction_outcome` 은 테스트가 없었다 (`rg` 확인: 테스트 파일에는 `compaction_outcome_of_cycle_outcome` 만). 실패가 스트릭을 전진시킨다는 것을 고정하는 테스트를 추가했다. hoist 자체(호출 지점의 위치)는 유닛 테스트 접점이 없으므로 CI 빌드와 기존 루프 테스트가 커버한다 — 그 사실을 숨기지 않고 적어 둔다.

## 검증

- 두 파일 `ocamlformat` 파싱 통과. `persist_compaction_outcome` 호출은 `keeper_heartbeat_loop.ml` 에 **한 곳**으로 유지.
- **로컬 타입체크 안 함**: 공유 opam 스위치가 `agent_sdk.0.223.1` 을 들고 있고 핀은 `45473aae` (= `0.222.2`) 다. 타입체크 권위는 CI.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. 변경은 실패 회계의 도달 가능성 하나이며, 기존 블록을 그대로 옮기고 새 추상화를 만들지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEwRSse6KzFf9MnVGkjbH
