### PR TITLE
feat(keeper): the failure judgment walks lane candidates instead of one runtime

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -14,11 +14,26 @@ default = "ollama_cloud.deepseek-v4-flash"
 # Periodic Memory OS fact-survival consolidation is a separate task route from
 # post-turn Librarian extraction. Model/provider selection belongs only here.
 memory_os_consolidation = "ollama_cloud_native.minimax-m3-native-structured"
-# Provider-native structured-output judges must not inherit the fleet chat
-# default when that default lacks schema support. Keep this lane explicit so
-# structured judgment lanes fail at config load on typo/unsupported
-# routing instead of discovering the mismatch in the daemon loop.
-structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
+# The failure-judgment boundary must not inherit the fleet chat default: keep it
+# explicit so a typo or an unroutable id fails at config load instead of surfacing
+# in the daemon loop.
+#
+# It does NOT request a provider-native wire format. Keeper_failure_judge clears
+# both structured-output fields (keeper_failure_judge.ml apply_output_schema ->
+# Keeper_structured_output_schema.without_response_format) and states the object
+# shape in config/prompts/keeper.failure_judgment.md, then parses strictly. That is
+# why #25719 could drop the last lane-candidate capability requirement: no consumer
+# asks for a response format, so requiring candidates to declare
+# supports-response-format-json checked nothing. Candidates therefore are not
+# limited to schema-capable providers.
+#
+# A lane, not one id, because the parse can only fail on how a runtime chose to
+# format its reply. A single id has no successor, and that is what made one
+# markdown-fenced reply terminal: keeper rondo settled its lane on
+# `Invalid token '```json` and advanced no turn for the next 17.5 hours
+# (event-queue.json last_settlement, 2026-07-25T10:44Z). Candidates span providers
+# so one provider's formatting habit is not the whole boundary.
+structured_judge = "judgment_lane"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.
@@ -982,6 +997,19 @@ strategy = "ordered"
 candidates = [
   "ollama_cloud.deepseek-v4-flash",
   "deepseek.deepseek-v4-pro",
+]
+
+# Referenced by [runtime].structured_judge. The first candidate keeps the runtime
+# that route named before it became a lane, so ordinary behaviour is unchanged; the
+# rest exist for the one failure this boundary can hit, a reply whose shape the
+# strict parser rejects. Three providers, because that failure is a formatting
+# habit and a second candidate on the same provider would repeat it.
+[runtime.lanes.judgment_lane]
+strategy = "ordered"
+candidates = [
+  "ollama_cloud_native.minimax-m3-native-structured",
+  "deepseek.deepseek-v4-pro",
+  "glm-coding.glm-5-turbo",
 ]
 
 # ── Keeper assignments ──────────────────────────────────────────────

--- a/lib/keeper/keeper_failure_judge.ml
+++ b/lib/keeper/keeper_failure_judge.ml
@@ -79,10 +79,32 @@ let reject_unregistered_tool ~name ~args:_ =
     "failure judgment is a tool-free boundary"
 ;;
 
-let resolve_runtime_id () =
+(* The configured [runtime].structured_judge value may name a lane or a single
+   runtime, the same two-shape identity [runtime].cross_verifier moved to on
+   2026-07-25 (runtime.toml: "cross_verifier 는 단일 runtime id 대신 lane 을 받는다").
+   Resolving it here yields the ordered candidate list the walk in {!run} needs; a
+   single runtime is a one-element list, so both shapes take one code path. *)
+let resolve_candidates () =
   match Runtime.runtime_id_for_structured_judge () with
-  | runtime_id -> Ok runtime_id
   | exception Failure detail -> Error (Runtime_configuration_error detail)
+  | configured ->
+    (match Runtime.resolve_assignment configured with
+     | `Single_runtime _ -> Ok [ configured ]
+     | `Lane lane ->
+       (match Runtime_lane.ordered_candidates lane with
+        | [] ->
+          Error
+            (Runtime_configuration_error
+               (Printf.sprintf
+                  "failure judgment lane %s resolves to no candidate"
+                  configured))
+        | candidates -> Ok candidates)
+     | `Missing ->
+       Error
+         (Runtime_configuration_error
+            (Printf.sprintf
+               "failure judgment runtime %s names neither a runtime nor a lane"
+               configured)))
 ;;
 
 let parse_response ~runtime_id response =
@@ -96,27 +118,64 @@ let parse_response ~runtime_id response =
      | Error detail -> Error (Response_contract_error { runtime_id; detail }))
 ;;
 
+let attempt_candidate ~base_path ~keeper_name ~prompt runtime_id =
+  match
+    Keeper_turn_driver_wrappers.run_named_with_masc_tools
+      ~runtime_id
+      ~keeper_name
+      ~goal:prompt
+      ~base_path
+      ~masc_tools:[]
+      ~dispatch:reject_unregistered_tool
+      ~provider_config_transform:apply_output_schema
+      ()
+  with
+  | Error error -> Error (Oas_error { runtime_id; error })
+  | Ok result ->
+    (match parse_response ~runtime_id result.response with
+     | Error _ as error -> error
+     | Ok verdict -> Ok { runtime_id; verdict })
+;;
+
+(* Only a response-contract failure advances the walk, and the reason is what the
+   error means rather than a preference for fewer failures. The request states its
+   object shape in the prompt and asks the provider for no wire format
+   ([apply_output_schema] clears both structured-output fields), so whether the
+   reply parses is that runtime's formatting behaviour: keeper rondo settled its
+   lane on `Invalid token '```json` from glm-coding.glm-5-turbo (event-queue.json
+   last_settlement, 2026-07-25T10:44Z) and re-asking the same runtime would fence
+   again. Another candidate is a different behaviour, so the refusal orders instead
+   of ending the walk.
+
+   The other three classes do not advance. A prompt-contract error is the same for
+   every candidate; a runtime-configuration error is about the configured identity,
+   not the runtime that answered; and an [Oas_error] has already been through OAS's
+   own candidate handling, so re-walking it here would dispatch the same turn twice
+   for one stimulus. *)
+let advances_walk = function
+  | Response_contract_error _ -> true
+  | Runtime_configuration_error _ | Prompt_contract_error _ | Oas_error _ -> false
+;;
+
 let run ~base_path ~keeper_name request =
-  match resolve_runtime_id () with
+  match resolve_candidates () with
   | Error _ as error -> error
-  | Ok runtime_id ->
+  | Ok candidates ->
     (match build_prompt ~keeper_name request with
      | Error detail -> Error (Prompt_contract_error detail)
      | Ok prompt ->
-       (match
-          Keeper_turn_driver_wrappers.run_named_with_masc_tools
-            ~runtime_id
-            ~keeper_name
-            ~goal:prompt
-            ~base_path
-            ~masc_tools:[]
-            ~dispatch:reject_unregistered_tool
-            ~provider_config_transform:apply_output_schema
-            ()
-        with
-        | Error error -> Error (Oas_error { runtime_id; error })
-        | Ok result ->
-          (match parse_response ~runtime_id result.response with
-           | Error _ as error -> error
-           | Ok verdict -> Ok { runtime_id; verdict })))
+       let rec walk = function
+         | [] ->
+           (* [resolve_candidates] rejects an empty list, so the walk always holds
+              at least one candidate and this is unreachable rather than a silent
+              default. *)
+           Error
+             (Runtime_configuration_error
+                "failure judgment walk reached an empty candidate list")
+         | runtime_id :: rest ->
+           (match attempt_candidate ~base_path ~keeper_name ~prompt runtime_id with
+            | Error error when advances_walk error && rest <> [] -> walk rest
+            | (Ok _ | Error _) as outcome -> outcome)
+       in
+       walk candidates)
 ;;

--- a/lib/keeper/keeper_failure_judge.mli
+++ b/lib/keeper/keeper_failure_judge.mli
@@ -3,7 +3,12 @@
 
     Runtime/provider selection remains an OAS concern reached through the
     opaque [Runtime.runtime_id_for_structured_judge] identity. MASC supplies
-    one provider-neutral JSON schema and strictly decodes the response. *)
+    one provider-neutral JSON schema and strictly decodes the response.
+
+    That identity may name a lane or a single runtime, the two-shape value
+    [runtime].cross_verifier already carries. When it names a lane, a response
+    that does not satisfy the contract advances to the next candidate instead of
+    ending the walk — see {!advances_walk} for which failures do that and why. *)
 
 type run_error =
   | Runtime_configuration_error of string
@@ -27,14 +32,32 @@ type error_disposition = Escalate_judge_failure
 val error_detail : run_error -> string
 val error_disposition : run_error -> error_disposition
 val error_disposition_label : error_disposition -> string
-(** A failure of the single configured structured-judge boundary terminates the
-    judgment stimulus explicitly. There is no alternate judge runtime to rotate
-    to; process-local observations are not durable retry authority. *)
+(** A failure that survives the whole candidate walk terminates the judgment
+    stimulus explicitly; process-local observations are not durable retry
+    authority. Before 2026-07-26 this also read "there is no alternate judge
+    runtime to rotate to", which described a single-id identity — a lane now
+    supplies candidates and {!advances_walk} says which failures use them. *)
 
-val resolve_runtime_id : unit -> (string, run_error) result
-(** Resolve the configured structured-judge lane used by {!run}. Configuration
-    errors are returned explicitly when the durable stimulus executes; they do
-    not become pre-claim admission authority. *)
+val advances_walk : run_error -> bool
+(** Whether this failure should be re-asked of the next lane candidate.
+
+    True only for {!Response_contract_error}. The request states its object shape
+    in the prompt and asks the provider for no wire format, so whether the reply
+    parses is that runtime's formatting behaviour and another candidate is a
+    different behaviour. False for the other three: a prompt-contract error is
+    identical for every candidate, a runtime-configuration error is about the
+    configured identity rather than the runtime that answered, and an
+    {!Oas_error} has already been through OAS's own candidate handling, so
+    walking it again would dispatch the same turn twice for one stimulus. *)
+
+val resolve_candidates : unit -> (string list, run_error) result
+(** Ordered candidates for {!run}, from the configured structured-judge identity.
+    A lane yields its ordered candidates; a single runtime yields a one-element
+    list, so both shapes take one code path. An empty lane and an identity that
+    names neither are configuration errors rather than an empty walk.
+
+    Configuration errors are returned explicitly when the durable stimulus
+    executes; they do not become pre-claim admission authority. *)
 
 val build_prompt :
   keeper_name:string ->

--- a/test/test_keeper_failure_judgment_contract.ml
+++ b/test/test_keeper_failure_judgment_contract.ml
@@ -14,6 +14,111 @@ let expect_error label json =
   | Ok _ -> failf "%s unexpectedly decoded" label
 ;;
 
+module Judge = Keeper_failure_judge
+
+let response_contract_error =
+  Judge.Response_contract_error
+    { runtime_id = "glm-coding.glm-5-turbo"
+    ; detail = "JSON parse error: Invalid token '```json"
+    }
+;;
+
+let oas_error =
+  Judge.Oas_error
+    { runtime_id = "glm-coding.glm-5-turbo"
+    ; error =
+        Agent_sdk.Error.Api
+          (Llm_provider.Retry.RateLimited { retry_after = None; message = "slow down" })
+    }
+;;
+
+(* The fence in [response_contract_error] is the live shape: keeper rondo settled its
+   lane on it (event-queue.json last_settlement, 2026-07-25T10:44Z) and stopped
+   advancing turns. Only that class may re-ask the next candidate; the enumeration is
+   exhaustive so a new error class has to make this decision explicitly. *)
+let test_only_a_response_contract_failure_advances_the_walk () =
+  check bool "a fenced reply is re-asked of the next candidate" true
+    (Judge.advances_walk response_contract_error);
+  check bool "an OAS error does not re-walk what OAS already walked" false
+    (Judge.advances_walk oas_error);
+  check bool "a prompt contract error is identical for every candidate" false
+    (Judge.advances_walk (Judge.Prompt_contract_error "template missing"));
+  check bool "a configuration error is about the identity, not the answer" false
+    (Judge.advances_walk (Judge.Runtime_configuration_error "no structured judge"))
+;;
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    output_string oc content)
+;;
+
+let runtime_toml ~judge =
+  Printf.sprintf
+    {|
+[runtime]
+default = "p.first"
+structured_judge = "%s"
+
+[runtime.lanes.judge_lane]
+strategy = "ordered"
+candidates = [ "p.first", "p.second" ]
+
+[providers.p]
+display-name = "P"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.first]
+api-name = "first"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[models.second]
+api-name = "second"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[p.first]
+is-default = true
+max-concurrent = 1
+
+[p.second]
+max-concurrent = 1
+|}
+    judge
+;;
+
+let require_candidates = function
+  | Ok candidates -> candidates
+  | Error error -> fail (Judge.error_detail error)
+;;
+
+let init_runtime ~judge =
+  let path = Filename.temp_file "failure_judgment_runtime_" ".toml" in
+  write_file path (runtime_toml ~judge);
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error detail -> failf "Runtime.init_default failed: %s" detail
+;;
+
+(* One code path for both shapes of the configured identity: a lane contributes its
+   ordered candidates, a single runtime contributes itself. Before this the judge
+   resolved one id, so a runtime that would not honour the contract had no successor. *)
+let test_lane_identity_yields_ordered_candidates () =
+  init_runtime ~judge:"judge_lane";
+  check (list string) "lane order is preserved" [ "p.first"; "p.second" ]
+    (Judge.resolve_candidates () |> require_candidates)
+;;
+
+let test_single_runtime_identity_yields_one_candidate () =
+  init_runtime ~judge:"p.second";
+  check (list string) "a single runtime is a one-element walk" [ "p.second" ]
+    (Judge.resolve_candidates () |> require_candidates)
+;;
+
 let test_resume_with_guidance () =
   let verdict =
     Contract.of_yojson
@@ -240,6 +345,20 @@ let () =
             "guidance binds exact observation"
             `Quick
             test_guidance_binds_exact_observation
+        ] )
+    ; ( "candidate_walk"
+      , [ test_case
+            "only a response contract failure advances"
+            `Quick
+            test_only_a_response_contract_failure_advances_the_walk
+        ; test_case
+            "lane identity yields ordered candidates"
+            `Quick
+            test_lane_identity_yields_ordered_candidates
+        ; test_case
+            "single runtime identity yields one candidate"
+            `Quick
+            test_single_runtime_identity_yields_one_candidate
         ] )
     ]
 ;;

--- a/test/test_keeper_failure_judgment_contract.ml
+++ b/test/test_keeper_failure_judgment_contract.ml
@@ -119,6 +119,36 @@ let test_single_runtime_identity_yields_one_candidate () =
     (Judge.resolve_candidates () |> require_candidates)
 ;;
 
+(* Nothing loaded the config this repository ships, so a seed that no longer parses
+   or a judgment identity that resolves to one id would reach a new install
+   unnoticed. Reading the shipped file rather than a fixture is the point: the
+   fixture above proves the resolver, this proves what operators actually get. *)
+let shipped_runtime_config () =
+  let candidates = [ "config/runtime.toml"; Filename.concat ".." "config/runtime.toml" ] in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None -> fail "shipped config/runtime.toml not found"
+;;
+
+let test_shipped_config_gives_the_judgment_boundary_a_successor () =
+  (match Runtime.init_default ~config_path:(shipped_runtime_config ()) with
+   | Ok () -> ()
+   | Error detail -> failf "shipped config/runtime.toml does not load: %s" detail);
+  let candidates = Judge.resolve_candidates () |> require_candidates in
+  (* One candidate is the shape that made a fenced reply terminal. *)
+  check bool "the shipped judgment identity has a successor" true
+    (List.length candidates > 1);
+  check bool "candidates are distinct" true
+    (List.length (List.sort_uniq compare candidates) = List.length candidates);
+  let provider id = match String.index_opt id '.' with
+    | Some i -> String.sub id 0 i
+    | None -> id
+  in
+  (* A second candidate on the same provider would repeat the formatting habit. *)
+  check bool "candidates span more than one provider" true
+    (List.length (List.sort_uniq compare (List.map provider candidates)) > 1)
+;;
+
 let test_resume_with_guidance () =
   let verdict =
     Contract.of_yojson
@@ -359,6 +389,10 @@ let () =
             "single runtime identity yields one candidate"
             `Quick
             test_single_runtime_identity_yields_one_candidate
+        ; test_case
+            "shipped config gives the judgment boundary a successor"
+            `Quick
+            test_shipped_config_gives_the_judgment_boundary_a_successor
         ] )
     ]
 ;;

--- a/test/test_keeper_failure_judgment_contract.ml
+++ b/test/test_keeper_failure_judgment_contract.ml
@@ -119,10 +119,13 @@ let test_single_runtime_identity_yields_one_candidate () =
     (Judge.resolve_candidates () |> require_candidates)
 ;;
 
-(* Nothing loaded the config this repository ships, so a seed that no longer parses
-   or a judgment identity that resolves to one id would reach a new install
-   unnoticed. Reading the shipped file rather than a fixture is the point: the
-   fixture above proves the resolver, this proves what operators actually get. *)
+(* test_runtime_config_validity.ml already loads the shipped seed and pins the
+   configured judgment id as a literal, which is a drift guard on the value. This
+   asserts the property that value has to satisfy: the boundary has a successor at
+   all, and the candidates are not one provider's formatting habit repeated. A pinned
+   string cannot say that — it would still pass if the lane were narrowed to a single
+   candidate on one provider. The fixture above proves the resolver; this proves what
+   an operator actually gets. *)
 let shipped_runtime_config () =
   let candidates = [ "config/runtime.toml"; Filename.concat ".." "config/runtime.toml" ] in
   match List.find_opt Sys.file_exists candidates with

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -754,10 +754,14 @@ let test_repo_runtime_toml_loads () =
       "Memory OS consolidation runtime"
       (Some "ollama_cloud_native.minimax-m3-native-structured")
       memory_os_consolidation;
+    (* A lane id, not a runtime id: the failure-judgment boundary needs a successor
+       because the only failure it can hit is how a runtime chose to format its
+       reply. The lane keeps the previously pinned runtime as its first candidate,
+       so routing for a healthy reply is unchanged. *)
     check
       (option string)
       "structured judge runtime"
-      (Some "ollama_cloud_native.minimax-m3-native-structured")
+      (Some "judgment_lane")
       structured_judge;
     (match Runtime_toml.parse_file path with
      | Error _ -> fail "repo runtime.toml exact-output lanes must parse"


### PR DESCRIPTION
> **커밋 메시지 정정**: 커밋 본문에 "Narrowing also deleted a runtime check … `| Some event -> Log.error \"context overflow classifier returned a non-overflow event\"`" 라고 적었는데 **이 변경의 일이 아니다**. 그 방어 분기 삭제는 `keeper_unified_turn.ml` 의 G-5 작업(별도 브랜치)에서 일어났다. 이 diff 는 그런 arm 을 지우지 않는다. 강제 push 대신 여기서 바로잡는다.

## 증상 (라이브)

keeper `rondo` 가 **17.5시간 동안 턴을 0개 진행**했다. 원인은 응답 하나가 마크다운 펜스로 감싸여 온 것이다.

`~/me/.masc/keepers/rondo/event-queue.json` `last_settlement`, 2026-07-25T10:44:57Z:

```
kind=escalate  reason=failure_judgment_boundary_failed
detail: failure judgment response contract on runtime glm-coding.glm-5-turbo:
        JSON parse error: Line 1, bytes 0-34: Invalid token '```json\n{\n  "decision": "await_ex'
```

이후 `leases: []`, `pending.length = 0`, 파일 mtime 무변경. 원장 6샘플(2026-07-26T04:00~04:28Z)에서 `total_turns` 8439 고정.

## 무엇이 종료를 만들었는가

형식을 요청하지 않는 것 자체는 **설계다**. `apply_output_schema` 가 두 structured-output 필드를 비우고(`keeper_failure_judge.ml:71-73`), `without_response_format` 의 독스트링(`keeper_structured_output_schema.mli:52-60`)이 전제를 명시한다 — "프롬프트가 객체 모양을 적고 **파서가 total 한** 호출부에 쓰라". 파서는 실제로 total 하다.

종료를 만든 것은 **물어볼 다른 곳이 없었다는 사실**이다. `resolve_runtime_id` 가 id 하나를 돌려주고, id 하나에는 후속이 없다.

## 변경

`[runtime].structured_judge` 값은 **이미** 레인일 수도 단일 런타임일 수도 있다 — `[runtime].cross_verifier` 가 2026-07-25 에 옮겨간 그 두-형태 값이다. `resolve_candidates` 가 `Runtime.resolve_assignment`(`runtime.mli:275`)와 `Runtime_lane.ordered_candidates`(`runtime_lane.mli:18`)로 해석한다: 레인은 순서 있는 후보를, 단일 런타임은 자기 자신을 낸다. **한 코드 경로, 새 추상화 0, 카운터 0, 새 settlement 종류 0, durable 스키마 변경 0.**

`advances_walk` 를 인라인하지 않고 노출한 이유는 리뷰어가 따질 결정이기 때문이다. `Response_contract_error` 만 전진하고 나머지 셋은 전진하지 않으며, **이유가 하나의 정책이 아니라 각각 다르다**:

| 에러 | 전진 | 이유 |
|---|---|---|
| `Response_contract_error` | ✅ | 형식은 그 런타임의 행동이고 다른 후보는 다른 행동이다 |
| `Prompt_contract_error` | ❌ | 모든 후보에게 동일하다 |
| `Runtime_configuration_error` | ❌ | 답한 런타임이 아니라 설정된 identity 에 관한 것이다 |
| `Oas_error` | ❌ | OAS 자신의 후보 처리를 이미 거쳤다 — 다시 걸으면 한 stimulus 에 같은 턴을 두 번 디스패치한다 |

match 가 exhaustive 이므로 새 에러 등급은 이 결정을 **명시적으로** 해야 한다.

## 로컬 검증 (Darwin 25.4.0)

`dune exec test/test_keeper_failure_judgment_contract.exe` — **9/9 통과**, 신규 3종:

- `only a response contract failure advances` — 4개 등급 전수를 `advances_walk` 로 확인
- `lane identity yields ordered candidates` — 실제 TOML fixture 로 `Runtime.init_default` 를 거쳐 `["p.first"; "p.second"]` 순서 확인
- `single runtime identity yields one candidate` — 단일 런타임이 1-원소 워크

테스트 exe 빌드에 **#25746 이 로컬 적용되어야 했다** (main 이 macOS 에서 `fs_compat` C stub 을 컴파일하지 못한다). 그 수정은 이 diff 에 없다.

## 미검증

- 라이브에서 실제로 후보 2번이 계약을 만족시키는 것은 확인하지 않았다. 현재 `runtime.toml:76` 이 "구조화 출력을 서비스할 수 있는 provider 는 glm-coding 하나뿐"이라 적고 있어, 이 변경이 라이브에서 효과를 내려면 **`structured_judge` 에 레인을 설정하고 그 레인에 2개 이상 후보를 두는 config 작업이 선행**한다. 지금 라이브에는 `structured_judge` 키가 아예 없어 default 로 폴백한다(`runtime.ml:1190-1194`).
- `dune build @runtest` 전체는 돌리지 않았다. 영향 범위(judge + 그 단일 소비자 `keeper_heartbeat_loop_cycle.ml:143`)를 참조로 찾아 해당 스위트만 실행했다.

## 관련

- #25742 — 이 원인 사슬의 이슈. A안(형식 실패 비종료)의 대안으로 제시했던 재시도 천장보다 이 정렬 방식이 좁다.
- #25746 — 로컬 빌드 선행.
- docs/fusion-judge-single-tier (#25743) — 같은 `without_response_format` 을 쓰는 형제 호출부의 문서 정정.

RFC-WAIVED: `lib/keeper/` 의 turn 에러 처리와 런타임 identity 해석. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
