### PR TITLE
ci: take pr-sync-check off the serial critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,25 @@ jobs:
             --base-ref "$BASE_REF" \
             --expected-head-sha "$PR_HEAD_SHA"
 
+  # Deliberately does NOT depend on pr-sync-check. That edge carried no data —
+  # nothing here reads a pr-sync-check output — so it only serialised 20 s of
+  # latency in front of every run, including the `changes` job and therefore
+  # every heavy job behind it.
+  #
+  # Dropping it costs one fail-fast and nothing else:
+  #   - Merge blocking is unchanged. `ci-gate` re-checks pr-sync-check in
+  #     `required` mode, so a failure still fails the aggregate check.
+  #   - The condition pr-sync-check tests for — "the branch advanced since
+  #     this payload was created" — is what `concurrency.cancel-in-progress`
+  #     already resolves: a new push is a `synchronize` event that cancels
+  #     this whole run. That is why the check has never fired: 140 sampled
+  #     runs on 2026-07-27 were 121 success / 18 skipped / 1 cancelled and
+  #     0 failure.
+  # The job still runs, in parallel, so the signal is kept.
   pr-live-gate:
     name: PR Live Gate
     runs-on: ubuntu-latest
-    needs: [pr-sync-check]
-    if: ${{ always() && !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ always() && !cancelled() }}
     timeout-minutes: 2
     permissions:
       pull-requests: read


### PR DESCRIPTION
## 문제

모든 CI 런이 세 잡의 **직렬 체인**으로 시작한다:

```
pr-sync-check (20 s) → pr-live-gate (3 s) → changes (21 s) → heavy jobs
```

첫 번째 엣지는 **데이터를 나르지 않는다**. `pr-live-gate` 는 `pr-sync-check` 의 출력을 하나도 읽지 않는다 (`outputs` 가 비어 있다). 순서만 산다.

그 대가로 모든 런이 heavy 잡 시작 전에 20 초 + 큐 지연을 낸다.

## 이 fail-fast 는 발동한 적이 없다

`scripts/check-pr-sync.sh` 의 목적:

> Fails when the branch has advanced since the workflow payload was created.

그건 `concurrency.cancel-in-progress` 가 이미 해소하는 경쟁이다. PR 브랜치에 새 푸시가 오면 `synchronize` 이벤트가 발생하고, 이 워크플로의 concurrency group 이 **런 전체를 취소**한다. pr-sync-check 가 검사하려는 상태에 도달하기 전에 런이 사라진다.

실측 — 2026-07-27, 완료된 CI 런 140 개의 `PR Sync Check` 결과:

| 결과 | 건수 |
|---|---:|
| success | 121 |
| skipped | 18 |
| cancelled | 1 |
| **failure** | **0** |

## 변경

`pr-live-gate` 에서 `needs: [pr-sync-check]` 를 제거한다. 두 잡이 동시에 출발한다.

```
pr-sync-check (20 s) ─┐
                      ├→ changes (21 s) → heavy jobs
pr-live-gate  (3 s) ──┘
```

**잡은 지우지 않았다.** 병렬로 계속 돌아 신호는 그대로 남는다. 사라지는 건 순서뿐이다.

## 머지 보호는 변하지 않는다

`ci-gate` 가 `pr-sync-check` 를 `required` 모드로 재검사한다 (`ci.yml:1240`):

```bash
check "pr-sync-check"   "$PR_SYNC_RESULT"
```

`check()` 는 `success`/`skipped` 가 아니면 `fail=1` 로 두고 마지막에 `[ "$fail" -eq 0 ]` 으로 잡을 실패시킨다. `pr-live-gate` 가 그 결과를 봤든 안 봤든 동일하다.

## 잃는 것

pr-sync-check 가 실패했을 때 heavy 잡을 **시작하기 전에** 멈추는 최적화. 이제는 heavy 잡이 이미 돌고 있고, ci-gate 가 머지를 막는다.

140 런 중 0 회 발동한 경로를 위해 매 런이 20 초를 내고 있었다. 만약 이 실패율이 올라가면 (예: concurrency group 설정이 바뀌어 취소가 안 되는 경우) 엣지를 되돌리는 게 맞다 — 한 줄이다.

## 검증

- `scripts/lint/yaml-syntax.sh` → 20 workflow file(s) parsed OK
- 잡 그래프 파싱 확인: `pr-sync-check` / `pr-live-gate` 모두 `needs=None`, `ci-gate` 는 `pr-sync-check` 를 계속 물고 있음
- `needs.pr-sync-check` 참조가 남은 곳은 `ci-gate` 뿐 (grep 전수)

## 크기

CI 벽시계 중앙값 772 초 중 ~23 초 (3%). 작다. 이 PR 의 근거는 크기가 아니라 **데이터 없는 엣지가 임계 경로를 직렬화하고 있었다**는 점이다.

대기시간의 지배적 원인은 따로 있고 #25801 에서 다룬다 (캐시 축출로 `Setup OCaml toolchain` 428 초 + 재저장 165 초).

RFC-WAIVED: CI 잡 의존 그래프 조정. `agent_delegation` 이 RFC 를 요구하는 subsystem 에 해당하지 않는다. 런타임 코드 변경 없음.

Refs #25755
