### PR TITLE
fix(goal): complete verifier metric from approved task

### DIFF
--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -574,6 +574,59 @@ let transition_task_outcome_r
             Masc_domain.task_status_is_done new_status
             && not (Masc_domain.task_status_is_done task.task_status)
           in
+          (* A verifier-approved task is the event counted by the
+             [verifier_approved_done_tasks] Goal metric. Keep this feedback at
+             the committed task transition: the task outcome remains
+             authoritative even if the separate Goal write fails. The current
+             metric contract intentionally supports the MVP target of one
+             verified task without introducing a second completion ledger. *)
+          (match action, new_status with
+           | Masc_domain.Approve_verification, Masc_domain.Done _
+             when completes_task ->
+             let linked_goal_ids =
+               Workspace_goal_index.read_goal_task_links config
+               |> List.filter_map (fun (goal_id, task_ids) ->
+                 if List.mem task_id task_ids then Some goal_id else None)
+             in
+             List.iter
+               (fun goal_id ->
+                 match Goal_store.get_goal config ~goal_id with
+                 | Some
+                     { Goal_store.phase = Goal_phase.Executing
+                     ; metric = Some "verifier_approved_done_tasks"
+                     ; target_value = Some "1"
+                     ; _
+                     } ->
+                   (match
+                      Goal_store.update_goal config ~goal_id (fun goal ->
+                        { goal with
+                          phase = Goal_phase.Completed
+                        ; last_review_note =
+                            Some
+                              (Printf.sprintf
+                                 "Verifier-approved task %s completed the goal."
+                                 task_id)
+                        })
+                    with
+                    | Ok _ -> ()
+                    | Error e ->
+                      Log.TaskState.warn
+                        "verifier-approved task committed but linked Goal update \
+                         failed (task=%s goal=%s): %s"
+                        task_id
+                        goal_id
+                        e)
+                 | Some _
+                 | None -> ())
+               linked_goal_ids
+           | Masc_domain.Claim, _
+           | Masc_domain.Start, _
+           | Masc_domain.Done_action, _
+           | Masc_domain.Cancel, _
+           | Masc_domain.Release, _
+           | Masc_domain.Submit_for_verification, _
+           | Masc_domain.Reject_verification, _
+           | Masc_domain.Approve_verification, _ -> ());
           let phase_duration_ms () =
             Some
               (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -583,42 +583,59 @@ let transition_task_outcome_r
           (match action, new_status with
            | Masc_domain.Approve_verification, Masc_domain.Done _
              when completes_task ->
-             let linked_goal_ids =
-               Workspace_goal_index.read_goal_task_links config
-               |> List.filter_map (fun (goal_id, task_ids) ->
-                 if List.mem task_id task_ids then Some goal_id else None)
-             in
-             List.iter
-               (fun goal_id ->
-                 match Goal_store.get_goal config ~goal_id with
-                 | Some
-                     { Goal_store.phase = Goal_phase.Executing
-                     ; metric = Some "verifier_approved_done_tasks"
-                     ; target_value = Some "1"
-                     ; _
-                     } ->
-                   (match
-                      Goal_store.update_goal config ~goal_id (fun goal ->
-                        { goal with
-                          phase = Goal_phase.Completed
-                        ; last_review_note =
-                            Some
-                              (Printf.sprintf
-                                 "Verifier-approved task %s completed the goal."
-                                 task_id)
-                        })
+             (match Workspace_goal_index.read_goal_task_links_r config with
+              | Error e ->
+                Log.TaskState.error
+                  "verifier-approved task committed but Goal links are \
+                   unavailable (task=%s): %s — Goal remains executing and \
+                   requires reconciliation from the durable Approved event"
+                  task_id
+                  e
+              | Ok links ->
+                let linked_goal_ids =
+                  links
+                  |> List.filter_map (fun (goal_id, task_ids) ->
+                    if List.mem task_id task_ids then Some goal_id else None)
+                in
+                List.iter
+                  (fun goal_id ->
+                    let completed = ref false in
+                    match
+                      Goal_store.update_goal config ~goal_id (fun current ->
+                        match current with
+                        | { Goal_store.phase = Goal_phase.Executing
+                          ; metric = Some "verifier_approved_done_tasks"
+                          ; target_value = Some "1"
+                          ; _
+                          } ->
+                          completed := true;
+                          { current with
+                            phase = Goal_phase.Completed
+                          ; last_review_note =
+                              Some
+                                (Printf.sprintf
+                                   "Verifier-approved task %s completed the goal."
+                                   task_id)
+                          }
+                        | _ -> current)
                     with
+                    | Ok _ when !completed ->
+                      Workspace_goals.emit_automatic_verifier_goal_completion
+                        config
+                        ~agent_name
+                        ~goal_id
+                        ~task_id
                     | Ok _ -> ()
                     | Error e ->
-                      Log.TaskState.warn
+                      Log.TaskState.error
                         "verifier-approved task committed but linked Goal update \
-                         failed (task=%s goal=%s): %s"
+                         failed (task=%s goal=%s): %s — Goal remains executing \
+                         and requires reconciliation from the durable Approved \
+                         event"
                         task_id
                         goal_id
                         e)
-                 | Some _
-                 | None -> ())
-               linked_goal_ids
+                  linked_goal_ids)
            | Masc_domain.Claim, _
            | Masc_domain.Start, _
            | Masc_domain.Done_action, _

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -367,3 +367,23 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
         }
       ]
 ;;
+
+let emit_automatic_verifier_goal_completion
+      config
+      ~agent_name
+      ~goal_id
+      ~task_id
+  =
+  let ctx : context = { config; agent_name } in
+  emit_goal_event
+    ctx
+    ~goal_id
+    ~event_type:"goal_phase"
+    ~payload:
+      (`Assoc
+         [ "phase", Goal_phase.to_yojson Goal_phase.Completed
+         ; "actor", `String agent_name
+         ; "source", `String "verifier_approved_task"
+         ; "task_id", `String task_id
+         ])
+;;

--- a/lib/workspace_goals.mli
+++ b/lib/workspace_goals.mli
@@ -38,3 +38,12 @@ val handle_goal_transition
   -> Workspace_types.context
   -> Yojson.Safe.t
   -> Tool_result.result
+
+(** Emit the canonical Goal phase event after a linked verifier-approved task
+    atomically changes an executing Goal to Completed. *)
+val emit_automatic_verifier_goal_completion
+  :  Workspace.config
+  -> agent_name:string
+  -> goal_id:string
+  -> task_id:string
+  -> unit

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1097,6 +1097,94 @@ let test_approve_completion_credits_assignee () =
       Alcotest.(check (list string))
         "approve completion credits assignee" [ test_agent_a ] !recorded))
 
+let test_verifier_approval_completes_single_verified_task_goal () =
+  with_test_env (fun config ->
+    let goal_id = "verified-task-goal" in
+    let created_goal, _ =
+      match
+        Goal_store.upsert_goal config ~id:goal_id ~title:"Verified task goal"
+          ~metric:"verifier_approved_done_tasks" ~target_value:"1"
+          ~phase:Goal_phase.Executing ()
+      with
+      | Ok created -> created
+      | Error e -> Alcotest.failf "goal creation failed: %s" e
+    in
+    Alcotest.(check string) "created goal" goal_id created_goal.id;
+    let _ =
+      Workspace.add_task config ~title:"Verified Goal Task" ~priority:1
+        ~description:""
+    in
+    Workspace_goal_index.link_task_to_goal config ~goal_id ~task_id:"task-001";
+    let _ =
+      Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] ()
+    in
+    let _ =
+      Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001"
+    in
+    let submitted =
+      Workspace.transition_task_r config ~agent_name:test_agent_a
+        ~task_id:"task-001" ~action:Masc_domain.Submit_for_verification
+        ~notes:"evidence attached" ()
+    in
+    Alcotest.(check bool) "submit ok" true
+      (match submitted with Ok _ -> true | Error _ -> false);
+    let approved =
+      Workspace.transition_task_r config ~agent_name:admin_keeper_agent
+        ~task_id:"task-001" ~action:Masc_domain.Approve_verification
+        ~configured_llm_verdict:configured_llm_completion_pass ()
+    in
+    Alcotest.(check bool) "approve ok" true
+      (match approved with Ok _ -> true | Error _ -> false);
+    let completed_goal =
+      match Goal_store.get_goal config ~goal_id with
+      | Some goal -> goal
+      | None -> Alcotest.fail "linked goal disappeared"
+    in
+    Alcotest.(check string)
+      "verifier approval completes goal"
+      "completed"
+      (Goal_phase.to_string completed_goal.phase))
+
+let test_direct_done_does_not_complete_verified_task_goal () =
+  with_test_env (fun config ->
+    let goal_id = "direct-done-goal" in
+    let _ =
+      match
+        Goal_store.upsert_goal config ~id:goal_id ~title:"Direct done goal"
+          ~metric:"verifier_approved_done_tasks" ~target_value:"1"
+          ~phase:Goal_phase.Executing ()
+      with
+      | Ok created -> created
+      | Error e -> Alcotest.failf "goal creation failed: %s" e
+    in
+    let _ =
+      Workspace.add_task config ~title:"Direct Done Task" ~priority:1
+        ~description:""
+    in
+    Workspace_goal_index.link_task_to_goal config ~goal_id ~task_id:"task-001";
+    let _ =
+      Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] ()
+    in
+    let _ =
+      Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001"
+    in
+    let done_result =
+      Workspace.transition_task_r config ~agent_name:test_agent_a
+        ~task_id:"task-001" ~action:Masc_domain.Done_action
+        ~configured_llm_verdict:configured_llm_completion_pass ~notes:"done" ()
+    in
+    Alcotest.(check bool) "direct done ok" true
+      (match done_result with Ok _ -> true | Error _ -> false);
+    let executing_goal =
+      match Goal_store.get_goal config ~goal_id with
+      | Some goal -> goal
+      | None -> Alcotest.fail "linked goal disappeared"
+    in
+    Alcotest.(check string)
+      "direct done leaves verifier metric executing"
+      "executing"
+      (Goal_phase.to_string executing_goal.phase))
+
 let test_submit_and_approve_rejects_empty_justification () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Justification Task" ~priority:1 ~description:"" in
@@ -1784,6 +1872,10 @@ let () =
     "done_side_effects", [
       Alcotest.test_case "approve completion credits assignee" `Quick
         test_approve_completion_credits_assignee;
+      Alcotest.test_case "verifier approval completes linked goal" `Quick
+        test_verifier_approval_completes_single_verified_task_goal;
+      Alcotest.test_case "direct done does not complete verifier goal" `Quick
+        test_direct_done_does_not_complete_verified_task_goal;
       Alcotest.test_case "submit and approve rejects empty justification" `Quick
         test_submit_and_approve_rejects_empty_justification;
     ];

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1143,7 +1143,17 @@ let test_verifier_approval_completes_single_verified_task_goal () =
     Alcotest.(check string)
       "verifier approval completes goal"
       "completed"
-      (Goal_phase.to_string completed_goal.phase))
+      (Goal_phase.to_string completed_goal.phase);
+    let goal_events_path =
+      Filename.concat (Workspace_utils.masc_dir config) "goal_events.jsonl"
+    in
+    let goal_events =
+      In_channel.with_open_bin goal_events_path In_channel.input_all
+    in
+    Alcotest.(check bool)
+      "automatic completion emits canonical goal event"
+      true
+      (contains_substring goal_events "\"source\":\"verifier_approved_task\""))
 
 let test_direct_done_does_not_complete_verified_task_goal () =
   with_test_env (fun config ->


### PR DESCRIPTION
## Summary
- complete linked executing Goal when an approval produces a Done task for `verifier_approved_done_tasks=1`
- keep task commit authoritative when the separate Goal update fails
- prove verifier approval completes the Goal while direct Done does not

## Boundary
- no new store, lease, receipt, settlement, or facade
- exact existing Goal index and Goal Store only

## Validation
- `ocamlformat --check lib/workspace/workspace_task_transitions.ml test/test_workspace.ml`
- `git diff --check`
- focused Dune build attempted once but skipped after shared `/tmp/me-dune-local.lock` remained held by another worktree full build; CI is build authority