### PR TITLE
feat(dashboard): preserve typed Keeper fleet operator facts

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -395,11 +395,11 @@ describe('dashboardHealthChips', () => {
 
     const chip = chips.find(c => c.key === 'fleet-liveness-risk')
     expect(chip).toEqual(expect.objectContaining({
-      label: 'Fleet execution unavailable',
-      tone: 'warn',
+      label: 'Current Keeper fact invalid',
+      tone: 'bad',
     }))
-    expect(chip?.detail).toContain('canonical keeper_fleet_safety executable snapshot unavailable')
-    expect(chip?.detail).toContain('no liveness or operator action inferred')
+    expect(chip?.detail).toContain('reason=current_fact_invalid')
+    expect(chip?.detail).toContain('restore a canonical current snapshot')
   })
 
   it('surfaces a P0 blocked fleet when health reports zero executable keeper fibers', () => {
@@ -415,6 +415,11 @@ describe('dashboardHealthChips', () => {
           paused_keepers: 13,
           keeper_fleet_safety: {
             status: 'blocked',
+            blocked_keepers: [{
+              keeper_name: 'paused-keeper',
+              reason: 'durable_paused_autoboot_enabled',
+              action: 'resume_or_leave_paused',
+            }],
             reason: null,
             blocker: 'no_executable_keeper_fibers',
             blocked_keeper_count: 14,
@@ -440,7 +445,7 @@ describe('dashboardHealthChips', () => {
 
     const chip = chips.find(c => c.key === 'fleet-liveness-risk')
     expect(chip).toEqual(expect.objectContaining({
-      label: 'P0 fleet blocked',
+      label: 'Keeper paused',
       tone: 'bad',
     }))
     expect(chip?.detail).toContain('status=blocked')
@@ -466,6 +471,11 @@ describe('dashboardHealthChips', () => {
           paused_keepers: 3,
           keeper_fleet_safety: {
             status: 'blocked',
+            blocked_keepers: [{
+              keeper_name: 'paused-keeper',
+              reason: 'durable_paused_autoboot_enabled',
+              action: 'resume_or_leave_paused',
+            }],
             reason: null,
             blocker: 'no_executable_keeper_fibers',
             blocked_keeper_count: 3,
@@ -491,7 +501,7 @@ describe('dashboardHealthChips', () => {
 
     const chip = chips.find(c => c.key === 'fleet-liveness-risk')
     expect(chip).toEqual(expect.objectContaining({
-      label: 'P0 fleet blocked',
+      label: 'Keeper paused',
       tone: 'bad',
     }))
     expect(chip?.detail).toContain('paused_keeper_count=3')
@@ -503,6 +513,11 @@ describe('dashboardHealthChips', () => {
       'failing-only',
       {
         status: 'blocked',
+        blocked_keepers: [{
+          keeper_name: 'failing-keeper',
+          reason: 'phase_failing',
+          action: 'repair_failing_keeper',
+        }],
         reason: null,
         blocker: 'no_executable_keeper_fibers',
         blocked_keeper_count: 2,
@@ -519,6 +534,11 @@ describe('dashboardHealthChips', () => {
       'recovering-only',
       {
         status: 'blocked',
+        blocked_keepers: [{
+          keeper_name: 'recovering-keeper',
+          reason: 'phase_restarting',
+          action: 'wait_for_keeper_restart',
+        }],
         reason: null,
         blocker: 'no_executable_keeper_fibers',
         blocked_keeper_count: 2,
@@ -535,6 +555,11 @@ describe('dashboardHealthChips', () => {
       'unknown',
       {
         status: 'blocked',
+        blocked_keepers: [{
+          keeper_name: null,
+          reason: 'current_fact_invalid',
+          action: 'inspect_current_keeper_fact',
+        }],
         reason: null,
         blocker: 'no_executable_keeper_fibers',
         blocked_keeper_count: 2,
@@ -545,7 +570,7 @@ describe('dashboardHealthChips', () => {
         target_reaction_capacity_count: 2,
       },
       'blocker=no_executable_keeper_fibers',
-      'blocked by no_executable_keeper_fibers',
+      'restore a canonical current snapshot',
     ],
   ] as const)('uses canonical %s evidence for blocked fleet operator advice', (
     _caseName,
@@ -589,6 +614,11 @@ describe('dashboardHealthChips', () => {
           paused_keepers: 14,
           keeper_fleet_safety: {
             status: 'blocked',
+            blocked_keepers: [{
+              keeper_name: 'paused-keeper',
+              reason: 'durable_paused_autoboot_enabled',
+              action: 'resume_or_leave_paused',
+            }],
             reason: null,
             blocker: 'no_executable_keeper_fibers',
             blocked_keeper_count: 16,
@@ -613,7 +643,7 @@ describe('dashboardHealthChips', () => {
 
     const chip = chips.find(c => c.key === 'fleet-liveness-risk')
     expect(chip).toEqual(expect.objectContaining({
-      label: 'P0 fleet blocked',
+      label: 'Keeper paused',
       tone: 'bad',
     }))
     expect(chip?.detail).toContain('paused_autoboot_enabled_keeper_count=13')
@@ -633,6 +663,11 @@ describe('dashboardHealthChips', () => {
           paused_keepers: 2,
           keeper_fleet_safety: {
             status: 'degraded',
+            blocked_keepers: [{
+              keeper_name: 'failing-keeper',
+              reason: 'phase_failing',
+              action: 'repair_failing_keeper',
+            }],
             reason: null,
             blocker: 'reaction_capacity_below_target',
             blocked_keeper_count: 10,
@@ -657,7 +692,7 @@ describe('dashboardHealthChips', () => {
 
     const chip = chips.find(c => c.key === 'fleet-liveness-risk')
     expect(chip).toEqual(expect.objectContaining({
-      label: 'Fleet capacity degraded',
+      label: 'Keeper failing',
       tone: 'warn',
     }))
     expect(chip?.detail).toContain('status=degraded')
@@ -681,6 +716,11 @@ describe('dashboardHealthChips', () => {
           paused_keepers: 0,
           keeper_fleet_safety: {
             status: 'degraded',
+            blocked_keepers: [{
+              keeper_name: 'running-keeper',
+              reason: 'phase_running',
+              action: 'inspect_capacity_accounting',
+            }],
             reason: null,
             blocker: 'reaction_capacity_below_target',
             blocked_keeper_count: 24,
@@ -705,7 +745,7 @@ describe('dashboardHealthChips', () => {
 
     const chip = chips.find(c => c.key === 'fleet-liveness-risk')
     expect(chip).toEqual(expect.objectContaining({
-      label: 'Fleet capacity degraded',
+      label: 'Keeper capacity fact inconsistent',
       tone: 'warn',
     }))
     expect(chip?.detail).not.toContain('FD pressure')
@@ -745,12 +785,11 @@ describe('dashboardHealthChips', () => {
       })
       const chip = chips.find(c => c.key === 'fleet-liveness-risk')
       expect(chip).toEqual(expect.objectContaining({
-        label: 'Fleet execution unavailable',
-        tone: 'warn',
+        label: 'Current Keeper fact invalid',
+        tone: 'bad',
       }))
-      expect(chip?.detail).toContain('canonical keeper_fleet_safety executable snapshot unavailable')
-      expect(chip?.detail).toContain('no liveness or operator action inferred')
-      expect(chip?.detail).not.toContain('executable_keeper_fiber_count=4')
+      expect(chip?.detail).toContain('reason=current_fact_invalid')
+      expect(chip?.detail).toContain('restore a canonical current snapshot')
     }
   })
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -56,6 +56,7 @@ import {
   widgetSoloUrlForRoute,
 } from './widget-solo'
 import {
+  CURRENT_KEEPER_FLEET_FACT_INVALID,
   keeperFleetOperatorFactPresentation,
   keeperFleetOperatorFacts,
 } from './keeper-fleet-operator-fact'
@@ -264,7 +265,7 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
   if (!fleetSafety) return null
   const fleet = fleetSafety.keeper_fleet_safety
   if (fleet?.status === 'ok') return null
-  const fact = keeperFleetOperatorFacts(fleet)[0]
+  const fact = keeperFleetOperatorFacts(fleet)[0] ?? CURRENT_KEEPER_FLEET_FACT_INVALID
   const presentation = keeperFleetOperatorFactPresentation(fact, fleet?.status)
   return {
     key: 'fleet-liveness-risk',

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -37,6 +37,7 @@ import {
 } from '../config/navigation'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
+import type { LucideIcon } from 'lucide-preact'
 import { ExternalLink } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
 import { CopyIdButton } from './common/copy-id-button'
@@ -54,6 +55,10 @@ import {
   WidgetSoloBar,
   widgetSoloUrlForRoute,
 } from './widget-solo'
+import {
+  keeperFleetOperatorFactPresentation,
+  keeperFleetOperatorFacts,
+} from './keeper-fleet-operator-fact'
 
 const buildIdentityOpen = signal(false)
 const shellRuntimeProviderProbe = signal<DashboardRuntimeProbePayload | null>(null)
@@ -211,6 +216,7 @@ interface DashboardHealthChip {
   label: string
   detail: string
   tone: DashboardHealthChipTone
+  Icon?: LucideIcon
   // Optional drill-down route. When set, DashboardHealthStrip renders this
   // chip as a RouteLink so operators can jump from "Source mismatch" /
   // "일시정지 keeper N" / "Reaction ledger pending N" straight to the page
@@ -257,80 +263,46 @@ interface DashboardHealthInput {
 function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): DashboardHealthChip | null {
   if (!fleetSafety) return null
   const fleet = fleetSafety.keeper_fleet_safety
-  const fleetStatus =
-    fleet?.status === 'ok' || fleet?.status === 'degraded' || fleet?.status === 'blocked'
-      ? fleet.status
-      : null
-  const executableValue = fleet?.executable_keeper_fiber_count
-  const executableFibers =
-    typeof executableValue === 'number'
-    && Number.isInteger(executableValue)
-    && executableValue >= 0
-      ? executableValue
-      : null
-  if (!fleet || fleetStatus == null || executableFibers == null) {
-    return {
-      key: 'fleet-liveness-risk',
-      label: 'Fleet execution unavailable',
-      detail: 'canonical keeper_fleet_safety executable snapshot unavailable; no liveness or operator action inferred.',
-      tone: 'warn',
-    }
-  }
-  const pausedKeepers = fleet.paused_keeper_count
-  const failingKeepers = fleet.failing_keeper_fiber_count
-  const recoveringKeepers = fleet.recovering_keeper_fiber_count
-  const pausedAutobootKeepers = fleet?.paused_autoboot_enabled_keeper_count ?? null
-  const targetCapacity = fleet?.target_reaction_capacity_count ?? null
-  const bootableKeepers = fleet?.bootable_keeper_count ?? null
-  const capacityShortfall = fleet?.reaction_capacity_shortfall_count ?? null
-  if (fleetStatus === 'blocked') {
-    const blocker = fleet.blocker?.trim() || null
-    const capacityDetail = [
-      `status=${fleetStatus}`,
-      `executable_keeper_fiber_count=${executableFibers}`,
-      pausedKeepers != null ? `paused_keeper_count=${pausedKeepers}` : null,
-      failingKeepers != null ? `failing_keeper_fiber_count=${failingKeepers}` : null,
-      recoveringKeepers != null ? `recovering_keeper_fiber_count=${recoveringKeepers}` : null,
-      pausedAutobootKeepers != null ? `paused_autoboot_enabled_keeper_count=${pausedAutobootKeepers}` : null,
-      bootableKeepers != null ? `bootable_keeper_count=${bootableKeepers}` : null,
-      targetCapacity != null ? `target_reaction_capacity_count=${targetCapacity}` : null,
-      blocker != null ? `blocker=${blocker}` : null,
-    ].filter((item): item is string => item != null).join(', ')
-    const operatorAction = (pausedKeepers ?? 0) > 0
-      ? 'resume selected paused keepers or confirm an intentional operator pause policy.'
-      : (failingKeepers ?? 0) > 0
-        ? 'inspect and recover failing keepers before retrying scheduled activation.'
-        : (recoveringKeepers ?? 0) > 0
-          ? 'keeper recovery is in progress; wait for executable capacity before intervening.'
-          : blocker != null
-            ? `blocked by ${blocker}; inspect canonical fleet evidence before choosing an operator action.`
-            : 'blocked cause unavailable; no operator action inferred.'
-    return {
-      key: 'fleet-liveness-risk',
-      label: 'P0 fleet blocked',
-      detail: `${capacityDetail}; ${operatorAction}`,
-      tone: 'bad',
-    }
-  }
-  if (fleetStatus === 'degraded') {
-    const capacityDetail = [
-      `status=${fleetStatus}`,
-      `executable_keeper_fiber_count=${executableFibers}`,
-      fleet.failing_keeper_fiber_count != null
+  if (fleet?.status === 'ok') return null
+  const fact = keeperFleetOperatorFacts(fleet)[0]
+  const presentation = keeperFleetOperatorFactPresentation(fact, fleet?.status)
+  return {
+    key: 'fleet-liveness-risk',
+    label: presentation.label,
+    detail: [
+      `status=${fleet?.status ?? 'current_fact_invalid'}`,
+      fleet?.executable_keeper_fiber_count != null
+        ? `executable_keeper_fiber_count=${fleet.executable_keeper_fiber_count}`
+        : null,
+      fleet?.paused_keeper_count != null
+        ? `paused_keeper_count=${fleet.paused_keeper_count}`
+        : null,
+      fleet?.failing_keeper_fiber_count != null
         ? `failing_keeper_fiber_count=${fleet.failing_keeper_fiber_count}`
         : null,
-      targetCapacity != null ? `target_reaction_capacity_count=${targetCapacity}` : null,
-      capacityShortfall != null ? `reaction_capacity_shortfall_count=${capacityShortfall}` : null,
+      fleet?.recovering_keeper_fiber_count != null
+        ? `recovering_keeper_fiber_count=${fleet.recovering_keeper_fiber_count}`
+        : null,
+      fleet?.paused_autoboot_enabled_keeper_count != null
+        ? `paused_autoboot_enabled_keeper_count=${fleet.paused_autoboot_enabled_keeper_count}`
+        : null,
+      fleet?.bootable_keeper_count != null
+        ? `bootable_keeper_count=${fleet.bootable_keeper_count}`
+        : null,
+      fleet?.target_reaction_capacity_count != null
+        ? `target_reaction_capacity_count=${fleet.target_reaction_capacity_count}`
+        : null,
+      fleet?.reaction_capacity_shortfall_count != null
+        ? `reaction_capacity_shortfall_count=${fleet.reaction_capacity_shortfall_count}`
+        : null,
       fleet?.blocker ? `blocker=${fleet.blocker}` : null,
-    ].filter((item): item is string => item != null).join(', ')
-    return {
-      key: 'fleet-liveness-risk',
-      label: 'Fleet capacity degraded',
-      detail: `${capacityDetail}; restore missing keeper fibers or confirm a reduced target capacity.`,
-      tone: 'warn',
-    }
+      `keeper=${presentation.keeper}`,
+      `reason=${presentation.reason}`,
+      `operator_action=${presentation.action}`,
+    ].filter((item): item is string => item != null).join(', '),
+    tone: presentation.tone,
+    Icon: presentation.Icon,
   }
-  return null
 }
 
 function ledgerCount(value: number | null | undefined): number {
@@ -719,18 +691,18 @@ export function DashboardHealthStrip({ hidden = false }: { hidden?: boolean }) {
           key=${chip.key}
           tab=${chip.route.tab}
           params=${chip.route.params}
-          class=${`dashboard-health-chip inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium transition-opacity hover:opacity-80 ${healthChipClass(chip.tone)}`}
+          class=${`dashboard-health-chip inline-flex min-h-6 items-center gap-1.5 rounded-[var(--r-1)] border px-2 py-0.5 font-medium transition-opacity hover:opacity-80 ${healthChipClass(chip.tone)}`}
           title=${chip.detail}
           data-testid=${`dashboard-health-chip-${chip.key}`}
-        >${chip.label}<//>
+        >${chip.Icon ? html`<${chip.Icon} size=${13} aria-hidden="true" />` : null}${chip.label}<//>
       ` : html`
         <span
           key=${chip.key}
-          class=${`dashboard-health-chip inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium ${healthChipClass(chip.tone)}`}
+          class=${`dashboard-health-chip inline-flex min-h-6 items-center gap-1.5 rounded-[var(--r-1)] border px-2 py-0.5 font-medium ${healthChipClass(chip.tone)}`}
           title=${chip.detail}
           data-testid=${`dashboard-health-chip-${chip.key}`}
         >
-          ${chip.label}
+          ${chip.Icon ? html`<${chip.Icon} size=${13} aria-hidden="true" />` : null}${chip.label}
         </span>
       `)}
     </div>

--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -200,7 +200,7 @@ describe('FleetHealthPanel', () => {
     expect(screen.getByTestId('runtime-blocker-board')).toBeTruthy()
     const operatorFact = screen.getByTestId('keeper-fleet-operator-fact-0')
     expect(operatorFact.getAttribute('data-tone')).toBe('warn')
-    expect(operatorFact.querySelector('svg')).toBeTruthy()
+    expect(operatorFact.querySelector('[data-icon="Wrench"]')).toBeTruthy()
     expect(operatorFact.textContent).toContain('Keeper failing')
     expect(operatorFact.textContent).toContain('inspect and recover failing keepers')
     expect(screen.getByText('13/17')).toBeTruthy()

--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -164,10 +164,22 @@ describe('FleetHealthPanel', () => {
           }],
         },
         keeper_fleet_safety: {
+          schema: 'masc.keeper_fleet_operator.v1',
           status: 'degraded',
           reason: null,
           blocker: 'reaction_capacity_below_target',
-          blocked_keeper_count: null,
+          blocked_keeper_count: 1,
+          blocked_keepers: [{
+            keeper_name: 'capacity-missing',
+            agent_name: null,
+            task_id: null,
+            task_status: null,
+            reason: 'phase_failing',
+            action: 'repair_failing_keeper',
+            operator_action_type: null,
+            operator_tool_name: null,
+            operator_action_confirm_required: null,
+          }],
           running_keeper_fiber_count: 8,
           executable_keeper_fiber_count: 13,
           target_reaction_capacity_count: 17,
@@ -186,6 +198,11 @@ describe('FleetHealthPanel', () => {
     expect(screen.getByText('capacity 13/17')).toBeTruthy()
     expect(screen.getByText('일시정지 3')).toBeTruthy()
     expect(screen.getByTestId('runtime-blocker-board')).toBeTruthy()
+    const operatorFact = screen.getByTestId('keeper-fleet-operator-fact-0')
+    expect(operatorFact.getAttribute('data-tone')).toBe('warn')
+    expect(operatorFact.querySelector('svg')).toBeTruthy()
+    expect(operatorFact.textContent).toContain('Keeper failing')
+    expect(operatorFact.textContent).toContain('inspect and recover failing keepers')
     expect(screen.getByText('13/17')).toBeTruthy()
     expect(screen.getByText('analyst')).toBeTruthy()
     expect(screen.getByText('operator_paused')).toBeTruthy()
@@ -203,10 +220,12 @@ describe('FleetHealthPanel', () => {
         keeper_reaction_ledger: null,
         paused_keepers_health: { count: 0, names: [], durable_count: 0, durable_names: [], autoboot_enabled_count: 0, autoboot_enabled_names: [], read_error_count: 0, read_errors: [], details: [] },
         keeper_fleet_safety: {
+          schema: 'masc.keeper_fleet_operator.v1',
           status: 'ok',
           reason: null,
           blocker: null,
-          blocked_keeper_count: null,
+          blocked_keeper_count: 0,
+          blocked_keepers: [],
           running_keeper_fiber_count: 8,
           executable_keeper_fiber_count: 8,
           target_reaction_capacity_count: 8,

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -13,6 +13,8 @@ import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-ref
 import { formatMsCompact, formatNumber } from '../lib/format-number'
 import { refreshShell, shellRuntimeResolution } from '../store'
 import type {
+  DashboardBlockedKeeperFact,
+  DashboardFleetPressureHealth,
   DashboardFleetSafetyHealth,
   DashboardPausedKeeperDetail,
 } from '../types'
@@ -34,6 +36,10 @@ import {
 } from './fleet-data-core'
 import { coverageGapDisplay, freshnessText, sourceHealthClass } from './common/source-health'
 import { CoverageGapBlock } from './common/coverage-gap-block'
+import {
+  keeperFleetOperatorFactPresentation,
+  keeperFleetOperatorFacts,
+} from './keeper-fleet-operator-fact'
 
 type FleetHealthView = 'default' | 'event-log' | 'comparison' | 'tool-quality' | 'gate' | 'attribution' | 'keeper-health'
 
@@ -242,11 +248,12 @@ function FleetCommandStrip() {
   const target = fleet?.target_reaction_capacity_count
   const shortfall = fleet?.reaction_capacity_shortfall_count
   const pausedCount = pausedHealth?.count ?? fleet?.paused_keeper_count ?? fleetSafety?.paused_keepers
-  const tone = fleet?.status === 'blocked'
-    ? 'bad'
-    : fleet?.operator_action_required || fleet?.reaction_capacity_below_target || (pausedCount && pausedCount > 0)
-      ? 'warn'
-      : runtime?.status === 'ready' ? 'ok' : 'warn'
+  const operatorFact = fleet?.status === 'ok' ? null : keeperFleetOperatorFacts(fleet)[0]
+  const operatorPresentation = operatorFact
+    ? keeperFleetOperatorFactPresentation(operatorFact, fleet?.status)
+    : null
+  const tone = operatorPresentation?.tone
+    ?? (fleet?.status === 'ok' && runtime?.status === 'ready' ? 'ok' : 'warn')
   const runtimeLabel = runtime?.status === 'ready' ? '런타임 가동' : `런타임 ${runtime?.status ?? 'unknown'}`
   const tick = fleetSafety ? 'runtime sample' : 'no runtime sample'
 
@@ -352,6 +359,76 @@ function RuntimePausedKeeperTable({ fleetSafety }: { fleetSafety: DashboardFleet
   `
 }
 
+function RuntimeBlockedKeeperFactRow({
+  fact,
+  fleetStatus,
+  index,
+}: {
+  fact: DashboardBlockedKeeperFact
+  fleetStatus: DashboardFleetPressureHealth['status'] | null | undefined
+  index: number
+}) {
+  const presentation = keeperFleetOperatorFactPresentation(fact, fleetStatus)
+  const Icon = presentation.Icon
+  const toneClass = presentation.tone === 'bad'
+    ? 'text-[var(--color-status-err)]'
+    : 'text-[var(--warn-bright)]'
+  return html`
+    <tr
+      class="v2-monitoring-row border-b border-[var(--color-border-default)]/30 last:border-b-0"
+      data-testid=${`keeper-fleet-operator-fact-${index}`}
+      data-tone=${presentation.tone}
+    >
+      <td class="px-3 py-2 font-mono text-[var(--color-fg-primary)]">${presentation.keeper}</td>
+      <td class=${`px-3 py-2 ${toneClass}`}>
+        <span class="inline-flex items-center gap-1.5">
+          <${Icon} size=${14} aria-hidden="true" />
+          <span>${presentation.label}</span>
+        </span>
+        <div class="font-mono text-3xs text-[var(--color-fg-muted)]">${presentation.reason}</div>
+      </td>
+      <td class="px-3 py-2 text-[var(--color-fg-secondary)]">${presentation.action}</td>
+    </tr>
+  `
+}
+
+function RuntimeBlockedKeeperFactTable({
+  fleet,
+}: {
+  fleet: DashboardFleetPressureHealth | null | undefined
+}) {
+  const facts = keeperFleetOperatorFacts(fleet)
+  if (facts.length === 0) {
+    return html`
+      <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-5 text-center text-2xs text-[var(--color-fg-muted)]">
+        No current Keeper blockers.
+      </div>
+    `
+  }
+  return html`
+    <div class="v2-monitoring-card overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+      <table class="v2-monitoring-table w-full text-2xs" aria-label="Keeper fleet operator facts">
+        <thead>
+          <tr class="border-b border-[var(--color-border-default)] text-[var(--color-fg-muted)]">
+            <th scope="col" class="px-3 py-2 text-left font-medium">Keeper</th>
+            <th scope="col" class="px-3 py-2 text-left font-medium">Current fact</th>
+            <th scope="col" class="px-3 py-2 text-left font-medium">Operator action</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${facts.map((fact, index) => html`
+            <${RuntimeBlockedKeeperFactRow}
+              fact=${fact}
+              fleetStatus=${fleet?.status}
+              index=${index}
+            />
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
 function RuntimeBlockerBoard() {
   useEffect(() => {
     void refreshShell({ force: true })
@@ -366,9 +443,13 @@ function RuntimeBlockerBoard() {
   const shortfall = fleet?.reaction_capacity_shortfall_count
   const pausedCount = pausedHealth?.count ?? fleet?.paused_keeper_count ?? fleetSafety?.paused_keepers
   const pausedNames = pausedHealth?.names ?? []
-  const capacityStatus = fleet?.status === 'blocked'
+  const operatorFact = fleet?.status === 'ok' ? null : keeperFleetOperatorFacts(fleet)[0]
+  const operatorTone = operatorFact
+    ? keeperFleetOperatorFactPresentation(operatorFact, fleet?.status).tone
+    : null
+  const capacityStatus = operatorTone === 'bad'
     ? 'crit'
-    : fleet?.operator_action_required || fleet?.reaction_capacity_below_target
+    : operatorTone === 'warn'
       ? 'warn'
       : fleet ? 'ok' : undefined
 
@@ -389,7 +470,11 @@ function RuntimeBlockerBoard() {
         />
       </div>
       <div>
-        <div class="mb-2 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Paused keeper blockers</div>
+        <div class="mb-2 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Keeper operator facts</div>
+        <${RuntimeBlockedKeeperFactTable} fleet=${fleet} />
+      </div>
+      <div>
+        <div class="mb-2 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Paused keeper diagnostics</div>
         <${RuntimePausedKeeperTable} fleetSafety=${fleetSafety} />
       </div>
     </section>

--- a/dashboard/src/components/keeper-fleet-operator-fact.test.ts
+++ b/dashboard/src/components/keeper-fleet-operator-fact.test.ts
@@ -36,6 +36,9 @@ describe('keeper fleet operator fact presentation', () => {
 
   it('fails a missing current fleet fact closed', () => {
     const [invalid] = keeperFleetOperatorFacts(null)
+    if (invalid == null) {
+      throw new Error('missing current fleet fact did not fail closed')
+    }
     const presentation = keeperFleetOperatorFactPresentation(invalid, null)
 
     expect(invalid).toEqual(CURRENT_KEEPER_FLEET_FACT_INVALID)

--- a/dashboard/src/components/keeper-fleet-operator-fact.test.ts
+++ b/dashboard/src/components/keeper-fleet-operator-fact.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { CirclePause } from 'lucide-preact'
 import type { DashboardBlockedKeeperFact } from '../types'
 import {
   CURRENT_KEEPER_FLEET_FACT_INVALID,
@@ -29,7 +30,7 @@ describe('keeper fleet operator fact presentation', () => {
 
     expect(presentation.label).toBe('Keeper paused')
     expect(presentation.tone).toBe('warn')
-    expect(presentation.Icon).toBeTypeOf('object')
+    expect(presentation.Icon).toBe(CirclePause)
     expect(presentation.action).toContain('resume selected paused keepers')
     expect(presentation.reason).toBe('durable_paused_autoboot_enabled')
   })

--- a/dashboard/src/components/keeper-fleet-operator-fact.test.ts
+++ b/dashboard/src/components/keeper-fleet-operator-fact.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardBlockedKeeperFact } from '../types'
+import {
+  CURRENT_KEEPER_FLEET_FACT_INVALID,
+  keeperFleetOperatorFactPresentation,
+  keeperFleetOperatorFacts,
+} from './keeper-fleet-operator-fact'
+
+function fact(
+  overrides: Partial<DashboardBlockedKeeperFact> = {},
+): DashboardBlockedKeeperFact {
+  return {
+    keeper_name: 'sangsu',
+    agent_name: null,
+    task_id: null,
+    task_status: null,
+    reason: 'durable_paused_autoboot_enabled',
+    action: 'resume_or_leave_paused',
+    operator_action_type: null,
+    operator_tool_name: null,
+    operator_action_confirm_required: null,
+    ...overrides,
+  }
+}
+
+describe('keeper fleet operator fact presentation', () => {
+  it('uses the same typed action for label, tone, icon, and operator instruction', () => {
+    const presentation = keeperFleetOperatorFactPresentation(fact(), 'degraded')
+
+    expect(presentation.label).toBe('Keeper paused')
+    expect(presentation.tone).toBe('warn')
+    expect(presentation.Icon).toBeTypeOf('object')
+    expect(presentation.action).toContain('resume selected paused keepers')
+    expect(presentation.reason).toBe('durable_paused_autoboot_enabled')
+  })
+
+  it('fails a missing current fleet fact closed', () => {
+    const [invalid] = keeperFleetOperatorFacts(null)
+    const presentation = keeperFleetOperatorFactPresentation(invalid, null)
+
+    expect(invalid).toEqual(CURRENT_KEEPER_FLEET_FACT_INVALID)
+    expect(presentation).toMatchObject({
+      label: 'Current Keeper fact invalid',
+      tone: 'bad',
+      reason: 'current_fact_invalid',
+    })
+    expect(presentation.action).toContain('canonical current snapshot')
+  })
+
+  it('raises every blocked fleet fact to bad without changing its action', () => {
+    const presentation = keeperFleetOperatorFactPresentation(fact(), 'blocked')
+
+    expect(presentation.tone).toBe('bad')
+    expect(presentation.action).toContain('resume selected paused keepers')
+  })
+})

--- a/dashboard/src/components/keeper-fleet-operator-fact.ts
+++ b/dashboard/src/components/keeper-fleet-operator-fact.ts
@@ -1,0 +1,201 @@
+import {
+  AlertTriangle,
+  CirclePause,
+  FileWarning,
+  Gauge,
+  LoaderCircle,
+  PlayCircle,
+  RefreshCcw,
+  ShieldAlert,
+  Square,
+  UserPlus,
+  Wrench,
+} from 'lucide-preact'
+import type { LucideIcon } from 'lucide-preact'
+import type {
+  DashboardBlockedKeeperFact,
+  DashboardFleetPressureHealth,
+  DashboardKeeperFleetOperatorAction,
+} from '../types'
+
+export type KeeperFleetOperatorTone = 'warn' | 'bad'
+
+interface KeeperFleetOperatorActionPresentation {
+  label: string
+  tone: KeeperFleetOperatorTone
+  Icon: LucideIcon
+  action: string
+}
+
+export interface KeeperFleetOperatorFactPresentation
+  extends KeeperFleetOperatorActionPresentation {
+  keeper: string
+  reason: DashboardBlockedKeeperFact['reason']
+}
+
+const ACTION_PRESENTATION = {
+  resume_or_leave_paused: {
+    label: 'Keeper paused',
+    tone: 'warn',
+    Icon: CirclePause,
+    action: 'resume selected paused keepers or confirm an intentional operator pause policy.',
+  },
+  repair_keeper_meta_file: {
+    label: 'Keeper metadata unreadable',
+    tone: 'bad',
+    Icon: FileWarning,
+    action: 'repair the current Keeper metadata file before activation.',
+  },
+  add_keeper_toml_or_disable_stale_autoboot_meta: {
+    label: 'Keeper definition missing',
+    tone: 'bad',
+    Icon: FileWarning,
+    action: 'add the Keeper definition or remove the unsupported runtime state.',
+  },
+  run_keeper_up_or_recreate_meta: {
+    label: 'Keeper metadata missing',
+    tone: 'bad',
+    Icon: PlayCircle,
+    action: 'create the current Keeper metadata before activation.',
+  },
+  repair_keeper_toml_config: {
+    label: 'Keeper configuration invalid',
+    tone: 'bad',
+    Icon: Wrench,
+    action: 'repair the current Keeper configuration.',
+  },
+  add_sandbox_profile_to_keeper_toml: {
+    label: 'Keeper sandbox profile missing',
+    tone: 'bad',
+    Icon: ShieldAlert,
+    action: 'add a valid sandbox profile to the Keeper definition.',
+  },
+  inspect_keeper_autoboot_logs: {
+    label: 'Keeper materialization failed',
+    tone: 'bad',
+    Icon: AlertTriangle,
+    action: 'inspect the typed materialization failure and repair its current input.',
+  },
+  enable_keeper_bootstrap_or_start_manually: {
+    label: 'Keeper bootstrap disabled',
+    tone: 'warn',
+    Icon: PlayCircle,
+    action: 'enable Keeper bootstrap or start the Keeper explicitly.',
+  },
+  inspect_dead_keeper_root_cause: {
+    label: 'Keeper dead',
+    tone: 'bad',
+    Icon: ShieldAlert,
+    action: 'inspect and repair the terminal Keeper cause before recovery.',
+  },
+  restart_or_disable_stopped_keeper: {
+    label: 'Keeper stopped',
+    tone: 'warn',
+    Icon: Square,
+    action: 'restart the Keeper or keep it explicitly disabled.',
+  },
+  start_or_recover_keeper: {
+    label: 'Keeper not running',
+    tone: 'warn',
+    Icon: PlayCircle,
+    action: 'start or recover the Keeper.',
+  },
+  inspect_capacity_accounting: {
+    label: 'Keeper capacity fact inconsistent',
+    tone: 'bad',
+    Icon: Gauge,
+    action: 'inspect the typed capacity fact before changing fleet targets.',
+  },
+  repair_failing_keeper: {
+    label: 'Keeper failing',
+    tone: 'bad',
+    Icon: Wrench,
+    action: 'inspect and recover failing keepers before retrying scheduled activation.',
+  },
+  recover_context_overflow: {
+    label: 'Keeper context overflowed',
+    tone: 'bad',
+    Icon: AlertTriangle,
+    action: 'recover the Keeper from the typed context-overflow state.',
+  },
+  wait_for_compaction: {
+    label: 'Keeper compacting',
+    tone: 'warn',
+    Icon: LoaderCircle,
+    action: 'wait for the current compaction operation to settle.',
+  },
+  wait_for_handoff: {
+    label: 'Keeper handing off',
+    tone: 'warn',
+    Icon: LoaderCircle,
+    action: 'wait for the current handoff operation to settle.',
+  },
+  wait_for_keeper_drain: {
+    label: 'Keeper draining',
+    tone: 'warn',
+    Icon: LoaderCircle,
+    action: 'wait for the current drain operation to settle.',
+  },
+  inspect_crashed_keeper: {
+    label: 'Keeper crashed',
+    tone: 'bad',
+    Icon: AlertTriangle,
+    action: 'inspect and repair the typed crash cause before recovery.',
+  },
+  wait_for_keeper_restart: {
+    label: 'Keeper restarting',
+    tone: 'warn',
+    Icon: RefreshCcw,
+    action: 'keeper recovery is in progress; wait for executable capacity before intervening.',
+  },
+  create_keeper_or_reassign_task: {
+    label: 'Task owner has no Keeper',
+    tone: 'bad',
+    Icon: UserPlus,
+    action: 'create the Keeper binding or reassign the task.',
+  },
+  inspect_current_keeper_fact: {
+    label: 'Current Keeper fact invalid',
+    tone: 'bad',
+    Icon: ShieldAlert,
+    action: 'inspect the current Keeper fleet fact and restore a canonical current snapshot.',
+  },
+} satisfies Record<DashboardKeeperFleetOperatorAction, KeeperFleetOperatorActionPresentation>
+
+export const CURRENT_KEEPER_FLEET_FACT_INVALID: DashboardBlockedKeeperFact = {
+  keeper_name: null,
+  agent_name: null,
+  task_id: null,
+  task_status: null,
+  reason: 'current_fact_invalid',
+  action: 'inspect_current_keeper_fact',
+  operator_action_type: null,
+  operator_tool_name: null,
+  operator_action_confirm_required: null,
+}
+
+export function keeperFleetOperatorFacts(
+  fleet: DashboardFleetPressureHealth | null | undefined,
+): DashboardBlockedKeeperFact[] {
+  if (fleet?.status === 'ok') return []
+  if (fleet?.blocked_keepers?.length) return fleet.blocked_keepers
+  return [CURRENT_KEEPER_FLEET_FACT_INVALID]
+}
+
+export function keeperFleetOperatorFactPresentation(
+  fact: DashboardBlockedKeeperFact,
+  fleetStatus: DashboardFleetPressureHealth['status'] | null | undefined,
+): KeeperFleetOperatorFactPresentation {
+  const presentation = ACTION_PRESENTATION[fact.action]
+  return {
+    ...presentation,
+    tone:
+      fact.reason === 'current_fact_invalid' || fleetStatus === 'blocked'
+        ? 'bad'
+        : fleetStatus === 'degraded'
+          ? 'warn'
+          : presentation.tone,
+    keeper: fact.keeper_name ?? fact.agent_name ?? 'Keeper fleet',
+    reason: fact.reason,
+  }
+}

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -461,6 +461,7 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         read_errors: [],
       },
       keeper_fleet_safety: {
+        schema: 'masc.keeper_fleet_operator.v1',
         status: 'blocked',
         blocker: 'no_executable_keeper_fibers',
         bootable_keeper_count: 1,
@@ -476,7 +477,25 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         paused_autoboot_enabled_keeper_count: 13,
         target_reaction_capacity_count: 14,
         operator_action_required: true,
-        blocked_keeper_count: 24,
+        blocked_keeper_count: 2,
+        blocked_keepers: [
+          {
+            keeper_name: 'analyst',
+            reason: 'durable_paused_autoboot_enabled',
+            action: 'resume_or_leave_paused',
+            operator_action_type: null,
+            operator_tool_name: null,
+            operator_action_confirm_required: null,
+          },
+          {
+            keeper_name: 'rondo',
+            reason: 'phase_restarting',
+            action: 'wait_for_keeper_restart',
+            operator_action_type: null,
+            operator_tool_name: null,
+            operator_action_confirm_required: null,
+          },
+        ],
       },
       keeper_reaction_ledger: {
         status: 'ok',
@@ -509,6 +528,7 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         }],
       },
       keeper_fleet_safety: {
+        schema: 'masc.keeper_fleet_operator.v1',
         status: 'blocked',
         blocker: 'no_executable_keeper_fibers',
         bootable_keeper_count: 1,
@@ -524,7 +544,19 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         paused_autoboot_enabled_keeper_count: 13,
         target_reaction_capacity_count: 14,
         operator_action_required: true,
-        blocked_keeper_count: 24,
+        blocked_keeper_count: 2,
+        blocked_keepers: [
+          {
+            keeper_name: 'analyst',
+            reason: 'durable_paused_autoboot_enabled',
+            action: 'resume_or_leave_paused',
+          },
+          {
+            keeper_name: 'rondo',
+            reason: 'phase_restarting',
+            action: 'wait_for_keeper_restart',
+          },
+        ],
       },
       keeper_reaction_ledger: {
         status: 'ok',
@@ -534,6 +566,35 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         pending_stimulus_count: 0,
         read_error_count: 0,
       },
+    })
+  })
+
+  it('collapses a malformed Keeper operator item into one bad current fact', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
+      keeper_fleet_safety: {
+        schema: 'masc.keeper_fleet_operator.v1',
+        status: 'degraded',
+        blocker: 'reaction_capacity_below_target',
+        blocked_keeper_count: 1,
+        blocked_keepers: [{
+          keeper_name: 'sangsu',
+          reason: 'phase_failing',
+          action: 'unsupported_action',
+        }],
+        operator_action_required: true,
+      },
+    }))
+
+    expect(result?.fleet_safety?.keeper_fleet_safety).toMatchObject({
+      status: 'blocked',
+      blocker: 'current_fact_invalid',
+      blocked_keeper_count: 1,
+      operator_action_required: true,
+      blocked_keepers: [{
+        keeper_name: null,
+        reason: 'current_fact_invalid',
+        action: 'inspect_current_keeper_fact',
+      }],
     })
   })
 

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -8,6 +8,11 @@ import {
 import { normalizeKeeperTrust } from './keeper-store-normalize'
 import { normalizeStopCause } from './lib/stop-cause'
 import { parseAgentStatus } from './lib/agent-status'
+import {
+  DASHBOARD_BLOCKED_KEEPER_REASONS,
+  DASHBOARD_KEEPER_FLEET_OPERATOR_ACTIONS,
+  DASHBOARD_KEEPER_FLEET_OPERATOR_SCHEMA,
+} from './types/dashboard-execution'
 import type {
   Agent, Task, TaskGateEvaluation, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
@@ -16,6 +21,9 @@ import type {
   DashboardExecutionContinuityBrief,
   DashboardConfigResolution,
   DashboardConfigResolutionItem,
+  DashboardBlockedKeeperFact,
+  DashboardBlockedKeeperReason,
+  DashboardKeeperFleetOperatorAction,
   DashboardFleetPressureHealth,
   DashboardFleetSafetyHealth,
   DashboardBlockerClassObject,
@@ -699,16 +707,83 @@ function normalizeDashboardPausedKeepersHealth(raw: unknown): DashboardPausedKee
   }
 }
 
+const dashboardBlockedKeeperReasonSet: ReadonlySet<string> =
+  new Set(DASHBOARD_BLOCKED_KEEPER_REASONS)
+const dashboardKeeperFleetOperatorActionSet: ReadonlySet<string> =
+  new Set(DASHBOARD_KEEPER_FLEET_OPERATOR_ACTIONS)
+
+function currentKeeperFleetFactInvalid(): DashboardBlockedKeeperFact {
+  return {
+    keeper_name: null,
+    agent_name: null,
+    task_id: null,
+    task_status: null,
+    reason: 'current_fact_invalid',
+    action: 'inspect_current_keeper_fact',
+    operator_action_type: null,
+    operator_tool_name: null,
+    operator_action_confirm_required: null,
+  }
+}
+
+function nonEmptyString(value: unknown): string | null {
+  const parsed = asString(value)?.trim()
+  return parsed ? parsed : null
+}
+
+function normalizeDashboardBlockedKeeperFact(raw: unknown): DashboardBlockedKeeperFact | null {
+  if (!isRecord(raw)) return null
+  const keeperName = raw.keeper_name === null ? null : nonEmptyString(raw.keeper_name)
+  const agentName = raw.agent_name == null ? null : nonEmptyString(raw.agent_name)
+  const taskId = raw.task_id == null ? null : nonEmptyString(raw.task_id)
+  const taskStatus = raw.task_status == null ? null : nonEmptyString(raw.task_status)
+  const rawReason = nonEmptyString(raw.reason)
+  const rawAction = nonEmptyString(raw.action)
+  if (
+    rawReason == null
+    || !dashboardBlockedKeeperReasonSet.has(rawReason)
+    || rawAction == null
+    || !dashboardKeeperFleetOperatorActionSet.has(rawAction)
+  ) {
+    return null
+  }
+  const reason = rawReason as DashboardBlockedKeeperReason
+  const action = rawAction as DashboardKeeperFleetOperatorAction
+  if (keeperName == null && !(reason === 'no_keeper_binding' && agentName != null)) {
+    return null
+  }
+  return {
+    keeper_name: keeperName,
+    agent_name: agentName,
+    task_id: taskId,
+    task_status: taskStatus,
+    reason,
+    action,
+    operator_action_type:
+      raw.operator_action_type == null ? null : nonEmptyString(raw.operator_action_type),
+    operator_tool_name:
+      raw.operator_tool_name == null ? null : nonEmptyString(raw.operator_tool_name),
+    operator_action_confirm_required:
+      raw.operator_action_confirm_required == null
+        ? null
+        : asBoolean(raw.operator_action_confirm_required) ?? null,
+  }
+}
+
 function normalizeDashboardFleetPressureHealth(raw: unknown): DashboardFleetPressureHealth | null {
   if (!isRecord(raw)) return null
+  const schema = asString(raw.schema)
   const rawStatus = asString(raw.status)
   const status =
     rawStatus === 'ok' || rawStatus === 'degraded' || rawStatus === 'blocked'
       ? rawStatus
       : null
   const reason = asString(raw.reason) ?? null
-  const blocker = asString(raw.blocker) ?? null
+  const blocker = raw.blocker === null ? null : asString(raw.blocker) ?? null
   const blockedKeeperCount = asNumber(raw.blocked_keeper_count)
+  const blockedKeepers = Array.isArray(raw.blocked_keepers)
+    ? raw.blocked_keepers.map(normalizeDashboardBlockedKeeperFact)
+    : null
   const bootableKeeperCount = asNumber(raw.bootable_keeper_count)
   const runningKeeperFiberCount = asNumber(raw.running_keeper_fiber_count)
   const failingKeeperFiberCount = asNumber(raw.failing_keeper_fiber_count)
@@ -722,32 +797,55 @@ function normalizeDashboardFleetPressureHealth(raw: unknown): DashboardFleetPres
   const pausedAutobootEnabledKeeperCount = asNumber(raw.paused_autoboot_enabled_keeper_count)
   const targetReactionCapacityCount = asNumber(raw.target_reaction_capacity_count)
   const operatorActionRequired = asBoolean(raw.operator_action_required)
-  if (
-    status == null
-    && reason == null
-    && blocker == null
-    && blockedKeeperCount == null
-    && bootableKeeperCount == null
-    && runningKeeperFiberCount == null
-    && failingKeeperFiberCount == null
-    && recoveringKeeperFiberCount == null
-    && executableKeeperFiberCount == null
-    && noExecutableKeeperFibers == null
-    && reactionCapacityBelowTarget == null
-    && reactionCapacityShortfallCount == null
-    && pausedKeeperCount == null
-    && autobootEnabledKeeperCount == null
-    && pausedAutobootEnabledKeeperCount == null
-    && targetReactionCapacityCount == null
-    && operatorActionRequired == null
-  ) {
-    return null
+  const canonicalBlockedKeepers =
+    blockedKeepers?.every((fact): fact is DashboardBlockedKeeperFact => fact != null)
+      ? blockedKeepers
+      : null
+  const blockedCountIsCurrent =
+    blockedKeeperCount != null
+    && Number.isInteger(blockedKeeperCount)
+    && blockedKeeperCount >= 0
+  const currentShape =
+    schema === DASHBOARD_KEEPER_FLEET_OPERATOR_SCHEMA
+    && status != null
+    && Object.prototype.hasOwnProperty.call(raw, 'blocker')
+    && blockedCountIsCurrent
+    && canonicalBlockedKeepers != null
+    && blockedKeeperCount === canonicalBlockedKeepers.length
+    && operatorActionRequired != null
+    && operatorActionRequired === (status !== 'ok')
+    && ((status === 'ok' && canonicalBlockedKeepers.length === 0)
+      || (status !== 'ok' && canonicalBlockedKeepers.length > 0))
+  if (!currentShape) {
+    return {
+      schema: DASHBOARD_KEEPER_FLEET_OPERATOR_SCHEMA,
+      status: 'blocked',
+      reason: 'current_fact_invalid',
+      blocker: 'current_fact_invalid',
+      blocked_keeper_count: 1,
+      blocked_keepers: [currentKeeperFleetFactInvalid()],
+      bootable_keeper_count: bootableKeeperCount ?? null,
+      running_keeper_fiber_count: runningKeeperFiberCount ?? null,
+      failing_keeper_fiber_count: failingKeeperFiberCount ?? null,
+      recovering_keeper_fiber_count: recoveringKeeperFiberCount ?? null,
+      executable_keeper_fiber_count: executableKeeperFiberCount ?? null,
+      no_executable_keeper_fibers: noExecutableKeeperFibers ?? null,
+      reaction_capacity_below_target: reactionCapacityBelowTarget ?? null,
+      reaction_capacity_shortfall_count: reactionCapacityShortfallCount ?? null,
+      paused_keeper_count: pausedKeeperCount ?? null,
+      autoboot_enabled_keeper_count: autobootEnabledKeeperCount ?? null,
+      paused_autoboot_enabled_keeper_count: pausedAutobootEnabledKeeperCount ?? null,
+      target_reaction_capacity_count: targetReactionCapacityCount ?? null,
+      operator_action_required: true,
+    }
   }
   return {
+    schema: DASHBOARD_KEEPER_FLEET_OPERATOR_SCHEMA,
     status,
     reason,
     blocker,
-    blocked_keeper_count: blockedKeeperCount ?? null,
+    blocked_keeper_count: blockedKeeperCount,
+    blocked_keepers: canonicalBlockedKeepers,
     bootable_keeper_count: bootableKeeperCount ?? null,
     running_keeper_fiber_count: runningKeeperFiberCount ?? null,
     failing_keeper_fiber_count: failingKeeperFiberCount ?? null,
@@ -760,7 +858,7 @@ function normalizeDashboardFleetPressureHealth(raw: unknown): DashboardFleetPres
     autoboot_enabled_keeper_count: autobootEnabledKeeperCount ?? null,
     paused_autoboot_enabled_keeper_count: pausedAutobootEnabledKeeperCount ?? null,
     target_reaction_capacity_count: targetReactionCapacityCount ?? null,
-    operator_action_required: operatorActionRequired ?? null,
+    operator_action_required: operatorActionRequired,
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -200,11 +200,82 @@ export interface DashboardKeeperReactionLedgerHealth {
   pending_by_keeper: DashboardKeeperReactionLedgerPendingKeeper[]
 }
 
+export const DASHBOARD_KEEPER_FLEET_OPERATOR_SCHEMA = 'masc.keeper_fleet_operator.v1' as const
+
+export const DASHBOARD_BLOCKED_KEEPER_REASONS = [
+  'durable_paused_autoboot_enabled',
+  'meta_read_error',
+  'not_bootable',
+  'missing_meta',
+  'config_invalid',
+  'sandbox_profile_required',
+  'materialization_failed',
+  'phase_offline',
+  'phase_running',
+  'phase_failing',
+  'phase_overflowed',
+  'phase_compacting',
+  'phase_handing_off',
+  'phase_draining',
+  'phase_paused',
+  'phase_stopped',
+  'phase_crashed',
+  'phase_restarting',
+  'phase_dead',
+  'keeper_bootstrap_disabled',
+  'not_registered',
+  'not_running',
+  'no_keeper_binding',
+  'current_fact_invalid',
+] as const
+
+export const DASHBOARD_KEEPER_FLEET_OPERATOR_ACTIONS = [
+  'resume_or_leave_paused',
+  'repair_keeper_meta_file',
+  'add_keeper_toml_or_disable_stale_autoboot_meta',
+  'run_keeper_up_or_recreate_meta',
+  'repair_keeper_toml_config',
+  'add_sandbox_profile_to_keeper_toml',
+  'inspect_keeper_autoboot_logs',
+  'enable_keeper_bootstrap_or_start_manually',
+  'inspect_dead_keeper_root_cause',
+  'restart_or_disable_stopped_keeper',
+  'start_or_recover_keeper',
+  'inspect_capacity_accounting',
+  'repair_failing_keeper',
+  'recover_context_overflow',
+  'wait_for_compaction',
+  'wait_for_handoff',
+  'wait_for_keeper_drain',
+  'inspect_crashed_keeper',
+  'wait_for_keeper_restart',
+  'create_keeper_or_reassign_task',
+  'inspect_current_keeper_fact',
+] as const
+
+export type DashboardBlockedKeeperReason = typeof DASHBOARD_BLOCKED_KEEPER_REASONS[number]
+export type DashboardKeeperFleetOperatorAction =
+  typeof DASHBOARD_KEEPER_FLEET_OPERATOR_ACTIONS[number]
+
+export interface DashboardBlockedKeeperFact {
+  keeper_name: string | null
+  agent_name: string | null
+  task_id: string | null
+  task_status: string | null
+  reason: DashboardBlockedKeeperReason
+  action: DashboardKeeperFleetOperatorAction
+  operator_action_type: string | null
+  operator_tool_name: string | null
+  operator_action_confirm_required: boolean | null
+}
+
 export interface DashboardFleetPressureHealth {
-  status: 'ok' | 'degraded' | 'blocked' | null
+  schema: typeof DASHBOARD_KEEPER_FLEET_OPERATOR_SCHEMA
+  status: 'ok' | 'degraded' | 'blocked'
   reason: string | null
   blocker?: string | null
-  blocked_keeper_count: number | null
+  blocked_keeper_count: number
+  blocked_keepers: DashboardBlockedKeeperFact[]
   bootable_keeper_count?: number | null
   running_keeper_fiber_count?: number | null
   failing_keeper_fiber_count?: number | null

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -683,7 +683,7 @@ type blocked_keeper_reason =
   | Not_registered
   | Not_running
   | No_keeper_binding
-  | Unknown
+  | Current_fact_invalid
 
 let blocked_keeper_reason_label = function
   | Durable_paused_autoboot_enabled -> "durable_paused_autoboot_enabled"
@@ -695,7 +695,7 @@ let blocked_keeper_reason_label = function
   | Not_registered -> "not_registered"
   | Not_running -> "not_running"
   | No_keeper_binding -> "no_keeper_binding"
-  | Unknown -> "unknown"
+  | Current_fact_invalid -> "current_fact_invalid"
 
 type blocked_keeper_operator_action =
   | Resume_or_leave_paused
@@ -718,6 +718,7 @@ type blocked_keeper_operator_action =
   | Inspect_crashed_keeper
   | Wait_for_keeper_restart
   | Create_keeper_or_reassign_task
+  | Inspect_current_keeper_fact
 
 let blocked_keeper_operator_action_to_string = function
   | Resume_or_leave_paused -> "resume_or_leave_paused"
@@ -742,6 +743,7 @@ let blocked_keeper_operator_action_to_string = function
   | Inspect_crashed_keeper -> "inspect_crashed_keeper"
   | Wait_for_keeper_restart -> "wait_for_keeper_restart"
   | Create_keeper_or_reassign_task -> "create_keeper_or_reassign_task"
+  | Inspect_current_keeper_fact -> "inspect_current_keeper_fact"
 
 let blocked_keeper_action = function
   | Durable_paused_autoboot_enabled -> Resume_or_leave_paused
@@ -771,7 +773,7 @@ let blocked_keeper_action = function
   | Not_registered -> Start_or_recover_keeper
   | Not_running -> Start_or_recover_keeper
   | No_keeper_binding -> Create_keeper_or_reassign_task
-  | Unknown -> Inspect_keeper_autoboot_logs
+  | Current_fact_invalid -> Inspect_current_keeper_fact
 
 let blocked_keeper_action_label reason =
   reason |> blocked_keeper_action |> blocked_keeper_operator_action_to_string
@@ -803,7 +805,7 @@ let blocked_keeper_operator_action = function
   | Not_registered
   | Not_running
   | No_keeper_binding
-  | Unknown ->
+  | Current_fact_invalid ->
       None
 
 let blocked_keeper_operator_action_fields reason =
@@ -985,7 +987,7 @@ let blocked_keeper_detail_json
              | None ->
                if keeper_bootstrap_enabled then Not_registered
                else Bootstrap_disabled)
-          else Unknown
+          else Current_fact_invalid
   in
   let terminal_phase_field =
     match phase with
@@ -1056,8 +1058,7 @@ let blocked_keeper_detail_json
   in
   `Assoc
     ([
-       ("keeper", `String name);
-       ("name", `String name);
+       ("keeper_name", `String name);
        ("reason", `String (blocked_keeper_reason_label reason));
        ("action", `String (blocked_keeper_action_label reason));
        ("phase", Json_util.string_opt_to_json phase_name);
@@ -1131,9 +1132,7 @@ let active_task_owner_without_executable_fiber_json row =
   in
   `Assoc
     [
-      ("keeper", Json_util.string_opt_to_json row.keeper_name);
-      (* Legacy alias retained for existing fleet-safety consumers. *)
-      ("name", Json_util.string_opt_to_json row.keeper_name);
+      ("keeper_name", Json_util.string_opt_to_json row.keeper_name);
       ("agent_name", `String row.agent_name);
       ("task_id", `String row.task_id);
       ("task_status", `String row.task_status);
@@ -1299,15 +1298,15 @@ let active_task_owner_blocked_detail_json row =
     | None -> No_keeper_binding
   in
   `Assoc
-    [
-      ("keeper", Json_util.string_opt_to_json row.keeper_name);
-      ("name", Json_util.string_opt_to_json row.keeper_name);
-      ("agent_name", `String row.agent_name);
-      ("task_id", `String row.task_id);
-      ("task_status", `String row.task_status);
-      ("reason", `String (blocked_keeper_reason_label reason));
-      ("action", `String (blocked_keeper_action_label reason));
-    ]
+    ([
+       ("keeper_name", Json_util.string_opt_to_json row.keeper_name);
+       ("agent_name", `String row.agent_name);
+       ("task_id", `String row.task_id);
+       ("task_status", `String row.task_status);
+       ("reason", `String (blocked_keeper_reason_label reason));
+       ("action", `String (blocked_keeper_action_label reason));
+     ]
+     @ blocked_keeper_operator_action_fields reason)
 
 let keeper_fleet_safety_health_json
     ?bootable_names:bootable_names_override
@@ -1459,7 +1458,6 @@ let keeper_fleet_safety_health_json
      a capacity shortfall; see the PR summary.
      Consumers should read this as "number of named blockers" rather than
      missing capacity slots. *)
-  let blocked_keeper_count = List.length blocked_keeper_names in
   let active_capacity_names = executable_names in
   let bootable_set = string_set_of_list bootable_names in
   let capacity_set = string_set_of_list active_capacity_names in
@@ -1471,7 +1469,7 @@ let keeper_fleet_safety_health_json
   let read_error_set =
     autoboot_scan.read_errors |> List.map fst |> string_set_of_list
   in
-  let blocked_keeper_reasons =
+  let blocked_keepers =
     if active_task_owner_is_selected_blocker then
       active_task_owner_scan.active_task_owner_without_executable_fibers
       |> List.map active_task_owner_blocked_detail_json
@@ -1490,6 +1488,7 @@ let keeper_fleet_safety_health_json
                ~read_error_set
                name)
   in
+  let blocked_keeper_count = List.length blocked_keepers in
   let blocker =
     if keeper_bootstrap_blocked then Some "keeper_bootstrap_disabled"
     else if no_executable_keeper_fibers then Some "no_executable_keeper_fibers"
@@ -1500,7 +1499,8 @@ let keeper_fleet_safety_health_json
     else None
   in
   `Assoc
-    [ "status", `String status
+    [ "schema", `String "masc.keeper_fleet_operator.v1"
+    ; "status", `String status
     ; ("blocker", Json_util.string_opt_to_json blocker)
     ; "keeper_bootstrap_enabled", `Bool keeper_bootstrap_enabled
     ; ( "keeper_bootstrap_blocker"
@@ -1570,10 +1570,8 @@ let keeper_fleet_safety_health_json
     ; "paused_autoboot_enabled_keeper_count", `Int paused_autoboot_count
     ; "blocked_keeper_count", `Int blocked_keeper_count
     ; ( "blocked_keeper_count_semantics"
-      , `String "number of named keepers currently listed in blocked_keeper_names" )
-    ; ( "blocked_keeper_names"
-      , `List (List.map (fun name -> `String name) blocked_keeper_names) )
-    ; "blocked_keeper_reasons", `List blocked_keeper_reasons
+      , `String "number of canonical blocked_keepers items" )
+    ; "blocked_keepers", `List blocked_keepers
     ; ( "operator_action_required"
       , `Bool
           (no_executable_keeper_fibers

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1971,6 +1971,15 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
         Alcotest.(check bool) "health does not require operator action" false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
+let canonical_blocked_keeper_rows json =
+  let open Yojson.Safe.Util in
+  json |> member "blocked_keepers" |> to_list
+
+let canonical_blocked_keeper_names json =
+  let open Yojson.Safe.Util in
+  canonical_blocked_keeper_rows json
+  |> List.filter_map (fun row -> row |> member "keeper_name" |> to_string_option)
+
 let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
   with_temp_dir "health-active-task-owner-without-binding" (fun dir ->
     let config_root = make_config_root dir in
@@ -2030,9 +2039,11 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Alcotest.(check int) "health exposes missing binding task row" 1
           (List.length active_owner_tasks);
         let active_owner_task = List.hd active_owner_tasks in
-        Alcotest.(check bool) "missing binding row keeper null" true
+        Alcotest.(check bool) "missing binding row keeper_name null" true
+          (active_owner_task |> member "keeper_name" = `Null);
+        Alcotest.(check bool) "missing binding row keeper alias absent" true
           (active_owner_task |> member "keeper" = `Null);
-        Alcotest.(check bool) "missing binding row name null" true
+        Alcotest.(check bool) "missing binding row name alias absent" true
           (active_owner_task |> member "name" = `Null);
         Alcotest.(check string) "missing binding row agent" assignee
           (active_owner_task |> member "agent_name" |> to_string);
@@ -2042,14 +2053,13 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Alcotest.(check string) "missing binding action"
           "create_keeper_or_reassign_task"
           (active_owner_task |> member "action" |> to_string);
-        Alcotest.(check (list string)) "health names missing binding assignee"
-          [ assignee ]
-          (fleet_safety |> member "blocked_keeper_names" |> to_list
-           |> List.map to_string);
+        Alcotest.(check (list string)) "health does not invent Keeper identity"
+          []
+          (canonical_blocked_keeper_names fleet_safety);
         Alcotest.(check (list (pair string string)))
           "health explains missing binding blocker"
           [ (assignee, "no_keeper_binding") ]
-          (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+          (fleet_safety |> member "blocked_keepers" |> to_list
            |> List.map (fun row ->
                 ( row |> member "agent_name" |> to_string
                 , row |> member "reason" |> to_string )));
@@ -2127,8 +2137,7 @@ let test_health_json_reports_non_keeper_active_task_owner_as_advisory () =
           (owner |> member "fleet_blocking" |> to_bool);
         Alcotest.(check (list string)) "health has no blocked keeper names"
           []
-          (fleet_safety |> member "blocked_keeper_names" |> to_list
-           |> List.map to_string);
+          (canonical_blocked_keeper_names fleet_safety);
         Alcotest.(check bool) "health does not ask operator action" false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
@@ -2505,24 +2514,27 @@ let test_health_json_degrades_when_only_one_running_phase_lane_is_live () =
             (fleet_safety |> member "blocked_keeper_count" |> to_int);
           Alcotest.(check (list string)) "health exposes blocked keeper names"
             [ "capacity-missing"; "capacity-running-b"; "example" ]
-            (fleet_safety |> member "blocked_keeper_names" |> to_list
-             |> List.map to_string);
+            (canonical_blocked_keeper_names fleet_safety);
           Alcotest.(check (list (pair string string)))
             "health explains blocked keeper reasons"
             [ ("capacity-missing", "not_registered")
             ; ("capacity-running-b", "phase_Running")
             ; ("example", "not_registered")
             ]
-            (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            (fleet_safety |> member "blocked_keepers" |> to_list
              |> List.map (fun row ->
-                  (row |> member "keeper" |> to_string, row |> member "reason" |> to_string)));
+                  (row |> member "keeper_name" |> to_string, row |> member "reason" |> to_string)));
           let blocked_detail name =
-            fleet_safety |> member "blocked_keeper_reasons" |> to_list
-            |> List.find (fun row -> row |> member "keeper" |> to_string = name)
+            fleet_safety |> member "blocked_keepers" |> to_list
+            |> List.find (fun row -> row |> member "keeper_name" |> to_string = name)
           in
-          Alcotest.(check string) "health keeps typed row name alias"
+          Alcotest.(check string) "health keeps canonical keeper_name"
             "capacity-missing"
-            (blocked_detail "capacity-missing" |> member "name" |> to_string);
+            (blocked_detail "capacity-missing" |> member "keeper_name" |> to_string);
+          Alcotest.(check bool) "health omits keeper alias" true
+            (blocked_detail "capacity-missing" |> member "keeper" = `Null);
+          Alcotest.(check bool) "health omits name alias" true
+            (blocked_detail "capacity-missing" |> member "name" = `Null);
           Alcotest.(check string) "health suggests missing target action"
             "start_or_recover_keeper"
             (blocked_detail "capacity-missing" |> member "action" |> to_string);
@@ -2597,8 +2609,7 @@ let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacit
               (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
             Alcotest.(check (list string)) "health names blocked target keepers"
               [ "example"; "target-missing" ]
-              (fleet_safety |> member "blocked_keeper_names" |> to_list
-               |> List.map to_string);
+              (canonical_blocked_keeper_names fleet_safety);
             Alcotest.(check int) "blocked count matches blocked keeper names" 2
               (fleet_safety |> member "blocked_keeper_count" |> to_int))))
 
@@ -2660,8 +2671,8 @@ let test_health_json_exposes_disabled_keeper_bootstrap_blocker () =
           "keeper_bootstrap_disabled"
           (fleet_safety |> member "keeper_bootstrap_blocker" |> to_string);
         let blocked_detail name =
-          fleet_safety |> member "blocked_keeper_reasons" |> to_list
-          |> List.find (fun row -> row |> member "keeper" |> to_string = name)
+          fleet_safety |> member "blocked_keepers" |> to_list
+          |> List.find (fun row -> row |> member "keeper_name" |> to_string = name)
         in
         let detail = blocked_detail "boot-disabled" in
         Alcotest.(check string) "health explains disabled bootstrap row"
@@ -2706,14 +2717,13 @@ let test_health_json_ignores_persisted_only_keeper_for_capacity_target () =
         Alcotest.(check (list string))
           "health excludes persisted-only keepers from blocked target"
           [ "example" ]
-          (fleet_safety |> member "blocked_keeper_names" |> to_list
-           |> List.map to_string);
+          (canonical_blocked_keeper_names fleet_safety);
         Alcotest.(check (list (pair string string)))
           "health explains remaining configured blocked target"
           [ ("example", "not_registered") ]
-          (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+          (fleet_safety |> member "blocked_keepers" |> to_list
            |> List.map (fun row ->
-                ( row |> member "keeper" |> to_string
+                ( row |> member "keeper_name" |> to_string
                 , row |> member "reason" |> to_string )))))
 
 let test_health_json_explains_phase_paused_capacity_blocker () =
@@ -2752,14 +2762,13 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
           Alcotest.(check (list string))
             "health includes phase-paused keeper in blocked targets"
             [ "example"; "phase-paused" ]
-            (fleet_safety |> member "blocked_keeper_names" |> to_list
-             |> List.map to_string);
+            (canonical_blocked_keeper_names fleet_safety);
           Alcotest.(check (list (pair string string)))
             "health explains phase-paused blocked keeper"
             [ ("example", "not_registered"); ("phase-paused", "phase_paused") ]
-            (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            (fleet_safety |> member "blocked_keepers" |> to_list
              |> List.map (fun row ->
-	                  ( row |> member "keeper" |> to_string
+	                  ( row |> member "keeper_name" |> to_string
 	                  , row |> member "reason" |> to_string ))))))
 
 let test_health_json_exposes_dead_keeper_registry_cause () =
@@ -2788,8 +2797,8 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
           let open Yojson.Safe.Util in
           let fleet_safety = json |> member "keeper_fleet_safety" in
           let blocked_detail name =
-            fleet_safety |> member "blocked_keeper_reasons" |> to_list
-            |> List.find (fun row -> row |> member "keeper" |> to_string = name)
+            fleet_safety |> member "blocked_keepers" |> to_list
+            |> List.find (fun row -> row |> member "keeper_name" |> to_string = name)
           in
           let detail = blocked_detail "phase-dead" in
           Alcotest.(check string) "health explains dead keeper reason" "phase_dead"
@@ -2877,20 +2886,19 @@ let test_health_json_explains_terminal_capacity_blocker
           Alcotest.(check (list string))
             "health includes terminal keeper in blocked targets"
             (List.sort String.compare [ keeper_name; "example" ])
-            (fleet_safety |> member "blocked_keeper_names" |> to_list
-             |> List.map to_string);
+            (canonical_blocked_keeper_names fleet_safety);
           Alcotest.(check (list (pair string string)))
             "health explains terminal blocked keeper"
             (List.sort compare
                [ (keeper_name, "phase_" ^ expected_phase); ("example", "not_registered") ])
-            (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            (fleet_safety |> member "blocked_keepers" |> to_list
              |> List.map (fun row ->
-                  ( row |> member "keeper" |> to_string
+                  ( row |> member "keeper_name" |> to_string
                   , row |> member "reason" |> to_string )));
           let terminal_detail =
-            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            fleet_safety |> member "blocked_keepers" |> to_list
             |> List.find (fun row ->
-                 row |> member "keeper" |> to_string = keeper_name)
+                 row |> member "keeper_name" |> to_string = keeper_name)
           in
           Alcotest.(check string) "health reports typed terminal phase"
             expected_phase
@@ -3015,21 +3023,20 @@ let test_health_json_explains_nonrecoverable_failing_keeper () =
           Alcotest.(check (list string))
             "health includes nonrecoverable failing keeper in blocked targets"
             [ "capacity-failing"; "example" ]
-            (fleet_safety |> member "blocked_keeper_names" |> to_list
-             |> List.map to_string);
+            (canonical_blocked_keeper_names fleet_safety);
           Alcotest.(check (list (pair string string)))
             "health explains nonrecoverable failing keeper"
             [ ("capacity-failing", "phase_dead"); ("example", "not_registered") ]
-            (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            (fleet_safety |> member "blocked_keepers" |> to_list
              |> List.map (fun row ->
-                  ( row |> member "keeper" |> to_string
+                  ( row |> member "keeper_name" |> to_string
                   , row |> member "reason" |> to_string )));
           let capacity_row =
-            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            fleet_safety |> member "blocked_keepers" |> to_list
             |> List.find_opt (fun row ->
                  String.equal
                    "capacity-failing"
-                   (row |> member "keeper" |> to_string))
+                   (row |> member "keeper_name" |> to_string))
           in
           match capacity_row with
           | None -> Alcotest.fail "missing capacity-failing blocked row"
@@ -3103,11 +3110,11 @@ let test_health_json_redacts_registry_failure_reason () =
           let open Yojson.Safe.Util in
           let fleet_safety = json |> member "keeper_fleet_safety" in
           let failing_row =
-            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            fleet_safety |> member "blocked_keepers" |> to_list
             |> List.find_opt (fun row ->
                  String.equal
                    "secret-failing"
-                   (row |> member "keeper" |> to_string))
+                   (row |> member "keeper_name" |> to_string))
           in
           match failing_row with
           | None -> Alcotest.fail "missing secret-failing blocked row"
@@ -3173,11 +3180,11 @@ let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
           let open Yojson.Safe.Util in
           let fleet_safety = json |> member "keeper_fleet_safety" in
           let restored_row =
-            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            fleet_safety |> member "blocked_keepers" |> to_list
             |> List.find_opt (fun row ->
                  String.equal
                    "restored-crash-log"
-                   (row |> member "keeper" |> to_string))
+                   (row |> member "keeper_name" |> to_string))
           in
           match restored_row with
           | None -> Alcotest.fail "missing restored-crash-log blocked row"


### PR DESCRIPTION
## Summary
- replace parallel Keeper fleet blocker arrays with canonical `blocked_keepers` items and `keeper_name` identity
- fail malformed or missing current operator facts closed as one `current_fact_invalid` fact
- drive dashboard shell and fleet UI label, tone, icon, and operator action from one exhaustive typed presentation table

## Boundary
- current schema only; no compatibility or migration path
- no provider, model, tier, pricing, count-derived action, or log-string-derived action
- does not fabricate `shutdown_admission_fence`; #25752 can publish that typed fact through this surface after its authority lands

## Validation
- not run locally per CI-authority instruction; draft CI is the build and test authority