### PR TITLE
fix(fs): preserve fatal write exceptions

### DIFF
--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -1115,6 +1115,36 @@ let write_cleanup_failures failures =
   List.map (fun failure -> Write_cleanup_failure failure) failures
 ;;
 
+let reraise_capability_write_cancellation
+      ~backtrace
+      ~operation
+      ~target_effect
+      ~interrupted_primary_failure
+      ~cleanup_failures
+      reason
+  =
+  let reason, interrupted_recovery, carried_cleanup_failures =
+    match reason with
+    | Capability_recovery_operation_cancelled (reason, interruption) ->
+      reason, Some interruption, []
+    | Parent_sync_cleanup_failed_on_cancellation (reason, failures) ->
+      reason, None, write_cleanup_failures failures
+    | reason -> reason, None, []
+  in
+  Printexc.raise_with_backtrace
+    (Eio.Cancel.Cancelled
+       (Capability_write_cancelled
+          ( reason
+          , { operation
+            ; target_effect
+            ; interrupted_primary_failure
+            ; interrupted_recovery
+            ; cleanup_failures =
+                cleanup_failures @ carried_cleanup_failures
+            } )))
+    backtrace
+;;
+
 let capture_recovery_cleanup ~recovery_phase operation =
   try
     match operation () with
@@ -1448,7 +1478,18 @@ let replace_capability_file_with
         !cleanup_failures)
     in
     let error primary_failure additional =
-      let cleanup_failures = additional @ cleanup () in
+      let cleanup_failures =
+        try additional @ cleanup () with
+        | Eio.Cancel.Cancelled reason ->
+          let backtrace = Printexc.get_raw_backtrace () in
+          reraise_capability_write_cancellation
+            ~backtrace
+            ~operation
+            ~target_effect:!target_effect
+            ~interrupted_primary_failure:(Some primary_failure)
+            ~cleanup_failures:additional
+            reason
+      in
       Error
         { operation
         ; target_effect = !target_effect
@@ -1863,11 +1904,25 @@ let create_capability_file_exclusive_with
            @ cleanup_parent_if_dirty ~before_stage ~sw ~parent parent_dirty))
     in
     let error failure additional =
+      let primary_failure = Write_primary_failure failure in
+      let additional = write_cleanup_failures additional in
+      let cleanup_failures =
+        try additional @ cleanup () with
+        | Eio.Cancel.Cancelled reason ->
+          let backtrace = Printexc.get_raw_backtrace () in
+          reraise_capability_write_cancellation
+            ~backtrace
+            ~operation
+            ~target_effect:!target_effect
+            ~interrupted_primary_failure:(Some primary_failure)
+            ~cleanup_failures:additional
+            reason
+      in
       Error
         { operation
         ; target_effect = !target_effect
-        ; primary_failure = Write_primary_failure failure
-        ; cleanup_failures = write_cleanup_failures additional @ cleanup ()
+        ; primary_failure
+        ; cleanup_failures
         }
     in
     let result =

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -732,6 +732,16 @@ let operation_failure stage exception_ backtrace =
   { stage; cause = Operation_failed { exception_; backtrace } }
 ;;
 
+let reraise_fatal_or_cancelled exception_ backtrace =
+  match exception_ with
+  | Out_of_memory
+  | Stack_overflow
+  | Sys.Break
+  | Eio.Cancel.Cancelled _ ->
+    Printexc.raise_with_backtrace exception_ backtrace
+  | _ -> ()
+;;
+
 let raise_failure stage cause =
   raise (Capability_write_failed ({ stage; cause }, []))
 ;;
@@ -741,10 +751,13 @@ let run_stage ~before_stage stage f =
     before_stage stage;
     f ()
   with
-  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | Eio.Cancel.Cancelled _ as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace cancellation backtrace
   | Capability_write_failed _ as failure -> raise failure
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal_or_cancelled exception_ backtrace;
     raise
       (Capability_write_failed
          (operation_failure stage exception_ backtrace, []))
@@ -759,6 +772,7 @@ let capture_cleanup ~before_stage stage f =
   | Capability_write_failed (failure, additional) -> failure :: additional
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal_or_cancelled exception_ backtrace;
     [ operation_failure stage exception_ backtrace ]
 ;;
 
@@ -855,6 +869,7 @@ let write_open_file_payload ~before_stage file content =
     | Error
         (Blocking_write.Open_file_operation_failed
           { exception_; backtrace; bytes_written }) ->
+      reraise_fatal_or_cancelled exception_ backtrace;
       raise
         (Capability_write_failed
            ( { stage = Write_payload
@@ -878,6 +893,7 @@ let sync_parent_capability ~before_stage ~stage ~sw parent =
         with
         | exception_ ->
           let backtrace = Printexc.get_raw_backtrace () in
+          reraise_fatal_or_cancelled exception_ backtrace;
           [ operation_failure stage exception_ backtrace ]
       in
       directory_file := None;
@@ -916,6 +932,7 @@ let sync_parent_capability ~before_stage ~stage ~sw parent =
          (failure, additional @ close_failures))
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal_or_cancelled exception_ backtrace;
     let close_failures = close_directory () in
     raise
       (Capability_write_failed
@@ -1108,6 +1125,7 @@ let capture_recovery_cleanup ~recovery_phase operation =
       ]
   with
   | Eio.Cancel.Cancelled reason ->
+    let backtrace = Printexc.get_raw_backtrace () in
     let original_reason, store_effect, cleanup_failures =
       match reason with
       | Recovery.Recovery_store_cancelled
@@ -1115,13 +1133,18 @@ let capture_recovery_cleanup ~recovery_phase operation =
         original_reason, store_effect, cleanup_failures
       | original_reason -> original_reason, Recovery.No_record_change, []
     in
-    [ Recovery_cleanup_failure
-        (recovery_interruption
-           recovery_phase
-           store_effect
-           original_reason
-           cleanup_failures)
-    ]
+    let interruption =
+      recovery_interruption
+        recovery_phase
+        store_effect
+        original_reason
+        cleanup_failures
+    in
+    Printexc.raise_with_backtrace
+      (Eio.Cancel.Cancelled
+         (Capability_recovery_operation_cancelled
+            (original_reason, interruption)))
+      backtrace
 ;;
 
 let cleanup_owned_staging_directory
@@ -1602,11 +1625,13 @@ let replace_capability_file_with
              before_publish entry;
              try Eio.Path.rename entry target_path with
              | Eio.Cancel.Cancelled _ as cancellation ->
+               let backtrace = Printexc.get_raw_backtrace () in
                target_effect := Target_state_unknown;
-               raise cancellation
+               Printexc.raise_with_backtrace cancellation backtrace
              | exception_ ->
                let backtrace = Printexc.get_raw_backtrace () in
                target_effect := Target_state_unknown;
+               reraise_fatal_or_cancelled exception_ backtrace;
                raise
                  (Capability_write_failed
                     ( operation_failure
@@ -1714,6 +1739,7 @@ let replace_capability_file_with
          (write_cleanup_failures additional)
      | exception_ ->
        let backtrace = Printexc.get_raw_backtrace () in
+       reraise_fatal_or_cancelled exception_ backtrace;
        error
          (Write_primary_failure
             (operation_failure Create_staging_directory exception_ backtrace))
@@ -1724,7 +1750,8 @@ let replace_capability_file_with
     result
   with
   | Eio.Cancel.Cancelled (Capability_write_cancelled _) as cancellation ->
-    raise cancellation
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace cancellation backtrace
   | Eio.Cancel.Cancelled reason as cancellation ->
     let backtrace = Printexc.get_raw_backtrace () in
     (match !callback_result with
@@ -1773,6 +1800,7 @@ let replace_capability_file_with
          })
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal_or_cancelled exception_ backtrace;
     let release_failure = operation_failure Cleanup_close exception_ backtrace in
     (match !callback_result with
      | Some (Error error) ->
@@ -1899,6 +1927,7 @@ let create_capability_file_exclusive_with
        error failure additional
      | exception_ ->
        let backtrace = Printexc.get_raw_backtrace () in
+       reraise_fatal_or_cancelled exception_ backtrace;
        error
          (operation_failure Create_target_entry exception_ backtrace)
          []
@@ -1908,7 +1937,8 @@ let create_capability_file_exclusive_with
     result
   with
   | Eio.Cancel.Cancelled (Capability_write_cancelled _) as cancellation ->
-    raise cancellation
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace cancellation backtrace
   | Eio.Cancel.Cancelled reason as cancellation ->
     let backtrace = Printexc.get_raw_backtrace () in
     (match !callback_result with
@@ -1957,6 +1987,7 @@ let create_capability_file_exclusive_with
          })
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal_or_cancelled exception_ backtrace;
     let release_failure = operation_failure Cleanup_close exception_ backtrace in
     (match !callback_result with
      | Some (Error error) ->
@@ -2012,7 +2043,8 @@ let replace_capability_file_through_access
         }
   with
   | Eio.Cancel.Cancelled (Capability_write_cancelled _) as cancellation ->
-    raise cancellation
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace cancellation backtrace
   | Eio.Cancel.Cancelled reason as cancellation ->
     let backtrace = Printexc.get_raw_backtrace () in
     (match !callback_result with
@@ -2070,11 +2102,14 @@ let sync_directory_capability_with ~before_stage directory =
     Eio.Fiber.check ();
     result
   with
-  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | Eio.Cancel.Cancelled _ as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace cancellation backtrace
   | Capability_write_failed (failure, cleanup_failures) ->
     Error { failure; cleanup_failures }
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal_or_cancelled exception_ backtrace;
     Error
       { failure = operation_failure Sync_parent exception_ backtrace
       ; cleanup_failures = []

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -331,7 +331,9 @@ exception Capability_write_cancelled of exn * capability_write_cancellation
     durable Bound obligation precedes payload creation. The Bound obligation
     is discharged only after rename, staging-directory sync and removal, and
     target-parent sync all complete. No target tree is scanned during failure
-    handling. *)
+    handling. [Out_of_memory], [Stack_overflow], [Sys.Break], and
+    [Eio.Cancel.Cancelled] are re-raised with their original backtrace rather
+    than entering the typed write-error channel. *)
 val replace_capability_file
   :  recovery:Publication_recovery_access.t
   -> parent:Eio.Fs.dir_ty Eio.Path.t
@@ -341,7 +343,8 @@ val replace_capability_file
 
 (** Exclusive creation is physically separate from replacement and has no
     recovery-obligation argument. Once the public leaf is created it is never
-    unlinked by failure cleanup. *)
+    unlinked by failure cleanup. Fatal runtime exceptions and cancellation
+    follow the same re-raise contract as {!replace_capability_file}. *)
 val create_capability_file_exclusive
   :  parent:Eio.Fs.dir_ty Eio.Path.t
   -> leaf:string

--- a/test/test_fs_compat_capability_write.ml
+++ b/test/test_fs_compat_capability_write.ml
@@ -158,6 +158,120 @@ let require_append_file = function
   | Error error -> fail (Fs_compat.capability_append_open_error_to_string error)
 ;;
 
+let nonrecoverable_write_exceptions () =
+  [ "out_of_memory", Out_of_memory
+  ; "stack_overflow", Stack_overflow
+  ; "sys_break", Sys.Break
+  ; "cancellation", Eio.Cancel.Cancelled Exit
+  ]
+;;
+
+let check_same_exception_and_backtrace
+      ~label
+      ~expected_exception
+      ~expected_backtrace
+      operation
+  =
+  let observed =
+    try
+      operation ();
+      None
+    with
+    | exception_ ->
+      Some (exception_, Printexc.get_raw_backtrace ())
+  in
+  match observed with
+  | None -> failf "%s unexpectedly entered the typed result channel" label
+  | Some (exception_, backtrace) ->
+    check bool (label ^ " preserves exception identity") true
+      (exception_ == expected_exception);
+    check string (label ^ " preserves raw backtrace")
+      (Printexc.raw_backtrace_to_string expected_backtrace)
+      (Printexc.raw_backtrace_to_string backtrace)
+;;
+
+let test_replace_nonrecoverable_exceptions_preserve_backtrace ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  List.iter
+    (fun (name, exception_) ->
+       let backtrace = Printexc.get_callstack 32 in
+       check_same_exception_and_backtrace
+         ~label:("replace " ^ name)
+         ~expected_exception:exception_
+         ~expected_backtrace:backtrace
+         (fun () ->
+            ignore
+              (replace_capability_file_for_testing
+                 ~before_stage:(function
+                   | Fs_compat.Acquire_mutation_lease ->
+                     Printexc.raise_with_backtrace exception_ backtrace
+                   | _ -> ())
+                 ~recovery
+                 ~allowed_root_path:directory
+                 ~parent
+                 ~leaf:"target"
+                 ~permissions:0o640
+                 "new"
+               : (unit, Fs_compat.capability_write_error) result)))
+    (nonrecoverable_write_exceptions ());
+  check string "fatal replace attempts leave target unchanged" "old"
+    (read_file target)
+;;
+
+let test_create_nonrecoverable_exceptions_preserve_backtrace ~fs () =
+  with_tmp_dir @@ fun directory ->
+  with_parent_capability ~fs directory @@ fun parent ->
+  List.iter
+    (fun (name, exception_) ->
+       let backtrace = Printexc.get_callstack 32 in
+       check_same_exception_and_backtrace
+         ~label:("exclusive create " ^ name)
+         ~expected_exception:exception_
+         ~expected_backtrace:backtrace
+         (fun () ->
+            ignore
+              (Capability_write_test.create_capability_file_exclusive
+                 ~before_stage:(function
+                   | Fs_compat.Validate_leaf ->
+                     Printexc.raise_with_backtrace exception_ backtrace
+                   | _ -> ())
+                 ~parent
+                 ~leaf:"target"
+                 ~permissions:0o640
+                 "new"
+               : (unit, Fs_compat.capability_write_error) result)))
+    (nonrecoverable_write_exceptions ());
+  check bool "fatal create attempts do not publish target" false
+    (Sys.file_exists (Filename.concat directory "target"))
+;;
+
+let test_cleanup_fatal_exception_preserves_backtrace ~fs () =
+  with_tmp_dir @@ fun directory ->
+  with_parent_capability ~fs directory @@ fun parent ->
+  let fatal = Out_of_memory in
+  let backtrace = Printexc.get_callstack 32 in
+  check_same_exception_and_backtrace
+    ~label:"exclusive create cleanup"
+    ~expected_exception:fatal
+    ~expected_backtrace:backtrace
+    (fun () ->
+       ignore
+         (Capability_write_test.create_capability_file_exclusive
+            ~before_stage:(function
+              | Fs_compat.Write_payload -> raise Exit
+              | Fs_compat.Cleanup_close ->
+                Printexc.raise_with_backtrace fatal backtrace
+              | _ -> ())
+            ~parent
+            ~leaf:"target"
+            ~permissions:0o640
+            "new"
+          : (unit, Fs_compat.capability_write_error) result))
+;;
+
 let test_atomic_replace_preserves_requested_mode ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
@@ -1892,6 +2006,12 @@ let () =
             (test_atomic_replace_replaces_symlink_not_referent ~fs)
         ; test_case "large payload complete" `Quick
             (test_atomic_replace_writes_complete_large_payload ~fs)
+        ; test_case "replace fatal and cancellation preserve backtrace" `Quick
+            (test_replace_nonrecoverable_exceptions_preserve_backtrace ~fs)
+        ; test_case "create fatal and cancellation preserve backtrace" `Quick
+            (test_create_nonrecoverable_exceptions_preserve_backtrace ~fs)
+        ; test_case "cleanup fatal preserves backtrace" `Quick
+            (test_cleanup_fatal_exception_preserves_backtrace ~fs)
         ; test_case "typed parent components" `Quick
             (test_atomic_replace_uses_typed_parent_components ~fs)
         ; test_case "owned restrictive staging directory" `Quick

--- a/test/test_fs_compat_capability_write.ml
+++ b/test/test_fs_compat_capability_write.ml
@@ -251,25 +251,229 @@ let test_create_nonrecoverable_exceptions_preserve_backtrace ~fs () =
 let test_cleanup_fatal_exception_preserves_backtrace ~fs () =
   with_tmp_dir @@ fun directory ->
   with_parent_capability ~fs directory @@ fun parent ->
-  let fatal = Out_of_memory in
+  List.iter
+    (fun (name, fatal) ->
+       let backtrace = Printexc.get_callstack 32 in
+       check_same_exception_and_backtrace
+         ~label:("exclusive create cleanup " ^ name)
+         ~expected_exception:fatal
+         ~expected_backtrace:backtrace
+         (fun () ->
+            ignore
+              (Capability_write_test.create_capability_file_exclusive
+                 ~before_stage:(function
+                   | Fs_compat.Write_payload -> raise Exit
+                   | Fs_compat.Cleanup_close ->
+                     Printexc.raise_with_backtrace fatal backtrace
+                   | _ -> ())
+                 ~parent
+                 ~leaf:("target-" ^ name)
+                 ~permissions:0o640
+                 "new"
+               : (unit, Fs_compat.capability_write_error) result)))
+    [ "out_of_memory", Out_of_memory
+    ; "stack_overflow", Stack_overflow
+    ; "sys_break", Sys.Break
+    ]
+;;
+
+let require_capability_write_cancellation ~label operation =
+  try
+    operation ();
+    failf "%s cancellation was swallowed" label
+  with
+  | Eio.Cancel.Cancelled
+      (Fs_compat.Capability_write_cancelled (reason, cancellation)) ->
+    reason, cancellation, Printexc.get_raw_backtrace ()
+  | Eio.Cancel.Cancelled _ ->
+    failf "%s cancellation lost capability-write authority" label
+;;
+
+let check_interrupted_write_stage
+      ~label
+      ~expected_stage
+      (cancellation : Fs_compat.capability_write_cancellation)
+  =
+  match cancellation.interrupted_primary_failure with
+  | Some (Fs_compat.Write_primary_failure failure) ->
+    check bool (label ^ " preserves interrupted primary stage") true
+      (failure.stage = expected_stage)
+  | Some (Fs_compat.Recovery_primary_failure failure) ->
+    fail (Fs_compat.capability_recovery_failure_to_string failure)
+  | Some (Fs_compat.Recovery_access_primary_failure _) ->
+    failf "%s replaced the write primary with recovery access" label
+  | None -> failf "%s omitted the interrupted write primary" label
+;;
+
+let check_direct_cleanup_cancellation
+      ~label
+      ~reason
+      ~backtrace
+      ~expected_operation
+      ~expected_target_effect
+      ~expected_primary_stage
+      operation
+  =
+  let observed_reason, cancellation, observed_backtrace =
+    require_capability_write_cancellation ~label operation
+  in
+  check bool (label ^ " preserves reason identity") true
+    (observed_reason == reason);
+  check string (label ^ " preserves raw backtrace")
+    (Printexc.raw_backtrace_to_string backtrace)
+    (Printexc.raw_backtrace_to_string observed_backtrace);
+  check bool (label ^ " preserves operation") true
+    (cancellation.operation = expected_operation);
+  check bool (label ^ " preserves target effect") true
+    (cancellation.target_effect = expected_target_effect);
+  check bool (label ^ " has no invented recovery interruption") true
+    (Option.is_none cancellation.interrupted_recovery);
+  check_interrupted_write_stage
+    ~label
+    ~expected_stage:expected_primary_stage
+    cancellation
+;;
+
+let test_replace_direct_cleanup_cancellation_preserves_authority ~fs () =
+  let run
+        ~label
+        ~primary_stage
+        ~cleanup_stage
+        ~expected_target_effect
+    =
+    with_tmp_dir @@ fun directory ->
+    let target = Filename.concat directory "target" in
+    write_file target "old";
+    with_replace_context ~fs directory @@ fun parent recovery ->
+    let reason = Failure label in
+    let backtrace = Printexc.get_callstack 32 in
+    check_direct_cleanup_cancellation
+      ~label
+      ~reason
+      ~backtrace
+      ~expected_operation:Fs_compat.Atomic_replace_operation
+      ~expected_target_effect
+      ~expected_primary_stage:primary_stage
+      (fun () ->
+         ignore
+           (replace_capability_file_for_testing
+              ~before_stage:(fun stage ->
+                if stage = primary_stage
+                then raise Exit
+                else if stage = cleanup_stage
+                then
+                  Printexc.raise_with_backtrace
+                    (Eio.Cancel.Cancelled reason)
+                    backtrace)
+              ~recovery
+              ~allowed_root_path:directory
+              ~parent
+              ~leaf:"target"
+              ~permissions:0o640
+              "new"
+            : (unit, Fs_compat.capability_write_error) result))
+  in
+  run
+    ~label:"replace unchanged cleanup"
+    ~primary_stage:Fs_compat.Write_payload
+    ~cleanup_stage:Fs_compat.Cleanup_close
+    ~expected_target_effect:Fs_compat.Target_unchanged;
+  run
+    ~label:"replace published cleanup"
+    ~primary_stage:Fs_compat.Sync_parent
+    ~cleanup_stage:Fs_compat.Cleanup_sync_parent
+    ~expected_target_effect:Fs_compat.Target_replaced
+;;
+
+let test_create_direct_cleanup_cancellation_preserves_authority ~fs () =
+  let run
+        ~label
+        ~primary_stage
+        ~cleanup_stage
+        ~expected_target_effect
+    =
+    with_tmp_dir @@ fun directory ->
+    with_parent_capability ~fs directory @@ fun parent ->
+    let reason = Failure label in
+    let backtrace = Printexc.get_callstack 32 in
+    check_direct_cleanup_cancellation
+      ~label
+      ~reason
+      ~backtrace
+      ~expected_operation:Fs_compat.Create_exclusive_operation
+      ~expected_target_effect
+      ~expected_primary_stage:primary_stage
+      (fun () ->
+         ignore
+           (Capability_write_test.create_capability_file_exclusive
+              ~before_stage:(fun stage ->
+                if stage = primary_stage
+                then raise Exit
+                else if stage = cleanup_stage
+                then
+                  Printexc.raise_with_backtrace
+                    (Eio.Cancel.Cancelled reason)
+                    backtrace)
+              ~parent
+              ~leaf:"target"
+              ~permissions:0o640
+              "new"
+            : (unit, Fs_compat.capability_write_error) result))
+  in
+  run
+    ~label:"create incomplete cleanup"
+    ~primary_stage:Fs_compat.Write_payload
+    ~cleanup_stage:Fs_compat.Cleanup_close
+    ~expected_target_effect:Fs_compat.Target_created_incomplete;
+  run
+    ~label:"create complete cleanup"
+    ~primary_stage:Fs_compat.Sync_parent
+    ~cleanup_stage:Fs_compat.Cleanup_sync_parent
+    ~expected_target_effect:Fs_compat.Target_created
+;;
+
+let test_recovery_cancellation_preserves_authority_and_backtrace ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  let reason = Failure "recovery discharge cancellation" in
   let backtrace = Printexc.get_callstack 32 in
-  check_same_exception_and_backtrace
-    ~label:"exclusive create cleanup"
-    ~expected_exception:fatal
-    ~expected_backtrace:backtrace
-    (fun () ->
-       ignore
-         (Capability_write_test.create_capability_file_exclusive
-            ~before_stage:(function
-              | Fs_compat.Write_payload -> raise Exit
-              | Fs_compat.Cleanup_close ->
-                Printexc.raise_with_backtrace fatal backtrace
-              | _ -> ())
-            ~parent
-            ~leaf:"target"
-            ~permissions:0o640
-            "new"
-          : (unit, Fs_compat.capability_write_error) result))
+  let observed_reason, cancellation, observed_backtrace =
+    require_capability_write_cancellation
+      ~label:"recovery discharge"
+      (fun () ->
+         ignore
+           (replace_capability_file_for_testing
+              ~before_stage:(function
+                | Fs_compat.Discharge_bound_recovery_obligation ->
+                  Printexc.raise_with_backtrace
+                    (Eio.Cancel.Cancelled reason)
+                    backtrace
+                | _ -> ())
+              ~recovery
+              ~allowed_root_path:directory
+              ~parent
+              ~leaf:"target"
+              ~permissions:0o640
+              "new"
+            : (unit, Fs_compat.capability_write_error) result))
+  in
+  check bool "recovery cancellation preserves reason identity" true
+    (observed_reason == reason);
+  check string "recovery cancellation preserves raw backtrace"
+    (Printexc.raw_backtrace_to_string backtrace)
+    (Printexc.raw_backtrace_to_string observed_backtrace);
+  check bool "recovery cancellation preserves replacement effect" true
+    (cancellation.target_effect = Fs_compat.Target_replaced);
+  check bool "recovery cancellation has no write primary" true
+    (Option.is_none cancellation.interrupted_primary_failure);
+  (match cancellation.interrupted_recovery with
+   | None -> fail "recovery cancellation omitted interruption authority"
+   | Some interruption ->
+     check bool "recovery cancellation preserves exact phase" true
+       (Fs_compat.capability_recovery_failure_phase interruption
+        = Fs_compat.Recovery_discharge_bound))
 ;;
 
 let test_atomic_replace_preserves_requested_mode ~fs () =
@@ -2012,6 +2216,12 @@ let () =
             (test_create_nonrecoverable_exceptions_preserve_backtrace ~fs)
         ; test_case "cleanup fatal preserves backtrace" `Quick
             (test_cleanup_fatal_exception_preserves_backtrace ~fs)
+        ; test_case "replace cleanup cancellation preserves authority" `Quick
+            (test_replace_direct_cleanup_cancellation_preserves_authority ~fs)
+        ; test_case "create cleanup cancellation preserves authority" `Quick
+            (test_create_direct_cleanup_cancellation_preserves_authority ~fs)
+        ; test_case "recovery cancellation preserves authority" `Quick
+            (test_recovery_cancellation_preserves_authority_and_backtrace ~fs)
         ; test_case "typed parent components" `Quick
             (test_atomic_replace_uses_typed_parent_components ~fs)
         ; test_case "owned restrictive staging directory" `Quick


### PR DESCRIPTION
## Summary

- keep `Out_of_memory`, `Stack_overflow`, `Sys.Break`, and `Eio.Cancel.Cancelled` out of capability write typed errors
- preserve the original raw backtrace through stage dispatch, payload propagation, cleanup, parent sync, publication, and Eio switch settlement
- retain the existing typed result contract for ordinary filesystem/write failures
- prove replace, exclusive-create, and cleanup propagation through the existing test-only `before_stage` seam without adding a production fault API

## Boundary

This changes only the shared filesystem atomic/exclusive-create primitive. It adds no Keeper, provider, model, catalog, migration, scan, or compatibility behavior.

## Validation

Per the current workflow direction, no local build, test, or formatter was run. GitHub CI is the validation authority for this draft PR.
