### PR TITLE
fix(keeper): preserve deferred Runtime failover suffix

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -21,7 +21,11 @@ import { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
 import { deriveOperationalInsight } from './fsm-hub-invariant-analysis'
 import { flagTooltip, invariantDescription } from './fsm-hub-health-panels'
 import { isTransitionInSegment } from './fsm-hub-timeline-panels'
-import { filterKeeperNames } from './fsm-hub'
+import {
+  executionReceiptLabel,
+  executionReceiptTitle,
+  filterKeeperNames,
+} from './fsm-hub'
 
 function observation(
   overrides: Partial<CompositeObservation> = {},
@@ -91,6 +95,27 @@ function snapshot(
 }
 
 describe('fsm-hub derived state', () => {
+  it('shows queued and applied deferred runtime targets from the receipt SSOT', () => {
+    const execution = {
+      latest_receipt_present: true,
+      outcome: 'receipt_failed',
+      terminal_reason_code: 'provider_error',
+      duration_ms: 1200,
+      runtime: {
+        degraded_retry_applied: false,
+        degraded_retry_runtime: 'runtime.b',
+        fallback_reason: 'deferred_runtime_lane',
+      },
+    } as KeeperCompositeSnapshot['execution']
+
+    expect(executionReceiptLabel(execution)).toContain('retry queued -> runtime.b')
+    expect(executionReceiptTitle(execution)).toContain('retry: queued -> runtime.b')
+
+    if (execution?.runtime) execution.runtime.degraded_retry_applied = true
+    expect(executionReceiptLabel(execution)).toContain('retry applied -> runtime.b')
+    expect(executionReceiptTitle(execution)).toContain('retry: applied -> runtime.b')
+  })
+
   it('skips duplicate observations when tracked fields are unchanged', () => {
     const first = observation()
 

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -97,24 +97,34 @@ function executionReceiptTone(execution: KeeperCompositeExecution | undefined): 
   return 'warn'
 }
 
-function executionReceiptLabel(execution: KeeperCompositeExecution | undefined): string | null {
+export function executionReceiptLabel(execution: KeeperCompositeExecution | undefined): string | null {
   if (!execution) return null
   if (!execution.latest_receipt_present) return 'receipt 없음'
   const terminal = shortText(execution.terminal_reason_code, 32)
   const elapsed = formatMs(execution.duration_ms)
+  const deferredRuntime = shortText(execution.runtime?.degraded_retry_runtime, 32)
+  const deferredRetry = deferredRuntime
+    ? `${execution.runtime?.degraded_retry_applied ? 'retry applied' : 'retry queued'} -> ${deferredRuntime}`
+    : ''
   return [
     execution.outcome ?? 'unknown',
     terminal,
     elapsed,
+    deferredRetry,
   ].filter(Boolean).join(' · ')
 }
 
-function executionReceiptTitle(execution: KeeperCompositeExecution | undefined): string {
+export function executionReceiptTitle(execution: KeeperCompositeExecution | undefined): string {
   if (!execution?.latest_receipt_present) return '아직 execution receipt가 없습니다.'
+  const deferredRuntime = execution.runtime?.degraded_retry_runtime
+  const deferredRetry = deferredRuntime
+    ? `retry: ${execution.runtime?.degraded_retry_applied ? 'applied' : 'queued'} -> ${deferredRuntime}`
+    : ''
   return [
     execution.recorded_at ? `recorded_at: ${execution.recorded_at}` : '',
     execution.operator_disposition ? `operator: ${execution.operator_disposition}` : '',
     execution.operator_disposition_reason ? `reason: ${execution.operator_disposition_reason}` : '',
+    deferredRetry,
     execution.runtime?.fallback_reason ? `fallback: ${execution.runtime.fallback_reason}` : '',
     execution.error?.kind ? `error: ${execution.error.kind}` : '',
     execution.error?.message_preview ? execution.error.message_preview : '',

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -241,6 +241,9 @@ let run_turn
       ?degraded_retry_runtime
       ?fallback_reason
       ?(runtime_rotation_attempts = [])
+      ?deferred_runtime_lane
+      ?on_runtime_retry_deferred
+      ?on_deferred_runtime_consumed
       ?(is_retry = false)
       ?shared_context
       ?event_bus
@@ -254,6 +257,11 @@ let run_turn
   : (run_result, Agent_sdk.Error.sdk_error) result
   =
   (* Section 1: Setup — sanitize input, build context, compose prompt. *)
+  let deferred_runtime_lane_ref = ref None in
+  let record_runtime_retry_deferred hint =
+    deferred_runtime_lane_ref := Some hint;
+    Option.iter (fun callback -> callback hint) on_runtime_retry_deferred
+  in
   let user_message = Keeper_run_prompt.sanitize_user_message user_message in
   Masc_runtime_events.emit_turn_start ();
   let partition, _ =
@@ -653,6 +661,9 @@ let run_turn
                              ~site:"runtime_runtime"
                              config
                              manifest)
+                      ?deferred_runtime_lane
+                      ~on_runtime_retry_deferred:record_runtime_retry_deferred
+                      ?on_deferred_runtime_consumed
                       ?stream_idle_timeout_s
                       ?body_timeout_s:
                         (Keeper_runtime_resolved.body_timeout_override_sec ())
@@ -794,6 +805,30 @@ let run_turn
                                 ())
                           ()))
                in
+       let deferred_retry =
+         Option.map
+           (fun (hint : Keeper_turn_driver.deferred_runtime_lane) ->
+              let reason =
+                match
+                  Keeper_error_classify.recoverable_runtime_failure_reason
+                    hint.failure
+                with
+                | Some reason -> reason
+                | None -> Keeper_error_classify.Deferred_runtime_lane
+              in
+              hint.next_runtime_id, reason)
+           !deferred_runtime_lane_ref
+       in
+       let receipt_degraded_retry_runtime =
+         match deferred_retry with
+         | Some (runtime_id, _) -> Some runtime_id
+         | None -> degraded_retry_runtime
+       in
+       let receipt_fallback_reason =
+         match deferred_retry with
+         | Some (_, reason) -> Some reason
+         | None -> fallback_reason
+       in
        let receipt_result =
          Keeper_agent_run_receipt.finalize
            ~config
@@ -806,8 +841,8 @@ let run_turn
            ~runtime_manifest_context
            ~acc
            ~degraded_retry_applied
-           ~degraded_retry_runtime
-           ~fallback_reason
+           ~degraded_retry_runtime:receipt_degraded_retry_runtime
+           ~fallback_reason:receipt_fallback_reason
            ~runtime_rotation_attempts
            ~turn_result
            ~receipt_turn_count_ref

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -150,6 +150,10 @@ val run_turn
   -> ?degraded_retry_runtime:string
   -> ?fallback_reason:Keeper_error_classify.degraded_retry_reason
   -> ?runtime_rotation_attempts:Keeper_execution_receipt.runtime_rotation_attempt list
+  -> ?deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane
+  -> ?on_runtime_retry_deferred:
+       (Keeper_turn_driver.deferred_runtime_lane -> unit)
+  -> ?on_deferred_runtime_consumed:(unit -> unit)
   -> ?is_retry:bool
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -357,6 +357,7 @@ type degraded_retry_reason =
   | Rate_limit
   | Server_error
   | Auth_error
+  | Deferred_runtime_lane
   | Empty_no_progress
   | Thinking_only_no_progress
 
@@ -369,6 +370,7 @@ let degraded_retry_reason_to_string = function
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
+  | Deferred_runtime_lane -> "deferred_runtime_lane"
   | Empty_no_progress -> "empty_no_progress"
   | Thinking_only_no_progress -> "thinking_only_no_progress"
 
@@ -645,6 +647,7 @@ let default_degraded_rotation_candidates
        Without this, two unavailable runtimes had nowhere to go (#23373,
        incidents 2026-05-21 / 2026-07-06). *)
     candidates_with_catalog
+  | Some Deferred_runtime_lane -> []
   | Some (Hard_quota | Rate_limit)
   | None ->
     default_candidates

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -102,6 +102,7 @@ type degraded_retry_reason =
   | Rate_limit
   | Server_error
   | Auth_error
+  | Deferred_runtime_lane
   | Empty_no_progress
   | Thinking_only_no_progress
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -124,6 +124,15 @@ type keepalive_turn_outcome = {
   cycle_status : keepalive_cycle_status;
 }
 
+let consume_deferred_runtime_lane_hint hint_ref expected =
+  match !hint_ref with
+  | Some current
+    when Keeper_turn_driver.equal_deferred_runtime_lane expected current ->
+    hint_ref := None;
+    true
+  | None | Some _ -> false
+;;
+
 exception Event_queue_settlement_failed of string
 
 type transition_projection_gate =
@@ -810,6 +819,9 @@ let commit_transcript_corruption_and_project
 ;;
 
 module For_testing = struct
+  let consume_deferred_runtime_lane_hint =
+    consume_deferred_runtime_lane_hint
+
   type nonrec transcript_corruption_commit = transcript_corruption_commit =
     | Transcript_pause_persisted
     | Transcript_pause_and_settlement_persisted
@@ -885,6 +897,10 @@ let run_keepalive_unified_turn
       ~(proactive_warmup_elapsed : bool)
       ~(reactive_wake : bool)
       ~(shared_context : Agent_sdk.Context.t)
+      ~(deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option)
+      ~(on_deferred_runtime_consumed : unit -> unit)
+      ~(record_deferred_runtime_lane :
+          Keeper_turn_driver.deferred_runtime_lane -> unit)
   : keepalive_turn_outcome
   =
   if not proactive_warmup_elapsed
@@ -1262,6 +1278,8 @@ let run_keepalive_unified_turn
           in
           let run_cycle () =
             run_keeper_cycle
+              ?deferred_runtime_lane
+              ~on_deferred_runtime_consumed
               ?exact_execution_guard:dispatch_guard
               ?event_bus
               ?hitl_resolution
@@ -1277,6 +1295,9 @@ let run_keepalive_unified_turn
               ()
           in
           let cycle_outcome = run_cycle () in
+          Option.iter
+            record_deferred_runtime_lane
+            (Cycle.deferred_runtime_lane cycle_outcome);
           cycle_outcome_ref := Some cycle_outcome;
           Cycle.meta cycle_outcome)
         else meta_after_triage
@@ -1665,6 +1686,7 @@ let run_heartbeat_loop
      and tool-call counters are recreated inside run_turn and therefore
      do not accumulate for the full keeper lifecycle. *)
   let shared_context = Agent_sdk.Context.create () in
+  let deferred_runtime_lane_ref = ref None in
   (* Mtime-based change detection for keeper meta disk reads.
      Avoids re-parsing the JSON file on every heartbeat cycle when
      no operator has modified it.  Initialized to 0.0 so the first
@@ -1849,6 +1871,16 @@ let run_heartbeat_loop
               | Keeper_keepalive_signal.Timeout | Keeper_keepalive_signal.Stopped ->
                 false
             in
+            let deferred_runtime_lane = !deferred_runtime_lane_ref in
+            let on_deferred_runtime_consumed () =
+              Option.iter
+                (fun expected ->
+                   ignore
+                     (consume_deferred_runtime_lane_hint
+                        deferred_runtime_lane_ref
+                        expected))
+                deferred_runtime_lane
+            in
             let r =
               run_keepalive_unified_turn
                 ~ctx
@@ -1858,6 +1890,10 @@ let run_heartbeat_loop
                 ~proactive_warmup_elapsed
                 ~reactive_wake
                 ~shared_context
+                ~deferred_runtime_lane
+                ~on_deferred_runtime_consumed
+                ~record_deferred_runtime_lane:
+                  (fun hint -> deferred_runtime_lane_ref := Some hint)
             in
             Keeper_keepalive_signal.pre_turn_complete_heartbeat ~turn_running;
             turn_running := false;

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -216,6 +216,10 @@ val run_keepalive_unified_turn :
   proactive_warmup_elapsed:bool ->
   reactive_wake:bool ->
   shared_context:Agent_sdk.Context.t ->
+  deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane option ->
+  on_deferred_runtime_consumed:(unit -> unit) ->
+  record_deferred_runtime_lane:
+    (Keeper_turn_driver.deferred_runtime_lane -> unit) ->
   keepalive_turn_outcome
 
 val refresh_work_as_heartbeat :
@@ -259,6 +263,11 @@ val run_heartbeat_loop :
   wakeup:bool Atomic.t -> unit
 
 module For_testing : sig
+  val consume_deferred_runtime_lane_hint :
+    Keeper_turn_driver.deferred_runtime_lane option ref ->
+    Keeper_turn_driver.deferred_runtime_lane ->
+    bool
+
   type transition_projection_gate =
     | Projection_ready_for_cycle
     | Projection_deferred_nonfailure

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -86,12 +86,21 @@ let manual_compaction_followup_failure = function
   | Manual_compaction_not_applied _ -> None
 ;;
 
+let rec deferred_runtime_lane = function
+  | Failed { failure; _ } -> failure.Keeper_unified_turn.deferred_runtime_lane
+  | Manual_compaction_applied { followup; _ } -> deferred_runtime_lane followup
+  | Completed _ | Cancelled _ | Skipped _ | Busy _ | Manual_compaction_failed _
+  | Manual_compaction_not_applied _ -> None
+;;
+
 (* Body of [run_keeper_cycle], runnable only while holding the keeper's
    turn slot ([Keeper_turn_admission]). The post-failure meta re-reads stay
    inside the slot for the same reason as the chat lane: a concurrent turn
    must not interleave with this lane's meta writes (RFC-0225 §1). *)
 let run_keeper_cycle_admitted
       ?exact_execution_guard
+      ?deferred_runtime_lane
+      ?on_deferred_runtime_consumed
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
@@ -108,6 +117,8 @@ let run_keeper_cycle_admitted
     In_turn_pulse.with_in_turn_liveness_pulse ~ctx ~meta:meta_after_triage ~stop (fun () ->
       Keeper_unified_turn.run_keeper_cycle
         ?exact_execution_guard
+        ?deferred_runtime_lane
+        ?on_deferred_runtime_consumed
         ~config:ctx.config
         ~meta:meta_after_triage
         ~publication_recovery_provider:ctx.publication_recovery_provider
@@ -188,6 +199,8 @@ let run_keeper_cycle_admitted
 let run_keeper_cycle_with
       ~run_manual_compaction
       ?exact_execution_guard
+      ?deferred_runtime_lane
+      ?on_deferred_runtime_consumed
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
@@ -242,6 +255,8 @@ let run_keeper_cycle_with
         ~keeper_name:meta_after_triage.name
         (run_keeper_cycle_admitted
            ?exact_execution_guard
+           ?deferred_runtime_lane
+           ?on_deferred_runtime_consumed
            ~ctx
            ~meta_after_triage
            ~stop
@@ -295,6 +310,8 @@ let run_keeper_cycle_with
 
 let run_keeper_cycle
       ?exact_execution_guard
+      ?deferred_runtime_lane
+      ?on_deferred_runtime_consumed
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
@@ -317,6 +334,8 @@ run_keeper_cycle_with
          ~meta
          ())
     ?exact_execution_guard
+    ?deferred_runtime_lane
+    ?on_deferred_runtime_consumed
     ?event_bus
     ?hitl_resolution
     ?continuation_delivery_channel

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -38,8 +38,13 @@ val manual_compaction_followup_failure
     Queue settlement uses this projection to preserve an LLM judgment
     successor without replaying the completed compaction transaction. *)
 
+val deferred_runtime_lane :
+  cycle_outcome -> Keeper_turn_driver.deferred_runtime_lane option
+
 val run_keeper_cycle
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> ?deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane
+  -> ?on_deferred_runtime_consumed:(unit -> unit)
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> ?continuation_delivery_channel:Keeper_continuation_channel.t

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -67,6 +67,27 @@ type provider_attempt_outcomes =
   ; turn_result : provider_run_result
   }
 
+type runtime_attempt_candidate =
+  | Resolved_runtime of Runtime.t
+  | Missing_runtime of string
+
+type deferred_runtime_lane =
+  { assignment_id : string
+  ; failed_runtime_id : string
+  ; next_runtime_id : string
+  ; later_runtime_ids : string list
+  ; failure : Agent_sdk.Error.sdk_error
+  }
+
+let deferred_runtime_ids hint =
+  hint.next_runtime_id :: hint.later_runtime_ids
+
+let equal_deferred_runtime_lane left right =
+  String.equal left.assignment_id right.assignment_id
+  && String.equal left.failed_runtime_id right.failed_runtime_id
+  && String.equal left.next_runtime_id right.next_runtime_id
+  && left.later_runtime_ids = right.later_runtime_ids
+
 let project_provider_attempt_result ~replay_prefix_projection provider_result =
   let turn_result =
     match provider_result with
@@ -134,6 +155,7 @@ let attempt_runtime_candidates
     ?(allow_accept_no_progress_retry = fun ~runtime_id:_ ~attempt:_ _error ->
       true)
     ?lane_id
+    ?(on_retry_deferred = fun _ -> ())
     ~runtime_id ~runtime_id_of
     ~(emit_runtime_manifest :
        ?status:string ->
@@ -173,31 +195,41 @@ let attempt_runtime_candidates
            ~status:"failed"
            ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
            Keeper_runtime_manifest.Runtime_failed;
-         if
-            let allow_retry =
-              allow_retry
-                ~runtime_id:attempt_runtime_id
-                ~attempt:idx
-                error
-            in
-            let allow_accept_no_progress_retry =
-              if
-                Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next
-                  error
-              then
-                allow_accept_no_progress_retry
-                  ~runtime_id:attempt_runtime_id
-                  ~attempt:idx
-                  error
-              else true
-            in
-            lane_should_retry
-              ~is_last
-              ~allow_retry
-              ~allow_accept_no_progress_retry
-              error
+         let retry_admitted =
+           allow_retry ~runtime_id:attempt_runtime_id ~attempt:idx error
+         in
+         let allow_accept_no_progress_retry =
+           if
+             Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next
+               error
+           then
+             allow_accept_no_progress_retry
+               ~runtime_id:attempt_runtime_id
+               ~attempt:idx
+               error
+           else true
+         in
+         let retryable_with_input_authority =
+           lane_should_retry
+             ~is_last
+             ~allow_retry:true
+             ~allow_accept_no_progress_retry
+             error
+         in
+         if retry_admitted && retryable_with_input_authority
          then loop (idx + 1) rest
-         else Error error)
+         else (
+           (match retryable_with_input_authority, rest with
+            | true, next :: later ->
+              on_retry_deferred
+                { assignment_id = runtime_id
+                ; failed_runtime_id = attempt_runtime_id
+                ; next_runtime_id = runtime_id_of next
+                ; later_runtime_ids = List.map runtime_id_of later
+                ; failure = error
+                }
+            | false, _ | true, [] -> ());
+           Error error))
   in
   loop 0 candidates
 
@@ -211,6 +243,13 @@ let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime -> Ok runtime
   | None -> Error (runtime_candidate_missing_error id)
+
+let resolve_runtime_candidate_for_attempt ?on_missing id =
+  match resolve_runtime_candidate id with
+  | Ok _ as resolved -> resolved
+  | Error _ as missing ->
+    Option.iter (fun consume -> consume ()) on_missing;
+    missing
 
 let resolve_runtime_candidates ids =
   let rec loop acc = function
@@ -312,6 +351,9 @@ let run_named
     ?on_runtime_observation
     ?runtime_manifest_context
     ?runtime_manifest_append
+    ?deferred_runtime_lane
+    ?on_runtime_retry_deferred
+    ?on_deferred_runtime_consumed
     ?provider_config_transform
     ?sw
     ?net
@@ -367,16 +409,18 @@ let run_named
      operators can route through explicit failover groups.  Lane candidate
      order passes through the sticky last-good preference so a known-healthy
      failover candidate is tried before re-hitting a dead head candidate. *)
-  let lane_resolution = Runtime.resolve_assignment runtime_id in
   let lane_id_opt, lane_candidate_ids =
-    match lane_resolution with
-    | `Missing -> None, []
-    | `Single_runtime runtime -> None, [ runtime.Runtime.id ]
-    | `Lane lane ->
-      let lane_id = Runtime_lane.id lane in
-      ( Some lane_id
-      , Runtime_lane_preference.prefer_order ~lane_id
-          (Runtime_lane.ordered_candidates lane) )
+    match deferred_runtime_lane with
+    | Some hint -> Some hint.assignment_id, deferred_runtime_ids hint
+    | None ->
+      (match Runtime.resolve_assignment runtime_id with
+       | `Missing -> None, []
+       | `Single_runtime runtime -> None, [ runtime.Runtime.id ]
+       | `Lane lane ->
+         let lane_id = Runtime_lane.id lane in
+         ( Some lane_id
+         , Runtime_lane_preference.prefer_order ~lane_id
+             (Runtime_lane.ordered_candidates lane) ))
   in
   if lane_candidate_ids = []
   then
@@ -409,15 +453,29 @@ let run_named
     | first :: rest -> first, rest
     | [] -> runtime_id, []
   in
-  let* first_candidate = resolve_runtime_candidate first_candidate_id in
-  let* remaining_runtimes = resolve_runtime_candidates remaining_candidate_ids in
+  let* first_candidate =
+    resolve_runtime_candidate_for_attempt
+      ?on_missing:
+        (match deferred_runtime_lane with
+         | Some _ -> on_deferred_runtime_consumed
+         | None -> None)
+      first_candidate_id
+  in
+  let* remaining_runtimes =
+    match deferred_runtime_lane with
+    | Some _ -> Ok []
+    | None -> resolve_runtime_candidates remaining_candidate_ids
+  in
   let reroute_decision =
-    lane_modality_reroute_decision
-      ~checkpoint_messages
-      ~initial_messages
-      ~goal_blocks:current_goal_blocks
-      ~first_candidate
-      ~remaining_runtimes
+    match deferred_runtime_lane with
+    | Some _ -> Runtime_agent.No_reroute_needed
+    | None ->
+      lane_modality_reroute_decision
+        ~checkpoint_messages
+        ~initial_messages
+        ~goal_blocks:current_goal_blocks
+        ~first_candidate
+        ~remaining_runtimes
   in
   let first_runtime_id, first_runtime =
     first_runtime_after_modality_reroute ~keeper_name ~assignment_id:runtime_id
@@ -425,6 +483,17 @@ let run_named
   in
   let attempt_runtimes =
     dedupe_runtimes_preserve_order (first_runtime :: remaining_runtimes)
+  in
+  let attempt_candidates =
+    match deferred_runtime_lane with
+    | None -> List.map (fun runtime -> Resolved_runtime runtime) attempt_runtimes
+    | Some hint ->
+      List.map
+        (fun runtime_id ->
+           match Runtime.get_runtime_by_id runtime_id with
+           | Some runtime -> Resolved_runtime runtime
+           | None -> Missing_runtime runtime_id)
+        (deferred_runtime_ids hint)
   in
   let assigned_runtime_context_window =
     Runtime.max_context_of_runtime first_candidate
@@ -527,6 +596,7 @@ let run_named
      move to the next candidate; on success we record completion and return. *)
   attempt_runtime_candidates
     ?lane_id:lane_id_opt
+    ?on_retry_deferred:on_runtime_retry_deferred
     ~allow_retry:(fun ~runtime_id:attempt_runtime_id ~attempt error ->
       let allowed =
         Keeper_turn_driver_try_provider.same_run_retry_allowed
@@ -543,10 +613,20 @@ let run_named
           attempt
           (Oas_compat.error_kind error);
       allowed)
-    ~runtime_id
-    ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.Runtime.id)
+    ~runtime_id:
+      (match deferred_runtime_lane with
+       | Some hint -> hint.assignment_id
+       | None -> runtime_id)
+    ~runtime_id_of:(function
+      | Resolved_runtime runtime -> runtime.Runtime.id
+      | Missing_runtime runtime_id -> runtime_id)
     ~emit_runtime_manifest
-    ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
+    ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id candidate ->
+      match candidate with
+      | Missing_runtime runtime_id ->
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        Error (runtime_candidate_missing_error runtime_id), None
+      | Resolved_runtime runtime ->
       let error_runtime_id = attempt_runtime_id in
       let inference_policy =
         attempt_inference_policy
@@ -558,8 +638,10 @@ let run_named
          match provider_config_transform with
          | None -> Ok runtime.Runtime.provider_config
          | Some transform -> transform runtime.Runtime.provider_config
-       with
-      | Error err -> Error err, None
+      with
+      | Error err ->
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        Error err, None
       | Ok provider_config ->
         let candidate = Runtime_candidate.of_provider_config provider_config in
         (* Cached provider health is observation only. Every eligible runtime
@@ -612,6 +694,7 @@ let run_named
             ; seq_ref
             }
           in
+          Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
           let provider_result, checkpoint_after, _success_sample =
             Keeper_turn_driver_try_provider.run_try_provider
               try_provider_ctx candidate
@@ -622,11 +705,21 @@ let run_named
               provider_result
           in
           outcomes.turn_result, checkpoint_after)
-    attempt_runtimes
+    attempt_candidates
 
 
 module For_testing = struct
   type nonrec provider_attempt_outcomes = provider_attempt_outcomes
+
+  let make_deferred_runtime_lane ~assignment_id ~failed_runtime_id
+        ~next_runtime_id ~later_runtime_ids ~failure =
+    { assignment_id
+    ; failed_runtime_id
+    ; next_runtime_id
+    ; later_runtime_ids
+    ; failure
+    }
+  ;;
 
   let project_provider_attempt_result = project_provider_attempt_result
   let provider_result outcomes = outcomes.provider_result
@@ -639,6 +732,10 @@ module For_testing = struct
 
   let lane_modality_reroute_decision = lane_modality_reroute_decision
   let dedupe_runtimes_preserve_order = dedupe_runtimes_preserve_order
+  let resolve_runtime_candidates = resolve_runtime_candidates
+  let resolve_runtime_candidate_for_attempt =
+    resolve_runtime_candidate_for_attempt
+
 	  let media_degrade_manifest_decision = media_degrade_manifest_decision
 	  let attempt_inference_policy = attempt_inference_policy
   let attempt_runtime_candidates = attempt_runtime_candidates

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -66,6 +66,18 @@ val provider_attempt_finished_decision :
 
 (** {1 Named runtime execution} *)
 
+type deferred_runtime_lane = private
+  { assignment_id : string
+  ; failed_runtime_id : string
+  ; next_runtime_id : string
+  ; later_runtime_ids : string list
+  ; failure : Agent_sdk.Error.sdk_error
+  }
+
+val deferred_runtime_ids : deferred_runtime_lane -> string list
+val equal_deferred_runtime_lane :
+  deferred_runtime_lane -> deferred_runtime_lane -> bool
+
 val run_named :
   runtime_id:string ->
   ?keeper_name:string ->
@@ -103,6 +115,9 @@ val run_named :
   ?on_runtime_observation:(Runtime_observation.runtime_observation -> unit) ->
   ?runtime_manifest_context:Keeper_runtime_manifest.turn_context ->
   ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit) ->
+  ?deferred_runtime_lane:deferred_runtime_lane ->
+  ?on_runtime_retry_deferred:(deferred_runtime_lane -> unit) ->
+  ?on_deferred_runtime_consumed:(unit -> unit) ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->
     (Llm_provider.Provider_config.t, Agent_sdk.Error.sdk_error) result) ->
@@ -122,6 +137,14 @@ type attempt_inference_policy =
   }
 
 module For_testing : sig
+  val make_deferred_runtime_lane :
+    assignment_id:string ->
+    failed_runtime_id:string ->
+    next_runtime_id:string ->
+    later_runtime_ids:string list ->
+    failure:Agent_sdk.Error.sdk_error ->
+    deferred_runtime_lane
+
   type provider_attempt_outcomes
 
   val project_provider_attempt_result :
@@ -167,6 +190,14 @@ module For_testing : sig
     Runtime_agent.reroute_decision
 
   val dedupe_runtimes_preserve_order : Runtime.t list -> Runtime.t list
+  val resolve_runtime_candidates :
+    string list ->
+    (Runtime.t list, Agent_sdk.Error.sdk_error) result
+
+  val resolve_runtime_candidate_for_attempt :
+    ?on_missing:(unit -> unit) ->
+    string ->
+    (Runtime.t, Agent_sdk.Error.sdk_error) result
 
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
@@ -183,6 +214,7 @@ module For_testing : sig
     ?allow_accept_no_progress_retry:
       (runtime_id:string -> attempt:int -> Agent_sdk.Error.sdk_error -> bool) ->
     ?lane_id:string ->
+    ?on_retry_deferred:(deferred_runtime_lane -> unit) ->
     runtime_id:string ->
     runtime_id_of:('candidate -> string) ->
     emit_runtime_manifest:

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -60,17 +60,19 @@ type turn_failure =
   ; runtime_id : string
   ; route : Keeper_runtime_failure_route.route
   ; source_lease_disposition : source_lease_disposition
+  ; deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option
   }
 
 let turn_failure_of_error
       ~runtime_id
       ~fallback_boundary
       ~exact_failure_execution
+      ~deferred_runtime_lane
       error
   =
   match exact_failure_execution with
   | Some (runtime_id, route, source_lease_disposition) ->
-    { error; runtime_id; route; source_lease_disposition }
+    { error; runtime_id; route; source_lease_disposition; deferred_runtime_lane }
   | None ->
     { error
     ; runtime_id
@@ -79,6 +81,7 @@ let turn_failure_of_error
           ~boundary:fallback_boundary
           error
     ; source_lease_disposition = Follow_failure_route
+    ; deferred_runtime_lane
     }
 ;;
 
@@ -597,6 +600,8 @@ let append_provider_overflow_manifest
 
 let run_keeper_cycle
       ?exact_execution_guard
+      ?deferred_runtime_lane
+      ?on_deferred_runtime_consumed
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ~(publication_recovery_provider :
@@ -636,6 +641,7 @@ let run_keeper_cycle
             ~boundary:Keeper_runtime_failure_route.Masc_execution
             error
       ; source_lease_disposition = Follow_failure_route
+      ; deferred_runtime_lane = None
       }
   | Ok { entry; publication_recovery } ->
   let meta = entry.meta in
@@ -667,11 +673,28 @@ let run_keeper_cycle
   in
   let turn_start = Mtime_clock.now () in
   let initial_turn_state : Keeper_unified_turn_types.turn_state =
+    let degraded_retry_info =
+      Option.map
+        (fun (hint : Keeper_turn_driver.deferred_runtime_lane) ->
+           let fallback_reason =
+             match
+               Keeper_error_classify.recoverable_runtime_failure_reason
+                 hint.failure
+             with
+             | Some reason -> reason
+             | None -> Keeper_error_classify.Deferred_runtime_lane
+           in
+           { Keeper_error_classify.next_runtime = hint.next_runtime_id
+           ; fallback_reason
+           })
+        deferred_runtime_lane
+    in
     { cycle_completed = false
     ; manifest_seq = 0
     ; current_turn_blocker_info = None
     ; last_execution = None
-    ; degraded_retry_info = None
+    ; degraded_retry_info
+    ; deferred_runtime_lane = None
     ; runtime_rotation_attempts = []
     ; failure_reason = None
     ; retry_phase_started_at = None
@@ -719,7 +742,11 @@ let run_keeper_cycle
       * Keeper_unified_turn_execution.turn_state
     =
       let _ = phase_opt in
-      let effective_runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
+      let effective_runtime_id =
+        match deferred_runtime_lane with
+        | Some hint -> hint.Keeper_turn_driver.next_runtime_id
+        | None -> Keeper_meta_contract.runtime_id_of_meta meta
+      in
       let source =
         match Runtime.runtime_id_for_keeper meta.name with
         | Some id when String.trim id <> "" -> "assigned"
@@ -768,6 +795,12 @@ let run_keeper_cycle
          (match profile_and_execution
           with
           | Error err ->
+            Option.iter
+              (fun _ ->
+                 Option.iter
+                   (fun consume -> consume ())
+                   on_deferred_runtime_consumed)
+              deferred_runtime_lane;
             let terminal_reason_code =
               Printf.sprintf
                 "pre_dispatch_%s"
@@ -1077,6 +1110,8 @@ let run_keeper_cycle
                            ; shared_context
                            ; trajectory_acc
                            ; turn_id = keeper_turn_id
+                           ; deferred_runtime_lane
+                           ; on_deferred_runtime_consumed
                            }
                            ~initial_execution
                            ~turn_state
@@ -1460,11 +1495,12 @@ dominant source of the observed CAS race exhaustion after
       ~turn_state
       ~registry_base_path
   in
-  let failure_of_error error =
+  let failure_of_error ?deferred_runtime_lane error =
     turn_failure_of_error
       ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta)
       ~fallback_boundary:Keeper_runtime_failure_route.Masc_execution
       ~exact_failure_execution:!exact_failure_execution
+      ~deferred_runtime_lane
       error
   in
   match phase_gate_outcome with
@@ -1475,8 +1511,12 @@ dominant source of the observed CAS race exhaustion after
   | Keeper_unified_turn_phase_gate.Phase_gate_terminal_error err ->
     Error (failure_of_error err)
   | Keeper_unified_turn_phase_gate.Phase_gate_proceed phase_opt ->
-    let result, _turn_state = main_path turn_state phase_opt in
-    result
-    |> Result.map (fun meta -> Turn_completed meta)
-    |> Result.map_error failure_of_error
+    let result, turn_state = main_path turn_state phase_opt in
+    (match result with
+     | Ok meta -> Ok (Turn_completed meta)
+     | Error error ->
+       Error
+         (failure_of_error
+            ?deferred_runtime_lane:turn_state.deferred_runtime_lane
+            error))
 ;;

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -198,6 +198,7 @@ type turn_failure =
   ; runtime_id : string
   ; route : Keeper_runtime_failure_route.route
   ; source_lease_disposition : source_lease_disposition
+  ; deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option
   }
 (** Exact execution identity and typed disposition route for a failed turn.
     The heartbeat queue settles from this value; it must not reconstruct a
@@ -214,6 +215,8 @@ type turn_success =
 
 val run_keeper_cycle
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> ?deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane
+  -> ?on_deferred_runtime_consumed:(unit -> unit)
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery_provider:

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -23,6 +23,15 @@ type retry_loop_input =
   ; attempted_runtimes : string list
   }
 
+type declared_lane_failure =
+  | Provider_context_overflow of Keeper_state_machine.event
+  | Declared_runtime_lane_exhausted
+
+let declared_lane_failure_of_error err =
+  match context_overflow_event_of_error err with
+  | Some event -> Provider_context_overflow event
+  | None -> Declared_runtime_lane_exhausted
+
 let autonomous_yield_request ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | None -> Error (Printf.sprintf "keeper not registered: %s" keeper_name)
@@ -82,6 +91,8 @@ type ctx =
   ; shared_context : Agent_sdk.Context.t option
   ; trajectory_acc : Trajectory.accumulator
   ; turn_id : int
+  ; deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option
+  ; on_deferred_runtime_consumed : (unit -> unit) option
   }
 
 let run (ctx : ctx)
@@ -117,6 +128,8 @@ let run (ctx : ctx)
       ; event_bus_integrity_error_snapshot = _
       ; tool_completed_count_snapshot = _
       ; attempt = _attempt
+      ; deferred_runtime_lane
+      ; on_deferred_runtime_consumed
       } =
     ctx
   in
@@ -134,6 +147,7 @@ let run (ctx : ctx)
       failure before any stage may fall back, while every typed stage blocks a
       same-run fallback. *)
    let checkpoint_stage_observed = Atomic.make false in
+   let deferred_runtime_lane_ref = ref None in
   let do_run
         ~(execution : runtime_execution)
         ~run_meta
@@ -212,6 +226,12 @@ let run (ctx : ctx)
                       turn_state.degraded_retry_info)
                  ~runtime_rotation_attempts:
                    (List.rev turn_state.runtime_rotation_attempts)
+                 ?deferred_runtime_lane:
+                   (if is_retry then None else deferred_runtime_lane)
+                 ~on_runtime_retry_deferred:
+                   (fun hint -> deferred_runtime_lane_ref := Some hint)
+                 ?on_deferred_runtime_consumed:
+                   (if is_retry then None else on_deferred_runtime_consumed)
                  ~temperature:execution.temperature
                  ~trajectory_acc
                  ~is_retry
@@ -246,30 +266,7 @@ let run (ctx : ctx)
     in
     result, turn_state
   in
-  let record_runtime_rotation_attempt
-        turn_state
-        ~productive_phase_elapsed_ms
-        ?retry_phase_elapsed_ms
-        ~(from_runtime : string)
-        ~(retry : EC.degraded_retry)
-        ~(outcome : Keeper_execution_receipt.runtime_rotation_outcome)
-        (err : Agent_sdk.Error.sdk_error)
-    =
-    let attempt : Keeper_execution_receipt.runtime_rotation_attempt =
-      Keeper_unified_turn_rotation_attempt.build
-        ~recorded_at:(now_iso ())
-        ~productive_phase_elapsed_ms
-        ?retry_phase_elapsed_ms
-        ~from_runtime
-        ~retry
-        ~outcome
-        err
-    in
-    { turn_state with
-      runtime_rotation_attempts = attempt :: turn_state.runtime_rotation_attempts
-    }
-  in
-  let rec retry_loop (input : retry_loop_input) (turn_state : turn_state) =
+  let retry_loop (input : retry_loop_input) (turn_state : turn_state) =
     let { run_meta
         ; execution
         ; run_generation
@@ -279,9 +276,6 @@ let run (ctx : ctx)
         }
       =
       input
-    in
-    let execution_runtime_id =
-      execution.runtime_id
     in
     let mark_terminal_error err =
       match EC.extract_input_required err with
@@ -336,6 +330,12 @@ let run (ctx : ctx)
         meta.name;
       Ok result, turn_state
     | Error err ->
+      let turn_state =
+        match !deferred_runtime_lane_ref with
+        | Some hint ->
+          { turn_state with deferred_runtime_lane = Some hint }
+        | None -> turn_state
+      in
       let checkpoint_observed =
         not
           (Keeper_turn_driver_try_provider.same_run_retry_allowed
@@ -351,138 +351,43 @@ let run (ctx : ctx)
            current OAS contract cannot continue without admitting the input again"
           meta.name
           checkpoint_observed;
-      match
-          ( Keeper_turn_runtime_budget.plan_degraded_retry_step
-            ~base_runtime:(runtime_id_of_meta meta)
-            ~current_runtime_id:execution_runtime_id
-            ~attempted_runtimes
-            ~attempt
-            ~err
-            ~allow_retry:(fun _ -> same_run_retry_has_input_authority)
-            ~publish_cascade_resolution:
-              (fun ~runtime_id ~decision ~reason ~next_runtime ~attempt err ->
-                 Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
-                   ~keeper_name:meta.name
-                   ~runtime_id
-                   ~decision
-                   ~reason
-                   ~next_runtime
-                   ~attempt
-                   ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-                   ~error_message:(Some (Agent_sdk.Error.to_string err)))
-            ~emit_runtime_selected:
-              (fun ~runtime_id ~fallback_reason ->
-                 Keeper_metrics.emit_runtime_selected
-                   ~keeper_name:meta.name
-                   ~runtime_id
-                   ~fallback_reason)
-            ~emit_runtime_rotation:
-              (fun ~from_runtime ~to_runtime ~reason ->
-                 Keeper_metrics.emit_runtime_rotation
-                   ~keeper_name:meta.name
-                   ~from_runtime
-                   ~to_runtime
-                   ~reason)
-            ~setup_runtime:
-              (fun runtime_id ->
-                 Keeper_unified_turn_pre_dispatch.build_runtime_execution
-                   ~meta
-                   ~runtime_id)
-          , context_overflow_event_of_error err )
-        with
-        | Keeper_turn_runtime_budget.Degraded_retry_step_setup_failed
-            { retry = degraded_retry; reason = fallback_reason; fail_open_err }, _ ->
-             let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-               current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
-             in
-             let turn_state =
-               record_runtime_rotation_attempt
-                 turn_state
-                 ~productive_phase_elapsed_ms
-                 ?retry_phase_elapsed_ms
-                 ~from_runtime:execution.runtime_id
-                 ~retry:degraded_retry
-                 ~outcome:
-                   Keeper_execution_receipt.Rotation_setup_failed
-                 fail_open_err
-             in
-             Log.Keeper.warn
-               "%s: recoverable runtime failure in %s suggested \
-                degraded retry to %s (reason=%s), but retry setup \
-                failed: %s"
-               meta.name
-               execution_runtime_id
-               degraded_retry.next_runtime
-               fallback_reason
-               (short_preview
-                  (Agent_sdk.Error.to_string fail_open_err));
-             mark_terminal_error fail_open_err;
-             Error fail_open_err, turn_state
-        | Keeper_turn_runtime_budget.Degraded_retry_step_prepared
-            { retry = degraded_retry; reason = fallback_reason; next = next_execution }, _ ->
-             let next_execution_runtime_id =
-               next_execution.runtime_id
-             in
-             let turn_state =
-               if Option.is_none turn_state.retry_phase_started_at
-               then { turn_state with retry_phase_started_at = Some (Eio.Time.now clock) }
-               else turn_state
-             in
-             let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-               current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
-             in
-             let turn_state =
-               record_runtime_rotation_attempt
-                 turn_state
-                 ~productive_phase_elapsed_ms
-                 ?retry_phase_elapsed_ms
-                 ~from_runtime:execution.runtime_id
-                 ~retry:degraded_retry
-                 ~outcome:
-                   Keeper_execution_receipt.Rotation_retry_scheduled
-                 err
-             in
-             let turn_state =
-               { turn_state with degraded_retry_info = Some degraded_retry }
-             in
-             (* A rotation retry was scheduled: the runtime failed but the lane
-                stays usable and recovers on the next runtime. This is a
-                recovering, receipted event (Rotation_retry_scheduled above), not
-                a failure that stalled the lane — Info per
-                docs/spec/18-log-severity-taxonomy.md. WARN is reserved for the
-                terminal setup-failed arm above, so WARN tracks failures that did
-                not self-heal instead of narrating every rotation. *)
-             Log.Keeper.info
-               "%s: recoverable runtime failure in %s; rotation \
-               retry on runtime=%s reason=%s max_context=%d \
-                context_budget=%d primary_budget=%d \
-                requested_override=%s: %s"
-               meta.name
-               execution_runtime_id
-               next_execution_runtime_id
-               fallback_reason
-               next_execution.max_context
-               next_execution.max_context_resolution.effective_budget
-               next_execution.max_context_resolution.primary_budget
-               (match
-                  next_execution.max_context_resolution
-                    .requested_override
-                with
-                | Some requested -> string_of_int requested
-                | None -> "none")
-               (short_preview (Agent_sdk.Error.to_string err));
-             Eio.Fiber.yield ();
-             retry_loop
-               { run_meta
-               ; execution = next_execution
-               ; run_generation
-               ; attempt = 1
-               ; is_retry = true
-               ; attempted_runtimes =
-                   next_execution_runtime_id :: attempted_runtimes
-               }
-               turn_state
-        | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed, Some overflow_event ->
+      match !deferred_runtime_lane_ref with
+      | Some hint ->
+        let reason =
+          (match
+             Keeper_error_classify.recoverable_runtime_failure_reason
+               hint.failure
+           with
+           | Some reason -> reason
+           | None -> Keeper_error_classify.Deferred_runtime_lane)
+          |> Keeper_error_classify.degraded_retry_reason_to_string
+        in
+        Log.Keeper.info
+          ~keeper_name:meta.name
+          "%s: deferred frozen runtime lane suffix after checkpoint \
+           failed_runtime=%s next_runtime=%s remaining=%d reason=%s"
+          meta.name
+          hint.failed_runtime_id
+          hint.next_runtime_id
+          (List.length hint.later_runtime_ids)
+          reason;
+        mark_terminal_error err;
+        Error err, turn_state
+      | None when Option.is_some deferred_runtime_lane ->
+        Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+          ~keeper_name:meta.name
+          ~runtime_id:execution.runtime_id
+          ~decision:No_degraded_retry
+          ~reason:"frozen_runtime_suffix_exhausted"
+          ~next_runtime:None
+          ~attempt
+          ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+          ~error_message:(Some (Agent_sdk.Error.to_string err));
+        mark_terminal_error err;
+        Error err, turn_state
+      | None ->
+        (match declared_lane_failure_of_error err with
+         | Provider_context_overflow overflow_event ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id
@@ -534,18 +439,18 @@ let run (ctx : ctx)
             ~reason:"provider_context_overflow";
           mark_terminal_error err;
           Error err, turn_state
-        | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed, None ->
+         | Declared_runtime_lane_exhausted ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id
             ~decision:No_degraded_retry
-            ~reason:"terminal_error_no_degraded_retry"
+            ~reason:"declared_runtime_lane_exhausted"
             ~next_runtime:None
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
             ~error_message:(Some (Agent_sdk.Error.to_string err));
           mark_terminal_error err;
-          Error err, turn_state
+          Error err, turn_state)
   in
   (* Do not wrap the full keeper turn in a cumulative wall-clock timeout.
      Long voice/OAS turns can keep making stream or tool progress beyond the
@@ -568,3 +473,11 @@ let run (ctx : ctx)
   in
   result, turn_state
 )
+
+module For_testing = struct
+  type nonrec declared_lane_failure = declared_lane_failure =
+    | Provider_context_overflow of Keeper_state_machine.event
+    | Declared_runtime_lane_exhausted
+
+  let declared_lane_failure_of_error = declared_lane_failure_of_error
+end

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -15,6 +15,7 @@ type turn_state =
   ; current_turn_blocker_info : Keeper_meta_contract.blocker_info option
   ; last_execution : Keeper_turn_runtime_budget.runtime_execution option
   ; degraded_retry_info : Keeper_error_classify.degraded_retry option
+  ; deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option
   ; runtime_rotation_attempts : Keeper_execution_receipt.runtime_rotation_attempt list
   ; failure_reason : Keeper_turn_fsm.failure_reason option
   ; retry_phase_started_at : float option

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -14,6 +14,7 @@ type turn_state =
   ; current_turn_blocker_info : Keeper_meta_contract.blocker_info option
   ; last_execution : Keeper_turn_runtime_budget.runtime_execution option
   ; degraded_retry_info : Keeper_error_classify.degraded_retry option
+  ; deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option
   ; runtime_rotation_attempts : Keeper_execution_receipt.runtime_rotation_attempt list
   ; failure_reason : Keeper_turn_fsm.failure_reason option
   ; retry_phase_started_at : float option

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1055,6 +1055,182 @@ let test_attempt_loop_overflow_on_last_candidate_is_terminal () =
     [ "small.test_model"; "smaller.test_model" ]
     !attempts
 
+let test_checkpoint_denial_defers_exact_frozen_suffix_once () =
+  let attempts = ref [] in
+  let deferred = ref [] in
+  let err =
+    Agent_sdk.Error.Api
+      (Agent_sdk.Retry.ServerError
+         { status = 500; message = "checkpoint-observed failure" })
+  in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~allow_retry:(fun ~runtime_id:_ ~attempt:_ _ -> false)
+      ~on_retry_deferred:(fun hint -> deferred := hint :: !deferred)
+      ~runtime_id:"lane.frozen"
+      ~runtime_id_of:Fun.id
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
+        attempts := runtime_id :: !attempts;
+        Error err, None)
+      [ "runtime.a"; "runtime.b"; "runtime.c"; "runtime.d" ]
+  in
+  (match result with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "checkpoint denial must end the current run");
+  Alcotest.(check (list string))
+    "no same-run second POST"
+    [ "runtime.a" ]
+    (List.rev !attempts);
+  match List.rev !deferred with
+  | [ hint ] ->
+    Alcotest.(check string)
+      "failed runtime"
+      "runtime.a"
+      hint.Driver.failed_runtime_id;
+    Alcotest.(check (list string))
+      "frozen suffix preserved"
+      [ "runtime.b"; "runtime.c"; "runtime.d" ]
+      (Driver.deferred_runtime_ids hint)
+  | hints ->
+    Alcotest.failf "expected one deferred suffix, got %d" (List.length hints)
+
+let test_deferred_cycle_starts_at_supplied_successor_and_keeps_tail () =
+  let attempts = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"runtime.b"
+      ~runtime_id_of:Fun.id
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
+        attempts := runtime_id :: !attempts;
+        match runtime_id with
+        | "runtime.b" -> Error (retryable_network_error "b failed"), None
+        | "runtime.c" -> Ok runtime_id, None
+        | "runtime.a" ->
+          Alcotest.fail "failed lane prefix must not replay on the next cycle"
+        | other -> Alcotest.failf "unexpected runtime %s" other)
+      [ "runtime.b"; "runtime.c"; "runtime.d" ]
+  in
+  (match result with
+   | Ok runtime_id ->
+     Alcotest.(check string) "same-run tail succeeds" "runtime.c" runtime_id
+   | Error error ->
+     Alcotest.failf "expected suffix success: %s" (Agent_sdk.Error.to_string error));
+  Alcotest.(check (list string))
+    "next cycle starts at B then advances to C"
+    [ "runtime.b"; "runtime.c" ]
+    (List.rev !attempts)
+
+let test_deferred_cycle_post_checkpoint_replaces_hint_with_tail () =
+  let deferred = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~allow_retry:(fun ~runtime_id:_ ~attempt:_ _ -> false)
+      ~on_retry_deferred:(fun hint -> deferred := hint :: !deferred)
+      ~runtime_id:"runtime.b"
+      ~runtime_id_of:Fun.id
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
+        Alcotest.(check string) "only B attempted" "runtime.b" runtime_id;
+        Error (retryable_network_error "b checkpoint failure"), None)
+      [ "runtime.b"; "runtime.c"; "runtime.d" ]
+  in
+  (match result with Error _ -> () | Ok _ -> Alcotest.fail "expected B failure");
+  match List.rev !deferred with
+  | [ hint ] ->
+    Alcotest.(check (list string))
+      "replacement hint is C,D"
+      [ "runtime.c"; "runtime.d" ]
+      (Driver.deferred_runtime_ids hint)
+  | hints ->
+    Alcotest.failf "expected one replacement hint, got %d" (List.length hints)
+
+let test_single_candidate_checkpoint_failure_has_no_hint () =
+  let deferred = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~allow_retry:(fun ~runtime_id:_ ~attempt:_ _ -> false)
+      ~on_retry_deferred:(fun hint -> deferred := hint :: !deferred)
+      ~runtime_id:"runtime.only"
+      ~runtime_id_of:Fun.id
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id:_ _candidate ->
+        Error (retryable_network_error "only failed"), None)
+      [ "runtime.only" ]
+  in
+  (match result with Error _ -> () | Ok _ -> Alcotest.fail "expected failure");
+  Alcotest.(check int) "no successor means no hint" 0 (List.length !deferred)
+
+let test_deferred_hint_refs_are_not_shared () =
+  let failure = retryable_network_error "checkpoint failure" in
+  let hint =
+    Driver.For_testing.make_deferred_runtime_lane
+      ~assignment_id:"lane.one"
+      ~failed_runtime_id:"runtime.a"
+      ~next_runtime_id:"runtime.b"
+      ~later_runtime_ids:[ "runtime.c" ]
+      ~failure
+  in
+  let first = ref (Some hint) in
+  let second = ref (Some hint) in
+  Alcotest.(check bool)
+    "first owner consumes its hint"
+    true
+    (Masc.Keeper_heartbeat_loop.For_testing.consume_deferred_runtime_lane_hint
+       first
+       hint);
+  Alcotest.(check bool) "first hint cleared" true (Option.is_none !first);
+  Alcotest.(check bool)
+    "second owner remains independent"
+    true
+    (Option.is_some !second)
+
+let test_missing_deferred_successor_is_typed_error () =
+  match
+    Driver.For_testing.resolve_runtime_candidates
+      [ "runtime.definitely-missing-deferred-successor" ]
+  with
+  | Error (Agent_sdk.Error.Internal detail) ->
+    Alcotest.(check bool)
+      "missing successor is loud"
+      true
+      (String.length (String.trim detail) > 0)
+  | Error error ->
+    Alcotest.failf
+      "expected typed internal missing-successor error, got %s"
+      (Agent_sdk.Error.to_string error)
+  | Ok _ -> Alcotest.fail "missing successor unexpectedly resolved"
+
+let test_missing_deferred_head_is_consumed_once () =
+  let consumed = ref 0 in
+  let result =
+    Driver.For_testing.resolve_runtime_candidate_for_attempt
+      ~on_missing:(fun () -> incr consumed)
+      "runtime.definitely-missing-deferred-head"
+  in
+  (match result with
+   | Error (Agent_sdk.Error.Internal _) -> ()
+   | Error error ->
+     Alcotest.failf
+       "expected typed missing-head error, got %s"
+       (Agent_sdk.Error.to_string error)
+   | Ok _ -> Alcotest.fail "missing deferred head unexpectedly resolved");
+  Alcotest.(check int) "missing head consumed once" 1 !consumed
+
+let test_initial_lane_exhaustion_cannot_escape_declared_candidates () =
+  match
+    Masc.Keeper_unified_turn_execution.For_testing
+      .declared_lane_failure_of_error
+      (retryable_network_error "declared lane exhausted")
+  with
+  | Masc.Keeper_unified_turn_execution.For_testing
+      .Declared_runtime_lane_exhausted ->
+    ()
+  | Masc.Keeper_unified_turn_execution.For_testing
+      .Provider_context_overflow _ ->
+    Alcotest.fail "network exhaustion must not enter an outer catalog fallback"
+
 let () =
   Alcotest.run
     "keeper_turn_driver_failover"
@@ -1145,5 +1321,37 @@ let () =
             "context overflow on last candidate stays terminal"
             `Quick
             test_attempt_loop_overflow_on_last_candidate_is_terminal;
+          Alcotest.test_case
+            "checkpoint denial defers exact frozen suffix once"
+            `Quick
+            test_checkpoint_denial_defers_exact_frozen_suffix_once;
+          Alcotest.test_case
+            "deferred cycle starts at supplied successor and keeps tail"
+            `Quick
+            test_deferred_cycle_starts_at_supplied_successor_and_keeps_tail;
+          Alcotest.test_case
+            "deferred post-checkpoint failure replaces hint with tail"
+            `Quick
+            test_deferred_cycle_post_checkpoint_replaces_hint_with_tail;
+          Alcotest.test_case
+            "single candidate checkpoint failure has no hint"
+            `Quick
+            test_single_candidate_checkpoint_failure_has_no_hint;
+          Alcotest.test_case
+            "deferred hint refs are not shared"
+            `Quick
+            test_deferred_hint_refs_are_not_shared;
+          Alcotest.test_case
+            "missing deferred successor is typed error"
+            `Quick
+            test_missing_deferred_successor_is_typed_error;
+          Alcotest.test_case
+            "missing deferred head is consumed once"
+            `Quick
+            test_missing_deferred_head_is_consumed_once;
+          Alcotest.test_case
+            "initial lane exhaustion cannot escape declared candidates"
+            `Quick
+            test_initial_lane_exhaustion_cannot_escape_declared_candidates;
         ] );
     ]


### PR DESCRIPTION
## Summary
- preserve the exact remaining Runtime suffix when checkpoint input authority forbids a same-run retry
- consume it once at the next actual Keeper attempt, retaining it across skipped or busy cycles
- preserve original lane provenance and sticky success preference
- make missing successors loud and prevent initial or resumed lane exhaustion from escaping into the global Runtime catalog
- project queued/applied retry target from the execution receipt SSOT in FSM Hub

## Boundary
- Runtime candidates come only from the declared frozen lane
- no model, provider, tier, pricing, tools-support, or catalog-derived routing
- no new store, lease, commit, settlement, journal, or legacy migration
- capacity refusal still reaches the existing compaction recovery path

## Focused proof
- scripts/dune-local.sh build @lib/check test/test_keeper_turn_driver_failover.exe
- keeper_turn_driver_failover: 29/29 green
- FSM Hub: 58/58 green
- TypeScript typecheck green
- git diff --check
- independent adversarial review: no P0/P1
