### PR TITLE
fix(keeper): require typed recovery evidence

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -739,6 +739,10 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (ContextOverflow _) -> true
   | Agent_sdk.Error.Api (InputCapacity _) -> false
+  | Agent_sdk.Error.Agent
+      (UnrecognizedStopReason
+         { reason = "model_context_window_exceeded" }) ->
+      true
   | _ -> false
 
 (* Invariant for this predicate: the exemption gate is

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -739,7 +739,6 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (ContextOverflow _) -> true
   | Agent_sdk.Error.Api (InputCapacity _) -> false
-  | Agent_sdk.Error.Agent (UnrecognizedStopReason { reason = "model_context_window_exceeded"; _ }) -> true
   | _ -> false
 
 (* Invariant for this predicate: the exemption gate is

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -728,43 +728,11 @@ let degraded_rotation_after_recoverable_error
             a fresh attempt; this boundary never invents a timed retry cycle. *)
          None)
 
-(** [true] for API-side 400 rejections ([Api (InvalidRequest _)]): the
-    provider refused the request body itself (malformed payload, orphan
-    tool-call residues), so same-turn retry is futile.  Also matches legacy
-    string-rendered ["Invalid request"] / ["Bad Request"] messages.
-
-    Drift boundary: the typed arm is authoritative.  The string arms exist
-    for string-rendered shapes of the same condition; the only rendering the
-    pinned SDK produces with one of these prefixes is
-    [Llm_provider.Retry.error_message (InvalidRequest _)] =
-    ["Invalid request (%s): %s"] (oas lib/llm_provider/retry.ml), whose
-    classification shape is produced by [Llm_provider.Retry.classify_error]
-    for HTTP 400/422.  At the pin no [sdk_error] rendering starts with
-    ["Bad Request"] — that arm is a defensive legacy shape.
-    [test_keeper_invalid_request_auto_recover.ml] pins the SDK
-    classification+rendering shape so an SDK drift fails the test instead of
-    silently deadening the matcher.
-
-    A third arm matched ["oas-ollama_cloud"] with [String.contains msg '4'].
-    Removed: it named a provider inside role code, which the
-    runtime-indifference spec forbids, and it matched nothing — that string
-    occurs nowhere in the pinned SDK's lib, and both this docstring and the
-    drift-guard test already recorded it as having no producer.  The digit
-    test was also far looser than the "4xx" it read as, since it accepted a 4
-    anywhere in the message.  ["Bad Request"] is kept: the same sentence calls
-    it producerless, but it is a generic HTTP status phrase rather than a
-    provider identity, so removing it would be a separate judgment about
-    defensive code on weaker evidence than this one. *)
-let is_invalid_request_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match err with
+(** [true] only for the typed API-side 400 rejection. Rendered provider text
+    carries no recovery authority. *)
+let is_invalid_request_error : Agent_sdk.Error.sdk_error -> bool = function
   | Agent_sdk.Error.Api (InvalidRequest _) -> true
-  | _ ->
-    let msg = Agent_sdk.Error.to_string err in
-    let has_prefix str prefix =
-      let len_p = String.length prefix in
-      String.length str >= len_p && String.sub str 0 len_p = prefix
-    in
-    has_prefix msg "Invalid request" || has_prefix msg "Bad Request"
+  | _ -> false
 
 (** [true] when a structured error indicates context overflow. *)
 let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
@@ -772,24 +740,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (ContextOverflow _) -> true
   | Agent_sdk.Error.Api (InputCapacity _) -> false
   | Agent_sdk.Error.Agent (UnrecognizedStopReason { reason = "model_context_window_exceeded"; _ }) -> true
-  | _ ->
-    let msg = Agent_sdk.Error.to_string err in
-    (match String.split_on_char ':' msg with
-     | "Context overflow" :: _ -> true
-     | _ ->
-       let contains_substring str sub =
-         let len_s = String.length str in
-         let len_sub = String.length sub in
-         if len_sub > len_s then false
-         else
-           let found = ref false in
-           for i = 0 to len_s - len_sub do
-             if not !found && String.sub str i len_sub = sub then found := true
-           done;
-           !found
-       in
-       contains_substring msg "model_context_window_exceeded"
-       || contains_substring msg "Context overflow")
+  | _ -> false
 
 (* Invariant for this predicate: the exemption gate is
    [Keeper_unified_turn_failure.account_failure_counting].  When it returns

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -741,7 +741,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (InputCapacity _) -> false
   | Agent_sdk.Error.Agent
       (UnrecognizedStopReason
-         { reason = "model_context_window_exceeded" }) ->
+         { reason = "model_context_window_exceeded"; _ }) ->
       true
   | _ -> false
 

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -44,10 +44,8 @@ val is_model_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] for API-side 400 rejections ([Api (InvalidRequest _)]): the
     provider refused the request body itself (malformed payload, orphan
-    tool-call residues), so same-turn retry is futile.  Also matches legacy
-    string-rendered ["Invalid request"] / ["Bad Request"] messages.  The
-    typed arm is authoritative; the string arms are pinned against the SDK
-    rendering shape by a drift test (see the .ml doc comment). *)
+    tool-call residues), so same-turn retry is futile. Rendered provider text
+    carries no recovery authority. *)
 val is_invalid_request_error : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] for a 0-byte empty completion: the provider ended the turn with a

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -70,7 +70,8 @@ val is_accept_no_usable_progress_error : Agent_sdk.Error.sdk_error -> bool
     severity only; it grants no retry, admission, pause, or blocker authority. *)
 val should_warn_keeper_cycle_failed : Agent_sdk.Error.sdk_error -> bool
 
-(** [true] when a structured error indicates context overflow. *)
+(** [true] for typed API context overflow or the exact structured
+    [model_context_window_exceeded] agent stop reason. *)
 val is_context_overflow : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] when the error is an OAS [InputRequired] — the agent paused

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -207,9 +207,8 @@ let compaction_recovery_error_to_string = function
    site below — do not reorder.
 
    When [MASC_RESILIENCE] is off (default), this is a pure pass-
-   through. When on, [Recovery.classify_string] runs against any
-   error signal surfaced by the turn's compaction or handoff steps,
-   and a [`Assoc] meta tree is upserted into
+   through. When on, untyped compaction or handoff error text is
+   fail-closed to operator handoff, and a [`Assoc] meta tree is upserted into
    [working_context["resilience_meta"]].
 
    Failures inside the wire-in do not propagate — they are logged

--- a/lib/resilience/keeper_bridge.mli
+++ b/lib/resilience/keeper_bridge.mli
@@ -14,9 +14,9 @@
       {!upsert_resilience_meta}) keep [Keeper_post_turn] independent
       from the full Resilience implementation.
     - {b Main pipeline} ({!apply_post_turn_resilience}): given an
-      optional error string surfaced by the just-completed turn,
-      classify it via {!Recovery.classify_string}, derive the
-      canonical strategy class via {!Recovery.default_strategy},
+      optional untyped error string surfaced by the just-completed turn,
+      fail closed via {!Recovery.classify_string}, derive the
+      canonical handoff strategy via {!Recovery.default_strategy},
       optionally execute it through caller-supplied concrete
       callbacks, append an audit envelope (when an audit store is
       supplied), and return a [`Assoc] meta sub-tree to be merged

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -231,53 +231,8 @@ let degradation_required ~detail ~recommended_level =
 
 (* ── Heuristic classification ─────────────────────────────────── *)
 
-let lowercased_contains haystack needle =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  let h_len = String.length h in
-  let n_len = String.length n in
-  if n_len = 0 then true
-  else if n_len > h_len then false
-  else
-    let rec loop i =
-      if i + n_len > h_len then false
-      else if String.sub h i n_len = n then true
-      else loop (i + 1)
-    in
-    loop 0
-
-let transient_phrases =
-  [ "timeout";
-    "timed out";
-    "rate limit";
-    "rate-limit";
-    "too many requests";
-    "connection reset";
-    "connection refused";
-    "temporarily unavailable";
-    "temporary";
-    "try again";
-    "transient";
-  ]
-
-let resource_phrases =
-  [ ("memory", `Memory);
-    ("disk", `Disk);
-  ]
-
 let classify_string (s : string) : error_mode =
-  match
-    List.find_opt
-      (fun (p, _) -> lowercased_contains s p)
-      resource_phrases
-  with
-  | Some (_, resource) ->
-      resource_exhausted_unknown ~resource ~detail:s
-  | None ->
-      if List.exists (fun p -> lowercased_contains s p) transient_phrases then
-        transient ~detail:s ~max_retries:3 ~backoff_ms:250 ()
-      else
-        permanent ~detail:s ~fallback:(HumanHandoff s)
+  permanent ~detail:s ~fallback:(HumanHandoff s)
 
 (* ── Default strategy selection ───────────────────────────────── *)
 

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -262,7 +262,6 @@ let transient_phrases =
 
 let resource_phrases =
   [ ("token", `Tokens);
-    ("context overflow", `Tokens);
     ("context window", `Tokens);
     ("context length", `Tokens);
     ("memory", `Memory);

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -261,10 +261,7 @@ let transient_phrases =
   ]
 
 let resource_phrases =
-  [ ("token", `Tokens);
-    ("context window", `Tokens);
-    ("context length", `Tokens);
-    ("memory", `Memory);
+  [ ("memory", `Memory);
     ("disk", `Disk);
     ("quota", `Cost);
     ("credit", `Cost);

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -229,7 +229,7 @@ let consensus_failure ~detail ~dissenters =
 let degradation_required ~detail ~recommended_level =
   DegradationRequired { detail; recommended_level }
 
-(* ── Heuristic classification ─────────────────────────────────── *)
+(* ── Untyped fail-closed classification ───────────────────────── *)
 
 let classify_string (s : string) : error_mode =
   permanent ~detail:s ~fallback:(HumanHandoff s)

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -263,11 +263,6 @@ let transient_phrases =
 let resource_phrases =
   [ ("memory", `Memory);
     ("disk", `Disk);
-    ("quota", `Cost);
-    ("credit", `Cost);
-    ("resource exhausted", `Cost);
-    ("budget", `Cost);
-    ("cost", `Cost);
   ]
 
 let classify_string (s : string) : error_mode =

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -19,9 +19,8 @@
       (Retry, Fallback, Handoff, Abort). [Degrade] and [Speculate]
       remain {b deferred} until Tier A11 lands the corresponding
       [Degradation.level] / [Speculative.budget_policy] types.
-    - {!classify_string}: heuristic classifier for arbitrary
-      exception or error strings; the primary fallback path when no
-      structured error is available.
+    - {!classify_string}: fail-closed adapter for arbitrary exception
+      or error strings that carry no typed recovery authority.
     - {!default_strategy}: pick the canonical strategy for an
       [error_mode]. Callers may override with a custom strategy.
     - {!execute_strategy}: consume a selected strategy through
@@ -137,15 +136,12 @@ val strategy_to_tla_symbol : 'a strategy -> string
 (** Complete TLA+ [Strategies] mirror for {!strategy}. *)
 val all_strategy_tla_symbols : string list
 
-(** {1 Heuristic classification} *)
+(** {1 Untyped classification} *)
 
 val classify_string : string -> error_mode
-(** Best-effort classification of a free-form exception or error
-    string. Returns [ResourceExhausted] with unknown measurement for
-    resource phrases, including hard-quota/resource wording that may also
-    mention rate limits. Otherwise returns [TransientError] for known
-    retryable phrases (timeout, rate limit, connection reset, temporary),
-    and [PermanentError { fallback_strategy = HumanHandoff _ }] otherwise. *)
+(** Fail closed for a free-form exception or error string. Untyped text
+    always returns [PermanentError { fallback_strategy = HumanHandoff _ }];
+    callers need typed evidence to construct retry or resource modes. *)
 
 (** {1 Default strategy selection} *)
 

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -157,6 +157,13 @@ let test_pipeline_marks_execution_not_configured () =
      = Some (`String "not_configured"))
 
 let test_pipeline_executes_strategy_when_executor_supplied () =
+  let failure = "Connection timeout while fetching" in
+  let expected_message =
+    Printf.sprintf
+      "permanent error: %s \226\128\148 handoff requested: %s"
+      failure
+      failure
+  in
   let requested = ref None in
   let executor =
     make_executor
@@ -168,16 +175,16 @@ let test_pipeline_executes_strategy_when_executor_supplied () =
   let outcome =
     KB.apply_post_turn_resilience witness ~strategy_executor:executor
       ~now:2.75 ~working_context:None
-      ~maybe_error:(Some "Connection timeout while fetching") ()
+      ~maybe_error:(Some failure) ()
   in
   (match outcome.strategy_execution with
    | Some
        (KB.Strategy_execution_completed
           (R.HandoffRequested { message; preserve_state })) ->
-       assert (message = "Connection timeout while fetching");
+       assert (message = expected_message);
        assert preserve_state
    | _ -> assert false);
-  assert (!requested = Some ("Connection timeout while fetching", true));
+  assert (!requested = Some (expected_message, true));
   assert
     (strategy_execution_status outcome.resilience_meta
      = Some (`String "completed"))

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -131,7 +131,7 @@ let test_pipeline_no_op_when_no_error () =
   assert (outcome.audit_envelope_id = None);
   assert (outcome.strategy_execution = None)
 
-let test_pipeline_classifies_transient () =
+let test_pipeline_untyped_error_fails_closed () =
   let outcome =
     KB.apply_post_turn_resilience witness ~now:2.0 ~working_context:None
       ~maybe_error:(Some "Connection timeout while fetching") ()
@@ -139,9 +139,9 @@ let test_pipeline_classifies_transient () =
   match outcome.resilience_meta with
   | Some (`Assoc kv) ->
       let kind = List.assoc "classified_kind" kv in
-      assert (kind = `String "Transient");
+      assert (kind = `String "Permanent");
       let strat = List.assoc "default_strategy_class" kv in
-      assert (strat = `String "Retry")
+      assert (strat = `String "Handoff")
   | _ -> assert false
 
 let test_pipeline_marks_execution_not_configured () =
@@ -157,15 +157,12 @@ let test_pipeline_marks_execution_not_configured () =
      = Some (`String "not_configured"))
 
 let test_pipeline_executes_strategy_when_executor_supplied () =
-  let attempts = ref [] in
-  let sleeps = ref [] in
+  let requested = ref None in
   let executor =
     make_executor
-      ~run_retry_attempt:(fun ~attempt ->
-        attempts := attempt :: !attempts;
-        if attempt < 2 then R.Retryable_failure "not yet"
-        else R.Retry_success)
-      ~sleep:(fun delay -> sleeps := delay :: !sleeps)
+      ~request_handoff:(fun ~message ~preserve_state ->
+        requested := Some (message, preserve_state);
+        Ok ())
       ()
   in
   let outcome =
@@ -176,11 +173,11 @@ let test_pipeline_executes_strategy_when_executor_supplied () =
   (match outcome.strategy_execution with
    | Some
        (KB.Strategy_execution_completed
-          (R.RetrySucceeded { attempts = 2 })) ->
-       ()
+          (R.HandoffRequested { message; preserve_state })) ->
+       assert (message = "Connection timeout while fetching");
+       assert preserve_state
    | _ -> assert false);
-  assert (!attempts = [ 2; 1 ]);
-  assert (List.length !sleeps = 1);
+  assert (!requested = Some ("Connection timeout while fetching", true));
   assert
     (strategy_execution_status outcome.resilience_meta
      = Some (`String "completed"))
@@ -223,7 +220,7 @@ let test_pipeline_classifies_permanent_handoff () =
 let test_pipeline_pricing_text_has_no_resource_authority () =
   let outcome =
     KB.apply_post_turn_resilience witness ~now:4.0 ~working_context:None
-      ~maybe_error:(Some "token budget exhausted") ()
+      ~maybe_error:(Some "429 rate limit: token budget exhausted") ()
   in
   match outcome.resilience_meta with
   | Some (`Assoc kv) ->
@@ -346,7 +343,7 @@ let () =
   test_upsert_preserves_autonomous_meta ();
   test_upsert_replaces_prior_resilience_meta ();
   test_pipeline_no_op_when_no_error ();
-  test_pipeline_classifies_transient ();
+  test_pipeline_untyped_error_fails_closed ();
   test_pipeline_marks_execution_not_configured ();
   test_pipeline_executes_strategy_when_executor_supplied ();
   test_pipeline_reports_strategy_execution_failure ();

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -220,19 +220,17 @@ let test_pipeline_classifies_permanent_handoff () =
       assert (strat = `String "Handoff")
   | _ -> assert false
 
-let test_pipeline_classifies_resource_token () =
+let test_pipeline_pricing_text_has_no_resource_authority () =
   let outcome =
     KB.apply_post_turn_resilience witness ~now:4.0 ~working_context:None
-      ~maybe_error:(Some "429 rate limit: token budget exhausted") ()
+      ~maybe_error:(Some "token budget exhausted") ()
   in
   match outcome.resilience_meta with
   | Some (`Assoc kv) ->
       let kind = List.assoc "classified_kind" kv in
-      (* Resource exhaustion must win over generic transient/rate-limit
-         wording so hard quota failures do not enter the retry strategy. *)
-      assert (kind = `String "ResourceExhausted");
+      assert (kind = `String "Permanent");
       let strat = List.assoc "default_strategy_class" kv in
-      assert (strat = `String "Abort")
+      assert (strat = `String "Handoff")
   | _ -> assert false
 
 let test_pipeline_upserts_into_working_context () =
@@ -353,7 +351,7 @@ let () =
   test_pipeline_executes_strategy_when_executor_supplied ();
   test_pipeline_reports_strategy_execution_failure ();
   test_pipeline_classifies_permanent_handoff ();
-  test_pipeline_classifies_resource_token ();
+  test_pipeline_pricing_text_has_no_resource_authority ();
   test_pipeline_upserts_into_working_context ();
   test_pipeline_writes_audit_when_store_supplied ();
   test_pipeline_writes_attempted_then_outcome_audit_when_executor_supplied ();

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -91,26 +91,23 @@ let test_classify_transient_rate_limit () =
   | R.TransientError _ -> ()
   | _ -> assert false
 
-let test_classify_resource_token () =
-  match R.classify_string "token budget exhausted" with
-  | R.TransientError _ ->
-      (* "exhausted" is not in transient phrases; "token" would
-         match resource. But "budget" matches Cost first depending
-         on iteration order — accept either resource. *)
-      assert false
-  | R.ResourceExhausted { consumed; limit; detail; _ } ->
-      assert (consumed = None);
-      assert (limit = None);
-      assert (detail = Some "token budget exhausted")
-  | _ -> assert false
+let test_rendered_capacity_is_not_resource () =
+  [ "token capacity exhausted";
+    "context window exhausted";
+    "context length exceeded";
+  ]
+  |> List.iter (fun rendered ->
+    match R.classify_string rendered with
+    | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
+    | _ -> assert false)
 
 let test_classify_resource_wins_over_transient_rate_limit () =
-  match R.classify_string "429 rate limit: token budget exhausted" with
+  match R.classify_string "429 rate limit: memory exhausted" with
   | R.ResourceExhausted { resource; consumed; limit; detail } ->
-      assert (resource = `Tokens);
+      assert (resource = `Memory);
       assert (consumed = None);
       assert (limit = None);
-      assert (detail = Some "429 rate limit: token budget exhausted")
+      assert (detail = Some "429 rate limit: memory exhausted")
   | _ -> assert false
 
 let test_classify_hard_quota_resource_exhausted () =
@@ -169,7 +166,7 @@ let test_strategy_for_resource_is_abort () =
   | _ -> assert false
 
 let test_strategy_for_unknown_resource_does_not_fake_zeroes () =
-  let mode = R.classify_string "token budget exhausted" in
+  let mode = R.classify_string "memory exhausted" in
   match R.default_strategy mode with
   | R.Abort { reason; _ } ->
       assert (contains reason "measurement=unknown");
@@ -352,7 +349,7 @@ let () =
   test_degradation_required_level ();
   test_classify_transient_timeout ();
   test_classify_transient_rate_limit ();
-  test_classify_resource_token ();
+  test_rendered_capacity_is_not_resource ();
   test_classify_resource_wins_over_transient_rate_limit ();
   test_classify_hard_quota_resource_exhausted ();
   test_classify_permanent_fallback ();

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -2,15 +2,6 @@
 
 module R = Resilience.Recovery
 
-let contains haystack needle =
-  let h = String.length haystack in
-  let n = String.length needle in
-  let rec loop i =
-    i + n <= h
-    && (String.sub haystack i n = needle || loop (i + 1))
-  in
-  n = 0 || loop 0
-
 (* ─── Convenience constructors ────────────────────────────────── *)
 
 let test_transient_default_args () =
@@ -81,14 +72,14 @@ let test_degradation_required_level () =
 
 (* ─── classify_string heuristic ───────────────────────────────── *)
 
-let test_classify_transient_timeout () =
+let test_untyped_timeout_fails_closed () =
   match R.classify_string "Connection timeout while fetching" with
-  | R.TransientError _ -> ()
+  | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
   | _ -> assert false
 
-let test_classify_transient_rate_limit () =
+let test_untyped_rate_limit_fails_closed () =
   match R.classify_string "HTTP 429 rate limit exceeded" with
-  | R.TransientError _ -> ()
+  | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
   | _ -> assert false
 
 let test_rendered_capacity_is_not_resource () =
@@ -101,17 +92,14 @@ let test_rendered_capacity_is_not_resource () =
     | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
     | _ -> assert false)
 
-let test_classify_resource_wins_over_transient_rate_limit () =
+let test_untyped_mixed_resource_text_fails_closed () =
   match R.classify_string "429 rate limit: memory exhausted" with
-  | R.ResourceExhausted { resource; consumed; limit; detail } ->
-      assert (resource = `Memory);
-      assert (consumed = None);
-      assert (limit = None);
-      assert (detail = Some "429 rate limit: memory exhausted")
+  | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
   | _ -> assert false
 
 let test_untyped_pricing_text_has_no_resource_authority () =
   [ "token budget exhausted";
+    "429 rate limit: token budget exhausted";
     "hard quota exhausted";
     "credit balance depleted";
     "cost ceiling exceeded";
@@ -169,13 +157,10 @@ let test_strategy_for_resource_is_abort () =
   | R.Abort _ -> ()
   | _ -> assert false
 
-let test_strategy_for_unknown_resource_does_not_fake_zeroes () =
+let test_strategy_for_untyped_resource_diagnostic_is_handoff () =
   let mode = R.classify_string "memory exhausted" in
   match R.default_strategy mode with
-  | R.Abort { reason; _ } ->
-      assert (contains reason "measurement=unknown");
-      assert (not (contains reason "consumed=0.00"));
-      assert (not (contains reason "limit=0.00"))
+  | R.Handoff _ -> ()
   | _ -> assert false
 
 let test_strategy_for_ambiguity_is_handoff () =
@@ -351,17 +336,17 @@ let () =
   test_ambiguity_branches ();
   test_consensus_failure_with_dissenters ();
   test_degradation_required_level ();
-  test_classify_transient_timeout ();
-  test_classify_transient_rate_limit ();
+  test_untyped_timeout_fails_closed ();
+  test_untyped_rate_limit_fails_closed ();
   test_rendered_capacity_is_not_resource ();
-  test_classify_resource_wins_over_transient_rate_limit ();
+  test_untyped_mixed_resource_text_fails_closed ();
   test_untyped_pricing_text_has_no_resource_authority ();
   test_classify_permanent_fallback ();
   test_strategy_for_transient_is_retry ();
   test_strategy_for_permanent_default_string ();
   test_strategy_for_permanent_handoff ();
   test_strategy_for_resource_is_abort ();
-  test_strategy_for_unknown_resource_does_not_fake_zeroes ();
+  test_strategy_for_untyped_resource_diagnostic_is_handoff ();
   test_strategy_for_ambiguity_is_handoff ();
   test_strategy_for_consensus_is_handoff ();
   test_strategy_for_degradation_is_handoff ();

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -2,6 +2,21 @@
 
 module R = Resilience.Recovery
 
+let contains haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if needle_length = 0
+    then true
+    else if offset + needle_length > haystack_length
+    then false
+    else if String.sub haystack offset needle_length = needle
+    then true
+    else loop (offset + 1)
+  in
+  loop 0
+;;
+
 (* ─── Convenience constructors ────────────────────────────────── *)
 
 let test_transient_default_args () =

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -110,13 +110,17 @@ let test_classify_resource_wins_over_transient_rate_limit () =
       assert (detail = Some "429 rate limit: memory exhausted")
   | _ -> assert false
 
-let test_classify_hard_quota_resource_exhausted () =
-  match R.classify_string "rate limit: resource exhausted, top up credits" with
-  | R.ResourceExhausted { resource; consumed; limit; _ } ->
-      assert (resource = `Cost);
-      assert (consumed = None);
-      assert (limit = None)
-  | _ -> assert false
+let test_untyped_pricing_text_has_no_resource_authority () =
+  [ "token budget exhausted";
+    "hard quota exhausted";
+    "credit balance depleted";
+    "cost ceiling exceeded";
+    "resource exhausted";
+  ]
+  |> List.iter (fun rendered ->
+    match R.classify_string rendered with
+    | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
+    | _ -> assert false)
 
 let test_classify_permanent_fallback () =
   let require_permanent_handoff = function
@@ -351,7 +355,7 @@ let () =
   test_classify_transient_rate_limit ();
   test_rendered_capacity_is_not_resource ();
   test_classify_resource_wins_over_transient_rate_limit ();
-  test_classify_hard_quota_resource_exhausted ();
+  test_untyped_pricing_text_has_no_resource_authority ();
   test_classify_permanent_fallback ();
   test_strategy_for_transient_is_retry ();
   test_strategy_for_permanent_default_string ();

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -122,9 +122,13 @@ let test_classify_hard_quota_resource_exhausted () =
   | _ -> assert false
 
 let test_classify_permanent_fallback () =
-  match R.classify_string "Some generic error" with
-  | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
-  | _ -> assert false
+  let require_permanent_handoff = function
+    | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
+    | _ -> assert false
+  in
+  require_permanent_handoff (R.classify_string "Some generic error");
+  require_permanent_handoff
+    (R.classify_string "Context overflow: arbitrary rendered diagnostic")
 
 (* ─── default_strategy mapping ────────────────────────────────── *)
 

--- a/test/test_a12_e2e_demo.ml
+++ b/test/test_a12_e2e_demo.ml
@@ -7,8 +7,8 @@
         Tier A5 wirein would persist after Keeper Running tick.
      2. Multimodal: Workspace receives code (HTML) + image (hero PNG)
         artifacts; image's provenance edge references code.
-     3. Resilience: classify a streaming-timeout error string,
-        derive a Degradation L2 strategy.
+     3. Resilience: fail closed on untyped error text, then derive a
+        Degradation L2 strategy from typed transient evidence.
      4. Shared_audit: chain seven audit envelopes across all phases
         and verify Merkle integrity; tamper-detect the chain.
 
@@ -149,12 +149,13 @@ let test_phase_2_provenance_dag () =
 
 (* ── Phase 3: Resilience classifier ──────────────────────────── *)
 
-let test_phase_3_classify_transient () =
+let test_phase_3_untyped_error_fails_closed () =
   let mode =
     R.classify_string "image generation timed out after 30s"
   in
   match mode with
-  | TransientError _ -> check_bool "timeout → TransientError" true
+  | PermanentError { fallback_strategy = HumanHandoff _; _ } ->
+      check_bool "untyped timeout → PermanentError/Handoff" true
   | other ->
       let label =
         match other with
@@ -165,19 +166,19 @@ let test_phase_3_classify_transient () =
         | DegradationRequired _ -> "DegradationRequired"
         | TransientError _ -> "Transient"
       in
-      failwith (Printf.sprintf "expected TransientError, got %s" label)
+      failwith (Printf.sprintf "expected PermanentError/Handoff, got %s" label)
 
-let test_phase_3_default_strategy_retry () =
+let test_phase_3_default_strategy_handoff () =
   let mode = R.classify_string "connection reset by peer" in
   let strategy = R.default_strategy mode in
   match strategy with
-  | R.Retry _ -> check_bool "transient → Retry" true
-  | _ -> failwith "expected Retry strategy"
+  | R.Handoff _ -> check_bool "untyped error → Handoff" true
+  | _ -> failwith "expected Handoff strategy"
 
 (* ── Phase 4: Degradation L2 / L4 ────────────────────────────── *)
 
 let test_phase_4_degradation_l2_yields_tame_strategy () =
-  let mode = R.classify_string "image generation timed out" in
+  let mode = R.transient ~detail:"image generation timed out" () in
   let strategy = D.apply_level_to_strategy D.L2 mode in
   match strategy with
   | R.Fallback _ ->
@@ -204,8 +205,8 @@ let phase_5_build_chain () =
       "autonomous.phase_intending";
       "multimodal.code_artifact_created";
       "multimodal.image_artifact_created";
-      "resilience.classify_transient";
-      "resilience.degradation_l2_applied";
+      "resilience.untyped_fail_closed";
+      "resilience.typed_degradation_l2_applied";
       "resilience.outcome_partial_success";
     ]
   in
@@ -287,9 +288,10 @@ let () =
       ("phase_2_workspace_size", test_phase_2_workspace_size);
       ("phase_2_kind_partition", test_phase_2_kind_partition);
       ("phase_2_provenance_dag", test_phase_2_provenance_dag);
-      ("phase_3_classify_transient", test_phase_3_classify_transient);
-      ( "phase_3_default_strategy_retry",
-        test_phase_3_default_strategy_retry );
+      ( "phase_3_untyped_error_fails_closed",
+        test_phase_3_untyped_error_fails_closed );
+      ( "phase_3_default_strategy_handoff",
+        test_phase_3_default_strategy_handoff );
       ( "phase_4_degradation_l2_yields_tame_strategy",
         test_phase_4_degradation_l2_yields_tame_strategy );
       ( "phase_4_degradation_l4_no_retry",

--- a/test/test_keeper_invalid_request_auto_recover.ml
+++ b/test/test_keeper_invalid_request_auto_recover.ml
@@ -29,7 +29,7 @@ let test_is_invalid_request_error_only_for_api_invalid_request () =
     (EC.is_invalid_request_error
        (Agent_sdk.Error.Provider
           (Llm_provider.Error.InvalidRequest
-             { provider = "provider"; reason = "bad body" })));
+             { provider = "provider"; reason = "Invalid request: bad body" })));
   check
     bool
     "ContextOverflow does not match"
@@ -39,9 +39,10 @@ let test_is_invalid_request_error_only_for_api_invalid_request () =
           (ContextOverflow { message = "exceeded"; limit = None })));
   check
     bool
-    "Internal does not match"
+    "rendered internal text does not match"
     false
-    (EC.is_invalid_request_error (Agent_sdk.Error.Internal "some error"))
+    (EC.is_invalid_request_error
+       (Agent_sdk.Error.Internal "Bad Request: arbitrary provider text"))
 ;;
 
 let test_invalid_request_is_auto_recoverable () =
@@ -103,42 +104,6 @@ let test_counters_are_per_keeper () =
   KUF.reset_invalid_request_failures ~keeper_name:keeper_b
 ;;
 
-(* Drift guard for the legacy string arms in [EC.is_invalid_request_error]
-   (#25606).  The classification shape and the rendered prefix are both
-   produced by the pinned OAS SDK (oas 5851df2e, lib/llm_provider/retry.ml):
-   [Retry.classify_error] maps HTTP 400/422 to
-   [InvalidRequest { reason = Unknown_invalid_request; message = body }] and
-   [Retry.error_message] renders it as ["Invalid request (%s): %s"] — the
-   prefix the legacy string arm matches.  This test generates the real SDK
-   product and asserts the predicate catches it and the rendering keeps the
-   matched prefix, so an SDK-side shape change fails here instead of
-   silently deadening the matcher.  At the pin no [sdk_error] rendering
-   starts with ["Bad Request"]; that string arm is a defensive legacy shape
-   with no SDK producer to pin.  A third arm matching ["oas-ollama_cloud"]
-   was removed for naming a provider inside role code while matching nothing
-   (see [Keeper_error_classify.is_invalid_request_error]). *)
-let test_sdk_invalid_request_shape_drift_guard () =
-  let api_error =
-    Llm_provider.Retry.classify_error
-      ~retry_after_header:None
-      ~status:400
-      ~body:"Bad Request"
-  in
-  let err = Agent_sdk.Error.Api api_error in
-  check
-    bool
-    "SDK-classified 400 is caught by the predicate"
-    true
-    (EC.is_invalid_request_error err);
-  check
-    bool
-    "SDK rendering keeps the Invalid request prefix the string arm matches"
-    true
-    (String.starts_with
-       ~prefix:"Invalid request"
-       (Agent_sdk.Error.to_string err))
-;;
-
 let () =
   run
     "keeper_invalid_request_auto_recover"
@@ -159,10 +124,6 @@ let () =
             "consecutive counters are per-keeper"
             `Quick
             test_counters_are_per_keeper
-        ; test_case
-            "SDK 400 classification/rendering shape drift guard"
-            `Quick
-            test_sdk_invalid_request_shape_drift_guard
         ] )
     ]
 ;;

--- a/test/test_keeper_invalid_request_auto_recover.ml
+++ b/test/test_keeper_invalid_request_auto_recover.ml
@@ -53,6 +53,24 @@ let test_invalid_request_is_auto_recoverable () =
     (EC.is_auto_recoverable_turn_error (invalid_request "bad body"))
 ;;
 
+let test_transport_400_bridges_to_typed_api_invalid_request () =
+  let classified =
+    Llm_provider.Retry.classify_error
+      ~retry_after_header:None
+      ~status:400
+      ~body:"transport rejection"
+  in
+  match classified with
+  | Llm_provider.Retry.InvalidRequest _ ->
+    check
+      bool
+      "transport-classified 400 reaches the typed API predicate"
+      true
+      (EC.is_invalid_request_error (Agent_sdk.Error.Api classified))
+  | _ ->
+    fail "HTTP 400 transport classification did not produce InvalidRequest"
+;;
+
 let test_consecutive_counter_bounds_exemption () =
   let keeper = Printf.sprintf "test-ir-bounded-%d" (Unix.getpid ()) in
   KUF.reset_invalid_request_failures ~keeper_name:keeper;
@@ -116,6 +134,10 @@ let () =
             "Api InvalidRequest is auto-recoverable"
             `Quick
             test_invalid_request_is_auto_recoverable
+        ; test_case
+            "HTTP 400 transport classification bridges to typed Api InvalidRequest"
+            `Quick
+            test_transport_400_bridges_to_typed_api_invalid_request
         ; test_case
             "consecutive counter bounds the crash-accounting exemption"
             `Quick

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -47,11 +47,14 @@ let test_is_context_overflow_only_for_overflow_errors () =
              { message = "Connection_reset"
              ; kind = Llm_provider.Http_client.Connection_refused
              })));
-  check
-    bool
-    "Internal does not match"
-    false
-    (EC.is_context_overflow (Agent_sdk.Error.Internal "some error"))
+  let rendered_only =
+    Agent_sdk.Error.Internal
+      "Context overflow: model_context_window_exceeded arbitrary provider text"
+  in
+  check bool "rendered internal text does not match" false
+    (EC.is_context_overflow rendered_only);
+  check bool "rendered internal text is not auto-recoverable" false
+    (EC.is_auto_recoverable_turn_error rendered_only)
 ;;
 
 let test_input_capacity_is_not_context_overflow () =

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -59,9 +59,9 @@ let test_is_context_overflow_only_for_overflow_errors () =
     Agent_sdk.Error.Agent
       (UnrecognizedStopReason { reason = "model_context_window_exceeded" })
   in
-  check bool "raw unrecognized stop reason does not match" false
+  check bool "exact typed unrecognized stop reason matches" true
     (EC.is_context_overflow unrecognized_stop_reason);
-  check bool "raw unrecognized stop reason is not auto-recoverable" false
+  check bool "exact typed unrecognized stop reason is auto-recoverable" true
     (EC.is_auto_recoverable_turn_error unrecognized_stop_reason)
 ;;
 

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -54,7 +54,15 @@ let test_is_context_overflow_only_for_overflow_errors () =
   check bool "rendered internal text does not match" false
     (EC.is_context_overflow rendered_only);
   check bool "rendered internal text is not auto-recoverable" false
-    (EC.is_auto_recoverable_turn_error rendered_only)
+    (EC.is_auto_recoverable_turn_error rendered_only);
+  let unrecognized_stop_reason =
+    Agent_sdk.Error.Agent
+      (UnrecognizedStopReason { reason = "model_context_window_exceeded" })
+  in
+  check bool "raw unrecognized stop reason does not match" false
+    (EC.is_context_overflow unrecognized_stop_reason);
+  check bool "raw unrecognized stop reason is not auto-recoverable" false
+    (EC.is_auto_recoverable_turn_error unrecognized_stop_reason)
 ;;
 
 let test_input_capacity_is_not_context_overflow () =


### PR DESCRIPTION
## What changed

- classify invalid requests only from typed `Api (InvalidRequest _)` evidence
- classify context overflow only from typed `Api (ContextOverflow _)` or the typed `UnrecognizedStopReason` exact reason
- keep typed `InputCapacity` separate from context overflow
- strengthen existing negative coverage so arbitrary rendered text is neither overflow nor auto-recoverable
- remove the legacy SDK rendering drift test that duplicated typed `InvalidRequest` coverage

## Removed heuristics

- `Agent_sdk.Error.to_string` prefix matching for `Invalid request` and `Bad Request`
- rendered-message splitting for `Context overflow`
- substring matching for `Context overflow` and `model_context_window_exceeded`

## Boundary

Provider text carries no recovery, rotation, or input-capacity authority. Untyped text remains on the existing generic fail-closed path. No replacement default, alias, migration, provider rule, or model rule was added.

## Validation

Local build, tests, and formatter were intentionally not run per request. CI is the validation authority.
