### PR TITLE
fix(board): board 도구 타임스탬프를 시계-상대 문자열이 아닌 시점으로 렌더링

### DIFF
--- a/lib/board_tool_adapter/board_tool.mli
+++ b/lib/board_tool_adapter/board_tool.mli
@@ -18,7 +18,7 @@
     Internal helpers stay private at this boundary
     ([board_list_cache] type + the cache cell, the
     [cached_board_list] adapter,
-    [format_ttl_remaining],
+    [format_expiry],
     [agent_lookup_hook] atomic ref,
     [resolve_board_post_kind], [format_post] /
     [format_post_compact] / [format_comment] /
@@ -70,10 +70,14 @@ val author_raw_agent_name_meta_key : string
 
 (** {1 Display formatting} *)
 
-val format_timestamp_relative : float -> string
-(** Renders a Unix timestamp as a human-readable relative
-    duration (["5s ago"] / ["3h ago"] / ["2d ago"]).
-    Used in board listing prompt blocks. *)
+val format_timestamp_absolute : float -> string
+(** Renders a Unix timestamp as an ISO8601 UTC instant
+    (["2026-07-28T02:15:30Z"]). Used in board listing prompt
+    blocks, which an LLM turn consumes: output must be a
+    function of the argument alone so the payload is
+    byte-stable across calls. Relative rendering is a
+    human-dashboard concern and lives in
+    [Dashboard_labels] / [Tempo]. *)
 
 (** {1 Board error rendering} *)
 

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -26,34 +26,35 @@ module Float = Stdlib.Float
 let raw_agent_name_meta_key ~field = field ^ "_raw_agent_name"
 let author_raw_agent_name_meta_key = raw_agent_name_meta_key ~field:"author"
 
-let format_timestamp_relative ts =
-  let now = Time_compat.now () in
-  let diff = now -. ts in
-  if Stdlib.Float.compare diff 60.0 < 0
-  then "just now"
-  else if Stdlib.Float.compare diff Masc_time_constants.hour < 0
-  then Printf.sprintf "%dm ago" (Stdlib.Int.of_float (diff /. 60.0))
-  else if Stdlib.Float.compare diff Masc_time_constants.day < 0
-  then Printf.sprintf "%dh ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.hour))
-  else Printf.sprintf "%dd ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.day))
-;;
+(* Board tool payloads are read by an LLM turn, not by a human watching a
+   dashboard, so the same post must render to the same bytes on every call.
 
-let format_ttl_remaining expires_at =
+   The previous [format_timestamp_relative] / [format_ttl_remaining] pair read
+   [Time_compat.now ()] inside functions whose signatures promised a pure
+   [float -> string]: the clock was a hidden second input. A re-listed post
+   therefore drifted "7m ago" -> "8m ago" while nothing about the post changed,
+   which (a) made every payload byte-new, so [Board_tool_cache] could never hit
+   and no downstream dedup was possible, and (b) read to the keeper as "the
+   board moved", re-arming its poll cycle. Measured on rondo turn
+   1785189305806: 44 [masc_board_search] calls, one real change, 44 distinct
+   payloads whose only diff was the minute counter; the turn's tool_result
+   accumulation was 81.3% byte-exact duplication.
+
+   Both now render the instant they were given, so output is a function of the
+   argument alone. The keeper resolves recency against [session:wall_time],
+   which [Masc_context_injector] refreshes per turn. Human-facing relative
+   rendering stays in [Dashboard_labels] / [Tempo], which have a human reader
+   and no cache or dedup contract. *)
+let format_timestamp_absolute ts = Masc_domain.iso8601_of_unix_seconds ts
+
+(* Reports the expiry instant rather than a remaining duration. "permanent" is
+   derived from the stored [0.0] sentinel, not from the clock, so it stays
+   stable too. Callers label this [expires:] rather than [TTL:] because an
+   absolute timestamp must not be misread as a duration. *)
+let format_expiry expires_at =
   if Stdlib.Float.compare expires_at 0.0 = 0
   then "permanent"
-  else (
-    let now = Time_compat.now () in
-    let remaining = expires_at -. now in
-    if Stdlib.Float.compare remaining 0.0 <= 0
-    then "expired"
-    else if Stdlib.Float.compare remaining Masc_time_constants.hour < 0
-    then Printf.sprintf "%dm left" (Stdlib.Int.of_float (remaining /. 60.0))
-    else if Stdlib.Float.compare remaining Masc_time_constants.day < 0
-    then Printf.sprintf "%dh left" (Stdlib.Int.of_float (remaining /. Masc_time_constants.hour))
-    else
-      Printf.sprintf
-        "%dd left"
-        (Stdlib.Int.of_float (remaining /. Masc_time_constants.day)))
+  else Masc_domain.iso8601_of_unix_seconds expires_at
 ;;
 
 let board_error_to_string = function
@@ -95,8 +96,8 @@ let visibility_of_string = Board.visibility_of_string
 
 let format_post (p : Board.post) =
   let vis_str = Board.visibility_to_string p.visibility in
-  let time_str = format_timestamp_relative p.created_at in
-  let ttl_str = format_ttl_remaining p.expires_at in
+  let time_str = format_timestamp_absolute p.created_at in
+  let ttl_str = format_expiry p.expires_at in
   let score = p.votes_up - p.votes_down in
   let hearth_str =
     match p.hearth with
@@ -109,7 +110,7 @@ let format_post (p : Board.post) =
     | None -> ""
   in
   Printf.sprintf
-    "**%s** · %s [%s]%s (by %s, %s, TTL: %s)\n%s\n[↑%d ↓%d = %+d] [%d replies]%s"
+    "**%s** · %s [%s]%s (by %s, %s, expires: %s)\n%s\n[↑%d ↓%d = %+d] [%d replies]%s"
     (Board.Post_id.to_string p.id)
     p.title
     vis_str
@@ -128,7 +129,7 @@ let format_post (p : Board.post) =
 (** Compact one-line format: id, title, author, time, score. Omits
     body/TTL/visibility/thread to minimize token usage. *)
 let format_post_compact (p : Board.post) =
-  let time_str = format_timestamp_relative p.created_at in
+  let time_str = format_timestamp_absolute p.created_at in
   let score = p.votes_up - p.votes_down in
   let hearth_str =
     match p.hearth with
@@ -149,7 +150,7 @@ let format_post_compact (p : Board.post) =
 let format_comment ?(indent = 0) (c : Board.comment) =
   let prefix = String.make indent ' ' in
   let tree_prefix = if indent > 0 then "└─ " else "" in
-  let time_str = format_timestamp_relative c.created_at in
+  let time_str = format_timestamp_absolute c.created_at in
   let vote_str =
     if c.votes_up > 0 || c.votes_down > 0
     then Printf.sprintf ", 👍%d 👎%d" c.votes_up c.votes_down

--- a/lib/board_tool_adapter/board_tool_format.mli
+++ b/lib/board_tool_adapter/board_tool_format.mli
@@ -11,7 +11,17 @@ type sort_order = Board_dispatch.sort_order =
 
 val raw_agent_name_meta_key : field:string -> string
 val author_raw_agent_name_meta_key : string
-val format_timestamp_relative : float -> string
+val format_timestamp_absolute : float -> string
+(** ISO8601 UTC rendering of the given instant. A function of its argument
+    alone — board tool payloads must be byte-stable across calls so
+    [Board_tool_cache] can hit and so a keeper does not read a drifting
+    minute counter as a board change. Relative ("Nm ago") rendering belongs
+    to the human-facing [Dashboard_labels] / [Tempo] renderers. *)
+
+val format_expiry : float -> string
+(** ["permanent"] for the [0.0] no-expiry sentinel, otherwise the ISO8601 UTC
+    expiry instant. Reports the instant, not the remaining duration, so the
+    clock is not a hidden input. *)
 val board_error_to_string : Board.board_error -> string
 val board_error_failure_class : Board.board_error -> Tool_result.tool_failure_class
 val error_of_board_error : tool_name:string -> start_time:float -> Board.board_error -> Tool_result.result

--- a/lib/board_tool_adapter/board_tool_handlers.ml
+++ b/lib/board_tool_adapter/board_tool_handlers.ml
@@ -513,7 +513,7 @@ let handle_board_cleanup ~tool_name ~start_time args : Tool_result.result =
                (Board.Post_id.to_string p.id)
                p.title
                (Board.Agent_id.to_string p.author)
-               (Board_tool_format.format_timestamp_relative p.created_at)
+               (Board_tool_format.format_timestamp_absolute p.created_at)
                p.reply_count
                (p.votes_up + p.votes_down))
           targets

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -215,19 +215,33 @@ let test_is_agent () =
     Alcotest.(check bool) "empty = not agent" false
       (Board_tool.is_agent ""))
 
-let test_format_timestamp_relative () =
-  with_eio @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  cleanup ();
-  let now = Time_compat.now () in
-  let s = Board_tool.format_timestamp_relative now in
-  Alcotest.(check string) "recent timestamp" "just now" s;
-  let old = now -. 86400.0 in
-  let s2 = Board_tool.format_timestamp_relative old in
-  Alcotest.(check bool) "1-day old has 'd'" true (String.contains s2 'd');
-  let minutes_ago = now -. 120.0 in
-  let s3 = Board_tool.format_timestamp_relative minutes_ago in
-  Alcotest.(check bool) "2min ago has 'm'" true (String.contains s3 'm')
+(* Pins the input -> output mapping exactly, in both renderers. The predecessors
+   ([format_timestamp_relative] / [format_ttl_remaining]) read
+   [Time_compat.now ()] inside a [float -> string] signature, so the same post
+   rendered differently from one minute to the next: every board payload was
+   byte-new, [Board_tool_cache] could never hit, and a keeper read the drifting
+   minute counter as a board change. The exact expectations below fail if a
+   clock read is reintroduced; the predecessor assertions could not catch it
+   because they only checked that the output contained the letters 'd' / 'm'. *)
+let test_format_timestamp_absolute () =
+  Alcotest.(check string)
+    "epoch renders as ISO8601 UTC"
+    "1970-01-01T00:00:00Z"
+    (Board_tool.format_timestamp_absolute 0.0);
+  Alcotest.(check string)
+    "fixed instant renders as ISO8601 UTC"
+    "2023-11-14T22:13:20Z"
+    (Board_tool.format_timestamp_absolute 1_700_000_000.0);
+  (* [0.0] is the stored no-expiry sentinel, so "permanent" is derived from the
+     data rather than from a clock comparison. *)
+  Alcotest.(check string)
+    "no-expiry sentinel"
+    "permanent"
+    (Board_tool_format.format_expiry 0.0);
+  Alcotest.(check string)
+    "expiry instant renders as ISO8601 UTC"
+    "2023-11-14T22:13:20Z"
+    (Board_tool_format.format_expiry 1_700_000_000.0)
 
 let json_member_string json key =
   match Yojson.Safe.Util.member key json with
@@ -1923,7 +1937,7 @@ let () =
           Alcotest.test_case "sort_order_of_string" `Quick test_sort_order_of_string;
           Alcotest.test_case "board_error_to_string" `Quick test_board_error_to_string;
           Alcotest.test_case "is_agent" `Quick test_is_agent;
-          Alcotest.test_case "format_timestamp_relative" `Quick test_format_timestamp_relative;
+          Alcotest.test_case "format_timestamp_absolute" `Quick test_format_timestamp_absolute;
           Alcotest.test_case "board actor identity canonicalizes keeper alias"
             `Quick test_board_actor_identity_canonicalizes_keeper_alias;
           Alcotest.test_case "board actor identity keeps non-keeper agent"


### PR DESCRIPTION
## 문제

`board_tool_format.ml`의 두 포매터가 **`float -> string` 시그니처로 순수 함수를 약속하면서 본문에서 `Time_compat.now ()`를 읽었다.** 시계가 숨은 두 번째 입력이었다.

```ocaml
let format_timestamp_relative ts =
  let now = Time_compat.now () in   (* 숨은 입력 *)
  ...  Printf.sprintf "%dm ago" ...
```

board 도구 응답은 **LLM 턴이 소비한다.** 같은 게시물이 1분 뒤 다시 조회되면 내용이 하나도 안 변했는데 `7m ago` → `8m ago`로 바이트가 달라진다.

## 실측 (rondo turn `1785189305806`, raw-trace 460KB / 971 record)

| 항목 | 값 |
|---|---|
| `masc_board_search` 호출 | 44회 |
| 실제 board 상태 변화 | 1회 (`+1 post`) |
| 서로 다른 payload | 44개 |
| 44개 응답 간 유일한 diff | 분 카운터 (`difflib.unified_diff` 확인) |
| 턴 `tool_result` 바이트 완전 중복률 | **81.3%** (83,633B / 102,927B) |
| `masc_status` 동일 응답 연속 반환 | 8회 (`500fcc61`) |
| `keeper_tasks_list` 동일 응답 연속 반환 | 8회 (`a3f28786`) |

44개 응답의 유일한 차이:

```diff
-p-b363eea179b0e4b2952d2271d4a93210 · VP-QH-A7F3-...  (by analyst, 7m ago, +0, 4 replies)
+p-b363eea179b0e4b2952d2271d4a93210 · VP-QH-A7F3-...  (by analyst, 8m ago, +0, 4 replies)
```

두 가지 결과가 따라왔다:

1. **모든 payload가 바이트-신규** → 같은 어댑터의 `Board_tool_cache`가 히트할 수 없고, 하류 dedup도 불가능하다.
2. **keeper가 그 drift를 "board가 움직였다"로 읽는다** → `masc_status → keeper_tasks_list → masc_board_search` 폴링 사이클이 계속 재무장된다. 앞의 두 도구는 바이트 동일 응답을 8회 연속 돌려주고 있었다.

## 변경

두 포매터가 **주어진 시각 그 자체**를 렌더링한다. 출력이 인자만의 함수가 된다.

- `format_timestamp_relative` → `format_timestamp_absolute` (ISO8601 UTC)
- `format_ttl_remaining` → `format_expiry`: 남은 기간이 아니라 만료 *시점*을 보고. `"permanent"`는 저장된 `0.0` sentinel에서 파생되므로 시계 비교가 없다.
- `format_post` 템플릿 라벨 `TTL:` → `expires:` — 절대 시각을 duration으로 오독하지 않게.

recency는 `session:wall_time`으로 해소된다. `Masc_context_injector`가 매 턴 갱신한다 (`masc_context_injector.ml:53`, `:122`). 정보 손실 없음.

**사람용 상대 시각 렌더링은 건드리지 않았다.** `Dashboard_labels`, `Tempo`는 사람이 읽고 캐시/dedup 계약이 없다. 청중이 다르므로 경계가 이미 모듈로 갈려 있었다.

## 검증

```
dune build @check                          -> exit 0
test_tool_board_coverage.exe test
  [OK] helpers 4  format_timestamp_absolute
  81 tests run, 5 failures
```

**양성 대조**: `origin/main`(`1c56b80f65`)에서 같은 exe를 재빌드해 실행 → **동일한 5건**(`post_crud 7-11`), **동일한 81 tests run**. 그 5건은 `make_keeper_meta` 픽스처가 `agent_name`을 손으로 써서 canonical keeper identity와 어긋나는 기존 실패이며 이 변경과 무관하다. #26066에서 `test_keeper_event_queue`에 대해 고친 것과 같은 계열의 픽스처 부패다 — 별건으로 기록한다.

## 테스트 강화

기존 테스트는 시계 의존성을 잡을 수 없었다 — 출력에 문자 `'d'` 또는 `'m'`이 포함되는지만 봤다:

```ocaml
Alcotest.(check bool) "1-day old has 'd'" true (String.contains s2 'd')
```

이제 입력→출력 매핑을 정확히 고정한다. 시계 읽기가 재도입되면 실패한다:

```ocaml
Alcotest.(check string) "fixed instant renders as ISO8601 UTC"
  "2023-11-14T22:13:20Z" (Board_tool.format_timestamp_absolute 1_700_000_000.0)
```

## 범위 밖 — #26088

이 PR은 중복 폭발의 **동력**을 제거하지만 **제동장치를 추가하지 않는다.**

#26088이 같은 폴링 루프를 `executor`에서 독립 실측했고(tool_use 1,030 중 폴링 888 = 86.2%, 최장 279회 연속), 그 이슈의 미해결 가설 "조회 결과가 매번 미세하게 달라 변화 있음으로 읽힌다"가 여기서 특정한 원인과 일치한다. 상세 대조는 그쪽 코멘트에 남겼다.

남은 층은 각각 별도 설계가 필요하다:

- 턴당 도구 호출 상한 부재 — masc의 `max_tool_calls`는 벤치마크 채점용이고 OAS 공개 인터페이스에는 `max_tokens`/`thinking_budget`만 있다
- 동일 payload dedup 부재 — `tool_result`가 원본 그대로 누적
- 예측형 컴팩션 부재 — `compaction_trigger.mli`의 5개 트리거가 전부 사후형이고 `keeper_post_turn.ml:453`이 `Not_requested`를 하드코딩

RFC-WAIVED: 변경 범위가 board 도구 응답 렌더링 2함수이며 credential / identity / operator control plane / keeper sandbox / hooks / workflow 문서를 건드리지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
