### PR TITLE
fix(keeper): project assigned verification evidence

### DIFF
--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -88,6 +88,52 @@ let repos_path (name : string) : string =
 let bundle_paths (name : string) : string list =
   [ bundle_root name; mind_path name; repos_path name ]
 
+type playground_file_path =
+  { keeper_name : string
+  ; relative_path : string
+  }
+
+let parse_playground_file_path ~base_path ~abs_path =
+  if Filename.is_relative abs_path then None
+  else
+    let base =
+      let n = String.length base_path in
+      if n > 1 && base_path.[n - 1] = '/'
+      then String.sub base_path 0 (n - 1)
+      else base_path
+    in
+    let base_with_slash = if String.equal base "/" then base else base ^ "/" in
+    if not (String.starts_with ~prefix:base_with_slash abs_path) then None
+    else
+      let rel =
+        String.sub abs_path (String.length base_with_slash)
+          (String.length abs_path - String.length base_with_slash)
+      in
+      let safe_relative keeper_name segments =
+        if
+          String.equal keeper_name ""
+          || segments = []
+          || List.exists
+               (fun segment ->
+                  String.equal segment ""
+                  || String.equal segment "."
+                  || String.equal segment "..")
+               segments
+        then None
+        else
+          Some
+            { keeper_name
+            ; relative_path = String.concat "/" segments
+            }
+      in
+      match String.split_on_char '/' rel with
+      | ".masc" :: "playground" :: "docker" :: keeper_name :: segments ->
+        safe_relative keeper_name segments
+      | ".masc" :: "playground" :: keeper_name :: segments ->
+        safe_relative keeper_name segments
+      | _ -> None
+;;
+
 (* RFC-0128 §4.5 — parse a sandbox playground absolute file path back
    into [(repo_id, rel_path)]. Used by the keeper write path so that
    files keepers edit inside their per-keeper repo clones map to the

--- a/lib/config/playground_paths.mli
+++ b/lib/config/playground_paths.mli
@@ -40,6 +40,25 @@ val bundle_paths : string -> string list
 (** All three bundle subdirs in canonical order:
     [\[bundle_root; mind_path; repos_path\]]. *)
 
+type playground_file_path =
+  { keeper_name : string
+  ; relative_path : string
+  }
+
+val parse_playground_file_path
+  :  base_path:string
+  -> abs_path:string
+  -> playground_file_path option
+(** Parse an absolute path below a local or Docker keeper playground.
+
+    Accepted layouts:
+    - [.masc/playground/<keeper>/<relative_path>]
+    - [.masc/playground/docker/<keeper>/<relative_path>]
+
+    Empty relative paths and [.] / [..] segments are rejected. This is a
+    structural parser only; callers enforcing an I/O boundary must pass
+    realpath-resolved inputs and separately check the filesystem kind. *)
+
 val parse_playground_repo_path
   :  base_path:string
   -> abs_path:string

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -780,7 +780,8 @@ let read_exact_file_descriptor ~path fd length =
   | cause -> owned_file_operation_error ~path Read_contents cause
 ;;
 
-let load_owned_regular_file_blocking ~ownership_root path =
+let load_owned_regular_file_blocking_with
+    ~ownership_root ~read_descriptor path =
   let parent = Filename.dirname path in
   let inspect_parent () =
     try
@@ -854,7 +855,7 @@ let load_owned_regular_file_blocking ~ownership_root path =
                | Ok false ->
                  owned_file_error (Filesystem_identity_changed { path })
                | Ok true ->
-                 (match read_exact_file_descriptor ~path fd descriptor.st_size with
+                 (match read_descriptor ~path fd descriptor with
                   | Error _ as error -> error
                   | Ok content ->
                     (match Unix.fstat fd with
@@ -887,6 +888,14 @@ let load_owned_regular_file_blocking ~ownership_root path =
              Error { error with close_failure = Some cause })))
 ;;
 
+let load_owned_regular_file_blocking ~ownership_root path =
+  load_owned_regular_file_blocking_with
+    ~ownership_root
+    ~read_descriptor:(fun ~path fd descriptor ->
+      read_exact_file_descriptor ~path fd descriptor.Unix.st_size)
+    path
+;;
+
 let load_owned_regular_file ~ownership_root path =
   with_fs_or_fallback
     ~path
@@ -895,6 +904,52 @@ let load_owned_regular_file ~ownership_root path =
        let result =
          Eio_unix.run_in_systhread (fun () ->
            load_owned_regular_file_blocking ~ownership_root path)
+       in
+       Eio.Fiber.check ();
+       result)
+;;
+
+type owned_regular_file_prefix =
+  { content : string
+  ; file_size : int
+  ; truncated : bool
+  }
+
+let load_owned_regular_file_prefix_blocking
+    ~ownership_root ~max_bytes path =
+  if max_bytes < 0
+  then
+    owned_file_operation_error
+      ~path
+      Read_contents
+      (Invalid_argument "max_bytes must be non-negative")
+  else
+    load_owned_regular_file_blocking_with
+      ~ownership_root
+      ~read_descriptor:(fun ~path fd descriptor ->
+        let length = min max_bytes descriptor.Unix.st_size in
+        match read_exact_file_descriptor ~path fd length with
+        | Error _ as error -> error
+        | Ok content ->
+          Ok
+            { content
+            ; file_size = descriptor.Unix.st_size
+            ; truncated = descriptor.Unix.st_size > length
+            })
+      path
+;;
+
+let load_owned_regular_file_prefix ~ownership_root ~max_bytes path =
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () ->
+      load_owned_regular_file_prefix_blocking
+        ~ownership_root ~max_bytes path)
+    (fun _fs ->
+       let result =
+         Eio_unix.run_in_systhread (fun () ->
+           load_owned_regular_file_prefix_blocking
+             ~ownership_root ~max_bytes path)
        in
        Eio.Fiber.check ();
        result)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -219,6 +219,22 @@ val load_owned_regular_file
   -> string
   -> (string option, owned_regular_file_read_error) result
 
+type owned_regular_file_prefix =
+  { content : string
+  ; file_size : int
+  ; truncated : bool
+  }
+
+val load_owned_regular_file_prefix
+  :  ownership_root:string
+  -> max_bytes:int
+  -> string
+  -> (owned_regular_file_prefix option, owned_regular_file_read_error) result
+(** Bounded-prefix sibling of {!load_owned_regular_file}. It preserves the
+    same no-follow parent-chain, descriptor identity, regular-file, and
+    changed-during-read checks, but reads at most [max_bytes]. The existing
+    whole-file API and its callers are unchanged. *)
+
 val owned_regular_file_read_error_to_string
   :  owned_regular_file_read_error
   -> string

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -668,7 +668,7 @@ let handle_update_priority ~tool_name ~start_time ctx args =
   let priority = get_int args "priority" 3 in
   Tool_result.ok ~tool_name ~start_time (Workspace.update_priority ctx.config ~task_id ~priority)
 
-let handle_tasks ~tool_name ~start_time ctx args =
+let handle_tasks_with_projection ~task_list_projection ~tool_name ~start_time ctx args =
   let include_done = get_bool args "include_done" false in
   let include_cancelled = get_bool args "include_cancelled" false in
   let status =
@@ -676,7 +676,26 @@ let handle_tasks ~tool_name ~start_time ctx args =
     | `String s when not (String.equal s "") -> Some s
     | _ -> None
   in
-  Tool_result.ok ~tool_name ~start_time (Workspace.list_tasks ctx.config ~include_done ~include_cancelled ?status)
+  let verification_viewer =
+    match task_list_projection with
+    | Tool_capability_projection.Keeper_tasks_list -> Some ctx.agent_name
+    | Tool_capability_projection.External_masc_tasks -> None
+  in
+  Tool_result.ok ~tool_name ~start_time
+    (Workspace.list_tasks
+       ctx.config
+       ~include_done
+       ~include_cancelled
+       ?status
+       ?verification_viewer)
+
+let handle_tasks ~tool_name ~start_time ctx args =
+  handle_tasks_with_projection
+    ~task_list_projection:Tool_capability_projection.External_masc_tasks
+    ~tool_name
+    ~start_time
+    ctx
+    args
 
 let read_event_lines config ~limit =
   let events_dir = Filename.concat (Workspace.masc_dir config) "events" in
@@ -782,7 +801,14 @@ let dispatch_with_task_list_projection ?created_by task_list_projection ctx ~nam
          args)
   | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
   | "masc_task_set_goal" -> Some (handle_set_goal ~tool_name:name ~start_time:start ctx args)
-  | "masc_tasks" -> Some (handle_tasks ~tool_name:name ~start_time:start ctx args)
+  | "masc_tasks" ->
+    Some
+      (handle_tasks_with_projection
+         ~task_list_projection
+         ~tool_name:name
+         ~start_time:start
+         ctx
+         args)
   | "masc_task_history" -> Some (handle_task_history ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -383,11 +383,13 @@ let add_indented_evidence_content buf content =
   String.split_on_char '\n' content
   |> List.iter (fun line -> Printf.bprintf buf "         | %s\n" line)
 
-let add_verification_evidence_projection buf config ~viewer verification_id =
+let add_verification_evidence_projection
+    buf config ~viewer ~task_verifier verification_id =
   match
     Workspace_verification_store.inspect_submitted_evidence
       ~base_path:config.base_path
       ~request_id:verification_id
+      ~task_verifier
       ~viewer
   with
   | Workspace_verification_store.Evidence_metadata_only { request; viewer = _ } ->
@@ -468,15 +470,20 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status
       Printf.bprintf buf "%s [%d] %s: %s\n" status_icon task.priority task.id task.title;
       Printf.bprintf buf "   └─ %s | %s\n" status_str assignee;
       match task.task_status with
-      | Masc_domain.AwaitingVerification { verification_id; _ } ->
+      | Masc_domain.AwaitingVerification { verification_id; phase; _ } ->
         (match verification_viewer with
          | None ->
            Printf.bprintf buf
              "   └─ verification_request=%s evidence=metadata_only\n"
              verification_id
          | Some viewer ->
+           let task_verifier =
+             match phase with
+             | Masc_domain.Awaiting_verifier -> None
+             | Masc_domain.Verifier_assigned { verifier } -> Some verifier
+           in
            add_verification_evidence_projection
-             buf config ~viewer verification_id)
+             buf config ~viewer ~task_verifier verification_id)
       | Masc_domain.Todo
       | Masc_domain.Claimed _
       | Masc_domain.InProgress _

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -379,8 +379,55 @@ let get_all_messages_raw config ~since_seq =
       in
       loop [] names
 
+let add_indented_evidence_content buf content =
+  String.split_on_char '\n' content
+  |> List.iter (fun line -> Printf.bprintf buf "         | %s\n" line)
+
+let add_verification_evidence_projection buf config ~viewer verification_id =
+  match
+    Workspace_verification_store.inspect_submitted_evidence
+      ~base_path:config.base_path
+      ~request_id:verification_id
+      ~viewer
+  with
+  | Workspace_verification_store.Evidence_metadata_only { request; viewer = _ } ->
+    let assigned =
+      match request.verifier with
+      | Some verifier -> verifier
+      | None -> "unassigned"
+    in
+    Printf.bprintf buf
+      "   └─ verification_request=%s assigned_verifier=%s evidence=metadata_only\n"
+      verification_id assigned
+  | Workspace_verification_store.Evidence_unavailable { request_id; reason } ->
+    Printf.bprintf buf
+      "   └─ verification_request=%s evidence=unavailable reason=%s\n"
+      request_id reason
+  | Workspace_verification_store.Evidence_available { request = _; items } ->
+    Printf.bprintf buf
+      "   └─ verification_request=%s submitted_evidence:\n"
+      verification_id;
+    List.iter
+      (function
+        | Workspace_verification_store.Evidence_note note ->
+          Printf.bprintf buf "      - note: %s\n" note
+        | Workspace_verification_store.Evidence_artifact
+            { reference; content; bytes; truncated } ->
+          Printf.bprintf buf
+            "      - artifact: %s bytes=%d truncated=%b content=untrusted_evidence\n"
+            reference bytes truncated;
+          add_indented_evidence_content buf content
+        | Workspace_verification_store.Evidence_artifact_unreadable
+            { reference; reason } ->
+          Printf.bprintf buf
+            "      - artifact: %s unreadable_reason=%s\n"
+            reference
+            (Workspace_verification_store.evidence_read_failure_to_string reason))
+      items
+
 (** List tasks *)
-let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status config =
+let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status
+    ?verification_viewer config =
   ensure_initialized config;
 
   let backlog = read_backlog config in
@@ -419,7 +466,22 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
       let assignee = Masc_domain.task_display_assignee task.task_status in
       let status_str = Masc_domain.string_of_task_status task.task_status in
       Printf.bprintf buf "%s [%d] %s: %s\n" status_icon task.priority task.id task.title;
-      Printf.bprintf buf "   └─ %s | %s\n" status_str assignee
+      Printf.bprintf buf "   └─ %s | %s\n" status_str assignee;
+      match task.task_status with
+      | Masc_domain.AwaitingVerification { verification_id; _ } ->
+        (match verification_viewer with
+         | None ->
+           Printf.bprintf buf
+             "   └─ verification_request=%s evidence=metadata_only\n"
+             verification_id
+         | Some viewer ->
+           add_verification_evidence_projection
+             buf config ~viewer verification_id)
+      | Masc_domain.Todo
+      | Masc_domain.Claimed _
+      | Masc_domain.InProgress _
+      | Masc_domain.Done _
+      | Masc_domain.Cancelled _ -> ()
     ) sorted;
 
     Buffer.contents buf

--- a/lib/workspace/workspace_query.mli
+++ b/lib/workspace/workspace_query.mli
@@ -82,7 +82,12 @@ val get_all_messages_raw :
 (** List tasks with optional filters, returning a formatted string. *)
 val list_tasks :
   ?include_done:bool -> ?include_cancelled:bool -> ?status:string ->
+  ?verification_viewer:string ->
   config -> string
+(** [verification_viewer] is supplied only by the trusted Keeper task tool.
+    For an AwaitingVerification task, the matching assigned verifier receives
+    a bounded read-only projection of the request's submitted evidence.
+    Other callers receive request metadata only. *)
 
 (** Return recent messages as a formatted string. *)
 val get_messages : config -> since_seq:int -> limit:int -> string

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -17,6 +17,45 @@ type request_header = {
   status : request_status;
 }
 
+type evidence_read_failure =
+  | Evidence_missing
+  | Evidence_not_regular_file
+  | Evidence_outside_worker_playground
+  | Evidence_read_error of string
+
+type submitted_evidence_item =
+  | Evidence_note of string
+  | Evidence_artifact of
+      { reference : string
+      ; content : string
+      ; bytes : int
+      ; truncated : bool
+      }
+  | Evidence_artifact_unreadable of
+      { reference : string
+      ; reason : evidence_read_failure
+      }
+
+type submitted_evidence_access =
+  | Evidence_available of
+      { request : request_header
+      ; items : submitted_evidence_item list
+      }
+  | Evidence_metadata_only of
+      { request : request_header
+      ; viewer : string
+      }
+  | Evidence_unavailable of
+      { request_id : string
+      ; reason : string
+      }
+
+let evidence_read_failure_to_string = function
+  | Evidence_missing -> "missing"
+  | Evidence_not_regular_file -> "not_regular_file"
+  | Evidence_outside_worker_playground -> "outside_worker_playground"
+  | Evidence_read_error detail -> "read_error:" ^ detail
+
 let project_root_of_base_path base_path =
   if Filename.basename base_path = Common.masc_dirname then
     Filename.dirname base_path
@@ -186,6 +225,155 @@ let load_request_header base_path req_id =
                 (Printexc.to_string exn))
   else
     Error (Printf.sprintf "Verification %s not found" req_id)
+
+let submitted_evidence_of_request_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "output" fields with
+     | Some (`Assoc output_fields) ->
+       (match List.assoc_opt "submitted_evidence" output_fields with
+        | Some (`List values) ->
+          let rec collect acc = function
+            | [] -> Ok (List.rev acc)
+            | `String value :: rest -> collect (value :: acc) rest
+            | value :: _ ->
+              Error
+                (Printf.sprintf
+                   "submitted_evidence must contain only strings, got %s"
+                   (Json_util.excerpt value))
+          in
+          collect [] values
+        | Some other ->
+          Error
+            (Printf.sprintf
+               "submitted_evidence must be a list, got %s"
+               (Json_util.excerpt other))
+        | None -> Error "verification request output has no submitted_evidence")
+     | Some other ->
+       Error
+         (Printf.sprintf
+            "verification request output must be an object, got %s"
+            (Json_util.excerpt other))
+     | None -> Error "verification request has no output")
+  | other ->
+    Error
+      (Printf.sprintf
+         "verification request must be an object, got %s"
+         (Json_util.excerpt other))
+
+let load_request_for_evidence base_path req_id =
+  let path = request_path base_path req_id in
+  if not (Sys.file_exists path) then
+    Error (Printf.sprintf "Verification %s not found" req_id)
+  else
+    try
+      let json = Safe_ops.read_json_eio path in
+      match request_header_of_yojson json with
+      | Error detail -> Error detail
+      | Ok request ->
+        (match submitted_evidence_of_request_json json with
+         | Error detail -> Error detail
+         | Ok evidence -> Ok (request, evidence))
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Error
+        (Printf.sprintf
+           "Failed to load verification %s evidence: %s"
+           req_id
+           (Printexc.to_string exn))
+
+let verification_evidence_max_bytes = 20_000
+
+let read_regular_file_prefix path stat =
+  try
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let requested = min verification_evidence_max_bytes stat.Unix.st_size in
+         let raw = really_input_string ic requested in
+         let content = String_util.utf8_prefix ~max_bytes:requested raw in
+         Ok
+           ( content
+           , stat.Unix.st_size
+           , stat.Unix.st_size > String.length content ))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Evidence_read_error (Printexc.to_string exn))
+
+let inspect_artifact_reference ~base_path ~worker reference =
+  let canonical_base =
+    try Ok (Unix.realpath (project_root_of_base_path base_path)) with
+    | Unix.Unix_error (Unix.ENOENT, _, _) -> Error Evidence_missing
+    | exn -> Error (Evidence_read_error (Printexc.to_string exn))
+  in
+  let canonical_target =
+    try Ok (Unix.realpath reference) with
+    | Unix.Unix_error (Unix.ENOENT, _, _) -> Error Evidence_missing
+    | exn -> Error (Evidence_read_error (Printexc.to_string exn))
+  in
+  match canonical_base, canonical_target with
+  | Error reason, _ | _, Error reason ->
+    Evidence_artifact_unreadable { reference; reason }
+  | Ok canonical_base, Ok canonical_target ->
+    (match
+       Playground_paths.parse_playground_file_path
+         ~base_path:canonical_base
+         ~abs_path:canonical_target
+     with
+     | Some parsed
+       when String.equal
+              parsed.Playground_paths.keeper_name
+              (Playground_paths.sanitize_keeper_name worker) ->
+       (try
+          let stat = Unix.stat canonical_target in
+          if stat.Unix.st_kind <> Unix.S_REG then
+            Evidence_artifact_unreadable
+              { reference; reason = Evidence_not_regular_file }
+          else
+            (match read_regular_file_prefix canonical_target stat with
+             | Error reason ->
+               Evidence_artifact_unreadable { reference; reason }
+             | Ok (content, bytes, truncated) ->
+               Evidence_artifact { reference; content; bytes; truncated })
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Evidence_artifact_unreadable
+            { reference
+            ; reason = Evidence_read_error (Printexc.to_string exn)
+            })
+     | Some _ | None ->
+       Evidence_artifact_unreadable
+         { reference; reason = Evidence_outside_worker_playground })
+
+let inspect_submitted_evidence ~base_path ~request_id ~viewer =
+  match load_request_for_evidence base_path request_id with
+  | Error reason -> Evidence_unavailable { request_id; reason }
+  | Ok (request, evidence_refs) ->
+    (match request.status with
+     | `Completed _ ->
+       Evidence_unavailable
+         { request_id
+         ; reason = "verification request is already completed"
+         }
+     | `Pending | `Assigned _ ->
+       (match request.verifier with
+        | Some assigned_verifier when String.equal assigned_verifier viewer ->
+          let items =
+            List.map
+              (fun reference ->
+                 if Filename.is_relative reference then
+                   Evidence_note reference
+                 else
+                   inspect_artifact_reference
+                     ~base_path
+                     ~worker:request.worker
+                     reference)
+              evidence_refs
+          in
+          Evidence_available { request; items }
+        | None | Some _ -> Evidence_metadata_only { request; viewer }))
 
 let list_request_headers base_path =
   let surface = "verification" in

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -24,7 +24,6 @@ type evidence_read_failure =
   | Evidence_invalid_utf8
   | Evidence_symbolic_link
   | Evidence_changed_during_read
-  | Evidence_too_large
   | Evidence_read_error of string
 
 type submitted_evidence_item =
@@ -61,7 +60,6 @@ let evidence_read_failure_to_string = function
   | Evidence_invalid_utf8 -> "invalid_utf8"
   | Evidence_symbolic_link -> "symbolic_link"
   | Evidence_changed_during_read -> "changed_during_read"
-  | Evidence_too_large -> "too_large"
   | Evidence_read_error detail -> "read_error:" ^ detail
 
 let project_root_of_base_path base_path =
@@ -291,7 +289,6 @@ let load_request_for_evidence base_path req_id =
            (Printexc.to_string exn))
 
 let verification_evidence_max_bytes = 20_000
-let verification_evidence_max_exact_read_bytes = 200_000L
 
 type utf8_scan =
   | Utf8_valid
@@ -335,85 +332,39 @@ let scan_utf8 bytes =
   in
   loop 0
 
-let exact_read_operation_to_string = function
-  | Fs_compat.Capability_exact_read.Pin_parent -> "pin_parent"
-  | Open_parent_descriptor -> "open_parent_descriptor"
-  | Open_leaf -> "open_leaf"
-  | Inspect_opened -> "inspect_opened"
-  | Allocate -> "allocate"
-  | Read_exact -> "read_exact"
-  | Inspect_after_read -> "inspect_after_read"
-  | Close_leaf -> "close_leaf"
-  | Settle_parent_resources -> "settle_parent_resources"
-  | Observe_parent_cancellation -> "observe_parent_cancellation"
+let evidence_read_failure_of_owned_read_failure = function
+  | Fs_compat.Ownership_boundary_rejected _ ->
+    Evidence_outside_worker_playground
+  | Path_is_not_regular_file { kind = Unix.S_LNK; _ } ->
+    Evidence_symbolic_link
+  | Path_is_not_regular_file _ ->
+    Evidence_not_regular_file
+  | Filesystem_identity_changed _ ->
+    Evidence_changed_during_read
+  | Owned_file_operation_failed { cause; _ } ->
+    Evidence_read_error (Printexc.to_string cause)
 
-let exact_read_diagnostic_to_string
-    (diagnostic : Fs_compat.Capability_exact_read.diagnostic) =
-  Printf.sprintf
-    "%s:%s"
-    (exact_read_operation_to_string diagnostic.operation)
-    diagnostic.detail
-
-let evidence_read_failure_of_exact_read_error = function
-  | Fs_compat.Capability_exact_read.Missing -> Evidence_missing
-  | Symbolic_link -> Evidence_symbolic_link
-  | Not_regular _ -> Evidence_not_regular_file
-  | Changed_during_read -> Evidence_changed_during_read
-  | Length_exceeds_max _ -> Evidence_too_large
-  | Invalid_leaf detail -> Evidence_read_error ("invalid_leaf:" ^ detail)
-  | Invalid_length_bounds _ -> Evidence_read_error "invalid_length_bounds"
-  | Length_not_representable length ->
-    Evidence_read_error
-      (Printf.sprintf "length_not_representable:%Ld" length)
-  | Cancelled diagnostic ->
-    Evidence_read_error
-      ("cancelled:" ^ exact_read_diagnostic_to_string diagnostic)
-  | Parent_descriptor_unavailable ->
-    Evidence_read_error "parent_descriptor_unavailable"
-  | Unsafe_link_count count ->
-    Evidence_read_error (Printf.sprintf "unsafe_link_count:%d" count)
-  | Unsafe_mode mode ->
-    Evidence_read_error (Printf.sprintf "unsafe_mode:%o" mode)
-  | Length_mismatch { expected_length; observed_length } ->
-    Evidence_read_error
-      (Printf.sprintf
-         "length_mismatch:expected=%Ld:observed=%Ld"
-         expected_length
-         observed_length)
-  | Io_error diagnostic ->
-    Evidence_read_error
-      (exact_read_diagnostic_to_string diagnostic)
-
-let read_regular_file_prefix path stat =
-  match Fs_compat.get_fs_opt () with
-  | None -> Error (Evidence_read_error "eio_filesystem_unavailable")
-  | Some fs ->
-    let parent = Eio.Path.(fs / Filename.dirname path) in
-    let leaf = Filename.basename path in
-    let expected_length = Int64.of_int stat.Unix.st_size in
-    (match
-       Fs_compat.Capability_exact_read.read
-         ~parent
-         ~leaf
-         ~expected_length
-         ~max_length:verification_evidence_max_exact_read_bytes
-     with
-     | Error failure ->
-       Error (evidence_read_failure_of_exact_read_error failure.error)
-     | Ok observation ->
-       let exact_bytes =
-         Fs_compat.Capability_exact_read.observation_bytes observation
-       in
-       let exact_length = String.length exact_bytes in
-       let requested = min verification_evidence_max_bytes exact_length in
-       let raw = String.sub exact_bytes 0 requested in
-       let source_truncated = exact_length > requested in
-       match scan_utf8 raw with
-       | Utf8_valid -> Ok (raw, exact_length, source_truncated)
-       | Utf8_incomplete_at index when source_truncated ->
-         Ok (String.sub raw 0 index, exact_length, true)
-       | Utf8_incomplete_at _ | Utf8_invalid ->
-         Error Evidence_invalid_utf8)
+let read_regular_file_prefix ~ownership_root path =
+  match
+    Fs_compat.load_owned_regular_file_prefix
+      ~ownership_root
+      ~max_bytes:verification_evidence_max_bytes
+      path
+  with
+  | Error error ->
+    Error (evidence_read_failure_of_owned_read_failure error.failure)
+  | Ok None -> Error Evidence_missing
+  | Ok (Some prefix) ->
+    (match scan_utf8 prefix.content with
+     | Utf8_valid ->
+       Ok (prefix.content, prefix.file_size, prefix.truncated)
+     | Utf8_incomplete_at index when prefix.truncated ->
+       Ok
+         ( String.sub prefix.content 0 index
+         , prefix.file_size
+         , true )
+     | Utf8_incomplete_at _ | Utf8_invalid ->
+       Error Evidence_invalid_utf8)
 
 let inspect_artifact_reference ~base_path ~worker reference =
   let canonical_base =
@@ -439,20 +390,22 @@ let inspect_artifact_reference ~base_path ~worker reference =
        when String.equal
               parsed.Playground_paths.keeper_name
               (Playground_paths.sanitize_keeper_name worker) ->
-       (try
-          let stat = Unix.stat canonical_target in
-          match read_regular_file_prefix canonical_target stat with
-          | Error reason ->
-            Evidence_artifact_unreadable { reference; reason }
-          | Ok (content, bytes, truncated) ->
-            Evidence_artifact { reference; content; bytes; truncated }
+       let relative_suffix = "/" ^ parsed.relative_path in
+       let ownership_root =
+         String.sub
+           canonical_target
+           0
+           (String.length canonical_target - String.length relative_suffix)
+       in
+       (match
+          read_regular_file_prefix
+            ~ownership_root
+            canonical_target
         with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Evidence_artifact_unreadable
-            { reference
-            ; reason = Evidence_read_error (Printexc.to_string exn)
-            })
+        | Error reason ->
+          Evidence_artifact_unreadable { reference; reason }
+        | Ok (content, bytes, truncated) ->
+          Evidence_artifact { reference; content; bytes; truncated })
      | Some _ | None ->
        Evidence_artifact_unreadable
          { reference; reason = Evidence_outside_worker_playground })

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -21,6 +21,10 @@ type evidence_read_failure =
   | Evidence_missing
   | Evidence_not_regular_file
   | Evidence_outside_worker_playground
+  | Evidence_invalid_utf8
+  | Evidence_symbolic_link
+  | Evidence_changed_during_read
+  | Evidence_too_large
   | Evidence_read_error of string
 
 type submitted_evidence_item =
@@ -54,6 +58,10 @@ let evidence_read_failure_to_string = function
   | Evidence_missing -> "missing"
   | Evidence_not_regular_file -> "not_regular_file"
   | Evidence_outside_worker_playground -> "outside_worker_playground"
+  | Evidence_invalid_utf8 -> "invalid_utf8"
+  | Evidence_symbolic_link -> "symbolic_link"
+  | Evidence_changed_during_read -> "changed_during_read"
+  | Evidence_too_large -> "too_large"
   | Evidence_read_error detail -> "read_error:" ^ detail
 
 let project_root_of_base_path base_path =
@@ -283,23 +291,129 @@ let load_request_for_evidence base_path req_id =
            (Printexc.to_string exn))
 
 let verification_evidence_max_bytes = 20_000
+let verification_evidence_max_exact_read_bytes = 200_000L
+
+type utf8_scan =
+  | Utf8_valid
+  | Utf8_incomplete_at of int
+  | Utf8_invalid
+
+let scan_utf8 bytes =
+  let length = String.length bytes in
+  let byte index = Char.code bytes.[index] in
+  let continuation index =
+    index < length && byte index land 0xC0 = 0x80
+  in
+  let rec loop index =
+    if index = length then Utf8_valid
+    else
+      let first = byte index in
+      if first <= 0x7F then loop (index + 1)
+      else
+        let required, second_min, second_max =
+          if first >= 0xC2 && first <= 0xDF then 2, 0x80, 0xBF
+          else if first = 0xE0 then 3, 0xA0, 0xBF
+          else if (first >= 0xE1 && first <= 0xEC) || (first >= 0xEE && first <= 0xEF)
+          then 3, 0x80, 0xBF
+          else if first = 0xED then 3, 0x80, 0x9F
+          else if first = 0xF0 then 4, 0x90, 0xBF
+          else if first >= 0xF1 && first <= 0xF3 then 4, 0x80, 0xBF
+          else if first = 0xF4 then 4, 0x80, 0x8F
+          else 0, 0, 0
+        in
+        if required = 0 then Utf8_invalid
+        else if index + required > length then Utf8_incomplete_at index
+        else
+          let second = byte (index + 1) in
+          if
+            second < second_min
+            || second > second_max
+            || (required >= 3 && not (continuation (index + 2)))
+            || (required = 4 && not (continuation (index + 3)))
+          then Utf8_invalid
+          else loop (index + required)
+  in
+  loop 0
+
+let exact_read_operation_to_string = function
+  | Fs_compat.Capability_exact_read.Pin_parent -> "pin_parent"
+  | Open_parent_descriptor -> "open_parent_descriptor"
+  | Open_leaf -> "open_leaf"
+  | Inspect_opened -> "inspect_opened"
+  | Allocate -> "allocate"
+  | Read_exact -> "read_exact"
+  | Inspect_after_read -> "inspect_after_read"
+  | Close_leaf -> "close_leaf"
+  | Settle_parent_resources -> "settle_parent_resources"
+  | Observe_parent_cancellation -> "observe_parent_cancellation"
+
+let exact_read_diagnostic_to_string
+    (diagnostic : Fs_compat.Capability_exact_read.diagnostic) =
+  Printf.sprintf
+    "%s:%s"
+    (exact_read_operation_to_string diagnostic.operation)
+    diagnostic.detail
+
+let evidence_read_failure_of_exact_read_error = function
+  | Fs_compat.Capability_exact_read.Missing -> Evidence_missing
+  | Symbolic_link -> Evidence_symbolic_link
+  | Not_regular _ -> Evidence_not_regular_file
+  | Changed_during_read -> Evidence_changed_during_read
+  | Length_exceeds_max _ -> Evidence_too_large
+  | Invalid_leaf detail -> Evidence_read_error ("invalid_leaf:" ^ detail)
+  | Invalid_length_bounds _ -> Evidence_read_error "invalid_length_bounds"
+  | Length_not_representable length ->
+    Evidence_read_error
+      (Printf.sprintf "length_not_representable:%Ld" length)
+  | Cancelled diagnostic ->
+    Evidence_read_error
+      ("cancelled:" ^ exact_read_diagnostic_to_string diagnostic)
+  | Parent_descriptor_unavailable ->
+    Evidence_read_error "parent_descriptor_unavailable"
+  | Unsafe_link_count count ->
+    Evidence_read_error (Printf.sprintf "unsafe_link_count:%d" count)
+  | Unsafe_mode mode ->
+    Evidence_read_error (Printf.sprintf "unsafe_mode:%o" mode)
+  | Length_mismatch { expected_length; observed_length } ->
+    Evidence_read_error
+      (Printf.sprintf
+         "length_mismatch:expected=%Ld:observed=%Ld"
+         expected_length
+         observed_length)
+  | Io_error diagnostic ->
+    Evidence_read_error
+      (exact_read_diagnostic_to_string diagnostic)
 
 let read_regular_file_prefix path stat =
-  try
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-         let requested = min verification_evidence_max_bytes stat.Unix.st_size in
-         let raw = really_input_string ic requested in
-         let content = String_util.utf8_prefix ~max_bytes:requested raw in
-         Ok
-           ( content
-           , stat.Unix.st_size
-           , stat.Unix.st_size > String.length content ))
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Evidence_read_error (Printexc.to_string exn))
+  match Fs_compat.get_fs_opt () with
+  | None -> Error (Evidence_read_error "eio_filesystem_unavailable")
+  | Some fs ->
+    let parent = Eio.Path.(fs / Filename.dirname path) in
+    let leaf = Filename.basename path in
+    let expected_length = Int64.of_int stat.Unix.st_size in
+    (match
+       Fs_compat.Capability_exact_read.read
+         ~parent
+         ~leaf
+         ~expected_length
+         ~max_length:verification_evidence_max_exact_read_bytes
+     with
+     | Error failure ->
+       Error (evidence_read_failure_of_exact_read_error failure.error)
+     | Ok observation ->
+       let exact_bytes =
+         Fs_compat.Capability_exact_read.observation_bytes observation
+       in
+       let exact_length = String.length exact_bytes in
+       let requested = min verification_evidence_max_bytes exact_length in
+       let raw = String.sub exact_bytes 0 requested in
+       let source_truncated = exact_length > requested in
+       match scan_utf8 raw with
+       | Utf8_valid -> Ok (raw, exact_length, source_truncated)
+       | Utf8_incomplete_at index when source_truncated ->
+         Ok (String.sub raw 0 index, exact_length, true)
+       | Utf8_incomplete_at _ | Utf8_invalid ->
+         Error Evidence_invalid_utf8)
 
 let inspect_artifact_reference ~base_path ~worker reference =
   let canonical_base =
@@ -327,15 +441,11 @@ let inspect_artifact_reference ~base_path ~worker reference =
               (Playground_paths.sanitize_keeper_name worker) ->
        (try
           let stat = Unix.stat canonical_target in
-          if stat.Unix.st_kind <> Unix.S_REG then
-            Evidence_artifact_unreadable
-              { reference; reason = Evidence_not_regular_file }
-          else
-            (match read_regular_file_prefix canonical_target stat with
-             | Error reason ->
-               Evidence_artifact_unreadable { reference; reason }
-             | Ok (content, bytes, truncated) ->
-               Evidence_artifact { reference; content; bytes; truncated })
+          match read_regular_file_prefix canonical_target stat with
+          | Error reason ->
+            Evidence_artifact_unreadable { reference; reason }
+          | Ok (content, bytes, truncated) ->
+            Evidence_artifact { reference; content; bytes; truncated }
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
@@ -347,7 +457,7 @@ let inspect_artifact_reference ~base_path ~worker reference =
        Evidence_artifact_unreadable
          { reference; reason = Evidence_outside_worker_playground })
 
-let inspect_submitted_evidence ~base_path ~request_id ~viewer =
+let inspect_submitted_evidence ~base_path ~request_id ~task_verifier ~viewer =
   match load_request_for_evidence base_path request_id with
   | Error reason -> Evidence_unavailable { request_id; reason }
   | Ok (request, evidence_refs) ->
@@ -358,8 +468,13 @@ let inspect_submitted_evidence ~base_path ~request_id ~viewer =
          ; reason = "verification request is already completed"
          }
      | `Pending | `Assigned _ ->
-       (match request.verifier with
-        | Some assigned_verifier when String.equal assigned_verifier viewer ->
+       (match request.status, request.verifier, task_verifier with
+        | ( `Assigned status_verifier
+          , Some request_verifier
+          , Some task_verifier )
+          when String.equal status_verifier viewer
+               && String.equal request_verifier viewer
+               && String.equal task_verifier viewer ->
           let items =
             List.map
               (fun reference ->
@@ -373,7 +488,7 @@ let inspect_submitted_evidence ~base_path ~request_id ~viewer =
               evidence_refs
           in
           Evidence_available { request; items }
-        | None | Some _ -> Evidence_metadata_only { request; viewer }))
+        | _ -> Evidence_metadata_only { request; viewer }))
 
 let list_request_headers base_path =
   let surface = "verification" in

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -335,10 +335,8 @@ let scan_utf8 bytes =
 let evidence_read_failure_of_owned_read_failure = function
   | Fs_compat.Ownership_boundary_rejected _ ->
     Evidence_outside_worker_playground
-  | Path_is_not_regular_file { kind = Unix.S_LNK; _ } ->
-    Evidence_symbolic_link
-  | Path_is_not_regular_file _ ->
-    Evidence_not_regular_file
+  | Path_is_not_regular_file { kind; _ } ->
+    if kind = Unix.S_LNK then Evidence_symbolic_link else Evidence_not_regular_file
   | Filesystem_identity_changed _ ->
     Evidence_changed_during_read
   | Owned_file_operation_failed { cause; _ } ->

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -17,6 +17,45 @@ type request_header = {
   status : request_status;
 }
 
+type evidence_read_failure =
+  | Evidence_missing
+  | Evidence_not_regular_file
+  | Evidence_outside_worker_playground
+  | Evidence_read_error of string
+
+type submitted_evidence_item =
+  | Evidence_note of string
+  | Evidence_artifact of
+      { reference : string
+      ; content : string
+      ; bytes : int
+      ; truncated : bool
+      }
+  | Evidence_artifact_unreadable of
+      { reference : string
+      ; reason : evidence_read_failure
+      }
+
+type submitted_evidence_access =
+  | Evidence_available of
+      { request : request_header
+      ; items : submitted_evidence_item list
+      }
+  | Evidence_metadata_only of
+      { request : request_header
+      ; viewer : string
+      }
+  | Evidence_unavailable of
+      { request_id : string
+      ; reason : string
+      }
+
+val evidence_read_failure_to_string : evidence_read_failure -> string
+val inspect_submitted_evidence :
+  base_path:string ->
+  request_id:string ->
+  viewer:string ->
+  submitted_evidence_access
 val verifications_dir : string -> string
 val request_path : string -> string -> string
 val list_request_headers : string -> request_header list

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -24,7 +24,6 @@ type evidence_read_failure =
   | Evidence_invalid_utf8
   | Evidence_symbolic_link
   | Evidence_changed_during_read
-  | Evidence_too_large
   | Evidence_read_error of string
 
 type submitted_evidence_item =
@@ -55,8 +54,8 @@ type submitted_evidence_access =
       }
 
 val evidence_read_failure_to_string : evidence_read_failure -> string
-val evidence_read_failure_of_exact_read_error :
-  Fs_compat.Capability_exact_read.error -> evidence_read_failure
+val evidence_read_failure_of_owned_read_failure :
+  Fs_compat.owned_regular_file_read_failure -> evidence_read_failure
 val inspect_submitted_evidence :
   base_path:string ->
   request_id:string ->

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -21,6 +21,10 @@ type evidence_read_failure =
   | Evidence_missing
   | Evidence_not_regular_file
   | Evidence_outside_worker_playground
+  | Evidence_invalid_utf8
+  | Evidence_symbolic_link
+  | Evidence_changed_during_read
+  | Evidence_too_large
   | Evidence_read_error of string
 
 type submitted_evidence_item =
@@ -51,9 +55,12 @@ type submitted_evidence_access =
       }
 
 val evidence_read_failure_to_string : evidence_read_failure -> string
+val evidence_read_failure_of_exact_read_error :
+  Fs_compat.Capability_exact_read.error -> evidence_read_failure
 val inspect_submitted_evidence :
   base_path:string ->
   request_id:string ->
+  task_verifier:string option ->
   viewer:string ->
   submitted_evidence_access
 val verifications_dir : string -> string

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -164,6 +164,38 @@ let test_parse_playground_repo_path () =
     None
     (parse "workspace/repo/.masc/playground/sangsu/repos/masc/lib/foo.ml")
 
+let test_parse_playground_file_path () =
+  let base_path = "/tmp/masc-base" in
+  let parse rel =
+    PP.parse_playground_file_path
+      ~base_path
+      ~abs_path:(Filename.concat base_path rel)
+  in
+  let parsed keeper_name relative_path =
+    Some PP.{ keeper_name; relative_path }
+  in
+  check bool "local playground artifact"
+    true
+    (parse ".masc/playground/executor/artifact.txt"
+     = parsed "executor" "artifact.txt");
+  check bool "docker playground artifact"
+    true
+    (parse ".masc/playground/docker/executor/artifact.txt"
+     = parsed "executor" "artifact.txt");
+  check bool "nested artifact"
+    true
+    (parse ".masc/playground/docker/executor/mind/report.txt"
+     = parsed "executor" "mind/report.txt");
+  check bool "outside playground rejected"
+    true
+    (parse "workspace/report.txt" = None);
+  check bool "dot-dot segment rejected"
+    true
+    (parse ".masc/playground/executor/../other/secret.txt" = None);
+  check bool "bundle root alone rejected"
+    true
+    (parse ".masc/playground/executor" = None)
+
 let () =
   run "Playground_paths"
     [
@@ -190,5 +222,6 @@ let () =
       ]);
       ("parse", [
         test_case "parse playground repo path" `Quick test_parse_playground_repo_path;
+        test_case "parse playground file path" `Quick test_parse_playground_file_path;
       ]);
     ]

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -37,6 +37,13 @@ let with_temp_dir f =
   let dir = Filename.temp_dir "masc_verify_test" "" in
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
+let with_eio_temp_dir f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fun.protect
+    ~finally:Fs_compat.clear_fs
+    (fun () -> with_temp_dir f)
+
 let contains_substring text needle =
   let text_len = String.length text in
   let needle_len = String.length needle in
@@ -318,11 +325,19 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
       ~verifier:"keeper-verifier-agent"
       ()
   with
-  | Ok request -> request
+  | Ok request ->
+    (match
+       V.assign_verifier
+         ~base_path
+         ~req_id:request.id
+         ~verifier:"keeper-verifier-agent"
+     with
+     | Ok assigned -> assigned
+     | Error detail -> Alcotest.fail detail)
   | Error detail -> Alcotest.fail detail
 
 let test_submitted_evidence_inspection_is_assigned_and_contained () =
-  with_temp_dir (fun base_path ->
+  with_eio_temp_dir (fun base_path ->
     let artifact_dir =
       Filename.concat
         base_path
@@ -337,6 +352,7 @@ let test_submitted_evidence_inspection_is_assigned_and_contained () =
        VS.inspect_submitted_evidence
          ~base_path
          ~request_id
+         ~task_verifier:(Some "keeper-verifier-agent")
          ~viewer:"keeper-verifier-agent"
      with
      | VS.Evidence_available
@@ -355,13 +371,14 @@ let test_submitted_evidence_inspection_is_assigned_and_contained () =
       VS.inspect_submitted_evidence
         ~base_path
         ~request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
         ~viewer:"keeper-sangsu-agent"
     with
     | VS.Evidence_metadata_only _ -> ()
     | _ -> Alcotest.fail "non-assigned keeper must receive metadata only")
 
 let test_submitted_evidence_inspection_rejects_cross_playground_path () =
-  with_temp_dir (fun base_path ->
+  with_eio_temp_dir (fun base_path ->
     let other_dir =
       Filename.concat
         base_path
@@ -376,6 +393,7 @@ let test_submitted_evidence_inspection_rejects_cross_playground_path () =
       VS.inspect_submitted_evidence
         ~base_path
         ~request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
         ~viewer:"keeper-verifier-agent"
     with
     | VS.Evidence_available
@@ -389,7 +407,7 @@ let test_submitted_evidence_inspection_rejects_cross_playground_path () =
     | _ -> Alcotest.fail "cross-playground artifact must remain unreadable")
 
 let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
-  with_temp_dir (fun base_path ->
+  with_eio_temp_dir (fun base_path ->
     let artifact_dir =
       Filename.concat
         base_path
@@ -405,6 +423,7 @@ let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
       VS.inspect_submitted_evidence
         ~base_path
         ~request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
         ~viewer:"keeper-verifier-agent"
     with
     | VS.Evidence_available
@@ -421,8 +440,170 @@ let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
         ascii_prefix content
     | _ -> Alcotest.fail "expected bounded UTF-8-safe artifact projection")
 
+let test_submitted_evidence_rejects_malformed_utf8 () =
+  with_eio_temp_dir (fun base_path ->
+    let artifact_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/executor"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let artifact_path = Filename.concat artifact_dir "malformed.txt" in
+    Fs_compat.save_file artifact_path "\xC3\x28";
+    let request_id = "vrf-malformed-evidence" in
+    ignore (create_evidence_request ~base_path ~request_id ~artifact_path);
+    match
+      VS.inspect_submitted_evidence
+        ~base_path
+        ~request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
+        ~viewer:"keeper-verifier-agent"
+    with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact_unreadable
+              { reason = VS.Evidence_invalid_utf8; _ }
+            :: _
+        ; _
+        } ->
+      ()
+    | _ -> Alcotest.fail "malformed UTF-8 must remain unreadable")
+
+let test_submitted_evidence_rejects_symlink_escape_and_fifo () =
+  with_eio_temp_dir (fun base_path ->
+    let artifact_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/executor"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let outside_path = Filename.concat base_path "outside-secret.txt" in
+    Fs_compat.save_file outside_path "outside-secret";
+    let symlink_path = Filename.concat artifact_dir "outside-link.txt" in
+    Unix.symlink outside_path symlink_path;
+    let symlink_request_id = "vrf-symlink-evidence" in
+    ignore
+      (create_evidence_request
+         ~base_path
+         ~request_id:symlink_request_id
+         ~artifact_path:symlink_path);
+    (match
+       VS.inspect_submitted_evidence
+         ~base_path
+         ~request_id:symlink_request_id
+         ~task_verifier:(Some "keeper-verifier-agent")
+         ~viewer:"keeper-verifier-agent"
+     with
+     | VS.Evidence_available
+         { items =
+             VS.Evidence_artifact_unreadable
+               { reason = VS.Evidence_outside_worker_playground; _ }
+             :: _
+         ; _
+         } ->
+       ()
+     | _ -> Alcotest.fail "symlink escape must remain unreadable");
+    let fifo_path = Filename.concat artifact_dir "evidence.fifo" in
+    Unix.mkfifo fifo_path 0o600;
+    let fifo_request_id = "vrf-fifo-evidence" in
+    ignore
+      (create_evidence_request
+         ~base_path
+         ~request_id:fifo_request_id
+         ~artifact_path:fifo_path);
+    match
+      VS.inspect_submitted_evidence
+        ~base_path
+        ~request_id:fifo_request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
+        ~viewer:"keeper-verifier-agent"
+    with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact_unreadable
+              { reason = VS.Evidence_not_regular_file; _ }
+            :: _
+        ; _
+        } ->
+      ()
+    | _ -> Alcotest.fail "FIFO evidence must remain unreadable")
+
+let test_changed_during_read_maps_to_typed_unreadable_reason () =
+  Alcotest.(check string)
+    "exact-read race remains typed"
+    "changed_during_read"
+    (VS.evidence_read_failure_of_exact_read_error
+       Fs_compat.Capability_exact_read.Changed_during_read
+     |> VS.evidence_read_failure_to_string)
+
+let test_submitted_evidence_requires_task_and_request_assignment () =
+  with_eio_temp_dir (fun base_path ->
+    let artifact_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/executor"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let artifact_path = Filename.concat artifact_dir "assignment.txt" in
+    Fs_compat.save_file artifact_path "assignment-secret";
+    let request_id = "vrf-assignment-authority" in
+    let pending =
+      match
+        V.create_request
+          ~base_path
+          ~request_id
+          ~task_id:"task-001"
+          ~output:
+            (`Assoc
+                [ ( "submitted_evidence"
+                  , `List [ `String artifact_path ] )
+                ])
+          ~criteria:[ V.Custom "inspect artifact" ]
+          ~worker:"keeper-executor-agent"
+          ~verifier:"keeper-verifier-agent"
+          ()
+      with
+      | Ok request -> request
+      | Error detail -> Alcotest.fail detail
+    in
+    let check_metadata_only label = function
+      | VS.Evidence_metadata_only _ -> ()
+      | _ -> Alcotest.fail label
+    in
+    check_metadata_only
+      "Pending request must not expose bytes"
+      (VS.inspect_submitted_evidence
+         ~base_path
+         ~request_id:pending.id
+         ~task_verifier:(Some "keeper-verifier-agent")
+         ~viewer:"keeper-verifier-agent");
+    let assigned =
+      match
+        V.assign_verifier
+          ~base_path
+          ~req_id:pending.id
+          ~verifier:"keeper-verifier-agent"
+      with
+      | Ok request -> request
+      | Error detail -> Alcotest.fail detail
+    in
+    check_metadata_only
+      "task phase verifier mismatch must not expose bytes"
+      (VS.inspect_submitted_evidence
+         ~base_path
+         ~request_id:assigned.id
+         ~task_verifier:(Some "keeper-sangsu-agent")
+         ~viewer:"keeper-verifier-agent");
+    check_metadata_only
+      "unassigned task phase must not expose bytes"
+      (VS.inspect_submitted_evidence
+         ~base_path
+         ~request_id:assigned.id
+         ~task_verifier:None
+         ~viewer:"keeper-verifier-agent"))
+
 let test_keeper_task_projection_exposes_snapshot_only_to_assigned_verifier () =
-  with_temp_dir (fun base_path ->
+  with_eio_temp_dir (fun base_path ->
     let config = W.default_config base_path in
     ignore (W.init config ~agent_name:None);
     ignore
@@ -718,6 +899,14 @@ let () =
         test_submitted_evidence_inspection_rejects_cross_playground_path;
       Alcotest.test_case "submitted evidence bounded UTF-8" `Quick
         test_submitted_evidence_inspection_is_bounded_and_utf8_safe;
+      Alcotest.test_case "submitted evidence rejects malformed UTF-8" `Quick
+        test_submitted_evidence_rejects_malformed_utf8;
+      Alcotest.test_case "submitted evidence rejects symlink and FIFO" `Quick
+        test_submitted_evidence_rejects_symlink_escape_and_fifo;
+      Alcotest.test_case "submitted evidence race remains typed" `Quick
+        test_changed_during_read_maps_to_typed_unreadable_reason;
+      Alcotest.test_case "submitted evidence requires exact assignment" `Quick
+        test_submitted_evidence_requires_task_and_request_assignment;
       Alcotest.test_case "keeper task projection assigned verifier only" `Quick
         test_keeper_task_projection_exposes_snapshot_only_to_assigned_verifier;
       Alcotest.test_case "assign verifier" `Quick test_assign_verifier;

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -416,7 +416,8 @@ let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
     Fs_compat.mkdir_p artifact_dir;
     let artifact_path = Filename.concat artifact_dir "large-artifact.txt" in
     let ascii_prefix = String.make 19_999 'a' in
-    Fs_compat.save_file artifact_path (ascii_prefix ^ "한글");
+    let full_artifact = ascii_prefix ^ "한글" ^ String.make 250_000 'z' in
+    Fs_compat.save_file artifact_path full_artifact;
     let request_id = "vrf-bounded-evidence" in
     ignore (create_evidence_request ~base_path ~request_id ~artifact_path);
     match
@@ -433,7 +434,8 @@ let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
             :: _
         ; _
         } ->
-      Alcotest.(check int) "full artifact byte count preserved" 20_005 bytes;
+      Alcotest.(check int) "full artifact byte count preserved"
+        (String.length full_artifact) bytes;
       Alcotest.(check int) "UTF-8 boundary stays below 20KB cap" 19_999
         (String.length content);
       Alcotest.(check string) "incomplete UTF-8 codepoint removed"
@@ -532,8 +534,8 @@ let test_changed_during_read_maps_to_typed_unreadable_reason () =
   Alcotest.(check string)
     "exact-read race remains typed"
     "changed_during_read"
-    (VS.evidence_read_failure_of_exact_read_error
-       Fs_compat.Capability_exact_read.Changed_during_read
+    (VS.evidence_read_failure_of_owned_read_failure
+       (Fs_compat.Filesystem_identity_changed { path = "artifact.txt" })
      |> VS.evidence_read_failure_to_string)
 
 let test_submitted_evidence_requires_task_and_request_assignment () =

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -7,6 +7,7 @@ module V = Masc.Verification
 module P = Masc.Otel_metric_store
 module VS = Workspace_verification_store
 module CU = Workspace_utils
+module W = Workspace_core
 
 let persistence_surface = "verification"
 
@@ -35,6 +36,16 @@ let rec rm_rf path =
 let with_temp_dir f =
   let dir = Filename.temp_dir "masc_verify_test" "" in
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop offset =
+    if offset + needle_len > text_len then false
+    else if String.sub text offset needle_len = needle then true
+    else loop (offset + 1)
+  in
+  needle_len = 0 || loop 0
 
 (* --- Criterion tests --- *)
 
@@ -288,6 +299,196 @@ let test_list_requests_ignores_legacy_root_entries () =
       before
       (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error))
 
+let create_evidence_request ~base_path ~request_id ~artifact_path =
+  match
+    V.create_request
+      ~base_path
+      ~request_id
+      ~task_id:"task-001"
+      ~output:
+        (`Assoc
+            [ ( "submitted_evidence"
+              , `List
+                  [ `String artifact_path
+                  ; `String "executor summary"
+                  ] )
+            ])
+      ~criteria:[ V.Custom "inspect artifact" ]
+      ~worker:"keeper-executor-agent"
+      ~verifier:"keeper-verifier-agent"
+      ()
+  with
+  | Ok request -> request
+  | Error detail -> Alcotest.fail detail
+
+let test_submitted_evidence_inspection_is_assigned_and_contained () =
+  with_temp_dir (fun base_path ->
+    let artifact_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/executor"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let artifact_path = Filename.concat artifact_dir "artifact-task-001.txt" in
+    Fs_compat.save_file artifact_path "verified artifact\nsecond line";
+    let request_id = "vrf-evidence-inspection" in
+    ignore (create_evidence_request ~base_path ~request_id ~artifact_path);
+    (match
+       VS.inspect_submitted_evidence
+         ~base_path
+         ~request_id
+         ~viewer:"keeper-verifier-agent"
+     with
+     | VS.Evidence_available
+         { items =
+             VS.Evidence_artifact { content; truncated = false; _ }
+             :: VS.Evidence_note "executor summary"
+             :: []
+         ; _
+         } ->
+       Alcotest.(check string)
+         "assigned verifier reads producer artifact"
+         "verified artifact\nsecond line"
+         content
+     | _ -> Alcotest.fail "expected assigned verifier evidence projection");
+    match
+      VS.inspect_submitted_evidence
+        ~base_path
+        ~request_id
+        ~viewer:"keeper-sangsu-agent"
+    with
+    | VS.Evidence_metadata_only _ -> ()
+    | _ -> Alcotest.fail "non-assigned keeper must receive metadata only")
+
+let test_submitted_evidence_inspection_rejects_cross_playground_path () =
+  with_temp_dir (fun base_path ->
+    let other_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/other"
+    in
+    Fs_compat.mkdir_p other_dir;
+    let artifact_path = Filename.concat other_dir "secret.txt" in
+    Fs_compat.save_file artifact_path "must not leak";
+    let request_id = "vrf-cross-playground" in
+    ignore (create_evidence_request ~base_path ~request_id ~artifact_path);
+    match
+      VS.inspect_submitted_evidence
+        ~base_path
+        ~request_id
+        ~viewer:"keeper-verifier-agent"
+    with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact_unreadable
+              { reason = VS.Evidence_outside_worker_playground; _ }
+            :: _
+        ; _
+        } ->
+      ()
+    | _ -> Alcotest.fail "cross-playground artifact must remain unreadable")
+
+let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
+  with_temp_dir (fun base_path ->
+    let artifact_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/executor"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let artifact_path = Filename.concat artifact_dir "large-artifact.txt" in
+    let ascii_prefix = String.make 19_999 'a' in
+    Fs_compat.save_file artifact_path (ascii_prefix ^ "한글");
+    let request_id = "vrf-bounded-evidence" in
+    ignore (create_evidence_request ~base_path ~request_id ~artifact_path);
+    match
+      VS.inspect_submitted_evidence
+        ~base_path
+        ~request_id
+        ~viewer:"keeper-verifier-agent"
+    with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact
+              { content; bytes; truncated = true; _ }
+            :: _
+        ; _
+        } ->
+      Alcotest.(check int) "full artifact byte count preserved" 20_005 bytes;
+      Alcotest.(check int) "UTF-8 boundary stays below 20KB cap" 19_999
+        (String.length content);
+      Alcotest.(check string) "incomplete UTF-8 codepoint removed"
+        ascii_prefix content
+    | _ -> Alcotest.fail "expected bounded UTF-8-safe artifact projection")
+
+let test_keeper_task_projection_exposes_snapshot_only_to_assigned_verifier () =
+  with_temp_dir (fun base_path ->
+    let config = W.default_config base_path in
+    ignore (W.init config ~agent_name:None);
+    ignore
+      (W.add_task
+         config
+         ~title:"Produce one verifiable artifact"
+         ~priority:1
+         ~description:"");
+    let artifact_dir =
+      Filename.concat
+        base_path
+        ".masc/playground/docker/executor"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let artifact_path = Filename.concat artifact_dir "artifact-task-001.txt" in
+    Fs_compat.save_file artifact_path "full-cycle-evidence";
+    let request_id = "vrf-task-list-projection" in
+    ignore (create_evidence_request ~base_path ~request_id ~artifact_path);
+    let backlog = W.read_backlog config in
+    let tasks =
+      List.map
+        (fun (task : Masc_domain.task) ->
+           { task with
+             task_status =
+               Masc_domain.AwaitingVerification
+                 { assignee = "keeper-executor-agent"
+                 ; submitted_at = "2026-07-28T00:00:00Z"
+                 ; verification_id = request_id
+                 ; phase =
+                     Masc_domain.Verifier_assigned
+                       { verifier = "keeper-verifier-agent" }
+                 }
+           })
+        backlog.tasks
+    in
+    W.write_backlog
+      config
+      { backlog with tasks; version = backlog.version + 1 };
+    let assigned =
+      W.list_tasks
+        config
+        ~verification_viewer:"keeper-verifier-agent"
+    in
+    Alcotest.(check bool)
+      "assigned verifier receives content"
+      true
+      (contains_substring assigned "full-cycle-evidence");
+    let other =
+      W.list_tasks
+        config
+        ~verification_viewer:"keeper-sangsu-agent"
+    in
+    Alcotest.(check bool)
+      "other keeper receives no content"
+      false
+      (contains_substring other "full-cycle-evidence");
+    Alcotest.(check bool)
+      "other keeper keeps request metadata"
+      true
+      (contains_substring other request_id);
+    let external_projection = W.list_tasks config in
+    Alcotest.(check bool)
+      "external task list receives no content"
+      false
+      (contains_substring external_projection "full-cycle-evidence"))
+
 let test_assign_verifier () =
   with_temp_dir (fun base_path ->
     match V.create_request ~base_path ~task_id:"t1"
@@ -511,6 +712,14 @@ let () =
         test_list_requests_ignores_legacy_only_stale_entries;
       Alcotest.test_case "list requests ignores legacy root entries" `Quick
         test_list_requests_ignores_legacy_root_entries;
+      Alcotest.test_case "submitted evidence assigned and contained" `Quick
+        test_submitted_evidence_inspection_is_assigned_and_contained;
+      Alcotest.test_case "submitted evidence rejects cross playground" `Quick
+        test_submitted_evidence_inspection_rejects_cross_playground_path;
+      Alcotest.test_case "submitted evidence bounded UTF-8" `Quick
+        test_submitted_evidence_inspection_is_bounded_and_utf8_safe;
+      Alcotest.test_case "keeper task projection assigned verifier only" `Quick
+        test_keeper_task_projection_exposes_snapshot_only_to_assigned_verifier;
       Alcotest.test_case "assign verifier" `Quick test_assign_verifier;
       Alcotest.test_case "cross-agent assign fail" `Quick test_assign_verifier_cross_agent_fail;
       Alcotest.test_case "submit verdict" `Quick test_submit_verdict;


### PR DESCRIPTION
## Summary

- extend the existing `keeper_tasks_list` read-only projection for an assigned verifier
- inspect only evidence refs already stored in the Verification request SSOT
- accept only canonical regular files inside the submitting Keeper's playground
- return a bounded 20KB UTF-8-safe text snapshot or a typed unreadable reason
- keep non-assigned and external callers metadata-only

## Boundary

- no new tool or store
- no lease, settlement, nonce, replay, migration, or arbitrary cross-sandbox `Read`
- caller authorization comes from the assigned verification request, not a hardcoded `verifier` name

## Validation

- `ocamlformat` check: pass
- diff check: pass
- production interface compilation progressed through the repaired MLI/wrapper errors
- final focused build/tests were blocked by the shared Dune lock; PR CI is the broad authority

## Live proof after merge/build

1. Start a fresh Task with an evidence-producing worker.
2. Let the worker autonomously claim/start/write/submit.
3. Do not broadcast or post evidence as operator.
4. Confirm the assigned verifier autonomously observes the pending request.
5. Confirm `keeper_tasks_list` includes the bounded typed evidence inspection for that verifier only.
6. Confirm the verifier approves/rejects and the Task transitions terminal without cross-sandbox `Read`.

## Follow-ups outside this PR

- Dashboard/API currently flattens typed `required_artifacts` and `submitted_evidence`; tracked separately in #26001.
- The previous live request stored a `fail` verdict with positively worded reasoning after operator intervention. Re-evaluate on the clean autonomous run before classifying it as a mapping defect.
