### PR TITLE
fix(gate): select the earliest startable Auto Judge entry per owner

### DIFF
--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -479,20 +479,15 @@ let compare_auto_judge_entries
   Int.compare left.sequence right.sequence
 ;;
 
-let earliest_auto_judge_for_owner ?exclude_id ~base_path ~keeper_name entries =
-  let sorted =
-    entries
-    |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
-      String.equal entry.audit_base_path base_path
-      && String.equal entry.keeper_name keeper_name
-      && (match exclude_id with
-          | Some id -> not (String.equal id entry.id)
-          | None -> true))
-    |> List.sort compare_auto_judge_entries
-  in
-  match sorted with
-  | [] -> None
-  | entry :: _ -> Some entry
+(* Every pending approval for the owner, in durable sequence order. Selection
+   ranges over this list; [ready_auto_judges_for_owner] decides which member
+   Auto Judge may start. *)
+let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
+  entries
+  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+    String.equal entry.audit_base_path base_path
+    && String.equal entry.keeper_name keeper_name)
+  |> List.sort compare_auto_judge_entries
 ;;
 
 let auto_judge_entry_has_start_reservation
@@ -517,35 +512,45 @@ let auto_judge_entry_has_start_reservation
   | _ -> false
 ;;
 
+(* Sequence order is kept, but selection ranges over the entries Auto Judge can
+   still start instead of testing only the FIFO head. A head that is not
+   startable is not always transient. An entry whose judgment concluded in
+   [Require_human] keeps [Summary_attempt_settled] with [Summary_available]
+   for as long as it stays pending, because [resolve_judgment] persists no
+   transition for that verdict; a [Summary_attempt_pre_worker_unavailable]
+   entry waits for an explicit operator retry. Both classify as not ready, so
+   testing only the head stops the whole owner queue at the first such entry
+   and no drain trigger can restart it. Observed on 2026-07-28: 18 approvals
+   across two Keepers sat behind two heads of exactly these two kinds, the
+   oldest for 2416s, while new submissions kept firing the drain. Concurrency
+   remains bounded by [claim_auto_judge], not by this ordering. Selection still
+   yields at most one entry, so a drain reached from the tool-call hot path
+   makes at most one start attempt; an entry that fails to start becomes not
+   startable and the next trigger passes over it. *)
 let ready_auto_judges_for_owner
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
       entries
   =
+  let startable (entry : Keeper_approval_queue.pending_approval) =
+    auto_judge_entry_ready entry
+    ||
+    (match reserved_id with
+     | Some reserved_id ->
+       auto_judge_entry_has_start_reservation reserved_id entry
+     | None -> false)
+  in
   match
-    earliest_auto_judge_for_owner
-      ?exclude_id
-      ~base_path
-      ~keeper_name
-      entries
+    owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries
+    |> List.find_opt startable
   with
-  | Some entry
-    when
-      auto_judge_entry_ready entry
-      ||
-      (match reserved_id with
-       | Some reserved_id ->
-         auto_judge_entry_has_start_reservation reserved_id entry
-       | None -> false) ->
-    [ entry ]
-  | Some _ | None -> []
+  | Some entry -> [ entry ]
+  | None -> []
 ;;
 
 type auto_judge_drain_blocker =
   | Drain_owner_active of string
-  | Drain_fifo_predecessor of string
   | Drain_entry_changed of string
   | Drain_entry_missing of string
   | Drain_start_failed of string * string
@@ -556,10 +561,6 @@ let auto_judge_drain_blocker_to_string = function
   | Drain_owner_active approval_id ->
     Printf.sprintf
       "Auto Judge retry could not start because approval %s owns the active worker"
-      approval_id
-  | Drain_fifo_predecessor approval_id ->
-    Printf.sprintf
-      "Auto Judge retry could not start because approval %s is first in FIFO"
       approval_id
   | Drain_entry_changed approval_id ->
     Printf.sprintf
@@ -854,7 +855,6 @@ and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
        Ok Skipped)
 
 and drain_auto_judge_owner_queue
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -907,32 +907,30 @@ and drain_auto_judge_owner_queue
   |> Result.map (fun entries ->
     let selected =
       ready_auto_judges_for_owner
-        ?exclude_id
         ?reserved_id
         ~base_path
         ~keeper_name
         entries
     in
+    (* Selection ranges over every startable entry, so an empty selection under
+       a reservation means the reserved entry itself is no longer startable --
+       never that an earlier approval holds the FIFO head. *)
     let blocker =
       match reserved_id, selected with
       | Some reserved_id, [] ->
         (match
-           earliest_auto_judge_for_owner
-             ?exclude_id
-             ~base_path
-             ~keeper_name
+           List.exists
+             (fun (entry : Keeper_approval_queue.pending_approval) ->
+                String.equal entry.id reserved_id)
              entries
          with
-         | None -> Some (Drain_entry_missing reserved_id)
-         | Some entry when String.equal entry.id reserved_id ->
-           Some (Drain_entry_changed entry.id)
-         | Some entry -> Some (Drain_fifo_predecessor entry.id))
+         | false -> Some (Drain_entry_missing reserved_id)
+         | true -> Some (Drain_entry_changed reserved_id))
       | _ -> None
     in
     loop [] blocker selected)
 
 and drain_auto_judge_owner
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -941,7 +939,6 @@ and drain_auto_judge_owner
   match Keeper_gate_mode.read ~base_path with
   | Ok Keeper_gate_mode.Auto_judge ->
     drain_auto_judge_owner_queue
-      ?exclude_id
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -1039,27 +1036,42 @@ let recovered_work_for_base_path ~base_path =
         Auto_judge_owner_set.empty
         entries
     in
+    let recovered_work_for_entry
+          (entry : Keeper_approval_queue.pending_approval)
+      =
+      match classify_auto_judge_entry entry with
+      | Auto_judge_not_requested
+      | Auto_judge_pending_unbound ->
+        Some (Activate_worker entry)
+      | Auto_judge_finalizable
+          ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
+           as summary) ->
+        Some (Finalize_judgment (entry, summary))
+      | Auto_judge_finalizable
+          { judgment = Keeper_approval_queue.Require_human; _ }
+      | Auto_judge_ineligible ->
+        None
+    in
+    let entry_of_recovered_work = function
+      | Activate_worker entry -> entry
+      | Finalize_judgment (entry, _) -> entry
+    in
+    (* Per owner, recover the earliest entry that still carries Auto Judge
+       work. Reading only the FIFO head and classifying it afterwards lets a
+       head with no work -- a Require_human judgment waiting on an operator, or
+       any ineligible disposition -- hide every recoverable entry behind it.
+       That is the same head-of-line stall [ready_auto_judges_for_owner]
+       avoids, and it would leave restart, the only remaining escape from a
+       stalled owner, recovering nothing for that owner. *)
     owners
     |> Auto_judge_owner_set.elements
     |> List.filter_map (fun (_, keeper_name) ->
-      earliest_auto_judge_for_owner
-        ~base_path
-        ~keeper_name
-        entries)
-    |> List.sort compare_auto_judge_entries
-    |> List.filter_map (fun entry ->
-        match classify_auto_judge_entry entry with
-        | Auto_judge_not_requested
-        | Auto_judge_pending_unbound ->
-          Some (Activate_worker entry)
-        | Auto_judge_finalizable
-            ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
-             as summary) ->
-          Some (Finalize_judgment (entry, summary))
-        | Auto_judge_finalizable
-            { judgment = Keeper_approval_queue.Require_human; _ }
-        | Auto_judge_ineligible ->
-          None))
+      owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries
+      |> List.find_map recovered_work_for_entry)
+    |> List.sort (fun left right ->
+      compare_auto_judge_entries
+        (entry_of_recovered_work left)
+        (entry_of_recovered_work right)))
 ;;
 
 let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval) =

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -110,9 +110,15 @@ val decide :
   decision
 
 (** Recover durable Auto Judge work for exactly one workspace. Each exact
-    [(base_path, keeper_name)] owner evaluates only its oldest entry.
-    Failed, quarantined, released, uncertain, or otherwise ineligible oldest
-    state is a FIFO barrier: recovery never activates a later same-owner entry.
+    [(base_path, keeper_name)] owner activates at most one entry: the oldest
+    one that still carries Auto Judge work. An oldest entry that is failed,
+    quarantined, released, uncertain, judged [Require_human], or otherwise
+    ineligible carries no such work and is passed over instead of held as a
+    FIFO barrier. None of those states leaves itself, so treating them as a
+    barrier starved every later same-owner entry for as long as the owner
+    stayed in one: observed on 2026-07-28 holding 25 approvals across two
+    Keepers, the oldest for 2416s, while every drive path kept firing. Entries
+    that do carry work keep durable sequence order among themselves.
     Completion drains only that owner's FIFO. Decisive output without an exact
     attempt identity is retained pending and recorded as a recovery failure.
     Completed exact output is first idempotently strict-rewritten with the same

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -706,6 +706,110 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
          Alcotest.failf "one oldest same-owner entry expected, got %d" (List.length entries))
 ;;
 
+(* Owner selection used to read only the FIFO head, so a head that never
+   becomes startable on its own froze every later approval for that Keeper.
+   Two durable shapes reach that state and neither clears without an operator:
+   a judgment that concluded in [Require_human], which [resolve_judgment]
+   persists no transition for, and a pre-worker failure awaiting an explicit
+   retry. Observed live on 2026-07-28 holding 18 approvals across two Keepers,
+   the oldest for 2416s. *)
+let head_of_line_owner = "head-of-line-owner"
+
+let require_human_summary () : AQ.hitl_context_summary =
+  { summary_version = AQ.current_hitl_context_summary_version
+  ; generated_at = 1.0
+  ; model_run_id = "model-run-head-of-line"
+  ; context_summary = "head approval was handed to a human"
+  ; key_questions = []
+  ; judgment = AQ.Require_human
+  ; rationale = "operator decision required"
+  }
+;;
+
+let completed_exact_binding (entry : AQ.pending_approval) =
+  AQ.exact_attempt_binding_with_status
+    (AQ.make_exact_attempt_binding
+       ~approval_id:entry.id
+       ~input_hash:entry.input_hash
+       ~sequence:entry.sequence
+       ~slot_id:"slot-head-of-line"
+       ~call_id:"call-head-of-line"
+       ~plan_fingerprint:"plan-head-of-line"
+       ~request_body_sha256:"sha256-head-of-line"
+       ())
+    AQ.Exact_completed
+;;
+
+let check_owner_selection label ~base_path ~expected entries =
+  match
+    Gate.For_testing.ready_auto_judges_for_owner
+      ~base_path
+      ~keeper_name:head_of_line_owner
+      entries
+  with
+  | [ selected ] ->
+    Alcotest.(check string) label expected selected.AQ.id
+  | [] -> Alcotest.failf "%s: owner selection returned nothing" label
+  | selected ->
+    Alcotest.failf "%s: expected one entry, got %d" label (List.length selected)
+;;
+
+let test_terminal_head_does_not_stall_owner_queue () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let head =
+         pending_entry_exn
+           (submit ~base_path ~keeper_name:head_of_line_owner ~input:(`Int 1))
+       in
+       let follower =
+         pending_entry_exn
+           (submit ~base_path ~keeper_name:head_of_line_owner ~input:(`Int 2))
+       in
+       Alcotest.(check bool)
+         "head carries the earlier durable sequence"
+         true
+         (head.sequence < follower.sequence);
+       check_owner_selection
+         "a startable head keeps its place at the front"
+         ~base_path
+         ~expected:head.id
+         [ follower; head ];
+       let judged_head =
+         { head with
+           AQ.summary_status = AQ.Summary_available (require_human_summary ())
+         ; AQ.summary_attempt_disposition = AQ.Summary_attempt_settled
+         ; AQ.exact_attempt = AQ.Exact_bound (completed_exact_binding head)
+         }
+       in
+       check_owner_selection
+         "a Require_human head releases the owner slot to the next approval"
+         ~base_path
+         ~expected:follower.id
+         [ judged_head; follower ];
+       let blocked_head =
+         { head with
+           AQ.summary_status = AQ.Summary_pending
+         ; AQ.summary_attempt_disposition =
+             AQ.Summary_attempt_pre_worker_unavailable
+               { reason_code = AQ.Summary_pre_worker_auto_judge_unavailable
+               ; operator_detail =
+                   "HITL summary: exact outer-turn request context is unavailable"
+               }
+         }
+       in
+       check_owner_selection
+         "a pre-worker-blocked head releases the owner slot to the next approval"
+         ~base_path
+         ~expected:follower.id
+         [ blocked_head; follower ])
+;;
+
 let test_different_owners_claim_in_parallel () =
   (* Real concurrent proof: fibers race the per-owner claim, so the
      one-winner-per-owner invariant is exercised under actual Atomic
@@ -2980,6 +3084,10 @@ let () =
             "same owner drains by durable sequence"
             `Quick
             test_same_owner_drain_uses_sequence_not_wall_clock
+        ; Alcotest.test_case
+            "terminal head does not stall the owner queue"
+            `Quick
+            test_terminal_head_does_not_stall_owner_queue
         ; Alcotest.test_case
             "different owners activate in parallel"
             `Quick


### PR DESCRIPTION
## 문제

Auto Judge는 keeper별로 한 번에 한 건만 판정합니다. 그 "다음 한 건"을 고르는 `ready_auto_judges_for_owner` (`lib/keeper/keeper_gate.ml:520`) 가 owner FIFO의 **선두 1건만** 검사하고, 그 선두가 startable이 아니면 빈 리스트를 반환합니다. 선두 너머는 보지 않습니다.

`earliest_auto_judge_for_owner` 는 `(audit_base_path, keeper_name)` 으로만 거르고 `sequence` 로 정렬해 맨 앞을 돌려줍니다. 자격 필터가 없습니다.

선두가 될 수 있는 상태 중 **스스로 빠져나오지 못하는 것이 둘** 있습니다.

| 선두 상태 | 발생 경로 | 자동 해소 |
|---|---|---|
| `Summary_attempt_settled` + `Summary_available { judgment = Require_human }` | Auto Judge가 정상적으로 "사람이 봐야 한다"고 판정. `resolve_judgment` (`:349-355`) 는 이 결론에 대해 아무 전이도 지속하지 않음 | 없음 — 사람이 해소해야 함 |
| `Summary_attempt_pre_worker_unavailable` | 워커 기동 전 실패 (예: `request_context` 부재) | 없음 — 운영자 재시도 필요 |

두 상태 모두 `classify_auto_judge_entry` (`:439`) 기준 not-ready 이므로, 선두에 앉는 순간 그 keeper의 **이후 모든 승인이 영구히 판정되지 않습니다**.

특히 첫 번째 항목이 기능 자체를 뒤집습니다. **Auto Judge가 `require_human` 을 한 번 내면 그 keeper의 자동 판정이 그때부터 멈춥니다.**

### 트리거는 멀쩡했습니다

드레인 진입점은 전부 정상 동작했습니다 — 새 제출마다 `defer` 가 `drain_auto_judge_owner` 를 호출하고 (`:1338`), 워커 완료 (`:680`), 운영자 복구 (`:1310`), 재기동 복구가 모두 살아 있습니다. 이들이 계속 발화하는데도 선택 함수가 매번 `[]` 를 돌려주었습니다. 그래서 실패가 조용했습니다: `reserved_id` 가 없으면 `blocker` 도 `None` 이 되어 (`:930`), 운영자는 이유 없는 `started=0` 만 봅니다.

## 관측 (2026-07-28, `~/me/.masc/gate/pending.json`)

교착 시점 스냅샷입니다.

| keeper | 선두 seq | 선두 분류 | 뒤에 갇힌 건수 |
|---|---|---|---|
| `lane-smith` | 317 | `pre_worker_unavailable` | 16 |
| `verifier` | 319 | `Require_human` 판정 완료 | 2 |

- pending 이 18 → 20 → 27 로 증가하는 동안 deliveries 는 280 에 고정. 최장 대기 2416초.
- 양성 대조: 같은 시간대에 `analyst` 는 seq 324, 336 을 정상 자동 판정·전달했습니다. owner 단위 교착이 맞습니다. `lane-smith` 전달은 seq 316 에서 끊깁니다.
- 갇힌 항목 대다수는 `request_context` 를 정상 보유했습니다. 컨텍스트 부재는 `lane-smith` 선두를 만든 원인일 뿐, 나머지가 굶은 원인이 아닙니다.

결과적으로 자동화율이 뒤집혔습니다.

| 구간 | 처리 건수 | Auto Judge | 사람이 대시보드에서 수동 승인 |
|---|---|---|---|
| seq < 317 (교착 전) | 278 | 242 (87.1%) | 36 |
| seq ≥ 317 (교착 후) | 33 | 3 (9.1%) | **30** |

큐는 결국 사람이 30번 클릭해서 비웠습니다.

## 변경

1. `owner_auto_judges_in_fifo_order` 를 분리하고, `ready_auto_judges_for_owner` 가 그 목록에서 **가장 이른 startable 항목**을 고르도록 했습니다. sequence 순서는 그대로 유지되고, 선택 대상만 "Auto Judge 가 아직 손댈 수 있는 항목"으로 좁아집니다.
   - 선택 결과는 여전히 최대 1건입니다. 툴 호출 hot path 에서 도달하는 드레인의 기동 시도 횟수를 늘리지 않기 위해서입니다. 기동에 실패한 항목은 not-startable 이 되어 다음 트리거가 지나갑니다.
   - 동시성 제한은 이 순서가 아니라 `claim_auto_judge` 가 계속 담당합니다.
2. `recovered_work_for_base_path` (`:1028`) 도 같은 결함이 있었습니다. owner별 선두를 읽고 나서 분류했기 때문에, 선두가 `Require_human` 이거나 ineligible 이면 그 owner 는 재기동 복구에서 **한 건도** 살아나지 않았습니다. 재기동은 현재 유일하게 남은 탈출구라 함께 고쳤습니다.
3. `Drain_fifo_predecessor` 가 도달 불가가 되어 제거했습니다. 선택이 startable 전체를 훑으므로, `reserved_id` 가 있는데 선택이 비었다는 것은 "앞선 승인이 선두"가 아니라 "예약된 승인이 시작 불가"를 뜻합니다. 해당 분기를 `Drain_entry_changed` / `Drain_entry_missing` 으로 정정했습니다. 새 분기는 예약된 id 가 아직 pending 인지를 직접 확인하므로, "owner 에 항목이 하나도 없음"으로 `Drain_entry_missing` 을 추정하던 기존 판정보다 정확합니다.
4. 죽은 표면 두 개를 함께 제거했습니다.
   - `earliest_auto_judge_for_owner` 는 이 변경으로 호출부가 0 이 되었습니다.
   - `?exclude_id` 는 `lib/` `test/` 전체에서 **한 번도 넘겨진 적이 없는** 파라미터였고, 위 함수들에 5중으로 배관돼 있었습니다. 함께 걷어냈습니다.

### 계약 문서 갱신

`keeper_gate.mli:112-116` 이 이 배리어를 **의도된 계약**으로 명시하고 있었습니다.

> Failed, quarantined, released, uncertain, or otherwise ineligible oldest state is a FIFO barrier: recovery never activates a later same-owner entry.

이 문장이 기술하는 상태들은 자동 탈출 경로가 없으므로, 배리어로 두면 liveness 상한이 없습니다. 계약을 새 동작으로 바꾸고 그 근거를 적었습니다.

## 검증

`test/test_keeper_approval_queue.ml` 에 `terminal head does not stall the owner queue` 를 추가했습니다. 두 종류의 종결 선두를 각각 만들어 뒤 항목이 선택되는지 확인하고, 선두가 startable 일 때는 여전히 선두가 먼저 선택되는지도 같이 확인합니다.

변이 검증 (lib 변경만 stash 하고 동일 테스트 실행):

| | 새 테스트 | 기존 #16 | 기존 #17 | 기존 #21 |
|---|---|---|---|---|
| 변경 전 | **FAIL** | FAIL | FAIL | FAIL |
| 변경 후 | **OK** | FAIL | FAIL | FAIL |

새 테스트는 옛 코드에서 실패하고 새 코드에서 통과합니다. #16 / #17 / #21 은 양쪽에서 동일하게 실패하는 기존 결함이며 이 변경과 무관합니다 (#16 은 raw backtrace 문자열 비교).

로컬: `scripts/dune-local.sh build @lib/check test/test_keeper_approval_queue.exe` 통과.

## 범위

`#25966` 의 컨텍스트 부재 축 (`#25968`, `#25971`) 과 파일이 겹치지 않습니다. 그쪽은 나쁜 선두가 *만들어지는* 원인을 줄이고, 이 PR 은 나쁜 선두가 큐 전체를 세우지 못하게 합니다.

`#25971` 이 머지되어 컨텍스트 부재가 곧바로 `pre_worker_unavailable` 로 굳는 경로는 줄었습니다. 그래서 **남는 배리어는 `Require_human` 쪽**이고, 이건 실패가 아니라 Auto Judge 의 정상 판정입니다. 즉 지금 상태에서 이 배리어를 만드는 주된 방법은 "Auto Judge 가 제 일을 하는 것" 입니다. 관측 당시 갇힌 항목의 대부분도 컨텍스트를 정상 보유했습니다.

`#25974` 는 `test/test_hitl_summary_worker.ml` 만 건드리므로 겹치지 않습니다.

RFC-WAIVED: 변경 범위가 credential / identity / operator control plane / sandbox / hooks 어디에도 해당하지 않습니다. 기존 함수의 선택 규칙 수정과 그에 따른 `.mli` 계약 갱신입니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
