### PR TITLE
fix(event-queue): persist the transition outbox so a settled WAL can retire

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -732,8 +732,20 @@ let commit_transform_unlocked
           (match save_state owner next with
            | Error _ as error -> error
            | Ok () ->
-             after_commit (State.pending next);
-             Ok value)))
+             (* [load_state_unlocked] above replayed the settlement WAL, so
+                [next] already carries that settlement's pending mutation and
+                its transition outbox, and the snapshot just written persists
+                both (schema v8). Retire the WAL here, paired with the revision
+                bump that absorbed it. Leaving it behind is what latches the
+                owner: the next load replays an already-absorbed row against
+                the advanced revision, [settle_committed] rejects it on
+                [source_revision], and no runtime path can clear it because the
+                projector itself starts with [load_state_unlocked] (#26074). *)
+             (match compact_settlement_wal_unlocked owner with
+              | Error _ as error -> error
+              | Ok () ->
+                after_commit (State.pending next);
+                Ok value))))
 ;;
 
 let commit_transform

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -256,7 +256,17 @@ type transfer_projection_result =
   | Transfer_projected
   | Transfer_already_projected
 
-let schema = "keeper.event_queue.state.v7"
+let schema = "keeper.event_queue.state.v8"
+
+(* v7 carried [schema; revision; pending] only. The transition outbox lived
+   solely in the settlement WAL, which forced that WAL to stay on disk after
+   its pending mutation had already been absorbed into a saved snapshot - and a
+   later revision bump then made the retained row unreplayable, latching the
+   owner into "reset required" with no runtime exit (#26074). v8 persists the
+   outbox so the WAL carries one obligation with one lifetime. v7 snapshots
+   decode with an empty outbox: any obligation they had is still in their WAL,
+   which replays as before. *)
+let schema_v7 = "keeper.event_queue.state.v7"
 
 let empty =
   { revision = 0L
@@ -3407,6 +3417,8 @@ let to_yojson state =
     [ "schema", `String schema
     ; "revision", int64_json state.revision
     ; "pending", Keeper_event_queue.queue_to_yojson state.pending
+    ; ( "transition_outbox"
+      , `List (List.map outbox_entry_to_yojson state.transition_outbox) )
     ]
 ;;
 
@@ -3557,22 +3569,44 @@ let of_yojson json =
   let context = "keeper event queue state" in
   let* fields = assoc_fields ~context json in
   let* schema_value = string_field ~context "schema" fields in
-  if not (String.equal schema_value schema)
-  then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
-  else
-    let expected_fields = [ "schema"; "revision"; "pending" ] in
-    let* () = exact_fields ~context ~expected:expected_fields fields in
-    let* revision = int64_field ~context "revision" fields in
-    let* pending_json = required_field ~context "pending" fields in
-    let* pending = Keeper_event_queue.queue_of_yojson pending_json in
-    validate_state
-      { revision
-      ; next_lease_sequence = 1L
-      ; pending
-      ; leases = []
-      ; last_settlement = None
-      ; transition_outbox = []
-      ; accepted_transfer_projections = []
-      ; exact_execution_bindings = []
-      }
+  let* expected_fields =
+    if String.equal schema_value schema
+    then Ok [ "schema"; "revision"; "pending"; "transition_outbox" ]
+    else if String.equal schema_value schema_v7
+    then Ok [ "schema"; "revision"; "pending" ]
+    else
+      Error
+        (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
+  in
+  let* () = exact_fields ~context ~expected:expected_fields fields in
+  let* revision = int64_field ~context "revision" fields in
+  let* pending_json = required_field ~context "pending" fields in
+  let* pending = Keeper_event_queue.queue_of_yojson pending_json in
+  let* transition_outbox =
+    if String.equal schema_value schema
+    then list_field ~context "transition_outbox" outbox_entry_of_yojson fields
+    else Ok []
+  in
+  (* [next_lease_sequence] is a private carrier, but it is not free: the state
+     invariant requires it to exceed every receipt sequence still held. A
+     restored outbox brings its receipts' sequences back, so seeding a constant
+     here would reject the very snapshot this decoder just read. Derive it from
+     what was restored; an empty outbox yields 1L, the pre-v8 seed. *)
+  let next_lease_sequence =
+    List.fold_left
+      (fun acc (entry : outbox_entry) -> Int64.max acc entry.receipt.lease_sequence)
+      0L
+      transition_outbox
+    |> Int64.succ
+  in
+  validate_state
+    { revision
+    ; next_lease_sequence
+    ; pending
+    ; leases = []
+    ; last_settlement = None
+    ; transition_outbox
+    ; accepted_transfer_projections = []
+    ; exact_execution_bindings = []
+    }
 ;;

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -670,6 +670,34 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
       check bool "cancellation WAL survives until projection" true
         (Sys.file_exists settlement_wal_path
          && String.trim (read_file settlement_wal_path) <> "");
+      (* #26074: projection is driven only by the janitor, so ordinary queue
+         traffic races it. An enqueue between the settlement and the projection
+         bumps the snapshot revision; if the settlement WAL is still on disk at
+         that point, every later load replays a row whose [source_revision] no
+         longer matches and the owner latches into "reset required" with no
+         runtime exit - the projector itself cannot recover because it begins
+         with [load_state_unlocked]. Drive that exact interleaving here. *)
+      let interleaved_stimulus : Keeper_event_queue.stimulus =
+        { cancellation.source with
+          post_id = "interleaved-enqueue-during-settlement"
+        ; arrived_at = 203.5
+        }
+      in
+      Keeper_registry_event_queue.enqueue ~base_path keeper_name interleaved_stimulus;
+      (match Keeper_event_queue_persistence.load_state_result ~base_path ~keeper_name with
+       | Ok _ -> ()
+       | Error detail ->
+         failf "enqueue after settlement made the event queue unloadable: %s" detail);
+      (* Withdraw the interleaved stimulus so the assertions below still measure
+         what the cancelled retry produced rather than what this probe added. *)
+      (match
+         Keeper_registry_event_queue.drop_by_post_id
+           ~base_path
+           keeper_name
+           ~post_id:interleaved_stimulus.post_id
+       with
+       | Ok _ -> ()
+       | Error message -> fail ("interleaved stimulus drop failed: " ^ message));
       (match
          Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
        with


### PR DESCRIPTION
Closes #26074.

## 문제

schedule 취소가 settle된 뒤 **enqueue나 ack이 한 번이라도** 일어나면, 이후 모든 로드가 실패하고 event queue가 `reset required`로 영구 래치됩니다. 런타임 복구 경로가 없어 파일 수동 삭제만 남습니다.

도입: #26045 (`322ebf8fe7`). 실행 중인 `main_eio.exe`에 포함돼 있으나 **아직 발화하지 않은 잠복 상태**입니다 (라이브 settlement WAL 0개, 로그 0건).

```
commit_transform_unlocked   load(WAL replay) → transform → bump R→R+1 → save
다음 로드                    스냅샷 R+1, WAL 행은 여전히 R 에 고정
settle_committed            source_revision 불일치 → reset_required_message
```

자가 복구가 안 되는 이유: `load_state_unlocked`가 재시작 때만이 아니라 **매 로드마다** WAL을 replay하고(`:541-548`), 프로젝터 자신도 `let* state = load_state_unlocked owner`로 시작하므로(`:1205`) 불일치가 생긴 순간 WAL을 영원히 회수할 수 없습니다.

## 근본 원인

revision 가드는 잘못이 없습니다. 이미 옮겨간 큐에 settlement를 재적용하는 것을 막는 TOCTOU 방어입니다.

문제는 **settlement WAL 하나가 수명이 다른 두 의무를 나른다**는 데 있습니다.

| 의무 | 수명 | 저장 위치 (수정 전) |
|---|---|---|
| pending 큐 변경 | 첫 `save_state_unlocked`에 흡수 | snapshot |
| reaction-ledger 투영 의무 (`transition_outbox`) | janitor가 투영할 때까지 | **snapshot에 없음 → WAL이 유일** |

`to_yojson`이 `schema`/`revision`/`pending`만 영속화하므로, ledger 의무를 지키려면 WAL을 남길 수밖에 없고, 남기면 이미 흡수된 pending 변경이 재적용 대상으로 남습니다. 두 요구가 같은 파일에서 충돌합니다.

투영은 커밋과 비동기이고 janitor만 구동합니다 (`InternalTimers.janitor_interval_sec = 60.0`). 취소 후 최소 한 주기 동안 창이 열립니다.

## 변경

**스키마 v8 — `transition_outbox`를 영속 필드로**

```ocaml
let to_yojson state =
  `Assoc
    [ "schema", `String schema
    ; "revision", int64_json state.revision
    ; "pending", Keeper_event_queue.queue_to_yojson state.pending
    ; "transition_outbox", `List (List.map outbox_entry_to_yojson state.transition_outbox)
    ]
```

**커밋이 흡수한 WAL을 그 자리에서 회수**

```ocaml
| Ok () ->
  (match compact_settlement_wal_unlocked owner with
   | Error _ as error -> error
   | Ok () -> after_commit (State.pending next); Ok value)
```

bump와 회수가 짝을 이룹니다. `source_revision` 가드는 **건드리지 않았습니다.**

### 하위호환

v7 스냅샷은 3필드로 계속 디코드되고 outbox는 `[]`로 시작합니다. 그들이 가진 의무는 아직 WAL에 있고 기존대로 replay됩니다. 마이그레이션이 필요 없습니다.

`next_lease_sequence`는 복원된 receipt에서 유도합니다 — 상태 불변식이 "모든 receipt sequence를 초과할 것"을 요구하므로 상수를 심으면 **방금 읽은 스냅샷을 스스로 거부**합니다. 이건 추론이 아니라 테스트가 잡아낸 실제 실패였습니다.

### 검토했으나 택하지 않은 대안

outbox 미처리 상태에서 bump를 거부하는 방법. enqueue/ack이 fail-closed가 되어 keeper liveness를 죽입니다. 이 저장소가 반복적으로 제거해온 형태라 채택하지 않았습니다.

## 검증

`test/test_schedule_consumer_dispatch.ml`의 기존 취소 케이스에 실제 경합을 끼워 넣었습니다 — settlement 후 enqueue, 그 다음 load.

| 조건 | 결과 |
|---|---|
| 이 변경 적용 | **15/15 통과** |
| `origin/main` + 테스트만 적용 | **1 실패** — `accepted cancellation source revision changed: expected 1, current 2` |

양성 대조가 예측한 오류 문자열을 정확히 재현합니다. 별도 테스트를 새로 만들지 않고 기존 케이스를 확장한 이유는, 이 결함이 라이브 시퀀스(취소 → 큐 트래픽 → 투영) 안에서만 나타나기 때문입니다. 프로브 stimulus는 뒤쪽 단언의 측정 대상을 흔들지 않도록 확인 후 회수합니다.

**미검증**: 이 스위트는 `ci.yml`의 실행 대상 목록에 없어 CI가 컴파일만 합니다. 위 결과는 로컬 실행입니다 (#25803).

## 관련

- #26046의 `keeper_event_queue_persistence.ml:1636` Codex P1 스레드가 같은 결함을 지적했고 미해결 상태입니다.
- 형태가 #26020이 제거한 lease 모델과 같습니다: 일시적 불일치 → 영구 상태, 런타임 해제 경로 없음.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
