### PR TITLE
fix(compaction): recover suspended checkpoints deterministically

### DIFF
--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -252,25 +252,26 @@ let append_manifest
             (Keeper_runtime_manifest.with_payload_role
                ~payload_role:Keeper_runtime_manifest.Checkpoint
                (`Assoc
-                 [ "trigger", `String (Compaction_trigger.to_label trigger)
-                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-                 ; ( Keeper_compaction_evidence.exact_evidence_key
-                   , Keeper_compaction_evidence.to_json recovery.evidence )
-                 ; ( "checkpoint_installation_schema"
-                   , `String "keeper.checkpoint_installation.v1" )
-                 ; "checkpoint_installation_state", `String "installed"
-                 ; ( "checkpoint_installed_ref"
-                   , checkpoint_ref_to_json installation.installed_ref )
-                 ; ( "checkpoint_installation_auxiliary"
-                   , `List
-                       (List.map
-                          checkpoint_installation_auxiliary_to_json
-                          installation.auxiliary) )
-                 ; ( "compaction_post_install_schema"
-                   , `String "keeper.compaction.post_install.v1" )
-                 ; "compaction_lifecycle", post_install_lifecycle_to_json lifecycle
-                 ; "operator_action_required", `Bool operator_action_required
-                 ]))))
+                 ([ "trigger", `String (Compaction_trigger.to_label trigger)
+                  ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                  ]
+                  @ Keeper_post_turn.compaction_recovery_evidence_fields
+                      recovery.evidence
+                  @ [ ( "checkpoint_installation_schema"
+                      , `String "keeper.checkpoint_installation.v1" )
+                    ; "checkpoint_installation_state", `String "installed"
+                    ; ( "checkpoint_installed_ref"
+                      , checkpoint_ref_to_json installation.installed_ref )
+                    ; ( "checkpoint_installation_auxiliary"
+                      , `List
+                          (List.map
+                             checkpoint_installation_auxiliary_to_json
+                             installation.auxiliary) )
+                    ; ( "compaction_post_install_schema"
+                      , `String "keeper.compaction.post_install.v1" )
+                    ; "compaction_lifecycle", post_install_lifecycle_to_json lifecycle
+                    ; "operator_action_required", `Bool operator_action_required
+                    ])))))
     ~checkpoint_path
     ()
   |> Keeper_runtime_manifest.append config

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -53,11 +53,21 @@ type post_turn_lifecycle = {
   message_count : int;
 }
 
+type deterministic_purge_evidence =
+  { report : Keeper_checkpoint_purge.report
+  ; before_checkpoint_bytes : int
+  ; after_checkpoint_bytes : int
+  }
+
+type compaction_recovery_evidence =
+  | Exact_execution_evidence of Keeper_compaction_evidence.t
+  | Deterministic_purge_evidence of deterministic_purge_evidence
+
 type compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation;
   trigger : Compaction_trigger.t;
-  evidence : Keeper_compaction_evidence.t;
+  evidence : compaction_recovery_evidence;
   turn_generation : int;
 }
 
@@ -90,6 +100,31 @@ type prepared_commit_outcome =
   | Already_committed of compaction_recovery
   | Already_rejected of no_compaction
   | Commit_failed of prepared_commit_failure
+
+let compaction_recovery_evidence_fields = function
+  | Exact_execution_evidence evidence ->
+    [ Keeper_compaction_evidence.exact_evidence_key
+    , Keeper_compaction_evidence.to_json evidence
+    ]
+  | Deterministic_purge_evidence
+      { report
+      ; before_checkpoint_bytes
+      ; after_checkpoint_bytes
+      } ->
+    [ ( "deterministic_purge_evidence"
+      , `Assoc
+          [ "schema", `String "keeper.compaction.deterministic_purge.v1"
+          ; "before_checkpoint_bytes", `Int before_checkpoint_bytes
+          ; "after_checkpoint_bytes", `Int after_checkpoint_bytes
+          ; "messages_before", `Int report.messages_before
+          ; "messages_after", `Int report.messages_after
+          ; "duplicates_dropped", `Int report.duplicates_dropped
+          ; "reasoning_blocks_stripped", `Int report.reasoning_blocks_stripped
+          ; "reasoning_messages_dropped", `Int report.reasoning_messages_dropped
+          ; "tool_results_cleared", `Int report.tool_results_cleared
+          ] )
+    ]
+;;
 
 let compaction_recovery_error_to_tag = function
   | Checkpoint_ref_load_failed Keeper_checkpoint_store.Ref_not_found ->
@@ -197,8 +232,8 @@ let compaction_recovery_error_to_string = function
   | Retry_suspended { consecutive_failures } ->
     Printf.sprintf
       "compaction retry suspended after %d consecutive failures; reactive \
-       prepare refused before the summarizer call — an operator-committed \
-       manual compaction resets the streak and lifts the suspension"
+       LLM prepare refused before the summarizer call; the one-shot recovery \
+       path may still apply a deterministic checkpoint purge"
       consecutive_failures
 
 (* ── Tier A6: resilience post-turn wire-in (Cycle 23) ──────────────
@@ -858,6 +893,21 @@ let commit_prepared_compaction_with
     |> terminalized_outcome
     |> publish_owner
   in
+  let publish_installed_failure recovery detail =
+    let terminal_detail =
+      match
+        Keeper_compaction_llm_summarizer.finish_post_success_commit_failure
+          post_success_terminalizer
+          detail
+      with
+      | Ok () -> detail
+      | Error terminal_detail -> terminal_detail
+    in
+    publish_owner
+      (commit_failure
+         ~committed:recovery
+         (Checkpoint_candidate_failed terminal_detail))
+  in
   let installed_recovery = ref None in
   let commit_claimed () =
     try
@@ -878,7 +928,7 @@ let commit_prepared_compaction_with
          { checkpoint = saved_checkpoint
          ; checkpoint_installation = installation
          ; trigger = prepared_trigger
-         ; evidence
+         ; evidence = Exact_execution_evidence evidence
          ; turn_generation
          }
        in
@@ -901,10 +951,7 @@ let commit_prepared_compaction_with
              complete_post_success_commit post_success_terminalizer
            with
            | Error detail ->
-             publish_owner
-               (commit_failure
-                  ~committed:recovery
-                  (Checkpoint_candidate_failed detail))
+             publish_installed_failure recovery detail
            | Ok () ->
              (try
                 Otel_metric_store.inc_counter
@@ -958,40 +1005,15 @@ let commit_prepared_compaction_with
             "post-install compaction finalization was cancelled: "
             ^ Printexc.to_string exn
           in
-          let terminal_detail =
-            match
-              Keeper_compaction_llm_summarizer
-              .finish_post_success_commit_failure
-                post_success_terminalizer
-                detail
-            with
-            | Ok () -> detail
-            | Error terminal_detail -> terminal_detail
-          in
-          publish_owner
-            (commit_failure
-               ~committed:recovery
-               (Checkpoint_candidate_failed terminal_detail))))
+          publish_installed_failure recovery detail))
     | exn ->
       let detail = Printexc.to_string exn in
       log_keeper_exn ~label:"compaction checkpoint save exception" exn;
       (match !installed_recovery with
        | Some recovery ->
-         let terminal_detail =
-           match
-             Keeper_compaction_llm_summarizer
-             .finish_post_success_commit_failure
-               post_success_terminalizer
-               ("post-install compaction finalization raised: " ^ detail)
-           with
-           | Ok () -> detail
-           | Error terminal_detail -> terminal_detail
-         in
-         publish_owner
-           (commit_failure
-              ~committed:recovery
-              (Checkpoint_candidate_failed
-                 terminal_detail))
+         publish_installed_failure
+           recovery
+           ("post-install compaction finalization raised: " ^ detail)
        | None ->
          Log.Keeper.error
            "compaction checkpoint save exception became terminal: %s"
@@ -1047,6 +1069,141 @@ module For_testing = struct
   ;;
 end
 
+let checkpoint_purge_error_to_string = function
+  | Keeper_checkpoint_purge.Invalid_config detail ->
+    "invalid deterministic purge config: " ^ detail
+  | Keeper_checkpoint_purge.Invalid_input_structure error ->
+    "deterministic purge input structure invalid: "
+    ^ Keeper_compaction_unit.show_structural_error error
+  | Keeper_checkpoint_purge.Invalid_output_structure error ->
+    "deterministic purge output structure invalid: "
+    ^ Keeper_compaction_unit.show_structural_error error
+;;
+
+(* RFC-0351 S1: once reactive LLM compaction is suspended, make one bounded
+   progress attempt with the already-validated deterministic purge. This path
+   has no model dispatch and therefore owns no exact-output slot/call
+   terminalizer. It still uses the canonical checkpoint source CAS and reports
+   its own typed evidence instead of fabricating LLM provenance. *)
+let recover_suspended_checkpoint_with_purge
+      ~base_dir
+      ~(meta : keeper_meta)
+      ~(trigger : Compaction_trigger.t)
+      ~suspended_error
+  : prepared_commit_outcome =
+  let session =
+    create_session
+      ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      ~base_dir
+  in
+  match
+    Keeper_checkpoint_store.load_oas_with_ref
+      ~session_dir:session.session_dir
+      ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+  with
+  | Error error ->
+    Commit_failed
+      { error = Checkpoint_ref_load_failed error
+      ; committed = None
+      }
+  | Ok (checkpoint, source_ref) ->
+    (match
+       Keeper_checkpoint_purge.purge
+         ~config:Keeper_checkpoint_purge.default_config
+         checkpoint
+     with
+     | Error error ->
+       Commit_failed
+         { error =
+             Checkpoint_candidate_failed
+               (checkpoint_purge_error_to_string error)
+         ; committed = None
+         }
+     | Ok (purged_checkpoint, report) ->
+       let source_context = context_of_oas_checkpoint checkpoint in
+       let purged_context = context_of_oas_checkpoint purged_checkpoint in
+       let before_checkpoint_bytes = serialized_bytes source_context in
+       let after_checkpoint_bytes = serialized_bytes purged_context in
+       if after_checkpoint_bytes >= before_checkpoint_bytes
+       then (
+         Log.Keeper.warn
+           ~keeper_name:meta.name
+           "deterministic compaction recovery produced no reduction \
+            before_bytes=%d after_bytes=%d; retaining retry suspension"
+           before_checkpoint_bytes
+           after_checkpoint_bytes;
+         Commit_failed { error = suspended_error; committed = None })
+       else (
+         let turn_generation =
+           checkpoint_generation checkpoint ~fallback:meta.runtime.nonce
+         in
+         let retry_meta =
+           if turn_generation = meta.runtime.nonce
+           then meta
+           else map_runtime (fun rt -> { rt with nonce = turn_generation }) meta
+         in
+         match
+           save_oas_checkpoint_if_source
+             ~multimodal_policy:retry_meta.multimodal_policy
+             ~keeper_name:retry_meta.name
+             ~session
+             ~agent_name:retry_meta.agent_name
+             ~ctx:purged_context
+             ~generation:turn_generation
+             ~expected_source_ref:source_ref
+         with
+         | Ok
+             ( saved_checkpoint
+             , (Keeper_checkpoint_store.Installed _ as installation) ) ->
+           let recovery =
+             { checkpoint = saved_checkpoint
+             ; checkpoint_installation = installation
+             ; trigger
+             ; evidence =
+                 Deterministic_purge_evidence
+                   { report
+                   ; before_checkpoint_bytes
+                   ; after_checkpoint_bytes
+                   }
+             ; turn_generation
+             }
+           in
+           (try
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string Compactions)
+                ~labels:[ "keeper", retry_meta.name ]
+                ()
+            with
+            | exn ->
+              log_keeper_exn
+                ~label:"deterministic compaction recovery metric emission"
+                exn);
+           Log.Keeper.info
+             ~keeper_name:retry_meta.name
+             "deterministic compaction recovery committed after suspended LLM \
+              retries before_bytes=%d after_bytes=%d messages_before=%d \
+              messages_after=%d"
+             before_checkpoint_bytes
+             after_checkpoint_bytes
+             report.messages_before
+             report.messages_after;
+           Committed recovery
+         | Ok
+             ( _
+             , Keeper_checkpoint_store.Not_installed { cause; _ } ) ->
+           Commit_failed { error = Checkpoint_cas_failed cause; committed = None }
+         | Error (Persistence_error error) ->
+           Commit_failed { error = Checkpoint_cas_failed error; committed = None }
+         | Error (Tool_history_invalid error) ->
+           Commit_failed
+             { error =
+                 Checkpoint_candidate_failed
+                   ("deterministic purge checkpoint structure invalid at save: "
+                    ^ Keeper_compaction_unit.show_structural_error error)
+             ; committed = None
+             }))
+;;
+
 let recover_latest_checkpoint_for_compaction
     ?before_dispatch_authority
     ?exact_execution_guard
@@ -1066,6 +1223,12 @@ let recover_latest_checkpoint_for_compaction
       ~trigger
       ()
   with
+  | Error (Retry_suspended _ as suspended_error) ->
+    recover_suspended_checkpoint_with_purge
+      ~base_dir
+      ~meta
+      ~trigger
+      ~suspended_error
   | Error error -> Commit_failed { error; committed = None }
   | Ok prepared -> commit_prepared_compaction prepared
 ;;

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -26,15 +26,31 @@ type post_turn_lifecycle =
   ; message_count : int
   }
 
+type deterministic_purge_evidence =
+  { report : Keeper_checkpoint_purge.report
+  ; before_checkpoint_bytes : int
+  ; after_checkpoint_bytes : int
+  }
+
+type compaction_recovery_evidence =
+  | Exact_execution_evidence of Keeper_compaction_evidence.t
+  | Deterministic_purge_evidence of deterministic_purge_evidence
+
 (** Recovered checkpoint after a durably applied explicit compaction request.
     Manual and provider-overflow callers consume the same result. *)
 type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation
   ; trigger : Compaction_trigger.t
-  ; evidence : Keeper_compaction_evidence.t
+  ; evidence : compaction_recovery_evidence
   ; turn_generation : int
   } [@@warning "-69"]
+
+val compaction_recovery_evidence_fields :
+  compaction_recovery_evidence -> (string * Yojson.Safe.t) list
+(** Closed manifest projection. Exact-output recovery preserves the existing
+    [exact_evidence] field; deterministic recovery uses its own typed schema
+    and never fabricates an LLM slot, call, or plan fingerprint. *)
 
 type no_compaction = Keeper_event_queue_state.no_compaction =
   { source : Keeper_checkpoint_ref.t
@@ -54,8 +70,10 @@ type compaction_recovery_error =
           checkpoint load and the summarizer LLM call — the settlement's
           per-stimulus escalation already stops the retries, and this gate
           stops the one bounded LLM attempt each new stimulus still paid.
-          [Manual] prepares bypass the gate: an operator-committed compaction
-          resets the streak and lifts the suspension. *)
+          [Manual] prepares bypass the gate. The one-shot recovery entrypoint
+          consumes this refusal by attempting the deterministic checkpoint
+          purge under source CAS; it retains [Retry_suspended] when that purge
+          cannot reduce the checkpoint. *)
 
 type prepared_commit_failure =
   { error : compaction_recovery_error
@@ -177,8 +195,10 @@ val no_compaction_of_uncommitted_prepared :
 
 (** Reload the canonical OAS checkpoint and apply an explicit typed
     compaction request. Composition of {!prepare_compaction} and
-    {!commit_prepared_compaction}; all affine ownership outcomes remain
-    explicit. *)
+    {!commit_prepared_compaction}. A suspended reactive request uses the
+    bounded, no-LLM deterministic purge instead; exact-output and deterministic
+    evidence remain distinct. All affine exact-output ownership outcomes
+    remain explicit. *)
 val recover_latest_checkpoint_for_compaction :
   ?before_dispatch_authority:
     Keeper_compaction_llm_summarizer.before_dispatch_authority ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -514,13 +514,12 @@ let append_provider_overflow_manifest
              (Keeper_runtime_manifest.with_payload_role
                 ~payload_role:Checkpoint
                 (`Assoc
-                  [ "trigger", `String (Compaction_trigger.to_label trigger)
-                  ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-                  ; "requeue_disposition_requested", `Bool true
-                  ; "error", error
-                  ; ( Keeper_compaction_evidence.exact_evidence_key
-                    , Keeper_compaction_evidence.to_json evidence )
-                  ])))
+                  ([ "trigger", `String (Compaction_trigger.to_label trigger)
+                   ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                   ; "requeue_disposition_requested", `Bool true
+                   ; "error", error
+                   ]
+                   @ Keeper_post_turn.compaction_recovery_evidence_fields evidence))))
         Keeper_runtime_manifest.Context_compacted
     in
     turn_state

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1314,6 +1314,145 @@ let test_suspended_streak_refuses_reactive_prepare () =
     ]
 ;;
 
+let test_suspended_recovery_uses_deterministic_purge () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let trace_id = "trace-suspended-deterministic-purge" in
+       let meta =
+         match
+           Masc_test_deps.meta_of_json_fixture
+             (`Assoc
+               [ "name", `String "suspended-deterministic-purge"
+               ; "trace_id", `String trace_id
+               ; "compaction_consecutive_failures", `Int 3
+               ])
+         with
+         | Ok meta -> meta
+         | Error detail -> failf "deterministic purge meta fixture: %s" detail
+       in
+       let checkpoint =
+         { (make_checkpoint ()) with
+           session_id = trace_id
+         ; agent_name = meta.agent_name
+         ; messages =
+             List.init 30 (fun _ ->
+               Agent_sdk.Types.text_message
+                 Agent_sdk.Types.User
+                 "byte-identical duplicate checkpoint message")
+         }
+       in
+       let base_dir = Masc.Keeper_types_profile.session_base_dir config in
+       let session =
+         Masc.Keeper_context_core.create_session
+           ~session_id:trace_id
+           ~base_dir
+       in
+       let context =
+         Masc.Keeper_context_core.context_of_oas_checkpoint checkpoint
+       in
+       (match
+          Masc.Keeper_context_core.save_oas_checkpoint_classified
+            ~multimodal_policy:meta.multimodal_policy
+            ~keeper_name:meta.name
+            ~session
+            ~agent_name:meta.agent_name
+            ~ctx:context
+            ~generation:meta.runtime.nonce
+        with
+        | Ok _ -> ()
+        | Error error ->
+          failf
+            "deterministic purge source fixture failed: %s"
+            (Masc.Keeper_context_core.checkpoint_write_error_to_string
+               ~persistence_error_to_string:(fun detail -> detail)
+               error));
+       let exact_dispatch_authority_calls = ref 0 in
+       let outcome =
+         Post_turn.recover_latest_checkpoint_for_compaction
+           ~before_dispatch_authority:(fun _observation ->
+             incr exact_dispatch_authority_calls;
+             Error "deterministic recovery must not dispatch exact output")
+           ~base_path:config.base_path
+           ~base_dir
+           ~meta
+           ~trigger:
+             (Compaction_trigger.Provider_overflow { limit_tokens = None })
+           ()
+       in
+       check int
+         "suspended deterministic recovery performs no exact-output dispatch"
+         0
+         !exact_dispatch_authority_calls;
+       match outcome with
+       | Post_turn.Committed
+           ({ evidence =
+                Post_turn.Deterministic_purge_evidence
+                  { report
+                  ; before_checkpoint_bytes
+                  ; after_checkpoint_bytes
+                  }
+            ; checkpoint
+            ; checkpoint_installation = Masc.Keeper_checkpoint_store.Installed _
+            ; _
+            } as recovery) ->
+         check bool
+           "deterministic purge strictly reduces checkpoint bytes"
+           true
+           (after_checkpoint_bytes < before_checkpoint_bytes);
+         check bool
+           "deterministic purge drops duplicate messages"
+           true
+           (report.duplicates_dropped > 0);
+         check bool
+           "deterministic purge reduces message count"
+           true
+           (report.messages_after < report.messages_before);
+         check int
+           "committed checkpoint matches purge report"
+           report.messages_after
+           (List.length checkpoint.messages);
+         (match
+            Masc.Keeper_checkpoint_store.load_oas_with_ref
+              ~session_dir:session.session_dir
+              ~session_id:trace_id
+          with
+          | Ok (reloaded, _) ->
+            check bool
+              "source-CAS store contains the committed purged checkpoint"
+              true
+              (reloaded.messages = recovery.checkpoint.messages)
+          | Error error ->
+            failf
+              "committed deterministic purge could not be reloaded: %s"
+              (Post_turn.compaction_recovery_error_to_string
+                 (Post_turn.Checkpoint_ref_load_failed error)))
+       | Post_turn.Committed
+           { evidence = Post_turn.Exact_execution_evidence _; _ } ->
+         fail "suspended recovery fabricated exact-output evidence"
+       | Post_turn.Committed
+           { checkpoint_installation = Masc.Keeper_checkpoint_store.Not_installed _
+           ; _
+           } ->
+         fail "deterministic recovery reported commit without installation"
+       | Post_turn.Commit_in_progress _
+       | Post_turn.Already_committed _
+       | Post_turn.Already_rejected _ ->
+         fail "deterministic recovery returned an impossible ownership outcome"
+       | Post_turn.Commit_failed { error; _ } ->
+         failf
+           "deterministic recovery failed: %s"
+           (Post_turn.compaction_recovery_error_to_string error))
+;;
+
 let () =
   run "post-turn durability" [
     "durable compaction", [
@@ -1346,6 +1485,8 @@ let () =
         `Quick test_post_dispatch_non_reducing_output_is_quarantined;
       test_case "suspended streak refuses reactive prepare"
         `Quick test_suspended_streak_refuses_reactive_prepare;
+      test_case "suspended recovery uses deterministic purge"
+        `Quick test_suspended_recovery_uses_deterministic_purge;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
     ];


### PR DESCRIPTION
## Summary
- keep the existing retry-suspension gate for LLM compaction
- when a one-shot recovery encounters Retry_suspended, attempt the bounded deterministic checkpoint purge with no model dispatch
- install only a strict byte reduction under the canonical source CAS
- emit typed deterministic-purge evidence instead of fabricating exact-output slot/call provenance
- retain Retry_suspended when the purge cannot reduce the checkpoint

## Why
Live taskmaster reached 31 consecutive compaction failures. The suspension stopped repeated LLM cost, but it also left no automatic recovery path. Keeper_checkpoint_purge existed behind the offline masc-checkpoint-purge operator CLI, but had no live-turn caller.

## Validation
- scripts/dune-local.sh build test/test_keeper_post_turn_wirein_order.exe
- durable compaction cases 11-13 passed: suspended prepare refuses LLM dispatch, suspended recovery performs deterministic strict reduction, and missing exact lane remains source-bound
- ocamlformat --check and git diff --check passed

The deterministic purge is deliberately limited: unique ordinary message histories that cannot be reduced remain suspended and still require a later compaction strategy/operator action.