### PR TITLE
fix(dashboard): converge the queue-lane placeholder into its history row

### DIFF
--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -402,6 +402,52 @@ describe('thread history merge & persistence', () => {
     expect(thread.map(e => e.id)).toEqual(['local-legacy', 'hist-legacy'])
   })
 
+  // Live 2026-07-28: a keeper that was busy answered through the queue lane,
+  // so the stream carried KEEPER_CHAT_QUEUED (receipt_id, no request_id) and
+  // died before REPLY_DETAILS. The assistant placeholder therefore holds the
+  // tool trace with a queue receipt and no turnRef, and the REST row carries
+  // the same receipt. Both rendered as separate "턴 타임라인" blocks, and only
+  // the placeholder had per-tool durations.
+  it('converges a queue-lane assistant placeholder that holds the tool trace', () => {
+    const receiptId = 'chatq_00000000-0000-4000-8000-000000000002'
+    const traceSteps: ChatTraceStep[] = [
+      { kind: 'tool', name: 'WebSearch', toolCallId: 'call-q1', status: 'ok' },
+      { kind: 'tool', name: 'WebFetch', toolCallId: 'call-q2', status: 'ok' },
+    ]
+    appendThreadEntry('echo', entry({
+      id: 'local-queued-assistant',
+      role: 'assistant',
+      text: '',
+      rawText: '',
+      delivery: 'sending',
+      timestamp: null,
+      turnRef: null,
+      traceSteps,
+      details: { queueReceiptId: receiptId },
+    }))
+
+    const history = chatHistoryEntriesFromRest('echo', [{
+      id: 'history-queued-assistant',
+      role: 'assistant',
+      content: '검색 결과 요약',
+      ts: 1_780_000_002,
+      delivery_key: {
+        kind: 'queue_receipts',
+        receipt_ids: [receiptId],
+      },
+    }])
+
+    mergeServerHistoryEntries('echo', history)
+
+    const assistants = (keeperThreads.value.echo ?? []).filter(candidate => candidate.role === 'assistant')
+    expect(assistants).toHaveLength(1)
+    expect(
+      (assistants[0]?.traceSteps ?? [])
+        .filter((step): step is Extract<ChatTraceStep, { kind: 'tool' }> => step.kind === 'tool')
+        .map(step => step.toolCallId),
+    ).toEqual(['call-q1', 'call-q2'])
+  })
+
   it('converges queue-lane user rows through an exact durable receipt', () => {
     const receiptId = 'chatq_00000000-0000-4000-8000-000000000001'
     appendThreadEntry('echo', entry({

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1433,6 +1433,28 @@ function mergeLocalAssistantTraceSteps(
       traceSteps: localTraceSourceByRequestId.traceSteps,
     }
   }
+  // Queue-lane join: a keeper that was busy answers through the chat queue, so
+  // the stream carries KEEPER_CHAT_QUEUED (receipt id, no request id). Such a
+  // placeholder has neither request id nor turnRef, and its receipt is the only
+  // producer identity shared with the history row. Without this the trace stays
+  // unmerged and the transcript renders a second "턴 타임라인".
+  const historyReceiptIds = new Set(queueReceiptIds(historyEntry))
+  const localTraceSourceByReceipt = historyReceiptIds.size > 0
+    ? localEntries.find(
+        entry =>
+          entry.role === 'assistant'
+          && (entry.traceSteps?.length ?? 0) > 0
+          && !consumed.has(entry.id)
+          && queueReceiptIds(entry).some(receiptId => historyReceiptIds.has(receiptId)),
+      )
+    : undefined
+  if (localTraceSourceByReceipt?.traceSteps?.length) {
+    consumed.add(localTraceSourceByReceipt.id)
+    return {
+      ...historyEntry,
+      traceSteps: localTraceSourceByReceipt.traceSteps,
+    }
+  }
   const historyTurnRef = historyEntry.turnRef?.trim()
   const localTraceSourceByTurnRef = historyTurnRef
     ? localEntries.find(
@@ -1479,11 +1501,27 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
       // A terminal durable-receipt observation is also operator evidence, not
       // a duplicate assistant reply: keep it alongside the canonical history
       // row so its Pending/Inflight/Delivered/Failed lifecycle remains visible.
+      // ...unless the history row already carries this placeholder's identity
+      // and its trace was folded in above (mergeLocalAssistantTraceSteps).
+      // A queue-lane placeholder whose stream died holds only the trace and an
+      // empty text; keeping it next to the converged history row renders the
+      // same turn twice, and only the placeholder copy shows per-tool
+      // durations (live 2026-07-28).
       const isReceiptObservation =
-        entry.role === 'assistant' && Boolean(entry.details?.queueReceiptId)
-      const shouldKeepLocalEntry = isInFlightDelivery(entry.delivery)
-        || isReceiptObservation
-        || !coveredByHistory
+        entry.role === 'assistant'
+        && Boolean(entry.details?.queueReceiptId)
+        && !coveredByHistory
+      // A converged assistant row supersedes its own placeholder even while the
+      // placeholder still reads in-flight: a stream that died before
+      // REPLY_DETAILS leaves `sending` set forever, so treating in-flight as
+      // unconditionally live renders the same turn twice (live 2026-07-28,
+      // queue lane). Convergence requires a shared producer identity, so this
+      // cannot collapse two genuinely distinct turns.
+      const supersededByHistory = entry.role === 'assistant' && coveredByHistory
+      const shouldKeepLocalEntry = !supersededByHistory
+        && (isInFlightDelivery(entry.delivery)
+          || isReceiptObservation
+          || !coveredByHistory)
       return entry.delivery !== 'history' && !isCoveredToolRow && shouldKeepLocalEntry
     },
   )


### PR DESCRIPTION
## 증상

같은 턴이 "턴 타임라인" 블록 **2개**로 렌더됩니다. 한쪽에만 도구별 duration 이 보이고, 같은 `tool_use_id` 가 양쪽에 중복 표시됩니다.

라이브 실측(2026-07-28, sangsu): 고유 tool_use id 는 **5개**인데 화면에는 **8개**로 보였습니다.

## 원인

keeper 가 이미 바쁘면 **chat 큐 레인**으로 답합니다. 이 경로의 스트림은 `KEEPER_CHAT_QUEUED`(receipt id 만, request id 없음)를 보내고, `REPLY_DETAILS` 전에 끊길 수 있습니다. 그러면 assistant placeholder 는:

- `requestId` 없음 (큐 레인은 `KEEPER_QUEUE_REQUEST` 를 보내지 않음)
- `turnRef` 없음 (REPLY_DETAILS 미도달)
- `queueReceiptId` **있음**

수렴 join 키는 `requestId → turnRef` 순서라 둘 다 실패했습니다. **receipt 는 서버·프론트 양쪽에 이미 있었는데 비교되지 않았습니다** — 라이브에서 값이 정확히 일치함을 확인했습니다(`chatq_71ea729e-…`).

라이브 대조로 확정했습니다:

| keeper | 스트림 이벤트 | 결과 |
|---|---|---|
| analyst, taskmaster | `KEEPER_QUEUE_REQUEST` | 정상 수렴 |
| **rondo** | `KEEPER_CHAT_QUEUED` | **블록 2개** |

## 수정 (3개 고리)

1. **queue receipt 를 join 키로 추가** — 이 레인이 공유하는 유일한 생산자 identity
2. `isReceiptObservation` 에 `!coveredByHistory` — history 가 흡수한 뒤에도 placeholder 를 무조건 보존하던 규칙
3. **수렴된 history 행이 자기 placeholder 를 대체** — 죽은 스트림은 `sending` 이 영원히 남아 in-flight 보존 규칙에 걸립니다. 수렴 자체가 생산자 identity 일치를 요구하므로 서로 다른 턴이 합쳐질 수는 없습니다

## 검증

```
vitest run              → 8833 passed (643 files)
tsc --noEmit            → clean
신규 회귀 테스트         → 'converges a queue-lane assistant placeholder that holds the tool trace'
```

신규 테스트는 **수정 전 실패를 먼저 확인**하고 작성했습니다(assistant 2개 → 1개).

## 남은 것 (이 PR 범위 밖)

같은 표면에서 감사로 확인된 별개 원인 2건:

- tool 행에는 turnRef 가 붙지 않는데 assistant history 행에는 붙어, `canBundleToolsWithAssistant` 가 bundle 을 분리합니다
- trajectory tool 행의 `turn` 이 전부 0 입니다 — `Trajectory.increment_turn` 의 프로덕션 호출자가 0 건이라, reload 시 history trace block 에 tool step 이 들어가지 않습니다

각각 별도 이슈로 올리겠습니다.
