### PR TITLE
chore(keeper): 어디에도 배선되지 않은 형식 티어를 제거한다

### DIFF
--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -305,50 +305,6 @@ let without_response_format (provider_cfg : Llm_provider.Provider_config.t) =
    response format; the tool schema carries the verdict enum SSOT. *)
 let anti_rationalization_reviewer_provider_config = without_response_format
 
-(* Capability-aware three-tier response-format selection for a request whose
-   prompt already states the exact output shape (#25266). Tier 1: a provider
-   that supports strict [json_schema] gets the schema enforced. Tier 2: a
-   provider that supports only [json_object] JSON mode (GLM/DeepSeek/Kimi —
-   the OpenAI-compat endpoints that reject json_schema) gets [JsonMode], which
-   at least forces syntactically valid JSON; the caller's prompt carries the
-   schema and the caller validates the parse, so the missing strict guarantee
-   is covered. Tier 3: neither — prompt only. Without tier 2 every
-   json_object-only provider is silently dropped from structured lanes,
-   leaving the single json_schema-capable native endpoint (minimax) as a SPOF.
-   Use ONLY where the prompt states the schema and the parse is validated
-   downstream; [apply_to_provider_config] stays the strict default.
-
-   CONTRACT (#25324): the OpenAI-compatible [json_object] response format
-   requires the request messages to contain the literal token "json"
-   (case-insensitive) or the endpoint returns HTTP 400. DeepSeek and Kimi
-   enforce this; GLM is lenient. This function only sets [response_format] on
-   [provider_cfg] and cannot see the messages, so any caller that reaches the
-   JsonMode tier MUST include a "json" token in its prompt. The compaction
-   summarizer does so in [Keeper_compaction_llm_summarizer.messages_for_plan]
-   (locked by test_compaction_llm_summarizer). *)
-let apply_schema_json_mode_or_prompt_tier ~log_label schema provider_cfg =
-  let native_cfg = apply_to_provider_config schema provider_cfg in
-  match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
-  | Ok () -> native_cfg
-  | Error detail ->
-    (match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
-     | Some caps when caps.Llm_provider.Capabilities.supports_response_format_json ->
-       Log.Keeper.info
-         "%s: json_object tier (native schema unavailable: %s)"
-         log_label
-         detail;
-       { provider_cfg with
-         response_format = Agent_sdk.Types.JsonMode
-       ; output_schema = None
-       }
-     | _ ->
-       Log.Keeper.info
-         "%s: prompt tier (native schema and json mode unavailable: %s)"
-         log_label
-         detail;
-       provider_cfg)
-;;
-
 let validate_provider_config schema provider_cfg =
   provider_cfg
   |> apply_to_provider_config schema
@@ -366,15 +322,6 @@ let provider_config_accepts_schema schema provider_cfg =
    fallback exists but is not sufficient for eligibility: a provider with
    neither capability is filtered out, matching the pre-#25266 fail-closed
    behavior for that case. *)
-let provider_config_accepts_schema_or_json_mode schema provider_cfg =
-  match validate_provider_config schema provider_cfg with
-  | Ok () -> true
-  | Error _ ->
-    (match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
-     | Some caps -> caps.Llm_provider.Capabilities.supports_response_format_json
-     | None -> false)
-;;
-
 let for_deterministic_subcall ~max_tokens (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
     Llm_provider.Provider_config.max_tokens

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -70,17 +70,6 @@ val anti_rationalization_reviewer_provider_config
     rejected json_object-only providers, leaving every task nonterminal
     (2026-07-21 live incident). *)
 
-val apply_schema_json_mode_or_prompt_tier
-  :  log_label:string
-  -> Yojson.Safe.t
-  -> Llm_provider.Provider_config.t
-  -> Llm_provider.Provider_config.t
-(** Three-tier response-format selection (#25266): enforce [schema] when the
-    provider supports strict json_schema; else set JSON mode ([JsonMode]) when
-    the provider supports json_object; else prompt only. Use ONLY where the
-    prompt already states the schema and the parser validates the response —
-    the json_object tier drops the strict guarantee. *)
-
 val validate_provider_config
   :  Yojson.Safe.t
   -> Llm_provider.Provider_config.t
@@ -92,14 +81,6 @@ val provider_config_accepts_schema
   -> Llm_provider.Provider_config.t
   -> bool
 (** True when [validate_provider_config] accepts [provider_cfg]. *)
-
-val provider_config_accepts_schema_or_json_mode
-  :  Yojson.Safe.t
-  -> Llm_provider.Provider_config.t
-  -> bool
-(** True when the provider can enforce [schema] (strict) OR honor JSON mode
-    (#25266). Eligibility gate for structured lanes that have a
-    json_object fallback; a provider with neither capability is rejected. *)
 
 val for_deterministic_subcall
   :  max_tokens:int option
@@ -125,5 +106,4 @@ val for_deterministic_subcall
     room than a per-turn summary); everything else is not.
 
     This does NOT apply the response-format/schema tier — sites differ there
-    and compose {!without_response_format} or
-    {!apply_schema_json_mode_or_prompt_tier} themselves. *)
+    and compose {!without_response_format} themselves. *)

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -177,61 +177,6 @@ let test_without_response_format_is_capability_independent () =
    prompt tier. [prompt_tier_oas_provider_config] is exactly this shape:
    openai_compat_chat_extended has response_format_json=true, and it disables
    only structured_output. *)
-let test_json_mode_tier_selects_json_mode_for_json_object_only () =
-  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
-  let base = prompt_tier_oas_provider_config () in
-  let configured =
-    Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-      ~log_label:"test json_mode"
-      schema
-      base
-  in
-  check bool "json_object-only provider gets JsonMode" true
-    (match configured.Llm_provider.Provider_config.response_format with
-     | Agent_sdk.Types.JsonMode -> true
-     | Agent_sdk.Types.JsonSchema _ | Agent_sdk.Types.Off -> false);
-  check (option bool) "JsonMode carries no output_schema" None
-    (Option.map
-       (Yojson.Safe.equal schema)
-       configured.Llm_provider.Provider_config.output_schema)
-
-let test_json_mode_tier_uses_native_schema_when_supported () =
-  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
-  let base = schema_capable_oas_provider_config () in
-  let configured =
-    Keeper_structured_output_schema.apply_schema_json_mode_or_prompt_tier
-      ~log_label:"test native over json_mode"
-      schema
-      base
-  in
-  check bool "schema-capable provider still gets strict json_schema" true
-    (has_json_schema_response_format schema configured)
-
-let test_accepts_schema_or_json_mode_admits_json_object_only () =
-  let schema = Keeper_structured_output_schema.librarian_episode_output_schema in
-  (* json_schema-capable and json_object-only are both eligible; neither is not. *)
-  check bool "json_schema provider is eligible" true
-    (Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
-       schema (schema_capable_oas_provider_config ()));
-  check bool "json_object-only provider is eligible" true
-    (Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
-       schema (prompt_tier_oas_provider_config ()));
-  let neither =
-    Llm_provider.Provider_config.make
-      ~kind:Llm_provider.Provider_config.OpenAI_compat
-      ~model_id:"neither-ratchet"
-      ~base_url:"https://neither.invalid/v1"
-      ~model_capabilities_override:
-        { Llm_provider.Capabilities.openai_compat_chat_extended_capabilities with
-          supports_structured_output = false
-        ; supports_response_format_json = false
-        }
-      ()
-  in
-  check bool "provider with neither capability is rejected" false
-    (Keeper_structured_output_schema.provider_config_accepts_schema_or_json_mode
-       schema neither)
-
 let test_operator_remote_tool_name_ssot_matches_remote_schemas () =
   let schema_names =
     Operator_tool.remote_schemas
@@ -534,18 +479,6 @@ let () =
             "without_response_format is capability-independent"
             `Quick
             test_without_response_format_is_capability_independent
-        ; test_case
-            "json_mode tier selects JsonMode for json_object-only provider"
-            `Quick
-            test_json_mode_tier_selects_json_mode_for_json_object_only
-        ; test_case
-            "json_mode tier still uses strict schema when supported"
-            `Quick
-            test_json_mode_tier_uses_native_schema_when_supported
-        ; test_case
-            "accepts-schema-or-json-mode admits json_object-only, rejects neither"
-            `Quick
-            test_accepts_schema_or_json_mode_admits_json_object_only
         ] )
     ; ( "dashboard schemas"
       , [ test_case


### PR DESCRIPTION
## 무엇이 죽어 있었나

`lib/keeper/keeper_structured_output_schema.ml` 이 3-tier 응답 형식 선택과 그 적격 판정을 들고 있었다. 둘 다 `.mli` 로 노출되고 테스트도 있는데, `_build` / `.git` 을 제외한 **전 저장소에서 호출자가 테스트뿐** 이다:

```
apply_schema_json_mode_or_prompt_tier        → .ml, .mli, test
provider_config_accepts_schema_or_json_mode  → .ml, .mli, test
```

티어 위 주석(`:308-319`)이 그것이 막는 것을 설명한다:

> Without tier 2 every json_object-only provider is silently dropped from structured lanes, leaving the single json_schema-capable native endpoint (minimax) as a SPOF.

**그 수정은 작성·문서화·테스트됐고 dispatch 경로에 연결되지 않았다.**

## 배선이 아니라 제거를 택한 이유

프로덕션 경로가 wire 응답 형식을 **요청하지 않는다**. `cross_verifier` 는 `anti_rationalization.ml:243-248` 경유로 `keeper_structured_output_schema.ml:306` 의 `without_response_format` 을, `structured_judge` 는 `keeper_failure_judge.ml:71-72` 의 같은 변환을 쓴다. 따라서 티어가 선택할 대상이 없다.

배선하면 역할 dispatch 에 형식 기반 분기를 되돌려 놓는 것이며, 그것은 runtime-indifference 작업이 제거하고 있는 방향이다. SPOF 우려는 유효하지만 해법이 다르다 — 후보 순서는 OAS 의 flow candidate walk 가 담당한다 (`oas/lib/llm_provider/exact_output.mli:126-132` `candidate_rejection_disposition`, `exact_output.ml:291-300` 의 `next`).

## 건드리지 않은 것

`provider_config_accepts_schema` (한 줄 아래) 는 **살아 있다** — `keeper_vision_tool.ml` 이 호출한다. 그대로 둔다.

## 테스트

제거한 3건은 제거한 두 함수만 검증한다. 따라서 **어떤 동작도 커버리지를 잃지 않는다** — 죽은 함수를 테스트하는 것은 무엇의 커버리지도 아니다.

## 게이트 영향

하네스 게이트 G-3(형식 무차별)의 남은 두 사이트가 이것들이다. `runtime.ml` 의 두 사이트는 #25719 가 별도로 처리하므로, 둘이 합쳐지면 G-3 이 **0 → PASS** 가 된다 — 이 세션에서 실제 코드 변경으로 FAIL→PASS 가 되는 첫 게이트다.

## 검증

3파일 `ocamlformat` 파싱 통과. `rg --no-ignore` 로 전 저장소에 잔여 참조 0건 확인. **로컬 타입체크 안 함** — 공유 opam 스위치가 `agent_sdk.0.223.1`, 핀은 `45473aae` (= `0.222.2`). 제거하지 못한 참조가 있으면 CI 빌드에서 드러난다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. 죽은 표면 제거이며 새 추상화를 만들지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEwRSse6KzFf9MnVGkjbH
