### PR TITLE
test(keeper): yojson 3 breaking change 로 깨진 비유한 테스트 2건 복구

### DIFF
--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -108,6 +108,28 @@ let keeper_context ?(active_goal_ids = []) () =
     ]
 ;;
 
+(* yojson 3.0.0 raises Json_error "Infinity value not allowed in standard JSON"
+   from [to_string] for any non-finite float, with or without [~std], so the
+   writer can no longer emit such a row. Its parser still ACCEPTS the bare
+   [Infinity] / [NaN] tokens, so a ledger written by an older binary can still
+   hold one and the reader guard is still load-bearing. Render the row textually
+   to reproduce exactly that on-disk shape. *)
+let render_row_with_non_finite ~field ~literal json =
+  match json with
+  | `Assoc fields ->
+    let rendered =
+      List.map
+        (fun (key, value) ->
+           Printf.sprintf
+             "%s:%s"
+             (Yojson.Safe.to_string (`String key))
+             (if String.equal key field then literal else Yojson.Safe.to_string value))
+        fields
+    in
+    Printf.sprintf "{%s}" (String.concat "," rendered)
+  | _ -> Alcotest.fail "candidate JSON is not an object"
+;;
+
 let candidate ?(context = keeper_context ()) signal :
   A.candidate
   =
@@ -481,8 +503,10 @@ let test_non_finite_lifecycle_times_are_rejected () =
       "sangsu.jsonl"
   in
   let non_finite_row =
-    A.candidate_to_json { valid with recorded_at = Float.infinity }
-    |> Yojson.Safe.to_string
+    render_row_with_non_finite
+      ~field:"recorded_at"
+      ~literal:"Infinity"
+      (A.candidate_to_json valid)
   in
   Out_channel.with_open_bin ledger_path (fun channel ->
     output_string channel (non_finite_row ^ "\n"));
@@ -495,10 +519,18 @@ let test_non_finite_complete_request_evidence_is_rejected () =
   with_temp_base "board-attention-candidate-request-finite" @@ fun base_path ->
   let base = candidate (signal "post-request-finite") in
   let at_signal value =
-    let signal =
-      { (signal "post-request-finite") with updated_at = Some value }
+    (* [candidate] derives candidate_id by serializing the signal, which yojson 3
+       refuses to do for a non-finite float. Hash a finite placeholder and inject
+       the value afterwards: the stored record, not the id, is under test. *)
+    let placeholder =
+      { (signal "post-request-finite") with updated_at = Some 0.0 }
     in
-    let candidate = candidate signal in
+    let candidate = candidate placeholder in
+    let candidate =
+      { candidate with
+        signal = { candidate.signal with updated_at = Some value }
+      }
+    in
     { candidate with
       judgment_request =
         candidate.judgment_request

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -108,12 +108,9 @@ let keeper_context ?(active_goal_ids = []) () =
     ]
 ;;
 
-(* yojson 3.0.0 raises Json_error "Infinity value not allowed in standard JSON"
-   from [to_string] for any non-finite float, with or without [~std], so the
-   writer can no longer emit such a row. Its parser still ACCEPTS the bare
-   [Infinity] / [NaN] tokens, so a ledger written by an older binary can still
-   hold one and the reader guard is still load-bearing. Render the row textually
-   to reproduce exactly that on-disk shape. *)
+(* The writer correctly refuses non-finite floats, so render the row textually
+   to model out-of-band corruption of an otherwise current-schema ledger and
+   verify that the reader fails closed through its recorded_at finite guard. *)
 let render_row_with_non_finite ~field ~literal json =
   match json with
   | `Assoc fields ->
@@ -302,9 +299,13 @@ let rewrite_first_comment rewrite = function
   | _ -> Alcotest.fail "expected comments array"
 ;;
 
-let expect_record_error ~base_path label candidate =
+let expect_record_error ?expected_detail ~base_path label candidate =
   match A.record ~base_path candidate with
-  | A.Record_error _ -> ()
+  | A.Record_error detail ->
+    Option.iter
+      (fun expected ->
+         Alcotest.(check string) (label ^ " error") expected detail)
+      expected_detail
   | A.Recorded _ | A.Duplicate _ -> Alcotest.fail (label ^ " was recorded")
 ;;
 
@@ -511,7 +512,13 @@ let test_non_finite_lifecycle_times_are_rejected () =
   Out_channel.with_open_bin ledger_path (fun channel ->
     output_string channel (non_finite_row ^ "\n"));
   match A.load_candidates ~base_path ~keeper_name:valid.keeper_name with
-  | Error _ -> ()
+  | Error detail ->
+    let expected = "board attention candidate.recorded_at must be finite" in
+    if not (String.ends_with ~suffix:expected detail)
+    then
+      Alcotest.failf
+        "non-finite durable candidate returned the wrong reader error: %s"
+        detail
   | Ok _ -> Alcotest.fail "load accepted a non-finite durable candidate"
 ;;
 
@@ -572,10 +579,13 @@ let test_non_finite_complete_request_evidence_is_rejected () =
     }
   in
   let locations =
-    [ "signal.updated_at", at_signal
-    ; "post.created_at", at_post
-    ; "comment.created_at", at_comment
-    ; "nested post evidence", at_nested_evidence
+    [ ( "signal.updated_at"
+      , Some
+          "invalid Board attention candidate: candidate.signal contains a non-finite number"
+      , at_signal )
+    ; "post.created_at", None, at_post
+    ; "comment.created_at", None, at_comment
+    ; "nested post evidence", None, at_nested_evidence
     ]
   in
   let non_finite_values =
@@ -585,10 +595,11 @@ let test_non_finite_complete_request_evidence_is_rejected () =
     ]
   in
   List.iter
-    (fun (location, make_candidate) ->
+    (fun (location, expected_detail, make_candidate) ->
        List.iter
          (fun (number, value) ->
             expect_record_error
+              ?expected_detail
               ~base_path
               (number ^ " at " ^ location)
               (make_candidate value))


### PR DESCRIPTION
## 문제

`test_keeper_board_attention_candidate` 의 비유한(non-finite) 테스트 2 건이 실패하고 있었다. 단언 실패가 아니라 **테스트 코드가 자기 픽스처를 만들다가 raise** 한다:

```
Yojson__Common.Json_error("Infinity value not allowed in standard JSON")
test_keeper_board_attention_candidate.ml:484-485
```

## 원인 — yojson 3.0.0 breaking change

실측 probe:

| | yojson 3.0.0 |
|---|---|
| `to_string` (`~std` 무관) | **raise** — 비유한 float 출력 불가 |
| `from_string "{\"x\":Infinity}"` | **OK** — 여전히 파싱됨 |

yojson 2 에서는 `~std:false` 가 bare `Infinity` 토큰을 그대로 내보냈다. 그래서 이 픽스처들이 만들어졌었다. 라이브러리가 밑에서 바뀐 것이다.

**파서는 안 바뀌었다는 게 핵심이다.** 구 바이너리가 쓴 원장에는 여전히 비유한 숫자가 들어 있을 수 있고, 현재 리더는 그걸 파싱한다. 즉 리더 가드는 여전히 유효한 방어이고 **이 테스트들은 낡은 게 아니다** — writer 를 통해 입력을 만들 수 없게 됐을 뿐이다.

## 수정 (원래 의도 보존)

- **리더 테스트**: `to_string` 에게 `Infinity` 를 뱉으라고 하지 않고 행을 **텍스트로 렌더**한다 (`render_row_with_non_finite`). 사실 이쪽이 실제 상황에 더 가깝다 — 그걸 출력할 수 있던 빌드가 디스크에 남긴 바이트.
- **라이터 테스트**의 `at_signal`: 유한한 placeholder 로 해시를 만든 뒤 비유한 값을 주입한다. `candidate_id` 가 직렬화된 signal 의 SHA 라서, 단언이 아니라 **id 계산**이 raise 하고 있었다. 테스트 대상은 저장되는 레코드다.

## 검증

`12 tests run, 0 failures` (이전 2 failures).

**Negative control**: `finite_time` 가드(`keeper_board_attention_candidate.ml:562`)를 무력화하면 복구한 테스트가 다시 실패한다(다른 하나와 함께 2 건). 즉 **테스트를 무력화한 게 아니라 복구한 것**이다.

**그 control 의 정직한 한계**: 정규화 함수 안의 별도 비유한 분기(`:487`)는 꺼도 **아무 테스트도 안 깨진다**. 이 테스트들이 지나는 모든 경로는 `validate_finite_json`(`:577`, `judgment_request` 에 `:1148` / `:1249` 에서 적용)이 먼저 잡으므로 `:487` 은 그들에겐 중복 방어다. 이 PR 에서 건드리지 않았고, 나중에 읽는 사람이 "커버돼 있다" 고 오해하지 않도록 적어 둔다.

## CI 에서 이 테스트는 여전히 안 돈다

`ci.yml` 은 runtest alias 를 손으로 열거하고 이 타깃은 목록 밖이다 (#25755: 419 개 중 4 개만 실행). **일회성 CI 스텝을 추가하지 않았다** — 그건 #25755 가 지적한 열거 패턴을 하나 더 늘리는 것이다. 근본 수정은 그쪽 이슈에서 다뤄야 한다.

대신 이 PR 은 그 근본 수정의 **선행 조건 3 건 중 1 건을 없앤다.** 남은 것: `test_fs_compat_capability_exact_read` 의 `fatal backtrace propagation` (darwin).

Refs #25755

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. 테스트 파일 1 개다.
