### PR TITLE
fix(keeper): 스탬프 없는 체크포인트를 generation 0 으로 위장하지 않는다

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -81,20 +81,48 @@ let encode_checkpoint_string_off_scheduler (ckpt : Agent_sdk.Checkpoint.t) :
 
 let keeper_generation_context_key = "keeper_generation"
 
-let keeper_generation_of_context (context : Agent_sdk.Context.t) : int =
+(* Absence and zero are different answers and this returned 0 for both. The strict
+   reader below ([checkpoint_generation_strict]) already errors on a missing stamp, so
+   the same key had two readers with opposite policies, and the lenient one silently
+   won wherever it was called. Returning [option] makes each call site state its own
+   policy where a reader can see it. *)
+let keeper_generation_of_context (context : Agent_sdk.Context.t) : int option =
   match
     Agent_sdk.Context.get_scoped context Agent_sdk.Context.Session
       keeper_generation_context_key
   with
-  | Some (`Int n) -> n
-  | Some (`Intlit raw) -> Option.value ~default:0 (int_of_string_opt raw)
-  | _ -> 0
+  | Some (`Int n) -> Some n
+  | Some (`Intlit raw) -> int_of_string_opt raw
+  | _ -> None
 
-let oas_history_snapshot_id_of_checkpoint (ckpt : Agent_sdk.Checkpoint.t) : string =
-  let generation = keeper_generation_of_context ckpt.context in
+let oas_history_snapshot_id_of_checkpoint
+      ?fallback_generation
+      (ckpt : Agent_sdk.Checkpoint.t)
+  : string
+  =
+  (* [fallback_generation] is what the CALLER knows when the checkpoint carries no
+     stamp. Only a caller holding the keeper's runtime nonce can answer that; the
+     0 this used to substitute was not an answer, and it is indistinguishable from a
+     genuine generation 0 in the emitted filename.
+
+     Without a fallback the id still has to be a valid history filename — the prefix
+     and suffix are what [list_oas_history_files] globs and what pruning walks — so
+     the generation field carries [unstamped] rather than a number. That string cannot
+     collide with a real generation, which "-g0" could. *)
+  let generation =
+    match keeper_generation_of_context ckpt.context, fallback_generation with
+    | Some generation, _ -> `Generation generation
+    | None, Some fallback -> `Generation fallback
+    | None, None -> `Unstamped
+  in
   let created_ms = max 0 (int_of_float (ckpt.created_at *. 1000.0)) in
-  Printf.sprintf "%s%013d-g%d%s"
-    oas_history_prefix created_ms generation oas_history_suffix
+  match generation with
+  | `Generation generation ->
+    Printf.sprintf "%s%013d-g%d%s"
+      oas_history_prefix created_ms generation oas_history_suffix
+  | `Unstamped ->
+    Printf.sprintf "%s%013d-gunstamped%s"
+      oas_history_prefix created_ms oas_history_suffix
 
 let prune_oas_history ~(session_dir : string) : unit =
   let files = list_oas_history_files ~session_dir in

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -33,9 +33,18 @@ val oas_history_path :
 val keeper_generation_context_key : string
 
 (** Compose an OAS history archive snapshot id from a checkpoint
-    (created_at_ms + keeper_generation suffix). *)
+    (created_at_ms + keeper_generation suffix).
+
+    [?fallback_generation] is used only when the checkpoint carries no
+    [keeper_generation] stamp. Supply it from what the caller knows — the
+    keeper's runtime nonce — rather than leaving the field to a substituted
+    number: a stampless checkpoint previously produced "-g0", which is
+    indistinguishable from a genuine generation 0. With no fallback the field
+    reads [gunstamped], which no real generation can produce. The prefix and
+    suffix are unchanged either way, so the id remains a filename that
+    {!list_oas_history_files} lists and pruning walks. *)
 val oas_history_snapshot_id_of_checkpoint :
-  Agent_sdk.Checkpoint.t -> string
+  ?fallback_generation:int -> Agent_sdk.Checkpoint.t -> string
 
 (** Save [ckpt] to the OAS history archive in [session_dir],
     pruning to [max_oas_history_retained] entries. Logs and

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -56,7 +56,12 @@ let inventory_json (config : Workspace.config) (name : string)
       match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:trace_id with
       | Ok checkpoint ->
         let current_history_snapshot_id =
-          Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint checkpoint
+          (* This route already holds the keeper's runtime nonce for the summary's
+             own fallback, so it can answer for a stampless checkpoint instead of
+             letting the id carry a substituted number. *)
+          Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint
+            ~fallback_generation:meta.runtime.nonce
+            checkpoint
         in
         oas_checkpoint_summary_json
           ~source_kind:"oas_current"

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -998,6 +998,53 @@ let test_exact_snapshot_preserves_locked_canonical_bytes () =
              (Keeper_checkpoint_store.exact_snapshot_reference decoded))
       | Error _ -> fail "exact snapshot bytes did not decode")
 
+let test_stampless_generation_is_not_generation_zero () =
+  (* keeper_generation_of_context returned 0 for both "the stamp says 0" and "there is
+     no stamp", so the history snapshot id spelled them the same. The strict reader in
+     the same module already errors on absence (Generation_missing), so one key had two
+     readers with opposite policies and the lenient one won wherever it was called. *)
+  let stamped_zero =
+    with_generation 0 (make_checkpoint ~session_id:"gen-zero" ~turn_count:1 ~marker:"z")
+  in
+  let stampless =
+    make_checkpoint ~session_id:"gen-absent" ~turn_count:1 ~marker:"a"
+  in
+  let id_of ?fallback_generation ckpt =
+    Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint
+      ?fallback_generation
+      ckpt
+  in
+  check bool
+    "a stampless checkpoint does not produce the generation-0 id"
+    false
+    (id_of stampless = id_of stamped_zero);
+  (* Both remain valid history filenames — the prefix and suffix are what listing and
+     pruning walk, and only the generation field differs. *)
+  let shares_envelope a b =
+    let split id =
+      match String.index_opt id 'g' with
+      | None -> id, ""
+      | Some at -> String.sub id 0 at, String.sub id at (String.length id - at)
+    in
+    fst (split a) = fst (split b)
+  in
+  check bool
+    "the stampless id keeps the history filename envelope"
+    true
+    (shares_envelope (id_of stampless) (id_of stamped_zero));
+  (* A caller that knows the generation answers for the checkpoint, rather than the id
+     carrying a substituted value: this is what the dashboard route now passes. *)
+  check string
+    "a supplied fallback fills the field for a stampless checkpoint"
+    (id_of (with_generation 7 stampless))
+    (id_of ~fallback_generation:7 stampless);
+  (* And a fallback never overrides a stamp the checkpoint carries. *)
+  check string
+    "a stamp wins over a supplied fallback"
+    (id_of stamped_zero)
+    (id_of ~fallback_generation:7 stamped_zero)
+;;
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -1045,5 +1092,7 @@ let () =
             test_checkpoint_ref_requires_generation;
           test_case "exact snapshot preserves canonical bytes" `Quick
             test_exact_snapshot_preserves_locked_canonical_bytes;
+          test_case "a stampless generation is not generation zero" `Quick
+            test_stampless_generation_is_not_generation_zero;
         ] );
     ]


### PR DESCRIPTION
## 무엇을

`keeper_generation_of_context` (`lib/keeper/keeper_checkpoint_store.ml:84`) 가 **"스탬프가 0"** 과 **"스탬프가 없음"** 에 같은 답 `0` 을 냈다:

```ocaml
| Some (`Int n) -> n
| Some (`Intlit raw) -> Option.value ~default:0 (int_of_string_opt raw)
| _ -> 0
```

같은 모듈의 엄격한 리더는 부재를 에러로 처리한다 — `checkpoint_generation_strict` 가 `:591` 에서 `Generation_missing` 을 낸다. 즉 **한 키에 정책이 반대인 두 리더**가 있었고, 호출되는 자리에서는 관대한 쪽이 조용히 이겼다.

## 실제로 일어난 일

`Generation_missing` 은 production 에서 관측됐다 — taskmaster 2026-07-24T09:47:34Z, `provider_overflow` 컴팩션이 `"checkpoint generation is missing"` 으로 settle. 스탬프 없는 체크포인트가 실재한다.

그리고 관대한 리더는 한 곳에서 호출되는데, 그 자리가 **durable 파일 이름**을 만든다. `oas_history_snapshot_id_of_checkpoint` 가 generation 을 히스토리 스냅샷 id 에 박는다. 스탬프 없는 체크포인트는 `-g0` 이 되고, 이는 진짜 generation 0 과 구별되지 않는다.

## 변경

- 리더가 `int option` 을 반환한다. 각 호출 지점이 자기 정책을 코드에 드러낸다.
- id 빌더가 `?fallback_generation` 을 받는다 — **호출자가 아는 값**이다. 없으면 `gunstamped` 를 쓴다. 실제 generation 이 만들 수 없는 문자열이고, `list_oas_history_files` 가 glob 하는 prefix/suffix 는 그대로라 여전히 유효한 히스토리 파일명이다.
- `server_dashboard_http_keeper_api_checkpoints.ml:59` 이 `meta.runtime.nonce` 를 넘긴다. 이 라우트는 요약의 자체 fallback 용으로 이미 nonce 를 들고 있었다 — 대체된 `0` 이 호출자가 손에 쥔 답을 선점하고 있었다.

## 검증

- `dune build @check` 트리 전체 통과
- `test_keeper_checkpoint_stale_guard` 22 tests 성공 (신규 1건)
- 테스트가 고정하는 것 4가지: 부재 ≠ generation 0 / 스탬프 없는 id 가 파일명 envelope 유지 / 넘긴 fallback 이 스탬프와 동일하게 채움 / 스탬프가 fallback 을 이김
- mutation: `| None, None -> `Generation 0` 으로 되돌리면 첫 단언이 실패한다 (확인함)

**로컬 빌드 트리 고지**: 이 워크스페이스의 opam 스위치는 다른 세션의 OAS 워크트리(미커밋 10파일)를 링크한다. 이 변경은 OAS API 를 건드리지 않고 masc 내부 리더/파일명 경계만 다루지만, 권위 있는 검증은 CI 로 둔다.

## 이 PR 이 하지 않는 것

스탬프 없는 체크포인트가 **왜** 생기는지 고치지 않는다. 두 writer (`keeper_context_core.ml:52`, `keeper_run_context.ml:112`) 는 모두 키를 설정하므로, 그 경로들을 지나지 않은 체크포인트가 있다는 뜻이다. 그 출처는 별건이며, 이 PR 은 그 상태가 `0` 으로 위장되지 않게 만들 뿐이다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 것도 건드리지 않는다.
WORKAROUND-WAIVED: 기본값 추가가 아니라 **제거**다. unknown 을 permissive default 로 압축하던 catch-all 을 닫힌 option 으로 바꾸고, 답을 아는 호출자가 답하게 한다.
