### PR TITLE
refactor: remove server-side steering from agent-facing observation surfaces

### DIFF
--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -42,15 +42,6 @@ let all_assertion_kinds = Workspace_assertions.all_assertion_kinds
 let valid_assertion_strings = Workspace_assertions.valid_assertion_strings
 let assertion_kind_of_string_lenient = Workspace_assertions.assertion_kind_of_string_lenient
 
-let take_items limit items =
-  let rec loop remaining acc = function
-    | _ when remaining <= 0 -> List.rev acc
-    | [] -> List.rev acc
-    | x :: xs -> loop (remaining - 1) (x :: acc) xs
-  in
-  loop limit [] items
-;;
-
 type text_cache =
   { mutable key : string option
   ; mutable value : string option
@@ -98,9 +89,6 @@ let effective_cluster_name (config : Workspace.config) =
 ;;
 
 (* Handlers *)
-
-let lifecycle_tools = [ "keeper_task_claim"; "masc_transition" ]
-let is_lifecycle_tool tool = List.exists (String.equal tool) lifecycle_tools
 
 let unique_strings items =
   List.fold_left
@@ -414,40 +402,6 @@ let status_summary_string ~task_list_projection (ctx : context) =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task
   in
   let planning_state = planning_context_state ctx binding active_tasks in
-  let suggested_next =
-    (* All branches must end with [take_items 2] so masc_status response
-       size stays bounded.  Prior pipeline had a trailing [|> take_items 2]
-       that applied uniformly; restoring that invariant explicitly per
-       branch (Copilot review #14662 thread tool_workspace.ml:492). *)
-    if Option.is_some planning_state.planning_missing_task
-    then []
-    else if Option.is_some planning_state.deliverable_conflict_task
-    then [ "masc_deliver"; "masc_status" ]
-    else (
-      let tools =
-        if Stdlib.List.length binding.assigned_task_ids > 0
-        then [ "masc_heartbeat"; "masc_transition" ]
-        else if fresh_todo_count > 0
-        then [ "keeper_task_claim"; "masc_status" ]
-        else [ "masc_status"; "masc_add_task" ]
-      in
-      let tools =
-        if credential_blocked
-        then List.filter (fun tool -> not (is_lifecycle_tool tool)) tools
-        else (
-          match binding.drift_reason with
-          | Some "no_owned" ->
-            let tools =
-              List.filter (fun tool -> not (String.equal tool "masc_transition")) tools
-            in
-            let tools =
-              if fresh_todo_count > 0 then "keeper_task_claim" :: tools else tools
-            in
-            unique_strings tools
-          | Some _ | None -> tools)
-      in
-      take_items 2 tools)
-  in
   let attention_items =
     let items = [] in
     let items =
@@ -555,7 +509,6 @@ let status_summary_string ~task_list_projection (ctx : context) =
     ~todo_conflict_task_ids
     ~binding
     ~planning_state
-    ~suggested_next
     ~attention_items
     ~state
     ~backlog

--- a/lib/tool_workspace.mli
+++ b/lib/tool_workspace.mli
@@ -16,8 +16,7 @@
     (\[text_cache] type, \[make_text_cache], \[_status_cache],
     \[cache_ttl_seconds], \[status_cache_ttl_s],
     \[invalidate_status_cache], \[cached_text_by_key]),
-    \[take_items], \[effective_cluster_name],
-    \[lifecycle_tools] / \[is_lifecycle_tool],
+    \[effective_cluster_name],
     \[unique_strings], \[credential_state],
     \[safe_resolve_agent_name] / \[safe_current_task] / \[safe_get_agents] /
     the deliverable-conflict scanners (\[todo_task_has_completed_deliverable_conflict],

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -155,7 +155,6 @@ let status_summary_string
     ~(todo_conflict_task_ids : string list)
     ~(binding : current_binding)
     ~(planning_state : planning_context_state)
-    ~(suggested_next : string list)
     ~(attention_items : string list)
     ~(state : Masc_domain.workspace_state)
     ~(backlog : Masc_domain.backlog) =
@@ -210,10 +209,6 @@ let status_summary_string
       (Printf.sprintf "Credential: required=yes | available=%s | candidates=%s\n"
          (bool_flag credential_state.credential_available)
          (String.concat "," credential_state.credential_candidates));
-  (match suggested_next with [] -> () | _ ->
-    Buffer.add_string buf
-      (Printf.sprintf "Suggested next: %s\n"
-         (String.concat " -> " suggested_next)));
   (match attention_items with
   | [] -> ()
   | _ ->

--- a/lib/workspace_status_rendering.mli
+++ b/lib/workspace_status_rendering.mli
@@ -5,7 +5,7 @@
     main entry point ({!status_summary_string}) renders the
     full operator-visible terminal block (cluster header,
     snapshot line, you-line, task-binding line, planning state,
-    credential state, suggestions, attention items, players,
+    credential state, attention items, players,
     quest board, messages).
 
     Two additional helpers
@@ -63,19 +63,18 @@ val status_summary_string :
   todo_conflict_task_ids:string list ->
   binding:Workspace_types.current_binding ->
   planning_state:Workspace_types.planning_context_state ->
-  suggested_next:string list ->
   attention_items:string list ->
   state:Masc_domain.workspace_state ->
   backlog:Masc_domain.backlog ->
   string
 (** [status_summary_string] renders the full [masc_status]
-    operator-visible string.  All 22 named arguments are
+    operator-visible string.  All 21 named arguments are
     required — there is no convenience overload because every
     line is a deliberate operator surface.
 
-    [task_list_projection] is the typed audience projection for follow-up
-    guidance: external callers receive [masc_tasks], Keeper models receive
-    [keeper_tasks_list].
+    [task_list_projection] is the typed audience projection for the
+    quest-board overflow footer: external callers receive [masc_tasks],
+    Keeper models receive [keeper_tasks_list].
 
     {2 Display caps}
 
@@ -98,12 +97,11 @@ val status_summary_string :
     6. Task binding line (assigned set / drift reason)
     7. Planning lines (missing-task / deliverable-conflict)
     8. Credential line (only when required)
-    9. Suggested-next line (only when non-empty)
-    10. Attention block (only when non-empty)
-    11. Players block (capped at 40)
-    12. Quest Board (capped at 30)
-    13. Summary line
-    14. Messages line
+    9. Attention block (only when non-empty)
+    10. Players block (capped at 40)
+    11. Quest Board (capped at 30)
+    12. Summary line
+    13. Messages line
 
     The icon set (🏢 / 📦 / 📍 / 📁 / ⚡ / 🧭 / 🔎 / 📝 / 🔐 /
     💡 / ⚠️ / 📌 / 📋 / 💬) is operator-visible — runbook

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -230,7 +230,7 @@ let () =
       let message = (Tool_result.message result) in
       assert (str_contains message "Snapshot:");
       assert (str_contains message "🧭 You:");
-      assert (str_contains message "Suggested next:")
+      assert (not (str_contains message "Suggested next:"))
     | None -> failwith "dispatch returned None")
 ;;
 
@@ -672,7 +672,7 @@ let () =
       assert (str_contains result "owned=task-001");
       assert (str_contains result "current=task-002");
       assert_contains result "Do not retry generic masc_plan_init from a drifted surface";
-      assert (not (str_contains result "Suggested next: masc_plan_init -> masc_status"));
+      assert (not (str_contains result "Suggested next:"));
       assert (str_contains result "planning current_task is unset or drifted")
     | None -> failwith "dispatch returned None")
 ;;
@@ -699,8 +699,7 @@ let () =
           "Credential: required=yes | available=no | candidates=test-agent");
       assert (
         str_contains result "Lifecycle actions are credential-blocked for test-agent");
-      assert (not (str_contains result "Suggested next: masc_status -> masc_transition"));
-      assert (not (str_contains result "Suggested next: keeper_task_claim"))
+      assert (not (str_contains result "Suggested next:"))
     | None -> failwith "dispatch returned None")
 ;;
 
@@ -729,12 +728,12 @@ let () =
           (str_contains
              result
              "Lifecycle actions are credential-blocked for keeper-sangsu-agent"));
-      assert (str_contains result "Suggested next:")
+      assert (not (str_contains result "Suggested next:"))
     | None -> failwith "dispatch returned None")
 ;;
 
 let () =
-  test "dispatch_status_no_owned_prefers_claim_next_over_transition" (fun () ->
+  test "dispatch_status_no_owned_reports_drift_without_steering" (fun () ->
     Fun.protect ~finally:Fs_compat.clear_fs
     @@ fun () ->
     Eio_main.run
@@ -752,8 +751,7 @@ let () =
       assert (str_contains result "owned=- | current=task-001");
       assert (str_contains result "drift_reason=no_owned");
       assert (str_contains result "claim_first_suppressed=no");
-      assert_contains result "Suggested next: keeper_task_claim -> masc_status";
-      assert_not_contains result "Suggested next: masc_status -> masc_transition"
+      assert_not_contains result "Suggested next:"
     | None -> failwith "dispatch returned None")
 ;;
 
@@ -783,9 +781,7 @@ let () =
       assert (
         str_contains result "Do not retry generic masc_plan_init from a drifted surface");
       assert (str_contains result "handoff/worktree/test logs as the temporary SSOT");
-      assert (not (str_contains result "Suggested next: masc_plan_init -> masc_status"));
-      assert (not (str_contains result "Suggested next: masc_heartbeat"));
-      assert (not (str_contains result "Suggested next: masc_status -> masc_transition"))
+      assert (not (str_contains result "Suggested next:"))
     | None -> failwith "dispatch returned None")
 ;;
 
@@ -821,9 +817,7 @@ let () =
          assert_contains
            result
            "Owned task task-001 already has a completed-looking deliverable";
-         assert (str_contains result "Suggested next: masc_deliver -> masc_status");
-         assert (
-           not (str_contains result "Suggested next: masc_status -> masc_transition"))
+         assert (not (str_contains result "Suggested next:"))
        | None -> failwith "dispatch returned None")
 ;;
 


### PR DESCRIPTION
## 무엇을

서버측 조향(steering) 코드 제거 스윕 — 2 커밋.

**Commit 1 — `suggested_next` 제거** (−80/+19)
- `lib/tool_workspace.ml`: 상태→도구명 하드코딩 테이블(구 417-449행) + 전용 헬퍼(`take_items`/`lifecycle_tools`/`is_lifecycle_tool`) 삭제
- `lib/workspace_status_rendering.ml/.mli`: `~suggested_next` 파라미터와 `"Suggested next: ..."` 렌더링 라인 삭제 (인자 22→21)
- 테스트: "Suggested next:" 양성 단언 → 부재 단언으로 반전 (조향 라인이 되돌아오면 실패)

**Commit 2 — 처방 문구 스윕** (−29/+15)
- `attention_items` 전 항목을 관찰 전용으로 축소. 제거된 처방: "Call masc_start" / "Mount a valid credential..." / "Do not retry generic masc_plan_init...; use handoff/worktree/test logs as the temporary SSOT..." / "Treat this as conflict triage..." / "Treat owned as canonical and call masc_plan_set_task" / "choose or reconcile the active lane..." / "treat primary_owned as the safe task lane" / "clear or rebind current_task..." / "treat them as control-plane conflicts..."
- `keeper_tools_oas_bundle.task_state_hint`: 무할당 시 "Use keeper_task_claim or keeper_tasks_list to find one." 삭제 → "No task currently assigned."만. 이 문구는 tool descriptor description에 상태 조건부 주입되던 것이라 조향인 동시에 tool 정의 바이트 안정성도 해치던 지점.


**Commit 3 — 코드 원저작 행동 명령 제거** (−29/+3)

규칙 확정: **채널 불문, `.ml` 코드에 하드코딩된 "에이전트에게 뭔가 하라"는 문자열은 제거.** 지시는 config/prompts 문서(편집 가능한 지시 채널)의 몫이고, 코드는 사실과 API 전제조건만 서술한다.

- `keeper_unified_prompt`: "Continue this task this turn... release it with a handoff summary" 하드코딩 지시 삭제 (task 사실 + handoff 릴레이는 유지)
- `voice_session_manager`: `keeper_next_actions` 리스트 2개 통삭제 — 사실 라우팅은 `keeper_output`/`operator_input` 필드에 이미 존재
- `workspace_task_schedule`: claim_next 거부 메시지의 "ACTION: Resume this task; do not call claim_next again" → 전제조건 서술("claim_next is unavailable until the held task is done or explicitly released")로 교체. resume vs release 선택은 에이전트 몫
- `keeper_world_observation_message_scope`: transcript 인용 프리앰블의 "Use them to answer..." / "Do not claim that you checked..." 명령문 삭제 ("context, not instructions" 데이터 의미 라벨은 유지)

**의도적으로 남긴 것**: `turn_intent_fallback_block`은 SSOT가 `config/prompts/keeper.turn_intent.md`인 인바이너리 미러(레지스트리 실패 시 fallback) — 조향이 아니라 config-degradation 설계 문제이며 fallback vs fail-loud는 별도 변경. 에러 전제조건 메시지·tool description·help registry(사용법 문서)·운영자용 로그 라인도 유지.

## 왜

원칙: **판단이 들어가는 자리는 LLM 경계에서 판단한다. 관찰 표면은 상태를 서술하되 행동을 처방하지 않는다.**

`suggested_next`류 코드는 서버가 `drift_reason` 문자열 매치와 하드코딩 도구명으로 에이전트의 다음 행동을 대신 판단해 관찰 응답에 실어주던 것. 노 휴리스틱·노 스트링 매치·관찰/제어 분리 위반.

## 분류 기준 (스윕에서 유지한 것과 이유)

| 분류 | 판정 | 예 |
|------|------|-----|
| 상태 조건부 행동 처방 (관찰 표면) | **제거** | suggested_next, attention 처방 문구, oas_bundle claim 유도 |
| 에러/전제조건 위반의 1:1 remediation | 유지 | `masc_error` "Use masc_init first", transition Remediation, `response.ml` `recovery_hints` |
| typed FSM의 합법 전이 노출 | 유지 | `next_actions_hint`의 `valid_next_actions=[...]` (closed variant 유래) |
| 정적 프로토콜/사용법 문서 | 유지 | MCP `instructions`의 워크플로 문자열, tool description, help registry, voice 모드별 계약(모드당 바이트 고정) |
| 코드 원저작 행동 명령 (채널 불문) | **제거** (Commit 3) | "Continue this task this turn...", `keeper_next_actions`, "ACTION: Resume...", "Do not claim that you checked..." — 지시는 config/prompts 문서로. handoff의 "Suggested next step"은 이전 keeper가 작성한 콘텐츠 릴레이라 유지 |


## 검증

- `lib/` 전체에서 처방 문구·`suggested_next` 잔여 참조 0건 (rg 전수).
- `test_warn_root_causes.ml:263`의 "No task currently assigned" 부분 문자열 단언은 유지된 문구로 계속 통과.
- dune 빌드/테스트는 CI에서 수행 (운영 원칙). push는 CI 기아 방지 위해 커밋당 1회로 배치.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HA6GposPqQteSu8fw1nvS
