### PR TITLE
fix(dashboard): stop the fleet chip and turn inspector from dropping operator facts

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const getMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./core', () => ({
+  get: getMock,
+}))
+
+import { fetchKeeperTurnRecords } from './dashboard-turn-records'
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    record: {
+      keeper: 'sangsu',
+      trace_id: 'trace-1',
+      absolute_turn: 7,
+      runtime_profile: 'anthropic.claude',
+      ts: 1_700_000_000,
+      execution_ids: ['exec-1'],
+      blocks: [],
+      input_tokens: 1200,
+      output_tokens: 340,
+      ...overrides,
+    },
+  }
+}
+
+function payload(...entries: ReturnType<typeof entry>[]) {
+  return { keeper: 'sangsu', count: entries.length, skipped_rows: 0, entries }
+}
+
+afterEach(() => {
+  getMock.mockReset()
+})
+
+// #25779 made the provider cache token counts durable on the turn record, but
+// the decoder rebuilt each entry without them, so they were discarded before
+// reaching the inspector. Absent stays absent — a legacy row must not decode to
+// a fabricated 0.
+describe('keeper turn record cache token counts', () => {
+  it('carries the durable cache counts through the decoder', async () => {
+    getMock.mockResolvedValue(
+      payload(entry({ cache_creation_input_tokens: 900, cache_read_input_tokens: 15_400 })),
+    )
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+
+    expect(response.entries).toHaveLength(1)
+    expect(response.entries[0]?.record).toMatchObject({
+      input_tokens: 1200,
+      output_tokens: 340,
+      cache_creation_input_tokens: 900,
+      cache_read_input_tokens: 15_400,
+    })
+  })
+
+  it('leaves the counts undefined when the row does not carry them', async () => {
+    getMock.mockResolvedValue(payload(entry()))
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+    const record = response.entries[0]?.record
+
+    expect(record?.cache_creation_input_tokens).toBeUndefined()
+    expect(record?.cache_read_input_tokens).toBeUndefined()
+  })
+
+  it('does not coerce a non-numeric count into a number', async () => {
+    getMock.mockResolvedValue(
+      payload(entry({ cache_read_input_tokens: 'many', cache_creation_input_tokens: null })),
+    )
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+    const record = response.entries[0]?.record
+
+    expect(record?.cache_read_input_tokens).toBeUndefined()
+    expect(record?.cache_creation_input_tokens).toBeUndefined()
+  })
+})

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -31,6 +31,13 @@ export type TurnRecordEntry = {
   enable_thinking?: boolean
   input_tokens?: number
   output_tokens?: number
+  // #25779 made the provider cache counts durable on the turn record
+  // (lib/types/turn_record.ml:79-82 writes them as optional fields). Same
+  // absent-means-absent contract as the neighbours: a legacy row that predates
+  // #25779, or a provider that reports no cache usage, leaves these undefined
+  // and the inspector renders absence rather than a fabricated zero.
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
   // RFC-0233 §8 — runtime model metadata. context_window is the keeper-resolved
   // effective token budget (the ctx-fill% denominator); the two prices are USD
   // per 1M tokens declared on the runtime binding. Absent (undefined) when the
@@ -331,6 +338,8 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     enable_thinking: typeof raw.enable_thinking === 'boolean' ? raw.enable_thinking : undefined,
     input_tokens: asNumber(raw.input_tokens),
     output_tokens: asNumber(raw.output_tokens),
+    cache_creation_input_tokens: asNumber(raw.cache_creation_input_tokens),
+    cache_read_input_tokens: asNumber(raw.cache_read_input_tokens),
     context_window: asNumber(raw.context_window),
     price_input_per_million: asNumber(raw.price_input_per_million),
     price_output_per_million: asNumber(raw.price_output_per_million),

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -265,7 +265,8 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
   if (!fleetSafety) return null
   const fleet = fleetSafety.keeper_fleet_safety
   if (fleet?.status === 'ok') return null
-  const fact = keeperFleetOperatorFacts(fleet)[0] ?? CURRENT_KEEPER_FLEET_FACT_INVALID
+  const facts = keeperFleetOperatorFacts(fleet)
+  const fact = facts[0] ?? CURRENT_KEEPER_FLEET_FACT_INVALID
   const presentation = keeperFleetOperatorFactPresentation(fact, fleet?.status)
   return {
     key: 'fleet-liveness-risk',
@@ -298,8 +299,13 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
         : null,
       fleet?.blocker ? `blocker=${fleet.blocker}` : null,
       `keeper=${presentation.keeper}`,
+      presentation.taskId ? `task=${presentation.taskId}` : null,
       `reason=${presentation.reason}`,
       presentation.detail ? `detail=${presentation.detail}` : null,
+      // One chip speaks for the whole fleet, so it has to say when it is
+      // showing the most severe of several blocked keepers rather than the
+      // only one.
+      facts.length > 1 ? `blocked_keeper_fact_count=${facts.length}` : null,
       `operator_action=${presentation.action}`,
     ].filter((item): item is string => item != null).join(', '),
     tone: presentation.tone,

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -379,7 +379,12 @@ function RuntimeBlockedKeeperFactRow({
       data-testid=${`keeper-fleet-operator-fact-${index}`}
       data-tone=${presentation.tone}
     >
-      <td class="px-3 py-2 font-mono text-[var(--color-fg-primary)]">${presentation.keeper}</td>
+      <td class="px-3 py-2 font-mono text-[var(--color-fg-primary)]">
+        ${presentation.keeper}
+        ${presentation.taskId
+          ? html`<div class="font-mono text-3xs text-[var(--color-fg-muted)]">${presentation.taskId}</div>`
+          : null}
+      </td>
       <td class=${`px-3 py-2 ${toneClass}`}>
         <span class="inline-flex items-center gap-1.5">
           <${Icon} size=${14} aria-hidden="true" />

--- a/dashboard/src/components/keeper-fleet-operator-fact.test.ts
+++ b/dashboard/src/components/keeper-fleet-operator-fact.test.ts
@@ -80,4 +80,72 @@ describe('keeper fleet operator fact presentation', () => {
     expect(presentation.tone).toBe('bad')
     expect(presentation.action).toContain('resume selected paused keepers')
   })
+
+  // The server orders blocked_keepers by keeper identity and three consumers
+  // take [0] to speak for the whole fleet, so a merely-waiting keeper could
+  // sort ahead of one that needed repair and hide it.
+  it('puts a keeper that needs repair ahead of one that is only waiting', () => {
+    const waiting = fact({ keeper_name: 'aaa', action: 'wait_for_compaction' })
+    const failing = fact({
+      keeper_name: 'zzz',
+      reason: 'runtime_meta_authority',
+      action: 'inspect_lifecycle_transaction',
+    })
+
+    const ordered = keeperFleetOperatorFacts({
+      status: 'degraded',
+      blocked_keepers: [waiting, failing],
+    } as unknown as Parameters<typeof keeperFleetOperatorFacts>[0])
+
+    expect(ordered[0]).toBe(failing)
+    expect(ordered[1]).toBe(waiting)
+  })
+
+  it('keeps the server order between facts of equal severity', () => {
+    const first = fact({ keeper_name: 'aaa', action: 'wait_for_compaction' })
+    const second = fact({ keeper_name: 'bbb', action: 'wait_for_handoff' })
+
+    const ordered = keeperFleetOperatorFacts({
+      status: 'degraded',
+      blocked_keepers: [first, second],
+    } as unknown as Parameters<typeof keeperFleetOperatorFacts>[0])
+
+    expect(ordered).toEqual([first, second])
+  })
+
+  it('does not mutate the fleet payload while ordering', () => {
+    const waiting = fact({ keeper_name: 'aaa', action: 'wait_for_compaction' })
+    const failing = fact({ keeper_name: 'zzz', action: 'inspect_lifecycle_transaction' })
+    const blocked = [waiting, failing]
+
+    keeperFleetOperatorFacts({
+      status: 'degraded',
+      blocked_keepers: blocked,
+    } as unknown as Parameters<typeof keeperFleetOperatorFacts>[0])
+
+    expect(blocked).toEqual([waiting, failing])
+  })
+
+  // no_keeper_binding rows collapse to agent_name, so without the task id two
+  // unbound tasks of one agent render identically while the instruction says
+  // to reassign "the task".
+  it('carries the task identity the action refers to', () => {
+    const presentation = keeperFleetOperatorFactPresentation(
+      fact({
+        keeper_name: null,
+        agent_name: 'dreamer',
+        task_id: 'task-7f3a',
+        reason: 'no_keeper_binding',
+        action: 'create_keeper_or_reassign_task',
+      }),
+      'degraded',
+    )
+
+    expect(presentation.keeper).toBe('dreamer')
+    expect(presentation.taskId).toBe('task-7f3a')
+  })
+
+  it('reports absent task identity as null rather than a placeholder', () => {
+    expect(keeperFleetOperatorFactPresentation(fact(), 'degraded').taskId).toBeNull()
+  })
 })

--- a/dashboard/src/components/keeper-fleet-operator-fact.ts
+++ b/dashboard/src/components/keeper-fleet-operator-fact.ts
@@ -32,6 +32,11 @@ export interface KeeperFleetOperatorFactPresentation
   keeper: string
   reason: DashboardBlockedKeeperFact['reason']
   detail: string | null
+  // The row collapses to keeper_name ?? agent_name, which is null for
+  // no_keeper_binding facts — so two unbound tasks of one agent rendered as
+  // indistinguishable rows while the instruction said to reassign "the task".
+  // Carried so the presentation names the identity its action refers to.
+  taskId: string | null
 }
 
 const ACTION_PRESENTATION = {
@@ -181,11 +186,27 @@ export const CURRENT_KEEPER_FLEET_FACT_INVALID: DashboardBlockedKeeperFact = {
   operator_action_confirm_required: null,
 }
 
+// Severity the action table already declares, not a new ranking invented here.
+// Exhaustive over the closed tone union, so adding a tone is a compile error
+// until it declares its rank.
+const TONE_RANK: Record<KeeperFleetOperatorTone, number> = { bad: 0, warn: 1 }
+
 export function keeperFleetOperatorFacts(
   fleet: DashboardFleetPressureHealth | null | undefined,
 ): DashboardBlockedKeeperFact[] {
   if (fleet?.status === 'ok') return []
-  if (fleet?.blocked_keepers?.length) return fleet.blocked_keepers
+  // The server orders blocked_keepers by keeper identity, and three of the four
+  // consumers take [0] to speak for the whole fleet — so a keeper that was only
+  // waiting could outrank, and hide, one that needed repair. Ordered here, at
+  // the single point every consumer goes through, rather than at each call site.
+  // Array.prototype.sort is stable, so equal-severity facts keep the server's
+  // order.
+  if (fleet?.blocked_keepers?.length)
+    return [...fleet.blocked_keepers].sort(
+      (a, b) =>
+        TONE_RANK[ACTION_PRESENTATION[a.action].tone] -
+        TONE_RANK[ACTION_PRESENTATION[b.action].tone],
+    )
   return [CURRENT_KEEPER_FLEET_FACT_INVALID]
 }
 
@@ -205,5 +226,6 @@ export function keeperFleetOperatorFactPresentation(
     keeper: fact.keeper_name ?? fact.agent_name ?? 'Keeper fleet',
     reason: fact.reason,
     detail: fact.lifecycle_admission_reason ?? null,
+    taskId: fact.task_id,
   }
 }

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -927,6 +927,8 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
         <span class="k">fsm.state</span><span class="v">n/a</span>
         <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>
         <span class="k">output tokens</span><span class="v">${t.tokOut.toLocaleString()}</span>
+        <span class="k">cache read tokens</span><span class="v">${record.cache_read_input_tokens?.toLocaleString() ?? '미상'}</span>
+        <span class="k">cache write tokens</span><span class="v">${record.cache_creation_input_tokens?.toLocaleString() ?? '미상'}</span>
         <span class="k">ctx window${record.context_window != null ? '' : ' · 미상'}</span><span class="v">${t.ctxPct != null ? `${t.ctxPct.toFixed(1)}% / ${record.context_window?.toLocaleString() ?? '미상'}` : '미상'}</span>
         <span class="k">keeper turn</span><span class="v">T${record.absolute_turn}</span>
         <span class="k">agent subturns</span><span class="v">${formatTurnList(uniqueNumbers(t.tools.map(tool => tool.agentSubturn)))}</span>


### PR DESCRIPTION
## 무엇

지난 24시간 머지 PR 리뷰 스윕(#25826 과 같은 스윕)에서 나온 dashboard 지적 3건. 셋 다 답글 없이 머지됐고, 현재 main(`3bb40255d9`) 기준으로 재검증 + 적대 반증을 통과했습니다.

OCaml 을 건드리지 않으므로 **현재 main red(#25819 진행 중)와 무관하게** 독립적으로 판정 가능합니다. 그래서 #25826 과 분리했습니다.

## #25762 — fleet chip 이 임의의 첫 blocker 로 함대 전체를 대변

`keeperFleetOperatorFacts(fleet)[0]` 가 chip 의 label·tone·operator 지시를 결정합니다. `blocked_keepers` 는 서버가 keeper 식별자 순으로 주므로, 이름이 앞선 "대기 중" keeper 가 "수리 필요" keeper 를 가립니다.

소비자는 4곳이고 3곳이 `[0]` 을 씁니다.

```
src/components/fleet-health-panel.ts:251   keeperFleetOperatorFacts(fleet)[0]
src/components/fleet-health-panel.ts:408   keeperFleetOperatorFacts(fleet)      ← 표 전체
src/components/fleet-health-panel.ts:454   keeperFleetOperatorFacts(fleet)[0]
src/components/dashboard-shell.ts:268      keeperFleetOperatorFacts(fleet)[0]
```

호출부마다 정렬을 붙이면 N-of-M 패치가 되므로, **모두가 지나가는 `keeperFleetOperatorFacts` 안에서** 정렬했습니다.

우선순위를 새로 만들지 않았습니다. `ACTION_PRESENTATION` 이 액션마다 이미 `tone: 'warn' | 'bad'` 를 선언하고 있고(bad 14 / warn 8), 그 심각도를 그대로 씁니다. `TONE_RANK` 는 닫힌 union 위의 `Record` 라 tone 이 늘면 rank 를 선언하기 전까지 컴파일되지 않습니다. `Array.prototype.sort` 는 stable 이므로 동급끼리는 서버 순서를 유지하고, `[...]` 로 복사해 payload 를 변형하지 않습니다.

chip 하나가 함대를 대변하는 구조 자체는 그대로 두되, 여러 건 중 하나를 보여주고 있을 때는 `blocked_keeper_fact_count=N` 을 detail 에 싣도록 했습니다.

## #25762 — no_keeper_binding 행에서 task 정체성 유실

행은 `keeper_name ?? agent_name` 으로 접히는데 `no_keeper_binding` fact 는 `keeper_name` 이 null 입니다. 한 agent 에 미결합 task 가 둘이면 두 행이 구분되지 않는데, 지시문은 "the task" 를 재배정하라고 말합니다. `task_id` 는 `DashboardBlockedKeeperFact`(`types/dashboard-execution.ts:270`)에 이미 있는데 presentation 이 버리고 있었습니다.

presentation 에 `taskId` 를 싣고, 표는 keeper 셀 아래에, chip 은 detail 에 `task=...` 로 렌더합니다.

## #25779 — 턴 레코드의 캐시 토큰 수가 디코더에서 버려짐

`lib/types/turn_record.ml:79-82` 가 `cache_creation_input_tokens` / `cache_read_input_tokens` 를 optional 필드로 씁니다. `dashboard-turn-records.ts` 의 `decodeTurnRecordEntry` 는 `input_tokens`/`output_tokens` 는 디코드하면서 이 둘은 재구성하지 않아, #25779 가 durable 로 만든 값이 인스펙터에 닿기 전에 사라졌습니다.

기존 `asNumber` 를 그대로 써서 부재/비숫자는 `undefined` 로 남깁니다 — 0 으로 날조하지 않습니다. 인스펙터는 이웃 필드와 같은 관례로 `미상` 을 렌더합니다.

## 검증

```
pnpm typecheck   EXIT=0
pnpm test        EXIT=0   Test Files 641 passed (641) / Tests 8785 passed (8785)
```

**공허하지 않음을 확인했습니다.** 테스트는 남기고 소스 수정 3파일만 `git stash` 한 상태로 재실행:

```
Test Files  2 failed (2)
Tests       4 failed | 8 passed (12)
```

수정 없이 실패하는 4건이 회귀 핀입니다: fleet fact 순서 1건, taskId 2건, 캐시 카운트 1건. 나머지 4건(부재→undefined, 비숫자→undefined, 동급 안정 정렬, payload 비변형)은 양방향으로 성립하는 계약 가드이며 회귀 핀이 아닙니다 — 구분해서 밝힙니다.

`pnpm lint` 는 `EXIT=1` 이지만 원인은 제가 건드리지 않은 `src/keeper-actions.ts:1046` 의 `no-nested-ternary` 1건이며, 변경을 stash 한 베이스라인에서도 동일하게 실패합니다(main 선행 상태).

## 건드리지 않은 것

서버 측 `blocked_keepers` 생성 순서, `ACTION_PRESENTATION` 의 label/tone/action 문구, ctx-fill%·비용 계산은 그대로입니다. 캐시 카운트는 표시만 하고 어떤 집계에도 넣지 않았습니다.

RFC-WAIVED: dashboard credential 관련 컴포넌트, keeper sandbox, operator control, hooks, workflow 문서 중 어느 것도 건드리지 않습니다.
