### PR TITLE
fix(metrics): classify legacy tool records separately

### DIFF
--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -46,15 +46,26 @@ type persisted_record = {
   duration_ms : float;
 }
 
+type parsed_record =
+  | Current_record of persisted_record
+  | Legacy_success_record
+
 let parse_record (json : Yojson.Safe.t)
-  : (persisted_record, string) Result.t =
+  : (parsed_record, string) Result.t =
   let tool_name = Safe_ops.json_string_opt "tool_name" json in
   let disposition = Safe_ops.json_string_opt "disposition" json in
+  let legacy_success = Safe_ops.json_bool_opt "success" json in
   let duration_ms = Safe_ops.json_float_opt "duration_ms" json in
-  match tool_name, disposition, duration_ms with
-  | Some tool_name, Some disposition, Some duration_ms ->
+  match tool_name, disposition, legacy_success, duration_ms with
+  | Some tool_name, Some disposition, _, Some duration_ms ->
     Tool_result.unit_disposition_of_string disposition
-    |> Result.map (fun disposition -> { tool_name; disposition; duration_ms })
+    |> Result.map (fun disposition ->
+      Current_record { tool_name; disposition; duration_ms })
+  | Some _, None, Some _, Some _ ->
+    (* The legacy success bit cannot distinguish the current Deferred and
+       Failed dispositions. Keep the execution-disposition SSOT intact while
+       classifying these rows separately from malformed data. *)
+    Ok Legacy_success_record
   | _ ->
     let missing =
       [ ("tool_name", Option.is_none tool_name)
@@ -204,12 +215,13 @@ let start_flush_fiber ~sw ~clock ~base_path =
 let restore ~base_path : int =
   let store = get_or_create_store ~base_path in
   let count = ref 0 in
+  let legacy = ref 0 in
   let skipped = ref 0 in
   let first_skip_reason = ref None in
   (try
      Dated_jsonl.iter_all store (fun json ->
        match parse_record json with
-       | Ok r ->
+       | Ok (Current_record r) ->
          let result : Tool_result.result =
            match r.disposition with
            | Tool_result.Completed () ->
@@ -237,10 +249,15 @@ let restore ~base_path : int =
          in
          Tool_metrics.record result;
          Stdlib.incr count
+       | Ok Legacy_success_record -> Stdlib.incr legacy
        | Error reason ->
          Stdlib.incr skipped;
          if Option.is_none !first_skip_reason then
            first_skip_reason := Some reason);
+     if !legacy > 0 then
+       Log.Metrics.info
+         "tool_metrics_persist: ignored %d legacy success-only record(s); boolean success cannot reconstruct completed/deferred/failed disposition"
+         !legacy;
      if !skipped > 0 then
        Log.Metrics.warn
          "tool_metrics_persist: skipped %d malformed restore record(s)%s"

--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -91,7 +91,7 @@ let test_malformed_lines_skipped () =
     Fs_compat.mkdir_p month_dir;
     let day_file = Filename.concat month_dir
       (Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday) in
-    (* One valid row, one malformed row, and one pre-disposition legacy row. *)
+    (* One valid row, one malformed row, and two pre-disposition legacy rows. *)
     let valid_line = Yojson.Safe.to_string
       (`Assoc [
         ("tool_name", `String "good");
@@ -100,28 +100,43 @@ let test_malformed_lines_skipped () =
         ("ts", `Float 1000.0);
     ]) in
     let malformed_line = "{\"garbage\": true}" in
-    let legacy_line =
+    let legacy_success_line =
       Yojson.Safe.to_string
         (`Assoc
-          [ "tool_name", `String "legacy"
+          [ "tool_name", `String "legacy-success"
           ; "success", `Bool true
           ; "duration_ms", `Float 2.0
           ; "ts", `Float 1000.0
           ])
     in
+    let legacy_failure_line =
+      Yojson.Safe.to_string
+        (`Assoc
+          [ "tool_name", `String "legacy-failure"
+          ; "success", `Bool false
+          ; "duration_ms", `Float 3.0
+          ; "ts", `Float 1000.0
+          ])
+    in
     let content =
-      String.concat "\n" [ valid_line; malformed_line; legacy_line; "" ]
+      String.concat
+        "\n"
+        [ valid_line; malformed_line; legacy_success_line; legacy_failure_line; "" ]
     in
     Fs_compat.append_file day_file content;
     let n = P.restore ~base_path in
-    Alcotest.(check int) "only valid record" 1 n;
+    Alcotest.(check int) "only current record restored" 1 n;
     (match M.stats_for "good" with
      | Some s -> Alcotest.(check int) "good count" 1 s.call_count
      | None -> Alcotest.fail "expected good stats");
     Alcotest.(check bool)
-      "legacy success bool is not migrated"
+      "legacy success is intentionally not reconstructed"
       true
-      (Option.is_none (M.stats_for "legacy")))
+      (Option.is_none (M.stats_for "legacy-success"));
+    Alcotest.(check bool)
+      "legacy failure is intentionally not reconstructed"
+      true
+      (Option.is_none (M.stats_for "legacy-failure")))
 
 let test_reset_clears_cached_store () =
   with_tmp_dir (fun base_path ->


### PR DESCRIPTION
## Summary

- distinguish pre-disposition `{success: bool}` tool-metric rows from malformed JSONL
- preserve the current `completed` / `deferred` / `failed` disposition SSOT instead of inventing a lossy legacy mapping
- report intentionally ignored legacy rows as one informational startup event while retaining WARN for genuinely malformed records

## Live finding

On the 2026-07-28 `~/.masc` full-cycle runtime, startup reported 189,077 malformed restore records. The persisted corpus contains exactly:

- 189,077 legacy `success` rows
- 31,735 current `disposition` rows

The legacy boolean cannot distinguish current Deferred from Failed, so this PR does not reconstruct it. It removes the false corruption signal while keeping current-schema metrics exact.

## Validation

- `ocamlformat --check lib/tool_metrics_persist.ml test/test_tool_metrics_persist.ml`
- `scripts/dune-local.sh build test/test_tool_metrics_persist.exe`
- `_build/default/test/test_tool_metrics_persist.exe` (6/6)
- `git diff --check`
