### PR TITLE
fix: preserve missing keeper ages as null

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -377,20 +377,21 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
             Workspace_resilience.Time.parse_iso8601_opt m.created_at
             |> Option.value ~default:0.0
           in
-          let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-          let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
+          let keeper_age_s = Keeper_status_metrics.age_seconds_opt ~now_ts created_ts in
+          let last_turn_ago_s =
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.usage.last_turn_ts
+          in
           let last_handoff_ago_s =
-            if m.runtime.last_handoff_ts <= 0.0 then 0.0 else now_ts -. m.runtime.last_handoff_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.last_handoff_ts
           in
           let last_compaction_ago_s =
-            if m.runtime.compaction_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.compaction_rt.last_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.compaction_rt.last_ts
           in
           let last_proactive_ago_s =
-            if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_ts
           in
           let last_visible_proactive_ago_s =
-            if m.runtime.proactive_rt.last_visible_ts <= 0.0 then 0.0
-            else now_ts -. m.runtime.proactive_rt.last_visible_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_visible_ts
           in
           (* C-3 fix: compute last_activity from the most recent activity timestamp
              to avoid showing misleading staleness when agent is actually active *)
@@ -415,7 +416,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
             | None -> 0.0
           in
           let last_activity_ago_s =
-            if last_activity_ts <= 0.0 then 0.0 else now_ts -. last_activity_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts last_activity_ts
           in
           let live_activity_fields =
             let source_json =
@@ -920,14 +921,17 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                 `String
                   (Keeper_status_runtime.keeper_surface_status ~agent_status:agent
                      ~diagnostic) );
-              ("keeper_age_s", `Float keeper_age_s);
-              ("uptime_hours", `Float (keeper_age_s /. Masc_time_constants.hour));
-              ("last_turn_ago_s", `Float last_turn_ago_s);
-              ("last_handoff_ago_s", `Float last_handoff_ago_s);
-              ("last_compaction_ago_s", `Float last_compaction_ago_s);
-              ("last_proactive_ago_s", `Float last_proactive_ago_s);
-              ("last_visible_proactive_ago_s", `Float last_visible_proactive_ago_s);
-              ("last_activity_ago_s", `Float last_activity_ago_s);
+              ("keeper_age_s", Json_util.float_opt_to_json keeper_age_s);
+              ( "uptime_hours"
+              , Json_util.option_to_yojson
+                  (fun age_s -> `Float (age_s /. Masc_time_constants.hour))
+                  keeper_age_s );
+              ("last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s);
+              ("last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s);
+              ("last_compaction_ago_s", Json_util.float_opt_to_json last_compaction_ago_s);
+              ("last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s);
+              ("last_visible_proactive_ago_s", Json_util.float_opt_to_json last_visible_proactive_ago_s);
+              ("last_activity_ago_s", Json_util.float_opt_to_json last_activity_ago_s);
               ("handoff_count_total", `Int trace_history_count);
               ("total_turns", `Int m.runtime.usage.total_turns);
               ("total_input_tokens", `Int m.runtime.usage.total_input_tokens);

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -43,14 +43,15 @@ let handle_keeper_list ctx args : tool_result =
           let created_ts =
             Workspace_resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
           in
-          let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-          let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
+          let keeper_age_s = Keeper_status_metrics.age_seconds_opt ~now_ts created_ts in
+          let last_turn_ago_s =
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.usage.last_turn_ts
+          in
           let last_proactive_ago_s =
-            if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_ts
           in
           let last_visible_proactive_ago_s =
-            if m.runtime.proactive_rt.last_visible_ts <= 0.0 then 0.0
-            else now_ts -. m.runtime.proactive_rt.last_visible_ts
+            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_visible_ts
           in
           let active_model = active_model_of_meta m in
           let next_model_hint = next_model_hint_of_meta m in
@@ -153,9 +154,9 @@ let handle_keeper_list ctx args : tool_result =
               ("run_state", run_state_json);
               ("active_model", `String active_model);
               ("next_model_hint", Json_util.string_opt_to_json next_model_hint);
-              ("keeper_age_s", `Float keeper_age_s);
-              ("last_turn_ago_s", `Float last_turn_ago_s);
-              ("last_proactive_ago_s", `Float last_proactive_ago_s);
+              ("keeper_age_s", Json_util.float_opt_to_json keeper_age_s);
+              ("last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s);
+              ("last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s);
               ("trace_history_count", `Int trace_history_count);
               ("handoff_count_total", `Int trace_history_count);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
@@ -175,7 +176,7 @@ let handle_keeper_list ctx args : tool_result =
                 compaction_decision_json_or_null m.runtime.compaction_rt.last_decision );
               ("last_proactive_ts", `Float m.runtime.proactive_rt.last_ts);
               ("last_visible_proactive_ts", `Float m.runtime.proactive_rt.last_visible_ts);
-              ("last_visible_proactive_ago_s", `Float last_visible_proactive_ago_s);
+              ("last_visible_proactive_ago_s", Json_util.float_opt_to_json last_visible_proactive_ago_s);
               ( "last_proactive_outcome"
               , `String
                   (proactive_cycle_outcome_to_string

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -410,16 +410,21 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          let created_ts =
            Workspace_resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
          in
-         let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-         let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
-         let last_handoff_ago_s = if m.runtime.last_handoff_ts <= 0.0 then 0.0 else now_ts -. m.runtime.last_handoff_ts in
-         let last_compaction_ago_s = if m.runtime.compaction_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.compaction_rt.last_ts in
+         let keeper_age_s = Keeper_status_metrics.age_seconds_opt ~now_ts created_ts in
+         let last_turn_ago_s =
+           Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.usage.last_turn_ts
+         in
+         let last_handoff_ago_s =
+           Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.last_handoff_ts
+         in
+         let last_compaction_ago_s =
+           Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.compaction_rt.last_ts
+         in
          let last_proactive_ago_s =
-           if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
+           Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_ts
          in
          let last_visible_proactive_ago_s =
-           if m.runtime.proactive_rt.last_visible_ts <= 0.0 then 0.0
-           else now_ts -. m.runtime.proactive_rt.last_visible_ts
+           Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_visible_ts
          in
          let trace_history_count = List.length m.runtime.trace_history in
          let runtime_runtime_metrics = `Null in
@@ -801,12 +806,12 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            ("paused", `Bool m.paused);
            ("keepalive_running", `Bool keepalive_running);
            ("agent", agent_status);
-           ("keeper_age_s", `Float keeper_age_s);
-           ("last_turn_ago_s", `Float last_turn_ago_s);
-           ("last_handoff_ago_s", `Float last_handoff_ago_s);
-           ("last_compaction_ago_s", `Float last_compaction_ago_s);
-           ("last_proactive_ago_s", `Float last_proactive_ago_s);
-           ("last_visible_proactive_ago_s", `Float last_visible_proactive_ago_s);
+           ("keeper_age_s", Json_util.float_opt_to_json keeper_age_s);
+           ("last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s);
+           ("last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s);
+           ("last_compaction_ago_s", Json_util.float_opt_to_json last_compaction_ago_s);
+           ("last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s);
+           ("last_visible_proactive_ago_s", Json_util.float_opt_to_json last_visible_proactive_ago_s);
            ("active_model", `Null);
            ("disposition", Json_util.string_opt_to_json disposition);
            ("disposition_reason", Json_util.string_opt_to_json disposition_reason);
@@ -835,16 +840,21 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            ("lifecycle", `Assoc [
              ("created_at", `String m.created_at);
              ("updated_at", `String m.updated_at);
-             ("uptime_hours", `Float (keeper_age_s /. Masc_time_constants.hour));
+             ( "uptime_hours"
+             , Json_util.option_to_yojson
+                 (fun age_s -> `Float (age_s /. Masc_time_constants.hour))
+                 keeper_age_s );
            ]);
            ("proactive", `Assoc [
              ("enabled", `Bool m.proactive.enabled);
              ("count_total", `Int m.runtime.proactive_rt.count_total);
              ("visible_count_total", `Int m.runtime.proactive_rt.visible_count_total);
              ("last_ts", `Float m.runtime.proactive_rt.last_ts);
-             ("last_ago_s", `Float last_proactive_ago_s);
+             ( "last_ago_s"
+             , Json_util.float_opt_to_json last_proactive_ago_s );
              ("last_visible_ts", `Float m.runtime.proactive_rt.last_visible_ts);
-             ("last_visible_ago_s", `Float last_visible_proactive_ago_s);
+             ( "last_visible_ago_s"
+             , Json_util.float_opt_to_json last_visible_proactive_ago_s );
              ( "last_outcome"
              , `String
                  (proactive_cycle_outcome_to_string

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -93,6 +93,9 @@ let empty_tool_audit_snapshot =
     tool_audit_at = None;
   }
 
+let age_seconds_opt ~now_ts timestamp =
+  if timestamp <= 0.0 then None else Some (now_ts -. timestamp)
+
 let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
   let interaction_points = s.turn_points + s.proactive_points in
   let intervention_share =

--- a/lib/keeper/keeper_status_metrics.mli
+++ b/lib/keeper/keeper_status_metrics.mli
@@ -9,6 +9,9 @@ type tool_audit_snapshot = {
 }
 
 val empty_metrics_summary : metrics_summary
+val age_seconds_opt : now_ts:float -> float -> float option
+(** Convert a persisted timestamp to an age while preserving the [0.0]
+    sentinel as [None]. A missing event must not render as "just now". *)
 val metrics_summary_to_json : metrics_summary -> Yojson.Safe.t
 val summarize_metrics_lines :
   string list -> default_generation:int -> metrics_summary

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -264,24 +264,20 @@ let keepers_json
                       |> Option.value ~default:0.0
                     in
                     let last_turn_ago_s =
-                      if meta.runtime.usage.last_turn_ts <= 0.0
-                      then 0.0
-                      else now_ts -. meta.runtime.usage.last_turn_ts
+                      Keeper_status_metrics.age_seconds_opt
+                        ~now_ts meta.runtime.usage.last_turn_ts
                     in
                     let last_handoff_ago_s =
-                      if meta.runtime.last_handoff_ts <= 0.0
-                      then 0.0
-                      else now_ts -. meta.runtime.last_handoff_ts
+                      Keeper_status_metrics.age_seconds_opt
+                        ~now_ts meta.runtime.last_handoff_ts
                     in
                     let last_compaction_ago_s =
-                      if meta.runtime.compaction_rt.last_ts <= 0.0
-                      then 0.0
-                      else now_ts -. meta.runtime.compaction_rt.last_ts
+                      Keeper_status_metrics.age_seconds_opt
+                        ~now_ts meta.runtime.compaction_rt.last_ts
                     in
                     let last_proactive_ago_s =
-                      if meta.runtime.proactive_rt.last_ts <= 0.0
-                      then 0.0
-                      else now_ts -. meta.runtime.proactive_rt.last_ts
+                      Keeper_status_metrics.age_seconds_opt
+                        ~now_ts meta.runtime.proactive_rt.last_ts
                     in
                     let last_activity_ts =
                       List.fold_left
@@ -295,7 +291,7 @@ let keepers_json
                         ]
                     in
                     let last_activity_ago_s =
-                      if last_activity_ts <= 0.0 then 0.0 else now_ts -. last_activity_ts
+                      Keeper_status_metrics.age_seconds_opt ~now_ts last_activity_ts
                     in
                     let diagnostic =
                       Keeper_status_runtime.keeper_diagnostic_json
@@ -409,11 +405,11 @@ let keepers_json
                          ; "agent", agent_json
                          ; "generation", `Int meta.runtime.nonce
                          ; "turn_count", `Int meta.runtime.usage.total_turns
-                         ; "last_turn_ago_s", `Float last_turn_ago_s
-                         ; "last_handoff_ago_s", `Float last_handoff_ago_s
-                         ; "last_compaction_ago_s", `Float last_compaction_ago_s
-                         ; "last_proactive_ago_s", `Float last_proactive_ago_s
-                         ; "last_activity_ago_s", `Float last_activity_ago_s
+                         ; "last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s
+                         ; "last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s
+                         ; "last_compaction_ago_s", Json_util.float_opt_to_json last_compaction_ago_s
+                         ; "last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s
+                         ; "last_activity_ago_s", Json_util.float_opt_to_json last_activity_ago_s
                          ; "last_model_used", `String (Keeper_status_runtime.active_model_of_meta meta)
                          ]
                          @ keeper_runtime_identity_fields meta

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -119,6 +119,21 @@ let test_compaction_decision_value_is_string () =
      = `String "provider_overflow")
 ;;
 
+let test_age_seconds_preserves_missing_timestamp () =
+  Alcotest.check (Alcotest.option (Alcotest.float 0.0001))
+    "zero sentinel becomes missing age"
+    None
+    (Keeper_status_metrics.age_seconds_opt ~now_ts:100.0 0.0);
+  Alcotest.check (Alcotest.option (Alcotest.float 0.0001))
+    "negative sentinel becomes missing age"
+    None
+    (Keeper_status_metrics.age_seconds_opt ~now_ts:100.0 (-1.0));
+  Alcotest.check (Alcotest.option (Alcotest.float 0.0001))
+    "real timestamp remains an age"
+    (Some 25.0)
+    (Keeper_status_metrics.age_seconds_opt ~now_ts:100.0 75.0)
+;;
+
 let () =
   Alcotest.run
     "keeper_status_bridge"
@@ -137,6 +152,12 @@ let () =
             "value decision -> `String"
             `Quick
             test_compaction_decision_value_is_string;
+        ] );
+      ( "timestamp age sentinel SSOT",
+        [ Alcotest.test_case
+            "missing timestamps do not become zero age"
+            `Quick
+            test_age_seconds_preserves_missing_timestamp
         ] );
       ( "profile default override provenance",
         [


### PR DESCRIPTION
## Summary

- preserve missing keeper timestamps as JSON `null` instead of `0` seconds ago
- centralize persisted-timestamp age conversion in `Keeper_status_metrics.age_seconds_opt`
- apply the projection consistently to keeper status, dashboard, and operator snapshots

## Root cause

The persisted runtime uses a non-positive timestamp as a sentinel for an event that has never occurred. The status projections converted that sentinel to the numeric age `0.0`, making “never” indistinguishable from “just now”.

The fix keeps the distinction typed as `float option` and serializes missing ages as `null`. Existing dashboard normalization already treats these fields as optional numbers.

## Validation

- `scripts/dune-local.sh build test/test_keeper_status_bridge.exe`
- `scripts/dune-local.sh build test/test_operator_control_snapshot.exe test/test_keeper_effective_meta_overlay.exe`
- `_build/default/test/test_keeper_status_bridge.exe test 'timestamp age sentinel SSOT'` — passed
- `_build/default/test/test_operator_control_snapshot.exe` — 7/7 passed
- `_build/default/test/test_keeper_effective_meta_overlay.exe` — 24/24 passed
- `git diff --check` — passed

The full `test_keeper_status_bridge` target still has two pre-existing failures in its profile fixture: current meta schema rejects the fixture's `runtime_id` field. The new timestamp test passes independently.
