### PR TITLE
fix(schedule): activate durable wakes without proactive turns

### DIFF
--- a/lib/keeper/keeper_activation_readiness.ml
+++ b/lib/keeper/keeper_activation_readiness.ml
@@ -192,7 +192,12 @@ let owner_execution_truth_to_wire = function
   | Unknown _ -> "unknown"
 ;;
 
-let classify_owner_execution ~shutdown_operation_id ~runtime meta_result =
+let classify_owner_execution_with
+      ~require_proactive
+      ~shutdown_operation_id
+      ~runtime
+      meta_result
+  =
   match meta_result with
   | Error detail -> Unknown detail
   | Ok meta ->
@@ -205,8 +210,9 @@ let classify_owner_execution ~shutdown_operation_id ~runtime meta_result =
           Paused_dead (Persisted_lifecycle_denied denial)
         | Some Autoboot_disabled ->
           Retained_disabled Retained_autoboot_disabled
-        | Some Proactive_disabled ->
+        | Some Proactive_disabled when require_proactive ->
           Retained_disabled Retained_proactive_disabled
+        | Some Proactive_disabled
         | None ->
           (match runtime with
            | Owner_unregistered -> Recoverable
@@ -221,6 +227,14 @@ let classify_owner_execution ~shutdown_operation_id ~runtime meta_result =
                    | Owner_unregistered -> assert false))
            | Owner_registered { live_fiber = true; _ } -> Executable
            | Owner_registered { live_fiber = false; _ } -> Recoverable)))
+;;
+
+let classify_owner_execution =
+  classify_owner_execution_with ~require_proactive:true
+;;
+
+let classify_durable_demand_execution =
+  classify_owner_execution_with ~require_proactive:false
 ;;
 
 let of_meta meta =

--- a/lib/keeper/keeper_activation_readiness.mli
+++ b/lib/keeper/keeper_activation_readiness.mli
@@ -89,4 +89,14 @@ val classify_owner_execution :
     Policy permission without one is [Recoverable], never runnable.
     Missing/unreadable metadata fails closed as [Unknown]. *)
 
+val classify_durable_demand_execution :
+  shutdown_operation_id:Keeper_shutdown_types.Operation_id.t option ->
+  runtime:owner_runtime ->
+  (Keeper_meta_contract.keeper_meta, string) result ->
+  owner_execution_truth
+(** Classify activation for an already-persisted explicit demand such as a due
+    schedule or HITL continuation. Lifecycle, shutdown, and autoboot policy
+    still apply, but [proactive_enabled] does not: that flag controls
+    unsolicited scheduled-autonomous turns, not reactive durable work. *)
+
 val to_yojson : t -> Yojson.Safe.t

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -223,7 +223,7 @@ let recover_projected_durable_demand_owner
            (Keeper_registry.get ~base_path keeper_name)
        in
        let truth =
-         Keeper_activation_readiness.classify_owner_execution
+         Keeper_activation_readiness.classify_durable_demand_execution
            ~shutdown_operation_id:
              admission.snapshot_shutdown_operation_id
            ~runtime

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -428,7 +428,7 @@ let activation_outcome_for_required_wake config ~base_path ~keeper_name =
         (Keeper_registry.get ~base_path keeper_name)
     in
     (match
-       Keeper_activation_readiness.classify_owner_execution
+       Keeper_activation_readiness.classify_durable_demand_execution
          ~shutdown_operation_id:admission.snapshot_shutdown_operation_id
          ~runtime
          meta_result

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -68,7 +68,7 @@ let make_meta name =
   let json =
     `Assoc
       [ ("name", `String name)
-      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name))
       ; ("trace_id", `String ("trace-gate-" ^ name))
       ]
   in
@@ -279,6 +279,69 @@ let test_owner_execution_requires_live_fiber () =
          (Ok (ready_meta ()))
      with
      | Readiness.Executable -> true
+     | Readiness.Recoverable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Shutdown_fenced _
+     | Readiness.Unknown _ -> false)
+;;
+
+let test_durable_demand_does_not_require_proactive () =
+  without_overrides @@ fun () ->
+  let ready = ready_meta () in
+  let proactive_disabled =
+    { ready with proactive = { enabled = false } }
+  in
+  check bool "ordinary autonomous execution remains disabled" true
+    (match
+       Readiness.classify_owner_execution
+         ~shutdown_operation_id:None
+         ~runtime:(owner_runtime ~phase:State_machine.Running ~live_fiber:true)
+         (Ok proactive_disabled)
+     with
+     | Readiness.Retained_disabled Readiness.Retained_proactive_disabled -> true
+     | Readiness.Executable
+     | Readiness.Recoverable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Shutdown_fenced _
+     | Readiness.Unknown _ -> false);
+  check bool "persisted reactive demand can wake the live owner" true
+    (match
+       Readiness.classify_durable_demand_execution
+         ~shutdown_operation_id:None
+         ~runtime:(owner_runtime ~phase:State_machine.Running ~live_fiber:true)
+         (Ok proactive_disabled)
+     with
+     | Readiness.Executable -> true
+     | Readiness.Recoverable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Shutdown_fenced _
+     | Readiness.Unknown _ -> false);
+  check bool "persisted demand can recover an absent owner" true
+    (match
+       Readiness.classify_durable_demand_execution
+         ~shutdown_operation_id:None
+         ~runtime:Readiness.Owner_unregistered
+         (Ok proactive_disabled)
+     with
+     | Readiness.Recoverable -> true
+     | Readiness.Executable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Shutdown_fenced _
+     | Readiness.Unknown _ -> false);
+  with_flag "MASC_KEEPER_AUTONOMOUS_ENABLED" "false" @@ fun () ->
+  check bool "persisted demand still respects the autoboot kill-switch" true
+    (match
+       Readiness.classify_durable_demand_execution
+         ~shutdown_operation_id:None
+         ~runtime:Readiness.Owner_unregistered
+         (Ok proactive_disabled)
+     with
+     | Readiness.Retained_disabled Readiness.Retained_autoboot_disabled -> true
+     | Readiness.Executable
      | Readiness.Recoverable
      | Readiness.Retained_disabled _
      | Readiness.Paused_dead _
@@ -524,6 +587,8 @@ let () =
             test_global_autonomous_off_blocks_readiness
         ; test_case "execution requires live fiber" `Quick
             test_owner_execution_requires_live_fiber
+        ; test_case "durable demand bypasses proactive policy" `Quick
+            test_durable_demand_does_not_require_proactive
         ; test_case "shutdown fence blocks boot" `Quick
             test_owner_execution_shutdown_fence_blocks_boot
         ; test_case "unknown owner truth fails closed" `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -118,8 +118,17 @@ let keeper_meta_for_name keeper_name =
   | Error msg -> fail ("keeper meta parse failed: " ^ msg)
 ;;
 
-let register_keeper config keeper_name =
-  let meta = keeper_meta_for_name keeper_name in
+let register_keeper ?proactive_enabled config keeper_name =
+  let meta =
+    let meta = keeper_meta_for_name keeper_name in
+    match proactive_enabled with
+    | None -> meta
+    | Some enabled ->
+      { meta with
+        autoboot_enabled = true
+      ; proactive = { enabled }
+      }
+  in
   (match Keeper_meta_store.write_meta config meta with
    | Ok () -> ()
    | Error detail -> fail ("keeper meta write failed: " ^ detail));
@@ -683,6 +692,43 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
         Yojson.Safe.Util.(evidence |> member "event_queue_cancelled_seen" |> to_bool))
 ;;
 
+let test_due_schedule_wakes_live_keeper_with_proactive_disabled () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let entry =
+    register_keeper ~proactive_enabled:false config keeper_name
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.unregister ~base_path keeper_name)
+    (fun () ->
+       let request = create_keeper_wake_schedule config in
+       Atomic.set entry.fiber_wakeup false;
+       let result = tick_ok config ~now:201.0 in
+       check bool "due schedule signals the live owner" true
+         (Atomic.get entry.fiber_wakeup);
+       match
+         Schedule_store.last_execution_for_schedule
+           (Schedule_store.read_state config)
+           ~schedule_id:request.schedule_id
+       with
+       | Some { detail = Some detail; _ } ->
+         check string "activation is signaled" "signaled"
+           Yojson.Safe.Util.(detail |> member "activation_status" |> to_string);
+         check string "proactive policy is not an activation blocker" ""
+           (match
+              Yojson.Safe.Util.(detail |> member "activation_reason")
+            with
+            | `Null -> ""
+            | json -> Yojson.Safe.to_string json);
+         check int "one schedule dispatch completed" 1
+           (List.length result.dispatches)
+       | Some _ -> fail "schedule execution detail missing"
+       | None -> fail "schedule execution missing")
+;;
+
 let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
   with_workspace
   @@ fun config ->
@@ -1026,6 +1072,8 @@ let () =
         ; test_case "cancelled occurrence recovery does not enqueue again"
             `Quick
             test_cancelled_occurrence_recovery_does_not_enqueue_again
+        ; test_case "due wake bypasses proactive policy" `Quick
+            test_due_schedule_wakes_live_keeper_with_proactive_disabled
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "dashboard live supported non-terminal evidence matches supported request"


### PR DESCRIPTION
## Summary

- classify already-persisted durable demand separately from unsolicited proactive work
- let due schedule/HITL event-queue demand wake or recover an autoboot Keeper even when `proactive_enabled=false`
- retain lifecycle pause/dead, shutdown fencing, autoboot/global autonomous kill-switch, live-fiber, and unknown-owner checks
- keep ordinary scheduled-autonomous turns blocked when proactive is disabled, avoiding idle heartbeat model calls between hourly occurrences
- repair the lifecycle test fixture to use the current canonical Keeper agent identity

## Live reproduction

Before this change, hourly schedule `audit-hourly-websearch` durably enqueued occurrence `443f8948...` but reported `activation_reason=autoboot_disabled`. Enabling autoboot+proactive let it run through WebSearch → Auto Judge → exact one-shot grant → WebSearch → board post `p-32bbd7de5857d894ae9fc6d3d7570e99`, but then caused non-due `scheduled_autonomous_turn` model calls roughly every 30 seconds.

This change lets the explicit durable wake use the reactive lane while proactive remains off.

## Validation

- `ocamlformat --check` on all six changed files
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_lifecycle_global_gate.exe test/test_schedule_consumer_dispatch.exe`
- `test_keeper_lifecycle_global_gate.exe`: 18/18 passed
- `test_schedule_consumer_dispatch.exe`: new `due wake bypasses proactive policy` case passed; suite remains 14/15 because the same pre-existing cancellation-retry failure reproduces on clean `main` (tracked separately in #26043)

Closes #26042
