### PR TITLE
fix(schedule): retain cancellation WAL until projection

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -1608,6 +1608,10 @@ let prepare_registration_result
     ()
 ;;
 
+let mark_transition_projected_result state ~transition_id =
+  State.mark_transition_projected ~transition_id state
+;;
+
 let project_transition_outbox_result
       ~append_before_retire
       ~base_path
@@ -1623,9 +1627,9 @@ let project_transition_outbox_result
       | [ entry ] ->
         let* () = append_before_retire entry in
         let* projected =
-          State.mark_transition_projected
-            ~transition_id:entry.receipt.transition_id
+          mark_transition_projected_result
             state
+            ~transition_id:entry.receipt.transition_id
         in
         let* projected = bump_revision projected in
         let* () = save_state_unlocked owner projected in

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -506,22 +506,13 @@ let replay_settlement_wal_unlocked owner state =
                ~surface:"settlement WAL"
                detail)
         | Ok replayed ->
-         (match bump_revision replayed with
-          | Error _ as error -> error
-          | Ok replayed ->
-            (match save_state_unlocked owner replayed with
-             | Ok () ->
-               (match compact_settlement_wal_unlocked owner with
-                | Ok () -> Ok replayed
-                | Error detail ->
-                  Error
-                    ("settlement WAL checkpoint recovered but compaction failed: "
-                     ^ detail))
-             | Error detail ->
-               Error
-                 (Printf.sprintf
-                    "settlement WAL is committed but checkpoint replay failed: %s"
-                    detail))))
+          (* [State.to_yojson] intentionally persists only the pending queue.
+             Leases and transition outboxes are no longer snapshot fields, so
+             checkpointing [replayed] and compacting this WAL here would erase
+             the only durable copy of the settlement before its reaction-ledger
+             projector can observe it. Keep the source-bearing WAL authoritative
+             until [project_transition_outbox_result] appends and retires it. *)
+          Ok replayed)
   in
   match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
   | Private_file_failed error ->
@@ -1170,8 +1161,14 @@ let commit_settlement_transition_unlocked_with
 
 let commit_settlement_transition_unlocked =
   commit_settlement_transition_unlocked_with
-    ~save_checkpoint:save_state_unlocked
-    ~compact_wal:compact_settlement_wal_unlocked
+    (* The settlement WAL is the commit record.  The current pending-only
+       snapshot cannot retain its lease or transition outbox, so replacing the
+       pre-commit snapshot here would make this WAL impossible to replay (and
+       would erase its only durable outbox if it were then compacted).  The
+       projector checkpoints the post-transition pending state only after its
+       reaction-ledger append succeeds. *)
+    ~save_checkpoint:(fun _owner _state -> Ok ())
+    ~compact_wal:(fun _owner -> Ok ())
 ;;
 
 let settle_result
@@ -1611,38 +1608,42 @@ let prepare_registration_result
     ()
 ;;
 
-let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =
-  commit_transform
-    ~base_path
-    ~keeper_name
-    ~after_commit:(fun _ -> ())
-    (fun state ->
-       match State.mark_transition_projected ~transition_id state with
-       | Error _ as error -> error
-       | Ok state -> Ok (state, ()))
-;;
-
 let project_transition_outbox_result
       ~append_before_retire
       ~base_path
       ~keeper_name
   =
   let ( let* ) = Result.bind in
-  let* state = load_state_result ~base_path ~keeper_name in
-  match State.transition_outbox state with
-  | [] -> Ok ()
-  | [ entry ] ->
-    let* () = append_before_retire entry in
-    mark_transition_projected_result
-      ~base_path
-      ~keeper_name
-      ~transition_id:entry.receipt.transition_id
-  | entries ->
+  let* owner = resolve_owner ~base_path ~keeper_name in
+  try
+    Owner_lock.with_durable_lock owner (fun () ->
+      let* state = load_state_unlocked owner in
+      match State.transition_outbox state with
+      | [] -> Ok ()
+      | [ entry ] ->
+        let* () = append_before_retire entry in
+        let* projected =
+          State.mark_transition_projected
+            ~transition_id:entry.receipt.transition_id
+            state
+        in
+        let* projected = bump_revision projected in
+        let* () = save_state_unlocked owner projected in
+        compact_settlement_wal_unlocked owner
+      | entries ->
+        Error
+          (Printf.sprintf
+             "event queue transition outbox cardinality invalid keeper=%s count=%d"
+             keeper_name
+             (List.length entries)))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     Error
       (Printf.sprintf
-         "event queue transition outbox cardinality invalid keeper=%s count=%d"
+         "event queue transition projection raised keeper=%s: %s"
          keeper_name
-         (List.length entries))
+         (Printexc.to_string exn))
 ;;
 
 let remove_post_ids stimuli state =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -54,6 +54,13 @@ let write_file path content =
     (fun () -> output_string output content)
 ;;
 
+let read_file path =
+  let input = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr input)
+    (fun () -> really_input_string input (in_channel_length input))
+;;
+
 let reaction_ledger_dir ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat
@@ -644,6 +651,16 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
        | Ok (Keeper_registry_event_queue.Committed_followup_failed _) ->
          fail "schedule cancellation follow-up failed"
        | Error detail -> fail detail);
+      let settlement_wal_path =
+        Filename.concat
+          (Filename.concat
+             (Common.keepers_runtime_dir_of_base ~base_path)
+             keeper_name)
+          "event-queue-settlements.jsonl"
+      in
+      check bool "cancellation WAL survives until projection" true
+        (Sys.file_exists settlement_wal_path
+         && String.trim (read_file settlement_wal_path) <> "");
       (match
          Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
        with
@@ -655,6 +672,8 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
          fail "scheduled cancellation projection was deferred by a busy owner claim"
        | Error error ->
          fail (Keeper_event_queue_recovery.projection_error_to_string error));
+      check string "projected cancellation retires WAL" ""
+        (read_file settlement_wal_path);
       (match Schedule_store.recover_running_on_startup config ~now:204.0 with
        | Ok (_, 1) -> ()
        | Ok (_, recovered) -> failf "expected one recovered schedule, got %d" recovered


### PR DESCRIPTION
## What changed

- keep the settlement WAL as the authoritative commit record until reaction-ledger projection succeeds
- avoid checkpointing a transition into the pending-only v7 snapshot, which cannot retain leases or transition outboxes
- perform ledger append, projected-state checkpoint, and WAL retirement under the owner lock

## Root cause

`commit_settlement_transition_unlocked_with` saved the post-cancellation state into a snapshot that serializes only `schema`, `revision`, and `pending`, then compacted the settlement WAL. That discarded the only durable transition outbox before `Keeper_reaction_ledger` could project terminal cancellation evidence. Schedule recovery therefore retried the occurrence as `awaiting_ack` instead of `already_cancelled`.

The fix does not add claim/lease state back to the snapshot. The pre-transition pending snapshot remains in place while the WAL carries the committed transition; projection then writes the final pending-only snapshot and retires the WAL.

## User impact

Cancelled scheduled occurrences remain terminal across recovery and are not enqueued again.

## Validation

- `scripts/dune-local.sh build test/test_schedule_consumer_dispatch.exe test/test_keeper_reaction_ledger.exe test/test_keeper_exact_execution_lease_guard.exe`
- `ocamlformat --check lib/keeper_runtime/keeper_event_queue_persistence.ml`
- `_build/default/test/test_schedule_consumer_dispatch.exe` — 14/14 passed

The two legacy lease suites remain red on current `main` because #25969 removed durable lease restoration while those tests still call claim/settle across persistence boundaries; that existing cleanup is tracked in #25981 and #26014 and is not caused by this one-file change.

Closes #26043
Related: #26014, #25981