### PR TITLE
diag(keeper): name the five outcomes hidden behind flow_execution_failed

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -423,6 +423,28 @@ let log_exact_error (entry : pending_approval) operation detail =
     detail
 ;;
 
+(* Four distinct flow errors settle as the same [Exact_flow_execution_failed]
+   quarantine cause, and the durable row keeps only that label. An operator
+   therefore reads "Auto Judge exact attempt quarantined: flow_execution_failed"
+   with no way to tell candidate exhaustion from an allocation failure, while the
+   evidence payload each error carries is discarded at this boundary. Observed
+   2026-07-28: 25 approvals quarantined under that one label with nothing in the
+   log naming the branch. Render the per-attempt provenance so the branch and the
+   slot it died on are recoverable. *)
+let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
+  match evidence.attempts with
+  | [] -> "no candidate attempt was recorded"
+  | attempts ->
+    attempts
+    |> List.map (fun (attempt : Exact_output.flow_attempt_snapshot) ->
+      Printf.sprintf
+        "slot=%s call_id=%s"
+        attempt.visit.identity.candidate_id
+        (Exact_output.generation_receipt_snapshot_call_id attempt.receipt
+         |> Exact_output.call_id_to_string))
+    |> String.concat "; "
+;;
+
 let exact_attempt_source_resolved (entry : pending_approval) = function
   | Exact_attempt_rejected (Exact_attempt_not_found approval_id) ->
     String.equal approval_id entry.id
@@ -815,29 +837,46 @@ let handle_semantic_exhaustion ~queue_ops (prepared : prepared_flow) trace =
 ;;
 
 let handle_flow_error ~queue_ops (prepared : prepared_flow) = function
-  | Exact_output.Flow_attempt_already_started _ ->
+  | Exact_output.Flow_attempt_already_started evidence ->
     record_outcome "exact_attempt_replay";
+    log_exact_error prepared.entry "attempt replay" (flow_evidence_detail evidence);
     settle_current_or_signal
       ~queue_ops
       prepared.entry
       ~reason:"HITL exact-output flow attempt was replayed"
       ~cause:Exact_attempt_replay
-  | Exact_output.Flow_attempt_start_failed _ ->
+  | Exact_output.Flow_attempt_start_failed { cause; evidence; _ } ->
     record_outcome "exact_attempt_start_failed";
+    let cause_detail =
+      match cause with
+      | Exact_output.Call_id_generation_failed detail -> detail
+    in
+    log_exact_error
+      prepared.entry
+      "candidate attempt allocation"
+      (Printf.sprintf "%s (%s)" cause_detail (flow_evidence_detail evidence));
     settle_current_or_signal
       ~queue_ops
       prepared.entry
       ~reason:"HITL exact-output candidate attempt allocation failed"
       ~cause:Exact_flow_execution_failed
-  | Exact_output.Flow_measurement_start_failed _ ->
+  | Exact_output.Flow_measurement_start_failed { evidence; _ } ->
     record_outcome "exact_measurement_start_failed";
+    log_exact_error
+      prepared.entry
+      "measurement allocation"
+      (flow_evidence_detail evidence);
     settle_current_or_signal
       ~queue_ops
       prepared.entry
       ~reason:"HITL exact-output measurement allocation failed"
       ~cause:Exact_flow_execution_failed
-  | Exact_output.Flow_candidates_exhausted _ ->
+  | Exact_output.Flow_candidates_exhausted { evidence; _ } ->
     record_outcome "exact_candidates_exhausted";
+    log_exact_error
+      prepared.entry
+      "candidate exhaustion before dispatch"
+      (flow_evidence_detail evidence);
     settle_current_or_signal
       ~queue_ops
       prepared.entry

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -423,14 +423,17 @@ let log_exact_error (entry : pending_approval) operation detail =
     detail
 ;;
 
-(* Four distinct flow errors settle as the same [Exact_flow_execution_failed]
-   quarantine cause, and the durable row keeps only that label. An operator
-   therefore reads "Auto Judge exact attempt quarantined: flow_execution_failed"
-   with no way to tell candidate exhaustion from an allocation failure, while the
-   evidence payload each error carries is discarded at this boundary. Observed
-   2026-07-28: 25 approvals quarantined under that one label with nothing in the
-   log naming the branch. Render the per-attempt provenance so the branch and the
-   slot it died on are recoverable. *)
+(* Five distinct outcomes settle as the same [Exact_flow_execution_failed]
+   quarantine cause - attempt-allocation failure, measurement-allocation failure,
+   candidate exhaustion, provider execution failure and provenance mismatch - and
+   the durable row keeps only that label. An operator therefore reads "Auto Judge
+   exact attempt quarantined: flow_execution_failed" with no way to tell a local
+   context-capacity refusal from a provider outage, while the evidence payload
+   each error carries is discarded at this boundary. Observed 2026-07-28: 25
+   approvals quarantined under that one label, zero occurrences of the word in
+   the system log, and no metrics endpoint listening to read the per-branch
+   counter [record_outcome] already writes. Render the per-attempt provenance so
+   the branch and the slot it died on are recoverable. *)
 let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
   match evidence.attempts with
   | [] -> "no candidate attempt was recorded"
@@ -443,6 +446,106 @@ let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
         (Exact_output.generation_receipt_snapshot_call_id attempt.receipt
          |> Exact_output.call_id_to_string))
     |> String.concat "; "
+;;
+
+let optional_tokens = function
+  | None -> "unknown"
+  | Some tokens -> string_of_int tokens
+;;
+
+(* [Flow_candidates_exhausted] means every declared slot was refused before any
+   request left this process, and the receipt carries the typed reason with its
+   token arithmetic. Discarding it is what makes a local capacity refusal
+   indistinguishable from a provider outage in the durable row. Matched
+   exhaustively so that a new OAS disposition is a compile error here rather
+   than an unexplained quarantine in production. *)
+let rec capacity_disposition_detail : Exact_output.input_capacity_disposition -> string
+  = function
+  | Token_measurement_required { accepted_through_tokens; rejected_from_tokens } ->
+    Printf.sprintf
+      "token measurement required (accepted_through=%d rejected_from=%s)"
+      accepted_through_tokens
+      (optional_tokens rejected_from_tokens)
+  | Context_window_exceeded { input_tokens; reserved_output_tokens; max_context_tokens } ->
+    Printf.sprintf
+      "context window exceeded (input=%d reserved_output=%d max_context=%d)"
+      input_tokens
+      reserved_output_tokens
+      max_context_tokens
+  | Token_capacity_rejected rejection -> token_capacity_detail rejection
+  | Serialized_request_body_too_large { actual_bytes; limit_bytes } ->
+    Printf.sprintf
+      "serialized request body too large (actual=%dB limit=%dB)"
+      actual_bytes
+      limit_bytes
+
+and token_capacity_detail : Exact_output.token_capacity_rejection -> string = function
+  | Capacity_evidence_not_yet_valid { now_unix_s; checked_at_unix_s } ->
+    Printf.sprintf
+      "capacity evidence not yet valid (now=%d checked_at=%d)"
+      now_unix_s
+      checked_at_unix_s
+  | Capacity_evidence_expired { now_unix_s; expires_at_unix_s } ->
+    Printf.sprintf
+      "capacity evidence expired (now=%d expires_at=%d)"
+      now_unix_s
+      expires_at_unix_s
+  | Capacity_boundary_unknown { input_tokens; accepted_through_tokens; rejected_from_tokens }
+    ->
+    Printf.sprintf
+      "capacity boundary unknown (input=%d accepted_through=%d rejected_from=%s)"
+      input_tokens
+      accepted_through_tokens
+      (optional_tokens rejected_from_tokens)
+  | Capacity_input_rejected { input_tokens; accepted_through_tokens; rejected_from_tokens }
+    ->
+    Printf.sprintf
+      "capacity input rejected (input=%d accepted_through=%d rejected_from=%d)"
+      input_tokens
+      accepted_through_tokens
+      rejected_from_tokens
+;;
+
+let rejection_disposition_detail : Exact_output.candidate_rejection_disposition -> string
+  = function
+  | Runtime_slot_unavailable -> "runtime slot unavailable"
+  | Runtime_contract_rejected -> "runtime contract rejected"
+  | Input_contract_rejected -> "input contract rejected"
+  | Output_requirement_rejected -> "output requirement rejected"
+  | Input_capacity disposition -> capacity_disposition_detail disposition
+  | Request_preparation_failed -> "request preparation failed"
+;;
+
+let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_receipt) =
+  Printf.sprintf
+    "slot=%s %s"
+    (Exact_output.candidate_rejection_identity rejection).candidate_id
+    (Exact_output.candidate_rejection_disposition rejection
+     |> rejection_disposition_detail)
+;;
+
+(* [Flow_exact_execution_failed] is the branch that carries the provider's own
+   verdict, and it was the only flow error settled with no log line at all. *)
+let capacity_refusal_detail : Exact_output.input_capacity_refusal -> string = function
+  | Context_window_refused { limit_tokens } ->
+    Printf.sprintf "context window refused (limit=%s)" (optional_tokens limit_tokens)
+  | Serialized_request_refused { http_status } ->
+    Printf.sprintf "serialized request refused (http_status=%d)" http_status
+;;
+
+let execution_cause_detail : Exact_output.execution_error_cause -> string = function
+  | Attempt_already_started -> "attempt already started"
+  | Clock_required_for_timeout -> "clock required for timeout"
+  | Frozen_request_mismatch -> "frozen request mismatch"
+  | Completion_failed -> "completion failed"
+  | Input_capacity_refused refusal ->
+    Printf.sprintf "input capacity refused: %s" (capacity_refusal_detail refusal)
+  | Incomplete_output -> "incomplete output"
+  | Missing_output -> "missing output"
+  | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count
+  | Unexpected_output_content -> "unexpected output content"
+  | Invalid_json_output -> "invalid json output"
+  | Internal_non_json_output -> "internal non-json output"
 ;;
 
 let exact_attempt_source_resolved (entry : pending_approval) = function
@@ -871,12 +974,15 @@ let handle_flow_error ~queue_ops (prepared : prepared_flow) = function
       prepared.entry
       ~reason:"HITL exact-output measurement allocation failed"
       ~cause:Exact_flow_execution_failed
-  | Exact_output.Flow_candidates_exhausted { evidence; _ } ->
+  | Exact_output.Flow_candidates_exhausted { rejection; evidence } ->
     record_outcome "exact_candidates_exhausted";
     log_exact_error
       prepared.entry
       "candidate exhaustion before dispatch"
-      (flow_evidence_detail evidence);
+      (Printf.sprintf
+         "%s (%s)"
+         (candidate_rejection_detail rejection)
+         (flow_evidence_detail evidence));
     settle_current_or_signal
       ~queue_ops
       prepared.entry
@@ -919,8 +1025,15 @@ let handle_flow_error ~queue_ops (prepared : prepared_flow) = function
          ~reason:(flow_callback_error_to_string cause)
          ~cause:Exact_terminal_persistence_failure);
     ignore failed
-  | Exact_output.Flow_exact_execution_failed { candidate; _ } ->
+  | Exact_output.Flow_exact_execution_failed { candidate; cause; evidence } ->
     record_outcome "exact_execution_failed";
+    log_exact_error
+      prepared.entry
+      "exact execution"
+      (Printf.sprintf
+         "%s (%s)"
+         (execution_cause_detail cause.cause)
+         (flow_evidence_detail evidence));
     quarantine_candidate
       ~queue_ops
       prepared.entry


### PR DESCRIPTION
## 문제

운영 화면에 뜨는 문구:

```
Auto Judge exact attempt quarantined: flow_execution_failed
```

2026-07-28 실측으로 25건이 이 라벨 하나로 격리됐고, **같은 런에서 Auto Judge는 동일 슬롯(`glm-coding.glm-5-turbo`)으로 60건을 정상 판정**했습니다. 즉 설정 문제가 아닙니다.

`flow_execution_failed`는 단일 원인이 아니라 **5개 서로 다른 결과가 뭉친 라벨**입니다:

| 분기 | 담고 있던 증거 | 기존 처리 |
|---|---|---|
| `Flow_exact_execution_failed` | `execution_error.cause` (provider 판정) | **로그 없음** |
| `Flow_candidates_exhausted` | `candidate_rejection_receipt` (토큰 산술) | `rejection` 폐기 |
| `Flow_attempt_start_failed` | `Call_id_generation_failed detail` | 폐기 |
| `Flow_measurement_start_failed` | `flow_evidence` | 폐기 |
| `Semantic_provenance_mismatch` | candidate | 폐기 |

## 왜 라이브에서 판별이 불가능한가

분기별 판별자는 **이미 기록되고 있습니다** — `record_outcome`이 `masc_keeper_hitl_summary_outcomes_total{outcome=...}` 카운터에 씁니다. 그런데 읽을 수가 없습니다:

- `/metrics`, `/api/v1/metrics`, `/api/v1/models/metrics` × 4개 포트: 전부 미응답
- 디스크 영속: 없음 (in-memory only)
- `~/.masc/logs/system_log_2026-07-28.jsonl`: `"quarantin"` 0건, `"flow_execution_failed"` 0건

판별자가 존재하는데 도달 경로가 없습니다.

## 변경 내용

두 개의 exhaustive 렌더러를 추가하고 5개 분기를 배선합니다.

```ocaml
let rec capacity_disposition_detail : Exact_output.input_capacity_disposition -> string
  = function
  | Context_window_exceeded { input_tokens; reserved_output_tokens; max_context_tokens } ->
    Printf.sprintf
      "context window exceeded (input=%d reserved_output=%d max_context=%d)"
      ...
  | Token_capacity_rejected rejection -> token_capacity_detail rejection
  ...
```

catch-all(`_ ->`)을 쓰지 않습니다. OAS가 새 disposition을 추가하면 이 파일이 컴파일 에러를 냅니다 — 프로덕션에서 설명 없는 quarantine이 되는 대신에.

## 동작 변경 없음

quarantine 여부, settle 경로, cause 라벨은 그대로입니다. `Log.Keeper.warn` 호출과 필드 렌더링만 추가됩니다.

## 이건 수정이 아니라 진단입니다

Auto Judge 고장은 이 PR로 해결되지 않습니다. 현재 가설 두 개가 갈려 있고, 이 로그가 붙어야 판별됩니다:

- `Context_window_exceeded` — 단, 294KB(≈73K 토큰) 실패가 `max_context_tokens=200000`에 안 걸리므로 단독으로는 설명 부족
- `Capacity_evidence_expired` — 작은 요청은 측정 없이 통과하고 큰 요청만 용량 증거가 필요하므로, 관측된 크기 상관관계(성공=0바이트 / 실패=294KB~1.1MB)에 더 부합

## 근본 해결은 OAS 쪽입니다

OAS `exact_output.mli`에는 오류/거부/판정 타입이 **20개**인데 렌더러가 있는 건 **1개**(`measurement_receipt_snapshot_decode_error_to_string`)뿐입니다. `val ..._to_string` 10개는 전부 식별자용(`call_id_to_string`, `flow_id_to_string`, `schema_fingerprint_to_string` 등)이고, `flow_execution_error`(생성자 9개)용은 없습니다. 그래서 소비처는 직접 분류기를 짜거나 `_`로 버리는 것 외에 선택지가 없고, masc는 둘 다 하고 있습니다:

| masc 파일 | OAS 오류 매치 arm |
|---|---|
| `keeper_error_classify.ml` | 153 |
| `keeper_event_bridge_error_json.ml` | 66 |
| `keeper_agent_error.ml` | 54 |
| `keeper_turn_runtime_budget.ml` | 30 |

그리고 flow evidence를 그대로 버리는 소비처가 4곳입니다 (`hitl_summary_worker`, `keeper_librarian_runtime`, `keeper_compaction_llm_summarizer`, `keeper_board_attention_exact_flow`).

이 PR은 그 중 **1곳만** 고칩니다. 나머지 3곳은 오늘 실패하고 있지 않아 범위에 넣지 않았습니다.

OAS 쪽 이슈: jeong-sik/masc#27861

WORKAROUND: production-blocking diagnosis. Auto Judge 자동화율이 라이브에서 붕괴했고 원인 분기를 식별할 다른 경로가 없습니다. 이 렌더러는 OAS가 자기 오류 렌더링 API를 노출하면 삭제 대상입니다.
RFC-0042 (string 분류기를 closed sum type으로 닫는 방향과 동일 계열 — 여기서는 반대로 typed payload가 소비처에서 증발하는 경우)
removal target: jeong-sik/masc#27861 (OAS flow-error 렌더링 API) 도입 시

## 검증

- `scripts/dune-local.sh build @lib/check` 통과
- 동작 변경 없으므로 신규 테스트 없음. 렌더러는 exhaustive match라 컴파일러가 전수성을 보증합니다.
- 미검증: 실제 로그 출력은 배포 후에만 확인 가능합니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
