### PR TITLE
feat(keeper): JSON 문법만 요구하는 세 번째 경계 옵션 (#25789)

### DIFF
--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -162,8 +162,14 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
    (2) #22768("native schema or fail before HTTP")이 native 미선언을 빌드 실패로
    만들었다가 뒤집힌 이력이 있다 — 미지원 preset의 fusion을 영구 불능으로 만들기
    때문이며, 2026-06-17~06-30 prompt 계약만으로 성공한 run이 다수다. *)
+(* (1)은 json_schema에 대한 관측이고 json_object에는 해당하지 않는다: 2026-07-27
+   probe 에서 ollama_cloud/deepseek-v4-flash 는 response_format={"type":"json_object"}
+   에 200 + 펜스 없는 JSON 문서로 답했다. 스키마를 조용히 무시하는 엔드포인트가
+   문서 요구는 지킨다. (2)의 이력도 그대로 유지된다 — json_object 는 capability
+   분기를 만들지 않으므로 미지원 preset 이 빌드/실행 실패로 가지 않고, 지원하지
+   않는 백엔드는 필드를 버린다. 계약을 지키는 것은 여전히 프롬프트와 파서다. *)
 let apply_fusion_judge_output_contract provider_cfg =
-  Ok (Keeper_structured_output_schema.without_response_format provider_cfg)
+  Ok (Keeper_structured_output_schema.json_syntax_only provider_cfg)
 
 (* 합성된 프롬프트를 받아 심판 에이전트를 빌드·실행·파싱한다. [run]/[run_refine]가
    서로 다른 [compose_*]로 만든 프롬프트를 넘기는 공유 본체 — 프롬프트 구성만 다르고

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -1,9 +1,10 @@
 (** Fusion — 심판. 패널 답들을 judge 모델에 넘겨 구조화 종합({!Fusion_types.judge_synthesis})을 받는다.
 
-    Judge 출력 계약은 **단일 tier**다. [apply_fusion_judge_output_contract]
-    (fusion_judge.ml:165-166)는 capability를 읽지 않고
-    [Keeper_structured_output_schema.without_response_format]를 무조건 적용한다 —
-    [response_format = Off], [output_schema = None]. 계약은 프롬프트의
+    Judge 출력 계약은 **단일 tier**다. [apply_fusion_judge_output_contract]는
+    capability를 읽지 않고 [Keeper_structured_output_schema.json_syntax_only]를
+    무조건 적용한다 — [response_format = JsonMode], [output_schema = None].
+    스키마 요청이 아니므로 [validate_output_schema_request]는 capability를 보지
+    않고, json_object 미지원 백엔드는 필드를 버린다. 계약은 프롬프트의
     {!Fusion_judge_parse.expected_json_doc} 지시로만 나가고, 응답은
     {!Fusion_judge_parse.of_string}의 strict 파싱을 통과해야 하며 위반은
     [Parse_error]로 fail-loud한다.

--- a/lib/keeper/keeper_failure_judge.ml
+++ b/lib/keeper/keeper_failure_judge.ml
@@ -67,9 +67,16 @@ let build_prompt ~keeper_name request =
    than the schema can: it fixes the exact field set and couples decision to
    guidance (null for await_external_input, non-empty otherwise), which JSON
    Schema cannot express without oneOf. Keeper_failure_judgment_contract
-   re-checks every one of those on the way in. *)
+   re-checks every one of those on the way in.
+
+   Asking for JSON syntax is not the same as asking for that schema: it demands a
+   document, not a shape, so the contract above still lives in the prompt and in
+   [Keeper_failure_judgment_contract]. What it removes is the case this boundary
+   was actually failing on — a reply that never was a JSON document. GLM-5-Turbo
+   fenced its answer and stopped taskmaster (#25789); the same runtime answers
+   json_object with a bare document. *)
 let apply_output_schema provider_config =
-  Ok (Keeper_structured_output_schema.without_response_format provider_config)
+  Ok (Keeper_structured_output_schema.json_syntax_only provider_config)
 ;;
 
 let reject_unregistered_tool ~name ~args:_ =

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -63,7 +63,14 @@ let with_facts_lock ?clock ~keeper_id f =
    only a capability branch: [validate_output_schema_request] rejects
    json_schema on every json_object-only endpoint, and the parse path never
    read a provider-side field anyway — [structured_json_of_response] extracts
-   JSON from the response's visible text. *)
+   JSON from the response's visible text.
+
+   Extracting JSON from visible text still requires the visible text to be a JSON
+   document, which is the part nothing was asking for. 36 replies failed that parse
+   on the live fleet (APC free_text_json_contracts), and none of them were markdown
+   fences — they opened a document and then diverged or stopped. [json_syntax_only]
+   asks for the document without asking for a schema, so the capability branch above
+   is still not taken. *)
 let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
@@ -71,7 +78,7 @@ let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
     | Some _ | None -> Some consolidation_max_tokens
   in
   Keeper_structured_output_schema.for_deterministic_subcall ~max_tokens provider_cfg
-  |> Keeper_structured_output_schema.without_response_format
+  |> Keeper_structured_output_schema.json_syntax_only
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -291,6 +291,37 @@ let without_response_format (provider_cfg : Llm_provider.Provider_config.t) =
   }
 ;;
 
+(* Ask the provider for a JSON document and for nothing else. This is the third
+   option the boundary did not have: {!apply_to_provider_config} demands a schema
+   and {!without_response_format} asks for no wire format at all, so a call site
+   that needs only "the reply parses as JSON" had to fall all the way to prose and
+   re-parse it.
+
+   The objection recorded above is about json_schema and does not reach here.
+   [Provider_config.structured_schema_requested] counts a request as a schema
+   request only when [output_schema] is set or [response_format] is [JsonSchema];
+   [JsonMode] with no output_schema is neither, so
+   [validate_output_schema_request] returns [Ok] without consulting the capability
+   at all (oas provider_config.ml:570-575, :619-636 at pin 3d4ee19a). The
+   json_object-only endpoints that rejected json_schema accept this one.
+
+   Measured on the live fleet 2026-07-27 with response_format={"type":"json_object"}:
+   glm-coding/GLM-5-Turbo and ollama_cloud/deepseek-v4-flash each answered 200 with a
+   bare JSON document and no markdown fence — GLM-5-Turbo being the runtime whose
+   fenced reply stopped taskmaster (#25789). Anthropic has no json_object mode and
+   [backend_anthropic.ml:138] drops the field, so those runtimes keep exactly today's
+   behaviour.
+
+   The prompt contract and the total parser stay in place either way. This does not
+   move the contract onto the wire; it removes the case where the model was never
+   asked for JSON at all. *)
+let json_syntax_only (provider_cfg : Llm_provider.Provider_config.t) =
+  { provider_cfg with
+    response_format = Agent_sdk.Types.JsonMode
+  ; output_schema = None
+  }
+;;
+
 (* The anti-rationalization reviewer's verdict channel is the
    [report_review_verdict] tool call: exactly-once dispatch enforced in
    [Workspace_metric_hooks], args re-validated by the total parser

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -59,6 +59,24 @@ val without_response_format
     already become a typed error rather than a bad write. Every provider then
     takes one identical request path with no capability branch. *)
 
+val json_syntax_only
+  :  Llm_provider.Provider_config.t
+  -> Llm_provider.Provider_config.t
+(** Ask the provider for a JSON document and for nothing else: [JsonMode] with no
+    output schema. For call sites whose prompt states the object shape and whose
+    parser is total, but which still need the reply to be a JSON document rather
+    than prose that happens to contain one.
+
+    Unlike {!apply_to_provider_config} this requests no schema, so it takes no
+    capability branch: [validate_output_schema_request] only consults the
+    capability when a schema is actually requested, and [JsonMode] with
+    [output_schema = None] is not a schema request. The json_object-only
+    endpoints (GLM/DeepSeek/Kimi) that rejected json_schema accept this.
+
+    Providers with no json_object mode drop the field at the backend, so this is
+    a no-op there rather than an error — the prompt contract and the total parser
+    remain the guarantee in both cases. *)
+
 val anti_rationalization_reviewer_provider_config
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -104,7 +104,16 @@ val for_deterministic_subcall
   :  max_tokens:int option
   -> Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
-(** Provider shape shared by MASC's deterministic LLM subcalls (librarian
+(** Provider shape for MASC's deterministic LLM subcalls. One caller today:
+    memory-OS consolidation. The librarian extraction named below moved onto the
+    exact-output lane (keeper_librarian_runtime.ml:638-641 builds an
+    [Exact_output] requirement instead of a subcall), where the provider comes
+    from the lane's admitted target and this shape is not applied — so the
+    paragraph below is the history of the tuning, not a list of its current
+    users. Whether the librarian still needs the suppression on that path is
+    open; nothing in this module can answer it.
+
+    Original note (librarian
     extraction, memory-OS consolidation): no tool choice, no parallel tool
     use, and thinking fully suppressed.
 

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -23,7 +23,6 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   ; decision = Fusion_types.Answer "ok"
   }
 
-let fusion_schema = Keeper_structured_output_schema.fusion_judge_output_schema
 
 let restore_model_catalog previous =
   match previous with
@@ -61,7 +60,13 @@ let response_with_text text : Agent_sdk.Types.api_response =
   ; telemetry = None
   }
 
-let test_output_contract_keeps_native_schema_when_supported () =
+(* These three cases were written against the 3-tier selector (#25324) and kept
+   asserting it after the code became single-tier: [apply_fusion_judge_output_contract]
+   stopped reading capability when it moved to [without_response_format], so the native
+   case has been asserting a schema the function cannot produce. They are rewritten to
+   the contract fusion_judge.mli states — one request shape for every provider — with
+   the schema-capable case kept as the one that proves capability is not consulted. *)
+let test_output_contract_asks_no_schema_of_a_schema_capable_provider () =
   let cfg =
     provider_cfg
       ~kind:Llm_provider.Provider_config.Anthropic
@@ -69,16 +74,14 @@ let test_output_contract_keeps_native_schema_when_supported () =
       ~base_url:"https://api.anthropic.test"
   in
   match Fusion_judge.For_testing.apply_output_contract cfg with
-  | Error msg -> fail ("expected native schema config: " ^ msg)
+  | Error msg -> fail ("single-tier contract must not fail the build: " ^ msg)
   | Ok configured ->
-    check bool "response_format uses JsonSchema" true
+    check bool "response_format asks for JSON syntax, not a schema" true
       (match configured.response_format with
-       | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal fusion_schema schema
-       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
-    check bool "output_schema mirrors schema" true
-      (match configured.output_schema with
-       | Some schema -> Yojson.Safe.equal fusion_schema schema
-       | None -> false)
+       | Agent_sdk.Types.JsonMode -> true
+       | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
+    check bool "no output_schema is attached even though the provider accepts one" true
+      (Option.is_none configured.output_schema)
 
 (* Prompt tier: 기본 카탈로그의 deepseek-v4-pro 항목은 native schema도 json_object
    response format도 선언하지 않으므로, 3-tier 선택기(#25324)에서도 schema 없이
@@ -99,8 +102,8 @@ let test_output_contract_prompt_tier_when_schema_is_not_native () =
   | Ok configured ->
     check bool "no native schema is attached (prompt tier)" true
       (match configured.response_format with
-       | Agent_sdk.Types.Off -> true
-       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
+       | Agent_sdk.Types.JsonMode -> true
+       | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
     check bool "output_schema stays empty (prompt tier)" true
       (Option.is_none configured.output_schema)
 
@@ -143,8 +146,8 @@ let test_output_contract_prompt_tier_when_no_output_contract_is_known () =
   | Ok configured ->
     check bool "no native schema is attached (prompt tier)" true
       (match configured.response_format with
-       | Agent_sdk.Types.Off -> true
-       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
+       | Agent_sdk.Types.JsonMode -> true
+       | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
     check bool "output_schema stays empty (prompt tier)" true
       (Option.is_none configured.output_schema)
 
@@ -343,9 +346,9 @@ let () =
   run "fusion_judge_usage"
     [ ( "output_contract"
       , [ test_case
-            "keeps native schema when supported"
+            "asks no schema of a schema-capable provider"
             `Quick
-            test_output_contract_keeps_native_schema_when_supported
+            test_output_contract_asks_no_schema_of_a_schema_capable_provider
         ; test_case
             "prompt tier when native schema is not available"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -547,18 +547,21 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
           "configured max_tokens cap is preserved"
           (Some 512)
           !seen_max_tokens;
-        (* The contract lives in the prompt and the parser, not in a wire
-           response_format. Pinning [Off] keeps the request identical across
-           providers: reintroducing a schema demand would make every
-           json_object-only endpoint (GLM/DeepSeek/Kimi) fail capability
-           validation and silently fall back to this same prompt path. *)
+        (* The object shape lives in the prompt and the parser, not in a wire
+           schema. What does go on the wire is the demand that the reply be a
+           JSON document at all: pinning [JsonMode] keeps the request identical
+           across providers, because it is not a schema request and so takes no
+           capability branch, while reintroducing a schema demand would make
+           every json_object-only endpoint (GLM/DeepSeek/Kimi) fail capability
+           validation and fall back to prose. [Off] was the previous pin and
+           produced 36 unparseable replies on the live fleet. *)
         Alcotest.(check (option bool))
-          "no response format is requested"
+          "JSON syntax is requested, without a schema"
           (Some true)
           (Option.map
              (function
-               | Atypes.Off -> true
-               | Atypes.JsonMode | Atypes.JsonSchema _ -> false)
+               | Atypes.JsonMode -> true
+               | Atypes.Off | Atypes.JsonSchema _ -> false)
              !seen_response_format);
         Alcotest.(check bool)
           "no output schema is attached"
@@ -590,11 +593,11 @@ let test_resolver_is_capability_independent () =
   in
   let resolved = Runtime.resolve_provider_for_consolidation json_object_only_cfg in
   Alcotest.(check bool)
-    "json_object-only provider still gets no response format"
+    "json_object-only provider gets the same JSON-syntax request as everyone else"
     true
     (match resolved.Llm_provider.Provider_config.response_format with
-     | Atypes.Off -> true
-     | Atypes.JsonMode | Atypes.JsonSchema _ -> false);
+     | Atypes.JsonMode -> true
+     | Atypes.Off | Atypes.JsonSchema _ -> false);
   Alcotest.(check bool)
     "no output_schema is attached"
     true

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -171,6 +171,59 @@ let test_without_response_format_is_capability_independent () =
        [ schema_capable; json_object_only ])
 ;;
 
+let asks_for_json_syntax_only provider_cfg =
+  match provider_cfg.Llm_provider.Provider_config.response_format with
+  | Agent_sdk.Types.JsonMode ->
+    Option.is_none provider_cfg.Llm_provider.Provider_config.output_schema
+  | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false
+;;
+
+(* [json_syntax_only] must reach both provider classes, including the
+   json_object-only one that rejects json_schema. That rejection is what pushed
+   these call sites to prose, and it does not apply here: a request carrying
+   [JsonMode] with no output_schema is not a schema request, so
+   [validate_output_schema_request] never consults the capability. If a future
+   change made [JsonMode] count as one, the last assertion fails rather than the
+   fleet silently returning to prose. *)
+let test_json_syntax_only_is_capability_independent () =
+  let schema_capable =
+    Keeper_structured_output_schema.json_syntax_only
+      (schema_capable_oas_provider_config ())
+  in
+  let json_object_only =
+    Keeper_structured_output_schema.json_syntax_only
+      (prompt_tier_oas_provider_config ())
+  in
+  check bool "schema-capable provider asks for JSON syntax" true
+    (asks_for_json_syntax_only schema_capable);
+  check bool "json_object-only provider asks for JSON syntax" true
+    (asks_for_json_syntax_only json_object_only);
+  check bool "neither request is a schema request" true
+    (List.for_all
+       (fun cfg ->
+          match Llm_provider.Provider_config.validate_output_schema_request cfg with
+          | Ok () -> true
+          | Error _ -> false)
+       [ schema_capable; json_object_only ])
+;;
+
+(* Composing over a config that already carries a native schema must drop it.
+   Keeping the schema while setting [JsonMode] would send both fields and turn
+   the request back into a schema request — the capability branch this avoids. *)
+let test_json_syntax_only_drops_an_attached_schema () =
+  let base =
+    Keeper_structured_output_schema.apply_to_provider_config
+      Keeper_structured_output_schema.librarian_episode_output_schema
+      (schema_capable_oas_provider_config ())
+  in
+  check bool "base starts with a native schema attached" true
+    (has_json_schema_response_format
+       Keeper_structured_output_schema.librarian_episode_output_schema
+       base);
+  check bool "json_syntax_only drops it" true
+    (asks_for_json_syntax_only (Keeper_structured_output_schema.json_syntax_only base))
+;;
+
 (* #25266: a json_object-only provider (structured_output=false,
    response_format_json=true — GLM/DeepSeek/Kimi's OpenAI-compat endpoints)
    must get JsonMode from the three-tier selector, not be dropped to the
@@ -479,6 +532,14 @@ let () =
             "without_response_format is capability-independent"
             `Quick
             test_without_response_format_is_capability_independent
+        ; test_case
+            "json_syntax_only is capability-independent"
+            `Quick
+            test_json_syntax_only_is_capability_independent
+        ; test_case
+            "json_syntax_only drops an attached schema"
+            `Quick
+            test_json_syntax_only_drops_an_attached_schema
         ] )
     ; ( "dashboard schemas"
       , [ test_case


### PR DESCRIPTION
feat(keeper): ask for JSON syntax without asking for a schema

The structured-output boundary offered two options and needed three.
apply_to_provider_config demands a schema (JsonSchema + output_schema);
without_response_format asks for nothing (Off + None). Nothing in masc
constructed Agent_sdk.Types.JsonMode, so a call site that needs only "the reply
is a JSON document" had to fall all the way to prose and re-parse it. 36 replies
failed that parse on the live fleet, and taskmaster stopped on one of them
(#25789).

The recorded objection to a wire format is about json_schema and does not reach
JsonMode. Provider_config.structured_schema_requested counts a request as a
schema request only when output_schema is set or response_format is JsonSchema;
JsonMode with output_schema = None is neither, so validate_output_schema_request
returns Ok without consulting the capability (oas provider_config.ml:570-575,
:619-636 at pin 3d4ee19a). The json_object-only endpoints that rejected
json_schema accept this one.

Measured 2026-07-27 with response_format={"type":"json_object"}:
glm-coding/GLM-5-Turbo and ollama_cloud/deepseek-v4-flash each answered 200 with
a bare JSON document and no fence. GLM-5-Turbo is the runtime whose fenced reply
stopped taskmaster. Anthropic has no json_object mode and backend_anthropic.ml
drops the field, so those runtimes keep today's behaviour exactly.

All three free-text sites move together (fusion judge, failure judge, memory-OS
consolidation); leaving any behind would be the N-of-M shape. The prompt
contract and the total parsers are untouched: this adds no schema and moves no
contract onto the wire.

test_fusion_judge_usage.ml asserted the 3-tier selector (#25324) that the code
dropped when it went single-tier, so its native case was asserting a schema
apply_fusion_judge_output_contract cannot produce. Those cases now assert the
contract fusion_judge.mli states.

Verified: ocamlformat --check clean on all seven files; JsonMode present in both
the declared pin and the installed agent_sdk 0.226.0. NOT verified locally: the
shared opam switch is pinned to 2186dfa5 while the repo declares 3d4ee19a, so a
local build would compile against a different OAS than the repo names. CI builds
this against the declared pin.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
