### PR TITLE
fix(keeper): judge approvals that carry no outer-turn context

### DIFF
--- a/config/prompts/keeper.gate_judgment.md
+++ b/config/prompts/keeper.gate_judgment.md
@@ -10,8 +10,14 @@ classification or product policy.
 
 Return `approve` when the visible evidence justifies this exact request,
 `deny` when the visible evidence justifies refusal, and `require_human` when
-the evidence is missing, ambiguous, or contradictory. If the request belongs
-to an active Task or Goal, state that relationship in the first sentence of
-the context summary. If `partial_context` is true, identify what is missing.
+the request stays ambiguous or contradictory after you have weighed every
+field you were given. If the request belongs to an active Task or Goal, state
+that relationship in the first sentence of the context summary.
+
+`partial_context` reports whether outer-turn context accompanied the request.
+When it is true, the request was raised outside a Keeper turn and no transcript
+exists to attach, so judge the registered operation identity and the complete
+input on their own and name the absent context in the rationale. A true
+`partial_context` is not by itself a reason to return `require_human`.
 
 Respond only through the requested structured JSON contract.

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -34,28 +34,30 @@ let record_outcome outcome =
 
 (* ── Immutable MASC request ─────────────────────── *)
 
-type context_bundle_error = Exact_request_context_unavailable
-
-let context_bundle_error_to_string = function
-  | Exact_request_context_unavailable ->
-    "HITL summary: exact outer-turn request context is unavailable"
-;;
-
+(* The fields that identify a request - keeper, tool, complete input, and
+   task/goal linkage - are present on every pending approval. Outer-turn
+   context is an accuracy aid that a request raised outside a Keeper turn
+   structurally cannot carry, so its absence is reported to the judge as
+   [partial_context] instead of ending the attempt. *)
 let build_context_bundle ~(entry : pending_approval) =
+  let request_identity =
+    [ "keeper_name", `String entry.keeper_name
+    ; "tool_name", `String entry.tool_name
+    ; "turn_id", Json_util.int_opt_to_json entry.turn_id
+    ; "task_id", Json_util.string_opt_to_json entry.task_id
+    ; "goal_id", Json_util.string_opt_to_json entry.goal_id
+    ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
+    ; "input", entry.input
+    ]
+  in
   match entry.request_context with
-  | None -> Error Exact_request_context_unavailable
   | Some request_context ->
-    Ok
-      (`Assoc
-         [ "keeper_name", `String entry.keeper_name
-         ; "tool_name", `String entry.tool_name
-         ; "turn_id", Json_util.int_opt_to_json entry.turn_id
-         ; "task_id", Json_util.string_opt_to_json entry.task_id
-         ; "goal_id", Json_util.string_opt_to_json entry.goal_id
-         ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
-         ; "input", entry.input
+    `Assoc
+      (request_identity
+       @ [ "partial_context", `Bool false
          ; "request_context", request_context
          ])
+  | None -> `Assoc (request_identity @ [ "partial_context", `Bool true ])
 ;;
 
 let message role text = Agent_sdk.Types.text_message role text
@@ -127,10 +129,7 @@ let snapshot_resolved_lane ~messages (resolved : Registry.resolved_lane) =
 let prepare_flow
       ~(entry : pending_approval)
   =
-  let* context_bundle =
-    build_context_bundle ~entry
-    |> Result.map_error context_bundle_error_to_string
-  in
+  let context_bundle = build_context_bundle ~entry in
   let* system_prompt =
     system_prompt ()
     |> Result.map_error (fun detail ->
@@ -1212,9 +1211,6 @@ let spawn =
 ;;
 
 module For_testing = struct
-  type nonrec context_bundle_error = context_bundle_error =
-    | Exact_request_context_unavailable
-
   type nonrec prepared_flow = prepared_flow
   type nonrec exact_transition = exact_transition
   type nonrec exact_completion_transition = exact_completion_transition
@@ -1222,7 +1218,6 @@ module For_testing = struct
   type nonrec exact_queue_ops = exact_queue_ops
 
   let build_context_bundle = build_context_bundle
-  let context_bundle_error_to_string = context_bundle_error_to_string
   let messages_for_summary = messages_for_summary
   let parse_summary = parse_summary
   let prepare_flow = prepare_flow

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -47,13 +47,9 @@ val spawn
 module For_testing : sig
   val system_prompt : unit -> (string, string) result
 
-  type context_bundle_error = Exact_request_context_unavailable
-
   val build_context_bundle
     :  entry:Keeper_approval_queue.pending_approval
-    -> (Yojson.Safe.t, context_bundle_error) result
-
-  val context_bundle_error_to_string : context_bundle_error -> string
+    -> Yojson.Safe.t
 
   val messages_for_summary
     :  system_prompt:string

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -287,32 +287,53 @@ let test_context_bundle_is_exact () =
   with_temp_dir "hitl-context" @@ fun base_path ->
   install_queue base_path;
   let entry = pending_entry ~base_path () in
-  match Worker.For_testing.build_context_bundle ~entry with
-  | Error error -> fail (Worker.For_testing.context_bundle_error_to_string error)
-  | Ok bundle ->
-    let open Yojson.Safe.Util in
-    check yojson "exact input" entry.input (bundle |> member "input");
-    check yojson
-      "exact outer-turn context"
-      (Option.get entry.request_context)
-      (bundle |> member "request_context");
-    check yojson "no derived classification" `Null (bundle |> member "classification")
+  let bundle = Worker.For_testing.build_context_bundle ~entry in
+  let open Yojson.Safe.Util in
+  check yojson "exact input" entry.input (bundle |> member "input");
+  check yojson
+    "exact outer-turn context"
+    (Option.get entry.request_context)
+    (bundle |> member "request_context");
+  check yojson "context is whole" (`Bool false) (bundle |> member "partial_context");
+  check yojson "no derived classification" `Null (bundle |> member "classification")
 ;;
 
-let test_missing_context_is_terminal_before_admission () =
+let test_missing_context_is_reported_as_partial () =
   with_temp_dir "hitl-missing-context" @@ fun base_path ->
   install_queue base_path;
   let entry = pending_entry ~base_path () in
-  match
-    Worker.For_testing.prepare_flow
+  let bundle =
+    Worker.For_testing.build_context_bundle
       ~entry:{ entry with request_context = None }
-  with
-  | Ok _ -> fail "missing exact context admitted an OAS flow"
-  | Error detail ->
-    check string
-      "stable failure"
-      "HITL summary: exact outer-turn request context is unavailable"
-      detail
+  in
+  let open Yojson.Safe.Util in
+  check yojson "context is partial" (`Bool true) (bundle |> member "partial_context");
+  check yojson "no fabricated context" `Null (bundle |> member "request_context");
+  check yojson "request identity survives" entry.input (bundle |> member "input");
+  check yojson
+    "keeper identity survives"
+    (`String entry.keeper_name)
+    (bundle |> member "keeper_name");
+  check yojson
+    "tool identity survives"
+    (`String entry.tool_name)
+    (bundle |> member "tool_name")
+;;
+
+let test_missing_context_does_not_change_flow_admission () =
+  with_temp_dir "hitl-context-admission" @@ fun base_path ->
+  install_queue base_path;
+  let entry = pending_entry ~base_path () in
+  let outcome candidate =
+    match Worker.For_testing.prepare_flow ~entry:candidate with
+    | Ok _ -> Ok ()
+    | Error detail -> Error detail
+  in
+  check
+    (result unit string)
+    "outer-turn context presence does not decide admission"
+    (outcome entry)
+    (outcome { entry with request_context = None })
 ;;
 
 let test_schema_is_closed_nonhierarchical_contract () =
@@ -1680,9 +1701,13 @@ let () =
         ; test_case "invalid judgment fails loud" `Quick test_invalid_judgment_fails_loud
         ; test_case "exact context bundle" `Quick test_context_bundle_is_exact
         ; test_case
-            "missing context fails before admission"
+            "missing context is reported as partial"
             `Quick
-            test_missing_context_is_terminal_before_admission
+            test_missing_context_is_reported_as_partial
+        ; test_case
+            "missing context does not change flow admission"
+            `Quick
+            test_missing_context_does_not_change_flow_admission
         ; test_case
             "closed nonhierarchical schema"
             `Quick


### PR DESCRIPTION
## 문제

Keeper 턴 밖에서 올라온 승인 요청은 `request_context`를 구조적으로 가질 수 없다. `build_context_bundle`은 그 필드 하나가 없다는 이유로 시도 전체를 `Error`로 버렸고, 요청을 식별하는 나머지 7개 필드(keeper, tool, 완전한 input, turn/task/goal 연결)는 모두 존재하는데도 판정이 시작되지 않았다.

그리고 `keeper.gate_judgment.md`는 이미 `partial_context` 플래그를 참조하고 있었다.

```
If `partial_context` is true, identify what is missing.
```

그런데 그 필드를 생산하는 코드가 없었다(`rg partial_context` → 프롬프트 파일 1곳). 모델 입장에서 결코 참이 될 수 없는 조건이었다. 즉 "부분 컨텍스트로도 판정한다"는 계약이 설계에만 있고 구현에는 없었다.

## 라이브 실측 (`~/me/.masc`, 2026-07-28 00:28)

```
lane-smith (17건 대기)
  seq=317  turn_id=None  pre_worker_unavailable  ctx 없음   ← 40분 정지
  seq=318..339           not_requested/ready     15건 ctx 있음

reason_code      auto_judge_unavailable
operator_detail  "HITL summary: exact outer-turn request context is unavailable"
```

같은 시간대 30분 집계: 판정 220건 / `grant_consumed` 2건.

## 변경

| 파일 | 내용 |
|---|---|
| `hitl_summary_worker.ml` | `build_context_bundle`을 total function으로. `context_bundle_error` 타입 삭제. 컨텍스트 부재는 `partial_context: true`로 판정자에게 전달 |
| `hitl_summary_worker.mli` | `For_testing` 시그니처 축소 (`Result` 및 에러 타입 제거) |
| `keeper.gate_judgment.md` | `require_human` 정의에서 "evidence is missing"을 분리. `partial_context: true` 자체는 `require_human` 사유가 아님을 명시 |
| `test_hitl_summary_worker.ml` | `missing context fails before admission` 테스트를 계약 반전에 맞춰 교체 |

프롬프트를 함께 고치지 않으면 번들만 채워도 모든 요청이 `require_human`으로 흘러 사람 대기가 그대로 남는다.

## 테스트

교체:
- `missing context is reported as partial` — 컨텍스트 없는 entry가 `partial_context: true`를 싣고, `request_context`를 날조하지 않으며, keeper/tool/input 신원이 보존됨
- `missing context does not change flow admission` — 컨텍스트 유무가 `prepare_flow` 결과를 바꾸지 않음(동치성 검증, 문자열 비교 아님)

## 로컬 검증

```
dune build @check                          통과
dune exec test/test_hitl_summary_worker.exe
  변경 후: 25 tests / 4 failures
  base(97e5ffeca8): 24 tests / 4 failures  ← 동일한 4건
```

실패 4건은 전부 `production exact flow` 그룹(cancellation / candidate rejection)이며 base에서 재현된다. 이 PR이 건드린 `domain` 그룹은 전량 통과.

## 미검증

- 실제 판정 품질. `partial_context: true` 요청에 대해 모델이 `approve`/`deny`를 내는지 `require_human`으로 회귀하는지는 배포 후 `audit-approvals`의 `decision_source=auto_judge` 분포로 확인해야 한다.
- 이 PR은 head 요청 하나가 판정 가능해지도록 만들 뿐, `keeper_gate.mli:113-116`이 선언한 FIFO barrier 자체는 그대로다. head가 다른 이유로 영구 실패하면 같은 정지가 재현된다. 별도 이슈로 다룬다.

RFC-WAIVED: `lib/keeper/hitl_summary_worker.*`는 agent_delegation RFC 목록(credential/identity, repo_manager, operator_control, keeper_sandbox, dashboard credential, hooks, workflow 문서) 어디에도 속하지 않는다. 선언된 프롬프트 계약(`partial_context`)을 구현으로 잇는 변경이며 새 설계를 도입하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
