### PR TITLE
fix(keeper): freeze turn sandbox profile across dispatch

### DIFF
--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -33,11 +33,6 @@ let normalize p =
   Keeper_alerting_path.normalize_path_for_check p
   |> strip_trailing_slashes
 
-let current_meta (t : t) =
-  match Keeper_registry.get ~base_path:t.config.base_path t.meta.name with
-  | Some entry -> entry.meta
-  | None -> t.meta
-
 let runtime_image (meta : Keeper_meta_contract.keeper_meta) =
   match meta.sandbox_image with
   | Some img when String.trim img <> "" -> img
@@ -54,7 +49,7 @@ let in_playground_of_cwd (t : t) ~meta ~cwd =
 
 let resolve (t : t) ~cwd =
   with_lock t (fun () ->
-    let meta = current_meta t in
+    let meta = t.meta in
     let in_playground = in_playground_of_cwd t ~meta ~cwd in
     let (effective_profile, effective_network) =
       Keeper_sandbox_runner.effective_sandbox_profile ~meta
@@ -96,7 +91,7 @@ let resolve_opt t_opt ~cwd =
   | Some t -> resolve t ~cwd
 
 let container_cwd_of_host t ~host_cwd =
-  let meta = current_meta t in
+  let meta = t.meta in
   let host_root =
     Keeper_sandbox.host_root_abs_of_meta ~config:t.config meta
     |> normalize

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -11,14 +11,13 @@
     values via [Keeper_turn_sandbox_runtime.container_cwd_of_host].
 
     Background: pre-PR-3b, [keeper_tools_oas.make_tool_bundle] inspected
-    [meta.sandbox_profile] eagerly at turn-start.  With the factory the
-    runtime decision is evaluated per call site, never at turn-start, and
-    the memo prevents the cold-start-every-call pattern that lingered after
-    PR-3.  Resolution also refreshes the keeper's current registry meta so
-    a turn-start factory cannot keep using stale sandbox fields after the
-    registry has reconciled TOML/runtime overlays.  The declared sandbox
-    profile remains the execution contract: [Local] resolves to [None] even
-    when DockerPlayground is enabled.
+    [meta.sandbox_profile] eagerly at turn-start.  The factory still creates
+    runtimes lazily at each call site, but freezes its construction meta so
+    path resolution and dispatch use one sandbox profile for the whole turn.
+    Registry reconciliation takes effect on the next turn; consulting it
+    mid-turn can otherwise route a Docker-scoped cwd through Local dispatch.
+    The declared sandbox profile remains the execution contract: [Local]
+    resolves to [Local_profile] even when DockerPlayground is enabled.
 
     The dependency on {!Keeper_sandbox_docker} stays acyclic:
     [keeper_sandbox_docker] only consumes [Keeper_turn_sandbox_runtime.t]
@@ -46,12 +45,12 @@ val resolve :
   cwd:string ->
   resolve_result
 (** Returns [Runtime runtime] when {!Keeper_sandbox_runner.effective_sandbox_profile}
-    yields [Docker] for the current registry meta, falling back to the
-    construction meta when the keeper is not registered. [in_playground] is
+    yields [Docker] for the construction meta. [in_playground] is
     derived from [cwd] vs the keeper's playground root for runtime workspace
     reuse only. Memoizes per [(in_playground, network_mode, host_root, image)]
     so subsequent compatible calls reuse the same container without crossing
-    sandbox-profile or image drift.
+    sandbox-profile or image drift. Registry changes are observed by the next
+    turn's factory, never midway through the current turn.
 
     [Local_profile] is returned when the effective sandbox profile is [Local].
     [No_factory] is only produced by {!resolve_opt}. *)

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -19,6 +19,7 @@ module Keeper_sandbox_factory = Masc.Keeper_sandbox_factory
 module Keeper_sandbox_runtime = Masc.Keeper_sandbox_runtime
 module Keeper_turn_sandbox_runtime = Masc.Keeper_turn_sandbox_runtime
 module Keeper_sandbox_docker = Masc.Keeper_sandbox_docker
+module Keeper_identity = Masc.Keeper_identity
 module Keeper_types = Keeper_types
 module Keeper_alerting_path = Masc.Keeper_alerting_path
 module Fs_compat = Fs_compat
@@ -188,7 +189,7 @@ let make_meta ~name ~sandbox () =
   let fields =
     [
       ("name", `String name);
-      ("agent_name", `String ("agent-" ^ name));
+      ("agent_name", `String (Keeper_identity.keeper_agent_name name));
       ("trace_id", `String ("trace-" ^ name));
     ]
   in
@@ -270,30 +271,34 @@ let with_turn_sandbox_factory ~config ~meta f =
   Fun.protect ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory) @@ fun () ->
   f factory
 
-let test_turn_sandbox_factory_uses_refreshed_registry_meta () =
-  setup ~sandbox:Keeper_types_profile_sandbox.Local
+let test_turn_sandbox_factory_ignores_mid_turn_registry_profile_drift () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground:_ ->
-  let docker_meta =
+  let local_meta =
     { meta with
-      Keeper_meta_contract.sandbox_profile = Keeper_types_profile_sandbox.Docker
+      Keeper_meta_contract.sandbox_profile = Keeper_types_profile_sandbox.Local
     }
   in
   let factory = Keeper_sandbox_factory.create ~config ~meta () in
-  ignore (Keeper_registry.For_testing.register ~base_path:config.Workspace.base_path meta.name docker_meta);
+  ignore
+    (Keeper_registry.For_testing.register
+       ~base_path:config.Workspace.base_path
+       meta.name
+       local_meta);
   Fun.protect
     ~finally:(fun () ->
       Keeper_sandbox_factory.cleanup factory;
       Keeper_registry.For_testing.unregister ~base_path:config.Workspace.base_path meta.name)
   @@ fun () ->
-  let docker_playground = Keeper_sandbox.host_root_abs_of_meta ~config docker_meta in
+  let docker_playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   match Keeper_sandbox_factory.resolve factory ~cwd:docker_playground with
   | Runtime runtime ->
     Alcotest.(check string)
-      "runtime host root follows refreshed Docker meta"
+      "runtime host root stays on the turn's Docker profile"
       (Keeper_alerting_path.normalize_path_for_check_stripped docker_playground)
       (Keeper_turn_sandbox_runtime.host_root runtime)
   | No_factory | Local_profile ->
-    Alcotest.fail "expected refreshed registry Docker meta to resolve a turn runtime"
+    Alcotest.fail "mid-turn registry drift must not change Docker dispatch to Local"
 
 let with_fake_docker script f =
   let dir = temp_dir () in
@@ -2038,8 +2043,8 @@ let () =
           Alcotest.test_case "unknown workspace op is unsupported before docker" `Quick
             test_unknown_workspace_op_is_unsupported_before_docker;
           Alcotest.test_case
-            "turn sandbox factory uses refreshed registry meta"
-            `Quick test_turn_sandbox_factory_uses_refreshed_registry_meta;
+            "turn sandbox factory ignores mid-turn registry profile drift"
+            `Quick test_turn_sandbox_factory_ignores_mid_turn_registry_profile_drift;
           Alcotest.test_case
             "docker command skips empty PATH segment"
             `Quick test_docker_command_skips_empty_path_segment;


### PR DESCRIPTION
## Summary

- freeze the turn sandbox factory on its construction meta
- prevent a Docker-scoped cwd from being dispatched as Local after mid-turn registry drift
- update the factory contract so reconciled sandbox settings take effect on the next turn
- replace the stale registry-refresh test with the live Docker-to-Local drift regression
- repair the touched fixture's current-schema keeper identity

## Live failure

On 2026-07-28, `executor` wrote under:

`/Users/dancer/me/.masc/playground/docker/executor/artifact-task-001.txt`

The next typed Execute resolved the same Docker cwd, but the factory re-read a Local registry meta and rejected it with:

`typed Shell IR Docker dispatch requires a turn sandbox factory (sandbox profile is Local)`

Docker itself was healthy and an executor turn container was running. The mismatch was a mid-turn profile split, not Docker unavailability.

## Boundary

- no cross-keeper filesystem access added
- no Gate or containment relaxation
- no new store, lease, settlement, facade, or migration
- existing Docker-image-unavailable local fallback remains unchanged
- verifier consumption of another keeper's `evidence_refs` is a separate authority boundary and is intentionally not included

## Validation

- `ocamlformat --check lib/keeper/keeper_sandbox_factory.ml lib/keeper/keeper_sandbox_factory.mli test/test_keeper_sandbox_docker_route.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_sandbox_docker_route.exe`
- `_build/default/test/test_keeper_sandbox_docker_route.exe test --color=never --show-errors '^docker_route_contract$' 2`

Focused build and exact regression passed locally.
