### PR TITLE
fix(keeper): nullable claim_kind 를 exact union 으로 표현 (#25730 발췌)

### DIFF
--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -20,11 +20,14 @@ let enum_schema values =
     ]
 ;;
 
+(* A string enum and the absent value are two separate branches, not one enum that
+   carries JSON [null] as if it were a domain token. MASC declares provider-neutral
+   content semantics; OAS owns provider and wire admission for the resulting
+   schema. The previous [type: [string, null]] plus [enum: [null, ...]] shape left
+   the null branch inside the token list, where a provider can accept the request
+   and ignore the union instead of rejecting an unsupported dialect. *)
 let nullable_enum_schema values =
-  `Assoc
-    [ "type", `List [ `String "string"; `String "null" ]
-    ; "enum", `List ((`Null) :: List.map (fun value -> `String value) values)
-    ]
+  `Assoc [ "anyOf", `List [ enum_schema values; `Assoc [ "type", `String "null" ] ] ]
 ;;
 
 let object_schema ~required properties =

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -114,6 +114,46 @@ let test_all_schemas_apply_as_oas_native_json_schema () =
     all_provider_native_schema_cases
 ;;
 
+let test_librarian_claim_kind_uses_nullable_enum_union () =
+  let claim_kind_schema =
+    Keeper_structured_output_schema.librarian_episode_output_schema
+    |> schema_property Keeper_librarian.wire_field_claims
+    |> schema_items
+    |> schema_property Keeper_librarian.wire_field_claim_kind
+  in
+  let claim_kind_values =
+    Keeper_memory_os_types.librarian_claim_kinds
+    |> List.map Keeper_memory_os_types.claim_kind_to_string
+  in
+  let string_enum =
+    `Assoc
+      [ "type", `String "string"
+      ; "enum", `List (List.map (fun value -> `String value) claim_kind_values)
+      ]
+  in
+  let expected =
+    `Assoc [ "anyOf", `List [ string_enum; `Assoc [ "type", `String "null" ] ] ]
+  in
+  check
+    bool
+    "claim_kind is exactly a nullable enum union"
+    true
+    (Yojson.Safe.equal expected claim_kind_schema);
+  (* The absent value must live in its own branch. If JSON null reappears inside the
+     token list, the union has collapsed back into a shape a provider can accept and
+     silently ignore. *)
+  let string_enum_contains_json_null =
+    match schema_member "enum" string_enum with
+    | Some (`List values) -> List.exists (Yojson.Safe.equal `Null) values
+    | _ -> true
+  in
+  check
+    bool
+    "claim_kind string enum excludes JSON null"
+    false
+    string_enum_contains_json_null
+;;
+
 let has_json_schema_response_format schema provider_cfg =
   match provider_cfg.Llm_provider.Provider_config.response_format with
   | Agent_sdk.Types.JsonSchema actual -> Yojson.Safe.equal schema actual
@@ -471,6 +511,10 @@ let () =
             "all schemas apply as OAS native JSON schema requests"
             `Quick
             test_all_schemas_apply_as_oas_native_json_schema
+        ; test_case
+            "librarian claim_kind uses a nullable enum union"
+            `Quick
+            test_librarian_claim_kind_uses_nullable_enum_union
         ; test_case
             "without_response_format clears a schema-capable provider too"
             `Quick


### PR DESCRIPTION
## 무엇을

Librarian `claim_kind` 의 nullable 표현을 `type: [string, null]` + `enum: [null, ...]` 에서
exact union `anyOf: [ {string enum}, {type: null} ]` 으로 바꾼다.

`nullable_enum_schema` 의 소비자는 `claim_kind` 단 1곳이다 (`rg nullable_enum_schema lib/ test/`).

## 왜

이전 형태는 JSON `null` 을 **string enum 토큰 목록 안에** 두었다. provider 는 이걸
"null 도 허용되는 문자열 enum" 으로 읽을 수도, "null 토큰을 가진 잘못된 enum" 으로 읽을 수도 있다.
갈리는 쪽이 후자면 요청을 200 으로 받아들이면서 union 을 무시할 수 있다 — 거부가 아니라 침묵이다.

두 축이 같은 지점을 가리킨다:

- `2026-07-22-structured-output-harness-provider-capability-audit.md` §11 P1-2
  ("silent-ignore behavior is real: 200 을 반환하면서 schema 필드를 무시") 와
  §12.4 `Unsupported_schema_dialect` — dialect 는 **판정 가능한 형태**여야 한다.
- `2026-07-26-llm-judgment-lane-blueprint` "null 의미 부여 금지" (Librarian lifetime,
  LIB-DEC-01) — 부재가 도메인 토큰처럼 보이는 형태를 제거한다.

두 갈래를 구조로 분리하면 provider 는 union 을 지원하거나 거부하며, 조용히 통과시킬 여지가 없다.

## 경계

MASC 는 provider-neutral content semantics 만 선언한다. 결과 schema 의 provider/wire admission
은 OAS 소관이다. 이 PR 은 provider/model 분기, capability 조회, response_format 변경,
migration, 영속 자산 변환을 추가하지 않는다.

## 출처

`#25730` 에서 발췌했다. 그 PR 은 이 schema 수정을 OAS `v0.223.2` 핀 bump 와 묶었고,
핀 축은 `#25809` 의 `v0.226` 소비로 대체되므로 schema 축만 분리해 남긴다.

## 추가한 테스트

`librarian claim_kind uses a nullable enum union`

- exact union 구조 일치
- string enum 브랜치에 JSON `null` 부재 — union 이 다시 붕괴하면 실패

## 검증 상태 (과대평가하지 않기 위해)

| 항목 | 상태 |
|---|---|
| 테스트 **실행** | **미검증** — 아래 두 사유 |
| `ocamlformat --check` | **증거로 쓰지 않음** — 공허하다 |

**`ocamlformat --check` 는 이 저장소에서 아무것도 증명하지 않는다.** `.ocamlformat:8` 에
`disable = true` 가 있다 (RFC-0010: `profile = janestreet` 가 #10633 에서 마이그레이션 없이 들어와
~85% 파일이 clean 하지 않으므로 repo-wide 무력화). positive control 로 확인했다 — 일부러 깨뜨린
`let x=1` / `let   y  =2` 도 `--check` 가 exit 0 을 낸다. 초기 본문에 이걸 검증 항목으로 적었던 것을 철회한다.

**로컬 빌드는 opam pin drift 로 차단됐다.** `scripts/dune-local.sh` 가 abort 했다:

```
agent_sdk pin source is git+https://github.com/jeong-sik/oas.git#2186dfa5fca2360e...
expected                git+https://github.com/jeong-sik/oas.git#3d4ee19a4773cbd8...
```

이 세션 중 로컬 switch 가 최소 두 번 바뀌었다(v0.226.0 잔존 → `3d4ee19a` → `2186dfa5`). 다른 세션이
opam 을 조작 중이라 판단해 복구하지 않았다. 로컬 검증 경로는 지금 신뢰할 수 없으므로 **CI 를 유일한
컴파일 권위로 삼는다** — `#25812` 이후 `ci.yml` 의 OCaml 컴파일 지점도 `Build and Test` 단 1곳이다.

`#25819` 머지(main `7495daa853`)를 이 브랜치에 병합해 다시 밀었다. 그 실행에서
`Build and Test` 가 green 이고 위 테스트가 실제로 통과하는 것을 확인한 뒤 Ready 로 전환한다.
`Health` / `Lint` / `ocamlformat-check` pass 는 컴파일 증거가 아니다.

<details>
<summary>귀속 정정 — 처음 적었던 두 번째 blocker 는 내 오판이었다</summary>

최초 작성 시 `lib/keeper/keeper_exact_flow_scope.ml:74` 의
`Unbound value Exact_output.create_flow_preference_store` 를 함께 적고 `#25804` 로 귀속했다. 틀렸다.

- `#25804` 는 `#25810` (Revert "pin OAS v0.226.0") 로 이미 해소됐다.
- 로컬 opam 은 `agent_sdk 0.223.1` / `3d4ee19a` 로 main 핀 SSOT 와 **정확히 일치**한다.
- 설치된 `exact_output.mli:269` 에 `create_flow_preference_store` 가 **존재**한다.
- 그 파일 mtime 은 `07-27 12:00` — 내 첫 빌드 직후다. 즉 첫 빌드 시점의 switch 가
  revert 이전(v0.226.0) 상태였고, 재설치 후 같은 빌드에서 이 오류는 사라졌다.

재빌드 후 남은 오류는 `~base_path` 한 건뿐이다.
</details>

RFC-WAIVED: `lib/keeper/keeper_structured_output_schema.ml` 는 credential/identity/operator-control/sandbox/hooks 어디에도 속하지 않는 domain schema 선언이며, 기존 형태의 exact union 교정이다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
