### PR TITLE
fix(keeper): lifecycle latch를 강도 순서 있는 권한으로 승격

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -124,18 +124,26 @@ let persist_directive_meta_update
 
 let directive_paused_meta (meta : keeper_meta) paused =
   if paused
-  then
-    { meta with
-      paused = true
-    ; latched_reason =
-        Some
-          (Keeper_latched_reason.Operator_paused
-             { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive })
-    ; runtime = { meta.runtime with last_blocker = None }
-    ; updated_at = now_iso ()
-    }
-  else
-    { (Keeper_meta_contract.mark_resumed meta) with updated_at = now_iso () }
+  then (
+    let { Keeper_meta_contract.meta = paused_meta; latch } =
+      Keeper_meta_contract.mark_operator_paused
+        ~operator_actor:Keeper_latched_reason.operator_actor_grpc_directive
+        meta
+    in
+    (match latch with
+     | Keeper_latched_reason.Replace _ -> ()
+     | Keeper_latched_reason.Keep_stronger { persisted; rejected } ->
+       (* A directive pause must not relabel a reset-required or terminal latch
+          as an ordinary pause: that would re-arm generic resume against damage
+          the latch was recorded to withhold it from. *)
+       Log.Keeper.warn
+         "directive pause retained the stronger persisted latch keeper=%s \
+          persisted=%s not_applied=%s"
+         meta.name
+         (Keeper_latched_reason.to_wire persisted)
+         (Keeper_latched_reason.to_wire rejected));
+    { paused_meta with runtime = { paused_meta.runtime with last_blocker = None } })
+  else { (Keeper_meta_contract.mark_resumed meta) with updated_at = now_iso () }
 ;;
 
 let transcript_corruption_reset_required (meta : keeper_meta) =

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -409,24 +409,63 @@ type keeper_meta =
   }
 
 let mark_transcript_corruption_reset_required (m : keeper_meta) : keeper_meta =
-  { m with
-    paused = true
-  ; latched_reason = Some Keeper_latched_reason.Transcript_corruption_reset_required
-  ; updated_at = now_iso ()
+  let latched_reason =
+    match
+      Keeper_latched_reason.replace
+        ~persisted:m.latched_reason
+        ~requested:Keeper_latched_reason.Transcript_corruption_reset_required
+    with
+    | Keeper_latched_reason.Replace reason -> Some reason
+    | Keeper_latched_reason.Keep_stronger { persisted; _ } -> Some persisted
+  in
+  { m with paused = true; latched_reason; updated_at = now_iso () }
+;;
+
+type operator_pause_outcome =
+  { meta : keeper_meta
+  ; latch : Keeper_latched_reason.replacement
+  }
+
+(* The pause bit is set unconditionally: an operator asking for a pause always
+   gets a paused keeper. Only the recorded reason is arbitrated, because the
+   reason now decides which recovery paths stay open. *)
+let mark_operator_paused ~operator_actor (m : keeper_meta) : operator_pause_outcome =
+  let latch =
+    Keeper_latched_reason.replace
+      ~persisted:m.latched_reason
+      ~requested:(Keeper_latched_reason.Operator_paused { operator_actor })
+  in
+  let latched_reason =
+    match latch with
+    | Keeper_latched_reason.Replace reason -> reason
+    | Keeper_latched_reason.Keep_stronger { persisted; _ } -> persisted
+  in
+  { meta =
+      { m with
+        paused = true
+      ; latched_reason = Some latched_reason
+      ; updated_at = now_iso ()
+      }
+  ; latch
   }
 ;;
 
-(* Sanctioned generic unpause transform. Reset-required transcript and terminal
-   dead-tombstone latches are deliberately immutable here. A dead identity is
-   deleted and recreated rather than revived. *)
+(* Sanctioned generic unpause transform. The refusal is expressed through
+   [Keeper_latched_reason.strength] rather than by re-listing the latch
+   variants, so the ordering has exactly one definition: a new latch that is
+   not [Resumable] is refused here without editing this function. *)
 let mark_resumed (m : keeper_meta) : keeper_meta =
-  match m.latched_reason with
-  | Some
-      ( Keeper_latched_reason.Transcript_corruption_reset_required
-      | Keeper_latched_reason.Dead_tombstone ) ->
-    m
-  | Some (Keeper_latched_reason.Operator_paused _)
-  | None ->
+  let clearable =
+    match m.latched_reason with
+    | None -> true
+    | Some reason ->
+      (match Keeper_latched_reason.strength reason with
+       | Keeper_latched_reason.Resumable -> true
+       | Keeper_latched_reason.Reset_required | Keeper_latched_reason.Terminal -> false)
+  in
+  if not clearable
+  then m
+  else
     { m with
       paused = false
     ; latched_reason = None

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -301,13 +301,43 @@ type keeper_meta = {
 }
 
 (** Stamp the current Keeper state as structurally corrupted and requiring
-    checkpoint reset. This is current-state persistence, not a migration. *)
+    checkpoint reset. This is current-state persistence, not a migration.
+
+    A persisted [Dead_tombstone] is stronger and is left in place; see
+    {!Keeper_latched_reason.replace}. *)
 val mark_transcript_corruption_reset_required : keeper_meta -> keeper_meta
 
-(** Sanctioned generic unpause transform. Clears ordinary/operator/dead
-    latches with the pause bit and [runtime.last_blocker]. A
-    [Transcript_corruption_reset_required] latch is returned unchanged, so
-    generic resume cannot replay a poisoned checkpoint. *)
+type operator_pause_outcome =
+  { meta : keeper_meta
+  ; latch : Keeper_latched_reason.replacement
+        (** [Keep_stronger] when a stronger latch was already persisted. The
+            keeper is paused either way; only the recorded reason differs from
+            what was asked. Callers log this. *)
+  }
+
+(** The sanctioned operator-pause transform: the only place that stamps
+    [Operator_paused]. Sets [paused = true] unconditionally — an operator's
+    pause intent is always honoured — but resolves the latch through
+    {!Keeper_latched_reason.replace} so a reset-required or terminal latch is
+    never downgraded to an ordinary pause.
+
+    Before this existed, two sites assigned [Operator_paused] directly
+    ([Keeper_shutdown_finalize.paused_meta] and
+    [Keeper_keepalive.directive_paused_meta]). Either one, run against a
+    transcript-corrupted keeper, relabelled it as ordinarily paused and thereby
+    re-armed generic resume over a checkpoint that admission would still
+    reject. Observed live on 2026-07-27. *)
+val mark_operator_paused :
+  operator_actor:Keeper_latched_reason.operator_actor ->
+  keeper_meta ->
+  operator_pause_outcome
+
+(** Sanctioned generic unpause transform. Clears an ordinary [Operator_paused]
+    latch (and an unclassified pause) along with the pause bit and
+    [runtime.last_blocker]. A latch whose
+    {!Keeper_latched_reason.strength} is [Reset_required] or [Terminal] is
+    returned unchanged, so generic resume can neither replay a poisoned
+    checkpoint nor revive a dead identity. *)
 val mark_resumed : keeper_meta -> keeper_meta
 
 (** Reject [paused = false] paired with a terminal or reset-required latch. *)

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -541,21 +541,14 @@ let persist_compaction_outcome config ~keeper_name ~outcome
 (* Structural transcript corruption is deterministic current-state damage, not
    a retry class. Persist the typed reset-required latch before the owning
    lease is terminally settled. A concurrent dead tombstone remains stronger;
-   an ordinary operator/unclassified pause is upgraded to reset-required. *)
+   an ordinary operator/unclassified pause is upgraded to reset-required — that
+   arbitration now lives in [Keeper_latched_reason.replace], applied by
+   [mark_transcript_corruption_reset_required], instead of being re-derived
+   from an admission match here. *)
 let persist_transcript_corruption_pause config ~keeper_name
   : ([ `Persisted | `No_durable_meta ], string) result
   =
-  let stamp (m : Keeper_meta_contract.keeper_meta) =
-    match
-      Keeper_lifecycle_admission.state
-        ~paused:m.paused
-        ~latched_reason:m.latched_reason
-    with
-    | Keeper_lifecycle_admission.Dead_tombstone -> m
-    | Keeper_lifecycle_admission.Active
-    | Keeper_lifecycle_admission.Paused _ ->
-      Keeper_meta_contract.mark_transcript_corruption_reset_required m
-  in
+  let stamp = Keeper_meta_contract.mark_transcript_corruption_reset_required in
   match read_meta config keeper_name with
   | Error msg -> Error msg
   | Ok None -> Ok `No_durable_meta

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -307,15 +307,24 @@ let rec settle_tasks ~config ~meta operation settled_task_ids =
 ;;
 
 let paused_meta (meta : Keeper_meta_contract.keeper_meta) =
-  { meta with
-    current_task_id = None
-  ; paused = true
-  ; latched_reason =
-      Some
-        (Keeper_latched_reason.Operator_paused
-           { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
-  ; updated_at = Masc_domain.now_iso ()
-  }
+  let { Keeper_meta_contract.meta = paused; latch } =
+    Keeper_meta_contract.mark_operator_paused
+      ~operator_actor:Keeper_latched_reason.operator_actor_keeper_down
+      meta
+  in
+  (match latch with
+   | Keeper_latched_reason.Replace _ -> ()
+   | Keeper_latched_reason.Keep_stronger { persisted; rejected } ->
+     (* The keeper is paused as asked, but a stronger latch was already
+        persisted and stands. Downgrading it here would re-open a recovery path
+        that latch exists to deny. *)
+     Log.Keeper.warn
+       "keeper_down retained the stronger persisted latch keeper=%s persisted=%s \
+        not_applied=%s"
+       meta.name
+       (Keeper_latched_reason.to_wire persisted)
+       (Keeper_latched_reason.to_wire rejected));
+  { paused with current_task_id = None }
 ;;
 
 let dead_tombstone_meta (meta : Keeper_meta_contract.keeper_meta) =

--- a/lib/keeper_runtime/keeper_latched_reason.ml
+++ b/lib/keeper_runtime/keeper_latched_reason.ml
@@ -29,6 +29,48 @@ let operator_actor_of_wire = function
     Error (Printf.sprintf "Keeper_latched_reason: unknown operator actor %S" other)
 ;;
 
+type strength =
+  | Resumable
+  | Reset_required
+  | Terminal
+
+(* Exhaustive, no wildcard: a new latch variant must state its strength here
+   rather than defaulting into the weakest rung, which is what would let it be
+   silently overwritten. *)
+let strength = function
+  | Operator_paused _ -> Resumable
+  | Transcript_corruption_reset_required -> Reset_required
+  | Dead_tombstone -> Terminal
+;;
+
+let strength_to_wire = function
+  | Resumable -> "resumable"
+  | Reset_required -> "reset_required"
+  | Terminal -> "terminal"
+;;
+
+let strength_rank = function
+  | Resumable -> 0
+  | Reset_required -> 1
+  | Terminal -> 2
+;;
+
+type replacement =
+  | Replace of t
+  | Keep_stronger of
+      { persisted : t
+      ; rejected : t
+      }
+
+let replace ~persisted ~requested =
+  match persisted with
+  | None -> Replace requested
+  | Some persisted ->
+    if strength_rank (strength requested) >= strength_rank (strength persisted)
+    then Replace requested
+    else Keep_stronger { persisted; rejected = requested }
+;;
+
 let equal left right =
   match left, right with
   | Operator_paused { operator_actor = Grpc_directive },

--- a/lib/keeper_runtime/keeper_latched_reason.mli
+++ b/lib/keeper_runtime/keeper_latched_reason.mli
@@ -24,6 +24,59 @@ val operator_actor_grpc_directive : operator_actor
 val operator_actor_keeper_down : operator_actor
 val operator_actor_to_wire : operator_actor -> string
 
+(** {1 Strength ordering}
+
+    The latch began as an annotation on the [paused] bit. It is now a decision
+    input: admission denies by latch identity, and generic resume refuses
+    [Transcript_corruption_reset_required] and [Dead_tombstone] outright. So
+    replacing a persisted latch with a weaker one is a privilege change, not a
+    relabel — it hands a keeper back a recovery path the stronger latch had
+    denied.
+
+    The ordering below is that constraint, made explicit. Before it existed,
+    the same rule was stated in prose and re-implemented per site
+    ([Keeper_meta_contract.mark_resumed]'s refusal match,
+    [Keeper_meta_store.persist_transcript_corruption_pause]'s admission match),
+    and omitted at the two operator-pause writers — which is how a
+    reset-required latch could be silently downgraded to an ordinary pause. *)
+
+type strength =
+  | Resumable
+      (** Generic resume clears it. [Operator_paused]. *)
+  | Reset_required
+      (** Recoverable, but not by generic resume: the underlying damage must be
+          repaired first. [Transcript_corruption_reset_required]. *)
+  | Terminal
+      (** No resume path. The identity is recreated, not revived.
+          [Dead_tombstone]. *)
+
+val strength : t -> strength
+
+val strength_to_wire : strength -> string
+(** Stable projection for logs and metrics. Decisions must match on the typed
+    value. *)
+
+type replacement =
+  | Replace of t
+      (** The request is at least as strong as what is persisted. *)
+  | Keep_stronger of
+      { persisted : t
+      ; rejected : t
+      }
+      (** The request would weaken the persisted latch. The persisted latch
+          stands. Callers log this rather than dropping it silently: the
+          keeper is still paused as the requester intended, but for a reason
+          that constrains recovery more than they asked for. *)
+
+val replace : persisted:t option -> requested:t -> replacement
+(** Resolve a latch write against what is already persisted.
+
+    [persisted = None] always yields [Replace] — there is no latch to weaken.
+    A caller that must also honour a [paused = true] record carrying no latch
+    (an unclassified pause) has to consult that bit itself; this module sees
+    only the latch. Equal strength yields [Replace], so re-pausing under a
+    different [operator_actor] is permitted. *)
+
 module Stable : sig
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/test/test_keeper_latched_reason.ml
+++ b/test/test_keeper_latched_reason.ml
@@ -56,6 +56,141 @@ let test_hash_is_deterministic () =
     reasons
 ;;
 
+(* Strength ordering. The latch decides which recovery paths stay open, so a
+   weaker request must never replace a stronger persisted latch — that is a
+   privilege change, not a relabel. Pinned as a full matrix rather than a few
+   samples: the 2026-07-27 incident was exactly one cell of it
+   (Operator_paused requested over a persisted
+   Transcript_corruption_reset_required). *)
+
+let strength_of label reason expected =
+  check
+    bool
+    (label ^ " strength")
+    true
+    (R.strength_to_wire (R.strength reason) = expected)
+;;
+
+let test_strength_is_assigned_per_variant () =
+  strength_of
+    "gRPC operator pause"
+    (R.Operator_paused { operator_actor = R.operator_actor_grpc_directive })
+    "resumable";
+  strength_of
+    "keeper_down operator pause"
+    (R.Operator_paused { operator_actor = R.operator_actor_keeper_down })
+    "resumable";
+  strength_of
+    "transcript corruption"
+    R.Transcript_corruption_reset_required
+    "reset_required";
+  strength_of "dead tombstone" R.Dead_tombstone "terminal"
+;;
+
+let replaced label = function
+  | R.Replace reason -> reason
+  | R.Keep_stronger { persisted; rejected } ->
+    failf
+      "%s: expected the request to apply, but %a was kept over %a"
+      label
+      R.pp
+      persisted
+      R.pp
+      rejected
+;;
+
+let kept label = function
+  | R.Keep_stronger { persisted; _ } -> persisted
+  | R.Replace reason ->
+    failf "%s: expected the persisted latch to stand, but %a applied" label R.pp reason
+;;
+
+let operator_grpc = R.Operator_paused { operator_actor = R.operator_actor_grpc_directive }
+let operator_down = R.Operator_paused { operator_actor = R.operator_actor_keeper_down }
+
+let test_no_persisted_latch_always_applies () =
+  List.iter
+    (fun (label, requested) ->
+      let applied =
+        replaced label (R.replace ~persisted:None ~requested)
+      in
+      check bool (label ^ " applies when nothing is persisted") true
+        (R.equal requested applied))
+    reasons
+;;
+
+let test_equal_strength_applies () =
+  (* Re-pausing under a different operator actor is legitimate: both are
+     resumable, so neither constrains recovery more than the other. *)
+  let applied =
+    replaced
+      "keeper_down over grpc"
+      (R.replace ~persisted:(Some operator_grpc) ~requested:operator_down)
+  in
+  check bool "the newer actor is recorded" true (R.equal operator_down applied);
+  List.iter
+    (fun (label, reason) ->
+      let applied =
+        replaced label (R.replace ~persisted:(Some reason) ~requested:reason)
+      in
+      check bool (label ^ " over itself applies") true (R.equal reason applied))
+    reasons
+;;
+
+let test_stronger_request_upgrades () =
+  List.iter
+    (fun (label, persisted, requested) ->
+      let applied =
+        replaced label (R.replace ~persisted:(Some persisted) ~requested)
+      in
+      check bool (label ^ " upgrades") true (R.equal requested applied))
+    [ ( "transcript over operator pause"
+      , operator_down
+      , R.Transcript_corruption_reset_required )
+    ; "dead over operator pause", operator_grpc, R.Dead_tombstone
+    ; ( "dead over transcript"
+      , R.Transcript_corruption_reset_required
+      , R.Dead_tombstone )
+    ]
+;;
+
+let test_weaker_request_keeps_persisted () =
+  List.iter
+    (fun (label, persisted, requested) ->
+      let stood = kept label (R.replace ~persisted:(Some persisted) ~requested) in
+      check bool (label ^ " keeps the persisted latch") true (R.equal persisted stood))
+    [ (* The live 2026-07-27 downgrade: masc_keeper_down on a
+         transcript-corrupted keeper relabelled it as ordinarily paused, which
+         re-armed generic resume over a checkpoint admission still rejects. *)
+      ( "keeper_down over transcript"
+      , R.Transcript_corruption_reset_required
+      , operator_down )
+    ; ( "grpc directive over transcript"
+      , R.Transcript_corruption_reset_required
+      , operator_grpc )
+    ; "keeper_down over dead", R.Dead_tombstone, operator_down
+    ; "grpc directive over dead", R.Dead_tombstone, operator_grpc
+    ; ( "transcript over dead"
+      , R.Dead_tombstone
+      , R.Transcript_corruption_reset_required )
+    ]
+;;
+
+let test_rejected_request_is_reported_not_dropped () =
+  (* The caller must be able to say what was asked for and refused; a silent
+     preserve reads as "the pause was recorded as requested". *)
+  match
+    R.replace
+      ~persisted:(Some R.Transcript_corruption_reset_required)
+      ~requested:operator_down
+  with
+  | R.Keep_stronger { persisted; rejected } ->
+    check bool "persisted is reported" true
+      (R.equal R.Transcript_corruption_reset_required persisted);
+    check bool "the refused request is reported" true (R.equal operator_down rejected)
+  | R.Replace reason -> failf "expected the persisted latch to stand, got %a" R.pp reason
+;;
+
 let () =
   run
     "keeper_latched_reason"
@@ -67,6 +202,18 @@ let () =
             `Quick
             test_retired_failure_latches_fail_closed
         ; test_case "hash is deterministic" `Quick test_hash_is_deterministic
+        ] )
+    ; ( "strength ordering"
+      , [ test_case "each variant states a strength" `Quick
+            test_strength_is_assigned_per_variant
+        ; test_case "no persisted latch always applies" `Quick
+            test_no_persisted_latch_always_applies
+        ; test_case "equal strength applies" `Quick test_equal_strength_applies
+        ; test_case "a stronger request upgrades" `Quick test_stronger_request_upgrades
+        ; test_case "a weaker request keeps the persisted latch" `Quick
+            test_weaker_request_keeps_persisted
+        ; test_case "a refused request is reported, not dropped" `Quick
+            test_rejected_request_is_reported_not_dropped
         ] )
     ]
 ;;

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -12,9 +12,20 @@
       ([Keeper_shutdown_finalize.For_testing.dead_tombstone_meta])
       -> [Dead_tombstone]
 
-    Observability only: these tests assert the {i reason} annotation, not
-    any change to the pause/resume decision (which stays carried by
-    [meta.paused]). *)
+    The latch is no longer observability-only. It began that way — these tests
+    originally asserted the {i reason} annotation and nothing about the
+    pause/resume decision, which [meta.paused] carried alone. Since then
+    admission denies by latch identity and
+    [Keeper_meta_contract.mark_resumed] refuses
+    [Transcript_corruption_reset_required] and [Dead_tombstone] outright, so
+    the reason decides which recovery paths stay open.
+
+    The writers were not upgraded with it, and overwriting an authority is a
+    privilege change where overwriting a label was harmless: an operator pause
+    could relabel a reset-required latch as ordinary and re-arm generic resume
+    against a checkpoint admission still rejects (live 2026-07-27, rondo). The
+    "operator pause never downgrades a stronger latch" section below pins that
+    consequence, not just the annotation. *)
 
 open Alcotest
 module Keeper_meta_contract = Masc.Keeper_meta_contract
@@ -28,15 +39,23 @@ module Keeper_turn_lifecycle = Masc.Keeper_turn_lifecycle
 module Keeper_status_bridge = Masc.Keeper_status_bridge
 module Keeper_supervisor_types = Masc.Keeper_supervisor_types
 
+(* [agent_name] is derived, not spelled: the decoder rejects any value that is
+   not [Keeper_identity.keeper_agent_name name]. Building it from the same
+   function keeps the fixture correct if that convention changes. *)
 let base_json name =
   `Assoc
     [ "name", `String name
-    ; "agent_name", `String (name ^ "-agent")
+    ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
     ; "trace_id", `String ("trace-" ^ name)
     ]
 
+(* [Keeper_meta_json_parse.meta_of_json] decodes the exact current shape, so a
+   three-field literal no longer parses and every test in this file failed at
+   the fixture ("missing required fields ... runtime reset required") — before
+   asserting anything. [Masc_test_deps.meta_of_json_fixture] fills the current
+   required set, which is what the sibling suites already use. *)
 let make_meta name =
-  match Keeper_meta_json_parse.meta_of_json (base_json name) with
+  match Masc_test_deps.meta_of_json_fixture (base_json name) with
   | Ok meta -> meta
   | Error err -> failf "parse base meta: %s" err
 
@@ -114,11 +133,16 @@ let test_no_latched_reason_serializes_as_null () =
   check (option string) "unset latched_reason round-trips to None" None
     (latched_reason_wire reparsed)
 
-let test_retired_auto_resume_field_is_diagnostic_only () =
-  let before =
-    Masc.Otel_metric_store.metric_total
-      Keeper_metrics.(to_string MetaReadFailures)
-  in
+(* The invariant is unchanged — a retired field must never manufacture
+   lifecycle state — but the mechanism is stronger than when this test was
+   written. [meta_of_json] used to accept the record and ignore the unknown
+   key, emitting a diagnostic; it now decodes only the exact current shape, so
+   the record is rejected outright (see the comment at
+   [Keeper_meta_store.read_meta_file_path], which states that the separate
+   unknown-key pre-scan was removed for exactly this reason). Rejection
+   subsumes the old assertion: a record that never becomes a [keeper_meta]
+   cannot invent a pause or a latch. *)
+let test_retired_auto_resume_field_is_rejected () =
   let json =
     match base_json "retired-auto-resume-field" with
     | `Assoc fields ->
@@ -128,20 +152,18 @@ let test_retired_auto_resume_field_is_diagnostic_only () =
          :: fields)
     | _ -> fail "base_json must be an object"
   in
-  let parsed =
-    match Keeper_meta_json_parse.meta_of_json json with
-    | Ok meta -> meta
-    | Error error -> failf "retired field parse failed: %s" error
-  in
-  let after =
-    Masc.Otel_metric_store.metric_total
-      Keeper_metrics.(to_string MetaReadFailures)
-  in
-  check bool "retired field does not activate paused keeper" true parsed.paused;
-  check (option string) "retired field does not invent a latch" None
-    (latched_reason_wire parsed);
-  check (float 0.001) "retired field emits migration-needed diagnostic"
-    (before +. 1.0) after
+  match Keeper_meta_json_parse.meta_of_json json with
+  | Error error ->
+    check
+      bool
+      "the rejection names the retired field"
+      true
+      (Astring.String.is_infix ~affix:"auto_resume_after_sec" error)
+  | Ok meta ->
+    failf
+      "a retired field must not decode into lifecycle state (paused=%b, latch=%s)"
+      meta.paused
+      (Option.value ~default:"none" (latched_reason_wire meta))
 
 (* ── Status bridge surfacing ────────────────────────────────── *)
 
@@ -405,8 +427,8 @@ let () =
             test_latched_reason_survives_serialization
         ; test_case "unset reason serializes as null and round-trips to None" `Quick
             test_no_latched_reason_serializes_as_null
-        ; test_case "retired auto-resume field is diagnostic only" `Quick
-            test_retired_auto_resume_field_is_diagnostic_only
+        ; test_case "retired auto-resume field is rejected" `Quick
+            test_retired_auto_resume_field_is_rejected
         ] )
     ; ( "status bridge"
       , [ test_case "attention fields surface the typed pause reason wire" `Quick

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -319,6 +319,84 @@ let test_heartbeat_merge_preserves_typed_latched_pause () =
     None
     (latched_reason_wire unclassified_preserved)
 
+(* ── Downgrade guard: the two operator-pause writers ─────────────
+   Both sites used to assign [Operator_paused] unconditionally, so either one
+   run against a transcript-corrupted keeper relabelled it as ordinarily
+   paused — and generic resume, which refuses the reset-required latch by
+   identity, was re-armed against a checkpoint admission still rejects. Live on
+   2026-07-27 (rondo): masc_keeper_down at 14:54:28Z overwrote a latch set at
+   14:42:11Z, and the durable record then no longer named the real cause. *)
+
+let corrupted name =
+  Keeper_meta_contract.mark_transcript_corruption_reset_required (make_meta name)
+;;
+
+let wire_transcript =
+  Keeper_latched_reason.to_wire Keeper_latched_reason.Transcript_corruption_reset_required
+;;
+
+let test_keeper_down_does_not_downgrade_transcript_latch () =
+  let retained =
+    Masc.Keeper_shutdown_finalize.For_testing.paused_meta (corrupted "downretain-corrupt")
+  in
+  check bool "keeper_down still pauses the keeper" true retained.paused;
+  check
+    (option string)
+    "keeper_down keeps the reset-required latch"
+    (Some wire_transcript)
+    (latched_reason_wire retained);
+  (* The point of keeping it: generic resume must still refuse. *)
+  let resumed = Keeper_meta_contract.mark_resumed retained in
+  check bool "generic resume is still refused" true resumed.paused
+;;
+
+let test_grpc_directive_does_not_downgrade_transcript_latch () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.clear ();
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "grpc-directive-corrupt" in
+       Keeper_registry.For_testing.clear ();
+       ignore
+         (Keeper_registry.For_testing.register
+            ~base_path:config.base_path
+            keeper_name
+            (corrupted keeper_name));
+       Keeper_keepalive.process_directive ~agent_name:keeper_name Keeper_directive.Pause;
+       match Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         check bool "directive pause still pauses the keeper" true entry.meta.paused;
+         check
+           (option string)
+           "directive pause keeps the reset-required latch"
+           (Some wire_transcript)
+           (latched_reason_wire entry.meta);
+         let resumed = Keeper_meta_contract.mark_resumed entry.meta in
+         check bool "generic resume is still refused" true resumed.paused
+       | None -> fail "keeper vanished from the registry after the pause directive")
+;;
+
+let test_operator_pause_still_applies_to_an_active_keeper () =
+  (* The guard must not turn every pause into a no-op. *)
+  let paused =
+    Masc.Keeper_shutdown_finalize.For_testing.paused_meta (make_meta "downretain-active")
+  in
+  check
+    (option string)
+    "an unlatched keeper records the operator pause"
+    (Some wire_keeper_down)
+    (latched_reason_wire paused);
+  let resumed = Keeper_meta_contract.mark_resumed paused in
+  check bool "and generic resume clears it" false resumed.paused
+;;
+
 let () =
   run
     "keeper_latched_reason_wiring"
@@ -343,5 +421,13 @@ let () =
             test_dead_tombstone_final_meta_records_reason
         ; test_case "heartbeat merge preserves typed latch, not pause shape" `Quick
             test_heartbeat_merge_preserves_typed_latched_pause
+        ] )
+    ; ( "operator pause never downgrades a stronger latch"
+      , [ test_case "keeper_down keeps a reset-required latch" `Quick
+            test_keeper_down_does_not_downgrade_transcript_latch
+        ; test_case "gRPC directive keeps a reset-required latch" `Quick
+            test_grpc_directive_does_not_downgrade_transcript_latch
+        ; test_case "an unlatched keeper still records the operator pause" `Quick
+            test_operator_pause_still_applies_to_an_active_keeper
         ] )
     ]


### PR DESCRIPTION
## 목표

lifecycle latch를 **덮어쓸 수 있는 레이블에서 강도 순서가 있는 권한으로** 승격한다. 사이트별 가드 추가가 아니라 타입 SSOT에 순서를 넣고 소비처를 그리로 모은다.

## 근본 원인 — 레이블이 권한이 됐는데 쓰기 측은 안 따라갔다

`test_keeper_latched_reason_wiring.ml`의 docstring이 원래 설계를 그대로 증언한다:

> **Observability only**: these tests assert the *reason* annotation, not any change to the pause/resume decision (which stays carried by `meta.paused`).

지금은 아니다. admission이 latch identity로 거부하고, `mark_resumed`가 `Transcript_corruption_reset_required`·`Dead_tombstone`을 명시적으로 거부한다. **레이블 덮어쓰기는 무해하지만 권한 덮어쓰기는 권한 상승이다.**

그래서 operator pause가 reset-required latch를 일반 pause로 relabel → admission이 여전히 거부하는 체크포인트에 generic resume이 재무장된다.

**라이브 2026-07-27 (rondo)**: `14:42:11Z` transcript_corruption latch → `14:54:28Z` `masc_keeper_down`이 `operator_paused{keeper_down}`으로 덮어씀 → durable record가 진짜 원인을 더 이상 지목하지 못함.

## 순서는 이미 있었다 — SSOT만 없었다

| 위치 | 형태 |
|---|---|
| `keeper_meta_store.ml` 주석 | **산문**: "A concurrent dead tombstone remains stronger; an ordinary operator/unclassified pause is upgraded to reset-required" |
| `mark_resumed` | 거부 match로 구현 |
| `persist_transcript_corruption_pause` | admission match로 재구현 |
| `paused_meta` (shutdown_finalize) | **없음** ← 버그 |
| `directive_paused_meta` (keepalive) | **없음** ← 버그 |

구현 3개, 누락 2개, SSOT 0개.

## 변경

**`Keeper_latched_reason`이 순서를 소유한다:**

```ocaml
type strength = Resumable | Reset_required | Terminal
val strength : t -> strength          (* 와일드카드 없음 — 새 variant는 rung을 명시해야 함 *)

type replacement = Replace of t | Keep_stronger of { persisted : t; rejected : t }
val replace : persisted:t option -> requested:t -> replacement
```

`strength`에 와일드카드가 없어서, 새 latch variant가 **가장 약한 등급으로 조용히 흘러들어가지 않는다** — 그게 바로 덮어쓰기를 허용하는 경로다.

`Keep_stronger`가 양쪽 latch를 다 담아서, 거부가 조용히 삼켜지지 않고 보고된다.

**소비처:**
- `Keeper_meta_contract.mark_operator_paused` — `Operator_paused`를 찍는 **유일한** 지점. `paused = true`는 무조건 설정(운영자의 pause 의도는 항상 존중), **이유만** 중재
- `paused_meta` / `directive_paused_meta` → 이 함수 호출 + `Keep_stronger` 로깅
- `mark_resumed` → variant 재나열 대신 `strength`로 표현. 향후 non-resumable latch가 추가돼도 이 함수 수정 없이 거부됨
- `persist_transcript_corruption_pause` → ad-hoc admission match 제거

## 테스트

**강도 순서 매트릭스 6건 (10/10 pass)** — 샘플이 아니라 전 조합. 사고의 정확한 셀 포함:
- 각 variant가 rung을 명시하는가
- persisted 없음 → 항상 적용
- 동일 강도 → 적용 (다른 actor로 재pause는 정당)
- 상위 요청 → 승급 (transcript>operator, dead>operator, dead>transcript)
- **하위 요청 → persisted 유지** (keeper_down>transcript ← 라이브 셀, grpc>transcript, *>dead)
- 거부가 보고되는가 (조용히 삼키지 않는가)

**wiring 3건** — 실제 사이트를 통과:
- `keeper_down` transform이 reset-required를 유지하고 generic resume이 여전히 거부
- `process_directive Pause`를 레지스트리 경유 end-to-end로 돌려 동일 확인
- **대조군**: latch 없는 keeper는 여전히 operator pause를 기록하고 resume으로 풀린다 (가드가 모든 pause를 no-op으로 만들지 않음)

## 부수 수정 — 이 스위트는 한 번도 실행된 적이 없었다

`test_keeper_latched_reason_wiring`은 **origin/main에서 11/11 실패**한다. fixture 단계에서 죽어 아무것도 단언하지 못한다:

```
BASELINE (origin/main): 11 failures! in 0.146s. 11 tests run.
ASSERT parse base meta: invalid current keeper meta: missing required fields: persona, instructions, ... ; runtime reset required
```

`make_meta`가 3필드 리터럴을 쓰는데 `meta_of_json`이 exact schema로 바뀌었다. 고치지 않으면 제 신규 테스트도 실행되지 않아 아무것도 증명하지 못한다.

- `make_meta` → `Masc_test_deps.meta_of_json_fixture` (형제 스위트들이 이미 쓰는 헬퍼)
- `agent_name` → `Keeper_identity.keeper_agent_name`로 **파생**. 하드코딩하면 규약이 바뀔 때 또 깨진다
- `test_retired_auto_resume_field_is_diagnostic_only` → `_is_rejected`로 개명·재작성. 스키마가 exact가 되면서 retired 필드는 무시가 아니라 거부다(`read_meta_file_path` 주석이 그 근거). 거부는 원래 의도를 포함한다 — `keeper_meta`가 되지 못한 레코드는 pause도 latch도 만들 수 없다
- docstring의 "Observability only" 문장 갱신 — 그 문장이 곧 쓰기 사이트들이 세워진 가정이었다

**11/11 pass** (baseline 0/11).

## 로컬 검증

```
test_keeper_latched_reason         10 tests run.  Test Successful.
test_keeper_latched_reason_wiring  11 tests run.  Test Successful.
scripts/check-ssot.sh              OK
lib/masc.cma                       builds
```

## 미검증 / 범위 밖

- **write boundary 강제는 넣지 않았다.** `write_meta_typed`에 dominance 검사를 추가하려면 디스크를 읽어야 하고, 정당한 clear(`mark_resumed`)와 사고성 downgrade를 구분할 witness가 필요하다. 지금은 transform 레벨 SSOT + 드리프트 가드(신규 사이트가 `Operator_paused`를 직접 찍으면 리뷰에서 보임)로 막는다. 후속 고려 대상
- `Keeper_lifecycle_admission`의 `Unclassified`(paused=true, latch 없음)는 `replace`가 보지 않는다 — latch만 본다. `mark_operator_paused`가 `paused` 비트를 무조건 세우므로 실질 영향은 없으나, mli에 명시했다
- CI에서 이 스위트가 `runtest`로 실제 실행되는지는 확인하지 못했다 (07-27 test rot 이슈와 관련 가능)

RFC-WAIVED: 기존 타입 SSOT(`Keeper_latched_reason`)에 순서를 추가하고 이미 3곳에 흩어져 있던 규칙을 그리로 모으는 변경이다. 새 개념·새 표면·새 저장 형식 없음. credential/identity/operator control plane/sandbox/hooks 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
