### PR TITLE
ci: 모든 PR 을 빌드하고 테스트 전체를 실행한다 (#25755 + #25793)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main, develop]
+  # No `branches:` filter. That filter matches the BASE branch, so a stacked PR
+  # (base = a feature branch) never triggered this workflow at all — no compile,
+  # no tests, no lint — while `gh pr checks` still reported SUCCESS from the few
+  # workflows that do run. #25792 reached "green" that way and turned out not to
+  # compile once its base moved to main. Every PR gets built regardless of base.
   pull_request:
-    branches: [main, develop]
     types: [opened, synchronize, reopened]
   workflow_dispatch: {}
 
@@ -792,8 +796,8 @@ jobs:
       # still compiles every test target; the authoritative runtime, operator,
       # transport, SSE, and contract suites below remain executable gates.
 
-      - name: Run operator control suite
-        id: operator_control_suite
+      - name: Run test suite
+        id: test_suite
         # Run regardless of earlier test failures, but only after a successful
         # compile, so every suite gets a chance to report and the job fails if
         # any suite fails.
@@ -809,8 +813,17 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          operator_targets="@test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${operator_targets}"
+          # Run the whole suite, not a hand-written list. The list had grown to
+          # three operator targets out of 419 test executables declared in
+          # test/dune alone (#25755): every other test compiled under @check and
+          # was never executed, so an assertion could rot indefinitely while CI
+          # stayed green. `runtest` is not part of `default`, so nothing outside
+          # this line ran.
+          #
+          # Local measurement (darwin, warm cache, 2026-07-27): `dune build
+          # @runtest` finished in 305s wall with 55 suites passing. Two suites
+          # dominate (281s and 168s, overlapping), so the tail is short.
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @runtest"
 
       - name: Run SSE reconnect e2e
         id: sse_reconnect_e2e

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -21,8 +21,9 @@ name: Fundamental Check
 # themselves are unchanged.
 
 on:
+  # No `branches:` filter on pull_request — see ci.yml. The filter matches the
+  # BASE branch, so stacked PRs skipped these guards entirely.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
`#25755` + `#25793` 동시 수정. 두 구멍 다 구조적이고, PR 단위 문제가 아니다.

## 구멍 1 — stacked PR 은 컴파일된 적이 없다 (#25793)

`pull_request.branches` 는 **base** 브랜치를 매칭한다. base 가 feature 브랜치면 `ci.yml` / `fundamental-check.yml` 이 **아예 트리거되지 않는다** — 빌드도, 테스트도, lint 도 없다. 그런데 `gh pr checks` 는 SUCCESS 를 보여주고 GraphQL `statusCheckRollup` 도 SUCCESS 를 돌려준다.

2026-07-27 실측:

| PR | base | 체크 수 |
|---|---|---|
| #25792 | feature | **3** (`check`×2, `ocamlformat`) |
| #25757 | feature | **3** |
| #25698 | feature | **4** |
| #25765 | main | **15** (`Build and Test`/`Health`/`Lint`/`CI Gate` 포함) |

`#25792` 는 본문에 "local build/tests/formatter intentionally not run. **CI is authoritative**" 라고 적은 채 green 이었다. base 가 main 으로 옮겨지자 첫 실제 실행에서 dune 순환 의존 + 타입 오류로 실패했다. 권위를 위임한 대상이 아무 일도 하지 않고 있었다.

## 구멍 2 — 테스트 스위트가 3 개였다 (#25755)

`Build and Test` 는 `dune build @default @check` (컴파일만) 후 손으로 쓴 목록을 돌렸다: runtime-config 1 개 + operator-control 3 개.

`test/dune` 에만 테스트 실행 파일이 **419 개** 있다 (`(tests (names ...))` 블록 306 + 개별 `(test ...)` 스탠자 113). `runtest` 는 `default` 에 배선돼 있지 않으므로 그 목록 밖 테스트는 **한 번도 실행된 적이 없다.** 단언이 썩어도 게이트는 초록이다.

두 수정은 같은 모양이다 — **열거를 그만두고 그냥 돌린다.**

## 비용 (실측)

darwin, warm cache, `dune build --root . @runtest`: **305 초**, 55 스위트 통과. 두 스위트가 지배적이고 서로 겹친다(281s, 168s) — 꼬리가 짧다.

CI 스텝은 `DUNE_JOBS: 1` 이므로 직렬화로 더 걸릴 것이다. **이 PR 의 첫 실행이 진짜 측정치다.**

## 빨간 결과가 나올 경우 — 이 커밋 탓이 아닌 것들

미리 적어 둔다. 로컬에서 4 스위트가 실패하고 **그중 3 개는 macOS 전용**이다:

```
Unsupported: parent directory capability has no Unix file descriptor
```

`fs_compat capability HEAD` (18/19), `capability write` (6/50), `capability exact read` (1/18) 이 darwin 에서 이 이유로 실패한다. `eio_posix` 의 디렉터리 capability 가 fd 를 노출하지 않아 그 서브시스템이 macOS 에서 아예 동작하지 않는다. #25745 에서 고친 `O_NOFOLLOW` 와 같은 클래스다. **CI 는 Linux 이므로 통과가 예상된다.**

나머지 로컬 실패는 `channel_gate_discord_state_in_process` (1/9), 원인 미규명.

별개로 `fs capability exact read` 에는 **플랫폼 무관한 진짜 결함**이 하나 있다 — settlement 중 fatal 예외가 원래 raise 지점을 잃는다 (Eio 의 `Switch.maybe_raise_exs` 가 새 백트레이스를 만든다). #25794 에 증거와 함께 등록했고, **여기서 단언을 약화해 덮지 않았다.**

## Linux 에서 실패가 나오면

이 커밋이 만들지 않은 실패가 드러나면 정직한 선택지는 둘이다: 고치거나, **링크된 이슈와 제거 시점을 명시해 명시적으로 격리**하거나. 3 개짜리 목록으로 되돌아가는 것은 선택지가 아니다.

## 미검증

- Linux 에서의 wall-clock. 로컬 305s 는 darwin + warm cache + 기본 병렬도이고, CI 는 `DUNE_JOBS: 1` 이다.
- `branches` 필터 제거로 늘어나는 워크플로 실행 수. 현재 stacked PR 은 3 건이라 실측 부하는 작다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 문서 중 어느 subsystem 도 건드리지 않는다. GitHub Actions 워크플로 2 개의 트리거 조건과 테스트 타깃 지정이다.
