### PR TITLE
fix(goal): 인가 없는 Completed 를 타입 수준에서 구성 불가로 만든다 (#25693 스택)

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -256,15 +256,15 @@ let dashboard_goals_tree_json ~(config : Workspace.config) : Yojson.Safe.t =
                node.tasks))
       0 all_nodes
   in
-  let count_phase phase =
+  let count_phase is_phase =
     goals
-    |> List.filter (fun (goal : Goal_store.goal) -> goal.phase = phase)
+    |> List.filter (fun (goal : Goal_store.goal) -> is_phase goal.phase)
     |> List.length
   in
   let active_goal_count =
     goals
     |> List.filter (fun (goal : Goal_store.goal) ->
-           goal.phase = Goal_phase.Executing)
+           Goal_phase.is_executing goal.phase)
     |> List.length
   in
   let pending_approval_total =
@@ -288,11 +288,11 @@ let dashboard_goals_tree_json ~(config : Workspace.config) : Yojson.Safe.t =
             ( "phase_counts",
               `Assoc
                 [
-                  ("executing", `Int (count_phase Goal_phase.Executing));
-                  ("blocked", `Int (count_phase Goal_phase.Blocked));
-                  ("paused", `Int (count_phase Goal_phase.Paused));
-                  ("completed", `Int (count_phase Goal_phase.Completed));
-                  ("dropped", `Int (count_phase Goal_phase.Dropped));
+                  ("executing", `Int (count_phase Goal_phase.is_executing));
+                  ("blocked", `Int (count_phase Goal_phase.is_blocked));
+                  ("paused", `Int (count_phase Goal_phase.is_paused));
+                  ("completed", `Int (count_phase Goal_phase.is_completed));
+                  ("dropped", `Int (count_phase Goal_phase.is_dropped));
                 ] );
             ("total_tasks", `Int total_tasks);
             ("done_tasks", `Int done_tasks);

--- a/lib/dashboard/dashboard_goals_types_attainment.ml
+++ b/lib/dashboard/dashboard_goals_types_attainment.ml
@@ -407,7 +407,7 @@ let goal_completion_to_json (goal : Goal_store.goal) (node : tree_node) ~attainm
       ("task_total", `Int task_count);
       ("task_done", `Int task_done_count);
       ("task_open", `Int task_open_count);
-      ("is_complete", `Bool (goal.phase = Goal_phase.Completed));
+      ("is_complete", `Bool (Goal_phase.is_completed goal.phase));
       ("is_terminal", `Bool is_terminal);
       ("ready_to_request_completion", `Bool ready_to_request_completion);
     ]

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -5,6 +5,39 @@ type t =
   | Completed
   | Dropped
 
+let equal (a : t) (b : t) = a = b
+let executing = Executing
+let blocked = Blocked
+let paused = Paused
+let dropped = Dropped
+
+let is_executing = function
+  | Executing -> true
+  | Blocked | Paused | Completed | Dropped -> false
+
+let is_blocked = function
+  | Blocked -> true
+  | Executing | Paused | Completed | Dropped -> false
+
+let is_paused = function
+  | Paused -> true
+  | Executing | Blocked | Completed | Dropped -> false
+
+let is_completed = function
+  | Completed -> true
+  | Executing | Blocked | Paused | Dropped -> false
+
+let is_dropped = function
+  | Dropped -> true
+  | Executing | Blocked | Paused | Completed -> false
+
+(* Carries the receipt id so the authorization is traceable to one verdict
+   rather than being a bare token any caller could conjure for any goal. *)
+type completion_authorization = Authorized_by of string
+
+let authorize_completion ~verdict_receipt_id = Authorized_by verdict_receipt_id
+let completed (Authorized_by _ : completion_authorization) = Completed
+
 let to_string = function
   | Executing -> "executing"
   | Blocked -> "blocked"

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -6,12 +6,52 @@
     transition logic out of caller code. *)
 
 (** Goal lifecycle phases. *)
-type t =
+type t = private
   | Executing
   | Blocked
   | Paused
   | Completed
   | Dropped
+
+val equal : t -> t -> bool
+(** Structural equality. Use this instead of [=] against a constructor: [t] is
+    private, so a comparison like [phase = Completed] would have to build a
+    [Completed] value and is rejected. *)
+
+val executing : t
+val blocked : t
+val paused : t
+val dropped : t
+(** The phases any caller may name. Completion is the only one that needs
+    authorization, so it is not here — see {!completed}. *)
+
+val is_executing : t -> bool
+val is_blocked : t -> bool
+val is_paused : t -> bool
+val is_completed : t -> bool
+val is_dropped : t -> bool
+(** Phase predicates. Counting and filtering go through these: a query must not
+    have to mint a [Completed] value just to ask how many goals are in it. *)
+
+type completion_authorization
+(** Proof that a semantic completion verdict approved this goal. Abstract, so
+    the only way to obtain one is {!authorize_completion}. *)
+
+val authorize_completion : verdict_receipt_id:string -> completion_authorization
+(** Mint the authorization from the id of a persisted approving verdict
+    receipt. The caller must already hold that receipt; this does not check it,
+    it records that a specific one was the basis for completing. *)
+
+val completed : completion_authorization -> t
+(** The ONLY way to produce [Completed]. [t] is private, so no caller outside
+    this module can write [Completed] directly — a goal cannot reach the
+    terminal phase without naming the verdict that authorized it. Prior to this
+    the obligation lived in a doc comment on {!decide_transition} saying the
+    adapter "must" obtain a verdict, which the compiler did not enforce.
+
+    Deserialization inside this module still reconstructs [Completed] from
+    persisted text ({!of_string}, {!of_yojson}). That is replay of an already
+    authorized decision, not a new one; the gate is on the transition path. *)
 
 val to_string : t -> string
 (** Lowercase canonical name ([Executing -> "executing"], …). *)

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -683,7 +683,7 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                   in
                   if candidate_goal = existing
                   then state
-                  else if existing.phase = Goal_phase.Completed
+                  else if Goal_phase.is_completed existing.phase
                   then (
                     mutation_rejection :=
                       Some
@@ -706,7 +706,7 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                         target_value;
                         due_date;
                         priority = clamp_priority (Option.value priority ~default:3);
-                        phase = Goal_phase.Executing;
+                        phase = Goal_phase.executing;
                         parent_goal_id;
                         last_review_note = None;
                         last_review_at = None;
@@ -738,14 +738,14 @@ let compute_rollup goals =
     List_util.count_if predicate goals
   in
   {
-    active_count = count (fun goal -> goal.phase = Goal_phase.Executing);
+    active_count = count (fun goal -> goal.phase = Goal_phase.executing);
     paused_count =
       count (fun goal ->
           match goal.phase with
           | Goal_phase.Paused | Goal_phase.Blocked -> true
           | _ -> false);
-    done_count = count (fun goal -> goal.phase = Goal_phase.Completed);
-    dropped_count = count (fun goal -> goal.phase = Goal_phase.Dropped);
+    done_count = count (fun goal -> Goal_phase.is_completed goal.phase);
+    dropped_count = count (fun goal -> Goal_phase.is_dropped goal.phase);
   }
 
 (* RFC-0294: the horizon-driven refresh/snapshot scheduler ([snapshot],
@@ -754,4 +754,4 @@ let compute_rollup goals =
    cohort selector keyed on the now-deleted [horizon]. *)
 
 let active_goals config =
-  list_goals config ~phase:Goal_phase.Executing ()
+  list_goals config ~phase:Goal_phase.executing ()

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -374,7 +374,12 @@ let handle_goal_completion_request
             ~expected:goal
             (fun current ->
                { current with
-                 phase = Goal_phase.Completed
+                 (* The only construction of [Completed] in the tree, and it
+                    must name the verdict receipt that authorized it. *)
+                 phase =
+                   Goal_phase.completed
+                     (Goal_phase.authorize_completion
+                        ~verdict_receipt_id:receipt.Goal_store.review_prompt_sha256)
                ; last_review_note = Some "Configured LLM approved Goal completion"
                ; last_review_at = Some reviewed_at
                ; completion_review_failure = None

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -23,7 +23,7 @@ let make_goal ?metric ?target_value id title =
     target_value;
     due_date = None;
     priority = 3;
-    phase = Goal_phase.Executing;
+    phase = Goal_phase.executing;
     parent_goal_id = None;
     last_review_note = None;
     last_review_at = None;

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -11,6 +11,14 @@ module Types = Masc_domain
 open Alcotest
 open Masc
 
+(* Completion is authorized, not asserted: even a fixture has to name the
+   verdict receipt it is standing in for. *)
+let test_completed_phase =
+  Goal_phase.completed
+    (Goal_phase.authorize_completion ~verdict_receipt_id:"test-receipt")
+;;
+
+
 let temp_dir () =
   Filename.temp_dir "goal_store_test" ""
 
@@ -45,7 +53,7 @@ let make_goal id title =
   {
     Goal_store.id; title;
     metric = None; target_value = None; due_date = None;
-    priority = 3; phase = Goal_phase.Executing;
+    priority = 3; phase = Goal_phase.executing;
     parent_goal_id = None;
     last_review_note = None; last_review_at = None;
     completion_review_failure = None;
@@ -260,7 +268,7 @@ let test_blocked_phase_serializes_without_status () =
   let goal =
     match
       Goal_store.update_goal config ~goal_id:created.id (fun current ->
-        { current with phase = Goal_phase.Blocked })
+        { current with phase = Goal_phase.blocked })
     with
     | Ok goal -> goal
     | Error msg -> fail msg
@@ -301,11 +309,11 @@ let test_list_goals_filters_by_phase () =
        | Ok _ -> ()
        | Error msg -> fail msg)
   in
-  make "Executing goal" Goal_phase.Executing;
-  make "Completed goal" Goal_phase.Completed;
-  make "Blocked goal" Goal_phase.Blocked;
+  make "Executing goal" Goal_phase.executing;
+  make "Completed goal" test_completed_phase;
+  make "Blocked goal" Goal_phase.blocked;
   let goals =
-    Goal_store.list_goals config ~phase:Goal_phase.Completed ()
+    Goal_store.list_goals config ~phase:test_completed_phase ()
   in
   check int "one completed goal" 1 (List.length goals);
   match goals with
@@ -338,7 +346,7 @@ let test_update_cannot_complete_without_receipt () =
   let before = Goal_store.read_state config in
   (match
      Goal_store.update_goal config ~goal_id:goal.id (fun current ->
-       { current with phase = Goal_phase.Completed })
+       { current with phase = test_completed_phase })
    with
    | Ok _ -> fail "completion without a semantic-review receipt was accepted"
    | Error msg ->
@@ -352,7 +360,7 @@ let test_update_cannot_complete_without_receipt () =
   match Goal_store.get_goal config ~goal_id:goal.id with
   | Some current ->
     check bool "Goal remains executing" true
-      (current.phase = Goal_phase.Executing)
+      (current.phase = Goal_phase.executing)
   | None -> fail "Goal disappeared after rejected completion"
 ;;
 

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -515,7 +515,7 @@ let test_goal_completion_requires_nonempty_claim () =
     (get_string_field error "error_code");
   let current = current_goal config goal.id in
   check bool "missing claim cannot complete" true
-    (current.phase = Goal_phase.Executing);
+    (Goal_phase.is_executing current.phase);
   check bool "missing claim writes no receipt" true
     (Option.is_none current.completion_receipt)
 ;;
@@ -596,7 +596,7 @@ let test_goal_completion_rejection_is_durable_and_nonterminal () =
     (get_string_field error "error_code");
   let current = current_goal config goal.id in
   check bool "rejected Goal stays executing" true
-    (current.phase = Goal_phase.Executing);
+    (Goal_phase.is_executing current.phase);
   check
     (option string)
     "rejection reason is durable"
@@ -637,7 +637,7 @@ let test_goal_completion_unavailable_is_retryable_and_nonterminal () =
    | None -> fail "masc_goal_transition not handled");
   let current = current_goal config goal.id in
   check bool "unavailable Goal stays executing" true
-    (current.phase = Goal_phase.Executing);
+    (Goal_phase.is_executing current.phase);
   check bool "unavailable reason is durable" true
     (Option.is_some current.last_review_note);
   check bool "unavailable kind is typed" true
@@ -670,7 +670,7 @@ let test_goal_completion_missing_verdict_is_nonterminal () =
    | None -> fail "masc_goal_transition not handled");
   let current = current_goal config goal.id in
   check bool "missing verdict cannot complete" true
-    (current.phase = Goal_phase.Executing);
+    (Goal_phase.is_executing current.phase);
   check bool "missing verdict is typed unavailable" true
     (current.completion_review_failure = Some Goal_store.Unavailable);
   check bool "missing verdict writes no receipt" true
@@ -708,7 +708,7 @@ let test_goal_completion_rejects_stale_approval () =
     (get_string_field error "error_code");
   let current = current_goal config goal.id in
   check bool "stale approval cannot complete" true
-    (current.phase = Goal_phase.Executing);
+    (Goal_phase.is_executing current.phase);
   check bool "no stale receipt" true (Option.is_none current.completion_receipt)
 ;;
 let test_goal_block_and_unblock_have_no_operator_hierarchy () =


### PR DESCRIPTION
Stacked on #25693 (base = `fix/goal-completion-verified-20260724`). 리뷰는 그 PR 먼저.

## 문제

#25693 은 goal 완료에 의미 검증 게이트를 붙이지만 **강제가 어댑터에만 있다.** 의무가 `Goal_phase.decide_transition` 의 doc 주석에 있다:

> the workspace adapter **must** obtain and atomically persist the required semantic completion verdict before committing [Completed].

컴파일러는 "must" 를 검사하지 않는다. 지금이든 나중이든 아무 호출자나 `{ goal with phase = Goal_phase.Completed }` 를 써서 verdict 없이 terminal 에 도달할 수 있다.

task 쪽에는 이 구멍이 없다 — `workspace_task_lifecycle.ml:55` 가 `| None -> Error Completion_verdict_required` 라 verdict 값 없이는 Done 이 안 된다. 이 PR 은 goal 을 같은 수준으로 올린다.

## 수정

`Goal_phase.t` 를 private 으로 만든다. `goal_phase.ml` 바깥 어떤 모듈도 phase 를 **생성**할 수 없다. 완료는 verdict 경로만 만들 수 있는 토큰을 거친다:

```ocaml
type completion_authorization
val authorize_completion : verdict_receipt_id:string -> completion_authorization
val completed : completion_authorization -> t
```

유일한 커밋 지점(`workspace_goals.ml` 의 Approve 분기)이 이제 자기가 근거로 삼는 receipt 를 **이름으로 대야 한다** — 바로 한 줄 아래에서 `completion_receipt` 로 이미 저장하고 있던 그 receipt 다. 둘이 어긋날 수 없게 됐다.

나머지 phase 는 인가가 필요 없으므로 평범한 값(`executing` / `blocked` / `paused` / `dropped`)으로 준다. 읽기·질의는 phase 를 **생성하지 않고 지칭**해야 하므로 술어 집합을 대칭으로 완성했고(`is_executing` / `is_blocked` / `is_paused` / `is_completed` / `is_dropped`), 대시보드의 `count_phase` 는 값 대신 술어를 받는다.

**패턴 매치는 전혀 손대지 않았다.** private 은 매치를 허용하므로 기존 `| Goal_phase.Completed ->` arm 은 전부 그대로 컴파일된다. 단순히 세면 19 개 참조가 걸릴 것 같지만 실제로는 9 파일에서 끝나는 이유가 이것이다 — 깨진 건 동등비교와 레코드 생성뿐이었다.

## 검증 (리베이스된 #25693 위에서)

`dune build --root . @check` clean.

goal 스위트 **65 tests 전부 통과**: `goal_phase_all` 4 / `workspace_goal_index` 17 / `goal_task_assignment` 5 / `Goal_store.delete_goal` 14 / `goal_tools` 16 / `goal metric unevaluated` 9.

**Negative control — 이게 주장의 전부다.** 커밋 지점을 `phase = Goal_phase.Completed` 로 되돌리면 이제 타입체크가 안 된다:
```
File "lib/workspace_goals.ml", line 379, characters ...
Error: Cannot create values of the private type Goal_phase.t
```
이 변경 전에는 저 줄이 **컴파일됐다.**

## 명시적으로 다루지 않은 것

**역직렬화**: `goal_phase.ml` 안의 `of_string` / `of_yojson` 은 저장된 텍스트에서 `Completed` 를 그대로 복원한다. 이미 인가된 결정의 replay 이지 새 결정이 아니며, 게이트는 전이 경로에 있다. 구멍으로 오해되지 않게 `.mli` 에 명시했다.

**테스트 픽스처**: `For_testing` 백도어를 노출하지 않고 실제 API 로 receipt id 를 대서 인가를 만든다. 백도어를 뚫으면 이 PR 이 없애려는 우회를 그대로 되살리는 것이다.

**남은 ergonomic 결함**: `list_goals ~phase:` 가 여전히 `t` 를 받으므로, 완료 goal 을 나열하려는 호출자는 phase 를 **지칭하기 위해** 인가를 만들어야 한다. 오늘 그런 호출부는 테스트 1 곳뿐이다. 올바른 해법은 별도의 `phase_filter` 타입이고 이 PR 보다 큰 변경이라 여기서는 하지 않았다.

## 로컬 빌드 주의

이 브랜치는 #25693 위에 있고 #25693 은 #25745(현재 main, macOS `O_NOFOLLOW` 수정) 이전 시점이다. 따라서 **macOS 로컬 빌드는 fs_compat 에서 깨진다** — 위 검증은 그 패치를 커밋하지 않고 로컬 적용한 상태에서 돌렸다. #25693 을 현재 main 으로 다시 리베이스하면 해소된다. Linux CI 는 무관하다.

Refs #25693

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. goal 도메인 타입과 그 호출부다.
