### PR TITLE
fix(keeper): close replay, stimulus, and tool-search context loss

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -70,6 +70,26 @@ let drop_leading_wake_marker ~user_turn_record current_suffix =
     -> current_suffix
 ;;
 
+let is_trailing_blank_assistant (message : Agent_sdk.Types.message) =
+  match message.role, message.content with
+  | Agent_sdk.Types.Assistant, [] -> true
+  | Agent_sdk.Types.Assistant, blocks ->
+    List.for_all
+      (function
+        | Agent_sdk.Types.Text text -> String.trim text = ""
+        | _ -> false)
+      blocks
+  | _, _ -> false
+;;
+
+let drop_trailing_blank_assistants messages =
+  let rec drop = function
+    | message :: rest when is_trailing_blank_assistant message -> drop rest
+    | reversed -> List.rev reversed
+  in
+  drop (List.rev messages)
+;;
+
 let canonical_success_replay_checkpoint
       ~(history_messages : Agent_sdk.Types.message list)
       ~(session_id : string)
@@ -82,17 +102,31 @@ let canonical_success_replay_checkpoint
       ~prefix:history_messages
       checkpoint.Agent_sdk.Checkpoint.messages
   with
-  | Ok current_suffix ->
-    let dropped_current_turn_replay = current_suffix <> [] in
+  | Ok original_current_suffix ->
     let current_suffix =
-      drop_leading_wake_marker ~user_turn_record current_suffix
+      drop_leading_wake_marker ~user_turn_record original_current_suffix
+    in
+    (* A blank visible response is not authority to erase typed replay. The
+       suffix may contain an actual user input, ToolUse/ToolResult pair,
+       thinking, or media whose effect has already happened. Remove only an
+       inert trailing Assistant shell; the typed skipped-wake rule above owns
+       the autonomous marker independently. *)
+    let current_suffix =
+      if String.trim response_text = ""
+      then drop_trailing_blank_assistants current_suffix
+      else current_suffix
+    in
+    let replay_suffix_pruned =
+      if current_suffix <> original_current_suffix
+      then Some Canonical_success_replay
+      else None
     in
     let checkpoint =
       if String.trim response_text = ""
       then
         { checkpoint with
           Agent_sdk.Checkpoint.session_id
-        ; messages = history_messages
+        ; messages = history_messages @ current_suffix
         ; working_context = None
         }
       else
@@ -119,9 +153,7 @@ let canonical_success_replay_checkpoint
     in
     Ok
       ( checkpoint
-      , if dropped_current_turn_replay
-        then Some Canonical_success_replay
-        else None )
+      , replay_suffix_pruned )
   | Error _ ->
     Error
       "refusing to save checkpoint: canonical replay persistence requires \

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -55,7 +55,7 @@ type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_registry_event_queue.pending_selection option;
-  event_queue_claim_error : string option;
+  event_queue_intake_error : Stimulus_intake.event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
@@ -84,6 +84,10 @@ type keepalive_scheduling_decision = Keeper_heartbeat_loop_scheduling.keepalive_
 }
 
 let decide_keepalive_scheduling = Keeper_heartbeat_loop_scheduling.decide_keepalive_scheduling
+
+let should_run_turn_after_event_intake ~scheduled ~event_queue_intake_error =
+  scheduled && Option.is_none event_queue_intake_error
+;;
 
 let provider_timeout_observation_reasons =
   Observations.provider_timeout_observation_reasons
@@ -573,9 +577,15 @@ let run_keepalive_unified_turn
       let manual_compaction_requested =
         manual_compaction_requested_of_stimuli event_intake.consumed_stimuli
       in
-      (match event_intake.event_queue_claim_error with
+      (match event_intake.event_queue_intake_error with
        | None -> ()
-       | Some message -> record_settlement_failure message);
+       | Some error
+         when
+           Stimulus_intake.event_queue_intake_error_counts_as_cycle_failure
+             error ->
+         record_settlement_failure
+           (Stimulus_intake.event_queue_intake_error_to_string error)
+       | Some _ -> ());
       let pending_board_events = event_intake.pending_board_events in
       let obs =
         Keeper_world_observation.observe
@@ -596,8 +606,18 @@ let run_keepalive_unified_turn
          stuck behind sticky blockers. Failed turns record evidence via
          Keeper_registry; recovery is autonomous (next turn's observation)
          or operator-driven (board/keeper_chat), not blocker-driven. *)
-      let should_run_turn = scheduling.should_run_turn in
-      let verdict_strs = scheduling.verdict_reasons in
+      let should_run_turn =
+        should_run_turn_after_event_intake
+          ~scheduled:scheduling.should_run_turn
+          ~event_queue_intake_error:event_intake.event_queue_intake_error
+      in
+      let verdict_strs =
+        match event_intake.event_queue_intake_error with
+        | None -> scheduling.verdict_reasons
+        | Some error ->
+          Stimulus_intake.event_queue_intake_error_reason_label error
+          :: scheduling.verdict_reasons
+      in
       let channel_str = scheduling.channel in
       if not should_run_turn
       then (
@@ -659,7 +679,7 @@ let run_keepalive_unified_turn
           "keepalive turn not scheduled for %s: should_run=%b channel=%s reasons=[%s] \
            idle=%ds since_last=%s%s"
           meta_after_triage.name
-          turn_decision.should_run
+          should_run_turn
           channel_str
           (String.concat "," verdict_strs)
           obs.idle_seconds

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -59,7 +59,8 @@ type heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_registry_event_queue.pending_selection option;
-  event_queue_claim_error : string option;
+  event_queue_intake_error :
+    Keeper_heartbeat_stimulus_intake.event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
@@ -77,6 +78,14 @@ val heartbeat_event_intake :
   meta_after_triage:keeper_meta ->
   pending_board_events:Keeper_world_observation.pending_board_event list ->
   heartbeat_event_intake
+
+(** Source-authority gate applied after world scheduling. A selected stimulus
+    whose intake failed must remain pending and cannot reach the provider. *)
+val should_run_turn_after_event_intake :
+  scheduled:bool ->
+  event_queue_intake_error:
+    Keeper_heartbeat_stimulus_intake.event_queue_intake_error option ->
+  bool
 
 type keepalive_scheduling_decision = {
   turn_decision : Keeper_world_observation.keeper_cycle_decision;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -22,28 +22,109 @@ let stimulus_urgency_to_string = function
   | Keeper_event_queue.Low -> "low"
 ;;
 
-let pending_board_event_of_stimulus ~meta_after_triage stim =
-  Keeper_world_observation.pending_board_event_of_stimulus
-    ~meta:meta_after_triage
-    stim
+let forced_transient_board_reads_for_test : int Atomic.t = Atomic.make 0
+
+module For_testing = struct
+  let force_transient_board_reads count =
+    Atomic.set forced_transient_board_reads_for_test (Int.max 0 count)
+  ;;
+end
+
+let consume_forced_transient_board_read () =
+  let rec loop () =
+    let remaining = Atomic.get forced_transient_board_reads_for_test in
+    if remaining <= 0
+    then false
+    else
+      Atomic.compare_and_set
+        forced_transient_board_reads_for_test
+        remaining
+        (remaining - 1)
+      || loop ()
+  in
+  loop ()
 ;;
 
-(* Board-unavailable-result: the intake layer is where the poison/transient
-   distinction is acted on (Keeper_world_observation only reports the read
-   failure). Both dispositions return [] for this turn — the leased stimulus
-   is treated as consumed either way; see [keeper_heartbeat_loop.ml]'s
-   settlement path, which acks the claimed lease based on the turn outcome,
-   not on whether any one board rendering succeeded. Permanent unavailability
-   (the dominant real cause, e.g. a swept post) must never resurface, so
-   dropping it is the fix. Transient unavailability is logged distinctly so
-   operators can tell the two apart, but — unlike the cursor-based scan path
-   in [Keeper_world_observation.collect_board_events], which can locally
-   retain its cursor — this queued-stimulus path has no per-stimulus
-   requeue lever below the whole-lease Ack/Requeue decision, so a genuine
-   retry for this one stimulus is not wired here. *)
+let pending_board_event_of_stimulus ~meta_after_triage stim =
+  match stim.Keeper_event_queue.payload with
+  | (Keeper_event_queue.Board_signal _ | Keeper_event_queue.Board_attention _)
+    when consume_forced_transient_board_read () ->
+    Error
+      { Keeper_world_observation_board_signal.operation =
+          Keeper_world_observation_board_signal.Get_post
+      ; post_id = stim.post_id
+      ; error = Board.Io_error "forced transient Board stimulus read failure"
+      }
+  | Keeper_event_queue.Board_signal _
+  | Keeper_event_queue.Board_attention _
+  | Keeper_event_queue.Bootstrap
+  | Keeper_event_queue.Fusion_completed _
+  | Keeper_event_queue.Bg_completed _
+  | Keeper_event_queue.Schedule_due _
+  | Keeper_event_queue.Connector_attention _
+  | Keeper_event_queue.Hitl_resolved _
+  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
+    Keeper_world_observation.pending_board_event_of_stimulus
+      ~meta:meta_after_triage
+      stim
+;;
+
+type stimulus_intake_result =
+  | Stimulus_consumed of Keeper_world_observation.pending_board_event list
+  | Stimulus_retry_later of
+      Keeper_world_observation_board_signal.board_unavailable
+
+type event_queue_intake_error =
+  | Pending_selection_failed of string
+  | Invalid_single_selection of { selected_count : int }
+  | Transient_board_read of
+      Keeper_world_observation_board_signal.board_unavailable
+
+let event_queue_intake_error_to_string = function
+  | Pending_selection_failed detail ->
+    "event queue pending selection failed: " ^ detail
+  | Invalid_single_selection { selected_count } ->
+    Printf.sprintf
+      "event queue Single selection contained %d stimuli instead of exactly one"
+      selected_count
+  | Transient_board_read unavailable ->
+    "event queue stimulus intake retry: "
+    ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable
+;;
+
+let event_queue_intake_error_reason_label = function
+  | Pending_selection_failed _ -> "event_queue_selection_failed"
+  | Invalid_single_selection _ -> "event_queue_selection_invalid"
+  | Transient_board_read _ -> "event_queue_transient_board_read"
+;;
+
+let event_queue_intake_error_counts_as_cycle_failure = function
+  | Pending_selection_failed _ | Invalid_single_selection _ -> true
+  | Transient_board_read _ -> false
+;;
+
+let classify_pending_board_event_result = function
+  | Ok events_opt -> Stimulus_consumed (Option.to_list events_opt)
+  | Error
+      (unavailable : Keeper_world_observation_board_signal.board_unavailable) ->
+    (match
+       Keeper_world_observation_board_signal.disposition_of_unavailable unavailable
+     with
+     | Keeper_world_observation_board_signal.Permanent -> Stimulus_consumed []
+     | Keeper_world_observation_board_signal.Transient ->
+       Stimulus_retry_later unavailable)
+;;
+
+(* Board-unavailable-result: permanent poison is consumed so a swept post
+   cannot crash-loop forever. A transient environment failure remains a typed
+   retry; the queue selection came from [peek_when_result], so retaining it
+   requires no mutation — only withholding consumption and ACK. *)
 let pending_board_events_of_stimulus_result ~meta_after_triage stim =
-  match pending_board_event_of_stimulus ~meta_after_triage stim with
-  | Ok events_opt -> Option.to_list events_opt
+  let read_result = pending_board_event_of_stimulus ~meta_after_triage stim in
+  match read_result with
+  | Ok _ -> classify_pending_board_event_result read_result
   | Error (unavailable : Keeper_world_observation_board_signal.board_unavailable) ->
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string ObservationQueryFailures)
@@ -62,12 +143,12 @@ let pending_board_events_of_stimulus_result ~meta_after_triage stim =
          (Keeper_world_observation_board_signal.unavailable_to_string unavailable)
      | Keeper_world_observation_board_signal.Transient ->
        Log.Keeper.warn
-         "stimulus intake: board read transiently unavailable, dropping this turn's \
-          rendering stimulus_id=%s keeper=%s: %s"
+         "stimulus intake: board read transiently unavailable, retaining exact \
+          pending source stimulus_id=%s keeper=%s: %s"
          stim.Keeper_event_queue.post_id
          meta_after_triage.name
          (Keeper_world_observation_board_signal.unavailable_to_string unavailable));
-    []
+    classify_pending_board_event_result read_result
 ;;
 
 let record_event_queue_stimulus_turn_started
@@ -96,7 +177,7 @@ type heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_registry_event_queue.pending_selection option;
-  event_queue_claim_error : string option;
+  event_queue_intake_error : event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
@@ -146,137 +227,142 @@ let consume_single_heartbeat_stimulus
       (stim : Keeper_event_queue.stimulus)
   =
   let class_str = Keeper_event_queue.payload_kind_label stim.payload in
-  Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string StimulusConsumed)
-    ~labels:[ "keeper", meta_after_triage.name; "class", class_str ]
-    ();
-  Log.Keeper.info
-    "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=%s (keeper=%s)"
-    stim.post_id
-    (stimulus_urgency_to_string stim.urgency)
-    class_str
-    meta_after_triage.name;
-  match stim.payload with
-  | Keeper_event_queue.Board_signal _ | Keeper_event_queue.Board_attention _ ->
-    pending_board_events_of_stimulus_result ~meta_after_triage stim
-  | Keeper_event_queue.Fusion_completed c ->
-    (* RFC-0266: an async fusion deliberation finished and woke this keeper.
-       Surface the resolved answer as a pending_board_event so this turn acts
-       on it (a non-empty list, unlike Bootstrap which
-       inject nothing — returning [] here would silently drop the result). *)
-    let terminal =
-      match c.terminal with
-      | Keeper_event_queue.Fusion_succeeded _ -> "succeeded"
-      | Keeper_event_queue.Fusion_failed _ -> "failed"
-      | Keeper_event_queue.Fusion_cancelled -> "cancelled"
-    in
+  let intake_result =
+    match stim.payload with
+    | Keeper_event_queue.Board_signal _ | Keeper_event_queue.Board_attention _ ->
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Fusion_completed c ->
+      (* RFC-0266: an async fusion deliberation finished and woke this keeper.
+         Surface the resolved answer as a pending_board_event so this turn acts
+         on it (a non-empty list, unlike Bootstrap which injects nothing). *)
+      let terminal =
+        match c.terminal with
+        | Keeper_event_queue.Fusion_succeeded _ -> "succeeded"
+        | Keeper_event_queue.Fusion_failed _ -> "failed"
+        | Keeper_event_queue.Fusion_cancelled -> "cancelled"
+      in
+      Log.Keeper.info
+        "turn entry: fusion result delivered run_id=%s terminal=%s (keeper=%s)"
+        c.run_id terminal meta_after_triage.name;
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Bg_completed c ->
+      (* RFC-0290: a background job finished and woke this keeper. Surface the
+         outcome as a pending_board_event so this turn acts on it. *)
+      Log.Keeper.info
+        "turn entry: bg result delivered run_id=%s kind=%s ok=%b (keeper=%s)"
+        c.bg_run_id
+        (Keeper_event_queue.bg_job_kind_to_string c.bg_kind)
+        (match c.bg_outcome with
+         | Keeper_event_queue.Bg_ok _ -> true
+         | Keeper_event_queue.Bg_failed _ -> false)
+        meta_after_triage.name;
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Schedule_due sw ->
+      Log.Keeper.info
+        "turn entry: scheduled wake delivered schedule_id=%s due_at=%.3f (keeper=%s)"
+        sw.schedule_id
+        sw.due_at
+        meta_after_triage.name;
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Goal_assigned ga ->
+      (* RFC-0315 P3 W0: a newly assigned standing objective is actionable
+         work. Promote it to a pending observation so the assignment turn does
+         not wake empty. *)
+      Log.Keeper.info
+        "turn entry: goal assignment delivered goal_id=%s assigned_by=%s (keeper=%s)"
+        ga.ga_goal_id
+        ga.ga_assigned_by
+        meta_after_triage.name;
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Goal_reconciliation_ready ready ->
+      Log.Keeper.info
+        "turn entry: goal reconciliation ready goal_id=%s triggering_task_id=%s \
+         (keeper=%s)"
+        ready.gr_goal_id
+        ready.gr_triggering_task_id
+        meta_after_triage.name;
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Manual_compaction_requested ->
+      Log.Keeper.info
+        "turn entry: manual compaction request delivered (keeper=%s)"
+        meta_after_triage.name;
+      Stimulus_consumed []
+    | Keeper_event_queue.Bootstrap ->
+      Log.Keeper.info
+        "turn entry: bootstrap stimulus consumed (keeper=%s)"
+        meta_after_triage.name;
+      Stimulus_consumed []
+    | Keeper_event_queue.Connector_attention ca ->
+      (* RFC-connector-ambient-attention-wake: the stimulus woke this keeper.
+         The event_id is a pointer only; the message/surface content stays in
+         Keeper_external_attention. Load it here and promote it to a pending
+         observation so the turn has real connector context instead of a
+         contentless wake reason. *)
+      let pending_events =
+        match
+          recorded_attention_item_by_event_id
+            ~base_path:ctx.config.base_path
+            ~keeper_name:meta_after_triage.name
+            ~event_id:ca.event_id
+        with
+        | Some item ->
+          [ Keeper_world_observation.pending_board_event_of_external_attention
+              ~meta:meta_after_triage
+              item
+          ]
+        | None ->
+          Log.Keeper.warn
+            "connector attention stimulus missing recorded item event_id=%s (keeper=%s)"
+            ca.event_id
+            meta_after_triage.name;
+          []
+      in
+      (match
+         Keeper_external_attention.claim_for_turn
+           ~base_path:ctx.config.base_path
+           ~keeper_name:meta_after_triage.name
+           ~event_ids:[ ca.event_id ]
+           ~claim_id:(Printf.sprintf "heartbeat-wake:%s" stim.post_id)
+           ~turn_id:None
+           ()
+       with
+       | Ok () -> ()
+       | Error err ->
+         Log.Keeper.warn
+           "connector attention claim_for_turn failed event_id=%s (keeper=%s): %s"
+           ca.event_id
+           meta_after_triage.name
+           err);
+      Log.Keeper.info
+        "turn entry: connector attention stimulus consumed event_id=%s (keeper=%s)"
+        ca.event_id
+        meta_after_triage.name;
+      Stimulus_consumed pending_events
+    | Keeper_event_queue.Hitl_resolved r ->
+      (* The approval has left the queue, so this cycle no longer skips. There
+         is no observation to fabricate: the typed resolution itself is
+         threaded as cycle context. *)
+      Log.Keeper.info
+        "turn entry: hitl resolution delivered approval=%s decision=%s (keeper=%s)"
+        r.approval_id
+        (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
+        meta_after_triage.name;
+      Stimulus_consumed []
+  in
+  match intake_result with
+  | Stimulus_retry_later _ -> intake_result
+  | Stimulus_consumed _ ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string StimulusConsumed)
+      ~labels:[ "keeper", meta_after_triage.name; "class", class_str ]
+      ();
     Log.Keeper.info
-      "turn entry: fusion result delivered run_id=%s terminal=%s (keeper=%s)"
-      c.run_id terminal meta_after_triage.name;
-    pending_board_events_of_stimulus_result ~meta_after_triage stim
-  | Keeper_event_queue.Bg_completed c ->
-    (* RFC-0290: a background job finished and woke this keeper. Surface the
-       outcome as a pending_board_event so the turn acts on it. Returning []
-       would compile but silently drop the completed job result. *)
-    Log.Keeper.info
-      "turn entry: bg result delivered run_id=%s kind=%s ok=%b (keeper=%s)"
-      c.bg_run_id
-      (Keeper_event_queue.bg_job_kind_to_string c.bg_kind)
-      (match c.bg_outcome with
-       | Keeper_event_queue.Bg_ok _ -> true
-       | Keeper_event_queue.Bg_failed _ -> false)
+      "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=%s (keeper=%s)"
+      stim.post_id
+      (stimulus_urgency_to_string stim.urgency)
+      class_str
       meta_after_triage.name;
-    pending_board_events_of_stimulus_result ~meta_after_triage stim
-  | Keeper_event_queue.Schedule_due sw ->
-    Log.Keeper.info
-      "turn entry: scheduled wake delivered schedule_id=%s due_at=%.3f (keeper=%s)"
-      sw.schedule_id
-      sw.due_at
-      meta_after_triage.name;
-    pending_board_events_of_stimulus_result ~meta_after_triage stim
-  | Keeper_event_queue.Goal_assigned ga ->
-    (* RFC-0315 P3 W0: a newly assigned standing objective is actionable
-       work. Promote it to a pending observation so the assignment turn does
-       not wake empty — returning [] would silently drop the edge. *)
-    Log.Keeper.info
-      "turn entry: goal assignment delivered goal_id=%s assigned_by=%s (keeper=%s)"
-      ga.ga_goal_id
-      ga.ga_assigned_by
-      meta_after_triage.name;
-    pending_board_events_of_stimulus_result ~meta_after_triage stim
-  | Keeper_event_queue.Goal_reconciliation_ready ready ->
-    Log.Keeper.info
-      "turn entry: goal reconciliation ready goal_id=%s triggering_task_id=%s \
-       (keeper=%s)"
-      ready.gr_goal_id
-      ready.gr_triggering_task_id
-      meta_after_triage.name;
-    pending_board_events_of_stimulus_result ~meta_after_triage stim
-  | Keeper_event_queue.Manual_compaction_requested ->
-    Log.Keeper.info
-      "turn entry: manual compaction request delivered (keeper=%s)"
-      meta_after_triage.name;
-    []
-  | Keeper_event_queue.Bootstrap ->
-    Log.Keeper.info
-      "turn entry: bootstrap stimulus consumed (keeper=%s)"
-      meta_after_triage.name;
-    []
-  | Keeper_event_queue.Connector_attention ca ->
-    (* RFC-connector-ambient-attention-wake: the stimulus woke this keeper.
-       The event_id is a pointer only; the message/surface content stays in
-       Keeper_external_attention. Load it here and promote it to a pending
-       observation so the turn has real connector context instead of a
-       contentless wake reason. *)
-    let pending_events =
-      match
-        recorded_attention_item_by_event_id
-          ~base_path:ctx.config.base_path
-          ~keeper_name:meta_after_triage.name
-          ~event_id:ca.event_id
-      with
-      | Some item ->
-        [ Keeper_world_observation.pending_board_event_of_external_attention
-            ~meta:meta_after_triage
-            item
-        ]
-      | None ->
-        Log.Keeper.warn
-          "connector attention stimulus missing recorded item event_id=%s (keeper=%s)"
-          ca.event_id
-          meta_after_triage.name;
-        []
-    in
-    (match
-       Keeper_external_attention.claim_for_turn
-         ~base_path:ctx.config.base_path
-         ~keeper_name:meta_after_triage.name
-         ~event_ids:[ ca.event_id ]
-         ~claim_id:(Printf.sprintf "heartbeat-wake:%s" stim.post_id)
-         ~turn_id:None
-         ()
-     with
-     | Ok () -> ()
-     | Error err ->
-       Log.Keeper.warn
-         "connector attention claim_for_turn failed event_id=%s (keeper=%s): %s"
-         ca.event_id meta_after_triage.name err);
-    Log.Keeper.info
-      "turn entry: connector attention stimulus consumed event_id=%s (keeper=%s)"
-      ca.event_id
-      meta_after_triage.name;
-    pending_events
-  | Keeper_event_queue.Hitl_resolved r ->
-    (* The approval has left the queue, so this cycle no longer skips. There is
-       no observation to fabricate: the typed resolution itself is threaded as
-       cycle context. An approved exact-action grant is consumed at the Gate;
-       reject/edit wakes carry no grant. *)
-    Log.Keeper.info
-      "turn entry: hitl resolution delivered approval=%s decision=%s (keeper=%s)"
-      r.approval_id
-      (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
-      meta_after_triage.name;
-    []
+    intake_result
 ;;
 
 let consume_board_stimulus_batch ~meta_after_triage batch =
@@ -286,8 +372,19 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
       "turn digest: coalesced %d board signals into one turn (keeper=%s)"
       batch_len
       meta_after_triage.name;
-  List.concat_map
-    (fun (stim : Keeper_event_queue.stimulus) ->
+  let rec render_batch acc = function
+    | [] -> Stimulus_consumed (List.concat (List.rev acc))
+    | (stim : Keeper_event_queue.stimulus) :: rest ->
+      (match pending_board_events_of_stimulus_result ~meta_after_triage stim with
+       | Stimulus_retry_later _ as retry -> retry
+       | Stimulus_consumed events -> render_batch (events :: acc) rest)
+  in
+  let intake_result = render_batch [] batch in
+  (match intake_result with
+   | Stimulus_retry_later _ -> ()
+   | Stimulus_consumed _ ->
+     List.iter
+       (fun (stim : Keeper_event_queue.stimulus) ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string StimulusConsumed)
          ~labels:[ "keeper", meta_after_triage.name; "class", "board_signal" ]
@@ -297,9 +394,9 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
           (keeper=%s)"
          stim.post_id
          (stimulus_urgency_to_string stim.urgency)
-         meta_after_triage.name;
-       pending_board_events_of_stimulus_result ~meta_after_triage stim)
-    batch
+         meta_after_triage.name)
+       batch);
+  intake_result
 ;;
 
 let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus) =
@@ -422,27 +519,39 @@ let heartbeat_event_intake
          select_pending_after_terminal_reconciliation ())
   in
   let pending_selection = select_pending_after_terminal_reconciliation () in
-  let queued_observations, consumed_stimuli, pending_selection, event_queue_claim_error =
+  let queued_observations, consumed_stimuli, pending_selection, event_queue_intake_error =
     match pending_selection with
     | Error message ->
       Log.Keeper.error
         "turn entry: event queue claim failed keeper=%s: %s"
         keeper_name
         message;
-      [], [], None, Some message
+      [], [], None, Some (Pending_selection_failed message)
     | Ok None -> [], [], None, None
     | Ok (Some selection) ->
       let stimuli = selection.Keeper_registry_event_queue.stimuli in
-      let observations =
+      let intake_result, selection_error =
         match selection.kind, stimuli with
         | Keeper_event_queue_persistence.Board_batch, batch ->
-          consume_board_stimulus_batch ~meta_after_triage batch
+          consume_board_stimulus_batch ~meta_after_triage batch, None
+        | Keeper_event_queue_persistence.Single, [ stimulus ] ->
+          ( consume_single_heartbeat_stimulus
+              ~ctx
+              ~meta_after_triage
+              stimulus
+          , None )
         | Keeper_event_queue_persistence.Single, stimuli ->
-          List.concat_map
-            (consume_single_heartbeat_stimulus ~ctx ~meta_after_triage)
-            stimuli
+          ( Stimulus_consumed []
+          , Some
+              (Invalid_single_selection
+                 { selected_count = List.length stimuli }) )
       in
-      observations, stimuli, Some selection, None
+      (match selection_error, intake_result with
+       | Some error, _ -> [], [], Some selection, Some error
+       | None, Stimulus_consumed observations ->
+         observations, stimuli, Some selection, None
+       | None, Stimulus_retry_later unavailable ->
+         [], [], Some selection, Some (Transient_board_read unavailable))
   in
   let consumed_stimulus_count = List.length consumed_stimuli in
   let event_queue_triggers = List.filter_map event_queue_trigger_of_stimulus consumed_stimuli in
@@ -484,7 +593,7 @@ let heartbeat_event_intake
   ; consumed_stimulus_count
   ; consumed_stimuli
   ; pending_selection
-  ; event_queue_claim_error
+  ; event_queue_intake_error
   ; event_queue_triggers
   }
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -24,18 +24,47 @@ val pending_board_event_of_stimulus
   -> Keeper_event_queue.stimulus
   -> (Keeper_world_observation.pending_board_event option, Keeper_world_observation_board_signal.board_unavailable) result
 
+(** Closed consumption result for an Event-Layer stimulus. A transient Board
+    read cannot be represented as an empty successful rendering: it retains
+    the exact pending queue selection for a later heartbeat. *)
+type stimulus_intake_result =
+  | Stimulus_consumed of Keeper_world_observation.pending_board_event list
+  | Stimulus_retry_later of
+      Keeper_world_observation_board_signal.board_unavailable
+
+(** Pure disposition boundary for one rendered Board event. Permanent
+    unavailability is consumed as an empty event; transient unavailability
+    remains a typed retry. *)
+val classify_pending_board_event_result
+  :  (Keeper_world_observation.pending_board_event option, Keeper_world_observation_board_signal.board_unavailable) result
+  -> stimulus_intake_result
+
 (** [pending_board_events_of_stimulus_result ~meta_after_triage stim] renders
     [stim] into zero-or-one pending board events. On [Error unavailable] it
     classifies the failure via
     {!Keeper_world_observation_board_signal.disposition_of_unavailable},
-    logs and counts it, and returns [] — the stimulus is treated as consumed
-    for this turn either way. See the [.ml] for why a queued stimulus has no
-    per-item requeue lever distinct from the whole-lease Ack/Requeue
-    decision. *)
+    logs and counts it, and returns either [Stimulus_consumed []] for a
+    permanent failure or [Stimulus_retry_later unavailable] for a transient
+    failure. *)
 val pending_board_events_of_stimulus_result
   :  meta_after_triage:keeper_meta
   -> Keeper_event_queue.stimulus
-  -> Keeper_world_observation.pending_board_event list
+  -> stimulus_intake_result
+
+type event_queue_intake_error =
+  | Pending_selection_failed of string
+  | Invalid_single_selection of { selected_count : int }
+  | Transient_board_read of
+      Keeper_world_observation_board_signal.board_unavailable
+
+val event_queue_intake_error_to_string : event_queue_intake_error -> string
+val event_queue_intake_error_reason_label : event_queue_intake_error -> string
+
+(** Only durable selection corruption/read failures count as a crashed cycle.
+    A transient Board read is an expected retry condition: it blocks dispatch
+    and retains the exact source without advancing Keeper failure state. *)
+val event_queue_intake_error_counts_as_cycle_failure :
+  event_queue_intake_error -> bool
 
 (** [record_event_queue_stimulus_turn_started ~ctx ~keeper_name stim] writes
     a generic [Turn_started] reaction for an event-queue stimulus after the
@@ -54,27 +83,27 @@ type heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_registry_event_queue.pending_selection option;
-  event_queue_claim_error : string option;
+  event_queue_intake_error : event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
 (** [consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim]
-    increments Otel_metric_store, logs the consumption, and returns a list of
-    pending board events derived from [stim] (empty for non-board
-    classes). *)
+    increments Otel_metric_store and logs only after consumption is known.
+    A transient Board read returns [Stimulus_retry_later] without incrementing
+    the consumed counter. *)
 val consume_single_heartbeat_stimulus
   :  ctx:_ context
   -> meta_after_triage:keeper_meta
   -> Keeper_event_queue.stimulus
-  -> Keeper_world_observation.pending_board_event list
+  -> stimulus_intake_result
 
-(** [consume_board_stimulus_batch ~meta_after_triage batch] increments
-    Otel_metric_store per stimulus, logs debounce coalescing, and returns the
-    pending board events derived from [batch]. *)
+(** [consume_board_stimulus_batch ~meta_after_triage batch] consumes the whole
+    exact batch only when every Board read is available or permanently
+    unavailable. Any transient read retains the full batch for retry. *)
 val consume_board_stimulus_batch
   :  meta_after_triage:keeper_meta
   -> Keeper_event_queue.stimulus list
-  -> Keeper_world_observation.pending_board_event list
+  -> stimulus_intake_result
 
 type terminal_schedule_reconciliation =
   | Not_terminal_schedule
@@ -96,10 +125,18 @@ val reconcile_terminal_schedule_selection
     accumulated by the caller, deduplicating by [post_id]. A
     [Hitl_resolved] stimulus remains queued until its exact approval id has
     left the pending map, while later ready stimuli can still be leased.
-    Runtime/provider availability cannot defer a durable claim; boundary
-    failures settle explicitly through the existing failure route. *)
+    A transient Board read returns no consumed stimuli, keeps the exact
+    [pending_selection], and sets [event_queue_intake_error]; the heartbeat
+    loop must not dispatch or acknowledge that selection. *)
 val heartbeat_event_intake
   :  ctx:'a context
   -> meta_after_triage:keeper_meta
   -> pending_board_events:Keeper_world_observation.pending_board_event list
   -> heartbeat_event_intake
+
+module For_testing : sig
+  (** Force the next [count] Board stimulus reads to report a transient
+      [Io_error], allowing the durable retry path to be exercised without a
+      real store outage. *)
+  val force_transient_board_reads : int -> unit
+end

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -147,8 +147,10 @@ let prepare_agent_setup
     ; extra_system_context_size = None
     }
   in
-  let local_search_fn_ref : (unit -> Keeper_tool_execution.t) ref =
-    ref (fun () ->
+  let local_search_fn_ref
+    : (query:string -> max_results:int -> Keeper_tool_execution.t) ref
+    =
+    ref (fun ~query:_ ~max_results:_ ->
       Keeper_tool_execution.success
         (Yojson.Safe.to_string (`Assoc [ "results", `List [] ])))
   in
@@ -163,7 +165,8 @@ let prepare_agent_setup
       ~meta
       ~publication_recovery
       ~ctx_snapshot
-      ~search_fn:(fun () -> !local_search_fn_ref ())
+      ~search_fn:(fun ~query ~max_results ->
+        !local_search_fn_ref ~query ~max_results)
       ?continuation_channel
       ~gate_context
       ?hitl_resolution
@@ -230,25 +233,43 @@ let prepare_agent_setup
            ; "actual_names", Json_util.json_string_list all_tool_names
            ])
       "Keeper model tool bundle differs from the descriptor projection";
-  let tool_catalog_results =
+  let tool_catalog_schemas =
     keeper_tools
     |> List.map (fun (tool : Agent_sdk.Tool.t) ->
-      `Assoc
-        [ "name", `String tool.schema.name
-        ; "description", `String tool.schema.description
-        ; ( "input_schema"
-          , Agent_sdk.Types.params_to_input_schema tool.schema.parameters )
-        ; "already_visible", `Bool true
-        ])
+      Masc_domain.
+        { name = tool.schema.name
+        ; description = tool.schema.description
+        ; input_schema =
+            Agent_sdk.Types.params_to_input_schema tool.schema.parameters
+        })
   in
   (local_search_fn_ref
-   := fun () ->
+   := fun ~query ~max_results ->
+        let ranked =
+          Keeper_tool_registry.rank_tool_schemas
+            ~query
+            ~max_results
+            tool_catalog_schemas
+        in
+        let results =
+          List.map
+            (fun (ranked : Keeper_tool_registry.ranked_tool_schema) ->
+               `Assoc
+                 [ "name", `String ranked.schema.name
+                 ; "score", `Float ranked.score
+                 ; "description", `String ranked.schema.description
+                 ; "input_schema", ranked.schema.input_schema
+                 ; "already_visible", `Bool true
+                 ])
+            ranked
+        in
         Keeper_tool_execution.success
           (Yojson.Safe.to_string
              (`Assoc
                [ "ok", `Bool true
-               ; "results", `List tool_catalog_results
-               ; "result_count", `Int (List.length tool_catalog_results)
+               ; "query", `String query
+               ; "results", `List results
+               ; "result_count", `Int (List.length results)
                ; "registered_descriptor_count", `Int (List.length registered_descriptors)
                ; "model_visible_descriptor_count", `Int (List.length model_visible_descriptors)
                ; "transport_alias_count", `Int transport_alias_count

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -960,14 +960,7 @@ let base_schema_input name =
     , unavailable_input_schema ("missing base tool schema for " ^ name) )
 
 let tool_search_schema =
-  object_schema
-    ~required:[ "query" ]
-    [ property "query" "string" "Search query for available keeper tools."
-    ; property
-        "max_results"
-        "integer"
-        "Maximum tool schemas to return. Default 5, capped at 10."
-    ]
+  Keeper_tool_registry.keeper_tool_search_schema.input_schema
 ;;
 
 let library_search_schema =

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -13,7 +13,7 @@ open Keeper_tool_shared_runtime
 include Keeper_tool_registry
 include Keeper_tool_policy
 
-let unavailable_tool_search () =
+let unavailable_tool_search ~query:_ ~max_results:_ =
   let data =
     `Assoc
       [ "ok", `Bool false

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -64,7 +64,8 @@ val execute_keeper_tool_call_with_outcome
        Keeper_publication_recovery_availability.turn_context
   -> ctx_work:working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
-  -> ?search_fn:(unit -> Keeper_tool_execution.t)
+  -> ?search_fn:
+       (query:string -> max_results:int -> Keeper_tool_execution.t)
   -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
@@ -90,7 +91,8 @@ val execute_keeper_tool_call
        Keeper_publication_recovery_availability.turn_context
   -> ctx_work:working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
-  -> ?search_fn:(unit -> Keeper_tool_execution.t)
+  -> ?search_fn:
+       (query:string -> max_results:int -> Keeper_tool_execution.t)
   -> name:string
   -> input:Yojson.Safe.t
   -> unit

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -37,13 +37,66 @@ let injected_masc_tool_names () =
 let keeper_tool_search_schema : Masc_domain.tool_schema =
   { name = Keeper_tool_name.to_string Keeper_tool_name.Tool_search
   ; description =
-      "Return the complete tool catalog already visible in this Keeper turn, \
-       including exact names, descriptions, and input schemas."
+      "Search the tool schemas visible in this Keeper turn by free-text query. \
+       Returns only the highest-ranked matching names, descriptions, and input \
+       schemas."
   ; input_schema =
       `Assoc
         [ "type", `String "object"
-        ; "properties", `Assoc []
-        ; "required", `List []
+        ; ( "properties"
+          , `Assoc
+              [ ( "query"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; "description", `String "Search query for available Keeper tools."
+                    ] )
+              ; ( "max_results"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; "minimum", `Int 1
+                    ; "maximum", `Int 10
+                    ; "default", `Int 5
+                    ; ( "description"
+                      , `String
+                          "Maximum tool schemas to return. Default 5, capped at 10." )
+                    ] )
+              ] )
+        ; "required", `List [ `String "query" ]
+        ; "additionalProperties", `Bool false
         ]
   }
+;;
+
+type ranked_tool_schema =
+  { schema : Masc_domain.tool_schema
+  ; score : float
+  }
+
+let rank_tool_schemas ~query ~max_results schemas =
+  let query = String.trim query in
+  if String.equal query ""
+  then []
+  else
+    let limit = Int.min 10 (Int.max 1 max_results) in
+    schemas
+    |> List.filter_map (fun (schema : Masc_domain.tool_schema) ->
+      let search_document =
+        String.concat
+          "\n"
+          [ schema.name
+          ; schema.description
+          ; Yojson.Safe.to_string schema.input_schema
+          ]
+      in
+      let score =
+        Text_similarity.jaccard_similarity query search_document
+      in
+      if Float.compare score 0.0 > 0
+      then Some { schema; score }
+      else None)
+    |> List.sort (fun left right ->
+      match Float.compare right.score left.score with
+      | 0 -> String.compare left.schema.name right.schema.name
+      | ordering -> ordering)
+    |> List.filteri (fun index _ -> index < limit)
 ;;

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -17,3 +17,18 @@ val injected_masc_tool_names : unit -> string list
 (** SSOT schema for [keeper_tool_search]. Defined here because this
     module is the canonical owner of keeper-internal tool metadata. *)
 val keeper_tool_search_schema : Masc_domain.tool_schema
+
+type ranked_tool_schema =
+  { schema : Masc_domain.tool_schema
+  ; score : float
+  }
+
+(** Rank the supplied, already-authorized tool schemas against [query] using
+    the repository-wide multilingual text-similarity contract. Zero-score
+    entries are omitted and no more than [max_results] (clamped to 1–10) are
+    returned. *)
+val rank_tool_schemas :
+  query:string ->
+  max_results:int ->
+  Masc_domain.tool_schema list ->
+  ranked_tool_schema list

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -17,7 +17,8 @@ type context =
       Keeper_publication_recovery_availability.turn_context
   ; ctx_work : Keeper_types.working_context
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
-  ; search_fn : unit -> Keeper_tool_execution.t
+  ; search_fn :
+      query:string -> max_results:int -> Keeper_tool_execution.t
   ; sw : Eio.Switch.t option
   ; clock : float Eio.Time.clock_ty Eio.Resource.t option
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
@@ -40,6 +41,20 @@ let descriptor_for_internal internal_name =
   match Keeper_tool_descriptor.descriptors_for_internal internal_name with
   | descriptor :: _ -> Some descriptor
   | [] -> None
+;;
+
+let invalid_tool_search_query () =
+  let data =
+    `Assoc
+      [ "ok", `Bool false
+      ; "error", `String "invalid_tool_search_query"
+      ; "reason", `String "query_required"
+      ]
+  in
+  Keeper_tool_execution.failure_data
+    ~class_:Tool_result.Policy_rejection
+    ~message:(Yojson.Safe.to_string data)
+    data
 ;;
 
 let handle_filesystem ctx descriptor args =
@@ -172,7 +187,19 @@ let handle_in_process ctx descriptor args =
     Some
       (Keeper_tool_execution.success
          (Keeper_tool_in_process_runtime.handle_tools_list ~meta:ctx.meta ~args))
-  | Tool_tool_search -> Some (ctx.search_fn ())
+  | Tool_tool_search ->
+    let query =
+      Safe_ops.json_string ~default:"" "query" args |> String.trim
+    in
+    if String.equal query ""
+    then Some (invalid_tool_search_query ())
+    else
+      let max_results =
+        Safe_ops.json_int ~default:5 "max_results" args
+        |> Int.max 1
+        |> Int.min 10
+      in
+      Some (ctx.search_fn ~query ~max_results)
   | Tool_context_status ->
     Some
       (Keeper_tool_execution.success

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -16,7 +16,8 @@ type context =
       Keeper_publication_recovery_availability.turn_context
   ; ctx_work : Keeper_types.working_context
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
-  ; search_fn : unit -> Keeper_tool_execution.t
+  ; search_fn :
+      query:string -> max_results:int -> Keeper_tool_execution.t
   ; sw : Eio.Switch.t option
   ; clock : float Eio.Time.clock_ty Eio.Resource.t option
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -10,7 +10,8 @@ val make_tool_bundle
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
   -> ctx_snapshot:Keeper_types.working_context
-  -> ?search_fn:(unit -> Keeper_tool_execution.t)
+  -> ?search_fn:
+       (query:string -> max_results:int -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?gate_context:Keeper_gate_causal_context.t
@@ -25,7 +26,8 @@ val make_tools
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
   -> ctx_snapshot:Keeper_types.working_context
-  -> ?search_fn:(unit -> Keeper_tool_execution.t)
+  -> ?search_fn:
+       (query:string -> max_results:int -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> unit
   -> Agent_sdk.Tool.t list

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -26,7 +26,8 @@ val make_keeper_tool_handler
        Keeper_publication_recovery_availability.turn_context
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
-  -> ?search_fn:(unit -> Keeper_tool_execution.t)
+  -> ?search_fn:
+       (query:string -> max_results:int -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?gate_context:(unit -> Keeper_gate.causal_context)

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -19,7 +19,8 @@ val execute_with_observers
        Keeper_publication_recovery_availability.turn_context
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
-  -> ?search_fn:(unit -> Keeper_tool_execution.t)
+  -> ?search_fn:
+       (query:string -> max_results:int -> Keeper_tool_execution.t)
   -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t

--- a/lib/tool_surface/tool_help_registry.ml
+++ b/lib/tool_surface/tool_help_registry.ml
@@ -135,14 +135,15 @@ let manual_help_entry name =
       Some
         {
           name;
-          short_description = "Search for additional tools by natural language query.";
-          when_to_use = "Use when your core tools are insufficient for the current task and you need help identifying relevant tools by describing the capability you need.";
+          short_description = "Search active Keeper tools by natural language query.";
+          when_to_use = "Use when you need to identify a relevant tool from the active Keeper schema by describing the capability you need.";
           key_constraints =
             [
+              "A non-empty query is required.";
               "Returns up to 10 matching results per query.";
             ];
           details_markdown =
-            "BM25 search over the full tool universe. Returns matching tool names, descriptions, and usage guidance for discovery and selection.";
+            "Ranked multilingual text search over the tool schemas visible in the current Keeper turn. Returns matching names, descriptions, and input schemas without dumping the full catalog.";
           doc_refs = [];
           prompt_hints = [];
           examples = [ "query='find a tool that edits files in place'" ];

--- a/test/test_keeper_board_unavailable.ml
+++ b/test/test_keeper_board_unavailable.ml
@@ -17,7 +17,10 @@
       created) no longer raises, is reported as [Error unavailable]
       classified [Permanent], and the stimulus-intake layer consumes it
       without crashing — stable across a second pass, unlike the old
-      exception-based loop. *)
+      exception-based loop.
+   3. a transient read failure is not collapsed into the permanent-consume
+      path: the exact queue selection remains pending and provider dispatch
+      is blocked until a later intake can render it. *)
 
 open Alcotest
 open Masc
@@ -50,13 +53,11 @@ let with_eio f () =
 
 let test_meta name =
   match
-    Keeper_meta_json_parse.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [ "name", `String name
          ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
          ; "trace_id", `String ("trace-" ^ name)
-         ; "sandbox_profile", `String "local"
-         ; "network_mode", `String "inherit"
          ])
   with
   | Ok meta -> meta
@@ -90,6 +91,15 @@ let test_disposition_of_error_classifies_every_variant () =
 ;;
 
 let poison_post_id = "nonexistent-post-poison-test"
+
+let transient_unavailable post_id :
+  Keeper_world_observation_board_signal.board_unavailable
+  =
+  { operation = Keeper_world_observation_board_signal.Get_post
+  ; post_id
+  ; error = Board.Io_error "forced transient board read failure"
+  }
+;;
 
 (* A [Board_signal] stimulus naming a post_id that was never created in this
    test's isolated JSONL store — the exact shape of the reported incident
@@ -155,21 +165,182 @@ let test_poison_stimulus_intake_does_not_crash_and_stays_dropped () =
       ~meta_after_triage:meta
       stim
   in
-  check
-    int
-    "first pass produces no pending_board_event (consumed, not crashed)"
-    0
-    (List.length first_pass);
+  (match first_pass with
+   | Keeper_heartbeat_stimulus_intake.Stimulus_consumed events ->
+     check
+       int
+       "first pass produces no pending_board_event (consumed, not crashed)"
+       0
+       (List.length events)
+   | Keeper_heartbeat_stimulus_intake.Stimulus_retry_later unavailable ->
+     failf
+       "permanent poison stimulus was incorrectly retained: %s"
+       (Keeper_world_observation_board_signal.unavailable_to_string unavailable));
   let second_pass =
     Keeper_heartbeat_stimulus_intake.pending_board_events_of_stimulus_result
       ~meta_after_triage:meta
       stim
   in
+  match second_pass with
+  | Keeper_heartbeat_stimulus_intake.Stimulus_consumed events ->
+    check
+      int
+      "second pass over the same stimulus stays empty (no crash-loop resurgence)"
+      0
+      (List.length events)
+  | Keeper_heartbeat_stimulus_intake.Stimulus_retry_later unavailable ->
+    failf
+      "permanent poison stimulus was incorrectly retained on repeat: %s"
+      (Keeper_world_observation_board_signal.unavailable_to_string unavailable)
+;;
+
+let test_transient_result_is_retryable () =
+  let unavailable = transient_unavailable "transient-classification" in
+  match
+    Keeper_heartbeat_stimulus_intake.classify_pending_board_event_result
+      (Error unavailable)
+  with
+  | Keeper_heartbeat_stimulus_intake.Stimulus_retry_later actual ->
+    check
+      string
+      "retry retains exact post id"
+      unavailable.post_id
+      actual.post_id
+  | Keeper_heartbeat_stimulus_intake.Stimulus_consumed _ ->
+    fail "transient board read was collapsed into consumed"
+;;
+
+let test_transient_intake_retains_pending_source_and_blocks_dispatch () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = fresh_test_base_path () in
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  Keeper_registry.For_testing.clear ();
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_heartbeat_stimulus_intake.For_testing.force_transient_board_reads 0;
+      Keeper_registry.For_testing.clear ())
+  @@ fun () ->
+  let meta = test_meta "transient-intake" in
+  let config = Workspace.default_config base_path in
+  let ctx : _ Keeper_types_profile.context =
+    { config
+    ; agent_name = "board-unavailable-test"
+    ; sw
+    ; clock = Eio.Stdenv.clock env
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  ignore
+    (Keeper_registry.For_testing.register
+       ~base_path
+       meta.name
+       meta);
+  let post =
+    match
+      Board_dispatch.create_post
+        ~author:"external-author"
+        ~content:"transient source remains available after retry"
+        ~post_kind:Board.Human_post
+        ~visibility:Board.Internal
+        ()
+    with
+    | Ok post -> post
+    | Error error ->
+      failf "failed to create retryable Board source: %s" (Board.show_board_error error)
+  in
+  let stimulus =
+    { (poison_board_signal_stimulus ()) with
+      post_id = Board.Post_id.to_string post.id
+    }
+  in
+  (match
+     Keeper_registry_event_queue.enqueue_durable_result
+       ~base_path
+       meta.name
+       stimulus
+   with
+   | Ok () -> ()
+   | Error message -> failf "failed to seed durable stimulus: %s" message);
+  Keeper_heartbeat_stimulus_intake.For_testing.force_transient_board_reads 1;
+  let intake =
+    Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+      ~ctx
+      ~meta_after_triage:meta
+      ~pending_board_events:[]
+  in
+  check int "transient source is not counted consumed" 0 intake.consumed_stimulus_count;
+  check int "transient source is not exposed as consumed" 0
+    (List.length intake.consumed_stimuli);
+  check bool "exact pending selection remains attached" true
+    (Option.is_some intake.pending_selection);
+  (match intake.event_queue_intake_error with
+   | Some
+       (Keeper_heartbeat_stimulus_intake.Transient_board_read unavailable) ->
+     check string "retry retains the exact source post id" stimulus.post_id
+       unavailable.post_id;
+     check bool "transient retry is not a crashed cycle" false
+       (Keeper_heartbeat_stimulus_intake
+        .event_queue_intake_error_counts_as_cycle_failure
+          (Keeper_heartbeat_stimulus_intake.Transient_board_read unavailable))
+   | Some error ->
+     failf
+       "expected transient Board retry, got %s"
+       (Keeper_heartbeat_stimulus_intake.event_queue_intake_error_to_string
+          error)
+   | None -> fail "transient intake error was lost");
   check
-    int
-    "second pass over the same stimulus stays empty (no crash-loop resurgence)"
-    0
-    (List.length second_pass)
+    bool
+    "provider dispatch is blocked while source rendering is transiently unavailable"
+    false
+    (Keeper_heartbeat_loop.should_run_turn_after_event_intake
+       ~scheduled:true
+       ~event_queue_intake_error:intake.event_queue_intake_error);
+  let queued =
+    match Keeper_registry_event_queue.snapshot_result ~base_path meta.name with
+    | Ok queue -> queue
+    | Error message -> failf "failed to reload durable queue: %s" message
+  in
+  check int "durable source remains pending for the next heartbeat" 1
+    (Keeper_event_queue.length queued);
+  let retry_intake =
+    Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+      ~ctx
+      ~meta_after_triage:meta
+      ~pending_board_events:[]
+  in
+  check int "later successful read consumes the retained source" 1
+    retry_intake.consumed_stimulus_count;
+  check int "later successful read renders the exact Board event" 1
+    (List.length retry_intake.pending_board_events);
+  check bool "retry clears the typed intake error" true
+    (Option.is_none retry_intake.event_queue_intake_error);
+  (match retry_intake.pending_selection with
+   | None -> fail "successful retry lost its exact pending selection"
+   | Some selection ->
+     (match
+        Keeper_registry_event_queue.ack_pending_result
+          ~base_path
+          meta.name
+          ~selection
+      with
+      | Ok () -> ()
+      | Error message -> failf "failed to acknowledge successful retry: %s" message));
+  let settled =
+    match Keeper_registry_event_queue.snapshot_result ~base_path meta.name with
+    | Ok queue -> queue
+    | Error message -> failf "failed to reload settled queue: %s" message
+  in
+  check int "successful retry can settle the exact source" 0
+    (Keeper_event_queue.length settled)
 ;;
 
 let () =
@@ -190,6 +361,16 @@ let () =
             "stimulus intake consumes without crash, stable on repeat"
             `Quick
             (with_eio test_poison_stimulus_intake_does_not_crash_and_stays_dropped)
+        ] )
+    ; ( "transient stimulus"
+      , [ test_case
+            "Io_error is a typed retry, not consumed"
+            `Quick
+            test_transient_result_is_retryable
+        ; test_case
+            "pending source is retained and provider dispatch is blocked"
+            `Quick
+            test_transient_intake_retains_pending_source_and_blocks_dispatch
         ] )
     ]
 ;;

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -151,8 +151,8 @@ let test_contract_observation_preserves_current_turn_suffix () =
     (text_of_last_assistant patched.messages);
   Alcotest.(check bool) "canonical replay clears working context" true
     (patched.working_context = None);
-  Alcotest.(check (option string)) "canonical replay reason"
-    (Some "canonical_success_replay")
+  Alcotest.(check (option string)) "retained replay has no prune reason"
+    None
     (prune_reason_to_string reason)
 ;;
 
@@ -216,8 +216,8 @@ let test_success_preserves_typed_replay_suffix () =
     |> expect_ok
   in
   Alcotest.(check int) "full replay retained" 6 (List.length patched.messages);
-  Alcotest.(check (option string)) "canonicalization reason"
-    (Some "canonical_success_replay")
+  Alcotest.(check (option string)) "retained replay has no prune reason"
+    None
     (prune_reason_to_string reason);
   Alcotest.(check bool) "thinking remains typed" true
     (has_content (function Thinking _ -> true | _ -> false) patched.messages);
@@ -253,7 +253,7 @@ let test_success_appends_missing_final_assistant () =
     (text_of_last_assistant patched.messages)
 ;;
 
-let test_empty_success_drops_current_turn_replay () =
+let test_empty_success_preserves_recorded_user_turn () =
   let open Agent_sdk.Types in
   let history =
     [ message User [ Text "old user" ]; message Assistant [ Text "old answer" ] ]
@@ -268,11 +268,55 @@ let test_empty_success_drops_current_turn_replay () =
       (checkpoint (history @ [ message User [ Text "current user" ] ]))
     |> expect_ok
   in
-  Alcotest.(check int) "empty visible result is not replayed" 2
+  Alcotest.(check int) "recorded user input survives blank completion" 3
     (List.length patched.messages);
   Alcotest.(check bool) "working context cleared on canonical success" true
     (patched.working_context = None);
-  Alcotest.(check (option string)) "canonicalization remains observable"
+  Alcotest.(check (option string)) "nothing was pruned"
+    None
+    (prune_reason_to_string reason)
+;;
+
+let test_empty_success_preserves_tool_execution_suffix () =
+  let open Agent_sdk.Types in
+  let history =
+    [ message User [ Text "old user" ]; message Assistant [ Text "old answer" ] ]
+  in
+  let current_turn =
+    [ message User [ Text "current user" ]
+    ; message Assistant
+        [ ToolUse
+            { id = "tool-1"; name = "keeper_context_status"; input = `Assoc [] }
+        ]
+    ; message Tool
+        [ ToolResult
+            { tool_use_id = "tool-1"
+            ; content = "status"
+            ; outcome = Tool_succeeded
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ; message Assistant [ Text "" ]
+    ]
+  in
+  let patched, reason =
+    Finalize.checkpoint_for_replay_persistence
+      ~history_messages:history
+      ~pre_turn_working_context:(Some (`Assoc [ "pre_turn", `Bool true ]))
+      ~completion_contract_result:Receipt.Completion_tool_execution_observed
+      ~session_id:"new-session"
+      ~response_text:""
+      (checkpoint (history @ current_turn))
+    |> expect_ok
+  in
+  Alcotest.(check bool)
+    "effectful replay survives without the trailing blank assistant"
+    true
+    (patched.messages = history @ List.rev (List.tl (List.rev current_turn)));
+  Alcotest.(check bool) "working context cleared on canonical success" true
+    (patched.working_context = None);
+  Alcotest.(check (option string)) "blank assistant pruning is observable"
     (Some "canonical_success_replay")
     (prune_reason_to_string reason)
 ;;
@@ -480,7 +524,7 @@ let test_skipped_wake_leaves_non_marker_suffix_untouched () =
     (List.length patched.messages)
 ;;
 
-let test_skipped_wake_blank_response_still_drops_whole_suffix () =
+let test_skipped_wake_blank_response_drops_only_inert_suffix () =
   let open Agent_sdk.Types in
   let suffix =
     [ message User [ Text wake_marker_text ]; message Assistant [ Text "" ] ]
@@ -523,9 +567,13 @@ let () =
             `Quick
             test_success_appends_missing_final_assistant
         ; Alcotest.test_case
-            "empty success drops current turn"
+            "empty success preserves recorded user turn"
             `Quick
-            test_empty_success_drops_current_turn_replay
+            test_empty_success_preserves_recorded_user_turn
+        ; Alcotest.test_case
+            "empty success preserves tool execution suffix"
+            `Quick
+            test_empty_success_preserves_tool_execution_suffix
         ; Alcotest.test_case
             "InputRequired preserves exact tool-failure suffix"
             `Quick
@@ -547,9 +595,9 @@ let () =
             `Quick
             test_skipped_wake_leaves_non_marker_suffix_untouched
         ; Alcotest.test_case
-            "skipped wake blank response still drops whole suffix"
+            "skipped wake blank response drops only inert suffix"
             `Quick
-            test_skipped_wake_blank_response_still_drops_whole_suffix
+            test_skipped_wake_blank_response_drops_only_inert_suffix
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1109,6 +1109,25 @@ let test_library_search_descriptor_has_recoverable_query_schema () =
     (List.mem "query" (schema_required_fields descriptor.input_schema))
 ;;
 
+let test_tool_search_descriptor_uses_registry_schema () =
+  let descriptor = required_internal_descriptor "keeper_tool_search" in
+  let canonical =
+    Masc.Keeper_tool_registry.keeper_tool_search_schema
+  in
+  Alcotest.(check bool)
+    "descriptor and registry share one exact input schema"
+    true
+    (descriptor.Descriptor.input_schema = canonical.input_schema);
+  Alcotest.(check bool)
+    "query remains required"
+    true
+    (List.mem "query" (schema_required_fields canonical.input_schema));
+  Alcotest.(check bool)
+    "search schema rejects unowned fields"
+    true
+    (schema_forbids_additional_properties canonical.input_schema)
+;;
+
 let test_readonly_policy_projection_is_descriptor_owned () =
   let projected = Descriptor.readonly_internal_names () in
   List.iter
@@ -1521,6 +1540,10 @@ let () =
             "Library search query is runtime-recoverable"
             `Quick
             test_library_search_descriptor_has_recoverable_query_schema
+        ; test_case
+            "Tool search descriptor uses registry SSOT"
+            `Quick
+            test_tool_search_descriptor_uses_registry_schema
         ] )
     ; ( "masc-board"
       , [ test_case

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1842,7 +1842,7 @@ let test_tool_search_without_session_searcher_is_unavailable () =
         KET.execute_keeper_tool_call_with_outcome
           ~config ~meta ~publication_recovery ~ctx_work
           ~name:"keeper_tool_search"
-          ~input:(`Assoc [])
+          ~input:(`Assoc [ "query", `String "read files" ])
           ()
       in
       check string "search outcome" "failure" (outcome_label result.disposition);
@@ -1857,9 +1857,9 @@ let test_tool_search_without_session_searcher_is_unavailable () =
 let test_tool_search_uses_exact_injected_searcher () =
   with_exec_fixture "keeper_tool_dispatch_runtime_injected_search"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
-      let observed = ref false in
-      let search_fn () =
-        observed := true;
+      let observed = ref None in
+      let search_fn ~query ~max_results =
+        observed := Some (query, max_results);
         Masc.Keeper_tool_execution.success
           (Yojson.Safe.to_string
              (`Assoc
@@ -1871,15 +1871,81 @@ let test_tool_search_uses_exact_injected_searcher () =
         KET.execute_keeper_tool_call_with_outcome
           ~config ~meta ~publication_recovery ~ctx_work ~search_fn
           ~name:"keeper_tool_search"
-          ~input:(`Assoc [])
+          ~input:
+            (`Assoc
+               [ "query", `String "read files"
+               ; "max_results", `Int 99
+               ])
           ()
       in
       check string "search outcome" "success" (outcome_label result.disposition);
-      check bool "injected catalog provider called" true !observed;
+      (match !observed with
+       | Some (query, max_results) ->
+         check string "query forwarded exactly" "read files" query;
+         check int "max_results capped at 10" 10 max_results
+       | None -> fail "injected catalog provider was not called");
       let json = Yojson.Safe.from_string result.raw_output in
       check string "injected result preserved" "injected-result"
         Yojson.Safe.Util.(member "results" json |> to_list |> List.hd
                           |> member "name" |> to_string))
+
+let test_tool_search_rejects_blank_query_before_provider () =
+  with_exec_fixture "keeper_tool_dispatch_runtime_blank_search"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+      let called = ref false in
+      let search_fn ~query:_ ~max_results:_ =
+        called := true;
+        Masc.Keeper_tool_execution.success "{}"
+      in
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~publication_recovery
+          ~ctx_work
+          ~search_fn
+          ~name:"keeper_tool_search"
+          ~input:(`Assoc [ "query", `String "   " ])
+          ()
+      in
+      check string "blank query outcome" "failure" (outcome_label result.disposition);
+      check bool "provider not called for blank query" false !called;
+      let json = Yojson.Safe.from_string result.raw_output in
+      check string "typed invalid-query error" "invalid_tool_search_query"
+        Yojson.Safe.Util.(member "error" json |> to_string))
+
+let test_tool_search_ranks_and_limits_visible_catalog () =
+  let schema name description : Masc_domain.tool_schema =
+    { name
+    ; description
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ]
+    }
+  in
+  let catalog =
+    [ schema "tool_read_file" "Read an existing file."
+    ; schema "tool_edit_file" "Edit an existing file in place."
+    ; schema "keeper_time_now" "Return the current wall-clock time."
+    ]
+  in
+  let ranked =
+    Masc.Keeper_tool_registry.rank_tool_schemas
+      ~query:"edit file"
+      ~max_results:1
+      catalog
+  in
+  check int "query returns only requested count, not full catalog" 1
+    (List.length ranked);
+  match ranked with
+  | [ result ] ->
+    check string "most relevant schema ranks first" "tool_edit_file"
+      result.Masc.Keeper_tool_registry.schema.name;
+    check bool "rank exposes a positive relevance score" true
+      (result.score > 0.0)
+  | _ -> fail "expected exactly one ranked tool schema"
 
 let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
   with_exec_fixture
@@ -3356,6 +3422,10 @@ let () =
         test_tool_search_without_session_searcher_is_unavailable;
       test_case "tool search uses injected session searcher" `Quick
         test_tool_search_uses_exact_injected_searcher;
+      test_case "tool search rejects blank query before provider" `Quick
+        test_tool_search_rejects_blank_query_before_provider;
+      test_case "tool search ranks and limits visible catalog" `Quick
+        test_tool_search_ranks_and_limits_visible_catalog;
       test_case "model-visible local tools dispatch to runtime handlers" `Quick
         test_model_visible_local_tools_dispatch_to_runtime_handlers;
       test_case "keeper_task_claim accepts explicit task_id" `Quick


### PR DESCRIPTION
## Summary

- Preserve typed current-turn replay when a provider completes with blank visible text, pruning only inert trailing Assistant shells.
- Retain the exact durable event-queue selection when a Board read fails transiently, block provider dispatch, and retry without incrementing the Keeper crashed-cycle state.
- Replace the full Keeper tool-catalog dump with required-query, bounded multilingual ranking over the schemas already visible in that turn.

## Root cause

Three independent context boundaries collapsed typed state into an empty-looking result:

1. blank `Completed` text authorized removal of the whole current-turn suffix, including ToolUse/ToolResult;
2. transient Board read errors were rendered as an empty successful intake, so later settlement could acknowledge the source;
3. `keeper_tool_search` ignored its query and returned the entire active schema catalog.

## Impact

Keeper replay now retains effectful history, transient Board failures remain lossless and retryable, and tool discovery returns at most 10 relevant schemas instead of duplicating the full catalog into context.

## Validation

- `scripts/dune-local.sh build test/test_keeper_replay_checkpoint.exe test/test_keeper_board_unavailable.exe test/test_keeper_tool_dispatch_runtime.exe test/test_keeper_tool_descriptor_registry_integrity.exe`
- `test_keeper_replay_checkpoint.exe`: 13/13
- `test_keeper_board_unavailable.exe`: 5/5, including transient failure -> same-selection retry -> exact ACK
- `test_keeper_tool_dispatch_runtime.exe test '^execute_keeper_tool_call_with_outcome$' 13-16`: 4/4
- `test_keeper_tool_descriptor_registry_integrity.exe`: 42/42
- `git diff --check`

The full tool-runtime executable also has three failures reproducible on the same `origin/main` SHA; they are outside this diff and tracked by #26008, #26009, and #26117.
