### PR TITLE
refactor(keeper): remove replay repair settlement

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -136,7 +136,7 @@ let operator_disposition (receipt : t)
     | External_effect_deferred
     | Turn_wall_clock_timeout
     | Runtime_attempts_exhausted
-    | Gate_replay_operator_attention
+    | Gate_replay_recovery_pending
     | Provider_error _
     | Unknown _ -> false
   in

--- a/lib/keeper/keeper_gate_path.ml
+++ b/lib/keeper/keeper_gate_path.ml
@@ -8,9 +8,5 @@ let replay_results ~base_path =
   Filename.concat (dir ~base_path) "replay-results.json"
 ;;
 
-let replay_repair_settlements ~base_path =
-  Filename.concat (dir ~base_path) "replay-repair-settlements.jsonl"
-;;
-
 let always_allowed ~base_path = Filename.concat (dir ~base_path) "always-allowed.json"
 ;;

--- a/lib/keeper/keeper_gate_path.mli
+++ b/lib/keeper/keeper_gate_path.mli
@@ -9,8 +9,4 @@ val replay_results : base_path:string -> string
     [pending.json]. A rollback binary can therefore keep decoding the v8
     pending snapshot while safely ignoring this additive sidecar. *)
 
-val replay_repair_settlements : base_path:string -> string
-(** Append-only durable audit of explicit operator settlements for
-    process-local replay repair payloads. *)
-
 val always_allowed : base_path:string -> string

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -238,7 +238,7 @@ type pending_repair =
    commit together. Each retained wake makes exactly one persistence-repair
    attempt and never re-runs the effect. This is deliberately process-local:
    after a restart, the missing outcome is delivered as an explicit
-   indeterminate approval result instead of guessing that the effect may be
+   indeterminate HITL message instead of guessing that the effect may be
    repeated. *)
 let pending_repairs = Atomic.make Repair_map.empty
 

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -237,8 +237,9 @@ type pending_repair =
    map. Keep the exact raw outcome until its blob reference and replay journal
    commit together. Each retained wake makes exactly one persistence-repair
    attempt and never re-runs the effect. This is deliberately process-local:
-   after a restart, consumed-without-outcome is unknown and requires operator
-   repair rather than guessing that the effect may be repeated. *)
+   after a restart, the missing outcome is delivered as an explicit
+   indeterminate approval result instead of guessing that the effect may be
+   repeated. *)
 let pending_repairs = Atomic.make Repair_map.empty
 
 let repair_key ~base_path ~approval_id =
@@ -266,215 +267,6 @@ let find_pending_repair ~base_path ~approval_id =
   Repair_map.find_opt
     (repair_key ~base_path ~approval_id)
     (Atomic.get pending_repairs)
-;;
-
-type operator_settlement_decision =
-  | Effect_outcome_reconciled_externally
-  | Approval_authority_removed
-
-type operator_settlement_error =
-  | No_pending_repair of string
-  | Settlement_resolution_lookup_failed of string
-  | Settlement_stage_mismatch of
-      { expected : repair_stage
-      ; actual : repair_stage
-      }
-  | Settlement_actor_missing
-  | Settlement_audit_failed of string
-  | Settlement_source_retirement_failed of string
-
-let operator_settlement_decision_to_string = function
-  | Effect_outcome_reconciled_externally ->
-    "effect_outcome_reconciled_externally"
-  | Approval_authority_removed -> "approval_authority_removed"
-;;
-
-let operator_settlement_error_to_string = function
-  | No_pending_repair approval_id ->
-    Printf.sprintf "no replay repair exists for %s" approval_id
-  | Settlement_resolution_lookup_failed detail ->
-    "operator replay repair resolution lookup failed: " ^ detail
-  | Settlement_stage_mismatch { expected; actual } ->
-    Printf.sprintf
-      "replay repair stage changed: expected %s, actual %s"
-      (repair_stage_to_string expected)
-      (repair_stage_to_string actual)
-  | Settlement_actor_missing -> "operator settlement actor must be non-blank"
-  | Settlement_audit_failed detail ->
-    "operator replay repair settlement audit failed: " ^ detail
-  | Settlement_source_retirement_failed detail ->
-    "operator replay repair source retirement failed: " ^ detail
-;;
-
-let effect_outcome_audit_fields = function
-  | Effect_applied output ->
-    "applied", Some Digestif.SHA256.(digest_string output |> to_hex)
-  | Effect_failed detail ->
-    "failed", Some Digestif.SHA256.(digest_string detail |> to_hex)
-;;
-
-type settlement_target =
-  { keeper_name : string
-  ; operation : replay_operation
-  ; stage : repair_stage
-  ; effect_kind : string
-  ; effect_sha256 : string option
-  }
-
-let settlement_target ~base_path ~approval_id =
-  match find_pending_repair ~base_path ~approval_id with
-  | Some { keeper_name; operation; replay_effect; stage } ->
-    let effect_kind, effect_sha256 =
-      effect_outcome_audit_fields replay_effect
-    in
-    Ok { keeper_name; operation; stage; effect_kind; effect_sha256 }
-  | None ->
-    (match
-       Keeper_approval_queue.approved_resolution_delivery
-         ~base_path
-         ~id:approval_id
-     with
-     | Error error ->
-       Error
-         (Settlement_resolution_lookup_failed
-            (Keeper_approval_queue.grant_error_to_string error))
-     | Ok
-         { request
-         ; state = Keeper_approval_queue.Resolution_consumed
-         ; replay_outcome = None
-         } ->
-       (match replay_operation_of_string request.tool_name with
-        | Some operation ->
-          Ok
-            { keeper_name = request.keeper_name
-            ; operation
-            ; stage = Replay_effect_indeterminate_after_restart
-            ; effect_kind = "unknown_after_restart"
-            ; effect_sha256 = None
-            }
-        | None -> Error (No_pending_repair approval_id))
-     | Ok _ -> Error (No_pending_repair approval_id))
-;;
-
-let settle_pending_repair
-      ~base_path
-      ~approval_id
-      ~expected_stage
-      ~actor
-      ~decision
-  =
-  let actor = String.trim actor in
-  if String.equal actor ""
-  then Error Settlement_actor_missing
-  else
-    match settlement_target ~base_path ~approval_id with
-    | Error _ as error -> error
-    | Ok { keeper_name; operation; stage; effect_kind; effect_sha256 } ->
-      if stage <> expected_stage
-      then
-        Error
-          (Settlement_stage_mismatch
-             { expected = expected_stage; actual = stage })
-      else
-        let source_post_id =
-          Keeper_event_queue.hitl_resolution_post_id_of_approval_id
-            approval_id
-        in
-        let source_present =
-          match
-            Keeper_registry_event_queue.snapshot_result
-              ~base_path
-              keeper_name
-          with
-          | Error detail ->
-            Error (Settlement_source_retirement_failed detail)
-          | Ok queue ->
-            if
-              Keeper_event_queue.to_list queue
-              |> List.exists (fun stimulus ->
-                String.equal stimulus.post_id source_post_id)
-            then Ok ()
-            else
-              Error
-                (Settlement_source_retirement_failed
-                   "exact Gate replay repair source is already absent")
-        in
-        Result.bind source_present (fun () ->
-        let audit =
-          `Assoc
-            [ "schema_version", `Int 1
-            ; ( "event"
-              , `String "gate_replay_repair_settlement_decision_committed" )
-            ; "approval_id", `String approval_id
-            ; "operation", `String (replay_operation_to_string operation)
-            ; "stage", `String (repair_stage_to_string stage)
-            ; "decision", `String (operator_settlement_decision_to_string decision)
-            ; "actor", `String actor
-            ; "effect_kind", `String effect_kind
-            ; ( "effect_sha256"
-              , match effect_sha256 with
-                | Some sha256 -> `String sha256
-                | None -> `Null )
-            ; "settled_at", `String (Masc_domain.now_iso ())
-            ]
-        in
-        let path = Keeper_gate_path.replay_repair_settlements ~base_path in
-        let suffix = Yojson.Safe.to_string audit ^ "\n" in
-        (try
-           match
-             Fs_compat.append_private_jsonl_durable_locked_result
-               path
-               suffix
-           with
-           | Fs_compat.Private_file_succeeded () ->
-             (match
-                Keeper_registry_event_queue.drop_by_post_id
-                  ~base_path
-                  keeper_name
-                  ~post_id:source_post_id
-              with
-              | Ok _ ->
-                forget_pending_repair ~base_path ~approval_id;
-                Ok ()
-              | Error detail ->
-                Error (Settlement_source_retirement_failed detail))
-           | Fs_compat.Private_file_succeeded_with_cleanup_failure
-               { value = (); cleanup_failure } ->
-             Log.Keeper.error
-               "Gate replay repair settlement committed with descriptor cleanup failure approval=%s: %s"
-               approval_id
-               (Fs_compat.private_jsonl_operation_failure_to_string
-                  cleanup_failure);
-             (match
-                Keeper_registry_event_queue.drop_by_post_id
-                  ~base_path
-                  keeper_name
-                  ~post_id:source_post_id
-              with
-              | Ok _ ->
-                forget_pending_repair ~base_path ~approval_id;
-                Ok ()
-              | Error detail ->
-                Error (Settlement_source_retirement_failed detail))
-           | Fs_compat.Private_file_failed error ->
-             Error
-               (Settlement_audit_failed
-                  (Fs_compat.private_jsonl_append_error_to_string error))
-           | Fs_compat.Private_file_failed_with_cleanup_failure
-               { error; cleanup_failure } ->
-             Error
-               (Settlement_audit_failed
-                  (Printf.sprintf
-                     "%s; descriptor_cleanup=%s"
-                     (Fs_compat.private_jsonl_append_error_to_string error)
-                     (Fs_compat.private_jsonl_operation_failure_to_string
-                        cleanup_failure)))
-         with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn ->
-           Error
-             (Settlement_audit_failed
-                (Printexc.to_string exn))))
 ;;
 
 let summarize_execution ~operation (execution : Keeper_tool_execution.t) =
@@ -621,7 +413,7 @@ let append_model_evidence ~approval_id ~user_message = function
       "\n"
       [ user_message
       ; ""
-      ; "Host Gate replay requires operator repair before provider dispatch."
+      ; "Host Gate replay is awaiting automatic recovery before provider dispatch."
       ; Printf.sprintf "- approval_id: %s" approval_id
       ; Printf.sprintf "- operation: %s" operation
       ; Printf.sprintf "- stage: %s" (repair_stage_to_string stage)
@@ -865,13 +657,12 @@ let replay_approved_effect
      | None ->
        (match replay_operation_of_string request.tool_name with
         | None -> Not_applicable
-        | Some operation ->
-          Repair_required
-            { operation = replay_operation_to_string operation
-            ; stage = Replay_effect_indeterminate_after_restart
-            ; detail =
-                "authorization is consumed but no durable replay outcome or in-memory repair payload exists"
-            }))
+        | Some _ ->
+          (* The effect may already have happened. Do not invent an outcome,
+             do not retry it, and do not let this consumed approval block the
+             FIFO forever. [compose_model_message] reuses the durable HITL
+             delivery to give the provider the explicit uncertainty warning. *)
+          Not_applicable))
   | Ok
       { request
       ; state = Keeper_approval_queue.Resolution_unconsumed

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -122,40 +122,6 @@ val replay_operation_of_string : string -> replay_operation option
     call. Exposed because a decode function that exists but is never dispatched
     to is indistinguishable from a working replay at the boundary. *)
 
-type operator_settlement_decision =
-  | Effect_outcome_reconciled_externally
-  | Approval_authority_removed
-
-type operator_settlement_error =
-  | No_pending_repair of string
-  | Settlement_resolution_lookup_failed of string
-  | Settlement_stage_mismatch of
-      { expected : repair_stage
-      ; actual : repair_stage
-      }
-  | Settlement_actor_missing
-  | Settlement_audit_failed of string
-  | Settlement_source_retirement_failed of string
-
-val operator_settlement_decision_to_string :
-  operator_settlement_decision -> string
-
-val operator_settlement_error_to_string : operator_settlement_error -> string
-
-val settle_pending_repair :
-  base_path:string ->
-  approval_id:string ->
-  expected_stage:repair_stage ->
-  actor:string ->
-  decision:operator_settlement_decision ->
-  (unit, operator_settlement_error) result
-(** Durably audit an explicit operator decision before retiring the exact
-    source wake and clearing any process-local raw effect outcome. The caller
-    must name the observed stage, so a stale dashboard action cannot settle a
-    different repair state. Consumed-without-outcome approvals remain
-    settleable after restart with a typed unknown outcome and no fabricated
-    hash. No effect content is persisted. An audit or source-retirement failure
-    leaves any process-local raw outcome in memory. *)
 (** Recover the execute tool arguments from the approved Gate input. Nothing is
     reconstructed: the Gate request wraps the arguments with execution context
     rather than re-encoding them. *)
@@ -170,9 +136,9 @@ val settle_pending_repair :
 
     [gate_context] is the same causal-context provider the model-issued write
     path supplies. A replay whose re-derived input no longer matches its
-    approval falls back to an ordinary Gate request, and a request without
-    causal context cannot be summarized for Auto Judge, which stalls the FIFO
-    drain for every later approval.
+    approval falls back to an ordinary Gate request. A request without causal
+    context cannot be summarized for Auto Judge, which stalls the FIFO drain
+    for every later approval.
 
     Consumption is the durable one-shot grant. A repeated call after a
     successful replay returns the already-recorded durable outcome without

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -104,7 +104,7 @@ let disposition_of_typed_runtime_blocker_class blocker_class =
       Keeper_turn_disposition.Provider_error
         Keeper_turn_terminal_code.Fiber_unresolved
   | Keeper_meta_contract.Gate_replay_repair_required _ ->
-      Keeper_turn_disposition.Gate_replay_operator_attention
+      Keeper_turn_disposition.Gate_replay_recovery_pending
   | Keeper_meta_contract.Sdk_context_window_exceeded
   | Keeper_meta_contract.Sdk_unrecognized_stop_reason
   | Keeper_meta_contract.Sdk_guardrail_violation

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -159,8 +159,6 @@ let gate_replay_repair_facts (meta : keeper_meta) =
     [ "approval_id", `String approval_id
     ; ( "stage"
       , `String (Keeper_internal_error.gate_replay_repair_stage_to_string stage) )
-    ; "operator_action_required", `Bool true
-    ; "operator_action", `String "settle_gate_replay_repair"
     ]
   | Some _ | None -> []
 ;;
@@ -229,7 +227,7 @@ let attention_fields_json_with_approval_queue
         true, Some "fiber_unresolved", Some "inspect_turn_finalization"
       | Some blocker
         when is_gate_replay_repair_blocker_class blocker.blocker_class ->
-        true, Some "gate_replay_repair_required", Some "settle_gate_replay_repair"
+        true, Some "gate_replay_repair_required", Some "inspect_latest_error"
       | Some _ -> true, Some "runtime_blocked", Some "inspect_runtime_blocker"
       | None when meta.paused -> true, Some "paused", Some "resume_or_review"
       | None -> false, None, None

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -121,7 +121,7 @@ let gate_replay_repair_detail_sha256 detail =
 
 let gate_replay_repair_summary ~approval_id ~stage ~detail =
   Printf.sprintf
-    "Gate replay repair requires operator settlement for approval %s at stage %s (detail_sha256=%s); the exact wake remains unacknowledged and the effect must not be re-run."
+    "Gate replay recovery is pending for approval %s at stage %s (detail_sha256=%s); the exact wake remains unacknowledged while recovery retries and the effect must not be re-run."
     approval_id
     (Keeper_internal_error.gate_replay_repair_stage_to_string stage)
     (gate_replay_repair_detail_sha256 detail)

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -15,7 +15,7 @@ type t =
   | External_effect_deferred
   | Turn_wall_clock_timeout
   | Runtime_attempts_exhausted
-  | Gate_replay_operator_attention
+  | Gate_replay_recovery_pending
   | Provider_error of Code.t
   | Unknown of { raw_error : string }
 
@@ -32,7 +32,7 @@ let severity = function
   | External_cancel
   | Turn_wall_clock_timeout
   | Runtime_attempts_exhausted
-  | Gate_replay_operator_attention -> Warn
+  | Gate_replay_recovery_pending -> Warn
   | Provider_error _ -> Bad
   | Unknown _ -> Unknown_bad
 ;;
@@ -47,8 +47,8 @@ let summary = function
     "keeper turn hit a stale/no-progress timeout"
   | Runtime_attempts_exhausted ->
     "runtime attempts exhausted; inspect per-attempt root causes"
-  | Gate_replay_operator_attention ->
-    "Gate replay is awaiting explicit operator settlement"
+  | Gate_replay_recovery_pending ->
+    "Gate replay is awaiting automatic recovery; the effect will not be re-run"
   | Provider_error code -> Printf.sprintf "keeper turn ended with %s" (Code.to_wire code)
   | Unknown { raw_error = "" } ->
     "keeper turn failed without a classified terminal reason"
@@ -62,7 +62,7 @@ let next_action = function
   | External_cancel -> Some "rerun_if_still_relevant"
   | Turn_wall_clock_timeout -> Some "inspect_turn_timeout"
   | Runtime_attempts_exhausted -> Some "inspect_runtime_attempts"
-  | Gate_replay_operator_attention -> Some "settle_gate_replay_repair"
+  | Gate_replay_recovery_pending -> Some "inspect_latest_error"
   | Provider_error _ | Unknown _ -> Some "inspect_latest_error"
 ;;
 
@@ -73,7 +73,7 @@ let to_wire = function
   | External_cancel -> "external_cancel"
   | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
   | Runtime_attempts_exhausted -> "runtime_attempts_exhausted"
-  | Gate_replay_operator_attention -> "gate_replay_repair_required"
+  | Gate_replay_recovery_pending -> "gate_replay_repair_required"
   | Provider_error code -> Code.to_wire code
   | Unknown { raw_error } -> raw_error
 ;;
@@ -106,7 +106,7 @@ let of_wire wire =
   | "external_cancel" -> External_cancel
   | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
   | "runtime_attempts_exhausted" -> Runtime_attempts_exhausted
-  | "gate_replay_repair_required" -> Gate_replay_operator_attention
+  | "gate_replay_repair_required" -> Gate_replay_recovery_pending
   | other ->
     (match Code.of_wire_exact other with
      | Some c -> of_termination_code c
@@ -120,7 +120,7 @@ let is_success = function
   | External_effect_deferred
   | Turn_wall_clock_timeout
   | Runtime_attempts_exhausted
-  | Gate_replay_operator_attention
+  | Gate_replay_recovery_pending
   | Provider_error _
   | Unknown _ -> false
 ;;
@@ -133,7 +133,7 @@ let equal a b =
   | External_cancel, External_cancel
   | Turn_wall_clock_timeout, Turn_wall_clock_timeout
   | Runtime_attempts_exhausted, Runtime_attempts_exhausted
-  | Gate_replay_operator_attention, Gate_replay_operator_attention -> true
+  | Gate_replay_recovery_pending, Gate_replay_recovery_pending -> true
   | Provider_error a, Provider_error b -> String.equal (Code.to_wire a) (Code.to_wire b)
   | Unknown a, Unknown b -> String.equal a.raw_error b.raw_error
   | ( Success
@@ -142,7 +142,7 @@ let equal a b =
     | External_cancel
     | Turn_wall_clock_timeout
     | Runtime_attempts_exhausted
-    | Gate_replay_operator_attention
+    | Gate_replay_recovery_pending
     | Provider_error _
     | Unknown _ ), _ -> false
 ;;

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -29,9 +29,9 @@ type t =
   (** Runtime aggregate outcome: all candidate attempts were exhausted.
           Operators should inspect per-attempt root causes instead of treating
           this as the root cause. *)
-  | Gate_replay_operator_attention
-  (** A host replay effect outcome requires explicit operator settlement.
-      This is neither a provider failure nor runtime exhaustion. *)
+  | Gate_replay_recovery_pending
+  (** A host replay effect outcome is being recovered without replaying the
+      effect. This is neither a provider failure nor runtime exhaustion. *)
   | Provider_error of Keeper_turn_terminal_code.t
   (** Runtime-layer termination promoted to operator-facing
           disposition. The inner code preserves the typed runtime cause
@@ -72,7 +72,7 @@ val next_action : t -> string option
     - [External_cancel] → ["external_cancel"]
     - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
     - [Runtime_attempts_exhausted] → ["runtime_attempts_exhausted"]
-    - [Gate_replay_operator_attention] → ["gate_replay_repair_required"]
+    - [Gate_replay_recovery_pending] → ["gate_replay_repair_required"]
     - [Provider_error code] → [Keeper_turn_terminal_code.to_wire code]
     - [Unknown { raw_error }] → [raw_error] verbatim *)
 val to_wire : t -> string

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -91,7 +91,7 @@ let of_failure ?(tool_call_count = 0) ~raw_error err =
     | Some (Keeper_turn_driver.Gate_replay_repair_required _) ->
       of_disposition
         ~source:"typed_error"
-        Keeper_turn_disposition.Gate_replay_operator_attention
+        Keeper_turn_disposition.Gate_replay_recovery_pending
     | None ->
       (* The driver classifier returned None, meaning err is a generic
          [Agent_sdk.Error.t] not in the masc_internal_error family.

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -164,7 +164,7 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.Input_required
   | Keeper_turn_disposition.External_effect_deferred
   | Keeper_turn_disposition.Turn_wall_clock_timeout
-  | Keeper_turn_disposition.Gate_replay_operator_attention
+  | Keeper_turn_disposition.Gate_replay_recovery_pending
   | Keeper_turn_disposition.Unknown _ -> None
 ;;
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -445,59 +445,6 @@ let dashboard_gate_resolve_http_json ~base_path ~created_by ~(args : Yojson.Safe
           Error (Gone err)))
 ;;
 
-let dashboard_gate_replay_repair_settle_http_json
-      ~base_path
-      ~actor
-      ~(args : Yojson.Safe.t)
-  =
-  let open Result.Syntax in
-  let required_string field =
-    match Safe_ops.json_string_opt field args with
-    | Some value when String.trim value <> "" -> Ok (String.trim value)
-    | Some _ | None -> Error (field ^ " is required")
-  in
-  let* approval_id = required_string "approval_id" in
-  let* stage_raw = required_string "stage" in
-  let* stage =
-    match Keeper_gate_replay.repair_stage_of_string stage_raw with
-    | Some stage
-      when String.equal stage_raw (Keeper_gate_replay.repair_stage_to_string stage) ->
-      Ok stage
-    | Some _ | None -> Error "stage is not a canonical Gate replay repair stage"
-  in
-  let* decision_raw = required_string "decision" in
-  let* decision =
-    match decision_raw with
-    | "effect_outcome_reconciled_externally" ->
-      Ok Keeper_gate_replay.Effect_outcome_reconciled_externally
-    | "approval_authority_removed" ->
-      Ok Keeper_gate_replay.Approval_authority_removed
-    | _ -> Error "decision is not a supported Gate replay repair settlement"
-  in
-  match
-    Keeper_gate_replay.settle_pending_repair
-      ~base_path
-      ~approval_id
-      ~expected_stage:stage
-      ~actor
-      ~decision
-  with
-  | Error error ->
-    Error (Keeper_gate_replay.operator_settlement_error_to_string error)
-  | Ok () ->
-    Ok
-      (`Assoc
-         [ "ok", `Bool true
-         ; "approval_id", `String approval_id
-         ; "stage", `String stage_raw
-         ; ( "decision"
-           , `String
-               (Keeper_gate_replay.operator_settlement_decision_to_string
-                  decision) )
-         ; "source_retired", `Bool true
-         ])
-;;
-
 let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let* fields =

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -94,12 +94,6 @@ val dashboard_gate_resolve_http_json :
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, approval_resolve_http_error) result
 
-val dashboard_gate_replay_repair_settle_http_json :
-  base_path:string ->
-  actor:string ->
-  args:Yojson.Safe.t ->
-  (Yojson.Safe.t, string) result
-
 val dashboard_gate_retry_http_json :
   base_path:string ->
   requested_by:string ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -540,38 +540,6 @@ let handle_gate_resolve_body state operator_name request reqd body_str =
       (operator_error_json (Printf.sprintf "invalid json: %s" message))
 ;;
 
-let handle_gate_replay_repair_settle_body
-      state
-      operator_name
-      request
-      reqd
-      body_str
-  =
-  try
-    let args = Yojson.Safe.from_string body_str in
-    let base_path = (Mcp_server.workspace_config state).Workspace.base_path in
-    match
-      dashboard_gate_replay_repair_settle_http_json
-        ~base_path
-        ~actor:operator_name
-        ~args
-    with
-    | Ok json -> respond_json_value_with_cors request reqd json
-    | Error message ->
-      respond_json_value_with_cors
-        ~status:`Bad_request
-        request
-        reqd
-        (operator_error_json message)
-  with
-  | Yojson.Json_error message ->
-    respond_json_value_with_cors
-      ~status:`Bad_request
-      request
-      reqd
-      (operator_error_json (Printf.sprintf "invalid json: %s" message))
-;;
-
 let handle_gate_retry_body state operator_name request reqd body_str =
   try
     let args = Yojson.Safe.from_string body_str in
@@ -1207,16 +1175,6 @@ let add_routes ~sw ~clock router =
          (fun state operator_name _req reqd ->
            Http.Request.read_body_async reqd
              (handle_gate_resolve_body state operator_name request reqd))
-         request reqd)
-  |> Http.Router.post "/api/v1/dashboard/gate/replay-repair/settle" (fun request reqd ->
-       with_token_permission_auth ~permission:Masc_domain.CanAdmin
-         (fun state operator_name _req reqd ->
-           Http.Request.read_body_async reqd
-             (handle_gate_replay_repair_settle_body
-                state
-                operator_name
-                request
-                reqd))
          request reqd)
   |> Http.Router.post "/api/v1/dashboard/gate/retry" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3066,7 +3066,7 @@ let test_failed_effect_is_durable_and_not_replayed () =
           "durable failure was executed again: %s"
           (Masc.Keeper_gate_replay.outcome_to_string outcome))
 
-let test_consumed_without_outcome_requires_operator_repair () =
+let test_consumed_without_outcome_delivers_indeterminate_result () =
   with_exec_fixture "keeper_gate_replay_unknown_restart"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
       (match
@@ -3132,104 +3132,25 @@ let test_consumed_without_outcome_requires_operator_repair () =
           ()
       in
       (match missing_after_restart with
-       | Masc.Keeper_gate_replay.Repair_required
-          {
-            stage =
-              Masc.Keeper_gate_replay.Replay_effect_indeterminate_after_restart
-          ; _
-          } ->
-        ()
+       | Masc.Keeper_gate_replay.Not_applicable ->
+         ()
        | outcome ->
         failf
-          "consumed unknown outcome entered replay: %s"
+          "consumed unknown outcome blocked normal HITL delivery: %s"
           (Masc.Keeper_gate_replay.outcome_to_string outcome));
-      let source_post_id =
-        Keeper_event_queue.hitl_resolution_post_id_of_approval_id approval_id
-      in
-      (match
-         Masc.Keeper_registry_event_queue.snapshot_result
-           ~base_path:config.base_path
-           meta.name
-       with
-       | Ok queue ->
-         check bool "repair source exists before settlement" true
-           (Keeper_event_queue.to_list queue
-            |> List.exists (fun stimulus ->
-              String.equal stimulus.post_id source_post_id))
-       | Error detail -> fail detail);
-      let settle_args =
-        `Assoc
-          [ "approval_id", `String approval_id
-          ; ( "stage"
-            , `String "effect_indeterminate_after_restart" )
-          ; ( "decision"
-            , `String "effect_outcome_reconciled_externally" )
-          ]
-      in
-      (match
-         Server_dashboard_http
-         .dashboard_gate_replay_repair_settle_http_json
-           ~base_path:config.base_path
-           ~actor:"authenticated-operator"
-           ~args:settle_args
-       with
-       | Ok json ->
-         check bool "settlement retires exact source" true
-           Yojson.Safe.Util.(json |> member "source_retired" |> to_bool)
-       | Error detail -> fail detail);
-      (match
-         Masc.Keeper_registry_event_queue.snapshot_result
-           ~base_path:config.base_path
-           meta.name
-       with
-       | Ok queue ->
-         check bool "settlement removed exact repair source" false
-           (Keeper_event_queue.to_list queue
-            |> List.exists (fun stimulus ->
-              String.equal stimulus.post_id source_post_id))
-       | Error detail -> fail detail);
-      let audit_path =
-        Masc.Keeper_gate_path.replay_repair_settlements
+      let message =
+        Masc.Keeper_gate_replay.compose_model_message
           ~base_path:config.base_path
+          ~user_message:"continue independent work"
+          ~hitl_resolution:(Some resolution)
+          ~replay_delivery:(Some (approval_id, missing_after_restart))
       in
-      let audit = Fs_compat.load_file audit_path in
-      check bool "restart settlement has typed unknown outcome" true
-        (contains_substring audit "\"effect_kind\":\"unknown_after_restart\"");
-      check bool "restart settlement fabricates no effect hash" true
-        (contains_substring audit "\"effect_sha256\":null");
-      check bool "settlement audit contains no raw repair detail" false
+      check bool "indeterminate result is explicit" true
         (contains_substring
-           audit
-           "authorization is consumed but no durable replay outcome");
-      (match
-         Server_dashboard_http
-         .dashboard_gate_replay_repair_settle_http_json
-           ~base_path:config.base_path
-           ~actor:"authenticated-operator"
-           ~args:settle_args
-       with
-       | Error _ -> ()
-       | Ok _ -> fail "same repair settlement succeeded twice");
-      match
-        Masc.Keeper_gate_replay.replay_approved_effect
-          ~config
-          ~meta
-          ~publication_recovery
-          ~turn_sandbox_factory:None
-          ~grant:restarted_grant
-          ~approval_id
-          ()
-      with
-      | Masc.Keeper_gate_replay.Repair_required
-          { stage =
-              Masc.Keeper_gate_replay.Replay_effect_indeterminate_after_restart
-          ; _
-          } ->
-        ()
-      | outcome ->
-        failf
-          "operator settlement caused unknown effect to rerun: %s"
-          (Masc.Keeper_gate_replay.outcome_to_string outcome))
+           message
+           "authorization consumed, replay outcome unavailable");
+      check bool "indeterminate result forbids effect replay" true
+        (contains_substring message "Do not request the operation again"))
 
 let workflow_rejection_message =
   "Invalid task state: Self-approval not allowed: verifier must be a different agent"
@@ -4304,8 +4225,8 @@ let () =
         test_journal_failure_retries_only_persistence;
       test_case "failed effect is durable and not replayed" `Quick
         test_failed_effect_is_durable_and_not_replayed;
-      test_case "consumed outcome gap requires operator repair" `Quick
-        test_consumed_without_outcome_requires_operator_repair;
+      test_case "consumed outcome gap delivers indeterminate result" `Quick
+        test_consumed_without_outcome_delivers_indeterminate_result;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "Manual Gate defers tool_execute before process" `Quick

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -142,7 +142,7 @@ let round_trippable : (string * D.t) list =
   ; "External_cancel", D.External_cancel
   ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
   ; "Runtime_attempts_exhausted", D.Runtime_attempts_exhausted
-  ; "Gate_replay_operator_attention", D.Gate_replay_operator_attention
+  ; "Gate_replay_recovery_pending", D.Gate_replay_recovery_pending
   ; "Unknown empty", D.Unknown { raw_error = "" }
   ; "Unknown raw", D.Unknown { raw_error = "fresh_unmapped_label" }
   ; (* Runtime wires that Code.of_wire_exact recognises losslessly (no payload

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -188,9 +188,9 @@ let test_runtime_stop_reason_controls_durable_source_completion () =
       ~raw_error:"must not classify as provider"
       replay_error
   in
-  check bool "Gate repair has operator-attention disposition" true
+  check bool "Gate repair has recovery-pending disposition" true
     (Masc.Keeper_turn_disposition.equal
-       Masc.Keeper_turn_disposition.Gate_replay_operator_attention
+       Masc.Keeper_turn_disposition.Gate_replay_recovery_pending
        terminal.disposition);
   let internal =
     Keeper_turn_driver.Gate_replay_repair_required
@@ -245,8 +245,8 @@ let test_runtime_stop_reason_controls_durable_source_completion () =
     (Some "gate_replay_repair_required")
     (List.assoc_opt "attention_reason" dashboard_fields
      |> Option.bind Yojson.Safe.Util.to_string_option);
-  check (option string) "dashboard action settles repair"
-    (Some "settle_gate_replay_repair")
+  check (option string) "dashboard action only inspects recovery"
+    (Some "inspect_latest_error")
     (List.assoc_opt "next_human_action" dashboard_fields
      |> Option.bind Yojson.Safe.Util.to_string_option)
 


### PR DESCRIPTION
## Why

Remove the new operator settlement facade rather than give it authority to retire an exact HITL source. The old path wrote an unread sidecar and required a raw HTTP-only action; a crash after audit append could duplicate the record while leaving the source queued.

## Change

- delete the settlement decision/error API, JSONL sidecar path/writer, Dashboard HTTP handler, and route
- rename the terminal disposition to recovery-pending and remove the non-existent settlement action
- when a consumed replay has no durable outcome after restart, keep the effect non-replayable, deliver the existing explicit uncertainty warning through the HITL message, and allow the normal turn/owner ACK path to advance

## Verification

- `scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe test/test_keeper_turn_outcome.exe test/test_keeper_turn_disposition.exe`
- `scripts/dune-local.sh exec test/test_keeper_tool_dispatch_runtime.exe`
- `scripts/dune-local.sh exec test/test_keeper_turn_outcome.exe`
- `scripts/dune-local.sh exec test/test_keeper_turn_disposition.exe`
- `ocamlformat --check` on changed OCaml files; `git diff --check`

Stacked on #26149 (`38fc1af61a70c8b288d37b45c2d934e979696a5e`).