### PR TITLE
fix: main red residue — audit doc code_refs + navigation test assertion

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -168,7 +168,7 @@ describe('lab navigation', () => {
       '감사 무결성',
     ])
     expect(labSections.find(item => item.id === 'memory-subsystems')?.description).toBe(
-      'Live episodes, user model projection, Hebbian synapses, and gated memory entries.',
+      'Hebbian synapses, recall quality, and delegation requests.',
     )
     expect(labSections.find(item => item.id === 'performance')?.description).toBe(
       'FPS meter, VirtualList, content-visibility, native dialog, and observer probes.',

--- a/docs/audit/2026-06-21-productization-blockers-adversarial-audit.md
+++ b/docs/audit/2026-06-21-productization-blockers-adversarial-audit.md
@@ -10,7 +10,6 @@ code_refs:
   - lib/config/feature_flag_registry.ml
   - lib/config/env_config_sandbox.ml
   - lib/keeper/keeper_tool_surface_ops.ml
-  - lib/keeper/keeper_memory_bank_env.ml
   - lib/workspace/workspace_gc.ml
   - lib/workspace/workspace_utils_paths_backend.ml
   - lib/keeper/keeper_chat_queue.ml
@@ -146,7 +145,7 @@ The repo has correctly moved toward `<base-path>/.masc`, but current gates mostl
 **Evidence**:
 
 - `lib/keeper/keeper_tool_surface_ops.ml:38-65` defines local TTL parsing over `Sys.getenv_opt`.
-- `lib/keeper/keeper_memory_bank_env.ml:14-67` defines a separate keeper-memory env parser family.
+- `lib/keeper/keeper_memory_bank_env.ml` defined a separate keeper-memory env parser family (module removed 2026-07-28 with the memory bank, #26128; the shared parser is `Env_config_memory`).
 
 **Impact**:
 


### PR DESCRIPTION
main red 잔여 2건 수정 (#26128/#26134 병합 여파, 둘 다 미선점 확인 후 처리):

1. **Meta Guards**: #26128이 `lib/keeper/keeper_memory_bank_env.ml`을 삭제했는데 `docs/audit/2026-06-21-productization-blockers-adversarial-audit.md`의 `code_refs`가 그 경로 참조 → `check-doc-truth` fail. 엔트리 제거 + 본문 근거 라인에 제거 주석.
2. **Dashboard**: #26134가 navigation.ts의 memory-subsystems 설명을 갱신했는데 `navigation.test.ts:171` 단언이 옛 문구를 핀 → 테스트 fail. 워킹트리에 있던 수정분이 병합에 누락된 것을 회수.

참고: Dashboard의 다른 실패(`'unbooted' vs 'offline'` vocabulary 계약 테스트)는 #26121 소산으로 본 PR 범위 밖.

RFC-WAIVED: 문서 1건 + 테스트 단언 1건, main red 복구. 코드 계약 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HA6GposPqQteSu8fw1nvS
