### PR TITLE
fix(test): failure-judge/nonce 제거 낙진 unbound symbol 6건 복구 (main red)

### DIFF
--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -316,7 +316,6 @@ let test_worker_exact_callback_integration_and_owner_settlement () =
    | W.Idle
    | W.Contended _
    | W.Rescan_later _
-   | W.Owner_unregistered_deferred _
    | W.Candidate_already_consumed _
    | W.Partition_blocked _ ->
      Alcotest.fail "worker exact callback chain did not complete");
@@ -371,10 +370,7 @@ let test_setup_error_stops_before_claim_without_hot_retry () =
        "typed setup failure stops the lifecycle"
        "Board attention exact setup unavailable before claim: network context unavailable"
        detail
-   | Ok
-       ( W.Drained
-       | W.Owner_generation_deferred _
-       | W.Retry_later _ ) ->
+   | Ok (W.Drained | W.Retry_later _) ->
      Alcotest.fail "setup-unavailable drain returned normally");
   Alcotest.(check int) "one setup attempt" 1 !calls;
   Alcotest.(check int) "setup failure did not yield into a retry" 0 !yields;
@@ -451,7 +447,6 @@ let test_claim_generation_change_discards_without_sibling_selection () =
    | W.Contended _ ->
      Alcotest.fail "changed generation reported quiescent or same-generation contention"
    | W.Judgment_completed _
-   | W.Owner_unregistered_deferred _
    | W.Candidate_already_consumed _
    | W.Partition_blocked _ ->
      Alcotest.fail "claim retry exhaustion produced a terminal step");
@@ -555,7 +550,6 @@ let test_exact_claim_retry_exhaustion_has_no_self_wake () =
    | W.Idle
    | W.Rescan_later _
    | W.Judgment_completed _
-   | W.Owner_unregistered_deferred _
    | W.Candidate_already_consumed _
    | W.Partition_blocked _ ->
      Alcotest.fail "exact claim exhaustion reported quiescent or terminal");
@@ -718,7 +712,6 @@ let test_rescan_later_reaches_delayed_run_rearm () =
        true
        (P.Generation.equal contention.generation observed.generation)
    | W.Drained
-   | W.Owner_generation_deferred _
    | W.Retry_later { reason = W.Exact_claim_contended; _ } ->
      Alcotest.fail "changed selection did not reach typed delayed rescan");
   Alcotest.(check int) "no same-turn rescan" 1 !process_calls;
@@ -1568,7 +1561,6 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
    | W.Contended _
    | W.Rescan_later _
    | W.Judgment_completed _
-   | W.Owner_unregistered_deferred _
    | W.Candidate_already_consumed _
    | W.Partition_blocked _ ->
      Alcotest.fail "blocked partition was exposed before authorization");
@@ -1683,7 +1675,6 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
    | W.Idle
    | W.Contended _
    | W.Rescan_later _
-   | W.Owner_unregistered_deferred _
    | W.Candidate_already_consumed _
    | W.Partition_blocked _ ->
      Alcotest.fail "authorized manual requeue did not complete its exact judgment");

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1089,7 +1089,7 @@ let test_failed_cycle_route_mapping () =
      ()
    | _ -> Alcotest.fail "context-compacted source stimulus was acknowledged");
   let quarantined_failure =
-    { judgment_failure with
+    { terminal_failure with
       source_lease_disposition =
         Masc.Keeper_unified_turn.Pause_after_transcript_corruption
           { detail = "fixture transcript corruption" }

--- a/test/test_keeper_exact_execution_lease_guard.ml
+++ b/test/test_keeper_exact_execution_lease_guard.ml
@@ -371,6 +371,126 @@ let test_restart_recovery_never_requeues_bound_lease () =
    | Error detail -> Alcotest.failf "matching receipt replay failed: %s" detail)
 ;;
 
+let run_exact_wal_followup_replay_case ~label ~failure ~expected_stage =
+  with_temp_dir ("masc-exact-wal-" ^ label) @@ fun base_path ->
+  let keeper_name = "exact_wal_" ^ label in
+  let slot_id = "slot-wal-" ^ label in
+  let call_id = "call-wal-" ^ label in
+  let plan_fingerprint = "plan-wal-" ^ label in
+  let request_body_sha256 = String.make 64 '2' in
+  let lease, terminal =
+    bind_and_quarantine
+      ~base_path
+      ~keeper_name
+      ~cause:P.Exact_execution_failed
+      ~slot_id
+      ~call_id
+      ~plan_fingerprint
+      ~request_body_sha256
+  in
+  let disposition =
+    prepare_terminal_disposition
+      ~base_path
+      ~keeper_name
+      ~lease
+      ~terminal
+      ~prepared_at:3.0
+  in
+  let precommit =
+    decode_raw_snapshot (label ^ " precommit") ~base_path ~keeper_name
+  in
+  (match
+     P.For_testing.finalize_exact_source_disposition_with_followup_failure_result
+       ~failure
+       ~base_path
+       ~keeper_name
+       ~settled_at:4.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Committed_followup_failed { stage; _ }) ->
+     Alcotest.(check bool)
+       (label ^ " reports the injected committed stage")
+       true
+       (stage = expected_stage)
+   | Ok _ -> Alcotest.failf "%s did not report a committed follow-up failure" label
+   | Error detail -> Alcotest.failf "%s lost the durable WAL commit: %s" label detail);
+  let wal_path = settlement_wal_path ~base_path ~keeper_name in
+  check_single_v2_wal_row label (read_file_or_fail label wal_path);
+  let before_replay =
+    decode_raw_snapshot (label ^ " before replay") ~base_path ~keeper_name
+  in
+  (match failure with
+   | P.For_testing.Fail_checkpoint _ ->
+     Alcotest.(check string)
+       (label ^ " checkpoint failure preserves precommit revision")
+       (Int64.to_string (State.revision precommit))
+       (Int64.to_string (State.revision before_replay));
+     check_same_state
+       (label ^ " checkpoint failure preserves the prepared snapshot")
+       precommit
+       before_replay;
+     (match State.exact_execution_binding before_replay with
+      | Some { status = P.Disposition_prepared prepared; _ }
+        when String.equal prepared.disposition_id disposition.disposition_id ->
+        ()
+      | Some _ ->
+        Alcotest.failf "%s checkpoint failure lost the prepared disposition" label
+      | None ->
+        Alcotest.failf "%s checkpoint failure removed the exact binding" label)
+   | P.For_testing.Fail_wal_compaction _ ->
+     Alcotest.(check string)
+       (label ^ " compaction failure retains the committed revision")
+       (Int64.to_string (Int64.succ (State.revision precommit)))
+       (Int64.to_string (State.revision before_replay));
+     check_no_active_lease (label ^ " committed snapshot") before_replay;
+     check_no_exact_binding (label ^ " committed snapshot") before_replay;
+     check_no_pending (label ^ " committed snapshot") before_replay;
+     ignore
+       (require_single_exact_outbox
+          ~disposition_id:disposition.disposition_id
+          (label ^ " committed snapshot")
+          before_replay));
+  let recovered = require_loaded_state (label ^ " first restart") ~base_path ~keeper_name in
+  check_no_active_lease (label ^ " first restart") recovered;
+  check_no_exact_binding (label ^ " first restart") recovered;
+  check_no_pending (label ^ " first restart") recovered;
+  let receipt =
+    require_single_exact_outbox
+      ~disposition_id:disposition.disposition_id
+      (label ^ " first restart")
+      recovered
+  in
+  Alcotest.(check string)
+    (label ^ " WAL compacted after replay")
+    ""
+    (read_file_or_fail label wal_path);
+  let loaded_again =
+    require_loaded_state (label ^ " second restart") ~base_path ~keeper_name
+  in
+  check_same_state (label ^ " second load is idempotent") recovered loaded_again;
+  (match
+     P.finalize_exact_source_disposition_result
+       ~base_path
+       ~keeper_name
+       ~settled_at:5.0
+       ~lease
+       ~disposition_id:disposition.disposition_id
+       ()
+   with
+   | Ok (P.Already_settled replayed) ->
+     Alcotest.(check bool)
+       (label ^ " old finalize returns the canonical receipt")
+       true
+       (State.transition_receipt_equal receipt replayed)
+   | Ok _ -> Alcotest.failf "%s old finalize was not idempotent" label
+   | Error detail -> Alcotest.failf "%s old finalize retry failed: %s" label detail);
+  let after_retry =
+    require_loaded_state (label ^ " post-retry load") ~base_path ~keeper_name
+  in
+  check_same_state (label ^ " old retry leaves state unchanged") loaded_again after_retry
+;;
 
 let test_exact_wal_followup_failures_replay_once () =
   run_exact_wal_followup_replay_case

--- a/test/test_keeper_memory_os_generation_base_path.ml
+++ b/test/test_keeper_memory_os_generation_base_path.ml
@@ -45,15 +45,18 @@ let test_explicit_base_paths_isolate_generation_counters () =
          check int
            "workspace A first reservation"
            0
-           (Io.next_generation_for_base_path ~base_path:workspace_a ~keeper_id ~trace_id);
+           (Io.next_generation_with_floor_for_base_path
+              ~base_path:workspace_a ~floor:0 ~keeper_id ~trace_id);
          check int
            "workspace A advances independently"
            1
-           (Io.next_generation_for_base_path ~base_path:workspace_a ~keeper_id ~trace_id);
+           (Io.next_generation_with_floor_for_base_path
+              ~base_path:workspace_a ~floor:0 ~keeper_id ~trace_id);
          check int
            "workspace B starts from its own counter"
            0
-           (Io.next_generation_for_base_path ~base_path:workspace_b ~keeper_id ~trace_id));
+           (Io.next_generation_with_floor_for_base_path
+              ~base_path:workspace_b ~floor:0 ~keeper_id ~trace_id));
        let episode_dir keepers_dir =
          Filename.concat keepers_dir (Filename.concat keeper_id "episodes")
        in

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -408,60 +408,6 @@ let test_dead_tombstone_pause_violation_classifies () =
   check bool "unpaused+no-latch is valid" true
     (Option.is_none (Keeper_meta_contract.terminal_latch_pause_violation unpaused_none))
 
-(* PR #24351 review (P1): [Keeper_turn_up_update.revival_decision] is the
-   extracted decision that used to be inlined in [update_keeper]. Before
-   this PR, [dead_revival_requested] required [old.paused = true]; this PR
-   decoupled it to trigger on the [Dead_tombstone] latch alone -- the
-   single riskiest behavior change in the PR, and until now the only tests
-   touching this area were store/contract-level (rejecting the split on
-   write, [mark_resumed] clearing it). Neither exercised the decision
-   itself. These pin the full [latched_reason] x [paused] matrix directly
-   against the pure function, no store/disk involved. *)
-let grpc_directive_pause =
-  Keeper_latched_reason.Operator_paused
-    { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive }
-
-(* The scenario the PR title promises: a keeper stranded at
-   paused=false + Dead_tombstone (the split
-   [test_store_rejects_unpaused_dead_tombstone] shows the store now refuses
-   to persist, but which legacy writers predating this PR could already
-   have left on disk) must still be revivable via masc_keeper_up, not
-   permanently stuck. *)
-let test_revival_decision_stranded_dead_tombstone_is_revivable () =
-  let decision =
-    Keeper_turn_up_update.revival_decision
-      ~latched_reason:(Some Keeper_latched_reason.Dead_tombstone) ~paused:false
-  in
-  check bool "stranded dead_tombstone requests dead-revival" true
-    decision.dead_revival_requested;
-  check bool "stranded dead_tombstone clears pause state" true
-    decision.clear_pause_state
-
-let test_revival_decision_matrix () =
-  let case ~label ~latched_reason ~paused ~expect_dead_revival ~expect_clear =
-    let decision = Keeper_turn_up_update.revival_decision ~latched_reason ~paused in
-    check bool (label ^ ": dead_revival_requested") expect_dead_revival
-      decision.dead_revival_requested;
-    check bool (label ^ ": clear_pause_state") expect_clear
-      decision.clear_pause_state
-  in
-  case ~label:"no latch, not paused" ~latched_reason:None ~paused:false
-    ~expect_dead_revival:false ~expect_clear:false;
-  case ~label:"no latch, paused (keeper_up retains pause)" ~latched_reason:None ~paused:true
-    ~expect_dead_revival:false ~expect_clear:false;
-  case ~label:"operator_paused latch, not paused (inconsistent state, not dead-revival)"
-    ~latched_reason:(Some grpc_directive_pause) ~paused:false
-    ~expect_dead_revival:false ~expect_clear:false;
-  case ~label:"operator_paused latch, paused (keeper_up retains pause)"
-    ~latched_reason:(Some grpc_directive_pause) ~paused:true
-    ~expect_dead_revival:false ~expect_clear:false;
-  case ~label:"dead_tombstone latch, not paused (stranded -- must still revive)"
-    ~latched_reason:(Some Keeper_latched_reason.Dead_tombstone) ~paused:false
-    ~expect_dead_revival:true ~expect_clear:true;
-  case ~label:"dead_tombstone latch, paused (canonical dead-revival)"
-    ~latched_reason:(Some Keeper_latched_reason.Dead_tombstone) ~paused:true
-    ~expect_dead_revival:true ~expect_clear:true
-
 let () =
   run "Keeper_types CAS retry (#9764/#9733/#9769)"
     [
@@ -473,13 +419,6 @@ let () =
             test_mark_resumed_clears_dead_tombstone_and_persists;
           test_case "dead_tombstone_pause_violation classifies states" `Quick
             test_dead_tombstone_pause_violation_classifies;
-        ] );
-      ( "update_keeper revival_decision (#24351)",
-        [
-          test_case "stranded paused=false + Dead_tombstone is still revivable" `Quick
-            test_revival_decision_stranded_dead_tombstone_is_revivable;
-          test_case "latched_reason x paused decision matrix" `Quick
-            test_revival_decision_matrix;
         ] );
       ( "write_meta_with_merge caller_wins",
         [

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -359,7 +359,7 @@ let test_wakeup_running_exact_respects_lifecycle_owner_and_replacement () =
         ~base_path
         ~keeper_name:captured.name
         ~expected_generation:captured.meta.runtime.nonce
-        ~purpose:Reservation.Dead_revival
+        ~purpose:Reservation.Paused_work_disposition
     with
     | Ok token -> token
     | Error _ -> fail "exact wake test could not acquire lifecycle ownership"


### PR DESCRIPTION
## 목표

main red 해소. `dune build .` 가 test/ 에서 unbound symbol 6건으로 실패합니다.

```
test_keeper_event_queue_state_v2.ml:1092        judgment_failure
test_keeper_memory_os_generation_base_path.ml:48 Io.next_generation_for_base_path
test_keeper_registry_hardening.ml:362           Reservation.Dead_revival
test_keeper_board_attention_worker.ml:319       W.Owner_unregistered_deferred
test_keeper_meta_cas_retry.ml:432               Keeper_turn_up_update.revival_decision
test_keeper_exact_execution_lease_guard.ml:376  run_exact_wal_followup_replay_case
```

## 원인

오늘 머지된 제거 작업 3건의 낙진입니다. 셋 다 의도된 제거이고, 이 PR 은 어느 것도 되돌리지 않습니다.

| 커밋 | 제거 내용 |
|---|---|
| `df70d71f6f` | failure-judgment 개념 전체 (`Escalate_judgment` → `Exhausted_visible_alive` rename 포함) |
| `15e7f2711a` | keeper lifecycle nonce revert (PR #25752) |
| #25842 | durable lifecycle authority |

## 판정 기준

에러마다 원인을 `git log -S` 로 확인한 뒤 하나를 골랐습니다.

- **기능이 숙청됨** → 테스트 삭제 (무력화 아님)
- **이름/API 변경** → 마이그레이션, assertion 강도 동일 유지
- **테스트 로컬 헬퍼 고아** → 복원 또는 호출부 제거

## 변경

```
 test/test_keeper_board_attention_worker.ml         |  11 +-
 test/test_keeper_event_queue_state_v2.ml           |   2 +-
 test/test_keeper_exact_execution_lease_guard.ml    | 120 +++++++++++++++++++++
 test/test_keeper_memory_os_generation_base_path.ml |   9 +-
 test/test_keeper_meta_cas_retry.ml                 |  61 -----------
 test/test_keeper_registry_hardening.ml             |   2 +-
 6 files changed, 129 insertions(+), 76 deletions(-)
```

`+120` 은 `test_keeper_exact_execution_lease_guard.ml` 에서 이전 편집이 지우고 호출부만 남긴 헬퍼 복원입니다.

## 하지 않은 것

- 스텁 / `assert true` / placeholder / TODO 추가 — diff 스캔으로 0건 확인
- assertion 약화, 기대값 변경
- catch-all `_ ->` arm 추가 (diff 의 `_ ->` 는 전부 실패 검출 arm)
- failure-judgment / lifecycle nonce / durable lifecycle authority 부활
- `lib/` 수정 — 이 PR 은 test/ 만 건드립니다

## 검증 상태

**로컬 빌드 미실행.** CI 가 게이트입니다.

이 6건 뒤에 추가 에러가 있을 수 있습니다 — 빌드가 여기서 멈춰 그 너머를 본 적이 없습니다. CI 결과 보고 후속 대응하겠습니다.

## 리뷰 포인트

`test_keeper_meta_cas_retry.ml` 의 `-61` 이 유일하게 커버리지가 줄어든 곳입니다. meta CAS retry 는 실제 불변식이므로, 삭제된 케이스의 주제가 정말 사라진 것인지(= nonce revert 로 revival_decision 경로 자체가 없어졌는지) 확인 부탁드립니다.

RFC-WAIVED: test-only 컴파일 복구. `lib/` 무변경, 신규 동작 없음, 아키텍처 결정 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f3e76ZnzDRwjkNe7EZxiE
