### PR TITLE
feat(keeper): correct context on a detached exact lane

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -29,6 +29,9 @@ slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 [runtime.exact_output_lanes.compaction_exact]
 slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 
+[runtime.exact_output_lanes.context_correction_exact]
+slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
+
 [runtime.exact_output_lanes.hitl_auto_judge]
 slots = ["glm-coding.glm-5-turbo", "glm-coding.glm-4-7-coding"]
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -359,6 +359,14 @@ let run_turn
       ~generation
       ()
   in
+  let context_correction_start =
+    Keeper_context_correction.capture_start
+      ~session_dir:ctx.session_dir
+      ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+  in
+  Keeper_context_correction.bind_start_context
+    context_correction_start
+    ctx.shared_context;
   let meta = ctx.meta in
   let temperature = ctx.temperature in
   let context_injector = ctx.context_injector in
@@ -769,6 +777,7 @@ let run_turn
                           ~result ~checkpoint_persistence_error
                           ~post_turn_t0 ~runtime_id_string
                           ~history_messages
+                          ~context_correction_start
                           ~pre_turn_working_context:
                             ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
                           ~prompt_metrics ~ctx_composition ~usage

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -216,7 +216,7 @@ module For_testing = struct
 end
 
 let finalize
-    ~config
+    ~(config : Workspace.config)
     ~meta
     ~generation
     ~manifest_keeper_turn_id
@@ -231,6 +231,7 @@ let finalize
     ~post_turn_t0
     ~runtime_id_string
     ~history_messages
+    ~context_correction_start
     ~pre_turn_working_context
     ~prompt_metrics
     ~ctx_composition
@@ -306,12 +307,17 @@ let finalize
               ~keeper_name:meta.name
               ~detail)
        | Ok (patched, replay_suffix_pruned) ->
+         let patched =
+           Keeper_context_correction.prepare_raw_checkpoint
+             ~start:context_correction_start
+             patched
+         in
          (match
             Keeper_checkpoint_store.save_oas_classified
               ~session_dir:session.session_dir
               patched
           with
-       | Ok (Keeper_checkpoint_store.Saved _) ->
+       | Ok (Keeper_checkpoint_store.Saved { installed_ref; _ }) ->
          append_manifest ~site:"checkpoint_saved"
            ~keeper_turn_id:manifest_keeper_turn_id
            ~oas_turn_count:result.turns
@@ -339,7 +345,7 @@ let finalize
                         completion_contract_result) );
                ])
            Keeper_runtime_manifest.Checkpoint_saved;
-         Ok (Some patched)
+         Ok (Some (patched, installed_ref, true))
        | Ok (Keeper_checkpoint_store.Stale_noop
                 { incoming_turn_count; known_turn_count }) ->
          Log.Keeper.warn ~keeper_name:meta.name
@@ -350,7 +356,18 @@ let finalize
            "masc_keeper_checkpoint_stale_noop_total"
            ~labels:[ "keeper", meta.name; "site", "finalize" ]
            ();
-         Ok None
+         (match
+            Keeper_checkpoint_store.load_oas_exact_snapshot
+              ~session_dir:session.session_dir
+              ~session_id:patched.session_id
+          with
+          | Ok snapshot ->
+            Ok
+              (Some
+                 ( Keeper_checkpoint_store.exact_snapshot_checkpoint snapshot
+                 , Keeper_checkpoint_store.exact_snapshot_reference snapshot
+                 , false ))
+          | Error _ -> Ok None)
        | Error e ->
          Log.Keeper.error ~keeper_name:meta.name
            "runtime=%s OAS checkpoint save failed: %s"
@@ -379,7 +396,40 @@ let finalize
   in
   match saved_checkpoint_result with
   | Error e -> Error e
-  | Ok saved_checkpoint ->
+  | Ok saved_raw_checkpoint ->
+    let saved_checkpoint =
+      Option.map (fun (checkpoint, _, _) -> checkpoint) saved_raw_checkpoint
+    in
+    (match saved_raw_checkpoint, result.stop_reason with
+     | Some (raw_checkpoint, raw_ref, true), Runtime_agent.Completed ->
+       let submission =
+         Keeper_context_correction.submit
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (fun () ->
+              let outcome =
+                Keeper_context_correction.run
+                  ~timeout_s:90.0
+                  ~keeper_name:meta.name
+                  ~session_dir:session.session_dir
+                  ~start:context_correction_start
+                  ~history_messages
+                  ~raw_checkpoint
+                  ~raw_ref
+              in
+              Log.Keeper.info
+                ~keeper_name:meta.name
+                "context correction terminal %s"
+                (Yojson.Safe.to_string
+                   (Keeper_context_correction.outcome_to_json outcome)))
+       in
+       append_manifest
+         ~site:"context_correction_scheduled"
+         ~keeper_turn_id:manifest_keeper_turn_id
+         ~oas_turn_count:result.turns
+         ~decision:(Keeper_context_correction.submission_to_json submission)
+         Keeper_runtime_manifest.Checkpoint_saved
+     | _ -> ());
     (* Retired proof-ledger evaluation is absent. Task completion judgment is
        owned by the configured LLM reviewer at the Task boundary. *)
     let librarian_messages =

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -294,7 +294,11 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
 type save_oas_relation = [ `Cold | `Forward | `Equal ]
 
 type save_oas_outcome =
-  | Saved of { relation : save_oas_relation; turn_count : int }
+  | Saved of
+      { relation : save_oas_relation
+      ; turn_count : int
+      ; installed_ref : Keeper_checkpoint_ref.t
+      }
   | Stale_noop of { incoming_turn_count : int; known_turn_count : int }
 
 let save_relation ~known ~incoming =
@@ -322,6 +326,7 @@ type save_oas_error =
   | Session_directory_unavailable of directory_failure
   | Existing_checkpoint_unreadable of checkpoint_load_error
   | Canonical_write_failed of Keeper_fs.durable_write_error
+  | Canonical_identity_invalid of string
   | Transaction_lock_failed of File_lock_eio.durable_lock_error
 
 let checkpoint_load_error_to_string = function
@@ -348,6 +353,8 @@ let save_oas_error_to_string = function
   | Canonical_write_failed error ->
     "canonical checkpoint write failed: "
     ^ Keeper_fs.durable_write_error_to_string error
+  | Canonical_identity_invalid detail ->
+    "canonical checkpoint identity invalid: " ^ detail
   | Transaction_lock_failed error ->
     "checkpoint transaction lock failed: "
     ^ File_lock_eio.durable_lock_error_to_string error
@@ -959,21 +966,47 @@ let save_oas_classified_typed
       | Ok existing ->
         let known = Option.map (fun (w : watermark) -> w.turn_count) existing in
         let ownership_root = Filename.dirname session_dir in
-        (match
-           Keeper_fs.save_json_durable_atomic_from
-             ~ownership_root
-             ~pretty:false
-             canonical_path
-             (fun () -> Agent_sdk.Checkpoint.to_json ckpt)
-         with
-         | Error error -> Error (Canonical_write_failed error)
-         | Ok () ->
-           archive_oas_history_best_effort ~session_dir ckpt;
-           Ok
-             (Saved
-                { relation = save_relation ~known ~incoming:ckpt.turn_count
-                ; turn_count = ckpt.turn_count
-                })))
+        let canonical_bytes = Agent_sdk.Checkpoint.to_string ckpt in
+        let generation =
+          match
+            Agent_sdk.Context.get_scoped ckpt.context Agent_sdk.Context.Session
+              keeper_generation_context_key
+          with
+          | Some (`Int value) -> Ok value
+          | Some (`Intlit raw) ->
+            Option.to_result
+              ~none:"generation is not an integer"
+              (int_of_string_opt raw)
+          | Some _ | None -> Error "generation is missing or not an integer"
+        in
+        (match generation with
+         | Error detail -> Error (Canonical_identity_invalid detail)
+         | Ok generation ->
+           (match
+              Keeper_checkpoint_ref.create
+                ~trace_id
+                ~generation
+                ~turn_count:ckpt.turn_count
+                ~canonical_checkpoint_bytes:canonical_bytes
+            with
+            | Error _ ->
+              Error (Canonical_identity_invalid "checkpoint ref rejected")
+            | Ok installed_ref ->
+              (match
+                 Keeper_fs.save_bytes_durable_atomic
+                   ~ownership_root
+                   canonical_path
+                   canonical_bytes
+               with
+               | Error error -> Error (Canonical_write_failed error)
+               | Ok () ->
+                 archive_oas_history_best_effort ~session_dir ckpt;
+                 Ok
+                   (Saved
+                      { relation = save_relation ~known ~incoming:ckpt.turn_count
+                      ; turn_count = ckpt.turn_count
+                      ; installed_ref
+                      })))))
 
 let save_oas_classified ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
   : (save_oas_outcome, string) result =

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -65,7 +65,11 @@ type save_oas_relation = [ `Cold | `Forward | `Equal ]
     behind the known high watermark. It must not be treated as keeper
     turn failure, pause, or stop. *)
 type save_oas_outcome =
-  | Saved of { relation : save_oas_relation; turn_count : int }
+  | Saved of
+      { relation : save_oas_relation
+      ; turn_count : int
+      ; installed_ref : Keeper_checkpoint_ref.t
+      }
   | Stale_noop of { incoming_turn_count : int; known_turn_count : int }
 
 (** Save [ckpt] in one locked disk-SSOT transaction. A missing [session_dir]

--- a/lib/keeper/keeper_context_correction.ml
+++ b/lib/keeper/keeper_context_correction.ml
@@ -1,0 +1,653 @@
+module Exact_output = Agent_sdk.Exact_output
+
+let ( let* ) = Result.bind
+let lane_id = "context_correction_exact"
+let state_context_key = "keeper.context_correction.v1"
+let state_version = 1
+let max_closed_units = 16
+let max_closed_bytes = 65_536
+
+let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
+
+type submission = Unavailable | Coalesced | Submitted
+
+let executor_sw : Eio.Switch.t option ref = ref None
+let executor_mu = Stdlib.Mutex.create ()
+let in_flight_keys : (string, unit) Hashtbl.t = Hashtbl.create 16
+
+let init ~sw =
+  Stdlib.Mutex.protect executor_mu (fun () -> executor_sw := Some sw)
+;;
+
+let executor_key ~base_path ~keeper_name =
+  Keeper_registry_types.registry_key ~base_path keeper_name
+;;
+
+let release_key key =
+  Stdlib.Mutex.protect executor_mu (fun () -> Hashtbl.remove in_flight_keys key)
+;;
+
+let submit ~base_path ~keeper_name job =
+  let key = executor_key ~base_path ~keeper_name in
+  let admitted =
+    Stdlib.Mutex.protect executor_mu (fun () ->
+      match !executor_sw with
+      | None -> `Unavailable
+      | Some _ when Hashtbl.mem in_flight_keys key -> `Coalesced
+      | Some sw ->
+        Hashtbl.add in_flight_keys key ();
+        `Admitted sw)
+  in
+  match admitted with
+  | `Unavailable -> Unavailable
+  | `Coalesced -> Coalesced
+  | `Admitted sw ->
+    (try
+       Eio.Fiber.fork ~sw (fun () ->
+         Fun.protect
+           ~finally:(fun () -> release_key key)
+           (fun () ->
+              try job () with
+              | Eio.Cancel.Cancelled _ -> ()
+              | exn ->
+                Log.Keeper.warn
+                  ~keeper_name
+                  "context correction detached fiber failed: %s"
+                  (Printexc.to_string exn)));
+       Submitted
+     with
+     | _ ->
+       release_key key;
+       Unavailable)
+;;
+
+let canonical_messages messages =
+  messages
+  |> List.map Keeper_context_core.message_to_json
+  |> fun values -> Yojson.Safe.to_string (`List values)
+;;
+
+type marker =
+  { semantic_message_count : int; semantic_state_sha256 : string;
+    accepted_closed_unit_count : int; accepted_closed_prefix_sha256 : string }
+
+let genesis_marker =
+  { semantic_message_count = 0
+  ; semantic_state_sha256 = sha256 "[]"
+  ; accepted_closed_unit_count = 0
+  ; accepted_closed_prefix_sha256 = sha256 "context-correction:v1:root"
+  }
+;;
+
+let marker_to_json marker =
+  `Assoc
+    [ "version", `Int state_version
+    ; "semantic_message_count", `Int marker.semantic_message_count
+    ; "semantic_state_sha256", `String marker.semantic_state_sha256
+    ; "accepted_closed_unit_count", `Int marker.accepted_closed_unit_count
+    ; ( "accepted_closed_prefix_sha256"
+      , `String marker.accepted_closed_prefix_sha256 )
+    ]
+;;
+
+type preserved_reason =
+  | Control_checkpoint | Raw_save_superseded | Start_checkpoint_unavailable
+  | Fresh_state_required | Marker_corrupt | Start_prefix_mismatch
+  | No_closed_delta | Closed_unit_over_budget | Network_unavailable
+  | Clock_unavailable | Exact_lane_unavailable | Exact_flow_failed
+  | Semantic_output_invalid | Deadline_exceeded
+  | Deadline_exceeded_before_cas | Cas_conflict | Cas_not_installed
+
+let preserved_reason_to_string = function
+  | Control_checkpoint -> "control_checkpoint"
+  | Raw_save_superseded -> "raw_save_superseded"
+  | Start_checkpoint_unavailable -> "start_checkpoint_unavailable"
+  | Fresh_state_required -> "fresh_state_required"
+  | Marker_corrupt -> "marker_corrupt"
+  | Start_prefix_mismatch -> "start_prefix_mismatch"
+  | No_closed_delta -> "no_closed_delta"
+  | Closed_unit_over_budget -> "closed_unit_over_budget"
+  | Network_unavailable -> "network_unavailable"
+  | Clock_unavailable -> "clock_unavailable"
+  | Exact_lane_unavailable -> "exact_lane_unavailable"
+  | Exact_flow_failed -> "exact_flow_failed"
+  | Semantic_output_invalid -> "semantic_output_invalid"
+  | Deadline_exceeded -> "deadline_exceeded"
+  | Deadline_exceeded_before_cas -> "deadline_exceeded_before_cas"
+  | Cas_conflict -> "cas_conflict"
+  | Cas_not_installed -> "cas_not_installed"
+;;
+
+let marker_of_json = function
+  | `Assoc fields ->
+    let expected = [ "accepted_closed_prefix_sha256"; "accepted_closed_unit_count";
+      "semantic_message_count"; "semantic_state_sha256"; "version" ] in
+    let keys = List.map fst fields |> List.sort String.compare in
+    let int_field name = match List.assoc_opt name fields with
+      | Some (`Int value) -> Some value | _ -> None in
+    let string_field name = match List.assoc_opt name fields with
+      | Some (`String value) -> Some value | _ -> None in
+    (match
+       ( keys = expected
+       , int_field "version"
+       , int_field "semantic_message_count"
+       , string_field "semantic_state_sha256"
+       , int_field "accepted_closed_unit_count"
+       , string_field "accepted_closed_prefix_sha256" )
+     with
+     | ( true
+       , Some version
+       , Some semantic_message_count
+       , Some semantic_state_sha256
+       , Some accepted_closed_unit_count
+       , Some accepted_closed_prefix_sha256 )
+       when version = state_version && semantic_message_count >= 0
+            && semantic_message_count <= 1 && accepted_closed_unit_count >= 0
+            && String.length semantic_state_sha256 = 64
+            && String.length accepted_closed_prefix_sha256 = 64 ->
+       Ok
+         { semantic_message_count
+         ; semantic_state_sha256
+         ; accepted_closed_unit_count
+         ; accepted_closed_prefix_sha256
+         }
+     | _ -> Error Marker_corrupt)
+  | _ -> Error Marker_corrupt
+;;
+
+let marker_of_context context =
+  match
+    Agent_sdk.Context.get_scoped
+      context
+      Agent_sdk.Context.Session
+      state_context_key
+  with
+  | None -> Error Fresh_state_required
+  | Some json -> marker_of_json json
+;;
+
+let set_marker context marker =
+  Agent_sdk.Context.set_scoped
+    context
+    Agent_sdk.Context.Session
+    state_context_key
+    (marker_to_json marker)
+;;
+
+type start = Fresh | Existing of Keeper_checkpoint_store.exact_checkpoint_snapshot
+  | Unavailable
+
+let capture_start ~session_dir ~session_id =
+  match
+    Keeper_checkpoint_store.load_oas_exact_snapshot ~session_dir ~session_id
+  with
+  | Ok snapshot -> Existing snapshot
+  | Error Keeper_checkpoint_store.Ref_not_found -> Fresh
+  | Error _ -> Unavailable
+;;
+
+let start_marker = function
+  | Fresh -> Ok genesis_marker
+  | Unavailable -> Error Start_checkpoint_unavailable
+  | Existing snapshot ->
+    snapshot
+    |> Keeper_checkpoint_store.exact_snapshot_checkpoint
+    |> fun checkpoint -> marker_of_context checkpoint.context
+;;
+
+let bind_start_context start context =
+  match start_marker start with
+  | Ok marker -> set_marker context marker
+  | Error _ -> ()
+;;
+
+let prepare_raw_checkpoint ~start (checkpoint : Agent_sdk.Checkpoint.t) =
+  match start_marker start with
+  | Error _ -> checkpoint
+  | Ok marker ->
+    let context = Agent_sdk.Context.copy checkpoint.context in
+    set_marker context marker;
+    { checkpoint with Agent_sdk.Checkpoint.context }
+;;
+
+let rec split_at count acc values =
+  if count = 0
+  then Ok (List.rev acc, values)
+  else
+    match values with
+    | [] -> Error Marker_corrupt
+    | value :: rest -> split_at (count - 1) (value :: acc) rest
+;;
+
+let messages_of_closed_unit = function
+  | Keeper_compaction_unit.Ordinary_message message -> [ message ]
+  | Keeper_compaction_unit.Closed_tool_cycle messages -> messages
+;;
+
+let select_closed_units units =
+  let rec loop count bytes selected = function
+    | [] -> Ok (List.rev selected, [])
+    | unit :: rest ->
+      let unit_bytes =
+        unit |> messages_of_closed_unit |> canonical_messages |> String.length
+      in
+      if count = 0 && unit_bytes > max_closed_bytes
+      then Error Closed_unit_over_budget
+      else if count >= max_closed_units || bytes + unit_bytes > max_closed_bytes
+      then Ok (List.rev selected, unit :: rest)
+      else loop (count + 1) (bytes + unit_bytes) (unit :: selected) rest
+  in
+  loop 0 0 [] units
+;;
+
+let advance_anchor marker units =
+  List.fold_left
+    (fun (count, digest) unit ->
+       let canonical = unit |> messages_of_closed_unit |> canonical_messages in
+       count + 1, sha256 (digest ^ "\000" ^ canonical))
+    ( marker.accepted_closed_unit_count
+    , marker.accepted_closed_prefix_sha256 )
+    units
+;;
+
+let prepare_candidate
+      ~marker
+      ~(raw_checkpoint : Agent_sdk.Checkpoint.t)
+      ~semantic_context
+  =
+  let semantic_context = String.trim semantic_context in
+  if semantic_context = ""
+  then Error Semantic_output_invalid
+  else
+    let* semantic_messages, backlog =
+      split_at marker.semantic_message_count [] raw_checkpoint.messages
+    in
+    if not (String.equal marker.semantic_state_sha256 (sha256 (canonical_messages semantic_messages)))
+    then Error Marker_corrupt
+    else
+      let* partition =
+        Keeper_compaction_unit.partition backlog
+        |> Result.map_error (fun _ -> Marker_corrupt)
+      in
+      let* selected, remaining =
+        select_closed_units partition.closed_prefix
+      in
+      if selected = []
+      then Error No_closed_delta
+      else
+        let semantic_message = Agent_sdk.Types.system_msg semantic_context in
+        let remaining_messages =
+          List.concat_map messages_of_closed_unit remaining
+          @ partition.protected_suffix
+        in
+        let count, digest = advance_anchor marker selected in
+        let marker =
+          { semantic_message_count = 1
+          ; semantic_state_sha256 = sha256 (canonical_messages [ semantic_message ])
+          ; accepted_closed_unit_count = count
+          ; accepted_closed_prefix_sha256 = digest
+          }
+        in
+        let context = Agent_sdk.Context.copy raw_checkpoint.context in
+        set_marker context marker;
+        Ok
+          ( { raw_checkpoint with
+              Agent_sdk.Checkpoint.messages =
+                semantic_message :: remaining_messages
+            ; context
+            ; working_context = None
+            }
+          , marker )
+;;
+
+type provenance =
+  { slot_id : string; call_id : string; plan_fingerprint : string;
+    request_body_sha256 : string }
+
+type outcome =
+  | Applied of
+      { checkpoint : Agent_sdk.Checkpoint.t; raw_ref : Keeper_checkpoint_ref.t;
+        installed_ref : Keeper_checkpoint_ref.t; provenance : provenance }
+  | Preserved of
+      { checkpoint : Agent_sdk.Checkpoint.t; raw_ref : Keeper_checkpoint_ref.t;
+        reason : preserved_reason }
+  | Skipped of preserved_reason
+
+let preserved checkpoint raw_ref reason =
+  Preserved { checkpoint; raw_ref; reason }
+;;
+
+let checkpoint_of_outcome = function
+  | Applied { checkpoint; _ } | Preserved { checkpoint; _ } -> Some checkpoint
+  | Skipped _ -> None
+;;
+
+let require_equal left right =
+  if String.equal left right then Ok () else Error Semantic_output_invalid
+;;
+
+let semantic_of_success flow_success =
+  let selected = Exact_output.flow_success_candidate flow_success in
+  let success = Exact_output.flow_success_output flow_success in
+  let call_id = Exact_output.call_id_to_string success.call_id in
+  let selected_call_id =
+    selected.receipt
+    |> Exact_output.receipt_call_id
+    |> Exact_output.call_id_to_string
+  in
+  let success_call_id =
+    success.receipt
+    |> Exact_output.receipt_call_id
+    |> Exact_output.call_id_to_string
+  in
+  let plan_fingerprint =
+    Exact_output.receipt_plan_fingerprint selected.receipt
+  in
+  let request_body_sha256 =
+    Exact_output.receipt_request_body_sha256 selected.receipt
+  in
+  let* () = require_equal call_id selected_call_id in
+  let* () = require_equal call_id success_call_id in
+  let* () =
+    require_equal
+      plan_fingerprint
+      (Exact_output.receipt_plan_fingerprint success.receipt)
+  in
+  let* () =
+    require_equal
+      request_body_sha256
+      (Exact_output.receipt_request_body_sha256 success.receipt)
+  in
+  match success.output with
+  | `Assoc [ "semantic_context", `String semantic_context ]
+    when String.trim semantic_context <> "" ->
+    Ok
+      ( semantic_context
+      , { slot_id = selected.visit.identity.candidate_id
+        ; call_id
+        ; plan_fingerprint
+        ; request_body_sha256
+        } )
+  | _ -> Error Semantic_output_invalid
+;;
+
+let flow_candidates selected_slots =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | (slot : Runtime_exact_output_registry.selected_slot) :: rest ->
+      (match
+         Exact_output.make_flow_candidate
+           ~id:slot.slot_id
+           ~admitted_target:slot.admitted_target
+       with
+       | Ok candidate -> loop (candidate :: acc) rest
+       | Error _ -> Error Exact_lane_unavailable)
+  in
+  loop [] selected_slots
+;;
+
+let exact_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "additionalProperties", `Bool false
+    ; ( "properties"
+      , `Assoc
+          [ "semantic_context"
+          , `Assoc [ "type", `String "string" ]
+          ] )
+    ; "required", `List [ `String "semantic_context" ]
+    ]
+;;
+
+let correction_messages marker semantic_messages selected =
+  let request =
+    `Assoc
+      [ "accepted_closed_unit_count", `Int marker.accepted_closed_unit_count
+      ; "prior_semantic_messages",
+        `List (List.map Keeper_context_core.message_to_json semantic_messages)
+      ; ( "new_closed_units"
+        , `List
+            (List.map
+               (fun unit ->
+                  `List
+                    (List.map
+                       Keeper_context_core.message_to_json
+                       (messages_of_closed_unit unit)))
+               selected) )
+      ]
+  in
+  [ Agent_sdk.Types.system_msg
+      "Update the Keeper's semantic context from the prior semantic state and \
+       the new closed turn units. Preserve decisions, constraints, goals, \
+       unresolved work, durable facts, and causal context. Return only the \
+       requested JSON object. Do not reproduce protocol shells."
+  ; Agent_sdk.Types.user_msg (Yojson.Safe.to_string request)
+  ]
+;;
+
+let execute_exact ~net ~clock ~marker ~semantic_messages ~selected =
+  let* registry =
+    Runtime_exact_output_registry.current ()
+    |> Result.map_error (fun _ -> Exact_lane_unavailable)
+  in
+  let* lane =
+    Runtime_exact_output_registry.resolve_lane registry ~lane_id
+    |> Result.map_error (fun _ -> Exact_lane_unavailable)
+  in
+  let* candidates = flow_candidates lane.selected_slots in
+  match candidates with
+  | [] -> Error Exact_lane_unavailable
+  | first :: rest ->
+    let requirement =
+      Exact_output.make_output_requirement
+        ~schema:exact_schema
+        ~minimum_guarantee:Exact_output.Json_syntax
+    in
+    let* snapshot =
+      Exact_output.snapshot_flow
+        ~first
+        ~rest
+        ~messages:(correction_messages marker semantic_messages selected)
+        requirement
+      |> Result.map_error (fun _ -> Exact_flow_failed)
+    in
+    let* attempt =
+      Exact_output.start_flow snapshot
+      |> Result.map_error (fun _ -> Exact_flow_failed)
+    in
+    let validate success =
+      match semantic_of_success success with
+      | Ok value -> Exact_output.Accept value
+      | Error reason -> Exact_output.Reject_and_advance reason
+    in
+    (match
+       Exact_output.execute_flow_once
+         ~net
+         ~clock
+         ~before_measurement_dispatch:(fun _ -> Ok ())
+         ~on_measurement_terminal:(fun _ -> Ok ())
+         ~before_dispatch:(fun _ -> Ok ())
+         ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+         ~validate
+         attempt
+     with
+     | Ok success -> Ok success.accepted
+     | Error
+         (Exact_output.Flow_semantic_candidates_exhausted _) ->
+       Error Semantic_output_invalid
+     | Error (Exact_output.Flow_execution_terminal _) ->
+       Error Exact_flow_failed)
+;;
+
+let classify_installation ~raw_checkpoint ~raw_ref ~candidate ~provenance = function
+  | Keeper_checkpoint_store.Installed { installed_ref; _ } ->
+    Applied { checkpoint = candidate; raw_ref; installed_ref; provenance }
+  | Keeper_checkpoint_store.Not_installed
+      { cause = Keeper_checkpoint_store.Source_changed _; _ } ->
+    preserved raw_checkpoint raw_ref Cas_conflict
+  | Keeper_checkpoint_store.Not_installed _ ->
+    preserved raw_checkpoint raw_ref Cas_not_installed
+;;
+
+let run
+      ~timeout_s
+      ~keeper_name
+      ~session_dir
+      ~start
+      ~history_messages
+      ~raw_checkpoint
+      ~raw_ref
+  =
+  let preserve = preserved raw_checkpoint raw_ref in
+  let raw_checkpoint_result =
+    match
+      Keeper_checkpoint_store.load_oas_exact_snapshot
+        ~session_dir
+        ~session_id:raw_checkpoint.session_id
+    with
+    | Error _ -> Error Cas_not_installed
+    | Ok snapshot ->
+      let current_ref =
+        Keeper_checkpoint_store.exact_snapshot_reference snapshot
+      in
+      if Keeper_checkpoint_ref.equal current_ref raw_ref
+      then
+        Ok (Keeper_checkpoint_store.exact_snapshot_checkpoint snapshot)
+      else Error Cas_conflict
+  in
+  match raw_checkpoint_result with
+  | Error reason -> preserve reason
+  | Ok raw_checkpoint ->
+  let preserve = preserved raw_checkpoint raw_ref in
+  let prepared =
+    let* marker = start_marker start in
+    let* () =
+      match start with
+      | Fresh ->
+        if history_messages = [] then Ok () else Error Start_prefix_mismatch
+      | Unavailable -> Error Start_checkpoint_unavailable
+      | Existing snapshot ->
+        let checkpoint =
+          Keeper_checkpoint_store.exact_snapshot_checkpoint snapshot
+        in
+        if checkpoint.messages = history_messages
+        then Ok ()
+        else Error Start_prefix_mismatch
+    in
+    let* raw_marker = marker_of_context raw_checkpoint.context in
+    let* () = if raw_marker = marker then Ok () else Error Marker_corrupt in
+    let* semantic_messages, backlog =
+      split_at marker.semantic_message_count [] raw_checkpoint.messages
+    in
+    let* () =
+      if String.equal marker.semantic_state_sha256 (sha256 (canonical_messages semantic_messages))
+      then Ok ()
+      else Error Marker_corrupt
+    in
+    let* partition =
+      Keeper_compaction_unit.partition backlog
+      |> Result.map_error (fun _ -> Marker_corrupt)
+    in
+    let* selected, _remaining = select_closed_units partition.closed_prefix in
+    if selected = []
+    then Error No_closed_delta
+    else Ok (marker, semantic_messages, selected)
+  in
+  match prepared with
+  | Error reason -> preserve reason
+  | Ok (marker, semantic_messages, selected) ->
+    (match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with
+     | None, _ -> preserve Network_unavailable
+     | _, None -> preserve Clock_unavailable
+     | Some net, Some clock ->
+       let deadline = Unix.gettimeofday () +. timeout_s in
+       let exact_result =
+         try
+           Eio.Time.with_timeout_exn clock timeout_s (fun () ->
+             execute_exact ~net ~clock ~marker ~semantic_messages ~selected)
+         with
+         | Eio.Time.Timeout -> Error Deadline_exceeded
+       in
+       (match exact_result with
+        | Error reason ->
+          Log.Keeper.warn
+            ~keeper_name
+            "context correction preserved raw checkpoint reason=%s"
+            (preserved_reason_to_string reason);
+          preserve reason
+        | Ok (semantic_context, provenance) ->
+          (match prepare_candidate ~marker ~raw_checkpoint ~semantic_context with
+           | Error reason -> preserve reason
+           | Ok (candidate, _marker) ->
+             if Unix.gettimeofday () >= deadline
+             then preserve Deadline_exceeded_before_cas
+             else
+               Keeper_checkpoint_store.save_oas_if_source
+                 ~session_dir
+                 ~expected_source_ref:raw_ref
+                 candidate
+               |> classify_installation
+                    ~raw_checkpoint
+                    ~raw_ref
+                    ~candidate
+                    ~provenance)))
+;;
+
+let provenance_to_json provenance =
+  `Assoc
+    [ "slot_id", `String provenance.slot_id
+    ; "call_id", `String provenance.call_id
+    ; "plan_fingerprint", `String provenance.plan_fingerprint
+    ; "request_body_sha256", `String provenance.request_body_sha256
+    ]
+;;
+
+let outcome_to_json = function
+  | Applied { raw_ref; installed_ref; provenance; _ } ->
+    `Assoc
+      [ "status", `String "applied"
+      ; "raw_checkpoint_sha256", `String raw_ref.sha256
+      ; "installed_checkpoint_sha256", `String installed_ref.sha256
+      ; "receipt", provenance_to_json provenance
+      ]
+  | Preserved { raw_ref; reason; _ } ->
+    `Assoc
+      [ "status", `String "preserved"
+      ; "raw_checkpoint_sha256", `String raw_ref.sha256
+      ; "reason", `String (preserved_reason_to_string reason)
+      ]
+  | Skipped reason ->
+    `Assoc
+      [ "status", `String "skipped"
+      ; "reason", `String (preserved_reason_to_string reason)
+      ]
+;;
+
+let submission_to_json (submission : submission) =
+  match submission with
+  | Unavailable -> `Assoc [ "status", `String "unavailable" ]
+  | Coalesced -> `Assoc [ "status", `String "coalesced" ]
+  | Submitted -> `Assoc [ "status", `String "submitted" ]
+;;
+
+module For_testing = struct
+  type nonrec marker = marker
+
+  let genesis_marker = genesis_marker
+  let marker_to_json = marker_to_json
+  let marker_of_json = marker_of_json
+  let prepare_candidate = prepare_candidate
+  let classify_installation = classify_installation
+
+  let reset_executor () =
+    Stdlib.Mutex.protect executor_mu (fun () ->
+      executor_sw := None;
+      Hashtbl.reset in_flight_keys)
+  ;;
+
+  let in_flight ~base_path ~keeper_name =
+    let key = executor_key ~base_path ~keeper_name in
+    Stdlib.Mutex.protect executor_mu (fun () ->
+      Hashtbl.mem in_flight_keys key)
+  ;;
+end

--- a/lib/keeper/keeper_context_correction.mli
+++ b/lib/keeper/keeper_context_correction.mli
@@ -1,0 +1,75 @@
+(** Per-turn LLM semantic replacement after the main provider run. Uses an
+    isolated exact flow and the existing checkpoint CAS only. *)
+
+val lane_id : string
+val state_context_key : string
+
+type submission = Unavailable | Coalesced | Submitted
+
+val init : sw:Eio.Switch.t -> unit
+val submit :
+  base_path:string -> keeper_name:string -> (unit -> unit) -> submission
+
+type start
+
+val capture_start : session_dir:string -> session_id:string -> start
+
+val bind_start_context : start -> Agent_sdk.Context.t -> unit
+val prepare_raw_checkpoint :
+  start:start -> Agent_sdk.Checkpoint.t -> Agent_sdk.Checkpoint.t
+
+type provenance =
+  { slot_id : string; call_id : string; plan_fingerprint : string;
+    request_body_sha256 : string }
+
+type preserved_reason =
+  | Control_checkpoint | Raw_save_superseded | Start_checkpoint_unavailable
+  | Fresh_state_required | Marker_corrupt | Start_prefix_mismatch
+  | No_closed_delta | Closed_unit_over_budget | Network_unavailable
+  | Clock_unavailable | Exact_lane_unavailable | Exact_flow_failed
+  | Semantic_output_invalid | Deadline_exceeded
+  | Deadline_exceeded_before_cas | Cas_conflict | Cas_not_installed
+
+type outcome =
+  | Applied of
+      { checkpoint : Agent_sdk.Checkpoint.t; raw_ref : Keeper_checkpoint_ref.t;
+        installed_ref : Keeper_checkpoint_ref.t; provenance : provenance }
+  | Preserved of
+      { checkpoint : Agent_sdk.Checkpoint.t; raw_ref : Keeper_checkpoint_ref.t;
+        reason : preserved_reason }
+  | Skipped of preserved_reason
+
+val run :
+  timeout_s:float ->
+  keeper_name:string ->
+  session_dir:string ->
+  start:start ->
+  history_messages:Agent_sdk.Types.message list ->
+  raw_checkpoint:Agent_sdk.Checkpoint.t ->
+  raw_ref:Keeper_checkpoint_ref.t ->
+  outcome
+
+val checkpoint_of_outcome : outcome -> Agent_sdk.Checkpoint.t option
+val outcome_to_json : outcome -> Yojson.Safe.t
+val submission_to_json : submission -> Yojson.Safe.t
+
+module For_testing : sig
+  type marker
+
+  val genesis_marker : marker
+  val marker_to_json : marker -> Yojson.Safe.t
+  val marker_of_json : Yojson.Safe.t -> (marker, preserved_reason) result
+
+  val prepare_candidate : marker:marker -> raw_checkpoint:Agent_sdk.Checkpoint.t ->
+    semantic_context:string ->
+    (Agent_sdk.Checkpoint.t * marker, preserved_reason) result
+
+  val classify_installation : raw_checkpoint:Agent_sdk.Checkpoint.t ->
+    raw_ref:Keeper_checkpoint_ref.t -> candidate:Agent_sdk.Checkpoint.t ->
+    provenance:provenance ->
+    Keeper_checkpoint_store.checkpoint_installation ->
+    outcome
+
+  val reset_executor : unit -> unit
+  val in_flight : base_path:string -> keeper_name:string -> bool
+end

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -485,6 +485,7 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
      switch. After [set_switch] so the lane and provider calls it forks share
      the same long-lived switch (cancelled together at shutdown). *)
   Keeper_memory_lane.init ~sw;
+  Keeper_context_correction.init ~sw;
   (* RFC-0107 Phase D.2c — record full Eio.Stdenv for piaf-backed
      Pool in Masc_http_client.  Optional: tests / pre-bootstrap
      callers may omit [env], in which case Pool falls back to a

--- a/test/dune
+++ b/test/dune
@@ -2611,3 +2611,4 @@
 
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
 (include stanzas/test_eio_resource_scope.inc)
+(include stanzas/test_keeper_context_correction.inc)

--- a/test/stanzas/test_keeper_context_correction.inc
+++ b/test/stanzas/test_keeper_context_correction.inc
@@ -1,0 +1,11 @@
+(test
+ (name test_keeper_context_correction)
+ (modules test_keeper_context_correction)
+ (libraries
+  agent_sdk
+  alcotest
+  eio
+  eio_main
+  masc
+  masc.keeper_checkpoint_ref
+  masc.keeper_registry))

--- a/test/test_keeper_context_correction.ml
+++ b/test/test_keeper_context_correction.ml
@@ -1,0 +1,302 @@
+module Correction = Masc.Keeper_context_correction
+module Testing = Correction.For_testing
+
+let message role text =
+  Agent_sdk.Types.make_message ~role [ Agent_sdk.Types.Text text ]
+;;
+
+let checkpoint ?(messages = []) () =
+  let context = Agent_sdk.Context.create_sync () in
+  Agent_sdk.Context.set_scoped
+    context
+    Agent_sdk.Context.Session
+    Masc.Keeper_checkpoint_store.keeper_generation_context_key
+    (`Int 1);
+  Agent_sdk.Checkpoint.
+    { version = checkpoint_version
+    ; session_id = "trace"
+    ; agent_name = "keeper"
+    ; model = "model"
+    ; system_prompt = Some "system"
+    ; messages
+    ; usage = Agent_sdk.Types.empty_usage
+    ; turn_count = 1
+    ; created_at = 1.0
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = None
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.Off
+    ; thinking_budget = None
+    ; reasoning_effort = None
+    ; cache_system_prompt = false
+    ; context
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+;;
+
+let checkpoint_ref (checkpoint : Agent_sdk.Checkpoint.t) =
+  let trace_id =
+    match Keeper_id.Trace_id.of_string checkpoint.Agent_sdk.Checkpoint.session_id with
+    | Ok value -> value
+    | Error detail -> Alcotest.fail detail
+  in
+  match
+    Keeper_checkpoint_ref.create
+      ~trace_id
+      ~generation:1
+      ~turn_count:checkpoint.turn_count
+      ~canonical_checkpoint_bytes:(Agent_sdk.Checkpoint.to_string checkpoint)
+  with
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "checkpoint ref"
+;;
+
+let install_marker checkpoint marker =
+  Agent_sdk.Context.set_scoped
+    checkpoint.Agent_sdk.Checkpoint.context
+    Agent_sdk.Context.Session
+    Correction.state_context_key
+    (Testing.marker_to_json marker)
+;;
+
+let provenance slot_id =
+  Correction.
+    { slot_id; call_id = "call"; plan_fingerprint = "plan";
+      request_body_sha256 = "request" }
+;;
+
+let expect_candidate marker checkpoint =
+  match
+    Testing.prepare_candidate
+      ~marker
+      ~raw_checkpoint:checkpoint
+      ~semantic_context:"semantic"
+  with
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "candidate rejected"
+;;
+
+let test_closed_units_advance_and_open_suffix_is_exact () =
+  let open_tool =
+    Agent_sdk.Types.make_message
+      ~role:Agent_sdk.Types.Assistant
+      [ Agent_sdk.Types.ToolUse
+          { id = "open"; name = "tool"; input = `Assoc [] }
+      ]
+  in
+  let raw =
+    checkpoint
+      ~messages:
+        [ message Agent_sdk.Types.User "u"
+        ; message Agent_sdk.Types.Assistant "a"
+        ; open_tool
+        ]
+      ()
+  in
+  let marker = Testing.genesis_marker in
+  install_marker raw marker;
+  let candidate, _ = expect_candidate marker raw in
+  match candidate.messages with
+  | semantic :: [ protected ] ->
+    Alcotest.(check bool) "fixed system role" true
+      (semantic.role = Agent_sdk.Types.System);
+    Alcotest.(check bool) "open suffix exact" true (protected = open_tool)
+  | _ -> Alcotest.fail "unexpected candidate partition"
+;;
+
+let test_marker_schema_is_current_only () =
+  match Testing.marker_of_json (`Assoc [ "version", `Int 0 ]) with
+  | Error Correction.Marker_corrupt -> ()
+  | _ -> Alcotest.fail "old marker accepted"
+;;
+
+let test_applied_checkpoint_is_downstream_checkpoint () =
+  let raw = checkpoint ~messages:[ message Agent_sdk.Types.User "u" ] () in
+  let marker = Testing.genesis_marker in
+  install_marker raw marker;
+  let candidate, _ = expect_candidate marker raw in
+  let raw_ref = checkpoint_ref raw in
+  let installed_ref = checkpoint_ref candidate in
+  let provenance = provenance "second" in
+  let outcome =
+    Testing.classify_installation
+      ~raw_checkpoint:raw
+      ~raw_ref
+      ~candidate
+      ~provenance
+      (Masc.Keeper_checkpoint_store.Installed
+         { installed_ref; auxiliary = [] })
+  in
+  Alcotest.(check bool) "corrected downstream" true
+    (Correction.checkpoint_of_outcome outcome = Some candidate)
+;;
+
+let test_cas_conflict_preserves_raw () =
+  let raw = checkpoint ~messages:[ message Agent_sdk.Types.User "u" ] () in
+  let marker = Testing.genesis_marker in
+  install_marker raw marker;
+  let candidate, _ = expect_candidate marker raw in
+  let raw_ref = checkpoint_ref raw in
+  let provenance = provenance "slot" in
+  let outcome =
+    Testing.classify_installation
+      ~raw_checkpoint:raw
+      ~raw_ref
+      ~candidate
+      ~provenance
+      (Masc.Keeper_checkpoint_store.Not_installed
+         { cause = Masc.Keeper_checkpoint_store.Source_changed raw_ref
+         ; auxiliary = []
+         })
+  in
+  match outcome with
+  | Correction.Preserved { checkpoint; reason = Correction.Cas_conflict; _ } ->
+    Alcotest.(check bool) "raw preserved" true (checkpoint = raw)
+  | _ -> Alcotest.fail "CAS conflict was not loud"
+;;
+
+let test_post_durable_auxiliary_is_applied () =
+  let raw = checkpoint ~messages:[ message Agent_sdk.Types.User "u" ] () in
+  let marker = Testing.genesis_marker in
+  install_marker raw marker;
+  let candidate, _ = expect_candidate marker raw in
+  let raw_ref = checkpoint_ref raw in
+  let installed_ref = checkpoint_ref candidate in
+  let provenance = provenance "slot" in
+  let outcome =
+    Testing.classify_installation
+      ~raw_checkpoint:raw
+      ~raw_ref
+      ~candidate
+      ~provenance
+      (Masc.Keeper_checkpoint_store.Installed
+         { installed_ref
+         ; auxiliary =
+             [ Masc.Keeper_checkpoint_store.Commit_observer_failed
+                 (Failure "observed after rename", Printexc.get_callstack 1)
+             ]
+         })
+  in
+  match outcome with
+  | Correction.Applied _ -> ()
+  | _ -> Alcotest.fail "durable installation was discarded"
+;;
+
+let test_empty_semantic_output_does_not_advance_marker () =
+  let raw = checkpoint ~messages:[ message Agent_sdk.Types.User "u" ] () in
+  let marker = Testing.genesis_marker in
+  install_marker raw marker;
+  match
+    Testing.prepare_candidate
+      ~marker
+      ~raw_checkpoint:raw
+      ~semantic_context:" "
+  with
+  | Error Correction.Semantic_output_invalid ->
+    Alcotest.(check bool) "marker unchanged" true
+      (Agent_sdk.Context.get_scoped
+         raw.context
+         Agent_sdk.Context.Session
+         Correction.state_context_key
+       = Some (Testing.marker_to_json marker))
+  | _ -> Alcotest.fail "empty semantic output accepted"
+;;
+
+let test_executor_never_runs_inline () =
+  Testing.reset_executor ();
+  let ran = ref false in
+  let outcome =
+    Correction.submit
+      ~base_path:"/tmp/context-correction"
+      ~keeper_name:"keeper"
+      (fun () -> ran := true)
+  in
+  Alcotest.(check bool) "unavailable" true
+    (outcome = Correction.Unavailable);
+  Alcotest.(check bool) "not inline" false !ran
+;;
+
+let test_executor_coalesces_and_releases () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Testing.reset_executor ();
+  Correction.init ~sw;
+  let release_p, release_u = Eio.Promise.create () in
+  let first =
+    Correction.submit
+      ~base_path:"/tmp/context-correction"
+      ~keeper_name:"keeper"
+      (fun () -> Eio.Promise.await release_p)
+  in
+  Eio.Fiber.yield ();
+  let second =
+    Correction.submit
+      ~base_path:"/tmp/context-correction"
+      ~keeper_name:"keeper"
+      (fun () -> ())
+  in
+  Alcotest.(check bool) "submitted" true (first = Correction.Submitted);
+  Alcotest.(check bool) "coalesced" true (second = Correction.Coalesced);
+  Eio.Promise.resolve release_u ();
+  let clock = Eio.Stdenv.clock env in
+  Eio.Time.with_timeout_exn clock 1.0 (fun () ->
+    while
+      Testing.in_flight
+        ~base_path:"/tmp/context-correction"
+        ~keeper_name:"keeper"
+    do Eio.Fiber.yield () done);
+  let third =
+    Correction.submit
+      ~base_path:"/tmp/context-correction"
+      ~keeper_name:"keeper"
+      (fun () -> ())
+  in
+  Alcotest.(check bool) "released" true (third = Correction.Submitted)
+;;
+
+let () =
+  Alcotest.run
+    "keeper context correction"
+    [ ( "correction"
+      , [ Alcotest.test_case
+            "closed units and protected suffix"
+            `Quick
+            test_closed_units_advance_and_open_suffix_is_exact
+        ; Alcotest.test_case
+            "current marker only"
+            `Quick
+            test_marker_schema_is_current_only
+        ; Alcotest.test_case
+            "applied checkpoint downstream"
+            `Quick
+            test_applied_checkpoint_is_downstream_checkpoint
+        ; Alcotest.test_case
+            "CAS conflict"
+            `Quick
+            test_cas_conflict_preserves_raw
+        ; Alcotest.test_case
+            "post durable install wins"
+            `Quick
+            test_post_durable_auxiliary_is_applied
+        ; Alcotest.test_case
+            "invalid output preserves marker"
+            `Quick
+            test_empty_semantic_output_does_not_advance_marker
+        ; Alcotest.test_case
+            "executor never inline"
+            `Quick
+            test_executor_never_runs_inline
+        ; Alcotest.test_case
+            "executor coalesces and releases"
+            `Quick
+            test_executor_coalesces_and_releases
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- seed a current-schema context-correction marker at genesis and preserve exact typed closed-unit coordinates
- commit the primary raw checkpoint and return the Keeper turn without waiting for semantic correction
- run LLM-authored semantic replacement on a Context-correction-owned detached executor with opaque OAS exact-output candidate failover
- reload and compare the immutable raw checkpoint ref before dispatch, then CAS-install only while that ref is still canonical
- preserve raw state and marker on unavailable, coalesced, invalid, timeout, or CAS-conflict outcomes

## Boundary
- no provider/model/capability/wire branching in MASC
- no OAS persistence or settlement facade
- no Memory/Librarian/Goal/Task coupling
- no inline fallback, durable queue, lease, journal, or migration

## Validation
- `scripts/dune-local.sh build test/test_keeper_context_correction.exe`
- `scripts/dune-local.sh exec test/test_keeper_context_correction.exe` (8 tests)
- `git diff --check`
