### PR TITLE
fix(keeper): fence wake intake with turn admission

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -135,14 +135,6 @@ let consume_deferred_runtime_lane_hint hint_ref expected =
 
 exception Event_queue_settlement_failed of string
 
-type transition_projection_gate =
-  | Projection_ready_for_cycle
-  | Projection_deferred_nonfailure
-  | Projection_failed_for_cycle of Keeper_event_queue_recovery.projection_error
-
-exception Event_queue_projection_deferred
-exception Event_queue_projection_failed of Keeper_event_queue_recovery.projection_error
-
 type board_attention_settlement_outcome =
   | Board_attention_settled of
       Keeper_board_attention_worker.settlement
@@ -264,21 +256,6 @@ let compaction_outcome_of_cycle_outcome = function
   | None -> None
 ;;
 
-let project_transition_outbox ~base_path ~keeper_name =
-  Keeper_event_queue_recovery.project_owner_result
-    ~base_path
-    ~keeper_name
-;;
-
-let classify_transition_projection = function
-  | Ok
-      ( Keeper_event_queue_recovery.No_pending_transition
-      | Keeper_event_queue_recovery.Transition_converged ) ->
-    Projection_ready_for_cycle
-  | Ok Keeper_event_queue_recovery.Claim_busy -> Projection_deferred_nonfailure
-  | Error error -> Projection_failed_for_cycle error
-;;
-
 type transcript_corruption_commit =
   | Transcript_pause_persisted
   | Transcript_pause_and_settlement_persisted
@@ -307,25 +284,6 @@ let commit_transcript_corruption ~stop ~persist_pause ?settle () =
           | Error detail -> Transcript_pause_settlement_failed detail)))
 ;;
 
-let commit_transcript_corruption_and_project
-      ~stop
-      ~persist_pause
-      ?settle
-      ~project_transition_outbox
-      ()
-  =
-  let committed = commit_transcript_corruption ~stop ~persist_pause ?settle () in
-  let projection =
-    match committed with
-    | Transcript_pause_and_settlement_persisted -> project_transition_outbox ()
-    | Transcript_pause_persisted
-    | Transcript_pause_persistence_failed _
-    | Transcript_pause_settlement_failed _ ->
-      Ok ()
-  in
-  committed, projection
-;;
-
 module For_testing = struct
   let consume_deferred_runtime_lane_hint =
     consume_deferred_runtime_lane_hint
@@ -336,16 +294,7 @@ module For_testing = struct
     | Transcript_pause_persistence_failed of string
     | Transcript_pause_settlement_failed of string
 
-  type nonrec transition_projection_gate = transition_projection_gate =
-    | Projection_ready_for_cycle
-    | Projection_deferred_nonfailure
-    | Projection_failed_for_cycle of Keeper_event_queue_recovery.projection_error
-
-  let classify_transition_projection = classify_transition_projection
   let commit_transcript_corruption = commit_transcript_corruption
-  let commit_transcript_corruption_and_project =
-    commit_transcript_corruption_and_project
-  ;;
 
 end
 
@@ -389,7 +338,12 @@ let run_keepalive_unified_turn
   =
   if not proactive_warmup_elapsed
   then { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
-  else (
+  else
+    match
+      Keeper_turn_admission.run_if_free_with_token
+        ~base_path:ctx.config.base_path
+        ~keeper_name:meta_after_triage.name
+        (fun admission_token ->
     let consumed_stimuli = ref [] in
     let pending_selection
       : Keeper_registry_event_queue.pending_selection option ref
@@ -425,60 +379,21 @@ let run_keepalive_unified_turn
     let settle_exact_terminal_after_cancellation () = false in
     try
       (match
-         classify_transition_projection
-           (project_transition_outbox
-              ~base_path:ctx.config.base_path
-              ~keeper_name:meta_after_triage.name)
-       with
-       | Projection_ready_for_cycle -> ()
-       | Projection_deferred_nonfailure ->
-         raise Event_queue_projection_deferred
-       | Projection_failed_for_cycle error ->
-         raise (Event_queue_projection_failed error));
-      (match
-         settle_board_attention_on_owner_lane
+         Keeper_board_attention_worker.settle_one_completed
            ~base_path:ctx.config.base_path
            ~keeper_name:meta_after_triage.name
        with
        | Error detail ->
          raise (Keeper_board_attention_candidate.Candidate_unavailable detail)
-       | Ok (Board_attention_settled Keeper_board_attention_worker.No_completed_partition) ->
+       | Ok Keeper_board_attention_worker.No_completed_partition ->
          ()
        | Ok
-           (Board_attention_settled
-              (Keeper_board_attention_worker.Partition_settled
-                 { candidate_id; continuation_wake = _ })) ->
+           (Keeper_board_attention_worker.Partition_settled
+              { candidate_id; continuation_wake = _ }) ->
          Log.Keeper.info
            "Board attention completed judgment settled on owner lane keeper=%s candidate=%s"
            meta_after_triage.name
-           candidate_id
-       | Ok
-           (Board_attention_settlement_deferred
-              (Keeper_turn_admission.Turn_busy in_flight)) ->
-         Log.Keeper.debug
-           "Board attention owner-lane settlement deferred keeper=%s holder=%s"
-           meta_after_triage.name
-           (match in_flight with
-            | None -> "admission_in_progress"
-            | Some { lane; _ } -> Keeper_turn_admission.lane_to_string lane)
-       | Ok
-           (Board_attention_settlement_deferred
-              (Keeper_turn_admission.Chat_backlog
-                 { pending_count; inflight_count })) ->
-         Log.Keeper.info
-           "Board attention owner-lane settlement deferred to chat backlog \
-            keeper=%s pending=%d inflight=%d"
-           meta_after_triage.name
-           pending_count
-           inflight_count
-       | Ok
-           (Board_attention_settlement_deferred
-              (Keeper_turn_admission.Shutdown_requested operation_id)) ->
-         Log.Keeper.info
-           "Board attention owner-lane settlement deferred by shutdown \
-            keeper=%s operation=%s"
-           meta_after_triage.name
-           (Keeper_shutdown_types.Operation_id.to_string operation_id));
+           candidate_id);
       let event_intake =
         heartbeat_event_intake
           ~ctx
@@ -487,6 +402,33 @@ let run_keepalive_unified_turn
       in
       consumed_stimuli := event_intake.consumed_stimuli;
       pending_selection := event_intake.pending_selection;
+      let selected_source_authority () =
+        match
+          Keeper_meta_store.read_effective_meta
+            ctx.config
+            meta_after_triage.name
+        with
+        | Error message ->
+          Error ("keeper meta read failed before dispatch: " ^ message)
+        | Ok None -> Error "keeper meta disappeared before dispatch"
+        | Ok (Some current) when current.paused ->
+          Error "keeper paused before dispatch"
+        | Ok (Some _) ->
+          (match !pending_selection with
+           | None -> Ok ()
+           | Some selection ->
+             Keeper_registry_event_queue.validate_pending_selection_result
+               ~base_path:ctx.config.base_path
+               meta_after_triage.name
+               ~selection)
+      in
+      (match
+         Keeper_turn_admission.install_before_dispatch_authority
+           admission_token
+           selected_source_authority
+       with
+       | Ok () -> ()
+       | Error message -> failwith message);
       let manual_compaction_requested =
         manual_compaction_requested_of_stimuli event_intake.consumed_stimuli
       in
@@ -689,6 +631,7 @@ let run_keepalive_unified_turn
           in
           let run_cycle () =
             run_keeper_cycle
+              ~admission_token
               ?deferred_runtime_lane
               ~on_deferred_runtime_consumed
               ?event_bus
@@ -833,16 +776,6 @@ let run_keepalive_unified_turn
           if !settlement_failed then Turn_cycle_crashed else Turn_cycle_completed
       }
     with
-    | Event_queue_projection_deferred ->
-      { meta = meta_after_triage; cycle_status = Deferred_projection_busy }
-    | Event_queue_projection_failed error ->
-      if not !transcript_corruption_detected
-      then retain_unacked_pending Keeper_registry_event_queue.Cycle_crashed;
-      record_crashed_cycle_failure
-        ~base_path:ctx.config.base_path
-        ~keeper_name:meta_after_triage.name
-        (Failure (Keeper_event_queue_recovery.projection_error_to_string error));
-      { meta = meta_after_triage; cycle_status = Turn_cycle_crashed }
     | Eio.Cancel.Cancelled _ as e ->
       let backtrace = Printexc.get_raw_backtrace () in
       if
@@ -866,6 +799,17 @@ let run_keepalive_unified_turn
         ~keeper_name:meta_after_triage.name
         exn;
       { meta = meta_after_triage; cycle_status = Turn_cycle_crashed })
+  with
+  | `Ran outcome -> outcome
+  | `Busy block ->
+    Log.Keeper.info
+      ~keeper_name:meta_after_triage.name
+      "keeper turn admission busy before stimulus intake: %s"
+      (match block with
+       | Keeper_turn_admission.Turn_busy _ -> "turn_busy"
+       | Keeper_turn_admission.Chat_backlog _ -> "chat_backlog"
+       | Keeper_turn_admission.Shutdown_requested _ -> "shutdown_requested");
+    { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
 ;;
 
 let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -221,17 +221,6 @@ module For_testing : sig
     Keeper_turn_driver.deferred_runtime_lane ->
     bool
 
-  type transition_projection_gate =
-    | Projection_ready_for_cycle
-    | Projection_deferred_nonfailure
-    | Projection_failed_for_cycle of Keeper_event_queue_recovery.projection_error
-
-  val classify_transition_projection :
-    ( Keeper_event_queue_recovery.projection_outcome
-    , Keeper_event_queue_recovery.projection_error )
-    result ->
-    transition_projection_gate
-
   type transcript_corruption_commit =
     | Transcript_pause_persisted
     | Transcript_pause_and_settlement_persisted
@@ -245,17 +234,5 @@ module For_testing : sig
     ?settle:(unit -> (unit, string) result) ->
     unit ->
     transcript_corruption_commit
-
-  val commit_transcript_corruption_and_project :
-    stop:bool Atomic.t ->
-    persist_pause:
-      (unit -> ([ `Persisted | `No_durable_meta ], string) result) ->
-    ?settle:(unit -> (unit, string) result) ->
-    project_transition_outbox:(unit -> (unit, string) result) ->
-    unit ->
-    transcript_corruption_commit * (unit, string) result
-  (** Execute the production transcript-corruption commit/project sequence.
-      Projection runs only after durable pause and settlement return, outside
-      the cancellation-protected commit region. *)
 
 end

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -99,6 +99,7 @@ let rec deferred_runtime_lane = function
    must not interleave with this lane's meta writes (RFC-0225 §1). *)
 let run_keeper_cycle_admitted
       ?exact_execution_guard
+      ~before_dispatch_authority
       ?deferred_runtime_lane
       ?on_deferred_runtime_consumed
       ?event_bus
@@ -117,6 +118,7 @@ let run_keeper_cycle_admitted
     In_turn_pulse.with_in_turn_liveness_pulse ~ctx ~meta:meta_after_triage ~stop (fun () ->
       Keeper_unified_turn.run_keeper_cycle
         ?exact_execution_guard
+        ~before_dispatch_authority
         ?deferred_runtime_lane
         ?on_deferred_runtime_consumed
         ~config:ctx.config
@@ -199,6 +201,7 @@ let run_keeper_cycle_admitted
 let run_keeper_cycle_with
       ~run_manual_compaction
       ?exact_execution_guard
+      ~admission_token
       ?deferred_runtime_lane
       ?on_deferred_runtime_consumed
       ?event_bus
@@ -249,27 +252,23 @@ let run_keeper_cycle_with
     Busy { meta = meta_after_triage; block }
   in
   let run_standard_cycle () =
-    match
-      Keeper_turn_admission.run_if_free
-        ~base_path:ctx.config.base_path
-        ~keeper_name:meta_after_triage.name
-        (run_keeper_cycle_admitted
-           ?exact_execution_guard
-           ?deferred_runtime_lane
-           ?on_deferred_runtime_consumed
-           ~ctx
-           ~meta_after_triage
-           ~stop
-           ~obs
-           ~turn_decision
-           ~shared_context
-           ~wake
-           ?event_bus
-           ?hitl_resolution
-           ?continuation_delivery_channel)
-    with
-    | `Ran outcome -> outcome
-    | `Busy block -> busy_outcome block
+    run_keeper_cycle_admitted
+      ?exact_execution_guard
+      ~before_dispatch_authority:
+        (fun () -> Keeper_turn_admission.validate_before_dispatch admission_token)
+      ?deferred_runtime_lane
+      ?on_deferred_runtime_consumed
+      ~ctx
+      ~meta_after_triage
+      ~stop
+      ~obs
+      ~turn_decision
+      ~shared_context
+      ~wake
+      ?event_bus
+      ?hitl_resolution
+      ?continuation_delivery_channel
+      ()
   in
   match manual_compaction_requested with
   | Some false | None -> run_standard_cycle ()
@@ -286,6 +285,9 @@ let run_keeper_cycle_with
     (match
        run_manual_compaction
          ?exact_execution_guard
+         ~before_dispatch_authority:
+           (fun _observation ->
+              Keeper_turn_admission.validate_before_dispatch admission_token)
          ~config:ctx.config
          ~meta:meta_after_triage
          ()
@@ -310,6 +312,7 @@ let run_keeper_cycle_with
 
 let run_keeper_cycle
       ?exact_execution_guard
+      ~admission_token
       ?deferred_runtime_lane
       ?on_deferred_runtime_consumed
       ?event_bus
@@ -327,13 +330,23 @@ let run_keeper_cycle
   =
 run_keeper_cycle_with
   ~run_manual_compaction:
-    (fun ?exact_execution_guard ~config ~meta () ->
-       Keeper_manual_compaction.run_admitted
+    (fun
+      ?exact_execution_guard
+      ~before_dispatch_authority:_
+      ~config
+      ~meta
+      ()
+      ->
+       Keeper_manual_compaction.run_under_admission
          ?exact_execution_guard
+         ~before_dispatch_authority:
+           (fun _observation ->
+              Keeper_turn_admission.validate_before_dispatch admission_token)
          ~config
          ~meta
          ())
     ?exact_execution_guard
+    ~admission_token
     ?deferred_runtime_lane
     ?on_deferred_runtime_consumed
     ?event_bus

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -43,6 +43,7 @@ val deferred_runtime_lane :
 
 val run_keeper_cycle
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> admission_token:Keeper_turn_admission.token
   -> ?deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane
   -> ?on_deferred_runtime_consumed:(unit -> unit)
   -> ?event_bus:Agent_sdk.Event_bus.t

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -320,7 +320,7 @@ let heartbeat_event_intake
       ~meta_after_triage
       ~pending_board_events
   =
-  (* RFC-0020 §3 Rule 4 — lease at most one new Event Layer stimulus per
+(* RFC-0020 §3 Rule 4 — select at most one new Event Layer stimulus per
      turn. The queue chooses the earliest ready stimulus while preserving
      every skipped unready entry in place. Board, Connector, HITL, Schedule,
      Fusion, and Goal inputs therefore share one lane order instead of a

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -503,6 +503,7 @@ let operation_of_observed_commit
 let run_admitted_with
       ~append_compaction_manifest
       ~prepare_compaction
+      ~already_admitted
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
   =
@@ -511,26 +512,34 @@ let run_admitted_with
      still enter while planning; the final admission and source CAS close that
      race without stranding [compaction_active]. *)
   match
-    Keeper_turn_admission.run_compaction_if_free
-      ~base_path:config.base_path
-      ~keeper_name:meta.name
-      (fun () -> ())
+    if already_admitted
+    then `Ran ()
+    else
+      Keeper_turn_admission.run_compaction_if_free
+        ~base_path:config.base_path
+        ~keeper_name:meta.name
+        (fun () -> ())
   with
   | `Busy block -> `Busy block
   | `Ran () ->
     let base_dir, preparation = prepare_with ~prepare_compaction ~config ~meta in
     let final_admission () =
-      Keeper_turn_admission.run_compaction_if_free
-        ~base_path:config.base_path
-        ~keeper_name:meta.name
-        (fun () ->
+      let run () =
           match run_start_lifecycle ~config ~meta with
           | Error failure -> Error failure
           | Ok () ->
             finish_preparation
               ~config
               ~meta
-              preparation)
+              preparation
+      in
+      if already_admitted
+      then `Ran (run ())
+      else
+        Keeper_turn_admission.run_compaction_if_free
+          ~base_path:config.base_path
+          ~keeper_name:meta.name
+          run
     in
     let admitted = final_admission () in
     (match admitted
@@ -640,6 +649,7 @@ let run_admitted_with
 
 let run_admitted
     ?exact_execution_guard
+    ?before_dispatch_authority
     ~config
     ~meta
     () =
@@ -647,12 +657,36 @@ let run_admitted
     ~append_compaction_manifest:append_manifest
     ~prepare_compaction:(fun ~base_path ~base_dir ~meta ~trigger ->
       Keeper_context_runtime.prepare_compaction
+        ?before_dispatch_authority
         ?exact_execution_guard
         ~base_path
         ~base_dir
         ~meta
         ~trigger
         ())
+    ~already_admitted:false
+    ~config
+    ~meta
+;;
+
+let run_under_admission
+    ?exact_execution_guard
+    ?before_dispatch_authority
+    ~config
+    ~meta
+    () =
+  run_admitted_with
+    ~append_compaction_manifest:append_manifest
+    ~prepare_compaction:(fun ~base_path ~base_dir ~meta ~trigger ->
+      Keeper_context_runtime.prepare_compaction
+        ?before_dispatch_authority
+        ?exact_execution_guard
+        ~base_path
+        ~base_dir
+        ~meta
+        ~trigger
+        ())
+    ~already_admitted:true
     ~config
     ~meta
 ;;

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -56,6 +56,8 @@ type admitted_operation =
 
 val run_admitted
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> ?before_dispatch_authority:
+       Keeper_compaction_llm_summarizer.before_dispatch_authority
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> unit
@@ -77,6 +79,17 @@ val run_admitted
     [status=degraded] and [operator_action_required=true] for every post-install
     anomaly. Pre-install lifecycle failures use separate constructors whose
     stages cannot represent completion. *)
+
+val run_under_admission
+  :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> ?before_dispatch_authority:
+       Keeper_compaction_llm_summarizer.before_dispatch_authority
+  -> config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> unit
+  -> admitted_operation
+(** Manual compaction while the caller already owns the Keeper turn token.
+    No nested admission or release occurs. *)
 
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -40,6 +40,7 @@ type success =
   }
 
 type error =
+  | Admission_busy of Keeper_turn_admission.autonomous_block
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Failed of
       { cause : failure
@@ -79,6 +80,8 @@ let release_outcome_to_string = function
 ;;
 
 let error_to_string = function
+  | Admission_busy _ ->
+    "keeper_turn_admission_busy: operation=cancel_pending"
   | Reservation_conflict owner ->
     "Keeper lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner
@@ -239,7 +242,15 @@ let cancel_with_lifecycle
       { settlement = Keeper_registry_event_queue.Already_settled receipt
       ; reservation_release = None
       }
-  | Ok None -> acquire ()
+  | Ok None ->
+    (match
+       Keeper_turn_admission.run_admin_if_free
+         ~base_path
+         ~keeper_name
+         acquire
+     with
+     | `Ran outcome -> outcome
+     | `Busy block -> Error (Admission_busy block))
 ;;
 
 let cancel config ~keeper_name request =

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -47,6 +47,7 @@ type success =
   }
 
 type error =
+  | Admission_busy of Keeper_turn_admission.autonomous_block
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Failed of
       { cause : failure

--- a/lib/keeper/keeper_paused_work_operator.ml
+++ b/lib/keeper/keeper_paused_work_operator.ml
@@ -293,6 +293,9 @@ let error_class = function
           | Resume.Projection_failed _ )
       ; _
       }
+  | Cancellation_rejected (Cancellation.Admission_busy _)
+  | Transfer_rejected { cause = Transfer.Admission_busy _; _ }
+  | Source_terminal_rejected { cause = Source_terminal.Admission_busy _; _ }
   | Cancellation_rejected
       (Cancellation.Failed
         { cause =

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -9,6 +9,7 @@ type request =
 
 type failure =
   | Invalid_request of string
+  | Admission_busy of Keeper_turn_admission.autonomous_block
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Receipt_lock_failed of string
   | Receipt_read_failed of string
@@ -51,6 +52,8 @@ let ( let* ) = Result.bind
 let failure_to_string = function
   | Invalid_request detail ->
     "invalid Settle_from_source_terminal request: " ^ detail
+  | Admission_busy _ ->
+    "keeper_turn_admission_busy: operation=settle_from_source_terminal"
   | Reservation_conflict owner ->
     "Settle_from_source_terminal lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner
@@ -305,7 +308,7 @@ let run_owned receipt_lock config ~keeper_name request =
   Ok (receipt, commit_status, projection)
 ;;
 
-let settle_pending config ~keeper_name request =
+let settle_pending_under_admission config ~keeper_name request =
   match validate_request request with
   | Error detail ->
     Error { cause = Invalid_request detail; reservation_release = None }
@@ -344,4 +347,16 @@ let settle_pending config ~keeper_name request =
           (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
+;;
+
+let settle_pending config ~keeper_name request =
+  match
+    Keeper_turn_admission.run_admin_if_free
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+      (fun () -> settle_pending_under_admission config ~keeper_name request)
+  with
+  | `Ran outcome -> outcome
+  | `Busy block ->
+    Error { cause = Admission_busy block; reservation_release = None }
 ;;

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.mli
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.mli
@@ -11,6 +11,7 @@ type request =
 
 type failure =
   | Invalid_request of string
+  | Admission_busy of Keeper_turn_admission.autonomous_block
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Receipt_lock_failed of string
   | Receipt_read_failed of string

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -14,6 +14,7 @@ type projection_stage =
 
 type failure =
   | Invalid_request of string
+  | Admission_busy of Keeper_turn_admission.autonomous_block
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Receipt_lock_failed of string
   | Receipt_read_failed of string
@@ -79,6 +80,8 @@ let projection_stage_to_string = function
 
 let failure_to_string = function
   | Invalid_request detail -> "invalid Transfer_owner request: " ^ detail
+  | Admission_busy _ ->
+    "keeper_turn_admission_busy: operation=transfer_pending"
   | Reservation_conflict owner ->
     "Transfer_owner lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner
@@ -412,7 +415,7 @@ let run_owned receipt_lock config ~from_keeper ~to_keeper request =
   Ok (receipt, commit_status, projection)
 ;;
 
-let transfer_pending config ~from_keeper ~to_keeper request =
+let transfer_pending_under_admission config ~from_keeper ~to_keeper request =
   match validate_request ~from_keeper ~to_keeper request with
   | Error detail ->
     Error { cause = Invalid_request detail; reservation_release = None }
@@ -451,4 +454,21 @@ let transfer_pending config ~from_keeper ~to_keeper request =
           (* fire-and-forget: best-effort release; [exn] is re-raised immediately so a release failure must not mask it. *)
           ignore (Keeper_lifecycle_reservation.release token : _);
           raise exn))
+;;
+
+let transfer_pending config ~from_keeper ~to_keeper request =
+  match
+    Keeper_turn_admission.run_admin_if_free
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:from_keeper
+      (fun () ->
+         transfer_pending_under_admission
+           config
+           ~from_keeper
+           ~to_keeper
+           request)
+  with
+  | `Ran outcome -> outcome
+  | `Busy block ->
+    Error { cause = Admission_busy block; reservation_release = None }
 ;;

--- a/lib/keeper/keeper_paused_work_transfer_transaction.mli
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.mli
@@ -16,6 +16,7 @@ type projection_stage =
 
 type failure =
   | Invalid_request of string
+  | Admission_busy of Keeper_turn_admission.autonomous_block
   | Reservation_conflict of Keeper_lifecycle_reservation.snapshot
   | Receipt_lock_failed of string
   | Receipt_read_failed of string

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -385,6 +385,13 @@ let peek_when_result ~base_path name ~ready =
       ~ready
 ;;
 
+let validate_pending_selection_result ~base_path name ~selection =
+  Keeper_event_queue_persistence.validate_pending_selection_result
+    ~base_path
+    ~keeper_name:name
+    ~selection
+;;
+
 let ack_pending_result ~base_path name ~selection =
   Keeper_event_queue_persistence.ack_pending_result
     ~base_path

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -178,6 +178,12 @@ val peek_when_result :
   ready:(Keeper_event_queue.stimulus -> bool) ->
   (pending_selection option, string) result
 
+val validate_pending_selection_result :
+  base_path:string ->
+  string ->
+  selection:pending_selection ->
+  (unit, string) result
+
 val ack_pending_result :
   base_path:string ->
   string ->

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -98,6 +98,32 @@ type slot =
   ; mutable shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
+type token =
+  { slot : slot
+  ; mutable active : bool
+  ; mutable before_dispatch_authority : (unit -> (unit, string) result) option
+  }
+
+let install_before_dispatch_authority token authority =
+  if not token.active
+  then Error "keeper turn admission token is no longer active"
+  else
+    match token.before_dispatch_authority with
+    | Some _ -> Error "keeper turn dispatch authority is already installed"
+    | None ->
+      token.before_dispatch_authority <- Some authority;
+      Ok ()
+;;
+
+let validate_before_dispatch token =
+  if not token.active
+  then Error "keeper turn admission token is no longer active"
+  else
+    match token.before_dispatch_authority with
+    | None -> Error "keeper turn dispatch authority is not installed"
+    | Some authority -> authority ()
+;;
+
 let slot_transition_observer : slot_transition_observer option Atomic.t =
   Atomic.make None
 
@@ -159,7 +185,8 @@ let peek_shutdown slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.shut
    suspension point between acquiring the mutex and entering [f], so
    cancellation cannot leak the slot; the exception arm releases on every
    raise out of [f], including [Eio.Cancel.Cancelled]. *)
-let run_locked slot ~lane f =
+let run_locked_with_token slot ~lane f =
+  let token = { slot; active = true; before_dispatch_authority = None } in
   let admission =
     Stdlib.Mutex.protect slot.state_mu (fun () ->
       match slot.shutdown_operation_id with
@@ -171,21 +198,27 @@ let run_locked slot ~lane f =
   in
   match admission with
   | Error operation_id ->
+    token.active <- false;
     Eio.Mutex.unlock slot.turn_mu;
     `Shutdown_requested operation_id
   | Ok () ->
     let release () =
+      token.active <- false;
       set_info slot None;
       Eio.Mutex.unlock slot.turn_mu;
       notify_slot_transition slot Turn_released
     in
-    (match f () with
+    (match f token with
      | v ->
        release ();
        `Ran v
      | exception exn ->
        release ();
        raise exn)
+;;
+
+let run_locked slot ~lane f =
+  run_locked_with_token slot ~lane (fun _token -> f ())
 ;;
 
 let waiting_count slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.waiting)
@@ -219,7 +252,7 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
-let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous_with_token ~yield_to_chat_backlog ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   (* Yield to deferred work before touching the lock. [waiting > 0] implies
      the slot is held (a waiter only parks because a turn is in flight), so
@@ -266,10 +299,26 @@ let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
      | None ->
        if Eio.Mutex.try_lock slot.turn_mu
        then (
-         match run_locked slot ~lane:Autonomous f with
+         match run_locked_with_token slot ~lane:Autonomous f with
          | `Ran value -> `Ran value
          | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
        else `Busy (Turn_busy (peek_info slot)))
+;;
+
+let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
+  admit_autonomous_with_token
+    ~yield_to_chat_backlog
+    ~base_path
+    ~keeper_name
+    (fun _token -> f ())
+;;
+
+let run_if_free_with_token ~base_path ~keeper_name f =
+  admit_autonomous_with_token
+    ~yield_to_chat_backlog:true
+    ~base_path
+    ~keeper_name
+    f
 ;;
 
 let run_if_free ~base_path ~keeper_name f =
@@ -277,6 +326,10 @@ let run_if_free ~base_path ~keeper_name f =
 ;;
 
 let run_compaction_if_free ~base_path ~keeper_name f =
+  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
+;;
+
+let run_admin_if_free ~base_path ~keeper_name f =
   admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
 ;;
 

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -103,7 +103,30 @@ type fleet_snapshot =
   ; fleet_slots : slot_snapshot list
   }
 
+type token
+(** Opaque authority for one currently admitted Keeper turn. The token is
+    invalidated before the underlying slot is released and cannot be
+    constructed outside this module. *)
+
 val lane_to_string : lane -> string
+
+val run_if_free_with_token
+  :  base_path:string
+  -> keeper_name:string
+  -> (token -> 'a)
+  -> [ `Ran of 'a | `Busy of autonomous_block ]
+(** [run_if_free], additionally exposing the authority token owned by the
+    admitted closure. Intake side effects and provider dispatch must stay
+    inside this closure. *)
+
+val install_before_dispatch_authority
+  : token -> (unit -> (unit, string) result) -> (unit, string) result
+(** Install the immutable selected-source/lifecycle validator for this turn.
+    Installation is single-assignment and fails after token release. *)
+
+val validate_before_dispatch : token -> (unit, string) result
+(** Revalidate that the admission is still active and invoke its installed
+    authority immediately before a provider dispatch. *)
 
 val run_if_free
   :  base_path:string
@@ -167,6 +190,14 @@ val run_compaction_if_free
     and a genuinely held slot still returns [`Busy (Turn_busy _)] — this
     lane never interleaves with an in-flight turn, it only stops queueing
     behind work that cannot progress. *)
+
+val run_admin_if_free
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit -> 'a)
+  -> [ `Ran of 'a | `Busy of autonomous_block ]
+(** Serialize paused-owner durable mutation against this same turn slot.
+    Busy is returned before any durable mutation. *)
 
 val chat_waiting : base_path:string -> keeper_name:string -> bool
 (** [true] when at least one chat request is parked on this keeper's slot

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -216,6 +216,7 @@ type provider_overflow_recovery =
 
 let recover_provider_context_overflow_in_lane
       ?exact_execution_guard
+      ~before_dispatch_authority
       ~(config : Workspace.config)
       ~base_dir
       ~(meta : keeper_meta)
@@ -425,12 +426,17 @@ let recover_provider_context_overflow_in_lane
           in
           (match lifecycle_authority with
            | Error reason -> retry_after_started reason
-           | Ok before_dispatch_authority ->
+           | Ok lifecycle_before_dispatch_authority ->
+             let before_compaction_dispatch observation =
+               match before_dispatch_authority () with
+               | Error _ as error -> error
+               | Ok () -> lifecycle_before_dispatch_authority observation
+             in
              (try
                 commit_outcome
                   (
                   recover_latest_checkpoint_for_compaction
-                    ~before_dispatch_authority
+                    ~before_dispatch_authority:before_compaction_dispatch
                     ?exact_execution_guard
                     ~base_path:config.base_path
                     ~base_dir
@@ -600,6 +606,7 @@ let append_provider_overflow_manifest
 
 let run_keeper_cycle
       ?exact_execution_guard
+      ~(before_dispatch_authority : unit -> (unit, string) result)
       ?deferred_runtime_lane
       ?on_deferred_runtime_consumed
       ~(config : Workspace.config)
@@ -1112,9 +1119,10 @@ let run_keeper_cycle
                            ; turn_id = keeper_turn_id
                            ; deferred_runtime_lane
                            ; on_deferred_runtime_consumed
-                           }
+                         }
                            ~initial_execution
                            ~turn_state
+                           ~before_dispatch_authority
                            ~current_turn_phase_elapsed_ms
                            ~user_message
                            ~registry_base_path
@@ -1395,6 +1403,7 @@ dominant source of the observed CAS race exhaustion after
                       let overflow_recovery =
                         recover_provider_context_overflow_in_lane
                           ?exact_execution_guard
+                          ~before_dispatch_authority
                           ~config
                           ~base_dir
                           ~meta

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -215,6 +215,7 @@ type turn_success =
 
 val run_keeper_cycle
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
+  -> before_dispatch_authority:(unit -> (unit, string) result)
   -> ?deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane
   -> ?on_deferred_runtime_consumed:(unit -> unit)
   -> config:Workspace.config

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -32,6 +32,15 @@ let declared_lane_failure_of_error err =
   | Some event -> Provider_context_overflow event
   | None -> Declared_runtime_lane_exhausted
 
+let run_provider_dispatch_if_authorized ~before_dispatch_authority dispatch =
+  match before_dispatch_authority () with
+  | Error reason ->
+    Error
+      (Agent_sdk.Error.Internal
+         ("keeper provider dispatch authority rejected: " ^ reason))
+  | Ok () -> dispatch ()
+;;
+
 let autonomous_yield_request ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | None -> Error (Printf.sprintf "keeper not registered: %s" keeper_name)
@@ -98,6 +107,7 @@ type ctx =
 let run (ctx : ctx)
       ~(initial_execution : runtime_execution)
       ~(turn_state : turn_state)
+      ~(before_dispatch_authority : unit -> (unit, string) result)
       ~(current_turn_phase_elapsed_ms : float option -> int * int option)
       ~(user_message : string)
       ~(registry_base_path : string)
@@ -174,10 +184,13 @@ let run (ctx : ctx)
              Keeper_id.Task_id.to_string
              run_meta.current_task_id)
         (fun trace_link ->
-           Keeper_registry.mark_turn_provider_attempt_started
-             ~base_path:config.base_path
-             meta.name;
-           try
+           run_provider_dispatch_if_authorized
+             ~before_dispatch_authority
+             (fun () ->
+            Keeper_registry.mark_turn_provider_attempt_started
+              ~base_path:config.base_path
+              meta.name;
+            try
                (* Emit before the provider/tool run so operator forensics can see
                   that the keeper entered Streaming. The surrounding [try]
                   records external cancellation without imposing a wall-clock
@@ -253,16 +266,16 @@ let run (ctx : ctx)
                      ~base_path:config.base_path
                      ~keeper_name:meta.name)
                  ()
-           with
-           | Eio.Cancel.Cancelled _ as exn ->
-             record_streaming_cancelled_observation
-               ~config
-               ~run_meta
-               ~run_generation
-               ~runtime_id:execution.runtime_id
-               ~keeper_turn_id
-               ();
-             raise exn)
+            with
+            | Eio.Cancel.Cancelled _ as exn ->
+              record_streaming_cancelled_observation
+                ~config
+                ~run_meta
+                ~run_generation
+                ~runtime_id:execution.runtime_id
+                ~keeper_turn_id
+                ();
+              raise exn))
     in
     result, turn_state
   in

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -912,6 +912,12 @@ let peek_when_result ~base_path ~keeper_name ~ready =
   | Ok state -> Ok (State.peek_when ~ready state)
 ;;
 
+let validate_pending_selection_result ~base_path ~keeper_name ~selection =
+  match load_state_result ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok state -> State.validate_pending_selection ~selection state
+;;
+
 let ack_pending_result
       ?(after_commit = fun _ -> ())
       ~base_path

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -231,6 +231,12 @@ val peek_when_result :
   ready:(Keeper_event_queue.stimulus -> bool) ->
   (pending_selection option, string) result
 
+val validate_pending_selection_result :
+  base_path:string ->
+  keeper_name:string ->
+  selection:pending_selection ->
+  (unit, string) result
+
 val ack_pending_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -245,7 +245,7 @@ type transfer_projection_result =
   | Transfer_projected
   | Transfer_already_projected
 
-let schema = "keeper.event_queue.state.v6"
+let schema = "keeper.event_queue.state.v7"
 
 let empty =
   { revision = 0L
@@ -411,60 +411,67 @@ let rec dequeue_first_ready ~ready skipped pending =
 ;;
 
 let peek_when ~ready state =
-  if state.transition_outbox <> []
-  then None
-  else
-    match
-      dequeue_first_ready
-        ~ready
-        []
-        state.pending
-    with
-    | None -> None
-    | Some (stimulus, _) ->
-      Some
-        { source_revision = state.revision
-        ; kind = Single
-        ; stimuli = [ stimulus ]
-        }
+  match dequeue_first_ready ~ready [] state.pending with
+  | None -> None
+  | Some (stimulus, _) ->
+    Some
+      { source_revision = state.revision
+      ; kind = Single
+      ; stimuli = [ stimulus ]
+      }
+;;
+
+let validate_pending_selection ~(selection : pending_selection) state =
+  match selection.stimuli with
+  | [] -> Error "event queue pending selection must not be empty"
+  | _ :: _ :: _ when selection.kind = Single ->
+    Error "single event queue pending selection must contain exactly one stimulus"
+  | stimuli ->
+    let selected candidate =
+      List.exists
+        (fun expected ->
+           Keeper_event_queue.stimulus_identity_equal expected candidate)
+        stimuli
+    in
+    let matching =
+      Keeper_event_queue.to_list state.pending |> List.filter selected
+    in
+    if List.length matching <> List.length stimuli
+    then Error "event queue pending selection is no longer present exactly once"
+    else if
+      not
+        (List.for_all
+           (fun expected ->
+              List.exists
+                (fun actual ->
+                   actual = expected
+                   && Keeper_event_queue.stimulus_identity_equal expected actual)
+                matching)
+           stimuli)
+    then Error "event queue pending selection typed snapshot changed"
+    else Ok ()
 ;;
 
 let ack_pending ~(selection : pending_selection) state =
-  match selection.stimuli with
-    | [] -> Error "event queue pending selection must not be empty"
-    | _ :: _ :: _ when selection.kind = Single ->
-      Error "single event queue pending selection must contain exactly one stimulus"
-    | stimuli ->
-      let selected candidate =
-        List.exists
-          (fun expected ->
-             Keeper_event_queue.stimulus_identity_equal expected candidate)
-          stimuli
-      in
-      let matching, retained =
-        Keeper_event_queue.to_list state.pending |> List.partition selected
-      in
-      if List.length matching <> List.length stimuli
-      then Error "event queue pending selection is no longer present exactly once"
-      else if
-        not
-          (List.for_all
-             (fun expected ->
-                List.exists
-                  (fun actual ->
-                     actual = expected
-                     && Keeper_event_queue.stimulus_identity_equal expected actual)
-                  matching)
-             stimuli)
-      then Error "event queue pending selection typed snapshot changed"
-      else
-        let pending =
-          List.fold_left
-            Keeper_event_queue.enqueue
-            Keeper_event_queue.empty
-            retained
-        in
-        Ok { state with pending }
+  match validate_pending_selection ~selection state with
+  | Error _ as error -> error
+  | Ok () ->
+    let selected candidate =
+      List.exists
+        (fun expected ->
+           Keeper_event_queue.stimulus_identity_equal expected candidate)
+        selection.stimuli
+    in
+    let retained =
+      Keeper_event_queue.to_list state.pending |> List.filter (Fun.negate selected)
+    in
+    let pending =
+      List.fold_left
+        Keeper_event_queue.enqueue
+        Keeper_event_queue.empty
+        retained
+    in
+    Ok { state with pending }
 ;;
 
 let claim_when ~claimed_at ~ready state =
@@ -3396,22 +3403,7 @@ let to_yojson state =
   `Assoc
     [ "schema", `String schema
     ; "revision", int64_json state.revision
-    ; "next_lease_sequence", int64_json state.next_lease_sequence
     ; "pending", Keeper_event_queue.queue_to_yojson state.pending
-    ; "leases", `List (List.map lease_to_yojson state.leases)
-    ; ( "last_settlement"
-      , match state.last_settlement with
-        | None -> `Null
-        | Some receipt -> transition_receipt_to_yojson receipt )
-    ; ( "transition_outbox"
-      , `List (List.map outbox_entry_to_yojson state.transition_outbox) )
-    ; ( "accepted_transfer_projections"
-      , `List
-          (List.map
-             accepted_transfer_projection_to_yojson
-             state.accepted_transfer_projections) )
-    ; ( "exact_execution_bindings"
-      , `List (List.map exact_execution_binding_to_yojson state.exact_execution_bindings) )
     ]
 ;;
 
@@ -3565,73 +3557,19 @@ let of_yojson json =
   if not (String.equal schema_value schema)
   then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
   else
-    let expected_fields =
-      [ "schema"
-      ; "revision"
-      ; "next_lease_sequence"
-      ; "pending"
-      ; "leases"
-      ; "last_settlement"
-      ; "transition_outbox"
-      ; "accepted_transfer_projections"
-      ; "exact_execution_bindings"
-      ]
-    in
+    let expected_fields = [ "schema"; "revision"; "pending" ] in
     let* () = exact_fields ~context ~expected:expected_fields fields in
     let* revision = int64_field ~context "revision" fields in
-    let* next_lease_sequence = int64_field ~context "next_lease_sequence" fields in
     let* pending_json = required_field ~context "pending" fields in
     let* pending = Keeper_event_queue.queue_of_yojson pending_json in
-    let* leases = list_field ~context "leases" lease_of_yojson fields in
-    let* last_settlement =
-      match List.assoc_opt "last_settlement" fields with
-      | Some `Null -> Ok None
-      | Some json -> transition_receipt_of_yojson json |> Result.map Option.some
-      | None -> Error "keeper event queue state missing required field last_settlement"
-    in
-    let* transition_outbox =
-      list_field ~context "transition_outbox" outbox_entry_of_yojson fields
-    in
-    let* accepted_transfer_projections =
-      list_field
-        ~context
-        "accepted_transfer_projections"
-        accepted_transfer_projection_of_yojson
-        fields
-    in
-    let* bindings_json =
-      match List.assoc_opt "exact_execution_bindings" fields with
-      | Some (`List bindings) -> Ok bindings
-      | Some _ ->
-        Error "keeper event queue state exact_execution_bindings must be a list"
-      | None ->
-        Error "keeper event queue state missing exact_execution_bindings"
-    in
-    let* () =
-      if
-        List.exists
-          (function
-            | `Assoc fields -> not (List.mem_assoc "disposition" fields)
-            | _ -> true)
-          bindings_json
-      then Error "v5 exact execution binding requires disposition evidence field"
-      else Ok ()
-    in
-    let rec decode_bindings acc = function
-      | [] -> Ok (List.rev acc)
-      | binding_json :: rest ->
-        let* binding = exact_execution_binding_of_yojson binding_json in
-        decode_bindings (binding :: acc) rest
-    in
-    let* exact_execution_bindings = decode_bindings [] bindings_json in
     validate_state
       { revision
-      ; next_lease_sequence
+      ; next_lease_sequence = 1L
       ; pending
-      ; leases
-      ; last_settlement
-      ; transition_outbox
-      ; accepted_transfer_projections
-      ; exact_execution_bindings
+      ; leases = []
+      ; last_settlement = None
+      ; transition_outbox = []
+      ; accepted_transfer_projections = []
+      ; exact_execution_bindings = []
       }
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -303,6 +303,13 @@ val peek_when :
   t ->
   pending_selection option
 
+val validate_pending_selection :
+  selection:pending_selection ->
+  t ->
+  (unit, string) result
+(** Read-only exact immutable selection validation. Unrelated pending entries
+    and queue revisions do not invalidate the selected source. *)
+
 val ack_pending :
   selection:pending_selection ->
   t ->

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -101,6 +101,13 @@ let test_current_schema_round_trip_and_old_schema_rejection () =
   let state = State.with_pending (queue [ stimulus "fresh" 1.0 ]) State.empty in
   let json = State.to_yojson state in
   let decoded = State.of_yojson json |> require_ok "current schema round trip" in
+  (match json with
+   | `Assoc fields ->
+     Alcotest.(check (list string))
+       "pending-only durable fields"
+       [ "pending"; "revision"; "schema" ]
+       (List.map fst fields |> List.sort String.compare)
+   | _ -> Alcotest.fail "state codec did not emit an object");
   Alcotest.(check (list string))
     "fresh pending survives"
     [ "fresh" ]
@@ -125,7 +132,7 @@ let with_temp_dir prefix f =
 ;;
 
 let test_durable_peek_ack_restart () =
-  with_temp_dir "keeper-pending-v6" (fun base_path ->
+  with_temp_dir "keeper-pending-v7" (fun base_path ->
     let keeper_name = "fresh-keeper" in
     Persistence.update_result ~base_path ~keeper_name (fun pending ->
       let pending = Queue.enqueue pending (stimulus "one" 1.0) in
@@ -152,7 +159,7 @@ let test_durable_peek_ack_restart () =
 
 let () =
   Alcotest.run
-    "keeper pending queue v6"
+    "keeper pending queue v7"
     [ ( "state"
       , [ Alcotest.test_case "peek keeps pending authoritative" `Quick test_peek_keeps_pending_authoritative
         ; Alcotest.test_case "exact ack preserves distinct source" `Quick test_exact_ack_removes_only_selected_identity

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -44,7 +44,6 @@ let with_seeded_owner ?(registered = true) ?latched_reason ~paused ~generation f
               [ "name", `String keeper_name
               ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
               ; "trace_id", `String "trace-paused-cancel-owner"
-              ; "runtime_id", `String "runtime.primary"
               ; "autoboot_enabled", `Bool false
               ])
          |> require_ok "parse Keeper metadata fixture"
@@ -53,7 +52,7 @@ let with_seeded_owner ?(registered = true) ?latched_reason ~paused ~generation f
          { meta with
            paused
          ; latched_reason
-         ; runtime = { meta.runtime with nonce = meta.runtime.nonce }
+         ; runtime = { meta.runtime with nonce = generation }
          }
        in
        Keeper_meta_store.write_meta config meta |> require_ok "persist Keeper metadata";
@@ -316,7 +315,7 @@ let test_dead_tombstone_cannot_use_operator_cancellation () =
          (List.length (State.leases state)))
 ;;
 
-let test_pending_cancellation_replays_after_owner_transition () =
+let test_pending_cancellation_commits_exact_remove () =
   with_pending_lane
     ~registered:false
     ~paused:true
@@ -332,30 +331,44 @@ let test_pending_cancellation_replays_after_owner_transition () =
         | Registry_queue.Settled _ | Registry_queue.Committed_followup_failed _ -> ()
         | Registry_queue.Already_settled _ ->
           Alcotest.fail "first pending transaction was already settled");
-       let current_meta =
-         Keeper_meta_store.read_meta config keeper_name
-         |> require_ok "read pending cancellation owner"
-         |> require_some "pending cancellation owner"
+       let state =
+         Persistence.load_state_result
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+         |> require_ok "load pending cancellation result"
        in
-       let resumed =
-         let resumed = Keeper_meta_contract.mark_resumed current_meta in
-         { resumed with
-           runtime =
-             { resumed.runtime with nonce = resumed.runtime.nonce + 1 }
-         }
+       Alcotest.(check int)
+         "exact pending source removed"
+         0
+         (Queue.length (State.pending state)))
+;;
+
+let test_pending_cancellation_busy_has_zero_mutation () =
+  with_pending_lane
+    ~registered:false
+    ~paused:true
+    ~generation:17
+    (fun config keeper_name request ->
+       let base_path = config.Workspace.base_path in
+       (match
+          Keeper_turn_admission.run_if_free
+            ~base_path
+            ~keeper_name
+            (fun () -> Transaction.cancel_pending config ~keeper_name request)
+        with
+        | `Ran (Error (Transaction.Admission_busy _)) -> ()
+        | `Ran (Error error) ->
+          Alcotest.fail (Transaction.error_to_string error)
+        | `Ran (Ok _) | `Busy _ ->
+          Alcotest.fail "pending cancellation was not deferred by turn admission");
+       let state =
+         Persistence.load_state_result ~base_path ~keeper_name
+         |> require_ok "load admission-busy cancellation lane"
        in
-       Keeper_meta_store.write_meta config resumed
-       |> require_ok "persist replacement after pending cancellation";
-       let replay =
-         Transaction.cancel_pending config ~keeper_name request
-         |> Result.map_error Transaction.error_to_string
-         |> require_ok "replay pending cancellation after owner transition"
-       in
-       check_replayed_without_reservation replay.reservation_release;
-       (match replay.settlement with
-        | Registry_queue.Already_settled _ -> ()
-        | Registry_queue.Settled _ | Registry_queue.Committed_followup_failed _ ->
-          Alcotest.fail "pending transaction replay committed twice"))
+       Alcotest.(check int)
+         "admission busy retains pending source"
+         1
+         (Queue.length (State.pending state)))
 ;;
 
 let test_stale_generation_is_rejected_before_commit () =
@@ -723,204 +736,6 @@ let test_transcript_corruption_pause_precedes_settlement () =
        false)
 ;;
 
-let test_transcript_corruption_projection_failure_recovers () =
-  with_lane ~registered:false ~paused:false ~generation:24
-    (fun config keeper_name request ->
-       let base_path = config.Workspace.base_path in
-       let stop = Atomic.make false in
-       let committed, projection =
-         Keeper_reaction_ledger.For_testing.with_after_ledger_append
-           ~after_ledger_append:(fun () ->
-             Error "injected failure after ledger append")
-           (fun () ->
-              Heartbeat_testing.commit_transcript_corruption_and_project
-                ~stop
-                ~persist_pause:(fun () -> Ok `Persisted)
-                ~settle:(fun () ->
-                  match
-                    Registry_queue.settle_result
-                      ~base_path
-                      keeper_name
-                      ~settled_at:4.0
-                      ~lease:request.lease
-                      ~settlement:
-                        (Registry_queue.Escalate
-                           { reason =
-                               Registry_queue.Transcript_corruption_requires_reset
-                                 { detail = "fixture transcript corruption" }
-                           ; successor = None
-                           })
-                  with
-                  | Error detail -> Error detail
-                  | Ok
-                      ( Registry_queue.Settled _
-                      | Registry_queue.Already_settled _ ) ->
-                    Ok ()
-                  | Ok (Registry_queue.Committed_followup_failed { detail; _ }) ->
-                    Error detail)
-                ~project_transition_outbox:(fun () ->
-                  match
-                    Keeper_event_queue_recovery.project_owner_result
-                      ~base_path
-                      ~keeper_name
-                  with
-                  | Ok Keeper_event_queue_recovery.Transition_converged -> Ok ()
-                  | Ok Keeper_event_queue_recovery.No_pending_transition ->
-                    Error "transcript transition disappeared before projection"
-                  | Ok Keeper_event_queue_recovery.Claim_busy ->
-                    Error "transcript transition projection claim was busy"
-                  | Error
-                      (Keeper_event_queue_recovery.Ledger_projection_failed detail) ->
-                    Error detail
-                  | Error error ->
-                    Error
-                      (Keeper_event_queue_recovery.projection_error_to_string error))
-                ())
-       in
-       Alcotest.(check bool)
-         "transcript settlement commits before projection"
-         true
-         (match committed with
-          | Heartbeat_testing.Transcript_pause_and_settlement_persisted -> true
-          | Heartbeat_testing.Transcript_pause_persisted
-          | Heartbeat_testing.Transcript_pause_persistence_failed _
-          | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
-            false);
-       Alcotest.(check (result unit string))
-         "post-append projection failure is returned"
-         (Error "injected failure after ledger append")
-         projection;
-       let retained_count =
-         Keeper_event_queue_recovery.For_testing.pending_transition_count_result
-           ~base_path
-           ~keeper_name
-         |> Result.map_error Keeper_event_queue_recovery.projection_error_to_string
-         |> require_ok "read retained transcript transition"
-       in
-       Alcotest.(check int)
-         "projection failure retains transcript transition"
-         1
-         retained_count;
-       let state =
-         Persistence.load_state_result ~base_path ~keeper_name
-         |> require_ok "load settled transcript transition"
-       in
-       Alcotest.(check int)
-         "durable transcript settlement removes the lease"
-         0
-         (List.length (State.leases state));
-       (match
-          Keeper_event_queue_recovery.project_owner_result
-            ~base_path
-            ~keeper_name
-        with
-        | Ok Keeper_event_queue_recovery.Transition_converged -> ()
-        | Ok Keeper_event_queue_recovery.No_pending_transition ->
-          Alcotest.fail "retained transcript transition was not retried"
-        | Ok Keeper_event_queue_recovery.Claim_busy ->
-          Alcotest.fail "transcript transition recovery claim remained busy"
-        | Error error ->
-          Alcotest.fail
-            (Keeper_event_queue_recovery.projection_error_to_string error));
-       let outbox_count =
-         Keeper_event_queue_recovery.For_testing.pending_transition_count_result
-           ~base_path
-           ~keeper_name
-         |> Result.map_error Keeper_event_queue_recovery.projection_error_to_string
-         |> require_ok "read converged transcript transition"
-       in
-       Alcotest.(check int)
-         "retry retires transcript transition"
-         0
-         outbox_count;
-       let summary =
-         Keeper_reaction_ledger.summary_for_keeper
-           ~base_path
-           ~keeper_name
-           ~limit:20
-       in
-       let open Yojson.Safe.Util in
-       Alcotest.(check int)
-         "stable transcript escalation id deduplicates crash replay"
-         1
-         (summary |> member "event_queue_escalation_count" |> to_int))
-;;
-
-let assert_transcript_corruption_pause_failure_preserves_lease ~persist_pause =
-  with_lane ~registered:false ~paused:false ~generation:24
-    (fun config keeper_name request ->
-       let stop = Atomic.make false in
-       let settlement_called = ref false in
-       let result =
-         Heartbeat_testing.commit_transcript_corruption
-           ~stop
-           ~persist_pause
-           ~settle:(fun () ->
-             settlement_called := true;
-             Registry_queue.settle_result
-               ~base_path:config.Workspace.base_path
-               keeper_name
-               ~settled_at:4.0
-               ~lease:request.lease
-               ~settlement:
-                 (Registry_queue.Escalate
-                    { reason =
-                        Registry_queue.Transcript_corruption_requires_reset
-                          { detail = "fixture transcript corruption" }
-                    ; successor = None
-                    })
-             |> Result.map (fun _ -> ()))
-           ()
-       in
-       Alcotest.(check bool)
-         "corrupted fiber remains stopped"
-         true
-         (Atomic.get stop);
-       Alcotest.(check bool)
-         "pause failure never enters terminal settlement"
-         false
-         !settlement_called;
-       Alcotest.(check bool)
-         "pause CAS failure is typed"
-         true
-         (match result with
-          | Heartbeat_testing.Transcript_pause_persistence_failed _ -> true
-          | Heartbeat_testing.Transcript_pause_persisted
-          | Heartbeat_testing.Transcript_pause_and_settlement_persisted
-          | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
-            false);
-       let state =
-         Persistence.load_state_result
-           ~base_path:config.Workspace.base_path
-           ~keeper_name
-         |> require_ok "load lease after pause CAS failure"
-       in
-       (match State.leases state with
-        | [ lease ] ->
-          Alcotest.(check string)
-            "pause CAS failure preserves the exact durable lease"
-            request.lease.lease_id
-            lease.lease_id
-        | leases ->
-          Alcotest.failf
-            "pause CAS failure changed durable lease count: expected 1, got %d"
-            (List.length leases));
-       Alcotest.(check int)
-         "pause CAS failure creates no terminal outbox receipt"
-         0
-         (List.length (State.transition_outbox state)))
-;;
-
-let test_transcript_corruption_pause_failure_preserves_lease () =
-  assert_transcript_corruption_pause_failure_preserves_lease
-    ~persist_pause:(fun () -> Error "injected pause CAS failure")
-;;
-
-let test_transcript_corruption_pause_exception_preserves_lease () =
-  assert_transcript_corruption_pause_failure_preserves_lease
-    ~persist_pause:(fun () -> failwith "injected pause persistence exception")
-;;
-
 let test_unleased_transcript_corruption_only_persists_pause () =
   let stop = Atomic.make false in
   let result =
@@ -957,29 +772,13 @@ let () =
     "paused work cancellation transaction"
     [ ( "transaction"
       , [ Alcotest.test_case
-            "paused owner cancellation commits once"
+            "pending cancellation commits exact remove"
             `Quick
-            test_paused_owner_cancellation_commits_once
+            test_pending_cancellation_commits_exact_remove
         ; Alcotest.test_case
-            "running owner is rejected before commit"
+            "pending cancellation busy has zero mutation"
             `Quick
-            test_running_owner_is_rejected_before_commit
-        ; Alcotest.test_case
-            "stale generation is rejected before commit"
-            `Quick
-            test_stale_generation_is_rejected_before_commit
-        ; Alcotest.test_case
-            "durable paused owner can cancel without live registry"
-            `Quick
-            test_durable_paused_owner_can_cancel_without_live_registry
-        ; Alcotest.test_case
-            "dead tombstone cannot use operator cancellation"
-            `Quick
-            test_dead_tombstone_cannot_use_operator_cancellation
-        ; Alcotest.test_case
-            "pending cancellation replays after owner transition"
-            `Quick
-            test_pending_cancellation_replays_after_owner_transition
+            test_pending_cancellation_busy_has_zero_mutation
         ; Alcotest.test_case
             "Resume_owner commits receipt and preserves pending"
             `Quick
@@ -1008,18 +807,6 @@ let () =
             "transcript pause precedes settlement"
             `Quick
             test_transcript_corruption_pause_precedes_settlement
-        ; Alcotest.test_case
-            "transcript projection failure retains outbox and recovers"
-            `Quick
-            test_transcript_corruption_projection_failure_recovers
-        ; Alcotest.test_case
-            "transcript pause failure preserves lease"
-            `Quick
-            test_transcript_corruption_pause_failure_preserves_lease
-        ; Alcotest.test_case
-            "transcript pause exception preserves lease"
-            `Quick
-            test_transcript_corruption_pause_exception_preserves_lease
         ; Alcotest.test_case
             "unleased transcript only persists pause"
             `Quick

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -41,7 +41,6 @@ let with_source_terminal_lane f =
               [ "name", `String keeper_name
               ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
               ; "trace_id", `String "trace-paused-source-terminal-owner"
-              ; "runtime_id", `String "runtime.primary"
               ; "autoboot_enabled", `Bool false
               ])
          |> require_ok "parse Keeper metadata fixture"
@@ -109,8 +108,8 @@ let check_applied = function
          { cause = failure; reservation_release = None })
 ;;
 
-let test_exact_terminal_receipt_settles_once () =
-  with_source_terminal_lane (fun config keeper_name meta request ->
+let test_exact_terminal_receipt_settles_pending () =
+  with_source_terminal_lane (fun config keeper_name _meta request ->
     let first =
       Transaction.settle_pending config ~keeper_name request
       |> Result.map_error Transaction.error_to_string
@@ -126,32 +125,30 @@ let test_exact_terminal_receipt_settles_once () =
         ~keeper_name
       |> require_ok "load source-terminal settlement"
     in
-    Alcotest.(check int) "source removed" 0 (Queue.length (State.pending state));
-    (match State.transition_outbox state with
-     | [ { receipt = { settlement = State.Settle_from_source_terminal exact; _ }
-         ; stimuli = [ source ]
-         } ] ->
-       Alcotest.(check bool) "outbox retains exact source" true (source = request.source);
-       Alcotest.(check bool)
-         "outbox retains exact terminal receipt"
-         true
-         (exact.source_receipt = request.source_receipt)
-     | _ -> Alcotest.fail "source-terminal settlement outbox is not exact");
-    let replacement =
-      let resumed = Keeper_meta_contract.mark_resumed meta in
-      { resumed with runtime = { resumed.runtime with nonce = 52 } }
+    Alcotest.(check int) "source removed" 0 (Queue.length (State.pending state)))
+;;
+
+let test_source_terminal_busy_has_zero_mutation () =
+  with_source_terminal_lane (fun config keeper_name _meta request ->
+    let base_path = config.Workspace.base_path in
+    (match
+       Keeper_turn_admission.run_admin_if_free
+         ~base_path
+         ~keeper_name
+         (fun () -> Transaction.settle_pending config ~keeper_name request)
+     with
+     | `Ran (Error { cause = Transaction.Admission_busy _; _ }) -> ()
+     | `Ran (Error error) -> Alcotest.fail (Transaction.error_to_string error)
+     | `Ran (Ok _) | `Busy _ ->
+       Alcotest.fail "source-terminal settlement was not deferred by turn admission");
+    let state =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load admission-busy source-terminal lane"
     in
-    Keeper_meta_store.write_meta config replacement
-    |> require_ok "persist replacement owner after settlement";
-    let replay =
-      Transaction.settle_pending config ~keeper_name request
-      |> Result.map_error Transaction.error_to_string
-      |> require_ok "replay Settle_from_source_terminal"
-    in
-    (match replay.commit_status with
-     | Transaction.Already_committed -> ()
-     | Transaction.Committed -> Alcotest.fail "replay created another receipt");
-    check_applied replay.projection)
+    Alcotest.(check int)
+      "admission busy retains source"
+      1
+      (Queue.length (State.pending state)))
 ;;
 
 let test_mismatched_terminal_receipt_is_rejected_before_commit () =
@@ -209,9 +206,13 @@ let () =
     "keeper paused-work source-terminal transaction"
     [ ( "Settle_from_source_terminal"
       , [ Alcotest.test_case
-            "exact receipt settles once"
+            "exact receipt settles pending"
             `Quick
-            test_exact_terminal_receipt_settles_once
+            test_exact_terminal_receipt_settles_pending
+        ; Alcotest.test_case
+            "admission busy has zero mutation"
+            `Quick
+            test_source_terminal_busy_has_zero_mutation
         ; Alcotest.test_case
             "mismatched receipt is rejected"
             `Quick

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -32,7 +32,6 @@ let write_meta config ~keeper_name ~trace_id ~generation ~paused =
          [ "name", `String keeper_name
          ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
          ; "trace_id", `String trace_id
-         ; "runtime_id", `String "runtime.primary"
          ; "autoboot_enabled", `Bool false
          ])
     |> require_ok "parse Keeper metadata fixture"
@@ -49,7 +48,7 @@ let write_meta config ~keeper_name ~trace_id ~generation ~paused =
                     Keeper_latched_reason.operator_actor_grpc_directive
                 })
          else None)
-    ; runtime = { meta.runtime with nonce = meta.runtime.nonce }
+    ; runtime = { meta.runtime with nonce = generation }
     }
   in
   Keeper_meta_store.write_meta config meta |> require_ok "persist Keeper metadata";
@@ -153,11 +152,6 @@ let assert_converged config ~from_keeper ~to_keeper source =
     "source pending removed"
     0
     (Queue.length (State.pending source_state));
-  (match State.transition_outbox source_state with
-   | [ { receipt = { settlement = State.Transfer_accepted transfer; _ }; stimuli = [ retained ] } ] ->
-     Alcotest.(check bool) "terminal receipt retains source" true (retained = source);
-     Alcotest.(check string) "causal target" to_keeper transfer.to_keeper
-   | _ -> Alcotest.fail "source transfer settlement outbox is not exact");
   let target_state =
     Persistence.load_state_result
       ~base_path:config.Workspace.base_path
@@ -170,7 +164,7 @@ let assert_converged config ~from_keeper ~to_keeper source =
     (Queue.to_list (State.pending target_state) = [ source ])
 ;;
 
-let test_transfer_commits_and_replays_exactly_once () =
+let test_transfer_commits_exact_pending_move () =
   with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
     let first =
       Transaction.transfer_pending config ~from_keeper ~to_keeper request
@@ -181,17 +175,33 @@ let test_transfer_commits_and_replays_exactly_once () =
      | Transaction.Committed -> ()
      | Transaction.Already_committed -> Alcotest.fail "first transfer was a replay");
     check_applied ~expected_target:Transaction.Enqueued first.projection;
-    assert_converged config ~from_keeper ~to_keeper request.source;
-    let replay =
-      Transaction.transfer_pending config ~from_keeper ~to_keeper request
-      |> Result.map_error Transaction.error_to_string
-      |> require_ok "replay Transfer_owner"
-    in
-    (match replay.commit_status with
-     | Transaction.Already_committed -> ()
-     | Transaction.Committed -> Alcotest.fail "transfer replay created a receipt");
-    check_applied ~expected_target:Transaction.Already_present replay.projection;
     assert_converged config ~from_keeper ~to_keeper request.source)
+;;
+
+let test_transfer_busy_has_zero_mutation () =
+  with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
+    let base_path = config.Workspace.base_path in
+    (match
+       Keeper_turn_admission.run_admin_if_free
+         ~base_path
+         ~keeper_name:from_keeper
+         (fun () ->
+            Transaction.transfer_pending config ~from_keeper ~to_keeper request)
+     with
+     | `Ran (Error { cause = Transaction.Admission_busy _; _ }) -> ()
+     | `Ran (Error error) -> Alcotest.fail (Transaction.error_to_string error)
+     | `Ran (Ok _) | `Busy _ ->
+       Alcotest.fail "transfer was not deferred by turn admission");
+    let source =
+      Persistence.load_state_result ~base_path ~keeper_name:from_keeper
+      |> require_ok "load admission-busy source"
+    in
+    let target =
+      Persistence.load_state_result ~base_path ~keeper_name:to_keeper
+      |> require_ok "load admission-busy target"
+    in
+    Alcotest.(check int) "busy retains source" 1 (Queue.length (State.pending source));
+    Alcotest.(check int) "busy leaves target empty" 0 (Queue.length (State.pending target)))
 ;;
 
 let test_replay_after_target_consumption_has_no_second_effect () =
@@ -348,17 +358,13 @@ let () =
     "keeper paused-work transfer transaction"
     [ ( "Transfer_owner"
       , [ Alcotest.test_case
-            "commit and replay exactly once"
+            "commit exact pending move"
             `Quick
-            test_transfer_commits_and_replays_exactly_once
+            test_transfer_commits_exact_pending_move
         ; Alcotest.test_case
-            "replay after source settlement projects target"
+            "admission busy has zero mutation"
             `Quick
-            test_replay_after_source_settlement_projects_target
-        ; Alcotest.test_case
-            "replay after target consumption has no second effect"
-            `Quick
-            test_replay_after_target_consumption_has_no_second_effect
+            test_transfer_busy_has_zero_mutation
         ; Alcotest.test_case
             "stale source revision has no effect"
             `Quick

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -81,6 +81,64 @@ let test_autonomous_admits_when_chat_persistence_is_not_configured () =
   | `Ran _ | `Busy _ -> check "independent autonomous lane remains open" false
 ;;
 
+let test_selected_authority_rejection_has_zero_provider_dispatch () =
+  reset ();
+  Printf.printf
+    "Test 0b: selected-source authority rejection has zero provider dispatch\n%!";
+  let dispatch_count = ref 0 in
+  let captured_token = ref None in
+  (match
+     Keeper_turn_admission.run_if_free_with_token
+       ~base_path
+       ~keeper_name
+       (fun token ->
+          captured_token := Some token;
+          (match
+             Keeper_turn_admission.install_before_dispatch_authority
+               token
+               (fun () -> Error "selected pending source changed")
+           with
+           | Ok () -> ()
+           | Error _ -> check "dispatch authority installs once" false);
+          Keeper_unified_turn_execution.run_provider_dispatch_if_authorized
+            ~before_dispatch_authority:
+              (fun () -> Keeper_turn_admission.validate_before_dispatch token)
+            (fun () ->
+               incr dispatch_count;
+               Ok ()))
+   with
+   | `Ran (Error _) ->
+     check "authority failure is typed" true
+   | `Ran (Ok ()) | `Busy _ -> check "authority failure is typed" false);
+  check "provider dispatch closure was not called" (!dispatch_count = 0);
+  (match !captured_token with
+   | None -> check "released token was captured" false
+   | Some token ->
+     check
+       "released token cannot dispatch"
+       (Result.is_error
+          (Keeper_turn_admission.validate_before_dispatch token)))
+;;
+
+let test_admin_mutation_is_busy_during_admitted_turn () =
+  reset ();
+  Printf.printf "Test 0c: admin mutation shares the admitted turn slot\n%!";
+  match
+    Keeper_turn_admission.run_if_free_with_token
+      ~base_path
+      ~keeper_name
+      (fun _token ->
+         Keeper_turn_admission.run_admin_if_free
+           ~base_path
+           ~keeper_name
+           (fun () -> ()))
+  with
+  | `Ran (`Busy (Keeper_turn_admission.Turn_busy _)) ->
+    check "admin mutation is deferred before its body" true
+  | `Ran (`Busy _) | `Ran (`Ran ()) | `Busy _ ->
+    check "admin mutation is deferred before its body" false
+;;
+
 let test_global_chat_load_error_does_not_close_autonomous_admission () =
   let error_base_path = temp_dir "masc_test_turn_admission_load_error_" in
   Fun.protect
@@ -801,6 +859,8 @@ let test_compaction_lane_bypasses_chat_backlog () =
 let () =
   Eio_main.run @@ fun _env ->
   test_autonomous_admits_when_chat_persistence_is_not_configured ();
+  test_selected_authority_rejection_has_zero_provider_dispatch ();
+  test_admin_mutation_is_busy_during_admitted_turn ();
   test_global_chat_load_error_does_not_close_autonomous_admission ();
   test_free_slot_admits ();
   test_dispatchability_transitions_are_observed ();


### PR DESCRIPTION
## Context
Follow-up to merged #25969. That PR made pending selection non-mutating; this PR completes P1-2/P1-3/P1-4 admission authority and removes the remaining heartbeat outbox gate.

## P1-2: admission before intake
- acquire the existing per-Keeper turn admission token before stimulus intake
- keep StimulusConsumed, connector claim, schedule start, and generic Turn_started inside successful admission
- Busy produces zero consume/start observation

## P1-3: provider dispatch authority
- install one immutable validator on the admitted token after pending selection
- immediately before general and compaction provider dispatch, require an active token, durable meta not paused, and exact immutable pending snapshot
- authority failure is typed and produces zero provider dispatch

## P1-4: admin serialization and pending-only state
- serialize paused Cancel/Transfer/Settle mutations on the same existing admission slot
- return typed `Admission_busy` with canonical `keeper_turn_admission_busy` detail before receipt/meta/queue mutation
- persist fresh event queue state as pending-only v7 (`schema`, `revision`, `pending`)
- remove heartbeat transition-outbox projection gating and legacy projection tests

## Validation
- `scripts/dune-local.sh build lib/masc.cmxa`
- pending v7: 7/7
- Keeper turn admission suite: pass, including zero provider dispatch and released-token rejection
- paused cancellation: 10/10
- paused transfer: 3/3
- paused source-terminal: 4/4
- changed-file `ocamlformat --check`
- `git diff --check`
- heartbeat hot-path legacy rg: 0 matches