### PR TITLE
fix: bind Keeper approvals to durable tool-call identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,20 @@ jobs:
           operator_targets="@test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${operator_targets}"
 
+      - name: Run Keeper approval contract suite
+        id: keeper_approval_contract_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          ALCOTEST_QUICK_TESTS: "1"
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          approval_targets="@test/runtest-test_keeper_approval_queue @test/runtest-test_keeper_gate_replay @test/runtest-test_keeper_approval_resolved_history"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${approval_targets}"
+
       - name: Run SSE reconnect e2e
         id: sse_reconnect_e2e
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,7 +829,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          approval_targets="@test/runtest-test_keeper_approval_queue @test/runtest-test_keeper_gate_replay @test/runtest-test_keeper_approval_resolved_history"
+          approval_targets="@test/runtest-test_keeper_approval_queue @test/runtest-test_keeper_gate_replay @test/runtest-test_keeper_approval_resolved_history @test/runtest-test_keeper_tool_dispatch_runtime"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${approval_targets}"
 
       - name: Run SSE reconnect e2e

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -1,7 +1,7 @@
 # Keeper Tool Boundary Matrix
 
 Status: P0 ratchet source for keeper agent tool boundaries.
-Last updated: 2026-07-12.
+Last updated: 2026-07-28.
 
 This matrix freezes the owner map for keeper modules that participate in the
 agent tool path. A new file in scope must be added here with exactly one owner
@@ -173,6 +173,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_visibility_projection.mli` - tool-surface-policy
 - `lib/keeper/keeper_tools_oas_bundle.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_bundle.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tool_call_identity.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tool_call_identity.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_telemetry.ml` - oas-tool-bridge

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -43,6 +43,7 @@ let build_context_bundle ~(entry : pending_approval) =
   let request_identity =
     [ "keeper_name", `String entry.keeper_name
     ; "tool_name", `String entry.tool_name
+    ; "tool_call_id", Json_util.string_opt_to_json entry.tool_call_id
     ; "turn_id", Json_util.int_opt_to_json entry.turn_id
     ; "task_id", Json_util.string_opt_to_json entry.task_id
     ; "goal_id", Json_util.string_opt_to_json entry.goal_id

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1416,6 +1416,7 @@ let audit_approval_event
       ~id
       ~keeper_name
       ~tool_name
+      ?tool_call_id
       ?turn_id
       ?task_id
       ?goal_id
@@ -1446,6 +1447,7 @@ let audit_approval_event
          ; "id", `String id
          ; "keeper", `String keeper_name
          ; "tool", `String tool_name
+         ; "tool_call_id", Json_util.string_opt_to_json tool_call_id
          ; "decision", `String decision
          ; "turn_id", Json_util.int_opt_to_json turn_id
          ; "task_id", Json_util.string_opt_to_json task_id
@@ -1580,6 +1582,7 @@ let resolved_approval_json_of_audit_event json =
     ; "event", `String (Safe_ops.json_string ~default:"" "event" json)
     ; "keeper_name", `String (Safe_ops.json_string ~default:"" "keeper" json)
     ; "tool_name", `String (Safe_ops.json_string ~default:"" "tool" json)
+    ; "tool_call_id", json_member_or_null "tool_call_id" json
     ; "decision", Json_util.string_opt_to_json_trimmed (Safe_ops.json_string_opt "decision" json)
     ; "decision_kind", Json_util.string_opt_to_json_trimmed (resolved_approval_decision_kind json)
     ; "decision_reason", json_member_or_null "decision_reason" json
@@ -1858,6 +1861,7 @@ let consume_approved_resolution
       ~id
       ~keeper_name:entry.keeper_name
       ~tool_name:entry.tool_name
+      ?tool_call_id:entry.tool_call_id
       ?turn_id:entry.turn_id
       ?task_id:entry.task_id
       ?goal_id:entry.goal_id
@@ -1985,6 +1989,7 @@ let record_pending (entry : pending_approval) =
     ~id:entry.id
     ~keeper_name:entry.keeper_name
     ~tool_name:entry.tool_name
+    ?tool_call_id:entry.tool_call_id
     ?turn_id:entry.turn_id
     ?task_id:entry.task_id
     ?goal_id:entry.goal_id
@@ -2986,6 +2991,7 @@ let resolve_entry
     ~id:entry.id
     ~keeper_name:entry.keeper_name
     ~tool_name:entry.tool_name
+    ?tool_call_id:entry.tool_call_id
     ?turn_id:entry.turn_id
     ?task_id:entry.task_id
     ?goal_id:entry.goal_id
@@ -3005,6 +3011,7 @@ let resolve_entry
                 [ "id", `String entry.id
                 ; "keeper_name", `String entry.keeper_name
                 ; "tool_name", `String entry.tool_name
+                ; "tool_call_id", Json_util.string_opt_to_json entry.tool_call_id
                 ; "decision", `String decision_str
                 ] )
           ])
@@ -3019,15 +3026,6 @@ let resolve_entry
       exn
 ;;
 
-(* [continuation_channel] stays in the dedup key while turn_id, task_id and the
-   goal fields do not. Those three are context that drifts across a retried
-   invocation, which is exactly what keying on [tool_call_id] exists to ignore.
-   The continuation channel is different in kind: it is where the result of the
-   approved effect is delivered. Not every provider emits a globally unique
-   tool-call id — a short per-response index ("call_0") repeats across turns —
-   so an id collision on the same keeper, operation and canonical input would
-   otherwise merge two genuinely distinct requests and deliver the second one's
-   result to the first one's channel. *)
 let pending_entry_matches
       (entry : pending_approval)
       ~base_path
@@ -3035,7 +3033,6 @@ let pending_entry_matches
       ~tool_name
       ~tool_call_id
       ~input_hash
-      ~continuation_channel
   =
   String.equal entry.audit_base_path base_path
   && String.equal entry.keeper_name keeper_name
@@ -3044,9 +3041,6 @@ let pending_entry_matches
       | None -> false
       | Some tool_call_id -> entry.tool_call_id = Some tool_call_id)
   && String.equal entry.input_hash input_hash
-  && Yojson.Safe.equal
-       (Keeper_continuation_channel.to_yojson entry.continuation_channel)
-       (Keeper_continuation_channel.to_yojson continuation_channel)
 ;;
 
 let pending_entry_owns_tool_call_id
@@ -3072,7 +3066,6 @@ let find_pending_id_in_map
       ~tool_name
       ~tool_call_id
       ~input_hash
-      ~continuation_channel
   =
   SMap.fold
     (fun id (entry : pending_approval) acc ->
@@ -3090,14 +3083,14 @@ let find_pending_id_in_map
          then
            if
              pending_entry_matches entry ~base_path ~keeper_name ~tool_name
-               ~tool_call_id ~input_hash ~continuation_channel
-           then Ok (Some id)
+               ~tool_call_id ~input_hash
+            then Ok (Some id)
            else
              (match tool_call_id with
               | Some tool_call_id ->
                 Error
                   (Printf.sprintf
-                     "tool_call_id %s is already pending for a different request (approval %s): the canonical input or the continuation channel differs"
+                     "tool_call_id %s is already pending for a different canonical request (approval %s)"
                      tool_call_id
                      id)
               | None -> Ok None)
@@ -3159,7 +3152,6 @@ let submit_pending
              ~tool_name
              ~tool_call_id
              ~input_hash
-             ~continuation_channel
          with
          | Error reason ->
            Error { path = pending_store_path ~base_path; reason }

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -3062,6 +3062,11 @@ let find_pending_id_in_map
 
 (* ── Nonblocking submission ───────────────────────────────── *)
 
+let valid_tool_call_id = function
+  | None -> true
+  | Some value -> String.trim value <> ""
+;;
+
 let submit_pending
       ~keeper_name
       ~tool_name
@@ -3082,7 +3087,14 @@ let submit_pending
     Option.value continuation_channel ~default:(default_continuation_channel ())
   in
   let stored =
-    with_pending_store_lock (fun () ->
+    if not (valid_tool_call_id tool_call_id)
+    then
+      Error
+        { path = pending_store_path ~base_path
+        ; reason = "tool_call_id must be non-blank when supplied"
+        }
+    else
+      with_pending_store_lock (fun () ->
       let map = Atomic.get pending in
       match next_sequence_lifecycle ~base_path with
       | Uninstalled ->

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -3050,11 +3050,14 @@ let find_pending_id_in_map
                 ~tool_call_id ~input_hash
            then Ok (Some id)
            else
-             Error
-               (Printf.sprintf
-                  "tool_call_id %s is already pending for a different canonical request (approval %s)"
-                  (Option.get tool_call_id)
-                  id)
+             (match tool_call_id with
+              | Some tool_call_id ->
+                Error
+                  (Printf.sprintf
+                     "tool_call_id %s is already pending for a different canonical request (approval %s)"
+                     tool_call_id
+                     id)
+              | None -> Ok None)
          else Ok None)
     map
     (Ok None)

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -253,7 +253,16 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 8
+(* v9 adds [tool_call_id] to every pending and delivery entry. The reader below
+   still accepts v8 snapshots, where the field is simply absent and decodes to
+   [None]; that is what keeps an upgrade from stranding in-flight operator
+   approvals. The number is bumped anyway so the version identifies the record
+   shape: a binary predating this change reports "version 9 is unsupported
+   (current 8); reset runtime state" instead of failing per entry on an unknown
+   field, which is the difference between a diagnosable rollback and an opaque
+   one. *)
+let pending_store_version = 9
+let pending_store_read_versions = [ 8; 9 ]
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
@@ -1026,14 +1035,18 @@ let snapshot_of_yojson ~base_path json =
     in
     let* () =
         match List.assoc_opt "version" fields with
-        | Some (`Int version) when version = pending_store_version -> Ok ()
+        | Some (`Int version) when List.mem version pending_store_read_versions
+          -> Ok ()
         | Some (`Int version) ->
           Error
             (Printf.sprintf
-               "%s.version %d is unsupported (current %d); reset runtime state \
-                before restarting MASC"
+               "%s.version %d is unsupported (readable %s, current %d); reset \
+                runtime state before restarting MASC"
                surface
                version
+               (String.concat
+                  ","
+                  (List.map string_of_int pending_store_read_versions))
                pending_store_version)
       | Some _ -> Error (surface ^ ".version must be an integer")
       | None -> Error (surface ^ ".version is required")
@@ -1780,12 +1793,28 @@ let approved_resolution_state ~base_path ~id =
     | Ok (Approved_delivery_unconsumed _) -> Ok Resolution_unconsumed)
 ;;
 
+(* The approval record is the authority for WHICH effect the operator granted:
+   keeper, operation, and the canonical input fingerprint. The consuming
+   invocation's own tool-call id is deliberately not part of that check.
+
+   Requiring [entry.tool_call_id = consuming_tool_call_id] made the grant
+   unspendable for every Gate operation that cannot replay. On the replay path
+   the caller injects the approval's own stored id into the causal context
+   before consuming ([Keeper_gate_replay.replay_approved_effect]), so the
+   comparison read a value back out of the record under test and authenticated
+   nothing. Off that path — network_read, connector_post — the model re-emits
+   the call, the provider assigns a fresh tool_use_id, the comparison fails,
+   and the operator's decision is silently discarded and re-requested.
+
+   Double-spend is prevented by [grant_consumed] (one-shot); which approval a
+   cycle may spend is fixed by the Hitl_resolution event carrying
+   [approval_id]. Request identity is enforced where it is meaningful: on
+   submission, where [tool_call_id] is the dedup key. *)
 let consume_approved_resolution
       ~base_path
       ~id
       ~keeper_name
       ~tool_name
-      ~tool_call_id
       ~input
   =
   let result =
@@ -1800,7 +1829,6 @@ let consume_approved_resolution
           not
             (String.equal entry.keeper_name keeper_name
              && String.equal entry.tool_name tool_name
-             && entry.tool_call_id = tool_call_id
              && String.equal entry.input_hash (normalized_input_hash input))
         then Ok (Consumption_without_audit Consumption_not_matching)
         else
@@ -2991,6 +3019,15 @@ let resolve_entry
       exn
 ;;
 
+(* [continuation_channel] stays in the dedup key while turn_id, task_id and the
+   goal fields do not. Those three are context that drifts across a retried
+   invocation, which is exactly what keying on [tool_call_id] exists to ignore.
+   The continuation channel is different in kind: it is where the result of the
+   approved effect is delivered. Not every provider emits a globally unique
+   tool-call id — a short per-response index ("call_0") repeats across turns —
+   so an id collision on the same keeper, operation and canonical input would
+   otherwise merge two genuinely distinct requests and deliver the second one's
+   result to the first one's channel. *)
 let pending_entry_matches
       (entry : pending_approval)
       ~base_path
@@ -2998,6 +3035,7 @@ let pending_entry_matches
       ~tool_name
       ~tool_call_id
       ~input_hash
+      ~continuation_channel
   =
   String.equal entry.audit_base_path base_path
   && String.equal entry.keeper_name keeper_name
@@ -3006,6 +3044,9 @@ let pending_entry_matches
       | None -> false
       | Some tool_call_id -> entry.tool_call_id = Some tool_call_id)
   && String.equal entry.input_hash input_hash
+  && Yojson.Safe.equal
+       (Keeper_continuation_channel.to_yojson entry.continuation_channel)
+       (Keeper_continuation_channel.to_yojson continuation_channel)
 ;;
 
 let pending_entry_owns_tool_call_id
@@ -3031,6 +3072,7 @@ let find_pending_id_in_map
       ~tool_name
       ~tool_call_id
       ~input_hash
+      ~continuation_channel
   =
   SMap.fold
     (fun id (entry : pending_approval) acc ->
@@ -3046,15 +3088,16 @@ let find_pending_id_in_map
              ~tool_name
              ~tool_call_id
          then
-           if pending_entry_matches entry ~base_path ~keeper_name ~tool_name
-                ~tool_call_id ~input_hash
+           if
+             pending_entry_matches entry ~base_path ~keeper_name ~tool_name
+               ~tool_call_id ~input_hash ~continuation_channel
            then Ok (Some id)
            else
              (match tool_call_id with
               | Some tool_call_id ->
                 Error
                   (Printf.sprintf
-                     "tool_call_id %s is already pending for a different canonical request (approval %s)"
+                     "tool_call_id %s is already pending for a different request (approval %s): the canonical input or the continuation channel differs"
                      tool_call_id
                      id)
               | None -> Ok None)
@@ -3116,6 +3159,7 @@ let submit_pending
              ~tool_name
              ~tool_call_id
              ~input_hash
+             ~continuation_channel
          with
          | Error reason ->
            Error { path = pending_store_path ~base_path; reason }

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -58,6 +58,7 @@ type exact_attempt_transition =
 type approved_resolution_request =
   { keeper_name : string
   ; tool_name : string
+  ; tool_call_id : string option
   ; input : Yojson.Safe.t
   }
 
@@ -335,6 +336,7 @@ let pending_entry_to_yojson
     [ "id", `String entry.id
     ; "keeper_name", `String entry.keeper_name
     ; "tool_name", `String entry.tool_name
+    ; "tool_call_id", Json_util.string_opt_to_json entry.tool_call_id
     ; "input_hash", `String entry.input_hash
     ; "input", entry.input
     ; "sequence", `Int entry.sequence
@@ -745,6 +747,7 @@ let pending_entry_of_yojson ~base_path json =
           [ "id"
           ; "keeper_name"
           ; "tool_name"
+          ; "tool_call_id"
           ; "input_hash"
           ; "input"
           ; "sequence"
@@ -765,6 +768,7 @@ let pending_entry_of_yojson ~base_path json =
     let* id = required_string ~surface "id" fields in
     let* keeper_name = required_string ~surface "keeper_name" fields in
     let* tool_name = required_string ~surface "tool_name" fields in
+    let* tool_call_id = optional_string ~surface "tool_call_id" fields in
     let* input_hash = required_string ~surface "input_hash" fields in
     let* input = required_member ~surface "input" fields in
     let expected_hash = request_fingerprint input in
@@ -832,18 +836,19 @@ let pending_entry_of_yojson ~base_path json =
       in
       Ok
         { id
-      ; keeper_name
-      ; tool_name
-      ; input_hash
-      ; input
-      ; sequence
-      ; requested_at
-      ; turn_id
-      ; request_context
-      ; task_id
-      ; goal_id
-      ; goal_ids
-      ; continuation_channel
+        ; keeper_name
+        ; tool_name
+        ; tool_call_id
+        ; input_hash
+        ; input
+        ; sequence
+        ; requested_at
+        ; turn_id
+        ; request_context
+        ; task_id
+        ; goal_id
+        ; goal_ids
+        ; continuation_channel
         ; audit_base_path = base_path
         ; summary_status
         ; exact_attempt
@@ -1762,6 +1767,7 @@ let approved_resolution_request ~base_path ~id =
         (Some
            { keeper_name = delivery.entry.keeper_name
            ; tool_name = delivery.entry.tool_name
+           ; tool_call_id = delivery.entry.tool_call_id
            ; input = delivery.entry.input
            }))
 ;;
@@ -1779,6 +1785,7 @@ let consume_approved_resolution
       ~id
       ~keeper_name
       ~tool_name
+      ~tool_call_id
       ~input
   =
   let result =
@@ -1793,6 +1800,7 @@ let consume_approved_resolution
           not
             (String.equal entry.keeper_name keeper_name
              && String.equal entry.tool_name tool_name
+             && entry.tool_call_id = tool_call_id
              && String.equal entry.input_hash (normalized_input_hash input))
         then Ok (Consumption_without_audit Consumption_not_matching)
         else
@@ -1848,6 +1856,7 @@ let create_entry
       ~sequence
       ~keeper_name
       ~tool_name
+      ?tool_call_id
       ~input
       ?turn_id
       ?request_context
@@ -1862,6 +1871,7 @@ let create_entry
   { id
   ; keeper_name
   ; tool_name
+  ; tool_call_id
   ; input_hash
   ; input
   ; sequence
@@ -1886,6 +1896,7 @@ let pending_entry_json_fields
   [ "id", `String entry.id
   ; "keeper_name", `String entry.keeper_name
   ; "tool_name", `String entry.tool_name
+  ; "tool_call_id", Json_util.string_opt_to_json entry.tool_call_id
   ; "input_hash", `String entry.input_hash
   ; "sequence", `Int entry.sequence
   ; "requested_at", `Float entry.requested_at
@@ -2985,24 +2996,32 @@ let pending_entry_matches
       ~base_path
       ~keeper_name
       ~tool_name
+      ~tool_call_id
       ~input_hash
-      ~turn_id
-      ~task_id
-      ~goal_id
-      ~goal_ids
-      ~continuation_channel
   =
   String.equal entry.audit_base_path base_path
   && String.equal entry.keeper_name keeper_name
   && String.equal entry.tool_name tool_name
+  && (match tool_call_id with
+      | None -> false
+      | Some tool_call_id -> entry.tool_call_id = Some tool_call_id)
   && String.equal entry.input_hash input_hash
-  && entry.turn_id = turn_id
-  && entry.task_id = task_id
-  && entry.goal_id = goal_id
-  && entry.goal_ids = goal_ids
-  && Yojson.Safe.equal
-       (Keeper_continuation_channel.to_yojson entry.continuation_channel)
-       (Keeper_continuation_channel.to_yojson continuation_channel)
+;;
+
+let pending_entry_owns_tool_call_id
+      (entry : pending_approval)
+      ~base_path
+      ~keeper_name
+      ~tool_name
+      ~tool_call_id
+  =
+  match tool_call_id with
+  | None -> false
+  | Some tool_call_id ->
+    String.equal entry.audit_base_path base_path
+    && String.equal entry.keeper_name keeper_name
+    && String.equal entry.tool_name tool_name
+    && entry.tool_call_id = Some tool_call_id
 ;;
 
 let find_pending_id_in_map
@@ -3010,34 +3029,35 @@ let find_pending_id_in_map
       ~base_path
       ~keeper_name
       ~tool_name
+      ~tool_call_id
       ~input_hash
-      ~turn_id
-      ~task_id
-      ~goal_id
-      ~goal_ids
-      ~continuation_channel
   =
   SMap.fold
     (fun id (entry : pending_approval) acc ->
        match acc with
-       | Some _ -> acc
-       | None ->
+       | Error _ as error -> error
+       | Ok (Some _) as found -> found
+       | Ok None ->
          if
-           pending_entry_matches
+           pending_entry_owns_tool_call_id
              entry
              ~base_path
              ~keeper_name
              ~tool_name
-             ~input_hash
-             ~turn_id
-             ~task_id
-             ~goal_id
-             ~goal_ids
-             ~continuation_channel
-         then Some id
-         else None)
+             ~tool_call_id
+         then
+           if pending_entry_matches entry ~base_path ~keeper_name ~tool_name
+                ~tool_call_id ~input_hash
+           then Ok (Some id)
+           else
+             Error
+               (Printf.sprintf
+                  "tool_call_id %s is already pending for a different canonical request (approval %s)"
+                  (Option.get tool_call_id)
+                  id)
+         else Ok None)
     map
-    None
+    (Ok None)
 ;;
 
 (* ── Nonblocking submission ───────────────────────────────── *)
@@ -3045,6 +3065,7 @@ let find_pending_id_in_map
 let submit_pending
       ~keeper_name
       ~tool_name
+      ?tool_call_id
       ~input
       ~base_path
       ?turn_id
@@ -3078,15 +3099,13 @@ let submit_pending
              ~base_path
              ~keeper_name
              ~tool_name
+             ~tool_call_id
              ~input_hash
-             ~turn_id
-             ~task_id
-             ~goal_id
-             ~goal_ids
-             ~continuation_channel
          with
-         | Some id -> Ok (id, None)
-         | None ->
+         | Error reason ->
+           Error { path = pending_store_path ~base_path; reason }
+         | Ok (Some id) -> Ok (id, None)
+         | Ok None ->
            let id = generate_id () in
            if sequence = max_int
            then
@@ -3102,6 +3121,7 @@ let submit_pending
                  ~keeper_name
                  ~tool_name
                  ~input
+                 ?tool_call_id
                  ?turn_id
               ?request_context
               ?task_id

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -71,6 +71,7 @@ type exact_attempt_transition =
 type approved_resolution_request =
   { keeper_name : string
   ; tool_name : string
+  ; tool_call_id : string option
   ; input : Yojson.Safe.t
   }
 
@@ -152,6 +153,7 @@ val consume_approved_resolution :
   id:string ->
   keeper_name:string ->
   tool_name:string ->
+  tool_call_id:string option ->
   input:Yojson.Safe.t ->
   (grant_consumption, grant_error) result
 
@@ -342,13 +344,16 @@ end
 
 (** {1 Nonblocking submission and explicit resolution} *)
 
-(** Durably enqueue an exact request without suspending the caller. Returns an
-    existing id only when the same Keeper, operation identity, canonical input,
-    turn/task/goal identity, and continuation channel are already pending. A
-    deduplicated request does not consume a durable queue sequence. *)
+(** Durably enqueue an exact request without suspending the caller. An existing
+    id is reused only when the caller supplies the same durable [tool_call_id],
+    Keeper, operation identity, and canonical input. Turn/task/goal/channel
+    fields are provenance and never deduplication keys. Requests without a
+    [tool_call_id] are never deduplicated. A deduplicated request does not
+    consume a durable queue sequence. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->
+  ?tool_call_id:string ->
   input:Yojson.Safe.t ->
   base_path:string ->
   ?turn_id:int ->

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -145,16 +145,23 @@ val approved_resolution_state :
   base_path:string -> id:string -> (approved_resolution_state, grant_error) result
 
 (** Atomically consume an approved resolution only when the Keeper, opaque
-    operation identity, durable [tool_call_id] (including its presence or
-    absence), and canonical complete input match its durable request. Turn,
-    Task, Goal, and channel fields remain provenance and never become
-    authorization constraints. *)
+    operation identity, and canonical complete input match its durable
+    request. Turn, Task, Goal, and channel fields remain provenance and never
+    become authorization constraints.
+
+    The consuming invocation's own [tool_call_id] is NOT compared. A grant is
+    spent either by replay — which injects the approval's stored id, so the
+    comparison would read a value back out of the record under test — or by the
+    model re-emitting the call, where the provider assigns a fresh tool_use_id
+    and the comparison could never succeed. Double-spend is prevented by the
+    one-shot [grant_consumed] flag; which approval a cycle may spend is fixed
+    by the Hitl_resolution event carrying its [approval_id]. [tool_call_id] is
+    the request-identity key on {!submit_pending}, where it is meaningful. *)
 val consume_approved_resolution :
   base_path:string ->
   id:string ->
   keeper_name:string ->
   tool_name:string ->
-  tool_call_id:string option ->
   input:Yojson.Safe.t ->
   (grant_consumption, grant_error) result
 

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -212,6 +212,7 @@ val audit_approval_event :
   id:string ->
   keeper_name:string ->
   tool_name:string ->
+  ?tool_call_id:string ->
   ?turn_id:int ->
   ?task_id:string ->
   ?goal_id:string ->

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -145,8 +145,9 @@ val approved_resolution_state :
   base_path:string -> id:string -> (approved_resolution_state, grant_error) result
 
 (** Atomically consume an approved resolution only when the Keeper, opaque
-    operation identity, and canonical complete input match its durable request.
-    Turn, Task, Goal, and channel fields remain provenance and never become
+    operation identity, durable [tool_call_id] (including its presence or
+    absence), and canonical complete input match its durable request. Turn,
+    Task, Goal, and channel fields remain provenance and never become
     authorization constraints. *)
 val consume_approved_resolution :
   base_path:string ->
@@ -344,12 +345,13 @@ end
 
 (** {1 Nonblocking submission and explicit resolution} *)
 
-(** Durably enqueue an exact request without suspending the caller. An existing
-    id is reused only when the caller supplies the same durable [tool_call_id],
-    Keeper, operation identity, and canonical input. Turn/task/goal/channel
-    fields are provenance and never deduplication keys. Requests without a
-    [tool_call_id] are never deduplicated. A deduplicated request does not
-    consume a durable queue sequence. *)
+(** Durably enqueue an exact request without suspending the caller. When
+    supplied, [tool_call_id] must be non-blank. An existing id is reused only
+    when the caller supplies the same durable [tool_call_id], Keeper, operation
+    identity, and canonical input. Turn/task/goal/channel fields are provenance
+    and never deduplication keys. Requests without a [tool_call_id] are never
+    deduplicated. A deduplicated request does not consume a durable queue
+    sequence. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -1,7 +1,7 @@
 type causal_context =
   { turn_id : int option
   ; tool_call_id : string option
-  ; snapshot : Yojson.Safe.t
+  ; snapshot : Yojson.Safe.t option
   }
 
 type request =
@@ -306,7 +306,7 @@ let submit request =
     ~base_path:request.base_path
     ?turn_id:(request_turn_id request)
     ?tool_call_id:(Option.bind request.causal_context (fun context -> context.tool_call_id))
-    ?request_context:(Option.map (fun context -> context.snapshot) request.causal_context)
+    ?request_context:(Option.bind request.causal_context (fun context -> context.snapshot))
     ?task_id:request.task_id
     ~goal_ids:request.goal_ids
     ?continuation_channel:request.continuation_channel

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -1,5 +1,6 @@
 type causal_context =
   { turn_id : int option
+  ; tool_call_id : string option
   ; snapshot : Yojson.Safe.t
   }
 
@@ -187,6 +188,7 @@ let rec take_matching_cycle_grant grant request =
         ~id:entry.approval_id
         ~keeper_name:request.keeper_name
         ~tool_name:request.operation
+        ~tool_call_id:(Option.bind request.causal_context (fun context -> context.tool_call_id))
         ~input:request.input
       with
       | Error error ->
@@ -303,6 +305,7 @@ let submit request =
     ~input:request.input
     ~base_path:request.base_path
     ?turn_id:(request_turn_id request)
+    ?tool_call_id:(Option.bind request.causal_context (fun context -> context.tool_call_id))
     ?request_context:(Option.map (fun context -> context.snapshot) request.causal_context)
     ?task_id:request.task_id
     ~goal_ids:request.goal_ids

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -288,6 +288,7 @@ let audit_allow request ?rule_match ?source_approval_id ?decision_source source 
          Keeper_approval_queue.generate_id ())
     ~keeper_name:request.keeper_name
     ~tool_name:request.operation
+    ?tool_call_id:(Option.bind request.causal_context (fun context -> context.tool_call_id))
     ?turn_id:(request_turn_id request)
     ?task_id:request.task_id
     ~goal_ids:request.goal_ids

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -188,7 +188,6 @@ let rec take_matching_cycle_grant grant request =
         ~id:entry.approval_id
         ~keeper_name:request.keeper_name
         ~tool_name:request.operation
-        ~tool_call_id:(Option.bind request.causal_context (fun context -> context.tool_call_id))
         ~input:request.input
       with
       | Error error ->

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -6,8 +6,8 @@
 
 type causal_context =
   { turn_id : int option
-  (** Provider/OAS tool-use identity. [None] is legacy or non-provider input;
-      it is never used to infer request deduplication. *)
+  (** Opaque execution-scoped tool-call identity. [None] is legacy or
+      non-provider input; it is never used to infer request deduplication. *)
   ; tool_call_id : string option
   ; snapshot : Yojson.Safe.t
   }

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -9,10 +9,11 @@ type causal_context =
   (** Opaque execution-scoped tool-call identity. [None] is legacy or
       non-provider input; it is never used to infer request deduplication. *)
   ; tool_call_id : string option
-  ; snapshot : Yojson.Safe.t
+  ; snapshot : Yojson.Safe.t option
   }
-(** Exact outer-turn evidence captured before the tool call. The Gate stores
-    and forwards [snapshot] without interpreting its fields. *)
+(** Exact outer-turn evidence captured before the tool call. [None] means the
+    identity is known but the causal evidence is partial. The Gate stores and
+    forwards a present [snapshot] without interpreting its fields. *)
 
 type request =
   { keeper_name : string

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -6,6 +6,9 @@
 
 type causal_context =
   { turn_id : int option
+  (** Provider/OAS tool-use identity. [None] is legacy or non-provider input;
+      it is never used to infer request deduplication. *)
+  ; tool_call_id : string option
   ; snapshot : Yojson.Safe.t
   }
 (** Exact outer-turn evidence captured before the tool call. The Gate stores

--- a/lib/keeper/keeper_gate_causal_context.ml
+++ b/lib/keeper/keeper_gate_causal_context.ml
@@ -46,6 +46,7 @@ let snapshot t : Keeper_gate.causal_context =
     |> List.rev_map completed_call_to_yojson
   in
   { turn_id = t.turn_id
+  ; tool_call_id = None
   ; snapshot =
       `Assoc
         [ "initial", t.initial

--- a/lib/keeper/keeper_gate_causal_context.ml
+++ b/lib/keeper/keeper_gate_causal_context.ml
@@ -48,9 +48,10 @@ let snapshot t : Keeper_gate.causal_context =
   { turn_id = t.turn_id
   ; tool_call_id = None
   ; snapshot =
-      `Assoc
-        [ "initial", t.initial
-        ; "completed_tool_calls", `List completed_calls
-        ]
+      Some
+        (`Assoc
+           [ "initial", t.initial
+           ; "completed_tool_calls", `List completed_calls
+           ])
   }
 ;;

--- a/lib/keeper/keeper_gate_causal_context.mli
+++ b/lib/keeper/keeper_gate_causal_context.mli
@@ -2,8 +2,8 @@
 
     The cell is created once by the outer Keeper turn and threaded through the
     OAS tool bundle. Each completed Tool appends its exact typed input/result.
-    [snapshot] returns immutable JSON for one later Gate request. No global,
-    string-keyed, or fiber-local carrier is used. *)
+    [snapshot] returns one complete immutable evidence snapshot for a later
+    Gate request. No global, string-keyed, or fiber-local carrier is used. *)
 
 type t
 

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -88,7 +88,7 @@ let replay_approved_effect
               | None ->
                 { Keeper_gate.turn_id = None
                 ; tool_call_id = None
-                ; snapshot = `Assoc []
+                ; snapshot = None
                 }
             in
             { base_context with tool_call_id = Some tool_call_id })

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -76,6 +76,23 @@ let replay_approved_effect
     Failed (Keeper_approval_queue.grant_error_to_string error)
   | Ok None -> Not_applicable
   | Ok (Some request) ->
+    let replay_gate_context =
+      match request.tool_call_id with
+      | None -> gate_context
+      | Some tool_call_id ->
+        Some
+          (fun () ->
+            let base_context =
+              match gate_context with
+              | Some current -> current ()
+              | None ->
+                { Keeper_gate.turn_id = None
+                ; tool_call_id = None
+                ; snapshot = `Assoc []
+                }
+            in
+            { base_context with tool_call_id = Some tool_call_id })
+    in
     let replay operation decode run =
       match decode request.input with
       | Error detail -> Failed detail
@@ -91,7 +108,7 @@ let replay_approved_effect
            ~meta
            ~publication_recovery
            ?continuation_channel
-           ?gate_context
+           ?gate_context:replay_gate_context
            ~gate_grant:grant
            ~args
            ())
@@ -102,7 +119,7 @@ let replay_approved_effect
            ~config
            ~meta
            ?continuation_channel
-           ?gate_context
+           ?gate_context:replay_gate_context
            ~gate_grant:grant
            ~args
            ()))

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -53,7 +53,7 @@ let keeper_turn_id_of_json json =
       | Some _ as value -> value
       | None -> json_int_opt_member "turn" json)
 
-let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
+let timeline_event_json ?trace_id ?keeper_turn_id ?tool_call_id ?task_id ?(goal_ids = [])
     ?next_human_action ?observed_at_unix ?(observation_only = false)
     ~ts_unix ~kind ~title ~summary ~severity () =
   let observed_at_unix = Option.value ~default:ts_unix observed_at_unix in
@@ -67,6 +67,7 @@ let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
       ("observation_only", `Bool observation_only);
       ("trace_id", Json_util.string_opt_to_json trace_id);
       ("keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id);
+      ("tool_call_id", Json_util.string_opt_to_json tool_call_id);
       ("task_id", Json_util.string_opt_to_json task_id);
       ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) goal_ids));
       ("title", `String title);
@@ -141,6 +142,7 @@ let live_pending_approval_timeline_event json =
       in
       Some
         (timeline_event_json
+           ?tool_call_id:(json_string_opt_member "tool_call_id" json)
            ?task_id
            ~ts_unix ~kind:"approval_pending_live"
            ~title:(Printf.sprintf "Operator Decision Pending · %s" tool_name)
@@ -226,6 +228,7 @@ let approval_event_timeline_event json =
       Some
         (timeline_event_json
            ?keeper_turn_id:(keeper_turn_id_of_json json)
+           ?tool_call_id:(json_string_opt_member "tool_call_id" json)
            ?task_id:(json_string_opt_member "task_id" json)
            ~goal_ids:(goal_ids_of_json json)
            ?next_human_action

--- a/lib/keeper/keeper_runtime_trust_timeline.mli
+++ b/lib/keeper/keeper_runtime_trust_timeline.mli
@@ -28,6 +28,7 @@ val keeper_turn_id_of_json : Yojson.Safe.t -> int option
 val timeline_event_json :
   ?trace_id:string ->
   ?keeper_turn_id:int ->
+  ?tool_call_id:string ->
   ?task_id:string ->
   ?goal_ids:string list ->
   ?next_human_action:string ->

--- a/lib/keeper/keeper_tool_call_identity.ml
+++ b/lib/keeper/keeper_tool_call_identity.ml
@@ -1,0 +1,25 @@
+type t = string
+
+let encode_string value = Printf.sprintf "%d:%s" (String.length value) value
+
+let create ~trace_id ?keeper_turn_id invocation =
+  let schedule = Agent_sdk.Tool_contract.Invocation.schedule invocation in
+  let keeper_turn =
+    match keeper_turn_id with
+    | Some value -> string_of_int value
+    | None -> "-"
+  in
+  String.concat
+    "|"
+    [ "keeper-tool-call/v1"
+    ; encode_string trace_id
+    ; keeper_turn
+    ; string_of_int (Agent_sdk.Tool_contract.Invocation.turn invocation)
+    ; string_of_int schedule.planned_index
+    ; string_of_int schedule.batch_index
+    ; string_of_int schedule.batch_size
+    ; encode_string (Agent_sdk.Tool_contract.Invocation.tool_use_id invocation)
+    ]
+;;
+
+let to_string value = value

--- a/lib/keeper/keeper_tool_call_identity.mli
+++ b/lib/keeper/keeper_tool_call_identity.mli
@@ -1,0 +1,17 @@
+(** Opaque durable identity for one OAS tool execution occurrence.
+
+    Provider [tool_use_id] values are only unique within an OAS assistant tool
+    batch. This value scopes one such ID with MASC's durable trace and, when
+    available, the Keeper turn, plus OAS's own occurrence coordinates. It is
+    serialized as one string because the approval journal already persists an
+    opaque [tool_call_id]; consumers must not parse or reconstruct it. *)
+
+type t
+
+val create :
+  trace_id:string ->
+  ?keeper_turn_id:int ->
+  Agent_sdk.Tool_contract.Invocation.t ->
+  t
+
+val to_string : t -> string

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -14,6 +14,38 @@ let producer_payload ~raw = function
   | None -> `String raw
 ;;
 
+(* The provider's tool-use identity is available at the OAS boundary, before
+   the producer runtime evaluates the Gate. Carry it through the existing
+   causal-context channel so every Gate-backed tool receives the same durable
+   identity without teaching individual tool handlers about OAS. *)
+let gate_context_for_invocation ~gate_context ~oas_invocation =
+  match oas_invocation with
+  | None -> gate_context
+  | Some invocation ->
+    let raw_tool_call_id =
+      Agent_sdk.Tool_contract.Invocation.tool_use_id invocation
+    in
+    let tool_call_id =
+      if String.trim raw_tool_call_id = "" then None else Some raw_tool_call_id
+    in
+    (match tool_call_id, gate_context with
+     | None, None -> None
+     | _ ->
+       Some
+         (fun () ->
+           let base_context =
+             match gate_context with
+             | Some current -> current ()
+             | None ->
+               { Keeper_gate.turn_id =
+                   Some (Agent_sdk.Tool_contract.Invocation.turn invocation)
+               ; tool_call_id = None
+               ; snapshot = `Assoc []
+               }
+           in
+           { base_context with tool_call_id }))
+;;
+
 let execute_with_observers
       ~(name : string)
       ~(config : Workspace.config)
@@ -38,6 +70,9 @@ let execute_with_observers
   =
   let t0 = Time_compat.now () in
   let invocation_fields = oas_invocation_fields oas_invocation in
+  let dispatch_gate_context =
+    gate_context_for_invocation ~gate_context ~oas_invocation
+  in
   try
     let result, duration_ms =
       Inference_utils.timed (fun () ->
@@ -54,7 +89,7 @@ let execute_with_observers
           ?net
           ?mcp_session_id
           ?continuation_channel
-          ?gate_context
+          ?gate_context:dispatch_gate_context
           ?gate_grant
           ~name
           ~input

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -14,36 +14,43 @@ let producer_payload ~raw = function
   | None -> `String raw
 ;;
 
-(* The provider's tool-use identity is available at the OAS boundary, before
-   the producer runtime evaluates the Gate. Carry it through the existing
-   causal-context channel so every Gate-backed tool receives the same durable
-   identity without teaching individual tool handlers about OAS. *)
-let gate_context_for_invocation ~gate_context ~oas_invocation =
+(* OAS documents [tool_use_id] as batch-scoped, not history-global. Scope it
+   with MASC's durable execution coordinates at the one OAS boundary rather
+   than teaching each Gate-backed producer about provider semantics. *)
+let gate_context_for_invocation
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~gate_context
+      ~oas_invocation
+  =
   match oas_invocation with
   | None -> gate_context
   | Some invocation ->
     let raw_tool_call_id =
       Agent_sdk.Tool_contract.Invocation.tool_use_id invocation
     in
-    let tool_call_id =
-      if String.trim raw_tool_call_id = "" then None else Some raw_tool_call_id
-    in
-    (match tool_call_id, gate_context with
-     | None, None -> None
-     | _ ->
-       Some
-         (fun () ->
-           let base_context =
-             match gate_context with
-             | Some current -> current ()
-             | None ->
-               { Keeper_gate.turn_id =
-                   Some (Agent_sdk.Tool_contract.Invocation.turn invocation)
-               ; tool_call_id = None
-               ; snapshot = `Assoc []
-               }
-           in
-           { base_context with tool_call_id }))
+    Some
+      (fun () ->
+         let base_context =
+           match gate_context with
+           | Some current -> current ()
+           | None ->
+             { Keeper_gate.turn_id = None
+             ; tool_call_id = None
+             ; snapshot = `Assoc []
+             }
+         in
+         let tool_call_id =
+           if String.trim raw_tool_call_id = ""
+           then None
+           else
+             Some
+               (Keeper_tool_call_identity.create
+                  ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                  ?keeper_turn_id:base_context.turn_id
+                  invocation
+                |> Keeper_tool_call_identity.to_string)
+         in
+         { base_context with tool_call_id })
 ;;
 
 let execute_with_observers
@@ -71,7 +78,7 @@ let execute_with_observers
   let t0 = Time_compat.now () in
   let invocation_fields = oas_invocation_fields oas_invocation in
   let dispatch_gate_context =
-    gate_context_for_invocation ~gate_context ~oas_invocation
+    gate_context_for_invocation ~meta ~gate_context ~oas_invocation
   in
   try
     let result, duration_ms =

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -36,7 +36,7 @@ let gate_context_for_invocation
            | None ->
              { Keeper_gate.turn_id = None
              ; tool_call_id = None
-             ; snapshot = `Assoc []
+             ; snapshot = None
              }
          in
          let tool_call_id =

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -25,9 +25,6 @@ let gate_context_for_invocation
   match oas_invocation with
   | None -> gate_context
   | Some invocation ->
-    let raw_tool_call_id =
-      Agent_sdk.Tool_contract.Invocation.tool_use_id invocation
-    in
     Some
       (fun () ->
          let base_context =
@@ -40,15 +37,12 @@ let gate_context_for_invocation
              }
          in
          let tool_call_id =
-           if String.trim raw_tool_call_id = ""
-           then None
-           else
-             Some
-               (Keeper_tool_call_identity.create
-                  ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                  ?keeper_turn_id:base_context.turn_id
-                  invocation
-                |> Keeper_tool_call_identity.to_string)
+           Some
+             (Keeper_tool_call_identity.create
+                ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                ?keeper_turn_id:base_context.turn_id
+                invocation
+              |> Keeper_tool_call_identity.to_string)
          in
          { base_context with tool_call_id })
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -101,6 +101,7 @@ type pending_approval =
   { id : string
   ; keeper_name : string
   ; tool_name : string
+  ; tool_call_id : string option
   ; input_hash : string
   ; input : Yojson.Safe.t
   ; sequence : int

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -99,6 +99,7 @@ type pending_approval =
   { id : string
   ; keeper_name : string
   ; tool_name : string
+  ; tool_call_id : string option
   ; input_hash : string
   ; input : Yojson.Safe.t
   ; sequence : int

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -188,6 +188,22 @@ let test_tool_call_identity_controls_pending_deduplication () =
          Keeper_continuation_channel.dashboard ~thread_id:"thread-b"
          |> Result.get_ok
        in
+       (match
+          AQ.submit_pending
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~tool_call_id:" \t "
+            ~input
+            ~base_path
+            ()
+        with
+        | Error error ->
+          Alcotest.(check string)
+            "blank tool call identity is rejected at ingress"
+            "tool_call_id must be non-blank when supplied"
+            error.reason
+        | Ok id ->
+          Alcotest.failf "blank tool call identity created approval %s" id);
        let first =
          submit_with_context
            ~tool_call_id:"tool-call-1"
@@ -984,7 +1000,15 @@ let test_resolution_is_durable_and_origin_scoped () =
     (fun () ->
        ignore (install_exn ~base_path);
        let input = `Assoc [ "target", `String "document"; "body", `String "hello" ] in
-       let id = submit ~base_path ~keeper_name ~input in
+       let tool_call_id = "tool-call-resolution" in
+       let id =
+         submit_with_context
+           ~tool_call_id
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
        let result =
          AQ.resolve_with_policy
            ~base_path
@@ -1016,6 +1040,10 @@ let test_resolution_is_durable_and_origin_scoped () =
         | Ok (Some request) ->
           Alcotest.(check string) "journal keeper" keeper_name request.keeper_name;
           Alcotest.(check string) "journal operation" "external-effect" request.tool_name;
+          Alcotest.(check (option string))
+            "journal tool call identity"
+            (Some tool_call_id)
+            request.tool_call_id;
           Alcotest.(check bool) "journal complete input" true
             (Yojson.Safe.equal input request.input)
         | Ok None -> Alcotest.fail "approved journal was consumed before Gate use"
@@ -1044,7 +1072,7 @@ let test_resolution_is_durable_and_origin_scoped () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
-            ~tool_call_id:None
+            ~tool_call_id:(Some tool_call_id)
             ~input:(`Assoc [ "target", `String "other" ])
         with
         | Ok AQ.Consumption_not_matching -> ()
@@ -1058,6 +1086,19 @@ let test_resolution_is_durable_and_origin_scoped () =
             ~keeper_name
             ~tool_name:"external-effect"
             ~tool_call_id:None
+            ~input
+        with
+        | Ok AQ.Consumption_not_matching -> ()
+        | Ok (AQ.Consumption_committed | AQ.Consumption_already_committed) ->
+          Alcotest.fail "missing tool call identity consumed the exact grant"
+        | Error error -> Alcotest.fail (AQ.grant_error_to_string error));
+       (match
+          AQ.consume_approved_resolution
+            ~base_path
+            ~id
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~tool_call_id:(Some tool_call_id)
             ~input
         with
         | Ok AQ.Consumption_committed -> ()

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1291,7 +1291,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
              Some
                { Gate.turn_id = Some 99
                ; tool_call_id = None
-               ; snapshot = `Assoc []
+               ; snapshot = Some (`Assoc [])
                }
          ; task_id
          ; goal_ids
@@ -3241,7 +3241,7 @@ let test_default_auto_judge_defers_without_blocking () =
              Some
                { Gate.turn_id = Some 9
                ; tool_call_id = None
-               ; snapshot = `Assoc []
+               ; snapshot = Some (`Assoc [])
                }
          ; task_id = Some "task-auto-judge"
          ; goal_ids = [ "goal-auto-judge" ]

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -97,6 +97,7 @@ let drop_resolution ~base_path ~keeper_name resolution =
 
 
 let submit_with_context
+      ?tool_call_id
       ?turn_id
       ?request_context
       ?task_id
@@ -112,6 +113,7 @@ let submit_with_context
     AQ.submit_pending
       ~keeper_name
       ~tool_name:"external-effect"
+      ?tool_call_id
       ~input
       ~base_path
       ?turn_id
@@ -170,7 +172,7 @@ let test_pending_store_lock_serializes_eio_fibers () =
     (List.rev !order)
 ;;
 
-let test_dedup_never_merges_distinct_origins () =
+let test_tool_call_identity_controls_pending_deduplication () =
   let base_path = temp_dir () in
   let keeper_name = "queue-distinct-origin" in
   Fun.protect
@@ -188,6 +190,7 @@ let test_dedup_never_merges_distinct_origins () =
        in
        let first =
          submit_with_context
+           ~tool_call_id:"tool-call-1"
            ~turn_id:1
            ~goal_ids:[ "goal-a" ]
            ~continuation_channel:dashboard_a
@@ -198,6 +201,7 @@ let test_dedup_never_merges_distinct_origins () =
        in
        let same =
          submit_with_context
+           ~tool_call_id:"tool-call-1"
            ~turn_id:1
            ~goal_ids:[ "goal-a" ]
            ~continuation_channel:dashboard_a
@@ -207,8 +211,27 @@ let test_dedup_never_merges_distinct_origins () =
            ()
        in
        Alcotest.(check string) "same origin deduplicates" first same;
+       (match
+          AQ.submit_pending
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~tool_call_id:"tool-call-1"
+            ~input:(`Assoc [ "target", `String "different-action" ])
+            ~base_path
+            ()
+        with
+        | Error error ->
+          Alcotest.(check bool)
+            "tool call identity collision fails closed"
+            true
+            (String.starts_with ~prefix:"tool_call_id" error.reason)
+        | Ok id ->
+          Alcotest.failf
+            "tool call identity collision created approval %s"
+            id);
        let another_turn =
          submit_with_context
+           ~tool_call_id:"tool-call-2"
            ~turn_id:2
            ~goal_ids:[ "goal-a" ]
            ~continuation_channel:dashboard_a
@@ -219,6 +242,7 @@ let test_dedup_never_merges_distinct_origins () =
        in
        let another_channel =
          submit_with_context
+           ~tool_call_id:"tool-call-3"
            ~turn_id:1
            ~goal_ids:[ "goal-a" ]
            ~continuation_channel:dashboard_b
@@ -229,6 +253,7 @@ let test_dedup_never_merges_distinct_origins () =
        in
        let another_goal_context =
          submit_with_context
+           ~tool_call_id:"tool-call-4"
            ~turn_id:1
            ~goal_ids:[ "goal-b" ]
            ~continuation_channel:dashboard_a
@@ -237,13 +262,43 @@ let test_dedup_never_merges_distinct_origins () =
            ~input
            ()
        in
+       let without_identity_first =
+         submit_with_context
+           ~turn_id:1
+           ~goal_ids:[ "goal-a" ]
+           ~continuation_channel:dashboard_a
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       let without_identity_second =
+         submit_with_context
+           ~turn_id:1
+           ~goal_ids:[ "goal-a" ]
+           ~continuation_channel:dashboard_a
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       Alcotest.(check bool)
+         "missing tool call identity never deduplicates by input"
+         true
+         (not (String.equal without_identity_first without_identity_second));
        List.iter
          (fun id ->
             Alcotest.(check bool) "distinct origin has its own request" true
               (not (String.equal first id)))
          [ another_turn; another_channel; another_goal_context ];
        List.iter (reject_and_cleanup ~base_path)
-         [ first; another_turn; another_channel; another_goal_context ])
+         [ first
+         ; another_turn
+         ; another_channel
+         ; another_goal_context
+         ; without_identity_first
+         ; without_identity_second
+         ])
 ;;
 
 let check_update label expected = function
@@ -547,6 +602,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
        in
        let first =
          submit_with_context
+           ~tool_call_id:"tool-call-exact"
            ~turn_id:12
            ~request_context
            ~base_path
@@ -562,6 +618,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
        in
        let same =
          submit_with_context
+           ~tool_call_id:"tool-call-exact"
            ~turn_id:12
            ~request_context
            ~base_path
@@ -577,6 +634,10 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
          |> to_list
          |> List.find (fun entry -> String.equal (entry |> member "id" |> to_string) first)
        in
+       Alcotest.(check string)
+         "tool call identity is durable"
+         "tool-call-exact"
+         (persisted_entry |> member "tool_call_id" |> to_string);
        Alcotest.(check int)
          "exact context wire version"
          1
@@ -983,6 +1044,7 @@ let test_resolution_is_durable_and_origin_scoped () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
+            ~tool_call_id:None
             ~input:(`Assoc [ "target", `String "other" ])
         with
         | Ok AQ.Consumption_not_matching -> ()
@@ -995,6 +1057,7 @@ let test_resolution_is_durable_and_origin_scoped () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
+            ~tool_call_id:None
             ~input
         with
         | Ok AQ.Consumption_committed -> ()
@@ -1125,7 +1188,11 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
          ; input
          ; base_path
          ; causal_context =
-             Some { Gate.turn_id = Some 99; snapshot = `Assoc [] }
+             Some
+               { Gate.turn_id = Some 99
+               ; tool_call_id = None
+               ; snapshot = `Assoc []
+               }
          ; task_id
          ; goal_ids
          ; continuation_channel = None
@@ -2808,6 +2875,7 @@ let test_persisted_delivery_replays_before_origin_wake () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
+            ~tool_call_id:None
             ~input:(`Assoc [ "target", `String "replay" ])
         with
         | Ok AQ.Consumption_committed -> ()
@@ -2932,6 +3000,7 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
+            ~tool_call_id:None
             ~input
         with
         | Ok AQ.Consumption_committed -> ()
@@ -3070,7 +3139,11 @@ let test_default_auto_judge_defers_without_blocking () =
          ; input = `Assoc [ "target", `String "auto-judge" ]
          ; base_path
          ; causal_context =
-             Some { Gate.turn_id = Some 9; snapshot = `Assoc [] }
+             Some
+               { Gate.turn_id = Some 9
+               ; tool_call_id = None
+               ; snapshot = `Assoc []
+               }
          ; task_id = Some "task-auto-judge"
          ; goal_ids = [ "goal-auto-judge" ]
          ; continuation_channel = None
@@ -3314,9 +3387,9 @@ let () =
             `Quick
             test_different_owners_claim_in_parallel
         ; Alcotest.test_case
-            "dedup keeps distinct origins"
+            "tool call identity controls dedup"
             `Quick
-            test_dedup_never_merges_distinct_origins
+            test_tool_call_identity_controls_pending_deduplication
         ; Alcotest.test_case
             "resolution wakes only origin"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -227,6 +227,48 @@ let test_tool_call_identity_controls_pending_deduplication () =
            ()
        in
        Alcotest.(check string) "same origin deduplicates" first same;
+       (* Turn and Goal are context that drifts across a retried invocation;
+          keying on tool_call_id exists precisely to ignore that drift, so the
+          same id and input must still resolve to the one approval. *)
+       let drifted_provenance =
+         submit_with_context
+           ~tool_call_id:"tool-call-1"
+           ~turn_id:9
+           ~goal_ids:[ "goal-z" ]
+           ~continuation_channel:dashboard_a
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       Alcotest.(check string)
+         "turn and goal drift never split one invocation"
+         first
+         drifted_provenance;
+       (* The continuation channel is not context: it is where the approved
+          effect's result is delivered. A provider that reuses a short
+          per-response id must not merge two requests whose delivery routes
+          differ, so this fails closed rather than binding the second request
+          to the first one's channel. *)
+       (match
+          AQ.submit_pending
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~tool_call_id:"tool-call-1"
+            ~input
+            ~base_path
+            ~continuation_channel:dashboard_b
+            ()
+        with
+        | Error _ -> ()
+        | Ok id when String.equal id first ->
+          Alcotest.fail
+            "reused tool call identity merged across continuation channels"
+        | Ok id ->
+          Alcotest.failf
+            "reused tool call identity created a second approval %s on another \
+             continuation channel"
+            id);
        (match
           AQ.submit_pending
             ~keeper_name
@@ -1066,31 +1108,32 @@ let test_resolution_is_durable_and_origin_scoped () =
           | Ok (AQ.Rule_match_active _) -> true
           | Ok (AQ.Rule_match_expired _ | AQ.Rule_match_absent) -> false
           | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error));
+       (* Changed canonical input must not spend the grant: the input
+          fingerprint is the integrity check on what the operator approved. *)
        (match
           AQ.consume_approved_resolution
             ~base_path
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
-            ~tool_call_id:(Some tool_call_id)
             ~input:(`Assoc [ "target", `String "other" ])
         with
         | Ok AQ.Consumption_not_matching -> ()
         | Ok (AQ.Consumption_committed | AQ.Consumption_already_committed) ->
           Alcotest.fail "changed input consumed the exact grant"
         | Error error -> Alcotest.fail (AQ.grant_error_to_string error));
+       (* A different Keeper must not spend it either. *)
        (match
           AQ.consume_approved_resolution
             ~base_path
             ~id
-            ~keeper_name
+            ~keeper_name:unrelated_keeper
             ~tool_name:"external-effect"
-            ~tool_call_id:None
             ~input
         with
         | Ok AQ.Consumption_not_matching -> ()
         | Ok (AQ.Consumption_committed | AQ.Consumption_already_committed) ->
-          Alcotest.fail "missing tool call identity consumed the exact grant"
+          Alcotest.fail "unrelated Keeper consumed the exact grant"
         | Error error -> Alcotest.fail (AQ.grant_error_to_string error));
        (match
           AQ.consume_approved_resolution
@@ -1098,7 +1141,6 @@ let test_resolution_is_durable_and_origin_scoped () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
-            ~tool_call_id:(Some tool_call_id)
             ~input
         with
         | Ok AQ.Consumption_committed -> ()
@@ -2916,7 +2958,6 @@ let test_persisted_delivery_replays_before_origin_wake () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
-            ~tool_call_id:None
             ~input:(`Assoc [ "target", `String "replay" ])
         with
         | Ok AQ.Consumption_committed -> ()
@@ -3041,7 +3082,6 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
             ~id
             ~keeper_name
             ~tool_name:"external-effect"
-            ~tool_call_id:None
             ~input
         with
         | Ok AQ.Consumption_committed -> ()

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,4 +1,5 @@
 module AQ = Masc.Keeper_approval_queue
+module Tool_call_identity = Masc.Keeper_tool_call_identity
 
 let reserve_retry_exact ~base_path (entry : AQ.pending_approval) =
   AQ.reserve_summary_attempt_retry
@@ -245,30 +246,6 @@ let test_tool_call_identity_controls_pending_deduplication () =
          "turn and goal drift never split one invocation"
          first
          drifted_provenance;
-       (* The continuation channel is not context: it is where the approved
-          effect's result is delivered. A provider that reuses a short
-          per-response id must not merge two requests whose delivery routes
-          differ, so this fails closed rather than binding the second request
-          to the first one's channel. *)
-       (match
-          AQ.submit_pending
-            ~keeper_name
-            ~tool_name:"external-effect"
-            ~tool_call_id:"tool-call-1"
-            ~input
-            ~base_path
-            ~continuation_channel:dashboard_b
-            ()
-        with
-        | Error _ -> ()
-        | Ok id when String.equal id first ->
-          Alcotest.fail
-            "reused tool call identity merged across continuation channels"
-        | Ok id ->
-          Alcotest.failf
-            "reused tool call identity created a second approval %s on another \
-             continuation channel"
-            id);
        (match
           AQ.submit_pending
             ~keeper_name
@@ -357,6 +334,46 @@ let test_tool_call_identity_controls_pending_deduplication () =
          ; without_identity_first
          ; without_identity_second
          ])
+;;
+
+let oas_invocation ~tool_use_id ~turn ~planned_index =
+  Agent_sdk.Tool_contract.Invocation.create
+    ~tool_use_id
+    ~turn
+    ~completion:Agent_sdk.Tool_contract.Continue_after_success
+    ~schedule:
+      { planned_index
+      ; batch_index = planned_index
+      ; batch_size = 2
+      ; execution_mode = Agent_sdk.Tool_contract.Concurrent
+      }
+;;
+
+let test_oas_tool_identity_is_execution_scoped () =
+  let same_provider_id = "toolu-reused" in
+  let identity ~keeper_turn_id ~turn =
+    Tool_call_identity.create
+      ~trace_id:"trace-a"
+      ~keeper_turn_id
+      (oas_invocation ~tool_use_id:same_provider_id ~turn ~planned_index:0)
+    |> Tool_call_identity.to_string
+  in
+  let first = identity ~keeper_turn_id:7 ~turn:3 in
+  let retried = identity ~keeper_turn_id:7 ~turn:3 in
+  let later_oas_turn = identity ~keeper_turn_id:7 ~turn:4 in
+  let later_keeper_turn = identity ~keeper_turn_id:8 ~turn:3 in
+  Alcotest.(check string) "the same OAS occurrence is stable" first retried;
+  List.iter
+    (fun scoped_identity ->
+       Alcotest.(check bool)
+         "a raw provider id is never persisted as the durable identity"
+         true
+         (not (String.equal scoped_identity same_provider_id));
+       Alcotest.(check bool)
+         "later execution occurrence receives a distinct durable identity"
+         true
+         (not (String.equal first scoped_identity)))
+    [ later_oas_turn; later_keeper_turn ]
 ;;
 
 let check_update label expected = function
@@ -1385,7 +1402,8 @@ let test_exact_binding_codec_validates_entry_identity () =
          (run_exact_transition AQ.bind_summary_exact_attempt identity);
        let snapshot = read_pending_snapshot ~base_path in
        let open Yojson.Safe.Util in
-       Alcotest.(check int) "v8 snapshot" 8 (snapshot |> member "version" |> to_int);
+       Alcotest.(check int) "current snapshot version" 9
+         (snapshot |> member "version" |> to_int);
        let exact_json =
          snapshot
          |> member "pending"
@@ -2862,7 +2880,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
         | Error
             (AQ.Install_storage_failed
               { reason =
-                  "gate_pending.version 7 is unsupported (current 8); reset \
+                  "gate_pending.version 7 is unsupported (readable 8,9, current 9); reset \
                    runtime state before restarting MASC"
               ; _
               }) ->
@@ -3471,6 +3489,10 @@ let () =
             "tool call identity controls dedup"
             `Quick
             test_tool_call_identity_controls_pending_deduplication
+        ; Alcotest.test_case
+            "OAS tool identity is execution scoped"
+            `Quick
+            test_oas_tool_identity_is_execution_scoped
         ; Alcotest.test_case
             "resolution wakes only origin"
             `Quick

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -62,7 +62,8 @@ let append_row ~base_path ~ts (row : Yojson.Safe.t) =
 (* A resolved decision as the audit writer records it. [?ts_field:false] drops
    the timestamp to exercise the undated-row boundary. *)
 let seed_resolved ~base_path ~ts ~id ?(keeper = "rondo") ?(tool = "tool_execute")
-      ?(decision = "approve") ?(source = "auto_judge") ?(ts_field = true) ()
+      ?(decision = "approve") ?(source = "auto_judge") ?tool_call_id
+      ?(ts_field = true) ()
   =
   let fields =
     [ "event", `String "resolved"
@@ -72,6 +73,11 @@ let seed_resolved ~base_path ~ts ~id ?(keeper = "rondo") ?(tool = "tool_execute"
     ; "decision", `String decision
     ; "decision_source", `String source
     ]
+  in
+  let fields =
+    match tool_call_id with
+    | Some tool_call_id -> ("tool_call_id", `String tool_call_id) :: fields
+    | None -> fields
   in
   let fields = if ts_field then ("ts", `Float ts) :: fields else fields in
   append_row ~base_path ~ts (`Assoc fields)
@@ -274,6 +280,43 @@ let test_judge_evidence_passes_through base_path =
   check yojson "legacy exact_attempt is null" `Null (member "exact_attempt" (find "legacy"))
 ;;
 
+let test_resolved_identity_projects_to_history_and_timeline base_path =
+  let tool_call_id = "keeper-tool-call/v1|scope" in
+  seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"scoped" ~tool_call_id ();
+  let history = AQ.list_recent_resolved ~base_path ~now_ts:now () in
+  let resolved_row =
+    match history.resolved_rows with
+    | [ `Assoc fields ] -> fields
+    | rows -> failf "expected one resolved history row, got %d" (List.length rows)
+  in
+  let string_field fields name =
+    match List.assoc_opt name fields with
+    | Some (`String value) -> Some value
+    | Some _ | None -> None
+  in
+  check (option string)
+    "resolved history keeps the execution-scoped tool identity"
+    (Some tool_call_id)
+    (string_field resolved_row "tool_call_id");
+  let timeline =
+    Masc.Keeper_runtime_trust_timeline.approval_event_timeline_event
+      (`Assoc
+         [ "ts", `Float now
+         ; "event", `String "resolved"
+         ; "tool", `String "tool_execute"
+         ; "tool_call_id", `String tool_call_id
+         ])
+  in
+  match timeline with
+  | Some (`Assoc fields) ->
+    check (option string)
+      "trust timeline keeps the execution-scoped tool identity"
+      (Some tool_call_id)
+      (string_field fields "tool_call_id")
+  | Some _ -> fail "trust timeline event is not an object"
+  | None -> fail "approval event did not project to the trust timeline"
+;;
+
 let test_bounds_are_clamped base_path =
   let over = AQ.list_recent_resolved ~base_path ~now_ts:now ~limit:100_000 ~window_minutes:999_999 () in
   check int "limit clamped to the max" AQ.recent_resolved_max_limit over.resolved_limit;
@@ -311,6 +354,8 @@ let () =
             (with_store test_undated_decision_is_excluded)
         ; test_case "empty store is an empty page" `Quick
             (with_store test_empty_store_is_an_empty_page)
+        ; test_case "resolved identity projects to history and timeline" `Quick
+            (with_store test_resolved_identity_projects_to_history_and_timeline)
         ] )
     ; ( "judge evidence"
       , [ test_case "judge evidence passes through, legacy rows project null" `Quick

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -638,6 +638,7 @@ let test_symlink_component_swap_cannot_escape_allowed_root
       Unix.rename component moved_component;
       Unix.symlink case_outside component;
       { Masc.Keeper_gate.turn_id = None
+      ; tool_call_id = None
       ; snapshot = `Assoc [ "race", `String "symlink_component_swap" ]
       }
     in
@@ -720,6 +721,7 @@ let test_sandbox_root_swap_after_open_keeps_pinned_capability
     Unix.rename playground moved_playground;
     Unix.symlink outside playground;
     { Masc.Keeper_gate.turn_id = None
+    ; tool_call_id = None
     ; snapshot = `Assoc [ "race", `String "sandbox_root_swap" ]
     }
   in
@@ -777,6 +779,7 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
       Unix.rename target moved_target;
       Unix.symlink outside_target target;
       { Masc.Keeper_gate.turn_id = None
+      ; tool_call_id = None
       ; snapshot = `Assoc [ "race", `String "leaf_swap" ]
       }
     in
@@ -846,6 +849,7 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
   let gate_context () =
     Unix.symlink outside_target target;
     { Masc.Keeper_gate.turn_id = None
+    ; tool_call_id = None
     ; snapshot = `Assoc [ "race", `String "missing_leaf_appeared" ]
     }
   in

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -639,7 +639,7 @@ let test_symlink_component_swap_cannot_escape_allowed_root
       Unix.symlink case_outside component;
       { Masc.Keeper_gate.turn_id = None
       ; tool_call_id = None
-      ; snapshot = `Assoc [ "race", `String "symlink_component_swap" ]
+      ; snapshot = Some (`Assoc [ "race", `String "symlink_component_swap" ])
       }
     in
     let raw =
@@ -722,7 +722,7 @@ let test_sandbox_root_swap_after_open_keeps_pinned_capability
     Unix.symlink outside playground;
     { Masc.Keeper_gate.turn_id = None
     ; tool_call_id = None
-    ; snapshot = `Assoc [ "race", `String "sandbox_root_swap" ]
+    ; snapshot = Some (`Assoc [ "race", `String "sandbox_root_swap" ])
     }
   in
   let raw =
@@ -780,7 +780,7 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
       Unix.symlink outside_target target;
       { Masc.Keeper_gate.turn_id = None
       ; tool_call_id = None
-      ; snapshot = `Assoc [ "race", `String "leaf_swap" ]
+      ; snapshot = Some (`Assoc [ "race", `String "leaf_swap" ])
       }
     in
     let raw =
@@ -850,7 +850,7 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
     Unix.symlink outside_target target;
     { Masc.Keeper_gate.turn_id = None
     ; tool_call_id = None
-    ; snapshot = `Assoc [ "race", `String "missing_leaf_appeared" ]
+    ; snapshot = Some (`Assoc [ "race", `String "missing_leaf_appeared" ])
     }
   in
   let raw =

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -159,9 +159,12 @@ let test_second_tool_snapshot_contains_first_tool_result () =
   let second_call_context = Keeper_gate_causal_context.snapshot context in
   check (option int) "same turn" (Some 17) second_call_context.turn_id;
   let calls =
-    second_call_context.snapshot
-    |> Yojson.Safe.Util.member "completed_tool_calls"
-    |> Yojson.Safe.Util.to_list
+    match second_call_context.snapshot with
+    | Some snapshot ->
+      snapshot
+      |> Yojson.Safe.Util.member "completed_tool_calls"
+      |> Yojson.Safe.Util.to_list
+    | None -> fail "turn-local causal evidence was unexpectedly partial"
   in
   match calls with
   | [ call ] ->

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -970,12 +970,49 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
             ~base_path:config.base_path
         with
         | Ok [ entry ] ->
-          check (option string)
-            "OAS tool_use_id is persisted on the approval"
-            (Some "toolu-gate-identity")
-            entry.Masc.Keeper_approval_queue.tool_call_id
+          (match entry.Masc.Keeper_approval_queue.tool_call_id with
+           | Some identity ->
+             check bool
+               "the raw OAS tool_use_id is not used as a durable identity"
+               true
+               (not (String.equal identity "toolu-gate-identity"))
+           | None -> fail "OAS execution occurrence identity was not persisted")
         | Ok entries ->
           failf "expected one pending approval, got %d" (List.length entries)
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.storage_error_to_string error));
+       let later_invocation =
+         Agent_sdk.Tool_contract.Invocation.create
+           ~tool_use_id:"toolu-gate-identity"
+           ~turn:18
+           ~completion:Agent_sdk.Tool_contract.Continue_after_success
+           ~schedule:
+             { planned_index = 0
+             ; batch_index = 0
+             ; batch_size = 1
+             ; execution_mode = Agent_sdk.Tool_contract.Serial
+             }
+       in
+       (match handler ~oas_invocation:later_invocation input with
+        | Tool_result.Deferred _ -> ()
+        | Tool_result.Completed _ | Tool_result.Failed _ ->
+          fail "later OAS occurrence did not remain Gate-deferred");
+       (match
+          Masc.Keeper_approval_queue.list_pending_entries_for_workspace
+            ~base_path:config.base_path
+        with
+        | Ok entries ->
+          let identities =
+            entries
+            |> List.filter_map
+                 (fun (entry : Masc.Keeper_approval_queue.pending_approval) ->
+                    entry.tool_call_id)
+            |> List.sort_uniq String.compare
+          in
+          check int
+            "a reused raw provider ID in a later OAS turn creates a new approval"
+            2
+            (List.length identities)
         | Error error ->
           fail (Masc.Keeper_approval_queue.storage_error_to_string error));
        (match Masc.Tool_bridge.to_oas_typed_result masc_result with

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -931,7 +931,19 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
            ~ctx_snapshot:ctx_work
            ()
        in
-       let masc_result = handler input in
+       let invocation =
+         Agent_sdk.Tool_contract.Invocation.create
+           ~tool_use_id:"toolu-gate-identity"
+           ~turn:17
+           ~completion:Agent_sdk.Tool_contract.Continue_after_success
+           ~schedule:
+             { planned_index = 0
+             ; batch_index = 0
+             ; batch_size = 1
+             ; execution_mode = Agent_sdk.Tool_contract.Serial
+             }
+       in
+       let masc_result = handler ~oas_invocation:invocation input in
        (match masc_result with
         | Tool_result.Deferred output ->
           check bool
@@ -953,6 +965,19 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
               (output.data |> member "gate" |> member "decision" |> to_string)
         | Tool_result.Completed _ -> fail "Gate deferral became Completed"
         | Tool_result.Failed _ -> fail "Gate deferral became Failed");
+       (match
+          Masc.Keeper_approval_queue.list_pending_entries_for_workspace
+            ~base_path:config.base_path
+        with
+        | Ok [ entry ] ->
+          check (option string)
+            "OAS tool_use_id is persisted on the approval"
+            (Some "toolu-gate-identity")
+            entry.Masc.Keeper_approval_queue.tool_call_id
+        | Ok entries ->
+          failf "expected one pending approval, got %d" (List.length entries)
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.storage_error_to_string error));
        (match Masc.Tool_bridge.to_oas_typed_result masc_result with
         | Ok { _meta = Some (`Assoc fields); _ } ->
           check (option string)

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -976,7 +976,27 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
                "the raw OAS tool_use_id is not used as a durable identity"
                true
                (not (String.equal identity "toolu-gate-identity"))
-           | None -> fail "OAS execution occurrence identity was not persisted")
+           | None -> fail "OAS execution occurrence identity was not persisted");
+          check bool
+            "missing causal evidence is not persisted as a complete snapshot"
+            true
+            (Option.is_none entry.request_context);
+          let context_bundle =
+            Masc.Hitl_summary_worker.For_testing.build_context_bundle ~entry
+          in
+          check bool
+            "Auto Judge sees missing causal evidence as partial"
+            true
+            Yojson.Safe.Util.(context_bundle |> member "partial_context" |> to_bool);
+          check bool
+            "Auto Judge receives no fabricated causal snapshot"
+            true
+            Yojson.Safe.Util.(context_bundle |> member "request_context" = `Null);
+          check (option string)
+            "Auto Judge still receives the durable tool-call identity"
+            entry.tool_call_id
+            Yojson.Safe.Util.
+              (context_bundle |> member "tool_call_id" |> to_string_option)
         | Ok entries ->
           failf "expected one pending approval, got %d" (List.length entries)
         | Error error ->

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -997,8 +997,39 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
             entry.tool_call_id
             Yojson.Safe.Util.
               (context_bundle |> member "tool_call_id" |> to_string_option)
-        | Ok entries ->
+       | Ok entries ->
           failf "expected one pending approval, got %d" (List.length entries)
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.storage_error_to_string error));
+       let blank_id_invocation =
+         Agent_sdk.Tool_contract.Invocation.create
+           ~tool_use_id:""
+           ~turn:17
+           ~completion:Agent_sdk.Tool_contract.Continue_after_success
+           ~schedule:
+             { planned_index = 1
+             ; batch_index = 1
+             ; batch_size = 2
+             ; execution_mode = Agent_sdk.Tool_contract.Serial
+             }
+       in
+       (match handler ~oas_invocation:blank_id_invocation input with
+        | Tool_result.Deferred _ -> ()
+        | Tool_result.Completed _ | Tool_result.Failed _ ->
+          fail "blank-id OAS occurrence did not remain Gate-deferred");
+       (match handler ~oas_invocation:blank_id_invocation input with
+        | Tool_result.Deferred _ -> ()
+        | Tool_result.Completed _ | Tool_result.Failed _ ->
+          fail "replayed blank-id OAS occurrence did not remain Gate-deferred");
+       (match
+          Masc.Keeper_approval_queue.list_pending_entries_for_workspace
+            ~base_path:config.base_path
+        with
+        | Ok entries ->
+          check int
+            "the repeated blank-id OAS occurrence has one durable approval"
+            2
+            (List.length entries)
         | Error error ->
           fail (Masc.Keeper_approval_queue.storage_error_to_string error));
        let later_invocation =
@@ -1031,7 +1062,7 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
           in
           check int
             "a reused raw provider ID in a later OAS turn creates a new approval"
-            2
+            3
             (List.length identities)
         | Error error ->
           fail (Masc.Keeper_approval_queue.storage_error_to_string error));

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -275,10 +275,16 @@ let test_public_read_rejects_unsupported_range_fields () =
          | `Assoc _ -> true
          | _ -> false))
 
-let test_public_read_rejects_offset_without_enrichment () =
+let test_public_read_supports_offset_line_window () =
   with_exec_fixture
-    "keeper_tool_dispatch_runtime_read_rejects_offset"
+    "keeper_tool_dispatch_runtime_read_offset"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
+      let playground = KES.keeper_default_write_root ~config ~meta in
+      mkdir_p playground;
+      let file_name = "offset-window.txt" in
+      write_file
+        (Filename.concat playground file_name)
+        "line-001\nline-002\nline-003\n";
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config
@@ -288,21 +294,19 @@ let test_public_read_rejects_offset_without_enrichment () =
           ~name:"Read"
           ~input:
             (`Assoc
-               [ "file_path", `String "lib/keeper/keeper_transition_audit.ml"
-               ; "offset", `Int 100
+               [ "file_path", `String file_name
+               ; "offset", `Int 2
+               ; "limit", `Int 1
                ])
           ()
       in
-      check string "runtime outcome" "failure" (outcome_label result.disposition);
-      let json =
-        match result.data with
-        | Some data -> data
-        | None -> fail "validation rejection omitted typed data"
-      in
-      check bool "dispatch does not add a tutor" true
-        Yojson.Safe.Util.(member "tool_tutor" json = `Null);
-      check bool "validation names exact field" true
-        (contains_substring result.raw_output "offset"))
+      let json = check_success_result "Read offset window" result in
+      check int "offset passes through as a line coordinate" 2
+        Yojson.Safe.Util.(member "offset" json |> to_int);
+      check int "limit caps returned lines" 1
+        Yojson.Safe.Util.(member "returned_lines" json |> to_int);
+      check string "Read starts at the requested line" "line-002\n"
+        (json_string_field ~default:"" "content" json))
 
 let test_raw_board_runtime_respects_projection () =
   let meta = make_meta ~name:"keeper-board-runtime-guard" () in
@@ -2134,8 +2138,10 @@ let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
       let execute_json = check_success_result "Execute" execute_result in
       check bool "Execute used typed Shell IR" true
         (json_bool_field ~default:false "typed" execute_json);
-      check bool "Execute ran in requested cwd" true
-        (contains_substring execute_result.raw_output playground))
+      check string
+        "Execute ran in requested cwd"
+        (Unix.realpath playground)
+        (json_string_field ~default:"" "output" execute_json |> String.trim))
 
 let test_keeper_task_claim_accepts_specific_task_id () =
   with_exec_fixture "keeper_tool_dispatch_specific_task_claim"
@@ -3367,6 +3373,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                fail "later success changed failure into an external defer"
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                fail "later success overwrote the failed terminal effect");
+            let broadcast_count_before_runtime_failure = !chat_broadcast_count in
             Unix.unlink chat_path;
             Unix.mkdir chat_path 0o755;
             let runtime_bundle =
@@ -3462,8 +3469,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
              | Masc.Keeper_tools_oas.Terminal_effect_completed ->
                fail "runtime terminal failure became completion");
             check int
-              "runtime failure emits no keeper chat broadcast"
-              0
+              "runtime failure emits no additional keeper chat broadcast"
+              broadcast_count_before_runtime_failure
               !chat_broadcast_count;
             check bool
               "runtime terminal delivery failure is not auto-recoverable"
@@ -3522,8 +3529,8 @@ let () =
     ("execute_keeper_tool_call_with_outcome", [
       test_case "public Read rejects unsupported range fields" `Quick
         test_public_read_rejects_unsupported_range_fields;
-      test_case "public Read rejects offset without dispatch enrichment" `Quick
-        test_public_read_rejects_offset_without_enrichment;
+      test_case "public Read supports offset line windows" `Quick
+        test_public_read_supports_offset_line_window;
       test_case "missing file is failure" `Quick
         test_execute_with_outcome_missing_file_is_failure;
       test_case "initializing recovery isolates only publication writes" `Quick

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -413,9 +413,12 @@ let test_gate_causal_context_preserves_deferred () =
     ~input:(`Assoc [])
     result;
   let call =
-    (Masc.Keeper_gate_causal_context.snapshot context).snapshot
-    |> Yojson.Safe.Util.member "completed_tool_calls"
-    |> Yojson.Safe.Util.index 0
+    match (Masc.Keeper_gate_causal_context.snapshot context).snapshot with
+    | Some snapshot ->
+      snapshot
+      |> Yojson.Safe.Util.member "completed_tool_calls"
+      |> Yojson.Safe.Util.index 0
+    | None -> Alcotest.fail "turn-local causal evidence was unexpectedly partial"
   in
   Alcotest.(check string)
     "deferred stays distinct"


### PR DESCRIPTION
## Summary

- Scope the persisted Gate tool_call_id to one MASC/OAS execution occurrence: MASC trace, optional Keeper turn, OAS turn/schedule, and the provider ID. The raw provider ID alone is not history-global.
- Deduplicate only a matching execution-scoped identity plus Keeper, operation, and canonical input. Calls without an identity are never deduplicated; blank identities are rejected.
- Make an approved HITL delivery consumable by its durable approval id, Keeper, operation, and canonical input, rather than the re-emitted invocation ID. grant_consumed remains the one-shot spend authority.
- Write pending snapshots as v9 while reading existing v8 snapshots, so legacy unconsumed approvals remain operable.
- Carry the identity through approval audit, resolved history, approval:resolved SSE, and the runtime trust timeline.
- Register the new OAS bridge identity module in the mandatory Keeper tool-boundary matrix.
- Execute the Keeper approval queue, replay, and resolved-history suites in CI.

## Why

OAS documents provider tool_use_id as assistant-batch scoped; later OAS turns may reuse it. The execution-scoped opaque ID prevents cross-turn pending-approval collisions. Conversely, a HITL resolution already selects one approval_id; comparing its stored ID with a new OAS invocation made non-replayable approved effects re-defer forever.

## Validation

- test_keeper_approval_queue: 36/36 passed
- test_keeper_gate_replay: 12/12 passed
- test_keeper_approval_resolved_history: 11/11 passed
- test_keeper_tool_dispatch_runtime: targeted OAS bridge regression passed (execute_keeper_tool_call_with_outcome, case 5)
- keeper-tool-boundary-matrix, doc truth, and OAS pin checks passed
- ocamlformat --check and git diff --check passed
- CI now explicitly executes the three approval-contract suites.