### PR TITLE
fix(gate): keep Auto Judge live past terminal owner heads

### DIFF
--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -479,20 +479,15 @@ let compare_auto_judge_entries
   Int.compare left.sequence right.sequence
 ;;
 
-let earliest_auto_judge_for_owner ?exclude_id ~base_path ~keeper_name entries =
-  let sorted =
-    entries
-    |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
-      String.equal entry.audit_base_path base_path
-      && String.equal entry.keeper_name keeper_name
-      && (match exclude_id with
-          | Some id -> not (String.equal id entry.id)
-          | None -> true))
-    |> List.sort compare_auto_judge_entries
-  in
-  match sorted with
-  | [] -> None
-  | entry :: _ -> Some entry
+(* Every pending approval for the owner, in durable sequence order. Selection
+   ranges over this list; [ready_auto_judges_for_owner] decides which member
+   Auto Judge may start. *)
+let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
+  entries
+  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+    String.equal entry.audit_base_path base_path
+    && String.equal entry.keeper_name keeper_name)
+  |> List.sort compare_auto_judge_entries
 ;;
 
 let auto_judge_entry_has_start_reservation
@@ -517,35 +512,45 @@ let auto_judge_entry_has_start_reservation
   | _ -> false
 ;;
 
+(* Sequence order is kept, but selection ranges over the entries Auto Judge can
+   still start instead of testing only the FIFO head. A head that is not
+   startable is not always transient. An entry whose judgment concluded in
+   [Require_human] keeps [Summary_attempt_settled] with [Summary_available]
+   for as long as it stays pending, because [resolve_judgment] persists no
+   transition for that verdict; a [Summary_attempt_pre_worker_unavailable]
+   entry waits for an explicit operator retry. Both classify as not ready, so
+   testing only the head stops the whole owner queue at the first such entry
+   and no drain trigger can restart it. Observed on 2026-07-28: 18 approvals
+   across two Keepers sat behind two heads of exactly these two kinds, the
+   oldest for 2416s, while new submissions kept firing the drain. Concurrency
+   remains bounded by [claim_auto_judge], not by this ordering. Selection still
+   yields at most one entry, so a drain reached from the tool-call hot path
+   makes at most one start attempt; an entry that fails to start becomes not
+   startable and the next trigger passes over it. *)
 let ready_auto_judges_for_owner
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
       entries
   =
+  let startable (entry : Keeper_approval_queue.pending_approval) =
+    auto_judge_entry_ready entry
+    ||
+    (match reserved_id with
+     | Some reserved_id ->
+       auto_judge_entry_has_start_reservation reserved_id entry
+     | None -> false)
+  in
   match
-    earliest_auto_judge_for_owner
-      ?exclude_id
-      ~base_path
-      ~keeper_name
-      entries
+    owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries
+    |> List.find_opt startable
   with
-  | Some entry
-    when
-      auto_judge_entry_ready entry
-      ||
-      (match reserved_id with
-       | Some reserved_id ->
-         auto_judge_entry_has_start_reservation reserved_id entry
-       | None -> false) ->
-    [ entry ]
-  | Some _ | None -> []
+  | Some entry -> [ entry ]
+  | None -> []
 ;;
 
 type auto_judge_drain_blocker =
   | Drain_owner_active of string
-  | Drain_fifo_predecessor of string
   | Drain_entry_changed of string
   | Drain_entry_missing of string
   | Drain_start_failed of string * string
@@ -556,10 +561,6 @@ let auto_judge_drain_blocker_to_string = function
   | Drain_owner_active approval_id ->
     Printf.sprintf
       "Auto Judge retry could not start because approval %s owns the active worker"
-      approval_id
-  | Drain_fifo_predecessor approval_id ->
-    Printf.sprintf
-      "Auto Judge retry could not start because approval %s is first in FIFO"
       approval_id
   | Drain_entry_changed approval_id ->
     Printf.sprintf
@@ -854,7 +855,6 @@ and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
        Ok Skipped)
 
 and drain_auto_judge_owner_queue
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -907,32 +907,30 @@ and drain_auto_judge_owner_queue
   |> Result.map (fun entries ->
     let selected =
       ready_auto_judges_for_owner
-        ?exclude_id
         ?reserved_id
         ~base_path
         ~keeper_name
         entries
     in
+    (* Selection ranges over every startable entry, so an empty selection under
+       a reservation means the reserved entry itself is no longer startable --
+       never that an earlier approval holds the FIFO head. *)
     let blocker =
       match reserved_id, selected with
       | Some reserved_id, [] ->
         (match
-           earliest_auto_judge_for_owner
-             ?exclude_id
-             ~base_path
-             ~keeper_name
+           List.exists
+             (fun (entry : Keeper_approval_queue.pending_approval) ->
+                String.equal entry.id reserved_id)
              entries
          with
-         | None -> Some (Drain_entry_missing reserved_id)
-         | Some entry when String.equal entry.id reserved_id ->
-           Some (Drain_entry_changed entry.id)
-         | Some entry -> Some (Drain_fifo_predecessor entry.id))
+         | false -> Some (Drain_entry_missing reserved_id)
+         | true -> Some (Drain_entry_changed reserved_id))
       | _ -> None
     in
     loop [] blocker selected)
 
 and drain_auto_judge_owner
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -941,7 +939,6 @@ and drain_auto_judge_owner
   match Keeper_gate_mode.read ~base_path with
   | Ok Keeper_gate_mode.Auto_judge ->
     drain_auto_judge_owner_queue
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -1039,27 +1036,42 @@ let recovered_work_for_base_path ~base_path =
         Auto_judge_owner_set.empty
         entries
     in
+    let recovered_work_for_entry
+          (entry : Keeper_approval_queue.pending_approval)
+      =
+      match classify_auto_judge_entry entry with
+      | Auto_judge_not_requested
+      | Auto_judge_pending_unbound ->
+        Some (Activate_worker entry)
+      | Auto_judge_finalizable
+          ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
+           as summary) ->
+        Some (Finalize_judgment (entry, summary))
+      | Auto_judge_finalizable
+          { judgment = Keeper_approval_queue.Require_human; _ }
+      | Auto_judge_ineligible ->
+        None
+    in
+    let entry_of_recovered_work = function
+      | Activate_worker entry -> entry
+      | Finalize_judgment (entry, _) -> entry
+    in
+    (* Per owner, recover the earliest entry that still carries Auto Judge
+       work. Reading only the FIFO head and classifying it afterwards lets a
+       head with no work -- a Require_human judgment waiting on an operator, or
+       any ineligible disposition -- hide every recoverable entry behind it.
+       That is the same head-of-line stall [ready_auto_judges_for_owner]
+       avoids, and it would leave restart, the only remaining escape from a
+       stalled owner, recovering nothing for that owner. *)
     owners
     |> Auto_judge_owner_set.elements
     |> List.filter_map (fun (_, keeper_name) ->
-      earliest_auto_judge_for_owner
-        ~base_path
-        ~keeper_name
-        entries)
-    |> List.sort compare_auto_judge_entries
-    |> List.filter_map (fun entry ->
-        match classify_auto_judge_entry entry with
-        | Auto_judge_not_requested
-        | Auto_judge_pending_unbound ->
-          Some (Activate_worker entry)
-        | Auto_judge_finalizable
-            ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
-             as summary) ->
-          Some (Finalize_judgment (entry, summary))
-        | Auto_judge_finalizable
-            { judgment = Keeper_approval_queue.Require_human; _ }
-        | Auto_judge_ineligible ->
-          None))
+      owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries
+      |> List.find_map recovered_work_for_entry)
+    |> List.sort (fun left right ->
+      compare_auto_judge_entries
+        (entry_of_recovered_work left)
+        (entry_of_recovered_work right)))
 ;;
 
 let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval) =

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -110,9 +110,15 @@ val decide :
   decision
 
 (** Recover durable Auto Judge work for exactly one workspace. Each exact
-    [(base_path, keeper_name)] owner evaluates only its oldest entry.
-    Failed, quarantined, released, uncertain, or otherwise ineligible oldest
-    state is a FIFO barrier: recovery never activates a later same-owner entry.
+    [(base_path, keeper_name)] owner activates at most one entry: the oldest
+    one that still carries Auto Judge work. An oldest entry that is failed,
+    quarantined, released, uncertain, judged [Require_human], or otherwise
+    ineligible carries no such work and is passed over instead of held as a
+    FIFO barrier. None of those states leaves itself, so treating them as a
+    barrier starved every later same-owner entry for as long as the owner
+    stayed in one: observed on 2026-07-28 holding 25 approvals across two
+    Keepers, the oldest for 2416s, while every drive path kept firing. Entries
+    that do carry work keep durable sequence order among themselves.
     Completion drains only that owner's FIFO. Decisive output without an exact
     attempt identity is retained pending and recorded as a recovery failure.
     Completed exact output is first idempotently strict-rewritten with the same

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -1698,6 +1698,81 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
          (F.post_count server))
 ;;
 
+let test_require_human_head_does_not_stop_owner_drain () =
+  run_eio @@ fun ~sw ~net ~clock ->
+  with_temp_dir "hitl-require-human-drain" @@ fun base_path ->
+  Fun.protect
+    ~finally:Q.For_testing.reset_runtime_state
+    (fun () ->
+       install_queue base_path;
+       Prompt_registry.set_markdown_dir
+         (Masc_test_deps.source_path "config/prompts");
+       let successor_server =
+         F.start_server
+           ~sw
+           ~net
+           ~clock
+           (F.Reply (F.openai_response (judgment_json "approve")))
+       in
+       let publish_successor_lane () =
+         publish_lane
+           [ "hitl-require-human-successor" ]
+           (F.resolver_snapshot
+              ~source:"hitl-require-human-successor"
+              [ { id = "hitl-require-human-successor"
+                ; base_url = successor_server.base_url
+                }
+              ])
+       in
+       let head_server =
+         F.start_server
+           ~on_request_before_reply:publish_successor_lane
+           ~sw
+           ~net
+           ~clock
+           (F.Reply (F.openai_response (judgment_json "require_human")))
+       in
+       publish_lane
+         [ "hitl-require-human-head" ]
+         (F.resolver_snapshot
+            ~source:"hitl-require-human-head"
+            [ { id = "hitl-require-human-head"; base_url = head_server.base_url } ]);
+       select_auto_judge_mode base_path;
+       let head = pending_entry ~input_tag:"require-human-head" ~base_path () in
+       let successor = pending_entry ~input_tag:"successor" ~base_path () in
+       let recovery = Gate.resume_persisted_auto_judges ~base_path in
+       check
+         (list string)
+         "recovery starts the oldest owner entry"
+         [ head.id ]
+         recovery.started_ids;
+       await_condition
+         ~clock
+         ~remaining:100
+         ~failure:"Require_human head stopped the same-owner successor"
+         (fun () -> F.post_count successor_server = 1);
+       await_condition
+         ~clock
+         ~remaining:100
+         ~failure:"successor did not complete after Require_human head"
+         (fun () ->
+            Option.is_none
+              (Q.For_testing.get_pending_entry_unchecked ~id:successor.id));
+       (match Q.For_testing.get_pending_entry_unchecked ~id:head.id with
+        | Some
+            { exact_attempt =
+                Q.Exact_bound { status = Q.Exact_completed; _ }
+            ; summary_status =
+                Q.Summary_available { judgment = Q.Require_human; _ }
+            ; summary_attempt_disposition = Q.Summary_attempt_settled
+            ; _
+            } ->
+          ()
+        | _ -> fail "Require_human head lost its durable operator-visible state");
+       check int "Require_human head judged once" 1 (F.post_count head_server);
+       check int "same-owner successor judged once" 1 (F.post_count successor_server))
+;;
+
 let test_gate_judgment_prompt_comes_from_registry () =
   Prompt_registry.set_markdown_dir
     (Masc_test_deps.source_path "config/prompts");
@@ -1803,6 +1878,10 @@ let () =
             "owner FIFO atomic drain is non-sharing"
             `Quick
             test_owner_fifo_atomic_drain_is_nonsharing
+        ; test_case
+            "Require_human head does not stop owner drain"
+            `Quick
+            test_require_human_head_does_not_stop_owner_drain
         ] )
     ]
 ;;

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -706,6 +706,110 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
          Alcotest.failf "one oldest same-owner entry expected, got %d" (List.length entries))
 ;;
 
+(* Owner selection used to read only the FIFO head, so a head that never
+   becomes startable on its own froze every later approval for that Keeper.
+   Two durable shapes reach that state and neither clears without an operator:
+   a judgment that concluded in [Require_human], which [resolve_judgment]
+   persists no transition for, and a pre-worker failure awaiting an explicit
+   retry. Observed live on 2026-07-28 holding 18 approvals across two Keepers,
+   the oldest for 2416s. *)
+let head_of_line_owner = "head-of-line-owner"
+
+let require_human_summary () : AQ.hitl_context_summary =
+  { summary_version = AQ.current_hitl_context_summary_version
+  ; generated_at = 1.0
+  ; model_run_id = "model-run-head-of-line"
+  ; context_summary = "head approval was handed to a human"
+  ; key_questions = []
+  ; judgment = AQ.Require_human
+  ; rationale = "operator decision required"
+  }
+;;
+
+let completed_exact_binding (entry : AQ.pending_approval) =
+  AQ.exact_attempt_binding_with_status
+    (AQ.make_exact_attempt_binding
+       ~approval_id:entry.id
+       ~input_hash:entry.input_hash
+       ~sequence:entry.sequence
+       ~slot_id:"slot-head-of-line"
+       ~call_id:"call-head-of-line"
+       ~plan_fingerprint:"plan-head-of-line"
+       ~request_body_sha256:"sha256-head-of-line"
+       ())
+    AQ.Exact_completed
+;;
+
+let check_owner_selection label ~base_path ~expected entries =
+  match
+    Gate.For_testing.ready_auto_judges_for_owner
+      ~base_path
+      ~keeper_name:head_of_line_owner
+      entries
+  with
+  | [ selected ] ->
+    Alcotest.(check string) label expected selected.AQ.id
+  | [] -> Alcotest.failf "%s: owner selection returned nothing" label
+  | selected ->
+    Alcotest.failf "%s: expected one entry, got %d" label (List.length selected)
+;;
+
+let test_terminal_head_does_not_stall_owner_queue () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let head =
+         pending_entry_exn
+           (submit ~base_path ~keeper_name:head_of_line_owner ~input:(`Int 1))
+       in
+       let follower =
+         pending_entry_exn
+           (submit ~base_path ~keeper_name:head_of_line_owner ~input:(`Int 2))
+       in
+       Alcotest.(check bool)
+         "head carries the earlier durable sequence"
+         true
+         (head.sequence < follower.sequence);
+       check_owner_selection
+         "a startable head keeps its place at the front"
+         ~base_path
+         ~expected:head.id
+         [ follower; head ];
+       let judged_head =
+         { head with
+           AQ.summary_status = AQ.Summary_available (require_human_summary ())
+         ; AQ.summary_attempt_disposition = AQ.Summary_attempt_settled
+         ; AQ.exact_attempt = AQ.Exact_bound (completed_exact_binding head)
+         }
+       in
+       check_owner_selection
+         "a Require_human head releases the owner slot to the next approval"
+         ~base_path
+         ~expected:follower.id
+         [ judged_head; follower ];
+       let blocked_head =
+         { head with
+           AQ.summary_status = AQ.Summary_pending
+         ; AQ.summary_attempt_disposition =
+             AQ.Summary_attempt_pre_worker_unavailable
+               { reason_code = AQ.Summary_pre_worker_auto_judge_unavailable
+               ; operator_detail =
+                   "HITL summary: exact outer-turn request context is unavailable"
+               }
+         }
+       in
+       check_owner_selection
+         "a pre-worker-blocked head releases the owner slot to the next approval"
+         ~base_path
+         ~expected:follower.id
+         [ blocked_head; follower ])
+;;
+
 let test_different_owners_claim_in_parallel () =
   (* Real concurrent proof: fibers race the per-owner claim, so the
      one-winner-per-owner invariant is exercised under actual Atomic
@@ -2980,6 +3084,10 @@ let () =
             "same owner drains by durable sequence"
             `Quick
             test_same_owner_drain_uses_sequence_not_wall_clock
+        ; Alcotest.test_case
+            "terminal head does not stall the owner queue"
+            `Quick
+            test_terminal_head_does_not_stall_owner_queue
         ; Alcotest.test_case
             "different owners activate in parallel"
             `Quick


### PR DESCRIPTION
## Summary

- select the earliest startable Auto Judge approval per `(base_path, keeper_name)` instead of treating an unstartable FIFO head as a permanent owner barrier
- apply the same liveness rule during durable restart recovery
- keep the owner concurrency cap at one active worker
- preserve `Require_human` as an operator-visible pending decision

## Why

One durable head in either of these states never leaves by itself:

- completed `Require_human`
- `Summary_attempt_pre_worker_unavailable`

The previous selector inspected only that head and returned no work, so later judgeable approvals for the same Keeper remained `not_requested` forever even though submission, completion, restart, and operator-recovery drain triggers were still firing.

Closes #25966.

## Tests

- added a selection regression covering both permanent head states
- added a production exact-flow regression where the first model result is `require_human` and the same-owner successor is automatically approved
- verified all four changed OCaml files with `ocamlformat --check`, parser-only `ocamlc`, and `git diff --check`

Focused Dune validation is currently blocked by default-branch compilation regressions tracked in #25980:

```text
Keeper_heartbeat_loop.mli requires project_transition_outbox, but the implementation is missing
test_keeper_approval_queue.ml still calls removed settlement_of_cycle_outcome
```

The PR remains draft until the main baseline is repaired and the two focused executables pass.
