### PR TITLE
fix(keeper): consume current OAS receipt facts

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -300,6 +300,22 @@ let exact_identity_of_candidate
   }
 ;;
 
+let exact_identity_of_snapshot
+      (candidate : Exact_output.flow_attempt_snapshot)
+  =
+  let receipt = candidate.receipt in
+  { slot_id = candidate.visit.identity.candidate_id
+  ; call_id =
+      receipt
+      |> Exact_output.generation_receipt_snapshot_call_id
+      |> Exact_output.call_id_to_string
+  ; plan_fingerprint =
+      Exact_output.generation_receipt_snapshot_plan_fingerprint receipt
+  ; request_body_sha256 =
+      Exact_output.generation_receipt_snapshot_request_body_sha256 receipt
+  }
+;;
+
 let exact_identity_of_binding (binding : exact_attempt_binding) =
   { slot_id = binding.slot_id
   ; call_id = binding.call_id
@@ -787,9 +803,9 @@ let handle_flow_error (prepared : prepared_flow) = function
     record_outcome "exact_success_ordinal_exhausted";
     (match List.rev evidence.attempts with
      | candidate :: _ ->
-       quarantine_candidate
+       quarantine_identity
          prepared.entry
-         candidate
+         (exact_identity_of_snapshot candidate)
          Exact_flow_execution_failed
      | [] ->
        settle_current_or_signal

--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -198,6 +198,21 @@ let attempt_provenance
   }
 ;;
 
+let attempt_snapshot_provenance
+      (attempt : Exact_output.flow_attempt_snapshot)
+  =
+  { slot_id = attempt.visit.identity.candidate_id
+  ; call_id =
+      attempt.receipt
+      |> Exact_output.generation_receipt_snapshot_call_id
+      |> string_of_call_id
+  ; plan_fingerprint =
+      Exact_output.generation_receipt_snapshot_plan_fingerprint attempt.receipt
+  ; request_body_sha256 =
+      Exact_output.generation_receipt_snapshot_request_body_sha256 attempt.receipt
+  }
+;;
+
 let candidate_visit (visit : Exact_output.flow_candidate_visit) =
   let identity = visit.identity in
   { flow_id = Exact_output.flow_id_to_string visit.flow_id
@@ -221,7 +236,7 @@ let advance_source_of_failure = function
 ;;
 
 let evidence_provenance (evidence : Exact_output.flow_evidence) =
-  List.map attempt_provenance evidence.attempts
+  List.map attempt_snapshot_provenance evidence.attempts
 ;;
 
 let admitted_candidate candidate_id admissions =

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -471,6 +471,26 @@ let observe_flow_attempt_receipt
   }
 ;;
 
+let observe_flow_attempt_snapshot
+      (candidate : Exact_output.flow_attempt_snapshot)
+  =
+  let receipt = candidate.receipt in
+  let identity = candidate.visit.identity in
+  { slot_id = identity.candidate_id
+  ; call_id =
+      receipt
+      |> Exact_output.generation_receipt_snapshot_call_id
+      |> call_id_to_string
+  ; catalog_generation_fingerprint =
+      identity.catalog_generation
+      |> Exact_output.catalog_generation_fingerprint
+  ; receipt_plan_fingerprint =
+      Exact_output.generation_receipt_snapshot_plan_fingerprint receipt
+  ; receipt_request_body_sha256 =
+      Exact_output.generation_receipt_snapshot_request_body_sha256 receipt
+  }
+;;
+
 let terminal_of_observation cause (observation : attempt_observation) =
   Keeper_event_queue_state.
     { cause
@@ -1485,7 +1505,7 @@ module For_testing = struct
     let evidence : Exact_output.flow_evidence =
       Exact_output.flow_attempt_evidence prepared_lane.flow_attempt
     in
-    List.map observe_flow_attempt_receipt evidence.attempts
+    List.map observe_flow_attempt_snapshot evidence.attempts
   ;;
 
   let candidate_snapshot_slot_ids prepared_lane =

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -48,6 +48,8 @@ let network_error_kind_to_wire = function
 let invalid_request_reason_to_wire = function
   | Agent_sdk.Retry.Json_parse_error -> "json_parse_error"
   | Agent_sdk.Retry.Request_body_too_large _ -> "request_body_too_large"
+  | Agent_sdk.Retry.Request_body_refused_by_provider _ ->
+    "request_body_refused_by_provider"
   | Agent_sdk.Retry.Unknown_invalid_request -> "unknown_invalid_request"
 ;;
 
@@ -178,6 +180,8 @@ let sdk_api_error_fields = function
          [ "actual_bytes", `Int actual_bytes
          ; "limit_bytes", `Int limit_bytes
          ]
+       | Agent_sdk.Retry.Request_body_refused_by_provider { status } ->
+         [ "status", `Int status ]
        | Agent_sdk.Retry.Json_parse_error
        | Agent_sdk.Retry.Unknown_invalid_request -> [])
   | Agent_sdk.Retry.NotFound { message } ->

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -390,6 +390,56 @@ let attempt_receipt_json (attempt : Exact_output.flow_attempt_receipt) =
     ]
 ;;
 
+let receipt_snapshot_json
+      (receipt : Exact_output.generation_receipt_snapshot)
+  =
+  `Assoc
+    [ ( "call_id"
+      , `String
+          (Exact_output.call_id_to_string
+             (Exact_output.generation_receipt_snapshot_call_id receipt)) )
+    ; ( "phase"
+      , `String
+          (effect_phase_to_string
+             (Exact_output.generation_receipt_snapshot_phase receipt)) )
+    ; ( "dispatch_count"
+      , `Int
+          (Exact_output.generation_receipt_snapshot_dispatch_count receipt) )
+    ; ( "http_status"
+      , match Exact_output.generation_receipt_snapshot_http_status receipt with
+        | Some status -> `Int status
+        | None -> `Null )
+    ; ( "plan_fingerprint"
+      , `String
+          (Exact_output.generation_receipt_snapshot_plan_fingerprint receipt) )
+    ; ( "request_body_sha256"
+      , `String
+          (Exact_output.generation_receipt_snapshot_request_body_sha256 receipt) )
+    ; ( "catalog_generation"
+      , `String
+          (Exact_output.catalog_generation_fingerprint
+             (Exact_output.generation_receipt_snapshot_catalog_generation
+                receipt)) )
+    ; ( "catalog_evidence_sha256"
+      , `String
+          (Exact_output.catalog_evidence_sha256
+             (Exact_output.generation_receipt_snapshot_catalog_evidence
+                receipt)) )
+    ; ( "target_identity"
+      , `String
+          (Exact_output.target_identity_fingerprint
+             (Exact_output.generation_receipt_snapshot_target_identity
+                receipt)) )
+    ]
+;;
+
+let attempt_snapshot_json (attempt : Exact_output.flow_attempt_snapshot) =
+  `Assoc
+    [ "candidate_id", `String attempt.visit.identity.candidate_id
+    ; "receipt", receipt_snapshot_json attempt.receipt
+    ]
+;;
+
 let exact_flow_state_dir ~keeper_id =
   Keeper_memory_os_io.facts_path ~keeper_id
   |> Filename.dirname
@@ -495,9 +545,9 @@ let flow_candidates selected_slots =
 
 let exact_execution_error error =
   let outward_effect =
-    match Exact_output.flow_execution_error_outward_dispatch error with
-    | Exact_output.No_outward_dispatch -> No_outward_effect
-    | Exact_output.Outward_dispatch_started -> Outward_effect_started
+    match Exact_output.flow_execution_error_generation_dispatch error with
+    | Exact_output.No_generation_dispatch -> No_outward_effect
+    | Exact_output.Generation_dispatch_started -> Outward_effect_started
   in
   let failure =
     match error with
@@ -553,7 +603,7 @@ let persist_exact_execution_terminal
          ~trace_id
          ~generation
          ~state:"execution_terminal"
-         [ "candidate", attempt_receipt_json candidate
+         [ "candidate", attempt_snapshot_json candidate
          ; "failure_cause", `String "success_ordinal_exhausted"
          ]
      | [] -> Error "success ordinal exhausted without attempt evidence")

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -403,6 +403,7 @@ let turn_event_bus_evidence_detail
 
 type capacity_refusal =
   | Provider_context_window of { limit_tokens : int option }
+  | Provider_request_body_refusal of { status : int }
   | Serialized_request_body of
       { actual_bytes : int
       ; limit_bytes : int
@@ -421,6 +422,9 @@ let capacity_refusal_of_error (err : Agent_sdk.Error.sdk_error) : capacity_refus
       (InvalidRequest { reason = Request_body_too_large { actual_bytes; limit_bytes }; _ })
     ->
     Some (Serialized_request_body { actual_bytes; limit_bytes })
+  | Agent_sdk.Error.Api
+      (InvalidRequest { reason = Request_body_refused_by_provider { status }; _ }) ->
+    Some (Provider_request_body_refusal { status })
   | Agent_sdk.Error.Api
       (InvalidRequest { reason = Json_parse_error | Unknown_invalid_request; _ }) ->
     (* A malformed request is a defect in what was built, not a size the target
@@ -457,7 +461,9 @@ let context_overflow_event_of_error
   match capacity_refusal_of_error err with
   | Some (Provider_context_window { limit_tokens }) ->
     Some (Keeper_state_machine.Context_overflow_detected { limit_tokens })
-  | Some (Serialized_request_body _) | None -> None
+  | Some (Provider_request_body_refusal _ | Serialized_request_body _)
+  | None ->
+    None
 
 (* Prefix that tags a [last_compaction_decision] value as a provider-overflow
    recovery failure. Kept as a named binding so the observability regression test

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -111,6 +111,14 @@ let request_body_too_large ~actual_bytes ~limit_bytes =
        })
 ;;
 
+let request_body_refused_by_provider ~status =
+  Agent_sdk.Error.Api
+    (InvalidRequest
+       { message = "provider refused the serialized request body"
+       ; reason = Agent_sdk.Retry.Request_body_refused_by_provider { status }
+       })
+;;
+
 (* The byte axis used to fall through [| _ -> None] and produce no compaction
    request at all, so these two assertions are the ones that failed before. *)
 let test_byte_axis_is_a_capacity_refusal () =
@@ -123,9 +131,21 @@ let test_byte_axis_is_a_capacity_refusal () =
           { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }) -> ()
    | Some (Budget.Serialized_request_body _) ->
      fail "the measured byte pair was not carried through"
+   | Some (Budget.Provider_request_body_refusal _) ->
+     fail "a measured local refusal became an unmeasured provider refusal"
    | Some (Budget.Provider_context_window _) ->
      fail "a byte refusal was classified on the token axis"
    | None -> fail "a declared-byte refusal was not classified as a capacity refusal");
+  (match
+     Budget.capacity_refusal_of_error
+       (request_body_refused_by_provider ~status:413)
+   with
+   | Some (Budget.Provider_request_body_refusal { status = 413 }) -> ()
+   | Some (Budget.Provider_request_body_refusal _) ->
+     fail "the provider refusal lost its HTTP status"
+   | Some (Budget.Provider_context_window _ | Budget.Serialized_request_body _) ->
+     fail "an unmeasured provider refusal was assigned a measured capacity"
+   | None -> fail "a provider request-body refusal was not typed as capacity");
   match
     Budget.capacity_refusal_of_error
       (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 }))
@@ -144,6 +164,13 @@ let test_event_projection_admits_only_the_token_axis () =
    with
    | None -> ()
    | Some _ -> fail "a byte refusal was projected as a context-overflow event");
+  (match
+     Budget.context_overflow_event_of_error
+       (request_body_refused_by_provider ~status:413)
+   with
+   | None -> ()
+   | Some _ ->
+     fail "a provider request-body refusal was projected on the token axis");
   match
     Budget.context_overflow_event_of_error
       (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None }))


### PR DESCRIPTION
## Summary

- read OAS v0.226 immutable `flow_attempt_snapshot` values through snapshot-specific accessors
- consume the renamed closed `flow_execution_error_generation_dispatch` fact
- preserve `Request_body_refused_by_provider { status }` as a distinct typed capacity refusal and event payload without fabricating byte or token limits

## Boundary

This PR intentionally does not fake the new durable exact-flow contract with `~commit:(fun _ -> Ok ())`. Current MASC still needs domain-specific durable intent/content ordering before removed settlement/preference APIs can be migrated. That blocker is tracked in #25808.

No compatibility shim, legacy branch, provider/model logic, Pricing policy, estimated limit, or migration path is added.

## Validation

Passed:

- `git diff --check`
- `ocamlformat --check` on all seven touched files

Focused build attempted:

- `scripts/dune-local.sh build test/test_keeper_unified_context_overflow.exe`
- stopped before Dune because the shared operator switch has agent_sdk 0.223.1 while the repo SSOT requires >= 0.226.0
- the shared opam switch was intentionally not mutated

This draft is not merge-ready while #25808 leaves current-pin settlement symbols uncompilable. CI is expected to expose the remaining exact blockers and must not be bypassed.
