### PR TITLE
fix(verification): persist producer evidence snapshots

### DIFF
--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -24,23 +24,17 @@ module Float = Stdlib.Float
 let masc_add_task_name =
   Tool_name.Task_name.to_string Tool_name.Task_name.Add_task
 
-let handoff_example_evidence_ref =
-  Filename.concat Common.masc_dirname "harness-evidence/proof.json"
-
 let handoff_context_description =
-  Printf.sprintf
-    "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class \
+  "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class \
      actions (submit_for_verification / done / release / cancel). On \
-     action='submit_for_verification' or 'done', 'evidence_refs' entries \
-     strengthen the completion review: an existing base-path artifact \
-     file/file:// URI, a commit hash present in the local git repo, or a %s \
-     trace/turn/receipt ref that resolves on disk. Entries must be non-empty \
-     strings, but the list itself is optional — the configured LLM completion \
+     action='submit_for_verification', every 'evidence_refs' entry must use \
+     'artifact:<producer-root-relative-path>' for a bounded file snapshot or \
+     'note:<text>' for narrative/commit/trace/URL evidence. Bare relative paths \
+     and absolute host paths are persisted as typed invalid references. The \
+     list itself is optional — the configured LLM completion \
      verdict decides the outcome (RFC-0337 withdrew the mandatory evidence \
      floor). Example: {\"summary\": \"tests green, local proof saved\", \
-     \"evidence_refs\": [\"%s\"]}."
-    Common.masc_dirname
-    handoff_example_evidence_ref
+     \"evidence_refs\": [\"artifact:artifacts/proof.json\"]}."
 
 let schemas : Masc_domain.tool_schema list = [
   {
@@ -293,7 +287,7 @@ Tip: Look for status='todo' tasks to claim.";
             ("evidence_refs", `Assoc [
               ("type", `String "array");
               ("items", `Assoc [ ("type", `String "string"); ("minLength", `Int 1) ]);
-              ("description", `String "References supplied as evidence for the task-completion evaluator or verifier. Entries must be non-empty strings at the transport boundary; their meaning and sufficiency are judged from task context, not by local reference-shape rules.");
+              ("description", `String "Typed verifier evidence. Use artifact:<producer-root-relative-path> for files or note:<text> for narrative, commit, trace, receipt, or URL evidence. Bare and absolute paths are invalid.");
             ]);
           ]);
           ("required", `List [`String "summary"]);

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -29,9 +29,9 @@ type submit_request_spec =
   ; board_title : string
   ; board_content : string
   ; evidence_fields : (string * Yojson.Safe.t) list
-      (* task-1664: [required_artifacts] / [submitted_evidence] JSON fields
-         spliced next to the flat [evidence_refs] so verifiers can tell the
-         contract's demanded artifacts apart from what the agent submitted. *)
+      (* task-1664: transient required/submitted role split for Board/SSE.
+         Request persistence replaces the raw [submitted_evidence] list with
+         its one typed submit-time snapshot SSOT. *)
   ; submitted_evidence : string list
   }
 
@@ -63,8 +63,9 @@ let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
     (match task.contract with
      | Some c -> c.completion_contract
      | None -> []) in
-  (* task-1664: derive the typed required/submitted split from the task (the
-     SSOT), and splice it next to the unchanged flat [evidence_refs] field. *)
+  (* task-1664: derive the required/submitted role split from the task SSOT.
+     The submitted strings remain transient here; [create_submit_request]
+     replaces them with the typed persisted snapshot. *)
   let verification_evidence =
     Masc_task_handlers.Tool_task_completion_review.concrete_verification_evidence
       ~submitted_evidence_refs:evidence_refs

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -134,7 +134,13 @@ let create_submit_request ~(config : Workspace.config)
   let output =
     match spec.output with
     | `Assoc fields ->
-      `Assoc (("submitted_evidence_snapshot", evidence_snapshot) :: fields)
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             if String.equal key "submitted_evidence"
+             then key, evidence_snapshot
+             else key, value)
+           fields)
     | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _)
       as impossible ->
       impossible

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -32,6 +32,7 @@ type submit_request_spec =
       (* task-1664: [required_artifacts] / [submitted_evidence] JSON fields
          spliced next to the flat [evidence_refs] so verifiers can tell the
          contract's demanded artifacts apart from what the agent submitted. *)
+  ; submitted_evidence : string list
   }
 
 let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
@@ -64,11 +65,14 @@ let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
      | None -> []) in
   (* task-1664: derive the typed required/submitted split from the task (the
      SSOT), and splice it next to the unchanged flat [evidence_refs] field. *)
+  let verification_evidence =
+    Masc_task_handlers.Tool_task_completion_review.concrete_verification_evidence
+      ~submitted_evidence_refs:evidence_refs
+      task
+  in
   let evidence_fields =
     Masc_task_handlers.Tool_task_completion_review.verification_evidence_fields
-      (Masc_task_handlers.Tool_task_completion_review.concrete_verification_evidence
-         ~submitted_evidence_refs:evidence_refs
-         task)
+      verification_evidence
   in
   let output =
     `Assoc
@@ -89,6 +93,7 @@ let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
   ; board_title
   ; board_content
   ; evidence_fields
+  ; submitted_evidence = verification_evidence.submitted_evidence
   }
 
 let warn_contract_gap (task : Masc_domain.task) =
@@ -120,9 +125,23 @@ let create_submit_request ~(config : Workspace.config)
   let base_path = config.Workspace.base_path in
   warn_contract_gap task;
   let spec = submit_request_spec ~config ~task ~assignee ~evidence_refs in
+  let evidence_snapshot =
+    Workspace_verification_store.snapshot_submitted_evidence_json
+      ~base_path
+      ~worker:assignee
+      spec.submitted_evidence
+  in
+  let output =
+    match spec.output with
+    | `Assoc fields ->
+      `Assoc (("submitted_evidence_snapshot", evidence_snapshot) :: fields)
+    | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _)
+      as impossible ->
+      impossible
+  in
   match
     Verification.create_request ~base_path ~task_id:task.id ~request_id:verification_id
-      ~output:spec.output ~criteria:spec.criteria ~worker:assignee ()
+      ~output ~criteria:spec.criteria ~worker:assignee ()
   with
   | Ok _ -> Ok ()
   | Error e ->

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -416,10 +416,10 @@ let add_verification_evidence_projection
         | Workspace_verification_store.Evidence_note note ->
           Printf.bprintf buf "      - note: %s\n" note
         | Workspace_verification_store.Evidence_artifact
-            { reference; content; bytes; truncated; sha256 } ->
+            { reference; content; bytes; truncated; content_sha256 } ->
           Printf.bprintf buf
-            "      - artifact: %s bytes=%d truncated=%b sha256=%s content=untrusted_evidence\n"
-            reference bytes truncated sha256;
+            "      - artifact: %s bytes=%d truncated=%b content_sha256=%s content=untrusted_evidence\n"
+            reference bytes truncated content_sha256;
           add_indented_evidence_content buf content
         | Workspace_verification_store.Evidence_artifact_unreadable
             { reference; reason } ->

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -416,10 +416,10 @@ let add_verification_evidence_projection
         | Workspace_verification_store.Evidence_note note ->
           Printf.bprintf buf "      - note: %s\n" note
         | Workspace_verification_store.Evidence_artifact
-            { reference; content; bytes; truncated } ->
+            { reference; content; bytes; truncated; sha256 } ->
           Printf.bprintf buf
-            "      - artifact: %s bytes=%d truncated=%b content=untrusted_evidence\n"
-            reference bytes truncated;
+            "      - artifact: %s bytes=%d truncated=%b sha256=%s content=untrusted_evidence\n"
+            reference bytes truncated sha256;
           add_indented_evidence_content buf content
         | Workspace_verification_store.Evidence_artifact_unreadable
             { reference; reason } ->
@@ -428,6 +428,44 @@ let add_verification_evidence_projection
             reference
             (Workspace_verification_store.evidence_read_failure_to_string reason))
       items
+
+let verification_evidence_projection config ~viewer ~(task : task) =
+  match task.task_status with
+  | Masc_domain.AwaitingVerification
+      { assignee = task_worker; verification_id; phase; _ } ->
+    let buf = Buffer.create 256 in
+    let task_verifier =
+      match phase with
+      | Masc_domain.Awaiting_verifier -> None
+      | Masc_domain.Verifier_assigned { verifier } -> Some verifier
+    in
+    add_verification_evidence_projection
+      buf
+      config
+      ~viewer
+      ~task_id:task.id
+      ~task_worker
+      ~task_verifier
+      verification_id;
+    (match phase with
+     | Masc_domain.Awaiting_verifier ->
+       Printf.bprintf buf
+         "   └─ ACTION: keeper_task_claim task_id=%s; do not Read producer \
+          paths; claim first to receive the typed submitted_evidence snapshot\n"
+         task.id
+     | Masc_domain.Verifier_assigned { verifier }
+       when not (Workspace_task_classify.same_task_actor config verifier viewer) ->
+       Printf.bprintf buf
+         "   └─ assigned_verifier=%s ACTION: skip; do not Read producer paths\n"
+         verifier
+     | Masc_domain.Verifier_assigned _ -> ());
+    Some (Buffer.contents buf)
+  | Masc_domain.Todo
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ ->
+    None
 
 (** List tasks *)
 let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status
@@ -480,26 +518,9 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status
              "   └─ verification_request=%s evidence=metadata_only\n"
              verification_id
          | Some viewer ->
-           let task_verifier =
-             match phase with
-             | Masc_domain.Awaiting_verifier -> None
-             | Masc_domain.Verifier_assigned { verifier } -> Some verifier
-           in
-           add_verification_evidence_projection
-             buf config ~viewer ~task_id:task.id ~task_worker ~task_verifier verification_id;
-           (match phase with
-            | Masc_domain.Awaiting_verifier ->
-              Printf.bprintf buf
-                "   └─ ACTION: keeper_task_claim task_id=%s; do not Read producer \
-                 paths; claim first to receive the typed submitted_evidence snapshot\n"
-                task.id
-            | Masc_domain.Verifier_assigned { verifier }
-              when not
-                     (Workspace_task_classify.same_task_actor config verifier viewer) ->
-              Printf.bprintf buf
-                "   └─ assigned_verifier=%s ACTION: skip; do not Read producer paths\n"
-                verifier
-            | Masc_domain.Verifier_assigned _ -> ()))
+           Option.iter
+             (Buffer.add_string buf)
+             (verification_evidence_projection config ~viewer ~task))
       | Masc_domain.Todo
       | Masc_domain.Claimed _
       | Masc_domain.InProgress _

--- a/lib/workspace/workspace_query.mli
+++ b/lib/workspace/workspace_query.mli
@@ -89,6 +89,15 @@ val list_tasks :
     a bounded read-only projection of the request's submitted evidence.
     Other callers receive request metadata only. *)
 
+val verification_evidence_projection :
+  config ->
+  viewer:string ->
+  task:Masc_domain.task ->
+  string option
+(** Return the same persisted verification evidence projection used by
+    [list_tasks] for one AwaitingVerification task. Claim responses use this
+    after the task-phase verifier binding commits. *)
+
 (** Return recent messages as a formatted string. *)
 val get_messages : config -> since_seq:int -> limit:int -> string
 

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -220,9 +220,20 @@ let claim_task_r config ~agent_name ~task_id ()
                ; "task", `String task_id
                ; "ts", `String (now_iso ())
                ]);
+           let evidence_projection =
+             Workspace_query.verification_evidence_projection
+               config
+               ~viewer:agent_name
+               ~task:claimed_task
+             |> Option.value ~default:""
+           in
            Ok
              (`New_claim
-               (Printf.sprintf "%s assigned as verifier for %s" agent_name task_id))
+               (Printf.sprintf
+                  "%s assigned as verifier for %s\n%s"
+                  agent_name
+                  task_id
+                  evidence_projection))
          | `Claimed_ok ->
            let claimed_task =
              List.find (fun (t : Masc_domain.task) -> String.equal t.id task_id) new_tasks

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -221,11 +221,14 @@ let claim_task_r config ~agent_name ~task_id ()
                ; "ts", `String (now_iso ())
                ]);
            let evidence_projection =
-             Workspace_query.verification_evidence_projection
-               config
-               ~viewer:agent_name
-               ~task:claimed_task
-             |> Option.value ~default:""
+             match
+               Workspace_query.verification_evidence_projection
+                 config
+                 ~viewer:agent_name
+                 ~task:claimed_task
+             with
+             | Some projection -> projection
+             | None -> ""
            in
            Ok
              (`New_claim

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -228,7 +228,14 @@ let claim_task_r config ~agent_name ~task_id ()
                  ~task:claimed_task
              with
              | Some projection -> projection
-             | None -> ""
+             | None ->
+               Log.Task.error
+                 ~keeper_name:agent_name
+                 "verification claim committed without an evidence projection (task=%s)"
+                 task_id;
+               Printf.sprintf
+                 "verification_request projection unavailable after assignment for %s; ACTION: stop and report this invariant failure"
+                 task_id
            in
            Ok
              (`New_claim

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -20,6 +20,7 @@ type evidence_read_failure =
   | Evidence_missing
   | Evidence_not_regular_file
   | Evidence_outside_worker_playground
+  | Evidence_invalid_reference
   | Evidence_invalid_utf8
   | Evidence_symbolic_link
   | Evidence_changed_during_read
@@ -32,6 +33,7 @@ type submitted_evidence_item =
       ; content : string
       ; bytes : int
       ; truncated : bool
+      ; sha256 : string
       }
   | Evidence_artifact_unreadable of
       { reference : string
@@ -56,10 +58,123 @@ let evidence_read_failure_to_string = function
   | Evidence_missing -> "missing"
   | Evidence_not_regular_file -> "not_regular_file"
   | Evidence_outside_worker_playground -> "outside_worker_playground"
+  | Evidence_invalid_reference -> "invalid_reference"
   | Evidence_invalid_utf8 -> "invalid_utf8"
   | Evidence_symbolic_link -> "symbolic_link"
   | Evidence_changed_during_read -> "changed_during_read"
   | Evidence_read_error detail -> "read_error:" ^ detail
+
+let evidence_read_failure_of_string = function
+  | "missing" -> Ok Evidence_missing
+  | "not_regular_file" -> Ok Evidence_not_regular_file
+  | "outside_worker_playground" -> Ok Evidence_outside_worker_playground
+  | "invalid_reference" -> Ok Evidence_invalid_reference
+  | "invalid_utf8" -> Ok Evidence_invalid_utf8
+  | "symbolic_link" -> Ok Evidence_symbolic_link
+  | "changed_during_read" -> Ok Evidence_changed_during_read
+  | raw when String.starts_with ~prefix:"read_error:" raw ->
+    Ok
+      (Evidence_read_error
+         (String.sub raw 11 (String.length raw - 11)))
+  | raw -> Error (Printf.sprintf "unknown evidence read failure %S" raw)
+
+let sha256 content =
+  Digestif.SHA256.(digest_string content |> to_hex)
+
+let submitted_evidence_item_to_yojson = function
+  | Evidence_note note ->
+    `Assoc [ "kind", `String "note"; "content", `String note ]
+  | Evidence_artifact { reference; content; bytes; truncated; sha256 } ->
+    `Assoc
+      [ "kind", `String "artifact"
+      ; "reference", `String reference
+      ; "content", `String content
+      ; "bytes", `Int bytes
+      ; "truncated", `Bool truncated
+      ; "sha256", `String sha256
+      ]
+  | Evidence_artifact_unreadable { reference; reason } ->
+    `Assoc
+      [ "kind", `String "artifact_unreadable"
+      ; "reference", `String reference
+      ; "reason", `String (evidence_read_failure_to_string reason)
+      ]
+
+let submitted_evidence_item_of_yojson = function
+  | `Assoc fields ->
+    let string_field key =
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Ok value
+      | Some value ->
+        Error
+          (Printf.sprintf
+             "submitted evidence snapshot field %s must be a string, got %s"
+             key
+             (Json_util.excerpt value))
+      | None ->
+        Error
+          (Printf.sprintf
+             "submitted evidence snapshot is missing string field %s"
+             key)
+    in
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "note") ->
+       Result.map (fun note -> Evidence_note note) (string_field "content")
+     | Some (`String "artifact") ->
+       let open Result.Syntax in
+       let* reference = string_field "reference" in
+       let* content = string_field "content" in
+       let* expected_sha256 = string_field "sha256" in
+       let* bytes =
+         match List.assoc_opt "bytes" fields with
+         | Some (`Int value) when value >= 0 -> Ok value
+         | Some value ->
+           Error
+             (Printf.sprintf
+                "submitted evidence snapshot bytes must be a non-negative integer, got %s"
+                (Json_util.excerpt value))
+         | None -> Error "submitted evidence snapshot is missing bytes"
+       in
+       let* truncated =
+         match List.assoc_opt "truncated" fields with
+         | Some (`Bool value) -> Ok value
+         | Some value ->
+           Error
+             (Printf.sprintf
+                "submitted evidence snapshot truncated must be a boolean, got %s"
+                (Json_util.excerpt value))
+         | None -> Error "submitted evidence snapshot is missing truncated"
+       in
+       if not (String.equal expected_sha256 (sha256 content))
+       then Error "submitted evidence snapshot sha256 does not match persisted content"
+       else
+         Ok
+           (Evidence_artifact
+              { reference
+              ; content
+              ; bytes
+              ; truncated
+              ; sha256 = expected_sha256
+              })
+     | Some (`String "artifact_unreadable") ->
+       let open Result.Syntax in
+       let* reference = string_field "reference" in
+       let* reason_raw = string_field "reason" in
+       let* reason = evidence_read_failure_of_string reason_raw in
+       Ok (Evidence_artifact_unreadable { reference; reason })
+     | Some (`String kind) ->
+       Error (Printf.sprintf "unknown submitted evidence snapshot kind %S" kind)
+     | Some value ->
+       Error
+         (Printf.sprintf
+            "submitted evidence snapshot kind must be a string, got %s"
+            (Json_util.excerpt value))
+     | None -> Error "submitted evidence snapshot is missing kind")
+  | value ->
+    Error
+      (Printf.sprintf
+         "submitted evidence snapshot item must be an object, got %s"
+         (Json_util.excerpt value))
 
 let project_root_of_base_path base_path =
   if Filename.basename base_path = Common.masc_dirname then
@@ -216,28 +331,27 @@ let load_request_header base_path req_id =
   else
     Error (Printf.sprintf "Verification %s not found" req_id)
 
-let submitted_evidence_of_request_json = function
+let submitted_evidence_snapshot_of_request_json = function
   | `Assoc fields ->
     (match List.assoc_opt "output" fields with
      | Some (`Assoc output_fields) ->
-       (match List.assoc_opt "submitted_evidence" output_fields with
+       (match List.assoc_opt "submitted_evidence_snapshot" output_fields with
         | Some (`List values) ->
           let rec collect acc = function
             | [] -> Ok (List.rev acc)
-            | `String value :: rest -> collect (value :: acc) rest
-            | value :: _ ->
-              Error
-                (Printf.sprintf
-                   "submitted_evidence must contain only strings, got %s"
-                   (Json_util.excerpt value))
+            | value :: rest ->
+              (match submitted_evidence_item_of_yojson value with
+               | Ok item -> collect (item :: acc) rest
+               | Error _ as error -> error)
           in
           collect [] values
         | Some other ->
           Error
             (Printf.sprintf
-               "submitted_evidence must be a list, got %s"
+               "submitted_evidence_snapshot must be a list, got %s"
                (Json_util.excerpt other))
-        | None -> Error "verification request output has no submitted_evidence")
+        | None ->
+          Error "verification request output has no submitted_evidence_snapshot")
      | Some other ->
        Error
          (Printf.sprintf
@@ -260,9 +374,9 @@ let load_request_for_evidence base_path req_id =
       match request_header_of_yojson json with
       | Error detail -> Error detail
       | Ok request ->
-        (match submitted_evidence_of_request_json json with
+        (match submitted_evidence_snapshot_of_request_json json with
          | Error detail -> Error detail
-         | Ok evidence -> Ok (request, evidence))
+         | Ok snapshot -> Ok (request, snapshot))
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
@@ -387,16 +501,91 @@ let inspect_artifact_reference ~base_path ~worker reference =
         | Error reason ->
           Evidence_artifact_unreadable { reference; reason }
         | Ok (content, bytes, truncated) ->
-          Evidence_artifact { reference; content; bytes; truncated })
+          Evidence_artifact
+            { reference
+            ; content
+            ; bytes
+            ; truncated
+            ; sha256 = sha256 content
+            })
      | Some _ | None ->
        Evidence_artifact_unreadable
          { reference; reason = Evidence_outside_worker_playground })
+
+let artifact_reference_prefix = "artifact:"
+let note_reference_prefix = "note:"
+
+let strip_prefix ~prefix value =
+  if String.starts_with ~prefix value
+  then
+    Some
+      (String.sub
+         value
+         (String.length prefix)
+         (String.length value - String.length prefix))
+  else None
+
+let valid_producer_relative_path path =
+  Filename.is_relative path
+  && not (String.equal path "")
+  && (String.split_on_char '/' path
+      |> List.for_all (fun segment ->
+        not
+          (String.equal segment ""
+           || String.equal segment "."
+           || String.equal segment "..")))
+
+let inspect_producer_relative_artifact ~base_path ~worker ~reference relative_path =
+  if not (valid_producer_relative_path relative_path)
+  then Evidence_artifact_unreadable { reference; reason = Evidence_invalid_reference }
+  else
+    let project_root = project_root_of_base_path base_path in
+    let ownership_root =
+      Keeper_sandbox_config.host_root_abs_of_agent
+        ~base_path:project_root
+        ~agent_name:worker
+      |> Env_config_core.strip_trailing_slashes
+    in
+    let target = Filename.concat ownership_root relative_path in
+    match read_regular_file_prefix ~ownership_root target with
+    | Error reason ->
+      Evidence_artifact_unreadable { reference; reason }
+    | Ok (content, bytes, truncated) ->
+      Evidence_artifact
+        { reference
+        ; content
+        ; bytes
+        ; truncated
+        ; sha256 = sha256 content
+        }
+
+let snapshot_submitted_evidence_item ~base_path ~worker reference =
+  match strip_prefix ~prefix:artifact_reference_prefix reference with
+  | Some relative_path ->
+    inspect_producer_relative_artifact
+      ~base_path
+      ~worker
+      ~reference
+      relative_path
+  | None ->
+    (match strip_prefix ~prefix:note_reference_prefix reference with
+     | Some note -> Evidence_note note
+     | None when Filename.is_relative reference -> Evidence_note reference
+     | None -> inspect_artifact_reference ~base_path ~worker reference)
+
+let snapshot_submitted_evidence_json ~base_path ~worker references =
+  `List
+    (List.map
+       (fun reference ->
+         snapshot_submitted_evidence_item ~base_path ~worker reference
+         |> submitted_evidence_item_to_yojson)
+       references)
 
 let inspect_submitted_evidence ~base_path ~request_id ~task_id ~task_worker
     ~task_verifier ~viewer =
   match load_request_for_evidence base_path request_id with
   | Error reason -> Evidence_unavailable { request_id; reason }
-  | Ok (request, evidence_refs) ->
+  | Ok (request, snapshot) ->
     (match request.status with
      | `Completed _ ->
        Evidence_unavailable
@@ -409,19 +598,7 @@ let inspect_submitted_evidence ~base_path ~request_id ~task_id ~task_worker
           when String.equal request.task_id task_id
                && String.equal request.worker task_worker
                && String.equal task_verifier viewer ->
-          let items =
-            List.map
-              (fun reference ->
-                 if Filename.is_relative reference then
-                   Evidence_note reference
-                 else
-                   inspect_artifact_reference
-                     ~base_path
-                     ~worker:request.worker
-                     reference)
-              evidence_refs
-          in
-          Evidence_available { request; items }
+          Evidence_available { request; items = snapshot }
         | Some _ | None -> Evidence_metadata_only { request; viewer }))
 
 let list_request_headers base_path =

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -33,7 +33,7 @@ type submitted_evidence_item =
       ; content : string
       ; bytes : int
       ; truncated : bool
-      ; sha256 : string
+      ; content_sha256 : string
       }
   | Evidence_artifact_unreadable of
       { reference : string
@@ -78,20 +78,21 @@ let evidence_read_failure_of_string = function
          (String.sub raw 11 (String.length raw - 11)))
   | raw -> Error (Printf.sprintf "unknown evidence read failure %S" raw)
 
-let sha256 content =
+let content_sha256 content =
   Digestif.SHA256.(digest_string content |> to_hex)
 
 let submitted_evidence_item_to_yojson = function
   | Evidence_note note ->
     `Assoc [ "kind", `String "note"; "content", `String note ]
-  | Evidence_artifact { reference; content; bytes; truncated; sha256 } ->
+  | Evidence_artifact
+      { reference; content; bytes; truncated; content_sha256 } ->
     `Assoc
       [ "kind", `String "artifact"
       ; "reference", `String reference
       ; "content", `String content
       ; "bytes", `Int bytes
       ; "truncated", `Bool truncated
-      ; "sha256", `String sha256
+      ; "content_sha256", `String content_sha256
       ]
   | Evidence_artifact_unreadable { reference; reason } ->
     `Assoc
@@ -124,7 +125,7 @@ let submitted_evidence_item_of_yojson = function
        let open Result.Syntax in
        let* reference = string_field "reference" in
        let* content = string_field "content" in
-       let* expected_sha256 = string_field "sha256" in
+       let* expected_content_sha256 = string_field "content_sha256" in
        let* bytes =
          match List.assoc_opt "bytes" fields with
          | Some (`Int value) when value >= 0 -> Ok value
@@ -145,8 +146,23 @@ let submitted_evidence_item_of_yojson = function
                 (Json_util.excerpt value))
          | None -> Error "submitted evidence snapshot is missing truncated"
        in
-       if not (String.equal expected_sha256 (sha256 content))
-       then Error "submitted evidence snapshot sha256 does not match persisted content"
+       let content_bytes = String.length content in
+       if
+         not
+           (String.equal
+              expected_content_sha256
+              (content_sha256 content))
+       then
+         Error
+           "submitted evidence snapshot content_sha256 does not match persisted content"
+       else if truncated && bytes <= content_bytes
+       then
+         Error
+           "truncated submitted evidence snapshot must report more source bytes than persisted content"
+       else if (not truncated) && bytes <> content_bytes
+       then
+         Error
+           "non-truncated submitted evidence snapshot bytes must equal persisted content length"
        else
          Ok
            (Evidence_artifact
@@ -154,7 +170,7 @@ let submitted_evidence_item_of_yojson = function
               ; content
               ; bytes
               ; truncated
-              ; sha256 = expected_sha256
+              ; content_sha256 = expected_content_sha256
               })
      | Some (`String "artifact_unreadable") ->
        let open Result.Syntax in
@@ -335,7 +351,7 @@ let submitted_evidence_snapshot_of_request_json = function
   | `Assoc fields ->
     (match List.assoc_opt "output" fields with
      | Some (`Assoc output_fields) ->
-       (match List.assoc_opt "submitted_evidence_snapshot" output_fields with
+       (match List.assoc_opt "submitted_evidence" output_fields with
         | Some (`List values) ->
           let rec collect acc = function
             | [] -> Ok (List.rev acc)
@@ -348,10 +364,10 @@ let submitted_evidence_snapshot_of_request_json = function
         | Some other ->
           Error
             (Printf.sprintf
-               "submitted_evidence_snapshot must be a list, got %s"
+               "submitted_evidence must be a typed snapshot list, got %s"
                (Json_util.excerpt other))
         | None ->
-          Error "verification request output has no submitted_evidence_snapshot")
+          Error "verification request output has no submitted_evidence")
      | Some other ->
        Error
          (Printf.sprintf
@@ -462,56 +478,6 @@ let read_regular_file_prefix ~ownership_root path =
      | Utf8_incomplete_at _ | Utf8_invalid ->
        Error Evidence_invalid_utf8)
 
-let inspect_artifact_reference ~base_path ~worker reference =
-  let canonical_base =
-    try Ok (Unix.realpath (project_root_of_base_path base_path)) with
-    | Unix.Unix_error (Unix.ENOENT, _, _) -> Error Evidence_missing
-    | exn -> Error (Evidence_read_error (Printexc.to_string exn))
-  in
-  let canonical_target =
-    try Ok (Unix.realpath reference) with
-    | Unix.Unix_error (Unix.ENOENT, _, _) -> Error Evidence_missing
-    | exn -> Error (Evidence_read_error (Printexc.to_string exn))
-  in
-  match canonical_base, canonical_target with
-  | Error reason, _ | _, Error reason ->
-    Evidence_artifact_unreadable { reference; reason }
-  | Ok canonical_base, Ok canonical_target ->
-    (match
-       Playground_paths.parse_playground_file_path
-         ~base_path:canonical_base
-         ~abs_path:canonical_target
-     with
-     | Some parsed
-       when String.equal
-              parsed.Playground_paths.keeper_name
-              (Playground_paths.sanitize_keeper_name worker) ->
-       let relative_suffix = "/" ^ parsed.relative_path in
-       let ownership_root =
-         String.sub
-           canonical_target
-           0
-           (String.length canonical_target - String.length relative_suffix)
-       in
-       (match
-          read_regular_file_prefix
-            ~ownership_root
-            canonical_target
-        with
-        | Error reason ->
-          Evidence_artifact_unreadable { reference; reason }
-        | Ok (content, bytes, truncated) ->
-          Evidence_artifact
-            { reference
-            ; content
-            ; bytes
-            ; truncated
-            ; sha256 = sha256 content
-            })
-     | Some _ | None ->
-       Evidence_artifact_unreadable
-         { reference; reason = Evidence_outside_worker_playground })
-
 let artifact_reference_prefix = "artifact:"
 let note_reference_prefix = "note:"
 
@@ -556,7 +522,7 @@ let inspect_producer_relative_artifact ~base_path ~worker ~reference relative_pa
         ; content
         ; bytes
         ; truncated
-        ; sha256 = sha256 content
+        ; content_sha256 = content_sha256 content
         }
 
 let snapshot_submitted_evidence_item ~base_path ~worker reference =
@@ -569,9 +535,11 @@ let snapshot_submitted_evidence_item ~base_path ~worker reference =
       relative_path
   | None ->
     (match strip_prefix ~prefix:note_reference_prefix reference with
-     | Some note -> Evidence_note note
-     | None when Filename.is_relative reference -> Evidence_note reference
-     | None -> inspect_artifact_reference ~base_path ~worker reference)
+     | Some note when not (String.equal (String.trim note) "") ->
+       Evidence_note note
+     | Some _ | None ->
+       Evidence_artifact_unreadable
+         { reference; reason = Evidence_invalid_reference })
 
 let snapshot_submitted_evidence_json ~base_path ~worker references =
   `List

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -64,7 +64,7 @@ val snapshot_submitted_evidence_json :
   Yojson.Safe.t
 (** Materialize submitted evidence once at the producer's submit boundary.
     ["artifact:<relative-path>"] is rooted at the producer's declared sandbox;
-    absolute paths remain accepted only when contained by that same playground.
+    ["note:<text>"] preserves non-file evidence explicitly.
     [content_sha256] covers the bounded UTF-8 content persisted in the
     snapshot, not bytes omitted beyond the projection cap. Bare and absolute
     references are persisted as typed invalid references. *)

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -33,7 +33,7 @@ type submitted_evidence_item =
       ; content : string
       ; bytes : int
       ; truncated : bool
-      ; sha256 : string
+      ; content_sha256 : string
       }
   | Evidence_artifact_unreadable of
       { reference : string
@@ -65,8 +65,9 @@ val snapshot_submitted_evidence_json :
 (** Materialize submitted evidence once at the producer's submit boundary.
     ["artifact:<relative-path>"] is rooted at the producer's declared sandbox;
     absolute paths remain accepted only when contained by that same playground.
-    The artifact SHA-256 covers the bounded UTF-8 content persisted in the
-    snapshot, not bytes omitted beyond the projection cap. *)
+    [content_sha256] covers the bounded UTF-8 content persisted in the
+    snapshot, not bytes omitted beyond the projection cap. Bare and absolute
+    references are persisted as typed invalid references. *)
 val inspect_submitted_evidence :
   base_path:string ->
   request_id:string ->

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -20,6 +20,7 @@ type evidence_read_failure =
   | Evidence_missing
   | Evidence_not_regular_file
   | Evidence_outside_worker_playground
+  | Evidence_invalid_reference
   | Evidence_invalid_utf8
   | Evidence_symbolic_link
   | Evidence_changed_during_read
@@ -32,6 +33,7 @@ type submitted_evidence_item =
       ; content : string
       ; bytes : int
       ; truncated : bool
+      ; sha256 : string
       }
   | Evidence_artifact_unreadable of
       { reference : string
@@ -55,6 +57,16 @@ type submitted_evidence_access =
 val evidence_read_failure_to_string : evidence_read_failure -> string
 val evidence_read_failure_of_owned_read_failure :
   Fs_compat.owned_regular_file_read_failure -> evidence_read_failure
+val snapshot_submitted_evidence_json :
+  base_path:string ->
+  worker:string ->
+  string list ->
+  Yojson.Safe.t
+(** Materialize submitted evidence once at the producer's submit boundary.
+    ["artifact:<relative-path>"] is rooted at the producer's declared sandbox;
+    absolute paths remain accepted only when contained by that same playground.
+    The artifact SHA-256 covers the bounded UTF-8 content persisted in the
+    snapshot, not bytes omitted beyond the projection cap. *)
 val inspect_submitted_evidence :
   base_path:string ->
   request_id:string ->

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -336,7 +336,24 @@ let test_list_requests_ignores_legacy_root_entries () =
       (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error))
 
 let create_evidence_request ~base_path ~request_id ~artifact_path =
-  let submitted_evidence = [ artifact_path; "executor summary" ] in
+  let profile_path =
+    Keeper_sandbox_config.keeper_toml_path
+      ~base_path
+      ~agent_name:"keeper-executor-agent"
+  in
+  Fs_compat.mkdir_p (Filename.dirname profile_path);
+  Fs_compat.save_file profile_path "[keeper]\nsandbox_profile = \"docker\"\n";
+  let submitted_evidence =
+    match
+      Playground_paths.parse_playground_file_path
+        ~base_path
+        ~abs_path:artifact_path
+    with
+    | Some { keeper_name = "executor"; relative_path } ->
+      [ "artifact:" ^ relative_path; "note:executor summary" ]
+    | Some _ | None ->
+      [ "artifact:../outside-worker-playground"; "note:executor summary" ]
+  in
   let evidence_snapshot =
     VS.snapshot_submitted_evidence_json
       ~base_path
@@ -350,10 +367,7 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
       ~task_id:"task-001"
       ~output:
         (`Assoc
-            [ ( "submitted_evidence"
-              , `List (List.map (fun value -> `String value) submitted_evidence) )
-            ; "submitted_evidence_snapshot", evidence_snapshot
-            ])
+            [ "submitted_evidence", evidence_snapshot ])
       ~criteria:[ V.Custom "inspect artifact" ]
       ~worker:"keeper-executor-agent"
       ()
@@ -492,7 +506,7 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
             VS.Evidence_artifact
               { reference = "artifact:artifacts/proof.txt"
               ; content = "docker-relative-proof"
-              ; sha256
+              ; content_sha256
               ; _
               }
             :: VS.Evidence_note "executor summary"
@@ -502,7 +516,7 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
       Alcotest.(check string)
         "snapshot hash covers persisted bounded content"
         Digestif.SHA256.(digest_string "docker-relative-proof" |> to_hex)
-        sha256
+        content_sha256
     | _ ->
       (match
          inspect_evidence
@@ -661,6 +675,62 @@ let test_submit_snapshot_rejects_relative_traversal_and_symlink_escape () =
           Alcotest.fail
             "relative traversal and symlink escape must persist typed unreadable snapshots"))
 
+let test_submit_snapshot_rejects_bare_and_absolute_references () =
+  with_eio_temp_dir (fun base_path ->
+    write_keeper_profile
+      ~base_path
+      ~keeper_name:"keeper-executor-agent"
+      ~sandbox_profile:"docker";
+    let producer_root =
+      Keeper_sandbox_config.host_root_abs_of_agent
+        ~base_path
+        ~agent_name:"keeper-executor-agent"
+    in
+    Fs_compat.mkdir_p producer_root;
+    let absolute_path = Filename.concat producer_root "absolute.txt" in
+    Fs_compat.save_file absolute_path "must-not-be-read";
+    let request_id = "vrf-explicit-reference-hard-cut" in
+    let snapshot =
+      VS.snapshot_submitted_evidence_json
+        ~base_path
+        ~worker:"keeper-executor-agent"
+        [ "artifacts/bare.txt"; absolute_path ]
+    in
+    ignore
+      (match
+         V.create_request
+           ~base_path
+           ~request_id
+           ~task_id:"task-001"
+           ~output:(`Assoc [ "submitted_evidence", snapshot ])
+           ~criteria:[ V.Custom "inspect explicit refs" ]
+           ~worker:"keeper-executor-agent"
+           ()
+       with
+       | Ok request -> request
+       | Error detail -> Alcotest.fail detail);
+    match
+      inspect_evidence
+        ~base_path
+        ~request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
+        ~viewer:"keeper-verifier-agent"
+        ()
+    with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact_unreadable
+              { reason = VS.Evidence_invalid_reference; _ }
+            :: VS.Evidence_artifact_unreadable
+                 { reason = VS.Evidence_invalid_reference; _ }
+            :: []
+        ; _
+        } ->
+      ()
+    | _ ->
+      Alcotest.fail
+        "bare and absolute references must remain typed invalid without file reads")
+
 let test_submitted_evidence_inspection_rejects_cross_playground_path () =
   with_eio_temp_dir (fun base_path ->
     let other_dir =
@@ -684,7 +754,7 @@ let test_submitted_evidence_inspection_rejects_cross_playground_path () =
     | VS.Evidence_available
         { items =
             VS.Evidence_artifact_unreadable
-              { reason = VS.Evidence_outside_worker_playground; _ }
+              { reason = VS.Evidence_invalid_reference; _ }
             :: _
         ; _
         } ->
@@ -787,7 +857,7 @@ let test_submitted_evidence_rejects_symlink_escape_and_fifo () =
      | VS.Evidence_available
          { items =
              VS.Evidence_artifact_unreadable
-               { reason = VS.Evidence_outside_worker_playground; _ }
+               { reason = VS.Evidence_symbolic_link; _ }
              :: _
          ; _
          } ->
@@ -847,12 +917,10 @@ let test_submitted_evidence_requires_exact_task_assignment_identity () =
           ~output:
             (`Assoc
                 [ ( "submitted_evidence"
-                  , `List [ `String artifact_path ] )
-                ; ( "submitted_evidence_snapshot"
                   , VS.snapshot_submitted_evidence_json
                       ~base_path
                       ~worker:"keeper-executor-agent"
-                      [ artifact_path ] )
+                      [ "artifact:assignment.txt" ] )
                 ])
           ~criteria:[ V.Custom "inspect artifact" ]
           ~worker:"keeper-executor-agent"
@@ -1258,6 +1326,8 @@ let () =
         test_submit_snapshot_survives_mutation_deletion_and_verifier_cwd;
       Alcotest.test_case "submit snapshot rejects traversal and symlink escape" `Quick
         test_submit_snapshot_rejects_relative_traversal_and_symlink_escape;
+      Alcotest.test_case "submit snapshot rejects bare and absolute refs" `Quick
+        test_submit_snapshot_rejects_bare_and_absolute_references;
       Alcotest.test_case "submitted evidence rejects cross playground" `Quick
         test_submitted_evidence_inspection_rejects_cross_playground_path;
       Alcotest.test_case "submitted evidence bounded UTF-8" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -336,6 +336,13 @@ let test_list_requests_ignores_legacy_root_entries () =
       (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error))
 
 let create_evidence_request ~base_path ~request_id ~artifact_path =
+  let submitted_evidence = [ artifact_path; "executor summary" ] in
+  let evidence_snapshot =
+    VS.snapshot_submitted_evidence_json
+      ~base_path
+      ~worker:"keeper-executor-agent"
+      submitted_evidence
+  in
   match
     V.create_request
       ~base_path
@@ -344,10 +351,8 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
       ~output:
         (`Assoc
             [ ( "submitted_evidence"
-              , `List
-                  [ `String artifact_path
-                  ; `String "executor summary"
-                  ] )
+              , `List (List.map (fun value -> `String value) submitted_evidence) )
+            ; "submitted_evidence_snapshot", evidence_snapshot
             ])
       ~criteria:[ V.Custom "inspect artifact" ]
       ~worker:"keeper-executor-agent"
@@ -355,6 +360,44 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
   with
   | Ok request -> request
   | Error detail -> Alcotest.fail detail
+
+let write_keeper_profile ~base_path ~keeper_name ~sandbox_profile =
+  let path =
+    Keeper_sandbox_config.keeper_toml_path
+      ~base_path
+      ~agent_name:keeper_name
+  in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Fs_compat.save_file
+    path
+    (Printf.sprintf "[keeper]\nsandbox_profile = %S\n" sandbox_profile)
+
+let create_protocol_evidence_request ~base_path ~request_id ~evidence_refs =
+  let config = W.default_config base_path in
+  ignore (W.init config ~agent_name:None);
+  ignore
+    (W.add_task
+       config
+       ~title:"Produce typed verification evidence"
+       ~priority:1
+       ~description:"");
+  let task =
+    match (W.read_backlog config).tasks with
+    | [ task ] -> task
+    | tasks ->
+      Alcotest.failf "expected one task, got %d" (List.length tasks)
+  in
+  (match
+     VP.create_submit_request
+       ~config
+       ~task
+       ~assignee:"keeper-executor-agent"
+       ~verification_id:request_id
+       ~evidence_refs
+   with
+   | Ok () -> ()
+   | Error detail -> Alcotest.fail detail);
+  task
 
 let inspect_evidence ?(task_id = "task-001")
     ?(task_worker = "keeper-executor-agent") ~base_path ~request_id
@@ -409,6 +452,214 @@ let test_submitted_evidence_inspection_is_assigned_and_contained () =
     with
     | VS.Evidence_metadata_only _ -> ()
     | _ -> Alcotest.fail "non-assigned keeper must receive metadata only")
+
+let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () =
+  with_eio_temp_dir (fun base_path ->
+    write_keeper_profile
+      ~base_path
+      ~keeper_name:"keeper-executor-agent"
+      ~sandbox_profile:"docker";
+    let artifact_dir =
+      Filename.concat
+        (Keeper_sandbox_config.host_root_abs_of_agent
+           ~base_path
+           ~agent_name:"keeper-executor-agent")
+        "artifacts"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    Fs_compat.save_file
+      (Filename.concat artifact_dir "proof.txt")
+      "docker-relative-proof";
+    let request_id = "vrf-docker-relative-snapshot" in
+    let task =
+      create_protocol_evidence_request
+        ~base_path
+        ~request_id
+        ~evidence_refs:
+          [ "artifact:artifacts/proof.txt"; "note:executor summary" ]
+    in
+    match
+      inspect_evidence
+        ~task_id:task.id
+        ~base_path
+        ~request_id
+        ~task_verifier:(Some "keeper-verifier-agent")
+        ~viewer:"keeper-verifier-agent"
+        ()
+    with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact
+              { reference = "artifact:artifacts/proof.txt"
+              ; content = "docker-relative-proof"
+              ; sha256
+              ; _
+              }
+            :: VS.Evidence_note "executor summary"
+            :: []
+        ; _
+        } ->
+      Alcotest.(check string)
+        "snapshot hash covers persisted bounded content"
+        Digestif.SHA256.(digest_string "docker-relative-proof" |> to_hex)
+        sha256
+    | _ ->
+      (match
+         inspect_evidence
+           ~task_id:task.id
+           ~base_path
+           ~request_id
+           ~task_verifier:(Some "keeper-verifier-agent")
+           ~viewer:"keeper-verifier-agent"
+           ()
+       with
+       | VS.Evidence_available
+           { items =
+               VS.Evidence_artifact_unreadable { reason; _ } :: _
+           ; _
+           } ->
+         Alcotest.failf
+           "Docker-relative artifact snapshot unreadable: %s"
+           (VS.evidence_read_failure_to_string reason)
+       | VS.Evidence_available { items; _ } ->
+         Alcotest.failf
+           "expected explicit artifact and note snapshot, got %d items"
+           (List.length items)
+       | VS.Evidence_metadata_only _ ->
+         Alcotest.fail "assigned verifier unexpectedly received metadata only"
+       | VS.Evidence_unavailable { reason; _ } ->
+         Alcotest.failf "persisted evidence snapshot unavailable: %s" reason))
+
+let test_submit_snapshot_survives_mutation_deletion_and_verifier_cwd () =
+  with_eio_temp_dir (fun base_path ->
+    write_keeper_profile
+      ~base_path
+      ~keeper_name:"keeper-executor-agent"
+      ~sandbox_profile:"docker";
+    let artifact_dir =
+      Filename.concat
+        (Keeper_sandbox_config.host_root_abs_of_agent
+           ~base_path
+           ~agent_name:"keeper-executor-agent")
+        "artifacts"
+    in
+    Fs_compat.mkdir_p artifact_dir;
+    let artifact_path = Filename.concat artifact_dir "immutable.txt" in
+    Fs_compat.save_file artifact_path "submit-time-content";
+    let request_id = "vrf-immutable-snapshot" in
+    let task =
+      create_protocol_evidence_request
+        ~base_path
+        ~request_id
+        ~evidence_refs:[ "artifact:artifacts/immutable.txt" ]
+    in
+    Fs_compat.save_file artifact_path "mutated-after-submit";
+    Sys.remove artifact_path;
+    let verifier_cwd = Filename.concat base_path "verifier-cwd" in
+    Fs_compat.mkdir_p verifier_cwd;
+    let original_cwd = Sys.getcwd () in
+    Fun.protect
+      ~finally:(fun () -> Sys.chdir original_cwd)
+      (fun () ->
+        Sys.chdir verifier_cwd;
+        match
+          inspect_evidence
+            ~task_id:task.id
+            ~base_path
+            ~request_id
+            ~task_verifier:(Some "keeper-verifier-agent")
+            ~viewer:"keeper-verifier-agent"
+            ()
+        with
+        | VS.Evidence_available
+            { items =
+                VS.Evidence_artifact
+                  { content = "submit-time-content"; _ }
+                :: []
+            ; _
+            } ->
+          ()
+        | _ ->
+          (match
+             inspect_evidence
+               ~task_id:task.id
+               ~base_path
+               ~request_id
+               ~task_verifier:(Some "keeper-verifier-agent")
+               ~viewer:"keeper-verifier-agent"
+               ()
+           with
+           | VS.Evidence_available
+               { items =
+                   VS.Evidence_artifact_unreadable { reason; _ } :: _
+               ; _
+               } ->
+             Alcotest.failf
+               "immutable artifact snapshot unreadable: %s"
+               (VS.evidence_read_failure_to_string reason)
+           | VS.Evidence_available { items; _ } ->
+             Alcotest.failf
+               "expected one immutable artifact snapshot, got %d items"
+               (List.length items)
+           | VS.Evidence_metadata_only _ ->
+             Alcotest.fail "assigned verifier unexpectedly received metadata only"
+           | VS.Evidence_unavailable { reason; _ } ->
+             Alcotest.failf "persisted evidence snapshot unavailable: %s" reason)))
+
+let test_submit_snapshot_rejects_relative_traversal_and_symlink_escape () =
+  with_eio_temp_dir (fun base_path ->
+    write_keeper_profile
+      ~base_path
+      ~keeper_name:"keeper-executor-agent"
+      ~sandbox_profile:"docker";
+    let producer_root =
+      Keeper_sandbox_config.host_root_abs_of_agent
+        ~base_path
+        ~agent_name:"keeper-executor-agent"
+    in
+    let artifact_dir = Filename.concat producer_root "artifacts" in
+    Fs_compat.mkdir_p artifact_dir;
+    let outside_path = Filename.concat base_path "outside-relative-secret.txt" in
+    Fs_compat.save_file outside_path "outside";
+    let symlink_path = Filename.concat artifact_dir "escape.txt" in
+    Unix.symlink outside_path symlink_path;
+    let request_id = "vrf-relative-boundary-snapshot" in
+    let task =
+      create_protocol_evidence_request
+        ~base_path
+        ~request_id
+        ~evidence_refs:
+          [ "artifact:../outside-relative-secret.txt"
+          ; "artifact:artifacts/escape.txt"
+          ]
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        try Unix.unlink symlink_path with
+        | Unix.Unix_error (Unix.ENOENT, _, _) -> ())
+      (fun () ->
+        match
+          inspect_evidence
+            ~task_id:task.id
+            ~base_path
+            ~request_id
+            ~task_verifier:(Some "keeper-verifier-agent")
+            ~viewer:"keeper-verifier-agent"
+            ()
+        with
+        | VS.Evidence_available
+            { items =
+                VS.Evidence_artifact_unreadable
+                  { reason = VS.Evidence_invalid_reference; _ }
+                :: VS.Evidence_artifact_unreadable
+                     { reason = VS.Evidence_symbolic_link; _ }
+                :: []
+            ; _
+            } ->
+          ()
+        | _ ->
+          Alcotest.fail
+            "relative traversal and symlink escape must persist typed unreadable snapshots"))
 
 let test_submitted_evidence_inspection_rejects_cross_playground_path () =
   with_eio_temp_dir (fun base_path ->
@@ -597,6 +848,11 @@ let test_submitted_evidence_requires_exact_task_assignment_identity () =
             (`Assoc
                 [ ( "submitted_evidence"
                   , `List [ `String artifact_path ] )
+                ; ( "submitted_evidence_snapshot"
+                  , VS.snapshot_submitted_evidence_json
+                      ~base_path
+                      ~worker:"keeper-executor-agent"
+                      [ artifact_path ] )
                 ])
           ~criteria:[ V.Custom "inspect artifact" ]
           ~worker:"keeper-executor-agent"
@@ -712,7 +968,11 @@ let test_keeper_task_projection_exposes_snapshot_only_to_assigned_verifier () =
     (match
        W.claim_task_r config ~agent_name:"keeper-verifier-agent" ~task_id:"task-001" ()
      with
-     | Ok _ -> ()
+     | Ok message ->
+       Alcotest.(check bool)
+         "claim response carries persisted snapshot"
+         true
+         (contains_substring message "full-cycle-evidence")
      | Error err ->
        Alcotest.fail
          ("verifier claim failed: " ^ Masc_domain.masc_error_to_string err));
@@ -992,6 +1252,12 @@ let () =
         test_list_requests_ignores_legacy_root_entries;
       Alcotest.test_case "submitted evidence assigned and contained" `Quick
         test_submitted_evidence_inspection_is_assigned_and_contained;
+      Alcotest.test_case "submit snapshot resolves Docker relative refs" `Quick
+        test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note;
+      Alcotest.test_case "submit snapshot is immutable and cwd-independent" `Quick
+        test_submit_snapshot_survives_mutation_deletion_and_verifier_cwd;
+      Alcotest.test_case "submit snapshot rejects traversal and symlink escape" `Quick
+        test_submit_snapshot_rejects_relative_traversal_and_symlink_escape;
       Alcotest.test_case "submitted evidence rejects cross playground" `Quick
         test_submitted_evidence_inspection_rejects_cross_playground_path;
       Alcotest.test_case "submitted evidence bounded UTF-8" `Quick


### PR DESCRIPTION
## Summary

- materialize explicit `artifact:<producer-root-relative-path>` and `note:<text>` evidence once at verification submit
- replace request `output.submitted_evidence` with that one typed snapshot SSOT; no parallel flat submitted list or snapshot field
- persist bounded UTF-8 content, source byte count, truncation flag, and `content_sha256` of the persisted bounded content
- resolve producer roots through the existing declared Keeper sandbox profile and persist typed invalid/unreadable items for traversal, symlinks, bare refs, absolute host paths, and ownership failures
- make assigned-verifier inspection parse only the persisted request snapshot, so producer mutation/deletion and verifier cwd cannot change evidence
- return the same persisted projection from verifier claim and `keeper_tasks_list`; a missing post-claim projection is logged and surfaced as an invariant failure

No new store, lease, settlement, nonce, migration path, compatibility branch, or arbitrary cross-sandbox `Read` is introduced.

Fixes #26052

## Validation

- rebased onto `origin/main` `273e0e12d5`
- `ocamlformat --check` on all changed OCaml files
- `git diff --check origin/main...HEAD`
- `bash scripts/dune-local.sh build test/test_verification.exe`
- `_build/default/test/test_verification.exe test '^storage$' '9-16'` (8/8)
- `_build/default/test/test_verification.exe test '^storage$' '18-20'` (3/3)

## Boundary

Top-level raw transition `notes` are not available at `Verification_protocol.create_submit_request` without widening hook signatures. Producers must encode narrative, commit, trace, receipt, or URL evidence explicitly as `note:<text>`; this PR does not introduce broad transition schema churn.