### PR TITLE
ci: bound the dune cache to the Actions eviction budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -903,6 +903,42 @@ jobs:
             echo "::notice::main_eio.exe not found, skipping config-diagnostic"
           fi
 
+      # Bound the dune cache before the post-step uploads it.
+      #
+      # A repository gets 10 GB of Actions cache; past that GitHub evicts by
+      # least-recently-used. This entry had grown to 8853 MB, so a single save
+      # left ~1.1 GB for everything else and pushed the repo to 10.32 GB total.
+      # Measured on 2026-07-27: every cache in the repository had been created
+      # within the preceding 31 minutes — opam-linux (934 MB), the ocamlformat
+      # switch (29 MB) and the pnpm store (80 MB) were all being evicted and
+      # rebuilt continuously, because main merges (30 in the preceding 21 h)
+      # write a fresh run-id-keyed copy of this cache every time.
+      #
+      # The cost landed on the jobs that lost their opam switch: successful
+      # `Build and Test` runs spent 428 s in `Setup OCaml toolchain` and a
+      # further 165 s re-saving the switch it should have restored.
+      #
+      # The ceiling is the eviction budget, not a dune tuning parameter:
+      # ~1.7 GB of non-dune caches were live at the sample, and PR-scoped
+      # copies multiply with open PR count, so this leaves room for roughly
+      # double that. dune trims least-recently-used entries, so the working
+      # set for an incremental rebuild survives.
+      - name: Trim dune cache to the eviction budget
+        if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          DUNE_CACHE_CEILING: 6GiB
+        run: |
+          set -euo pipefail
+          if [ ! -d ~/.cache/dune ]; then
+            echo "::notice::no dune cache to trim"
+            exit 0
+          fi
+          # `dune cache trim` reports what it freed. Do not measure the
+          # directory with `du`: the cache is hundreds of thousands of small
+          # files and the walk costs minutes, which is the latency this
+          # change exists to remove.
+          opam exec -- dune cache trim --size="${DUNE_CACHE_CEILING}"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 문제

저장소 Actions 캐시 총량이 **10.32 GB** 인데 한도는 10 GB 다. 넘으면 GitHub 이 LRU 로 축출한다.

2026-07-27 실측 — 저장소의 **모든** 캐시가 생성 31 분 이내였다. 30 분 넘은 캐시가 하나도 없다:

```
00:36:44   934MB  opam-linux-oas-otel-02-5.5.0-...-v2
00:37:54   146MB  v3-setup-ocaml-opam-...
00:39:47    29MB  opam-ocamlformat-0.29.0-...
00:50:44    80MB  pnpm-Linux-...
01:04:43  8853MB  dune-linux-oas-otel-02-5.5.0-30228028055   ← 나머지를 밀어낸다
```

8853 MB 엔트리 하나가 예산의 88% 를 쓴다. 키에 `github.run_id` 가 들어가는 건 **의도된 설계**다 — 안정 키를 쓰면 첫 저장 후 영원히 stale 해진다. 다만 그 결과로 main 머지마다 새 ~8.9 GB 사본이 쓰이고, main 은 직전 21 시간에 30 회 머지됐다 (42 분당 1 회).

매 발행이 한도를 넘겨, 임계 경로의 모든 잡이 실제로 필요로 하는 작은 캐시들을 축출한다.

## 비용

`Build and Test` 성공 런의 스텝별 중앙값 (최근 완료 런 40 개 중 성공 9 개):

| 스텝 | 중앙값 |
|---|---:|
| Build | 1097 s |
| **Setup OCaml toolchain** | **428 s** |
| **Post Setup OCaml toolchain** (스위치 재저장) | **165 s** |
| Pin external OCaml dependencies | 126 s |
| Free disk space | 77 s |
| Install system and OCaml dependencies | 60 s |
| 테스트 4 종 합계 | 66 s |

428 s 는 복원됐어야 할 스위치를 부트스트랩하는 시간이고, 165 s 는 그걸 다시 저장하는 시간이다. `actions/cache` 는 primary key 가 정확히 적중하면 저장을 건너뛴다 — 9/9 런이 저장했다는 건 9/9 가 미스였다는 뜻이다.

ocamlformat 워크플로가 중앙값 158 s / p90 390 s 인 것도 같은 원인이다. 29 MB 짜리 스위치 캐시가 같이 축출된다.

## 변경

post 스텝이 업로드하기 전에 dune 캐시를 상한까지 trim 한다. main push 에서만 돈다 (PR 은 restore-only 라 저장하지 않는다).

숫자는 dune 튜닝 파라미터가 아니라 **축출 예산**이다. 샘플 시점에 non-dune 캐시가 ~1.7 GB 살아 있었고 PR 스코프 사본은 열린 PR 수에 비례해 늘어나므로, 6 GiB 는 관측된 non-dune 총량의 약 2 배 여유를 남긴다. dune 은 LRU 로 버리므로 증분 빌드가 의존하는 working set 이 남는 쪽이다.

## 검증

- `scripts/lint/yaml-syntax.sh` → 20 workflow file(s) parsed OK
- `dune cache trim --size=BYTES` 는 로컬 dune 3.x 에서 존재 확인 (`--help=plain`)
- 스텝 배치는 `build` 잡의 마지막 main 스텝 — post 스텝은 모든 main 스텝 이후에 돌므로 trim 이 저장 직전에 적용된다

## 검증 못 한 것

- **trim 이후의 dune 캐시 적중률.** 8.85 GB → 6 GiB 로 줄면 일부 엔트리는 사라진다. 그 결과 `Build` 스텝이 얼마나 느려지는지는 이 PR 이 main 에 들어가 최소 한 번 발행되기 전에는 측정할 수 없다. 예상은 순이득이다 — 잃는 건 오래된 dune 엔트리이고 되찾는 건 매 잡이 무조건 쓰는 opam 스위치다. 다만 이건 예상이지 측정이 아니다.
- 되돌리는 방법은 이 스텝 삭제 한 줄이고, 캐시는 스스로 다시 자란다.

## 후속

- 6 GiB 로도 계속 축출되면 다음 손잡이는 `prune-pr-caches.yml` 의 PR 스코프 사본 정리 범위다.
- 측정 중 발견한 별건: `Build and Test` 는 33 분 중 66 초만 테스트에 쓴다. 테스트 범위 확대는 #25795 에서 다룬다.

RFC-WAIVED: CI 캐시 예산 조정. `agent_delegation` 이 RFC 를 요구하는 subsystem (credential/identity, repo_manager, operator control, keeper sandbox, dashboard credential, .claude/hooks, instructions/workflow*) 에 해당하지 않는다. 런타임 코드 변경 없음.

Refs #25755
