### PR TITLE
fix(test): main 컴파일 복구 — deferred_runtime_lane fixture 3곳

### DIFF
--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1026,6 +1026,9 @@ let turn_failure route : Masc.Keeper_unified_turn.turn_failure =
   ; runtime_id = "exact-final-runtime"
   ; route
   ; source_lease_disposition = Masc.Keeper_unified_turn.Follow_failure_route
+    (* This helper feeds the failure-route mapping assertions, which never
+       exercise runtime failover; a lane here would assert nothing. *)
+  ; deferred_runtime_lane = None
   }
 ;;
 

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3105,6 +3105,9 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
               ; route = exact_route
               ; source_lease_disposition =
                   Masc.Keeper_unified_turn.Follow_failure_route
+                (* Settlement is asserted off the exact route; this case has no
+                   successor runtime, so the failover lane is absent. *)
+              ; deferred_runtime_lane = None
               }
             in
             match

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -289,6 +289,9 @@ let empty_turn_state : Unified_types.turn_state =
   ; runtime_rotation_attempts = []
   ; failure_reason = None
   ; retry_phase_started_at = None
+    (* [empty_turn_state] is the pre-execution state: no runtime has failed, so
+       there is no deferred failover lane to carry. *)
+  ; deferred_runtime_lane = None
   }
 ;;
 


### PR DESCRIPTION
## 문제

`main`이 컴파일되지 않습니다. PR #25950 (`61b7c7c358`)이 `deferred_runtime_lane` 필드를 `turn_failure`와 `turn_state`에 추가했지만, 해당 레코드를 리터럴로 만드는 `test/` 3곳을 갱신하지 않았습니다.

```
Error: Some record fields are undefined: deferred_runtime_lane
  test/test_keeper_event_queue_state_v2.ml:1025
  test/test_keeper_tool_dispatch_runtime.ml:3103
  test/test_keeper_turn_disposition.ml:284
```

## 왜 통과했나

#25950의 빌드 범위가 `@lib/check` + 단일 실행파일(`test_keeper_turn_driver_failover.exe`)이었습니다. 나머지 `test/` 파일은 컴파일 대상에 포함되지 않았으므로 필드 누락이 드러날 수 없었습니다.

## 각 사이트가 `None`인 근거

placeholder가 아니라, 해당 경로에 failover lane이 존재하지 않는 것이 맞습니다.

| 파일 | 근거 |
|---|---|
| `test_keeper_event_queue_state_v2` | 헬퍼가 failure-route 매핑 assertion 전용. runtime failover를 실행하지 않음 |
| `test_keeper_tool_dispatch_runtime` | exact route 기준 settlement 검증. successor runtime이 없는 케이스 |
| `test_keeper_turn_disposition` | `empty_turn_state` = 실행 전 상태. 실패한 runtime이 아직 없음 |

failover lane 자체의 커버리지는 `test_keeper_turn_driver_failover`에 그대로 있고 통과합니다 (hint 소유권 독립성, successor 부재 시 hint 없음, typed missing-successor).

## 검증

- `bash scripts/dune-local.sh build .` — clean
- `test_keeper_turn_disposition` PASS
- `test_keeper_turn_driver_failover` PASS

선행 실패로 남는 것 (이 PR 범위 밖):

- `test_keeper_event_queue_state_v2` 7 failures / 38
- `test_keeper_tool_dispatch_runtime` 34 failures / 38

원인은 `make_meta failed: invalid current keeper meta: agent_name does not match canonical keeper identity` 이며, 이 변경을 stash 해도 동일하게 재현됩니다. 컴파일 복구와 별건이라 이 PR에서 다루지 않았습니다.
