### PR TITLE
fix(test): main dashboard typecheck 복구 — approval parity 인벤토리 타입

### DIFF
--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -196,12 +196,18 @@ describe('SSE event-type cross-boundary parity (exact-match routes)', () => {
   // verdicts settled invisibly until the 120-180s periodic sweep. Full-surface
   // reverse parity remains the closed-sum keystone's job; this pins the one
   // class the HITL queue's liveness depends on.
-  const backendApprovalEvents = [
-    ...new Set(
-      readFileSync(resolve(process.cwd(), '../lib/keeper/keeper_approval_queue.ml'), 'utf8')
-        .matchAll(/"(approval:[a-z_]+)"/g),
-    ),
-  ].map(match => match[1])
+  const backendApprovalEvents = ((): string[] => {
+    const source = readFileSync(
+      resolve(process.cwd(), '../lib/keeper/keeper_approval_queue.ml'),
+      'utf8',
+    )
+    const found = new Set<string>()
+    for (const match of source.matchAll(/"(approval:[a-z_]+)"/g)) {
+      const eventType = match[1]
+      if (eventType !== undefined) found.add(eventType)
+    }
+    return [...found]
+  })()
 
   it('parses a non-empty backend approval:* inventory', () => {
     // Positive control: a rename or regex drift that matches nothing must fail


### PR DESCRIPTION
## 문제

`main` 의 dashboard typecheck가 실패합니다.

```
src/sse-event-type-parity.test.ts(213,70): error TS2345:
  Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

#25959 에서 추가한 역방향 parity 검사가 `matchAll` 결과를 `.map(match => match[1])` 로 모았는데, strict index signature 아래에서 `match[1]` 은 `string | undefined` 입니다. 그 배열이 `feRouted.has(t)` 로 흘러가면서 거부됩니다.

## 왜 놓쳤나

로컬에서 `vitest` 만 돌렸습니다. vitest는 트랜스파일만 하고 타입을 검사하지 않으므로 61/61 통과했고, `tsc --noEmit` 은 실행하지 않았습니다. #25959 의 Dashboard CI가 이 오류로 실패했지만 머지가 먼저 진행됐습니다.

## 수정

명시적 `undefined` 체크로 수집합니다. `!` 나 `as string` 으로 타입을 우회하지 않습니다.

```ts
for (const match of source.matchAll(/"(approval:[a-z_]+)"/g)) {
  const eventType = match[1]
  if (eventType !== undefined) found.add(eventType)
}
```

## 검증

- `tsc --noEmit` exit 0
- `sse-event-type-parity.test.ts` + `sse-store.test.ts` 61/61
