### PR TITLE
fix(keeper): restore the transition outbox projection body (#25978)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -44,6 +44,13 @@ let with_in_turn_liveness_pulse =
    aliases so callers (incl. .mli consumers) stay byte-identical. *)
 module Stimulus_intake = Keeper_heartbeat_stimulus_intake
 
+(* #25978 removed this body while its interface declaration and two test
+   consumers remained, so the library stopped matching its own signature. The
+   recovery projection it delegates to is unchanged. *)
+let project_transition_outbox ~base_path ~keeper_name =
+  Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
+;;
+
 let stimulus_urgency_to_string = Stimulus_intake.stimulus_urgency_to_string
 let pending_board_event_of_stimulus = Stimulus_intake.pending_board_event_of_stimulus
 let record_event_queue_stimulus_turn_started =


### PR DESCRIPTION
## 문제

`lib/keeper` 가 컴파일되지 않습니다. 라이브러리 자체가 red 라 테스트 이전에 빌드가 멈춥니다.

```
File "lib/keeper/keeper_heartbeat_loop.ml", line 1:
Error: The implementation lib/keeper/keeper_heartbeat_loop.pp.ml
       does not match the interface lib/keeper/keeper_heartbeat_loop.pp.mli:
       The value project_transition_outbox is required but not provided
```

#25978 (커밋 0d6291253a) 이 `.ml` 에서 구현을 제거하면서 `.mli` 의 `val` 선언과 테스트 소비자 2곳(`test/test_schedule_consumer_dispatch.ml:627,743`)을 그대로 두었습니다.

## 수정

구현을 원래 형태로 복원합니다. 위임 대상인 `Keeper_event_queue_recovery.project_owner_result` 는 그대로 존재하므로 재구성이 아니라 복원입니다.

```ocaml
let project_transition_outbox ~base_path ~keeper_name =
  Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
```

만약 이 함수를 **의도적으로** 폐기하는 것이 #25978 의 방향이라면, 이 PR 대신 `.mli` 선언과 테스트 소비자 2곳을 함께 제거하는 쪽이 맞습니다. 다만 그 판단은 #25978 저자 몫이라, 지금은 main 을 되살리는 최소 변경만 올립니다.

## 검증

```
scripts/dune-local.sh build lib/keeper   # exit 0
```

`@check` 전체는 아직 red 입니다 — 별개 원인(#25969 이 제거한 settlement 심볼을 참조하는 테스트 4파일 18곳)이며 다른 브랜치에서 처리 중입니다. 이 PR 은 **라이브러리 컴파일만** 되살립니다.

관련: #25975 (하루 4회 반복된 '제거 PR 이 소비자를 이전하지 않음' 패턴)
