### PR TITLE
fix(dashboard): render checkpoint load diagnostics

### DIFF
--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -221,12 +221,34 @@ export interface KeeperCheckpointSummary {
   } | null
 }
 
+export interface KeeperCheckpointCurrentError {
+  kind: 'store_error' | 'parse_error' | 'io_error' | 'sdk_other_error' | string
+  detail: string
+}
+
+export interface KeeperCheckpointHistoryError {
+  snapshot_id: string
+  source_kind: 'oas_history' | string
+  is_current: false
+  path: string
+  file_stat: {
+    size_bytes?: number
+    mtime?: number
+  } | null
+  status: 'missing' | 'unavailable'
+  error_kind: 'not_found' | 'store_error' | 'parse_error' | 'io_error' | 'sdk_other_error' | string
+  error_detail: string | null
+}
+
 export interface KeeperCheckpointInventory {
   keeper: string
   trace_id: string
   session_dir: string
   current: KeeperCheckpointSummary | null
+  current_status: 'available' | 'missing' | 'unavailable'
+  current_error: KeeperCheckpointCurrentError | null
   history: KeeperCheckpointSummary[]
+  history_errors: KeeperCheckpointHistoryError[]
 }
 
 interface KeeperCheckpointDeleteResponse {

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1220,7 +1220,10 @@ describe('keeper lifecycle', () => {
         trace_id: 'trace-keeper-test',
         session_dir: '/tmp/trace-keeper-test',
         current: null,
+        current_status: 'missing',
+        current_error: null,
         history: [],
+        history_errors: [],
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1238,7 +1241,9 @@ describe('keeper lifecycle', () => {
       }),
     )
     expect(result.trace_id).toBe('trace-keeper-test')
+    expect(result.current_status).toBe('missing')
     expect(result.history).toEqual([])
+    expect(result.history_errors).toEqual([])
   })
 
   it('posts selected OAS history snapshot ids for deletion', async () => {
@@ -1254,7 +1259,10 @@ describe('keeper lifecycle', () => {
           trace_id: 'trace-keeper-test',
           session_dir: '/tmp/trace-keeper-test',
           current: null,
+          current_status: 'missing',
+          current_error: null,
           history: [],
+          history_errors: [],
         },
       }), {
         status: 200,

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -102,6 +102,8 @@ export {
 
 // --- Keeper lifecycle (split to keeper-lifecycle.ts) ---
 export type {
+  KeeperCheckpointCurrentError,
+  KeeperCheckpointHistoryError,
   KeeperCheckpointSummary,
   KeeperCheckpointInventory,
   BulkKeeperDirectiveAction,

--- a/dashboard/src/components/keeper-detail-history.test.ts
+++ b/dashboard/src/components/keeper-detail-history.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment happy-dom
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render } from "preact"
+import { act } from "preact/test-utils"
 import { html } from "htm/preact"
 import {
   filterCheckpointHistory,
+  KeeperCheckpointPanel,
   lineageTransitionLabel,
   MonoBadge,
 } from "./keeper-detail-history"
@@ -93,5 +95,64 @@ describe("lineageTransitionLabel", () => {
 
   it("handles zero parent generation", () => {
     expect(lineageTransitionLabel(0, 1)).toBe("gen 0 -> gen 1")
+  })
+})
+
+describe("KeeperCheckpointPanel diagnostics", () => {
+  it("renders typed current and history checkpoint failures separately", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      keeper: "keeper-test",
+      trace_id: "trace-test",
+      session_dir: "/tmp/trace-test",
+      current: null,
+      current_status: "unavailable",
+      current_error: {
+        kind: "parse_error",
+        detail: "invalid current checkpoint",
+      },
+      history: [],
+      history_errors: [{
+        snapshot_id: "history-broken.json",
+        source_kind: "oas_history",
+        is_current: false,
+        path: "/tmp/trace-test/history-broken.json",
+        file_stat: { size_bytes: 19 },
+        status: "unavailable",
+        error_kind: "io_error",
+        error_detail: "permission denied",
+      }],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    try {
+      await act(async () => {
+        render(
+          html`<${KeeperCheckpointPanel}
+            keeperName="keeper-test"
+            refreshToken=${0}
+          />`,
+          container,
+        )
+      })
+
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("checkpoint 읽기 실패")
+      })
+      expect(container.textContent).toContain("parse_error")
+      expect(container.textContent).toContain("invalid current checkpoint")
+      expect(container.textContent).toContain("읽지 못한 checkpoint history")
+      expect(container.textContent).toContain("history-broken.json")
+      expect(container.textContent).toContain("io_error")
+      expect(container.textContent).not.toContain("저장된 checkpoint 없음")
+    } finally {
+      render(null, container)
+      document.body.removeChild(container)
+      globalThis.fetch = originalFetch
+    }
   })
 })

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -8,6 +8,8 @@ import { requestConfirm } from './common/confirm-dialog'
 import {
   deleteKeeperHistorySnapshots,
   fetchKeeperCheckpoints,
+  type KeeperCheckpointCurrentError,
+  type KeeperCheckpointHistoryError,
   type KeeperCheckpointInventory,
   type KeeperCheckpointSummary,
 } from '../api/keeper'
@@ -67,11 +69,31 @@ export function filterCheckpointHistory(
 function CheckpointSummaryCard({
   title,
   summary,
+  status,
+  error,
 }: {
   title: string
   summary: KeeperCheckpointSummary | null
+  status: KeeperCheckpointInventory['current_status']
+  error: KeeperCheckpointCurrentError | null
 }) {
   if (!summary) {
+    if (status === 'unavailable') {
+      return html`
+        <div
+          class="rounded-[var(--r-1)] border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-xs text-[var(--rose-light)] v2-monitoring-card"
+          role="alert"
+        >
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="font-semibold">${title}: checkpoint 읽기 실패</span>
+            <${SnapshotBadge} tone="bad">${error?.kind ?? 'unknown'}</${SnapshotBadge}>
+          </div>
+          ${error?.detail
+            ? html`<div class="mt-2 break-words font-mono text-2xs">${error.detail}</div>`
+            : null}
+        </div>
+      `
+    }
     return html`
       <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-3 text-xs text-[var(--color-fg-muted)] v2-monitoring-card">
         ${title}: 저장된 checkpoint 없음
@@ -95,6 +117,46 @@ function CheckpointSummaryCard({
       ${summary.latest_preview
         ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--color-fg-primary)]">${summary.latest_preview}</div>`
         : null}
+    </div>
+  `
+}
+
+function CheckpointHistoryFailures({
+  failures,
+}: {
+  failures: readonly KeeperCheckpointHistoryError[]
+}) {
+  if (failures.length === 0) return null
+  return html`
+    <div
+      class="rounded-[var(--r-1)] border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 v2-monitoring-panel"
+      role="alert"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-xs font-semibold text-[var(--rose-light)]">
+          읽지 못한 checkpoint history
+        </span>
+        <${SnapshotBadge} tone="bad">${failures.length}</${SnapshotBadge}>
+      </div>
+      <div class="mt-2 flex flex-col gap-2">
+        ${failures.map(failure => html`
+          <div
+            class="rounded-[var(--r-1)] border border-[var(--bad-30)] bg-[var(--color-bg-surface)] px-2.5 py-2 text-2xs"
+            key=${failure.snapshot_id}
+          >
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="font-mono text-[var(--color-fg-primary)]">${failure.snapshot_id}</span>
+              <${SnapshotBadge} tone=${failure.status === 'missing' ? 'warn' : 'bad'}>
+                ${failure.error_kind}
+              </${SnapshotBadge}>
+            </div>
+            ${failure.error_detail
+              ? html`<div class="mt-1 break-words font-mono text-[var(--rose-light)]">${failure.error_detail}</div>`
+              : null}
+            <div class="mt-1 break-all font-mono text-[var(--color-fg-muted)]">${failure.path}</div>
+          </div>
+        `)}
+      </div>
     </div>
   `
 }
@@ -198,6 +260,17 @@ export function KeeperCheckpointPanel({
     `
   }
 
+  if (!inventory) {
+    return html`
+      <div
+        class="rounded-[var(--r-1)] border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-xs text-[var(--rose-light)] v2-monitoring-panel"
+        role="alert"
+      >
+        checkpoint inventory 응답이 없습니다.
+      </div>
+    `
+  }
+
   return html`
     <div class="flex flex-col gap-3 v2-monitoring-panel">
       <div class="flex items-center justify-between gap-3 v2-monitoring-toolbar">
@@ -221,8 +294,12 @@ export function KeeperCheckpointPanel({
 
       <${CheckpointSummaryCard}
         title="현재 active checkpoint"
-        summary=${inventory?.current ?? null}
+        summary=${inventory.current}
+        status=${inventory.current_status}
+        error=${inventory.current_error}
       />
+
+      <${CheckpointHistoryFailures} failures=${inventory.history_errors} />
 
       <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] v2-monitoring-panel">
         <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--color-border-default)] px-3 py-2 v2-monitoring-toolbar">


### PR DESCRIPTION
## Summary
- render current checkpoint missing as a neutral empty state
- render current checkpoint unavailable as a red typed diagnostic with exact kind and detail
- keep failed history loads separate from normal checkpoint summaries
- preserve the additive checkpoint inventory API as the sole status source

## Boundary
- no dashboard inference from log prose or file presence
- no second mutable state or repair action
- source API fields map directly to wording, tone, and diagnostic rows

## Focused proof
- KeeperCheckpointPanel and keeper API Vitest: 59/59 green
- TypeScript typecheck green
- git diff --check
- actual Vite dashboard rendered in headless Chrome; live screen correctly showed the still-deployed old build and 7/8 fleet state
