### PR TITLE
test(gate): prove partial-context FIFO progress

### DIFF
--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -65,6 +65,7 @@ let ensure_registered_keeper ~base_path keeper_name =
 let pending_entry
       ?(input_tag = "default")
       ?(keeper_name = "keeper")
+      ?(include_request_context = true)
       ~base_path
       ()
   =
@@ -94,7 +95,8 @@ let pending_entry
              ; "input_tag", `String input_tag
              ])
         ~base_path
-        ~request_context
+        ?request_context:
+          (if include_request_context then Some request_context else None)
         ()
     with
     | Ok id -> id
@@ -1640,8 +1642,19 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
             ~source:"hitl-owner-fifo-drain"
             [ { id = "hitl-owner-fifo-drain"; base_url = server.base_url } ]);
        select_auto_judge_mode base_path;
-       let first = pending_entry ~input_tag:"first" ~base_path () in
+       let first =
+         pending_entry
+           ~input_tag:"first"
+           ~include_request_context:false
+           ~base_path
+           ()
+       in
        let second = pending_entry ~input_tag:"second" ~base_path () in
+       check
+         (option yojson)
+         "FIFO head reproduces absent causal context"
+         None
+         first.request_context;
        let initial = Gate.resume_persisted_auto_judges ~base_path in
        check
          (list string)


### PR DESCRIPTION
## 목적

#25971은 `request_context`가 없는 승인을 `partial_context=true`로 판정 가능하게 만들었습니다. 이 PR은 이 변경이 실제 durable per-Keeper FIFO를 끝까지 전진시키는지 회귀 테스트로 고정합니다.

## 변경

- HITL test fixture가 context 없는 pending approval을 만들 수 있게 함
- 기존 owner FIFO integration test의 선두를 context 없는 entry로 구성
- 선두의 context 부재를 먼저 확인한 뒤 다음을 검증:
  - 선두가 provider에 dispatch됨
  - 선두 완료 전에는 후속 entry가 dispatch되지 않음
  - 선두 완료 후 후속 entry가 자동 dispatch됨
  - 두 entry가 각각 정확히 한 번씩 실행됨

## 검증

- `ocamlformat --check test/test_hitl_summary_worker.ml`: PASS
- `ocamlc -stop-after parsing test/test_hitl_summary_worker.ml`: PASS
- `git diff --check`: PASS
- 동일 회귀 테스트를 #25971과 같은 total-context 방향의 sibling branch에서 실행: PASS

현재 machine-wide Dune guard가 root checkout의 bare `dune build .`와 동시 실행을 거부해 이 branch의 focused executable 재빌드는 보류했습니다. Draft CI로 broad compile/test를 확인하며, review 요청 전 focused local build를 다시 실행합니다.

관련: #25966, #25971
