### PR TITLE
refactor(keeper): hard-cut turn content projection

### DIFF
--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -302,7 +302,6 @@ Resolution 순서:
 - `provider_name_of_label`: "llama:qwen3.5" -> Some "llama"
 - `max_context_of_label`: label -> Provider_registry.find -> entry.max_context (fallback: 128,000)
 - `resolve_primary_max_context`: label list에서 available한 첫 모델의 max_context
-- `ensure_api_keys_for_labels`: 사용 가능한 API key 존재 여부 검증
 
 ---
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -258,7 +258,6 @@ let turn_resources_error ~surface failure =
 
 let preflight_keeper_invocation ~surface ctx args request =
   let name = Keeper_invocation_contract.target_name request in
-    let direct_reply = get_bool args "direct_reply" false in
     let tool_name = invocation_tool_name surface in
     match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
     | Error e -> Error e
@@ -275,21 +274,8 @@ let preflight_keeper_invocation ~surface ctx args request =
     match ensure_keeper_exists ~ctx ~name with
     | Error e -> Error e
     | Ok meta ->
-      match resolve_turn_runtime_id meta with
-      | Error e -> Error e
-      | Ok turn_runtime_id ->
-        let effective_models =
-          if direct_reply then
-            Provider_runtime_projection.default_execution_model_strings
-              (                 (turn_runtime_id))
-          else
-            effective_model_labels_for_turn meta
-        in
-        match Keeper_types_support.ensure_api_keys_for_labels effective_models with
-        | Error e -> Error e
-        | Ok () ->
-          Keeper_turn_helpers.ensure_local_discovery_ready effective_models
-          |> Result.map (fun () -> request))))
+      resolve_turn_runtime_id meta
+      |> Result.map (fun _ -> request))))
 
 let preflight_keeper_msg ctx args =
   let name = get_string args "name" "" in
@@ -533,32 +519,14 @@ let run_keeper_invocation_turn_admitted
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~generation:meta.runtime.nonce ()
       in
-      let effective_models =
-        if direct_reply then
-          Provider_runtime_projection.default_execution_model_strings
-            turn_runtime_id
-        else
-          effective_model_labels_for_turn meta
-      in
-      Progress.Tracker.step turn_tracker ~message:"Validating API keys" ();
-      (match Keeper_types_support.ensure_api_keys_for_labels effective_models with
-       | Error e ->
-         Progress.stop_tracking turn_task_id;
-         tool_result_error ("" ^ e)
-       | Ok () ->
-         Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
-         (match Keeper_turn_helpers.ensure_local_discovery_ready effective_models with
-          | Error e ->
-            Progress.stop_tracking turn_task_id;
-            tool_result_error ("" ^ e)
-	      | Ok () ->
-	        (match
-	           Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
-	             ~requested_override:meta.max_context_override
-	             ~runtime_id:turn_runtime_id
-	         with
-	         | Error error ->
-	           Progress.stop_tracking turn_task_id;
+      Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
+      (match
+         Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+           ~requested_override:meta.max_context_override
+           ~runtime_id:turn_runtime_id
+       with
+		         | Error error ->
+		           Progress.stop_tracking turn_task_id;
 	           tool_result_error
 	             (Keeper_context_runtime.max_context_resolution_error_to_string error)
 	         | Ok resolution ->
@@ -1029,7 +997,7 @@ let run_keeper_invocation_turn_admitted
               in
               tool_result_ok_data reply_json
 
-))))))))))
+))))))))
 
 let handle_keeper_invocation
       ?on_text_delta

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -367,23 +367,3 @@ let record_pre_dispatch_terminal_observation
       ~side_effect:(activity_kind ^ " emit")
       (Printexc.to_string exn)
 ;;
-
-let local_discovery_refresh_for_test : (string list -> bool) option Atomic.t =
-  Atomic.make None
-;;
-
-(* Local discovery disabled: tier-based local/non-local classification
-   no longer exists. All providers are treated uniformly. *)
-let ensure_local_discovery_ready ?refresh:_ (_labels : string list) : (unit, string) result =
-  Ok ()
-;;
-
-module For_testing = struct
-  let with_local_discovery_refresh refresh f =
-    let previous = Atomic.get local_discovery_refresh_for_test in
-    Atomic.set local_discovery_refresh_for_test (Some refresh);
-    Eio_guard.protect
-      ~finally:(fun () -> Atomic.set local_discovery_refresh_for_test previous)
-      f
-  ;;
-end

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -82,17 +82,3 @@ val record_pre_dispatch_terminal_observation :
   unit -> unit
 (** Record a terminal observation (receipt + activity graph event) for a
     pre-dispatch failure or early exit. *)
-
-val ensure_local_discovery_ready :
-  ?refresh:(string list -> bool) ->
-  string list ->
-  (unit, string) result
-(** Ensure local-provider discovery is refreshed before a turn when the
-    selected labels depend on runtime discovery. *)
-
-module For_testing : sig
-  val with_local_discovery_refresh :
-    (string list -> bool) -> (unit -> 'a) -> 'a
-  (** Install a scoped refresh override and force the discovery branch for
-      deterministic preflight tests. *)
-end

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -16,14 +16,6 @@ let session_base_dir_ (config : Workspace.config) =
   let d = Filename.concat (Workspace.masc_root_dir config) "traces" in
   ensure_dir_ d
 
-(** RFC-0206 single-binding: API keys for the default runtime are resolved at
-    startup, so there is no per-label key check. Retained as a total no-op so
-    callers keep their result-shaped contract.
-    Runtime behavior changed: per-label key availability is no longer probed;
-    verify keeper turn startup at deploy. *)
-let ensure_api_keys_for_labels (_labels : string list) : (unit, string) result =
-  Ok ()
-
 (** Date-split metrics store: [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl].
     Cached per keeper name so all callers share the same Eio.Mutex. *)
 let metrics_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -14,10 +14,6 @@ val keeper_dir_ : Workspace.config -> string
     creating it if missing. *)
 val session_base_dir_ : Workspace.config -> string
 
-(** Check API key availability for the given model labels via
-    [Runtime_runtime]. *)
-val ensure_api_keys_for_labels : string list -> (unit, string) result
-
 (** Date-split metrics store: [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl].
     Cached per keeper name so all callers share the same Eio.Mutex. *)
 val keeper_metrics_store : Workspace.config -> string -> Dated_jsonl.t

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -75,13 +75,6 @@ val resolved_max_context_for_turn
   -> Keeper_context_runtime.max_context_resolution
   -> int
 
-(** Ensure local-provider discovery is refreshed before a turn when the
-    selected labels depend on runtime discovery. Exposed for targeted tests. *)
-val ensure_local_discovery_ready
-  :  ?refresh:(string list -> bool)
-  -> string list
-  -> (unit, string) result
-
 (* runtime→Runtime 숙청: phase-buffer liveness probe 기계 재export 제거
    (단일 runtime 에서 죽은 코드였으므로 제거됨). *)
 

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -36,63 +36,42 @@ let build_runtime_execution
   if String.equal runtime_id "" then
     Error (Agent_sdk.Error.Internal "runtime_id must be non-empty")
   else
-  let model_labels =
-    Keeper_context_runtime.effective_model_labels_for_turn meta
-  in
   let log_pre_dispatch_error ~site detail =
-    let model_labels_detail =
-      match model_labels with
-      | [] -> "none"
-      | labels -> String.concat "," labels
-    in
     Log.Keeper.error
-      "%s: pre_dispatch: %s failed for runtime_id=%s model_labels=[%s]: %s"
+      "%s: pre_dispatch: %s failed for runtime_id=%s: %s"
       meta.name
       site
       runtime_id
-      model_labels_detail
       detail
   in
-  match Keeper_types_support.ensure_api_keys_for_labels model_labels with
-  | Error e ->
-    log_pre_dispatch_error ~site:"ensure_api_keys_for_labels" e;
-    Error (Agent_sdk.Error.Internal e)
-  | Ok () ->
-    (match
-       Keeper_turn_helpers.ensure_local_discovery_ready model_labels
-     with
-     | Error e ->
-       log_pre_dispatch_error ~site:"ensure_local_discovery_ready" e;
-       Error (Agent_sdk.Error.Internal e)
-     | Ok () ->
-       (match
-          Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
-            ~requested_override:meta.max_context_override
-            ~runtime_id
-        with
-        | Error error ->
-          let detail =
-            Keeper_context_runtime.max_context_resolution_error_to_string error
-          in
-          log_pre_dispatch_error ~site:"resolve_context_window" detail;
-          Error
-            (Agent_sdk.Error.Config
-               (Agent_sdk.Error.InvalidConfig
-                  { field = "runtime.context_window"; detail }))
-        | Ok max_context_resolution ->
-          let max_context =
-            Keeper_turn_runtime_budget.resolved_max_context_for_turn
-              ~meta
-              max_context_resolution
-          in
-          let temperature =
-            Runtime_inference.resolve_temperature
-              ~runtime_id
-              ~fallback:Keeper_config.keeper_unified_temperature
-          in
-          Ok
-            { Keeper_turn_runtime_budget.runtime_id
-            ; max_context_resolution
-            ; max_context
-            ; temperature
-            }))
+  match
+    Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+      ~requested_override:meta.max_context_override
+      ~runtime_id
+  with
+  | Error error ->
+    let detail =
+      Keeper_context_runtime.max_context_resolution_error_to_string error
+    in
+    log_pre_dispatch_error ~site:"resolve_context_window" detail;
+    Error
+      (Agent_sdk.Error.Config
+         (Agent_sdk.Error.InvalidConfig
+            { field = "runtime.context_window"; detail }))
+  | Ok max_context_resolution ->
+    let max_context =
+      Keeper_turn_runtime_budget.resolved_max_context_for_turn
+        ~meta
+        max_context_resolution
+    in
+    let temperature =
+      Runtime_inference.resolve_temperature
+        ~runtime_id
+        ~fallback:Keeper_config.keeper_unified_temperature
+    in
+    Ok
+      { Keeper_turn_runtime_budget.runtime_id
+      ; max_context_resolution
+      ; max_context
+      ; temperature
+      }

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -1,10 +1,8 @@
 (** Pre-dispatch validation stage extracted from
     [Keeper_unified_turn.run_keeper_cycle] per RFC-0136 PR-3.
 
-    Owns the runtime-execution builder: runtime-name → keeper-meta
-    projection, model-label resolution, API-key + local-discovery
-    readiness checks, context-window resolution, and temperature inference.
-    Returns a
+    Owns the runtime-execution builder: runtime-id validation,
+    context-window resolution, and temperature inference. Returns a
     [Keeper_turn_runtime_budget.runtime_execution] record on success,
     or a typed [Agent_sdk.Error.sdk_error] on the first failed check.
 
@@ -37,8 +35,6 @@ val build_runtime_execution
     [meta]'s context.
 
     Failure modes (returned as [Error]):
-    - [Keeper_types_support.ensure_api_keys_for_labels] missing required keys.
-    - [ensure_local_discovery_ready] local-runtime discovery fail.
     - The exact [runtime_id] has no configured context window.
     - [meta.max_context_override] is not positive.
 

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -10,9 +10,6 @@
 
 let default_config_path = Runtime.config_path
 
-let default_model_strings ~runtime_id =
-  Provider_runtime_projection.default_execution_model_strings runtime_id
-
 (* Named model execution *)
 
 let require_eio ?sw ?net () =

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -12,9 +12,6 @@
 val default_config_path : unit -> string option
 (** Alias for [Runtime.config_path]. *)
 
-val default_model_strings : runtime_id:string -> string list
-(** Alias for [Runtime_runtime.default_model_strings]. *)
-
 (** {1 Eio context validation} *)
 
 val require_eio :

--- a/lib/runtime_model/provider_runtime_projection.ml
+++ b/lib/runtime_model/provider_runtime_projection.ml
@@ -262,7 +262,3 @@ let default_execution_model_strings _runtime_id =
   | [] -> [ default_local_fallback_label () ]
   | labels -> labels
 ;;
-
-let default_execution_model_strings_result runtime_id =
-  Ok (default_execution_model_strings runtime_id)
-;;

--- a/lib/runtime_model/provider_runtime_projection.mli
+++ b/lib/runtime_model/provider_runtime_projection.mli
@@ -31,4 +31,3 @@ val default_model_candidate_for_runtime_prefix :
   ?getenv:(string -> string option) -> string -> default_model_candidate option
 
 val default_execution_model_strings : string -> string list
-val default_execution_model_strings_result : string -> (string list, 'a) result

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -34,30 +34,29 @@ FORBIDDEN_IDENTIFIERS = (
     "ensure_local_discovery_ready",
 )
 
-RAW_ENV_READ_PATTERN = re.compile(r"\b(?:Sys|Unix)\s*\.\s*getenv(?:_opt)?\b")
-ENV_CONFIG_PATH_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9_'])"
-    r"Env_config(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']*)+"
-    r"(?![A-Za-z0-9_'])"
+OCAML_IDENTIFIER_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_'])[A-Za-z_][A-Za-z0-9_']*(?![A-Za-z0-9_'])"
 )
 ENV_BINDING_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_']*_env\b", re.IGNORECASE)
+CHAR_LITERAL_PATTERN = re.compile(r"'(?:[^'\\\r\n]|\\[^\r\n])'")
+CAMEL_CASE_BOUNDARY_PATTERN = re.compile(
+    r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
+)
+FORBIDDEN_ENV_IDENTIFIERS = frozenset(("Env_config", "getenv", "getenv_opt"))
 POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
 
 
 def has_policy_token(identifier: str) -> bool:
-    tokens = [
-        token.rstrip("'")
-        for token in re.split(r"_+", identifier.lower())
-        if token.rstrip("'")
-    ]
+    tokens = []
+    for snake_part in re.split(r"_+", identifier):
+        for camel_part in CAMEL_CASE_BOUNDARY_PATTERN.split(snake_part):
+            token = camel_part.rstrip("'").lower()
+            if token:
+                tokens.append(token)
     return any(token in POLICY_TOKENS for token in tokens) or any(
         left == "api" and right == "key"
         for left, right in zip(tokens, tokens[1:])
     )
-
-
-def is_policy_env_config_path(path: str) -> bool:
-    return any(has_policy_token(segment.strip()) for segment in path.split(".")[1:])
 
 
 def mask_non_code(source: str) -> str:
@@ -85,6 +84,11 @@ def mask_non_code(source: str) -> str:
                 else:
                     index += 1
             blank(start, index)
+            continue
+        char_literal = CHAR_LITERAL_PATTERN.match(source, index)
+        if char_literal:
+            blank(index, char_literal.end())
+            index = char_literal.end()
             continue
         if source[index] == '"':
             start = index
@@ -135,22 +139,17 @@ for raw_path in sys.argv[1:]:
             failures.append(
                 f"{path}:{location(source, match.start())}: forbidden identifier {identifier}"
             )
-    match = RAW_ENV_READ_PATTERN.search(code)
-    if match:
-        failures.append(
-            f"{path}:{location(source, match.start())}: forbidden raw environment read: {match.group(0)}"
-        )
     match = next(
         (
             candidate
-            for candidate in ENV_CONFIG_PATH_PATTERN.finditer(code)
-            if is_policy_env_config_path(candidate.group(0))
+            for candidate in OCAML_IDENTIFIER_PATTERN.finditer(code)
+            if candidate.group(0).rstrip("'") in FORBIDDEN_ENV_IDENTIFIERS
         ),
         None,
     )
     if match:
         failures.append(
-            f"{path}:{location(source, match.start())}: forbidden provider/model/credential environment projection: {match.group(0)}"
+            f"{path}:{location(source, match.start())}: forbidden environment dependency: {match.group(0)}"
         )
     match = next(
         (
@@ -199,10 +198,12 @@ let _decoy = "Keeper_model_labels ensure_api_keys_for_labels"
 let _quoted_decoy = {|
 Provider_runtime_binding ensure_local_discovery_ready
 |}
-let _ = Env_config.Tokenizer.path
-let _ = Env_config.Remodeling.enabled
-let _ = Env_config . Tokenizer . path
-let _ = Env_config . Remodeling . enabled
+let _tagged_decoy = {tag|Env_config getenv getenv_opt|tag}
+let _ordinary_env_decoy = "Env_config getenv getenv_opt"
+let _quote = '"'
+let _ = Env_configuration.Tokenizer.path
+let _ = getenv_optimal ()
+let _ = my_getenv_opt ()
 let _ = Tokenizer_env.path
 let _ = Remodeling_env.enabled
 let _ = Tokenizer'_env.path
@@ -222,9 +223,13 @@ EOF
     'let _ = ensure_local_discovery_ready []' \
     'let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"' \
     'let _ = Sys . getenv_opt "MASC_DEFAULT_MODEL"' \
+    'let _ = Sys.(getenv_opt "MASC_DEFAULT_MODEL")' \
+    'let _ = let open Unix in getenv "PROVIDER_API_KEY"' \
     $'let _ = Unix.\ngetenv_opt "PROVIDER_API_KEY"' \
     'let _ = Unix.getenv "PROVIDER_API_KEY"' \
     'let _ = Env_config.Model_defaults.default_runtime_opt ()' \
+    'let _ = Env_config.(Model_defaults.default_runtime_opt ())' \
+    'let _ = let open Env_config in Model_defaults.default_runtime_opt ()' \
     'let _ = Env_config.Default_model.value' \
     'let _ = Env_config.Cloud_provider.key' \
     'let _ = Env_config.Runtime_api_key.path' \
@@ -233,8 +238,14 @@ EOF
     'let _ = Env_config.Runtime__api_key.path' \
     'let _ = Env_config.Nested.Default_model.value' \
     'let _ = Env_config . Nested . Default_model.value' \
+    'let _ = Env_config.Runtime.ApiKey.value' \
+    'let _ = Env_config.Runtime.Api.Key.value' \
     "let _ = Env_config.Model'.value" \
+    "let _ = Env_config'.Model.value" \
+    'let _ = ApiKey_env.fallback ()' \
+    'let _ = APIKey_env.fallback ()' \
     "let _ = model'_env.fallback ()" \
+    $'let _quote = \'"\'\nlet _ = Env_config.Model_defaults.default_runtime_opt ()' \
     'let _ = Credential_env.fallback ()'
   do
     cp "${first_clean}" "${first}"

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -34,16 +34,22 @@ FORBIDDEN_IDENTIFIERS = (
     "ensure_local_discovery_ready",
 )
 
-RAW_ENV_READ_PATTERN = re.compile(r"\b(?:Sys|Unix)\.getenv(?:_opt)?\b")
+RAW_ENV_READ_PATTERN = re.compile(r"\b(?:Sys|Unix)\s*\.\s*getenv(?:_opt)?\b")
 ENV_CONFIG_PATH_PATTERN = re.compile(
-    r"\bEnv_config(?:\.[A-Za-z_][A-Za-z0-9_']*)+\b"
+    r"(?<![A-Za-z0-9_'])"
+    r"Env_config(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']*)+"
+    r"(?![A-Za-z0-9_'])"
 )
 ENV_BINDING_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_']*_env\b", re.IGNORECASE)
 POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
 
 
 def has_policy_token(identifier: str) -> bool:
-    tokens = [token for token in re.split(r"_+", identifier.lower()) if token]
+    tokens = [
+        token.rstrip("'")
+        for token in re.split(r"_+", identifier.lower())
+        if token.rstrip("'")
+    ]
     return any(token in POLICY_TOKENS for token in tokens) or any(
         left == "api" and right == "key"
         for left, right in zip(tokens, tokens[1:])
@@ -51,7 +57,7 @@ def has_policy_token(identifier: str) -> bool:
 
 
 def is_policy_env_config_path(path: str) -> bool:
-    return any(has_policy_token(segment) for segment in path.split(".")[1:])
+    return any(has_policy_token(segment.strip()) for segment in path.split(".")[1:])
 
 
 def mask_non_code(source: str) -> str:
@@ -121,7 +127,10 @@ for raw_path in sys.argv[1:]:
     source = path.read_text(encoding="utf-8")
     code = mask_non_code(source)
     for identifier in FORBIDDEN_IDENTIFIERS:
-        match = re.search(rf"\b{re.escape(identifier)}\b", code)
+        qualified_pattern = r"\s*\.\s*".join(
+            re.escape(part) for part in identifier.split(".")
+        )
+        match = re.search(rf"\b{qualified_pattern}\b", code)
         if match:
             failures.append(
                 f"{path}:{location(source, match.start())}: forbidden identifier {identifier}"
@@ -192,8 +201,11 @@ Provider_runtime_binding ensure_local_discovery_ready
 |}
 let _ = Env_config.Tokenizer.path
 let _ = Env_config.Remodeling.enabled
+let _ = Env_config . Tokenizer . path
+let _ = Env_config . Remodeling . enabled
 let _ = Tokenizer_env.path
 let _ = Remodeling_env.enabled
+let _ = Tokenizer'_env.path
 EOF
   MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
     bash "${BASH_SOURCE[0]}" --check >/dev/null
@@ -205,9 +217,12 @@ EOF
     'let _ = Runtime_model.resolve "x"' \
     'let _ = Keeper_model_labels.configured "x"' \
     'let _ = Keeper_context_runtime.effective_model_labels_for_turn ctx' \
+    'let _ = Keeper_context_runtime . effective_model_labels_for_turn ctx' \
     'let _ = ensure_api_keys_for_labels []' \
     'let _ = ensure_local_discovery_ready []' \
     'let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"' \
+    'let _ = Sys . getenv_opt "MASC_DEFAULT_MODEL"' \
+    $'let _ = Unix.\ngetenv_opt "PROVIDER_API_KEY"' \
     'let _ = Unix.getenv "PROVIDER_API_KEY"' \
     'let _ = Env_config.Model_defaults.default_runtime_opt ()' \
     'let _ = Env_config.Default_model.value' \
@@ -217,6 +232,9 @@ EOF
     'let _ = Env_config.Default__model.value' \
     'let _ = Env_config.Runtime__api_key.path' \
     'let _ = Env_config.Nested.Default_model.value' \
+    'let _ = Env_config . Nested . Default_model.value' \
+    "let _ = Env_config.Model'.value" \
+    "let _ = model'_env.fallback ()" \
     'let _ = Credential_env.fallback ()'
   do
     cp "${first_clean}" "${first}"

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+TARGETS=(
+  "${REPO_ROOT}/lib/keeper/keeper_turn.ml"
+  "${REPO_ROOT}/lib/keeper/keeper_unified_turn_pre_dispatch.ml"
+)
+
+fail() {
+  echo "[keeper-turn-content-boundary] $*" >&2
+  exit 1
+}
+
+check_boundary() {
+  local target
+  for target in "${TARGETS[@]}"; do
+    [[ -f "${target}" ]] || fail "required target not found: ${target}"
+  done
+
+  python3 - "${TARGETS[@]}" <<'PY'
+import pathlib
+import re
+import sys
+
+FORBIDDEN_IDENTIFIERS = (
+    "Provider_runtime_projection",
+    "Provider_runtime_binding",
+    "Runtime_model",
+    "Keeper_model_labels",
+    "ensure_api_keys_for_labels",
+    "ensure_local_discovery_ready",
+)
+
+ENV_READ_PATTERNS = (
+    (
+        "raw environment read",
+        re.compile(r"\b(?:Sys|Unix)\.getenv(?:_opt)?\b"),
+    ),
+    (
+        "provider/model/credential environment projection",
+        re.compile(
+            r"\b(?:"
+            r"Env_config\.[A-Za-z0-9_'.]*(?:Provider|Model|Credential|Api_key|Token)"
+            r"|(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_']*_env"
+            r")\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+def mask_non_code(source: str) -> str:
+    chars = list(source)
+    length = len(source)
+    index = 0
+
+    def blank(start: int, stop: int) -> None:
+        for offset in range(start, stop):
+            if chars[offset] != "\n":
+                chars[offset] = " "
+
+    while index < length:
+        if source.startswith("(*", index):
+            start = index
+            index += 2
+            depth = 1
+            while index < length and depth:
+                if source.startswith("(*", index):
+                    depth += 1
+                    index += 2
+                elif source.startswith("*)", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    index += 1
+            blank(start, index)
+            continue
+        if source[index] == '"':
+            start = index
+            index += 1
+            while index < length:
+                if source[index] == "\\":
+                    index += 2
+                elif source[index] == '"':
+                    index += 1
+                    break
+                else:
+                    index += 1
+            blank(start, min(index, length))
+            continue
+        quoted = re.match(r"\{([a-z_][A-Za-z0-9_']*)?\|", source[index:])
+        if quoted:
+            start = index
+            tag = quoted.group(1) or ""
+            index += quoted.end()
+            close = "|" + tag + "}"
+            close_at = source.find(close, index)
+            index = length if close_at < 0 else close_at + len(close)
+            blank(start, index)
+            continue
+        index += 1
+
+    return "".join(chars)
+
+
+def location(source: str, offset: int) -> str:
+    line = source.count("\n", 0, offset) + 1
+    previous_newline = source.rfind("\n", 0, offset)
+    column = offset - previous_newline
+    return f"{line}:{column}"
+
+
+failures = []
+for raw_path in sys.argv[1:]:
+    path = pathlib.Path(raw_path)
+    source = path.read_text(encoding="utf-8")
+    code = mask_non_code(source)
+    for identifier in FORBIDDEN_IDENTIFIERS:
+        match = re.search(rf"\b{re.escape(identifier)}\b", code)
+        if match:
+            failures.append(
+                f"{path}:{location(source, match.start())}: forbidden identifier {identifier}"
+            )
+    for label, pattern in ENV_READ_PATTERNS:
+        match = pattern.search(code)
+        if match:
+            failures.append(
+                f"{path}:{location(source, match.start())}: forbidden {label}: {match.group(0)}"
+            )
+
+if failures:
+    print("\n".join(failures), file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+  echo "[keeper-turn-content-boundary] OK"
+}
+
+self_test() (
+  local fixture first second first_clean second_clean injection
+  fixture="$(mktemp -d "${TMPDIR:-/tmp}/keeper-turn-content-boundary.XXXXXX")"
+  trap "rm -rf '${fixture}'" EXIT
+  mkdir -p "${fixture}/lib/keeper"
+  first="${fixture}/lib/keeper/keeper_turn.ml"
+  second="${fixture}/lib/keeper/keeper_unified_turn_pre_dispatch.ml"
+  printf '%s\n' 'let preflight request = Ok request' >"${first}"
+  printf '%s\n' 'let build runtime_id = Ok runtime_id' >"${second}"
+  first_clean="${fixture}/keeper_turn.ml.clean"
+  second_clean="${fixture}/keeper_unified_turn_pre_dispatch.ml.clean"
+  cp "${first}" "${first_clean}"
+  cp "${second}" "${second_clean}"
+
+  MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
+    bash "${BASH_SOURCE[0]}" --check >/dev/null
+
+  cat >>"${first}" <<'EOF'
+(*
+let _ = Provider_runtime_projection.default_execution_model_strings "ignored"
+let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"
+*)
+let _decoy = "Keeper_model_labels ensure_api_keys_for_labels"
+let _quoted_decoy = {|
+Provider_runtime_binding ensure_local_discovery_ready
+|}
+EOF
+  MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
+    bash "${BASH_SOURCE[0]}" --check >/dev/null
+  cp "${first_clean}" "${first}"
+
+  for injection in \
+    'let _ = Provider_runtime_projection.default_execution_model_strings "x"' \
+    'let _ = Provider_runtime_binding.find "x"' \
+    'let _ = Runtime_model.resolve "x"' \
+    'let _ = Keeper_model_labels.configured "x"' \
+    'let _ = ensure_api_keys_for_labels []' \
+    'let _ = ensure_local_discovery_ready []' \
+    'let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"' \
+    'let _ = Unix.getenv "PROVIDER_API_KEY"' \
+    'let _ = Env_config.Model_defaults.default_runtime_opt ()' \
+    'let _ = Credential_env.fallback ()'
+  do
+    cp "${first_clean}" "${first}"
+    printf '\n%s\n' "${injection}" >>"${first}"
+    if
+      MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
+        bash "${BASH_SOURCE[0]}" --check >/dev/null 2>&1
+    then
+      fail "self-test accepted forbidden injection: ${injection}"
+    fi
+  done
+  cp "${first_clean}" "${first}"
+
+  printf '%s\n' 'let _ = Provider_runtime_projection.default_execution_model_strings "x"' \
+    >>"${second}"
+  if
+    MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
+      bash "${BASH_SOURCE[0]}" --check >/dev/null 2>&1
+  then
+    fail "self-test did not scan keeper_unified_turn_pre_dispatch.ml"
+  fi
+  cp "${second_clean}" "${second}"
+
+  rm "${second}"
+  if
+    MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
+      bash "${BASH_SOURCE[0]}" --check >/dev/null 2>&1
+  then
+    fail "self-test accepted a missing required target"
+  fi
+
+  echo "[keeper-turn-content-boundary:self-test] clean=pass decoys=pass identifiers=fail env=fail both-targets=fail missing=fail"
+)
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    ;;
+  --check | "")
+    check_boundary
+    ;;
+  *)
+    fail "usage: $0 [--self-test|--check]"
+    ;;
+esac

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -44,8 +44,8 @@ ENV_READ_PATTERNS = (
         re.compile(
             r"\b(?:"
             r"Env_config\.(?:[A-Za-z0-9_']+\.)*"
-            r"(?:Provider|Model|Credential|Api_key|Token)"
-            r"(?:_[A-Za-z0-9_']+)?(?:\.[A-Za-z0-9_']+)*"
+            r"(?:[A-Za-z0-9']+_)*(?:Provider|Model|Credential|Api_key|Token)"
+            r"(?:_[A-Za-z0-9_']*)?(?:\.[A-Za-z0-9_']+)*"
             r"|(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_']*_env"
             r")\b",
             re.IGNORECASE,
@@ -185,6 +185,9 @@ EOF
     'let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"' \
     'let _ = Unix.getenv "PROVIDER_API_KEY"' \
     'let _ = Env_config.Model_defaults.default_runtime_opt ()' \
+    'let _ = Env_config.Default_model.value' \
+    'let _ = Env_config.Cloud_provider.key' \
+    'let _ = Env_config.Runtime_api_key.path' \
     'let _ = Credential_env.fallback ()'
   do
     cp "${first_clean}" "${first}"

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -38,6 +38,9 @@ OCAML_IDENTIFIER_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_'])[A-Za-z_][A-Za-z0-9_']*(?![A-Za-z0-9_'])"
 )
 CHAR_LITERAL_PATTERN = re.compile(r"'(?:[^'\\\r\n]|\\[^\r\n])'")
+APPROVED_UNIX_GETTIMEOFDAY_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_'.])Unix\.gettimeofday(?![A-Za-z0-9_'])"
+)
 CAMEL_CASE_BOUNDARY_PATTERN = re.compile(
     r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
 )
@@ -153,10 +156,14 @@ for raw_path in sys.argv[1:]:
             failures.append(
                 f"{path}:{location(source, match.start())}: forbidden identifier {identifier}"
             )
+    environment_code = APPROVED_UNIX_GETTIMEOFDAY_PATTERN.sub(
+        lambda candidate: " " * len(candidate.group(0)),
+        code,
+    )
     match = next(
         (
             candidate
-            for candidate in OCAML_IDENTIFIER_PATTERN.finditer(code)
+            for candidate in OCAML_IDENTIFIER_PATTERN.finditer(environment_code)
             if candidate.group(0).rstrip("'") in FORBIDDEN_ENV_IDENTIFIERS
         ),
         None,
@@ -216,6 +223,7 @@ Provider_runtime_binding ensure_local_discovery_ready
 let _tagged_decoy = {tag|Env_config environment getenv getenv_opt|tag}
 let _ordinary_env_decoy = "Env_config environment getenv getenv_opt"
 let _quote = '"'
+let _ = Unix.gettimeofday ()
 let _ = Env_configuration.Tokenizer.path
 let _ = getenv_optimal ()
 let _ = my_getenv_opt ()
@@ -249,6 +257,10 @@ EOF
     'let _ = Sys . getenv_opt "MASC_DEFAULT_MODEL"' \
     'let _ = Sys.(getenv_opt "MASC_DEFAULT_MODEL")' \
     'let _ = let open Unix in getenv "PROVIDER_API_KEY"' \
+    'let _ = Unix . gettimeofday ()' \
+    'let _ = Unix.(gettimeofday ())' \
+    'let _ = Wrapper.Unix.gettimeofday ()' \
+    $'module U = Unix\nlet _ = U.gettimeofday ()' \
     'let _ = Unix.environment ()' \
     'let _ = let open Unix in environment ()' \
     $'let _ = Unix.\ngetenv_opt "PROVIDER_API_KEY"' \

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -45,7 +45,7 @@ CAMEL_CASE_BOUNDARY_PATTERN = re.compile(
     r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
 )
 FORBIDDEN_ENV_IDENTIFIERS = frozenset(
-    ("Env_config", "Sys", "Unix", "getenv", "getenv_opt")
+    ("Env_config", "Sys", "Unix", "UnixLabels", "getenv", "getenv_opt")
 )
 POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
 TOKEN_NORMALIZATION = {
@@ -53,6 +53,7 @@ TOKEN_NORMALIZATION = {
     "envs": "env",
     "environments": "env",
     "environment": "env",
+    "getenv": "env",
     "keys": "key",
     "models": "model",
     "providers": "provider",
@@ -62,7 +63,7 @@ TOKEN_NORMALIZATION = {
 
 def is_policy_environment_binding(identifier: str) -> bool:
     tokens = []
-    for snake_part in re.split(r"_+", identifier):
+    for snake_part in re.split(r"[_']+", identifier):
         for camel_part in CAMEL_CASE_BOUNDARY_PATTERN.split(snake_part):
             token = camel_part.rstrip("'").lower()
             if token:
@@ -257,6 +258,11 @@ EOF
     'let _ = Sys . getenv_opt "MASC_DEFAULT_MODEL"' \
     'let _ = Sys.(getenv_opt "MASC_DEFAULT_MODEL")' \
     'let _ = let open Unix in getenv "PROVIDER_API_KEY"' \
+    'let _ = UnixLabels.unsafe_getenv "PROVIDER_API_KEY"' \
+    'let _ = UnixLabels.environment ()' \
+    'let _ = UnixLabels.unsafe_environment ()' \
+    $'module U = UnixLabels\nlet _ = U.unsafe_getenv "PROVIDER_API_KEY"' \
+    'let _ = let open UnixLabels in unsafe_getenv "PROVIDER_API_KEY"' \
     'let _ = Unix . gettimeofday ()' \
     'let _ = Unix.(gettimeofday ())' \
     'let _ = Wrapper.Unix.gettimeofday ()' \
@@ -291,6 +297,10 @@ EOF
     'let _ = ProvidersEnvs.fallback ()' \
     'let _ = ApiKeys_envs.fallback ()' \
     'let _ = CredentialsEnvs.fallback ()' \
+    "let _ = Model'Env.fallback ()" \
+    "let _ = Api'Key'Env.fallback ()" \
+    'let _ = model_getenv ()' \
+    'let _ = ApiKeyGetenv ()' \
     "let _ = model'_env.fallback ()" \
     $'let _quote = \'"\'\nlet _ = Env_config.Model_defaults.default_runtime_opt ()' \
     'let _ = Credential_env.fallback ()'

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -45,7 +45,7 @@ CAMEL_CASE_BOUNDARY_PATTERN = re.compile(
     r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
 )
 FORBIDDEN_ENV_IDENTIFIERS = frozenset(
-    ("Env_config", "Sys", "Unix", "UnixLabels", "getenv", "getenv_opt")
+    ("Env_config", "Sys", "Unix", "UnixLabels", "external", "getenv", "getenv_opt")
 )
 POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
 TOKEN_NORMALIZATION = {
@@ -263,6 +263,7 @@ EOF
     'let _ = UnixLabels.unsafe_environment ()' \
     $'module U = UnixLabels\nlet _ = U.unsafe_getenv "PROVIDER_API_KEY"' \
     'let _ = let open UnixLabels in unsafe_getenv "PROVIDER_API_KEY"' \
+    $'external read_setting : string -> string = "caml_sys_getenv"\nlet _ = read_setting "PROVIDER_API_KEY"' \
     'let _ = Unix . gettimeofday ()' \
     'let _ = Unix.(gettimeofday ())' \
     'let _ = Wrapper.Unix.gettimeofday ()' \

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -29,6 +29,7 @@ FORBIDDEN_IDENTIFIERS = (
     "Provider_runtime_binding",
     "Runtime_model",
     "Keeper_model_labels",
+    "Keeper_context_runtime.effective_model_labels_for_turn",
     "ensure_api_keys_for_labels",
     "ensure_local_discovery_ready",
 )
@@ -141,7 +142,7 @@ PY
 self_test() (
   local fixture first second first_clean second_clean injection
   fixture="$(mktemp -d "${TMPDIR:-/tmp}/keeper-turn-content-boundary.XXXXXX")"
-  trap "rm -rf '${fixture}'" EXIT
+  trap 'rm -rf -- "${fixture}"' EXIT
   mkdir -p "${fixture}/lib/keeper"
   first="${fixture}/lib/keeper/keeper_turn.ml"
   second="${fixture}/lib/keeper/keeper_unified_turn_pre_dispatch.ml"
@@ -174,6 +175,7 @@ EOF
     'let _ = Provider_runtime_binding.find "x"' \
     'let _ = Runtime_model.resolve "x"' \
     'let _ = Keeper_model_labels.configured "x"' \
+    'let _ = Keeper_context_runtime.effective_model_labels_for_turn ctx' \
     'let _ = ensure_api_keys_for_labels []' \
     'let _ = ensure_local_discovery_ready []' \
     'let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"' \

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -37,25 +37,38 @@ FORBIDDEN_IDENTIFIERS = (
 OCAML_IDENTIFIER_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_'])[A-Za-z_][A-Za-z0-9_']*(?![A-Za-z0-9_'])"
 )
-ENV_BINDING_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_']*_env\b", re.IGNORECASE)
 CHAR_LITERAL_PATTERN = re.compile(r"'(?:[^'\\\r\n]|\\[^\r\n])'")
 CAMEL_CASE_BOUNDARY_PATTERN = re.compile(
     r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
 )
-FORBIDDEN_ENV_IDENTIFIERS = frozenset(("Env_config", "getenv", "getenv_opt"))
+FORBIDDEN_ENV_IDENTIFIERS = frozenset(
+    ("Env_config", "environment", "getenv", "getenv_opt")
+)
 POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
+TOKEN_NORMALIZATION = {
+    "credentials": "credential",
+    "environments": "env",
+    "environment": "env",
+    "keys": "key",
+    "models": "model",
+    "providers": "provider",
+    "tokens": "token",
+}
 
 
-def has_policy_token(identifier: str) -> bool:
+def is_policy_environment_binding(identifier: str) -> bool:
     tokens = []
     for snake_part in re.split(r"_+", identifier):
         for camel_part in CAMEL_CASE_BOUNDARY_PATTERN.split(snake_part):
             token = camel_part.rstrip("'").lower()
             if token:
-                tokens.append(token)
-    return any(token in POLICY_TOKENS for token in tokens) or any(
-        left == "api" and right == "key"
-        for left, right in zip(tokens, tokens[1:])
+                tokens.append(TOKEN_NORMALIZATION.get(token, token))
+    return "env" in tokens and (
+        any(token in POLICY_TOKENS for token in tokens)
+        or any(
+            left == "api" and right == "key"
+            for left, right in zip(tokens, tokens[1:])
+        )
     )
 
 
@@ -154,8 +167,8 @@ for raw_path in sys.argv[1:]:
     match = next(
         (
             candidate
-            for candidate in ENV_BINDING_PATTERN.finditer(code)
-            if has_policy_token(candidate.group(0))
+            for candidate in OCAML_IDENTIFIER_PATTERN.finditer(code)
+            if is_policy_environment_binding(candidate.group(0))
         ),
         None,
     )
@@ -190,23 +203,30 @@ self_test() (
     bash "${BASH_SOURCE[0]}" --check >/dev/null
 
   cat >>"${first}" <<'EOF'
-(*
+(* 
 let _ = Provider_runtime_projection.default_execution_model_strings "ignored"
 let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"
+let _ = Unix.environment ()
 *)
 let _decoy = "Keeper_model_labels ensure_api_keys_for_labels"
 let _quoted_decoy = {|
 Provider_runtime_binding ensure_local_discovery_ready
 |}
-let _tagged_decoy = {tag|Env_config getenv getenv_opt|tag}
-let _ordinary_env_decoy = "Env_config getenv getenv_opt"
+let _tagged_decoy = {tag|Env_config environment getenv getenv_opt|tag}
+let _ordinary_env_decoy = "Env_config environment getenv getenv_opt"
 let _quote = '"'
 let _ = Env_configuration.Tokenizer.path
 let _ = getenv_optimal ()
 let _ = my_getenv_opt ()
+let _ = environment_name ()
+let _ = runtime_environment ()
 let _ = Tokenizer_env.path
+let _ = TokenizerEnv.path
 let _ = Remodeling_env.enabled
+let _ = RemodelingEnv.enabled
 let _ = Tokenizer'_env.path
+let _ = modeling_env ()
+let _ = Credentialing_env.path
 EOF
   MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
     bash "${BASH_SOURCE[0]}" --check >/dev/null
@@ -227,6 +247,8 @@ EOF
     'let _ = Sys . getenv_opt "MASC_DEFAULT_MODEL"' \
     'let _ = Sys.(getenv_opt "MASC_DEFAULT_MODEL")' \
     'let _ = let open Unix in getenv "PROVIDER_API_KEY"' \
+    'let _ = Unix.environment ()' \
+    'let _ = let open Unix in environment ()' \
     $'let _ = Unix.\ngetenv_opt "PROVIDER_API_KEY"' \
     'let _ = Unix.getenv "PROVIDER_API_KEY"' \
     'let _ = Env_config.Model_defaults.default_runtime_opt ()' \
@@ -246,6 +268,11 @@ EOF
     "let _ = Env_config'.Model.value" \
     'let _ = ApiKey_env.fallback ()' \
     'let _ = APIKey_env.fallback ()' \
+    'let _ = ApiKeyEnv.fallback ()' \
+    'let _ = apiKeyEnv ()' \
+    'let _ = ApiKeysEnv.fallback ()' \
+    'let _ = Credentials_env.fallback ()' \
+    'let _ = model_env_opt ()' \
     "let _ = model'_env.fallback ()" \
     $'let _quote = \'"\'\nlet _ = Env_config.Model_defaults.default_runtime_opt ()' \
     'let _ = Credential_env.fallback ()'

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -34,24 +34,24 @@ FORBIDDEN_IDENTIFIERS = (
     "ensure_local_discovery_ready",
 )
 
-ENV_READ_PATTERNS = (
-    (
-        "raw environment read",
-        re.compile(r"\b(?:Sys|Unix)\.getenv(?:_opt)?\b"),
-    ),
-    (
-        "provider/model/credential environment projection",
-        re.compile(
-            r"\b(?:"
-            r"Env_config\.(?:[A-Za-z0-9_']+\.)*"
-            r"(?:[A-Za-z0-9']+_)*(?:Provider|Model|Credential|Api_key|Token)"
-            r"(?:_[A-Za-z0-9_']*)?(?:\.[A-Za-z0-9_']+)*"
-            r"|(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_']*_env"
-            r")\b",
-            re.IGNORECASE,
-        ),
-    ),
+RAW_ENV_READ_PATTERN = re.compile(r"\b(?:Sys|Unix)\.getenv(?:_opt)?\b")
+ENV_CONFIG_PATH_PATTERN = re.compile(
+    r"\bEnv_config(?:\.[A-Za-z_][A-Za-z0-9_']*)+\b"
 )
+ENV_BINDING_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_']*_env\b", re.IGNORECASE)
+POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
+
+
+def has_policy_token(identifier: str) -> bool:
+    tokens = [token for token in re.split(r"_+", identifier.lower()) if token]
+    return any(token in POLICY_TOKENS for token in tokens) or any(
+        left == "api" and right == "key"
+        for left, right in zip(tokens, tokens[1:])
+    )
+
+
+def is_policy_env_config_path(path: str) -> bool:
+    return any(has_policy_token(segment) for segment in path.split(".")[1:])
 
 
 def mask_non_code(source: str) -> str:
@@ -126,12 +126,35 @@ for raw_path in sys.argv[1:]:
             failures.append(
                 f"{path}:{location(source, match.start())}: forbidden identifier {identifier}"
             )
-    for label, pattern in ENV_READ_PATTERNS:
-        match = pattern.search(code)
-        if match:
-            failures.append(
-                f"{path}:{location(source, match.start())}: forbidden {label}: {match.group(0)}"
-            )
+    match = RAW_ENV_READ_PATTERN.search(code)
+    if match:
+        failures.append(
+            f"{path}:{location(source, match.start())}: forbidden raw environment read: {match.group(0)}"
+        )
+    match = next(
+        (
+            candidate
+            for candidate in ENV_CONFIG_PATH_PATTERN.finditer(code)
+            if is_policy_env_config_path(candidate.group(0))
+        ),
+        None,
+    )
+    if match:
+        failures.append(
+            f"{path}:{location(source, match.start())}: forbidden provider/model/credential environment projection: {match.group(0)}"
+        )
+    match = next(
+        (
+            candidate
+            for candidate in ENV_BINDING_PATTERN.finditer(code)
+            if has_policy_token(candidate.group(0))
+        ),
+        None,
+    )
+    if match:
+        failures.append(
+            f"{path}:{location(source, match.start())}: forbidden provider/model/credential environment projection: {match.group(0)}"
+        )
 
 if failures:
     print("\n".join(failures), file=sys.stderr)
@@ -169,6 +192,8 @@ Provider_runtime_binding ensure_local_discovery_ready
 |}
 let _ = Env_config.Tokenizer.path
 let _ = Env_config.Remodeling.enabled
+let _ = Tokenizer_env.path
+let _ = Remodeling_env.enabled
 EOF
   MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
     bash "${BASH_SOURCE[0]}" --check >/dev/null
@@ -188,6 +213,10 @@ EOF
     'let _ = Env_config.Default_model.value' \
     'let _ = Env_config.Cloud_provider.key' \
     'let _ = Env_config.Runtime_api_key.path' \
+    'let _ = Env_config._model.value' \
+    'let _ = Env_config.Default__model.value' \
+    'let _ = Env_config.Runtime__api_key.path' \
+    'let _ = Env_config.Nested.Default_model.value' \
     'let _ = Credential_env.fallback ()'
   do
     cp "${first_clean}" "${first}"

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -42,11 +42,12 @@ CAMEL_CASE_BOUNDARY_PATTERN = re.compile(
     r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])"
 )
 FORBIDDEN_ENV_IDENTIFIERS = frozenset(
-    ("Env_config", "environment", "getenv", "getenv_opt")
+    ("Env_config", "Sys", "Unix", "getenv", "getenv_opt")
 )
 POLICY_TOKENS = frozenset(("provider", "model", "credential", "token"))
 TOKEN_NORMALIZATION = {
     "credentials": "credential",
+    "envs": "env",
     "environments": "env",
     "environment": "env",
     "keys": "key",
@@ -218,6 +219,7 @@ let _quote = '"'
 let _ = Env_configuration.Tokenizer.path
 let _ = getenv_optimal ()
 let _ = my_getenv_opt ()
+let environment = execution_context
 let _ = environment_name ()
 let _ = runtime_environment ()
 let _ = Tokenizer_env.path
@@ -273,6 +275,10 @@ EOF
     'let _ = ApiKeysEnv.fallback ()' \
     'let _ = Credentials_env.fallback ()' \
     'let _ = model_env_opt ()' \
+    'let _ = Models_envs.fallback ()' \
+    'let _ = ProvidersEnvs.fallback ()' \
+    'let _ = ApiKeys_envs.fallback ()' \
+    'let _ = CredentialsEnvs.fallback ()' \
     "let _ = model'_env.fallback ()" \
     $'let _quote = \'"\'\nlet _ = Env_config.Model_defaults.default_runtime_opt ()' \
     'let _ = Credential_env.fallback ()'

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -43,7 +43,9 @@ ENV_READ_PATTERNS = (
         "provider/model/credential environment projection",
         re.compile(
             r"\b(?:"
-            r"Env_config\.[A-Za-z0-9_'.]*(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_'.]*"
+            r"Env_config\.(?:[A-Za-z0-9_']+\.)*"
+            r"(?:Provider|Model|Credential|Api_key|Token)"
+            r"(?:_[A-Za-z0-9_']+)?(?:\.[A-Za-z0-9_']+)*"
             r"|(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_']*_env"
             r")\b",
             re.IGNORECASE,
@@ -165,6 +167,8 @@ let _decoy = "Keeper_model_labels ensure_api_keys_for_labels"
 let _quoted_decoy = {|
 Provider_runtime_binding ensure_local_discovery_ready
 |}
+let _ = Env_config.Tokenizer.path
+let _ = Env_config.Remodeling.enabled
 EOF
   MASC_KEEPER_TURN_CONTENT_BOUNDARY_ROOT="${fixture}" \
     bash "${BASH_SOURCE[0]}" --check >/dev/null

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -43,7 +43,7 @@ ENV_READ_PATTERNS = (
         "provider/model/credential environment projection",
         re.compile(
             r"\b(?:"
-            r"Env_config\.[A-Za-z0-9_'.]*(?:Provider|Model|Credential|Api_key|Token)"
+            r"Env_config\.[A-Za-z0-9_'.]*(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_'.]*"
             r"|(?:Provider|Model|Credential|Api_key|Token)[A-Za-z0-9_']*_env"
             r")\b",
             re.IGNORECASE,

--- a/scripts/check-keeper-turn-content-boundary.sh
+++ b/scripts/check-keeper-turn-content-boundary.sh
@@ -29,7 +29,7 @@ FORBIDDEN_IDENTIFIERS = (
     "Provider_runtime_binding",
     "Runtime_model",
     "Keeper_model_labels",
-    "Keeper_context_runtime.effective_model_labels_for_turn",
+    "effective_model_labels_for_turn",
     "ensure_api_keys_for_labels",
     "ensure_local_discovery_ready",
 )
@@ -219,6 +219,8 @@ EOF
     'let _ = Keeper_model_labels.configured "x"' \
     'let _ = Keeper_context_runtime.effective_model_labels_for_turn ctx' \
     'let _ = Keeper_context_runtime . effective_model_labels_for_turn ctx' \
+    'let _ = Keeper_context_runtime.(effective_model_labels_for_turn ctx)' \
+    'let _ = let open Keeper_context_runtime in effective_model_labels_for_turn ctx' \
     'let _ = ensure_api_keys_for_labels []' \
     'let _ = ensure_local_discovery_ready []' \
     'let _ = Sys.getenv_opt "MASC_DEFAULT_MODEL"' \

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -53,6 +53,8 @@ blocking_lints() {
   run_lint "Tool substrate adapter surface" bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
   run_lint "Tool -> Keeper dependency-direction ratchet (RFC-0194)" bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
   run_lint "MASC domain ownership ratchet" bash scripts/lint/masc-domain-boundary-ratchet.sh --fail
+  run_lint "Keeper turn content boundary self-test" bash scripts/check-keeper-turn-content-boundary.sh --self-test
+  run_lint "Keeper turn content boundary" bash scripts/check-keeper-turn-content-boundary.sh --check
   run_lint "Compaction exact-flow boundary self-test" bash scripts/check-compaction-exact-flow-boundary.sh --self-test
   run_lint "Compaction exact-flow boundary" bash scripts/check-compaction-exact-flow-boundary.sh
   run_lint "No Tool_result.error + Printexc (RFC-0148)" bash scripts/lint/no-tool-result-error-printexc.sh


### PR DESCRIPTION
## Summary
- remove provider/model/credential projection and no-op readiness evaluation from Keeper turn pre-dispatch surfaces
- delete orphaned no-op helper APIs and default-model aliases
- add a semantic Keeper turn content-boundary ratchet with a non-vacuous self-test and blocking lint-suite wiring

## Scope
- based on `origin/main` at merged #25728 (`abdaa3ab61c35ad597be904b1dea0f75e2d898b6`)
- runtime inference, modality reroute, schema, failover, dashboard, and historical JSON are unchanged

## Validation
- not run locally per task instruction; CI is the compile and ratchet authority

## Test coverage exception

# ci:skip-test-coverage

This PR deletes pre-dispatch policy evaluation and adds a boundary ratchet with its own --self-test; it does not add a runtime behavior that warrants a duplicate product test.
