### PR TITLE
fix(tui): send valid Keeper chat payloads

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -6,7 +6,7 @@ open Masc_tui_loader
 (** Local exception for breaking the main TUI loop without using Exit. *)
 exception Break
 
-(** Send a message to a keeper via HTTP POST to /api/v1/keepers/chat/stream *)
+(** Send a message through the Keeper chat streaming endpoint. *)
 let send_keeper_message (state : state) (keeper_name : string) (message : string) : string =
   try
     let host = Env_config_core.masc_host () in
@@ -17,7 +17,6 @@ let send_keeper_message (state : state) (keeper_name : string) (message : string
           [
             ("name", `String keeper_name);
             ("message", `String message);
-            ("models", `List []);
           ])
     in
     match

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -36,6 +36,16 @@ let test_http_client_does_not_own_tui_env_contract () =
     (Ast_grep.count_value_bindings ~module_path ~name:"timeout_env")
 ;;
 
+let test_keeper_chat_omits_removed_model_args () =
+  let module_path = "bin/masc_tui.ml" in
+  check int "TUI keeper chat has no removed models field" 0
+    (Ast_grep.count_string_literals ~module_path ~needle:"models");
+  check int "TUI still targets the keeper chat stream" 1
+    (Ast_grep.count_string_literals
+       ~module_path
+       ~needle:"/api/v1/keepers/chat/stream")
+;;
+
 let test_planning_constructors_do_not_collide () =
   let module_path = "bin/masc_tui_types.ml" in
   let planning_mode_constructors =
@@ -159,6 +169,10 @@ let () =
           "http client does not own TUI env contract"
           `Quick
           test_http_client_does_not_own_tui_env_contract;
+        test_case
+          "keeper chat omits removed model args"
+          `Quick
+          test_keeper_chat_omits_removed_model_args;
         test_case
           "planning constructors do not collide"
           `Quick


### PR DESCRIPTION
## Problem

The TUI Keeper chat request always included `"models": []`. The public Keeper chat endpoint rejects any `models` field because per-call model selection was removed, so TUI messages could never enter the Keeper queue.

## Change

Remove the stale field and add an AST regression that keeps the streaming endpoint while forbidding the removed payload key.

## Validation

- `scripts/dune-local.sh build bin/masc_tui.exe @runtest-test_tui_http_ast`
- 8 TUI HTTP regression tests passed
- `git diff --check`