### PR TITLE
fix(transition-audit): return recent transitions newest first, as the interface says

### DIFF
--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -312,7 +312,10 @@ let recent_transitions ~keeper_name ~limit : transition_record list =
       | Some r -> result := r :: !result
       | None -> ()
     done;
-    !result
+    (* [i = 0] is the newest slot and [::] prepends, so the accumulator ends up
+       oldest-first. Reverse it to honour the newest-first contract in the .mli,
+       which [recent_completed_turns] below already keeps. *)
+    List.rev !result
 ;;
 
 let recent_transitions_json ~keeper_name ~limit : Yojson.Safe.t =
@@ -336,6 +339,10 @@ let recent_transitions_json ~keeper_name ~limit : Yojson.Safe.t =
                Some record
              | _ -> None)
           | _ -> None)
+        (* [read_recent] returns oldest-first, so without this the cap below
+           kept the OLDEST [limit] rows of the scanned window and presented
+           them as "recent". Reverse first: take the newest, newest-first. *)
+        |> List.rev
         |> List.filteri (fun idx _ -> idx < limit)
       in
       `List items)

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -340,6 +340,81 @@ let test_sync_fallback_appends_inline () =
                   check bool "store written inline" true
                     (Sys.file_exists (default_store_dir base_dir))))))
 
+(* Ordering is a documented contract — keeper_transition_audit.mli:22 promises
+   "recent transitions for a keeper, newest first" — and both read paths used to
+   break it. Nothing asserted order before, only List.length, which is why the
+   store path could also select the OLDEST rows of its scan window and still
+   pass. `keeper_runtime_trust_snapshot` reads it with ~limit:6 and
+   `/api/v1/.../transitions` renders it straight to an operator. *)
+let stamped ts = { (transition ()) with Audit.wall_clock_at_decision = ts }
+
+let stamps_of_json = function
+  | `List items ->
+    List.filter_map
+      (function
+        | `Assoc fields ->
+          (match List.assoc_opt "wall_clock_at_decision" fields with
+           | Some (`Float ts) -> Some ts
+           | Some (`Int ts) -> Some (float_of_int ts)
+           | _ -> None)
+        | _ -> None)
+      items
+  | _ -> []
+
+let test_ring_returns_newest_first () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
+          with_env "MASC_BASE_PATH" base_dir (fun () ->
+              with_env "MASC_BASE_PATH_INPUT" base_dir (fun () ->
+                  let keeper_name = "ordering-ring-keeper" in
+                  List.iter
+                    (fun ts -> Audit.record_transition ~keeper_name (stamped ts))
+                    [ 100.0; 200.0; 300.0 ];
+                  (* limit < recorded, so this pins selection as well as order:
+                     the oldest record must not appear at all. *)
+                  match Audit.recent_transitions ~keeper_name ~limit:2 with
+                  | [ first; second ] ->
+                      check (float 0.001) "newest first" 300.0
+                        first.Audit.wall_clock_at_decision;
+                      check (float 0.001) "then the next newest" 200.0
+                        second.Audit.wall_clock_at_decision
+                  | other ->
+                      fail
+                        (Printf.sprintf "expected 2 transitions, got %d"
+                           (List.length other))))))
+
+let test_store_fallback_returns_newest_first () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
+          with_env "MASC_BASE_PATH" base_dir (fun () ->
+              with_env "MASC_BASE_PATH_INPUT" base_dir (fun () ->
+                  let keeper_name = "ordering-store-keeper" in
+                  List.iter
+                    (fun ts -> Audit.record_transition ~keeper_name (stamped ts))
+                    [ 100.0; 200.0; 300.0; 400.0; 500.0 ];
+                  (* Drop the in-memory ring so the JSON reader has to fall
+                     through to the on-disk store, which is the path that
+                     serves an operator after a restart. *)
+                  Audit.For_testing.reset_state ();
+                  let stamps =
+                    stamps_of_json
+                      (Audit.recent_transitions_json ~keeper_name ~limit:2)
+                  in
+                  check (list (float 0.001)) "newest two, newest first"
+                    [ 500.0; 400.0 ] stamps))))
+
 let test_default_transition_append_failure_is_observed_and_ring_retained () =
   Audit.For_testing.reset_state ();
   with_invalid_default_store (fun () ->
@@ -494,6 +569,13 @@ let () =
             test_async_queue_defers_store_write_until_flush;
           test_case "sync fallback appends inline" `Quick
             test_sync_fallback_appends_inline;
+        ] );
+      ( "ordering",
+        [
+          test_case "ring returns the newest transitions, newest first" `Quick
+            test_ring_returns_newest_first;
+          test_case "store fallback returns the newest transitions, newest first"
+            `Quick test_store_fallback_returns_newest_first;
         ] );
       ( "append_failures",
         [


### PR DESCRIPTION
## 문제

`keeper_transition_audit.mli:22`

```
(** Retrieve recent transitions for a keeper, newest first. *)
val recent_transitions : keeper_name:string -> limit:int -> transition_record list
```

**두 읽기 경로 모두 oldest first 를 반환합니다.**

### ring 경로

```ocaml
for i = 0 to n - 1 do                      (* i = 0 이 최신 슬롯 *)
  match ring.buf.(idx) with
  | Some r -> result := r :: !result       (* prepend → 최신이 맨 아래로 *)
```

같은 파일의 형제 `recent_completed_turns` (`.mli:39`, **동일한 "newest first" 문구**) 는 `!result @ [ r ]` 로 append 해서 올바릅니다.

### store 경로

```ocaml
Dated_jsonl.read_recent store (max limit 1 * 8)   (* oldest-first 반환 *)
|> List.filter_map ...                            (* keeper 로 필터 *)
|> List.filteri (fun idx _ -> idx < limit)        (* ← 가장 오래된 limit 개를 취함 *)
```

`read_recent` 가 oldest-first 이므로 이건 **표현 문제가 아니라 선택 문제**입니다. 48행 창에서 가장 오래된 6개를 골라 "recent" 라고 내보냅니다.

## 왜 한 줄이 아닌가

`List.rev` 를 store 경로에만 넣으면 **같은 함수의 두 경로가 서로 어긋납니다** (store=newest-first, ring=oldest-first). ring 은 재시작 전, store 는 재시작 후를 서빙하므로 운영자가 보는 순서가 재시작 여부에 따라 뒤집힙니다. 둘 다 고칩니다.

## 소비자

| 소비자 | 사용 | 영향 |
|---|---|---|
| `dashboard_http_keeper_outcomes.ml:38` | `List.iter` 이벤트 카운트 | 순서 무관 |
| `keeper_runtime_trust_snapshot.ml:818` | `~limit:6` → timeline → 정렬 | **선택 오류** — 48행 중 가장 오래된 6개 |
| `server_dashboard_http_keeper_api.ml:1966` | `transitions` + `count` 로 응답 | **운영자에게 직접 오표시** |

## 테스트

기존 케이스는 **`List.length` 만** 검사합니다. 그래서 "가장 오래된 것을 고르는" 경로가 계속 통과했습니다. 형제 함수에는 `recent_completed_turns / ring ordering newest first` 가 이미 있었고, 이쪽에만 없었습니다.

추가한 2건은 `limit` 을 기록 수보다 작게 두어 **순서와 선택을 동시에 고정**합니다 — 가장 오래된 레코드는 결과에 아예 나오면 안 됩니다.

```
ring   : 100,200,300 기록 → limit:2 → [300, 200]
store  : 100..500 기록 → ring 비움 → limit:2 → [500, 400]
```

| 검증 | 결과 |
|---|---|
| `dune build @check` | exit 0 |
| `test_keeper_transition_audit` | 18 tests, 신규 2건 통과 |
| `test_keeper_transition_audit_types` | 2 통과 |
| `test_keeper_runtime_trust_snapshot` (소비자) | 18 통과 |
| meta bug-class 게이트 (determinism / silent-failure / ssot / enum / log-severity) | 통과 |

## 함께 발견한 것 — 별도 처리

**이 스위트는 CI 에서 실행되지 않습니다.** `@check` 로 컴파일만 됩니다:

```
rg -c 'runtest-test_keeper_transition_audit' .github/workflows/ci.yml  →  0
```

그래서 (a) 제가 추가한 assertion 은 오늘 시점에선 **로컬 증거**이고, (b) 기존 실패 1건이 탐지 없이 살아있습니다:

```
test_runtime_trust_timeline_carries_transition_observation
  meta_of_json failed: invalid current keeper meta:
  fields outside the current schema: runtime_id; runtime reset required
```

origin/main 에서 동일하게 실패합니다 (기준선 16 tests/1 failure vs 본 PR 18 tests/1 failure — 같은 케이스). 이 PR 에 끌어넣지 않고 이슈로 분리합니다. 스위트를 지금 CI 게이트에 넣으면 이 선재 실패로 main 이 red 가 되므로, 순서가 (1) 스키마 실패 수정 → (2) 게이트 편입 이어야 합니다.

## 배경

PR #26099 후속 SSOT 스윕에서 나온 건입니다. 스윕은 이걸 "store 경로에 `List.rev` 한 줄, 리스크 최저" 로 보고했는데, 실제로 읽어보니 ring 경로도 같은 계약을 위반하고 있었고 한쪽만 고치면 새 불일치가 생깁니다.

RFC-WAIVED: credential / identity / operator control / keeper sandbox / hooks / workflow 문서 미접촉. 감사 리더의 정렬 계약 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
