### PR TITLE
fix(keeper): stop telling a Keeper to emit a call the runtime replays

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -120,6 +120,40 @@ let turn_success_of_stop_reason ~meta = function
   | Runtime_agent.InputRequired _ -> Turn_input_required meta
 ;;
 
+(* RFC-0356: for the operations [Keeper_gate_replay] dispatches to, the runtime
+   spends the grant itself during tool-bundle setup (#25947, #26089). That
+   happens after this message is composed — [keeper_agent_run.ml:560] runs
+   [prepare_agent_setup] well past [build_turn_context] — so the approval store
+   still reads unconsumed here and the Keeper would be told to emit a call the
+   runtime is about to emit for it. Branching on the same dispatch the replay
+   uses keeps the instruction true for both halves. *)
+let approved_resolution_message ~approval_id ~tool_name ~input ~user_message =
+  let closing =
+    match Keeper_gate_replay.replayable_of_operation tool_name with
+    | Some _ ->
+      "The runtime spends this one-shot authorization itself this turn: the \
+       operation above runs from that exact input without you re-emitting it. \
+       A repeat call finds the authorization gone and opens a new Gate request \
+       instead. Other external effects follow the ordinary Gate independently."
+    | None ->
+      "The one-shot authorization belongs to this exact operation and input. \
+       Other external effects follow the ordinary Gate independently."
+  in
+  String.concat
+    "\n"
+    [ user_message
+    ; ""
+    ; "Gate resolution delivered:"
+    ; Printf.sprintf "- approval_id: %s" approval_id
+    ; Printf.sprintf "- operation: %s" tool_name
+    ; "- exact input:"
+    ; "```json"
+    ; Yojson.Safe.pretty_to_string input
+    ; "```"
+    ; closing
+    ]
+;;
+
 let user_message_with_hitl_resolution ~base_path ~user_message = function
   | Some
       { Keeper_event_queue.approval_id
@@ -132,19 +166,11 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
          ~id:approval_id
      with
      | Ok (Some request) ->
-       String.concat
-         "\n"
-         [ user_message
-         ; ""
-         ; "Gate resolution delivered:"
-         ; Printf.sprintf "- approval_id: %s" approval_id
-         ; Printf.sprintf "- operation: %s" request.tool_name
-         ; "- exact input:"
-         ; "```json"
-         ; Yojson.Safe.pretty_to_string request.input
-         ; "```"
-         ; "The one-shot authorization belongs to this exact operation and input. Other external effects follow the ordinary Gate independently."
-         ]
+       approved_resolution_message
+         ~approval_id
+         ~tool_name:request.tool_name
+         ~input:request.input
+         ~user_message
      | Ok None ->
        Log.Keeper.info
          "approved Gate request already consumed approval=%s"

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -19,6 +19,24 @@ val decide_degraded_retry
   -> Agent_sdk.Error.sdk_error
   -> degraded_retry_decision
 
+val approved_resolution_message :
+  approval_id:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  user_message:string ->
+  string
+(** Render the approved-resolution block appended to the turn input.
+
+    Whether the Keeper must emit the approved call depends on the same
+    dispatch the replay uses ({!Keeper_gate_replay.replayable_of_operation}).
+    For a replayed operation the runtime spends the grant during tool-bundle
+    setup, which happens after this message is composed, so the approval store
+    still reads unconsumed here — an instruction to re-emit would send the
+    Keeper after an authorization the runtime is about to spend for it.
+
+    Exposed separately from the store read so the rendering is testable
+    without a durable approval journal. *)
+
 val user_message_with_hitl_resolution :
   base_path:string ->
   user_message:string ->

--- a/test/test_keeper_hitl_resolution_prompt.ml
+++ b/test/test_keeper_hitl_resolution_prompt.ml
@@ -80,6 +80,69 @@ let test_edited_input_is_durable_and_not_a_grant () =
     (Option.is_none (Keeper_gate.cycle_grant_of_resolution resolution))
 ;;
 
+(* RFC-0356: the runtime replays an approved filesystem_write / tool_execute
+   during tool-bundle setup, which runs after this message is composed. Telling
+   the Keeper to spend a grant the runtime is about to spend sends it after an
+   authorization that will be gone, and the repeat call opens a new Gate
+   request. The instruction has to follow the same dispatch the replay uses. *)
+let approved_message ~tool_name =
+  Keeper_unified_turn.approved_resolution_message
+    ~approval_id:"approval-approved"
+    ~tool_name
+    ~input:(`Assoc [ "path", `String "/repo/a.ml"; "content", `String "let a = 1\n" ])
+    ~user_message:"continue"
+;;
+
+let test_replayed_operation_is_not_asked_for_again () =
+  List.iter
+    (fun tool_name ->
+       let message = approved_message ~tool_name in
+       check bool
+         (tool_name ^ ": the exact input still reaches the model")
+         true
+         (contains ~needle:"\"path\": \"/repo/a.ml\"" message);
+       check bool
+         (tool_name ^ ": the runtime is named as the spender")
+         true
+         (contains ~needle:"runtime spends this one-shot authorization itself" message);
+       check bool
+         (tool_name ^ ": the pre-replay instruction to emit it is gone")
+         false
+         (contains ~needle:"authorization belongs to this exact operation" message))
+    [ "filesystem_write"; "tool_execute" ]
+;;
+
+(* An operation the replay does not dispatch to still depends on the Keeper
+   emitting the call, so the original instruction must survive there. *)
+let test_unreplayed_operation_still_owns_its_grant () =
+  let message = approved_message ~tool_name:"network_read" in
+  check bool
+    "the Keeper is still told the grant is its to spend"
+    true
+    (contains ~needle:"authorization belongs to this exact operation" message);
+  check bool
+    "and is not told the runtime already spent it"
+    false
+    (contains ~needle:"runtime spends this one-shot authorization itself" message)
+;;
+
+(* The branch is the replay dispatch itself, not a copy of its operation list:
+   a future replayable operation must not need this renderer edited too. *)
+let test_message_follows_replay_dispatch () =
+  List.iter
+    (fun tool_name ->
+       let replayed =
+         Option.is_some (Keeper_gate_replay.replayable_of_operation tool_name)
+       in
+       check bool
+         (tool_name ^ ": message agrees with replay dispatch")
+         replayed
+         (contains
+            ~needle:"runtime spends this one-shot authorization itself"
+            (approved_message ~tool_name)))
+    [ "filesystem_write"; "tool_execute"; "network_read"; "keeper_board_post"; "" ]
+;;
+
 let () =
   run
     "keeper HITL resolution prompt"
@@ -92,6 +155,20 @@ let () =
             "edited input is durable and not authorization"
             `Quick
             test_edited_input_is_durable_and_not_a_grant
+        ] )
+    ; ( "approved resolution"
+      , [ test_case
+            "replayed operation is not asked for again"
+            `Quick
+            test_replayed_operation_is_not_asked_for_again
+        ; test_case
+            "unreplayed operation still owns its grant"
+            `Quick
+            test_unreplayed_operation_still_owns_its_grant
+        ; test_case
+            "message follows replay dispatch"
+            `Quick
+            test_message_follows_replay_dispatch
         ] )
     ]
 ;;


### PR DESCRIPTION
#26089 이후 승인 해소 메시지가 사실과 어긋납니다.

## 턴 입력이 이미 끝난 일을 하라고 지시합니다

승인된 Gate 해소가 배달되면 턴의 user message 에 이 블록이 붙습니다 (`keeper_unified_turn.ml:122-146`).

```
Gate resolution delivered:
- approval_id: appr_…
- operation: filesystem_write
- exact input:
```json
{ … }
```
The one-shot authorization belongs to this exact operation and input.
```

RFC-0356 이전에는 맞는 말이었습니다. Keeper 가 바이트 동일한 호출을 다시 내야 인가를 쓸 수 있었으니까요. 지금은 아닙니다 — `Keeper_gate_replay` 가 dispatch 하는 operation(`filesystem_write`, `tool_execute`)은 런타임이 tool bundle 구성 시점에 직접 씁니다.

문제는 순서입니다.

```
keeper_unified_turn.ml:940   user_message_with_hitl_resolution   ← 메시지 구성
keeper_agent_run.ml:507      build_turn_context
keeper_agent_run.ml:526-556  Context_injected (user_message_digest 기록)
keeper_agent_run.ml:560      prepare_agent_setup
   → keeper_run_tools_setup.ml:161  make_tool_bundle
      → keeper_tools_oas_bundle.ml:94  replay_approved_effect   ← 여기서 grant 소비
```

메시지가 replay 보다 먼저 구성되므로 `approved_resolution_request` 는 아직 미소비 상태를 돌려주고, 항상 "당신 것이니 쓰라" 분기가 발화합니다. 그 직후 런타임이 그 인가를 씁니다.

## 라이브 확인 (2026-07-28, 읽기 전용)

`traces/*/oas-snapshot-*.json` 최근 40 개에서 `Gate resolution delivered` 블록을 approval 단위로 집계했습니다.

```
고유 approval 31
  "one-shot authorization belongs …"   30
  "authorization already consumed"      0
  rejected                              1
```

같은 창의 `gate replay approval=… applied` 로그는 39 줄 / 고유 approval 27 건입니다. 즉 런타임이 실제로 대신 쓰고 있는 동안, 프롬프트는 30/30 으로 Keeper 에게 쓰라고 말하고 있었습니다.

## 변경

`replayable_of_operation` 로 분기합니다. 이 함수는 #26089 에서 노출했고, 그 이유가 정확히 "dispatch 되지 않는 decode 함수는 경계에서 작동하는 replay 와 구별되지 않는다" 였습니다. 같은 dispatch 를 쓰므로 replay 대상이 늘어도 이 렌더러를 따로 고칠 필요가 없습니다.

- replay 대상 → "The runtime spends this one-shot authorization itself this turn: the operation above runs from that exact input without you re-emitting it. A repeat call finds the authorization gone and opens a new Gate request instead."
- 그 외 (`network_read` 등) → 기존 문구 유지. 여전히 Keeper 가 호출을 내야 합니다.

`exact input` 블록은 양쪽 모두 유지합니다. Keeper 가 무엇이 실행되는지/실행할지 알아야 하는 건 변하지 않습니다.

렌더링을 `approved_resolution_message` 로 분리해 노출했습니다. 저장소 읽기와 렌더링이 붙어 있으면 durable approval journal 없이는 테스트할 수 없습니다.

## 검증

```
scripts/dune-local.sh build @check                      exit 0, Error 0
test_keeper_hitl_resolution_prompt.exe                  5/5
```

변이 양방향:

```
분기를 제거하고 옛 문구로 고정      2 failures
되돌림                              5/5
```

세 번째 케이스(`message follows replay dispatch`)는 문구가 아니라 `replayable_of_operation` 과의 일치를 검사합니다. `filesystem_write` / `tool_execute` / `network_read` / `keeper_board_post` / `""` 다섯 입력에서 dispatch 결과와 메시지가 같은 방향이어야 통과합니다.

## 이 PR 이 고치지 않는 것

replay 의 **결과**는 여전히 Keeper 에게 돌아가지 않습니다. `keeper_tools_oas_bundle.ml:85-115` 가 `let () = … in` 안에서 `Applied _ -> Log.Keeper.info` 로 끝내므로, 실행 요약(`{"ok":true,…,"bytes_written":5561}`)은 operator 로그에만 남고 transcript / receipt / 다음 관측 프레임 어디에도 들어가지 않습니다. 그걸 고치려면 replay 를 프롬프트 구성 앞으로 옮겨야 하고, 턴 임계 경로 재배치라 이 PR 범위 밖입니다. 근거와 실측은 #26060 코멘트에 기록했습니다.

이 PR 은 그와 별개로 지금 거짓인 지시문만 바로잡습니다. 런타임 동작은 바뀌지 않습니다.

RFC-WAIVED: 모델 대면 문구 정정 + 렌더러 분리. 실행 경로 / 상태 전이 / 타입 무변경 (`@check` exit 0). 참조 RFC-0356 은 #26089 에서 인용됨. credential / identity / sandbox / operator control plane 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
