### PR TITLE
fix(fs): macOS 에서 O_NOFOLLOW 가 가려져 main 이 빌드되지 않는다

### DIFF
--- a/lib/fs_compat/capability_exact_read_stubs.c
+++ b/lib/fs_compat/capability_exact_read_stubs.c
@@ -6,6 +6,13 @@
 #define _POSIX_C_SOURCE 200809L
 #endif
 
+/* _POSIX_C_SOURCE alone hides the BSD extensions on Apple platforms, so
+   O_NOFOLLOW disappears from <fcntl.h> and the guard below fires. glibc
+   re-exposes them through _GNU_SOURCE, which is why Linux CI never saw this. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
## 증상

main 이 **macOS 에서 빌드되지 않는다.** `dune build @check` 가 즉시 실패한다.

```
capability_exact_read_stubs.c:21:2: error: "capability exact read requires O_NONBLOCK, O_CLOEXEC, O_NOFOLLOW, and O_NOCTTY"
capability_exact_read_stubs.c:37:43: error: use of undeclared identifier 'O_NOFOLLOW'
```

## 원인

`capability_exact_read_stubs.c` 가 `_POSIX_C_SOURCE 200809L` 을 정의한다. Apple 플랫폼에서 이 매크로는 BSD 확장을 **추가하는 게 아니라 가린다** — `O_NOFOLLOW` / `O_NOCTTY` 가 `<fcntl.h>` 에서 사라지고 파일 상단의 `#error` 가드가 발화한다.

glibc 는 같은 파일이 정의하는 `_GNU_SOURCE` 로 확장을 다시 노출하므로 **Linux CI 는 초록인 채로 통과**한다. 즉 CI 로는 구조적으로 감지 불가능하고, macOS 체크아웃만 전부 막힌다.

## 수정

`__APPLE__` 에서 `_DARWIN_C_SOURCE` 를 정의해 glibc 쪽과 같은 상태로 만든다. Linux 동작 변화 없음. `#error` 가드는 남겨둬서 플래그가 실제로 없는 플랫폼은 여전히 크게 실패한다.

## 검증

darwin 25.4.0, `dune build --root . lib/fs_compat`:

- 이 변경 없이: **exit 1** (위 에러)
- 이 변경 후: **exit 0**

`git stash` 로 변경을 뺀 상태에서 재현 확인했다.

## 미검증

Linux 에서 직접 빌드하지 않았다. `_DARWIN_C_SOURCE` 는 `__APPLE__` 가드 안에 있어 Linux 전처리에는 도달하지 않으므로 CI 가 그 부분을 증명한다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. C 전처리기 define 한 줄이다.