### PR TITLE
fix(keeper): guard 부재를 exact dispatch 경계에서 타입으로 구별한다

### DIFF
--- a/lib/keeper/keeper_compact_rejection.ml
+++ b/lib/keeper/keeper_compact_rejection.ml
@@ -26,10 +26,7 @@ let compaction_rejection_to_tag = function
   | Exact_owner_unregistered_deferred ->
     "exact_owner_unregistered_deferred"
   | Exact_execution_context_unavailable -> "exact_execution_context_unavailable"
-  (* The absent case names the lease. An operator reading only
-     "guard absent" has no way to reach the stimulus lease that decides it. *)
-  | Exact_execution_guard_absent ->
-    "exact_execution_guard_absent_no_stimulus_lease"
+  | Exact_execution_guard_absent -> "exact_execution_guard_absent"
   | Exact_execution_bind_failed -> "exact_execution_bind_failed"
   | Exact_flow_already_started -> "exact_flow_already_started"
   | Exact_execution_terminal terminal ->

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -1061,6 +1061,7 @@ let prepare_lane ~base_path ~keeper_name ~registry ~lane_id ~units =
 
 type exact_flow_callback_failure =
   | Owner_unregistered_deferred
+  | Guard_absent
   | Bind_failed
   | Bind_sync_unconfirmed of Keeper_event_queue_state.exact_execution_terminal
   | Release_failed of Keeper_event_queue_state.exact_execution_terminal
@@ -1078,7 +1079,7 @@ let bind_exact_execution
       "compaction exact durable execution guard is unavailable slot=%s call_id=%s"
       observation.slot_id
       observation.call_id;
-    Error Bind_failed
+    Error Guard_absent
   | Some guard ->
     (match guard.before_dispatch observation with
      | Ok Fsync_completed -> Ok ()
@@ -1145,6 +1146,7 @@ let release_exact_execution
 
 let summarization_failure_of_callback = function
   | Owner_unregistered_deferred -> Exact_owner_unregistered_deferred
+  | Guard_absent -> Exact_execution_guard_absent
   | Bind_failed -> Exact_execution_bind_failed
   | Bind_sync_unconfirmed terminal
   | Release_failed terminal
@@ -1365,35 +1367,17 @@ let execute_prepared_lane ~keeper_name ~net ?clock ?exact_execution_guard prepar
         (registered_lane_id
            ~base_path:prepared_lane.base_path
            ~keeper_name:prepared_lane.keeper_name)
-      (fun () -> ())
+      (fun () ->
+         execute_prepared_lane_current
+           ~keeper_name
+           ~net
+           ?clock
+           ?exact_execution_guard
+           prepared_lane)
   with
   | Keeper_exact_flow_scope.Owner_unregistered_deferred ->
     Error Exact_owner_unregistered_deferred
-  | Keeper_exact_flow_scope.Current () ->
-    (* The guard is required to accept a plan, and [execute_prepared_lane_current]
-       reads it only after the provider has answered and the plan has been built
-       (:1329-1330 below). Its absence is knowable now: in production the guard is
-       constructed only when the cycle claimed an event-queue stimulus lease
-       (keeper_heartbeat_loop.ml:1362-1370), so a cycle woken by the proactive cadence
-       tick can never satisfy it and the dispatch is paid for and discarded. Measured:
-       sangsu 2026-07-25T09:31:46Z spent elapsed_ms=100507 on a provider_overflow
-       compaction and settled retryable_failure with the guard refusal.
-
-       The check sits here rather than at the policy entrypoint because the lane
-       classifications are produced by [prepare_lane_with_scope] (:955) on the way to
-       this point: refusing earlier reported a missing guard for an unconfigured lane
-       and lost a terminal configuration fault behind a nonterminal one
-       (test_keeper_post_turn_wirein_order.ml:855 pins that). Owner registration keeps
-       its precedence for the same reason — it is a deferral, not a refusal. *)
-    (match exact_execution_guard with
-     | None -> Error Exact_execution_guard_absent
-     | Some _ ->
-       execute_prepared_lane_current
-         ~keeper_name
-         ~net
-         ?clock
-         ?exact_execution_guard
-         prepared_lane)
+  | Keeper_exact_flow_scope.Current result -> result
 ;;
 
 let run_exact

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -1370,12 +1370,30 @@ let execute_prepared_lane ~keeper_name ~net ?clock ?exact_execution_guard prepar
   | Keeper_exact_flow_scope.Owner_unregistered_deferred ->
     Error Exact_owner_unregistered_deferred
   | Keeper_exact_flow_scope.Current () ->
-    execute_prepared_lane_current
-      ~keeper_name
-      ~net
-      ?clock
-      ?exact_execution_guard
-      prepared_lane
+    (* The guard is required to accept a plan, and [execute_prepared_lane_current]
+       reads it only after the provider has answered and the plan has been built
+       (:1329-1330 below). Its absence is knowable now: in production the guard is
+       constructed only when the cycle claimed an event-queue stimulus lease
+       (keeper_heartbeat_loop.ml:1362-1370), so a cycle woken by the proactive cadence
+       tick can never satisfy it and the dispatch is paid for and discarded. Measured:
+       sangsu 2026-07-25T09:31:46Z spent elapsed_ms=100507 on a provider_overflow
+       compaction and settled retryable_failure with the guard refusal.
+
+       The check sits here rather than at the policy entrypoint because the lane
+       classifications are produced by [prepare_lane_with_scope] (:955) on the way to
+       this point: refusing earlier reported a missing guard for an unconfigured lane
+       and lost a terminal configuration fault behind a nonterminal one
+       (test_keeper_post_turn_wirein_order.ml:855 pins that). Owner registration keeps
+       its precedence for the same reason — it is a deferral, not a refusal. *)
+    (match exact_execution_guard with
+     | None -> Error Exact_execution_guard_absent
+     | Some _ ->
+       execute_prepared_lane_current
+         ~keeper_name
+         ~net
+         ?clock
+         ?exact_execution_guard
+         prepared_lane)
 ;;
 
 let run_exact

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -97,10 +97,10 @@ type summarization_failure =
   | Exact_owner_unregistered_deferred
   | Exact_execution_context_unavailable
   | Exact_execution_guard_absent
-        (** No exact-execution guard was supplied to the summarizer, so the plan
-            was built and then refused. In production the guard is constructed
-            only when the cycle claimed an event-queue stimulus lease, so this
-            reports a missing lease rather than a persistence fault. *)
+        (** No exact-execution guard was supplied. The current optional boundary
+            reports this from OAS's before-dispatch callback, after affine replay
+            detection and before POST. It does not diagnose why the caller lacked
+            a guard. *)
   | Exact_execution_bind_failed
         (** A guard was supplied and its before-dispatch bind did not reach
             Fsync_completed. A persistence fault, unrelated to lease ownership. *)

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -481,7 +481,7 @@ let test_bind_failure_prevents_post () =
        ~exact_execution_guard:guard
        prepared
    with
-   | Error (C.Exact_execution_guard_absent | C.Exact_execution_bind_failed) -> ()
+   | Error C.Exact_execution_bind_failed -> ()
    | Error _ -> Alcotest.fail "bind failure returned the wrong typed failure"
    | Ok _ -> Alcotest.fail "bind failure unexpectedly executed");
   Alcotest.(check int) "bind failure prevents POST" 0 (F.post_count server)
@@ -506,9 +506,19 @@ let test_missing_dispatch_guard_prevents_post () =
        ~clock
        prepared
    with
-   | Error (C.Exact_execution_guard_absent | C.Exact_execution_bind_failed) -> ()
+   | Error C.Exact_execution_guard_absent -> ()
    | Error _ -> Alcotest.fail "missing guard returned the wrong typed failure"
    | Ok _ -> Alcotest.fail "missing guard unexpectedly executed");
+  (match
+     C.execute_prepared_lane
+       ~keeper_name:"keeper-missing-guard"
+       ~net
+       ~clock
+       prepared
+   with
+   | Error C.Exact_flow_already_started -> ()
+   | Error _ -> Alcotest.fail "consumed missing-guard flow hid affine replay"
+   | Ok _ -> Alcotest.fail "consumed missing-guard flow executed twice");
   Alcotest.(check int) "missing guard prevents POST" 0 (F.post_count server)
 ;;
 

--- a/test/test_compaction_exact_output_entrypoint_clockless.ml
+++ b/test/test_compaction_exact_output_entrypoint_clockless.ml
@@ -192,28 +192,11 @@ let test_domain_invalid_and_clockless_flow_failure_are_terminal () =
         (Exact_fixture.post_count before_dispatch_server))
 ;;
 
-let test_absent_guard_refuses_before_the_summarizer_call () =
-  (* The summarizer refuses a plan built without a guard
-     (keeper_compaction_llm_summarizer.ml:1329-1330) only after the plan exists, so
-     the provider call is paid for and discarded. In production the guard is
-     constructed only when the cycle claimed an event-queue stimulus lease
-     (keeper_heartbeat_loop.ml:1362-1370), so a proactive-tick cycle can never
-     satisfy it and the outcome is known before any work starts. Measured cost of
-     the old order: sangsu 2026-07-25T09:31:46Z spent elapsed_ms=100507 on a
-     provider_overflow compaction and settled retryable_failure with
-     exact_execution_guard_failed.
-
-     What this test proves is the typed distinction, which is #25713's complaint:
-     before the hoist, an absent guard reached the summarizer and settled as
-     exact_execution_bind_failed, collapsing "no lease" and "the bind did not reach
-     the flow" into one string. After it, the absence reports itself.
-
-     What it does NOT prove is the saved provider call. This process has no Eio clock
-     by construction, so the unfixed path also refuses before dispatch here and the
-     post count is 0 either way — measured, not assumed. The saved call is evidenced
-     by the production record cited above, not by this fixture. The assertion stays
-     as a regression guard: if a future edit makes this boundary dispatch first, it
-     fails. *)
+let test_absent_guard_is_typed_at_before_dispatch () =
+  (* The existing before-dispatch callback already prevented POST when the guard
+     was absent. This test proves only that the current optional boundary reports
+     that absence separately from a supplied guard's persistence failure. It makes
+     no provider-cost claim. *)
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
@@ -242,16 +225,14 @@ let test_absent_guard_refuses_before_the_summarizer_call () =
       in
       publish_exact_fixture ~source:"absent guard" server;
       let preparation =
-        (* No ~exact_execution_guard: the argument is optional at this boundary and
-           its absence is the production shape being pinned. *)
+        (* No ~exact_execution_guard: the current optional boundary must fail
+           closed with its own typed reason. *)
         Compact_policy.compact_for_request_typed
           ~base_path:exact_flow_base_path
           ~meta
           ~trigger:Compaction_trigger.Manual
           context
       in
-      (* Asserted before the constructor so an ordering regression cannot abort the
-         run before this line is reached. *)
       check int
         "no provider request is made when the guard is absent"
         0
@@ -278,9 +259,9 @@ let () =
             `Quick
             test_domain_invalid_and_clockless_flow_failure_are_terminal
         ; test_case
-            "an absent guard refuses before the summarizer call"
+            "an absent guard is typed at before-dispatch"
             `Quick
-            test_absent_guard_refuses_before_the_summarizer_call
+            test_absent_guard_is_typed_at_before_dispatch
         ] )
     ]
 ;;

--- a/test/test_compaction_exact_output_entrypoint_clockless.ml
+++ b/test/test_compaction_exact_output_entrypoint_clockless.ml
@@ -192,6 +192,83 @@ let test_domain_invalid_and_clockless_flow_failure_are_terminal () =
         (Exact_fixture.post_count before_dispatch_server))
 ;;
 
+let test_absent_guard_refuses_before_the_summarizer_call () =
+  (* The summarizer refuses a plan built without a guard
+     (keeper_compaction_llm_summarizer.ml:1329-1330) only after the plan exists, so
+     the provider call is paid for and discarded. In production the guard is
+     constructed only when the cycle claimed an event-queue stimulus lease
+     (keeper_heartbeat_loop.ml:1362-1370), so a proactive-tick cycle can never
+     satisfy it and the outcome is known before any work starts. Measured cost of
+     the old order: sangsu 2026-07-25T09:31:46Z spent elapsed_ms=100507 on a
+     provider_overflow compaction and settled retryable_failure with
+     exact_execution_guard_failed.
+
+     What this test proves is the typed distinction, which is #25713's complaint:
+     before the hoist, an absent guard reached the summarizer and settled as
+     exact_execution_bind_failed, collapsing "no lease" and "the bind did not reach
+     the flow" into one string. After it, the absence reports itself.
+
+     What it does NOT prove is the saved provider call. This process has no Eio clock
+     by construction, so the unfixed path also refuses before dispatch here and the
+     post count is 0 either way — measured, not assumed. The saved call is evidenced
+     by the production record cited above, not by this fixture. The assertion stays
+     as a regression guard: if a future edit makes this boundary dispatch first, it
+     fails. *)
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  with_clockless_eio_context env sw @@ fun () ->
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+      init_runtime_fixture ();
+      let meta = make_meta () in
+      Masc.Keeper_registry.For_testing.clear ();
+      ignore
+        (Masc.Keeper_registry.register_offline
+           ~base_path:exact_flow_base_path
+           meta.name
+           meta);
+      let context =
+        Masc.Keeper_context_core.context_of_oas_checkpoint (make_checkpoint ())
+      in
+      let server =
+        Exact_fixture.start_server
+          ~sw
+          ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env)
+          (Exact_fixture.Reply (summarize_response "would have summarized"))
+      in
+      publish_exact_fixture ~source:"absent guard" server;
+      let preparation =
+        (* No ~exact_execution_guard: the argument is optional at this boundary and
+           its absence is the production shape being pinned. *)
+        Compact_policy.compact_for_request_typed
+          ~base_path:exact_flow_base_path
+          ~meta
+          ~trigger:Compaction_trigger.Manual
+          context
+      in
+      (* Asserted before the constructor so an ordering regression cannot abort the
+         run before this line is reached. *)
+      check int
+        "no provider request is made when the guard is absent"
+        0
+        (Exact_fixture.post_count server);
+      (match preparation.Compact_policy.decision with
+       | Compact_policy.Rejected (Manual, Exact_execution_guard_absent) -> ()
+       | _ ->
+         fail
+           "an absent exact-execution guard did not reject as \
+            Exact_execution_guard_absent");
+      check bool
+        "the original context is preserved"
+        true
+        (Masc.Keeper_context_core.message_count preparation.Compact_policy.context
+         = Masc.Keeper_context_core.message_count context))
+;;
+
 let () =
   run
     "compaction exact-output clockless entrypoint"
@@ -200,6 +277,10 @@ let () =
             "domain invalid and clockless flow failure are terminal"
             `Quick
             test_domain_invalid_and_clockless_flow_failure_are_terminal
+        ; test_case
+            "an absent guard refuses before the summarizer call"
+            `Quick
+            test_absent_guard_refuses_before_the_summarizer_call
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇을

현재 optional exact-execution guard 경계에서 서로 다른 두 실패를 타입으로 구별한다.

- guard 부재 -> `Exact_execution_guard_absent`
- supplied guard의 durable bind 실패 -> `Exact_execution_bind_failed`

guard 부재는 OAS `before_dispatch` callback 안에서 분류된다. 새로운 preflight 기능이나 provider-cost 최적화가 아니다.

## 정확한 실행 순서

1. MASC가 owner generation pin을 획득한다.
2. OAS `execute_flow_once`가 affine attempt를 claim한다.
3. 이미 소비된 prepared lane이면 `Exact_flow_already_started`가 먼저 반환된다.
4. 새 attempt만 `before_dispatch`에 도달한다.
5. callback이 current owner generation을 다시 확인한다.
6. guard 부재는 `Guard_absent`, supplied guard의 fsync 실패는 `Bind_failed`로 구별된다.
7. callback이 실패하면 OAS는 provider POST를 수행하지 않는다.

따라서 consumed replay가 guard absence에 가려지지 않고, owner replacement/unregistration은 `Exact_owner_unregistered_deferred` precedence를 유지한다.

## 최초 주장 정정

최초 설명은 `elapsed_ms=100507` production record를 absent guard가 provider POST 뒤에 검사된 증거로 해석했다. 이는 틀렸다.

기존 코드도 `bind_exact_execution`을 OAS `before_dispatch`에서 호출했고, guard가 없으면 callback error를 반환했다. OAS는 callback 성공 뒤에만 POST한다. 따라서 이 PR 전후 모두 absent guard의 POST count는 0이다.

이 PR은 100초 burn을 해결하지 않는다. 실제 elapsed phase는 #25787에서 별도로 추적한다.

## 테스트 계약

- supplied guard bind failure는 정확히 `Exact_execution_bind_failed`
- first absent-guard attempt는 정확히 `Exact_execution_guard_absent`
- 같은 prepared lane replay는 `Exact_flow_already_started`
- absent guard에서는 provider POST 0
- 기존 stale owner-generation conformance는 absent guard보다 `Exact_owner_unregistered_deferred`가 우선함을 유지

로컬 build/test/formatter는 수행하지 않았다. 새 head의 PR CI를 검증 권위로 사용한다.

## 하지 않는 것

- guard optional API를 새 기능으로 확장하지 않는다.
- compaction을 성공시키거나 stimulus lease 결합을 제거하지 않는다.
- 100초 elapsed의 원인을 추측하지 않는다.
- provider/model 정책을 MASC에 추가하지 않는다.

관련: #25713, #25787

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 문서를 변경하지 않는다.
WORKAROUND-WAIVED: 문자열 분류가 아니라 existing before-dispatch typed boundary에서 합쳐진 두 실패를 분리한다.