### PR TITLE
fix(ci): make proxy health counts measurement-only

### DIFF
--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -11,7 +11,6 @@ BASELINE_FILE=".ci/health-baseline.json"
 BASELINE_REF=""
 CHANGED_REF=""
 FAIL_ON_LIB_REGRESSION=0
-FAIL_ON_ML_LINE_CAP_REGRESSION=0
 
 usage() {
   cat <<'EOF'
@@ -24,8 +23,6 @@ Options:
   --baseline-ref <git-ref>     Read the baseline file from a git ref
   --changed-ref <git-ref>      Read changed-file scope from a git ref
   --fail-on-lib-regression     Exit non-zero when lib counts exceed baseline
-  --fail-on-ml-line-cap-regression
-                               Exit non-zero when .ml line-cap regresses
 EOF
 }
 
@@ -53,10 +50,6 @@ while [ "$#" -gt 0 ]; do
       ;;
     --fail-on-lib-regression)
       FAIL_ON_LIB_REGRESSION=1
-      shift
-      ;;
-    --fail-on-ml-line-cap-regression)
-      FAIL_ON_ML_LINE_CAP_REGRESSION=1
       shift
       ;;
     -h|--help)
@@ -281,9 +274,6 @@ fi
 if [ -n "$CHANGED_REF" ]; then
   ml_line_cap_cmd+=(--changed-ref "$CHANGED_REF" --fail-on-changed-violations)
 fi
-if [ "$FAIL_ON_ML_LINE_CAP_REGRESSION" -eq 1 ]; then
-  ml_line_cap_cmd+=(--fail-on-regression)
-fi
 "${ml_line_cap_cmd[@]}"
 
 manual_ml_over_500="$(extract_json_int "$ml_line_cap_json" "manual_ml_over_500")"
@@ -323,7 +313,6 @@ if [ "$FAIL_ON_LIB_REGRESSION" -eq 1 ]; then
     baseline_lib_obj_magic="$(extract_baseline_value "$baseline_content" "lib_obj_magic")"
   fi
 
-  [ "$lib_failwith" -gt "$baseline_lib_failwith" ] && regressions+=("lib_failwith ${baseline_lib_failwith}->${lib_failwith}")
   [ "$lib_list_hd" -gt "$baseline_lib_list_hd" ] && regressions+=("lib_list_hd ${baseline_lib_list_hd}->${lib_list_hd}")
   [ "$lib_list_tl" -gt "$baseline_lib_list_tl" ] && regressions+=("lib_list_tl ${baseline_lib_list_tl}->${lib_list_tl}")
   [ "$lib_option_get" -gt "$baseline_lib_option_get" ] && regressions+=("lib_option_get ${baseline_lib_option_get}->${lib_option_get}")
@@ -375,7 +364,7 @@ echo "Unsafe patterns (test): failwith=${test_failwith} list_hd=${test_list_hd} 
 echo "Base policy: mli_open_base=${mli_open_base} ml_base_stdlib_shadow=${ml_base_stdlib_shadow} bin_ml_base_stdlib_shadow=${bin_ml_base_stdlib_shadow}"
 echo "ML line cap: manual=${manual_ml_over_500} excepted=${excepted_ml_over_500} lib=${lib_ml_over_500} bin=${bin_ml_over_500} test=${test_ml_over_500} examples=${examples_ml_over_500}"
 echo "ML line cap changed: ${ml_line_cap_changed_status} (${ml_line_cap_changed_message})"
-echo "ML line cap ratchet: ${ml_line_cap_status} (${ml_line_cap_message})"
+echo "ML line cap aggregate: ${ml_line_cap_status} (${ml_line_cap_message})"
 echo "Ratchet: ${ratchet_status} (${ratchet_message})"
 
 json_payload="$(cat <<EOF
@@ -478,7 +467,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "- Anti-fake: \`$anti_fake_label\` (good=$anti_fake_good suspect=$anti_fake_suspect fake=$anti_fake_fake total=$anti_fake_total)"
     echo "- Base policy: mli_open_base=\`$mli_open_base\` ml_base_stdlib_shadow=\`$ml_base_stdlib_shadow\` bin_ml_base_stdlib_shadow=\`$bin_ml_base_stdlib_shadow\`"
     echo "- ML line cap changed: \`$ml_line_cap_changed_status\` ($ml_line_cap_changed_message)"
-    echo "- ML line cap ratchet: \`$ml_line_cap_status\` ($ml_line_cap_message)"
+    echo "- ML line cap aggregate: \`$ml_line_cap_status\` ($ml_line_cap_message)"
     echo "- Ratchet: \`$ratchet_status\` ($ratchet_message)"
     if [ "${#regressions[@]}" -gt 0 ]; then
       echo "- Regressions:"

--- a/scripts/ml_line_cap_audit.sh
+++ b/scripts/ml_line_cap_audit.sh
@@ -33,7 +33,7 @@ def parse_args(repo_root: Path) -> argparse.Namespace:
     parser.add_argument(
         "--baseline-ref",
         default="",
-        help="Git ref to compare total manual-over-cap count against.")
+        help="Git ref to include in the aggregate measurement.")
     parser.add_argument(
         "--changed-ref",
         default="",
@@ -42,10 +42,6 @@ def parse_args(repo_root: Path) -> argparse.Namespace:
         "--json-out",
         default="",
         help="Write machine-readable JSON output to this path.")
-    parser.add_argument(
-        "--fail-on-regression",
-        action="store_true",
-        help="Exit non-zero when manual-over-cap count exceeds the baseline.")
     parser.add_argument(
         "--fail-on-changed-violations",
         action="store_true",
@@ -214,19 +210,15 @@ def main() -> int:
         changed_manual.sort(key=lambda item: (-item["lines"], item["path"]))
 
     if baseline_counts is None:
-        regression_status = "disabled"
-        regression_message = "baseline unavailable"
+        aggregate_status = "unavailable"
+        aggregate_message = "baseline unavailable"
     else:
         current_manual = current["counts"]["manual_ml_over_500"]
         baseline_manual = baseline_counts["manual_ml_over_500"]
-        if current_manual > baseline_manual:
-            regression_status = "fail"
-            regression_message = (
-                f"manual_ml_over_500 {baseline_manual}->{current_manual}"
-            )
-        else:
-            regression_status = "pass"
-            regression_message = f"manual_ml_over_500 {baseline_manual}->{current_manual}"
+        aggregate_status = "measurement"
+        aggregate_message = (
+            f"manual_ml_over_500 {baseline_manual}->{current_manual}"
+        )
 
     changed_status = "disabled"
     changed_message = "changed ref unavailable"
@@ -253,8 +245,8 @@ def main() -> int:
         "baseline": {
             "source": baseline_source,
             "counts": baseline_counts,
-            "status": regression_status,
-            "message": regression_message,
+            "status": aggregate_status,
+            "message": aggregate_message,
         },
         "changed": {
             "ref": args.changed_ref or None,
@@ -282,7 +274,7 @@ def main() -> int:
         f"test={current['counts']['test_ml_over_500']} "
         f"examples={current['counts']['examples_ml_over_500']}"
     )
-    print(f"Regression: {regression_status} ({regression_message})")
+    print(f"Aggregate: {aggregate_status} ({aggregate_message})")
     print(f"Changed: {changed_status} ({changed_message})")
     print_entries("Changed manual violations", changed_manual)
 
@@ -292,8 +284,6 @@ def main() -> int:
         json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
     exit_code = 0
-    if args.fail_on_regression and regression_status == "fail":
-        exit_code = 1
     if args.fail_on_changed_violations and changed_status == "fail":
         exit_code = 1
     return exit_code


### PR DESCRIPTION
## Summary

- keep `lib_failwith` and `.ml >500` totals as Health snapshot measurements
- stop failing Health on the aggregate `lib_failwith` count
- remove the aggregate `.ml >500` regression mode while preserving changed-file enforcement
- leave typed safety checks, other unsafe-pattern/base-policy gates, and the single OCaml compile authority detector unchanged

## Why

Aggregate source counts are proxy metrics, not behavioral proof. They forced unrelated product refactors without proving Keeper liveness, typed settlement, or Input/Output correctness.

## Focused validation

- `bash -n scripts/health_snapshot.sh scripts/ml_line_cap_audit.sh`
- `git diff --check`
- synthetic baseline: `manual_ml_over_500 0->397` reports `measurement`; changed-file gate reports `pass`
- synthetic baseline: `lib_failwith 0->23` remains visible while Health ratchet reports `pass`

## Adversarial review

- P0: none
- P1: none
- changed-file `.ml` line-cap enforcement remains available
- `List.hd`, `List.tl`, `Option.get`, `Obj.magic`, and base-policy gates remain unchanged
- `.github/workflows/ci.yml` and `scripts/ci/check-ocaml-compile-authority.sh` are untouched
