### PR TITLE
fix(keeper): synchronize activation config authority

### DIFF
--- a/lib/keeper_toml/keeper_toml_loader.ml
+++ b/lib/keeper_toml/keeper_toml_loader.ml
@@ -60,10 +60,10 @@ let toml_string_list (doc : toml_doc) (key : string) : string list =
 (** Update or insert a key under a [table] in a TOML file.
     Preserves comments, formatting, and other fields.
     Returns [Ok new_content] or [Error reason]. *)
-let update_field_in_content
+let update_rendered_field_in_content
       ~(table : string)
       ~(key : string)
-      ~(value : string)
+      ~(rendered_value : string)
       (content : string)
   : (string, string) result
   =
@@ -82,7 +82,7 @@ let update_field_in_content
        if !insert_before_next_table && String.length trimmed > 0 && trimmed.[0] = '['
        then (
          (* New table started — insert the field before it *)
-         result_lines := Printf.sprintf "%s = \"%s\"" key value :: !result_lines;
+         result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
          found := true;
          insert_before_next_table := false);
        if String.trim trimmed = table_header
@@ -95,7 +95,7 @@ let update_field_in_content
          in_target_table := false;
          if !insert_before_next_table && not !found
          then (
-           result_lines := Printf.sprintf "%s = \"%s\"" key value :: !result_lines;
+           result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
            found := true;
            insert_before_next_table := false);
          result_lines := line :: !result_lines)
@@ -105,7 +105,7 @@ let update_field_in_content
          && ((String.starts_with trimmed ~prefix:key_prefix)
              || (String.starts_with trimmed ~prefix:key_prefix_eq))
        then (
-         result_lines := Printf.sprintf "%s = \"%s\"" key value :: !result_lines;
+         result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
          found := true;
          insert_before_next_table := false)
        else result_lines := line :: !result_lines)
@@ -113,11 +113,19 @@ let update_field_in_content
   (* If we were in the target table at EOF and didn't find the key, append *)
   if (not !found) && !insert_before_next_table
   then (
-    result_lines := Printf.sprintf "%s = \"%s\"" key value :: !result_lines;
+    result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
     found := true);
   if not !found
   then Error (Printf.sprintf "table [%s] not found in TOML" table)
   else Ok (String.concat "\n" (List.rev !result_lines))
+;;
+
+let update_field_in_content ~table ~key ~value content =
+  update_rendered_field_in_content
+    ~table
+    ~key
+    ~rendered_value:(Printf.sprintf "\"%s\"" value)
+    content
 ;;
 
 (** Atomic file write: write to temp file then rename.
@@ -149,6 +157,29 @@ let update_keeper_toml_field ~(path : string) ~(key : string) ~(value : string)
   | Ok content ->
     (match update_field_in_content ~table:"keeper" ~key ~value content with
      | Error e -> Error e
+     | Ok updated -> atomic_write_file ~path updated)
+;;
+
+let update_keeper_toml_bool_fields ~(path : string) fields
+  : (unit, string) result
+  =
+  match Safe_ops.read_file_safe path with
+  | Error e -> Error (Printf.sprintf "cannot read %s: %s" path e)
+  | Ok content ->
+    let updated =
+      List.fold_left
+        (fun result (key, value) ->
+          Result.bind result (fun current ->
+            update_rendered_field_in_content
+              ~table:"keeper"
+              ~key
+              ~rendered_value:(string_of_bool value)
+              current))
+        (Ok content)
+        fields
+    in
+    (match updated with
+     | Error _ as error -> error
      | Ok updated -> atomic_write_file ~path updated)
 ;;
 

--- a/lib/keeper_toml/keeper_toml_loader.mli
+++ b/lib/keeper_toml/keeper_toml_loader.mli
@@ -44,3 +44,7 @@ val update_field_in_content :
     Returns [Ok ()] on success or [Error reason] on failure. *)
 val update_keeper_toml_field :
   path:string -> key:string -> value:string -> (unit, string) result
+
+(** Atomically update boolean fields under [\[keeper\]]. *)
+val update_keeper_toml_bool_fields :
+  path:string -> (string * bool) list -> (unit, string) result

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -688,6 +688,93 @@ let context_shrink_of_patch ~(meta : Keeper_meta_contract.keeper_meta) fields =
      | Some _ -> None)
   | _ -> None
 
+type activation_write_error = { code : string; detail : string }
+
+let activation_bool_fields fields =
+  [ "autoboot_enabled"; "proactive_enabled" ]
+  |> List.filter_map (fun key ->
+       match List.assoc_opt key fields with
+       | Some (`Bool value) -> Some (key, value)
+       | Some _ | None -> None)
+
+let persist_activation_fields ~(config : Workspace.config) ~name fields =
+  match activation_bool_fields fields with
+  | [] -> Ok ()
+  | bool_fields ->
+    (match
+       Keeper_types_profile.keeper_toml_path_opt_for_base_path
+         ~base_path:config.base_path
+         name
+     with
+     | None ->
+       Error
+         { code = "keeper_toml_missing"
+         ; detail = Printf.sprintf "keeper %S has no declarative TOML" name
+         }
+     | Some path ->
+       (match Keeper_toml_loader.update_keeper_toml_bool_fields ~path bool_fields with
+        | Ok () -> Ok ()
+        | Error detail ->
+          Error
+            { code = "keeper_toml_write_failed"
+            ; detail = Printf.sprintf "%s: %s" path detail
+            }))
+
+let prevalidate_config_update
+      (config : Workspace.config)
+      (old : Keeper_meta_contract.keeper_meta)
+      (parsed : Keeper_turn_up_args.parsed_args)
+  =
+  match old.latched_reason with
+  | Some Keeper_latched_reason.Dead_tombstone ->
+    Error "keeper identity is terminal; create a fresh Keeper"
+  | Some
+      ( Keeper_latched_reason.Operator_paused _
+      | Keeper_latched_reason.Transcript_corruption_reset_required )
+  | None ->
+    (match
+       Keeper_turn_up_update.resolve_active_goal_ids
+         config
+         parsed
+         old.active_goal_ids
+     with
+     | Error _ as error -> error
+     | Ok _ ->
+       Keeper_turn_up_args.validate_sandbox_settings
+         ~allowed_paths:
+           (Option.value ~default:old.allowed_paths parsed.allowed_paths_opt))
+
+let invalidate_config_surfaces ~(config : Workspace.config) ~name runtime_event =
+  Dashboard_cache.invalidate (keeper_config_cache_key config name);
+  Dashboard_cache.invalidate (keeper_composite_cache_key config name);
+  Dashboard_cache.invalidate_prefix
+    (Printf.sprintf "dashboard:fleet-composite:%s" config.base_path);
+  match runtime_event with
+  | Some event -> refresh_keeper_execution_surfaces ~config ~name event
+  | None -> invalidate_keeper_execution_surfaces ~config ()
+
+let respond_config_sync_error
+      ~request
+      reqd
+      ~status
+      ~name
+      ~config_applied
+      ~code
+      ~detail
+      ()
+  =
+  Http.Response.json_value
+    ~status
+    ~request
+    (`Assoc
+      [ "ok", `Bool false
+      ; "keeper", `String name
+      ; "config_applied", `Bool config_applied
+      ; "runtime_sync", `Bool false
+      ; "error", `Assoc [ "code", `String code; "detail", `String detail ]
+      ])
+    reqd
+
 let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_config in
@@ -773,6 +860,25 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                            respond_error reqd
                              (Keeper_types_profile.tool_result_body result)
                        | Ok parsed ->
+                           (match prevalidate_config_update config meta0 parsed with
+                            | Error detail -> respond_error reqd detail
+                            | Ok () ->
+                           (match persist_activation_fields ~config ~name fields with
+                            | Error { code; detail } ->
+                              Log.Keeper.error
+                                "dashboard keeper activation config rejected keeper=%s: %s"
+                                name
+                                detail;
+                              respond_config_sync_error
+                                ~request:req
+                                reqd
+                                ~status:`Conflict
+                                ~name
+                                ~config_applied:false
+                                ~code
+                                ~detail
+                                ()
+                            | Ok () ->
                            (* Dashboard edits are user-initiated and win for the
                               fields they touch; update_keeper now persists via
                               a CAS merge ([heartbeat_fields_from_disk]) so a
@@ -787,18 +893,30 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                            in
                            if not
                                 (Keeper_types_profile.tool_result_success result)
-                           then
-                             respond_error reqd
-                               (Keeper_types_profile.tool_result_body result)
+                           then (
+                             let detail = Keeper_types_profile.tool_result_body result in
+                             Log.Keeper.error
+                               "dashboard keeper config runtime sync failed keeper=%s: %s"
+                               name
+                               detail;
+                             invalidate_config_surfaces ~config ~name None;
+                             respond_config_sync_error
+                               ~request:req
+                               reqd
+                               ~status:`Service_unavailable
+                               ~name
+                               ~config_applied:true
+                               ~code:"keeper_runtime_sync_failed"
+                               ~detail
+                               ())
                            else (
-                             Dashboard_cache.invalidate
-                               (keeper_config_cache_key config name);
+                             invalidate_config_surfaces ~config ~name (Some "restarted");
                              let (_st, json) =
                                Dashboard_http_keeper.keeper_config_json config
                                  name
                              in
                              Http.Response.json_value ~compress:true
-                               ~request:req json reqd))))
+                               ~request:req json reqd))))))
            | None ->
                respond_error reqd "request body must be a JSON object"
          with Yojson.Json_error e ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -740,9 +740,12 @@ let prevalidate_config_update
      with
      | Error _ as error -> error
      | Ok _ ->
-       Keeper_turn_up_args.validate_sandbox_settings
-         ~allowed_paths:
-           (Option.value ~default:old.allowed_paths parsed.allowed_paths_opt))
+       let allowed_paths =
+         match parsed.allowed_paths_opt with
+         | Some allowed_paths -> allowed_paths
+         | None -> old.allowed_paths
+       in
+       Keeper_turn_up_args.validate_sandbox_settings ~allowed_paths)
 
 let invalidate_config_surfaces ~(config : Workspace.config) ~name runtime_event =
   Dashboard_cache.invalidate (keeper_config_cache_key config name);

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -2084,6 +2084,182 @@ let test_context_shrink_detection () =
     (shrink (with_max_override base (Some 1000)) [ ("name", `String "shrink-fixture") ])
 ;;
 
+let config_sync_runtime_toml =
+  {|[runtime]
+default = "test_provider.test_model"
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let prepare_config_sync_keeper config name =
+  let runtime_path = Filename.concat config.Workspace.base_path "runtime.toml" in
+  write_file runtime_path config_sync_runtime_toml;
+  (match Runtime.init_default ~config_path:runtime_path with
+   | Ok () -> ()
+   | Error error -> fail ("runtime init: " ^ error));
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
+          ; "trace_id", `String (name ^ "-trace")
+          ])
+    with
+    | Error error -> fail ("meta fixture: " ^ error)
+    | Ok meta ->
+      { meta with
+        Masc.Keeper_meta_contract.autoboot_enabled = true
+      ; proactive = { enabled = false }
+      }
+  in
+  match Masc.Keeper_meta_store.write_meta config meta with
+  | Ok () -> ()
+  | Error error -> fail ("write meta: " ^ error)
+
+let write_config_sync_toml config name =
+  let dir =
+    Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.Workspace.base_path
+  in
+  mkdir_p dir;
+  let path = Filename.concat dir (name ^ ".toml") in
+  write_file path
+    "[keeper]\nsandbox_profile = \"local\"\nautoboot_enabled = false\nproactive_enabled = false\n";
+  path
+
+let post_config ~sw ~clock ~state ~name body =
+  let output = Buffer.create 512 in
+  let connection =
+    Httpun.Server_connection.create (fun reqd ->
+      Keeper_config_post.handle_keeper_config_post
+        ~sw ~clock state "dashboard-test" (Httpun.Reqd.request reqd) reqd body)
+  in
+  let request =
+    Printf.sprintf "POST /api/v1/keepers/%s/config HTTP/1.1\r\nHost: x\r\n\r\n" name
+  in
+  let input = Bigstringaf.of_string ~off:0 ~len:(String.length request) request in
+  ignore (Httpun.Server_connection.read_eof connection input ~off:0 ~len:(Bigstringaf.length input));
+  let rec drain () =
+    match Httpun.Server_connection.next_write_operation connection with
+    | `Write iovecs ->
+      let bytes =
+        List.fold_left
+          (fun total (iov : Bigstringaf.t Httpun.IOVec.t) ->
+            Buffer.add_string output
+              (Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len);
+            total + iov.len)
+          0 iovecs
+      in
+      Httpun.Server_connection.report_write_result connection (`Ok bytes);
+      drain ()
+    | `Yield | `Close _ -> ()
+  in
+  drain ();
+  let raw = Buffer.contents output in
+  let body =
+    match List.rev (String.split_on_char '\n' raw) with
+    | body :: _ -> String.trim body
+    | [] -> fail "HTTP response has no body"
+  in
+  raw, Yojson.Safe.from_string body
+
+let test_config_post_restarts_from_atomic_toml () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let name = "config-sync-success" in
+  prepare_config_sync_keeper config name;
+  let path = write_config_sync_toml config name in
+  ignore
+    (post_config ~sw ~clock:(Eio.Stdenv.clock env)
+       ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
+       ~name {|{"autoboot_enabled":true,"proactive_enabled":true}|});
+  let parsed = Keeper_toml_loader.parse_toml (In_channel.with_open_bin path In_channel.input_all) in
+  (match parsed with
+   | Error error -> fail error
+   | Ok doc ->
+     check (option bool) "autoboot committed" (Some true)
+       (Keeper_toml_loader.toml_bool_opt doc "keeper.autoboot_enabled");
+     check (option bool) "proactive committed" (Some true)
+       (Keeper_toml_loader.toml_bool_opt doc "keeper.proactive_enabled"));
+  check bool "running projection converged" true
+    (match Masc.Keeper_registry.get ~base_path:config.base_path name with
+     | Some entry -> entry.meta.proactive.enabled
+     | None -> false);
+  ignore (Masc.Keeper_keepalive.stop_keepalive_and_await ~base_path:config.base_path name)
+
+let test_config_post_requires_toml () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let name = "config-sync-no-toml" in
+  prepare_config_sync_keeper config name;
+  let raw, json =
+    post_config ~sw ~clock:(Eio.Stdenv.clock env)
+      ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
+      ~name {|{"proactive_enabled":true}|}
+  in
+  check bool "HTTP 409" true (String.starts_with ~prefix:"HTTP/1.1 409" raw);
+  let open Yojson.Safe.Util in
+  check bool "config not applied" false (json |> member "config_applied" |> to_bool);
+  check bool "runtime not synced" false (json |> member "runtime_sync" |> to_bool)
+
+let test_config_post_reports_runtime_sync_failure () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let name = "config-sync-partial" in
+  prepare_config_sync_keeper config name;
+  let toml_path = write_config_sync_toml config name in
+  Sys.remove (Filename.concat config.base_path "runtime.toml");
+  let raw, json =
+    post_config ~sw ~clock:(Eio.Stdenv.clock env)
+      ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
+      ~name {|{"proactive_enabled":true,"runtime_id":"missing.runtime"}|}
+  in
+  check bool "HTTP 503" true (String.starts_with ~prefix:"HTTP/1.1 503" raw);
+  let open Yojson.Safe.Util in
+  check bool "TOML committed" true (json |> member "config_applied" |> to_bool);
+  check bool "runtime not synced" false (json |> member "runtime_sync" |> to_bool);
+  check string "typed failure" "keeper_runtime_sync_failed"
+    (json |> member "error" |> member "code" |> to_string);
+  let doc =
+    match
+      Keeper_toml_loader.parse_toml
+        (In_channel.with_open_bin toml_path In_channel.input_all)
+    with
+    | Ok doc -> doc
+    | Error error -> fail error
+  in
+  check (option bool) "committed TOML is not rolled back" (Some true)
+    (Keeper_toml_loader.toml_bool_opt doc "keeper.proactive_enabled")
+
+let test_config_post_prevalidates_mixed_request () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let name = "config-sync-invalid-mixed" in
+  prepare_config_sync_keeper config name;
+  let toml_path = write_config_sync_toml config name in
+  let raw, _ =
+    post_config ~sw ~clock:(Eio.Stdenv.clock env)
+      ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
+      ~name {|{"proactive_enabled":true,"allowed_paths":["*"]}|}
+  in
+  check bool "HTTP 400" true (String.starts_with ~prefix:"HTTP/1.1 400" raw);
+  let doc =
+    match
+      Keeper_toml_loader.parse_toml
+        (In_channel.with_open_bin toml_path In_channel.input_all)
+    with
+    | Ok doc -> doc
+    | Error error -> fail error
+  in
+  check (option bool) "activation was not committed" (Some false)
+    (Keeper_toml_loader.toml_bool_opt doc "keeper.proactive_enabled")
+
 let () =
   run "dashboard_http_core"
     [
@@ -2205,5 +2381,13 @@ let () =
       ( "context-window shrink guard (#25062/#25268)",
         [ test_case "shrink of max_context_override is detected" `Quick
             test_context_shrink_detection;
+          test_case "config POST atomically restarts runtime" `Quick
+            test_config_post_restarts_from_atomic_toml;
+          test_case "activation config requires TOML" `Quick
+            test_config_post_requires_toml;
+          test_case "runtime sync failure preserves commit" `Quick
+            test_config_post_reports_runtime_sync_failure;
+          test_case "mixed invalid request commits nothing" `Quick
+            test_config_post_prevalidates_mixed_request;
         ] );
     ]


### PR DESCRIPTION
## Summary
- persist dashboard activation edits to the Keeper TOML declarative SSOT
- prevalidate mixed config requests before any activation commit
- restart runtime projection after a successful commit and expose typed partial operational failure
- invalidate Keeper and fleet dashboard surfaces together

## Boundary
- no new store, lease, settlement, rollback, or legacy migration
- TOML remains the forward-only authority
- partial commit is reported only when the declarative write succeeded and runtime synchronization failed

## Focused proof
- `scripts/dune-local.sh build @lib/check test/test_dashboard_http_core.exe`
- `test_dashboard_http_core` context-window group cases 1-4
- `git diff --check`
