### PR TITLE
fix(test): main red — current_meta_json_fixture 헬퍼 누락 (#25835)

### DIFF
--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -105,6 +105,18 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
            | None -> meta.telemetry_feedback_window_hours)
       }
 
+(** Current-schema [keeper_meta] JSON exactly as the production writer emits it.
+
+    Schema-conformance tests use this instead of a hand-written object so the
+    fixture cannot drift from the writer: the only caller-supplied value is the
+    name, and every other key comes from [meta_to_json]. A fixture that stopped
+    matching the schema would therefore be a writer change, not a stale literal. *)
+let current_meta_json_fixture ~name () =
+  match meta_of_json_fixture (`Assoc [ ("name", `String name) ]) with
+  | Ok meta -> Masc.Keeper_meta_json.meta_to_json meta
+  | Error detail ->
+    failwith ("current_meta_json_fixture could not build current meta: " ^ detail)
+
 (** Persist a current-schema fixture. An absent row is created only through a
     fresh, admission-scoped lifecycle nonce witness; an existing row uses the
     ordinary identity-preserving write path. *)


### PR DESCRIPTION
## 증상

main 이 `#25835` 머지 이후 red 다. CI run `30237593030` (`e900024f5e`) 와 로컬 `dune build .` 가 같은 오류를 낸다:

```
File "test/test_keeper_meta_current_schema.ml", line 7, characters 2-42:
Error: Unbound value Masc_test_deps.current_meta_json_fixture

File "test/test_keeper_meta_current_keyset.ml", line 34, characters 10-50:
Error: Unbound value Masc_test_deps.current_meta_json_fixture
```

`#25835` 가 두 conformance 테스트를 추가하면서 두 테스트가 호출하는 헬퍼를 `test/deps/masc_test_deps.ml`
에 넣지 않았다.

## 수정

`current_meta_json_fixture ~name ()` 를 추가한다. 리터럴 객체를 손으로 쓰지 않고 **production writer 를
경유**한다:

```ocaml
let current_meta_json_fixture ~name () =
  match meta_of_json_fixture (`Assoc [ ("name", `String name) ]) with
  | Ok meta -> Masc.Keeper_meta_json.meta_to_json meta
  | Error detail -> failwith (...)
```

caller 가 주는 값은 이름 하나뿐이고 나머지 키는 전부 `meta_to_json` 이 만든다. 그래서 fixture 가
스키마와 어긋나는 상황은 "오래된 리터럴" 이 아니라 "writer 가 바뀜" 이 된다 — 두 테스트가 고정하려는
것이 정확히 그 지점이다.

## 검증

- 두 소비자 시그니처 일치 확인: `~name:"current-meta" ()` / `~name:"meta-wire-key" ()` → `Yojson.Safe.t`
- `Masc.Keeper_meta_json.meta_to_json : Keeper_meta_contract.keeper_meta -> Yojson.Safe.t` 존재 확인
  (`keeper_meta_json.mli:11`)

**로컬 빌드 미실행 (사유 명시)**: 이 머신의 opam switch 에 `agent_sdk 0.226.0` 이 설치돼 있어 repo 핀
(`v0.223.1` / `3d4ee19a`) 과 불일치한다. `scripts/dune-local.sh` 가 pin drift 로 abort 하며, 되돌리면
현재 진행 중인 v0.227 소비자 작업(#25837)이 깨진다. **CI 가 repo 핀으로 설치하므로 CI 를 검증 권위로
삼는다** — `#25812` 이후 `ci.yml` 의 OCaml 컴파일 지점도 `Build and Test` 단 1곳이다.

## 범위 밖

`keeper_up resume` 스위트 실패는 별개다. `7495daa853`(#25819 머지) 시점부터 main 에서 재현되며 이
변경과 무관하다. 컴파일이 복구되면 그 다음 red 로 드러날 것이다.

RFC-WAIVED: 테스트 헬퍼 1개 추가로, credential/identity/operator-control/sandbox/hooks 어디에도 속하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
