### PR TITLE
fix(keeper): preserve busy cycle admission status

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -117,7 +117,7 @@ let run_keeper_cycle = Cycle.run_keeper_cycle
 type keepalive_cycle_status =
   | Turn_cycle_completed
   | Turn_cycle_crashed
-  | Deferred_projection_busy
+  | Turn_cycle_busy of Keeper_turn_admission.autonomous_block
 
 type keepalive_turn_outcome = {
   meta : keeper_meta;
@@ -805,11 +805,8 @@ let run_keepalive_unified_turn
     Log.Keeper.info
       ~keeper_name:meta_after_triage.name
       "keeper turn admission busy before stimulus intake: %s"
-      (match block with
-       | Keeper_turn_admission.Turn_busy _ -> "turn_busy"
-       | Keeper_turn_admission.Chat_backlog _ -> "chat_backlog"
-       | Keeper_turn_admission.Shutdown_requested _ -> "shutdown_requested");
-    { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
+      (Keeper_turn_admission.autonomous_block_to_string block);
+    { meta = meta_after_triage; cycle_status = Turn_cycle_busy block }
 ;;
 
 let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat
@@ -1113,18 +1110,25 @@ let run_heartbeat_loop
         in
         let meta_after_proactive = turn_outcome.meta in
         (match turn_outcome.cycle_status with
-         | Deferred_projection_busy ->
+         | Turn_cycle_busy block ->
+           Keeper_registry.record_skip_reasons
+             ~base_path:ctx.config.base_path
+             m.name
+             ~reasons:
+               [ "turn_admission_"
+                 ^ Keeper_turn_admission.autonomous_block_kind block
+               ];
            Log.Keeper.info
              ~keeper_name:m.name
-             "event queue transition projection deferred because the canonical owner \
-              claim is busy; this keepalive cycle records no turn status, crash, or \
-              work-health refresh"
+             "turn admission deferred autonomous work: %s; this keepalive cycle \
+              records no turn status, crash, or work-health refresh"
+             (Keeper_turn_admission.autonomous_block_to_string block)
          | Turn_cycle_completed | Turn_cycle_crashed ->
            if not lifecycle_blocked
            then (
              (* The registry tracks failure count as observation. A
-                lifecycle-blocked or projection-deferred cycle did not run a turn
-                and must not emit a false [Turn_succeeded]. *)
+                lifecycle-blocked cycle did not run a turn and must not emit a
+                false [Turn_succeeded]. *)
              let turn_fail_count =
                Keeper_registry.get_turn_failures
                  ~base_path:ctx.config.base_path
@@ -1161,7 +1165,7 @@ let run_heartbeat_loop
                  ~work_as_hb
                  ~last_successful_heartbeat_ts
                  ~consecutive_failures
-             | Deferred_projection_busy -> assert false));
+             | Turn_cycle_busy _ -> assert false));
         let t_turn_end = Time_compat.now () in
         let interval =
           float_of_int (Keeper_heartbeat_snapshot.keepalive_interval_sec ())

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -98,12 +98,12 @@ val provider_timeout_observation_reasons : string list
 val record_provider_timeout_observation :
   base_path:string -> keeper_name:string -> unit
 
-(** Closed accounting status for one keepalive cycle. A deferred projection
-    performs no turn accounting, crash accounting, or work-health refresh. *)
+(** Closed accounting status for one keepalive cycle. Admission busy performs
+    no turn accounting, crash accounting, or work-health refresh. *)
 type keepalive_cycle_status =
   | Turn_cycle_completed
   | Turn_cycle_crashed
-  | Deferred_projection_busy
+  | Turn_cycle_busy of Keeper_turn_admission.autonomous_block
 
 (** Outcome of one keepalive cycle evaluation.
 
@@ -111,8 +111,9 @@ type keepalive_cycle_status =
     keep the keeper fiber alive (T6 audit), or a durable event-queue
     claim/settlement did not commit. The failure has already been recorded via
     [Keeper_registry.increment_turn_failures], so the caller dispatches
-    [Turn_failed]. [Deferred_projection_busy] is a typed nonfailure and must
-    not dispatch either turn status or refresh the work-as-heartbeat lease. *)
+    [Turn_failed]. [Turn_cycle_busy] preserves its typed admission reason and
+    must not dispatch either turn status or refresh the work-as-heartbeat
+    lease. *)
 type keepalive_turn_outcome = {
   meta : keeper_meta;
   cycle_status : keepalive_cycle_status;
@@ -139,16 +140,6 @@ val compaction_outcome_of_cycle_outcome :
     operator's manual commit maps to [`Committed] (count + reset).
     Outcomes with no compaction involvement return [None]. *)
 
-
-val project_transition_outbox :
-  base_path:string ->
-  keeper_name:string ->
-  ( Keeper_event_queue_recovery.projection_outcome
-  , Keeper_event_queue_recovery.projection_error )
-  result
-(** Idempotently materialize the lane's single durable transition into the
-    reaction ledger, then retire the outbox entry. New claims remain blocked
-    while this projection is incomplete. *)
 
 (** Pure: post-turn status event derived from the registry
     turn-failure counter. [turn_fail_count > 0] maps to [Turn_failed];

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -80,8 +80,10 @@ let release_outcome_to_string = function
 ;;
 
 let error_to_string = function
-  | Admission_busy _ ->
-    "keeper_turn_admission_busy: operation=cancel_pending"
+  | Admission_busy block ->
+    Printf.sprintf
+      "keeper_turn_admission_busy: operation=cancel_pending %s"
+      (Keeper_turn_admission.autonomous_block_to_string block)
   | Reservation_conflict owner ->
     "Keeper lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner

--- a/lib/keeper/keeper_paused_work_operator.ml
+++ b/lib/keeper/keeper_paused_work_operator.ml
@@ -219,6 +219,20 @@ let error_to_string = function
   | Source_terminal_rejected error -> Source_terminal.error_to_string error
 ;;
 
+let admission_busy = function
+  | Cancellation_rejected (Cancellation.Admission_busy block) -> Some block
+  | Transfer_rejected { cause = Transfer.Admission_busy block; _ } -> Some block
+  | Source_terminal_rejected
+      { cause = Source_terminal.Admission_busy block; _ } ->
+    Some block
+  | Invalid_request _
+  | Resume_rejected _
+  | Cancellation_rejected _
+  | Transfer_rejected _
+  | Source_terminal_rejected _ ->
+    None
+;;
+
 let error_class = function
   | Invalid_request _ -> `Bad_request
   | Resume_rejected { cause = Resume.Invalid_request _; _ }

--- a/lib/keeper/keeper_paused_work_operator.mli
+++ b/lib/keeper/keeper_paused_work_operator.mli
@@ -47,6 +47,8 @@ val outcome_to_yojson : outcome -> Yojson.Safe.t
 val outcome_projection_complete : outcome -> bool
 val error_to_string : error -> string
 val error_class : error -> error_class
+val admission_busy : error -> Keeper_turn_admission.autonomous_block option
+(** Typed unavailable detail for boundary adapters. *)
 
 val inventory_json :
   Workspace.config -> keeper_name:string -> (Yojson.Safe.t, inventory_error) result

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -52,8 +52,10 @@ let ( let* ) = Result.bind
 let failure_to_string = function
   | Invalid_request detail ->
     "invalid Settle_from_source_terminal request: " ^ detail
-  | Admission_busy _ ->
-    "keeper_turn_admission_busy: operation=settle_from_source_terminal"
+  | Admission_busy block ->
+    Printf.sprintf
+      "keeper_turn_admission_busy: operation=settle_from_source_terminal %s"
+      (Keeper_turn_admission.autonomous_block_to_string block)
   | Reservation_conflict owner ->
     "Settle_from_source_terminal lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -80,8 +80,10 @@ let projection_stage_to_string = function
 
 let failure_to_string = function
   | Invalid_request detail -> "invalid Transfer_owner request: " ^ detail
-  | Admission_busy _ ->
-    "keeper_turn_admission_busy: operation=transfer_pending"
+  | Admission_busy block ->
+    Printf.sprintf
+      "keeper_turn_admission_busy: operation=transfer_pending %s"
+      (Keeper_turn_admission.autonomous_block_to_string block)
   | Reservation_conflict owner ->
     "Transfer_owner lifecycle reservation conflict: "
     ^ Keeper_lifecycle_reservation.snapshot_to_string owner

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -80,6 +80,56 @@ let lane_to_string = function
   | Chat -> "chat"
 ;;
 
+let autonomous_block_kind = function
+  | Turn_busy _ -> "turn_busy"
+  | Chat_backlog _ -> "chat_backlog"
+  | Shutdown_requested _ -> "shutdown_requested"
+;;
+
+let autonomous_block_to_string = function
+  | Turn_busy None -> "reason=turn_busy holder=unpublished"
+  | Turn_busy (Some { lane; started_at }) ->
+    Printf.sprintf
+      "reason=turn_busy holder_lane=%s holder_started_at=%.17g"
+      (lane_to_string lane)
+      started_at
+  | Chat_backlog { pending_count; inflight_count } ->
+    Printf.sprintf
+      "reason=chat_backlog pending_count=%d inflight_count=%d"
+      pending_count
+      inflight_count
+  | Shutdown_requested operation_id ->
+    Printf.sprintf
+      "reason=shutdown_requested operation_id=%s"
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+;;
+
+let autonomous_block_to_yojson = function
+  | Turn_busy holder ->
+    let holder_json =
+      match holder with
+      | None -> `Null
+      | Some { lane; started_at } ->
+        `Assoc
+          [ "lane", `String (lane_to_string lane)
+          ; "started_at", `Float started_at
+          ]
+    in
+    `Assoc [ "kind", `String "turn_busy"; "holder", holder_json ]
+  | Chat_backlog { pending_count; inflight_count } ->
+    `Assoc
+      [ "kind", `String "chat_backlog"
+      ; "pending_count", `Int pending_count
+      ; "inflight_count", `Int inflight_count
+      ]
+  | Shutdown_requested operation_id ->
+    `Assoc
+      [ "kind", `String "shutdown_requested"
+      ; ( "operation_id"
+        , `String (Keeper_shutdown_types.Operation_id.to_string operation_id) )
+      ]
+;;
+
 type slot =
   { base_path : string
   ; keeper_name : string

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -53,6 +53,12 @@ type autonomous_block =
         slot when the durable chat backlog was the actual fence. *)
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
+val autonomous_block_kind : autonomous_block -> string
+val autonomous_block_to_string : autonomous_block -> string
+val autonomous_block_to_yojson : autonomous_block -> Yojson.Safe.t
+(** Canonical typed projections for admission diagnostics. Consumers must not
+    recover block detail by parsing prose. *)
+
 type rejection =
   { waiting : int (** chat requests already waiting on this keeper's slot *)
   ; in_flight : in_flight_info option

--- a/lib/server/server_dashboard_http_keeper_paused_work.ml
+++ b/lib/server/server_dashboard_http_keeper_paused_work.ml
@@ -9,7 +9,16 @@ let keeper_name req =
     suffix
 ;;
 
-let error_json message = `Assoc [ "ok", `Bool false; "error", `String message ]
+let error_json ?admission_busy message =
+  let fields = [ "ok", `Bool false; "error", `String message ] in
+  match admission_busy with
+  | None -> `Assoc fields
+  | Some block ->
+    `Assoc
+      (fields
+       @ [ "error_code", `String "keeper_turn_admission_busy"
+         ; "admission", Keeper_turn_admission.autonomous_block_to_yojson block
+         ])
 
 let handle_get state req reqd =
   let name = keeper_name req in
@@ -72,7 +81,9 @@ let handle_post state req reqd body =
          Http.Response.json_value
            ~status:(http_status (Operator.error_class error))
            ~request:req
-           (error_json (Operator.error_to_string error))
+           (error_json
+              ?admission_busy:(Operator.admission_busy error)
+              (Operator.error_to_string error))
            reqd
        | Ok outcome ->
          Log.Dashboard.info


### PR DESCRIPTION
## Summary
- hard-delete the obsolete `project_transition_outbox` heartbeat API declaration
- preserve typed `Turn_cycle_busy` admission reasons without emitting turn completion or refreshing work-heartbeat success
- project exact busy holder/backlog/shutdown detail through paused-work errors and HTTP 503 JSON without string heuristics

## Boundary
- no new store, lease, or cross-layer ownership
- cancellation exactly-once and transcript repair remain out of scope

## Validation
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- structural absence checks for `project_transition_outbox`, `Deferred_projection_busy`, and detail-dropping `Admission_busy _` renderers
- focused `lib/masc.cmxa bin/main_eio.exe` reached the changed heartbeat code; fixed the first compiler-reported positional API mismatch
- rerun and narrow tests blocked by the shared repo-local Dune lock; PR CI is the broad build/test authority
