### PR TITLE
test: isolate operator snapshot workspace roots

### DIFF
--- a/lib/keeper/keeper_lifecycle_admission_durable_transaction.ml
+++ b/lib/keeper/keeper_lifecycle_admission_durable_transaction.ml
@@ -179,10 +179,11 @@ let with_revival_launch_admission_under_lock
     (match journal_parent config, journal_entropy () with
      | Ok parent, Ok secure_random ->
        (match
-          Head.read
-            ~secure_random
-            ~parent
-            ~leaf:(journal_leaf keeper_name)
+          with_head_parent parent (fun parent ->
+            Head.read
+              ~secure_random
+              ~parent
+              ~leaf:(journal_leaf keeper_name))
         with
         | Ok snapshot
           when Head.snapshot_settlement_warnings snapshot <> [] ->
@@ -389,4 +390,5 @@ let projection_to_yojson projection =
 
 module For_testing = struct
   let permit_matches = permit_matches
+  let with_fd_backed_parent_opening = with_fd_backed_parent_opening
 end

--- a/lib/keeper/keeper_lifecycle_admission_durable_transaction.mli
+++ b/lib/keeper/keeper_lifecycle_admission_durable_transaction.mli
@@ -122,4 +122,5 @@ val projection_to_yojson : projection -> Yojson.Safe.t
 
 module For_testing : sig
   val permit_matches : permit -> Workspace.config -> string -> bool
+  val with_fd_backed_parent_opening : (unit -> 'a) -> 'a
 end

--- a/lib/keeper/keeper_lifecycle_admission_journal.ml
+++ b/lib/keeper/keeper_lifecycle_admission_journal.ml
@@ -6,6 +6,20 @@ open Keeper_lifecycle_admission_durable_types
 let journal_schema = "masc.keeper-dead-revival-journal.v3"
 let head_entropy_bytes = 32 * 33
 
+let fd_backed_parent_opening_key : unit Eio.Fiber.key =
+  Eio.Fiber.create_key ()
+;;
+
+let with_head_parent parent fn =
+  match Eio.Fiber.get fd_backed_parent_opening_key with
+  | Some () -> Eio.Path.with_open_dir parent fn
+  | None -> fn parent
+;;
+
+let with_fd_backed_parent_opening fn =
+  Eio.Fiber.with_binding fd_backed_parent_opening_key () fn
+;;
+
 let sha256 value =
   Digestif.SHA256.(to_hex (digest_string value))
 ;;
@@ -279,10 +293,11 @@ let read_revival_locked config keeper_name =
     Blocked (Authority_unreadable { keeper_name; failure })
   | Ok parent, Ok secure_random ->
     (match
-       Head.read
-         ~secure_random
-         ~parent
-         ~leaf:(journal_leaf keeper_name)
+       with_head_parent parent (fun parent ->
+         Head.read
+           ~secure_random
+           ~parent
+           ~leaf:(journal_leaf keeper_name))
      with
      | Error _ ->
        Blocked

--- a/test/test_keeper_lifecycle_nonce.ml
+++ b/test/test_keeper_lifecycle_nonce.ml
@@ -450,6 +450,9 @@ let test_authority_root_is_cluster_scoped () =
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Masc.Keeper_lifecycle_admission.Durable_transaction.For_testing
+  .with_fd_backed_parent_opening
+  @@ fun () ->
   Nonce.For_testing.with_fd_backed_parent_opening @@ fun () ->
   Masc.Keeper_shutdown_generation_floor.For_testing.with_fd_backed_parent_opening
   @@ fun () ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -806,6 +806,7 @@ let test_lifecycle_reservation_is_per_keeper_and_owner_typed () =
 let test_lifecycle_owner_gates_meta_and_registry_mutations () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_fd_backed_lifecycle_head_parents @@ fun () ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -2623,6 +2624,7 @@ let test_update_keeper_surfaces_committed_cleanup_required () =
 let test_update_keeper_rebases_intent_after_join_race () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_fd_backed_lifecycle_head_parents @@ fun () ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let keeper_name = "update-rebase-after-join-race" in
@@ -2780,6 +2782,7 @@ let ordinary_update_args keeper_name =
 let with_running_ordinary_update_fixture ~keeper_name fn =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_fd_backed_lifecycle_head_parents @@ fun () ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
@@ -3190,6 +3193,7 @@ let test_create_keeper_fork_rejection_removes_candidate_state () =
 let test_create_runtime_meta_crash_recovery_removes_dangling_runtime () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_fd_backed_lifecycle_head_parents @@ fun () ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let keeper_name = "create-runtime-meta-crash" in
@@ -3327,6 +3331,7 @@ let test_update_runtime_meta_crash_recovery_retries_durable_intent () =
 let test_runtime_meta_identical_target_honors_forward_preference () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_fd_backed_lifecycle_head_parents @@ fun () ->
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   let keeper_name = "runtime-meta-identical-forward" in

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -8,10 +8,25 @@ let () =
     ~backend:Server_startup_state.Filesystem_backend
   |> Result.get_ok
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let temp_base_path_scopes = Hashtbl.create 8
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> unsetenv name
+
 let temp_dir () =
   let dir = Filename.temp_file "test_operator_control_" "" in
   Unix.unlink dir;
   Unix.mkdir dir 0o755;
+  Hashtbl.replace
+    temp_base_path_scopes
+    dir
+    ( Sys.getenv_opt Env_config_core.base_path_env_key
+    , Sys.getenv_opt Env_config_core.base_path_input_env_key );
+  Unix.putenv Env_config_core.base_path_env_key dir;
+  Unix.putenv Env_config_core.base_path_input_env_key dir;
   dir
 
 (** Ensure Fs_compat has the Eio fs handle set.
@@ -53,7 +68,15 @@ let cleanup_dir dir =
       else
         Unix.unlink path
   in
-  try rm dir with _ -> ()
+  Fun.protect
+    ~finally:(fun () ->
+      match Hashtbl.find_opt temp_base_path_scopes dir with
+      | None -> ()
+      | Some (base_path, base_path_input) ->
+        Hashtbl.remove temp_base_path_scopes dir;
+        restore_env Env_config_core.base_path_env_key base_path;
+        restore_env Env_config_core.base_path_input_env_key base_path_input)
+    (fun () -> try rm dir with _ -> ())
 
 let parse_json_exn body =
   try Yojson.Safe.from_string body

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -39,6 +39,9 @@ let ensure_fs env =
   Fs_compat.set_fs (Eio.Stdenv.fs env)
 
 let with_fd_backed_lifecycle_head_parents fn =
+  Keeper_lifecycle_admission.Durable_transaction.For_testing
+  .with_fd_backed_parent_opening
+  @@ fun () ->
   Keeper_lifecycle_nonce.For_testing.with_fd_backed_parent_opening
   @@ fun () ->
   Keeper_dead_revival_transaction.For_testing.with_fd_backed_parent_opening fn


### PR DESCRIPTION
## Summary

- Scope each operator-control fixture's `MASC_BASE_PATH` and `MASC_BASE_PATH_INPUT` to its own temporary workspace root.
- Restore the prior value, including the genuinely-unset state, from the existing `cleanup_dir` finally path.
- Keep production workspace/lifecycle authority semantics and all 49 test expectations unchanged.

## Why

The post-merge `Build and Test` run for #25819 opened compilation and then exposed a test-isolation failure in `test_operator_control_snapshot`: 40 of 49 cases failed during setup.

The first fixture synchronized the process-global base-path authority to `/tmp/.../test_operator_control_609644` and later removed that root. Subsequent fixtures requested a different temp root but logged `Ignoring test MASC_BASE_PATH override=...609644 for requested path ...`, followed by `authority_unreadable:authority_read_failed`. That is stale one-root state leaking across fixtures in a single executable, not a reason to relax production authority or add a legacy fallback.

`test_operator_control_support.temp_dir` now captures both base-path environment variables before installing the fixture root. The existing `cleanup_dir` path restores the captured values in `Fun.protect`, so every fixture enters `Workspace.default_config` with its own live root and leaves no process-global authority behind.

## Validation

- `ocamlformat --check test/test_operator_control_support.ml`: pass
- `git diff --check origin/main..HEAD`: pass
- Focused wrapper requested for the three operator snapshot executables: environment-blocked before compilation because another session is running bare `dune build .`; that process was not interrupted or bypassed. PR CI is the build authority.

RFC-WAIVED: test-support isolation only; no production credential, identity, operator-control, sandbox, hooks, or workflow behavior changes.


## Typed authority follow-up

The first CI pass on this PR proved the environment scope works: every fixture logged its own explicit temp root. It still failed 40/49 because the first durable admission point-read could not stabilize its capability HEAD parent.

Static path evidence rules out a writer/reader split: `Keeper_dead_revival_transaction` and `Keeper_lifecycle_admission_journal` both derive the same `Workspace.masc_root_dir config/keeper-lifecycle-transactions` parent and the same domain-separated hashed `revival-*.json` leaf. The first failing fixture has no HEAD row yet, so its typed expected result is `snapshot_row = None`.

A standalone execution of the current `Capability_head.read` against the same `Eio.Stdenv.fs / absolute-parent` shape returned `Unsupported "parent directory capability has no Unix file descriptor"`. The exact expected parent contained the newly-created stable lock at mode `0600`, size `0`; initialization stopped at parent fsync before the lock epoch could be written.

Nonce and dead-revival authorities already solve this in tests with Fiber-scoped `For_testing.with_fd_backed_parent_opening`. Durable admission now exposes and uses the same scoped hook around both exact point-reads. Operator fixtures and the nonce admission suite opt into that test scope. Production admission decisions, fail-closed behavior, authority rows, and all test expectations remain unchanged.

### Latest validation

- `ocamlformat --check` on all six follow-up files: pass
- `ocamlc -stop-after parsing` on all six follow-up files: pass
- `git diff --check`: pass
- Focused operator + nonce wrapper: environment-blocked before compilation by shared `agent_sdk` pin drift (`2186dfa5...` installed, `3d4ee19...` expected). The shared pin was not changed or bypassed after the patch; CI is authoritative.
