### PR TITLE
fix(gate): retryable 제거 + 판정 증거를 resolution까지 운반 (#26094, #26126)

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -335,7 +335,6 @@ describe('normalizeKeeperApprovalQueueItem', () => {
         summary_status: {
           status: 'failed',
           reason: 'Auto Judge exact attempt quarantined: flow_execution_failed',
-          retryable: false,
         },
       })!.summary_status,
     ).toEqual({
@@ -361,8 +360,16 @@ describe('normalizeKeeperApprovalQueueItem', () => {
         summary_status: {
           status: 'failed',
           reason: 'Auto Judge exact attempt quarantined: cancellation',
-          retryable: false,
         },
+      }),
+    ).toBeNull()
+    // `retryable` left the wire contract with #26094: the OCaml producer no
+    // longer writes it, so any occurrence — either value — is a stale or
+    // hand-edited payload and rejects the row.
+    expect(
+      normalizeKeeperApprovalQueueItem({
+        ...baseItem,
+        summary_status: { status: 'failed', reason: 'provider down', retryable: false },
       }),
     ).toBeNull()
     expect(

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -130,7 +130,7 @@ function normalizeHitlContextSummary(raw: unknown): HitlContextSummary | null {
 /** Parse the backend `summary_status` wire value into the typed union. Returns
  *  `null` for an absent or contract-violating shape — a malformed status must
  *  not silently read as `not_requested`, which would hide a wiring fault. */
-function normalizeHitlSummaryStatus(raw: unknown): HitlSummaryStatus | null {
+export function normalizeHitlSummaryStatus(raw: unknown): HitlSummaryStatus | null {
   if (raw === 'not_requested') return { status: 'not_requested' }
   if (raw === 'pending') return { status: 'pending' }
   if (!isRecord(raw)) return null
@@ -141,11 +141,13 @@ function normalizeHitlSummaryStatus(raw: unknown): HitlSummaryStatus | null {
       return summary ? { status: 'available', summary } : null
     }
     case 'failed': {
-      if (!hasOnlyKeys(raw, ['status', 'reason', 'retryable'])) return null
+      // `retryable` was removed producer-side (#26094): it was write-only
+      // `false` in OCaml, and requiring that exact value here turned one
+      // drifted row into a blank approval queue. The server no longer sends
+      // the field, so its presence is a contract violation for this row.
+      if (!hasOnlyKeys(raw, ['status', 'reason'])) return null
       const reason = asString(raw.reason, '').trim()
-      return reason && raw.retryable === false
-        ? { status: 'failed', reason }
-        : null
+      return reason ? { status: 'failed', reason } : null
     }
     default:
       return null
@@ -178,7 +180,7 @@ function hasOnlyKeys(raw: Record<string, unknown>, allowed: readonly string[]): 
   return keys.length === allowed.length && keys.every(key => allowed.includes(key))
 }
 
-function normalizeKeeperExactAttempt(raw: unknown): KeeperExactAttemptState | null {
+export function normalizeKeeperExactAttempt(raw: unknown): KeeperExactAttemptState | null {
   if (!isRecord(raw)) return null
   if (raw.state === 'unbound') {
     return hasOnlyKeys(raw, ['state']) ? { state: 'unbound' } : null

--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -3,17 +3,24 @@
 
 import { ApiRequestError, get, post, withRetries } from './core'
 import { isRecord, asBoolean, asInt, asNullableString, asString } from '../components/common/normalize'
-import { asNullableIsoTimestamp, normalizeKeeperApprovalQueueItem } from './board'
+import {
+  asNullableIsoTimestamp,
+  normalizeKeeperApprovalQueueItem,
+  normalizeHitlSummaryStatus,
+  normalizeKeeperExactAttempt,
+} from './board'
 import { normalizeKeeperResolvedApprovalDecision } from '../lib/keeper-approval-decision'
 import type {
   KeeperApprovalRule,
   DashboardGateResponse,
   KeeperApprovalQueueItem,
+  KeeperApprovalQueueRowViolation,
   KeeperResolvedApprovalItem,
   KeeperResolvedApprovalPage,
   KeeperApprovalQueueState,
   KeeperAutoJudgeRearmExpectation,
   GateDecisionSource,
+  GateJudgeLane,
   GateMode,
   GateModeStatus,
 } from '../types'
@@ -107,10 +114,32 @@ function normalizeGateMode(raw: unknown): GateModeStatus | undefined {
   }
 }
 
+/** Parse the closed `judge_lane` variant emitted by `dashboard_gate.ml`.
+ *  Returns undefined for an absent field (older server) or a shape outside
+ *  the contract — the header then simply omits the judge model. */
+function normalizeGateJudgeLane(raw: unknown): GateJudgeLane | undefined {
+  if (!isRecord(raw)) return undefined
+  const laneId = asString(raw.lane_id, '').trim()
+  if (!laneId) return undefined
+  if (raw.status === 'available' && Array.isArray(raw.slots)) {
+    const slots = raw.slots.filter(
+      (slot): slot is string => typeof slot === 'string' && slot.trim() !== '',
+    )
+    if (slots.length === 0 || slots.length !== raw.slots.length) return undefined
+    return { status: 'available', lane_id: laneId, slots }
+  }
+  if (raw.status === 'unavailable') {
+    const reason = asString(raw.reason, '').trim()
+    return reason ? { status: 'unavailable', lane_id: laneId, reason } : undefined
+  }
+  return undefined
+}
+
 function normalizeHitlStatus(raw: unknown): DashboardGateResponse['hitl'] | undefined {
   if (!isRecord(raw)) return undefined
   return {
     gate_mode: normalizeGateMode(raw.gate_mode),
+    judge_lane: normalizeGateJudgeLane(raw.judge_lane),
   }
 }
 
@@ -134,6 +163,20 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
   const decisionRaw = asNullableString(raw.decision)
   const decisionKind = asNullableString(raw.decision_kind)
   const decisionReason = asNullableString(raw.decision_reason)
+  // Judge evidence rides on resolved audit events written since #26126;
+  // older events project the members as null. Absent stays null (nothing was
+  // recorded); a present-but-malformed blob rejects the row like any other
+  // contract violation instead of silently degrading to "not recorded".
+  let summaryStatus: KeeperResolvedApprovalItem['summary_status'] = null
+  if (raw.summary_status !== undefined && raw.summary_status !== null) {
+    summaryStatus = normalizeHitlSummaryStatus(raw.summary_status)
+    if (summaryStatus === null) return null
+  }
+  let exactAttempt: KeeperResolvedApprovalItem['exact_attempt'] = null
+  if (raw.exact_attempt !== undefined && raw.exact_attempt !== null) {
+    exactAttempt = normalizeKeeperExactAttempt(raw.exact_attempt)
+    if (exactAttempt === null) return null
+  }
   return {
     id,
     keeper_name: keeperName,
@@ -150,6 +193,8 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
       : [],
     decision_source: normalizeGateDecisionSource(raw.decision_source),
     rule_match: ruleMatch,
+    summary_status: summaryStatus,
+    exact_attempt: exactAttempt,
   }
 }
 
@@ -202,6 +247,7 @@ export function fetchDashboardGate(
     })
     const approvalQueueState = normalizeApprovalQueueState(raw.approval_queue_state)
     let approvalQueue: KeeperApprovalQueueItem[] | null
+    const approvalQueueViolations: KeeperApprovalQueueRowViolation[] = []
     if (approvalQueueState.state === 'unavailable') {
       if (raw.approval_queue !== null) {
         return gateSnapshotProtocolDrift('unavailable approval_queue must be null')
@@ -211,11 +257,27 @@ export function fetchDashboardGate(
       if (!Array.isArray(raw.approval_queue)) {
         return gateSnapshotProtocolDrift('ready approval_queue must be an array')
       }
-      const normalized = raw.approval_queue.map(item => normalizeKeeperApprovalQueueItem(item))
-      if (normalized.some(item => item === null)) {
-        return gateSnapshotProtocolDrift('approval_queue contains a contract-violating row')
-      }
-      approvalQueue = normalized as KeeperApprovalQueueItem[]
+      // A contract-violating row is quarantined as a visible placeholder
+      // instead of failing the whole snapshot (#26094): one drifted row used
+      // to blank the entire queue — the surface an operator needs precisely
+      // when rows are drifting. Identity fields are best-effort salvage so
+      // the placeholder still names the pending request.
+      const accepted: KeeperApprovalQueueItem[] = []
+      raw.approval_queue.forEach((item, index) => {
+        const normalized = normalizeKeeperApprovalQueueItem(item)
+        if (normalized !== null) {
+          accepted.push(normalized)
+          return
+        }
+        const record = isRecord(item) ? item : undefined
+        approvalQueueViolations.push({
+          index,
+          id: record ? asNullableString(record.id) : null,
+          keeper_name: record ? asNullableString(record.keeper_name) : null,
+          tool_name: record ? asNullableString(record.tool_name) : null,
+        })
+      })
+      approvalQueue = accepted
     }
     const recentResolved = Array.isArray(raw.recent_resolved)
       ? raw.recent_resolved
@@ -233,6 +295,7 @@ export function fetchDashboardGate(
       note: typeof raw.note === 'string' && raw.note.trim() !== '' ? raw.note.trim() : undefined,
       approval_queue: approvalQueue,
       approval_queue_state: approvalQueueState,
+      approval_queue_violations: approvalQueueViolations,
       recent_resolved: recentResolved,
       recent_resolved_page: recentResolvedPage,
       approval_rules: approvalRules,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1738,6 +1738,170 @@ describe('fetchDashboardGate', () => {
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('quarantines a contract-violating queue row instead of blanking the queue (#26094)', async () => {
+    const validItem = {
+      id: 'appr-valid',
+      keeper_name: 'keeper-a',
+      tool_name: 'shell_exec',
+      input_hash: 'a'.repeat(64),
+      sequence: 3,
+      requested_at: 1_782_522_100,
+      waiting_s: 30,
+      turn_id: null,
+      task_id: null,
+      goal_id: null,
+      goal_ids: [],
+      summary_status: 'not_requested',
+      exact_attempt: { state: 'unbound' },
+      summary_attempt_disposition: { code: 'ready' },
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [
+          validItem,
+          {
+            id: 'appr-drifted',
+            keeper_name: 'keeper-b',
+            tool_name: 'fs_write',
+            input_hash: 'b'.repeat(64),
+            sequence: 4,
+            summary_status: { status: 'failed', reason: 'x', retryable: true },
+            exact_attempt: { state: 'unbound' },
+            summary_attempt_disposition: { code: 'ready' },
+          },
+        ],
+        approval_queue_state: { state: 'ready' },
+        recent_resolved: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.approval_queue).toHaveLength(1)
+    expect(result.approval_queue?.[0]?.id).toBe('appr-valid')
+    expect(result.approval_queue_violations).toEqual([
+      { index: 1, id: 'appr-drifted', keeper_name: 'keeper-b', tool_name: 'fs_write' },
+    ])
+  })
+
+  it('carries judge evidence on resolved rows and null for pre-enrichment events', async () => {
+    const judgeSummary = {
+      summary_version: 2,
+      generated_at: 1_782_522_120,
+      model_run_id: 'run-1',
+      context_summary: 'Keeper requested a read-only listing.',
+      key_questions: ['Is the path inside the sandbox?'],
+      judgment: 'approve',
+      rationale: 'Read-only and scoped.',
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        recent_resolved: [
+          {
+            id: 'appr-judged',
+            keeper_name: 'keeper-a',
+            tool_name: 'shell_exec',
+            decision: 'approve',
+            decision_kind: 'approve',
+            decision_source: 'auto_judge',
+            resolved_at: 1_782_522_183,
+            summary_status: { status: 'available', summary: judgeSummary },
+            exact_attempt: {
+              state: 'bound',
+              approval_id: 'appr-judged',
+              input_hash: 'a'.repeat(64),
+              sequence: 7,
+              slot_id: 'glm-coding.glm-5-turbo',
+              call_id: 'call-1',
+              plan_fingerprint: 'plan-1',
+              request_body_sha256: 'c'.repeat(64),
+              status: 'completed',
+              quarantine_cause: null,
+            },
+          },
+          {
+            id: 'appr-legacy',
+            keeper_name: 'keeper-a',
+            tool_name: 'fs_write',
+            decision: 'approve',
+            decision_kind: 'approve',
+            resolved_at: 1_782_522_100,
+            summary_status: null,
+            exact_attempt: null,
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    const result = await fetchDashboardGate()
+
+    const judged = result.recent_resolved?.find(item => item.id === 'appr-judged')
+    expect(judged?.summary_status?.status).toBe('available')
+    expect(
+      judged?.summary_status?.status === 'available'
+        ? judged.summary_status.summary.context_summary
+        : null,
+    ).toBe('Keeper requested a read-only listing.')
+    expect(
+      judged?.exact_attempt?.state === 'bound' ? judged.exact_attempt.slot_id : null,
+    ).toBe('glm-coding.glm-5-turbo')
+    const legacy = result.recent_resolved?.find(item => item.id === 'appr-legacy')
+    expect(legacy?.summary_status).toBeNull()
+    expect(legacy?.exact_attempt).toBeNull()
+  })
+
+  it('parses the closed judge_lane variant and drops shapes outside it', async () => {
+    const snapshot = (judgeLane: unknown) => new Response(JSON.stringify({
+      approval_queue: [],
+      approval_queue_state: { state: 'ready' },
+      recent_resolved: [],
+      hitl: {
+        gate_mode: { mode: 'auto_judge', configured: false, state: 'ready' },
+        judge_lane: judgeLane,
+      },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(snapshot({
+      status: 'available',
+      lane_id: 'hitl_auto_judge',
+      slots: ['glm-coding.glm-5-turbo', 'ollama_cloud.deepseek-v4-flash'],
+    })))
+    expect((await fetchDashboardGate()).hitl?.judge_lane).toEqual({
+      status: 'available',
+      lane_id: 'hitl_auto_judge',
+      slots: ['glm-coding.glm-5-turbo', 'ollama_cloud.deepseek-v4-flash'],
+    })
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(snapshot({
+      status: 'unavailable',
+      lane_id: 'hitl_auto_judge',
+      reason: 'registry_not_published',
+    })))
+    expect((await fetchDashboardGate()).hitl?.judge_lane).toEqual({
+      status: 'unavailable',
+      lane_id: 'hitl_auto_judge',
+      reason: 'registry_not_published',
+    })
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(snapshot({
+      status: 'available',
+      lane_id: 'hitl_auto_judge',
+      slots: [],
+    })))
+    expect((await fetchDashboardGate()).hitl?.judge_lane).toBeUndefined()
+  })
 })
 
 describe('setGateMode', () => {

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -63,11 +63,13 @@ function responseWithQueue(
     state: 'ready',
   },
   recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
+  approval_queue_violations: DashboardGateResponse['approval_queue_violations'] = [],
 ): DashboardGateResponse {
   return {
     generated_at: '2026-06-19T00:00:00Z',
     approval_queue,
     approval_queue_state,
+    approval_queue_violations,
     recent_resolved,
     recent_resolved_page,
     approval_rules,
@@ -86,6 +88,7 @@ async function loadSurface(
     state: 'ready',
   },
   recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
+  approval_queue_violations: DashboardGateResponse['approval_queue_violations'] = [],
 ) {
   vi.resetModules()
   const resolveGateApproval = vi
@@ -115,6 +118,7 @@ async function loadSurface(
         hitl,
         approval_queue_state,
         recent_resolved_page,
+        approval_queue_violations,
       )
     : responseWithQueue(
         approval_queue,
@@ -123,6 +127,7 @@ async function loadSurface(
         undefined,
         approval_queue_state,
         recent_resolved_page,
+        approval_queue_violations,
       )
   const apiMock = () => ({
     fetchDashboardGate: vi.fn().mockResolvedValue(response),
@@ -688,6 +693,129 @@ describe('ApprovalsSurface', () => {
     expect(history?.querySelector('.ap-history-decision')?.className).toContain('decision-reject')
     expect(history?.querySelector('.ap-history-decision')?.className).not.toContain('operator denied')
     expect(history?.querySelector('.ap-history-at')?.textContent).toContain('2026')
+  }, 20000)
+
+  it('unfolds judge evidence and slot on resolved rows that carry it, none on legacy rows', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [
+        {
+          id: 'appr-judged',
+          keeper_name: 'keeper-a',
+          tool_name: 'shell_exec',
+          decision: 'approve',
+          decision_source: 'auto_judge',
+          resolved_at: '2026-07-28T09:39:00Z',
+          summary_status: {
+            status: 'available',
+            summary: {
+              summary_version: 2,
+              generated_at: '2026-07-28T09:38:40Z',
+              model_run_id: 'run-1',
+              context_summary: 'Keeper requested a read-only listing.',
+              key_questions: ['Is the path inside the sandbox?'],
+              judgment: 'approve',
+              rationale: 'Read-only and scoped.',
+            },
+          },
+          exact_attempt: {
+            state: 'bound',
+            approval_id: 'appr-judged',
+            input_hash: 'a'.repeat(64),
+            sequence: 7,
+            slot_id: 'glm-coding.glm-5-turbo',
+            call_id: 'call-1',
+            plan_fingerprint: 'plan-1',
+            request_body_sha256: 'c'.repeat(64),
+            status: 'completed',
+            quarantine_cause: null,
+          },
+        },
+        {
+          id: 'appr-legacy',
+          keeper_name: 'keeper-a',
+          tool_name: 'fs_write',
+          decision: 'approve',
+          resolved_at: '2026-07-28T09:10:00Z',
+          summary_status: null,
+          exact_attempt: null,
+        },
+      ],
+    )
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    container.querySelector<HTMLButtonElement>('.ap-viewbtn:not(.on)')?.click()
+    await flushUi()
+
+    const rows = container.querySelectorAll('[data-testid="approval-history-item"]')
+    expect(rows).toHaveLength(2)
+    const judged = container.querySelector('[data-approval-id="appr-judged"]')
+    expect(judged?.querySelector('[data-testid="approval-history-slot"]')?.textContent)
+      .toBe('glm-coding.glm-5-turbo')
+    const fold = judged?.querySelector('[data-testid="approval-history-judge"]')
+    expect(fold?.textContent).toContain('Keeper requested a read-only listing.')
+    expect(fold?.textContent).toContain('Is the path inside the sandbox?')
+    expect(fold?.textContent).toContain('Read-only and scoped.')
+    const legacy = container.querySelector('[data-approval-id="appr-legacy"]')
+    expect(legacy?.querySelector('[data-testid="approval-history-slot"]')).toBeNull()
+    expect(legacy?.querySelector('[data-testid="approval-history-judge"]')).toBeNull()
+  }, 20000)
+
+  it('shows contract-violating queue rows as a visible banner instead of a clean empty queue', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [],
+      [],
+      undefined,
+      { state: 'ready' },
+      null,
+      [{ index: 0, id: 'appr-drifted', keeper_name: 'keeper-b', tool_name: 'fs_write' }],
+    )
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const banner = container.querySelector('[data-testid="approvals-queue-violations"]')
+    expect(banner).not.toBeNull()
+    expect(banner?.textContent).toContain('표시 불가 대기 요청 1건')
+    expect(banner?.textContent).toContain('appr-drifted')
+    expect(container.querySelector('[data-testid="approvals-empty"]')).toBeNull()
+  }, 20000)
+
+  it('names the judge lane model in the Gate mode card, and its unavailability', async () => {
+    const { ApprovalsSurface } = await loadSurface([], [], [], {
+      gate_mode: { mode: 'auto_judge', configured: true, state: 'ready' },
+      judge_lane: {
+        status: 'available',
+        lane_id: 'hitl_auto_judge',
+        slots: ['glm-coding.glm-5-turbo', 'ollama_cloud.deepseek-v4-flash'],
+      },
+    })
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const lane = container.querySelector('[data-testid="gate-judge-lane"]')
+    expect(lane?.textContent).toContain('판정 모델 glm-coding.glm-5-turbo')
+    expect(lane?.textContent).toContain('+1 failover')
+
+    const { ApprovalsSurface: UnavailableSurface } = await loadSurface([], [], [], {
+      gate_mode: { mode: 'auto_judge', configured: true, state: 'ready' },
+      judge_lane: {
+        status: 'unavailable',
+        lane_id: 'hitl_auto_judge',
+        reason: 'registry_not_published',
+      },
+    })
+
+    render(html`<${UnavailableSurface} />`, container)
+    await flushUi()
+
+    const unavailable = container.querySelector('[data-testid="gate-judge-lane"]')
+    expect(unavailable?.textContent).toContain('hitl_auto_judge')
+    expect(unavailable?.textContent).toContain('registry_not_published')
   }, 20000)
 
   it('filters resolved approval history and surfaces Always-rule evidence', async () => {

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -118,6 +118,13 @@ function decisionSourceLabel(source: GateDecisionSource | null | undefined): str
 
 function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
   const decision = keeperResolvedApprovalDecisionLabel(item.decision)
+  // Judge evidence recorded at resolution time (#26126). Older audit events
+  // carry none, so the row renders without the fold rather than implying a
+  // judgment that was never recorded.
+  const judgeSummary =
+    item.summary_status?.status === 'available' ? item.summary_status.summary : null
+  const judgeSlot =
+    item.exact_attempt?.state === 'bound' ? item.exact_attempt.slot_id : null
   return html`
     <li
       class="ap-history-item"
@@ -129,11 +136,30 @@ function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
       <span class="ap-history-keeper">${item.keeper_name}</span>
       <span class="ap-history-source">${decisionSourceLabel(item.decision_source)}</span>
       <span class="ap-history-id mono">${item.id}</span>
+      ${judgeSlot
+        ? html`<span class="ap-history-slot mono" data-testid="approval-history-slot">${judgeSlot}</span>`
+        : null}
       ${item.rule_match?.rule_id
         ? html`<span class="ap-history-rule mono">rule ${item.rule_match.rule_id}</span>`
         : null}
       ${item.resolved_at
         ? html`<span class="ap-history-at">${formatDateTimeKo(item.resolved_at)}</span>`
+        : null}
+      ${judgeSummary
+        ? html`
+            <details class="ap-history-judge" data-testid="approval-history-judge">
+              <summary>판정 근거</summary>
+              <p class="ap-summary-text">${judgeSummary.context_summary}</p>
+              ${judgeSummary.key_questions.length
+                ? html`<ul class="ap-summary-questions">
+                    ${judgeSummary.key_questions.map(q => html`<li>${q}</li>`)}
+                  </ul>`
+                : null}
+              ${judgeSummary.rationale.trim()
+                ? html`<p class="ap-summary-rationale">${judgeSummary.rationale.trim()}</p>`
+                : null}
+            </details>
+          `
         : null}
     </li>
   `
@@ -593,6 +619,7 @@ function ApAside({
     .sort((a, b) => resolvedAtMs(b) - resolvedAtMs(a))
     .slice(0, ASIDE_RECENT_LIMIT)
   const gateMode = hitl?.gate_mode
+  const judgeLane = hitl?.judge_lane
   const acting = gateApprovalActing.value
   const modeDisabled = acting !== null
   const hiddenRules = Math.max(0, rules.length - ASIDE_RULES_LIMIT)
@@ -626,6 +653,21 @@ function ApAside({
           <div class="wka-auto-note">
             Human은 사람이 판단하고, Auto Judge는 LLM이 판단하며, Always Allow는 workspace의 명시적 선택입니다.
           </div>
+          ${judgeLane
+            ? judgeLane.status === 'available'
+              ? html`
+                  <div class="wka-auto-stat mono" data-testid="gate-judge-lane">
+                    판정 모델 ${judgeLane.slots[0]}${judgeLane.slots.length > 1
+                      ? ` (+${judgeLane.slots.length - 1} failover)`
+                      : ''}
+                  </div>
+                `
+              : html`
+                  <div class="ap-env-warn mono" data-testid="gate-judge-lane">
+                    판정 lane ${judgeLane.lane_id} 확인 불가: ${judgeLane.reason}
+                  </div>
+                `
+            : null}
           ${gateMode?.state === 'invalid' || gateMode?.state === 'unavailable' || gateMode?.read_error
             ? html`<div class="ap-env-warn mono">Gate mode ${gateMode.state ?? 'invalid'}: ${gateMode.read_error ?? '상태 확인 실패'}</div>`
             : null}
@@ -695,6 +737,7 @@ export function ApprovalsSurface() {
   const resolvedItems = gateData.value?.recent_resolved ?? []
   const resolvedPage = gateData.value?.recent_resolved_page ?? null
   const rules = gateData.value?.approval_rules ?? []
+  const queueViolations = gateData.value?.approval_queue_violations ?? []
   const error = gateError.value
   // First load only: gateResource is stale-while-revalidate, so a refetch
   // keeps the previous data — gateData is null ONLY before the first load
@@ -752,6 +795,23 @@ export function ApprovalsSurface() {
         </header>
 
         ${error ? html`<div class="ap-error" role="alert" data-testid="approvals-error">${error}</div>` : null}
+        ${queueViolations.length > 0
+          ? html`
+              <div class="ap-error sev-warn" role="alert" data-testid="approvals-queue-violations">
+                <strong><span aria-hidden="true">!</span> 표시 불가 대기 요청 ${queueViolations.length}건</strong>
+                <span>
+                  아래 행은 디코딩 계약을 위반해 카드로 표시할 수 없지만, 대기 중인
+                  승인 요청은 실재합니다. 서버 원장(audit-approvals)에서 확인하세요.
+                </span>
+                ${queueViolations.map(violation => html`
+                  <span class="mono" key=${violation.index}>
+                    #${violation.index} · ${violation.keeper_name ?? 'keeper?'} ·
+                    ${violation.tool_name ?? 'tool?'} · ${violation.id ?? 'id?'}
+                  </span>
+                `)}
+              </div>
+            `
+          : null}
         ${queueUnavailable
           ? html`
               <div
@@ -813,7 +873,7 @@ export function ApprovalsSurface() {
               </div>
             `
           : null}
-        ${items.length === 0 && !error && !queueUnavailable
+        ${items.length === 0 && !error && !queueUnavailable && queueViolations.length === 0
           ? html`
               <div class="ap-clear" data-testid="approvals-empty">
                 <div class="ico">${'✓'}</div>

--- a/dashboard/src/types/gate.ts
+++ b/dashboard/src/types/gate.ts
@@ -169,7 +169,28 @@ export interface KeeperResolvedApprovalItem {
   rule_match?: {
     rule_id?: string | null
   } | null
+  /** Judge evidence recorded on the resolved audit event at resolution time
+   *  (#26126). `null` on events written before that enrichment existed. */
+  summary_status?: HitlSummaryStatus | null
+  exact_attempt?: KeeperExactAttemptState | null
 }
+
+/** An approval_queue row the server sent but the client contract rejected.
+ *  Rendered as an explicit placeholder instead of blanking the whole queue
+ *  (#26094): the operator must know a pending request exists even when its
+ *  row cannot be decoded. Identity fields are best-effort salvage. */
+export interface KeeperApprovalQueueRowViolation {
+  index: number
+  id?: string | null
+  keeper_name?: string | null
+  tool_name?: string | null
+}
+
+/** Which exact-output lane serves Gate Auto Judge. Slot order is OAS failover
+ *  order: the first slot is the model that actually judges. */
+export type GateJudgeLane =
+  | { status: 'available'; lane_id: string; slots: string[] }
+  | { status: 'unavailable'; lane_id: string; reason: string }
 
 export interface KeeperApprovalRule {
   id: string
@@ -211,11 +232,13 @@ export interface DashboardGateResponse {
   note?: string
   approval_queue: KeeperApprovalQueueItem[] | null
   approval_queue_state: KeeperApprovalQueueState
+  approval_queue_violations?: KeeperApprovalQueueRowViolation[]
   recent_resolved?: KeeperResolvedApprovalItem[]
   recent_resolved_page?: KeeperResolvedApprovalPage | null
   approval_rules?: KeeperApprovalRule[]
   hitl?: {
     gate_mode?: GateModeStatus
+    judge_lane?: GateJudgeLane
   }
 }
 

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -4,8 +4,44 @@
     queue, exact Always Allowed rules, and recent decisions. It derives no
     product policy or execution authority. *)
 
+(* Which exact-output lane serves Gate Auto Judge, read from the published
+   runtime registry. The first slot is the model that judges; later slots are
+   OAS failover order. An unpublished or busy registry reports itself as a
+   closed unavailable variant instead of guessing (#26126). *)
+let judge_lane_json () =
+  let lane_id = Hitl_summary_worker.lane_id in
+  let unavailable reason =
+    `Assoc
+      [ "status", `String "unavailable"
+      ; "lane_id", `String lane_id
+      ; "reason", `String reason
+      ]
+  in
+  match Runtime_exact_output_registry.current () with
+  | Error error ->
+    unavailable (Runtime_exact_output_registry.publication_error_to_string error)
+  | Ok registry ->
+    (match Runtime_exact_output_registry.resolve_lane registry ~lane_id with
+     | Error error ->
+       unavailable (Runtime_exact_output_registry.lane_resolution_error_to_string error)
+     | Ok { selected_slots } ->
+       `Assoc
+         [ "status", `String "available"
+         ; "lane_id", `String lane_id
+         ; ( "slots"
+           , `List
+               (List.map
+                  (fun (slot : Runtime_exact_output_registry.selected_slot) ->
+                    `String slot.slot_id)
+                  selected_slots) )
+         ])
+;;
+
 let hitl_status_json ~base_path =
-  `Assoc [ "gate_mode", Keeper_gate_mode.status_json ~base_path ]
+  `Assoc
+    [ "gate_mode", Keeper_gate_mode.status_json ~base_path
+    ; "judge_lane", judge_lane_json ()
+    ]
 ;;
 
 (* The page bounds travel with the rows. Without them a client cannot tell an

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -655,7 +655,6 @@ let exact_attempt_quarantine_summary_status cause =
         Printf.sprintf
           "Auto Judge exact attempt quarantined: %s"
           (exact_attempt_quarantine_cause_to_string cause)
-    ; retryable = false
     }
 ;;
 
@@ -1408,6 +1407,8 @@ let audit_approval_event
       ?actor
       ?decision_source
       ?decision
+      ?summary_status
+      ?exact_attempt
       ()
   =
   let decision, decision_kind, decision_reason =
@@ -1449,6 +1450,13 @@ let audit_approval_event
             | None -> [])
          @ (match decision_reason with
             | Some reason -> [ "decision_reason", `String reason ]
+            | None -> [])
+         @ (match summary_status with
+            | Some status -> [ "summary_status", summary_status_to_yojson status ]
+            | None -> [])
+         @ (match exact_attempt with
+            | Some attempt ->
+              [ "exact_attempt", exact_attempt_state_to_yojson attempt ]
             | None -> [])
          )
     in
@@ -1565,6 +1573,10 @@ let resolved_approval_json_of_audit_event json =
     ; "actor", json_member_or_null "actor" json
     ; "decision_source", json_member_or_null "decision_source" json
     ; "rule_match", json_member_or_null "rule_match" json
+      (* Judge evidence recorded at resolution time (#26126). Events written
+         before that enrichment have no such members and project as [`Null]. *)
+    ; "summary_status", json_member_or_null "summary_status" json
+    ; "exact_attempt", json_member_or_null "exact_attempt" json
     ]
 ;;
 
@@ -1945,7 +1957,7 @@ let record_pending (entry : pending_approval) =
 let summary_audit_extras (entry : pending_approval) : (string * Yojson.Safe.t) list =
   match entry.summary_status with
   | Summary_available summary -> [ "model_run_id", `String summary.model_run_id ]
-  | Summary_failed { reason; _ } -> [ "failure_reason", `String reason ]
+  | Summary_failed { reason } -> [ "failure_reason", `String reason ]
   | Summary_not_requested | Summary_pending -> []
 ;;
 
@@ -2941,6 +2953,8 @@ let resolve_entry
     ~goal_ids:entry.goal_ids
     ~decision_source:source
     ~decision
+    ~summary_status:entry.summary_status
+    ~exact_attempt:entry.exact_attempt
     ();
   before_terminal_publish ();
   try
@@ -3627,8 +3641,7 @@ let retire_summary_owner ~base_path ~keeper_name ~reason =
                  , SMap.add
                      id
                      { entry with
-                       summary_status =
-                         Summary_failed { reason; retryable = false }
+                       summary_status = Summary_failed { reason }
                      }
                      map
                  , bound )

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -211,6 +211,8 @@ val audit_approval_event :
   ?actor:string ->
   ?decision_source:decision_source ->
   ?decision:decision ->
+  ?summary_status:summary_status ->
+  ?exact_attempt:exact_attempt_state ->
   unit ->
   unit
 

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -23,7 +23,7 @@ type summary_status =
   | Summary_not_requested
   | Summary_pending
   | Summary_available of hitl_context_summary
-  | Summary_failed of { reason : string; retryable : bool }
+  | Summary_failed of { reason : string }
 
 type exact_attempt_quarantine_cause =
   | Exact_flow_execution_failed
@@ -254,12 +254,8 @@ let summary_status_to_yojson = function
       [ "status", `String "available"
       ; "summary", hitl_context_summary_to_yojson summary
       ]
-  | Summary_failed { reason; retryable } ->
-    `Assoc
-      [ "status", `String "failed"
-      ; "reason", `String reason
-      ; "retryable", `Bool retryable
-      ]
+  | Summary_failed { reason } ->
+    `Assoc [ "status", `String "failed"; "reason", `String reason ]
 ;;
 
 let exact_attempt_status_to_string = function
@@ -696,10 +692,13 @@ let summary_status_of_yojson_with_error json =
            fields
        in
        let* reason = required_string ~surface:"summary_status" "reason" fields in
+       (* Legacy field: pre-#26094 stores persisted a write-only [retryable]
+          bool that no OCaml or dashboard reader consumed, and whose [true]
+          value blanked the dashboard approval queue. Accepted and discarded
+          on load so existing stores keep parsing; never written back. *)
        (match List.assoc_opt "retryable" fields with
-        | Some (`Bool retryable) -> Ok (Summary_failed { reason; retryable })
-        | Some _ -> Error "summary_status.retryable must be a boolean"
-        | None -> Error "summary_status.retryable is required")
+        | None | Some (`Bool _) -> Ok (Summary_failed { reason })
+        | Some _ -> Error "summary_status.retryable must be a boolean when present")
      | other -> Error (Printf.sprintf "summary_status.status %S is unknown" other))
   | _ -> Error "summary_status must be a known string or JSON object"
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -24,7 +24,7 @@ type summary_status =
   | Summary_not_requested
   | Summary_pending
   | Summary_available of hitl_context_summary
-  | Summary_failed of { reason : string; retryable : bool }
+  | Summary_failed of { reason : string }
 
 type exact_attempt_quarantine_cause =
   | Exact_flow_execution_failed

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -1010,8 +1010,7 @@ let test_flow_execution_failure_quarantines_and_blocks_owner () =
         | Some
             { input_hash
             ; sequence
-            ; summary_status =
-                Q.Summary_failed { reason; retryable = false }
+            ; summary_status = Q.Summary_failed { reason }
             ; exact_attempt =
                 Q.Exact_bound
                   { slot_id

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1448,8 +1448,7 @@ let test_exact_attempt_binding_release_and_conflicts () =
          true
          (quarantine_exact replacement quarantine_cause);
        (match pending_entry_exn id with
-        | { summary_status =
-              AQ.Summary_failed { reason; retryable = false }
+        | { summary_status = AQ.Summary_failed { reason }
           ; exact_attempt =
               AQ.Exact_bound
                 { status =
@@ -2473,7 +2472,7 @@ let test_operator_recovery_skips_terminal_exact_failure () =
          (reserve_retry_exact ~base_path (pending_entry_exn quarantined_id));
        (match AQ.For_testing.get_pending_entry_unchecked ~id:quarantined_id with
         | Some
-            { summary_status = AQ.Summary_failed { retryable = false; _ }
+            { summary_status = AQ.Summary_failed _
             ; exact_attempt =
                 AQ.Exact_bound
                   { status =
@@ -2564,9 +2563,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
             ids);
        match AQ.For_testing.get_pending_entry_unchecked ~id:retirable with
        | Some
-           { summary_status =
-               AQ.Summary_failed
-                 { reason = "retired"; retryable = false }
+           { summary_status = AQ.Summary_failed { reason = "retired" }
            ; _
            } ->
          ()
@@ -3240,6 +3237,50 @@ let test_nonapproved_resolution_payload_is_delivered () =
        drop_resolution ~base_path ~keeper_name edited)
 ;;
 
+(* #26126: resolution writes the judge evidence the entry carried onto the
+   resolved audit event, so the decision remains explainable after the entry
+   leaves the pending queue. *)
+let test_resolved_audit_event_carries_judge_evidence () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-judge-evidence" in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () ->
+       ignore (install_exn ~base_path);
+       let id =
+         submit ~base_path ~keeper_name ~input:(`Assoc [ "target", `String "doc" ])
+       in
+       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+        | Ok () -> ()
+        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
+       let history =
+         AQ.list_recent_resolved
+           ~base_path
+           ~now_ts:(Unix.gettimeofday ())
+           ~window_minutes:60
+           ()
+       in
+       let open Yojson.Safe.Util in
+       let row =
+         List.find_opt
+           (fun row -> String.equal (row |> member "id" |> to_string) id)
+           history.resolved_rows
+       in
+       match row with
+       | None -> Alcotest.fail "resolved decision missing from history"
+       | Some row ->
+         Alcotest.check yojson
+           "summary_status recorded at resolution"
+           (`String "not_requested")
+           (row |> member "summary_status");
+         Alcotest.check yojson
+           "exact_attempt recorded at resolution"
+           (AQ.exact_attempt_state_to_yojson AQ.Exact_unbound)
+           (row |> member "exact_attempt"))
+;;
+
 let () =
   Alcotest.run
     "Keeper_approval_queue"
@@ -3280,6 +3321,10 @@ let () =
             "resolution wakes only origin"
             `Quick
             test_resolution_is_durable_and_origin_scoped
+        ; Alcotest.test_case
+            "resolved audit event carries judge evidence"
+            `Quick
+            test_resolved_audit_event_carries_judge_evidence
         ; Alcotest.test_case
             "remembered rule carries requested expiry"
             `Quick

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -148,12 +148,60 @@ let test_rule_parser_rejects_duplicate_fields () =
       reason
 ;;
 
+(* #26094: [retryable] was a write-only bool — OCaml only ever wrote [false],
+   no reader consumed it, and the dashboard blanked the whole approval queue on
+   any other value. The field left the wire contract; stores written before the
+   removal still parse, and the serializer never emits it again. *)
+let test_summary_failed_has_no_retryable () =
+  let failed = Q.Summary_failed { reason = "provider down" } in
+  (match Q.summary_status_to_yojson failed with
+   | `Assoc fields ->
+     check
+       (list string)
+       "serialized fields"
+       [ "status"; "reason" ]
+       (List.map fst fields)
+   | _ -> fail "Summary_failed must serialize as an object");
+  let decode json = Q.summary_status_of_yojson_with_error json in
+  (match
+     decode (`Assoc [ "status", `String "failed"; "reason", `String "provider down" ])
+   with
+   | Ok status -> check bool "modern decode" true (status = failed)
+   | Error e -> fail e);
+  (match
+     decode
+       (`Assoc
+           [ "status", `String "failed"
+           ; "reason", `String "provider down"
+           ; "retryable", `Bool true
+           ])
+   with
+   | Ok status -> check bool "legacy retryable discarded" true (status = failed)
+   | Error e -> fail e);
+  match
+    decode
+      (`Assoc
+          [ "status", `String "failed"
+          ; "reason", `String "provider down"
+          ; "retryable", `String "yes"
+          ])
+  with
+  | Ok _ -> fail "non-boolean legacy retryable must reject"
+  | Error _ -> ()
+;;
+
 let () =
   run
     "Keeper_approval_queue_rules_types"
     [ ( "judgment"
       , [ test_case "typed judgment round trip" `Quick test_advisory_judgment_round_trip
         ; test_case "summary has no hierarchy" `Quick test_summary_json_is_nonhierarchical
+        ] )
+    ; ( "summary status"
+      , [ test_case
+            "retryable is out of the contract, legacy stores still parse"
+            `Quick
+            test_summary_failed_has_no_retryable
         ] )
     ; ( "exact rule"
       , [ test_case "JSON round trip" `Quick test_approval_rule_json_round_trip

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -226,6 +226,54 @@ let test_empty_store_is_an_empty_page base_path =
   check bool "scan not exhausted" false history.resolved_scan_exhausted
 ;;
 
+(* #26126: judge evidence recorded on the resolved audit event at resolution
+   time must survive projection verbatim; events written before the enrichment
+   project the members as [`Null] rather than being dropped or invented. *)
+let yojson = testable Yojson.Safe.pretty_print Yojson.Safe.equal
+
+let test_judge_evidence_passes_through base_path =
+  let summary_status : Yojson.Safe.t =
+    `Assoc [ "status", `String "failed"; "reason", `String "quarantined" ]
+  in
+  let exact_attempt : Yojson.Safe.t = `Assoc [ "state", `String "unbound" ] in
+  append_row
+    ~base_path
+    ~ts:(now -. minutes 5)
+    (`Assoc
+        [ "event", `String "resolved"
+        ; "id", `String "with-judge"
+        ; "ts", `Float (now -. minutes 5)
+        ; "keeper", `String "rondo"
+        ; "tool", `String "tool_execute"
+        ; "decision", `String "approve"
+        ; "decision_source", `String "auto_judge"
+        ; "summary_status", summary_status
+        ; "exact_attempt", exact_attempt
+        ]);
+  seed_resolved ~base_path ~ts:(now -. minutes 10) ~id:"legacy" ();
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:60 () in
+  let member name row =
+    match row with
+    | `Assoc fields -> Option.value ~default:`Null (List.assoc_opt name fields)
+    | _ -> `Null
+  in
+  let find id =
+    List.find (fun row -> member "id" row = `String id) history.resolved_rows
+  in
+  check
+    yojson
+    "summary_status passes through"
+    summary_status
+    (member "summary_status" (find "with-judge"));
+  check
+    yojson
+    "exact_attempt passes through"
+    exact_attempt
+    (member "exact_attempt" (find "with-judge"));
+  check yojson "legacy summary_status is null" `Null (member "summary_status" (find "legacy"));
+  check yojson "legacy exact_attempt is null" `Null (member "exact_attempt" (find "legacy"))
+;;
+
 let test_bounds_are_clamped base_path =
   let over = AQ.list_recent_resolved ~base_path ~now_ts:now ~limit:100_000 ~window_minutes:999_999 () in
   check int "limit clamped to the max" AQ.recent_resolved_max_limit over.resolved_limit;
@@ -263,6 +311,10 @@ let () =
             (with_store test_undated_decision_is_excluded)
         ; test_case "empty store is an empty page" `Quick
             (with_store test_empty_store_is_an_empty_page)
+        ] )
+    ; ( "judge evidence"
+      , [ test_case "judge evidence passes through, legacy rows project null" `Quick
+            (with_store test_judge_evidence_passes_through)
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제 (#26094 + #26126)

Gate Auto Judge의 가시성 결함 3종이 겹쳐 있었다:

1. **`summary_status.retryable` 지뢰 (#26094)** — OCaml은 `false`만 쓰고, 아무도 읽지 않고, dashboard는 다른 값이 오면 **큐 전체를 blank** 처리. 한쪽만 만들 수 있고 다른 쪽이 한 값만 받는 bool은 정보가 아니라 지뢰.
2. **행 하나 위반 = 전체 표면 상실** — `approval_queue`의 계약 위반 행 1건이 `gateSnapshotProtocolDrift`로 스냅샷 전체를 죽였다. 행이 drift하는 순간이 바로 운영자가 화면을 필요로 하는 순간.
3. **판정 근거의 가시성 윈도우가 수십 초 (#26126)** — Auto Judge는 17~42초에 resolve하고 엔트리가 큐에서 빠지는데 `recent_resolved`에는 rationale/모델이 없어, 사람이 볼 때는 항상 이미 사라진 뒤였다.

## 수정 (producer + consumer 동시 이동)

- `Summary_failed of { reason }` — `retryable` 필드를 타입/직렬화/역직렬화에서 제거. 기존 store 호환: decoder는 legacy boolean을 받고 폐기(비불리언은 거부), 다시 쓰지 않는다.
- dashboard: `failed`는 `{status, reason}`만 계약. 위반 행은 **행 단위 격리** — 전체 blank 대신 index+복구된 identity를 가진 가시적 placeholder(`approvals-queue-violations` 배너)로 렌더. 빈 큐 empty state는 위반이 있으면 뜨지 않는다.
- `resolve_entry`가 entry의 `summary_status`/`exact_attempt`를 **resolved audit 이벤트에 기록**, `list_recent_resolved`가 그대로 투영(구 이벤트는 `Null`). 이력 행에 판정 근거 접이식(`판정 근거`) + 서빙 slot 칩 렌더.
- Gate 모드 카드에 **judge lane 슬롯 표시** — `Runtime_exact_output_registry.current()` → `resolve_lane`으로 published registry에서 읽음. 미발행/미구성은 closed unavailable variant로 자기보고.

## 검증

- `dune build @check` — 클린 (**최신 main `0b2b0563d9` 머지 트리에서 재확인**, 오늘 #26083×#26046 교차 사고 재발 방지 절차)
- OCaml: `test_keeper_approval_queue` 35/35 (신규: resolved audit 이벤트가 판정 증거를 실음) · `test_keeper_approval_queue_rules_types` 10/10 (신규: legacy retryable decode) · `test_keeper_approval_resolved_history` 10/10 (신규: 투영 pass-through + legacy null)
- dashboard: vitest 8,841/8,842 pass — 신규 테스트 6종 (row-scoped 격리, resolved 판정 필드, judge_lane closed parse, 렌더 3종) 포함
- 기존 실패 2건은 main 베이스라인과 동일 (내 회귀 아님): `test_hitl_summary_worker` production-exact-flow 2/8/11/12/13, `keeper-status-vocabulary` offline residual — #26113 계열
- eslint: 신규 위반 0 (keeper-actions.ts 1건은 main에도 존재, 미접촉 파일)

## 남는 것 (이 PR 범위 밖)

- resolved 이벤트 enrichment는 **이 PR 이후의 resolution부터** 기록된다. 과거 판정의 rationale은 여전히 `summary_updated` 이벤트에만 있다 (#26126의 조회 API 제안은 후속).

Closes #26094
Refs #26126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## 운영 노트 (적대적 self-review에서 나온 발견)

1. **롤백 편도성**: 새 바이너리가 `retryable` 없는 `Summary_failed`를 store에 쓴 뒤 **pre-PR 바이너리로 롤백**하면, 구 decoder가 `summary_status.retryable is required`로 해당 store 로드를 거부한다 (fail-closed → `reset_required`). failed-summary 엔트리가 pending에 존재하는 순간에만 해당. 필드 제거의 표준 비용이며, 대안(영원히 dead field 쓰기)이 바로 #26094의 지뢰였다.
2. **배포 직후 구 탭**: 열려 있던 구 dashboard JS는 failed 행에 `retryable === false`를 요구하므로, 새 서버 응답(필드 없음)을 보면 구 코드의 전체-blank 경로를 탄다. 새로고침으로 해소되는 과도기 현상.
3. **판정 증거 파서의 강성**: resolved 행의 judge blob이 계약 위반(예: 미래의 summary_version bump 미반영)이면 그 행 전체를 거부한다 — 조용히 잘못된 증거를 보여주는 것보다 이력 카운트 감소로 드러나는 쪽을 선택. queue/resolved가 같은 파서를 공유하므로 version bump 시 함께 갱신된다.
4. `resolve_lane`은 순수 읽기(구현 확인: `List.find_opt` + map, 락/lease 없음) — 대시보드 폴링이 판정 워커와 경합하지 않는다.
5. KPI '열린 승인'은 디코딩된 행만 센다. 위반 행은 바로 위 배너에 건수/identity로 표시된다 (두 수를 섞지 않음).
