### PR TITLE
fix(dashboard): align verification request test with immutable UI

### DIFF
--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -193,18 +193,16 @@ describe('VerificationRequestsPanel', () => {
     })
   })
 
-  it('renders conflict-triage pending rows as read-only summary and next action', async () => {
+  it('renders immutable submissions as read-only summary and next action', async () => {
     setData([
       makeRequest({
         request_id: 'req-conflict',
-            request_kind: 'conflict_triage',
         request_summary: 'Conflict verification required: board / planning / mutation path disagree.',
         next_action: 'Reconcile board / planning / mutation surfaces before ordinary approval.',
       }),
     ])
     render(html`<${VerificationRequestsPanel} />`)
 
-    expect(screen.getByText('충돌 triage')).toBeTruthy()
     expect(screen.queryByRole('columnheader', { name: '액션' })).toBeNull()
     expect(screen.queryByRole('button', { name: '승인' })).toBeNull()
     expect(screen.queryByRole('button', { name: '반려' })).toBeNull()


### PR DESCRIPTION
## What changed

- Rename the stale conflict-triage test around the immutable verification submission UI.
- Remove the unused `request_kind = conflict_triage` fixture override.
- Remove the assertion for the deleted `충돌 triage` derived-status label.
- Keep the read-only summary, next-action, and no approve/reject action assertions intact.

## Root cause

The Dashboard CI test still expected a derived conflict-triage label after the product UI was simplified to render immutable submission fields only. The test fixture also carried an unused conflict-triage override.

## Impact

This is test-only. It does not reintroduce derived verdict/status fields or change the product UI.

## Checks

- `vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/verification-requests-panel.test.ts` (10 passed)
- `tsc --noEmit`