### PR TITLE
fix(keeper): default fresh keeper-up to local playground

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -494,7 +494,12 @@ let effective_meta_of_profile_defaults
   let target_sandbox_profile =
     match defaults.sandbox_profile, defaults.manifest_path with
     | Some profile, _ -> Ok profile
-    | None, _ -> Error (missing_required_sandbox_profile_error ~keeper_name:meta.name defaults)
+    | None, None -> Ok meta.sandbox_profile
+    | None, Some _ ->
+      Error
+        (missing_required_sandbox_profile_error
+           ~keeper_name:meta.name
+           defaults)
   in
   match target_sandbox_profile with
   | Error _ as err -> err

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -167,7 +167,8 @@ let keeper_schemas : tool_schema list = [
         ("sandbox_profile", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "local"; `String "docker"]);
-          ("description", `String "Sandbox isolation profile. Required when creating a keeper that has no TOML declaring one; ignored in favour of the TOML when it does. Stated rather than defaulted because it is an isolation boundary.");
+          ("default", `String "local");
+          ("description", `String "Sandbox isolation profile. New keepers default to local with playground-only writes when omitted; select docker explicitly when required.");
         ]);
         ("autoboot_enabled", `Assoc [
           ("type", `String "boolean");
@@ -235,6 +236,12 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Goal IDs this keeper is allowed to claim work for. Empty clears goal scoping.");
+        ]);
+        ("sandbox_profile", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "local"; `String "docker"]);
+          ("default", `String "local");
+          ("description", `String "Sandbox isolation profile. New keepers default to local with playground-only writes when omitted; select docker explicitly when required.");
         ]);
         ("autoboot_enabled", `Assoc [
           ("type", `String "boolean");

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -104,11 +104,21 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
     | Error e -> Error (tool_result_error e)
     | Ok () ->
     match
-      reject_removed_keeper_input_keys ~allow_sandbox_fields
+      reject_removed_keeper_input_keys ~allow_sandbox_fields:true
         ~tool_name:"masc_keeper_up" args
     with
     | Error e -> Error (tool_result_error e)
     | Ok () ->
+    if
+      (not allow_sandbox_fields)
+      && Option.is_some (Json_util.assoc_member_opt "network_mode" args)
+    then
+      Error
+        (tool_result_error
+           "removed keeper sandbox args for masc_keeper_up: network_mode. Configure \
+            network posture in keeper TOML/profile defaults; the public keeper-up \
+            contract accepts only the optional sandbox_profile isolation boundary.")
+    else
     let allowed_paths_opt_res = parse_present_string_list_opt args "allowed_paths" in
     let active_goal_ids_opt_res = parse_present_string_list_opt args "active_goal_ids" in
     let mention_targets_opt_res = parse_present_string_list_opt args "mention_targets" in
@@ -137,27 +147,21 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
     | Error error ->
       Error (tool_result_error (keeper_toml_load_error_to_string error))
     | Ok profile_defaults ->
-    (* The caller's [sandbox_profile] satisfies this requirement as well as the TOML
-       does. It is required because the sandbox is an isolation boundary and must be
-       stated rather than defaulted — but it was only readable from a keeper TOML the
-       tool does not write, so [masc_keeper_up] could not create a keeper that did not
-       already exist on disk while describing itself as "Create or update" (masc#25767).
-       The argument was already parsed here and already honoured by the update path
-       (keeper_turn_up_update.ml:65-73); only this gate ignored it.
-
-       An invalid value is rejected here rather than passed through: the create path
-       resolves the profile from [profile_defaults], so a bad string would otherwise
-       satisfy the gate and then be silently dropped. *)
+    (* An explicit profile must be valid. When neither the call nor keeper TOML states
+       one, creation uses the local sandbox with playground-only writes. This is the
+       narrow safe bootstrap: a fresh keeper can start without a hand-authored TOML,
+       while docker remains an explicit opt-in. *)
     let sandbox_profile_error =
-      match profile_defaults.sandbox_profile, sandbox_profile_opt with
-      | Some _, _ -> None
-      | None, Some raw when Option.is_none (sandbox_profile_of_string raw) ->
+      match sandbox_profile_opt, profile_defaults.sandbox_profile,
+        profile_defaults.manifest_path
+      with
+      | Some raw, _, _ when Option.is_none (sandbox_profile_of_string raw) ->
         Some
           (Printf.sprintf
              "invalid sandbox_profile: %S (expected: local or docker)"
              raw)
-      | None, Some _ -> None
-      | None, None ->
+      | Some _, _, _ | None, Some _, _ | None, None, None -> None
+      | None, None, Some _ ->
         Some
           (missing_required_sandbox_profile_error
              ~keeper_name:name
@@ -207,17 +211,12 @@ let resolve_mention_targets ~mention_targets_opt ~fallback_targets ~name =
   in
   raw |> List.filter_map String_util.trim_nonempty |> dedupe_keep_order
 
-(* An explicit request wins over the TOML default. Without this the create gate would
-   accept a caller-supplied profile and then create the keeper with a different one —
-   accepting a value and dropping it is worse than refusing it, because the operator has
-   no signal that the isolation boundary is not what they asked for. Parsing already
-   succeeded at the gate (keeper_turn_up_args.ml, sandbox_profile_error), so an
-   unparseable value cannot reach here; it is treated as absent rather than silently
-   mapped to the default. *)
+(* An explicit request wins over the TOML default. Without either source, use the
+   canonical local sandbox; creation pairs it with playground-only writes. *)
 let resolve_sandbox_profile ?requested ~fallback () =
   match Option.bind requested sandbox_profile_of_string with
-  | Some _ as stated -> stated
-  | None -> fallback
+  | Some stated -> stated
+  | None -> Option.value ~default:default_sandbox_profile fallback
 
 let resolve_network_mode ~sandbox_profile ~fallback =
   fallback

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -216,7 +216,10 @@ let resolve_mention_targets ~mention_targets_opt ~fallback_targets ~name =
 let resolve_sandbox_profile ?requested ~fallback () =
   match Option.bind requested sandbox_profile_of_string with
   | Some stated -> stated
-  | None -> Option.value ~default:default_sandbox_profile fallback
+  | None ->
+    (match fallback with
+     | Some stated -> stated
+     | None -> default_sandbox_profile)
 
 let resolve_network_mode ~sandbox_profile ~fallback =
   fallback

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -66,16 +66,12 @@ val resolve_sandbox_profile :
   ?requested:string ->
   fallback:sandbox_profile option ->
   unit ->
-  sandbox_profile option
-(** An explicit [requested] profile wins over the TOML [fallback]. [None] when neither
-    states one.
+  sandbox_profile
+(** An explicit [requested] profile wins over the TOML [fallback].
 
-    No built-in default. The sandbox is an isolation boundary, so a caller that states
-    nothing gets [None] rather than a quietly chosen profile — the determinism gate
-    names that shape "permissive default on unknown input", and it is the same rule this
-    tool applies by requiring the value at all. The tool gate rejects the
-    nothing-stated case before creation, so this returning [None] is a contract the
-    caller can rely on rather than a case it has to guess at.
+    When neither source states a profile, returns the canonical local sandbox default.
+    Fresh keepers also default to an empty [allowed_paths] list, so that local sandbox
+    is restricted to [.masc/playground/<keeper_name>/].
 
     [requested] is the caller's raw string; an unparseable one is treated as absent,
     since the gate rejects those first. *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -94,24 +94,11 @@ let create_keeper_admitted_body
             (Printf.sprintf "unknown active_goal_ids: %s"
                (String.concat ", " missing))
   in
-  (* [None] cannot reach here: the tool gate rejects a turn-up that states no sandbox
-     profile in either the argument or the keeper TOML
-     (keeper_turn_up_args.ml, sandbox_profile_error). Raising rather than choosing one
-     keeps that contract checkable — a quiet default here would decide an isolation
-     boundary on behalf of a caller who stated nothing, which is the requirement this
-     tool exists to enforce. *)
   let sandbox_profile =
-    match
-      resolve_sandbox_profile
-        ?requested:p.sandbox_profile_opt
-        ~fallback:p.profile_defaults.sandbox_profile
-        ()
-    with
-    | Some sp -> sp
-    | None ->
-      invalid_arg
-        "Keeper_turn_up_create: no sandbox_profile in argument or keeper TOML; the \
-         turn-up gate must reject this before creation"
+    resolve_sandbox_profile
+      ?requested:p.sandbox_profile_opt
+      ~fallback:p.profile_defaults.sandbox_profile
+      ()
   in
   let network_mode =
     resolve_network_mode

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -549,47 +549,87 @@ instructions = "missing sandbox profile"
        ~needle:"sandbox_profile is required"
        (Profile.tool_result_body result))
 
-let test_keeper_up_rejects_missing_profile_source () =
+let test_public_keeper_up_creates_local_playground_without_profile_source () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
-  let name = "nosourceup" in
+  let name = "fresh-local-keeper" in
+  let rejected_name = "network-mode-keeper" in
   let config = Workspace.default_config base in
-  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  ignore (Workspace.init config ~agent_name:(Some "test-agent"));
+  Masc.Server_startup_state.mark_state_ready
+    ~backend:Masc.Server_startup_state.Filesystem_backend
+  |> Result.get_ok;
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  let ctx : _ Profile.context =
-    {
-      config;
-      agent_name = "test-agent";
-      sw;
-      clock = Eio.Stdenv.clock env;
-      proc_mgr = None;
-      net = None;
-      publication_recovery_provider =
-        Masc_test_deps.non_runtime_publication_recovery_provider;
-    }
+  let dispatch args =
+    match
+      !Masc.Keeper_dispatch_ref.dispatch
+        ~config
+        ~agent_name:"test-agent"
+        ~publication_recovery_provider:
+          Masc_test_deps.non_runtime_publication_recovery_provider
+        ~sw
+        ~clock:(Eio.Stdenv.clock env)
+        ~name:"masc_keeper_up"
+        ~args
+        ()
+    with
+    | Some result -> result
+    | None -> Alcotest.fail "public masc_keeper_up dispatch was not registered"
   in
-  let result = Turn.handle_keeper_up ctx (`Assoc [ ("name", `String name) ]) in
-  if Profile.tool_result_success result then
-    Alcotest.fail "keeper_up should reject missing TOML/persona source";
+  let rejected =
+    dispatch
+      (`Assoc
+        [ "name", `String rejected_name
+        ; "network_mode", `String "none"
+        ])
+  in
   Alcotest.(check bool)
-    "keeper_up missing source error names sandbox_profile"
+    "public keeper_up rejects network_mode"
+    false
+    (Profile.tool_result_success rejected);
+  Alcotest.(check bool)
+    "network_mode rejection names the removed field"
     true
     (contains_substring
-       ~needle:"sandbox_profile is required"
-       (Profile.tool_result_body result))
-
-let test_missing_profile_source_fails_loud () =
-  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
-  let name = "nosource" in
-  let config = Workspace.default_config base in
-  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
-  match Store.read_effective_meta config name with
-  | Ok _ -> Alcotest.fail "expected absent TOML/persona source to fail loudly"
-  | Error err ->
-      Alcotest.(check bool)
-        "error names missing sandbox_profile"
-        true
-        (contains_substring ~needle:"sandbox_profile is required" err)
+       ~needle:"network_mode"
+       (Profile.tool_result_body rejected));
+  (match Store.read_meta config rejected_name with
+   | Ok None -> ()
+   | Ok (Some _) -> Alcotest.fail "rejected network_mode call persisted a keeper"
+   | Error err -> Alcotest.failf "rejected keeper meta read failed: %s" err);
+  let result = dispatch (`Assoc [ "name", `String name ]) in
+  if not (Profile.tool_result_success result) then
+    Alcotest.failf
+      "public keeper_up failed without a profile source: %s"
+      (Profile.tool_result_body result);
+  (match Store.read_effective_meta config name with
+   | Error err -> Alcotest.failf "effective created keeper meta read failed: %s" err
+   | Ok None -> Alcotest.fail "public keeper_up did not persist the fresh keeper"
+   | Ok (Some meta) ->
+     Alcotest.(check string)
+       "fresh keeper persists local sandbox"
+       "local"
+       (Profile.sandbox_profile_to_string meta.sandbox_profile);
+     Alcotest.(check (list string))
+       "fresh keeper persists no extra allowed paths"
+       []
+       meta.allowed_paths;
+     Alcotest.(check (list string))
+       "empty allowed paths resolves to the keeper playground only"
+       [ Printf.sprintf ".masc/playground/%s/" name ]
+       (Masc.Keeper_alerting_path.effective_write_allowed_paths ~meta));
+  let toml_path =
+    Filename.concat
+      (Filename.concat
+         (Filename.concat (Filename.concat base ".masc") "config")
+         "keepers")
+      (name ^ ".toml")
+  in
+  Alcotest.(check bool)
+    "fresh local keeper requires no compatibility TOML"
+    false
+    (Sys.file_exists toml_path)
 
 let test_status_tracks_toml_overlay_changes () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
@@ -1217,11 +1257,10 @@ let () =
           Alcotest.test_case
             "keeper_up rejects profile source without sandbox_profile"
             `Quick test_keeper_up_rejects_profile_source_without_sandbox_profile;
-          Alcotest.test_case "keeper_up rejects missing profile source" `Quick
-            test_keeper_up_rejects_missing_profile_source;
           Alcotest.test_case
-            "missing profile source fails loudly"
-            `Quick test_missing_profile_source_fails_loud;
+            "public keeper_up creates local playground without profile source"
+            `Quick
+            test_public_keeper_up_creates_local_playground_without_profile_source;
           Alcotest.test_case "status tracks TOML overlay edits" `Quick
             test_status_tracks_toml_overlay_changes;
           Alcotest.test_case "status reports normalized options"

--- a/test/test_keeper_turn_up_args.ml
+++ b/test/test_keeper_turn_up_args.ml
@@ -78,7 +78,7 @@ let test_requested_sandbox_profile_wins_over_the_toml_fallback () =
     "an explicit request creates without a TOML default"
     true
     (A.resolve_sandbox_profile ~requested:"docker" ~fallback:None ()
-     = Some Keeper_types_profile_toml_io.Docker);
+     = Keeper_types_profile_toml_io.Docker);
   check
     bool
     "an explicit request overrides the TOML default"
@@ -87,7 +87,7 @@ let test_requested_sandbox_profile_wins_over_the_toml_fallback () =
        ~requested:"local"
        ~fallback:(Some Keeper_types_profile_toml_io.Docker)
        ()
-     = Some Keeper_types_profile_toml_io.Local);
+     = Keeper_types_profile_toml_io.Local);
   check
     bool
     "no request keeps the TOML default"
@@ -95,7 +95,7 @@ let test_requested_sandbox_profile_wins_over_the_toml_fallback () =
     (A.resolve_sandbox_profile
        ~fallback:(Some Keeper_types_profile_toml_io.Docker)
        ()
-     = Some Keeper_types_profile_toml_io.Docker);
+     = Keeper_types_profile_toml_io.Docker);
   (* Unparseable is treated as absent rather than mapped to a profile: the tool gate
      rejects it before this point, and inventing an isolation boundary here would hide
      that rejection if the gate were ever bypassed. *)
@@ -107,13 +107,14 @@ let test_requested_sandbox_profile_wins_over_the_toml_fallback () =
        ~requested:"chroot"
        ~fallback:(Some Keeper_types_profile_toml_io.Docker)
        ()
-     = Some Keeper_types_profile_toml_io.Docker);
-  (* Nothing stated resolves to nothing rather than to a quietly chosen boundary. *)
+     = Keeper_types_profile_toml_io.Docker);
+  (* Nothing stated gets the narrow local + playground-only bootstrap profile. *)
   check
     bool
-    "neither stated resolves to None, not to a default"
+    "neither stated resolves to the local sandbox default"
     true
-    (A.resolve_sandbox_profile ~fallback:None () = None)
+    (A.resolve_sandbox_profile ~fallback:None ()
+     = Keeper_types_profile_toml_io.Local)
 ;;
 
 let () =

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -606,7 +606,7 @@ let test_masc_keeper_up_schema () =
   | Some schema ->
       match get_json_assoc "properties" schema.input_schema with
       | Some props ->
-          Alcotest.(check bool) "omits sandbox_profile" false
+          Alcotest.(check bool) "has sandbox_profile" true
             (List.mem_assoc "sandbox_profile" props);
           Alcotest.(check bool) "omits network_mode" false
             (List.mem_assoc "network_mode" props);


### PR DESCRIPTION
## Summary

- make `sandbox_profile` optional on public `masc_keeper_up`; omitted fresh keepers use the concrete `Local` default while an explicit `docker` request still wins
- reject any public `network_mode` key, including `null`, while preserving the dashboard-only sandbox edit path
- keep declarative TOML/persona profiles fail-loud when they exist but omit `sandbox_profile`; only the no-profile-source path reconstructs persisted Local/empty posture
- hard-cut `resolve_sandbox_profile` to return `sandbox_profile`, not an impossible option
- align both `masc_keeper_up` and `masc_keeper_create_from_persona` schemas on `default = local`
- add a real `Keeper_dispatch_ref.dispatch` integration path proving network-mode rejection, fresh creation without TOML, effective-meta persistence as Local with `allowed_paths = []`, and the sole write root `.masc/playground/<keeper>/`

No compatibility facade, TOML migration, or generated keeper TOML is added.

Follow-up to #25768.
Refs #25767.

## Validation

- `ocamlformat --check` on all touched OCaml files: pass
- `git diff --check`: pass
- `ocamlc -stop-after parsing` on all touched OCaml files: pass
- focused wrapper build attempted for `test_keeper_turn_up_args.exe`, `test_keeper_effective_meta_overlay.exe`, and `test_tools_coverage.exe`

The wrapper stopped before compilation because this checkout expects `agent_sdk` pin `3d4ee19a4773cbd8b1b73ed5555c5cdfe82e6d77`, while the shared switch has `2186dfa5fca2360e4e99fa5e47052ba4c0cc687f`. Re-running with `MASC_SKIP_PIN_CHECK=1` reached unrelated stale-SDK failures (`Exact_output.create_flow_preference_store`, `Exact_output.Domain_already_settled`, `flow_execution_error_outward_dispatch`, and newer `Agent_sdk.Retry` variants). The shared switch was not changed. CI is the type/test authority for this head.

RFC-WAIVED: narrow keeper turn-up argument/default semantics and public schema alignment; no new sandbox backend or policy surface.