### PR TITLE
test(schedule): cover hourly interval live contract

### DIFF
--- a/scripts/harness/contract/scheduler_live_supported_contract.sh
+++ b/scripts/harness/contract/scheduler_live_supported_contract.sh
@@ -15,7 +15,8 @@ BASE_URL="${MCP_URL%/mcp}"
 SCHEDULE_ID="contract-live-supported-$$"
 KEEPER_NAME="contract-scheduler-keeper"
 NOW_UNIX="$(date +%s)"
-DUE_AT_UNIX="$((NOW_UNIX + 3600))"
+INTERVAL_SEC="${SCHEDULER_LIVE_INTERVAL_SEC:-3600}"
+DUE_AT_UNIX="$((NOW_UNIX + INTERVAL_SEC))"
 DASHBOARD_JSON="$(mcp_mktemp_file "masc-scheduler-live-supported-dashboard" ".json")"
 AUTH_HEADER_FILE=""
 CREATED_SCHEDULE_ID=""
@@ -108,6 +109,8 @@ assert_dashboard_matched_supported_non_terminal() {
       and (($evidence.matched_schedule_ids // []) | index($schedule_id) != null)
       and $row.payload_kind == "masc.keeper_wake"
       and $row.payload_support == "supported"
+      and $row.recurrence_kind == "interval"
+      and $row.next_due_at == $row.due_at
       and (($row.status | IN("succeeded", "failed", "cancelled", "expired")) | not)
   ' "$DASHBOARD_JSON" >/dev/null
 }
@@ -131,10 +134,13 @@ create_payload="$(
     --arg message "Contract harness live supported scheduler evidence." \
     --argjson requested_at "$NOW_UNIX" \
     --argjson due_at "$DUE_AT_UNIX" \
+    --argjson interval_sec "$INTERVAL_SEC" \
     '{
       schedule_id: $schedule_id,
       requested_at_unix: $requested_at,
       due_at_unix: $due_at,
+      recurrence_kind: "interval",
+      recurrence_interval_sec: $interval_sec,
       requested_by_id: "contract-operator",
       scheduled_by_id: "contract-scheduler",
       payload_kind: "masc.keeper_wake",


### PR DESCRIPTION
## Summary
- make the supported scheduler live contract create a real interval request instead of a one-shot request
- default the interval to 3600 seconds and allow a shorter explicit test override
- require the dashboard projection to preserve interval recurrence and the initial next due
- keep the existing cleanup path, which cancels the created future request

## Live evidence
Ran against the local server on 2026-07-28 KST with a persistent base explicitly enabled. MCP create and dashboard projection passed for contract-live-supported-88967; cleanup left the row cancelled. The durable row records recurrence kind interval and interval_sec 3600.

## Validation
- bash -n
- shellcheck (only the existing SC1091 sourced-helper info)
- scheduler live supported contract passed against http://127.0.0.1:8935
- test_schedule_tool_wiring: 8/8 passed
- test_schedule_runner: 11/11 passed
- test_schedule_consumer_dispatch: 13/16 passed; the remaining three current-main fixture failures reject legacy last_model_used, already fixed independently by draft PR #26002

This contract proves interval registration/projection. Due-to-Keeper execution is covered by the runner/consumer suites; the Auto Judge/WebSearch provider-loop liveness regression is covered by #26004.