### PR TITLE
feat(memory-os): add read-only existing store projection

### DIFF
--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -1786,9 +1786,13 @@ let store_identity_warnings values =
     values
 ;;
 
-let read_store_identity_with_exact_read exact_read ~root ~owner_id =
+let read_store_identity_with_missing_warnings
+      ~on_missing_warnings
+      ~root
+      ~owner_id
+  =
   match
-    exact_read
+    Exact_read.read
       ~parent:root
       ~leaf:store_identity_leaf
       ~expected_length:store_identity_byte_count
@@ -1799,7 +1803,9 @@ let read_store_identity_with_exact_read exact_read ~root ~owner_id =
     (match failure.error with
      | Exact_read.Missing ->
        let warnings =
-         store_identity_warnings failure.settlement_warnings
+         failure.settlement_warnings
+         |> on_missing_warnings
+         |> store_identity_warnings
        in
        (match warnings with
         | [] -> Ok None
@@ -1844,8 +1850,11 @@ let read_store_identity_with_exact_read exact_read ~root ~owner_id =
        else Ok (Some (identity, warnings)))
 ;;
 
-let read_store_identity =
-  read_store_identity_with_exact_read Exact_read.read
+let read_store_identity ~root ~owner_id =
+  read_store_identity_with_missing_warnings
+    ~on_missing_warnings:Fun.id
+    ~root
+    ~owner_id
 ;;
 
 let private_root_entries root =
@@ -3756,10 +3765,18 @@ module For_testing = struct
       Current_head_settlement_warning_tag
   ;;
 
-  let read_store_identity_with_exact_hooks hooks ~root ~owner_id =
+  let read_store_identity_with_parent_settlement_failure ~root ~owner_id =
+    let on_missing_warnings warnings =
+      warnings
+      @ [ Exact_read.Settle_resources
+            { operation = Exact_read.Settle_parent_resources
+            ; detail = "injected parent settlement failure"
+            }
+        ]
+    in
     match
-      read_store_identity_with_exact_read
-        (Exact_read.For_testing.read ~hooks)
+      read_store_identity_with_missing_warnings
+        ~on_missing_warnings
         ~root
         ~owner_id
     with

--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -1786,9 +1786,9 @@ let store_identity_warnings values =
     values
 ;;
 
-let read_store_identity ~root ~owner_id =
+let read_store_identity_with_exact_read exact_read ~root ~owner_id =
   match
-    Exact_read.read
+    exact_read
       ~parent:root
       ~leaf:store_identity_leaf
       ~expected_length:store_identity_byte_count
@@ -1797,7 +1797,17 @@ let read_store_identity ~root ~owner_id =
   | Error failure ->
     let failure : Exact_read.failure = failure in
     (match failure.error with
-     | Exact_read.Missing -> Ok None
+     | Exact_read.Missing ->
+       let warnings =
+         store_identity_warnings failure.settlement_warnings
+       in
+       (match warnings with
+        | [] -> Ok None
+        | _ ->
+          Error
+            (make_error
+               ~settlement_warnings:warnings
+               (Store_identity_read_failed Exact_read.Missing)))
      | failure_kind ->
        Error
          (make_error
@@ -1832,6 +1842,10 @@ let read_store_identity ~root ~owner_id =
               (Invalid_store_identity
                  "owner binding does not match the opened owner"))
        else Ok (Some (identity, warnings)))
+;;
+
+let read_store_identity =
+  read_store_identity_with_exact_read Exact_read.read
 ;;
 
 let private_root_entries root =
@@ -3740,6 +3754,18 @@ module For_testing = struct
       Store_identity_settlement_warning_tag
     | Current_head_settlement_warning _ ->
       Current_head_settlement_warning_tag
+  ;;
+
+  let read_store_identity_with_exact_hooks hooks ~root ~owner_id =
+    match
+      read_store_identity_with_exact_read
+        (Exact_read.For_testing.read ~hooks)
+        ~root
+        ~owner_id
+    with
+    | Ok None -> Ok false
+    | Ok (Some _) -> Ok true
+    | Error error -> Error error
   ;;
 
   let publish_with_head_hooks hooks store prepared =

--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -2598,16 +2598,21 @@ let read_existing_current_head ~root ~owner_id =
              in
              Ok (Some loaded)
          in
+         let verified_warnings =
+           match verified with
+           | None -> opening_warnings
+           | Some loaded -> loaded.warnings
+         in
          let* final_identity =
            read_store_identity ~root ~owner_id
-           |> with_prior_warnings opening_warnings
+           |> with_prior_warnings verified_warnings
          in
          let* final_identity_warnings =
            match final_identity with
            | None ->
              Error
                (make_error
-                  ~settlement_warnings:opening_warnings
+                  ~settlement_warnings:verified_warnings
                   (Invalid_store_identity
                      "identity disappeared during verified read"))
            | Some (final, warnings) ->
@@ -2617,36 +2622,35 @@ let read_existing_current_head ~root ~owner_id =
                Error
                  (make_error
                     ~settlement_warnings:
-                      (opening_warnings @ warnings)
+                      (verified_warnings @ warnings)
                     (Invalid_store_identity
                        "identity changed during verified read"))
          in
          let* final_row, final_head_warnings =
            read_existing_head_row ~root
            |> with_prior_warnings
-                (opening_warnings @ final_identity_warnings)
+                (verified_warnings @ final_identity_warnings)
          in
          if first_row <> final_row
          then
            Error
-             (make_error
-                ~settlement_warnings:
-                  (opening_warnings
-                   @ final_identity_warnings
-                   @ final_head_warnings)
-                Current_head_changed_during_read)
+              (make_error
+                 ~settlement_warnings:
+                   (verified_warnings
+                    @ final_identity_warnings
+                    @ final_head_warnings)
+                 Current_head_changed_during_read)
          else
-           let current_head, verified_warnings =
+           let current_head =
              match verified with
-             | None -> Empty, opening_warnings
+             | None -> Empty
              | Some loaded ->
-               ( Present
-                   { receipt_id = loaded.commit.receipt_id
-                   ; operation_id = loaded.commit.operation_id
-                   ; state_digest = loaded.commit.state_sha256
-                   ; generation = loaded.head.generation
-                   }
-               , loaded.warnings )
+               Present
+                 { receipt_id = loaded.commit.receipt_id
+                 ; operation_id = loaded.commit.operation_id
+                 ; state_digest = loaded.commit.state_sha256
+                 ; generation = loaded.head.generation
+                 }
            in
            Ok
              (Existing
@@ -3670,6 +3674,8 @@ module For_testing = struct
     | Store_identity_create_failed_error
     | Store_identity_read_failed_error
     | Invalid_store_identity_error
+    | Current_head_read_failed_error
+    | Current_head_changed_during_read_error
     | Invalid_publication_obligation_error
     | Publication_obligation_owner_mismatch_error
     | Publication_obligation_store_mismatch_error
@@ -3681,6 +3687,7 @@ module For_testing = struct
     | Head_indeterminate_warning_tag
     | Immutable_settlement_warning_tag
     | Store_identity_settlement_warning_tag
+    | Current_head_settlement_warning_tag
 
   let error_tag (value : error) =
     match value.kind with

--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -99,6 +99,7 @@ type settlement_warning =
   | Head_indeterminate_warning of Head.error
   | Immutable_settlement_warning of immutable_ref * Exact_read.settlement_warning
   | Store_identity_settlement_warning of Exact_read.settlement_warning
+  | Current_head_settlement_warning of Exact_read.settlement_warning
 
 type error_kind =
   | Invalid_layout of string
@@ -141,6 +142,8 @@ type error_kind =
   | Store_identity_create_failed of Fs_compat.capability_write_error
   | Store_identity_read_failed of Exact_read.error
   | Invalid_store_identity of string
+  | Current_head_read_failed of Exact_read.error
+  | Current_head_changed_during_read
   | Invalid_publication_obligation of string
   | Publication_obligation_owner_mismatch of
       { obligation_owner_id : string
@@ -315,6 +318,24 @@ type recovery_outcome =
   | Recovered_committed of commit_receipt
   | Recovered_not_published of snapshot
   | Recovered_superseded of snapshot
+
+type current_head_projection =
+  { receipt_id : Sha256.t
+  ; operation_id : string
+  ; state_digest : Sha256.t
+  ; generation : int64
+  }
+
+type current_head =
+  | Empty
+  | Present of current_head_projection
+
+type existing_store =
+  | Absent
+  | Existing of
+      { current_head : current_head
+      ; settlement_warnings : settlement_warning list
+      }
 
 module Canonical_bytes = struct
   type sink =
@@ -924,6 +945,13 @@ let settlement_warning_to_string = function
       (Exact_read.Settle_resources diagnostic) ->
     "store identity parent resource settlement warning: "
     ^ exact_read_diagnostic_to_string diagnostic
+  | Current_head_settlement_warning (Exact_read.Close_failed diagnostic) ->
+    "current HEAD close failed: "
+    ^ exact_read_diagnostic_to_string diagnostic
+  | Current_head_settlement_warning
+      (Exact_read.Settle_resources diagnostic) ->
+    "current HEAD parent resource settlement warning: "
+    ^ exact_read_diagnostic_to_string diagnostic
 ;;
 
 let error_settlement_warnings (value : error) = value.settlement_warnings
@@ -1039,6 +1067,11 @@ let error_to_string (value : error) =
     ^ exact_read_error_to_string failure
   | Invalid_store_identity detail ->
     "invalid Memory OS store identity: " ^ detail
+  | Current_head_read_failed failure ->
+    "failed to read existing Memory OS HEAD: "
+    ^ exact_read_error_to_string failure
+  | Current_head_changed_during_read ->
+    "existing Memory OS HEAD changed during verified read"
   | Invalid_publication_obligation detail ->
     "invalid Memory OS publication obligation: " ^ detail
   | Publication_obligation_owner_mismatch
@@ -1572,10 +1605,23 @@ let warnings_of_exact (reference : immutable_ref) values =
     values
 ;;
 
-let read_object_raw (store : t) (reference : immutable_ref) =
+type read_context =
+  { root : Eio.Fs.dir_ty Eio.Path.t
+  ; owner_id : string
+  ; store_id : string
+  }
+
+let read_context_of_store (store : t) =
+  { root = store.root
+  ; owner_id = store.owner_id
+  ; store_id = store.store_id
+  }
+;;
+
+let read_object_raw_in (context : read_context) (reference : immutable_ref) =
   match
     Exact_read.read
-      ~parent:store.root
+      ~parent:context.root
       ~leaf:reference.leaf
       ~expected_length:reference.byte_count
       ~max_length:immutable_serialization_safety_ceiling_bytes
@@ -1603,17 +1649,30 @@ let read_object_raw (store : t) (reference : immutable_ref) =
     else Ok (raw, warnings)
 ;;
 
-let read_object
-      (store : t)
+let read_object_raw store reference =
+  read_object_raw_in (read_context_of_store store) reference
+;;
+
+let read_object_in
+      (context : read_context)
       (reference : immutable_ref)
       ~artifact
       ~decode
       ~encode
   =
-  let* raw, warnings = read_object_raw store reference in
+  let* raw, warnings = read_object_raw_in context reference in
   match decode_canonical ~artifact ~decode ~encode raw with
   | Ok value -> Ok (value, warnings)
   | Error error -> Error (prepend_warnings warnings error)
+;;
+
+let read_object store reference ~artifact ~decode ~encode =
+  read_object_in
+    (read_context_of_store store)
+    reference
+    ~artifact
+    ~decode
+    ~encode
 ;;
 
 let random_token_from_source secure_random purpose =
@@ -2116,25 +2175,32 @@ let empty_snapshot (store : t) (head_snapshot : Head.snapshot) =
    : snapshot)
 ;;
 
-let load_from_head (store : t) (head_snapshot : Head.snapshot) =
-  let head_warnings =
-    store.opening_warnings
-    @ warnings_of_head (Head.snapshot_settlement_warnings head_snapshot)
-  in
-  match Head.snapshot_row head_snapshot with
-  | None -> Ok (empty_snapshot store head_snapshot)
-  | Some row ->
+type verified_head =
+  { head : head_record
+  ; commit : commit_record
+  ; manifest : manifest
+  ; episode_objects : (immutable_ref * Types.episode) list
+  ; state : state
+  ; warnings : settlement_warning list
+  }
+
+let load_verified_row
+      (context : read_context)
+      ~opening_warnings
+      row
+  =
+  let head_warnings = opening_warnings in
     let* (head : head_record) =
       head_of_row row |> with_prior_warnings head_warnings
     in
-    if not (String.equal head.owner_id store.owner_id)
+    if not (String.equal head.owner_id context.owner_id)
     then
       Error
         (make_error
            ~settlement_warnings:head_warnings
            (Persisted_store_binding_mismatch
               "HEAD owner_id does not match the opened owner"))
-    else if not (String.equal head.store_id store.store_id)
+    else if not (String.equal head.store_id context.store_id)
     then
       Error
         (make_error
@@ -2144,8 +2210,8 @@ let load_from_head (store : t) (head_snapshot : Head.snapshot) =
     else
       let commit_artifact = "commit:" ^ head.commit_ref.leaf in
       let* ((commit : commit_record), commit_warnings) =
-        read_object
-          store
+        read_object_in
+          context
           head.commit_ref
           ~artifact:commit_artifact
           ~decode:commit_record_of_json
@@ -2166,8 +2232,8 @@ let load_from_head (store : t) (head_snapshot : Head.snapshot) =
       in
       let manifest_artifact = "manifest:" ^ commit.manifest_ref.leaf in
       let* ((manifest : manifest), manifest_warnings) =
-        read_object
-          store
+        read_object_in
+          context
           commit.manifest_ref
           ~artifact:manifest_artifact
           ~decode:manifest_of_json
@@ -2188,8 +2254,8 @@ let load_from_head (store : t) (head_snapshot : Head.snapshot) =
       in
       let facts_artifact = "facts:" ^ manifest.facts_ref.leaf in
       let* ((facts_object : facts_object), facts_warnings) =
-        read_object
-          store
+        read_object_in
+          context
           manifest.facts_ref
           ~artifact:facts_artifact
           ~decode:facts_object_of_json
@@ -2224,8 +2290,8 @@ let load_from_head (store : t) (head_snapshot : Head.snapshot) =
           let artifact = "episode:" ^ reference.leaf in
           let* ((episode_object : episode_object), object_warnings) =
             match
-              read_object
-                store
+              read_object_in
+                context
                 reference
                 ~artifact
                 ~decode:episode_object_of_json
@@ -2295,20 +2361,45 @@ let load_from_head (store : t) (head_snapshot : Head.snapshot) =
                 }))
       else
         Ok
-          ({ binding = store.binding
-           ; cursor = Head.snapshot_cursor head_snapshot
-           ; head_row = Some row
-           ; store_id = Some head.store_id
-           ; generation = head.generation
-           ; commit_ref = Some head.commit_ref
-           ; commit = Some commit
-           ; manifest_ref = Some commit.manifest_ref
-           ; facts_ref = Some manifest.facts_ref
+          ({ head
+           ; commit
+           ; manifest
            ; episode_objects
            ; state
-           ; settlement_warnings = warnings
+           ; warnings
            }
-           : snapshot)
+           : verified_head)
+;;
+
+let load_from_head (store : t) (head_snapshot : Head.snapshot) =
+  let head_warnings =
+    store.opening_warnings
+    @ warnings_of_head (Head.snapshot_settlement_warnings head_snapshot)
+  in
+  match Head.snapshot_row head_snapshot with
+  | None -> Ok (empty_snapshot store head_snapshot)
+  | Some row ->
+    let* verified =
+      load_verified_row
+        (read_context_of_store store)
+        ~opening_warnings:head_warnings
+        row
+    in
+    Ok
+      ({ binding = store.binding
+       ; cursor = Head.snapshot_cursor head_snapshot
+       ; head_row = Some row
+       ; store_id = Some verified.head.store_id
+       ; generation = verified.head.generation
+       ; commit_ref = Some verified.head.commit_ref
+       ; commit = Some verified.commit
+       ; manifest_ref = Some verified.commit.manifest_ref
+       ; facts_ref = Some verified.manifest.facts_ref
+       ; episode_objects = verified.episode_objects
+       ; state = verified.state
+       ; settlement_warnings = verified.warnings
+       }
+       : snapshot)
 ;;
 
 let check_active (store : t) =
@@ -2348,6 +2439,223 @@ let with_store ~secure_random ~root ~owner_id fn =
          ; opening_warnings
          }
          : t))
+;;
+
+type existing_root =
+  | Existing_root_absent
+  | Existing_root_entries of string list
+
+let inspect_existing_root root =
+  try Ok (Existing_root_entries (Eio.Path.read_dir root)) with
+  | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _)
+  | Unix.Unix_error (Unix.ENOENT, _, _) ->
+    Ok Existing_root_absent
+  | (Eio.Cancel.Cancelled _ | Out_of_memory | Stack_overflow | Sys.Break)
+    as exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace exception_ backtrace
+  | exception_ ->
+    Error
+      (make_error
+         (Invalid_layout
+            ("failed to inspect existing private store root: "
+             ^ Printexc.to_string exception_)))
+;;
+
+let current_head_warnings values =
+  List.map
+    (fun value -> Current_head_settlement_warning value)
+    values
+;;
+
+let corrupt_existing_head detail =
+  make_error
+    (Head_operation_failed
+       { phase = "read-only"
+       ; failure = Head.Corrupt_head detail
+       })
+;;
+
+let row_of_existing_head_payload payload =
+  let length = String.length payload in
+  if length < 2
+  then
+    Error
+      (corrupt_existing_head
+         "HEAD must contain one non-empty LF-terminated row")
+  else if not (Char.equal payload.[length - 1] '\n')
+  then Error (corrupt_existing_head "HEAD is not LF-terminated")
+  else
+    let row = String.sub payload 0 (length - 1) in
+    if String.length row > Head.max_row_bytes
+    then
+      Error
+        (corrupt_existing_head "HEAD row exceeds max_row_bytes")
+    else if
+      String.exists
+        (fun char -> Char.equal char '\n' || Char.equal char '\r')
+        row
+    then
+      Error
+        (corrupt_existing_head "HEAD contains multiple rows or CR")
+    else Ok row
+;;
+
+let read_existing_head_row ~root =
+  let path = Eio.Path.(root / head_leaf) in
+  try
+    match Eio.Path.kind ~follow:false path with
+    | `Not_found -> Ok (None, [])
+    | `Regular_file ->
+      let stat = Eio.Path.stat ~follow:false path in
+      let expected_length = Optint.Int63.to_int64 stat.size in
+      let maximum = Int64.of_int (Head.max_row_bytes + 1) in
+      (match
+         Exact_read.read
+           ~parent:root
+           ~leaf:head_leaf
+           ~expected_length
+           ~max_length:maximum
+       with
+       | Error failure ->
+         let failure : Exact_read.failure = failure in
+         Error
+           (make_error
+              ~settlement_warnings:
+                (current_head_warnings failure.settlement_warnings)
+              (Current_head_read_failed failure.error))
+       | Ok observation ->
+         let warnings =
+           current_head_warnings
+             (Exact_read.observation_settlement_warnings observation)
+         in
+         let* row =
+           row_of_existing_head_payload
+             (Exact_read.observation_bytes observation)
+           |> with_prior_warnings warnings
+         in
+         Ok (Some row, warnings))
+    | `Symbolic_link ->
+      Error
+        (corrupt_existing_head "HEAD path is a symbolic link")
+    | _ ->
+      Error
+        (corrupt_existing_head "HEAD path is not a regular file")
+  with
+  | (Eio.Cancel.Cancelled _ | Out_of_memory | Stack_overflow | Sys.Break)
+    as exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace exception_ backtrace
+  | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _)
+  | Unix.Unix_error (Unix.ENOENT, _, _) ->
+    Error (make_error (Current_head_read_failed Exact_read.Missing))
+  | exception_ ->
+    Error
+      (make_error
+         (Invalid_layout
+            ("failed to inspect existing Memory OS HEAD: "
+             ^ Printexc.to_string exception_)))
+;;
+
+let read_existing_current_head ~root ~owner_id =
+  if String.trim owner_id = ""
+  then Error (make_error (Invalid_layout "owner_id must be non-empty"))
+  else
+    let* root_observation = inspect_existing_root root in
+    match root_observation with
+    | Existing_root_absent -> Ok Absent
+    | Existing_root_entries entries ->
+      let* observed_identity = read_store_identity ~root ~owner_id in
+      (match observed_identity with
+       | None ->
+         if entries = []
+         then Ok Absent
+         else
+           Error
+             (make_error
+                (Store_identity_missing_from_non_fresh_root
+                   (List.length entries)))
+       | Some (identity, identity_warnings) ->
+         let context : read_context =
+           { root; owner_id; store_id = identity.store_id }
+         in
+         let* first_row, first_head_warnings =
+           read_existing_head_row ~root
+           |> with_prior_warnings identity_warnings
+         in
+         let opening_warnings =
+           identity_warnings @ first_head_warnings
+         in
+         let* verified =
+           match first_row with
+           | None -> Ok None
+           | Some row ->
+             let* loaded =
+               load_verified_row
+                 context
+                 ~opening_warnings
+                 row
+             in
+             Ok (Some loaded)
+         in
+         let* final_identity =
+           read_store_identity ~root ~owner_id
+           |> with_prior_warnings opening_warnings
+         in
+         let* final_identity_warnings =
+           match final_identity with
+           | None ->
+             Error
+               (make_error
+                  ~settlement_warnings:opening_warnings
+                  (Invalid_store_identity
+                     "identity disappeared during verified read"))
+           | Some (final, warnings) ->
+             if String.equal final.store_id identity.store_id
+             then Ok warnings
+             else
+               Error
+                 (make_error
+                    ~settlement_warnings:
+                      (opening_warnings @ warnings)
+                    (Invalid_store_identity
+                       "identity changed during verified read"))
+         in
+         let* final_row, final_head_warnings =
+           read_existing_head_row ~root
+           |> with_prior_warnings
+                (opening_warnings @ final_identity_warnings)
+         in
+         if first_row <> final_row
+         then
+           Error
+             (make_error
+                ~settlement_warnings:
+                  (opening_warnings
+                   @ final_identity_warnings
+                   @ final_head_warnings)
+                Current_head_changed_during_read)
+         else
+           let current_head, verified_warnings =
+             match verified with
+             | None -> Empty, opening_warnings
+             | Some loaded ->
+               ( Present
+                   { receipt_id = loaded.commit.receipt_id
+                   ; operation_id = loaded.commit.operation_id
+                   ; state_digest = loaded.commit.state_sha256
+                   ; generation = loaded.head.generation
+                   }
+               , loaded.warnings )
+           in
+           Ok
+             (Existing
+                { current_head
+                ; settlement_warnings =
+                    verified_warnings
+                    @ final_identity_warnings
+                    @ final_head_warnings
+                }))
 ;;
 
 let load store =
@@ -3403,6 +3711,9 @@ module For_testing = struct
     | Store_identity_create_failed _ -> Store_identity_create_failed_error
     | Store_identity_read_failed _ -> Store_identity_read_failed_error
     | Invalid_store_identity _ -> Invalid_store_identity_error
+    | Current_head_read_failed _ -> Current_head_read_failed_error
+    | Current_head_changed_during_read ->
+      Current_head_changed_during_read_error
     | Invalid_publication_obligation _ ->
       Invalid_publication_obligation_error
     | Publication_obligation_owner_mismatch _ ->
@@ -3420,6 +3731,8 @@ module For_testing = struct
     | Immutable_settlement_warning _ -> Immutable_settlement_warning_tag
     | Store_identity_settlement_warning _ ->
       Store_identity_settlement_warning_tag
+    | Current_head_settlement_warning _ ->
+      Current_head_settlement_warning_tag
   ;;
 
   let publish_with_head_hooks hooks store prepared =

--- a/lib/keeper/keeper_memory_os_store.mli
+++ b/lib/keeper/keeper_memory_os_store.mli
@@ -38,6 +38,24 @@ type publication_obligation
 type settlement_warning
 type error
 
+type current_head_projection =
+  { receipt_id : Sha256.t
+  ; operation_id : string
+  ; state_digest : Sha256.t
+  ; generation : int64
+  }
+
+type current_head =
+  | Empty
+  | Present of current_head_projection
+
+type existing_store =
+  | Absent
+  | Existing of
+      { current_head : current_head
+      ; settlement_warnings : settlement_warning list
+      }
+
 type persisted_artifact =
   [ `Facts
   | `Episode
@@ -116,6 +134,19 @@ val with_store :
   owner_id:string ->
   (t -> ('a, error) result) ->
   ('a, error) result
+
+(** Read the current store authority without creating the private root, store
+    identity, stable HEAD lock, HEAD, or any immutable object.
+
+    A missing root or a genuinely empty root without an identity is [Absent].
+    Data without the exact current identity is rejected rather than adopted or
+    migrated. [Present] is returned only after the exact canonical HEAD framing,
+    every reachable immutable object and digest, the reconstructed state digest,
+    and a final unchanged HEAD observation have been verified. *)
+val read_existing_current_head :
+  root:Eio.Fs.dir_ty Eio.Path.t ->
+  owner_id:string ->
+  (existing_store, error) result
 
 val load : t -> (snapshot, error) result
 
@@ -236,6 +267,8 @@ module For_testing : sig
     | Store_identity_create_failed_error
     | Store_identity_read_failed_error
     | Invalid_store_identity_error
+    | Current_head_read_failed_error
+    | Current_head_changed_during_read_error
     | Invalid_publication_obligation_error
     | Publication_obligation_owner_mismatch_error
     | Publication_obligation_store_mismatch_error
@@ -247,6 +280,7 @@ module For_testing : sig
     | Head_indeterminate_warning_tag
     | Immutable_settlement_warning_tag
     | Store_identity_settlement_warning_tag
+    | Current_head_settlement_warning_tag
 
   val error_tag : error -> error_tag
   val warning_tag : settlement_warning -> warning_tag

--- a/lib/keeper/keeper_memory_os_store.mli
+++ b/lib/keeper/keeper_memory_os_store.mli
@@ -285,8 +285,7 @@ module For_testing : sig
   val error_tag : error -> error_tag
   val warning_tag : settlement_warning -> warning_tag
 
-  val read_store_identity_with_exact_hooks :
-    Fs_compat.Capability_exact_read.For_testing.hooks ->
+  val read_store_identity_with_parent_settlement_failure :
     root:Eio.Fs.dir_ty Eio.Path.t ->
     owner_id:string ->
     (bool, error) result

--- a/lib/keeper/keeper_memory_os_store.mli
+++ b/lib/keeper/keeper_memory_os_store.mli
@@ -285,6 +285,12 @@ module For_testing : sig
   val error_tag : error -> error_tag
   val warning_tag : settlement_warning -> warning_tag
 
+  val read_store_identity_with_exact_hooks :
+    Fs_compat.Capability_exact_read.For_testing.hooks ->
+    root:Eio.Fs.dir_ty Eio.Path.t ->
+    owner_id:string ->
+    (bool, error) result
+
   (** Exercise the production publication state machine with deterministic
       hooks from the underlying capability-relative HEAD primitive. *)
   val publish_with_head_hooks :

--- a/test/test_keeper_memory_os_store.ml
+++ b/test/test_keeper_memory_os_store.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Store = Masc.Keeper_memory_os_store
 module Types = Masc.Keeper_memory_os_types
 module Head = Fs_compat.Capability_head
+module Exact_read = Fs_compat.Capability_exact_read
 
 let require_ok = function
   | Ok value -> value
@@ -294,6 +295,36 @@ let test_existing_read_absent_is_effect_free ~fs () =
     "identity-free empty root remains byte-for-byte unchanged"
     before
     (root_snapshot empty_path)
+;;
+
+let test_missing_identity_preserves_settlement_warning ~fs () =
+  with_root ~fs "masc_memory_os_identity_missing_warning_"
+  @@ fun _root_path root ->
+  let hooks =
+    Exact_read.For_testing.hooks
+      ~on_settle_resources:(fun () ->
+        raise (Failure "injected parent settlement failure"))
+      ()
+  in
+  match
+    Store.For_testing.read_store_identity_with_exact_hooks
+      hooks
+      ~root
+      ~owner_id:"keeper-a"
+  with
+  | Ok _ ->
+    fail "identity absence silently discarded a settlement warning"
+  | Error error ->
+    check
+      bool
+      "missing identity with a settlement warning fails typed"
+      true
+      (Store.For_testing.error_tag error
+       = Store.For_testing.Store_identity_read_failed_error);
+    expect_single_warning_tag
+      "missing identity preserves the settlement warning"
+      Store.For_testing.Store_identity_settlement_warning_tag
+      (Store.error_settlement_warnings error)
 ;;
 
 let test_existing_read_empty_store_is_read_only ~fs () =
@@ -1928,6 +1959,8 @@ let () =
     [ ( "store"
       , [ test_case "existing absent read is effect-free" `Quick
             (test_existing_read_absent_is_effect_free ~fs)
+        ; test_case "missing identity preserves settlement warning" `Quick
+            (test_missing_identity_preserves_settlement_warning ~fs)
         ; test_case "existing empty store read is read-only" `Quick
             (test_existing_read_empty_store_is_read_only ~fs)
         ; test_case "existing populated projection is exact" `Quick

--- a/test/test_keeper_memory_os_store.ml
+++ b/test/test_keeper_memory_os_store.ml
@@ -3,7 +3,6 @@ open Alcotest
 module Store = Masc.Keeper_memory_os_store
 module Types = Masc.Keeper_memory_os_types
 module Head = Fs_compat.Capability_head
-module Exact_read = Fs_compat.Capability_exact_read
 
 let require_ok = function
   | Ok value -> value
@@ -300,15 +299,8 @@ let test_existing_read_absent_is_effect_free ~fs () =
 let test_missing_identity_preserves_settlement_warning ~fs () =
   with_root ~fs "masc_memory_os_identity_missing_warning_"
   @@ fun _root_path root ->
-  let hooks =
-    Exact_read.For_testing.hooks
-      ~on_settle_resources:(fun () ->
-        raise (Failure "injected parent settlement failure"))
-      ()
-  in
   match
-    Store.For_testing.read_store_identity_with_exact_hooks
-      hooks
+    Store.For_testing.read_store_identity_with_parent_settlement_failure
       ~root
       ~owner_id:"keeper-a"
   with

--- a/test/test_keeper_memory_os_store.ml
+++ b/test/test_keeper_memory_os_store.ml
@@ -55,6 +55,14 @@ let with_root ~fs prefix fn =
     (fun () -> fn root Eio.Path.(fs / root))
 ;;
 
+let with_absent_root ~fs prefix fn =
+  let root = Filename.temp_file prefix ".tmp" in
+  Sys.remove root;
+  Fun.protect
+    ~finally:(fun () -> remove_tree root)
+    (fun () -> fn root Eio.Path.(fs / root))
+;;
+
 let entropy_source ?(chunks = 256) seed =
   Eio.Flow.string_source
     (String.init
@@ -177,6 +185,14 @@ let root_snapshot root =
     leaf, load_raw path)
 ;;
 
+let check_root_snapshot label expected actual =
+  check
+    (list (pair string string))
+    label
+    expected
+    actual
+;;
+
 let immutable_object_sizes root =
   Sys.readdir root
   |> Array.to_list
@@ -244,6 +260,184 @@ let load_result ?(seed = 101) ~root () =
     ~root
     ~owner_id:"keeper-a"
     (fun store -> Store.load store)
+;;
+
+let test_existing_read_absent_is_effect_free ~fs () =
+  with_absent_root ~fs "masc_memory_os_existing_absent_"
+  @@ fun root_path root ->
+  (match
+     require_ok
+       (Store.read_existing_current_head
+          ~root
+          ~owner_id:"keeper-a")
+   with
+   | Store.Absent -> ()
+   | Store.Existing _ ->
+     fail "absent private root was reported as an existing store");
+  check bool
+    "absent private root remains absent"
+    false
+    (Sys.file_exists root_path);
+  with_root ~fs "masc_memory_os_existing_empty_without_identity_"
+  @@ fun empty_path empty_root ->
+  let before = root_snapshot empty_path in
+  (match
+     require_ok
+       (Store.read_existing_current_head
+          ~root:empty_root
+          ~owner_id:"keeper-a")
+   with
+   | Store.Absent -> ()
+   | Store.Existing _ ->
+     fail "identity-free empty root was reported as an existing store");
+  check_root_snapshot
+    "identity-free empty root remains byte-for-byte unchanged"
+    before
+    (root_snapshot empty_path)
+;;
+
+let test_existing_read_empty_store_is_read_only ~fs () =
+  with_root ~fs "masc_memory_os_existing_valid_empty_"
+  @@ fun root_path root ->
+  within_store ~root ~owner:"keeper-a" (fun _ -> ());
+  let before = root_snapshot root_path in
+  (match
+     require_ok
+       (Store.read_existing_current_head
+          ~root
+          ~owner_id:"keeper-a")
+   with
+   | Store.Existing { current_head = Store.Empty; _ } -> ()
+   | Store.Existing { current_head = Store.Present _; _ } ->
+     fail "identity-only store unexpectedly had a current HEAD"
+   | Store.Absent ->
+     fail "valid identity-only store was reported absent");
+  check_root_snapshot
+    "valid empty store read creates no stable lock or HEAD"
+    before
+    (root_snapshot root_path)
+;;
+
+let test_existing_read_populated_projection_is_exact ~fs () =
+  with_root ~fs "masc_memory_os_existing_populated_"
+  @@ fun root_path root ->
+  let receipt = seed_commit ~root "projection" in
+  let before = root_snapshot root_path in
+  (match
+     require_ok
+       (Store.read_existing_current_head
+          ~root
+          ~owner_id:"keeper-a")
+   with
+   | Store.Existing
+       { current_head =
+           Store.Present
+             { receipt_id
+             ; operation_id
+             ; state_digest
+             ; generation
+             }
+       ; _
+       } ->
+     check string
+       "projection receipt id"
+       (sha256_string (Store.commit_receipt_id receipt))
+       (sha256_string receipt_id);
+     check string
+       "projection operation id"
+       "operation-projection"
+       operation_id;
+     check string
+       "projection state digest"
+       (sha256_string (Store.commit_receipt_state_sha256 receipt))
+       (sha256_string state_digest);
+     check int64
+       "projection generation"
+       (Store.commit_receipt_generation receipt)
+       generation
+   | Store.Existing { current_head = Store.Empty; _ } ->
+     fail "populated store was projected as empty"
+   | Store.Absent ->
+     fail "populated store was reported absent");
+  check_root_snapshot
+    "populated projection read is byte-for-byte read-only"
+    before
+    (root_snapshot root_path)
+;;
+
+let test_existing_read_rejects_current_schema_failures ~fs () =
+  with_root ~fs "masc_memory_os_existing_identity_tamper_"
+  @@ fun root_path root ->
+  within_store ~root ~owner:"keeper-a" (fun _ -> ());
+  let identity_path = store_identity_path root_path in
+  load_raw identity_path
+  |> Yojson.Safe.from_string
+  |> replace_json_field "store_id" (`String (String.make 64 'a'))
+  |> Yojson.Safe.to_string
+  |> save_raw identity_path;
+  let before = root_snapshot root_path in
+  expect_error_tag
+    "tampered current identity fails closed"
+    Store.For_testing.Invalid_store_identity_error
+    (Store.read_existing_current_head
+       ~root
+       ~owner_id:"keeper-a");
+  check_root_snapshot
+    "identity failure is read-only"
+    before
+    (root_snapshot root_path);
+  with_root ~fs "masc_memory_os_existing_foreign_owner_"
+  @@ fun foreign_path foreign_root ->
+  within_store ~root:foreign_root ~owner:"keeper-a" (fun _ -> ());
+  let before = root_snapshot foreign_path in
+  expect_error_tag
+    "foreign owner identity fails closed"
+    Store.For_testing.Invalid_store_identity_error
+    (Store.read_existing_current_head
+       ~root:foreign_root
+       ~owner_id:"keeper-b");
+  check_root_snapshot
+    "foreign owner failure is read-only"
+    before
+    (root_snapshot foreign_path);
+  with_root ~fs "masc_memory_os_existing_nonfresh_"
+  @@ fun nonfresh_path nonfresh_root ->
+  save_raw (Filename.concat nonfresh_path "legacy.json") "{}";
+  let before = root_snapshot nonfresh_path in
+  expect_error_tag
+    "nonfresh data without current identity is never adopted"
+    Store.For_testing.Store_identity_missing_from_non_fresh_root_error
+    (Store.read_existing_current_head
+       ~root:nonfresh_root
+       ~owner_id:"keeper-a");
+  check_root_snapshot
+    "nonfresh rejection is read-only"
+    before
+    (root_snapshot nonfresh_path);
+  with_root ~fs "masc_memory_os_existing_graph_tamper_"
+  @@ fun graph_path graph_root ->
+  ignore (seed_commit ~root:graph_root "graph-tamper"
+    : Store.commit_receipt);
+  let commit_path =
+    load_head graph_path
+    |> commit_leaf_of_head
+    |> Filename.concat graph_path
+  in
+  let raw = load_raw commit_path in
+  let tampered = Bytes.of_string raw in
+  Bytes.set tampered 0 '[';
+  save_raw commit_path (Bytes.unsafe_to_string tampered);
+  let before = root_snapshot graph_path in
+  expect_error_tag
+    "reachable immutable graph tamper fails closed"
+    Store.For_testing.Immutable_digest_mismatch_error
+    (Store.read_existing_current_head
+       ~root:graph_root
+       ~owner_id:"keeper-a");
+  check_root_snapshot
+    "graph tamper failure is read-only"
+    before
+    (root_snapshot graph_path)
 ;;
 
 let test_genesis_roundtrip_reopen ~fs () =
@@ -1732,7 +1926,15 @@ let () =
   run
     "keeper memory os canonical store"
     [ ( "store"
-      , [ test_case "genesis roundtrip reopen" `Quick
+      , [ test_case "existing absent read is effect-free" `Quick
+            (test_existing_read_absent_is_effect_free ~fs)
+        ; test_case "existing empty store read is read-only" `Quick
+            (test_existing_read_empty_store_is_read_only ~fs)
+        ; test_case "existing populated projection is exact" `Quick
+            (test_existing_read_populated_projection_is_exact ~fs)
+        ; test_case "existing read rejects current-schema failures" `Quick
+            (test_existing_read_rejects_current_schema_failures ~fs)
+        ; test_case "genesis roundtrip reopen" `Quick
             (test_genesis_roundtrip_reopen ~fs)
         ; test_case "current replay and conflict" `Quick
             (test_current_replay_and_conflict ~fs)


### PR DESCRIPTION
## Summary

- add a non-creating existing-store query with typed Absent and explicit Empty / Present
- verify the exact current identity, HEAD framing, reachable immutable graph, reconstructed state digest, and final unchanged HEAD
- expose provider-neutral receipt, operation, state digest, and generation metadata without migration, fallback, or legacy adoption
- prove absent, empty, populated, tampered, foreign-owner, and nonfresh paths stay read-only

## Boundary

This is a fresh-state-only MASC content-store surface. It contains no provider, model, pricing, capacity, migration, fallback, or legacy adoption policy.

## Validation

Per the active program instruction, no local build, tests, or formatter were run. PR CI is the validation authority.