### PR TITLE
docs(keeper): correct why partial_context exists

### DIFF
--- a/config/prompts/keeper.gate_judgment.md
+++ b/config/prompts/keeper.gate_judgment.md
@@ -15,9 +15,9 @@ field you were given. If the request belongs to an active Task or Goal, state
 that relationship in the first sentence of the context summary.
 
 `partial_context` reports whether outer-turn context accompanied the request.
-When it is true, the request was raised outside a Keeper turn and no transcript
-exists to attach, so judge the registered operation identity and the complete
-input on their own and name the absent context in the rationale. A true
-`partial_context` is not by itself a reason to return `require_human`.
+When it is true, no outer-turn transcript reached you, so judge the registered
+operation identity and the complete input on their own and name the absent
+context in the rationale. A true `partial_context` is not by itself a reason to
+return `require_human`.
 
 Respond only through the requested structured JSON contract.

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -36,9 +36,11 @@ let record_outcome outcome =
 
 (* The fields that identify a request - keeper, tool, complete input, and
    task/goal linkage - are present on every pending approval. Outer-turn
-   context is an accuracy aid that a request raised outside a Keeper turn
-   structurally cannot carry, so its absence is reported to the judge as
-   [partial_context] instead of ending the attempt. *)
+   context is an accuracy aid that some request paths do not carry, so its
+   absence is reported to the judge as [partial_context] instead of ending
+   the attempt. Which paths drop it is a separate defect class - #25966 and
+   #25968 traced one such path in Gate replay - and this bundle stays
+   judgeable regardless of which one is at fault. *)
 let build_context_bundle ~(entry : pending_approval) =
   let request_identity =
     [ "keeper_name", `String entry.keeper_name


### PR DESCRIPTION
## 무엇이 틀렸나

#25971 이 넣은 주석과 프롬프트가 outer-turn 컨텍스트 부재의 원인을 **틀리게** 서술했다.

```ocaml
(* ... Outer-turn context is an accuracy aid that a request raised outside
   a Keeper turn structurally cannot carry, ... *)
```

나는 `turn_id = None` 을 보고 "턴 밖에서 올라온 요청"이라고 추정했다. #25968 이 실제 경로를 추적했다: #25954 가 추가한 Gate replay 가 `gate_context` 를 전달하지 않아 replay 된 요청이 `request_context = None` 으로 기록됐다.

#25968 의 라이브 표가 결정적이다.

| tool | 건수 | request_context |
|---|---|---|
| `tool_execute` | 14 | 전부 있음 |
| `filesystem_write` | 2 | 전부 없음 |

갈린 축이 **도구별**이지 턴 기원이 아니다. "턴 밖 요청"이라는 설명으로는 이 분포가 나오지 않는다.

## 왜 고치는가

주석이 특정한 잘못된 원인을 못박으면, 다음 사람이 그 전제로 조사를 시작한다. `partial_context` 는 컨텍스트를 떨어뜨리는 경로가 무엇이든 판정을 계속하게 하는 방어층이고, 어떤 경로가 떨어뜨리는지는 별개 결함 계열이다. 관측 가능한 조건만 서술하고 결함 계열은 이슈로 가리킨다.

## 변경

- `hitl_summary_worker.ml` 주석: 원인 단정을 제거하고 `#25966` / `#25968` 을 가리킨다
- `keeper.gate_judgment.md`: `the request was raised outside a Keeper turn and no transcript exists to attach` → `no outer-turn transcript reached you`

동작 변경 없음. 주석과 프롬프트 문안만 바뀐다.

## 검증

`dune build @check` 는 현재 `main` 에서 이미 실패한다 (#25982 — `#25969` 가 `For_testing.settle_claimed_lease_exact` 를 삭제하며 소비자 테스트를 이전하지 않음). 이 PR 의 변경분은 주석 1개와 프롬프트 문장 1개뿐이라 그 실패와 무관하며, 실패 지점은 `test/test_keeper_exact_execution_lease_guard.ml` 로 이 PR 이 건드리는 파일이 아니다.

RFC-WAIVED: 주석과 프롬프트 문안 정정이며 동작을 바꾸지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
