### PR TITLE
fix: close six unaddressed review findings from 24h-merged PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,14 @@ jobs:
           # harness file — including non-.sh/.json ones and future extensions —
           # must force build=true. ci_core is intentionally NOT OR-ed here:
           # the ci_core block below already forces build=true.
-          if has_match '^(bin/|lib/|test/|proto/|config/|tools/|scripts/harness/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|.*\.c$|.*\.h$|.*\.json$|.*\.sh$|(.*/)?dune$)'; then
+          # scripts/fixtures/ is a prefix for the same reason (#25726 moved the
+          # release-evidence fixtures out of heredocs into files): test/dune
+          # declares (source_tree ../scripts/fixtures) and
+          # test_runtime_config_validity.ml discovers scripts/fixtures/<name>/
+          # runtime.toml, so a fixture edit changes test input while matching
+          # none of the suffixes above (.toml is not .ml/.json/.sh) and the
+          # Build job would skip.
+          if has_match '^(bin/|lib/|test/|proto/|config/|tools/|scripts/harness/|scripts/fixtures/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|.*\.c$|.*\.h$|.*\.json$|.*\.sh$|(.*/)?dune$)'; then
             build=true
           fi
 

--- a/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
+++ b/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
@@ -197,6 +197,22 @@ val all : sw:Eio.Switch.t -> ?clock:_ -> ?max_fibers:int
 
 ### 7.2 심판 — `Structured.extract`
 
+> **철회됨 (2026-07-27).** 아래의 provider-native JSON schema 강제는 구현되지 않았고,
+> 되돌릴 계획도 없다. `Fusion_judge.apply_fusion_judge_output_contract`는 capability를
+> 읽지 않고 `Keeper_structured_output_schema.without_response_format`를 무조건 적용한다
+> (`response_format = Off`, `output_schema = None`). 계약은 프롬프트의
+> `Fusion_judge_parse.expected_json_doc`가 싣고, `Fusion_judge_parse.of_string`의 strict
+> 파싱이 위반을 `Parse_error`로 fail-loud한다.
+>
+> 철회 근거는 `lib/fusion/fusion_judge.ml:157-164`에 기록되어 있다: (1) capability 사실이
+> 거짓일 수 있다 — ollama.com cloud는 `json_schema`를 declared로 보고하면서 조용히 무시한다
+> (2026-07-02 probe), 그리고 현재 심판 런타임이 가리키는 엔드포인트가 그것이다. (2) #22768이
+> "native schema or fail before HTTP"를 도입했다가 미지원 preset의 fusion을 영구 불능으로
+> 만들어 되돌려졌다.
+>
+> 이 절은 `lib/fusion/fusion_judge.mli` 헤더가 "RFC가 요구하는지 확인하지 않았다"로 남겨둔
+> 미해결 항목이었다. 요구는 실재했고, 맞추는 쪽이 RFC다.
+
 `oas/lib/structured.mli:38` (provider-native JSON schema 강제, 미지원 provider fail-fast):
 ```ocaml
 val extract : sw:_ -> net:_ -> ?provider:Provider.config -> config:agent_config

--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -8,8 +8,21 @@ type t =
 
 (* Field names are the wire contract for [of_detail_json]; naming them once keeps
    the encoder and the decoder from drifting apart. *)
+let kind_field = "kind"
+let limit_tokens_field = "limit_tokens"
 let actual_bytes_field = "actual_bytes"
 let limit_bytes_field = "limit_bytes"
+
+(* Every key [to_detail_json] can emit, across all constructors. Consumers that
+   filter the encoded object — the runtime manifest public projection is the
+   one in tree — read this instead of restating the keys, so adding a field to
+   a trigger constructor cannot leave a stale allowlist silently dropping it.
+   Before this existed the manifest listed only [kind_field] and
+   [limit_tokens_field], so the byte bounds of a
+   [Request_body_over_capacity] refusal never reached the dashboard. *)
+let wire_field_names =
+  [ kind_field; limit_tokens_field; actual_bytes_field; limit_bytes_field ]
+;;
 
 let to_label = function
   | Provider_overflow _ -> "provider_overflow"
@@ -32,19 +45,19 @@ let to_human = function
 let to_detail_json : t -> Yojson.Safe.t = function
   | Provider_overflow { limit_tokens } ->
     `Assoc
-      [ "kind", `String "provider_overflow"
-      ; ( "limit_tokens"
+      [ kind_field, `String "provider_overflow"
+      ; ( limit_tokens_field
         , match limit_tokens with
           | Some limit_tokens -> `Int limit_tokens
           | None -> `Null )
       ]
   | Request_body_over_capacity { actual_bytes; limit_bytes } ->
     `Assoc
-      [ "kind", `String "request_body_over_capacity"
+      [ kind_field, `String "request_body_over_capacity"
       ; actual_bytes_field, `Int actual_bytes
       ; limit_bytes_field, `Int limit_bytes
       ]
-  | Manual -> `Assoc [ "kind", `String "manual" ]
+  | Manual -> `Assoc [ kind_field, `String "manual" ]
 ;;
 
 type decode_error =
@@ -101,10 +114,10 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
     in
     let ( let* ) = Result.bind in
     let* () = reject_duplicate_fields [] fields in
-    (match List.assoc_opt "kind" fields with
+    (match List.assoc_opt kind_field fields with
      | Some (`String "provider_overflow") ->
-       let* () = reject_unknown_fields [ "kind"; "limit_tokens" ] in
-       (match List.assoc_opt "limit_tokens" fields with
+       let* () = reject_unknown_fields [ kind_field; limit_tokens_field ] in
+       (match List.assoc_opt limit_tokens_field fields with
         | Some `Null -> Ok (Provider_overflow { limit_tokens = None })
         | Some (`Int limit_tokens) when limit_tokens > 0 ->
           Ok (Provider_overflow { limit_tokens = Some limit_tokens })
@@ -112,7 +125,7 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
         | Some _ -> Error Invalid_provider_limit)
      | Some (`String "request_body_over_capacity") ->
        let* () =
-         reject_unknown_fields [ "kind"; actual_bytes_field; limit_bytes_field ]
+         reject_unknown_fields [ kind_field; actual_bytes_field; limit_bytes_field ]
        in
        let positive_int field =
          match List.assoc_opt field fields with
@@ -129,7 +142,7 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
        then Ok (Request_body_over_capacity { actual_bytes; limit_bytes })
        else Error (Request_body_within_capacity { actual_bytes; limit_bytes })
      | Some (`String "manual") ->
-       let* () = reject_unknown_fields [ "kind" ] in
+       let* () = reject_unknown_fields [ kind_field ] in
        Ok Manual
      | Some (`String kind) -> Error (Unknown_kind kind)
      | Some _ -> Error Invalid_kind

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -31,6 +31,13 @@ val to_human : t -> string
 (** Structured JSON detail for durable observation. *)
 val to_detail_json : t -> Yojson.Safe.t
 
+(** Every key {!to_detail_json} can emit, across all constructors. A consumer
+    that filters or validates the encoded object reads this rather than
+    restating the keys, so a field added to a constructor cannot be dropped by
+    a stale allowlist. Not the per-kind key set — {!of_detail_json} still
+    rejects a key that does not belong to the decoded [kind]. *)
+val wire_field_names : string list
+
 type decode_error =
   | Expected_object
   | Unknown_field of string

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -10,16 +10,26 @@
 
     2026-07-26까지 이 문서는 "OAS capability facts가 native structured output을
     허용하면 JsonSchema를 싣는다(Native tier)"와 "tier 결정은 로그로 관측"을
-    적고 있었다. 구현에는 그 분기도 tier 로그도 없다. 그리고 실제 위험은 문서가
-    부인했던 [JsonMode] silent downgrade가 아니라 그 반대다: 아무 형식도 요청하지
-    않으므로 provider가 마크다운 펜스를 붙이면 strict 파싱이 실패한다. 라이브에서
-    관측된 형태이며(keeper rondo, event-queue.json last_settlement,
-    2026-07-25T10:44Z, ``Invalid token '```json``) tier 기록이 없어 실패한 뒤
-    settlement에서만 보였다.
+    적고 있었다. 구현에는 그 분기도 tier 로그도 없다.
 
-    설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 —
-    RFC가 tier를 요구한다면 구현이 빠진 것이고, 요구하지 않는다면 RFC 쪽을
-    맞춰야 한다. 어느 쪽인지는 확인하지 않았다. *)
+    실패 형태는 마크다운 펜스 자체가 아니다. {!Fusion_judge_parse.of_string}은
+    Yojson 에 넘기기 전에 [strip_fences] 로 선두 ``` / ```json 펜스와 후행 펜스를
+    벗기므로(fusion_judge_parse.ml:177-190), 응답 전체가 펜스 블록 하나면 파싱은
+    통과한다. 벗겨지지 않는 경우는 둘뿐이다 — 펜스 앞에 산문이 붙어 첫 3바이트가
+    ``` 이 아니거나, 펜스 뒤에 개행이 없어 [String.index_opt s '\n'] 이 [None]
+    이라 원문이 그대로 나가는 경우. 라이브 관측(keeper rondo, event-queue.json
+    last_settlement, 2026-07-25T10:44Z, ``Invalid token '```json``)은 Yojson 이
+    펜스를 봤다는 뜻이므로 이 둘 중 하나이며, 어느 쪽인지는 tier 기록이 없어
+    settlement 만으로는 가려지지 않는다.
+
+    설계 SSOT 와의 충돌은 미해결이 아니라 확인된 상태다:
+    docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 는 provider-native
+    JSON schema 강제([Structured.extract], 미지원 provider fail-fast)를 요구한다.
+    구현은 그 요구를 의도적으로 철회했고 근거는 fusion_judge.ml:157-164 에 있다 —
+    (1) capability 사실이 거짓일 수 있다(ollama.com cloud 는 declared 인데
+    json_schema 를 무시, 2026-07-02 probe), (2) #22768 "native schema or fail
+    before HTTP" 가 미지원 preset 의 fusion 을 영구 불능으로 만들어 되돌려졌다.
+    따라서 맞춰야 하는 쪽은 RFC 이며, §7.2 에 그 사실을 기재했다. *)
 
 (** 질문 + 패널 답들로 심판 프롬프트를 구성한다
     ({!Fusion_judge_parse.expected_json_doc} 지시 포함). 순수 — 테스트 가능. *)
@@ -28,7 +38,8 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
 (** 심판 모델을 실행해 구조화 종합을 받는다.
 
     [judge_model]: runtime_id("provider.model"). [question]/[panel]로 프롬프트를
-    구성해 실행하고, capability-aware output contract를 적용한 응답 텍스트를
+    구성해 실행하고, [apply_fusion_judge_output_contract](capability 를 읽지 않고
+    무조건 [response_format = Off] / [output_schema = None])를 적용한 응답 텍스트를
     {!Fusion_judge_parse.of_string}으로 파싱한다.
     [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
     [max_tokens]는 출력 토큰 예산이다. 생략하면 Runtime_agent 기본값을 보존한다.

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -364,9 +364,17 @@ let manifest_top_level_allowlist =
     ; "runtime_id"; "status"; "decision"; "links"
     ]
 
+(* [trigger_detail] keys come from the encoder that writes them, not from a
+   copy kept here. The flat list below used to name only "kind" and
+   "limit_tokens", so a [Request_body_over_capacity] refusal reached the public
+   projection stripped of the two measured integers that justify it — the
+   operator saw the refusal and not its bounds. Sourcing the key set from
+   {!Compaction_trigger.wire_field_names} means a field added to a trigger
+   constructor cannot be dropped here without also failing to compile there. *)
 let decision_public_allowlist =
   StringSet.of_list
-    [ "edge_id"; "lane"; "source_clock"; "observed_at"; "started_at"; "finished_at"
+    (Compaction_trigger.wire_field_names
+    @ [ "edge_id"; "lane"; "source_clock"; "observed_at"; "started_at"; "finished_at"
     ; "elapsed_ms"; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"
     ; "compaction_id"; "event_bus_correlation_id"
     ; "event_bus_run_id"; "parent_event_id"; "caused_by"; "logical_seq"
@@ -379,7 +387,7 @@ let decision_public_allowlist =
     ; "routing_action"; "routing_reason"; "degraded_runtime_id"
     ; "runtime_execution_built"
     ; "media_dropped_total"; "media_dropped_counts"
-    ; "payload_role"; "trigger"; "trigger_detail"; "kind"; "limit_tokens"
+    ; "payload_role"; "trigger"; "trigger_detail"
     ; "ratio"; "threshold"; "count"
     ; "source_requeued"; Keeper_compaction_evidence.exact_evidence_key
     ; "clock_refs"
@@ -389,7 +397,7 @@ let decision_public_allowlist =
     ; "operator_action_required"; "trace_id"; "generation"; "turn_count"
     ; "sha256"; "kind"; "detail"; "backtrace_present"; "completion_error"
     ; "failure_dispatch"; "failure_dispatch_error"
-    ]
+    ])
 
 let compaction_evidence_public_allowlist =
   StringSet.of_list Keeper_compaction_evidence.wire_field_names

--- a/test/test_fs_compat_capability_exact_read.ml
+++ b/test/test_fs_compat_capability_exact_read.ml
@@ -1031,19 +1031,31 @@ let test_darwin_feature_level_precedes_fcntl () =
     | Some offset -> offset
     | None -> failf "capability exact read stub does not contain %S" needle
   in
-  let darwin_level = offset_of "_DARWIN_C_SOURCE" in
+  (* Anchored on the whole guarded block rather than on the bare macro name.
+     The first occurrence of "_DARWIN_C_SOURCE" in the stub is the guard's own
+     !defined(...) test, not the #define under it, so deleting the #define line
+     — the exact #25734 regression #25745 repaired — left both of the previous
+     orderings satisfied and this case green while no macOS checkout could
+     compile fs_compat. No CI runner is macOS (every runs-on in .github is
+     ubuntu-latest except release.yml's continue-on-error macos-14 matrix
+     entry), so nothing else would have caught it. Matching the block proves in
+     one needle that the definition exists, sits inside the __APPLE__ guard,
+     and is closed; offset_of fails the case when it does not. *)
+  let darwin_level_block =
+    String.concat
+      "\n"
+      [ "#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)"
+      ; "#define _DARWIN_C_SOURCE"
+      ; "#endif"
+      ]
+  in
+  let darwin_level = offset_of darwin_level_block in
   let fcntl_include = offset_of "#include <fcntl.h>" in
   check
     bool
-    "Darwin feature level is raised before <fcntl.h>"
+    "the Apple-guarded Darwin feature level is raised before <fcntl.h>"
     true
-    (darwin_level < fcntl_include);
-  (* Raised under an __APPLE__ guard so other platforms keep their own level. *)
-  check
-    bool
-    "the Darwin level is guarded to Apple"
-    true
-    (offset_of "defined(__APPLE__)" < darwin_level)
+    (darwin_level < fcntl_include)
 ;;
 
 let () =

--- a/test/test_keeper_failure_judgment_contract.ml
+++ b/test/test_keeper_failure_judgment_contract.ml
@@ -199,10 +199,18 @@ let test_malformed_response_has_one_dispatch_surface () =
     "one opaque OAS execution is dispatched per failure-judgment stimulus"
     1
     dispatch_count;
-  check int
-    "a response-contract failure returns as the typed terminal result"
-    1
-    (count_occurrences ~needle:"| Error _ as error -> error" source);
+  (* No source-text count pins the response-contract propagation arm here.
+     #25769 added [check int ... 1 (count_occurrences ~needle:"| Error _ as
+     error -> error")], but that needle matches both propagation arms of [run]
+     — the [resolve_runtime_id] arm and the [parse_response] arm — so it read 2
+     and the case failed unconditionally from the moment it merged. Retuning
+     the needle or raising the expectation to 2 would keep a string classifier
+     over source text (CLAUDE.md workaround signature #2) that any refactor of
+     an unrelated arm breaks again. The property it claimed is already pinned
+     by type: [test_typed_judge_error_disposition] asserts
+     [Response_contract_error] disposes to [Escalate_judge_failure] through the
+     exposed .mli. The dispatch count above and the forbidden-token list below
+     are what this case actually owns. *)
   List.iter
     (fun forbidden ->
        check int


### PR DESCRIPTION
## 무엇

지난 24시간 내 머지된 masc PR 39건에서 Codex 리뷰 지적 115건을 수집했고, 그중 **답글 한 줄 없이 머지된 46건**을 현재 main 기준으로 재검증했습니다. 재검증 후 적대적 반증까지 통과한 6건을 고칩니다.

| 출처 PR | 등급 | 증상 |
|---|---|---|
| #25726 | P1 | `scripts/fixtures/*.toml` 만 바꾼 PR은 Build job이 skip |
| #25769 | P1 | `test_malformed_response_has_one_dispatch_surface` 가 머지 시점부터 **무조건 실패** |
| #25754 | P2 | Darwin feature-level 회귀 핀이 공허 — 회귀를 통과시킴 |
| #25739 | P2 | 용량 거부의 측정 바이트값이 공개 매니페스트에서 드롭 |
| #25743 | P2 x3 | `fusion_judge.mli` 3개 서술이 코드/RFC와 불일치 |

## 왜 지금도 유효한가

각 건은 지적 당시가 아니라 **현재 main HEAD 코드**로 확인했습니다.

**#25726 — build 트리거 누락.** `ci.yml:272` 분류기에 두 fixture 경로를 실제로 통과시켜 확인했습니다.

```
$ printf '%s\n' scripts/fixtures/release-evidence/runtime.toml \
    scripts/fixtures/release-evidence/oas-models-overlay.toml \
    scripts/harness/x.py lib/a.ml | grep -E '<ci.yml:272 regex>'
scripts/harness/x.py
lib/a.ml
```

fixture 2건은 매칭되지 않습니다. `.toml` 은 목록의 어떤 suffix에도 걸리지 않고 `scripts/harness/` 접두사도 아닙니다. 반면 `test/dune:725` 는 `(source_tree ../scripts/fixtures)` 를 dep으로 선언하고 `test_runtime_config_validity.ml` 은 `scripts/fixtures/<name>/runtime.toml` 을 **발견 방식**으로 스캔합니다. 즉 fixture만 고친 PR은 테스트 입력을 바꾸면서 Build를 건너뛴 채 머지될 수 있습니다. `scripts/harness/` 와 같은 이유이므로 같은 방식(디렉터리 접두사)으로 처리했습니다.

**#25769 — 항상 실패하는 단언.** `count_occurrences ~needle:"| Error _ as error -> error"` 는 1을 기대하지만 `keeper_failure_judge.ml` 에는 두 개가 있습니다.

```
$ grep -n -F '| Error _ as error -> error' lib/keeper/keeper_failure_judge.ml
101:  | Error _ as error -> error      (* resolve_runtime_id arm *)
120:           | Error _ as error -> error   (* parse_response arm *)
```

needle을 다시 맞추거나 기대값을 2로 올리지 않았습니다. 둘 다 소스 텍스트 위의 문자열 분류기(CLAUDE.md 워크어라운드 시그니처 #2)를 유지하는 것이고, 무관한 arm을 리팩터링하면 또 깨집니다. 이 단언이 주장한 속성은 같은 파일 `test_typed_judge_error_disposition` 이 `Response_contract_error → Escalate_judge_failure` 로 **타입 수준에서** 이미 고정하고 있습니다. 케이스 이름이 말하는 single-dispatch는 남은 dispatch 카운트와 forbidden-token 목록이 담당합니다.

**#25754 — 공허한 회귀 핀.** stub의 첫 `_DARWIN_C_SOURCE` 는 `#define` 이 아니라 가드 자신의 `!defined(...)` 입니다.

```
첫 _DARWIN_C_SOURCE   : 374   ← "&& !defined(_DARWIN_C_SOURCE)"
#define _DARWIN_C_SOURCE: 392
#include <fcntl.h>     : 444
```

`#define` 줄만 지우는 변이(=#25734 가 냈던 바로 그 회귀)를 넣으면 두 단언이 모두 green으로 남습니다. 블록 전체를 needle로 바꿔 변이 2종을 검증했습니다: (a) `#define` 삭제 → 블록 부재로 케이스 실패, (b) 블록을 `<fcntl.h>` 뒤로 이동 → 순서 단언 실패. PR/main CI에 macOS runner가 없으므로(모든 `runs-on` 이 ubuntu-latest, release.yml 의 `continue-on-error` macos-14 제외) 이 핀 외에는 잡을 수단이 없습니다.

**#25739 — 드롭되는 측정값.** `Compaction_trigger.to_detail_json` 은 `Request_body_over_capacity` 에 `actual_bytes`/`limit_bytes` 를 싣지만 `keeper_runtime_manifest.ml` 의 `decision_public_allowlist` 는 `kind`/`limit_tokens` 만 나열했습니다. `public_projection_of_decision` 은 미허용 키를 `List.filter_map` 으로 **조용히 버리므로**, `public_to_json` → dashboard HTTP(`server_dashboard_http_keeper_api_types.ml:435`)에는 거부 사실만 가고 그 근거인 두 정수는 사라집니다. allowlist를 인코더가 소유한 `Compaction_trigger.wire_field_names` 에서 가져오도록 바꿔, trigger 생성자에 필드가 늘어도 여기서 조용히 빠질 수 없게 했습니다.

**#25743 — 문서 3건.**
- 펜스: `Fusion_judge_parse.strip_fences`(`fusion_judge_parse.ml:177-190`)가 선두 ```` ``` ````/```` ```json ```` 과 후행 펜스를 벗깁니다. 응답 전체가 펜스 블록이면 파싱은 통과합니다. 실패 조건은 펜스 앞 산문 또는 펜스 뒤 개행 부재(`| None -> s`) 둘뿐이며, 그렇게 고쳐 적었습니다.
- `run` 독스트링의 "capability-aware output contract" 는 헤더가 선언한 단일 tier와 모순이라 실제 동작으로 교체했습니다.
- RFC-0252 §7.2 는 `Structured.extract`(provider-native schema 강제, 미지원 fail-fast)를 **실제로 요구합니다**. 구현은 `fusion_judge.ml:157-164` 에 기록된 두 근거(ollama.com cloud 가 declared 인데 무시, #22768 revert)로 의도적으로 철회했습니다. mli 헤더의 "어느 쪽인지 확인하지 않았다" 를 지우고, §7.2 를 철회 표시했습니다.

## 검증

- `ci.yml` YAML 파싱 OK. 분류기 정규식에 fixture 경로 직접 통과 (위 출력).
- `#define` 삭제 변이를 실제 macOS SDK로 컴파일해 `use of undeclared identifier 'O_NOFOLLOW'` 재현 확인. 구 단언이 그 변이를 통과함도 확인.
- `dune build lib/compaction_trigger` EXIT=0 (이 라이브러리는 agent_sdk 비의존).

**미검증 — 정직하게 밝힙니다.** 전체 `dune build @check` 를 로컬에서 돌리지 못했습니다. 공유 opam switch가 현재 agent_sdk **0.226.0** 이고(#25822 작업 세션이 설정), main SSOT는 `0.223.1` 이라 `scripts/dune-local.sh` 가 핀 drift로 빌드를 거부합니다. switch를 되돌리면 #25822 세션을 깨뜨리므로 하지 않았습니다. `lib/keeper/keeper_runtime_manifest.ml` 과 두 테스트의 컴파일·실행은 CI가 권위입니다.

또한 **이 브랜치의 CI는 main red를 상속합니다**: 현재 main(`3bb40255d9`)의 `Build and Test` 가 red이며(`keeper_runtime_meta_transaction.ml` 컴파일 실패), #25819 가 수정 중입니다. 그 PR이 머지된 뒤 이 브랜치를 리베이스해야 green 여부를 판정할 수 있습니다.

## 건드리지 않은 것

provider/model/pricing 정책 없음. 마이그레이션·레거시 분기 없음. 새 텔레메트리 없음. 문자열 분류기 추가 없음(하나 제거). `keeper_shutdown_finalize.ml`(#25816 진행 중), `keeper_meta_store.ml`(#25780 진행 중)은 의도적으로 제외했습니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 문서 중 어느 것도 건드리지 않습니다. 변경 범위는 CI 트리거 1줄, 테스트 단언 2건, 매니페스트 allowlist 1건, 문서 4건입니다.
