### PR TITLE
fix(hitl): stop replaying observed resolution wakes

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -3202,7 +3202,34 @@ let complete_delivery delivery =
                (match remove_delivery_from_store delivery with
                 | Error storage_error ->
                   Error (Persistence_failed { approval_id = id; storage_error })
-                | Ok () -> finish ()))))
+               | Ok () -> finish ()))))
+;;
+
+let delivery_wake_was_observed delivery =
+  let resolution : Keeper_event_queue.hitl_resolution =
+    { approval_id = delivery.entry.id
+    ; decision =
+        hitl_resolution_decision_of_approval_decision delivery.decision
+    ; channel = delivery.entry.continuation_channel
+    }
+  in
+  let post_id = Keeper_event_queue.hitl_resolution_post_id resolution in
+  match
+    Keeper_reaction_ledger.event_queue_turn_started_seen_for_source_result
+      ~base_path:delivery.entry.audit_base_path
+      ~keeper_name:delivery.entry.keeper_name
+      ~post_id
+      ~stimulus_kind:Keeper_reaction_ledger.Hitl_resolved
+  with
+  | Ok observed -> observed
+  | Error error ->
+    Log.Keeper.warn
+      ~keeper_name:delivery.entry.keeper_name
+      "approval_queue: could not verify prior HITL wake delivery approval=%s; replaying safely: %s"
+      delivery.entry.id
+      (Keeper_reaction_ledger.event_queue_reaction_evidence_error_to_string
+         error);
+    false
 ;;
 
 let compare_pending_order left right =
@@ -3301,6 +3328,8 @@ let install_persistence_internal ~after_load ~base_path =
           }
       | delivery :: rest ->
         if delivery.grant_consumed
+        then replay count failures rest
+        else if delivery_wake_was_observed delivery
         then replay count failures rest
         else
           (match complete_delivery delivery with

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -173,11 +173,12 @@ let connector_attention_event_ids_of_stimuli stimuli =
     stimuli
 ;;
 
-let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
+let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
   List.iter
     (fun (stimulus : Keeper_event_queue.stimulus) ->
        match stimulus.payload with
-       | Keeper_event_queue.Schedule_due _ ->
+       | ( Keeper_event_queue.Schedule_due _
+         | Keeper_event_queue.Hitl_resolved _ ) ->
          record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
        | Keeper_event_queue.Board_signal _
        | Keeper_event_queue.Board_attention _
@@ -185,7 +186,6 @@ let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Bg_completed _
        | Keeper_event_queue.Bootstrap
        | Keeper_event_queue.Connector_attention _
-       | Keeper_event_queue.Hitl_resolved _
        | Keeper_event_queue.Manual_compaction_requested
        | Keeper_event_queue.Goal_assigned _ -> ())
     stimuli
@@ -596,7 +596,7 @@ let run_keepalive_unified_turn
              admitted. The four prior inline pressure gates here were removed: they
              ran AFTER intake had already consumed the stimulus, forcing a
              consume/requeue churn loop, and logged only at DEBUG (a silent skip). *)
-          record_schedule_due_turn_started_reactions
+          record_replay_owned_turn_started_reactions
             ~ctx
             ~keeper_name:meta_after_triage.name
             !consumed_stimuli;

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -1166,6 +1166,49 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
   end
 ;;
 
+let event_queue_turn_started_seen_for_source_result
+    ~base_path
+    ~keeper_name
+    ~post_id
+    ~stimulus_kind
+  =
+  if String.equal post_id ""
+  then Error Evidence_invalid_stimulus_id
+  else
+    let turn_started_seen = ref false in
+    let expected_stimulus_kind = stimulus_kind_to_string stimulus_kind in
+    let note_parsed_row row =
+      match decode_current_row ~keeper_name row with
+      | Ok
+          (Current_reaction
+             { metadata
+             ; reaction_kind = Turn_started
+             ; transition_receipt = None
+             }) ->
+        (match assoc_field "reaction" metadata.raw with
+         | Some reaction
+           when string_field "post_id" reaction = Some post_id
+                && string_field "stimulus_kind" reaction
+                   = Some expected_stimulus_kind ->
+           turn_started_seen := true
+         | Some _ | None -> ())
+      | Ok
+          ( Current_stimulus _
+          | Current_reaction _
+          | Current_cursor_ack _ )
+      | Error _ ->
+        ()
+    in
+    let store = store_for_base_path ~base_path ~keeper_name in
+    match
+      Dated_jsonl.iter_all_entries_result store (function
+        | Dated_jsonl.Parsed row -> note_parsed_row row
+        | Dated_jsonl.Malformed_json _ -> ())
+    with
+    | Error error -> Error (Evidence_read_error error)
+    | Ok () -> Ok !turn_started_seen
+;;
+
 let nested_string_field outer inner json =
   match assoc_field outer json with
   | Some nested -> string_field inner nested

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -120,6 +120,17 @@ val event_queue_reaction_evidence_result :
     terminals remain distinct typed evidence. Empty query identities and
     storage failures remain typed errors. *)
 
+val event_queue_turn_started_seen_for_source_result :
+  base_path:string ->
+  keeper_name:string ->
+  post_id:string ->
+  stimulus_kind:stimulus_kind ->
+  (bool, event_queue_reaction_evidence_error) result
+(** Return [true] only when a current-schema, semantically valid turn-start
+    reaction exists for the exact durable source identity. Invalid matching
+    rows do not become positive evidence; read failures remain explicit so
+    callers can conservatively replay. *)
+
 val record_board_cursor_ack :
   base_path:string ->
   keeper_name:string ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -18,6 +18,8 @@ let check_rearm label expected = function
 
 module Gate = Masc.Keeper_gate
 module Registry_queue = Masc.Keeper_registry_event_queue
+module Event_queue_persistence = Keeper_event_queue_persistence
+module Reaction_ledger = Masc.Keeper_reaction_ledger
 
 (* Test-local shim for the excised [Keeper_approval_queue.resolve] wrapper:
    reproduces its unit projection over [resolve_with_policy] so these
@@ -2732,6 +2734,122 @@ let test_persisted_delivery_replays_before_origin_wake () =
        drop_resolution ~base_path ~keeper_name resolution)
 ;;
 
+let test_observed_delivery_preserves_grant_without_replaying_wake () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-acked-replay-origin" in
+  let input = `Assoc [ "target", `String "acked-replay" ] in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let id = submit ~base_path ~keeper_name ~input in
+       (match
+          aq_resolve
+            ~base_path
+            ~id
+            ~decision:AQ.Decision.Approve
+        with
+        | Ok () -> ()
+       | Error error ->
+          Alcotest.fail (AQ.resolve_error_to_string error));
+       let resolution =
+         match
+           durable_resolution_opt
+             ~base_path
+             ~keeper_name
+             ~approval_id:id
+         with
+         | Some resolution -> resolution
+         | None -> Alcotest.fail "HITL wake was not durably queued"
+       in
+       let selection =
+         match
+           Event_queue_persistence.peek_when_result
+             ~base_path
+             ~keeper_name
+             ~ready:(fun _ -> true)
+         with
+       | Ok (Some selection) -> selection
+       | Ok None -> Alcotest.fail "HITL wake was not durably queued"
+       | Error detail -> Alcotest.fail detail
+       in
+       List.iter
+         (Reaction_ledger.record_event_queue_turn_started
+            ~base_path
+            ~keeper_name)
+         selection.stimuli;
+       (match
+          Event_queue_persistence.ack_pending_result
+            ~base_path
+            ~keeper_name
+            ~selection
+            ()
+        with
+        | Ok () -> ()
+        | Error detail -> Alcotest.fail detail);
+       let post_id =
+         Keeper_event_queue.hitl_resolution_post_id resolution
+       in
+       (match
+          Reaction_ledger.event_queue_turn_started_seen_for_source_result
+            ~base_path
+            ~keeper_name
+            ~post_id
+            ~stimulus_kind:Reaction_ledger.Hitl_resolved
+        with
+        | Ok true -> ()
+        | Ok false ->
+          Alcotest.failf
+            "turn-started delivery evidence was not found: %s"
+            (Reaction_ledger.summary_for_keeper
+               ~base_path
+               ~keeper_name
+               ~limit:10
+             |> Yojson.Safe.to_string)
+        | Error error ->
+          Alcotest.fail
+            (Reaction_ledger.event_queue_reaction_evidence_error_to_string
+               error));
+       AQ.For_testing.reset_runtime_state ();
+       let report = install_exn ~base_path in
+       Alcotest.(check int)
+         "observed wake is not replayed"
+         0
+         report.replayed_deliveries;
+       Alcotest.(check bool)
+         "observed wake stays absent after ack"
+         true
+         (Option.is_none
+            (durable_resolution_opt
+               ~base_path
+               ~keeper_name
+               ~approval_id:id));
+       (match AQ.approved_resolution_state ~base_path ~id with
+        | Ok AQ.Resolution_unconsumed -> ()
+        | Ok AQ.Resolution_consumed ->
+          Alcotest.fail "wake acknowledgement consumed the exact grant"
+        | Error error ->
+          Alcotest.fail (AQ.grant_error_to_string error));
+       (match
+          AQ.consume_approved_resolution
+            ~base_path
+            ~id
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~input
+        with
+        | Ok AQ.Consumption_committed -> ()
+        | Ok
+            ( AQ.Consumption_already_committed
+            | AQ.Consumption_not_matching ) ->
+          Alcotest.fail "preserved exact grant was not consumable"
+        | Error error ->
+          Alcotest.fail (AQ.grant_error_to_string error)))
+;;
+
 let test_one_delivery_replay_failure_does_not_stop_others () =
   let base_path = temp_dir () in
   let keeper_name = "queue-independent-replay" in
@@ -3134,6 +3252,10 @@ let () =
             "delivery journal replays"
             `Quick
             test_persisted_delivery_replays_before_origin_wake
+        ; Alcotest.test_case
+            "observed delivery preserves grant without replaying wake"
+            `Quick
+            test_observed_delivery_preserves_grant_without_replaying_wake
         ; Alcotest.test_case
             "one replay failure does not stop others"
             `Quick


### PR DESCRIPTION
## Problem

An approved but unconsumed exact grant remains in the durable delivery journal by design. On every process restart, install replayed its `hitl-approval:<id>` wake even when that wake had already started and completed a Keeper turn. This reopened stale conversation context and could repeatedly drive unrelated work.

The recent peek/ack event-queue model keeps an unacknowledged source pending itself, so once a durable turn-start proves delivery, the approval journal no longer owns wake retry. The exact grant must still remain available until the matching tool consumes it.

## Changes

- record durable turn-start evidence for HITL resolution stimuli, as already done for schedule wakes
- query only current-schema, semantically valid reaction-ledger rows for the exact post ID and stimulus kind
- skip install-time wake replay after delivery evidence exists
- keep conservative replay when evidence is absent, invalid, or unreadable
- preserve the unconsumed exact grant and prove it remains consumable

## Validation

- focused build: `scripts/dune-local.sh build test/test_keeper_approval_queue.exe`
- pre-delivery restart still replays exactly once
- post-delivery/ack restart replays zero wakes
- exact grant remains `Resolution_unconsumed` and consumes successfully
- focused cases 25 and 26 passed
- ocamlformat checks and `git diff --check` passed

Closes #26030