### PR TITLE
feat(scripts): read the OAS request traces nobody was reading

### DIFF
--- a/scripts/audit-oas-payload.py
+++ b/scripts/audit-oas-payload.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Report what is actually in the OAS request payloads MASC sends.
+
+Every keeper turn writes its exact request to
+``<base>/.masc/traces/<trace>/oas-snapshot-*.json``: system_prompt, tools and
+messages verbatim. Nothing reads them. This walks that directory and answers
+the questions the files already contain:
+
+  - how the payload splits across system_prompt / tools / messages
+  - how many offered tools are ever called, and how many schema bytes are spent
+    on ones that are not
+  - whether one tool dominates the conversation, which is what a polling loop
+    looks like from the outside
+  - whether consecutive calls to a tool carry identical input, which is what a
+    loop that learns nothing looks like
+
+Exit status is 0 for a report and 1 when a threshold is exceeded, so this can
+become a gate without changing the output format.
+
+Usage:
+    scripts/audit-oas-payload.py [TRACES_DIR] [--json] [--limit N]
+                                 [--max-top-tool-share PCT]
+                                 [--max-repeat-run N]
+                                 [--min-tool-usage PCT]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# A single tool holding more of the turn budget than this is a loop, not work.
+DEFAULT_MAX_TOP_TOOL_SHARE: Final[float] = 60.0
+# Consecutive identical calls to one tool. Two is a retry; twenty is a loop.
+DEFAULT_MAX_REPEAT_RUN: Final[int] = 10
+# Offered tools that are never called still cost their schema bytes every turn.
+DEFAULT_MIN_TOOL_USAGE: Final[float] = 25.0
+
+SNAPSHOT_GLOB: Final[str] = "oas-snapshot-*.json"
+
+
+@dataclass(frozen=True, slots=True)
+class ToolUse:
+    name: str
+    payload: str
+
+
+@dataclass(frozen=True, slots=True)
+class Snapshot:
+    path: Path
+    total_bytes: int
+    system_bytes: int
+    tools_bytes: int
+    messages_bytes: int
+    message_count: int
+    offered: tuple[str, ...]
+    unused_schema_bytes: int
+    calls: tuple[ToolUse, ...]
+    tool_choice: str | None
+
+    @property
+    def call_counts(self) -> Counter[str]:
+        return Counter(call.name for call in self.calls)
+
+    @property
+    def top_tool(self) -> tuple[str, int] | None:
+        counts = self.call_counts.most_common(1)
+        return counts[0] if counts else None
+
+    @property
+    def top_tool_share(self) -> float:
+        top = self.top_tool
+        if top is None or not self.calls:
+            return 0.0
+        return 100.0 * top[1] / len(self.calls)
+
+    @property
+    def tool_usage_ratio(self) -> float:
+        if not self.offered:
+            return 0.0
+        return 100.0 * len(self.call_counts) / len(self.offered)
+
+    @property
+    def longest_repeat_run(self) -> tuple[str, int]:
+        """Longest run of consecutive calls to one tool carrying identical input."""
+        best_name, best_len = "", 0
+        run_name, run_payload, run_len = "", "", 0
+        for call in self.calls:
+            if call.name == run_name and call.payload == run_payload:
+                run_len += 1
+            else:
+                run_name, run_payload, run_len = call.name, call.payload, 1
+            if run_len > best_len:
+                best_name, best_len = run_name, run_len
+        return best_name, best_len
+
+
+def _encoded_length(value: object) -> int:
+    if isinstance(value, str):
+        return len(value)
+    return len(json.dumps(value, ensure_ascii=False))
+
+
+def _tool_uses(messages: list[object]) -> tuple[ToolUse, ...]:
+    uses: list[ToolUse] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            name = block.get("name")
+            if not isinstance(name, str):
+                continue
+            uses.append(
+                ToolUse(
+                    name=name,
+                    payload=json.dumps(block.get("input"), sort_keys=True),
+                )
+            )
+    return tuple(uses)
+
+
+def load_snapshot(path: Path) -> Snapshot | None:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+
+    system = raw.get("system_prompt")
+    tools = raw.get("tools")
+    messages = raw.get("messages")
+    tools_list: list[object] = tools if isinstance(tools, list) else []
+    messages_list: list[object] = messages if isinstance(messages, list) else []
+
+    calls = _tool_uses(messages_list)
+    called = {call.name for call in calls}
+
+    offered: list[str] = []
+    unused_bytes = 0
+    for tool in tools_list:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name")
+        if not isinstance(name, str):
+            continue
+        offered.append(name)
+        if name not in called:
+            unused_bytes += _encoded_length(tool)
+
+    choice = raw.get("tool_choice")
+    return Snapshot(
+        path=path,
+        total_bytes=_encoded_length(raw),
+        system_bytes=_encoded_length(system) if system is not None else 0,
+        tools_bytes=_encoded_length(tools_list),
+        messages_bytes=_encoded_length(messages_list),
+        message_count=len(messages_list),
+        offered=tuple(offered),
+        unused_schema_bytes=unused_bytes,
+        calls=calls,
+        tool_choice=None if choice is None else json.dumps(choice),
+    )
+
+
+def _pct(part: int, whole: int) -> float:
+    return 100.0 * part / whole if whole else 0.0
+
+
+def render_text(snapshots: list[Snapshot], violations: list[str]) -> str:
+    lines: list[str] = []
+    header = (
+        f"{'snapshot':26s} {'total':>10s} {'sys%':>5s} {'tool%':>6s} {'msg%':>5s} "
+        f"{'calls':>6s} {'used/offered':>13s} {'top tool':>34s}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    for snap in snapshots:
+        top = snap.top_tool
+        top_text = f"{top[0]}x{top[1]} ({snap.top_tool_share:.0f}%)" if top else "-"
+        used_offered = f"{len(snap.call_counts)}/{len(snap.offered)}"
+        lines.append(
+            f"{snap.path.name[-26:]:26s} {snap.total_bytes:10,d} "
+            f"{_pct(snap.system_bytes, snap.total_bytes):5.1f} "
+            f"{_pct(snap.tools_bytes, snap.total_bytes):6.1f} "
+            f"{_pct(snap.messages_bytes, snap.total_bytes):5.1f} "
+            f"{len(snap.calls):6d} "
+            f"{used_offered:>13s} "
+            f"{top_text:>34s}"
+        )
+
+    total = sum(s.total_bytes for s in snapshots)
+    unused = sum(s.unused_schema_bytes for s in snapshots)
+    tools_bytes = sum(s.tools_bytes for s in snapshots)
+    lines.append("")
+    lines.append(f"snapshots            : {len(snapshots)}")
+    lines.append(f"payload total        : {total:,d} bytes")
+    lines.append(
+        f"unused tool schemas  : {unused:,d} of {tools_bytes:,d} tool bytes "
+        f"({_pct(unused, tools_bytes):.1f}%), {_pct(unused, total):.1f}% of payload"
+    )
+
+    runs = [s.longest_repeat_run for s in snapshots]
+    worst = max(runs, key=lambda r: r[1], default=("", 0))
+    lines.append(f"longest identical run: {worst[0] or '-'} x{worst[1]}")
+
+    choices = Counter(
+        s.tool_choice for s in snapshots if s.tool_choice not in (None, "null")
+    )
+    if choices:
+        lines.append(f"tool_choice set      : {dict(choices)}")
+
+    if violations:
+        lines.append("")
+        lines.append("THRESHOLDS EXCEEDED:")
+        lines.extend(f"  - {v}" for v in violations)
+    return "\n".join(lines)
+
+
+def collect_violations(
+    snapshots: list[Snapshot],
+    *,
+    max_top_tool_share: float,
+    max_repeat_run: int,
+    min_tool_usage: float,
+) -> list[str]:
+    violations: list[str] = []
+    for snap in snapshots:
+        top = snap.top_tool
+        if top is not None and snap.top_tool_share > max_top_tool_share:
+            violations.append(
+                f"{snap.path.name}: {top[0]} is {snap.top_tool_share:.0f}% of "
+                f"{len(snap.calls)} calls (limit {max_top_tool_share:.0f}%)"
+            )
+        name, run = snap.longest_repeat_run
+        if run > max_repeat_run:
+            violations.append(
+                f"{snap.path.name}: {name} called {run} times consecutively with "
+                f"identical input (limit {max_repeat_run})"
+            )
+        if snap.offered and snap.tool_usage_ratio < min_tool_usage:
+            violations.append(
+                f"{snap.path.name}: {len(snap.call_counts)} of {len(snap.offered)} "
+                f"offered tools used ({snap.tool_usage_ratio:.0f}%, "
+                f"floor {min_tool_usage:.0f}%)"
+            )
+    return violations
+
+
+def snapshot_to_json(snap: Snapshot) -> dict[str, object]:
+    top = snap.top_tool
+    run_tool, run_len = snap.longest_repeat_run
+    return {
+        "path": str(snap.path),
+        "total_bytes": snap.total_bytes,
+        "system_bytes": snap.system_bytes,
+        "tools_bytes": snap.tools_bytes,
+        "messages_bytes": snap.messages_bytes,
+        "message_count": snap.message_count,
+        "offered_tools": len(snap.offered),
+        "used_tools": len(snap.call_counts),
+        "unused_schema_bytes": snap.unused_schema_bytes,
+        "tool_calls": len(snap.calls),
+        "top_tool": top[0] if top else None,
+        "top_tool_calls": top[1] if top else 0,
+        "top_tool_share_pct": round(snap.top_tool_share, 1),
+        "longest_identical_run": run_len,
+        "longest_identical_run_tool": run_tool or None,
+        "tool_choice": snap.tool_choice,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "traces_dir",
+        nargs="?",
+        default=str(Path.home() / "me" / ".masc" / "traces"),
+        help="directory holding <trace>/oas-snapshot-*.json (default: ~/me/.masc/traces)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--limit", type=int, default=20, help="newest N snapshots (default 20)"
+    )
+    parser.add_argument(
+        "--max-top-tool-share", type=float, default=DEFAULT_MAX_TOP_TOOL_SHARE
+    )
+    parser.add_argument("--max-repeat-run", type=int, default=DEFAULT_MAX_REPEAT_RUN)
+    parser.add_argument("--min-tool-usage", type=float, default=DEFAULT_MIN_TOOL_USAGE)
+    args = parser.parse_args()
+
+    root = Path(args.traces_dir)
+    if not root.is_dir():
+        print(f"no traces directory: {root}", file=sys.stderr)
+        return 2
+
+    paths = sorted(root.glob(f"*/{SNAPSHOT_GLOB}"), key=lambda p: p.stat().st_mtime)
+    if args.limit > 0:
+        paths = paths[-args.limit :]
+    if not paths:
+        print(f"no {SNAPSHOT_GLOB} under {root}", file=sys.stderr)
+        return 2
+
+    snapshots = [snap for snap in (load_snapshot(p) for p in paths) if snap is not None]
+    if not snapshots:
+        print(f"every snapshot under {root} failed to parse", file=sys.stderr)
+        return 2
+
+    violations = collect_violations(
+        snapshots,
+        max_top_tool_share=args.max_top_tool_share,
+        max_repeat_run=args.max_repeat_run,
+        min_tool_usage=args.min_tool_usage,
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "snapshots": [snapshot_to_json(s) for s in snapshots],
+                    "violations": violations,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render_text(snapshots, violations))
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit-oas-payload.py
+++ b/scripts/audit-oas-payload.py
@@ -17,8 +17,13 @@ the questions the files already contain:
 Exit status is 0 for a report and 1 when a threshold is exceeded, so this can
 become a gate without changing the output format.
 
+Traces live under ``<base-path>/.masc/traces``. RFC-0121 makes MASC_BASE_PATH
+the sole canonical source for that base path; there is no home-directory or cwd
+fallback. Pass --traces-dir to point at an exported copy instead.
+
 Usage:
-    scripts/audit-oas-payload.py [TRACES_DIR] [--json] [--limit N]
+    MASC_BASE_PATH=<base> scripts/audit-oas-payload.py [--json] [--limit N]
+                                 [--traces-dir DIR]
                                  [--max-top-tool-share PCT]
                                  [--max-repeat-run N]
                                  [--min-tool-usage PCT]
@@ -28,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections import Counter
 from dataclasses import dataclass
@@ -42,6 +48,21 @@ DEFAULT_MAX_REPEAT_RUN: Final[int] = 10
 DEFAULT_MIN_TOOL_USAGE: Final[float] = 25.0
 
 SNAPSHOT_GLOB: Final[str] = "oas-snapshot-*.json"
+MASC_DIRNAME: Final[str] = ".masc"
+TRACES_DIRNAME: Final[str] = "traces"
+
+
+def default_traces_dir() -> Path | None:
+    """Resolve <base-path>/.masc/traces from MASC_BASE_PATH.
+
+    RFC-0121: MASC_BASE_PATH is the sole canonical source. No home-directory or
+    cwd fallback — a wrong base path would silently audit someone else's
+    workspace and report confident numbers about it.
+    """
+    value = os.environ.get("MASC_BASE_PATH", "").strip()
+    if not value:
+        return None
+    return Path(value) / MASC_DIRNAME / TRACES_DIRNAME
 
 
 @dataclass(frozen=True, slots=True)
@@ -283,10 +304,12 @@ def snapshot_to_json(snap: Snapshot) -> dict[str, object]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "traces_dir",
-        nargs="?",
-        default=str(Path.home() / "me" / ".masc" / "traces"),
-        help="directory holding <trace>/oas-snapshot-*.json (default: ~/me/.masc/traces)",
+        "--traces-dir",
+        default=None,
+        help=(
+            "directory holding <trace>/oas-snapshot-*.json "
+            "(default: $MASC_BASE_PATH/.masc/traces)"
+        ),
     )
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     parser.add_argument(
@@ -299,7 +322,14 @@ def main() -> int:
     parser.add_argument("--min-tool-usage", type=float, default=DEFAULT_MIN_TOOL_USAGE)
     args = parser.parse_args()
 
-    root = Path(args.traces_dir)
+    root = Path(args.traces_dir) if args.traces_dir else default_traces_dir()
+    if root is None:
+        print(
+            "MASC_BASE_PATH is required (RFC-0121: sole canonical source, no "
+            "home/cwd fallback). Export it, or pass --traces-dir explicitly.",
+            file=sys.stderr,
+        )
+        return 2
     if not root.is_dir():
         print(f"no traces directory: {root}", file=sys.stderr)
         return 2


### PR DESCRIPTION
## 무엇을

`~/me/.masc/traces/<trace>/oas-snapshot-*.json`을 읽어 **실제로 프로바이더에 보낸 요청**을 보고하는 스크립트를 추가합니다.

그 파일들은 이미 존재합니다 — 매 keeper 턴이 `system_prompt`·`tools`·`messages`를 그대로 씁니다. 이 머신에만 **120MB**가 쌓여 있습니다. 그리고 **읽는 코드가 없습니다**: `keeper_checkpoint_store`가 쓰고, 트리의 나머지 참조는 대시보드 *테스트* 하나뿐입니다.

그래서 그 파일들이 이미 답하고 있는 질문들이 측정 대신 논쟁의 대상이었습니다.

## 로컬 트레이스 실측 (최신 12개 스냅샷)

```
snapshot                        total  sys%  tool%  msg%  calls  used/offered            top tool
------------------------------------------------------------------------------------------------
shot-1785253765554-g1.json  1,086,181   0.9    6.4  92.6    612        17/115  keeper_tasks_listx477 (78%)
shot-1785253782523-g1.json  1,235,359   0.7    5.6  93.6    704        19/115  keeper_tasks_listx175 (25%)
shot-1785253757270-g1.json    363,443   2.6   19.1  77.9    102        11/115   keeper_board_postx43 (42%)
...

unused tool schemas  : 672,712 of 833,736 tool bytes (80.7%), 6.2% of payload
longest identical run: keeper_tasks_list x37
```

| | |
|---|---|
| 미호출 도구 스키마 | **672,712 / 833,736 바이트 (80.7%)** |
| 사용/제공 도구 | 12개 스냅샷 전부 **1~19 / 115** |
| 최장 동일입력 연속 호출 | `keeper_tasks_list` **×37** |
| 같은 패턴, 실행 도구 | `Execute` **×22** 연속, 동일 입력 |
| messages 비중 | 66.7 ~ 93.6% |

## 왜 "동일입력 연속" 지표인가

*"`keeper_tasks_list`가 933번 호출됐다"*는 총계입니다. *"동일한 바이트 입력으로 연속 37번 호출됐다"*는 다른 진술입니다 — 입력이 같으니 응답도 같고, **에이전트는 그 37턴 동안 아무것도 배우지 않았습니다.** 후자가 루프의 정의에 가깝고 반증 가능합니다.

그리고 이 지표가 `Execute`에서도 22회로 걸립니다. 조회 도구만의 패턴이 아닙니다.

## 임계값

라운드 넘버가 아니라 각각 근거를 답니다:

| 옵션 | 근거 |
|---|---|
| `--max-top-tool-share` (60%) | 한 도구가 턴 예산 대부분을 차지하면 작업이 아니라 루프 |
| `--max-repeat-run` (10) | 동일 호출 2회는 재시도, 20회는 루프 |
| `--min-tool-usage` (25%) | 제공만 되고 호출 안 되는 도구도 매 턴 스키마 바이트를 씀 |

종료 코드: **0** 정상 리포트 / **1** 임계값 초과 / **2** 경로 오류. 출력 형식을 바꾸지 않고 나중에 게이트로 승격할 수 있습니다. `--json`은 소비용.

## 검증

- 종료 코드 4가지 전부 기대대로 (`0/1/2` + 위반 없음)
- **양성 대조**: 임계값을 느슨하게 하면 `EXIT=0` — 항상 발화하는 게 아니라 판별력이 있음을 확인
- 깨진 JSON만 있는 디렉터리 / 없는 디렉터리 방어
- `pyright` **0 errors**

## 범위

읽기 전용 진단 스크립트 하나입니다. CI에 붙이지 않았고 런타임 코드를 건드리지 않습니다. 게이트로 승격할지, 임계값을 어디에 둘지는 별도 판단입니다.

관련: #26113 (CI가 855개 중 6개만 실행), #26112 (도구 카탈로그 115/13), #26088 (폴링 루프)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
