### PR TITLE
fix(gate): bound resolved history by wall-clock window, not row count

### DIFF
--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -10,6 +10,7 @@ import type {
   DashboardGateResponse,
   KeeperApprovalQueueItem,
   KeeperResolvedApprovalItem,
+  KeeperResolvedApprovalPage,
   KeeperApprovalQueueState,
   KeeperAutoJudgeRearmExpectation,
   GateDecisionSource,
@@ -152,6 +153,45 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
   }
 }
 
+/**
+ * Page bounds for the resolved history. Returns null when the server did not
+ * send them or sent them incompletely — an older server during a rolling
+ * deploy, for instance. Null must render as "completeness unknown", never as
+ * "this is everything": presenting a slice as the whole history is the defect
+ * this field exists to remove, so a partial page is rejected outright rather
+ * than filled in with defaults.
+ */
+function normalizeKeeperResolvedApprovalPage(
+  raw: unknown,
+): KeeperResolvedApprovalPage | null {
+  if (!isRecord(raw)) return null
+  const returned = asInt(raw.returned)
+  const matched = asInt(raw.matched)
+  const limit = asInt(raw.limit)
+  const windowMinutes = asInt(raw.window_minutes)
+  const truncated = asBoolean(raw.truncated)
+  const scanExhausted = asBoolean(raw.scan_exhausted)
+  if (
+    returned === undefined
+    || matched === undefined
+    || limit === undefined
+    || windowMinutes === undefined
+    || truncated === undefined
+    || scanExhausted === undefined
+  ) {
+    return null
+  }
+  if (returned < 0 || matched < 0 || limit < 0 || windowMinutes <= 0) return null
+  return {
+    returned,
+    matched,
+    limit,
+    window_minutes: windowMinutes,
+    truncated,
+    scan_exhausted: scanExhausted,
+  }
+}
+
 export function fetchDashboardGate(
   opts?: FetchDashboardGateOptions,
 ): Promise<DashboardGateResponse> {
@@ -182,6 +222,7 @@ export function fetchDashboardGate(
           .map(item => normalizeKeeperResolvedApprovalItem(item))
           .filter((item): item is KeeperResolvedApprovalItem => item !== null)
       : []
+    const recentResolvedPage = normalizeKeeperResolvedApprovalPage(raw.recent_resolved_page)
     const approvalRules = Array.isArray(raw.approval_rules)
       ? raw.approval_rules
           .map(item => normalizeKeeperApprovalRule(item))
@@ -193,6 +234,7 @@ export function fetchDashboardGate(
       approval_queue: approvalQueue,
       approval_queue_state: approvalQueueState,
       recent_resolved: recentResolved,
+      recent_resolved_page: recentResolvedPage,
       approval_rules: approvalRules,
       hitl: normalizeHitlStatus(raw.hitl),
     }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1620,6 +1620,82 @@ describe('fetchDashboardGate', () => {
     ])
   })
 
+  // The resolved history is capped by the server. Without the page bounds a
+  // client renders a slice as the whole history, so a page that is absent or
+  // incomplete must normalize to null ("completeness unknown") rather than to
+  // a zeroed record that reads as "this is everything".
+  function gateResponseWithPage(page: unknown) {
+    return vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        recent_resolved: [],
+        recent_resolved_page: page,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  }
+
+  it('normalizes a complete resolved-history page', async () => {
+    vi.stubGlobal('fetch', gateResponseWithPage({
+      returned: 20,
+      matched: 149,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: true,
+      scan_exhausted: false,
+    }))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.recent_resolved_page).toEqual({
+      returned: 20,
+      matched: 149,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: true,
+      scan_exhausted: false,
+    })
+  })
+
+  it('rejects a partial resolved-history page instead of defaulting it', async () => {
+    vi.stubGlobal('fetch', gateResponseWithPage({
+      returned: 20,
+      matched: 149,
+      limit: 20,
+      // window_minutes and the two flags are missing: an older server, or drift.
+    }))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.recent_resolved_page).toBeNull()
+  })
+
+  it('reports an absent resolved-history page as unknown, not as a full history', async () => {
+    vi.stubGlobal('fetch', gateResponseWithPage(undefined))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.recent_resolved_page).toBeNull()
+  })
+
+  it('rejects a resolved-history page with a nonsensical window', async () => {
+    vi.stubGlobal('fetch', gateResponseWithPage({
+      returned: 1,
+      matched: 1,
+      limit: 20,
+      window_minutes: 0,
+      truncated: false,
+      scan_exhausted: false,
+    }))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.recent_resolved_page).toBeNull()
+  })
+
   it('preserves typed unavailable queue state without fabricating an empty ready queue', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -62,12 +62,14 @@ function responseWithQueue(
   approval_queue_state: DashboardGateResponse['approval_queue_state'] = {
     state: 'ready',
   },
+  recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
 ): DashboardGateResponse {
   return {
     generated_at: '2026-06-19T00:00:00Z',
     approval_queue,
     approval_queue_state,
     recent_resolved,
+    recent_resolved_page,
     approval_rules,
     hitl,
   } as DashboardGateResponse
@@ -83,6 +85,7 @@ async function loadSurface(
   approval_queue_state: DashboardGateResponse['approval_queue_state'] = {
     state: 'ready',
   },
+  recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
 ) {
   vi.resetModules()
   const resolveGateApproval = vi
@@ -111,6 +114,7 @@ async function loadSurface(
         approval_rules,
         hitl,
         approval_queue_state,
+        recent_resolved_page,
       )
     : responseWithQueue(
         approval_queue,
@@ -118,6 +122,7 @@ async function loadSurface(
         approval_rules,
         undefined,
         approval_queue_state,
+        recent_resolved_page,
       )
   const apiMock = () => ({
     fetchDashboardGate: vi.fn().mockResolvedValue(response),
@@ -556,6 +561,98 @@ describe('ApprovalsSurface', () => {
     expect(container.textContent).not.toContain('보류')
     expect(container.textContent).not.toContain('되돌리기')
     expect(container.textContent).not.toContain('처리이력')
+  }, 20000)
+
+  // The history list is a server-capped page. These four cases pin that the
+  // screen states its scope: a slice must never read as the whole history, and
+  // an unreported page must read as unknown rather than complete.
+  const resolvedRow: KeeperResolvedApprovalItem = {
+    id: 'appr-1',
+    keeper_name: 'rondo',
+    tool_name: 'tool_execute',
+    decision: 'approve',
+    decision_source: 'auto_judge',
+    resolved_at: '2026-07-28T02:53:47Z',
+  }
+
+  async function openHistory(page: DashboardGateResponse['recent_resolved_page']) {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [resolvedRow],
+      [],
+      undefined,
+      { state: 'ready' },
+      page,
+    )
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+    container.querySelector<HTMLButtonElement>('.ap-viewbtn:not(.on)')?.click()
+    await flushUi()
+    return container.querySelector('[data-testid="approvals-history-scope"]')
+  }
+
+  it('states the window and the total when the history is complete', async () => {
+    const scope = await openHistory({
+      returned: 1,
+      matched: 1,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: false,
+      scan_exhausted: false,
+    })
+
+    expect(scope?.textContent).toContain('최근 1일')
+    expect(scope?.textContent).toContain('건 전체')
+    expect(scope?.className).not.toContain('warn')
+  }, 20000)
+
+  it('says how much of the window is missing when the page is a slice', async () => {
+    const scope = await openHistory({
+      returned: 20,
+      matched: 149,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: true,
+      scan_exhausted: false,
+    })
+
+    expect(scope?.textContent).toContain('149')
+    expect(scope?.textContent).toContain('20')
+    expect(scope?.className).toContain('warn')
+  }, 20000)
+
+  it('says the window was not fully read when the server hit its row cap', async () => {
+    const scope = await openHistory({
+      returned: 20,
+      matched: 20,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: false,
+      scan_exhausted: true,
+    })
+
+    expect(scope?.textContent).toContain('읽지 못했습니다')
+    expect(scope?.className).toContain('warn')
+  }, 20000)
+
+  it('reports unknown scope rather than completeness when the server sent no page', async () => {
+    const scope = await openHistory(null)
+
+    expect(scope?.textContent).toContain('확인할 수 없습니다')
+    // Must not make the completeness claim the complete branch makes.
+    expect(scope?.textContent).not.toContain('건 전체')
+  }, 20000)
+
+  it('counts resolved decisions on the history tab so the default screen shows they exist', async () => {
+    const { ApprovalsSurface } = await loadSurface([], [resolvedRow])
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    // Still on the queue tab: the badge is the only cue that history exists.
+    expect(container.querySelector('[data-testid="approvals-history-view"]')).toBeNull()
+    expect(
+      container.querySelector('[data-testid="approvals-history-count"]')?.textContent,
+    ).toBe('1')
   }, 20000)
 
   it('renders resolved approval history with resolved timestamp and closed decision class', async () => {

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -16,6 +16,7 @@ import type {
   KeeperApprovalQueueItem,
   KeeperApprovalRule,
   KeeperResolvedApprovalItem,
+  KeeperResolvedApprovalPage,
   GateDecisionSource,
   GateMode,
   HitlContextSummary,
@@ -143,7 +144,57 @@ function resolvedAtMs(item: KeeperResolvedApprovalItem): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
-function ApHistory({ items }: { items: KeeperResolvedApprovalItem[] }) {
+function historyWindowLabel(minutes: number): string {
+  if (minutes % 1440 === 0) return `최근 ${minutes / 1440}일`
+  if (minutes % 60 === 0) return `최근 ${minutes / 60}시간`
+  return `최근 ${minutes}분`
+}
+
+/**
+ * States the scope of what is on screen. Without it the list reads as the
+ * complete history, which it is not when the server capped it — the defect
+ * this line exists to remove. A null page means the server did not report its
+ * bounds, so the scope is stated as unknown rather than assumed complete.
+ */
+function ApHistoryScope({ page }: { page: KeeperResolvedApprovalPage | null | undefined }) {
+  if (page == null) {
+    return html`
+      <p class="ap-hist-scope" data-testid="approvals-history-scope">
+        조회 범위를 확인할 수 없습니다 — 표시된 항목이 전체가 아닐 수 있습니다.
+      </p>
+    `
+  }
+  const scope = historyWindowLabel(page.window_minutes)
+  if (page.scan_exhausted) {
+    return html`
+      <p class="ap-hist-scope warn" data-testid="approvals-history-scope">
+        ${scope} · <b class="mono">${page.returned}</b>건 표시 ·
+        조회 상한에 걸려 ${scope} 전체를 읽지 못했습니다
+      </p>
+    `
+  }
+  if (page.truncated) {
+    return html`
+      <p class="ap-hist-scope warn" data-testid="approvals-history-scope">
+        ${scope} <b class="mono">${page.matched}</b>건 중
+        <b class="mono">${page.returned}</b>건 표시
+      </p>
+    `
+  }
+  return html`
+    <p class="ap-hist-scope" data-testid="approvals-history-scope">
+      ${scope} <b class="mono">${page.matched}</b>건 전체
+    </p>
+  `
+}
+
+function ApHistory({
+  items,
+  page,
+}: {
+  items: KeeperResolvedApprovalItem[]
+  page: KeeperResolvedApprovalPage | null | undefined
+}) {
   const [filter, setFilter] = useState<ApprovalHistoryFilter>('all')
   const sorted = useMemo(
     () => [...items].sort((a, b) => resolvedAtMs(b) - resolvedAtMs(a)),
@@ -161,6 +212,7 @@ function ApHistory({ items }: { items: KeeperResolvedApprovalItem[] }) {
 
   return html`
     <section class="ap-hist" data-testid="approvals-history-view">
+      <${ApHistoryScope} page=${page} />
       <div class="ap-hist-summary" aria-label="승인 이력 요약">
         <div class="ap-hist-stat"><b class="mono ok">${counts.approve}</b> 승인</div>
         <div class="ap-hist-stat"><b class="mono bad">${counts.reject}</b> 거부</div>
@@ -641,6 +693,7 @@ export function ApprovalsSurface() {
       ? approvalQueueState
       : null
   const resolvedItems = gateData.value?.recent_resolved ?? []
+  const resolvedPage = gateData.value?.recent_resolved_page ?? null
   const rules = gateData.value?.approval_rules ?? []
   const error = gateError.value
   // First load only: gateResource is stale-while-revalidate, so a refetch
@@ -686,7 +739,11 @@ export function ApprovalsSurface() {
                 class=${`ap-viewbtn ${view === 'history' ? 'on' : ''}`}
                 aria-selected=${view === 'history'}
                 onClick=${() => setView('history')}
-              >이력</button>
+              >
+                이력${resolvedItems.length > 0
+                  ? html`<span class="ap-viewbtn-n neutral mono" data-testid="approvals-history-count">${resolvedItems.length}</span>`
+                  : null}
+              </button>
             </div>
             ${view === 'queue' && items && items.length > 0 && stats
               ? html`<span class="ap-sla mono" title="가장 오래 대기 중인 건">최장 대기 ${apAge(stats.longest)}</span>`
@@ -712,7 +769,7 @@ export function ApprovalsSurface() {
         ${firstLoad
           ? html`<${LoadingState}>Gate 큐 불러오는 중...<//>`
           : view === 'history'
-            ? html`<${ApHistory} items=${resolvedItems} />`
+            ? html`<${ApHistory} items=${resolvedItems} page=${resolvedPage} />`
           : queueUnavailable || items === null
             ? null
           : html`

--- a/dashboard/src/components/gate-resource-swr.test.ts
+++ b/dashboard/src/components/gate-resource-swr.test.ts
@@ -116,6 +116,9 @@ describe('Gate resource (stale-while-revalidate)', () => {
         icon: '!',
       },
       recent_resolved: [],
+      // Null, not a zeroed page: an observation error leaves the history bounds
+      // unknown, and a zeroed page would render as "nothing was decided".
+      recent_resolved_page: null,
       approval_rules: [],
     })
     expect(signals.gateError.value).toContain('Gate 새로고침 실패')

--- a/dashboard/src/components/gate-signals.ts
+++ b/dashboard/src/components/gate-signals.ts
@@ -16,6 +16,9 @@ export function gateObservationErrorSnapshot(operatorDetail: string): DashboardG
     approval_queue: null,
     approval_queue_state: gateObservationErrorState(operatorDetail),
     recent_resolved: [],
+    // Null, not a zeroed page: an observation error means the history bounds
+    // are unknown, and a zeroed page would read as "nothing was decided".
+    recent_resolved_page: null,
     approval_rules: [],
   }
 }

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -38,6 +38,9 @@
 .ap-viewbtn:hover { color: var(--text-primary); background: var(--bg-panel); }
 .ap-viewbtn.on { color: var(--text-bright); background: var(--volt-wash); box-shadow: inset 0 0 0 1px var(--volt-dim); }
 .ap-viewbtn-n { min-width: 16px; padding: 1px 5px; border-radius: var(--radius-pill); color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+/* The queue badge is red because a waiting queue is a problem. The history
+   badge counts decisions already made, so it stays neutral. */
+.ap-viewbtn-n.neutral { color: var(--text-dim); background: color-mix(in oklab, var(--text-dim) 12%, transparent); }
 
 /* Queue ↔ detail-rail two-column workspace (live surface; not in the prototype,
    which uses a right operations aside instead). */
@@ -148,6 +151,12 @@
 .ap-hist-stat b { display: block; margin-bottom: 2px; color: var(--text-bright); font-size: var(--fs-18); }
 .ap-hist-stat b.ok { color: var(--status-ok); }
 .ap-hist-stat b.bad { color: var(--status-bad); }
+/* Scope line above the history list: what window the rows cover and whether
+   they are all of it. Warn tint only when the list is a slice. */
+.ap-hist-scope { margin: 0; color: var(--text-dim); font-size: var(--fs-12); }
+.ap-hist-scope b { color: var(--text-bright); }
+.ap-hist-scope.warn { color: var(--status-warn); }
+.ap-hist-scope.warn b { color: var(--status-warn); }
 .ap-hist-filters { display: flex; flex-wrap: wrap; gap: 6px; }
 .ap-hist-f { border: 1px solid var(--border-soft); border-radius: var(--radius-xs); background: var(--bg-sunken); color: var(--text-dim); padding: 6px 9px; font-size: var(--fs-11); cursor: pointer; }
 .ap-hist-f:hover { color: var(--text-primary); border-color: var(--border-main); }

--- a/dashboard/src/types/gate.ts
+++ b/dashboard/src/types/gate.ts
@@ -190,12 +190,29 @@ export interface GateModeStatus {
   read_error?: string
 }
 
+/**
+ * Bounds that produced `recent_resolved`. Read them with the rows: `returned`
+ * alone cannot distinguish a complete history from the newest slice of one.
+ * `truncated` means more decisions exist inside the window; `scan_exhausted`
+ * means the server's row cap stopped before it reached the window start, so
+ * even `matched` is a floor.
+ */
+export interface KeeperResolvedApprovalPage {
+  returned: number
+  matched: number
+  limit: number
+  window_minutes: number
+  truncated: boolean
+  scan_exhausted: boolean
+}
+
 export interface DashboardGateResponse {
   generated_at?: string
   note?: string
   approval_queue: KeeperApprovalQueueItem[] | null
   approval_queue_state: KeeperApprovalQueueState
   recent_resolved?: KeeperResolvedApprovalItem[]
+  recent_resolved_page?: KeeperResolvedApprovalPage | null
   approval_rules?: KeeperApprovalRule[]
   hitl?: {
     gate_mode?: GateModeStatus

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -33,8 +33,16 @@ let dashboard_json ~base_path ~limit ~window_minutes =
     | Error error ->
       `Null, Keeper_approval_queue.approval_queue_unavailable_state_json error
   in
+  (* NDT-OK: HTTP observation boundary; captured once for the pure projection,
+     matching [Dashboard_gate_metrics.gate_tool_events_json]. *)
+  let now_ts = Unix.gettimeofday () in
   let resolved_history =
-    Keeper_approval_queue.list_recent_resolved ~base_path ~limit ~window_minutes ()
+    Keeper_approval_queue.list_recent_resolved
+      ~base_path
+      ~now_ts
+      ~limit
+      ~window_minutes
+      ()
   in
   let approval_rules, approval_rules_state =
     match Keeper_approval_queue.list_rules_dashboard_json ~base_path () with

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -8,7 +8,21 @@ let hitl_status_json ~base_path =
   `Assoc [ "gate_mode", Keeper_gate_mode.status_json ~base_path ]
 ;;
 
-let dashboard_json ~base_path ~limit:_ ~offset:_ ~status_filter:_ =
+(* The page bounds travel with the rows. Without them a client cannot tell an
+   empty window from a store it never reached, or a complete history from the
+   newest slice of one. *)
+let recent_resolved_page_json (history : Keeper_approval_queue.resolved_history) =
+  `Assoc
+    [ "returned", `Int (List.length history.resolved_rows)
+    ; "matched", `Int history.resolved_matched
+    ; "limit", `Int history.resolved_limit
+    ; "window_minutes", `Int history.resolved_window_minutes
+    ; "truncated", `Bool (history.resolved_matched > history.resolved_limit)
+    ; "scan_exhausted", `Bool history.resolved_scan_exhausted
+    ]
+;;
+
+let dashboard_json ~base_path ~limit ~window_minutes =
   let approval_queue, approval_queue_state =
     match
       Keeper_approval_queue.list_pending_dashboard_json_for_workspace
@@ -19,11 +33,8 @@ let dashboard_json ~base_path ~limit:_ ~offset:_ ~status_filter:_ =
     | Error error ->
       `Null, Keeper_approval_queue.approval_queue_unavailable_state_json error
   in
-  let recent_resolved =
-    Keeper_approval_queue.list_recent_resolved_json
-      ~base_path
-      ~n:Keeper_approval_queue.recent_resolved_history_limit
-      ()
+  let resolved_history =
+    Keeper_approval_queue.list_recent_resolved ~base_path ~limit ~window_minutes ()
   in
   let approval_rules, approval_rules_state =
     match Keeper_approval_queue.list_rules_dashboard_json ~base_path () with
@@ -42,7 +53,8 @@ let dashboard_json ~base_path ~limit:_ ~offset:_ ~status_filter:_ =
           "External effects use exact Always Allowed, Auto Judge, or nonblocking human HITL." )
     ; "approval_queue", approval_queue
     ; "approval_queue_state", approval_queue_state
-    ; "recent_resolved", `List recent_resolved
+    ; "recent_resolved", `List resolved_history.resolved_rows
+    ; "recent_resolved_page", recent_resolved_page_json resolved_history
     ; "approval_rules", approval_rules
     ; "approval_rules_state", approval_rules_state
     ; "hitl", hitl_status_json ~base_path

--- a/lib/dashboard/dashboard_gate.mli
+++ b/lib/dashboard/dashboard_gate.mli
@@ -3,6 +3,16 @@
 val dashboard_json :
   base_path:string ->
   limit:int ->
-  offset:int ->
-  status_filter:'a ->
+  window_minutes:int ->
   Yojson.Safe.t
+(** [dashboard_json ~base_path ~limit ~window_minutes] projects the Gate mode,
+    the pending HITL queue, the exact Always Allowed rules, and the resolved
+    decisions of the last [window_minutes] capped at [limit] rows.
+
+    The resolved page is emitted as two fields that must be read together:
+    ["recent_resolved"] holds the rows and ["recent_resolved_page"] holds the
+    bounds that produced them ([returned], [matched], [limit],
+    [window_minutes], [truncated], [scan_exhausted]). A client that renders the
+    rows alone cannot distinguish a complete history from the newest slice of a
+    larger one. Both bounds are enforced by
+    {!Keeper_approval_queue.list_recent_resolved}. *)

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1251,6 +1251,40 @@ let wide_audit_scan_window n =
   max audit_wide_scan_min_rows (max n 1 * audit_wide_scan_multiplier)
 ;;
 
+(* Resolved-history bounds. The wall-clock window is what an operator reasons
+   about ("the last day"); the row cap is what keeps one dashboard poll from
+   parsing the whole audit store. The two are independent because the store
+   interleaves [resolved] rows with far more numerous [summary_updated] and
+   [pending] rows, so a row cap alone silently returns fewer decisions as
+   non-resolved traffic grows. Both bounds are reported to the caller. *)
+let recent_resolved_max_limit = 200
+let recent_resolved_default_window_minutes = 1440
+let recent_resolved_min_window_minutes = 5
+let recent_resolved_max_window_minutes = 10_080
+let resolved_history_scan_min_rows = 2_000
+let resolved_history_scan_max_rows = 20_000
+
+let resolved_history_scan_rows limit =
+  max
+    resolved_history_scan_min_rows
+    (min
+       resolved_history_scan_max_rows
+       (max limit 1 * audit_wide_scan_multiplier))
+;;
+
+(* A page of resolved decisions plus the evidence needed to tell "this is
+   everything in the window" from "this is the newest slice of more". Callers
+   that render only [resolved_rows] would repeat the silent truncation this
+   record exists to remove. *)
+type resolved_history =
+  { resolved_rows : Yojson.Safe.t list (* newest first, at most [resolved_limit] *)
+  ; resolved_matched : int (* resolved decisions inside the window that were scanned *)
+  ; resolved_limit : int
+  ; resolved_window_minutes : int
+  ; resolved_scan_exhausted : bool
+      (* the row cap stopped the scan before it reached the window start *)
+  }
+
 let recent_audit_cache_key store limit =
   Printf.sprintf "%s:%d" (Dated_jsonl.base_dir store) limit
 ;;
@@ -1446,7 +1480,6 @@ let audit_scan_window ?keeper_name n =
     wide_audit_scan_window n
 ;;
 
-let resolved_audit_scan_window = wide_audit_scan_window
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
@@ -1533,29 +1566,121 @@ let resolved_approval_json_of_audit_event json =
     ]
 ;;
 
-let list_recent_resolved_json ~base_path ?(n = recent_resolved_history_limit) ()
-  : Yojson.Safe.t list
+(* Day key for the [YYYY-MM/DD.jsonl] layout. Must stay UTC: the write path
+   ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
+   local-time key here would look in the wrong file for the hours where the
+   two calendars disagree. Pinned by
+   [test_keeper_approval_resolved_history.ml]. *)
+let audit_day_string_of_ts ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf
+    "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+;;
+
+let clamp_int value ~low ~high = max low (min high value)
+
+let resolved_history_empty ~limit ~window_minutes =
+  { resolved_rows = []
+  ; resolved_matched = 0
+  ; resolved_limit = limit
+  ; resolved_window_minutes = window_minutes
+  ; resolved_scan_exhausted = false
+  }
+;;
+
+let list_recent_resolved
+      ~base_path
+      ?(limit = recent_resolved_history_limit)
+      ?(window_minutes = recent_resolved_default_window_minutes)
+      ()
+  : resolved_history
   =
-  if n <= 0
-  then []
+  let limit = clamp_int limit ~low:0 ~high:recent_resolved_max_limit in
+  let window_minutes =
+    clamp_int
+      window_minutes
+      ~low:recent_resolved_min_window_minutes
+      ~high:recent_resolved_max_window_minutes
+  in
+  let empty = resolved_history_empty ~limit ~window_minutes in
+  if limit <= 0
+  then empty
   else (
     match get_audit_store ~base_path () with
-    | None -> []
+    | None -> empty
     | Some store ->
-      try
-        read_recent_audit_raw store (resolved_audit_scan_window n)
-        |> List.filter resolved_history_event
-        |> List.rev
-        |> List.filteri (fun idx _ -> idx < n)
-        |> List.map resolved_approval_json_of_audit_event
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        record_audit_read_failure
-          ~metric_site:Keeper_approval_queue_failure_site.Audit_list_recent_resolved
-          ~site:"approval_audit.list_recent_resolved"
-          exn;
-        [])
+      (try
+         let now = Unix.gettimeofday () in
+         let window_start =
+           now -. (float_of_int window_minutes *. Masc_time_constants.minute)
+         in
+         let scan_rows = resolved_history_scan_rows limit in
+         (* Chronological, oldest first, tail-bounded to [scan_rows]. *)
+         let scanned =
+           Dated_jsonl.read_range_recent
+             store
+             ~since:(audit_day_string_of_ts window_start)
+             ~until:(audit_day_string_of_ts now)
+             scan_rows
+         in
+         let scanned_count = List.length scanned in
+         (* The row cap only hides decisions when it stopped us before we
+            reached back to the window start. If the oldest row we read is
+            already older than the window, the window is fully covered and the
+            cap is irrelevant. *)
+         let scan_exhausted =
+           scanned_count >= scan_rows
+           &&
+           match scanned with
+           | [] -> true
+           | oldest :: _ ->
+             (match Safe_ops.json_float_opt "ts" oldest with
+              | None -> true
+              | Some ts -> ts > window_start)
+         in
+         (* An undated row cannot be placed in a wall-clock window, so it is
+            excluded rather than dated by guesswork. The audit writer always
+            stamps [ts]; this is the boundary that keeps a future regression
+            from silently mis-dating history. *)
+         let matched_rows =
+           scanned
+           |> List.filter_map (fun json ->
+             if resolved_history_event json
+             then (
+               match Safe_ops.json_float_opt "ts" json with
+               | Some ts when ts >= window_start -> Some (ts, json)
+               | Some _ | None -> None)
+             else None)
+           (* Newest first by timestamp, not by file position. The audit writer
+              stamps [ts] before it takes the append lock, so two concurrent
+              resolutions can land in the file in the opposite order from the
+              one they were decided in. [stable_sort] keeps file order as the
+              tie-break for identical stamps. *)
+           |> List.stable_sort (fun (left, _) (right, _) -> Float.compare right left)
+           |> List.map snd
+         in
+         let rows =
+           matched_rows
+           |> List.filteri (fun idx _ -> idx < limit)
+           |> List.map resolved_approval_json_of_audit_event
+         in
+         { resolved_rows = rows
+         ; resolved_matched = List.length matched_rows
+         ; resolved_limit = limit
+         ; resolved_window_minutes = window_minutes
+         ; resolved_scan_exhausted = scan_exhausted
+         }
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         record_audit_read_failure
+           ~metric_site:Keeper_approval_queue_failure_site.Audit_list_recent_resolved
+           ~site:"approval_audit.list_recent_resolved"
+           exn;
+         empty))
 ;;
 
 let generate_id () = make_generated_id "appr"

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1593,6 +1593,7 @@ let resolved_history_empty ~limit ~window_minutes =
 
 let list_recent_resolved
       ~base_path
+      ~now_ts
       ?(limit = recent_resolved_history_limit)
       ?(window_minutes = recent_resolved_default_window_minutes)
       ()
@@ -1613,9 +1614,8 @@ let list_recent_resolved
     | None -> empty
     | Some store ->
       (try
-         let now = Unix.gettimeofday () in
          let window_start =
-           now -. (float_of_int window_minutes *. Masc_time_constants.minute)
+           now_ts -. (float_of_int window_minutes *. Masc_time_constants.minute)
          in
          let scan_rows = resolved_history_scan_rows limit in
          (* Chronological, oldest first, tail-bounded to [scan_rows]. *)
@@ -1623,7 +1623,7 @@ let list_recent_resolved
            Dated_jsonl.read_range_recent
              store
              ~since:(audit_day_string_of_ts window_start)
-             ~until:(audit_day_string_of_ts now)
+             ~until:(audit_day_string_of_ts now_ts)
              scan_rows
          in
          let scanned_count = List.length scanned in

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -252,17 +252,23 @@ type resolved_history =
 
 val list_recent_resolved :
   base_path:string ->
+  now_ts:float ->
   ?limit:int ->
   ?window_minutes:int ->
   unit ->
   resolved_history
-(** [list_recent_resolved ~base_path ()] returns resolved Gate decisions from
-    the last [window_minutes] (default
+(** [list_recent_resolved ~base_path ~now_ts ()] returns resolved Gate decisions
+    from the last [window_minutes] (default
     {!recent_resolved_default_window_minutes}, clamped to
     [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
     newest first, capped at [limit] (default
     {!recent_resolved_history_limit}, clamped to
     [[0, recent_resolved_max_limit]]).
+
+    [now_ts] is supplied by the caller rather than read here, matching
+    {!Dashboard_gate_metrics.tool_rejection_counts}: the observation boundary
+    captures the clock once for the whole projection, and this function stays
+    deterministic so a test can pin an exact window.
 
     Rows without a [ts] are excluded: a wall-clock window cannot place an
     undated decision, and dating it by guesswork would misreport history.

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -219,12 +219,56 @@ val audit_rule_event :
 
 val generate_id : unit -> string
 val recent_resolved_history_limit : int
+val recent_resolved_max_limit : int
+val recent_resolved_default_window_minutes : int
+val recent_resolved_min_window_minutes : int
+val recent_resolved_max_window_minutes : int
 
 val read_recent_audit :
   base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
 
-val list_recent_resolved_json :
-  base_path:string -> ?n:int -> unit -> Yojson.Safe.t list
+val audit_day_string_of_ts : float -> string
+(** Day key ["YYYY-MM-DD"] for the [YYYY-MM/DD.jsonl] audit layout. Exposed as
+    a pure function so the UTC invariant is testable: the write path
+    ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
+    local-time key would read the wrong file for the hours where the two
+    calendars disagree. *)
+
+type resolved_history =
+  { resolved_rows : Yojson.Safe.t list
+  ; resolved_matched : int
+  ; resolved_limit : int
+  ; resolved_window_minutes : int
+  ; resolved_scan_exhausted : bool
+  }
+(** A page of resolved Gate decisions together with the bounds that produced
+    it. [resolved_rows] is newest first and holds at most [resolved_limit]
+    entries; [resolved_matched] counts every resolved decision the scan saw
+    inside the window, so [resolved_matched > resolved_limit] means the page is
+    a slice rather than the whole window. [resolved_scan_exhausted] reports the
+    second bound: the physical row cap stopped the scan before it reached the
+    window start, so even [resolved_matched] undercounts. Rendering only
+    [resolved_rows] reintroduces the silent truncation this type removes. *)
+
+val list_recent_resolved :
+  base_path:string ->
+  ?limit:int ->
+  ?window_minutes:int ->
+  unit ->
+  resolved_history
+(** [list_recent_resolved ~base_path ()] returns resolved Gate decisions from
+    the last [window_minutes] (default
+    {!recent_resolved_default_window_minutes}, clamped to
+    [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
+    newest first, capped at [limit] (default
+    {!recent_resolved_history_limit}, clamped to
+    [[0, recent_resolved_max_limit]]).
+
+    Rows without a [ts] are excluded: a wall-clock window cannot place an
+    undated decision, and dating it by guesswork would misreport history.
+
+    Storage failures are reported through the approval-queue failure metric and
+    yield an empty page rather than raising. *)
 
 module For_testing : sig
   type strict_snapshot_writer =

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -194,12 +194,31 @@ let dashboard_memory_http_json ?config request : Yojson.Safe.t =
 
 include Server_dashboard_http_memory_subsystems
 
+(** Read the resolved-history page bounds. [?limit=<rows>] caps the returned
+    decisions and [?window=<minutes>] caps how far back they may be dated,
+    matching the [?window=] idiom of {!dashboard_gate_tool_events_http_json}.
+    Both are clamped by the approval queue, which owns the bounds; the clamp
+    here only keeps a hostile query from allocating before that. [offset] and
+    [status_filter] used to be parsed and cache-keyed here while the projection
+    discarded them, which fragmented the cache across keys that computed
+    identical payloads — they are gone rather than silently ignored. *)
 let dashboard_gate_http_json request ~base_path : Yojson.Safe.t =
-  let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
-  let offset =
-    int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000
+  let limit =
+    int_query_param
+      request
+      "limit"
+      ~default:Keeper_approval_queue.recent_resolved_history_limit
+    |> clamp ~min_v:1 ~max_v:Keeper_approval_queue.recent_resolved_max_limit
   in
-  let status_filter = None in
+  let window_minutes =
+    int_query_param
+      request
+      "window"
+      ~default:Keeper_approval_queue.recent_resolved_default_window_minutes
+    |> clamp
+         ~min_v:Keeper_approval_queue.recent_resolved_min_window_minutes
+         ~max_v:Keeper_approval_queue.recent_resolved_max_window_minutes
+  in
   let force = bool_query_param request "force" ~default:false in
   let approval_queue_revision =
     Keeper_approval_queue.store_revision_for_workspace ~base_path
@@ -209,12 +228,12 @@ let dashboard_gate_http_json request ~base_path : Yojson.Safe.t =
       "gate:%s;%d;%d;%d"
       base_path
       limit
-      offset
+      window_minutes
       approval_queue_revision
   in
   let compute () =
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      Dashboard_gate.dashboard_json ~base_path ~limit ~offset ~status_filter)
+      Dashboard_gate.dashboard_json ~base_path ~limit ~window_minutes)
   in
   if force then Dashboard_cache.invalidate cache_key;
   Dashboard_cache.get_or_compute cache_key ~ttl:dashboard_projection_cache_ttl_s compute

--- a/test/dune
+++ b/test/dune
@@ -2020,6 +2020,8 @@
 
 (include stanzas/test_keeper_approval_queue.inc)
 
+(include stanzas/test_keeper_approval_resolved_history.inc)
+
 (include stanzas/test_keeper_toml_parser.inc)
 
 (include stanzas/test_keeper_toml_loader.inc)

--- a/test/stanzas/test_keeper_approval_resolved_history.inc
+++ b/test/stanzas/test_keeper_approval_resolved_history.inc
@@ -1,0 +1,6 @@
+; Keeper_approval_queue — resolved history window, row cap, and page counts
+
+(test
+ (name test_keeper_approval_resolved_history)
+ (modules test_keeper_approval_resolved_history)
+ (libraries masc_test_deps))

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -123,6 +123,11 @@ let ids (history : AQ.resolved_history) =
 
 let minutes n = float_of_int n *. 60.0
 
+(* Fixed clock: 2026-07-28T03:00:00Z. The function under test takes [now_ts]
+   instead of reading the clock, so every window boundary below is exact rather
+   than relative to whenever the suite happens to run. *)
+let now = 1785207600.0
+
 (* The day key follows the audit file layout, which is UTC. 2026-07-27T23:30Z
    is already 2026-07-28 in KST; a local-time key would name the wrong file for
    every such hour. *)
@@ -137,16 +142,15 @@ let test_day_key_is_utc () =
    audit writer stamps [ts] before it takes the append lock, so concurrent
    resolutions can land out of stamp order. *)
 let test_window_excludes_older_decisions base_path =
-  let now = Unix.gettimeofday () in
   seed_resolved ~base_path ~ts:(now -. minutes 10) ~id:"recent" ();
   seed_resolved ~base_path ~ts:(now -. minutes 120) ~id:"two_hours" ();
   seed_resolved ~base_path ~ts:(now -. minutes 1800) ~id:"thirty_hours" ();
-  let hour = AQ.list_recent_resolved ~base_path ~window_minutes:60 () in
+  let hour = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:60 () in
   check (list string) "60m window keeps only the recent decision" [ "recent" ] (ids hour);
   check int "60m matched" 1 hour.resolved_matched;
-  let day = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  let day = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:1440 () in
   check (list string) "24h window, newest first" [ "recent"; "two_hours" ] (ids day);
-  let week = AQ.list_recent_resolved ~base_path ~window_minutes:10_080 () in
+  let week = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:10_080 () in
   check int "7d window reaches all three" 3 week.resolved_matched
 ;;
 
@@ -156,11 +160,10 @@ let test_window_excludes_older_decisions base_path =
    decision while reporting nothing unusual. The count is chosen to exceed the
    old bound and stay inside the current one. *)
 let test_noise_does_not_consume_the_page base_path =
-  let now = Unix.gettimeofday () in
   seed_resolved ~base_path ~ts:(now -. minutes 40) ~id:"decision_a" ();
   seed_resolved ~base_path ~ts:(now -. minutes 30) ~id:"decision_b" ();
   seed_noise ~base_path ~ts:(now -. minutes 20) ~count:1500;
-  let history = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:1440 () in
   check (list string) "both decisions survive 1500 buried noise rows"
     [ "decision_b"; "decision_a" ] (ids history);
   check int "matched counts decisions, not rows" 2 history.resolved_matched;
@@ -173,15 +176,13 @@ let test_noise_does_not_consume_the_page base_path =
    it reached the window start, so it says so instead of presenting a partial
    page as the whole window. *)
 let test_row_cap_reports_itself base_path =
-  let now = Unix.gettimeofday () in
   seed_resolved ~base_path ~ts:(now -. minutes 30) ~id:"decision" ();
   seed_noise ~base_path ~ts:(now -. minutes 20) ~count:2500;
-  let history = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:1440 () in
   check bool "row cap is reported, not hidden" true history.resolved_scan_exhausted
 ;;
 
 let test_limit_caps_rows_and_matched_reports_the_rest base_path =
-  let now = Unix.gettimeofday () in
   for i = 1 to 30 do
     seed_resolved
       ~base_path
@@ -189,7 +190,7 @@ let test_limit_caps_rows_and_matched_reports_the_rest base_path =
       ~id:(Printf.sprintf "d%02d" i)
       ()
   done;
-  let history = AQ.list_recent_resolved ~base_path ~limit:10 ~window_minutes:1440 () in
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~limit:10 ~window_minutes:1440 () in
   check int "returned is capped" 10 (List.length history.resolved_rows);
   check int "matched sees the whole window" 30 history.resolved_matched;
   check int "limit is echoed" 10 history.resolved_limit;
@@ -199,9 +200,8 @@ let test_limit_caps_rows_and_matched_reports_the_rest base_path =
 ;;
 
 let test_limit_zero_returns_empty_page base_path =
-  let now = Unix.gettimeofday () in
   seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"only" ();
-  let history = AQ.list_recent_resolved ~base_path ~limit:0 () in
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~limit:0 () in
   check (list string) "no rows" [] (ids history);
   check int "matched not claimed" 0 history.resolved_matched;
   check bool "scan not claimed exhausted" false history.resolved_scan_exhausted
@@ -210,16 +210,15 @@ let test_limit_zero_returns_empty_page base_path =
 (* An undated decision cannot be placed in a wall-clock window. It is excluded
    rather than dated by guesswork, and it must not inflate [matched] either. *)
 let test_undated_decision_is_excluded base_path =
-  let now = Unix.gettimeofday () in
   seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"dated" ();
   seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"undated" ~ts_field:false ();
-  let history = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:1440 () in
   check (list string) "only the dated decision" [ "dated" ] (ids history);
   check int "matched excludes the undated row" 1 history.resolved_matched
 ;;
 
 let test_empty_store_is_an_empty_page base_path =
-  let history = AQ.list_recent_resolved ~base_path () in
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now () in
   check (list string) "no rows" [] (ids history);
   check int "matched" 0 history.resolved_matched;
   check int "default window is echoed" AQ.recent_resolved_default_window_minutes
@@ -228,11 +227,11 @@ let test_empty_store_is_an_empty_page base_path =
 ;;
 
 let test_bounds_are_clamped base_path =
-  let over = AQ.list_recent_resolved ~base_path ~limit:100_000 ~window_minutes:999_999 () in
+  let over = AQ.list_recent_resolved ~base_path ~now_ts:now ~limit:100_000 ~window_minutes:999_999 () in
   check int "limit clamped to the max" AQ.recent_resolved_max_limit over.resolved_limit;
   check int "window clamped to the max" AQ.recent_resolved_max_window_minutes
     over.resolved_window_minutes;
-  let under = AQ.list_recent_resolved ~base_path ~limit:5 ~window_minutes:0 () in
+  let under = AQ.list_recent_resolved ~base_path ~now_ts:now ~limit:5 ~window_minutes:0 () in
   check int "window clamped to the min" AQ.recent_resolved_min_window_minutes
     under.resolved_window_minutes;
   check int "a limit inside the range is kept" 5 under.resolved_limit

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -1,0 +1,269 @@
+(** Resolved Gate history: the wall-clock window, the row cap, and the counts
+    that keep either bound from truncating silently.
+
+    Before this suite the history was a fixed slice of the newest 1280 physical
+    audit rows. Because the store interleaves [resolved] rows with far more
+    numerous [summary_updated] rows, the number of decisions that survived that
+    slice fell as non-resolved traffic grew, and nothing in the payload said
+    so. The tests below pin both bounds and the reporting. *)
+
+open Alcotest
+
+module AQ = Masc.Keeper_approval_queue
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_approval_resolved_history_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let rec cleanup_dir path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Array.iter (fun name -> cleanup_dir (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path)
+  then (
+    mkdir_p (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
+(* Day file for [ts] computed independently of the module under test, mirroring
+   the write path ([Jsonl_writer.dated_path], UTC). Seeding through this rather
+   than through [AQ.audit_day_string_of_ts] keeps the reader honest: a reader
+   that switched to local time would stop finding rows the writer placed here. *)
+let audit_day_file ~base_path ts =
+  let tm = Unix.gmtime ts in
+  let month = Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) in
+  let dir =
+    Filename.concat (Filename.concat base_path ".masc") "audit-approvals"
+    |> fun d -> Filename.concat d month
+  in
+  mkdir_p dir;
+  Filename.concat dir (Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday)
+;;
+
+let append_row ~base_path ~ts (row : Yojson.Safe.t) =
+  let path = audit_day_file ~base_path ts in
+  let oc = open_out_gen [ Open_append; Open_creat; Open_wronly ] 0o644 path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (Yojson.Safe.to_string row ^ "\n"))
+;;
+
+(* A resolved decision as the audit writer records it. [?ts_field:false] drops
+   the timestamp to exercise the undated-row boundary. *)
+let seed_resolved ~base_path ~ts ~id ?(keeper = "rondo") ?(tool = "tool_execute")
+      ?(decision = "approve") ?(source = "auto_judge") ?(ts_field = true) ()
+  =
+  let fields =
+    [ "event", `String "resolved"
+    ; "id", `String id
+    ; "keeper", `String keeper
+    ; "tool", `String tool
+    ; "decision", `String decision
+    ; "decision_source", `String source
+    ]
+  in
+  let fields = if ts_field then ("ts", `Float ts) :: fields else fields in
+  append_row ~base_path ~ts (`Assoc fields)
+;;
+
+(* Bulk [summary_updated] rows, written through one handle so a test can afford
+   thousands of them. These are the rows that used to crowd decisions out of a
+   row-counted scan. *)
+let seed_noise ~base_path ~ts ~count =
+  let path = audit_day_file ~base_path ts in
+  let oc = open_out_gen [ Open_append; Open_creat; Open_wronly ] 0o644 path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+      for i = 1 to count do
+        let row : Yojson.Safe.t =
+          `Assoc
+            [ "event", `String "summary_updated"
+            ; "id", `String (Printf.sprintf "noise_%d" i)
+            ; "ts", `Float ts
+            ; "keeper", `String "rondo"
+            ]
+        in
+        output_string oc (Yojson.Safe.to_string row ^ "\n")
+      done)
+;;
+
+let with_store f () =
+  let base_path = temp_dir () in
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () -> f base_path)
+;;
+
+let ids (history : AQ.resolved_history) =
+  List.map
+    (fun row ->
+      match row with
+      | `Assoc fields ->
+        (match List.assoc_opt "id" fields with
+         | Some (`String id) -> id
+         | _ -> "<no-id>")
+      | _ -> "<not-an-object>")
+    history.resolved_rows
+;;
+
+let minutes n = float_of_int n *. 60.0
+
+(* The day key follows the audit file layout, which is UTC. 2026-07-27T23:30Z
+   is already 2026-07-28 in KST; a local-time key would name the wrong file for
+   every such hour. *)
+let test_day_key_is_utc () =
+  check string "23:30Z stays on the UTC day" "2026-07-27"
+    (AQ.audit_day_string_of_ts 1785195000.0);
+  check string "00:30Z is the next UTC day" "2026-07-28"
+    (AQ.audit_day_string_of_ts 1785198600.0)
+;;
+
+(* Seeded newest-first on purpose: file position must not decide the order. The
+   audit writer stamps [ts] before it takes the append lock, so concurrent
+   resolutions can land out of stamp order. *)
+let test_window_excludes_older_decisions base_path =
+  let now = Unix.gettimeofday () in
+  seed_resolved ~base_path ~ts:(now -. minutes 10) ~id:"recent" ();
+  seed_resolved ~base_path ~ts:(now -. minutes 120) ~id:"two_hours" ();
+  seed_resolved ~base_path ~ts:(now -. minutes 1800) ~id:"thirty_hours" ();
+  let hour = AQ.list_recent_resolved ~base_path ~window_minutes:60 () in
+  check (list string) "60m window keeps only the recent decision" [ "recent" ] (ids hour);
+  check int "60m matched" 1 hour.resolved_matched;
+  let day = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  check (list string) "24h window, newest first" [ "recent"; "two_hours" ] (ids day);
+  let week = AQ.list_recent_resolved ~base_path ~window_minutes:10_080 () in
+  check int "7d window reaches all three" 3 week.resolved_matched
+;;
+
+(* The regression this suite exists for. The decisions are the OLDEST rows and
+   are then buried under 1500 [summary_updated] rows — past the 1280-row slice
+   the previous implementation used, so that implementation returned neither
+   decision while reporting nothing unusual. The count is chosen to exceed the
+   old bound and stay inside the current one. *)
+let test_noise_does_not_consume_the_page base_path =
+  let now = Unix.gettimeofday () in
+  seed_resolved ~base_path ~ts:(now -. minutes 40) ~id:"decision_a" ();
+  seed_resolved ~base_path ~ts:(now -. minutes 30) ~id:"decision_b" ();
+  seed_noise ~base_path ~ts:(now -. minutes 20) ~count:1500;
+  let history = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  check (list string) "both decisions survive 1500 buried noise rows"
+    [ "decision_b"; "decision_a" ] (ids history);
+  check int "matched counts decisions, not rows" 2 history.resolved_matched;
+  check bool "not truncated" false
+    (history.resolved_matched > history.resolved_limit);
+  check bool "window was fully covered" false history.resolved_scan_exhausted
+;;
+
+(* The second bound must report itself. Past the row cap the scan cannot prove
+   it reached the window start, so it says so instead of presenting a partial
+   page as the whole window. *)
+let test_row_cap_reports_itself base_path =
+  let now = Unix.gettimeofday () in
+  seed_resolved ~base_path ~ts:(now -. minutes 30) ~id:"decision" ();
+  seed_noise ~base_path ~ts:(now -. minutes 20) ~count:2500;
+  let history = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  check bool "row cap is reported, not hidden" true history.resolved_scan_exhausted
+;;
+
+let test_limit_caps_rows_and_matched_reports_the_rest base_path =
+  let now = Unix.gettimeofday () in
+  for i = 1 to 30 do
+    seed_resolved
+      ~base_path
+      ~ts:(now -. minutes (60 - i))
+      ~id:(Printf.sprintf "d%02d" i)
+      ()
+  done;
+  let history = AQ.list_recent_resolved ~base_path ~limit:10 ~window_minutes:1440 () in
+  check int "returned is capped" 10 (List.length history.resolved_rows);
+  check int "matched sees the whole window" 30 history.resolved_matched;
+  check int "limit is echoed" 10 history.resolved_limit;
+  check bool "page reports truncation" true
+    (history.resolved_matched > history.resolved_limit);
+  check string "newest first" "d30" (List.hd (ids history))
+;;
+
+let test_limit_zero_returns_empty_page base_path =
+  let now = Unix.gettimeofday () in
+  seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"only" ();
+  let history = AQ.list_recent_resolved ~base_path ~limit:0 () in
+  check (list string) "no rows" [] (ids history);
+  check int "matched not claimed" 0 history.resolved_matched;
+  check bool "scan not claimed exhausted" false history.resolved_scan_exhausted
+;;
+
+(* An undated decision cannot be placed in a wall-clock window. It is excluded
+   rather than dated by guesswork, and it must not inflate [matched] either. *)
+let test_undated_decision_is_excluded base_path =
+  let now = Unix.gettimeofday () in
+  seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"dated" ();
+  seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"undated" ~ts_field:false ();
+  let history = AQ.list_recent_resolved ~base_path ~window_minutes:1440 () in
+  check (list string) "only the dated decision" [ "dated" ] (ids history);
+  check int "matched excludes the undated row" 1 history.resolved_matched
+;;
+
+let test_empty_store_is_an_empty_page base_path =
+  let history = AQ.list_recent_resolved ~base_path () in
+  check (list string) "no rows" [] (ids history);
+  check int "matched" 0 history.resolved_matched;
+  check int "default window is echoed" AQ.recent_resolved_default_window_minutes
+    history.resolved_window_minutes;
+  check bool "scan not exhausted" false history.resolved_scan_exhausted
+;;
+
+let test_bounds_are_clamped base_path =
+  let over = AQ.list_recent_resolved ~base_path ~limit:100_000 ~window_minutes:999_999 () in
+  check int "limit clamped to the max" AQ.recent_resolved_max_limit over.resolved_limit;
+  check int "window clamped to the max" AQ.recent_resolved_max_window_minutes
+    over.resolved_window_minutes;
+  let under = AQ.list_recent_resolved ~base_path ~limit:5 ~window_minutes:0 () in
+  check int "window clamped to the min" AQ.recent_resolved_min_window_minutes
+    under.resolved_window_minutes;
+  check int "a limit inside the range is kept" 5 under.resolved_limit
+;;
+
+let () =
+  run
+    "keeper_approval_resolved_history"
+    [ ( "day_key"
+      , [ test_case "audit day key is UTC" `Quick test_day_key_is_utc ] )
+    ; ( "window"
+      , [ test_case "older decisions fall outside the window" `Quick
+            (with_store test_window_excludes_older_decisions)
+        ; test_case "non-resolved rows do not consume the page" `Quick
+            (with_store test_noise_does_not_consume_the_page)
+        ; test_case "row cap reports itself" `Quick
+            (with_store test_row_cap_reports_itself)
+        ] )
+    ; ( "bounds"
+      , [ test_case "limit caps rows and matched reports the rest" `Quick
+            (with_store test_limit_caps_rows_and_matched_reports_the_rest)
+        ; test_case "limit zero yields an empty page" `Quick
+            (with_store test_limit_zero_returns_empty_page)
+        ; test_case "limit and window are clamped" `Quick
+            (with_store test_bounds_are_clamped)
+        ] )
+    ; ( "boundaries"
+      , [ test_case "undated decision is excluded" `Quick
+            (with_store test_undated_decision_is_excluded)
+        ; test_case "empty store is an empty page" `Quick
+            (with_store test_empty_store_is_an_empty_page)
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

Gate 처리 이력이 **시간이 아니라 물리 행 수**로 잘리고 있었고, 잘렸다는 사실이 응답에 없었습니다.

```ocaml
read_recent_audit_raw store (resolved_audit_scan_window n)   (* max 500 (n*64) = 1280행 *)
|> List.filter resolved_history_event
|> List.filteri (fun idx _ -> idx < n)                       (* 있는 만큼만 자름 *)
```

감사 저장소는 `resolved` 행 사이에 훨씬 많은 `summary_updated` / `pending` 행을 섞어 씁니다. 그래서 비-resolved 트래픽이 늘수록 슬라이스에서 살아남는 판정 수가 줄어들고, 응답에는 그 사실이 나타나지 않습니다.

라이브 저장소 실측 (`.masc/audit-approvals/2026-07/`):

| 파일 | 전체 행 | resolved | 밀도 |
|---|---|---|---|
| `27.jsonl` | 808 | 172 (auto_judge 148 / human 24) | 21.3% |
| `28.jsonl` | 685 | 9 (auto_judge 9) | **1.31%** |

1280행 창이 20건을 채우려면 최소 1.56% 밀도가 필요합니다. 7/28 트래픽 패턴만으로는 **못 채웁니다.** 지금 20건이 나오는 건 7/27의 고밀도 행이 아직 창에 남아 있기 때문입니다.

`summary_updated : resolved` 비율은 7/27 2.5:1 → 7/28 **54:1**로 벌어졌습니다.

## 함께 발견된 것: 파라미터를 받아서 버림

```ocaml
(* server_dashboard_http.ml *)
let limit  = int_query_param request "limit"  ~default:50 |> clamp ~min_v:1 ~max_v:200
let offset = int_query_param request "offset" ~default:0  |> clamp ~min_v:0 ~max_v:5000
let cache_key = Printf.sprintf "gate:%s;%d;%d;%d" base_path limit offset revision

(* dashboard_gate.ml *)
let dashboard_json ~base_path ~limit:_ ~offset:_ ~status_filter:_ =
```

파싱하고 clamp하고 **캐시 키에 넣은 뒤** 버립니다. 결과:

- 더 많이 달라고 요청할 방법이 UI에도 API에도 없음
- 출력에 영향이 없는 값이 캐시 키에 들어가 최대 200 × 5001개 키가 동일 payload를 계산

## 변경

### 1. 시간 창 + 행 상한, 둘 다 보고

형제 엔드포인트 `/api/v1/dashboard/gate/tool-events`가 이미 쓰는 `?window=<minutes>` 관용구를 그대로 따릅니다.

```ocaml
type resolved_history =
  { resolved_rows : Yojson.Safe.t list   (* newest first, at most limit *)
  ; resolved_matched : int               (* 창 안에서 스캔된 판정 전부 *)
  ; resolved_limit : int
  ; resolved_window_minutes : int
  ; resolved_scan_exhausted : bool       (* 행 상한이 창 시작 전에 스캔을 끊음 *)
  }
```

- `matched > limit` → 이 페이지는 창의 일부
- `scan_exhausted` → `matched`조차 하한값

`GET /api/v1/dashboard/gate?window=1440&limit=200` 이 이제 실제로 동작합니다. 기본 24시간, 5분~7일 clamp.

### 2. 화면이 범위를 말함

이력 목록 위에 한 줄:

- 전체: `최근 1일 149건 전체`
- 일부: `최근 1일 149건 중 20건 표시` (warn)
- 상한: `최근 1일 · 20건 표시 · 조회 상한에 걸려 최근 1일 전체를 읽지 못했습니다` (warn)
- 페이지 미보고: `조회 범위를 확인할 수 없습니다 — 표시된 항목이 전체가 아닐 수 있습니다`

그리고 **이력 탭에 건수 배지**를 붙였습니다. 지금까지 기본 화면(큐 탭)은 큐가 0이면 배지가 사라지고 이력 탭엔 배지 코드가 아예 없어서, 자동 판정이 20건 일어나도 화면에 단서가 0개였습니다. 큐 배지는 대기가 문제라서 빨강이고, 이력 배지는 이미 내린 판정이라 중립색입니다.

부분/누락 페이지는 `null`로 정규화되어 "범위 불명"으로 렌더됩니다. 0으로 채운 레코드는 "아무 판정도 없었다"로 읽히므로 만들지 않습니다.

### 3. 정렬 기준을 파일 위치 → 타임스탬프

감사 writer는 append 락을 잡기 **전에** `ts`를 찍습니다. 동시 판정 2건이 결정 순서와 반대로 파일에 들어갈 수 있어, 파일 위치 기반 "newest first"는 계약이 아니었습니다. `stable_sort`로 `ts` 내림차순, 동일 스탬프는 파일 순서로 tie-break.

### 4. 소비하지 않는 파라미터 제거

`offset` / `status_filter`를 시그니처와 HTTP 파싱에서 삭제했습니다. 클라이언트 동작은 그대로(무시됨)이고, 캐시 키 오염만 사라집니다.

## 검증

**양성 대조** — 새 회귀 테스트가 구현 이전 동작을 실제로 잡는지 확인:

| 스캔 창 | 결과 |
|---|---|
| 1280행 (구버전) | **1 failure** — `non-resolved rows do not consume the page` |
| 2000행 + 시간 창 | **9/9 통과** |

되돌림 후 잔여 참조 0 확인. 이 회귀 테스트는 판정 2건을 가장 오래된 행으로 두고 그 위에 `summary_updated` 1500행을 쌓습니다 — 구 1280행 상한 밖, 신 상한 안.

| 스위트 | 결과 |
|---|---|
| `test_keeper_approval_resolved_history` (신규) | 9 통과 |
| `test_keeper_approval_queue` | 34 통과 |
| `test_keeper_approval_queue_rules` | 17 통과 |
| `test_dashboard_gate_metrics` | 9 통과 |
| `dune build @check` | exit 0 |
| dashboard `vitest run` (전체) | **8837 통과 / 643 파일** |
| dashboard `tsc --noEmit` | exit 0 |

신규 OCaml 테스트가 고정하는 것: UTC 일자 키(로컬 시각이면 KST에서 하루 9시간 동안 엉뚱한 파일을 봄), 시간 창 경계, 노이즈 행이 페이지를 잠식하지 않음, 행 상한이 자기 자신을 보고함, limit/window clamp, 타임스탬프 없는 행 제외, 빈 저장소.

신규 dashboard 테스트가 고정하는 것: 완전/일부/상한/미보고 4가지 범위 표시, 이력 탭 배지, 부분 페이지를 기본값으로 채우지 않고 거부.

## 남은 것

`summary_updated` 484건이 `resolved` 9건에 붙은 7/28의 54:1 비율은 #26081(Auto Judge 컨텍스트 초과) 때문에 판정이 반복 재시도된 결과입니다. #26087로 그 비율은 정상화되지만, **행 수 기반 조회라는 구조**는 이 PR이 고칩니다.

RFC-WAIVED: credential / identity / operator control / keeper sandbox / hooks / workflow 문서 중 어느 것도 건드리지 않는 read-only 대시보드 projection 변경.

WORKAROUND-WAIVED: 이 PR은 cap을 추가하지 않고 **말없이 자르던 cap을 제거하고 보고를 강제**합니다. 남은 행 상한은 원래 있던 것이고, 이제 `scan_exhausted`로 자기 자신을 보고합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
