### PR TITLE
fix(goal): replay approved tasks into goal completion

### DIFF
--- a/lib/goal/dune
+++ b/lib/goal/dune
@@ -17,6 +17,7 @@
   masc_config
   masc_log
   masc_workspace
+  masc.activity_graph
   shared_audit
   time_compat
   fs_compat

--- a/lib/goal/goal_approved_task_projector.ml
+++ b/lib/goal/goal_approved_task_projector.ml
@@ -1,0 +1,236 @@
+(** Goal-owned projection of durable Task approval events. *)
+
+module String_set = Set.Make (String)
+
+type t =
+  { mutable last_seq : int
+  ; mutable approved_task_ids : String_set.t
+  }
+
+type error =
+  | Link_read_failed of string
+  | Event_read_failed of string
+  | Goal_update_failed of
+      { goal_id : string
+      ; detail : string
+      }
+  | Goal_event_failed of
+      { goal_id : string
+      ; detail : string
+      }
+
+type report =
+  { eligible_goal_count : int
+  ; replayed_event_count : int
+  ; approved_task_count : int
+  ; completed_goal_ids : string list
+  ; last_seq : int
+  }
+
+type metric =
+  | Verifier_approved_done_tasks of { target : int }
+
+let create () =
+  { last_seq = 0; approved_task_ids = String_set.empty }
+;;
+
+let last_seq (state : t) = state.last_seq
+
+let error_to_string = function
+  | Link_read_failed detail ->
+      "goal approved-task projector link read failed: " ^ detail
+  | Event_read_failed detail ->
+      "goal approved-task projector event replay failed: " ^ detail
+  | Goal_update_failed { goal_id; detail } ->
+      Printf.sprintf
+        "goal approved-task projector update failed (goal=%s): %s"
+        goal_id
+        detail
+  | Goal_event_failed { goal_id; detail } ->
+      Printf.sprintf
+        "goal approved-task projector event emit failed (goal=%s): %s"
+        goal_id
+        detail
+;;
+
+let metric_of_goal (goal : Goal_store.goal) =
+  match goal.metric, goal.target_value with
+  | Some "verifier_approved_done_tasks", Some raw_target ->
+      (match int_of_string_opt (String.trim raw_target) with
+       | Some target when target > 0 ->
+           Some (Verifier_approved_done_tasks { target })
+       | Some _ | None -> None)
+  | _ -> None
+;;
+
+let eligible_goal (goal : Goal_store.goal) =
+  goal.phase = Goal_phase.Executing
+  && Option.is_some (metric_of_goal goal)
+;;
+
+let approved_task_id (event : Activity_graph.event) =
+  match Event_kind.Task.of_string event.kind with
+  | Some Event_kind.Task.Approved ->
+      (match Json_util.get_string event.payload "task_id", event.subject with
+       | Some task_id, Some subject
+         when String.trim task_id <> ""
+              && String.equal subject.kind "task"
+              && String.equal subject.id task_id ->
+           Some task_id
+       | _ ->
+           Log.Misc.warn
+             "goal approved-task projector ignored malformed Approved event \
+              (seq=%d)"
+             event.seq;
+           None)
+  | Some
+      ( Event_kind.Task.Created
+      | Event_kind.Task.Claimed
+      | Event_kind.Task.Started
+      | Event_kind.Task.Released
+      | Event_kind.Task.Done
+      | Event_kind.Task.Cancelled
+      | Event_kind.Task.Submit_for_verification
+      | Event_kind.Task.Rejected
+      | Event_kind.Task.Linked )
+  | None -> None
+;;
+
+let linked_task_ids links goal_id =
+  match List.assoc_opt goal_id links with
+  | Some task_ids -> task_ids
+  | None -> []
+;;
+
+let target_satisfied ~approved_task_ids ~links (goal : Goal_store.goal) =
+  match metric_of_goal goal with
+  | None -> false
+  | Some (Verifier_approved_done_tasks { target }) ->
+      let approved_count =
+        linked_task_ids links goal.id
+        |> List.fold_left
+             (fun count task_id ->
+               if String_set.mem task_id approved_task_ids
+               then count + 1
+               else count)
+             0
+      in
+      approved_count >= target
+;;
+
+let replay_events (state : t) config =
+  try
+    let events =
+      Activity_graph.list_events
+        config
+        ~kinds:[ Event_kind.Task.to_string Event_kind.Task.Approved ]
+        ~after_seq:state.last_seq
+        ~limit:Int.max_int
+        ()
+    in
+    let approved_task_ids, next_last_seq =
+      List.fold_left
+        (fun (approved, max_seq) event ->
+          let approved =
+            match approved_task_id event with
+            | Some task_id -> String_set.add task_id approved
+            | None -> approved
+          in
+          approved, max max_seq event.Activity_graph.seq)
+        (state.approved_task_ids, state.last_seq)
+        events
+    in
+    Ok (events, approved_task_ids, next_last_seq)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Event_read_failed (Printexc.to_string exn))
+;;
+
+let run (state : t) config =
+  let eligible_goals =
+    Goal_store.list_goals config ~phase:Goal_phase.Executing ()
+    |> List.filter eligible_goal
+  in
+  match eligible_goals with
+  | [] ->
+      Ok
+        { eligible_goal_count = 0
+        ; replayed_event_count = 0
+        ; approved_task_count = String_set.cardinal state.approved_task_ids
+        ; completed_goal_ids = []
+        ; last_seq = state.last_seq
+        }
+  | _ ->
+      (match Workspace_goal_index.read_goal_task_links_r config with
+       | Error detail -> Error (Link_read_failed detail)
+       | Ok links ->
+           (match replay_events state config with
+            | Error _ as error -> error
+            | Ok (events, approved_task_ids, next_last_seq) ->
+                let rec complete completed = function
+                  | [] -> Ok (List.rev completed)
+                  | (goal : Goal_store.goal) :: rest ->
+                      if not (target_satisfied ~approved_task_ids ~links goal)
+                      then complete completed rest
+                      else
+                        let review_at = Masc_domain.now_iso () in
+                        (match
+                           Goal_store.update_goal_if
+                             config
+                             ~goal_id:goal.id
+                             (fun current ->
+                               if
+                                 current.phase = Goal_phase.Executing
+                                 && target_satisfied
+                                      ~approved_task_ids
+                                      ~links
+                                      current
+                               then
+                                 Some
+                                   { current with
+                                     phase = Goal_phase.Completed
+                                   ; last_review_note =
+                                       Some
+                                         "Completed from durable verifier-approved \
+                                          Task events."
+                                   ; last_review_at = Some review_at
+                                   }
+                               else None)
+                         with
+                         | Error detail ->
+                             Error
+                               (Goal_update_failed
+                                  { goal_id = goal.id; detail })
+                         | Ok (Goal_store.Unchanged _) ->
+                             complete completed rest
+                         | Ok (Goal_store.Updated updated) ->
+                             (try
+                                Goal_event.emit_phase
+                                  config
+                                  ~goal_id:updated.id
+                                  ~phase:updated.phase
+                                  ~actor:"system/goal-approved-task-projector";
+                                complete (updated.id :: completed) rest
+                              with
+                              | Eio.Cancel.Cancelled _ as exn -> raise exn
+                              | exn ->
+                                  Error
+                                    (Goal_event_failed
+                                       { goal_id = updated.id
+                                       ; detail = Printexc.to_string exn
+                                       })))
+                in
+                (match complete [] eligible_goals with
+                 | Error _ as error -> error
+                 | Ok completed_goal_ids ->
+                     state.approved_task_ids <- approved_task_ids;
+                     state.last_seq <- next_last_seq;
+                     Ok
+                       { eligible_goal_count = List.length eligible_goals
+                       ; replayed_event_count = List.length events
+                       ; approved_task_count =
+                           String_set.cardinal approved_task_ids
+                       ; completed_goal_ids
+                       ; last_seq = next_last_seq
+                       })))
+;;

--- a/lib/goal/goal_approved_task_projector.ml
+++ b/lib/goal/goal_approved_task_projector.ml
@@ -64,7 +64,7 @@ let metric_of_goal (goal : Goal_store.goal) =
 ;;
 
 let eligible_goal (goal : Goal_store.goal) =
-  goal.phase = Goal_phase.Executing
+  (goal.phase = Goal_phase.Executing || goal.phase = Goal_phase.Completed)
   && Option.is_some (metric_of_goal goal)
 ;;
 
@@ -106,16 +106,35 @@ let target_satisfied ~approved_task_ids ~links (goal : Goal_store.goal) =
   match metric_of_goal goal with
   | None -> false
   | Some (Verifier_approved_done_tasks { target }) ->
-      let approved_count =
+      let linked_task_ids =
         linked_task_ids links goal.id
-        |> List.fold_left
-             (fun count task_id ->
-               if String_set.mem task_id approved_task_ids
-               then count + 1
-               else count)
-             0
+        |> String_set.of_list
+      in
+      let approved_count =
+        String_set.inter linked_task_ids approved_task_ids
+        |> String_set.cardinal
       in
       approved_count >= target
+;;
+
+let projector_actor = "system/goal-approved-task-projector"
+
+let ensure_completed_goal_event config (goal : Goal_store.goal) =
+  try
+    ignore
+      (Goal_event.ensure_phase
+         config
+         ~goal_id:goal.id
+         ~phase:Goal_phase.Completed
+         ~actor:projector_actor
+         ~goal_updated_at:goal.updated_at);
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      Error
+        (Goal_event_failed
+           { goal_id = goal.id; detail = Printexc.to_string exn })
 ;;
 
 let replay_events (state : t) config =
@@ -148,7 +167,7 @@ let replay_events (state : t) config =
 
 let run (state : t) config =
   let eligible_goals =
-    Goal_store.list_goals config ~phase:Goal_phase.Executing ()
+    Goal_store.list_goals config ()
     |> List.filter eligible_goal
   in
   match eligible_goals with
@@ -161,12 +180,39 @@ let run (state : t) config =
         ; last_seq = state.last_seq
         }
   | _ ->
-      (match Workspace_goal_index.read_goal_task_links_r config with
-       | Error detail -> Error (Link_read_failed detail)
-       | Ok links ->
-           (match replay_events state config with
-            | Error _ as error -> error
-            | Ok (events, approved_task_ids, next_last_seq) ->
+      let completed_goals, executing_goals =
+        List.partition
+          (fun (goal : Goal_store.goal) ->
+            goal.phase = Goal_phase.Completed)
+          eligible_goals
+      in
+      let rec ensure_existing = function
+        | [] -> Ok ()
+        | goal :: rest ->
+            (match ensure_completed_goal_event config goal with
+             | Error _ as error -> error
+             | Ok () -> ensure_existing rest)
+      in
+      (match ensure_existing completed_goals with
+       | Error _ as error -> error
+       | Ok () ->
+           (match executing_goals with
+            | [] ->
+                Ok
+                  { eligible_goal_count = List.length eligible_goals
+                  ; replayed_event_count = 0
+                  ; approved_task_count =
+                      String_set.cardinal state.approved_task_ids
+                  ; completed_goal_ids = []
+                  ; last_seq = state.last_seq
+                  }
+            | _ ->
+                (match Workspace_goal_index.read_goal_task_links_r config with
+                 | Error detail -> Error (Link_read_failed detail)
+                 | Ok links ->
+                     (match replay_events state config with
+                      | Error _ as error -> error
+                      | Ok (events, approved_task_ids, next_last_seq) ->
                 let rec complete completed = function
                   | [] -> Ok (List.rev completed)
                   | (goal : Goal_store.goal) :: rest ->
@@ -175,52 +221,30 @@ let run (state : t) config =
                       else
                         let review_at = Masc_domain.now_iso () in
                         (match
-                           Goal_store.update_goal_if
+                           Goal_store.complete_goal_if_matches
                              config
                              ~goal_id:goal.id
-                             (fun current ->
-                               if
-                                 current.phase = Goal_phase.Executing
-                                 && target_satisfied
-                                      ~approved_task_ids
-                                      ~links
-                                      current
-                               then
-                                 Some
-                                   { current with
-                                     phase = Goal_phase.Completed
-                                   ; last_review_note =
-                                       Some
-                                         "Completed from durable verifier-approved \
-                                          Task events."
-                                   ; last_review_at = Some review_at
-                                   }
-                               else None)
+                             ~metric:goal.metric
+                             ~target_value:goal.target_value
+                             ~last_review_note:
+                               (Some
+                                  "Completed from durable verifier-approved \
+                                   Task events.")
+                             ~last_review_at:(Some review_at)
                          with
                          | Error detail ->
                              Error
                                (Goal_update_failed
                                   { goal_id = goal.id; detail })
-                         | Ok (Goal_store.Unchanged _) ->
+                         | Ok (Goal_store.Not_completed _) ->
                              complete completed rest
-                         | Ok (Goal_store.Updated updated) ->
-                             (try
-                                Goal_event.emit_phase
-                                  config
-                                  ~goal_id:updated.id
-                                  ~phase:updated.phase
-                                  ~actor:"system/goal-approved-task-projector";
-                                complete (updated.id :: completed) rest
-                              with
-                              | Eio.Cancel.Cancelled _ as exn -> raise exn
-                              | exn ->
-                                  Error
-                                    (Goal_event_failed
-                                       { goal_id = updated.id
-                                       ; detail = Printexc.to_string exn
-                                       })))
+                         | Ok (Goal_store.Completed_now updated) ->
+                             (match ensure_completed_goal_event config updated with
+                              | Error _ as error -> error
+                              | Ok () ->
+                                  complete (updated.id :: completed) rest))
                 in
-                (match complete [] eligible_goals with
+                (match complete [] executing_goals with
                  | Error _ as error -> error
                  | Ok completed_goal_ids ->
                      state.approved_task_ids <- approved_task_ids;
@@ -232,5 +256,6 @@ let run (state : t) config =
                            String_set.cardinal approved_task_ids
                        ; completed_goal_ids
                        ; last_seq = next_last_seq
-                       })))
+                       }))))
+       )
 ;;

--- a/lib/goal/goal_approved_task_projector.mli
+++ b/lib/goal/goal_approved_task_projector.mli
@@ -1,0 +1,36 @@
+(** Idempotent Goal-owned projection of durable [Task.Approved] events. *)
+
+type t
+
+type error =
+  | Link_read_failed of string
+  | Event_read_failed of string
+  | Goal_update_failed of
+      { goal_id : string
+      ; detail : string
+      }
+  | Goal_event_failed of
+      { goal_id : string
+      ; detail : string
+      }
+
+type report =
+  { eligible_goal_count : int
+  ; replayed_event_count : int
+  ; approved_task_count : int
+  ; completed_goal_ids : string list
+  ; last_seq : int
+  }
+
+val create : unit -> t
+val last_seq : t -> int
+val error_to_string : error -> string
+
+val run :
+  t ->
+  Workspace_utils.config ->
+  (report, error) result
+(** Replays retained approved-task events on the first eligible pass and only
+    events after the in-memory sequence on later passes. The in-memory sequence
+    and approved-task set advance only after link reads, Goal updates, and
+    canonical Goal event emission all succeed. *)

--- a/lib/goal/goal_event.ml
+++ b/lib/goal/goal_event.ml
@@ -26,3 +26,59 @@ let emit_phase config ~goal_id ~phase ~actor =
          ; "actor", `String actor
          ])
 ;;
+
+type ensure_outcome =
+  | Emitted
+  | Already_present
+
+let phase_event_matches ~goal_id ~phase ~actor ~goal_updated_at json =
+  match json with
+  | `Assoc _ ->
+      let payload =
+        Option.value
+          ~default:`Null
+          (Json_util.assoc_member_opt "payload" json)
+      in
+      Json_util.get_string json "goal_id" = Some goal_id
+      && Json_util.get_string json "event_type" = Some "goal_phase"
+      && Json_util.get_string payload "phase" = Some (Goal_phase.to_string phase)
+      && Json_util.get_string payload "actor" = Some actor
+      && Json_util.get_string payload "goal_updated_at" = Some goal_updated_at
+  | `List _ | `String _ | `Float _ | `Int _ | `Intlit _ | `Bool _ | `Null ->
+      false
+;;
+
+let ensure_phase config ~goal_id ~phase ~actor ~goal_updated_at =
+  let event_path = path config in
+  Workspace_utils.with_file_lock config event_path (fun () ->
+    let present =
+      if not (Sys.file_exists event_path)
+      then false
+      else
+        Fs_compat.fold_jsonl_lines
+          ~init:false
+          ~f:(fun present ~line_no:_ json ->
+            present
+            || phase_event_matches
+                 ~goal_id
+                 ~phase
+                 ~actor
+                 ~goal_updated_at
+                 json)
+          event_path
+    in
+    if present
+    then Already_present
+    else (
+      emit
+        config
+        ~goal_id
+        ~event_type:"goal_phase"
+        ~payload:
+          (`Assoc
+             [ "phase", Goal_phase.to_yojson phase
+             ; "actor", `String actor
+             ; "goal_updated_at", `String goal_updated_at
+             ]);
+      Emitted))
+;;

--- a/lib/goal/goal_event.ml
+++ b/lib/goal/goal_event.ml
@@ -1,0 +1,28 @@
+(** Canonical durable Goal event producer. *)
+
+let path config =
+  Filename.concat (Workspace_utils.masc_dir config) "goal_events.jsonl"
+;;
+
+let emit config ~goal_id ~event_type ~payload =
+  Fs_compat.append_jsonl
+    (path config)
+    (`Assoc
+       [ "ts", `String (Masc_domain.now_iso ())
+       ; "goal_id", `String goal_id
+       ; "event_type", `String event_type
+       ; "payload", payload
+       ])
+;;
+
+let emit_phase config ~goal_id ~phase ~actor =
+  emit
+    config
+    ~goal_id
+    ~event_type:"goal_phase"
+    ~payload:
+      (`Assoc
+         [ "phase", Goal_phase.to_yojson phase
+         ; "actor", `String actor
+         ])
+;;

--- a/lib/goal/goal_event.mli
+++ b/lib/goal/goal_event.mli
@@ -1,0 +1,12 @@
+(** Canonical durable Goal event producer over the existing
+    [goal_events.jsonl] log. *)
+
+val path : Workspace_utils.config -> string
+
+val emit_phase :
+  Workspace_utils.config ->
+  goal_id:string ->
+  phase:Goal_phase.t ->
+  actor:string ->
+  unit
+(** Appends the canonical [goal_phase] event consumed by Goal timelines. *)

--- a/lib/goal/goal_event.mli
+++ b/lib/goal/goal_event.mli
@@ -10,3 +10,17 @@ val emit_phase :
   actor:string ->
   unit
 (** Appends the canonical [goal_phase] event consumed by Goal timelines. *)
+
+type ensure_outcome =
+  | Emitted
+  | Already_present
+
+val ensure_phase :
+  Workspace_utils.config ->
+  goal_id:string ->
+  phase:Goal_phase.t ->
+  actor:string ->
+  goal_updated_at:string ->
+  ensure_outcome
+(** Ensures exactly one canonical phase projection for a specific persisted
+    Goal version. The existing Goal event log is the idempotence authority. *)

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -306,20 +306,37 @@ let update_state config f =
 let get_goal config ~goal_id =
   read_state config |> fun state -> find_goal state.goals goal_id
 
-type conditional_update_outcome =
-  | Updated of goal
-  | Unchanged of goal
+type conditional_completion_outcome =
+  | Completed_now of goal
+  | Not_completed of goal
 
-let update_goal_if config ~goal_id (f : goal -> goal option) =
+let complete_goal_if_matches
+      config
+      ~goal_id
+      ~metric
+      ~target_value
+      ~last_review_note
+      ~last_review_at
+  =
   let lock_path = goals_path config in
   Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       match find_goal state.goals goal_id with
       | None -> Error "goal not found"
       | Some goal ->
-          (match f goal with
-           | None -> Ok (Unchanged goal)
-           | Some (candidate : goal) ->
+          if
+            goal.phase <> Goal_phase.Executing
+            || goal.metric <> metric
+            || goal.target_value <> target_value
+          then Ok (Not_completed goal)
+          else
+            let candidate =
+              { goal with
+                phase = Goal_phase.Completed
+              ; last_review_note
+              ; last_review_at
+              }
+            in
                let now = Masc_domain.now_iso () in
                let updated_goal = { candidate with updated_at = now } in
                let next_state =
@@ -330,7 +347,7 @@ let update_goal_if config ~goal_id (f : goal -> goal option) =
                  }
                in
                let* () = write_state_result config next_state in
-               Ok (Updated updated_goal)))
+               Ok (Completed_now updated_goal))
 
 let update_goal config ~goal_id f =
   let lock_path = goals_path config in

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -306,6 +306,32 @@ let update_state config f =
 let get_goal config ~goal_id =
   read_state config |> fun state -> find_goal state.goals goal_id
 
+type conditional_update_outcome =
+  | Updated of goal
+  | Unchanged of goal
+
+let update_goal_if config ~goal_id (f : goal -> goal option) =
+  let lock_path = goals_path config in
+  Workspace_utils.with_file_lock config lock_path (fun () ->
+      let state = read_state config in
+      match find_goal state.goals goal_id with
+      | None -> Error "goal not found"
+      | Some goal ->
+          (match f goal with
+           | None -> Ok (Unchanged goal)
+           | Some (candidate : goal) ->
+               let now = Masc_domain.now_iso () in
+               let updated_goal = { candidate with updated_at = now } in
+               let next_state =
+                 {
+                   version = state.version + 1;
+                   updated_at = now;
+                   goals = replace_goal state.goals updated_goal;
+                 }
+               in
+               let* () = write_state_result config next_state in
+               Ok (Updated updated_goal)))
+
 let update_goal config ~goal_id f =
   let lock_path = goals_path config in
   Workspace_utils.with_file_lock config lock_path (fun () ->

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -129,17 +129,21 @@ val update_state :
 
 val get_goal : Workspace_utils.config -> goal_id:string -> goal option
 
-type conditional_update_outcome =
-  | Updated of goal
-  | Unchanged of goal
+type conditional_completion_outcome =
+  | Completed_now of goal
+  | Not_completed of goal
 
-val update_goal_if :
+val complete_goal_if_matches :
   Workspace_utils.config ->
   goal_id:string ->
-  (goal -> goal option) ->
-  (conditional_update_outcome, string) result
-(** Atomically applies a conditional update under the Goal store lock.
-    [None] returns [Unchanged] without writing the store or bumping its version. *)
+  metric:string option ->
+  target_value:string option ->
+  last_review_note:string option ->
+  last_review_at:string option ->
+  (conditional_completion_outcome, string) result
+(** Atomically completes an executing Goal only when its current metric and
+    target still match the caller's typed snapshot. A mismatch returns
+    [Not_completed] without writing or bumping the Goal store version. *)
 
 val update_goal :
   Workspace_utils.config ->

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -129,6 +129,18 @@ val update_state :
 
 val get_goal : Workspace_utils.config -> goal_id:string -> goal option
 
+type conditional_update_outcome =
+  | Updated of goal
+  | Unchanged of goal
+
+val update_goal_if :
+  Workspace_utils.config ->
+  goal_id:string ->
+  (goal -> goal option) ->
+  (conditional_update_outcome, string) result
+(** Atomically applies a conditional update under the Goal store lock.
+    [None] returns [Unchanged] without writing the store or bumping its version. *)
+
 val update_goal :
   Workspace_utils.config ->
   goal_id:string ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -447,6 +447,41 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       Tool_metrics_persist.enqueue r
     | _ -> ());
   Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:(Mcp_server.workspace_config state).base_path;
+  (* Goal-owned approved-task projector. Task transitions only emit the
+     existing durable Task.Approved event; this independent consumer replays
+     it once on startup and incrementally thereafter. Its cursor is
+     process-local and advances only after every cross-SSOT projection succeeds,
+     so a failed pass is retried without adding another durable coordination
+     store. *)
+  let goal_approved_task_projector =
+    Goal_approved_task_projector.create ()
+  in
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "goal_approved_task_projector")
+    (fun () ->
+      let rec loop () =
+        (match Goal_approved_task_projector.run goal_approved_task_projector config with
+         | Ok report ->
+             if report.completed_goal_ids <> []
+             then
+               Log.Server.info
+                 "goal approved-task projector: completed=%d replayed=%d \
+                  approved_tasks=%d last_seq=%d"
+                 (List.length report.completed_goal_ids)
+                 report.replayed_event_count
+                 report.approved_task_count
+                 report.last_seq
+         | Error error ->
+             Log.Server.warn
+               "goal approved-task projector: reconciliation required: %s"
+               (Goal_approved_task_projector.error_to_string error));
+        Eio.Time.sleep
+          clock
+          Env_config_runtime.InternalTimers.janitor_interval_sec;
+        loop ()
+      in
+      loop ());
   (* RFC-0234 scheduled automation runner.  Public schedule tools and the
      dashboard-only approval route only mutate the durable ledger; this loop is
      the production caller that observes due rows and emits at-most-once generic wake signals.  It

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -220,20 +220,6 @@ let update_goal_phase (ctx : context) (goal : Goal_store.goal) ~phase ?note () =
     })
 ;;
 
-let emit_goal_event (ctx : context) ~goal_id ~event_type ~payload =
-  let path =
-    Filename.concat (Workspace_utils.masc_dir ctx.config) "goal_events.jsonl"
-  in
-  Fs_compat.append_jsonl
-    path
-    (`Assoc
-       [ "ts", `String (Masc_domain.now_iso ())
-       ; "goal_id", `String goal_id
-       ; "event_type", `String event_type
-       ; "payload", payload
-       ])
-;;
-
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( reject_retired_goal_list_status args
@@ -339,15 +325,11 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
            | Error msg ->
              error_result_typed ~tool_name ~start_time ~code:Internal_error msg
            | Ok updated_goal ->
-             emit_goal_event
-               ctx
+             Goal_event.emit_phase
+               ctx.config
                ~goal_id
-               ~event_type:"goal_phase"
-               ~payload:
-                 (`Assoc
-                    [ "phase", Goal_phase.to_yojson updated_goal.phase
-                    ; "actor", `String ctx.agent_name
-                    ]);
+               ~phase:updated_goal.phase
+               ~actor:ctx.agent_name;
              ok_result
                ~tool_name
                ~start_time

--- a/test/dune
+++ b/test/dune
@@ -1065,6 +1065,7 @@
   test_goal_tools
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
+  test_goal_approved_task_projector
   test_goal_metric_unevaluated
   test_string_util
   test_prompt_asset_sync
@@ -1229,6 +1230,7 @@
   test_goal_tools
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
+  test_goal_approved_task_projector
   test_goal_metric_unevaluated
   test_string_util
   test_prompt_asset_sync

--- a/test/test_goal_approved_task_projector.ml
+++ b/test/test_goal_approved_task_projector.ml
@@ -1,0 +1,197 @@
+open Alcotest
+open Masc
+
+let temp_dir () = Filename.temp_dir "goal_approved_task_projector" ""
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Workspace.default_config dir in
+      ignore (Workspace.init config ~agent_name:(Some "test"));
+      f config)
+;;
+
+let create_goal config ~id ~target =
+  match
+    Goal_store.upsert_goal
+      config
+      ~id
+      ~title:id
+      ~metric:"verifier_approved_done_tasks"
+      ~target_value:(string_of_int target)
+      ~phase:Goal_phase.Executing
+      ()
+  with
+  | Ok (goal, _) -> goal
+  | Error detail -> fail detail
+;;
+
+let emit_task_event config ~kind ~task_id =
+  ignore
+    (Activity_graph.emit
+       config
+       ~kind:(Event_kind.Task.to_string kind)
+       ~actor:(Activity_graph.entity ~kind:"agent" "verifier")
+       ~subject:(Activity_graph.entity ~kind:"task" task_id)
+       ~tags:[ "task" ]
+       ~payload:(`Assoc [ "task_id", `String task_id ])
+       ())
+;;
+
+let goal_phase config goal_id =
+  match Goal_store.get_goal config ~goal_id with
+  | Some goal -> goal.phase
+  | None -> fail ("missing goal: " ^ goal_id)
+;;
+
+let goal_event_count config =
+  let path = Goal_event.path config in
+  if not (Sys.file_exists path)
+  then 0
+  else
+    Fs_compat.load_file path
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> String.trim line <> "")
+    |> List.length
+;;
+
+let test_restart_replay_and_idempotence () =
+  with_workspace
+  @@ fun config ->
+  let goal = create_goal config ~id:"goal-replay" ~target:1 in
+  Workspace_goal_index.link_task_to_goal
+    config
+    ~goal_id:goal.id
+    ~task_id:"task-1";
+  emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-1";
+  let projector = Goal_approved_task_projector.create () in
+  (match Goal_approved_task_projector.run projector config with
+   | Ok report ->
+       check (list string) "completed goal" [ goal.id ] report.completed_goal_ids
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check string "goal completed" "completed"
+    (Goal_phase.to_string (goal_phase config goal.id));
+  let version = (Goal_store.read_state config).version in
+  check int "one canonical event" 1 (goal_event_count config);
+  (match Goal_approved_task_projector.run projector config with
+   | Ok _ -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check int "idempotent version" version (Goal_store.read_state config).version;
+  check int "idempotent event" 1 (goal_event_count config)
+;;
+
+let test_target_counts_distinct_approved_tasks () =
+  with_workspace
+  @@ fun config ->
+  let goal = create_goal config ~id:"goal-two" ~target:2 in
+  List.iter
+    (fun task_id ->
+      Workspace_goal_index.link_task_to_goal
+        config
+        ~goal_id:goal.id
+        ~task_id)
+    [ "task-1"; "task-2" ];
+  let projector = Goal_approved_task_projector.create () in
+  emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-1";
+  emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-1";
+  ignore (Goal_approved_task_projector.run projector config);
+  check string "duplicate approval is one task" "executing"
+    (Goal_phase.to_string (goal_phase config goal.id));
+  emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-2";
+  (match Goal_approved_task_projector.run projector config with
+   | Ok _ -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check string "second distinct task completes" "completed"
+    (Goal_phase.to_string (goal_phase config goal.id))
+;;
+
+let test_direct_done_is_not_approval () =
+  with_workspace
+  @@ fun config ->
+  let goal = create_goal config ~id:"goal-direct" ~target:1 in
+  Workspace_goal_index.link_task_to_goal
+    config
+    ~goal_id:goal.id
+    ~task_id:"task-direct";
+  emit_task_event config ~kind:Event_kind.Task.Done ~task_id:"task-direct";
+  let projector = Goal_approved_task_projector.create () in
+  (match Goal_approved_task_projector.run projector config with
+   | Ok _ -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check string "direct done ignored" "executing"
+    (Goal_phase.to_string (goal_phase config goal.id))
+;;
+
+let test_link_failure_holds_cursor_for_retry () =
+  with_workspace
+  @@ fun config ->
+  let goal = create_goal config ~id:"goal-retry" ~target:1 in
+  emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-retry";
+  let links_path = Workspace_goal_index.goal_task_links_path config in
+  let recovery_path = links_path ^ ".last-good" in
+  Unix.mkdir links_path 0o755;
+  Unix.mkdir recovery_path 0o755;
+  let projector = Goal_approved_task_projector.create () in
+  (match Goal_approved_task_projector.run projector config with
+   | Error (Goal_approved_task_projector.Link_read_failed _) -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error)
+   | Ok _ -> fail "expected link read failure");
+  check int "cursor held" 0 (Goal_approved_task_projector.last_seq projector);
+  Unix.rmdir links_path;
+  Unix.rmdir recovery_path;
+  Workspace_goal_index.link_task_to_goal
+    config
+    ~goal_id:goal.id
+    ~task_id:"task-retry";
+  (match Goal_approved_task_projector.run projector config with
+   | Ok _ -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check string "retry completes" "completed"
+    (Goal_phase.to_string (goal_phase config goal.id))
+;;
+
+let () =
+  run
+    "goal-approved-task-projector"
+    [ ( "projection"
+      , [ test_case
+            "restart replay and idempotence"
+            `Quick
+            test_restart_replay_and_idempotence
+        ; test_case
+            "target counts distinct approvals"
+            `Quick
+            test_target_counts_distinct_approved_tasks
+        ; test_case
+            "direct done is ignored"
+            `Quick
+            test_direct_done_is_not_approval
+        ; test_case
+            "link failure holds cursor"
+            `Quick
+            test_link_failure_holds_cursor_for_retry
+        ] )
+    ]
+;;

--- a/test/test_goal_approved_task_projector.ml
+++ b/test/test_goal_approved_task_projector.ml
@@ -102,13 +102,9 @@ let test_target_counts_distinct_approved_tasks () =
   with_workspace
   @@ fun config ->
   let goal = create_goal config ~id:"goal-two" ~target:2 in
-  List.iter
-    (fun task_id ->
-      Workspace_goal_index.link_task_to_goal
-        config
-        ~goal_id:goal.id
-        ~task_id)
-    [ "task-1"; "task-2" ];
+  Workspace_goal_index.write_goal_task_links
+    config
+    [ goal.id, [ "task-1"; "task-1"; "task-2" ] ];
   let projector = Goal_approved_task_projector.create () in
   emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-1";
   emit_task_event config ~kind:Event_kind.Task.Approved ~task_id:"task-1";
@@ -172,6 +168,43 @@ let test_link_failure_holds_cursor_for_retry () =
     (Goal_phase.to_string (goal_phase config goal.id))
 ;;
 
+let test_goal_event_failure_is_repaired () =
+  with_workspace
+  @@ fun config ->
+  let goal = create_goal config ~id:"goal-event-repair" ~target:1 in
+  Workspace_goal_index.link_task_to_goal
+    config
+    ~goal_id:goal.id
+    ~task_id:"task-event-repair";
+  emit_task_event
+    config
+    ~kind:Event_kind.Task.Approved
+    ~task_id:"task-event-repair";
+  let event_path = Goal_event.path config in
+  Unix.mkdir event_path 0o755;
+  let projector = Goal_approved_task_projector.create () in
+  (match Goal_approved_task_projector.run projector config with
+   | Error (Goal_approved_task_projector.Goal_event_failed _) -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error)
+   | Ok _ -> fail "expected Goal event failure");
+  check string "Goal update committed" "completed"
+    (Goal_phase.to_string (goal_phase config goal.id));
+  check int "cursor held for repair" 0
+    (Goal_approved_task_projector.last_seq projector);
+  Unix.rmdir event_path;
+  (match Goal_approved_task_projector.run projector config with
+   | Ok _ -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check int "canonical event repaired once" 1 (goal_event_count config);
+  (match Goal_approved_task_projector.run projector config with
+   | Ok _ -> ()
+   | Error error ->
+       fail (Goal_approved_task_projector.error_to_string error));
+  check int "repair is idempotent" 1 (goal_event_count config)
+;;
+
 let () =
   run
     "goal-approved-task-projector"
@@ -192,6 +225,10 @@ let () =
             "link failure holds cursor"
             `Quick
             test_link_failure_holds_cursor_for_retry
+        ; test_case
+            "Goal event failure is repaired"
+            `Quick
+            test_goal_event_failure_is_repaired
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add a Goal-owned idempotent projector over durable typed `task.approved` events
- keep an ephemeral sequence cursor and approved-task set, advancing only after links, Goal updates, and canonical events succeed
- centralize canonical `goal_phase` emission and repair event gaps from the persisted Goal version
- run reconciliation in an isolated server maintenance fiber

## Safety
- Task transition files remain untouched
- no new durable store, cursor, lease, settlement, or receipt
- Goal completion rechecks phase and typed metric target under the Goal store lock
- duplicate goal-task links are counted once via set intersection

## Validation
- `scripts/dune-local.sh build test/test_goal_approved_task_projector.exe lib/server/masc_server.cmxa`
- `scripts/dune-local.sh exec ./test/test_goal_approved_task_projector.exe` (5 passed)
- `scripts/dune-local.sh exec ./test/test_goal_store.exe` (13 passed)
- `opam exec -- ocamlformat --check <changed OCaml files>`

Closes #25957