### PR TITLE
fix(operator): fallback 관찰과 action projection 분리

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -346,33 +346,27 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
     match Operator_action_constants.target_type_of_string target_type with
     | Some Operator_action_constants.Workspace ->
         let confirm_scope = pending_confirm_scope ?actor config in
-        let keeper_attention, keeper_recommendations =
-          keeper_attention_projection_items config |> List.split
+        let keeper_attention =
+          keeper_attention_projection_items config |> List.map fst
         in
         let attention_items =
           build_workspace_attention_items config
           @ keeper_attention
           |> List.sort compare_attention
         in
-        let recommended_actions =
-          dedup_recommendations
-            (workspace_recommendations config @ keeper_recommendations)
+        let fallback_observation_summary =
+          summary_of_attention_items attention_items
         in
-        let fallback_recommendation_summary =
-          summary_of_recommendations ~actor:actor_name recommended_actions
-        in
-        let fallback_recommendations =
-          List.map
-            (recommended_action_to_yojson ~actor:actor_name)
-            recommended_actions
+        let empty_recommendation_summary =
+          summary_of_recommendations ~actor:actor_name []
         in
         let active_guidance =
           active_guidance
             ~config
             ~target_type:Operator_action_constants.workspace_target_type
             ~target_id:None
-            ~fallback_recommendations
-            ~fallback_summary:fallback_recommendation_summary
+            ~fallback_observation_summary
+            ~empty_recommendation_summary
         in
         let recent_reviews =
           Operator_review_state.recent_review_decisions_json ~limit:12 config

--- a/lib/operator/operator_digest_guidance.ml
+++ b/lib/operator/operator_digest_guidance.ml
@@ -1,8 +1,8 @@
 (** Active-guidance layer for operator digest.
 
     Resolves whether a fresh operator judgment exists for the given
-    surface and builds the guidance fields accordingly.  Falls back to
-    deterministic recommendations when no judgment is available. *)
+    surface and builds the guidance fields accordingly.  Without one,
+    exposes only the deterministic observation summary. *)
 
 module U = Yojson.Safe.Util
 
@@ -56,8 +56,8 @@ let judgment_recommendation_summary_json actions =
    OCaml (action_type="keeper_probe", reason="Inspect pending external
    attention") and hand it to the model as though a decision had been made;
    the summary below states the observed condition instead. *)
-let active_guidance ~config ~target_type ~target_id ~fallback_recommendations
-    ~fallback_summary =
+let active_guidance ~config ~target_type ~target_id ~fallback_observation_summary
+    ~empty_recommendation_summary =
   match fresh_operator_judgment config ~target_type ~target_id with
   | Some judgment_json ->
       let recommended_actions =
@@ -90,10 +90,10 @@ let active_guidance ~config ~target_type ~target_id ~fallback_recommendations
             ("authoritative_judgment_available", `Bool false);
             ("judgment", `Null);
             ("active_guidance_layer", `String "fallback");
-            ("active_summary", fallback_summary);
+            ("active_summary", fallback_observation_summary);
             ("active_recommended_actions", `List []);
-            ("active_recommendation_summary", fallback_summary);
+            ("active_recommendation_summary", empty_recommendation_summary);
           ];
-        recommended_actions = fallback_recommendations;
-        recommendation_summary = fallback_summary;
+        recommended_actions = [];
+        recommendation_summary = empty_recommendation_summary;
       }

--- a/lib/operator/operator_digest_guidance.mli
+++ b/lib/operator/operator_digest_guidance.mli
@@ -1,8 +1,8 @@
 (** Active-guidance layer for operator digest.
 
     Resolves whether a fresh operator judgment exists and builds the guidance
-    fields plus the effective recommendation projection. Falls back to
-    deterministic recommendations when no judgment is available.
+    fields plus the effective recommendation projection. Without a judgment,
+    deterministic observations remain visible but cannot become actions.
 
     Internal helpers ([fresh_operator_judgment], [judgment_summary_json]) are
     intentionally hidden — only the
@@ -18,13 +18,13 @@ val active_guidance :
   config:Workspace.config ->
   target_type:string ->
   target_id:string option ->
-  fallback_recommendations:Yojson.Safe.t list ->
-  fallback_summary:Yojson.Safe.t ->
+  fallback_observation_summary:Yojson.Safe.t ->
+  empty_recommendation_summary:Yojson.Safe.t ->
   projection
 (** Build the digest's [active_*] guidance fields and effective top-level
     recommendation projection. When a fresh
     operator judgment exists, emits
     [judgment_owner = "operator_keeper"] with the judgment's
     summary/recommendation; otherwise emits
-    [judgment_owner = "fallback_read_model"] and keeps the supplied
-    fallback projection. *)
+    [judgment_owner = "fallback_read_model"], preserves the supplied
+    observation summary, and emits no recommendation. *)

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -103,7 +103,12 @@ let test_digest_workspace_ignores_stale_operator_judgment () =
       Alcotest.(check string) "active guidance layer fallback" "fallback"
         Yojson.Safe.Util.(digest |> member "active_guidance_layer" |> to_string);
       Alcotest.(check bool) "judgment missing" true
-        (Yojson.Safe.Util.member "judgment" digest = `Null))
+        (Yojson.Safe.Util.member "judgment" digest = `Null);
+      Alcotest.(check int) "stale judgment cannot leave fallback actions" 0
+        Yojson.Safe.Util.(digest |> member "recommended_actions" |> to_list |> List.length);
+      Alcotest.(check int) "stale judgment recommendation summary is empty" 0
+        Yojson.Safe.Util.
+          (digest |> member "recommendation_summary" |> member "count" |> to_int))
 
 let test_guidance_ignores_unsupported_target_type () =
   Eio_main.run @@ fun env ->
@@ -121,8 +126,8 @@ let test_guidance_ignores_unsupported_target_type () =
       let fields =
         Operator_digest_guidance.active_guidance ~config
           ~target_type:"keeper" ~target_id:None
-          ~fallback_recommendations:[]
-          ~fallback_summary:(`Assoc [ ("count", `Int 0) ])
+          ~fallback_observation_summary:(`Assoc [ ("count", `Int 0) ])
+          ~empty_recommendation_summary:(`Assoc [ ("count", `Int 0) ])
       in
       let guidance = `Assoc fields.fields in
       Alcotest.(check string) "judgment owner fallback" "fallback_read_model"
@@ -133,7 +138,9 @@ let test_guidance_ignores_unsupported_target_type () =
       Alcotest.(check string) "active guidance layer fallback" "fallback"
         Yojson.Safe.Util.(guidance |> member "active_guidance_layer" |> to_string);
       Alcotest.(check bool) "judgment missing" true
-        (Yojson.Safe.Util.member "judgment" guidance = `Null))
+        (Yojson.Safe.Util.member "judgment" guidance = `Null);
+      Alcotest.(check int) "fallback cannot synthesize actions" 0
+        (List.length fields.recommended_actions))
 
 let test_operator_judgment_write_and_latest_roundtrip () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -724,10 +724,12 @@ let test_digest_workspace_includes_keeper_runtime_attention () =
           && String.equal "keeper_probe" (row |> member "action_type" |> to_string))
         |> Option.value ~default:`Null
       in
-      Alcotest.(check bool) "keeper probe recommendation present" true
-        (keeper_probe <> `Null);
-      Alcotest.(check bool) "recommendation summary is non-empty" true
-        (digest |> member "recommendation_summary" |> member "count" |> to_int > 0))
+      Alcotest.(check bool) "fallback cannot synthesize keeper probe" true
+        (keeper_probe = `Null);
+      Alcotest.(check int) "fallback recommendation summary is empty" 0
+        (digest |> member "recommendation_summary" |> member "count" |> to_int);
+      Alcotest.(check bool) "observation summary remains visible" true
+        (digest |> member "active_summary" |> member "count" |> to_int > 0))
 
 let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
Follow-up to #26123이에용.

#26123 merge 직전 current-head 리뷰에서 fallback read model이 만든 `keeper_probe`가 top-level `recommended_actions`로 다시 노출되는 P2를 확인했어용.

## 바꾼 내용

- fresh operator judgment가 있을 때만 action/summary를 top-level projection으로 전달해용.
- judgment가 없으면 attention은 `active_summary` 관찰로만 남겨용.
- fallback `recommended_actions`와 recommendation summary는 비워용.
- stale judgment, unsupported target, keeper attention 회귀 테스트를 보강했어용.

## 검증

- `ocamlformat --check` 통과
- 변경 OCaml 파일 parsing 통과
- determinism/silent-failure gate 통과
- PR hygiene 통과
- OCaml structure ratchet 통과
- `git diff --check` 통과

로컬 Dune은 실행하지 않았고 전체 타입/테스트 권위는 PR CI로 확인해용.
