### PR TITLE
feat(keeper): replay an approved tool_execute instead of waiting for it again

### DIFF
--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -13,6 +13,7 @@ let outcome_to_string = function
    approved operation stays with its own producer. The identity is read from
    that producer so the literal has one definition. *)
 let write_operation = Keeper_tool_filesystem_runtime.gate_operation
+let execute_operation = Keeper_tool_execute_runtime.gate_operation
 
 (* The producer owns both the argument schema and the effect encoding, so it
    owns the inversion; replay only decides whether to spend the grant. *)
@@ -20,18 +21,41 @@ let write_args_of_gate_input =
   Keeper_tool_filesystem_runtime.replay_args_of_gate_input
 ;;
 
-let summarize_execution (execution : Keeper_tool_execution.t) =
+let execute_args_of_gate_input =
+  Keeper_tool_execute_runtime.replay_args_of_gate_input
+;;
+
+(* Which approved operations this module can spend without the Keeper
+   re-emitting the call. Separated from the replay body so the set is
+   assertable: a decode function that exists but is never dispatched to looks
+   exactly like a working replay from the outside. *)
+type replayable =
+  | Replay_write
+  | Replay_execute
+
+let replayable_of_operation operation =
+  if String.equal operation write_operation
+  then Some Replay_write
+  else if String.equal operation execute_operation
+  then Some Replay_execute
+  else None
+;;
+
+let summarize_execution ~operation (execution : Keeper_tool_execution.t) =
   match execution.disposition with
   | Tool_result.Completed _ -> Applied execution.raw_output
   | Tool_result.Deferred _ ->
-    (* The re-derived canonical input no longer matches the approval — the
-       pinned target changed between approval and replay. The effect stays
-       unapplied and its new request follows the ordinary Gate. *)
-    Failed "approved write no longer matches its pinned target; not applied"
+    (* The re-derived canonical input no longer matches the approval — what
+       the approval pinned is not what replay would act on now. The effect
+       stays unapplied and its new request follows the ordinary Gate. *)
+    Failed
+      (Printf.sprintf
+         "approved %s no longer matches what was approved; not applied"
+         operation)
   | Tool_result.Failed _ -> Failed execution.raw_output
 ;;
 
-let replay_approved_write
+let replay_approved_effect
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
@@ -52,23 +76,34 @@ let replay_approved_write
     Failed (Keeper_approval_queue.grant_error_to_string error)
   | Ok None -> Not_applicable
   | Ok (Some request) ->
-    if not (String.equal request.tool_name write_operation)
-    then Not_applicable
-    else (
-      match write_args_of_gate_input request.input with
+    let replay operation decode run =
+      match decode request.input with
       | Error detail -> Failed detail
-      | Ok args ->
-        let execution =
-          Keeper_tool_filesystem_runtime.handle_file_write_with_outcome
-            ~turn_sandbox_factory
-            ~config
-            ~meta
-            ~publication_recovery
-            ?continuation_channel
-            ?gate_context
-            ~gate_grant:grant
-            ~args
-            ()
-        in
-        summarize_execution execution)
+      | Ok args -> summarize_execution ~operation (run args)
+    in
+    (match replayable_of_operation request.tool_name with
+     | None -> Not_applicable
+     | Some Replay_write ->
+       replay write_operation write_args_of_gate_input (fun args ->
+         Keeper_tool_filesystem_runtime.handle_file_write_with_outcome
+           ~turn_sandbox_factory
+           ~config
+           ~meta
+           ~publication_recovery
+           ?continuation_channel
+           ?gate_context
+           ~gate_grant:grant
+           ~args
+           ())
+     | Some Replay_execute ->
+       replay execute_operation execute_args_of_gate_input (fun args ->
+         Keeper_tool_execute_runtime.handle_tool_execute_with_outcome
+           ~turn_sandbox_factory
+           ~config
+           ~meta
+           ?continuation_channel
+           ?gate_context
+           ~gate_grant:grant
+           ~args
+           ()))
 ;;

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -14,8 +14,8 @@
 
 type outcome =
   | Not_applicable
-      (** No unconsumed approval, or the approved operation is not a write
-          this module replays. *)
+      (** No unconsumed approval, or the approved operation is not one this
+          module replays. *)
   | Applied of string  (** Opaque human-readable summary of the replay. *)
   | Failed of string
 
@@ -29,7 +29,29 @@ val outcome_to_string : outcome -> string
     so an approved content write never gains edit fields and vice versa. *)
 val write_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
 
-(** Replay the approved write behind [approval_id] exactly once.
+val execute_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
+(** Recover the execute tool arguments from the approved Gate input. Nothing is
+    reconstructed: the Gate request wraps the arguments with execution context
+    rather than re-encoding them. *)
+
+type replayable =
+  | Replay_write
+  | Replay_execute
+
+val replayable_of_operation : string -> replayable option
+(** Which approved operations can be spent without the Keeper re-emitting the
+    call. Exposed because a decode function that exists but is never dispatched
+    to is indistinguishable from a working replay at the boundary. *)
+(** Recover the execute tool arguments from the approved Gate input. Nothing is
+    reconstructed: the Gate request wraps the arguments with execution context
+    rather than re-encoding them. *)
+
+(** Replay the approved effect behind [approval_id] exactly once.
+
+    Covers the two operations whose approvals a Keeper must otherwise re-earn
+    by re-emitting a byte-identical call: [filesystem_write] and
+    [tool_execute]. Any other operation is {!Not_applicable} and still
+    requires resubmission.
 
     [gate_context] is the same causal-context provider the model-issued write
     path supplies. A replay whose re-derived input no longer matches its
@@ -39,7 +61,7 @@ val write_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
 
     Consumption is the durable one-shot grant, so a repeated call after a
     successful replay reports {!Not_applicable} rather than writing twice. *)
-val replay_approved_write :
+val replay_approved_effect :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   publication_recovery:Keeper_publication_recovery_availability.turn_context ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -40,6 +40,10 @@ let sandbox_target_label = function
   | Masc_exec.Sandbox_target.Docker { image; _ } -> "docker:" ^ image
 ;;
 
+(* The Gate operation name this runtime submits under. Shared with the replay
+   path so the two cannot drift apart into a silent Not_applicable. *)
+let gate_operation = "tool_execute"
+
 let execute_gate_input ~input ~cwd ~sandbox_profile ~sandbox_target =
   `Assoc
     [ "schema", `String "masc.keeper_gate.request.v1"
@@ -48,6 +52,26 @@ let execute_gate_input ~input ~cwd ~sandbox_profile ~sandbox_target =
     ; "sandbox_profile", `String sandbox_profile
     ; "sandbox_target", `String sandbox_target
     ]
+;;
+
+(* Inverse of [execute_gate_input]. The producer owns the argument schema and
+   the effect encoding, so it owns the inversion — replay only decides whether
+   to spend the grant.
+
+   Unlike the write path, nothing is reconstructed: the approved tool
+   arguments were stored verbatim under [input], because the Gate request
+   wraps them with execution context rather than re-encoding them. The
+   surrounding [cwd]/[sandbox_*] fields describe where the approval was
+   granted; the handler re-derives them from the current turn, and a
+   divergence there fails the canonical-input match rather than silently
+   executing somewhere else. *)
+let replay_args_of_gate_input input =
+  match input with
+  | `Assoc fields ->
+    (match List.assoc_opt "input" fields with
+     | Some args -> Ok args
+     | None -> Error "approved Gate input has no input")
+  | _ -> Error "approved Gate input is not an object"
 ;;
 
 let execute_secret_redaction ~base_path ~keeper_name =
@@ -286,7 +310,7 @@ let handle_tool_execute_typed
         in
         let gate_request : Keeper_gate.request =
           { keeper_name = meta.name
-          ; operation = "tool_execute"
+          ; operation = gate_operation
           ; input = gate_input
           ; base_path = config.base_path
           ; causal_context = Option.map (fun current -> current ()) gate_context
@@ -303,7 +327,7 @@ let handle_tool_execute_typed
          with
          | Keeper_gate.Deferred { approval_id; reason } ->
            Keeper_gate_deferred_payload.create
-             ~operation:"tool_execute"
+             ~operation:gate_operation
              ~approval_id
              ~reason
              ~context:(`Assoc typed_context_fields)

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -14,6 +14,19 @@ val handle_tool_execute :
   unit ->
   string
 
+val gate_operation : string
+(** The Gate operation name this runtime submits under. Shared with the replay
+    path so an approved execute is recognised rather than skipped. *)
+
+val replay_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
+(** Recover the approved tool arguments from the stored Gate input.
+
+    The Gate request wraps the arguments with execution context rather than
+    re-encoding them, so the approved arguments are returned verbatim. The
+    stored [cwd]/[sandbox_*] fields are not replayed: the handler re-derives
+    them from the current turn, and a divergence fails the canonical-input
+    match instead of executing somewhere the approval did not describe. *)
+
 val handle_tool_execute_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Workspace.config ->

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -87,7 +87,7 @@ let make_tool_bundle
           }
       , Some grant ) ->
       (match
-         Keeper_gate_replay.replay_approved_write
+         Keeper_gate_replay.replay_approved_effect
            ~config
            ~meta
            ~publication_recovery

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -138,6 +138,97 @@ let test_non_object_input_is_rejected () =
   | Error _ -> ()
 ;;
 
+
+(* [tool_execute] is 66% of live approvals and was Not_applicable until now,
+   so a Keeper had to re-emit a byte-identical command to spend its own
+   approval. Unlike the write path nothing is reconstructed: the Gate request
+   wraps the arguments with execution context instead of re-encoding them. *)
+let approved_execute_input =
+  `Assoc
+    [ "schema", `String "masc.keeper_gate.request.v1"
+    ; ( "input"
+      , `Assoc
+          [ "argv", `List [ `String "git"; `String "status" ]
+          ; "timeout_sec", `Int 30
+          ] )
+    ; "cwd", `String "/repo"
+    ; "sandbox_profile", `String "docker"
+    ; "sandbox_target", `String "docker:masc"
+    ]
+;;
+
+let test_execute_args_are_the_approved_arguments () =
+  Alcotest.check
+    result_json
+    "the approved arguments are replayed verbatim"
+    (Ok
+       (`Assoc
+          [ "argv", `List [ `String "git"; `String "status" ]
+          ; "timeout_sec", `Int 30
+          ]))
+    (Masc.Keeper_gate_replay.execute_args_of_gate_input approved_execute_input)
+;;
+
+let test_execute_context_is_not_replayed () =
+  (* cwd and the sandbox fields describe where the approval was granted. The
+     handler re-derives them from the current turn; carrying the stored ones
+     would execute somewhere the approval never described. *)
+  match
+    Masc.Keeper_gate_replay.execute_args_of_gate_input approved_execute_input
+  with
+  | Error detail -> Alcotest.fail detail
+  | Ok (`Assoc fields) ->
+    List.iter
+      (fun key ->
+         Alcotest.check
+           Alcotest.bool
+           (key ^ " is not carried into the replayed arguments")
+           false
+           (List.mem_assoc key fields))
+      [ "cwd"; "sandbox_profile"; "sandbox_target"; "schema" ]
+  | Ok _ -> Alcotest.fail "replayed execute arguments are not an object"
+;;
+
+let test_execute_without_input_is_rejected () =
+  match
+    Masc.Keeper_gate_replay.execute_args_of_gate_input
+      (`Assoc [ "cwd", `String "/repo" ])
+  with
+  | Ok _ -> Alcotest.fail "a Gate input with no arguments replayed anyway"
+  | Error _ -> ()
+;;
+
+
+(* The decode functions above are only reachable if dispatch routes to them.
+   An operation that has a decoder but is never dispatched to is
+   indistinguishable from a working replay at the call site — it just returns
+   Not_applicable and the Keeper is left re-emitting its own approved call. *)
+let test_dispatch_covers_both_replayable_operations () =
+  let open Masc.Keeper_gate_replay in
+  Alcotest.check
+    Alcotest.bool
+    "an approved filesystem_write is replayed"
+    true
+    (replayable_of_operation "filesystem_write" = Some Replay_write);
+  Alcotest.check
+    Alcotest.bool
+    "an approved tool_execute is replayed"
+    true
+    (replayable_of_operation "tool_execute" = Some Replay_execute)
+;;
+
+let test_dispatch_refuses_unknown_operations () =
+  let open Masc.Keeper_gate_replay in
+  List.iter
+    (fun operation ->
+       Alcotest.check
+         Alcotest.bool
+         (operation ^ " still requires resubmission")
+         true
+         (replayable_of_operation operation = None))
+    [ "network_read"; "keeper_board_post"; "" ]
+;;
+
 let () =
   Alcotest.run
     "keeper_gate_replay"
@@ -161,6 +252,30 @@ let () =
             "non-object rejected"
             `Quick
             test_non_object_input_is_rejected
+        ] )
+    ; ( "execute replay"
+      , [ Alcotest.test_case
+            "approved arguments replayed verbatim"
+            `Quick
+            test_execute_args_are_the_approved_arguments
+        ; Alcotest.test_case
+            "approval-time context is not replayed"
+            `Quick
+            test_execute_context_is_not_replayed
+        ; Alcotest.test_case
+            "input without arguments rejected"
+            `Quick
+            test_execute_without_input_is_rejected
+        ] )
+    ; ( "dispatch"
+      , [ Alcotest.test_case
+            "covers both replayable operations"
+            `Quick
+            test_dispatch_covers_both_replayable_operations
+        ; Alcotest.test_case
+            "refuses operations it cannot replay"
+            `Quick
+            test_dispatch_refuses_unknown_operations
         ] )
     ]
 ;;


### PR DESCRIPTION
Refs #25947, RFC-0356

## 승인이 나면 그냥 실행하면 되는 것 아닌가

RFC-0356 이 그렇게 정했습니다 — 승인은 효과를 소유하고, 런타임이 저장된 페이로드로 직접 실행합니다. Keeper 는 아무것도 재현하지 않습니다.

그런데 `filesystem_write` 에만 착지했습니다. `tool_execute` 는 여전히 재제출을 기다립니다.

```ocaml
(* keeper_gate_replay.ml, 변경 전 *)
if not (String.equal request.tool_name write_operation)
then Not_applicable                                    ← tool_execute 가 여기
```

`tool_execute` 는 라이브 승인의 **66%** 입니다. 가장 큰 몫이 replay 대상이 아니었습니다.

## 역함수는 write 보다 단순합니다

```ocaml
(* execute_gate_input — 인자를 감싸기만 함 *)
`Assoc [ "schema", ...; "input", input; "cwd", ...; "sandbox_*", ... ]
                          ↑ 승인된 인자가 그대로 들어있음
```

write 는 `requested_target` + `effect.operation` + carried fields 로 25 줄짜리 재구성이 필요했지만, execute 는 `input` 필드를 꺼내면 끝입니다. 어려워서 안 된 게 아니라 순서가 그랬던 것으로 보입니다.

기존 주석의 원칙을 따라 역함수는 생산자 옆에 둡니다.

> The producer owns both the argument schema and the effect encoding, so it owns the inversion; replay only decides whether to spend the grant.

## 저장된 실행 컨텍스트는 replay 하지 않습니다

`cwd` / `sandbox_profile` / `sandbox_target` 은 **승인이 발급된 시점의 환경**입니다. 핸들러가 현재 턴에서 다시 도출하며, 어긋나면 canonical input 불일치로 실패합니다 — 승인이 서술하지 않은 곳에서 실행되는 대신에.

## 첫 버전은 테스트를 통과하면서 동작하지 않았습니다

execute 분기를 지우고 테스트를 돌렸더니 **12개 전부 통과**했습니다. decode 함수는 검증되는데 거기로 라우팅되는지는 아무도 안 봤기 때문입니다.

decode 는 있는데 도달하지 않는 상태는 밖에서 보면 정상 replay 와 구별되지 않습니다 — `Not_applicable` 을 돌려주고 Keeper 는 계속 자기 승인을 다시 받으러 갑니다. 오늘 `#26072` 에서 같은 형태를 겪었습니다: 코드는 맞았고 그 경로가 안 불렸습니다.

그래서 dispatch 를 이름 있는 술어로 뽑았습니다.

```ocaml
type replayable = Replay_write | Replay_execute
val replayable_of_operation : string -> replayable option
```

**변이 검증 (양방향)**: 분기를 지우면 실패합니다. 실행 확인함.

## 테스트

`test/test_keeper_gate_replay.ml` 에 5 케이스 추가 (기존 7 → 12):

- 승인된 인자가 그대로 replay 된다
- 승인 시점 컨텍스트(`cwd`/`sandbox_*`/`schema`)는 replay 되지 않는다
- 인자 없는 Gate input 은 거부된다
- dispatch 가 replay 가능한 두 operation 을 모두 집는다
- dispatch 가 나머지(`network_read` 등)는 거부한다 — 여전히 재제출 필요

## 로컬 검증

```
dune build @check                            통과
dune exec test/test_keeper_gate_replay.exe       12/12 통과
변이(execute 분기 제거) 후                        1 failure (의도대로)
```

## 라이브 근거 (`~/.masc`, 2026-07-28)

```
delivery 58 건 → 고유 (keeper, tool, input_hash) 21 개    중복 2.8 배
같은 hash 가 소비된 건과 미소비 건 양쪽에 존재            9 건
```

같은 호출이 여러 번 승인 요청을 만들고 하나만 소비됩니다. 첫 grant 를 쓸 수 없어서 모델이 다시 냈기 때문입니다.

## 범위

`network_read` 등 나머지 operation 은 그대로 `Not_applicable` 이며 재제출이 필요합니다. 각 operation 의 생산자가 자기 역함수를 갖는 구조이므로 확장은 같은 패턴을 따르면 됩니다.

## 미검증

- 라이브에서 실제로 `tool_execute` 승인이 replay 되는지는 배포 후 `gate replay approval=... applied` 로그로만 확인됩니다.
- `execute_gate_input` 이 인자를 감싸기만 한다는 것은 그 함수를 읽어 확인했습니다. 다른 경로에서 다르게 인코딩된 execute 요청이 있는지는 확인하지 않았습니다.

RFC-0356 이 명시한 변경 지점 중 남아 있던 operation 하나를 같은 패턴으로 채웁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
