### PR TITLE
fix(test): operator_control_snapshot fixture 를 current keeper meta schema 에 정렬 (main red)

### DIFF
--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -339,12 +339,7 @@ let context_test_meta ~name ~last_input_tokens =
   let base =
     match
       Masc_test_deps.meta_of_json_fixture
-        (`Assoc
-          [ "name", `String name
-          ; "agent_name", `String (name ^ "-agent")
-          ; "trace_id", `String ("trace-" ^ name)
-          ; "runtime_id", `String "primary"
-          ])
+        (`Assoc [ "name", `String name ])
     with
     | Ok meta -> meta
     | Error error -> Alcotest.fail error


### PR DESCRIPTION
## 목표

main red (CI "Build and Test" failure, run 30260729416) 해소.

## 원인

`test_operator_control_snapshot` 의 `context_test_meta` fixture 가 current keeper meta schema 에 맞지 않음. 555a425595 ("make current meta failure explicit") 이후 production parser 가 current schema 위반을 명시적으로 거부:

- `runtime_id`: RFC-0211 (runtime.toml SSOT keeper-assignment) 로 meta JSON 에서 제거됨. `Keeper_meta_contract.runtime_id_of_meta` 로 resolve 하므로 fixture 가 직접 넣으면 "fields outside the current schema" 거부.
- `agent_name`: canonical keeper identity 여야 함. hand-set string(`name ^ "-agent"`)은 "agent_name does not match canonical keeper identity" 거부.

## 변경

fixture 를 name-only 로 단순화. identity 필드(agent_name, trace_id)는 `meta_of_json_fixture` 의 canonical default 에 맡김. 이는 해당 함수의 설계 의도("omitted field 를 current-schema default 로 채운다")와 일치.

## 검증

- 로컬(macOS): `operator_control_snapshot` 7 tests [OK] (context metrics ledger 3건 복구)
- 미검증: CI(Linux) 전체 — PR 에서 확인

## 메모

- runtime-tunables.md stale: 로컬 regenerate diff 없음(이미 최신, entries=211). CI 에서 재발 시 별도 대응.
- 디스크 full (No space left on device): CI runner flake. 코드 결함 아님.

## RFC

본 변경은 test fixture repair (current schema 동기화) 이며 `lib/` behavior 변경 없음. 근원 schema 변경은 RFC-0211 (persona⊥{model,runtime} + runtime.toml SSOT keeper-assignment).