### PR TITLE
fix(keeper): yield turns on deferred tools

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -162,6 +162,8 @@ let dispatch_after_provider_transcript_admission ~messages ~dispatch =
 
 let terminal_effect_boundary_decision = function
   | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
+  | Keeper_tools_oas.External_effect_deferred ->
+    Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
   | Keeper_tools_oas.Terminal_effect_completed ->
     Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
   | Keeper_tools_oas.Terminal_effect_failed

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -35,9 +35,11 @@ type autonomous_yield_request = {
 val terminal_effect_boundary_decision
   :  Keeper_tools_oas.terminal_effect_state
   -> (Runtime_agent.cooperative_yield_decision, Agent_sdk.Error.sdk_error) result
-(** Production boundary projection for terminal Keeper tools. Failed terminal
-    effects retain their typed [Tool_result.tool_failure_class] in the exact
-    structured Keeper error envelope. *)
+(** Production boundary projection for Keeper tool results. Deferred external
+    effects yield the current provider loop so their durable resolution can
+    wake a later turn. Failed terminal effects retain their typed
+    [Tool_result.tool_failure_class] in the exact structured Keeper error
+    envelope. *)
 
 module For_testing : sig
   val sse_event_progress_kind : Agent_sdk.Types.sse_event -> string option

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -17,6 +17,7 @@ type terminal_effect_failure =
 
 type terminal_effect_state =
   | Terminal_effect_open
+  | External_effect_deferred
   | Terminal_effect_completed
   | Terminal_effect_failed of terminal_effect_failure
 

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -19,6 +19,7 @@ type terminal_effect_failure =
 
 type terminal_effect_state =
   | Terminal_effect_open
+  | External_effect_deferred
   | Terminal_effect_completed
   | Terminal_effect_failed of terminal_effect_failure
 

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -124,24 +124,44 @@ let make_tool_bundle
   (* Every descriptor-declared model tool is materialized. The turn hook sends
      this exact list to OAS without per-Keeper or per-turn reduction. *)
   let model_visible_descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
-  (* The bundle lives for exactly one Agent run. Its typed terminal-effect
+  (* The bundle lives for exactly one Agent run. Its typed tool-boundary
      state is request-scoped and observed by the OAS tool-boundary probe only
-     after the whole tool batch and checkpoint sink have completed. A proven
-     terminal failure dominates completion regardless of callback order.
-     Failure is sticky so its first diagnostic remains authoritative. *)
+     after the whole tool batch and checkpoint sink have completed. Deferred
+     external effects stop the provider loop until their durable resolution
+     wakes a later turn. A terminal completion supersedes a defer in the same
+     batch; a proven terminal failure dominates every state regardless of
+     callback order. Failure is sticky so its first diagnostic remains
+     authoritative. *)
   let terminal_effect_state = Atomic.make Terminal_effect_open in
-  let mark_terminal_effect_completed () =
+  let mark_external_effect_deferred () =
     ignore
       (Atomic.compare_and_set
          terminal_effect_state
          Terminal_effect_open
-         Terminal_effect_completed)
+         External_effect_deferred)
+  in
+  let mark_terminal_effect_completed () =
+    let rec transition () =
+      match Atomic.get terminal_effect_state with
+      | Terminal_effect_completed | Terminal_effect_failed _ -> ()
+      | (Terminal_effect_open | External_effect_deferred) as current ->
+        if
+          not
+            (Atomic.compare_and_set
+               terminal_effect_state
+               current
+               Terminal_effect_completed)
+        then transition ()
+    in
+    transition ()
   in
   let mark_terminal_effect_failed failure =
     let rec transition () =
       match Atomic.get terminal_effect_state with
       | Terminal_effect_failed _ -> ()
-      | (Terminal_effect_open | Terminal_effect_completed) as current ->
+      | ( Terminal_effect_open
+        | External_effect_deferred
+        | Terminal_effect_completed ) as current ->
         if
           not
             (Atomic.compare_and_set
@@ -185,6 +205,7 @@ let make_tool_bundle
                  ?gate_grant
                  ?record_gate_result
                  ?on_completed
+                 ~on_deferred:mark_external_effect_deferred
                  ?on_failed
                  ~pre_validate_input:(fun input ->
                    match

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -24,6 +24,7 @@ let make_keeper_tool_handler
       ?gate_grant
       ?record_gate_result
       ?on_completed
+      ?on_deferred
       ?on_failed
       ?(pre_validate_input = fun input -> Ok input)
       ?(translate_input = fun j -> j)
@@ -44,6 +45,8 @@ let make_keeper_tool_handler
     (match result with
      | Tool_result.Completed _ ->
        Option.iter (fun completed -> completed ()) on_completed
+     | Tool_result.Deferred _ ->
+       Option.iter (fun deferred -> deferred ()) on_deferred
      | Tool_result.Failed { class_; message; _ } ->
        let effect_disposition =
          Option.value
@@ -61,7 +64,7 @@ let make_keeper_tool_handler
                  ; diagnostic = message
                  })
             on_failed)
-     | Tool_result.Deferred _ -> ());
+    );
     result
   in
   fun ?oas_invocation raw_input ->

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -34,6 +34,7 @@ val make_keeper_tool_handler
   -> ?record_gate_result:
        (operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit)
   -> ?on_completed:(unit -> unit)
+  -> ?on_deferred:(unit -> unit)
   -> ?on_failed:(Keeper_tools_oas.terminal_effect_failure -> unit)
   -> ?pre_validate_input:
        (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -316,10 +316,11 @@ let admit_autonomous_with_token ~yield_to_chat_backlog ~base_path ~keeper_name f
      lock-only, non-suspending peek and is the SSOT signal that closes the
      gap: the autonomous lane cooperates on the same backlog the consumer
      drains, so the consumer's [in_flight = None] window opens
-     deterministically instead of racing the next autonomous cycle. A leased
-     receipt remains active until its terminal decision commits, so the
-     autonomous lane must also yield during the short lease-to-admission and
-     admission-to-finalization windows.
+     deterministically instead of racing the next autonomous cycle. Once a
+     receipt is leased, the actual per-Keeper turn mutex is the authority for
+     whether its chat turn is still executing. An inflight receipt with a free
+     mutex may be between delivery and finalization or stranded after failure;
+     it must not become a second, durable global turn lock.
 
      [yield_to_chat_backlog:false] (the manual-compaction lane) skips only
      that queue peek: the backlog yield presumes the chat consumer can make
@@ -339,9 +340,10 @@ let admit_autonomous_with_token ~yield_to_chat_backlog ~base_path ~keeper_name f
            failures. They are not evidence of queued work and therefore
            cannot close an otherwise independent autonomous lane. *)
         match List.length snapshot.pending, List.length snapshot.inflight with
-        | 0, 0 -> None
-        | pending_count, inflight_count ->
-          Some (Chat_backlog { pending_count; inflight_count }))
+        | 0, _ -> None
+        | pending_count, 0 ->
+          Some (Chat_backlog { pending_count; inflight_count = 0 })
+        | _, _ -> None)
       else None
     in
     (match chat_backlog with

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -44,9 +44,12 @@ type autonomous_block =
       { pending_count : int
       ; inflight_count : int
       }
-    (** The slot mutex itself is free, but active [Keeper_chat_queue]
-        receipts exist for this keeper; the standard autonomous lane yields
-        so the chat consumer can drain them. Distinct from [Turn_busy None]
+    (** The slot mutex itself is free and pending [Keeper_chat_queue] receipts
+        exist without a currently leased receipt; the standard autonomous lane
+        yields so the chat consumer can drain them. Inflight receipts are not
+        a second turn lock: an executing chat is fenced by the actual slot,
+        while a stranded/finalizing receipt must not halt unrelated progress.
+        Distinct from [Turn_busy None]
         (a held slot whose holder has not yet published its info): before
         this variant existed both cases logged as "holder info not yet
         published", which mis-directed the #24865 diagnosis toward a stale

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -69,7 +69,8 @@ let make_meta ?(name = "keeper-exec-tools") () =
       (`Assoc
         [
           ("name", `String name);
-          ("agent_name", `String name);
+          ( "agent_name"
+          , `String (Masc.Keeper_identity.keeper_agent_name name) );
           ("trace_id", `String "keeper-exec-tools-trace");
           ("allowed_paths", `List [ `String "*" ]);
         ])
@@ -101,6 +102,15 @@ let with_exec_fixture
           ~proc_mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env);
       let config = Masc.Workspace.default_config dir in
+      (match
+         Masc.Keeper_approval_queue.install_persistence
+           ~base_path:config.base_path
+       with
+       | Ok _ -> ()
+       | Error error ->
+         fail
+           ("Gate persistence fixture failed: "
+            ^ Masc.Keeper_approval_queue.install_error_to_string error));
       let meta =
         let meta = { (make_meta ()) with allowed_paths = [ config.base_path ] } in
         if always_allow then { meta with always_allow = Some true } else meta
@@ -2221,6 +2231,102 @@ let test_manual_gate_defers_web_tools_before_network () =
                 [ search; fetch ];
               check int "Manual Gate executes no WebFetch callback" 0 !fetch_calls)))
 
+let test_approved_web_search_grant_executes_exact_request () =
+  with_exec_fixture "keeper_tool_dispatch_approved_web_search"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+      (match
+         Masc.Keeper_gate_mode.set
+           config
+           ~actor:"test"
+           Masc.Keeper_gate_mode.Manual
+       with
+       | Ok _ -> ()
+       | Error detail -> fail ("failed to select Manual Gate mode: " ^ detail));
+      let input = `Assoc [ "query", `String "hourly scheduled search" ] in
+      let first =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~publication_recovery
+          ~ctx_work
+          ~name:"WebSearch"
+          ~input
+          ()
+      in
+      (match first.disposition with
+       | Tool_result.Deferred () -> ()
+       | Tool_result.Completed () | Tool_result.Failed _ ->
+         fail "approval-gated WebSearch did not defer before execution");
+      let approval_id =
+        match
+          Masc.Keeper_approval_queue.list_pending_entries_for_workspace
+            ~base_path:config.base_path
+        with
+        | Ok [ entry ] -> entry.id
+        | Ok entries ->
+          failf "expected one pending WebSearch approval, got %d" (List.length entries)
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.storage_error_to_string error)
+      in
+      (match
+         Masc.Keeper_approval_queue.resolve_with_policy
+           ~base_path:config.base_path
+           ~id:approval_id
+           ~decision:Masc.Keeper_approval_queue.Decision.Approve
+           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ()
+       with
+       | Ok _ -> ()
+       | Error error ->
+         fail (Masc.Keeper_approval_queue.resolve_error_to_string error));
+      let resolution : Keeper_event_queue.hitl_resolution =
+        { approval_id
+        ; decision = Keeper_event_queue.Hitl_approved
+        ; channel =
+            Keeper_continuation_channel.unrouted
+              "approved WebSearch test"
+        }
+      in
+      let grant =
+        match Masc.Keeper_gate.cycle_grant_of_resolution resolution with
+        | Some grant -> grant
+        | None -> fail "approved WebSearch resolution did not create a grant"
+      in
+      Masc.Tool_misc.with_web_search_simulation_for_test
+        ~outcomes:
+          [ ( "duckduckgo"
+            , `Hits
+                [ ( "Scheduled result"
+                  , "https://example.com/scheduled"
+                  , "approved exact WebSearch"
+                  )
+                ] )
+          ]
+        (fun () ->
+          let second =
+            KET.execute_keeper_tool_call_with_outcome
+              ~config
+              ~meta
+              ~publication_recovery
+              ~ctx_work
+              ~gate_grant:grant
+              ~name:"WebSearch"
+              ~input
+              ()
+          in
+          check string "approved WebSearch executes" "success"
+            (outcome_label second.disposition));
+      match
+        Masc.Keeper_approval_queue.approved_resolution_state
+          ~base_path:config.base_path
+          ~id:approval_id
+      with
+      | Ok Masc.Keeper_approval_queue.Resolution_consumed -> ()
+      | Ok Masc.Keeper_approval_queue.Resolution_unconsumed ->
+        fail "approved WebSearch did not consume its one-shot grant"
+      | Error error ->
+        fail (Masc.Keeper_approval_queue.grant_error_to_string error))
+
 let workflow_rejection_message =
   "Invalid task state: Self-approval not allowed: verifier must be a different agent"
 
@@ -2714,6 +2820,8 @@ let test_invalid_surface_post_input_stays_correction_capable () =
         | Ok _ -> fail "handler-level invalid terminal input unexpectedly succeeded");
        (match bundle.terminal_effect_state () with
         | Masc.Keeper_tools_oas.Terminal_effect_open -> ()
+        | Masc.Keeper_tools_oas.External_effect_deferred ->
+          fail "invalid terminal input unexpectedly deferred an external effect"
         | Masc.Keeper_tools_oas.Terminal_effect_completed ->
           fail "invalid terminal input completed the terminal effect"
         | Masc.Keeper_tools_oas.Terminal_effect_failed _ ->
@@ -2733,6 +2841,8 @@ let test_invalid_surface_post_input_stays_correction_capable () =
         | Masc.Keeper_tools_oas.Terminal_effect_completed -> ()
         | Masc.Keeper_tools_oas.Terminal_effect_open ->
           fail "corrected terminal input left the terminal effect open"
+        | Masc.Keeper_tools_oas.External_effect_deferred ->
+          fail "corrected terminal input unexpectedly deferred an external effect"
         | Masc.Keeper_tools_oas.Terminal_effect_failed _ ->
           fail "corrected terminal input failed the terminal effect");
        let chat_path =
@@ -2758,6 +2868,8 @@ let test_invalid_surface_post_input_stays_correction_capable () =
        | Masc.Keeper_tools_oas.Terminal_effect_failed _ -> ()
        | Masc.Keeper_tools_oas.Terminal_effect_open ->
          fail "later failure reopened the completed terminal effect"
+       | Masc.Keeper_tools_oas.External_effect_deferred ->
+         fail "later failure unexpectedly became an external defer"
        | Masc.Keeper_tools_oas.Terminal_effect_completed ->
          fail "later failure was hidden by the completed terminal effect")
 ;;
@@ -2842,6 +2954,101 @@ let with_openai_tool_call_server ~tool_name ~tool_input f =
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
   let result = f ~sw ~net ~base_url in
   result, !provider_call_count
+;;
+
+let test_deferred_web_search_yields_before_provider_retry () =
+  with_exec_fixture
+    ~bind_eio_context:true
+    "deferred_web_search_yield"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"test"
+            Masc.Keeper_gate_mode.Manual
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to select Manual Gate mode: " ^ detail));
+       let bundle =
+         Masc.Keeper_tools_oas_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       let runtime_result, provider_call_count =
+         with_openai_tool_call_server
+           ~tool_name:"WebSearch"
+           ~tool_input:
+             (`Assoc [ "query", `String "hourly scheduled search" ])
+         @@ fun ~sw ~net ~base_url ->
+         let provider_cfg =
+           Llm_provider.Provider_config.make
+             ~kind:Llm_provider.Provider_config.OpenAI_compat
+             ~model_id:"deferred-effect-model"
+             ~base_url
+             ~api_key:"test-key"
+             ~request_path:"/chat/completions"
+             ~tool_stream:false
+             ()
+         in
+         let runtime_config =
+           Runtime_agent.default_config
+             ~name:"deferred-effect-runtime"
+             ~provider_cfg
+             ~system_prompt:"Search for the requested tool."
+             ~tools:bundle.tools
+         in
+         Runtime_agent.run_blocks
+           ~sw
+           ~net
+           ~config:runtime_config
+           ~cooperative_yield_probe:(fun _boundary ->
+             Masc.Keeper_agent_run.terminal_effect_boundary_decision
+               (bundle.terminal_effect_state ()))
+           [ Agent_sdk.Types.Text "search for the tool" ]
+       in
+       check int
+         "deferred effect stops before a second provider call"
+         1
+         provider_call_count;
+       (match
+          Masc.Keeper_approval_queue.list_pending_entries_for_workspace
+            ~base_path:config.base_path
+        with
+        | Ok [ { tool_name = "network_read"; _ } ] -> ()
+        | Ok entries ->
+          failf
+            "deferred WebSearch produced %d unexpected approval rows"
+            (List.length entries)
+        | Error error ->
+          fail
+            (Masc.Keeper_approval_queue.storage_error_to_string error));
+       (match runtime_result with
+        | Ok
+            { Runtime_agent.stop_reason =
+                Runtime_agent.Yielded_to_durable_stimulus _
+            ; _
+            } ->
+          ()
+        | Ok result ->
+          failf
+            "deferred effect returned stop_reason=%s"
+            (Masc.Keeper_execution_receipt_types.stop_reason_to_string
+               result.Runtime_agent.stop_reason)
+        | Error error ->
+          failf
+            "deferred effect failed instead of yielding: %s"
+            (Agent_sdk.Error.to_string error));
+       match bundle.terminal_effect_state () with
+       | Masc.Keeper_tools_oas.External_effect_deferred -> ()
+       | Masc.Keeper_tools_oas.Terminal_effect_open ->
+         fail "deferred effect was not observed at the tool boundary"
+       | Masc.Keeper_tools_oas.Terminal_effect_completed ->
+         fail "deferred effect became terminal completion"
+       | Masc.Keeper_tools_oas.Terminal_effect_failed _ ->
+         fail "deferred effect became terminal failure")
 ;;
 
 let test_surface_post_append_failure_does_not_complete_terminal_effect () =
@@ -2930,12 +3137,15 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                  (contains_substring failure.diagnostic chat_path)
              | Masc.Keeper_tools_oas.Terminal_effect_open ->
                fail "failed surface delivery left the terminal effect open"
+             | Masc.Keeper_tools_oas.External_effect_deferred ->
+               fail "failed surface delivery became an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                fail "failed surface delivery set terminal completion");
             let first_terminal_failure =
               match terminal_state with
               | Masc.Keeper_tools_oas.Terminal_effect_failed failure -> failure
               | Masc.Keeper_tools_oas.Terminal_effect_open
+              | Masc.Keeper_tools_oas.External_effect_deferred
               | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                 fail "failed surface delivery lost its terminal failure"
             in
@@ -2961,6 +3171,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                  (failure = first_terminal_failure)
              | Masc.Keeper_tools_oas.Terminal_effect_open ->
                fail "later success reopened the failed terminal effect"
+             | Masc.Keeper_tools_oas.External_effect_deferred ->
+               fail "later success changed failure into an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                fail "later success overwrote the failed terminal effect");
             Unix.unlink chat_path;
@@ -3051,6 +3263,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                  (contains_substring failure.diagnostic chat_path)
              | Masc.Keeper_tools_oas.Terminal_effect_open ->
                fail "runtime terminal failure was not recorded"
+             | Masc.Keeper_tools_oas.External_effect_deferred ->
+               fail "runtime terminal failure became an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                fail "runtime terminal failure became completion");
             check int
@@ -3156,6 +3370,8 @@ let () =
         test_public_masc_web_fetch_reaches_localhost_after_gate;
       test_case "Manual Gate defers web tools before network" `Quick
         test_manual_gate_defers_web_tools_before_network;
+      test_case "approved WebSearch grant executes exact request" `Quick
+        test_approved_web_search_grant_executes_exact_request;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "Manual Gate defers tool_execute before process" `Quick
@@ -3174,6 +3390,8 @@ let () =
         test_malformed_json_looking_success_stays_success;
       test_case "only typed producer failure is failure" `Quick
         test_only_typed_producer_failure_is_failure;
+      test_case "deferred WebSearch yields before provider retry" `Quick
+        test_deferred_web_search_yields_before_provider_retry;
       test_case "invalid surface input stays correction-capable" `Quick
         test_invalid_surface_post_input_stays_correction_capable;
       test_case "surface append failure is not terminal completion" `Quick

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -643,7 +643,9 @@ let test_autonomous_yields_to_queued_connector_message () =
    | `Ran () ->
      check "run_if_free must not admit while a connector message is queued" false);
   (* Leasing changes the receipt to Inflight but does not make it disappear.
-     The autonomous lane keeps yielding until the terminal decision commits. *)
+     The actual turn mutex, not that durable receipt, is the execution fence.
+     A free mutex plus an inflight receipt must stay progress-capable even when
+     a second message is pending — this is the live timeout/orphan shape. *)
   let lease =
     match Keeper_chat_queue.lease_next ~keeper_name with
     | `Leased lease -> Some lease
@@ -651,11 +653,21 @@ let test_autonomous_yields_to_queued_connector_message () =
       check "lease_next leases the queued connector message" false;
       None
   in
+  (match Keeper_chat_queue.enqueue ~keeper_name { queued_message with content = "next" } with
+   | Ok _ -> ()
+   | Error error ->
+     check
+       ("second enqueue succeeds: "
+        ^ Keeper_chat_queue.mutation_error_to_string error)
+       false);
   let inflight = Keeper_chat_queue.snapshot ~keeper_name in
   check "leased receipt remains visible" (List.length inflight.inflight = 1);
+  check "second receipt remains pending" (List.length inflight.pending = 1);
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy _ -> check "run_if_free yields while the receipt is inflight" true
-   | `Ran () -> check "run_if_free must not overtake an inflight receipt" false);
+   | `Ran () ->
+     check "stranded/finalizing inflight receipt does not become a second lock" true
+   | `Busy _ ->
+     check "inflight receipt with a free turn mutex must not halt progress" false);
   (match lease with
    | None -> ()
    | Some lease ->
@@ -668,6 +680,29 @@ let test_autonomous_yields_to_queued_connector_message () =
       | `Finalized _ -> ()
       | `Unknown_lease | `Error _ ->
         check "finalize commits the terminal receipt" false));
+  (* With the inflight receipt gone, the still-pending chat is again the
+     authoritative backlog and the autonomous lane yields to its consumer. *)
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy (Keeper_turn_admission.Chat_backlog
+       { pending_count = 1; inflight_count = 0 }) ->
+     check "pending-only backlog still has chat priority" true
+   | `Busy _ | `Ran () ->
+     check "pending-only backlog must retain chat priority" false);
+  (match Keeper_chat_queue.lease_next ~keeper_name with
+   | `Leased lease ->
+     (match
+        Keeper_chat_queue.finalize
+          ~keeper_name
+          ~lease_id:lease.lease_id
+          ~outcome:
+            (Keeper_chat_queue.Mark_delivered
+               { completed_at = 3.0; outcome_ref = None })
+      with
+      | `Finalized _ -> ()
+      | `Unknown_lease | `Error _ ->
+        check "second finalize commits the terminal receipt" false)
+   | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
+     check "second receipt leases for cleanup" false);
   let settled = Keeper_chat_queue.snapshot ~keeper_name in
   check
     "queue has no active receipts after finalization"
@@ -810,9 +845,9 @@ let test_compaction_lane_bypasses_chat_backlog () =
    with
    | `Ran 7 -> check "compaction lane admits despite a pending receipt" true
    | `Ran _ | `Busy _ -> check "compaction lane admits despite a pending receipt" false);
-  (* Leasing moves the receipt to inflight; the compaction lane still admits
-     (an inflight receipt whose delivery cannot progress is exactly the
-     #24865 wedge), while the standard lane keeps yielding. *)
+  (* Leasing moves the receipt to inflight. Both autonomous entry points use
+     the actual turn mutex as the execution fence; the durable receipt is not
+     a second global lock. *)
   (match Keeper_chat_queue.lease_next ~keeper_name with
    | `Leased _ -> ()
    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
@@ -822,15 +857,13 @@ let test_compaction_lane_bypasses_chat_backlog () =
    with
    | `Ran 8 -> check "compaction lane admits despite an inflight receipt" true
    | `Ran _ | `Busy _ -> check "compaction lane admits despite an inflight receipt" false);
-  (* Production order (#24865 review): the compaction admission released the
-     slot on return, and a follow-up turn re-entering the standard lane still
-     yields to the remaining backlog — the bypass covers the compaction
-     commit only, never the turn that follows it. *)
+  (* Once the compaction admission releases the slot, a follow-up standard
+     turn also remains live despite a stranded/finalizing inflight receipt. *)
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog _) ->
-     check "standard lane still yields to the backlog after compaction admission" true
-   | `Busy _ | `Ran () ->
-     check "standard lane still yields to the backlog after compaction admission" false);
+   | `Ran () ->
+     check "standard lane admits past an inflight receipt after compaction" true
+   | `Busy _ ->
+     check "inflight receipt must not refence standard lane after compaction" false);
   (* A genuinely held slot still refuses the compaction lane: it must never
      interleave with an in-flight turn. *)
   Keeper_turn_admission.For_testing.with_unpublished_turn_lock


### PR DESCRIPTION
## Summary
- observe typed Tool_result.Deferred at the request-scoped OAS tool boundary
- cooperatively yield the provider loop until the durable HITL/Auto Judge resolution wakes a later turn
- stop treating an inflight chat receipt as a second global turn lock once the real per-Keeper turn mutex is free
- install Gate persistence in the tool runtime fixture
- cover approval-gated WebSearch defer, Auto Judge one-shot grant consumption, exact WebSearch execution, and provider-loop yield

## Root cause
The OAS bridge intentionally projected Deferred as a successful tool response, but the request boundary discarded the typed defer. The provider therefore retried the same external effect until timeout. A leftover inflight chat receipt could then block later autonomous/HITL work even though the actual turn mutex was free.

Closes #25991

## Validation
- scripts/dune-local.sh build test/test_keeper_turn_admission.exe test/test_keeper_tool_dispatch_runtime.exe
- test_keeper_turn_admission.exe (all checks passed)
- tool runtime cases 21,22,32: Manual Gate defers WebSearch before network, an Auto Judge approval grants and consumes exactly one matching WebSearch, and a deferred WebSearch yields before a second provider call
- focused Auto Judge exact-flow and cycle-grant suites passed from current main

Known current-main limits: the full tool runtime executable has two unrelated pre-existing failures, now tracked as #26008 (typed validation data) and #26009 (terminal surface broadcast count).