### PR TITLE
feat(compaction): 측정형 용량 초과 트리거 — [BLOCKED: oas#2808 + 핀 bump]

### DIFF
--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -1,9 +1,30 @@
+type capacity_dimension =
+  | Input_tokens
+  | Serialized_bytes
+
 type t =
   | Provider_overflow of { limit_tokens : int option }
+  | Measured_capacity_exceeded of
+      { dimension : capacity_dimension
+      ; measured : int
+      ; limit : int
+      }
   | Manual
+
+let dimension_to_string = function
+  | Input_tokens -> "input_tokens"
+  | Serialized_bytes -> "serialized_bytes"
+;;
+
+let dimension_of_string = function
+  | "input_tokens" -> Some Input_tokens
+  | "serialized_bytes" -> Some Serialized_bytes
+  | _ -> None
+;;
 
 let to_label = function
   | Provider_overflow _ -> "provider_overflow"
+  | Measured_capacity_exceeded _ -> "measured_capacity_exceeded"
   | Manual -> "manual"
 ;;
 
@@ -14,6 +35,12 @@ let to_human = function
       (match limit_tokens with
        | Some limit_tokens -> string_of_int limit_tokens
        | None -> "unknown")
+  | Measured_capacity_exceeded { dimension; measured; limit } ->
+    Printf.sprintf
+      "measured_capacity_exceeded(dimension=%s,measured=%d,limit=%d)"
+      (dimension_to_string dimension)
+      measured
+      limit
   | Manual -> "manual"
 ;;
 
@@ -25,6 +52,13 @@ let to_detail_json : t -> Yojson.Safe.t = function
         , match limit_tokens with
           | Some limit_tokens -> `Int limit_tokens
           | None -> `Null )
+      ]
+  | Measured_capacity_exceeded { dimension; measured; limit } ->
+    `Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "dimension", `String (dimension_to_string dimension)
+      ; "measured", `Int measured
+      ; "limit", `Int limit
       ]
   | Manual -> `Assoc [ "kind", `String "manual" ]
 ;;
@@ -38,6 +72,10 @@ type decode_error =
   | Unknown_kind of string
   | Missing_provider_limit
   | Invalid_provider_limit
+  | Missing_measured_field of string
+  | Invalid_measured_field of string
+  | Unknown_dimension of string
+  | Measured_not_exceeding_limit
 
 let decode_error_to_string = function
   | Expected_object -> "compaction trigger detail must be an object"
@@ -51,6 +89,15 @@ let decode_error_to_string = function
   | Missing_provider_limit -> "provider overflow trigger is missing limit_tokens"
   | Invalid_provider_limit ->
     "provider overflow limit_tokens must be null or a positive integer"
+  | Missing_measured_field name ->
+    Printf.sprintf "measured capacity trigger is missing field %S" name
+  | Invalid_measured_field name ->
+    Printf.sprintf "measured capacity trigger field %S must be a positive integer" name
+  | Unknown_dimension dimension ->
+    Printf.sprintf "unknown capacity dimension %S" dimension
+  | Measured_not_exceeding_limit ->
+    "measured capacity trigger requires measured > limit; a value at the limit has \
+     not been exceeded"
 ;;
 
 let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
@@ -77,6 +124,28 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
           Ok (Provider_overflow { limit_tokens = Some limit_tokens })
         | None -> Error Missing_provider_limit
         | Some _ -> Error Invalid_provider_limit)
+     | Some (`String "measured_capacity_exceeded") ->
+       let* () = reject_unknown_fields [ "kind"; "dimension"; "measured"; "limit" ] in
+       let positive_int name =
+         match List.assoc_opt name fields with
+         | None -> Error (Missing_measured_field name)
+         | Some (`Int value) when value > 0 -> Ok value
+         | Some _ -> Error (Invalid_measured_field name)
+       in
+       let* dimension =
+         match List.assoc_opt "dimension" fields with
+         | None -> Error (Missing_measured_field "dimension")
+         | Some (`String raw) ->
+           (match dimension_of_string raw with
+            | Some dimension -> Ok dimension
+            | None -> Error (Unknown_dimension raw))
+         | Some _ -> Error (Invalid_measured_field "dimension")
+       in
+       let* measured = positive_int "measured" in
+       let* limit = positive_int "limit" in
+       if measured > limit
+       then Ok (Measured_capacity_exceeded { dimension; measured; limit })
+       else Error Measured_not_exceeding_limit
      | Some (`String "manual") ->
        let* () = reject_unknown_fields [ "kind" ] in
        Ok Manual

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -1,9 +1,27 @@
 (** Compaction_trigger — explicit context compaction request origin. *)
 
+type capacity_dimension =
+  | Input_tokens
+  | Serialized_bytes
+      (** The two dimensions are independent and differ in measurability.
+          [Serialized_bytes] is locally deterministic — serialize and count.
+          [Input_tokens] needs a provider count-tokens round trip, which only some
+          protocols offer. Neither is derived from the other. *)
+
 type t =
   | Provider_overflow of { limit_tokens : int option }
       (** Typed provider context-window overflow. [limit_tokens] is the
           provider-declared limit when present, never an estimated count. *)
+  | Measured_capacity_exceeded of
+      { dimension : capacity_dimension
+      ; measured : int
+      ; limit : int
+      }
+      (** A declared capacity was exceeded by a measurement, not by a provider
+          verdict. Both numbers come from whoever measured: [measured] is what the
+          request actually is on [dimension], [limit] is what the target declared.
+          [measured > limit] holds by construction — a value at the limit has not
+          been exceeded, and the decoder refuses a row that says otherwise. *)
   | Manual
 
 (** Closed label set for Otel_metric_store / SSE [trigger] label.
@@ -25,6 +43,10 @@ type decode_error =
   | Unknown_kind of string
   | Missing_provider_limit
   | Invalid_provider_limit
+  | Missing_measured_field of string
+  | Invalid_measured_field of string
+  | Unknown_dimension of string
+  | Measured_not_exceeding_limit
 
 val decode_error_to_string : decode_error -> string
 

--- a/test/compaction_trigger/dune
+++ b/test/compaction_trigger/dune
@@ -1,0 +1,12 @@
+; Deliberately NOT in test/dune. That stanza links masc_test_deps, which pulls the
+; agent_sdk chain; this leaf needs only yojson, so keeping it separate lets the
+; codec be built and run while the shared opam switch holds a different agent_sdk
+; than the pin. Same reason lib/compaction_trigger/dune stays a leaf.
+
+(include_subdirs no)
+
+(test
+ (name test_compaction_trigger_codec)
+ (flags
+  (:standard -w +4))
+ (libraries masc_compaction_trigger yojson))

--- a/test/compaction_trigger/test_compaction_trigger_codec.ml
+++ b/test/compaction_trigger/test_compaction_trigger_codec.ml
@@ -1,0 +1,132 @@
+(* Codec conformance for Compaction_trigger, including the measured-capacity origin.
+
+   of_detail_json is documented as the exact inverse of to_detail_json, so every
+   variant is round-tripped rather than only encoded. The rejection cases matter as
+   much as the round trips: a decoder that accepts a row it should refuse turns a
+   durable observation into a value nobody can trust. *)
+
+let failures = ref 0
+
+let check name condition =
+  if condition then print_endline ("ok   " ^ name)
+  else begin
+    incr failures;
+    print_endline ("FAIL " ^ name)
+  end
+;;
+
+let roundtrip name (trigger : Compaction_trigger.t) =
+  match Compaction_trigger.of_detail_json (Compaction_trigger.to_detail_json trigger) with
+  | Ok decoded -> check name (decoded = trigger)
+  | Error error ->
+    incr failures;
+    print_endline
+      ("FAIL " ^ name ^ ": " ^ Compaction_trigger.decode_error_to_string error)
+;;
+
+let rejects name json =
+  match Compaction_trigger.of_detail_json json with
+  | Error _ -> print_endline ("ok   " ^ name)
+  | Ok _ ->
+    incr failures;
+    print_endline ("FAIL " ^ name ^ ": accepted a row it must refuse")
+;;
+
+let () =
+  roundtrip "manual round-trips" Compaction_trigger.Manual;
+  roundtrip
+    "provider overflow with a declared limit round-trips"
+    (Compaction_trigger.Provider_overflow { limit_tokens = Some 1_048_576 });
+  roundtrip
+    "provider overflow without a limit round-trips"
+    (Compaction_trigger.Provider_overflow { limit_tokens = None });
+  roundtrip
+    "measured byte overflow round-trips"
+    (Compaction_trigger.Measured_capacity_exceeded
+       { dimension = Compaction_trigger.Serialized_bytes
+       ; measured = 453_515
+       ; limit = 262_144
+       });
+  roundtrip
+    "measured token overflow round-trips"
+    (Compaction_trigger.Measured_capacity_exceeded
+       { dimension = Compaction_trigger.Input_tokens; measured = 476_486; limit = 200_000 });
+
+  check
+    "measured trigger has its own label"
+    (String.equal
+       (Compaction_trigger.to_label
+          (Compaction_trigger.Measured_capacity_exceeded
+             { dimension = Compaction_trigger.Serialized_bytes
+             ; measured = 2
+             ; limit = 1
+             }))
+       "measured_capacity_exceeded");
+  check
+    "human rendering names the dimension and both numbers"
+    (String.equal
+       (Compaction_trigger.to_human
+          (Compaction_trigger.Measured_capacity_exceeded
+             { dimension = Compaction_trigger.Serialized_bytes
+             ; measured = 453_515
+             ; limit = 262_144
+             }))
+       "measured_capacity_exceeded(dimension=serialized_bytes,measured=453515,limit=262144)");
+
+  (* measured = limit is not an excess. Accepting it would let a trigger claim an
+     overflow that did not happen. *)
+  rejects
+    "measured equal to the limit is refused"
+    (`Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "dimension", `String "serialized_bytes"
+      ; "measured", `Int 100
+      ; "limit", `Int 100
+      ]);
+  rejects
+    "measured below the limit is refused"
+    (`Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "dimension", `String "serialized_bytes"
+      ; "measured", `Int 10
+      ; "limit", `Int 100
+      ]);
+  rejects
+    "an unknown dimension is refused rather than defaulted"
+    (`Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "dimension", `String "wall_clock"
+      ; "measured", `Int 200
+      ; "limit", `Int 100
+      ]);
+  rejects
+    "a missing dimension is refused"
+    (`Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "measured", `Int 200
+      ; "limit", `Int 100
+      ]);
+  rejects
+    "a non-positive measurement is refused"
+    (`Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "dimension", `String "input_tokens"
+      ; "measured", `Int 0
+      ; "limit", `Int 100
+      ]);
+  rejects
+    "an unknown field is refused"
+    (`Assoc
+      [ "kind", `String "measured_capacity_exceeded"
+      ; "dimension", `String "input_tokens"
+      ; "measured", `Int 200
+      ; "limit", `Int 100
+      ; "estimated", `Bool true
+      ]);
+
+  if !failures = 0 then print_endline "compaction trigger codec: all checks passed"
+  else begin
+    print_endline (Printf.sprintf "compaction trigger codec: %d failed" !failures);
+    exit 1
+  end
+;;


### PR DESCRIPTION
> **이 PR 은 단독으로 머지하면 안 된다.** 라이즈 지점이 OAS 변경에 의존한다 (아래 §의존성). 하네스 게이트 G-5 가 선언과 raise 를 구별하므로, 지금 머지하면 `1/2 declared, matched in N place(s), never raised` 로 남는다 — 그 판정이 옳다.

## 무엇이 없었나

`Compaction_trigger.t` 의 두 origin 은 **둘 다 반응형** 이다. `Provider_overflow` 는 provider 가 typed overflow 를 반환할 때만 만들어지고, `Manual` 은 운영자 행위다. **"측정 결과 요청이 선언된 상한을 넘었다"** 를 표현하는 origin 이 없다 — 그래서 OAS 가 dispatch 전에 판정하는 용량 거부가 될 트리거가 없다.

## 변경

```ocaml
type capacity_dimension = Input_tokens | Serialized_bytes

| Measured_capacity_exceeded of
    { dimension : capacity_dimension
    ; measured : int
    ; limit : int
    }
```

두 차원은 **독립이고 측정 가능성이 다르다**. `Serialized_bytes` 는 직렬화 후 카운트라 로컬 결정론이고, `Input_tokens` 는 provider 의 count-tokens 왕복이 필요해 일부 protocol 만 가능하다. 하나로 다른 하나를 유도하지 않으므로 트리거가 **어느 차원을 측정했는지** 명시한다.

`measured > limit` 는 구성상 성립하며 **디코더가 강제한다**. 상한과 같은 값은 초과가 아니고, 그런 행을 받아주면 durable observation 이 일어나지 않은 초과를 주장하게 된다.

## 검증 (로컬)

이 leaf 는 `yojson` 만 의존하므로 masc 의 핀 경합과 무관하게 빌드된다:

- `dune build --root . lib/compaction_trigger` → 성공
- `dune build --root . @test/compaction_trigger/runtest` → **13/13 통과**, 왕복 5건 + 거부 8건 (상한과 같은 값 / 미달 / 미지 차원 / 차원 누락 / 비양수 측정값 / 미지 필드)

코덱 테스트를 `test/compaction_trigger/` 의 **별도 dune** 에 둔 이유: `test/dune` 은 `masc_test_deps` 를 링크해 agent_sdk 체인을 끌어온다. 공유 opam 스위치가 `agent_sdk.0.223.1` 을 들고 있고 핀은 `45473aae` (= `0.222.2`) 이므로, 격리해야 이 코덱을 실제로 돌려볼 수 있다 — `lib/compaction_trigger/dune` 이 leaf 인 것과 같은 이유다.

## 의존성 — 왜 지금 머지하면 안 되는가

라이즈 지점은 `lib/keeper/keeper_turn_runtime_budget.ml:407` 이다. 지금 그곳은 `Agent_sdk.Error.Api (ContextOverflow { limit; _ })` **만** 매치한다. 바이트 차원 초과는 `Request_body_too_large` 로 오는데, OAS 의 `error_domain.ml:94` 가 `InvalidRequest.reason` 을 버려서 masc 에 도달하지 못한다 (masc #25720 에 사슬 전문).

순서:

1. **oas#2808** — `` `Invalid_request `` 가 typed reason 을 보존 (OAS CI: `OCaml Format` pass, `Build & Test` 진행 중; 로컬 `dune build @test/runtest` exit 0 / `[FAIL]` 0)
2. `scripts/oas-agent-sdk-pin.sh` 핀 bump
3. **이 PR** + `keeper_turn_runtime_budget.ml:407` 에 arm 추가

2·3 을 먼저 올리면 매치할 생성자가 없어 빌드가 깨진다. 그래서 트리거만 먼저 검증해 두고 arm 은 핀 이후에 붙인다.

## 이 변경이 회귀를 막는 이유

선제 압축을 `manual_compaction_requested` 로 태우면 안 된다. `keeper_meta_store.ml:505-509` 가 기록한다 — operator-committed manual 은 스트릭을 **리셋** 하고 in-lane 반응형은 **전진** 시키며, 920B(0.07%) 만 줄이는 계획이 매 루프마다 카운터를 리셋해 압축 불가 키퍼가 천장에 도달하지 못한 사례가 있다. 트리거를 종류로 구별해야 outcome 매핑이 스트릭을 옳게 움직인다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. leaf 타입에 origin 하나와 그 코덱·테스트를 추가한 것이며 새 추상화를 만들지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEwRSse6KzFf9MnVGkjbH
