### PR TITLE
fix(keeper): 레인이 이미 해제된 셧다운을 차단하지 않는다

### DIFF
--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -374,7 +374,26 @@ let update_registry_meta_exact operation entry retained =
      with
      | Keeper_registry.Exact_updated -> Ok ()
      | Keeper_registry.Exact_update_missing ->
-       Error "Keeper registry entry disappeared before meta update"
+       (* The lane this shutdown owned is gone from the in-memory registry.
+          That is the state this shutdown is driving toward, and the durable
+          meta update has already committed above — the registry projection of
+          a lane that no longer exists is a no-op, not a conflict.
+
+          Reading [None] one line earlier (the [Registered_lane _, None] arm)
+          already returns [Ok ()] for the identical end state. Treating the
+          same fact as success or as a permanent block depending on whether a
+          concurrent unregister landed before or after the read is a TOCTOU
+          verdict split, and the losing side is expensive: [block] latches the
+          operation, and a blocked operation holds keeper admission
+          ([Registration_shutdown_reserved], keeper_keepalive.ml:723-726) with
+          no runtime release — recovery only runs at boot
+          (server_bootstrap_loops.ml:1197). One racing unregister therefore
+          costs every later boot of that keeper until the process restarts.
+
+          Lane *replacement* stays an error below: a different lane means
+          someone else owns the keeper now, and this operation must not write
+          its retained meta over theirs. Disappearance is not replacement. *)
+       Ok ()
      | Keeper_registry.Exact_update_replaced ->
        Error "Keeper registry lane changed during meta update"
      | Keeper_registry.Exact_update_invalid validation_error ->
@@ -814,4 +833,6 @@ module For_testing = struct
     Atomic.set completion_handler (fun _config _operation _action ->
       Error "shutdown completion handler is not registered")
   ;;
+
+  let update_registry_meta_exact = update_registry_meta_exact
 end

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -53,4 +53,14 @@ module For_testing : sig
 
   val reset_remove_pending_confirms_by_target : unit -> unit
   val reset_completion_handler : unit -> unit
+
+  val update_registry_meta_exact :
+    Keeper_shutdown_types.t ->
+    Keeper_registry.registry_entry option ->
+    Keeper_meta_contract.keeper_meta ->
+    (unit, string) result
+  (** The registry projection step of cleanup preparation. Exposed so the
+      lane-disappeared verdict can be pinned: a lane that vanished mid-operation
+      and a lane that was already absent are the same end state, and both must
+      succeed. A lane that was *replaced* must still fail. *)
 end

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -231,6 +231,119 @@ let test_recovery_still_settles_prepared_without_turn () =
       (requires_admission_fence recovered))
 ;;
 
+(* A shutdown whose lane is unregistered by a concurrent fiber (supervisor,
+   keepalive, or a sibling shutdown) must not block. Reading the registry one
+   step earlier already returns [Ok ()] for an absent lane, so blocking when
+   the same absence is observed one step later is a TOCTOU verdict split — and
+   the losing side is permanent: a blocked operation fences keeper admission
+   with no runtime release, so every later boot of that keeper fails until the
+   process restarts. Observed live on 2026-07-27 (sangsu).
+
+   Lane *replacement* is a different fact and must still fail: someone else
+   owns the keeper, and this operation must not write its retained meta over
+   theirs. *)
+
+let meta_fixture_exn ~keeper_name =
+  let json =
+    `Assoc
+      [ "name", `String keeper_name
+      ; "agent_name", `String (Printf.sprintf "keeper-%s-agent" keeper_name)
+      ; "trace_id", `String "trace-reconciliation-settlement-test"
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error detail -> failf "meta fixture rejected: %s" detail
+;;
+
+let registry_projection ~keeper_name ~lane_ownership ~entry =
+  let operation =
+    { (make_operation
+         ~keeper_name
+         ~phase:Prepared
+         ~turn_disposition:No_inflight_turn)
+      with
+      lane_ownership
+    }
+  in
+  Keeper_shutdown_finalize.For_testing.update_registry_meta_exact
+    operation
+    entry
+    (meta_fixture_exn ~keeper_name)
+;;
+
+let test_vanished_lane_matches_absent_lane () =
+  let base_path = temp_dir "shutdown_lane_vanish_" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let keeper_name = "vanished-lane" in
+       let entry =
+         Keeper_registry.register_offline
+           ~base_path
+           keeper_name
+           (meta_fixture_exn ~keeper_name)
+       in
+       let lane_ownership = Registered_lane (Keeper_lane.id entry.lane) in
+       (* Baseline: the lane was already gone when the entry was read. The
+          [Registered_lane _, None] arm returns Ok. *)
+       (match registry_projection ~keeper_name ~lane_ownership ~entry:None with
+        | Ok () -> ()
+        | Error detail -> failf "absent lane must succeed, got: %s" detail);
+       (* The race: the entry was read, then a concurrent fiber unregistered
+          the lane before the projection ran, so [update_entry_exact] reports
+          [Exact_update_missing]. Identical end state, so identical verdict. *)
+       Keeper_registry.For_testing.unregister ~base_path keeper_name;
+       check
+         bool
+         "precondition: the lane is gone from the registry"
+         true
+         (Option.is_none (Keeper_registry.get ~base_path keeper_name));
+       match registry_projection ~keeper_name ~lane_ownership ~entry:(Some entry) with
+       | Ok () -> ()
+       | Error detail ->
+         failf
+           "a lane that vanished mid-operation must succeed like an absent \
+            lane, got: %s"
+           detail)
+;;
+
+let test_replaced_lane_still_fails () =
+  let base_path = temp_dir "shutdown_lane_replaced_" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let keeper_name = "replaced-lane" in
+       let meta = meta_fixture_exn ~keeper_name in
+       let original = Keeper_registry.register_offline ~base_path keeper_name meta in
+       (* A different lane now owns the keeper. The operation still names the
+          lane it owned, so its retained meta must not overwrite the new one. *)
+       Keeper_registry.For_testing.unregister ~base_path keeper_name;
+       let replacement =
+         Keeper_registry.register_offline ~base_path keeper_name meta
+       in
+       check
+         bool
+         "precondition: the replacement lane differs from the original"
+         false
+         (Keeper_lane.Id.equal
+            (Keeper_lane.id original.lane)
+            (Keeper_lane.id replacement.lane));
+       match
+         registry_projection
+           ~keeper_name
+           ~lane_ownership:(Registered_lane (Keeper_lane.id original.lane))
+           ~entry:(Some replacement)
+       with
+       | Ok () ->
+         fail "a replaced lane must not be projected over: another owner holds it"
+       | Error _ -> ())
+;;
+
 let () =
   run
     "keeper-shutdown-reconciliation-settlement"
@@ -247,6 +360,16 @@ let () =
             "still settles a prepared operation without a turn"
             `Quick
             test_recovery_still_settles_prepared_without_turn
+        ] )
+    ; ( "registry projection"
+      , [ test_case
+            "a lane that vanished mid-operation settles like an absent lane"
+            `Quick
+            test_vanished_lane_matches_absent_lane
+        ; test_case
+            "a replaced lane is still rejected"
+            `Quick
+            test_replaced_lane_still_fails
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

`update_registry_meta_exact`가 **같은 사실에 두 가지 판정**을 내리는 것을 바로잡는다. 레인이 사라진 셧다운이 영구 차단되면서 해당 keeper의 이후 모든 boot이 프로세스 재시작 전까지 실패한다.

## 문제

`lib/keeper/keeper_shutdown_finalize.ml:359-382`, 같은 함수 안:

```ocaml
| Registered_lane _, None -> Ok ()                    (* 읽을 때 이미 없음 → 성공 *)
| Registered_lane _, Some registry_entry ->
  (match Keeper_registry.update_entry_exact ... with
   | Exact_update_missing ->
     Error "Keeper registry entry disappeared before meta update")   (* 읽고 나서 사라짐 → 차단 *)
```

**최종 상태는 동일합니다** — 이 셧다운이 소유하던 레인이 없음. 그건 셧다운이 지향하는 상태이고, durable meta 업데이트는 그 시점에 이미 커밋돼 있습니다. 존재하지 않는 레인에 retained meta를 투영하는 건 no-op이지 충돌이 아닙니다.

**지는 쪽의 대가가 비대칭적으로 큽니다.** `Error` → `block` → blocked 오퍼레이션이 `Registration_shutdown_reserved`로 admission을 점유(`keeper_keepalive.ml:723-726`) → **런타임 해제 경로 없음**, 복구는 부팅 시에만(`server_bootstrap_loops.ml:1197`).

즉 supervisor/keepalive/형제 셧다운 중 하나가 `unregister_exact`를 호출하는 것만으로 그 keeper는 재시작 전까지 부팅 불가가 됩니다.

## 라이브 재현 (2026-07-27)

래치 해제 후 4마리를 깨울 때:

| keeper | registry 상태 | 결과 |
|---|---|---|
| executor / kinobot-frontend / rondo | 엔트리 부재 (`None` arm) | ✅ boot 성공, 즉시 턴 실행 |
| **sangsu** | 엔트리 존재 → 경합으로 소멸 | ❌ blocked, boot 400 |

```
keeper metadata was updated but lane restart failed:
shutdown operation shutdown-a5fc8a0f-... owns keeper admission
```

```json
"phase":{"kind":"blocked","failure":{"stage":"meta_update",
         "detail":"Keeper registry entry disappeared before meta update"}}
```

## 변경

`Exact_update_missing` → `Ok ()`.

`Exact_update_replaced`는 **그대로 실패**시킵니다. 다른 레인이 있다는 건 다른 소유자가 keeper를 잡고 있다는 뜻이고, 이 오퍼레이션이 자기 retained meta를 그 위에 덮으면 안 됩니다. **소멸은 교체가 아닙니다.**

`validate_registry_owner_exact`(`:404-421`)는 이미 부재를 `Ok`로 처리하므로, 이 변경으로 cleanup 경로의 레지스트리 판독 3곳이 서로 합의하게 됩니다.

## 테스트

스텁이 아니라 **실제 경합을 재현**합니다: `register_offline` → 엔트리 확보 → `unregister` → 투영 실행. 동시 fiber가 하는 일 그대로입니다.

- `a lane that vanished mid-operation settles like an absent lane` — ✅
- `a replaced lane is still rejected` — ✅ (두 번째 `register_offline`이 다른 lane id를 만드는지 precondition으로 확인)

## 로컬 검증

```
registry projection   0   a lane that vanished mid-operation...   [OK]
registry projection   1   a replaced lane is still rejected       [OK]
```

## 선재 실패 (본 PR과 무관)

같은 스위트의 `boot recovery` 3건은 **origin/main에서도 동일하게 실패**합니다. 제 변경을 `git stash`하고 재빌드·재실행해 확인했습니다:

```
BASELINE (origin/main): 3 failures! in 0.024s. 3 tests run.
```

사유는 `Keeper metadata identity changed before finalization`이고, `15e7f2711a` (`Revert "...keeper-lifecycle-nonce-20260726"`) 이후로 보입니다. 본 PR에서 다루지 않습니다.

## 미검증

- 이 스위트가 CI `runtest`에 실제로 포함되는지 확인 못 했습니다 (07-27에 확인된 test rot 이슈와 관련 가능)
- sangsu는 이 수정으로 **자동 복구되지 않습니다** — 이미 blocked 레코드가 디스크에 있고, 그건 부팅 시 복구됩니다

RFC-WAIVED: 단일 match arm의 판정 정정입니다. credential/identity/operator control plane/sandbox/hooks 중 어디도 건드리지 않으며, 새 개념이나 표면을 도입하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
