### PR TITLE
fix(keeper): give direct turns their held task context

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -85,6 +85,11 @@ let direct_turn_observation ~(config : Workspace.config) (meta : keeper_meta) :
     ~config
     ~meta
 
+let direct_turn_task_context ~(current_task : Masc_domain.task option) : string =
+  match current_task with
+  | Some task -> Keeper_unified_prompt.format_current_task task
+  | None -> ""
+
 let direct_owner_conversation_context
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -192,6 +197,7 @@ let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
 
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
+  let direct_turn_task_context = direct_turn_task_context
   let surface_context_to_instructions = surface_context_to_instructions
   let direct_no_progress_retry_reason =
     Keeper_turn_runtime_budget.direct_no_progress_retry_reason
@@ -555,6 +561,18 @@ let run_keeper_invocation_turn_admitted
               | _ -> root
             in
             let live_worktree_change = None in
+            (* The direct-message lane used to construct its prompt before it
+               read the held task. It still observed the task state later for
+               receipt classification, but the model that answered the owner
+               could not see its own in-progress work or handoff. Keep this
+               as fresh per-turn context, exactly like the unified wake lane;
+               it is deliberately not written to conversation history. *)
+            let current_task =
+              Keeper_world_observation_inputs.read_current_task
+                ~config:ctx.config
+                ~meta
+            in
+            let task_context = direct_turn_task_context ~current_task in
             let build_turn_prompt ~base_system_prompt ~messages:_
                 : Keeper_agent_run.turn_prompt =
               (* === SOFT CONTEXT (injected via extra_system_context) === *)
@@ -610,7 +628,8 @@ let run_keeper_invocation_turn_admitted
               in
               let soft_parts = List.filter
                 (fun s -> String.trim s <> "")
-                [ recent_direct_conversation_text;
+                [ task_context;
+                  recent_direct_conversation_text;
                   worktree_text;
                   telemetry_feedback_text;
                   turn_instructions_text ]

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -90,6 +90,23 @@ let direct_turn_task_context ~(current_task : Masc_domain.task option) : string 
   | Some task -> Keeper_unified_prompt.format_current_task task
   | None -> ""
 
+let direct_turn_dynamic_context
+      ~(current_task : Masc_domain.task option)
+      ~(recent_direct_conversation_text : string)
+      ~(worktree_text : string)
+      ~(telemetry_feedback_text : string)
+      ~(turn_instructions_text : string)
+  : string
+  =
+  [ direct_turn_task_context ~current_task
+  ; recent_direct_conversation_text
+  ; worktree_text
+  ; telemetry_feedback_text
+  ; turn_instructions_text
+  ]
+  |> List.filter (fun text -> String.trim text <> "")
+  |> String.concat "\n\n"
+
 let direct_owner_conversation_context
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -197,7 +214,7 @@ let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
 
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
-  let direct_turn_task_context = direct_turn_task_context
+  let direct_turn_dynamic_context = direct_turn_dynamic_context
   let surface_context_to_instructions = surface_context_to_instructions
   let direct_no_progress_retry_reason =
     Keeper_turn_runtime_budget.direct_no_progress_retry_reason
@@ -572,7 +589,6 @@ let run_keeper_invocation_turn_admitted
                 ~config:ctx.config
                 ~meta
             in
-            let task_context = direct_turn_task_context ~current_task in
             let build_turn_prompt ~base_system_prompt ~messages:_
                 : Keeper_agent_run.turn_prompt =
               (* === SOFT CONTEXT (injected via extra_system_context) === *)
@@ -626,15 +642,14 @@ let run_keeper_invocation_turn_admitted
                       |> Model_inference_metrics.render_keeper_prompt_feedback)
                 | Some false | None -> ""
               in
-              let soft_parts = List.filter
-                (fun s -> String.trim s <> "")
-                [ task_context;
-                  recent_direct_conversation_text;
-                  worktree_text;
-                  telemetry_feedback_text;
-                  turn_instructions_text ]
+              let dynamic_context =
+                direct_turn_dynamic_context
+                  ~current_task
+                  ~recent_direct_conversation_text
+                  ~worktree_text
+                  ~telemetry_feedback_text
+                  ~turn_instructions_text
               in
-              let dynamic_context = String.concat "\n\n" soft_parts in
               (* === HARD CONSTRAINTS (stay in system_prompt) === *)
               (* 1. Direct reply mode *)
               let prompt =

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -42,6 +42,12 @@ module For_testing : sig
     channel:string ->
     string
 
+  val direct_turn_task_context :
+    current_task:Masc_domain.task option ->
+    string
+  (** Fresh task context for a direct message. This is prompt-only and must
+      never be appended to the durable conversation history. *)
+
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   (** Format a dashboard co-view context object ({ label, route, scene, fields })
       into turn instructions when no explicit [turn_instructions] is supplied. *)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -42,11 +42,15 @@ module For_testing : sig
     channel:string ->
     string
 
-  val direct_turn_task_context :
+  val direct_turn_dynamic_context :
     current_task:Masc_domain.task option ->
+    recent_direct_conversation_text:string ->
+    worktree_text:string ->
+    telemetry_feedback_text:string ->
+    turn_instructions_text:string ->
     string
-  (** Fresh task context for a direct message. This is prompt-only and must
-      never be appended to the durable conversation history. *)
+  (** Production composition boundary for fresh direct-turn context. The
+      result is prompt-only and must never enter durable conversation history. *)
 
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   (** Format a dashboard co-view context object ({ label, route, scene, fields })

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -34,6 +34,11 @@ val autonomous_wake_marker : string
     tiny by design: the observation frame lives in
     {!turn_prompt_parts.world_state}, not in the message history. *)
 
+val format_current_task : Masc_domain.task -> string
+(** Render one held task as per-turn observation context. The direct-message
+    lane reuses this renderer so it sees the same task identity, status, and
+    handoff as an autonomous wake without persisting that context. *)
+
 (** Build the three-channel unified prompt from keeper state.
 
     @param meta Keeper metadata (identity, soul, goals, instructions)

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -147,6 +147,17 @@ let contains ~needle haystack =
   in
   loop 0
 
+let count_occurrences ~needle haystack =
+  let needle_length = String.length needle in
+  let haystack_length = String.length haystack in
+  let rec loop offset count =
+    if needle_length = 0 || offset + needle_length > haystack_length then count
+    else if String.sub haystack offset needle_length = needle
+    then loop (offset + needle_length) (count + 1)
+    else loop (offset + 1) count
+  in
+  loop 0 0
+
 let make_task ?(handoff_context = None) ~task_status () : Masc_domain.task =
   {
     id = "task-42";
@@ -234,18 +245,36 @@ let test_direct_turn_reuses_current_task_context () =
       ()
   in
   let context =
-    Turn.For_testing.direct_turn_task_context ~current_task:(Some task)
+    Turn.For_testing.direct_turn_dynamic_context
+      ~current_task:(Some task)
+      ~recent_direct_conversation_text:"recent owner message"
+      ~worktree_text:"worktree state"
+      ~telemetry_feedback_text:"telemetry state"
+      ~turn_instructions_text:"turn instructions"
   in
-  check bool "same current-task header" true
-    (contains ~needle:"### Current Task (held by you)" context);
+  check int "current task is injected exactly once" 1
+    (count_occurrences
+       ~needle:"### Current Task (held by you)"
+       context);
   check bool "held task id and title" true
     (contains ~needle:"task-42 — Wire the wake-turn context" context);
   check bool "handoff is available to direct reply" true
-    (contains ~needle:"parser is ready for a direct reply" context)
+    (contains ~needle:"parser is ready for a direct reply" context);
+  check bool "other fresh direct context is preserved" true
+    (contains ~needle:"recent owner message" context)
 
 let test_direct_turn_has_no_synthetic_task_context () =
-  let context = Turn.For_testing.direct_turn_task_context ~current_task:None in
-  check string "no held task means no context" "" context
+  let context =
+    Turn.For_testing.direct_turn_dynamic_context
+      ~current_task:None
+      ~recent_direct_conversation_text:"recent owner message"
+      ~worktree_text:""
+      ~telemetry_feedback_text:""
+      ~turn_instructions_text:""
+  in
+  check bool "no held task means no synthetic task context" false
+    (contains ~needle:"### Current Task" context);
+  check string "non-task context remains" "recent owner message" context
 
 (* --- 2. Threaded turn decision --- *)
 

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -16,6 +16,7 @@ open Alcotest
 
 module WO = Masc.Keeper_world_observation
 module Prompt = Masc.Keeper_unified_prompt
+module Turn = Masc.Keeper_turn
 
 let has_repo_prompts root =
   Sys.file_exists (Filename.concat root "config/prompts/keeper.unified.system.md")
@@ -212,6 +213,40 @@ let test_current_task_section_absent_without_task () =
   check bool "no section without current task" false
     (contains ~needle:"### Current Task" user)
 
+let test_direct_turn_reuses_current_task_context () =
+  let task =
+    make_task
+      ~task_status:
+        (Masc_domain.InProgress
+           { assignee = "wake-context-keeper"; started_at = "2026-07-07T01:00:00Z" })
+      ~handoff_context:
+        (Some
+           {
+             summary = "parser is ready for a direct reply";
+             reason = None;
+             next_step = Some "answer with the current parser status";
+             failure_mode = None;
+             reclaim_policy = None;
+             evidence_refs = [];
+             updated_at = None;
+             updated_by = None;
+           })
+      ()
+  in
+  let context =
+    Turn.For_testing.direct_turn_task_context ~current_task:(Some task)
+  in
+  check bool "same current-task header" true
+    (contains ~needle:"### Current Task (held by you)" context);
+  check bool "held task id and title" true
+    (contains ~needle:"task-42 — Wire the wake-turn context" context);
+  check bool "handoff is available to direct reply" true
+    (contains ~needle:"parser is ready for a direct reply" context)
+
+let test_direct_turn_has_no_synthetic_task_context () =
+  let context = Turn.For_testing.direct_turn_task_context ~current_task:None in
+  check string "no held task means no context" "" context
+
 (* --- 2. Threaded turn decision --- *)
 
 let test_threaded_stimulus_decision_renders_wake_reason () =
@@ -310,6 +345,10 @@ let () =
             test_current_task_section_renders;
           test_case "absent without a held task" `Quick
             test_current_task_section_absent_without_task;
+          test_case "direct reply receives the held task and handoff" `Quick
+            test_direct_turn_reuses_current_task_context;
+          test_case "direct reply invents no task when none is held" `Quick
+            test_direct_turn_has_no_synthetic_task_context;
         ] );
       ( "threaded turn decision",
         [


### PR DESCRIPTION
## Summary
- read the held task before direct-message prompt composition
- reuse the unified task renderer in fresh dynamic context only
- pin the held-task/handoff and no-synthetic-task cases

Fixes #26156

## Validation
- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_turn.ml lib/keeper/keeper_turn.mli lib/keeper/keeper_unified_prompt.mli test/test_keeper_wake_turn_context.ml`
- `ocamlc -stop-after parsing -c` on the four touched OCaml files
- CI Build and Test is the compilation/test authority