### PR TITLE
fix(keeper): cue goal completion after terminal tasks

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -91,15 +91,20 @@ let goal_completion_next_action ~config ~task_id =
       tasks
   with
   | Some { task_status = Masc_domain.Done _; _ } ->
+    let goal_task_links =
+      Workspace_goal_index.read_goal_task_links config
+    in
     let task_goal_index =
-      Workspace_goal_index.build_task_goal_index_for_config config
+      Workspace_goal_index.build_task_goal_index ~goal_task_links ()
     in
     (match Stdlib.Hashtbl.find_opt task_goal_index task_id with
      | Some [ goal_id ] ->
        (match Goal_store.get_goal config ~goal_id with
         | Some { phase = Goal_phase.Executing; _ } ->
           let goal_task_index =
-            Workspace_goal_index.build_goal_task_index_for_config config tasks
+            Workspace_goal_index.build_goal_task_index
+              ~goal_task_links
+              tasks
           in
           if
             Workspace_goal_index.tasks_for_goal goal_task_index ~goal_id <> []

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -268,7 +268,17 @@ and handle_transition
       ctx
       ~task_id
       ~action_s
-  | Some _ ->
+  | Some task_before ->
+  let task_was_done_before =
+    match task_before.task_status with
+    | Masc_domain.Done _ -> true
+    | Masc_domain.Todo
+    | Masc_domain.Claimed _
+    | Masc_domain.InProgress _
+    | Masc_domain.AwaitingVerification _
+    | Masc_domain.Cancelled _ ->
+      false
+  in
   let release_owner_mismatch_rejection =
     match action, task_opt with
     | Masc_domain.Release, Some task ->
@@ -702,7 +712,8 @@ and handle_transition
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
    | Error _, _ -> ());
   match result, task_list_projection with
-  | Ok message, Tool_capability_projection.Keeper_tasks_list ->
+  | Ok message, Tool_capability_projection.Keeper_tasks_list
+    when not task_was_done_before ->
     (match goal_completion_next_action ~config:ctx.config ~task_id with
      | Some next_action ->
        Tool_result.make_ok
@@ -716,6 +727,8 @@ and handle_transition
               ])
          ()
      | None -> result_to_response ~tool_name ~start_time result)
+  | Ok _, Tool_capability_projection.Keeper_tasks_list ->
+    result_to_response ~tool_name ~start_time result
   | Error _, Tool_capability_projection.Keeper_tasks_list ->
     result_to_response ~tool_name ~start_time result
   | (Ok _ | Error _), Tool_capability_projection.External_masc_tasks ->

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -83,6 +83,46 @@ let missing_live_task_transition_rejection ~task_list_projection ~tool_name
         bindings and suppressed transition action=%s."
        task_id action_s)
 
+let goal_completion_next_action ~config ~task_id =
+  let tasks = Workspace.get_tasks_raw config in
+  match
+    List.find_opt
+      (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+      tasks
+  with
+  | Some { task_status = Masc_domain.Done _; _ } ->
+    let task_goal_index =
+      Workspace_goal_index.build_task_goal_index_for_config config
+    in
+    (match Stdlib.Hashtbl.find_opt task_goal_index task_id with
+     | Some [ goal_id ] ->
+       (match Goal_store.get_goal config ~goal_id with
+        | Some { phase = Goal_phase.Executing; _ } ->
+          let goal_task_index =
+            Workspace_goal_index.build_goal_task_index_for_config config tasks
+          in
+          if
+            Workspace_goal_index.tasks_for_goal goal_task_index ~goal_id <> []
+            && Workspace_goal_index.open_task_count_for_goal_indexed
+                 goal_task_index
+                 ~goal_id
+               = 0
+          then
+            Some
+              (`Assoc
+                 [ "tool", `String "masc_goal_transition"
+                 ; ( "arguments"
+                   , `Assoc
+                       [ "goal_id", `String goal_id
+                       ; "action", `String "request_complete"
+                       ] )
+                 ; "reason", `String "all_linked_tasks_terminal"
+                 ])
+          else None
+        | Some _ | None -> None)
+     | Some (_ :: _ :: _) | Some [] | None -> None)
+  | Some _ | None -> None
+
 let rec handle_done
       ?(task_list_projection = Tool_capability_projection.External_masc_tasks)
       ~tool_name ~start_time ctx args =
@@ -661,7 +701,25 @@ and handle_transition
    | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
    | Error _, _ -> ());
-  result_to_response ~tool_name ~start_time result
+  match result, task_list_projection with
+  | Ok message, Tool_capability_projection.Keeper_tasks_list ->
+    (match goal_completion_next_action ~config:ctx.config ~task_id with
+     | Some next_action ->
+       Tool_result.make_ok
+         ~tool_name
+         ~start_time
+         ~data:
+           (`Assoc
+              [ "message", `String message
+              ; "task_id", `String task_id
+              ; "next_action", next_action
+              ])
+         ()
+     | None -> result_to_response ~tool_name ~start_time result)
+  | Error _, Tool_capability_projection.Keeper_tasks_list ->
+    result_to_response ~tool_name ~start_time result
+  | (Ok _ | Error _), Tool_capability_projection.External_masc_tasks ->
+    result_to_response ~tool_name ~start_time result
 
 let handle_update_priority ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1954,6 +1954,15 @@ let () =
        in
        if not (Tool_result.is_success submit_result) then
          failwith (Tool_result.message submit_result);
+       let claim_result =
+         Task.Tool.handle_claim
+           ~tool_name:"keeper_task_claim"
+           ~start_time:0.0
+           verifier_ctx
+           (`Assoc [ "task_id", `String "task-001" ])
+       in
+       if not (Tool_result.is_success claim_result) then
+         failwith (Tool_result.message claim_result);
        let result =
          keeper_transition
            verifier_ctx

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -242,6 +242,67 @@ let start_task_001 ctx =
   in
   if not (Tool_result.is_success start) then failwith (Tool_result.message start)
 
+let create_executing_goal ctx ~goal_id =
+  match
+    Goal_store.upsert_goal
+      ctx.Task.Tool.config
+      ~id:goal_id
+      ~title:("Goal " ^ goal_id)
+      ~phase:Goal_phase.Executing
+      ()
+  with
+  | Ok goal -> goal
+  | Error message -> failwith message
+
+let add_goal_linked_task ctx ~goal_id ~title =
+  let result =
+    Task.Tool.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ "title", `String title; "goal_id", `String goal_id ])
+  in
+  if not (Tool_result.is_success result) then
+    failwith (Tool_result.message result)
+
+let keeper_transition ctx args =
+  match
+    Task.Tool.dispatch_for_keeper
+      ~created_by:ctx.Task.Tool.agent_name
+      ctx
+      ~name:"masc_transition"
+      ~args
+  with
+  | Some result -> result
+  | None -> failwith "Keeper transition dispatch returned None"
+
+let assert_goal_completion_next_action result ~goal_id =
+  if not (Tool_result.is_success result) then
+    failwith (Tool_result.message result);
+  let next_action =
+    Tool_result.data result |> Yojson.Safe.Util.member "next_action"
+  in
+  assert
+    (Yojson.Safe.Util.(next_action |> member "tool" |> to_string)
+     = "masc_goal_transition");
+  assert
+    (Yojson.Safe.Util.(
+       next_action |> member "arguments" |> member "goal_id" |> to_string)
+     = goal_id);
+  assert
+    (Yojson.Safe.Util.(
+       next_action |> member "arguments" |> member "action" |> to_string)
+     = "request_complete");
+  assert
+    (Yojson.Safe.Util.(next_action |> member "reason" |> to_string)
+     = "all_linked_tasks_terminal")
+
+let assert_goal_still_executing ctx ~goal_id =
+  match Goal_store.get_goal ctx.Task.Tool.config ~goal_id with
+  | Some { phase = Goal_phase.Executing; _ } -> ()
+  | Some _ -> failwith "task completion must not mutate the linked Goal"
+  | None -> failwith "linked Goal disappeared"
+
 let register_test_keeper ctx ~keeper_name ~agent_name =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -1832,6 +1893,133 @@ let () = test "handle_transition_verifier_allows_verdict_actions" (fun () ->
     match (only_task worker_ctx).Masc_domain.task_status with
     | Masc_domain.Done _ -> ()
     | _ -> failwith "expected verifier approval to complete task"))
+
+let () =
+  test "keeper direct done cues request_complete for the sole executing Goal"
+    (fun () ->
+       let ctx = make_test_ctx () in
+       let goal_id = "goal-direct-done" in
+       ignore (create_executing_goal ctx ~goal_id);
+       add_goal_linked_task ctx ~goal_id ~title:"Complete the sole linked task";
+       start_task_001 ctx;
+       let result =
+         keeper_transition
+           ctx
+           (`Assoc
+              [ "task_id", `String "task-001"
+              ; "action", `String "done"
+              ; "notes", `String "The sole linked task is complete."
+              ; ( "handoff_context"
+                , `Assoc
+                    [ "summary", `String "The sole linked task is complete."
+                    ; "evidence_refs", `List [ `String "commit:abc123" ]
+                    ] )
+              ])
+       in
+       assert_goal_completion_next_action result ~goal_id;
+       assert_goal_still_executing ctx ~goal_id)
+
+let () =
+  test "keeper approved verification cues request_complete after persisted Done"
+    (fun () ->
+       let worker_ctx = make_test_ctx_with_agent "worker" in
+       let verifier_ctx =
+         { worker_ctx with Task.Tool.agent_name = "verifier" }
+       in
+       let goal_id = "goal-approved-verification" in
+       ignore (create_executing_goal worker_ctx ~goal_id);
+       add_goal_linked_task
+         worker_ctx
+         ~goal_id
+         ~title:"Complete through verification";
+       ignore
+         (Workspace.claim_task
+            worker_ctx.config
+            ~agent_name:"worker"
+            ~task_id:"task-001");
+       let submit_result =
+         Task.Tool.handle_transition
+           ~tool_name:"test_tool"
+           ~start_time:0.0
+           worker_ctx
+           (`Assoc
+              [ "task_id", `String "task-001"
+              ; "action", `String "submit_for_verification"
+              ; ( "notes"
+                , `String
+                    "completion_notes: implementation complete. \
+                     reviewable_evidence_ref: artifact:goal-cue.json"
+                )
+              ])
+       in
+       if not (Tool_result.is_success submit_result) then
+         failwith (Tool_result.message submit_result);
+       let result =
+         keeper_transition
+           verifier_ctx
+           (`Assoc
+              [ "task_id", `String "task-001"
+              ; "action", `String "approve"
+              ; "notes", `String "evidence verified"
+              ])
+       in
+       assert_goal_completion_next_action result ~goal_id;
+       assert_goal_still_executing worker_ctx ~goal_id)
+
+let () =
+  test "keeper done suppresses Goal cue while another linked task is open"
+    (fun () ->
+       let ctx = make_test_ctx () in
+       let goal_id = "goal-open-task" in
+       ignore (create_executing_goal ctx ~goal_id);
+       add_goal_linked_task ctx ~goal_id ~title:"First linked task";
+       add_goal_linked_task ctx ~goal_id ~title:"Second linked task";
+       start_task_001 ctx;
+       let result =
+         keeper_transition
+           ctx
+           (`Assoc
+              [ "task_id", `String "task-001"
+              ; "action", `String "done"
+              ; "notes", `String "Only the first linked task is complete."
+              ; ( "handoff_context"
+                , `Assoc
+                    [ ( "summary"
+                      , `String "Only the first linked task is complete." )
+                    ; "evidence_refs", `List [ `String "commit:abc123" ]
+                    ] )
+              ])
+       in
+       if not (Tool_result.is_success result) then
+         failwith (Tool_result.message result);
+       assert
+         (Json_util.assoc_member_opt "next_action" (Tool_result.data result)
+          = None);
+       assert_goal_still_executing ctx ~goal_id)
+
+let () =
+  test "external done suppresses Keeper-only Goal completion cue" (fun () ->
+    let ctx = make_test_ctx () in
+    let goal_id = "goal-external-done" in
+    ignore (create_executing_goal ctx ~goal_id);
+    add_goal_linked_task ctx ~goal_id ~title:"External completion";
+    start_task_001 ctx;
+    let result =
+      Task.Tool.handle_done
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        ctx
+        (`Assoc
+           [ "task_id", `String "task-001"
+           ; "notes", `String "External caller completes the task."
+           ; "evidence_refs", `List [ `String "commit:abc123" ]
+           ])
+    in
+    if not (Tool_result.is_success result) then
+      failwith (Tool_result.message result);
+    assert
+      (Json_util.assoc_member_opt "next_action" (Tool_result.data result) = None);
+    assert_goal_still_executing ctx ~goal_id)
 
 let () = test "handle_transition_submitter_may_deliver_llm_verdict" (fun () ->
   (

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2021,6 +2021,50 @@ let () =
       (Json_util.assoc_member_opt "next_action" (Tool_result.data result) = None);
     assert_goal_still_executing ctx ~goal_id)
 
+let () =
+  test "keeper stale verification no-op suppresses Goal completion cue"
+    (fun () ->
+       let ctx = make_test_ctx () in
+       let verifier_ctx = { ctx with Task.Tool.agent_name = "verifier" } in
+       let goal_id = "goal-stale-verification" in
+       ignore (create_executing_goal ctx ~goal_id);
+       add_goal_linked_task ctx ~goal_id ~title:"Already completed task";
+       start_task_001 ctx;
+       let done_result =
+         Task.Tool.handle_done
+           ~tool_name:"test_tool"
+           ~start_time:0.0
+           ctx
+           (`Assoc
+              [ "task_id", `String "task-001"
+              ; "notes", `String "The linked task is already complete."
+              ; "evidence_refs", `List [ `String "commit:abc123" ]
+              ])
+       in
+       if not (Tool_result.is_success done_result) then
+         failwith (Tool_result.message done_result);
+       let stale_result =
+         keeper_transition
+           verifier_ctx
+           (`Assoc
+              [ "task_id", `String "task-001"
+              ; "action", `String "approve"
+              ; "notes", `String "stale verifier delivery"
+              ])
+       in
+       if not (Tool_result.is_success stale_result) then
+         failwith (Tool_result.message stale_result);
+       assert
+         (str_contains
+            (Tool_result.message stale_result)
+            "Stale verification verdict ignored");
+       assert
+         (Json_util.assoc_member_opt
+            "next_action"
+            (Tool_result.data stale_result)
+          = None);
+       assert_goal_still_executing ctx ~goal_id)
+
 let () = test "handle_transition_submitter_may_deliver_llm_verdict" (fun () ->
   (
     let worker_ctx = make_test_ctx_with_agent "worker" in


### PR DESCRIPTION
## Summary
- project a structured `masc_goal_transition request_complete` next action only to Keeper task callers
- derive the cue from the persisted Done task, the current goal-task link SSOT, and a single linked Executing Goal with no open tasks
- keep Goal lifecycle mutation explicit and suppress the cue for external callers or remaining open tasks

## Validation
- `opam exec -- ocamlformat --check lib/task/tool_task.ml test/test_tool_task_coverage.ml`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_tool_task_coverage.exe`
- `_build/default/test/test_tool_task_coverage.exe test coverage 48-51`

Closes #26025
