### PR TITLE
feat(keeper): record what a yielding turn yielded to

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -63,17 +63,64 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
+(* What the queue held when the turn decided to yield. The decision itself is
+   [pending <> empty], so without this the record says a yield happened and
+   nothing about what it yielded to. *)
+type durable_stimulus_summary =
+  { pending_count : int
+  ; head : Keeper_event_queue.stimulus option
+  ; head_age_sec : float
+  ; kinds : Keeper_event_queue.stimulus_payload list
+  }
+
 type autonomous_yield_reason =
   | Chat_waiting
-  | Durable_stimulus_waiting
+  | Durable_stimulus_waiting of durable_stimulus_summary
 
 type autonomous_yield_request =
   { reason : autonomous_yield_reason }
 
+let durable_stimulus_summary ~now (pending : Keeper_event_queue.t) =
+  let stimuli = Keeper_event_queue.to_list pending in
+  let kinds =
+    List.map (fun (s : Keeper_event_queue.stimulus) -> s.payload) stimuli
+  in
+  match stimuli with
+  | [] -> { pending_count = 0; head = None; head_age_sec = 0.; kinds = [] }
+  | head :: _ ->
+    { pending_count = List.length stimuli
+    ; head = Some head
+    ; (* A stimulus stamped by a different clock can sit ahead of [now]. A
+         negative age reads as a stimulus from the future rather than as the
+         clock skew it is. *)
+      head_age_sec = Float.max 0. (now -. head.arrived_at)
+    ; kinds
+    }
+;;
+
+(* Rendering happens here, at the boundary where the value leaves the type
+   system for a log line. The summary itself holds the typed payloads. *)
+let durable_stimulus_summary_to_string summary =
+  let label (payload : Keeper_event_queue.stimulus_payload) =
+    Keeper_event_queue.payload_kind_label payload
+  in
+  Printf.sprintf
+    "pending=%d head=%s head_age_sec=%.1f kinds=[%s]"
+    summary.pending_count
+    (match summary.head with
+     | None -> "none"
+     | Some head -> label head.payload)
+    summary.head_age_sec
+    (summary.kinds
+     |> List.map label
+     |> List.sort_uniq String.compare
+     |> String.concat ",")
+;;
+
 let runtime_yield_reason request =
   match request.reason with
   | Chat_waiting -> Runtime_agent.Chat_waiting
-  | Durable_stimulus_waiting ->
+  | Durable_stimulus_waiting _ ->
     Runtime_agent.Durable_stimulus_waiting
 ;;
 

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -24,13 +24,34 @@ type raw_trace_sink_outcome =
 
 (** Typed reason for an autonomous Keeper run to release its lane after OAS
     completes a tool boundary. *)
+type durable_stimulus_summary = {
+  pending_count : int;
+  head : Keeper_event_queue.stimulus option;
+  head_age_sec : float;
+  kinds : Keeper_event_queue.stimulus_payload list;
+}
+(** What the durable queue held at the instant the turn yielded. The yield
+    condition is [pending <> empty], so a yield record without this says only
+    that a yield happened, not what it yielded to — which cannot distinguish
+    healthy cooperation from a keeper that never finishes a turn. *)
+
 type autonomous_yield_reason =
   | Chat_waiting
-  | Durable_stimulus_waiting
+  | Durable_stimulus_waiting of durable_stimulus_summary
 
 type autonomous_yield_request = {
   reason : autonomous_yield_reason;
 }
+
+val durable_stimulus_summary
+  :  now:float
+  -> Keeper_event_queue.t
+  -> durable_stimulus_summary
+(** Project the queue snapshot the yield decision already read. [now] is
+    supplied by the caller so the age is measured against the same clock the
+    decision used. *)
+
+val durable_stimulus_summary_to_string : durable_stimulus_summary -> string
 
 val terminal_effect_boundary_decision
   :  Keeper_tools_oas.terminal_effect_state

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -323,9 +323,16 @@ let make_hooks
         let prompt_tok_s = fmt_tok_s prompt_tok_s_opt in
         let decode_tok_s = fmt_tok_s decode_tok_s_opt in
         let thinking = summarize_thinking_blocks response.content in
+        (* [tokens] alone is a numerator. Runtimes in one fleet declare
+           windows from 200K to 1M, so the same absolute count means a
+           different amount of pressure per keeper and the log cannot be
+           compared across them. The window is already on the turn record;
+           carrying it here makes the log self-sufficient. [0] means the
+           provider reported no window rather than a window of zero. *)
+        let context_window = context_max_of_telemetry response.telemetry in
         Log.Keeper.info ~keeper_name:meta.name
-          "turn=%d total_turns=%d runtime_lane=%s tokens=%d wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s latency_ms=%d thinking_present=%b thinking_blocks=%d thinking_chars=%d redacted_thinking_blocks=%d thinking_kind=%s"
-          turn meta.runtime.usage.total_turns model total_tok
+          "turn=%d total_turns=%d runtime_lane=%s tokens=%d context_window=%d wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s latency_ms=%d thinking_present=%b thinking_blocks=%d thinking_chars=%d redacted_thinking_blocks=%d thinking_kind=%s"
+          turn meta.runtime.usage.total_turns model total_tok context_window
           wall_tok_s prompt_tok_s decode_tok_s latency_ms
           thinking.thinking_present
           thinking.thinking_blocks
@@ -433,7 +440,8 @@ let make_hooks
          | Tool_result.Error -> Log.Keeper.error
          | Tool_result.Ok | Tool_result.Unknown -> Log.Keeper.info)
           "keeper:%s tool_call tool=%s params=[%s] input_shape=[%s] outcome=%s out_len=%d error_preview=%s"
-          (!meta_ref).name tool_name input_keys input_shape outcome_s out_len error_preview;
+          (!meta_ref).name tool_name input_keys input_shape outcome_s out_len
+          error_preview;
         (* Persistent tool call I/O log for dashboard inspector.
            tool_start_time is keeper-local (one ref per make_hooks call).
            Tool calls within Agent.run are sequential, so no race. *)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -60,10 +60,20 @@ let autonomous_yield_request ~base_path ~keeper_name =
          in
          if Keeper_event_queue.is_empty pending
          then Ok None
-         else
+         else (
+           let summary =
+             Keeper_agent_run.durable_stimulus_summary
+               ~now:(Time_compat.now ())
+               pending
+           in
+           Log.Keeper.info
+             ~keeper_name
+             "autonomous turn yields to durable stimulus: %s"
+             (Keeper_agent_run.durable_stimulus_summary_to_string summary);
            Ok
              (Some
-                Keeper_agent_run.{ reason = Durable_stimulus_waiting }))
+                Keeper_agent_run.
+                  { reason = Durable_stimulus_waiting summary })))
 ;;
 
 (** [run] operates on the immutable [Keeper_unified_turn_types.turn_state]

--- a/test/dune
+++ b/test/dune
@@ -670,6 +670,11 @@
 
 
 (test
+ (name test_keeper_yield_observability)
+ (modules test_keeper_yield_observability)
+ (libraries alcotest astring masc_test_deps))
+
+(test
  (name test_keeper_paused_work_cancellation_transaction)
  (modules test_keeper_paused_work_cancellation_transaction)
  (libraries alcotest masc_test_deps eio_main))

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -73,7 +73,14 @@ let test_autonomous_yield_boundary_contract () =
     { reason = Masc.Keeper_agent_run.Chat_waiting }
   in
   let durable_stimulus : Masc.Keeper_agent_run.autonomous_yield_request =
-    { reason = Masc.Keeper_agent_run.Durable_stimulus_waiting }
+    { reason =
+        Masc.Keeper_agent_run.Durable_stimulus_waiting
+          { pending_count = 1
+          ; head = None
+          ; head_age_sec = 0.
+          ; kinds = [ Keeper_event_queue.Bootstrap ]
+          }
+    }
   in
   (match F.runtime_yield_reason chat with
    | Runtime_agent.Chat_waiting -> ()

--- a/test/test_keeper_yield_observability.ml
+++ b/test/test_keeper_yield_observability.ml
@@ -1,0 +1,98 @@
+(* A yield record that carries only [turns_used] cannot distinguish a Keeper
+   cooperating with a real queue from one that never finishes a turn. These
+   fix what the record says about the queue it yielded to. *)
+
+open Alcotest
+
+module Run = Masc.Keeper_agent_run
+module Q = Keeper_event_queue
+
+let stimulus ~post_id ~arrived_at ~payload =
+  { Q.post_id; urgency = Q.Normal; arrived_at; payload }
+;;
+
+let queue_of stimuli = List.fold_left Q.enqueue Q.empty stimuli
+
+let test_summary_reports_what_the_turn_yielded_to () =
+  let now = 1000. in
+  let pending =
+    queue_of
+      [ stimulus ~post_id:"a" ~arrived_at:940. ~payload:Q.Bootstrap
+      ; stimulus ~post_id:"b" ~arrived_at:990. ~payload:Q.Manual_compaction_requested
+      ; stimulus ~post_id:"c" ~arrived_at:995. ~payload:Q.Bootstrap
+      ]
+  in
+  let s = Run.durable_stimulus_summary ~now pending in
+  check int "every waiting stimulus is counted" 3 s.pending_count;
+  (match s.head with
+   | Some head ->
+     check
+       bool
+       "the head is the one that will run next"
+       true
+       (head.Q.payload = Q.Bootstrap)
+   | None -> fail "a non-empty queue reported no head");
+  check (float 0.001) "the head's wait is measured, not the newest" 60. s.head_age_sec;
+  check
+    int
+    "every waiting payload is retained, not deduplicated in the value"
+    3
+    (List.length s.kinds)
+;;
+
+let test_empty_queue_reports_absence_not_a_fabricated_head () =
+  let s = Run.durable_stimulus_summary ~now:1000. Q.empty in
+  check int "no pending" 0 s.pending_count;
+  check bool "no head is named" true (s.head = None);
+  check (float 0.001) "no age is invented" 0. s.head_age_sec;
+  check int "no kinds" 0 (List.length s.kinds)
+;;
+
+let test_head_age_never_goes_negative () =
+  (* A stimulus stamped by a different clock can be ahead of [now]. A negative
+     age would read as a stimulus from the future rather than a clock skew. *)
+  let pending =
+    queue_of [ stimulus ~post_id:"a" ~arrived_at:2000. ~payload:Q.Bootstrap ]
+  in
+  let s = Run.durable_stimulus_summary ~now:1000. pending in
+  check (float 0.001) "skew clamps to zero" 0. s.head_age_sec
+;;
+
+let test_summary_renders_every_field () =
+  let pending =
+    queue_of [ stimulus ~post_id:"a" ~arrived_at:900. ~payload:Q.Bootstrap ]
+  in
+  let rendered =
+    Run.durable_stimulus_summary ~now:1000. pending
+    |> Run.durable_stimulus_summary_to_string
+  in
+  List.iter
+    (fun fragment ->
+       check
+         bool
+         (fragment ^ " is present in the log line")
+         true
+         (Astring.String.is_infix ~affix:fragment rendered))
+    [ "pending=1"; "head=bootstrap"; "head_age_sec=100.0"; "kinds=[bootstrap]" ]
+;;
+
+let () =
+  run
+    "Keeper yield observability"
+    [ ( "durable stimulus summary"
+      , [ test_case
+            "reports what the turn yielded to"
+            `Quick
+            test_summary_reports_what_the_turn_yielded_to
+        ; test_case
+            "empty queue reports absence"
+            `Quick
+            test_empty_queue_reports_absence_not_a_fabricated_head
+        ; test_case
+            "head age never goes negative"
+            `Quick
+            test_head_age_never_goes_negative
+        ; test_case "renders every field" `Quick test_summary_renders_every_field
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇이 안 보이는가

autonomous 턴은 durable 큐가 비어있지 않으면 양보합니다 (`keeper_unified_turn_execution.ml`). 남는 기록은 `yielded_to_durable_stimulus:<turns_used>` 이고, 그 숫자는 provider 턴 카운터입니다 — 큐에 대한 정보가 아닙니다. **대기 1건과 12건이 같은 기록을 남깁니다.**

그래서 두 상태가 밖에서 구분되지 않습니다.

- 실제 백로그와 협조하는 keeper
- 매 provider 턴마다 양보하며 턴을 끝내지 못하는 keeper

라이브 turn-record 는 후자를 보여줍니다. `turns_used` 가 1 씩 증가합니다.

```
07:08:31  yielded_to_durable_stimulus:56   in=46498 out=99
07:09:19  yielded_to_durable_stimulus:57   in=47063 out=285
07:10:01  yielded_to_durable_stimulus:58   in=48400 out=268
...
09:14:29  yielded_to_durable_stimulus:356  in=245776 out=150
```

매 턴이 provider 턴 하나를 쓰고 양보합니다. 그런데 기록만 봐서는 이것과 "큐가 붐벼서 양보" 를 구분할 수 없습니다.

## 변경

**1. 양보 결정이 이미 읽은 큐 스냅샷을 버리지 않고 싣습니다.**

```ocaml
type durable_stimulus_summary = {
  pending_count : int;
  head : Keeper_event_queue.stimulus option;
  head_age_sec : float;
  kinds : Keeper_event_queue.stimulus_payload list;
}
```

값은 typed 로 들고 있습니다. 문자열 렌더링은 로그 호출 지점 한 곳에서만 일어납니다. 빈 큐는 `head = None` 이며 `"none"` 라벨이 아닙니다.

결정 지점에 로그 한 줄이 추가됩니다.

```
autonomous turn yields to durable stimulus: pending=3 head=bootstrap head_age_sec=60.0 kinds=[bootstrap,manual_compaction_requested]
```

**2. 턴 완료 라인에 `context_window` 를 추가합니다.**

`tokens` 는 분자입니다. 한 함대 안에서 런타임이 선언하는 윈도우가 200K ~ 1M 이라 같은 절대값이 keeper 마다 다른 압박을 뜻하고, 로그만으로는 keeper 간 비교가 불가능합니다. 값은 이미 turn-record 에 있고(`context_window`) 로그에만 없었습니다.

오늘 이 결함으로 실제 오판이 났습니다 — rondo 의 예산이 로그에 없어 같은 로그에 있던 analyst 의 `max_context=200000` 을 참조해 "rondo 가 상한을 초과했다" 고 결론냈는데, rondo 의 실제 윈도우는 1,048,576 이었고 사용률은 26% 였습니다. `turn_record.mli:65-69` 가 이 상황을 "the fabricated 200K" 로 미리 경고하고 있습니다.

## 동작은 바뀌지 않습니다

양보 조건, 양보 결정, 런타임 stop reason 모두 그대로입니다. 관측만 추가됩니다.

## 테스트

신규 `test/test_keeper_yield_observability.ml` — 4 케이스:

- 대기 중인 자극 수, head 의 신원, head 의 대기 시간, 뒤에 있는 payload 들을 모두 보고한다
- 빈 큐는 head 부재를 보고하고 값을 지어내지 않는다
- 다른 시계에서 찍힌 자극이 `now` 보다 앞서도 나이가 음수가 되지 않는다 (미래에서 온 자극으로 읽히지 않게)
- 로그 문자열에 네 필드가 모두 렌더링된다

## 로컬 검증

```
dune build @check                                통과
dune exec test/test_keeper_yield_observability.exe   4/4 통과
```

## 미검증

- 이 로그가 실제로 무엇을 드러낼지는 배포 후에만 압니다. 매 양보가 `pending=1` 이면 큐가 거의 비어있는데도 양보하는 것이고, 큰 수면 실제 백로그입니다. 지금은 둘을 구분할 데이터가 없어 어느 쪽인지 말할 수 없습니다.
- 양보 자체가 결함인지는 이 PR 이 답하지 않습니다. 답할 데이터를 만들 뿐입니다.

## 이 PR 이 하지 않는 것

중복 호출 계수를 넣으려다 걷어냈습니다. 최근 N 건 윈도우 방식이었는데 N 에 근거가 없었습니다 — 하드코딩된 휴리스틱이고, 관측이라는 명목으로 임의 상수를 심는 것이라 삭제했습니다.

RFC-WAIVED: 기존 결정이 이미 읽은 값을 기록에 싣는 관측 추가입니다. 새 설계나 새 판정 경로를 도입하지 않으며 동작을 바꾸지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
