### PR TITLE
fix(keeper): authorize confined playground writes

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -769,7 +769,10 @@ let public_descriptors =
       ~id:"agent.write_file"
       ~public_name:"Write"
       ~internal_name:"tool_write_file"
-      ~description:"Write full file content into the keeper sandbox or an allowed path."
+      ~description:
+        "Write full file content into the keeper sandbox or an allowed path. Missing \
+         parent directories are created safely; call Write directly instead of using \
+         Execute mkdir."
       ~input_schema:write_file_schema
       ~policy:
         (policy

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -1173,6 +1173,19 @@ let decide_file_write
     }
 ;;
 
+let confined_write_is_keeper_playground
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      confined
+  =
+  let normalized path =
+    Keeper_alerting_path.normalize_path_for_check_stripped path
+  in
+  String.equal
+    (normalized (Keeper_alerting_path.confined_root confined))
+    (normalized (Keeper_sandbox.host_root_abs_of_meta ~config meta))
+;;
+
 type file_write_attempt =
   | Write_succeeded of string
   | Write_deferred of Keeper_gate_deferred_payload.t
@@ -1939,46 +1952,54 @@ let handle_file_write_with_outcome
   let content = Safe_ops.json_string ~default:"" "content" args in
   let mode_raw = Safe_ops.json_string ~default:"overwrite" "mode" args in
   let mode_opt = fs_write_mode_of_string_opt mode_raw in
-  let after_gate ~target ~input continue =
-    match
-      decide_file_write
-        ~config
-        ~meta
-        ?continuation_channel
-        ?gate_context
-        ?gate_grant
-        ~input
-        ()
-    with
-    | Keeper_gate.Deferred { approval_id; reason } ->
-      Ok
-        (Write_deferred
-           (Keeper_gate_deferred_payload.create
-              ~operation:gate_operation
-              ~approval_id
-              ~reason
-              ~context:(`Assoc [ "path", `String target ])
-              ()))
-    | Keeper_gate.Unavailable reason ->
-      Ok
-        (Write_failed
-           { payload =
-               error_json
-                 ~fields:
-                   [ "path", `String target
-                   ; "error", `String "gate_unavailable"
-                   ; "gate_reason"
-                   , `String (Keeper_gate.unavailable_reason_to_string reason)
-                   ]
-                 "External effect was not executed because the Gate could not durably record its decision state. This Keeper remains active and may continue other work."
-           ; class_ = Tool_result.Runtime_failure
-           })
-    | Keeper_gate.Allow authorization ->
+  let after_gate ~confined ~target ~input continue =
+    if confined_write_is_keeper_playground ~config ~meta confined
+    then (
       Log.Keeper.info
         ~keeper_name:meta.name
-        "external effect authorized operation=filesystem_write source=%s"
-        (Keeper_gate.authorization_source_to_string authorization.source);
-      continue ()
+        "internal playground write authorized by confined capability path=%s"
+        target;
+      continue ())
+    else
+      match
+        decide_file_write
+          ~config
+          ~meta
+          ?continuation_channel
+          ?gate_context
+          ?gate_grant
+          ~input
+          ()
+      with
+      | Keeper_gate.Deferred { approval_id; reason } ->
+        Ok
+          (Write_deferred
+             (Keeper_gate_deferred_payload.create
+                ~operation:gate_operation
+                ~approval_id
+                ~reason
+                ~context:(`Assoc [ "path", `String target ])
+                ()))
+      | Keeper_gate.Unavailable reason ->
+        Ok
+          (Write_failed
+             { payload =
+                 error_json
+                   ~fields:
+                     [ "path", `String target
+                     ; "error", `String "gate_unavailable"
+                     ; "gate_reason"
+                     , `String (Keeper_gate.unavailable_reason_to_string reason)
+                     ]
+                   "External effect was not executed because the Gate could not durably record its decision state. This Keeper remains active and may continue other work."
+             ; class_ = Tool_result.Runtime_failure
+             })
+      | Keeper_gate.Allow authorization ->
+        Log.Keeper.info
+          ~keeper_name:meta.name
+          "external effect authorized operation=filesystem_write source=%s"
+          (Keeper_gate.authorization_source_to_string authorization.source);
+        continue ()
   in
   let protect_write ~target f =
     try f () with
@@ -2049,7 +2070,7 @@ let handle_file_write_with_outcome
            ; class_ = Tool_result.Runtime_failure
            })
   in
-  let finish_content_write ~target ~mode_label ~gate_effect write =
+  let finish_content_write ~confined ~target ~mode_label ~gate_effect write =
     let input =
       file_write_gate_input
         ~gate_effect
@@ -2057,7 +2078,7 @@ let handle_file_write_with_outcome
         ~content
         ()
     in
-    after_gate ~target ~input
+    after_gate ~confined ~target ~input
     @@ fun () ->
     protect_write ~target
     @@ fun () ->
@@ -2196,6 +2217,7 @@ let handle_file_write_with_outcome
           Keeper_alerting_path.atomic_replace_recovery_target projection
         in
         finish_content_write
+          ~confined
           ~target
           ~mode_label
           ~gate_effect
@@ -2254,6 +2276,7 @@ let handle_file_write_with_outcome
             |> Result.map_error Keeper_alerting_path.path_effect_projection_error_to_string
           in
           finish_content_write
+            ~confined
             ~target
             ~mode_label
             ~gate_effect
@@ -2326,6 +2349,7 @@ let handle_file_write_with_outcome
                          Keeper_alerting_path.path_effect_projection_error_to_string
                   in
                   finish_content_write
+                    ~confined
                     ~target
                     ~mode_label
                     ~gate_effect
@@ -2392,7 +2416,7 @@ let handle_file_write_with_outcome
                     ~replace_all
                     ()
                 in
-                after_gate ~target ~input
+                after_gate ~confined ~target ~input
                 @@ fun () ->
                 protect_write ~target
                 @@ fun () ->

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -73,7 +73,11 @@ val handle_file_write_with_outcome :
     The project root's parent is the operator-owned capability-acquisition
     boundary. An explicit allowed root outside the project likewise requires
     an operator-owned parent; Keeper-writable components must begin below the
-    opened root capability. *)
+    opened root capability.
+
+    Writes whose selected confined root is exactly this Keeper's playground
+    root proceed after the capability and root-identity checks without an
+    approval Gate. Writes through every other allowed root retain the Gate. *)
 
 module For_testing : sig
   type created_directory_fault_stage =

--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -77,14 +77,14 @@ let make_meta name =
   let json =
     `Assoc
       [ "name", `String name
-      ; "agent_name", `String ("agent-" ^ name)
+      ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
       ; "trace_id", `String ("trace-" ^ name)
-      ; "sandbox_profile", `String "docker"
-      ; "always_allow", `Bool true
+      ; "always_allow", `Bool false
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with sandbox_profile = Keeper_types_profile_sandbox.Docker }
   | Error e -> Alcotest.fail e
 ;;
 
@@ -112,7 +112,7 @@ let setup f =
     (fun () ->
        Keeper_registry.For_testing.clear ();
        let config = Workspace.default_config base in
-       let meta = { (make_meta "tester") with always_allow = Some true } in
+       let meta = make_meta "tester" in
        let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
        ensure_dir playground;
        let (_registered : Keeper_registry.registry_entry) =
@@ -138,7 +138,7 @@ let parse_ok raw =
   parse raw |> Json.member "ok" |> Json.to_bool_option |> Option.value ~default:false
 ;;
 
-let test_docker_write_allows_explicit_root () =
+let test_docker_write_defers_explicit_root () =
   setup
   @@ fun ~config ~meta ~playground:_ ~publication_recovery ->
   let meta = { meta with allowed_paths = [ config.base_path ] } in
@@ -158,11 +158,11 @@ let test_docker_write_allows_explicit_root () =
             ])
       ()
   in
-  if not (parse_ok raw) then Alcotest.failf "expected ok response, got: %s" raw;
-  Alcotest.(check string) "content landed" "must not land" (Fs_compat.load_file path)
+  Alcotest.(check bool) "write deferred" false (parse_ok raw);
+  Alcotest.(check bool) "content did not land" false (Sys.file_exists path)
 ;;
 
-let test_docker_write_allows_playground () =
+let test_docker_write_allows_playground_without_gate () =
   setup
   @@ fun ~config ~meta ~playground ~publication_recovery ->
   let path = Filename.concat playground "mind/allowed.txt" in
@@ -185,18 +185,80 @@ let test_docker_write_allows_playground () =
   Alcotest.(check string) "content landed" "allowed" (Fs_compat.load_file path)
 ;;
 
+let test_docker_write_rejects_playground_symlink_escape () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery ->
+  let outside = Filename.concat config.base_path "outside" in
+  ensure_dir outside;
+  let link = Filename.concat playground "escape" in
+  Unix.symlink outside link;
+  let escaped = Filename.concat link "escaped.txt" in
+  let raw =
+    handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery
+      ~args:
+        (`Assoc
+            [ "path", `String escaped
+            ; "mode", `String "overwrite"
+            ; "content", `String "must not escape"
+            ])
+      ()
+  in
+  Alcotest.(check bool) "escape rejected" false (parse_ok raw);
+  Alcotest.(check bool)
+    "outside file absent"
+    false
+    (Sys.file_exists (Filename.concat outside "escaped.txt"))
+;;
+
+let test_docker_write_rejects_parent_traversal () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery ->
+  let escaped = Filename.concat playground "../escaped.txt" in
+  let raw =
+    handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery
+      ~args:
+        (`Assoc
+            [ "path", `String escaped
+            ; "mode", `String "overwrite"
+            ; "content", `String "must not escape"
+            ])
+      ()
+  in
+  Alcotest.(check bool) "traversal rejected" false (parse_ok raw);
+  Alcotest.(check bool)
+    "traversal file absent"
+    false
+    (Sys.file_exists escaped)
+;;
+
 let () =
   Alcotest.run
     "Keeper_fs_edit_containment"
     [ ( "fs_edit"
       , [ Alcotest.test_case
-            "docker write allows explicit root outside playground"
+            "docker write defers explicit root outside playground"
             `Quick
-            test_docker_write_allows_explicit_root
+            test_docker_write_defers_explicit_root
         ; Alcotest.test_case
-            "docker write allows playground"
+            "docker write allows playground without gate"
             `Quick
-            test_docker_write_allows_playground
+            test_docker_write_allows_playground_without_gate
+        ; Alcotest.test_case
+            "docker write rejects playground symlink escape"
+            `Quick
+            test_docker_write_rejects_playground_symlink_escape
+        ; Alcotest.test_case
+            "docker write rejects parent traversal"
+            `Quick
+            test_docker_write_rejects_parent_traversal
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

Fresh 8-Keeper Full Cycle stalled artifact production because both `Execute mkdir` and the subsequent capability-confined `Write` waited on Auto Judge.

Live evidence:
- `appr_d30db9f5-1317-4df9-a5b0-96feb02780cb`: `tool_execute`, `decision_source=auto_judge`, `actor=null`
- `appr_2f0a9856-95c3-4508-a925-7d963ee8bdfc`: `filesystem_write`, `decision_source=auto_judge`, `actor=null`
- the judge noticed the path was redundantly nested but approved it anyway

## Fix

- let `Write`/`Edit` proceed without Gate only when the selected capability-confined root exactly matches the active Keeper playground root
- retain existing root device/inode verification, capability traversal, endpoint semantics, symlink checks, and atomic publication
- retain Gate for explicit allowed roots and project/repository writes
- leave general `Execute` policy unchanged
- tell the model that `Write` creates missing parents, so `Execute mkdir` is unnecessary
- hard-cut stale test fixture fields rather than adding migration compatibility

## Validation

```text
scripts/dune-local.sh build test/test_keeper_fs_edit_containment.exe
_build/default/test/test_keeper_fs_edit_containment.exe
```

4/4 passed:
- explicit root remains deferred
- Keeper playground write succeeds without Gate
- symlink escape is rejected
- parent traversal is rejected

Closes #26048
