### PR TITLE
feat(memory-os): expose publication obligation identity

### DIFF
--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -3061,6 +3061,38 @@ let publication_obligation_of_bytes raw =
     Error (make_error (Invalid_publication_obligation detail))
 ;;
 
+let publication_obligation_operation_id
+      (value : publication_obligation)
+  =
+  value.operation_id
+;;
+
+let publication_obligation_desired_receipt_id
+      (value : publication_obligation)
+  =
+  match value.desired with
+  | Head_authority desired -> desired.receipt_id
+  | Empty_authority ->
+    (* Construction and decoding both reject an empty desired authority. *)
+    assert false
+;;
+
+let publication_obligation_desired_state_sha256
+      (value : publication_obligation)
+  =
+  value.state_sha256
+;;
+
+let publication_obligation_desired_generation
+      (value : publication_obligation)
+  =
+  match value.desired with
+  | Head_authority desired -> desired.generation
+  | Empty_authority ->
+    (* Construction and decoding both reject an empty desired authority. *)
+    assert false
+;;
+
 let publication_obligation_of_prepared
       (store : t)
       (prepared : prepared_commit)

--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -279,22 +279,24 @@ type pending_publication =
   ; settlement_warnings : settlement_warning list
   }
 
+type head_authority =
+  { payload_sha256 : Sha256.t
+  ; payload_bytes : int64
+  ; store_id : string
+  ; generation : int64
+  ; commit_ref : immutable_ref
+  ; receipt_id : Sha256.t
+  }
+
 type authority_token =
   | Empty_authority
-  | Head_authority of
-      { payload_sha256 : Sha256.t
-      ; payload_bytes : int64
-      ; store_id : string
-      ; generation : int64
-      ; commit_ref : immutable_ref
-      ; receipt_id : Sha256.t
-      }
+  | Head_authority of head_authority
 
 type publication_obligation =
   { owner_id : string
   ; store_id : string
   ; expected : authority_token
-  ; desired : authority_token
+  ; desired : head_authority
   ; operation_id : string
   ; state_sha256 : Sha256.t
   }
@@ -2821,14 +2823,13 @@ let authority_of_prepared (prepared : prepared_commit) =
   let payload_sha256, payload_bytes =
     head_payload_fingerprint prepared.head_row
   in
-  Head_authority
-    { payload_sha256
-    ; payload_bytes
-    ; store_id = prepared.store_id
-    ; generation = prepared.generation
-    ; commit_ref = prepared.commit_ref
-    ; receipt_id = prepared.receipt_id
-    }
+  { payload_sha256
+  ; payload_bytes
+  ; store_id = prepared.store_id
+  ; generation = prepared.generation
+  ; commit_ref = prepared.commit_ref
+  ; receipt_id = prepared.receipt_id
+  }
 ;;
 
 let same_immutable_ref (left : immutable_ref) (right : immutable_ref) =
@@ -2943,7 +2944,7 @@ let publication_obligation_payload_to_json
     ; "owner_id", `String value.owner_id
     ; "store_id", `String value.store_id
     ; "expected", authority_token_to_json value.expected
-    ; "desired", authority_token_to_json value.desired
+    ; "desired", authority_token_to_json (Head_authority value.desired)
     ; "operation_id", `String value.operation_id
     ; "state_sha256", `String (Sha256.to_string value.state_sha256)
     ]
@@ -2979,16 +2980,15 @@ let validate_publication_obligation
   else if String.trim value.operation_id = ""
   then Error "operation_id must be non-empty"
   else
-    match value.desired, value.expected with
-    | Empty_authority, _ ->
-      Error "desired authority must name a HEAD commit"
-    | Head_authority desired, Empty_authority ->
+    let desired = value.desired in
+    match value.expected with
+    | Empty_authority ->
       if not (String.equal desired.store_id value.store_id)
       then Error "desired authority store identifier differs from scope"
       else if Int64.equal desired.generation 1L
       then Ok ()
       else Error "genesis desired generation must be one"
-    | Head_authority desired, Head_authority expected ->
+    | Head_authority expected ->
       if
         not (String.equal desired.store_id value.store_id)
         || not (String.equal expected.store_id value.store_id)
@@ -3028,7 +3028,13 @@ let decode_publication_obligation raw =
     let* expected_json = required_field "expected" fields in
     let* expected = authority_token_of_json expected_json in
     let* desired_json = required_field "desired" fields in
-    let* desired = authority_token_of_json desired_json in
+    let* desired_token = authority_token_of_json desired_json in
+    let* desired =
+      match desired_token with
+      | Empty_authority ->
+        Error "desired authority must name a HEAD commit"
+      | Head_authority desired -> Ok desired
+    in
     let* operation_id = string_field "operation_id" fields in
     let* state_sha256 = sha256_field "state_sha256" fields in
     let* checksum = sha256_field "checksum_sha256" fields in
@@ -3070,11 +3076,7 @@ let publication_obligation_operation_id
 let publication_obligation_desired_receipt_id
       (value : publication_obligation)
   =
-  match value.desired with
-  | Head_authority desired -> desired.receipt_id
-  | Empty_authority ->
-    (* Construction and decoding both reject an empty desired authority. *)
-    assert false
+  value.desired.receipt_id
 ;;
 
 let publication_obligation_desired_state_sha256
@@ -3086,11 +3088,7 @@ let publication_obligation_desired_state_sha256
 let publication_obligation_desired_generation
       (value : publication_obligation)
   =
-  match value.desired with
-  | Head_authority desired -> desired.generation
-  | Empty_authority ->
-    (* Construction and decoding both reject an empty desired authority. *)
-    assert false
+  value.desired.generation
 ;;
 
 let publication_obligation_of_prepared
@@ -3126,44 +3124,38 @@ let validate_publication_obligation_scope
       (store : t)
       (obligation : publication_obligation)
   =
-  match obligation.desired with
-  | Empty_authority ->
+  let desired = obligation.desired in
+  let artifact = "obligation commit:" ^ desired.commit_ref.leaf in
+  let* ((commit : commit_record), warnings) =
+    read_object
+      store
+      desired.commit_ref
+      ~artifact
+      ~decode:commit_record_of_json
+      ~encode:commit_record_to_json
+  in
+  let* () =
+    ensure_identity
+      ~artifact
+      ~expected_store_id:desired.store_id
+      ~expected_owner_id:obligation.owner_id
+      ~expected_generation:desired.generation
+      ~store_id:commit.store_id
+      ~owner_id:commit.owner_id
+      ~generation:commit.generation
+    |> with_prior_warnings warnings
+  in
+  if
+    not (Sha256.equal commit.receipt_id desired.receipt_id)
+    || not (String.equal commit.operation_id obligation.operation_id)
+    || not (Sha256.equal commit.state_sha256 obligation.state_sha256)
+  then
     Error
       (make_error
+         ~settlement_warnings:warnings
          (Publication_obligation_mismatch
-            "desired authority does not contain a commit scope proof"))
-  | Head_authority desired ->
-    let artifact = "obligation commit:" ^ desired.commit_ref.leaf in
-    let* ((commit : commit_record), warnings) =
-      read_object
-        store
-        desired.commit_ref
-        ~artifact
-        ~decode:commit_record_of_json
-        ~encode:commit_record_to_json
-    in
-    let* () =
-      ensure_identity
-        ~artifact
-        ~expected_store_id:desired.store_id
-        ~expected_owner_id:obligation.owner_id
-        ~expected_generation:desired.generation
-        ~store_id:commit.store_id
-        ~owner_id:commit.owner_id
-        ~generation:commit.generation
-      |> with_prior_warnings warnings
-    in
-    if
-      not (Sha256.equal commit.receipt_id desired.receipt_id)
-      || not (String.equal commit.operation_id obligation.operation_id)
-      || not (Sha256.equal commit.state_sha256 obligation.state_sha256)
-    then
-      Error
-        (make_error
-           ~settlement_warnings:warnings
-           (Publication_obligation_mismatch
-              "desired commit scope proof diverges from receipt metadata"))
-    else Ok warnings
+            "desired commit scope proof diverges from receipt metadata"))
+  else Ok warnings
 ;;
 
 let validate_superseding_authority
@@ -3177,20 +3169,17 @@ let validate_superseding_authority
          ~settlement_warnings:current.settlement_warnings
          (Publication_obligation_mismatch detail))
   in
-  match obligation.expected, obligation.desired, current_authority with
-  | _, Empty_authority, _ ->
-    mismatch "desired authority is unexpectedly empty"
-  | Empty_authority, Head_authority _, Empty_authority ->
+  let desired = obligation.desired in
+  match obligation.expected, current_authority with
+  | Empty_authority, Empty_authority ->
     mismatch "empty authority should have matched the genesis expectation"
-  | Empty_authority, Head_authority desired, Head_authority observed ->
+  | Empty_authority, Head_authority observed ->
     if Sha256.equal observed.receipt_id desired.receipt_id
     then mismatch "desired receipt appears under different HEAD authority"
     else Ok ()
-  | Head_authority _, Head_authority _, Empty_authority ->
+  | Head_authority _, Empty_authority ->
     mismatch "current authority regressed below the non-empty expectation"
-  | ( Head_authority expected
-    , Head_authority desired
-    , Head_authority observed ) ->
+  | Head_authority expected, Head_authority observed ->
     if not (String.equal observed.store_id desired.store_id)
     then mismatch "current authority belongs to a different persisted store"
     else if Int64.compare observed.generation desired.generation < 0
@@ -3226,20 +3215,21 @@ let recover_publication
   else
     let* current = load store in
     let* current_authority = authority_of_snapshot current in
-    if same_authority current_authority obligation.desired
+    if
+      same_authority
+        current_authority
+        (Head_authority obligation.desired)
     then
-      (match receipt_of_snapshot current, obligation.desired with
-       | Some receipt, Head_authority desired
+      (match receipt_of_snapshot current with
+       | Some receipt
          when
+           let desired = obligation.desired in
            Int64.equal receipt.generation desired.generation
            && Sha256.equal receipt.receipt_id desired.receipt_id
            && String.equal receipt.operation_id obligation.operation_id
            && Sha256.equal receipt.state_sha256 obligation.state_sha256 ->
          Ok (Recovered_committed receipt)
-       | Some _, Head_authority _
-       | None, Head_authority _
-       | Some _, Empty_authority
-       | None, Empty_authority ->
+       | Some _ | None ->
          Error
            (make_error
               ~settlement_warnings:current.settlement_warnings

--- a/lib/keeper/keeper_memory_os_store.ml
+++ b/lib/keeper/keeper_memory_os_store.ml
@@ -2936,18 +2936,23 @@ let authority_token_of_json json =
   | _ -> Error ("unknown authority kind " ^ kind)
 ;;
 
+let publication_obligation_payload_fields
+      (value : publication_obligation)
+  =
+  [ "schema", `String publication_obligation_schema
+  ; "owner_id", `String value.owner_id
+  ; "store_id", `String value.store_id
+  ; "expected", authority_token_to_json value.expected
+  ; "desired", authority_token_to_json (Head_authority value.desired)
+  ; "operation_id", `String value.operation_id
+  ; "state_sha256", `String (Sha256.to_string value.state_sha256)
+  ]
+;;
+
 let publication_obligation_payload_to_json
       (value : publication_obligation)
   =
-  `Assoc
-    [ "schema", `String publication_obligation_schema
-    ; "owner_id", `String value.owner_id
-    ; "store_id", `String value.store_id
-    ; "expected", authority_token_to_json value.expected
-    ; "desired", authority_token_to_json (Head_authority value.desired)
-    ; "operation_id", `String value.operation_id
-    ; "state_sha256", `String (Sha256.to_string value.state_sha256)
-    ]
+  `Assoc (publication_obligation_payload_fields value)
 ;;
 
 let publication_obligation_checksum value =
@@ -2957,17 +2962,14 @@ let publication_obligation_checksum value =
 ;;
 
 let publication_obligation_to_bytes value =
-  match publication_obligation_payload_to_json value with
-  | `Assoc fields ->
-    canonical_json
-      (`Assoc
-         (fields
-          @ [ ( "checksum_sha256"
-              , `String
-                  (Sha256.to_string
-                     (publication_obligation_checksum value)) )
-            ]))
-  | _ -> assert false
+  canonical_json
+    (`Assoc
+       (publication_obligation_payload_fields value
+        @ [ ( "checksum_sha256"
+            , `String
+                (Sha256.to_string
+                   (publication_obligation_checksum value)) )
+          ]))
 ;;
 
 let validate_publication_obligation

--- a/lib/keeper/keeper_memory_os_store.mli
+++ b/lib/keeper/keeper_memory_os_store.mli
@@ -188,6 +188,26 @@ val publication_obligation_of_bytes :
   string ->
   (publication_obligation, error) result
 
+(** Provider-neutral identity projections over the exact canonical desired
+    publication already bound by the obligation checksum. These expose no
+    expected authority, store-private payload, or immutable object reference
+    and confer no Memory OS read or publication authority. *)
+val publication_obligation_operation_id :
+  publication_obligation ->
+  string
+
+val publication_obligation_desired_receipt_id :
+  publication_obligation ->
+  Sha256.t
+
+val publication_obligation_desired_state_sha256 :
+  publication_obligation ->
+  Sha256.t
+
+val publication_obligation_desired_generation :
+  publication_obligation ->
+  int64
+
 val publish :
   t ->
   prepared_commit ->

--- a/test/test_keeper_memory_os_store.ml
+++ b/test/test_keeper_memory_os_store.ml
@@ -1889,6 +1889,57 @@ let test_obligation_codec_is_exact_and_tamper_evident ~fs () =
     (Store.publication_obligation_of_bytes (" " ^ bytes))
 ;;
 
+let test_obligation_projectors_bind_published_identity ~fs () =
+  with_root ~fs "masc_memory_os_obligation_projectors_"
+  @@ fun _root_path root ->
+  within_store ~root ~owner:"keeper-a" @@ fun store ->
+  let empty = require_ok (Store.load store) in
+  let prepared =
+    prepare_new
+      store
+      empty
+      "projected-obligation-operation"
+      (state "projected-obligation")
+  in
+  let prepared_obligation =
+    require_ok
+      (Store.publication_obligation_of_prepared store prepared)
+  in
+  let encoded =
+    Store.publication_obligation_to_bytes prepared_obligation
+  in
+  let decoded_obligation =
+    require_ok (Store.publication_obligation_of_bytes encoded)
+  in
+  check string
+    "decoded obligation retains exact canonical bytes"
+    encoded
+    (Store.publication_obligation_to_bytes decoded_obligation);
+  let receipt = publish_committed store prepared in
+  let check_projection label obligation =
+    check string
+      (label ^ " operation id")
+      (Store.commit_receipt_operation_id receipt)
+      (Store.publication_obligation_operation_id obligation);
+    check string
+      (label ^ " desired receipt id")
+      (sha256_string (Store.commit_receipt_id receipt))
+      (sha256_string
+         (Store.publication_obligation_desired_receipt_id obligation));
+    check string
+      (label ^ " desired state digest")
+      (sha256_string (Store.commit_receipt_state_sha256 receipt))
+      (sha256_string
+         (Store.publication_obligation_desired_state_sha256 obligation));
+    check int64
+      (label ^ " desired generation")
+      (Store.commit_receipt_generation receipt)
+      (Store.publication_obligation_desired_generation obligation)
+  in
+  check_projection "prepared" prepared_obligation;
+  check_projection "decoded" decoded_obligation
+;;
+
 let test_foreign_owner_obligation_fails_closed ~fs () =
   with_root ~fs "masc_memory_os_obligation_owner_source_"
   @@ fun _source_path source ->
@@ -2031,6 +2082,8 @@ let () =
             (test_same_receipt_different_authority_fails_closed ~fs)
         ; test_case "obligation codec is exact and tamper evident" `Quick
             (test_obligation_codec_is_exact_and_tamper_evident ~fs)
+        ; test_case "obligation projectors bind published identity" `Quick
+            (test_obligation_projectors_bind_published_identity ~fs)
         ; test_case "foreign owner obligation fails closed" `Quick
             (test_foreign_owner_obligation_fails_closed ~fs)
         ; test_case "recovery validates desired reachable graph" `Quick


### PR DESCRIPTION
## Summary
- expose provider-neutral typed projectors for publication obligation operation ID
- expose the checksum-bound desired receipt ID, state SHA-256, and generation
- prove prepared and decoded obligations bind the same identity as the committed receipt

## Boundary
- no owner, store, expected authority, payload digest/length, or immutable commit reference is exposed
- no obligation decoding or private-byte duplication is added to callers
- no OAS, provider, model, pricing, migration, alias, publication, or recovery behavior changes

## Validation
- Not run locally by explicit instruction; PR CI is the build, formatting, and test authority.