### PR TITLE
fix(keeper): settle a selection its route calls deterministic

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -74,6 +74,42 @@ let consume_single_heartbeat_stimulus = Stimulus_intake.consume_single_heartbeat
 let consume_board_stimulus_batch = Stimulus_intake.consume_board_stimulus_batch
 let heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake
 
+(* Whether this cycle finished with its selected stimulus, so the selection can
+   leave pending. A selection that stays pending is re-selected next cycle, so
+   every arm answering [false] is a claim that running the same stimulus again
+   can produce a different outcome. *)
+let selection_is_settled cycle_outcome =
+  match cycle_outcome with
+  | Some
+      ( Cycle.Completed _
+      | Cycle.Manual_compaction_applied _
+      | Cycle.Manual_compaction_not_applied _ ) ->
+    true
+  | Some (Cycle.Failed { failure; _ }) ->
+    (match failure.Keeper_unified_turn.source_lease_disposition with
+     | Keeper_unified_turn.Acknowledge_after_in_turn_handling
+     | Keeper_unified_turn.Escalate_after_exact_output_terminal _ -> true
+     | Keeper_unified_turn.Follow_failure_route
+     | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
+       (* Following the route means honouring what the route says.
+          [Exhausted_visible_alive] is the deterministic class: "mechanical
+          retry or rotation cannot change the outcome"
+          (keeper_runtime_failure_route.mli). Re-selecting it spends a provider
+          turn that cannot progress. *)
+       (match failure.Keeper_unified_turn.route with
+        | Keeper_runtime_failure_route.Exhausted_visible_alive _ -> true
+        | Keeper_runtime_failure_route.Retry_after_observed _
+        | Keeper_runtime_failure_route.Rotate_now _ -> false)
+     | Keeper_unified_turn.Requeue_after_context_compaction _
+     | Keeper_unified_turn.Pause_after_transcript_corruption _ -> false)
+  | Some
+      ( Cycle.Cancelled _
+      | Cycle.Skipped _
+      | Cycle.Busy _
+      | Cycle.Manual_compaction_failed _ )
+  | None -> false
+;;
+
 (* Keepalive scheduling decision (record + decide function) extracted to
    [Keeper_heartbeat_loop_scheduling] (godfile decomp). *)
 type keepalive_scheduling_decision = Keeper_heartbeat_loop_scheduling.keepalive_scheduling_decision = {
@@ -309,7 +345,7 @@ module For_testing = struct
     | Transcript_pause_settlement_failed of string
 
   let commit_transcript_corruption = commit_transcript_corruption
-
+  let selection_is_settled = selection_is_settled
 end
 
 (* Pure: post-turn status event derived from the registry turn-failure
@@ -706,31 +742,7 @@ let run_keepalive_unified_turn
          match !pending_selection with
        | None -> ()
        | Some selection ->
-         let should_ack =
-           match !cycle_outcome_ref with
-           | Some
-               ( Cycle.Completed _
-               | Cycle.Manual_compaction_applied _
-               | Cycle.Manual_compaction_not_applied _ ) ->
-             true
-           | Some (Cycle.Failed { failure; _ }) ->
-             (match failure.Keeper_unified_turn.source_lease_disposition with
-              | Keeper_unified_turn.Acknowledge_after_in_turn_handling
-              | Keeper_unified_turn.Escalate_after_exact_output_terminal _ ->
-                true
-              | Keeper_unified_turn.Follow_failure_route
-              | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
-              | Keeper_unified_turn.Requeue_after_context_compaction _
-              | Keeper_unified_turn.Pause_after_transcript_corruption _ ->
-                false)
-           | Some
-               ( Cycle.Cancelled _
-               | Cycle.Skipped _
-               | Cycle.Busy _
-               | Cycle.Manual_compaction_failed _ )
-           | None ->
-             false
-         in
+         let should_ack = selection_is_settled !cycle_outcome_ref in
          if should_ack
          then
            match

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -236,4 +236,9 @@ module For_testing : sig
     unit ->
     transcript_corruption_commit
 
+  val selection_is_settled :
+    Keeper_heartbeat_loop_cycle.cycle_outcome option -> bool
+  (** Whether the cycle finished with its selected stimulus. [false] leaves the
+      selection pending, which re-selects the same stimulus next cycle, so
+      [false] asserts that running it again can produce a different outcome. *)
 end

--- a/test/dune
+++ b/test/dune
@@ -670,6 +670,11 @@
 
 
 (test
+ (name test_keeper_selection_settlement)
+ (modules test_keeper_selection_settlement)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_keeper_paused_work_cancellation_transaction)
  (modules test_keeper_paused_work_cancellation_transaction)
  (libraries alcotest masc_test_deps eio_main))

--- a/test/test_keeper_selection_settlement.ml
+++ b/test/test_keeper_selection_settlement.ml
@@ -1,0 +1,131 @@
+(* Whether a cycle's selected stimulus leaves the pending queue.
+
+   A selection that stays pending is re-selected on the next cycle, so an
+   arm answering [false] asserts that running the same stimulus again can
+   produce a different outcome. For a route the SSOT already calls
+   deterministic that assertion is false, and the keeper spends provider
+   turns forever. *)
+
+open Alcotest
+
+module Loop = Masc.Keeper_heartbeat_loop
+module Cycle = Masc.Keeper_heartbeat_loop_cycle
+module Route = Keeper_runtime_failure_route
+module Turn = Masc.Keeper_unified_turn
+
+let meta () =
+  Masc_test_deps.meta_of_json_fixture
+    (`Assoc [ "name", `String "keeper"; "trace_id", `String "trace-keeper" ])
+  |> Result.get_ok
+;;
+
+let failure ~route ~disposition =
+  { Turn.error = Agent_sdk.Error.Internal "deterministic rejection"
+  ; runtime_id = "runtime"
+  ; route
+  ; source_lease_disposition = disposition
+  ; deferred_runtime_lane = None
+  }
+;;
+
+let exhausted =
+  Route.Exhausted_visible_alive
+    { terminal = Route.Deterministic_request
+    ; provenance = Route.Oas_api_error
+    ; detail = "request body rejected"
+    }
+;;
+
+let retryable =
+  Route.Retry_after_observed { retry_class = Route.Rate_limited; retry_after = None }
+;;
+
+let rotatable = Route.Rotate_now { rotate = Route.Auth_failed }
+
+let settled ~route ~disposition =
+  Loop.For_testing.selection_is_settled
+    (Some (Cycle.Failed { meta = meta (); failure = failure ~route ~disposition }))
+;;
+
+let test_exhausted_route_settles_its_selection () =
+  List.iter
+    (fun (label, disposition) ->
+       check
+         bool
+         (label ^ ": a deterministically exhausted selection does not stay pending")
+         true
+         (settled ~route:exhausted ~disposition))
+    [ "follow_failure_route", Turn.Follow_failure_route
+    ; ( "follow_failure_route_after_no_compaction"
+      , Turn.Follow_failure_route_after_no_compaction
+          { reason = Keeper_event_queue_state.No_eligible_history } )
+    ]
+;;
+
+let test_recoverable_routes_keep_their_selection () =
+  List.iter
+    (fun (label, route) ->
+       check
+         bool
+         (label ^ ": a route that another attempt can satisfy stays pending")
+         false
+         (settled ~route ~disposition:Turn.Follow_failure_route))
+    [ "retry_after_observed", retryable; "rotate_now", rotatable ]
+;;
+
+let test_route_decides_only_when_the_disposition_defers_to_it () =
+  check
+    bool
+    "an in-turn acknowledgement settles regardless of route"
+    true
+    (settled ~route:retryable ~disposition:Turn.Acknowledge_after_in_turn_handling);
+  check
+    bool
+    "a transcript pause keeps its selection even when the route is exhausted"
+    false
+    (settled
+       ~route:exhausted
+       ~disposition:(Turn.Pause_after_transcript_corruption { detail = "orphan" }))
+;;
+
+let test_non_failure_outcomes_are_unchanged () =
+  check
+    bool
+    "a completed cycle settles"
+    true
+    (Loop.For_testing.selection_is_settled (Some (Cycle.Completed (meta ()))));
+  check
+    bool
+    "a cancelled cycle keeps its selection"
+    false
+    (Loop.For_testing.selection_is_settled (Some (Cycle.Cancelled (meta ()))));
+  check
+    bool
+    "no outcome keeps its selection"
+    false
+    (Loop.For_testing.selection_is_settled None)
+;;
+
+let () =
+  run
+    "Keeper selection settlement"
+    [ ( "route"
+      , [ test_case
+            "exhausted route settles its selection"
+            `Quick
+            test_exhausted_route_settles_its_selection
+        ; test_case
+            "recoverable routes keep their selection"
+            `Quick
+            test_recoverable_routes_keep_their_selection
+        ; test_case
+            "route decides only when the disposition defers to it"
+            `Quick
+            test_route_decides_only_when_the_disposition_defers_to_it
+        ; test_case
+            "non-failure outcomes are unchanged"
+            `Quick
+            test_non_failure_outcomes_are_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 증상

keeper 가 같은 자극을 매 cycle 재선택하며 프로바이더 턴을 소모한다. 진전은 없다.

라이브 실측 (`~/.masc`, 2026-07-28 02:14, 깨끗한 초기화 28분 후):

| keeper | 실행 턴 | total_turns | total_turns 값 집합 |
|---|---|---|---|
| analyst | 44 | 33 | 0,1,2,3,4,… 단조 증가 |
| taskmaster | 79 | 27 | 증가 |
| sangsu | 73 | 28 | 증가 |
| executor | 90 | 8 | 증가 |
| **lane-smith** | **94** | **1** | **{0, 1}** |

lane-smith 는 94 턴을 실행하고 1 건만 정산했다. 도구 호출은 `outcome=ok` 로 정상이고 `paused=false` 다. 실패한 keeper 가 아니라, 같은 자극이 계속 재선택되는 상태다.

## 원인

`should_ack` 이 `source_lease_disposition` 만 보고 `failure.route` 를 읽지 않는다. `Follow_failure_route` 는 무조건 `false` → 선택이 pending 에 남고 다음 cycle 에 재선택된다.

그런데 route 의 SSOT 는 이렇게 선언한다 (`lib/keeper_runtime/keeper_runtime_failure_route.mli:14-17`):

```
[Exhausted_visible_alive] — deterministic failure: mechanical retry or
rotation cannot change the outcome.
```

즉 `Follow_failure_route` 는 "route 를 따르라"는 뜻인데 route 를 읽지 않았다.

`#25969` (`2f60744277`) 이전에는 매핑이 있었다:

```
2f60744277^:lib/keeper/keeper_heartbeat_loop.ml:250-251
  | Keeper_runtime_failure_route.Exhausted_visible_alive _ ->
    Keeper_registry_event_queue.Ack
```

`claimed_lease` → `pending_selection` 재작성이 이 매핑을 옮기지 않았고, 대체 경로도 없다. 현재 `Exhausted_visible_alive` 는 자신의 선언 파일 밖에 소비자가 0 이다 (`rg` + `grep -rl` 2 형태로 확인, `lib/`·`bin/` 범위).

## 변경

- `should_ack` 판정을 loop body 밖으로 꺼내 `selection_is_settled` 로 명명. 거대한 클로저 안에 묻혀 있어 테스트할 수 없었다.
- `Follow_failure_route` / `Follow_failure_route_after_no_compaction` 이 route 를 읽도록 복원. route 3 생성자 전부 명시 (catch-all 없음).
- 다른 disposition 의 동작은 그대로다.

## 테스트

신규 `test/test_keeper_selection_settlement.ml` — 4 케이스:

- exhausted route 는 두 disposition 모두에서 정산된다
- `Retry_after_observed` / `Rotate_now` 는 pending 을 유지한다
- disposition 이 우선한다 — `Acknowledge_after_in_turn_handling` 은 route 무관하게 정산, `Pause_after_transcript_corruption` 은 route 가 exhausted 여도 유지
- 실패 아닌 outcome (`Completed` / `Cancelled` / `None`) 은 변경 없음

**변이 검증**: route arm 을 `false` 로 되돌리면 첫 케이스가 실패한다. 실행 확인함.

## 로컬 검증

```
dune build @check                              통과
dune exec test/test_keeper_selection_settlement.exe   4/4 통과
변이 후 재실행                                  1 failure (의도대로)
```

## 미검증

- 이 수정으로 lane-smith 가 실제 진전하는지는 배포 후 `total_turns` 추이로만 확인된다.
- keeper 별 정산 비율 차이(analyst 75% vs executor 9%)가 전부 이 결함으로 설명되는지는 확인하지 않았다. lane-smith 의 1% 는 명백한 이탈이지만 중간 값들은 실패 유형 분포일 수 있다.
- `Exhausted_visible_alive` 의 소비자가 이 한 곳뿐이어도 되는지 — route 가 telemetry 외에 다른 곳에서 쓰여야 하는지는 이 PR 범위 밖이다.

## 관련

`refactor/purge-event-queue-lease-20260728` 브랜치에서 event-queue lease 제거가 진행 중인 것으로 보인다. 이 PR 은 lease 를 건드리지 않고 `pending_selection` 경로만 고치므로 그 작업과 충돌하지 않을 것으로 보이나, 같은 파일을 만지므로 머지 순서 조율이 필요할 수 있다.

RFC-WAIVED: `#25969` 리팩터에서 이전되지 않은 매핑 1 건의 복원이다. 새 설계를 도입하지 않으며, 복원 대상 동작은 해당 커밋 이전에 존재했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
