### PR TITLE
ci: make Build the sole OCaml compile authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,9 @@ jobs:
           bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep
 
+      - name: Check single OCaml compile authority
+        run: bash scripts/ci/check-ocaml-compile-authority.sh
+
       - name: Guard pending release tag on main PRs
         if: github.event_name == 'pull_request' && github.base_ref == 'main'
         env:
@@ -520,22 +523,6 @@ jobs:
           bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep bc
 
-      - name: Setup OCaml toolchain
-        if: needs.changes.outputs.health_snapshot == 'true'
-        uses: ./.github/actions/setup-ocaml-toolchain
-
-      - name: Pin external OCaml dependencies
-        if: needs.changes.outputs.health_snapshot == 'true'
-        uses: ./.github/actions/pin-ocaml-deps
-        with:
-          pin-flags: --with-bisect
-
-      - name: Install system and OCaml dependencies
-        if: needs.changes.outputs.health_snapshot == 'true'
-        uses: ./.github/actions/install-ocaml-deps
-        with:
-          install-flags: --with-test
-
       - name: Fetch baseline for health ratchet
         if: needs.changes.outputs.health_snapshot == 'true'
         env:
@@ -571,12 +558,14 @@ jobs:
           fi
 
           if [ -n "${baseline_ref}" ]; then
-            opam exec -- bash scripts/health_snapshot.sh \
+            bash scripts/health_snapshot.sh \
+              --skip-build \
               --json-out .health/health-snapshot.json \
               --baseline-ref "${baseline_ref}" \
               --fail-on-lib-regression
           else
-            opam exec -- bash scripts/health_snapshot.sh \
+            bash scripts/health_snapshot.sh \
+              --skip-build \
               --json-out .health/health-snapshot.json \
               --baseline-file .ci/health-baseline.json
           fi
@@ -695,7 +684,11 @@ jobs:
           # runtest subset, so a PR that breaks test compilation can land
           # green (#23196/#23211/#23353 landed that way on 2026-07-04~06).
           # @check compiles every library/executable/test without running.
-          opam exec -- dune build --root . @default @check &
+          # @install adds the public package/install surface that Lint used to
+          # compile independently. The root dune env is the warning-as-error
+          # SSOT, so this one cacheable rule graph is authoritative for all
+          # three surfaces.
+          opam exec -- dune build --root . @default @check @install &
           build_pid=$!
 
           (
@@ -718,6 +711,13 @@ jobs:
           kill "${heartbeat_pid}" 2>/dev/null || true
           wait "${heartbeat_pid}" 2>/dev/null || true
           exit "${build_status}"
+
+      - name: Check keeper event queue projection boundary
+        # This parser uses compiler-libs directly, so keep it beside the sole
+        # OCaml toolchain instead of bootstrapping another toolchain in Lint.
+        run: |
+          chmod +x scripts/check-keeper-event-queue-projection-boundary.sh
+          scripts/check-keeper-event-queue-projection-boundary.sh
 
       - name: Sublib boundary gate against real dune graph (RFC-0056 G1)
         # The self-test (in the Meta Guards job) only validates the checker
@@ -906,9 +906,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    # Dependency installation plus @install warn-error build regularly exceeds
-    # 20 minutes on cold runners; keep this above the install-only worst case.
-    timeout-minutes: 40
+    # Source ratchets and proto drift are shell/Python-only after the product
+    # compile authority moved to Build and Test.
+    timeout-minutes: 20
     needs: [pr-live-gate, changes]
     if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.lint == 'true' }}
 
@@ -917,6 +917,11 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Install lint dependencies
+        run: |
+          bash scripts/ci/apt-refresh.sh
+          sudo apt-get install -y -qq ripgrep protobuf-compiler
 
       - name: Run #8605 family detector
         run: bash scripts/lint/no-unknown-permissive-default.sh
@@ -935,17 +940,6 @@ jobs:
 
       - name: Run dashboard agent-status SSOT lint (RFC-0139 §10)
         run: bash scripts/lint/dashboard-ssot-agent-status.sh
-
-      - name: Setup OCaml toolchain
-        uses: ./.github/actions/setup-ocaml-toolchain
-
-      - name: Pin external OCaml dependencies
-        uses: ./.github/actions/pin-ocaml-deps
-
-      - name: Install system and OCaml dependencies
-        uses: ./.github/actions/install-ocaml-deps
-        with:
-          os-packages: ripgrep
 
       - name: Check Eio conventions
         run: |
@@ -981,11 +975,6 @@ jobs:
           chmod +x scripts/check-boundary-guard.sh
           scripts/check-boundary-guard.sh
 
-      - name: Check keeper event queue projection boundary
-        run: |
-          chmod +x scripts/check-keeper-event-queue-projection-boundary.sh
-          scripts/check-keeper-event-queue-projection-boundary.sh
-
       - name: Check boundary-guard .mli pairing (sweep-miss gate)
         env:
           BASE_REF: origin/${{ github.base_ref || 'main' }}
@@ -998,15 +987,8 @@ jobs:
           chmod +x scripts/check-ssot.sh
           scripts/check-ssot.sh
 
-      - name: Build with warnings as errors
-        run: |
-          opam exec -- dune build --root . @install --force
-        env:
-          OCAMLPARAM: "_,warn-error=+a"
-
       - name: Check gRPC proto descriptor drift
         run: |
-          sudo apt-get install -y -qq protobuf-compiler
           chmod +x scripts/gen-grpc-descriptors.sh
           scripts/gen-grpc-descriptors.sh --check
 

--- a/dune
+++ b/dune
@@ -10,10 +10,10 @@
 (env
  (dev
   (flags
-   (:standard -warn-error +8)))
+   (:standard -warn-error +a)))
  (release
   (flags
-   (:standard -warn-error +8))))
+   (:standard -warn-error +a))))
 
 ; Build-time check: reject OPERATOR_TODO placeholders in source code.
 ; This prevents deployment of code with unresolved placeholders.

--- a/scripts/ci/check-ocaml-compile-authority.sh
+++ b/scripts/ci/check-ocaml-compile-authority.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="${repo_root}/.github/workflows/ci.yml"
+dune_root="${repo_root}/dune"
+
+fail() {
+  echo "OCaml compile authority drift: $*" >&2
+  exit 1
+}
+
+job_body() {
+  local job="$1"
+  awk -v job="${job}" '
+    $0 == "  " job ":" {
+      in_job = 1
+    }
+    in_job && $0 ~ /^  [[:alnum:]_-]+:$/ && $0 != "  " job ":" {
+      exit
+    }
+    in_job {
+      print
+    }
+  ' "${workflow}"
+}
+
+require_text() {
+  local body="$1"
+  local needle="$2"
+  local label="$3"
+  grep -Fq -- "${needle}" <<<"${body}" \
+    || fail "${label} must contain: ${needle}"
+}
+
+reject_text() {
+  local body="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "${needle}" <<<"${body}"; then
+    fail "${label} must not contain: ${needle}"
+  fi
+}
+
+build_body="$(job_body build)"
+health_body="$(job_body health)"
+lint_body="$(job_body lint)"
+
+require_text \
+  "${build_body}" \
+  "opam exec -- dune build --root . @default @check @install &" \
+  "Build and Test"
+require_text \
+  "${build_body}" \
+  "scripts/check-keeper-event-queue-projection-boundary.sh" \
+  "Build and Test"
+reject_text "${build_body}" "OCAMLPARAM" "Build and Test"
+reject_text "${build_body}" "dune build --root . @default @check @install --force" "Build and Test"
+
+health_invocations="$(grep -c 'bash scripts/health_snapshot.sh' <<<"${health_body}" || true)"
+health_skip_builds="$(grep -c -- '--skip-build' <<<"${health_body}" || true)"
+if [ "${health_invocations}" -eq 0 ] || [ "${health_invocations}" -ne "${health_skip_builds}" ]; then
+  fail "every Health snapshot invocation must pass --skip-build"
+fi
+for forbidden in \
+  ".github/actions/setup-ocaml-toolchain" \
+  ".github/actions/pin-ocaml-deps" \
+  ".github/actions/install-ocaml-deps" \
+  "opam exec" \
+  "dune build"
+do
+  reject_text "${health_body}" "${forbidden}" "Health"
+done
+
+require_text "${lint_body}" "scripts/check-eio-conventions.sh" "Lint"
+require_text "${lint_body}" "scripts/check-ssot.sh" "Lint"
+require_text "${lint_body}" "scripts/gen-grpc-descriptors.sh --check" "Lint"
+for forbidden in \
+  ".github/actions/setup-ocaml-toolchain" \
+  ".github/actions/pin-ocaml-deps" \
+  ".github/actions/install-ocaml-deps" \
+  "opam exec" \
+  "dune build" \
+  "scripts/check-keeper-event-queue-projection-boundary.sh"
+do
+  reject_text "${lint_body}" "${forbidden}" "Lint"
+done
+
+full_compile_count="$(
+  grep -Ec \
+    '^[[:space:]]+(opam exec -- )?(scripts/dune-local\.sh|dune) build .*@(default|check|install)' \
+    "${workflow}" \
+    || true
+)"
+[ "${full_compile_count}" -eq 1 ] \
+  || fail "ci.yml must contain exactly one full OCaml compile command, found ${full_compile_count}"
+
+warn_error_all_count="$(grep -Fc '(:standard -warn-error +a)' "${dune_root}" || true)"
+[ "${warn_error_all_count}" -eq 2 ] \
+  || fail "root dune env must enforce -warn-error +a in dev and release"
+
+echo "OCaml compile authority: PASS (Build owns @default @check @install; Health and Lint are compile-free)"


### PR DESCRIPTION
## Problem

`CI` compiled the same OCaml graph independently on three isolated runners:

- `Health` called `health_snapshot.sh`, whose default is `dune build @check`.
- `Build and Test` compiled `@default @check`.
- `Lint` forced a separate `@install` build with `OCAMLPARAM`.

The jobs restore historical Dune cache entries, but they do not share artifacts produced by the current workflow run. A single source error therefore appeared independently in Health, Build, and Lint while paying for three OCaml toolchain/dependency bootstraps.

## Change

- Make `Build and Test` the sole full OCaml compile authority with one cacheable `@default @check @install` graph.
- Move warning-as-error policy into the root Dune `env` stanza (`+a`) so it participates in the generated rule graph instead of relying on a job-local environment plus `--force`.
- Run Health with `health_snapshot.sh --skip-build`; retain baseline fetching, source ratchets, JSON publication, path scope, and CI Gate visibility.
- Keep Lint as shell/Python/SSOT/Eio/proto-drift checks with explicit `ripgrep` and `protobuf-compiler` dependencies; remove its opam/Dune bootstrap.
- Move the compiler-libs projection checker from Lint to Build, where the sole OCaml toolchain already exists.
- Add a Meta Guard ratchet that rejects reintroduction of Health/Lint compilation or a second full compile command.

No `_build` or cross-job artifact upload is introduced. Main-push safety-net, path classifiers, proto drift, and CI Gate aggregation are unchanged.

## Expected savings topology

- Full product graphs per scoped CI run: 3 -> 1.
- OCaml toolchain and opam dependency bootstraps: 3 jobs -> 1 job.
- Forced `@install` rebuild: removed; `@install` joins the authoritative cached graph.
- Health/Lint remain parallel, independent failure surfaces rather than waiting on Build.

## Focused validation

- `bash -n scripts/ci/check-ocaml-compile-authority.sh scripts/health_snapshot.sh`
- `bash scripts/ci/check-ocaml-compile-authority.sh`
- `python3 scripts/ci/check-yaml-syntax.py` (38 YAML files)
- `bash scripts/health_snapshot.sh --skip-build ...` plus JSON assertion for `build.skipped=true`
- `bash scripts/check-keeper-event-queue-projection-boundary.sh`
- `git diff --check`

No local full Dune build was run. This PR deliberately uses the single GitHub Build job as the broad compile authority.

## Risk

The root warning policy now explicitly rejects every OCaml warning in dev and release profiles. This expands the former explicit `+8` root setting to the `+a` policy Lint already enforced on `@install`; CI may expose warnings in test-only targets that the old Lint graph did not cover. Such failures are intended compile-authority findings, not downgraded Lint output.