### PR TITLE
fix(schedule): reject keeper_wake creation for unregistered targets

### DIFF
--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -213,6 +213,26 @@ let validate_request_payload_for_creation ~payload =
   |> Result.map_error creation_rejection_message
 ;;
 
+let creation_keeper_wake_target ~payload =
+  match payload with
+  | `Assoc fields ->
+    (match assoc_string "kind" fields with
+     | Some raw_kind ->
+       (match classify_kind raw_kind with
+        | Some Keeper_wake ->
+          (match List.assoc_opt "body" fields with
+           | Some (`Assoc body) ->
+             (match assoc_string "keeper_name" body with
+              | Some keeper_name -> Ok (Some keeper_name)
+              | None ->
+                Error
+                  (keeper_wake_kind ^ " payload requires non-empty body.keeper_name"))
+           | Some _ | None -> Error (keeper_wake_kind ^ " payload.body must be an object"))
+        | None -> Ok None)
+     | None -> Error "payload.kind is required")
+  | _ -> Error "payload must be a JSON object"
+;;
+
 let dispatch_view_detailed request =
   let* view =
     payload_view request |> Result.map_error (fun msg -> Dispatch_invalid_payload msg)

--- a/lib/schedule_payload_projection.mli
+++ b/lib/schedule_payload_projection.mli
@@ -55,6 +55,14 @@ val validate_request_payload_for_creation
   :  payload:Yojson.Safe.t
   -> (unit, string) result
 
+(** Extract the wake target keeper name from a creation payload. [Ok (Some name)]
+    for a structurally complete [masc.keeper_wake] payload, [Ok None] for any
+    other kind (creation validation rejects those separately). Total on raw
+    JSON so callers can consult the target before the request is persisted. *)
+val creation_keeper_wake_target
+  :  payload:Yojson.Safe.t
+  -> (string option, string) result
+
 val dispatch_view_detailed
   :  Schedule_domain.schedule_request
   -> (known_kind * payload_view, dispatch_rejection) result

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -172,18 +172,32 @@ let validate_known_payload_request ~payload =
 (* A keeper_wake schedule whose target has no durable metadata can never be
    settled: dispatch defers activation with owner_unknown and no Keeper turn
    ever closes the occurrence (#26092). Reject at creation unless the caller
-   explicitly schedules for a keeper that will be registered later. *)
+   explicitly schedules for a keeper that will be registered later. The
+   registry lookup arrives via [Workspace_hooks] so this tool module keeps no
+   static keeper dependency (RFC-0194). *)
+let allow_unregistered_keeper_of_args args =
+  match Json_util.assoc_member_opt "allow_unregistered_keeper" args with
+  | None | Some `Null -> Ok false
+  | Some (`Bool value) -> Ok value
+  | Some _ -> Error "allow_unregistered_keeper must be a boolean"
+;;
+
 let validate_keeper_wake_target ctx ~payload args =
   match Schedule_payload_projection.creation_keeper_wake_target ~payload with
   | Error msg -> Error msg
   | Ok None -> Ok ()
   | Ok (Some keeper_name) ->
-    if Option.value ~default:false (Json_util.get_bool args "allow_unregistered_keeper")
+    let* allow_unregistered = allow_unregistered_keeper_of_args args in
+    if allow_unregistered
     then Ok ()
     else (
-      match Keeper_meta_store.read_effective_meta ctx.config keeper_name with
-      | Ok (Some _) -> Ok ()
-      | Ok None ->
+      match
+        (Atomic.get Workspace_hooks.schedule_wake_target_registered_fn)
+          ctx.config
+          keeper_name
+      with
+      | Ok true -> Ok ()
+      | Ok false ->
         Error
           (Printf.sprintf
              "schedule target keeper '%s' has no durable metadata; register the \

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -169,6 +169,35 @@ let validate_known_payload_request ~payload =
     Error (Schedule_payload_projection.creation_rejection_message rejection)
 ;;
 
+(* A keeper_wake schedule whose target has no durable metadata can never be
+   settled: dispatch defers activation with owner_unknown and no Keeper turn
+   ever closes the occurrence (#26092). Reject at creation unless the caller
+   explicitly schedules for a keeper that will be registered later. *)
+let validate_keeper_wake_target ctx ~payload args =
+  match Schedule_payload_projection.creation_keeper_wake_target ~payload with
+  | Error msg -> Error msg
+  | Ok None -> Ok ()
+  | Ok (Some keeper_name) ->
+    if Option.value ~default:false (Json_util.get_bool args "allow_unregistered_keeper")
+    then Ok ()
+    else (
+      match Keeper_meta_store.read_effective_meta ctx.config keeper_name with
+      | Ok (Some _) -> Ok ()
+      | Ok None ->
+        Error
+          (Printf.sprintf
+             "schedule target keeper '%s' has no durable metadata; register the \
+              keeper first or pass allow_unregistered_keeper=true to schedule for \
+              a keeper that will be created later"
+             keeper_name)
+      | Error detail ->
+        Error
+          (Printf.sprintf
+             "schedule target keeper '%s' metadata read failed: %s"
+             keeper_name
+             detail))
+;;
+
 let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
   let next_due_at =
     match request.status with
@@ -279,6 +308,7 @@ let handle_create ~tool_name ~start_time ctx args =
   let result =
     let* payload = payload_from_args args in
     let* () = validate_known_payload_request ~payload in
+    let* () = validate_keeper_wake_target ctx ~payload args in
     let* source = source_of_arg args in
     let* recurrence = recurrence_of_arg args in
     let requested_at =

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -35,6 +35,17 @@ let integer_prop ?description name =
   name, `Assoc fields
 ;;
 
+let boolean_prop ?description name =
+  let fields =
+    [ "type", `String "boolean" ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
 let object_prop ?description ?(additional_properties = true) name =
   let fields =
     [ "type", `String "object"; "additionalProperties", `Bool additional_properties ]
@@ -123,6 +134,12 @@ let create_schema =
         ~description:
           "Required when recurrence_kind is daily or cron. Fixed-offset only: UTC, Asia/Seoul/KST as +09:00 aliases, or offsets like +09:00/UTC+09:00. DST-aware IANA zones are not supported."
         "recurrence_timezone"
+    ; boolean_prop
+        ~description:
+          "Allow a masc.keeper_wake schedule whose target keeper has no durable \
+           metadata yet. Default false: creation is rejected because such a wake \
+           can never be settled until the keeper exists."
+        "allow_unregistered_keeper"
     ; string_prop ~description:"Requester actor id. Defaults to operator." "requested_by_id"
     ; string_prop ~enum:actor_kinds "requested_by_kind"
     ; string_prop ~description:"Requester display name." "requested_by_display_name"

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -53,6 +53,13 @@ let runtime_agents_fn
   : (Workspace_utils_backend_setup.config -> Masc_domain.agent list) Atomic.t
   = Atomic.make (fun _config -> [])
 
+(* Default allows every target so embedded contexts without the runtime wiring
+   keep creating schedules; the runtime installs the durable-metadata reader at
+   boot. Tool_schedule stays free of static keeper dependencies (RFC-0194). *)
+let schedule_wake_target_registered_fn
+  : (Workspace_utils_backend_setup.config -> string -> (bool, string) result) Atomic.t
+  = Atomic.make (fun _config _keeper_name -> Ok true)
+
 (** Relation materializer: agent session end — wraps Relation_materializer.on_agent_session_ended. *)
 let relation_on_leave_fn
   : (leaving_agent:string -> active_agents:string list -> unit) Atomic.t

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -40,6 +40,14 @@ val activity_emit_fn : (Workspace_utils_backend_setup.config ->
            Atomic.t
 val runtime_agents_fn :
   (Workspace_utils_backend_setup.config -> Masc_domain.agent list) Atomic.t
+
+(** Whether a schedule keeper_wake target has durable keeper metadata.
+    [Ok true] = registered, [Ok false] = absent, [Error] = read failure.
+    Default allows every target; the runtime installs the
+    durable-metadata reader at boot so the tool layer keeps no static
+    keeper dependency (RFC-0194). *)
+val schedule_wake_target_registered_fn :
+  (Workspace_utils_backend_setup.config -> string -> (bool, string) result) Atomic.t
 val relation_on_leave_fn : (leaving_agent:string -> active_agents:string list -> unit)
            Atomic.t
 val relation_on_task_done_fn : (assignee:string -> active_agents:string list -> unit) Atomic.t

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -256,6 +256,11 @@ let record_anti_rationalization_outcome ~outcome ~runtime =
 ;;
 
 let install () =
+  Atomic.set Workspace_hooks.schedule_wake_target_registered_fn (fun config keeper_name ->
+    match Keeper_meta_store.read_effective_meta config keeper_name with
+    | Ok (Some _) -> Ok true
+    | Ok None -> Ok false
+    | Error detail -> Error detail);
   Atomic.set Workspace_hooks.observe_agent_lifecycle_fn (fun config ~agent_id ~event ~details ->
     observe_agent_lifecycle config ~agent_id ~event ~details);
   Atomic.set Workspace_hooks.observe_task_transition_fn (fun config ~agent_name ~task_id ~transition ~details ->

--- a/scripts/harness/contract/scheduler_live_supported_contract.sh
+++ b/scripts/harness/contract/scheduler_live_supported_contract.sh
@@ -144,6 +144,7 @@ create_payload="$(
       requested_by_id: "contract-operator",
       scheduled_by_id: "contract-scheduler",
       payload_kind: "masc.keeper_wake",
+      allow_unregistered_keeper: true,
       payload_body: {
         keeper_name: $keeper_name,
         title: "Contract scheduler evidence",

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -37,6 +37,11 @@ let with_config f =
   Eio.Switch.on_release sw (fun () -> rm_rf path);
   let config = Workspace.default_config path in
   ignore (Workspace.init config ~agent_name:(Some "schedule-test"));
+  Atomic.set Workspace_hooks.schedule_wake_target_registered_fn (fun config keeper_name ->
+    match Keeper_meta_store.read_effective_meta config keeper_name with
+    | Ok (Some _) -> Ok true
+    | Ok None -> Ok false
+    | Error detail -> Error detail);
   register_wake_target config "schedule-keeper";
   f config
 ;;

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -11,6 +11,22 @@ let rec rm_rf path =
       Sys.remove path
 ;;
 
+let register_wake_target config keeper_name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
+        ; "trace_id", `String ("trace-" ^ keeper_name)
+        ])
+  with
+  | Error msg -> fail ("keeper meta parse failed: " ^ msg)
+  | Ok meta ->
+    (match Keeper_meta_store.write_meta config meta with
+     | Ok () -> ()
+     | Error detail -> fail ("keeper meta write failed: " ^ detail))
+;;
+
 let with_config f =
   Eio_main.run
   @@ fun env ->
@@ -21,6 +37,7 @@ let with_config f =
   Eio.Switch.on_release sw (fun () -> rm_rf path);
   let config = Workspace.default_config path in
   ignore (Workspace.init config ~agent_name:(Some "schedule-test"));
+  register_wake_target config "schedule-keeper";
   f config
 ;;
 
@@ -208,6 +225,39 @@ let test_removed_convenience_input_does_not_synthesize_payload () =
     (List.length (Schedule_store.read_state config).schedules)
 ;;
 
+let test_unregistered_wake_target_rejected () =
+  with_config
+  @@ fun config ->
+  let ghost_args allow =
+    `Assoc
+      ([ "schedule_id", `String "sched-ghost-target"
+       ; "due_at_unix", `Float 200.0
+       ; "payload_kind", `String Schedule_supported_kinds.keeper_wake
+       ; ( "payload_body"
+         , `Assoc
+             [ "keeper_name", `String "ghost-keeper"
+             ; "message", `String "wake for a keeper that does not exist"
+             ] )
+       ; "requested_by_id", `String "operator"
+       ; "scheduled_by_id", `String "scheduler-agent"
+       ]
+       @ if allow then [ "allow_unregistered_keeper", `Bool true ] else [])
+  in
+  let rejected = dispatch_exn config Tool_schemas_schedule.Create_request (ghost_args false) in
+  check bool "unregistered wake target rejected" false (Tool_result.is_success rejected);
+  check bool "rejection names the missing keeper metadata" true
+    (String_util.contains_substring
+       (Tool_result.message rejected)
+       "has no durable metadata");
+  check int "rejected schedule is not persisted" 0
+    (List.length (Schedule_store.read_state config).schedules);
+  let allowed = dispatch_exn config Tool_schemas_schedule.Create_request (ghost_args true) in
+  check bool "explicit opt-in schedules the unregistered target" true
+    (Tool_result.is_success allowed);
+  check int "opted-in schedule persisted" 1
+    (List.length (Schedule_store.read_state config).schedules)
+;;
+
 let test_unknown_payload_is_rejected_before_persistence () =
   with_config
   @@ fun config ->
@@ -359,6 +409,8 @@ let () =
         ; test_case "create list get cancel" `Quick test_create_list_get_cancel
         ; test_case "removed convenience input does not synthesize payload" `Quick
             test_removed_convenience_input_does_not_synthesize_payload
+        ; test_case "unregistered wake target rejected" `Quick
+            test_unregistered_wake_target_rejected
         ; test_case "unknown payload rejected before persistence" `Quick
             test_unknown_payload_is_rejected_before_persistence
         ; test_case "payload contracts are schema only" `Quick


### PR DESCRIPTION
## 문제

존재하지 않는 keeper를 대상으로 한 `masc.keeper_wake` 스케줄이 생성을 통과한다. 라이브 실측(#26092, 2026-07-28):

- 수정 전 main: dispatch가 `owner_unknown`("durable keeper metadata missing")을 스스로 기록하고도 schedule/execution 둘 다 `succeeded` 보고
- #26046 이후: 정직하게 `running/dispatched`로 남지만 정산할 Keeper 턴이 영원히 없어 **영구 미종결**
- 부수효과: 존재하지 않는 keeper의 event-queue/reaction-ledger 디렉토리가 디스크에 물질화

## 수정 (생성 시점 fail-closed)

- `Schedule_payload_projection.creation_keeper_wake_target` 추가 — payload envelope 파싱 SSOT를 projection에 유지
- `Tool_schedule.handle_create`가 대상 keeper를 `Keeper_meta_store.read_effective_meta`로 확인, 메타데이터 부재 시 생성 거부 (읽기 실패도 fail-closed)
- "미래에 등록될 keeper 예약" 사용례는 명시적 `allow_unregistered_keeper=true`로만 허용 (create 스키마에 boolean 추가)
- dispatch 계층의 owner_unknown deferred는 등록-후-다운 keeper용으로 그대로 유지

## 검증

- `dune build @check` — pass
- `test_schedule_tool_wiring` — 신규 케이스 포함 PASS (거부 메시지 + 미영속 확인 + opt-in 허용)
- `test_schedule_consumer_dispatch` / `test_schedule_domain` — PASS
- `bin/main_eio.exe` 빌드 성공

Closes #26092

🤖 Generated with [Claude Code](https://claude.com/claude-code)
