### PR TITLE
refactor(keeper): base= 상속 로직 사본 제거 (Python 재귀 구현 2곳 + 문서)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Removed
+- **Breaking (keeper config schema)**: removed the keeper TOML `base = "..."` inheritance mechanism. `keeper.base` is no longer a recognised key, `config/keepers/base.toml` and `presets/classic/keepers/base.toml` are deleted, and every keeper TOML now states its own values. Effective per-keeper profiles are unchanged: each formerly inherited value was written out explicitly (`config/keepers/{taskmaster,issue_king,verifier,adversary}.toml`, `presets/classic/keepers/{backend,frontend,qa,tech_lead}.toml`).
+  - Migration order matters. A keeper TOML that still carries `base = "..."` after this build is deployed does **not** fail to boot: `keeper.base` becomes an unrecognised key, so the keeper loads while silently losing every value it used to inherit, with one `Log.Keeper.warn`, a `masc_config_unknown_keys_ignored_total` increment, and a row on the dashboard drift surface. `/health` additionally reports `keeper_config_schema: config_unknown_keys` with status `blocked` and `operator_action_required: true` for the whole server (`server_routes_http_runtime.ml:479-488`). Flatten the deployed TOMLs first, then deploy this build.
+  - `merge_keeper_profile_defaults` and `merge_string_list` are retained: they still implement the persona `profile.json` → keeper TOML overlay (`keeper_types_profile.ml:244`), which is a separate mechanism. Note `merge_string_list` is replace-if-non-empty, not union.
+
 ### Changed
 - Bumped the OAS Agent SDK pin to `ca7a02b7` (oas#2766). Supports non-standard stop_reason provider dialects (e.g. `context_length_exceeded`, `max_context_length`) and preserves empty completion stop_reason in GLM parser to prevent orphan retries on context overflow.
 - Bumped the OAS Agent SDK pin to `c1eaa88b` (oas#2764). Allows empty delta `id` and `name` strings as `Ok None` in the SSE stream parser to prevent stream failure crashes on GLM-5-Turbo and OpenAI-compatible backends emitting empty initial delta fragments.

--- a/docs/ROOT-CAUSE-Execute-args-rejection.md
+++ b/docs/ROOT-CAUSE-Execute-args-rejection.md
@@ -139,9 +139,15 @@ non-canonical field that reaches MASC is rejected explicitly.
 
 ### 4.5 Persona / prompt examples
 
-The `issue_king` persona (`config/personas/issue_king/profile.json`) and base keeper config (`config/keepers/base.toml`) explicitly instruct:
+The `issue_king` persona (`config/personas/issue_king/profile.json`) explicitly instructs:
 
 > "PR 생성은 준비된 작업 브랜치에서 git push 후 별도 실행 축이 아니라 Execute typed argv 경로로 수행한다."
+
+This section previously also cited `config/keepers/base.toml` as a second source of that
+instruction. That file no longer exists: the keeper TOML `base = "..."` inheritance
+mechanism was removed and every keeper TOML now carries its own `instructions` block
+verbatim. When auditing prompt text, grep every file under `config/keepers/`; there is no
+single shared prompt file to check.
 
 This is correct, but if any few-shot example, memory, or older prompt template still shows an `args` or `command` wrapper, the model may copy it.
 
@@ -222,9 +228,9 @@ Search `.masc/trajectories/`, `logs/`, or telemetry for the affected `issue_king
 
 | File | Why |
 |---|---|
-| `config/keepers/issue_king.toml` | Provider/runtime binding for `issue_king` |
+| `config/keepers/issue_king.toml` | Provider/runtime binding for `issue_king`, and its own `instructions` block |
 | `config/personas/issue_king/profile.json` | Prompt examples mentioning Execute |
-| `config/keepers/base.toml` | Base prompt examples |
+| `config/keepers/*.toml` | Prompt examples — each keeper carries its own `instructions`; the former shared `base.toml` is gone |
 | `oas/lib/llm_provider/backend_gemini.ml` | If provider is Gemini, check `args` unwrap |
 | `oas/lib/llm_provider/backend_openai_parse.ml` | If provider is OpenAI-compatible |
 | `oas/lib/llm_provider/backend_anthropic.ml` | If provider is Anthropic |

--- a/docs/audit-responses/2026-05-05-integrated-improvement-design.md
+++ b/docs/audit-responses/2026-05-05-integrated-improvement-design.md
@@ -14,6 +14,20 @@
   Semaphore wait O(K²), Dashboard N+1 O(K×N), Credential starvation O(K),
   Config 파일 O(K) 폭발. "땜빵을 땜빵으로 막지 말고" 근본 재설계.
 
+## Superseded 2026-07-27 — keeper TOML `base =` 상속 제거
+
+이 문서가 2026-05-05 에 확인한 내용 중, keeper TOML 의 `base = "base.toml"`
+상속 기제에 근거한 rebuttal 은 더 이상 성립하지 않습니다. 해당 기제는
+2026-07-27 에 제거되었습니다: `config/keepers/base.toml` 삭제, loader 의
+`keeper.base` 해석 삭제, 모든 keeper TOML 이 자기 값을 직접 갖는 형태로
+flatten. 따라서 `keeper.base` 는 이제 **unknown key** 로 취급되어 WARN +
+drift surface 에 보고됩니다 — audit 이 원래 주장했던 "unknown key 경고"
+쪽이 지금은 맞습니다.
+
+영향받는 행: §1-4 전체, §2 요구사항 2 첫 행, §2 요구사항 3 첫 행,
+§4-1 `keeper.base` 행, Phase 2 action item 11. 각 행에 `— superseded
+2026-07-27` 를 붙였습니다. 원문 판정은 작성 시점 기록으로 보존합니다.
+
 ## Why this response document
 
 이 audit은 매우 야심찬 통합 설계서이며, 정량 클레임 다수(turn slot 1, keeper
@@ -121,12 +135,19 @@ GitHub identity materialization은 현재 설계 대상이 아니다. audit이 �
 | 클레임 | 실제 | 분류 |
 |--------|------|------|
 | `config/keepers/`에 14개 .toml 파일 | **6개** (`base.toml`, `issue_king.toml`, `masc-improver.toml`, `ramarama.toml`, `sangsu.toml`, `taskmaster.toml`) | **D** |
-| 36개로 확장 → 36개 파일 | base+overrides 패턴 이미 적용됨 — `sangsu.toml` line 2: `base = "base.toml"` (overrides 4 줄) | **D** |
-| "5개 keeper 파일을 base+overrides로 축소 필요"의 근거 | 이미 5 persona × ~5 line override + 1 base.toml 구조 | **D** |
+| 36개로 확장 → 36개 파일 | base+overrides 패턴 이미 적용됨 — `sangsu.toml` line 2: `base = "base.toml"` (overrides 4 줄) — superseded 2026-07-27 | **D** |
+| "5개 keeper 파일을 base+overrides로 축소 필요"의 근거 | 이미 5 persona × ~5 line override + 1 base.toml 구조 — superseded 2026-07-27 | **D** |
 
 **§1-4 결과**: audit의 가장 명백한 stale. 5 persona file은 이미 minimal
 override 형태이고 36-keeper로 늘어나도 1 line 추가 수준. base+overrides는
 이미 land.
+
+> superseded 2026-07-27: base+overrides 는 land 된 뒤 제거되었다. 측정
+> 결과 상속이 실제로 전달한 값은 거의 없었다(live fleet 17 children 중
+> `instructions` 상속 1건, `autoboot_enabled` 0건). 지금은 keeper TOML 당
+> 파일 수가 곧 keeper 수이고, 각 파일이 자기 값을 전부 갖는다. 즉 이
+> 행이 반박했던 "파일 수 O(K)" 쪽이 현재 구조다 — 단, 그것을 비용이
+> 아니라 명시성으로 택한 결정이다.
 
 ### §1-5 Metric/Telemetry: O(K²) 콜백
 
@@ -156,7 +177,7 @@ override 형태이고 36-keeper로 늘어나도 1 line 추가 수준. base+overr
 
 | 클레임 | 실제 | 분류 |
 |--------|------|------|
-| `unknown keys: keeper.base` 경고 | **경고 없음으로 확인됨**: `lib/keeper/keeper_types_profile.ml:1237` 에서 `keeper.base` 를 base inheritance pointer 로 별도 처리하고, 1253 줄에서 `unknown_toml_keys` 리스트에서 명시적으로 filter out (`k <> "keeper.base"`). 즉 `keeper.base` 키는 valid key 로 인정되며 warning 발생 시점이 없음 | **D** |
+| `unknown keys: keeper.base` 경고 | **경고 없음으로 확인됨**: `lib/keeper/keeper_types_profile.ml:1237` 에서 `keeper.base` 를 base inheritance pointer 로 별도 처리하고, 1253 줄에서 `unknown_toml_keys` 리스트에서 명시적으로 filter out (`k <> "keeper.base"`). 즉 `keeper.base` 키는 valid key 로 인정되며 warning 발생 시점이 없음 — **superseded 2026-07-27: 인용된 코드는 삭제됨. `keeper.base` 는 이제 unknown key 로 WARN + drift 보고됨(audit 쪽이 맞음)** | **D → 현재 무효** |
 | 죽은 필드 (`work_discovery_sources`, `retired_git_author_config`, etc.) | active cleanup 트랙: **#13091 (drop dead persona-schema computed signals -6 LOC)**, **#13076 (unexport internal-only helpers across 4 components)**, **#13070 (-655 LOC dead ide-editor-mock)**, **#13071 (-40 LOC orphans)** — 같은 axis 매주 진행 | **B** |
 | `masc persona create` CLI + validate | 미구현 | **C — design idea** |
 
@@ -166,7 +187,7 @@ override 형태이고 36-keeper로 늘어나도 1 line 추가 수준. base+overr
 
 | 클레임 | 실제 | 분류 |
 |--------|------|------|
-| 모든 필드가 TOML에 노출됨 | sangsu.toml 실제 5줄 (basic 필드만) — base.toml에 default 응집 | **D — already minimal** |
+| 모든 필드가 TOML에 노출됨 | sangsu.toml 실제 5줄 (basic 필드만) — base.toml에 default 응집 — **superseded 2026-07-27: base.toml 삭제, default 응집 없음. 각 keeper TOML 이 자기 값을 명시** | **D → 현재 무효** |
 | `--advanced` 옵션 필요 | 5 persona file이 모두 minimal override임을 감안하면 advanced disclosure는 unprioritized | **C** |
 
 **§2-3 결과**: 현재 config는 이미 minimal. Progressive disclosure는 향후 CLI
@@ -212,7 +233,7 @@ candidate (RFC-0029)**.
 
 | 필드 | audit 클레임 | 실제 | 분류 |
 |------|-------------|------|------|
-| `keeper.base` | 죽음 (unknown key 경고) | sangsu.toml line 2가 실제 사용 — base.toml inheritance 선언 | **D — false** |
+| `keeper.base` | 죽음 (unknown key 경고) | sangsu.toml line 2가 실제 사용 — base.toml inheritance 선언 — **superseded 2026-07-27: 기제 제거됨. audit 의 "unknown key 경고" 가 현재 동작** | **D → 현재 audit 이 맞음** |
 | `work_discovery_sources` | 죽음, `work.source`로 대체 | sangsu.toml line 4가 실제 사용. 코드 caller 확인 필요 | TBD |
 | `retired_git_author_config` | 죽음, 항상 `"retired_credential_config"` | active cleanup 후보 | **C** |
 | retired nested tool-access preset field | 중복 with `tools.preset` | sangsu.toml line 8 실제 사용. `tools.preset`은 audit의 가정 키 | **D — false** |
@@ -274,7 +295,7 @@ cleanup 트랙에 추가 가능.
 | 8 | Turn slot 1개 → K/2개 | **D** | 이미 32 default + env-tunable |
 | 9 | Semaphore → Token Bucket | **B** | RFC-0026/0027 active axis (memory `feedback_semaphore_tier_is_architectural_anti_pattern.md`) |
 | 10 | Dashboard N+1 → batch query | **C** | 진짜 design improvement. SQL 제안은 스택 mismatch — RFC-0029 후보 |
-| 11 | Config TOML 14개 → base+overrides 2개 | **D** | 이미 적용됨 (5 persona × `base = "base.toml"`) |
+| 11 | Config TOML 14개 → base+overrides 2개 | **D → 현재 무효** | 이미 적용됨 (5 persona × `base = "base.toml"`) — superseded 2026-07-27: 기제 제거, 파일당 self-contained |
 
 ### Phase 3: 필드 정리
 

--- a/lib/dashboard/dashboard_http_keeper.mli
+++ b/lib/dashboard/dashboard_http_keeper.mli
@@ -35,9 +35,12 @@ val keeper_count : Workspace.config -> int
 (** Total keepers visible in [config.base_path] meta. *)
 
 val configured_keeper_count : Workspace.config -> int
-(** Total materializable declarative runtime keeper profiles discovered from
-    keeper TOML. Loader-level templates are excluded only when they do not opt
-    into runtime materialization, e.g. via [autoboot_enabled=true]. *)
+(** Number of distinct keeper names discovered from [*.toml] in the keepers
+    config dir. Every file counts, including ones that fail to load (their name
+    falls back to the filename stem); no filename or [autoboot_enabled]
+    filtering happens here. The materializability-filtered view is
+    [materializable_configured_keeper_names] in
+    [server_routes_http_runtime_fleet_scan]. *)
 
 val keeper_names : Workspace.config -> string list
 (** Keeper names visible in [config.base_path] meta. *)

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -170,33 +170,17 @@ def load_toml(path: Path) -> dict[str, Any]:
     return data
 
 
-def merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
-    merged = dict(base)
-    for key, value in overlay.items():
-        if isinstance(value, dict) and isinstance(merged.get(key), dict):
-            merged[key] = merge_dicts(merged[key], value)
-        else:
-            merged[key] = value
-    return merged
+def load_keeper_config(path: Path) -> dict[str, Any]:
+    """Read one keeper TOML's [keeper] table.
 
-
-def load_keeper_config(path: Path, seen: set[Path] | None = None) -> dict[str, Any]:
-    seen = set() if seen is None else seen
-    resolved = path.resolve()
-    if resolved in seen:
-        raise ValueError(f"{path}: cyclic keeper.base include")
-    seen.add(resolved)
-
+    Keeper TOMLs are self-contained: there is no cross-file inheritance, so the
+    file's own [keeper] table is the whole effective config. This mirrors
+    lib/keeper/keeper_types_profile_toml_io.ml inspect_keeper_toml.
+    """
     raw = load_toml(path)
     keeper = raw.get("keeper")
     if not isinstance(keeper, dict):
         return {}
-
-    base_name = keeper.get("base")
-    if isinstance(base_name, str) and base_name.strip():
-        base_path = path.parent / base_name
-        base_keeper = load_keeper_config(base_path, seen)
-        return merge_dicts(base_keeper, keeper)
     return keeper
 
 
@@ -1155,9 +1139,9 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
     if not config_dir.is_dir():
         raise SystemExit(f"keeper config dir not found: {config_dir}")
 
-    config_paths = sorted(
-        path for path in config_dir.glob("*.toml") if path.name != "base.toml"
-    )
+    # Every *.toml in the keepers dir is a keeper, matching discover_keepers_toml
+    # in lib/keeper/keeper_types_profile_toml_io.ml. No filename is reserved.
+    config_paths = sorted(config_dir.glob("*.toml"))
     keepers = [
         audit_keeper(
             base_path=base_path,

--- a/scripts/harness/workload/keeper_product_design_board_reprobe.sh
+++ b/scripts/harness/workload/keeper_product_design_board_reprobe.sh
@@ -299,22 +299,9 @@ except ModuleNotFoundError:
 root = pathlib.Path(sys.argv[1])
 
 
-def merge_dicts(base, overlay):
-    merged = dict(base)
-    for key, value in overlay.items():
-        if isinstance(value, dict) and isinstance(merged.get(key), dict):
-            merged[key] = merge_dicts(merged[key], value)
-        else:
-            merged[key] = value
-    return merged
-
-
-def load_keeper_config(path, seen=None):
-    seen = set() if seen is None else seen
-    resolved = path.resolve()
-    if resolved in seen:
-        return {}
-    seen.add(resolved)
+# Keeper TOMLs are self-contained: no cross-file inheritance, so the file's own
+# [keeper] table is the whole effective config, and every *.toml is a keeper.
+def load_keeper_config(path):
     try:
         raw = tomllib.loads(path.read_text())
     except Exception:
@@ -322,16 +309,11 @@ def load_keeper_config(path, seen=None):
     keeper = raw.get("keeper")
     if not isinstance(keeper, dict):
         return {}
-    base_name = keeper.get("base")
-    if isinstance(base_name, str) and base_name.strip():
-        return merge_dicts(load_keeper_config(path.parent / base_name, seen), keeper)
     return keeper
 
 
 names = []
 for path in sorted(root.glob("*.toml")):
-    if path.name == "base.toml":
-        continue
     keeper = load_keeper_config(path)
     if keeper.get("sandbox_profile") != "docker":
         continue

--- a/scripts/seed-team.sh
+++ b/scripts/seed-team.sh
@@ -92,11 +92,11 @@ while IFS= read -r rel || [ -n "$rel" ]; do
   dest="$CONFIG_DIR/$rel"
   [ -f "$src" ] || die "manifest lists missing file: $rel (expected $src)"
 
-  # Track bootable keepers for the summary (keepers/<name>.toml, excluding base).
+  # Track bootable keepers for the summary. Every keepers/<name>.toml is a
+  # keeper; no filename is reserved for shared defaults.
   case "$rel" in
     keepers/*.toml)
-      stem="$(basename "$rel" .toml)"
-      [ "$stem" = "base" ] || keeper_names+=("$stem")
+      keeper_names+=("$(basename "$rel" .toml)")
       ;;
   esac
 


### PR DESCRIPTION
## 목표

`#25949` (상속 메커니즘 제거) 의 후속. `lib/` 밖에 남아 있던 **같은 로직의 사본** 을 제거합니다.

## 의미론 사본이 3개였습니다

| 위치 | 구현 |
|---|---|
| `lib/keeper/keeper_types_profile_toml_io.ml` | **1단계** 해석 (#25949 에서 제거됨) |
| `scripts/audit-keeper-fleet-readiness.py:190-200` | **재귀** + 순환 include 가드 |
| `scripts/harness/workload/keeper_product_design_board_reprobe.sh:320-333` | 자체 merge |

그리고 **서로 달랐습니다**. Python 쪽은 `base` 를 재귀적으로 따라가며 `cyclic keeper.base include` 를 검출했고, OCaml 은 정확히 한 단계만 해석했습니다. 즉 같은 TOML 을 두 도구가 다르게 읽을 수 있었습니다.

죽은 분기로 남기지 않고 둘 다 제거합니다.

## 변경

```
 CHANGELOG.md                                       |  5 ++++
 docs/ROOT-CAUSE-Execute-args-rejection.md          | 12 ++++++--
 docs/audit-responses/2026-05-05-...design.md       | 33 +++++++++++++++++----
 lib/dashboard/dashboard_http_keeper.mli            |  9 ++++--
 scripts/audit-keeper-fleet-readiness.py            | 34 ++++++----------------
 scripts/harness/.../keeper_product_design_board_reprobe.sh | 24 ++-----------
 scripts/seed-team.sh                               |  6 ++--
 7 files changed, 62 insertions(+), 61 deletions(-)
```

- `seed-team.sh`: 부팅 목록에서 `base` stem 을 제외하던 코드 제거 (파일이 없어졌으므로 불필요)
- `dashboard_http_keeper.mli`: `configured_keeper_count` 주석이 "loader-level template 은 runtime materialization 을 opt-in 하지 않으면 제외" 라고 설명했는데, 이제 loader-level template 자체가 없습니다. 함수가 **실제로 세는 것** 을 기술하도록 정정
- 문서 2건: `config/keepers/base.toml` 을 살아있는 소스로 인용하던 부분 정정. 주변 분석은 여전히 유효하므로 삭제가 아니라 수정

## 경위 (정직하게)

이 커밋은 원래 `#25949` 브랜치에 push 됐는데, 그 PR 이 이미 squash merge 된 뒤였습니다. squash merge 후 브랜치에 추가된 커밋은 main 에 도달하지 않으므로 고아가 됐고, 현재 main (`61b7c7c358`) 위로 cherry-pick 해 이 PR 로 복구했습니다.

## 검증 상태

**로컬 빌드 미실행.** CI 가 게이트입니다.

RFC-WAIVED: 제거된 메커니즘의 잔여 사본 정리. 신규 동작 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f3e76ZnzDRwjkNe7EZxiE
