### PR TITLE
test(keeper): goal reconciliation wake의 Board-activity 분할 측을 고정

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -56,6 +56,10 @@ let is_board_activity_event (event : pending_board_event) =
   | Bg_completed
   | External_attention
   | Goal_assigned
+  (* Goal-lifecycle signal, not a schedule dispatch, so it sits with
+     [Goal_assigned]. The [false] arm would also compile but would route the
+     event to the Scheduled Automation renderer and drop it from
+     [board_activity_count]. *)
   | Goal_reconciliation_ready -> true
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -54,23 +54,23 @@ type pending_board_event = {
 (** [false] only for a scheduled-work carrier that shares the historical
     observation container but must not be projected as Board activity.
 
-    This partition decides classification and prompt placement, not turn
-    admission. {!Keeper_unified_prompt} renders the [false] events under
-    Scheduled Automation and the [true] events under Board Activity, and
-    {!Keeper_contract_classifier} counts only the [true] ones into
-    [board_activity_count] — an observation classified [false] yields
-    [No_actionable_signal] there, which is captured as receipt metadata and
-    does not authorize or block the turn
-    (see [Keeper_execution_receipt_types.t.actionable_signal]).
-    Wake itself is unaffected: [actionable_signal_present] treats any pending
-    event as actionable, and a consumed [Schedule_due] stimulus carries its
-    own admission trigger —
+    This partition decides prompt placement, contributes to turn admission,
+    and feeds the classifier. {!Keeper_unified_prompt} renders the [false]
+    events under Scheduled Automation and the [true] events under Board
+    Activity. {!Keeper_contract_classifier} counts only the [true] ones into
+    [board_activity_count]; classifying one event [false] yields
+    [No_actionable_signal] only when there is no claimable task or other
+    [true] board event.
+
+    Admission depends on the event kind. A consumed [Schedule_due] stimulus
+    carries its own trigger:
     [Keeper_heartbeat_stimulus_intake.event_queue_trigger_of_stimulus] maps
-    it to [Scheduled_automation_stimulus] independently of this partition.
+    it to [Scheduled_automation_stimulus] independently of this partition
     ([scheduled_automation.due_ready_count] is a separate live-store
     observation, not the stimulus's trigger; it can already be zero once
-    dispatch begins.) A misplaced event kind therefore loses its Board
-    classification and prompt section, not its wake.
+    dispatch begins). [Goal_reconciliation_ready] has no dedicated event-queue
+    trigger, so classifying an isolated reconciliation event [false] also
+    removes [Board_event_pending] and suppresses its intended reactive turn.
 
     A new event kind placed on the wrong side compiles cleanly and fails
     silently. Classify by whether the event carries scheduled-work dispatch,

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -54,12 +54,18 @@ type pending_board_event = {
 (** [false] only for a scheduled-work carrier that shares the historical
     observation container but must not be projected as Board activity.
 
-    This is a partition, not an advisory flag. {!Keeper_unified_prompt} renders
-    the [false] events under Scheduled Automation and the [true] events under
-    Board Activity, and {!Keeper_contract_classifier} counts only the [true]
-    ones into [board_activity_count] — an observation classified [false]
-    contributes no actionable signal, so a keeper woken by that event alone
-    reaches [No_actionable_signal] and does not act.
+    This partition decides classification and prompt placement, not turn
+    admission. {!Keeper_unified_prompt} renders the [false] events under
+    Scheduled Automation and the [true] events under Board Activity, and
+    {!Keeper_contract_classifier} counts only the [true] ones into
+    [board_activity_count] — an observation classified [false] yields
+    [No_actionable_signal] there, which is captured as receipt metadata and
+    does not authorize or block the turn
+    (see [Keeper_execution_receipt_types.t.actionable_signal]).
+    Wake itself is unaffected: [actionable_signal_present] treats any pending
+    event as actionable, and scheduled stimuli carry their own trigger via
+    [scheduled_automation.due_ready_count]. A misplaced event kind therefore
+    loses its Board classification and prompt section, not its wake.
 
     A new event kind placed on the wrong side compiles cleanly and fails
     silently. Classify by whether the event carries scheduled-work dispatch,

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -63,9 +63,14 @@ type pending_board_event = {
     does not authorize or block the turn
     (see [Keeper_execution_receipt_types.t.actionable_signal]).
     Wake itself is unaffected: [actionable_signal_present] treats any pending
-    event as actionable, and scheduled stimuli carry their own trigger via
-    [scheduled_automation.due_ready_count]. A misplaced event kind therefore
-    loses its Board classification and prompt section, not its wake.
+    event as actionable, and a consumed [Schedule_due] stimulus carries its
+    own admission trigger —
+    [Keeper_heartbeat_stimulus_intake.event_queue_trigger_of_stimulus] maps
+    it to [Scheduled_automation_stimulus] independently of this partition.
+    ([scheduled_automation.due_ready_count] is a separate live-store
+    observation, not the stimulus's trigger; it can already be zero once
+    dispatch begins.) A misplaced event kind therefore loses its Board
+    classification and prompt section, not its wake.
 
     A new event kind placed on the wrong side compiles cleanly and fails
     silently. Classify by whether the event carries scheduled-work dispatch,

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -52,7 +52,18 @@ type pending_board_event = {
 }
 
 (** [false] only for a scheduled-work carrier that shares the historical
-    observation container but must not be projected as Board activity. *)
+    observation container but must not be projected as Board activity.
+
+    This is a partition, not an advisory flag. {!Keeper_unified_prompt} renders
+    the [false] events under Scheduled Automation and the [true] events under
+    Board Activity, and {!Keeper_contract_classifier} counts only the [true]
+    ones into [board_activity_count] — an observation classified [false]
+    contributes no actionable signal, so a keeper woken by that event alone
+    reaches [No_actionable_signal] and does not act.
+
+    A new event kind placed on the wrong side compiles cleanly and fails
+    silently. Classify by whether the event carries scheduled-work dispatch,
+    and pin the answer in a test. *)
 val is_board_activity_event : pending_board_event -> bool
 
 (** Read-only projection of one schedule row that needs keeper attention. *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -617,8 +617,9 @@ let () =
   (* The Board-activity partition decides which prompt section renders this
      event and whether it reaches [Keeper_contract_classifier]'s
      [board_activity_count]. Classifying a reconciliation wake as scheduled
-     work compiles cleanly but leaves a keeper woken by it alone at
-     [No_actionable_signal], so pin both sides here. *)
+     work compiles cleanly but drops it from the Board Activity prompt section
+     and from [board_activity_count] (receipt metadata only — the turn still
+     runs), so pin both sides here. *)
   assert (Masc.Keeper_world_observation.is_board_activity_event prompt_event);
   assert (
     not

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -614,6 +614,18 @@ let () =
     contains_substring
       ~needle:"Re-read Goal and Task SSOT"
       prompt_event.preview);
+  (* The Board-activity partition decides which prompt section renders this
+     event and whether it reaches [Keeper_contract_classifier]'s
+     [board_activity_count]. Classifying a reconciliation wake as scheduled
+     work compiles cleanly but leaves a keeper woken by it alone at
+     [No_actionable_signal], so pin both sides here. *)
+  assert (Masc.Keeper_world_observation.is_board_activity_event prompt_event);
+  assert (
+    not
+      (Masc.Keeper_world_observation.is_board_activity_event
+         { prompt_event with
+           event_kind = Masc.Keeper_world_observation.Schedule_due
+         }));
   (* Producer diff is edge-only: additions wake, removals and unchanged ids
      never do. *)
   assert (

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -618,8 +618,9 @@ let () =
      event and whether it reaches [Keeper_contract_classifier]'s
      [board_activity_count]. Classifying a reconciliation wake as scheduled
      work compiles cleanly but drops it from the Board Activity prompt section
-     and from [board_activity_count] (receipt metadata only — the turn still
-     runs), so pin both sides here. *)
+     and from [board_activity_count]; when the event is isolated, it also
+     removes [Board_event_pending] and suppresses the intended reactive turn,
+     so pin both sides here. *)
   assert (Masc.Keeper_world_observation.is_board_activity_event prompt_event);
   assert (
     not


### PR DESCRIPTION
## 배경

#26095가 main red를 복구했다. #26083이 `Goal_reconciliation_ready`를 추가(11:57)했고, 그와 무관한 base에서 갈라져 나온 #26046이 새 exhaustive match 3곳을 들고 들어와(12:16 머지) 텍스트 충돌 없이 합쳐지면서 `warning 8 [partial-match]`로 main이 깨졌다.

세 arm 중 둘은 기계적이다 — reconciliation wake는 schedule occurrence를 안 실으므로 `Schedule_store` 정산 대상이 아니고, 로그도 scheduled work가 아니다.

**세 번째는 다르다.** `is_board_activity_event`는 분할(partition)이고 **양쪽 다 컴파일된다.**

## 왜 위험한가

| 소비처 | `false` 쪽 | `true` 쪽 |
|---|---|---|
| `Keeper_unified_prompt` `:821` / `:856` | Scheduled Automation 섹션에 렌더 | Board Activity 섹션에 렌더 |
| `Keeper_contract_classifier` `:25` | `board_activity_count`에 미포함 | 포함 |

`board_activity_count`가 0이면 `classify_actionable_signal`이 `No_actionable_signal`을 낸다. 즉 reconciliation wake를 `false` 쪽에 놓으면 **엉뚱한 섹션에 렌더되고, 그 이벤트만으로 깨어난 keeper는 행동할 신호가 없다** — #26083이 추가하려던 wake가 정확히 무효화된다. 컴파일러는 이걸 못 본다.

## 변경

**동작 변경 없음.** arm은 #26095가 머지한 그대로다.

1. `test_keeper_event_queue.ml` — 기존 goal reconciliation 테스트에 분할 양쪽을 고정하는 assertion 2줄 추가 (positive + negative control)
2. `keeper_world_observation.mli` — 계약 명시. 기존 문서는 `"[false] only for a scheduled-work carrier"`까지만 말하고, 잘못 고르면 왜 조용히 실패하는지(두 소비처)를 말하지 않았다
3. `keeper_world_observation.ml` — 해당 arm에 판단 근거 주석

## 변이 검증

`Goal_reconciliation_ready`를 `false` arm으로 옮기고:

```
dune build test/test_keeper_event_queue.exe   -> Error 0건 (컴파일 통과)
./test_keeper_event_queue.exe                 -> exit 2
  Fatal error: exception File "test/test_keeper_event_queue.ml", line 622: Assertion failed
```

원복 후 `exit 0`. 타입 시스템이 못 잡는 실수를 테스트가 든다는 증명이다.

RFC-WAIVED: 테스트 + 문서화이며 동작 변경이 없다. credential / identity / operator control plane / keeper sandbox / hooks / workflow 문서를 건드리지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
