### PR TITLE
fix(keeper): hold lifecycle admission through shutdown cleanup

### DIFF
--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -723,7 +723,13 @@ let deliver_finalized_completion ~config operation =
   | Superseded _ -> Error Unsupported_phase
 ;;
 
-let complete_cleanup ~(config : Workspace.config) ~entry operation cleanup =
+let complete_cleanup_admitted
+      ~(config : Workspace.config)
+      ~entry
+      ~permit
+      operation
+      cleanup
+  =
   let retire_summary_owner () =
     match operation.cleanup_intent.reason with
     | Operator_stop_retain_meta -> Ok ()
@@ -897,12 +903,16 @@ let complete_cleanup ~(config : Workspace.config) ~entry operation cleanup =
          result
        | None -> assert false)
   in
+  finalize_with_permit permit
+;;
+
+let with_cleanup_admission ~(config : Workspace.config) operation fn =
   match
     Keeper_lifecycle_admission.Durable_transaction
     .with_durable_lifecycle_admission
       config
       ~keeper_name:operation.keeper_name
-      finalize_with_permit
+      fn
   with
   | Admission_completed (Ok finalized) ->
     deliver_finalized_completion ~config finalized
@@ -935,6 +945,27 @@ let complete_cleanup ~(config : Workspace.config) ~entry operation cleanup =
                reason ))
 ;;
 
+let prepare_and_complete_cleanup
+      ~(config : Workspace.config)
+      ~entry
+      operation
+      settled_task_ids
+  =
+  with_cleanup_admission ~config operation (fun permit ->
+    match prepare_cleanup ~config ~entry operation settled_task_ids with
+    | Error _ as error -> error
+    | Ok ready ->
+      (match ready.phase with
+       | Cleanup_ready cleanup ->
+         complete_cleanup_admitted
+           ~config
+           ~entry
+           ~permit
+           ready
+           cleanup
+       | _ -> Error Unsupported_phase))
+;;
+
 let run ~config ~entry operation =
   match operation.phase with
   | Joined_idle ->
@@ -944,12 +975,11 @@ let run ~config ~entry operation =
        (match settle_tasks ~config ~meta operation [] with
         | Error _ as error -> error
         | Ok (settled_operation, settled_task_ids) ->
-          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
-           | Error _ as error -> error
-           | Ok ready ->
-             (match ready.phase with
-              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
-              | _ -> Error Unsupported_phase))))
+          prepare_and_complete_cleanup
+            ~config
+            ~entry
+            settled_operation
+            settled_task_ids))
   | Finalizing_tasks settled_task_ids ->
     (match read_operation_meta ~config operation with
      | Error detail -> block ~config operation Meta_update detail
@@ -957,13 +987,19 @@ let run ~config ~entry operation =
        (match settle_tasks ~config ~meta operation settled_task_ids with
         | Error _ as error -> error
         | Ok (settled_operation, settled_task_ids) ->
-          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
-           | Error _ as error -> error
-           | Ok ready ->
-             (match ready.phase with
-              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
-              | _ -> Error Unsupported_phase))))
-  | Cleanup_ready cleanup -> complete_cleanup ~config ~entry operation cleanup
+          prepare_and_complete_cleanup
+            ~config
+            ~entry
+            settled_operation
+            settled_task_ids))
+  | Cleanup_ready cleanup ->
+    with_cleanup_admission ~config operation (fun permit ->
+      complete_cleanup_admitted
+        ~config
+        ~entry
+        ~permit
+        operation
+        cleanup)
   | Finalized _ -> deliver_finalized_completion ~config operation
   | Prepared
   | Reconciliation_required _

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2472,6 +2472,7 @@ let install_pending_summary ~base_path ~keeper_name ~bind_exact =
 let test_keeper_shutdown_finalizes_idle_operation () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir "shutdown-finalize" in
   Fun.protect
     ~finally:(fun () ->
@@ -2501,8 +2502,46 @@ let test_keeper_shutdown_finalizes_idle_operation () =
       (match Masc_test_deps.write_current_keeper_meta config meta with
        | Ok () -> ()
        | Error detail -> fail detail);
+      let module Durable =
+        Masc.Keeper_lifecycle_admission.Durable_transaction
+      in
+      let competing_cleanup_entered = Atomic.make false in
+      let competing_cleanup_started, resolve_competing_cleanup_started =
+        Eio.Promise.create ()
+      in
+      let competing_cleanup_done, resolve_competing_cleanup_done =
+        Eio.Promise.create ()
+      in
       Shutdown_finalize.register_remove_pending_confirms_by_target
-        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+        (fun callback_config ~target_type:_ ~target_id:_ ->
+           Eio.Fiber.fork ~sw (fun () ->
+             Eio.Promise.resolve resolve_competing_cleanup_started ();
+             let outcome =
+               Masc.Keeper_lifecycle_admission_permit
+               .without_inherited_permit_scope
+                 (fun () ->
+                    Durable.with_durable_lifecycle_admission
+                      callback_config
+                      ~keeper_name:meta.name
+                      (fun _permit ->
+                         Atomic.set competing_cleanup_entered true))
+             in
+             (match outcome with
+              | Durable.Admission_completed ()
+              | Durable.Admission_completed_with_attention ((), _) -> ()
+              | Durable.Admission_blocked reason ->
+                fail
+                  ("competing cleanup admission remained blocked: "
+                   ^ Durable.blocked_reason_to_wire reason));
+             Eio.Promise.resolve resolve_competing_cleanup_done ());
+           Eio.Promise.await competing_cleanup_started;
+           Eio.Fiber.yield ();
+           check
+             bool
+             "pending-confirm retirement retains lifecycle admission"
+             false
+             (Atomic.get competing_cleanup_entered);
+           Ok 0);
       let operation_id = Shutdown_types.Operation_id.generate () in
       let operation : Shutdown_types.t =
         { schema_version = Shutdown_types.schema_version
@@ -2541,6 +2580,12 @@ let test_keeper_shutdown_finalizes_idle_operation () =
         | Ok finalized -> finalized
         | Error error -> fail (Shutdown_finalize.error_to_string error)
       in
+      Eio.Promise.await competing_cleanup_done;
+      check
+        bool
+        "competing lifecycle enters after shutdown cleanup"
+        true
+        (Atomic.get competing_cleanup_entered);
       (match finalized.phase with
        | Shutdown_types.Finalized evidence ->
          check int "no pending confirms" 0 evidence.cleanup.pending_confirms_removed


### PR DESCRIPTION
## What

- acquire durable lifecycle admission before pending-confirm retirement
- retain the same permit through Cleanup_ready and finalization
- make Cleanup_ready recovery reacquire the same authority boundary
- prove a non-inheriting competing fiber cannot enter during pending-confirm cleanup

## Invariants

- no irreversible pending-confirm deletion outside lifecycle authority
- no legacy state handling or migration
- Keeper remains retryable when admission is blocked

## Validation

- Local full build intentionally not run; stacked PR checks and parent #25752 CI are the authority.