### PR TITLE
build(deps): pin OAS v0.226.0 with its consumer migration (#25808, incomplete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.223.1-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.226.0-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.223.1`, runtime pin: `main@3d4ee19a4773cbd8b1b73ed5555c5cdfe82e6d77`, declared base version: `v0.223.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.226.0`, runtime pin: `main@2186dfa5fca2360e4e99fa5e47052ba4c0cc687f`, declared base version: `v0.226.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.223.1))
+  (agent_sdk (>= 0.226.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -198,6 +198,7 @@ let prepare_flow ~(entry : pending_approval) =
       ~base_path
       ~keeper_name
       ~surface:Keeper_exact_flow_scope.Hitl_summary
+    |> Result.map_error Keeper_exact_flow_scope.setup_error_to_string
   in
   prepare_flow_with_scope ~base_path ~keeper_name ~flow_scope ~entry
 ;;
@@ -209,36 +210,35 @@ let snapshot_topology_readiness () =
     Registry.resolve_lane registry ~lane_id
     |> Result.map_error lane_error
   in
-  let preference_store =
-    Exact_output.create_flow_preference_store ~capacity:1
-    |> Result.get_ok
+  let* preference_store =
+    Exact_output.recover_flow_preferences
+      ~concurrent_scope_budget:1
+      ~evidence:[]
+    |> Result.map_error (fun _ ->
+      "HITL topology probe could not recover its independent empty preference store")
   in
-  let scope =
+  let* scope =
     Exact_output.make_flow_scope ~id:"masc:hitl-readiness"
-    |> Result.get_ok
+    |> Result.map_error (fun Exact_output.Blank_flow_scope_id ->
+      "HITL topology probe scope identity is invalid")
   in
-  Fun.protect
-    ~finally:(fun () ->
-      ignore
-        (Exact_output.remove_flow_preference_scope preference_store scope))
-    (fun () ->
-       let* candidates = flow_candidates resolved.selected_slots in
-       match candidates with
-       | [] -> Error "HITL exact-output lane has no usable candidates"
-       | first :: rest ->
-         Exact_output.snapshot_flow
-           ~preferences:preference_store
-           ~scope
-           ~first
-           ~rest
-           ~messages:
-             (messages_for_summary
-                ~system_prompt
-                ~context_bundle:(`Assoc []))
-           output_requirement
-         |> Result.map (fun _ -> ())
-         |> Result.map_error (fun _ ->
-           "HITL exact-output readiness snapshot failed"))
+  let* candidates = flow_candidates resolved.selected_slots in
+  match candidates with
+  | [] -> Error "HITL exact-output lane has no usable candidates"
+  | first :: rest ->
+    Exact_output.snapshot_flow
+      ~preferences:preference_store
+      ~scope
+      ~first
+      ~rest
+      ~messages:
+        (messages_for_summary
+           ~system_prompt
+           ~context_bundle:(`Assoc []))
+      output_requirement
+    |> Result.map (fun _ -> ())
+    |> Result.map_error (fun _ ->
+      "HITL exact-output readiness snapshot failed")
 ;;
 
 (* ── MASC domain validation ─────────────────────── *)

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -300,6 +300,22 @@ let exact_identity_of_candidate
   }
 ;;
 
+let exact_identity_of_snapshot
+      (candidate : Exact_output.flow_attempt_snapshot)
+  =
+  let receipt = candidate.receipt in
+  { slot_id = candidate.visit.identity.candidate_id
+  ; call_id =
+      receipt
+      |> Exact_output.generation_receipt_snapshot_call_id
+      |> Exact_output.call_id_to_string
+  ; plan_fingerprint =
+      Exact_output.generation_receipt_snapshot_plan_fingerprint receipt
+  ; request_body_sha256 =
+      Exact_output.generation_receipt_snapshot_request_body_sha256 receipt
+  }
+;;
+
 let exact_identity_of_binding (binding : exact_attempt_binding) =
   { slot_id = binding.slot_id
   ; call_id = binding.call_id
@@ -787,9 +803,9 @@ let handle_flow_error (prepared : prepared_flow) = function
     record_outcome "exact_success_ordinal_exhausted";
     (match List.rev evidence.attempts with
      | candidate :: _ ->
-       quarantine_candidate
+       quarantine_identity
          prepared.entry
-         candidate
+         (exact_identity_of_snapshot candidate)
          Exact_flow_execution_failed
      | [] ->
        settle_current_or_signal

--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -198,6 +198,21 @@ let attempt_provenance
   }
 ;;
 
+let attempt_snapshot_provenance
+      (attempt : Exact_output.flow_attempt_snapshot)
+  =
+  { slot_id = attempt.visit.identity.candidate_id
+  ; call_id =
+      attempt.receipt
+      |> Exact_output.generation_receipt_snapshot_call_id
+      |> string_of_call_id
+  ; plan_fingerprint =
+      Exact_output.generation_receipt_snapshot_plan_fingerprint attempt.receipt
+  ; request_body_sha256 =
+      Exact_output.generation_receipt_snapshot_request_body_sha256 attempt.receipt
+  }
+;;
+
 let candidate_visit (visit : Exact_output.flow_candidate_visit) =
   let identity = visit.identity in
   { flow_id = Exact_output.flow_id_to_string visit.flow_id
@@ -221,7 +236,7 @@ let advance_source_of_failure = function
 ;;
 
 let evidence_provenance (evidence : Exact_output.flow_evidence) =
-  List.map attempt_provenance evidence.attempts
+  List.map attempt_snapshot_provenance evidence.attempts
 ;;
 
 let admitted_candidate candidate_id admissions =

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -471,6 +471,26 @@ let observe_flow_attempt_receipt
   }
 ;;
 
+let observe_flow_attempt_snapshot
+      (candidate : Exact_output.flow_attempt_snapshot)
+  =
+  let receipt = candidate.receipt in
+  let identity = candidate.visit.identity in
+  { slot_id = identity.candidate_id
+  ; call_id =
+      receipt
+      |> Exact_output.generation_receipt_snapshot_call_id
+      |> call_id_to_string
+  ; catalog_generation_fingerprint =
+      identity.catalog_generation
+      |> Exact_output.catalog_generation_fingerprint
+  ; receipt_plan_fingerprint =
+      Exact_output.generation_receipt_snapshot_plan_fingerprint receipt
+  ; receipt_request_body_sha256 =
+      Exact_output.generation_receipt_snapshot_request_body_sha256 receipt
+  }
+;;
+
 let terminal_of_observation cause (observation : attempt_observation) =
   Keeper_event_queue_state.
     { cause
@@ -1485,7 +1505,7 @@ module For_testing = struct
     let evidence : Exact_output.flow_evidence =
       Exact_output.flow_attempt_evidence prepared_lane.flow_attempt
     in
-    List.map observe_flow_attempt_receipt evidence.attempts
+    List.map observe_flow_attempt_snapshot evidence.attempts
   ;;
 
   let candidate_snapshot_slot_ids prepared_lane =

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -48,6 +48,8 @@ let network_error_kind_to_wire = function
 let invalid_request_reason_to_wire = function
   | Agent_sdk.Retry.Json_parse_error -> "json_parse_error"
   | Agent_sdk.Retry.Request_body_too_large _ -> "request_body_too_large"
+  | Agent_sdk.Retry.Request_body_refused_by_provider _ ->
+    "request_body_refused_by_provider"
   | Agent_sdk.Retry.Unknown_invalid_request -> "unknown_invalid_request"
 ;;
 
@@ -178,6 +180,8 @@ let sdk_api_error_fields = function
          [ "actual_bytes", `Int actual_bytes
          ; "limit_bytes", `Int limit_bytes
          ]
+       | Agent_sdk.Retry.Request_body_refused_by_provider { status } ->
+         [ "status", `Int status ]
        | Agent_sdk.Retry.Json_parse_error
        | Agent_sdk.Retry.Unknown_invalid_request -> [])
   | Agent_sdk.Retry.NotFound { message } ->

--- a/lib/keeper/keeper_exact_flow_evidence_journal.ml
+++ b/lib/keeper/keeper_exact_flow_evidence_journal.ml
@@ -1,0 +1,537 @@
+module Exact_output = Agent_sdk.Exact_output
+
+type evidence_kind =
+  | Domain_settlement
+  | Scope_retirement
+
+type recovery_origin =
+  | Fresh_start
+  | Recovered of { evidence_count : int }
+
+type evidence_decode_error =
+  | Invalid_domain_settlement_intent of
+      { index : int
+      ; cause : Exact_output.domain_settlement_intent_decode_error
+      }
+  | Invalid_scope_retirement_intent of
+      { index : int
+      ; cause : Exact_output.flow_preference_retirement_intent_decode_error
+      }
+
+type journal_decode_error =
+  | Journal_malformed_json of string
+  | Journal_invalid_fields
+  | Journal_unknown_format of string
+  | Journal_unsupported_version of int
+  | Journal_invalid_field of string
+  | Journal_owner_mismatch of string
+  | Journal_unknown_evidence_kind of
+      { index : int
+      ; kind : string
+      }
+  | Journal_invalid_evidence of evidence_decode_error
+  | Journal_integrity_mismatch
+
+type load_error =
+  | Invalid_owner_identity of string
+  | Journal_read_failed of
+      { path : string
+      ; detail : string
+      }
+  | Journal_decode_failed of
+      { path : string
+      ; cause : journal_decode_error
+      }
+  | Journal_initialize_failed of
+      { path : string
+      ; cause : Keeper_fs.durable_write_error
+      }
+  | Preference_recovery_failed of Exact_output.flow_preference_recovery_error
+
+type commit_error =
+  | Evidence_conflict of
+      { kind : evidence_kind
+      ; evidence_id : string
+      }
+  | Evidence_write_failed of Keeper_fs.durable_write_error
+
+type identity =
+  { keeper_name : string
+  ; keeper_generation : string
+  ; surface : string
+  }
+
+type evidence =
+  | Domain_settlement_evidence of
+      { intent : Exact_output.domain_settlement_intent
+      ; encoded : string
+      }
+  | Scope_retirement_evidence of
+      { intent : Exact_output.flow_preference_retirement_intent
+      ; encoded : string
+      }
+
+type durable_writer =
+  on_durable_commit:(unit -> unit)
+  -> ownership_root:string
+  -> path:string
+  -> bytes:string
+  -> (Keeper_fs.durable_commit_outcome, Keeper_fs.durable_write_error) result
+
+type t =
+  { identity : identity
+  ; ownership_root : string
+  ; path : string
+  ; durable_write : durable_writer
+  ; mutex : Eio.Mutex.t
+  ; mutable evidence : evidence list
+  }
+
+let ( let* ) = Result.bind
+let journal_format = "masc.keeper-exact-flow-preference-evidence-journal"
+let journal_version = 1
+let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let evidence_kind_to_string = function
+  | Domain_settlement -> "domain_settlement"
+  | Scope_retirement -> "scope_retirement"
+;;
+
+let evidence_kind = function
+  | Domain_settlement_evidence _ -> Domain_settlement
+  | Scope_retirement_evidence _ -> Scope_retirement
+;;
+
+let evidence_encoded = function
+  | Domain_settlement_evidence { encoded; _ }
+  | Scope_retirement_evidence { encoded; _ } -> encoded
+;;
+
+let evidence_id = function
+  | Domain_settlement_evidence { intent; _ } ->
+    Exact_output.domain_settlement_intent_id intent
+    |> Exact_output.domain_settlement_id_to_string
+  | Scope_retirement_evidence { intent; _ } ->
+    Exact_output.flow_preference_retirement_intent_id intent
+    |> Exact_output.flow_preference_retirement_id_to_string
+;;
+
+let recovery_evidence = function
+  | Domain_settlement_evidence { intent; _ } ->
+    Exact_output.Domain_settlement_evidence intent
+  | Scope_retirement_evidence { intent; _ } ->
+    Exact_output.Scope_retirement_evidence intent
+;;
+
+let evidence_to_json evidence =
+  `Assoc
+    [ "kind", `String (evidence_kind evidence |> evidence_kind_to_string)
+    ; "intent", `String (evidence_encoded evidence)
+    ]
+;;
+
+let payload_fields identity evidence =
+  [ "format", `String journal_format
+  ; "version", `Int journal_version
+  ; "keeper_name", `String identity.keeper_name
+  ; "keeper_generation", `String identity.keeper_generation
+  ; "surface", `String identity.surface
+  ; "evidence", `List (List.map evidence_to_json evidence)
+  ]
+;;
+
+let encode_document identity evidence =
+  let payload = payload_fields identity evidence in
+  let integrity_sha256 = `Assoc payload |> Yojson.Safe.to_string |> sha256 in
+  `Assoc (payload @ [ "integrity_sha256", `String integrity_sha256 ])
+  |> Yojson.Safe.to_string
+;;
+
+let expected_document_fields =
+  [ "format"
+  ; "version"
+  ; "keeper_name"
+  ; "keeper_generation"
+  ; "surface"
+  ; "evidence"
+  ; "integrity_sha256"
+  ]
+;;
+
+let exact_fields expected fields =
+  List.map fst fields |> List.sort String.compare
+  = List.sort String.compare expected
+;;
+
+let find_field fields name =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Journal_invalid_field name)
+;;
+
+let string_field fields name =
+  let* value = find_field fields name in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Journal_invalid_field name)
+;;
+
+let decode_evidence index = function
+  | `Assoc fields when exact_fields [ "kind"; "intent" ] fields ->
+    let* kind = string_field fields "kind" in
+    let* encoded = string_field fields "intent" in
+    (match kind with
+     | "domain_settlement" ->
+       (match Exact_output.domain_settlement_intent_of_string encoded with
+        | Ok intent -> Ok (Domain_settlement_evidence { intent; encoded })
+        | Error cause ->
+          Error
+            (Journal_invalid_evidence
+               (Invalid_domain_settlement_intent { index; cause })))
+     | "scope_retirement" ->
+       (match Exact_output.flow_preference_retirement_intent_of_string encoded with
+        | Ok intent -> Ok (Scope_retirement_evidence { intent; encoded })
+        | Error cause ->
+          Error
+            (Journal_invalid_evidence
+               (Invalid_scope_retirement_intent { index; cause })))
+     | kind -> Error (Journal_unknown_evidence_kind { index; kind }))
+  | `Assoc _
+  | _ -> Error (Journal_invalid_field (Printf.sprintf "evidence[%d]" index))
+;;
+
+let decode_document identity encoded =
+  try
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields when exact_fields expected_document_fields fields ->
+      let* format = string_field fields "format" in
+      let* () =
+        if String.equal format journal_format
+        then Ok ()
+        else Error (Journal_unknown_format format)
+      in
+      let* version = find_field fields "version" in
+      let* () =
+        match version with
+        | `Int version when version = journal_version -> Ok ()
+        | `Int version -> Error (Journal_unsupported_version version)
+        | _ -> Error (Journal_invalid_field "version")
+      in
+      let* keeper_name = string_field fields "keeper_name" in
+      let* keeper_generation = string_field fields "keeper_generation" in
+      let* surface = string_field fields "surface" in
+      let* () =
+        if String.equal keeper_name identity.keeper_name
+        then Ok ()
+        else Error (Journal_owner_mismatch "keeper_name")
+      in
+      let* () =
+        if String.equal keeper_generation identity.keeper_generation
+        then Ok ()
+        else Error (Journal_owner_mismatch "keeper_generation")
+      in
+      let* () =
+        if String.equal surface identity.surface
+        then Ok ()
+        else Error (Journal_owner_mismatch "surface")
+      in
+      let* evidence_json = find_field fields "evidence" in
+      let* evidence =
+        match evidence_json with
+        | `List values ->
+          let rec loop index decoded = function
+            | [] -> Ok (List.rev decoded)
+            | value :: rest ->
+              let* evidence = decode_evidence index value in
+              loop (index + 1) (evidence :: decoded) rest
+          in
+          loop 0 [] values
+        | _ -> Error (Journal_invalid_field "evidence")
+      in
+      let* integrity_sha256 = string_field fields "integrity_sha256" in
+      let expected_integrity =
+        payload_fields identity evidence
+        |> fun payload -> `Assoc payload
+        |> Yojson.Safe.to_string
+        |> sha256
+      in
+      if String.equal integrity_sha256 expected_integrity
+      then Ok evidence
+      else Error Journal_integrity_mismatch
+    | `Assoc _ | _ -> Error Journal_invalid_fields
+  with
+  | Yojson.Json_error detail -> Error (Journal_malformed_json detail)
+;;
+
+let journal_path ~base_path identity =
+  let identity_digest =
+    String.concat
+      "\000"
+      [ identity.keeper_name; identity.keeper_generation; identity.surface ]
+    |> sha256
+  in
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       ".exact-flow-preferences")
+    (identity_digest ^ ".journal.json")
+;;
+
+let production_durable_write ~on_durable_commit ~ownership_root ~path ~bytes =
+  Keeper_fs.save_bytes_durable_atomic_observed
+    ~on_durable_commit
+    ~ownership_root
+    path
+    bytes
+;;
+
+let write_document journal evidence =
+  let bytes = encode_document journal.identity evidence in
+  match
+    journal.durable_write
+      ~on_durable_commit:(fun () -> journal.evidence <- evidence)
+      ~ownership_root:journal.ownership_root
+      ~path:journal.path
+      ~bytes
+  with
+  | Ok Keeper_fs.Committed -> Ok ()
+  | Ok (Keeper_fs.Committed_but_observer_failed (exn, backtrace)) ->
+    Printexc.raise_with_backtrace exn backtrace
+  | Error cause -> Error (Evidence_write_failed cause)
+;;
+
+let append journal next =
+  Eio_guard.with_mutex journal.mutex (fun () ->
+    let next_kind = evidence_kind next in
+    let next_id = evidence_id next in
+    let existing =
+      List.find_opt
+        (fun current ->
+           evidence_kind current = next_kind
+           && String.equal (evidence_id current) next_id)
+        journal.evidence
+    in
+    match existing with
+    | Some current
+      when String.equal (evidence_encoded current) (evidence_encoded next) -> Ok ()
+    | Some _ ->
+      Error (Evidence_conflict { kind = next_kind; evidence_id = next_id })
+    | None -> write_document journal (journal.evidence @ [ next ]))
+;;
+
+let commit_domain_settlement journal intent =
+  append
+    journal
+    (Domain_settlement_evidence
+       { intent; encoded = Exact_output.domain_settlement_intent_to_string intent })
+;;
+
+let commit_scope_retirement journal intent =
+  append
+    journal
+    (Scope_retirement_evidence
+       { intent
+       ; encoded = Exact_output.flow_preference_retirement_intent_to_string intent
+       })
+;;
+
+let read_file path =
+  try
+    Eio_guard.run_in_systhread (fun () ->
+      if not (Sys.file_exists path)
+      then Ok None
+      else
+        let channel = open_in_bin path in
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr channel)
+          (fun () ->
+             let length = in_channel_length channel in
+             Ok (Some (really_input_string channel length))))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let valid_identity_field value = not (String.equal (String.trim value) "")
+
+let initialize_current_journal journal =
+  let bytes = encode_document journal.identity [] in
+  match
+    journal.durable_write
+      ~on_durable_commit:(fun () -> journal.evidence <- [])
+      ~ownership_root:journal.ownership_root
+      ~path:journal.path
+      ~bytes
+  with
+  | Ok Keeper_fs.Committed -> Ok ()
+  | Ok (Keeper_fs.Committed_but_observer_failed (exn, backtrace)) ->
+    Printexc.raise_with_backtrace exn backtrace
+  | Error cause ->
+    Error (Journal_initialize_failed { path = journal.path; cause })
+;;
+
+let recover_with
+      ~durable_write
+      ~base_path
+      ~keeper_name
+      ~keeper_generation
+      ~surface
+      ~concurrent_scope_budget
+  =
+  let identity = { keeper_name; keeper_generation; surface } in
+  let invalid_identity =
+    if not (valid_identity_field keeper_name)
+    then Some "keeper_name"
+    else if not (valid_identity_field keeper_generation)
+    then Some "keeper_generation"
+    else if not (valid_identity_field surface)
+    then Some "surface"
+    else None
+  in
+  match invalid_identity with
+  | Some field -> Error (Invalid_owner_identity field)
+  | None ->
+    let path = journal_path ~base_path identity in
+    let ownership_root = Common.masc_dir_from_base_path ~base_path in
+    let* stored =
+      read_file path
+      |> Result.map_error (fun detail -> Journal_read_failed { path; detail })
+    in
+    let* evidence, origin =
+      match stored with
+      | Some encoded ->
+        let* evidence =
+          decode_document identity encoded
+          |> Result.map_error (fun cause -> Journal_decode_failed { path; cause })
+        in
+        Ok (evidence, Recovered { evidence_count = List.length evidence })
+      | None -> Ok ([], Fresh_start)
+    in
+    let journal =
+      { identity
+      ; ownership_root
+      ; path
+      ; durable_write
+      ; mutex = Eio.Mutex.create ()
+      ; evidence
+      }
+    in
+    let* () =
+      match origin with
+      | Recovered _ -> Ok ()
+      | Fresh_start -> initialize_current_journal journal
+    in
+    let* preference_store =
+      Exact_output.recover_flow_preferences
+        ~concurrent_scope_budget
+        ~evidence:(List.map recovery_evidence journal.evidence)
+      |> Result.map_error (fun cause -> Preference_recovery_failed cause)
+    in
+    Ok (journal, preference_store, origin)
+;;
+
+let recover =
+  recover_with ~durable_write:production_durable_write
+;;
+
+let path journal = journal.path
+let evidence_count journal = List.length journal.evidence
+
+let domain_decode_error_to_string = function
+  | Exact_output.Domain_settlement_intent_malformed_json detail ->
+    "malformed JSON: " ^ detail
+  | Exact_output.Domain_settlement_intent_invalid_fields -> "invalid fields"
+  | Exact_output.Domain_settlement_intent_unknown_format format ->
+    "unknown format: " ^ format
+  | Exact_output.Domain_settlement_intent_unsupported_version version ->
+    Printf.sprintf "unsupported version: %d" version
+  | Exact_output.Domain_settlement_intent_invalid_field field ->
+    "invalid field: " ^ field
+  | Exact_output.Domain_settlement_intent_integrity_mismatch ->
+    "integrity mismatch"
+;;
+
+let retirement_decode_error_to_string = function
+  | Exact_output.Flow_preference_retirement_intent_malformed_json detail ->
+    "malformed JSON: " ^ detail
+  | Exact_output.Flow_preference_retirement_intent_invalid_fields -> "invalid fields"
+  | Exact_output.Flow_preference_retirement_intent_unknown_format format ->
+    "unknown format: " ^ format
+  | Exact_output.Flow_preference_retirement_intent_unsupported_version version ->
+    Printf.sprintf "unsupported version: %d" version
+  | Exact_output.Flow_preference_retirement_intent_invalid_field field ->
+    "invalid field: " ^ field
+  | Exact_output.Flow_preference_retirement_intent_integrity_mismatch ->
+    "integrity mismatch"
+;;
+
+let journal_decode_error_to_string = function
+  | Journal_malformed_json detail -> "malformed journal JSON: " ^ detail
+  | Journal_invalid_fields -> "journal has invalid fields"
+  | Journal_unknown_format format -> "journal has unknown format: " ^ format
+  | Journal_unsupported_version version ->
+    Printf.sprintf "journal has unsupported version: %d" version
+  | Journal_invalid_field field -> "journal has invalid field: " ^ field
+  | Journal_owner_mismatch field -> "journal owner mismatch: " ^ field
+  | Journal_unknown_evidence_kind { index; kind } ->
+    Printf.sprintf "journal evidence[%d] has unknown kind: %s" index kind
+  | Journal_invalid_evidence
+      (Invalid_domain_settlement_intent { index; cause }) ->
+    Printf.sprintf
+      "journal evidence[%d] domain settlement is invalid: %s"
+      index
+      (domain_decode_error_to_string cause)
+  | Journal_invalid_evidence
+      (Invalid_scope_retirement_intent { index; cause }) ->
+    Printf.sprintf
+      "journal evidence[%d] scope retirement is invalid: %s"
+      index
+      (retirement_decode_error_to_string cause)
+  | Journal_integrity_mismatch -> "journal complete-evidence integrity mismatch"
+;;
+
+let recovery_error_to_string = function
+  | Exact_output.Invalid_concurrent_scope_budget budget ->
+    Printf.sprintf "invalid concurrent scope budget: %d" budget
+  | Exact_output.Conflicting_domain_settlement_evidence id ->
+    "conflicting domain settlement evidence: "
+    ^ Exact_output.domain_settlement_id_to_string id
+  | Exact_output.Conflicting_scope_retirement_evidence id ->
+    "conflicting scope retirement evidence: "
+    ^ Exact_output.flow_preference_retirement_id_to_string id
+;;
+
+let load_error_to_string = function
+  | Invalid_owner_identity field -> "invalid exact-flow owner identity: " ^ field
+  | Journal_read_failed { path; detail } ->
+    Printf.sprintf "cannot read exact-flow evidence journal %s: %s" path detail
+  | Journal_decode_failed { path; cause } ->
+    Printf.sprintf
+      "cannot decode exact-flow evidence journal %s: %s"
+      path
+      (journal_decode_error_to_string cause)
+  | Journal_initialize_failed { path; cause } ->
+    Printf.sprintf
+      "cannot initialize exact-flow evidence journal %s: %s"
+      path
+      (Keeper_fs.durable_write_error_to_string cause)
+  | Preference_recovery_failed cause ->
+    "OAS exact-flow preference recovery failed: " ^ recovery_error_to_string cause
+;;
+
+let commit_error_to_string = function
+  | Evidence_conflict { kind; evidence_id } ->
+    Printf.sprintf
+      "conflicting %s evidence id=%s"
+      (evidence_kind_to_string kind)
+      evidence_id
+  | Evidence_write_failed cause ->
+    "exact-flow evidence durable write failed: "
+    ^ Keeper_fs.durable_write_error_to_string cause
+;;
+
+module For_testing = struct
+  type nonrec durable_writer = durable_writer
+
+  let recover = recover_with
+end

--- a/lib/keeper/keeper_exact_flow_evidence_journal.mli
+++ b/lib/keeper/keeper_exact_flow_evidence_journal.mli
@@ -1,0 +1,106 @@
+(** Current-schema-only durable OAS exact-flow preference evidence.
+
+    One journal is bound to exactly one Keeper generation and execution
+    surface. The complete owner-bound evidence set is integrity checked before
+    any OAS preference store is recovered. *)
+
+module Exact_output = Agent_sdk.Exact_output
+
+type evidence_kind =
+  | Domain_settlement
+  | Scope_retirement
+
+type recovery_origin =
+  | Fresh_start
+  | Recovered of { evidence_count : int }
+
+type evidence_decode_error =
+  | Invalid_domain_settlement_intent of
+      { index : int
+      ; cause : Exact_output.domain_settlement_intent_decode_error
+      }
+  | Invalid_scope_retirement_intent of
+      { index : int
+      ; cause : Exact_output.flow_preference_retirement_intent_decode_error
+      }
+
+type journal_decode_error =
+  | Journal_malformed_json of string
+  | Journal_invalid_fields
+  | Journal_unknown_format of string
+  | Journal_unsupported_version of int
+  | Journal_invalid_field of string
+  | Journal_owner_mismatch of string
+  | Journal_unknown_evidence_kind of
+      { index : int
+      ; kind : string
+      }
+  | Journal_invalid_evidence of evidence_decode_error
+  | Journal_integrity_mismatch
+
+type load_error =
+  | Invalid_owner_identity of string
+  | Journal_read_failed of
+      { path : string
+      ; detail : string
+      }
+  | Journal_decode_failed of
+      { path : string
+      ; cause : journal_decode_error
+      }
+  | Journal_initialize_failed of
+      { path : string
+      ; cause : Keeper_fs.durable_write_error
+      }
+  | Preference_recovery_failed of Exact_output.flow_preference_recovery_error
+
+type commit_error =
+  | Evidence_conflict of
+      { kind : evidence_kind
+      ; evidence_id : string
+      }
+  | Evidence_write_failed of Keeper_fs.durable_write_error
+
+type t
+
+val recover
+  :  base_path:string
+  -> keeper_name:string
+  -> keeper_generation:string
+  -> surface:string
+  -> concurrent_scope_budget:int
+  -> (t * Exact_output.flow_preference_store * recovery_origin, load_error) result
+
+val path : t -> string
+val evidence_count : t -> int
+
+val commit_domain_settlement
+  :  t
+  -> Exact_output.domain_settlement_intent
+  -> (unit, commit_error) result
+
+val commit_scope_retirement
+  :  t
+  -> Exact_output.flow_preference_retirement_intent
+  -> (unit, commit_error) result
+
+val load_error_to_string : load_error -> string
+val commit_error_to_string : commit_error -> string
+
+module For_testing : sig
+  type durable_writer =
+    on_durable_commit:(unit -> unit)
+    -> ownership_root:string
+    -> path:string
+    -> bytes:string
+    -> (Keeper_fs.durable_commit_outcome, Keeper_fs.durable_write_error) result
+
+  val recover
+    :  durable_write:durable_writer
+    -> base_path:string
+    -> keeper_name:string
+    -> keeper_generation:string
+    -> surface:string
+    -> concurrent_scope_budget:int
+    -> (t * Exact_output.flow_preference_store * recovery_origin, load_error) result
+end

--- a/lib/keeper/keeper_exact_flow_scope.ml
+++ b/lib/keeper/keeper_exact_flow_scope.ml
@@ -1,10 +1,31 @@
 module Exact_output = Agent_sdk.Exact_output
+module Evidence_journal = Keeper_exact_flow_evidence_journal
 
 type surface =
   | Compaction
   | Board_attention
   | Hitl_summary
   | Librarian
+
+type evidence_commit_error = Evidence_journal.commit_error
+
+type setup_error =
+  | Owner_not_registered of { keeper_name : string }
+  | Owner_draining of { keeper_name : string }
+  | Evidence_recovery_blocked of
+      { surface : surface
+      ; cause : Evidence_journal.load_error
+      }
+  | Scope_identity_invalid of { surface : surface }
+
+type release_error =
+  | Retirement_deferred
+  | Retirement_commit_failed of
+      { surface : surface
+      ; cause : evidence_commit_error
+      }
+  | Retirement_in_progress of { surface : surface }
+  | Retirement_conflict of { surface : surface }
 
 type librarian_execution_slot =
   { mutable capacity : int
@@ -30,6 +51,8 @@ type owner_state =
 
 type t =
   { owner : owner_state
+  ; surface : surface
+  ; evidence_journal : Evidence_journal.t
   ; preference_store : Exact_output.flow_preference_store
   ; scope : Exact_output.flow_scope
   }
@@ -51,6 +74,8 @@ type owner =
   ; librarian : t
   }
 
+let ( let* ) = Result.bind
+
 let surface_label = function
   | Compaction -> "compaction"
   | Board_attention -> "board_attention"
@@ -58,27 +83,90 @@ let surface_label = function
   | Librarian -> "librarian"
 ;;
 
+let setup_error_to_string = function
+  | Owner_not_registered { keeper_name } ->
+    Printf.sprintf "exact-flow owner is not registered: keeper=%s" keeper_name
+  | Owner_draining { keeper_name } ->
+    Printf.sprintf "exact-flow owner is draining: keeper=%s" keeper_name
+  | Evidence_recovery_blocked { surface; cause } ->
+    Printf.sprintf
+      "exact-flow evidence recovery blocked: surface=%s cause=%s"
+      (surface_label surface)
+      (Evidence_journal.load_error_to_string cause)
+  | Scope_identity_invalid { surface } ->
+    Printf.sprintf "exact-flow scope identity is invalid: surface=%s" (surface_label surface)
+;;
+
+let evidence_commit_error_to_string = Evidence_journal.commit_error_to_string
+
+let release_error_to_string = function
+  | Retirement_deferred -> "exact-flow retirement is waiting for bound work"
+  | Retirement_commit_failed { surface; cause } ->
+    Printf.sprintf
+      "exact-flow retirement commit failed: surface=%s cause=%s"
+      (surface_label surface)
+      (evidence_commit_error_to_string cause)
+  | Retirement_in_progress { surface } ->
+    Printf.sprintf
+      "exact-flow retirement is already in progress: surface=%s"
+      (surface_label surface)
+  | Retirement_conflict { surface } ->
+    Printf.sprintf
+      "exact-flow retirement conflicted: surface=%s"
+      (surface_label surface)
+;;
+
+let owners : (string, owner) Hashtbl.t = Hashtbl.create 16
+let owners_mu = Stdlib.Mutex.create ()
+
+let owner_key ~base_path ~keeper_name =
+  Keeper_registry_types.registry_key ~base_path keeper_name
+;;
+
+let owner_fingerprint state surface =
+  String.concat
+    "\000"
+    [ state.base_path
+    ; state.keeper_name
+    ; Keeper_lane.Id.to_string state.lane_id
+    ; surface_label surface
+    ]
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
 let create_scope state surface =
-  let owner_fingerprint =
-    String.concat
-      "\000"
-      [ state.base_path
-      ; state.keeper_name
-      ; Keeper_lane.Id.to_string state.lane_id
-      ; surface_label surface
-      ]
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
+  let* evidence_journal, preference_store, recovery_origin =
+    Evidence_journal.recover
+      ~base_path:state.base_path
+      ~keeper_name:state.keeper_name
+      ~keeper_generation:(Keeper_lane.Id.to_string state.lane_id)
+      ~surface:(surface_label surface)
+      ~concurrent_scope_budget:1
+    |> Result.map_error (fun cause -> Evidence_recovery_blocked { surface; cause })
   in
-  let preference_store =
-    Exact_output.create_flow_preference_store ~capacity:1
-    |> Result.get_ok
+  (match recovery_origin with
+   | Evidence_journal.Fresh_start ->
+     Log.Keeper.warn
+       "exact-flow current evidence was absent; initialized explicit fresh state keeper=%s generation=%s surface=%s journal=%s"
+       state.keeper_name
+       (Keeper_lane.Id.to_string state.lane_id)
+       (surface_label surface)
+       (Evidence_journal.path evidence_journal)
+   | Evidence_journal.Recovered { evidence_count } ->
+     Log.Keeper.info
+       "exact-flow recovered authenticated current evidence keeper=%s generation=%s surface=%s evidence_count=%d journal=%s"
+       state.keeper_name
+       (Keeper_lane.Id.to_string state.lane_id)
+       (surface_label surface)
+       evidence_count
+       (Evidence_journal.path evidence_journal));
+  let* scope =
+    Exact_output.make_flow_scope ~id:("masc:" ^ owner_fingerprint state surface)
+    |> Result.map_error (fun Exact_output.Blank_flow_scope_id ->
+      Scope_identity_invalid { surface })
   in
-  let scope =
-    Exact_output.make_flow_scope ~id:("masc:" ^ owner_fingerprint)
-    |> Result.get_ok
-  in
-  { owner = state; preference_store; scope }
+  Ok { owner = state; surface; evidence_journal; preference_store; scope }
 ;;
 
 let create_owner ~base_path ~keeper_name ~lane_id =
@@ -94,12 +182,11 @@ let create_owner ~base_path ~keeper_name ~lane_id =
     ; librarian_execution_slot_mu = Eio.Mutex.create ()
     }
   in
-  { state
-  ; compaction = create_scope state Compaction
-  ; board_attention = create_scope state Board_attention
-  ; hitl_summary = create_scope state Hitl_summary
-  ; librarian = create_scope state Librarian
-  }
+  let* compaction = create_scope state Compaction in
+  let* board_attention = create_scope state Board_attention in
+  let* hitl_summary = create_scope state Hitl_summary in
+  let* librarian = create_scope state Librarian in
+  Ok { state; compaction; board_attention; hitl_summary; librarian }
 ;;
 
 let surface_scope owner = function
@@ -109,57 +196,105 @@ let surface_scope owner = function
   | Librarian -> owner.librarian
 ;;
 
-let owners : (string, owner) Hashtbl.t = Hashtbl.create 16
-let owners_mu = Stdlib.Mutex.create ()
-
-let owner_key ~base_path ~keeper_name =
-  Keeper_registry_types.registry_key ~base_path keeper_name
+let commit_domain_settlement_intent scope intent =
+  match Evidence_journal.commit_domain_settlement scope.evidence_journal intent with
+  | Ok () -> Ok ()
+  | Error cause as error ->
+    Log.Keeper.error
+      "exact-flow domain evidence commit blocked keeper=%s generation=%s surface=%s cause=%s"
+      scope.owner.keeper_name
+      (Keeper_lane.Id.to_string scope.owner.lane_id)
+      (surface_label scope.surface)
+      (evidence_commit_error_to_string cause);
+    error
 ;;
 
 let release_scope scope =
-  ignore
-    (Exact_output.remove_flow_preference_scope
-       scope.preference_store
-       scope.scope)
+  match
+    Exact_output.commit_and_retire_flow_preference_scope
+      ~commit:(Evidence_journal.commit_scope_retirement scope.evidence_journal)
+      scope.preference_store
+      scope.scope
+  with
+  | Ok _ | Error Exact_output.Flow_preference_scope_not_reserved -> Ok ()
+  | Error (Exact_output.Flow_preference_retirement_commit_failed cause) ->
+    Error (Retirement_commit_failed { surface = scope.surface; cause })
+  | Error Exact_output.Flow_preference_retirement_in_progress ->
+    Error (Retirement_in_progress { surface = scope.surface })
+  | Error Exact_output.Flow_preference_retirement_conflict ->
+    Error (Retirement_conflict { surface = scope.surface })
 ;;
 
 let release_owner_scopes owner =
-  release_scope owner.compaction;
-  release_scope owner.board_attention;
-  release_scope owner.hitl_summary;
+  let* () = release_scope owner.compaction in
+  let* () = release_scope owner.board_attention in
+  let* () = release_scope owner.hitl_summary in
   release_scope owner.librarian
 ;;
 
+let remove_owner_binding owner =
+  let key =
+    owner_key
+      ~base_path:owner.state.base_path
+      ~keeper_name:owner.state.keeper_name
+  in
+  Stdlib.Mutex.protect owners_mu (fun () ->
+    match Hashtbl.find_opt owners key with
+    | Some current when current == owner -> Hashtbl.remove owners key
+    | Some _ | None -> ())
+;;
+
+let finish_owner_retirement owner =
+  match release_owner_scopes owner with
+  | Ok () ->
+    Stdlib.Mutex.protect owner.state.boundary_mu (fun () ->
+      Atomic.set owner.state.phase Retired);
+    remove_owner_binding owner;
+    Ok ()
+  | Error cause as error ->
+    Log.Keeper.error
+      "exact-flow owner retirement blocked keeper=%s generation=%s cause=%s"
+      owner.state.keeper_name
+      (Keeper_lane.Id.to_string owner.state.lane_id)
+      (release_error_to_string cause);
+    error
+;;
+
 let retire_owner owner =
-  let release_now =
+  let action =
     Stdlib.Mutex.protect owner.state.boundary_mu (fun () ->
       match Atomic.get owner.state.phase with
-      | Retired -> false
+      | Retired -> `Released
       | Active
       | Draining ->
-        Atomic.set owner.state.phase Retired;
+        Atomic.set owner.state.phase Draining;
         if owner.state.boundary_users = 0
-        then true
+        then `Release_now
         else (
-          owner.state.deferred_release <-
-            Some (fun () -> release_owner_scopes owner);
-          false))
+          if Option.is_none owner.state.deferred_release
+          then
+            owner.state.deferred_release <-
+              Some (fun () -> ignore (finish_owner_retirement owner));
+          `Deferred))
   in
-  if release_now then release_owner_scopes owner
+  match action with
+  | `Released -> Ok `Released
+  | `Deferred -> Ok `Deferred
+  | `Release_now -> Result.map (fun () -> `Released) (finish_owner_retirement owner)
+;;
+
+let note_retirement_result = function
+  | Ok _ -> ()
+  | Error cause ->
+    Log.Keeper.error
+      "exact-flow detached owner remains blocked: %s"
+      (release_error_to_string cause)
 ;;
 
 let for_registered ~registered_lane_id ~base_path ~keeper_name ~surface =
   let key = owner_key ~base_path ~keeper_name in
-  let unavailable () =
-    Printf.sprintf
-      "exact-flow owner is not registered: keeper=%s"
-      keeper_name
-  in
-  let draining () =
-    Printf.sprintf
-      "exact-flow owner is draining: keeper=%s"
-      keeper_name
-  in
+  let unavailable () = Owner_not_registered { keeper_name } in
+  let draining () = Owner_draining { keeper_name } in
   let initial =
     Keeper_lifecycle_reservation.with_key_lock
       ~base_path
@@ -182,47 +317,57 @@ let for_registered ~registered_lane_id ~base_path ~keeper_name ~surface =
                `Create lane_id))
   in
   match initial with
-  | `Error detail -> Error detail
+  | `Error cause -> Error cause
   | `Existing owner -> Ok (surface_scope owner surface)
   | `Create lane_id ->
-    let candidate = create_owner ~base_path ~keeper_name ~lane_id in
-    let installed =
-      Keeper_lifecycle_reservation.with_key_lock
-        ~base_path
-        ~keeper_name
-        (fun () ->
-           match registered_lane_id () with
-           | Some current_lane_id
-             when Keeper_lane.Id.equal current_lane_id lane_id ->
-             Stdlib.Mutex.protect owners_mu (fun () ->
-               match Hashtbl.find_opt owners key with
-               | Some owner
-                 when Atomic.get owner.state.phase = Active
-                      && Keeper_lane.Id.equal owner.state.lane_id lane_id ->
-                 `Existing owner
-               | Some owner
-                 when Keeper_lane.Id.equal owner.state.lane_id lane_id ->
-                 `Error (draining ())
-               | Some stale ->
-                 Hashtbl.replace owners key candidate;
-                 `Installed (candidate, Some stale)
-               | None ->
-                 Hashtbl.add owners key candidate;
-                 `Installed (candidate, None))
-           | Some _
-           | None ->
-             `Error (unavailable ()))
-    in
-    (match installed with
-     | `Existing owner ->
-       retire_owner candidate;
-       Ok (surface_scope owner surface)
-     | `Installed (owner, stale) ->
-       Option.iter retire_owner stale;
-       Ok (surface_scope owner surface)
-     | `Error detail ->
-       retire_owner candidate;
-       Error detail)
+    (match create_owner ~base_path ~keeper_name ~lane_id with
+     | Error cause ->
+       Log.Keeper.error
+         "exact-flow owner recovery blocked while Keeper lifecycle remains registered keeper=%s generation=%s cause=%s"
+         keeper_name
+         (Keeper_lane.Id.to_string lane_id)
+         (setup_error_to_string cause);
+       Error cause
+     | Ok candidate ->
+       let installed =
+         Keeper_lifecycle_reservation.with_key_lock
+           ~base_path
+           ~keeper_name
+           (fun () ->
+              match registered_lane_id () with
+              | Some current_lane_id
+                when Keeper_lane.Id.equal current_lane_id lane_id ->
+                Stdlib.Mutex.protect owners_mu (fun () ->
+                  match Hashtbl.find_opt owners key with
+                  | Some owner
+                    when Atomic.get owner.state.phase = Active
+                         && Keeper_lane.Id.equal owner.state.lane_id lane_id ->
+                    `Existing owner
+                  | Some owner
+                    when Keeper_lane.Id.equal owner.state.lane_id lane_id ->
+                    `Error (draining ())
+                  | Some stale ->
+                    Hashtbl.replace owners key candidate;
+                    `Installed (candidate, Some stale)
+                  | None ->
+                    Hashtbl.add owners key candidate;
+                    `Installed (candidate, None))
+              | Some _
+              | None ->
+                `Error (unavailable ()))
+       in
+       match installed with
+       | `Existing owner ->
+         retire_owner candidate |> note_retirement_result;
+         Ok (surface_scope owner surface)
+       | `Installed (owner, stale) ->
+         Option.iter
+           (fun stale -> retire_owner stale |> note_retirement_result)
+           stale;
+         Ok (surface_scope owner surface)
+       | `Error cause ->
+         retire_owner candidate |> note_retirement_result;
+         Error cause)
 ;;
 
 let preference_store scope = scope.preference_store
@@ -333,18 +478,23 @@ let begin_retirement ~base_path ~keeper_name ~expected_lane_id =
 
 let release_owner ~base_path ~keeper_name ~expected_lane_id =
   let key = owner_key ~base_path ~keeper_name in
-  let removed =
+  let owner =
     Stdlib.Mutex.protect owners_mu (fun () ->
       match Hashtbl.find_opt owners key with
       | Some owner
         when Keeper_lane.Id.equal owner.state.lane_id expected_lane_id ->
-        Hashtbl.remove owners key;
         Some owner
       | Some _
       | None ->
         None)
   in
-  Option.iter retire_owner removed
+  match owner with
+  | None -> Ok ()
+  | Some owner ->
+    (match retire_owner owner with
+     | Ok `Released -> Ok ()
+     | Ok `Deferred -> Error Retirement_deferred
+     | Error _ as error -> error)
 ;;
 
 let clear () =
@@ -354,5 +504,7 @@ let clear () =
       Hashtbl.reset owners;
       removed)
   in
-  List.iter retire_owner removed
+  List.iter
+    (fun owner -> retire_owner owner |> note_retirement_result)
+    removed
 ;;

--- a/lib/keeper/keeper_exact_flow_scope.mli
+++ b/lib/keeper/keeper_exact_flow_scope.mli
@@ -8,6 +8,26 @@ type surface =
 
 type t
 
+type evidence_commit_error = Keeper_exact_flow_evidence_journal.commit_error
+
+type setup_error =
+  | Owner_not_registered of { keeper_name : string }
+  | Owner_draining of { keeper_name : string }
+  | Evidence_recovery_blocked of
+      { surface : surface
+      ; cause : Keeper_exact_flow_evidence_journal.load_error
+      }
+  | Scope_identity_invalid of { surface : surface }
+
+type release_error =
+  | Retirement_deferred
+  | Retirement_commit_failed of
+      { surface : surface
+      ; cause : evidence_commit_error
+      }
+  | Retirement_in_progress of { surface : surface }
+  | Retirement_conflict of { surface : surface }
+
 type 'a current_boundary =
   | Current of 'a
   | Owner_unregistered_deferred
@@ -22,10 +42,22 @@ val for_registered
   -> base_path:string
   -> keeper_name:string
   -> surface:surface
-  -> (t, string) result
+  -> (t, setup_error) result
+
+val setup_error_to_string : setup_error -> string
+val release_error_to_string : release_error -> string
+val evidence_commit_error_to_string : evidence_commit_error -> string
 
 val preference_store : t -> Agent_sdk.Exact_output.flow_preference_store
 val scope : t -> Agent_sdk.Exact_output.flow_scope
+
+val commit_domain_settlement_intent
+  :  t
+  -> Agent_sdk.Exact_output.domain_settlement_intent
+  -> (unit, evidence_commit_error) result
+(** Durable callback for every domain terminal on this exact owner/surface.
+    The encoded current OAS intent is committed to the same journal used by
+    startup recovery. *)
 
 val with_current
   :  t
@@ -64,7 +96,10 @@ val release_owner
   :  base_path:string
   -> keeper_name:string
   -> expected_lane_id:Keeper_lane.Id.t
-  -> unit
-(** Retire only the exact registry generation that was removed. *)
+  -> (unit, release_error) result
+(** Retire only the exact registry generation that was removed. Every reserved
+    surface commits its current OAS retirement intent before OAS releases the
+    scope. A pinned owner returns [Retirement_deferred] and remains alive until
+    the last pin runs the same durable retirement boundary. *)
 
 val clear : unit -> unit

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -390,6 +390,56 @@ let attempt_receipt_json (attempt : Exact_output.flow_attempt_receipt) =
     ]
 ;;
 
+let receipt_snapshot_json
+      (receipt : Exact_output.generation_receipt_snapshot)
+  =
+  `Assoc
+    [ ( "call_id"
+      , `String
+          (Exact_output.call_id_to_string
+             (Exact_output.generation_receipt_snapshot_call_id receipt)) )
+    ; ( "phase"
+      , `String
+          (effect_phase_to_string
+             (Exact_output.generation_receipt_snapshot_phase receipt)) )
+    ; ( "dispatch_count"
+      , `Int
+          (Exact_output.generation_receipt_snapshot_dispatch_count receipt) )
+    ; ( "http_status"
+      , match Exact_output.generation_receipt_snapshot_http_status receipt with
+        | Some status -> `Int status
+        | None -> `Null )
+    ; ( "plan_fingerprint"
+      , `String
+          (Exact_output.generation_receipt_snapshot_plan_fingerprint receipt) )
+    ; ( "request_body_sha256"
+      , `String
+          (Exact_output.generation_receipt_snapshot_request_body_sha256 receipt) )
+    ; ( "catalog_generation"
+      , `String
+          (Exact_output.catalog_generation_fingerprint
+             (Exact_output.generation_receipt_snapshot_catalog_generation
+                receipt)) )
+    ; ( "catalog_evidence_sha256"
+      , `String
+          (Exact_output.catalog_evidence_sha256
+             (Exact_output.generation_receipt_snapshot_catalog_evidence
+                receipt)) )
+    ; ( "target_identity"
+      , `String
+          (Exact_output.target_identity_fingerprint
+             (Exact_output.generation_receipt_snapshot_target_identity
+                receipt)) )
+    ]
+;;
+
+let attempt_snapshot_json (attempt : Exact_output.flow_attempt_snapshot) =
+  `Assoc
+    [ "candidate_id", `String attempt.visit.identity.candidate_id
+    ; "receipt", receipt_snapshot_json attempt.receipt
+    ]
+;;
+
 let exact_flow_state_dir ~keeper_id =
   Keeper_memory_os_io.facts_path ~keeper_id
   |> Filename.dirname
@@ -495,9 +545,9 @@ let flow_candidates selected_slots =
 
 let exact_execution_error error =
   let outward_effect =
-    match Exact_output.flow_execution_error_outward_dispatch error with
-    | Exact_output.No_outward_dispatch -> No_outward_effect
-    | Exact_output.Outward_dispatch_started -> Outward_effect_started
+    match Exact_output.flow_execution_error_generation_dispatch error with
+    | Exact_output.No_generation_dispatch -> No_outward_effect
+    | Exact_output.Generation_dispatch_started -> Outward_effect_started
   in
   let failure =
     match error with
@@ -553,7 +603,7 @@ let persist_exact_execution_terminal
          ~trace_id
          ~generation
          ~state:"execution_terminal"
-         [ "candidate", attempt_receipt_json candidate
+         [ "candidate", attempt_snapshot_json candidate
          ; "failure_cause", `String "success_ordinal_exhausted"
          ]
      | [] -> Error "success ordinal exhausted without attempt evidence")

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -888,7 +888,9 @@ let resolve_flow_scope ~base_path ~keeper_id =
     ~keeper_name:keeper_id
     ~surface:Keeper_exact_flow_scope.Librarian
   |> Result.map_error (fun detail ->
-    Exact_setup_failed (Exact_owner_unavailable detail))
+    Exact_setup_failed
+      (Exact_owner_unavailable
+         (Keeper_exact_flow_scope.setup_error_to_string detail)))
 ;;
 
 let extract_with_flow_scope_classified

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -194,7 +194,7 @@ type exact_execution_failure =
   | Exact_callback_persistence_failed of string
   | Oas_execution_failed
   | Exact_flow_progress_failed of string
-  | Exact_domain_settlement_failed
+  | Exact_domain_settlement_failed of string
 
 type outward_effect =
   | No_outward_effect
@@ -272,6 +272,11 @@ let exact_setup_error_to_string = function
     Printf.sprintf
       "exact flow preference capacity exhausted capacity=%d"
       capacity
+  (* Distinct from the capacity variant above: no declared capacity was reached,
+     the reservation pool simply had no free slot, so there is no number to
+     report. *)
+  | Exact_flow_snapshot_failed Exact_output.Flow_preference_reservation_exhausted
+    -> "exact flow preference reservation exhausted"
   | Exact_flow_start_failed
       (Exact_output.Flow_id_generation_failed detail) ->
     "exact flow identity allocation failed: " ^ detail
@@ -290,8 +295,8 @@ let extraction_error_to_string = function
       | Oas_execution_failed -> "oas_execution_failed"
       | Exact_flow_progress_failed detail ->
         "flow_progress_failed: " ^ detail
-      | Exact_domain_settlement_failed ->
-        "domain_settlement_failed"
+      | Exact_domain_settlement_failed reason ->
+        "domain_settlement_failed: " ^ reason
     in
     Printf.sprintf
       "librarian exact execution failed outward_effect=%s cause=%s"
@@ -543,6 +548,19 @@ let flow_candidates selected_slots =
   loop 0 [] selected_slots
 ;;
 
+(* The three settlement outcomes mean different things to an operator: a failed
+   durable journal commit, a benign same-disposition race, and a real
+   disposition disagreement. They share one librarian failure because the
+   librarian reacts identically, so the distinction is carried in the reason
+   rather than discarded. *)
+let domain_commit_error_reason = function
+  | Exact_output.Domain_commit_failed cause ->
+    "commit_failed: "
+    ^ Keeper_exact_flow_scope.evidence_commit_error_to_string cause
+  | Exact_output.Domain_settlement_in_progress -> "settlement_in_progress"
+  | Exact_output.Domain_settlement_conflict -> "settlement_conflict"
+;;
+
 let exact_execution_error error =
   let outward_effect =
     match Exact_output.flow_execution_error_generation_dispatch error with
@@ -561,6 +579,20 @@ let exact_execution_error error =
       | Exact_output.Call_id_generation_failed detail -> detail
     in
     Exact_flow_progress_failed ("attempt_start_failed: " ^ detail)
+  | Flow_measurement_start_failed { cause; _ } ->
+    let detail =
+      match cause with
+      | Exact_output.Measurement_operation_id_generation_failed detail -> detail
+      | Exact_output.Measurement_clock_required_for_timeout ->
+        "clock_required_for_timeout"
+    in
+    Exact_flow_progress_failed ("measurement_start_failed: " ^ detail)
+  (* Every guarded callback carries the same cause type regardless of the phase
+     that ran it, and the librarian reacts to the cause rather than the phase,
+     so the measurement callbacks join the arm that already merges dispatch and
+     advance. *)
+  | Flow_before_measurement_dispatch_callback_failed { cause; _ }
+  | Flow_measurement_terminal_callback_failed { cause; _ }
   | Flow_before_dispatch_callback_failed { cause; _ }
   | Flow_before_advance_callback_failed { cause; _ } ->
     (match cause with
@@ -607,7 +639,11 @@ let persist_exact_execution_terminal
          ; "failure_cause", `String "success_ordinal_exhausted"
          ]
      | [] -> Error "success ordinal exhausted without attempt evidence")
+  (* [Flow_measurement_start_failed] carries a candidate visit rather than an
+     attempt receipt, exactly like [Flow_attempt_start_failed]: no attempt was
+     allocated, so there is no receipt to record. *)
   | Flow_attempt_start_failed _
+  | Flow_measurement_start_failed _
   | Flow_candidates_exhausted _ ->
     persist_exact_flow_state
       ~keeper_id
@@ -616,6 +652,8 @@ let persist_exact_execution_terminal
       ~state:"execution_terminal"
       []
   | Flow_attempt_already_started _ -> Ok ()
+  | Flow_before_measurement_dispatch_callback_failed { cause; _ }
+  | Flow_measurement_terminal_callback_failed { cause; _ }
   | Flow_before_dispatch_callback_failed { cause; _ }
   | Flow_before_advance_callback_failed { cause; _ } ->
     (match cause with
@@ -784,13 +822,20 @@ let extract_with_exact_output_classified_unlocked
       (match Keeper_librarian.episode_of_json_result ~generation inp output.output with
        | Ok episode ->
          (match
-            Exact_output.settle_flow_domain success Exact_output.Domain_valid
+            Exact_output.commit_and_settle_flow_domain
+              ~commit:
+                (Keeper_exact_flow_scope.commit_domain_settlement_intent
+                   flow_scope)
+              success
+              Exact_output.Domain_valid
           with
-          | Error _ ->
+          | Error error ->
             Error
               (Exact_execution_failed
                  { outward_effect = Outward_effect_started
-                 ; failure = Exact_domain_settlement_failed
+                 ; failure =
+                     Exact_domain_settlement_failed
+                       (domain_commit_error_reason error)
                  })
           | Ok _ ->
             (match
@@ -806,13 +851,20 @@ let extract_with_exact_output_classified_unlocked
        | Error error ->
          let parse_error = Keeper_librarian.parse_error_to_string error in
          (match
-            Exact_output.settle_flow_domain success Exact_output.Domain_rejected
+            Exact_output.commit_and_settle_flow_domain
+              ~commit:
+                (Keeper_exact_flow_scope.commit_domain_settlement_intent
+                   flow_scope)
+              success
+              Exact_output.Domain_rejected
           with
-          | Error _ ->
+          | Error error ->
             Error
               (Exact_execution_failed
                  { outward_effect = Outward_effect_started
-                 ; failure = Exact_domain_settlement_failed
+                 ; failure =
+                     Exact_domain_settlement_failed
+                       (domain_commit_error_reason error)
                  })
           | Ok _ ->
             (match

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -784,49 +784,62 @@ let remove_entry
       ~base_path
       name
   =
-  Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
-  match
-    Keeper_lifecycle_reservation.authorize
-      ?token:lifecycle_token
+  let result, release_lane =
+    Keeper_lifecycle_reservation.with_key_lock
       ~base_path
       ~keeper_name:name
-      ()
-  with
-  | Error owner -> Entry_lifecycle_reserved owner
-  | Ok () ->
-  let key = registry_key ~base_path name in
-  let rec loop () =
-    let current = Atomic.get registry in
-    match StringMap.find_opt key current with
-    | None ->
-      Option.iter
-        (fun expected_entry ->
-           Keeper_exact_flow_scope.release_owner
+      (fun () ->
+         match
+           Keeper_lifecycle_reservation.authorize
+             ?token:lifecycle_token
              ~base_path
              ~keeper_name:name
-             ~expected_lane_id:(Keeper_lane.id expected_entry.lane))
-        expected;
-      Entry_missing
-    | Some entry ->
-      (match expected with
-       | Some expected_entry
-         when not
-                (Keeper_lane.Id.equal
-                   (Keeper_lane.id entry.lane)
-                   (Keeper_lane.id expected_entry.lane)) ->
-         Entry_replaced
-       | None | Some _ ->
-         let updated = StringMap.remove key current in
-         if Atomic.compare_and_set registry current updated
-        then (
-           Keeper_exact_flow_scope.release_owner
-             ~base_path
-             ~keeper_name:name
-             ~expected_lane_id:(Keeper_lane.id entry.lane);
-           Entry_removed entry)
-         else loop ())
+             ()
+         with
+         | Error owner -> Entry_lifecycle_reserved owner, None
+         | Ok () ->
+           let key = registry_key ~base_path name in
+           let rec loop () =
+             let current = Atomic.get registry in
+             match StringMap.find_opt key current with
+             | None ->
+               ( Entry_missing
+               , Option.map
+                   (fun expected_entry -> Keeper_lane.id expected_entry.lane)
+                   expected )
+             | Some entry ->
+               (match expected with
+                | Some expected_entry
+                  when not
+                         (Keeper_lane.Id.equal
+                            (Keeper_lane.id entry.lane)
+                            (Keeper_lane.id expected_entry.lane)) ->
+                  Entry_replaced, None
+                | None | Some _ ->
+                  let updated = StringMap.remove key current in
+                  if Atomic.compare_and_set registry current updated
+                  then Entry_removed entry, Some (Keeper_lane.id entry.lane)
+                  else loop ())
+           in
+           loop ())
   in
-  loop ())
+  Option.iter
+    (fun expected_lane_id ->
+       match
+         Keeper_exact_flow_scope.release_owner
+           ~base_path
+           ~keeper_name:name
+           ~expected_lane_id
+       with
+       | Ok () -> ()
+       | Error cause ->
+         Log.Keeper.error
+           "registry: exact-flow owner retirement remains blocked name=%s base_path=%s cause=%s"
+           name
+           base_path
+           (Keeper_exact_flow_scope.release_error_to_string cause))
+    release_lane;
+  result
 ;;
 
 let finish_unregistration entry =

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -604,16 +604,19 @@ let begin_exact_retirement ~base_path operation entry =
 ;;
 
 let unregister_retired_exact ~base_path operation entry =
+  let release expected_lane_id =
+    Keeper_exact_flow_scope.release_owner
+      ~base_path
+      ~keeper_name:operation.keeper_name
+      ~expected_lane_id
+    |> Result.map_error Keeper_exact_flow_scope.release_error_to_string
+  in
   match operation.lane_ownership, entry with
   | Dormant_meta, None -> Ok false
   | Dormant_meta, Some _ ->
     Error "dormant Keeper operation found a registered lane before finalization"
   | Registered_lane expected_lane_id, None ->
-    Keeper_exact_flow_scope.release_owner
-      ~base_path
-      ~keeper_name:operation.keeper_name
-      ~expected_lane_id;
-    Ok false
+    Result.map (fun () -> false) (release expected_lane_id)
   | Registered_lane expected_lane_id, Some entry ->
     if
       not
@@ -625,11 +628,7 @@ let unregister_retired_exact ~base_path operation entry =
       (match Keeper_registry.unregister_exact entry with
        | Keeper_registry.Exact_unregistered
        | Keeper_registry.Exact_entry_missing ->
-         Keeper_exact_flow_scope.release_owner
-           ~base_path
-           ~keeper_name:operation.keeper_name
-           ~expected_lane_id;
-         Ok true
+         Result.map (fun () -> true) (release expected_lane_id)
      | Keeper_registry.Exact_entry_replaced ->
        Error "Keeper registry lane was replaced during finalization"
      | Keeper_registry.Exact_unregister_lifecycle_reserved owner ->

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -403,6 +403,7 @@ let turn_event_bus_evidence_detail
 
 type capacity_refusal =
   | Provider_context_window of { limit_tokens : int option }
+  | Provider_request_body_refusal of { status : int }
   | Serialized_request_body of
       { actual_bytes : int
       ; limit_bytes : int
@@ -421,6 +422,9 @@ let capacity_refusal_of_error (err : Agent_sdk.Error.sdk_error) : capacity_refus
       (InvalidRequest { reason = Request_body_too_large { actual_bytes; limit_bytes }; _ })
     ->
     Some (Serialized_request_body { actual_bytes; limit_bytes })
+  | Agent_sdk.Error.Api
+      (InvalidRequest { reason = Request_body_refused_by_provider { status }; _ }) ->
+    Some (Provider_request_body_refusal { status })
   | Agent_sdk.Error.Api
       (InvalidRequest { reason = Json_parse_error | Unknown_invalid_request; _ }) ->
     (* A malformed request is a defect in what was built, not a size the target
@@ -457,7 +461,9 @@ let context_overflow_event_of_error
   match capacity_refusal_of_error err with
   | Some (Provider_context_window { limit_tokens }) ->
     Some (Keeper_state_machine.Context_overflow_detected { limit_tokens })
-  | Some (Serialized_request_body _) | None -> None
+  | Some (Provider_request_body_refusal _ | Serialized_request_body _)
+  | None ->
+    None
 
 (* Prefix that tags a [last_compaction_decision] value as a provider-overflow
    recovery failure. Kept as a named binding so the observability regression test

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -193,14 +193,18 @@ val turn_event_bus_evidence_detail :
 
 type capacity_refusal =
   | Provider_context_window of { limit_tokens : int option }
+  | Provider_request_body_refusal of { status : int }
   | Serialized_request_body of
       { actual_bytes : int
       ; limit_bytes : int
       }
-(** Why a target refused to serve a request for its size. One closed set for both
-    measured axes: a provider-declared token window and a declared serialized-body
-    byte limit. The units are not interchangeable, so neither axis is expressed in
-    the other's field. *)
+(** Why a target refused to serve a request for its size. One closed set over the
+    two measured axes plus the unmeasured provider refusal: a provider-declared
+    token window, a declared serialized-body byte limit, and a provider that
+    refused the body while declaring neither limit. The units are not
+    interchangeable, so neither axis is expressed in the other's field, and
+    [Provider_request_body_refusal] carries only the transport status because no
+    limit was measured. *)
 
 val capacity_refusal_of_error :
   Agent_sdk.Error.sdk_error ->

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.223.1"}
+  "agent_sdk" {>= "0.226.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.223.1"}
+  "agent_sdk" {= "0.226.0"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.223.1"
-  "git+https://github.com/jeong-sik/oas.git#3d4ee19a4773cbd8b1b73ed5555c5cdfe82e6d77"
+  "agent_sdk.0.226.0"
+  "git+https://github.com/jeong-sik/oas.git#2186dfa5fca2360e4e99fa5e47052ba4c0cc687f"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.223.1"
-# v0.223.1 preserves the immutable exact-flow contract from v0.223.0 while
-# restoring the supported Eio 1.3 dependency solution. MASC consumes only
-# opaque flow, receipt, and provenance facts; provider/model resolution,
-# admission, successor choice, and Pricing remain OAS-owned.
-# Previous pin: v0.223.0 (e87cc15c).
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.226.0"
+# v0.226.0 replaces the process-local exact-flow settlement surface with
+# commit-fenced entry points: recover_flow_preferences ~evidence,
+# commit_and_settle_flow_domain ~commit, and
+# commit_and_retire_flow_preference_scope ~commit. The callback is the durable
+# content-commit fence, so MASC owns a current-schema preference evidence
+# journal (#25808) rather than acknowledging evidence it did not persist.
+# This pin only lands together with those consumers: #25799 bumped the pin
+# alone and left main unable to compile, which #25810 reverted.
+# Previous pin: v0.223.1 (3d4ee19a).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guard in check-oas-pin.sh tracks main; oas-drift-check.sh
 # reports the public-surface delta at pin-bump time.
-# Pinned to the v0.223.1 release commit.
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.223.1"
+# Pinned to the v0.226.0 release commit.
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.226.0"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="3d4ee19a4773cbd8b1b73ed5555c5cdfe82e6d77"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.223.1"
+readonly OAS_AGENT_SDK_SHA="2186dfa5fca2360e4e99fa5e47052ba4c0cc687f"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.226.0"

--- a/test/dune
+++ b/test/dune
@@ -2620,3 +2620,4 @@
 
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
 (include stanzas/test_eio_resource_scope.inc)
+(include stanzas/test_keeper_exact_flow_evidence_journal.inc)

--- a/test/stanzas/test_keeper_exact_flow_evidence_journal.inc
+++ b/test/stanzas/test_keeper_exact_flow_evidence_journal.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_exact_flow_evidence_journal)
+ (modules test_keeper_exact_flow_evidence_journal)
+ (libraries alcotest digestif eio_main masc_test_deps yojson))

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2631,7 +2631,8 @@ let test_destructive_shutdown_drains_bound_summary_then_completes () =
                   ~surface:Masc.Keeper_exact_flow_scope.Hitl_summary
               with
               | Ok scope -> scope
-              | Error detail -> fail detail
+              | Error detail ->
+                fail (Masc.Keeper_exact_flow_scope.setup_error_to_string detail)
             in
             let approval_id =
               install_pending_summary

--- a/test/test_keeper_exact_flow_evidence_journal.ml
+++ b/test/test_keeper_exact_flow_evidence_journal.ml
@@ -1,0 +1,303 @@
+open Alcotest
+
+module EO = Agent_sdk.Exact_output
+module Journal = Masc.Keeper_exact_flow_evidence_journal
+module Keeper_fs = Masc.Keeper_fs
+
+let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let decode_domain encoded =
+  match EO.domain_settlement_intent_of_string encoded with
+  | Ok intent -> intent
+  | Error _ -> fail "current domain settlement fixture did not decode"
+;;
+
+let domain_intent disposition =
+  let structural =
+    [ "format", `String "oas.exact-output.domain-settlement-intent"
+    ; "version", `Int 1
+    ; "flow_id", `String "flow-journal-test"
+    ; "scope", `String "/masc/test/journal"
+    ; "reservation_ordinal", `String "1"
+    ; "candidate_id", `String "candidate-a"
+    ; "candidate_binding_sha256", `String (String.make 64 'a')
+    ; "success_ordinal", `String "1"
+    ; "execution_evidence_sha256", `String (String.make 64 'b')
+    ]
+  in
+  let settlement_id = `Assoc structural |> Yojson.Safe.to_string |> sha256 in
+  let payload =
+    structural
+    @ [ "settlement_id", `String settlement_id
+      ; "disposition", `String disposition
+      ]
+  in
+  let integrity_sha256 = `Assoc payload |> Yojson.Safe.to_string |> sha256 in
+  `Assoc (payload @ [ "integrity_sha256", `String integrity_sha256 ])
+  |> Yojson.Safe.to_string
+  |> decode_domain
+;;
+
+let decode_retirement encoded =
+  match EO.flow_preference_retirement_intent_of_string encoded with
+  | Ok intent -> intent
+  | Error _ -> fail "current scope retirement fixture did not decode"
+;;
+
+let retirement_intent () =
+  let structural =
+    [ "format", `String "oas.exact-output.flow-preference-retirement-intent"
+    ; "version", `Int 1
+    ; "scope", `String "/masc/test/journal"
+    ; "reservation_ordinal", `String "1"
+    ; "success_high_water", `String "1"
+    ]
+  in
+  let retirement_id = `Assoc structural |> Yojson.Safe.to_string |> sha256 in
+  let payload = structural @ [ "retirement_id", `String retirement_id ] in
+  let integrity_sha256 = `Assoc payload |> Yojson.Safe.to_string |> sha256 in
+  `Assoc (payload @ [ "integrity_sha256", `String integrity_sha256 ])
+  |> Yojson.Safe.to_string
+  |> decode_retirement
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_test_deps.cleanup_test_workspace base_path;
+      Fs_compat.clear_fs ())
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       f base_path)
+;;
+
+let recover_with_writer ~durable_write base_path =
+  match
+    Journal.For_testing.recover
+      ~durable_write
+      ~base_path
+      ~keeper_name:"journal-test"
+      ~keeper_generation:"lane-journal-test"
+      ~surface:"compaction"
+      ~concurrent_scope_budget:1
+  with
+  | Ok recovered -> recovered
+  | Error error -> fail (Journal.load_error_to_string error)
+;;
+
+let fake_write_error =
+  { Keeper_fs.renamed = false
+  ; stage = Keeper_fs.Payload_write
+  ; failure = Keeper_fs.Operation_failed "injected journal write failure"
+  }
+;;
+
+let test_commit_error_is_typed_and_does_not_advance_journal () =
+  with_workspace
+  @@ fun base_path ->
+  let writes = ref 0 in
+  let durable_write ~on_durable_commit ~ownership_root:_ ~path:_ ~bytes:_ =
+    incr writes;
+    if !writes = 1
+    then (
+      on_durable_commit ();
+      Ok Keeper_fs.Committed)
+    else Error fake_write_error
+  in
+  let journal, _, _ = recover_with_writer ~durable_write base_path in
+  (match Journal.commit_domain_settlement journal (domain_intent "domain_valid") with
+   | Error (Journal.Evidence_write_failed _) -> ()
+   | Ok () | Error (Journal.Evidence_conflict _) ->
+     fail "journal write failure lost its typed commit outcome");
+  check int "failed commit retained no evidence" 0 (Journal.evidence_count journal)
+;;
+
+let test_cancellation_preserves_backtrace_after_durable_observer () =
+  with_workspace
+  @@ fun base_path ->
+  let writes = ref 0 in
+  let durable_write ~on_durable_commit ~ownership_root:_ ~path:_ ~bytes:_ =
+    incr writes;
+    on_durable_commit ();
+    if !writes = 1
+    then Ok Keeper_fs.Committed
+    else (
+      let cancelled =
+        Eio.Cancel.Cancelled (Failure "injected exact-flow journal cancellation")
+      in
+      Printexc.raise_with_backtrace cancelled (Printexc.get_callstack 32))
+  in
+  let journal, _, _ = recover_with_writer ~durable_write base_path in
+  let cancellation_backtrace =
+    try
+      ignore
+        (Journal.commit_domain_settlement journal (domain_intent "domain_valid"));
+      None
+    with
+    | Eio.Cancel.Cancelled (Failure detail)
+      when String.equal detail "injected exact-flow journal cancellation" ->
+      Some (Printexc.get_raw_backtrace () |> Printexc.raw_backtrace_to_string)
+    | exn -> raise exn
+  in
+  let backtrace_preserved =
+    match cancellation_backtrace with
+    | Some backtrace -> not (String.equal backtrace "")
+    | None -> false
+  in
+  check bool "cancellation escaped with a backtrace" true backtrace_preserved;
+  check int "durable observer retained committed evidence" 1
+    (Journal.evidence_count journal)
+;;
+
+let test_restart_replays_complete_current_evidence () =
+  with_workspace
+  @@ fun base_path ->
+  let recover () =
+    Journal.recover
+      ~base_path
+      ~keeper_name:"journal-test"
+      ~keeper_generation:"lane-journal-test"
+      ~surface:"compaction"
+      ~concurrent_scope_budget:1
+  in
+  let journal =
+    match recover () with
+    | Ok (journal, _, Journal.Fresh_start) -> journal
+    | Ok (_, _, Journal.Recovered _) -> fail "missing journal was not a fresh start"
+    | Error error -> fail (Journal.load_error_to_string error)
+  in
+  (match Journal.commit_domain_settlement journal (domain_intent "domain_valid") with
+   | Ok () -> ()
+   | Error error -> fail (Journal.commit_error_to_string error));
+  match recover () with
+  | Ok (recovered, _, Journal.Recovered { evidence_count = 1 }) ->
+    check int "restart loaded one complete intent" 1
+      (Journal.evidence_count recovered)
+  | Ok _ -> fail "restart did not report the complete recovered evidence set"
+  | Error error -> fail (Journal.load_error_to_string error)
+;;
+
+let test_duplicate_same_intent_is_idempotent () =
+  with_workspace
+  @@ fun base_path ->
+  let writes = ref 0 in
+  let durable_write ~on_durable_commit ~ownership_root:_ ~path:_ ~bytes:_ =
+    incr writes;
+    on_durable_commit ();
+    Ok Keeper_fs.Committed
+  in
+  let journal, _, _ = recover_with_writer ~durable_write base_path in
+  let intent = domain_intent "domain_valid" in
+  List.iter
+    (fun () ->
+       match Journal.commit_domain_settlement journal intent with
+       | Ok () -> ()
+       | Error error -> fail (Journal.commit_error_to_string error))
+    [ (); () ];
+  check int "initialization plus one logical append" 2 !writes;
+  check int "duplicate did not create a second entry" 1
+    (Journal.evidence_count journal)
+;;
+
+let test_same_id_conflict_fails_closed () =
+  with_workspace
+  @@ fun base_path ->
+  let writes = ref 0 in
+  let durable_write ~on_durable_commit ~ownership_root:_ ~path:_ ~bytes:_ =
+    incr writes;
+    on_durable_commit ();
+    Ok Keeper_fs.Committed
+  in
+  let journal, _, _ = recover_with_writer ~durable_write base_path in
+  (match Journal.commit_domain_settlement journal (domain_intent "domain_valid") with
+   | Ok () -> ()
+   | Error error -> fail (Journal.commit_error_to_string error));
+  (match
+     Journal.commit_domain_settlement journal (domain_intent "domain_rejected")
+   with
+   | Error
+       (Journal.Evidence_conflict
+          { kind = Journal.Domain_settlement; _ }) -> ()
+   | Ok () | Error _ -> fail "opposite disposition did not fail closed");
+  check int "conflict performed no durable write" 2 !writes;
+  check int "conflict retained original evidence only" 1
+    (Journal.evidence_count journal)
+;;
+
+let test_retirement_commit_is_durable_before_effect () =
+  with_workspace
+  @@ fun base_path ->
+  let writes = ref 0 in
+  let events = ref [] in
+  let durable_write ~on_durable_commit ~ownership_root:_ ~path:_ ~bytes:_ =
+    incr writes;
+    if !writes > 1 then events := !events @ [ "write" ];
+    on_durable_commit ();
+    if !writes > 1 then events := !events @ [ "durable" ];
+    Ok Keeper_fs.Committed
+  in
+  let journal, _, _ = recover_with_writer ~durable_write base_path in
+  (match Journal.commit_scope_retirement journal (retirement_intent ()) with
+   | Ok () -> events := !events @ [ "oas_effect" ]
+   | Error error -> fail (Journal.commit_error_to_string error));
+  check (list string) "retirement ordering"
+    [ "write"; "durable"; "oas_effect" ] !events
+;;
+
+let test_invalid_current_journal_is_typed_and_not_defaulted () =
+  with_workspace
+  @@ fun base_path ->
+  let journal, _, _ =
+    match
+      Journal.recover
+        ~base_path
+        ~keeper_name:"journal-test"
+        ~keeper_generation:"lane-journal-test"
+        ~surface:"compaction"
+        ~concurrent_scope_budget:1
+    with
+    | Ok recovered -> recovered
+    | Error error -> fail (Journal.load_error_to_string error)
+  in
+  (match Fs_compat.save_file_atomic (Journal.path journal) "{}" with
+   | Ok () -> ()
+   | Error detail -> fail detail);
+  match
+    Journal.recover
+      ~base_path
+      ~keeper_name:"journal-test"
+      ~keeper_generation:"lane-journal-test"
+      ~surface:"compaction"
+      ~concurrent_scope_budget:1
+  with
+  | Error (Journal.Journal_decode_failed _) -> ()
+  | Ok _ | Error _ -> fail "invalid current journal was default-filled or erased"
+;;
+
+let () =
+  run
+    "keeper exact-flow evidence journal"
+    [ ( "current-schema durability"
+      , [ test_case "commit error is typed" `Quick
+            test_commit_error_is_typed_and_does_not_advance_journal
+        ; test_case "cancellation preserves backtrace" `Quick
+            test_cancellation_preserves_backtrace_after_durable_observer
+        ; test_case "restart replays complete evidence" `Quick
+            test_restart_replays_complete_current_evidence
+        ; test_case "same-intent replay is idempotent" `Quick
+            test_duplicate_same_intent_is_idempotent
+        ; test_case "same-id conflict fails closed" `Quick
+            test_same_id_conflict_fails_closed
+        ; test_case "retirement is durable before effect" `Quick
+            test_retirement_commit_is_durable_before_effect
+        ; test_case "invalid current journal is typed" `Quick
+            test_invalid_current_journal_is_typed_and_not_defaulted
+        ] )
+    ]
+;;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3172,7 +3172,8 @@ let with_librarian_scopes keeper_ids f =
              ~surface:Exact_flow_scope.Librarian
          with
          | Ok scope -> keeper_id, scope
-         | Error detail -> Alcotest.fail detail
+         | Error detail ->
+           Alcotest.fail (Exact_flow_scope.setup_error_to_string detail)
        in
        f (List.map scope_for keeper_ids))
 ;;

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1774,7 +1774,10 @@ let test_exact_scope_release_defers_until_settlement_pin_leaves () =
              ~surface:Masc.Keeper_exact_flow_scope.Compaction
          with
          | Ok flow_scope -> flow_scope
-         | Error detail -> failf "scope pin fixture failed: %s" detail
+         | Error detail ->
+           failf
+             "scope pin fixture failed: %s"
+             (Masc.Keeper_exact_flow_scope.setup_error_to_string detail)
        in
        let entered, publish_entered = Eio.Promise.create () in
        let continue_promise, publish_continue = Eio.Promise.create () in
@@ -1815,7 +1818,9 @@ let test_exact_scope_release_defers_until_settlement_pin_leaves () =
                 with
                 | Ok replacement_scope -> replacement_scope
                 | Error detail ->
-                  failf "replacement scope allocation failed: %s" detail
+                  failf
+                    "replacement scope allocation failed: %s"
+                    (Masc.Keeper_exact_flow_scope.setup_error_to_string detail)
               in
               (match
                  Masc.Keeper_exact_flow_scope.with_current

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -111,6 +111,14 @@ let request_body_too_large ~actual_bytes ~limit_bytes =
        })
 ;;
 
+let request_body_refused_by_provider ~status =
+  Agent_sdk.Error.Api
+    (InvalidRequest
+       { message = "provider refused the serialized request body"
+       ; reason = Agent_sdk.Retry.Request_body_refused_by_provider { status }
+       })
+;;
+
 (* The byte axis used to fall through [| _ -> None] and produce no compaction
    request at all, so these two assertions are the ones that failed before. *)
 let test_byte_axis_is_a_capacity_refusal () =
@@ -123,9 +131,21 @@ let test_byte_axis_is_a_capacity_refusal () =
           { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }) -> ()
    | Some (Budget.Serialized_request_body _) ->
      fail "the measured byte pair was not carried through"
+   | Some (Budget.Provider_request_body_refusal _) ->
+     fail "a measured local refusal became an unmeasured provider refusal"
    | Some (Budget.Provider_context_window _) ->
      fail "a byte refusal was classified on the token axis"
    | None -> fail "a declared-byte refusal was not classified as a capacity refusal");
+  (match
+     Budget.capacity_refusal_of_error
+       (request_body_refused_by_provider ~status:413)
+   with
+   | Some (Budget.Provider_request_body_refusal { status = 413 }) -> ()
+   | Some (Budget.Provider_request_body_refusal _) ->
+     fail "the provider refusal lost its HTTP status"
+   | Some (Budget.Provider_context_window _ | Budget.Serialized_request_body _) ->
+     fail "an unmeasured provider refusal was assigned a measured capacity"
+   | None -> fail "a provider request-body refusal was not typed as capacity");
   match
     Budget.capacity_refusal_of_error
       (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 }))
@@ -144,6 +164,13 @@ let test_event_projection_admits_only_the_token_axis () =
    with
    | None -> ()
    | Some _ -> fail "a byte refusal was projected as a context-overflow event");
+  (match
+     Budget.context_overflow_event_of_error
+       (request_body_refused_by_provider ~status:413)
+   with
+   | None -> ()
+   | Some _ ->
+     fail "a provider request-body refusal was projected on the token axis");
   match
     Budget.context_overflow_event_of_error
       (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None }))


### PR DESCRIPTION
Draft. Does not merge as-is: `#25808` is not complete. Opened so the work stops being invisible — the two commits below existed only in a local unpushed worktree, so CI had never seen them.

## Why the pin rides along

`#25799` bumped the OAS pin to v0.226.0 alone. `main` could not compile and `#25810` reverted it. The in-flight migration then had the mirror-image problem: consumer code written against v0.226 while `scripts/oas-agent-sdk-pin.sh` still declared `0.223.1`, so CI would have compiled it against the wrong SDK. Pin and consumers only make sense together, so this branch carries both.

Pin: `v0.223.1` (`3d4ee19a`) → `v0.226.0` (`2186dfa5`, the `release 0.226.0` commit on `oas` main). `scripts/sync-oas-pin-docs.sh` and `scripts/sync-oas-pin-manifests.sh` ran; `scripts/oas-api-surface.json` is deliberately **not** regenerated because that needs an actual review of the upstream surface delta, not a blind `--surface`.

## Inherited commits

`20c786153e` and `6d9d69b06d` are not mine. They are the existing migration work — receipt facts, and the current-schema preference evidence journal that `#25808` requires — carried here unchanged with their authorship.

## What this commit adds

- `keeper_turn_runtime_budget.mli` exposes `Provider_request_body_refusal`, which the `.ml` already carried. Its doc no longer claims the set covers only two measured axes.
- `keeper_librarian_runtime` handles the three execution-error variants v0.226 adds, renders `Flow_preference_reservation_exhausted` distinctly, and carries a reason on `Exact_domain_settlement_failed`.
- `commit_and_settle_flow_domain` wired to the evidence journal.

## What is NOT done

The durable ordering clause of `#25808` is unmet everywhere. Measured, not estimated — this is the actual `dune build @check` output against the v0.226 switch:

| File | Line | Remaining |
|---|---|---|
| `keeper_librarian_runtime.ml` | 899 | `execute_flow_once` needs `~before_measurement_dispatch` / `~on_measurement_terminal` |
| `keeper_librarian_runtime.ml` | 819 | Domain_valid callback must commit **the episode**, not only the intent |
| `keeper_board_attention_exact_flow.ml` | 439 | same measurement callbacks |
| `keeper_board_attention_exact_flow.ml` | 452-462 | both dispositions still settle before the durable terminal |
| `hitl_summary_worker.ml` | 717 | `Unbound record field catalog_generation` |
| `hitl_summary_worker.ml` | 766 | completion write must move into the commit callback |
| `keeper_compaction_llm_summarizer.ml` | 585 | `Domain_already_settled` removed from the closed set |
| `keeper_unified_turn.ml` | 220, 239 | `Provider_request_body_refusal` unhandled — see below |

Plus the acceptance tests `#25808` requires: commit error, cancellation, restart replay, duplicate same-intent replay, conflict, retirement ordering.

## Two findings for whoever continues

**1. Nesting a scope boundary inside the OAS commit callback is safe.** The ordering clause requires calling `append_episode_for_current_owner` (which takes `with_settlement`) from inside `commit_and_settle_flow_domain ~commit`, while the caller may already hold a `with_current` pin. `keeper_exact_flow_scope.ml:390` `with_boundary` takes `Keeper_lifecycle_reservation.with_key_lock` only around pin acquisition and releases it before running the callback; `boundary_users` is a counter. OAS separately documents that no callback runs while the preference mutex is held. So there is no lock held across the nesting and no deadlock path. This was the blocking unknown and it is resolved.

**2. `keeper_unified_turn.ml` is a durable-schema decision, not a compile fix.** `#25808` does not mention it. The two arms map a `capacity_refusal` onto `Compaction_trigger.t`, and `Compaction_trigger.t` is encoded into durable records through `to_detail_json` / `of_detail_json`. A provider body refusal declares no limit, so it cannot be folded into `Request_body_over_capacity { actual_bytes; limit_bytes }` without fabricating the integers that `#25809` explicitly refused to fabricate, and it cannot be dropped without silently withholding compaction from a request the provider refused for size. Adding a variant is a durable codec change and a compaction-policy decision, so it is left for an explicit decision rather than made here.

## Verification

- `git diff --check`, `ocamlformat --check` on the touched files: pass
- `bash scripts/check-oas-pin.sh`: manifests match `v0.226.0`
- `dune build @check` against the v0.226 switch: the table above is its output

One operational note: the shared opam switch moved from `0.226.0` to `0.223.1` partway through this work without any action from this session. A single global switch cannot serve both `main` (which needs `0.223.1`) and this branch (which needs `0.226.0`), so local builds here are only reproducible while the switch happens to hold the matching pin.

RFC-WAIVED: no credential, identity, operator control-plane, sandbox, hooks, or workflow surface is touched; the OAS migration itself is specified in #25808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
