### PR TITLE
fix(keeper): separate waiting on an approval from waiting on a queue

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -210,7 +210,12 @@ let dispatch_after_provider_transcript_admission ~messages ~dispatch =
 let terminal_effect_boundary_decision = function
   | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
   | Keeper_tools_oas.External_effect_deferred ->
-    Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
+    (* Not a durable-stimulus yield: nothing is queued behind this turn. A
+       tool is parked on an approval or gate decision, and the keeper cannot
+       advance it. Reporting both as [Durable_stimulus_waiting] made a keeper
+       blocked on an unanswered approval indistinguishable from one that
+       simply had work queued. *)
+    Ok (Runtime_agent.Yield Runtime_agent.External_effect_waiting)
   | Keeper_tools_oas.Terminal_effect_completed ->
     Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
   | Keeper_tools_oas.Terminal_effect_failed

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -28,7 +28,8 @@ let observed_completion_evidence
   match stop_reason with
   | Runtime_agent.InputRequired _
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ ->
     Keeper_execution_receipt.Completion_observation_unknown
   | Runtime_agent.Completed ->
     if actual_keeper_tool_names <> []

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -184,7 +184,8 @@ let checkpoint_for_replay_persistence
          "refusing to save input-required checkpoint: messages do not match \
           pre-turn history prefix")
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ ->
     (* A control-boundary checkpoint retains the current-turn tool result so
        resumption cannot repeat an already committed effect. *)
     observation_replay_checkpoint ~history_messages ~session_id checkpoint

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -6,7 +6,8 @@ type finalized = {
 
 let stop_reason_suppresses_visible_response = function
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ -> true
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ -> true
   | Runtime_agent.Completed
   | Runtime_agent.InputRequired _ ->
     false

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -199,6 +199,8 @@ let stop_reason_to_string = function
     Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
     Printf.sprintf "yielded_to_durable_stimulus:%d" turns_used
+  | Runtime_agent.Yielded_to_external_effect { turns_used } ->
+    Printf.sprintf "yielded_to_external_effect:%d" turns_used
   | Runtime_agent.InputRequired _ ->
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Input_required
 ;;
@@ -212,7 +214,8 @@ let receipt_terminal_reason_code_of_stop_reason = function
   | Runtime_agent.Completed ->
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success
   | ( Runtime_agent.Yielded_to_chat_waiting _
-    | Runtime_agent.Yielded_to_durable_stimulus _ ) as stop_reason ->
+    | Runtime_agent.Yielded_to_durable_stimulus _
+    | Runtime_agent.Yielded_to_external_effect _ ) as stop_reason ->
     stop_reason_to_string stop_reason
 ;;
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -152,7 +152,8 @@ let apply_accept
   match run_result.stop_reason with
   | Runtime_agent.InputRequired _
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ ->
     (* These are typed host-control terminals, not model deliverables. Running
        the normal response accept predicate over their question/blank carrier
        would turn them into [Accept_rejected] and incorrectly rotate providers,

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -33,14 +33,16 @@ let turn_ref_wire_key = "turn_ref"
 let of_stop_reason = function
   | Runtime_agent.Completed -> Visible_reply
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ -> Continuation_checkpoint
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_result_surface ~response_text = function
   | Runtime_agent.Completed ->
       if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ -> Continuation_checkpoint
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_reply_payload payload =

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -60,7 +60,8 @@ let terminal_outcome_of_result result =
   | Runtime_agent.Completed -> Terminal_done
   | Runtime_agent.InputRequired _ -> Terminal_input_required
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_external_effect _ ->
     Terminal_checkpoint
 ;;
 
@@ -256,6 +257,8 @@ let emit_usage_metrics_and_log
       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
     | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
       Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
+    | Runtime_agent.Yielded_to_external_effect { turns_used } ->
+      Printf.sprintf "yielded_to_external_effect(%d)" turns_used
     | Runtime_agent.InputRequired { turns_used; _ } ->
       Printf.sprintf "input_required(%d)" turns_used
   in
@@ -268,6 +271,8 @@ let emit_usage_metrics_and_log
        | Runtime_agent.Yielded_to_chat_waiting _ -> "yielded_to_chat_waiting"
        | Runtime_agent.Yielded_to_durable_stimulus _ ->
          "yielded_to_durable_stimulus"
+       | Runtime_agent.Yielded_to_external_effect _ ->
+         "yielded_to_external_effect"
        | Runtime_agent.InputRequired _ -> "input_required"
        | Runtime_agent.Completed -> "success")
   in
@@ -383,6 +388,7 @@ let terminal_reason_of_outcome result = function
     (match result.Keeper_agent_run.stop_reason with
      | Runtime_agent.Yielded_to_chat_waiting _
      | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Yielded_to_external_effect _
      | Runtime_agent.InputRequired _ ->
        Keeper_turn_terminal.of_disposition
          ~source:"runtime_stop_reason"
@@ -459,6 +465,15 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Log.Keeper.info ~keeper_name:updated_meta.name
       "yielded autonomous run for a pending durable stimulus after %d turn(s), \
        checkpoint saved — will resume next cycle"
+      turns_used;
+    reset_failure_state ()
+  | Runtime_agent.Yielded_to_external_effect { turns_used } ->
+    (* Distinct from the durable-stimulus yield above: this one does not
+       resolve on the next cycle. Something outside the keeper — an approval,
+       a gate decision — has to land first. *)
+    Log.Keeper.info ~keeper_name:updated_meta.name
+      "yielded autonomous run waiting on an external effect after %d turn(s), \
+       checkpoint saved — resumes when the effect resolves"
       turns_used;
     reset_failure_state ()
   | Runtime_agent.InputRequired { turns_used; request } ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -64,6 +64,7 @@ type stop_reason =
   | Completed
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Yielded_to_external_effect of { turns_used : int }
   | InputRequired of {
       turns_used : int;
       request : Agent_sdk.Error.input_required;
@@ -72,6 +73,7 @@ type stop_reason =
 type cooperative_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | External_effect_waiting
   | Terminal_tool_completed
 
 type cooperative_yield_decision =
@@ -775,6 +777,7 @@ let stop_reason_of_cooperative_yield ~turns_used = function
   | Chat_waiting -> Yielded_to_chat_waiting { turns_used }
   | Durable_stimulus_waiting ->
     Yielded_to_durable_stimulus { turns_used }
+  | External_effect_waiting -> Yielded_to_external_effect { turns_used }
   (* The provider loop yielded at OAS's durable post-tool boundary because
      the typed reply effect already completed. This is successful completion,
      not a continuation checkpoint that should replay on the next cycle. *)
@@ -915,6 +918,8 @@ let dashboard_status_of_stop_reason = function
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_chat_waiting" }
   | Yielded_to_durable_stimulus _ ->
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_durable_stimulus" }
+  | Yielded_to_external_effect _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "yielded_to_external_effect" }
   | InputRequired _ ->
       Dashboard_oas_bridge.Cancelled { reason = "input_required" }
 

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -23,6 +23,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
   | Completed
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Yielded_to_external_effect of { turns_used : int }
   | InputRequired of {
       turns_used : int;
       request : Agent_sdk.Error.input_required;
@@ -31,6 +32,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
 type cooperative_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | External_effect_waiting
   | Terminal_tool_completed
 
 type cooperative_yield_decision =

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -17,7 +17,17 @@ type stop_reason =
   | Yielded_to_durable_stimulus of { turns_used : int }
     (* The current autonomous cycle completed at least one OAS provider turn,
        then released its lane because another durable stimulus was queued
-       behind the stimulus already leased by this cycle. *)
+       behind the stimulus already leased by this cycle. Resolves on its own:
+       the next cycle drains the queue. *)
+  | Yielded_to_external_effect of { turns_used : int }
+    (* The run released its lane because a tool it invoked is waiting on an
+       external decision — an approval, a gate. Nothing the keeper does
+       advances it; a human or the gate has to resolve it first.
+
+       Distinct from [Yielded_to_durable_stimulus] because the two need
+       opposite operator responses, and folding them together made a keeper
+       blocked on an unanswered approval look like one cooperating with a busy
+       queue. *)
   | InputRequired of
       { turns_used : int
       ; request : Agent_sdk.Error.input_required

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -16,6 +16,11 @@ type stop_reason =
   | Completed
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+      (** Another stimulus was queued behind the one this cycle leased. The
+          next cycle drains it; no operator action is involved. *)
+  | Yielded_to_external_effect of { turns_used : int }
+      (** A tool is waiting on an approval or gate decision. The keeper cannot
+          advance this on its own. *)
   | InputRequired of {
       turns_used : int;
       request : Agent_sdk.Error.input_required;

--- a/test/dune
+++ b/test/dune
@@ -670,6 +670,11 @@
 
 
 (test
+ (name test_keeper_yield_reason_split)
+ (modules test_keeper_yield_reason_split)
+ (libraries alcotest astring masc_test_deps))
+
+(test
  (name test_keeper_yield_observability)
  (modules test_keeper_yield_observability)
  (libraries alcotest astring masc_test_deps))

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -85,11 +85,13 @@ let test_autonomous_yield_boundary_contract () =
   (match F.runtime_yield_reason chat with
    | Runtime_agent.Chat_waiting -> ()
    | Runtime_agent.Durable_stimulus_waiting
+   | Runtime_agent.External_effect_waiting
    | Runtime_agent.Terminal_tool_completed ->
      fail "chat request mapped to the durable reason");
   (match F.runtime_yield_reason durable_stimulus with
    | Runtime_agent.Durable_stimulus_waiting -> ()
    | Runtime_agent.Chat_waiting
+   | Runtime_agent.External_effect_waiting
    | Runtime_agent.Terminal_tool_completed ->
      fail "durable request mapped to the chat reason");
   check bool "terminal tool yield settles as completion" true
@@ -101,6 +103,7 @@ let test_autonomous_yield_boundary_contract () =
      | Runtime_agent.Completed -> true
      | Runtime_agent.Yielded_to_chat_waiting _
      | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Yielded_to_external_effect _
      | Runtime_agent.InputRequired _ -> false)
 
 let test_terminal_effect_handler_contract () =

--- a/test/test_keeper_yield_reason_split.ml
+++ b/test/test_keeper_yield_reason_split.ml
@@ -1,0 +1,92 @@
+(* Two reasons a turn releases its lane, and they need opposite responses.
+
+   A durable-stimulus yield resolves itself: the next cycle drains the queue.
+   An external-effect yield does not: a human or a gate has to answer first.
+   While both produced [Yielded_to_durable_stimulus], a keeper stuck on an
+   unanswered approval was indistinguishable from one cooperating with a busy
+   queue, and every record — log line, finish_reason, dashboard status — said
+   the same thing about both. *)
+
+open Alcotest
+
+module Run = Masc.Keeper_agent_run
+module Receipt = Masc.Keeper_execution_receipt_types
+
+let test_deferred_external_effect_is_not_a_stimulus_yield () =
+  let decision =
+    Run.terminal_effect_boundary_decision
+      Masc.Keeper_tools_oas.External_effect_deferred
+  in
+  match decision with
+  | Ok (Runtime_agent.Yield Runtime_agent.External_effect_waiting) -> ()
+  | Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting) ->
+    fail "a tool parked on an approval was reported as a queued stimulus"
+  | Ok _ | Error _ -> fail "a deferred external effect did not yield"
+;;
+
+let test_open_effect_still_continues () =
+  match
+    Run.terminal_effect_boundary_decision
+      Masc.Keeper_tools_oas.Terminal_effect_open
+  with
+  | Ok Runtime_agent.Continue -> ()
+  | Ok _ | Error _ -> fail "an open effect must not release the lane"
+;;
+
+let test_each_yield_reason_maps_to_its_own_stop_reason () =
+  let stop_of reason =
+    Runtime_agent.For_testing.stop_reason_of_cooperative_yield ~turns_used:7 reason
+  in
+  (match stop_of Runtime_agent.Durable_stimulus_waiting with
+   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+     check int "turns carried through" 7 turns_used
+   | _ -> fail "stimulus yield lost its reason");
+  match stop_of Runtime_agent.External_effect_waiting with
+  | Runtime_agent.Yielded_to_external_effect { turns_used } ->
+    check int "turns carried through" 7 turns_used
+  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+    fail "external-effect yield collapsed into the stimulus reason"
+  | _ -> fail "external-effect yield lost its reason"
+;;
+
+let test_the_two_are_distinguishable_in_the_durable_record () =
+  (* finish_reason is what a later reader has. If the two share a string the
+     distinction exists only at runtime and never reaches anyone. *)
+  let wire stop = Receipt.stop_reason_to_string stop in
+  let a = wire (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 3 }) in
+  let b = wire (Runtime_agent.Yielded_to_external_effect { turns_used = 3 }) in
+  check bool "the two yields do not share a finish_reason" true (a <> b);
+  check
+    bool
+    "the stimulus yield keeps its existing wire form"
+    true
+    (Astring.String.is_prefix ~affix:"yielded_to_durable_stimulus" a);
+  check
+    bool
+    "the external-effect yield names what it waits on"
+    true
+    (Astring.String.is_prefix ~affix:"yielded_to_external_effect" b)
+;;
+
+let () =
+  run
+    "Keeper yield reason split"
+    [ ( "production"
+      , [ test_case
+            "a deferred external effect is not a stimulus yield"
+            `Quick
+            test_deferred_external_effect_is_not_a_stimulus_yield
+        ; test_case "an open effect still continues" `Quick test_open_effect_still_continues
+        ] )
+    ; ( "propagation"
+      , [ test_case
+            "each reason maps to its own stop reason"
+            `Quick
+            test_each_yield_reason_maps_to_its_own_stop_reason
+        ; test_case
+            "the two are distinguishable in the durable record"
+            `Quick
+            test_the_two_are_distinguishable_in_the_durable_record
+        ] )
+    ]
+;;


### PR DESCRIPTION
Closes #26084

## 두 조건이 같은 값을 만들고 있었습니다

```ocaml
(* keeper_agent_run.ml:212 *)
| External_effect_deferred -> Ok (Yield Durable_stimulus_waiting)

(* keeper_unified_turn_execution.ml:57 *)
if Keeper_event_queue.is_empty pending then Ok None
else Ok (Some { reason = Durable_stimulus_waiting ... })
```

앞의 것은 **도구가 승인이나 게이트 결정을 기다리는 상태** 입니다. keeper 가 무엇을 해도 진행되지 않고 사람이나 게이트가 먼저 답해야 합니다.

뒤의 것은 **큐에 다음 일이 있는 상태** 입니다. 다음 사이클이 알아서 처리합니다.

둘은 운영자가 정반대로 대응해야 하는데, 로그·`finish_reason`·대시보드 상태가 전부 같은 말을 했습니다.

## 하나가 다른 하나를 완전히 가렸습니다

probe 는 terminal-effect 를 먼저 판정합니다 (`keeper_agent_run.ml:629-641`). 도구가 deferred 면 큐 판정은 **실행되지 않습니다.**

라이브 실측 (`~/.masc`, 2026-07-28):

```
양보                                        75 건
승인 요청                                  216 건
양보 ±15초 내 같은 keeper 의 승인 요청 존재   52 건 (69%)
```

`#26072` 가 큐 판정 지점에 추가한 로그는 배포 후 **0 건** 출력됐습니다. 같은 구간에 양보는 9 건 있었습니다. 바이너리에 문자열은 있으므로(`strings` 확인) 배포 문제가 아니라 그 지점이 도달되지 않은 것입니다.

## 변경

`Yielded_to_external_effect` 를 `Yielded_to_durable_stimulus` 에서, `External_effect_waiting` 을 `Durable_stimulus_waiting` 에서 분리합니다.

문자열 접미사나 로그 문구 추가가 아니라 **타입 분기** 입니다. 컴파일러가 소비 지점 11 곳을 전부 지목했고, 각 지점이 둘 중 무엇을 뜻하는지 명시하게 됐습니다 — 한 arm 에 얹혀 가지 않습니다.

`finish_reason` 에 `yielded_to_external_effect:<n>` 이 생깁니다. 나중에 기록을 읽는 쪽이 실제로 갖는 것이 이것이므로, 구분이 durable record 까지 살아남습니다.

## 테스트

신규 `test/test_keeper_yield_reason_split.ml` — 4 케이스:

- deferred external effect 가 stimulus yield 로 보고되지 않는다
- open effect 는 여전히 lane 을 놓지 않는다
- 두 reason 이 각자의 stop_reason 으로 매핑되고 `turns_used` 를 보존한다
- 두 yield 가 `finish_reason` 문자열에서 구분된다 (런타임에만 다르고 기록에서 같으면 아무에게도 안 닿음)

**변이 검증**: `External_effect_deferred` 를 다시 stimulus reason 으로 되돌리면 첫 케이스가 실패합니다. 실행 확인함.

## 로컬 검증

```
dune build @check                                  통과
dune exec test/test_keeper_yield_reason_split.exe      4/4 통과
변이 후 재실행                                      1 failure (의도대로)
```

## 동작 변화

`Yielded_to_external_effect` 는 기존 `Yielded_to_durable_stimulus` 와 동일하게 처리됩니다 — checkpoint 저장, lane 해제, failure state 리셋. 분기가 늘었을 뿐 어느 경로의 처리도 바뀌지 않습니다.

바뀌는 것은 기록입니다.

```
before  yielded autonomous run for a pending durable stimulus after N turn(s)
after   yielded autonomous run waiting on an external effect after N turn(s),
        checkpoint saved — resumes when the effect resolves
```

## 미검증

- 69% 라는 비율은 15 초 창 기준입니다. 창을 넓히면 달라집니다. 배포 후에는 창 추정 없이 `finish_reason` 으로 직접 셀 수 있습니다.
- `External_effect_deferred` 가 승인 대기 외 다른 경우에도 나오는지 확인하지 않았습니다. 생산자는 `keeper_tools_oas_bundle.ml:141` 한 곳으로 보이나 그 조건을 읽지 않았습니다.

RFC-WAIVED: 하나의 값에 뭉쳐 있던 두 조건을 typed variant 로 분리합니다. 새 설계를 도입하지 않으며 어느 경로의 처리도 바꾸지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
