### PR TITLE
Fix queued Gate-deferred Keeper replies

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -29,6 +29,14 @@ let normalize_response_text_for_finalization
       ~tool_names
       ()
   =
+  match run_result.stop_reason with
+  | Runtime_agent.Awaiting_external_effect _ ->
+    Ok Keeper_agent_run_response_text.external_effect_deferred_acknowledgement
+  | Runtime_agent.Completed
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_after_repeated_tool_call _
+  | Runtime_agent.InputRequired _ ->
   if
     Keeper_agent_run_response_text.stop_reason_suppresses_visible_response
       run_result.stop_reason
@@ -244,8 +252,10 @@ let dispatch_after_provider_transcript_admission ~messages ~dispatch =
 
 let terminal_effect_boundary_decision = function
   | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
-  | Keeper_tools_oas.External_effect_deferred ->
+  | Keeper_tools_oas.Deferred_tool_result ->
     Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
+  | Keeper_tools_oas.External_effect_deferred ->
+    Ok (Runtime_agent.Yield Runtime_agent.External_effect_deferred)
   | Keeper_tools_oas.Terminal_effect_completed ->
     Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
   | Keeper_tools_oas.Terminal_effect_failed

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -56,9 +56,10 @@ val durable_stimulus_summary_to_string : durable_stimulus_summary -> string
 val terminal_effect_boundary_decision
   :  Keeper_tools_oas.terminal_effect_state
   -> (Runtime_agent.cooperative_yield_decision, Agent_sdk.Error.sdk_error) result
-(** Production boundary projection for Keeper tool results. Deferred external
-    effects yield the current provider loop so their durable resolution can
-    wake a later turn. Failed terminal effects retain their typed
+(** Production boundary projection for Keeper tool results. Generic deferred
+    tool transitions retain the normal durable-stimulus checkpoint; deferred
+    external effects yield the current provider loop so their durable
+    resolution can wake a later turn. Failed terminal effects retain their typed
     [Tool_result.tool_failure_class] in the exact structured Keeper error
     envelope. *)
 

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -29,6 +29,7 @@ let observed_completion_evidence
   | Runtime_agent.InputRequired _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Keeper_execution_receipt.Completion_observation_unknown
   | Runtime_agent.Completed ->

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -217,6 +217,7 @@ let checkpoint_for_replay_persistence
           pre-turn history prefix")
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     (* A control-boundary checkpoint retains the current-turn tool result so
        resumption cannot repeat an already committed effect. *)

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -4,12 +4,17 @@ type finalized = {
   response_text : string;
 }
 
+let external_effect_deferred_acknowledgement =
+  "External effect is awaiting Gate approval. The Keeper will continue after the durable resolution."
+;;
+
 let stop_reason_suppresses_visible_response = function
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     true
   | Runtime_agent.Completed
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.InputRequired _ ->
     false
 ;;

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -4,6 +4,11 @@ type finalized = {
   response_text : string;
 }
 
+(** Deterministic acknowledgement emitted for a Gate-deferred external effect.
+    This is a user-facing completion for the originating chat request; the
+    effect result itself is delivered by the later durable resolution. *)
+val external_effect_deferred_acknowledgement : string
+
 (** [true] for typed control checkpoints and no-output execution observations
     that must not manufacture a chat reply. Their state remains observable
     through typed stop/event surfaces. *)

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -199,6 +199,8 @@ let stop_reason_to_string = function
     Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
     Printf.sprintf "yielded_to_durable_stimulus:%d" turns_used
+  | Runtime_agent.Awaiting_external_effect { turns_used } ->
+    Printf.sprintf "awaiting_external_effect:%d" turns_used
   | Runtime_agent.Yielded_after_repeated_tool_call
       { turns_used; tool_name; repeated_count } ->
     Printf.sprintf
@@ -220,6 +222,7 @@ let receipt_terminal_reason_code_of_stop_reason = function
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success
   | ( Runtime_agent.Yielded_to_chat_waiting _
     | Runtime_agent.Yielded_to_durable_stimulus _
+    | Runtime_agent.Awaiting_external_effect _
     | Runtime_agent.Yielded_after_repeated_tool_call _ ) as stop_reason ->
     stop_reason_to_string stop_reason
 ;;

--- a/lib/keeper/keeper_gate_deferred_payload.ml
+++ b/lib/keeper/keeper_gate_deferred_payload.ml
@@ -33,7 +33,7 @@ let data t =
 ;;
 
 let to_execution t =
-  Keeper_tool_execution.deferred_data (data t)
+  Keeper_tool_execution.deferred_external_effect_data (data t)
 ;;
 
 let to_tool_result ~tool_name ~start_time t =

--- a/lib/keeper/keeper_tool_execution.ml
+++ b/lib/keeper/keeper_tool_execution.ml
@@ -1,3 +1,7 @@
+type deferred_kind =
+  | Generic_deferred
+  | External_effect_deferred
+
 type t =
   { raw_output : string
   ; data : Yojson.Safe.t option
@@ -5,6 +9,7 @@ type t =
   ; failure_effect_disposition : Tool_result.failure_effect_disposition
   ; disposition :
       (unit, unit, Tool_result.tool_failure_class) Tool_result.disposition
+  ; deferred_kind : deferred_kind option
   }
 
 let success raw_output =
@@ -13,6 +18,7 @@ let success raw_output =
   ; metadata = None
   ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
   ; disposition = Tool_result.Completed ()
+  ; deferred_kind = None
   }
 ;;
 
@@ -22,6 +28,7 @@ let success_data ?metadata data =
   ; metadata
   ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
   ; disposition = Tool_result.Completed ()
+  ; deferred_kind = None
   }
 ;;
 
@@ -31,6 +38,17 @@ let deferred_data ?metadata data =
   ; metadata
   ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
   ; disposition = Tool_result.Deferred ()
+  ; deferred_kind = Some Generic_deferred
+  }
+;;
+
+let deferred_external_effect_data ?metadata data =
+  { raw_output = Yojson.Safe.to_string data
+  ; data = Some data
+  ; metadata
+  ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
+  ; disposition = Tool_result.Deferred ()
+  ; deferred_kind = Some External_effect_deferred
   }
 ;;
 
@@ -44,6 +62,7 @@ let failure
   ; metadata = None
   ; failure_effect_disposition = effect_disposition
   ; disposition = Tool_result.Failed class_
+  ; deferred_kind = None
   }
 ;;
 
@@ -58,6 +77,7 @@ let failure_data
   ; metadata = None
   ; failure_effect_disposition = effect_disposition
   ; disposition = Tool_result.Failed class_
+  ; deferred_kind = None
   }
 ;;
 
@@ -71,6 +91,7 @@ let of_tool_result (result : Tool_result.result) =
     ; metadata
     ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
     ; disposition = Tool_result.Completed ()
+    ; deferred_kind = None
     }
   | Tool_result.Deferred { metadata; _ } ->
     { raw_output
@@ -78,6 +99,7 @@ let of_tool_result (result : Tool_result.result) =
     ; metadata
     ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
     ; disposition = Tool_result.Deferred ()
+    ; deferred_kind = Some Generic_deferred
     }
   | Tool_result.Failed { class_; _ } ->
     { raw_output
@@ -85,5 +107,6 @@ let of_tool_result (result : Tool_result.result) =
     ; metadata = None
     ; failure_effect_disposition = Tool_result.Effect_outcome_unknown
     ; disposition = Tool_result.Failed class_
+    ; deferred_kind = None
     }
 ;;

--- a/lib/keeper/keeper_tool_execution.mli
+++ b/lib/keeper/keeper_tool_execution.mli
@@ -1,6 +1,13 @@
 (** Producer-owned Keeper execution result.
 
-    [disposition] uses the canonical {!Tool_result.disposition}; this module
+    [deferred_kind] distinguishes a generic deferred tool transition from a
+    deferred external effect. It is producer-owned and must never be recovered
+    by parsing the opaque provider-facing tool body. *)
+type deferred_kind =
+  | Generic_deferred
+  | External_effect_deferred
+
+(** [disposition] uses the canonical {!Tool_result.disposition}; this module
     deliberately defines no parallel outcome enum.  [raw_output] is opaque
     text. [data] and [metadata] exist only when the producer supplied them. *)
 
@@ -14,6 +21,7 @@ type t = private
           strongest phase they can prove. *)
   ; disposition :
       (unit, unit, Tool_result.tool_failure_class) Tool_result.disposition
+  ; deferred_kind : deferred_kind option
   }
 
 val success : string -> t
@@ -25,6 +33,10 @@ val success_data : ?metadata:Yojson.Safe.t -> Yojson.Safe.t -> t
 (** Typed deferral. [metadata] is an opaque one-way OAS projection, never a
     source from which MASC recovers the disposition. *)
 val deferred_data : ?metadata:Yojson.Safe.t -> Yojson.Safe.t -> t
+
+(** Typed deferral for an external effect whose durable resolution resumes the
+    Keeper later. *)
+val deferred_external_effect_data : ?metadata:Yojson.Safe.t -> Yojson.Safe.t -> t
 
 val failure
   :  ?class_:Tool_result.tool_failure_class

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -17,6 +17,7 @@ type terminal_effect_failure =
 
 type terminal_effect_state =
   | Terminal_effect_open
+  | Deferred_tool_result
   | External_effect_deferred
   | Terminal_effect_completed
   | Terminal_effect_failed of terminal_effect_failure

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -19,7 +19,11 @@ type terminal_effect_failure =
 
 type terminal_effect_state =
   | Terminal_effect_open
+      (** No tool has requested a turn boundary. *)
+  | Deferred_tool_result
+      (** A normal tool transition deferred; it is not a Gate external effect. *)
   | External_effect_deferred
+      (** Gate deferred an external effect and will emit a durable resolution. *)
   | Terminal_effect_completed
   | Terminal_effect_failed of terminal_effect_failure
 

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -130,25 +130,49 @@ let make_tool_bundle
   let model_visible_descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
   (* The bundle lives for exactly one Agent run. Its typed tool-boundary
      state is request-scoped and observed by the OAS tool-boundary probe only
-     after the whole tool batch and checkpoint sink have completed. Deferred
-     external effects stop the provider loop until their durable resolution
-     wakes a later turn. A terminal completion supersedes a defer in the same
-     batch; a proven terminal failure dominates every state regardless of
-     callback order. Failure is sticky so its first diagnostic remains
-     authoritative. *)
+     after the whole tool batch and checkpoint sink have completed. A generic
+     deferred tool transition retains the existing durable-stimulus checkpoint;
+     only a typed external-effect defer stops the provider loop until Gate's
+     durable resolution wakes a later turn. A terminal completion supersedes a
+     defer in the same batch; a proven terminal failure dominates every state
+     regardless of callback order. Failure is sticky so its first diagnostic
+     remains authoritative. *)
   let terminal_effect_state = Atomic.make Terminal_effect_open in
-  let mark_external_effect_deferred () =
+  let mark_deferred_tool_result () =
     ignore
       (Atomic.compare_and_set
          terminal_effect_state
          Terminal_effect_open
-         External_effect_deferred)
+         Deferred_tool_result)
+  in
+  let mark_external_effect_deferred () =
+    (* A generic deferred transition may precede the Gate result in one OAS
+       batch. The external effect owns the user-facing terminal projection, so
+       it must promote that generic state rather than being hidden by it. *)
+    let rec transition () =
+      match Atomic.get terminal_effect_state with
+      | External_effect_deferred
+      | Terminal_effect_completed
+      | Terminal_effect_failed _ ->
+        ()
+      | (Terminal_effect_open | Deferred_tool_result) as current ->
+        if
+          not
+            (Atomic.compare_and_set
+               terminal_effect_state
+               current
+               External_effect_deferred)
+        then transition ()
+    in
+    transition ()
   in
   let mark_terminal_effect_completed () =
     let rec transition () =
       match Atomic.get terminal_effect_state with
       | Terminal_effect_completed | Terminal_effect_failed _ -> ()
-      | (Terminal_effect_open | External_effect_deferred) as current ->
+      | ( Terminal_effect_open
+        | Deferred_tool_result
+        | External_effect_deferred ) as current ->
         if
           not
             (Atomic.compare_and_set
@@ -164,6 +188,7 @@ let make_tool_bundle
       match Atomic.get terminal_effect_state with
       | Terminal_effect_failed _ -> ()
       | ( Terminal_effect_open
+        | Deferred_tool_result
         | External_effect_deferred
         | Terminal_effect_completed ) as current ->
         if
@@ -209,7 +234,8 @@ let make_tool_bundle
                  ?gate_grant
                  ?record_gate_result
                  ?on_completed
-                 ~on_deferred:mark_external_effect_deferred
+                 ~on_deferred:mark_deferred_tool_result
+                 ~on_external_effect_deferred:mark_external_effect_deferred
                  ?on_failed
                  ~pre_validate_input:(fun input ->
                    match

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -25,6 +25,7 @@ let make_keeper_tool_handler
       ?record_gate_result
       ?on_completed
       ?on_deferred
+      ?on_external_effect_deferred
       ?on_failed
       ?(pre_validate_input = fun input -> Ok input)
       ?(translate_input = fun j -> j)
@@ -40,13 +41,20 @@ let make_keeper_tool_handler
   in
   let observe_terminal_execution_result
         ~failure_effect_disposition
+        ~deferred_kind
         (result : Tool_result.result)
     =
     (match result with
      | Tool_result.Completed _ ->
        Option.iter (fun completed -> completed ()) on_completed
      | Tool_result.Deferred _ ->
-       Option.iter (fun deferred -> deferred ()) on_deferred
+       (match deferred_kind with
+        | Some Keeper_tool_execution.External_effect_deferred ->
+          Option.iter
+            (fun deferred -> deferred ())
+            on_external_effect_deferred
+        | None | Some Keeper_tool_execution.Generic_deferred ->
+          Option.iter (fun deferred -> deferred ()) on_deferred)
      | Tool_result.Failed { class_; message; _ } ->
        let effect_disposition =
          Option.value
@@ -176,6 +184,7 @@ let make_keeper_tool_handler
             |> observe_terminal_execution_result
                  ~failure_effect_disposition:
                    execution.failure_effect_disposition
+                 ~deferred_kind:execution.deferred_kind
           in
           run_with_current_eio_context ?clock:current_clock ())
 ;;

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -36,6 +36,7 @@ val make_keeper_tool_handler
        (operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit)
   -> ?on_completed:(unit -> unit)
   -> ?on_deferred:(unit -> unit)
+  -> ?on_external_effect_deferred:(unit -> unit)
   -> ?on_failed:(Keeper_tools_oas.terminal_effect_failure -> unit)
   -> ?pre_validate_input:
        (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -6,6 +6,7 @@ open Keeper_tools_oas_handler_telemetry
 type execution_result =
   { tool_result : Tool_result.result
   ; failure_effect_disposition : Tool_result.failure_effect_disposition option
+  ; deferred_kind : Keeper_tool_execution.deferred_kind option
   }
 
 let producer_payload ~raw = function
@@ -132,6 +133,7 @@ let execute_with_observers
         ();
       { tool_result = dispatch_result
       ; failure_effect_disposition = Some result.failure_effect_disposition
+      ; deferred_kind = None
       }
     | Tool_result.Completed () ->
       Option.iter
@@ -192,7 +194,10 @@ let execute_with_observers
         ~keeper_name:meta.name
         ~original_bytes:original_len
         ();
-      { tool_result = observed_result; failure_effect_disposition = None }
+      { tool_result = observed_result
+      ; failure_effect_disposition = None
+      ; deferred_kind = None
+      }
     | Tool_result.Deferred () ->
       Option.iter
         (Keeper_tool_emission_hook.capture_typed_result_for_keeper
@@ -248,7 +253,10 @@ let execute_with_observers
         ~keeper_name:meta.name
         ~original_bytes:(String.length projected_result)
         ();
-      { tool_result = observed_result; failure_effect_disposition = None }
+      { tool_result = observed_result
+      ; failure_effect_disposition = None
+      ; deferred_kind = result.deferred_kind
+      }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -315,5 +323,6 @@ let execute_with_observers
       ();
     { tool_result = exception_result
     ; failure_effect_disposition = Some Tool_result.Effect_outcome_unknown
+    ; deferred_kind = None
     }
 ;;

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -3,6 +3,7 @@
 type execution_result =
   { tool_result : Tool_result.result
   ; failure_effect_disposition : Tool_result.failure_effect_disposition option
+  ; deferred_kind : Keeper_tool_execution.deferred_kind option
   }
 
 (** Execute a keeper tool call with full observability: telemetry,

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -153,6 +153,7 @@ let apply_accept
   | Runtime_agent.InputRequired _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     (* These are typed host-control terminals, not model deliverables. Running
        the normal response accept predicate over their question/blank carrier

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -36,6 +36,7 @@ let of_stop_reason = function
   | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Continuation_checkpoint
+  | Runtime_agent.Awaiting_external_effect _ -> Visible_reply
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_result_surface ~response_text = function
@@ -45,6 +46,8 @@ let of_result_surface ~response_text = function
   | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Continuation_checkpoint
+  | Runtime_agent.Awaiting_external_effect _ ->
+    if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_reply_payload payload =

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -7,7 +7,9 @@
     ([Continuation_checkpoint]).  Consumers (lane persistence, stream
     terminal, direct-reply surface, dashboard) match on the decoded
     variant; the legacy ["Continuation checkpoint saved;"] prefix sniff
-    is deleted. *)
+    is deleted. A typed Gate deferral is instead finalized as a visible,
+    host-authored acknowledgement; it must not be projected as a checkpoint
+    transport failure. *)
 
 type t =
   | Visible_reply

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -114,6 +114,7 @@ let turn_success_of_stop_reason ~meta = function
   | Runtime_agent.Completed -> Turn_completed meta
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Turn_checkpointed meta
   | Runtime_agent.InputRequired _ -> Turn_input_required meta

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -61,6 +61,7 @@ let terminal_outcome_of_result result =
   | Runtime_agent.InputRequired _ -> Terminal_input_required
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Terminal_checkpoint
 ;;
@@ -257,6 +258,8 @@ let emit_usage_metrics_and_log
       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
     | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
       Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
+    | Runtime_agent.Awaiting_external_effect { turns_used } ->
+      Printf.sprintf "awaiting_external_effect(%d)" turns_used
     | Runtime_agent.Yielded_after_repeated_tool_call
         { turns_used; tool_name; repeated_count } ->
       Printf.sprintf
@@ -276,6 +279,7 @@ let emit_usage_metrics_and_log
        | Runtime_agent.Yielded_to_chat_waiting _ -> "yielded_to_chat_waiting"
        | Runtime_agent.Yielded_to_durable_stimulus _ ->
          "yielded_to_durable_stimulus"
+       | Runtime_agent.Awaiting_external_effect _ -> "awaiting_external_effect"
        | Runtime_agent.Yielded_after_repeated_tool_call _ ->
          "yielded_after_repeated_tool_call"
        | Runtime_agent.InputRequired _ -> "input_required"
@@ -393,6 +397,7 @@ let terminal_reason_of_outcome result = function
     (match result.Keeper_agent_run.stop_reason with
      | Runtime_agent.Yielded_to_chat_waiting _
      | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Awaiting_external_effect _
      | Runtime_agent.Yielded_after_repeated_tool_call _
      | Runtime_agent.InputRequired _ ->
        Keeper_turn_terminal.of_disposition
@@ -470,6 +475,11 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Log.Keeper.info ~keeper_name:updated_meta.name
       "yielded autonomous run for a pending durable stimulus after %d turn(s), \
        checkpoint saved — will resume next cycle"
+      turns_used;
+    reset_failure_state ()
+  | Runtime_agent.Awaiting_external_effect { turns_used } ->
+    Log.Keeper.info ~keeper_name:updated_meta.name
+      "external effect awaits Gate resolution after %d turn(s), checkpoint saved"
       turns_used;
     reset_failure_state ()
   | Runtime_agent.Yielded_after_repeated_tool_call

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -64,6 +64,7 @@ type stop_reason =
   | Completed
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Awaiting_external_effect of { turns_used : int }
   | Yielded_after_repeated_tool_call of
       { turns_used : int
       ; tool_name : string
@@ -77,6 +78,7 @@ type stop_reason =
 type cooperative_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | External_effect_deferred
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
@@ -784,6 +786,7 @@ let stop_reason_of_cooperative_yield ~turns_used = function
   | Chat_waiting -> Yielded_to_chat_waiting { turns_used }
   | Durable_stimulus_waiting ->
     Yielded_to_durable_stimulus { turns_used }
+  | External_effect_deferred -> Awaiting_external_effect { turns_used }
   | Repeated_tool_call { tool_name; repeated_count } ->
     Yielded_after_repeated_tool_call
       { turns_used; tool_name; repeated_count }
@@ -927,6 +930,8 @@ let dashboard_status_of_stop_reason = function
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_chat_waiting" }
   | Yielded_to_durable_stimulus _ ->
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_durable_stimulus" }
+  | Awaiting_external_effect _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "awaiting_external_effect" }
   | Yielded_after_repeated_tool_call _ ->
       Dashboard_oas_bridge.Cancelled
         { reason = "yielded_after_repeated_tool_call" }

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -23,6 +23,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
   | Completed
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Awaiting_external_effect of { turns_used : int }
   | Yielded_after_repeated_tool_call of {
       turns_used : int;
       tool_name : string;
@@ -36,6 +37,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
 type cooperative_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | External_effect_deferred
   | Repeated_tool_call of {
       tool_name : string;
       repeated_count : int;
@@ -55,8 +57,11 @@ type cooperative_yield_probe =
     turn slot to a parked dashboard/connector chat request.
     [Yielded_to_durable_stimulus] fires after at least one provider turn when
     another durable event is waiting behind the event currently leased by the
-    cycle. [Yielded_after_repeated_tool_call] fires only after repeated exact
-    tool input and output prove that the provider loop is not advancing.
+    cycle. [Awaiting_external_effect] fires when a typed external-effect
+    handler durably defers through Gate; it is distinct because the originating
+    chat must receive an acknowledgement rather than a transport failure.
+    [Yielded_after_repeated_tool_call] fires only after repeated exact tool
+    input and output prove that the provider loop is not advancing.
     [InputRequired] means OAS returned a typed elicitation request whose
     question and checkpoint must be surfaced without provider fallback. These
     typed non-completion stops persist checkpoints rather than claiming a

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -18,6 +18,10 @@ type stop_reason =
     (* The current autonomous cycle completed at least one OAS provider turn,
        then released its lane because another durable stimulus was queued
        behind the stimulus already leased by this cycle. *)
+  | Awaiting_external_effect of { turns_used : int }
+    (* A typed external-effect handler recorded a Gate request. The request is
+       still live, and its origin must receive an acknowledgement while the
+       durable resolution owns the eventual continuation. *)
   | Yielded_after_repeated_tool_call of
       { turns_used : int
       ; tool_name : string

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -16,6 +16,7 @@ type stop_reason =
   | Completed
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Awaiting_external_effect of { turns_used : int }
   | Yielded_after_repeated_tool_call of {
       turns_used : int;
       tool_name : string;

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2886,6 +2886,8 @@ let test_invalid_surface_post_input_stays_correction_capable () =
         | Ok _ -> fail "handler-level invalid terminal input unexpectedly succeeded");
        (match bundle.terminal_effect_state () with
         | Masc.Keeper_tools_oas.Terminal_effect_open -> ()
+        | Masc.Keeper_tools_oas.Deferred_tool_result ->
+          fail "invalid terminal input unexpectedly deferred a tool result"
         | Masc.Keeper_tools_oas.External_effect_deferred ->
           fail "invalid terminal input unexpectedly deferred an external effect"
         | Masc.Keeper_tools_oas.Terminal_effect_completed ->
@@ -2907,6 +2909,8 @@ let test_invalid_surface_post_input_stays_correction_capable () =
         | Masc.Keeper_tools_oas.Terminal_effect_completed -> ()
         | Masc.Keeper_tools_oas.Terminal_effect_open ->
           fail "corrected terminal input left the terminal effect open"
+        | Masc.Keeper_tools_oas.Deferred_tool_result ->
+          fail "corrected terminal input unexpectedly deferred a tool result"
         | Masc.Keeper_tools_oas.External_effect_deferred ->
           fail "corrected terminal input unexpectedly deferred an external effect"
         | Masc.Keeper_tools_oas.Terminal_effect_failed _ ->
@@ -2934,6 +2938,8 @@ let test_invalid_surface_post_input_stays_correction_capable () =
        | Masc.Keeper_tools_oas.Terminal_effect_failed _ -> ()
        | Masc.Keeper_tools_oas.Terminal_effect_open ->
          fail "later failure reopened the completed terminal effect"
+       | Masc.Keeper_tools_oas.Deferred_tool_result ->
+         fail "later failure unexpectedly became a generic defer"
        | Masc.Keeper_tools_oas.External_effect_deferred ->
          fail "later failure unexpectedly became an external defer"
        | Masc.Keeper_tools_oas.Terminal_effect_completed ->
@@ -3094,7 +3100,7 @@ let test_deferred_web_search_yields_before_provider_retry () =
        (match runtime_result with
         | Ok
             { Runtime_agent.stop_reason =
-                Runtime_agent.Yielded_to_durable_stimulus _
+                Runtime_agent.Awaiting_external_effect _
             ; _
             } ->
           ()
@@ -3109,6 +3115,8 @@ let test_deferred_web_search_yields_before_provider_retry () =
             (Agent_sdk.Error.to_string error));
        match bundle.terminal_effect_state () with
        | Masc.Keeper_tools_oas.External_effect_deferred -> ()
+       | Masc.Keeper_tools_oas.Deferred_tool_result ->
+         fail "Gate deferred effect became a generic tool defer"
        | Masc.Keeper_tools_oas.Terminal_effect_open ->
          fail "deferred effect was not observed at the tool boundary"
        | Masc.Keeper_tools_oas.Terminal_effect_completed ->
@@ -3203,6 +3211,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                  (contains_substring failure.diagnostic chat_path)
              | Masc.Keeper_tools_oas.Terminal_effect_open ->
                fail "failed surface delivery left the terminal effect open"
+             | Masc.Keeper_tools_oas.Deferred_tool_result ->
+               fail "failed surface delivery became a generic defer"
              | Masc.Keeper_tools_oas.External_effect_deferred ->
                fail "failed surface delivery became an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
@@ -3211,6 +3221,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
               match terminal_state with
               | Masc.Keeper_tools_oas.Terminal_effect_failed failure -> failure
               | Masc.Keeper_tools_oas.Terminal_effect_open
+              | Masc.Keeper_tools_oas.Deferred_tool_result
               | Masc.Keeper_tools_oas.External_effect_deferred
               | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                 fail "failed surface delivery lost its terminal failure"
@@ -3237,6 +3248,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                  (failure = first_terminal_failure)
              | Masc.Keeper_tools_oas.Terminal_effect_open ->
                fail "later success reopened the failed terminal effect"
+             | Masc.Keeper_tools_oas.Deferred_tool_result ->
+               fail "later success changed failure into a generic defer"
              | Masc.Keeper_tools_oas.External_effect_deferred ->
                fail "later success changed failure into an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
@@ -3329,6 +3342,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                  (contains_substring failure.diagnostic chat_path)
              | Masc.Keeper_tools_oas.Terminal_effect_open ->
                fail "runtime terminal failure was not recorded"
+             | Masc.Keeper_tools_oas.Deferred_tool_result ->
+               fail "runtime terminal failure became a generic defer"
              | Masc.Keeper_tools_oas.External_effect_deferred ->
                fail "runtime terminal failure became an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -457,6 +457,32 @@ let test_finalization_blank_response_is_typed_accept_rejection () =
        Alcotest.failf "expected typed keeper error, got %s"
          (Agent_sdk.Error.to_string err))
 
+let test_external_effect_finalization_returns_visible_acknowledgement () =
+  let run_result =
+    { (run_result ()) with
+      stop_reason = Runtime_agent.Awaiting_external_effect { turns_used = 1 }
+    }
+  in
+  match
+    Masc.Keeper_agent_run.For_testing.normalize_response_text_for_finalization
+      ~runtime_id:"test-runtime"
+      ~initial_messages:[]
+      ~run_result
+      ~text:""
+      ~tool_names:[]
+      ()
+  with
+  | Ok acknowledgement ->
+    Alcotest.(check string)
+      "external effect acknowledgement"
+      Masc.Keeper_agent_run_response_text.external_effect_deferred_acknowledgement
+      acknowledgement
+  | Error error ->
+    Alcotest.failf
+      "external effect acknowledgement unexpectedly rejected: %s"
+      (Agent_sdk.Error.to_string error)
+;;
+
 let test_finalization_does_not_surface_hidden_reasoning () =
   let hidden = "private chain of thought must not become a user reply" in
   let response =
@@ -1718,6 +1744,10 @@ let () =
             "blank finalization response is typed no-progress"
             `Quick
             test_finalization_blank_response_is_typed_accept_rejection;
+          Alcotest.test_case
+            "external effect finalization returns visible acknowledgement"
+            `Quick
+            test_external_effect_finalization_returns_visible_acknowledgement;
           Alcotest.test_case
             "finalization does not surface hidden reasoning"
             `Quick

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -19,6 +19,7 @@ module Stream = Server_routes_http_keeper_stream
 module UT = Masc.Keeper_unified_turn
 module Cycle = Masc.Keeper_heartbeat_loop_cycle
 module Heartbeat = Masc.Keeper_heartbeat_loop.For_testing
+module Response_text = Masc.Keeper_agent_run_response_text
 
 let outcome : TO.t testable =
   testable
@@ -59,6 +60,9 @@ let test_of_stop_reason () =
   check outcome "durable stimulus yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
        (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 }));
+  check outcome "external effect wait -> visible" TO.Visible_reply
+    (TO.of_stop_reason
+       (Runtime_agent.Awaiting_external_effect { turns_used = 2 }));
   check outcome "repeated tool yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
        (Runtime_agent.Yielded_after_repeated_tool_call
@@ -111,6 +115,10 @@ let test_runtime_stop_reason_controls_durable_source_completion () =
     (Heartbeat.cycle_outcome_acks_source
        (cycle_of_stop_reason
           (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 })));
+  check bool "external effect wait retains durable source" false
+    (Heartbeat.cycle_outcome_acks_source
+       (cycle_of_stop_reason
+          (Runtime_agent.Awaiting_external_effect { turns_used = 2 })));
   check bool "repeated tool yield retains durable source" false
     (Heartbeat.cycle_outcome_acks_source
        (cycle_of_stop_reason
@@ -167,6 +175,40 @@ let test_of_result_surface () =
     TO.No_visible_reply
     (TO.of_result_surface ~response_text:"   " Runtime_agent.Completed)
 
+let test_external_effect_wait_acknowledgement_is_visible () =
+  let stop_reason = Runtime_agent.Awaiting_external_effect { turns_used = 2 } in
+  let acknowledgement = Response_text.external_effect_deferred_acknowledgement in
+  check bool "external effect acknowledgement is not suppressed" false
+    (Response_text.stop_reason_suppresses_visible_response stop_reason);
+  check bool "external effect acknowledgement is nonblank" true
+    (String.trim acknowledgement <> "");
+  check outcome "external effect acknowledgement reaches chat"
+    TO.Visible_reply
+    (TO.of_result_surface ~response_text:acknowledgement stop_reason)
+
+let test_terminal_effect_defer_kinds_remain_distinct () =
+  let expect_yield label state expected =
+    match Masc.Keeper_agent_run.terminal_effect_boundary_decision state with
+    | Ok (Runtime_agent.Yield actual) ->
+      check string label expected
+        (match actual with
+         | Runtime_agent.Durable_stimulus_waiting -> "durable_stimulus_waiting"
+         | Runtime_agent.External_effect_deferred -> "external_effect_deferred"
+         | Runtime_agent.Chat_waiting -> "chat_waiting"
+         | Runtime_agent.Repeated_tool_call _ -> "repeated_tool_call"
+         | Runtime_agent.Terminal_tool_completed -> "terminal_tool_completed")
+    | Ok Runtime_agent.Continue -> fail (label ^ " unexpectedly continued")
+    | Error error -> fail (label ^ ": " ^ Agent_sdk.Error.to_string error)
+  in
+  expect_yield
+    "generic deferred tool preserves existing checkpoint"
+    Masc.Keeper_tools_oas.Deferred_tool_result
+    "durable_stimulus_waiting";
+  expect_yield
+    "typed external effect uses Gate acknowledgement path"
+    Masc.Keeper_tools_oas.External_effect_deferred
+    "external_effect_deferred"
+
 let tool_call ?(input = Some "input") ?(output = Some "output") tool_name
     : Masc.Keeper_agent_result.tool_call_detail =
   { tool_name
@@ -221,14 +263,16 @@ let test_autonomous_yield_boundary_contract () =
     }
   in
   (match F.runtime_yield_reason chat with
-   | Runtime_agent.Chat_waiting -> ()
-   | Runtime_agent.Durable_stimulus_waiting
-   | Runtime_agent.Repeated_tool_call _
+    | Runtime_agent.Chat_waiting -> ()
+    | Runtime_agent.Durable_stimulus_waiting
+    | Runtime_agent.External_effect_deferred
+    | Runtime_agent.Repeated_tool_call _
    | Runtime_agent.Terminal_tool_completed ->
      fail "chat request mapped to the durable reason");
   (match F.runtime_yield_reason durable_stimulus with
-   | Runtime_agent.Durable_stimulus_waiting -> ()
-   | Runtime_agent.Chat_waiting
+    | Runtime_agent.Durable_stimulus_waiting -> ()
+    | Runtime_agent.Chat_waiting
+    | Runtime_agent.External_effect_deferred
    | Runtime_agent.Repeated_tool_call _
    | Runtime_agent.Terminal_tool_completed ->
      fail "durable request mapped to the chat reason");
@@ -248,6 +292,7 @@ let test_autonomous_yield_boundary_contract () =
      | Runtime_agent.Completed
      | Runtime_agent.Yielded_to_chat_waiting _
      | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Awaiting_external_effect _
      | Runtime_agent.Yielded_after_repeated_tool_call _
      | Runtime_agent.InputRequired _ ->
        false);
@@ -260,6 +305,7 @@ let test_autonomous_yield_boundary_contract () =
      | Runtime_agent.Completed -> true
      | Runtime_agent.Yielded_to_chat_waiting _
      | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Awaiting_external_effect _
      | Runtime_agent.Yielded_after_repeated_tool_call _
      | Runtime_agent.InputRequired _ -> false)
 
@@ -458,6 +504,10 @@ let () =
           test_case "cooperative yield ignores only active source identity" `Quick
             test_cooperative_yield_ignores_only_active_source_identity;
           test_case "of_result_surface" `Quick test_of_result_surface;
+          test_case "external effect wait acknowledgement is visible" `Quick
+            test_external_effect_wait_acknowledgement_is_visible;
+          test_case "terminal effect defer kinds remain distinct" `Quick
+            test_terminal_effect_defer_kinds_remain_distinct;
           test_case "repeated exact tool call boundary" `Quick
             test_repeated_exact_tool_call_boundary;
           test_case "autonomous yield boundary contract" `Quick

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -195,6 +195,23 @@ let test_keeper_execution_preserves_explicit_typed_data () =
      | None -> false)
 ;;
 
+let test_keeper_execution_defer_kind_is_producer_typed () =
+  let data = `Assoc [ "approval_id", `String "approval-1" ] in
+  let generic = Keeper_tool_execution.deferred_data data in
+  let external_effect =
+    Keeper_tool_execution.deferred_external_effect_data data
+  in
+  Alcotest.(check bool)
+    "ordinary deferred execution remains generic"
+    true
+    (generic.deferred_kind = Some Keeper_tool_execution.Generic_deferred);
+  Alcotest.(check bool)
+    "external deferred execution is explicit"
+    true
+    (external_effect.deferred_kind
+     = Some Keeper_tool_execution.External_effect_deferred)
+;;
+
 let test_to_json () =
   let start = Time_compat.now () in
   let r = Tool_result.ok ~tool_name:"masc_transition" ~start_time:start "done" in
@@ -498,6 +515,10 @@ let () =
             "keeper execution preserves typed data"
             `Quick
             test_keeper_execution_preserves_explicit_typed_data
+        ; Alcotest.test_case
+            "keeper execution defer kind is producer typed"
+            `Quick
+            test_keeper_execution_defer_kind_is_producer_typed
         ] )
     ; "to_json", [ Alcotest.test_case "fields present" `Quick test_to_json ]
     ; ( "message"


### PR DESCRIPTION
## What changed

- distinguish a generic deferred tool transition from a typed Gate-deferred external effect at the Keeper/OAS execution boundary
- project Gate deferral to `Awaiting_external_effect`, returning a visible acknowledgement instead of a queued `Continuation_checkpoint`
- preserve the existing durable Gate-resolution replay; the original request is not requeued or repeated
- ensure an external effect defer promotes a prior generic defer in the same OAS batch

## Root cause

A Gate-deferred external effect was collapsed into the generic durable-stimulus yield. For a queued dashboard turn, that projected as `Continuation_checkpoint`, which the HTTP stream correctly treats as an undeliverable reply and reports as a transport failure.

## Impact

Queued Keeper chat now records and delivers a normal acknowledgement while Gate owns the later durable resolution. Ordinary Task/FSM `Deferred` behavior remains a checkpoint and is not presented as Gate approval pending.

## Validation

- `test_keeper_turn_outcome.exe`: 17 passing
- `test_tool_result.exe`: 24 passing
- `test_keeper_tool_dispatch_runtime.exe test 'execute_keeper_tool_call_with_outcome' 34`: passing with host loopback permission; exercises Gate-deferred WebSearch
- `git diff --check` and `ocamlformat --check`: passing

The full focused dispatch executable has three independent existing failures in Read validation data, Execute cwd, and surface-post broadcast assertions; the Gate case passes. A shared worktree was holding the Dune lock during the final focused rebuild, so CI remains the full build authority.
