### PR TITLE
fix(keeper): capture exact OAS tool schemas

### DIFF
--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -540,6 +540,7 @@ let assemble_hooks
                        ~extra_system_context:ctx
                        ~user_message
                        ~history_messages:messages
+                       ~tools
                        ())
                   manifest_keeper_turn_id;
                 Eio.Fiber.yield ();

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -104,13 +104,38 @@ let json_string_opt redaction = function
   | Some value -> `String (redact redaction value)
   | None -> `Null
 
+let rec redact_json_strings
+          redaction
+          (json : Yojson.Safe.t)
+  : Yojson.Safe.t
+  =
+  match json with
+  | `String value -> `String (redact redaction value)
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (key, value) -> key, redact_json_strings redaction value)
+         fields)
+  | `List values ->
+    `List (List.map (redact_json_strings redaction) values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as value -> value
+
 let capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~sdk_turn
-    ~system_prompt ~extra_system_context ~user_message ~history_messages ?trace_id
-    () =
+    ~system_prompt ~extra_system_context ~user_message ~history_messages ~tools
+    ?trace_id () =
   if not (enabled ()) then ()
   else
     best_effort ~site:Request_capture ~masc_root ~keeper_name ~turn_id (fun () ->
       let redaction = Keeper_secret_redaction.snapshot ~base_path ~keeper_name in
+      let raw_tools =
+        List.map Agent_sdk.Tool.schema_to_json tools
+      in
+      let tool_schema_bytes =
+        Yojson.Safe.to_string (`List raw_tools) |> String.length
+      in
+      let redacted_tools =
+        List.map (redact_json_strings redaction) raw_tools
+      in
       let history =
         List.map
           (fun (m : Agent_sdk.Types.message) ->
@@ -138,6 +163,13 @@ let capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~sdk_turn
             , json_string_opt redaction extra_system_context )
           ; ( "extra_system_context_present"
             , `Bool (Option.is_some extra_system_context) )
+          ; ( "extra_system_context_bytes"
+            , match extra_system_context with
+              | Some context -> `Int (String.length context)
+              | None -> `Null )
+          ; ("tool_count", `Int (List.length tools))
+          ; ("tool_schema_bytes", `Int tool_schema_bytes)
+          ; ("tools", `List redacted_tools)
           ; ("user_message", `String (redact redaction user_message))
           ; ("history_message_count", `Int (List.length history_messages))
           ; ("history", `List history)

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -1,11 +1,12 @@
 (** Env-gated capture of the MASC->OAS request boundary (redacted).
 
     Records the effective request parameters MASC hands to OAS per SDK turn —
-    system prompt, extra system context, user message, and the replayed
-    conversation history ([initial_messages]) — so degenerate-repetition
-    feedback loops can be diagnosed from the actual input rather than from
-    digests/sizes (the only signal available today). String content is passed
-    through {!Llm_provider.Secret_redactor} and the exact
+    system prompt, extra system context, tool schemas, user message, and the
+    replayed conversation history ([initial_messages]) — so
+    degenerate-repetition feedback loops can be diagnosed from the actual
+    input rather than from digests/sizes. Tool schemas use the same
+    {!Agent_sdk.Tool.schema_to_json} projection OAS prepares for the provider.
+    String content is passed through {!Llm_provider.Secret_redactor} and the exact
     {!Keeper_secret_redaction} projection snapshot before it is written.
 
     Writes are best-effort and dated under
@@ -42,18 +43,22 @@ val capture_request :
   extra_system_context:string option ->
   user_message:string ->
   history_messages:Agent_sdk.Types.message list ->
+  tools:Agent_sdk.Tool.t list ->
   ?trace_id:Keeper_id.Trace_id.t ->
   unit ->
   unit
 (** [capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
-    ~extra_system_context ~user_message ~history_messages ~trace_id ()] appends
-    one redacted request record ([kind:"request"]). No-op unless {!enabled}.
+    ~extra_system_context ~user_message ~history_messages ~tools ~trace_id ()]
+    appends one redacted request record ([kind:"request"]). No-op unless
+    {!enabled}.
     [turn_id] is the 1-based keeper turn index; [sdk_turn] disambiguates
     multiple OAS/provider calls inside that keeper turn. [trace_id] is the
     keeper runtime trace id passed to OAS as [session_id] for raw-trace
     correlation. [base_path] selects the exact Keeper secret projection
     snapshot; [masc_root] must already be the effective cluster-aware MASC
-    root. *)
+    root. [tool_schema_bytes] records the byte length of the exact unredacted
+    compact JSON schema array while [tools] stores its recursively redacted
+    content. *)
 
 val capture_response :
   base_path:string ->

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -215,7 +215,7 @@ let disabled_is_noop () =
     Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
       ~turn_id:1
       ~sdk_turn:1 ~system_prompt:"sys" ~extra_system_context:None
-      ~user_message:"u" ~history_messages:[] ();
+      ~user_message:"u" ~history_messages:[] ~tools:[] ();
     Alcotest.(check (list string))
       "no jsonl written when disabled" [] (find_jsonl base))
 
@@ -234,7 +234,7 @@ let enabled_writes_redacted () =
       ~sdk_turn:3
       ~system_prompt:("token " ^ projected_secret ^ " end")
       ~extra_system_context:(Some "dynamic context")
-      ~user_message:"hello world" ~history_messages:history ();
+      ~user_message:"hello world" ~history_messages:history ~tools:[] ();
     let files = find_jsonl base in
     Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
     let content = read_file (List.hd files) in
@@ -252,6 +252,14 @@ let enabled_writes_redacted () =
       "dynamic context" json;
     check_json_bool "extra context presence recorded"
       "extra_system_context_present" true json;
+    check_json_int "extra context bytes recorded"
+      "extra_system_context_bytes"
+      (String.length "dynamic context")
+      json;
+    check_json_int "empty tool count recorded" "tool_count" 0 json;
+    check_json_int "empty tool schema bytes recorded" "tool_schema_bytes"
+      (String.length "[]") json;
+    check_json_list_length "empty tool schemas recorded" "tools" 0 json;
     check_json_string "user message recorded" "user_message" "hello world" json;
     check_json_int "history_message_count recorded" "history_message_count" 2
       json;
@@ -266,6 +274,54 @@ let enabled_writes_redacted () =
        check_json_string "user text recorded" "text" "continue" user
      | _ -> Alcotest.fail "history shape should have been checked above"))
 
+let request_captures_exact_redacted_tool_schemas () =
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_tools" "" in
+    install_projected_secret ~base_path:base ~keeper_name:"sangsu";
+    let tool =
+      Agent_sdk.Tool.create
+        ~name:"probe_tool"
+        ~description:("search with " ^ projected_secret)
+        ~parameters:
+          [ { Agent_sdk.Types.name = "query"
+            ; description = "query " ^ projected_secret
+            ; param_type = Agent_sdk.Types.String
+            ; required = true
+            }
+          ]
+        (fun _input -> Ok { Agent_sdk.Types.content = "ok"; _meta = None })
+    in
+    let raw_tools = `List [ Agent_sdk.Tool.schema_to_json tool ] in
+    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+      ~turn_id:8
+      ~sdk_turn:2 ~system_prompt:"sys" ~extra_system_context:None
+      ~user_message:"hello" ~history_messages:[] ~tools:[ tool ] ();
+    let files = find_jsonl base in
+    Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
+    let content = read_file (List.hd files) in
+    let json = parse_single_jsonl content in
+    Alcotest.(check bool) "tool schema secret is redacted" false
+      (contains ~needle:projected_secret content);
+    check_json_int "tool count recorded" "tool_count" 1 json;
+    check_json_int "pre-redaction tool schema bytes recorded"
+      "tool_schema_bytes"
+      (Yojson.Safe.to_string raw_tools |> String.length)
+      json;
+    match json_list "tools" json with
+    | [ tool_json ] ->
+      check_json_string "tool name recorded" "name" "probe_tool" tool_json;
+      Alcotest.(check bool) "tool description redaction marker present" true
+        (contains ~needle:"[REDACTED]" (json_string "description" tool_json));
+      let query_schema =
+        json_member "input_schema" tool_json
+        |> json_member "properties"
+        |> json_member "query"
+      in
+      Alcotest.(check bool) "parameter description is recursively redacted" true
+        (contains ~needle:"[REDACTED]"
+           (json_string "description" query_schema))
+    | _ -> Alcotest.fail "tool schema list shape should have been checked above")
+
 let request_trace_id_emitted () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_req_trace" "" in
@@ -273,7 +329,7 @@ let request_trace_id_emitted () =
     Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
       ~turn_id:1
       ~trace_id ~sdk_turn:1 ~system_prompt:"sys" ~extra_system_context:None
-      ~user_message:"hello" ~history_messages:[] ();
+      ~user_message:"hello" ~history_messages:[] ~tools:[] ();
     let json = read_single_json_record base in
     check_json_string "request trace_id string recorded" "trace_id"
       "trace-req-abc" json)
@@ -294,7 +350,7 @@ let request_capture_failure_is_best_effort () =
         Wire.capture_request ~base_path:root_file ~masc_root:root_file ~keeper_name
           ~turn_id
           ~sdk_turn:1 ~system_prompt:"sys" ~extra_system_context:None
-          ~user_message:"hello" ~history_messages:[] ()))
+          ~user_message:"hello" ~history_messages:[] ~tools:[] ()))
 
 let response_disabled_is_noop () =
   with_flag "" (fun () ->
@@ -533,6 +589,8 @@ let () =
           Alcotest.test_case "disabled is a no-op" `Quick disabled_is_noop;
           Alcotest.test_case "enabled writes redacted jsonl" `Quick
             enabled_writes_redacted;
+          Alcotest.test_case "captures exact redacted tool schemas" `Quick
+            request_captures_exact_redacted_tool_schemas;
           Alcotest.test_case "write failure is best effort" `Quick
             request_capture_failure_is_best_effort;
           Alcotest.test_case "trace_id is emitted when provided" `Quick


### PR DESCRIPTION
## Summary

- Capture the exact `Agent_sdk.Tool.schema_to_json` array supplied to OAS on every enabled Keeper wire-capture request.
- Recursively redact every string inside tool schemas with the existing provider-neutral and Keeper projection redactors.
- Record `tool_count`, exact pre-redaction `tool_schema_bytes`, and `extra_system_context_bytes` alongside the already-captured redacted tail content.

## Why

The existing diagnostic capture already persisted `extra_system_context` when enabled, but omitted the tool schema layer. That made the MASC -> OAS request payload impossible to reconstruct and caused the 2026-07-28 context-flow report to overstate the tail blind spot while correctly identifying the missing tool layer.

## Impact

A bounded, opt-in wire capture can now attribute system, tail, tools, user input, and replay history at the same SDK-turn boundary without writing projected secrets. Disabled behavior remains a filesystem-free no-op.

## Validation

- Red proof: the test contract failed to compile because `capture_request` had no `~tools` boundary.
- `scripts/dune-local.sh build test/test_keeper_wire_capture.exe`
- `DUNE_SOURCEROOT=$PWD _build/default/test/test_keeper_wire_capture.exe`: 16/16
- `git diff --check`
