### PR TITLE
fix(test): compaction exact-output 스위트 컴파일 복구 + 실행된 적 없던 assertion 2건 수정

### DIFF
--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -647,7 +647,7 @@ let test_domain_invalid_output_advances_to_declared_successor () =
     ; "release:" ^ first_slot
     ; "bind:declared-domain-successor"
     ]
-    (List.rev !events)
+    !events
 ;;
 
 let test_semantic_exhaustion_terminalizes_final_bound () =
@@ -705,7 +705,7 @@ let test_semantic_exhaustion_terminalizes_final_bound () =
     ; "bind:" ^ final_slot
     ; "quarantine:" ^ final_slot
     ]
-    (List.rev !events)
+    !events
 ;;
 
 let test_final_oas_flow_failure_is_generic_source_terminal () =
@@ -957,15 +957,6 @@ let () =
             "release failure blocks successor"
             `Quick
             test_release_failure_blocks_successor
-        ; Alcotest.test_case
-            "heartbeat guard binds before POST"
-            `Quick
-        ; Alcotest.test_case
-            "post-success restart stays fenced at most once"
-            `Quick
-        ; Alcotest.test_case
-            "visible sync uncertainty seams fail closed"
-            `Quick
         ] )
     ; ( "terminal ownership"
       , [ Alcotest.test_case
@@ -985,23 +976,9 @@ let () =
             `Quick
             test_cancellation_preserves_lifecycle_authorized_identity
         ; Alcotest.test_case
-            "terminalization is canonical and durable"
-            `Quick
-        ; Alcotest.test_case
             "commit claim blocks reject after install"
             `Quick
             test_post_success_commit_claim_blocks_reject
-        ; Alcotest.test_case
-            "terminalization overlap is affine and durable"
-            `Quick
-        ; Alcotest.test_case
-            "terminalization failures preserve full binding"
-            `Quick
-        ] )
-    ; ( "affinity and non-sharing"
-      , [ Alcotest.test_case
-            "same-flow loser mutates no queue"
-            `Quick
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

`main`이 red다. #25993(`1add127cb5`)이 테스트 함수 7개를 삭제하면서 `Alcotest.run` 목록의 등록 항목 7개를 그대로 남겼다.

```
File "test/test_compaction_exact_output_conformance.ml", lines 960-962:
Error: This expression has type ('a -> unit) -> 'a Alcotest.test_case
       but an expression was expected of type unit Alcotest.test_case
```

`Alcotest.test_case`는 3-arity다. 인자 2개만 주면 값이 아니라 부분 적용된 함수라 리스트 원소 타입과 불일치한다.

## 수정

**1. 매달린 등록 7건 제거 (컴파일 복구)**

제거한 이름은 #25993 커밋 메시지가 "Coverage dropped"로 기록한 7항목과 1:1로 일치한다. 즉 그 커밋이 하려던 삭제의 미완성 부분을 완결한다.

`"affinity and non-sharing"` 그룹은 유일한 케이스가 삭제 대상이라 그룹째 제거했다. Alcotest는 빈 케이스 리스트를 런타임에 거부하므로, 항목만 빼면 컴파일 에러를 런타임 에러로 옮기는 것이 된다.

**2. 한 번도 실행된 적 없는 assertion 2건 수정**

컴파일이 복구되자 실패 3건이 드러났다. 이 스위트는 컴파일이 깨져 있어 실행된 적이 없다.

```
push_event events event = events := !events @ [ event ]   (* append *)
```

`!events`는 이미 호출 순서다. 그런데 소비처 4곳 중 2곳(650, 708)이 `List.rev`를 한 번 더 걸어 관측 순서의 역순과 비교했다. 통과하던 나머지 2곳(468, 588)은 `!events`를 그대로 읽는다.

실측 증거 — 기대값의 정확한 역순이 관측됐다:

```
Expected: ["bind:domain-invalid"; "release:domain-invalid"; "bind:declared-domain-successor"]
Received: ["bind:declared-domain-successor"; "release:domain-invalid"; "bind:domain-invalid"]
```

프로덕션 콜백 순서는 처음부터 정확했다. 하네스 쪽 결함이다.

## 로컬 검증

```
$ bash scripts/dune-local.sh build test/test_compaction_exact_output_conformance.exe   # 통과
$ ./_build/default/test/test_compaction_exact_output_conformance.exe
1 failure! in 0.293s. 12 tests run.
```

수정 전 3 failures → 수정 후 1 failure.

## 남은 실패 1건은 고치지 않았다

`preparation/0 "missing lane is explicit"`는 하네스 버그가 아니라 프로덕션 갭이다.

```ocaml
let prepare_lane
      ~base_path:_          (* 96cb2a406a 이후 인자를 버린다 *)
      ~keeper_name
```

테스트는 잘못된 registry owner(base_path/keeper_name 불일치)에 대해 `Exact_execution_context_unavailable`을 기대하는데, 구현은 `base_path`를 무시하고 lane 조회를 먼저 해 `Exact_lane_unconfigured`를 반환한다. `git log -S'~base_path:_'` 결과 `96cb2a406a refactor(keeper): migrate exact flows to OAS validation`에서 도입됐다.

소유권 판정 순서를 되살릴지, 테스트의 주장을 폐기할지는 설계 결정이므로 이 PR에서 판단하지 않는다. 별도 이슈로 분리한다.

## 이 PR이 드러낸 구조적 문제

`test_compaction_exact_output_conformance`는 CI의 **실행** 게이트가 아니다. `ci.yml`은 `@default @check @install`로 컴파일만 하고, 실행은 operator/SSE/transport 등 명시된 스위트만 한다. 그래서:

- 컴파일 깨짐은 CI가 잡는다 (이번에 main red로 드러남)
- 실행 실패는 CI가 영원히 못 잡는다 (소유권 회귀가 은폐된 경로)

컴파일 에러가 프로덕션 회귀를 가린 사례다.

RFC-WAIVED: 변경 범위가 `test/` 단일 파일이며 credential/identity/operator/sandbox/hooks/workflow 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

## 주의: #25995는 빈 머지였다

`22a2acd017 test(compaction): remove registrations and helpers left by the case removal (#25995)`이 같은 문제를 고쳤다고 기록하지만, **실제 diff가 0이다**.

```
$ git show -s --format='%P' 22a2acd017      # 부모 1개
1add127cb598aa6ac02112f8bb1d8420e776f97f
$ git diff --stat 22a2acd017^1 22a2acd017   # 변경 없음
$ gh pr diff 25995 --name-only              # 변경 파일 0
```

커밋 2개를 가진 PR이었지만 변경 파일이 0으로 머지됐다. 따라서 `main`은 그 머지 이후에도 여전히 컴파일 실패 상태이며, 이 PR이 실제 수정이다.
