### PR TITLE
fix(dashboard): make paused Keeper recovery reachable

### DIFF
--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -337,6 +337,13 @@ export async function resumeKeeper(
     opts,
   )
   if (result.ok) clearCommittedResumeIntent(name, intent)
+  // Resume_owner commits the durable pause disposition before projecting the
+  // live lane. If projection is ambiguous or temporarily unavailable, the
+  // pause is already cleared and boot is the safe committed follow-up.
+  if (!result.ok && result.committed === true) {
+    const boot = await bootKeeper(name, opts)
+    return { ...boot, committed: true }
+  }
   return result
 }
 

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1325,6 +1325,38 @@ describe('keeper lifecycle', () => {
     })
   })
 
+  it('boots after a durable resume commit cannot project the offline lane', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          ok: false,
+          action: 'resume',
+          name: 'offline-janitor',
+          committed: true,
+          projection: 'committed_followup_failed',
+        }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, action: 'boot', name: 'offline-janitor' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resumeKeeper('offline-janitor', 7, {
+      operatorOperationId: 'dashboard-resume-offline-1',
+    })
+
+    expect(result).toMatchObject({ ok: true, action: 'boot', committed: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/v1/keepers/offline-janitor/directive')
+    expect(fetchMock.mock.calls[1]![0]).toBe('/api/v1/keepers/offline-janitor/boot')
+  })
+
   it('reuses the same resume operation ID after an ambiguous failed response', async () => {
     vi.stubGlobal('crypto', { randomUUID: vi.fn(() => 'stable-resume-uuid') })
     const fetchMock = vi.fn()

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -30,8 +30,8 @@ function makeKeeper(overrides: Partial<Keeper>): Keeper {
     status: 'active',
     phase: 'Running',
     paused: false,
-    // A keeper with its fiber alive is the normal case; tests that exercise
-    // the dead-paused boot path override this to false explicitly.
+    // A keeper with its fiber alive is the normal case; paused-owner tests
+    // override this to false explicitly.
     keepalive_running: true,
     ...overrides,
   } as unknown as Keeper
@@ -103,23 +103,20 @@ describe('keeperActionVisibility', () => {
   })
 
   describe('paused keeper whose fiber died (keepalive_running=false)', () => {
-    it('exposes boot instead of resume — resume needs a live owner nonce', () => {
+    it('exposes resume before boot because the durable generation is the owner nonce', () => {
       const k = makeKeeper({ status: 'active', phase: 'Paused', paused: true, keepalive_running: false })
       const v = keeperActionVisibility(k)
-      expect(v.canResume).toBe(false)
-      expect(v.canBoot).toBe(true)
+      expect(v.canResume).toBe(true)
+      expect(v.canBoot).toBe(false)
       expect(v.canPause).toBe(false)
       expect(v.canShutdown).toBe(true)
     })
 
-    it('still exposes boot when phase is null but the paused flag lingers', () => {
-      // Reproduces the live incident: paused directive persisted after the
-      // process died, phase never repopulated — resume errored with
-      // "current owner generation is unavailable" while boot stayed hidden.
+    it('still exposes resume when phase is null but the paused flag lingers', () => {
       const k = makeKeeper({ status: 'active', phase: null, paused: true, keepalive_running: false })
       const v = keeperActionVisibility(k)
-      expect(v.canResume).toBe(false)
-      expect(v.canBoot).toBe(true)
+      expect(v.canResume).toBe(true)
+      expect(v.canBoot).toBe(false)
     })
   })
 

--- a/dashboard/src/components/keeper-detail-lifecycle.test.ts
+++ b/dashboard/src/components/keeper-detail-lifecycle.test.ts
@@ -1,0 +1,46 @@
+import { fireEvent, render } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { runKeeperAction } = vi.hoisted(() => ({
+  runKeeperAction: vi.fn(),
+}))
+
+vi.mock('./keeper-action-panel', () => ({
+  KEEPER_ACTION_LABELS: {
+    resume: { title: 'resume', verb: '재개하기' },
+    boot: { title: 'boot', verb: '기동하기' },
+    shutdown: { title: 'shutdown', verb: '종료하기' },
+  },
+  runKeeperAction,
+}))
+
+import { KeeperLifecycleButtons } from './keeper-detail-lifecycle'
+import type { Keeper } from '../types'
+
+describe('KeeperLifecycleButtons', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    runKeeperAction.mockReset()
+  })
+
+  it('resumes an offline paused keeper with its durable owner generation', () => {
+    const keeper = {
+      name: 'lane-smith',
+      status: 'offline',
+      phase: 'Paused',
+      paused: true,
+      keepalive_running: false,
+      generation: 1275,
+    } as Keeper
+
+    const { getByRole, queryByText } = render(html`
+      <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus="offline" />
+    `)
+
+    fireEvent.click(getByRole('button', { name: '재개하기' }))
+
+    expect(queryByText('기동하기')).toBeNull()
+    expect(runKeeperAction).toHaveBeenCalledWith('lane-smith', 'resume', 1275)
+  })
+})

--- a/dashboard/src/components/keeper-detail-lifecycle.ts
+++ b/dashboard/src/components/keeper-detail-lifecycle.ts
@@ -7,6 +7,7 @@ import { DialogOverlay } from './common/dialog'
 import { TextArea } from './common/input'
 import { Checkbox } from './common/checkbox'
 import { isOfflineStatus } from '../lib/keeper-classifiers'
+import { keeperActionVisibility } from '../lib/keeper-predicates'
 
 export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; effectiveStatus: string }) {
   // SSOT: `isOfflineStatus` from keeper-classifiers.ts (includes crashed,
@@ -15,11 +16,19 @@ export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Ke
   // SSOT predicate covers the full display-status union.
   const isOffline = isOfflineStatus(effectiveStatus)
   const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(effectiveStatus)
+  const visibility = keeperActionVisibility(keeper)
 
   // Both buttons route through runKeeperAction: same toast copy, same
   // post-action refresh (refreshKeeperRuntimeStatus), and the shutdown
   // confirm gate lives there — this surface previously duplicated all three.
-  if (isOffline) return html`
+  if (visibility.canResume) return html`
+    <button type="button"
+      class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)] hover:bg-[var(--ok-soft)] transition-colors v2-monitoring-action"
+      title=${KEEPER_ACTION_LABELS.resume.title}
+      onClick=${() => { void runKeeperAction(keeper.name, 'resume', keeper.generation) }}
+    >${KEEPER_ACTION_LABELS.resume.verb}</button>`
+
+  if (isOffline && visibility.canBoot) return html`
     <button type="button"
       class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)] hover:bg-[var(--ok-soft)] transition-colors v2-monitoring-action"
       title=${KEEPER_ACTION_LABELS.boot.title}

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -174,19 +174,15 @@ export function keeperActionVisibility(keeper: Keeper): KeeperActionVisibility {
   const isPaused = isKeeperPaused(keeper)
   const isOffline = isKeeperOffline(keeper)
   const isRunning = isKeeperRunningExcludingRestarting(keeper)
-  // A paused directive can outlive its process: the persisted `paused` flag
-  // stays set after the keeper fiber dies, but only a live fiber can be
-  // resumed — resume needs a live owner nonce as its fencing token, and
-  // a dead keeper has none. Treat paused-but-not-live as needing boot, so
-  // the boot verb surfaces for a dead paused keeper and resume stays hidden
-  // instead of returning "current owner generation is unavailable".
-  const live = keeper.keepalive_running === true
+  // A paused directive can outlive its process. The durable owner generation
+  // remains the Resume_owner fencing token after the live lane exits, so a
+  // paused keeper must resume before an offline lane is booted.
 
   return {
     canPause:    isRunning && !isPaused,
-    canResume:   isPaused && live,
+    canResume:   isPaused,
     canWake:     keeperCanWakeup(keeper),
-    canBoot:     isOffline || (isPaused && !live),
+    canBoot:     isOffline && !isPaused,
     canShutdown: isRunning || isPaused,
   }
 }


### PR DESCRIPTION
## Summary

- show `resume` for paused keepers even when their live fiber has exited
- keep `boot` for genuinely offline, non-paused keepers
- retry boot after a durable `Resume_owner` commit whose live projection needs follow-up
- add regression coverage for dead/offline paused recovery and committed follow-up

Related to #25855 and the operator recovery gap described in #25548.

## Validation

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/keeper.test.ts src/components/keeper-action-panel.test.ts src/components/keeper-detail-lifecycle.test.ts` — 63 passed
- `pnpm run typecheck` — passed
- `pnpm run build` — passed
- focused eslint on changed production files — passed
- full `pnpm run lint` remains blocked by pre-existing `src/keeper-actions.ts:1046` (`no-nested-ternary`)

The durable resume transaction remains the backend authority; this change makes the existing recovery path reachable from the operator UI and handles its committed-follow-up response.
