### PR TITLE
feat(fs): add capability-relative strict HEAD CAS

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -86,6 +86,7 @@
   (eio_posix (>= 0.16))
   (cstruct (>= 6.0))
   (digestif (>= 1.1))
+  (optint)
   (ocaml-protoc-plugin (>= 4.0))
   (pbrt (and (>= 3.0) (< 4.0)))
   ; [ctypes] + [ctypes-foreign] removed: zero callers in lib/ bin/ test/

--- a/dune-project
+++ b/dune-project
@@ -86,7 +86,7 @@
   (eio_posix (>= 0.16))
   (cstruct (>= 6.0))
   (digestif (>= 1.1))
-  (optint)
+  optint
   (ocaml-protoc-plugin (>= 4.0))
   (pbrt (and (>= 3.0) (< 4.0)))
   ; [ctypes] + [ctypes-foreign] removed: zero callers in lib/ bin/ test/

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -331,7 +331,7 @@ let try_lock file =
          Eio_unix.run_in_systhread
            ~label:"capability_head.try_lock"
            (fun () ->
-             ignore (Unix.lseek raw_fd 0 Unix.SEEK_SET);
+             let _position = Unix.lseek raw_fd 0 Unix.SEEK_SET in
              Unix.lockf raw_fd Unix.F_TLOCK 0));
        Ok ()
      with
@@ -347,7 +347,7 @@ let fresh_epoch secure_random =
 
 let write_initial_marker file epoch =
   protect_io Initialize_lock_marker (fun () ->
-    ignore (Eio.File.seek file (Optint.Int63.of_int 0) `Set);
+    let _position = Eio.File.seek file (Optint.Int63.of_int 0) `Set in
     Eio.Flow.copy_string (marker epoch) file;
     Eio.File.sync file)
 
@@ -679,6 +679,9 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
           in
           let cleanup_stage = ref true in
           let stage_identity = ref None in
+          (* fun-protect-finally-ok: identity-checked stage cleanup must run
+             while the protected Eio switch is alive; cleanup failures are
+             caught and retained as settlement warnings. *)
           Fun.protect
             ~finally:(fun () ->
               if !cleanup_stage

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -50,7 +50,8 @@ type snapshot =
 
 let snapshot_row snapshot = snapshot.row
 let snapshot_cursor snapshot = snapshot.cursor
-let snapshot_settlement_warnings snapshot = snapshot.settlement_warnings
+let snapshot_settlement_warnings (snapshot : snapshot) =
+  snapshot.settlement_warnings
 
 type error =
   | Invalid_leaf of string
@@ -536,11 +537,11 @@ let verify_lock_binding lock =
 
 let normalize_result ~warnings ~set_success_warnings = function
   | Ok value -> Ok (set_success_warnings value warnings)
-  | Error failure ->
-    Error
-      { failure with
-        settlement_warnings = failure.settlement_warnings @ warnings
-      }
+    | Error (failed : failure) ->
+      Error
+        { failed with
+          settlement_warnings = failed.settlement_warnings @ warnings
+        }
 
 let run_transaction ~hooks ~parent ~leaf ~publication_state ~set_success_warnings transaction =
   Eio.Fiber.check ();

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -537,11 +537,11 @@ let verify_lock_binding lock =
 
 let normalize_result ~warnings ~set_success_warnings = function
   | Ok value -> Ok (set_success_warnings value warnings)
-    | Error (failed : failure) ->
-      Error
-        { failed with
-          settlement_warnings = failed.settlement_warnings @ warnings
-        }
+  | Error (failed : failure) ->
+    Error
+      { failed with
+        settlement_warnings = failed.settlement_warnings @ warnings
+      }
 
 let run_transaction ~hooks ~parent ~leaf ~publication_state ~set_success_warnings transaction =
   Eio.Fiber.check ();
@@ -616,11 +616,19 @@ let read ~secure_random ~parent ~leaf =
       ~parent
       ~leaf
       ~publication_state
-      ~set_success_warnings:(fun snapshot warnings ->
+      ~set_success_warnings:(fun (snapshot : snapshot) warnings ->
         { snapshot with settlement_warnings = snapshot.settlement_warnings @ warnings })
       (fun ~sw ~parent ~parent_stat ~warnings:_ ->
-        let* lock = open_lock ~sw ~secure_random ~parent ~leaf in
-        let* snapshot = read_current ~sw ~parent ~parent_stat ~leaf ~lock in
+        let* lock =
+          match open_lock ~sw ~secure_random ~parent ~leaf with
+          | Ok lock -> Ok lock
+          | Error error -> Error (failure error)
+        in
+        let* snapshot =
+          match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+          | Ok snapshot -> Ok snapshot
+          | Error error -> Error (failure error)
+        in
         Ok snapshot)
 
 let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row =

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -99,7 +99,6 @@ let publication_settlement_warnings publication = publication.settlement_warning
 let max_row_bytes = 64 * 1024
 let max_lock_marker_bytes = 128
 let lock_magic = "MASC-CAPABILITY-HEAD-LOCK-v2"
-let stage_counter = Atomic.make 0
 
 let ( let* ) result fn =
   match result with
@@ -481,25 +480,26 @@ let read_current ~sw ~parent ~parent_stat ~leaf ~lock =
 let cursor_equal left right =
   left = right
 
-let stage_leaf ~leaf ~payload =
-  let serial = Atomic.fetch_and_add stage_counter 1 in
-  let digest = sha256 (Printf.sprintf "%s\000%s\000%d" leaf payload serial) in
-  ".masc-capability-head-stage-" ^ String.sub digest 0 32
+let fresh_stage_leaf secure_random =
+  protect_io Create_stage (fun () ->
+    let entropy = Cstruct.create 32 in
+    Eio.Flow.read_exact secure_random entropy;
+    ".masc-capability-head-stage-" ^ sha256 (Cstruct.to_string entropy))
 
-let rec create_stage ~sw ~parent ~leaf ~payload attempts =
+let rec create_stage ~sw ~secure_random ~parent attempts =
   if attempts = 0
   then Error (Io_error { operation = Create_stage; detail = "stage namespace exhausted" })
   else
-    let stage_leaf = stage_leaf ~leaf ~payload in
+    let* stage_leaf = fresh_stage_leaf secure_random in
     let path = Eio.Path.(parent / stage_leaf) in
-    try
-      let file = Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) path in
-      Ok (path, file)
-    with
-    | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
-      create_stage ~sw ~parent ~leaf ~payload (attempts - 1)
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Io_error (diagnostic Create_stage exn))
+    (try
+       let file = Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) path in
+       Ok (path, file)
+     with
+     | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
+       create_stage ~sw ~secure_random ~parent (attempts - 1)
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Io_error (diagnostic Create_stage exn)))
 
 let write_stage ~path file payload =
   let* () = protect_io Write_stage (fun () -> Eio.Flow.copy_string payload file) in
@@ -662,7 +662,7 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
             }
           in
           let* stage_path, stage_file =
-            match create_stage ~sw ~parent ~leaf ~payload 32 with
+            match create_stage ~sw ~secure_random ~parent 32 with
             | Ok stage -> Ok stage
             | Error error -> fail error
           in

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -207,8 +207,8 @@ let target_effect_of_transaction = function
   | Renamed evidence -> Publication_indeterminate evidence
   | Durable evidence -> Published evidence
 
-let failure_for_effect effect error =
-  failure ~target_effect:(target_effect_of_transaction effect) error
+let failure_for_effect publication_state error =
+  failure ~target_effect:(target_effect_of_transaction publication_state) error
 
 let validate_leaf leaf =
   if String.equal leaf ""
@@ -542,7 +542,7 @@ let normalize_result ~warnings ~set_success_warnings = function
         settlement_warnings = failure.settlement_warnings @ warnings
       }
 
-let run_transaction ~hooks ~parent ~leaf ~effect ~set_success_warnings transaction =
+let run_transaction ~hooks ~parent ~leaf ~publication_state ~set_success_warnings transaction =
   Eio.Fiber.check ();
   let token = ref None in
   let completed = ref None in
@@ -580,7 +580,7 @@ let run_transaction ~hooks ~parent ~leaf ~effect ~set_success_warnings transacti
             result)
       with
       | Eio.Cancel.Cancelled _ as exn
-        when !effect = Before_publication && Option.is_none !completed ->
+        when !publication_state = Before_publication && Option.is_none !completed ->
         raise exn
       | exn ->
         let detail = diagnostic_of_exception Settle_resources exn in
@@ -595,7 +595,7 @@ let run_transaction ~hooks ~parent ~leaf ~effect ~set_success_warnings transacti
              }
          | None ->
            Error
-             { (failure_for_effect !effect (Io_error detail)) with
+             { (failure_for_effect !publication_state (Io_error detail)) with
                settlement_warnings = List.rev !warnings
              }))
 
@@ -603,12 +603,12 @@ let read ~secure_random ~parent ~leaf =
   match validate_leaf leaf with
   | Error error -> Error (failure error)
   | Ok () ->
-    let effect = ref Before_publication in
+    let publication_state = ref Before_publication in
     run_transaction
       ~hooks:no_hooks
       ~parent
       ~leaf
-      ~effect
+      ~publication_state
       ~set_success_warnings:(fun snapshot warnings ->
         { snapshot with settlement_warnings = snapshot.settlement_warnings @ warnings })
       (fun ~sw ~parent ~parent_stat ~warnings:_ ->
@@ -620,18 +620,18 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
   match validate_leaf leaf, validate_row row with
   | Error error, _ | _, Error error -> Error (failure error)
   | Ok (), Ok () ->
-    let effect = ref Before_publication in
+    let publication_state = ref Before_publication in
     run_transaction
       ~hooks
       ~parent
       ~leaf
-      ~effect
+      ~publication_state
       ~set_success_warnings:(fun publication warnings ->
         { publication with
           settlement_warnings = publication.settlement_warnings @ warnings
         })
       (fun ~sw ~parent ~parent_stat ~warnings ->
-        let fail error = Error (failure_for_effect !effect error) in
+        let fail error = Error (failure_for_effect !publication_state error) in
         let* lock =
           match open_lock ~sw ~secure_random ~parent ~leaf with
           | Ok lock -> Ok lock
@@ -714,7 +714,7 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
                   | Error error -> fail error
                 in
                 cleanup_stage := false;
-                effect := Renamed indeterminate;
+                publication_state := Renamed indeterminate;
                 invoke_hook Rename_head hooks.after_rename;
                 let* () =
                   match sync_parent parent with
@@ -727,7 +727,7 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
                   | Ok published -> Ok published
                   | Error error -> fail error
                 in
-                effect :=
+                publication_state :=
                   Renamed { indeterminate with observed = Some published.cursor };
                 match published.row, published.cursor.target with
                 | Some observed_row, Some observed_target
@@ -741,7 +741,7 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
                     ; published_cursor = published.cursor
                     }
                   in
-                  effect := Durable evidence;
+                  publication_state := Durable evidence;
                   invoke_hook Verify_publication hooks.after_verified;
                   Ok { evidence; settlement_warnings = [] }
                 | _ -> fail (Corrupt_head "published HEAD does not match the staged row"))))

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -744,7 +744,7 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
                   effect := Durable evidence;
                   invoke_hook Verify_publication hooks.after_verified;
                   Ok { evidence; settlement_warnings = [] }
-                | _ -> fail (Corrupt_head "published HEAD does not match the staged row")))
+                | _ -> fail (Corrupt_head "published HEAD does not match the staged row"))))
 
 let compare_and_swap ~secure_random ~parent ~leaf ~expected ~row =
   compare_and_swap_internal ~hooks:no_hooks ~secure_random ~parent ~leaf ~expected ~row

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -99,6 +99,7 @@ let publication_settlement_warnings publication = publication.settlement_warning
 let max_row_bytes = 64 * 1024
 let max_lock_marker_bytes = 128
 let lock_magic = "MASC-CAPABILITY-HEAD-LOCK-v2"
+let internal_leaf_prefix = ".masc-capability-head-"
 
 let ( let* ) result fn =
   match result with
@@ -214,6 +215,7 @@ let validate_leaf leaf =
   if String.equal leaf ""
      || String.equal leaf "."
      || String.equal leaf ".."
+     || String.starts_with ~prefix:internal_leaf_prefix leaf
      || String.exists (fun char -> Char.equal char '/' || Char.equal char '\000') leaf
   then Error (Invalid_leaf leaf)
   else Ok ()
@@ -228,7 +230,7 @@ let validate_row row =
   else Ok ()
 
 let lock_leaf leaf =
-  ".masc-capability-head-" ^ sha256 leaf ^ ".lock"
+  internal_leaf_prefix ^ sha256 leaf ^ ".lock"
 
 let marker epoch =
   Printf.sprintf "%s %s\n" lock_magic epoch
@@ -484,7 +486,7 @@ let fresh_stage_leaf secure_random =
   protect_io Create_stage (fun () ->
     let entropy = Cstruct.create 32 in
     Eio.Flow.read_exact secure_random entropy;
-    ".masc-capability-head-stage-" ^ sha256 (Cstruct.to_string entropy))
+    internal_leaf_prefix ^ "stage-" ^ sha256 (Cstruct.to_string entropy))
 
 let rec create_stage ~sw ~secure_random ~parent attempts =
   if attempts = 0

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -555,8 +555,14 @@ let run_transaction ~hooks ~parent ~leaf ~publication_state ~set_success_warning
           Eio.Switch.on_release sw (fun () ->
             try hooks.on_resource_settlement () with
             | exn -> raise (Hook_failed (diagnostic Settle_resources exn)));
-          let exact_parent = Eio.Path.open_dir ~sw parent in
-          let parent_stat = Eio.Path.stat ~follow:false exact_parent in
+          let exact_parent, parent_stat =
+            try
+              let exact_parent = Eio.Path.open_dir ~sw parent in
+              exact_parent, Eio.Path.stat ~follow:false exact_parent
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn -> raise (Hook_failed (diagnostic Pin_parent exn))
+          in
           match
             Lease.try_acquire
               ~parent_dev:parent_stat.dev
@@ -684,11 +690,12 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
               in
               let* () =
                 match
-                  verify_path_binding
-                    ~path:stage_path
-                    ~opened_stat:stage_stat
-                    ~what:"stage"
-                    ~corrupt:(fun detail -> Io_error { operation = Revalidate; detail })
+                  protect_result Revalidate (fun () ->
+                    verify_path_binding
+                      ~path:stage_path
+                      ~opened_stat:stage_stat
+                      ~what:"stage"
+                      ~corrupt:(fun detail -> Io_error { operation = Revalidate; detail }))
                 with
                 | Ok () -> Ok ()
                 | Error error -> fail error
@@ -703,7 +710,7 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
               else (
                 invoke_hook Revalidate hooks.before_rename;
                 let* () =
-                  match verify_lock_binding lock with
+                  match protect_result Revalidate (fun () -> verify_lock_binding lock) with
                   | Ok () -> Ok ()
                   | Error error -> fail error
                 in

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -1,0 +1,693 @@
+type lock_state =
+  | Virgin
+  | Active
+
+type target_fingerprint =
+  { dev : int64
+  ; ino : int64
+  ; length : int64
+  ; sha256 : string
+  }
+
+type cursor =
+  { parent_dev : int64
+  ; parent_ino : int64
+  ; leaf : string
+  ; lock_dev : int64
+  ; lock_ino : int64
+  ; lock_epoch : string
+  ; lock_state : lock_state
+  ; target : target_fingerprint option
+  }
+
+type snapshot =
+  { row : string option
+  ; cursor : cursor
+  ; settlement_warnings : string list
+  }
+
+let snapshot_row snapshot = snapshot.row
+let snapshot_cursor snapshot = snapshot.cursor
+let snapshot_settlement_warnings snapshot = snapshot.settlement_warnings
+
+type io_error =
+  { operation : string
+  ; detail : string
+  }
+
+type error =
+  | Invalid_leaf of string
+  | Invalid_row of string
+  | Busy
+  | Conflict of snapshot
+  | Corrupt_lock of string
+  | Corrupt_head of string
+  | Unsupported of string
+  | Io_error of io_error
+
+type publication_indeterminate =
+  { intended_sha256 : string
+  ; intended_length : int64
+  ; observed : cursor option
+  }
+
+type target_effect =
+  | Unchanged
+  | Publication_indeterminate of publication_indeterminate
+
+type failure =
+  { error : error
+  ; target_effect : target_effect
+  ; settlement_warnings : string list
+  }
+
+type publication =
+  { cursor : cursor
+  ; settlement_warnings : string list
+  }
+
+let publication_cursor publication = publication.cursor
+let publication_settlement_warnings publication = publication.settlement_warnings
+
+module Lease = struct
+  module Key = struct
+    type t = int64 * int64 * string
+
+    let equal (left_dev, left_ino, left_leaf) (right_dev, right_ino, right_leaf) =
+      Int64.equal left_dev right_dev
+      && Int64.equal left_ino right_ino
+      && String.equal left_leaf right_leaf
+
+    let hash = Hashtbl.hash
+  end
+
+  module Held = Hashtbl.Make (Key)
+
+  type token = Key.t
+
+  let mutex = Mutex.create ()
+  let held = Held.create 32
+
+  let try_acquire ~parent_dev ~parent_ino ~leaf =
+    let key = parent_dev, parent_ino, leaf in
+    Mutex.protect mutex (fun () ->
+      if Held.mem held key
+      then None
+      else (
+        Held.add held key ();
+        Some key))
+
+  let release token =
+    Mutex.protect mutex (fun () ->
+      if not (Held.mem held token)
+      then invalid_arg "Capability_head.Lease.release: token is not held";
+      Held.remove held token)
+end
+
+type lock_handle =
+  { file : Eio.File.rw_ty Eio.Resource.t
+  ; path : Eio.Fs.dir_ty Eio.Path.t
+  ; stat : Eio.File.Stat.t
+  ; epoch : string
+  ; state : lock_state
+  }
+
+type transaction_effect =
+  | Before_publication
+  | Renamed of publication_indeterminate
+  | Durable of cursor
+
+let lock_magic = "MASC-CAPABILITY-HEAD-LOCK-v1"
+let max_lock_marker_bytes = 256
+let stage_counter = Atomic.make 0
+
+let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let exception_detail exn =
+  Printexc.to_string exn
+
+let io_error operation exn =
+  Io_error { operation; detail = exception_detail exn }
+
+let failure ?(target_effect = Unchanged) error =
+  { error; target_effect; settlement_warnings = [] }
+
+let target_effect_of_transaction = function
+  | Before_publication -> Unchanged
+  | Renamed evidence -> Publication_indeterminate evidence
+  | Durable _ -> Unchanged
+
+let failure_for_effect effect error =
+  failure ~target_effect:(target_effect_of_transaction effect) error
+
+let validate_leaf leaf =
+  if String.equal leaf ""
+     || String.equal leaf "."
+     || String.equal leaf ".."
+     || String.exists (fun char -> Char.equal char '/' || Char.equal char '\000') leaf
+  then Error (Invalid_leaf leaf)
+  else Ok ()
+
+let validate_row row =
+  if String.equal row ""
+  then Error (Invalid_row "HEAD row must be non-empty")
+  else if String.exists (fun char -> Char.equal char '\n' || Char.equal char '\r') row
+  then Error (Invalid_row "HEAD row must not contain CR or LF")
+  else Ok ()
+
+let lock_state_name = function
+  | Virgin -> "virgin"
+  | Active -> "active"
+
+let lock_leaf leaf =
+  ".masc-capability-head-" ^ sha256 leaf ^ ".lock"
+
+let is_lower_hex value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+
+let marker ~state ~epoch =
+  Printf.sprintf "%s %s %s\n" lock_magic (lock_state_name state) epoch
+
+let parse_marker value =
+  let length = String.length value in
+  if length = 0
+  then Error (Corrupt_lock "stable lock marker is empty")
+  else if not (Char.equal value.[length - 1] '\n')
+  then Error (Corrupt_lock "stable lock marker is not LF-terminated")
+  else
+    let body = String.sub value 0 (length - 1) in
+    if String.exists (fun char -> Char.equal char '\n' || Char.equal char '\r') body
+    then Error (Corrupt_lock "stable lock marker contains multiple rows or CR")
+    else
+      match String.split_on_char ' ' body with
+      | [ magic; state; epoch ] when String.equal magic lock_magic && is_lower_hex epoch ->
+        (match state with
+         | "virgin" -> Ok (Virgin, epoch)
+         | "active" -> Ok (Active, epoch)
+         | _ -> Error (Corrupt_lock "stable lock marker has an unknown state"))
+      | _ -> Error (Corrupt_lock "stable lock marker has an invalid shape")
+
+let same_identity (left : Eio.File.Stat.t) (right : Eio.File.Stat.t) =
+  Int64.equal left.dev right.dev && Int64.equal left.ino right.ino
+
+let same_open_file (left : Eio.File.Stat.t) (right : Eio.File.Stat.t) =
+  same_identity left right
+  && Int64.equal
+       (Optint.Int63.to_int64 left.size)
+       (Optint.Int63.to_int64 right.size)
+
+let validate_private_regular ~what ~corrupt (stat : Eio.File.Stat.t) =
+  if stat.kind <> `Regular_file
+  then Error (corrupt (what ^ " is not a regular file"))
+  else if not (Int64.equal stat.nlink 1L)
+  then Error (corrupt (what ^ " must have exactly one hard link"))
+  else if stat.perm land 0o777 <> 0o600
+  then Error (corrupt (what ^ " must have mode 0600"))
+  else Ok ()
+
+let verify_path_binding ~path ~opened_stat ~what ~corrupt =
+  match Eio.Path.kind ~follow:false path with
+  | `Regular_file ->
+    let path_stat = Eio.Path.stat ~follow:false path in
+    if same_identity opened_stat path_stat
+    then Ok ()
+    else Error (corrupt (what ^ " path no longer names the opened inode"))
+  | `Not_found -> Error (corrupt (what ^ " path disappeared"))
+  | `Symbolic_link -> Error (corrupt (what ^ " path is a symbolic link"))
+  | _ -> Error (corrupt (what ^ " path is not a regular file"))
+
+let read_open_file ~max_bytes ~what ~corrupt file =
+  let before = Eio.File.stat file in
+  let size64 = Optint.Int63.to_int64 before.size in
+  if Int64.compare size64 0L < 0
+  then Error (corrupt (what ^ " has a negative size"))
+  else if Int64.compare size64 (Int64.of_int max_bytes) > 0
+  then Error (corrupt (what ^ " exceeds its byte bound"))
+  else
+    let size = Int64.to_int size64 in
+    ignore (Eio.File.seek file (Optint.Int63.of_int 0) `Set);
+    let value = Eio.Flow.read_all ~max_size:(max_bytes + 1) file in
+    let after = Eio.File.stat file in
+    if not (same_open_file before after)
+    then Error (corrupt (what ^ " changed while it was being read"))
+    else if String.length value <> size
+    then Error (corrupt (what ^ " size changed while it was being read"))
+    else Ok (value, after)
+
+let write_exact file value =
+  Eio.File.truncate file (Optint.Int63.of_int 0);
+  ignore (Eio.File.seek file (Optint.Int63.of_int 0) `Set);
+  Eio.Flow.copy_string value file;
+  Eio.File.truncate file (Optint.Int63.of_int (String.length value));
+  Eio.File.sync file
+
+let sync_parent parent =
+  let resource, _relative = parent in
+  match Eio_unix.Resource.fd_opt resource with
+  | None -> Error (Unsupported "parent directory capability has no Unix file descriptor")
+  | Some fd ->
+    (try
+       Eio_unix.Fd.use_exn "capability_head.sync_parent" fd (fun raw_fd ->
+         Eio_unix.run_in_systhread
+           ~label:"capability_head.sync_parent"
+           (fun () -> Unix.fsync raw_fd));
+       Ok ()
+     with
+     | exn -> Error (io_error "sync_parent" exn))
+
+let try_lock file =
+  match Eio_unix.Resource.fd_opt file with
+  | None -> Error (Unsupported "stable lock has no Unix file descriptor")
+  | Some fd ->
+    (try
+       Eio_unix.Fd.use_exn "capability_head.try_lock" fd (fun raw_fd ->
+         Eio_unix.run_in_systhread
+           ~label:"capability_head.try_lock"
+           (fun () ->
+             ignore (Unix.lseek raw_fd 0 Unix.SEEK_SET);
+             Unix.lockf raw_fd Unix.F_TLOCK 0));
+       Ok ()
+     with
+     | Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> Error Busy
+     | exn -> Error (io_error "try_lock" exn))
+
+let epoch_for_lock ~parent_stat ~leaf (lock_stat : Eio.File.Stat.t) =
+  sha256
+    (Printf.sprintf
+       "%Ld\000%Ld\000%s\000%Ld\000%Ld\000%.17g\000%.17g"
+       parent_stat.Eio.File.Stat.dev
+       parent_stat.ino
+       leaf
+       lock_stat.dev
+       lock_stat.ino
+       lock_stat.ctime
+       lock_stat.mtime)
+
+let open_lock ~sw ~parent ~parent_stat ~leaf =
+  let target_path = Eio.Path.(parent / leaf) in
+  let path = Eio.Path.(parent / lock_leaf leaf) in
+  match Eio.Path.kind ~follow:false path with
+  | (`Not_found | `Regular_file) ->
+    let file = Eio.Path.open_out ~sw ~create:(`If_missing 0o600) path in
+    (match try_lock file with
+     | Error error -> Error error
+     | Ok () ->
+       let opened_stat = Eio.File.stat file in
+       (match
+          validate_private_regular
+            ~what:"stable lock"
+            ~corrupt:(fun detail -> Corrupt_lock detail)
+            opened_stat
+        with
+        | Error error -> Error error
+        | Ok () ->
+          (match
+             verify_path_binding
+               ~path
+               ~opened_stat
+               ~what:"stable lock"
+               ~corrupt:(fun detail -> Corrupt_lock detail)
+           with
+           | Error error -> Error error
+           | Ok () ->
+             (match
+                read_open_file
+                  ~max_bytes:max_lock_marker_bytes
+                  ~what:"stable lock marker"
+                  ~corrupt:(fun detail -> Corrupt_lock detail)
+                  file
+              with
+              | Error error -> Error error
+              | Ok ("", _) ->
+                (match Eio.Path.kind ~follow:false target_path with
+                 | `Not_found ->
+                   Eio.File.sync file;
+                   (match sync_parent parent with
+                    | Error error -> Error error
+                    | Ok () ->
+                      let epoch = epoch_for_lock ~parent_stat ~leaf opened_stat in
+                      write_exact file (marker ~state:Virgin ~epoch);
+                      Ok { file; path; stat = opened_stat; epoch; state = Virgin })
+                 | _ ->
+                   Error
+                     (Corrupt_lock
+                        "empty stable lock exists beside a non-empty HEAD namespace"))
+              | Ok (value, _) ->
+                (match parse_marker value with
+                 | Error error -> Error error
+                 | Ok (state, epoch) ->
+                   Ok { file; path; stat = opened_stat; epoch; state })))))
+  | `Symbolic_link -> Error (Corrupt_lock "stable lock path is a symbolic link")
+  | _ -> Error (Corrupt_lock "stable lock path is not a regular file")
+
+let parse_head_payload payload =
+  let length = String.length payload in
+  if length < 2
+  then Error (Corrupt_head "HEAD must contain one non-empty LF-terminated row")
+  else if not (Char.equal payload.[length - 1] '\n')
+  then Error (Corrupt_head "HEAD is not LF-terminated")
+  else
+    let row = String.sub payload 0 (length - 1) in
+    if String.exists (fun char -> Char.equal char '\n' || Char.equal char '\r') row
+    then Error (Corrupt_head "HEAD contains multiple rows or CR")
+    else Ok row
+
+let read_target ~sw ~parent ~leaf =
+  let path = Eio.Path.(parent / leaf) in
+  match Eio.Path.kind ~follow:false path with
+  | `Not_found -> Ok None
+  | `Regular_file ->
+    let file = Eio.Path.open_in ~sw path in
+    let opened_stat = Eio.File.stat file in
+    (match
+       validate_private_regular
+         ~what:"HEAD"
+         ~corrupt:(fun detail -> Corrupt_head detail)
+         opened_stat
+     with
+     | Error error -> Error error
+     | Ok () ->
+       (match
+          verify_path_binding
+            ~path
+            ~opened_stat
+            ~what:"HEAD"
+            ~corrupt:(fun detail -> Corrupt_head detail)
+        with
+        | Error error -> Error error
+        | Ok () ->
+          let max_bytes = Sys.max_string_length - 1 in
+          (match
+             read_open_file
+               ~max_bytes
+               ~what:"HEAD"
+               ~corrupt:(fun detail -> Corrupt_head detail)
+               file
+           with
+           | Error error -> Error error
+           | Ok (payload, final_stat) ->
+             (match
+                verify_path_binding
+                  ~path
+                  ~opened_stat:final_stat
+                  ~what:"HEAD"
+                  ~corrupt:(fun detail -> Corrupt_head detail)
+              with
+              | Error error -> Error error
+              | Ok () ->
+                (match parse_head_payload payload with
+                 | Error error -> Error error
+                 | Ok row ->
+                   let fingerprint =
+                     { dev = final_stat.dev
+                     ; ino = final_stat.ino
+                     ; length = Int64.of_int (String.length payload)
+                     ; sha256 = sha256 payload
+                     }
+                   in
+                   Ok (Some (row, fingerprint)))))))
+  | `Symbolic_link -> Error (Corrupt_head "HEAD path is a symbolic link")
+  | _ -> Error (Corrupt_head "HEAD path is not a regular file")
+
+let verify_lock_binding lock =
+  verify_path_binding
+    ~path:lock.path
+    ~opened_stat:lock.stat
+    ~what:"stable lock"
+    ~corrupt:(fun detail -> Corrupt_lock detail)
+
+let activate_lock lock =
+  match verify_lock_binding lock with
+  | Error error -> Error error
+  | Ok () ->
+    write_exact lock.file (marker ~state:Active ~epoch:lock.epoch);
+    Ok { lock with state = Active }
+
+let make_cursor ~parent_stat ~leaf ~lock ~target =
+  { parent_dev = parent_stat.Eio.File.Stat.dev
+  ; parent_ino = parent_stat.ino
+  ; leaf
+  ; lock_dev = lock.stat.dev
+  ; lock_ino = lock.stat.ino
+  ; lock_epoch = lock.epoch
+  ; lock_state = lock.state
+  ; target
+  }
+
+let read_current ~sw ~parent ~parent_stat ~leaf ~lock =
+  match read_target ~sw ~parent ~leaf with
+  | Error error -> Error error
+  | Ok None ->
+    (match lock.state with
+     | Active -> Error (Corrupt_head "an active stable lock has no HEAD")
+     | Virgin ->
+       let cursor = make_cursor ~parent_stat ~leaf ~lock ~target:None in
+       Ok ({ row = None; cursor; settlement_warnings = [] }, lock))
+  | Ok (Some (row, target)) ->
+    (match lock.state with
+     | Active ->
+       let cursor = make_cursor ~parent_stat ~leaf ~lock ~target:(Some target) in
+       Ok ({ row = Some row; cursor; settlement_warnings = [] }, lock)
+     | Virgin ->
+       (match sync_parent parent with
+        | Error error -> Error error
+        | Ok () ->
+          (match activate_lock lock with
+           | Error error -> Error error
+           | Ok active_lock ->
+             let cursor =
+               make_cursor ~parent_stat ~leaf ~lock:active_lock ~target:(Some target)
+             in
+             Ok ({ row = Some row; cursor; settlement_warnings = [] }, active_lock))))
+
+let cursor_equal left right =
+  left = right
+
+let stage_leaf ~leaf ~payload =
+  let serial = Atomic.fetch_and_add stage_counter 1 in
+  let digest = sha256 (Printf.sprintf "%s\000%s\000%d" leaf payload serial) in
+  ".masc-capability-head-stage-" ^ String.sub digest 0 32
+
+let rec create_stage ~sw ~parent ~leaf ~payload attempts =
+  if attempts = 0
+  then Error (Io_error { operation = "create_stage"; detail = "stage namespace exhausted" })
+  else
+    let stage_leaf = stage_leaf ~leaf ~payload in
+    let path = Eio.Path.(parent / stage_leaf) in
+    try
+      let file = Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) path in
+      Ok (path, file)
+    with
+    | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
+      create_stage ~sw ~parent ~leaf ~payload (attempts - 1)
+
+let write_stage ~path file payload =
+  Eio.Flow.copy_string payload file;
+  Eio.File.sync file;
+  let opened_stat = Eio.File.stat file in
+  match
+    validate_private_regular
+      ~what:"stage"
+      ~corrupt:(fun detail -> Io_error { operation = "write_stage"; detail })
+      opened_stat
+  with
+  | Error error -> Error error
+  | Ok () ->
+    if
+      not
+        (Int64.equal
+           (Optint.Int63.to_int64 opened_stat.size)
+           (Int64.of_int (String.length payload)))
+    then Error (Io_error { operation = "write_stage"; detail = "stage size mismatch" })
+    else
+      verify_path_binding
+        ~path
+        ~opened_stat
+        ~what:"stage"
+        ~corrupt:(fun detail -> Io_error { operation = "write_stage"; detail })
+
+let add_warning warnings operation exn =
+  warnings := (operation ^ ": " ^ exception_detail exn) :: !warnings
+
+let normalize_result ~warnings ~set_success_warnings = function
+  | Ok value -> Ok (set_success_warnings value warnings)
+  | Error failure ->
+    Error
+      { failure with
+        settlement_warnings = failure.settlement_warnings @ warnings
+      }
+
+let run_transaction ~parent ~leaf ~effect ~set_success_warnings transaction =
+  Eio.Fiber.check ();
+  let token = ref None in
+  let completed = ref None in
+  let warnings = ref [] in
+  Fun.protect
+    ~finally:(fun () -> Option.iter Lease.release !token)
+    (fun () ->
+      try
+        Eio.Switch.run_protected (fun sw ->
+          let exact_parent = Eio.Path.open_dir ~sw parent in
+          let parent_stat = Eio.Path.stat ~follow:false exact_parent in
+          match
+            Lease.try_acquire
+              ~parent_dev:parent_stat.dev
+              ~parent_ino:parent_stat.ino
+              ~leaf
+          with
+          | None ->
+            let result = Error (failure Busy) in
+            completed := Some result;
+            result
+          | Some acquired ->
+            token := Some acquired;
+            let result = transaction ~sw ~parent:exact_parent ~parent_stat ~warnings in
+            let result =
+              normalize_result
+                ~warnings:(List.rev !warnings)
+                ~set_success_warnings
+                result
+            in
+            completed := Some result;
+            result)
+      with
+      | Eio.Cancel.Cancelled _ as exn
+        when !effect = Before_publication && Option.is_none !completed ->
+        raise exn
+      | exn ->
+        let close_warning = "resource settlement: " ^ exception_detail exn in
+        (match !completed with
+         | Some (Ok value) -> Ok (set_success_warnings value [ close_warning ])
+         | Some (Error failure) ->
+           Error
+             { failure with
+               settlement_warnings = failure.settlement_warnings @ [ close_warning ]
+             }
+         | None ->
+           let error = io_error "capability_head_transaction" exn in
+           Error
+             { (failure_for_effect !effect error) with
+               settlement_warnings = List.rev !warnings @ [ close_warning ]
+             }))
+
+let read ~parent ~leaf =
+  match validate_leaf leaf with
+  | Error error -> Error (failure error)
+  | Ok () ->
+    let effect = ref Before_publication in
+    run_transaction
+      ~parent
+      ~leaf
+      ~effect
+      ~set_success_warnings:(fun snapshot warnings ->
+        { snapshot with settlement_warnings = snapshot.settlement_warnings @ warnings })
+      (fun ~sw ~parent ~parent_stat ~warnings:_ ->
+        match open_lock ~sw ~parent ~parent_stat ~leaf with
+        | Error error -> Error (failure_for_effect !effect error)
+        | Ok lock ->
+          (match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+           | Error error -> Error (failure_for_effect !effect error)
+           | Ok (snapshot, _lock) -> Ok snapshot))
+
+let compare_and_swap ~parent ~leaf ~expected ~row =
+  match validate_leaf leaf, validate_row row with
+  | Error error, _ | _, Error error -> Error (failure error)
+  | Ok (), Ok () ->
+    let effect = ref Before_publication in
+    run_transaction
+      ~parent
+      ~leaf
+      ~effect
+      ~set_success_warnings:(fun publication warnings ->
+        { publication with
+          settlement_warnings = publication.settlement_warnings @ warnings
+        })
+      (fun ~sw ~parent ~parent_stat ~warnings ->
+        match open_lock ~sw ~parent ~parent_stat ~leaf with
+        | Error error -> Error (failure_for_effect !effect error)
+        | Ok lock ->
+          (match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+           | Error error -> Error (failure_for_effect !effect error)
+           | Ok (current, lock) ->
+             if not (cursor_equal expected current.cursor)
+             then Error (failure (Conflict current))
+             else
+               let payload = row ^ "\n" in
+               let intended =
+                 { intended_sha256 = sha256 payload
+                 ; intended_length = Int64.of_int (String.length payload)
+                 ; observed = None
+                 }
+               in
+               (match create_stage ~sw ~parent ~leaf ~payload 32 with
+                | Error error -> Error (failure_for_effect !effect error)
+                | Ok (stage_path, stage_file) ->
+                  let cleanup_stage = ref true in
+                  Fun.protect
+                    ~finally:(fun () ->
+                      if !cleanup_stage
+                      then
+                        try Eio.Path.unlink stage_path with
+                        | exn -> add_warning warnings "stage cleanup" exn)
+                    (fun () ->
+                      match write_stage ~path:stage_path stage_file payload with
+                      | Error error -> Error (failure_for_effect !effect error)
+                      | Ok () ->
+                        (match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+                         | Error error -> Error (failure_for_effect !effect error)
+                         | Ok (revalidated, lock) ->
+                           if not (cursor_equal expected revalidated.cursor)
+                           then Error (failure (Conflict revalidated))
+                           else
+                             (match verify_lock_binding lock with
+                              | Error error -> Error (failure_for_effect !effect error)
+                              | Ok () ->
+                                let target_path = Eio.Path.(parent / leaf) in
+                                Eio.Path.rename stage_path target_path;
+                                cleanup_stage := false;
+                                effect := Renamed intended;
+                                (match sync_parent parent with
+                                 | Error error ->
+                                   Error (failure_for_effect !effect error)
+                                 | Ok () ->
+                                   (match
+                                      read_current
+                                        ~sw
+                                        ~parent
+                                        ~parent_stat
+                                        ~leaf
+                                        ~lock
+                                    with
+                                    | Error error ->
+                                      Error (failure_for_effect !effect error)
+                                    | Ok (published, _active_lock) ->
+                                      effect :=
+                                        Renamed
+                                          { intended with
+                                            observed = Some published.cursor
+                                          };
+                                      (match published.row, published.cursor.target with
+                                       | Some observed_row, Some observed_target
+                                         when String.equal observed_row row
+                                              && String.equal
+                                                   observed_target.sha256
+                                                   intended.intended_sha256
+                                              && Int64.equal
+                                                   observed_target.length
+                                                   intended.intended_length ->
+                                         effect := Durable published.cursor;
+                                         Ok
+                                           { cursor = published.cursor
+                                           ; settlement_warnings = []
+                                           }
+                                       | _ ->
+                                         Error
+                                           (failure_for_effect
+                                              !effect
+                                              (Corrupt_head
+                                                 "published HEAD does not match the staged row")))))))))))

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -212,10 +212,11 @@ let failure_for_effect publication_state error =
   failure ~target_effect:(target_effect_of_transaction publication_state) error
 
 let validate_leaf leaf =
+  let normalized_leaf = String.lowercase_ascii leaf in
   if String.equal leaf ""
      || String.equal leaf "."
      || String.equal leaf ".."
-     || String.starts_with ~prefix:internal_leaf_prefix leaf
+     || String.starts_with ~prefix:internal_leaf_prefix normalized_leaf
      || String.exists (fun char -> Char.equal char '/' || Char.equal char '\000') leaf
   then Error (Invalid_leaf leaf)
   else Ok ()

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -1,7 +1,3 @@
-type lock_state =
-  | Virgin
-  | Active
-
 type target_fingerprint =
   { dev : int64
   ; ino : int64
@@ -16,24 +12,45 @@ type cursor =
   ; lock_dev : int64
   ; lock_ino : int64
   ; lock_epoch : string
-  ; lock_state : lock_state
   ; target : target_fingerprint option
   }
+
+type operation =
+  | Pin_parent
+  | Open_lock
+  | Acquire_cross_process_lock
+  | Read_lock_marker
+  | Initialize_lock_marker
+  | Read_head
+  | Create_stage
+  | Write_stage
+  | Sync_stage
+  | Close_stage
+  | Revalidate
+  | Rename_head
+  | Sync_parent
+  | Verify_publication
+  | Cleanup_stage
+  | Settle_resources
+
+type diagnostic =
+  { operation : operation
+  ; detail : string
+  }
+
+type settlement_warning =
+  | Cleanup_failed of diagnostic
+  | Resource_settlement_failed of diagnostic
 
 type snapshot =
   { row : string option
   ; cursor : cursor
-  ; settlement_warnings : string list
+  ; settlement_warnings : settlement_warning list
   }
 
 let snapshot_row snapshot = snapshot.row
 let snapshot_cursor snapshot = snapshot.cursor
 let snapshot_settlement_warnings snapshot = snapshot.settlement_warnings
-
-type io_error =
-  { operation : string
-  ; detail : string
-  }
 
 type error =
   | Invalid_leaf of string
@@ -43,31 +60,50 @@ type error =
   | Corrupt_lock of string
   | Corrupt_head of string
   | Unsupported of string
-  | Io_error of io_error
+  | Io_error of diagnostic
+
+type publication_evidence =
+  { expected_cursor : cursor
+  ; intended_sha256 : string
+  ; intended_length : int64
+  ; published_cursor : cursor
+  }
 
 type publication_indeterminate =
-  { intended_sha256 : string
+  { expected_cursor : cursor
+  ; intended_sha256 : string
   ; intended_length : int64
   ; observed : cursor option
   }
 
 type target_effect =
   | Unchanged
+  | Published of publication_evidence
   | Publication_indeterminate of publication_indeterminate
 
 type failure =
   { error : error
   ; target_effect : target_effect
-  ; settlement_warnings : string list
+  ; settlement_warnings : settlement_warning list
   }
 
 type publication =
-  { cursor : cursor
-  ; settlement_warnings : string list
+  { evidence : publication_evidence
+  ; settlement_warnings : settlement_warning list
   }
 
-let publication_cursor publication = publication.cursor
+let publication_evidence publication = publication.evidence
 let publication_settlement_warnings publication = publication.settlement_warnings
+
+let max_row_bytes = 64 * 1024
+let max_lock_marker_bytes = 128
+let lock_magic = "MASC-CAPABILITY-HEAD-LOCK-v2"
+let stage_counter = Atomic.make 0
+
+let ( let* ) result fn =
+  match result with
+  | Ok value -> fn value
+  | Error error -> Error error
 
 module Lease = struct
   module Key = struct
@@ -109,25 +145,59 @@ type lock_handle =
   ; path : Eio.Fs.dir_ty Eio.Path.t
   ; stat : Eio.File.Stat.t
   ; epoch : string
-  ; state : lock_state
+  }
+
+type hooks =
+  { after_lock_acquired : unit -> unit
+  ; before_rename : unit -> unit
+  ; after_rename : unit -> unit
+  ; after_parent_sync : unit -> unit
+  ; after_verified : unit -> unit
+  ; before_stage_cleanup : unit -> unit
+  ; on_resource_settlement : unit -> unit
+  }
+
+let no_hooks =
+  { after_lock_acquired = (fun () -> ())
+  ; before_rename = (fun () -> ())
+  ; after_rename = (fun () -> ())
+  ; after_parent_sync = (fun () -> ())
+  ; after_verified = (fun () -> ())
+  ; before_stage_cleanup = (fun () -> ())
+  ; on_resource_settlement = (fun () -> ())
   }
 
 type transaction_effect =
   | Before_publication
   | Renamed of publication_indeterminate
-  | Durable of cursor
+  | Durable of publication_evidence
 
-let lock_magic = "MASC-CAPABILITY-HEAD-LOCK-v1"
-let max_lock_marker_bytes = 256
-let stage_counter = Atomic.make 0
+exception Hook_failed of diagnostic
 
 let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+let exception_detail exn = Printexc.to_string exn
 
-let exception_detail exn =
-  Printexc.to_string exn
+let diagnostic operation exn =
+  { operation; detail = exception_detail exn }
 
-let io_error operation exn =
-  Io_error { operation; detail = exception_detail exn }
+let protect_io operation fn =
+  try Ok (fn ()) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Io_error (diagnostic operation exn))
+
+let protect_result operation fn =
+  try fn () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Io_error (diagnostic operation exn))
+
+let invoke_hook operation hook =
+  try hook () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> raise (Hook_failed (diagnostic operation exn))
+
+let diagnostic_of_exception default_operation = function
+  | Hook_failed diagnostic -> diagnostic
+  | exn -> diagnostic default_operation exn
 
 let failure ?(target_effect = Unchanged) error =
   { error; target_effect; settlement_warnings = [] }
@@ -135,7 +205,7 @@ let failure ?(target_effect = Unchanged) error =
 let target_effect_of_transaction = function
   | Before_publication -> Unchanged
   | Renamed evidence -> Publication_indeterminate evidence
-  | Durable _ -> Unchanged
+  | Durable evidence -> Published evidence
 
 let failure_for_effect effect error =
   failure ~target_effect:(target_effect_of_transaction effect) error
@@ -151,16 +221,17 @@ let validate_leaf leaf =
 let validate_row row =
   if String.equal row ""
   then Error (Invalid_row "HEAD row must be non-empty")
+  else if String.length row > max_row_bytes
+  then Error (Invalid_row "HEAD row exceeds max_row_bytes")
   else if String.exists (fun char -> Char.equal char '\n' || Char.equal char '\r') row
   then Error (Invalid_row "HEAD row must not contain CR or LF")
   else Ok ()
 
-let lock_state_name = function
-  | Virgin -> "virgin"
-  | Active -> "active"
-
 let lock_leaf leaf =
   ".masc-capability-head-" ^ sha256 leaf ^ ".lock"
+
+let marker epoch =
+  Printf.sprintf "%s %s\n" lock_magic epoch
 
 let is_lower_hex value =
   String.length value = 64
@@ -169,9 +240,6 @@ let is_lower_hex value =
          | '0' .. '9' | 'a' .. 'f' -> true
          | _ -> false)
        value
-
-let marker ~state ~epoch =
-  Printf.sprintf "%s %s %s\n" lock_magic (lock_state_name state) epoch
 
 let parse_marker value =
   let length = String.length value in
@@ -185,11 +253,8 @@ let parse_marker value =
     then Error (Corrupt_lock "stable lock marker contains multiple rows or CR")
     else
       match String.split_on_char ' ' body with
-      | [ magic; state; epoch ] when String.equal magic lock_magic && is_lower_hex epoch ->
-        (match state with
-         | "virgin" -> Ok (Virgin, epoch)
-         | "active" -> Ok (Active, epoch)
-         | _ -> Error (Corrupt_lock "stable lock marker has an unknown state"))
+      | [ magic; epoch ] when String.equal magic lock_magic && is_lower_hex epoch ->
+        Ok epoch
       | _ -> Error (Corrupt_lock "stable lock marker has an invalid shape")
 
 let same_identity (left : Eio.File.Stat.t) (right : Eio.File.Stat.t) =
@@ -206,8 +271,8 @@ let validate_private_regular ~what ~corrupt (stat : Eio.File.Stat.t) =
   then Error (corrupt (what ^ " is not a regular file"))
   else if not (Int64.equal stat.nlink 1L)
   then Error (corrupt (what ^ " must have exactly one hard link"))
-  else if stat.perm land 0o777 <> 0o600
-  then Error (corrupt (what ^ " must have mode 0600"))
+  else if stat.perm land 0o7777 <> 0o600
+  then Error (corrupt (what ^ " must have mode 0600 and no special bits"))
   else Ok ()
 
 let verify_path_binding ~path ~opened_stat ~what ~corrupt =
@@ -221,44 +286,38 @@ let verify_path_binding ~path ~opened_stat ~what ~corrupt =
   | `Symbolic_link -> Error (corrupt (what ^ " path is a symbolic link"))
   | _ -> Error (corrupt (what ^ " path is not a regular file"))
 
-let read_open_file ~max_bytes ~what ~corrupt file =
-  let before = Eio.File.stat file in
-  let size64 = Optint.Int63.to_int64 before.size in
-  if Int64.compare size64 0L < 0
-  then Error (corrupt (what ^ " has a negative size"))
-  else if Int64.compare size64 (Int64.of_int max_bytes) > 0
-  then Error (corrupt (what ^ " exceeds its byte bound"))
-  else
-    let size = Int64.to_int size64 in
-    ignore (Eio.File.seek file (Optint.Int63.of_int 0) `Set);
-    let value = Eio.Flow.read_all ~max_size:(max_bytes + 1) file in
-    let after = Eio.File.stat file in
-    if not (same_open_file before after)
-    then Error (corrupt (what ^ " changed while it was being read"))
-    else if String.length value <> size
-    then Error (corrupt (what ^ " size changed while it was being read"))
-    else Ok (value, after)
-
-let write_exact file value =
-  Eio.File.truncate file (Optint.Int63.of_int 0);
-  ignore (Eio.File.seek file (Optint.Int63.of_int 0) `Set);
-  Eio.Flow.copy_string value file;
-  Eio.File.truncate file (Optint.Int63.of_int (String.length value));
-  Eio.File.sync file
+let read_open_file ~max_bytes ~operation ~what ~corrupt file =
+  protect_result operation (fun () ->
+    let before = Eio.File.stat file in
+    let size64 = Optint.Int63.to_int64 before.size in
+    if Int64.compare size64 0L < 0
+    then Error (corrupt (what ^ " has a negative size"))
+    else if Int64.compare size64 (Int64.of_int max_bytes) > 0
+    then Error (corrupt (what ^ " exceeds its byte bound"))
+    else
+      let size = Int64.to_int size64 in
+      let buffer = Cstruct.create size in
+      if size > 0
+      then
+        Eio.File.pread_exact
+          file
+          ~file_offset:(Optint.Int63.of_int 0)
+          [ buffer ];
+      let after = Eio.File.stat file in
+      if not (same_open_file before after)
+      then Error (corrupt (what ^ " changed while it was being read"))
+      else Ok (Cstruct.to_string buffer, after))
 
 let sync_parent parent =
   let resource, _relative = parent in
   match Eio_unix.Resource.fd_opt resource with
   | None -> Error (Unsupported "parent directory capability has no Unix file descriptor")
   | Some fd ->
-    (try
-       Eio_unix.Fd.use_exn "capability_head.sync_parent" fd (fun raw_fd ->
-         Eio_unix.run_in_systhread
-           ~label:"capability_head.sync_parent"
-           (fun () -> Unix.fsync raw_fd));
-       Ok ()
-     with
-     | exn -> Error (io_error "sync_parent" exn))
+    protect_io Sync_parent (fun () ->
+      Eio_unix.Fd.use_exn "capability_head.sync_parent" fd (fun raw_fd ->
+        Eio_unix.run_in_systhread
+          ~label:"capability_head.sync_parent"
+          (fun () -> Unix.fsync raw_fd)))
 
 let try_lock file =
   match Eio_unix.Resource.fd_opt file with
@@ -274,76 +333,67 @@ let try_lock file =
        Ok ()
      with
      | Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> Error Busy
-     | exn -> Error (io_error "try_lock" exn))
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Io_error (diagnostic Acquire_cross_process_lock exn)))
 
-let epoch_for_lock ~parent_stat ~leaf (lock_stat : Eio.File.Stat.t) =
-  sha256
-    (Printf.sprintf
-       "%Ld\000%Ld\000%s\000%Ld\000%Ld\000%.17g\000%.17g"
-       parent_stat.Eio.File.Stat.dev
-       parent_stat.ino
-       leaf
-       lock_stat.dev
-       lock_stat.ino
-       lock_stat.ctime
-       lock_stat.mtime)
+let fresh_epoch secure_random =
+  protect_io Initialize_lock_marker (fun () ->
+    let bytes = Cstruct.create 32 in
+    Eio.Flow.read_exact secure_random bytes;
+    sha256 (Cstruct.to_string bytes))
 
-let open_lock ~sw ~parent ~parent_stat ~leaf =
-  let target_path = Eio.Path.(parent / leaf) in
-  let path = Eio.Path.(parent / lock_leaf leaf) in
-  match Eio.Path.kind ~follow:false path with
-  | (`Not_found | `Regular_file) ->
-    let file = Eio.Path.open_out ~sw ~create:(`If_missing 0o600) path in
-    (match try_lock file with
-     | Error error -> Error error
-     | Ok () ->
-       let opened_stat = Eio.File.stat file in
-       (match
-          validate_private_regular
-            ~what:"stable lock"
-            ~corrupt:(fun detail -> Corrupt_lock detail)
-            opened_stat
-        with
-        | Error error -> Error error
-        | Ok () ->
-          (match
-             verify_path_binding
-               ~path
-               ~opened_stat
-               ~what:"stable lock"
-               ~corrupt:(fun detail -> Corrupt_lock detail)
-           with
-           | Error error -> Error error
-           | Ok () ->
-             (match
-                read_open_file
-                  ~max_bytes:max_lock_marker_bytes
-                  ~what:"stable lock marker"
-                  ~corrupt:(fun detail -> Corrupt_lock detail)
-                  file
-              with
-              | Error error -> Error error
-              | Ok ("", _) ->
-                (match Eio.Path.kind ~follow:false target_path with
-                 | `Not_found ->
-                   Eio.File.sync file;
-                   (match sync_parent parent with
-                    | Error error -> Error error
-                    | Ok () ->
-                      let epoch = epoch_for_lock ~parent_stat ~leaf opened_stat in
-                      write_exact file (marker ~state:Virgin ~epoch);
-                      Ok { file; path; stat = opened_stat; epoch; state = Virgin })
-                 | _ ->
-                   Error
-                     (Corrupt_lock
-                        "empty stable lock exists beside a non-empty HEAD namespace"))
-              | Ok (value, _) ->
-                (match parse_marker value with
-                 | Error error -> Error error
-                 | Ok (state, epoch) ->
-                   Ok { file; path; stat = opened_stat; epoch; state })))))
-  | `Symbolic_link -> Error (Corrupt_lock "stable lock path is a symbolic link")
-  | _ -> Error (Corrupt_lock "stable lock path is not a regular file")
+let write_initial_marker file epoch =
+  protect_io Initialize_lock_marker (fun () ->
+    ignore (Eio.File.seek file (Optint.Int63.of_int 0) `Set);
+    Eio.Flow.copy_string (marker epoch) file;
+    Eio.File.sync file)
+
+let open_lock ~sw ~secure_random ~parent ~leaf =
+  protect_result Open_lock (fun () ->
+    let target_path = Eio.Path.(parent / leaf) in
+    let path = Eio.Path.(parent / lock_leaf leaf) in
+    match Eio.Path.kind ~follow:false path with
+    | (`Not_found | `Regular_file) ->
+      let file = Eio.Path.open_out ~sw ~create:(`If_missing 0o600) path in
+      let* () = try_lock file in
+      let opened_stat = Eio.File.stat file in
+      let* () =
+        validate_private_regular
+          ~what:"stable lock"
+          ~corrupt:(fun detail -> Corrupt_lock detail)
+          opened_stat
+      in
+      let* () =
+        verify_path_binding
+          ~path
+          ~opened_stat
+          ~what:"stable lock"
+          ~corrupt:(fun detail -> Corrupt_lock detail)
+      in
+      let* contents, _ =
+        read_open_file
+          ~max_bytes:max_lock_marker_bytes
+          ~operation:Read_lock_marker
+          ~what:"stable lock marker"
+          ~corrupt:(fun detail -> Corrupt_lock detail)
+          file
+      in
+      if not (String.equal contents "")
+      then
+        let* epoch = parse_marker contents in
+        Ok { file; path; stat = opened_stat; epoch }
+      else
+        (match Eio.Path.kind ~follow:false target_path with
+         | `Not_found ->
+           let* () = protect_io Initialize_lock_marker (fun () -> Eio.File.sync file) in
+           let* () = sync_parent parent in
+           let* epoch = fresh_epoch secure_random in
+           let* () = write_initial_marker file epoch in
+           Ok { file; path; stat = opened_stat; epoch }
+         | _ ->
+           Error (Corrupt_lock "empty stable lock exists beside a present HEAD"))
+    | `Symbolic_link -> Error (Corrupt_lock "stable lock path is a symbolic link")
+    | _ -> Error (Corrupt_lock "stable lock path is not a regular file"))
 
 let parse_head_payload payload =
   let length = String.length payload in
@@ -353,80 +403,59 @@ let parse_head_payload payload =
   then Error (Corrupt_head "HEAD is not LF-terminated")
   else
     let row = String.sub payload 0 (length - 1) in
-    if String.exists (fun char -> Char.equal char '\n' || Char.equal char '\r') row
+    if String.length row > max_row_bytes
+    then Error (Corrupt_head "HEAD row exceeds max_row_bytes")
+    else if String.exists (fun char -> Char.equal char '\n' || Char.equal char '\r') row
     then Error (Corrupt_head "HEAD contains multiple rows or CR")
     else Ok row
 
 let read_target ~sw ~parent ~leaf =
-  let path = Eio.Path.(parent / leaf) in
-  match Eio.Path.kind ~follow:false path with
-  | `Not_found -> Ok None
-  | `Regular_file ->
-    let file = Eio.Path.open_in ~sw path in
-    let opened_stat = Eio.File.stat file in
-    (match
-       validate_private_regular
-         ~what:"HEAD"
-         ~corrupt:(fun detail -> Corrupt_head detail)
-         opened_stat
-     with
-     | Error error -> Error error
-     | Ok () ->
-       (match
-          verify_path_binding
-            ~path
-            ~opened_stat
-            ~what:"HEAD"
-            ~corrupt:(fun detail -> Corrupt_head detail)
-        with
-        | Error error -> Error error
-        | Ok () ->
-          let max_bytes = Sys.max_string_length - 1 in
-          (match
-             read_open_file
-               ~max_bytes
-               ~what:"HEAD"
-               ~corrupt:(fun detail -> Corrupt_head detail)
-               file
-           with
-           | Error error -> Error error
-           | Ok (payload, final_stat) ->
-             (match
-                verify_path_binding
-                  ~path
-                  ~opened_stat:final_stat
-                  ~what:"HEAD"
-                  ~corrupt:(fun detail -> Corrupt_head detail)
-              with
-              | Error error -> Error error
-              | Ok () ->
-                (match parse_head_payload payload with
-                 | Error error -> Error error
-                 | Ok row ->
-                   let fingerprint =
-                     { dev = final_stat.dev
-                     ; ino = final_stat.ino
-                     ; length = Int64.of_int (String.length payload)
-                     ; sha256 = sha256 payload
-                     }
-                   in
-                   Ok (Some (row, fingerprint)))))))
-  | `Symbolic_link -> Error (Corrupt_head "HEAD path is a symbolic link")
-  | _ -> Error (Corrupt_head "HEAD path is not a regular file")
-
-let verify_lock_binding lock =
-  verify_path_binding
-    ~path:lock.path
-    ~opened_stat:lock.stat
-    ~what:"stable lock"
-    ~corrupt:(fun detail -> Corrupt_lock detail)
-
-let activate_lock lock =
-  match verify_lock_binding lock with
-  | Error error -> Error error
-  | Ok () ->
-    write_exact lock.file (marker ~state:Active ~epoch:lock.epoch);
-    Ok { lock with state = Active }
+  protect_result Read_head (fun () ->
+    let path = Eio.Path.(parent / leaf) in
+    match Eio.Path.kind ~follow:false path with
+    | `Not_found -> Ok None
+    | `Regular_file ->
+      let file = Eio.Path.open_in ~sw path in
+      let opened_stat = Eio.File.stat file in
+      let* () =
+        validate_private_regular
+          ~what:"HEAD"
+          ~corrupt:(fun detail -> Corrupt_head detail)
+          opened_stat
+      in
+      let* () =
+        verify_path_binding
+          ~path
+          ~opened_stat
+          ~what:"HEAD"
+          ~corrupt:(fun detail -> Corrupt_head detail)
+      in
+      let* payload, final_stat =
+        read_open_file
+          ~max_bytes:(max_row_bytes + 1)
+          ~operation:Read_head
+          ~what:"HEAD"
+          ~corrupt:(fun detail -> Corrupt_head detail)
+          file
+      in
+      let* () =
+        verify_path_binding
+          ~path
+          ~opened_stat:final_stat
+          ~what:"HEAD"
+          ~corrupt:(fun detail -> Corrupt_head detail)
+      in
+      let* row = parse_head_payload payload in
+      let fingerprint =
+        { dev = final_stat.dev
+        ; ino = final_stat.ino
+        ; length = Int64.of_int (String.length payload)
+        ; sha256 = sha256 payload
+        }
+      in
+      Ok (Some (row, fingerprint))
+    | `Symbolic_link -> Error (Corrupt_head "HEAD path is a symbolic link")
+    | _ -> Error (Corrupt_head "HEAD path is not a regular file"))
 
 let make_cursor ~parent_stat ~leaf ~lock ~target =
   { parent_dev = parent_stat.Eio.File.Stat.dev
@@ -435,35 +464,18 @@ let make_cursor ~parent_stat ~leaf ~lock ~target =
   ; lock_dev = lock.stat.dev
   ; lock_ino = lock.stat.ino
   ; lock_epoch = lock.epoch
-  ; lock_state = lock.state
   ; target
   }
 
 let read_current ~sw ~parent ~parent_stat ~leaf ~lock =
-  match read_target ~sw ~parent ~leaf with
-  | Error error -> Error error
-  | Ok None ->
-    (match lock.state with
-     | Active -> Error (Corrupt_head "an active stable lock has no HEAD")
-     | Virgin ->
-       let cursor = make_cursor ~parent_stat ~leaf ~lock ~target:None in
-       Ok ({ row = None; cursor; settlement_warnings = [] }, lock))
-  | Ok (Some (row, target)) ->
-    (match lock.state with
-     | Active ->
-       let cursor = make_cursor ~parent_stat ~leaf ~lock ~target:(Some target) in
-       Ok ({ row = Some row; cursor; settlement_warnings = [] }, lock)
-     | Virgin ->
-       (match sync_parent parent with
-        | Error error -> Error error
-        | Ok () ->
-          (match activate_lock lock with
-           | Error error -> Error error
-           | Ok active_lock ->
-             let cursor =
-               make_cursor ~parent_stat ~leaf ~lock:active_lock ~target:(Some target)
-             in
-             Ok ({ row = Some row; cursor; settlement_warnings = [] }, active_lock))))
+  let* target = read_target ~sw ~parent ~leaf in
+  match target with
+  | None ->
+    let cursor = make_cursor ~parent_stat ~leaf ~lock ~target:None in
+    Ok { row = None; cursor; settlement_warnings = [] }
+  | Some (row, fingerprint) ->
+    let cursor = make_cursor ~parent_stat ~leaf ~lock ~target:(Some fingerprint) in
+    Ok { row = Some row; cursor; settlement_warnings = [] }
 
 let cursor_equal left right =
   left = right
@@ -475,7 +487,7 @@ let stage_leaf ~leaf ~payload =
 
 let rec create_stage ~sw ~parent ~leaf ~payload attempts =
   if attempts = 0
-  then Error (Io_error { operation = "create_stage"; detail = "stage namespace exhausted" })
+  then Error (Io_error { operation = Create_stage; detail = "stage namespace exhausted" })
   else
     let stage_leaf = stage_leaf ~leaf ~payload in
     let path = Eio.Path.(parent / stage_leaf) in
@@ -485,34 +497,42 @@ let rec create_stage ~sw ~parent ~leaf ~payload attempts =
     with
     | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
       create_stage ~sw ~parent ~leaf ~payload (attempts - 1)
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Io_error (diagnostic Create_stage exn))
 
 let write_stage ~path file payload =
-  Eio.Flow.copy_string payload file;
-  Eio.File.sync file;
-  let opened_stat = Eio.File.stat file in
-  match
-    validate_private_regular
-      ~what:"stage"
-      ~corrupt:(fun detail -> Io_error { operation = "write_stage"; detail })
-      opened_stat
-  with
-  | Error error -> Error error
-  | Ok () ->
+  let* () = protect_io Write_stage (fun () -> Eio.Flow.copy_string payload file) in
+  let* () = protect_io Sync_stage (fun () -> Eio.File.sync file) in
+  protect_result Sync_stage (fun () ->
+    let opened_stat = Eio.File.stat file in
+    let* () =
+      validate_private_regular
+        ~what:"stage"
+        ~corrupt:(fun detail -> Io_error { operation = Sync_stage; detail })
+        opened_stat
+    in
     if
       not
         (Int64.equal
            (Optint.Int63.to_int64 opened_stat.size)
            (Int64.of_int (String.length payload)))
-    then Error (Io_error { operation = "write_stage"; detail = "stage size mismatch" })
+    then Error (Io_error { operation = Sync_stage; detail = "stage size mismatch" })
     else
-      verify_path_binding
-        ~path
-        ~opened_stat
-        ~what:"stage"
-        ~corrupt:(fun detail -> Io_error { operation = "write_stage"; detail })
+      let* () =
+        verify_path_binding
+          ~path
+          ~opened_stat
+          ~what:"stage"
+          ~corrupt:(fun detail -> Io_error { operation = Sync_stage; detail })
+      in
+      Ok opened_stat)
 
-let add_warning warnings operation exn =
-  warnings := (operation ^ ": " ^ exception_detail exn) :: !warnings
+let verify_lock_binding lock =
+  verify_path_binding
+    ~path:lock.path
+    ~opened_stat:lock.stat
+    ~what:"stable lock"
+    ~corrupt:(fun detail -> Corrupt_lock detail)
 
 let normalize_result ~warnings ~set_success_warnings = function
   | Ok value -> Ok (set_success_warnings value warnings)
@@ -522,7 +542,7 @@ let normalize_result ~warnings ~set_success_warnings = function
         settlement_warnings = failure.settlement_warnings @ warnings
       }
 
-let run_transaction ~parent ~leaf ~effect ~set_success_warnings transaction =
+let run_transaction ~hooks ~parent ~leaf ~effect ~set_success_warnings transaction =
   Eio.Fiber.check ();
   let token = ref None in
   let completed = ref None in
@@ -532,6 +552,9 @@ let run_transaction ~parent ~leaf ~effect ~set_success_warnings transaction =
     (fun () ->
       try
         Eio.Switch.run_protected (fun sw ->
+          Eio.Switch.on_release sw (fun () ->
+            try hooks.on_resource_settlement () with
+            | exn -> raise (Hook_failed (diagnostic Settle_resources exn)));
           let exact_parent = Eio.Path.open_dir ~sw parent in
           let parent_stat = Eio.Path.stat ~follow:false exact_parent in
           match
@@ -560,46 +583,46 @@ let run_transaction ~parent ~leaf ~effect ~set_success_warnings transaction =
         when !effect = Before_publication && Option.is_none !completed ->
         raise exn
       | exn ->
-        let close_warning = "resource settlement: " ^ exception_detail exn in
+        let detail = diagnostic_of_exception Settle_resources exn in
         (match !completed with
-         | Some (Ok value) -> Ok (set_success_warnings value [ close_warning ])
+         | Some (Ok value) ->
+           Ok (set_success_warnings value [ Resource_settlement_failed detail ])
          | Some (Error failure) ->
            Error
              { failure with
-               settlement_warnings = failure.settlement_warnings @ [ close_warning ]
+               settlement_warnings =
+                 failure.settlement_warnings @ [ Resource_settlement_failed detail ]
              }
          | None ->
-           let error = io_error "capability_head_transaction" exn in
            Error
-             { (failure_for_effect !effect error) with
-               settlement_warnings = List.rev !warnings @ [ close_warning ]
+             { (failure_for_effect !effect (Io_error detail)) with
+               settlement_warnings = List.rev !warnings
              }))
 
-let read ~parent ~leaf =
+let read ~secure_random ~parent ~leaf =
   match validate_leaf leaf with
   | Error error -> Error (failure error)
   | Ok () ->
     let effect = ref Before_publication in
     run_transaction
+      ~hooks:no_hooks
       ~parent
       ~leaf
       ~effect
       ~set_success_warnings:(fun snapshot warnings ->
         { snapshot with settlement_warnings = snapshot.settlement_warnings @ warnings })
       (fun ~sw ~parent ~parent_stat ~warnings:_ ->
-        match open_lock ~sw ~parent ~parent_stat ~leaf with
-        | Error error -> Error (failure_for_effect !effect error)
-        | Ok lock ->
-          (match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
-           | Error error -> Error (failure_for_effect !effect error)
-           | Ok (snapshot, _lock) -> Ok snapshot))
+        let* lock = open_lock ~sw ~secure_random ~parent ~leaf in
+        let* snapshot = read_current ~sw ~parent ~parent_stat ~leaf ~lock in
+        Ok snapshot)
 
-let compare_and_swap ~parent ~leaf ~expected ~row =
+let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row =
   match validate_leaf leaf, validate_row row with
   | Error error, _ | _, Error error -> Error (failure error)
   | Ok (), Ok () ->
     let effect = ref Before_publication in
     run_transaction
+      ~hooks
       ~parent
       ~leaf
       ~effect
@@ -608,86 +631,146 @@ let compare_and_swap ~parent ~leaf ~expected ~row =
           settlement_warnings = publication.settlement_warnings @ warnings
         })
       (fun ~sw ~parent ~parent_stat ~warnings ->
-        match open_lock ~sw ~parent ~parent_stat ~leaf with
-        | Error error -> Error (failure_for_effect !effect error)
-        | Ok lock ->
-          (match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
-           | Error error -> Error (failure_for_effect !effect error)
-           | Ok (current, lock) ->
-             if not (cursor_equal expected current.cursor)
-             then Error (failure (Conflict current))
-             else
-               let payload = row ^ "\n" in
-               let intended =
-                 { intended_sha256 = sha256 payload
-                 ; intended_length = Int64.of_int (String.length payload)
-                 ; observed = None
-                 }
-               in
-               (match create_stage ~sw ~parent ~leaf ~payload 32 with
-                | Error error -> Error (failure_for_effect !effect error)
-                | Ok (stage_path, stage_file) ->
-                  let cleanup_stage = ref true in
-                  Fun.protect
-                    ~finally:(fun () ->
-                      if !cleanup_stage
-                      then
-                        try Eio.Path.unlink stage_path with
-                        | exn -> add_warning warnings "stage cleanup" exn)
-                    (fun () ->
-                      match write_stage ~path:stage_path stage_file payload with
-                      | Error error -> Error (failure_for_effect !effect error)
-                      | Ok () ->
-                        (match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
-                         | Error error -> Error (failure_for_effect !effect error)
-                         | Ok (revalidated, lock) ->
-                           if not (cursor_equal expected revalidated.cursor)
-                           then Error (failure (Conflict revalidated))
-                           else
-                             (match verify_lock_binding lock with
-                              | Error error -> Error (failure_for_effect !effect error)
-                              | Ok () ->
-                                let target_path = Eio.Path.(parent / leaf) in
-                                Eio.Path.rename stage_path target_path;
-                                cleanup_stage := false;
-                                effect := Renamed intended;
-                                (match sync_parent parent with
-                                 | Error error ->
-                                   Error (failure_for_effect !effect error)
-                                 | Ok () ->
-                                   (match
-                                      read_current
-                                        ~sw
-                                        ~parent
-                                        ~parent_stat
-                                        ~leaf
-                                        ~lock
-                                    with
-                                    | Error error ->
-                                      Error (failure_for_effect !effect error)
-                                    | Ok (published, _active_lock) ->
-                                      effect :=
-                                        Renamed
-                                          { intended with
-                                            observed = Some published.cursor
-                                          };
-                                      (match published.row, published.cursor.target with
-                                       | Some observed_row, Some observed_target
-                                         when String.equal observed_row row
-                                              && String.equal
-                                                   observed_target.sha256
-                                                   intended.intended_sha256
-                                              && Int64.equal
-                                                   observed_target.length
-                                                   intended.intended_length ->
-                                         effect := Durable published.cursor;
-                                         Ok
-                                           { cursor = published.cursor
-                                           ; settlement_warnings = []
-                                           }
-                                       | _ ->
-                                         Error
-                                           (failure_for_effect
-                                              !effect
-                                              (Corrupt_head
-                                                 "published HEAD does not match the staged row")))))))))))
+        let fail error = Error (failure_for_effect !effect error) in
+        let* lock =
+          match open_lock ~sw ~secure_random ~parent ~leaf with
+          | Ok lock -> Ok lock
+          | Error error -> fail error
+        in
+        invoke_hook Acquire_cross_process_lock hooks.after_lock_acquired;
+        let* current =
+          match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+          | Ok current -> Ok current
+          | Error error -> fail error
+        in
+        if not (cursor_equal expected current.cursor)
+        then Error (failure (Conflict current))
+        else
+          let payload = row ^ "\n" in
+          let indeterminate =
+            { expected_cursor = expected
+            ; intended_sha256 = sha256 payload
+            ; intended_length = Int64.of_int (String.length payload)
+            ; observed = None
+            }
+          in
+          let* stage_path, stage_file =
+            match create_stage ~sw ~parent ~leaf ~payload 32 with
+            | Ok stage -> Ok stage
+            | Error error -> fail error
+          in
+          let cleanup_stage = ref true in
+          Fun.protect
+            ~finally:(fun () ->
+              if !cleanup_stage
+              then
+                try
+                  invoke_hook Cleanup_stage hooks.before_stage_cleanup;
+                  Eio.Path.unlink stage_path
+                with
+                | exn ->
+                  warnings :=
+                    Cleanup_failed (diagnostic_of_exception Cleanup_stage exn) :: !warnings)
+            (fun () ->
+              let* stage_stat =
+                match write_stage ~path:stage_path stage_file payload with
+                | Ok stat -> Ok stat
+                | Error error -> fail error
+              in
+              let* () =
+                match protect_io Close_stage (fun () -> Eio.Flow.close stage_file) with
+                | Ok () -> Ok ()
+                | Error error -> fail error
+              in
+              let* () =
+                match
+                  verify_path_binding
+                    ~path:stage_path
+                    ~opened_stat:stage_stat
+                    ~what:"stage"
+                    ~corrupt:(fun detail -> Io_error { operation = Revalidate; detail })
+                with
+                | Ok () -> Ok ()
+                | Error error -> fail error
+              in
+              let* revalidated =
+                match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+                | Ok current -> Ok current
+                | Error error -> fail error
+              in
+              if not (cursor_equal expected revalidated.cursor)
+              then Error (failure (Conflict revalidated))
+              else (
+                invoke_hook Revalidate hooks.before_rename;
+                let* () =
+                  match verify_lock_binding lock with
+                  | Ok () -> Ok ()
+                  | Error error -> fail error
+                in
+                let target_path = Eio.Path.(parent / leaf) in
+                let* () =
+                  match protect_io Rename_head (fun () -> Eio.Path.rename stage_path target_path) with
+                  | Ok () -> Ok ()
+                  | Error error -> fail error
+                in
+                cleanup_stage := false;
+                effect := Renamed indeterminate;
+                invoke_hook Rename_head hooks.after_rename;
+                let* () =
+                  match sync_parent parent with
+                  | Ok () -> Ok ()
+                  | Error error -> fail error
+                in
+                invoke_hook Sync_parent hooks.after_parent_sync;
+                let* published =
+                  match read_current ~sw ~parent ~parent_stat ~leaf ~lock with
+                  | Ok published -> Ok published
+                  | Error error -> fail error
+                in
+                effect :=
+                  Renamed { indeterminate with observed = Some published.cursor };
+                match published.row, published.cursor.target with
+                | Some observed_row, Some observed_target
+                  when String.equal observed_row row
+                       && String.equal observed_target.sha256 indeterminate.intended_sha256
+                       && Int64.equal observed_target.length indeterminate.intended_length ->
+                  let evidence =
+                    { expected_cursor = expected
+                    ; intended_sha256 = indeterminate.intended_sha256
+                    ; intended_length = indeterminate.intended_length
+                    ; published_cursor = published.cursor
+                    }
+                  in
+                  effect := Durable evidence;
+                  invoke_hook Verify_publication hooks.after_verified;
+                  Ok { evidence; settlement_warnings = [] }
+                | _ -> fail (Corrupt_head "published HEAD does not match the staged row")))
+
+let compare_and_swap ~secure_random ~parent ~leaf ~expected ~row =
+  compare_and_swap_internal ~hooks:no_hooks ~secure_random ~parent ~leaf ~expected ~row
+
+module For_testing = struct
+  type nonrec hooks = hooks
+
+  let hooks
+      ?(after_lock_acquired = fun () -> ())
+      ?(before_rename = fun () -> ())
+      ?(after_rename = fun () -> ())
+      ?(after_parent_sync = fun () -> ())
+      ?(after_verified = fun () -> ())
+      ?(before_stage_cleanup = fun () -> ())
+      ?(on_resource_settlement = fun () -> ())
+      ()
+    =
+    { after_lock_acquired
+    ; before_rename
+    ; after_rename
+    ; after_parent_sync
+    ; after_verified
+    ; before_stage_cleanup
+    ; on_resource_settlement
+    }
+
+  let compare_and_swap hooks ~secure_random ~parent ~leaf ~expected ~row =
+    compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
+end

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -666,23 +666,58 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
             | Error error -> fail error
           in
           let cleanup_stage = ref true in
+          let stage_identity = ref None in
           Fun.protect
             ~finally:(fun () ->
               if !cleanup_stage
               then
                 try
                   invoke_hook Cleanup_stage hooks.before_stage_cleanup;
-                  Eio.Path.unlink stage_path
+                  (match !stage_identity with
+                   | None ->
+                     warnings :=
+                       Cleanup_failed
+                         { operation = Cleanup_stage
+                         ; detail = "stage identity unavailable; unknown path preserved"
+                         }
+                       :: !warnings
+                   | Some opened_stat ->
+                     (match
+                        verify_path_binding
+                          ~path:stage_path
+                          ~opened_stat
+                          ~what:"stage"
+                          ~corrupt:(fun _detail ->
+                            Io_error
+                              { operation = Cleanup_stage
+                              ; detail = "stage binding changed"
+                              })
+                      with
+                      | Ok () -> Eio.Path.unlink stage_path
+                      | Error _ ->
+                        warnings :=
+                          Cleanup_failed
+                            { operation = Cleanup_stage
+                            ; detail = "stage path no longer names created inode; preserved"
+                            }
+                          :: !warnings))
                 with
                 | exn ->
                   warnings :=
                     Cleanup_failed (diagnostic_of_exception Cleanup_stage exn) :: !warnings)
             (fun () ->
+              let* initial_stage_stat =
+                match protect_io Create_stage (fun () -> Eio.File.stat stage_file) with
+                | Ok stat -> Ok stat
+                | Error error -> fail error
+              in
+              stage_identity := Some initial_stage_stat;
               let* stage_stat =
                 match write_stage ~path:stage_path stage_file payload with
                 | Ok stat -> Ok stat
                 | Error error -> fail error
               in
+              stage_identity := Some stage_stat;
               let* () =
                 match protect_io Close_stage (fun () -> Eio.Flow.close stage_file) with
                 | Ok () -> Ok ()

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -3,7 +3,12 @@
     HEAD is the only content authority. The stable lock contains only an
     immutable random fencing epoch and is never rewritten, renamed, or deleted.
     This surface deliberately exposes no append, scan, fallback, repair, delete,
-    or migration operation. *)
+    or migration operation.
+
+    The parent namespace must be private to cooperating callers. Direct unlink
+    or replacement outside this surface is out of contract: remembering such a
+    deletion would require a second persistent freshness authority, which this
+    single-authority API intentionally rejects. *)
 
 val max_row_bytes : int
 

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -1,0 +1,60 @@
+(** Capability-relative, one-row durable HEAD authority.
+
+    This surface deliberately does not expose append, scan, fallback, repair, or
+    migration operations.  A HEAD is either absent, or exactly one non-empty
+    LF-terminated row. *)
+
+type cursor
+type snapshot
+
+val snapshot_row : snapshot -> string option
+val snapshot_cursor : snapshot -> cursor
+val snapshot_settlement_warnings : snapshot -> string list
+
+type io_error =
+  { operation : string
+  ; detail : string
+  }
+
+type error =
+  | Invalid_leaf of string
+  | Invalid_row of string
+  | Busy
+  | Conflict of snapshot
+  | Corrupt_lock of string
+  | Corrupt_head of string
+  | Unsupported of string
+  | Io_error of io_error
+
+type publication_indeterminate =
+  { intended_sha256 : string
+  ; intended_length : int64
+  ; observed : cursor option
+  }
+
+type target_effect =
+  | Unchanged
+  | Publication_indeterminate of publication_indeterminate
+
+type failure = private
+  { error : error
+  ; target_effect : target_effect
+  ; settlement_warnings : string list
+  }
+
+type publication
+
+val publication_cursor : publication -> cursor
+val publication_settlement_warnings : publication -> string list
+
+val read :
+  parent:Eio.Fs.dir_ty Eio.Path.t ->
+  leaf:string ->
+  (snapshot, failure) result
+
+val compare_and_swap :
+  parent:Eio.Fs.dir_ty Eio.Path.t ->
+  leaf:string ->
+  expected:cursor ->
+  row:string ->
+  (publication, failure) result

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -1,20 +1,45 @@
 (** Capability-relative, one-row durable HEAD authority.
 
-    This surface deliberately does not expose append, scan, fallback, repair, or
-    migration operations.  A HEAD is either absent, or exactly one non-empty
-    LF-terminated row. *)
+    HEAD is the only content authority. The stable lock contains only an
+    immutable random fencing epoch and is never rewritten, renamed, or deleted.
+    This surface deliberately exposes no append, scan, fallback, repair, delete,
+    or migration operation. *)
+
+val max_row_bytes : int
 
 type cursor
+type operation =
+  | Pin_parent
+  | Open_lock
+  | Acquire_cross_process_lock
+  | Read_lock_marker
+  | Initialize_lock_marker
+  | Read_head
+  | Create_stage
+  | Write_stage
+  | Sync_stage
+  | Close_stage
+  | Revalidate
+  | Rename_head
+  | Sync_parent
+  | Verify_publication
+  | Cleanup_stage
+  | Settle_resources
+
+type diagnostic =
+  { operation : operation
+  ; detail : string
+  }
+
+type settlement_warning =
+  | Cleanup_failed of diagnostic
+  | Resource_settlement_failed of diagnostic
+
 type snapshot
 
 val snapshot_row : snapshot -> string option
 val snapshot_cursor : snapshot -> cursor
-val snapshot_settlement_warnings : snapshot -> string list
-
-type io_error =
-  { operation : string
-  ; detail : string
-  }
+val snapshot_settlement_warnings : snapshot -> settlement_warning list
 
 type error =
   | Invalid_leaf of string
@@ -24,37 +49,72 @@ type error =
   | Corrupt_lock of string
   | Corrupt_head of string
   | Unsupported of string
-  | Io_error of io_error
+  | Io_error of diagnostic
+
+type publication_evidence =
+  { expected_cursor : cursor
+  ; intended_sha256 : string
+  ; intended_length : int64
+  ; published_cursor : cursor
+  }
 
 type publication_indeterminate =
-  { intended_sha256 : string
+  { expected_cursor : cursor
+  ; intended_sha256 : string
   ; intended_length : int64
   ; observed : cursor option
   }
 
 type target_effect =
   | Unchanged
+  | Published of publication_evidence
   | Publication_indeterminate of publication_indeterminate
 
 type failure = private
   { error : error
   ; target_effect : target_effect
-  ; settlement_warnings : string list
+  ; settlement_warnings : settlement_warning list
   }
 
 type publication
 
-val publication_cursor : publication -> cursor
-val publication_settlement_warnings : publication -> string list
+val publication_evidence : publication -> publication_evidence
+val publication_settlement_warnings : publication -> settlement_warning list
 
 val read :
+  secure_random:Eio.Flow.source_ty Eio.Resource.t ->
   parent:Eio.Fs.dir_ty Eio.Path.t ->
   leaf:string ->
   (snapshot, failure) result
 
 val compare_and_swap :
+  secure_random:Eio.Flow.source_ty Eio.Resource.t ->
   parent:Eio.Fs.dir_ty Eio.Path.t ->
   leaf:string ->
   expected:cursor ->
   row:string ->
   (publication, failure) result
+
+module For_testing : sig
+  type hooks
+
+  val hooks :
+    ?after_lock_acquired:(unit -> unit) ->
+    ?before_rename:(unit -> unit) ->
+    ?after_rename:(unit -> unit) ->
+    ?after_parent_sync:(unit -> unit) ->
+    ?after_verified:(unit -> unit) ->
+    ?before_stage_cleanup:(unit -> unit) ->
+    ?on_resource_settlement:(unit -> unit) ->
+    unit ->
+    hooks
+
+  val compare_and_swap :
+    hooks ->
+    secure_random:Eio.Flow.source_ty Eio.Resource.t ->
+    parent:Eio.Fs.dir_ty Eio.Path.t ->
+    leaf:string ->
+    expected:cursor ->
+    row:string ->
+    (publication, failure) result
+end

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -56,6 +56,9 @@ type error =
   | Unsupported of string
   | Io_error of diagnostic
 
+(** In publication evidence, [intended_sha256] and [intended_length] describe
+    the exact on-disk HEAD payload: the caller-provided row followed by one LF.
+    They do not describe the row string before LF framing. *)
 type publication_evidence =
   { expected_cursor : cursor
   ; intended_sha256 : string

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -56,9 +56,10 @@ type error =
   | Unsupported of string
   | Io_error of diagnostic
 
-(** In publication evidence, [intended_sha256] and [intended_length] describe
-    the exact on-disk HEAD payload: the caller-provided row followed by one LF.
-    They do not describe the row string before LF framing. *)
+(** In publication evidence, [intended_sha256] is the 64-character lowercase
+    SHA-256 hex digest and [intended_length] is the byte length of the exact
+    on-disk HEAD payload [row || 0x0A]. They do not describe [row] before LF
+    framing. *)
 type publication_evidence =
   { expected_cursor : cursor
   ; intended_sha256 : string
@@ -66,6 +67,9 @@ type publication_evidence =
   ; published_cursor : cursor
   }
 
+(** [intended_sha256] and [intended_length] have the same wire-payload
+    definition as in {!publication_evidence}: lowercase SHA-256 hex and byte
+    length over [row || 0x0A]. *)
 type publication_indeterminate =
   { expected_cursor : cursor
   ; intended_sha256 : string

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -9,8 +9,9 @@
     or replacement outside this surface is out of contract: remembering such a
     deletion would require a second persistent freshness authority, which this
     single-authority API intentionally rejects. The sibling namespace prefix
-    [.masc-capability-head-] is reserved for stable locks and publication stages;
-    public [leaf] values beginning with it are rejected with [Invalid_leaf]. *)
+    [.masc-capability-head-] and all of its ASCII case variants are reserved for
+    stable locks and publication stages; public [leaf] values beginning with any
+    such variant are rejected with [Invalid_leaf]. *)
 
 val max_row_bytes : int
 

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -8,7 +8,9 @@
     The parent namespace must be private to cooperating callers. Direct unlink
     or replacement outside this surface is out of contract: remembering such a
     deletion would require a second persistent freshness authority, which this
-    single-authority API intentionally rejects. *)
+    single-authority API intentionally rejects. The sibling namespace prefix
+    [.masc-capability-head-] is reserved for stable locks and publication stages;
+    public [leaf] values beginning with it are rejected with [Invalid_leaf]. *)
 
 val max_row_bytes : int
 

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -92,6 +92,10 @@ val read :
   leaf:string ->
   (snapshot, failure) result
 
+(** Pending caller cancellation is checked before dispatch. Once the protected
+    transaction begins, parent cancellation is deferred until one typed
+    publication outcome is settled; no cancellation check occurs after
+    publication. *)
 val compare_and_swap :
   secure_random:Eio.Flow.source_ty Eio.Resource.t ->
   parent:Eio.Fs.dir_ty Eio.Path.t ->

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -22,7 +22,7 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries eio eio.unix unix yojson uuidm digestif))
+ (libraries eio eio.unix unix yojson uuidm digestif optint))
 
 (library
  (name fs_compat)

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -9,6 +9,7 @@
   fd_cache
   owned_directory_chain
   capability_leaf
+  capability_head
   capability_mutation_lease
   eio_resource_scope
   capability_recovery_obligation

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -22,7 +22,7 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries eio eio.unix unix yojson uuidm digestif optint))
+ (libraries eio eio.unix unix yojson uuidm digestif optint cstruct))
 
 (library
  (name fs_compat)

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -3309,3 +3309,4 @@ let append_jsonl_batch (path : string) (jsons : Yojson.Safe.t list) : unit =
         Stdlib.flush oc))
   end
 ;;
+module Capability_head = Capability_head

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -1199,3 +1199,4 @@ val reset_fd_cache_for_testing : unit -> unit
     creation, HOME guards, and per-path write serialization stay composed
     at the public append boundary. *)
 val with_cached_writer_for_testing : string -> (out_channel -> 'a) -> 'a
+module Capability_head = Capability_head

--- a/masc.opam
+++ b/masc.opam
@@ -57,6 +57,7 @@ depends: [
   "eio_posix" {>= "0.16"}
   "cstruct" {>= "6.0"}
   "digestif" {>= "1.1"}
+  "optint"
   "ocaml-protoc-plugin" {>= "4.0"}
   "pbrt" {>= "3.0" & < "4.0"}
   "h2" {>= "0.13"}

--- a/test/dune
+++ b/test/dune
@@ -2592,7 +2592,7 @@
 (test
  (name test_fs_compat_capability_head)
  (modules test_fs_compat_capability_head)
- (libraries alcotest fs_compat eio eio_main unix))
+ (libraries alcotest cstruct fs_compat eio eio_main unix))
 
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
 (include stanzas/test_eio_resource_scope.inc)

--- a/test/dune
+++ b/test/dune
@@ -2588,5 +2588,11 @@
 (include stanzas/test_keeper_gate_effect_coverage.inc)
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)
 (include stanzas/test_fs_compat_capability_write.inc)
+
+(test
+ (name test_fs_compat_capability_head)
+ (modules test_fs_compat_capability_head)
+ (libraries alcotest fs_compat eio eio_main unix))
+
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
 (include stanzas/test_eio_resource_scope.inc)

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -337,28 +337,46 @@ let test_before_rename_failure_and_cancellation_are_unchanged
   =
   with_tmp_dir "masc_capability_head_before_rename_" @@ fun directory ->
   with_parent ~fs directory @@ fun parent ->
-  List.iter
-    (fun (leaf, label, inject) ->
-       let absent = read ~secure_random ~parent ~leaf (label ^ " read") in
-       let hooks = Head.For_testing.hooks ~before_rename:inject () in
-       publish_for_testing
-         hooks
-         ~secure_random
-         ~parent
-         ~leaf
-         ~expected:absent
-         ~row:"must-not-publish"
-       |> require_unchanged_failure label;
-       read ~secure_random ~parent ~leaf (label ^ " final read")
-       |> check_row (label ^ " keeps HEAD absent") None)
-    [ "HEAD-exception", "before-rename exception", (fun () -> raise Exit)
-    ; ( "HEAD-cancellation"
-      , "before-rename cancellation"
-      , (fun () ->
-          raise
-            (Eio.Cancel.Cancelled
-               (Failure "injected before-rename cancellation"))) )
-    ]
+  let exception_leaf = "HEAD-exception" in
+  let exception_label = "before-rename exception" in
+  let absent = read ~secure_random ~parent ~leaf:exception_leaf (exception_label ^ " read") in
+  let hooks = Head.For_testing.hooks ~before_rename:(fun () -> raise Exit) () in
+  publish_for_testing
+    hooks
+    ~secure_random
+    ~parent
+    ~leaf:exception_leaf
+    ~expected:absent
+    ~row:"must-not-publish"
+  |> require_unchanged_failure exception_label;
+  read ~secure_random ~parent ~leaf:exception_leaf (exception_label ^ " final read")
+  |> check_row (exception_label ^ " keeps HEAD absent") None;
+  let cancellation_leaf = "HEAD-cancellation" in
+  let cancellation_label = "before-rename cancellation" in
+  let absent =
+    read ~secure_random ~parent ~leaf:cancellation_leaf (cancellation_label ^ " read")
+  in
+  let hooks =
+    Head.For_testing.hooks
+      ~before_rename:(fun () ->
+        raise
+          (Eio.Cancel.Cancelled
+             (Failure "injected before-rename cancellation")))
+      ()
+  in
+  (match
+     publish_for_testing
+       hooks
+       ~secure_random
+       ~parent
+       ~leaf:cancellation_leaf
+       ~expected:absent
+       ~row:"must-not-publish"
+   with
+   | exception Eio.Cancel.Cancelled _ -> ()
+   | _ -> Alcotest.fail "pre-publication cancellation was swallowed");
+  read ~secure_random ~parent ~leaf:cancellation_leaf (cancellation_label ^ " final read")
+  |> check_row (cancellation_label ^ " keeps HEAD absent") None
 ;;
 
 let test_after_rename_failure_is_indeterminate ~fs ~secure_random () =

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -124,6 +124,51 @@ let check_publication_evidence label row (evidence : Head.publication_evidence) 
     (String.length evidence.Head.intended_sha256)
 ;;
 
+let cross_process_holder_arg = "--capability-head-cross-process-holder"
+
+let () =
+  if
+    Array.length Sys.argv = 5
+    && String.equal Sys.argv.(1) cross_process_holder_arg
+  then (
+    let directory = Sys.argv.(2) in
+    let leaf = Sys.argv.(3) in
+    let row = Sys.argv.(4) in
+    let exit_code =
+      try
+        Eio_main.run @@ fun env ->
+        let fs = Eio.Stdenv.fs env in
+        let secure_random = Eio.Stdenv.secure_random env in
+        with_parent ~fs directory @@ fun parent ->
+        match Head.read ~secure_random ~parent ~leaf with
+        | Error _ -> 2
+        | Ok expected ->
+          let hooks =
+            Head.For_testing.hooks
+              ~after_lock_acquired:(fun () ->
+                output_char stdout 'R';
+                flush stdout;
+                if input_char stdin <> 'X'
+                then failwith "invalid cross-process release signal")
+              ()
+          in
+          (match
+             Head.For_testing.compare_and_swap
+               hooks
+               ~secure_random
+               ~parent
+               ~leaf
+               ~expected:(Head.snapshot_cursor expected)
+               ~row
+           with
+           | Ok _ -> 0
+           | Error _ -> 3)
+      with
+      | _ -> 4
+    in
+    exit exit_code)
+;;
+
 let test_absent_publish_and_reopen ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_reopen_" @@ fun directory ->
   let leaf = "HEAD" in
@@ -329,6 +374,72 @@ let test_different_roots_do_not_false_share ~fs ~secure_random () =
   |> check_row "root A retains its authority" (Some "root-a");
   read ~secure_random ~parent:parent_b ~leaf "root B final read"
   |> check_row "root B progressed independently" (Some "root-b")
+;;
+
+let test_cross_process_lock_then_stale_cursor
+      ~fs
+      ~secure_random
+      ~process_mgr
+      ()
+  =
+  with_tmp_dir "masc_capability_head_cross_process_" @@ fun directory ->
+  let leaf = "HEAD" in
+  let child_row = "cross-process-winner" in
+  with_parent ~fs directory @@ fun parent ->
+  let original = read ~secure_random ~parent ~leaf "cross-process initial read" in
+  Eio.Switch.run @@ fun sw ->
+  let child_stdin, parent_stdin = Eio.Process.pipe ~sw process_mgr in
+  let parent_stdout, child_stdout = Eio.Process.pipe ~sw process_mgr in
+  let child =
+    Eio.Process.spawn
+      ~sw
+      process_mgr
+      ~stdin:child_stdin
+      ~stdout:child_stdout
+      ~executable:Sys.executable_name
+      [ Sys.executable_name
+      ; cross_process_holder_arg
+      ; directory
+      ; leaf
+      ; child_row
+      ]
+  in
+  Eio.Flow.close child_stdin;
+  Eio.Flow.close child_stdout;
+  let ready = Cstruct.create 1 in
+  Eio.Flow.read_exact parent_stdout ready;
+  check string
+    "separate process owns the stable lock"
+    "R"
+    (Cstruct.to_string ready);
+  Head.compare_and_swap
+    ~secure_random
+    ~parent
+    ~leaf
+    ~expected:(Head.snapshot_cursor original)
+    ~row:"contender-must-not-publish"
+  |> require_busy "cross-process contender";
+  Eio.Flow.copy_string "X" parent_stdin;
+  Eio.Flow.close parent_stdin;
+  Eio.Process.await_exn child;
+  Eio.Flow.close parent_stdout;
+  let current =
+    Head.compare_and_swap
+      ~secure_random
+      ~parent
+      ~leaf
+      ~expected:(Head.snapshot_cursor original)
+      ~row:"stale-cursor-must-not-publish"
+    |> require_conflict "cursor after cross-process publication"
+  in
+  check_row
+    "released child publication invalidates the original cursor"
+    (Some child_row)
+    current;
+  read ~secure_random ~parent ~leaf "cross-process final read"
+  |> check_row
+       "cross-process winner remains the exact HEAD authority"
+       (Some child_row)
 ;;
 
 let test_parent_cancellation_after_dispatch_returns_publication
@@ -553,8 +664,13 @@ let test_resource_settlement_warning_preserves_success ~fs ~secure_random () =
     |> require_publication "resource settlement"
   in
   (match Head.publication_settlement_warnings publication with
+   | [ Head.Resource_settlement_failed
+         ({ operation = Head.Settle_resources; _ } : Head.diagnostic) ] ->
+     ()
    | [] -> fail "resource-settlement failure was silently dropped"
-   | _ :: _ -> ());
+   | _ ->
+     fail
+       "resource settlement did not produce exactly one typed Settle_resources warning");
   Head.publication_evidence publication
   |> check_publication_evidence "resource settlement" "settled-row";
   read ~secure_random ~parent ~leaf "resource settlement final read"
@@ -565,6 +681,7 @@ let () =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
   let secure_random = Eio.Stdenv.secure_random env in
+  let process_mgr = Eio.Stdenv.process_mgr env in
   run
     "fs_compat capability HEAD"
     [ ( "authority"
@@ -582,6 +699,11 @@ let () =
             (test_same_directory_contention_is_busy ~fs ~secure_random)
         ; test_case "different roots do not false-share" `Quick
             (test_different_roots_do_not_false_share ~fs ~secure_random)
+        ; test_case "cross-process lock and stale cursor" `Quick
+            (test_cross_process_lock_then_stale_cursor
+               ~fs
+               ~secure_random
+               ~process_mgr)
         ; test_case "parent cancellation after dispatch publishes once" `Quick
             (test_parent_cancellation_after_dispatch_returns_publication
                ~fs

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -320,17 +320,22 @@ let test_strict_row_shape_rejection ~fs ~secure_random () =
 
 let test_reserved_namespace_is_rejected_before_dispatch ~fs () =
   with_tmp_dir "masc_capability_head_reserved_leaf_" @@ fun directory ->
-  let leaf = ".masc-capability-head-forbidden" in
   with_parent ~fs directory @@ fun parent ->
-  Head.read
-    ~secure_random:(Eio.Flow.string_source "")
-    ~parent
-    ~leaf
-  |> require_invalid_leaf ~expected:leaf "reserved capability HEAD namespace";
-  check (list string)
-    "reserved leaf creates neither target nor stable lock"
-    []
-    (directory_entries directory)
+  List.iter
+    (fun (label, leaf) ->
+       Head.read
+         ~secure_random:(Eio.Flow.string_source "")
+         ~parent
+         ~leaf
+       |> require_invalid_leaf ~expected:leaf label;
+       check (list string)
+         (label ^ " creates neither target nor stable lock")
+         []
+         (directory_entries directory))
+    [ "lowercase reserved capability HEAD namespace", ".masc-capability-head-forbidden"
+    ; "uppercase reserved capability HEAD namespace", ".MASC-CAPABILITY-HEAD-FORBIDDEN"
+    ; "mixed-case reserved capability HEAD namespace", ".MaSc-CaPaBiLiTy-HeAd-forbidden"
+    ]
 ;;
 
 let test_first_read_entropy_eof_is_unchanged_and_recoverable

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -13,6 +13,10 @@ let with_parent ~fs directory f =
   Eio.Path.with_open_dir Eio.Path.(fs / directory) f
 ;;
 
+let directory_entries directory =
+  Sys.readdir directory |> Array.to_list |> List.sort String.compare
+;;
+
 let require_read label = function
   | Ok snapshot -> snapshot
   | Error _ -> failf "%s: HEAD read failed" label
@@ -54,6 +58,31 @@ let require_invalid_row label = function
     ()
   | Error _ -> failf "%s: expected an unchanged typed invalid-row failure" label
   | Ok _ -> failf "%s: invalid row unexpectedly published" label
+;;
+
+let require_invalid_leaf ~expected label = function
+  | Error
+      ({ error = Head.Invalid_leaf observed
+       ; target_effect = Head.Unchanged
+       ; _
+       } : Head.failure) ->
+    check string (label ^ " rejected leaf") expected observed
+  | Error _ -> failf "%s: expected an unchanged typed invalid-leaf failure" label
+  | Ok _ -> failf "%s: reserved leaf unexpectedly dispatched" label
+;;
+
+let require_unchanged_io_error ~operation label = function
+  | Error
+      ({ error =
+           Head.Io_error
+             ({ operation = observed_operation; _ } : Head.diagnostic)
+       ; target_effect = Head.Unchanged
+       ; _
+       } : Head.failure)
+    when observed_operation = operation ->
+    ()
+  | Error _ -> failf "%s: expected the exact unchanged typed IO failure" label
+  | Ok _ -> failf "%s: entropy exhaustion unexpectedly succeeded" label
 ;;
 
 let require_unchanged_failure label = function
@@ -287,6 +316,64 @@ let test_strict_row_shape_rejection ~fs ~secure_random () =
        "valid row after rejections");
   read ~secure_random ~parent ~leaf "valid row post-read"
   |> check_row "invalid attempts do not poison later publication" (Some "valid-row")
+;;
+
+let test_reserved_namespace_is_rejected_before_dispatch ~fs () =
+  with_tmp_dir "masc_capability_head_reserved_leaf_" @@ fun directory ->
+  let leaf = ".masc-capability-head-forbidden" in
+  with_parent ~fs directory @@ fun parent ->
+  Head.read
+    ~secure_random:(Eio.Flow.string_source "")
+    ~parent
+    ~leaf
+  |> require_invalid_leaf ~expected:leaf "reserved capability HEAD namespace";
+  check (list string)
+    "reserved leaf creates neither target nor stable lock"
+    []
+    (directory_entries directory)
+;;
+
+let test_first_read_entropy_eof_is_unchanged_and_recoverable
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_lock_entropy_" @@ fun directory ->
+  let leaf = "HEAD" in
+  let target = Filename.concat directory leaf in
+  with_parent ~fs directory @@ fun parent ->
+  Head.read
+    ~secure_random:(Eio.Flow.string_source (String.make 31 'x'))
+    ~parent
+    ~leaf
+  |> require_unchanged_io_error
+       ~operation:Head.Initialize_lock_marker
+       "finite lock-marker entropy";
+  check bool "lock-marker entropy EOF leaves HEAD absent" false (Sys.file_exists target);
+  Head.read ~secure_random ~parent ~leaf
+  |> require_read "fresh entropy after lock-marker EOF"
+  |> check_row "fresh entropy recovers an absent HEAD" None
+;;
+
+let test_stage_entropy_eof_is_unchanged ~fs ~secure_random () =
+  with_tmp_dir "masc_capability_head_stage_entropy_" @@ fun directory ->
+  let leaf = "HEAD" in
+  let target = Filename.concat directory leaf in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "initialized lock read" in
+  Head.compare_and_swap
+    ~secure_random:(Eio.Flow.string_source "")
+    ~parent
+    ~leaf
+    ~expected:(Head.snapshot_cursor absent)
+    ~row:"must-not-stage"
+  |> require_unchanged_io_error
+       ~operation:Head.Create_stage
+       "empty stage entropy";
+  check bool "stage entropy EOF leaves HEAD absent" false (Sys.file_exists target);
+  Head.read ~secure_random ~parent ~leaf
+  |> require_read "exact read after stage entropy EOF"
+  |> check_row "stage entropy EOF leaves authority unchanged" None
 ;;
 
 let test_same_directory_contention_is_busy ~fs ~secure_random () =
@@ -697,6 +784,14 @@ let () =
             (test_cross_root_absent_cursor_conflicts ~fs ~secure_random)
         ; test_case "strict one-row shape" `Quick
             (test_strict_row_shape_rejection ~fs ~secure_random)
+        ; test_case "reserved namespace rejected before dispatch" `Quick
+            (test_reserved_namespace_is_rejected_before_dispatch ~fs)
+        ; test_case "lock entropy EOF is unchanged and recoverable" `Quick
+            (test_first_read_entropy_eof_is_unchanged_and_recoverable
+               ~fs
+               ~secure_random)
+        ; test_case "stage entropy EOF is unchanged" `Quick
+            (test_stage_entropy_eof_is_unchanged ~fs ~secure_random)
         ] )
     ; ( "concurrency"
       , [ test_case "same-directory contention is busy" `Quick

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -125,6 +125,7 @@ let check_publication_evidence label row (evidence : Head.publication_evidence) 
 ;;
 
 let cross_process_holder_arg = "--capability-head-cross-process-holder"
+let cross_process_timeout_seconds = 10.0
 
 let () =
   if
@@ -380,66 +381,68 @@ let test_cross_process_lock_then_stale_cursor
       ~fs
       ~secure_random
       ~process_mgr
+      ~clock
       ()
   =
   with_tmp_dir "masc_capability_head_cross_process_" @@ fun directory ->
   let leaf = "HEAD" in
   let child_row = "cross-process-winner" in
   with_parent ~fs directory @@ fun parent ->
-  let original = read ~secure_random ~parent ~leaf "cross-process initial read" in
-  Eio.Switch.run @@ fun sw ->
-  let child_stdin, parent_stdin = Eio.Process.pipe ~sw process_mgr in
-  let parent_stdout, child_stdout = Eio.Process.pipe ~sw process_mgr in
-  let child =
-    Eio.Process.spawn
-      ~sw
-      process_mgr
-      ~stdin:child_stdin
-      ~stdout:child_stdout
-      ~executable:Sys.executable_name
-      [ Sys.executable_name
-      ; cross_process_holder_arg
-      ; directory
-      ; leaf
-      ; child_row
-      ]
-  in
-  Eio.Flow.close child_stdin;
-  Eio.Flow.close child_stdout;
-  let ready = Cstruct.create 1 in
-  Eio.Flow.read_exact parent_stdout ready;
-  check string
-    "separate process owns the stable lock"
-    "R"
-    (Cstruct.to_string ready);
-  Head.compare_and_swap
-    ~secure_random
-    ~parent
-    ~leaf
-    ~expected:(Head.snapshot_cursor original)
-    ~row:"contender-must-not-publish"
-  |> require_busy "cross-process contender";
-  Eio.Flow.copy_string "X" parent_stdin;
-  Eio.Flow.close parent_stdin;
-  Eio.Process.await_exn child;
-  Eio.Flow.close parent_stdout;
-  let current =
+  Eio.Time.with_timeout_exn clock cross_process_timeout_seconds (fun () ->
+    let original = read ~secure_random ~parent ~leaf "cross-process initial read" in
+    Eio.Switch.run @@ fun sw ->
+    let child_stdin, parent_stdin = Eio.Process.pipe ~sw process_mgr in
+    let parent_stdout, child_stdout = Eio.Process.pipe ~sw process_mgr in
+    let child =
+      Eio.Process.spawn
+        ~sw
+        process_mgr
+        ~stdin:child_stdin
+        ~stdout:child_stdout
+        ~executable:Sys.executable_name
+        [ Sys.executable_name
+        ; cross_process_holder_arg
+        ; directory
+        ; leaf
+        ; child_row
+        ]
+    in
+    Eio.Flow.close child_stdin;
+    Eio.Flow.close child_stdout;
+    let ready = Cstruct.create 1 in
+    Eio.Flow.read_exact parent_stdout ready;
+    check string
+      "separate process owns the stable lock"
+      "R"
+      (Cstruct.to_string ready);
     Head.compare_and_swap
       ~secure_random
       ~parent
       ~leaf
       ~expected:(Head.snapshot_cursor original)
-      ~row:"stale-cursor-must-not-publish"
-    |> require_conflict "cursor after cross-process publication"
-  in
-  check_row
-    "released child publication invalidates the original cursor"
-    (Some child_row)
-    current;
-  read ~secure_random ~parent ~leaf "cross-process final read"
-  |> check_row
-       "cross-process winner remains the exact HEAD authority"
-       (Some child_row)
+      ~row:"contender-must-not-publish"
+    |> require_busy "cross-process contender";
+    Eio.Flow.copy_string "X" parent_stdin;
+    Eio.Flow.close parent_stdin;
+    Eio.Process.await_exn child;
+    Eio.Flow.close parent_stdout;
+    let current =
+      Head.compare_and_swap
+        ~secure_random
+        ~parent
+        ~leaf
+        ~expected:(Head.snapshot_cursor original)
+        ~row:"stale-cursor-must-not-publish"
+      |> require_conflict "cursor after cross-process publication"
+    in
+    check_row
+      "released child publication invalidates the original cursor"
+      (Some child_row)
+      current;
+    read ~secure_random ~parent ~leaf "cross-process final read"
+    |> check_row
+         "cross-process winner remains the exact HEAD authority"
+         (Some child_row))
 ;;
 
 let test_parent_cancellation_after_dispatch_returns_publication
@@ -682,6 +685,7 @@ let () =
   let fs = Eio.Stdenv.fs env in
   let secure_random = Eio.Stdenv.secure_random env in
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
   run
     "fs_compat capability HEAD"
     [ ( "authority"
@@ -703,7 +707,8 @@ let () =
             (test_cross_process_lock_then_stale_cursor
                ~fs
                ~secure_random
-               ~process_mgr)
+               ~process_mgr
+               ~clock)
         ; test_case "parent cancellation after dispatch publishes once" `Quick
             (test_parent_cancellation_after_dispatch_returns_publication
                ~fs

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -34,6 +34,17 @@ let require_conflict label = function
   | Ok _ -> failf "%s: stale or foreign cursor unexpectedly published" label
 ;;
 
+let require_busy label = function
+  | Error
+      ({ error = Head.Busy
+       ; target_effect = Head.Unchanged
+       ; _
+       } : Head.failure) ->
+    ()
+  | Error _ -> failf "%s: expected an unchanged typed busy result" label
+  | Ok _ -> failf "%s: contending publication unexpectedly succeeded" label
+;;
+
 let require_invalid_row label = function
   | Error
       ({ error = Head.Invalid_row _
@@ -45,12 +56,33 @@ let require_invalid_row label = function
   | Ok _ -> failf "%s: invalid row unexpectedly published" label
 ;;
 
-let read ~parent ~leaf label =
-  Head.read ~parent ~leaf |> require_read label
+let require_unchanged_failure label = function
+  | Error ({ target_effect = Head.Unchanged; _ } : Head.failure) -> ()
+  | Error _ -> failf "%s: failure crossed the publication boundary" label
+  | Ok _ -> failf "%s: injected pre-publication failure unexpectedly succeeded" label
 ;;
 
-let publish ~parent ~leaf ~expected ~row label =
+let require_indeterminate_failure label = function
+  | Error
+      ({ target_effect = Head.Publication_indeterminate evidence; _ } : Head.failure) ->
+    evidence
+  | Error _ -> failf "%s: expected publication-indeterminate evidence" label
+  | Ok _ -> failf "%s: injected post-rename failure unexpectedly returned success" label
+;;
+
+let require_published_failure label = function
+  | Error ({ target_effect = Head.Published evidence; _ } : Head.failure) -> evidence
+  | Error _ -> failf "%s: expected typed published evidence" label
+  | Ok _ -> failf "%s: injected post-verification failure unexpectedly returned success" label
+;;
+
+let read ~secure_random ~parent ~leaf label =
+  Head.read ~secure_random ~parent ~leaf |> require_read label
+;;
+
+let publish ~secure_random ~parent ~leaf ~expected ~row label =
   Head.compare_and_swap
+    ~secure_random
     ~parent
     ~leaf
     ~expected:(Head.snapshot_cursor expected)
@@ -58,47 +90,81 @@ let publish ~parent ~leaf ~expected ~row label =
   |> require_publication label
 ;;
 
+let publish_for_testing
+      hooks
+      ~secure_random
+      ~parent
+      ~leaf
+      ~expected
+      ~row
+  =
+  Head.For_testing.compare_and_swap
+    hooks
+    ~secure_random
+    ~parent
+    ~leaf
+    ~expected:(Head.snapshot_cursor expected)
+    ~row
+;;
+
 let check_row label expected snapshot =
   check (option string) label expected (Head.snapshot_row snapshot)
 ;;
 
-let test_absent_publish_and_reopen ~fs () =
+let check_publication_evidence label row evidence =
+  ignore evidence.Head.expected_cursor;
+  ignore evidence.Head.published_cursor;
+  check int64
+    (label ^ " intended byte length")
+    (Int64.of_int (String.length row + 1))
+    evidence.Head.intended_length;
+  check int
+    (label ^ " SHA-256 hex length")
+    64
+    (String.length evidence.Head.intended_sha256)
+;;
+
+let test_absent_publish_and_reopen ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_reopen_" @@ fun directory ->
   let leaf = "HEAD" in
   with_parent ~fs directory (fun parent ->
-    let absent = read ~parent ~leaf "initial absent read" in
+    let absent = read ~secure_random ~parent ~leaf "initial absent read" in
     check_row "fresh HEAD is absent" None absent;
-    let publication =
-      publish
-        ~parent
-        ~leaf
-        ~expected:absent
-        ~row:"manifest-v1"
-        "initial publication"
-    in
-    ignore (Head.publication_cursor publication));
+    publish
+      ~secure_random
+      ~parent
+      ~leaf
+      ~expected:absent
+      ~row:"manifest-v1"
+      "initial publication"
+    |> Head.publication_evidence
+    |> check_publication_evidence "initial publication" "manifest-v1");
   with_parent ~fs directory (fun reopened_parent ->
-    let reopened = read ~parent:reopened_parent ~leaf "reopened read" in
+    let reopened =
+      read ~secure_random ~parent:reopened_parent ~leaf "reopened read"
+    in
     check_row "reopened HEAD observes first row" (Some "manifest-v1") reopened;
     ignore
       (publish
+         ~secure_random
          ~parent:reopened_parent
          ~leaf
          ~expected:reopened
          ~row:"manifest-v2"
          "publication after reopen"));
   with_parent ~fs directory (fun final_parent ->
-    read ~parent:final_parent ~leaf "final reopened read"
+    read ~secure_random ~parent:final_parent ~leaf "final reopened read"
     |> check_row "second publication remains authoritative" (Some "manifest-v2"))
 ;;
 
-let test_stale_cursor_conflicts_without_mutation ~fs () =
+let test_stale_cursor_conflicts_without_mutation ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_stale_" @@ fun directory ->
   let leaf = "HEAD" in
   with_parent ~fs directory @@ fun parent ->
-  let absent = read ~parent ~leaf "stale fixture read" in
+  let absent = read ~secure_random ~parent ~leaf "stale fixture read" in
   ignore
     (publish
+       ~secure_random
        ~parent
        ~leaf
        ~expected:absent
@@ -106,6 +172,7 @@ let test_stale_cursor_conflicts_without_mutation ~fs () =
        "winner publication");
   let current =
     Head.compare_and_swap
+      ~secure_random
       ~parent
       ~leaf
       ~expected:(Head.snapshot_cursor absent)
@@ -113,20 +180,21 @@ let test_stale_cursor_conflicts_without_mutation ~fs () =
     |> require_conflict "stale publication"
   in
   check_row "conflict carries current authority" (Some "winner") current;
-  read ~parent ~leaf "read after stale conflict"
+  read ~secure_random ~parent ~leaf "read after stale conflict"
   |> check_row "stale attempt leaves authority unchanged" (Some "winner")
 ;;
 
-let test_cross_root_absent_cursor_conflicts ~fs () =
+let test_cross_root_absent_cursor_conflicts ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_cursor_a_" @@ fun directory_a ->
   with_tmp_dir "masc_capability_head_cursor_b_" @@ fun directory_b ->
   let leaf = "HEAD" in
   with_parent ~fs directory_a @@ fun parent_a ->
   with_parent ~fs directory_b @@ fun parent_b ->
-  let foreign = read ~parent:parent_a ~leaf "root A absent read" in
+  let foreign = read ~secure_random ~parent:parent_a ~leaf "root A absent read" in
   check_row "root A is absent" None foreign;
   let current =
     Head.compare_and_swap
+      ~secure_random
       ~parent:parent_b
       ~leaf
       ~expected:(Head.snapshot_cursor foreign)
@@ -134,25 +202,26 @@ let test_cross_root_absent_cursor_conflicts ~fs () =
     |> require_conflict "cross-root publication"
   in
   check_row "foreign cursor conflict reports root B absent" None current;
-  read ~parent:parent_b ~leaf "root B after foreign cursor"
+  read ~secure_random ~parent:parent_b ~leaf "root B after foreign cursor"
   |> check_row "foreign cursor cannot create root B HEAD" None
 ;;
 
-let test_strict_row_shape_rejection ~fs () =
+let test_strict_row_shape_rejection ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_row_" @@ fun directory ->
   let leaf = "HEAD" in
   with_parent ~fs directory @@ fun parent ->
   List.iter
     (fun (label, row) ->
-       let absent = read ~parent ~leaf (label ^ " pre-read") in
+       let absent = read ~secure_random ~parent ~leaf (label ^ " pre-read") in
        check_row (label ^ " keeps HEAD absent before CAS") None absent;
        Head.compare_and_swap
+         ~secure_random
          ~parent
          ~leaf
          ~expected:(Head.snapshot_cursor absent)
          ~row
        |> require_invalid_row label;
-       read ~parent ~leaf (label ^ " post-read")
+       read ~secure_random ~parent ~leaf (label ^ " post-read")
        |> check_row (label ^ " leaves HEAD absent") None)
     [ "empty row", ""
     ; "LF-only row", "\n"
@@ -160,93 +229,251 @@ let test_strict_row_shape_rejection ~fs () =
     ; "CRLF row", "row\r\n"
     ; "embedded LF row", "left\nright"
     ];
-  let absent = read ~parent ~leaf "valid row pre-read" in
+  let absent = read ~secure_random ~parent ~leaf "valid row pre-read" in
   ignore
     (publish
+       ~secure_random
        ~parent
        ~leaf
        ~expected:absent
        ~row:"valid-row"
        "valid row after rejections");
-  read ~parent ~leaf "valid row post-read"
+  read ~secure_random ~parent ~leaf "valid row post-read"
   |> check_row "invalid attempts do not poison later publication" (Some "valid-row")
 ;;
 
-let test_independent_same_directory_handles_have_one_winner ~fs () =
-  with_tmp_dir "masc_capability_head_handles_" @@ fun directory ->
+let test_same_directory_contention_is_busy ~fs ~secure_random () =
+  with_tmp_dir "masc_capability_head_contention_" @@ fun directory ->
   let leaf = "HEAD" in
   with_parent ~fs directory @@ fun parent_a ->
   with_parent ~fs directory @@ fun parent_b ->
-  let candidate_a = read ~parent:parent_a ~leaf "handle A absent read" in
-  let candidate_b = read ~parent:parent_b ~leaf "handle B absent read" in
-  check_row "handle A observes absent HEAD" None candidate_a;
-  check_row "handle B observes the same absent generation" None candidate_b;
-  ignore
-    (publish
-       ~parent:parent_a
-       ~leaf
-       ~expected:candidate_a
-       ~row:"handle-a-wins"
-       "handle A publication");
-  let current =
-    Head.compare_and_swap
-      ~parent:parent_b
+  let candidate_a = read ~secure_random ~parent:parent_a ~leaf "handle A read" in
+  let candidate_b = read ~secure_random ~parent:parent_b ~leaf "handle B read" in
+  Eio.Switch.run @@ fun sw ->
+  let lock_acquired, resolve_lock_acquired = Eio.Promise.create () in
+  let release_lock, resolve_release_lock = Eio.Promise.create () in
+  let result_a, resolve_result_a = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let hooks =
+      Head.For_testing.hooks
+        ~after_lock_acquired:(fun () ->
+          Eio.Promise.resolve resolve_lock_acquired ();
+          Eio.Promise.await release_lock)
+        ()
+    in
+    publish_for_testing
+      hooks
+      ~secure_random
+      ~parent:parent_a
       ~leaf
-      ~expected:(Head.snapshot_cursor candidate_b)
-      ~row:"handle-b-must-lose"
-    |> require_conflict "handle B publication"
-  in
-  check_row "losing handle receives winning authority" (Some "handle-a-wins") current;
-  read ~parent:parent_b ~leaf "losing handle final read"
-  |> check_row "only the first candidate published" (Some "handle-a-wins")
+      ~expected:candidate_a
+      ~row:"handle-a-wins"
+    |> Eio.Promise.resolve resolve_result_a);
+  Eio.Promise.await lock_acquired;
+  Head.compare_and_swap
+    ~secure_random
+    ~parent:parent_b
+    ~leaf
+    ~expected:(Head.snapshot_cursor candidate_b)
+    ~row:"handle-b-must-not-enter"
+  |> require_busy "second same-directory writer";
+  Eio.Promise.resolve resolve_release_lock ();
+  Eio.Promise.await result_a
+  |> require_publication "first same-directory writer"
+  |> ignore;
+  read ~secure_random ~parent:parent_b ~leaf "contention final read"
+  |> check_row "lock owner is the only publisher" (Some "handle-a-wins")
 ;;
 
-let test_different_roots_do_not_false_share ~fs () =
+let test_different_roots_do_not_false_share ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_root_a_" @@ fun directory_a ->
   with_tmp_dir "masc_capability_head_root_b_" @@ fun directory_b ->
   let leaf = "HEAD" in
   with_parent ~fs directory_a @@ fun parent_a ->
   with_parent ~fs directory_b @@ fun parent_b ->
-  let absent_a = read ~parent:parent_a ~leaf "root A read" in
-  let absent_b = read ~parent:parent_b ~leaf "root B read" in
+  let candidate_a = read ~secure_random ~parent:parent_a ~leaf "root A read" in
+  let candidate_b = read ~secure_random ~parent:parent_b ~leaf "root B read" in
+  Eio.Switch.run @@ fun sw ->
+  let lock_acquired, resolve_lock_acquired = Eio.Promise.create () in
+  let release_lock, resolve_release_lock = Eio.Promise.create () in
+  let result_a, resolve_result_a = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let hooks =
+      Head.For_testing.hooks
+        ~after_lock_acquired:(fun () ->
+          Eio.Promise.resolve resolve_lock_acquired ();
+          Eio.Promise.await release_lock)
+        ()
+    in
+    publish_for_testing
+      hooks
+      ~secure_random
+      ~parent:parent_a
+      ~leaf
+      ~expected:candidate_a
+      ~row:"root-a"
+    |> Eio.Promise.resolve resolve_result_a);
+  Eio.Promise.await lock_acquired;
   ignore
     (publish
-       ~parent:parent_a
-       ~leaf
-       ~expected:absent_a
-       ~row:"root-a"
-       "root A publication");
-  ignore
-    (publish
+       ~secure_random
        ~parent:parent_b
        ~leaf
-       ~expected:absent_b
+       ~expected:candidate_b
        ~row:"root-b"
-       "root B publication");
-  read ~parent:parent_a ~leaf "root A final read"
-  |> check_row "root A retains its own authority" (Some "root-a");
-  read ~parent:parent_b ~leaf "root B final read"
-  |> check_row "root B retains its own authority" (Some "root-b")
+       "root B while root A is locked");
+  Eio.Promise.resolve resolve_release_lock ();
+  Eio.Promise.await result_a |> require_publication "root A writer" |> ignore;
+  read ~secure_random ~parent:parent_a ~leaf "root A final read"
+  |> check_row "root A retains its authority" (Some "root-a");
+  read ~secure_random ~parent:parent_b ~leaf "root B final read"
+  |> check_row "root B progressed independently" (Some "root-b")
+;;
+
+let test_before_rename_failure_and_cancellation_are_unchanged
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_before_rename_" @@ fun directory ->
+  with_parent ~fs directory @@ fun parent ->
+  List.iter
+    (fun (leaf, label, inject) ->
+       let absent = read ~secure_random ~parent ~leaf (label ^ " read") in
+       let hooks = Head.For_testing.hooks ~before_rename:inject () in
+       publish_for_testing
+         hooks
+         ~secure_random
+         ~parent
+         ~leaf
+         ~expected:absent
+         ~row:"must-not-publish"
+       |> require_unchanged_failure label;
+       read ~secure_random ~parent ~leaf (label ^ " final read")
+       |> check_row (label ^ " keeps HEAD absent") None)
+    [ "HEAD-exception", "before-rename exception", (fun () -> raise Exit)
+    ; ( "HEAD-cancellation"
+      , "before-rename cancellation"
+      , (fun () ->
+          raise
+            (Eio.Cancel.Cancelled
+               (Failure "injected before-rename cancellation"))) )
+    ]
+;;
+
+let test_after_rename_failure_is_indeterminate ~fs ~secure_random () =
+  with_tmp_dir "masc_capability_head_after_rename_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "after-rename fixture read" in
+  let hooks =
+    Head.For_testing.hooks ~after_rename:(fun () -> raise Exit) ()
+  in
+  let evidence =
+    publish_for_testing
+      hooks
+      ~secure_random
+      ~parent
+      ~leaf
+      ~expected:absent
+      ~row:"renamed-row"
+    |> require_indeterminate_failure "after-rename exception"
+  in
+  check int64
+    "indeterminate evidence retains intended length"
+    (Int64.of_int (String.length "renamed-row" + 1))
+    evidence.Head.intended_length;
+  check int
+    "indeterminate evidence retains intended SHA-256"
+    64
+    (String.length evidence.Head.intended_sha256)
+;;
+
+let test_after_verified_failure_reports_published ~fs ~secure_random () =
+  with_tmp_dir "masc_capability_head_after_verified_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "after-verified fixture read" in
+  let hooks =
+    Head.For_testing.hooks ~after_verified:(fun () -> raise Exit) ()
+  in
+  publish_for_testing
+    hooks
+    ~secure_random
+    ~parent
+    ~leaf
+    ~expected:absent
+    ~row:"published-row"
+  |> require_published_failure "after-verified exception"
+  |> check_publication_evidence "after-verified exception" "published-row";
+  read ~secure_random ~parent ~leaf "after-verified final read"
+  |> check_row "published effect matches durable authority" (Some "published-row")
+;;
+
+let test_resource_settlement_warning_preserves_success ~fs ~secure_random () =
+  with_tmp_dir "masc_capability_head_settlement_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "settlement fixture read" in
+  let hooks =
+    Head.For_testing.hooks
+      ~on_resource_settlement:(fun () -> raise Exit)
+      ()
+  in
+  let publication =
+    publish_for_testing
+      hooks
+      ~secure_random
+      ~parent
+      ~leaf
+      ~expected:absent
+      ~row:"settled-row"
+    |> require_publication "resource settlement"
+  in
+  (match Head.publication_settlement_warnings publication with
+   | [] -> fail "resource-settlement failure was silently dropped"
+   | _ :: _ -> ());
+  Head.publication_evidence publication
+  |> check_publication_evidence "resource settlement" "settled-row";
+  read ~secure_random ~parent ~leaf "resource settlement final read"
+  |> check_row "settlement warning does not hide publication" (Some "settled-row")
 ;;
 
 let () =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
+  let secure_random = Eio.Stdenv.secure_random env in
   run
     "fs_compat capability HEAD"
     [ ( "authority"
       , [ test_case "absent publish and reopen" `Quick
-            (test_absent_publish_and_reopen ~fs)
+            (test_absent_publish_and_reopen ~fs ~secure_random)
         ; test_case "stale cursor conflicts without mutation" `Quick
-            (test_stale_cursor_conflicts_without_mutation ~fs)
+            (test_stale_cursor_conflicts_without_mutation ~fs ~secure_random)
         ; test_case "cross-root absent cursor conflicts" `Quick
-            (test_cross_root_absent_cursor_conflicts ~fs)
+            (test_cross_root_absent_cursor_conflicts ~fs ~secure_random)
         ; test_case "strict one-row shape" `Quick
-            (test_strict_row_shape_rejection ~fs)
-        ; test_case "independent same-directory handles have one winner" `Quick
-            (test_independent_same_directory_handles_have_one_winner ~fs)
+            (test_strict_row_shape_rejection ~fs ~secure_random)
+        ] )
+    ; ( "concurrency"
+      , [ test_case "same-directory contention is busy" `Quick
+            (test_same_directory_contention_is_busy ~fs ~secure_random)
         ; test_case "different roots do not false-share" `Quick
-            (test_different_roots_do_not_false_share ~fs)
+            (test_different_roots_do_not_false_share ~fs ~secure_random)
+        ] )
+    ; ( "publication-boundary"
+      , [ test_case "before rename stays unchanged" `Quick
+            (test_before_rename_failure_and_cancellation_are_unchanged
+               ~fs
+               ~secure_random)
+        ; test_case "after rename is indeterminate" `Quick
+            (test_after_rename_failure_is_indeterminate ~fs ~secure_random)
+        ; test_case "after verified is published" `Quick
+            (test_after_verified_failure_reports_published ~fs ~secure_random)
+        ; test_case "settlement warning preserves success" `Quick
+            (test_resource_settlement_warning_preserves_success
+               ~fs
+               ~secure_random)
         ] )
     ]
 ;;

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -1,0 +1,252 @@
+open Alcotest
+
+module Head = Fs_compat.Capability_head
+
+let with_tmp_dir prefix f =
+  let path = Filename.temp_file prefix ".tmp" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree path) (fun () -> f path)
+;;
+
+let with_parent ~fs directory f =
+  Eio.Path.with_open_dir Eio.Path.(fs / directory) f
+;;
+
+let require_read label = function
+  | Ok snapshot -> snapshot
+  | Error _ -> failf "%s: HEAD read failed" label
+;;
+
+let require_publication label = function
+  | Ok publication -> publication
+  | Error _ -> failf "%s: HEAD publication failed" label
+;;
+
+let require_conflict label = function
+  | Error
+      ({ error = Head.Conflict current
+       ; target_effect = Head.Unchanged
+       ; _
+       } : Head.failure) ->
+    current
+  | Error _ -> failf "%s: expected an unchanged typed conflict" label
+  | Ok _ -> failf "%s: stale or foreign cursor unexpectedly published" label
+;;
+
+let require_invalid_row label = function
+  | Error
+      ({ error = Head.Invalid_row _
+       ; target_effect = Head.Unchanged
+       ; _
+       } : Head.failure) ->
+    ()
+  | Error _ -> failf "%s: expected an unchanged typed invalid-row failure" label
+  | Ok _ -> failf "%s: invalid row unexpectedly published" label
+;;
+
+let read ~parent ~leaf label =
+  Head.read ~parent ~leaf |> require_read label
+;;
+
+let publish ~parent ~leaf ~expected ~row label =
+  Head.compare_and_swap
+    ~parent
+    ~leaf
+    ~expected:(Head.snapshot_cursor expected)
+    ~row
+  |> require_publication label
+;;
+
+let check_row label expected snapshot =
+  check (option string) label expected (Head.snapshot_row snapshot)
+;;
+
+let test_absent_publish_and_reopen ~fs () =
+  with_tmp_dir "masc_capability_head_reopen_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory (fun parent ->
+    let absent = read ~parent ~leaf "initial absent read" in
+    check_row "fresh HEAD is absent" None absent;
+    let publication =
+      publish
+        ~parent
+        ~leaf
+        ~expected:absent
+        ~row:"manifest-v1"
+        "initial publication"
+    in
+    ignore (Head.publication_cursor publication));
+  with_parent ~fs directory (fun reopened_parent ->
+    let reopened = read ~parent:reopened_parent ~leaf "reopened read" in
+    check_row "reopened HEAD observes first row" (Some "manifest-v1") reopened;
+    ignore
+      (publish
+         ~parent:reopened_parent
+         ~leaf
+         ~expected:reopened
+         ~row:"manifest-v2"
+         "publication after reopen"));
+  with_parent ~fs directory (fun final_parent ->
+    read ~parent:final_parent ~leaf "final reopened read"
+    |> check_row "second publication remains authoritative" (Some "manifest-v2"))
+;;
+
+let test_stale_cursor_conflicts_without_mutation ~fs () =
+  with_tmp_dir "masc_capability_head_stale_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~parent ~leaf "stale fixture read" in
+  ignore
+    (publish
+       ~parent
+       ~leaf
+       ~expected:absent
+       ~row:"winner"
+       "winner publication");
+  let current =
+    Head.compare_and_swap
+      ~parent
+      ~leaf
+      ~expected:(Head.snapshot_cursor absent)
+      ~row:"stale-overwrite"
+    |> require_conflict "stale publication"
+  in
+  check_row "conflict carries current authority" (Some "winner") current;
+  read ~parent ~leaf "read after stale conflict"
+  |> check_row "stale attempt leaves authority unchanged" (Some "winner")
+;;
+
+let test_cross_root_absent_cursor_conflicts ~fs () =
+  with_tmp_dir "masc_capability_head_cursor_a_" @@ fun directory_a ->
+  with_tmp_dir "masc_capability_head_cursor_b_" @@ fun directory_b ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory_a @@ fun parent_a ->
+  with_parent ~fs directory_b @@ fun parent_b ->
+  let foreign = read ~parent:parent_a ~leaf "root A absent read" in
+  check_row "root A is absent" None foreign;
+  let current =
+    Head.compare_and_swap
+      ~parent:parent_b
+      ~leaf
+      ~expected:(Head.snapshot_cursor foreign)
+      ~row:"must-not-cross-roots"
+    |> require_conflict "cross-root publication"
+  in
+  check_row "foreign cursor conflict reports root B absent" None current;
+  read ~parent:parent_b ~leaf "root B after foreign cursor"
+  |> check_row "foreign cursor cannot create root B HEAD" None
+;;
+
+let test_strict_row_shape_rejection ~fs () =
+  with_tmp_dir "masc_capability_head_row_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  List.iter
+    (fun (label, row) ->
+       let absent = read ~parent ~leaf (label ^ " pre-read") in
+       check_row (label ^ " keeps HEAD absent before CAS") None absent;
+       Head.compare_and_swap
+         ~parent
+         ~leaf
+         ~expected:(Head.snapshot_cursor absent)
+         ~row
+       |> require_invalid_row label;
+       read ~parent ~leaf (label ^ " post-read")
+       |> check_row (label ^ " leaves HEAD absent") None)
+    [ "empty row", ""
+    ; "LF-only row", "\n"
+    ; "LF-terminated row", "row\n"
+    ; "CRLF row", "row\r\n"
+    ; "embedded LF row", "left\nright"
+    ];
+  let absent = read ~parent ~leaf "valid row pre-read" in
+  ignore
+    (publish
+       ~parent
+       ~leaf
+       ~expected:absent
+       ~row:"valid-row"
+       "valid row after rejections");
+  read ~parent ~leaf "valid row post-read"
+  |> check_row "invalid attempts do not poison later publication" (Some "valid-row")
+;;
+
+let test_independent_same_directory_handles_have_one_winner ~fs () =
+  with_tmp_dir "masc_capability_head_handles_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent_a ->
+  with_parent ~fs directory @@ fun parent_b ->
+  let candidate_a = read ~parent:parent_a ~leaf "handle A absent read" in
+  let candidate_b = read ~parent:parent_b ~leaf "handle B absent read" in
+  check_row "handle A observes absent HEAD" None candidate_a;
+  check_row "handle B observes the same absent generation" None candidate_b;
+  ignore
+    (publish
+       ~parent:parent_a
+       ~leaf
+       ~expected:candidate_a
+       ~row:"handle-a-wins"
+       "handle A publication");
+  let current =
+    Head.compare_and_swap
+      ~parent:parent_b
+      ~leaf
+      ~expected:(Head.snapshot_cursor candidate_b)
+      ~row:"handle-b-must-lose"
+    |> require_conflict "handle B publication"
+  in
+  check_row "losing handle receives winning authority" (Some "handle-a-wins") current;
+  read ~parent:parent_b ~leaf "losing handle final read"
+  |> check_row "only the first candidate published" (Some "handle-a-wins")
+;;
+
+let test_different_roots_do_not_false_share ~fs () =
+  with_tmp_dir "masc_capability_head_root_a_" @@ fun directory_a ->
+  with_tmp_dir "masc_capability_head_root_b_" @@ fun directory_b ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory_a @@ fun parent_a ->
+  with_parent ~fs directory_b @@ fun parent_b ->
+  let absent_a = read ~parent:parent_a ~leaf "root A read" in
+  let absent_b = read ~parent:parent_b ~leaf "root B read" in
+  ignore
+    (publish
+       ~parent:parent_a
+       ~leaf
+       ~expected:absent_a
+       ~row:"root-a"
+       "root A publication");
+  ignore
+    (publish
+       ~parent:parent_b
+       ~leaf
+       ~expected:absent_b
+       ~row:"root-b"
+       "root B publication");
+  read ~parent:parent_a ~leaf "root A final read"
+  |> check_row "root A retains its own authority" (Some "root-a");
+  read ~parent:parent_b ~leaf "root B final read"
+  |> check_row "root B retains its own authority" (Some "root-b")
+;;
+
+let () =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  run
+    "fs_compat capability HEAD"
+    [ ( "authority"
+      , [ test_case "absent publish and reopen" `Quick
+            (test_absent_publish_and_reopen ~fs)
+        ; test_case "stale cursor conflicts without mutation" `Quick
+            (test_stale_cursor_conflicts_without_mutation ~fs)
+        ; test_case "cross-root absent cursor conflicts" `Quick
+            (test_cross_root_absent_cursor_conflicts ~fs)
+        ; test_case "strict one-row shape" `Quick
+            (test_strict_row_shape_rejection ~fs)
+        ; test_case "independent same-directory handles have one winner" `Quick
+            (test_independent_same_directory_handles_have_one_winner ~fs)
+        ; test_case "different roots do not false-share" `Quick
+            (test_different_roots_do_not_false_share ~fs)
+        ] )
+    ]
+;;

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -111,7 +111,7 @@ let check_row label expected snapshot =
   check (option string) label expected (Head.snapshot_row snapshot)
 ;;
 
-let check_publication_evidence label row evidence =
+let check_publication_evidence label row (evidence : Head.publication_evidence) =
   ignore evidence.Head.expected_cursor;
   ignore evidence.Head.published_cursor;
   check int64
@@ -228,6 +228,7 @@ let test_strict_row_shape_rejection ~fs ~secure_random () =
     ; "LF-terminated row", "row\n"
     ; "CRLF row", "row\r\n"
     ; "embedded LF row", "left\nright"
+    ; "oversized row", String.make (Head.max_row_bytes + 1) 'x'
     ];
   let absent = read ~secure_random ~parent ~leaf "valid row pre-read" in
   ignore
@@ -330,6 +331,73 @@ let test_different_roots_do_not_false_share ~fs ~secure_random () =
   |> check_row "root B progressed independently" (Some "root-b")
 ;;
 
+let test_parent_cancellation_after_dispatch_returns_publication
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_parent_cancel_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "parent cancellation fixture read" in
+  let receipts = ref [] in
+  let cancel_was_issued = Atomic.make false in
+  Eio.Switch.run (fun sw ->
+    let sub_context, resolve_sub_context = Eio.Promise.create () in
+    let lock_acquired, resolve_lock_acquired = Eio.Promise.create () in
+    let release_lock, resolve_release_lock = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      let context = Eio.Promise.await sub_context in
+      Eio.Promise.await lock_acquired;
+      Eio.Cancel.cancel
+        context
+        (Failure "caller cancellation after HEAD dispatch");
+      Atomic.set cancel_was_issued true;
+      Eio.Promise.resolve resolve_release_lock ());
+    (try
+       Eio.Cancel.sub (fun context ->
+         Eio.Promise.resolve resolve_sub_context context;
+         let hooks =
+           Head.For_testing.hooks
+             ~after_lock_acquired:(fun () ->
+               Eio.Promise.resolve resolve_lock_acquired ();
+               Eio.Promise.await release_lock)
+             ()
+         in
+         let receipt =
+           publish_for_testing
+             hooks
+             ~secure_random
+             ~parent
+             ~leaf
+             ~expected:absent
+             ~row:"published-after-parent-cancel"
+         in
+         receipts := receipt :: !receipts)
+     with
+     | Eio.Cancel.Cancelled _ -> ()));
+  check bool
+    "outer sibling issued real parent cancellation"
+    true
+    (Atomic.get cancel_was_issued);
+  (match !receipts with
+   | [ Ok publication ] ->
+     Head.publication_evidence publication
+     |> check_publication_evidence
+          "parent cancellation publication"
+          "published-after-parent-cancel"
+   | [ Error _ ] ->
+     fail "protected CAS returned a failure after parent cancellation"
+   | [] ->
+     fail "parent cancellation escaped before CAS returned a receipt"
+   | _ :: _ :: _ ->
+     fail "parent cancellation produced more than one CAS receipt");
+  read ~secure_random ~parent ~leaf "parent cancellation final read"
+  |> check_row
+       "successful receipt matches published HEAD"
+       (Some "published-after-parent-cancel")
+;;
+
 let test_before_rename_failure_and_cancellation_are_unchanged
       ~fs
       ~secure_random
@@ -352,7 +420,7 @@ let test_before_rename_failure_and_cancellation_are_unchanged
   read ~secure_random ~parent ~leaf:exception_leaf (exception_label ^ " final read")
   |> check_row (exception_label ^ " keeps HEAD absent") None;
   let cancellation_leaf = "HEAD-cancellation" in
-  let cancellation_label = "before-rename cancellation" in
+  let cancellation_label = "before-rename injected Cancelled exception" in
   let absent =
     read ~secure_random ~parent ~leaf:cancellation_leaf (cancellation_label ^ " read")
   in
@@ -478,6 +546,10 @@ let () =
             (test_same_directory_contention_is_busy ~fs ~secure_random)
         ; test_case "different roots do not false-share" `Quick
             (test_different_roots_do_not_false_share ~fs ~secure_random)
+        ; test_case "parent cancellation after dispatch publishes once" `Quick
+            (test_parent_cancellation_after_dispatch_returns_publication
+               ~fs
+               ~secure_random)
         ] )
     ; ( "publication-boundary"
       , [ test_case "before rename stays unchanged" `Quick

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -475,6 +475,42 @@ let test_after_rename_failure_is_indeterminate ~fs ~secure_random () =
     (String.length evidence.Head.intended_sha256)
 ;;
 
+let test_after_parent_sync_failure_is_indeterminate_but_visible
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_after_parent_sync_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "parent-sync fixture read" in
+  let hooks =
+    Head.For_testing.hooks ~after_parent_sync:(fun () -> raise Exit) ()
+  in
+  let evidence =
+    publish_for_testing
+      hooks
+      ~secure_random
+      ~parent
+      ~leaf
+      ~expected:absent
+      ~row:"parent-synced-row"
+    |> require_indeterminate_failure "after-parent-sync exception"
+  in
+  check int64
+    "parent-sync indeterminate evidence retains intended length"
+    (Int64.of_int (String.length "parent-synced-row" + 1))
+    evidence.Head.intended_length;
+  check int
+    "parent-sync indeterminate evidence retains intended SHA-256"
+    64
+    (String.length evidence.Head.intended_sha256);
+  read ~secure_random ~parent ~leaf "after-parent-sync exact read"
+  |> check_row
+       "exact read observes the parent-synced row"
+       (Some "parent-synced-row")
+;;
+
 let test_after_verified_failure_reports_published ~fs ~secure_random () =
   with_tmp_dir "masc_capability_head_after_verified_" @@ fun directory ->
   let leaf = "HEAD" in
@@ -558,6 +594,10 @@ let () =
                ~secure_random)
         ; test_case "after rename is indeterminate" `Quick
             (test_after_rename_failure_is_indeterminate ~fs ~secure_random)
+        ; test_case "after parent sync is indeterminate but visible" `Quick
+            (test_after_parent_sync_failure_is_indeterminate_but_visible
+               ~fs
+               ~secure_random)
         ; test_case "after verified is published" `Quick
             (test_after_verified_failure_reports_published ~fs ~secure_random)
         ; test_case "settlement warning preserves success" `Quick


### PR DESCRIPTION
## Summary

- add one capability-relative, bounded one-row HEAD authority under `Fs_compat.Capability_head`
- bind cursors to the pinned parent directory inode, immutable stable-lock epoch, leaf, and target inode/length/SHA-256
- serialize same-process writers with a nonblocking `(parent.dev,parent.ino,leaf)` lease, followed by a nonblocking cross-process stable-file lock
- publish through a fresh secure-random opaque stage, exclusive write, file sync, stage close, capability-relative rename, parent sync, and exact target verification
- return typed `Unchanged`, `Publication_indeterminate`, or `Published` effects plus typed cleanup/resource-settlement evidence
- bind every success receipt to expected cursor, exact LF-framed wire SHA-256/byte length, and published cursor

## Authority boundary

HEAD is the only content authority. The stable lock contains only an immutable 256-bit random fencing epoch supplied through the caller's Eio secure-random capability. It is never rewritten, renamed, deleted, or used to decide domain content or freshness.

The API exposes no append, scan, fallback, recovery, repair, delete, or migration surface. Public leaf names cannot use the internal `.masc-capability-head-` namespace in any ASCII case variant, keeping targets disjoint from stable locks and publication stages on case-sensitive and case-insensitive filesystems.

Direct external namespace mutation is outside the cooperating private-directory contract and is not silently reconciled. This is the prerequisite for #25731. It contains no Memory OS codec, provider/model/catalog/credential/pricing knowledge, legacy import, or automatic retry.

## Concurrency and cancellation

- the exact parent directory is pinned as an Eio capability before any authority operation
- process-local lease is acquired before opening the stable lock FD
- `F_TLOCK` begins at offset zero and is nonblocking
- pending caller cancellation is checked before dispatch
- once dispatched, parent cancellation is deferred until one typed publication outcome and receipt settle
- no cancellation check occurs after publication
- callback result and switch settlement remain separate
- post-rename failures carry intended/observed evidence; post-verification failures carry `Published`

## Focused proof surface

- absent publish and close/reopen
- stale and cross-root cursors
- strict empty/CR/LF/oversized row rejection
- reserved internal namespace rejection before entropy consumption or filesystem mutation, including ASCII case variants
- real two-fiber same-root `Busy` and different-root non-sharing
- real separate-process `F_TLOCK` contention with bounded deadline, followed by stale-cursor conflict
- pending cancellation, injected pre-rename cancellation, and real post-dispatch parent cancellation
- pre-rename, post-rename, post-parent-sync, and post-verification effect boundaries
- secure-random EOF at lock initialization and stage creation returns typed `Unchanged`; empty-lock bootstrap remains recoverable
- resource-settlement failure preserves success with the exact typed warning

## Validation

Local build/test/formatter intentionally not run per current workflow direction. Draft CI is the compile and conformance authority.

[근거] OCaml 5.5 manual, installed Eio v1.3 interfaces, Eio v1.4 release notes dated 2026-07-23, and POSIX.1-2024 lock/rename contracts checked 2026-07-26 KST. Confidence High.
