### PR TITLE
test: 단정문에 도달하지 못하던 keeper meta fixture 10개 복구 (37 실패 → 6)

### DIFF
--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -8,10 +8,7 @@ let make_meta ?(allowed_paths = []) ~name () =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
         ("trace_id", `String ("trace-" ^ name));
-        ("sandbox_profile", `String "local");
-        ("network_mode", `String "inherit");
         ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
       ]
   in

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -77,16 +77,13 @@ let make_meta ?(sandbox = Keeper_types_profile_sandbox.Local) name =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
-        ("trace_id", `String ("trace-" ^ name));
         ("allowed_paths", `List [ `String "*" ]);
         ("always_allow", `Bool true);
-        ( "sandbox_profile",
-          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok m -> m
+  | Ok m ->
+    { m with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
   | Error e -> Alcotest.fail e
 
 let with_eio_fs f =

--- a/test/test_keeper_path_ssot.ml
+++ b/test/test_keeper_path_ssot.ml
@@ -40,14 +40,11 @@ let make_meta ~name ~sandbox =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
-        ("trace_id", `String ("trace-" ^ name));
-        ( "sandbox_profile",
-          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok m -> m
+  | Ok m ->
+    { m with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
   | Error e -> Alcotest.fail e
 
 let make_config () =

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -41,13 +41,8 @@ let make_meta ?(sandbox_profile = Keeper_types_profile_sandbox.Local) name =
   let json =
     `Assoc
       [ "name", `String name
-      ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
       ; "allowed_paths", `List [ `String "*" ]
-      ; ( "sandbox_profile"
-        , `String
-            (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
-        )
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -44,15 +44,12 @@ let make_meta ?(allowed_paths = []) ~name ~sandbox () =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String name);
-        ("trace_id", `String "test-trace-containment");
-        ("sandbox_profile",
-         `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox));
         ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok m -> m
+  | Ok m ->
+    { m with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
   | Error e -> Alcotest.fail e
 
 (* ── Tests ───────────────────────────────────────────────────────── *)

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -102,14 +102,11 @@ let make_meta ~name ~sandbox =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
-        ("trace_id", `String ("trace-" ^ name));
-        ( "sandbox_profile",
-          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok m -> m
+  | Ok m ->
+    { m with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
   | Error e -> Alcotest.fail e
 
 (* ── should_route_read profile policy ────────────────────────────── *)

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -31,15 +31,13 @@ let make_meta ~sandbox : Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [ "name", `String "runner-test"
-      ; "agent_name", `String "runner-test-agent"
       ; "trace_id", `String "runner-test-trace"
       ; "allowed_paths", `List [ `String "*" ]
-      ; ( "sandbox_profile",
-          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
   | Error e -> Alcotest.fail e
 
 module Fake_backend = struct

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -68,15 +68,12 @@ let make_meta ~name ~sandbox =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
-        ("trace_id", `String ("trace-" ^ name));
         ("allowed_paths", `List [ `String "*" ]);
-        ( "sandbox_profile",
-          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
   | Error e -> Alcotest.fail e
 
 let with_eio_fs f =

--- a/test/test_keeper_tool_search_files_via_field.ml
+++ b/test/test_keeper_tool_search_files_via_field.ml
@@ -40,10 +40,8 @@ let make_meta ~name =
     `Assoc
       [
         ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
         ("trace_id", `String ("trace-" ^ name));
         ("allowed_paths", `List [ `String "*" ]);
-        ("sandbox_profile", `String "local");
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -91,10 +91,7 @@ let make_meta
   let json =
     `Assoc
       [ "name", `String name
-      ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; ( "sandbox_profile"
-        , `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with


### PR DESCRIPTION
## 10개 스위트가 단정문에 도달하지 못한 채 실패하고 있었습니다

fixture 가 keeper_meta 를 만들 때 `sandbox_profile` 을 meta JSON 에 넣고 `agent_name` 을 손으로 철자합니다. 둘 다 현재 계약에서 통과하지 못합니다.

- `sandbox_profile` 은 **persisted 스키마의 필드가 아닙니다** — 파서가 default 로 seed 하고 실제 값은 keeper TOML 에서 옵니다. closed 스키마는 미지 필드를 거부합니다 (`fields outside the current schema: sandbox_profile`)
- 손으로 쓴 `agent_name` 은 canonical identity 검사에 걸립니다 (`agent_name does not match canonical keeper identity`)

따라서 해당 파일의 **모든 케이스가 `make_meta` 안에서 죽었습니다.** 스키마가 닫힌 시점부터 지금까지 아무것도 검증하지 않고 있었고, CI 가 863개 중 5개만 실행하므로(#26113) 드러나지 않았습니다.

## 수정

`name` 만 넘기고 `agent_name` / `trace_id` 는 fixture 의 정규 규칙이 유도하게 합니다. 특정 백엔드가 필요한 스위트는 **레코드 필드**로 `sandbox_profile` 을 설정합니다.

```ocaml
match Masc_test_deps.meta_of_json_fixture json with
| Ok m -> { m with Masc.Keeper_meta_contract.sandbox_profile = sandbox }
```

## 결과 (origin/main `f73f057583` 기준 로컬 실행)

| 스위트 | 기준선 | 수정 후 |
|---|---|---|
| `sandbox_containment` | 6 실패 | **6/6 통과** |
| `sandbox_read_backend` | 26 실패 | **48/48 통과** |
| `sandbox_runner` | 5 실패 | **5/5 통과** |
| `path_ssot` | 6 실패 | **9/9 통과** |
| `allowed_paths` | 2 실패 | **6/6 통과** |
| `tool_search_files_containment` | | **15/15 통과** |
| `tool_search_files_via_field` | | **2/2 통과** |
| `visible_path_projection` | | **8/8 통과** |
| `fs_edit_patch` | 26 실패 | 5 실패 |
| `run_tools_hooks` | 4 실패 | 1 실패 |

마지막 두 개는 fixture 형태가 아닌 **실제 단정 실패**가 남습니다. 고치지 않았습니다 — 다만 이제 fixture 에 가려지지 않고 보입니다.

## 범위에서 뺀 것

`test_keeper_tool_read_window.ml` 과 `test_keeper_turn_up_args.ml` 은 **되돌렸습니다.** 일괄 편집의 다행 항목 정규식이 닫는 토큰을 삼켰고, `turn_up_args` 는 Alcotest 등록 목록 일부까지 손상됐습니다. 손으로 복구하는 대신 원상복구했으므로 두 파일은 여전히 낡은 fixture 를 가지고 있습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build @check` | exit 0 |
| 기준선 대조 | origin/main 에서 동일 스위트 실행해 before 수치 확보 |

Refs #26113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
