### PR TITLE
fix(keeper): playground 캐시 부재를 관측 실패로 보고하지 않음 (라이브 66회/15분 노이즈)

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -312,6 +312,13 @@ let playground_repo_entry_json ~(source : string) ~(repo_name : string)
 let cached_playground_repo_entries playground_abs =
   let cache_path = Filename.concat playground_abs ".playground_state.json" in
   try
+    (* An absent cache is the normal state before the first observation writes
+       one, so it is not an observation failure; only a present-but-unreadable
+       cache is. The existence check stays inside the handler because
+       [Fs_compat.file_exists] can itself raise [Sys_error], and that raise is a
+       genuine failure. [observed_is_dir] draws the same line for directories. *)
+    if not (Fs_compat.file_exists cache_path) then []
+    else
     match Yojson.Safe.from_file cache_path with
     | `Assoc _ as json -> (
         match Json_util.assoc_member_opt "repos" json with


### PR DESCRIPTION
## 문제

`cached_playground_repo_entries` 가 **"캐시 파일이 아직 없음"** 과 **"파일이 있는데 못 읽음"** 을 같은 `Sys_error` 핸들러로 처리해 둘 다 WARN 을 냅니다. 캐시 부재는 첫 관측이 캐시를 쓰기 전의 **정상 상태**입니다.

### 라이브 실측 (22:57 KST, 8-keeper fleet)

**15분에 66회 (~4.4/분)** — 로그 최다 라인입니다.

```
playground cache observation failed
  path=/Users/dancer/me/.masc/playground/lane-smith/.playground_state.json
  error=... No such file or directory
```

`/Users/dancer/me/.masc/playground/` 아래 `.playground_state.json` 은 **0개**입니다. 이 노이즈가 keeper 의 실제 tool_call·에러 라인을 덮고 있었습니다 (fleet 상태 진단 시 1위로 올라와 정작 필요한 신호를 가림).

## 수정

```ocaml
 let cached_playground_repo_entries playground_abs =
   let cache_path = Filename.concat playground_abs ".playground_state.json" in
   try
+    if not (Fs_compat.file_exists cache_path) then []
+    else
     match Yojson.Safe.from_file cache_path with
     ...
   with
   | Sys_error error -> Log.Keeper.warn "playground cache observation failed ..."
```

존재 확인을 **핸들러 앞이 아니라 안에** 둔 이유: `Fs_compat.file_exists` 자체가 `Sys_error` 를 던질 수 있고, 그 raise 는 진짜 실패라 계속 경고해야 합니다. 앞에 두면 미포착 예외가 됩니다.

같은 파일의 `observed_is_dir` (`keeper_sandbox_control.ml:266-273`) 가 디렉터리에 대해 이미 정확히 이 선을 긋고 있어 관용구를 맞췄습니다.

## 동작 변화 없음

호출자 관점에서는 그대로입니다 — 부재 시 이미 `[]` 를 반환했고 여전히 `[]` 입니다. **로그 스트림만** 바뀝니다.

- 있지만 못 읽는 캐시 → 여전히 WARN
- 잘못된 JSON → 자기 핸들러로 여전히 WARN
- 없는 캐시 → 조용히 `[]`

## 테스트 없음 — 이유

효과가 **전부 로그 스트림에만** 있습니다. 그리고:

- 이 저장소에 로그 캡처 테스트 설비가 없습니다 (`Log.set_sink` / `log_capture` / `Log.For_testing` 를 lib/ test/ 전체 검색 → 0건)
- `cached_playground_repo_entries` 는 비공개이고, 테스트를 위해 노출하는 것은 test backdoor 입니다
- 이 모듈엔 기존 playground 관측 테스트가 없어, 6줄 수정에 `Workspace.config` + `keeper_meta` 픽스처를 새로 짓는 것은 비례가 맞지 않습니다

### 검증 조건 (배포 후 라이브)

```bash
L=~/.masc/logs/system_log_$(date +%Y-%m-%d).jsonl
# 없는 파일에 대한 경고가 0 이어야 함
rg -c "playground cache observation failed" "$L"

# 반대 방향: 읽을 수 없는 캐시는 여전히 경고해야 함
# (keeper 하나의 playground 에 chmod 000 캐시를 두고 관측 유도)
```

두 방향 모두 확인해야 유효합니다 — 한쪽만 보면 조용히 삼키는 것과 구분되지 않습니다.

## 변경

`lib/keeper/keeper_sandbox_control.ml` 1파일, `+7`.

**로컬 빌드 미실행.** CI 가 게이트입니다.

RFC-WAIVED: 단일 함수의 부재/실패 구분. 신규 동작 없음, 호출자 계약 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f3e76ZnzDRwjkNe7EZxiE
