### PR TITLE
feat(fs): add capability-relative exact reads

### DIFF
--- a/lib/fs_compat/capability_exact_read.ml
+++ b/lib/fs_compat/capability_exact_read.ml
@@ -1,0 +1,532 @@
+type operation =
+  | Pin_parent
+  | Open_parent_descriptor
+  | Open_leaf
+  | Inspect_opened
+  | Allocate
+  | Read_exact
+  | Inspect_after_read
+  | Close_leaf
+  | Settle_parent_resources
+  | Observe_parent_cancellation
+
+type diagnostic =
+  { operation : operation
+  ; detail : string
+  }
+
+type settlement_warning =
+  | Close_failed of diagnostic
+  | Settle_resources of diagnostic
+
+type error =
+  | Invalid_leaf of string
+  | Invalid_length_bounds of
+      { expected_length : int64
+      ; max_length : int64
+      }
+  | Length_not_representable of int64
+  | Cancelled of diagnostic
+  | Parent_descriptor_unavailable
+  | Missing
+  | Symbolic_link
+  | Not_regular of Unix.file_kind
+  | Unsafe_link_count of int
+  | Unsafe_mode of int
+  | Length_exceeds_max of
+      { max_length : int64
+      ; observed_length : int64
+      }
+  | Length_mismatch of
+      { expected_length : int64
+      ; observed_length : int64
+      }
+  | Changed_during_read
+  | Io_error of diagnostic
+
+type observation =
+  { bytes : string
+  ; length : int64
+  ; settlement_warnings : settlement_warning list
+  }
+
+let observation_bytes observation = observation.bytes
+let observation_length observation = observation.length
+
+let observation_settlement_warnings observation =
+  observation.settlement_warnings
+
+type failure =
+  { error : error
+  ; settlement_warnings : settlement_warning list
+  }
+
+type hooks =
+  { before_open : unit -> unit
+  ; after_open_stat : unit -> unit
+  ; before_allocate : unit -> unit
+  ; after_exact_read : unit -> unit
+  ; on_close : unit -> unit
+  ; on_settle_resources : (unit -> unit) option
+  }
+
+let no_hook () = ()
+
+let production_hooks =
+  { before_open = no_hook
+  ; after_open_stat = no_hook
+  ; before_allocate = no_hook
+  ; after_exact_read = no_hook
+  ; on_close = no_hook
+  ; on_settle_resources = None
+  }
+
+external openat_nofollow_ro_nonblock :
+  Unix.file_descr -> string -> Unix.file_descr
+  = "caml_masc_fs_compat_openat_nofollow_ro_nonblock"
+
+let diagnostic operation exn =
+  { operation; detail = Printexc.to_string exn }
+
+let is_fatal = function
+  | Out_of_memory | Stack_overflow | Sys.Break -> true
+  | _ -> false
+
+let reraise_if_fatal ~backtrace exn =
+  if is_fatal exn then
+    Printexc.raise_with_backtrace exn backtrace
+
+let error_of_exception operation = function
+  | (Out_of_memory | Stack_overflow | Sys.Break) as exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace exn backtrace
+  | Eio.Cancel.Cancelled _ as exn ->
+      Cancelled (diagnostic operation exn)
+  | exn ->
+      Io_error (diagnostic operation exn)
+
+let failure error =
+  Error { error; settlement_warnings = [] }
+
+let run_hook operation hook =
+  try
+    hook ();
+    Ok ()
+  with
+  | exn ->
+      Error (error_of_exception operation exn)
+
+let validate ~leaf ~expected_length ~max_length =
+  if
+    String.index_opt leaf '\000' <> None
+    || Option.is_none (Capability_leaf.of_string leaf)
+  then
+    Error (Invalid_leaf leaf)
+  else if
+    Int64.compare expected_length 0L < 0
+    || Int64.compare max_length 0L < 0
+    || Int64.compare expected_length max_length > 0
+  then
+    Error (Invalid_length_bounds { expected_length; max_length })
+  else
+    let largest_representable =
+      Int64.of_int Sys.max_string_length
+    in
+    if Int64.compare expected_length largest_representable > 0 then
+      Error (Length_not_representable expected_length)
+    else
+      Ok (Int64.to_int expected_length)
+
+let open_leaf parent_fd leaf =
+  try
+    Ok
+      (Eio_unix.Fd.use_exn
+         "capability exact read parent"
+         parent_fd
+         (fun raw_parent_fd ->
+            Eio_unix.run_in_systhread (fun () ->
+              openat_nofollow_ro_nonblock raw_parent_fd leaf)))
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Error Missing
+  | Unix.Unix_error (Unix.ELOOP, _, _) -> Error Symbolic_link
+  | exn -> Error (error_of_exception Open_leaf exn)
+
+let fstat operation fd =
+  try
+    Ok
+      (Eio_unix.run_in_systhread (fun () ->
+         Unix.LargeFile.fstat fd))
+  with
+  | exn -> Error (error_of_exception operation exn)
+
+type exact_read =
+  | Short_read
+  | Exact_eof
+  | Extra_byte
+
+let read_exact_and_eof fd bytes =
+  try
+    Ok
+      (Eio_unix.run_in_systhread (fun () ->
+         let expected = Bytes.length bytes in
+         let rec fill offset =
+           if offset = expected then
+             true
+           else
+             try
+               match Unix.read fd bytes offset (expected - offset) with
+               | 0 -> false
+               | count -> fill (offset + count)
+             with
+             | Unix.Unix_error (Unix.EINTR, _, _) -> fill offset
+         in
+         if not (fill 0) then
+           Short_read
+         else
+           let probe = Bytes.create 1 in
+           let rec probe_eof () =
+             try
+               match Unix.read fd probe 0 1 with
+               | 0 -> Exact_eof
+               | _ -> Extra_byte
+             with
+             | Unix.Unix_error (Unix.EINTR, _, _) -> probe_eof ()
+           in
+           probe_eof ()))
+  with
+  | exn -> Error (error_of_exception Read_exact exn)
+
+let same_file left right =
+  left.Unix.LargeFile.st_dev = right.Unix.LargeFile.st_dev
+  && left.st_ino = right.st_ino
+  && left.st_kind = right.st_kind
+  && left.st_nlink = right.st_nlink
+  && left.st_perm = right.st_perm
+  && Int64.equal left.st_size right.st_size
+
+let inspect_initial ~expected_length ~max_length stat =
+  if stat.Unix.LargeFile.st_kind <> Unix.S_REG then
+    Error (Not_regular stat.st_kind)
+  else if stat.st_nlink <> 1 then
+    Error (Unsafe_link_count stat.st_nlink)
+  else if stat.st_perm <> 0o600 then
+    Error (Unsafe_mode stat.st_perm)
+  else if Int64.compare stat.st_size max_length > 0 then
+    Error
+      (Length_exceeds_max
+         { max_length; observed_length = stat.st_size })
+  else if not (Int64.equal stat.st_size expected_length) then
+    Error
+      (Length_mismatch
+         { expected_length; observed_length = stat.st_size })
+  else
+    Ok ()
+
+type settlement_call =
+  | Settled
+  | Settlement_warning of settlement_warning
+  | Settlement_fatal of exn * Printexc.raw_backtrace
+
+let capture_close_call call =
+  try
+    call ();
+    Settled
+  with
+  | exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      if is_fatal exn then
+        Settlement_fatal (exn, backtrace)
+      else
+        Settlement_warning
+          (Close_failed (diagnostic Close_leaf exn))
+
+let close_leaf hooks fd =
+  let hook_outcome = capture_close_call hooks.on_close in
+  let close_outcome = capture_close_call (fun () -> Unix.close fd) in
+  match hook_outcome, close_outcome with
+  | Settlement_fatal (exn, backtrace), _
+  | _, Settlement_fatal (exn, backtrace) ->
+      Printexc.raise_with_backtrace exn backtrace
+  | _ ->
+      let warnings = function
+        | Settlement_warning warning -> [warning]
+        | Settled | Settlement_fatal _ -> []
+      in
+      warnings hook_outcome @ warnings close_outcome
+
+let read_opened
+    ~hooks
+    ~fd
+    ~expected_length
+    ~max_length
+    ~expected_length_int
+  =
+  match fstat Inspect_opened fd with
+  | Error error -> Error error
+  | Ok initial_stat ->
+      (match inspect_initial ~expected_length ~max_length initial_stat with
+       | Error error -> Error error
+       | Ok () ->
+           (match run_hook Inspect_opened hooks.after_open_stat with
+            | Error error -> Error error
+            | Ok () ->
+                (match run_hook Allocate hooks.before_allocate with
+                 | Error error -> Error error
+                 | Ok () ->
+                     let bytes = Bytes.create expected_length_int in
+                     (match read_exact_and_eof fd bytes with
+                      | Error error -> Error error
+                      | Ok (Short_read | Extra_byte) ->
+                          Error Changed_during_read
+                      | Ok Exact_eof ->
+                          (match
+                             run_hook
+                               Read_exact
+                               hooks.after_exact_read
+                           with
+                           | Error error -> Error error
+                           | Ok () ->
+                               (match fstat Inspect_after_read fd with
+                                | Error error -> Error error
+                                | Ok final_stat ->
+                                    if
+                                      not
+                                        (same_file
+                                           initial_stat
+                                           final_stat)
+                                    then
+                                      Error Changed_during_read
+                                    else
+                                      Ok (Bytes.unsafe_to_string bytes)))))))
+
+let attach_settlement_warnings outcome settlement_warnings =
+  match outcome with
+  | Ok bytes ->
+      Ok
+        { bytes
+        ; length = Int64.of_int (String.length bytes)
+        ; settlement_warnings
+        }
+  | Error error ->
+      Error { error; settlement_warnings }
+
+let append_settlement_warning
+    (outcome : (observation, failure) result)
+    warning
+  =
+  match outcome with
+  | Ok observation ->
+      Ok
+        { observation with
+          settlement_warnings =
+            observation.settlement_warnings @ [warning]
+        }
+  | Error failure ->
+      Error
+        { failure with
+          settlement_warnings =
+            failure.settlement_warnings @ [warning]
+        }
+
+let diagnostic_of_raised operation (raised : Eio_resource_scope.raised) =
+  diagnostic operation raised.exception_
+
+let diagnostic_of_cancelled
+    operation
+    (cancelled : Eio_resource_scope.cancelled)
+  =
+  diagnostic
+    operation
+    (Eio.Cancel.Cancelled cancelled.reason)
+
+let reraise_raised_if_fatal (raised : Eio_resource_scope.raised) =
+  reraise_if_fatal
+    ~backtrace:raised.backtrace
+    raised.exception_
+
+let outcome_of_resource_scope scope =
+  (match scope.Eio_resource_scope.callback with
+   | Some (Eio_resource_scope.Raised raised) ->
+       reraise_raised_if_fatal raised
+   | Some
+       ( Eio_resource_scope.Returned _
+       | Eio_resource_scope.Cancelled _ )
+   | None ->
+       ());
+  Option.iter reraise_raised_if_fatal scope.scope_failure;
+  let callback_outcome =
+    match scope.Eio_resource_scope.callback with
+    | Some (Eio_resource_scope.Returned outcome) -> outcome
+    | Some (Eio_resource_scope.Raised raised) ->
+        failure
+          (error_of_exception
+             Settle_parent_resources
+             raised.exception_)
+    | Some (Eio_resource_scope.Cancelled cancelled) ->
+        failure
+          (Cancelled
+             (diagnostic_of_cancelled
+                Settle_parent_resources
+                cancelled))
+    | None ->
+        (match scope.parent_cancellation, scope.scope_failure with
+         | Some cancelled, _ ->
+             failure
+               (Cancelled
+                  (diagnostic_of_cancelled
+                     Settle_parent_resources
+                     cancelled))
+         | None, Some raised ->
+             failure
+               (error_of_exception
+                  Settle_parent_resources
+                  raised.exception_)
+         | None, None ->
+             failure
+               (Io_error
+                  (diagnostic
+                     Settle_parent_resources
+                     (Failure
+                        "resource scope callback did not run"))))
+  in
+  match scope.callback with
+  | None -> callback_outcome
+  | Some _ ->
+      let with_scope_failure =
+        match scope.scope_failure with
+        | None -> callback_outcome
+        | Some raised ->
+            append_settlement_warning
+              callback_outcome
+              (Settle_resources
+                 (diagnostic_of_raised
+                    Settle_parent_resources
+                    raised))
+      in
+      (match scope.parent_cancellation with
+       | None -> with_scope_failure
+       | Some cancelled ->
+           append_settlement_warning
+             with_scope_failure
+             (Settle_resources
+                (diagnostic_of_cancelled
+                   Observe_parent_cancellation
+                   cancelled)))
+
+let read_with_hooks
+    ~hooks
+    ~parent
+    ~leaf
+    ~expected_length
+    ~max_length
+  =
+  Eio.Fiber.check ();
+  match validate ~leaf ~expected_length ~max_length with
+  | Error error -> failure error
+  | Ok expected_length_int ->
+      let scope =
+        Eio_resource_scope.run_resource_only (fun sw ->
+           Option.iter
+             (Eio.Switch.on_release sw)
+             hooks.on_settle_resources;
+           match
+             try Ok (Eio.Path.open_dir ~sw parent) with
+             | exn -> Error (error_of_exception Pin_parent exn)
+           with
+           | Error error -> failure error
+           | Ok exact_parent ->
+               (match
+                  try
+                    Ok
+                      (Eio.Path.open_in
+                         ~sw
+                         Eio.Path.(exact_parent / "."))
+                  with
+                  | exn ->
+                      Error
+                        (error_of_exception
+                           Open_parent_descriptor
+                           exn)
+                with
+                | Error error -> failure error
+                | Ok parent_resource ->
+                    (match Eio_unix.Resource.fd_opt parent_resource with
+                     | None -> failure Parent_descriptor_unavailable
+                     | Some parent_fd ->
+                         (match
+                            run_hook Open_leaf hooks.before_open
+                          with
+                          | Error error -> failure error
+                          | Ok () ->
+                              Eio.Cancel.protect (fun () ->
+                                match open_leaf parent_fd leaf with
+                                | Error error -> failure error
+                                | Ok fd ->
+                                    let outcome =
+                                      try
+                                        read_opened
+                                          ~hooks
+                                          ~fd
+                                          ~expected_length
+                                          ~max_length
+                                          ~expected_length_int
+                                      with
+                                      | ( Out_of_memory
+                                        | Stack_overflow
+                                        | Sys.Break ) as exn ->
+                                          let backtrace =
+                                            Printexc.get_raw_backtrace ()
+                                          in
+                                          (try
+                                             ignore
+                                               (close_leaf hooks fd)
+                                           with
+                                           | _ -> ());
+                                          Printexc.raise_with_backtrace
+                                            exn
+                                            backtrace
+                                      | exn ->
+                                          Error
+                                            (error_of_exception
+                                               Read_exact
+                                               exn)
+                                    in
+                                    let settlement_warnings =
+                                      close_leaf hooks fd
+                                    in
+                                    attach_settlement_warnings
+                                      outcome
+                                      settlement_warnings)))))
+      in
+      outcome_of_resource_scope scope
+
+let read ~parent ~leaf ~expected_length ~max_length =
+  read_with_hooks
+    ~hooks:production_hooks
+    ~parent
+    ~leaf
+    ~expected_length
+    ~max_length
+
+module For_testing = struct
+  type nonrec hooks = hooks
+
+  let hooks
+      ?(before_open = no_hook)
+      ?(after_open_stat = no_hook)
+      ?(before_allocate = no_hook)
+      ?(after_exact_read = no_hook)
+      ?(on_close = no_hook)
+      ?on_settle_resources
+      ()
+    =
+    { before_open
+    ; after_open_stat
+    ; before_allocate
+    ; after_exact_read
+    ; on_close
+    ; on_settle_resources
+    }
+
+  let read = read_with_hooks
+end

--- a/lib/fs_compat/capability_exact_read.ml
+++ b/lib/fs_compat/capability_exact_read.ml
@@ -247,7 +247,8 @@ let close_leaf hooks fd =
   | Settlement_fatal (exn, backtrace), _
   | _, Settlement_fatal (exn, backtrace) ->
       Printexc.raise_with_backtrace exn backtrace
-  | _ ->
+  | (Settled | Settlement_warning _),
+    (Settled | Settlement_warning _) ->
       let warnings = function
         | Settlement_warning warning -> [warning]
         | Settled | Settlement_fatal _ -> []

--- a/lib/fs_compat/capability_exact_read.mli
+++ b/lib/fs_compat/capability_exact_read.mli
@@ -1,0 +1,111 @@
+(** Capability-scoped observation of one immutable regular-file snapshot.
+
+    This module owns no digest, schema, history, migration, scan, retry, repair,
+    or deletion policy. It pins the supplied parent capability and dispatches
+    exactly one single-component leaf open.
+
+    Before allocation, [read] proves non-negative [expected_length <=
+    max_length], representability, regular-file kind, one link, mode [0600]
+    without special bits, the safety ceiling, and the exact expected size. It
+    then reads exactly N bytes plus EOF and checks the opened descriptor's
+    identity, link count, mode, and size again. Successful observations and
+    non-fatal typed failures preserve child-close and parent-resource
+    settlement warnings. [Out_of_memory], [Stack_overflow], and [Sys.Break]
+    remain fatal: they are re-raised with their original backtrace and are
+    outside the typed-outcome and settlement-warning preservation contract.
+
+    Cancellation is linearized as follows: pending parent cancellation is
+    checked when [read] starts. The child open dispatch, exact observation, and
+    close settlement run in a protected cancellation scope. The completed
+    typed outcome is never replaced by a later cancellation: cancellation
+    observed during parent-resource settlement is retained as a typed
+    [Settle_resources] warning rather than raised by a final check. *)
+
+type operation =
+  | Pin_parent
+  | Open_parent_descriptor
+  | Open_leaf
+  | Inspect_opened
+  | Allocate
+  | Read_exact
+  | Inspect_after_read
+  | Close_leaf
+  | Settle_parent_resources
+  | Observe_parent_cancellation
+
+type diagnostic =
+  { operation : operation
+  ; detail : string
+  }
+
+type settlement_warning =
+  | Close_failed of diagnostic
+  | Settle_resources of diagnostic
+
+type error =
+  | Invalid_leaf of string
+  | Invalid_length_bounds of
+      { expected_length : int64
+      ; max_length : int64
+      }
+  | Length_not_representable of int64
+  | Cancelled of diagnostic
+  | Parent_descriptor_unavailable
+  | Missing
+  | Symbolic_link
+  | Not_regular of Unix.file_kind
+  | Unsafe_link_count of int
+  | Unsafe_mode of int
+  | Length_exceeds_max of
+      { max_length : int64
+      ; observed_length : int64
+      }
+  | Length_mismatch of
+      { expected_length : int64
+      ; observed_length : int64
+      }
+  | Changed_during_read
+  | Io_error of diagnostic
+
+type observation
+
+val observation_bytes : observation -> string
+val observation_length : observation -> int64
+val observation_settlement_warnings : observation -> settlement_warning list
+
+type failure = private
+  { error : error
+  ; settlement_warnings : settlement_warning list
+  }
+
+(** [read ~parent ~leaf ~expected_length ~max_length] observes only [leaf]
+    relative to the pinned [parent] descriptor. [leaf] must be one valid path
+    component. *)
+val read :
+  parent:Eio.Fs.dir_ty Eio.Path.t ->
+  leaf:string ->
+  expected_length:int64 ->
+  max_length:int64 ->
+  (observation, failure) result
+
+module For_testing : sig
+  type hooks
+
+  val hooks :
+    ?before_open:(unit -> unit) ->
+    ?after_open_stat:(unit -> unit) ->
+    ?before_allocate:(unit -> unit) ->
+    ?after_exact_read:(unit -> unit) ->
+    ?on_close:(unit -> unit) ->
+    ?on_settle_resources:(unit -> unit) ->
+    unit ->
+    hooks
+
+  val read :
+    hooks:hooks ->
+    parent:Eio.Fs.dir_ty Eio.Path.t ->
+    leaf:string ->
+    expected_length:int64 ->
+    max_length:int64 ->
+    (observation, failure) result
+end

--- a/lib/fs_compat/capability_exact_read_for_testing.ml
+++ b/lib/fs_compat/capability_exact_read_for_testing.ml
@@ -1,0 +1,1 @@
+include Fs_compat_internal.Capability_exact_read

--- a/lib/fs_compat/capability_exact_read_for_testing.mli
+++ b/lib/fs_compat/capability_exact_read_for_testing.mli
@@ -1,0 +1,1 @@
+include module type of Fs_compat_internal.Capability_exact_read

--- a/lib/fs_compat/capability_exact_read_stubs.c
+++ b/lib/fs_compat/capability_exact_read_stubs.c
@@ -1,0 +1,49 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+#if !defined(O_NONBLOCK) || !defined(O_CLOEXEC) || !defined(O_NOFOLLOW) || \
+    !defined(O_NOCTTY)
+#error "capability exact read requires O_NONBLOCK, O_CLOEXEC, O_NOFOLLOW, and O_NOCTTY"
+#endif
+
+CAMLprim value
+caml_masc_fs_compat_openat_nofollow_ro_nonblock(value v_dirfd, value v_leaf)
+{
+  CAMLparam2(v_dirfd, v_leaf);
+  char *leaf = caml_stat_strdup(String_val(v_leaf));
+  int descriptor;
+  int saved_errno;
+
+  caml_enter_blocking_section();
+  descriptor =
+    openat(
+      Int_val(v_dirfd),
+      leaf,
+      O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW | O_NOCTTY);
+  saved_errno = errno;
+  caml_leave_blocking_section();
+
+  caml_stat_free(leaf);
+
+  if (descriptor == -1) {
+    errno = saved_errno;
+    uerror("openat", v_leaf);
+  }
+
+  CAMLreturn(Val_int(descriptor));
+}

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -47,6 +47,7 @@ type snapshot
 
 val snapshot_row : snapshot -> string option
 val snapshot_cursor : snapshot -> cursor
+val cursor_equal : cursor -> cursor -> bool
 val snapshot_settlement_warnings : snapshot -> settlement_warning list
 
 type error =

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -10,6 +10,7 @@
   owned_directory_chain
   capability_leaf
   capability_head
+  capability_exact_read
   capability_mutation_lease
   eio_resource_scope
   capability_recovery_obligation
@@ -22,7 +23,10 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries eio eio.unix unix yojson uuidm digestif optint cstruct))
+ (libraries eio eio.unix unix yojson uuidm digestif optint cstruct)
+ (foreign_stubs
+  (language c)
+  (names capability_exact_read_stubs)))
 
 (library
  (name fs_compat)
@@ -42,7 +46,10 @@
 
 (library
  (name fs_compat_test_support)
- (modules publication_recovery_for_testing capability_write_for_testing)
+ (modules
+  publication_recovery_for_testing
+  capability_write_for_testing
+  capability_exact_read_for_testing)
  (flags
   (:standard -w +4))
  (libraries

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -16,6 +16,7 @@
 open Fs_compat_internal
 
 module Atomic_orphan_size_class = Atomic_orphan_size_class
+module Capability_exact_read = Capability_exact_read
 
 (** Global fs — WORM Atomic (write-once at startup, read from any domain).
     Using Atomic.t is required for OCaml 5 multi-domain safety:

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -7,6 +7,98 @@ open Fs_compat_internal
 
 module Atomic_orphan_size_class = Atomic_orphan_size_class
 
+(** Capability-scoped observation of one immutable regular-file snapshot.
+
+    This module owns no digest, schema, history, migration, scan, retry, repair,
+    or deletion policy. It pins the supplied parent capability and dispatches
+    exactly one single-component leaf open.
+
+    Before allocation, [read] proves non-negative [expected_length <=
+    max_length], representability, regular-file kind, one link, mode [0600]
+    without special bits, the safety ceiling, and the exact expected size. It
+    then reads exactly N bytes plus EOF and checks the opened descriptor's
+    identity, link count, mode, and size again. Successful observations and
+    non-fatal typed failures preserve child-close and parent-resource
+    settlement warnings. [Out_of_memory], [Stack_overflow], and [Sys.Break]
+    remain fatal: they are re-raised with their original backtrace and are
+    outside the typed-outcome and settlement-warning preservation contract.
+
+    Cancellation is linearized as follows: pending parent cancellation is
+    checked when [read] starts. The child open dispatch, exact observation, and
+    close settlement run in a protected cancellation scope. The completed
+    typed outcome is never replaced by a later cancellation: cancellation
+    observed during parent-resource settlement is retained as a typed
+    [Settle_resources] warning rather than raised by a final check. *)
+module Capability_exact_read : sig
+  type operation =
+    | Pin_parent
+    | Open_parent_descriptor
+    | Open_leaf
+    | Inspect_opened
+    | Allocate
+    | Read_exact
+    | Inspect_after_read
+    | Close_leaf
+    | Settle_parent_resources
+    | Observe_parent_cancellation
+
+  type diagnostic =
+    { operation : operation
+    ; detail : string
+    }
+
+  type settlement_warning =
+    | Close_failed of diagnostic
+    | Settle_resources of diagnostic
+
+  type error =
+    | Invalid_leaf of string
+    | Invalid_length_bounds of
+        { expected_length : int64
+        ; max_length : int64
+        }
+    | Length_not_representable of int64
+    | Cancelled of diagnostic
+    | Parent_descriptor_unavailable
+    | Missing
+    | Symbolic_link
+    | Not_regular of Unix.file_kind
+    | Unsafe_link_count of int
+    | Unsafe_mode of int
+    | Length_exceeds_max of
+        { max_length : int64
+        ; observed_length : int64
+        }
+    | Length_mismatch of
+        { expected_length : int64
+        ; observed_length : int64
+        }
+    | Changed_during_read
+    | Io_error of diagnostic
+
+  type observation
+
+  val observation_bytes : observation -> string
+  val observation_length : observation -> int64
+  val observation_settlement_warnings :
+    observation -> settlement_warning list
+
+  type failure = private
+    { error : error
+    ; settlement_warnings : settlement_warning list
+    }
+
+  (** [read ~parent ~leaf ~expected_length ~max_length] observes only [leaf]
+      relative to the pinned [parent] descriptor. [leaf] must be one valid path
+      component. *)
+  val read :
+    parent:Eio.Fs.dir_ty Eio.Path.t ->
+    leaf:string ->
+    expected_length:int64 ->
+    max_length:int64 ->
+    (observation, failure) result
+end
+
 (** #9921: raised by mutating [Fs_compat] entry points
     ([append_file], [save_file], [mkdir_p]) when the target path falls
     under [HOME] and the process is a test executable. Defense in depth

--- a/test/dune
+++ b/test/dune
@@ -2584,6 +2584,15 @@
  (deps
   (source_tree ../lib)
   (source_tree ../bin)))
+
+(test
+ (name test_fs_compat_capability_exact_read)
+ (modules test_fs_compat_capability_exact_read)
+ (libraries alcotest fs_compat fs_compat_test_support eio eio_main eio.unix unix)
+ (deps
+  ../lib/fs_compat/fs_compat.mli
+  ../lib/fs_compat/capability_exact_read_stubs.c))
+
 (include stanzas/test_keeper_turn_attempt_observer.inc)
 (include stanzas/test_keeper_gate_effect_coverage.inc)
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)

--- a/test/test_fs_compat_capability_exact_read.ml
+++ b/test/test_fs_compat_capability_exact_read.ml
@@ -1,0 +1,1065 @@
+open Alcotest
+
+module Public = Fs_compat.Capability_exact_read
+
+module Test_read =
+  Fs_compat_test_support.Capability_exact_read_for_testing
+
+module For_testing = Test_read.For_testing
+
+let _public_read_signature
+  :  parent:Eio.Fs.dir_ty Eio.Path.t
+  -> leaf:string
+  -> expected_length:int64
+  -> max_length:int64
+  -> (Public.observation, Public.failure) result
+  =
+  Public.read
+;;
+
+let fifo_helper_flag = "--capability-exact-read-fifo-helper"
+let fatal_callback_helper_flag =
+  "--capability-exact-read-fatal-callback-helper"
+let fatal_settlement_helper_flag =
+  "--capability-exact-read-fatal-settlement-helper"
+
+let rec remove_tree path =
+  match Unix.lstat path with
+  | stat ->
+    (match stat.Unix.st_kind with
+     | Unix.S_DIR ->
+       Sys.readdir path
+       |> Array.iter (fun leaf ->
+         remove_tree (Filename.concat path leaf));
+       Unix.rmdir path
+     | _ -> Unix.unlink path)
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+;;
+
+let fresh_directory prefix =
+  let path = Filename.temp_file prefix ".tmp" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  path
+;;
+
+let with_directory ~fs prefix fn =
+  let root = fresh_directory prefix in
+  Fun.protect
+    ~finally:(fun () -> remove_tree root)
+    (fun () ->
+      let parent = Eio.Path.(fs / root) in
+      fn root parent)
+;;
+
+let write_file ?(mode = 0o600) path contents =
+  let channel = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr channel)
+    (fun () -> output_string channel contents);
+  Unix.chmod path mode
+;;
+
+let append_file path contents =
+  let channel =
+    open_out_gen
+      [ Open_wronly; Open_append; Open_binary ]
+      0
+      path
+  in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr channel)
+    (fun () -> output_string channel contents)
+;;
+
+let require_success label
+    (result : (Test_read.observation, Test_read.failure) result)
+  =
+  match result with
+  | Ok observation -> observation
+  | Error _ -> failf "%s: expected success" label
+;;
+
+let require_failure label
+    (result : (Test_read.observation, Test_read.failure) result)
+  =
+  match result with
+  | Error failure -> failure
+  | Ok _ -> failf "%s: expected failure" label
+;;
+
+let check_error label predicate result =
+  let failure = require_failure label result in
+  check bool label true (predicate failure.error);
+  failure
+;;
+
+let operation_token = function
+  | Test_read.Pin_parent -> "pin_parent"
+  | Open_parent_descriptor -> "open_parent_descriptor"
+  | Open_leaf -> "open_leaf"
+  | Inspect_opened -> "inspect_opened"
+  | Allocate -> "allocate"
+  | Read_exact -> "read_exact"
+  | Inspect_after_read -> "inspect_after_read"
+  | Close_leaf -> "close_leaf"
+  | Settle_parent_resources -> "settle_parent_resources"
+  | Observe_parent_cancellation -> "observe_parent_cancellation"
+;;
+
+let warning_token = function
+  | Test_read.Close_failed diagnostic ->
+    "close:" ^ operation_token diagnostic.operation
+  | Settle_resources diagnostic ->
+    "settle:" ^ operation_token diagnostic.operation
+;;
+
+let check_warnings label expected warnings =
+  let actual = List.map warning_token warnings in
+  check
+    int
+    (label ^ " cardinality")
+    (List.length expected)
+    (List.length actual);
+  check
+    (list string)
+    (label ^ " multiset")
+    (List.sort String.compare expected)
+    (List.sort String.compare actual)
+;;
+
+let test_pre_dispatch_validation ~fs () =
+  with_directory ~fs "cap_exact_validate_" @@ fun _root parent ->
+  let opened = ref 0 in
+  let allocated = ref 0 in
+  let hooks =
+    For_testing.hooks
+      ~before_open:(fun () -> incr opened)
+      ~before_allocate:(fun () -> incr allocated)
+      ()
+  in
+  let read ~leaf ~expected_length ~max_length =
+    For_testing.read
+      ~hooks
+      ~parent
+      ~leaf
+      ~expected_length
+      ~max_length
+  in
+  ignore
+    (check_error
+       "invalid leaf"
+       (function
+         | Test_read.Invalid_leaf "../escape" -> true
+         | _ -> false)
+       (read ~leaf:"../escape" ~expected_length:0L ~max_length:0L));
+  ignore
+    (check_error
+       "negative expected length"
+       (function
+         | Test_read.Invalid_length_bounds
+             { expected_length = -1L; max_length = 0L } ->
+           true
+         | _ -> false)
+       (read ~leaf:"object" ~expected_length:(-1L) ~max_length:0L));
+  ignore
+    (check_error
+       "expected exceeds max"
+       (function
+         | Test_read.Invalid_length_bounds
+             { expected_length = 2L; max_length = 1L } ->
+           true
+         | _ -> false)
+       (read ~leaf:"object" ~expected_length:2L ~max_length:1L));
+  let unrepresentable =
+    Int64.succ (Int64.of_int Sys.max_string_length)
+  in
+  ignore
+    (check_error
+       "representation bound"
+       (function
+         | Test_read.Length_not_representable observed ->
+           Int64.equal observed unrepresentable
+         | _ -> false)
+       (read
+          ~leaf:"object"
+          ~expected_length:unrepresentable
+          ~max_length:unrepresentable));
+  check int "no leaf open dispatched" 0 !opened;
+  check int "no allocation dispatched" 0 !allocated
+;;
+
+let test_exact_success ~fs () =
+  with_directory ~fs "cap_exact_success_" @@ fun root parent ->
+  let payload = "exact immutable bytes" in
+  write_file (Filename.concat root "object") payload;
+  match
+    Public.read
+      ~parent
+      ~leaf:"object"
+      ~expected_length:(Int64.of_int (String.length payload))
+      ~max_length:1024L
+  with
+  | Error _ -> fail "exact public read failed"
+  | Ok observation ->
+    check
+      string
+      "exact bytes"
+      payload
+      (Public.observation_bytes observation);
+    check
+      int64
+      "exact length"
+      (Int64.of_int (String.length payload))
+      (Public.observation_length observation);
+    check
+      int
+      "no settlement warning"
+      0
+      (List.length
+         (Public.observation_settlement_warnings observation))
+;;
+
+let test_missing ~fs () =
+  with_directory ~fs "cap_exact_missing_" @@ fun _root parent ->
+  let failure =
+    check_error
+      "missing"
+      (function
+        | Test_read.Missing -> true
+        | _ -> false)
+      (Test_read.read
+         ~parent
+         ~leaf:"absent"
+         ~expected_length:0L
+         ~max_length:0L)
+  in
+  check_warnings
+    "missing has no settlement warning"
+    []
+    failure.settlement_warnings
+;;
+
+let run_fifo_helper root leaf =
+  Eio_main.run @@ fun env ->
+  let parent = Eio.Path.(Eio.Stdenv.fs env / root) in
+  match
+    Public.read
+      ~parent
+      ~leaf
+      ~expected_length:0L
+      ~max_length:0L
+  with
+  | Error failure ->
+    (match failure.error with
+     | Public.Not_regular Unix.S_FIFO -> 0
+     | _ -> 2)
+  | Ok _ -> 3
+;;
+
+let run_fatal_helper ~settlement root leaf =
+  Printexc.record_backtrace true;
+  let injected_backtrace = ref None in
+  let inject_fatal () =
+    match raise Sys.Break with
+    | exception Sys.Break ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      injected_backtrace := Some backtrace;
+      Printexc.raise_with_backtrace Sys.Break backtrace
+    | _ -> Alcotest.fail "fatal injection unexpectedly returned"
+  in
+  try
+    Eio_main.run @@ fun env ->
+    let parent = Eio.Path.(Eio.Stdenv.fs env / root) in
+    let hooks =
+      if settlement
+      then For_testing.hooks ~on_settle_resources:inject_fatal ()
+      else For_testing.hooks ~after_open_stat:inject_fatal ()
+    in
+    ignore
+      (For_testing.read
+         ~hooks
+         ~parent
+         ~leaf
+         ~expected_length:4L
+         ~max_length:4L);
+    2
+  with
+  | Sys.Break ->
+    let observed = Printexc.get_raw_backtrace () in
+    (match !injected_backtrace with
+     | None -> 3
+     | Some expected ->
+       let expected = Printexc.raw_backtrace_to_string expected in
+       let observed = Printexc.raw_backtrace_to_string observed in
+       if
+         not (String.equal expected "")
+         && String.equal expected observed
+       then 0
+       else 4)
+  | _ -> 5
+;;
+
+let run_helper_if_requested () =
+  if Array.length Sys.argv = 4 then
+    let flag = Sys.argv.(1) in
+    let root = Sys.argv.(2) in
+    let leaf = Sys.argv.(3) in
+    if String.equal flag fifo_helper_flag then
+      exit (run_fifo_helper root leaf)
+    else if String.equal flag fatal_callback_helper_flag then
+      exit (run_fatal_helper ~settlement:false root leaf)
+    else if String.equal flag fatal_settlement_helper_flag then
+      exit (run_fatal_helper ~settlement:true root leaf)
+;;
+
+let run_self_helper ~clock ~process_mgr ~flag root leaf =
+  Eio.Switch.run @@ fun sw ->
+  let executable = Unix.realpath Sys.executable_name in
+  let child =
+    Eio.Process.spawn
+      ~sw
+      process_mgr
+      [ executable; flag; root; leaf ]
+  in
+  Eio.Time.with_timeout_exn clock 3.0 (fun () ->
+    Eio.Process.await child)
+;;
+
+let require_helper_success label = function
+  | `Exited 0 -> ()
+  | `Exited code ->
+    failf "%s helper exited with code %d" label code
+  | `Signaled signal ->
+    failf "%s helper was signaled: %d" label signal
+;;
+
+let test_special_files
+    ~fs
+    ~clock
+    ~process_mgr
+    ()
+  =
+  with_directory ~fs "cap_exact_special_" @@ fun root parent ->
+  let target = Filename.concat root "target" in
+  let symlink = Filename.concat root "symlink" in
+  let directory = Filename.concat root "directory" in
+  let fifo = Filename.concat root "fifo" in
+  write_file target "target";
+  Unix.symlink target symlink;
+  Unix.mkdir directory 0o700;
+  Unix.mkfifo fifo 0o600;
+  let symlink_result =
+    Eio.Time.with_timeout_exn clock 2.0 (fun () ->
+      Test_read.read
+        ~parent
+        ~leaf:"symlink"
+        ~expected_length:6L
+        ~max_length:6L)
+  in
+  ignore
+    (check_error
+       "symlink is not followed"
+       (function
+         | Test_read.Symbolic_link -> true
+         | _ -> false)
+       symlink_result);
+  let directory_result =
+    Eio.Time.with_timeout_exn clock 2.0 (fun () ->
+      Test_read.read
+        ~parent
+        ~leaf:"directory"
+        ~expected_length:0L
+        ~max_length:0L)
+  in
+  ignore
+    (check_error
+       "directory is rejected"
+       (function
+         | Test_read.Not_regular Unix.S_DIR -> true
+         | _ -> false)
+       directory_result);
+  run_self_helper
+    ~clock
+    ~process_mgr
+    ~flag:fifo_helper_flag
+    root
+    "fifo"
+  |> require_helper_success "FIFO"
+;;
+
+let test_wrong_mode_and_link_count ~fs () =
+  with_directory ~fs "cap_exact_metadata_" @@ fun root parent ->
+  let wrong_mode = Filename.concat root "wrong-mode" in
+  write_file ~mode:0o644 wrong_mode "mode";
+  ignore
+    (check_error
+       "wrong mode"
+       (function
+         | Test_read.Unsafe_mode 0o644 -> true
+         | _ -> false)
+       (Test_read.read
+          ~parent
+          ~leaf:"wrong-mode"
+          ~expected_length:4L
+          ~max_length:4L));
+  let source = Filename.concat root "source" in
+  let linked = Filename.concat root "linked" in
+  write_file source "link";
+  Unix.link source linked;
+  ignore
+    (check_error
+       "multiple hard links"
+       (function
+         | Test_read.Unsafe_link_count 2 -> true
+         | _ -> false)
+       (Test_read.read
+          ~parent
+          ~leaf:"linked"
+          ~expected_length:4L
+          ~max_length:4L))
+;;
+
+let test_length_failures_precede_allocation ~fs () =
+  with_directory ~fs "cap_exact_lengths_" @@ fun root parent ->
+  write_file (Filename.concat root "object") "four";
+  let allocations = ref 0 in
+  let hooks =
+    For_testing.hooks
+      ~before_allocate:(fun () -> incr allocations)
+      ()
+  in
+  let read expected_length max_length =
+    For_testing.read
+      ~hooks
+      ~parent
+      ~leaf:"object"
+      ~expected_length
+      ~max_length
+  in
+  ignore
+    (check_error
+       "declared shorter"
+       (function
+         | Test_read.Length_mismatch
+             { expected_length = 3L; observed_length = 4L } ->
+           true
+         | _ -> false)
+       (read 3L 8L));
+  ignore
+    (check_error
+       "declared longer"
+       (function
+         | Test_read.Length_mismatch
+             { expected_length = 5L; observed_length = 4L } ->
+           true
+         | _ -> false)
+       (read 5L 8L));
+  ignore
+    (check_error
+       "observed exceeds max"
+       (function
+         | Test_read.Length_exceeds_max
+             { max_length = 3L; observed_length = 4L } ->
+           true
+         | _ -> false)
+       (read 3L 3L));
+  check int "no allocation after stat rejection" 0 !allocations
+;;
+
+let test_after_stat_mutations ~fs () =
+  with_directory ~fs "cap_exact_mutations_" @@ fun root parent ->
+  let shrink = Filename.concat root "shrink" in
+  write_file shrink "four";
+  let shrink_hooks =
+    For_testing.hooks
+      ~after_open_stat:(fun () -> Unix.truncate shrink 2)
+      ()
+  in
+  ignore
+    (check_error
+       "post-stat shrink"
+       (function
+         | Test_read.Changed_during_read -> true
+         | _ -> false)
+       (For_testing.read
+          ~hooks:shrink_hooks
+          ~parent
+          ~leaf:"shrink"
+          ~expected_length:4L
+          ~max_length:4L));
+  let grow = Filename.concat root "grow" in
+  write_file grow "four";
+  let grow_hooks =
+    For_testing.hooks
+      ~after_open_stat:(fun () -> append_file grow "!")
+      ()
+  in
+  ignore
+    (check_error
+       "post-stat grow"
+       (function
+         | Test_read.Changed_during_read -> true
+         | _ -> false)
+       (For_testing.read
+          ~hooks:grow_hooks
+          ~parent
+          ~leaf:"grow"
+          ~expected_length:4L
+          ~max_length:4L));
+  let target = Filename.concat root "rename-target" in
+  let replacement = Filename.concat root "replacement" in
+  write_file target "old!";
+  write_file replacement "new!";
+  let rename_hooks =
+    For_testing.hooks
+      ~after_open_stat:(fun () -> Unix.rename replacement target)
+      ()
+  in
+  ignore
+    (check_error
+       "rename-over never adopts replacement bytes"
+       (function
+         | Test_read.Changed_during_read -> true
+         | _ -> false)
+       (For_testing.read
+          ~hooks:rename_hooks
+          ~parent
+          ~leaf:"rename-target"
+          ~expected_length:4L
+          ~max_length:4L))
+;;
+
+let test_post_read_metadata_drift ~fs () =
+  with_directory ~fs "cap_exact_post_stat_" @@ fun root parent ->
+  let chmod_path = Filename.concat root "chmod" in
+  write_file chmod_path "four";
+  let chmod_hooks =
+    For_testing.hooks
+      ~after_exact_read:(fun () -> Unix.chmod chmod_path 0o640)
+      ()
+  in
+  ignore
+    (check_error
+       "post-read mode drift"
+       (function
+         | Test_read.Changed_during_read -> true
+         | _ -> false)
+       (For_testing.read
+          ~hooks:chmod_hooks
+          ~parent
+          ~leaf:"chmod"
+          ~expected_length:4L
+          ~max_length:4L));
+  let link_path = Filename.concat root "link-source" in
+  let added_link = Filename.concat root "added-link" in
+  write_file link_path "four";
+  let link_hooks =
+    For_testing.hooks
+      ~after_exact_read:(fun () -> Unix.link link_path added_link)
+      ()
+  in
+  ignore
+    (check_error
+       "post-read link-count drift"
+       (function
+         | Test_read.Changed_during_read -> true
+         | _ -> false)
+       (For_testing.read
+          ~hooks:link_hooks
+          ~parent
+          ~leaf:"link-source"
+          ~expected_length:4L
+          ~max_length:4L))
+;;
+
+let test_pinned_parent_path_swap ~fs () =
+  with_directory ~fs "cap_exact_parent_swap_" @@ fun root _outer ->
+  let live_parent = Filename.concat root "objects" in
+  let moved_parent = Filename.concat root "objects-pinned" in
+  Unix.mkdir live_parent 0o700;
+  write_file (Filename.concat live_parent "object") "owned";
+  let parent = Eio.Path.(fs / live_parent) in
+  let hooks =
+    For_testing.hooks
+      ~before_open:(fun () ->
+        Unix.rename live_parent moved_parent;
+        Unix.mkdir live_parent 0o700;
+        write_file (Filename.concat live_parent "object") "trap!")
+      ()
+  in
+  let observation =
+    require_success
+      "pinned parent"
+      (For_testing.read
+         ~hooks
+         ~parent
+         ~leaf:"object"
+         ~expected_length:5L
+         ~max_length:5L)
+  in
+  check
+    string
+    "old pinned parent remains authoritative"
+    "owned"
+    (Test_read.observation_bytes observation)
+;;
+
+let test_leaf_close_warnings ~fs () =
+  with_directory ~fs "cap_exact_leaf_close_" @@ fun root parent ->
+  let success_path = Filename.concat root "success" in
+  write_file success_path "okay";
+  let success_hooks =
+    For_testing.hooks
+      ~on_close:(fun () -> raise (Failure "injected leaf close"))
+      ()
+  in
+  let observation =
+    require_success
+      "success with close warning"
+      (For_testing.read
+         ~hooks:success_hooks
+         ~parent
+         ~leaf:"success"
+         ~expected_length:4L
+         ~max_length:4L)
+  in
+  check string "successful bytes retained" "okay"
+    (Test_read.observation_bytes observation);
+  check_warnings
+    "successful close warning"
+    [ "close:close_leaf" ]
+    (Test_read.observation_settlement_warnings observation);
+  let failure_path = Filename.concat root "failure" in
+  write_file failure_path "four";
+  let failure_hooks =
+    For_testing.hooks
+      ~after_open_stat:(fun () -> Unix.truncate failure_path 2)
+      ~on_close:(fun () -> raise (Failure "injected leaf close"))
+      ()
+  in
+  let failure =
+    check_error
+      "primary read failure retained"
+      (function
+        | Test_read.Changed_during_read -> true
+        | _ -> false)
+      (For_testing.read
+         ~hooks:failure_hooks
+         ~parent
+         ~leaf:"failure"
+         ~expected_length:4L
+         ~max_length:4L)
+  in
+  check_warnings
+    "failure close warning"
+    [ "close:close_leaf" ]
+    failure.settlement_warnings
+;;
+
+let test_hook_failures_preserve_close_warning ~fs () =
+  with_directory ~fs "cap_exact_hook_failure_" @@ fun root parent ->
+  let generic_path = Filename.concat root "generic" in
+  write_file generic_path "four";
+  let generic_hooks =
+    For_testing.hooks
+      ~after_open_stat:(fun () ->
+        raise (Failure "injected callback failure"))
+      ~on_close:(fun () -> raise (Failure "injected leaf close"))
+      ()
+  in
+  let generic_failure =
+    check_error
+      "generic hook failure"
+      (function
+        | Test_read.Io_error
+            { operation = Test_read.Inspect_opened; _ } ->
+          true
+        | _ -> false)
+      (For_testing.read
+         ~hooks:generic_hooks
+         ~parent
+         ~leaf:"generic"
+         ~expected_length:4L
+         ~max_length:4L)
+  in
+  check_warnings
+    "generic hook close warning"
+    [ "close:close_leaf" ]
+    generic_failure.settlement_warnings;
+  let cancelled_path = Filename.concat root "cancelled" in
+  write_file cancelled_path "four";
+  let cancelled_hooks =
+    For_testing.hooks
+      ~after_open_stat:(fun () ->
+        raise
+          (Eio.Cancel.Cancelled
+             (Failure "injected callback cancellation")))
+      ~on_close:(fun () -> raise (Failure "injected leaf close"))
+      ()
+  in
+  let cancelled_failure =
+    check_error
+      "explicit hook cancellation"
+      (function
+        | Test_read.Cancelled
+            { operation = Test_read.Inspect_opened; _ } ->
+          true
+        | _ -> false)
+      (For_testing.read
+         ~hooks:cancelled_hooks
+         ~parent
+         ~leaf:"cancelled"
+         ~expected_length:4L
+         ~max_length:4L)
+  in
+  check_warnings
+    "cancelled hook close warning"
+    [ "close:close_leaf" ]
+    cancelled_failure.settlement_warnings
+;;
+
+let test_pending_cancellation_prevents_dispatch ~fs () =
+  with_directory ~fs "cap_exact_pending_cancel_" @@ fun root parent ->
+  write_file (Filename.concat root "object") "four";
+  let opened = ref 0 in
+  let allocated = ref 0 in
+  let hooks =
+    For_testing.hooks
+      ~before_open:(fun () -> incr opened)
+      ~before_allocate:(fun () -> incr allocated)
+      ()
+  in
+  let outcome =
+    Eio.Cancel.sub @@ fun cancellation ->
+    Eio.Cancel.cancel
+      cancellation
+      (Failure "cancel before exact read");
+    match
+      For_testing.read
+        ~hooks
+        ~parent
+        ~leaf:"object"
+        ~expected_length:4L
+        ~max_length:4L
+    with
+    | _ -> `Returned
+    | exception Eio.Cancel.Cancelled _ -> `Cancelled
+  in
+  check
+    string
+    "pending cancellation raised"
+    "cancelled"
+    (match outcome with
+     | `Cancelled -> "cancelled"
+     | `Returned -> "returned");
+  check int "pending cancellation dispatched no open" 0 !opened;
+  check int "pending cancellation allocated nothing" 0 !allocated
+;;
+
+let test_parent_cancellation_after_dispatch ~fs () =
+  with_directory ~fs "cap_exact_cancel_" @@ fun root parent ->
+  write_file (Filename.concat root "object") "okay";
+  let result =
+    Eio.Cancel.sub @@ fun cancellation ->
+    let hooks =
+      For_testing.hooks
+        ~after_open_stat:(fun () ->
+          Eio.Cancel.cancel
+            cancellation
+            (Failure "cancel after leaf dispatch"))
+        ~on_close:(fun () -> raise (Failure "injected leaf close"))
+        ()
+    in
+    For_testing.read
+      ~hooks
+      ~parent
+      ~leaf:"object"
+      ~expected_length:4L
+      ~max_length:4L
+  in
+  let observation =
+    require_success "dispatched cancellation settles" result
+  in
+  check string "cancelled read bytes retained" "okay"
+    (Test_read.observation_bytes observation);
+  check_warnings
+    "close and parent cancellation warnings"
+    [ "close:close_leaf"
+    ; "settle:observe_parent_cancellation"
+    ]
+    (Test_read.observation_settlement_warnings observation)
+;;
+
+let settlement_failure () =
+  raise (Failure "injected parent resource settlement")
+;;
+
+let test_parent_resource_settlement ~fs () =
+  with_directory ~fs "cap_exact_parent_settle_" @@ fun root parent ->
+  write_file (Filename.concat root "object") "okay";
+  let success_hooks =
+    For_testing.hooks
+      ~on_settle_resources:settlement_failure
+      ()
+  in
+  let observation =
+    require_success
+      "success survives parent settlement failure"
+      (For_testing.read
+         ~hooks:success_hooks
+         ~parent
+         ~leaf:"object"
+         ~expected_length:4L
+         ~max_length:4L)
+  in
+  check string "settled success bytes" "okay"
+    (Test_read.observation_bytes observation);
+  check_warnings
+    "success parent settlement warning"
+    [ "settle:settle_parent_resources" ]
+    (Test_read.observation_settlement_warnings observation);
+  let error_hooks =
+    For_testing.hooks
+      ~on_settle_resources:settlement_failure
+      ()
+  in
+  let failure =
+    check_error
+      "primary error survives parent settlement failure"
+      (function
+        | Test_read.Missing -> true
+        | _ -> false)
+      (For_testing.read
+         ~hooks:error_hooks
+         ~parent
+         ~leaf:"absent"
+         ~expected_length:0L
+         ~max_length:0L)
+  in
+  check_warnings
+    "error parent settlement warning"
+    [ "settle:settle_parent_resources" ]
+    failure.settlement_warnings
+;;
+
+let test_parent_resource_settlement_cancellation ~fs () =
+  with_directory ~fs "cap_exact_parent_settle_cancel_" @@ fun root parent ->
+  write_file (Filename.concat root "object") "okay";
+  let hooks =
+    For_testing.hooks
+      ~on_settle_resources:(fun () ->
+        raise
+          (Eio.Cancel.Cancelled
+             (Failure "injected settlement cancellation")))
+      ()
+  in
+  let observation =
+    require_success
+      "settlement cancellation preserves success"
+      (For_testing.read
+         ~hooks
+         ~parent
+         ~leaf:"object"
+         ~expected_length:4L
+         ~max_length:4L)
+  in
+  check string "settlement-cancelled bytes" "okay"
+    (Test_read.observation_bytes observation);
+  check_warnings
+    "settlement cancellation warning"
+    [ "settle:settle_parent_resources" ]
+    (Test_read.observation_settlement_warnings observation)
+;;
+
+let test_fatal_backtrace_propagation ~fs ~clock ~process_mgr () =
+  with_directory ~fs "cap_exact_fatal_" @@ fun root _parent ->
+  write_file (Filename.concat root "object") "four";
+  [ "callback", fatal_callback_helper_flag
+  ; "settlement", fatal_settlement_helper_flag
+  ]
+  |> List.iter (fun (label, flag) ->
+    run_self_helper
+      ~clock
+      ~process_mgr
+      ~flag
+      root
+      "object"
+    |> require_helper_success ("fatal " ^ label))
+;;
+
+let load_workspace_file relative =
+  let candidates =
+    [ relative
+    ; Filename.concat ".." relative
+    ]
+  in
+  let path =
+    match List.find_opt Sys.file_exists candidates with
+    | Some path -> path
+    | None -> failf "source dependency not found: %s" relative
+  in
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () ->
+      really_input_string channel (in_channel_length channel))
+;;
+
+let find_substring haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if offset + needle_length > haystack_length
+    then None
+    else if
+      String.equal
+        (String.sub haystack offset needle_length)
+        needle
+    then Some offset
+    else loop (offset + 1)
+  in
+  if needle_length = 0 then Some 0 else loop 0
+;;
+
+let count_substring haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset count =
+    if offset + needle_length > haystack_length then
+      count
+    else if
+      String.equal
+        (String.sub haystack offset needle_length)
+        needle
+    then
+      loop (offset + needle_length) (count + 1)
+    else
+      loop (offset + 1) count
+  in
+  if needle_length = 0 then 0 else loop 0 0
+;;
+
+let contains haystack needle =
+  Option.is_some (find_substring haystack needle)
+;;
+
+let exact_read_public_surface source =
+  let marker = "module Capability_exact_read : sig" in
+  let start =
+    match find_substring source marker with
+    | Some offset -> offset + String.length marker
+    | None -> fail "public exact-read module signature is missing"
+  in
+  let remainder =
+    String.sub source start (String.length source - start)
+  in
+  let length =
+    match find_substring remainder "\nend\n" with
+    | Some offset -> offset
+    | None -> fail "public exact-read module signature is unterminated"
+  in
+  String.sub remainder 0 length
+;;
+
+let compact_ascii_whitespace source =
+  source
+  |> String.to_seq
+  |> Seq.filter (function
+    | ' ' | '\t' | '\r' | '\n' -> false
+    | _ -> true)
+  |> String.of_seq
+;;
+
+let test_static_surface_and_raw_openat () =
+  let public_mli =
+    load_workspace_file "lib/fs_compat/fs_compat.mli"
+    |> exact_read_public_surface
+  in
+  check bool "test hooks hidden from public module" false
+    (contains public_mli "For_testing");
+  check bool "raw C primitive hidden from public module" false
+    (contains public_mli "openat_nofollow");
+  let stub =
+    load_workspace_file
+      "lib/fs_compat/capability_exact_read_stubs.c"
+  in
+  check int "one raw openat call" 1
+    (count_substring stub "openat(");
+  check int "no raw open fallback" 0
+    (count_substring stub "open(");
+  let call_start =
+    match find_substring stub "openat(" with
+    | Some offset -> offset
+    | None -> fail "raw openat call is missing"
+  in
+  let call_tail =
+    String.sub stub call_start (String.length stub - call_start)
+  in
+  let call_length =
+    match find_substring call_tail ");" with
+    | Some offset -> offset + 2
+    | None -> fail "raw openat call is unterminated"
+  in
+  check bool "raw openat expression is bounded" true
+    (call_length <= 512);
+  let call =
+    String.sub call_tail 0 call_length
+    |> compact_ascii_whitespace
+  in
+  check
+    string
+    "raw openat directly binds exact flags"
+    "openat(Int_val(v_dirfd),leaf,O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOFOLLOW|O_NOCTTY);"
+    call
+;;
+
+let () =
+  run_helper_if_requested ();
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let clock = Eio.Stdenv.mono_clock env in
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  run
+    "fs capability exact read"
+    [ ( "conformance"
+      , [ test_case "validation precedes dispatch" `Quick
+            (test_pre_dispatch_validation ~fs)
+        ; test_case "exact success" `Quick
+            (test_exact_success ~fs)
+        ; test_case "missing" `Quick
+            (test_missing ~fs)
+        ; test_case "symlink directory FIFO" `Quick
+            (test_special_files ~fs ~clock ~process_mgr)
+        ; test_case "mode and link count" `Quick
+            (test_wrong_mode_and_link_count ~fs)
+        ; test_case "length failures precede allocation" `Quick
+            (test_length_failures_precede_allocation ~fs)
+        ; test_case "after-stat mutations" `Quick
+            (test_after_stat_mutations ~fs)
+        ; test_case "post-read metadata drift" `Quick
+            (test_post_read_metadata_drift ~fs)
+        ; test_case "pinned parent path swap" `Quick
+            (test_pinned_parent_path_swap ~fs)
+        ; test_case "leaf close warnings" `Quick
+            (test_leaf_close_warnings ~fs)
+        ; test_case "hook failures preserve close warning" `Quick
+            (test_hook_failures_preserve_close_warning ~fs)
+        ; test_case "pending cancellation prevents dispatch" `Quick
+            (test_pending_cancellation_prevents_dispatch ~fs)
+        ; test_case "parent cancellation after dispatch" `Quick
+            (test_parent_cancellation_after_dispatch ~fs)
+        ; test_case "parent resource settlement" `Quick
+            (test_parent_resource_settlement ~fs)
+        ; test_case "parent settlement cancellation" `Quick
+            (test_parent_resource_settlement_cancellation ~fs)
+        ; test_case "fatal backtrace propagation" `Quick
+            (test_fatal_backtrace_propagation
+               ~fs
+               ~clock
+               ~process_mgr)
+        ; test_case "static public surface and raw openat" `Quick
+            test_static_surface_and_raw_openat
+        ] )
+    ]
+;;

--- a/test/test_fs_compat_capability_exact_read.ml
+++ b/test/test_fs_compat_capability_exact_read.ml
@@ -1018,7 +1018,7 @@ let () =
   run_helper_if_requested ();
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
-  let clock = Eio.Stdenv.mono_clock env in
+  let clock = Eio.Stdenv.clock env in
   let process_mgr = Eio.Stdenv.process_mgr env in
   run
     "fs capability exact read"


### PR DESCRIPTION
## Summary

- add `Fs_compat.Capability_exact_read`, a capability-relative bounded exact-read primitive for immutable private files
- open one final leaf with a single raw `openat(dirfd, leaf, O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_NOFOLLOW|O_NOCTTY)` syscall
- reject invalid bounds, non-regular files, hard links, unsafe modes, size mismatches, and metadata/identity drift before returning bytes
- read exactly the declared bytes plus an EOF probe, with no scan, retry, fallback, repair, delete, migration, digest, schema, or domain ownership
- preserve child-close and parent-resource settlement warnings independently from successful bytes or primary typed failures
- expose existing semantic `Capability_head.cursor_equal` so downstream code never uses polymorphic equality on the opaque cursor

## Authority boundary

The caller supplies a pinned parent capability, a single-component leaf, a declared byte length, and a trusted maximum. This primitive owns filesystem confinement, byte bounds, exact-read settlement, and no-follow semantics only. The caller remains responsible for digest verification before decode and for all schema/domain authority.

Fatal runtime exceptions (`Out_of_memory`, `Stack_overflow`, `Sys.Break`) retain their original backtrace and are outside the typed failure/warning contract. Pending cancellation is checked before dispatch; after child open dispatch, read and resource settlement finish as one protected typed outcome.

## Proof surface

- validation and representation limits before open/allocation
- exact success, missing, symlink, directory, FIFO nonblocking rejection
- mode and hard-link rejection plus post-read metadata drift
- short/long/over-max lengths before allocation
- shrink/grow/rename-over and pinned-parent path-swap traps
- success/error/cancellation with child-close and parent-settlement warnings
- fatal callback/scope exception and backtrace preservation in bounded subprocesses
- exact raw `openat` call expression and production/test-surface separation

## Validation

Local build/test/formatter intentionally not run per current workflow direction. Draft CI is the compile and conformance authority.

[근거] OCaml 5.5 and Eio/eio_posix 1.3 installed public interfaces/source, Eio v1.4 release notes (2026-07-23), POSIX `openat`/`O_NOFOLLOW` contracts; checked 2026-07-26 KST. Confidence High.
