### PR TITLE
fix(keeper): reject unattributed durable events

### DIFF
--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -369,10 +369,10 @@ let drop_by_post_id ~base_path name ~post_id =
   | Ok persisted_removed -> Ok persisted_removed
 ;;
 
-let snapshot ~base_path name =
+let snapshot_result ~base_path name =
   match Keeper_registry.get ~base_path name with
-  | None -> Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
-  | Some entry -> Atomic.get entry.event_queue
+  | None -> Keeper_event_queue_persistence.load_result ~base_path ~keeper_name:name
+  | Some entry -> Ok (Atomic.get entry.event_queue)
 ;;
 
 let claim_when_result ~base_path name ~claimed_at ~ready =

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -359,8 +359,10 @@ val enqueue_hitl_resolution_durable_result :
     function returns [Ok ()]. *)
 
 (** Read-only snapshot of the keeper's queue. If the keeper is not registered,
-    read the durable snapshot so diagnostics still expose pending replay. *)
-val snapshot : base_path:string -> string -> Keeper_event_queue.t
+    read the durable snapshot so diagnostics still expose pending replay.
+    Durable read failures remain explicit. *)
+val snapshot_result :
+  base_path:string -> string -> (Keeper_event_queue.t, string) result
 
 val drop_by_post_id :
   base_path:string

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -37,8 +37,8 @@ let autonomous_yield_request ~base_path ~keeper_name =
             ^ Keeper_chat_queue.mutation_error_to_string error)
        | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
        | Ok false ->
-         let pending =
-           Keeper_registry_event_queue.snapshot ~base_path keeper_name
+         let* pending =
+           Keeper_registry_event_queue.snapshot_result ~base_path keeper_name
          in
          if Keeper_event_queue.is_empty pending
          then Ok None

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -612,6 +612,17 @@ let continuation_channel_field fields =
 let payload_of_yojson json =
   let context = "stimulus.payload" in
   let* fields = assoc_fields ~context json in
+  let kind_count =
+    List.fold_left
+      (fun count (name, _) -> if String.equal name "kind" then count + 1 else count)
+      0
+      fields
+  in
+  let* () =
+    if kind_count = 1
+    then Ok ()
+    else Error (Printf.sprintf "%s.kind must occur exactly once" context)
+  in
   let* kind = string_field ~context "kind" fields in
   let parse_board_stimulus () =
     let* board_kind = string_field ~context "board_kind" fields in

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -636,40 +636,26 @@ let payload_of_yojson json =
   | "fusion_completed" ->
     let* run_id = string_field ~context "run_id" fields in
     let* terminal =
-      match optional_field "terminal" fields with
-      | Some terminal_json ->
-        let* terminal_fields =
-          assoc_fields ~context:"stimulus.payload.terminal" terminal_json
+      let* terminal_json = required_field ~context "terminal" fields in
+      let* terminal_fields =
+        assoc_fields ~context:"stimulus.payload.terminal" terminal_json
+      in
+      let* terminal_kind =
+        string_field ~context:"stimulus.payload.terminal" "kind" terminal_fields
+      in
+      match terminal_kind with
+      | "succeeded" ->
+        let* answer =
+          string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
         in
-        let* terminal_kind =
-          string_field ~context:"stimulus.payload.terminal" "kind" terminal_fields
+        Ok (Fusion_succeeded answer)
+      | "failed" ->
+        let* detail =
+          string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
         in
-        (match terminal_kind with
-         | "succeeded" ->
-           let* answer =
-             string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
-           in
-           Ok (Fusion_succeeded answer)
-         | "failed" ->
-           let* detail =
-             string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
-           in
-           Ok (Fusion_failed detail)
-         | "cancelled" -> Ok Fusion_cancelled
-         | value -> Error (Printf.sprintf "unknown fusion terminal kind: %s" value))
-      | None ->
-        (* Compatibility read for rows persisted before the typed terminal:
-           the old shape carried [ok]+[resolved_answer], and cancellation did
-           not exist, so the two legacy fields determine the terminal exactly.
-           The writer emits only the typed shape. removal target: the next
-           event-queue state generation bump, when pre-terminal rows can no
-           longer exist in a live store. *)
-        let* ok = bool_field ~context "ok" fields in
-        let* resolved_answer = string_field ~context "resolved_answer" fields in
-        Ok
-          (if ok
-           then Fusion_succeeded resolved_answer
-           else Fusion_failed resolved_answer)
+        Ok (Fusion_failed detail)
+      | "cancelled" -> Ok Fusion_cancelled
+      | value -> Error (Printf.sprintf "unknown fusion terminal kind: %s" value)
     in
     let* board_post_id = string_field ~context "board_post_id" fields in
     let* channel = continuation_channel_field fields in
@@ -722,13 +708,8 @@ let payload_of_yojson json =
         Error (Printf.sprintf "unknown failure_judgment class: %s" judgment_label)
     in
     let* provenance =
-      match List.assoc_opt "provenance" fields with
-      | Some json -> Keeper_runtime_failure_route.judgment_provenance_of_yojson json
-      | None ->
-        (* Explicit migration state for pre-provenance durable envelopes. New
-           producers never emit it, but old queues remain replayable without
-           inventing an execution boundary. *)
-        Ok Keeper_runtime_failure_route.Legacy_unattributed
+      let* json = required_field ~context "provenance" fields in
+      Keeper_runtime_failure_route.judgment_provenance_of_yojson json
     in
     let* detail = string_field ~context "detail" fields in
     Ok

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -449,6 +449,19 @@ let required_field ~context name fields =
   | Some value -> Ok value
   | None -> Error (Printf.sprintf "%s missing required field %s" context name)
 
+let exact_fields ~context ~expected fields =
+  let actual = List.map fst fields |> List.sort String.compare in
+  let expected = List.sort String.compare expected in
+  if actual = expected
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "%s fields must be exactly [%s], got [%s]"
+         context
+         (String.concat "," expected)
+         (String.concat "," actual))
+
 let optional_field name fields =
   match List.assoc_opt name fields with
   | Some `Null | None -> None
@@ -634,6 +647,12 @@ let payload_of_yojson json =
       Ok (Board_attention { candidate_id; signal })
   | "bootstrap" -> Ok Bootstrap
   | "fusion_completed" ->
+    let* () =
+      exact_fields
+        ~context
+        ~expected:[ "kind"; "run_id"; "terminal"; "board_post_id"; "channel" ]
+        fields
+    in
     let* run_id = string_field ~context "run_id" fields in
     let* terminal =
       let* terminal_json = required_field ~context "terminal" fields in
@@ -645,16 +664,35 @@ let payload_of_yojson json =
       in
       match terminal_kind with
       | "succeeded" ->
+        let* () =
+          exact_fields
+            ~context:"stimulus.payload.terminal"
+            ~expected:[ "kind"; "message" ]
+            terminal_fields
+        in
         let* answer =
           string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
         in
         Ok (Fusion_succeeded answer)
       | "failed" ->
+        let* () =
+          exact_fields
+            ~context:"stimulus.payload.terminal"
+            ~expected:[ "kind"; "message" ]
+            terminal_fields
+        in
         let* detail =
           string_field ~context:"stimulus.payload.terminal" "message" terminal_fields
         in
         Ok (Fusion_failed detail)
-      | "cancelled" -> Ok Fusion_cancelled
+      | "cancelled" ->
+        let* () =
+          exact_fields
+            ~context:"stimulus.payload.terminal"
+            ~expected:[ "kind" ]
+            terminal_fields
+        in
+        Ok Fusion_cancelled
       | value -> Error (Printf.sprintf "unknown fusion terminal kind: %s" value)
     in
     let* board_post_id = string_field ~context "board_post_id" fields in

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -737,6 +737,12 @@ let payload_of_yojson json =
     let* channel = continuation_channel_field fields in
     Ok (Hitl_resolved { approval_id; decision; channel })
   | "failure_judgment" ->
+    let* () =
+      exact_fields
+        ~context
+        ~expected:[ "kind"; "runtime_id"; "judgment_class"; "provenance"; "detail" ]
+        fields
+    in
     let* runtime_id = string_field ~context "runtime_id" fields in
     let* judgment_label = string_field ~context "judgment_class" fields in
     let* judgment =
@@ -781,6 +787,12 @@ let stimulus_to_yojson (stimulus : stimulus) =
 let stimulus_of_yojson json =
   let context = "stimulus" in
   let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:[ "post_id"; "urgency"; "arrived_at_unix"; "payload" ]
+      fields
+  in
   let* post_id = string_field ~context "post_id" fields in
   let* urgency_s = string_field ~context "urgency" fields in
   let* urgency = urgency_of_string urgency_s in

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -639,11 +639,6 @@ let load_pending_result ~base_path ~keeper_name =
   load_state_result ~base_path ~keeper_name |> Result.map State.pending
 ;;
 
-type snapshot_pair =
-  { pending : Keeper_event_queue.t
-  ; inflight : Keeper_event_queue.t
-  }
-
 type snapshot_pair_with_errors =
   { pending : Keeper_event_queue.t
   ; inflight : Keeper_event_queue.t
@@ -691,11 +686,6 @@ let load_snapshot_pair_with_errors ~base_path ~keeper_name =
     ; inflight = Keeper_event_queue.empty
     ; read_errors = diagnose_snapshot_read_error ~base_path ~keeper_name message
     }
-;;
-
-let load_snapshot_pair ~base_path ~keeper_name =
-  let snapshot = load_snapshot_pair_with_errors ~base_path ~keeper_name in
-  { pending = snapshot.pending; inflight = snapshot.inflight }
 ;;
 
 type snapshot_discovery =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -608,33 +608,6 @@ let load_result ~base_path ~keeper_name =
   load_with_projection ~projection:replay_queue ~base_path ~keeper_name
 ;;
 
-let unavailable_projection_exn ~keeper_name message =
-  Failure
-    (Printf.sprintf
-       "event queue state unavailable keeper=%s: %s"
-       keeper_name
-       message)
-;;
-
-let load ~base_path ~keeper_name =
-  match load_result ~base_path ~keeper_name with
-  | Error message -> raise (unavailable_projection_exn ~keeper_name message)
-  | Ok queue ->
-    if not (Keeper_event_queue.is_empty queue)
-    then
-      Log.Keeper.info
-        "event_queue_snapshot: restored %s for keeper=%s"
-        (Keeper_event_queue.summary queue)
-        keeper_name;
-    queue
-;;
-
-let load_pending ~base_path ~keeper_name =
-  match load_with_projection ~projection:State.pending ~base_path ~keeper_name with
-  | Ok queue -> queue
-  | Error message -> raise (unavailable_projection_exn ~keeper_name message)
-;;
-
 let load_pending_result ~base_path ~keeper_name =
   load_state_result ~base_path ~keeper_name |> Result.map State.pending
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -233,11 +233,6 @@ val load_pending : base_path:string -> keeper_name:string -> Keeper_event_queue.
 val load_pending_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
 
-type snapshot_pair =
-  { pending : Keeper_event_queue.t
-  ; inflight : Keeper_event_queue.t
-  }
-
 type snapshot_read_error_kind =
   | Invalid_path
   | Read_failed
@@ -262,7 +257,6 @@ type snapshot_discovery =
 
 val snapshot_read_error_kind_to_string : snapshot_read_error_kind -> string
 val discover_keeper_names_with_snapshots : base_path:string -> snapshot_discovery
-val load_snapshot_pair : base_path:string -> keeper_name:string -> snapshot_pair
 val load_snapshot_pair_with_errors :
   base_path:string -> keeper_name:string -> snapshot_pair_with_errors
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -215,23 +215,14 @@ val active_lease_result :
 val exact_execution_binding_result :
   base_path:string -> keeper_name:string -> (exact_execution_binding option, string) result
 
-val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
-(** Compatibility replay projection: pending followed by active lease stimuli.
-    New live registry code should use {!load_pending} after explicitly
-    recovering abandoned leases at registration. Raises [Failure] when the
-    durable state is unavailable; it never substitutes an empty queue. *)
-
 val load_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
-(** Result-returning replay projection for callers that can propagate a durable
-    read failure. *)
-
-val load_pending : base_path:string -> keeper_name:string -> Keeper_event_queue.t
-(** Compatibility pending projection. Raises [Failure] on a durable read
-    failure; use {!load_pending_result} in production control flow. *)
+(** Strict replay projection: pending followed by active lease stimuli.
+    Durable read failures remain explicit. *)
 
 val load_pending_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
+(** Strict pending projection. Durable read failures remain explicit. *)
 
 type snapshot_read_error_kind =
   | Invalid_path

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -42,7 +42,6 @@ type judgment_provenance =
   | Oas_internal_error
   | Masc_internal_error
   | Completion_contract
-  | Legacy_unattributed
 
 type error_boundary =
   | Masc_execution
@@ -312,7 +311,6 @@ let judgment_provenance_label = function
   | Oas_internal_error -> "oas_internal_error"
   | Masc_internal_error -> "masc_internal_error"
   | Completion_contract -> "completion_contract"
-  | Legacy_unattributed -> "legacy_unattributed"
 
 type judgment_provenance_boundary =
   | Boundary_oas_api
@@ -326,7 +324,6 @@ type judgment_provenance_boundary =
   | Boundary_oas_internal
   | Boundary_masc_internal
   | Boundary_completion_contract
-  | Boundary_legacy_unattributed
 
 let judgment_provenance_boundary = function
   | Oas_api_error -> Boundary_oas_api
@@ -340,7 +337,6 @@ let judgment_provenance_boundary = function
   | Oas_internal_error -> Boundary_oas_internal
   | Masc_internal_error -> Boundary_masc_internal
   | Completion_contract -> Boundary_completion_contract
-  | Legacy_unattributed -> Boundary_legacy_unattributed
 ;;
 
 let judgment_provenance_same_boundary left right =
@@ -360,8 +356,7 @@ let judgment_provenance_to_yojson provenance =
   | Oas_orchestration_error
   | Oas_internal_error
   | Masc_internal_error
-  | Completion_contract
-  | Legacy_unattributed ->
+  | Completion_contract ->
     `Assoc [ kind ]
 
 let require_exact_provenance_fields expected fields =
@@ -408,8 +403,6 @@ let judgment_provenance_of_yojson = function
        provenance_without_payload fields Masc_internal_error
      | Some (`String "completion_contract") ->
        provenance_without_payload fields Completion_contract
-     | Some (`String "legacy_unattributed") ->
-       provenance_without_payload fields Legacy_unattributed
      | Some (`String kind) ->
        Error (Printf.sprintf "unknown failure judgment provenance: %s" kind)
      | Some _ | None ->

--- a/lib/keeper_runtime/keeper_runtime_failure_route.mli
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.mli
@@ -76,8 +76,7 @@ type judgment_class =
 
 (** Typed origin of a judgment request. The route class says what kind of
     decision is needed; this provenance says which execution boundary produced
-    it. [Legacy_unattributed] is a decode-only state for persisted
-    pre-provenance stimuli and is never emitted by current producers. *)
+    it. *)
 type judgment_provenance =
   | Oas_api_error
   | Oas_provider_error
@@ -90,7 +89,6 @@ type judgment_provenance =
   | Oas_internal_error
   | Masc_internal_error
   | Completion_contract
-  | Legacy_unattributed
 
 type error_boundary =
   | Masc_execution

--- a/test/test_fusion_delivery_obligation.ml
+++ b/test/test_fusion_delivery_obligation.ml
@@ -2,6 +2,16 @@ open Alcotest
 open Masc
 
 module Obligation = Fusion_delivery_obligation
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Keeper_event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> fail detail
+  ;;
+end
 
 let () = Mirage_crypto_rng_unix.use_default ()
 

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -330,18 +330,12 @@ let test_fusion_cancellation_is_typed_and_actionable () =
        ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
-(* Rows persisted before the typed terminal carry { ok; resolved_answer }.
-   The compatibility read must derive the exact terminal from them; on main
-   before this branch these rows decoded, and a terminal-only decoder would
-   reject every pre-deploy row in a live store. *)
-let test_fusion_legacy_rows_decode_to_typed_terminal () =
-  let legacy ~ok =
-    let json =
-      fusion_stimulus ~run_id:"fus-legacy"
-        ~terminal:(Keeper_event_queue.Fusion_succeeded "unused") ()
-      |> Keeper_event_queue.stimulus_to_yojson
-    in
-    match json with
+let test_fusion_missing_terminal_is_rejected () =
+  let missing_terminal =
+    fusion_stimulus ~run_id:"fus-missing-terminal"
+      ~terminal:(Keeper_event_queue.Fusion_succeeded "unused") ()
+    |> Keeper_event_queue.stimulus_to_yojson
+    |> function
     | `Assoc fields ->
       `Assoc
         (List.map
@@ -355,32 +349,14 @@ let test_fusion_legacy_rows_decode_to_typed_terminal () =
                   , `Assoc
                       (List.filter
                          (fun (name, _) -> not (String.equal name "terminal"))
-                         payload_fields
-                       @ [ "ok", `Bool ok
-                         ; "resolved_answer", `String "legacy answer"
-                         ]) )
+                         payload_fields) )
                 | _ -> fail "stimulus payload must be an object"))
            fields)
     | _ -> fail "stimulus json must be an object"
   in
-  (match Keeper_event_queue.stimulus_of_yojson (legacy ~ok:true) with
-   | Ok
-       { payload =
-           Keeper_event_queue.Fusion_completed
-             { terminal = Keeper_event_queue.Fusion_succeeded answer; _ }
-       ; _
-       } -> check string "legacy ok row keeps its answer" "legacy answer" answer
-   | Ok _ -> fail "legacy ok row lost its typed terminal"
-   | Error detail -> fail ("legacy ok row failed to decode: " ^ detail));
-  match Keeper_event_queue.stimulus_of_yojson (legacy ~ok:false) with
-  | Ok
-      { payload =
-          Keeper_event_queue.Fusion_completed
-            { terminal = Keeper_event_queue.Fusion_failed detail; _ }
-      ; _
-      } -> check string "legacy failed row keeps its detail" "legacy answer" detail
-  | Ok _ -> fail "legacy failed row lost its typed terminal"
-  | Error detail -> fail ("legacy failed row failed to decode: " ^ detail)
+  match Keeper_event_queue.stimulus_of_yojson missing_terminal with
+  | Error _ -> ()
+  | Ok _ -> fail "fusion completion without terminal decoded"
 ;;
 
 (* RFC-0290: a completed background job follows the same non-empty delivery
@@ -1082,9 +1058,9 @@ let () =
             `Quick
             test_fusion_cancellation_is_typed_and_actionable
         ; test_case
-            "legacy ok/resolved_answer rows decode to the typed terminal"
+            "fusion completion without terminal is rejected"
             `Quick
-            test_fusion_legacy_rows_decode_to_typed_terminal
+            test_fusion_missing_terminal_is_rejected
         ; test_case
             "missing board_post_id falls back to fusion-run id"
             `Quick

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -14,6 +14,17 @@
 open Alcotest
 open Masc
 
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Keeper_event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> fail detail
+  ;;
+end
+
 (* substring check without pulling in the [str] library *)
 let contains ~needle haystack =
   let nl = String.length needle and hl = String.length haystack in

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -42,14 +42,18 @@ let rec ensure_dir path =
 ;;
 
 let durable_resolution_opt ~base_path ~keeper_name ~approval_id =
-  Registry_queue.snapshot ~base_path keeper_name
-  |> Keeper_event_queue.to_list
-  |> List.find_map (fun (stimulus : Keeper_event_queue.stimulus) ->
-    match stimulus.payload with
-    | Keeper_event_queue.Hitl_resolved resolution
-      when String.equal resolution.approval_id approval_id ->
-      Some resolution
-    | _ -> None)
+  match Registry_queue.snapshot_result ~base_path keeper_name with
+  | Error reason ->
+    Alcotest.failf "registry queue snapshot failed: %s" reason
+  | Ok queue ->
+    queue
+    |> Keeper_event_queue.to_list
+    |> List.find_map (fun (stimulus : Keeper_event_queue.stimulus) ->
+      match stimulus.payload with
+      | Keeper_event_queue.Hitl_resolved resolution
+        when String.equal resolution.approval_id approval_id ->
+        Some resolution
+      | _ -> None)
 ;;
 
 let require_some message = function

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -1,6 +1,15 @@
 module A = Masc.Keeper_board_attention_candidate
 module Event_queue = Keeper_event_queue
-module Event_queue_persistence = Keeper_event_queue_persistence
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+end
 module J = Masc.Keeper_board_attention_judgment
 module Wake = Masc.Keeper_board_attention_worker_wake
 

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -1,7 +1,16 @@
 module A = Masc.Keeper_board_attention_candidate
 module E = Masc.Keeper_board_attention_exact_flow
 module Event_queue = Keeper_event_queue
-module Event_queue_persistence = Keeper_event_queue_persistence
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+end
 module J = Masc.Keeper_board_attention_judgment
 module P = Masc.Keeper_board_attention_partition
 module Q = Masc.Keeper_board_attention_quarantine_command

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -9,6 +9,16 @@
 open Alcotest
 module WO = Masc.Keeper_world_observation
 module A = Masc.Keeper_external_attention
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Keeper_event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> fail detail
+  ;;
+end
 
 let contains ~needle haystack =
   let nl = String.length needle in

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1,3 +1,19 @@
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Keeper_event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+end
+
+let registry_snapshot ~base_path keeper_name =
+  match Masc.Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+  | Ok queue -> queue
+  | Error detail -> Alcotest.fail detail
+
 let temp_dir prefix =
   Filename.temp_dir prefix ""
 
@@ -63,35 +79,35 @@ let read_file path =
     ~finally:(fun () -> close_in_noerr input)
     (fun () -> really_input_string input (in_channel_length input))
 
-let remove_payload_field ~kind ~field json =
-  let removed = ref 0 in
+let rewrite_payload_fields ~kind ~label rewrite_fields json =
+  let rewritten = ref 0 in
   let rec rewrite = function
     | `Assoc fields ->
       let fields =
         match List.assoc_opt "kind" fields with
         | Some (`String observed_kind) when String.equal observed_kind kind ->
-          if List.mem_assoc field fields
-          then (
-            incr removed;
-            List.remove_assoc field fields)
-          else fields
+          let next = rewrite_fields fields in
+          if next <> fields then incr rewritten;
+          next
         | _ -> fields
       in
       `Assoc (List.map (fun (name, value) -> name, rewrite value) fields)
     | `List values -> `List (List.map rewrite values)
     | other -> other
   in
-  let rewritten = rewrite json in
+  let rewritten_json = rewrite json in
   Alcotest.(check int)
-    (Printf.sprintf "removed exactly one %s field from %s payload" field kind)
+    (Printf.sprintf "rewrote exactly one %s payload for %s" kind label)
     1
-    !removed;
-  rewritten
+    !rewritten;
+  rewritten_json
 
-let latest_log_seq () =
-  match Log.Ring.recent ~limit:1 () with
-  | (entry : Log.Ring.entry) :: _ -> entry.seq
-  | [] -> -1
+let remove_payload_field ~kind ~field =
+  rewrite_payload_fields
+    ~kind
+    ~label:("missing " ^ field)
+    (fun fields ->
+       if List.mem_assoc field fields then List.remove_assoc field fields else fields)
 
 let contains_substring ~needle haystack =
   let needle_len = String.length needle in
@@ -116,13 +132,6 @@ let with_strict_executor f =
   Executor_pool_ref.For_testing.with_pool
     (Domain_pool.executor_pool pool)
     f
-
-let restored_log_messages_since before_seq =
-  Log.Ring.recent ~limit:20 ~module_filter:"Keeper" ~since_seq:before_seq ()
-  |> List.filter_map (fun (entry : Log.Ring.entry) ->
-    if contains_substring ~needle:"event_queue_snapshot: restored " entry.message
-    then Some entry.message
-    else None)
 
 let claim_single ~base_path ~keeper_name ~claimed_at ~ready =
   match
@@ -794,34 +803,6 @@ let () =
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
-  (* --- operator snapshot reads stay quiet; live hydration still announces replay. --- *)
-  let base_path = temp_dir "keeper-event-queue-restore-log-gate" in
-  Fun.protect
-    ~finally:(fun () -> rm_rf base_path)
-    (fun () ->
-      Log.set_level Log.Info;
-      let keeper_name = "keeper-event-queue-restore-log-gate-test" in
-      let q = enqueue empty board_stim |> fun q -> enqueue q bootstrap_stim in
-      Keeper_event_queue_persistence.persist ~base_path ~keeper_name q;
-      let before_operator_read = latest_log_seq () in
-      ignore
-        (Keeper_event_queue_persistence.load_snapshot_pair_with_errors
-           ~base_path
-           ~keeper_name);
-      Alcotest.(check (list string))
-        "operator snapshot read does not emit restore log"
-        []
-        (restored_log_messages_since before_operator_read);
-      let before_live_load = latest_log_seq () in
-      ignore (Keeper_event_queue_persistence.load ~base_path ~keeper_name);
-      Alcotest.(check bool)
-        "live load emits restore log"
-        true
-        (List.exists
-           (contains_substring
-              ~needle:"keeper=keeper-event-queue-restore-log-gate-test")
-           (restored_log_messages_since before_live_load)));
-
   (* --- strict persisted load rejects current payloads missing required
          terminal provenance and preserves the operator-reset evidence. --- *)
   let failure_judgment : failure_judgment =
@@ -850,12 +831,12 @@ let () =
       ; payload = Failure_judgment failure_judgment
       }
   in
-  let assert_strict_persisted_missing_field ~kind ~field =
-    let base_path = temp_dir ("keeper-event-queue-missing-" ^ field) in
+  let assert_strict_persisted_rejected ~label ~rewrite ~expected_detail =
+    let base_path = temp_dir ("keeper-event-queue-" ^ label) in
     Fun.protect
       ~finally:(fun () -> rm_rf base_path)
       (fun () ->
-        let keeper_name = "strict-persisted-required-fields" in
+        let keeper_name = "strict-persisted-" ^ label in
         Keeper_event_queue_persistence.persist
           ~base_path
           ~keeper_name
@@ -864,7 +845,7 @@ let () =
         let malformed =
           read_file path
           |> Yojson.Safe.from_string
-          |> remove_payload_field ~kind ~field
+          |> rewrite
           |> Yojson.Safe.to_string
         in
         write_file path malformed;
@@ -874,27 +855,75 @@ let () =
              ~keeper_name
          with
          | Ok _ ->
-           Alcotest.failf "persisted %s payload without %s loaded" kind field
+           Alcotest.failf "persisted malformed payload loaded: %s" label
          | Error detail ->
            Alcotest.(check bool)
-             (Printf.sprintf "%s error requires reset" field)
+             (label ^ " error requires reset")
              true
              (contains_substring ~needle:"reset required" detail);
-           Alcotest.(check bool)
-             (Printf.sprintf "%s error names missing field" field)
-             true
-             (contains_substring ~needle:field detail));
+           (match expected_detail with
+            | None -> ()
+            | Some expected ->
+              Alcotest.(check bool)
+                (label ^ " error preserves decoder detail")
+                true
+                (contains_substring ~needle:expected detail)));
         Alcotest.(check string)
-          (Printf.sprintf "%s evidence is not rewritten" field)
+          (label ^ " evidence is not rewritten")
           malformed
           (read_file path))
   in
-  assert_strict_persisted_missing_field
-    ~kind:"fusion_completed"
-    ~field:"terminal";
-  assert_strict_persisted_missing_field
-    ~kind:"failure_judgment"
-    ~field:"provenance";
+  assert_strict_persisted_rejected
+    ~label:"missing-terminal"
+    ~rewrite:(remove_payload_field ~kind:"fusion_completed" ~field:"terminal")
+    ~expected_detail:(Some "terminal");
+  assert_strict_persisted_rejected
+    ~label:"missing-provenance"
+    ~rewrite:(remove_payload_field ~kind:"failure_judgment" ~field:"provenance")
+    ~expected_detail:(Some "provenance");
+  let rewrite_fusion_payload ~label rewrite_fields =
+    rewrite_payload_fields ~kind:"fusion_completed" ~label rewrite_fields
+  in
+  let rewrite_terminal rewrite_fields fields =
+    List.map
+      (function
+        | "terminal", `Assoc terminal_fields ->
+          "terminal", `Assoc (rewrite_fields terminal_fields)
+        | field -> field)
+      fields
+  in
+  assert_strict_persisted_rejected
+    ~label:"fusion-output-fields"
+    ~rewrite:
+      (rewrite_fusion_payload
+         ~label:"unexpected output fields"
+         (fun fields ->
+            ("ok", `Bool true)
+            :: ("resolved_answer", `String "conflicting answer")
+            :: fields))
+    ~expected_detail:None;
+  assert_strict_persisted_rejected
+    ~label:"fusion-terminal-extra-field"
+    ~rewrite:
+      (rewrite_fusion_payload
+         ~label:"terminal extra field"
+         (rewrite_terminal (fun fields -> ("unexpected", `String "value") :: fields)))
+    ~expected_detail:None;
+  assert_strict_persisted_rejected
+    ~label:"fusion-terminal-duplicate-kind"
+    ~rewrite:
+      (rewrite_fusion_payload
+         ~label:"terminal duplicate kind"
+         (rewrite_terminal (fun fields -> ("kind", `String "failed") :: fields)))
+    ~expected_detail:None;
+  assert_strict_persisted_rejected
+    ~label:"fusion-terminal-duplicate-message"
+    ~rewrite:
+      (rewrite_fusion_payload
+         ~label:"terminal duplicate message"
+         (rewrite_terminal (fun fields ->
+            ("message", `String "conflicting message") :: fields)))
+    ~expected_detail:None;
 
   (* --- durable snapshot load collapses legacy duplicates that differ only by
          arrival time. --- *)
@@ -1242,11 +1271,11 @@ let () =
       ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
-      assert (length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
+      assert (length (registry_snapshot ~base_path keeper_name) = 1);
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
       Masc.Keeper_registry.For_testing.clear ();
       ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
-      let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+      let restored = registry_snapshot ~base_path keeper_name in
       assert (length restored = 1);
       (match
          Masc.Keeper_registry_event_queue.claim_when_result
@@ -1259,7 +1288,7 @@ let () =
        | Ok (Some _) -> Alcotest.fail "unready stimulus must remain queued"
        | Error error -> Alcotest.fail ("readiness claim failed: " ^ error));
       assert (
-        length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
+        length (registry_snapshot ~base_path keeper_name) = 1);
       let replay_lease, replayed =
         claim_single
           ~base_path
@@ -1337,7 +1366,7 @@ let () =
       Alcotest.(check (list string))
         "both aliases publish to one live atomic"
         expected_post_ids
-        (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name
+        (registry_snapshot ~base_path keeper_name
          |> queue_post_ids);
       Alcotest.(check (list string))
         "both alias stimuli share one durable snapshot"
@@ -1356,7 +1385,7 @@ let () =
       Alcotest.(check (list string))
         "restart through alias restores both stimuli"
         expected_post_ids
-        (Masc.Keeper_registry_event_queue.snapshot
+        (registry_snapshot
            ~base_path
            keeper_name
          |> queue_post_ids));
@@ -1474,10 +1503,10 @@ let () =
         keeper_name
         duplicate_bootstrap_stim;
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
-      let pending = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+      let pending = registry_snapshot ~base_path keeper_name in
       assert (length pending = 2);
       ignore (Masc.Keeper_registry.For_testing.register ~base_path keeper_name meta);
-      let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+      let restored = registry_snapshot ~base_path keeper_name in
       assert (length restored = 2);
       let claim_and_ack expected_post_id =
         let claimed_at = Time_compat.now () in
@@ -1739,7 +1768,7 @@ let () =
        | Ok () -> ()
        | Error msg -> Alcotest.fail ("offline durable enqueue failed: " ^ msg));
       assert (
-        length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
+        length (registry_snapshot ~base_path keeper_name) = 1);
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name)));
 
   (* --- critical delivery: an unwritable path is an explicit error, never an

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -812,6 +812,24 @@ let () =
     ; fj_detail = "strict persisted fixture"
     }
   in
+  (match
+     stimulus_to_yojson
+       { post_id = "duplicate-payload"
+       ; urgency = Normal
+       ; arrived_at = 9.0
+       ; payload = fusion_payload ()
+       }
+   with
+   | `Assoc fields ->
+     let malformed =
+       `Assoc
+         (fields
+          @ [ "payload", `Assoc [ "kind", `String "bootstrap" ] ])
+     in
+     (match stimulus_of_yojson malformed with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.fail "stimulus with duplicate payload loaded")
+   | _ -> Alcotest.fail "stimulus serializer did not emit an object");
   let strict_queue =
     empty
     |> fun queue ->
@@ -881,6 +899,26 @@ let () =
     ~label:"missing-provenance"
     ~rewrite:(remove_payload_field ~kind:"failure_judgment" ~field:"provenance")
     ~expected_detail:(Some "provenance");
+  let rewrite_failure_judgment_payload ~label rewrite_fields =
+    rewrite_payload_fields ~kind:"failure_judgment" ~label rewrite_fields
+  in
+  assert_strict_persisted_rejected
+    ~label:"failure-judgment-duplicate-provenance"
+    ~rewrite:
+      (rewrite_failure_judgment_payload
+         ~label:"duplicate provenance"
+         (fun fields ->
+            match List.assoc_opt "provenance" fields with
+            | Some provenance -> ("provenance", provenance) :: fields
+            | None -> Alcotest.fail "failure judgment fixture has no provenance"))
+    ~expected_detail:None;
+  assert_strict_persisted_rejected
+    ~label:"failure-judgment-extra-field"
+    ~rewrite:
+      (rewrite_failure_judgment_payload
+         ~label:"extra compatibility field"
+         (fun fields -> ("legacy_provenance", `String "ignored") :: fields))
+    ~expected_detail:None;
   let rewrite_fusion_payload ~label rewrite_fields =
     rewrite_payload_fields ~kind:"fusion_completed" ~label rewrite_fields
   in

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -57,6 +57,37 @@ let write_file path contents =
   let oc = open_out_bin path in
   Fun.protect ~finally:(fun () -> close_out oc) (fun () -> output_string oc contents)
 
+let read_file path =
+  let input = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr input)
+    (fun () -> really_input_string input (in_channel_length input))
+
+let remove_payload_field ~kind ~field json =
+  let removed = ref 0 in
+  let rec rewrite = function
+    | `Assoc fields ->
+      let fields =
+        match List.assoc_opt "kind" fields with
+        | Some (`String observed_kind) when String.equal observed_kind kind ->
+          if List.mem_assoc field fields
+          then (
+            incr removed;
+            List.remove_assoc field fields)
+          else fields
+        | _ -> fields
+      in
+      `Assoc (List.map (fun (name, value) -> name, rewrite value) fields)
+    | `List values -> `List (List.map rewrite values)
+    | other -> other
+  in
+  let rewritten = rewrite json in
+  Alcotest.(check int)
+    (Printf.sprintf "removed exactly one %s field from %s payload" field kind)
+    1
+    !removed;
+  rewritten
+
 let latest_log_seq () =
   match Log.Ring.recent ~limit:1 () with
   | (entry : Log.Ring.entry) :: _ -> entry.seq
@@ -763,7 +794,7 @@ let () =
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
-  (* --- health snapshot reads stay quiet; live hydration still announces replay. --- *)
+  (* --- operator snapshot reads stay quiet; live hydration still announces replay. --- *)
   let base_path = temp_dir "keeper-event-queue-restore-log-gate" in
   Fun.protect
     ~finally:(fun () -> rm_rf base_path)
@@ -772,16 +803,15 @@ let () =
       let keeper_name = "keeper-event-queue-restore-log-gate-test" in
       let q = enqueue empty board_stim |> fun q -> enqueue q bootstrap_stim in
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name q;
-      let before_health_reads = latest_log_seq () in
-      ignore (Keeper_event_queue_persistence.load_snapshot_pair ~base_path ~keeper_name);
+      let before_operator_read = latest_log_seq () in
       ignore
         (Keeper_event_queue_persistence.load_snapshot_pair_with_errors
            ~base_path
            ~keeper_name);
       Alcotest.(check (list string))
-        "health snapshot reads do not emit restore log"
+        "operator snapshot read does not emit restore log"
         []
-        (restored_log_messages_since before_health_reads);
+        (restored_log_messages_since before_operator_read);
       let before_live_load = latest_log_seq () in
       ignore (Keeper_event_queue_persistence.load ~base_path ~keeper_name);
       Alcotest.(check bool)
@@ -791,6 +821,80 @@ let () =
            (contains_substring
               ~needle:"keeper=keeper-event-queue-restore-log-gate-test")
            (restored_log_messages_since before_live_load)));
+
+  (* --- strict persisted load rejects current payloads missing required
+         terminal provenance and preserves the operator-reset evidence. --- *)
+  let failure_judgment : failure_judgment =
+    { fj_runtime_id = "strict-persisted-runtime"
+    ; fj_judgment = Keeper_runtime_failure_route.Protocol_error
+    ; fj_provenance = Keeper_runtime_failure_route.Oas_mcp_error
+    ; fj_detail = "strict persisted fixture"
+    }
+  in
+  let strict_queue =
+    empty
+    |> fun queue ->
+    enqueue
+      queue
+      { post_id = "strict-persisted-fusion"
+      ; urgency = Normal
+      ; arrived_at = 10.0
+      ; payload = fusion_payload ()
+      }
+    |> fun queue ->
+    enqueue
+      queue
+      { post_id = failure_judgment_post_id failure_judgment
+      ; urgency = Normal
+      ; arrived_at = 11.0
+      ; payload = Failure_judgment failure_judgment
+      }
+  in
+  let assert_strict_persisted_missing_field ~kind ~field =
+    let base_path = temp_dir ("keeper-event-queue-missing-" ^ field) in
+    Fun.protect
+      ~finally:(fun () -> rm_rf base_path)
+      (fun () ->
+        let keeper_name = "strict-persisted-required-fields" in
+        Keeper_event_queue_persistence.persist
+          ~base_path
+          ~keeper_name
+          strict_queue;
+        let path = snapshot_path ~base_path ~keeper_name in
+        let malformed =
+          read_file path
+          |> Yojson.Safe.from_string
+          |> remove_payload_field ~kind ~field
+          |> Yojson.Safe.to_string
+        in
+        write_file path malformed;
+        (match
+           Keeper_event_queue_persistence.load_state_result
+             ~base_path
+             ~keeper_name
+         with
+         | Ok _ ->
+           Alcotest.failf "persisted %s payload without %s loaded" kind field
+         | Error detail ->
+           Alcotest.(check bool)
+             (Printf.sprintf "%s error requires reset" field)
+             true
+             (contains_substring ~needle:"reset required" detail);
+           Alcotest.(check bool)
+             (Printf.sprintf "%s error names missing field" field)
+             true
+             (contains_substring ~needle:field detail));
+        Alcotest.(check string)
+          (Printf.sprintf "%s evidence is not rewritten" field)
+          malformed
+          (read_file path))
+  in
+  assert_strict_persisted_missing_field
+    ~kind:"fusion_completed"
+    ~field:"terminal";
+  assert_strict_persisted_missing_field
+    ~kind:"failure_judgment"
+    ~field:"provenance";
 
   (* --- durable snapshot load collapses legacy duplicates that differ only by
          arrival time. --- *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -830,6 +830,27 @@ let () =
       | Error _ -> ()
       | Ok _ -> Alcotest.fail "stimulus with duplicate payload loaded")
    | _ -> Alcotest.fail "stimulus serializer did not emit an object");
+  let duplicate_discriminator =
+    stimulus_to_yojson
+      { post_id = "duplicate-discriminator"
+      ; urgency = Normal
+      ; arrived_at = 9.5
+      ; payload = Failure_judgment failure_judgment
+      }
+    |> function
+    | `Assoc stimulus_fields ->
+      `Assoc
+        (List.map
+           (function
+             | "payload", `Assoc payload_fields ->
+               "payload", `Assoc (("kind", `String "bootstrap") :: payload_fields)
+             | field -> field)
+           stimulus_fields)
+    | _ -> Alcotest.fail "stimulus serializer did not emit an object"
+  in
+  (match stimulus_of_yojson duplicate_discriminator with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "stimulus with duplicate payload kind loaded");
   let strict_queue =
     empty
     |> fun queue ->

--- a/test/test_keeper_event_queue_owner_lock.ml
+++ b/test/test_keeper_event_queue_owner_lock.ml
@@ -4,7 +4,22 @@
     There are no timing thresholds: a participant either reaches the protected
     transition or remains blocked until the owning Keeper lane releases it. *)
 
-module Persistence = Keeper_event_queue_persistence
+module Persistence_source = Keeper_event_queue_persistence
+module Persistence = struct
+  include Persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+
+  let load_pending ~base_path ~keeper_name =
+    match load_pending_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+end
 module Queue = Keeper_event_queue
 
 let rec rm_rf path =

--- a/test/test_keeper_event_queue_persist_poison.ml
+++ b/test/test_keeper_event_queue_persist_poison.ml
@@ -12,6 +12,17 @@
     that the owner's cooperative gate remains usable; a different BasePath
     cannot accidentally make the assertion pass through lock isolation. *)
 
+module Event_queue_persistence_source = Keeper_event_queue_persistence
+module Keeper_event_queue_persistence = struct
+  include Event_queue_persistence_source
+
+  let load ~base_path ~keeper_name =
+    match load_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+end
+
 let rec rm_rf path =
   if Sys.file_exists path
   then

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1,6 +1,15 @@
 module Queue = Keeper_event_queue
 module State = Keeper_event_queue_state
-module Persistence = Keeper_event_queue_persistence
+module Persistence_source = Keeper_event_queue_persistence
+module Persistence = struct
+  include Persistence_source
+
+  let load_pending ~base_path ~keeper_name =
+    match load_pending_result ~base_path ~keeper_name with
+    | Ok queue -> queue
+    | Error detail -> Alcotest.fail detail
+  ;;
+end
 
 let require_ok label = function
   | Ok value -> value

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -434,10 +434,13 @@ let persist_and_register_board_lane config meta =
 ;;
 
 let board_queue_length config keeper_name =
-  Keeper_registry_event_queue.snapshot
-    ~base_path:config.Workspace.base_path
-    keeper_name
-  |> Keeper_event_queue.length
+  match
+    Keeper_registry_event_queue.snapshot_result
+      ~base_path:config.Workspace.base_path
+      keeper_name
+  with
+  | Ok queue -> Keeper_event_queue.length queue
+  | Error detail -> fail ("event queue snapshot failed: " ^ detail)
 ;;
 
 let board_attention_count config keeper_name =

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -15,6 +15,12 @@ module Lane = Masc.Keeper_lane
 
 let base_path = "/tmp/test_keeper_registry_hardening"
 
+let registry_snapshot ~base_path keeper_name =
+  match Masc.Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+  | Ok queue -> queue
+  | Error detail -> fail detail
+;;
+
 let make_meta name =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -497,7 +503,7 @@ let test_reactive_wakeup_defers_offline_lane_after_queue_commit () =
        check bool "offline reactive wake flag remains clear" false
          (Atomic.get entry.fiber_wakeup);
        match
-         Masc.Keeper_registry_event_queue.snapshot ~base_path:dir meta.name
+         registry_snapshot ~base_path:dir meta.name
          |> Keeper_event_queue.to_list
        with
        | [ { post_id; payload = Keeper_event_queue.Bootstrap; _ } ] ->
@@ -534,7 +540,7 @@ let test_goal_assignment_defers_offline_lane_after_queue_commit () =
        check bool "offline goal wake flag remains clear" false
          (Atomic.get entry.fiber_wakeup);
        match
-         Masc.Keeper_registry_event_queue.snapshot
+         registry_snapshot
            ~base_path:config.base_path
            meta.name
          |> Keeper_event_queue.to_list

--- a/test/test_keeper_runtime_failure_route.ml
+++ b/test/test_keeper_runtime_failure_route.ml
@@ -288,7 +288,6 @@ let test_judgment_provenance_codec () =
     ; KFR.Oas_internal_error
     ; KFR.Masc_internal_error
     ; KFR.Completion_contract
-    ; KFR.Legacy_unattributed
     ]
   in
   List.iter
@@ -348,7 +347,7 @@ let test_queue_stimulus_roundtrip () =
       "roundtrip preserves identity"
       true
       (Keeper_event_queue.stimulus_identity_equal stimulus parsed);
-    let legacy_json =
+    let missing_provenance_json =
       match Keeper_event_queue.stimulus_to_yojson stimulus with
       | `Assoc stimulus_fields ->
         let payload =
@@ -365,16 +364,9 @@ let test_queue_stimulus_roundtrip () =
            :: List.remove_assoc "payload" stimulus_fields)
       | _ -> Alcotest.fail "fixture stimulus is not an object"
     in
-    (match Keeper_event_queue.stimulus_of_yojson legacy_json with
-     | Ok
-         { payload =
-             Keeper_event_queue.Failure_judgment
-               { fj_provenance = KFR.Legacy_unattributed; _ }
-         ; _
-         } ->
-       ()
-     | Ok _ -> Alcotest.fail "legacy stimulus invented a provenance"
-     | Error detail -> Alcotest.failf "legacy stimulus did not decode: %s" detail)
+    (match Keeper_event_queue.stimulus_of_yojson missing_provenance_json with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "failure judgment without provenance decoded")
   | Error msg -> Alcotest.failf "roundtrip failed: %s" msg
 
 let failure_judgment_stimulus ~detail : Keeper_event_queue.stimulus =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1,6 +1,17 @@
 open Alcotest
 open Masc
 
+module Registry_event_queue_source = Keeper_registry_event_queue
+module Keeper_registry_event_queue = struct
+  include Registry_event_queue_source
+
+  let snapshot ~base_path keeper_name =
+    match snapshot_result ~base_path keeper_name with
+    | Ok queue -> queue
+    | Error detail -> fail detail
+  ;;
+end
+
 let () = Mirage_crypto_rng_unix.use_default ()
 
 let temp_dir () =


### PR DESCRIPTION
## Summary
- require the current typed fusion terminal in durable event rows
- require typed failure-judgment provenance and remove `Legacy_unattributed` from the public/runtime codec surface
- replace compatibility fixtures with explicit missing-terminal and missing-provenance rejection coverage

Old or malformed rows now use the existing typed read-failure/reset-required path. No migration, reconciliation, provider/model, or pricing behavior is added.

## Validation
- Not run per task instruction (no local build, tests, or formatter).