### PR TITLE
fix(keeper): reject untyped runtime blocker fallbacks

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -108,21 +108,10 @@ let disposition_of_typed_runtime_blocker_class blocker_class =
   | Keeper_meta_contract.Sdk_tripwire_violation ->
     Keeper_turn_disposition.Unknown { raw_error = "" }
 
-let legacy_provider_runtime_blocker_disposition raw_blocker_class =
-  match raw_blocker_class with
-  | "no_capable_provider" | "provider_runtime_error" ->
-      Some
-        (Keeper_turn_disposition.Provider_error
-           (Keeper_turn_terminal_code.Provider_runtime_error raw_blocker_class))
-  | _ -> None
-
 let disposition_of_runtime_blocker_class raw_blocker_class =
   match Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class with
   | Some blocker_class -> disposition_of_typed_runtime_blocker_class blocker_class
-  | None -> (
-    match legacy_provider_runtime_blocker_disposition raw_blocker_class with
-    | Some disposition -> disposition
-    | None -> Keeper_turn_disposition.Unknown { raw_error = "" })
+  | None -> Keeper_turn_disposition.Unknown { raw_error = "" }
 
 let terminal_reason_from_runtime_blocker_fields runtime_blocker_fields =
   match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with


### PR DESCRIPTION
## Summary
- remove provider-named legacy runtime blocker string recovery
- accept only the current typed runtime blocker decoder
- fail closed as unknown for unrecognized blocker wire values

## Boundary
MASC does not infer provider/model semantics from persisted strings. This is a current-schema hard cut; no migration or compatibility decoder is added.

## Validation
- local build/tests/formatter intentionally not run; PR CI is authoritative