### PR TITLE
fix(fs): preserve fatal capability head failures

### DIFF
--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -181,20 +181,35 @@ let exception_detail exn = Printexc.to_string exn
 let diagnostic operation exn =
   { operation; detail = exception_detail exn }
 
+let reraise_fatal exn raw_backtrace =
+  match exn with
+  | Out_of_memory | Stack_overflow | Sys.Break ->
+    Printexc.raise_with_backtrace exn raw_backtrace
+  | _ -> ()
+
 let protect_io operation fn =
   try Ok (fn ()) with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Io_error (diagnostic operation exn))
+  | exn ->
+    let raw_backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal exn raw_backtrace;
+    Error (Io_error (diagnostic operation exn))
 
 let protect_result operation fn =
   try fn () with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Io_error (diagnostic operation exn))
+  | exn ->
+    let raw_backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal exn raw_backtrace;
+    Error (Io_error (diagnostic operation exn))
 
 let invoke_hook operation hook =
   try hook () with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> raise (Hook_failed (diagnostic operation exn))
+  | exn ->
+    let raw_backtrace = Printexc.get_raw_backtrace () in
+    reraise_fatal exn raw_backtrace;
+    raise (Hook_failed (diagnostic operation exn))
 
 let diagnostic_of_exception default_operation = function
   | Hook_failed diagnostic -> diagnostic
@@ -337,7 +352,10 @@ let try_lock file =
      with
      | Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) -> Error Busy
      | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn -> Error (Io_error (diagnostic Acquire_cross_process_lock exn)))
+     | exn ->
+       let raw_backtrace = Printexc.get_raw_backtrace () in
+       reraise_fatal exn raw_backtrace;
+       Error (Io_error (diagnostic Acquire_cross_process_lock exn)))
 
 let fresh_epoch secure_random =
   protect_io Initialize_lock_marker (fun () ->
@@ -502,7 +520,10 @@ let rec create_stage ~sw ~secure_random ~parent attempts =
      | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
        create_stage ~sw ~secure_random ~parent (attempts - 1)
      | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn -> Error (Io_error (diagnostic Create_stage exn)))
+     | exn ->
+       let raw_backtrace = Printexc.get_raw_backtrace () in
+       reraise_fatal exn raw_backtrace;
+       Error (Io_error (diagnostic Create_stage exn)))
 
 let write_stage ~path file payload =
   let* () = protect_io Write_stage (fun () -> Eio.Flow.copy_string payload file) in
@@ -558,14 +579,21 @@ let run_transaction ~hooks ~parent ~leaf ~publication_state ~set_success_warning
         Eio.Switch.run_protected (fun sw ->
           Eio.Switch.on_release sw (fun () ->
             try hooks.on_resource_settlement () with
-            | exn -> raise (Hook_failed (diagnostic Settle_resources exn)));
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+              let raw_backtrace = Printexc.get_raw_backtrace () in
+              reraise_fatal exn raw_backtrace;
+              raise (Hook_failed (diagnostic Settle_resources exn)));
           let exact_parent, parent_stat =
             try
               let exact_parent = Eio.Path.open_dir ~sw parent in
               exact_parent, Eio.Path.stat ~follow:false exact_parent
             with
             | Eio.Cancel.Cancelled _ as exn -> raise exn
-            | exn -> raise (Hook_failed (diagnostic Pin_parent exn))
+            | exn ->
+              let raw_backtrace = Printexc.get_raw_backtrace () in
+              reraise_fatal exn raw_backtrace;
+              raise (Hook_failed (diagnostic Pin_parent exn))
           in
           match
             Lease.try_acquire
@@ -593,6 +621,8 @@ let run_transaction ~hooks ~parent ~leaf ~publication_state ~set_success_warning
         when !publication_state = Before_publication && Option.is_none !completed ->
         raise exn
       | exn ->
+        let raw_backtrace = Printexc.get_raw_backtrace () in
+        reraise_fatal exn raw_backtrace;
         let detail = diagnostic_of_exception Settle_resources exn in
         (match !completed with
          | Some (Ok value) ->
@@ -717,7 +747,10 @@ let compare_and_swap_internal ~hooks ~secure_random ~parent ~leaf ~expected ~row
                             }
                           :: !warnings))
                 with
+                | Eio.Cancel.Cancelled _ as exn -> raise exn
                 | exn ->
+                  let raw_backtrace = Printexc.get_raw_backtrace () in
+                  reraise_fatal exn raw_backtrace;
                   warnings :=
                     Cleanup_failed (diagnostic_of_exception Cleanup_stage exn) :: !warnings)
             (fun () ->

--- a/test/test_fs_compat_capability_head.ml
+++ b/test/test_fs_compat_capability_head.ml
@@ -153,6 +153,46 @@ let check_publication_evidence label row (evidence : Head.publication_evidence) 
     (String.length evidence.Head.intended_sha256)
 ;;
 
+let raise_with_captured_backtrace captured exn =
+  try raise exn with
+  | raised ->
+    let raw_backtrace = Printexc.get_raw_backtrace () in
+    captured := Some raw_backtrace;
+    Printexc.raise_with_backtrace raised raw_backtrace
+;;
+
+let fatal_kind = function
+  | Out_of_memory -> "Out_of_memory"
+  | Stack_overflow -> "Stack_overflow"
+  | Sys.Break -> "Sys.Break"
+  | exn -> Printexc.to_string exn
+;;
+
+let require_original_fatal_backtrace ~label ~expected ~captured run =
+  Printexc.record_backtrace true;
+  let outcome =
+    try
+      ignore (run ());
+      `Returned
+    with
+    | exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+  in
+  match outcome, !captured with
+  | `Raised (observed, observed_backtrace), Some original_backtrace ->
+    check string
+      (label ^ " preserves fatal kind")
+      (fatal_kind expected)
+      (fatal_kind observed);
+    check string
+      (label ^ " preserves original raw backtrace")
+      (Printexc.raw_backtrace_to_string original_backtrace)
+      (Printexc.raw_backtrace_to_string observed_backtrace)
+  | `Raised (_, _), None ->
+    failf "%s: fatal source did not capture its raw backtrace" label
+  | `Returned, _ ->
+    failf "%s: fatal exception was flattened into a typed result" label
+;;
+
 let cross_process_holder_arg = "--capability-head-cross-process-holder"
 let cross_process_timeout_seconds = 10.0
 
@@ -772,6 +812,111 @@ let test_resource_settlement_warning_preserves_success ~fs ~secure_random () =
   |> check_row "settlement warning does not hide publication" (Some "settled-row")
 ;;
 
+let test_pre_publication_fatal_preserves_backtrace_and_disk
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_pre_fatal_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "pre-publication fatal fixture" in
+  let captured = ref None in
+  let hooks =
+    Head.For_testing.hooks
+      ~before_rename:(fun () ->
+        raise_with_captured_backtrace captured Sys.Break)
+      ()
+  in
+  require_original_fatal_backtrace
+    ~label:"pre-publication Sys.Break"
+    ~expected:Sys.Break
+    ~captured
+    (fun () ->
+      publish_for_testing
+        hooks
+        ~secure_random
+        ~parent
+        ~leaf
+        ~expected:absent
+        ~row:"must-not-publish");
+  read ~secure_random ~parent ~leaf "pre-publication fatal final read"
+  |> check_row "pre-publication fatal leaves HEAD absent" None;
+  check bool
+    "pre-publication fatal cleans its private stage"
+    false
+    (directory_entries directory
+     |> List.exists (String.starts_with ~prefix:".masc-capability-head-stage-"))
+;;
+
+let test_post_rename_fatal_preserves_backtrace_and_disk
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_post_fatal_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "post-rename fatal fixture" in
+  let captured = ref None in
+  let hooks =
+    Head.For_testing.hooks
+      ~after_rename:(fun () ->
+        raise_with_captured_backtrace captured Out_of_memory)
+      ()
+  in
+  require_original_fatal_backtrace
+    ~label:"post-rename Out_of_memory"
+    ~expected:Out_of_memory
+    ~captured
+    (fun () ->
+      publish_for_testing
+        hooks
+        ~secure_random
+        ~parent
+        ~leaf
+        ~expected:absent
+        ~row:"renamed-before-fatal");
+  read ~secure_random ~parent ~leaf "post-rename fatal final read"
+  |> check_row
+       "post-rename fatal does not erase the visible HEAD effect"
+       (Some "renamed-before-fatal")
+;;
+
+let test_settlement_fatal_preserves_backtrace_and_disk
+      ~fs
+      ~secure_random
+      ()
+  =
+  with_tmp_dir "masc_capability_head_settlement_fatal_" @@ fun directory ->
+  let leaf = "HEAD" in
+  with_parent ~fs directory @@ fun parent ->
+  let absent = read ~secure_random ~parent ~leaf "settlement fatal fixture" in
+  let captured = ref None in
+  let hooks =
+    Head.For_testing.hooks
+      ~on_resource_settlement:(fun () ->
+        raise_with_captured_backtrace captured Stack_overflow)
+      ()
+  in
+  require_original_fatal_backtrace
+    ~label:"settlement Stack_overflow"
+    ~expected:Stack_overflow
+    ~captured
+    (fun () ->
+      publish_for_testing
+        hooks
+        ~secure_random
+        ~parent
+        ~leaf
+        ~expected:absent
+        ~row:"durable-before-settlement-fatal");
+  read ~secure_random ~parent ~leaf "settlement fatal final read"
+  |> check_row
+       "settlement fatal does not erase the durable HEAD effect"
+       (Some "durable-before-settlement-fatal")
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
@@ -829,6 +974,18 @@ let () =
             (test_after_verified_failure_reports_published ~fs ~secure_random)
         ; test_case "settlement warning preserves success" `Quick
             (test_resource_settlement_warning_preserves_success
+               ~fs
+               ~secure_random)
+        ; test_case "pre-publication fatal preserves backtrace and disk" `Quick
+            (test_pre_publication_fatal_preserves_backtrace_and_disk
+               ~fs
+               ~secure_random)
+        ; test_case "post-rename fatal preserves backtrace and disk" `Quick
+            (test_post_rename_fatal_preserves_backtrace_and_disk
+               ~fs
+               ~secure_random)
+        ; test_case "settlement fatal preserves backtrace and disk" `Quick
+            (test_settlement_fatal_preserves_backtrace_and_disk
                ~fs
                ~secure_random)
         ] )


### PR DESCRIPTION
## Summary

- re-raise `Out_of_memory`, `Stack_overflow`, and `Sys.Break` from every generic `Capability_head` exception boundary with the original raw backtrace
- keep `Eio.Cancel.Cancelled` separate so the existing effect-first pre-publication escape and post-effect typed settlement semantics remain authoritative
- prove pre-rename, post-rename, and resource-settlement fatal behavior through existing private testing hooks, including the resulting HEAD disk effect

## Boundary

- no production fault-injection API
- no change to `Published`, `Publication_indeterminate`, `Unchanged`, or settlement-warning authority
- no provider/model/runtime policy

## Validation

Not run locally per current coordination policy. PR CI is the validation authority.
