### PR TITLE
fix(gate): Auto Judge 판정 SSE 배선 + delivery request_context 제거

### DIFF
--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -34,6 +34,7 @@ import { describe, expect, it } from 'vitest'
 const BACKEND_EMITTED: Record<string, string> = {
   'approval:pending': '../lib/keeper/keeper_approval_queue.ml',
   'approval:resolved': '../lib/keeper/keeper_approval_queue.ml',
+  'approval:summary_updated': '../lib/keeper/keeper_approval_queue.ml',
   execution_snapshot: '../lib/server/server_dashboard_http_execution_surfaces.ml',
   runtime_param_changed: '../lib/server/server_routes_http_routes_activity.ml',
   keeper_chat_appended: '../lib/keeper/keeper_chat_broadcast.ml',
@@ -186,4 +187,33 @@ describe('SSE event-type cross-boundary parity (exact-match routes)', () => {
       expect(source).toContain(`"${eventType}"`)
     })
   }
+
+  // Reverse direction, scoped to the approval:* class. The interim scope note
+  // at the top of this file excludes "backend emits a type the FE never
+  // handles", and that exclusion is exactly how approval:summary_updated
+  // shipped unrouted: the constant existed in schemas/sse.ts, the payload had
+  // schema coverage, and nothing bound it to a refresh — so Auto Judge
+  // verdicts settled invisibly until the 120-180s periodic sweep. Full-surface
+  // reverse parity remains the closed-sum keystone's job; this pins the one
+  // class the HITL queue's liveness depends on.
+  const backendApprovalEvents = [
+    ...new Set(
+      readFileSync(resolve(process.cwd(), '../lib/keeper/keeper_approval_queue.ml'), 'utf8')
+        .matchAll(/"(approval:[a-z_]+)"/g),
+    ),
+  ].map(match => match[1])
+
+  it('parses a non-empty backend approval:* inventory', () => {
+    // Positive control: a rename or regex drift that matches nothing must fail
+    // loud here rather than vacuously pass the assertion below.
+    expect(backendApprovalEvents).toContain('approval:pending')
+  })
+
+  it('routes every backend-emitted approval:* event on the FE', () => {
+    const unrouted = backendApprovalEvents.filter(t => !feRouted.has(t))
+    expect(
+      unrouted,
+      `backend emits these approval events but sse-store.ts never routes them, so the HITL queue will not refresh on them: ${unrouted.join(', ')}`,
+    ).toEqual([])
+  })
 })

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -261,6 +261,23 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshGate).toHaveBeenCalledWith({ force: true })
   })
 
+  it('routes an approval:summary_updated SSE event to the Gate refresh (Auto Judge verdict contract)', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshGate = vi.fn<(opts?: { force?: boolean }) => void>()
+    sseStore.registerGateRefresh(refreshGate)
+
+    // The Auto Judge verdict lands on this event, not on approval:resolved: a
+    // `require_human` judgment settles the summary while the row stays pending,
+    // so resolution never fires. Without this route the queue kept rendering
+    // "generating summary" until the 120-180s periodic sweep even though the
+    // judge had settled in ~2s.
+    sseStore.routeServerPushEvent({ type: 'approval:summary_updated' })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshGate).toHaveBeenCalledWith({ force: true })
+  })
+
   it('hydrates the canonical project_snapshot SSE event without an HTTP fetch', async () => {
     const { sseStore, sse } = await loadSseStore()
     const cleanup = sseStore.setupSSEReaction()

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -65,6 +65,7 @@ import { parseOasPayloadOrNull } from './schemas/sse-event-payload'
 import {
   SSE_APPROVAL_PENDING_EVENT,
   SSE_APPROVAL_RESOLVED_EVENT,
+  SSE_APPROVAL_SUMMARY_UPDATED_EVENT,
 } from './schemas/sse'
 import { route } from './router'
 import { routeWantsRefreshTarget, type RouteRefreshTarget } from './refresh-scope'
@@ -584,9 +585,15 @@ export function routeServerPushEvent(event: SSEEvent): void {
     scheduleIdeWorkspaceRefresh()
   }
 
+  // summary_updated carries the Auto Judge verdict transition (summary
+  // pending -> available, disposition in_flight -> settled). Without it the
+  // queue only refreshes on arrival and terminal resolution, so a verdict of
+  // require_human leaves the row rendering "generating summary" until the
+  // periodic sweep (120-180s) even though the judge settled in ~2s.
   const approvalRefreshEvent =
     event.type === SSE_APPROVAL_PENDING_EVENT
     || event.type === SSE_APPROVAL_RESOLVED_EVENT
+    || event.type === SSE_APPROVAL_SUMMARY_UPDATED_EVENT
 
   if (
     event.type.startsWith('decision_')

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -309,7 +309,13 @@ let report_pending_read_drop ~reason ~path ~detail =
 
 let exact_request_context_version = 1
 
-let pending_entry_to_yojson (entry : pending_approval) =
+let pending_entry_to_yojson
+      ?(include_request_context = true)
+      (entry : pending_approval)
+  =
+  let request_context =
+    if include_request_context then entry.request_context else None
+  in
   `Assoc
     [ "id", `String entry.id
     ; "keeper_name", `String entry.keeper_name
@@ -320,11 +326,11 @@ let pending_entry_to_yojson (entry : pending_approval) =
     ; "requested_at", `Float entry.requested_at
     ; "turn_id", Json_util.int_opt_to_json entry.turn_id
     ; ( "request_context"
-      , match entry.request_context with
+      , match request_context with
         | Some context -> context
         | None -> `Null )
     ; ( "request_context_version"
-      , match entry.request_context with
+      , match request_context with
         | Some _ -> `Int exact_request_context_version
         | None -> `Null )
     ; "task_id", Json_util.string_opt_to_json entry.task_id
@@ -347,9 +353,19 @@ let approval_decision_to_yojson = function
     `Assoc [ "kind", `String "edit"; "input", input ]
 ;;
 
+(* [request_context] is the Auto Judge / HITL summary input: the whole Keeper
+   turn context (history_messages, system prompts, dynamic_context) captured at
+   request time. Its only reader is Hitl_summary_worker, which runs while the
+   entry is still pending. A delivery is already resolved, so the context is
+   dead weight there — and it dominated the store: 71 deliveries held ~30MB of
+   duplicated context against 19 bytes of decision each.
+
+   Dropping it on the delivery wire shape stays decode-compatible: the reader
+   treats [request_context] as optional and keys the version field off its
+   presence, so existing snapshots still load and re-save smaller. *)
 let persisted_delivery_to_yojson delivery =
   `Assoc
-    [ "entry", pending_entry_to_yojson delivery.entry
+    [ "entry", pending_entry_to_yojson ~include_request_context:false delivery.entry
     ; "decision", approval_decision_to_yojson delivery.decision
     ; "source", `String (decision_source_to_string delivery.source)
     ; "remember_rule", `Bool delivery.remember_rule
@@ -368,7 +384,9 @@ let map_values_for_base ~base_path map project =
 let snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map =
   let pending_entries =
     map_values_for_base ~base_path pending_map Fun.id
-    |> List.map pending_entry_to_yojson
+    (* Wrapped rather than passed bare: [pending_entry_to_yojson] now leads with
+       an optional argument, which OCaml only erases at application. *)
+    |> List.map (fun entry -> pending_entry_to_yojson entry)
   in
   let delivery_entries =
     map_values_for_base ~base_path delivery_map (fun delivery -> delivery.entry)

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -752,6 +752,78 @@ let test_different_owners_claim_in_parallel () =
          (Gate.For_testing.claim_auto_judge entry_a2))
 ;;
 
+let test_delivery_wire_shape_drops_request_context () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-delivery-context" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       ignore (install_exn ~base_path);
+       (* Stands in for the production capture, which is the whole outer turn
+          (history_messages + system prompts). Padded so a regression that
+          re-inlines it into the delivery shows up in the byte assertion below,
+          not only in the shape assertions. *)
+       let bulky_history =
+         List.init 64 (fun i ->
+           `String (Printf.sprintf "outer turn message %d %s" i (String.make 256 'x')))
+       in
+       let request_context =
+         `Assoc
+           [ ( "initial"
+             , `Assoc
+                 [ "history_messages", `List bulky_history
+                 ; "base_system_prompt", `String (String.make 512 'b')
+                 ] )
+           ; "completed_tool_calls", `List []
+           ]
+       in
+       let context_bytes = String.length (Yojson.Safe.to_string request_context) in
+       let id =
+         submit_with_context
+           ~turn_id:7
+           ~request_context
+           ~base_path
+           ~keeper_name
+           ~input:(`Assoc [ "target", `String "document" ])
+           ()
+       in
+       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+        | Ok () -> ()
+        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
+       let open Yojson.Safe.Util in
+       let delivery_entry =
+         read_pending_snapshot ~base_path
+         |> member "deliveries"
+         |> to_list
+         |> List.map (fun delivery -> delivery |> member "entry")
+         |> List.find_opt (fun entry ->
+           String.equal (entry |> member "id" |> to_string) id)
+       in
+       (match delivery_entry with
+        | None -> Alcotest.fail "approved request did not persist a delivery"
+        | Some delivery_entry ->
+          Alcotest.check yojson
+            "delivery drops the summary-only request context"
+            `Null
+            (delivery_entry |> member "request_context");
+          Alcotest.check yojson
+            "delivery drops the context version marker"
+            `Null
+            (delivery_entry |> member "request_context_version"));
+       let snapshot_bytes = String.length (read_pending_snapshot_bytes ~base_path) in
+       Alcotest.(check bool)
+         (Printf.sprintf
+            "resolved snapshot (%d bytes) stays under the dropped context (%d bytes)"
+            snapshot_bytes
+            context_bytes)
+         true
+         (snapshot_bytes < context_bytes);
+       (* The trimmed delivery shape must still load: the reader keys the
+          version field off request_context presence, so absent is legal. *)
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path))
+;;
+
 let test_resolution_is_durable_and_origin_scoped () =
   let base_path = temp_dir () in
   let keeper_name = "queue-origin" in
@@ -3008,6 +3080,10 @@ let () =
             "non-approved resolution payload is delivered"
             `Quick
             test_nonapproved_resolution_payload_is_delivered
+        ; Alcotest.test_case
+            "delivery wire shape drops the request context"
+            `Quick
+            test_delivery_wire_shape_drops_request_context
         ] )
     ]
 ;;


### PR DESCRIPTION
## 증상

Gate 모드가 `Auto Judge` 인데 승인 큐가 "컨텍스트 요약 생성 중…" + "8초 대기" 에서 멈춘 것처럼 보입니다. 실제로는 Auto Judge가 약 2초에 판정을 끝냈고, 화면이 그 사실을 받지 못한 것입니다.

라이브 판정 레코드 (`appr_53c3389f`):

```
requested_at        1785159011.95
summary generated   1785159014.03   -> 2.1초
exact_attempt       completed
disposition         settled
judgment            require_human
```

## 원인 1 — 판정 완료 SSE가 배선되지 않음

서버는 `approval:summary_updated` 를 발행합니다 (`keeper_approval_queue.ml:1828`). 대시보드에는

- `schemas/sse.ts:29` 상수 정의
- `schemas/sse.test.ts:379` "drift로 버리지 않는다" 테스트

까지 있지만, `sse-store.ts` 의 `approvalRefreshEvent` 는 `approval:pending` / `approval:resolved` 두 개만 포함합니다. 이 상수는 `schemas/sse.ts` 밖에서 **소비되지 않았습니다**.

이 이벤트가 Auto Judge 판정 전이(summary `pending -> available`, disposition `in_flight -> settled`)를 나릅니다. 판정이 `require_human` 이면 row는 pending으로 남아 `approval:resolved` 가 오지 않으므로, 폴백인 주기 갱신(dev 180s / prod 120s)까지 화면이 stale 상태로 남습니다.

2026-07-27 승인 감사 로그 기준 규모:

| 이벤트 | 건수 |
|---|---|
| `summary_updated` | **578** |
| `pending` | 160 |
| `resolved` | 145 |

578건의 갱신 신호가 화면에 도달하지 못했습니다.

## 원인 2 — parity gate가 한 방향만 검사

`sse-event-type-parity.test.ts` 는 스스로 "FE -> backend 방향만"이라고 명시하고, 역방향(backend가 발행하는데 FE가 라우팅하지 않음)을 범위에서 제외합니다. 정의만 되고 배선되지 않은 이벤트가 green으로 남은 경로가 정확히 여기입니다.

전체 역방향은 closed-sum keystone 과제로 남기고, 이 PR은 `approval:*` 클래스에 한정한 역방향 검사를 추가합니다. positive control(인벤토리가 비면 loud fail)을 함께 넣었습니다.

## 원인 3 — delivery가 request_context를 복제

`persisted_delivery_to_yojson` 이 `pending_entry_to_yojson` 을 그대로 재사용해 delivery에도 `request_context` 가 실립니다. 이 필드는 Keeper 턴 전체 컨텍스트(history_messages + base/turn system prompt + dynamic_context)이고, 유일한 소비자인 `Hitl_summary_worker` 는 entry가 pending인 동안에만 동작합니다.

라이브 `~/me/.masc/gate/pending.json` 실측:

```
전체             37MB   (조사 20분 사이 30MB -> 37MB)
pending    2건    1.1MB
deliveries 71건  30.4MB  <- entry 사본
delivery 1건: request_context ~419KB  vs  decision 19 bytes
```

delivery wire shape에서 제거했습니다. pending entry는 restart 복원 경로가 읽으므로 유지합니다. 디코더가 `request_context` 를 optional로 취급하고 version 필드를 존재 여부로 키잉하므로, 기존 스냅샷도 그대로 로드되고 다음 저장에서 축소됩니다.

## 검증

- dashboard `sse-store.test.ts` + `sse-event-type-parity.test.ts`: **61/61**
- mutation: 라우팅 한 줄을 제거하면 **3건 실패** (parity 2, refresh contract 1) — 하네스가 실제로 이 결함을 잡습니다
- OCaml `test_keeper_approval_queue.exe`
  - 신규 `delivery wire shape drops the request context` PASS
  - baseline(`012dcbdf46`) 3 failures / 30 tests → 이 PR 3 failures / **31** tests
  - 선행 실패 3건(`exact staged durability`, `dashboard resolve rejects`, `blocked disposition`)은 baseline과 동일하며 이 변경과 무관합니다

## 남은 것 (이 PR 밖)

Auto Judge 입력으로 약 500KB의 `request_context` 가 매 게이트 요청마다 `ollama_cloud.deepseek-v4-flash` 로 전달됩니다 (`hitl_summary_worker.ml:57`). 게이트 판정에 턴 전체 히스토리가 필요한지는 별도 검토가 필요합니다.
