### PR TITLE
test(keeper): cover busy cycle accounting

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -44,13 +44,6 @@ let with_in_turn_liveness_pulse =
    aliases so callers (incl. .mli consumers) stay byte-identical. *)
 module Stimulus_intake = Keeper_heartbeat_stimulus_intake
 
-(* #25978 removed this body while its interface declaration and two test
-   consumers remained, so the library stopped matching its own signature. The
-   recovery projection it delegates to is unchanged. *)
-let project_transition_outbox ~base_path ~keeper_name =
-  Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
-;;
-
 let stimulus_urgency_to_string = Stimulus_intake.stimulus_urgency_to_string
 let pending_board_event_of_stimulus = Stimulus_intake.pending_board_event_of_stimulus
 let record_event_queue_stimulus_turn_started =
@@ -125,6 +118,20 @@ type keepalive_cycle_status =
   | Turn_cycle_completed
   | Turn_cycle_crashed
   | Turn_cycle_busy of Keeper_turn_admission.autonomous_block
+
+type keepalive_cycle_accounting =
+  { record_turn_status : bool
+  ; refresh_work_heartbeat : bool
+  }
+
+let keepalive_cycle_accounting = function
+  | Turn_cycle_completed ->
+    { record_turn_status = true; refresh_work_heartbeat = true }
+  | Turn_cycle_crashed ->
+    { record_turn_status = true; refresh_work_heartbeat = false }
+  | Turn_cycle_busy _ ->
+    { record_turn_status = false; refresh_work_heartbeat = false }
+;;
 
 type keepalive_turn_outcome = {
   meta : keeper_meta;
@@ -1116,23 +1123,26 @@ let run_heartbeat_loop
             r)
         in
         let meta_after_proactive = turn_outcome.meta in
-        (match turn_outcome.cycle_status with
-         | Turn_cycle_busy block ->
-           Keeper_registry.record_skip_reasons
-             ~base_path:ctx.config.base_path
-             m.name
-             ~reasons:
-               [ "turn_admission_"
-                 ^ Keeper_turn_admission.autonomous_block_kind block
-               ];
-           Log.Keeper.info
-             ~keeper_name:m.name
-             "turn admission deferred autonomous work: %s; this keepalive cycle \
-              records no turn status, crash, or work-health refresh"
-             (Keeper_turn_admission.autonomous_block_to_string block)
-         | Turn_cycle_completed | Turn_cycle_crashed ->
-           if not lifecycle_blocked
-           then (
+        let accounting = keepalive_cycle_accounting turn_outcome.cycle_status in
+        if not accounting.record_turn_status
+        then (
+          match turn_outcome.cycle_status with
+          | Turn_cycle_busy block ->
+            Keeper_registry.record_skip_reasons
+              ~base_path:ctx.config.base_path
+              m.name
+              ~reasons:
+                [ "turn_admission_"
+                  ^ Keeper_turn_admission.autonomous_block_kind block
+                ];
+            Log.Keeper.info
+              ~keeper_name:m.name
+              "turn admission deferred autonomous work: %s; this keepalive cycle \
+               records no turn status, crash, or work-health refresh"
+              (Keeper_turn_admission.autonomous_block_to_string block)
+          | Turn_cycle_completed | Turn_cycle_crashed -> assert false)
+        else if not lifecycle_blocked
+        then (
              (* The registry tracks failure count as observation. A
                 lifecycle-blocked cycle did not run a turn and must not emit a
                 false [Turn_succeeded]. *)
@@ -1159,12 +1169,8 @@ let run_heartbeat_loop
                 On failure: leave timestamp unchanged → presence sync resumes next cycle.
                 T6 audit: a crashed cycle proves nothing about health — do not
                 refresh the lease or reset consecutive_failures for it. *)
-             match turn_outcome.cycle_status with
-             | Turn_cycle_crashed ->
-               Log.Keeper.info
-                 "%s: skipping work-as-heartbeat refresh after crashed keepalive cycle"
-                 m.name
-             | Turn_cycle_completed ->
+             if accounting.refresh_work_heartbeat
+             then
                refresh_work_as_heartbeat
                  ~ctx
                  ~meta_after_proactive
@@ -1172,7 +1178,10 @@ let run_heartbeat_loop
                  ~work_as_hb
                  ~last_successful_heartbeat_ts
                  ~consecutive_failures
-             | Turn_cycle_busy _ -> assert false));
+             else
+               Log.Keeper.info
+                 "%s: skipping work-as-heartbeat refresh after crashed keepalive cycle"
+                 m.name);
         let t_turn_end = Time_compat.now () in
         let interval =
           float_of_int (Keeper_heartbeat_snapshot.keepalive_interval_sec ())

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -105,6 +105,16 @@ type keepalive_cycle_status =
   | Turn_cycle_crashed
   | Turn_cycle_busy of Keeper_turn_admission.autonomous_block
 
+type keepalive_cycle_accounting =
+  { record_turn_status : bool
+  ; refresh_work_heartbeat : bool
+  }
+
+val keepalive_cycle_accounting :
+  keepalive_cycle_status -> keepalive_cycle_accounting
+(** Closed accounting policy used by the heartbeat loop. Busy cycles record
+    neither turn completion nor work-heartbeat success. *)
+
 (** Outcome of one keepalive cycle evaluation.
 
     [Turn_cycle_crashed] means the cycle's catch-all swallowed an exception to

--- a/lib/keeper/keeper_paused_work_operator.ml
+++ b/lib/keeper/keeper_paused_work_operator.ml
@@ -233,6 +233,20 @@ let admission_busy = function
     None
 ;;
 
+let error_to_yojson error =
+  let fields =
+    [ "ok", `Bool false; "error", `String (error_to_string error) ]
+  in
+  match admission_busy error with
+  | None -> `Assoc fields
+  | Some block ->
+    `Assoc
+      (fields
+       @ [ "error_code", `String "keeper_turn_admission_busy"
+         ; "admission", Keeper_turn_admission.autonomous_block_to_yojson block
+         ])
+;;
+
 let error_class = function
   | Invalid_request _ -> `Bad_request
   | Resume_rejected { cause = Resume.Invalid_request _; _ }

--- a/lib/keeper/keeper_paused_work_operator.mli
+++ b/lib/keeper/keeper_paused_work_operator.mli
@@ -49,6 +49,8 @@ val error_to_string : error -> string
 val error_class : error -> error_class
 val admission_busy : error -> Keeper_turn_admission.autonomous_block option
 (** Typed unavailable detail for boundary adapters. *)
+val error_to_yojson : error -> Yojson.Safe.t
+(** Canonical HTTP error envelope, including typed admission detail. *)
 
 val inventory_json :
   Workspace.config -> keeper_name:string -> (Yojson.Safe.t, inventory_error) result

--- a/lib/server/server_dashboard_http_keeper_paused_work.ml
+++ b/lib/server/server_dashboard_http_keeper_paused_work.ml
@@ -9,16 +9,7 @@ let keeper_name req =
     suffix
 ;;
 
-let error_json ?admission_busy message =
-  let fields = [ "ok", `Bool false; "error", `String message ] in
-  match admission_busy with
-  | None -> `Assoc fields
-  | Some block ->
-    `Assoc
-      (fields
-       @ [ "error_code", `String "keeper_turn_admission_busy"
-         ; "admission", Keeper_turn_admission.autonomous_block_to_yojson block
-         ])
+let error_json message = `Assoc [ "ok", `Bool false; "error", `String message ]
 
 let handle_get state req reqd =
   let name = keeper_name req in
@@ -68,7 +59,7 @@ let handle_post state req reqd body =
       Http.Response.json_value
         ~status:(http_status (Operator.error_class error))
         ~request:req
-        (error_json (Operator.error_to_string error))
+        (Operator.error_to_yojson error)
         reqd
     | Ok request ->
       let config = Mcp_server.workspace_config state in
@@ -81,9 +72,7 @@ let handle_post state req reqd body =
          Http.Response.json_value
            ~status:(http_status (Operator.error_class error))
            ~request:req
-           (error_json
-              ?admission_busy:(Operator.admission_busy error)
-              (Operator.error_to_string error))
+           (Operator.error_to_yojson error)
            reqd
        | Ok outcome ->
          Log.Dashboard.info

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -5,6 +5,7 @@ module State = Keeper_event_queue_state
 module Persistence = Keeper_event_queue_persistence
 module Disposition = Keeper_paused_work_disposition_receipt
 module Operator = Keeper_paused_work_operator
+module Cancellation = Keeper_paused_work_cancellation_transaction
 
 let require_ok label = function
   | Ok value -> value
@@ -262,6 +263,62 @@ let test_inventory_exposes_exact_durable_fences () =
       | Error detail -> Alcotest.fail detail)
 ;;
 
+let admission_error_json block =
+  Operator.error_to_yojson
+    (Operator.Cancellation_rejected (Cancellation.Admission_busy block))
+;;
+
+let test_admission_busy_http_json_preserves_typed_detail () =
+  let open Yojson.Safe.Util in
+  let holder =
+    admission_error_json
+      (Keeper_turn_admission.Turn_busy
+         (Some { lane = Keeper_turn_admission.Chat; started_at = 42.5 }))
+  in
+  Alcotest.(check string)
+    "holder error code"
+    "keeper_turn_admission_busy"
+    (holder |> member "error_code" |> to_string);
+  Alcotest.(check string)
+    "holder kind"
+    "turn_busy"
+    (holder |> member "admission" |> member "kind" |> to_string);
+  Alcotest.(check string)
+    "holder lane"
+    "chat"
+    (holder |> member "admission" |> member "holder" |> member "lane" |> to_string);
+  Alcotest.(check (float 0.0))
+    "holder start"
+    42.5
+    (holder
+     |> member "admission"
+     |> member "holder"
+     |> member "started_at"
+     |> to_float);
+  let backlog =
+    admission_error_json
+      (Keeper_turn_admission.Chat_backlog
+         { pending_count = 3; inflight_count = 2 })
+  in
+  Alcotest.(check int)
+    "chat pending count"
+    3
+    (backlog |> member "admission" |> member "pending_count" |> to_int);
+  Alcotest.(check int)
+    "chat inflight count"
+    2
+    (backlog |> member "admission" |> member "inflight_count" |> to_int);
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  let shutdown =
+    admission_error_json
+      (Keeper_turn_admission.Shutdown_requested operation_id)
+  in
+  Alcotest.(check string)
+    "shutdown operation id"
+    (Keeper_shutdown_types.Operation_id.to_string operation_id)
+    (shutdown |> member "admission" |> member "operation_id" |> to_string)
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -274,6 +331,12 @@ let () =
             "durable exact identity and revision"
             `Quick
             test_inventory_exposes_exact_durable_fences
+        ] )
+    ; ( "admission"
+      , [ Alcotest.test_case
+            "HTTP JSON preserves typed busy detail"
+            `Quick
+            test_admission_busy_http_json_preserves_typed_detail
         ] )
     ]
 ;;

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -624,7 +624,9 @@ let test_acked_occurrence_recovery_does_not_enqueue_or_wake_again () =
        | Ok (Keeper_registry_event_queue.Already_settled _) -> ()
        | Ok _ -> fail "scheduled occurrence settlement follow-up failed"
        | Error detail -> fail detail);
-      (match Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name with
+      (match
+         Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
+       with
        | Ok
            ( Keeper_event_queue_recovery.No_pending_transition
            | Keeper_event_queue_recovery.Transition_converged ) ->
@@ -740,7 +742,9 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_or_wake_again () =
         (event_queue_snapshot_path ~base_path ~keeper_name)
         (Yojson.Safe.to_string
            (Keeper_event_queue_state.to_yojson cancelled_state));
-      (match Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name with
+      (match
+         Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
+       with
        | Ok
            ( Keeper_event_queue_recovery.No_pending_transition
            | Keeper_event_queue_recovery.Transition_converged ) ->

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -131,6 +131,21 @@ let test_freshness_disabled_flag () =
   let fresh = work_as_hb && (now -. last_hb < max_silence) in
   check bool "feature disabled → always stale" false fresh
 
+let test_busy_cycle_records_no_turn_status_or_work_heartbeat () =
+  let accounting =
+    Masc.Keeper_heartbeat_loop.keepalive_cycle_accounting
+      (Masc.Keeper_heartbeat_loop.Turn_cycle_busy
+         (Masc.Keeper_turn_admission.Chat_backlog
+            { pending_count = 2; inflight_count = 1 }))
+  in
+  check bool "busy cycle records no turn status" false accounting.record_turn_status;
+  check
+    bool
+    "busy cycle refreshes no work-heartbeat success"
+    false
+    accounting.refresh_work_heartbeat
+;;
+
 (* ── Percentile function (Phase 0 profiling) ────────────── *)
 
 let test_percentile_empty () =
@@ -199,6 +214,12 @@ let () =
       test_case "exact boundary → stale (strict <)" `Quick test_freshness_exact_boundary;
       test_case "never heartbeated → stale" `Quick test_freshness_never_heartbeated;
       test_case "feature disabled → always stale" `Quick test_freshness_disabled_flag;
+    ];
+    "cycle_accounting", [
+      test_case
+        "busy records no completion or work-heartbeat success"
+        `Quick
+        test_busy_cycle_records_no_turn_status_or_work_heartbeat;
     ];
     "config_invariants", [
       test_case "max_silence >= interval" `Quick test_config_invariant_silence_ge_interval;


### PR DESCRIPTION
## Summary
- remove the obsolete `Keeper_heartbeat_loop.project_transition_outbox` implementation and rewrite schedule recovery tests against `Keeper_event_queue_recovery.project_owner_result`
- make the closed heartbeat accounting policy explicit and test that `Turn_cycle_busy` records neither turn completion nor work-heartbeat success
- make paused-work operator errors own the canonical HTTP JSON envelope and test holder lane/start, chat pending/inflight counts, and shutdown operation ID

## Boundary
- current schema only
- no legacy heartbeat adapter/API restoration
- no new store, lease, or string heuristic

## Validation
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- zero exact references/definitions for `Keeper_heartbeat_loop.project_transition_outbox`
- focused local build/test was blocked by shared Dune/opam lock churn and then the wrapper correctly refused a concurrent bare `dune build .`; PR CI is the focused build/test authority
