### PR TITLE
docs(keeper): correct the replayed-cwd contract and pin it with a test

### DIFF
--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -32,7 +32,9 @@ val write_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
 val execute_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
 (** Recover the execute tool arguments from the approved Gate input. Nothing is
     reconstructed: the Gate request wraps the arguments with execution context
-    rather than re-encoding them. *)
+    rather than re-encoding them, and the approved [cwd] the submitting handler
+    upserted into those arguments rides along. The envelope's own sandbox
+    fields stay behind for the handler to re-derive. *)
 
 type replayable =
   | Replay_write
@@ -42,9 +44,6 @@ val replayable_of_operation : string -> replayable option
 (** Which approved operations can be spent without the Keeper re-emitting the
     call. Exposed because a decode function that exists but is never dispatched
     to is indistinguishable from a working replay at the boundary. *)
-(** Recover the execute tool arguments from the approved Gate input. Nothing is
-    reconstructed: the Gate request wraps the arguments with execution context
-    rather than re-encoding them. *)
 
 (** Replay the approved effect behind [approval_id] exactly once.
 

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -22,10 +22,17 @@ val replay_args_of_gate_input : Yojson.Safe.t -> (Yojson.Safe.t, string) result
 (** Recover the approved tool arguments from the stored Gate input.
 
     The Gate request wraps the arguments with execution context rather than
-    re-encoding them, so the approved arguments are returned verbatim. The
-    stored [cwd]/[sandbox_*] fields are not replayed: the handler re-derives
-    them from the current turn, and a divergence fails the canonical-input
-    match instead of executing somewhere the approval did not describe. *)
+    re-encoding them, so the approved arguments are returned verbatim —
+    including the [cwd] the submitting turn resolved and upserted into them.
+    Replaying that [cwd] is the point: the approval describes one working
+    directory, and re-deriving the current turn's default would execute
+    somewhere the operator never saw.
+
+    The envelope's sibling [cwd]/[sandbox_profile]/[sandbox_target] fields
+    stay behind. The handler re-derives the sandbox from the current turn and
+    rebuilds the envelope, so a sandbox that moved between approval and replay
+    produces a different canonical input and fails the match rather than
+    executing under a profile the approval did not describe. *)
 
 val handle_tool_execute_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -139,10 +139,17 @@ let test_non_object_input_is_rejected () =
 ;;
 
 
-(* [tool_execute] is 66% of live approvals and was Not_applicable until now,
+(* [tool_execute] dominates live approvals and was Not_applicable until now,
    so a Keeper had to re-emit a byte-identical command to spend its own
    approval. Unlike the write path nothing is reconstructed: the Gate request
-   wraps the arguments with execution context instead of re-encoding them. *)
+   wraps the arguments with execution context instead of re-encoding them.
+
+   The submitting handler upserts the resolved [cwd] into the arguments before
+   wrapping them (keeper_tool_execute_runtime.ml), so every approved execute
+   carries it twice: once inside [input] and once in the envelope. This fixture
+   reproduces that shape — 130 of 130 pending [tool_execute] entries in the
+   2026-07-28 store had [input.cwd], with no exceptions. A fixture without it
+   passes assertions the producer can never satisfy. *)
 let approved_execute_input =
   `Assoc
     [ "schema", `String "masc.keeper_gate.request.v1"
@@ -150,6 +157,7 @@ let approved_execute_input =
       , `Assoc
           [ "argv", `List [ `String "git"; `String "status" ]
           ; "timeout_sec", `Int 30
+          ; "cwd", `String "/repo"
           ] )
     ; "cwd", `String "/repo"
     ; "sandbox_profile", `String "docker"
@@ -165,14 +173,33 @@ let test_execute_args_are_the_approved_arguments () =
        (`Assoc
           [ "argv", `List [ `String "git"; `String "status" ]
           ; "timeout_sec", `Int 30
+          ; "cwd", `String "/repo"
           ]))
     (Masc.Keeper_gate_replay.execute_args_of_gate_input approved_execute_input)
 ;;
 
-let test_execute_context_is_not_replayed () =
-  (* cwd and the sandbox fields describe where the approval was granted. The
-     handler re-derives them from the current turn; carrying the stored ones
-     would execute somewhere the approval never described. *)
+(* The approved [cwd] is part of the effect the operator authorized, so it
+   rides along inside the arguments. Dropping it would run the command in the
+   current turn's default directory — an effect nobody approved. *)
+let test_approved_cwd_is_replayed () =
+  match
+    Masc.Keeper_gate_replay.execute_args_of_gate_input approved_execute_input
+  with
+  | Error detail -> Alcotest.fail detail
+  | Ok (`Assoc fields) ->
+    Alcotest.check
+      (Alcotest.option json)
+      "the approved working directory reaches the replayed call"
+      (Some (`String "/repo"))
+      (List.assoc_opt "cwd" fields)
+  | Ok _ -> Alcotest.fail "replayed execute arguments are not an object"
+;;
+
+(* The envelope siblings describe the sandbox the approval was granted under.
+   The handler re-derives those and rebuilds the envelope, so a sandbox that
+   moved since approval fails the canonical-input match instead of executing
+   under a profile the approval never described. *)
+let test_execute_envelope_is_not_replayed () =
   match
     Masc.Keeper_gate_replay.execute_args_of_gate_input approved_execute_input
   with
@@ -185,7 +212,7 @@ let test_execute_context_is_not_replayed () =
            (key ^ " is not carried into the replayed arguments")
            false
            (List.mem_assoc key fields))
-      [ "cwd"; "sandbox_profile"; "sandbox_target"; "schema" ]
+      [ "sandbox_profile"; "sandbox_target"; "schema" ]
   | Ok _ -> Alcotest.fail "replayed execute arguments are not an object"
 ;;
 
@@ -259,9 +286,13 @@ let () =
             `Quick
             test_execute_args_are_the_approved_arguments
         ; Alcotest.test_case
-            "approval-time context is not replayed"
+            "approved cwd is replayed"
             `Quick
-            test_execute_context_is_not_replayed
+            test_approved_cwd_is_replayed
+        ; Alcotest.test_case
+            "approval-time envelope is not replayed"
+            `Quick
+            test_execute_envelope_is_not_replayed
         ; Alcotest.test_case
             "input without arguments rejected"
             `Quick


### PR DESCRIPTION
Follow-up to #26089.

## 문서가 코드와 반대로 적혀 있습니다

#26089 가 머지되면서 다음 문장이 main 에 들어갔습니다.

```
keeper_tool_execute_runtime.mli:26-28
  "The stored [cwd]/[sandbox_*] fields are not replayed: the handler
   re-derives them from the current turn"
```

실제로는 replay 됩니다. 제출 핸들러가 인자를 감싸기 **전에** 해결된 `cwd` 를 인자 객체 안에 넣기 때문입니다.

```ocaml
(* keeper_tool_execute_runtime.ml:167, :303 *)
let typed_args = assoc_upsert "cwd" (`String cwd) args in
...
execute_gate_input ~input:typed_args ~cwd ~sandbox_profile ~sandbox_target
```

`replay_args_of_gate_input` 은 `input` 을 그대로 돌려주므로 그 안의 `cwd` 가 같이 갑니다. `keeper_tool_execute_path.ml:29` 가 다시 읽습니다.

라이브 확인 (2026-07-28, 읽기 전용):

```
gate/pending.json                     tool_execute delivery 7/7 이 input.cwd 보유
gate-quarantine-20260728T1140/…       pending tool_execute 130/130 이 input.cwd 보유, 예외 0
```

**동작은 바꾸지 않습니다.** 승인된 `cwd` 를 replay 하는 것이 RFC-0356 이 요구하는 바입니다 — 승인은 하나의 작업 디렉터리를 서술하고, 현재 턴 기준으로 재도출하면 operator 가 본 적 없는 곳에서 실행됩니다. 머지된 write 경로가 `requested_target` → `path` 로 하는 것과 같습니다.

envelope 쪽 형제 필드(`cwd`/`sandbox_profile`/`sandbox_target`)는 그대로 남습니다. 핸들러가 현재 턴에서 sandbox 를 다시 도출해 envelope 을 재구성하므로, 승인과 replay 사이에 sandbox 가 바뀌었으면 canonical input 이 달라져 매칭에 실패합니다.

## 테스트가 producer 가 만들 수 없는 모양을 검증하고 있었습니다

```ocaml
(* 변경 전 fixture — input 에 cwd 없음 *)
"input", `Assoc [ "argv", …; "timeout_sec", `Int 30 ]

(* 그 위에 세운 단언 *)
List.mem_assoc key fields = false  for [ "cwd"; "sandbox_profile"; … ]
```

producer 는 `cwd` 를 항상 넣습니다(라이브 130/130). fixture 가 그 필드를 빼놓았기 때문에 단언이 통과했을 뿐입니다. fixture 를 실제 모양으로 바꾸면 그 단언은 성립하지 않습니다.

그래서 fixture 에 `cwd` 를 넣고 케이스를 둘로 나눴습니다.

- `approved cwd is replayed` — 승인된 작업 디렉터리가 replay 호출에 도달한다
- `approval-time envelope is not replayed` — `sandbox_profile`/`sandbox_target`/`schema` 는 도달하지 않는다

## 변이 검증 (양방향)

```
main 동작 그대로                                 13/13 통과
replay_args_of_gate_input 이 cwd 를 제거하도록 변이   2 failures
변이 되돌림                                       13/13 통과
```

이전 테스트는 같은 변이에 green 이었습니다. 이번에는 실패합니다.

부수로 `keeper_gate_replay.mli:45-47` 의 중복 docstring 을 제거했습니다. `replayable_of_operation` 뒤에 `execute_args_of_gate_input` 설명이 한 번 더 붙어 있었고, 컴파일러가 warning 50 으로 버리므로 odoc/merlin 에는 보이지 않습니다.

## 검증

```
scripts/dune-local.sh build test/test_keeper_gate_replay.exe    통과
test_keeper_gate_replay.exe                                     13/13 (origin/main 기준)
```

## 미검증

- 라이브에서 replay 된 execute 가 승인된 `cwd` 에서 실행되는 것까지는 확인하지 않았습니다. 이 PR 이후 `gate replay approval=… applied` 로그가 나오는 창에서만 확인 가능합니다.
- 코드는 건드리지 않았으므로 런타임 동작 변화는 없습니다.

RFC-WAIVED: 문서/테스트만 변경. 실행 경로·타입·상태 전이 무변경. 참조 RFC-0356 은 #26089 에서 인용됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
