### PR TITLE
fix(test): drop settlement assertions left by the peek/ack migration

### DIFF
--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -18,7 +18,6 @@ let check_rearm label expected = function
 
 module Gate = Masc.Keeper_gate
 module Registry_queue = Masc.Keeper_registry_event_queue
-module Queue_state = Keeper_event_queue_state
 
 (* Test-local shim for the excised [Keeper_approval_queue.resolve] wrapper:
    reproduces its unit projection over [resolve_with_policy] so these
@@ -94,21 +93,6 @@ let drop_resolution ~base_path ~keeper_name resolution =
   | Error reason -> Alcotest.fail reason
 ;;
 
-let lease_for_resolution (resolution : Keeper_event_queue.hitl_resolution) =
-  let stimulus : Keeper_event_queue.stimulus =
-    { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
-    ; urgency = Keeper_event_queue.Immediate
-    ; arrived_at = 1.0
-    ; payload = Keeper_event_queue.Hitl_resolved resolution
-    }
-  in
-  let pending = Keeper_event_queue.enqueue Keeper_event_queue.empty stimulus in
-  let state = Queue_state.with_pending pending Queue_state.empty in
-  match Queue_state.claim_when ~claimed_at:2.0 ~ready:(fun _ -> true) state with
-  | Ok (_, Some lease) -> lease
-  | Ok (_, None) -> Alcotest.fail "approved resolution was not claimed"
-  | Error reason -> Alcotest.fail reason
-;;
 
 let submit_with_context
       ?turn_id
@@ -1020,20 +1004,15 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
          | Some grant -> grant
          | None -> Alcotest.fail "approved resolution did not create a cycle grant"
        in
-       let lease = lease_for_resolution resolution in
-       (match
-          Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
-            ~base_path
-            ~settled_at:3.0
-            ~stop_requested:false
-            ~compaction_consecutive_failures:0
-            ~lease
-            None
-        with
-        | Masc.Keeper_registry_event_queue.Requeue
-            Masc.Keeper_registry_event_queue.Turn_not_scheduled ->
-          ()
-        | _ -> Alcotest.fail "unscheduled grant wake was not requeued");
+       (* The two lease-settlement assertions that used to sit here and below
+          checked that a wake producing no cycle outcome requeued the lease
+          instead of acknowledging it, so the grant's stimulus was not dropped.
+          #25969 replaced claim/settle with peek/ack: nothing computes a
+          settlement any more, and "no turn ran" is expressed by not calling
+          [ack_pending] at all. That PR deleted the same class of assertion
+          from test_keeper_event_queue_state_v2.ml but left these two, which is
+          why this executable stopped compiling. The property now belongs to
+          the peek/ack intake path rather than to this file; see #25980. *)
        let request ~input ~task_id ~goal_ids : Gate.request =
          { keeper_name
          ; operation = "external-effect"
@@ -1095,19 +1074,6 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
         | Gate.Exact_always_rule _
         | Gate.Workspace_always_allow ->
           Alcotest.fail "one-shot grant was consumed more than once");
-       (match
-          Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
-            ~base_path
-            ~settled_at:4.0
-            ~stop_requested:false
-            ~compaction_consecutive_failures:0
-            ~lease
-            None
-        with
-        | Masc.Keeper_registry_event_queue.Requeue
-            Masc.Keeper_registry_event_queue.Turn_not_scheduled ->
-          ()
-        | _ -> Alcotest.fail "unscheduled consumed grant wake was not requeued");
        AQ.For_testing.reset_runtime_state ();
        let _ = install_exn ~base_path in
        (match AQ.approved_resolution_state ~base_path ~id:approval_id with


### PR DESCRIPTION
Closes #25980

## 문제

`origin/main` 에서 `test/test_keeper_approval_queue.exe` 가 컴파일되지 않습니다.

```
File "test/test_keeper_approval_queue.ml", line 1025, characters 10-64:
Error: Unbound value Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome
```

`2f60744277` (#25969) 이 `lib/keeper/keeper_heartbeat_loop.mli` 에서 settlement API 를 제거하면서 (`+1/-66`) 소비자 하나 (`test/test_keeper_event_queue_state_v2.ml`) 는 갱신했지만, 같은 API 를 쓰던 `test/test_keeper_approval_queue.ml` 의 2 곳을 남겨두었습니다. 그 결과 이 파일의 32 개 케이스 전체가 실행 불가입니다.

## 변경

`test_cycle_grant_uses_exact_effect_and_is_consumed_once` 안의 settlement 단정 2 개를 제거했습니다. 둘 다 같은 형태였습니다.

```ocaml
Masc.Keeper_heartbeat_loop.settlement_of_cycle_outcome ... ~lease None
| Requeue Turn_not_scheduled -> ()
| _ -> Alcotest.fail "unscheduled grant wake was not requeued"
```

지키던 성질은 **"턴을 만들지 못한 wake 는 lease 를 ack 하지 말아야 한다"** — 그래야 승인 grant 의 stimulus 가 유실되지 않습니다.

#25969 는 claim/settle 을 peek/ack 으로 바꿨습니다 (`keeper_event_queue_state.mli` 에 `peek_when` / `ack_pending` 추가). 새 모델에서는 settlement 를 계산하는 함수가 없고, "턴이 실행되지 않았다" 는 `ack_pending` 을 **호출하지 않는 것**으로 표현됩니다. 즉 이 성질은 순수 함수에 대한 단정이 아니라 intake 경로의 구조가 되었습니다. 같은 PR 이 `test_keeper_event_queue_state_v2.ml` (3300 줄 → 180 줄) 에서 이 계열 단정을 전부 삭제한 것도 같은 이유로 보입니다.

이 성질을 peek/ack 경로에서 다시 검증할지는 #25980 에 남겨두었습니다. **커버리지가 줄어드는 것을 인지하고 제거합니다.** 코드에도 왜 사라졌는지 주석으로 남겼습니다.

곁가지로 두 개가 미사용이 되어 함께 제거했습니다.

- `lease_for_resolution` — 위 두 단정이 유일한 사용처였습니다.
- `module Queue_state` alias — `lease_for_resolution` 이 유일한 사용처였습니다.

## 뒤따르는 정리 (이 PR 범위 아님)

`lease_for_resolution` 제거로 이 파일의 마지막 `Keeper_event_queue_state.claim_when` 사용이 사라집니다. `claim_when` / `claim_when_result` 는 **프로덕션 호출부가 0** 입니다.

```
claim_when 참조: lib/ 8 줄 (정의 + 2 층 래퍼끼리의 참조뿐), test/ 26 곳 / 14 파일
라이브 경로는 peek_when_result (keeper_heartbeat_stimulus_intake.ml:331)
```

즉 #25969 이 프로덕션을 peek/ack 으로 옮긴 뒤에도 claim/settle 스택 전체가 **테스트만을 위해** 살아 있습니다. 이건 별도 PR 로 걷어내겠습니다.

## 검증

`scripts/dune-local.sh build test/test_keeper_approval_queue.exe` 로 컴파일 복구를 확인하고 스위트를 실행했습니다. 결과는 아래 코멘트에 붙입니다.

이 파일에는 이 변경과 무관한 기존 실패가 3 건 있습니다 (#16 exact staged durability — raw backtrace 문자열 전체 일치 비교, #17, #21). #25980 에 기록했습니다.

RFC-WAIVED: 테스트 파일에서 이미 제거된 API 의 호출부를 걷어내는 변경입니다. credential / identity / operator control plane / sandbox / hooks 어디에도 해당하지 않습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
