### PR TITLE
feat(keeper): raise compaction on a declared-byte capacity refusal

### DIFF
--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -1,9 +1,19 @@
 type t =
   | Provider_overflow of { limit_tokens : int option }
+  | Request_body_over_capacity of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
   | Manual
+
+(* Field names are the wire contract for [of_detail_json]; naming them once keeps
+   the encoder and the decoder from drifting apart. *)
+let actual_bytes_field = "actual_bytes"
+let limit_bytes_field = "limit_bytes"
 
 let to_label = function
   | Provider_overflow _ -> "provider_overflow"
+  | Request_body_over_capacity _ -> "request_body_over_capacity"
   | Manual -> "manual"
 ;;
 
@@ -14,6 +24,8 @@ let to_human = function
       (match limit_tokens with
        | Some limit_tokens -> string_of_int limit_tokens
        | None -> "unknown")
+  | Request_body_over_capacity { actual_bytes; limit_bytes } ->
+    Printf.sprintf "request_body_over_capacity(%dB>%dB)" actual_bytes limit_bytes
   | Manual -> "manual"
 ;;
 
@@ -25,6 +37,12 @@ let to_detail_json : t -> Yojson.Safe.t = function
         , match limit_tokens with
           | Some limit_tokens -> `Int limit_tokens
           | None -> `Null )
+      ]
+  | Request_body_over_capacity { actual_bytes; limit_bytes } ->
+    `Assoc
+      [ "kind", `String "request_body_over_capacity"
+      ; actual_bytes_field, `Int actual_bytes
+      ; limit_bytes_field, `Int limit_bytes
       ]
   | Manual -> `Assoc [ "kind", `String "manual" ]
 ;;
@@ -38,6 +56,12 @@ type decode_error =
   | Unknown_kind of string
   | Missing_provider_limit
   | Invalid_provider_limit
+  | Missing_request_body_bytes of string
+  | Invalid_request_body_bytes of string
+  | Request_body_within_capacity of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
 
 let decode_error_to_string = function
   | Expected_object -> "compaction trigger detail must be an object"
@@ -51,6 +75,15 @@ let decode_error_to_string = function
   | Missing_provider_limit -> "provider overflow trigger is missing limit_tokens"
   | Invalid_provider_limit ->
     "provider overflow limit_tokens must be null or a positive integer"
+  | Missing_request_body_bytes field ->
+    Printf.sprintf "request body over capacity trigger is missing %s" field
+  | Invalid_request_body_bytes field ->
+    Printf.sprintf "request body over capacity %s must be a positive integer" field
+  | Request_body_within_capacity { actual_bytes; limit_bytes } ->
+    Printf.sprintf
+      "request body over capacity requires actual_bytes > limit_bytes, got %d and %d"
+      actual_bytes
+      limit_bytes
 ;;
 
 let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
@@ -77,6 +110,24 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
           Ok (Provider_overflow { limit_tokens = Some limit_tokens })
         | None -> Error Missing_provider_limit
         | Some _ -> Error Invalid_provider_limit)
+     | Some (`String "request_body_over_capacity") ->
+       let* () =
+         reject_unknown_fields [ "kind"; actual_bytes_field; limit_bytes_field ]
+       in
+       let positive_int field =
+         match List.assoc_opt field fields with
+         | Some (`Int value) when value > 0 -> Ok value
+         | None -> Error (Missing_request_body_bytes field)
+         | Some _ -> Error (Invalid_request_body_bytes field)
+       in
+       let* actual_bytes = positive_int actual_bytes_field in
+       let* limit_bytes = positive_int limit_bytes_field in
+       (* The name asserts a comparison, so a record that does not satisfy it is
+          not a value of this type. Decoding it would put a trigger claiming
+          over-capacity in front of a compaction that had no capacity reason. *)
+       if actual_bytes > limit_bytes
+       then Ok (Request_body_over_capacity { actual_bytes; limit_bytes })
+       else Error (Request_body_within_capacity { actual_bytes; limit_bytes })
      | Some (`String "manual") ->
        let* () = reject_unknown_fields [ "kind" ] in
        Ok Manual

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -4,6 +4,21 @@ type t =
   | Provider_overflow of { limit_tokens : int option }
       (** Typed provider context-window overflow. [limit_tokens] is the
           provider-declared limit when present, never an estimated count. *)
+  | Request_body_over_capacity of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
+      (** The serialized request body exceeded the byte capacity the target
+          declares. Both integers are measured, never estimated:
+          [Agent_sdk.Retry.Request_body_too_large] carries them from the
+          serialization OAS performs before any HTTP call, so
+          [actual_bytes > limit_bytes] already held upstream and
+          {!of_detail_json} rejects a record where it does not.
+
+          Separate from {!Provider_overflow} because the unit differs. A byte
+          refusal says nothing about the provider's token window, so folding it
+          into [limit_tokens] would have to report [None] — an unknown limit for
+          a limit that is known exactly. *)
   | Manual
 
 (** Closed label set for Otel_metric_store / SSE [trigger] label.
@@ -25,6 +40,12 @@ type decode_error =
   | Unknown_kind of string
   | Missing_provider_limit
   | Invalid_provider_limit
+  | Missing_request_body_bytes of string
+  | Invalid_request_body_bytes of string
+  | Request_body_within_capacity of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
 
 val decode_error_to_string : decode_error -> string
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -744,13 +744,22 @@ let prepare_compaction_with
     Keeper_meta_contract.compaction_retry_suspended meta.runtime.compaction_rt
   in
   match trigger with
-  | Compaction_trigger.Provider_overflow _ when suspended ->
+  (* The suspension guard follows the trigger's origin, not its axis. Both
+     capacity triggers are raised by the turn path itself, so a suspended retry
+     must refuse them or a keeper whose compactions keep failing would keep
+     re-entering compaction on every turn. [Manual] stays exempt: an operator
+     asked for this one, and refusing it would leave no way to intervene. *)
+  | Compaction_trigger.Provider_overflow _
+  | Compaction_trigger.Request_body_over_capacity _
+    when suspended ->
     Error
       (Retry_suspended
          { consecutive_failures =
              meta.runtime.compaction_rt.consecutive_failures
          })
-  | Compaction_trigger.Provider_overflow _ | Compaction_trigger.Manual ->
+  | Compaction_trigger.Provider_overflow _
+  | Compaction_trigger.Request_body_over_capacity _
+  | Compaction_trigger.Manual ->
     prepare_compaction_admitted
       ~compact_for_request
       ~base_dir

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -401,12 +401,63 @@ let turn_event_bus_evidence_detail
     summary.event_count
     (String.concat "," summary.payload_kinds)
 
-let context_overflow_event_of_error
-    (err : Agent_sdk.Error.sdk_error) : Keeper_state_machine.event option =
+type capacity_refusal =
+  | Provider_context_window of { limit_tokens : int option }
+  | Serialized_request_body of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
+
+(* Variants are enumerated rather than closed with [_ -> None] so a new SDK error
+   forces a decision here. The catch-all this replaces is why the byte axis was
+   invisible: [Request_body_too_large] carries two measured integers and fell
+   through as "not a capacity refusal", so a request that provably exceeded the
+   target's declared byte limit produced no compaction request at all. *)
+let capacity_refusal_of_error (err : Agent_sdk.Error.sdk_error) : capacity_refusal option =
   match err with
   | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) ->
-    Some (Keeper_state_machine.Context_overflow_detected { limit_tokens = limit })
-  | _ -> None
+    Some (Provider_context_window { limit_tokens = limit })
+  | Agent_sdk.Error.Api
+      (InvalidRequest { reason = Request_body_too_large { actual_bytes; limit_bytes }; _ })
+    ->
+    Some (Serialized_request_body { actual_bytes; limit_bytes })
+  | Agent_sdk.Error.Api
+      (InvalidRequest { reason = Json_parse_error | Unknown_invalid_request; _ }) ->
+    (* A malformed request is a defect in what was built, not a size the target
+       refused. Compacting would send the same defect at a smaller size. *)
+    None
+  | Agent_sdk.Error.Api (InputCapacity _) ->
+    (* A third axis, not yet carried: [Serving_constraint.admission_error] measures
+       input *tokens* against probed serving evidence (input_tokens,
+       accepted_through, rejected_from), so it needs its own trigger variant
+       rather than being folded into either axis above. Reaching masc at all means
+       OAS already advanced through every candidate
+       (oas exact_output.ml:924-925), which is where a reduction request belongs. *)
+    None
+  | Agent_sdk.Error.Api
+      ( RateLimited _ | Overloaded _ | ServerError _ | AuthError _
+      | AuthorizationError _ | PaymentRequired _ | NotFound _ | NetworkError _
+      | Timeout _ )
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ -> None
+
+(* Projection for the two token-axis call sites. Both publish
+   reason="provider_context_overflow" and the [Sdk_context_window_exceeded]
+   blocker class (keeper_unified_turn_execution.ml:485-509), labels that would be
+   wrong for a declared-byte refusal, so this projection admits only the context
+   window. Byte refusals reach compaction through {!capacity_refusal_of_error}. *)
+let context_overflow_event_of_error
+    (err : Agent_sdk.Error.sdk_error) : Keeper_state_machine.event option =
+  match capacity_refusal_of_error err with
+  | Some (Provider_context_window { limit_tokens }) ->
+    Some (Keeper_state_machine.Context_overflow_detected { limit_tokens })
+  | Some (Serialized_request_body _) | None -> None
 
 (* Prefix that tags a [last_compaction_decision] value as a provider-overflow
    recovery failure. Kept as a named binding so the observability regression test

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -191,11 +191,31 @@ val turn_event_bus_evidence_detail :
 (** Compact forensic string for observed OAS events around a typed provider
     failure. *)
 
+type capacity_refusal =
+  | Provider_context_window of { limit_tokens : int option }
+  | Serialized_request_body of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
+(** Why a target refused to serve a request for its size. One closed set for both
+    measured axes: a provider-declared token window and a declared serialized-body
+    byte limit. The units are not interchangeable, so neither axis is expressed in
+    the other's field. *)
+
+val capacity_refusal_of_error :
+  Agent_sdk.Error.sdk_error ->
+  capacity_refusal option
+(** Classify a typed SDK error as a capacity refusal. Every SDK variant is
+    enumerated, so adding one forces a decision here instead of returning [None]
+    by default. *)
+
 val context_overflow_event_of_error :
   Agent_sdk.Error.sdk_error ->
   Keeper_state_machine.event option
-(** [Some] only for typed [Api (ContextOverflow _)]. Other errors return
-    [None]. *)
+(** The context-window axis of {!capacity_refusal_of_error} as a lifecycle event.
+    [Some] only for [Provider_context_window]; a byte refusal returns [None]
+    because this projection's call sites label the failure as a context-window
+    exceedance. *)
 
 val provider_overflow_decision : reason:string -> string
 (** The [compaction_rt.last_decision] value stamped by [record_overflow_failure]

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -212,13 +212,36 @@ let recover_provider_context_overflow_in_lane
       ~(meta : keeper_meta)
       error
   =
-  match context_overflow_event_of_error error with
+  match capacity_refusal_of_error error with
   | None -> Not_provider_overflow
-  | Some
-      ((Keeper_state_machine.Context_overflow_detected { limit_tokens }) as
-       overflow_event) ->
+  | Some refusal ->
     let origin = Keeper_registry.Post_turn_lifecycle in
-    let trigger = Compaction_trigger.Provider_overflow { limit_tokens } in
+    let trigger =
+      match refusal with
+      | Keeper_turn_runtime_budget.Provider_context_window { limit_tokens } ->
+        Compaction_trigger.Provider_overflow { limit_tokens }
+      | Keeper_turn_runtime_budget.Serialized_request_body { actual_bytes; limit_bytes }
+        -> Compaction_trigger.Request_body_over_capacity { actual_bytes; limit_bytes }
+    in
+    (* [Context_overflow_detected] is the only event that latches
+       [context_overflow] (keeper_state_machine.ml:214), the flag the lane needs
+       before it will admit a compaction, and that flag is axis-agnostic. Its
+       payload is read only for the "overflowed" lifecycle log line
+       (keeper_state_machine.ml:287-291), so a byte refusal carries no token limit
+       and that one line reads limit=unknown. The measured bytes are not lost:
+       they travel on [trigger] into the durable compaction record. Reshaping the
+       event payload into a closed capacity-evidence sum is the follow-up — it
+       touches keeper_state_machine_json.ml, a durable codec, so it needs a schema
+       migration rather than riding along here. *)
+    let overflow_event =
+      Keeper_state_machine.Context_overflow_detected
+        { limit_tokens =
+            (match refusal with
+             | Keeper_turn_runtime_budget.Provider_context_window { limit_tokens } ->
+               limit_tokens
+             | Keeper_turn_runtime_budget.Serialized_request_body _ -> None)
+        }
+    in
     let dispatch stage event =
       match
         dispatch_keeper_phase_event_result
@@ -369,12 +392,6 @@ let recover_provider_context_overflow_in_lane
                    (Printexc.to_string cleanup_exn));
              Printexc.raise_with_backtrace exn backtrace
            | exn -> retry_after_started (Printexc.to_string exn))))
-  | Some event ->
-    Log.Keeper.error
-      ~keeper_name:meta.name
-      "context overflow classifier returned a non-overflow event: %s"
-      (Keeper_state_machine.event_to_string event);
-    Not_provider_overflow
 ;;
 
 let append_provider_overflow_manifest

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -35,8 +35,37 @@ let test_provider_overflow_trigger_roundtrip () =
        | Ok _ | Error _ -> fail "typed compaction trigger did not round-trip")
     [ trigger
     ; Compaction_trigger.Provider_overflow { limit_tokens = None }
+    ; Compaction_trigger.Request_body_over_capacity
+        { actual_bytes = 1_048_577; limit_bytes = 1_048_576 }
     ; Compaction_trigger.Manual
     ]
+;;
+
+let test_request_body_over_capacity_rejects_non_refusals () =
+  let decode fields =
+    Compaction_trigger.of_detail_json
+      (`Assoc (("kind", `String "request_body_over_capacity") :: fields))
+  in
+  (* The label asserts actual > limit. A record that satisfies the field shape but
+     not the comparison describes a request that fit, so decoding it would put a
+     capacity trigger in front of a compaction that had no capacity reason. *)
+  (match decode [ "actual_bytes", `Int 100; "limit_bytes", `Int 100 ] with
+   | Error
+       (Compaction_trigger.Request_body_within_capacity
+          { actual_bytes = 100; limit_bytes = 100 }) -> ()
+   | Ok _ | Error _ -> fail "an equal-size request body was admitted as over capacity");
+  (match decode [ "actual_bytes", `Int 200 ] with
+   | Error (Compaction_trigger.Missing_request_body_bytes "limit_bytes") -> ()
+   | Ok _ | Error _ -> fail "a trigger missing limit_bytes was admitted");
+  (match decode [ "actual_bytes", `Int 0; "limit_bytes", `Int 10 ] with
+   | Error (Compaction_trigger.Invalid_request_body_bytes "actual_bytes") -> ()
+   | Ok _ | Error _ -> fail "a zero-byte body was admitted as a measurement");
+  match
+    decode
+      [ "actual_bytes", `Int 200; "limit_bytes", `Int 100; "limit_tokens", `Int 5 ]
+  with
+  | Error (Compaction_trigger.Unknown_field "limit_tokens") -> ()
+  | Ok _ | Error _ -> fail "the token field was accepted on the byte axis"
 ;;
 
 let test_retired_trigger_kinds_are_rejected () =
@@ -250,6 +279,8 @@ let () =
         test_provider_overflow_trigger_roundtrip;
       test_case "retired trigger kinds rejected" `Quick
         test_retired_trigger_kinds_are_rejected;
+      test_case "request body over capacity rejects non-refusals" `Quick
+        test_request_body_over_capacity_rejects_non_refusals;
       test_case "malformed trigger details are typed errors" `Quick
         test_malformed_trigger_details_are_typed_errors;
       test_case "happy path" `Quick test_happy_path;

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -90,6 +90,57 @@ let test_context_overflow_is_auto_recoverable () =
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 })))
 ;;
 
+module Budget = Masc.Keeper_turn_runtime_budget
+
+let request_body_too_large ~actual_bytes ~limit_bytes =
+  Agent_sdk.Error.Api
+    (InvalidRequest
+       { message = "serialized request body exceeds the declared limit"
+       ; reason = Agent_sdk.Retry.Request_body_too_large { actual_bytes; limit_bytes }
+       })
+;;
+
+(* The byte axis used to fall through [| _ -> None] and produce no compaction
+   request at all, so these two assertions are the ones that failed before. *)
+let test_byte_axis_is_a_capacity_refusal () =
+  (match
+     Budget.capacity_refusal_of_error
+       (request_body_too_large ~actual_bytes:2_000_000 ~limit_bytes:1_048_576)
+   with
+   | Some
+       (Budget.Serialized_request_body
+          { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }) -> ()
+   | Some (Budget.Serialized_request_body _) ->
+     fail "the measured byte pair was not carried through"
+   | Some (Budget.Provider_context_window _) ->
+     fail "a byte refusal was classified on the token axis"
+   | None -> fail "a declared-byte refusal was not classified as a capacity refusal");
+  match
+    Budget.capacity_refusal_of_error
+      (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 }))
+  with
+  | Some (Budget.Provider_context_window { limit_tokens = Some 32768 }) -> ()
+  | Some _ | None -> fail "the context window axis regressed"
+;;
+
+(* The projection feeding the cascade path publishes
+   reason="provider_context_overflow" and the Sdk_context_window_exceeded blocker
+   class, so admitting a byte refusal there would label it as a window exceedance. *)
+let test_event_projection_admits_only_the_token_axis () =
+  (match
+     Budget.context_overflow_event_of_error
+       (request_body_too_large ~actual_bytes:2_000_000 ~limit_bytes:1_048_576)
+   with
+   | None -> ()
+   | Some _ -> fail "a byte refusal was projected as a context-overflow event");
+  match
+    Budget.context_overflow_event_of_error
+      (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None }))
+  with
+  | Some (Keeper_state_machine.Context_overflow_detected { limit_tokens = None }) -> ()
+  | Some _ | None -> fail "the context overflow event projection regressed"
+;;
+
 let () =
   run
     "keeper_unified_context_overflow"
@@ -106,6 +157,14 @@ let () =
             "input capacity is not context overflow"
             `Quick
             test_input_capacity_is_not_context_overflow
+        ; test_case
+            "declared-byte refusal is a capacity refusal"
+            `Quick
+            test_byte_axis_is_a_capacity_refusal
+        ; test_case
+            "event projection admits only the token axis"
+            `Quick
+            test_event_projection_admits_only_the_token_axis
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

선언된 바이트 용량을 초과한 요청이 컴팩션 요청으로 이어지게 한다. 지금은 이어지지 않는다.

`keeper_turn_runtime_budget.ml:404-409` 이 SDK 에러를 lifecycle 이벤트로 분류하면서 `| _ -> None` catch-all 로 닫혀 있었고, `Retry.InvalidRequest { reason = Request_body_too_large { actual_bytes; limit_bytes } }` 가 그리로 떨어졌다. 타깃이 선언한 바이트 한계를 **증명 가능하게** 넘은 요청이 "오버플로 아님"으로 기록되고, 컴팩션 요청이 나가지 않고, 다음 턴이 같은 크기의 요청을 다시 보낸다.

masc 는 이미 두 정수를 JSON 으로 내보내고 있었다 (`keeper_event_bridge_error_json.ml:176-181`). 숫자는 보이는데 아무도 그걸로 판단하지 않는 상태였다.

## 변경

**`capacity_refusal` — 측정 축의 닫힌 집합** (`keeper_turn_runtime_budget.mli`)

| 변형 | 의미 |
|---|---|
| `Provider_context_window { limit_tokens : int option }` | provider 가 *보고한* 토큰 창. 안 보낼 수도 있으므로 `option` |
| `Serialized_request_body { actual_bytes; limit_bytes }` | OAS 가 HTTP 호출 전에 직렬화하며 *측정한* 바이트. 둘 다 필수 |

`capacity_refusal_of_error` 는 SDK 변형을 전수 열거한다. catch-all 을 없앴으므로 새 에러가 추가되면 이 지점에서 컴파일 타임에 결정을 강제받는다. 그중 두 결정은 우연이 아니라 명시적이다.

- 잘못된 형식의 요청은 *만든 것의 결함*이지 *거부된 크기*가 아니다. 컴팩션하면 같은 결함을 더 작게 보낼 뿐이다.
- `Api (InputCapacity _)` 는 **세 번째 축**이다. 그 정수는 serving-constraint 토큰(`input_tokens`/`accepted_through`/`rejected_from`)이므로 위 두 축 어디에도 접어 넣을 수 없고 자기 변형이 필요하다. 후속으로 분리한다.

**`Compaction_trigger.Request_body_over_capacity { actual_bytes; limit_bytes }`**

토큰 필드 재사용이 아니다. 바이트를 `limit_tokens` 에 접으면 `None` 을 넣어야 하고, 이는 **정확히 아는 한계를 모른다고 기록**하는 것이다.

`of_detail_json` 은 라벨이 주장하는 비교를 강제한다: `actual_bytes > limit_bytes`, 둘 다 양수, 토큰 필드는 이 축에서 거부. 필드 모양은 맞지만 비교가 성립하지 않는 레코드는 *들어맞은 요청*을 서술하므로, 그것을 받아들이면 용량 이유가 없는 컴팩션 앞에 용량 트리거가 붙는다.

**타입을 좁혀 런타임 검사 하나가 삭제됐다**

회복 경로 끝에 `| Some event -> Log.error "context overflow classifier returned a non-overflow event"` 가 있었다. 분류기가 `event option`(생성자 20+)을 반환하는데 하나만 기대했기 때문에 존재한 분기다. 생성자 2개 합타입으로 좁히자 컴파일러가 그 arm 을 도달 불가로 증명했다.

**`keeper_post_turn` suspension 가드는 축이 아니라 출처를 따른다**

두 용량 트리거 모두 턴 경로가 스스로 올리므로, retry 가 정지된 keeper 는 둘 다 거부해야 한다. 그러지 않으면 컴팩션이 계속 실패하는 keeper 가 매 턴 컴팩션에 재진입한다. `Manual` 은 면제 — 운영자가 요청한 것이고, 거부하면 개입 수단이 없어진다. 이 결정은 컴파일러가 강제했다(exhaustive match, 빠질 catch-all 이 없다).

## 남긴 것과 이유

lifecycle dispatch 는 여전히 `Context_overflow_detected` 를 보낸다. 그것이 `context_overflow` 를 래치하는 유일한 이벤트이고(`keeper_state_machine.ml:214`), 그 플래그는 lane 이 컴팩션을 수용하기 전에 필요하며 **축에 무관**하다. payload 는 "overflowed" 로그 한 줄에서만 읽히므로(`:287-291`) 바이트 거부일 때 그 한 줄이 `limit=unknown` 으로 남는다. 측정된 바이트는 유실되지 않는다 — 트리거를 타고 durable 컴팩션 레코드로 간다.

이벤트 payload 를 닫힌 evidence 합타입으로 바꾸는 것은 **별개 변경**이다. `keeper_state_machine_json.ml` 이 그것을 durable 하게 인코딩하므로 스키마 마이그레이션이 필요하고, 같은 변환의 부분 적용이 아니라 다른 층의 다른 작업이다.

## 로컬 검증

```
dune exec test/test_keeper_unified_context_overflow.exe   5 tests  (2 new)
dune exec test/test_keeper_overflow_recovery.exe          9 tests  (1 new + roundtrip 확장)
dune exec test/test_pbt_context_overflow.exe              2 tests
dune exec test/test_keeper_post_turn_wirein_order.exe     14 tests
dune exec test/test_keeper_turn_driver_failover.exe       21 tests
```

51 tests, 전부 통과. 새 케이스 2개는 이 변경 없이는 실패한다.

## 미검증

- 라이브 fleet 에서 바이트 거부가 실제로 발생해 컴팩션이 완주하는 것은 확인하지 않았다. runtime-indifference 스펙의 G-6(라이브 루프)이 그 질문이고 별도로 남아 있다.
- `dune build @runtest` 전체는 돌리지 않았다. 영향 범위(분류기 + 트리거 소비자)를 참조로 찾아 해당 스위트만 실행했다.

RFC-WAIVED: 변경 범위가 credential/identity/repo/operator/sandbox/hooks/workflow 중 어디에도 해당하지 않는다. `lib/keeper/` 의 턴 에러 분류와 `lib/compaction_trigger/` 의 변형 추가이며, RFC 발견 체크가 지정한 subsystem 밖이다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
