### PR TITLE
test(keeper): pin that the byte capacity axis shares the token axis's admission gate

### DIFF
--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1676,21 +1676,51 @@ let test_suspended_streak_refuses_reactive_prepare () =
        "suspended manual prepare did not reach the checkpoint load: %s"
        (Post_turn.compaction_recovery_error_to_string error)
    | Ok _ -> fail "manual prepare on an empty store produced a compaction");
-  match
-    prepare
-      ~streak:2
-      ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
-  with
+  (match
+     prepare
+       ~streak:2
+       ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+   with
+   | Error
+       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
+     ->
+     (* Below the threshold the reactive path is admitted unchanged. *)
+     ()
+   | Error error ->
+     failf
+       "below-threshold reactive prepare did not reach the checkpoint load: %s"
+       (Post_turn.compaction_recovery_error_to_string error)
+   | Ok _ -> fail "reactive prepare on an empty store produced a compaction");
+  (* The byte axis follows the same gate as the token axis, not the operator lever.
+     Both are raised by the turn path itself, so a suspended keeper must refuse both —
+     the compiler forced that decision when the variant was added (masc#25739) but
+     nothing pinned the answer, and the two plausible wrong answers are opposites:
+     treating it like Manual would let a failing keeper re-enter compaction every turn,
+     while refusing it below the threshold would deny a reduction the token axis is
+     granted. *)
+  let byte_over_capacity =
+    Compaction_trigger.Request_body_over_capacity
+      { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }
+  in
+  (match prepare ~streak:3 ~trigger:byte_over_capacity with
+   | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
+     check int "suspended byte-axis refusal reports the streak" 3 consecutive_failures
+   | Error error ->
+     failf
+       "suspended byte-axis prepare reached I/O instead of the admission gate: %s"
+       (Post_turn.compaction_recovery_error_to_string error)
+   | Ok _ -> fail "suspended byte-axis prepare produced a prepared compaction");
+  match prepare ~streak:2 ~trigger:byte_over_capacity with
   | Error
       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
     ->
-    (* Below the threshold the reactive path is admitted unchanged. *)
+    (* Below the threshold the byte axis is admitted exactly as the token axis is. *)
     ()
   | Error error ->
     failf
-      "below-threshold reactive prepare did not reach the checkpoint load: %s"
+      "below-threshold byte-axis prepare did not reach the checkpoint load: %s"
       (Post_turn.compaction_recovery_error_to_string error)
-  | Ok _ -> fail "reactive prepare on an empty store produced a compaction"
+  | Ok _ -> fail "byte-axis prepare on an empty store produced a compaction"
 ;;
 
 let test_exact_scope_release_defers_until_settlement_pin_leaves () =


### PR DESCRIPTION
## 무엇

`Request_body_over_capacity` 가 `Provider_overflow` 와 **같은 suspension 게이트**를 지난다는 것을 고정한다. 기존 테스트의 `prepare ~streak ~trigger` 헬퍼에 두 케이스를 더한다 — 새 fixture 없음.

## 왜

masc#25739 가 그 결정을 내렸고 match 가 exhaustive 라 **컴파일러가 강제**했지만, **답 자체를 고정한 것은 없었다**. 두 오답은 서로 반대 방향이라 주석이 아니라 테스트가 필요하다:

| 오답 | 결과 |
|---|---|
| 바이트 축을 `Manual` 처럼 취급 | 컴팩션이 계속 실패하는 keeper 가 **매 턴 컴팩션에 재진입** |
| 임계값 아래에서도 거부 | 토큰 축은 받는 축소를 **바이트 축만 거부** |

## 단정

- streak 3 → `Retry_suspended { consecutive_failures = 3 }` (지속된 streak 보고)
- streak 2 → checkpoint load 까지 도달 (`Provider_overflow` 와 **정확히 동일**)

## 공허하지 않음

suspension arm 에서 `Request_body_over_capacity` 를 제거하는 변이 — 즉 "Manual 처럼 취급" — 을 넣으면 이 스위트의 케이스 11 이 **실패한다**(실측).

## 검증

`test_keeper_post_turn_wirein_order` **14/14**.

## 맥락

runtime-indifference 스펙 §7 G-5 는 용량 초과가 **거부가 아니라 제어**로 이어질 것을 요구한다. 이 테스트는 그 사슬의 한 마디 — 자동 트리거가 게이트에서 어떻게 취급되는가 — 를 고정한다. 스펙이 요구하는 나머지(합성 저용량 런타임에서 압축이 먼저 일어나고 진행) 는 별도 fixture 가 필요하며 후속이다.

RFC-WAIVED: 기존 테스트에 단정 2개 추가. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>