### PR TITLE
fix(keeper): durable store 네임스페이스를 row schema version 에서 파생 (#25287 5번째 사례)

### DIFF
--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -39,6 +39,19 @@ let protect ~module_name ~finally_label ~finally f =
 
 let masc_dirname = ".masc"
 
+(* The storage namespace is DERIVED from the row schema version rather than
+   tracked beside it as a second constant. #25197 was caused by exactly that
+   drift: the namespace string and the row schema were independent literals, so
+   one could advance without the other. Deriving removes the pair. *)
+let generation_namespaced_dir ~parent_dir ~schema_version =
+  if schema_version < 1
+  then
+    invalid_arg
+      (Printf.sprintf
+         "Common.generation_namespaced_dir: schema_version must be >= 1, got %d"
+         schema_version);
+  Filename.concat parent_dir (Printf.sprintf "v%d" schema_version)
+
 (* OUTPUT root segment for server-written keeper runtime state (meta json +
    metrics/memory/decisions/receipts sidecars). The SINGLE literal behind both
    keeper-dir SSOT functions; the input/output relocation (RFC) flips this one

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -45,6 +45,33 @@ val masc_dir_from_base_path : base_path:string -> string
     [Filename.concat base_path masc_dirname]. Canonical way to spell
     [<base_path>/.masc]. *)
 
+val generation_namespaced_dir : parent_dir:string -> schema_version:int -> string
+(** [<parent_dir>/v<schema_version>]: the storage namespace a durable store must
+    use, derived from the row schema version it reads and writes.
+
+    A store that spells its directory this way cannot present bytes of one
+    schema version to a reader compiled for another: bumping [schema_version]
+    relocates the whole store, so the new reader starts on an empty namespace
+    instead of rejecting the old rows in place. That in-place rejection is the
+    repeated failure tracked by #25287 — five instances in 2026-07 (#25078,
+    #25197, #25231, #25135, and the board-attention partition v5/v6 hard cut
+    this function is introduced for), each of which took live state off the hot
+    path with no reader that could still decode it.
+
+    Retirement is NON-DESTRUCTIVE and this function performs no I/O: rows of a
+    retired version stay exactly where they were written, directly under
+    [parent_dir]. Nothing here deletes, moves, or rewrites them, and nothing
+    here reports them — a store whose retired namespace may hold rows an
+    operator still needs must provide its own drain or export path.
+
+    Raises [Invalid_argument] when [schema_version < 1]; version 0 is the
+    [Safe_ops.json_int ~default:0] miss value and must never name a namespace.
+
+    Adopting this in a store that already holds live rows at the flat path is
+    only safe when those rows are of the CURRENT version — they would otherwise
+    be relocated out from under a reader that can still decode them. Such a
+    store needs a relocation step first, not just this function. *)
+
 val keepers_runtime_dirname : string
 (** OUTPUT root segment for server-written keeper runtime state. Single literal
     behind both keeper-dir SSOT functions; the input/output relocation flips it. *)

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -576,8 +576,17 @@ let of_yojson json =
     }
 ;;
 
+(* Namespaced by [schema_version] so a bump relocates the store instead of
+   making the new reader reject the old rows where they lie. The v5 rows this
+   reader used to reject in place stay under the parent directory; every one of
+   them was a terminal partition, so nothing in flight is left behind. *)
 let partition_dir base_path =
-  Filename.concat (Common.masc_dir_from_base_path ~base_path) "board_attention_partitions"
+  Common.generation_namespaced_dir
+    ~parent_dir:
+      (Filename.concat
+         (Common.masc_dir_from_base_path ~base_path)
+         "board_attention_partitions")
+    ~schema_version
 ;;
 
 let path ~base_path ~keeper_name =

--- a/lib/keeper/keeper_board_attention_partition.mli
+++ b/lib/keeper/keeper_board_attention_partition.mli
@@ -10,6 +10,14 @@
 module Candidate = Keeper_board_attention_candidate
 module Generation = Keeper_board_attention_partition_generation
 
+val schema_version : int
+(** Row schema this module reads and writes. The store's directory is derived
+    from it via {!Common.generation_namespaced_dir}, so bumping this constant
+    relocates the whole ledger and the new reader starts on an empty namespace
+    instead of rejecting the previous version's rows in place. Exposed so a
+    test can assert the path carries this version rather than restating the
+    integer. *)
+
 module Worker_epoch : sig
   type t
 

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -33,9 +33,13 @@ module Event_id_set = Set.Make (String)
 
 (* The storage namespace and row schema advance together.  A generation hard
    cut never scans or writes an older namespace, so retired data cannot remain
-   on the exact-evidence hot path or become a second authority. *)
-let storage_generation = "v4"
-let schema = "keeper.reaction_ledger." ^ storage_generation
+   on the exact-evidence hot path or become a second authority.
+
+   Both are now derived from one integer rather than kept as a namespace string
+   beside a row schema string. #25197 was that drift: two independent literals,
+   one of which could advance alone. *)
+let schema_version = 4
+let schema = Printf.sprintf "keeper.reaction_ledger.v%d" schema_version
 
 let stimulus_kind_to_string = function
   | Board_signal -> "board_signal"
@@ -139,11 +143,12 @@ let urgency_to_string = function
 ;;
 
 let store_dir ~masc_root ~keeper_name =
-  Filename.concat
-    (Filename.concat
-       (Filename.concat (Filename.concat masc_root "keepers") keeper_name)
-       "reaction-ledger")
-    storage_generation
+  Common.generation_namespaced_dir
+    ~parent_dir:
+      (Filename.concat
+         (Filename.concat (Filename.concat masc_root "keepers") keeper_name)
+         "reaction-ledger")
+    ~schema_version
 ;;
 
 let store_for_base_path ~base_path ~keeper_name =

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -71,6 +71,44 @@ let test_protect_preserves_exception () =
   in
   check (option string) "main exception preserved" (Some "main") raised
 
+(* #25287: a durable store must namespace itself by the row schema version it
+   reads, so bumping the version relocates the store instead of leaving the new
+   reader to reject the old bytes where they lie. *)
+let test_generation_dir_carries_version () =
+  check
+    string
+    "namespace is the version segment under the parent"
+    (Filename.concat "/tmp/store" "v6")
+    (Common.generation_namespaced_dir ~parent_dir:"/tmp/store" ~schema_version:6)
+
+let test_generation_dir_separates_versions () =
+  let v5 = Common.generation_namespaced_dir ~parent_dir:"/tmp/store" ~schema_version:5 in
+  let v6 = Common.generation_namespaced_dir ~parent_dir:"/tmp/store" ~schema_version:6 in
+  check bool "consecutive versions never share a directory" false (String.equal v5 v6);
+  (* The reader must not reach the retired rows by walking down from its own
+     namespace either: v5 is a sibling of v6, not an ancestor or descendant. *)
+  check bool "retired namespace is not inside the active one" false
+    (String.starts_with ~prefix:(v6 ^ Filename.dir_sep) v5);
+  check bool "active namespace is not inside the retired one" false
+    (String.starts_with ~prefix:(v5 ^ Filename.dir_sep) v6)
+
+(* Version 0 is what [Safe_ops.json_int ~default:0] yields on a missing or
+   malformed schema_version field. Letting it name a directory would give every
+   undecodable row a shared home that no reader claims. *)
+let test_generation_dir_rejects_non_positive () =
+  List.iter
+    (fun schema_version ->
+       check
+         bool
+         (Printf.sprintf "schema_version %d is refused" schema_version)
+         true
+         (match
+            Common.generation_namespaced_dir ~parent_dir:"/tmp/store" ~schema_version
+          with
+          | (_ : string) -> false
+          | exception Invalid_argument _ -> true))
+    [ 0; -1 ]
+
 let () =
   run "Common" [
     "finalizer_guard", [
@@ -78,5 +116,11 @@ let () =
       test_case "finalizer error no raise" `Quick test_protect_finally_error_no_raise;
       test_case "finalizer error raise" `Quick test_protect_finally_error_raise;
       test_case "preserve main exception" `Quick test_protect_preserves_exception;
+    ];
+    "generation_namespaced_dir", [
+      test_case "carries the schema version" `Quick test_generation_dir_carries_version;
+      test_case "separates versions" `Quick test_generation_dir_separates_versions;
+      test_case "rejects non-positive versions" `Quick
+        test_generation_dir_rejects_non_positive;
     ];
   ]

--- a/test/test_keeper_board_attention_partition.ml
+++ b/test/test_keeper_board_attention_partition.ml
@@ -1056,6 +1056,50 @@ let test_predispatch_rejection_chain_binds_oas_selected_third_slot () =
   | _ -> Alcotest.fail "third OAS-selected slot was not bindable"
 ;;
 
+(* #25287 5th instance: a v6 reader met a ledger of v5 rows at the same path and
+   raised Candidate_unavailable on every keeper cycle (2026-07-26, sangsu: 157
+   of 157 cycle exceptions). The ledger path must therefore carry the schema
+   version, so a bump relocates the store rather than rejecting the old rows
+   where they lie. *)
+let test_ledger_path_is_namespaced_by_schema_version () =
+  let path = P.For_testing.path ~base_path:"/tmp/base" ~keeper_name:"sangsu" in
+  let parent = Filename.dirname path in
+  Alcotest.(check string)
+    "the ledger sits directly under a version segment"
+    (Printf.sprintf "v%d" P.schema_version)
+    (Filename.basename parent);
+  Alcotest.(check string)
+    "and that segment sits under the store family directory"
+    "board_attention_partitions"
+    (Filename.basename (Filename.dirname parent))
+
+(* The reader must not merely reject retired rows — it must not reach them. A
+   v5 ledger left at the pre-namespace path is invisible, so load reports an
+   empty store rather than the fatal decode error that took the cycle down. *)
+let test_retired_namespace_is_never_read_in_place () =
+  with_temp_base "board-attention-partition-retired" @@ fun base_path ->
+  let active = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  (* The pre-namespace layout: the ledger lived directly in the family dir. *)
+  let retired_dir = Filename.dirname (Filename.dirname active) in
+  let retired = Filename.concat retired_dir "sangsu.jsonl" in
+  Unix.mkdir (Filename.dirname retired_dir) 0o700;
+  Unix.mkdir retired_dir 0o700;
+  let oc = open_out retired in
+  output_string
+    oc
+    {|{"schema_version":5,"partition_id":"p1","keeper_name":"sangsu","context_key":"k","candidate_id":"c1","created_at":1.0,"state":"ready"}
+|};
+  close_out oc;
+  Alcotest.(check bool)
+    "the retired ledger is still on disk — retirement never deletes"
+    true
+    (Sys.file_exists retired);
+  Alcotest.(check (list string))
+    "and the active namespace reports an empty store, not a decode failure"
+    []
+    (ok "load over a retired namespace" (P.load ~base_path ~keeper_name:"sangsu")
+     |> List.map (fun (_ : P.t) -> "unexpected partition"))
+
 let () =
   Alcotest.run
     "keeper_board_attention_partition"
@@ -1112,6 +1156,14 @@ let () =
             "invalid or mismatched provenance never rewrites"
             `Quick
             test_invalid_or_mismatched_provenance_never_rewrites
+        ; Alcotest.test_case
+            "ledger path is namespaced by schema version"
+            `Quick
+            test_ledger_path_is_namespaced_by_schema_version
+        ; Alcotest.test_case
+            "a retired namespace is never read in place"
+            `Quick
+            test_retired_namespace_is_never_read_in_place
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

v6 partition 리더가 같은 경로에서 v5 행을 만나 keeper 사이클마다 `Candidate_unavailable` 을 raise 한다. 2026-07-26 기준 sangsu 사이클 예외 **157건 중 157건**이 이 원인이고, board-attention 판정 레인이 fleet-wide 0 이다.

```
sangsu: keeper cycle exception (recorded as turn failure):
  Masc.Keeper_board_attention_candidate.Candidate_unavailable(
    "unsupported Board attention partition schema version 5")
Raised at Masc__Keeper_heartbeat_loop.run_keepalive_unified_turn, keeper_heartbeat_loop.ml:1112
```

부팅은 성공하고 서버는 healthy 로 보고한다. keeper 턴 시점에만 터지므로 startup preflight 로는 잡을 수 없다.

**#25287 이 추적 중인 클래스의 5번째 사례**다 (#25078, #25197, #25231, #25135). 매번 durable store 의 schema version 을 올리면서 새 리더가 이전 버전 바이트를 **그 자리에서** 거부하게 뒀다.

## 수정

디렉터리를 버전에서 파생시킨다. `Common.generation_namespaced_dir` 가 store 를 `<parent>/v<schema_version>` 아래 둬서, 버전을 올리면 store 가 이동하고 새 리더는 빈 네임스페이스에서 시작한다. **"리더 버전 ≠ 파일 버전"이 경로 수준에서 표현 불가능해진다.**

소비자 2곳이 채택한다:

- `keeper_board_attention_partition` — 깨진 쪽. 이동이 무손실임을 라이브 원장으로 확인했다. 222행을 partition_id 별 최신 상태로 접으면 **37/37 전부 terminal `settled`**, advancing 0.
- `keeper_reaction_ledger` — 이미 같은 모양을 자유 문자열(`"v4"`)로 손수 구현하고 있었고, 그 문자열과 row schema 가 별개 상수였던 게 정확히 #25197 의 드리프트 원인이다. 이제 정수 하나에서 둘 다 파생하며 경로는 바이트 동일(`.../reaction-ledger/v4`).

## 채택하지 않은 곳과 그 이유

`keeper_board_attention_candidate` 는 **의도적으로 제외**했다. 라이브 원장이 v3 이고 리더도 v3 을 원한다 — 일치하며 정상 동작 중이다.

```
apc-alpha v=3 rows=93 / apc-beta v=3 rows=85 / apc-gamma v=3 rows=66
kinobot-frontend v=3 rows=4 / rondo v=3 rows=1 / sangsu v=3 rows=43
```

지금 옮기면 **292행(그중 pending candidate 255건)이 고아**가 된다. 이건 #25287 이 막으려는 바로 그 사고다. 일치하는 store 의 이동은 그 이슈 제안 (1) 의 migration primitive 가 필요하지 이 함수로 될 일이 아니다.

## 남는 것 — 이 PR 로 #25287 을 닫지 말 것

- 은퇴는 비파괴적이다. v5 행은 쓰인 자리에 그대로 남고 이 변경은 삭제도 재작성도 하지 않는다.
- 그러나 **drain/export 경로를 추가하지 않는다.** 오늘 유일한 복구 도구인 `keeper_board_attention_quarantine_command.ml:223` 은 여전히 깨진 리더를 호출한다.

## 부수 논증 — #25287 제안 (3) 은 구현 불가

"schema version 을 phantom type 으로 store 에 결속"은 원리적으로 안 된다. phantom type 은 **프로그램에 존재하는 값**을 인덱싱하는데, 여기 실패 양태는 **삭제**다. 작성자가 `let schema_version = 5` 를 6 으로 고치고 디코더를 갈아끼우면 구 타입의 값이 어디서도 생성되지 않으므로 migration 함수도 어디서도 요구되지 않는다. **코드를 지우는 것은 타입 에러가 아니다.** 이 반박은 이슈에도 게시했다.

## 검증

로컬 실행 (macOS, `dune build --root .`):

- `@check` 전체 통과
- `@test/runtest-test_common` — 7 tests, 통과
- `@test/runtest-test_keeper_board_attention_partition` — 15 tests, 통과
- `@test/runtest-test_keeper_reaction_ledger` — 26 tests, 통과
- 라이브 경로 확인: `.masc/keepers/*/reaction-ledger/v4/` 그대로

**Negative control**: `partition_dir` 을 플랫 경로로 되돌리면 신규 partition 테스트 2개가 실패한다 (`2 failures! in 0.038s. 15 tests run.`). 되돌리기 전에는 0.

테스트 내용:
- 경로가 버전 세그먼트를 담는다 (`P.schema_version` 를 SSOT 로 참조, 정수 재기술 안 함)
- 연속 버전은 형제 디렉터리 — 리더가 자기 네임스페이스에서 은퇴 네임스페이스로 걸어 들어갈 수 없다
- version 0 (`Safe_ops.json_int ~default:0` 의 miss 값) 은 `Invalid_argument`
- pre-namespace 경로의 v5 원장은 치명적 디코드 에러가 아니라 **빈 store** 로 로드된다

## 미검증

- 실제 fleet 에 배포했을 때의 거동. 로컬 테스트와 라이브 상태 판독까지만 했다.
- `test_keeper_board_attention_candidate` 의 기존 실패 2건(`non-finite lifecycle times`, `non-finite complete request`)은 **이 PR 이전부터** 실패한다. 변경 전체를 stash 하고 재현 확인했다. Yojson `Infinity value not allowed in standard JSON` 이고 CI 는 이 타깃을 실행하지 않아(`@check` 컴파일만) 드러나지 않았다. 별건.

Refs #25287

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. 변경 범위는 durable store 경로 파생(lib/core/common, lib/keeper/keeper_board_attention_partition, lib/keeper/keeper_reaction_ledger)과 테스트뿐이다.
