### PR TITLE
refactor(runtime): 라우팅 대상을 지명하는 모든 필드를 검증기 하나로

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -105,35 +105,6 @@ let unresolved_runtime_suffix ~(dropped_bindings : (string * string) list)
     fail-fast: [\[runtime\] default] 가 없거나 그 id 가 목록에 없으면 [Error].
     silent fallback 일절 없음 (runtime→Runtime 비전: TOML 에 default 없으면
     프로그램 실행 불가). *)
-(* RFC keeper→runtime assignment validation: every [[runtime.assignments]]
-   target must resolve to a configured runtime. An unknown id is an operator
-   error rejected at load (mirrors [runtime].default validation), NOT a silent
-   fallback to the default — that would mask a typo'd assignment
-   (Unknown→Permissive anti-pattern). A keeper *absent* from the table is the
-   intended designed fallback to the default and is handled at lookup time, not
-   here. *)
-let validate_keeper_assignments ~(config_path : string)
-    ~(dropped_bindings : (string * string) list) (runtimes : t list)
-    (assignments : (string * string) list) : (unit, string) result =
-  let runtime_exists id =
-    List.exists (fun (r : t) -> String.equal r.id id) runtimes
-  in
-  match
-    List.find_opt (fun (_, runtime_id) -> not (runtime_exists runtime_id)) assignments
-  with
-  | None -> Ok ()
-  | Some (keeper_name, runtime_id) ->
-    Error
-      (Printf.sprintf
-         "%s: [runtime.assignments].%s = %S%s"
-         config_path
-         keeper_name
-         runtime_id
-         (unresolved_runtime_suffix ~dropped_bindings
-            ~runtime_count:(List.length runtimes) runtime_id))
-;;
-
-
 (* Route ids resolve with lane precedence ([resolve_assignment] prefers a lane
    over a same-named runtime), so route validation must judge the same target
    the consumer will actually get: lane first, runtime second. *)
@@ -141,181 +112,129 @@ let find_declared_lane (lanes : Runtime_lane.t list) (id : string) =
   List.find_opt (fun lane -> String.equal (Runtime_lane.id lane) id) lanes
 ;;
 
-(* Every lane candidate must satisfy the route's capability contract: the
-   turn-driver lane walk attempts candidates without re-filtering by
-   capability, so one incapable candidate would silently downgrade the
-   contract mid-failover. [validate_lanes] already guarantees candidate ids
-   resolve; the [None] arm stays total for the error message anyway. *)
-let validate_lane_candidates_capability
-    ~(config_path : string)
-    ~(route_name : string)
-    ~(capability_key : string)
-    ~(runtime_supports : t -> bool)
-    (runtimes : t list)
-    (lane : Runtime_lane.t) : (unit, string) result =
-  let lane_id = Runtime_lane.id lane in
-  let rec check = function
-    | [] -> Ok ()
-    | candidate_id :: rest ->
-      (match
-         List.find_opt (fun (r : t) -> String.equal r.id candidate_id) runtimes
-       with
-       | None ->
-         Error
-           (Printf.sprintf
-              "%s: [runtime].%s = %S lane candidate %S is not a configured \
-               runtime"
-              config_path
-              route_name
-              lane_id
-              candidate_id)
-       | Some runtime ->
-         if runtime_supports runtime
-         then check rest
-         else
-           Error
-             (Printf.sprintf
-                "%s: [runtime].%s = %S lane candidate %S uses model %S, which \
-                 does not declare %s"
-                config_path
-                route_name
-                lane_id
-                candidate_id
-                runtime.model.id
-                capability_key))
-  in
-  check (Runtime_lane.ordered_candidates lane)
-;;
+(* One admission path for every [runtime] field that names a routing target.
+   Three validators — keeper assignments, the per-route ids, and the
+   media_failover list — answered one question, "does this id resolve to
+   something a consumer can route to", and had drifted into three resolution
+   domains and three error shapes for it. The turn driver reaches all three
+   through the same lane-aware dispatch, so a single parse is what the
+   runtime-indifference spec asks for; three parses is how they diverge.
 
-(* One admission path for the routes that name a runtime. Each route resolves an
-   id with lane precedence ([resolve_assignment] prefers a lane over a same-named
-   runtime), and some routes additionally require the resolved target to declare a
-   capability. The requirement is a closed variant rather than an optional
-   argument, so a route that needs no capability states that instead of relying on
-   a caller to omit a parameter that silently changes the outcome.
+   The domain travels with the reference rather than with the call, because it is
+   a property of the field's consumer, not of the validation phase:
 
-   Merging the three per-route validators removed an asymmetry with no stated
-   reason: [runtime].memory_os_consolidation was validated before lanes were
-   materialised, so it alone could not name a lane while cross_verifier and
-   structured_judge could.
+   - [Runtime_only] for keeper assignments and media_failover entries.
+     runtime.mli documents the assignment snapshot as ids that resolve to a
+     configured runtime, and Keeper_vision_tool looks media_failover entries up
+     among runtimes (keeper_vision_tool.ml:82-89). Admitting a lane id at either
+     site would load a config its consumer cannot route.
+   - [Lane_then_runtime] for the route ids, mirroring [resolve_assignment]
+     (:1341-1348): a lane shadows a same-named runtime, so validation must judge
+     the target the consumer will actually get.
 
-   [None] stays the designed "inherit [runtime].default" case for every route, and
-   an unknown id remains an operator typo rejected at load rather than a silent
-   fallback (Unknown -> Permissive anti-pattern). *)
-type route_requirement =
-  | Resolves_only
-  | Declares_capability of
-      { key : string
-      ; supported_by : t -> bool
-      }
+   [None] stays the designed "inherit [runtime].default" case for a route, [[]]
+   the designed "derive capable runtimes from declared capabilities" case for
+   media_failover, and a keeper absent from the assignment table still falls back
+   at lookup time. An unknown id remains an operator typo rejected at load rather
+   than a silent fallback (Unknown -> Permissive anti-pattern).
 
-(* Capability accessors preserve the existing [None -> false] reading: a model
-   with no declared capabilities does not satisfy the requirement. That denial on
-   unknown is carried over unchanged, not introduced here; whether an unknown
-   capability should order a candidate later rather than exclude it up front is
-   the separate question tracked against the format axis. *)
-(* Neither [runtime].cross_verifier nor [runtime].structured_judge requests a wire
-   response format, so neither can require one.
+   Removed with the merge: [Declares_capability] and its lane-candidate helper.
+   #25719 dropped the last capability requirement after finding neither consumer
+   requests a wire response format, leaving a variant with match arms and no
+   construction site — dead weight that reads as an available option. The tool
+   channel it could not express is refused by OAS at dispatch through
+   candidate_rejection_disposition (oas/lib/llm_provider/exact_output.mli:126-132),
+   which is pre-dispatch and therefore failover-eligible: ordering rather than
+   exclusion, which is what the spec asks for. *)
+type reference_domain =
+  | Runtime_only
+  | Lane_then_runtime
 
-   cross_verifier delivers its verdict through the report_review_verdict TOOL CALL
-   (lib/task/anti_rationalization.ml:243-248, with
-   Keeper_structured_output_schema.anti_rationalization_reviewer_provider_config =
-   without_response_format at keeper_structured_output_schema.ml:306).
-   structured_judge applies the same without_response_format transform
-   (lib/keeper/keeper_failure_judge.ml:71-72, passed at :114) and parses by text
-   extraction with structured_json_of_response at :88-90; :79-80 calls that boundary
-   tool-free.
+(* A list entry renders as "field entry \"id\"" and a scalar as "field = \"id\"".
+   Keeping both is not cosmetic: [runtime].media_failover = "x" would tell the
+   operator a list field equals one id. The variance is in rendering the site,
+   never in deciding it. *)
+type reference_shape =
+  | Scalar
+  | List_entry
 
-   cross_verifier does need tool calling, and this catalog cannot say that.
-   Runtime_schema.model_capabilities declares supports_tool_choice,
-   supports_required_tool_choice, supports_named_tool_choice and
-   supports_parallel_tool_calls — the shapes of choosing a tool, not whether the
-   model can call one. Substituting supports_tool_choice would state a requirement
-   the role does not have, which is the same error as the JSON-mode requirement it
-   replaces. A capability that cannot be declared cannot be admitted on, so the
-   requirement is dropped rather than approximated.
+type runtime_reference =
+  { site : string (* the config path as the operator wrote it *)
+  ; shape : reference_shape
+  ; id : string
+  ; domain : reference_domain
+  }
 
-   The axis is not lost. A candidate that cannot serve the tool channel is refused
-   by OAS at dispatch through candidate_rejection_disposition
-   (oas/lib/llm_provider/exact_output.mli:126-132), which is pre-dispatch and
-   therefore failover-eligible — ordering rather than exclusion, which is what the
-   spec asks for. *)
-
-let validate_route_runtime
-    ~(config_path : string)
-    ~(dropped_bindings : (string * string) list)
-    ~(route_name : string)
-    ~(requirement : route_requirement)
-    (runtimes : t list)
-    (lanes : Runtime_lane.t list)
-    (route_id : string option) : (unit, string) result =
-  match route_id with
-  | None -> Ok ()
-  | Some id ->
-    (match find_declared_lane lanes id, requirement with
-     | Some _, Resolves_only ->
-       (* [validate_lanes] already guaranteed every candidate id resolves. *)
-       Ok ()
-     | Some lane, Declares_capability { key; supported_by } ->
-       validate_lane_candidates_capability
-         ~config_path
-         ~route_name
-         ~capability_key:key
-         ~runtime_supports:supported_by
-         runtimes
-         lane
-     | None, _ ->
-       (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
-        | None ->
-          Error
-            (Printf.sprintf
-               "%s: [runtime].%s = %S%s"
-               config_path
-               route_name
-               id
-               (unresolved_runtime_suffix
-                  ~dropped_bindings
-                  ~runtime_count:(List.length runtimes)
-                  id))
-        | Some runtime ->
-          (match requirement with
-           | Resolves_only -> Ok ()
-           | Declares_capability { key; supported_by } ->
-             if supported_by runtime
-             then Ok ()
-             else
-               Error
-                 (Printf.sprintf
-                    "%s: [runtime].%s = %S uses model %S, which does not declare %s"
-                    config_path
-                    route_name
-                    id
-                    runtime.model.id
-                    key))))
-;;
-
-(* [runtime].media_failover (RFC-0265) validates each id in the ordered list: an
-   unknown id is an operator typo rejected at load, not a silent drop
-   (Unknown→Permissive anti-pattern). [[]] is the designed
-   "derive capable runtimes from declared capabilities" case. *)
-let validate_media_failover ~(config_path : string)
+let validate_runtime_references ~(config_path : string)
     ~(dropped_bindings : (string * string) list) (runtimes : t list)
-    (media_failover : string list) : (unit, string) result =
-  match
-    List.find_opt
-      (fun id ->
-        not (List.exists (fun (r : t) -> String.equal r.id id) runtimes))
-      media_failover
-  with
+    (lanes : Runtime_lane.t list) (references : runtime_reference list)
+  : (unit, string) result
+  =
+  let resolves_as_runtime id =
+    List.exists (fun (r : t) -> String.equal r.id id) runtimes
+  in
+  let resolves (reference : runtime_reference) =
+    match reference.domain with
+    | Runtime_only -> resolves_as_runtime reference.id
+    | Lane_then_runtime ->
+      (* [validate_lanes] already guaranteed every candidate id of a declared
+         lane resolves, so naming the lane is enough. *)
+      Option.is_some (find_declared_lane lanes reference.id)
+      || resolves_as_runtime reference.id
+  in
+  match List.find_opt (fun reference -> not (resolves reference)) references with
   | None -> Ok ()
-  | Some id ->
+  | Some { site; shape; id; domain = _ } ->
+    let named =
+      match shape with
+      | Scalar -> Printf.sprintf "%s = %S" site id
+      | List_entry -> Printf.sprintf "%s entry %S" site id
+    in
     Error
       (Printf.sprintf
-         "%s: [runtime].media_failover entry %S%s"
+         "%s: %s%s"
          config_path
-         id
+         named
          (unresolved_runtime_suffix ~dropped_bindings
             ~runtime_count:(List.length runtimes) id))
+;;
+
+(* Reference constructors keep each site string next to the field it names, so a
+   renamed config key cannot drift away from its diagnostic. *)
+let assignment_references (assignments : (string * string) list) =
+  List.map
+    (fun (keeper_name, runtime_id) ->
+      { site = Printf.sprintf "[runtime.assignments].%s" keeper_name
+      ; shape = Scalar
+      ; id = runtime_id
+      ; domain = Runtime_only
+      })
+    assignments
+;;
+
+let route_references (routes : (string * string option) list) =
+  List.filter_map
+    (fun (route_name, route_id) ->
+      Option.map
+        (fun id ->
+          { site = Printf.sprintf "[runtime].%s" route_name
+          ; shape = Scalar
+          ; id
+          ; domain = Lane_then_runtime
+          })
+        route_id)
+    routes
+;;
+
+let media_failover_references (media_failover : string list) =
+  List.map
+    (fun id ->
+      { site = "[runtime].media_failover"
+      ; shape = List_entry
+      ; id
+      ; domain = Runtime_only
+      })
+    media_failover
 ;;
 
 (* [runtime.lanes.<id>] candidate ids must resolve to configured runtimes.
@@ -952,8 +871,15 @@ let materialize_config
                  ~runtime_count:(List.length runtimes) did))
        | Some rt -> Ok rt)
   in
+  (* Assignments are checked before lanes are materialized, which keeps the order
+     in which a typo'd assignment surfaces ahead of a typo'd lane candidate.
+     [Runtime_only] never consults the lane list, so the empty list here is not a
+     stand-in for lanes that do not exist yet — it states that no lane is
+     admissible at this site, which is the assignment contract runtime.mli
+     documents and Keeper_turn_driver's lane-aware dispatch relies on. *)
   let* () =
-    validate_keeper_assignments ~config_path ~dropped_bindings runtimes assignments
+    validate_runtime_references ~config_path ~dropped_bindings runtimes []
+      (assignment_references assignments)
   in
   (* Lanes are materialized before every route validation so any route id can
      name a lane (#25394); candidate resolution is enforced by [validate_lanes]
@@ -962,39 +888,16 @@ let materialize_config
   let* lanes =
     lanes_of_decls ~config_path ~dropped_bindings runtimes cfg.lane_decls
   in
+  (* One list in the order the errors used to surface: the three routes, then the
+     media_failover entries. *)
   let* () =
-    validate_route_runtime
-      ~config_path
-      ~dropped_bindings
-      ~route_name:"memory_os_consolidation"
-      ~requirement:Resolves_only
-      runtimes
-      lanes
-      cfg.memory_os_consolidation_runtime_id
-  in
-  let* () =
-    validate_route_runtime
-      ~config_path
-      ~dropped_bindings
-      ~route_name:"structured_judge"
-      ~requirement:Resolves_only
-      runtimes
-      lanes
-      cfg.structured_judge_runtime_id
-  in
-  let* () =
-    validate_route_runtime
-      ~config_path
-      ~dropped_bindings
-      ~route_name:"cross_verifier"
-      ~requirement:Resolves_only
-      runtimes
-      lanes
-      cfg.cross_verifier_runtime_id
-  in
-  let* () =
-    validate_media_failover ~config_path ~dropped_bindings runtimes
-      cfg.media_failover
+    validate_runtime_references ~config_path ~dropped_bindings runtimes lanes
+      (route_references
+         [ "memory_os_consolidation", cfg.memory_os_consolidation_runtime_id
+         ; "structured_judge", cfg.structured_judge_runtime_id
+         ; "cross_verifier", cfg.cross_verifier_runtime_id
+         ]
+      @ media_failover_references cfg.media_failover)
   in
   let* () =
     if validate_max_context

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -979,7 +979,8 @@ let parse_runtime_media_failover ~path value =
      to [] (the repo's Unknown→Permissive anti-pattern). An explicit empty array
      [] is preserved as the intentional derive-from-declared-caps signal; id typos
      in a well-typed array are still caught loudly by
-     {!Runtime.validate_media_failover}. *)
+     {!Runtime.validate_runtime_references}, which now judges every [runtime]
+     field that names a routing target. *)
   try Ok (Otoml.get_array Otoml.get_string value) with
   | Otoml.Type_error msg ->
     Error

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1659,6 +1659,92 @@ let test_runtime_assignment_rejects_commented_disabled_binding () =
       check bool "error mentions disabled runtime id" true
         (String_util.contains_substring msg "local.disabled"))
 
+(* One validator now decides every [runtime] field that names a routing target
+   (keeper assignments, the route ids, media_failover entries), so the properties
+   that were spread across three functions are asserted together.
+
+   Two things can break in a merge like this and neither shows up as a type error.
+   The diagnostics can collapse into one generic message, leaving the operator
+   without the field that is wrong; and the two resolution domains can collapse
+   into one, which would pass any "does the id resolve" test while admitting a
+   lane id at a site whose consumer looks only among runtimes — a config that
+   loads and then cannot route. *)
+let routing_reference_base =
+  "[providers.local]\n\
+   protocol = \"openai-compatible-http\"\n\
+   endpoint = \"http://127.0.0.1:1/v1\"\n\
+   \n\
+   [models.good]\n\
+   api-name = \"chat\"\n\
+   max-context = 1024\n\
+   \n\
+   [local.good]\n\
+   \n\
+   [runtime]\n\
+   default = \"local.good\"\n"
+
+let load_error_of_runtime_toml ~what content =
+  with_temp_runtime_toml content (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ -> failf "%s should be rejected at load" what
+    | Error msg -> msg)
+
+let test_every_routing_field_names_itself_in_its_diagnostic () =
+  let assignment =
+    load_error_of_runtime_toml
+      ~what:"an assignment to an unknown runtime"
+      (routing_reference_base ^ "\n[runtime.assignments]\nkeeper_a = \"local.typo\"\n")
+  in
+  check bool "assignment diagnostic names the keeper's table entry" true
+    (String_util.contains_substring assignment "[runtime.assignments].keeper_a = \"local.typo\"");
+  let route =
+    load_error_of_runtime_toml
+      ~what:"a route naming an unknown runtime"
+      (routing_reference_base ^ "structured_judge = \"local.typo\"\n")
+  in
+  check bool "route diagnostic names the route field" true
+    (String_util.contains_substring route "[runtime].structured_judge = \"local.typo\"");
+  let media =
+    load_error_of_runtime_toml
+      ~what:"a media_failover entry naming an unknown runtime"
+      (routing_reference_base ^ "media_failover = [\"local.typo\"]\n")
+  in
+  (* A list field renders as an entry rather than an equality: [runtime]
+     .media_failover = "local.typo" would tell the operator the list equals one id. *)
+  check bool "media_failover diagnostic names an entry, not an equality" true
+    (String_util.contains_substring media "[runtime].media_failover entry \"local.typo\"")
+
+let test_routing_reference_domains_stay_distinct () =
+  let lane = "\n[runtime.lanes.safe]\nstrategy = \"ordered\"\ncandidates = [\"local.good\"]\n" in
+  (* A route resolves lane-first, mirroring [resolve_assignment], so naming a lane
+     is valid config. *)
+  with_temp_runtime_toml
+    (routing_reference_base ^ "structured_judge = \"safe\"\n" ^ lane)
+    (fun path ->
+      match Runtime.load_list ~config_path:path with
+      | Error msg -> failf "a route may name a lane: %s" msg
+      | Ok (_, _, _, _, structured_judge, _, _, _) ->
+        check (option string) "route keeps the lane id" (Some "safe") structured_judge);
+  (* An assignment resolves among runtimes only. runtime.mli documents the
+     assignment snapshot as ids that resolve to a configured runtime, so admitting
+     a lane here would load a config the assignment consumer cannot look up. *)
+  let assignment =
+    load_error_of_runtime_toml
+      ~what:"an assignment naming a lane"
+      (routing_reference_base ^ lane ^ "\n[runtime.assignments]\nkeeper_a = \"safe\"\n")
+  in
+  check bool "assignment refuses a lane id" true
+    (String_util.contains_substring assignment "[runtime.assignments].keeper_a = \"safe\"");
+  (* Keeper_vision_tool resolves media_failover entries among runtimes
+     (keeper_vision_tool.ml:82-89), so the same refusal applies. *)
+  let media =
+    load_error_of_runtime_toml
+      ~what:"a media_failover entry naming a lane"
+      (routing_reference_base ^ "media_failover = [\"safe\"]\n" ^ lane)
+  in
+  check bool "media_failover refuses a lane id" true
+    (String_util.contains_substring media "[runtime].media_failover entry \"safe\"")
+
 let test_strict_init_rejects_assigned_runtime_absent_from_oas_catalog () =
   let catalog =
     "[[models]]\n\
@@ -2250,9 +2336,11 @@ let test_structured_judge_runtime_routing () =
            "structured_judge"))
 
 (* #25394 slice 1: [runtime].structured_judge / .cross_verifier accept a
-   [runtime.lanes] id. The capability contract extends to every candidate
-   (the turn-driver lane walk does not re-filter by capability), and
-   validation follows [resolve_assignment]'s lane-over-runtime precedence. *)
+   [runtime.lanes] id, following [resolve_assignment]'s lane-over-runtime
+   precedence. There is no longer a per-candidate capability contract: #25719
+   dropped the wire-format requirement after finding neither consumer requests
+   one, and the lane-candidate capability check that enforced it was removed with
+   the per-route validators it belonged to. *)
 let judge_lane_base =
   "[providers.local]\n\
    display-name = \"Local\"\n\
@@ -2976,6 +3064,12 @@ let () =
           test_case
             "runtime assignment rejects commented disabled binding"
             `Quick test_runtime_assignment_rejects_commented_disabled_binding;
+          test_case
+            "every routing field names itself in its diagnostic"
+            `Quick test_every_routing_field_names_itself_in_its_diagnostic;
+          test_case
+            "routing reference domains stay distinct"
+            `Quick test_routing_reference_domains_stay_distinct;
           test_case
             "strict init rejects assigned runtime absent from OAS catalog"
             `Quick test_strict_init_rejects_assigned_runtime_absent_from_oas_catalog;


### PR DESCRIPTION
## 무엇을

`[runtime]` 아래에서 라우팅 대상을 지명하는 모든 필드를 **검증기 하나**가 판정하게 합니다. 기존에는 keeper assignments, 세 개의 route id, `media_failover` 리스트가 각각 자기 검증기를 갖고 있었고, 셋 다 같은 질문("이 id 가 소비자가 라우팅할 수 있는 무언가로 해석되는가")에 답하면서 **해석 도메인 3가지와 에러 형태 3가지로 이미 갈라져 있었습니다.**

- 삭제: `validate_keeper_assignments`, `validate_route_runtime`, `validate_media_failover`, `validate_lane_candidates_capability`, `type route_requirement`
- 추가: `validate_runtime_references` + `reference_domain` / `reference_shape` / `runtime_reference`
- 순수 코드 변경입니다. **config 마이그레이션 없음** — route 키는 이미 `runtime_toml.ml:1005-1045` 의 같은 `[runtime]` 테이블에서 하나의 `match key with` 로 파싱되어 서로 다른 레코드 필드로 들어갑니다. 별개인 것은 레코드 필드였고 config 구조가 아니었습니다.

## 해석 도메인을 참조가 들고 다니는 이유

도메인은 검증 *단계*의 성질이 아니라 **그 필드 소비자**의 성질입니다. 호출 인자로 두면 같은 필드가 호출 위치에 따라 다르게 판정될 수 있습니다.

| 도메인 | 적용 필드 | 근거 |
|---|---|---|
| `Runtime_only` | keeper assignments | `runtime.mli:205-210` 이 "every runtime id in the returned snapshot resolves to a configured runtime" 를 계약으로 명시 |
| `Runtime_only` | `media_failover` 항목 | `keeper_vision_tool.ml:82-89` 가 runtimes 중에서만 조회 (`List.filter_map by_id media_failover`) |
| `Lane_then_runtime` | 세 route id | `resolve_assignment` (`runtime.ml:1341-1348`) 이 lane 우선으로 해석하므로, 검증은 소비자가 실제로 받을 대상을 판정해야 함 |

## 동작 보존

- **에러 우선순위 동일**: assignments 는 여전히 lane materialize *이전에* 검사됩니다. 그래서 typo 난 assignment 가 typo 난 lane candidate 보다 먼저 보고됩니다. 검증기 하나를 두 시점에서 호출하는 형태이며, 판정 경로는 하나입니다.
- **진단 문자열 바이트 단위 보존**: 스칼라 필드는 `field = "id"`, 리스트 항목은 `field entry "id"`. 둘을 통일하지 않은 이유는 `[runtime].media_failover = "x"` 가 운영자에게 "리스트가 id 하나와 같다"고 말하기 때문입니다. 형태 차이는 **렌더링**에만 있고 **판정**에는 없습니다.
- `None` / `[]` / assignment 테이블 부재는 모두 기존 설계된 fallback 그대로입니다. 미해석 id 는 여전히 load 에서 거부됩니다 (Unknown→Permissive 안티패턴 회피).

## 죽은 능력 분기 제거

`Declares_capability` 는 **생산자가 0개**였습니다. #25719 가 두 소비자 모두 wire response format 을 요청하지 않는다는 것을 확인하고 마지막 능력 요구를 제거했고, 그 뒤로는 match arm 만 남은 variant 였습니다 — 선택 가능한 옵션처럼 읽히는 죽은 무게입니다. 표현할 수 없었던 tool 채널 축은 OAS 가 dispatch 에서 `candidate_rejection_disposition` 으로 거부하며, 이는 pre-dispatch 이므로 failover 적격입니다(배제가 아니라 정렬).

`test_structured_judge_lane_target` 의 stale 주석("The capability contract extends to every candidate")도 함께 정정했습니다 — #25719 이후 거짓이었습니다.

## 테스트

두 개를 추가했습니다. 이 종류의 통합에서 **타입 에러 없이** 깨질 수 있는 두 가지를 겨냥합니다.

1. `every routing field names itself in its diagnostic` — 진단이 일반 메시지로 뭉개지면 운영자가 어느 필드가 틀렸는지 모릅니다.
2. `routing reference domains stay distinct` — 도메인이 하나로 뭉개지면 "id 가 해석되는가" 테스트는 통과하면서 소비자가 조회할 수 없는 lane id 를 assignment/media_failover 에 허용합니다. load 는 되고 라우팅은 안 되는 config 가 됩니다.

## 검증

- `dune build lib/runtime/.masc_runtime.objs/byte/runtime.cmo` → **exit 0, 경고 0**
- `ocamlformat 0.29.0 --check` → 3 파일 통과 (CI 와 동일한 명령·버전)
- `scripts/lint/no-docstring-escape-quote.sh`, `scripts/lint/no-provider-name-hardcoding.sh` → 통과 (`provider_name_new_literals 0`)

**미검증 (명시)**: 새 테스트는 **로컬에서 실행하지 못했습니다.** 공유 opam 스위치가 `agent_sdk.0.223.1` (`3d4ee19a`) 에 핀되어 있고 repo SSOT 는 `0.222.2` (`45473aae`) 이므로 `lib/runtime` 전체가 `runtime_exact_output_registry.ml:434` 의 `Exact_output.Missing_target_credential` 미해결로 빌드되지 않습니다. #25711 이 그 적응을 진행 중이라 핀을 되돌리면 그쪽 작업을 깹니다. 따라서 CI 가 이 테스트의 최초 실행입니다.

## 근거

`docs/design/2026-07-25-masc-runtime-indifference-spec.md` §7 (G-2). 하네스 측정: 이 브랜치에서 G-2 가 `PASS measured=1 ['runtime.ml:881 validate_runtime_references']` 로 읽힙니다 (main 은 3).

RFC-WAIVED: `lib/runtime/` 는 RFC 필수 subsystem 목록(credential / repo_manager / operator_control / keeper_sandbox / dashboard credential / hooks / workflow 문서)에 포함되지 않으며, 이 PR 은 동작을 보존하는 코드 통합입니다.
