### PR TITLE
fix(keeper): keep Docker paths sandbox-visible

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -190,7 +190,8 @@ let build_keeper_system_prompt
       Printf.sprintf
         "\n\
          <home_ground>\n\
-         - Keeper-visible sandbox root: %s\n\
+         - Keeper-visible sandbox root (informational only): %s\n\
+         - Pass a relative typed `cwd` (usually `.`), not this absolute root.\n\
          - Relative argv path operands resolve from the typed `cwd`.\n\
          - The working directory persists between tool calls, but shell state does not.\n\
          - Prefer relative argv path operands. In Docker, host absolute paths are unavailable.\n\

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -190,10 +190,10 @@ let build_keeper_system_prompt
       Printf.sprintf
         "\n\
          <home_ground>\n\
-         - Repository root: %s\n\
-         - All relative paths resolve from this directory.\n\
+         - Keeper-visible sandbox root: %s\n\
+         - Relative argv path operands resolve from the typed `cwd`.\n\
          - The working directory persists between tool calls, but shell state does not.\n\
-         - Prefer absolute paths over `cd` to avoid directory confusion.\n\
+         - Prefer relative argv path operands. In Docker, host absolute paths are unavailable.\n\
          </home_ground>\n"
         (String_util.escape_xml home_ground)
   in

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -61,7 +61,7 @@ let build_base_system_prompt
     ~persona_extended
     ~keeper_name:meta.name
     ~active_goals
-    ~home_ground:config.base_path
+    ~home_ground:(Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
     ()
 
 let prepare_run_context

--- a/lib/keeper/keeper_sandbox_repo_path.ml
+++ b/lib/keeper/keeper_sandbox_repo_path.ml
@@ -183,49 +183,55 @@ let host_execution_location_json
     ]
 
 let execution_location_json ~config ~meta ~args ~cwd =
-  let host_root = normalize_path (playground_root_no_create ~config ~meta) in
-  let visible_root =
-    normalize_path (Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
-  in
-  let project_path path =
-    let path = normalize_path path in
-    if String.equal path host_root
-    then `String visible_root
-    else
-      let prefix =
-        if String.equal host_root Filename.dir_sep
-        then host_root
-        else host_root ^ Filename.dir_sep
-      in
-      if String.length path > String.length prefix
-         && String.sub path 0 (String.length prefix) = prefix
-      then
-        `String
-          (Filename.concat
-             visible_root
-             (String.sub
-                path
-                (String.length prefix)
-                (String.length path - String.length prefix)))
-      else if Filename.is_relative path
-      then `String path
-      else `Null
-  in
-  let path_fields = [ "cwd"; "playground_root"; "relative_path_base"; "repo_root" ] in
-  let rec project = function
-    | `Assoc fields ->
-      `Assoc
-        (List.map
-           (fun (key, value) ->
-              if List.mem key path_fields
-              then
-                ( key
-                , match value with
-                  | `String path -> project_path path
-                  | other -> other )
-              else key, project value)
-           fields)
-    | `List values -> `List (List.map project values)
-    | value -> value
-  in
-  project (host_execution_location_json ~config ~meta ~args ~cwd)
+  let host_location = host_execution_location_json ~config ~meta ~args ~cwd in
+  match meta.sandbox_profile with
+  | Keeper_types_profile_sandbox.Local -> host_location
+  | Keeper_types_profile_sandbox.Docker ->
+    let host_root = normalize_path (playground_root_no_create ~config ~meta) in
+    let visible_root =
+      Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
+    in
+    let project_path path =
+      let path = normalize_path path in
+      if String.equal path host_root
+      then `String visible_root
+      else
+        let prefix =
+          if String.equal host_root Filename.dir_sep
+          then host_root
+          else host_root ^ Filename.dir_sep
+        in
+        if String.length path > String.length prefix
+           && String.sub path 0 (String.length prefix) = prefix
+        then
+          `String
+            (Filename.concat
+               visible_root
+               (String.sub
+                  path
+                  (String.length prefix)
+                  (String.length path - String.length prefix)))
+        else if Filename.is_relative path
+        then `String path
+        else `Null
+    in
+    let path_fields =
+      [ "cwd"; "playground_root"; "relative_path_base"; "repo_root" ]
+    in
+    let rec project = function
+      | `Assoc fields ->
+        `Assoc
+          (List.map
+             (fun (key, value) ->
+                if List.mem key path_fields
+                then
+                  ( key
+                  , match value with
+                    | `String path -> project_path path
+                    | other -> other )
+                else key, project value)
+             fields)
+      | `List values -> `List (List.map project values)
+      | value -> value
+    in
+    project host_location

--- a/lib/keeper/keeper_sandbox_repo_path.ml
+++ b/lib/keeper/keeper_sandbox_repo_path.ml
@@ -131,7 +131,7 @@ let relative_path_of_segments = function
   | [] -> "."
   | segments -> String.concat "/" segments
 
-let execution_location_json
+let host_execution_location_json
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -181,3 +181,51 @@ let execution_location_json
     ; "repo_name", Json_util.string_opt_to_json repo_name
     ; "repo_root", Json_util.string_opt_to_json repo_root
     ]
+
+let execution_location_json ~config ~meta ~args ~cwd =
+  let host_root = normalize_path (playground_root_no_create ~config ~meta) in
+  let visible_root =
+    normalize_path (Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
+  in
+  let project_path path =
+    let path = normalize_path path in
+    if String.equal path host_root
+    then `String visible_root
+    else
+      let prefix =
+        if String.equal host_root Filename.dir_sep
+        then host_root
+        else host_root ^ Filename.dir_sep
+      in
+      if String.length path > String.length prefix
+         && String.sub path 0 (String.length prefix) = prefix
+      then
+        `String
+          (Filename.concat
+             visible_root
+             (String.sub
+                path
+                (String.length prefix)
+                (String.length path - String.length prefix)))
+      else if Filename.is_relative path
+      then `String path
+      else `Null
+  in
+  let path_fields = [ "cwd"; "playground_root"; "relative_path_base"; "repo_root" ] in
+  let rec project = function
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+              if List.mem key path_fields
+              then
+                ( key
+                , match value with
+                  | `String path -> project_path path
+                  | other -> other )
+              else key, project value)
+           fields)
+    | `List values -> `List (List.map project values)
+    | value -> value
+  in
+  project (host_execution_location_json ~config ~meta ~args ~cwd)

--- a/lib/keeper/keeper_sandbox_repo_path.mli
+++ b/lib/keeper/keeper_sandbox_repo_path.mli
@@ -59,9 +59,12 @@ val execution_location_json :
   args:Yojson.Safe.t ->
   cwd:string ->
   Yojson.Safe.t
-(** Structured cwd contract for Execute responses. The JSON tells the agent
+(** Keeper-visible structured cwd contract for Execute responses. The JSON
+    tells the agent
     whether the effective cwd is inside the keeper playground
     ([playground_root], [playground_subpath], [repo_root], [repo_subpath])
     or outside it ([outside_playground]). [relative_cwd] is relative to
     [playground_root] for playground scopes and [null] when the cwd is outside
-    the playground. Relative argv paths resolve against the effective cwd. *)
+    the playground. Host-only absolute paths are projected into the selected
+    sandbox namespace or returned as [null]. Relative argv paths resolve
+    against the effective cwd. *)

--- a/lib/keeper/keeper_sandbox_repo_path.mli
+++ b/lib/keeper/keeper_sandbox_repo_path.mli
@@ -65,6 +65,7 @@ val execution_location_json :
     ([playground_root], [playground_subpath], [repo_root], [repo_subpath])
     or outside it ([outside_playground]). [relative_cwd] is relative to
     [playground_root] for playground scopes and [null] when the cwd is outside
-    the playground. Host-only absolute paths are projected into the selected
-    sandbox namespace or returned as [null]. Relative argv paths resolve
-    against the effective cwd. *)
+    the playground. Docker host-only absolute paths are projected into the
+    mounted sandbox namespace or returned as [null]; Local paths retain their
+    host namespace identity. Relative argv paths resolve against the effective
+    cwd. *)

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -134,6 +134,8 @@ let docker_local_fallback_target ~meta ?timeout_sec () =
     Some
       ( Masc_exec.Sandbox_target.host ()
       , [ "requested_sandbox", `String "docker"
+        ; "via", `String "local_fallback"
+        ; "fallback_reason", `String "docker_preflight_unavailable"
         ; "sandbox_fallback", `String "local_playground"
         ; "sandbox_fallback_reason", `String (Exec_policy.truncate_for_log message)
         ] )

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -2,9 +2,45 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_tool_shared_runtime
+open Keeper_path_rejection
 
 let resolve_missing_cwd cwd =
   Error (Printf.sprintf "cwd_not_directory: %s (directory does not exist)" cwd)
+
+type execute_cwd_resolution_error =
+  | Cwd_missing of { cwd : string }
+  | Cwd_not_directory of { cwd : string }
+  | Cwd_rejected of Keeper_path_rejection.keeper_path_rejection
+
+let execute_cwd_resolution_error_code = function
+  | Cwd_missing _ -> "cwd_missing"
+  | Cwd_not_directory _ -> "cwd_not_directory"
+  | Cwd_rejected (Outside_sandbox _) -> "cwd_outside_sandbox"
+  | Cwd_rejected
+      ( Path_required
+      | Invalid_lexical_endpoint
+      | Invalid_normalized_path_projection _
+      | Allowed_paths_normalized_empty _ ) ->
+    "cwd_invalid"
+
+let execute_cwd_resolution_error_public_message = function
+  | Cwd_missing _ -> "Requested cwd does not exist in the Keeper-visible workspace."
+  | Cwd_not_directory _ -> "Requested cwd is not a directory."
+  | Cwd_rejected (Outside_sandbox _) -> "Requested cwd is outside the Keeper sandbox."
+  | Cwd_rejected
+      ( Path_required
+      | Invalid_lexical_endpoint
+      | Invalid_normalized_path_projection _
+      | Allowed_paths_normalized_empty _ ) ->
+    "Requested cwd is invalid."
+
+let execute_cwd_resolution_error_private_message = function
+  | Cwd_missing { cwd } ->
+    Printf.sprintf "cwd_not_directory: %s (directory does not exist)" cwd
+  | Cwd_not_directory { cwd } ->
+    Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd
+  | Cwd_rejected rejection ->
+    Keeper_path_rejection.rejection_to_user_message rejection
 
 let resolve_tool_read_cwd
       ~(config : Workspace.config)
@@ -36,21 +72,27 @@ let requested_tool_execute_cwd ~config ~meta ~write_enabled ~args =
   then Filename.concat (keeper_default_write_root ~config ~meta) raw_cwd
   else raw_cwd
 
-let resolve_tool_execute_cwd ~config ~meta ~write_enabled ~args =
+let resolve_tool_execute_cwd_typed ~config ~meta ~write_enabled ~args =
   let raw_path = requested_tool_execute_cwd ~config ~meta ~write_enabled ~args in
   let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
   let resolved =
     if raw_cwd = ""
     then Ok raw_path
-    else resolve_keeper_execute_cwd ~config ~meta ~raw_path
+    else
+      resolve_keeper_execute_cwd_typed ~config ~meta ~raw_path
+      |> Result.map_error (fun rejection -> Cwd_rejected rejection)
   in
   match resolved with
   | Error _ as err -> err
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
   | Ok cwd ->
-    if not (Fs_compat.file_exists cwd) then resolve_missing_cwd cwd
-    else
-      Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
+    if not (Fs_compat.file_exists cwd)
+    then Error (Cwd_missing { cwd })
+    else Error (Cwd_not_directory { cwd })
+
+let resolve_tool_execute_cwd ~config ~meta ~write_enabled ~args =
+  resolve_tool_execute_cwd_typed ~config ~meta ~write_enabled ~args
+  |> Result.map_error execute_cwd_resolution_error_private_message
 
 (* Docker playground path mapping: host → container.
    Host:      <base_path>/.masc/playground/<keeper>/repos/X

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -25,22 +25,24 @@ let resolve_tool_read_cwd
     else
       Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
 
+let requested_tool_execute_cwd ~config ~meta ~write_enabled ~args =
+  let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
+  if raw_cwd = ""
+  then
+    if write_enabled
+    then keeper_default_write_root ~config ~meta
+    else Keeper_sandbox_repo_path.playground_root_no_create ~config ~meta
+  else if Filename.is_relative raw_cwd
+  then Filename.concat (keeper_default_write_root ~config ~meta) raw_cwd
+  else raw_cwd
+
 let resolve_tool_execute_cwd ~config ~meta ~write_enabled ~args =
+  let raw_path = requested_tool_execute_cwd ~config ~meta ~write_enabled ~args in
   let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
   let resolved =
     if raw_cwd = ""
-    then
-      Ok
-        (if write_enabled
-         then keeper_default_write_root ~config ~meta
-         else Keeper_sandbox_repo_path.playground_root_no_create ~config ~meta)
-    else
-      let raw_path =
-        if Filename.is_relative raw_cwd
-        then Filename.concat (keeper_default_write_root ~config ~meta) raw_cwd
-        else raw_cwd
-      in
-      resolve_keeper_execute_cwd ~config ~meta ~raw_path
+    then Ok raw_path
+    else resolve_keeper_execute_cwd ~config ~meta ~raw_path
   in
   match resolved with
   | Error _ as err -> err

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -34,7 +34,13 @@ let resolve_tool_execute_cwd ~config ~meta ~write_enabled ~args =
         (if write_enabled
          then keeper_default_write_root ~config ~meta
          else Keeper_sandbox_repo_path.playground_root_no_create ~config ~meta)
-    else resolve_keeper_execute_cwd ~config ~meta ~raw_path:raw_cwd
+    else
+      let raw_path =
+        if Filename.is_relative raw_cwd
+        then Filename.concat (keeper_default_write_root ~config ~meta) raw_cwd
+        else raw_cwd
+      in
+      resolve_keeper_execute_cwd ~config ~meta ~raw_path
   in
   match resolved with
   | Error _ as err -> err

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -17,6 +17,19 @@ val resolve_tool_execute_cwd :
     Execute uses the no-create playground root. Explicit cwd resolution
     never creates directories or changes repo/worktree state. *)
 
+type execute_cwd_resolution_error
+
+val resolve_tool_execute_cwd_typed :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  write_enabled:bool ->
+  args:Yojson.Safe.t ->
+  (string, execute_cwd_resolution_error) result
+
+val execute_cwd_resolution_error_code : execute_cwd_resolution_error -> string
+val execute_cwd_resolution_error_public_message : execute_cwd_resolution_error -> string
+val execute_cwd_resolution_error_private_message : execute_cwd_resolution_error -> string
+
 val requested_tool_execute_cwd :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -17,6 +17,16 @@ val resolve_tool_execute_cwd :
     Execute uses the no-create playground root. Explicit cwd resolution
     never creates directories or changes repo/worktree state. *)
 
+val requested_tool_execute_cwd :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  write_enabled:bool ->
+  args:Yojson.Safe.t ->
+  string
+(** Return the host-side cwd candidate used by Execute resolution. This is
+    exposed so response projection can describe a failed resolution without
+    reconstructing relative-path anchoring separately. *)
+
 val resolve_tool_read_path :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -11,29 +11,16 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
-let sandbox_extra_uses_docker sandbox_extra_fields =
-  List.exists
-    (function
-      | "via", `String "docker" -> true
-      | _ -> false)
-    sandbox_extra_fields
-
-let typed_execute_response_cwd_json
-      ~turn_sandbox_factory
-      ~cwd
-      ~sandbox_extra_fields
-  =
-  if sandbox_extra_uses_docker sandbox_extra_fields then
-    match
-      Keeper_sandbox_factory.container_cwd_of_host_opt
-        turn_sandbox_factory
-        ~host_cwd:cwd
-    with
-    | Some container_cwd ->
-      Keeper_cwd_response.docker ~host_cwd:cwd ~container_cwd
-      |> Keeper_cwd_response.to_yojson_response
-    | None -> `String cwd
-  else `String cwd
+let model_execute_location_fields ~config ~meta ~args ~cwd =
+  let execution_location =
+    Keeper_sandbox_repo_path.execution_location_json ~config ~meta ~args ~cwd
+  in
+  let response_cwd =
+    match execution_location with
+    | `Assoc fields -> Option.value ~default:`Null (List.assoc_opt "cwd" fields)
+    | _ -> `Null
+  in
+  [ "cwd", response_cwd; "execution_location", execution_location ]
 
 let sandbox_target_label = function
   | Masc_exec.Sandbox_target.Host -> "host"
@@ -66,7 +53,7 @@ let redact_execute_output redaction ~stdout ~stderr =
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
-  let typed_execute_response_cwd_json = typed_execute_response_cwd_json
+  let model_execute_location_fields = model_execute_location_fields
   let execute_gate_input = execute_gate_input
   let redact_execute_output ~base_path ~keeper_name ~stdout ~stderr =
     let redaction = execute_secret_redaction ~base_path ~keeper_name in
@@ -135,10 +122,8 @@ let handle_tool_execute_typed
   with
     | Error e -> Keeper_tool_execution.failure (error_json e)
     | Ok cwd ->
-        let execution_location_fields cwd =
-          [ ( "execution_location"
-            , Keeper_sandbox_repo_path.execution_location_json ~config ~meta ~args ~cwd )
-          ]
+        let model_location_fields =
+          model_execute_location_fields ~config ~meta ~args ~cwd
       in
       let typed_args = assoc_upsert "cwd" (`String cwd) args in
       match Keeper_tool_execute_typed_input.of_json typed_args with
@@ -147,15 +132,13 @@ let handle_tool_execute_typed
           ~class_:Tool_result.Policy_rejection
           (error_json
              ~fields:
-               ([ "typed", `Bool true; "cwd", `String cwd ]
-                @ execution_location_fields cwd)
+               ([ "typed", `Bool true ] @ model_location_fields)
              e)
       | Ok input ->
         (match Keeper_tool_execute_typed_input.validate input with
          | Error e ->
            let fields =
-             [ "typed", `Bool true; "cwd", `String cwd ]
-             @ execution_location_fields cwd
+             [ "typed", `Bool true ] @ model_location_fields
            in
            Keeper_tool_execution.failure
              ~class_:Tool_result.Policy_rejection
@@ -219,18 +202,11 @@ let handle_tool_execute_typed
            Keeper_tool_execution.failure
              (error_json
                 ~fields:
-                  ([ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
-                   @ execution_location_fields cwd
+                  ([ "typed", `Bool true; "cmd", `String cmd ]
+                   @ model_location_fields
                    @ fields)
                 message)
          | Ok (dispatch_sandbox, sandbox_extra_fields, base_host_env) ->
-        let response_cwd_json =
-          typed_execute_response_cwd_json
-            ~turn_sandbox_factory
-            ~cwd
-            ~sandbox_extra_fields
-        in
-        let response_cwd_field = [ "cwd", response_cwd_json ] in
         (* Lower the validated typed input exactly once. The resulting Shell IR
            is the neutral dispatch representation; it carries no product or
            inferred authorization semantics. *)
@@ -238,8 +214,7 @@ let handle_tool_execute_typed
         | Error e ->
           let fields =
             [ "typed", `Bool true; "cmd", `String cmd ]
-            @ response_cwd_field
-            @ execution_location_fields cwd
+            @ model_location_fields
           in
           Keeper_tool_execution.failure
             ~class_:Tool_result.Policy_rejection
@@ -259,8 +234,7 @@ let handle_tool_execute_typed
         in
         let typed_context_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log ]
-          @ response_cwd_field
-          @ execution_location_fields cwd
+          @ model_location_fields
         in
         let typed_error_json
               ?(class_ = Tool_result.Runtime_failure)
@@ -507,8 +481,7 @@ let handle_tool_execute_typed
                     ]
                     @ failure_error_fields
                     @ sandbox_extra_fields
-                    @ response_cwd_field
-                    @ execution_location_fields cwd))
+                    @ model_location_fields))
             in
             if succeeded
             then Keeper_tool_execution.success payload

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -17,10 +17,26 @@ let model_execute_location_fields ~config ~meta ~args ~cwd =
   in
   let response_cwd =
     match execution_location with
-    | `Assoc fields -> Option.value ~default:`Null (List.assoc_opt "cwd" fields)
+    | `Assoc fields ->
+      (match List.assoc_opt "cwd" fields with
+       | Some cwd -> cwd
+       | None -> `Null)
     | _ -> `Null
   in
   [ "cwd", response_cwd; "execution_location", execution_location ]
+
+let model_execute_cwd_resolution_error ~config ~meta ~args ~cwd error =
+  let fields =
+    [ "typed", `Bool true ] @ model_execute_location_fields ~config ~meta ~args ~cwd
+  in
+  let message =
+    match meta.sandbox_profile with
+    | Docker -> "cwd_resolution_failed: requested cwd is unavailable"
+    | _ -> error
+  in
+  Keeper_tool_execution.failure
+    ~class_:Tool_result.Policy_rejection
+    (error_json ~fields message)
 
 let sandbox_target_label = function
   | Masc_exec.Sandbox_target.Host -> "host"
@@ -120,7 +136,15 @@ let handle_tool_execute_typed
       ~write_enabled:true
       ~args
   with
-    | Error e -> Keeper_tool_execution.failure (error_json e)
+    | Error e ->
+      let cwd =
+        Keeper_tool_execute_path.requested_tool_execute_cwd
+          ~config
+          ~meta
+          ~write_enabled:true
+          ~args
+      in
+      model_execute_cwd_resolution_error ~config ~meta ~args ~cwd e
     | Ok cwd ->
         let model_location_fields =
           model_execute_location_fields ~config ~meta ~args ~cwd

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -242,6 +242,18 @@ let handle_tool_execute_typed
                    @ fields)
                 message)
          | Ok (dispatch_sandbox, sandbox_extra_fields, base_host_env) ->
+        let dispatched_model_location_fields =
+          match dispatch_sandbox with
+          | Masc_exec.Sandbox_target.Host ->
+            let local_meta =
+              { meta with sandbox_profile = Keeper_types_profile_sandbox.Local }
+            in
+            let local_cwd =
+              normalize_path_for_keeper_tool_execute_shell_ir_containment cwd
+            in
+            model_execute_location_fields ~config ~meta:local_meta ~args ~cwd:local_cwd
+          | Docker _ -> model_location_fields
+        in
         (* Lower the validated typed input exactly once. The resulting Shell IR
            is the neutral dispatch representation; it carries no product or
            inferred authorization semantics. *)
@@ -249,7 +261,7 @@ let handle_tool_execute_typed
         | Error e ->
           let fields =
             [ "typed", `Bool true; "cmd", `String cmd ]
-            @ model_location_fields
+            @ dispatched_model_location_fields
           in
           Keeper_tool_execution.failure
             ~class_:Tool_result.Policy_rejection
@@ -269,7 +281,7 @@ let handle_tool_execute_typed
         in
         let typed_context_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log ]
-          @ model_location_fields
+          @ dispatched_model_location_fields
         in
         let typed_error_json
               ?(class_ = Tool_result.Runtime_failure)
@@ -516,7 +528,7 @@ let handle_tool_execute_typed
                     ]
                     @ failure_error_fields
                     @ sandbox_extra_fields
-                    @ model_location_fields))
+                    @ dispatched_model_location_fields))
             in
             if succeeded
             then Keeper_tool_execution.success payload

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -26,13 +26,24 @@ let model_execute_location_fields ~config ~meta ~args ~cwd =
   [ "cwd", response_cwd; "execution_location", execution_location ]
 
 let model_execute_cwd_resolution_error ~config ~meta ~args ~cwd error =
+  let code = Keeper_tool_execute_path.execute_cwd_resolution_error_code error in
+  let private_message =
+    Keeper_tool_execute_path.execute_cwd_resolution_error_private_message error
+  in
+  Log.Keeper.warn
+    ~keeper_name:meta.name
+    "execute cwd resolution rejected code=%s detail=%s"
+    code
+    private_message;
   let fields =
-    [ "typed", `Bool true ] @ model_execute_location_fields ~config ~meta ~args ~cwd
+    [ "typed", `Bool true; "code", `String code ]
+    @ model_execute_location_fields ~config ~meta ~args ~cwd
   in
   let message =
     match meta.sandbox_profile with
-    | Docker -> "cwd_resolution_failed: requested cwd is unavailable"
-    | _ -> error
+    | Docker ->
+      Keeper_tool_execute_path.execute_cwd_resolution_error_public_message error
+    | _ -> private_message
   in
   Keeper_tool_execution.failure
     ~class_:Tool_result.Policy_rejection
@@ -127,7 +138,7 @@ let handle_tool_execute_typed
     execute_secret_redaction ~base_path:config.base_path ~keeper_name:meta.name
   in
   match
-    Keeper_tool_execute_path.resolve_tool_execute_cwd
+    Keeper_tool_execute_path.resolve_tool_execute_cwd_typed
       ~config
       ~meta
       (* Keep all keepers on the shared execute-worktree root. The exact

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -27,11 +27,12 @@ val handle_tool_execute_with_outcome :
 
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
-  val typed_execute_response_cwd_json :
-    turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+  val model_execute_location_fields :
+    config:Workspace.config ->
+    meta:Keeper_meta_contract.keeper_meta ->
+    args:Yojson.Safe.t ->
     cwd:string ->
-    sandbox_extra_fields:(string * Yojson.Safe.t) list ->
-    Yojson.Safe.t
+    (string * Yojson.Safe.t) list
   val execute_gate_input :
     input:Yojson.Safe.t ->
     cwd:string ->

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -266,7 +266,7 @@ let resolve_keeper_read_cwd
   | Ok path -> Ok path
 ;;
 
-let resolve_keeper_execute_cwd
+let resolve_keeper_execute_cwd_typed
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ~(raw_path : string)
@@ -280,7 +280,12 @@ let resolve_keeper_execute_cwd
       ~raw_path:(String.trim raw_path)
   with
   | Ok confined -> Ok (Keeper_alerting_path.confined_host_path confined)
-  | Error rejection -> user_message_error rejection
+  | Error rejection -> Error rejection
+;;
+
+let resolve_keeper_execute_cwd ~config ~meta ~raw_path =
+  resolve_keeper_execute_cwd_typed ~config ~meta ~raw_path
+  |> Result.map_error Keeper_alerting_path.rejection_to_user_message
 ;;
 
 let keeper_agent_sender ~(meta : keeper_meta) = meta.agent_name

--- a/lib/keeper/keeper_tool_shared_runtime.mli
+++ b/lib/keeper/keeper_tool_shared_runtime.mli
@@ -113,6 +113,12 @@ val resolve_keeper_read_cwd
   -> (string, string) result
 
 (** [resolve_keeper_read_cwd] for the execute/write boundary. *)
+val resolve_keeper_execute_cwd_typed
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> raw_path:string
+  -> (string, Keeper_path_rejection.keeper_path_rejection) result
+
 val resolve_keeper_execute_cwd
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta

--- a/lib/tool_surface/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.ml
@@ -88,7 +88,8 @@ let tool_execute_cwd_field =
       ; ( "description"
         , `String
             "Optional working directory for the command. Must stay within the keeper \
-             sandbox or an explicit allowed path. Use the Keeper-visible sandbox path; \
+             sandbox or an explicit allowed path. Pass a relative cwd, typically '.'. \
+             The Keeper-visible absolute root is informational, not a cwd input. \
              Docker host absolute paths are unavailable." )
       ] )
 ;;
@@ -186,8 +187,9 @@ let tool_execute_description =
    metacharacters in argv are data, not syntax; use typed stdin/stdout/stderr \
    objects for redirection and the pipeline field for pipelines. Use Grep for \
    structured file-content search. cwd must resolve inside the Keeper path jail. \
-   Filesystem operands use the selected sandbox namespace, and relative argv paths \
-   resolve against cwd; Docker host absolute paths are unavailable. \
+   Pass a relative cwd (typically '.') and relative filesystem operands, which \
+   resolve against cwd. The Keeper-visible absolute root is informational; Docker \
+   host absolute paths are unavailable. \
    MASC does not interpret program or subcommand \
    meaning: after typed lowering, path containment, sandbox resolution, and the \
    external-effect Gate, the invoked program owns its syntax and exit result."

--- a/lib/tool_surface/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.ml
@@ -46,6 +46,9 @@ let tool_execute_argv_field =
         , `String
             "Typed single-process form: a non-empty process vector. argv[0] is \
              the executable and remaining tokens are arguments, all passed verbatim. \
+             Filesystem arguments use the selected sandbox namespace; relative path \
+             operands resolve against the typed cwd. Docker cannot access host \
+             absolute paths. \
              A literal '|' token is data, not a pipe. Wildcards (*, ?, [...]) are \
              NOT expanded either: there is no shell, so 'foo*.ml' is a literal \
              filename, not a glob. Use exact paths or list a directory first." )
@@ -60,7 +63,9 @@ let tool_execute_pipeline_field =
       ; ( "description"
         , `String
             "Typed pipeline form: ordered exec stages. Use this instead of putting \
-             '|' in argv. Mutually exclusive with top-level argv." )
+             '|' in argv. Stage argv uses the selected sandbox namespace, and relative \
+             path operands resolve against the typed cwd. Mutually exclusive with \
+             top-level argv." )
       ] )
 ;;
 
@@ -83,7 +88,8 @@ let tool_execute_cwd_field =
       ; ( "description"
         , `String
             "Optional working directory for the command. Must stay within the keeper \
-             sandbox or an explicit allowed path." )
+             sandbox or an explicit allowed path. Use the Keeper-visible sandbox path; \
+             Docker host absolute paths are unavailable." )
       ] )
 ;;
 
@@ -180,6 +186,8 @@ let tool_execute_description =
    metacharacters in argv are data, not syntax; use typed stdin/stdout/stderr \
    objects for redirection and the pipeline field for pipelines. Use Grep for \
    structured file-content search. cwd must resolve inside the Keeper path jail. \
+   Filesystem operands use the selected sandbox namespace, and relative argv paths \
+   resolve against cwd; Docker host absolute paths are unavailable. \
    MASC does not interpret program or subcommand \
    meaning: after typed lowering, path containment, sandbox resolution, and the \
    external-effect Gate, the invoked program owns its syntax and exit result."

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -214,7 +214,40 @@ let test_typed_execute_response_cwd_uses_container_path () =
         error_cwd;
       check string "Docker error location cwd matches top-level cwd"
         error_cwd
-        error_location_cwd)
+        error_location_cwd;
+      let missing_relative = "missing-relative" in
+      let missing_raw =
+        Keeper_tool_command_runtime.handle_tool_execute
+          ~turn_sandbox_factory:(Some factory)
+          ~config
+          ~meta
+          ~args:
+            (`Assoc
+              [ "argv", `List [ `String "pwd" ]
+              ; "cwd", `String missing_relative
+              ])
+          ()
+      in
+      check bool "Docker missing-cwd error does NOT contain host base" false
+        (Astring.String.is_infix ~affix:base missing_raw);
+      let missing_response = Yojson.Safe.from_string missing_raw in
+      let missing_cwd =
+        missing_response
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      let missing_location_cwd =
+        missing_response
+        |> Yojson.Safe.Util.member "execution_location"
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      check string "Docker missing-cwd top-level path is visible"
+        (Filename.concat visible_root missing_relative)
+        missing_cwd;
+      check string "Docker missing-cwd location matches top-level cwd"
+        missing_cwd
+        missing_location_cwd)
 
 let test_retired_path_jail_env_detection () =
   let configured value =

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -231,6 +231,16 @@ let test_typed_execute_response_cwd_uses_container_path () =
       check bool "Docker missing-cwd error does NOT contain host base" false
         (Astring.String.is_infix ~affix:base missing_raw);
       let missing_response = Yojson.Safe.from_string missing_raw in
+      let missing_code =
+        missing_response
+        |> Yojson.Safe.Util.member "code"
+        |> Yojson.Safe.Util.to_string
+      in
+      let missing_error =
+        missing_response
+        |> Yojson.Safe.Util.member "error"
+        |> Yojson.Safe.Util.to_string
+      in
       let missing_cwd =
         missing_response
         |> Yojson.Safe.Util.member "cwd"
@@ -242,12 +252,66 @@ let test_typed_execute_response_cwd_uses_container_path () =
         |> Yojson.Safe.Util.member "cwd"
         |> Yojson.Safe.Util.to_string
       in
+      check string "Docker missing-cwd code is actionable"
+        "cwd_missing"
+        missing_code;
       check string "Docker missing-cwd top-level path is visible"
         (Filename.concat visible_root missing_relative)
         missing_cwd;
       check string "Docker missing-cwd location matches top-level cwd"
         missing_cwd
-        missing_location_cwd)
+        missing_location_cwd;
+      let not_directory = "not-directory" in
+      let host_file = Filename.concat host_root not_directory in
+      let oc = open_out host_file in
+      close_out oc;
+      let not_directory_raw =
+        Keeper_tool_command_runtime.handle_tool_execute
+          ~turn_sandbox_factory:(Some factory)
+          ~config
+          ~meta
+          ~args:
+            (`Assoc
+              [ "argv", `List [ `String "pwd" ]
+              ; "cwd", `String not_directory
+              ])
+          ()
+      in
+      check bool "Docker non-directory error does NOT contain host base" false
+        (Astring.String.is_infix ~affix:base not_directory_raw);
+      let not_directory_response = Yojson.Safe.from_string not_directory_raw in
+      let not_directory_code =
+        not_directory_response
+        |> Yojson.Safe.Util.member "code"
+        |> Yojson.Safe.Util.to_string
+      in
+      let not_directory_error =
+        not_directory_response
+        |> Yojson.Safe.Util.member "error"
+        |> Yojson.Safe.Util.to_string
+      in
+      let not_directory_cwd =
+        not_directory_response
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      let not_directory_location_cwd =
+        not_directory_response
+        |> Yojson.Safe.Util.member "execution_location"
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      check string "Docker non-directory code is actionable"
+        "cwd_not_directory"
+        not_directory_code;
+      check bool "Docker cwd errors keep distinct public messages" false
+        (String.equal missing_error not_directory_error);
+      check string "Docker non-directory top-level path is visible"
+        (Filename.concat visible_root not_directory)
+        not_directory_cwd;
+      check string "Docker non-directory location matches top-level cwd"
+        not_directory_cwd
+        not_directory_location_cwd)
 
 let test_retired_path_jail_env_detection () =
   let configured value =

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -92,7 +92,41 @@ let test_container_path_translation_under_sandbox () =
         (Astring.String.is_infix ~affix:container_cwd json_str);
       check string "operator_host accessor returns the host_cwd"
         host_cwd
-        (Keeper_cwd_response.operator_host cwd_response))
+        (Keeper_cwd_response.operator_host cwd_response);
+      let explicit_cwd =
+        Keeper_sandbox_repo_path.normalize_path
+          (Filename.concat base "explicit-local-allowed")
+      in
+      Unix.mkdir explicit_cwd 0o755;
+      let local_meta =
+        { (make_docker_meta ~name:"local-explicit-path") with
+          sandbox_profile = Keeper_types_profile_sandbox.Local
+        ; allowed_paths = [ explicit_cwd ]
+        }
+      in
+      let raw =
+        Keeper_tool_command_runtime.handle_tool_execute
+          ~turn_sandbox_factory:None
+          ~config
+          ~meta:local_meta
+          ~args:
+            (`Assoc
+              [ "argv", `List []
+              ; "cwd", `String explicit_cwd
+              ])
+          ()
+      in
+      let response = Yojson.Safe.from_string raw in
+      let open Yojson.Safe.Util in
+      check string "Local explicit cwd remains visible at top level"
+        explicit_cwd
+        (response |> member "cwd" |> to_string);
+      check string "Local explicit cwd remains visible in execution_location"
+        explicit_cwd
+        (response
+         |> member "execution_location"
+         |> member "cwd"
+         |> to_string))
 
 let test_typed_execute_response_cwd_uses_container_path () =
   Eio_main.run @@ fun _env ->
@@ -131,42 +165,56 @@ let test_typed_execute_response_cwd_uses_container_path () =
         (Astring.String.is_infix
            ~affix:"host absolute paths are unavailable"
            prompt);
-      let response_cwd =
-        Keeper_tool_execute_runtime.For_testing.typed_execute_response_cwd_json
-           ~turn_sandbox_factory:(Some factory)
-           ~cwd:host_cwd
-           ~sandbox_extra_fields:
-             [
-               "requested_sandbox", `String "docker";
-               "via", `String "docker";
-             "sandbox_profile", `String "docker";
-           ]
-      in
-      let execution_location =
-        Keeper_sandbox_repo_path.execution_location_json
+      let response_fields =
+        Keeper_tool_execute_runtime.For_testing.model_execute_location_fields
           ~config
           ~meta
           ~args:(`Assoc [ "argv", `List [ `String "find"; `String "." ] ])
           ~cwd:host_cwd
       in
-      let full_response =
-        `Assoc
-          [ "cwd", response_cwd
-          ; "execution_location", execution_location
-          ]
-      in
+      let full_response = `Assoc response_fields in
       let json_str = Yojson.Safe.to_string full_response in
       check bool "typed Execute cwd JSON does NOT contain host base" false
         (Astring.String.is_infix ~affix:base json_str);
        check bool "typed Execute cwd JSON does NOT contain host cwd" false
          (Astring.String.is_infix ~affix:host_cwd json_str);
-       match response_cwd with
-       | `String cwd ->
-         check bool
-           "typed Execute cwd is rooted at /home/keeper/playground"
-           true
-           (Astring.String.is_prefix ~affix:"/home/keeper/playground" cwd)
-       | _ -> fail "typed Execute cwd response should serialize as a string")
+      let response_cwd =
+        full_response
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      check string
+        "typed Execute cwd is projected from the host sandbox root"
+        (Filename.concat visible_root "repos/masc/.worktrees/task-cwd-pin")
+        response_cwd;
+      let error_raw =
+        Keeper_tool_command_runtime.handle_tool_execute
+          ~turn_sandbox_factory:(Some factory)
+          ~config
+          ~meta
+          ~args:(`Assoc [ "argv", `List []; "cwd", `String "." ])
+          ()
+      in
+      check bool "Docker validation error does NOT contain host base" false
+        (Astring.String.is_infix ~affix:base error_raw);
+      let error_response = Yojson.Safe.from_string error_raw in
+      let error_cwd =
+        error_response
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      let error_location_cwd =
+        error_response
+        |> Yojson.Safe.Util.member "execution_location"
+        |> Yojson.Safe.Util.member "cwd"
+        |> Yojson.Safe.Util.to_string
+      in
+      check string "Docker error top-level cwd uses visible root"
+        visible_root
+        error_cwd;
+      check string "Docker error location cwd matches top-level cwd"
+        error_cwd
+        error_location_cwd)
 
 let test_retired_path_jail_env_detection () =
   let configured value =

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -40,16 +40,16 @@ let make_docker_meta ~name : Keeper_meta_contract.keeper_meta =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
+        ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
         ("trace_id", `String ("trace-" ^ name));
         ("allowed_paths", `List [ `String "*" ]);
-        ( "sandbox_profile"
-        , `String
-            (Keeper_types_profile_sandbox.sandbox_profile_to_string Keeper_types_profile_sandbox.Docker) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with
+      sandbox_profile = Keeper_types_profile_sandbox.Docker
+    }
   | Error e -> Alcotest.fail e
 
 let test_container_path_translation_under_sandbox () =
@@ -106,23 +106,58 @@ let test_typed_execute_response_cwd_uses_container_path () =
       cleanup_dir base)
     (fun () ->
        let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
-       let host_cwd =
-         Filename.concat host_root "repos/masc/.worktrees/task-cwd-pin"
-       in
-       let response_cwd =
-         Keeper_tool_execute_runtime.For_testing.typed_execute_response_cwd_json
+      let host_cwd =
+        Filename.concat host_root "repos/masc/.worktrees/task-cwd-pin"
+      in
+      let visible_root =
+        Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
+      in
+      let prompt =
+        Keeper_run_context.build_base_system_prompt
+          ~config
+          ~profile_defaults:
+            Keeper_types_profile_defaults.empty_keeper_profile_defaults
+          ~meta
+      in
+      check bool "Docker prompt does NOT contain host base" false
+        (Astring.String.is_infix ~affix:base prompt);
+      check bool "Docker prompt contains Keeper-visible sandbox root" true
+        (Astring.String.is_infix ~affix:visible_root prompt);
+      check bool "Docker prompt recommends relative argv operands" true
+        (Astring.String.is_infix
+           ~affix:"Prefer relative argv path operands"
+           prompt);
+      check bool "Docker prompt rejects host absolute paths" true
+        (Astring.String.is_infix
+           ~affix:"host absolute paths are unavailable"
+           prompt);
+      let response_cwd =
+        Keeper_tool_execute_runtime.For_testing.typed_execute_response_cwd_json
            ~turn_sandbox_factory:(Some factory)
            ~cwd:host_cwd
            ~sandbox_extra_fields:
              [
                "requested_sandbox", `String "docker";
                "via", `String "docker";
-               "sandbox_profile", `String "docker";
-             ]
-       in
-       let json_str = Yojson.Safe.to_string response_cwd in
-       check bool "typed Execute cwd JSON does NOT contain host base" false
-         (Astring.String.is_infix ~affix:base json_str);
+             "sandbox_profile", `String "docker";
+           ]
+      in
+      let execution_location =
+        Keeper_sandbox_repo_path.execution_location_json
+          ~config
+          ~meta
+          ~args:(`Assoc [ "argv", `List [ `String "find"; `String "." ] ])
+          ~cwd:host_cwd
+      in
+      let full_response =
+        `Assoc
+          [ "cwd", response_cwd
+          ; "execution_location", execution_location
+          ]
+      in
+      let json_str = Yojson.Safe.to_string full_response in
+      check bool "typed Execute cwd JSON does NOT contain host base" false
+        (Astring.String.is_infix ~affix:base json_str);
        check bool "typed Execute cwd JSON does NOT contain host cwd" false
          (Astring.String.is_infix ~affix:host_cwd json_str);
        match response_cwd with

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -722,20 +722,22 @@ let test_execute_typed_pipeline_falls_back_to_local_playground () =
       ()
   in
   check_typed_pipeline_response raw;
+  let local_cwd =
+    Keeper_alerting_path.normalize_path_for_check playground
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
   Alcotest.(check (option string)) "requested docker" (Some "docker")
     (parse_string_field raw "requested_sandbox");
   Alcotest.(check (option string)) "fallback local playground"
     (Some "local_playground")
     (parse_string_field raw "sandbox_fallback");
-  Alcotest.(check (option string)) "fallback is not reported as via docker" None
+  Alcotest.(check (option string)) "fallback dispatch identity"
+    (Some "local_fallback")
     (parse_string_field raw "via");
-  let visible_root =
-    Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
-  in
-  Alcotest.(check bool) "fallback response contains no host base" false
+  Alcotest.(check bool) "fallback response exposes actual Local host namespace" true
     (contains_substring raw config.Workspace.base_path);
-  Alcotest.(check (option string)) "fallback top-level cwd is Keeper-visible"
-    (Some visible_root)
+  Alcotest.(check (option string)) "fallback top-level cwd is Local host cwd"
+    (Some local_cwd)
     (parse_string_field raw "cwd");
   let execution_location_cwd =
     try
@@ -748,7 +750,7 @@ let test_execute_typed_pipeline_falls_back_to_local_playground () =
     | Yojson.Json_error _ -> None
   in
   Alcotest.(check (option string)) "fallback nested cwd matches top-level cwd"
-    (Some visible_root)
+    (Some local_cwd)
     execution_location_cwd
 
 let test_execute_typed_pipeline_uses_local_shell_ir_dispatch () =
@@ -794,7 +796,7 @@ let test_execute_routes_through_docker () =
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
     Keeper_tool_command_runtime.handle_tool_execute ~turn_sandbox_factory:(Some factory) ~config ~meta
-      ~args:(tool_execute_typed_exec_args ~cwd:playground "echo" ~argv:[ "hello" ])
+      ~args:(tool_execute_typed_exec_args ~cwd:playground "pwd" ~argv:[])
       ()
   in
   Alcotest.(check (option bool)) "typed Execute succeeds via local fallback" (Some true)
@@ -803,7 +805,39 @@ let test_execute_routes_through_docker () =
     (parse_string_field raw "requested_sandbox");
   Alcotest.(check (option string)) "fallback local playground"
     (Some "local_playground")
-    (parse_string_field raw "sandbox_fallback")
+    (parse_string_field raw "sandbox_fallback");
+  Alcotest.(check (option string)) "fallback dispatch identity"
+    (Some "local_fallback")
+    (parse_string_field raw "via");
+  Alcotest.(check (option string)) "fallback reason is typed"
+    (Some "docker_preflight_unavailable")
+    (parse_string_field raw "fallback_reason");
+  Alcotest.(check bool) "fallback retains private preflight detail" true
+    (Option.is_some (parse_string_field raw "sandbox_fallback_reason"));
+  let stdout =
+    parse_string_field raw "output"
+    |> Option.map String.trim
+  in
+  let local_cwd =
+    Keeper_alerting_path.normalize_path_for_check playground
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  Alcotest.(check (option string)) "fallback stdout reports Local cwd"
+    (Some local_cwd)
+    stdout;
+  Alcotest.(check (option string)) "fallback top-level cwd reports Local namespace"
+    stdout
+    (parse_string_field raw "cwd");
+  let execution_location_cwd =
+    raw
+    |> Yojson.Safe.from_string
+    |> Yojson.Safe.Util.member "execution_location"
+    |> Yojson.Safe.Util.member "cwd"
+    |> Yojson.Safe.Util.to_string_option
+  in
+  Alcotest.(check (option string)) "fallback nested cwd reports Local namespace"
+    stdout
+    execution_location_cwd
 
 let test_execute_legacy_skips_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
@@ -1415,8 +1449,9 @@ let test_execute_outside_playground_rejects_before_image_preflight () =
   in
   Alcotest.(check (option bool)) "legacy ok omitted" None
     (parse_bool_field raw "ok");
-  Alcotest.(check bool) "path rejection" true
-    (response_mentions raw "error" "path_outside_sandbox");
+  Alcotest.(check (option string)) "typed path rejection"
+    (Some "cwd_outside_sandbox")
+    (parse_string_field raw "code");
   Alcotest.(check (option string)) "docker not requested" None
     (parse_string_field raw "requested_sandbox");
   let log = if Sys.file_exists log_path then read_file log_path else "" in

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -726,7 +726,30 @@ let test_execute_typed_pipeline_falls_back_to_local_playground () =
     (parse_string_field raw "requested_sandbox");
   Alcotest.(check (option string)) "fallback local playground"
     (Some "local_playground")
-    (parse_string_field raw "sandbox_fallback")
+    (parse_string_field raw "sandbox_fallback");
+  Alcotest.(check (option string)) "fallback is not reported as via docker" None
+    (parse_string_field raw "via");
+  let visible_root =
+    Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
+  in
+  Alcotest.(check bool) "fallback response contains no host base" false
+    (contains_substring raw config.Workspace.base_path);
+  Alcotest.(check (option string)) "fallback top-level cwd is Keeper-visible"
+    (Some visible_root)
+    (parse_string_field raw "cwd");
+  let execution_location_cwd =
+    try
+      raw
+      |> Yojson.Safe.from_string
+      |> Yojson.Safe.Util.member "execution_location"
+      |> Yojson.Safe.Util.member "cwd"
+      |> Yojson.Safe.Util.to_string_option
+    with
+    | Yojson.Json_error _ -> None
+  in
+  Alcotest.(check (option string)) "fallback nested cwd matches top-level cwd"
+    (Some visible_root)
+    execution_location_cwd
 
 let test_execute_typed_pipeline_uses_local_shell_ir_dispatch () =
   setup ~sandbox:Keeper_types_profile_sandbox.Local


### PR DESCRIPTION
## Summary

- build Keeper prompts from the selected sandbox's Keeper-visible root instead of the host workspace base
- document Execute argv/cwd filesystem operands as belonging to the selected sandbox namespace
- project model-facing `execution_location` paths into the Keeper-visible namespace without rewriting argv or broadening Docker mounts
- cover the Docker prompt and complete Execute response envelope with a host-path non-leak regression

## Context

A Docker Keeper received `/Users/dancer/me` as its prompt home ground and later passed that host-only absolute path to `find`, while its actual container cwd was `/home/keeper/playground/sangsu`. Execute responses also mixed a container-visible top-level `cwd` with host-only nested `execution_location` fields.

## Validation

- `scripts/dune-local.sh build test/test_keeper_sandbox_docker_cwd_response.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_sandbox_docker_cwd_response.exe` (4 tests passed)
- `opam exec -- ocamlformat --check <touched OCaml files>`
- `git diff --check`

Repository-wide `scripts/dune-local.sh build @fmt` remains red on pre-existing formatting differences in unrelated Dune files; none were changed here.
