### PR TITLE
fix(keeper): compact closed tool cycles atomically

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -637,6 +637,36 @@ function decodeCompactionReinjectionObservation(
   }
 }
 
+function decodeCompactionOutcome(raw: unknown): KeeperCompactionOutcome | null | undefined {
+  if (raw === null) return null
+  const value = asString(raw)
+  switch (value) {
+    case 'checkpoint_committed':
+    case 'retry_without_checkpoint':
+    case 'lifecycle_cleanup_failed_without_checkpoint':
+      return value
+    case undefined:
+    default:
+      return undefined
+  }
+}
+
+function compactionOutcomeContractIsValid(
+  outcome: KeeperCompactionOutcome | null,
+  evidence: KeeperCompactionExactEvidence | null,
+  failureCause: string | null,
+): boolean {
+  switch (outcome) {
+    case null:
+      return evidence === null && failureCause === null
+    case 'checkpoint_committed':
+      return evidence !== null && failureCause === null
+    case 'retry_without_checkpoint':
+    case 'lifecycle_cleanup_failed_without_checkpoint':
+      return evidence === null && Boolean(failureCause?.trim())
+  }
+}
+
 function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id)
@@ -649,23 +679,18 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
   const runtimeId = asNullableString(raw.runtime_id)
   const compactionSource = asNullableString(raw.compaction_source)
   const exactEvidence = decodeCompactionExactEvidence(raw.exact_evidence)
-  const compactionOutcome = asNullableString(raw.compaction_outcome)
-  const failureCause = asNullableString(raw.failure_cause)
+  const compactionOutcome = decodeCompactionOutcome(raw.compaction_outcome)
+  const failureCause =
+    raw.failure_cause === null ? null : asString(raw.failure_cause)
   const reinjectionObservation =
     decodeCompactionReinjectionObservation(raw.reinjection_observation)
-  if (exactEvidence === undefined || reinjectionObservation === undefined) return null
   if (
-    compactionOutcome !== null
-    && compactionOutcome !== 'checkpoint_committed'
-    && compactionOutcome !== 'retry_without_checkpoint'
-    && compactionOutcome !== 'lifecycle_cleanup_failed_without_checkpoint'
+    exactEvidence === undefined
+    || compactionOutcome === undefined
+    || failureCause === undefined
+    || reinjectionObservation === undefined
   ) return null
-  if (compactionOutcome === 'checkpoint_committed' && exactEvidence === null) return null
-  if (
-    (compactionOutcome === 'retry_without_checkpoint'
-      || compactionOutcome === 'lifecycle_cleanup_failed_without_checkpoint')
-    && !failureCause?.trim()
-  ) return null
+  if (!compactionOutcomeContractIsValid(compactionOutcome, exactEvidence, failureCause)) return null
   return {
     id,
     keeper,

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -281,7 +281,7 @@ export type KeeperCompactionSnapshot = {
   readonly compaction_id: string | null
   readonly compaction_source: string | null
   readonly compaction_outcome: KeeperCompactionOutcome | null
-  readonly failure_cause: string | null
+  readonly cause: string | null
   readonly status: string
   readonly links: KeeperCompactionSnapshotLinks
   readonly exact_evidence: KeeperCompactionExactEvidence | null
@@ -654,16 +654,16 @@ function decodeCompactionOutcome(raw: unknown): KeeperCompactionOutcome | null |
 function compactionOutcomeContractIsValid(
   outcome: KeeperCompactionOutcome | null,
   evidence: KeeperCompactionExactEvidence | null,
-  failureCause: string | null,
+  cause: string | null,
 ): boolean {
   switch (outcome) {
     case null:
-      return evidence === null && failureCause === null
+      return evidence === null && cause === null
     case 'checkpoint_committed':
-      return evidence !== null && failureCause === null
+      return evidence !== null && (cause === null || Boolean(cause.trim()))
     case 'retry_without_checkpoint':
     case 'lifecycle_cleanup_failed_without_checkpoint':
-      return evidence === null && Boolean(failureCause?.trim())
+      return evidence === null && Boolean(cause?.trim())
   }
 }
 
@@ -680,17 +680,17 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
   const compactionSource = asNullableString(raw.compaction_source)
   const exactEvidence = decodeCompactionExactEvidence(raw.exact_evidence)
   const compactionOutcome = decodeCompactionOutcome(raw.compaction_outcome)
-  const failureCause =
-    raw.failure_cause === null ? null : asString(raw.failure_cause)
+  const cause =
+    raw.cause === null ? null : asString(raw.cause)
   const reinjectionObservation =
     decodeCompactionReinjectionObservation(raw.reinjection_observation)
   if (
     exactEvidence === undefined
     || compactionOutcome === undefined
-    || failureCause === undefined
+    || cause === undefined
     || reinjectionObservation === undefined
   ) return null
-  if (!compactionOutcomeContractIsValid(compactionOutcome, exactEvidence, failureCause)) return null
+  if (!compactionOutcomeContractIsValid(compactionOutcome, exactEvidence, cause)) return null
   return {
     id,
     keeper,
@@ -708,7 +708,7 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
     compaction_id: asNullableString(raw.compaction_id),
     compaction_source: compactionSource,
     compaction_outcome: compactionOutcome,
-    failure_cause: failureCause,
+    cause: cause,
     status,
     links: decodeKeeperCompactionSnapshotLinks(raw.links),
     exact_evidence: exactEvidence,

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -259,6 +259,11 @@ export type KeeperCompactionReinjectionObservation = {
   readonly context_injected_receipts: number
 }
 
+export type KeeperCompactionOutcome =
+  | 'checkpoint_committed'
+  | 'retry_without_checkpoint'
+  | 'lifecycle_cleanup_failed_without_checkpoint'
+
 export type KeeperCompactionSnapshot = {
   readonly id: string
   readonly keeper: string
@@ -275,6 +280,8 @@ export type KeeperCompactionSnapshot = {
   readonly saved_tokens: number | null
   readonly compaction_id: string | null
   readonly compaction_source: string | null
+  readonly compaction_outcome: KeeperCompactionOutcome | null
+  readonly failure_cause: string | null
   readonly status: string
   readonly links: KeeperCompactionSnapshotLinks
   readonly exact_evidence: KeeperCompactionExactEvidence | null
@@ -642,9 +649,23 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
   const runtimeId = asNullableString(raw.runtime_id)
   const compactionSource = asNullableString(raw.compaction_source)
   const exactEvidence = decodeCompactionExactEvidence(raw.exact_evidence)
+  const compactionOutcome = asNullableString(raw.compaction_outcome)
+  const failureCause = asNullableString(raw.failure_cause)
   const reinjectionObservation =
     decodeCompactionReinjectionObservation(raw.reinjection_observation)
   if (exactEvidence === undefined || reinjectionObservation === undefined) return null
+  if (
+    compactionOutcome !== null
+    && compactionOutcome !== 'checkpoint_committed'
+    && compactionOutcome !== 'retry_without_checkpoint'
+    && compactionOutcome !== 'lifecycle_cleanup_failed_without_checkpoint'
+  ) return null
+  if (compactionOutcome === 'checkpoint_committed' && exactEvidence === null) return null
+  if (
+    (compactionOutcome === 'retry_without_checkpoint'
+      || compactionOutcome === 'lifecycle_cleanup_failed_without_checkpoint')
+    && !failureCause?.trim()
+  ) return null
   return {
     id,
     keeper,
@@ -661,6 +682,8 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
     saved_tokens: nullableNumber(raw.saved_tokens),
     compaction_id: asNullableString(raw.compaction_id),
     compaction_source: compactionSource,
+    compaction_outcome: compactionOutcome,
+    failure_cause: failureCause,
     status,
     links: decodeKeeperCompactionSnapshotLinks(raw.links),
     exact_evidence: exactEvidence,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -544,8 +544,8 @@ describe('keeper tool telemetry fetchers', () => {
             compaction_id: 'cmp-42',
             compaction_source: 'provider_overflow',
             compaction_outcome: 'checkpoint_committed',
-            failure_cause: null,
-            status: 'observed',
+            cause: 'compaction completion dispatch failed',
+            status: 'retryable_failure',
             links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
             exact_evidence: {
               before_checkpoint_bytes: 4096, after_checkpoint_bytes: 1024,
@@ -576,7 +576,7 @@ describe('keeper tool telemetry fetchers', () => {
             compaction_id: null,
             compaction_source: 'pre_dispatch_hygiene',
             compaction_outcome: 'retry_without_checkpoint',
-            failure_cause: 'compaction dispatch failed',
+            cause: 'compaction dispatch failed',
             status: 'retryable_failure',
             links: {},
             exact_evidence: null,
@@ -602,8 +602,8 @@ describe('keeper tool telemetry fetchers', () => {
             compaction_id: 'cmp-43',
             compaction_source: 'event_bus',
             compaction_outcome: 'checkpoint_committed',
-            failure_cause: null,
-            status: 'observed',
+            cause: 'lifecycle cleanup failed',
+            status: 'lifecycle_cleanup_failed',
             links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
             exact_evidence: {
               before_checkpoint_bytes: 2048, after_checkpoint_bytes: 512,
@@ -634,7 +634,7 @@ describe('keeper tool telemetry fetchers', () => {
             compaction_id: 'cmp-contradictory',
             compaction_source: 'provider_overflow',
             compaction_outcome: 'retry_without_checkpoint',
-            failure_cause: 'compaction dispatch failed',
+            cause: 'compaction dispatch failed',
             status: 'retryable_failure',
             links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
             exact_evidence: {
@@ -671,6 +671,11 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.items[1]?.runtime_id).toBeNull()
     expect(result.items[1]?.links.checkpoint_path).toBeNull()
     expect(result.items[0]?.exact_evidence?.before_checkpoint_bytes).toBe(4096)
+    expect(result.items[0]?.compaction_outcome).toBe('checkpoint_committed')
+    expect(result.items[0]?.cause).toBe('compaction completion dispatch failed')
+    expect(result.items[2]?.compaction_outcome).toBe('checkpoint_committed')
+    expect(result.items[2]?.exact_evidence?.before_checkpoint_bytes).toBe(2048)
+    expect(result.items[2]?.cause).toBe('lifecycle cleanup failed')
     expect(result.items).toHaveLength(3)
     expect(result.items.some(item => item.trace_id === 'trace-contradictory')).toBe(false)
   })

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -528,7 +528,7 @@ describe('keeper tool telemetry fetchers', () => {
         scan_truncated: false,
         items: [
           {
-            id: 'manifest:trace-a:event_bus_correlated:2026-06-26T03:03:00Z',
+            id: 'manifest:trace-a:context_compacted:2026-06-26T03:03:00Z',
             keeper: 'keeper-alpha',
             ts_iso: '2026-06-26T03:03:00Z',
             ts_unix: 1_782_444_580,
@@ -542,7 +542,9 @@ describe('keeper tool telemetry fetchers', () => {
             after_tokens: 120000,
             saved_tokens: 90000,
             compaction_id: 'cmp-42',
-            compaction_source: 'event_bus',
+            compaction_source: 'provider_overflow',
+            compaction_outcome: 'checkpoint_committed',
+            failure_cause: null,
             status: 'observed',
             links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
             exact_evidence: {
@@ -573,7 +575,9 @@ describe('keeper tool telemetry fetchers', () => {
             saved_tokens: null,
             compaction_id: null,
             compaction_source: 'pre_dispatch_hygiene',
-            status: 'compacted',
+            compaction_outcome: 'retry_without_checkpoint',
+            failure_cause: 'compaction dispatch failed',
+            status: 'retryable_failure',
             links: {},
             exact_evidence: null,
             reinjection_observation: {
@@ -597,11 +601,45 @@ describe('keeper tool telemetry fetchers', () => {
             saved_tokens: 90000,
             compaction_id: 'cmp-43',
             compaction_source: 'event_bus',
+            compaction_outcome: 'checkpoint_committed',
+            failure_cause: null,
             status: 'observed',
             links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
             exact_evidence: {
               before_checkpoint_bytes: 2048, after_checkpoint_bytes: 512,
               before_message_count: 9, after_message_count: 3,
+              summarized_message_count: 4, dropped_message_count: 1,
+              before_tool_use_count: 2, after_tool_use_count: 1,
+              before_tool_result_count: 2, after_tool_result_count: 1,
+            },
+            reinjection_observation: {
+              state: 'not_linked', keeper_turn_id: null,
+              checkpoint_loaded_receipts: 0, context_injected_receipts: 0,
+            },
+          },
+          {
+            id: 'manifest:trace-contradictory:context_compacted:2026-06-26T04:05:00Z',
+            keeper: 'keeper-alpha',
+            ts_iso: '2026-06-26T04:05:00Z',
+            ts_unix: null,
+            trace_id: 'trace-contradictory',
+            keeper_turn_id: 15,
+            source: 'runtime_manifest',
+            trigger: 'provider_overflow',
+            runtime_id: 'oas-seoul-1',
+            display_runtime: 'oas-seoul-1',
+            before_tokens: null,
+            after_tokens: null,
+            saved_tokens: null,
+            compaction_id: 'cmp-contradictory',
+            compaction_source: 'provider_overflow',
+            compaction_outcome: 'retry_without_checkpoint',
+            failure_cause: 'compaction dispatch failed',
+            status: 'retryable_failure',
+            links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+            exact_evidence: {
+              before_checkpoint_bytes: 4096, after_checkpoint_bytes: 1024,
+              before_message_count: 8, after_message_count: 3,
               summarized_message_count: 4, dropped_message_count: 1,
               before_tool_use_count: 2, after_tool_use_count: 1,
               before_tool_result_count: 2, after_tool_result_count: 1,
@@ -633,6 +671,8 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.items[1]?.runtime_id).toBeNull()
     expect(result.items[1]?.links.checkpoint_path).toBeNull()
     expect(result.items[0]?.exact_evidence?.before_checkpoint_bytes).toBe(4096)
+    expect(result.items).toHaveLength(3)
+    expect(result.items.some(item => item.trace_id === 'trace-contradictory')).toBe(false)
   })
 })
 

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -500,8 +500,8 @@ export function CompactionInspectorOverlay({
           ${outcomePresentation
             ? html`<div class="cmp-trigger"><span class="sub-k">결과</span><strong style=${{ color: outcomePresentation.color }}>${outcomePresentation.label}</strong></div>`
             : null}
-          ${ev.failureCause
-            ? html`<div class="cmp-trigger"><span class="sub-k">실패 원인</span><span class="mono" style=${{ color: 'var(--color-status-err)' }}>${ev.failureCause}</span></div>`
+          ${ev.cause
+            ? html`<div class="cmp-trigger"><span class="sub-k">원인</span><span class="mono" style=${{ color: 'var(--color-status-err)' }}>${ev.cause}</span></div>`
             : null}
           ${ev.reinjection
             ? html`<div class="cmp-trigger"><span class="sub-k">재주입 관측</span><span class="mono">${ev.reinjection.state} · load=${ev.reinjection.checkpoint_loaded_receipts} · inject=${ev.reinjection.context_injected_receipts}</span></div>`

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -63,6 +63,26 @@ function fmtBytes(n: number): string {
   return `${n}B`
 }
 
+function compactionOutcomePresentation(outcome: CompactionSnapshot['outcome']): {
+  readonly label: string
+  readonly color: string
+} | null {
+  switch (outcome) {
+    case 'checkpoint_committed':
+      return { label: '체크포인트 커밋 완료', color: 'var(--status-ok)' }
+    case 'retry_without_checkpoint':
+      return { label: '체크포인트 없이 재시도', color: 'var(--status-warn)' }
+    case 'lifecycle_cleanup_failed_without_checkpoint':
+      return {
+        label: '체크포인트 없이 lifecycle 정리 실패',
+        color: 'var(--color-status-err)',
+      }
+    case null:
+    case undefined:
+      return null
+  }
+}
+
 function shortDigest(digest: string): string {
   return digest.length > 12 ? digest.slice(0, 12) : digest
 }
@@ -438,6 +458,7 @@ export function CompactionInspectorOverlay({
 
   const safeIdx = Math.max(0, Math.min(idx, events.length - 1))
   const ev = events[safeIdx]!
+  const outcomePresentation = compactionOutcomePresentation(ev.outcome)
   const hasTokenPair = isFiniteNumber(ev.before.tok) && isFiniteNumber(ev.after.tok)
   const reduction = hasTokenPair && ev.before.tok > 0
     ? Math.round((1 - ev.after.tok / ev.before.tok) * 100)
@@ -476,6 +497,12 @@ export function CompactionInspectorOverlay({
           <div class="cmp-trigger"><span class="sub-k">트리거</span>${ev.trigger}</div>
           <div class="cmp-trigger"><span class="sub-k">수행 런타임</span><span class="mono">${ev.runtime}</span></div>
           <div class="cmp-trigger"><span class="sub-k">소스</span><span class="mono">${ev.detailSource ?? ev.source}${ev.status ? ` · ${ev.status}` : ''}</span></div>
+          ${outcomePresentation
+            ? html`<div class="cmp-trigger"><span class="sub-k">결과</span><strong style=${{ color: outcomePresentation.color }}>${outcomePresentation.label}</strong></div>`
+            : null}
+          ${ev.failureCause
+            ? html`<div class="cmp-trigger"><span class="sub-k">실패 원인</span><span class="mono" style=${{ color: 'var(--color-status-err)' }}>${ev.failureCause}</span></div>`
+            : null}
           ${ev.reinjection
             ? html`<div class="cmp-trigger"><span class="sub-k">재주입 관측</span><span class="mono">${ev.reinjection.state} · load=${ev.reinjection.checkpoint_loaded_receipts} · inject=${ev.reinjection.context_injected_receipts}</span></div>`
             : null}

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -35,7 +35,7 @@ export interface CompactionSnapshot {
   readonly keeperTurnId?: number | null
   readonly status?: string | null
   readonly outcome?: KeeperCompactionOutcome | null
-  readonly failureCause?: string | null
+  readonly cause?: string | null
   readonly detailSource?: string | null
   readonly summarizedCount?: number | null
   readonly droppedCount?: number | null
@@ -121,7 +121,7 @@ function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): Compaction
     keeperTurnId: snapshot.keeper_turn_id,
     status: snapshot.status,
     outcome: snapshot.compaction_outcome,
-    failureCause: snapshot.failure_cause,
+    cause: snapshot.cause,
     detailSource: snapshot.source,
     summarizedCount: evidence?.summarized_message_count ?? null,
     droppedCount: evidence?.dropped_message_count ?? null,

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -8,7 +8,10 @@
 
 import { signal, type Signal } from '@preact/signals'
 import type { KeeperCompactionSnapshot as BackendCompactionSnapshot } from '../../api/dashboard'
-import type { KeeperCompactionReinjectionObservation } from '../../api/dashboard-turn-records'
+import type {
+  KeeperCompactionOutcome,
+  KeeperCompactionReinjectionObservation,
+} from '../../api/dashboard-turn-records'
 
 export interface CompactionSnapshotNumbers {
   readonly tok: number | null
@@ -31,6 +34,8 @@ export interface CompactionSnapshot {
   readonly traceId?: string | null
   readonly keeperTurnId?: number | null
   readonly status?: string | null
+  readonly outcome?: KeeperCompactionOutcome | null
+  readonly failureCause?: string | null
   readonly detailSource?: string | null
   readonly summarizedCount?: number | null
   readonly droppedCount?: number | null
@@ -115,6 +120,8 @@ function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): Compaction
     traceId: snapshot.trace_id,
     keeperTurnId: snapshot.keeper_turn_id,
     status: snapshot.status,
+    outcome: snapshot.compaction_outcome,
+    failureCause: snapshot.failure_cause,
     detailSource: snapshot.source,
     summarizedCount: evidence?.summarized_message_count ?? null,
     droppedCount: evidence?.dropped_message_count ?? null,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -108,7 +108,7 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
           compaction_id: 'cmp-42',
           compaction_source: 'event_bus',
           compaction_outcome: 'checkpoint_committed',
-          failure_cause: null,
+          cause: null,
           status: 'observed',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
           exact_evidence: {
@@ -945,7 +945,7 @@ describe('KeeperWorkspaceRail', () => {
           compaction_id: 'cmp-failed',
           compaction_source: 'provider_overflow',
           compaction_outcome: 'retry_without_checkpoint',
-          failure_cause: 'compaction dispatch failed',
+          cause: 'compaction dispatch failed',
           status: 'retryable_failure',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
           exact_evidence: null,
@@ -967,6 +967,8 @@ describe('KeeperWorkspaceRail', () => {
 
     await waitFor(() => expect(container.textContent).toContain('체크포인트 없이 재시도'))
     expect(container.textContent).toContain('compaction dispatch failed')
+    expect(container.textContent).toContain('원인')
+    expect(container.textContent).not.toContain('실패 원인')
     expect(container.textContent).not.toContain('체크포인트 커밋 완료')
   })
 
@@ -1001,7 +1003,7 @@ describe('KeeperWorkspaceRail', () => {
           compaction_id: null,
           compaction_source: 'pre_dispatch_hygiene',
           compaction_outcome: null,
-          failure_cause: null,
+          cause: null,
           status: 'compacted',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
           exact_evidence: null,
@@ -1119,7 +1121,7 @@ describe('KeeperWorkspaceRail', () => {
         compaction_id: 'cmp-old',
         compaction_source: 'event_bus',
         compaction_outcome: null,
-        failure_cause: null,
+        cause: null,
         status: 'observed',
         links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
         exact_evidence: null,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -107,6 +107,8 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
           saved_tokens: 90000,
           compaction_id: 'cmp-42',
           compaction_source: 'event_bus',
+          compaction_outcome: 'checkpoint_committed',
+          failure_cause: null,
           status: 'observed',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
           exact_evidence: {
@@ -914,6 +916,60 @@ describe('KeeperWorkspaceRail', () => {
     expect(promptContext.textContent).toContain('raw prompt text는 이 화면/API에서 노출하지 않습니다')
   })
 
+  it('renders no-checkpoint compaction outcome and cause without success wording', async () => {
+    vi.mocked(fetchKeeperCompactionSnapshots).mockResolvedValueOnce({
+      schema: 'keeper.compaction_snapshots.v1',
+      keeper: 'masc-improver',
+      source: 'runtime_manifest|keeper_meta',
+      producer: 'keeper_runtime_manifest|keeper_meta_store',
+      limit: 25,
+      count: 1,
+      read_error_count: 0,
+      read_errors: [],
+      scan_truncated: false,
+      items: [
+        {
+          id: 'manifest:trace-failed:context_compacted:2026-06-03T11:02:00Z',
+          keeper: 'masc-improver',
+          ts_iso: '2026-06-03T11:02:00Z',
+          ts_unix: 1_780_464_120,
+          trace_id: 'trace-failed',
+          keeper_turn_id: 13,
+          source: 'runtime_manifest',
+          trigger: 'provider_overflow',
+          runtime_id: 'oas-seoul-1',
+          display_runtime: 'oas-seoul-1',
+          before_tokens: null,
+          after_tokens: null,
+          saved_tokens: null,
+          compaction_id: 'cmp-failed',
+          compaction_source: 'provider_overflow',
+          compaction_outcome: 'retry_without_checkpoint',
+          failure_cause: 'compaction dispatch failed',
+          status: 'retryable_failure',
+          links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+          exact_evidence: null,
+          reinjection_observation: {
+            state: 'not_linked',
+            keeper_turn_id: null,
+            checkpoint_loaded_receipts: 0,
+            context_injected_receipts: 0,
+          },
+        },
+      ],
+    })
+
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
+    const btn = Array.from(container.querySelectorAll('.cmp-open')).find(
+      el => el.textContent?.includes('before/after'),
+    ) as HTMLElement | undefined
+    fireEvent.click(btn as HTMLElement)
+
+    await waitFor(() => expect(container.textContent).toContain('체크포인트 없이 재시도'))
+    expect(container.textContent).toContain('compaction dispatch failed')
+    expect(container.textContent).not.toContain('체크포인트 커밋 완료')
+  })
+
   it('renders live durable compaction snapshots even when token counts are missing', async () => {
     vi.mocked(fetchKeeperCompactionSnapshots).mockResolvedValueOnce({
       schema: 'keeper.compaction_snapshots.v1',
@@ -944,6 +1000,8 @@ describe('KeeperWorkspaceRail', () => {
           saved_tokens: null,
           compaction_id: null,
           compaction_source: 'pre_dispatch_hygiene',
+          compaction_outcome: null,
+          failure_cause: null,
           status: 'compacted',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
           exact_evidence: null,
@@ -1060,6 +1118,8 @@ describe('KeeperWorkspaceRail', () => {
         saved_tokens: 90000,
         compaction_id: 'cmp-old',
         compaction_source: 'event_bus',
+        compaction_outcome: null,
+        failure_cause: null,
         status: 'observed',
         links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
         exact_evidence: null,

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -163,12 +163,21 @@ type requested_compaction =
   ; post_success_terminalizer :
       Keeper_compaction_llm_summarizer.post_success_terminalizer
   ; summarized_message_count : int
+  ; summarized_unit_count : int
   ; dropped_message_count : int
+  ; normalized_message_count : int
+  ; removed_tool_use_count : int
+  ; removed_tool_result_count : int
   }
 
 let unit_message_count = function
   | Keeper_compaction_unit.Ordinary_message _ -> 1
   | Keeper_compaction_unit.Closed_tool_cycle messages -> List.length messages
+;;
+
+let messages_of_unit = function
+  | Keeper_compaction_unit.Ordinary_message message -> [ message ]
+  | Keeper_compaction_unit.Closed_tool_cycle messages -> messages
 ;;
 
 let selected_message_count units selected =
@@ -177,6 +186,39 @@ let selected_message_count units selected =
     (fun count index -> count + unit_message_count units.(index))
     0
     selected
+;;
+
+let tool_block_counts messages =
+  let rec count_blocks (uses, results) blocks =
+    List.fold_left
+      (fun (uses, results) -> function
+         | Agent_sdk.Types.ToolUse _ -> uses + 1, results
+         | Agent_sdk.Types.ToolResult { content_blocks; _ } ->
+           let counts = uses, results + 1 in
+           Option.fold ~none:counts ~some:(count_blocks counts) content_blocks
+         | Agent_sdk.Types.Text _
+         | Agent_sdk.Types.Thinking _
+         | Agent_sdk.Types.ReasoningDetails _
+         | Agent_sdk.Types.RedactedThinking _
+         | Agent_sdk.Types.Image _
+         | Agent_sdk.Types.Document _
+         | Agent_sdk.Types.Audio _ ->
+           uses, results)
+      (uses, results)
+      blocks
+  in
+  List.fold_left
+    (fun counts (message : Agent_sdk.Types.message) ->
+       count_blocks counts message.content)
+    (0, 0)
+    messages
+;;
+
+let selected_tool_block_counts units selected =
+  let units = Array.of_list units in
+  selected
+  |> List.concat_map (fun index -> messages_of_unit units.(index))
+  |> tool_block_counts
 ;;
 
 let terminal_rejection terminalizer cause =
@@ -270,6 +312,18 @@ let requested_messages_with_plan
            Keeper_compaction_llm_summarizer.completed_post_success_terminalizer
              completed
          in
+         let summarized_indices =
+           Keeper_compaction_llm_summarizer.summarized_indices plan
+         in
+         let dropped_indices =
+           Keeper_compaction_llm_summarizer.dropped_indices plan
+         in
+         let normalized_indices =
+           Keeper_compaction_llm_summarizer.normalized_indices plan
+         in
+         let removed_tool_use_count, removed_tool_result_count =
+           selected_tool_block_counts units (summarized_indices @ dropped_indices)
+         in
             if not (Keeper_compaction_llm_summarizer.has_changes plan)
             then
               Error
@@ -285,11 +339,16 @@ let requested_messages_with_plan
                 ; summarized_message_count =
                     selected_message_count
                       units
-                      (Keeper_compaction_llm_summarizer.summarized_indices plan)
+                      summarized_indices
+                ; summarized_unit_count = List.length summarized_indices
                 ; dropped_message_count =
                     selected_message_count
                       units
-                      (Keeper_compaction_llm_summarizer.dropped_indices plan)
+                      dropped_indices
+                ; normalized_message_count =
+                    selected_message_count units normalized_indices
+                ; removed_tool_use_count
+                ; removed_tool_result_count
                 }))
 ;;
 
@@ -312,32 +371,6 @@ let requested_messages
       with
       | None -> Error Keeper_compaction_llm_summarizer.Exact_execution_context_unavailable
       | Some summarize -> summarize ~units)
-    messages
-;;
-
-let tool_block_counts messages =
-  let rec count_blocks (uses, results) blocks =
-    List.fold_left
-      (fun (uses, results) -> function
-         | Agent_sdk.Types.ToolUse _ -> uses + 1, results
-         | Agent_sdk.Types.ToolResult { content_blocks; _ } ->
-           let counts = uses, results + 1 in
-           Option.fold ~none:counts ~some:(count_blocks counts) content_blocks
-         | Agent_sdk.Types.Text _
-         | Agent_sdk.Types.Thinking _
-         | Agent_sdk.Types.ReasoningDetails _
-         | Agent_sdk.Types.RedactedThinking _
-         | Agent_sdk.Types.Image _
-         | Agent_sdk.Types.Document _
-         | Agent_sdk.Types.Audio _ ->
-           uses, results)
-      (uses, results)
-      blocks
-  in
-  List.fold_left
-    (fun counts (message : Agent_sdk.Types.message) ->
-       count_blocks counts message.content)
-    (0, 0)
     messages
 ;;
 
@@ -462,11 +495,15 @@ let compact_for_request_typed_with
           ~before_message_count:before_messages
           ~after_message_count:after_messages
           ~summarized_message_count:requested.summarized_message_count
+          ~summarized_unit_count:requested.summarized_unit_count
           ~dropped_message_count:requested.dropped_message_count
+          ~normalized_message_count:requested.normalized_message_count
           ~before_tool_use_count
           ~after_tool_use_count
           ~before_tool_result_count
           ~after_tool_result_count
+          ~removed_tool_use_count:requested.removed_tool_use_count
+          ~removed_tool_result_count:requested.removed_tool_result_count
       with
       | Error error ->
         (match

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -163,11 +163,14 @@ type requested_compaction =
   ; post_success_terminalizer :
       Keeper_compaction_llm_summarizer.post_success_terminalizer
   ; summarized_message_count : int
-  ; summarized_unit_count : int
   ; dropped_message_count : int
-  ; normalized_message_count : int
-  ; removed_tool_use_count : int
-  ; removed_tool_result_count : int
+  ; plan_accounting : plan_accounting
+  }
+
+and plan_accounting =
+  { expected_after_message_count : int
+  ; expected_after_tool_use_count : int
+  ; expected_after_tool_result_count : int
   }
 
 let unit_message_count = function
@@ -212,13 +215,6 @@ let tool_block_counts messages =
        count_blocks counts message.content)
     (0, 0)
     messages
-;;
-
-let selected_tool_block_counts units selected =
-  let units = Array.of_list units in
-  selected
-  |> List.concat_map (fun index -> messages_of_unit units.(index))
-  |> tool_block_counts
 ;;
 
 let terminal_rejection terminalizer cause =
@@ -318,11 +314,11 @@ let requested_messages_with_plan
          let dropped_indices =
            Keeper_compaction_llm_summarizer.dropped_indices plan
          in
-         let normalized_indices =
-           Keeper_compaction_llm_summarizer.normalized_indices plan
+         let messages =
+           Keeper_compaction_llm_summarizer.apply plan @ protected_suffix
          in
-         let removed_tool_use_count, removed_tool_result_count =
-           selected_tool_block_counts units (summarized_indices @ dropped_indices)
+         let expected_after_tool_use_count, expected_after_tool_result_count =
+           tool_block_counts messages
          in
             if not (Keeper_compaction_llm_summarizer.has_changes plan)
             then
@@ -332,23 +328,22 @@ let requested_messages_with_plan
                    Keeper_event_queue_state.Domain_invalid_output)
             else
               Ok
-                { messages =
-                    Keeper_compaction_llm_summarizer.apply plan @ protected_suffix
+                { messages
                 ; exact_execution_evidence
                 ; post_success_terminalizer
                 ; summarized_message_count =
                     selected_message_count
                       units
                       summarized_indices
-                ; summarized_unit_count = List.length summarized_indices
                 ; dropped_message_count =
                     selected_message_count
                       units
                       dropped_indices
-                ; normalized_message_count =
-                    selected_message_count units normalized_indices
-                ; removed_tool_use_count
-                ; removed_tool_result_count
+                ; plan_accounting =
+                    { expected_after_message_count = List.length messages
+                    ; expected_after_tool_use_count
+                    ; expected_after_tool_result_count
+                    }
                 }))
 ;;
 
@@ -471,40 +466,60 @@ let compact_for_request_typed_with
       let after_tool_use_count, after_tool_result_count =
         tool_block_counts (messages_of_context compacted_ctx)
       in
-      match
+      let evidence_result =
         let exact = requested.exact_execution_evidence in
-        Keeper_compaction_evidence.create
-          ~slot_id:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_slot_id exact)
-          ~call_id:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_call_id exact)
-          ~target_identity_fingerprint:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_target_identity_fingerprint exact)
-          ~catalog_generation_fingerprint:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_catalog_generation_fingerprint exact)
-          ~catalog_evidence_sha256:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_catalog_evidence_sha256 exact)
-          ~plan_fingerprint:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_plan_fingerprint exact)
-          ~receipt_plan_fingerprint:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_receipt_plan_fingerprint exact)
-          ~receipt_request_body_sha256:
-            (Keeper_compaction_llm_summarizer.exact_execution_evidence_receipt_request_body_sha256 exact)
-          ~before_checkpoint_bytes:before_bytes
-          ~after_checkpoint_bytes:after_bytes
-          ~before_message_count:before_messages
-          ~after_message_count:after_messages
-          ~summarized_message_count:requested.summarized_message_count
-          ~summarized_unit_count:requested.summarized_unit_count
-          ~dropped_message_count:requested.dropped_message_count
-          ~normalized_message_count:requested.normalized_message_count
-          ~before_tool_use_count
-          ~after_tool_use_count
-          ~before_tool_result_count
-          ~after_tool_result_count
-          ~removed_tool_use_count:requested.removed_tool_use_count
-          ~removed_tool_result_count:requested.removed_tool_result_count
-      with
+        let accounting = requested.plan_accounting in
+        if after_messages <> accounting.expected_after_message_count
+        then
+          Error
+            (Keeper_compaction_evidence.Invalid_transition
+               ( Keeper_compaction_evidence.Messages
+               , accounting.expected_after_message_count
+               , after_messages ))
+        else if after_tool_use_count <> accounting.expected_after_tool_use_count
+        then
+          Error
+            (Keeper_compaction_evidence.Invalid_transition
+               ( Keeper_compaction_evidence.Tool_uses
+               , accounting.expected_after_tool_use_count
+               , after_tool_use_count ))
+        else if after_tool_result_count <> accounting.expected_after_tool_result_count
+        then
+          Error
+            (Keeper_compaction_evidence.Invalid_transition
+               ( Keeper_compaction_evidence.Tool_results
+               , accounting.expected_after_tool_result_count
+               , after_tool_result_count ))
+        else
+          Keeper_compaction_evidence.create
+            ~slot_id:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_slot_id exact)
+            ~call_id:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_call_id exact)
+            ~target_identity_fingerprint:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_target_identity_fingerprint exact)
+            ~catalog_generation_fingerprint:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_catalog_generation_fingerprint exact)
+            ~catalog_evidence_sha256:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_catalog_evidence_sha256 exact)
+            ~plan_fingerprint:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_plan_fingerprint exact)
+            ~receipt_plan_fingerprint:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_receipt_plan_fingerprint exact)
+            ~receipt_request_body_sha256:
+              (Keeper_compaction_llm_summarizer.exact_execution_evidence_receipt_request_body_sha256 exact)
+            ~before_checkpoint_bytes:before_bytes
+            ~after_checkpoint_bytes:after_bytes
+            ~before_message_count:before_messages
+            ~after_message_count:after_messages
+            ~summarized_message_count:requested.summarized_message_count
+            ~dropped_message_count:requested.dropped_message_count
+            ~before_tool_use_count
+            ~after_tool_use_count
+            ~before_tool_result_count
+            ~after_tool_result_count
+      in
+      match evidence_result with
       | Error error ->
         (match
            Keeper_compaction_llm_summarizer.terminalize_post_success
@@ -569,6 +584,7 @@ let compact_for_request_typed
 module For_testing = struct
   let compact_for_request_typed_with_accounting
         ~plan_for_units
+        ?expected_after_message_count_override
         ~summarized_message_count_override
         ~meta
         ~trigger
@@ -577,7 +593,16 @@ module For_testing = struct
     let requested_messages messages =
       requested_messages_with_plan ~plan_for_units messages
       |> Result.map (fun requested ->
-        { requested with summarized_message_count = summarized_message_count_override })
+        let plan_accounting =
+          match expected_after_message_count_override with
+          | None -> requested.plan_accounting
+          | Some expected_after_message_count ->
+            { requested.plan_accounting with expected_after_message_count }
+        in
+        { requested with
+          summarized_message_count = summarized_message_count_override
+        ; plan_accounting
+        })
     in
     compact_for_request_typed_with ~requested_messages ~meta ~trigger ctx
   ;;

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -70,6 +70,7 @@ module For_testing : sig
           ( Keeper_compaction_llm_summarizer.completed_plan
           , Keeper_compaction_llm_summarizer.summarization_failure )
             result)
+    -> ?expected_after_message_count_override:int
     -> summarized_message_count_override:int
     -> meta:Keeper_meta_contract.keeper_meta
     -> trigger:Compaction_trigger.t

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -8,10 +8,24 @@ module Int_set = Set.Make (Int)
 module Int_map = Map.Make (Int)
 module String_set = Set.Make (String)
 
+type assistant_text_source =
+  { normalized_message : Agent_sdk.Types.message
+  ; text_blocks : string list
+  ; reasoning_discarded : bool
+  }
+
+type closed_tool_cycle_source =
+  { source_messages : Agent_sdk.Types.message list
+  ; semantic_json : Yojson.Safe.t
+  }
+
+type eligible_payload =
+  | Assistant_text of assistant_text_source
+  | Closed_tool_cycle of closed_tool_cycle_source
+
 type eligible_source =
   { source_index : int
-  ; message : Agent_sdk.Types.message
-  ; text_blocks : string list
+  ; payload : eligible_payload
   }
 
 type action =
@@ -158,24 +172,170 @@ let messages_of_unit = function
   | Keeper_compaction_unit.Ordinary_message message -> [ message ]
   | Keeper_compaction_unit.Closed_tool_cycle messages -> messages
 
-let text_blocks blocks =
-  List.fold_right
-    (fun block texts ->
-      match block, texts with
-      | Agent_sdk.Types.Text text, Some texts -> Some (text :: texts)
-      | ( Agent_sdk.Types.Thinking _
-        | Agent_sdk.Types.ReasoningDetails _
-        | Agent_sdk.Types.RedactedThinking _
-        | Agent_sdk.Types.ToolUse _
-        | Agent_sdk.Types.ToolResult _
-        | Agent_sdk.Types.Image _
-        | Agent_sdk.Types.Document _
-        | Agent_sdk.Types.Audio _ )
-        , _ ->
-        None
-      | _, None -> None)
-    blocks
-    (Some [])
+let canonical_json =
+  let rec canonicalize = function
+    | `Assoc fields ->
+      `Assoc
+        (fields
+         |> List.map (fun (key, value) -> key, canonicalize value)
+         |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+    | `List values -> `List (List.map canonicalize values)
+    | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
+      value
+  in
+  canonicalize
+
+let option_json project = function
+  | None -> `Null
+  | Some value -> project value
+
+let tool_failure_kind_string = function
+  | Agent_sdk.Types.Validation_error -> "validation_error"
+  | Agent_sdk.Types.Recoverable_tool_error -> "recoverable_tool_error"
+  | Agent_sdk.Types.Non_retryable_tool_error -> "non_retryable_tool_error"
+  | Agent_sdk.Types.Reported_tool_error -> "reported_tool_error"
+  | Agent_sdk.Types.Unattributed_tool_error -> "unattributed_tool_error"
+
+let tool_error_class_string = function
+  | Agent_sdk.Types.Transient -> "transient"
+  | Agent_sdk.Types.Deterministic -> "deterministic"
+  | Agent_sdk.Types.Unknown -> "unknown"
+
+let tool_result_outcome_json = function
+  | Agent_sdk.Types.Tool_succeeded -> `Assoc [ "kind", `String "succeeded" ]
+  | Agent_sdk.Types.Tool_failed { failure_kind; error_class } ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "failure_kind", `String (tool_failure_kind_string failure_kind)
+      ; ( "error_class"
+        , option_json (fun value -> `String (tool_error_class_string value)) error_class )
+      ]
+
+type semantic_projection_error =
+  | Unsupported_media
+
+let rec semantic_content_blocks_json blocks =
+  let rec loop projected_rev = function
+    | [] -> Ok (`List (List.rev projected_rev))
+    | Agent_sdk.Types.Text text :: rest ->
+      loop
+        (`Assoc [ "type", `String "text"; "text", `String text ] :: projected_rev)
+        rest
+    | ( Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.ReasoningDetails _
+      | Agent_sdk.Types.RedactedThinking _ )
+      :: rest ->
+      loop projected_rev rest
+    | Agent_sdk.Types.ToolUse { id; name; input } :: rest ->
+      loop
+        (`Assoc
+           [ "type", `String "tool_use"
+           ; "id", `String id
+           ; "name", `String name
+           ; "input", canonical_json input
+           ]
+         :: projected_rev)
+        rest
+    | Agent_sdk.Types.ToolResult
+        { tool_use_id; content; outcome; json; content_blocks }
+      :: rest ->
+      (match semantic_optional_content_blocks_json content_blocks with
+       | Error _ as error -> error
+       | Ok content_blocks_json ->
+         loop
+           (`Assoc
+              [ "type", `String "tool_result"
+              ; "tool_use_id", `String tool_use_id
+              ; "content", `String content
+              ; "outcome", tool_result_outcome_json outcome
+              ; "json", option_json canonical_json json
+              ; "content_blocks", content_blocks_json
+              ]
+            :: projected_rev)
+           rest)
+    | (Agent_sdk.Types.Image _ | Agent_sdk.Types.Document _ | Agent_sdk.Types.Audio _)
+      :: _ ->
+      Error Unsupported_media
+  in
+  loop [] blocks
+
+and semantic_optional_content_blocks_json = function
+  | None -> Ok `Null
+  | Some blocks -> semantic_content_blocks_json blocks
+
+let semantic_message_json (message : Agent_sdk.Types.message) =
+  match semantic_content_blocks_json message.content with
+  | Error _ as error -> error
+  | Ok content_blocks ->
+    Ok
+      (`Assoc
+         [ "role", `String (Agent_sdk.Types.role_to_string message.role)
+         ; "content_blocks", content_blocks
+         ; "name", option_json (fun value -> `String value) message.name
+         ; "tool_call_id", option_json (fun value -> `String value) message.tool_call_id
+         ; "metadata", canonical_json (`Assoc message.metadata)
+         ])
+
+let semantic_messages_json messages =
+  let rec loop projected_rev = function
+    | [] -> Ok (`List (List.rev projected_rev))
+    | message :: rest ->
+      (match semantic_message_json message with
+       | Error _ as error -> error
+       | Ok projected -> loop (projected :: projected_rev) rest)
+  in
+  loop [] messages
+
+let assistant_text_source message blocks =
+  let rec loop text_blocks_rev reasoning_discarded = function
+    | [] ->
+      let text_blocks = List.rev text_blocks_rev in
+      if List.exists (fun text -> String.trim text <> "") text_blocks
+      then
+        Some
+          { normalized_message =
+              { message with
+                content = List.map (fun text -> Agent_sdk.Types.Text text) text_blocks
+              }
+          ; text_blocks
+          ; reasoning_discarded
+          }
+      else None
+    | Agent_sdk.Types.Text text :: rest ->
+      loop (text :: text_blocks_rev) reasoning_discarded rest
+    | ( Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.ReasoningDetails _
+      | Agent_sdk.Types.RedactedThinking _ )
+      :: rest ->
+      loop text_blocks_rev true rest
+    | ( Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.ToolResult _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ )
+      :: _ ->
+      None
+  in
+  loop [] false blocks
+
+let cycle_has_tool_protocol messages =
+  let has_tool_use =
+    List.exists
+      (fun (message : Agent_sdk.Types.message) ->
+        List.exists
+          (function Agent_sdk.Types.ToolUse _ -> true | _ -> false)
+          message.content)
+      messages
+  in
+  let has_tool_result =
+    List.exists
+      (fun (message : Agent_sdk.Types.message) ->
+        List.exists
+          (function Agent_sdk.Types.ToolResult _ -> true | _ -> false)
+          message.content)
+      messages
+  in
+  has_tool_use && has_tool_result
 
 let eligible_source source_index = function
   | Keeper_compaction_unit.Ordinary_message
@@ -185,11 +345,18 @@ let eligible_source source_index = function
        ; tool_call_id = None
        ; metadata = []
        } as message) ->
-    (match text_blocks content with
-     | Some (_ :: _ as text_blocks)
-       when List.exists (fun text -> String.trim text <> "") text_blocks ->
-       Some { source_index; message; text_blocks }
-     | Some [] | Some (_ :: _) | None -> None)
+    (match assistant_text_source message content with
+     | Some source -> Some { source_index; payload = Assistant_text source }
+     | None -> None)
+  | Keeper_compaction_unit.Closed_tool_cycle messages
+    when cycle_has_tool_protocol messages ->
+    (match Keeper_compaction_unit.validate messages, semantic_messages_json messages with
+     | Ok (), Ok semantic_json ->
+       Some
+         { source_index
+         ; payload = Closed_tool_cycle { source_messages = messages; semantic_json }
+         }
+     | Error _, _ | _, Error _ -> None)
   | Keeper_compaction_unit.Ordinary_message _
   | Keeper_compaction_unit.Closed_tool_cycle _ ->
     None
@@ -205,25 +372,36 @@ let eligible_units_json sources =
   `List
     (List.map
        (fun source ->
-         `Assoc
-           [ Schema.compaction_plan_field_unit_index, `Int source.source_index
-           ; "role", `String (Agent_sdk.Types.role_to_string source.message.role)
-           ; "text_blocks", `List (List.map (fun text -> `String text) source.text_blocks)
-           ])
+         match source.payload with
+         | Assistant_text { text_blocks; _ } ->
+           `Assoc
+             [ Schema.compaction_plan_field_unit_index, `Int source.source_index
+             ; "kind", `String "assistant_text"
+             ; "role", `String "assistant"
+             ; "text_blocks", `List (List.map (fun text -> `String text) text_blocks)
+             ]
+         | Closed_tool_cycle { semantic_json; _ } ->
+           `Assoc
+             [ Schema.compaction_plan_field_unit_index, `Int source.source_index
+             ; "kind", `String "closed_tool_cycle"
+             ; "messages", semantic_json
+             ])
        sources)
 
 let messages_for_plan ~units =
   let sources = eligible_sources units in
   let system =
-    "You compact only the explicitly supplied eligible Assistant text units. \
+    "You compact only the explicitly supplied atomic eligible units. \
      Return exactly one decision for every supplied unit_index and do not \
-     invent indices. keep preserves the source verbatim. summarize replaces \
-     that unit in place with its faithful summary. drop is valid only when the \
+     invent indices. Each closed_tool_cycle contains a complete ordered tool \
+     request/result protocol and must be decided as one indivisible unit. keep \
+     preserves the source unit. summarize replaces that whole unit in place \
+     with one faithful Assistant memory. drop is valid only when the whole \
      unit contributes no state, decision, evidence, constraint, unresolved \
      work, or outcome. For keep and drop, summary must be null. For summarize, \
-     summary must be a non-empty string. Do not infer recency policy, merge \
-     units, relocate facts, invent facts, or include markdown fences. Respond \
-     with a single JSON object and no other text."
+     summary must be a non-empty string. Do not split tool cycles, infer \
+     recency policy, merge units, relocate facts, invent facts, or include \
+     markdown fences. Respond with a single JSON object and no other text."
   in
   let user =
     Printf.sprintf
@@ -351,6 +529,12 @@ let parse_decisions ~sources decisions_json =
   in
   parse Int_set.empty [] decisions_json
 
+let source_normalizes = function
+  | { payload = Assistant_text { reasoning_discarded = true; _ }; _ } -> true
+  | { payload = Assistant_text { reasoning_discarded = false; _ }; _ }
+  | { payload = Closed_tool_cycle _; _ } ->
+    false
+
 let plan_of_json ~units json =
   let sources = eligible_sources units in
   if sources = []
@@ -379,7 +563,7 @@ let plan_of_json ~units json =
          (fun decision ->
            match decision.action with
            | Drop | Summarize _ -> true
-           | Keep -> false)
+           | Keep -> source_normalizes decision.source)
          decisions
     then Ok ()
     else Error "plan keeps every eligible unit without changing any"
@@ -413,13 +597,14 @@ let apply (plan : compaction_plan) =
   |> List.mapi (fun idx unit_ -> idx, unit_)
   |> List.concat_map (fun (idx, unit_) ->
     match Int_map.find_opt idx decisions with
-    | None | Some { action = Keep; _ } -> messages_of_unit unit_
+    | None -> messages_of_unit unit_
+    | Some { source = { payload = Assistant_text source; _ }; action = Keep } ->
+      [ source.normalized_message ]
+    | Some { source = { payload = Closed_tool_cycle source; _ }; action = Keep } ->
+      source.source_messages
     | Some { action = Drop; _ } -> []
-    | Some { source; action = Summarize summary } ->
-      [ { source.message with
-          content = [ Agent_sdk.Types.Text summary ]
-        }
-      ])
+    | Some { action = Summarize summary; _ } ->
+      [ message Agent_sdk.Types.Assistant summary ])
 
 let indices_for_action predicate plan =
   plan.decisions
@@ -428,7 +613,15 @@ let indices_for_action predicate plan =
 
 let summarized_indices = indices_for_action (function Summarize _ -> true | Keep | Drop -> false)
 let dropped_indices = indices_for_action (function Drop -> true | Keep | Summarize _ -> false)
-let has_changes plan = summarized_indices plan <> [] || dropped_indices plan <> []
+let has_changes plan =
+  summarized_indices plan <> []
+  || dropped_indices plan <> []
+  || List.exists
+       (fun decision ->
+         match decision.action with
+         | Keep -> source_normalizes decision.source
+         | Drop | Summarize _ -> false)
+       plan.decisions
 
 let exact_output_requirement =
   Exact_output.make_output_requirement

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -612,13 +612,6 @@ let indices_for_action predicate plan =
 
 let summarized_indices = indices_for_action (function Summarize _ -> true | Keep | Drop -> false)
 let dropped_indices = indices_for_action (function Drop -> true | Keep | Summarize _ -> false)
-let normalized_indices plan =
-  plan.decisions
-  |> List.filter_map (fun decision ->
-    match decision.action with
-    | Keep when source_normalizes decision.source ->
-      Some decision.source.source_index
-    | Keep | Drop | Summarize _ -> None)
 
 let has_changes plan =
   summarized_indices plan <> []

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -273,7 +273,6 @@ let semantic_message_json (message : Agent_sdk.Types.message) =
          ; "content_blocks", content_blocks
          ; "name", option_json (fun value -> `String value) message.name
          ; "tool_call_id", option_json (fun value -> `String value) message.tool_call_id
-         ; "metadata", canonical_json (`Assoc message.metadata)
          ])
 
 let semantic_messages_json messages =
@@ -613,6 +612,14 @@ let indices_for_action predicate plan =
 
 let summarized_indices = indices_for_action (function Summarize _ -> true | Keep | Drop -> false)
 let dropped_indices = indices_for_action (function Drop -> true | Keep | Summarize _ -> false)
+let normalized_indices plan =
+  plan.decisions
+  |> List.filter_map (fun decision ->
+    match decision.action with
+    | Keep when source_normalizes decision.source ->
+      Some decision.source.source_index
+    | Keep | Drop | Summarize _ -> None)
+
 let has_changes plan =
   summarized_indices plan <> []
   || dropped_indices plan <> []

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -216,6 +216,7 @@ val exact_execution_evidence_receipt_request_body_sha256 : exact_execution_evide
 val apply : compaction_plan -> Agent_sdk.Types.message list
 val summarized_indices : compaction_plan -> int list
 val dropped_indices : compaction_plan -> int list
+val normalized_indices : compaction_plan -> int list
 val has_changes : compaction_plan -> bool
 
 module For_testing : sig

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -216,7 +216,6 @@ val exact_execution_evidence_receipt_request_body_sha256 : exact_execution_evide
 val apply : compaction_plan -> Agent_sdk.Types.message list
 val summarized_indices : compaction_plan -> int list
 val dropped_indices : compaction_plan -> int list
-val normalized_indices : compaction_plan -> int list
 val has_changes : compaction_plan -> bool
 
 module For_testing : sig

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -247,28 +247,30 @@ let append_manifest
     ~decision:
       (Keeper_runtime_manifest.with_clock_refs
          ~clock_refs
-         (Keeper_runtime_manifest.with_payload_role
-            ~payload_role:Keeper_runtime_manifest.Checkpoint
-            (`Assoc
-              [ "trigger", `String (Compaction_trigger.to_label trigger)
-              ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-              ; ( Keeper_compaction_evidence.exact_evidence_key
-                , Keeper_compaction_evidence.to_json recovery.evidence )
-              ; ( "checkpoint_installation_schema"
-                , `String "keeper.checkpoint_installation.v1" )
-              ; "checkpoint_installation_state", `String "installed"
-              ; ( "checkpoint_installed_ref"
-                , checkpoint_ref_to_json installation.installed_ref )
-              ; ( "checkpoint_installation_auxiliary"
-                , `List
-                    (List.map
-                       checkpoint_installation_auxiliary_to_json
-                       installation.auxiliary) )
-              ; ( "compaction_post_install_schema"
-                , `String "keeper.compaction.post_install.v1" )
-              ; "compaction_lifecycle", post_install_lifecycle_to_json lifecycle
-              ; "operator_action_required", `Bool operator_action_required
-              ])))
+         (Keeper_runtime_manifest.with_compaction_outcome
+            ~compaction_outcome:Keeper_runtime_manifest.Checkpoint_committed
+            (Keeper_runtime_manifest.with_payload_role
+               ~payload_role:Keeper_runtime_manifest.Checkpoint
+               (`Assoc
+                 [ "trigger", `String (Compaction_trigger.to_label trigger)
+                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                 ; ( Keeper_compaction_evidence.exact_evidence_key
+                   , Keeper_compaction_evidence.to_json recovery.evidence )
+                 ; ( "checkpoint_installation_schema"
+                   , `String "keeper.checkpoint_installation.v1" )
+                 ; "checkpoint_installation_state", `String "installed"
+                 ; ( "checkpoint_installed_ref"
+                   , checkpoint_ref_to_json installation.installed_ref )
+                 ; ( "checkpoint_installation_auxiliary"
+                   , `List
+                       (List.map
+                          checkpoint_installation_auxiliary_to_json
+                          installation.auxiliary) )
+                 ; ( "compaction_post_install_schema"
+                   , `String "keeper.compaction.post_install.v1" )
+                 ; "compaction_lifecycle", post_install_lifecycle_to_json lifecycle
+                 ; "operator_action_required", `Bool operator_action_required
+                 ]))))
     ~checkpoint_path
     ()
   |> Keeper_runtime_manifest.append config

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -615,6 +615,51 @@ type parsed_row = {
   links : links;
 }
 
+let canonicalize_compaction_evidence ~event_wire decision =
+  let evidence_key = Keeper_compaction_evidence.exact_evidence_key in
+  let evidence_required =
+    String.equal event_wire (event_kind_to_string Context_compacted)
+  in
+  match decision with
+  | `Assoc fields ->
+    (match List.filter (fun (key, _) -> String.equal key evidence_key) fields with
+     | [] when evidence_required ->
+       Error
+         (Printf.sprintf
+            "field \"decision.%s\" is required for current context_compacted rows"
+            evidence_key)
+     | [] -> Ok decision
+     | [ _, evidence_json ] ->
+       (match Keeper_compaction_evidence.of_json evidence_json with
+        | Error error ->
+          Error
+            (Printf.sprintf
+               "field \"decision.%s\" is invalid: %s"
+               evidence_key
+               (Keeper_compaction_evidence.decode_error_to_string error))
+        | Ok evidence ->
+          let canonical = Keeper_compaction_evidence.to_json evidence in
+          Ok
+            (`Assoc
+               (List.map
+                  (fun (key, value) ->
+                     if String.equal key evidence_key
+                     then key, canonical
+                     else key, value)
+                  fields)))
+     | _ ->
+       Error
+         (Printf.sprintf
+            "field \"decision.%s\" must appear exactly once"
+            evidence_key))
+  | _ when evidence_required ->
+    Error
+      (Printf.sprintf
+         "field \"decision.%s\" is required for current context_compacted rows"
+         evidence_key)
+  | _ -> Ok decision
+;;
+
 let parse_row = function
   | `Assoc fields -> (
       let ( >>= ) result f =
@@ -640,6 +685,8 @@ let parse_row = function
             optional_string "runtime_id" fields >>= fun runtime_id ->
             required_string "status" fields >>= fun status ->
             field "decision" fields >>= fun decision ->
+            canonicalize_compaction_evidence ~event_wire decision
+            >>= fun decision ->
             field "links" fields >>= fun links_json ->
             links_of_json links_json >>= fun links ->
             Ok

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -70,6 +70,28 @@ type status =
   | Skipped
   | Other of string
 
+type compaction_outcome =
+  | Checkpoint_committed
+  | Retry_without_checkpoint
+  | Lifecycle_cleanup_failed_without_checkpoint
+
+let compaction_outcome_key = "compaction_outcome"
+
+let compaction_outcome_to_string = function
+  | Checkpoint_committed -> "checkpoint_committed"
+  | Retry_without_checkpoint -> "retry_without_checkpoint"
+  | Lifecycle_cleanup_failed_without_checkpoint ->
+    "lifecycle_cleanup_failed_without_checkpoint"
+;;
+
+let compaction_outcome_of_string = function
+  | "checkpoint_committed" -> Some Checkpoint_committed
+  | "retry_without_checkpoint" -> Some Retry_without_checkpoint
+  | "lifecycle_cleanup_failed_without_checkpoint" ->
+    Some Lifecycle_cleanup_failed_without_checkpoint
+  | _ -> None
+;;
+
 let skipped_status = "skipped"
 
 let status_of_string value =
@@ -307,6 +329,15 @@ let with_payload_role ~payload_role decision =
         ("payload_role", `String (payload_role_to_string payload_role));
       ]
 
+let with_compaction_outcome ~compaction_outcome decision =
+  let outcome_json = `String (compaction_outcome_to_string compaction_outcome) in
+  match decision with
+  | `Assoc fields when assoc_has_key compaction_outcome_key fields -> decision
+  | `Assoc fields -> `Assoc (fields @ [ compaction_outcome_key, outcome_json ])
+  | other ->
+    `Assoc [ "decision", other; compaction_outcome_key, outcome_json ]
+;;
+
 let make ?(ts = Masc_domain.now_iso ()) ~keeper_name ?agent_name ~trace_id
     ?generation ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ?runtime_id
     ?(status = "ok") ?(decision = `Assoc []) ?receipt_path ?checkpoint_path
@@ -389,7 +420,8 @@ let decision_public_allowlist =
     ; "media_dropped_total"; "media_dropped_counts"
     ; "payload_role"; "trigger"; "trigger_detail"
     ; "ratio"; "threshold"; "count"
-    ; "source_requeued"; Keeper_compaction_evidence.exact_evidence_key
+    ; "source_requeued"; compaction_outcome_key
+    ; Keeper_compaction_evidence.exact_evidence_key
     ; "clock_refs"
     ; "checkpoint_installation_schema"; "checkpoint_installation_state"
     ; "checkpoint_installed_ref"; "checkpoint_installation_auxiliary"
@@ -617,46 +649,112 @@ type parsed_row = {
 
 let canonicalize_compaction_evidence ~event_wire decision =
   let evidence_key = Keeper_compaction_evidence.exact_evidence_key in
-  let evidence_required =
-    String.equal event_wire (event_kind_to_string Context_compacted)
+  let canonicalize_present fields evidence_json =
+    match Keeper_compaction_evidence.of_json evidence_json with
+    | Error error ->
+      Error
+        (Printf.sprintf
+           "field \"decision.%s\" is invalid: %s"
+           evidence_key
+           (Keeper_compaction_evidence.decode_error_to_string error))
+    | Ok evidence ->
+      let canonical = Keeper_compaction_evidence.to_json evidence in
+      Ok
+        (`Assoc
+           (List.map
+              (fun (key, value) ->
+                 if String.equal key evidence_key then key, canonical else key, value)
+              fields))
   in
   match decision with
   | `Assoc fields ->
-    (match List.filter (fun (key, _) -> String.equal key evidence_key) fields with
-     | [] when evidence_required ->
-       Error
-         (Printf.sprintf
-            "field \"decision.%s\" is required for current context_compacted rows"
-            evidence_key)
-     | [] -> Ok decision
-     | [ _, evidence_json ] ->
-       (match Keeper_compaction_evidence.of_json evidence_json with
-        | Error error ->
-          Error
-            (Printf.sprintf
-               "field \"decision.%s\" is invalid: %s"
-               evidence_key
-               (Keeper_compaction_evidence.decode_error_to_string error))
-        | Ok evidence ->
-          let canonical = Keeper_compaction_evidence.to_json evidence in
-          Ok
-            (`Assoc
-               (List.map
-                  (fun (key, value) ->
-                     if String.equal key evidence_key
-                     then key, canonical
-                     else key, value)
-                  fields)))
-     | _ ->
-       Error
-         (Printf.sprintf
-            "field \"decision.%s\" must appear exactly once"
-            evidence_key))
-  | _ when evidence_required ->
+    let evidence_entries =
+      List.filter (fun (key, _) -> String.equal key evidence_key) fields
+    in
+    if not (String.equal event_wire (event_kind_to_string Context_compacted))
+    then
+      (match evidence_entries with
+       | [] -> Ok decision
+       | [ _, evidence_json ] -> canonicalize_present fields evidence_json
+       | _ ->
+         Error
+           (Printf.sprintf
+              "field \"decision.%s\" must appear exactly once"
+              evidence_key))
+    else
+      let outcome_entries =
+        List.filter (fun (key, _) -> String.equal key compaction_outcome_key) fields
+      in
+      (match outcome_entries with
+       | [ _, `String wire ] ->
+         (match compaction_outcome_of_string wire with
+          | None ->
+            Error
+              (Printf.sprintf
+                 "field \"decision.%s\" has unknown value %S"
+                 compaction_outcome_key
+                 wire)
+          | Some Checkpoint_committed ->
+            (match evidence_entries with
+             | [ _, evidence_json ] -> canonicalize_present fields evidence_json
+             | [] ->
+               Error
+                 (Printf.sprintf
+                    "field \"decision.%s\" is required for checkpoint_committed"
+                    evidence_key)
+             | _ ->
+               Error
+                 (Printf.sprintf
+                    "field \"decision.%s\" must appear exactly once"
+                    evidence_key))
+          | Some
+              (Retry_without_checkpoint
+              | Lifecycle_cleanup_failed_without_checkpoint) ->
+            (match evidence_entries with
+             | _ :: _ ->
+               Error
+                 (Printf.sprintf
+                    "field \"decision.%s\" is forbidden without a committed checkpoint"
+                    evidence_key)
+             | [] ->
+               (match
+                  List.filter (fun (key, _) -> String.equal key "error") fields
+                with
+                | [ _, `String cause ] when String.trim cause <> "" -> Ok decision
+                | [ _, `String _ ] ->
+                  Error
+                    "field \"decision.error\" must be nonblank for a failed compaction outcome"
+                | [ _, other ] ->
+                  Error
+                    (Printf.sprintf
+                       "field \"decision.error\" must be a string (received %s)"
+                       (Json_util.kind_name other))
+                | [] ->
+                  Error
+                    "field \"decision.error\" is required for a failed compaction outcome"
+                | _ ->
+                  Error "field \"decision.error\" must appear exactly once")))
+       | [ _, other ] ->
+         Error
+           (Printf.sprintf
+              "field \"decision.%s\" must be a string (received %s)"
+              compaction_outcome_key
+              (Json_util.kind_name other))
+       | [] ->
+         Error
+           (Printf.sprintf
+              "field \"decision.%s\" is required for current context_compacted rows"
+              compaction_outcome_key)
+       | _ ->
+         Error
+           (Printf.sprintf
+              "field \"decision.%s\" must appear exactly once"
+              compaction_outcome_key))
+  | _ when String.equal event_wire (event_kind_to_string Context_compacted) ->
     Error
       (Printf.sprintf
          "field \"decision.%s\" is required for current context_compacted rows"
-         evidence_key)
+         compaction_outcome_key)
   | _ -> Ok decision
 ;;
 

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -73,6 +73,11 @@ type status =
   | Skipped
   | Other of string
 
+type compaction_outcome =
+  | Checkpoint_committed
+  | Retry_without_checkpoint
+  | Lifecycle_cleanup_failed_without_checkpoint
+
 (** {1 Own-module vals} *)
 
 val payload_role_to_string : payload_role -> string
@@ -89,6 +94,9 @@ val safe_segment : string -> string
 val status_of_string : string -> status
 val status_to_string : status -> string
 val status_is_skipped : t -> bool
+val compaction_outcome_key : string
+val compaction_outcome_to_string : compaction_outcome -> string
+val compaction_outcome_of_string : string -> compaction_outcome option
 
 val clock_refs :
   ?edge_id:string ->
@@ -128,6 +136,9 @@ val clock_refs_for_context :
 val with_clock_refs : clock_refs:Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
 
 val with_payload_role : payload_role:payload_role -> Yojson.Safe.t -> Yojson.Safe.t
+
+val with_compaction_outcome :
+  compaction_outcome:compaction_outcome -> Yojson.Safe.t -> Yojson.Safe.t
 
 val make :
   ?ts:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -497,16 +497,18 @@ let append_provider_overflow_manifest
         ~compaction_source:"provider_overflow"
         ~checkpoint_path
         ~decision:
-          (Keeper_runtime_manifest.with_payload_role
-             ~payload_role:Checkpoint
-             (`Assoc
-               [ "trigger", `String (Compaction_trigger.to_label trigger)
-               ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "requeue_disposition_requested", `Bool true
-               ; "error", error
-               ; ( Keeper_compaction_evidence.exact_evidence_key
-                 , Keeper_compaction_evidence.to_json evidence )
-               ]))
+          (Keeper_runtime_manifest.with_compaction_outcome
+             ~compaction_outcome:Checkpoint_committed
+             (Keeper_runtime_manifest.with_payload_role
+                ~payload_role:Checkpoint
+                (`Assoc
+                  [ "trigger", `String (Compaction_trigger.to_label trigger)
+                  ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                  ; "requeue_disposition_requested", `Bool true
+                  ; "error", error
+                  ; ( Keeper_compaction_evidence.exact_evidence_key
+                    , Keeper_compaction_evidence.to_json evidence )
+                  ])))
         Keeper_runtime_manifest.Context_compacted
     in
     turn_state
@@ -560,14 +562,16 @@ let append_provider_overflow_manifest
         ~status:"retryable_failure"
         ~compaction_source:"provider_overflow"
         ~decision:
-          (Keeper_runtime_manifest.with_payload_role
-             ~payload_role:Checkpoint
-             (`Assoc
-               [ "trigger", `String (Compaction_trigger.to_label trigger)
-               ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "requeue_disposition_requested", `Bool true
-               ; "error", `String reason
-               ]))
+          (Keeper_runtime_manifest.with_compaction_outcome
+             ~compaction_outcome:Retry_without_checkpoint
+             (Keeper_runtime_manifest.with_payload_role
+                ~payload_role:Checkpoint
+                (`Assoc
+                  [ "trigger", `String (Compaction_trigger.to_label trigger)
+                  ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                  ; "requeue_disposition_requested", `Bool true
+                  ; "error", `String reason
+                  ])))
         Keeper_runtime_manifest.Context_compacted
     in
     Requeue_after_context_compaction (Compaction_attempt_failed { reason }),
@@ -592,13 +596,15 @@ let append_provider_overflow_manifest
           ~status:"lifecycle_cleanup_failed"
           ~compaction_source:"provider_overflow"
           ~decision:
-            (Keeper_runtime_manifest.with_payload_role
-               ~payload_role:Checkpoint
-               (`Assoc
-                 [ "trigger", `String (Compaction_trigger.to_label trigger)
-                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-                 ; "reason", `String reason
-                 ]))
+            (Keeper_runtime_manifest.with_compaction_outcome
+               ~compaction_outcome:Lifecycle_cleanup_failed_without_checkpoint
+               (Keeper_runtime_manifest.with_payload_role
+                  ~payload_role:Checkpoint
+                  (`Assoc
+                    [ "trigger", `String (Compaction_trigger.to_label trigger)
+                    ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                    ; "error", `String reason
+                    ])))
           Keeper_runtime_manifest.Context_compacted
     in
     source_lease_disposition, turn_state

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -74,7 +74,9 @@ type decode_error =
       { before_message_count : int
       ; after_message_count : int
       ; summarized_message_count : int
+      ; summarized_unit_count : int
       ; dropped_message_count : int
+      ; normalized_message_count : int
       }
   | Invalid_tool_protocol_accounting of
       { before_tool_use_count : int
@@ -185,14 +187,19 @@ let decode_error_to_string = function
       { before_message_count
       ; after_message_count
       ; summarized_message_count
+      ; summarized_unit_count
       ; dropped_message_count
+      ; normalized_message_count
       } ->
     Printf.sprintf
-      "invalid_message_accounting:before=%d:after=%d:summarized=%d:dropped=%d"
+      "invalid_message_accounting:before=%d:after=%d:summarized=%d:\
+       summarized_units=%d:dropped=%d:normalized=%d"
       before_message_count
       after_message_count
       summarized_message_count
+      summarized_unit_count
       dropped_message_count
+      normalized_message_count
   | Invalid_tool_protocol_accounting
       { before_tool_use_count
       ; after_tool_use_count
@@ -216,10 +223,16 @@ let message_accounting_is_exact
       ~summarized_message_count
       ~summarized_unit_count
       ~dropped_message_count
+      ~normalized_message_count
   =
   summarized_message_count <= before_message_count
   && summarized_unit_count <= summarized_message_count
+  && Bool.equal
+       (summarized_message_count = 0)
+       (summarized_unit_count = 0)
   && dropped_message_count <= before_message_count - summarized_message_count
+  && normalized_message_count
+     <= before_message_count - summarized_message_count - dropped_message_count
   && after_message_count
      = before_message_count
        - dropped_message_count
@@ -373,14 +386,17 @@ let create
               ~after_message_count
               ~summarized_message_count
               ~summarized_unit_count
-              ~dropped_message_count)
+              ~dropped_message_count
+              ~normalized_message_count)
        then
          Error
            (Invalid_message_accounting
               { before_message_count
               ; after_message_count
               ; summarized_message_count
+              ; summarized_unit_count
               ; dropped_message_count
+              ; normalized_message_count
               })
        else
          Ok

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -12,15 +12,11 @@ type t =
   ; before_message_count : int
   ; after_message_count : int
   ; summarized_message_count : int
-  ; summarized_unit_count : int
   ; dropped_message_count : int
-  ; normalized_message_count : int
   ; before_tool_use_count : int
   ; after_tool_use_count : int
   ; before_tool_result_count : int
   ; after_tool_result_count : int
-  ; removed_tool_use_count : int
-  ; removed_tool_result_count : int
   }
 
 type field =
@@ -37,15 +33,11 @@ type field =
   | Before_message_count
   | After_message_count
   | Summarized_message_count
-  | Summarized_unit_count
   | Dropped_message_count
-  | Normalized_message_count
   | Before_tool_use_count
   | After_tool_use_count
   | Before_tool_result_count
   | After_tool_result_count
-  | Removed_tool_use_count
-  | Removed_tool_result_count
 
 type field_error =
   | Missing
@@ -74,9 +66,7 @@ type decode_error =
       { before_message_count : int
       ; after_message_count : int
       ; summarized_message_count : int
-      ; summarized_unit_count : int
       ; dropped_message_count : int
-      ; normalized_message_count : int
       }
   | Invalid_tool_protocol_accounting of
       { before_tool_use_count : int
@@ -100,15 +90,11 @@ let field_name = function
   | Before_message_count -> "before_message_count"
   | After_message_count -> "after_message_count"
   | Summarized_message_count -> "summarized_message_count"
-  | Summarized_unit_count -> "summarized_unit_count"
   | Dropped_message_count -> "dropped_message_count"
-  | Normalized_message_count -> "normalized_message_count"
   | Before_tool_use_count -> "before_tool_use_count"
   | After_tool_use_count -> "after_tool_use_count"
   | Before_tool_result_count -> "before_tool_result_count"
   | After_tool_result_count -> "after_tool_result_count"
-  | Removed_tool_use_count -> "removed_tool_use_count"
-  | Removed_tool_result_count -> "removed_tool_result_count"
 ;;
 
 let exact_fields =
@@ -129,15 +115,11 @@ let integer_fields =
   ; Before_message_count
   ; After_message_count
   ; Summarized_message_count
-  ; Summarized_unit_count
   ; Dropped_message_count
-  ; Normalized_message_count
   ; Before_tool_use_count
   ; After_tool_use_count
   ; Before_tool_result_count
   ; After_tool_result_count
-  ; Removed_tool_use_count
-  ; Removed_tool_result_count
   ]
 ;;
 
@@ -187,19 +169,14 @@ let decode_error_to_string = function
       { before_message_count
       ; after_message_count
       ; summarized_message_count
-      ; summarized_unit_count
       ; dropped_message_count
-      ; normalized_message_count
       } ->
     Printf.sprintf
-      "invalid_message_accounting:before=%d:after=%d:summarized=%d:\
-       summarized_units=%d:dropped=%d:normalized=%d"
+      "invalid_message_accounting:before=%d:after=%d:summarized=%d:dropped=%d"
       before_message_count
       after_message_count
       summarized_message_count
-      summarized_unit_count
       dropped_message_count
-      normalized_message_count
   | Invalid_tool_protocol_accounting
       { before_tool_use_count
       ; after_tool_use_count
@@ -217,27 +194,17 @@ let decode_error_to_string = function
 
 let ( let* ) = Result.bind
 
-let message_accounting_is_exact
+let message_accounting_is_structurally_possible
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
-      ~summarized_unit_count
       ~dropped_message_count
-      ~normalized_message_count
   =
+  let removed_message_count = before_message_count - after_message_count in
   summarized_message_count <= before_message_count
-  && summarized_unit_count <= summarized_message_count
-  && Bool.equal
-       (summarized_message_count = 0)
-       (summarized_unit_count = 0)
   && dropped_message_count <= before_message_count - summarized_message_count
-  && normalized_message_count
-     <= before_message_count - summarized_message_count - dropped_message_count
-  && after_message_count
-     = before_message_count
-       - dropped_message_count
-       - summarized_message_count
-       + summarized_unit_count
+  && removed_message_count >= dropped_message_count
+  && removed_message_count <= dropped_message_count + summarized_message_count
 ;;
 
 let decode_nonblank_string fields field =
@@ -281,15 +248,11 @@ let create
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
-      ~summarized_unit_count
       ~dropped_message_count
-      ~normalized_message_count
       ~before_tool_use_count
       ~after_tool_use_count
       ~before_tool_result_count
       ~after_tool_result_count
-      ~removed_tool_use_count
-      ~removed_tool_result_count
   =
   let values =
     [ Before_checkpoint_bytes, before_checkpoint_bytes
@@ -297,15 +260,11 @@ let create
     ; Before_message_count, before_message_count
     ; After_message_count, after_message_count
     ; Summarized_message_count, summarized_message_count
-    ; Summarized_unit_count, summarized_unit_count
     ; Dropped_message_count, dropped_message_count
-    ; Normalized_message_count, normalized_message_count
     ; Before_tool_use_count, before_tool_use_count
     ; After_tool_use_count, after_tool_use_count
     ; Before_tool_result_count, before_tool_result_count
     ; After_tool_result_count, after_tool_result_count
-    ; Removed_tool_use_count, removed_tool_use_count
-    ; Removed_tool_result_count, removed_tool_result_count
     ]
   in
   match List.find_opt (fun (_, value) -> value < 0) values with
@@ -341,31 +300,19 @@ let create
          Error
            (Invalid_transition
               (Messages, before_message_count, after_message_count))
-       else if removed_tool_use_count > before_tool_use_count
-       then
-         Error
-           (Invalid_transition
-              (Tool_uses, before_tool_use_count, removed_tool_use_count))
-       else if removed_tool_result_count > before_tool_result_count
-       then
-         Error
-           (Invalid_transition
-              (Tool_results, before_tool_result_count, removed_tool_result_count))
-       else if
-         after_tool_use_count <> before_tool_use_count - removed_tool_use_count
+       else if after_tool_use_count > before_tool_use_count
        then
          Error
            (Invalid_transition
               (Tool_uses, before_tool_use_count, after_tool_use_count))
-       else if
-         after_tool_result_count
-         <> before_tool_result_count - removed_tool_result_count
+       else if after_tool_result_count > before_tool_result_count
        then
          Error
            (Invalid_transition
               (Tool_results, before_tool_result_count, after_tool_result_count))
        else if
-         removed_tool_use_count <> removed_tool_result_count
+         before_tool_use_count - after_tool_use_count
+         <> before_tool_result_count - after_tool_result_count
        then
          Error
            (Invalid_tool_protocol_accounting
@@ -375,28 +322,19 @@ let create
               ; after_tool_result_count
               })
        else if
-         summarized_unit_count = 0
-         && dropped_message_count = 0
-         && normalized_message_count = 0
-       then Error No_messages_compacted
-       else if
          not
-           (message_accounting_is_exact
+           (message_accounting_is_structurally_possible
               ~before_message_count
               ~after_message_count
               ~summarized_message_count
-              ~summarized_unit_count
-              ~dropped_message_count
-              ~normalized_message_count)
+              ~dropped_message_count)
        then
          Error
            (Invalid_message_accounting
               { before_message_count
               ; after_message_count
               ; summarized_message_count
-              ; summarized_unit_count
               ; dropped_message_count
-              ; normalized_message_count
               })
        else
          Ok
@@ -413,15 +351,11 @@ let create
            ; before_message_count
            ; after_message_count
            ; summarized_message_count
-           ; summarized_unit_count
            ; dropped_message_count
-           ; normalized_message_count
            ; before_tool_use_count
            ; after_tool_use_count
            ; before_tool_result_count
            ; after_tool_result_count
-           ; removed_tool_use_count
-           ; removed_tool_result_count
            })
 ;;
 
@@ -451,15 +385,11 @@ let of_json = function
     let* before_message_count = integer Before_message_count in
     let* after_message_count = integer After_message_count in
     let* summarized_message_count = integer Summarized_message_count in
-    let* summarized_unit_count = integer Summarized_unit_count in
     let* dropped_message_count = integer Dropped_message_count in
-    let* normalized_message_count = integer Normalized_message_count in
     let* before_tool_use_count = integer Before_tool_use_count in
     let* after_tool_use_count = integer After_tool_use_count in
     let* before_tool_result_count = integer Before_tool_result_count in
     let* after_tool_result_count = integer After_tool_result_count in
-    let* removed_tool_use_count = integer Removed_tool_use_count in
-    let* removed_tool_result_count = integer Removed_tool_result_count in
     create
       ~slot_id
       ~call_id
@@ -474,15 +404,11 @@ let of_json = function
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
-      ~summarized_unit_count
       ~dropped_message_count
-      ~normalized_message_count
       ~before_tool_use_count
       ~after_tool_use_count
       ~before_tool_result_count
       ~after_tool_result_count
-      ~removed_tool_use_count
-      ~removed_tool_result_count
   | _ -> Error Expected_object
 ;;
 
@@ -501,14 +427,10 @@ let to_json evidence =
     ; "before_message_count", `Int evidence.before_message_count
     ; "after_message_count", `Int evidence.after_message_count
     ; "summarized_message_count", `Int evidence.summarized_message_count
-    ; "summarized_unit_count", `Int evidence.summarized_unit_count
     ; "dropped_message_count", `Int evidence.dropped_message_count
-    ; "normalized_message_count", `Int evidence.normalized_message_count
     ; "before_tool_use_count", `Int evidence.before_tool_use_count
     ; "after_tool_use_count", `Int evidence.after_tool_use_count
     ; "before_tool_result_count", `Int evidence.before_tool_result_count
     ; "after_tool_result_count", `Int evidence.after_tool_result_count
-    ; "removed_tool_use_count", `Int evidence.removed_tool_use_count
-    ; "removed_tool_result_count", `Int evidence.removed_tool_result_count
     ]
 ;;

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -12,11 +12,15 @@ type t =
   ; before_message_count : int
   ; after_message_count : int
   ; summarized_message_count : int
+  ; summarized_unit_count : int
   ; dropped_message_count : int
+  ; normalized_message_count : int
   ; before_tool_use_count : int
   ; after_tool_use_count : int
   ; before_tool_result_count : int
   ; after_tool_result_count : int
+  ; removed_tool_use_count : int
+  ; removed_tool_result_count : int
   }
 
 type field =
@@ -33,11 +37,15 @@ type field =
   | Before_message_count
   | After_message_count
   | Summarized_message_count
+  | Summarized_unit_count
   | Dropped_message_count
+  | Normalized_message_count
   | Before_tool_use_count
   | After_tool_use_count
   | Before_tool_result_count
   | After_tool_result_count
+  | Removed_tool_use_count
+  | Removed_tool_result_count
 
 type field_error =
   | Missing
@@ -68,6 +76,12 @@ type decode_error =
       ; summarized_message_count : int
       ; dropped_message_count : int
       }
+  | Invalid_tool_protocol_accounting of
+      { before_tool_use_count : int
+      ; after_tool_use_count : int
+      ; before_tool_result_count : int
+      ; after_tool_result_count : int
+      }
   | No_messages_compacted
 
 let field_name = function
@@ -84,11 +98,15 @@ let field_name = function
   | Before_message_count -> "before_message_count"
   | After_message_count -> "after_message_count"
   | Summarized_message_count -> "summarized_message_count"
+  | Summarized_unit_count -> "summarized_unit_count"
   | Dropped_message_count -> "dropped_message_count"
+  | Normalized_message_count -> "normalized_message_count"
   | Before_tool_use_count -> "before_tool_use_count"
   | After_tool_use_count -> "after_tool_use_count"
   | Before_tool_result_count -> "before_tool_result_count"
   | After_tool_result_count -> "after_tool_result_count"
+  | Removed_tool_use_count -> "removed_tool_use_count"
+  | Removed_tool_result_count -> "removed_tool_result_count"
 ;;
 
 let exact_fields =
@@ -109,11 +127,15 @@ let integer_fields =
   ; Before_message_count
   ; After_message_count
   ; Summarized_message_count
+  ; Summarized_unit_count
   ; Dropped_message_count
+  ; Normalized_message_count
   ; Before_tool_use_count
   ; After_tool_use_count
   ; Before_tool_result_count
   ; After_tool_result_count
+  ; Removed_tool_use_count
+  ; Removed_tool_result_count
   ]
 ;;
 
@@ -171,6 +193,18 @@ let decode_error_to_string = function
       after_message_count
       summarized_message_count
       dropped_message_count
+  | Invalid_tool_protocol_accounting
+      { before_tool_use_count
+      ; after_tool_use_count
+      ; before_tool_result_count
+      ; after_tool_result_count
+      } ->
+    Printf.sprintf
+      "invalid_tool_protocol_accounting:uses=%d->%d:results=%d->%d"
+      before_tool_use_count
+      after_tool_use_count
+      before_tool_result_count
+      after_tool_result_count
   | No_messages_compacted -> "no_messages_compacted"
 ;;
 
@@ -180,11 +214,17 @@ let message_accounting_is_exact
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
+      ~summarized_unit_count
       ~dropped_message_count
   =
   summarized_message_count <= before_message_count
+  && summarized_unit_count <= summarized_message_count
   && dropped_message_count <= before_message_count - summarized_message_count
-  && after_message_count = before_message_count - dropped_message_count
+  && after_message_count
+     = before_message_count
+       - dropped_message_count
+       - summarized_message_count
+       + summarized_unit_count
 ;;
 
 let decode_nonblank_string fields field =
@@ -228,11 +268,15 @@ let create
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
+      ~summarized_unit_count
       ~dropped_message_count
+      ~normalized_message_count
       ~before_tool_use_count
       ~after_tool_use_count
       ~before_tool_result_count
       ~after_tool_result_count
+      ~removed_tool_use_count
+      ~removed_tool_result_count
   =
   let values =
     [ Before_checkpoint_bytes, before_checkpoint_bytes
@@ -240,11 +284,15 @@ let create
     ; Before_message_count, before_message_count
     ; After_message_count, after_message_count
     ; Summarized_message_count, summarized_message_count
+    ; Summarized_unit_count, summarized_unit_count
     ; Dropped_message_count, dropped_message_count
+    ; Normalized_message_count, normalized_message_count
     ; Before_tool_use_count, before_tool_use_count
     ; After_tool_use_count, after_tool_use_count
     ; Before_tool_result_count, before_tool_result_count
     ; After_tool_result_count, after_tool_result_count
+    ; Removed_tool_use_count, removed_tool_use_count
+    ; Removed_tool_result_count, removed_tool_result_count
     ]
   in
   match List.find_opt (fun (_, value) -> value < 0) values with
@@ -280,17 +328,43 @@ let create
          Error
            (Invalid_transition
               (Messages, before_message_count, after_message_count))
-       else if after_tool_use_count <> before_tool_use_count
+       else if removed_tool_use_count > before_tool_use_count
+       then
+         Error
+           (Invalid_transition
+              (Tool_uses, before_tool_use_count, removed_tool_use_count))
+       else if removed_tool_result_count > before_tool_result_count
+       then
+         Error
+           (Invalid_transition
+              (Tool_results, before_tool_result_count, removed_tool_result_count))
+       else if
+         after_tool_use_count <> before_tool_use_count - removed_tool_use_count
        then
          Error
            (Invalid_transition
               (Tool_uses, before_tool_use_count, after_tool_use_count))
-       else if after_tool_result_count <> before_tool_result_count
+       else if
+         after_tool_result_count
+         <> before_tool_result_count - removed_tool_result_count
        then
          Error
            (Invalid_transition
               (Tool_results, before_tool_result_count, after_tool_result_count))
-       else if summarized_message_count = 0 && dropped_message_count = 0
+       else if
+         removed_tool_use_count <> removed_tool_result_count
+       then
+         Error
+           (Invalid_tool_protocol_accounting
+              { before_tool_use_count
+              ; after_tool_use_count
+              ; before_tool_result_count
+              ; after_tool_result_count
+              })
+       else if
+         summarized_unit_count = 0
+         && dropped_message_count = 0
+         && normalized_message_count = 0
        then Error No_messages_compacted
        else if
          not
@@ -298,6 +372,7 @@ let create
               ~before_message_count
               ~after_message_count
               ~summarized_message_count
+              ~summarized_unit_count
               ~dropped_message_count)
        then
          Error
@@ -322,11 +397,15 @@ let create
            ; before_message_count
            ; after_message_count
            ; summarized_message_count
+           ; summarized_unit_count
            ; dropped_message_count
+           ; normalized_message_count
            ; before_tool_use_count
            ; after_tool_use_count
            ; before_tool_result_count
            ; after_tool_result_count
+           ; removed_tool_use_count
+           ; removed_tool_result_count
            })
 ;;
 
@@ -356,11 +435,15 @@ let of_json = function
     let* before_message_count = integer Before_message_count in
     let* after_message_count = integer After_message_count in
     let* summarized_message_count = integer Summarized_message_count in
+    let* summarized_unit_count = integer Summarized_unit_count in
     let* dropped_message_count = integer Dropped_message_count in
+    let* normalized_message_count = integer Normalized_message_count in
     let* before_tool_use_count = integer Before_tool_use_count in
     let* after_tool_use_count = integer After_tool_use_count in
     let* before_tool_result_count = integer Before_tool_result_count in
     let* after_tool_result_count = integer After_tool_result_count in
+    let* removed_tool_use_count = integer Removed_tool_use_count in
+    let* removed_tool_result_count = integer Removed_tool_result_count in
     create
       ~slot_id
       ~call_id
@@ -375,11 +458,15 @@ let of_json = function
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
+      ~summarized_unit_count
       ~dropped_message_count
+      ~normalized_message_count
       ~before_tool_use_count
       ~after_tool_use_count
       ~before_tool_result_count
       ~after_tool_result_count
+      ~removed_tool_use_count
+      ~removed_tool_result_count
   | _ -> Error Expected_object
 ;;
 
@@ -398,10 +485,14 @@ let to_json evidence =
     ; "before_message_count", `Int evidence.before_message_count
     ; "after_message_count", `Int evidence.after_message_count
     ; "summarized_message_count", `Int evidence.summarized_message_count
+    ; "summarized_unit_count", `Int evidence.summarized_unit_count
     ; "dropped_message_count", `Int evidence.dropped_message_count
+    ; "normalized_message_count", `Int evidence.normalized_message_count
     ; "before_tool_use_count", `Int evidence.before_tool_use_count
     ; "after_tool_use_count", `Int evidence.after_tool_use_count
     ; "before_tool_result_count", `Int evidence.before_tool_result_count
     ; "after_tool_result_count", `Int evidence.after_tool_result_count
+    ; "removed_tool_use_count", `Int evidence.removed_tool_use_count
+    ; "removed_tool_result_count", `Int evidence.removed_tool_result_count
     ]
 ;;

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -14,11 +14,15 @@ type t =
   ; before_message_count : int
   ; after_message_count : int
   ; summarized_message_count : int
+  ; summarized_unit_count : int
   ; dropped_message_count : int
+  ; normalized_message_count : int
   ; before_tool_use_count : int
   ; after_tool_use_count : int
   ; before_tool_result_count : int
   ; after_tool_result_count : int
+  ; removed_tool_use_count : int
+  ; removed_tool_result_count : int
   }
 
 type field =
@@ -35,11 +39,15 @@ type field =
   | Before_message_count
   | After_message_count
   | Summarized_message_count
+  | Summarized_unit_count
   | Dropped_message_count
+  | Normalized_message_count
   | Before_tool_use_count
   | After_tool_use_count
   | Before_tool_result_count
   | After_tool_result_count
+  | Removed_tool_use_count
+  | Removed_tool_result_count
 
 type field_error =
   | Missing
@@ -70,6 +78,12 @@ type decode_error =
       ; summarized_message_count : int
       ; dropped_message_count : int
       }
+  | Invalid_tool_protocol_accounting of
+      { before_tool_use_count : int
+      ; after_tool_use_count : int
+      ; before_tool_result_count : int
+      ; after_tool_result_count : int
+      }
   | No_messages_compacted
 
 val decode_error_to_string : decode_error -> string
@@ -95,18 +109,27 @@ val create
   -> before_message_count:int
   -> after_message_count:int
   -> summarized_message_count:int
+  -> summarized_unit_count:int
   -> dropped_message_count:int
+  -> normalized_message_count:int
   -> before_tool_use_count:int
   -> after_tool_use_count:int
   -> before_tool_result_count:int
   -> after_tool_result_count:int
+  -> removed_tool_use_count:int
+  -> removed_tool_result_count:int
   -> (t, decode_error) result
 (** Construct evidence through the same closed validation boundary used by
-    persisted JSON restoration. Message accounting is exact:
-    [after = before - dropped]. Every summarized source message is replaced in
-    place by exactly one summary message, so summarization changes bytes without
-    changing message cardinality. Tool-use and tool-result counts must remain
-    exactly equal because tool-bearing units are protected from compaction. *)
+    persisted JSON restoration. Every dropped source message disappears.
+    Summarizing one atomic source unit removes zero or more of its source
+    messages and emits exactly one Assistant summary, so the total removed
+    message count is exact:
+    [after = before - dropped - summarized_messages + summarized_units]. A
+    reasoning-normalizing Keep is recorded separately and may strictly reduce
+    checkpoint bytes without changing message cardinality. Tool-use and
+    tool-result removals are derived from the original whole-unit dispositions;
+    actual after counts must equal those exact removals, and the two removal
+    counts must match. *)
 
 val to_json : t -> Yojson.Safe.t
 (** Self-contained structural and exact-execution evidence projection. *)
@@ -116,5 +139,6 @@ val of_json : Yojson.Safe.t -> (t, decode_error) result
     object. Unknown, duplicate, missing, malformed, blank, mismatched, or
     objectively impossible evidence is rejected explicitly; no external
     provenance labels or historical shape are inferred or migrated.
-    [Checkpoint_bytes] must strictly reduce, message accounting must be exact,
-    and ToolUse/ToolResult counts must remain equal. *)
+    [Checkpoint_bytes] must strictly reduce, message accounting must remain
+    equal the original source-unit disposition, and ToolUse/ToolResult removal
+    counts must remain equal. *)

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -76,7 +76,9 @@ type decode_error =
       { before_message_count : int
       ; after_message_count : int
       ; summarized_message_count : int
+      ; summarized_unit_count : int
       ; dropped_message_count : int
+      ; normalized_message_count : int
       }
   | Invalid_tool_protocol_accounting of
       { before_tool_use_count : int

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -14,15 +14,11 @@ type t =
   ; before_message_count : int
   ; after_message_count : int
   ; summarized_message_count : int
-  ; summarized_unit_count : int
   ; dropped_message_count : int
-  ; normalized_message_count : int
   ; before_tool_use_count : int
   ; after_tool_use_count : int
   ; before_tool_result_count : int
   ; after_tool_result_count : int
-  ; removed_tool_use_count : int
-  ; removed_tool_result_count : int
   }
 
 type field =
@@ -39,15 +35,11 @@ type field =
   | Before_message_count
   | After_message_count
   | Summarized_message_count
-  | Summarized_unit_count
   | Dropped_message_count
-  | Normalized_message_count
   | Before_tool_use_count
   | After_tool_use_count
   | Before_tool_result_count
   | After_tool_result_count
-  | Removed_tool_use_count
-  | Removed_tool_result_count
 
 type field_error =
   | Missing
@@ -76,9 +68,7 @@ type decode_error =
       { before_message_count : int
       ; after_message_count : int
       ; summarized_message_count : int
-      ; summarized_unit_count : int
       ; dropped_message_count : int
-      ; normalized_message_count : int
       }
   | Invalid_tool_protocol_accounting of
       { before_tool_use_count : int
@@ -111,27 +101,19 @@ val create
   -> before_message_count:int
   -> after_message_count:int
   -> summarized_message_count:int
-  -> summarized_unit_count:int
   -> dropped_message_count:int
-  -> normalized_message_count:int
   -> before_tool_use_count:int
   -> after_tool_use_count:int
   -> before_tool_result_count:int
   -> after_tool_result_count:int
-  -> removed_tool_use_count:int
-  -> removed_tool_result_count:int
   -> (t, decode_error) result
 (** Construct evidence through the same closed validation boundary used by
-    persisted JSON restoration. Every dropped source message disappears.
-    Summarizing one atomic source unit removes zero or more of its source
-    messages and emits exactly one Assistant summary, so the total removed
-    message count is exact:
-    [after = before - dropped - summarized_messages + summarized_units]. A
-    reasoning-normalizing Keep is recorded separately and may strictly reduce
-    checkpoint bytes without changing message cardinality. Tool-use and
-    tool-result removals are derived from the original whole-unit dispositions;
-    actual after counts must equal those exact removals, and the two removal
-    counts must match. *)
+    persisted JSON restoration. This persisted shape is an observability
+    projection, not restart execution authority. The pre-persist compaction
+    gate separately compares applied-plan accounting with the serialized
+    checkpoint exactly. Here, message reduction must remain structurally
+    possible for the summarized/dropped source counts, ToolUse/ToolResult counts
+    cannot increase, and their removal counts must match. *)
 
 val to_json : t -> Yojson.Safe.t
 (** Self-contained structural and exact-execution evidence projection. *)
@@ -142,5 +124,5 @@ val of_json : Yojson.Safe.t -> (t, decode_error) result
     objectively impossible evidence is rejected explicitly; no external
     provenance labels or historical shape are inferred or migrated.
     [Checkpoint_bytes] must strictly reduce, message accounting must remain
-    equal the original source-unit disposition, and ToolUse/ToolResult removal
-    counts must remain equal. *)
+    structurally possible, and ToolUse/ToolResult removal counts must remain
+    equal. *)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -569,7 +569,7 @@ type compaction_snapshot_item =
   ; compaction_id : string option
   ; compaction_source : string option
   ; compaction_outcome : string option
-  ; failure_cause : string option
+  ; cause : string option
   ; status : string
   ; links : Yojson.Safe.t
   ; exact_evidence : Yojson.Safe.t option
@@ -600,7 +600,7 @@ let compaction_snapshot_item_json (item : compaction_snapshot_item) =
     ; "compaction_id", Json_util.string_opt_to_json item.compaction_id
     ; "compaction_source", Json_util.string_opt_to_json item.compaction_source
     ; "compaction_outcome", Json_util.string_opt_to_json item.compaction_outcome
-    ; "failure_cause", Json_util.string_opt_to_json item.failure_cause
+    ; "cause", Json_util.string_opt_to_json item.cause
     ; "status", `String item.status
     ; "links", item.links
     ; ( "exact_evidence"
@@ -772,7 +772,7 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
          ; compaction_source =
              compaction_snapshot_clock_string row.decision "compaction_source"
          ; compaction_outcome = None
-         ; failure_cause = None
+         ; cause = None
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
          ; exact_evidence = None
@@ -807,7 +807,7 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
             ; compaction_id = compaction_snapshot_clock_string row.decision "compaction_id"
             ; compaction_source
             ; compaction_outcome = None
-            ; failure_cause = None
+            ; cause = None
             ; status = row.status
             ; links = compaction_snapshot_links_json row.links
             ; exact_evidence = None
@@ -857,7 +857,7 @@ let compaction_context_snapshot_json
              Json_util.get_string
                row.decision
                Keeper_runtime_manifest.compaction_outcome_key
-         ; failure_cause = Json_util.get_string row.decision "error"
+         ; cause = Json_util.get_string row.decision "error"
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
          ; exact_evidence =
@@ -922,7 +922,7 @@ let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
              ; compaction_id = None
              ; compaction_source = None
              ; compaction_outcome = None
-             ; failure_cause = None
+             ; cause = None
              ; status = "latest"
              ; links = `Assoc []
              ; exact_evidence = None

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -568,6 +568,8 @@ type compaction_snapshot_item =
   ; saved_tokens : int option
   ; compaction_id : string option
   ; compaction_source : string option
+  ; compaction_outcome : string option
+  ; failure_cause : string option
   ; status : string
   ; links : Yojson.Safe.t
   ; exact_evidence : Yojson.Safe.t option
@@ -597,6 +599,8 @@ let compaction_snapshot_item_json (item : compaction_snapshot_item) =
     ; "saved_tokens", Json_util.int_opt_to_json item.saved_tokens
     ; "compaction_id", Json_util.string_opt_to_json item.compaction_id
     ; "compaction_source", Json_util.string_opt_to_json item.compaction_source
+    ; "compaction_outcome", Json_util.string_opt_to_json item.compaction_outcome
+    ; "failure_cause", Json_util.string_opt_to_json item.failure_cause
     ; "status", `String item.status
     ; "links", item.links
     ; ( "exact_evidence"
@@ -767,6 +771,8 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
          ; compaction_id = compaction_snapshot_clock_string row.decision "compaction_id"
          ; compaction_source =
              compaction_snapshot_clock_string row.decision "compaction_source"
+         ; compaction_outcome = None
+         ; failure_cause = None
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
          ; exact_evidence = None
@@ -800,6 +806,8 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
             ; saved_tokens = None
             ; compaction_id = compaction_snapshot_clock_string row.decision "compaction_id"
             ; compaction_source
+            ; compaction_outcome = None
+            ; failure_cause = None
             ; status = row.status
             ; links = compaction_snapshot_links_json row.links
             ; exact_evidence = None
@@ -845,6 +853,11 @@ let compaction_context_snapshot_json
          ; saved_tokens = compaction_saved_tokens before_tokens after_tokens
          ; compaction_id = compaction_snapshot_clock_string row.decision "compaction_id"
          ; compaction_source
+         ; compaction_outcome =
+             Json_util.get_string
+               row.decision
+               Keeper_runtime_manifest.compaction_outcome_key
+         ; failure_cause = Json_util.get_string row.decision "error"
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
          ; exact_evidence =
@@ -908,6 +921,8 @@ let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
              ; saved_tokens = compaction_saved_tokens before_tokens after_tokens
              ; compaction_id = None
              ; compaction_source = None
+             ; compaction_outcome = None
+             ; failure_cause = None
              ; status = "latest"
              ; links = `Assoc []
              ; exact_evidence = None

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -13,15 +13,11 @@ let evidence : Keeper_compaction_evidence.t =
     ~before_message_count:12
     ~after_message_count:11
     ~summarized_message_count:6
-    ~summarized_unit_count:6
     ~dropped_message_count:1
-    ~normalized_message_count:0
     ~before_tool_use_count:3
     ~after_tool_use_count:3
     ~before_tool_result_count:3
     ~after_tool_result_count:3
-    ~removed_tool_use_count:0
-    ~removed_tool_result_count:0
   |> Result.get_ok
 ;;
 
@@ -70,15 +66,11 @@ let test_projection_and_roundtrip () =
       ; "before_message_count", `Int 12
       ; "after_message_count", `Int 11
       ; "summarized_message_count", `Int 6
-      ; "summarized_unit_count", `Int 6
       ; "dropped_message_count", `Int 1
-      ; "normalized_message_count", `Int 0
       ; "before_tool_use_count", `Int 3
       ; "after_tool_use_count", `Int 3
       ; "before_tool_result_count", `Int 3
       ; "after_tool_result_count", `Int 3
-      ; "removed_tool_use_count", `Int 0
-      ; "removed_tool_result_count", `Int 0
       ]
   in
   Alcotest.check
@@ -106,7 +98,6 @@ let test_rejections () =
   let impossible_accounting =
     replace "summarized_message_count" (`Int 999) canonical
   in
-  let inexact_after = replace "after_message_count" (`Int 10) canonical in
   List.iter
     (fun (label, expected, json) -> check label expected json)
     [ ( "negative"
@@ -163,9 +154,7 @@ let test_rejections () =
           ; before_tool_result_count = 3
           ; after_tool_result_count = 3
           }
-      , canonical
-        |> replace "after_tool_use_count" (`Int 2)
-        |> replace "removed_tool_use_count" (`Int 1) )
+      , replace "after_tool_use_count" (`Int 2) canonical )
     ; ( "tool result count increase"
       , Invalid_transition (Tool_results, 3, 4)
       , replace "after_tool_result_count" (`Int 4) canonical )
@@ -176,49 +165,15 @@ let test_rejections () =
           ; before_tool_result_count = 3
           ; after_tool_result_count = 2
           }
-      , canonical
-        |> replace "after_tool_result_count" (`Int 2)
-        |> replace "removed_tool_result_count" (`Int 1) )
+      , replace "after_tool_result_count" (`Int 2) canonical )
     ; ( "impossible message accounting"
       , Invalid_message_accounting
           { before_message_count = 12
           ; after_message_count = 11
           ; summarized_message_count = 999
-          ; summarized_unit_count = 6
           ; dropped_message_count = 1
-          ; normalized_message_count = 0
           }
       , impossible_accounting )
-    ; ( "inexact after count"
-      , Invalid_message_accounting
-          { before_message_count = 12
-          ; after_message_count = 10
-          ; summarized_message_count = 6
-          ; summarized_unit_count = 6
-          ; dropped_message_count = 1
-          ; normalized_message_count = 0
-          }
-      , inexact_after )
-    ; ( "summarized units cannot disappear"
-      , Invalid_message_accounting
-          { before_message_count = 12
-          ; after_message_count = 11
-          ; summarized_message_count = 6
-          ; summarized_unit_count = 0
-          ; dropped_message_count = 1
-          ; normalized_message_count = 0
-          }
-      , replace "summarized_unit_count" (`Int 0) canonical )
-    ; ( "normalization count stays within untouched sources"
-      , Invalid_message_accounting
-          { before_message_count = 12
-          ; after_message_count = 11
-          ; summarized_message_count = 6
-          ; summarized_unit_count = 6
-          ; dropped_message_count = 1
-          ; normalized_message_count = 6
-          }
-      , replace "normalized_message_count" (`Int 6) canonical )
     ]
 ;;
 
@@ -227,12 +182,9 @@ let test_atomic_cycle_and_normalization_accounting () =
         ~before_message_count
         ~after_message_count
         ~summarized_message_count
-        ~summarized_unit_count
         ~dropped_message_count
-        ~normalized_message_count
         ~before_tool_count
         ~after_tool_count
-        ~removed_tool_count
     =
     Keeper_compaction_evidence.create
       ~slot_id:"compaction-slot"
@@ -248,15 +200,11 @@ let test_atomic_cycle_and_normalization_accounting () =
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
-      ~summarized_unit_count
       ~dropped_message_count
-      ~normalized_message_count
       ~before_tool_use_count:before_tool_count
       ~after_tool_use_count:after_tool_count
       ~before_tool_result_count:before_tool_count
       ~after_tool_result_count:after_tool_count
-      ~removed_tool_use_count:removed_tool_count
-      ~removed_tool_result_count:removed_tool_count
   in
   List.iter
     (fun (label, result) ->
@@ -272,34 +220,25 @@ let test_atomic_cycle_and_normalization_accounting () =
           ~before_message_count:12
           ~after_message_count:12
           ~summarized_message_count:0
-          ~summarized_unit_count:0
           ~dropped_message_count:0
-          ~normalized_message_count:1
           ~before_tool_count:3
-          ~after_tool_count:3
-          ~removed_tool_count:0 )
+          ~after_tool_count:3 )
     ; ( "atomic cycle summary"
       , create
           ~before_message_count:12
           ~after_message_count:10
           ~summarized_message_count:3
-          ~summarized_unit_count:1
           ~dropped_message_count:0
-          ~normalized_message_count:0
           ~before_tool_count:3
-          ~after_tool_count:2
-          ~removed_tool_count:1 )
+          ~after_tool_count:2 )
     ; ( "atomic cycle drop"
       , create
           ~before_message_count:12
           ~after_message_count:9
           ~summarized_message_count:0
-          ~summarized_unit_count:0
           ~dropped_message_count:3
-          ~normalized_message_count:0
           ~before_tool_count:3
-          ~after_tool_count:2
-          ~removed_tool_count:1 )
+          ~after_tool_count:2 )
     ]
 ;;
 

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -184,7 +184,9 @@ let test_rejections () =
           { before_message_count = 12
           ; after_message_count = 11
           ; summarized_message_count = 999
+          ; summarized_unit_count = 6
           ; dropped_message_count = 1
+          ; normalized_message_count = 0
           }
       , impossible_accounting )
     ; ( "inexact after count"
@@ -192,9 +194,31 @@ let test_rejections () =
           { before_message_count = 12
           ; after_message_count = 10
           ; summarized_message_count = 6
+          ; summarized_unit_count = 6
           ; dropped_message_count = 1
+          ; normalized_message_count = 0
           }
       , inexact_after )
+    ; ( "summarized units cannot disappear"
+      , Invalid_message_accounting
+          { before_message_count = 12
+          ; after_message_count = 11
+          ; summarized_message_count = 6
+          ; summarized_unit_count = 0
+          ; dropped_message_count = 1
+          ; normalized_message_count = 0
+          }
+      , replace "summarized_unit_count" (`Int 0) canonical )
+    ; ( "normalization count stays within untouched sources"
+      , Invalid_message_accounting
+          { before_message_count = 12
+          ; after_message_count = 11
+          ; summarized_message_count = 6
+          ; summarized_unit_count = 6
+          ; dropped_message_count = 1
+          ; normalized_message_count = 6
+          }
+      , replace "normalized_message_count" (`Int 6) canonical )
     ]
 ;;
 

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -13,11 +13,15 @@ let evidence : Keeper_compaction_evidence.t =
     ~before_message_count:12
     ~after_message_count:11
     ~summarized_message_count:6
+    ~summarized_unit_count:6
     ~dropped_message_count:1
+    ~normalized_message_count:0
     ~before_tool_use_count:3
     ~after_tool_use_count:3
     ~before_tool_result_count:3
     ~after_tool_result_count:3
+    ~removed_tool_use_count:0
+    ~removed_tool_result_count:0
   |> Result.get_ok
 ;;
 
@@ -66,11 +70,15 @@ let test_projection_and_roundtrip () =
       ; "before_message_count", `Int 12
       ; "after_message_count", `Int 11
       ; "summarized_message_count", `Int 6
+      ; "summarized_unit_count", `Int 6
       ; "dropped_message_count", `Int 1
+      ; "normalized_message_count", `Int 0
       ; "before_tool_use_count", `Int 3
       ; "after_tool_use_count", `Int 3
       ; "before_tool_result_count", `Int 3
       ; "after_tool_result_count", `Int 3
+      ; "removed_tool_use_count", `Int 0
+      ; "removed_tool_result_count", `Int 0
       ]
   in
   Alcotest.check
@@ -92,11 +100,6 @@ let test_rejections () =
     | Error actual -> Alcotest.(check bool) label true (actual = expected)
     | Ok _ -> Alcotest.failf "%s: invalid evidence decoded" label
   in
-  let no_messages =
-    canonical
-    |> replace "summarized_message_count" (`Int 0)
-    |> replace "dropped_message_count" (`Int 0)
-  in
   let duplicate =
     `Assoc (("after_message_count", `Int 11) :: fields canonical)
   in
@@ -112,7 +115,6 @@ let test_rejections () =
     ; ( "not reduced"
       , Invalid_transition (Checkpoint_bytes, 4096, 4096)
       , replace "after_checkpoint_bytes" (`Int 4096) canonical )
-    ; "no messages", No_messages_compacted, no_messages
     ; ( "missing exact field"
       , Invalid_field (Target_identity_fingerprint, Missing)
       , remove "target_identity_fingerprint" canonical )
@@ -154,15 +156,29 @@ let test_rejections () =
     ; ( "tool use count increase"
       , Invalid_transition (Tool_uses, 3, 4)
       , replace "after_tool_use_count" (`Int 4) canonical )
-    ; ( "tool use count decrease"
-      , Invalid_transition (Tool_uses, 3, 2)
-      , replace "after_tool_use_count" (`Int 2) canonical )
+    ; ( "unpaired tool use decrease"
+      , Invalid_tool_protocol_accounting
+          { before_tool_use_count = 3
+          ; after_tool_use_count = 2
+          ; before_tool_result_count = 3
+          ; after_tool_result_count = 3
+          }
+      , canonical
+        |> replace "after_tool_use_count" (`Int 2)
+        |> replace "removed_tool_use_count" (`Int 1) )
     ; ( "tool result count increase"
       , Invalid_transition (Tool_results, 3, 4)
       , replace "after_tool_result_count" (`Int 4) canonical )
-    ; ( "tool result count decrease"
-      , Invalid_transition (Tool_results, 3, 2)
-      , replace "after_tool_result_count" (`Int 2) canonical )
+    ; ( "unpaired tool result decrease"
+      , Invalid_tool_protocol_accounting
+          { before_tool_use_count = 3
+          ; after_tool_use_count = 3
+          ; before_tool_result_count = 3
+          ; after_tool_result_count = 2
+          }
+      , canonical
+        |> replace "after_tool_result_count" (`Int 2)
+        |> replace "removed_tool_result_count" (`Int 1) )
     ; ( "impossible message accounting"
       , Invalid_message_accounting
           { before_message_count = 12
@@ -179,6 +195,87 @@ let test_rejections () =
           ; dropped_message_count = 1
           }
       , inexact_after )
+    ]
+;;
+
+let test_atomic_cycle_and_normalization_accounting () =
+  let create
+        ~before_message_count
+        ~after_message_count
+        ~summarized_message_count
+        ~summarized_unit_count
+        ~dropped_message_count
+        ~normalized_message_count
+        ~before_tool_count
+        ~after_tool_count
+        ~removed_tool_count
+    =
+    Keeper_compaction_evidence.create
+      ~slot_id:"compaction-slot"
+      ~call_id:"call-atomic"
+      ~target_identity_fingerprint:"target-identity"
+      ~catalog_generation_fingerprint:"catalog-generation"
+      ~catalog_evidence_sha256:"catalog-evidence"
+      ~plan_fingerprint:"plan-fingerprint"
+      ~receipt_plan_fingerprint:"plan-fingerprint"
+      ~receipt_request_body_sha256:"request-body"
+      ~before_checkpoint_bytes:4096
+      ~after_checkpoint_bytes:1024
+      ~before_message_count
+      ~after_message_count
+      ~summarized_message_count
+      ~summarized_unit_count
+      ~dropped_message_count
+      ~normalized_message_count
+      ~before_tool_use_count:before_tool_count
+      ~after_tool_use_count:after_tool_count
+      ~before_tool_result_count:before_tool_count
+      ~after_tool_result_count:after_tool_count
+      ~removed_tool_use_count:removed_tool_count
+      ~removed_tool_result_count:removed_tool_count
+  in
+  List.iter
+    (fun (label, result) ->
+      match result with
+      | Ok _ -> ()
+      | Error error ->
+        Alcotest.failf
+          "%s evidence rejected: %s"
+          label
+          (Keeper_compaction_evidence.decode_error_to_string error))
+    [ ( "reasoning normalization"
+      , create
+          ~before_message_count:12
+          ~after_message_count:12
+          ~summarized_message_count:0
+          ~summarized_unit_count:0
+          ~dropped_message_count:0
+          ~normalized_message_count:1
+          ~before_tool_count:3
+          ~after_tool_count:3
+          ~removed_tool_count:0 )
+    ; ( "atomic cycle summary"
+      , create
+          ~before_message_count:12
+          ~after_message_count:10
+          ~summarized_message_count:3
+          ~summarized_unit_count:1
+          ~dropped_message_count:0
+          ~normalized_message_count:0
+          ~before_tool_count:3
+          ~after_tool_count:2
+          ~removed_tool_count:1 )
+    ; ( "atomic cycle drop"
+      , create
+          ~before_message_count:12
+          ~after_message_count:9
+          ~summarized_message_count:0
+          ~summarized_unit_count:0
+          ~dropped_message_count:3
+          ~normalized_message_count:0
+          ~before_tool_count:3
+          ~after_tool_count:2
+          ~removed_tool_count:1 )
     ]
 ;;
 
@@ -212,6 +309,10 @@ let () =
             `Quick
             test_projection_and_roundtrip
         ; Alcotest.test_case "closed rejections" `Quick test_rejections
+        ; Alcotest.test_case
+            "atomic cycle and normalization accounting"
+            `Quick
+            test_atomic_cycle_and_normalization_accounting
         ; Alcotest.test_case
             "legacy pair-repair field rejected"
             `Quick

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -53,7 +53,9 @@ let closed_cycle id =
 
 let provider_cycle id =
   U.Closed_tool_cycle
-    [ message T.Assistant
+    [ message
+        ~metadata:[ "SECRET_CYCLE_METADATA", `String ("metadata:" ^ id) ]
+        T.Assistant
         [ T.Thinking { content = "private-call:" ^ id; signature = Some "signed" }
         ; tool_use id
         ]
@@ -292,6 +294,8 @@ let test_configured_runtime_boundary_preserves_cycle_semantics () =
     ; "SECRET_THINKING"
     ; "private-call:SECRET_TOOL"
     ; "private-final:SECRET_TOOL"
+    ; "SECRET_CYCLE_METADATA"
+    ; "metadata:SECRET_TOOL"
     ; "SECRET_METADATA"
     ]
 

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -51,6 +51,34 @@ let closed_cycle id =
     ; message T.Tool [ tool_result id ]
     ]
 
+let provider_cycle id =
+  U.Closed_tool_cycle
+    [ message T.Assistant
+        [ T.Thinking { content = "private-call:" ^ id; signature = Some "signed" }
+        ; tool_use id
+        ]
+    ; message T.Tool
+        [ T.ToolResult
+            { tool_use_id = id
+            ; content = "text-result:" ^ id
+            ; outcome = T.Tool_succeeded
+            ; json = Some (`Assoc [ "structured", `String ("json-result:" ^ id) ])
+            ; content_blocks = Some [ T.Text ("block-result:" ^ id) ]
+            }
+        ]
+    ; message T.Assistant
+        [ T.ReasoningDetails { reasoning_content = Some ("private-final:" ^ id); details = [] }
+        ; T.Text ("final:" ^ id)
+        ]
+    ]
+
+let parallel_cycle left right =
+  U.Closed_tool_cycle
+    [ message T.Assistant [ tool_use left; tool_use right ]
+    ; message T.Tool [ tool_result right ]
+    ; message T.Tool [ tool_result left ]
+    ]
+
 let eligibility_units =
   [ ordinary (text T.System "system")
   ; ordinary (text T.User "user")
@@ -64,16 +92,54 @@ let eligibility_units =
   ; closed_cycle "closed"
   ]
 
-let test_only_plain_assistant_text_is_eligible () =
+let test_reasoning_text_and_closed_cycles_are_eligible () =
   Alcotest.(check bool) "mixed source has eligible text" true
     (C.has_eligible_units eligibility_units);
   List.iteri
     (fun index unit_ ->
       Alcotest.(check bool)
         (Printf.sprintf "unit %d eligibility" index)
-        (index = 3)
+        (index = 3 || index = 5 || index = 9)
         (C.has_eligible_units [ unit_ ]))
     eligibility_units
+
+let test_thinking_only_and_media_are_ineligible () =
+  let thinking_only =
+    ordinary
+      (message T.Assistant
+         [ T.Thinking { content = "private"; signature = None }
+         ; T.RedactedThinking "opaque"
+         ])
+  in
+  let media_cycle =
+    U.Closed_tool_cycle
+      [ message T.Assistant [ tool_use "media" ]
+      ; message T.Tool
+          [ T.ToolResult
+              { tool_use_id = "media"
+              ; content = "binary"
+              ; outcome = T.Tool_succeeded
+              ; json = None
+              ; content_blocks =
+                  Some
+                    [ T.Image
+                        { media_type = "image/png"
+                        ; data = "SECRET_BINARY"
+                        ; source_type = T.Base64
+                        }
+                    ]
+              }
+          ]
+      ]
+  in
+  Alcotest.(check bool) "thinking-only source stays protected" false
+    (C.has_eligible_units [ thinking_only ]);
+  Alcotest.(check bool) "media cycle fails closed as ineligible" false
+    (C.has_eligible_units [ media_cycle ]);
+  let request = C.For_testing.messages_for_plan ~units:[ media_cycle ] in
+  let wire = request |> List.map T.text_of_message |> String.concat "\n" in
+  Alcotest.(check bool) "binary media is never truncated into request" false
+    (Astring.String.is_infix ~affix:"SECRET_BINARY" wire)
 
 let validation_units =
   [ ordinary (text T.System "protected-system")
@@ -87,7 +153,7 @@ let test_valid_source_decisions_accepted () =
   let result =
     plan_of_json
       ~units:validation_units
-      (plan_json [ summarize 1 "first summary"; keep 4 ])
+      (plan_json [ summarize 1 "first summary"; keep 2; keep 4 ])
   in
   match result with
   | Error detail -> Alcotest.failf "valid source-bound plan rejected: %s" detail
@@ -99,34 +165,36 @@ let test_valid_source_decisions_accepted () =
 let test_all_kept_rejected () =
   Alcotest.(check bool) "all-kept is not compaction" true
     (is_error
-       (plan_of_json ~units:validation_units (plan_json [ keep 1; keep 4 ])))
+       (plan_of_json ~units:validation_units (plan_json [ keep 1; keep 2; keep 4 ])))
 
 let test_drop_with_kept_accepted () =
   Alcotest.(check bool) "drop plus keep is a valid change" true
     (is_ok
-       (plan_of_json ~units:validation_units (plan_json [ drop 1; keep 4 ])))
+       (plan_of_json ~units:validation_units (plan_json [ drop 1; keep 2; keep 4 ])))
 
-let test_protected_index_rejected () =
+let test_noneligible_index_rejected () =
   Alcotest.(check bool) "provider cannot target protected source index" true
     (is_error
-       (plan_of_json ~units:validation_units (plan_json [ summarize 0 "x"; keep 4 ])))
+       (plan_of_json
+          ~units:validation_units
+          (plan_json [ summarize 0 "x"; keep 2; keep 4 ])))
 
 let test_missing_eligible_index_rejected () =
   Alcotest.(check bool) "every eligible source needs a decision" true
     (is_error
-       (plan_of_json ~units:validation_units (plan_json [ summarize 1 "x" ])))
+       (plan_of_json ~units:validation_units (plan_json [ summarize 1 "x"; keep 2 ])))
 
 let test_duplicate_index_rejected () =
   Alcotest.(check bool) "duplicate source decision rejected" true
     (is_error
        (plan_of_json
           ~units:validation_units
-          (plan_json [ summarize 1 "x"; drop 1; keep 4 ])))
+          (plan_json [ summarize 1 "x"; drop 1; keep 2; keep 4 ])))
 
 let test_all_dropped_rejected () =
   Alcotest.(check bool) "planner cannot remove every eligible unit" true
     (is_error
-       (plan_of_json ~units:validation_units (plan_json [ drop 1; drop 4 ])))
+       (plan_of_json ~units:validation_units (plan_json [ drop 1; drop 2; drop 4 ])))
 
 let test_action_summary_contract_rejected () =
   let invalid =
@@ -143,19 +211,19 @@ let test_action_summary_contract_rejected () =
         (is_error
            (plan_of_json
               ~units:validation_units
-              (plan_json [ invalid_decision; keep 4 ]))))
+              (plan_json [ invalid_decision; keep 2; keep 4 ]))))
     invalid
 
 let test_unknown_and_duplicate_fields_rejected () =
   let unknown_top =
     `Assoc
-      [ S.compaction_plan_field_decisions, `List [ summarize 1 "x"; keep 4 ]
+      [ S.compaction_plan_field_decisions, `List [ summarize 1 "x"; keep 2; keep 4 ]
       ; "unexpected", `Null
       ]
   in
   let duplicate_top =
     `Assoc
-      [ S.compaction_plan_field_decisions, `List [ summarize 1 "x"; keep 4 ]
+      [ S.compaction_plan_field_decisions, `List [ summarize 1 "x"; keep 2; keep 4 ]
       ; S.compaction_plan_field_decisions, `List []
       ]
   in
@@ -182,15 +250,15 @@ let test_unknown_and_duplicate_fields_rejected () =
     [ `Assoc []
     ; unknown_top
     ; duplicate_top
-    ; plan_json [ unknown_decision; keep 4 ]
-    ; plan_json [ duplicate_decision; keep 4 ]
+    ; plan_json [ unknown_decision; keep 2; keep 4 ]
+    ; plan_json [ duplicate_decision; keep 2; keep 4 ]
     ]
 
-let test_request_excludes_protected_content () =
+let test_configured_runtime_boundary_preserves_cycle_semantics () =
   let units =
     [ ordinary (text T.System "SECRET_SYSTEM")
     ; ordinary (text T.User "SECRET_USER")
-    ; closed_cycle "SECRET_TOOL"
+    ; provider_cycle "SECRET_TOOL"
     ; ordinary
         (message T.Assistant
            [ T.Text "SECRET_MIXED"; T.Thinking { content = "SECRET_THINKING"; signature = None } ])
@@ -204,16 +272,109 @@ let test_request_excludes_protected_content () =
   Alcotest.(check bool) "eligible assistant text crosses boundary" true
     (Astring.String.is_infix ~affix:"VISIBLE_ASSISTANT" wire);
   List.iter
+    (fun semantic ->
+      Alcotest.(check bool) (semantic ^ " crosses configured compaction boundary") true
+        (Astring.String.is_infix ~affix:semantic wire))
+    [ "SECRET_TOOL"
+    ; "test_tool"
+    ; "text-result:SECRET_TOOL"
+    ; "json-result:SECRET_TOOL"
+    ; "block-result:SECRET_TOOL"
+    ; "final:SECRET_TOOL"
+    ; "SECRET_MIXED"
+    ];
+  List.iter
     (fun secret ->
       Alcotest.(check bool) (secret ^ " remains private") false
         (Astring.String.is_infix ~affix:secret wire))
     [ "SECRET_SYSTEM"
     ; "SECRET_USER"
-    ; "SECRET_TOOL"
-    ; "SECRET_MIXED"
     ; "SECRET_THINKING"
+    ; "private-call:SECRET_TOOL"
+    ; "private-final:SECRET_TOOL"
     ; "SECRET_METADATA"
     ]
+
+let test_all_keep_reasoning_normalization_is_material () =
+  let mixed =
+    message T.Assistant
+      [ T.Thinking { content = "private"; signature = None }
+      ; T.Text "visible"
+      ; T.RedactedThinking "opaque"
+      ; T.Text "ordered"
+      ]
+  in
+  match plan_of_json ~units:[ ordinary mixed ] (plan_json [ keep 0 ]) with
+  | Error detail -> Alcotest.failf "normalizing keep rejected: %s" detail
+  | Ok plan ->
+    Alcotest.(check bool) "reasoning strip counts as material change" true
+      (C.has_changes plan);
+    Alcotest.(check bool) "keep emits ordered Text blocks only" true
+      (C.apply plan
+       = [ { mixed with content = [ T.Text "visible"; T.Text "ordered" ] } ])
+
+let test_closed_cycle_actions_are_atomic () =
+  let cycle = provider_cycle "atomic" in
+  let messages =
+    match cycle with
+    | U.Closed_tool_cycle messages -> messages
+    | U.Ordinary_message _ -> Alcotest.fail "expected closed cycle"
+  in
+  let apply decisions =
+    match plan_of_json ~units:[ cycle; ordinary (text T.Assistant "anchor") ] decisions with
+    | Error detail -> Alcotest.failf "cycle plan rejected: %s" detail
+    | Ok plan -> C.apply plan
+  in
+  Alcotest.(check bool) "keep preserves the complete original cycle" true
+    (apply (plan_json [ keep 0; summarize 1 "anchor summary" ])
+     = messages @ [ text T.Assistant "anchor summary" ]);
+  Alcotest.(check bool) "drop removes the complete cycle" true
+    (apply (plan_json [ drop 0; keep 1 ]) = [ text T.Assistant "anchor" ]);
+  Alcotest.(check bool) "summarize replaces cycle with one fresh Assistant text" true
+    (apply (plan_json [ summarize 0 "cycle summary"; keep 1 ])
+     = [ text T.Assistant "cycle summary"; text T.Assistant "anchor" ])
+
+let test_parallel_cycle_is_one_planner_unit () =
+  let cycle = parallel_cycle "left" "right" in
+  let request = C.For_testing.messages_for_plan ~units:[ cycle ] in
+  let wire = request |> List.map T.text_of_message |> String.concat "\n" in
+  Alcotest.(check bool) "parallel closed cycle is eligible" true
+    (C.has_eligible_units [ cycle ]);
+  List.iter
+    (fun semantic ->
+      Alcotest.(check bool) (semantic ^ " is preserved") true
+        (Astring.String.is_infix ~affix:semantic wire))
+    [ "left"; "right" ];
+  Alcotest.(check bool) "only the whole-cycle index is accepted" true
+    (is_ok
+       (plan_of_json
+          ~units:[ cycle; ordinary (text T.Assistant "anchor") ]
+          (plan_json [ summarize 0 "parallel summary"; keep 1 ])));
+  Alcotest.(check bool) "an inner message index is not addressable" true
+    (is_error
+       (plan_of_json
+          ~units:[ cycle; ordinary (text T.Assistant "anchor") ]
+          (plan_json [ keep 0; summarize 2 "not an index" ])))
+
+let test_open_cycle_remains_protected () =
+  let open_messages =
+    [ message T.Assistant
+        [ T.Thinking { content = "OPEN_PRIVATE"; signature = None }
+        ; tool_use "OPEN_TOOL"
+        ]
+    ]
+  in
+  match U.partition open_messages with
+  | Error _ -> Alcotest.fail "valid open cycle was structurally rejected"
+  | Ok partition ->
+    Alcotest.(check bool) "open cycle has no closed eligible unit" false
+      (C.has_eligible_units partition.closed_prefix);
+    let request = C.For_testing.messages_for_plan ~units:partition.closed_prefix in
+    let wire = request |> List.map T.text_of_message |> String.concat "\n" in
+    Alcotest.(check bool) "open tool request never crosses boundary" false
+      (Astring.String.is_infix ~affix:"OPEN_TOOL" wire);
+    Alcotest.(check bool) "open cycle remains exact protected suffix" true
+      (partition.protected_suffix = open_messages)
 
 let test_apply_preserves_protected_units_and_source_order () =
   let system = text T.System "system" in
@@ -241,7 +402,7 @@ let test_apply_preserves_protected_units_and_source_order () =
   match
     plan_of_json
       ~units
-      (plan_json [ summarize 1 "first summary"; summarize 5 "second summary" ])
+      (plan_json [ summarize 1 "first summary"; keep 2; summarize 5 "second summary" ])
   with
   | Error detail -> Alcotest.failf "expected valid plan: %s" detail
   | Ok plan ->
@@ -262,10 +423,16 @@ let test_apply_preserves_protected_units_and_source_order () =
 let () =
   Alcotest.run "compaction_llm_summarizer"
     [ ( "eligibility"
-      , [ Alcotest.test_case "plain Assistant text only" `Quick
-            test_only_plain_assistant_text_is_eligible
-        ; Alcotest.test_case "protected content never reaches exact boundary" `Quick
-            test_request_excludes_protected_content
+      , [ Alcotest.test_case "reasoning text and closed cycles" `Quick
+            test_reasoning_text_and_closed_cycles_are_eligible
+        ; Alcotest.test_case "thinking-only and media stay ineligible" `Quick
+            test_thinking_only_and_media_are_ineligible
+        ; Alcotest.test_case "configured runtime disclosure boundary" `Quick
+            test_configured_runtime_boundary_preserves_cycle_semantics
+        ; Alcotest.test_case "parallel cycle is one planner unit" `Quick
+            test_parallel_cycle_is_one_planner_unit
+        ; Alcotest.test_case "open cycle remains protected" `Quick
+            test_open_cycle_remains_protected
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid source decisions accepted" `Quick
@@ -273,8 +440,8 @@ let () =
         ; Alcotest.test_case "all kept rejected" `Quick test_all_kept_rejected
         ; Alcotest.test_case "drop with kept accepted" `Quick
             test_drop_with_kept_accepted
-        ; Alcotest.test_case "protected index rejected" `Quick
-            test_protected_index_rejected
+        ; Alcotest.test_case "noneligible index rejected" `Quick
+            test_noneligible_index_rejected
         ; Alcotest.test_case "missing eligible index rejected" `Quick
             test_missing_eligible_index_rejected
         ; Alcotest.test_case "duplicate index rejected" `Quick
@@ -286,7 +453,11 @@ let () =
             test_unknown_and_duplicate_fields_rejected
         ] )
     ; ( "apply"
-      , [ Alcotest.test_case "protected units and source order stay exact" `Quick
+      , [ Alcotest.test_case "reasoning normalization is material" `Quick
+            test_all_keep_reasoning_normalization_is_material
+        ; Alcotest.test_case "closed cycle actions are atomic" `Quick
+            test_closed_cycle_actions_are_atomic
+        ; Alcotest.test_case "protected units and source order stay exact" `Quick
             test_apply_preserves_protected_units_and_source_order
         ] )
     ]

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3890,6 +3890,28 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
         ~compaction_source:"provider_overflow"
         ()
     in
+    let exact_evidence =
+      `Assoc
+        [ "slot_id", `String "compaction-slot"
+        ; "call_id", `String "call-dashboard"
+        ; "target_identity_fingerprint", `String "target-identity"
+        ; "catalog_generation_fingerprint", `String "catalog-generation"
+        ; "catalog_evidence_sha256", `String "catalog-evidence"
+        ; "plan_fingerprint", `String "plan-fingerprint"
+        ; "receipt_plan_fingerprint", `String "plan-fingerprint"
+        ; "receipt_request_body_sha256", `String "request-body"
+        ; "before_checkpoint_bytes", `Int 4096
+        ; "after_checkpoint_bytes", `Int 1024
+        ; "before_message_count", `Int 8
+        ; "after_message_count", `Int 3
+        ; "summarized_message_count", `Int 4
+        ; "dropped_message_count", `Int 1
+        ; "before_tool_use_count", `Int 2
+        ; "after_tool_use_count", `Int 1
+        ; "before_tool_result_count", `Int 2
+        ; "after_tool_result_count", `Int 1
+        ]
+    in
     let decision =
       Runtime_manifest.with_clock_refs
         ~clock_refs
@@ -3899,19 +3921,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
               [ "trigger", `String "provider_overflow"
               ; "before_tokens", `Int 210_000
               ; "after_tokens", `Int 120_000
-              ; ( "exact_evidence"
-                , `Assoc
-                    [ "before_checkpoint_bytes", `Int 4096
-                    ; "after_checkpoint_bytes", `Int 1024
-                    ; "before_message_count", `Int 8
-                    ; "after_message_count", `Int 3
-                    ; "summarized_message_count", `Int 4
-                    ; "dropped_message_count", `Int 1
-                    ; "before_tool_use_count", `Int 2
-                    ; "after_tool_use_count", `Int 1
-                    ; "before_tool_result_count", `Int 2
-                    ; "after_tool_result_count", `Int 1
-                    ] )
+              ; "exact_evidence", exact_evidence
               ]))
     in
     let row =
@@ -3995,6 +4005,11 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
     Alcotest.(check int) "before" 210_000 (json_int_field "item" item "before_tokens");
     Alcotest.(check int) "after" 120_000 (json_int_field "item" item "after_tokens");
     Alcotest.(check int) "saved" 90_000 (json_int_field "item" item "saved_tokens");
+    Alcotest.check
+      (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+      "canonical exact evidence"
+      exact_evidence
+      (List.assoc "exact_evidence" item);
     Alcotest.(check string)
       "compaction id"
       "cmp-42"

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3976,6 +3976,39 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       ~status:"lifecycle_cleanup_failed"
       ~compaction_outcome:Runtime_manifest.Lifecycle_cleanup_failed_without_checkpoint
       ~error:"lifecycle cleanup failed";
+    let append_committed_with_cause ~ts ~status ~error =
+      Runtime_manifest.make
+        ~ts
+        ~keeper_name:keeper_id
+        ~trace_id
+        ~keeper_turn_id:12
+        ~event:Runtime_manifest.Context_compacted
+        ~runtime_id:"oas-seoul-1"
+        ~status
+        ~decision:
+          (Runtime_manifest.with_clock_refs
+             ~clock_refs
+             (Runtime_manifest.with_compaction_outcome
+                ~compaction_outcome:Runtime_manifest.Checkpoint_committed
+                (Runtime_manifest.with_payload_role
+                   ~payload_role:Runtime_manifest.Checkpoint
+                   (`Assoc
+                      [ "trigger", `String "provider_overflow"
+                      ; "error", `String error
+                      ; "exact_evidence", exact_evidence
+                      ]))))
+        ~checkpoint_path:"/checkpoint/trace.json"
+        ()
+      |> append
+    in
+    append_committed_with_cause
+      ~ts:"2026-06-26T03:03:30Z"
+      ~status:"retryable_failure"
+      ~error:"compaction completion dispatch failed";
+    append_committed_with_cause
+      ~ts:"2026-06-26T03:03:40Z"
+      ~status:"lifecycle_cleanup_failed"
+      ~error:"lifecycle cleanup failed after checkpoint";
     let receipt event decision =
       Runtime_manifest.make
         ~ts:"2026-06-26T03:04:00Z"
@@ -4003,7 +4036,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "schema"
       "keeper.compaction_snapshots.v1"
       (json_string_field "compaction_snapshots" top "schema");
-    Alcotest.(check int) "count" 3 (json_int_field "compaction_snapshots" top "count");
+    Alcotest.(check int) "count" 5 (json_int_field "compaction_snapshots" top "count");
     Alcotest.(check int)
       "read errors"
       0
@@ -4032,7 +4065,24 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       | Some item -> item
       | None -> Alcotest.failf "missing compaction outcome %s" expected
     in
-    let item = find_outcome "checkpoint_committed" in
+    let find_status_outcome expected_status expected_outcome =
+      match
+        List.find_opt
+          (fun item ->
+             String.equal expected_status (json_string_field "item" item "status")
+             && String.equal
+                  expected_outcome
+                  (json_string_field "item" item "compaction_outcome"))
+          items
+      with
+      | Some item -> item
+      | None ->
+        Alcotest.failf
+          "missing compaction status/outcome %s/%s"
+          expected_status
+          expected_outcome
+    in
+    let item = find_status_outcome "observed" "checkpoint_committed" in
     Alcotest.(check string)
       "source"
       "runtime_manifest"
@@ -4063,7 +4113,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
          Alcotest.(check string)
            (outcome ^ " failure cause")
            cause
-           (json_string_field "item" failed "failure_cause");
+           (json_string_field "item" failed "cause");
          Alcotest.check
            (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
            (outcome ^ " has no exact evidence")
@@ -4072,6 +4122,26 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       [ "retry_without_checkpoint", "compaction dispatch failed"
       ; ( "lifecycle_cleanup_failed_without_checkpoint"
         , "lifecycle cleanup failed" )
+      ];
+    List.iter
+      (fun (status, cause) ->
+         let committed = find_status_outcome status "checkpoint_committed" in
+         Alcotest.(check string)
+           (status ^ " cause")
+           cause
+           (json_string_field "item" committed "cause");
+         Alcotest.(check string)
+           (status ^ " outcome")
+           "checkpoint_committed"
+           (json_string_field "item" committed "compaction_outcome");
+         Alcotest.check
+           (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+           (status ^ " retains exact evidence")
+           exact_evidence
+           (List.assoc "exact_evidence" committed))
+      [ "retryable_failure", "compaction completion dispatch failed"
+      ; ( "lifecycle_cleanup_failed"
+        , "lifecycle cleanup failed after checkpoint" )
       ];
     Alcotest.(check string)
       "compaction id"

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3915,14 +3915,16 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
     let decision =
       Runtime_manifest.with_clock_refs
         ~clock_refs
-        (Runtime_manifest.with_payload_role
-           ~payload_role:Runtime_manifest.Checkpoint
-           (`Assoc
-              [ "trigger", `String "provider_overflow"
-              ; "before_tokens", `Int 210_000
-              ; "after_tokens", `Int 120_000
-              ; "exact_evidence", exact_evidence
-              ]))
+        (Runtime_manifest.with_compaction_outcome
+           ~compaction_outcome:Runtime_manifest.Checkpoint_committed
+           (Runtime_manifest.with_payload_role
+              ~payload_role:Runtime_manifest.Checkpoint
+              (`Assoc
+                 [ "trigger", `String "provider_overflow"
+                 ; "before_tokens", `Int 210_000
+                 ; "after_tokens", `Int 120_000
+                 ; "exact_evidence", exact_evidence
+                 ])))
     in
     let row =
       Runtime_manifest.make
@@ -3941,6 +3943,39 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       Result.get_ok (Runtime_manifest.append config row)
     in
     append row;
+    let append_failure ~ts ~status ~compaction_outcome ~error =
+      Runtime_manifest.make
+        ~ts
+        ~keeper_name:keeper_id
+        ~trace_id
+        ~keeper_turn_id:12
+        ~event:Runtime_manifest.Context_compacted
+        ~runtime_id:"oas-seoul-1"
+        ~status
+        ~decision:
+          (Runtime_manifest.with_clock_refs
+             ~clock_refs
+             (Runtime_manifest.with_compaction_outcome
+                ~compaction_outcome
+                (Runtime_manifest.with_payload_role
+                   ~payload_role:Runtime_manifest.Checkpoint
+                   (`Assoc
+                      [ "trigger", `String "provider_overflow"
+                      ; "error", `String error
+                      ]))))
+        ()
+      |> append
+    in
+    append_failure
+      ~ts:"2026-06-26T03:03:10Z"
+      ~status:"retryable_failure"
+      ~compaction_outcome:Runtime_manifest.Retry_without_checkpoint
+      ~error:"compaction dispatch failed";
+    append_failure
+      ~ts:"2026-06-26T03:03:20Z"
+      ~status:"lifecycle_cleanup_failed"
+      ~compaction_outcome:Runtime_manifest.Lifecycle_cleanup_failed_without_checkpoint
+      ~error:"lifecycle cleanup failed";
     let receipt event decision =
       Runtime_manifest.make
         ~ts:"2026-06-26T03:04:00Z"
@@ -3968,7 +4003,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "schema"
       "keeper.compaction_snapshots.v1"
       (json_string_field "compaction_snapshots" top "schema");
-    Alcotest.(check int) "count" 1 (json_int_field "compaction_snapshots" top "count");
+    Alcotest.(check int) "count" 3 (json_int_field "compaction_snapshots" top "count");
     Alcotest.(check int)
       "read errors"
       0
@@ -3981,11 +4016,23 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "scan truncated"
       false
       (json_bool_field "compaction_snapshots" top "scan_truncated");
-    let item =
-      match json_item_list "compaction_snapshots" top "items" with
-      | [ item ] -> json_assoc "compaction_snapshots.items[0]" item
-      | items -> Alcotest.failf "expected one compaction item, got %d" (List.length items)
+    let items =
+      json_item_list "compaction_snapshots" top "items"
+      |> List.map (json_assoc "compaction_snapshots.items")
     in
+    let find_outcome expected =
+      match
+        List.find_opt
+          (fun item ->
+             String.equal
+               expected
+               (json_string_field "item" item "compaction_outcome"))
+          items
+      with
+      | Some item -> item
+      | None -> Alcotest.failf "missing compaction outcome %s" expected
+    in
+    let item = find_outcome "checkpoint_committed" in
     Alcotest.(check string)
       "source"
       "runtime_manifest"
@@ -4010,6 +4057,22 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "canonical exact evidence"
       exact_evidence
       (List.assoc "exact_evidence" item);
+    List.iter
+      (fun (outcome, cause) ->
+         let failed = find_outcome outcome in
+         Alcotest.(check string)
+           (outcome ^ " failure cause")
+           cause
+           (json_string_field "item" failed "failure_cause");
+         Alcotest.check
+           (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+           (outcome ^ " has no exact evidence")
+           `Null
+           (List.assoc "exact_evidence" failed))
+      [ "retry_without_checkpoint", "compaction dispatch failed"
+      ; ( "lifecycle_cleanup_failed_without_checkpoint"
+        , "lifecycle cleanup failed" )
+      ];
     Alcotest.(check string)
       "compaction id"
       "cmp-42"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -229,6 +229,94 @@ let tool_result id =
     ; content_blocks = None
     }
 
+let test_atomic_cycle_and_normalization_cross_evidence_gate () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_path in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      init_runtime_fixture ();
+      let run_case ~name ~messages response =
+        let server =
+          Exact_fixture.start_server
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            (Exact_fixture.Reply response)
+        in
+        publish_exact_fixture ~source:name server;
+        let meta = make_meta ~name () in
+        ensure_registered_keeper ~base_path:config.base_path meta;
+        let checkpoint = { (make_checkpoint ()) with messages } in
+        let context =
+          checkpoint |> Masc.Keeper_context_core.context_of_oas_checkpoint
+        in
+        let preparation =
+          Compact_policy.compact_for_request_typed
+            ~exact_execution_guard:Exact_fixture.permissive_exact_execution_guard
+            ~base_path:config.base_path
+            ~meta
+            ~trigger:Compaction_trigger.Manual
+            context
+        in
+        check int (name ^ " dispatches exactly once") 1
+          (Exact_fixture.post_count server);
+        match preparation.decision, preparation.evidence with
+        | Compact_policy.Prepared Compaction_trigger.Manual, Some _ ->
+          (match preparation.post_success_terminalizer with
+           | None -> failf "%s lost its post-success terminalizer" name
+           | Some terminalizer ->
+             (match
+                Summarizer.terminalize_post_success
+                  terminalizer
+                  Keeper_event_queue_state.Domain_invalid_output
+              with
+              | Summarizer.Terminalized _ -> ()
+              | _ -> failf "%s could not close its exact attempt" name))
+        | _ -> failf "%s did not cross the structural evidence gate" name
+      in
+      run_case
+        ~name:"atomic-cycle-evidence"
+        ~messages:
+          [ block_message Agent_sdk.Types.User [ Agent_sdk.Types.Text "prompt" ]
+          ; block_message Agent_sdk.Types.Assistant
+              [ Agent_sdk.Types.Thinking
+                  { content = "private"; signature = None }
+              ; tool_use "atomic"
+              ]
+          ; block_message Agent_sdk.Types.Tool
+              [ Agent_sdk.Types.ToolResult
+                  { tool_use_id = "atomic"
+                  ; content = String.make 4096 'r'
+                  ; outcome = Tool_succeeded
+                  ; json = Some (`Assoc [ "status", `String "done" ])
+                  ; content_blocks = None
+                  }
+              ]
+          ]
+        (exact_response [ compaction_decision ~summary:"done" 1 Schema.compaction_plan_action_summarize ]);
+      run_case
+        ~name:"reasoning-normalization-evidence"
+        ~messages:
+          [ block_message Agent_sdk.Types.User [ Agent_sdk.Types.Text "prompt" ]
+          ; block_message Agent_sdk.Types.Assistant
+              [ Agent_sdk.Types.Thinking
+                  { content = String.make 4096 'p'; signature = None }
+              ; Agent_sdk.Types.Text "visible"
+              ]
+          ]
+        (exact_response [ compaction_decision 1 Schema.compaction_plan_action_keep ]))
+;;
+
 let test_regular_post_turn_does_not_auto_compact () =
   Eio_main.run @@ fun _env ->
   let meta = make_meta () in
@@ -1233,6 +1321,10 @@ let () =
         `Quick test_final_admission_busy_requeues_only_pre_dispatch_no_compaction;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
+      test_case
+        "atomic cycle and normalization cross evidence gate"
+        `Quick
+        test_atomic_cycle_and_normalization_cross_evidence_gate;
       test_case "checkpoint installation auxiliary manifest tags"
         `Quick test_checkpoint_installation_auxiliary_manifest_tags;
       test_case "malformed structure preserves checkpoint"

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1043,7 +1043,8 @@ let test_invalid_structural_evidence_after_dispatch_is_terminal () =
       let preparation =
         Compact_policy.For_testing.compact_for_request_typed_with_accounting
           ~plan_for_units
-          ~summarized_message_count_override:(-1)
+          ~expected_after_message_count_override:0
+          ~summarized_message_count_override:1
           ~meta
           ~trigger:Compaction_trigger.Manual
           context
@@ -1054,12 +1055,14 @@ let test_invalid_structural_evidence_after_dispatch_is_terminal () =
        | Compact_policy.Rejected
            ( Manual
            , Invalid_structural_evidence
-               ( Keeper_compaction_evidence.Invalid_field
-                   (Keeper_compaction_evidence.Summarized_message_count, Negative_integer)
+               ( Keeper_compaction_evidence.Invalid_transition
+                   (Keeper_compaction_evidence.Messages, 0, observed_after_message_count)
                , { cause = Keeper_event_queue_state.Invalid_structural_evidence
                  ; slot_id
                  ; call_id
                  } ) ) ->
+         check bool "observed count is not the injected expectation" true
+           (observed_after_message_count > 0);
          check bool "invalid evidence terminal retains slot" true
            (String.trim slot_id <> "");
          check bool "invalid evidence terminal retains call" true
@@ -1337,7 +1340,7 @@ let () =
         `Quick test_post_install_domain_valid_exception_resolves_waiters;
       test_case "post-install cancellation returns committed failure"
         `Quick test_post_install_cancellation_returns_committed_failure;
-      test_case "invalid structural evidence is post-dispatch terminal"
+      test_case "ephemeral plan accounting mismatch is post-dispatch terminal"
         `Quick test_invalid_structural_evidence_after_dispatch_is_terminal;
       test_case "non-reducing output is quarantined"
         `Quick test_post_dispatch_non_reducing_output_is_quarantined;

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -153,10 +153,11 @@ let test_compaction_evidence_public_projection () =
       | `Assoc fields -> `Assoc (("error", `String "must-not-leak") :: fields)
       | _ -> Alcotest.fail "canonical compaction evidence must be an object"
     in
-    M.with_payload_role
-      ~payload_role:M.Checkpoint
-      (`Assoc
-        [ "exact_evidence", evidence_with_cross_scope_field ])
+    M.with_compaction_outcome
+      ~compaction_outcome:M.Checkpoint_committed
+      (M.with_payload_role
+         ~payload_role:M.Checkpoint
+         (`Assoc [ "exact_evidence", evidence_with_cross_scope_field ]))
   in
   let json =
     manifest ~event:M.Context_compacted ~decision ~links:(links ())
@@ -187,8 +188,16 @@ let test_current_compaction_evidence_read_boundary () =
     manifest ~event:M.Context_compacted ~decision ~links:(links ())
     |> M.to_json
   in
+  let decision compaction_outcome fields =
+    M.with_compaction_outcome
+      ~compaction_outcome
+      (`Assoc fields)
+  in
   let canonical_row =
-    row (`Assoc [ Keeper_compaction_evidence.exact_evidence_key, evidence ])
+    row
+      (decision
+         M.Checkpoint_committed
+         [ Keeper_compaction_evidence.exact_evidence_key, evidence ])
   in
   (match M.of_json canonical_row with
    | Error detail -> Alcotest.failf "canonical current evidence rejected: %s" detail
@@ -203,6 +212,33 @@ let test_current_compaction_evidence_read_boundary () =
        "Dashboard source is canonical evidence"
        evidence
        actual);
+  List.iter
+    (fun (label, outcome, cause) ->
+       let failure_decision =
+         decision outcome [ "error", `String cause ]
+       in
+       match M.of_json (row failure_decision) with
+       | Error detail ->
+         Alcotest.failf "%s current failure outcome rejected: %s" label detail
+       | Ok restored ->
+         let open Yojson.Safe.Util in
+         Alcotest.(check string)
+           (label ^ " outcome retained")
+           (M.compaction_outcome_to_string outcome)
+           (restored.decision
+            |> member M.compaction_outcome_key
+            |> to_string);
+         Alcotest.(check string)
+           (label ^ " cause retained")
+           cause
+           (restored.decision |> member "error" |> to_string))
+    [ ( "retry without checkpoint"
+      , M.Retry_without_checkpoint
+      , "compaction dispatch failed" )
+    ; ( "lifecycle cleanup without checkpoint"
+      , M.Lifecycle_cleanup_failed_without_checkpoint
+      , "lifecycle cleanup failed" )
+    ];
   let unknown_evidence =
     match evidence with
     | `Assoc fields -> `Assoc (("unexpected", `Bool true) :: fields)
@@ -213,19 +249,30 @@ let test_current_compaction_evidence_read_boundary () =
       match M.of_json json with
       | Ok _ -> Alcotest.failf "%s current evidence was accepted" label
       | Error _ -> ())
-    [ "missing", row (`Assoc [])
+    [ "missing", row (decision M.Checkpoint_committed [])
     ; ( "wrong type"
       , row
-          (`Assoc
+          (decision
+             M.Checkpoint_committed
              [ Keeper_compaction_evidence.exact_evidence_key
              , `String "not-an-object"
              ]) )
     ; ( "unknown field"
       , row
-          (`Assoc
+          (decision
+             M.Checkpoint_committed
              [ Keeper_compaction_evidence.exact_evidence_key
              , unknown_evidence
              ]) )
+    ; ( "evidence on retry without checkpoint"
+      , row
+          (decision
+             M.Retry_without_checkpoint
+             [ "error", `String "retry"
+             ; Keeper_compaction_evidence.exact_evidence_key, evidence
+             ]) )
+    ; ( "missing retry cause"
+      , row (decision M.Retry_without_checkpoint []) )
     ]
 
 let () =

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -121,9 +121,8 @@ let test_is_complete_turn () =
   Alcotest.(check bool) "finished+receipt+checkpoint is complete" true
     (M.is_complete_turn complete)
 
-let test_compaction_evidence_public_projection () =
-  let evidence =
-    Keeper_compaction_evidence.create
+let canonical_compaction_evidence () =
+  Keeper_compaction_evidence.create
       ~slot_id:"compaction-slot"
       ~call_id:"call-01"
       ~target_identity_fingerprint:"target-identity"
@@ -137,18 +136,17 @@ let test_compaction_evidence_public_projection () =
       ~before_message_count:12
       ~after_message_count:4
       ~summarized_message_count:4
-      ~summarized_unit_count:4
       ~dropped_message_count:8
-      ~normalized_message_count:0
       ~before_tool_use_count:3
       ~after_tool_use_count:3
       ~before_tool_result_count:3
       ~after_tool_result_count:3
-      ~removed_tool_use_count:0
-      ~removed_tool_result_count:0
     |> Result.get_ok
     |> Keeper_compaction_evidence.to_json
-  in
+;;
+
+let test_compaction_evidence_public_projection () =
+  let evidence = canonical_compaction_evidence () in
   let decision =
     let evidence_with_cross_scope_field =
       match evidence with
@@ -183,6 +181,53 @@ let test_compaction_evidence_public_projection () =
     evidence
     (json |> member "decision" |> member "exact_evidence")
 
+let test_current_compaction_evidence_read_boundary () =
+  let evidence = canonical_compaction_evidence () in
+  let row decision =
+    manifest ~event:M.Context_compacted ~decision ~links:(links ())
+    |> M.to_json
+  in
+  let canonical_row =
+    row (`Assoc [ Keeper_compaction_evidence.exact_evidence_key, evidence ])
+  in
+  (match M.of_json canonical_row with
+   | Error detail -> Alcotest.failf "canonical current evidence rejected: %s" detail
+   | Ok restored ->
+     let actual =
+       Yojson.Safe.Util.member
+         Keeper_compaction_evidence.exact_evidence_key
+         restored.decision
+     in
+     Alcotest.check
+       (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+       "Dashboard source is canonical evidence"
+       evidence
+       actual);
+  let unknown_evidence =
+    match evidence with
+    | `Assoc fields -> `Assoc (("unexpected", `Bool true) :: fields)
+    | _ -> Alcotest.fail "canonical evidence must be an object"
+  in
+  List.iter
+    (fun (label, json) ->
+      match M.of_json json with
+      | Ok _ -> Alcotest.failf "%s current evidence was accepted" label
+      | Error _ -> ())
+    [ "missing", row (`Assoc [])
+    ; ( "wrong type"
+      , row
+          (`Assoc
+             [ Keeper_compaction_evidence.exact_evidence_key
+             , `String "not-an-object"
+             ]) )
+    ; ( "unknown field"
+      , row
+          (`Assoc
+             [ Keeper_compaction_evidence.exact_evidence_key
+             , unknown_evidence
+             ]) )
+    ]
+
 let () =
   Alcotest.run "keeper_runtime_manifest_completeness"
     [ ( "completeness"
@@ -197,5 +242,7 @@ let () =
             test_is_complete_turn
         ; Alcotest.test_case "compaction evidence public projection" `Quick
             test_compaction_evidence_public_projection
+        ; Alcotest.test_case "current evidence read boundary" `Quick
+            test_current_compaction_evidence_read_boundary
         ] )
     ]

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -137,11 +137,15 @@ let test_compaction_evidence_public_projection () =
       ~before_message_count:12
       ~after_message_count:4
       ~summarized_message_count:4
+      ~summarized_unit_count:4
       ~dropped_message_count:8
+      ~normalized_message_count:0
       ~before_tool_use_count:3
       ~after_tool_use_count:3
       ~before_tool_result_count:3
       ~after_tool_result_count:3
+      ~removed_tool_use_count:0
+      ~removed_tool_result_count:0
     |> Result.get_ok
     |> Keeper_compaction_evidence.to_json
   in


### PR DESCRIPTION
## Summary

- admit each structurally closed tool protocol as one atomic compaction planner unit
- strip `Thinking`, `ReasoningDetails`, and `RedactedThinking` from standalone Assistant planner input while preserving ordered Text blocks
- apply one whole-unit `Keep` / `Drop` / `Summarize` decision without partial tool-cycle salvage
- fail closed for open cycles and typed media blocks rather than truncating or projecting binary payloads
- type current compaction manifest outcomes so failed attempts remain visible without fabricated evidence

## Execution accounting

- compute typed `plan_accounting` ephemerally from the accepted plan and original units
- compare exact expected message/ToolUse/ToolResult counts with the serialized checkpoint observations before evidence creation
- reject an expected-vs-observed mismatch as typed `Invalid_transition` after dispatch
- do not persist derived planner counters or use manifest evidence as recovery/execution authority
- retain balanced ToolUse/ToolResult removal and structurally possible message-accounting checks as observability validation

No legacy defaults, migration, or compatibility branch are included.

## Manifest and Dashboard boundary

Current `context_compacted` decisions have a closed outcome:

- `checkpoint_committed`: canonical `exact_evidence` is required
- `retry_without_checkpoint`: evidence is forbidden and a nonblank cause is required
- `lifecycle_cleanup_failed_without_checkpoint`: evidence is forbidden and a nonblank cause is required

The manifest and TypeScript readers reject unknown, missing, malformed, or contradictory outcome/evidence/cause shapes and canonicalizes committed evidence through `Keeper_compaction_evidence.of_json` / `to_json`. The API and Dashboard use the same outcome SSOT for labels and success/warning/error color; failed no-checkpoint rows stay visible with their cause rather than being dropped or shown as successful compactions.

## Boundary

- semantic summaries remain LLM-produced
- deterministic code only strips private reasoning, strips technical message metadata from provider projection, builds ordered source projection, and verifies structural/count invariants
- no heuristic summary, truncation, migration, CAS/install/live-delta, store, lease, settlement, or new hash
- a normalizing `Keep` is material only when private reasoning was actually removed; plain all-`Keep` plans remain invalid

## Validation

- changed-file `ocamlformat`; `git diff --check`
- focused OCaml wrapper build for manifest, Dashboard backend, and producer paths
- compaction summarizer: 17/17 green
- compaction evidence projection/accounting: 5/5 green
- runtime-manifest completeness/current outcome/evidence boundary: 7/7 green
- actual atomic accounting success gate: focused 1/1 green
- ephemeral expected-vs-observed mismatch rejection: focused 1/1 green
- producer -> manifest decoder -> Dashboard API, all three outcomes: focused 1/1 green
- Dashboard TypeScript: `tsc --noEmit` green
- Dashboard outcome/cause wording and no-false-success UI: focused 1/1 green
- Dashboard API compaction decoder: focused 1/1 green

Closes #26038
Parent: #25430
