### PR TITLE
fix(keeper): keep failure judgment single-dispatch

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -14,26 +14,11 @@ default = "ollama_cloud.deepseek-v4-flash"
 # Periodic Memory OS fact-survival consolidation is a separate task route from
 # post-turn Librarian extraction. Model/provider selection belongs only here.
 memory_os_consolidation = "ollama_cloud_native.minimax-m3-native-structured"
-# The failure-judgment boundary must not inherit the fleet chat default: keep it
-# explicit so a typo or an unroutable id fails at config load instead of surfacing
-# in the daemon loop.
-#
-# It does NOT request a provider-native wire format. Keeper_failure_judge clears
-# both structured-output fields (keeper_failure_judge.ml apply_output_schema ->
-# Keeper_structured_output_schema.without_response_format) and states the object
-# shape in config/prompts/keeper.failure_judgment.md, then parses strictly. That is
-# why #25719 could drop the last lane-candidate capability requirement: no consumer
-# asks for a response format, so requiring candidates to declare
-# supports-response-format-json checked nothing. Candidates therefore are not
-# limited to schema-capable providers.
-#
-# A lane, not one id, because the parse can only fail on how a runtime chose to
-# format its reply. A single id has no successor, and that is what made one
-# markdown-fenced reply terminal: keeper rondo settled its lane on
-# `Invalid token '```json` and advanced no turn for the next 17.5 hours
-# (event-queue.json last_settlement, 2026-07-25T10:44Z). Candidates span providers
-# so one provider's formatting habit is not the whole boundary.
-structured_judge = "judgment_lane"
+# Provider-native structured-output judges must not inherit the fleet chat
+# default when that default lacks schema support. Keep this lane explicit so
+# structured judgment lanes fail at config load on typo/unsupported
+# routing instead of discovering the mismatch in the daemon loop.
+structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.
@@ -997,19 +982,6 @@ strategy = "ordered"
 candidates = [
   "ollama_cloud.deepseek-v4-flash",
   "deepseek.deepseek-v4-pro",
-]
-
-# Referenced by [runtime].structured_judge. The first candidate keeps the runtime
-# that route named before it became a lane, so ordinary behaviour is unchanged; the
-# rest exist for the one failure this boundary can hit, a reply whose shape the
-# strict parser rejects. Three providers, because that failure is a formatting
-# habit and a second candidate on the same provider would repeat it.
-[runtime.lanes.judgment_lane]
-strategy = "ordered"
-candidates = [
-  "ollama_cloud_native.minimax-m3-native-structured",
-  "deepseek.deepseek-v4-pro",
-  "glm-coding.glm-5-turbo",
 ]
 
 # ── Keeper assignments ──────────────────────────────────────────────

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -14,10 +14,9 @@ default = "ollama_cloud.deepseek-v4-flash"
 # Periodic Memory OS fact-survival consolidation is a separate task route from
 # post-turn Librarian extraction. Model/provider selection belongs only here.
 memory_os_consolidation = "ollama_cloud_native.minimax-m3-native-structured"
-# Provider-native structured-output judges must not inherit the fleet chat
-# default when that default lacks schema support. Keep this lane explicit so
-# structured judgment lanes fail at config load on typo/unsupported
-# routing instead of discovering the mismatch in the daemon loop.
+# Failure judgment must not inherit the fleet chat default. Keep its opaque
+# runtime identity explicit so MASC submits once without unfolding candidates
+# or rotating after a domain response-contract failure.
 structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for

--- a/lib/keeper/keeper_failure_judge.ml
+++ b/lib/keeper/keeper_failure_judge.ml
@@ -79,32 +79,10 @@ let reject_unregistered_tool ~name ~args:_ =
     "failure judgment is a tool-free boundary"
 ;;
 
-(* The configured [runtime].structured_judge value may name a lane or a single
-   runtime, the same two-shape identity [runtime].cross_verifier moved to on
-   2026-07-25 (runtime.toml: "cross_verifier 는 단일 runtime id 대신 lane 을 받는다").
-   Resolving it here yields the ordered candidate list the walk in {!run} needs; a
-   single runtime is a one-element list, so both shapes take one code path. *)
-let resolve_candidates () =
+let resolve_runtime_id () =
   match Runtime.runtime_id_for_structured_judge () with
+  | runtime_id -> Ok runtime_id
   | exception Failure detail -> Error (Runtime_configuration_error detail)
-  | configured ->
-    (match Runtime.resolve_assignment configured with
-     | `Single_runtime _ -> Ok [ configured ]
-     | `Lane lane ->
-       (match Runtime_lane.ordered_candidates lane with
-        | [] ->
-          Error
-            (Runtime_configuration_error
-               (Printf.sprintf
-                  "failure judgment lane %s resolves to no candidate"
-                  configured))
-        | candidates -> Ok candidates)
-     | `Missing ->
-       Error
-         (Runtime_configuration_error
-            (Printf.sprintf
-               "failure judgment runtime %s names neither a runtime nor a lane"
-               configured)))
 ;;
 
 let parse_response ~runtime_id response =
@@ -118,64 +96,27 @@ let parse_response ~runtime_id response =
      | Error detail -> Error (Response_contract_error { runtime_id; detail }))
 ;;
 
-let attempt_candidate ~base_path ~keeper_name ~prompt runtime_id =
-  match
-    Keeper_turn_driver_wrappers.run_named_with_masc_tools
-      ~runtime_id
-      ~keeper_name
-      ~goal:prompt
-      ~base_path
-      ~masc_tools:[]
-      ~dispatch:reject_unregistered_tool
-      ~provider_config_transform:apply_output_schema
-      ()
-  with
-  | Error error -> Error (Oas_error { runtime_id; error })
-  | Ok result ->
-    (match parse_response ~runtime_id result.response with
-     | Error _ as error -> error
-     | Ok verdict -> Ok { runtime_id; verdict })
-;;
-
-(* Only a response-contract failure advances the walk, and the reason is what the
-   error means rather than a preference for fewer failures. The request states its
-   object shape in the prompt and asks the provider for no wire format
-   ([apply_output_schema] clears both structured-output fields), so whether the
-   reply parses is that runtime's formatting behaviour: keeper rondo settled its
-   lane on `Invalid token '```json` from glm-coding.glm-5-turbo (event-queue.json
-   last_settlement, 2026-07-25T10:44Z) and re-asking the same runtime would fence
-   again. Another candidate is a different behaviour, so the refusal orders instead
-   of ending the walk.
-
-   The other three classes do not advance. A prompt-contract error is the same for
-   every candidate; a runtime-configuration error is about the configured identity,
-   not the runtime that answered; and an [Oas_error] has already been through OAS's
-   own candidate handling, so re-walking it here would dispatch the same turn twice
-   for one stimulus. *)
-let advances_walk = function
-  | Response_contract_error _ -> true
-  | Runtime_configuration_error _ | Prompt_contract_error _ | Oas_error _ -> false
-;;
-
 let run ~base_path ~keeper_name request =
-  match resolve_candidates () with
+  match resolve_runtime_id () with
   | Error _ as error -> error
-  | Ok candidates ->
+  | Ok runtime_id ->
     (match build_prompt ~keeper_name request with
      | Error detail -> Error (Prompt_contract_error detail)
      | Ok prompt ->
-       let rec walk = function
-         | [] ->
-           (* [resolve_candidates] rejects an empty list, so the walk always holds
-              at least one candidate and this is unreachable rather than a silent
-              default. *)
-           Error
-             (Runtime_configuration_error
-                "failure judgment walk reached an empty candidate list")
-         | runtime_id :: rest ->
-           (match attempt_candidate ~base_path ~keeper_name ~prompt runtime_id with
-            | Error error when advances_walk error && rest <> [] -> walk rest
-            | (Ok _ | Error _) as outcome -> outcome)
-       in
-       walk candidates)
+       (match
+          Keeper_turn_driver_wrappers.run_named_with_masc_tools
+            ~runtime_id
+            ~keeper_name
+            ~goal:prompt
+            ~base_path
+            ~masc_tools:[]
+            ~dispatch:reject_unregistered_tool
+            ~provider_config_transform:apply_output_schema
+            ()
+        with
+        | Error error -> Error (Oas_error { runtime_id; error })
+        | Ok result ->
+          (match parse_response ~runtime_id result.response with
+           | Error _ as error -> error
+           | Ok verdict -> Ok { runtime_id; verdict })))
 ;;

--- a/lib/keeper/keeper_failure_judge.mli
+++ b/lib/keeper/keeper_failure_judge.mli
@@ -3,12 +3,7 @@
 
     Runtime/provider selection remains an OAS concern reached through the
     opaque [Runtime.runtime_id_for_structured_judge] identity. MASC supplies
-    one provider-neutral JSON schema and strictly decodes the response.
-
-    That identity may name a lane or a single runtime, the two-shape value
-    [runtime].cross_verifier already carries. When it names a lane, a response
-    that does not satisfy the contract advances to the next candidate instead of
-    ending the walk — see {!advances_walk} for which failures do that and why. *)
+    one provider-neutral JSON schema and strictly decodes the response. *)
 
 type run_error =
   | Runtime_configuration_error of string
@@ -32,32 +27,14 @@ type error_disposition = Escalate_judge_failure
 val error_detail : run_error -> string
 val error_disposition : run_error -> error_disposition
 val error_disposition_label : error_disposition -> string
-(** A failure that survives the whole candidate walk terminates the judgment
-    stimulus explicitly; process-local observations are not durable retry
-    authority. Before 2026-07-26 this also read "there is no alternate judge
-    runtime to rotate to", which described a single-id identity — a lane now
-    supplies candidates and {!advances_walk} says which failures use them. *)
+(** A failure of the single configured structured-judge boundary terminates the
+    judgment stimulus explicitly. There is no alternate judge runtime to rotate
+    to; process-local observations are not durable retry authority. *)
 
-val advances_walk : run_error -> bool
-(** Whether this failure should be re-asked of the next lane candidate.
-
-    True only for {!Response_contract_error}. The request states its object shape
-    in the prompt and asks the provider for no wire format, so whether the reply
-    parses is that runtime's formatting behaviour and another candidate is a
-    different behaviour. False for the other three: a prompt-contract error is
-    identical for every candidate, a runtime-configuration error is about the
-    configured identity rather than the runtime that answered, and an
-    {!Oas_error} has already been through OAS's own candidate handling, so
-    walking it again would dispatch the same turn twice for one stimulus. *)
-
-val resolve_candidates : unit -> (string list, run_error) result
-(** Ordered candidates for {!run}, from the configured structured-judge identity.
-    A lane yields its ordered candidates; a single runtime yields a one-element
-    list, so both shapes take one code path. An empty lane and an identity that
-    names neither are configuration errors rather than an empty walk.
-
-    Configuration errors are returned explicitly when the durable stimulus
-    executes; they do not become pre-claim admission authority. *)
+val resolve_runtime_id : unit -> (string, run_error) result
+(** Resolve the configured structured-judge lane used by {!run}. Configuration
+    errors are returned explicitly when the durable stimulus executes; they do
+    not become pre-claim admission authority. *)
 
 val build_prompt :
   keeper_name:string ->

--- a/lib/keeper/keeper_failure_judge.mli
+++ b/lib/keeper/keeper_failure_judge.mli
@@ -32,9 +32,9 @@ val error_disposition_label : error_disposition -> string
     to; process-local observations are not durable retry authority. *)
 
 val resolve_runtime_id : unit -> (string, run_error) result
-(** Resolve the configured structured-judge lane used by {!run}. Configuration
-    errors are returned explicitly when the durable stimulus executes; they do
-    not become pre-claim admission authority. *)
+(** Resolve the configured opaque structured-judge runtime identity used by
+    {!run}. Configuration errors are returned explicitly when the durable
+    stimulus executes; they do not become pre-claim admission authority. *)
 
 val build_prompt :
   keeper_name:string ->

--- a/test/test_keeper_failure_judgment_contract.ml
+++ b/test/test_keeper_failure_judgment_contract.ml
@@ -14,144 +14,6 @@ let expect_error label json =
   | Ok _ -> failf "%s unexpectedly decoded" label
 ;;
 
-module Judge = Keeper_failure_judge
-
-let response_contract_error =
-  Judge.Response_contract_error
-    { runtime_id = "glm-coding.glm-5-turbo"
-    ; detail = "JSON parse error: Invalid token '```json"
-    }
-;;
-
-let oas_error =
-  Judge.Oas_error
-    { runtime_id = "glm-coding.glm-5-turbo"
-    ; error =
-        Agent_sdk.Error.Api
-          (Llm_provider.Retry.RateLimited { retry_after = None; message = "slow down" })
-    }
-;;
-
-(* The fence in [response_contract_error] is the live shape: keeper rondo settled its
-   lane on it (event-queue.json last_settlement, 2026-07-25T10:44Z) and stopped
-   advancing turns. Only that class may re-ask the next candidate; the enumeration is
-   exhaustive so a new error class has to make this decision explicitly. *)
-let test_only_a_response_contract_failure_advances_the_walk () =
-  check bool "a fenced reply is re-asked of the next candidate" true
-    (Judge.advances_walk response_contract_error);
-  check bool "an OAS error does not re-walk what OAS already walked" false
-    (Judge.advances_walk oas_error);
-  check bool "a prompt contract error is identical for every candidate" false
-    (Judge.advances_walk (Judge.Prompt_contract_error "template missing"));
-  check bool "a configuration error is about the identity, not the answer" false
-    (Judge.advances_walk (Judge.Runtime_configuration_error "no structured judge"))
-;;
-
-let write_file path content =
-  let oc = open_out path in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-    output_string oc content)
-;;
-
-let runtime_toml ~judge =
-  Printf.sprintf
-    {|
-[runtime]
-default = "p.first"
-structured_judge = "%s"
-
-[runtime.lanes.judge_lane]
-strategy = "ordered"
-candidates = [ "p.first", "p.second" ]
-
-[providers.p]
-display-name = "P"
-protocol = "openai-compatible-http"
-endpoint = "http://127.0.0.1:1"
-
-[models.first]
-api-name = "first"
-max-context = 8192
-tools-support = true
-streaming = true
-
-[models.second]
-api-name = "second"
-max-context = 8192
-tools-support = true
-streaming = true
-
-[p.first]
-is-default = true
-max-concurrent = 1
-
-[p.second]
-max-concurrent = 1
-|}
-    judge
-;;
-
-let require_candidates = function
-  | Ok candidates -> candidates
-  | Error error -> fail (Judge.error_detail error)
-;;
-
-let init_runtime ~judge =
-  let path = Filename.temp_file "failure_judgment_runtime_" ".toml" in
-  write_file path (runtime_toml ~judge);
-  match Runtime.init_default ~config_path:path with
-  | Ok () -> ()
-  | Error detail -> failf "Runtime.init_default failed: %s" detail
-;;
-
-(* One code path for both shapes of the configured identity: a lane contributes its
-   ordered candidates, a single runtime contributes itself. Before this the judge
-   resolved one id, so a runtime that would not honour the contract had no successor. *)
-let test_lane_identity_yields_ordered_candidates () =
-  init_runtime ~judge:"judge_lane";
-  check (list string) "lane order is preserved" [ "p.first"; "p.second" ]
-    (Judge.resolve_candidates () |> require_candidates)
-;;
-
-let test_single_runtime_identity_yields_one_candidate () =
-  init_runtime ~judge:"p.second";
-  check (list string) "a single runtime is a one-element walk" [ "p.second" ]
-    (Judge.resolve_candidates () |> require_candidates)
-;;
-
-(* test_runtime_config_validity.ml already loads the shipped seed and pins the
-   configured judgment id as a literal, which is a drift guard on the value. This
-   asserts the property that value has to satisfy: the boundary has a successor at
-   all, and the candidates are not one provider's formatting habit repeated. A pinned
-   string cannot say that — it would still pass if the lane were narrowed to a single
-   candidate on one provider. The fixture above proves the resolver; this proves what
-   an operator actually gets. *)
-let shipped_runtime_config () =
-  let candidates = [ "config/runtime.toml"; Filename.concat ".." "config/runtime.toml" ] in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None -> fail "shipped config/runtime.toml not found"
-;;
-
-let test_shipped_config_gives_the_judgment_boundary_a_successor () =
-  (match Runtime.init_default ~config_path:(shipped_runtime_config ()) with
-   | Ok () -> ()
-   | Error detail -> failf "shipped config/runtime.toml does not load: %s" detail);
-  let candidates = Judge.resolve_candidates () |> require_candidates in
-  (* One candidate is the shape that made a fenced reply terminal. *)
-  check bool "the shipped judgment identity has a successor" true
-    (List.length candidates > 1);
-  check bool "candidates are distinct" true
-    (List.length (List.sort_uniq compare candidates) = List.length candidates);
-  let provider id = match String.index_opt id '.' with
-    | Some i -> String.sub id 0 i
-    | None -> id
-  in
-  (* A second candidate on the same provider would repeat the formatting habit. *)
-  check bool "candidates span more than one provider" true
-    (List.length (List.sort_uniq compare (List.map provider candidates)) > 1)
-;;
-
 let test_resume_with_guidance () =
   let verdict =
     Contract.of_yojson
@@ -298,6 +160,63 @@ let test_typed_judge_error_disposition () =
        { runtime_id = "structured-judge"; detail = "invalid JSON" })
 ;;
 
+let read_source path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+;;
+
+let count_occurrences ~needle haystack =
+  let needle_length = String.length needle in
+  let haystack_length = String.length haystack in
+  let rec loop offset count =
+    if offset + needle_length > haystack_length
+    then count
+    else if String.equal (String.sub haystack offset needle_length) needle
+    then loop (offset + needle_length) (count + 1)
+    else loop (offset + 1) count
+  in
+  loop 0 0
+;;
+
+let failure_judge_source () =
+  let relative = Filename.concat "lib/keeper" "keeper_failure_judge.ml" in
+  let candidates = [ relative; Filename.concat ".." relative ] in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> read_source path
+  | None -> fail "keeper_failure_judge.ml source not found"
+;;
+
+let test_malformed_response_has_one_dispatch_surface () =
+  let source = failure_judge_source () in
+  let dispatch_count =
+    count_occurrences
+      ~needle:"Keeper_turn_driver_wrappers.run_named_with_masc_tools"
+      source
+  in
+  check int
+    "one opaque OAS execution is dispatched per failure-judgment stimulus"
+    1
+    dispatch_count;
+  check int
+    "a response-contract failure returns as the typed terminal result"
+    1
+    (count_occurrences ~needle:"| Error _ as error -> error" source);
+  List.iter
+    (fun forbidden ->
+       check int
+         ("MASC does not own " ^ forbidden)
+         0
+         (count_occurrences ~needle:forbidden source))
+    [ "resolve_candidates"
+    ; "Runtime.resolve_assignment"
+    ; "Runtime_lane.ordered_candidates"
+    ; "let rec walk"
+    ; "Runtime_agent.run"
+    ]
+;;
+
 let failure_event post_id : Keeper_world_observation.pending_board_event =
   { event_kind = Keeper_world_observation.Failure_judgment
   ; post_id
@@ -375,27 +294,13 @@ let () =
             `Quick
             test_typed_judge_error_disposition
         ; test_case
+            "malformed response has one dispatch surface"
+            `Quick
+            test_malformed_response_has_one_dispatch_surface
+        ; test_case
             "guidance binds exact observation"
             `Quick
             test_guidance_binds_exact_observation
-        ] )
-    ; ( "candidate_walk"
-      , [ test_case
-            "only a response contract failure advances"
-            `Quick
-            test_only_a_response_contract_failure_advances_the_walk
-        ; test_case
-            "lane identity yields ordered candidates"
-            `Quick
-            test_lane_identity_yields_ordered_candidates
-        ; test_case
-            "single runtime identity yields one candidate"
-            `Quick
-            test_single_runtime_identity_yields_one_candidate
-        ; test_case
-            "shipped config gives the judgment boundary a successor"
-            `Quick
-            test_shipped_config_gives_the_judgment_boundary_a_successor
         ] )
     ]
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -754,14 +754,10 @@ let test_repo_runtime_toml_loads () =
       "Memory OS consolidation runtime"
       (Some "ollama_cloud_native.minimax-m3-native-structured")
       memory_os_consolidation;
-    (* A lane id, not a runtime id: the failure-judgment boundary needs a successor
-       because the only failure it can hit is how a runtime chose to format its
-       reply. The lane keeps the previously pinned runtime as its first candidate,
-       so routing for a healthy reply is unchanged. *)
     check
       (option string)
       "structured judge runtime"
-      (Some "judgment_lane")
+      (Some "ollama_cloud_native.minimax-m3-native-structured")
       structured_judge;
     (match Runtime_toml.parse_file path with
      | Error _ -> fail "repo runtime.toml exact-output lanes must parse"


### PR DESCRIPTION
## Summary
- correct the merged #25747 ownership regression by restoring one opaque configured judgment runtime per MASC call
- remove MASC-side candidate walking and provider-diversity/runtime-candidate assertions
- keep the strict domain response codec; a post-dispatch parse failure is a typed terminal judgment failure, not another dispatch
- add a source ratchet that pins exactly one opaque judgment execution surface and forbids direct `Runtime_agent.run`/candidate-walk ownership in this module

## Boundary
OAS owns provider/model candidates and failover. MASC submits domain input once, consumes one opaque result, and validates domain output. MASC does not parse provider identity or unfold candidate order.

## Validation
No local build, tests, or formatter were run. PR CI is the validation authority.

Corrects #25747.