### PR TITLE
fix(test): failure-judge 제거가 흘린 lease_for fixture 복원 (main red)

### DIFF
--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -61,6 +61,12 @@ let claim_head state =
   |> require_ok "claim head"
 ;;
 
+let lease_for stimulus =
+  let state = State.with_pending (queue [ stimulus ]) State.empty in
+  let _state, lease = claim_head state in
+  require_some "fixture lease" lease
+;;
+
 let checkpoint_source ~turn_count =
   let trace_id =
     Keeper_id.Trace_id.of_string "trace-no-compaction-source"


### PR DESCRIPTION
## 목표

main red 해소 (#25846 의 잔여 1건).

```
test/test_keeper_event_queue_state_v2.ml:1132   Unbound value lease_for
```

## 원인

`df70d71f6f` (failure judge 제거) 가 judgment 케이스들을 지우면서 그 옆에 있던 `lease_for` fixture 까지 같이 삭제했는데, **호출부 5곳이 살아남았습니다**.

| 라인 | 케이스 |
|---|---|
| 1132 | manual compaction / overflow escalation |
| 1186 | 〃 |
| 1367 | compaction retry |
| 1768 | phase-gated |
| 1892 | 〃 |

전부 failure judgment 과 무관한 케이스입니다.

## 변경

`df70d71f6f~1` 기준 **바이트 동일** 복원. 호출하는 `claim_head` 바로 뒤에 배치.

```ocaml
let lease_for stimulus =
  let state = State.with_pending (queue [ stimulus ]) State.empty in
  let _state, lease = claim_head state in
  require_some "fixture lease" lease
;;
```

의존 심볼 3개 전부 main 에 생존 확인: `require_some` (:19), `queue` (:53), `claim_head` (:59).

## 하지 않은 것

- 호출부 수정 0건, assertion 변경 0건
- failure-judgment 제거를 되돌리지 않음
- 스텁 / catch-all 없음

`+6 lines`, 파일 1개.

## 검증 상태

**로컬 빌드 미실행.** CI 가 게이트입니다. 이 뒤에 또 다른 에러가 있을 수 있습니다 — 빌드가 여기서 멈춰 그 너머를 못 봤습니다.

RFC-WAIVED: test fixture 복원. `lib/` 무변경, 신규 동작 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f3e76ZnzDRwjkNe7EZxiE
