### PR TITLE
fix: route autonomous turns to history.jsonl (#25939)

### DIFF
--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -188,7 +188,7 @@ let run (ctx : ctx)
                  ~runtime_id:execution.runtime_id
                  ~world_observation:observation
                  ~generation:run_generation
-                 ~history_user_source:"world_state_prompt"
+                 ~history_user_source:"autonomous_user"
                  (* RFC-0351 section 5 / #25462: on this lane the user turn is
                     the wake marker constant unless a HITL resolution was
                     appended to it. A bare marker carries nothing forward — the
@@ -197,7 +197,7 @@ let run (ctx : ctx)
                  ~user_turn_record:
                    (Keeper_run_prompt.user_turn_record_of_hitl_resolution
                       hitl_resolution)
-                 ~history_assistant_source:"internal_assistant"
+                 ~history_assistant_source:"autonomous_assistant"
                  ~degraded_retry_applied:
                    (Option.is_some turn_state.degraded_retry_info)
                  ?degraded_retry_runtime:


### PR DESCRIPTION
## Summary

Fixes keeper turn history not appearing in `masc_keeper_status history_tail`.

## Root Cause

Autonomous turns in `keeper_unified_turn_execution.ml` used internal history sources:
- `history_user_source:"world_state_prompt"`
- `history_assistant_source:"internal_assistant"`

Both match `is_internal_history_source()`, routing all messages to `history.internal.jsonl` instead of `history.jsonl`.

The `masc_keeper_status` command reads `history.jsonl` for the `history_tail` field, resulting in `history_tail_count: 0` for autonomous keepers.

## Fix

Changed history sources to non-internal values:
- `history_user_source:"autonomous_user"`
- `history_assistant_source:"autonomous_assistant"`

## Verification

After this fix, autonomous turns will be persisted to `history.jsonl`. Verification:
```
masc_keeper_status --name lane-smith --include_history_tail true
```
Should show `history_tail_count > 0` after the next autonomous turn.

## References

Fixes #25939