### PR TITLE
fix(oas-drift): fingerprint Retry.invalid_request_reason, and stop reporting a missing section as a match

### DIFF
--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -25,6 +25,11 @@
       "ProviderTerminal",
       "TimeoutError"
     ],
+    "invalid_request_reasons": [
+      "Json_parse_error",
+      "Request_body_too_large",
+      "Unknown_invalid_request"
+    ],
     "metrics_fields": [
       "on_cache_hit",
       "on_cache_miss",

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -147,6 +147,30 @@ extract_http_error_variants() {
   ' "${file}" | sort -u
 }
 
+# Retry.invalid_request_reason constructors from the .mli type.
+#
+# MASC reads this type as a control decision, not as telemetry:
+# keeper_turn_runtime_budget.ml classifies Request_body_too_large as a capacity
+# refusal that requests a compaction, and Json_parse_error / Unknown_invalid_request
+# as a defect in what was built, which must not. A new constructor therefore changes
+# what MASC does, not just what it prints — and it can be satisfied by the wire
+# renderer alone (keeper_event_bridge_error_json.ml) while the control classifier
+# still answers None for it, which compiles. That is the telemetry-without-control
+# shape this repository refuses, so the surface belongs in this fingerprint.
+extract_invalid_request_reasons() {
+  local src="$1"
+  local file="${src}/lib/llm_provider/retry.mli"
+  [[ -f "${file}" ]] || { echo "missing ${file}" >&2; return 1; }
+  awk '
+    /^type invalid_request_reason/ { inblock=1; next }
+    inblock && /^(and|type|val|let|module) / { inblock=0 }
+    inblock && /^  \| [A-Z]/ {
+      sub(/^  \| /, ""); sub(/[[:space:]].*/, "");
+      print
+    }
+  ' "${file}" | sort -u
+}
+
 # Metrics.t record fields from the .mli type t.
 extract_metrics_fields() {
   local src="$1"
@@ -297,9 +321,10 @@ lines_to_json_array() {
 
 build_fingerprint() {
   local src="$1"
-  local ebv hev mf eod eor
+  local ebv hev irr mf eod eor
   ebv="$(extract_event_bus_variants   "${src}" | lines_to_json_array)"
   hev="$(extract_http_error_variants  "${src}" | lines_to_json_array)"
+  irr="$(extract_invalid_request_reasons "${src}" | lines_to_json_array)"
   mf="$( extract_metrics_fields       "${src}" | lines_to_json_array)"
   eod="$(extract_exact_output_declarations "${src}" | lines_to_json_array)"
   eor="$(extract_exact_output_reexport_declarations "${src}" | lines_to_json_array)"
@@ -309,6 +334,7 @@ build_fingerprint() {
     --arg ver "${OAS_AGENT_SDK_BASE_VERSION}" \
     --argjson ebv "${ebv}" \
     --argjson hev "${hev}" \
+    --argjson irr "${irr}" \
     --argjson mf  "${mf}" \
     --argjson eod "${eod}" \
     --argjson eor "${eor}" \
@@ -318,6 +344,7 @@ build_fingerprint() {
        surfaces: {
          event_bus_payload_variants: $ebv,
          http_error_variants:        $hev,
+         invalid_request_reasons:    $irr,
          metrics_fields:             $mf,
          exact_output_declarations:  $eod,
          exact_output_reexport_declarations: $eor
@@ -338,6 +365,23 @@ diff_arrays_removed() {
 
 report_diff() {
   local section_name="$1" prev_arr="$2" curr_arr="$3"
+  # A section the committed fingerprint does not carry is drift, not a match. jq
+  # reported "array and null cannot be subtracted" here and the run still ended with
+  # "OAS API surface matches fingerprint": the subtraction failed, both counts parsed
+  # as zero, and the section was skipped. Adding a surface to this script therefore
+  # produced a green check that had compared nothing — the failure this script exists
+  # to prevent, in the script itself.
+  if [[ "${prev_arr}" == "null" || "${curr_arr}" == "null" ]]; then
+    echo
+    echo "  [${section_name}]"
+    if [[ "${prev_arr}" == "null" ]]; then
+      echo "    absent from the committed fingerprint — run --regenerate after review"
+    else
+      echo "    absent from the current source — the extractor found no such surface"
+    fi
+    return 1
+  fi
+
   local added removed
   added="$(diff_arrays_added   "${prev_arr}" "${curr_arr}")"
   removed="$(diff_arrays_removed "${prev_arr}" "${curr_arr}")"
@@ -417,7 +461,7 @@ case "${MODE}" in
     if ! report_metadata_diff "${prev}" "${current}"; then
       drift=1
     fi
-    for section in event_bus_payload_variants http_error_variants metrics_fields exact_output_declarations exact_output_reexport_declarations; do
+    for section in event_bus_payload_variants http_error_variants invalid_request_reasons metrics_fields exact_output_declarations exact_output_reexport_declarations; do
       prev_arr="$(jq ".surfaces.${section}" <<<"${prev}")"
       curr_arr="$(jq ".surfaces.${section}" <<<"${current}")"
       if ! report_diff "${section}" "${prev_arr}" "${curr_arr}"; then


### PR DESCRIPTION
결함 두 개. 두 번째는 첫 번째를 고치다 드러났다.

## 1. `Retry.invalid_request_reason` 이 지문에 없었다

지문이 덮는 surface: `event_bus_payload_variants`, `http_error_variants`, `metrics_fields`, exact_output 2종. `Retry.invalid_request_reason` 은 빠져 있었다.

MASC 는 이 타입을 **텔레메트리가 아니라 제어 판정**으로 읽는다 — `keeper_turn_runtime_budget.ml:425`:

| reason | MASC 판정 |
|---|---|
| `Request_body_too_large` | 용량 거부 → **컴팩션 요청** |
| `Json_parse_error` / `Unknown_invalid_request` | 만든 것의 결함 → 요청 없음 |

즉 새 constructor 는 MASC 가 **무엇을 하는지**를 바꾼다.

### 그리고 절반만 만족시켜도 컴파일된다

이 타입을 읽는 masc 3개 지점은 모두 exhaustive 다(`keeper_event_bridge_error_json.ml:48-52`·`:176-182`, `keeper_turn_runtime_budget.ml:425`) — catch-all 없음. 그런데 **셋 중 둘은 wire 렌더러**다. 새 constructor 에 wire 문자열만 주면 컴파일은 깨끗하고, 제어 분류기는 여전히 `None` 을 답한다. 텔레메트리는 있고 제어는 없는 형태 — 이 저장소가 거부하는 그 형태다.

oas#2818 이 정확히 그런 constructor(`Request_body_refused_by_provider`)를 추가하므로, 이 surface 는 빌드가 깨진 **뒤**가 아니라 핀 bump **시점**에 보여야 한다. 그게 이 스크립트가 스스로 선언한 목적이다(`:6-11`).

## 2. 그 검사가 거짓 초록이었다

새 섹션에 대해 jq 가 `array and null cannot be subtracted` 를 출력하는데도 실행은 **`OAS API surface matches fingerprint`** 로 끝났다. 뺄셈이 실패하고 두 count 가 0 으로 파싱되어 섹션이 건너뛰어진 것이다.

**surface 를 추가하면 아무것도 비교하지 않은 초록이 나온다** — 이 스크립트가 막으려는 실패가 스크립트 안에 있었다.

이제 어느 쪽에든 없는 섹션은 보고하고 nonzero 로 종료하며, **어느 쪽이 없는지** 명시한다.

## 검증

| 단계 | 결과 |
|---|---|
| regenerate 전 | `[invalid_request_reasons] absent from the committed fingerprint`, **exit 2** |
| `--regenerate` 후 | exit 0, 현재 constructor 3개 기록 |
| 새 추출기를 oas#2818 브랜치에 실행 | `Request_body_refused_by_provider` 열거 — 핀 bump 시 노출됨 |

`bash -n` 통과.

RFC-WAIVED: 핀 bump 시점 drift 보고 스크립트와 그 baseline. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
