### PR TITLE
fix(gate): give the judge turn-local evidence, not the whole conversation

### DIFF
--- a/config/prompts/keeper.gate_judgment.md
+++ b/config/prompts/keeper.gate_judgment.md
@@ -20,4 +20,13 @@ exists to attach, so judge the registered operation identity and the complete
 input on their own and name the absent context in the rationale. A true
 `partial_context` is not by itself a reason to return `require_human`.
 
+`request_context.initial.history_messages` carries the most recent turn
+messages that fit the evidence budget, and
+`request_context.initial.history_messages_omitted` counts the older messages
+left out. When that count is above zero you are seeing the lead-up, not the
+whole session: judge the request on the operation identity, the complete
+input, and the messages you were given, and say in the rationale that older
+turn history was outside the window. A non-zero count is not by itself a
+reason to return `require_human`.
+
 Respond only through the requested structured JSON contract.

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -8,6 +8,74 @@ open Keeper_agent_result
 open Keeper_agent_error
 open Keeper_agent_prompt_metrics
 
+(* [config/prompts/keeper.gate_judgment.md] hands the judge this bundle as its
+   entire visible evidence, and [keeper_gate_causal_context.mli] declares that
+   evidence to be turn-local. The capture did not match. Measured on live
+   pending approvals 2026-07-28: [history_messages] was 1,278,158 B of a
+   1,300,053 B bundle (98%), and 88.7% of that was three read-only polls
+   replayed in full - masc_status x308, keeper_board_list x200,
+   keeper_tasks_list x380. Every request raised inside a turn therefore
+   exceeded the judge model's prompt limit and was quarantined (#26081).
+
+   Recent lead-up is real evidence, so the newest messages are kept within a
+   declared budget rather than dropped wholesale. The budget is set against
+   measured behaviour of the judge slot (glm-coding.glm-5-turbo): a 400 KB
+   prompt was accepted, an 800 KB prompt was refused with
+   {"code":"1261","message":"Prompt exceeds max length"}, and 300 KB of
+   poorly-tokenising content was refused. 64 KB of history on top of the
+   ~41 KB remainder of the bundle stays well below the nearest refusal. *)
+let gate_history_budget_bytes = 64 * 1024
+
+let tool_use_ids_of_message (message : Agent_sdk.Types.message) =
+  List.filter_map
+    (fun (block : Agent_sdk.Types.content_block) ->
+       match block with
+       | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+       | _ -> None)
+    message.content
+;;
+
+let tool_result_ids_of_message (message : Agent_sdk.Types.message) =
+  List.filter_map
+    (fun (block : Agent_sdk.Types.content_block) ->
+       match block with
+       | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+       | _ -> None)
+    message.content
+;;
+
+(* Returns the newest messages that fit the budget, plus how many were left
+   out. The count is carried into the bundle: a judge that cannot tell it was
+   handed a partial view weighs partial evidence as if it were complete, and
+   the prompt already asks it to name absent context in its rationale. *)
+let gate_history_slice (messages : Agent_sdk.Types.message list) =
+  let sized =
+    List.map
+      (fun message ->
+         let json = Keeper_context_core.message_to_json message in
+         message, json, String.length (Yojson.Safe.to_string json))
+      messages
+  in
+  let rec newest_within budget kept = function
+    | [] -> kept
+    | (message, json, size) :: older ->
+      if size > budget then kept else newest_within (budget - size) ((message, json) :: kept) older
+  in
+  let kept = newest_within gate_history_budget_bytes [] (List.rev sized) in
+  (* A tool result whose call fell outside the window reads as evidence of
+     something the judge never sees happen. Drop those rather than present a
+     dangling half of a pair. *)
+  let visible_calls = List.concat_map (fun (message, _) -> tool_use_ids_of_message message) kept in
+  let kept =
+    List.filter
+      (fun (message, _) ->
+         tool_result_ids_of_message message
+         |> List.for_all (fun id -> List.mem id visible_calls))
+      kept
+  in
+  List.map snd kept, List.length messages - List.length kept
+;;
+
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -45,16 +113,14 @@ let prepare_agent_setup
     | None -> None
   in
   let ctx_snapshot = ctx_work in
+  let gate_history, gate_history_omitted = gate_history_slice history_messages in
   let gate_context =
     Keeper_gate_causal_context.create
       ~turn_id:manifest_keeper_turn_id
       ~initial:
         (`Assoc
-           [ ( "history_messages"
-             , `List
-                 (List.map
-                    Keeper_context_core.message_to_json
-                    history_messages) )
+           [ "history_messages", `List gate_history
+           ; "history_messages_omitted", `Int gate_history_omitted
            ; "base_system_prompt", `String base_system_prompt
            ; "turn_system_prompt", `String turn_system_prompt
            ; "user_message", `String user_message

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -298,6 +298,77 @@ let test_partition_bare_relative_outside_repos_is_base_unresolved () =
       fail "expected Base_unresolved partition for playground-local file")
 ;;
 
+(* --- gate history slice ------------------------------------------------- *)
+
+module Setup = Masc.Keeper_run_tools_setup
+
+let encoded_bytes jsons =
+  List.fold_left
+    (fun acc json -> acc + String.length (Yojson.Safe.to_string json))
+    0
+    jsons
+;;
+
+let bulky_message index =
+  Agent_sdk.Types.text_message
+    Agent_sdk.Types.Assistant
+    (Printf.sprintf "turn %d %s" index (String.make 4096 'x'))
+;;
+
+let as_json message = Masc.Keeper_context_core.message_to_json message
+
+let test_gate_history_keeps_newest_within_budget () =
+  let messages = List.init 200 bulky_message in
+  let kept, omitted = Setup.gate_history_slice messages in
+  check bool "slice stays inside the declared budget" true
+    (encoded_bytes kept <= Setup.gate_history_budget_bytes);
+  check bool "older messages were dropped" true (omitted > 0);
+  (* Nothing may vanish unreported: the judge reads [omitted] to know it was
+     handed a partial view. *)
+  check int "every message is either kept or counted" (List.length messages)
+    (List.length kept + omitted);
+  check bool "kept slice is not empty" true (kept <> []);
+  check
+    (of_pp (fun fmt json -> Format.pp_print_string fmt (Yojson.Safe.to_string json)))
+    "the newest message survives"
+    (as_json (bulky_message 199))
+    (List.nth kept (List.length kept - 1))
+;;
+
+let test_gate_history_short_history_is_whole () =
+  let messages = List.init 3 bulky_message in
+  let kept, omitted = Setup.gate_history_slice messages in
+  check int "nothing is dropped" 0 omitted;
+  check int "every message is kept" (List.length messages) (List.length kept)
+;;
+
+let test_gate_history_drops_orphan_tool_result () =
+  (* The call is the oldest message and falls outside the window; its result is
+     the newest. A retained result with no visible call reads as evidence of
+     something the judge never sees happen. *)
+  let call =
+    Agent_sdk.Types.make_message
+      ~role:Agent_sdk.Types.Assistant
+      [ Agent_sdk.Types.ToolUse
+          { id = "call-outside-window"; name = "masc_status"; input = `Assoc [] }
+      ]
+  in
+  let orphan_result =
+    Agent_sdk.Types.tool_result_msg
+      ~tool_use_id:"call-outside-window"
+      ~content:"cluster snapshot"
+      ()
+  in
+  let messages = (call :: List.init 40 bulky_message) @ [ orphan_result ] in
+  let kept, omitted = Setup.gate_history_slice messages in
+  check bool "the orphan result is not retained" false
+    (List.exists
+       (fun json -> Yojson.Safe.equal json (as_json orphan_result))
+       kept);
+  check int "the dropped result is reported" (List.length messages)
+    (List.length kept + omitted)
+;;
+
 let () =
   run
     "keeper_run_tools_hooks"
@@ -333,6 +404,14 @@ let () =
             test_files_list_uses_first_object_file_path
         ; test_case "missing path falls back to base_path" `Quick
             test_missing_path_falls_back_to_base_path
+        ] )
+    ; ( "gate_history_slice"
+      , [ test_case "keeps the newest messages within the budget" `Quick
+            test_gate_history_keeps_newest_within_budget
+        ; test_case "short history is passed through whole" `Quick
+            test_gate_history_short_history_is_whole
+        ; test_case "drops a tool result whose call fell outside" `Quick
+            test_gate_history_drops_orphan_tool_result
         ] )
     ; ( "observation_partition"
       , [ test_case


### PR DESCRIPTION
#26081 의 근본 수정.

## 문제

HITL Auto Judge 가 승인 요청을 `flow_execution_failed` 로 격리합니다. 원인은 판정 프롬프트가 keeper 대화 이력 전체를 실어 모델의 프롬프트 한계를 넘기기 때문입니다.

라이브 `~/.masc/gate/pending.json` 111 건 전수:

```
최소   294,465B
중앙값 611,036B
최대 1,320,738B
  <100KB: 0건
```

`history_messages` 비중은 전 건 89~98% 이고, 그 안의 88.7% 는 읽기 전용 폴링 3종의 응답입니다:

| 도구 | 횟수 | 바이트 | 비중 |
|---|---|---|---|
| `masc_status` | 308 | 497,704 | 50.3% |
| `keeper_board_list` | 200 | 199,196 | 20.1% |
| `keeper_tasks_list` | 380 | 180,754 | 18.3% |
| **소계** | **888** | **877,654** | **88.7%** |
| `Execute` (실제 작업) | 71 | 68,266 | 6.9% |

판정자는 도구 호출 하나를 승인할지 정하는데 낡은 클러스터 스냅샷 308 장을 받습니다.

## 계약 불일치

`lib/keeper/keeper_gate_causal_context.mli:1-6`:

```
(** Explicit turn-local causal evidence for contextual Gate judgment.
    Each completed Tool appends its exact typed input/result. *)
```

계약은 turn-local 을 말하는데 대화 이력은 turn-local 이 아닙니다. 그리고 계약이 지목하는 필드는 비어 있습니다:

```
1,278,158B  history_messages       ← 계약 밖, 98%
        2B  completed_tool_calls   ← 계약이 말하는 그것, "[]"
```

## 변경

`keeper_run_tools_setup.ml` 이 예산 내 최신 이력만 싣습니다.

```ocaml
let gate_history_budget_bytes = 64 * 1024

let gate_history_slice messages = ...
  (* 최신부터 예산까지 채우고, 호출이 창 밖으로 나간 tool_result 는 제외 *)
  List.map snd kept, List.length messages - List.length kept
```

번들에 누락 개수를 명시합니다:

```ocaml
[ "history_messages", `List gate_history
; "history_messages_omitted", `Int gate_history_omitted
; ... ]
```

`config/prompts/keeper.gate_judgment.md` 에 그 필드의 의미를 추가했습니다. 판정자가 부분 뷰임을 모르면 부분 증거를 전체로 착각해 판정합니다. 프롬프트는 이미 `partial_context` 에 대해 같은 취급을 하고 있어 형태를 맞췄습니다.

### 왜 truncate 가 아니라고 보는가

두 지점에서 갈립니다.

1. **누락을 보고합니다.** 조용히 자르면 silent failure 입니다.
2. **tool 쌍을 깨지 않습니다.** 호출이 창 밖으로 나간 결과만 남으면 판정자는 보지도 못한 일의 증거를 읽습니다. 이 저장소가 `transcript_corruption` 계열로 반복해서 겪은 형태입니다.

### 예산 64KB 의 근거

같은 슬롯(`glm-coding.glm-5-turbo`)에 구조화 출력 요청을 직접 보내 측정했습니다:

| 컨텍스트 | HTTP | 시간 |
|---|---|---|
| 400KB (산문) | 200 | 10.1s |
| 600KB (산문) | 200 | 9.8s |
| **800KB (산문)** | **400** | 3.4s |
| **300KB (base64)** | **400** | 2.3s |

거부 본문: `{"error":{"code":"1261","message":"Prompt exceeds max length"}}`

한계는 바이트가 아니라 토큰입니다. 이력 64KB + 나머지 번들 ~41KB = 105KB 로, 가장 가까운 관측 거부(300KB)에서 3배 여유입니다.

## 검증

`test/test_keeper_run_tools_hooks.ml` 에 3 건 추가:

- `keeps the newest messages within the budget` — 예산 준수, 누락 카운트가 전체를 설명(`kept + omitted = total`), 최신 메시지 생존
- `short history is passed through whole` — 예산 이하에서는 누락 0
- `drops a tool result whose call fell outside` — 창 밖 호출의 결과는 남기지 않음

`scripts/dune-local.sh build @lib/check` 통과. 스위트 로컬 실행에서 추가 3 건 통과.

**미검증 / 알려진 사항**

- 같은 스위트의 `observation_partition` 4 건이 실패하는데, `sandbox_profile` 이 JSON 픽스처 경로에서 거부되는 별개의 선행 결함입니다. 이 PR 과 무관합니다.
- 이 스위트는 `ci.yml` 실행 대상 목록에 없어 CI 는 컴파일만 합니다 (#25803).
- 이 변경은 **새로 생성되는 승인**에만 적용됩니다. 이미 저장된 pending 111 건은 여전히 1.2~1.3MB 컨텍스트를 갖고 있어 재시도해도 같은 자리에서 실패합니다. 소비 시점 처리는 별도 판단이 필요합니다.

## 관련

- masc#26081 (근본원인), masc#26069 (진단 로그)
- oas#2836 — OAS 가 객체형 `error` 를 파싱하지 않아 이 거부가 `Completion_failed` 로 강등됩니다
- oas#2835 — 소비처가 `cause` 를 렌더링할 수 없는 문제

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
