### PR TITLE
fix(dashboard): preserve verification evidence roles

### DIFF
--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -252,6 +252,7 @@ export interface VerificationRequest {
   completion_contract: string[]
   required_artifacts: string[]
   submitted_evidence: string[]
+  evidence_projection_error: string | null
   verdict: VerificationRequestVerdict
   verdict_reason: string
 }

--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -250,7 +250,8 @@ export interface VerificationRequest {
   submitted_by: string
   approved_by: string | null
   completion_contract: string[]
-  required_evidence: string[]
+  required_artifacts: string[]
+  submitted_evidence: string[]
   verdict: VerificationRequestVerdict
   verdict_reason: string
 }

--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -104,7 +104,8 @@ function makeRequest(overrides: Partial<VerificationRequest> = {}): Verification
     submitted_by: 'agent-a',
     approved_by: null,
     completion_contract: [],
-    required_evidence: [],
+    required_artifacts: [],
+    submitted_evidence: [],
     verdict: null,
     verdict_reason: '',
     ...overrides,
@@ -281,6 +282,25 @@ describe('VerificationRequestsPanel', () => {
           'Reconcile board / planning / mutation surfaces before ordinary approval.',
         ),
       ).toBeTruthy()
+    })
+  })
+
+  it('renders required artifacts separately from submitted evidence', async () => {
+    setData([
+      makeRequest({
+        required_artifacts: ['artifact://required-contract'],
+        submitted_evidence: ['trace://submitted-runtime-proof'],
+      }),
+    ])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    fireEvent.click(screen.getByText('자세히'))
+    await waitFor(() => {
+      expect(screen.getByText('Required Artifacts')).toBeTruthy()
+      expect(screen.getByText('artifact://required-contract')).toBeTruthy()
+      expect(screen.getByText('Submitted Evidence')).toBeTruthy()
+      expect(screen.getByText('trace://submitted-runtime-proof')).toBeTruthy()
+      expect(screen.queryByText('Required Evidence')).toBeNull()
     })
   })
 })

--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -106,6 +106,7 @@ function makeRequest(overrides: Partial<VerificationRequest> = {}): Verification
     completion_contract: [],
     required_artifacts: [],
     submitted_evidence: [],
+    evidence_projection_error: null,
     verdict: null,
     verdict_reason: '',
     ...overrides,
@@ -302,6 +303,23 @@ describe('VerificationRequestsPanel', () => {
       expect(screen.getByText('trace://submitted-runtime-proof')).toBeTruthy()
       expect(screen.queryByText('Required Evidence')).toBeNull()
     })
+  })
+
+  it('renders missing and malformed evidence projection warnings', () => {
+    setData([
+      makeRequest({
+        evidence_projection_error:
+          'missing current-schema field "required_artifacts"; malformed current-schema field "submitted_evidence": expected an array of strings',
+      }),
+    ])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    expect(screen.getByRole('alert').textContent).toContain(
+      'missing current-schema field "required_artifacts"',
+    )
+    expect(screen.getByRole('alert').textContent).toContain(
+      'malformed current-schema field "submitted_evidence"',
+    )
   })
 })
 

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -325,6 +325,7 @@ function VerificationRow({
   const hasContract = row.completion_contract.length > 0
   const hasRequiredArtifacts = row.required_artifacts.length > 0
   const hasSubmittedEvidence = row.submitted_evidence.length > 0
+  const hasEvidenceProjectionError = row.evidence_projection_error != null
   const hasTaskTitle = row.task_title !== ''
   const hasRequestSummary = row.request_summary !== ''
   const hasNextAction = row.next_action != null && row.next_action !== ''
@@ -332,6 +333,7 @@ function VerificationRow({
     hasContract ||
     hasRequiredArtifacts ||
     hasSubmittedEvidence ||
+    hasEvidenceProjectionError ||
     hasTaskTitle ||
     hasRequestSummary ||
     hasNextAction ||
@@ -387,6 +389,16 @@ function VerificationRow({
           : html`<span class="text-[var(--color-fg-muted)]">—</span>`}
       </td>
       <td class="py-2">
+        ${hasEvidenceProjectionError
+          ? html`
+              <div
+                role="alert"
+                class="mb-1 text-3xs text-[var(--text-bad)]"
+              >
+                Evidence projection error: ${row.evidence_projection_error}
+              </div>
+            `
+          : null}
         ${hasDetails
           ? html`
               <details class="text-2xs">

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -323,13 +323,15 @@ function VerificationRow({
   refresh,
 }: { row: VerificationRequest; refresh: () => void }) {
   const hasContract = row.completion_contract.length > 0
-  const hasEvidence = row.required_evidence.length > 0
+  const hasRequiredArtifacts = row.required_artifacts.length > 0
+  const hasSubmittedEvidence = row.submitted_evidence.length > 0
   const hasTaskTitle = row.task_title !== ''
   const hasRequestSummary = row.request_summary !== ''
   const hasNextAction = row.next_action != null && row.next_action !== ''
   const hasDetails =
     hasContract ||
-    hasEvidence ||
+    hasRequiredArtifacts ||
+    hasSubmittedEvidence ||
     hasTaskTitle ||
     hasRequestSummary ||
     hasNextAction ||
@@ -426,12 +428,22 @@ function VerificationRow({
                         </div>
                       `
                     : null}
-                  ${hasEvidence
+                  ${hasRequiredArtifacts
                     ? html`
                         <div>
-                          <${DetailLabel}>Required Evidence</${DetailLabel}>
+                          <${DetailLabel}>Required Artifacts</${DetailLabel}>
                           <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)]">
-                            ${row.required_evidence.map((e) => html`<li><code>${e}</code></li>`)}
+                            ${row.required_artifacts.map((artifact) => html`<li><code>${artifact}</code></li>`)}
+                          </ul>
+                        </div>
+                      `
+                    : null}
+                  ${hasSubmittedEvidence
+                    ? html`
+                        <div>
+                          <${DetailLabel}>Submitted Evidence</${DetailLabel}>
+                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)]">
+                            ${row.submitted_evidence.map((evidence) => html`<li><code>${evidence}</code></li>`)}
                           </ul>
                         </div>
                       `

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -32,19 +32,35 @@ let completion_contract_of_criteria (criteria : V.criterion list) : string list 
     | V.Contains _ | V.Not_contains _ | V.Schema_match _ -> None
   ) criteria
 
-(** Read one current typed evidence list. Missing or malformed fields project
-    as empty; no legacy field aliases are consulted. *)
-let string_list_of_output field (output : Yojson.Safe.t) : string list =
+(** Read one required current-schema evidence list. Empty arrays are valid;
+    missing or malformed fields carry a public projection error. No legacy
+    field aliases are consulted and malformed arrays are never partially
+    projected. *)
+let string_list_of_output field (output : Yojson.Safe.t)
+  : string list * string option =
+  let missing () =
+    [], Some (Printf.sprintf "missing current-schema field %S" field)
+  in
+  let malformed detail =
+    ( [],
+      Some (Printf.sprintf
+        "malformed current-schema field %S: %s" field detail) )
+  in
+  let rec strings acc = function
+    | [] -> Some (List.rev acc)
+    | `String value :: rest -> strings (value :: acc) rest
+    | _ -> None
+  in
   match output with
   | `Assoc fields ->
       (match List.assoc_opt field fields with
        | Some (`List items) ->
-           List.filter_map (function
-             | `String s -> Some s
-             | _ -> None
-           ) items
-       | _ -> [])
-  | _ -> []
+           (match strings [] items with
+            | Some values -> values, None
+            | None -> malformed "expected an array of strings")
+       | Some _ -> malformed "expected an array of strings"
+       | None -> missing ())
+  | _ -> malformed "verification output must be an object"
 
 (* Pull task_title from the submit envelope so the UI detail cell has a
    fallback when contract/evidence/verdict_reason are all empty. Empty
@@ -120,11 +136,18 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
     derive_status_fields req
   in
   let contract = completion_contract_of_criteria req.criteria in
-  let required_artifacts =
+  let required_artifacts, required_artifacts_error =
     string_list_of_output "required_artifacts" req.output
   in
-  let submitted_evidence =
+  let submitted_evidence, submitted_evidence_error =
     string_list_of_output "submitted_evidence" req.output
+  in
+  let evidence_projection_error =
+    [required_artifacts_error; submitted_evidence_error]
+    |> List.filter_map Fun.id
+    |> function
+    | [] -> None
+    | errors -> Some (String.concat "; " errors)
   in
   let task_title = task_title_of_output req.output in
   let request_kind = request_kind_of_output req.output in
@@ -151,6 +174,8 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
      `List (List.map (fun s -> `String s) required_artifacts));
     ("submitted_evidence",
      `List (List.map (fun s -> `String s) submitted_evidence));
+    ("evidence_projection_error",
+     Json_util.string_opt_to_json evidence_projection_error);
     ("verdict", Json_util.string_opt_to_json verdict_opt);
     ("verdict_reason", `String verdict_reason);
   ]

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -32,13 +32,12 @@ let completion_contract_of_criteria (criteria : V.criterion list) : string list 
     | V.Contains _ | V.Not_contains _ | V.Schema_match _ -> None
   ) criteria
 
-(** The Verification_protocol.on_submit_for_verification writes
-    [output = { evidence_refs = [...]; task_title = "..." }]. We read
-    evidence_refs in a tolerant way: missing or malformed -> empty list. *)
-let required_evidence_of_output (output : Yojson.Safe.t) : string list =
+(** Read one current typed evidence list. Missing or malformed fields project
+    as empty; no legacy field aliases are consulted. *)
+let string_list_of_output field (output : Yojson.Safe.t) : string list =
   match output with
   | `Assoc fields ->
-      (match List.assoc_opt "evidence_refs" fields with
+      (match List.assoc_opt field fields with
        | Some (`List items) ->
            List.filter_map (function
              | `String s -> Some s
@@ -121,7 +120,12 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
     derive_status_fields req
   in
   let contract = completion_contract_of_criteria req.criteria in
-  let evidence = required_evidence_of_output req.output in
+  let required_artifacts =
+    string_list_of_output "required_artifacts" req.output
+  in
+  let submitted_evidence =
+    string_list_of_output "submitted_evidence" req.output
+  in
   let task_title = task_title_of_output req.output in
   let request_kind = request_kind_of_output req.output in
   let request_summary = request_summary_of_output req.output in
@@ -143,8 +147,10 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
     ("approved_by", Json_util.string_opt_to_json approved_by);
     ("completion_contract",
      `List (List.map (fun s -> `String s) contract));
-    ("required_evidence",
-     `List (List.map (fun s -> `String s) evidence));
+    ("required_artifacts",
+     `List (List.map (fun s -> `String s) required_artifacts));
+    ("submitted_evidence",
+     `List (List.map (fun s -> `String s) submitted_evidence));
     ("verdict", Json_util.string_opt_to_json verdict_opt);
     ("verdict_reason", `String verdict_reason);
   ]

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -39,6 +39,8 @@
         "completion_contract": [ "criterion text", ... ],
         "required_artifacts":  [ "required artifact", ... ],
         "submitted_evidence":  [ "submitted evidence ref", ... ],
+        "evidence_projection_error":
+          "missing/malformed current-schema field ..." | null,
         "verdict":             "pass" | "fail" | "partial" | null,
         "verdict_reason":      "..."
       }

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -1,5 +1,5 @@
 (** Dashboard projection for verification requests — the Mission detail table
-    that surfaces Completion Contract + Required Evidence per
+    that surfaces Completion Contract + Required Artifacts + Submitted Evidence per
     {!Verification_protocol} request.
 
     Consumes {!Verification.list_requests}, which reads
@@ -37,7 +37,8 @@
         "submitted_by":       "keeper-name",
         "approved_by":        "keeper-name" | null,
         "completion_contract": [ "criterion text", ... ],
-        "required_evidence":   [ "evidence description or ref", ... ],
+        "required_artifacts":  [ "required artifact", ... ],
+        "submitted_evidence":  [ "submitted evidence ref", ... ],
         "verdict":             "pass" | "fail" | "partial" | null,
         "verdict_reason":      "..."
       }

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -89,14 +89,26 @@ let test_config_input_override_restores_boot_override () =
     Alcotest.(check (option string)) "boot override restored"
       (Some "before") (Config_boot_overrides.get_opt name))
 
-let create_pending_request ~base_path ~task_id ~worker ~criteria ~evidence =
+let create_pending_request_with_artifacts ~required_artifacts ~base_path ~task_id
+    ~worker ~criteria ~evidence =
   let output = `Assoc [
-    ("evidence_refs", `List (List.map (fun s -> `String s) evidence));
+    ("required_artifacts",
+     `List (List.map (fun s -> `String s) required_artifacts));
+    ("submitted_evidence", `List (List.map (fun s -> `String s) evidence));
     ("task_title", `String (Printf.sprintf "title for %s" task_id));
   ] in
   match V.create_request ~base_path ~task_id ~output ~criteria ~worker () with
   | Ok req -> req
   | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e)
+
+let create_pending_request ~base_path ~task_id ~worker ~criteria ~evidence =
+  create_pending_request_with_artifacts
+    ~required_artifacts:[]
+    ~base_path
+    ~task_id
+    ~worker
+    ~criteria
+    ~evidence
 
 let member key j = Yojson.Safe.Util.member key j
 
@@ -144,14 +156,18 @@ let test_temp_base_path_overrides_and_restores_env_inputs () =
 
 let test_requests_json_shape () =
   with_temp_base_path (fun base_path ->
-    let _req = create_pending_request ~base_path
+    let _req = create_pending_request_with_artifacts ~base_path
         ~task_id:"task-shape"
         ~worker:"keeper-alpha"
         ~criteria:[
           V.Custom "Must reduce FD leak";
           V.Custom "Must pass integration tests";
         ]
-        ~evidence:["artifacts/lsof.before"; "artifacts/lsof.after"] in
+        ~required_artifacts:[
+          "artifact://required-report";
+          "artifact://required-test-log";
+        ]
+        ~evidence:["trace://submitted-runtime-proof"] in
     let j = D.requests_json ~base_path () in
     (* Envelope: updated_at, total, requests *)
     (match member "updated_at" j with
@@ -199,15 +215,26 @@ let test_requests_json_shape () =
            | _ -> Alcotest.fail "contract entry must be string"
          ) items
      | _ -> Alcotest.fail "completion_contract should be list");
-    (match member "required_evidence" r with
+    (match member "required_artifacts" r with
      | `List items ->
-         Alcotest.(check int) "required_evidence len"
+         Alcotest.(check (list string)) "required artifacts stay distinct"
+           ["artifact://required-report"; "artifact://required-test-log"]
+           (List.map Yojson.Safe.Util.to_string items);
+         Alcotest.(check int) "required_artifacts len"
            2 (List.length items);
          List.iter (function
            | `String _ -> ()
-           | _ -> Alcotest.fail "evidence entry must be string"
+           | _ -> Alcotest.fail "required artifact entry must be string"
          ) items
-     | _ -> Alcotest.fail "required_evidence should be list");
+     | _ -> Alcotest.fail "required_artifacts should be list");
+    (match member "submitted_evidence" r with
+     | `List items ->
+         Alcotest.(check (list string)) "submitted evidence stays distinct"
+           ["trace://submitted-runtime-proof"]
+           (List.map Yojson.Safe.Util.to_string items)
+     | _ -> Alcotest.fail "submitted_evidence should be list");
+    Alcotest.(check bool) "legacy required_evidence alias removed"
+      true (member "required_evidence" r = `Null);
     (* Pending status (no verifier yet) *)
     (match member "status" r with
      | `String "pending" -> ()
@@ -346,7 +373,8 @@ let test_requests_json_surfaces_conflict_triage_fields () =
   with_temp_base_path (fun base_path ->
     let output =
       `Assoc [
-        ("evidence_refs", `List [`String "ref-A"]);
+        ("required_artifacts", `List [`String "artifact://required-A"]);
+        ("submitted_evidence", `List [`String "trace://submitted-A"]);
         ("task_title", `String "conflict task");
         ("request_kind", `String "conflict_triage");
         ( "request_summary",

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -235,6 +235,8 @@ let test_requests_json_shape () =
      | _ -> Alcotest.fail "submitted_evidence should be list");
     Alcotest.(check bool) "legacy required_evidence alias removed"
       true (member "required_evidence" r = `Null);
+    Alcotest.(check bool) "valid empty/non-empty evidence has no projection error"
+      true (member "evidence_projection_error" r = `Null);
     (* Pending status (no verifier yet) *)
     (match member "status" r with
      | `String "pending" -> ()
@@ -413,6 +415,39 @@ let test_requests_json_surfaces_conflict_triage_fields () =
      | `String "Reconcile board / planning / mutation surfaces before ordinary approval." -> ()
      | _ -> Alcotest.fail "next_action mismatch"))
 
+let test_requests_json_surfaces_evidence_projection_error () =
+  with_temp_base_path (fun base_path ->
+    let output =
+      `Assoc [
+        ("submitted_evidence", `List [
+          `String "trace://must-not-be-partially-projected";
+          `Int 7;
+        ]);
+      ]
+    in
+    let _req =
+      match V.create_request ~base_path ~task_id:"task-malformed-evidence"
+              ~output ~criteria:[] ~worker:"keeper-alpha" () with
+      | Ok req -> req
+      | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e)
+    in
+    let row =
+      match member "requests" (D.requests_json ~base_path ()) with
+      | `List [row] -> row
+      | _ -> Alcotest.fail "expected one malformed evidence request"
+    in
+    Alcotest.(check (list string)) "missing required artifacts project empty"
+      [] (member "required_artifacts" row |> Yojson.Safe.Util.to_list
+          |> List.map Yojson.Safe.Util.to_string);
+    Alcotest.(check (list string)) "malformed submitted evidence projects empty"
+      [] (member "submitted_evidence" row |> Yojson.Safe.Util.to_list
+          |> List.map Yojson.Safe.Util.to_string);
+    Alcotest.(check string) "missing and malformed fields are distinguished"
+      ("missing current-schema field \"required_artifacts\"; "
+       ^ "malformed current-schema field \"submitted_evidence\": "
+       ^ "expected an array of strings")
+      (member "evidence_projection_error" row |> Yojson.Safe.Util.to_string))
+
 (* ── summary_json ───────────────────────────────────── *)
 
 let int_field name j =
@@ -555,6 +590,8 @@ let () =
         test_requests_json_ignores_legacy_root_entries;
       Alcotest.test_case "conflict triage fields" `Quick
         test_requests_json_surfaces_conflict_triage_fields;
+      Alcotest.test_case "evidence projection errors" `Quick
+        test_requests_json_surfaces_evidence_projection_error;
       Alcotest.test_case "fd pressure remains observation-only" `Quick
         test_requests_and_summary_remain_available_after_fd_observation;
     ];


### PR DESCRIPTION
## Summary

- project typed `required_artifacts` and `submitted_evidence` separately from the Verification request SSOT
- render distinct Required Artifacts and Submitted Evidence sections
- remove the semantically false legacy `required_evidence` alias pre-1.0
- add deliberately different OCaml and frontend fixtures so the roles cannot flatten again

## Boundary

- dashboard projection, API type, panel, and focused tests only
- no raw Verification store or Task FSM changes
- no filesystem authority and no overlap with #26003
- no migration or compatibility alias

## Validation

- focused OCaml build: pass
- `test_dashboard_verification`: 11/11 pass
- focused panel Vitest: 14/14 pass
- `tsc --noEmit`: pass
- `ocamlformat`, diff check, and static legacy-reference check: pass
- focused ESLint reports two pre-existing errors in the touched panel at lines 560 and 595; this PR does not alter those expressions

Closes #26001
