### PR TITLE
fix(task): keep peer verification strict-only

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -303,7 +303,8 @@ let persist_scheduled_work_terminal ~ctx ~keeper_name ~settlement stimuli =
          | Keeper_event_queue.Connector_attention _
          | Keeper_event_queue.Hitl_resolved _
          | Keeper_event_queue.Manual_compaction_requested
-         | Keeper_event_queue.Goal_assigned _ ->
+         | Keeper_event_queue.Goal_assigned _
+         | Keeper_event_queue.Goal_reconciliation_ready _ ->
            loop rest)
     in
     loop stimuli

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -470,7 +470,8 @@ let heartbeat_event_intake
             | Keeper_world_observation.Fusion_completed
             | Keeper_world_observation.Bg_completed
             | Keeper_world_observation.External_attention
-            | Keeper_world_observation.Goal_assigned ->
+            | Keeper_world_observation.Goal_assigned
+            | Keeper_world_observation.Goal_reconciliation_ready ->
               Log.Keeper.info
                 "turn entry: promoted queued observation post_id=%s keeper=%s"
                 event.Keeper_world_observation.post_id

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -790,12 +790,21 @@ let handle_keeper_task_tool_with_outcome
              message)
       | Ok evidence_refs ->
       (* Map keeper vocabulary (`result`) onto MASC domain typed
-         handoff_context.summary and submit the evidence to the ordinary
-         verifier workflow instead of completing through an internal lane. *)
+         handoff_context.summary. Strict contracts enter the verifier workflow;
+         advisory/default tasks complete directly through the workspace FSM. *)
+      let action =
+        Workspace.get_tasks_raw config
+        |> List.find_opt (fun (task : Masc_domain.task) ->
+          String.equal task.id task_id)
+        |> Option.exists Masc_domain.task_requires_verification
+        |> function
+        | true -> "submit_for_verification"
+        | false -> "done"
+      in
       let args_for_transition =
         [
           "task_id", `String task_id;
-          "action", `String "submit_for_verification";
+          "action", `String action;
           "notes", `String result_text;
           ( "handoff_context",
             `Assoc

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -35,7 +35,11 @@ let task_state_hint ~(config : Workspace.config) ~(meta : Keeper_meta_contract.k
         | None -> Printf.sprintf "Current task: %s (not found in backlog)" task_id
         | Some task ->
           let status = Masc_domain.task_status_to_string task.task_status in
-          let hint = Workspace_task_classify.next_actions_hint task.task_status in
+          let hint =
+            Workspace_task_classify.next_actions_hint
+              ~requires_verification:(Masc_domain.task_requires_verification task)
+              task.task_status
+          in
           Printf.sprintf "Current task: %s, status=%s%s" task_id status hint))
 ;;
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -55,7 +55,8 @@ let is_board_activity_event (event : pending_board_event) =
   | Fusion_completed
   | Bg_completed
   | External_attention
-  | Goal_assigned -> true
+  | Goal_assigned
+  | Goal_reconciliation_ready -> true
 ;;
 
 type scheduled_automation_item =

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -399,31 +399,6 @@ and handle_transition
       ~alternatives
       message
   | None ->
-  match client_side_transition_gate_error ~task_opt ~action ~action_s with
-  | Some (Masc_domain.Task_error.InvalidState message as err) ->
-    log_task_transition_failed ~agent_name:ctx.agent_name (Masc_domain.Task err);
-    workflow_rejection_result
-      ~tool_name
-      ~start_time
-      ~rule_id:"task_transition_invalid_state"
-      ~tool_suggestion:task_list_name
-      ~hint:
-        "The requested lifecycle transition is not valid for the task's current \
-         state. Inspect the task status and use a valid next action instead of \
-         retrying the same transition."
-      ~scope_policy:"observe"
-      ~recoverable:false
-      ~alternatives:[ task_list_name; "masc_transition" ]
-      ~extra_fields:
-        [ "task_id", `String task_id
-        ; "action", `String action_s
-        ; "requested_agent", `String ctx.agent_name
-        ]
-      (Printf.sprintf "Invalid task state: %s" message)
-  | Some err ->
-    log_task_transition_failed ~agent_name:ctx.agent_name (Masc_domain.Task err);
-    result_to_response ~tool_name ~start_time (Error (Masc_domain.Task err))
-  | None ->
   match handoff_context with
   | Error error ->
       (* RFC-0189: handoff_context parse error — caller passed
@@ -645,9 +620,30 @@ and handle_transition
           ~success:false
           ~reason:(Some "task_cancelled");
         ()
-   | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
+  | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
             | Masc_domain.Reject_verification | Masc_domain.Release)
-   | Error _, _ -> ());
+  | Error _, _ -> ());
+  let transition_result_to_response = function
+    | Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState message)) ->
+      workflow_rejection_result
+        ~tool_name
+        ~start_time
+        ~rule_id:"task_transition_invalid_state"
+        ~tool_suggestion:task_list_name
+        ~hint:
+          "The lifecycle decision rejected this transition. Follow the exact \
+           remediation in the error instead of retrying the same transition."
+        ~scope_policy:"observe"
+        ~recoverable:false
+        ~alternatives:[ task_list_name; "masc_transition" ]
+        ~extra_fields:
+          [ "task_id", `String task_id
+          ; "action", `String action_s
+          ; "requested_agent", `String ctx.agent_name
+          ]
+        (Printf.sprintf "Invalid task state: %s" message)
+    | result -> result_to_response ~tool_name ~start_time result
+  in
   match result, task_list_projection with
   | Ok message, Tool_capability_projection.Keeper_tasks_list
     when not task_was_done_before ->
@@ -663,13 +659,13 @@ and handle_transition
               ; "next_action", next_action
               ])
          ()
-     | None -> result_to_response ~tool_name ~start_time result)
+     | None -> transition_result_to_response result)
   | Ok _, Tool_capability_projection.Keeper_tasks_list ->
-    result_to_response ~tool_name ~start_time result
+    transition_result_to_response result
   | Error _, Tool_capability_projection.Keeper_tasks_list ->
-    result_to_response ~tool_name ~start_time result
+    transition_result_to_response result
   | (Ok _ | Error _), Tool_capability_projection.External_masc_tasks ->
-    result_to_response ~tool_name ~start_time result
+    transition_result_to_response result
 
 let handle_update_priority ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -453,8 +453,33 @@ and handle_transition
             let ts = Masc_domain.parse_iso8601 ~default_time claimed_at in
             let collabs = if not (String.equal assignee "") && not (String.equal assignee ctx.agent_name) then [assignee] else [] in
             (ts, collabs)
+        | Masc_domain.AwaitingVerification { submitted_at; assignee; _ } ->
+            let ts = Masc_domain.parse_iso8601 ~default_time submitted_at in
+            let collabs =
+              if
+                not (String.equal assignee "")
+                && not (String.equal assignee ctx.agent_name)
+              then [ assignee ]
+              else []
+            in
+            (ts, collabs)
         | _ -> (default_time, []))
     | None -> (default_time, [])
+  in
+  let completion_owner =
+    match task_opt with
+    | Some task ->
+      Option.value
+        ~default:ctx.agent_name
+        (Masc_domain.task_assignee_of_status task.task_status)
+    | None -> ctx.agent_name
+  in
+  let completion_collaborators =
+    if
+      (=) action Masc_domain.Approve_verification
+      && not (String.equal completion_owner ctx.agent_name)
+    then [ ctx.agent_name ]
+    else collaborators_from_task
   in
   let prepare_verification_request =
     match action with
@@ -567,14 +592,9 @@ and handle_transition
                "approve_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
-             if String.equal (String.trim notes) "" then
-               task_log_warn ~task_id
-                 "approve_verification for task %s rejected: empty justification (rubber-stamp guard)"
-                 task_id
-             else
-               (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
-                 ~task_id ~verifier:ctx.agent_name ~verification_id
-                 ~decision:(`Approve notes))
+             (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
+               ~task_id ~verifier:ctx.agent_name ~verification_id
+               ~decision:(`Approve notes))
         | Masc_domain.Reject_verification ->
           let reason = if not (String.equal notes "") then notes else reason in
           (match verification_id_before with
@@ -583,33 +603,28 @@ and handle_transition
                "reject_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
-             if String.equal (String.trim reason) "" then
-               task_log_warn ~task_id
-                 "reject_verification for task %s rejected: empty justification (unsubstantiated guard)"
-                 task_id
-             else
-               (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
-                 ~task_id ~verifier:ctx.agent_name ~verification_id
-                 ~decision:(`Reject reason))
+             (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
+               ~task_id ~verifier:ctx.agent_name ~verification_id
+               ~decision:(`Reject reason))
         | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel | Masc_domain.Release -> ())
    | Error err ->
        log_task_transition_failed ~agent_name:ctx.agent_name err);
   (* Record metrics *)
   (match result, action with
-   | Ok _, Masc_domain.Done_action ->
+   | Ok _, (Masc_domain.Done_action | Masc_domain.Approve_verification) ->
        (Atomic.get Workspace_hooks.record_task_metric_fn)
          ctx.config
-         ~agent_id:ctx.agent_name
+         ~agent_id:completion_owner
          ~task_id
          ~started_at:started_at_actual
          ~completed_at:(Some (Time_compat.now ()))
          ~success:true
          ~error_message:None
-         ~collaborators:collaborators_from_task
+         ~collaborators:completion_collaborators
          ~handoff_from:None
          ~handoff_to:None;
         (Atomic.get Workspace_hooks.record_thompson_result_fn)
-          ~agent_name:ctx.agent_name
+          ~agent_name:completion_owner
           ~success:true
           ~reason:None;
         ()
@@ -631,7 +646,7 @@ and handle_transition
           ~reason:(Some "task_cancelled");
         ()
    | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
-            | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
+            | Masc_domain.Reject_verification | Masc_domain.Release)
    | Error _, _ -> ());
   match result, task_list_projection with
   | Ok message, Tool_capability_projection.Keeper_tasks_list

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -100,28 +100,6 @@ let log_task_transition_failed ~agent_name err =
       task_agent_log_warn ~agent_name "task transition failed: %s" message
   | _ -> task_agent_log_error ~agent_name "task transition failed: %s" message
 
-(** Client-side FSM gate: reject impossible transitions before server dispatch.
-    Uses [Workspace_task_classify.valid_next_actions_for_status] as SSOT. *)
-let client_side_transition_gate_error ~task_opt ~action ~action_s =
-  match task_opt with
-  | None -> None
-  | Some (task : Masc_domain.task) ->
-    let valid_actions =
-      Workspace_task_classify.valid_next_actions_for_status
-        ~requires_verification:(Masc_domain.task_requires_verification task)
-        task.task_status
-    in
-    if List.mem action valid_actions
-    then None
-    else
-      Some
-        (Masc_domain.Task_error.InvalidState
-           (Printf.sprintf
-              "Transition '%s' from status '%s' is not allowed. Valid actions: %s"
-              action_s
-              (Masc_domain.task_status_to_string task.task_status)
-              (String.concat ", " (List.map Masc_domain.task_action_to_string valid_actions))))
-
 include Tool_task_payloads
 
 let sync_planning_current_task_with_owned_task (ctx : context) =

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -106,7 +106,11 @@ let client_side_transition_gate_error ~task_opt ~action ~action_s =
   match task_opt with
   | None -> None
   | Some (task : Masc_domain.task) ->
-    let valid_actions = Workspace_task_classify.valid_next_actions_for_status task.task_status in
+    let valid_actions =
+      Workspace_task_classify.valid_next_actions_for_status
+        ~requires_verification:(Masc_domain.task_requires_verification task)
+        task.task_status
+    in
     if List.mem action valid_actions
     then None
     else

--- a/lib/task/tool_task_handlers.mli
+++ b/lib/task/tool_task_handlers.mli
@@ -40,12 +40,6 @@ val result_to_response :
 val log_task_transition_failed :
   agent_name:string -> Masc_domain.masc_error -> unit
 
-val client_side_transition_gate_error :
-  task_opt:Masc_domain.task option ->
-  action:Masc_domain.task_action ->
-  action_s:string ->
-  Masc_domain.Task_error.t option
-
 val sync_planning_current_task_with_owned_task : context -> unit
 val sync_owner_current_task_binding : context -> unit
 val handle_add_task :

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -40,7 +40,7 @@ let schemas : Masc_domain.tool_schema list = [
     description = Printf.sprintf
       "Add a new task to the backlog for agents to claim. \
 Tasks default to an advisory verification contract with completion/evidence requirements. \
-Completion must be submitted for an assigned verifier's approve/reject verdict. \
+Only tasks with contract.strict=true must be submitted for an assigned verifier's approve/reject verdict; advisory/default tasks may complete directly. \
 submit_for_verification creates an asynchronous review state; any non-producer may race to claim it, but only the committed phase-assigned distinct verifier may approve/reject. \
 To re-run completed work, create a new task with predecessor_task_id instead of touching the done one. \
 Priority 1=urgent, 5=low (default 3). \
@@ -219,7 +219,7 @@ Tip: Look for status='todo' tasks to claim.";
   {
     name = "masc_transition";
     description =
-      "Move a Task through claim, start, submit_for_verification, approve, reject, done, cancel, or release. Ownership is exact and cannot be overridden by caller arguments. Direct done is rejected for active tasks: the assignee submits completion evidence, a distinct verifier claims it, and only that assigned verifier may approve or reject. Supports expected_version CAS.";
+      "Move a Task through claim, start, submit_for_verification, approve, reject, done, cancel, or release. Ownership is exact and cannot be overridden by caller arguments. Direct done is terminal for advisory/default tasks. Tasks with contract.strict=true require the assignee to submit completion evidence, then a distinct phase-assigned verifier may approve or reject. Supports expected_version CAS.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -265,20 +265,21 @@ let task_assignee_of_status = Masc_domain.task_assignee_of_status
     will fail to compile. Each branch lists actions that
     [transition_task_r]'s match-arms accept for that status — keep this
     in sync if you add new transitions there. *)
-let valid_next_actions_for_status
+let valid_next_actions_for_status ~requires_verification
   : Masc_domain.task_status -> Masc_domain.task_action list
   = function
   | Masc_domain.Todo -> [ Masc_domain.Claim; Masc_domain.Release; Masc_domain.Cancel ]
   | Masc_domain.Claimed _ ->
     [ Masc_domain.Start
-    ; Masc_domain.Done_action
-    ; Masc_domain.Submit_for_verification
+    ]
+    @ (if requires_verification then [] else [ Masc_domain.Done_action ])
+    @ [ Masc_domain.Submit_for_verification
     ; Masc_domain.Release
     ; Masc_domain.Cancel
     ]
   | Masc_domain.InProgress _ ->
-    [ Masc_domain.Done_action
-    ; Masc_domain.Submit_for_verification
+    (if requires_verification then [] else [ Masc_domain.Done_action ])
+    @ [ Masc_domain.Submit_for_verification
     ; Masc_domain.Release
     ; Masc_domain.Cancel
     ]
@@ -287,8 +288,8 @@ let valid_next_actions_for_status
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> [] (* terminal *)
 ;;
 
-let next_actions_hint status =
-  match valid_next_actions_for_status status with
+let next_actions_hint ~requires_verification status =
+  match valid_next_actions_for_status ~requires_verification status with
   | [] -> ""
   | xs ->
     Printf.sprintf

--- a/lib/workspace/workspace_task_classify.mli
+++ b/lib/workspace/workspace_task_classify.mli
@@ -101,13 +101,17 @@ val task_assignee_of_status : Masc_domain.task_status -> string option
     LLM keepers see what they SHOULD have called, not just what failed.
     Empty list for terminal states ([Done], [Cancelled]). *)
 val valid_next_actions_for_status
-  :  Masc_domain.task_status
+  :  requires_verification:bool
+  -> Masc_domain.task_status
   -> Masc_domain.task_action list
 
 (** Issue #7646: rendered hint string suitable for embedding in error
     messages, e.g. [", valid_next_actions=[claim;cancel]"]. Returns the
     empty string for terminal states. *)
-val next_actions_hint : Masc_domain.task_status -> string
+val next_actions_hint
+  :  requires_verification:bool
+  -> Masc_domain.task_status
+  -> string
 
 val task_started_at_unix : Masc_domain.task_status -> float
 

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -64,6 +64,7 @@ let decide
       ~agent_name
       ~task_id
       ~task_status
+      ~requires_verification
       ~action
       ~now
       ~notes
@@ -116,7 +117,9 @@ let decide
       | Masc_domain.InProgress { assignee; _ } ) ) ->
     if not (same_agent assignee)
     then Error Invalid_transition
-    else Error Verification_submission_required
+    else if requires_verification
+    then Error Verification_submission_required
+    else ok (done_status ~assignee ~now ~notes)
   | Masc_domain.Done_action, Masc_domain.Done _ -> ok task_status
   | ( Masc_domain.Done_action
     , ( Masc_domain.Todo
@@ -213,7 +216,7 @@ let decide
     Error Invalid_transition
 ;;
 
-let valid_next_actions ~same_agent ~task_status =
+let valid_next_actions ~same_agent ~task_status ~requires_verification =
   let same_agent_pred _ = same_agent in
   let try_action action =
     match
@@ -223,6 +226,7 @@ let valid_next_actions ~same_agent ~task_status =
         ~agent_name:""
         ~task_id:""
         ~task_status
+        ~requires_verification
         ~action
         ~now:""
         ~notes:""

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -6,6 +6,8 @@ type invalid =
   | Verification_claim_required
   | Verification_assigned_to of string
   | Verification_self_claim
+  | Verification_approval_notes_required
+  | Verification_rejection_reason_required
   | Invalid_transition
 
 type decision =
@@ -177,6 +179,8 @@ let decide
         } ) ->
     if not (same_agent verifier)
     then Error (Verification_assigned_to verifier)
+    else if String.equal (String.trim notes) ""
+    then Error Verification_approval_notes_required
     else
       ok
         (Masc_domain.Done
@@ -206,6 +210,8 @@ let decide
         { assignee; phase = Masc_domain.Verifier_assigned { verifier }; _ } ) ->
     if not (same_agent verifier)
     then Error (Verification_assigned_to verifier)
+    else if String.equal (String.trim notes) "" && String.equal (String.trim reason) ""
+    then Error Verification_rejection_reason_required
     else ok (Masc_domain.InProgress { assignee; started_at = now })
   | ( Masc_domain.Reject_verification
     , ( Masc_domain.Todo
@@ -229,8 +235,8 @@ let valid_next_actions ~same_agent ~task_status ~requires_verification =
         ~requires_verification
         ~action
         ~now:""
-        ~notes:""
-        ~reason:""
+        ~notes:"preview"
+        ~reason:"preview"
     with
     | Ok _ -> true
     | Error _ -> false

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -6,6 +6,8 @@ type invalid =
   | Verification_claim_required
   | Verification_assigned_to of string
   | Verification_self_claim
+  | Verification_approval_notes_required
+  | Verification_rejection_reason_required
   | Invalid_transition
 
 type decision =

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -34,6 +34,7 @@ val decide
   -> agent_name:string
   -> task_id:string
   -> task_status:Masc_domain.task_status
+  -> requires_verification:bool
   -> action:Masc_domain.task_action
   -> now:string
   -> notes:string
@@ -43,4 +44,5 @@ val decide
 val valid_next_actions
   :  same_agent:bool
   -> task_status:Masc_domain.task_status
+  -> requires_verification:bool
   -> Masc_domain.task_action list

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -135,6 +135,18 @@ let transition_task_outcome_r
               (Masc_domain.Task
                  (Masc_domain.Task_error.InvalidState
                     "Submitting worker cannot claim its own verification request"))
+          | Error Workspace_task_lifecycle.Verification_approval_notes_required ->
+            Error
+              (Masc_domain.Task
+                 (Masc_domain.Task_error.InvalidState
+                    "approve requires non-empty notes explaining the verification \
+                     decision"))
+          | Error Workspace_task_lifecycle.Verification_rejection_reason_required ->
+            Error
+              (Masc_domain.Task
+                 (Masc_domain.Task_error.InvalidState
+                    "reject requires a non-empty reason or notes explaining what \
+                     must be fixed"))
           | Error Workspace_task_lifecycle.Invalid_transition ->
             let assignee_hint =
               match task_assignee_of_status task.task_status with
@@ -144,7 +156,12 @@ let transition_task_outcome_r
             in
 (* Issue #7646: ownership-mismatch dominates; only show valid_next_actions when the failure isn't an ownership problem. *)
             let actions_hint =
-              if assignee_hint <> "" then "" else next_actions_hint task.task_status
+              if assignee_hint <> ""
+              then ""
+              else
+                next_actions_hint
+                  ~requires_verification:(Masc_domain.task_requires_verification task)
+                  task.task_status
             in
 (* Concrete remediation. *)
 (* WORKAROUND: task_status (6 ctors) × task_action (9 ctors) = 54 combos, with ~11 specific hint cases. *)

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -66,8 +66,9 @@ let transition_task_outcome_r
           | None -> Error (Masc_domain.Task (Masc_domain.Task_error.NotFound task_id))
           | Some task -> Ok task
         in
-        (* The workspace FSM owns lifecycle and identity invariants. Completion
-           evidence is submitted for an assigned verifier's terminal verdict. *)
+        (* The workspace FSM owns lifecycle and identity invariants. Strict
+           contracts submit evidence for an assigned verifier's terminal
+           verdict; advisory/default tasks preserve direct owner completion. *)
         let* () =
           (match action, task.task_status with
           | Masc_domain.Claim, Masc_domain.Todo ->
@@ -102,6 +103,7 @@ let transition_task_outcome_r
               ~agent_name
               ~task_id
               ~task_status:task.task_status
+              ~requires_verification:(Masc_domain.task_requires_verification task)
               ~action
               ~now
               ~notes

--- a/scripts/check-hitl-exact-flow-boundary.sh
+++ b/scripts/check-hitl-exact-flow-boundary.sh
@@ -129,7 +129,7 @@ check_boundary() {
     "$WORKER" \
     "worker must not regain provider/config/sampling/degradation policy"
   forbid_pattern \
-    'Http_client|Cohttp|request_path|http_status|Retry\.|retry_policy|retry_after|is_retryable|Error_domain|Capabilities|capability_|supports_|validate_output_schema_request' \
+    'Http_client|Cohttp|request_path|Retry\.|retry_policy|retry_after|is_retryable|Error_domain|Capabilities|capability_|supports_|validate_output_schema_request' \
     "$WORKER" \
     "worker must not bypass OAS HTTP, retry, or capability policy"
   forbid_pattern \
@@ -153,7 +153,7 @@ check_boundary() {
     "$ROOT/lib" \
     "the retired exact failure-to-retry queue transition must not return"
   forbid_pattern \
-    'Pricing|pricing|price|Limit|limit' \
+    '(^|[^_[:alnum:]])(open[[:space:]]+)?(Pricing|Limit_policy)([^_[:alnum:]]|$)|pricing_policy|price_policy|limit_policy|limit_observation|observe_limit' \
     "$WORKER" \
     "pricing and limit observations are not HITL execution policy"
   forbid_pattern \
@@ -201,6 +201,13 @@ self_test() (
     >>"$fixture/lib/keeper/hitl_summary_worker.ml"
   if HITL_EXACT_BOUNDARY_ROOT="$fixture" "$0" --check >/dev/null 2>&1; then
     fail "self-test did not reject a direct provider subcall"
+  fi
+  cp "$WORKER" "$fixture/lib/keeper/hitl_summary_worker.ml"
+
+  printf '\nlet _ = Limit_policy.apply\n' \
+    >>"$fixture/lib/keeper/hitl_summary_worker.ml"
+  if HITL_EXACT_BOUNDARY_ROOT="$fixture" "$0" --check >/dev/null 2>&1; then
+    fail "self-test did not reject direct limit-policy ownership"
   fi
   cp "$WORKER" "$fixture/lib/keeper/hitl_summary_worker.ml"
 

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Golden Path 1 Contract — Core workspace collaboration e2e verification.
+# Golden Path 1 Contract — Strict workspace collaboration e2e verification.
 #
 # Tests the fundamental 10-step external MCP workflow:
 #   producer join → add_task → claim → plan_set_task → heartbeat → broadcast
 #   → status → direct-done rejection → submit_for_verification
 #   → awaiting-verification projection
 #
-# This is the minimum viable path that must always work.
-# If this contract fails, MASC workspace collaboration is broken.
+# This is the opt-in strict verification path. Advisory/default task completion
+# remains direct and is covered by the workspace and Keeper outcome suites.
 #
 # Usage:
 #   MCP_URL=http://127.0.0.1:8935/mcp MCP_TOKEN=... ./golden_path_1_contract.sh
@@ -80,7 +80,7 @@ ensure_contract_goal
 # ── Step 2/10: add_task ──
 echo "[2/10] masc_add_task"
 task_title="GP1 contract task $(date +%s)"
-r2="$(call_tool 1002 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" --arg task_title "$task_title" '{title: $task_title, goal_id: $goal_id, priority: 2, description: "Automated golden path 1 contract verification"}')")"
+r2="$(call_tool 1002 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" --arg task_title "$task_title" '{title: $task_title, goal_id: $goal_id, priority: 2, description: "Automated strict golden path contract verification", contract:{strict:true,completion_contract:["distinct verifier approval"]}}')")"
 if require_ok "$r2"; then
   step_pass
 else

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -323,34 +323,21 @@ evidence_ref="note:public MCP tool live sweep verified by producer ${AGENT_NAME}
 done_notes="Public MCP tool live sweep completed all requested tool calls and verified each response before task completion."
 done_summary="public tool live sweep verified across the public MCP surface"
 
-next_step "masc_transition direct done rejection"
+next_step "masc_transition direct done"
 r_done="$(call_tool 5037 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" --arg notes "$done_notes" --arg summary "$done_summary" --arg evidence_ref "$evidence_ref" '{task_id:$task_id,agent_name:$agent_name,action:"done",notes:$notes,handoff_context:{summary:$summary,evidence_refs:[$evidence_ref]}}')")"
-if response_transport_ok "$r_done" \
-  && ! response_tool_ok "$r_done" \
-  && [[ "$r_done" == *"Task completion must be submitted for verification"* ]] \
-  && [[ "$r_done" != *"Configured LLM completion verifier"* ]]; then
-  echo "  PASS: masc_transition direct done rejection"
+expect_ok "masc_transition direct done" "$r_done"
+
+next_step "masc_tasks done producer credit"
+r_completed="$(call_tool 5038 "masc_tasks" '{"status":"done","include_done":true}')"
+if response_tool_ok "$r_completed" \
+  && [[ "$r_completed" == *"$task_id"* ]] \
+  && [[ "$r_completed" == *"done"* ]] \
+  && [[ "$r_completed" == *"$AGENT_NAME"* ]]; then
+  echo "  PASS: masc_tasks done producer credit"
 else
   mcp_fail_with_context \
-    "masc_transition direct done: expected Verification_submission_required" \
-    "$r_done"
-fi
-
-next_step "masc_transition submit_for_verification"
-r_submit="$(call_tool 5038 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" --arg notes "$done_notes" --arg summary "$done_summary" --arg evidence_ref "$evidence_ref" '{task_id:$task_id,agent_name:$agent_name,action:"submit_for_verification",notes:$notes,handoff_context:{summary:$summary,evidence_refs:[$evidence_ref]}}')")"
-expect_ok "masc_transition submit_for_verification" "$r_submit"
-
-next_step "masc_tasks awaiting_verification producer credit"
-r_awaiting="$(call_tool 5039 "masc_tasks" '{"status":"awaiting_verification"}')"
-if response_tool_ok "$r_awaiting" \
-  && [[ "$r_awaiting" == *"$task_id"* ]] \
-  && [[ "$r_awaiting" == *"awaiting_verification"* ]] \
-  && [[ "$r_awaiting" == *"$AGENT_NAME"* ]]; then
-  echo "  PASS: masc_tasks awaiting_verification producer credit"
-else
-  mcp_fail_with_context \
-    "masc_tasks: AwaitingVerification projection did not retain producer credit" \
-    "$r_awaiting"
+    "masc_tasks: Done projection did not retain producer credit" \
+    "$r_completed"
 fi
 CLEANUP_TASK_FINALIZED=1
 

--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -204,7 +204,16 @@ let test_done_failed_transition_emits_typed_error () =
             | Some (Outcome.No_progress _) -> "No_progress"
             | Some (Outcome.Error _) -> "Error"))
 
-let test_done_submits_for_ordinary_verification () =
+let strict_contract : Masc_domain.task_contract =
+  { strict = true
+  ; completion_contract = [ "peer verification required" ]
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; links = { operation_id = None; session_id = None }
+  }
+
+let test_strict_done_submits_for_verification () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -215,6 +224,7 @@ let test_done_submits_for_ordinary_verification () =
        ignore
          (Masc.Workspace.add_task
             config
+            ~contract:strict_contract
             ~title:"Evidence-bearing completion"
             ~priority:1
             ~description:"");
@@ -258,6 +268,66 @@ let test_done_submits_for_ordinary_verification () =
        | tasks ->
          failf "expected exactly one persisted task, got %d" (List.length tasks))
 
+let test_default_done_is_terminal () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       let agent_name = "keeper-task-create-test-agent" in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       ignore
+         (Masc.Workspace.add_task
+            config
+            ~title:"Advisory completion"
+            ~priority:1
+            ~description:"");
+       ignore
+         (Masc.Workspace.bind_session
+            config
+            ~agent_name
+            ~capabilities:[]
+            ());
+       (match
+          Masc.Workspace.claim_task_r
+            config
+            ~agent_name
+            ~task_id:"task-001"
+            ()
+        with
+        | Ok _ -> ()
+        | Error error ->
+          fail
+            ("claim failed: " ^ Masc_domain.masc_error_to_string error));
+       let meta = meta_with_active_goals [] in
+       let execution =
+         Task.handle_keeper_task_tool_with_outcome
+           ~config
+           ~meta
+           ~name:"keeper_task_done"
+           ~args:
+             (`Assoc
+               [ "task_id", `String "task-001"
+               ; "result", `String "implementation complete"
+               ; "evidence_refs", `List [ `String "commit:abc123" ]
+               ])
+       in
+       (match execution.disposition with
+        | Tool_result.Completed () -> ()
+        | Tool_result.Deferred () -> fail "default completion was deferred"
+        | Tool_result.Failed _ ->
+          fail ("default completion failed: " ^ execution.raw_output));
+       match Masc.Workspace.get_tasks_raw config with
+       | [ { task_status = Masc_domain.Done _;
+             handoff_context = Some handoff; _ } ] ->
+         check string "result preserved as summary"
+           "implementation complete" handoff.summary;
+         check (list string) "evidence preserved"
+           [ "commit:abc123" ] handoff.evidence_refs
+       | [ _ ] -> fail "advisory/default completion was not terminal"
+       | tasks ->
+         failf "expected exactly one persisted task, got %d" (List.length tasks))
+
 let () =
   run "keeper task outcomes"
     [ ( "outcomes"
@@ -277,7 +347,9 @@ let () =
             `Quick test_done_missing_evidence_refs_emits_typed_error
         ; test_case "rejected done (failed transition) emits typed Error (D1)"
             `Quick test_done_failed_transition_emits_typed_error
-        ; test_case "done submits for ordinary verification"
-            `Quick test_done_submits_for_ordinary_verification
+        ; test_case "strict done submits for verification"
+            `Quick test_strict_done_submits_for_verification
+        ; test_case "default done is terminal"
+            `Quick test_default_done_is_terminal
         ] )
     ]

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2575,6 +2575,114 @@ let () = test "claim_next_filters_out_cancelled_tasks" (fun () ->
 )
 
 let () =
+  test "strict verdict validates justification and credits producer metrics" (fun () ->
+    let ctx = make_test_ctx_with_agent "producer" in
+    let verifier_ctx = { ctx with Task.Tool.agent_name = "verifier" } in
+    add_priority_task ctx ~title:"Strict completion metrics";
+    set_only_task_contract
+      ctx
+      (Some (make_task_contract ~strict:true ()));
+    start_task_001 ctx;
+    let submitted =
+      Task.Tool.handle_transition
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        ctx
+        (`Assoc
+          [ "task_id", `String "task-001"
+          ; "action", `String "submit_for_verification"
+          ; "notes", `String "producer evidence is ready"
+          ])
+    in
+    if not (Tool_result.is_success submitted)
+    then failwith (Tool_result.message submitted);
+    (match
+       Workspace.claim_task_r
+         ctx.config
+         ~agent_name:"verifier"
+         ~task_id:"task-001"
+         ()
+     with
+     | Ok _ -> ()
+     | Error error -> failwith (Masc_domain.masc_error_to_string error));
+    let expect_assigned () =
+      match (only_task ctx).Masc_domain.task_status with
+      | Masc_domain.AwaitingVerification
+          { phase = Masc_domain.Verifier_assigned { verifier }; _ }
+        when String.equal verifier "verifier" -> ()
+      | _ -> failwith "failed verdict must not mutate the assigned verification"
+    in
+    let blank_approve =
+      Task.Tool.handle_transition
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        verifier_ctx
+        (`Assoc
+          [ "task_id", `String "task-001"
+          ; "action", `String "approve"
+          ; "notes", `String " "
+          ])
+    in
+    assert (not (Tool_result.is_success blank_approve));
+    assert (str_contains (Tool_result.message blank_approve) "non-empty notes");
+    expect_assigned ();
+    let blank_reject =
+      Task.Tool.handle_transition
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        verifier_ctx
+        (`Assoc
+          [ "task_id", `String "task-001"
+          ; "action", `String "reject"
+          ; "reason", `String " "
+          ])
+    in
+    assert (not (Tool_result.is_success blank_reject));
+    assert (str_contains (Tool_result.message blank_reject) "non-empty reason");
+    expect_assigned ();
+    let previous_metric = Atomic.get Workspace_hooks.record_task_metric_fn in
+    let previous_thompson = Atomic.get Workspace_hooks.record_thompson_result_fn in
+    let metric_events = ref [] in
+    let thompson_events = ref [] in
+    Fun.protect
+      ~finally:(fun () ->
+        Atomic.set Workspace_hooks.record_task_metric_fn previous_metric;
+        Atomic.set Workspace_hooks.record_thompson_result_fn previous_thompson)
+      (fun () ->
+        Atomic.set Workspace_hooks.record_task_metric_fn
+          (fun _config
+               ~agent_id
+               ~task_id:_
+               ~started_at:_
+               ~completed_at:_
+               ~success
+               ~error_message:_
+               ~collaborators
+               ~handoff_from:_
+               ~handoff_to:_ ->
+             metric_events := (agent_id, success, collaborators) :: !metric_events);
+        Atomic.set Workspace_hooks.record_thompson_result_fn
+          (fun ~agent_name ~success ~reason:_ ->
+             thompson_events := (agent_name, success) :: !thompson_events);
+        let approved =
+          Task.Tool.handle_transition
+            ~tool_name:"test_tool"
+            ~start_time:0.0
+            verifier_ctx
+            (`Assoc
+              [ "task_id", `String "task-001"
+              ; "action", `String "approve"
+              ; "notes", `String "tests and evidence verified"
+              ])
+        in
+        if not (Tool_result.is_success approved)
+        then failwith (Tool_result.message approved));
+    assert
+      (List.mem ("producer", true, [ "verifier" ]) !metric_events);
+    assert (List.mem ("producer", true) !thompson_events))
+;;
+
+let () =
   ensure_test_runtime ();
   Alcotest.run "Task.Tool"
     [

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -882,7 +882,7 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
   assert (not (Tool_result.is_success result));
   assert (str_contains (Tool_result.message result) "Invalid task state");
   assert (str_contains (Tool_result.message result) "todo");
-  assert (str_contains (Tool_result.message result) "Valid actions");
+  assert (str_contains (Tool_result.message result) "valid_next_actions");
   assert (str_contains (Tool_result.message result) "claim");
   (* The output must be a structured workflow rejection so the OAS retry
      ladder treats it as deterministic non-retryable. *)
@@ -898,7 +898,7 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
       (fun (entry : Log.Ring.entry) ->
          str_contains entry.message "task transition failed:"
          && str_contains entry.message
-              "Transition 'start' from status 'todo'")
+              "Invalid transition: todo -> start")
       task_entries
   with
   | Some entry ->
@@ -1351,6 +1351,47 @@ let () = test "handle_transition_done_prefers_ownership_error_over_completion_ga
   assert (str_contains (Tool_result.message result) "currently owned by other-agent");
   assert (not (str_contains (Tool_result.message result) "contract verdict"))
 )
+
+let () = test "handle_transition_strict_done_reaches_lifecycle_submission_error" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("title", `String "Strict completion task");
+          ( "contract",
+            `Assoc
+              [
+                ("strict", `Bool true);
+                ("completion_contract", `List [ `String "review required" ]);
+              ] );
+        ])
+  in
+  let _ =
+    Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  let result =
+    Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "done");
+          ("notes", `String "review required");
+        ])
+  in
+  assert (not (Tool_result.is_success result));
+  assert
+    (str_contains
+       (Tool_result.message result)
+       "Task completion must be submitted for verification");
+  match (only_task ctx).Masc_domain.task_status with
+  | Masc_domain.Claimed { assignee; _ } ->
+    assert (String.equal assignee "test-agent")
+  | status ->
+    failwith
+      ("strict direct done mutated task to "
+       ^ Masc_domain.task_status_to_string status))
 
 let () = test "handle_transition_force_is_not_a_done_action" (fun () ->
   let ctx = make_test_ctx_with_agent "admin-agent" in
@@ -2078,8 +2119,11 @@ let () = test "transition_submit_for_verification_todo_rejects_instead_of_alias"
           ])
     in
     assert (not (Tool_result.is_success result));
-    assert (str_contains (Tool_result.message result) "Transition 'submit_for_verification'");
-    assert (str_contains (Tool_result.message result) "from status 'todo' is not allowed");
+    assert
+      (str_contains
+         (Tool_result.message result)
+         "Invalid transition: todo -> submit_for_verification");
+    assert (str_contains (Tool_result.message result) "valid_next_actions=[claim;release;cancel]");
     assert_task_todo ctx)
 )
 

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -890,7 +890,9 @@ let () =
 (* Issue #7646: valid_next_actions_for_status hint tests. One per
    [Masc_domain.task_status] variant. The witness ensures every variant has a
    defined hint AND the ones with content list each action canonically. *)
-let next_hint = Workspace_task.next_actions_hint
+let next_hint ?(requires_verification = false) status =
+  Workspace_task.next_actions_hint ~requires_verification status
+;;
 
 let () =
   test "next_hint_todo lists claim, release, and cancel" (fun () ->
@@ -917,6 +919,17 @@ let () =
     assert (str_contains h "release");
     assert (not (str_contains h "claim"))
     (* Claim is not legal from InProgress *))
+;;
+
+let () =
+  test "next_hint_strict_in_progress lists submit but not done" (fun () ->
+    let h =
+      next_hint
+        ~requires_verification:true
+        (Masc_domain.InProgress { assignee = "a"; started_at = "t" })
+    in
+    assert (str_contains h "submit_for_verification");
+    assert (not (str_contains h "done")))
 ;;
 
 let () =

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1174,7 +1174,7 @@ let test_strict_task_done_requires_verification_submission () =
        | Some { task_status = Masc_domain.Claimed _; _ } -> true
        | Some _ | None -> false))
 
-let test_default_task_done_requires_verification_submission () =
+let test_default_task_done_is_terminal () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Default Task" ~priority:1 ~description:"" in
     let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
@@ -1184,13 +1184,14 @@ let test_default_task_done_requires_verification_submission () =
         ~action:Masc_domain.Done_action
         ~notes:"done" ()
     in
-    Alcotest.(check bool) "default task direct done rejected" true
+    Alcotest.(check bool) "default task direct done succeeds" true
       (match direct with
-       | Error error ->
-         str_contains
-           (Masc_domain.masc_error_to_string error)
-           "must be submitted for verification"
-       | Ok _ -> false))
+       | Ok _ -> true
+       | Error _ -> false);
+    Alcotest.(check bool) "default task is terminal" true
+      (match find_task config "task-001" with
+       | Some { task_status = Masc_domain.Done _; _ } -> true
+       | Some _ | None -> false))
 
 let test_audit_orphan_tasks () =
   with_test_env (fun config ->
@@ -1807,8 +1808,8 @@ let () =
     "verification_guard", [
       Alcotest.test_case "strict task done requires verification submission" `Quick
         test_strict_task_done_requires_verification_submission;
-      Alcotest.test_case "default task done requires verification submission" `Quick
-        test_default_task_done_requires_verification_submission;
+      Alcotest.test_case "default task done is terminal" `Quick
+        test_default_task_done_is_terminal;
     ];
 
     (* === Board Admin Tests === *)

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1105,7 +1105,8 @@ let test_approve_completion_credits_assignee () =
       in
       let approved =
         Workspace.transition_task_r config ~agent_name:admin_keeper_agent
-          ~task_id:"task-001" ~action:Masc_domain.Approve_verification ()
+          ~task_id:"task-001" ~action:Masc_domain.Approve_verification
+          ~notes:"verified submitted evidence" ()
       in
       Alcotest.(check bool) "approve ok" true
         (match approved with Ok _ -> true | Error _ -> false);
@@ -1132,8 +1133,17 @@ let test_submit_and_approve_rejects_empty_justification () =
         ~task_id:"task-001" ~action:Masc_domain.Approve_verification
         ~notes:"   " ()
     in
-    Alcotest.(check bool) "approve transition ok" true
-      (match approved with Ok _ -> true | Error _ -> false))
+    Alcotest.(check bool) "empty approval rejected before transition" false
+      (match approved with Ok _ -> true | Error _ -> false);
+    match find_task config "task-001" with
+    | Some
+        { task_status =
+            Masc_domain.AwaitingVerification
+              { phase = Masc_domain.Verifier_assigned { verifier }; _ }
+        ; _
+        }
+      when String.equal verifier admin_keeper_agent -> ()
+    | _ -> Alcotest.fail "empty approval mutated the verification state")
 
 (* === RFC-0323 G-1 (implements RFC-0308): verification-required done guard === *)
 

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -4,7 +4,15 @@ module D = Masc_domain
 let owner = "alice"
 let now = "2026-07-13T00:00:00Z"
 
-let decide ?(requires_verification = true) ~same_agent ~task_status ~action () =
+let decide
+      ?(requires_verification = true)
+      ?(notes = "evidence at /tmp/proof")
+      ?(reason = "")
+      ~same_agent
+      ~task_status
+      ~action
+      ()
+  =
   L.decide
     ~new_verification_id:(fun () -> "vrf-1")
     ~same_agent:(fun _ -> same_agent)
@@ -14,8 +22,8 @@ let decide ?(requires_verification = true) ~same_agent ~task_status ~action () =
     ~requires_verification
     ~action
     ~now
-    ~notes:"evidence at /tmp/proof"
-    ~reason:""
+    ~notes
+    ~reason
 ;;
 
 let in_progress = D.InProgress { assignee = owner; started_at = now }
@@ -97,6 +105,35 @@ let test_verdict_requires_assigned_winner () =
   | Ok _ | Error _ -> failwith "assigned winner reject must return task to producer"
 ;;
 
+let test_verdict_requires_justification_before_commit () =
+  decide
+    ~notes:"  "
+    ~same_agent:true
+    ~task_status:(assigned "verifier")
+    ~action:D.Approve_verification
+    ()
+  |> expect_error L.Verification_approval_notes_required;
+  decide
+    ~notes:""
+    ~reason:" "
+    ~same_agent:true
+    ~task_status:(assigned "verifier")
+    ~action:D.Reject_verification
+    ()
+  |> expect_error L.Verification_rejection_reason_required;
+  match
+    decide
+      ~notes:""
+      ~reason:"missing test evidence"
+      ~same_agent:true
+      ~task_status:(assigned "verifier")
+      ~action:D.Reject_verification
+      ()
+  with
+  | Ok { new_status = D.InProgress _; _ } -> ()
+  | Ok _ | Error _ -> failwith "non-empty rejection reason must be accepted"
+;;
+
 let task_with_status task_status : D.task =
   { id = "task-1"
   ; title = "review"
@@ -149,5 +186,6 @@ let () =
   test_claimed_done_requires_verification_submission ();
   test_default_done_is_terminal ();
   test_verdict_requires_assigned_winner ();
+  test_verdict_requires_justification_before_commit ();
   test_awaiting_claim_has_one_non_producer_winner ();
   Printf.printf "workspace_task_lifecycle: all tests passed\n%!"

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -4,13 +4,14 @@ module D = Masc_domain
 let owner = "alice"
 let now = "2026-07-13T00:00:00Z"
 
-let decide ~same_agent ~task_status ~action () =
+let decide ?(requires_verification = true) ~same_agent ~task_status ~action () =
   L.decide
     ~new_verification_id:(fun () -> "vrf-1")
     ~same_agent:(fun _ -> same_agent)
     ~agent_name:owner
     ~task_id:"task-1"
     ~task_status
+    ~requires_verification
     ~action
     ~now
     ~notes:"evidence at /tmp/proof"
@@ -52,6 +53,20 @@ let test_claimed_done_requires_verification_submission () =
   let claimed = D.Claimed { assignee = owner; claimed_at = now } in
   decide ~same_agent:true ~task_status:claimed ~action:D.Done_action ()
   |> expect_error L.Verification_submission_required
+;;
+
+let test_default_done_is_terminal () =
+  match
+    decide
+      ~requires_verification:false
+      ~same_agent:true
+      ~task_status:in_progress
+      ~action:D.Done_action
+      ()
+  with
+  | Ok { new_status = D.Done { assignee; _ }; _ }
+    when String.equal assignee owner -> ()
+  | Ok _ | Error _ -> failwith "advisory/default owner completion must be terminal"
 ;;
 
 let test_verdict_requires_assigned_winner () =
@@ -132,6 +147,7 @@ let test_awaiting_claim_has_one_non_producer_winner () =
 let () =
   test_done_requires_verification_submission ();
   test_claimed_done_requires_verification_submission ();
+  test_default_done_is_terminal ();
   test_verdict_requires_assigned_winner ();
   test_awaiting_claim_has_one_non_producer_winner ();
   Printf.printf "workspace_task_lifecycle: all tests passed\n%!"


### PR DESCRIPTION
## Summary

- connect `Masc_domain.task_requires_verification` to the lifecycle FSM
- let advisory/default tasks reach terminal `Done` directly from their owner
- keep only `contract.strict=true` tasks on submit → distinct verifier claim → approve/reject
- make `keeper_task_done` choose that path from the persisted task contract
- reject blank verifier approval/rejection rationale before the FSM commit
- credit strict approval completion metrics and Thompson success to the producer, with the verifier as collaborator
- make Keeper prompts and transition hints contract-aware
- remove the duplicate client-side FSM preflight so the typed workspace lifecycle is the single transition decision point
- preserve structured deterministic rejection metadata after the lifecycle decision

This is the main-based liveness follow-up to merged #26055. Without the strict-only split, every default task requires a second Keeper and a single-Keeper deployment has no terminal path.

## Validation

Latest-main focused validation passed:

- `scripts/dune-local.sh build test/test_workspace_task_lifecycle.exe test/test_tool_workspace_coverage.exe test/test_tool_task_coverage.exe test/test_keeper_task_outcomes.exe test/test_workspace.exe bin/main_eio.exe`
- `test_workspace_task_lifecycle.exe` — pass
- `test_tool_workspace_coverage.exe` — 37/37
- `test_tool_task_coverage.exe` — 87/87
- `test_keeper_task_outcomes.exe` — 8/8
- `test_workspace.exe` verification-focused cases exercised; unrelated pre-existing canonical-identity fixture cases remain red outside this diff
- `opam exec -- ocamlformat --check` on changed OCaml files
- `bash -n` and `shellcheck` on the changed public contract harness
- full local live contract harness — pass: streamable HTTP, strict golden path 10/10, public/default tool sweep 36/36, scheduler supported contract 3/3
- `git diff --check`

The strict golden path creates an explicitly strict task and proves direct `done` reaches the exact verification-submission decision. The public tool sweep proves an advisory/default task can complete directly and retains producer credit.

## Review follow-up

- approval/rejection justification now validates before task state mutation
- strict approval records the producer's successful task/Thompson result
- exposed next actions are derived with `task_requires_verification`
- the obsolete `masc_task_completion_path_total` classifier raised in review was removed on main by the #26055/#26073 refactor, so this rebased branch does not reintroduce or relabel that retired metric
- CI exposed that the duplicate client-side gate intercepted the richer lifecycle error; it is now deleted rather than patched with another exception
