### PR TITLE
fix(trajectory): stamp tool calls with the turn they ran in

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -336,6 +336,13 @@ let make_hooks
            cost_usd from OAS Pricing.annotate_response_cost (oas#393 resolved). *)
         (match trajectory_acc with
          | Some acc ->
+           (* The accumulator's turn counter had no producer, so every
+              tool-call entry was written with turn = 0 while reasoning
+              entries carried the runtime's real turn. The transcript joins
+              trace rows on that number, so a reload found no tool steps for
+              any turn and the tool timeline disappeared. Adopt the turn the
+              runtime already assigns here; [round] derives from it. *)
+           Trajectory.set_turn acc turn;
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
              ~input_tokens:raw_input_tok ~output_tokens:raw_output_tok

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -610,6 +610,9 @@ let clear_task_id (acc : accumulator) : unit =
 let increment_turn (acc : accumulator) : unit =
   acc.turn <- acc.turn + 1
 
+let set_turn (acc : accumulator) (turn : int) : unit =
+  if turn > acc.turn then acc.turn <- turn
+
 let record_entry ?runtime_contract ?action_radius ?on_persist_error
     (acc : accumulator) (entry : tool_call_entry) : unit =
   acc.entries <- entry :: acc.entries;

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -195,6 +195,12 @@ val create_accumulator :
 val set_task_id : accumulator -> string -> unit
 val clear_task_id : accumulator -> unit
 val increment_turn : accumulator -> unit
+
+val set_turn : accumulator -> int -> unit
+(** Adopt the turn number the runtime already assigns, so tool-call entries
+    carry the same turn as the reasoning entries they belong to. Monotonic:
+    a lower value is ignored, which keeps [calls_in_current_turn] from
+    re-counting an earlier turn's rounds. *)
 val record_entry :
   ?runtime_contract:Yojson.Safe.t ->
   ?action_radius:Yojson.Safe.t ->

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -145,6 +145,25 @@ let test_increment_turn () =
     Trajectory.increment_turn acc;
     Alcotest.(check int) "turn 2" 2 acc.Trajectory.turn)
 
+let test_set_turn_adopts_runtime_turn () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-005b" ~generation:0 () in
+    Alcotest.(check int) "turn starts at 0" 0 acc.Trajectory.turn;
+    (* The runtime numbers turns itself; the accumulator adopts that number
+       so tool-call entries land on the same turn as the reasoning entries
+       the transcript joins them with. *)
+    Trajectory.set_turn acc 7;
+    Alcotest.(check int) "adopts runtime turn" 7 acc.Trajectory.turn;
+    (* Monotonic: a stale or repeated lower number must not rewind the
+       counter, which would make calls_in_current_turn recount an earlier
+       turn's rounds. *)
+    Trajectory.set_turn acc 3;
+    Alcotest.(check int) "lower turn is ignored" 7 acc.Trajectory.turn;
+    Trajectory.set_turn acc 7;
+    Alcotest.(check int) "same turn is a no-op" 7 acc.Trajectory.turn)
+
 (* ================================================================ *)
 (* Test: finalize creates trajectory record                          *)
 (* ================================================================ *)
@@ -961,6 +980,7 @@ let () =
       Alcotest.test_case "create" `Quick test_create_accumulator;
       Alcotest.test_case "record_entry" `Quick test_record_entry;
       Alcotest.test_case "increment_turn" `Quick test_increment_turn;
+      Alcotest.test_case "set_turn adopts runtime turn" `Quick test_set_turn_adopts_runtime_turn;
       Alcotest.test_case "calls_in_current_turn" `Quick test_calls_in_current_turn;
     ]);
     ("entropy", [


### PR DESCRIPTION
## 증상

새로고침하면 **도구 타임라인이 사라집니다.** 스트림 중에는 도구 호출과 duration 이 보이는데, reload 후 그 턴에는 tool step 이 하나도 없습니다.

## 원인

`Trajectory.increment_turn` 의 **프로덕션 호출자가 0건**입니다 (`rg 'Trajectory.increment_turn' lib/ bin/` → 0). accumulator 의 turn 카운터를 아무도 올리지 않아, tool-call 엔트리가 trace 전체에 걸쳐 `turn = 0` 으로 기록됩니다.

라이브 실측 (`~/.masc/trajectories/analyst/trace-1785189111840-00000.jsonl`, 497행):

| type | 건수 | turn |
|---|---|---|
| `thinking` | 220 | 0..N (증가) |
| tool 호출 | **124** | **전부 0** |
| `trajectory_summary` | 153 | — |

reasoning 엔트리는 다른 경로로 런타임의 실제 turn 을 받는데 tool 엔트리만 0 에 머무는 비대칭이 단서였습니다.

transcript 는 trace 행을 그 turn 번호로 조인하므로(`chat_trace_block_by_turn_ref`), 어떤 턴도 tool step 을 찾지 못합니다. `round` 는 `calls_in_current_turn` → `e.turn = acc.turn` 으로 파생되므로 함께 틀렸습니다.

데이터 자체는 멀쩡합니다 — 그 행에 `duration_ms`, `execution_id`, `gate`, `cost_usd` 가 다 들어 있습니다. 화면에 닿지 못했을 뿐입니다.

## 수정

`after_turn` 훅이 이미 SDK 로부터 `turn` 을 받고 accumulator 도 손에 쥐고 있습니다(cost 이벤트·reasoning 영속화에 씀). 그 지점에서 turn 을 채택합니다.

`set_turn` 은 **단조**입니다: 반복되거나 뒤늦은 낮은 값이 카운터를 되돌리면 `calls_in_current_turn` 이 이전 턴의 round 를 다시 세게 되므로 무시합니다.

## 검증

```
scripts/dune-local.sh build lib/trajectory lib/keeper   → exit 0
./_build/default/test/test_trajectory.exe               → 48 tests, Successful
```

신규 회귀 테스트 `set_turn adopts runtime turn`: 런타임 turn 채택, 낮은 값 무시, 같은 값 no-op.

## 남은 것

같은 화면의 별개 원인 1건이 남습니다 — tool 행에는 `turnRef` 가 붙지 않는데 assistant history 행에는 붙어 `canBundleToolsWithAssistant` 가 bundle 을 분리합니다. 별도 PR 로 다루겠습니다.

관련: #26065 (같은 화면의 queue-lane 수렴 결함, 머지됨)
