### PR TITLE
test(dashboard): pin post-#26121 unbooted semantics — last main Dashboard red

### DIFF
--- a/dashboard/src/lib/keeper-status-vocabulary.contract.test.ts
+++ b/dashboard/src/lib/keeper-status-vocabulary.contract.test.ts
@@ -80,9 +80,9 @@ describe('keeperDisplayStatus stays inside the token union', () => {
     ['backend status idle', { name: 'k', status: 'idle' } as Keeper, 'idle'],
     ['backend status listening', { name: 'k', status: 'listening' } as Keeper, 'listening'],
     [
-      'offline residual: agent record exists but no turn was ever run',
-      { name: 'k', status: 'offline', agent: { exists: true } } as unknown as Keeper,
-      'offline',
+      'offline residual: no recorded activity renders unbooted',
+      { name: 'k', status: 'offline' } as Keeper,
+      'unbooted',
     ],
   ]
 


### PR DESCRIPTION
main Dashboard red의 마지막 잔여 1건 수정.

**증상**: `keeper-status-vocabulary.contract.test.ts`의 `offline residual: agent record exists but no turn was ever run` 케이스가 `expected 'unbooted' to be 'offline'`로 실패 (main run 30350245837).

**원인**: #26121(`a6802ca1b6`)이 agent registry existence flag를 제거하면서 `refineOfflineStatus`의 `unbooted` 분기에서 `!agentExists` 조건이 사라짐 → generation 0 + turn 0 offline keeper는 무조건 `unbooted`. 같은 커밋이 `keeper-runtime-display.test.ts`는 갱신했지만 contract 테스트의 동일 케이스를 누락 (N-of-M missed site, #26135의 navigation 단언 누락과 동일 패턴).

**수정**: 케이스를 제거된 개념(`agent.exists`) 없이 post-#26121 의미로 재핀 — `{ status: 'offline' }` → `'unbooted'`. `unbooted`/`stopped` 분기 자체는 `keeper-runtime-display.test.ts`에 이미 양쪽 다 핀되어 있어, 이 케이스는 token-union membership 역할만 유지.

**검증**: 로컬 vitest 불가 (fresh worktree, node_modules 없음) — Dashboard CI가 게이트.

RFC-WAIVED: 테스트 단언 1건 갱신, main red 복구. 코드 계약 변경 없음 (#26121이 이미 바꾼 의미를 테스트가 따라감).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HA6GposPqQteSu8fw1nvS
