### PR TITLE
fix(dashboard): expose checkpoint inventory failures

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -24,6 +24,7 @@ let oas_checkpoint_summary_json
     [ "snapshot_id", `String snapshot_id
     ; "source_kind", `String source_kind
     ; "is_current", `Bool is_current
+    ; "status", `String "available"
     ; "path", `String path
     ; "created_at", `Float checkpoint.created_at
     ; "generation", `Int generation
@@ -36,6 +37,60 @@ let oas_checkpoint_summary_json
     ; ( "latest_preview", Json_util.string_opt_to_json (latest_preview_of_messages messages) )
     ; "file_stat", stat_json_of_path path
     ]
+;;
+
+let checkpoint_load_error_json
+      (error : Keeper_checkpoint_store.checkpoint_load_error)
+  =
+  let status, kind, detail =
+    match error with
+    | Not_found -> "missing", "not_found", `Null
+    | Store_error detail -> "unavailable", "store_error", `String detail
+    | Parse_error detail -> "unavailable", "parse_error", `String detail
+    | Io_error detail -> "unavailable", "io_error", `String detail
+    | Sdk_other_error detail ->
+      "unavailable", "sdk_other_error", `String detail
+  in
+  `Assoc
+    [ "status", `String status
+    ; "error_kind", `String kind
+    ; "error_detail", detail
+    ]
+;;
+
+let current_checkpoint_error_json
+      (error : Keeper_checkpoint_store.checkpoint_load_error)
+  =
+  match error with
+  | Not_found -> `Null
+  | Store_error detail ->
+    `Assoc [ "kind", `String "store_error"; "detail", `String detail ]
+  | Parse_error detail ->
+    `Assoc [ "kind", `String "parse_error"; "detail", `String detail ]
+  | Io_error detail ->
+    `Assoc [ "kind", `String "io_error"; "detail", `String detail ]
+  | Sdk_other_error detail ->
+    `Assoc [ "kind", `String "sdk_other_error"; "detail", `String detail ]
+;;
+
+let checkpoint_load_failure_json
+      ~(source_kind : string)
+      ~(snapshot_id : string)
+      ~(path : string)
+      ~(is_current : bool)
+      (error : Keeper_checkpoint_store.checkpoint_load_error)
+  =
+  let identity_fields =
+    [ "snapshot_id", `String snapshot_id
+    ; "source_kind", `String source_kind
+    ; "is_current", `Bool is_current
+    ; "path", `String path
+    ; "file_stat", stat_json_of_path path
+    ]
+  in
+  match checkpoint_load_error_json error with
+  | `Assoc error_fields -> `Assoc (identity_fields @ error_fields)
+  | _ -> assert false
 ;;
 
 let inventory_json (config : Workspace.config) (name : string)
@@ -52,7 +107,7 @@ let inventory_json (config : Workspace.config) (name : string)
     let current_path =
       Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:trace_id
     in
-    let current_json =
+    let current_json, current_history_snapshot_id, current_status, current_error =
       match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:trace_id with
       | Ok checkpoint ->
         let current_history_snapshot_id =
@@ -65,30 +120,49 @@ let inventory_json (config : Workspace.config) (name : string)
           ~is_current:true
           ~fallback_generation:meta.runtime.nonce
           checkpoint
-        |> fun json -> Some (json, current_history_snapshot_id)
-      | Error _ -> None
+        |> fun json -> Some json, current_history_snapshot_id, "available", `Null
+      | Error error ->
+        let status =
+          match error with
+          | Keeper_checkpoint_store.Not_found -> "missing"
+          | Store_error _ | Parse_error _ | Io_error _ | Sdk_other_error _ ->
+            "unavailable"
+        in
+        None, "", status, current_checkpoint_error_json error
     in
-    let history_json =
+    let history_json, history_errors =
       Keeper_checkpoint_store.list_oas_history_files ~session_dir
       |> List.filter (fun snapshot_id ->
-        match current_json with
-        | Some (_json, current_history_snapshot_id) ->
-          snapshot_id <> current_history_snapshot_id
-        | None -> true)
-      |> List.filter_map (fun snapshot_id ->
-        match
-          Keeper_checkpoint_store.load_oas_history_file ~session_dir ~snapshot_id
-        with
-        | Ok checkpoint ->
-          Some
-            (oas_checkpoint_summary_json
-               ~source_kind:"oas_history"
-               ~snapshot_id
-               ~path:(Keeper_checkpoint_store.oas_history_path ~session_dir ~snapshot_id)
-               ~is_current:false
-               ~fallback_generation:meta.runtime.nonce
-               checkpoint)
-        | Error _ -> None)
+        snapshot_id <> current_history_snapshot_id)
+      |> List.fold_left
+           (fun (available, failures) snapshot_id ->
+             let path =
+               Keeper_checkpoint_store.oas_history_path ~session_dir ~snapshot_id
+             in
+             match
+               Keeper_checkpoint_store.load_oas_history_file ~session_dir ~snapshot_id
+             with
+             | Ok checkpoint ->
+               ( oas_checkpoint_summary_json
+                   ~source_kind:"oas_history"
+                   ~snapshot_id
+                   ~path
+                   ~is_current:false
+                   ~fallback_generation:meta.runtime.nonce
+                   checkpoint
+                 :: available
+               , failures )
+             | Error error ->
+               ( available
+               , checkpoint_load_failure_json
+                   ~source_kind:"oas_history"
+                   ~snapshot_id
+                   ~path
+                   ~is_current:false
+                   error
+                 :: failures ))
+           ([], [])
+      |> fun (available, failures) -> List.rev available, List.rev failures
     in
     ( `OK
     , `Assoc
@@ -97,9 +171,12 @@ let inventory_json (config : Workspace.config) (name : string)
         ; "session_dir", `String session_dir
         ; ( "current"
           , match current_json with
-            | Some (json, _snapshot_id) -> json
+            | Some json -> json
             | None -> `Null )
+        ; "current_status", `String current_status
+        ; "current_error", current_error
         ; "history", `List history_json
+        ; "history_errors", `List history_errors
         ] )
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
@@ -11,6 +11,16 @@ val oas_checkpoint_summary_json :
   Agent_sdk.Checkpoint.t ->
   Yojson.Safe.t
 
+(** Total dashboard projection of a typed checkpoint load failure. [Not_found]
+    is a normal missing asset; every other constructor is an unavailable asset
+    with its original categorical kind and detail preserved. *)
+val checkpoint_load_error_json :
+  Keeper_checkpoint_store.checkpoint_load_error -> Yojson.Safe.t
+
+(** Additive checkpoint inventory projection. [current] remains a summary or
+    null and [history] remains a summary list. [current_status],
+    [current_error], and [history_errors] expose missing or unavailable assets
+    without mixing diagnostic rows into the compatibility fields. *)
 val inventory_json : Workspace.config -> string -> [ `Not_found | `OK ] * Yojson.Safe.t
 
 val linked_artifact_json : kind:string -> string -> Yojson.Safe.t

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -2,6 +2,7 @@ open Alcotest
 open Masc
 module Trace = Server_dashboard_http_keeper_api_trace
 module Types = Server_dashboard_http_keeper_api_types
+module Checkpoints = Server_dashboard_http_keeper_api_checkpoints
 module Runtime_lens_scan = Server_dashboard_http_keeper_runtime_manifest_scan
 module Runtime_lens_swimlane = Server_dashboard_http_keeper_runtime_lens_swimlane
 module T = Trajectory
@@ -365,6 +366,167 @@ let test_tool_runtime_zero_event_lane_is_not_observed () =
     (string_member "completeness" json)
 ;;
 
+let make_checkpoint_inventory_meta ~name ~trace_id =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
+        ; "trace_id", `String trace_id
+        ])
+  with
+  | Ok meta -> meta
+  | Error detail -> fail ("checkpoint inventory meta fixture failed: " ^ detail)
+;;
+
+let make_inventory_checkpoint ~session_id ~turn_count ~created_at =
+  Agent_sdk.Checkpoint.
+    { version = checkpoint_version
+    ; session_id
+    ; agent_name = "checkpoint-inventory-test"
+    ; model = "opaque-runtime"
+    ; system_prompt = None
+    ; messages = []
+    ; usage = Agent_sdk.Types.empty_usage
+    ; turn_count
+    ; created_at
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = None
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; reasoning_effort = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.Off
+    ; thinking_budget = None
+    ; cache_system_prompt = false
+    ; context = Agent_sdk.Context.create_sync ()
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+;;
+
+let check_checkpoint_error_projection error ~status ~kind ~detail =
+  let open Yojson.Safe.Util in
+  let json = Checkpoints.checkpoint_load_error_json error in
+  check string "checkpoint status" status (json |> member "status" |> to_string);
+  check string "checkpoint error kind" kind (json |> member "error_kind" |> to_string);
+  check (option string)
+    "checkpoint error detail"
+    detail
+    (json |> member "error_detail" |> to_string_option)
+;;
+
+let test_checkpoint_load_error_projection_is_total () =
+  let module Store = Keeper_checkpoint_store in
+  check_checkpoint_error_projection
+    Store.Not_found
+    ~status:"missing"
+    ~kind:"not_found"
+    ~detail:None;
+  check_checkpoint_error_projection
+    (Store.Store_error "store unavailable")
+    ~status:"unavailable"
+    ~kind:"store_error"
+    ~detail:(Some "store unavailable");
+  check_checkpoint_error_projection
+    (Store.Parse_error "invalid checkpoint")
+    ~status:"unavailable"
+    ~kind:"parse_error"
+    ~detail:(Some "invalid checkpoint");
+  check_checkpoint_error_projection
+    (Store.Io_error "permission denied")
+    ~status:"unavailable"
+    ~kind:"io_error"
+    ~detail:(Some "permission denied");
+  check_checkpoint_error_projection
+    (Store.Sdk_other_error "sdk failure")
+    ~status:"unavailable"
+    ~kind:"sdk_other_error"
+    ~detail:(Some "sdk failure")
+;;
+
+let test_checkpoint_inventory_preserves_partial_load_failures () =
+  with_temp_dir @@ fun dir ->
+  let config = Workspace.default_config dir in
+  let keeper_name = "checkpoint-inventory" in
+  let trace_id = "trace-checkpoint-inventory" in
+  Keeper_meta_store.write_meta
+    config
+    (make_checkpoint_inventory_meta ~name:keeper_name ~trace_id)
+  |> Result.map_error (fun detail -> fail ("checkpoint inventory meta write failed: " ^ detail))
+  |> Result.get_ok;
+  let session_dir = Keeper_types_support.keeper_session_dir config trace_id in
+  let current = make_inventory_checkpoint ~session_id:trace_id ~turn_count:2 ~created_at:2.0 in
+  (match Keeper_checkpoint_store.save_oas_classified ~session_dir current with
+   | Ok _ -> ()
+   | Error detail -> fail ("checkpoint inventory current save failed: " ^ detail));
+  let corrupt_history =
+    make_inventory_checkpoint ~session_id:trace_id ~turn_count:1 ~created_at:1.0
+  in
+  let corrupt_snapshot_id =
+    Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint corrupt_history
+  in
+  let corrupt_path =
+    Keeper_checkpoint_store.oas_history_path
+      ~session_dir
+      ~snapshot_id:corrupt_snapshot_id
+  in
+  Fs_compat.mkdir_p (Filename.dirname corrupt_path);
+  Fs_compat.save_file corrupt_path "{not-a-checkpoint";
+  let status, json = Checkpoints.inventory_json config keeper_name in
+  check bool "partial checkpoint inventory remains HTTP 200" true (status = `OK);
+  let open Yojson.Safe.Util in
+  check string
+    "current checkpoint remains available"
+    "available"
+    (json |> member "current_status" |> to_string);
+  check bool "available current has no error" true
+    (json |> member "current_error" = `Null);
+  let history = json |> member "history" |> to_list in
+  check int "corrupt history is not mixed with summaries" 0 (List.length history);
+  let history_errors = json |> member "history_errors" |> to_list in
+  check int "corrupt history remains visible" 1 (List.length history_errors);
+  let failed = List.hd history_errors in
+  check string
+    "history failure is unavailable"
+    "unavailable"
+    (failed |> member "status" |> to_string);
+  check string
+    "history failure preserves typed parse kind"
+    "parse_error"
+    (failed |> member "error_kind" |> to_string);
+  check bool
+    "history failure preserves diagnostic detail"
+    true
+    (failed |> member "error_detail" |> to_string |> String.length > 0)
+;;
+
+let test_checkpoint_inventory_projects_missing_current () =
+  with_temp_dir @@ fun dir ->
+  let config = Workspace.default_config dir in
+  let keeper_name = "checkpoint-missing" in
+  let trace_id = "trace-checkpoint-missing" in
+  Keeper_meta_store.write_meta
+    config
+    (make_checkpoint_inventory_meta ~name:keeper_name ~trace_id)
+  |> Result.map_error (fun detail -> fail ("checkpoint inventory meta write failed: " ^ detail))
+  |> Result.get_ok;
+  let status, json = Checkpoints.inventory_json config keeper_name in
+  check bool "missing current inventory remains HTTP 200" true (status = `OK);
+  let open Yojson.Safe.Util in
+  check bool "missing current remains null" true (json |> member "current" = `Null);
+  check string
+    "missing current is explicit"
+    "missing"
+    (json |> member "current_status" |> to_string);
+  check bool "normal missing current has no error" true
+    (json |> member "current_error" = `Null)
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
@@ -406,6 +568,20 @@ let () =
             "surfaces retired and unsupported rows without repeated warnings"
             `Quick
             test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings
+        ] )
+    ; ( "checkpoint_inventory"
+      , [ test_case
+            "projects every typed checkpoint load error"
+            `Quick
+            test_checkpoint_load_error_projection_is_total
+        ; test_case
+            "preserves partial history failures with HTTP 200"
+            `Quick
+            test_checkpoint_inventory_preserves_partial_load_failures
+        ; test_case
+            "projects missing current without failing inventory"
+            `Quick
+            test_checkpoint_inventory_projects_missing_current
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- preserve the existing current summary-or-null and history summary-array contract
- add typed current_status, current_error, and history_errors
- distinguish a normal missing checkpoint from store, parse, I/O, and SDK unavailability
- keep partial inventories HTTP 200 without silently dropping failed rows

## Boundary
- read-only additive projection
- no new state, migration, store, lease, commit, or repair path
- dashboard evidence comes from the typed checkpoint load ADT

## Focused proof
- scripts/dune-local.sh build @lib/check test/test_server_dashboard_http_keeper_api_trace.exe
- checkpoint inventory cases 0-2: 3/3 green
- git diff --check
