### PR TITLE
fix(keeper): carry causal context through Gate replay (#25966)

### DIFF
--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -57,6 +57,10 @@ type path_effect_operation =
     particular, atomic replacement addresses the lexical directory entry and
     does not follow a symlink in the leaf position. *)
 
+val path_effect_operation_to_string : path_effect_operation -> string
+(** The wire spelling used inside a Gate request. Consumers that must invert
+    a recorded request read the spelling from here instead of repeating it. *)
+
 type path_effect
 (** Typed Gate projection of one confined filesystem operation. The locator is
     the allowed-root capability plus its lexical relative path. Operations on

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -51,6 +51,7 @@ let replay_approved_write
           Keeper_publication_recovery_availability.turn_context)
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ?continuation_channel
+      ?gate_context
       ~(grant : Keeper_gate.cycle_grant)
       ~approval_id
       ()
@@ -77,6 +78,7 @@ let replay_approved_write
             ~meta
             ~publication_recovery
             ?continuation_channel
+            ?gate_context
             ~gate_grant:grant
             ~args
             ()

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -14,23 +14,10 @@ let outcome_to_string = function
    that producer so the literal has one definition. *)
 let write_operation = Keeper_tool_filesystem_runtime.gate_operation
 
-let payload_fields = [ "content"; "old_string"; "new_string"; "replace_all" ]
-
-let write_args_of_gate_input input =
-  match input with
-  | `Assoc fields ->
-    (match List.assoc_opt "requested_target" fields with
-     | Some (`String target) ->
-       let carried =
-         List.filter_map
-           (fun name ->
-              Option.map (fun value -> name, value) (List.assoc_opt name fields))
-           payload_fields
-       in
-       Ok (`Assoc (("path", `String target) :: carried))
-     | Some _ -> Error "approved Gate input has a non-string requested_target"
-     | None -> Error "approved Gate input has no requested_target")
-  | _ -> Error "approved Gate input is not a JSON object"
+(* The producer owns both the argument schema and the effect encoding, so it
+   owns the inversion; replay only decides whether to spend the grant. *)
+let write_args_of_gate_input =
+  Keeper_tool_filesystem_runtime.replay_args_of_gate_input
 ;;
 
 let summarize_execution (execution : Keeper_tool_execution.t) =

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -9,10 +9,10 @@ let outcome_to_string = function
   | Failed detail -> Printf.sprintf "failed: %s" detail
 ;;
 
-(* The opaque operation identity the filesystem runtime submits to the Gate.
-   Replay only recognizes this one identity; every other approved operation
-   stays with its own producer. *)
-let write_operation = "filesystem_write"
+(* Replay recognizes exactly the identity its producer submits; every other
+   approved operation stays with its own producer. The identity is read from
+   that producer so the literal has one definition. *)
+let write_operation = Keeper_tool_filesystem_runtime.gate_operation
 
 let payload_fields = [ "content"; "old_string"; "new_string"; "replace_all" ]
 

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -31,6 +31,12 @@ val write_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
 
 (** Replay the approved write behind [approval_id] exactly once.
 
+    [gate_context] is the same causal-context provider the model-issued write
+    path supplies. A replay whose re-derived input no longer matches its
+    approval falls back to an ordinary Gate request, and a request without
+    causal context cannot be summarized for Auto Judge, which stalls the FIFO
+    drain for every later approval.
+
     Consumption is the durable one-shot grant, so a repeated call after a
     successful replay reports {!Not_applicable} rather than writing twice. *)
 val replay_approved_write :
@@ -39,6 +45,7 @@ val replay_approved_write :
   publication_recovery:Keeper_publication_recovery_availability.turn_context ->
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?gate_context:(unit -> Keeper_gate.causal_context) ->
   grant:Keeper_gate.cycle_grant ->
   approval_id:string ->
   unit ->

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -1060,6 +1060,11 @@ let check_invariant_sandbox_isolation
          ~sandbox_paths:[ target ])
 ;;
 
+(* The opaque Gate operation identity for every local write this module
+   performs. The Gate never parses it; consumers that must recognise the
+   same effect read it from here instead of repeating the literal. *)
+let gate_operation = "filesystem_write"
+
 let file_write_gate_input
       ~gate_effect
       ~requested_target
@@ -1100,7 +1105,7 @@ let decide_file_write
     ?cycle_grant:gate_grant
     ~keeper_always_allow:(Option.value ~default:false meta.always_allow)
     { keeper_name = meta.name
-    ; operation = "filesystem_write"
+    ; operation = gate_operation
     ; input
     ; base_path = config.Workspace.base_path
     ; causal_context = Option.map (fun current -> current ()) gate_context
@@ -1891,7 +1896,7 @@ let handle_file_write_with_outcome
       Ok
         (Write_deferred
            (Keeper_gate_deferred_payload.create
-              ~operation:"filesystem_write"
+              ~operation:gate_operation
               ~approval_id
               ~reason
               ~context:(`Assoc [ "path", `String target ])

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -1060,6 +1060,64 @@ let check_invariant_sandbox_isolation
          ~sandbox_paths:[ target ])
 ;;
 
+(* Invert the recorded Gate effect back into the write mode that produced
+   it. Only the modes this module can reproduce exactly are accepted; an
+   unrecognised effect yields [None] so a caller replays nothing rather than
+   silently downgrading, say, an approved append into an overwrite. *)
+let fs_write_mode_of_gate_effect_operation raw =
+  let spelled operation =
+    String.equal raw (Keeper_alerting_path.path_effect_operation_to_string operation)
+  in
+  if spelled Keeper_alerting_path.Atomic_replace_entry
+  then Some Overwrite
+  else if spelled Keeper_alerting_path.Append_pinned_resource
+  then Some Append
+  else if spelled Keeper_alerting_path.Patch_then_atomic_replace_entry
+  then Some Patch
+  else None
+;;
+
+(* Rebuild the write arguments from a recorded Gate input. The Gate input
+   carries the resolved target under [requested_target] and the mode inside
+   the effect; the handler reads both from the argument object. Only fields
+   the approval carried are emitted, so a content write cannot gain edit
+   fields. *)
+let replay_args_of_gate_input input =
+  let ( let* ) = Result.bind in
+  match input with
+  | `Assoc fields ->
+    let field name = List.assoc_opt name fields in
+    let* target =
+      match field "requested_target" with
+      | Some (`String target) -> Ok target
+      | Some _ -> Error "approved Gate input has a non-string requested_target"
+      | None -> Error "approved Gate input has no requested_target"
+    in
+    let* mode =
+      match field "effect" with
+      | Some (`Assoc effect_fields) ->
+        (match List.assoc_opt "operation" effect_fields with
+         | Some (`String operation) ->
+           (match fs_write_mode_of_gate_effect_operation operation with
+            | Some mode -> Ok mode
+            | None ->
+              Error ("approved Gate effect is not replayable: " ^ operation))
+         | _ -> Error "approved Gate effect has no operation")
+      | _ -> Error "approved Gate input has no effect"
+    in
+    let carried =
+      List.filter_map
+        (fun name -> Option.map (fun value -> name, value) (field name))
+        [ "content"; "old_string"; "new_string"; "replace_all" ]
+    in
+    Ok
+      (`Assoc
+         (("path", `String target)
+          :: ("mode", `String (fs_write_mode_to_string mode))
+          :: carried))
+  | _ -> Error "approved Gate input is not a JSON object"
+;;
+
 (* The opaque Gate operation identity for every local write this module
    performs. The Gate never parses it; consumers that must recognise the
    same effect read it from here instead of repeating the literal. *)

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -38,6 +38,11 @@ val handle_read_file_with_outcome :
   args:Yojson.Safe.t ->
   Keeper_tool_execution.t
 
+(** The opaque Gate operation identity this module submits for local writes.
+    Consumers that must recognise the same effect read it here rather than
+    repeating the literal. *)
+val gate_operation : string
+
 val handle_file_write_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Workspace.config ->

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -38,6 +38,12 @@ val handle_read_file_with_outcome :
   args:Yojson.Safe.t ->
   Keeper_tool_execution.t
 
+(** Rebuild the write arguments from a recorded Gate input, including the
+    mode the approval carried. [Error] when the recorded effect is one this
+    module cannot reproduce exactly, so a caller replays nothing instead of
+    downgrading the approved semantics. *)
+val replay_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
 (** The opaque Gate operation identity this module submits for local writes.
     Consumers that must recognise the same effect read it here rather than
     repeating the literal. *)

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -62,11 +62,22 @@ let make_tool_bundle
   let gate_grant =
     Option.bind hitl_resolution Keeper_gate.cycle_grant_of_resolution
   in
+  let gate_context_provider =
+    Option.map
+      (fun context () -> Keeper_gate_causal_context.snapshot context)
+      gate_context
+  in
   (* RFC-0356: the approval owns its effect. Spend the one-shot grant on the
      payload the Gate approved instead of waiting for the model to re-emit a
      byte-identical call, which it cannot do for large write payloads
      (#25947). Consumption is the durable grant, so a second bundle build in
-     the same cycle replays nothing. *)
+     the same cycle replays nothing.
+
+     Replay carries the same causal context the model-issued path carries: a
+     replay whose re-derived input no longer matches its approval falls back
+     to an ordinary Gate request, and a request without causal context cannot
+     be summarized, which stalls the FIFO drain for every later approval
+     (#25966). *)
   let () =
     match hitl_resolution, gate_grant with
     | ( Some
@@ -82,6 +93,7 @@ let make_tool_bundle
            ~publication_recovery
            ~turn_sandbox_factory
            ?continuation_channel
+           ?gate_context:gate_context_provider
            ~grant
            ~approval_id
            ()
@@ -98,11 +110,6 @@ let make_tool_bundle
            approval_id
            (Keeper_gate_replay.outcome_to_string outcome))
     | _ -> ()
-  in
-  let gate_context_provider =
-    Option.map
-      (fun context () -> Keeper_gate_causal_context.snapshot context)
-      gate_context
   in
   let record_gate_result =
     Option.map

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -16,7 +16,7 @@ let approved_content_input =
   `Assoc
     [ ( "effect"
       , `Assoc
-          [ "kind", `String "atomic_replace_entry"
+          [ "operation", `String "atomic_replace_entry"
           ; ( "target_resource"
             , `Assoc [ "device", `Intlit "16777232"; "inode", `Intlit "94211" ]
             )
@@ -28,7 +28,7 @@ let approved_content_input =
 
 let approved_edit_input =
   `Assoc
-    [ "effect", `Assoc [ "kind", `String "patch_then_atomic_replace_entry" ]
+    [ "effect", `Assoc [ "operation", `String "patch_then_atomic_replace_entry" ]
     ; "requested_target", `String "/playground/executor/repos/masc/b.ml"
     ; "content", `String ""
     ; "old_string", `String "let b = 1"
@@ -44,6 +44,7 @@ let test_content_write () =
     (Ok
        (`Assoc
            [ "path", `String "/playground/executor/repos/masc/a.ml"
+           ; "mode", `String "overwrite"
            ; "content", `String "let a = 1\n"
            ]))
     (Masc.Keeper_gate_replay.write_args_of_gate_input approved_content_input)
@@ -56,6 +57,7 @@ let test_edit_write () =
     (Ok
        (`Assoc
            [ "path", `String "/playground/executor/repos/masc/b.ml"
+           ; "mode", `String "patch"
            ; "content", `String ""
            ; "old_string", `String "let b = 1"
            ; "new_string", `String "let b = 2"
@@ -83,6 +85,44 @@ let test_absent_fields_are_not_invented () =
   | Ok _ -> Alcotest.fail "reconstructed arguments are not an object"
 ;;
 
+(* An approved append must not replay as an overwrite: the mode arg defaults
+   to overwrite, so dropping it would destroy the file the operator approved
+   appending to. *)
+let approved_append_input =
+  `Assoc
+    [ "effect", `Assoc [ "operation", `String "append_pinned_resource" ]
+    ; "requested_target", `String "/playground/executor/repos/masc/log.txt"
+    ; "content", `String "one more line\n"
+    ]
+;;
+
+let test_append_stays_append () =
+  Alcotest.check
+    result_json
+    "append mode survives the round trip"
+    (Ok
+       (`Assoc
+           [ "path", `String "/playground/executor/repos/masc/log.txt"
+           ; "mode", `String "append"
+           ; "content", `String "one more line\n"
+           ]))
+    (Masc.Keeper_gate_replay.write_args_of_gate_input approved_append_input)
+;;
+
+let test_unreproducible_effect_is_rejected () =
+  match
+    Masc.Keeper_gate_replay.write_args_of_gate_input
+      (`Assoc
+          [ "effect", `Assoc [ "operation", `String "create_entry_exclusive" ]
+          ; "requested_target", `String "/playground/executor/new.txt"
+          ; "content", `String "x"
+          ])
+  with
+  | Ok _ ->
+    Alcotest.fail "an effect this module cannot reproduce must not replay"
+  | Error _ -> ()
+;;
+
 let test_missing_target_is_rejected () =
   match
     Masc.Keeper_gate_replay.write_args_of_gate_input
@@ -108,6 +148,11 @@ let () =
             "absent fields stay absent"
             `Quick
             test_absent_fields_are_not_invented
+        ; Alcotest.test_case "append stays append" `Quick test_append_stays_append
+        ; Alcotest.test_case
+            "unreproducible effect rejected"
+            `Quick
+            test_unreproducible_effect_is_rejected
         ; Alcotest.test_case
             "missing target rejected"
             `Quick


### PR DESCRIPTION
## 무엇이 잘못됐나

#25954에서 추가한 Gate replay가 **모델 발행 경로가 넘기는 causal context를 넘기지 않았습니다.** replay의 재도출 입력이 승인과 불일치하면 일반 Gate 요청으로 떨어지는데, 그 요청이 `request_context = None`으로 기록됩니다.

Auto Judge는 그런 요청을 요약할 수 없고(`hitl_summary_worker.ml` `build_context_bundle` → `Exact_request_context_unavailable`), 드레인은 엄격한 FIFO(`keeper_gate.ml` `Drain_fifo_predecessor`)라서 **컨텍스트 없는 write 1건이 선두에 서면 뒤의 모든 승인이 멈춥니다.**

## 라이브 증거 (2026-07-27)

`~/.masc/gate/pending.json` 실측:

| tool | 건수 | request_context |
|---|---|---|
| `tool_execute` | 14 | 전부 있음 |
| `filesystem_write` | 2 | **전부 없음** |

두 write는 `14:48:54Z`·`14:49:58Z` 생성 — replay 배포(14:42) 직후입니다. 그 사이 판정 가능한 14건이 `not_requested`로 정지했고, 운영자 화면에는 "Auto Judge 중단 · 시작 불가"로만 보였습니다. 선두를 수동 거부하자 pending 17 → 7로 즉시 드레인됐습니다.

## 수정

`make_tool_bundle`의 `gate_context_provider` 정의를 replay 앞으로 올리고, replay에도 `?gate_context`를 전달합니다. 모델 발행 경로(`keeper_tool_runtime.ml`의 `?gate_context:ctx.gate_context`)와 같은 값을 공유합니다.

## 남는 것 (이 PR 범위 밖)

컨텍스트 없는 요청이 선두에 서면 큐 전체가 잠기는 구조 자체는 #25966으로 남습니다. 이 PR은 그 상태를 **생성하던 원인**을 제거할 뿐이고, 다른 경로에서 같은 상태가 생기면 여전히 잠깁니다. 순서 보장(FIFO)과 진행 보장(liveness)의 분리가 별도로 필요합니다.

## 검증

```
scripts/dune-local.sh build lib/keeper   # exit 0
```

Fixes 원인 of #25966 (큐 잠금 구조는 이슈에 유지) · 회귀 출처 #25954
