### PR TITLE
test(fs): pin the Darwin feature level ordering the exact-read flags depend on

### DIFF
--- a/test/test_fs_compat_capability_exact_read.ml
+++ b/test/test_fs_compat_capability_exact_read.ml
@@ -1014,6 +1014,39 @@ let test_static_surface_and_raw_openat () =
     call
 ;;
 
+(* The flags above only exist if the headers declare them, and on Darwin
+   O_NOFOLLOW / O_NOCTTY / O_CLOEXEC sit behind __DARWIN_C_LEVEL: defining
+   _POSIX_C_SOURCE alone lowers that level below their declarations and the stub's
+   own #error fires. That is a compile break, so no behavioural test can reach it —
+   and the symlink case above cannot either, because on glibc _GNU_SOURCE exposes
+   everything and the test passes whatever the macros say. CI is Linux, so #25734
+   shipped a stub that no macOS checkout could compile and every local test target
+   linking fs_compat failed. This asserts the ordering that keeps the flags
+   visible: the Darwin level is raised, and it is raised before <fcntl.h>. *)
+let test_darwin_feature_level_precedes_fcntl () =
+  let stub =
+    load_workspace_file "lib/fs_compat/capability_exact_read_stubs.c"
+  in
+  let offset_of needle =
+    match find_substring stub needle with
+    | Some offset -> offset
+    | None -> failf "capability exact read stub does not contain %S" needle
+  in
+  let darwin_level = offset_of "_DARWIN_C_SOURCE" in
+  let fcntl_include = offset_of "#include <fcntl.h>" in
+  check
+    bool
+    "Darwin feature level is raised before <fcntl.h>"
+    true
+    (darwin_level < fcntl_include);
+  (* Raised under an __APPLE__ guard so other platforms keep their own level. *)
+  check
+    bool
+    "the Darwin level is guarded to Apple"
+    true
+    (offset_of "defined(__APPLE__)" < darwin_level)
+;;
+
 let () =
   run_helper_if_requested ();
   Eio_main.run @@ fun env ->
@@ -1060,6 +1093,8 @@ let () =
                ~process_mgr)
         ; test_case "static public surface and raw openat" `Quick
             test_static_surface_and_raw_openat
+        ; test_case "Darwin feature level precedes fcntl.h" `Quick
+            test_darwin_feature_level_precedes_fcntl
         ] )
     ]
 ;;


### PR DESCRIPTION
#25745 로 파손은 고쳐졌지만, `test_static_surface_and_raw_openat` 이 단정하는 `O_NOFOLLOW|O_NOCTTY|O_CLOEXEC` 가 **보이게 유지하는 매크로 순서를 아무도 고정하지 않는다**. 같은 파손이 다시 들어올 수 있다.

동작 테스트로는 도달할 수 없다. 파손이 컴파일 실패이고, 기존 symlink 케이스(`:345-366`)도 잡지 못한다 — glibc 는 `_GNU_SOURCE` 로 전부 보이므로 매크로가 어떻든 통과한다. 그래서 이웃 테스트와 같은 방식(stub 소스 읽기)으로 두 순서를 단정한다: `_DARWIN_C_SOURCE` 가 올라가는지, 그리고 `<fcntl.h>` **앞에서** 올라가는지, `__APPLE__` 가드 아래.

**구현 무관하다**: #25745 는 `_DARWIN_C_SOURCE` 를 `_POSIX_C_SOURCE` 뒤에 두고 내 원래 안(#25746)은 앞에 두었다. 이 테스트는 둘 다 통과한다 — 요구하는 것은 `<fcntl.h>` 보다 앞이라는 사실뿐이다.

## 검증 (Darwin 25.4.0, main = d2364f2aa2)

`dune exec test/test_fs_compat_capability_exact_read.exe` — 신규 케이스 #17 통과.

## 이 PR 범위 밖 — main 의 Darwin 실패 하나

빌드가 열리자 기존 실패가 드러난다: `#15 fatal backtrace propagation` → `fatal callback helper exited with code 4`. 18 중 17 통과. CI(Linux)는 이 케이스를 통과시키므로 Darwin 전용이다. 이 PR 에서 건드리지 않았고 별도 이슈로 남긴다.

#25746 을 이 PR 로 대체한다 (그쪽 `.c` 변경은 #25745 와 중복이므로 제거).

RFC-WAIVED: 테스트 추가만. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>