### PR TITLE
fix(test): event-queue meta 픽스처를 공용 스키마 픽스처로 전환 (#26064 후속)

### DIFF
--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1182,14 +1182,16 @@ let () =
         true
         (bool_field "operator_action_required" json));
 
+  (* Build the meta through the shared fixture, not a hand-written object: it
+     fills every field of the current schema from
+     [Keeper_meta_json_current_schema.all_fields], so a schema change cannot
+     leave this helper behind. The hand-written version drifted twice -- it
+     passed the removed [last_model_used] (fixed in #26064) and supplies only
+     three of the schema's required fields. *)
   let meta_for_keeper keeper_name trace_id =
     match
-      Masc.Keeper_meta_json_parse.meta_of_json
-        (`Assoc
-          [ "name", `String keeper_name
-          ; "agent_name", `String keeper_name
-          ; "trace_id", `String trace_id
-          ])
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc [ "name", `String keeper_name; "trace_id", `String trace_id ])
     with
     | Ok meta -> meta
     | Error msg -> Alcotest.fail ("meta parse failed: " ^ msg)


### PR DESCRIPTION
## 문제

`#26064` 는 `meta_for_keeper` 에서 제거된 `last_model_used` 키만 걷어냈다. 그러자 다음 관문이 드러났다 — 손으로 쓴 객체는 3개 필드를 주는데 현재 스키마는 약 50개를 요구한다. `meta_of_json` 이 여전히 fail-closed 로 거부하고, top-level `Alcotest.fail` 이 `Alcotest.run` 이전에 프로세스를 죽인다.

```
meta parse failed: invalid current keeper meta: missing required fields:
persona, instructions, multimodal_policy, trace_history, generation,
last_handoff_ts, created_at, updated_at, total_turns, ... meta_version;
runtime reset required
```

그 결과 이 스위트는 `[OK]` 0줄, `[FAIL]` 0줄 — **테스트가 한 개도 실행되지 않는다.**

## 수정

리터럴을 또 기워도 다음 스키마 변경에서 같은 일이 반복된다. 실제로 두 번 드리프트했다(제거된 키 + 부족한 필드).

`Masc_test_deps.meta_of_json_fixture` 를 쓴다. 이 헬퍼는 `Keeper_meta_json_current_schema.all_fields` 를 순회해 모든 필드를 채우고 호출자가 준 키만 덮어쓴다. docstring 이 의도를 명시한다.

> the fixture "cannot drift from the writer"

`masc_test_deps` 는 이 테스트의 dune stanza 에 이미 링크돼 있고, meta 가 필요한 다른 스위트는 전부 이걸 쓴다. 이 파일만 예외였다.

`agent_name` 은 호출에서 뺐다. 픽스처가 `Keeper_identity.keeper_agent_name` 으로 파생하므로, keeper 이름을 그대로 넘기면 canonical-identity 검사에 걸린다.

## 로컬 검증

```
$ bash scripts/dune-local.sh build test/test_keeper_event_queue.exe
BUILD_EXIT=0
$ ./_build/default/test/test_keeper_event_queue.exe
TEST_EXIT=0
```

수정 전: top-level `Fatal error`, 케이스 0개 실행. 수정 후: 스위트가 끝까지 실행되고 exit 0.

## CI 가 잡을 수 없는 이유

`ci.yml` 은 `@default @check @install` 로 모든 테스트를 컴파일하지만 **실행** 하는 것은 다음뿐이다.

- `@test/runtest-test_runtime_config_validity`
- `@test/runtest-test_operator_control_snapshot{,_state,_cache}`
- `./test/test_sse_storm_e2e.exe`

`Alcotest.run` 도달 전에 죽는 스위트는 통과하는 스위트와 구분되지 않는다.

RFC-WAIVED: 변경 범위가 `test/` 단일 파일의 픽스처 헬퍼이며 credential/identity/operator/sandbox/hooks/workflow 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
