### PR TITLE
fix(dashboard): keeper 상태를 화면마다 다른 단어로 표시하던 것 통일

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -7,7 +7,7 @@ import { formatPct } from '../lib/format-number'
 import { useMemo, useRef } from 'preact/hooks'
 import { SectionCard } from './common/card'
 import { EmptyState, ErrorState } from './common/feedback-state'
-import { StatusBadge } from './common/status-badge'
+import { StatusBadge, statusBadgeToneForKeeper } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { resolveUnifiedStatus } from '../lib/unified-status'
 import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
@@ -257,7 +257,11 @@ export function AgentDetailOverlay() {
                   ${showSecondaryLabel ? html`<span class="font-mono text-xs text-[var(--color-fg-muted)] bg-[var(--color-bg-elevated)] px-2 py-0.5 rounded-[var(--r-1)]">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
-                  <${StatusBadge} status=${unified.canonical} />
+                  <${StatusBadge}
+                    status=${unified.canonical}
+                    label=${unified.label}
+                    tone=${unified.token ? statusBadgeToneForKeeper(unified.token) : undefined}
+                  />
                   ${keeper ? html`<${KeeperPhaseBadge} phase=${keeper.phase} compact=${true} />` : null}
                   ${unified.description !== unified.label ? html`<span class="text-2xs font-medium py-1 px-2 border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)] whitespace-nowrap rounded-[var(--r-1)]" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -53,6 +53,7 @@ import {
 import {
   keeperActivityDisplay,
   keeperDisplayRuntime,
+  keeperDisplayStatus,
   keeperRuntimeBlockerHint,
   keeperRuntimeBlockerLabel,
   keeperWorkPreview,
@@ -70,7 +71,7 @@ import {
   KEEPER_TRANSIENT_LABEL_KO,
 } from '../lib/keeper-operational-state'
 import { isKeeperPaused } from '../lib/keeper-predicates'
-import { FL_TONE_LABEL, type FleetTone } from '../lib/fleet-tone'
+import { FL_TONE_LABEL, PHASE_LABEL_KO, type FleetTone } from '../lib/fleet-tone'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { compositeSnapshotForKeeper } from '../lib/keeper-composite-lookup'
 import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../composite-signals'
@@ -360,10 +361,18 @@ export function rosterBlockerDisplay(
 // keeper-v2 Fleet skin (fleet.css .fl-*) helpers. The prototype keys every
 // chip / rail / aside-state on a 5-value tone vocabulary
 // (ok/warn/bad/busy/idle). RFC-0295 brings masc's RuntimeBand to the same 5
-// values via ROSTER_BAND_TONE (transient → busy); the Korean tone label
-// is the SSOT `FL_TONE_LABEL` from `lib/fleet-tone.ts` (shared with
-// `keeper-workspace-shared.ts`), used for the aside "selected runtime"
-// state line. Do not redeclare here — see fleet-tone.ts.
+// values via ROSTER_BAND_TONE (transient → busy). Do not redeclare the
+// tone vocabulary here — see fleet-tone.ts.
+//
+// `FL_TONE_LABEL` no longer names the aside "selected runtime" state line
+// when the selection is a keeper. It is a 5-word vocabulary over tones
+// (실행 / 대기 / 주의 / 전이 / 정지), and rendering it as a state word put it
+// next to the 16-word phase vocabulary every other keeper surface uses:
+// the same `Failing` keeper read `주의` here and `오류 발생` on the keepers
+// page, `Paused` read `대기` vs `일시정지`, `Stopped` read `정지` vs `중지`.
+// The tone still drives the dot colour; the word now comes from
+// `PHASE_LABEL_KO`. Workspace agents have no keeper phase, so they keep
+// the tone word.
 
 // CTX pressure threshold the prototype paints `hot` at (>=85%). Mirrors the
 // existing live threshold used in the aside CTX meter so both surfaces agree.
@@ -1370,7 +1379,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               <span class="fl-as-ey">${selectedRow.isKeeper ? 'selected keeper runtime' : 'selected workspace agent'}</span>
               <span class="fl-as-state">
                 <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:currentColor" aria-hidden="true"></span>
-                ${FL_TONE_LABEL[selectedTone]}
+                ${selectedRow.keeperRuntime
+                  ? PHASE_LABEL_KO[keeperDisplayStatus(selectedRow.keeperRuntime)]
+                  : FL_TONE_LABEL[selectedTone]}
               </span>
             </div>
 

--- a/dashboard/src/components/common/status-badge.ts
+++ b/dashboard/src/components/common/status-badge.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { statusLabel } from '../../lib/status-label'
+import { PHASE_TONE, type FleetTone, type KeeperPhaseToken } from '../../lib/fleet-tone'
 
 type StatusBadgeTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
 
@@ -65,6 +66,30 @@ export function statusBadgeTone(status: string): StatusBadgeTone {
 
 export function statusDotColor(status: string): string {
   return DOT_CLASS[statusBadgeTone(status)]
+}
+
+/** Keeper tone → badge tone.
+ *
+ *  `statusBadgeTone` above answers for task-shaped statuses. Most keeper
+ *  phase tokens have no arm there and hit its `default: neutral`, so a
+ *  `crashed` or `dead` keeper rendered grey in this badge while the fleet
+ *  panel painted it red from `PHASE_TONE`; `running` rendered `warn`
+ *  (orange) here and `ok` (green) there. Keeper surfaces route their token
+ *  through this map instead of relying on the string switch.
+ *
+ *  `busy → info` rather than `warn`: a transitional phase (compacting /
+ *  handoff / restarting) is progress, not an operator warning. `idle` is
+ *  the fleet tone for stopped/unbooted, so it maps to `neutral`. */
+const FLEET_TONE_TO_BADGE_TONE: Readonly<Record<FleetTone, StatusBadgeTone>> = {
+  ok: 'ok',
+  warn: 'warn',
+  bad: 'bad',
+  busy: 'info',
+  idle: 'neutral',
+}
+
+export function statusBadgeToneForKeeper(token: KeeperPhaseToken): StatusBadgeTone {
+  return FLEET_TONE_TO_BADGE_TONE[PHASE_TONE[token]]
 }
 
 export function StatusBadge({ status, label, tone, children }: StatusBadgeProps) {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -13,6 +13,47 @@ import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
 import type { DashboardRuntimeProviderSnapshot, KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import { formatTokens } from '../lib/format-number'
+import {
+  PHASE_LABEL_KO,
+  PHASE_TONE,
+  type FleetTone,
+  type KeeperPhaseToken,
+} from '../lib/fleet-tone'
+
+/** The config overlay's phase pill reads three runtime booleans rather than
+ *  a `Keeper`, so it cannot call `keeperDisplayStatus`. It maps them onto
+ *  the same token union instead, so the word and the dot colour below come
+ *  from the shared tables like every other surface.
+ *
+ *  The pill used to compute its word and its dot from two separate ternary
+ *  chains with opposite precedence — the word tested `paused` first, the dot
+ *  tested `keepalive_running` first. In the window where both are true, which
+ *  is the normal state right after a pause (the pause button's own title says
+ *  "running → paused, 현재 turn 은 정상 종료"), it rendered `일시정지` beside a
+ *  green glowing dot. One token now feeds both.
+ *
+ *  `registered` without a running keepalive loop is `unbooted`, matching
+ *  `PHASE_DESCRIPTION_KO.unbooted` — "등록만 되어 있고 아직 부팅되지 않았습니다". */
+function configPhaseToken(runtime: {
+  paused?: boolean
+  keepalive_running?: boolean
+  registered?: boolean
+}): KeeperPhaseToken {
+  if (runtime.paused) return 'paused'
+  if (runtime.keepalive_running) return 'running'
+  if (runtime.registered) return 'unbooted'
+  return 'offline'
+}
+
+/** v2 skin colour names (`--status-*`, `styles/variables.css`) rather than
+ *  the `--color-status-*` role names, matching the rest of this overlay. */
+const PHASE_DOT_COLOR: Record<FleetTone, string> = {
+  ok: 'var(--status-ok)',
+  warn: 'var(--status-warn)',
+  bad: 'var(--status-bad)',
+  busy: 'var(--color-accent-fg)',
+  idle: 'var(--text-dim)',
+}
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
 import { MISSING_DATA_DASH } from '../lib/format-string'
 import { relativeTime } from '../lib/format-time'
@@ -2207,20 +2248,23 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   }
   const activeTab = kcfTab.value
   const activeTabLabel = KCF_TABS.find((t) => t[0] === activeTab)?.[1] ?? ''
-  const phaseLabel = c.runtime.paused
-    ? '일시정지'
-    : c.runtime.keepalive_running
-      ? '실행'
-      : c.runtime.registered
-        ? '대기'
-        : '오프라인'
-  // Phase pill status dot (prototype .kcf-top-phase carries a StatusDot): green
-  // when running, amber when paused, dim otherwise.
-  const phaseDotColor = c.runtime.keepalive_running
-    ? 'var(--status-ok)'
-    : c.runtime.paused
-      ? 'var(--status-warn)'
-      : 'var(--text-dim)'
+  // One token drives both the word and the dot.
+  //
+  // These were two independent ternaries with *opposite* precedence: the
+  // label tested `paused` first, the dot tested `keepalive_running` first.
+  // A keeper in the window where both are true — which is the normal state
+  // right after a pause, since the directive is delivered to a still-running
+  // keepalive loop (see the pause button's own title: "running → paused,
+  // 현재 turn 은 정상 종료") — rendered the word `일시정지` next to a green
+  // glowing dot.
+  //
+  // The words also came from a 4-value vocabulary local to this pill
+  // (`실행` / `대기` / `오프라인`) that no other surface uses; they now come
+  // from `PHASE_LABEL_KO`, so this pill agrees with the roster, the phase
+  // badge and the agent detail header.
+  const phaseToken = configPhaseToken(c.runtime)
+  const phaseLabel = PHASE_LABEL_KO[phaseToken]
+  const phaseDotColor = PHASE_DOT_COLOR[PHASE_TONE[phaseToken]]
 
   return html`
     <div
@@ -2239,7 +2283,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
             <div class="kcf-top-sub mono">${c.execution.selected_runtime_id || c.sources.default_source_kind || MISSING_DATA_DASH}</div>
           </div>
           <span class="kcf-top-phase">
-            <span style=${`width:7px;height:7px;border-radius:50%;background:${phaseDotColor};display:inline-block;${c.runtime.keepalive_running ? 'box-shadow:0 0 6px ' + phaseDotColor + ';' : ''}`} aria-hidden="true"></span>
+            <span style=${`width:7px;height:7px;border-radius:50%;background:${phaseDotColor};display:inline-block;${phaseToken === 'running' ? 'box-shadow:0 0 6px ' + phaseDotColor + ';' : ''}`} aria-hidden="true"></span>
             ${phaseLabel}
           </span>
           <div class="kcf-top-spacer"></div>

--- a/dashboard/src/components/keeper-phase-indicator.test.ts
+++ b/dashboard/src/components/keeper-phase-indicator.test.ts
@@ -60,16 +60,16 @@ describe('PHASE_STYLES', () => {
 // ================================================================
 
 describe('getPhaseStyle', () => {
-  it('returns Offline for null', () => {
-    expect(getPhaseStyle(null).label).toBe('오프라인')
+  it('returns the unknown style for null', () => {
+    expect(getPhaseStyle(null).label).toBe('확인 필요')
   })
 
-  it('returns Offline for undefined', () => {
-    expect(getPhaseStyle(undefined).label).toBe('오프라인')
+  it('returns the unknown style for undefined', () => {
+    expect(getPhaseStyle(undefined).label).toBe('확인 필요')
   })
 
-  it('returns Offline for empty string', () => {
-    expect(getPhaseStyle('').label).toBe('오프라인')
+  it('returns the unknown style for empty string', () => {
+    expect(getPhaseStyle('').label).toBe('확인 필요')
   })
 
   it('returns correct style for Running (ok group)', () => {
@@ -100,8 +100,8 @@ describe('getPhaseStyle', () => {
     expect(tones[0]).toBe('var(--color-accent-fg)')
   })
 
-  it('returns Offline for unknown phase string', () => {
-    expect(getPhaseStyle('UnknownPhase').label).toBe('오프라인')
+  it('returns the unknown style for an unrecognized phase string', () => {
+    expect(getPhaseStyle('UnknownPhase').label).toBe('확인 필요')
   })
 
   it('returns correct style for all phases', () => {

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -51,9 +51,15 @@ const STRONG_GLOW = '0 0 10px color-mix(in srgb, currentColor 32%, transparent)'
 export const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
   // Labels come from the fleet-tone PHASE_LABEL_KO SSOT (PascalCase
   // KeeperPhase → lowercase KeeperPhaseToken is a 1:1 mapping) so the
-  // badge cannot drift from the roster/workspace vocabulary. 'Offline'
-  // has no KeeperPhaseToken counterpart, so it keeps the local literal.
-  Offline:    { label: '오프라인',     color: 'var(--color-fg-muted)', bg: 'var(--color-bg-elevated)',   border: 'var(--color-border-default)',   glow: 'none',        icon: '○' },
+  // badge cannot drift from the roster/workspace vocabulary.
+  //
+  // `Offline` reads `unbooted`, not `offline`: `keeperLifecycleStatus`
+  // (`lib/keeper-runtime-display.ts`) maps the `Offline` phase onto the
+  // `unbooted` token, so every other surface renders `미기동` for this
+  // keeper. This entry said `오프라인` and was the last cell where the
+  // agent detail header disagreed with itself — the phase badge and the
+  // status badge sit on the same line.
+  Offline:    { label: PHASE_LABEL_KO.unbooted,     color: 'var(--color-fg-muted)', bg: 'var(--color-bg-elevated)',   border: 'var(--color-border-default)',   glow: 'none',        icon: '○' },
   Running:    { label: PHASE_LABEL_KO.running,     color: 'var(--color-status-ok)',         bg: 'var(--ok-10)',     border: 'var(--ok-20)',      glow: SOFT_GLOW,     icon: '●' },
   Failing:    { label: PHASE_LABEL_KO.failing,     color: 'var(--color-status-warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '▲' },
   Overflowed: { label: PHASE_LABEL_KO.overflowed, color: 'var(--color-status-warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '⚠' },
@@ -90,8 +96,24 @@ export function pipelineStageDetailLabel(detail: string | null | undefined): str
   return PIPELINE_STAGE_DETAIL_LABELS[trimmed] ?? trimmed.replaceAll('_', ' ')
 }
 
+/** Shown when there is no phase to show — absent, blank, or a token this
+ *  build does not know.
+ *
+ *  Previously this was `PHASE_STYLES.Offline`, which was fine only while
+ *  that entry's label was the vague `오프라인`. Now that `Offline` carries
+ *  its real meaning (`미기동`, matching `keeperLifecycleStatus`'s
+ *  `Offline → unbooted` mapping), reusing it as the fallback would assert
+ *  "this keeper never booted" about a keeper we simply have no phase for.
+ *  It renders `확인 필요` instead — the same word every other surface uses
+ *  for an unresolved status — while keeping the neutral grey styling. */
+const UNKNOWN_PHASE_STYLE: PhaseStyle = {
+  ...PHASE_STYLES.Offline,
+  label: PHASE_LABEL_KO.unknown,
+  icon: '?',
+}
+
 export function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
-  if (!phase) return PHASE_STYLES.Offline
+  if (!phase) return UNKNOWN_PHASE_STYLE
   // Use the SSOT boundary parser (`toKeeperPhase`) instead of the raw
   // `as KeeperPhase` assertion. `toKeeperPhase` accepts both PascalCase
   // (canonical `Keeper.phase`) and lowercase backend tokens (the same
@@ -102,7 +124,7 @@ export function getPhaseStyle(phase: KeeperPhase | string | null | undefined): P
   // total parser, not coerced through an unchecked cast that silently
   // accesses an undefined record key.
   const typed = toKeeperPhase(phase)
-  return typed != null ? PHASE_STYLES[typed] : PHASE_STYLES.Offline
+  return typed != null ? PHASE_STYLES[typed] : UNKNOWN_PHASE_STYLE
 }
 
 /** Phase badge — color-coded pill showing the keeper lifecycle phase. */

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -80,39 +80,22 @@ export function WorkspaceSigil({
   return html`<span class=${`kw-sigil${beat ? ' kw-sigil-beat' : ''}`} style=${style} title=${id} aria-label=${id}>${sigil}</span>`
 }
 
-/** Normalize the canonical status token (from `keeperDisplayStatus`) into
- *  the closed `KeeperPhaseToken` keyspace. Unknown tokens collapse to
- *  `'unknown'` so `PHASE_TONE` / `PHASE_LABEL_KO` lookups are total.
+/** The canonical status token for a keeper.
  *
- *  Previously this was `keeperPhaseToken` reading from `lifecycle_phase`
- *  directly. That returned the raw `lifecycle_phase ?? phase` value
- *  (PascalCase) — incompatible with the lowercase-keyed SSOT in
- *  `fleet-tone.ts`. Routing through `keeperDisplayStatus` (which already
- *  applies the lowercasing + isKeeperPaused short-circuit) means there is
- *  exactly one mapping table from `KeeperPhase` to lowercase token (in
- *  `keeper-runtime-display.ts:197` `keeperLifecycleStatus`). */
+ *  `keeperDisplayStatus` now declares `KeeperPhaseToken` as its return
+ *  type, so this is a pass-through. It previously re-narrowed with a
+ *  runtime `hasOwnProperty` guard because that function returned `string`;
+ *  the guard was where `'idle'` / `'listening'` / `'handingoff'` /
+ *  `'offline'` silently became `'unknown'`, i.e. `확인 필요`. Parsing now
+ *  happens once, at the wire boundary inside `keeperDisplayStatus`
+ *  (`toKeeperPhaseToken` in `lib/fleet-tone.ts`), so re-checking here would
+ *  only be able to hide a producer bug, not catch one.
+ *
+ *  Kept as a named function rather than inlined: three call sites read it
+ *  as "the token for this keeper", and it is the seam to change if the
+ *  workspace ever needs a token different from the shared display one. */
 export function phaseTokenFromKeeper(keeper: Keeper): KeeperPhaseToken {
-  const token = keeperDisplayStatus(keeper).trim().toLowerCase()
-  return isKeeperPhaseToken(token) ? token : 'unknown'
-}
-
-/** Closed-sum guard. `keeperDisplayStatus` returns a `string` (its
- *  signature is intentionally permissive because callers pass through
- *  arbitrary backend status values), so we narrow here against the
- *  declared token union. New tokens from the wire that are not yet in
- *  `KeeperPhaseToken` collapse to `'unknown'` via this fallback.
- *
- *  Why `Object.prototype.hasOwnProperty.call` instead of `value in PHASE_TONE`:
- *  the `in` operator walks the prototype chain. Although `PHASE_TONE` is
- *  now built with `Object.create(null)` (see `lib/fleet-tone.ts`) so
- *  this specific leak no longer applies, the `hasOwnProperty` form is
- *  defensive against future refactors that switch the map to a plain
- *  object literal or a `Map`. Either backend leak mode would let a
- *  wire token like `'constructor'` or `'toString'` slip past the
- *  `'unknown'` fallback and surface inherited `Object.prototype`
- *  members in `keeperStatusTone` / `keeperPhaseLabel`. */
-function isKeeperPhaseToken(value: string): value is KeeperPhaseToken {
-  return Object.prototype.hasOwnProperty.call(PHASE_TONE, value)
+  return keeperDisplayStatus(keeper)
 }
 
 /** Phase label shown in the roster sub-row and the chat header state pill.

--- a/dashboard/src/lib/fleet-tone.ts
+++ b/dashboard/src/lib/fleet-tone.ts
@@ -26,15 +26,26 @@ export const FL_TONE_LABEL: Readonly<Record<FleetTone, string>> = {
   idle: '정지',
 }
 
-/** Canonical lower-cased phase token emitted by `keeperDisplayStatus`
- *  (`lib/keeper-runtime-display.ts:180`). The labels in PHASE_LABEL_KO and
- *  the tones in PHASE_TONE key on these tokens, NOT on the PascalCase
- *  `KeeperPhase` enum. This union is closed: any new lowercase token added
- *  by `keeperLifecycleStatus` (or any future status surface) forces the
- *  compiler to flag a missing entry here.
+/** The complete codomain of `keeperDisplayStatus`
+ *  (`lib/keeper-runtime-display.ts`), as lower-cased tokens. The labels in
+ *  PHASE_LABEL_KO and the tones in PHASE_TONE key on these tokens, NOT on
+ *  the PascalCase `KeeperPhase` enum. `keeperDisplayStatus` declares this
+ *  as its return type, so a new emission that is not listed here is a
+ *  compile error rather than a runtime collapse to `'unknown'`.
  *
- *  Derivation: `KeeperPhase` collapses via `keeperLifecycleStatus`
- *  to lowercase tokens, plus `unknown` for the fallback path.
+ *  Two groups:
+ *   - Lifecycle phases: `KeeperPhase` collapses onto these via
+ *     `keeperLifecycleStatus`. `Offline` maps to `unbooted`, not `offline`.
+ *   - Non-phase display states: `idle` / `listening` come from the agent
+ *     status axis (a keeper that is alive between turns), and `offline` is
+ *     the residual `refineOfflineStatus` case (registered, agent record
+ *     exists, never ran a turn, heartbeat stale). These are not FSM phases,
+ *     which is why `KeeperPhase` has no counterpart for them.
+ *
+ *  Before 2026-07-27 the union covered only the lifecycle group. The three
+ *  non-phase tokens were emitted anyway and collapsed to `'unknown'` at
+ *  `phaseTokenFromKeeper`, which renders as `확인 필요` — an alarm word for
+ *  a healthy idle keeper. Measured: 5 distinct inputs hit that path.
  */
 export type KeeperPhaseToken =
   | 'running'
@@ -49,6 +60,9 @@ export type KeeperPhaseToken =
   | 'unbooted'
   | 'crashed'
   | 'dead'
+  | 'idle'
+  | 'listening'
+  | 'offline'
   | 'unknown'
 
 /** Closed tone map. Keys MUST match `KeeperPhaseToken` and MUST be kept in
@@ -91,6 +105,14 @@ export const PHASE_TONE: Readonly<Record<KeeperPhaseToken, FleetTone>> =
       unbooted: 'idle',
       crashed: 'bad',
       dead: 'bad',
+      // Alive between turns. `ROSTER_BAND_TONE.active = 'ok'`
+      // (`agent-roster.ts`) already routes this band to `ok`; matching it
+      // keeps the dot colour of an idle keeper the same on both surfaces.
+      idle: 'ok',
+      listening: 'ok',
+      // Residual offline case — same "not running, not an error" bucket as
+      // `stopped` / `unbooted`.
+      offline: 'idle',
       unknown: 'idle',
     }) as Record<KeeperPhaseToken, FleetTone>,
   )
@@ -118,9 +140,94 @@ export const PHASE_LABEL_KO: Readonly<Record<KeeperPhaseToken, string>> =
       unbooted: '미기동',
       crashed: '비정상 종료',
       dead: '종료됨',
+      // Words taken from the existing `statusLabel` SSOT
+      // (`lib/status-label.ts`) rather than coined here, so the generic
+      // status vocabulary and the keeper vocabulary agree on these keys.
+      idle: '대기',
+      listening: '수신 대기',
+      offline: '오프라인',
       unknown: UNKNOWN_STATUS_LABEL,
     }) as Record<KeeperPhaseToken, string>,
   )
+
+/** One-sentence operator explanation per token — the tooltip / secondary
+ *  line that sits under the label.
+ *
+ *  Lifted verbatim from `PHASE_LABELS` in `lib/monitoring-runtime.ts`,
+ *  which owned the only such table. It moved here so the label, the tone
+ *  and the explanation share one keyspace; `monitoring-runtime` now reads
+ *  from this map instead of holding a parallel copy.
+ *
+ *  One collapse during the move: `Stopped` and the lowercase `stopped`
+ *  entry carried different sentences ('정상 정지된 런타임입니다.' vs
+ *  '이전에 실행되었지만 현재는 정지 상태입니다.') for the same token. The
+ *  PascalCase one wins because it is the FSM phase; the lowercase entry
+ *  was the status-field alias for the same condition. */
+export const PHASE_DESCRIPTION_KO: Readonly<Record<KeeperPhaseToken, string>> =
+  Object.freeze(
+    Object.assign(Object.create(null), {
+      running: 'keeper_state_machine 기준으로 정상 실행 상태입니다.',
+      paused: 'keeper가 재개 대기 상태로 멈춰 있습니다.',
+      compacting: '컨텍스트를 정리하는 중입니다.',
+      handoff: '새 세대로 넘기는 중입니다.',
+      draining: '현재 작업을 마무리하는 중입니다.',
+      restarting: '복구를 시도하고 있습니다.',
+      failing: '최근 실행에서 오류를 감지했습니다.',
+      overflowed: '프롬프트가 runtime 컨텍스트 한도를 넘겨 자동 복구가 필요합니다.',
+      stopped: '정상 정지된 런타임입니다.',
+      unbooted: '등록만 되어 있고 아직 부팅되지 않았습니다.',
+      crashed: 'fiber가 비정상적으로 종료되었습니다.',
+      dead: '명시적인 tombstone으로 종료된 상태입니다.',
+      idle: '프로세스는 살아 있지만 현재 턴 작업은 없습니다.',
+      listening: '프로세스는 살아 있고 입력을 기다리고 있습니다.',
+      offline: '런타임 연결을 확인하지 못했습니다.',
+      unknown: 'phase 정보가 부족해 수동 확인이 필요합니다.',
+    }) as Record<KeeperPhaseToken, string>,
+  )
+
+/** Wire-status synonyms that mean an already-modelled token.
+ *
+ *  Sourced from the alias arms that `KEEPER_STATUS_LABEL_KO`
+ *  (`lib/keeper-operational-state.ts`) already carries — that table lists
+ *  `active` / `live` / `busy` / `executing` and maps all four to `실행 중`,
+ *  which is the evidence that the backend emits them as `keeper.status`.
+ *  They are folded here instead of being re-listed as separate tokens so
+ *  the tone and label tables stay one-entry-per-meaning.
+ *
+ *  Not an open extension point: anything absent from both this map and
+ *  `PHASE_TONE` parses to `null`, and the caller decides the fallback. */
+const KEEPER_STATUS_ALIASES: Readonly<Record<string, KeeperPhaseToken>> =
+  Object.freeze(
+    Object.assign(Object.create(null), {
+      active: 'running',
+      live: 'running',
+      busy: 'running',
+      executing: 'running',
+      inactive: 'offline',
+    }) as Record<string, KeeperPhaseToken>,
+  )
+
+/** Boundary parse for the token union — the only sanctioned way to turn an
+ *  arbitrary wire string into a `KeeperPhaseToken`. Returns `null` on an
+ *  unrecognized value rather than guessing, so callers state their own
+ *  fallback at the call site instead of inheriting a silent one.
+ *
+ *  `hasOwnProperty` rather than `in`: `PHASE_TONE` is null-prototype today,
+ *  but the guard must keep holding if it is ever rebuilt as a plain object
+ *  literal, where a wire token like `'constructor'` would otherwise pass. */
+export function toKeeperPhaseToken(
+  value: string | null | undefined,
+): KeeperPhaseToken | null {
+  const normalized = (value ?? '').trim().toLowerCase()
+  if (!normalized) return null
+  if (Object.prototype.hasOwnProperty.call(PHASE_TONE, normalized)) {
+    return normalized as KeeperPhaseToken
+  }
+  if (Object.prototype.hasOwnProperty.call(KEEPER_STATUS_ALIASES, normalized)) {
+    return KEEPER_STATUS_ALIASES[normalized] ?? null
+  }
+  return null
+}
 
 // The runtime helper `phaseTokenFromPhase` is defined in the workspace
 // surface (keeper-workspace-shared.ts) because it depends on

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -39,9 +39,17 @@ describe('keeperDisplayStatus', () => {
     expect(keeperDisplayStatus(undefined)).toBe('unknown')
   })
 
-  it('passes through non-offline statuses', () => {
-    expect(keeperDisplayStatus(makeKeeper({ status: 'active' }))).toBe('active')
+  it('normalizes non-offline statuses onto the token union', () => {
+    // `active` is a wire synonym of `running` (KEEPER_STATUS_ALIASES), so it
+    // folds; `idle` is its own token, so it stays. The old behaviour passed
+    // the raw string through, which is how `idle` reached the roster as
+    // `확인 필요` — it was not a member of KeeperPhaseToken.
+    expect(keeperDisplayStatus(makeKeeper({ status: 'active' }))).toBe('running')
     expect(keeperDisplayStatus(makeKeeper({ status: 'idle' }))).toBe('idle')
+  })
+
+  it('collapses a status outside the union to unknown rather than leaking it', () => {
+    expect(keeperDisplayStatus(makeKeeper({ status: 'banana' }))).toBe('unknown')
   })
 
   describe('offline refinement into unbooted/stopped', () => {

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -2,6 +2,9 @@ import type { Keeper, KeeperRuntimeBlockerClass } from '../types'
 import { relativeTime } from './format-time'
 import { firstNonEmptyString } from './format-string'
 import { isKeeperPaused } from './keeper-predicates'
+// `fleet-tone` is leaf-level (it imports only `format-string`), so this
+// direction introduces no cycle.
+import { toKeeperPhaseToken, type KeeperPhaseToken } from './fleet-tone'
 import { HEARTBEAT_STALE_MS } from '../config/constants'
 
 /** Max seconds since last heartbeat to consider the keeper process alive. */
@@ -252,7 +255,19 @@ export function keeperActivityDisplay(
   }
 }
 
-export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
+/** The keeper status token every display surface keys on.
+ *
+ *  Returns `KeeperPhaseToken`, not `string`. Until 2026-07-27 this returned
+ *  `string` and passed unmodelled values (`'idle'`, `'listening'`,
+ *  `'handingoff'`, `'offline'`, and any unrecognized `keeper.status`)
+ *  straight through; `phaseTokenFromKeeper` then collapsed them to
+ *  `'unknown'`, which the roster and chat header render as `확인 필요`.
+ *  Narrowing the return type moves that from a runtime collapse to a
+ *  compile error at whichever arm produces a new value. */
+export function keeperDisplayStatus(
+  keeper: Keeper | null | undefined,
+  fallbackStatus?: string | null,
+): KeeperPhaseToken {
   if (keeper && isKeeperPaused(keeper)) return 'paused'
   const lifecycleStatus = keeperLifecycleStatus(keeper?.lifecycle_phase)
   // Honor the FSM phase first: a Running keeper whose status field says
@@ -266,10 +281,12 @@ export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackS
     return refineOfflineStatus(keeper)
   }
 
-  return status && status.trim() !== '' ? status : 'unknown'
+  return toKeeperPhaseToken(status) ?? 'unknown'
 }
 
-function keeperLifecycleStatus(phase: Keeper['lifecycle_phase'] | string | null | undefined): string | null {
+function keeperLifecycleStatus(
+  phase: Keeper['lifecycle_phase'] | string | null | undefined,
+): KeeperPhaseToken | null {
   switch (phase) {
     case 'Offline':
       return 'unbooted'
@@ -398,7 +415,7 @@ export function keeperPauseDisplay(keeper: Keeper): KeeperPauseDisplay | null {
 /** Distinguish "never booted" from "was running but stopped" keepers.
  *  Reconciles heartbeat liveness with agent registration status:
  *  if heartbeat is recent but agent is offline, shows phase instead of "offline". */
-function refineOfflineStatus(keeper: Keeper | null | undefined): string {
+function refineOfflineStatus(keeper: Keeper | null | undefined): KeeperPhaseToken {
   if (!keeper) return 'offline'
 
   // Heartbeat alive but agent offline — keepalive fiber is running.
@@ -417,8 +434,17 @@ function refineOfflineStatus(keeper: Keeper | null | undefined): string {
   // only the 13 PascalCase phases, none of which lowercase to
   // `'inactive'`), so the guard was dead defensive.
   if (keeper.last_heartbeat && isHeartbeatAlive(keeper.last_heartbeat)) {
-    const phase = (keeper.lifecycle_phase ?? keeper.phase)?.trim().toLowerCase()
-    if (phase && phase !== 'offline') return phase
+    // Route through `keeperLifecycleStatus`, not `.toLowerCase()`. The
+    // PascalCase phase names are not their own tokens: `'HandingOff'`
+    // lowercases to `'handingoff'`, but the token is `'handoff'`. It was
+    // the only multi-word phase, so it was the only one that broke — a
+    // handing-off keeper rendered as `확인 필요` while `Compacting` (one
+    // word, so `.toLowerCase()` happened to land on its token) rendered
+    // correctly. Unrecognized phases still fall through to `'idle'`.
+    const phase = (keeper.lifecycle_phase ?? keeper.phase)?.trim()
+    if (phase && phase.toLowerCase() !== 'offline') {
+      return keeperLifecycleStatus(phase) ?? toKeeperPhaseToken(phase) ?? 'idle'
+    }
     return 'idle'
   }
 

--- a/dashboard/src/lib/keeper-status-vocabulary.contract.test.ts
+++ b/dashboard/src/lib/keeper-status-vocabulary.contract.test.ts
@@ -1,0 +1,127 @@
+// Contract: one keeper state renders as one word, everywhere.
+//
+// The dashboard shows keeper status on four independent surfaces, each
+// reached through a different call chain. Before 2026-07-27 all twelve
+// `KeeperPhase` values rendered 2–4 different words depending on which
+// surface you were looking at — `Offline` was 미기동 / 정지 / 확인 필요 /
+// 오프라인 at the same moment. Each surface was internally consistent, so
+// the compiler saw nothing wrong: every table was total over its own union.
+//
+// This test is the thing the type system cannot express — that four
+// separately-typed lookups agree. It fails if any one of them is edited
+// alone.
+import { describe, it, expect } from 'vitest'
+import { keeperDisplayStatus } from './keeper-runtime-display'
+import { PHASE_TONE, PHASE_LABEL_KO, PHASE_DESCRIPTION_KO, toKeeperPhaseToken, type KeeperPhaseToken } from './fleet-tone'
+import { resolveUnifiedStatus } from './unified-status'
+import { keeperPhaseLabel } from '../components/keeper-workspace/keeper-workspace-shared'
+import { PHASE_STYLES, getPhaseStyle } from '../components/keeper-phase-indicator'
+import type { Keeper, KeeperPhase } from '../types/core'
+
+const ALL_PHASES: KeeperPhase[] = [
+  'Offline', 'Running', 'Failing', 'Overflowed', 'Compacting',
+  'HandingOff', 'Draining', 'Paused', 'Stopped', 'Crashed', 'Restarting', 'Dead',
+]
+
+function keeperInPhase(phase: KeeperPhase): Keeper {
+  return { name: 'contract', lifecycle_phase: phase, phase } as Keeper
+}
+
+/** The four places an operator can read this keeper's state. Each entry is
+ *  the expression the corresponding component renders — keep them in step
+ *  with the call sites named in the comments. */
+function renderedWords(phase: KeeperPhase): Record<string, string> {
+  const keeper = keeperInPhase(phase)
+  return {
+    // keepers page: workspace roster row + chat header pill
+    //   keeper-workspace-roster.ts, keeper-workspace-chat.ts
+    workspaceRoster: keeperPhaseLabel(keeper),
+    // monitoring page: roster aside "selected keeper runtime" state line
+    //   agent-roster.ts, keeper branch
+    rosterAside: PHASE_LABEL_KO[keeperDisplayStatus(keeper)],
+    // agent detail header: <StatusBadge label=${unified.label}>
+    //   agent-detail.ts
+    agentDetailBadge: resolveUnifiedStatus(keeperDisplayStatus(keeper), null, null).label,
+    // agent detail header: <KeeperPhaseBadge>, rendered on the same line
+    //   agent-detail.ts -> keeper-phase-indicator.ts
+    phaseBadge: PHASE_STYLES[phase].label,
+  }
+}
+
+describe('keeper status vocabulary is single-valued across surfaces', () => {
+  it.each(ALL_PHASES)('%s renders as one word everywhere', phase => {
+    const words = renderedWords(phase)
+    const distinct = [...new Set(Object.values(words))]
+    expect(distinct, `surfaces disagree for ${phase}: ${JSON.stringify(words)}`).toHaveLength(1)
+  })
+
+  it('covers every KeeperPhase, so a new phase cannot skip this test', () => {
+    // Guards against the list above drifting from the type. `PHASE_STYLES`
+    // is `Record<KeeperPhase, …>`, so its keys are exactly the union.
+    expect([...ALL_PHASES].sort()).toEqual(Object.keys(PHASE_STYLES).sort())
+  })
+})
+
+describe('keeperDisplayStatus stays inside the token union', () => {
+  // The union is the function's declared return type, so a producer arm
+  // that invents a value is a compile error. These cases pin the inputs
+  // that used to escape it at runtime and surface as `확인 필요`.
+  const escapees: Array<[string, Keeper, KeeperPhaseToken]> = [
+    [
+      'heartbeat alive with no lifecycle phase',
+      { name: 'k', status: 'offline', last_heartbeat: new Date().toISOString() } as Keeper,
+      'idle',
+    ],
+    [
+      'HandingOff via keeper.phase — PascalCase lowercases to handingoff, not handoff',
+      { name: 'k', status: 'offline', phase: 'HandingOff', last_heartbeat: new Date().toISOString() } as Keeper,
+      'handoff',
+    ],
+    ['backend status idle', { name: 'k', status: 'idle' } as Keeper, 'idle'],
+    ['backend status listening', { name: 'k', status: 'listening' } as Keeper, 'listening'],
+    [
+      'offline residual: agent record exists but no turn was ever run',
+      { name: 'k', status: 'offline', agent: { exists: true } } as unknown as Keeper,
+      'offline',
+    ],
+  ]
+
+  it.each(escapees)('%s', (_name, keeper, expected) => {
+    const token = keeperDisplayStatus(keeper)
+    expect(token).toBe(expected)
+    expect(PHASE_LABEL_KO[token]).not.toBe(PHASE_LABEL_KO.unknown)
+  })
+
+  it('does not leak an unmodelled backend status', () => {
+    expect(keeperDisplayStatus({ name: 'k', status: 'no-such-status' } as Keeper)).toBe('unknown')
+  })
+})
+
+describe('the three token-keyed tables cover the same keys', () => {
+  it('tone, label and description agree on the keyspace', () => {
+    const tone = Object.keys(PHASE_TONE).sort()
+    expect(Object.keys(PHASE_LABEL_KO).sort()).toEqual(tone)
+    expect(Object.keys(PHASE_DESCRIPTION_KO).sort()).toEqual(tone)
+  })
+
+  it('every token round-trips through the boundary parser', () => {
+    for (const token of Object.keys(PHASE_TONE) as KeeperPhaseToken[]) {
+      expect(toKeeperPhaseToken(token)).toBe(token)
+    }
+  })
+
+  it('no two tokens share a label, so a word identifies a state', () => {
+    const labels = Object.values(PHASE_LABEL_KO)
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+})
+
+describe('the unknown fallback does not assert a state', () => {
+  it('an unrecognized phase does not claim the keeper never booted', () => {
+    // `PHASE_STYLES.Offline` carries `미기동`, which is a claim. Reusing it
+    // as the fallback would make "we have no phase" read as "never booted".
+    expect(getPhaseStyle('NoSuchPhase').label).toBe(PHASE_LABEL_KO.unknown)
+    expect(getPhaseStyle(null).label).toBe(PHASE_LABEL_KO.unknown)
+    expect(PHASE_STYLES.Offline.label).toBe(PHASE_LABEL_KO.unbooted)
+  })
+})

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -10,7 +10,7 @@ import {
   KEEPER_STATUS_LABEL_KO,
   KEEPER_TRANSIENT_LABEL_KO,
 } from './keeper-operational-state'
-import { PHASE_LABEL_KO } from './fleet-tone'
+import { PHASE_DESCRIPTION_KO, PHASE_LABEL_KO, type KeeperPhaseToken } from './fleet-tone'
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline' | 'transient'
 
@@ -56,33 +56,44 @@ const OFFLINE_STAGE_META: StageMeta = {
   description: '활동 정보를 확인하지 못했습니다.',
 }
 
-// Phase labels come from the fleet-tone PHASE_LABEL_KO SSOT (keyed on the
-// lowercase KeeperPhaseToken; the PascalCase KeeperPhase keys below map
-// 1:1 onto those tokens). Keys with no KeeperPhaseToken counterpart
-// ('Offline'/'offline' — the token union has no 'offline' arm — and the
-// non-phase lifecycle buckets active/busy/listening/idle) keep their
-// local literals.
+/** Build a `PhaseMeta` from the fleet-tone SSOT.
+ *
+ *  Both the label and the one-line explanation now come from
+ *  `PHASE_LABEL_KO` / `PHASE_DESCRIPTION_KO`. The descriptions used to be
+ *  written out here; they moved to `fleet-tone.ts` so the label, the tone
+ *  and the sentence share one keyspace, and this file reads them back. */
+function phaseMetaFromToken(key: string, token: KeeperPhaseToken): PhaseMeta {
+  return { key, label: PHASE_LABEL_KO[token], description: PHASE_DESCRIPTION_KO[token] }
+}
+
+// Every key now has a `KeeperPhaseToken` counterpart. Until 2026-07-27 the
+// union had no `offline` / `idle` / `listening` arm, so those rows carried
+// local literals that drifted from the SSOT — `active: '실행중'` against
+// `PHASE_LABEL_KO.running = '실행 중'` differed only by a space, and
+// `listening: '대기중'` against `수신 대기` differed outright.
 const PHASE_LABELS: Record<string, PhaseMeta> = {
-  Offline: { key: 'Offline', label: '오프라인', description: '런타임이 올라오지 않았거나 연결 정보가 없습니다.' },
-  Running: { key: 'Running', label: PHASE_LABEL_KO.running, description: 'keeper_state_machine 기준으로 정상 실행 상태입니다.' },
-  Failing: { key: 'Failing', label: PHASE_LABEL_KO.failing, description: '최근 실행에서 오류를 감지했습니다.' },
-  Overflowed: { key: 'Overflowed', label: PHASE_LABEL_KO.overflowed, description: '프롬프트가 runtime 컨텍스트 한도를 넘겨 자동 복구가 필요합니다.' },
-  Compacting: { key: 'Compacting', label: PHASE_LABEL_KO.compacting, description: '컨텍스트를 정리하는 중입니다.' },
-  HandingOff: { key: 'HandingOff', label: PHASE_LABEL_KO.handoff, description: '새 세대로 넘기는 중입니다.' },
-  Draining: { key: 'Draining', label: PHASE_LABEL_KO.draining, description: '현재 작업을 마무리하는 중입니다.' },
-  Paused: { key: 'Paused', label: PHASE_LABEL_KO.paused, description: 'keeper가 재개 대기 상태로 멈춰 있습니다.' },
-  Stopped: { key: 'Stopped', label: PHASE_LABEL_KO.stopped, description: '정상 정지된 런타임입니다.' },
-  Crashed: { key: 'Crashed', label: PHASE_LABEL_KO.crashed, description: 'fiber가 비정상적으로 종료되었습니다.' },
-  Restarting: { key: 'Restarting', label: PHASE_LABEL_KO.restarting, description: '복구를 시도하고 있습니다.' },
-  Dead: { key: 'Dead', label: PHASE_LABEL_KO.dead, description: '명시적인 tombstone으로 종료된 상태입니다.' },
-  active: { key: 'active', label: '실행중', description: '프로세스는 살아 있지만 state projection이 부족합니다.' },
-  busy: { key: 'busy', label: '작업중', description: '프로세스는 살아 있고 현재 작업을 수행 중입니다.' },
-  listening: { key: 'listening', label: '대기중', description: '프로세스는 살아 있고 입력을 기다리고 있습니다.' },
-  idle: { key: 'idle', label: '대기', description: '프로세스는 살아 있지만 현재 턴 작업은 없습니다.' },
-  paused: { key: 'paused', label: PHASE_LABEL_KO.paused, description: 'keeper가 재개 대기 상태로 멈춰 있습니다.' },
-  stopped: { key: 'stopped', label: PHASE_LABEL_KO.stopped, description: '이전에 실행되었지만 현재는 정지 상태입니다.' },
-  unbooted: { key: 'unbooted', label: PHASE_LABEL_KO.unbooted, description: '등록만 되어 있고 아직 부팅되지 않았습니다.' },
-  offline: { key: 'offline', label: '오프라인', description: '런타임 연결을 확인하지 못했습니다.' },
+  Offline: { key: 'Offline', label: PHASE_LABEL_KO.offline, description: '런타임이 올라오지 않았거나 연결 정보가 없습니다.' },
+  Running: phaseMetaFromToken('Running', 'running'),
+  Failing: phaseMetaFromToken('Failing', 'failing'),
+  Overflowed: phaseMetaFromToken('Overflowed', 'overflowed'),
+  Compacting: phaseMetaFromToken('Compacting', 'compacting'),
+  HandingOff: phaseMetaFromToken('HandingOff', 'handoff'),
+  Draining: phaseMetaFromToken('Draining', 'draining'),
+  Paused: phaseMetaFromToken('Paused', 'paused'),
+  Stopped: phaseMetaFromToken('Stopped', 'stopped'),
+  Crashed: phaseMetaFromToken('Crashed', 'crashed'),
+  Restarting: phaseMetaFromToken('Restarting', 'restarting'),
+  Dead: phaseMetaFromToken('Dead', 'dead'),
+  // `active` / `busy` are wire synonyms of `running` (see
+  // KEEPER_STATUS_ALIASES in fleet-tone.ts) — same word, same sentence.
+  active: phaseMetaFromToken('active', 'running'),
+  busy: phaseMetaFromToken('busy', 'running'),
+  listening: phaseMetaFromToken('listening', 'listening'),
+  idle: phaseMetaFromToken('idle', 'idle'),
+  paused: phaseMetaFromToken('paused', 'paused'),
+  stopped: phaseMetaFromToken('stopped', 'stopped'),
+  unbooted: phaseMetaFromToken('unbooted', 'unbooted'),
+  offline: phaseMetaFromToken('offline', 'offline'),
   unknown: UNKNOWN_PHASE_META,
 }
 

--- a/dashboard/src/lib/unified-status.test.ts
+++ b/dashboard/src/lib/unified-status.test.ts
@@ -28,7 +28,10 @@ describe('resolveUnifiedStatus', () => {
   it('resolves running status', () => {
     const r = resolveUnifiedStatus('running', null, null)
     expect(r.canonical).toBe('running')
-    expect(r.label).toBe('진행 중')
+    // `실행 중` (the keeper vocabulary), not `진행 중` (statusLabel's word
+    // for a task in progress). This function feeds the agent detail header,
+    // which sits next to a keeper phase badge saying `실행 중`.
+    expect(r.label).toBe('실행 중')
   })
 
   it('resolves active status with stale annotation', () => {

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -3,11 +3,42 @@
 
 import { statusLabel } from './status-label.js'
 import { UNKNOWN_STATUS_LABEL } from './format-string'
+import {
+  PHASE_DESCRIPTION_KO,
+  PHASE_LABEL_KO,
+  toKeeperPhaseToken,
+  type KeeperPhaseToken,
+} from './fleet-tone'
 
 interface UnifiedStatusResult {
   canonical: string
   label: string
   description: string
+  /** Set when `primary` parsed as a keeper display token.
+   *
+   *  Exists so a caller can pick a tone from `PHASE_TONE` rather than from
+   *  `statusBadgeTone` (`components/common/status-badge.ts`), whose switch
+   *  was written for task states: it answers `warn` for `running`, `ok`
+   *  for `active`, and falls to `neutral` for `crashed` / `dead` /
+   *  `overflowed` / `compacting` / `handoff` / `draining` / `restarting` /
+   *  `unbooted`. A crashed keeper therefore rendered grey there and red on
+   *  the fleet panel.
+   *
+   *  `null` for statuses that are not keeper tokens — `'working'` is the
+   *  live example (a UI-derived PulseState). Those keep the generic tone. */
+  token: KeeperPhaseToken | null
+}
+
+/** The keeper vocabulary wins whenever the status is a keeper token.
+ *
+ *  `statusLabel` is the generic status vocabulary (tasks, connectors,
+ *  fusion runs, board moderation). Where the two keyspaces overlap they
+ *  disagree — `compacting` is `컴팩팅` there and `압축 중` in the keeper
+ *  SSOT, `handoff` is `핸드오프` vs `인계 중`, `running` is `진행 중` vs
+ *  `실행 중` — so the agent detail header used to disagree with the
+ *  keepers page about the same keeper. */
+function unifiedLabel(primary: string, token: KeeperPhaseToken | null): string {
+  return token ? PHASE_LABEL_KO[token] : statusLabel(primary)
 }
 
 /**
@@ -25,39 +56,48 @@ export function resolveUnifiedStatus(
 ): UnifiedStatusResult {
   const primary = (keeperStatus ?? agentStatus ?? '').toLowerCase()
   const signal = (signalTruth ?? '').toLowerCase()
+  // Parsed once. The arms below keep their own `canonical` values because
+  // those are part of this function's contract (`active` stays `active`,
+  // `busy` stays `busy`); only the label and the tone hint route through
+  // the keeper SSOT.
+  const token = toKeeperPhaseToken(primary)
 
   // Offline / inactive — process not running.
   // Matches agent-status.ts SSOT: isAgentOffline checks the same two tokens.
   if (primary === 'offline' || primary === 'inactive') {
     return {
       canonical: 'offline',
-      label: '오프라인',
+      label: PHASE_LABEL_KO.offline,
       description: signal === 'live'
         ? '프로세스 오프라인 (미션 신호는 최근 수신됨)'
         : '프로세스 오프라인',
+      token: 'offline',
     }
   }
 
   if (primary === 'paused') {
     return {
       canonical: 'paused',
-      label: statusLabel(primary),
+      label: unifiedLabel(primary, token),
       description: signal === 'live'
         ? '일시정지됨 (미션 신호는 최근 수신됨)'
         : '일시정지됨',
+      token,
     }
   }
 
   // Active states. `'working'` is a UI-derived PulseState, not a backend
-  // agent status — intentionally outside ACTIVE_STATUSES SSOT.
+  // agent status — intentionally outside ACTIVE_STATUSES SSOT, and the one
+  // arm here that yields a null token.
   if (primary === 'active' || primary === 'running' || primary === 'busy' || primary === 'working') {
     const desc = signal === 'stale'
       ? '프로세스 활성 (미션 활동은 오래됨)'
       : '프로세스 활성'
     return {
       canonical: primary,
-      label: statusLabel(primary),
+      label: unifiedLabel(primary, token),
       description: desc,
+      token,
     }
   }
 
@@ -65,10 +105,11 @@ export function resolveUnifiedStatus(
   if (primary === 'listening' || primary === 'idle') {
     return {
       canonical: primary,
-      label: statusLabel(primary),
+      label: unifiedLabel(primary, token),
       description: signal === 'live'
         ? '대기 중 (미션 신호 수신 중)'
         : '대기 중',
+      token,
     }
   }
 
@@ -76,21 +117,43 @@ export function resolveUnifiedStatus(
   if (primary === 'compacting' || primary === 'handoff') {
     return {
       canonical: primary,
-      label: statusLabel(primary),
+      label: unifiedLabel(primary, token),
       description: primary === 'compacting' ? '컨텍스트 압축 중' : '핸드오프 진행 중',
+      token,
     }
   }
 
-  // No keeper/agent status — fall back to signal_truth
+  // No keeper/agent status — fall back to signal_truth. These describe the
+  // mission signal, not a runtime phase, so they carry no keeper token.
   if (!primary && signal) {
     if (signal === 'live') {
-      return { canonical: 'live', label: '활성 (신호)', description: '미션 신호만 확인됨 (프로세스 상태 불명)' }
+      return { canonical: 'live', label: '활성 (신호)', description: '미션 신호만 확인됨 (프로세스 상태 불명)', token: null }
     }
     if (signal === 'stale') {
-      return { canonical: 'stale', label: '오래됨', description: '미션 신호 오래됨, 프로세스 상태 불명' }
+      return { canonical: 'stale', label: '오래됨', description: '미션 신호 오래됨, 프로세스 상태 불명', token: null }
     }
     if (signal === 'archived') {
-      return { canonical: 'archived', label: '보관됨', description: '미션 종료됨' }
+      return { canonical: 'archived', label: '보관됨', description: '미션 종료됨', token: null }
+    }
+  }
+
+  // Every keeper lifecycle token the hand-written arms above do not
+  // special-case. Without this the arms covered 4 of the 12 `KeeperPhase`
+  // values, and `Failing` / `Overflowed` / `Draining` / `Stopped` /
+  // `Crashed` / `Restarting` / `Dead` / `unbooted` all fell to `unknown` —
+  // so the agent detail header rendered `확인 필요` next to a phase badge
+  // that said `중지` or `종료됨` for the same keeper (`agent-detail.ts`
+  // renders both badges on one line). Measured 2026-07-27: 8 of 12.
+  //
+  // Placed after the signal-truth arms, not before, because those arms
+  // annotate a known status with mission-signal context; this one only
+  // fires when no arm claimed the status.
+  if (token && token !== 'unknown') {
+    return {
+      canonical: token,
+      label: PHASE_LABEL_KO[token],
+      description: PHASE_DESCRIPTION_KO[token],
+      token,
     }
   }
 
@@ -99,5 +162,6 @@ export function resolveUnifiedStatus(
     canonical: 'unknown',
     label: UNKNOWN_STATUS_LABEL,
     description: '상태 정보 없음',
+    token: null,
   }
 }

--- a/dashboard/src/styles/pixel-avatar.css
+++ b/dashboard/src/styles/pixel-avatar.css
@@ -36,7 +36,17 @@
     0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
-/* State animations applied to the avatar container */
+/* State animations applied to the avatar container.
+ *
+ * `running` is the canonical keeper token; `active` / `busy` are wire
+ * synonyms that `toKeeperPhaseToken` (`src/lib/fleet-tone.ts`) now folds
+ * onto it, so a keeper whose backend status is `active` arrives here as
+ * `running`. Both spellings are kept: agents (not keepers) still reach
+ * this component with the raw `active` / `busy` status.
+ *
+ * `busy` keeps its own vibrate animation for the agent path even though
+ * the keeper path no longer emits it. */
+.pixel-avatar[data-status="running"],
 .pixel-avatar[data-status="active"],
 .pixel-avatar[data-status="working"] {
   animation: avatar-bounce 1.2s var(--ease-inout) infinite;
@@ -54,8 +64,17 @@
   animation: avatar-pulse-glow 2s var(--ease-inout) infinite;
 }
 
+/* Not running. `unbooted` / `stopped` / `dead` / `crashed` are what
+ * `keeperLifecycleStatus` actually emits for a down keeper — only the
+ * generic `offline` / `inactive` spellings were listed here, so a stopped
+ * or dead keeper kept a full-colour avatar while the roster chip painted
+ * it grey. */
 .pixel-avatar[data-status="offline"],
-.pixel-avatar[data-status="inactive"] {
+.pixel-avatar[data-status="inactive"],
+.pixel-avatar[data-status="unbooted"],
+.pixel-avatar[data-status="stopped"],
+.pixel-avatar[data-status="dead"],
+.pixel-avatar[data-status="crashed"] {
   filter: grayscale(0.85) brightness(0.6);
   opacity: 0.55;
 }


### PR DESCRIPTION
## 무엇

대시보드에서 같은 keeper 가 페이지마다 다른 단어·다른 색으로 표시되던 것을 하나로 맞췄습니다.

측정치입니다. 12 개 `KeeperPhase` × 운영자가 상태를 읽을 수 있는 4 개 지점:

| phase | 워크스페이스 로스터 | 로스터 aside | 상세 상태배지 | 상세 phase배지 | 단어수 |
|---|---|---|---|---|---|
| Offline | 미기동 | 정지 | 확인 필요 | 오프라인 | **4** |
| Running | 실행 중 | 실행 | 진행 중 | 실행 중 | 3 |
| Failing | 오류 발생 | 주의 | 확인 필요 | 오류 발생 | 3 |
| Stopped | 중지 | 정지 | 확인 필요 | 중지 | 3 |
| Dead | 종료됨 | 주의 | 확인 필요 | 종료됨 | 3 |
| Paused | 일시정지 | 대기 | 일시정지 | 일시정지 | 2 |

12 개 전부 2 개 이상이었습니다. 수정 후 12 개 전부 1 개입니다.

컴파일러가 못 잡은 이유는 테이블이 서로 **모순**이라서가 아닙니다. 겹치는 키에서는 문구가 완전히 일치했습니다 (`labelConflicts: []`). 각 테이블이 자기 union 에 대해 total 이고 **커버 범위가 달라서**, 서로 다른 fallback 이 서로 다른 단어로 빈칸을 메운 것입니다. grep 으로는 안 보이고 값을 실행해야 보입니다.

## 원인 5 가지

### 1. `resolveUnifiedStatus` 가 12 개 중 4 개만 처리 (`lib/unified-status.ts`)

`failing` `overflowed` `draining` `stopped` `crashed` `restarting` `dead` `unbooted` 에 분기가 없어 전부 `unknown` 으로 떨어졌습니다. 그 결과가 위 표의 "상세 상태배지" 열입니다.

`agent-detail.ts:260-264` 는 이 배지와 phase 배지를 **같은 줄에** 렌더합니다. 즉 페이지 간 불일치가 아니라 한 줄 안에서 `확인 필요` 옆에 `중지` 가 붙었습니다.

토큰 SSOT 를 거치는 arm 을 signal-truth arm 뒤에 추가했습니다. 앞이 아니라 뒤인 이유는 앞쪽 arm 들이 알려진 상태에 미션 신호 맥락을 덧붙이는 역할이기 때문입니다.

### 2. `keeperDisplayStatus` 가 토큰 union 밖 값을 5 종 방출 (`lib/keeper-runtime-display.ts`)

`string` 을 반환하면서 `KeeperPhaseToken` 에 없는 값을 내보냈고, 하류 `phaseTokenFromKeeper` 가 `unknown` 으로 접었습니다. `PHASE_LABEL_KO.unknown` 은 `확인 필요` — 멀쩡히 대기 중인 keeper 에 경보 단어가 붙었습니다.

측정된 5 종:

```
heartbeat 살아있고 lifecycle_phase 없음  -> 'idle'       -> 확인 필요
backend status = idle                   -> 'idle'       -> 확인 필요
backend status = listening              -> 'listening'  -> 확인 필요
heartbeat 살아있고 phase=HandingOff      -> 'handingoff' -> 확인 필요
offline 잔여 (agent 있고 턴 0)           -> 'offline'    -> 확인 필요
```

`handingoff` 는 케이싱 버그입니다. `refineOfflineStatus` 가 바로 옆에 있는 매핑 함수(`keeperLifecycleStatus`)를 우회하고 PascalCase 를 `.toLowerCase()` 했는데, 토큰은 `handoff` 입니다. `HandingOff` 가 유일한 두 단어 phase 라서 혼자 깨졌고 `Compacting` 은 우연히 통과했습니다.

### 3. 톤 어휘가 상태 단어로 렌더됨 (`components/agent-roster.ts:1373`)

`FL_TONE_LABEL` 은 톤 5 개에 붙인 단어(`실행` `대기` `주의` `전이` `정지`)입니다. 색을 고르는 축인데 aside 의 "selected keeper runtime" 상태 줄에 사람이 읽는 단어로 나갔습니다. 이게 위 표의 `주의` `정지` `대기` 입니다.

keeper 선택 시에는 phase 단어를 쓰도록 바꿨습니다. 톤은 점 색깔로 계속 씁니다. workspace agent 는 keeper phase 가 없으므로 톤 단어를 유지합니다.

### 4. 설정 오버레이 phase 알약의 라벨·점이 반대 우선순위 (`components/keeper-config-panel.ts`)

```
phaseLabel    = paused            -> keepalive_running -> registered -> ...
phaseDotColor = keepalive_running -> paused            -> ...
```

둘 다 true 인 구간 — 일시정지 직후의 정상 상태입니다. 일시정지 버튼 자신의 title 이 `running → paused, 현재 turn 은 정상 종료` 라고 적고 있습니다 — 에서 `일시정지` 글자에 **초록 glow 점**이 붙었습니다. 어휘도 이 알약 전용 4 값(`실행` `대기` `오프라인`)이었습니다.

토큰 하나에서 단어와 점을 모두 파생시켰습니다.

### 5. `StatusBadge` 톤 스위치가 task 용 (`components/common/status-badge.ts`)

`statusBadgeTone` 은 `running -> warn`, `active -> ok` 이고 `crashed` `dead` `overflowed` `compacting` `handoff` `draining` `restarting` `unbooted` 는 전부 `default: neutral` 입니다. crashed keeper 가 상세에선 회색, 플릿 패널에선 빨강이었습니다.

`statusBadgeToneForKeeper` 를 추가해 keeper 서피스는 `PHASE_TONE` 에서 톤을 가져오게 했습니다. `busy -> info` 로 둔 이유는 전이 단계가 경고가 아니기 때문입니다.

## 재발 방지: 타입 레벨

`keeperDisplayStatus` 의 반환 타입을 `string` -> `KeeperPhaseToken` 으로 좁혔습니다. 새 값을 내보내는 arm 이 생기면 런타임 붕괴가 아니라 그 자리에서 컴파일 에러입니다.

**한계를 분명히 합니다**: 반환 타입 narrowing 은 항상 할당 호환이라 call site 8 곳에서 오류가 0 건 났습니다. 이 가드는 **생산자 쪽만** 지킵니다. 소비자 쪽 합의는 타입으로 표현할 수 없어서 계약 테스트로 잡습니다.

`active`/`live`/`busy`/`executing` 는 `KEEPER_STATUS_ALIASES` 로 `running` 에 접습니다. 이 별칭 목록은 제가 고른 게 아니라 `KEEPER_STATUS_LABEL_KO` 가 이미 네 개를 모두 `실행 중` 에 매핑하고 있다는 사실 — 즉 백엔드가 그 값들을 낸다는 증거 — 에서 가져왔습니다.

## 계약 테스트와 변이 검증

`lib/keeper-status-vocabulary.contract.test.ts` 가 12 phase 각각에 대해 4 개 렌더 경로가 같은 단어를 내는지 봅니다.

**통과만으로는 증거가 아니므로 변이 3 종으로 확인했습니다.**

| 변이 | 결과 |
|---|---|
| `PHASE_STYLES.Offline` 만 `오프라인` 으로 되돌림 (한 화면 이탈) | 2 건 실패, 어느 화면이 어긋났는지 진단문에 표시 |
| `refineOfflineStatus` 케이싱 버그 복원 | 1 건 실패 (`expected 'idle' to be 'handoff'`) |
| `unified-status` 새 arm 비활성화 | **8 건 실패** — 원래 결함이 있던 정확히 그 8 개 phase |

먼저 시도한 변이(`PHASE_LABEL_KO.paused` 를 `멈춤` 으로)는 **살아남았고**, 그건 결함이 아니라 제 변이가 잘못된 축을 찌른 것입니다. SSOT 를 바꾸면 네 화면이 같이 바뀌므로 여전히 합의합니다. 교차 테스트가 잡아야 하는 것은 SSOT 변경이 아니라 **한 화면의 이탈**이고, 그건 잡습니다.

## `pixel-avatar.css` 를 건드린 이유

`active -> running` 정규화가 회귀를 만들 뻔했습니다. `pixel-avatar.css:40` 은 `[data-status="active"]` 만 스타일하고 `running` 규칙이 없어서, 정규화하는 순간 아바타 bounce 애니메이션이 조용히 사라집니다. `running` 셀렉터를 추가했습니다.

같이 확인하다 발견한 선행 문제도 고쳤습니다: 회색 처리 규칙이 `offline`/`inactive` 만 나열해서, `stopped`/`dead`/`crashed`/`unbooted` keeper 는 로스터 칩이 회색인데 아바타는 총천연색이었습니다.

## 검증

```
npx tsc --noEmit          EXIT=0
npx vitest run            642/643 파일 · 8824/8825 테스트 통과
```

**실패 1 건은 제 변경과 무관합니다.** 근거: 같은 명령을 제 변경을 stash 한 베이스라인에서도 돌렸더니 **다른 파일**이 1 건 실패했습니다 (제 브랜치 `auth-status.test.ts` focus trap / 베이스라인 `keeper-detail.test.ts`). 실패 파일이 실행마다 바뀌는 스위트 간 오염이고, 두 파일 모두 단독 실행하면 통과합니다. 양쪽 다 정확히 1 건입니다.

**lint 는 검증 근거가 되지 못합니다.** `pnpm lint` 는 `src` 전체가 아니라 `eslint.config.mjs` 의 명시적 allowlist(`TARGET_FILES`)만 검사하고, **제가 바꾼 10 개 파일은 하나도 그 목록에 없습니다**. 그래서 green 이 아무것도 보장하지 않습니다. 대신 `no-nested-ternary` 를 게이트가 못 보더라도 직접 지켜 4 번 수정의 중첩 삼항을 함수로 뺐습니다. (참고로 `pnpm lint` 자체는 `src/keeper-actions.ts:1046` 선행 실패 1 건이 있으며 main 에서도 동일합니다.)

## 기존 테스트 3 건을 고친 이유

숨긴 게 아니라 셋 다 제가 없앤 불일치를 고정하고 있었습니다.

- `unified-status.test.ts` — `running` 라벨을 `진행 중`(task 어휘)으로 고정. `실행 중` 으로 변경.
- `keeper-runtime-display.test.ts` — `'passes through non-offline statuses'` 가 `active` 원문 통과를 고정. 별칭 접기로 변경하고, union 밖 값이 새지 않는지 보는 케이스를 추가.
- `keeper-phase-indicator.test.ts` 4 건 — `getPhaseStyle(null/''/unknown)` 이 `오프라인` 을 내는 걸 고정.

마지막 것은 제 변경이 만든 **진짜 문제를 하나 드러냈습니다**. `PHASE_STYLES.Offline` 이 실제 Offline phase 이자 unknown fallback 을 겸하고 있었습니다. 라벨을 `미기동` 으로 바꾸니 "phase 를 모름" 이 "부팅된 적 없음" 이라는 **없는 주장**이 됐습니다. fallback 을 별도 `UNKNOWN_PHASE_STYLE`(`확인 필요`)로 분리했습니다.

## 이번에 안 고친 것

같은 감사에서 나왔지만 성격이 달라 남겨둡니다. 필요하면 이슈로 올리겠습니다.

- `keeper-fleet-operator-fact.ts` 의 `ACTION_PRESENTATION` 22 개가 **영문** 라벨(`Keeper paused`, `Keeper dead`)이고 `dashboard-shell.ts` 칩에 그대로 나옵니다. 같은 화면에 `일시정지 keeper N` 과 `Keeper paused` 가 공존합니다. 22 개 번역은 문구 결정이 필요합니다.
- `fleet-fsm-matrix.ts` 의 `CHIP_CLASS_BY_STATE` 키가 KSM 만 PascalCase 인데 wire 는 소문자라, 소문자 토큰은 라벨은 한국어인데 칩 색은 기본 회색으로 떨어집니다.
- `compositePhaseTone` 과 `PHASE_TONE` 이 5 개 phase 에서 심각도가 어긋납니다 (`Stopped` 는 FSM 다이어그램에서 `err`, 칩에서 `idle`). 다이어그램 노드 색이라 렌더 도메인이 달라 이번 어휘 통일 범위 밖입니다.
- `stop_cause.code`, `trust.disposition`, `pipeline_stage` 등 백엔드 원시 토큰이 한국어 테이블을 거치지 않고 그대로 나오는 지점이 몇 군데 있습니다.

## 건드리지 않은 것

`FL_TONE_LABEL` 자체와 톤->색 매핑, `PHASE_TONE` 의 톤 배정, `statusBadgeTone` 의 task 계열 동작, 백엔드 페이로드, 카운트/집계 로직은 그대로입니다. 새 어휘를 창작하지 않았습니다 — 추가한 단어(`대기` `수신 대기` `오프라인`)는 전부 기존 `statusLabel` SSOT 에서 가져왔습니다.

RFC-WAIVED: credential / identity / operator control plane / keeper sandbox / dashboard credential 컴포넌트 / `.claude/hooks/` / workflow 문서 중 어느 것도 건드리지 않습니다. 변경은 대시보드 표시 계층에 한정됩니다.
