### PR TITLE
test(fs): Darwin feature level 이 fcntl.h 보다 앞선다는 것을 고정 (#25746 테스트 절반 복구)

### DIFF
--- a/test/test_fs_compat_capability_exact_read.ml
+++ b/test/test_fs_compat_capability_exact_read.ml
@@ -1014,6 +1014,38 @@ let test_static_surface_and_raw_openat () =
     call
 ;;
 
+(* The flags this stub needs only exist if the headers declare them, and on
+   Darwin O_NOFOLLOW / O_NOCTTY / O_CLOEXEC sit behind __DARWIN_C_LEVEL:
+   defining _POSIX_C_SOURCE alone lowers that level below their declarations and
+   the stub's own #error fires. That is a compile break, so no behavioural test
+   can reach it — and the symlink cases above cannot either, because on glibc
+   _GNU_SOURCE exposes everything and they pass whatever the macros say. CI is
+   Linux, so #25734 shipped a stub that no macOS checkout could compile and every
+   local test target linking fs_compat failed; #25745 fixed the stub but nothing
+   pinned the ordering it depends on. This asserts that ordering: the Darwin
+   level is raised, and it is raised before <fcntl.h>. *)
+let test_darwin_feature_level_precedes_fcntl () =
+  let stub = load_workspace_file "lib/fs_compat/capability_exact_read_stubs.c" in
+  let offset_of needle =
+    match find_substring stub needle with
+    | Some offset -> offset
+    | None -> failf "capability exact read stub does not contain %S" needle
+  in
+  let darwin_level = offset_of "_DARWIN_C_SOURCE" in
+  let fcntl_include = offset_of "#include <fcntl.h>" in
+  check
+    bool
+    "Darwin feature level is raised before <fcntl.h>"
+    true
+    (darwin_level < fcntl_include);
+  (* Raised under an __APPLE__ guard so other platforms keep their own level. *)
+  check
+    bool
+    "the Darwin level is guarded to Apple"
+    true
+    (offset_of "defined(__APPLE__)" < darwin_level)
+;;
+
 let () =
   run_helper_if_requested ();
   Eio_main.run @@ fun env ->
@@ -1060,6 +1092,8 @@ let () =
                ~process_mgr)
         ; test_case "static public surface and raw openat" `Quick
             test_static_surface_and_raw_openat
+        ; test_case "Darwin feature level precedes fcntl.h" `Quick
+            test_darwin_feature_level_precedes_fcntl
         ] )
     ]
 ;;


### PR DESCRIPTION
## 왜 필요한가

#25745 가 스텁을 고쳐 macOS 빌드를 복구했지만, **그 수정이 의존하는 순서를 고정하는 게 아무것도 없다.** 나중에 누가 `_DARWIN_C_SOURCE` 정의를 `#include <fcntl.h>` 아래로 옮기면 모든 macOS 체크아웃이 다시 깨지는데, **Linux CI 는 그대로 초록**이다 — glibc 는 순서와 무관하게 `_GNU_SOURCE` 로 `O_NOFOLLOW` 를 노출하므로 CI 에서 동작 테스트로는 관측할 수 없다.

이건 #25746 이 제안했던 분할의 **테스트 절반**이다. 그 PR 은 #25745 와 동일한 `.c` 변경을 함께 들고 있었고 통째로 닫히면서 테스트도 같이 사라졌다. (#25745 코멘트에서 "`.c` 는 이쪽, 테스트는 #25746" 으로 합의했었다.)

## 왜 소스를 읽는 테스트인가

실패 양태가 **컴파일 break** 라서 동작 테스트로는 도달할 수 없다:

- macOS: 테스트 바이너리가 만들어지기 전에 스텁의 `#error` 가 발화한다.
- Linux: 매크로가 뭐라 하든 플래그가 보이므로 기존 symlink 케이스가 그냥 통과한다.

그래서 단언 대상이 텍스트일 수밖에 없다 — `_DARWIN_C_SOURCE` 가 정의되고, `<fcntl.h>` 보다 **앞서** 정의되고, `__APPLE__` 가드 아래 있어 다른 플랫폼은 자기 feature level 을 유지한다.

기존 헬퍼(`load_workspace_file`, `find_substring`)를 그대로 쓴다. 새 인프라 없음.

## 검증 (darwin 25.4.0)

**Positive**: `[OK] Darwin feature level precedes fcntl.h`

**Negative control**: 정의를 include 아래로 옮기면 원래 파손이 그대로 재현된다.
```
error: use of undeclared identifier 'O_NOFOLLOW'
error: "capability exact read requires O_NONBLOCK, O_CLOEXEC, O_NOFOLLOW, and O_NOCTTY"
```
macOS 에서는 컴파일러가 먼저 잡고, Linux 에서는 같은 변형이 컴파일을 통과한 뒤 **이 단언이 잡는다**. 후자가 이 테스트의 존재 이유다.

## 별건 — 같은 스위트의 선행 실패

`#15 fatal backtrace propagation` 이 darwin 에서 `fatal callback helper exited with code 4` 로 실패한다. 이 PR 은 건드리지 않았고, 변경 없는 체크아웃에서 재현 확인했다. #25746 작성자도 같은 걸 관측했다.

공통 원인은 **CI 가 이 타깃을 실행하지 않는다**는 것이다. `ci.yml` 은 `@default @check` 로 컴파일만 하고 runtest alias 를 손으로 열거하는데(`test_runtime_config_validity` + operator 3종), 목록 밖 테스트는 영원히 안 돈다. 이 PR 의 새 테스트도 그 목록 밖이라 **CI 에서 실행되지 않는다** — 로컬과 `@check` 컴파일까지만 보장된다. runtest 열거 목록을 손대는 건 범위 밖이라 여기서는 하지 않았고, 별도로 제기할 사안이다.

Refs #25745, #25746

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. 테스트 파일 1개 추가다.
