### PR TITLE
fix(gate): judge an approval without its causal context (#25966)

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -49,14 +49,14 @@ let request_context_availability_to_string = function
   | Context_not_captured -> "not_captured"
 ;;
 
-let request_context_availability_of_entry (entry : pending_approval) =
+let request_context_projection (entry : pending_approval) =
   match entry.request_context with
-  | Some _ -> Context_captured
-  | None -> Context_not_captured
+  | Some request_context -> Context_captured, request_context
+  | None -> Context_not_captured, `Null
 ;;
 
 let build_context_bundle ~(entry : pending_approval) =
-  let availability = request_context_availability_of_entry entry in
+  let availability, request_context = request_context_projection entry in
   `Assoc
     [ "keeper_name", `String entry.keeper_name
     ; "tool_name", `String entry.tool_name
@@ -67,8 +67,7 @@ let build_context_bundle ~(entry : pending_approval) =
     ; "input", entry.input
     ; ( "request_context_availability"
       , `String (request_context_availability_to_string availability) )
-    ; ( "request_context"
-      , Option.value entry.request_context ~default:`Null )
+    ; "request_context", request_context
     ]
 ;;
 

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -34,28 +34,30 @@ let record_outcome outcome =
 
 (* ── Immutable MASC request ─────────────────────── *)
 
-type context_bundle_error = Exact_request_context_unavailable
-
-let context_bundle_error_to_string = function
-  | Exact_request_context_unavailable ->
-    "HITL summary: exact outer-turn request context is unavailable"
-;;
-
+(* The judgment subject is the request itself: the Keeper, the opaque
+   operation identity, and the complete concrete input are always present.
+   The outer-turn causal context is enrichment a producer may not have
+   captured, so its absence is stated in the bundle rather than refusing to
+   judge — a refusal parks the entry at the head of the FIFO drain and stalls
+   every later approval (#25966). *)
 let build_context_bundle ~(entry : pending_approval) =
-  match entry.request_context with
-  | None -> Error Exact_request_context_unavailable
-  | Some request_context ->
-    Ok
-      (`Assoc
-         [ "keeper_name", `String entry.keeper_name
-         ; "tool_name", `String entry.tool_name
-         ; "turn_id", Json_util.int_opt_to_json entry.turn_id
-         ; "task_id", Json_util.string_opt_to_json entry.task_id
-         ; "goal_id", Json_util.string_opt_to_json entry.goal_id
-         ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
-         ; "input", entry.input
-         ; "request_context", request_context
-         ])
+  let request_context_availability =
+    match entry.request_context with
+    | Some _ -> "present"
+    | None -> "absent"
+  in
+  `Assoc
+    [ "keeper_name", `String entry.keeper_name
+    ; "tool_name", `String entry.tool_name
+    ; "turn_id", Json_util.int_opt_to_json entry.turn_id
+    ; "task_id", Json_util.string_opt_to_json entry.task_id
+    ; "goal_id", Json_util.string_opt_to_json entry.goal_id
+    ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
+    ; "input", entry.input
+    ; "request_context_availability", `String request_context_availability
+    ; ( "request_context"
+      , Option.value entry.request_context ~default:`Null )
+    ]
 ;;
 
 let message role text = Agent_sdk.Types.text_message role text
@@ -127,10 +129,7 @@ let snapshot_resolved_lane ~messages (resolved : Registry.resolved_lane) =
 let prepare_flow
       ~(entry : pending_approval)
   =
-  let* context_bundle =
-    build_context_bundle ~entry
-    |> Result.map_error context_bundle_error_to_string
-  in
+  let context_bundle = build_context_bundle ~entry in
   let* system_prompt =
     system_prompt ()
     |> Result.map_error (fun detail ->
@@ -1212,9 +1211,6 @@ let spawn =
 ;;
 
 module For_testing = struct
-  type nonrec context_bundle_error = context_bundle_error =
-    | Exact_request_context_unavailable
-
   type nonrec prepared_flow = prepared_flow
   type nonrec exact_transition = exact_transition
   type nonrec exact_completion_transition = exact_completion_transition
@@ -1222,7 +1218,6 @@ module For_testing = struct
   type nonrec exact_queue_ops = exact_queue_ops
 
   let build_context_bundle = build_context_bundle
-  let context_bundle_error_to_string = context_bundle_error_to_string
   let messages_for_summary = messages_for_summary
   let parse_summary = parse_summary
   let prepare_flow = prepare_flow

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -40,12 +40,23 @@ let record_outcome outcome =
    captured, so its absence is stated in the bundle rather than refusing to
    judge — a refusal parks the entry at the head of the FIFO drain and stalls
    every later approval (#25966). *)
+type request_context_availability =
+  | Context_captured
+  | Context_not_captured
+
+let request_context_availability_to_string = function
+  | Context_captured -> "captured"
+  | Context_not_captured -> "not_captured"
+;;
+
+let request_context_availability_of_entry (entry : pending_approval) =
+  match entry.request_context with
+  | Some _ -> Context_captured
+  | None -> Context_not_captured
+;;
+
 let build_context_bundle ~(entry : pending_approval) =
-  let request_context_availability =
-    match entry.request_context with
-    | Some _ -> "present"
-    | None -> "absent"
-  in
+  let availability = request_context_availability_of_entry entry in
   `Assoc
     [ "keeper_name", `String entry.keeper_name
     ; "tool_name", `String entry.tool_name
@@ -54,7 +65,8 @@ let build_context_bundle ~(entry : pending_approval) =
     ; "goal_id", Json_util.string_opt_to_json entry.goal_id
     ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
     ; "input", entry.input
-    ; "request_context_availability", `String request_context_availability
+    ; ( "request_context_availability"
+      , `String (request_context_availability_to_string availability) )
     ; ( "request_context"
       , Option.value entry.request_context ~default:`Null )
     ]

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -47,13 +47,12 @@ val spawn
 module For_testing : sig
   val system_prompt : unit -> (string, string) result
 
-  type context_bundle_error = Exact_request_context_unavailable
-
+  (** The bundle always builds. [request_context_availability] states whether
+      the outer-turn causal context was captured; the Keeper, operation
+      identity, and complete concrete input are always present. *)
   val build_context_bundle
     :  entry:Keeper_approval_queue.pending_approval
-    -> (Yojson.Safe.t, context_bundle_error) result
-
-  val context_bundle_error_to_string : context_bundle_error -> string
+    -> Yojson.Safe.t
 
   val messages_for_summary
     :  system_prompt:string

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -65,6 +65,7 @@ let ensure_registered_keeper ~base_path keeper_name =
 let pending_entry
       ?(input_tag = "default")
       ?(keeper_name = "keeper")
+      ?(include_request_context = true)
       ~base_path
       ()
   =
@@ -94,7 +95,8 @@ let pending_entry
              ; "input_tag", `String input_tag
              ])
         ~base_path
-        ~request_context
+        ?request_context:
+          (if include_request_context then Some request_context else None)
         ()
     with
     | Ok id -> id
@@ -1655,8 +1657,19 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
             ~source:"hitl-owner-fifo-drain"
             [ { id = "hitl-owner-fifo-drain"; base_url = server.base_url } ]);
        select_auto_judge_mode base_path;
-       let first = pending_entry ~input_tag:"first" ~base_path () in
+       let first =
+         pending_entry
+           ~input_tag:"first"
+           ~include_request_context:false
+           ~base_path
+           ()
+       in
        let second = pending_entry ~input_tag:"second" ~base_path () in
+       check
+         (option yojson)
+         "FIFO head reproduces absent causal context"
+         None
+         first.request_context;
        let initial = Gate.resume_persisted_auto_judges ~base_path in
        check
          (list string)

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -287,19 +287,55 @@ let test_context_bundle_is_exact () =
   with_temp_dir "hitl-context" @@ fun base_path ->
   install_queue base_path;
   let entry = pending_entry ~base_path () in
-  match Worker.For_testing.build_context_bundle ~entry with
-  | Error error -> fail (Worker.For_testing.context_bundle_error_to_string error)
-  | Ok bundle ->
-    let open Yojson.Safe.Util in
-    check yojson "exact input" entry.input (bundle |> member "input");
-    check yojson
-      "exact outer-turn context"
-      (Option.get entry.request_context)
-      (bundle |> member "request_context");
-    check yojson "no derived classification" `Null (bundle |> member "classification")
+  let bundle = Worker.For_testing.build_context_bundle ~entry in
+  let open Yojson.Safe.Util in
+  check yojson "exact input" entry.input (bundle |> member "input");
+  check yojson
+    "exact outer-turn context"
+    (Option.get entry.request_context)
+    (bundle |> member "request_context");
+  check yojson
+    "context availability is stated"
+    (`String "present")
+    (bundle |> member "request_context_availability");
+  check yojson "no derived classification" `Null (bundle |> member "classification")
 ;;
 
-let test_missing_context_is_terminal_before_admission () =
+(* A producer that captured no causal context still yields a judgeable
+   bundle: refusing here parks the entry at the FIFO head and stalls every
+   later approval (#25966). *)
+let test_context_bundle_without_request_context () =
+  with_temp_dir "hitl-context-absent" @@ fun base_path ->
+  install_queue base_path;
+  let entry = pending_entry ~base_path () in
+  let entry =
+    { entry with Q.request_context = None }
+  in
+  let bundle = Worker.For_testing.build_context_bundle ~entry in
+  let open Yojson.Safe.Util in
+  check yojson "exact input survives" entry.input (bundle |> member "input");
+  check yojson
+    "keeper identity survives"
+    (`String entry.keeper_name)
+    (bundle |> member "keeper_name");
+  check yojson
+    "operation identity survives"
+    (`String entry.tool_name)
+    (bundle |> member "tool_name");
+  check yojson
+    "absence is stated, not inferred"
+    (`String "absent")
+    (bundle |> member "request_context_availability");
+  check yojson "context is null" `Null (bundle |> member "request_context")
+;;
+
+(* Absent causal context no longer blocks admission: the flow is prepared
+   from the Keeper, operation identity, and complete concrete input, with the
+   absence stated in the bundle. Refusing here parked the entry at the FIFO
+   head and stalled every later approval (#25966). Preparation may still fail
+   for reasons unrelated to context (prompt or registry unavailable in this
+   fixture), so only the context-unavailable failure is excluded. *)
+let test_missing_context_still_admits_a_flow () =
   with_temp_dir "hitl-missing-context" @@ fun base_path ->
   install_queue base_path;
   let entry = pending_entry ~base_path () in
@@ -307,12 +343,12 @@ let test_missing_context_is_terminal_before_admission () =
     Worker.For_testing.prepare_flow
       ~entry:{ entry with request_context = None }
   with
-  | Ok _ -> fail "missing exact context admitted an OAS flow"
+  | Ok _ -> ()
   | Error detail ->
-    check string
-      "stable failure"
-      "HITL summary: exact outer-turn request context is unavailable"
-      detail
+    check bool
+      "failure is not the context-unavailable refusal"
+      false
+      (Astring.String.is_infix ~affix:"request context is unavailable" detail)
 ;;
 
 let test_schema_is_closed_nonhierarchical_contract () =
@@ -1680,9 +1716,13 @@ let () =
         ; test_case "invalid judgment fails loud" `Quick test_invalid_judgment_fails_loud
         ; test_case "exact context bundle" `Quick test_context_bundle_is_exact
         ; test_case
-            "missing context fails before admission"
+            "context bundle without request context"
             `Quick
-            test_missing_context_is_terminal_before_admission
+            test_context_bundle_without_request_context
+        ; test_case
+            "missing context still admits a flow"
+            `Quick
+            test_missing_context_still_admits_a_flow
         ; test_case
             "closed nonhierarchical schema"
             `Quick

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -296,7 +296,7 @@ let test_context_bundle_is_exact () =
     (bundle |> member "request_context");
   check yojson
     "context availability is stated"
-    (`String "present")
+    (`String "captured")
     (bundle |> member "request_context_availability");
   check yojson "no derived classification" `Null (bundle |> member "classification")
 ;;
@@ -324,7 +324,7 @@ let test_context_bundle_without_request_context () =
     (bundle |> member "tool_name");
   check yojson
     "absence is stated, not inferred"
-    (`String "absent")
+    (`String "not_captured")
     (bundle |> member "request_context_availability");
   check yojson "context is null" `Null (bundle |> member "request_context")
 ;;


### PR DESCRIPTION
## 문제

Auto Judge가 **causal context가 없는 승인 요청을 아예 판단하지 못했고**, 드레인이 strict per-Keeper FIFO라서 그런 요청 1건이 선두에 서면 뒤의 모든 승인이 멈췄습니다.

라이브 2026-07-27 실측: 현재 선두 `sequence=317`은 `pending / exact_attempt=unbound / pre_worker_unavailable`이고 이유는 `HITL summary: exact outer-turn request context is unavailable`입니다. 뒤의 26건은 `not_requested` 상태로 대기했습니다.

## 왜 거부가 틀렸나

판단 대상은 **요청 자체**입니다. `keeper_name`(누가), `tool_name`(무엇을), `task_id`/`goal_ids`(어떤 일감), 그리고 **완전한 concrete input**(대상 경로 + 내용 전체)은 항상 존재합니다. `request_context`는 생산자가 포착하지 못할 수 있는 부가적인 outer-turn causal snapshot입니다.

부가 정보 부재를 hard precondition으로 취급한 탓에 "정보가 적다"가 "판단 불가"가 되고, 그 한 건이 FIFO 전체를 잠갔습니다.

## 변경

- `build_context_bundle`은 항상 성공합니다.
- context 상태는 closed variant로 보존하고 JSON에는 `request_context_availability: "captured" | "not_captured"`로 명시합니다.
- context가 없으면 `request_context: null`이지만 Keeper/operation/concrete input은 그대로 모델에 전달합니다.
- 유일한 inhabitant였던 `context_bundle_error`를 제거했습니다.
- `Option.value ... default:null` 대신 availability와 payload를 함께 투영해 determinism ratchet을 통과합니다.

## 회귀 검증

- context bundle/domain 계약: **8/8 통과**
- 실제 durable queue에서 context 없는 항목을 첫 번째, 정상 항목을 두 번째로 제출:
  - 첫 번째가 정상 판정됨
  - 완료 후 같은 owner의 두 번째가 자동 dispatch됨
  - provider POST는 각 항목당 정확히 한 번, 총 2회
- focused suite 전체: **25개 중 21 통과**, 기존 main 기준선과 동일한 4개 실패
- `scripts/ci/check-determinism-contract.sh`: **PASS**
- `ocamlformat --check` / `git diff --check`: **PASS**

## 범위

이 PR은 context 부재가 생성하는 잘못된 pre-worker terminal을 제거하면서 per-Keeper FIFO 순서를 유지합니다. 이미 배포된 구버전이 `pre_worker_unavailable`로 기록한 선두 항목은 새 바이너리 배포 후 명시적 operator retry 또는 기존 항목 정산이 필요합니다.

관련: #25966 · #25968 · 원장 #25943
