### PR TITLE
fix(keeper): cover Goal_reconciliation_ready in schedule settlement surfaces (main red)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -303,7 +303,8 @@ let persist_scheduled_work_terminal ~ctx ~keeper_name ~settlement stimuli =
          | Keeper_event_queue.Connector_attention _
          | Keeper_event_queue.Hitl_resolved _
          | Keeper_event_queue.Manual_compaction_requested
-         | Keeper_event_queue.Goal_assigned _ ->
+         | Keeper_event_queue.Goal_assigned _
+         | Keeper_event_queue.Goal_reconciliation_ready _ ->
            loop rest)
     in
     loop stimuli

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -470,7 +470,8 @@ let heartbeat_event_intake
             | Keeper_world_observation.Fusion_completed
             | Keeper_world_observation.Bg_completed
             | Keeper_world_observation.External_attention
-            | Keeper_world_observation.Goal_assigned ->
+            | Keeper_world_observation.Goal_assigned
+            | Keeper_world_observation.Goal_reconciliation_ready ->
               Log.Keeper.info
                 "turn entry: promoted queued observation post_id=%s keeper=%s"
                 event.Keeper_world_observation.post_id

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -55,7 +55,8 @@ let is_board_activity_event (event : pending_board_event) =
   | Fusion_completed
   | Bg_completed
   | External_attention
-  | Goal_assigned -> true
+  | Goal_assigned
+  | Goal_reconciliation_ready -> true
 ;;
 
 type scheduled_automation_item =


### PR DESCRIPTION
## 무엇이 깨졌나

main(`9fca7c5269`, #26046 squash)이 컴파일되지 않습니다. `dune build @check`가 warning 8(partial-match)로 3개 파일에서 실패합니다.

```
lib/keeper/keeper_world_observation.ml:50-58        — Goal_reconciliation_ready 미커버
lib/keeper/keeper_heartbeat_stimulus_intake.ml:461-477 — 동일
lib/keeper/keeper_heartbeat_loop.ml:254-307          — 동일
```

## 근본 원인

의미론적 머지 교차(semantic merge crossing):

- #26083이 `Keeper_event_queue`/`Keeper_world_observation`에 `Goal_reconciliation_ready` constructor를 추가 (02:5X 머지)
- #26046은 그 constructor가 없던 base(1c56b80f65)에서 같은 타입 위의 **새 match 3개**를 작성 (03:16 머지)
- 두 변경의 hunk가 텍스트로는 겹치지 않아 squash 머지는 충돌 없이 통과, 컴파일은 즉시 실패

PR 단위 CI는 각자 green이었습니다. 머지 결과 트리를 컴파일하는 gate가 머지 큐에 없는 한 이 계열(variant 추가 × 신규 match)은 재발합니다. 관련 선례: #25795 (핀 PR 소비자 컴파일 미강제).

## 수정

세 지점 모두 `Goal_assigned`를 미러링해 `Goal_reconciliation_ready` arm 추가. 근거: `keeper_reaction_ledger.ml:1010,1409`가 이미 `Goal_assigned | Goal_reconciliation_ready`를 동일 그룹으로 취급하며, reconciliation 이벤트는 `pending_board_event`로 구성되어(`keeper_world_observation.ml:610`) 프롬프트에 board 이벤트로 렌더링됩니다(`keeper_unified_prompt.ml:159`).

- `is_board_activity_event` → `true` (Goal_assigned와 동일; #26046의 제외 대상은 Schedule_due뿐)
- turn-entry intake promote 로그 → Goal_assigned 그룹에 합류
- scheduled-occurrence settlement walk → skip (`loop rest`)

와일드카드(`_`) 미사용 — 다음 variant 추가 시 컴파일러가 다시 강제하도록 유지.

## 검증

- `bash scripts/dune-local.sh build @check` — pass (수정 전: 3파일 실패 재현)
- `test_schedule_domain` / `test_schedule_runner` / `test_schedule_store` / `test_schedule_consumer_dispatch` / `test_keeper_turn_outcome` — 전부 PASS
- `bin/main_eio.exe` 빌드 성공

## 참고

- 스케줄 기능 전수 감사 중 발견 (관련: #26092)
- 후속 논의 거리: 머지 큐에서 머지-결과-트리 컴파일 강제 (이 PR 범위 밖)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
