### PR TITLE
fix(keeper): remove agent registry existence flag

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -620,7 +620,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         agentRaw
           ? {
               name: asString(agentRaw.name),
-              exists: typeof agentRaw.exists === 'boolean' ? agentRaw.exists : undefined,
               error: asString(agentRaw.error),
               agent_type: asString(agentRaw.agent_type),
               status: asString(agentRaw.status),

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -58,7 +58,6 @@ describe('keeperDisplayStatus', () => {
         status: 'offline',
         generation: 0,
         turn_count: 0,
-        agent: { exists: false },
       })
       expect(keeperDisplayStatus(keeper)).toBe('unbooted')
     })
@@ -68,7 +67,6 @@ describe('keeperDisplayStatus', () => {
         status: 'inactive',
         generation: 0,
         turn_count: 0,
-        agent: { exists: false },
       })
       expect(keeperDisplayStatus(keeper)).toBe('unbooted')
     })
@@ -89,18 +87,6 @@ describe('keeperDisplayStatus', () => {
         turn_count: 5,
       })
       expect(keeperDisplayStatus(keeper)).toBe('stopped')
-    })
-
-    it('classifies offline keeper with agent.exists=true but no turns as offline', () => {
-      // agent exists but generation=0, turn_count=0 — doesn't match unbooted
-      // (agent exists) and doesn't match stopped (no turns/generation)
-      const keeper = makeKeeper({
-        status: 'offline',
-        generation: 0,
-        turn_count: 0,
-        agent: { exists: true },
-      })
-      expect(keeperDisplayStatus(keeper)).toBe('offline')
     })
 
     it('classifies offline keeper with all activity signals as stopped', () => {

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -413,13 +413,13 @@ export function keeperPauseDisplay(keeper: Keeper): KeeperPauseDisplay | null {
 }
 
 /** Distinguish "never booted" from "was running but stopped" keepers.
- *  Reconciles heartbeat liveness with agent registration status:
- *  if heartbeat is recent but agent is offline, shows phase instead of "offline". */
+ *  A recent heartbeat is authoritative for a live keeper; otherwise activity
+ *  counters distinguish a cold start from a stopped process. */
 function refineOfflineStatus(keeper: Keeper | null | undefined): KeeperPhaseToken {
   if (!keeper) return 'offline'
 
-  // Heartbeat alive but agent offline — keepalive fiber is running.
-  // Show actual phase instead of misleading "offline".
+  // Heartbeat alive — keepalive fiber is running. Show actual phase instead of
+  // misleading "offline".
   //
   // `keeper.phase` carries the typed `KeeperPhase` PascalCase token
   // (`dashboard/src/types/core.ts:879-892`), normalised by
@@ -450,10 +450,9 @@ function refineOfflineStatus(keeper: Keeper | null | undefined): KeeperPhaseToke
 
   const generation = keeper.generation ?? 0
   const turnCount = keeper.turn_count ?? 0
-  const agentExists = keeper.agent?.exists ?? false
 
-  // Never ran a single turn or generation — registered but never booted
-  if (generation === 0 && turnCount === 0 && !agentExists) {
+  // Never ran a single turn or generation — never booted
+  if (generation === 0 && turnCount === 0) {
     return 'unbooted'
   }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1303,7 +1303,6 @@ export interface Keeper {
   metrics_window?: MetricsWindow
   agent?: {
     name?: string
-    exists?: boolean
     error?: string
     agent_type?: string
     status?: string

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -98,15 +98,15 @@ let parse_agent_status (config : Workspace.config) ~(agent_name : string) : Yojs
     Filename.concat (Workspace.agents_dir config) (Workspace.safe_filename agent_name ^ ".json")
   in
   if not (Workspace.path_exists config agent_file) then
-    `Assoc [ ("exists", `Bool false) ]
+    `Assoc []
   else (
     match Workspace.read_json_opt config agent_file with
     | None ->
-        `Assoc [ ("exists", `Bool true); ("error", `String "failed_to_read") ]
+        `Assoc [ ("error", `String "failed_to_read") ]
     | Some json -> (
         match Masc_domain.agent_of_yojson json with
         | Error _ ->
-            `Assoc [ ("exists", `Bool true); ("error", `String "failed_to_parse") ]
+            `Assoc [ ("error", `String "failed_to_parse") ]
         | Ok (agent : Masc_domain.agent) ->
             let now_ts = Time_compat.now () in
             let session_bound_ts =
@@ -123,7 +123,6 @@ let parse_agent_status (config : Workspace.config) ~(agent_name : string) : Yojs
             in
             `Assoc
               [
-                ("exists", `Bool true);
                 ("name", `String agent.name);
                 ("agent_type", `String agent.agent_type);
                 ("status", `String (Masc_domain.string_of_agent_status agent.status));
@@ -137,9 +136,6 @@ let parse_agent_status (config : Workspace.config) ~(agent_name : string) : Yojs
               ]))
 
 let json_string_opt key json = Json_util.get_string_nonempty json key
-
-let json_bool key json default =
-  Safe_ops.json_bool ~default key json
 
 let json_float_opt key json =
   Safe_ops.json_float_opt key json
@@ -297,8 +293,7 @@ let live_signal_supersedes_persisted_error ~keepalive_running ~agent_status ~met
       proactive_error_ts > 0.0 && last_turn_ts > proactive_error_ts
     in
     let external_live_signal =
-      json_bool "exists" agent_status false
-      && agent_runtime_has_live_signal agent_status
+      agent_runtime_has_live_signal agent_status
       &&
       match agent_last_seen_ts_opt agent_status with
       | Some last_seen_ts -> last_seen_ts > max proactive_error_ts last_turn_ts
@@ -344,8 +339,8 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   | Fiber_zombie -> KH_zombie
   | Fiber_dead -> KH_dead
   | Fiber_alive | Fiber_unknown ->
-  let agent_exists = json_bool "exists" agent_status false in
   let agent_runtime_status = agent_runtime_status_opt agent_status in
+  let agent_registry_status_present = Option.is_some agent_runtime_status in
   let last_seen_ago_s =
     json_float_opt "last_seen_ago_s" agent_status |> Option.value ~default:max_float
   in
@@ -353,10 +348,13 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   let _ = now_ts in
   if
     (not keepalive_running)
-    && (not agent_exists || agent_runtime_status = Some Masc_domain.Inactive)
+    &&
+    (not agent_registry_status_present
+    || agent_runtime_status = Some Masc_domain.Inactive)
   then KH_offline
   else if keepalive_running then
-    if agent_exists && last_seen_ago_s > 2.0 *. keepalive_interval_s then KH_stale
+    if agent_registry_status_present && last_seen_ago_s > 2.0 *. keepalive_interval_s
+    then KH_stale
     else
       (match quiet_reason with
     | Some "graphql_error" | Some "model_error" -> KH_degraded

--- a/lib/keeper/keeper_status_runtime.mli
+++ b/lib/keeper/keeper_status_runtime.mli
@@ -8,6 +8,8 @@ val next_model_hint_of_meta : keeper_meta -> string option
 val string_of_fiber_health : fiber_health -> string
 (** Parse the "status" field of an agent-status snapshot blob (produced by
     {!parse_agent_status}) into the closed [Masc_domain.agent_status] ADT.
+    An absent agent-registry record is represented by an empty object; the
+    snapshot has no separate existence flag.
     Returns [None] when the field is absent or not one of the four canonical
     lowercase labels, so callers classify the closed domain exhaustively
     instead of comparing string literals. *)

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -255,9 +255,6 @@ let keepers_json
                       Keeper_status_bridge.runtime_keepalive_started_at config meta
                     in
                     dt_ka := Time_compat.now () -. t_ka;
-                    let agent_exists =
-                      Safe_ops.json_bool ~default:false "exists" agent_json
-                    in
                     let now_ts = Time_compat.now () in
                     let created_ts =
                       Workspace_resilience.Time.parse_iso8601_opt meta.created_at
@@ -332,12 +329,9 @@ let keepers_json
                     in
                     dt_audit := Time_compat.now () -. t_audit;
                     let surface_status =
-                      if not agent_exists
-                      then "offline"
-                      else
-                        Keeper_status_runtime.keeper_surface_status
-                          ~agent_status:agent_json
-                          ~diagnostic
+                      Keeper_status_runtime.keeper_surface_status
+                        ~agent_status:agent_json
+                        ~diagnostic
                     in
                     let aligned_status =
                       if meta.paused

--- a/test/test_keeper_agent_runtime_status.ml
+++ b/test/test_keeper_agent_runtime_status.ml
@@ -46,7 +46,29 @@ let test_outside_domain_is_none () =
 
 let test_absent_status_is_none () =
   check bool "blob without status field -> None" true
-    (K.agent_runtime_status_opt (blob [ ("exists", `Bool true) ]) = None)
+    (K.agent_runtime_status_opt (blob []) = None)
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_agent_status_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  try Unix.rmdir dir with Unix.Unix_error _ -> ()
+
+let test_absent_registry_has_no_existence_field () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      match K.parse_agent_status config ~agent_name:"missing-agent" with
+      | `Assoc fields ->
+          check bool "missing registry is an empty projection" true (fields = []);
+          check bool "missing registry has no existence field" false
+            (List.mem_assoc "exists" fields)
+      | _ -> check bool "missing registry is an object" true false)
 
 let test_live_signal () =
   let live s = blob [ ("status", `String s); ("last_seen_ago_s", `Float 1.0) ] in
@@ -70,6 +92,8 @@ let test_surface_status () =
   check string "healthy + active -> active" "active"
     (K.keeper_surface_status ~agent_status:(status "active")
        ~diagnostic:(diag "healthy"));
+  check string "healthy + absent registry -> active" "active"
+    (K.keeper_surface_status ~agent_status:(blob []) ~diagnostic:(diag "healthy"));
   check string "healthy + inactive -> offline" "offline"
     (K.keeper_surface_status ~agent_status:(status "inactive")
        ~diagnostic:(diag "healthy"));
@@ -94,6 +118,8 @@ let () =
           test_case "case-insensitive" `Quick test_case_insensitive;
           test_case "outside-domain -> None" `Quick test_outside_domain_is_none;
           test_case "absent -> None" `Quick test_absent_status_is_none;
+          test_case "absent registry has no exists field" `Quick
+            test_absent_registry_has_no_existence_field;
         ] );
       ( "predicates",
         [

--- a/test/test_keeper_diagnostic_stale_last_error.ml
+++ b/test/test_keeper_diagnostic_stale_last_error.ml
@@ -9,10 +9,10 @@
 
     Production shape matters here: keepers do NOT publish an external
     agent-registry record ([.masc/agents/<agent_name>.json] is absent), so the
-    real [agent_status] passed in is [{exists=false}]. The supersede therefore
+    real [agent_status] passed in is an empty registry projection. The supersede therefore
     has to fire on the keeper's OWN signal — a turn completed after the
     erroring proactive cycle ([usage.last_turn_ts] > [proactive_rt.last_ts]).
-    The tests pin both: the keeper-self path with the production [{exists=false}]
+    The tests pin both: the keeper-self path with the production empty projection
     status, and the external-registry path for non-keeper participants.
 
     The error reason modelled here is the deleted tool-retry-budget bug
@@ -56,7 +56,6 @@ let meta_with_persisted_error ~proactive_ts ~last_turn_ts =
         [ ("name", `String "stalekeeper")
         ; ("agent_name", `String "keeper-stalekeeper-agent")
         ; ("trace_id", `String "trace-stalekeeper")
-        ; ("runtime_id", `String "ollama_cloud.deepseek-v4-flash")
         ; ("last_proactive_outcome", `String "error")
         ; ("last_proactive_reason", `String error_reason)
         ; ("last_proactive_ts", `Float proactive_ts)
@@ -69,14 +68,13 @@ let meta_with_persisted_error ~proactive_ts ~last_turn_ts =
   | Error err -> Alcotest.failf "meta_of_json_fixture failed: %s" err
 ;;
 
-(* The real agent_status a keeper gets: no agent-registry file -> exists=false. *)
-let keeper_agent_status = `Assoc [ ("exists", `Bool false) ]
+(* The real agent_status a keeper gets: no agent-registry file -> empty projection. *)
+let keeper_agent_status = `Assoc []
 
 (* A non-keeper participant that publishes a fresh live agent record. *)
 let external_live_agent_status ~last_seen =
   `Assoc
-    [ ("exists", `Bool true)
-    ; ("status", `String "active")
+    [ ("status", `String "active")
     ; ("last_seen_ago_s", `Float 5.0)
     ; ("last_seen", `String last_seen)
     ]
@@ -101,7 +99,7 @@ let diagnostic_of ~meta ~agent_status ~keepalive_running =
     ~now_ts
 ;;
 
-(* Production case: keeper (exists=false agent_status) that turned after its
+(* Production case: keeper with no registry projection that turned after its
    erroring proactive cycle. This is the case that previously kept showing
    "이전 오류" across restarts and that the external-signal-only guard could
    never clear. *)


### PR DESCRIPTION
## Summary
- remove the Keeper agent.exists wire field from server projection and dashboard consumers
- derive liveness/surface decisions from typed status, keepalive, fiber health, and activity signals
- add regression coverage for the empty registry projection and repair the stale-error fixture to the current meta schema

## Root cause
Keepers do not publish .masc/agents records, but the projection emitted agent.exists=false. Operator snapshot and dashboard code treated that registry absence as Keeper offline, overriding live keepalive/fiber evidence.

## Checks
- scripts/dune-local.sh build test/test_keeper_agent_runtime_status.exe test/test_keeper_diagnostic_stale_last_error.exe
- focused OCaml tests: 7 + 5 passed
- scripts/dune-local.sh build lib/operator/operator_control_snapshot.ml
- dashboard: npx tsc --noEmit --pretty
- dashboard Vitest not run: worktree has no installed vitest dependency