### PR TITLE
test(compaction): remove helpers left dead by the case removal

### DIFF
--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -26,7 +26,6 @@ open Masc
 module C = Keeper_compaction_llm_summarizer
 module F = Compaction_exact_output_fixture
 module P = Keeper_event_queue_persistence
-module Q = Keeper_event_queue
 module Recovery = Keeper_exact_disposition_recovery
 module Registry = Runtime_exact_output_registry
 module S = Keeper_structured_output_schema
@@ -67,83 +66,11 @@ let with_temp_dir prefix f =
   Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
 ;;
 
-let claim_manual_lease ~base_path ~keeper_name =
-  let stimulus : Q.stimulus =
-    { post_id = "manual-compaction"
-    ; urgency = Q.Immediate
-    ; arrived_at = 1.0
-    ; payload = Q.Manual_compaction_requested
-    }
-  in
-  (match
-     P.update_checked_result
-       ~base_path
-       ~keeper_name
-       (fun pending -> Ok (Q.enqueue pending stimulus))
-   with
-   | Ok () -> ()
-   | Error detail -> Alcotest.failf "manual stimulus persist failed: %s" detail);
-  match
-    P.claim_when_result
-      ~base_path
-      ~keeper_name
-      ~claimed_at:2.0
-      ~ready:(fun _ -> true)
-      ()
-  with
-  | Ok (Some lease) -> lease
-  | Ok None -> Alcotest.fail "manual lease was not claimed"
-  | Error detail -> Alcotest.failf "manual lease claim failed: %s" detail
-;;
-
-let persisted_checkpoint_source_exn trace_id =
-  match Keeper_id.Trace_id.of_string trace_id with
-  | Error detail -> Alcotest.failf "checkpoint source trace id failed: %s" detail
-  | Ok trace_id ->
-    (match
-       Keeper_checkpoint_ref.of_persisted
-         ~trace_id
-         ~generation:1
-         ~turn_count:1
-         ~sha256:(String.make 64 'a')
-     with
-     | Ok source -> source
-     | Error _ -> Alcotest.fail "persisted checkpoint source ref failed")
-;;
-
-let settle_terminal_disposition_result
-      ~base_path
-      ~keeper_name
-      ~lease
-      ~source
-      ~(terminal : P.exact_execution_terminal)
-      ~settled_at
-  =
-  let disposition =
-    match
-      P.prepare_exact_source_disposition_result
-        ~base_path
-        ~keeper_name
-        ~lease
-        ~source
-        ~terminal
-        ~semantic:P.Exact_no_compaction
-        ~prepared_at:settled_at
-        ()
-    with
-    | Error detail -> Alcotest.failf "terminal disposition preparation failed: %s" detail
-    | Ok (_, P.Visible_sync_unconfirmed detail) ->
-      Alcotest.failf "terminal disposition preparation durability unknown: %s" detail
-    | Ok (disposition, P.Fsync_completed) -> disposition
-  in
-  P.finalize_exact_source_disposition_result
-    ~base_path
-    ~keeper_name
-    ~settled_at
-    ~lease
-    ~disposition_id:disposition.disposition_id
-    ()
-;;
+(* claim_manual_lease, persisted_checkpoint_source_exn, and
+   settle_terminal_disposition_result used to live here. They existed only to
+   drive the durable exact-execution guard removed above (a claimed lease to
+   bind it to, a checkpoint source and a terminal disposition to settle
+   against), so none of the surviving cases call them. *)
 
 let execute_prepared_lane
       ~keeper_name


### PR DESCRIPTION
## 성격 변경 (main 은 이미 green)

이 PR 은 원래 main red 수정으로 열었으나, 그 사이 #25996 이 컴파일을 복구했습니다. 남은 내용은 **죽은 코드 정리**입니다.

## 지우는 것

#25993 이 7개 케이스를 제거한 뒤 아무도 쓰지 않게 된 것들:

| 대상 | 근거 |
|---|---|
| `claim_manual_lease` | 파일 전체에서 등장 1회 = 정의뿐 |
| `persisted_checkpoint_source_exn` | 등장 1회 = 정의뿐 |
| `module Q = Keeper_event_queue` | `Q.` 사용처가 위 헬퍼 안에만 있었음 |

## 왜 컴파일러가 안 잡나

이 저장소는 warning 32(unused value declaration)가 활성화되어 있지 않습니다. `-warn-error +a` 는 **이미 켜진 경고만** 에러로 승격하고, OCaml 기본 `-w` 는 32-42 를 끕니다. 실험으로 확인했습니다 — 미사용 top-level let 을 추가해도 빌드가 통과합니다. 그래서 이런 잔재는 사람이 지우지 않으면 계속 남습니다.

## 검증

```
origin/main 1b89a33d51 기준 rebase
scripts/dune-local.sh build @check   → exit 0
```

관련: #25849 (dead-surface wire-or-remove) · #25455 (warning 32 미활성)
