### PR TITLE
fix(grpc): reject invalid tool arguments before dispatch

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -4,8 +4,7 @@
  (public_name masc)
  (private_modules
   keeper_fs_durable_directory
-  keeper_exact_flow_scope
-  server_grpc_tool_dispatch)
+  keeper_exact_flow_scope)
  (libraries
   mcp_protocol
   mcp_protocol.eio

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,10 @@
 (library
  (name masc)
  (public_name masc)
- (private_modules keeper_fs_durable_directory keeper_exact_flow_scope)
+ (private_modules
+  keeper_fs_durable_directory
+  keeper_exact_flow_scope
+  server_grpc_tool_dispatch)
  (libraries
   mcp_protocol
   mcp_protocol.eio

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -1,23 +1,16 @@
 (include_subdirs no)
 
 (library
- (name server_grpc_tool_dispatch_internal)
- (wrapped false)
- (modules server_grpc_tool_dispatch)
- (libraries yojson))
-
-(library
  (name masc_server)
  (public_name masc.server)
  (wrapped false)
- (modules (:standard \ server_grpc_tool_dispatch))
  (private_modules
   keeper_grpc_heartbeat
+  server_grpc_tool_dispatch
   server_dashboard_http_schedule_actions
   server_schedule_runner_policy)
  (flags :standard -open Masc)
  (libraries
-  server_grpc_tool_dispatch_internal
   masc
   masc.dashboard
   masc.fd_accountant

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -6,6 +6,7 @@
  (wrapped false)
  (private_modules
   keeper_grpc_heartbeat
+  server_grpc_tool_dispatch
   server_dashboard_http_schedule_actions
   server_schedule_runner_policy)
  (flags :standard -open Masc)

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -1,16 +1,23 @@
 (include_subdirs no)
 
 (library
+ (name server_grpc_tool_dispatch_internal)
+ (wrapped false)
+ (modules server_grpc_tool_dispatch)
+ (libraries yojson))
+
+(library
  (name masc_server)
  (public_name masc.server)
  (wrapped false)
+ (modules (:standard \ server_grpc_tool_dispatch))
  (private_modules
   keeper_grpc_heartbeat
-  server_grpc_tool_dispatch
   server_dashboard_http_schedule_actions
   server_schedule_runner_policy)
  (flags :standard -open Masc)
  (libraries
+  server_grpc_tool_dispatch_internal
   masc
   masc.dashboard
   masc.fd_accountant

--- a/lib/server/masc_grpc_server.ml
+++ b/lib/server/masc_grpc_server.ml
@@ -418,7 +418,10 @@ end
 let create_server
       ~(port : int)
       ~(workspace_config : Workspace_utils_backend_setup.config)
-      ~(tool_dispatcher : string -> string -> (string, string) result)
+      ~(tool_dispatcher :
+         string ->
+         string ->
+         (string, Server_grpc_tool_dispatch.error) result)
       ~(lsp_dispatcher :
           language_id:string
           -> jsonrpc_request_json:string
@@ -481,7 +484,10 @@ let start
       ~(sw : Eio.Switch.t)
       ~(env : Eio_unix.Stdenv.base)
       ~(workspace_config : Workspace_utils_backend_setup.config)
-      ~(tool_dispatcher : string -> string -> (string, string) result)
+      ~(tool_dispatcher :
+         string ->
+         string ->
+         (string, Server_grpc_tool_dispatch.error) result)
   : unit
   =
   if not (is_enabled ())

--- a/lib/server/masc_grpc_server.mli
+++ b/lib/server/masc_grpc_server.mli
@@ -25,7 +25,10 @@ end
 val create_server :
   port:int ->
   workspace_config:Workspace_utils_backend_setup.config ->
-  tool_dispatcher:(string -> string -> (string, string) result) ->
+  tool_dispatcher:
+    (string ->
+     string ->
+     (string, Server_grpc_tool_dispatch.error) result) ->
   lsp_dispatcher:(language_id:string ->
                    jsonrpc_request_json:string ->
                    workspace_root:string option ->
@@ -44,5 +47,8 @@ val start :
   sw:Eio.Switch.t ->
   env:Eio_unix.Stdenv.base ->
   workspace_config:Workspace_utils_backend_setup.config ->
-  tool_dispatcher:(string -> string -> (string, string) result) ->
+  tool_dispatcher:
+    (string ->
+     string ->
+     (string, Server_grpc_tool_dispatch.error) result) ->
   unit

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -152,7 +152,10 @@ let handle_get_status (workspace_config : Workspace_utils_backend_setup.config) 
 
 (** ToolCall handler: dispatch an MCP tool call via gRPC. *)
 let handle_tool_call
-      (tool_dispatcher : string -> string -> (string, string) result)
+      (tool_dispatcher :
+         string ->
+         string ->
+         (string, Server_grpc_tool_dispatch.error) result)
       (bytes : string)
   : string
   =
@@ -164,9 +167,15 @@ let handle_tool_call
     | Ok result_json ->
       T.ToolCallResponse.
         { success = true; result_json; error_message = ""; error_code = 0 }
-    | Error msg ->
+    | Error error ->
       T.ToolCallResponse.
-        { success = false; result_json = ""; error_message = msg; error_code = Mcp_error_code.(to_wire_code Internal_error) }
+        { success = false
+        ; result_json = ""
+        ; error_message = Server_grpc_tool_dispatch.error_message error
+        ; error_code =
+            Server_grpc_tool_dispatch.error_code error
+            |> Mcp_error_code.to_wire_code
+        }
   in
   T.ToolCallResponse.to_bytes result
 ;;
@@ -559,13 +568,15 @@ let handle_subscribe (workspace_config : Workspace_utils_backend_setup.config) (
 (** Create the gRPC service with all handlers wired to the given workspace config.
 
     @param workspace_config The MASC workspace configuration.
-    @param tool_dispatcher Function that dispatches tool calls:
-      [tool_name -> arguments_json -> (result_json, error_message) result].
+    @param tool_dispatcher Function that dispatches typed tool calls.
     @param lsp_dispatcher Function that forwards LSP JSON-RPC requests:
       [language_id -> jsonrpc_request_json -> workspace_root -> (response_json, error) result]. *)
 let create_service
       ~(workspace_config : Workspace_utils_backend_setup.config)
-      ~(tool_dispatcher : string -> string -> (string, string) result)
+      ~(tool_dispatcher :
+         string ->
+         string ->
+         (string, Server_grpc_tool_dispatch.error) result)
       ~(lsp_dispatcher :
           language_id:string
           -> jsonrpc_request_json:string

--- a/lib/server/masc_grpc_service.mli
+++ b/lib/server/masc_grpc_service.mli
@@ -17,13 +17,15 @@ val stream_max_buffer : unit -> int
 (** Create the gRPC service with all handlers wired to the given workspace config.
 
     @param workspace_config The MASC workspace configuration.
-    @param tool_dispatcher Function that dispatches tool calls:
-      [tool_name -> arguments_json -> (result_json, error_message) result].
+    @param tool_dispatcher Function that dispatches typed tool calls.
     @param lsp_dispatcher Function that forwards LSP JSON-RPC requests:
       [language_id -> jsonrpc_request_json -> workspace_root -> (response_json, error) result]. *)
 val create_service :
   workspace_config:Workspace_utils_backend_setup.config ->
-  tool_dispatcher:(string -> string -> (string, string) result) ->
+  tool_dispatcher:
+    (string ->
+     string ->
+     (string, Server_grpc_tool_dispatch.error) result) ->
   lsp_dispatcher:(language_id:string ->
                    jsonrpc_request_json:string ->
                    workspace_root:string option ->

--- a/lib/server/server_grpc_tool_dispatch.ml
+++ b/lib/server/server_grpc_tool_dispatch.ml
@@ -2,7 +2,7 @@
    [Mcp_server_eio_execute.execute_tool_eio], which owns request, audit, and
    tool-span telemetry; rejected input performs no tool action. *)
 type error =
-  { code : Mcp_error_code.t
+  { code : Masc.Mcp_error_code.t
   ; message : string
   }
 
@@ -22,12 +22,12 @@ let dispatch ~dispatch arguments_json =
   match parsed with
   | Error () ->
     Error
-      { code = Mcp_error_code.Invalid_params
+      { code = Masc.Mcp_error_code.Invalid_params
       ; message = "Invalid params: expected object"
       }
   | Ok arguments ->
     (match dispatch arguments with
      | Ok _ as result -> result
      | Error message ->
-       Error { code = Mcp_error_code.Internal_error; message })
+       Error { code = Masc.Mcp_error_code.Internal_error; message })
 ;;

--- a/lib/server/server_grpc_tool_dispatch.ml
+++ b/lib/server/server_grpc_tool_dispatch.ml
@@ -1,3 +1,6 @@
+(* TEL-OK: pure fail-closed JSON shape gate. Its sole production callback is
+   [Mcp_server_eio_execute.execute_tool_eio], which owns request, audit, and
+   tool-span telemetry; rejected input performs no tool action. *)
 let dispatch ~dispatch arguments_json =
   match Yojson.Safe.from_string arguments_json with
   | (`Assoc _ as arguments) -> dispatch arguments

--- a/lib/server/server_grpc_tool_dispatch.ml
+++ b/lib/server/server_grpc_tool_dispatch.ml
@@ -1,9 +1,33 @@
 (* TEL-OK: pure fail-closed JSON shape gate. Its sole production callback is
    [Mcp_server_eio_execute.execute_tool_eio], which owns request, audit, and
    tool-span telemetry; rejected input performs no tool action. *)
+type error =
+  { code : Mcp_error_code.t
+  ; message : string
+  }
+
+let error_code error = error.code
+let error_message error = error.message
+
 let dispatch ~dispatch arguments_json =
-  match Yojson.Safe.from_string arguments_json with
-  | (`Assoc _ as arguments) -> dispatch arguments
-  | _ -> Error "Invalid params: expected object"
-  | exception Yojson.Json_error _ -> Error "Invalid params: expected object"
+  let parsed =
+    if String.equal arguments_json ""
+    then Ok (`Assoc [])
+    else
+      match Yojson.Safe.from_string arguments_json with
+      | (`Assoc _ as arguments) -> Ok arguments
+      | _ -> Error ()
+      | exception Yojson.Json_error _ -> Error ()
+  in
+  match parsed with
+  | Error () ->
+    Error
+      { code = Mcp_error_code.Invalid_params
+      ; message = "Invalid params: expected object"
+      }
+  | Ok arguments ->
+    (match dispatch arguments with
+     | Ok _ as result -> result
+     | Error message ->
+       Error { code = Mcp_error_code.Internal_error; message })
 ;;

--- a/lib/server/server_grpc_tool_dispatch.ml
+++ b/lib/server/server_grpc_tool_dispatch.ml
@@ -1,0 +1,6 @@
+let dispatch ~dispatch arguments_json =
+  match Yojson.Safe.from_string arguments_json with
+  | (`Assoc _ as arguments) -> dispatch arguments
+  | _ -> Error "Invalid params: expected object"
+  | exception Yojson.Json_error _ -> Error "Invalid params: expected object"
+;;

--- a/lib/server/server_grpc_tool_dispatch.mli
+++ b/lib/server/server_grpc_tool_dispatch.mli
@@ -1,6 +1,11 @@
 (** Private transport seam that rejects invalid gRPC tool arguments before
     invoking the production dispatcher. *)
+type error
+
+val error_code : error -> Mcp_error_code.t
+val error_message : error -> string
+
 val dispatch :
   dispatch:(Yojson.Safe.t -> ('a, string) result) ->
   string ->
-  ('a, string) result
+  ('a, error) result

--- a/lib/server/server_grpc_tool_dispatch.mli
+++ b/lib/server/server_grpc_tool_dispatch.mli
@@ -1,0 +1,6 @@
+(** Private transport seam that rejects invalid gRPC tool arguments before
+    invoking the production dispatcher. *)
+val dispatch :
+  dispatch:(Yojson.Safe.t -> ('a, string) result) ->
+  string ->
+  ('a, string) result

--- a/lib/server/server_grpc_tool_dispatch.mli
+++ b/lib/server/server_grpc_tool_dispatch.mli
@@ -2,7 +2,7 @@
     invoking the production dispatcher. *)
 type error
 
-val error_code : error -> Mcp_error_code.t
+val error_code : error -> Masc.Mcp_error_code.t
 val error_message : error -> string
 
 val dispatch :

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -351,9 +351,17 @@ let install_domain_pool_references domain_pool =
   Executor_pool_ref.set (Domain_pool.executor_pool domain_pool)
 ;;
 
+let dispatch_grpc_tool_call ~dispatch arguments_json =
+  match Yojson.Safe.from_string arguments_json with
+  | (`Assoc _ as arguments) -> dispatch arguments
+  | _ -> Error "Invalid params: expected object"
+  | exception Yojson.Json_error _ -> Error "Invalid params: expected object"
+;;
+
 module For_testing = struct
   let configure_exact_output_registry = configure_exact_output_registry
   let install_domain_pool_references = install_domain_pool_references
+  let dispatch_grpc_tool_call = dispatch_grpc_tool_call
 end
 
 (* GC tuning for long-running server with bursty allocation.
@@ -1370,26 +1378,23 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
          unrelated Keeper lanes. *)
       (* gRPC workspace transport (default-on, opt-out via MASC_GRPC_ENABLED=0) *)
       let tool_dispatcher tool_name args_json =
-        let arguments =
-          try Yojson.Safe.from_string args_json
-          with Yojson.Json_error _ -> `Assoc []
-        in
-        let workspace_scope = Mcp_server.workspace_scope state in
-        let result =
-          Mcp_server_eio_execute.execute_tool_eio
-            ~sw
-            ~clock
-            ~workspace_scope
-            state
-            ~name:tool_name ~arguments
-        in
-        let success = not (Tool_result.is_failed result)
-        and result_str = Tool_result.message result
-        in
-        if not success then
-          Log.Server.error "gRPC tool call failed: tool=%s error_bytes=%d"
-            tool_name (String.length result_str);
-        if success then Ok result_str else Error result_str
+        dispatch_grpc_tool_call args_json ~dispatch:(fun arguments ->
+          let workspace_scope = Mcp_server.workspace_scope state in
+          let result =
+            Mcp_server_eio_execute.execute_tool_eio
+              ~sw
+              ~clock
+              ~workspace_scope
+              state
+              ~name:tool_name ~arguments
+          in
+          let success = not (Tool_result.is_failed result)
+          and result_str = Tool_result.message result
+          in
+          if not success then
+            Log.Server.error "gRPC tool call failed: tool=%s error_bytes=%d"
+              tool_name (String.length result_str);
+          if success then Ok result_str else Error result_str)
       in
       Masc_grpc_server.start ~sw ~env ~workspace_config:(Mcp_server.workspace_config state)
         ~tool_dispatcher;

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -351,17 +351,9 @@ let install_domain_pool_references domain_pool =
   Executor_pool_ref.set (Domain_pool.executor_pool domain_pool)
 ;;
 
-let dispatch_grpc_tool_call ~dispatch arguments_json =
-  match Yojson.Safe.from_string arguments_json with
-  | (`Assoc _ as arguments) -> dispatch arguments
-  | _ -> Error "Invalid params: expected object"
-  | exception Yojson.Json_error _ -> Error "Invalid params: expected object"
-;;
-
 module For_testing = struct
   let configure_exact_output_registry = configure_exact_output_registry
   let install_domain_pool_references = install_domain_pool_references
-  let dispatch_grpc_tool_call = dispatch_grpc_tool_call
 end
 
 (* GC tuning for long-running server with bursty allocation.
@@ -1378,7 +1370,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
          unrelated Keeper lanes. *)
       (* gRPC workspace transport (default-on, opt-out via MASC_GRPC_ENABLED=0) *)
       let tool_dispatcher tool_name args_json =
-        dispatch_grpc_tool_call args_json ~dispatch:(fun arguments ->
+      Server_grpc_tool_dispatch.dispatch args_json ~dispatch:(fun arguments ->
           let workspace_scope = Mcp_server.workspace_scope state in
           let result =
             Mcp_server_eio_execute.execute_tool_eio

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -89,11 +89,6 @@ val mandatory_exact_output_lane_ids : string list
 module For_testing : sig
   val configure_exact_output_registry : ?config_root:string -> unit -> unit
   val install_domain_pool_references : Domain_pool.t -> unit
-
-  val dispatch_grpc_tool_call :
-    dispatch:(Yojson.Safe.t -> (string, string) result) ->
-    string ->
-    (string, string) result
 end
 
 val runtime_path_diagnostics :

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -89,6 +89,11 @@ val mandatory_exact_output_lane_ids : string list
 module For_testing : sig
   val configure_exact_output_registry : ?config_root:string -> unit -> unit
   val install_domain_pool_references : Domain_pool.t -> unit
+
+  val dispatch_grpc_tool_call :
+    dispatch:(Yojson.Safe.t -> (string, string) result) ->
+    string ->
+    (string, string) result
 end
 
 val runtime_path_diagnostics :

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -3,9 +3,11 @@
 ; All deps use re_export so consumers see the modules directly.
 ; Keep sorted. Add new deps here, not in individual test stanzas.
 
+(copy_files ../../lib/server/server_grpc_tool_dispatch.ml)
+
 (library
  (name masc_test_deps)
- (modules masc_test_deps)
+ (modules masc_test_deps server_grpc_tool_dispatch)
  (foreign_stubs
   (language c)
   (names test_env_stubs))

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -1,6 +1,8 @@
 (* Shared dependency re-export for MASC test suite.
    Also hosts tiny test helpers that need a single SSOT across files. *)
 
+module Server_grpc_tool_dispatch = Server_grpc_tool_dispatch
+
 (** Install the Eio clock + optional switch in every registry the lib
     code reads from.
 

--- a/test/dune
+++ b/test/dune
@@ -1247,7 +1247,11 @@
   test_board_render_discord
   test_board_render_slack
   test_board_moderation)
- (libraries masc_test_deps masc.embedded_config bigstringaf)
+ (libraries
+  masc_test_deps
+  masc.embedded_config
+  server_grpc_tool_dispatch_internal
+  bigstringaf)
  (deps ../bin/main_eio.exe))
 
 (test

--- a/test/dune
+++ b/test/dune
@@ -1250,7 +1250,6 @@
  (libraries
   masc_test_deps
   masc.embedded_config
-  server_grpc_tool_dispatch_internal
   bigstringaf)
  (deps ../bin/main_eio.exe))
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -113,7 +113,7 @@ let test_grpc_tool_arguments_fail_closed_before_dispatch () =
   [ "malformed", "{"; "non-object", "[]" ]
   |> List.iter (fun (label, arguments_json) ->
     match
-          Server_grpc_tool_dispatch.dispatch ~dispatch arguments_json
+          Masc_test_deps.Server_grpc_tool_dispatch.dispatch ~dispatch arguments_json
     with
     | Error message ->
       Alcotest.(check string)

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -113,9 +113,7 @@ let test_grpc_tool_arguments_fail_closed_before_dispatch () =
   [ "malformed", "{"; "non-object", "[]" ]
   |> List.iter (fun (label, arguments_json) ->
     match
-      Server_runtime_bootstrap.For_testing.dispatch_grpc_tool_call
-        ~dispatch
-        arguments_json
+          Server_grpc_tool_dispatch.dispatch ~dispatch arguments_json
     with
     | Error message ->
       Alcotest.(check string)

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -122,9 +122,9 @@ let test_grpc_tool_arguments_fail_closed_before_dispatch () =
         (Masc_test_deps.Server_grpc_tool_dispatch.error_message error);
       Alcotest.(check int)
         (label ^ " invalid-params code")
-        (Mcp_error_code.to_wire_code Mcp_error_code.Invalid_params)
+        (Masc.Mcp_error_code.to_wire_code Masc.Mcp_error_code.Invalid_params)
         (Masc_test_deps.Server_grpc_tool_dispatch.error_code error
-         |> Mcp_error_code.to_wire_code)
+         |> Masc.Mcp_error_code.to_wire_code)
     | Ok _ -> Alcotest.failf "%s arguments reached the dispatcher" label);
   Alcotest.(check int) "rejected dispatcher calls" 0 !dispatch_calls;
   (match

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -104,6 +104,28 @@ let contains_substring haystack needle =
   in
   loop 0
 
+let test_grpc_tool_arguments_fail_closed_before_dispatch () =
+  let dispatch_calls = ref 0 in
+  let dispatch _arguments =
+    incr dispatch_calls;
+    Ok "{}"
+  in
+  [ "malformed", "{"; "non-object", "[]" ]
+  |> List.iter (fun (label, arguments_json) ->
+    match
+      Server_runtime_bootstrap.For_testing.dispatch_grpc_tool_call
+        ~dispatch
+        arguments_json
+    with
+    | Error message ->
+      Alcotest.(check string)
+        (label ^ " typed error")
+        "Invalid params: expected object"
+        message
+    | Ok _ -> Alcotest.failf "%s arguments reached the dispatcher" label);
+  Alcotest.(check int) "dispatcher calls" 0 !dispatch_calls
+;;
+
 let canonical_path path =
   try Unix.realpath path with Unix.Unix_error _ -> path
 
@@ -4798,6 +4820,10 @@ let () =
             "transition projection cursor commits before isolated owner recovery"
             `Quick
             test_transition_projection_cursor_commits_before_isolated_owner_recovery;
+          Alcotest.test_case
+            "gRPC tool arguments fail closed before dispatch"
+            `Quick
+            test_grpc_tool_arguments_fail_closed_before_dispatch;
           Alcotest.test_case
             "model catalog installs explicit env override"
             `Quick test_model_catalog_configuration_installs_explicit_env_override;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -115,13 +115,27 @@ let test_grpc_tool_arguments_fail_closed_before_dispatch () =
     match
           Masc_test_deps.Server_grpc_tool_dispatch.dispatch ~dispatch arguments_json
     with
-    | Error message ->
+    | Error error ->
       Alcotest.(check string)
         (label ^ " typed error")
         "Invalid params: expected object"
-        message
+        (Masc_test_deps.Server_grpc_tool_dispatch.error_message error);
+      Alcotest.(check int)
+        (label ^ " invalid-params code")
+        (Mcp_error_code.to_wire_code Mcp_error_code.Invalid_params)
+        (Masc_test_deps.Server_grpc_tool_dispatch.error_code error
+         |> Mcp_error_code.to_wire_code)
     | Ok _ -> Alcotest.failf "%s arguments reached the dispatcher" label);
-  Alcotest.(check int) "dispatcher calls" 0 !dispatch_calls
+  Alcotest.(check int) "rejected dispatcher calls" 0 !dispatch_calls;
+  (match
+     Masc_test_deps.Server_grpc_tool_dispatch.dispatch ~dispatch ""
+   with
+   | Ok "{}" -> ()
+   | Ok result -> Alcotest.failf "unexpected omitted-arguments result: %s" result
+   | Error error ->
+     Alcotest.fail
+       (Masc_test_deps.Server_grpc_tool_dispatch.error_message error));
+  Alcotest.(check int) "omitted arguments dispatch once" 1 !dispatch_calls
 ;;
 
 let canonical_path path =


### PR DESCRIPTION
## What changed

- require gRPC tool `arguments_json` to decode as a JSON object
- return the existing typed `Error` path before `execute_tool_eio` for malformed and non-object input
- cover both invalid shapes in the existing runtime bootstrap test while proving the injected dispatcher is never called

## Root cause

Malformed JSON was silently replaced with `{}`, so an invalid request could reach the MCP tool dispatcher as a different valid request.

## Scope

This is limited to the gRPC tool argument decode boundary. It does not change providers, models, pricing, migration, or adjacent dispatch behavior.

## Validation

Local build, tests, and formatter were intentionally not run per request. CI is the validation authority.
