### PR TITLE
feat(turn-record): 버려지던 provider 캐시 토큰 수를 턴 레코드에 싣는다

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -840,10 +840,22 @@ let run_turn
         let usage : Turn_record.usage =
           match turn_result with
           | Ok result when result.usage_reported ->
+            (* Cache counts travel with the turn rather than being dropped: a large
+               input_tokens on a cache-heavy turn and one on a genuinely large prompt
+               read identically without them, and the ctx-fill denominator below is the
+               compaction ceiling, so the difference is what an operator acts on. *)
             { input_tokens = Some result.usage.input_tokens
             ; output_tokens = Some result.usage.output_tokens
+            ; cache_creation_input_tokens =
+                Some result.usage.cache_creation_input_tokens
+            ; cache_read_input_tokens = Some result.usage.cache_read_input_tokens
             }
-          | Ok _ | Error _ -> { input_tokens = None; output_tokens = None }
+          | Ok _ | Error _ ->
+            { input_tokens = None
+            ; output_tokens = None
+            ; cache_creation_input_tokens = None
+            ; cache_read_input_tokens = None
+            }
         in
         let request_latency_ms : int option =
           (* RFC-0233 §9 — wall-clock duration of the provider call in

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -15,6 +15,8 @@ type sampling =
 type usage =
   { input_tokens : int option
   ; output_tokens : int option
+  ; cache_creation_input_tokens : int option
+  ; cache_read_input_tokens : int option
   }
 
 type t =
@@ -74,6 +76,10 @@ let to_json (r : t) : Yojson.Safe.t =
     @ opt_field "thinking_budget" (fun v -> `Int v) r.sampling.thinking_budget
     @ opt_field "enable_thinking" (fun v -> `Bool v) r.sampling.enable_thinking
     @ opt_field "input_tokens" (fun v -> `Int v) r.usage.input_tokens
+    @ opt_field "cache_creation_input_tokens" (fun v -> `Int v)
+        r.usage.cache_creation_input_tokens
+    @ opt_field "cache_read_input_tokens" (fun v -> `Int v)
+        r.usage.cache_read_input_tokens
     @ opt_field "output_tokens" (fun v -> `Int v) r.usage.output_tokens
     @ [ ("ts", `Float r.ts) ])
 
@@ -172,6 +178,12 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* thinking_budget = opt_member "thinking_budget" fields as_int in
       let* enable_thinking = opt_member "enable_thinking" fields as_bool in
       let* input_tokens = opt_member "input_tokens" fields as_int in
+      let* cache_creation_input_tokens =
+        opt_member "cache_creation_input_tokens" fields as_int
+      in
+      let* cache_read_input_tokens =
+        opt_member "cache_read_input_tokens" fields as_int
+      in
       let* output_tokens = opt_member "output_tokens" fields as_int in
       let* ts_json = require "ts" fields in
       let* ts = as_float "ts" ts_json in
@@ -191,7 +203,12 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; request_latency_ms
         ; ttfrc_ms
         ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
-        ; usage = { input_tokens; output_tokens }
+        ; usage =
+            { input_tokens
+            ; output_tokens
+            ; cache_creation_input_tokens
+            ; cache_read_input_tokens
+            }
         ; ts
         }
   | _ -> Error "turn_record: row is not an object"

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -28,6 +28,15 @@ type sampling =
 type usage =
   { input_tokens : int option
   ; output_tokens : int option
+  ; cache_creation_input_tokens : int option
+  ; cache_read_input_tokens : int option
+    (* The provider reports these alongside [input_tokens]
+       (Agent_sdk.Types.api_usage) and this record used to drop them, so a reader
+       could not tell whether a large [input_tokens] was mostly cache reads. That
+       matters against [context_window] below: the fill percentage it denominates is
+       read as pressure on the compaction ceiling, and cache-heavy turns and
+       genuinely large prompts are different situations with the same numerator.
+       [None] on legacy rows and on turns where the provider reported no usage. *)
   }
 
 type t =

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -59,9 +59,51 @@ let sample_record () : Turn_record.t =
       ; thinking_budget = Some 1500
       ; enable_thinking = Some true
       }
-  ; usage = { input_tokens = Some 18000; output_tokens = Some 412 }
+  ; usage =
+      { input_tokens = Some 18000
+      ; output_tokens = Some 412
+      ; cache_creation_input_tokens = Some 2048
+      ; cache_read_input_tokens = Some 15000
+      }
   ; ts = 1781200000.5
   }
+
+(* The cache counts used to be dropped at the writer, so a row with a large
+   input_tokens could not be read as either a cache-heavy turn or a genuinely large
+   prompt. context_window denominates the ctx-fill percentage against the compaction
+   ceiling, so those two situations look identical on a dashboard while calling for
+   different action. A row that omits them still decodes — legacy rows and turns where
+   the provider reported no usage carry None rather than a fabricated zero. *)
+let test_cache_counts_round_trip_and_stay_optional () =
+  let record = sample_record () in
+  (match Turn_record.of_json (Turn_record.to_json record) with
+   | Error e -> failf "decode failed: %s" e
+   | Ok decoded ->
+     check (option int) "cache creation survives" (Some 2048)
+       decoded.usage.cache_creation_input_tokens;
+     check (option int) "cache read survives" (Some 15000)
+       decoded.usage.cache_read_input_tokens);
+  (* A row written before these fields existed. *)
+  let legacy =
+    match Turn_record.to_json record with
+    | `Assoc fields ->
+      `Assoc
+        (List.filter
+           (fun (k, _) ->
+             k <> "cache_creation_input_tokens" && k <> "cache_read_input_tokens")
+           fields)
+    | other -> other
+  in
+  match Turn_record.of_json legacy with
+  | Error e -> failf "legacy row without cache fields failed to decode: %s" e
+  | Ok decoded ->
+    check (option int) "absent cache creation decodes as None" None
+      decoded.usage.cache_creation_input_tokens;
+    check (option int) "absent cache read decodes as None" None
+      decoded.usage.cache_read_input_tokens;
+    check (option int) "the rest of the row is unaffected" (Some 18000)
+      decoded.usage.input_tokens
+;;
 
 let test_codec_roundtrip () =
   let record = sample_record () in
@@ -133,7 +175,12 @@ let test_codec_optional_fields_absent () =
         ; thinking_budget = None
         ; enable_thinking = None
         }
-    ; usage = { input_tokens = None; output_tokens = None }
+    ; usage =
+        { input_tokens = None
+        ; output_tokens = None
+        ; cache_creation_input_tokens = None
+        ; cache_read_input_tokens = None
+        }
     ; turn_ref = None
     }
   in
@@ -320,6 +367,8 @@ let () =
         ] )
     ; ( "codec"
       , [ test_case "roundtrip" `Quick test_codec_roundtrip
+        ; test_case "cache counts round-trip and stay optional" `Quick
+            test_cache_counts_round_trip_and_stay_optional
         ; test_case "optional fields absent" `Quick test_codec_optional_fields_absent
         ; test_case "rejects malformed rows" `Quick test_codec_rejects_malformed
         ; test_case "unknown block decodes as Other" `Quick


### PR DESCRIPTION
## 무엇을

`Turn_record.usage` 가 provider 가 이미 보고한 캐시 토큰 수 두 개를 버리고 있었습니다. 버리지 않게 합니다.

`Agent_sdk.Types.api_usage` 는 `input_tokens` 와 함께 `cache_creation_input_tokens` / `cache_read_input_tokens` 를 실어 보냅니다 (oas `types.mli:329-332`). `lib/keeper/keeper_agent_run.ml:843` 은 앞의 두 개만 읽고 나머지를 버렸습니다.

## 왜 이 두 값인가

`turn_record.mli:63-69` 는 `context_window` 를 "keeper compaction ceiling (`max_context`)" 로 정의합니다. 즉 이 레코드가 만들어내는 ctx-fill 퍼센트의 분모는 **컴팩션이 걸려야 하는 지점**입니다.

캐시 히트가 큰 턴과 실제로 큰 프롬프트를 보낸 턴은 같은 `input_tokens` 를 냅니다. 분모가 컴팩션 천장인 이상, 둘은 같은 퍼센트로 표시되지만 취해야 할 조치가 다릅니다. 두 필드가 없으면 읽는 쪽에서 구분할 방법이 없습니다.

대시보드는 이미 OAS runtime-event 채널에서 이 값들을 모델링합니다 (`dashboard/src/oas-runtime-store.ts:398`, `oas-runtime-store.test.ts:120-123`). 값을 버리고 있던 것은 turn-record 채널 쪽이었습니다.

## 변경

- `Turn_record.usage` 에 `cache_creation_input_tokens` / `cache_read_input_tokens` (`int option`) 추가
- 인코더/디코더가 함께 나릅니다. 이 변경 이전에 쓰인 행은 `0` 을 지어내지 않고 `None` 으로 디코드됩니다
- `keeper_agent_run.ml` 은 `usage_reported` 경로에서만 채웁니다. 에러 경로는 `None`
- 테스트: 왕복 + 두 키를 제거한 legacy 행이 여전히 `None` 으로 디코드되는지 (`test/test_turn_record.ml`)

## 이 PR 이 하지 않는 것

컴팩션이 걸리지 않는 문제를 고치지 않습니다. taskmaster 가 200,000 천장에 대해 297,821 input tokens 를 보고하면서 12턴 중 10턴을 `completed` 로 넘긴 현상 (masc#25773) 은 그대로입니다. 이 PR 은 그 현상을 판독 가능한 상태로 만들 뿐이고, 판정 경로 변경은 별건입니다.

## 검증

- `dune build @check` 통과 (트리 전체)
- `test/test_turn_record.exe` 13 tests, 성공 (신규 1건 포함)

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 문서 중 어느 것도 건드리지 않음. 변경 범위는 `lib/types/turn_record.{ml,mli}`, `lib/keeper/keeper_agent_run.ml` 의 usage 구성 지점, 해당 테스트.
WORKAROUND-WAIVED: 새 카운터를 추가해 증상을 관찰만 하는 변경이 아니라, 이미 측정된 값을 기록 경계에서 버리던 손실을 제거하는 변경입니다. 판정 로직이나 임계값은 건드리지 않습니다.
