### PR TITLE
refactor!: drop bank-era memory telemetry readers (영구 0 카운터 제거)

### DIFF
--- a/dashboard/src/components/keeper-detail-kpi.ts
+++ b/dashboard/src/components/keeper-detail-kpi.ts
@@ -62,16 +62,13 @@ export function OperationalHealth({ keeper }: { keeper: Keeper }) {
   const hb = keeper.last_heartbeat
   const compSavedRatio = mw?.compaction_saved_ratio
   const avgSaved = mw?.avg_compaction_saved_tokens
-  const dropRatio = mw?.memory_compaction_drop_ratio
   const lastCompAgo = keeper.last_compaction_ago_s
 
   const hbTone: KpiTone = !hb ? 'default' : 'ok'
   const compTone: KpiTone = compSavedRatio == null ? 'default'
     : compSavedRatio >= 0.4 ? 'ok' : compSavedRatio >= 0.2 ? 'warn' : 'bad'
-  const dropTone: KpiTone = dropRatio == null ? 'default'
-    : dropRatio <= 0.1 ? 'ok' : dropRatio <= 0.3 ? 'warn' : 'bad'
 
-  const hasAny = hb || compSavedRatio != null || dropRatio != null || lastCompAgo != null
+  const hasAny = hb || compSavedRatio != null || lastCompAgo != null
   if (!hasAny) return null
 
   return html`
@@ -89,12 +86,6 @@ export function OperationalHealth({ keeper }: { keeper: Keeper }) {
             <${Eyebrow}>압축 절감률</${Eyebrow}>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[compTone]}">${formatPct1(compSavedRatio)}</span>
             ${avgSaved != null ? html`<${MutedSpan}>avg ${formatTokens(avgSaved)} saved</${MutedSpan}>` : null}
-          </div>
-        ` : null}
-        ${dropRatio != null ? html`
-          <div class="p-2 rounded-[var(--r-1)] border ${KPI_TONE[dropTone]} flex flex-col gap-0.5 v2-monitoring-card">
-            <${Eyebrow}>메모리 손실률</${Eyebrow}>
-            <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[dropTone]}">${formatPct1(dropRatio)}</span>
           </div>
         ` : null}
         ${lastCompAgo != null ? html`

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -303,7 +303,7 @@ describe('RuntimeSignals', () => {
       metrics_window: {
         fallback_rate: 0.12,
         model_fallback_rate: 0.05,
-        memory_compaction_drop_ratio: 0.4,
+        compaction_saved_ratio: 0.4,
       },
     }
 
@@ -311,14 +311,14 @@ describe('RuntimeSignals', () => {
 
     // Before filtering: labels from multiple groups are visible.
     expect(screen.getByText('전체 폴백')).toBeInTheDocument()
-    expect(screen.getByText('컴팩션 드롭 비율')).toBeInTheDocument()
+    expect(screen.getByText('컴팩션 절감')).toBeInTheDocument()
 
-    const input = screen.getByPlaceholderText('신호 지표 필터 (예: 폴백, 메모리, 컴팩션)') as HTMLInputElement
+    const input = screen.getByPlaceholderText('신호 지표 필터 (예: 폴백, 컴팩션)') as HTMLInputElement
     fireEvent.input(input, { target: { value: '컴팩션' } })
 
     // Non-matching labels are gone, matching ones remain.
     expect(screen.queryByText('전체 폴백')).not.toBeInTheDocument()
-    expect(screen.getByText('컴팩션 드롭 비율')).toBeInTheDocument()
+    expect(screen.getByText('컴팩션 절감')).toBeInTheDocument()
   })
 
   it('shows the filter-specific empty state when no rows match', () => {
@@ -332,7 +332,7 @@ describe('RuntimeSignals', () => {
 
     render(h(RuntimeSignals, { keeper }))
 
-    const input = screen.getByPlaceholderText('신호 지표 필터 (예: 폴백, 메모리, 컴팩션)') as HTMLInputElement
+    const input = screen.getByPlaceholderText('신호 지표 필터 (예: 폴백, 컴팩션)') as HTMLInputElement
     fireEvent.input(input, { target: { value: 'nonexistent-zzz' } })
 
     expect(screen.getByText(/필터 결과 없음/)).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -875,9 +875,8 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
       ],
     },
     {
-      title: '메모리 & 컴팩션',
+      title: '컴팩션',
       rows: [
-        { label: '컴팩션 드롭 비율', value: formatPct1(mw?.memory_compaction_drop_ratio) },
         { label: '컴팩션 절감', value: formatPct1(mw?.compaction_saved_ratio) },
         { label: '평균 절감 토큰', value: fmtFixed(mw?.avg_compaction_saved_tokens, 0) },
       ],
@@ -917,7 +916,7 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
               <${TextInput}
                 type="search"
                 class="flex-1 min-w-0 !py-1.5 !px-2 !text-2xs"
-                placeholder="신호 지표 필터 (예: 폴백, 메모리, 컴팩션)"
+                placeholder="신호 지표 필터 (예: 폴백, 컴팩션)"
                 ariaLabel="런타임 신호 지표 필터"
                 value=${signalQuery}
                 onInput=${(event: Event) => {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -537,7 +537,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
 
 // Top-N list keys that contain arrays of { tool/kind/model/..., count } objects
 const TOP_LIST_KEYS = new Set([
-  'top_tools', 'top_work_kinds', 'top_models', 'top_memory_kinds',
+  'top_tools', 'top_work_kinds', 'top_models',
   'top_drift_reasons', 'top_compaction_triggers', 'generation_equipment',
 ])
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1095,22 +1095,10 @@ export interface MetricsWindow {
   // -- Tool --
   tool_call_count?: number
 
-  // -- Memory --
-  memory_notes_added?: number
-
-  // -- Memory compaction --
-  memory_compaction_events?: number
-  memory_compaction_before_notes?: number
-  memory_compaction_dropped_notes?: number
-  memory_compaction_invalid_dropped?: number
-  memory_compaction_drop_ratio?: number
-  memory_compaction_drop_avg?: number
-
   // -- Top-N lists --
   top_work_kinds?: MetricsWindowTopItem[]
   top_models?: MetricsWindowTopItem[]
   top_tools?: MetricsWindowTopItem[]
-  top_memory_kinds?: MetricsWindowTopItem[]
   top_drift_reasons?: MetricsWindowTopItem[]
   top_compaction_triggers?: MetricsWindowTopItem[]
   generation_equipment?: MetricsWindowTopItem[]

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -16,12 +16,6 @@ type metrics_acc = {
   ma_proactive_points : int;
   ma_drift_applied_count : int;
 
-  ma_memory_notes_added : int;
-  ma_memory_compaction_events : int;
-  ma_memory_compaction_before_notes : int;
-  ma_memory_compaction_dropped_notes : int;
-  ma_memory_compaction_invalid_dropped : int;
-
   ma_last_handoff : Yojson.Safe.t option;
   ma_last_compaction : Yojson.Safe.t option;
 }
@@ -38,12 +32,6 @@ let init_acc = {
   ma_heartbeat_points = 0;
   ma_proactive_points = 0;
   ma_drift_applied_count = 0;
-
-  ma_memory_notes_added = 0;
-  ma_memory_compaction_events = 0;
-  ma_memory_compaction_before_notes = 0;
-  ma_memory_compaction_dropped_notes = 0;
-  ma_memory_compaction_invalid_dropped = 0;
 
   ma_last_handoff = None;
   ma_last_compaction = None;
@@ -62,7 +50,6 @@ let compute_metrics_window
   let work_kind_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let model_counts_window : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let tool_counts_window : (string, int) Hashtbl.t = Hashtbl.create 16 in
-  let memory_kind_counts_window : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let drift_reason_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let compaction_trigger_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let generation_stats : (int, keeper_gen_window_stats) Hashtbl.t = Hashtbl.create 8 in
@@ -135,17 +122,6 @@ let compute_metrics_window
           |> Option.map String.trim
           |> function Some s when s <> "" -> Some s | _ -> None
         in
-        let memory_notes_added_now = Safe_ops.json_int ~default:0 "memory_notes_added" j in
-        let memory_top_kind_now = Safe_ops.json_string_opt "memory_top_kind" j in
-        let memory_note_kinds =
-          match j |> m "memory_note_kinds" with
-          | `List xs -> List.filter_map (function `String s when String.trim s <> "" -> Some (String.trim s) | _ -> None) xs
-          | _ -> []
-        in
-        let memory_compaction_performed_now = Safe_ops.json_bool ~default:false "memory_compaction_performed" j in
-        let memory_compaction_before_notes_now = Safe_ops.json_int ~default:0 "memory_compaction_before_notes" j in
-        let memory_compaction_dropped_notes_now = Safe_ops.json_int ~default:0 "memory_compaction_dropped_notes" j in
-        let memory_compaction_invalid_dropped_now = Safe_ops.json_int ~default:0 "memory_compaction_invalid_dropped" j in
         let tools_used =
           match j |> m "tools_used" with
           | `List xs -> List.filter_map (function `String s when String.trim s <> "" -> Some s | _ -> None) xs
@@ -221,24 +197,7 @@ let compute_metrics_window
             List.iter (count_table_incr tool_counts_window) tools_used;
             let acc = { acc with
               ma_tool_call_count = acc.ma_tool_call_count + tool_call_count_now;
-              ma_memory_notes_added = acc.ma_memory_notes_added + memory_notes_added_now;
             } in
-            let acc =
-              if memory_compaction_performed_now then
-                { acc with
-                  ma_memory_compaction_events = acc.ma_memory_compaction_events + 1;
-                  ma_memory_compaction_before_notes = acc.ma_memory_compaction_before_notes + memory_compaction_before_notes_now;
-                  ma_memory_compaction_dropped_notes = acc.ma_memory_compaction_dropped_notes + memory_compaction_dropped_notes_now;
-                  ma_memory_compaction_invalid_dropped = acc.ma_memory_compaction_invalid_dropped + memory_compaction_invalid_dropped_now;
-                }
-              else acc
-            in
-            List.iter (count_table_incr memory_kind_counts_window) memory_note_kinds;
-            if memory_note_kinds = [] then
-              (match memory_top_kind_now with
-               | Some kind when String.trim kind <> "" -> count_table_incr memory_kind_counts_window kind
-               | Some _ | None -> ());
-
             let gen_stats =
               match Hashtbl.find_opt generation_stats gen with
               | Some gs -> gs
@@ -253,11 +212,6 @@ let compute_metrics_window
             gen_stats.total_tokens <- gen_stats.total_tokens + Option.value ~default:0 total_tokens;
             if handoff_performed then gen_stats.handoffs <- gen_stats.handoffs + 1;
             if compacted then gen_stats.compactions <- gen_stats.compactions + 1;
-            if memory_compaction_performed_now then begin
-              gen_stats.memory_compactions <- gen_stats.memory_compactions + 1;
-              gen_stats.memory_trimmed <- gen_stats.memory_trimmed + memory_compaction_dropped_notes_now;
-            end;
-            gen_stats.memory_notes <- gen_stats.memory_notes + memory_notes_added_now;
             if gen_stats.first_ts <= 0.0 || ts_unix < gen_stats.first_ts then gen_stats.first_ts <- ts_unix;
             if ts_unix > gen_stats.last_ts then gen_stats.last_ts <- ts_unix;
             if model_bucket <> "" then count_table_incr gen_stats.models model_bucket;
@@ -317,13 +271,6 @@ let compute_metrics_window
 
               ("drift_applied", `Bool drift_applied_now);
               ("drift_reason", Json_util.string_opt_to_json drift_reason_now);
-              ("memory_notes_added", `Int memory_notes_added_now);
-              ("memory_top_kind", Json_util.string_opt_to_json (match memory_top_kind_now with Some s when String.trim s <> "" -> Some s | _ -> None));
-              ("memory_note_kinds", `List (List.map (fun s -> `String s) memory_note_kinds));
-              ("memory_compaction_performed", `Bool memory_compaction_performed_now);
-              ("memory_compaction_before_notes", `Int memory_compaction_before_notes_now);
-	              ("memory_compaction_dropped_notes", `Int memory_compaction_dropped_notes_now);
-	              ("memory_compaction_invalid_dropped", `Int memory_compaction_invalid_dropped_now);
               ( "inference_telemetry",
                 j
                 |> m "inference_telemetry"
@@ -371,18 +318,6 @@ let compute_metrics_window
     if acc.ma_compaction_events = 0 then 0.0 else
       float_of_int acc.ma_compaction_saved_tokens /. float_of_int acc.ma_compaction_events
   in
-  let memory_compaction_drop_ratio =
-    if acc.ma_memory_compaction_before_notes = 0 then 0.0
-    else
-      float_of_int acc.ma_memory_compaction_dropped_notes
-      /. float_of_int acc.ma_memory_compaction_before_notes
-  in
-  let memory_compaction_drop_avg =
-    if acc.ma_memory_compaction_events = 0 then 0.0
-    else
-      float_of_int acc.ma_memory_compaction_dropped_notes
-      /. float_of_int acc.ma_memory_compaction_events
-  in
   let top_work_kinds =
     top_counts_json ~limit:5 ~name_key:"kind" work_kind_counts
   in
@@ -391,9 +326,6 @@ let compute_metrics_window
   in
   let top_tools =
     top_counts_json ~limit:5 ~name_key:"tool" tool_counts_window
-  in
-  let top_memory_kinds =
-    top_counts_json ~limit:5 ~name_key:"kind" memory_kind_counts_window
   in
   let top_drift_reasons =
     top_counts_json ~limit:5 ~name_key:"reason" drift_reason_counts
@@ -425,9 +357,6 @@ let compute_metrics_window
            ("total_tokens", `Int gs.total_tokens);
            ("handoffs", `Int gs.handoffs);
            ("compactions", `Int gs.compactions);
-           ("memory_compactions", `Int gs.memory_compactions);
-           ("memory_trimmed", `Int gs.memory_trimmed);
-           ("memory_notes", `Int gs.memory_notes);
            ("first_ts_unix", `Float gs.first_ts);
            ("last_ts_unix", `Float gs.last_ts);
            ("top_model", top_model);
@@ -472,17 +401,9 @@ let compute_metrics_window
     ("drift_applied_rate", `Float drift_applied_rate);
 
     ("tool_call_count", `Int acc.ma_tool_call_count);
-    ("memory_notes_added", `Int acc.ma_memory_notes_added);
-    ("memory_compaction_events", `Int acc.ma_memory_compaction_events);
-    ("memory_compaction_before_notes", `Int acc.ma_memory_compaction_before_notes);
-    ("memory_compaction_dropped_notes", `Int acc.ma_memory_compaction_dropped_notes);
-    ("memory_compaction_invalid_dropped", `Int acc.ma_memory_compaction_invalid_dropped);
-    ("memory_compaction_drop_ratio", `Float memory_compaction_drop_ratio);
-    ("memory_compaction_drop_avg", `Float memory_compaction_drop_avg);
     ("top_work_kinds", `List top_work_kinds);
     ("top_models", `List top_models);
     ("top_tools", `List top_tools);
-    ("top_memory_kinds", `List top_memory_kinds);
     ("top_drift_reasons", `List top_drift_reasons);
     ("top_compaction_triggers", `List top_compaction_triggers);
     ("generation_equipment", `List generation_equipment);

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -28,9 +28,6 @@ type keeper_gen_window_stats = {
   mutable total_tokens: int;
   mutable handoffs: int;
   mutable compactions: int;
-  mutable memory_compactions: int;
-  mutable memory_trimmed: int;
-  mutable memory_notes: int;
   mutable first_ts: float;
   mutable last_ts: float;
   models: (string, int) Hashtbl.t;
@@ -45,9 +42,6 @@ let create_keeper_gen_window_stats () : keeper_gen_window_stats =
     total_tokens = 0;
     handoffs = 0;
     compactions = 0;
-    memory_compactions = 0;
-    memory_trimmed = 0;
-    memory_notes = 0;
     first_ts = 0.0;
     last_ts = 0.0;
     models = Hashtbl.create 8;

--- a/lib/dashboard/dashboard_http_keeper_metrics.mli
+++ b/lib/dashboard/dashboard_http_keeper_metrics.mli
@@ -33,9 +33,6 @@ type keeper_gen_window_stats = {
   mutable total_tokens : int;
   mutable handoffs : int;
   mutable compactions : int;
-  mutable memory_compactions : int;
-  mutable memory_trimmed : int;
-  mutable memory_notes : int;
   mutable first_ts : float;
   mutable last_ts : float;
   models : (string, int) Hashtbl.t;

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -583,10 +583,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                    try
                      let j = Yojson.Safe.from_string line in
                      let compacted = Safe_ops.json_bool ~default:false "compacted" j in
-                     let memory_compaction_performed =
-                       Safe_ops.json_bool ~default:false "memory_compaction_performed" j
-                     in
-                     if (not compacted) && (not memory_compaction_performed) then acc
+                     if not compacted then acc
                      else
                        let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
                        let age_s =
@@ -595,26 +592,9 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                        let before_tokens = Safe_ops.json_int ~default:0 "compaction_before_tokens" j in
                        let after_tokens = Safe_ops.json_int ~default:0 "compaction_after_tokens" j in
                        let saved_tokens = max 0 (before_tokens - after_tokens) in
-                       let memory_before_notes =
-                         Safe_ops.json_int ~default:0 "memory_compaction_before_notes" j
-                       in
-                       let memory_after_notes =
-                         Safe_ops.json_int ~default:0 "memory_compaction_after_notes" j
-                       in
-                       let memory_dropped_notes =
-                         Safe_ops.json_int ~default:0 "memory_compaction_dropped_notes" j
-                       in
-                       let memory_invalid_dropped =
-                         Safe_ops.json_int ~default:0 "memory_compaction_invalid_dropped" j
-                       in
-                       let event_kind =
-                         if compacted && memory_compaction_performed then "context+memory"
-                         else if compacted then "context"
-                         else "memory"
-                       in
                        let item =
                          `Assoc [
-                           ("kind", `String event_kind);
+                           ("kind", `String "context");
                            ("channel", `String (Safe_ops.json_string ~default:"turn" "channel" j));
                            ("ts_unix", `Float ts_unix);
                            ("age_s", Json_util.float_opt_to_json age_s);
@@ -625,15 +605,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                            ("context_saved_tokens", `Int saved_tokens);
                            ( "context_trigger",
                              match Safe_ops.json_string_opt "compaction_trigger" j with
-                             | Some reason when String.trim reason <> "" -> `String reason
-                             | _ -> `Null );
-                           ("memory_compaction_performed", `Bool memory_compaction_performed);
-                           ("memory_before_notes", `Int memory_before_notes);
-                           ("memory_after_notes", `Int memory_after_notes);
-                           ("memory_dropped_notes", `Int memory_dropped_notes);
-                           ("memory_invalid_dropped", `Int memory_invalid_dropped);
-                           ( "memory_reason",
-                             match Safe_ops.json_string_opt "memory_compaction_reason" j with
                              | Some reason when String.trim reason <> "" -> `String reason
                              | _ -> `Null );
                          ]

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -10,10 +10,6 @@ type metrics_summary = {
   handoff_count : int;
   compaction_events : int;
   compaction_saved_tokens : int;
-  memory_compaction_events : int;
-  memory_compaction_before_notes : int;
-  memory_compaction_dropped_notes : int;
-  memory_compaction_invalid_dropped : int;
   last_handoff : Yojson.Safe.t option;
   last_compaction : Yojson.Safe.t option;
 }
@@ -60,10 +56,6 @@ let empty_metrics_summary =
     handoff_count = 0;
     compaction_events = 0;
     compaction_saved_tokens = 0;
-    memory_compaction_events = 0;
-    memory_compaction_before_notes = 0;
-    memory_compaction_dropped_notes = 0;
-    memory_compaction_invalid_dropped = 0;
     last_handoff = None;
     last_compaction = None;
   }
@@ -94,18 +86,6 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
     if interaction_points = 0 then 0.0
     else float_of_int s.drift_applied_count /. float_of_int interaction_points
   in
-  let memory_compaction_drop_ratio =
-    if s.memory_compaction_before_notes = 0 then 0.0
-    else
-      float_of_int s.memory_compaction_dropped_notes
-      /. float_of_int s.memory_compaction_before_notes
-  in
-  let memory_compaction_drop_avg =
-    if s.memory_compaction_events = 0 then 0.0
-    else
-      float_of_int s.memory_compaction_dropped_notes
-      /. float_of_int s.memory_compaction_events
-  in
   `Assoc
     [
       ("sample_points", `Int s.sample_points);
@@ -120,12 +100,6 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
       ("handoff_count", `Int s.handoff_count);
       ("compaction_events", `Int s.compaction_events);
       ("compaction_saved_tokens", `Int s.compaction_saved_tokens);
-      ("memory_compaction_events", `Int s.memory_compaction_events);
-      ("memory_compaction_before_notes", `Int s.memory_compaction_before_notes);
-      ("memory_compaction_dropped_notes", `Int s.memory_compaction_dropped_notes);
-      ("memory_compaction_invalid_dropped", `Int s.memory_compaction_invalid_dropped);
-      ("memory_compaction_drop_ratio", `Float memory_compaction_drop_ratio);
-      ("memory_compaction_drop_avg", `Float memory_compaction_drop_avg);
       ("last_handoff", match s.last_handoff with Some j -> j | None -> `Null);
       ("last_compaction", match s.last_compaction with Some j -> j | None -> `Null);
     ]
@@ -182,18 +156,6 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
         let to_model = Safe_ops.json_string_opt "to_model" handoff in
         let prev_trace_id = Safe_ops.json_string_opt "prev_trace_id" handoff in
         let new_trace_id = Safe_ops.json_string_opt "new_trace_id" handoff in
-        let memory_compaction_performed =
-          Safe_ops.json_bool ~default:false "memory_compaction_performed" j
-        in
-        let memory_compaction_before_now =
-          Safe_ops.json_int ~default:0 "memory_compaction_before_notes" j
-        in
-        let memory_compaction_dropped_now =
-          Safe_ops.json_int ~default:0 "memory_compaction_dropped_notes" j
-        in
-        let memory_compaction_invalid_now =
-          Safe_ops.json_int ~default:0 "memory_compaction_invalid_dropped" j
-        in
         let drift = m "drift" in
         let drift_applied_now =
           Safe_ops.json_bool ~default:false "applied" drift
@@ -249,18 +211,6 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
           compaction_saved_tokens =
             acc.compaction_saved_tokens
             + (if is_interaction && compacted then saved_tokens else 0);
-          memory_compaction_events =
-            acc.memory_compaction_events
-            + (if is_interaction && memory_compaction_performed then 1 else 0);
-          memory_compaction_before_notes =
-            acc.memory_compaction_before_notes
-            + (if is_interaction && memory_compaction_performed then memory_compaction_before_now else 0);
-          memory_compaction_dropped_notes =
-            acc.memory_compaction_dropped_notes
-            + (if is_interaction && memory_compaction_performed then memory_compaction_dropped_now else 0);
-          memory_compaction_invalid_dropped =
-            acc.memory_compaction_invalid_dropped
-            + (if is_interaction && memory_compaction_performed then memory_compaction_invalid_now else 0);
           last_handoff = handoff_json;
           last_compaction = compaction_json;
         }


### PR DESCRIPTION
Memory SSOT 캠페인 마무리 — #26128(bank 제거)·#26139(recall 휴리스틱 제거)가 남긴 bank-era 텔레메트리 리더를 제거.

## 근거

**생산자 0 확인**: `memory_notes_added`, `memory_top_kind`, `memory_note_kinds`, `memory_compaction_*`를 JSONL에 쓰는 코드는 repo에 없다 (#26128이 bank note-compaction과 함께 제거). 남아 있던 것은 죽은 필드를 읽어 **영구 0 카운터**를 만드는 리더 체인뿐.

## 제거 대상

1. **`keeper_status_metrics.ml`**: `memory_compaction_*` summary 필드 4종 + 파싱 + drop_ratio/drop_avg 투영.
2. **`keeper_status_detail.ml`**: compaction-events feed에서 memory 절반 제거 — context compaction만 남고, `context+memory`/`memory` kind 라벨과 `memory_*` item 필드 삭제 (`kind`는 상수 `"context"`).
3. **`dashboard_http_keeper_detail.ml`**: `memory_kind_counts_window`·`top_memory_kinds`(kind 어휘의 마지막 잔재), `ma_memory_*` 누적 5종, per-item `memory_*` JSON 7종, per-generation `memory_compactions/memory_trimmed/memory_notes` (+`dashboard_http_keeper_metrics.ml/.mli` 레코드 필드).
4. **TS**: `metrics_window` 타입 8필드 + `top_memory_kinds`, '메모리 손실률' KPI 카드, '컴팩션 드롭 비율' signal row, normalize 리스트. 필터 테스트 픽스처는 살아있는 `compaction_saved_ratio`로 이동.

## 검증
- 제거 필드 repo 전체(lib/test/bin/dashboard/docs) 잔존 참조 0 — 부재 판정은 필드명 13종으로 재검색.
- 외부 소비자 0: `metrics_summary`는 mli abstract, gen stats 소비자는 detail.ml 한 곳.
- 로컬 dune/vitest 미실행 (원칙: 빌드는 CI에서) — CI가 게이트.

RFC-WAIVED: 죽은 텔레메트리 리더의 순수 삭제 — 생산자는 #26128에서 이미 제거됨. 신규 메커니즘 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HA6GposPqQteSu8fw1nvS
