### PR TITLE
fix(keeper): drop the provider-named arm from the invalid-request classifier

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -735,15 +735,26 @@ let degraded_rotation_after_recoverable_error
 
     Drift boundary: the typed arm is authoritative.  The string arms exist
     for string-rendered shapes of the same condition; the only rendering the
-    pinned SDK (oas 5851df2e) produces with one of these prefixes is
+    pinned SDK produces with one of these prefixes is
     [Llm_provider.Retry.error_message (InvalidRequest _)] =
     ["Invalid request (%s): %s"] (oas lib/llm_provider/retry.ml), whose
     classification shape is produced by [Llm_provider.Retry.classify_error]
     for HTTP 400/422.  At the pin no [sdk_error] rendering starts with
-    ["Bad Request"] or ["oas-ollama_cloud"] — those arms are defensive
-    legacy shapes.  [test_keeper_invalid_request_auto_recover.ml] pins the
-    SDK classification+rendering shape so an SDK drift fails the test
-    instead of silently deadening the matcher. *)
+    ["Bad Request"] — that arm is a defensive legacy shape.
+    [test_keeper_invalid_request_auto_recover.ml] pins the SDK
+    classification+rendering shape so an SDK drift fails the test instead of
+    silently deadening the matcher.
+
+    A third arm matched ["oas-ollama_cloud"] with [String.contains msg '4'].
+    Removed: it named a provider inside role code, which the
+    runtime-indifference spec forbids, and it matched nothing — that string
+    occurs nowhere in the pinned SDK's lib, and both this docstring and the
+    drift-guard test already recorded it as having no producer.  The digit
+    test was also far looser than the "4xx" it read as, since it accepted a 4
+    anywhere in the message.  ["Bad Request"] is kept: the same sentence calls
+    it producerless, but it is a generic HTTP status phrase rather than a
+    provider identity, so removing it would be a separate judgment about
+    defensive code on weaker evidence than this one. *)
 let is_invalid_request_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (InvalidRequest _) -> true
@@ -753,9 +764,7 @@ let is_invalid_request_error (err : Agent_sdk.Error.sdk_error) : bool =
       let len_p = String.length prefix in
       String.length str >= len_p && String.sub str 0 len_p = prefix
     in
-    has_prefix msg "Invalid request"
-    || has_prefix msg "Bad Request"
-    || has_prefix msg "oas-ollama_cloud" && String.contains msg '4'
+    has_prefix msg "Invalid request" || has_prefix msg "Bad Request"
 
 (** [true] when a structured error indicates context overflow. *)
 let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =

--- a/test/test_keeper_invalid_request_auto_recover.ml
+++ b/test/test_keeper_invalid_request_auto_recover.ml
@@ -113,8 +113,10 @@ let test_counters_are_per_keeper () =
    product and asserts the predicate catches it and the rendering keeps the
    matched prefix, so an SDK-side shape change fails here instead of
    silently deadening the matcher.  At the pin no [sdk_error] rendering
-   starts with ["Bad Request"] or ["oas-ollama_cloud"]; those string arms
-   are defensive legacy shapes with no SDK producer to pin. *)
+   starts with ["Bad Request"]; that string arm is a defensive legacy shape
+   with no SDK producer to pin.  A third arm matching ["oas-ollama_cloud"]
+   was removed for naming a provider inside role code while matching nothing
+   (see [Keeper_error_classify.is_invalid_request_error]). *)
 let test_sdk_invalid_request_shape_drift_guard () =
   let api_error =
     Llm_provider.Retry.classify_error


### PR DESCRIPTION
## 무엇

`is_invalid_request_error`(`lib/keeper/keeper_error_classify.ml`)의 마지막 arm 을 제거한다:

```ocaml
|| has_prefix msg "oas-ollama_cloud" && String.contains msg '4'
```

## 왜

**① role code 안에서 provider 를 이름으로 부른다** — runtime-indifference 스펙이 금지하는 바로 그것이고, provider literal 스캔이 아직 부채를 보고하던 **유일한** 이유다.

**② 가장 느슨한 형태의 문자열 분류기다.** `String.contains msg '4'` 는 "4xx" 가 아니라 **메시지 아무 데나 있는 숫자 4** 를 받는다. `"Invalid request (model-4o): ..."` 도 통과한다.

**③ 아무것도 매칭하지 않는다.** `oas-ollama_cloud` 는 현재 핀(`3d4ee19a`)의 SDK `lib/` 어디에도 없다(`git grep -c` → 0). 그리고 이 함수의 docstring 과 drift-guard 테스트(`test_keeper_invalid_request_auto_recover.ml:116`)가 **이미** "no SDK producer to pin" 이라고 기록하고 있었다.

즉 안전망 제거가 아니라 죽은 코드 제거다.

## 남긴 것과 그 이유

`"Bad Request"` 는 **유지**한다. 같은 문장이 그것도 producerless 라고 적지만, 그건 provider 정체성이 아니라 **일반 HTTP status 문구**다. 제거하려면 "방어 코드를 얼마나 신뢰할 것인가" 라는 별개 판단이 필요하고 근거도 이쪽보다 약하다. 두 개를 섞으면 각 제거가 어떤 근거에 서 있는지 가려진다.

typed arm(`Api (InvalidRequest _)`)은 그대로이며 여전히 authoritative 하다.

## 검증

| 항목 | 결과 |
|---|---|
| `test_keeper_invalid_request_auto_recover` | **5/5** (drift guard 는 `"Invalid request"` prefix 를 검사 — 무변경) |
| `dune build lib/` | clean |
| `provider_literal_scan --all` (이 브랜치) | **0 literals in role code** |
| `provider_literal_scan --all` (main) | 1 literal |

## 후속

APC 하네스 G-1 이 이 사이트를 `KNOWN` 으로 고정하고 있다. 머지되면 그 핀이 stale 이 되고 게이트가 `pin_no_longer_present` 로 보고한다(이미 그 전환을 위해 설계된 필드다). 핀 제거는 머지 후 별도로 한다 — 지금 제거하면 main 기준으로 게이트가 FAIL 한다.

RFC-WAIVED: `lib/keeper/` 의 turn 에러 분류 arm 1개 제거. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
