### PR TITLE
fix(keeper): retire a spent Gate grant replay without spending a turn

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -422,11 +422,18 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
     true
 ;;
 
-type terminal_schedule_reconciliation =
-  | Not_terminal_schedule
-  | Terminal_schedule_acknowledged
+(* A selection can be ready to intake and still have nothing left for a turn to
+   do, because the work it refers to settled elsewhere. Delivering one costs a
+   full turn and leaves the entry at the queue head, so a turn that checkpoints
+   instead of completing re-reads the same entry on the next cycle and the
+   Keeper makes no progress for as long as that entry stays spent. Retire them
+   here, before a turn is spent on them. *)
+type spent_selection_reconciliation =
+  | Selection_actionable
+  | Spent_schedule_acknowledged
+  | Spent_grant_replay_acknowledged
 
-let reconcile_terminal_schedule_selection ~config ~keeper_name selection =
+let reconcile_spent_selection ~config ~keeper_name selection =
   match
     selection.Keeper_registry_event_queue.kind,
     selection.Keeper_registry_event_queue.stimuli
@@ -466,7 +473,7 @@ let reconcile_terminal_schedule_selection ~config ~keeper_name selection =
            with
            | Error message ->
              Error ("schedule terminal reconciliation ack failed: " ^ message)
-           | Ok () -> Ok Terminal_schedule_acknowledged)
+           | Ok () -> Ok Spent_schedule_acknowledged)
         | Some
             { Schedule_domain.status =
                 ( Schedule_domain.Execution_running
@@ -474,10 +481,43 @@ let reconcile_terminal_schedule_selection ~config ~keeper_name selection =
             ; _
             }
         | None ->
-          Ok Not_terminal_schedule))
+          Ok Selection_actionable))
+  | Keeper_event_queue_persistence.Single,
+    [ { Keeper_event_queue.payload =
+          Hitl_resolved { approval_id; decision = Keeper_event_queue.Hitl_approved; _ }
+      ; _
+      }
+    ] ->
+    (* An approved grant is one-shot. Once consumed, this wake authorizes
+       nothing further — [Keeper_unified_turn] renders it as "authorization
+       already consumed" — so the turn it costs can only observe that fact and
+       re-enter the queue behind the same entry. Observed 2026-07-28: one
+       consumed grant held a Keeper's queue head while 42 stimuli accumulated
+       behind it, 0 consumed all day, ~204k input tokens burned every 45s.
+
+       No lock: consumption is monotonic. A state read as [Resolution_consumed]
+       never returns to unconsumed, so the ACK cannot race a grant becoming
+       usable again. A read error leaves the entry actionable, which keeps a
+       transient journal failure from discarding a live grant. *)
+    (match Keeper_approval_queue.approved_resolution_state
+             ~base_path:config.Workspace_utils.base_path
+             ~id:approval_id
+     with
+     | Ok Keeper_approval_queue.Resolution_consumed ->
+       (match
+          Keeper_registry_event_queue.ack_pending_result
+            ~base_path:config.Workspace_utils.base_path
+            keeper_name
+            ~selection
+        with
+        | Error message ->
+          Error ("spent grant replay ack failed: " ^ message)
+        | Ok () -> Ok Spent_grant_replay_acknowledged)
+     | Ok Keeper_approval_queue.Resolution_unconsumed | Error _ ->
+       Ok Selection_actionable)
   | Keeper_event_queue_persistence.Single, _
   | Keeper_event_queue_persistence.Board_batch, _ ->
-    Ok Not_terminal_schedule
+    Ok Selection_actionable
 ;;
 
 let heartbeat_event_intake
@@ -498,27 +538,30 @@ let heartbeat_event_intake
       keeper_name
       ~ready:(stimulus_ready_for_intake ~base_path)
   in
-  let rec select_pending_after_terminal_reconciliation () =
+  let rec select_pending_after_spent_reconciliation () =
     match select_pending () with
     | Error _ as error -> error
     | Ok None as empty -> empty
     | Ok (Some selection) ->
       (match
-         reconcile_terminal_schedule_selection
-           ~config:ctx.config
-           ~keeper_name
-           selection
+         reconcile_spent_selection ~config:ctx.config ~keeper_name selection
        with
        | Error message -> Error message
-       | Ok Not_terminal_schedule -> Ok (Some selection)
-       | Ok Terminal_schedule_acknowledged ->
+       | Ok Selection_actionable -> Ok (Some selection)
+       | Ok Spent_schedule_acknowledged ->
          Log.Keeper.info
            "turn entry: acknowledged already-terminal scheduled occurrence \
             without duplicate turn keeper=%s"
            keeper_name;
-         select_pending_after_terminal_reconciliation ())
+         select_pending_after_spent_reconciliation ()
+       | Ok Spent_grant_replay_acknowledged ->
+         Log.Keeper.info
+           "turn entry: acknowledged spent Gate grant replay without a turn \
+            keeper=%s"
+           keeper_name;
+         select_pending_after_spent_reconciliation ())
   in
-  let pending_selection = select_pending_after_terminal_reconciliation () in
+  let pending_selection = select_pending_after_spent_reconciliation () in
   let queued_observations, consumed_stimuli, pending_selection, event_queue_intake_error =
     match pending_selection with
     | Error message ->

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -105,18 +105,28 @@ val consume_board_stimulus_batch
   -> Keeper_event_queue.stimulus list
   -> stimulus_intake_result
 
-type terminal_schedule_reconciliation =
-  | Not_terminal_schedule
-  | Terminal_schedule_acknowledged
+type spent_selection_reconciliation =
+  | Selection_actionable
+  | Spent_schedule_acknowledged
+  | Spent_grant_replay_acknowledged
 
-val reconcile_terminal_schedule_selection
+val reconcile_spent_selection
   :  config:Workspace_utils.config
   -> keeper_name:string
   -> Keeper_registry_event_queue.pending_selection
-  -> (terminal_schedule_reconciliation, string) result
-(** Atomically acknowledges an exact schedule stimulus only when its execution
-    is terminal. The schedule ledger remains locked through the queue ACK, so a
-    same-occurrence retry cannot start between the observation and deletion. *)
+  -> (spent_selection_reconciliation, string) result
+(** Acknowledges a selection whose work has already settled elsewhere, so no
+    turn is spent re-observing it. Two kinds settle that way.
+
+    An exact schedule stimulus is acknowledged only when its execution is
+    terminal; the schedule ledger stays locked through the queue ACK, so a
+    same-occurrence retry cannot start between the observation and deletion.
+
+    An approved Gate resolution is acknowledged once its one-shot grant is
+    consumed, because the replay then authorizes nothing and a turn spent on it
+    can only re-read the same entry. That path takes no lock: consumption is
+    monotonic, so a consumed state cannot revert to usable. A read error leaves
+    the selection actionable rather than discarding a possibly live grant. *)
 
 (** [heartbeat_event_intake ~ctx ~meta_after_triage
      ~pending_board_events]

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -805,14 +805,16 @@ let test_terminal_reconciliation_before_retry_recreates_wake () =
     (Schedule_runner.dispatch_status_to_string (List.hd first.dispatches).status);
   let selection = pending_selection_exn ~base_path ~keeper_name in
   (match
-     Keeper_heartbeat_stimulus_intake.reconcile_terminal_schedule_selection
+     Keeper_heartbeat_stimulus_intake.reconcile_spent_selection
        ~config
        ~keeper_name
        selection
    with
-   | Ok Keeper_heartbeat_stimulus_intake.Terminal_schedule_acknowledged -> ()
-   | Ok Keeper_heartbeat_stimulus_intake.Not_terminal_schedule ->
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_schedule_acknowledged -> ()
+   | Ok Keeper_heartbeat_stimulus_intake.Selection_actionable ->
      fail "failed occurrence was not reconciled as terminal"
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_grant_replay_acknowledged ->
+     fail "schedule selection was reconciled as a spent grant replay"
    | Error detail -> fail detail);
   check int "terminal wake removed before retry" 0
     (Keeper_registry_event_queue.snapshot ~base_path keeper_name
@@ -856,14 +858,16 @@ let test_retry_before_terminal_reconciliation_retains_wake () =
     (Schedule_runner.dispatch_status_to_string (List.hd retried.dispatches).status);
   let selection = pending_selection_exn ~base_path ~keeper_name in
   (match
-     Keeper_heartbeat_stimulus_intake.reconcile_terminal_schedule_selection
+     Keeper_heartbeat_stimulus_intake.reconcile_spent_selection
        ~config
        ~keeper_name
        selection
    with
-   | Ok Keeper_heartbeat_stimulus_intake.Not_terminal_schedule -> ()
-   | Ok Keeper_heartbeat_stimulus_intake.Terminal_schedule_acknowledged ->
+   | Ok Keeper_heartbeat_stimulus_intake.Selection_actionable -> ()
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_schedule_acknowledged ->
      fail "non-terminal retry wake was acknowledged"
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_grant_replay_acknowledged ->
+     fail "schedule selection was reconciled as a spent grant replay"
    | Error detail -> fail detail);
   check int "retry wake remains pending" 1
     (Keeper_registry_event_queue.snapshot ~base_path keeper_name
@@ -1236,6 +1240,114 @@ let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
     (List.mem "../bad" queue_discovery.keeper_names)
 ;;
 
+(* A resolved approval wakes its Keeper so it re-evaluates immediately. Once the
+   one-shot grant is consumed, that wake carries no authorization, so a turn
+   spent on it can only observe the fact — and a turn that checkpoints instead
+   of completing leaves the entry at the queue head to be delivered again.
+   Reconciliation retires the spent replay before a turn is spent on it. *)
+let approved_grant_fixture ~base_path ~keeper_name ~input =
+  (match Keeper_approval_queue.install_persistence ~base_path with
+   | Ok _ -> ()
+   | Error error -> fail (Keeper_approval_queue.install_error_to_string error));
+  let approval_id =
+    match
+      Keeper_approval_queue.submit_pending
+        ~keeper_name
+        ~tool_name:"external-effect"
+        ~input
+        ~base_path
+        ()
+    with
+    | Ok id -> id
+    | Error error -> fail (Keeper_approval_queue.storage_error_to_string error)
+  in
+  (match
+     Keeper_approval_queue.resolve_with_policy
+       ~base_path
+       ~id:approval_id
+       ~decision:Keeper_approval_queue.Decision.Approve
+       ()
+   with
+   | Ok _ -> ()
+   | Error error -> fail (Keeper_approval_queue.resolve_error_to_string error));
+  approval_id
+;;
+
+(* Resolving an approval for a Keeper that holds no live lane persists the
+   [Hitl_resolved] wake for replay, which is the exact queue state this
+   reconciliation reads. Assert it rather than enqueueing a second copy. *)
+let check_single_queued_replay ~base_path ~keeper_name =
+  check int "resolution queued exactly one replay" 1
+    (Keeper_registry_event_queue.snapshot ~base_path keeper_name
+     |> Keeper_event_queue.length)
+;;
+
+let test_spent_grant_replay_retires_without_a_turn () =
+  with_workspace
+  @@ fun config ->
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_name = "spent-grant-keeper" in
+  let input = `Assoc [ "target", `String "spent-grant" ] in
+  let approval_id = approved_grant_fixture ~base_path ~keeper_name ~input in
+  (match
+     Keeper_approval_queue.consume_approved_resolution
+       ~base_path
+       ~id:approval_id
+       ~keeper_name
+       ~tool_name:"external-effect"
+       ~input
+   with
+   | Ok Keeper_approval_queue.Consumption_committed -> ()
+   | Ok Keeper_approval_queue.Consumption_already_committed ->
+     fail "grant was already consumed before the test consumed it"
+   | Ok Keeper_approval_queue.Consumption_not_matching ->
+     fail "exact grant did not match its own request"
+   | Error error -> fail (Keeper_approval_queue.grant_error_to_string error));
+  check_single_queued_replay ~base_path ~keeper_name;
+  let selection = pending_selection_exn ~base_path ~keeper_name in
+  (match
+     Keeper_heartbeat_stimulus_intake.reconcile_spent_selection
+       ~config
+       ~keeper_name
+       selection
+   with
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_grant_replay_acknowledged -> ()
+   | Ok Keeper_heartbeat_stimulus_intake.Selection_actionable ->
+     fail "spent grant replay was left for a turn to observe"
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_schedule_acknowledged ->
+     fail "grant replay was reconciled as a schedule occurrence"
+   | Error detail -> fail detail);
+  check int "spent grant replay left the queue" 0
+    (Keeper_registry_event_queue.snapshot ~base_path keeper_name
+     |> Keeper_event_queue.length)
+;;
+
+let test_unconsumed_grant_replay_stays_actionable () =
+  with_workspace
+  @@ fun config ->
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_name = "live-grant-keeper" in
+  let input = `Assoc [ "target", `String "live-grant" ] in
+  ignore (approved_grant_fixture ~base_path ~keeper_name ~input : string);
+  check_single_queued_replay ~base_path ~keeper_name;
+  let selection = pending_selection_exn ~base_path ~keeper_name in
+  (match
+     Keeper_heartbeat_stimulus_intake.reconcile_spent_selection
+       ~config
+       ~keeper_name
+       selection
+   with
+   | Ok Keeper_heartbeat_stimulus_intake.Selection_actionable -> ()
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_grant_replay_acknowledged ->
+     fail "an unconsumed grant was discarded before its Keeper could use it"
+   | Ok Keeper_heartbeat_stimulus_intake.Spent_schedule_acknowledged ->
+     fail "grant replay was reconciled as a schedule occurrence"
+   | Error detail -> fail detail);
+  check int "unconsumed grant replay stays queued" 1
+    (Keeper_registry_event_queue.snapshot ~base_path keeper_name
+     |> Keeper_event_queue.length)
+;;
+
 let () =
   run "Schedule_consumer_dispatch"
     [ ( "keeper_wake"
@@ -1280,6 +1392,10 @@ let () =
         ; test_case "keeper wake receipt decoder rejects noncanonical shapes"
             `Quick
             test_keeper_wake_receipt_decoder_rejects_noncanonical_shapes
+        ; test_case "spent grant replay retires without a turn" `Quick
+            test_spent_grant_replay_retires_without_a_turn
+        ; test_case "unconsumed grant replay stays actionable" `Quick
+            test_unconsumed_grant_replay_stays_actionable
         ] )
     ]
 ;;


### PR DESCRIPTION
## What changed

Intake retires a `Hitl_resolved` wake whose one-shot grant is already consumed, before a turn is spent on it. This joins the already-terminal schedule occurrence that the same reconciliation already retired, so the function and its result type are now named for what they cover: `reconcile_spent_selection` / `spent_selection_reconciliation`.

## Why

A resolved approval wakes its Keeper so it re-evaluates immediately instead of waiting for an unrelated stimulus. Once the grant is consumed, that wake authorizes nothing — `Keeper_unified_turn` renders it as:

```
- state: authorization already consumed
This replay grants no authorization. Continue independent work
```

The Keeper can act on that in no way at all, but the wake still costs a full turn. And a turn that ends in a checkpoint rather than a completion does not ack its source, so the entry stays at the queue head and is delivered again next cycle.

## Live evidence (2026-07-28, production runtime)

One consumed grant, `appr_e5aaf85a-…`, held `lane-smith`'s queue head:

| | |
|---|---|
| pending stimuli | 42 (33 `hitl_resolved`, growing) |
| `consumed stimulus` | **0** for the whole day |
| loop period | ~45s |
| input tokens per turn | 204,549 |
| cumulative input tokens | 65,293,503 |

The five most recent turns carried byte-identical prompts naming the same approval id, and each output was the Keeper planning to retry: *"Execute가 이번에 진짜로 작동하는지 확인"*.

It did not recover on its own. Ten minutes with **no** external input grew the queue from 36 to 42 while `consumed stimulus` stayed at 0 — so this is not a chat-lane contention artifact.

## Design notes

- **No lock on the grant path.** Consumption is monotonic: a state read as `Resolution_consumed` never reverts to unconsumed, so the ACK cannot race a grant becoming usable again. The schedule path keeps its lock because a same-occurrence retry genuinely can start between observation and deletion.
- **Read errors leave the selection actionable.** A transient journal failure must not discard a live grant.
- **Only `Hitl_approved` is reconciled.** `Hitl_rejected` and `Hitl_edited` carry a rationale the Keeper can still act on; only an approval produces a one-shot grant.
- **Ack timing for checkpointed turns is unchanged.** A wake whose work is still live is still retained for the next cycle.

## Known gap this does not close

The general defect is that ack timing does not distinguish *informational* stimuli (`Hitl_resolved`, `Bg_completed`, `Fusion_completed` — delivery is the whole purpose) from *work* stimuli (`Schedule_due`, `Board_signal`, `Goal_assigned` — completion is). Today both settle through one selection-level `should_ack`, so any informational wake that a checkpointing turn receives is re-delivered indefinitely. This PR removes the one case that is provably unactionable; splitting ack semantics per stimulus kind is a larger change and is not attempted here.

## Validation

- `test_schedule_consumer_dispatch.exe` — 19/19 (17 existing + 2 new)
- new: `spent grant replay retires without a turn`, `unconsumed grant replay stays actionable`
- the new tests drive the real path — `resolve_with_policy` itself queues the replay for an unregistered lane, so the fixture asserts that single queued entry rather than enqueueing its own
- `ocamlformat --check` on all three changed files; `scripts/check-ssot.sh`
