### PR TITLE
fix(fs): raise the Darwin feature level before fcntl.h in the exact-read stub

### DIFF
--- a/lib/fs_compat/capability_exact_read_stubs.c
+++ b/lib/fs_compat/capability_exact_read_stubs.c
@@ -2,6 +2,17 @@
 #define _GNU_SOURCE
 #endif
 
+/* Darwin gates O_NOFOLLOW, O_NOCTTY and O_CLOEXEC behind __DARWIN_C_LEVEL, and
+   defining _POSIX_C_SOURCE alone lowers that level below the point where the
+   headers declare them. The guard further down then fires and the build stops
+   with "capability exact read requires ...". glibc never showed it because
+   _GNU_SOURCE exposes everything, so CI stayed green while every macOS checkout
+   could not compile this stub — and therefore could not build any test target
+   that links fs_compat. Raise the Darwin level explicitly, before <fcntl.h>. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #endif

--- a/test/test_fs_compat_capability_exact_read.ml
+++ b/test/test_fs_compat_capability_exact_read.ml
@@ -1014,6 +1014,39 @@ let test_static_surface_and_raw_openat () =
     call
 ;;
 
+(* The flags above only exist if the headers declare them, and on Darwin
+   O_NOFOLLOW / O_NOCTTY / O_CLOEXEC sit behind __DARWIN_C_LEVEL: defining
+   _POSIX_C_SOURCE alone lowers that level below their declarations and the stub's
+   own #error fires. That is a compile break, so no behavioural test can reach it —
+   and the symlink case above cannot either, because on glibc _GNU_SOURCE exposes
+   everything and the test passes whatever the macros say. CI is Linux, so #25734
+   shipped a stub that no macOS checkout could compile and every local test target
+   linking fs_compat failed. This asserts the ordering that keeps the flags
+   visible: the Darwin level is raised, and it is raised before <fcntl.h>. *)
+let test_darwin_feature_level_precedes_fcntl () =
+  let stub =
+    load_workspace_file "lib/fs_compat/capability_exact_read_stubs.c"
+  in
+  let offset_of needle =
+    match find_substring stub needle with
+    | Some offset -> offset
+    | None -> failf "capability exact read stub does not contain %S" needle
+  in
+  let darwin_level = offset_of "_DARWIN_C_SOURCE" in
+  let fcntl_include = offset_of "#include <fcntl.h>" in
+  check
+    bool
+    "Darwin feature level is raised before <fcntl.h>"
+    true
+    (darwin_level < fcntl_include);
+  (* Raised under an __APPLE__ guard so other platforms keep their own level. *)
+  check
+    bool
+    "the Darwin level is guarded to Apple"
+    true
+    (offset_of "defined(__APPLE__)" < darwin_level)
+;;
+
 let () =
   run_helper_if_requested ();
   Eio_main.run @@ fun env ->
@@ -1060,6 +1093,8 @@ let () =
                ~process_mgr)
         ; test_case "static public surface and raw openat" `Quick
             test_static_surface_and_raw_openat
+        ; test_case "Darwin feature level precedes fcntl.h" `Quick
+            test_darwin_feature_level_precedes_fcntl
         ] )
     ]
 ;;


### PR DESCRIPTION
## 증상

macOS 에서 `main` 이 **빌드되지 않는다**. `lib/fs_compat/` 를 링크하는 모든 타깃(테스트 exe 전부 포함)이 실패한다.

```
capability_exact_read_stubs.c:21:2: error: "capability exact read requires O_NONBLOCK, O_CLOEXEC, O_NOFOLLOW, and O_NOCTTY"
capability_exact_read_stubs.c:37:43: error: use of undeclared identifier 'O_NOFOLLOW'
```

## 원인

`capability_exact_read_stubs.c:5-7` 이 `<fcntl.h>` **앞에서** `_POSIX_C_SOURCE 200809L` 를 정의한다. Darwin 은 `O_NOFOLLOW`·`O_NOCTTY`·`O_CLOEXEC` 를 `__DARWIN_C_LEVEL` 뒤에 감추고, `_POSIX_C_SOURCE` 만 정의하면 그 레벨이 선언 지점 아래로 내려간다. 그래서 파일 자신의 `#if !defined(...)` 가드(`:19-22`)가 발화한다.

glibc 는 `_GNU_SOURCE` 로 전부 보이므로 **CI(Linux)는 초록**이다. #25734 머지 이후로 CI 가 볼 수 없는 플랫폼 파손이 유지됐다.

## 수정

Apple 에서 `_DARWIN_C_SOURCE` 를 `<fcntl.h>` 앞에 명시적으로 올린다. 한 줄이고 다른 플랫폼 동작은 바뀌지 않는다(`__APPLE__` 가드).

## 검증 (Darwin 25.4.0)

| 명령 | origin/main | 이 커밋 |
|---|---|---|
| `dune build lib/fs_compat/` | 실패 | **통과** |
| `dune build test/test_keeper_failure_judgment_contract.exe` | 실패 | **통과** |

## 발견 경로

keeper failure-judgment 변경의 테스트를 로컬에서 돌리려다 막혔다. CI 초록만 보고 있으면 이 종류는 안 보인다 — 로컬 검증이 필요한 모든 작업이 조용히 막힌다.

RFC-WAIVED: C feature-macro 한 줄. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>