### PR TITLE
fix(librarian): coalesce saturated memory snapshots

### DIFF
--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -25,19 +25,25 @@ let lane_label = function
   | Librarian -> "librarian"
 ;;
 
+type librarian_drain =
+  { mutable latest : (unit -> unit) option
+  ; mutable in_flight : bool
+  ; mutable switch_hook : Eio.Switch.hook option
+  }
+
 type entry =
   { mem_mu : Eio.Mutex.t
-    (* Serializes memory work within one keeper and lane; the librarian lane
-       holds it across a provider round trip (seconds), hence the
-       fiber-cooperative Eio.Mutex. Raw lock/unlock, not [use_rw]: a raising
-       unit must not poison the lane. *)
+    (* Serializes deterministic work. Librarian work has one drain fiber, so its
+       [librarian_drain] state is the serialization boundary. *)
   ; state_mu : Stdlib.Mutex.t
-    (* Guards [pending]. Critical sections never yield. *)
+    (* Guards [pending] and [librarian_drain]. Critical sections never yield. *)
   ; mutable pending : int
+  ; mutable librarian_drain : librarian_drain option
   }
 
 type outcome =
   | Submitted
+  | Coalesced
   | Ran_inline
   | Dropped
 
@@ -86,6 +92,7 @@ let entry_for ~base_path ~keeper_name ~lane =
         { mem_mu = Eio.Mutex.create ()
         ; state_mu = Stdlib.Mutex.create ()
         ; pending = 0
+        ; librarian_drain = None
         }
       in
       Hashtbl.add entries key e;
@@ -125,6 +132,20 @@ let inc_in_flight ~keeper_name ~lane () =
 let dec_in_flight ~keeper_name ~lane () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLaneInFlight)
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ()
+;;
+
+let inc_latest_pending ~keeper_name ~lane () =
+  Otel_metric_store.inc_gauge
+    (metric_name MemoryLaneLatestPending)
+    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ()
+;;
+
+let dec_latest_pending ~keeper_name ~lane () =
+  Otel_metric_store.dec_gauge
+    (metric_name MemoryLaneLatestPending)
     ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
     ()
 ;;
@@ -245,6 +266,267 @@ let run_unit ~keeper_name ~lane entry reservation sw f =
           (Printexc.to_string exn))
 ;;
 
+type librarian_submission =
+  | Start_drain of librarian_drain
+  | Queue_latest
+  | Replace_latest
+
+type librarian_drain_step =
+  | Drain_stopped
+  | Drain_done of Eio.Switch.hook option
+  | Drain_next of (unit -> unit)
+
+let librarian_reserve entry f =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    match entry.librarian_drain with
+    | None ->
+      let drain = { latest = None; in_flight = false; switch_hook = None } in
+      entry.librarian_drain <- Some drain;
+      entry.pending <- 1;
+      Start_drain drain
+    | Some drain ->
+      (match drain.latest with
+       | None ->
+         drain.latest <- Some f;
+         entry.pending <- entry.pending + 1;
+         Queue_latest
+       | Some _ ->
+         drain.latest <- Some f;
+         Replace_latest))
+;;
+
+let librarian_drain_is_active entry drain =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    match entry.librarian_drain with
+    | Some current -> current == drain
+    | None -> false)
+;;
+
+let emit_librarian_cleanup ~keeper_name ~pending ~in_flight ~latest_pending =
+  for _ = 1 to pending do
+    protect_cleanup ~keeper_name ~lane:Librarian "dec_pending" (fun () ->
+      dec_pending ~keeper_name ~lane:Librarian ())
+  done;
+  if in_flight
+  then
+    protect_cleanup ~keeper_name ~lane:Librarian "dec_in_flight" (fun () ->
+      dec_in_flight ~keeper_name ~lane:Librarian ());
+  if latest_pending
+  then
+    protect_cleanup ~keeper_name ~lane:Librarian "dec_latest_pending" (fun () ->
+      dec_latest_pending ~keeper_name ~lane:Librarian ())
+;;
+
+let detach_librarian_drain entry drain =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    match entry.librarian_drain with
+    | Some current when current == drain ->
+      let pending = entry.pending in
+      let in_flight = drain.in_flight in
+      let latest_pending = Option.is_some drain.latest in
+      let hook = drain.switch_hook in
+      entry.pending <- 0;
+      entry.librarian_drain <- None;
+      drain.latest <- None;
+      drain.in_flight <- false;
+      drain.switch_hook <- None;
+      Some (pending, in_flight, latest_pending, hook)
+    | Some _ | None -> None)
+;;
+
+let cleanup_librarian_drain ~keeper_name ~remove_hook entry drain =
+  match detach_librarian_drain entry drain with
+  | None -> ()
+  | Some (pending, in_flight, latest_pending, hook) ->
+    emit_librarian_cleanup ~keeper_name ~pending ~in_flight ~latest_pending;
+    if remove_hook
+    then Option.iter (fun h -> ignore (Eio.Switch.try_remove_hook h)) hook
+;;
+
+let arm_librarian_switch_release ~keeper_name entry drain sw =
+  let release_from_switch () =
+    protect_cleanup ~keeper_name ~lane:Librarian
+      "librarian_executor_switch_release"
+      (fun () ->
+        cleanup_librarian_drain ~keeper_name ~remove_hook:false entry drain)
+  in
+  try
+    let hook = Eio.Switch.on_release_cancellable sw release_from_switch in
+    let retained =
+      Stdlib.Mutex.protect entry.state_mu (fun () ->
+        match entry.librarian_drain with
+        | Some current when current == drain ->
+          drain.switch_hook <- Some hook;
+          true
+        | Some _ | None -> false)
+    in
+    if not retained then ignore (Eio.Switch.try_remove_hook hook)
+  with
+  | _exn ->
+    (* A finished switch may run the callback and raise while registering it.
+       Cleanup is idempotent for this exact drain identity. *)
+    release_from_switch ()
+;;
+
+let librarian_begin_current ~keeper_name entry drain =
+  let started =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      match entry.librarian_drain with
+      | Some current when current == drain ->
+        drain.in_flight <- true;
+        true
+      | Some _ | None -> false)
+  in
+  if started then inc_in_flight ~keeper_name ~lane:Librarian ();
+  started
+;;
+
+let librarian_finish_current ~keeper_name entry drain =
+  let in_flight, took_latest, step =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      match entry.librarian_drain with
+      | Some current when current == drain ->
+        let in_flight = drain.in_flight in
+        drain.in_flight <- false;
+        entry.pending <- entry.pending - 1;
+        (match drain.latest with
+         | Some next ->
+           drain.latest <- None;
+           in_flight, true, Drain_next next
+         | None ->
+           let hook = drain.switch_hook in
+           drain.switch_hook <- None;
+           entry.librarian_drain <- None;
+           in_flight, false, Drain_done hook)
+      | Some _ | None -> false, false, Drain_stopped)
+  in
+  if in_flight
+  then dec_in_flight ~keeper_name ~lane:Librarian ();
+  (match step with
+   | Drain_stopped -> ()
+   | Drain_done _ | Drain_next _ ->
+     dec_pending ~keeper_name ~lane:Librarian ());
+  if took_latest then dec_latest_pending ~keeper_name ~lane:Librarian ();
+  step
+;;
+
+let rec run_librarian_drain ~keeper_name entry drain sw current =
+  if librarian_begin_current ~keeper_name entry drain
+  then (
+    let cancelled =
+      try
+        Eio_context.with_turn_switch sw current;
+        false
+      with
+      | Eio.Cancel.Cancelled _ -> true
+      | exn ->
+        record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+        Log.Keeper.warn ~keeper_name
+          "memory lane unit failed: %s"
+          (Printexc.to_string exn);
+        false
+    in
+    if cancelled
+    then cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain
+    else (
+      match librarian_finish_current ~keeper_name entry drain with
+      | Drain_stopped -> ()
+      | Drain_done hook ->
+        Option.iter (fun h -> ignore (Eio.Switch.try_remove_hook h)) hook
+      | Drain_next latest ->
+        run_librarian_drain ~keeper_name entry drain sw latest))
+;;
+
+let submit_librarian ~keeper_name entry sw f =
+  match librarian_reserve entry f with
+  | Queue_latest ->
+    inc_pending ~keeper_name ~lane:Librarian ();
+    inc_latest_pending ~keeper_name ~lane:Librarian ();
+    record_counter ~keeper_name ~lane:Librarian MemoryLaneSubmitted;
+    Submitted
+  | Replace_latest ->
+    record_counter ~keeper_name ~lane:Librarian MemoryLaneCoalesced;
+    Log.Keeper.warn ~keeper_name
+      "memory lane coalesced latest snapshot (lane=librarian pending=2): replacing \
+       superseded post-turn memory unit";
+    Coalesced
+  | Start_drain drain ->
+    inc_pending ~keeper_name ~lane:Librarian ();
+    record_counter ~keeper_name ~lane:Librarian MemoryLaneSubmitted;
+    arm_librarian_switch_release ~keeper_name entry drain sw;
+    if not (librarian_drain_is_active entry drain)
+    then (
+      record_counter ~keeper_name ~lane:Librarian MemoryLaneDropped;
+      Log.Keeper.warn ~keeper_name
+        "memory lane executor switch unavailable (lane=librarian): dropping post-turn \
+         memory unit";
+      Dropped)
+    else (
+      try
+        Eio.Fiber.fork ~sw (fun () ->
+          run_librarian_drain ~keeper_name entry drain sw f);
+        Submitted
+      with
+      | Eio.Cancel.Cancelled _ as e ->
+        cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain;
+        raise e
+      | exn ->
+        cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain;
+        record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+        Log.Keeper.warn ~keeper_name
+          "memory lane fork failed: %s"
+          (Printexc.to_string exn);
+        Dropped)
+;;
+
+let submit_bounded ~keeper_name ~lane entry sw f =
+  match try_reserve ~keeper_name ~lane entry with
+  | None ->
+    record_counter ~keeper_name ~lane MemoryLaneDropped;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:
+        [ "keeper", keeper_name
+        ; "site", "memory_lane_saturated"
+        ; "lane", lane_label lane
+        ]
+      ();
+    Log.Keeper.warn ~keeper_name
+      "memory lane saturated (lane=%s pending>=%d): dropping post-turn memory unit"
+      (lane_label lane)
+      (max_pending ());
+    Dropped
+  | Some _bound ->
+    let reservation = make_reservation () in
+    arm_switch_release ~keeper_name ~lane entry reservation sw;
+    if reservation_released reservation
+    then (
+      record_counter ~keeper_name ~lane MemoryLaneDropped;
+      Log.Keeper.warn ~keeper_name
+        "memory lane executor switch unavailable (lane=%s): dropping post-turn memory unit"
+        (lane_label lane);
+      Dropped)
+    else (
+      try
+        record_counter ~keeper_name ~lane MemoryLaneSubmitted;
+        Eio.Fiber.fork ~sw (fun () ->
+          run_unit ~keeper_name ~lane entry reservation sw f);
+        Submitted
+      with
+      | Eio.Cancel.Cancelled _ as e ->
+        protect_cleanup ~keeper_name ~lane "fork_cancel_release" (fun () ->
+          release_reservation_once ~keeper_name ~lane entry reservation);
+        raise e
+      | exn ->
+        protect_cleanup ~keeper_name ~lane "fork_failure_release" (fun () ->
+          release_reservation_once ~keeper_name ~lane entry reservation);
+        record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
+        Log.Keeper.warn ~keeper_name
+          "memory lane fork failed: %s"
+          (Printexc.to_string exn);
+        Dropped)
+;;
+
 let submit ~base_path ~keeper_name ~lane f =
   match current_sw () with
   | None ->
@@ -262,52 +544,9 @@ let submit ~base_path ~keeper_name ~lane f =
     Ran_inline
   | Some sw ->
     let entry = entry_for ~base_path ~keeper_name ~lane in
-    (match try_reserve ~keeper_name ~lane entry with
-     | None ->
-       record_counter ~keeper_name ~lane MemoryLaneDropped;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string DispatchEventFailures)
-         ~labels:
-           [ "keeper", keeper_name
-           ; "site", "memory_lane_saturated"
-           ; "lane", lane_label lane
-           ]
-         ();
-       Log.Keeper.warn ~keeper_name
-         "memory lane saturated (lane=%s pending>=%d): dropping post-turn memory unit"
-         (lane_label lane)
-         (max_pending ());
-       Dropped
-     | Some _bound ->
-       let reservation = make_reservation () in
-       arm_switch_release ~keeper_name ~lane entry reservation sw;
-       if reservation_released reservation
-       then (
-         record_counter ~keeper_name ~lane MemoryLaneDropped;
-         Log.Keeper.warn ~keeper_name
-           "memory lane executor switch unavailable (lane=%s): dropping post-turn memory \
-            unit"
-           (lane_label lane);
-         Dropped)
-       else (
-         try
-           record_counter ~keeper_name ~lane MemoryLaneSubmitted;
-           Eio.Fiber.fork ~sw (fun () ->
-             run_unit ~keeper_name ~lane entry reservation sw f);
-           Submitted
-         with
-         | Eio.Cancel.Cancelled _ as e ->
-           protect_cleanup ~keeper_name ~lane "fork_cancel_release" (fun () ->
-             release_reservation_once ~keeper_name ~lane entry reservation);
-           raise e
-         | exn ->
-           protect_cleanup ~keeper_name ~lane "fork_failure_release" (fun () ->
-             release_reservation_once ~keeper_name ~lane entry reservation);
-           record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
-           Log.Keeper.warn ~keeper_name
-             "memory lane fork failed: %s"
-             (Printexc.to_string exn);
-           Dropped))
+    (match lane with
+     | Librarian -> submit_librarian ~keeper_name entry sw f
+     | Deterministic -> submit_bounded ~keeper_name ~lane entry sw f)
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -25,10 +25,12 @@
     retry. Each lane now has its own mutex and its own budget; ordering within a
     lane is unchanged.
 
-    The per-keeper, per-lane reservation bound is controlled by
-    [MASC_KEEPER_MEMORY_LANE_MAX_PENDING] (default [2]). Submission outcomes
-    are counted under [masc_keeper_memory_lane_*] and per-keeper pending /
-    in-flight gauges are exported, all labelled by [lane]. *)
+    The deterministic per-keeper reservation bound is controlled by
+    [MASC_KEEPER_MEMORY_LANE_MAX_PENDING] (default [2]). Librarian work instead
+    has a fixed process-local bound of one running unit plus one overwriteable
+    latest snapshot. Submission outcomes are counted under
+    [masc_keeper_memory_lane_*]; per-keeper pending, in-flight, and
+    latest-pending gauges are exported, all labelled by [lane]. *)
 
 type lane =
   | Deterministic
@@ -36,19 +38,24 @@ type lane =
           permanent, so it must not queue behind provider-backed work. *)
   | Librarian
       (** Provider-backed episode extraction. Holds its lane across the round
-          trip; a drop is retried on the next due turn by its own cadence. *)
+          trip. Saturated submissions replace the queued latest snapshot, so
+          cleanup remains reliably eventual without blocking the Keeper turn. *)
 
 type outcome =
   | Submitted
-      (** Forked onto the keeper's lane and serialized behind its mutex. *)
+      (** Accepted as the running unit or the queued latest snapshot. *)
+  | Coalesced
+      (** The Librarian lane already had one running and one latest unit. The
+          prior latest snapshot was replaced atomically by this newer immutable
+          snapshot. Deterministic submissions never return this outcome. *)
   | Ran_inline
       (** Executor switch not initialized; the unit ran synchronously in the
           caller so no work is lost (tests, or startup before {!init}). A
           raising unit is contained and emits a metric instead of escaping. *)
   | Dropped
-      (** The keeper's lane was saturated (pending at the bound); the unit was
-          discarded. Memory extraction is best-effort, so saturation drops
-          rather than blocking the turn. The drop is counted, never silent. *)
+      (** The executor switch could not own the unit, or the deterministic lane
+          was saturated. Librarian saturation returns {!Coalesced}, not
+          [Dropped]. The drop is counted, never silent. *)
 
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
@@ -61,11 +68,12 @@ val submit
   -> (unit -> unit)
   -> outcome
 (** [submit ~base_path ~keeper_name ~lane f] runs [f] on [keeper_name]'s [lane].
-    When the executor switch is set, [f] is forked and serialized behind that
-    keeper's mutex; over the pending bound it is dropped and counted. When the
-    executor is not initialized, [f] runs inline and any exception is contained
-    and counted rather than escaping. The bound, outcomes, and per-keeper
-    pending/in-flight state are exported as metrics. *)
+    With an executor switch, deterministic work retains the bounded serialized
+    submission policy. Librarian work uses a non-blocking latest-wins drain:
+    one running unit plus one overwriteable latest snapshot. When the executor
+    is not initialized, [f] runs inline and any exception is contained and
+    counted rather than escaping. Outcomes and per-keeper state are exported as
+    metrics. *)
 
 module For_testing : sig
   val reset : unit -> unit

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -141,8 +141,10 @@ type t =
   | MemoryLaneSubmitted
   | MemoryLaneRanInline
   | MemoryLaneDropped
+  | MemoryLaneCoalesced
   | MemoryLanePending
   | MemoryLaneInFlight
+  | MemoryLaneLatestPending
   | MemoryLaneExecutionSlotBusy
   | MemoryBankCompactionFailures
   | WriteMetaCycleFailures
@@ -359,8 +361,10 @@ let to_string = function
   | MemoryLaneSubmitted -> "masc_keeper_memory_lane_submitted_total"
   | MemoryLaneRanInline -> "masc_keeper_memory_lane_ran_inline_total"
   | MemoryLaneDropped -> "masc_keeper_memory_lane_dropped_total"
+  | MemoryLaneCoalesced -> "masc_keeper_memory_lane_coalesced_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
+  | MemoryLaneLatestPending -> "masc_keeper_memory_lane_latest_pending"
   | MemoryLaneExecutionSlotBusy -> "masc_keeper_memory_lane_execution_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -132,8 +132,10 @@ type t =
   | MemoryLaneSubmitted
   | MemoryLaneRanInline
   | MemoryLaneDropped
+  | MemoryLaneCoalesced
   | MemoryLanePending
   | MemoryLaneInFlight
+  | MemoryLaneLatestPending
   | MemoryLaneExecutionSlotBusy
   | MemoryBankCompactionFailures
   | WriteMetaCycleFailures

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -22,6 +22,7 @@ let test_inline_when_uninitialized () =
   match outcome with
   | Lane.Ran_inline -> ()
   | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
+  | Lane.Coalesced -> Alcotest.fail "expected Ran_inline, got Coalesced"
   | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
 ;;
 
@@ -34,6 +35,7 @@ let test_inline_contains_raise () =
   match outcome with
   | Lane.Ran_inline -> ()
   | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
+  | Lane.Coalesced -> Alcotest.fail "expected Ran_inline, got Coalesced"
   | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
 ;;
 
@@ -103,19 +105,23 @@ let test_independent_across_keepers () =
   Alcotest.(check (list string)) "k2 before k1" [ "k2"; "k1" ] (List.rev !order)
 ;;
 
-(* With max_pending = 2, a third concurrent unit for one keeper is dropped. *)
-let test_saturation_drops () =
+(* The deterministic lane retains its existing bounded-drop policy. *)
+let test_deterministic_saturation_drops () =
   Lane.For_testing.reset ();
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
       let p_release, set_release = Eio.Promise.create () in
       let o1 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () ->
           Eio.Promise.await p_release)
       in
-      let o2 = Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ()) in
-      let o3 = Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ()) in
+      let o2 =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () -> ())
+      in
+      let o3 =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () -> ())
+      in
       (match o1 with
        | Lane.Submitted -> ()
        | _ -> Alcotest.fail "o1 not submitted");
@@ -125,8 +131,62 @@ let test_saturation_drops () =
       (match o3 with
        | Lane.Dropped -> ()
        | Lane.Submitted -> Alcotest.fail "o3 should be Dropped, got Submitted"
+       | Lane.Coalesced -> Alcotest.fail "deterministic lane must not coalesce"
        | Lane.Ran_inline -> Alcotest.fail "o3 should be Dropped, got Ran_inline");
       Eio.Promise.resolve set_release ()))
+;;
+
+(* Librarian saturation keeps one running unit and one overwriteable latest
+   snapshot. Every submit returns immediately; only the newest pending snapshot
+   evaluates after the blocker. *)
+let test_librarian_saturation_coalesces_latest () =
+  Lane.For_testing.reset ();
+  let evaluated = ref [] in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let started, set_started = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
+      let running =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await release;
+          evaluated := "running" :: !evaluated)
+      in
+      Eio.Promise.await started;
+      let snapshot trace generation messages () =
+        evaluated :=
+          Printf.sprintf "%s:%d:%s" trace generation (String.concat "," messages)
+          :: !evaluated
+      in
+      let stale =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian
+          (snapshot "trace-stale" 1 [ "stale" ])
+      in
+      let newer =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian
+          (snapshot "trace-newer" 2 [ "newer" ])
+      in
+      let newest =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian
+          (snapshot "trace-newest" 3 [ "newest-a"; "newest-b" ])
+      in
+      (match running, stale, newer, newest with
+       | Lane.Submitted, Lane.Submitted, Lane.Coalesced, Lane.Coalesced -> ()
+       | _ -> Alcotest.fail "unexpected Librarian coalescing outcomes");
+      (match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+       | Some 2 -> ()
+       | Some n -> Alcotest.failf "running+latest bound should be 2, got %d" n
+       | None -> Alcotest.fail "missing Librarian lane entry");
+      Eio.Promise.resolve set_release ()));
+  Alcotest.(check (list string))
+    "only running and newest snapshot evaluate"
+    [ "running"; "trace-newest:3:newest-a,newest-b" ]
+    (List.rev !evaluated);
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+  | Some 0 -> ()
+  | Some n -> Alcotest.failf "pending leaked after coalesced drain: %d" n
+  | None -> Alcotest.fail "Librarian lane entry missing"
 ;;
 
 (* The regression this split exists for: a saturated librarian lane must not
@@ -161,10 +221,12 @@ let test_lanes_have_independent_budgets () =
        | Lane.Submitted, Lane.Submitted -> ()
        | _ -> Alcotest.fail "librarian lane should admit two units");
       (match lib3 with
-       | Lane.Dropped -> ()
-       | _ -> Alcotest.fail "librarian lane should be saturated at the bound");
+       | Lane.Coalesced -> ()
+       | _ -> Alcotest.fail "librarian lane should coalesce at the bound");
       (match det with
        | Lane.Submitted -> ()
+       | Lane.Coalesced ->
+         Alcotest.fail "deterministic unit must not use Librarian coalescing"
        | Lane.Dropped ->
          Alcotest.fail "deterministic unit dropped by a saturated librarian lane"
        | Lane.Ran_inline -> Alcotest.fail "deterministic unit ran inline");
@@ -183,21 +245,28 @@ let test_lanes_have_independent_budgets () =
    recovers and later units run. *)
 let test_releases_on_raise () =
   Lane.For_testing.reset ();
-  let ran_after = ref false in
+  let latest_ran = ref false in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> raise Test_boom)
+      let started, set_started = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
+      let first =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await release;
+          raise Test_boom)
       in
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ();
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ran_after := true)
+      Eio.Promise.await started;
+      let latest =
+        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+          latest_ran := true)
       in
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ()));
-  Alcotest.(check bool) "lane recovered after raise" true !ran_after;
+      (match first, latest with
+       | Lane.Submitted, Lane.Submitted -> ()
+       | _ -> Alcotest.fail "raise fixture submissions were not accepted");
+      Eio.Promise.resolve set_release ()));
+  Alcotest.(check bool) "latest runs after raising unit" true !latest_ran;
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked: %d" n
@@ -207,6 +276,7 @@ let test_releases_on_raise () =
 (* Cancellation during shutdown releases both the mutex and the pending slot. *)
 let test_releases_on_cancel () =
   Lane.For_testing.reset ();
+  let latest_ran = ref false in
   (try
      Eio_main.run (fun _env ->
        Eio.Switch.run (fun sw ->
@@ -218,14 +288,25 @@ let test_releases_on_cancel () =
              Eio.Promise.resolve set_started ();
              Eio.Promise.await never)
          in
+         let latest =
+           Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+             latest_ran := true)
+         in
          (match outcome with
           | Lane.Submitted -> ()
-         | Lane.Ran_inline -> Alcotest.fail "cancel test unexpectedly ran inline"
-         | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped");
+          | Lane.Coalesced -> Alcotest.fail "first cancel unit unexpectedly coalesced"
+          | Lane.Ran_inline -> Alcotest.fail "cancel test unexpectedly ran inline"
+          | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped");
+         (match latest with
+          | Lane.Submitted -> ()
+          | Lane.Coalesced -> Alcotest.fail "first latest unit unexpectedly coalesced"
+         | Lane.Ran_inline -> Alcotest.fail "latest cancel unit unexpectedly ran inline"
+          | Lane.Dropped -> Alcotest.fail "latest cancel unit unexpectedly dropped");
          Eio.Promise.await started;
          Eio.Switch.fail sw Cancel_lane_test))
    with
    | Cancel_lane_test -> ());
+  Alcotest.(check bool) "latest did not run after switch cancel" false !latest_ran;
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after cancel: %d" n
@@ -254,6 +335,7 @@ let test_finished_switch_drops_without_leak () =
   (match outcome with
    | Lane.Dropped -> ()
    | Lane.Submitted -> Alcotest.fail "expected Dropped, got Submitted"
+   | Lane.Coalesced -> Alcotest.fail "expected Dropped, got Coalesced"
    | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline");
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
   | Some 0 -> ()
@@ -281,7 +363,14 @@ let () =
             "independent across keepers"
             `Quick
             test_independent_across_keepers
-        ; Alcotest.test_case "saturation drops" `Quick test_saturation_drops
+        ; Alcotest.test_case
+            "deterministic saturation drops"
+            `Quick
+            test_deterministic_saturation_drops
+        ; Alcotest.test_case
+            "librarian saturation coalesces latest"
+            `Quick
+            test_librarian_saturation_coalesces_latest
         ; Alcotest.test_case
             "lanes have independent budgets"
             `Quick


### PR DESCRIPTION
## Summary

- replace Librarian saturation drops with a per-Keeper process-local latest-wins drain
- keep at most one running input and one overwriteable latest immutable snapshot
- return typed `Coalesced` immediately and drain the latest after current completion
- clear the latest slot on cancellation/switch release
- expose coalesced total and latest-pending metrics
- leave the deterministic memory lane unchanged

## Boundary

- no lease, durable store, migration, FSM, replay facade, or Keeper-turn blocking
- no overlap with #26003 or #26012

## Validation

- focused build: pass
- `test_keeper_memory_lane`: 10/10 pass
- cancellation regression caught and fixed a race that would have drained latest after switch cancellation
- `ocamlformat` and diff check: pass

Closes #26016
