### PR TITLE
feat(keeper): a summarizer that grows the checkpoint gets its own terminal cause

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -411,16 +411,26 @@ let compact_for_request_typed_with
       ; post_success_terminalizer = None
       }
     in
-    let reject_post_dispatch_domain_output () =
-      reject
-        (terminal_rejection
-           requested.post_success_terminalizer
-           Keeper_event_queue_state.Domain_invalid_output)
+    (* Both outcomes are terminal for this attempt, and both used to report
+       [Domain_invalid_output]. That label is defensible — the contract is that only a
+       strictly reducing plan is prepared, so a plan that does not reduce did not
+       satisfy the domain requirement — but it folds two situations an operator repairs
+       differently into one word:
+
+         after = before   the context could not be reduced further
+         after > before   the summarizer produced a LARGER context than it was given
+
+       The second is the summarizer working against itself and is worth seeing on its
+       own; the first is a property of the input. Naming them keeps the terminal's
+       slot_id / call_id / plan fingerprint, which a flat rejection would have dropped
+       (keeper_post_turn.ml maps the two shapes to different payloads). *)
+    let reject_terminal cause =
+      reject (terminal_rejection requested.post_success_terminalizer cause)
     in
     if after_bytes = before_bytes
-    then reject_post_dispatch_domain_output ()
+    then reject_terminal Keeper_event_queue_state.Compaction_produced_no_reduction
     else if after_bytes > before_bytes
-    then reject_post_dispatch_domain_output ()
+    then reject_terminal Keeper_event_queue_state.Compaction_increased_checkpoint
     else (
       let after_messages = message_count compacted_ctx in
       let before_tool_use_count, before_tool_result_count =

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -22,6 +22,8 @@ type exact_execution_terminal_cause = Keeper_event_queue_persistence.exact_execu
   | Exact_execution_failed
   | Exact_execution_cancelled
   | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.ml
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.ml
@@ -6,6 +6,8 @@ struct
     | Exact_execution_failed
     | Exact_execution_cancelled
     | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
     | Invalid_structural_evidence
     | Invalid_structural_source_after_dispatch
     | Commit_admission_unavailable

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.mli
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.mli
@@ -6,6 +6,8 @@ module Make (Publish : sig
     | Exact_execution_failed
     | Exact_execution_cancelled
     | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
     | Invalid_structural_evidence
     | Invalid_structural_source_after_dispatch
     | Commit_admission_unavailable

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -38,6 +38,8 @@ type exact_execution_terminal_cause = State.exact_execution_terminal_cause =
   | Exact_execution_failed
   | Exact_execution_cancelled
   | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -42,6 +42,8 @@ type exact_execution_terminal_cause = Keeper_event_queue_state.exact_execution_t
   | Exact_execution_failed
   | Exact_execution_cancelled
   | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -16,6 +16,8 @@ type exact_execution_terminal_cause =
   | Exact_execution_failed
   | Exact_execution_cancelled
   | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable
@@ -481,6 +483,8 @@ let exact_execution_terminal_cause_label = function
   | Exact_execution_failed -> "exact_execution_failed"
   | Exact_execution_cancelled -> "exact_execution_cancelled"
   | Domain_invalid_output -> "domain_invalid_output"
+  | Compaction_produced_no_reduction -> "compaction_produced_no_reduction"
+  | Compaction_increased_checkpoint -> "compaction_increased_checkpoint"
   | Invalid_structural_evidence -> "invalid_structural_evidence"
   | Invalid_structural_source_after_dispatch ->
     "invalid_structural_source_after_dispatch"
@@ -496,6 +500,8 @@ let exact_execution_terminal_cause_of_label = function
   | "exact_execution_failed" -> Ok Exact_execution_failed
   | "exact_execution_cancelled" -> Ok Exact_execution_cancelled
   | "domain_invalid_output" -> Ok Domain_invalid_output
+  | "compaction_produced_no_reduction" -> Ok Compaction_produced_no_reduction
+  | "compaction_increased_checkpoint" -> Ok Compaction_increased_checkpoint
   | "invalid_structural_evidence" -> Ok Invalid_structural_evidence
   | "invalid_structural_source_after_dispatch" ->
     Ok Invalid_structural_source_after_dispatch

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -23,6 +23,8 @@ type exact_execution_terminal_cause =
   | Exact_execution_failed
   | Exact_execution_cancelled
   | Domain_invalid_output
+  | Compaction_produced_no_reduction
+  | Compaction_increased_checkpoint
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -194,6 +194,11 @@ let test_exact_output_terminal_reasons_round_trip () =
     ; State.Lifecycle_transition_failed_after_dispatch
     ; State.Checkpoint_source_changed
     ; State.Checkpoint_persistence_failed
+      (* Both compaction outcomes reported Domain_invalid_output until they were named:
+         a context that could not shrink and a summarizer that returned a larger one are
+         repaired differently, and the second is the summarizer working against itself. *)
+    ; State.Compaction_produced_no_reduction
+    ; State.Compaction_increased_checkpoint
     ];
   (* Malformed structural evidence and planner invariant violations remain
      retryable/escalated and cannot be encoded as terminal no-compaction. *)

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1552,7 +1552,7 @@ let test_post_dispatch_non_reducing_output_is_quarantined () =
       let config = Masc.Workspace.default_config base_path in
       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
       init_runtime_fixture ();
-      let run_case ~name response =
+      let run_case ~name ~expected_cause response =
         let server =
           Exact_fixture.start_server
             ~sw
@@ -1586,29 +1586,34 @@ let test_post_dispatch_non_reducing_output_is_quarantined () =
          | Compact_policy.Rejected
              ( Manual
              , Exact_execution_terminal
-                 { cause = Keeper_event_queue_state.Domain_invalid_output
-                 ; slot_id
-                 ; call_id
-                 } ) ->
+                 { cause; slot_id; call_id } )
+           when cause = expected_cause ->
            check bool (name ^ " terminal retains slot") true
              (String.trim slot_id <> "");
            check bool (name ^ " terminal retains call") true
              (String.trim call_id <> "")
-         | _ -> fail (name ^ " was not a domain-invalid exact terminal"));
+         | _ -> fail (name ^ " did not report its own non-reduction cause"));
         match !quarantine_calls with
-        | [ Keeper_event_queue_state.Domain_invalid_output, observation ] ->
+        | [ (cause, observation) ] when cause = expected_cause ->
           check bool (name ^ " quarantine retains slot") true
             (String.trim observation.slot_id <> "");
           check bool (name ^ " quarantine retains call") true
             (String.trim observation.call_id <> "")
         | _ -> fail (name ^ " was not quarantined exactly once")
       in
+      (* The two cases reported the same cause. Only one of them should: a plan the
+         domain validator rejects IS invalid output, while a summarizer that returns a
+         LARGER context produced valid output that worked against the purpose. Both stay
+         terminal and quarantined and keep slot and call provenance; they no longer read
+         as the same failure. *)
       run_case
         ~name:"unchanged-plan"
+        ~expected_cause:Keeper_event_queue_state.Domain_invalid_output
         (exact_response
            [ compaction_decision 1 Schema.compaction_plan_action_keep ]);
       run_case
         ~name:"larger-checkpoint"
+        ~expected_cause:Keeper_event_queue_state.Compaction_increased_checkpoint
         (summarize_response (String.make 20_000 'x')))
 ;;
 


### PR DESCRIPTION
## 무엇

컴팩션 정책이 **서로 다른 두 결과를 한 cause 로** 거부했다.

| 상황 | 성격 |
|---|---|
| 도메인 검증기가 거부한 plan | **무효한 출력** |
| 요약기가 받은 것보다 **큰** 컨텍스트를 반환 | 출력은 유효하나 **목적에 역행** |

둘 다 `Domain_invalid_output` 이었고, 기존 테스트가 그 동일성을 **이름이 이미 다른 두 fixture**(`unchanged-plan`, `larger-checkpoint`)에 걸쳐 단정하고 있었다.

## 어떻게

`exact_execution_terminal_cause` 에 `Compaction_produced_no_reduction`·`Compaction_increased_checkpoint` 를 추가한다.

**rejection 모양을 바꾸지 않고 cause 를 늘린 것은 의도적이다**: `keeper_post_turn.ml:504-510` 이 평평한 rejection 과 exact terminal 을 서로 다른 payload 로 매핑하므로, 평평한 `Structurally_unchanged` 로 바꿨다면 terminal 이 싣는 **slot_id·call_id·plan fingerprint 를 버렸을 것**이다. 타입이 durable 이라 라벨 코덱과 미러 정의가 함께 움직인다 — 5파일, 전부 컴파일러가 강제.

## fixture 가 증명하는 만큼만

- `larger-checkpoint` → `Compaction_increased_checkpoint` 를 **끝까지** 고정(quarantine 이 그 cause 로 정확히 1회 발화하고 slot·call 유지 포함)
- `unchanged-plan` → `Domain_invalid_output` **유지**. 바이트 비교 이전에 도메인 검증기가 거부한다. 그 사이트를 먼저 바꿨다가 **테스트가 잡았고**, 그래서 이 fixture 가 이름과 다른 경로를 탄다는 것을 알았다.
- `Compaction_produced_no_reduction` 은 `after = before` arm 에 배선했으나 **fixture 가 없다**. 도달 가능하고 이름이 정직하지만, 테스트가 증명한다고 주장하지 않는다.

## 검증

| 스위트 | 결과 |
|---|---|
| `test_keeper_post_turn_wirein_order` | **14/14** |
| `test_keeper_event_queue_state_v2` | **39/39** (두 cause 를 terminal 왕복 목록에 추가) |
| `test_keeper_exact_disposition_recovery` | 4/4 |
| `test_keeper_overflow_recovery` | 9/9 |
| `dune build @check` | clean |

## 맥락

masc#25771 — `Structurally_unchanged`·`Checkpoint_not_reduced` 는 정착 사유 타입에서 여전히 죽은 어휘다. 이 PR 은 그것들을 되살리지 않는다. 정책이 **성격이 다른 결과를 다른 뜻의 cause 에 접어 넣는 것**을 멈출 뿐이다.

RFC-WAIVED: 컴팩션 terminal cause 어휘와 그 코덱. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>