### PR TITLE
fix(test): event-queue 스위트가 top-level fatal로 전혀 실행되지 않던 픽스처 rot 제거

### DIFF
--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1189,7 +1189,6 @@ let () =
           [ "name", `String keeper_name
           ; "agent_name", `String keeper_name
           ; "trace_id", `String trace_id
-          ; "last_model_used", `String "llama:auto"
           ])
     with
     | Ok meta -> meta


### PR DESCRIPTION
## 문제

`test/test_keeper_event_queue.ml` 의 Alcotest 테스트가 **한 개도 실행되지 않는다.** `[OK]` 도 `[FAIL]` 도 0줄이다.

`meta_for_keeper` (파일 top level, `Alcotest.run` 이전) 가 keeper meta 스키마에서 제거된 `last_model_used` 를 계속 넘긴다. `Keeper_meta_contract` 에 그 필드가 없으므로 `meta_of_json` 이 fail-closed 로 거부하고, 헬퍼가 `Alcotest.fail` 을 호출한다. top level 예외이므로 치명적이다.

```
$ ./_build/default/test/test_keeper_event_queue.exe
ASSERT meta parse failed: invalid current keeper meta: fields outside the current schema: last_model_used; runtime reset required
Fatal error: exception Alcotest assertion failure
FAIL meta parse failed: ...
```

```
$ rg -n 'last_model_used' lib/keeper/keeper_meta_contract.ml
(no matches)
```

## 수정

픽스처에서 그 필드만 제거한다. 헬퍼의 의도는 "현재 파서가 받아들이는 meta 를 만드는 것" 이고, 어떤 assertion 도 이 필드의 존재에 의존하지 않는다. 스키마 쪽은 건드리지 않는다 — fail-closed 거부는 의도된 설계다.

## 왜 CI 가 못 잡았나

`ci.yml` 은 `@default @check @install` 로 모든 테스트를 **컴파일** 하지만, **실행** 하는 것은 다음뿐이다.

- `@test/runtest-test_runtime_config_validity`
- `@test/runtest-test_operator_control_snapshot{,_state,_cache}`
- `./test/test_sse_storm_e2e.exe`

그래서 `Alcotest.run` 도달 전에 죽는 스위트는 통과하는 스위트와 구분되지 않는다. 이 파일은 컴파일만 강제되고 있었다.

## 파급

이 상태에서는 `test_keeper_event_queue` 를 근거로 든 검증 서술이 성립하지 않는다. 실제 사례:

- #26032 는 이 스위트에 새 assertion 3단계를 추가하고 "CI remains the broad authority" 라고 적었지만, CI 는 이 스위트를 실행하지 않고 로컬에서도 top-level 에서 죽어 새 assertion 에 도달하지 못한다.

## 로컬 검증

```
$ bash scripts/dune-local.sh build test/test_keeper_event_queue.exe   # 통과
```

수정 전 실행: top-level `Fatal error`, 케이스 0개 실행.

전체 스위트 실행 결과는 확인 중이며 결과를 코멘트로 추가한다. 이 PR 자체는 top-level fatal 을 제거해 **케이스가 실행되기 시작하게** 하는 변경이므로, 그 뒤에 드러나는 개별 실패는 별도로 분리해 다룬다.

RFC-WAIVED: 변경 범위가 `test/` 단일 파일의 픽스처 1줄이며 credential/identity/operator/sandbox/hooks/workflow 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
