### PR TITLE
feat(keeper): define typed capacity compaction request contract

### DIFF
--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -144,7 +144,11 @@ type decode_error =
       { input_tokens : int
       ; accepted_through : int
       }
-  | Invalid_serving_capacity_boundary of
+  | Invalid_boundary_unknown of
+      { input_tokens : int
+      ; rejected_from : int
+      }
+  | Invalid_input_rejected_boundary of
       { input_tokens : int
       ; accepted_through : int
       ; rejected_from : int option
@@ -180,10 +184,15 @@ let decode_error_to_string = function
       "serving input capacity requires input_tokens > accepted_through, got %d and %d"
       input_tokens
       accepted_through
-  | Invalid_serving_capacity_boundary
+  | Invalid_boundary_unknown { input_tokens; rejected_from } ->
+    Printf.sprintf
+      "serving input capacity boundary_unknown requires rejected_from > input_tokens, got input=%d rejected=%d"
+      input_tokens
+      rejected_from
+  | Invalid_input_rejected_boundary
       { input_tokens; accepted_through; rejected_from } ->
     Printf.sprintf
-      "serving input capacity rejected_from must be greater than accepted_through and no greater than input_tokens, got input=%d accepted=%d rejected=%s"
+      "serving input capacity input_rejected requires accepted_through < rejected_from <= input_tokens, got input=%d accepted=%d rejected=%s"
       input_tokens
       accepted_through
       (match rejected_from with
@@ -236,7 +245,12 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
      | Some (`String "serving_input_capacity") ->
        let* () =
          reject_unknown_fields
-           [ "kind"; "reason"; "input_tokens"; "accepted_through"; "rejected_from" ]
+           [ kind_field
+           ; reason_field
+           ; input_tokens_field
+           ; accepted_through_field
+           ; rejected_from_field
+           ]
        in
        let integer_field ~positive field =
          match List.assoc_opt field fields with
@@ -245,20 +259,22 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
          | None -> Error (Missing_serving_capacity_field field)
          | Some _ -> Error (Invalid_serving_capacity_field field)
        in
-       let* input_tokens = integer_field ~positive:true "input_tokens" in
-       let* accepted_through = integer_field ~positive:false "accepted_through" in
+       let* input_tokens = integer_field ~positive:true input_tokens_field in
+       let* accepted_through =
+         integer_field ~positive:false accepted_through_field
+       in
        let* reason =
-         match List.assoc_opt "reason" fields with
+         match List.assoc_opt reason_field fields with
          | Some (`String value) -> Ok value
-         | None -> Error (Missing_serving_capacity_field "reason")
-         | Some _ -> Error (Invalid_serving_capacity_field "reason")
+         | None -> Error (Missing_serving_capacity_field reason_field)
+         | Some _ -> Error (Invalid_serving_capacity_field reason_field)
        in
        let* rejected_from =
-         match List.assoc_opt "rejected_from" fields with
+         match List.assoc_opt rejected_from_field fields with
          | Some `Null -> Ok None
          | Some (`Int value) when value > 0 -> Ok (Some value)
-         | None -> Error (Missing_serving_capacity_field "rejected_from")
-         | Some _ -> Error (Invalid_serving_capacity_field "rejected_from")
+         | None -> Error (Missing_serving_capacity_field rejected_from_field)
+         | Some _ -> Error (Invalid_serving_capacity_field rejected_from_field)
        in
        if input_tokens <= accepted_through
        then Error (Serving_capacity_not_over_limit { input_tokens; accepted_through })
@@ -277,10 +293,13 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
                     ; accepted_through
                     ; rejected_from = Some rejected_from
                     }))
-          | "boundary_unknown", _
+          | "boundary_unknown", Some rejected_from ->
+            Error
+              (Invalid_boundary_unknown
+                 { input_tokens; rejected_from })
           | "input_rejected", None ->
             Error
-              (Invalid_serving_capacity_boundary
+              (Invalid_input_rejected_boundary
                  { input_tokens; accepted_through; rejected_from })
           | "input_rejected", Some rejected_from
             when rejected_from > accepted_through
@@ -291,9 +310,9 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
                     { input_tokens; accepted_through; rejected_from }))
           | "input_rejected", Some _ ->
             Error
-              (Invalid_serving_capacity_boundary
+              (Invalid_input_rejected_boundary
                  { input_tokens; accepted_through; rejected_from })
-          | _, _ -> Error (Invalid_serving_capacity_field "reason"))
+          | _, _ -> Error (Invalid_serving_capacity_field reason_field))
      | Some (`String "manual") ->
        let* () = reject_unknown_fields [ kind_field ] in
        Ok Manual

--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -1,9 +1,22 @@
+type serving_input_capacity =
+  | Boundary_unknown of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int option
+      }
+  | Input_rejected of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int
+      }
+
 type t =
   | Provider_overflow of { limit_tokens : int option }
   | Request_body_over_capacity of
       { actual_bytes : int
       ; limit_bytes : int
       }
+  | Serving_input_capacity of serving_input_capacity
   | Manual
 
 (* Field names are the wire contract for [of_detail_json]; naming them once keeps
@@ -14,6 +27,7 @@ let limit_bytes_field = "limit_bytes"
 let to_label = function
   | Provider_overflow _ -> "provider_overflow"
   | Request_body_over_capacity _ -> "request_body_over_capacity"
+  | Serving_input_capacity _ -> "serving_input_capacity"
   | Manual -> "manual"
 ;;
 
@@ -26,6 +40,22 @@ let to_human = function
        | None -> "unknown")
   | Request_body_over_capacity { actual_bytes; limit_bytes } ->
     Printf.sprintf "request_body_over_capacity(%dB>%dB)" actual_bytes limit_bytes
+  | Serving_input_capacity
+      (Boundary_unknown { input_tokens; accepted_through; rejected_from }) ->
+    Printf.sprintf
+      "serving_input_capacity(boundary_unknown,input=%d,accepted=%d,rejected=%s)"
+      input_tokens
+      accepted_through
+      (match rejected_from with
+       | Some value -> string_of_int value
+       | None -> "unknown")
+  | Serving_input_capacity
+      (Input_rejected { input_tokens; accepted_through; rejected_from }) ->
+    Printf.sprintf
+      "serving_input_capacity(input_rejected,input=%d,accepted=%d,rejected=%d)"
+      input_tokens
+      accepted_through
+      rejected_from
   | Manual -> "manual"
 ;;
 
@@ -44,6 +74,27 @@ let to_detail_json : t -> Yojson.Safe.t = function
       ; actual_bytes_field, `Int actual_bytes
       ; limit_bytes_field, `Int limit_bytes
       ]
+  | Serving_input_capacity
+      (Boundary_unknown { input_tokens; accepted_through; rejected_from }) ->
+    `Assoc
+      [ "kind", `String "serving_input_capacity"
+      ; "reason", `String "boundary_unknown"
+      ; "input_tokens", `Int input_tokens
+      ; "accepted_through", `Int accepted_through
+      ; ( "rejected_from"
+        , match rejected_from with
+          | Some value -> `Int value
+          | None -> `Null )
+      ]
+  | Serving_input_capacity
+      (Input_rejected { input_tokens; accepted_through; rejected_from }) ->
+    `Assoc
+      [ "kind", `String "serving_input_capacity"
+      ; "reason", `String "input_rejected"
+      ; "input_tokens", `Int input_tokens
+      ; "accepted_through", `Int accepted_through
+      ; "rejected_from", `Int rejected_from
+      ]
   | Manual -> `Assoc [ "kind", `String "manual" ]
 ;;
 
@@ -61,6 +112,17 @@ type decode_error =
   | Request_body_within_capacity of
       { actual_bytes : int
       ; limit_bytes : int
+      }
+  | Missing_serving_capacity_field of string
+  | Invalid_serving_capacity_field of string
+  | Serving_capacity_not_over_limit of
+      { input_tokens : int
+      ; accepted_through : int
+      }
+  | Invalid_serving_capacity_boundary of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int option
       }
 
 let decode_error_to_string = function
@@ -84,6 +146,24 @@ let decode_error_to_string = function
       "request body over capacity requires actual_bytes > limit_bytes, got %d and %d"
       actual_bytes
       limit_bytes
+  | Missing_serving_capacity_field field ->
+    Printf.sprintf "serving input capacity trigger is missing %s" field
+  | Invalid_serving_capacity_field field ->
+    Printf.sprintf "serving input capacity trigger has invalid %s" field
+  | Serving_capacity_not_over_limit { input_tokens; accepted_through } ->
+    Printf.sprintf
+      "serving input capacity requires input_tokens > accepted_through, got %d and %d"
+      input_tokens
+      accepted_through
+  | Invalid_serving_capacity_boundary
+      { input_tokens; accepted_through; rejected_from } ->
+    Printf.sprintf
+      "serving input capacity rejected_from must be greater than accepted_through and no greater than input_tokens, got input=%d accepted=%d rejected=%s"
+      input_tokens
+      accepted_through
+      (match rejected_from with
+       | Some value -> string_of_int value
+       | None -> "missing")
 ;;
 
 let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
@@ -128,6 +208,64 @@ let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
        if actual_bytes > limit_bytes
        then Ok (Request_body_over_capacity { actual_bytes; limit_bytes })
        else Error (Request_body_within_capacity { actual_bytes; limit_bytes })
+     | Some (`String "serving_input_capacity") ->
+       let* () =
+         reject_unknown_fields
+           [ "kind"; "reason"; "input_tokens"; "accepted_through"; "rejected_from" ]
+       in
+       let integer_field ~positive field =
+         match List.assoc_opt field fields with
+         | Some (`Int value) when if positive then value > 0 else value >= 0 ->
+           Ok value
+         | None -> Error (Missing_serving_capacity_field field)
+         | Some _ -> Error (Invalid_serving_capacity_field field)
+       in
+       let* input_tokens = integer_field ~positive:true "input_tokens" in
+       let* accepted_through = integer_field ~positive:false "accepted_through" in
+       let* reason =
+         match List.assoc_opt "reason" fields with
+         | Some (`String value) -> Ok value
+         | None -> Error (Missing_serving_capacity_field "reason")
+         | Some _ -> Error (Invalid_serving_capacity_field "reason")
+       in
+       let* rejected_from =
+         match List.assoc_opt "rejected_from" fields with
+         | Some `Null -> Ok None
+         | Some (`Int value) when value > 0 -> Ok (Some value)
+         | None -> Error (Missing_serving_capacity_field "rejected_from")
+         | Some _ -> Error (Invalid_serving_capacity_field "rejected_from")
+       in
+       if input_tokens <= accepted_through
+       then Error (Serving_capacity_not_over_limit { input_tokens; accepted_through })
+       else
+         let boundary_valid =
+           match rejected_from with
+           | None -> true
+           | Some value ->
+             value > accepted_through && value <= input_tokens
+         in
+         if not boundary_valid
+         then
+           Error
+             (Invalid_serving_capacity_boundary
+                { input_tokens; accepted_through; rejected_from })
+         else
+           (match reason, rejected_from with
+            | "boundary_unknown", rejected_from ->
+              Ok
+                (Serving_input_capacity
+                   (Boundary_unknown
+                      { input_tokens; accepted_through; rejected_from }))
+            | "input_rejected", Some rejected_from ->
+              Ok
+                (Serving_input_capacity
+                   (Input_rejected
+                      { input_tokens; accepted_through; rejected_from }))
+            | "input_rejected", None ->
+              Error
+                (Invalid_serving_capacity_boundary
+                   { input_tokens; accepted_through; rejected_from = None })
+            | _, _ -> Error (Invalid_serving_capacity_field "reason"))
      | Some (`String "manual") ->
        let* () = reject_unknown_fields [ "kind" ] in
        Ok Manual

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -1,5 +1,20 @@
 (** Compaction_trigger — explicit context compaction request origin. *)
 
+type serving_input_capacity =
+  | Boundary_unknown of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int option
+      }
+  | Input_rejected of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int
+      }
+(** Provider-neutral token-capacity evidence produced by OAS admission. The
+    measured request and accepted/rejected boundary remain distinct from both
+    a model context-window declaration and serialized request-body bytes. *)
+
 type t =
   | Provider_overflow of { limit_tokens : int option }
       (** Typed provider context-window overflow. [limit_tokens] is the
@@ -19,6 +34,11 @@ type t =
           refusal says nothing about the provider's token window, so folding it
           into [limit_tokens] would have to report [None] — an unknown limit for
           a limit that is known exactly. *)
+  | Serving_input_capacity of serving_input_capacity
+      (** OAS exhausted admission candidates and returned a measured token
+          boundary. Only [Boundary_unknown] and [Input_rejected] can construct
+          this trigger; unavailable or stale measurements are not compaction
+          requests. *)
   | Manual
 
 (** Closed label set for Otel_metric_store / SSE [trigger] label.
@@ -45,6 +65,17 @@ type decode_error =
   | Request_body_within_capacity of
       { actual_bytes : int
       ; limit_bytes : int
+      }
+  | Missing_serving_capacity_field of string
+  | Invalid_serving_capacity_field of string
+  | Serving_capacity_not_over_limit of
+      { input_tokens : int
+      ; accepted_through : int
+      }
+  | Invalid_serving_capacity_boundary of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int option
       }
 
 val decode_error_to_string : decode_error -> string

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -79,7 +79,11 @@ type decode_error =
       { input_tokens : int
       ; accepted_through : int
       }
-  | Invalid_serving_capacity_boundary of
+  | Invalid_boundary_unknown of
+      { input_tokens : int
+      ; rejected_from : int
+      }
+  | Invalid_input_rejected_boundary of
       { input_tokens : int
       ; accepted_through : int
       ; rejected_from : int option

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -743,13 +743,18 @@ let prepare_compaction_with
     Keeper_meta_contract.compaction_retry_suspended meta.runtime.compaction_rt
   in
   match trigger with
-  (* The suspension guard follows the trigger's origin, not its axis. Both
-     capacity triggers are raised by the turn path itself, so a suspended retry
-     must refuse them or a keeper whose compactions keep failing would keep
+  (* The suspension guard follows the trigger's origin, not its axis. The
+     provider token window, serialized byte limit, and serving-admission token
+     evidence are all raised by the turn path itself, so a suspended retry must
+     refuse them or a keeper whose compactions keep failing would keep
      re-entering compaction on every turn. [Manual] stays exempt: an operator
      asked for this one, and refusing it would leave no way to intervene. *)
   | Compaction_trigger.Provider_overflow _
   | Compaction_trigger.Request_body_over_capacity _
+  | Compaction_trigger.Serving_input_capacity
+      (Compaction_trigger.Boundary_unknown _)
+  | Compaction_trigger.Serving_input_capacity
+      (Compaction_trigger.Input_rejected _)
     when suspended ->
     Error
       (Retry_suspended
@@ -758,6 +763,10 @@ let prepare_compaction_with
          })
   | Compaction_trigger.Provider_overflow _
   | Compaction_trigger.Request_body_over_capacity _
+  | Compaction_trigger.Serving_input_capacity
+      (Compaction_trigger.Boundary_unknown _)
+  | Compaction_trigger.Serving_input_capacity
+      (Compaction_trigger.Input_rejected _)
   | Compaction_trigger.Manual ->
     prepare_compaction_admitted
       ~compact_for_request

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -518,6 +518,7 @@ let capacity_refusal_of_error
     ->
     Some (Serialized_request_body { actual_bytes; limit_bytes })
   | Compact_next_cycle (Compaction_trigger.Serving_input_capacity _)
+  | Compact_next_cycle Compaction_trigger.Manual
   | Capacity_non_compacting _
   | Not_capacity ->
     None

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -447,6 +447,104 @@ let capacity_refusal_of_error (err : Agent_sdk.Error.sdk_error) : capacity_refus
   | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.Internal _ -> None
 
+type capacity_non_compaction =
+  | Serving_evidence_not_yet_valid of
+      { now_unix_s : int
+      ; checked_at_unix_s : int
+      }
+  | Serving_evidence_expired of
+      { now_unix_s : int
+      ; expires_at_unix_s : int
+      }
+  | Token_measurement_unavailable of
+      { protocol : Llm_provider.Input_token_count.protocol }
+
+type capacity_transition =
+  | Not_capacity
+  | Compact_next_cycle of Compaction_trigger.t
+  | Capacity_non_compacting of capacity_non_compaction
+
+let capacity_transition_of_error
+    (err : Agent_sdk.Error.sdk_error) : capacity_transition =
+  match err with
+  | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) ->
+    Compact_next_cycle
+      (Compaction_trigger.Provider_overflow { limit_tokens = limit })
+  | Agent_sdk.Error.Api
+      (InvalidRequest
+         { reason = Request_body_too_large { actual_bytes; limit_bytes }; _ })
+    ->
+    Compact_next_cycle
+      (Compaction_trigger.Request_body_over_capacity
+         { actual_bytes; limit_bytes })
+  | Agent_sdk.Error.Api
+      (InputCapacity
+         { reason =
+             Serving_constraint_rejected
+               (Llm_provider.Serving_constraint.Boundary_unknown
+                  { input_tokens; accepted_through; rejected_from })
+         ; _
+         })
+    ->
+    Compact_next_cycle
+      (Compaction_trigger.Serving_input_capacity
+         (Compaction_trigger.Boundary_unknown
+            { input_tokens; accepted_through; rejected_from }))
+  | Agent_sdk.Error.Api
+      (InputCapacity
+         { reason =
+             Serving_constraint_rejected
+               (Llm_provider.Serving_constraint.Input_rejected
+                  { input_tokens; accepted_through; rejected_from })
+         ; _
+         })
+    ->
+    Compact_next_cycle
+      (Compaction_trigger.Serving_input_capacity
+         (Compaction_trigger.Input_rejected
+            { input_tokens; accepted_through; rejected_from }))
+  | Agent_sdk.Error.Api
+      (InputCapacity
+         { reason =
+             Serving_constraint_rejected
+               (Llm_provider.Serving_constraint.Evidence_not_yet_valid
+                  { now_unix_s; checked_at_unix_s })
+         ; _
+         })
+    ->
+    Capacity_non_compacting
+      (Serving_evidence_not_yet_valid { now_unix_s; checked_at_unix_s })
+  | Agent_sdk.Error.Api
+      (InputCapacity
+         { reason =
+             Serving_constraint_rejected
+               (Llm_provider.Serving_constraint.Evidence_expired
+                  { now_unix_s; expires_at_unix_s })
+         ; _
+         })
+    ->
+    Capacity_non_compacting
+      (Serving_evidence_expired { now_unix_s; expires_at_unix_s })
+  | Agent_sdk.Error.Api
+      (InputCapacity { reason = Token_measurement_unavailable protocol; _ }) ->
+    Capacity_non_compacting (Token_measurement_unavailable { protocol })
+  | Agent_sdk.Error.Api
+      (InvalidRequest { reason = Json_parse_error | Unknown_invalid_request; _ })
+  | Agent_sdk.Error.Api
+      ( RateLimited _ | Overloaded _ | ServerError _ | AuthError _
+      | AuthorizationError _ | PaymentRequired _ | NotFound _ | NetworkError _
+      | Timeout _ )
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ ->
+    Not_capacity
+;;
+
 (* Projection for the two token-axis call sites. Both publish
    reason="provider_context_overflow" and the [Sdk_context_window_exceeded]
    blocker class (keeper_unified_turn_execution.ml:485-509), labels that would be

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -209,6 +209,33 @@ val capacity_refusal_of_error :
     enumerated, so adding one forces a decision here instead of returning [None]
     by default. *)
 
+type capacity_non_compaction =
+  | Serving_evidence_not_yet_valid of
+      { now_unix_s : int
+      ; checked_at_unix_s : int
+      }
+  | Serving_evidence_expired of
+      { now_unix_s : int
+      ; expires_at_unix_s : int
+      }
+  | Token_measurement_unavailable of
+      { protocol : Llm_provider.Input_token_count.protocol }
+
+type capacity_transition =
+  | Not_capacity
+  | Compact_next_cycle of Compaction_trigger.t
+  | Capacity_non_compacting of capacity_non_compaction
+(** Provider-neutral transition input for the durable compaction lane.
+    [Compact_next_cycle] preserves the measured token or byte axis.
+    Future/expired serving evidence and unavailable token measurement remain
+    typed non-compacting facts; they are never guessed into a capacity limit. *)
+
+val capacity_transition_of_error :
+  Agent_sdk.Error.sdk_error ->
+  capacity_transition
+(** Total classifier over typed SDK errors. This function does not inspect
+    rendered error prose and does not select a provider, model, or failover. *)
+
 val context_overflow_event_of_error :
   Agent_sdk.Error.sdk_error ->
   Keeper_state_machine.event option

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -178,6 +178,56 @@ and goal_assignment = {
      repeat assignments of the same goal dedup regardless of actor. *)
 }
 
+type capacity_compaction_request = {
+  ccr_trigger : Compaction_trigger.t;
+}
+
+let capacity_compaction_request_schema =
+  "keeper.capacity_compaction_request.v1"
+
+let capacity_compaction_request_to_yojson request =
+  `Assoc
+    [ "schema", `String capacity_compaction_request_schema
+    ; "trigger", Compaction_trigger.to_detail_json request.ccr_trigger
+    ]
+
+let capacity_compaction_request_of_yojson = function
+  | `Assoc
+      [ ("schema", `String schema)
+      ; ("trigger", trigger_json)
+      ]
+    when String.equal schema capacity_compaction_request_schema ->
+    (match Compaction_trigger.of_detail_json trigger_json with
+     | Ok ccr_trigger -> Ok { ccr_trigger }
+     | Error error ->
+       Error (Compaction_trigger.decode_error_to_string error))
+  | `Assoc
+      [ ("trigger", trigger_json)
+      ; ("schema", `String schema)
+      ]
+    when String.equal schema capacity_compaction_request_schema ->
+    (match Compaction_trigger.of_detail_json trigger_json with
+     | Ok ccr_trigger -> Ok { ccr_trigger }
+     | Error error ->
+       Error (Compaction_trigger.decode_error_to_string error))
+  | `Assoc _ ->
+    Error
+      "capacity compaction request fields must be exactly [schema,trigger] with the current schema"
+  | _ -> Error "capacity compaction request must be a JSON object"
+
+let capacity_compaction_request_identity_equal left right =
+  left.ccr_trigger = right.ccr_trigger
+
+let capacity_compaction_request_post_id request =
+  let digest =
+    request
+    |> capacity_compaction_request_to_yojson
+    |> Yojson.Safe.to_string
+    |> Digest.string
+    |> Digest.to_hex
+  in
+  "capacity-compaction-request:" ^ digest
+
 let fusion_completion_post_id (fc : fusion_completion) = "fusion-run:" ^ fc.run_id
 
 let bg_job_completion_post_id (c : bg_job_completion) =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -201,6 +201,26 @@ and goal_assignment = {
 }
 (** Payload for [Goal_assigned]. *)
 
+type capacity_compaction_request = {
+  ccr_trigger : Compaction_trigger.t;
+}
+(** Current-schema request value for the next-cycle compaction lane. It is not
+    yet a queue payload: this pure contract lets the producer and consumer
+    share one strict codec and identity before runtime wiring lands. *)
+
+val capacity_compaction_request_to_yojson :
+  capacity_compaction_request -> Yojson.Safe.t
+
+val capacity_compaction_request_of_yojson :
+  Yojson.Safe.t -> (capacity_compaction_request, string) result
+
+val capacity_compaction_request_identity_equal :
+  capacity_compaction_request -> capacity_compaction_request -> bool
+
+val capacity_compaction_request_post_id :
+  capacity_compaction_request -> post_id
+(** Stable identity derived only from the typed trigger detail. Display prose,
+    runtime identity, provider, and model do not participate. *)
 
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Canonical dedup/correlation id for [Fusion_completed], always

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -37,8 +37,68 @@ let test_provider_overflow_trigger_roundtrip () =
     ; Compaction_trigger.Provider_overflow { limit_tokens = None }
     ; Compaction_trigger.Request_body_over_capacity
         { actual_bytes = 1_048_577; limit_bytes = 1_048_576 }
+    ; Compaction_trigger.Serving_input_capacity
+        (Compaction_trigger.Boundary_unknown
+           { input_tokens = 524_299
+           ; accepted_through = 524_298
+           ; rejected_from = None
+           })
+    ; Compaction_trigger.Serving_input_capacity
+        (Compaction_trigger.Input_rejected
+           { input_tokens = 524_300
+           ; accepted_through = 524_298
+           ; rejected_from = 524_299
+           })
     ; Compaction_trigger.Manual
     ]
+;;
+
+let test_capacity_request_codec_and_identity () =
+  let request : Keeper_event_queue.capacity_compaction_request =
+    { ccr_trigger =
+        Compaction_trigger.Serving_input_capacity
+          (Compaction_trigger.Input_rejected
+             { input_tokens = 524_300
+             ; accepted_through = 524_298
+             ; rejected_from = 524_299
+             })
+    }
+  in
+  let encoded = Keeper_event_queue.capacity_compaction_request_to_yojson request in
+  let decoded =
+    match Keeper_event_queue.capacity_compaction_request_of_yojson encoded with
+    | Ok decoded -> decoded
+    | Error detail -> failf "capacity compaction request did not decode: %s" detail
+  in
+  check
+    bool
+    "request identity round-trips"
+    true
+    (Keeper_event_queue.capacity_compaction_request_identity_equal
+       request
+       decoded);
+  check
+    string
+    "stable post id round-trips"
+    (Keeper_event_queue.capacity_compaction_request_post_id request)
+    (Keeper_event_queue.capacity_compaction_request_post_id decoded);
+  let different =
+    { Keeper_event_queue.ccr_trigger =
+        Compaction_trigger.Serving_input_capacity
+          (Compaction_trigger.Boundary_unknown
+             { input_tokens = 524_300
+             ; accepted_through = 524_298
+             ; rejected_from = Some 524_299
+             })
+    }
+  in
+  check
+    bool
+    "different typed evidence has different identity"
+    false
+    (Keeper_event_queue.capacity_compaction_request_identity_equal
+       request
+       different)
 ;;
 
 let test_request_body_over_capacity_rejects_non_refusals () =
@@ -277,6 +337,8 @@ let () =
     "overflow-lifecycle",
     [ test_case "provider overflow trigger codec" `Quick
         test_provider_overflow_trigger_roundtrip;
+      test_case "capacity request codec and identity" `Quick
+        test_capacity_request_codec_and_identity;
       test_case "retired trigger kinds rejected" `Quick
         test_retired_trigger_kinds_are_rejected;
       test_case "request body over capacity rejects non-refusals" `Quick

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -74,7 +74,14 @@ let test_provider_overflow_trigger_roundtrip () =
        ~accepted_through:524_298
        ~rejected_from:524_299
    with
-   | Error (Compaction_trigger.Invalid_serving_capacity_boundary _) -> ()
+   | Error
+       (Compaction_trigger.Invalid_boundary_unknown
+          { input_tokens = 524_300; rejected_from = 524_299 } as error) ->
+     check
+       string
+       "boundary_unknown diagnostic states its valid side"
+       "serving input capacity boundary_unknown requires rejected_from > input_tokens, got input=524300 rejected=524299"
+       (Compaction_trigger.decode_error_to_string error)
    | Ok _ | Error _ ->
      fail "boundary_unknown admitted a rejection at or below the measured input");
   match
@@ -84,7 +91,17 @@ let test_provider_overflow_trigger_roundtrip () =
       ~accepted_through:524_298
       ~rejected_from:524_301
   with
-  | Error (Compaction_trigger.Invalid_serving_capacity_boundary _) -> ()
+  | Error
+      (Compaction_trigger.Invalid_input_rejected_boundary
+         { input_tokens = 524_300
+         ; accepted_through = 524_298
+         ; rejected_from = Some 524_301
+         } as error) ->
+    check
+      string
+      "input_rejected diagnostic states its valid interval"
+      "serving input capacity input_rejected requires accepted_through < rejected_from <= input_tokens, got input=524300 accepted=524298 rejected=524301"
+      (Compaction_trigger.decode_error_to_string error)
   | Ok _ | Error _ ->
     fail "input_rejected admitted a boundary above the measured input"
 ;;

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1715,17 +1715,62 @@ let test_suspended_streak_refuses_reactive_prepare () =
        "suspended byte-axis prepare reached I/O instead of the admission gate: %s"
        (Post_turn.compaction_recovery_error_to_string error)
    | Ok _ -> fail "suspended byte-axis prepare produced a prepared compaction");
-  match prepare ~streak:2 ~trigger:byte_over_capacity with
-  | Error
-      (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-    ->
-    (* Below the threshold the byte axis is admitted exactly as the token axis is. *)
-    ()
-  | Error error ->
-    failf
-      "below-threshold byte-axis prepare did not reach the checkpoint load: %s"
-      (Post_turn.compaction_recovery_error_to_string error)
-  | Ok _ -> fail "byte-axis prepare on an empty store produced a compaction"
+  (match prepare ~streak:2 ~trigger:byte_over_capacity with
+   | Error
+       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
+     ->
+     (* Below the threshold the byte axis is admitted exactly as the token axis is. *)
+     ()
+   | Error error ->
+     failf
+       "below-threshold byte-axis prepare did not reach the checkpoint load: %s"
+       (Post_turn.compaction_recovery_error_to_string error)
+   | Ok _ -> fail "byte-axis prepare on an empty store produced a compaction");
+  List.iter
+    (fun (reason, trigger) ->
+       (match prepare ~streak:3 ~trigger with
+        | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
+          check
+            int
+            ("suspended serving-axis " ^ reason ^ " reports the streak")
+            3
+            consecutive_failures
+        | Error error ->
+          failf
+            "suspended serving-axis %s reached I/O instead of the admission gate: %s"
+            reason
+            (Post_turn.compaction_recovery_error_to_string error)
+        | Ok _ ->
+          failf "suspended serving-axis %s produced a prepared compaction" reason);
+       match prepare ~streak:2 ~trigger with
+       | Error
+           (Post_turn.Checkpoint_ref_load_failed
+              Masc.Keeper_checkpoint_store.Ref_not_found) ->
+         ()
+       | Error error ->
+         failf
+           "below-threshold serving-axis %s did not reach the checkpoint load: %s"
+           reason
+           (Post_turn.compaction_recovery_error_to_string error)
+       | Ok _ ->
+         failf
+           "serving-axis %s prepare on an empty store produced a compaction"
+           reason)
+    [ ( "boundary_unknown"
+      , Compaction_trigger.Serving_input_capacity
+          (Compaction_trigger.Boundary_unknown
+             { input_tokens = 524_299
+             ; accepted_through = 524_298
+             ; rejected_from = Some 524_300
+             }) )
+    ; ( "input_rejected"
+      , Compaction_trigger.Serving_input_capacity
+          (Compaction_trigger.Input_rejected
+             { input_tokens = 524_300
+             ; accepted_through = 524_298
+             ; rejected_from = 524_299
+             }) )
+    ]
 ;;
 
 let test_exact_scope_release_defers_until_settlement_pin_leaves () =

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -24,6 +24,16 @@ let input_capacity constraint_ reason =
        ; reason = Agent_sdk.Retry.Serving_constraint_rejected reason
        })
 
+let measurement_unavailable constraint_ =
+  Agent_sdk.Error.Api
+    (InputCapacity
+       { message = "token measurement unavailable"
+       ; constraint_
+       ; reason =
+           Agent_sdk.Retry.Token_measurement_unavailable
+             Llm_provider.Input_token_count.Anthropic_messages_count_tokens
+       })
+
 let test_is_context_overflow_only_for_overflow_errors () =
   check
     bool
@@ -134,6 +144,67 @@ let test_byte_axis_is_a_capacity_refusal () =
   | Some _ | None -> fail "the context window axis regressed"
 ;;
 
+let test_typed_capacity_transition_preserves_axes () =
+  let constraint_ = serving_constraint () in
+  let boundary =
+    input_capacity
+      constraint_
+      (Llm_provider.Serving_constraint.Boundary_unknown
+         { input_tokens = 524_299
+         ; accepted_through = 524_298
+         ; rejected_from = None
+         })
+  in
+  (match Budget.capacity_transition_of_error boundary with
+   | Budget.Compact_next_cycle
+       (Compaction_trigger.Serving_input_capacity
+          (Compaction_trigger.Boundary_unknown
+             { input_tokens = 524_299
+             ; accepted_through = 524_298
+             ; rejected_from = None
+             })) ->
+     ()
+   | _ -> fail "typed serving boundary did not become a token-capacity trigger");
+  match
+    Budget.capacity_transition_of_error
+      (request_body_too_large
+         ~actual_bytes:2_000_000
+         ~limit_bytes:1_048_576)
+  with
+  | Budget.Compact_next_cycle
+      (Compaction_trigger.Request_body_over_capacity
+         { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }) ->
+    ()
+  | _ -> fail "serialized byte provenance was not preserved"
+;;
+
+let test_unusable_capacity_evidence_is_non_compacting () =
+  let constraint_ = serving_constraint () in
+  (match
+     Budget.capacity_transition_of_error
+       (input_capacity
+          constraint_
+          (Llm_provider.Serving_constraint.Evidence_expired
+             { now_unix_s = 200; expires_at_unix_s = 199 }))
+   with
+   | Budget.Capacity_non_compacting
+       (Budget.Serving_evidence_expired
+          { now_unix_s = 200; expires_at_unix_s = 199 }) ->
+     ()
+   | _ -> fail "expired serving evidence became compactable");
+  match
+    Budget.capacity_transition_of_error
+      (measurement_unavailable constraint_)
+  with
+  | Budget.Capacity_non_compacting
+      (Budget.Token_measurement_unavailable
+         { protocol =
+             Llm_provider.Input_token_count.Anthropic_messages_count_tokens
+         }) ->
+    ()
+  | _ -> fail "measurement-unavailable became compactable"
+;;
+
 (* The projection feeding the cascade path publishes
    reason="provider_context_overflow" and the Sdk_context_window_exceeded blocker
    class, so admitting a byte refusal there would label it as a window exceedance. *)
@@ -172,6 +243,14 @@ let () =
             "declared-byte refusal is a capacity refusal"
             `Quick
             test_byte_axis_is_a_capacity_refusal
+        ; test_case
+            "typed capacity transition preserves axes"
+            `Quick
+            test_typed_capacity_transition_preserves_axes
+        ; test_case
+            "unusable capacity evidence is non-compacting"
+            `Quick
+            test_unusable_capacity_evidence_is_non_compacting
         ; test_case
             "event projection admits only the token axis"
             `Quick


### PR DESCRIPTION
## Summary

First behavior-free stack PR for #25725.

- classify current typed Agent SDK input-capacity failures without prose matching
- preserve token serving-boundary and serialized request-byte provenance as typed compaction triggers
- define a strict current-schema capacity compaction request codec and stable identity
- keep failover-only and measurement-unavailable outcomes explicitly non-compacting

## Boundary

This PR intentionally does not add the request to stimulus_payload, enqueue it, execute compaction, or change runtime behavior. Production wiring and removal of the obsolete inline recovery path belong to the next stack PR.

No provider/model policy, legacy JSON migration, compatibility default, or error-string heuristic is introduced.

## Validation

- git diff --check passed
- focused local builds were attempted through scripts/dune-local.sh
- build execution was blocked before compilation by the shared agent_sdk pin guard: installed 2186dfa5fca2360e4e99fa5e47052ba4c0cc687f, repository expected 3d4ee19a4773cbd8b1b73ed5555c5cdfe82e6d77
- shared pin was deliberately left unchanged

Stack: PR-A of PR-A/PR-B/PR-C.