### PR TITLE
fix(goal): wake Keeper for terminal task reconciliation

### DIFF
--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -69,7 +69,7 @@ let wake_keeper ~base_path keeper_name goal_id =
       (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
       goal_id
 
-let enqueue_ready ~config ~completing_agent_name
+let enqueue_ready ?(wake_if_present = false) ~config ~completing_agent_name
       ({ Masc_task_handlers.Task_goal_reconciliation.goal_id; triggering_task_id } as ready_fact)
   =
   match target_keeper_name ~config ~completing_agent_name ~goal_id with
@@ -104,6 +104,8 @@ let enqueue_ready ~config ~completing_agent_name
          wake_keeper ~base_path:config.base_path keeper_name goal_id;
          Enqueued { goal_id; keeper_name }
        | Keeper_registry_event_queue.Stimulus_already_present ->
+         if wake_if_present
+         then wake_keeper ~base_path:config.base_path keeper_name goal_id;
          Already_present { goal_id; keeper_name }
        | Keeper_registry_event_queue.Stimulus_storage_error detail ->
          Log.Keeper.error
@@ -137,6 +139,7 @@ let reconcile_startup ~config =
          Masc_task_handlers.Task_goal_reconciliation.startup_ready) ->
        let outcome =
          enqueue_ready
+           ~wake_if_present:true
            ~config
            ~completing_agent_name:candidate.completing_agent_name
            candidate.ready

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -5,19 +5,42 @@ type enqueue_outcome =
   | Already_present of { goal_id : string; keeper_name : string }
   | Enqueue_failed of { goal_id : string; keeper_name : string; detail : string }
 
-let sole_assigned_keeper goal_id =
+type reconciliation_summary = {
+  ready_count : int;
+  enqueued_count : int;
+  already_present_count : int;
+  unresolved_count : int;
+  failed_count : int;
+}
+
+let registered_assigned_keepers goal_id =
   Keeper_registry.all ()
   |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
        if List.mem goal_id entry.meta.active_goal_ids then Some entry.name else None)
+;;
+
+let durable_assigned_keepers config goal_id =
+  Keeper_meta_store.keepalive_keeper_names config
+  |> List.filter_map (fun keeper_name ->
+       match Keeper_meta_store.read_effective_meta config keeper_name with
+       | Ok (Some meta)
+         when not meta.Keeper_meta_contract.paused
+              && List.mem goal_id meta.active_goal_ids ->
+         Some meta.name
+       | Ok (Some _) | Ok None | Error _ -> None)
+;;
+
+let sole_assigned_keeper ~config goal_id =
+  registered_assigned_keepers goal_id @ durable_assigned_keepers config goal_id
   |> List.sort_uniq String.compare
   |> function
   | [ keeper_name ] -> Some keeper_name
   | [] | _ :: _ :: _ -> None
 
-let target_keeper_name ~completing_agent_name ~goal_id =
+let target_keeper_name ~config ~completing_agent_name ~goal_id =
   match Keeper_identity.canonical_keeper_name_from_agent_name completing_agent_name with
   | Some keeper_name -> Some keeper_name
-  | None -> sole_assigned_keeper goal_id
+  | None -> sole_assigned_keeper ~config goal_id
 
 let wake_keeper ~base_path keeper_name goal_id =
   match
@@ -46,15 +69,10 @@ let wake_keeper ~base_path keeper_name goal_id =
       (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
       goal_id
 
-let enqueue_if_ready ~config ~completing_agent_name ~task_id =
-  match
-    Masc_task_handlers.Task_goal_reconciliation.ready_after_terminal_task
-      ~config
-      ~task_id
-  with
-  | None -> Not_ready
-  | Some { goal_id; triggering_task_id } ->
-    (match target_keeper_name ~completing_agent_name ~goal_id with
+let enqueue_ready ~config ~completing_agent_name
+      ({ Masc_task_handlers.Task_goal_reconciliation.goal_id; triggering_task_id } as ready_fact)
+  =
+  match target_keeper_name ~config ~completing_agent_name ~goal_id with
      | None ->
        Log.Keeper.warn
          "goal reconciliation ready but no unambiguous Keeper target goal_id=%s \
@@ -65,7 +83,9 @@ let enqueue_if_ready ~config ~completing_agent_name ~task_id =
        No_keeper_target { goal_id }
      | Some keeper_name ->
        let ready : Keeper_event_queue.goal_reconciliation_ready =
-         { gr_goal_id = goal_id; gr_triggering_task_id = triggering_task_id }
+         { gr_goal_id = ready_fact.goal_id
+         ; gr_triggering_task_id = ready_fact.triggering_task_id
+         }
        in
        let stimulus : Keeper_event_queue.stimulus =
          { post_id = Keeper_event_queue.goal_reconciliation_ready_post_id ready
@@ -74,31 +94,18 @@ let enqueue_if_ready ~config ~completing_agent_name ~task_id =
          ; payload = Keeper_event_queue.Goal_reconciliation_ready ready
          }
        in
-       let already_present =
-         match
-           Keeper_event_queue_persistence.load_pending_result
-             ~base_path:config.base_path
-             ~keeper_name
-         with
-         | Ok queue ->
-           Keeper_event_queue.to_list queue
-           |> List.exists (fun pending ->
-                Keeper_event_queue.stimulus_identity_equal pending stimulus)
-         | Error _ -> false
-       in
        match
-         Keeper_registry_event_queue.enqueue_durable_result
+         Keeper_registry_event_queue.enqueue_stimulus_durable_result
            ~base_path:config.base_path
            keeper_name
            stimulus
        with
-       | Ok () ->
-         if already_present
-         then Already_present { goal_id; keeper_name }
-         else (
-           wake_keeper ~base_path:config.base_path keeper_name goal_id;
-           Enqueued { goal_id; keeper_name })
-       | Error detail ->
+       | Keeper_registry_event_queue.Stimulus_enqueued ->
+         wake_keeper ~base_path:config.base_path keeper_name goal_id;
+         Enqueued { goal_id; keeper_name }
+       | Keeper_registry_event_queue.Stimulus_already_present ->
+         Already_present { goal_id; keeper_name }
+       | Keeper_registry_event_queue.Stimulus_storage_error detail ->
          Log.Keeper.error
            "goal reconciliation durable enqueue failed keeper=%s goal_id=%s \
             triggering_task_id=%s: %s"
@@ -106,4 +113,51 @@ let enqueue_if_ready ~config ~completing_agent_name ~task_id =
            goal_id
            triggering_task_id
            detail;
-         Enqueue_failed { goal_id; keeper_name; detail })
+         Enqueue_failed { goal_id; keeper_name; detail }
+;;
+
+let enqueue_if_ready ~config ~completing_agent_name ~task_id =
+  match
+    Masc_task_handlers.Task_goal_reconciliation.ready_after_terminal_task
+      ~config
+      ~task_id
+  with
+  | None -> Not_ready
+  | Some ready -> enqueue_ready ~config ~completing_agent_name ready
+;;
+
+let reconcile_startup ~config =
+  let ready =
+    Masc_task_handlers.Task_goal_reconciliation.ready_executing_goals ~config
+  in
+  List.fold_left
+    (fun
+       summary
+       (candidate :
+         Masc_task_handlers.Task_goal_reconciliation.startup_ready) ->
+       let outcome =
+         enqueue_ready
+           ~config
+           ~completing_agent_name:candidate.completing_agent_name
+           candidate.ready
+       in
+       match outcome with
+       | Not_ready -> summary
+       | Enqueued _ ->
+         { summary with enqueued_count = summary.enqueued_count + 1 }
+       | Already_present _ ->
+         { summary with
+           already_present_count = summary.already_present_count + 1
+         }
+       | No_keeper_target _ ->
+         { summary with unresolved_count = summary.unresolved_count + 1 }
+       | Enqueue_failed _ ->
+         { summary with failed_count = summary.failed_count + 1 })
+    { ready_count = List.length ready
+    ; enqueued_count = 0
+    ; already_present_count = 0
+    ; unresolved_count = 0
+    ; failed_count = 0
+    }
+    ready
+;;

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -1,0 +1,109 @@
+type enqueue_outcome =
+  | Not_ready
+  | No_keeper_target of { goal_id : string }
+  | Enqueued of { goal_id : string; keeper_name : string }
+  | Already_present of { goal_id : string; keeper_name : string }
+  | Enqueue_failed of { goal_id : string; keeper_name : string; detail : string }
+
+let sole_assigned_keeper goal_id =
+  Keeper_registry.all ()
+  |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
+       if List.mem goal_id entry.meta.active_goal_ids then Some entry.name else None)
+  |> List.sort_uniq String.compare
+  |> function
+  | [ keeper_name ] -> Some keeper_name
+  | [] | _ :: _ :: _ -> None
+
+let target_keeper_name ~completing_agent_name ~goal_id =
+  match Keeper_identity.canonical_keeper_name_from_agent_name completing_agent_name with
+  | Some keeper_name -> Some keeper_name
+  | None -> sole_assigned_keeper goal_id
+
+let wake_keeper ~base_path keeper_name goal_id =
+  match
+    Keeper_registry.wakeup_running
+      ~intent:Keeper_registry.Goal_signal
+      ~base_path
+      keeper_name
+  with
+  | Keeper_registry.Signaled -> ()
+  | Keeper_registry.Deferred_unregistered ->
+    Log.Keeper.info
+      "goal reconciliation wake persisted for unregistered keeper=%s goal_id=%s"
+      keeper_name
+      goal_id
+  | Keeper_registry.Deferred_not_running phase ->
+    Log.Keeper.info
+      "goal reconciliation wake deferred by registry phase contract keeper=%s \
+       phase=%s goal_id=%s"
+      keeper_name
+      (Keeper_state_machine.phase_to_string phase)
+      goal_id
+  | Keeper_registry.Deferred_lifecycle denial ->
+    Log.Keeper.info
+      "goal reconciliation wake deferred by lifecycle keeper=%s reason=%s goal_id=%s"
+      keeper_name
+      (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
+      goal_id
+
+let enqueue_if_ready ~config ~completing_agent_name ~task_id =
+  match
+    Masc_task_handlers.Task_goal_reconciliation.ready_after_terminal_task
+      ~config
+      ~task_id
+  with
+  | None -> Not_ready
+  | Some { goal_id; triggering_task_id } ->
+    (match target_keeper_name ~completing_agent_name ~goal_id with
+     | None ->
+       Log.Keeper.warn
+         "goal reconciliation ready but no unambiguous Keeper target goal_id=%s \
+          triggering_task_id=%s completing_agent=%s"
+         goal_id
+         triggering_task_id
+         completing_agent_name;
+       No_keeper_target { goal_id }
+     | Some keeper_name ->
+       let ready : Keeper_event_queue.goal_reconciliation_ready =
+         { gr_goal_id = goal_id; gr_triggering_task_id = triggering_task_id }
+       in
+       let stimulus : Keeper_event_queue.stimulus =
+         { post_id = Keeper_event_queue.goal_reconciliation_ready_post_id ready
+         ; urgency = Keeper_event_queue.Immediate
+         ; arrived_at = Time_compat.now ()
+         ; payload = Keeper_event_queue.Goal_reconciliation_ready ready
+         }
+       in
+       let already_present =
+         match
+           Keeper_event_queue_persistence.load_pending_result
+             ~base_path:config.base_path
+             ~keeper_name
+         with
+         | Ok queue ->
+           Keeper_event_queue.to_list queue
+           |> List.exists (fun pending ->
+                Keeper_event_queue.stimulus_identity_equal pending stimulus)
+         | Error _ -> false
+       in
+       match
+         Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path:config.base_path
+           keeper_name
+           stimulus
+       with
+       | Ok () ->
+         if already_present
+         then Already_present { goal_id; keeper_name }
+         else (
+           wake_keeper ~base_path:config.base_path keeper_name goal_id;
+           Enqueued { goal_id; keeper_name })
+       | Error detail ->
+         Log.Keeper.error
+           "goal reconciliation durable enqueue failed keeper=%s goal_id=%s \
+            triggering_task_id=%s: %s"
+           keeper_name
+           goal_id
+           triggering_task_id
+           detail;
+         Enqueue_failed { goal_id; keeper_name; detail })

--- a/lib/keeper/keeper_goal_reconciliation_wake.mli
+++ b/lib/keeper/keeper_goal_reconciliation_wake.mli
@@ -5,6 +5,14 @@ type enqueue_outcome =
   | Already_present of { goal_id : string; keeper_name : string }
   | Enqueue_failed of { goal_id : string; keeper_name : string; detail : string }
 
+type reconciliation_summary = {
+  ready_count : int;
+  enqueued_count : int;
+  already_present_count : int;
+  unresolved_count : int;
+  failed_count : int;
+}
+
 val enqueue_if_ready :
   config:Workspace.config ->
   completing_agent_name:string ->
@@ -13,5 +21,12 @@ val enqueue_if_ready :
 (** Re-read canonical Goal/Task state after a terminal Task commit, durably
     enqueue one typed reconciliation stimulus, then wake its Keeper. The
     completing Keeper is preferred; an external completion may target the sole
-    registered Keeper whose [active_goal_ids] contains the Goal. The function
+    durable Keeper whose [active_goal_ids] contains the Goal. The function
     never mutates Goal phase. *)
+
+val reconcile_startup :
+  config:Workspace.config -> reconciliation_summary
+(** Re-scan canonical Goal, Task, and link state and atomically restore missing
+    reconciliation stimuli. Safe to call on every existing supervisor
+    reconciliation pass: accounted stimuli are reported as already present,
+    storage failures remain visible and retryable, and no Goal state changes. *)

--- a/lib/keeper/keeper_goal_reconciliation_wake.mli
+++ b/lib/keeper/keeper_goal_reconciliation_wake.mli
@@ -1,0 +1,17 @@
+type enqueue_outcome =
+  | Not_ready
+  | No_keeper_target of { goal_id : string }
+  | Enqueued of { goal_id : string; keeper_name : string }
+  | Already_present of { goal_id : string; keeper_name : string }
+  | Enqueue_failed of { goal_id : string; keeper_name : string; detail : string }
+
+val enqueue_if_ready :
+  config:Workspace.config ->
+  completing_agent_name:string ->
+  task_id:string ->
+  enqueue_outcome
+(** Re-read canonical Goal/Task state after a terminal Task commit, durably
+    enqueue one typed reconciliation stimulus, then wake its Keeper. The
+    completing Keeper is preferred; an external completion may target the sole
+    registered Keeper whose [active_goal_ids] contains the Goal. The function
+    never mutates Goal phase. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -168,7 +168,8 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Bootstrap
       | Keeper_event_queue.Hitl_resolved _
       | Keeper_event_queue.Manual_compaction_requested
-      | Keeper_event_queue.Goal_assigned _ ->
+      | Keeper_event_queue.Goal_assigned _
+      | Keeper_event_queue.Goal_reconciliation_ready _ ->
         None)
     stimuli
 ;;
@@ -187,7 +188,8 @@ let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Bootstrap
        | Keeper_event_queue.Connector_attention _
        | Keeper_event_queue.Manual_compaction_requested
-       | Keeper_event_queue.Goal_assigned _ -> ())
+       | Keeper_event_queue.Goal_assigned _
+       | Keeper_event_queue.Goal_reconciliation_ready _ -> ())
     stimuli
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -132,7 +132,8 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Board_attention _
   | Keeper_event_queue.Fusion_completed _
   | Keeper_event_queue.Bg_completed _
-  | Keeper_event_queue.Goal_assigned _ ->
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
     (* No dedicated turn_reason: like the other async-completion wakes, the
        stimulus itself forces the keeper to re-run its cycle and proceed on its
        own state. *)
@@ -201,6 +202,14 @@ let consume_single_heartbeat_stimulus
       "turn entry: goal assignment delivered goal_id=%s assigned_by=%s (keeper=%s)"
       ga.ga_goal_id
       ga.ga_assigned_by
+      meta_after_triage.name;
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
+  | Keeper_event_queue.Goal_reconciliation_ready ready ->
+    Log.Keeper.info
+      "turn entry: goal reconciliation ready goal_id=%s triggering_task_id=%s \
+       (keeper=%s)"
+      ready.gr_goal_id
+      ready.gr_triggering_task_id
       meta_after_triage.name;
     pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Manual_compaction_requested ->
@@ -311,7 +320,8 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
   | Keeper_event_queue.Schedule_due _
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Manual_compaction_requested
-  | Keeper_event_queue.Goal_assigned _ ->
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
     true
 ;;
 

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -63,7 +63,8 @@ let continuation_binding_of_source source =
   | Keeper_event_queue.Bg_completed _
   | Keeper_event_queue.Schedule_due _
   | Keeper_event_queue.Manual_compaction_requested
-  | Keeper_event_queue.Goal_assigned _ ->
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
     No_channel
 ;;
 

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -15,6 +15,7 @@ type stimulus_kind =
   | Manual_compaction
   | Goal_assigned
       (* RFC-0315 P3 W0: goal entered active_goal_ids — assignment edge wake. *)
+  | Goal_reconciliation_ready
 
 type reaction_kind =
   | Turn_started
@@ -45,6 +46,7 @@ let stimulus_kind_to_string = function
   | Hitl_resolved -> "hitl_resolved"
   | Manual_compaction -> "manual_compaction"
   | Goal_assigned -> "goal_assigned"
+  | Goal_reconciliation_ready -> "goal_reconciliation_ready"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -61,6 +63,7 @@ let stimulus_kind_of_string = function
   | "hitl_resolved" -> Some Hitl_resolved
   | "manual_compaction" -> Some Manual_compaction
   | "goal_assigned" -> Some Goal_assigned
+  | "goal_reconciliation_ready" -> Some Goal_reconciliation_ready
   | _ -> None
 ;;
 
@@ -107,6 +110,8 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Hitl_resolved _ -> Hitl_resolved
   | Keeper_event_queue.Manual_compaction_requested -> Manual_compaction
   | Keeper_event_queue.Goal_assigned _ -> Goal_assigned
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
+    Goal_reconciliation_ready
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -212,6 +217,11 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "goal_assigned goal_id=%s assigned_by=%s"
       ga.ga_goal_id
       ga.ga_assigned_by
+  | Keeper_event_queue.Goal_reconciliation_ready ready ->
+    Printf.sprintf
+      "goal_reconciliation_ready goal_id=%s triggering_task_id=%s"
+      ready.gr_goal_id
+      ready.gr_triggering_task_id
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -229,7 +239,8 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Connector_attention _
     | Keeper_event_queue.Hitl_resolved _
     | Keeper_event_queue.Manual_compaction_requested
-    | Keeper_event_queue.Goal_assigned _ -> None
+    | Keeper_event_queue.Goal_assigned _
+    | Keeper_event_queue.Goal_reconciliation_ready _ -> None
   in
   `Assoc
     (base_fields
@@ -996,7 +1007,7 @@ let decode_current_row ~keeper_name row =
       | Board_signal, (Some _ | None)
       | ( Bootstrap | Fusion_completed | Bg_completed | Schedule_due
         | Connector_attention | Hitl_resolved
-        | Manual_compaction | Goal_assigned ),
+        | Manual_compaction | Goal_assigned | Goal_reconciliation_ready ),
         _ -> Ok ()
     in
     let expected_event_id = digest_id "krl" (stimulus_id ^ "|stimulus") in
@@ -1395,7 +1406,7 @@ let board_stimulus_token metadata stimulus_kind =
     Option.map (fun timestamp -> timestamp, post_id) updated_at
   | Bootstrap | Fusion_completed | Bg_completed | Schedule_due
   | Connector_attention | Hitl_resolved
-  | Manual_compaction | Goal_assigned -> None
+  | Manual_compaction | Goal_assigned | Goal_reconciliation_ready -> None
 ;;
 
 let summarize_rows ~keeper_name ~limit rows =

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -24,6 +24,8 @@ type stimulus_kind =
   | Manual_compaction
   | Goal_assigned
       (** RFC-0315 P3 W0: goal entered active_goal_ids — assignment edge wake. *)
+  | Goal_reconciliation_ready
+      (** Linked Tasks reached a terminal boundary and Goal synthesis is ready. *)
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -226,7 +226,8 @@ let board_attention_event_id (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
   | Keeper_event_queue.Manual_compaction_requested
-  | Keeper_event_queue.Goal_assigned _ ->
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
     None
 ;;
 

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -129,6 +129,30 @@ let reconcile_keepalive_keepers
        reconcile_one name;
        Eio_guard.yield_step reconcile_ym)
     names;
+  (try
+     let summary =
+       Keeper_goal_reconciliation_wake.reconcile_startup ~config:ctx.config
+     in
+     if
+       summary.enqueued_count > 0
+       || summary.unresolved_count > 0
+       || summary.failed_count > 0
+     then
+       Log.Keeper.info
+         "goal reconciliation startup scan ready=%d enqueued=%d already_present=%d \
+          unresolved=%d failed=%d"
+         summary.ready_count
+         summary.enqueued_count
+         summary.already_present_count
+         summary.unresolved_count
+         summary.failed_count
+   with
+   | Eio.Cancel.Cancelled _ as exn -> raise exn
+   | exn ->
+     inc_reconcile_failure ~name:"fleet" ~operation:"goal_reconciliation";
+     Log.Keeper.warn
+       "goal reconciliation startup scan failed non-fatally and will retry: %s"
+       (Printexc.to_string exn));
   Log.Keeper.debug
     "reconcile_keepalive_keepers: completed (elapsed_ms=%d)"
     (int_of_float ((Time_compat.now () -. t0) *. 1000.0))

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -156,6 +156,8 @@ let board_event_kind_label = function
   | Keeper_world_observation.Schedule_due -> "schedule_due"
   | Keeper_world_observation.External_attention -> "external_attention"
   | Keeper_world_observation.Goal_assigned -> "goal_assigned"
+  | Keeper_world_observation.Goal_reconciliation_ready ->
+    "goal_reconciliation_ready"
 ;;
 
 let quote_prompt_field value =
@@ -200,7 +202,8 @@ let board_event_note = function
   | Keeper_world_observation.Fusion_completed
   | Keeper_world_observation.Bg_completed
   | Keeper_world_observation.Schedule_due
-  | Keeper_world_observation.Goal_assigned -> ""
+  | Keeper_world_observation.Goal_assigned
+  | Keeper_world_observation.Goal_reconciliation_ready -> ""
 ;;
 
 let format_board_event_text

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -27,6 +27,7 @@ type pending_board_event_kind =
   | Schedule_due
   | External_attention
   | Goal_assigned
+  | Goal_reconciliation_ready
 
 type pending_board_event =
   { event_kind : pending_board_event_kind
@@ -588,6 +589,36 @@ let pending_board_event_of_goal_assignment
   }
 ;;
 
+let pending_board_event_of_goal_reconciliation_ready
+      ~meta
+      ~(arrived_at : float)
+      (ready : Keeper_event_queue.goal_reconciliation_ready)
+  : pending_board_event
+  =
+  { event_kind = Goal_reconciliation_ready
+  ; post_id = Keeper_event_queue.goal_reconciliation_ready_post_id ready
+  ; author = "masc"
+  ; title = Printf.sprintf "Goal reconciliation ready: %s" ready.gr_goal_id
+  ; preview =
+      short_preview
+        ~max_len:fusion_result_preview_max_len
+        (Printf.sprintf
+           "Task %s made every linked Task terminal. Re-read Goal and Task SSOT; \
+            choose masc_goal_transition request_complete or block, or create a \
+            follow-up Task. Do not infer Goal completion from task counts."
+           ready.gr_triggering_task_id)
+  ; hearth = None
+  ; post_kind = Board.System_post
+  ; updated_at = arrived_at
+  ; explicit_mention = true
+  ; matched_targets = [ meta.name; ready.gr_goal_id ]
+  ; self_commented = false
+  ; new_external_since = 0
+  ; latest_external_author = None
+  ; latest_external_preview = None
+  }
+;;
+
 let pending_board_event_of_stimulus
       ~(meta : keeper_meta)
   (stimulus : Keeper_event_queue.stimulus)
@@ -631,6 +662,13 @@ let pending_board_event_of_stimulus
             ~meta
             ~arrived_at:stimulus.arrived_at
             ga))
+  | Keeper_event_queue.Goal_reconciliation_ready ready ->
+    Ok
+      (Some
+         (pending_board_event_of_goal_reconciliation_ready
+            ~meta
+            ~arrived_at:stimulus.arrived_at
+            ready))
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -26,6 +26,9 @@ type pending_board_event_kind =
   | Goal_assigned
       (** RFC-0315 P3 W0: a goal entered this keeper's [active_goal_ids];
           the assignment edge surfaces as actionable turn input. *)
+  | Goal_reconciliation_ready
+      (** All linked Tasks are terminal; the Keeper must re-read SSOT and
+          choose completion, blocking, or follow-up work. *)
 
 type pending_board_event = {
   event_kind : pending_board_event_kind;

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -76,6 +76,7 @@ type stimulus_payload =
          discovered only if some unrelated stimulus happened to fire.
          Uses the same no-dedicated-reason pattern as async completions:
          turn_reason; the injected pending observation drives the turn. *)
+  | Goal_reconciliation_ready of goal_reconciliation_ready
 
 and board_attention = {
   candidate_id : string;
@@ -159,6 +160,11 @@ and goal_assignment = {
      repeat assignments of the same goal dedup regardless of actor. *)
 }
 
+and goal_reconciliation_ready = {
+  gr_goal_id : string;
+  gr_triggering_task_id : string;
+}
+
 let fusion_completion_post_id (fc : fusion_completion) = "fusion-run:" ^ fc.run_id
 
 let bg_job_completion_post_id (c : bg_job_completion) =
@@ -173,6 +179,9 @@ let goal_assignment_post_id (ga : goal_assignment) =
   (* Stable per goal: re-assigning the same goal before the keeper consumes
      the first wake collapses under queue identity dedup. *)
   "goal-assigned:" ^ ga.ga_goal_id
+
+let goal_reconciliation_ready_post_id (ready : goal_reconciliation_ready) =
+  "goal-reconciliation-ready:" ^ ready.gr_goal_id
 
 let hitl_resolution_decision_to_string = function
   | Hitl_approved -> "approve"
@@ -219,7 +228,7 @@ let identity_payload = function
     Goal_assigned { ga with ga_goal_title = ""; ga_assigned_by = "" }
   | ( Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
     | Bg_completed _ | Schedule_due _ | Connector_attention _ | Hitl_resolved _
-    | Manual_compaction_requested
+    | Manual_compaction_requested | Goal_reconciliation_ready _
     ) as payload ->
     payload
 
@@ -323,12 +332,14 @@ let payload_kind_label = function
   | Hitl_resolved _ -> "hitl_resolved"
   | Manual_compaction_requested -> "manual_compaction_requested"
   | Goal_assigned _ -> "goal_assigned"
+  | Goal_reconciliation_ready _ -> "goal_reconciliation_ready"
 
 let is_board_signal = function
   | Board_signal _ | Board_attention _ -> true
   | Bootstrap | Fusion_completed _ | Bg_completed _
   | Schedule_due _ | Connector_attention _ | Hitl_resolved _
-  | Manual_compaction_requested | Goal_assigned _ ->
+  | Manual_compaction_requested | Goal_assigned _
+  | Goal_reconciliation_ready _ ->
     false
 
 let drain_board_all (queue : t) : stimulus list * t =
@@ -555,6 +566,12 @@ let payload_to_yojson = function
       ; "goal_title", `String ga.ga_goal_title
       ; "assigned_by", `String ga.ga_assigned_by
       ]
+  | Goal_reconciliation_ready ready ->
+    `Assoc
+      [ "kind", `String "goal_reconciliation_ready"
+      ; "goal_id", `String ready.gr_goal_id
+      ; "triggering_task_id", `String ready.gr_triggering_task_id
+      ]
 
 let continuation_channel_field fields =
   let* json = required_field ~context:"stimulus.payload" "channel" fields in
@@ -709,6 +726,14 @@ let payload_of_yojson json =
          ; ga_goal_title = goal_title
          ; ga_assigned_by = assigned_by
          })
+  | "goal_reconciliation_ready" ->
+    let* goal_id = string_field ~context "goal_id" fields in
+    let* triggering_task_id =
+      string_field ~context "triggering_task_id" fields
+    in
+    Ok
+      (Goal_reconciliation_ready
+         { gr_goal_id = goal_id; gr_triggering_task_id = triggering_task_id })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -93,6 +93,10 @@ type stimulus_payload =
           stimulus; the owning Keeper consumes it under its turn slot. *)
   | Goal_assigned of goal_assignment
       (** A goal was newly added to this keeper's [active_goal_ids]. *)
+  | Goal_reconciliation_ready of goal_reconciliation_ready
+      (** Every Task linked to an executing Goal is terminal. This wakes a
+          Keeper to re-read SSOT and choose a Goal action; it does not authorize
+          automatic completion. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -186,6 +190,12 @@ and goal_assignment = {
 }
 (** Payload for [Goal_assigned]. *)
 
+and goal_reconciliation_ready = {
+  gr_goal_id : string;
+  gr_triggering_task_id : string;
+}
+(** Identifier-only payload for [Goal_reconciliation_ready]. *)
+
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Canonical dedup/correlation id for [Fusion_completed], always
     ["fusion-run:<run_id>"]. Board projection availability is not event
@@ -203,6 +213,9 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 val manual_compaction_post_id : post_id
 
 val goal_assignment_post_id : goal_assignment -> post_id
+
+val goal_reconciliation_ready_post_id :
+  goal_reconciliation_ready -> post_id
 
 val hitl_resolution_decision_to_string : hitl_resolution_decision -> string
 (** Stable wire/log label for a HITL resolution wake decision. *)

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -949,7 +949,8 @@ let source_terminal_receipt_of_stimulus source =
   | Keeper_event_queue.Schedule_due _
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Manual_compaction_requested
-  | Keeper_event_queue.Goal_assigned _ ->
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
     Error "source event does not carry a typed terminal receipt"
 ;;
 

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -36,6 +36,7 @@ type wake_producer =
   | Keeper_turn_admission
   | Operator_pending_confirm_store
   | Keeper_goal_assignment
+  | Keeper_goal_reconciliation
   | Keeper_compaction_request
   | Read_model_reader
 
@@ -113,6 +114,7 @@ let wake_producer_to_string = function
   | Keeper_turn_admission -> "keeper_turn_admission"
   | Operator_pending_confirm_store -> "operator_pending_confirm_store"
   | Keeper_goal_assignment -> "keeper_goal_assignment"
+  | Keeper_goal_reconciliation -> "keeper_goal_reconciliation"
   | Keeper_compaction_request -> "keeper_compaction_request"
   | Read_model_reader -> "read_model_reader"
 ;;
@@ -129,6 +131,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Hitl_resolved _ -> Hitl_resolution_hook
   | Manual_compaction_requested -> Keeper_compaction_request
   | Goal_assigned _ -> Keeper_goal_assignment
+  | Goal_reconciliation_ready _ -> Keeper_goal_reconciliation
 ;;
 
 let unix_iso_json = function

--- a/lib/task/dune
+++ b/lib/task/dune
@@ -10,6 +10,7 @@
   planning_eio
   task_dispatch
   task_goal_assignment
+  task_goal_reconciliation
   tool_task
   tool_task_args
   tool_task_completion_review

--- a/lib/task/task_goal_reconciliation.ml
+++ b/lib/task/task_goal_reconciliation.ml
@@ -1,0 +1,37 @@
+type ready = {
+  goal_id : string;
+  triggering_task_id : string;
+}
+
+module Workspace = Workspace_core
+
+let ready_after_terminal_task ~config ~task_id =
+  let tasks = Workspace.get_tasks_raw config in
+  match
+    List.find_opt
+      (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+      tasks
+  with
+  | Some task when Masc_domain.task_status_is_terminal task.task_status ->
+    let goal_task_links = Workspace_goal_index.read_goal_task_links config in
+    let task_goal_index =
+      Workspace_goal_index.build_task_goal_index ~goal_task_links ()
+    in
+    (match Hashtbl.find_opt task_goal_index task_id with
+     | Some [ goal_id ] ->
+       (match Goal_store.get_goal config ~goal_id with
+        | Some { phase = Goal_phase.Executing; _ } ->
+          let goal_task_index =
+            Workspace_goal_index.build_goal_task_index ~goal_task_links tasks
+          in
+          if
+            Workspace_goal_index.tasks_for_goal goal_task_index ~goal_id <> []
+            && Workspace_goal_index.open_task_count_for_goal_indexed
+                 goal_task_index
+                 ~goal_id
+               = 0
+          then Some { goal_id; triggering_task_id = task_id }
+          else None
+        | Some _ | None -> None)
+     | Some (_ :: _ :: _) | Some [] | None -> None)
+  | Some _ | None -> None

--- a/lib/task/task_goal_reconciliation.ml
+++ b/lib/task/task_goal_reconciliation.ml
@@ -3,7 +3,43 @@ type ready = {
   triggering_task_id : string;
 }
 
+type startup_ready = {
+  ready : ready;
+  completing_agent_name : string;
+}
+
 module Workspace = Workspace_core
+
+let terminal_fact (task : Masc_domain.task) =
+  match task.task_status with
+  | Masc_domain.Done { assignee; completed_at; _ } ->
+    Some (completed_at, assignee)
+  | Masc_domain.Cancelled { cancelled_by; cancelled_at; _ } ->
+    Some (cancelled_at, cancelled_by)
+  | Masc_domain.Todo
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.AwaitingVerification _ -> None
+;;
+
+let latest_terminal_task tasks =
+  match
+    tasks
+    |> List.filter_map (fun task ->
+         Option.map
+           (fun (terminal_at, completing_agent_name) ->
+              task, terminal_at, completing_agent_name)
+           (terminal_fact task))
+    |> List.sort (fun
+         ((left : Masc_domain.task), left_at, _)
+         ((right : Masc_domain.task), right_at, _) ->
+         match String.compare right_at left_at with
+         | 0 -> String.compare right.id left.id
+         | ordering -> ordering)
+  with
+  | [] -> None
+  | latest :: _ -> Some latest
+;;
 
 let ready_after_terminal_task ~config ~task_id =
   let tasks = Workspace.get_tasks_raw config in
@@ -35,3 +71,34 @@ let ready_after_terminal_task ~config ~task_id =
         | Some _ | None -> None)
      | Some (_ :: _ :: _) | Some [] | None -> None)
   | Some _ | None -> None
+
+let ready_executing_goals ~config =
+  let tasks = Workspace.get_tasks_raw config in
+  let goal_task_links = Workspace_goal_index.read_goal_task_links config in
+  let goal_task_index =
+    Workspace_goal_index.build_goal_task_index ~goal_task_links tasks
+  in
+  Goal_store.list_goals config ~phase:Goal_phase.Executing ()
+  |> List.sort (fun left right -> String.compare left.Goal_store.id right.Goal_store.id)
+  |> List.filter_map (fun (goal : Goal_store.goal) ->
+       let linked_tasks =
+         Workspace_goal_index.tasks_for_goal goal_task_index ~goal_id:goal.id
+       in
+       if
+         linked_tasks = []
+         || not
+              (List.for_all
+                 (fun (task : Masc_domain.task) ->
+                    Masc_domain.task_status_is_terminal task.task_status)
+                 linked_tasks)
+       then None
+       else
+         match latest_terminal_task linked_tasks with
+         | None -> None
+         | Some (task, _, completing_agent_name) ->
+           Some
+             { ready =
+                 { goal_id = goal.id; triggering_task_id = task.Masc_domain.id }
+             ; completing_agent_name
+             })
+;;

--- a/lib/task/task_goal_reconciliation.mli
+++ b/lib/task/task_goal_reconciliation.mli
@@ -1,0 +1,12 @@
+type ready = {
+  goal_id : string;
+  triggering_task_id : string;
+}
+
+val ready_after_terminal_task :
+  config:Workspace_core.config -> task_id:string -> ready option
+(** Re-read the canonical Task, Goal link, and Goal stores after a terminal
+    Task commit. Returns a reconciliation cue only when the triggering Task is
+    terminal, belongs to exactly one executing Goal, and every linked Task is
+    terminal. This is evidence that Goal-level synthesis is ready, not authority
+    to complete the Goal. *)

--- a/lib/task/task_goal_reconciliation.mli
+++ b/lib/task/task_goal_reconciliation.mli
@@ -3,6 +3,11 @@ type ready = {
   triggering_task_id : string;
 }
 
+type startup_ready = {
+  ready : ready;
+  completing_agent_name : string;
+}
+
 val ready_after_terminal_task :
   config:Workspace_core.config -> task_id:string -> ready option
 (** Re-read the canonical Task, Goal link, and Goal stores after a terminal
@@ -10,3 +15,10 @@ val ready_after_terminal_task :
     terminal, belongs to exactly one executing Goal, and every linked Task is
     terminal. This is evidence that Goal-level synthesis is ready, not authority
     to complete the Goal. *)
+
+val ready_executing_goals :
+  config:Workspace_core.config -> startup_ready list
+(** Deterministically scans canonical Goal, Task, and link state for executing
+    Goals whose linked Tasks are all terminal. The latest terminal Task
+    supplies the stable stimulus id and delivery actor. This is restart
+    reconciliation only; it never mutates Goal or Task state. *)

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -83,51 +83,6 @@ let missing_live_task_transition_rejection ~task_list_projection ~tool_name
         bindings and suppressed transition action=%s."
        task_id action_s)
 
-let goal_completion_next_action ~config ~task_id =
-  let tasks = Workspace.get_tasks_raw config in
-  match
-    List.find_opt
-      (fun (task : Masc_domain.task) -> String.equal task.id task_id)
-      tasks
-  with
-  | Some { task_status = Masc_domain.Done _; _ } ->
-    let goal_task_links =
-      Workspace_goal_index.read_goal_task_links config
-    in
-    let task_goal_index =
-      Workspace_goal_index.build_task_goal_index ~goal_task_links ()
-    in
-    (match Stdlib.Hashtbl.find_opt task_goal_index task_id with
-     | Some [ goal_id ] ->
-       (match Goal_store.get_goal config ~goal_id with
-        | Some { phase = Goal_phase.Executing; _ } ->
-          let goal_task_index =
-            Workspace_goal_index.build_goal_task_index
-              ~goal_task_links
-              tasks
-          in
-          if
-            Workspace_goal_index.tasks_for_goal goal_task_index ~goal_id <> []
-            && Workspace_goal_index.open_task_count_for_goal_indexed
-                 goal_task_index
-                 ~goal_id
-               = 0
-          then
-            Some
-              (`Assoc
-                 [ "tool", `String "masc_goal_transition"
-                 ; ( "arguments"
-                   , `Assoc
-                       [ "goal_id", `String goal_id
-                       ; "action", `String "request_complete"
-                       ] )
-                 ; "reason", `String "all_linked_tasks_terminal"
-                 ])
-          else None
-        | Some _ | None -> None)
-     | Some (_ :: _ :: _) | Some [] | None -> None)
-  | Some _ | None -> None
-
 let rec handle_done
       ?(task_list_projection = Tool_capability_projection.External_masc_tasks)
       ~tool_name ~start_time ctx args =
@@ -268,16 +223,6 @@ and handle_transition
       ~task_id
       ~action_s
   | Some task_before ->
-  let task_was_done_before =
-    match task_before.task_status with
-    | Masc_domain.Done _ -> true
-    | Masc_domain.Todo
-    | Masc_domain.Claimed _
-    | Masc_domain.InProgress _
-    | Masc_domain.AwaitingVerification _
-    | Masc_domain.Cancelled _ ->
-      false
-  in
   let release_owner_mismatch_rejection =
     match action, task_opt with
     | Masc_domain.Release, Some task ->
@@ -633,28 +578,7 @@ and handle_transition
    | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
    | Error _, _ -> ());
-  match result, task_list_projection with
-  | Ok message, Tool_capability_projection.Keeper_tasks_list
-    when not task_was_done_before ->
-    (match goal_completion_next_action ~config:ctx.config ~task_id with
-     | Some next_action ->
-       Tool_result.make_ok
-         ~tool_name
-         ~start_time
-         ~data:
-           (`Assoc
-              [ "message", `String message
-              ; "task_id", `String task_id
-              ; "next_action", next_action
-              ])
-         ()
-     | None -> result_to_response ~tool_name ~start_time result)
-  | Ok _, Tool_capability_projection.Keeper_tasks_list ->
-    result_to_response ~tool_name ~start_time result
-  | Error _, Tool_capability_projection.Keeper_tasks_list ->
-    result_to_response ~tool_name ~start_time result
-  | (Ok _ | Error _), Tool_capability_projection.External_masc_tasks ->
-    result_to_response ~tool_name ~start_time result
+  result_to_response ~tool_name ~start_time result
 
 let handle_update_priority ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -85,6 +85,10 @@ type agent_lifecycle_event =
   | Session_rebound
   | Session_ended
 
+type task_terminal_delivery =
+  | Task_terminal_delivered
+  | Task_terminal_delivery_degraded of { kind : string; detail : string }
+
 let agent_lifecycle_event_to_string = function
   | Session_bound -> "session_bound"
   | Session_rebound -> "session_rebound"
@@ -271,8 +275,10 @@ let task_terminal_committed_fn
   : (Workspace_utils_backend_setup.config ->
      agent_name:string ->
      task_id:string ->
-     unit) Atomic.t
-  = Atomic.make (fun _config ~agent_name:_ ~task_id:_ -> ())
+     task_terminal_delivery) Atomic.t
+  =
+  Atomic.make
+    (fun _config ~agent_name:_ ~task_id:_ -> Task_terminal_delivered)
 
 let verification_submit_request_fn
   : (Workspace_utils_backend_setup.config ->

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -267,6 +267,13 @@ let push_task_event_fn
   : (event_type:string -> details:(string * Yojson.Safe.t) list -> unit) Atomic.t
   = Atomic.make (fun ~event_type:_ ~details:_ -> ())
 
+let task_terminal_committed_fn
+  : (Workspace_utils_backend_setup.config ->
+     agent_name:string ->
+     task_id:string ->
+     unit) Atomic.t
+  = Atomic.make (fun _config ~agent_name:_ ~task_id:_ -> ())
+
 let verification_submit_request_fn
   : (Workspace_utils_backend_setup.config ->
      task:Masc_domain.task ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -28,6 +28,10 @@ type agent_lifecycle_event =
   | Session_rebound
   | Session_ended
 
+type task_terminal_delivery =
+  | Task_terminal_delivered
+  | Task_terminal_delivery_degraded of { kind : string; detail : string }
+
 val activity_emit_fn : (Workspace_utils_backend_setup.config ->
             actor:activity_entity ->
             ?subject:activity_entity ->
@@ -130,7 +134,7 @@ val task_terminal_committed_fn :
   (Workspace_utils_backend_setup.config ->
    agent_name:string ->
    task_id:string ->
-   unit) Atomic.t
+   task_terminal_delivery) Atomic.t
 
 val verification_submit_request_fn :
   (Workspace_utils_backend_setup.config ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -126,6 +126,12 @@ val record_thompson_result_fn :
 val push_task_event_fn :
   (event_type:string -> details:(string * Yojson.Safe.t) list -> unit) Atomic.t
 
+val task_terminal_committed_fn :
+  (Workspace_utils_backend_setup.config ->
+   agent_name:string ->
+   task_id:string ->
+   unit) Atomic.t
+
 val verification_submit_request_fn :
   (Workspace_utils_backend_setup.config ->
    task:Masc_domain.task ->

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -485,11 +485,29 @@ let transition_task_outcome_r
             Masc_domain.task_status_is_terminal new_status
             && not (Masc_domain.task_status_is_terminal task.task_status)
           in
-          if became_terminal then
-            (Atomic.get Workspace_hooks.task_terminal_committed_fn)
-              config
-              ~agent_name
-              ~task_id;
+          if became_terminal
+          then (
+            let delivery =
+              try
+                (Atomic.get Workspace_hooks.task_terminal_committed_fn)
+                  config
+                  ~agent_name
+                  ~task_id
+              with
+              | exn ->
+                Workspace_hooks.Task_terminal_delivery_degraded
+                  { kind = "hook_exception"; detail = Printexc.to_string exn }
+            in
+            match delivery with
+            | Workspace_hooks.Task_terminal_delivered -> ()
+            | Workspace_hooks.Task_terminal_delivery_degraded { kind; detail } ->
+              Log.TaskState.error
+                "task terminal commit succeeded but reconciliation delivery degraded \
+                 task_id=%s agent=%s kind=%s detail=%s"
+                task_id
+                agent_name
+                kind
+                detail);
           let phase_duration_ms () =
             Some
               (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -481,6 +481,15 @@ let transition_task_outcome_r
             Masc_domain.task_status_is_done new_status
             && not (Masc_domain.task_status_is_done task.task_status)
           in
+          let became_terminal =
+            Masc_domain.task_status_is_terminal new_status
+            && not (Masc_domain.task_status_is_terminal task.task_status)
+          in
+          if became_terminal then
+            (Atomic.get Workspace_hooks.task_terminal_committed_fn)
+              config
+              ~agent_name
+              ~task_id;
           let phase_duration_ms () =
             Some
               (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -494,6 +494,7 @@ let transition_task_outcome_r
                   ~agent_name
                   ~task_id
               with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
               | exn ->
                 Workspace_hooks.Task_terminal_delivery_degraded
                   { kind = "hook_exception"; detail = Printexc.to_string exn }

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -438,6 +438,14 @@ let install () =
     ) in
     Subscriptions.push_event_to_sessions payload);
 
+  Atomic.set Workspace_hooks.task_terminal_committed_fn
+    (fun config ~agent_name ~task_id ->
+       ignore
+         (Keeper_goal_reconciliation_wake.enqueue_if_ready
+            ~config
+            ~completing_agent_name:agent_name
+            ~task_id));
+
   Atomic.set Workspace_hooks.verification_submit_request_fn
     (fun config ~task ~assignee ~verification_id ~evidence_refs ->
        Verification_protocol.create_submit_request

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -440,11 +440,30 @@ let install () =
 
   Atomic.set Workspace_hooks.task_terminal_committed_fn
     (fun config ~agent_name ~task_id ->
-       ignore
-         (Keeper_goal_reconciliation_wake.enqueue_if_ready
-            ~config
-            ~completing_agent_name:agent_name
-            ~task_id));
+       match
+         Keeper_goal_reconciliation_wake.enqueue_if_ready
+           ~config
+           ~completing_agent_name:agent_name
+           ~task_id
+       with
+       | Keeper_goal_reconciliation_wake.Not_ready
+       | Keeper_goal_reconciliation_wake.Enqueued _
+       | Keeper_goal_reconciliation_wake.Already_present _ ->
+         Workspace_hooks.Task_terminal_delivered
+       | Keeper_goal_reconciliation_wake.No_keeper_target { goal_id } ->
+         Workspace_hooks.Task_terminal_delivery_degraded
+           { kind = "no_keeper_target"; detail = "goal_id=" ^ goal_id }
+       | Keeper_goal_reconciliation_wake.Enqueue_failed
+           { goal_id; keeper_name; detail } ->
+         Workspace_hooks.Task_terminal_delivery_degraded
+           { kind = "storage_error"
+           ; detail =
+               Printf.sprintf
+                 "keeper=%s goal_id=%s: %s"
+                 keeper_name
+                 goal_id
+                 detail
+           });
 
   Atomic.set Workspace_hooks.verification_submit_request_fn
     (fun config ~task ~assignee ~verification_id ~evidence_refs ->

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -212,7 +212,8 @@ let relevant_delivery_count ~base_path ~candidate_id =
           | Event_queue.Connector_attention _
           | Event_queue.Hitl_resolved _
           | Event_queue.Manual_compaction_requested
-          | Event_queue.Goal_assigned _ -> count)
+          | Event_queue.Goal_assigned _
+          | Event_queue.Goal_reconciliation_ready _ -> count)
        0
 ;;
 

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -118,6 +118,18 @@ let contains_substring ~needle haystack =
   in
   String.equal needle "" || scan 0
 
+let event_queue_test_meta keeper_name trace_id =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String ("keeper-" ^ keeper_name ^ "-agent")
+        ; "trace_id", `String trace_id
+        ])
+  with
+  | Ok meta -> meta
+  | Error detail -> Alcotest.fail detail
+
 let with_strict_executor f =
   Eio_main.run
   @@ fun env ->
@@ -558,6 +570,50 @@ let () =
     }
   in
   assert (stimulus_identity_equal assignment_stim assignment_retitled);
+  let reconciliation =
+    { gr_goal_id = "goal-9"; gr_triggering_task_id = "task-4" }
+  in
+  let reconciliation_stim =
+    { post_id = goal_reconciliation_ready_post_id reconciliation
+    ; urgency = Immediate
+    ; arrived_at = 9.0
+    ; payload = Goal_reconciliation_ready reconciliation
+    }
+  in
+  assert (
+    String.equal
+      reconciliation_stim.post_id
+      "goal-reconciliation-ready:goal-9");
+  assert (
+    String.equal
+      (payload_kind_label reconciliation_stim.payload)
+      "goal_reconciliation_ready");
+  (match stimulus_of_yojson (stimulus_to_yojson reconciliation_stim) with
+   | Ok { payload = Goal_reconciliation_ready decoded; _ } ->
+     assert (String.equal decoded.gr_goal_id "goal-9");
+     assert (String.equal decoded.gr_triggering_task_id "task-4")
+   | Ok _ -> Alcotest.fail "Goal_reconciliation_ready codec changed payload"
+   | Error msg ->
+     Alcotest.fail
+       ("Goal_reconciliation_ready stimulus round-trip failed: " ^ msg));
+  let prompt_event =
+    match
+      Masc.Keeper_world_observation.pending_board_event_of_stimulus
+        ~meta:(event_queue_test_meta "goal-reconciler" "trace-goal-reconciler")
+        reconciliation_stim
+    with
+    | Ok (Some event) -> event
+    | Ok None -> Alcotest.fail "goal reconciliation wake produced no prompt event"
+    | Error _ -> Alcotest.fail "goal reconciliation wake prompt projection failed"
+  in
+  assert (
+    match prompt_event.event_kind with
+    | Masc.Keeper_world_observation.Goal_reconciliation_ready -> true
+    | _ -> false);
+  assert (
+    contains_substring
+      ~needle:"Re-read Goal and Task SSOT"
+      prompt_event.preview);
   (* Producer diff is edge-only: additions wake, removals and unchanged ids
      never do. *)
   assert (

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -833,6 +833,7 @@ let test_stimulus_kind_string_roundtrip () =
     ; Keeper_reaction_ledger.Hitl_resolved
     ; Keeper_reaction_ledger.Manual_compaction
     ; Keeper_reaction_ledger.Goal_assigned
+    ; Keeper_reaction_ledger.Goal_reconciliation_ready
     ];
   check bool "unknown stimulus kind string is None" true
     (Option.is_none (Keeper_reaction_ledger.stimulus_kind_of_string "totally_unknown"))

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -666,6 +666,172 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
        | None -> fail "Goal disappeared")
 ;;
 
+let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
+  let dir = temp_dir "registry_goal_reconciliation_restart" in
+  let previous_hook = Atomic.get Workspace_hooks.task_terminal_committed_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.task_terminal_committed_fn previous_hook;
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.For_testing.clear ();
+       let config = Masc.Workspace.default_config dir in
+       let meta = make_goal_reconciler_meta () in
+       ignore (Masc.Workspace.init config ~agent_name:(Some meta.agent_name));
+       Atomic.set Workspace_hooks.task_terminal_committed_fn
+         (fun _config ~agent_name:_ ~task_id:_ ->
+            Workspace_hooks.Task_terminal_delivered);
+       let goal, _ =
+         match
+           Goal_store.upsert_goal
+             config
+             ~id:"goal-reconciliation-restart"
+             ~title:"Recover a missed terminal hook"
+             ()
+         with
+         | Ok result -> result
+         | Error detail -> fail detail
+       in
+       ignore
+         (Workspace_task.add_task
+            ~goal_id:goal.id
+            config
+            ~title:"terminal before restart"
+            ~priority:2
+            ~description:"missed hook");
+       let transition action =
+         match
+           Masc.Workspace.transition_task_r
+             config
+             ~agent_name:meta.agent_name
+             ~task_id:"task-001"
+             ~action
+             ()
+         with
+         | Ok _ -> ()
+         | Error error -> fail (Masc_domain.masc_error_to_string error)
+       in
+       transition Masc_domain.Claim;
+       transition Masc_domain.Start;
+       transition Masc_domain.Cancel;
+       check int "missed hook left no queue item" 0
+         (registry_snapshot ~base_path:config.base_path meta.name
+          |> Keeper_event_queue.length);
+       let queue_path =
+         Filename.concat
+           (Filename.concat
+              (Common.keepers_runtime_dir_of_base ~base_path:config.base_path)
+              meta.name)
+           "event-queue.json"
+       in
+       Fs_compat.mkdir_p queue_path;
+       let failed =
+         Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
+       in
+       check int "storage failure remains visible" 1 failed.failed_count;
+       Unix.rmdir queue_path;
+       let first = ref None in
+       let second = ref None in
+       Eio.Fiber.both
+         (fun () ->
+            first :=
+              Some
+                (Masc.Keeper_goal_reconciliation_wake.reconcile_startup
+                   ~config))
+         (fun () ->
+            second :=
+              Some
+                (Masc.Keeper_goal_reconciliation_wake.reconcile_startup
+                   ~config));
+       let require_summary = function
+         | Some summary -> summary
+         | None -> fail "concurrent reconciliation fiber returned no summary"
+       in
+       let first = require_summary !first in
+       let second = require_summary !second in
+       check int "one concurrent scan enqueued"
+         1 (first.enqueued_count + second.enqueued_count);
+       check int "the other concurrent scan observed durable identity"
+         1 (first.already_present_count + second.already_present_count);
+       check int "restart recovery persisted exactly once" 1
+         (registry_snapshot ~base_path:config.base_path meta.name
+          |> Keeper_event_queue.length))
+;;
+
+let test_terminal_hook_degradation_does_not_invalidate_task_commit () =
+  let dir = temp_dir "registry_goal_reconciliation_hook_degradation" in
+  let previous_hook = Atomic.get Workspace_hooks.task_terminal_committed_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.task_terminal_committed_fn previous_hook;
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Masc.Workspace.default_config dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "external"));
+       let terminal_with hook title =
+         Atomic.set Workspace_hooks.task_terminal_committed_fn hook;
+         ignore
+           (Workspace_task.add_task
+              config
+              ~title
+              ~priority:2
+              ~description:"");
+         let task_id =
+           match
+             Masc.Workspace.get_tasks_raw config
+             |> List.find_opt (fun (task : Masc_domain.task) ->
+                  String.equal task.title title)
+           with
+           | Some task -> task.id
+           | None -> fail "newly added hook-degradation Task was not persisted"
+         in
+         let transition action =
+           Masc.Workspace.transition_task_r
+             config
+             ~agent_name:"external"
+             ~task_id
+             ~action
+             ()
+         in
+         (match transition Masc_domain.Claim with
+          | Ok _ -> ()
+          | Error error -> fail (Masc_domain.masc_error_to_string error));
+         (match transition Masc_domain.Start with
+          | Ok _ -> ()
+          | Error error -> fail (Masc_domain.masc_error_to_string error));
+         (match transition Masc_domain.Cancel with
+          | Ok _ ->
+            (match
+               Masc.Workspace.get_tasks_raw config
+               |> List.find_opt (fun (task : Masc_domain.task) ->
+                    String.equal task.id task_id)
+             with
+             | Some task
+               when Masc_domain.task_status_is_terminal task.task_status ->
+               ()
+             | Some _ | None ->
+               fail "terminal hook degradation lost terminal state")
+          | Error error ->
+            fail
+              ("committed terminal transition was reported as failure: "
+               ^ Masc_domain.masc_error_to_string error))
+       in
+       terminal_with
+         (fun _config ~agent_name:_ ~task_id:_ ->
+            Workspace_hooks.Task_terminal_delivery_degraded
+              { kind = "injected"; detail = "delivery unavailable" })
+         "typed delivery degradation";
+       terminal_with
+         (fun _config ~agent_name:_ ~task_id:_ ->
+            failwith "injected hook exception")
+         "hook exception")
+;;
+
 let contains_substring text needle =
   let text_len = String.length text in
   let needle_len = String.length needle in
@@ -853,6 +1019,14 @@ let () =
             "goal reconciliation persists once after last terminal task"
             `Quick
             test_goal_reconciliation_enqueues_once_after_last_terminal_task
+        ; test_case
+            "restart scan retries missed reconciliation exactly once"
+            `Quick
+            test_goal_reconciliation_restart_scan_retries_missed_delivery
+        ; test_case
+            "terminal hook degradation preserves committed Task outcome"
+            `Quick
+            test_terminal_hook_degradation_does_not_invalidate_task_commit
         ] )
     ; ( "tool_dispatch_exact_resources"
       , [ test_case "preserves exact meta after healthy entry replacement" `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -37,6 +37,21 @@ let make_meta name =
   | Error e -> failwith ("make_meta failed: " ^ e)
 ;;
 
+let make_goal_reconciler_meta () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String "goal-reconciler"
+        ; "agent_name", `String "keeper-goal-reconciler-agent"
+        ; "trace_id", `String "trace-goal-reconciler"
+        ; "allowed_paths", `List [ `String "*" ]
+        ; "autoboot_enabled", `Bool false
+        ])
+  with
+  | Ok meta -> meta
+  | Error detail -> failwith ("goal reconciler meta failed: " ^ detail)
+;;
+
 let register name =
   let meta = make_meta name in
   KR.For_testing.register ~base_path meta.name meta
@@ -551,6 +566,106 @@ let test_goal_assignment_defers_offline_lane_after_queue_commit () =
        | _ -> fail "goal assignment was not retained in the offline lane")
 ;;
 
+let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
+  let dir = temp_dir "registry_goal_reconciliation" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.For_testing.clear ();
+       let config = Masc.Workspace.default_config dir in
+       let meta = make_goal_reconciler_meta () in
+       ignore (Masc.Workspace.init config ~agent_name:(Some meta.agent_name));
+       Masc.Workspace_metric_hooks.install ();
+       ignore (KR.register_offline ~base_path:config.base_path meta.name meta);
+       let goal, _ =
+         match
+           Goal_store.upsert_goal
+             config
+             ~id:"goal-reconciliation-test"
+             ~title:"Reconcile after terminal tasks"
+             ()
+         with
+         | Ok result -> result
+         | Error detail -> fail detail
+       in
+       ignore
+         (Workspace_task.add_task
+            ~goal_id:goal.id
+            config
+            ~title:"first"
+            ~priority:2
+            ~description:"first linked task");
+       ignore
+         (Workspace_task.add_task
+            ~goal_id:goal.id
+            config
+            ~title:"second"
+            ~priority:2
+            ~description:"second linked task");
+       let agent_name = "keeper-goal-reconciler-agent" in
+       let transition task_id action =
+         match
+           Masc.Workspace.transition_task_r
+             config
+             ~agent_name
+             ~task_id
+             ~action
+             ()
+         with
+         | Ok _ -> ()
+         | Error error -> fail (Masc_domain.masc_error_to_string error)
+       in
+       let finish task_id =
+         transition task_id Masc_domain.Claim;
+         transition task_id Masc_domain.Start;
+         transition task_id Masc_domain.Cancel
+       in
+       finish "task-001";
+       check int "no early durable wake" 0
+         (registry_snapshot ~base_path:config.base_path meta.name
+          |> Keeper_event_queue.length);
+       finish "task-002";
+       check int "last terminal commit enqueued reconciliation" 1
+         (registry_snapshot ~base_path:config.base_path meta.name
+          |> Keeper_event_queue.length);
+       (match
+          Masc.Keeper_goal_reconciliation_wake.enqueue_if_ready
+            ~config
+            ~completing_agent_name:agent_name
+            ~task_id:"task-002"
+        with
+        | Masc.Keeper_goal_reconciliation_wake.Already_present _ -> ()
+        | _ -> fail "terminal replay did not deduplicate reconciliation");
+       check int "exactly one pending reconciliation" 1
+         (registry_snapshot ~base_path:config.base_path meta.name
+          |> Keeper_event_queue.length);
+       KR.For_testing.clear ();
+       (match
+          Keeper_event_queue_persistence.load_pending_result
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+        with
+        | Ok queue ->
+          (match Keeper_event_queue.to_list queue with
+           | [ { payload =
+                   Keeper_event_queue.Goal_reconciliation_ready ready
+               ; _
+               } ] ->
+             check string "durable goal id" goal.id ready.gr_goal_id;
+             check string "triggering task id" "task-002"
+               ready.gr_triggering_task_id
+           | _ -> fail "durable reconciliation stimulus was not retained")
+        | Error detail -> fail detail);
+       match Goal_store.get_goal config ~goal_id:goal.id with
+       | Some { phase = Goal_phase.Executing; _ } -> ()
+       | Some _ -> fail "Task completion must not auto-complete its Goal"
+       | None -> fail "Goal disappeared")
+;;
+
 let contains_substring text needle =
   let text_len = String.length text in
   let needle_len = String.length needle in
@@ -734,6 +849,10 @@ let () =
             "goal assignment persists while offline wake is deferred"
             `Quick
             test_goal_assignment_defers_offline_lane_after_queue_commit
+        ; test_case
+            "goal reconciliation persists once after last terminal task"
+            `Quick
+            test_goal_reconciliation_enqueues_once_after_last_terminal_task
         ] )
     ; ( "tool_dispatch_exact_resources"
       , [ test_case "preserves exact meta after healthy entry replacement" `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -761,6 +761,206 @@ let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
           |> Keeper_event_queue.length))
 ;;
 
+let add_and_cancel_goal_task ~config ~goal_id ~title ~agent_name =
+  let goal, _ =
+    match Goal_store.upsert_goal config ~id:goal_id ~title () with
+    | Ok result -> result
+    | Error detail -> fail detail
+  in
+  ignore
+    (Workspace_task.add_task
+       ~goal_id:goal.id
+       config
+       ~title:(title ^ " task")
+       ~priority:2
+       ~description:"terminal reconciliation fixture");
+  let task =
+    Masc.Workspace.get_tasks_raw config
+    |> List.find (fun (task : Masc_domain.task) ->
+         String.equal task.title (title ^ " task"))
+  in
+  let transition action =
+    match
+      Masc.Workspace.transition_task_r
+        config
+        ~agent_name
+        ~task_id:task.id
+        ~action
+        ()
+    with
+    | Ok _ -> ()
+    | Error error -> fail (Masc_domain.masc_error_to_string error)
+  in
+  transition Masc_domain.Claim;
+  transition Masc_domain.Start;
+  transition Masc_domain.Cancel;
+  goal, task.id
+;;
+
+let goal_reconciliation_stimulus ~goal_id ~task_id =
+  let ready : Keeper_event_queue.goal_reconciliation_ready =
+    { gr_goal_id = goal_id; gr_triggering_task_id = task_id }
+  in
+  { Keeper_event_queue.post_id =
+      Keeper_event_queue.goal_reconciliation_ready_post_id ready
+  ; urgency = Keeper_event_queue.Immediate
+  ; arrived_at = 100.0
+  ; payload = Keeper_event_queue.Goal_reconciliation_ready ready
+  }
+;;
+
+let test_goal_reconciliation_retry_after_keeper_registration () =
+  let dir = temp_dir "registry_goal_reconciliation_late_keeper" in
+  let previous_hook = Atomic.get Workspace_hooks.task_terminal_committed_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.task_terminal_committed_fn previous_hook;
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.For_testing.clear ();
+       let config = Masc.Workspace.default_config dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "external"));
+       Atomic.set Workspace_hooks.task_terminal_committed_fn
+         (fun _config ~agent_name:_ ~task_id:_ ->
+            Workspace_hooks.Task_terminal_delivered);
+       let goal, _ =
+         add_and_cancel_goal_task
+           ~config
+           ~goal_id:"goal-reconciliation-late-keeper"
+           ~title:"Late keeper"
+           ~agent_name:"external"
+       in
+       let unresolved =
+         Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
+       in
+       check int "ready Goal remains visibly unresolved" 1 unresolved.unresolved_count;
+       let meta =
+         { (make_goal_reconciler_meta ()) with active_goal_ids = [ goal.id ] }
+       in
+       let entry =
+         KR.For_testing.register ~base_path:config.base_path meta.name meta
+       in
+       Atomic.set entry.fiber_wakeup false;
+       let retried =
+         Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
+       in
+       check int "later registered owner receives durable event" 1 retried.enqueued_count;
+       check bool "later reconciliation emits wake" true
+         (Atomic.get entry.fiber_wakeup);
+       check int "later reconciliation enqueues once" 1
+         (registry_snapshot ~base_path:config.base_path meta.name
+          |> Keeper_event_queue.length))
+;;
+
+let test_goal_reconciliation_outbox_identity_rewakes_without_duplicate () =
+  let dir = temp_dir "registry_goal_reconciliation_outbox" in
+  let previous_hook = Atomic.get Workspace_hooks.task_terminal_committed_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.task_terminal_committed_fn previous_hook;
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.For_testing.clear ();
+       let config = Masc.Workspace.default_config dir in
+       let meta = make_goal_reconciler_meta () in
+       ignore (Masc.Workspace.init config ~agent_name:(Some meta.agent_name));
+       Atomic.set Workspace_hooks.task_terminal_committed_fn
+         (fun _config ~agent_name:_ ~task_id:_ ->
+            Workspace_hooks.Task_terminal_delivered);
+       let goal, task_id =
+         add_and_cancel_goal_task
+           ~config
+           ~goal_id:"goal-reconciliation-outbox"
+           ~title:"Outbox identity"
+           ~agent_name:meta.agent_name
+       in
+       let stimulus =
+         goal_reconciliation_stimulus ~goal_id:goal.id ~task_id
+       in
+       (match
+          Masc.Keeper_registry_event_queue.enqueue_stimulus_durable_result
+            ~base_path:config.base_path
+            meta.name
+            stimulus
+        with
+        | Masc.Keeper_registry_event_queue.Stimulus_enqueued -> ()
+        | _ -> fail "failed to seed durable reconciliation source");
+       let state =
+         match
+           Keeper_event_queue_persistence.load_state_result
+             ~base_path:config.base_path
+             ~keeper_name:meta.name
+         with
+         | Ok state -> state
+         | Error detail -> fail detail
+       in
+       let cancellation : Keeper_event_queue_persistence.accepted_cancellation =
+         { source = stimulus
+         ; source_revision = Keeper_event_queue_state.revision state
+         ; owner_nonce = 17
+         ; operator_operation_id = "goal-reconciliation-outbox-fixture"
+         ; reason = "stage source in genuine transition outbox"
+         }
+       in
+       (match
+          Keeper_event_queue_persistence.cancel_pending_accepted_result
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+            ~current_owner_nonce:17
+            ~settled_at:101.0
+            ~cancellation
+            ()
+        with
+        | Ok
+            (Keeper_event_queue_persistence.Settled _
+            | Keeper_event_queue_persistence.Already_settled _) -> ()
+        | Error detail -> fail detail
+        | Ok (Keeper_event_queue_persistence.Committed_followup_failed { detail; _ }) ->
+          fail detail);
+       let staged =
+         match
+           Keeper_event_queue_persistence.load_state_result
+             ~base_path:config.base_path
+             ~keeper_name:meta.name
+         with
+         | Ok state -> state
+         | Error detail -> fail detail
+       in
+       check int "source left pending" 0
+         (Keeper_event_queue_state.pending staged |> Keeper_event_queue.length);
+       check int "genuine transition outbox retained source" 1
+         (Keeper_event_queue_state.transition_outbox staged |> List.length);
+       let entry =
+         KR.For_testing.register ~base_path:config.base_path meta.name meta
+       in
+       Atomic.set entry.fiber_wakeup false;
+       let replay =
+         Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
+       in
+       check int "outbox identity is already accounted" 1 replay.already_present_count;
+       check bool "startup reconciliation restores lost wake" true
+         (Atomic.get entry.fiber_wakeup);
+       let after =
+         match
+           Keeper_event_queue_persistence.load_state_result
+             ~base_path:config.base_path
+             ~keeper_name:meta.name
+         with
+         | Ok state -> state
+         | Error detail -> fail detail
+       in
+       check int "reconciliation did not duplicate pending source" 0
+         (Keeper_event_queue_state.pending after |> Keeper_event_queue.length);
+       check int "reconciliation preserved sole outbox identity" 1
+         (Keeper_event_queue_state.transition_outbox after |> List.length))
+;;
+
 let test_terminal_hook_degradation_does_not_invalidate_task_commit () =
   let dir = temp_dir "registry_goal_reconciliation_hook_degradation" in
   let previous_hook = Atomic.get Workspace_hooks.task_terminal_committed_fn in
@@ -829,7 +1029,53 @@ let test_terminal_hook_degradation_does_not_invalidate_task_commit () =
        terminal_with
          (fun _config ~agent_name:_ ~task_id:_ ->
             failwith "injected hook exception")
-         "hook exception")
+         "hook exception";
+       let cancellation_title = "hook cancellation" in
+       ignore
+         (Workspace_task.add_task
+            config
+            ~title:cancellation_title
+            ~priority:2
+            ~description:"");
+       let cancellation_task =
+         Masc.Workspace.get_tasks_raw config
+         |> List.find (fun (task : Masc_domain.task) ->
+              String.equal task.title cancellation_title)
+       in
+       let transition action =
+         Masc.Workspace.transition_task_r
+           config
+           ~agent_name:"external"
+           ~task_id:cancellation_task.id
+           ~action
+           ()
+       in
+       (match transition Masc_domain.Claim with
+        | Ok _ -> ()
+        | Error error -> fail (Masc_domain.masc_error_to_string error));
+       (match transition Masc_domain.Start with
+        | Ok _ -> ()
+        | Error error -> fail (Masc_domain.masc_error_to_string error));
+       Atomic.set Workspace_hooks.task_terminal_committed_fn
+         (fun _config ~agent_name:_ ~task_id:_ ->
+            raise
+              (Eio.Cancel.Cancelled
+                 (Failure "injected post-commit cancellation")));
+       let cancellation_propagated =
+         try
+           ignore (transition Masc_domain.Cancel);
+           false
+         with
+         | Eio.Cancel.Cancelled _ -> true
+       in
+       check bool "post-commit cancellation is re-raised" true cancellation_propagated;
+       match
+         Masc.Workspace.get_tasks_raw config
+         |> List.find_opt (fun (task : Masc_domain.task) ->
+              String.equal task.id cancellation_task.id)
+       with
+       | Some task when Masc_domain.task_status_is_terminal task.task_status -> ()
+       | Some _ | None -> fail "cancellation propagation invalidated committed Task")
 ;;
 
 let contains_substring text needle =
@@ -1023,6 +1269,14 @@ let () =
             "restart scan retries missed reconciliation exactly once"
             `Quick
             test_goal_reconciliation_restart_scan_retries_missed_delivery
+        ; test_case
+            "no target retries after Keeper registration"
+            `Quick
+            test_goal_reconciliation_retry_after_keeper_registration
+        ; test_case
+            "outbox identity restores wake without duplicate enqueue"
+            `Quick
+            test_goal_reconciliation_outbox_identity_rewakes_without_duplicate
         ; test_case
             "terminal hook degradation preserves committed Task outcome"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -265,27 +265,6 @@ let keeper_transition ctx args =
   | Some result -> result
   | None -> failwith "Keeper transition dispatch returned None"
 
-let assert_goal_completion_next_action result ~goal_id =
-  if not (Tool_result.is_success result) then
-    failwith (Tool_result.message result);
-  let next_action =
-    Tool_result.data result |> Yojson.Safe.Util.member "next_action"
-  in
-  assert
-    (Yojson.Safe.Util.(next_action |> member "tool" |> to_string)
-     = "masc_goal_transition");
-  assert
-    (Yojson.Safe.Util.(
-       next_action |> member "arguments" |> member "goal_id" |> to_string)
-     = goal_id);
-  assert
-    (Yojson.Safe.Util.(
-       next_action |> member "arguments" |> member "action" |> to_string)
-     = "request_complete");
-  assert
-    (Yojson.Safe.Util.(next_action |> member "reason" |> to_string)
-     = "all_linked_tasks_terminal")
-
 let assert_goal_still_executing ctx ~goal_id =
   match Goal_store.get_goal ctx.Task.Tool.config ~goal_id with
   | Some { phase = Goal_phase.Executing; _ } -> ()
@@ -1550,7 +1529,7 @@ let () = test "handle_transition_verifier_allows_verdict_actions" (fun () ->
     | _ -> failwith "expected verifier approval to complete task"))
 
 let () =
-  test "keeper approved verification cues request_complete after persisted Done"
+  test "keeper approved verification leaves Goal action to durable reconciler"
     (fun () ->
        let worker_ctx = make_test_ctx_with_agent "worker" in
        let verifier_ctx =
@@ -1602,7 +1581,13 @@ let () =
               ; "notes", `String "evidence verified"
               ])
        in
-       assert_goal_completion_next_action result ~goal_id;
+       if not (Tool_result.is_success result) then
+         failwith (Tool_result.message result);
+       assert (
+         match Tool_result.data result with
+         | `Assoc fields -> not (List.mem_assoc "next_action" fields)
+         | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _
+         | `List _ -> true);
        assert_goal_still_executing worker_ctx ~goal_id)
 
 let () = test "handle_claim_sets_planning_current_task" (fun () ->


### PR DESCRIPTION
## Summary
- replace the ephemeral `next_action=request_complete` facade with a typed `Goal_reconciliation_ready` Keeper stimulus
- emit only after an authoritative open-to-terminal Task commit and re-read Goal/Task/link SSOT before enqueue
- durably deduplicate the wake, notify the completing Keeper (or sole assigned Keeper), and keep Goal phase unchanged for semantic `complete` / `block` / follow-up choice
- project the typed stimulus through the existing event queue, reaction ledger, waiting inventory, world observation, and Keeper prompt

## Boundary
- no automatic Goal completion
- no new store, lease, settlement, polling, or derived Goal status
- payload contains only `goal_id` and `triggering_task_id`
- no legacy migration path

## Validation
- `scripts/dune-local.sh build lib/masc.cma test/test_keeper_event_queue.exe test/test_keeper_registry_hardening.exe test/test_tool_task_coverage.exe test/test_keeper_reaction_ledger.exe test/test_keeper_board_attention_worker.exe`
- `test_keeper_event_queue.exe` PASS
- `test_tool_task_coverage.exe` PASS (85/85)
- `test_keeper_reaction_ledger.exe` PASS (20/20)
- focused `test_keeper_registry_hardening.exe test wakeup_callers 2` PASS
- post-rebase focused build and tests PASS on `aeabba3532`

## Known baseline
- full `test_keeper_registry_hardening.exe` has pre-existing noncanonical test fixtures outside the new focused case
- full `test_keeper_board_attention_worker.exe` has 5 pre-existing exact-owner failures; the executable builds and the new closed-variant branch compiles
