### PR TITLE
fix(keeper): keep HITL context request-local

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -368,12 +368,14 @@ let approval_decision_to_yojson = function
     `Assoc [ "kind", `String "edit"; "input", input ]
 ;;
 
-(* [request_context] is the Auto Judge / HITL summary input: the whole Keeper
-   turn context (history_messages, system prompts, dynamic_context) captured at
-   request time. Its only reader is Hitl_summary_worker, which runs while the
-   entry is still pending. A delivery is already resolved, so the context is
-   dead weight there — and it dominated the store: 71 deliveries held ~30MB of
-   duplicated context against 19 bytes of decision each.
+(* [request_context] is the Auto Judge / HITL summary input: request-local
+   causal evidence (bounded history lead-up, the triggering user message,
+   current dynamic context, and completed tool calls) captured at request time.
+   It is not the whole Keeper turn or its system prompts. Its only reader is
+   Hitl_summary_worker, which runs while the entry is still pending. A delivery
+   is already resolved, so the context is dead weight there — and it dominated
+   the store: 71 deliveries held ~30MB of duplicated context against 19 bytes
+   of decision each.
 
    Dropping it on the delivery wire shape stays decode-compatible: the reader
    treats [request_context] as optional and keys the version field off its

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -76,6 +76,20 @@ let gate_history_slice (messages : Agent_sdk.Types.message list) =
   List.map snd kept, List.length messages - List.length kept
 ;;
 
+let gate_causal_initial
+      ~gate_history
+      ~gate_history_omitted
+      ~user_message
+      ~dynamic_context
+  =
+  `Assoc
+    [ "history_messages", `List gate_history
+    ; "history_messages_omitted", `Int gate_history_omitted
+    ; "user_message", `String user_message
+    ; "dynamic_context", `String dynamic_context
+    ]
+;;
+
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -118,15 +132,11 @@ let prepare_agent_setup
     Keeper_gate_causal_context.create
       ~turn_id:manifest_keeper_turn_id
       ~initial:
-        (`Assoc
-           [ "history_messages", `List gate_history
-           ; "history_messages_omitted", `Int gate_history_omitted
-           ; "base_system_prompt", `String base_system_prompt
-           ; "turn_system_prompt", `String turn_system_prompt
-           ; "user_message", `String user_message
-           ; "dynamic_context", `String dynamic_context
-           ; "runtime_id", `String runtime_id
-           ])
+        (gate_causal_initial
+           ~gate_history
+           ~gate_history_omitted
+           ~user_message
+           ~dynamic_context)
   in
   let agent_name = meta.agent_name in
   let acc : Keeper_run_tools_hook_accumulator.hook_accumulator =

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -74,11 +74,8 @@ let pending_entry
       [ ( "initial"
         , `Assoc
             [ "history_messages", `List [ `String "older turn" ]
-            ; "base_system_prompt", `String "base policy"
-            ; "turn_system_prompt", `String "turn policy"
             ; "user_message", `String "inspect the exact requested operation"
             ; "dynamic_context", `String "current context"
-            ; "runtime_id", `String "opaque"
             ] )
       ; "completed_tool_calls", `List []
       ]

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -312,6 +312,26 @@ let bulky_message index =
 
 let as_json message = Masc.Keeper_context_core.message_to_json message
 
+let test_gate_causal_initial_is_request_local () =
+  let open Yojson.Safe.Util in
+  let initial =
+    Setup.gate_causal_initial
+      ~gate_history:[ `String "recent" ]
+      ~gate_history_omitted:4
+      ~user_message:"inspect the request"
+      ~dynamic_context:"current state"
+  in
+  check
+    (list string)
+    "only request-local evidence fields are captured"
+    [ "history_messages"; "history_messages_omitted"; "user_message"; "dynamic_context" ]
+    (initial |> to_assoc |> List.map fst);
+  check string "trigger is preserved" "inspect the request"
+    (initial |> member "user_message" |> to_string);
+  check string "current state is preserved" "current state"
+    (initial |> member "dynamic_context" |> to_string)
+;;
+
 let test_gate_history_keeps_newest_within_budget () =
   let messages = List.init 200 bulky_message in
   let kept, omitted = Setup.gate_history_slice messages in
@@ -401,7 +421,9 @@ let () =
             test_missing_path_falls_back_to_base_path
         ] )
     ; ( "gate_history_slice"
-      , [ test_case "keeps the newest messages within the budget" `Quick
+      , [ test_case "captures only request-local causal fields" `Quick
+            test_gate_causal_initial_is_request_local
+        ; test_case "keeps the newest messages within the budget" `Quick
             test_gate_history_keeps_newest_within_budget
         ; test_case "short history is passed through whole" `Quick
             test_gate_history_short_history_is_whole


### PR DESCRIPTION
## What changed

- Keep the Gate causal snapshot request-local: bounded history evidence, its omitted count, the triggering user message, and current dynamic context.
- Stop persisting the base/turn system prompts and runtime id inside each HITL request context.
- Add a contract test proving the captured field set and retain the existing bounded-history tests.

## Why

Auto Judge does not need the Keeper's system prompts or runtime identity to judge an exact external-effect request. Carrying those fields with the causal evidence made the HITL context larger and obscured the actual request-local contract.

## Validation

- Focused Dune build for `test_keeper_run_tools_hooks.exe` and `test_hitl_summary_worker.exe`.
- `keeper_run_tools_hooks`: 4 Gate-history tests passed.
- `hitl_summary_worker`: 6 domain tests passed.
- `git diff --check` and `ocamlformat --check` passed.
- The broader HITL exact-flow suite retains five failures that reproduce on clean `main`; they are unrelated baseline failures.

Refs #26081
