### PR TITLE
fix(keeper): bypass Gate for network-isolated Docker Execute

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -516,6 +516,7 @@ let handle_tool_execute_typed
             Keeper_gate.decide
               ?cycle_grant:gate_grant
               ~keeper_always_allow:(Option.value ~default:false meta.always_allow)
+              (* DET-OK: persisted optional policy; absence deterministically fails closed. *)
               gate_request
           with
           | Keeper_gate.Deferred { approval_id; reason } ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -40,6 +40,18 @@ let sandbox_target_label = function
   | Masc_exec.Sandbox_target.Docker { image; _ } -> "docker:" ^ image
 ;;
 
+let confined_docker_execute_is_internal
+      ~sandbox_profile
+      ~network_mode
+      ~sandbox_target
+  =
+  match sandbox_profile, network_mode, sandbox_target with
+  | Docker, Network_none, Masc_exec.Sandbox_target.Docker _ -> true
+  | (Local | Docker), (Network_none | Network_inherit),
+    (Masc_exec.Sandbox_target.Host | Masc_exec.Sandbox_target.Docker _) ->
+    false
+;;
+
 let execute_gate_input ~input ~cwd ~sandbox_profile ~sandbox_target =
   `Assoc
     [ "schema", `String "masc.keeper_gate.request.v1"
@@ -68,6 +80,7 @@ module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
   let typed_execute_response_cwd_json = typed_execute_response_cwd_json
   let execute_gate_input = execute_gate_input
+  let confined_docker_execute_is_internal = confined_docker_execute_is_internal
   let redact_execute_output ~base_path ~keeper_name ~stdout ~stderr =
     let redaction = execute_secret_redaction ~base_path ~keeper_name in
     redact_execute_output redaction ~stdout ~stderr
@@ -165,7 +178,7 @@ let handle_tool_execute_typed
         let timeout_sec = typed_input_timeout_sec input in
         let input = input_with_cwd cwd input in
         let in_playground = Keeper_tool_execute_path.in_playground ~root ~cwd ~meta in
-        let sandbox_profile, _sandbox_network_mode =
+        let sandbox_profile, sandbox_network_mode =
           Keeper_sandbox_runner.effective_sandbox_profile ~meta
         in
         let local_dispatch_sandbox ?(extra_fields = []) () =
@@ -295,33 +308,11 @@ let handle_tool_execute_typed
           ; continuation_channel
           }
         in
-        (match
-           Keeper_gate.decide
-             ?cycle_grant:gate_grant
-             ~keeper_always_allow:(Option.value ~default:false meta.always_allow)
-             gate_request
-         with
-         | Keeper_gate.Deferred { approval_id; reason } ->
-           Keeper_gate_deferred_payload.create
-             ~operation:"tool_execute"
-             ~approval_id
-             ~reason
-             ~context:(`Assoc typed_context_fields)
-             ()
-           |> Keeper_gate_deferred_payload.to_execution
-         | Keeper_gate.Unavailable reason ->
-           typed_error_json
-             ~extra_fields:
-               [ "error", `String "gate_unavailable"
-               ; "gate_reason"
-               , `String (Keeper_gate.unavailable_reason_to_string reason)
-               ]
-             "External effect was not executed because the Gate could not durably record its decision state. This Keeper remains active and may continue other work."
-         | Keeper_gate.Allow authorization ->
+        let dispatch_authorized authorization_source =
           Log.Keeper.info
             ~keeper_name:meta.name
             "external effect authorized operation=tool_execute source=%s"
-            (Keeper_gate.authorization_source_to_string authorization.source);
+            authorization_source;
           (* NDT-OK: wall clock is used only for elapsed telemetry, never for
              dispatch branching or policy decisions. *)
           let t0 = Unix.gettimeofday () in
@@ -513,6 +504,39 @@ let handle_tool_execute_typed
             if succeeded
             then Keeper_tool_execution.success payload
             else Keeper_tool_execution.failure payload
+        in
+        if
+          confined_docker_execute_is_internal
+            ~sandbox_profile
+            ~network_mode:sandbox_network_mode
+            ~sandbox_target:dispatch_sandbox
+        then dispatch_authorized "confined_docker_network_none"
+        else (
+          match
+            Keeper_gate.decide
+              ?cycle_grant:gate_grant
+              ~keeper_always_allow:(Option.value ~default:false meta.always_allow)
+              gate_request
+          with
+          | Keeper_gate.Deferred { approval_id; reason } ->
+            Keeper_gate_deferred_payload.create
+              ~operation:"tool_execute"
+              ~approval_id
+              ~reason
+              ~context:(`Assoc typed_context_fields)
+              ()
+            |> Keeper_gate_deferred_payload.to_execution
+          | Keeper_gate.Unavailable reason ->
+            typed_error_json
+              ~extra_fields:
+                [ "error", `String "gate_unavailable"
+                ; "gate_reason"
+                , `String (Keeper_gate.unavailable_reason_to_string reason)
+                ]
+              "External effect was not executed because the Gate could not durably record its decision state. This Keeper remains active and may continue other work."
+          | Keeper_gate.Allow authorization ->
+            dispatch_authorized
+              (Keeper_gate.authorization_source_to_string authorization.source)
         )))
 
 let handle_tool_execute_with_outcome

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -38,6 +38,11 @@ module For_testing : sig
     sandbox_profile:string ->
     sandbox_target:string ->
     Yojson.Safe.t
+  val confined_docker_execute_is_internal :
+    sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile ->
+    network_mode:Keeper_types_profile_sandbox.network_mode ->
+    sandbox_target:Masc_exec.Sandbox_target.t ->
+    bool
   val redact_execute_output :
     base_path:string ->
     keeper_name:string ->

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module KET = Masc.Keeper_tool_dispatch_runtime
 module KTE = Masc.Keeper_tool_execution
+module KTER = Masc.Keeper_tool_execute_runtime
 module KES = Masc.Keeper_tool_shared_runtime
 module KTD = Masc.Keeper_tool_descriptor
 module Workspace = Masc.Workspace
@@ -2279,6 +2280,45 @@ let test_manual_gate_defers_tool_execute_before_process () =
         Yojson.Safe.Util.(data |> member "gate" |> member "decision" |> to_string);
       check bool "Manual Gate starts no process" false (Sys.file_exists marker))
 
+let test_only_network_none_docker_execute_is_internal () =
+  let module Profile = Keeper_types_profile_sandbox in
+  let module Target = Masc_exec.Sandbox_target in
+  let runner
+        ~on_stdout_chunk:_
+        ~on_stderr_chunk:_
+        ~stdin_content:_
+        ~argv:_
+        ~env:_
+        ~cwd:_
+    =
+    Unix.WEXITED 0, "", ""
+  in
+  let docker = Target.docker ~image:"test-image" ~runner () in
+  let host = Target.host () in
+  let internal sandbox_profile network_mode sandbox_target =
+    KTER.For_testing.confined_docker_execute_is_internal
+      ~sandbox_profile
+      ~network_mode
+      ~sandbox_target
+  in
+  check bool
+    "network-none Docker dispatch is internal"
+    true
+    (internal Profile.Docker Profile.Network_none docker);
+  check bool
+    "network-inherit Docker dispatch still uses Gate"
+    false
+    (internal Profile.Docker Profile.Network_inherit docker);
+  check bool
+    "Docker profile local fallback still uses Gate"
+    false
+    (internal Profile.Docker Profile.Network_none host);
+  check bool
+    "Local dispatch still uses Gate"
+    false
+    (internal Profile.Local Profile.Network_inherit host)
+;;
+
 let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
   with_exec_fixture "tool_execute_raw_cmd_requires_typed_shell_ir"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -3160,6 +3200,8 @@ let () =
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "Manual Gate defers tool_execute before process" `Quick
         test_manual_gate_defers_tool_execute_before_process;
+      test_case "only network-none Docker execute is internal" `Quick
+        test_only_network_none_docker_execute_is_internal;
       test_case "tool_execute raw cmd requires typed Shell IR" `Quick
         test_tool_execute_raw_cmd_requires_typed_shell_ir;
       test_case "OAS handler threads Eio context to keeper dispatch" `Quick


### PR DESCRIPTION
## Summary
- treat typed `tool_execute` as an internal effect only when the effective Keeper profile is Docker, the network mode is `none`, and dispatch resolved to an actual Docker target
- preserve Gate behavior for network-inheriting Docker, Docker-to-Host fallback, and Local execution
- add a focused typed boundary test for all four cases

This removes an approval dependency that stranded otherwise confined Keeper Turns when Auto Judge had a transient exact-lane failure.

Closes #26058

## Validation
- `scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe`
- `_build/default/test/test_keeper_tool_dispatch_runtime.exe test '^execute_keeper_tool_call_with_outcome$' 24 --color=never --show-errors`
- `git diff --check`

The repository-wide fixture executable is not claimed here: unrelated cases in the live workspace reject stale Keeper identities. The new isolated case passes and PR CI remains the broad authority.
