### PR TITLE
fix(tool-blobs): retain by durable reference ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,6 +812,19 @@ jobs:
           oas_pin_targets="@test/runtest-test_keeper_hooks_oas_introspection @test/runtest-test_keeper_execution_join"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${oas_pin_targets}"
 
+      - name: Run tool blob retention suite
+        id: tool_blob_retention_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          tool_blob_targets="@test/runtest-test_tool_blob_store @test/runtest-test_keeper_tool_call_log"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${tool_blob_targets}"
+
       - name: Run operator control suite
         id: operator_control_suite
         # Run regardless of earlier test failures, but only after a successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,7 +822,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          tool_blob_targets="@test/runtest-test_tool_blob_store @test/runtest-test_keeper_tool_call_log"
+          tool_blob_targets="@test/runtest-test_tool_blob_store @test/runtest-test_keeper_tool_call_log @test/runtest-test_keeper_wire_capture"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${tool_blob_targets}"
 
       - name: Run operator control suite

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -46,6 +46,27 @@ let store_for ~masc_root =
       entry)
 ;;
 
+type prune_error =
+  | Retention_prune_failed of
+      { path : string
+      ; detail : string
+      }
+
+let prune_error_to_string = function
+  | Retention_prune_failed { path; detail } ->
+    Printf.sprintf "wire-capture retention prune failed path=%s: %s" path detail
+;;
+
+let prune_expired ~masc_root =
+  let path = wire_capture_dir masc_root in
+  try
+    let { store; retention_days; _ } = store_for ~masc_root in
+    Ok (Dated_jsonl.prune store ~days:retention_days)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Retention_prune_failed { path; detail = Printexc.to_string exn })
+;;
+
 type record_skip_reason = Current_file_byte_cap
 
 let record_skip_reason_label = function

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -33,6 +33,21 @@ val enabled : unit -> bool
     {!Env_config_keeper.KeeperWireCapture}. When [false], {!capture_request} is
     a no-op with no filesystem access. *)
 
+type prune_error =
+  | Retention_prune_failed of
+      { path : string
+      ; detail : string
+      }
+
+val prune_error_to_string : prune_error -> string
+
+val prune_expired : masc_root:string -> (int, prune_error) result
+(** Prune expired capture day-files using this module's configured retention
+    SSOT. This is intentionally ungated: captures written while the feature
+    was enabled must still expire after it is disabled. Startup blob maintenance
+    calls this before scanning references, so expired diagnostic rows cannot
+    retain a blob indefinitely. *)
+
 val capture_request :
   base_path:string ->
   masc_root:string ->

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -340,16 +340,8 @@ let start_flush_fiber ~sw ~clock =
     consumers are updated in the same change to accept either shape. *)
 let blob_aware_output_json (output : string) : Yojson.Safe.t =
   match Tool_output.decode_from_oas output with
-  | Tool_output.Decoded { sha256; bytes; preview; mime } ->
-    `Assoc
-      [ ( "_blob"
-        , `Assoc
-            [ "sha256", `String sha256
-            ; "bytes", `Int bytes
-            ; "mime", `String mime
-            ; "preview", `String preview
-            ] )
-      ]
+  | Tool_output.Decoded reference ->
+    Tool_output.normalized_artifact_ref_to_json reference
   | Tool_output.Not_marker | Tool_output.Invalid_marker _ -> `String output
 ;;
 

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -932,7 +932,38 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
               | Error err ->
                 Log.Server.warn
                   "periodic schedule prune failed: %s"
-                  (Schedule_service.service_error_to_string err))
+                  (Schedule_service.service_error_to_string err));
+             (* Tool-result and Gate-replay blobs are shared across every
+                durable Keeper store. A live server may create a reference
+                after this scan, so the periodic owner records candidates but
+                never deletes. The next startup performs the second scan and
+                deletion before Keeper persistence writers start. Any scan or
+                parse failure retains every blob. *)
+             (match
+                Executor_pool_ref.submit_strict (fun () ->
+                  Tool_blob_maintenance.run
+                    ~base_path:
+                      (Mcp_server.workspace_config state).base_path
+                    ~mode:Tool_blob_maintenance.Observe_only)
+              with
+              | Ok (Ok report) ->
+                if report.candidates_recorded > 0 || report.deleted > 0
+                then
+                  Log.Server.info
+                    "tool blob maintenance: live=%d blobs=%d candidates=%d \
+                     deleted=%d"
+                    report.live_references
+                    report.blobs_observed
+                    report.candidates_recorded
+                    report.deleted
+              | Ok (Error error) ->
+                Log.Server.warn
+                  "tool blob maintenance retained all blobs: %s"
+                  (Tool_blob_maintenance.error_to_string error)
+              | Error error ->
+                Log.Server.warn
+                  "tool blob maintenance executor unavailable: %s"
+                  (Executor_pool_ref.strict_submit_error_to_string error))
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -932,38 +932,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
               | Error err ->
                 Log.Server.warn
                   "periodic schedule prune failed: %s"
-                  (Schedule_service.service_error_to_string err));
-             (* Tool-result and Gate-replay blobs are shared across every
-                durable Keeper store. A live server may create a reference
-                after this scan, so the periodic owner records candidates but
-                never deletes. The next startup performs the second scan and
-                deletion before Keeper persistence writers start. Any scan or
-                parse failure retains every blob. *)
-             (match
-                Executor_pool_ref.submit_strict (fun () ->
-                  Tool_blob_maintenance.run
-                    ~base_path:
-                      (Mcp_server.workspace_config state).base_path
-                    ~mode:Tool_blob_maintenance.Observe_only)
-              with
-              | Ok (Ok report) ->
-                if report.candidates_recorded > 0 || report.deleted > 0
-                then
-                  Log.Server.info
-                    "tool blob maintenance: live=%d blobs=%d candidates=%d \
-                     deleted=%d"
-                    report.live_references
-                    report.blobs_observed
-                    report.candidates_recorded
-                    report.deleted
-              | Ok (Error error) ->
-                Log.Server.warn
-                  "tool blob maintenance retained all blobs: %s"
-                  (Tool_blob_maintenance.error_to_string error)
-              | Error error ->
-                Log.Server.warn
-                  "tool blob maintenance executor unavailable: %s"
-                  (Executor_pool_ref.strict_submit_error_to_string error))
+                  (Schedule_service.service_error_to_string err))
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -912,8 +912,9 @@ let initialize_owner_state_blocking
      two complete startup scans before deletion. A failed scan retains every
      blob and does not make unrelated server startup unavailable. *)
   (match
-     Keeper_wire_capture.prune_expired
-       ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
+     Eio_unix.run_in_systhread (fun () ->
+       Keeper_wire_capture.prune_expired
+         ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state)))
    with
    | Error error ->
      Log.Server.warn

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -906,12 +906,11 @@ let initialize_owner_state_blocking
         (Owner_initialization_failed
            (Keeper_persistence_preparation_failed error))
   in
-  (* The periodic maintenance owner only records unreferenced candidates:
-     deleting while live writers can still create references would race the
-     scan. Preparation above has converged recovery writes, while Keeper
+  (* Preparation above has converged recovery writes, while Keeper
      persistence owners have not started yet, so startup is the sole
-     quiescent deletion boundary. A failed scan retains every blob and does
-     not make unrelated server startup unavailable. *)
+     quiescent scan/deletion boundary. A blob must remain unreferenced across
+     two complete startup scans before deletion. A failed scan retains every
+     blob and does not make unrelated server startup unavailable. *)
   (match
      Eio_unix.run_in_systhread (fun () ->
        Tool_blob_maintenance.run

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -906,6 +906,32 @@ let initialize_owner_state_blocking
         (Owner_initialization_failed
            (Keeper_persistence_preparation_failed error))
   in
+  (* The periodic maintenance owner only records unreferenced candidates:
+     deleting while live writers can still create references would race the
+     scan. Preparation above has converged recovery writes, while Keeper
+     persistence owners have not started yet, so startup is the sole
+     quiescent deletion boundary. A failed scan retains every blob and does
+     not make unrelated server startup unavailable. *)
+  (match
+     Eio_unix.run_in_systhread (fun () ->
+       Tool_blob_maintenance.run
+         ~base_path
+         ~mode:Tool_blob_maintenance.Delete_previous_candidates)
+   with
+   | Ok report ->
+     if report.candidates_recorded > 0 || report.deleted > 0
+     then
+       Log.Server.info
+         "startup tool blob maintenance: live=%d blobs=%d candidates=%d \
+          deleted=%d"
+         report.live_references
+         report.blobs_observed
+         report.candidates_recorded
+         report.deleted
+   | Error error ->
+     Log.Server.warn
+       "startup tool blob maintenance stopped; no further blobs were deleted: %s"
+       (Tool_blob_maintenance.error_to_string error));
   Runtime_settings.ensure_init ();
   Runtime_params.restore ~base_path;
   Log.Server.info "Runtime_params restored from %s" base_path;

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -912,25 +912,39 @@ let initialize_owner_state_blocking
      two complete startup scans before deletion. A failed scan retains every
      blob and does not make unrelated server startup unavailable. *)
   (match
-     Eio_unix.run_in_systhread (fun () ->
-       Tool_blob_maintenance.run
-         ~base_path
-         ~mode:Tool_blob_maintenance.Delete_previous_candidates)
+     Keeper_wire_capture.prune_expired
+       ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
    with
-   | Ok report ->
-     if report.candidates_recorded > 0 || report.deleted > 0
-     then
-       Log.Server.info
-         "startup tool blob maintenance: live=%d blobs=%d candidates=%d \
-          deleted=%d"
-         report.live_references
-         report.blobs_observed
-         report.candidates_recorded
-         report.deleted
    | Error error ->
      Log.Server.warn
-       "startup tool blob maintenance stopped; no further blobs were deleted: %s"
-       (Tool_blob_maintenance.error_to_string error));
+       "startup tool blob maintenance stopped; wire-capture retention prune failed: %s"
+       (Keeper_wire_capture.prune_error_to_string error)
+   | Ok wire_capture_pruned ->
+     if wire_capture_pruned > 0
+     then
+       Log.Server.info
+         "startup wire-capture retention: pruned %d expired day-file(s)"
+         wire_capture_pruned;
+     (match
+        Eio_unix.run_in_systhread (fun () ->
+          Tool_blob_maintenance.run
+            ~base_path
+            ~mode:Tool_blob_maintenance.Delete_previous_candidates)
+      with
+      | Ok report ->
+        if report.candidates_recorded > 0 || report.deleted > 0
+        then
+          Log.Server.info
+            "startup tool blob maintenance: live=%d blobs=%d candidates=%d \
+             deleted=%d"
+            report.live_references
+            report.blobs_observed
+            report.candidates_recorded
+            report.deleted
+      | Error error ->
+        Log.Server.warn
+          "startup tool blob maintenance stopped; no further blobs were deleted: %s"
+          (Tool_blob_maintenance.error_to_string error)));
   Runtime_settings.ensure_init ();
   Runtime_params.restore ~base_path;
   Log.Server.info "Runtime_params restored from %s" base_path;

--- a/lib/tool_blob_store/dune
+++ b/lib/tool_blob_store/dune
@@ -11,8 +11,8 @@
  (name masc_tool_blob_store)
  (public_name masc.masc_tool_blob_store)
  (wrapped false)
- (modules tool_blob_store tool_output)
+ (modules tool_blob_store tool_output tool_blob_maintenance)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries digestif digestif.c unix fs_compat masc_core))
+ (libraries digestif digestif.c unix yojson fs_compat masc_core))

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -5,6 +5,10 @@ type mode =
   | Delete_previous_candidates
 
 type error =
+  | Clustered_durable_roots_uncoordinated of
+      { path : string
+      ; entries : int
+      }
   | Durable_source_stat_failed of
       { path : string
       ; reason : string
@@ -47,6 +51,12 @@ type report =
   }
 
 let error_to_string = function
+  | Clustered_durable_roots_uncoordinated { path; entries } ->
+    Printf.sprintf
+      "tool blob maintenance requires cross-cluster writer coordination before \
+       scanning shared blobs path=%s entries=%d"
+      path
+      entries
   | Durable_source_stat_failed { path; reason } ->
     Printf.sprintf "durable source stat failed path=%s: %s" path reason
   | Durable_source_read_failed { path; reason } ->
@@ -235,13 +245,75 @@ let durable_consumer_roots ~base_path =
   List.map (Filename.concat runtime_root) durable_consumer_basenames
 ;;
 
-let live_references ~base_path =
-  let same_directory (left : Unix.stats) (right : Unix.stats) =
-    left.st_dev = right.st_dev
-    && left.st_ino = right.st_ino
-    && left.st_kind = Unix.S_DIR
-    && right.st_kind = Unix.S_DIR
+let same_directory_snapshot (left : Unix.stats) (right : Unix.stats) =
+  left.st_dev = right.st_dev
+  && left.st_ino = right.st_ino
+  && left.st_kind = Unix.S_DIR
+  && right.st_kind = Unix.S_DIR
+  && left.st_size = right.st_size
+  && left.st_mtime = right.st_mtime
+  && left.st_ctime = right.st_ctime
+;;
+
+let reject_uncoordinated_cluster_roots ~base_path =
+  let path =
+    Filename.concat
+      (Common.masc_dir_from_base_path ~base_path)
+      "clusters"
   in
+  let inspect () =
+    match
+      Fs_compat.inspect_owned_directory_chain
+        ~ownership_root:base_path
+        path
+    with
+    | Ok observation -> Ok observation
+    | Error rejection ->
+      Error
+        (Durable_source_stat_failed
+           { path
+           ; reason =
+               Fs_compat.owned_directory_chain_rejection_to_string
+                 rejection
+           })
+  in
+  match inspect () with
+  | Error _ as error -> error
+  | Ok Fs_compat.Owned_directory_missing -> Ok ()
+  | Ok (Fs_compat.Owned_directory before) ->
+    (try
+       let entries = Sys.readdir path in
+       match inspect () with
+       | Error _ as error -> error
+       | Ok Fs_compat.Owned_directory_missing ->
+         Error
+           (Durable_source_stat_failed
+              { path; reason = "cluster root disappeared during scan" })
+       | Ok (Fs_compat.Owned_directory after) ->
+         if not (same_directory_snapshot before after)
+         then
+           Error
+             (Durable_source_stat_failed
+                { path; reason = "cluster root changed during scan" })
+         else if Array.length entries = 0
+         then Ok ()
+         else
+           Error
+             (Clustered_durable_roots_uncoordinated
+                { path; entries = Array.length entries })
+     with
+     | Sys_error reason ->
+       Error (Durable_source_stat_failed { path; reason })
+     | Unix.Unix_error (code, fn, arg) ->
+       Error
+         (Durable_source_stat_failed
+            { path
+            ; reason =
+                Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+            }))
+;;
+
+let live_references ~base_path =
   let read_directory path =
     let inspect () =
       match
@@ -272,7 +344,7 @@ let live_references ~base_path =
             (Durable_source_stat_failed
                { path; reason = "directory disappeared during scan" })
         | Ok (Fs_compat.Owned_directory after) ->
-          if same_directory before after
+          if same_directory_snapshot before after
           then Ok (Some entries)
           else
             Error
@@ -466,6 +538,7 @@ let save_candidate_snapshot ~base_path candidates =
 
 let run ~base_path ~mode =
   let open Result.Syntax in
+  let* () = reject_uncoordinated_cluster_roots ~base_path in
   let store = Tool_blob_store.create ~base_path in
   let* live = live_references ~base_path in
   let* previous_candidates = load_candidate_snapshot ~base_path in

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -1,0 +1,408 @@
+module String_set = Set_util.StringSet
+
+type mode =
+  | Observe_only
+  | Delete_previous_candidates
+
+type error =
+  | Durable_source_stat_failed of
+      { path : string
+      ; reason : string
+      }
+  | Durable_source_read_failed of
+      { path : string
+      ; reason : string
+      }
+  | Malformed_artifact_reference of
+      { path : string
+      ; line : int
+      ; offset : int
+      ; detail : string
+      }
+  | Candidate_snapshot_invalid of
+      { path : string
+      ; detail : string
+      }
+  | Candidate_snapshot_read_failed of
+      { path : string
+      ; detail : string
+      }
+  | Candidate_snapshot_write_failed of
+      { path : string
+      ; detail : string
+      }
+  | Blob_listing_failed of Tool_blob_store.list_error
+  | Blob_delete_failed of Tool_blob_store.delete_error
+
+type report =
+  { live_references : int
+  ; blobs_observed : int
+  ; candidates_recorded : int
+  ; deleted : int
+  }
+
+let error_to_string = function
+  | Durable_source_stat_failed { path; reason } ->
+    Printf.sprintf "durable source stat failed path=%s: %s" path reason
+  | Durable_source_read_failed { path; reason } ->
+    Printf.sprintf "durable source read failed path=%s: %s" path reason
+  | Malformed_artifact_reference { path; line; offset; detail } ->
+    Printf.sprintf
+      "malformed artifact reference path=%s line=%d offset=%d: %s"
+      path
+      line
+      offset
+      detail
+  | Candidate_snapshot_invalid { path; detail } ->
+    Printf.sprintf "blob maintenance candidate snapshot invalid path=%s: %s" path detail
+  | Candidate_snapshot_read_failed { path; detail } ->
+    Printf.sprintf
+      "blob maintenance candidate snapshot read failed path=%s: %s"
+      path
+      detail
+  | Candidate_snapshot_write_failed { path; detail } ->
+    Printf.sprintf "blob maintenance candidate snapshot write failed path=%s: %s" path detail
+  | Blob_listing_failed error ->
+    Printf.sprintf
+      "blob listing failed path=%s: %s"
+      error.Tool_blob_store.path
+      error.reason
+  | Blob_delete_failed error ->
+    Printf.sprintf
+      "blob delete failed sha256=%s path=%s: %s"
+      error.Tool_blob_store.sha256
+      error.path
+      error.reason
+;;
+
+let candidate_snapshot_path ~base_path =
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path)
+       "tool_blob_maintenance")
+    "candidates.json"
+;;
+
+let add_references ~path ~line references text =
+  match Tool_output.artifact_refs_in_text text with
+  | Ok found ->
+    Ok
+      (List.fold_left
+         (fun acc reference ->
+            String_set.add reference.Tool_output.sha256 acc)
+         references
+         found)
+  | Error error ->
+    Error
+      (Malformed_artifact_reference
+         { path
+         ; line
+         ; offset = error.offset
+         ; detail = error.detail
+         })
+;;
+
+let rec references_in_json ~path ~line references = function
+  | `String text -> add_references ~path ~line references text
+  | `Assoc fields ->
+    List.fold_left
+      (fun result (_, value) ->
+         Result.bind result (fun current ->
+           references_in_json ~path ~line current value))
+      (Ok references)
+      fields
+  | `List values
+  | `Tuple values ->
+    List.fold_left
+      (fun result value ->
+         Result.bind result (fun current ->
+           references_in_json ~path ~line current value))
+      (Ok references)
+      values
+  | `Variant (_, Some value) ->
+    references_in_json ~path ~line references value
+  | `Null
+  | `Bool _
+  | `Int _
+  | `Intlit _
+  | `Float _
+  | `Variant (_, None) ->
+    Ok references
+;;
+
+let references_in_file ~ownership_root path =
+  match Fs_compat.load_owned_regular_file ~ownership_root path with
+  | Error error ->
+    Error
+      (Durable_source_read_failed
+         { path
+         ; reason =
+             Fs_compat.owned_regular_file_read_error_to_string error
+         })
+  | Ok None ->
+    Error
+      (Durable_source_read_failed
+         { path; reason = "durable source disappeared during scan" })
+  | Ok (Some payload) ->
+    try
+      references_in_json
+        ~path
+        ~line:1
+        String_set.empty
+        (Yojson.Safe.from_string payload)
+    with
+    | Yojson.Json_error _ ->
+      payload
+      |> String.split_on_char '\n'
+      |> List.fold_left
+           (fun (line_number, result) line ->
+              let next =
+                Result.bind result (fun references ->
+                  try
+                    references_in_json
+                      ~path
+                      ~line:line_number
+                      references
+                      (Yojson.Safe.from_string line)
+                  with
+                  | Yojson.Json_error _ ->
+                    add_references
+                      ~path
+                      ~line:line_number
+                      references
+                      line)
+              in
+              line_number + 1, next)
+           (1, Ok String_set.empty)
+      |> snd
+;;
+
+let live_references ~base_path =
+  let runtime_root = Common.masc_dir_from_base_path ~base_path in
+  let blob_root = Tool_blob_store.(create ~base_path |> root_dir) in
+  let candidate_path = candidate_snapshot_path ~base_path in
+  let same_directory (left : Unix.stats) (right : Unix.stats) =
+    left.st_dev = right.st_dev
+    && left.st_ino = right.st_ino
+    && left.st_kind = Unix.S_DIR
+    && right.st_kind = Unix.S_DIR
+  in
+  let read_directory path =
+    let inspect () =
+      match
+        Fs_compat.inspect_owned_directory_chain
+          ~ownership_root:base_path
+          path
+      with
+      | Ok observation -> Ok observation
+      | Error rejection ->
+        Error
+          (Durable_source_stat_failed
+             { path
+             ; reason =
+                 Fs_compat.owned_directory_chain_rejection_to_string
+                   rejection
+             })
+    in
+    match inspect () with
+    | Error _ as error -> error
+    | Ok Fs_compat.Owned_directory_missing -> Ok None
+    | Ok (Fs_compat.Owned_directory before) ->
+      try
+        let entries = Sys.readdir path in
+        match inspect () with
+        | Error _ as error -> error
+        | Ok Fs_compat.Owned_directory_missing ->
+          Error
+            (Durable_source_stat_failed
+               { path; reason = "directory disappeared during scan" })
+        | Ok (Fs_compat.Owned_directory after) ->
+          if same_directory before after
+          then Ok (Some entries)
+          else
+            Error
+              (Durable_source_stat_failed
+                 { path; reason = "directory identity changed during scan" })
+      with
+      | Sys_error reason ->
+        Error (Durable_source_stat_failed { path; reason })
+      | Unix.Unix_error (code, fn, arg) ->
+        Error
+          (Durable_source_stat_failed
+             { path
+             ; reason =
+                 Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+             })
+  in
+  let rec scan_entry path references =
+    if String.equal path blob_root || String.equal path candidate_path
+    then Ok references
+    else
+      try
+        match (Unix.lstat path).Unix.st_kind with
+        | Unix.S_DIR -> scan_directory path references
+        | Unix.S_REG ->
+          Result.map
+            (String_set.union references)
+            (references_in_file ~ownership_root:base_path path)
+        | Unix.S_LNK ->
+          Error
+            (Durable_source_stat_failed
+               { path
+               ; reason =
+                   "symbolic links are not durable maintenance sources"
+               })
+        | Unix.S_CHR
+        | Unix.S_BLK
+        | Unix.S_FIFO
+        | Unix.S_SOCK ->
+          Ok references
+      with
+      | Sys_error reason ->
+        Error (Durable_source_stat_failed { path; reason })
+      | Unix.Unix_error (code, fn, arg) ->
+        Error
+          (Durable_source_stat_failed
+             { path
+             ; reason =
+                 Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+             })
+  and scan_directory path references =
+    match read_directory path with
+    | Error _ as error -> error
+    | Ok None ->
+      if String.equal path runtime_root
+      then Ok references
+      else
+        Error
+          (Durable_source_stat_failed
+             { path; reason = "directory disappeared during scan" })
+    | Ok (Some entries) ->
+      entries
+      |> Array.to_list
+      |> List.sort String.compare
+      |> List.fold_left
+           (fun result name ->
+              Result.bind result (fun current ->
+                scan_entry (Filename.concat path name) current))
+           (Ok references)
+  in
+  scan_directory runtime_root String_set.empty
+;;
+
+let candidate_snapshot_to_json candidates =
+  `Assoc
+    [ "schema_version", `Int 1
+    ; ( "unreferenced_candidates"
+      , `List
+          (String_set.elements candidates
+           |> List.map (fun sha256 -> `String sha256)) )
+    ]
+;;
+
+let candidate_snapshot_of_json ~path = function
+  | `Assoc
+      [ "schema_version", `Int 1
+      ; "unreferenced_candidates", `List candidates
+      ] ->
+    let rec decode acc = function
+      | [] -> Ok acc
+      | `String sha256 :: rest ->
+        (match Tool_blob_store.validate_sha256 sha256 with
+         | Ok () -> decode (String_set.add sha256 acc) rest
+         | Error invalid ->
+           Error
+             (Candidate_snapshot_invalid
+                { path
+                ; detail =
+                    Tool_blob_store.invalid_sha256_to_string invalid
+                }))
+      | _ ->
+        Error
+          (Candidate_snapshot_invalid
+             { path; detail = "candidate hashes must be strings" })
+    in
+    decode String_set.empty candidates
+  | _ ->
+    Error
+      (Candidate_snapshot_invalid
+         { path
+         ; detail =
+             "expected exact schema_version=1 and unreferenced_candidates"
+         })
+;;
+
+let load_candidate_snapshot ~base_path =
+  let path = candidate_snapshot_path ~base_path in
+  match Fs_compat.load_owned_regular_file ~ownership_root:base_path path with
+  | Ok None -> Ok String_set.empty
+  | Ok (Some payload) ->
+    (try
+       Yojson.Safe.from_string payload |> candidate_snapshot_of_json ~path
+     with
+    | Yojson.Json_error detail ->
+      Error (Candidate_snapshot_invalid { path; detail }))
+  | Error error ->
+    Error
+      (Candidate_snapshot_read_failed
+         { path
+         ; detail =
+             Fs_compat.owned_regular_file_read_error_to_string error
+         })
+;;
+
+let save_candidate_snapshot ~base_path candidates =
+  let path = candidate_snapshot_path ~base_path in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let payload =
+    candidate_snapshot_to_json candidates
+    |> Yojson.Safe.pretty_to_string
+  in
+  match Fs_compat.save_file_atomic path payload with
+  | Ok () -> Ok ()
+  | Error detail ->
+    Error (Candidate_snapshot_write_failed { path; detail })
+;;
+
+let run ~base_path ~mode =
+  let open Result.Syntax in
+  let store = Tool_blob_store.create ~base_path in
+  let* live = live_references ~base_path in
+  let* previous_candidates = load_candidate_snapshot ~base_path in
+  let* blob_list =
+    match Tool_blob_store.list_all_result store with
+    | Ok blobs -> Ok blobs
+    | Error error -> Error (Blob_listing_failed error)
+  in
+  let blobs =
+    blob_list
+    |> List.fold_left
+         (fun acc sha256 -> String_set.add sha256 acc)
+         String_set.empty
+  in
+  let current_candidates = String_set.diff blobs live in
+  let* () = save_candidate_snapshot ~base_path current_candidates in
+  let deletable =
+    match mode with
+    | Observe_only -> String_set.empty
+    | Delete_previous_candidates ->
+      String_set.inter previous_candidates current_candidates
+  in
+  let* deleted =
+    String_set.fold
+      (fun sha256 result ->
+         let* count = result in
+         match Tool_blob_store.delete store ~sha256 with
+         | Ok true -> Ok (count + 1)
+         | Ok false -> Ok count
+         | Error error -> Error (Blob_delete_failed error))
+      deletable
+      (Ok 0)
+  in
+  Ok
+    { live_references = String_set.cardinal live
+    ; blobs_observed = String_set.cardinal blobs
+    ; candidates_recorded = String_set.cardinal current_candidates
+    ; deleted
+    }
+;;

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -19,6 +19,11 @@ type error =
       ; offset : int
       ; detail : string
       }
+  | Malformed_structured_artifact_reference of
+      { path : string
+      ; line : int
+      ; detail : string
+      }
   | Candidate_snapshot_invalid of
       { path : string
       ; detail : string
@@ -52,6 +57,12 @@ let error_to_string = function
       path
       line
       offset
+      detail
+  | Malformed_structured_artifact_reference { path; line; detail } ->
+    Printf.sprintf
+      "malformed structured artifact reference path=%s line=%d: %s"
+      path
+      line
       detail
   | Candidate_snapshot_invalid { path; detail } ->
     Printf.sprintf "blob maintenance candidate snapshot invalid path=%s: %s" path detail
@@ -104,13 +115,21 @@ let add_references ~path ~line references text =
 
 let rec references_in_json ~path ~line references = function
   | `String text -> add_references ~path ~line references text
-  | `Assoc fields ->
-    List.fold_left
-      (fun result (_, value) ->
-         Result.bind result (fun current ->
-           references_in_json ~path ~line current value))
-      (Ok references)
-      fields
+  | (`Assoc fields as json) ->
+    (match Tool_output.normalized_artifact_ref_of_json json with
+     | Tool_output.Decoded_normalized_artifact_ref reference ->
+       Ok (String_set.add reference.Tool_output.sha256 references)
+     | Tool_output.Invalid_normalized_artifact_ref { detail } ->
+       Error
+         (Malformed_structured_artifact_reference
+            { path; line; detail })
+     | Tool_output.Not_normalized_artifact_ref ->
+       List.fold_left
+         (fun result (_, value) ->
+            Result.bind result (fun current ->
+              references_in_json ~path ~line current value))
+         (Ok references)
+         fields)
   | `List values
   | `Tuple values ->
     List.fold_left

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -113,6 +113,19 @@ let add_references ~path ~line references text =
          })
 ;;
 
+let contains_substring ~needle text =
+  let needle_length = String.length needle in
+  let text_length = String.length text in
+  let rec loop offset =
+    if offset + needle_length > text_length
+    then false
+    else if String.sub text offset needle_length = needle
+    then true
+    else loop (offset + 1)
+  in
+  needle_length = 0 || loop 0
+;;
+
 let rec references_in_json ~path ~line references = function
   | `String text -> add_references ~path ~line references text
   | (`Assoc fields as json) ->
@@ -180,12 +193,23 @@ let references_in_file ~ownership_root path =
                       references
                       (Yojson.Safe.from_string line)
                   with
-                  | Yojson.Json_error _ ->
-                    add_references
-                      ~path
-                      ~line:line_number
-                      references
-                      line)
+                  | Yojson.Json_error detail ->
+                    if contains_substring ~needle:"\"_blob\"" line
+                    then
+                      Error
+                        (Malformed_structured_artifact_reference
+                           { path
+                           ; line = line_number
+                           ; detail =
+                               "unparseable durable row contains a _blob key: "
+                               ^ detail
+                           })
+                    else
+                      add_references
+                        ~path
+                        ~line:line_number
+                        references
+                        line)
               in
               line_number + 1, next)
            (1, Ok String_set.empty)
@@ -376,13 +400,64 @@ let load_candidate_snapshot ~base_path =
 
 let save_candidate_snapshot ~base_path candidates =
   let path = candidate_snapshot_path ~base_path in
-  Fs_compat.mkdir_p (Filename.dirname path);
+  let parent = Filename.dirname path in
   let payload =
     candidate_snapshot_to_json candidates
     |> Yojson.Safe.pretty_to_string
   in
-  match Fs_compat.save_file_atomic path payload with
-  | Ok () -> Ok ()
+  let inspect_parent () =
+    match
+      Fs_compat.inspect_owned_directory_chain
+        ~ownership_root:base_path
+        parent
+    with
+    | Ok observation -> Ok observation
+    | Error rejection ->
+      Error
+        (Fs_compat.owned_directory_chain_rejection_to_string rejection)
+  in
+  let open Result.Syntax in
+  let* before =
+    match inspect_parent () with
+    | Error detail ->
+      Error (Candidate_snapshot_write_failed { path; detail })
+    | Ok Fs_compat.Owned_directory_missing ->
+      (try
+         Fs_compat.mkdir_p parent;
+         match inspect_parent () with
+         | Ok (Fs_compat.Owned_directory stats) -> Ok stats
+         | Ok Fs_compat.Owned_directory_missing ->
+           Error
+             (Candidate_snapshot_write_failed
+                { path; detail = "candidate snapshot parent was not created" })
+         | Error detail ->
+           Error (Candidate_snapshot_write_failed { path; detail })
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         Error
+           (Candidate_snapshot_write_failed
+              { path; detail = Printexc.to_string exn }))
+    | Ok (Fs_compat.Owned_directory stats) -> Ok stats
+  in
+  let* () =
+    match Fs_compat.save_file_atomic_strict path payload with
+    | Ok () -> Ok ()
+    | Error detail ->
+      Error (Candidate_snapshot_write_failed { path; detail })
+  in
+  match inspect_parent () with
+  | Ok (Fs_compat.Owned_directory after)
+    when before.st_dev = after.st_dev && before.st_ino = after.st_ino ->
+    Ok ()
+  | Ok (Fs_compat.Owned_directory _) ->
+    Error
+      (Candidate_snapshot_write_failed
+         { path; detail = "candidate snapshot parent identity changed" })
+  | Ok Fs_compat.Owned_directory_missing ->
+    Error
+      (Candidate_snapshot_write_failed
+         { path; detail = "candidate snapshot parent disappeared" })
   | Error detail ->
     Error (Candidate_snapshot_write_failed { path; detail })
 ;;

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -192,10 +192,23 @@ let references_in_file ~ownership_root path =
       |> snd
 ;;
 
-let live_references ~base_path =
+let durable_consumer_basenames =
+  [ "gate"
+  ; Common.keepers_runtime_dirname
+  ; "keeper_chat"
+  ; "messages"
+  ; "tool_calls"
+  ; "traces"
+  ; Common.keeper_runtime_store_dirname Common.Keeper_trajectories
+  ]
+;;
+
+let durable_consumer_roots ~base_path =
   let runtime_root = Common.masc_dir_from_base_path ~base_path in
-  let blob_root = Tool_blob_store.(create ~base_path |> root_dir) in
-  let candidate_path = candidate_snapshot_path ~base_path in
+  List.map (Filename.concat runtime_root) durable_consumer_basenames
+;;
+
+let live_references ~base_path =
   let same_directory (left : Unix.stats) (right : Unix.stats) =
     left.st_dev = right.st_dev
     && left.st_ino = right.st_ino
@@ -250,48 +263,38 @@ let live_references ~base_path =
              })
   in
   let rec scan_entry path references =
-    if String.equal path blob_root || String.equal path candidate_path
-    then Ok references
-    else
-      try
-        match (Unix.lstat path).Unix.st_kind with
-        | Unix.S_DIR -> scan_directory path references
-        | Unix.S_REG ->
-          Result.map
-            (String_set.union references)
-            (references_in_file ~ownership_root:base_path path)
-        | Unix.S_LNK ->
-          Error
-            (Durable_source_stat_failed
-               { path
-               ; reason =
-                   "symbolic links are not durable maintenance sources"
-               })
-        | Unix.S_CHR
-        | Unix.S_BLK
-        | Unix.S_FIFO
-        | Unix.S_SOCK ->
-          Ok references
-      with
-      | Sys_error reason ->
-        Error (Durable_source_stat_failed { path; reason })
-      | Unix.Unix_error (code, fn, arg) ->
+    try
+      match (Unix.lstat path).Unix.st_kind with
+      | Unix.S_DIR -> scan_directory path references
+      | Unix.S_REG ->
+        Result.map
+          (String_set.union references)
+          (references_in_file ~ownership_root:base_path path)
+      | Unix.S_LNK ->
         Error
           (Durable_source_stat_failed
              { path
-             ; reason =
-                 Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+             ; reason = "symbolic links are not durable maintenance sources"
              })
+      | Unix.S_CHR
+      | Unix.S_BLK
+      | Unix.S_FIFO
+      | Unix.S_SOCK ->
+        Ok references
+    with
+    | Sys_error reason ->
+      Error (Durable_source_stat_failed { path; reason })
+    | Unix.Unix_error (code, fn, arg) ->
+      Error
+        (Durable_source_stat_failed
+           { path
+           ; reason =
+               Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+           })
   and scan_directory path references =
     match read_directory path with
     | Error _ as error -> error
-    | Ok None ->
-      if String.equal path runtime_root
-      then Ok references
-      else
-        Error
-          (Durable_source_stat_failed
-             { path; reason = "directory disappeared during scan" })
+    | Ok None -> Ok references
     | Ok (Some entries) ->
       entries
       |> Array.to_list
@@ -302,7 +305,12 @@ let live_references ~base_path =
                 scan_entry (Filename.concat path name) current))
            (Ok references)
   in
-  scan_directory runtime_root String_set.empty
+  durable_consumer_roots ~base_path
+  |> List.fold_left
+       (fun result root ->
+          Result.bind result (fun references ->
+            scan_directory root references))
+       (Ok String_set.empty)
 ;;
 
 let candidate_snapshot_to_json candidates =

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -130,22 +130,18 @@ let rec references_in_json ~path ~line references = function
               references_in_json ~path ~line current value))
          (Ok references)
          fields)
-  | `List values
-  | `Tuple values ->
+  | `List values ->
     List.fold_left
       (fun result value ->
          Result.bind result (fun current ->
            references_in_json ~path ~line current value))
       (Ok references)
       values
-  | `Variant (_, Some value) ->
-    references_in_json ~path ~line references value
   | `Null
   | `Bool _
   | `Int _
   | `Intlit _
-  | `Float _
-  | `Variant (_, None) ->
+  | `Float _ ->
     Ok references
 ;;
 

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -224,6 +224,9 @@ let durable_consumer_basenames =
   ; "tool_calls"
   ; "traces"
   ; Common.keeper_runtime_store_dirname Common.Keeper_trajectories
+  (* The bounded diagnostic store owns every blob reference for as long as
+     its dated JSONL row remains inside wire-capture retention. *)
+  ; "wire-capture"
   ]
 ;;
 
@@ -422,22 +425,21 @@ let save_candidate_snapshot ~base_path candidates =
     | Error detail ->
       Error (Candidate_snapshot_write_failed { path; detail })
     | Ok Fs_compat.Owned_directory_missing ->
-      (try
-         Fs_compat.mkdir_p parent;
-         match inspect_parent () with
-         | Ok (Fs_compat.Owned_directory stats) -> Ok stats
-         | Ok Fs_compat.Owned_directory_missing ->
+      Safe_ops.handle
+        (fun () ->
+           Fs_compat.mkdir_p parent;
+           match inspect_parent () with
+           | Ok (Fs_compat.Owned_directory stats) -> Ok stats
+           | Ok Fs_compat.Owned_directory_missing ->
+             Error
+               (Candidate_snapshot_write_failed
+                  { path; detail = "candidate snapshot parent was not created" })
+           | Error detail ->
+             Error (Candidate_snapshot_write_failed { path; detail }))
+        (fun exn ->
            Error
              (Candidate_snapshot_write_failed
-                { path; detail = "candidate snapshot parent was not created" })
-         | Error detail ->
-           Error (Candidate_snapshot_write_failed { path; detail })
-       with
-       | Eio.Cancel.Cancelled _ as exn -> raise exn
-       | exn ->
-         Error
-           (Candidate_snapshot_write_failed
-              { path; detail = Printexc.to_string exn }))
+                { path; detail = Printexc.to_string exn }))
     | Ok (Fs_compat.Owned_directory stats) -> Ok stats
   in
   let* () =

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -2,10 +2,11 @@
 
     Live references are the union of exact {!Tool_output} markers in the
     closed durable-consumer registry: Keeper state/checkpoints, Gate replay,
-    tool-call logs, trajectories, traces, messages, and Keeper chat. Repository
-    mirrors, build products, operator config, and observational logs are not
-    blob consumers and are never traversed. A new durable consumer must be
-    added to this registry in the same change that persists a reference.
+    tool-call logs, trajectories, traces, messages, Keeper chat, and bounded
+    wire captures. Repository mirrors, build products, operator config, and
+    unrelated observational logs are not blob consumers and are never
+    traversed. A new durable consumer must be added to this registry in the
+    same change that persists a reference.
 
     Retention is an explicit two-state policy, not an age/count heuristic:
     [Observe_only] records every currently unreferenced blob as a durable
@@ -14,13 +15,20 @@
     unreferenced in the new complete scan. Production calls it only at the
     quiescent startup boundary, so two complete startup scans are required.
     A malformed reference, scan failure, candidate-store failure, or unlink
-    failure aborts visibly. *)
+    failure aborts visibly. Because the blob store is shared across clusters
+    while several consumers are cluster-aware, any non-empty
+    [<base>/.masc/clusters] tree currently disables maintenance fail-closed
+    until cross-cluster writer quiescence has one coordination owner. *)
 
 type mode =
   | Observe_only
   | Delete_previous_candidates
 
 type error =
+  | Clustered_durable_roots_uncoordinated of
+      { path : string
+      ; entries : int
+      }
   | Durable_source_stat_failed of
       { path : string
       ; reason : string

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -1,17 +1,20 @@
 (** Single maintenance owner for the shared {!Tool_blob_store}.
 
-    Live references are the union of exact {!Tool_output} markers in every
-    regular durable file below the workspace runtime root, including Gate
-    replay sidecars and shared [Tool_bridge] consumers. Blob payloads and this
-    module's own candidate snapshot are excluded.
+    Live references are the union of exact {!Tool_output} markers in the
+    closed durable-consumer registry: Keeper state/checkpoints, Gate replay,
+    tool-call logs, trajectories, traces, messages, and Keeper chat. Repository
+    mirrors, build products, operator config, and observational logs are not
+    blob consumers and are never traversed. A new durable consumer must be
+    added to this registry in the same change that persists a reference.
 
     Retention is an explicit two-state policy, not an age/count heuristic:
     [Observe_only] records every currently unreferenced blob as a durable
     candidate and deletes nothing. [Delete_previous_candidates] deletes only
     hashes that were candidates in the previous durable snapshot and remain
-    unreferenced in the new complete scan. The caller owns the quiescent
-    maintenance window. A malformed reference, scan failure, candidate-store
-    failure, or unlink failure aborts visibly. *)
+    unreferenced in the new complete scan. Production calls it only at the
+    quiescent startup boundary, so two complete startup scans are required.
+    A malformed reference, scan failure, candidate-store failure, or unlink
+    failure aborts visibly. *)
 
 type mode =
   | Observe_only

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -32,6 +32,11 @@ type error =
       ; offset : int
       ; detail : string
       }
+  | Malformed_structured_artifact_reference of
+      { path : string
+      ; line : int
+      ; detail : string
+      }
   | Candidate_snapshot_invalid of
       { path : string
       ; detail : string

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -1,0 +1,59 @@
+(** Single maintenance owner for the shared {!Tool_blob_store}.
+
+    Live references are the union of exact {!Tool_output} markers in every
+    regular durable file below the workspace runtime root, including Gate
+    replay sidecars and shared [Tool_bridge] consumers. Blob payloads and this
+    module's own candidate snapshot are excluded.
+
+    Retention is an explicit two-state policy, not an age/count heuristic:
+    [Observe_only] records every currently unreferenced blob as a durable
+    candidate and deletes nothing. [Delete_previous_candidates] deletes only
+    hashes that were candidates in the previous durable snapshot and remain
+    unreferenced in the new complete scan. The caller owns the quiescent
+    maintenance window. A malformed reference, scan failure, candidate-store
+    failure, or unlink failure aborts visibly. *)
+
+type mode =
+  | Observe_only
+  | Delete_previous_candidates
+
+type error =
+  | Durable_source_stat_failed of
+      { path : string
+      ; reason : string
+      }
+  | Durable_source_read_failed of
+      { path : string
+      ; reason : string
+      }
+  | Malformed_artifact_reference of
+      { path : string
+      ; line : int
+      ; offset : int
+      ; detail : string
+      }
+  | Candidate_snapshot_invalid of
+      { path : string
+      ; detail : string
+      }
+  | Candidate_snapshot_read_failed of
+      { path : string
+      ; detail : string
+      }
+  | Candidate_snapshot_write_failed of
+      { path : string
+      ; detail : string
+      }
+  | Blob_listing_failed of Tool_blob_store.list_error
+  | Blob_delete_failed of Tool_blob_store.delete_error
+
+type report =
+  { live_references : int
+  ; blobs_observed : int
+  ; candidates_recorded : int
+  ; deleted : int
+  }
+
+val error_to_string : error -> string
+val candidate_snapshot_path : base_path:string -> string
+val run : base_path:string -> mode:mode -> (report, error) result

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -1,5 +1,3 @@
-module SS = Set_util.StringSet
-
 type t =
   { root : string
   ; ownership_root : string
@@ -135,16 +133,179 @@ let list_all t =
     ) shards;
     !acc
 
-let gc t ~keep_set =
-  let keep = List.fold_left (fun acc s -> SS.add s acc) SS.empty keep_set in
-  let deleted = ref 0 in
-  List.iter (fun sha256 ->
-    if not (SS.mem sha256 keep) then begin
-      let path = shard_path t sha256 in
-      try
-        Unix.unlink path;
-        incr deleted
-      with Unix.Unix_error _ -> ()
-    end
-  ) (list_all t);
-  !deleted
+type list_error =
+  { path : string
+  ; reason : string
+  }
+
+let list_all_result t =
+  let same_directory (left : Unix.stats) (right : Unix.stats) =
+    left.st_dev = right.st_dev
+    && left.st_ino = right.st_ino
+    && left.st_kind = Unix.S_DIR
+    && right.st_kind = Unix.S_DIR
+  in
+  let inspect_dir path =
+    match
+      Fs_compat.inspect_owned_directory_chain
+        ~ownership_root:t.ownership_root
+        path
+    with
+    | Ok observation -> Ok observation
+    | Error rejection ->
+      Error
+        { path
+        ; reason =
+            Fs_compat.owned_directory_chain_rejection_to_string rejection
+        }
+  in
+  let read_dir path =
+    match inspect_dir path with
+    | Error _ as error -> error
+    | Ok Fs_compat.Owned_directory_missing -> Ok None
+    | Ok (Fs_compat.Owned_directory before) ->
+      (try
+         let entries = Sys.readdir path in
+         match inspect_dir path with
+         | Error _ as error -> error
+         | Ok Fs_compat.Owned_directory_missing ->
+           Error { path; reason = "directory disappeared during listing" }
+         | Ok (Fs_compat.Owned_directory after) ->
+           if same_directory before after
+           then Ok (Some entries)
+           else Error { path; reason = "directory identity changed during listing" }
+       with
+       | Sys_error reason -> Error { path; reason }
+       | Unix.Unix_error (code, fn, arg) ->
+         Error
+           { path
+           ; reason =
+               Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+           })
+  in
+  match read_dir t.root with
+  | Error _ as error -> error
+  | Ok None -> Ok []
+  | Ok (Some shards) ->
+      let rec scan_shards acc index =
+        if index = Array.length shards
+        then Ok acc
+        else
+          let shard_dir = Filename.concat t.root shards.(index) in
+          match read_dir shard_dir with
+          | Error _ as error -> error
+          | Ok None -> scan_shards acc (index + 1)
+          | Ok (Some files) ->
+            let acc =
+              Array.fold_left
+                (fun current filename ->
+                   match validate_sha256 filename with
+                   | Ok () -> filename :: current
+                   | Error _ -> current)
+                acc
+                files
+            in
+            scan_shards acc (index + 1)
+      in
+      scan_shards [] 0
+
+type delete_error =
+  { sha256 : string
+  ; path : string
+  ; reason : string
+  }
+
+let delete_error_to_string { sha256; path; reason } =
+  Printf.sprintf "blob delete failed sha256=%s path=%s: %s" sha256 path reason
+;;
+
+let file_kind_to_string = function
+  | Unix.S_REG -> "regular_file"
+  | Unix.S_DIR -> "directory"
+  | Unix.S_CHR -> "character_device"
+  | Unix.S_BLK -> "block_device"
+  | Unix.S_LNK -> "symbolic_link"
+  | Unix.S_FIFO -> "fifo"
+  | Unix.S_SOCK -> "socket"
+;;
+
+let delete t ~sha256 =
+  match validate_sha256 sha256 with
+  | Error invalid ->
+    Error
+      { sha256
+      ; path = t.root
+      ; reason = invalid_sha256_to_string invalid
+      }
+  | Ok () ->
+    let path = shard_path t sha256 in
+    let parent = Filename.dirname path in
+    (match
+       Fs_compat.inspect_owned_directory_chain
+         ~ownership_root:t.ownership_root
+         parent
+     with
+     | Error rejection ->
+       Error
+         { sha256
+         ; path
+         ; reason =
+             Fs_compat.owned_directory_chain_rejection_to_string rejection
+         }
+     | Ok Fs_compat.Owned_directory_missing -> Ok false
+     | Ok (Fs_compat.Owned_directory parent_before) ->
+       (try
+          let target = Unix.lstat path in
+          if target.st_kind <> Unix.S_REG
+          then
+            Error
+              { sha256
+              ; path
+              ; reason =
+                  Printf.sprintf
+                    "refusing to delete non-regular blob kind=%s"
+                    (file_kind_to_string target.st_kind)
+              }
+          else
+            (match
+               Fs_compat.inspect_owned_directory_chain
+                 ~ownership_root:t.ownership_root
+                 parent
+             with
+             | Error rejection ->
+               Error
+                 { sha256
+                 ; path
+                 ; reason =
+                     Fs_compat.owned_directory_chain_rejection_to_string
+                       rejection
+                 }
+             | Ok Fs_compat.Owned_directory_missing ->
+               Error { sha256; path; reason = "blob parent disappeared" }
+             | Ok (Fs_compat.Owned_directory parent_after) ->
+               if
+                 parent_before.st_dev <> parent_after.st_dev
+                 || parent_before.st_ino <> parent_after.st_ino
+               then
+                 Error
+                   { sha256
+                   ; path
+                   ; reason = "blob parent identity changed before deletion"
+                   }
+               else (
+                 Unix.unlink path;
+                 Ok true))
+        with
+        | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+        | Unix.Unix_error (code, fn, arg) ->
+          Error
+            { sha256
+            ; path
+            ; reason =
+                Printf.sprintf
+                  "%s(%s): %s"
+                  fn
+                  arg
+                  (Unix.error_message code)
+            }
+        | Sys_error reason -> Error { sha256; path; reason }))

--- a/lib/tool_blob_store/tool_blob_store.mli
+++ b/lib/tool_blob_store/tool_blob_store.mli
@@ -56,9 +56,27 @@ val fetch : t -> sha256:string -> (string option, fetch_error) result
 
 val list_all : t -> string list
 (** List all sha256 hashes currently in the store. O(n) in store size.
-    Mainly used by [gc] and tests. *)
+    Mainly used by tests. Production retention is owned exclusively by
+    {!Tool_blob_maintenance}. *)
 
-val gc : t -> keep_set:string list -> int
-(** Delete every artifact whose sha256 is NOT in [keep_set].
-    Returns the number of artifacts deleted. Best-effort: unlink failures
-    are silently skipped. *)
+type list_error =
+  { path : string
+  ; reason : string
+  }
+
+val list_all_result : t -> (string list, list_error) result
+(** Typed production listing. Directory read/stat failures never collapse to
+    an empty store. *)
+
+type delete_error =
+  { sha256 : string
+  ; path : string
+  ; reason : string
+  }
+
+val delete_error_to_string : delete_error -> string
+val delete : t -> sha256:string -> (bool, delete_error) result
+(** Delete one exact blob. [Ok false] means it is already absent; filesystem
+    failures remain typed and visible. Bulk retention/deletion is owned
+    exclusively by {!Tool_blob_maintenance}; callers must not synthesize a
+    partial consumer keep-set. *)

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -56,6 +56,58 @@ let make_artifact_ref ~sha256 ~bytes ~preview ~mime =
 
 let with_preview artifact_ref preview = { artifact_ref with preview }
 
+let normalized_artifact_ref_key = "_blob"
+
+let normalized_artifact_ref_to_json { sha256; bytes; preview; mime } =
+  `Assoc
+    [ ( normalized_artifact_ref_key
+      , `Assoc
+          [ "sha256", `String sha256
+          ; "bytes", `Int bytes
+          ; "mime", `String mime
+          ; "preview", `String preview
+          ] )
+    ]
+;;
+
+type normalized_artifact_ref_decode =
+  | Not_normalized_artifact_ref
+  | Invalid_normalized_artifact_ref of { detail : string }
+  | Decoded_normalized_artifact_ref of artifact_ref
+
+let normalized_artifact_ref_of_json = function
+  | `Assoc [ (key, `Assoc fields) ]
+    when String.equal key normalized_artifact_ref_key ->
+    let fields =
+      List.sort
+        (fun (left, _) (right, _) -> String.compare left right)
+        fields
+    in
+    (match fields with
+     | [ "bytes", `Int bytes
+       ; "mime", `String mime
+       ; "preview", `String preview
+       ; "sha256", `String sha256
+       ] ->
+       (match make_artifact_ref ~sha256 ~bytes ~preview ~mime with
+        | Ok reference -> Decoded_normalized_artifact_ref reference
+        | Error error ->
+          Invalid_normalized_artifact_ref
+            { detail = make_error_to_string error })
+     | _ ->
+       Invalid_normalized_artifact_ref
+         { detail =
+             "expected exact _blob fields bytes, mime, preview, and sha256"
+         })
+  | `Assoc [ (key, _) ] when String.equal key normalized_artifact_ref_key ->
+    Invalid_normalized_artifact_ref
+      { detail = "_blob value must be an object" }
+  | `Assoc fields when List.mem_assoc normalized_artifact_ref_key fields ->
+    Invalid_normalized_artifact_ref
+      { detail = "_blob wrapper must contain no sibling fields" }
+  | _ -> Not_normalized_artifact_ref
+;;
+
 type t =
   | Inline of string
   | Stored of artifact_ref

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -92,3 +92,57 @@ let decode_from_oas s =
       match make_artifact_ref ~sha256 ~bytes ~preview ~mime with
       | Ok artifact_ref -> Decoded artifact_ref
       | Error err -> Invalid_marker { detail = make_error_to_string err })
+
+type embedded_reference_error =
+  { offset : int
+  ; detail : string
+  }
+
+let artifact_refs_in_text text =
+  let text_length = String.length text in
+  let prefix_length = String.length marker_prefix in
+  let rec find_prefix offset =
+    if offset + prefix_length > text_length
+    then None
+    else if String.sub text offset prefix_length = marker_prefix
+    then Some offset
+    else find_prefix (offset + 1)
+  in
+  let rec marker_end index in_quotes escaped =
+    if index >= text_length
+    then None
+    else
+      let character = String.unsafe_get text index in
+      if escaped
+      then marker_end (index + 1) in_quotes false
+      else if in_quotes && character = '\\'
+      then marker_end (index + 1) in_quotes true
+      else if character = '"'
+      then marker_end (index + 1) (not in_quotes) false
+      else if character = ']' && not in_quotes
+      then Some index
+      else marker_end (index + 1) in_quotes false
+  in
+  let rec collect offset references =
+    match find_prefix offset with
+    | None -> Ok (List.rev references)
+    | Some start ->
+      (match marker_end (start + prefix_length) false false with
+       | None ->
+         Error
+           { offset = start
+           ; detail = "artifact marker has no closing bracket"
+           }
+       | Some stop ->
+         let marker = String.sub text start (stop - start + 1) in
+         (match decode_from_oas marker with
+          | Decoded reference ->
+            collect (stop + 1) (reference :: references)
+          | Invalid_marker { detail } -> Error { offset = start; detail }
+          | Not_marker ->
+            Error
+              { offset = start
+              ; detail = "artifact marker prefix was not recognized"
+              }))
+  in
+  collect 0 []

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -51,6 +51,23 @@ val with_preview : artifact_ref -> string -> artifact_ref
 (** Replace the preview, keeping the validated identity fields. Total — the
     existing reference already passed validation. *)
 
+(** The exact structured representation used when a durable consumer stores a
+    blob reference as JSON rather than its OAS marker. The producer and every
+    durable owner must use this codec; a marker-shaped JSON object is never
+    guessed into a reference. *)
+val normalized_artifact_ref_to_json : artifact_ref -> Yojson.Safe.t
+
+type normalized_artifact_ref_decode =
+  | Not_normalized_artifact_ref
+  | Invalid_normalized_artifact_ref of { detail : string }
+  | Decoded_normalized_artifact_ref of artifact_ref
+
+val normalized_artifact_ref_of_json :
+  Yojson.Safe.t -> normalized_artifact_ref_decode
+(** Strictly decode the singleton ["_blob"] wrapper emitted by
+    {!normalized_artifact_ref_to_json}. A malformed wrapper is reported
+    explicitly so retention code fails closed. *)
+
 (** {1 Wire codec} *)
 
 type t =

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -72,3 +72,14 @@ type decode_result =
   | Decoded of artifact_ref
 
 val decode_from_oas : string -> decode_result
+
+type embedded_reference_error =
+  { offset : int
+  ; detail : string
+  }
+
+val artifact_refs_in_text :
+  string -> (artifact_ref list, embedded_reference_error) result
+(** Parse every exact artifact marker embedded in arbitrary durable text.
+    Marker-shaped malformed content fails the whole scan with its byte offset;
+    it is never treated as an unreferenced blob. *)

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -429,6 +429,23 @@ let capture_prunes_old_files () =
         Alcotest.(check int) "only current capture remains" 1
           (List.length (find_jsonl base)))))
 
+let startup_prune_removes_old_files_without_new_capture () =
+  with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_startup_prune" "" in
+    let capture_dir = Filename.concat base "wire-capture" in
+    let old_month = Filename.concat capture_dir "2000-01" in
+    ensure_dir capture_dir;
+    ensure_dir old_month;
+    let old_file = Filename.concat old_month "01.jsonl" in
+    write_file old_file (String.make 1024 'x');
+    match Wire.prune_expired ~masc_root:base with
+    | Ok count ->
+      Alcotest.(check int) "startup owner prune removes expired capture" 1 count;
+      Alcotest.(check bool) "expired capture is gone without a new write" false
+        (Sys.file_exists old_file)
+    | Error error ->
+      Alcotest.fail (Wire.prune_error_to_string error))
+
 let capture_cache_reloads_when_retention_changes () =
   with_flag "1" (fun () ->
     with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "4096" (fun () ->
@@ -606,6 +623,8 @@ let () =
             response_capture_failure_is_best_effort;
           Alcotest.test_case "capture store prunes old files" `Quick
             capture_prunes_old_files;
+          Alcotest.test_case "startup owner prune expires inactive captures" `Quick
+            startup_prune_removes_old_files_without_new_capture;
           Alcotest.test_case "capture store reloads on retention change" `Quick
             capture_cache_reloads_when_retention_changes;
           Alcotest.test_case "current file cap skips oversized record" `Quick

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -257,7 +257,7 @@ let test_maintenance_keeps_live_and_deletes_stable_dead_after_restart () =
       let durable_consumer =
         Filename.concat
           (Common.masc_dir_from_base_path ~base_path)
-          "shared-tool-bridge/history.jsonl"
+          "keepers/keeper-a/sessions/history.jsonl"
       in
       Fs_compat.mkdir_p (Filename.dirname durable_consumer);
       Fs_compat.save_file
@@ -322,7 +322,7 @@ let test_maintenance_malformed_reference_fails_closed () =
       let source =
         Filename.concat
           (Common.masc_dir_from_base_path ~base_path)
-          "gate-replay/malformed.jsonl"
+          "gate/malformed.jsonl"
       in
       Fs_compat.mkdir_p (Filename.dirname source);
       Fs_compat.save_file source "{\"output\":\"[masc:blob garbage]\"}\n";
@@ -338,6 +338,38 @@ let test_maintenance_malformed_reference_fails_closed () =
       Alcotest.(check (option string))
         "blob retained on malformed reference"
         (Some "must survive malformed source")
+        (fetch_ok store ~sha256:blob.sha256))
+
+let test_maintenance_does_not_scan_repository_mirrors () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let blob =
+        B.put store ~bytes:"not owned by a repository mirror" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let repository_source =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "repos/masc/docs/blob-marker.md"
+      in
+      Fs_compat.mkdir_p (Filename.dirname repository_source);
+      Fs_compat.save_file
+        repository_source
+        "documentation example: [masc:blob not-a-reference]";
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "repository source does not claim blob ownership"
+        1
+        observed.candidates_recorded;
+      let swept =
+        maintenance_ok
+          ~base_path
+          ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "stable unowned blob is deleted" 1 swept.deleted;
+      Alcotest.(check (option string))
+        "repository text did not retain the blob"
+        None
         (fetch_ok store ~sha256:blob.sha256))
 
 let test_maintenance_rechecks_candidate_referenced_before_startup () =
@@ -525,8 +557,9 @@ let test_maintenance_rejects_symbolic_link_durable_source () =
       let linked_source =
         Filename.concat
           (Common.masc_dir_from_base_path ~base_path)
-          "linked-consumer.json"
+          "messages/linked-consumer.json"
       in
+      Fs_compat.mkdir_p (Filename.dirname linked_source);
       Unix.symlink outside linked_source;
       (match M.run ~base_path ~mode:M.Observe_only with
        | Error (M.Durable_source_stat_failed { path; _ }) ->
@@ -753,6 +786,10 @@ let () =
             "maintenance malformed reference fails closed"
             `Quick
             test_maintenance_malformed_reference_fails_closed;
+          Alcotest.test_case
+            "maintenance ignores repository mirrors"
+            `Quick
+            test_maintenance_does_not_scan_repository_mirrors;
           Alcotest.test_case
             "maintenance rechecks candidate referenced before startup"
             `Quick

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -89,6 +89,25 @@ let test_stored_roundtrip () =
   | O.Invalid_marker { detail } ->
       Alcotest.failf "expected Decoded, got Invalid_marker: %s" detail
 
+let test_normalized_artifact_ref_roundtrip () =
+  let reference =
+    ref_exn
+      ~sha256:(String.make 64 'b')
+      ~bytes:4096
+      ~mime:"application/json"
+      ~preview:"{\"ok\":true}"
+  in
+  match O.normalized_artifact_ref_of_json (O.normalized_artifact_ref_to_json reference) with
+  | O.Decoded_normalized_artifact_ref decoded ->
+    Alcotest.(check string) "sha256" reference.sha256 decoded.sha256;
+    Alcotest.(check int) "bytes" reference.bytes decoded.bytes;
+    Alcotest.(check string) "mime" reference.mime decoded.mime;
+    Alcotest.(check string) "preview" reference.preview decoded.preview
+  | O.Not_normalized_artifact_ref ->
+    Alcotest.fail "expected normalized artifact reference"
+  | O.Invalid_normalized_artifact_ref { detail } ->
+    Alcotest.failf "normalized artifact reference rejected: %s" detail
+
 let test_encoded_marker_stays_under_externalization_threshold () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
@@ -353,6 +372,100 @@ let test_maintenance_rechecks_candidate_referenced_before_startup () =
         (Some "referenced before startup sweep")
         (fetch_ok store ~sha256:candidate.sha256))
 
+let test_maintenance_keeps_normalized_tool_call_blob_reference () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let reference =
+        B.put
+          store
+          ~bytes:"normalized tool-call output"
+          ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let tool_call_log =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "tool_calls/2026-07/29.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname tool_call_log);
+      Fs_compat.save_file
+        tool_call_log
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "keeper", `String "keeper-tool-log"
+             ; "tool", `String "large_output"
+             ; ( "output"
+               , `Assoc
+                   [ ( "_blob"
+                     , `Assoc
+                         [ "sha256", `String reference.sha256
+                         ; "bytes", `Int reference.bytes
+                         ; "mime", `String reference.mime
+                         ; "preview", `String reference.preview
+                         ] )
+                   ] )
+             ])
+         ^ "\n");
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "normalized tool-call reference is live"
+        1
+        observed.live_references;
+      Alcotest.(check int)
+        "normalized live blob is not a candidate"
+        0
+        observed.candidates_recorded;
+      let swept =
+        maintenance_ok
+          ~base_path
+          ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "normalized live blob is not deleted" 0 swept.deleted;
+      Alcotest.(check (option string))
+        "normalized tool-call blob remains readable"
+        (Some "normalized tool-call output")
+        (fetch_ok store ~sha256:reference.sha256))
+
+let test_maintenance_malformed_normalized_blob_fails_closed () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let reference =
+        B.put store ~bytes:"survive malformed normalized ref" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let tool_call_log =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "tool_calls/2026-07/29.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname tool_call_log);
+      Fs_compat.save_file
+        tool_call_log
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ ( "output"
+               , `Assoc
+                   [ ( "_blob"
+                     , `Assoc [ "sha256", `String reference.sha256 ] )
+                   ] )
+             ])
+         ^ "\n");
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error
+           (M.Malformed_structured_artifact_reference
+             { path; line; _ }) ->
+         Alcotest.(check string) "exact malformed tool-call log" tool_call_log path;
+         Alcotest.(check int) "exact malformed tool-call line" 1 line
+       | Error error ->
+         Alcotest.failf
+           "unexpected normalized-reference error: %s"
+           (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "malformed normalized reference reached deletion");
+      Alcotest.(check (option string))
+        "malformed normalized reference retains every blob"
+        (Some "survive malformed normalized ref")
+        (fetch_ok store ~sha256:reference.sha256))
+
 let test_maintenance_unlink_failure_is_typed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -609,6 +722,10 @@ let () =
           Alcotest.test_case "inline" `Quick test_inline_roundtrip;
           Alcotest.test_case "stored" `Quick test_stored_roundtrip;
           Alcotest.test_case
+            "normalized artifact reference"
+            `Quick
+            test_normalized_artifact_ref_roundtrip;
+          Alcotest.test_case
             "encoded marker stays under externalization threshold"
             `Quick
             test_encoded_marker_stays_under_externalization_threshold;
@@ -640,6 +757,14 @@ let () =
             "maintenance rechecks candidate referenced before startup"
             `Quick
             test_maintenance_rechecks_candidate_referenced_before_startup;
+          Alcotest.test_case
+            "maintenance keeps normalized tool-call blob reference"
+            `Quick
+            test_maintenance_keeps_normalized_tool_call_blob_reference;
+          Alcotest.test_case
+            "maintenance malformed normalized blob fails closed"
+            `Quick
+            test_maintenance_malformed_normalized_blob_fails_closed;
           Alcotest.test_case
             "maintenance unlink failure is typed"
             `Quick

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -498,6 +498,48 @@ let test_maintenance_malformed_normalized_blob_fails_closed () =
         (Some "survive malformed normalized ref")
         (fetch_ok store ~sha256:reference.sha256))
 
+let test_maintenance_truncated_normalized_blob_fails_closed () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let reference =
+        B.put store ~bytes:"survive truncated normalized ref" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "unreferenced blob is first recorded"
+        1
+        observed.candidates_recorded;
+      let tool_call_log =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "tool_calls/2026-07/29.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname tool_call_log);
+      let complete_reference =
+        O.normalized_artifact_ref_to_json reference
+        |> Yojson.Safe.to_string
+      in
+      Fs_compat.save_file
+        tool_call_log
+        ("{\"output\":" ^ complete_reference);
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error
+           (M.Malformed_structured_artifact_reference
+             { path; line; _ }) ->
+         Alcotest.(check string) "exact truncated tool-call log" tool_call_log path;
+         Alcotest.(check int) "exact truncated tool-call line" 1 line
+       | Error error ->
+         Alcotest.failf
+           "unexpected truncated-reference error: %s"
+           (M.error_to_string error)
+       | Ok _ ->
+         Alcotest.fail "truncated normalized reference reached deletion");
+      Alcotest.(check (option string))
+        "truncated normalized reference retains every blob"
+        (Some "survive truncated normalized ref")
+        (fetch_ok store ~sha256:reference.sha256))
+
 let test_maintenance_unlink_failure_is_typed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -802,6 +844,10 @@ let () =
             "maintenance malformed normalized blob fails closed"
             `Quick
             test_maintenance_malformed_normalized_blob_fails_closed;
+          Alcotest.test_case
+            "maintenance truncated normalized blob fails closed"
+            `Quick
+            test_maintenance_truncated_normalized_blob_fails_closed;
           Alcotest.test_case
             "maintenance unlink failure is typed"
             `Quick

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -7,10 +7,12 @@
       outcome, not a silent inline fallback.
     - Content-addressed: same bytes -> same sha -> idempotent put.
     - Sharding: blobs land under [<sha[0..1]>/<sha>].
-    - GC: blobs not in keep_set are deleted; kept ones survive.
+    - Maintenance: union-scanned live refs survive and stable dead refs are
+      deleted only on the second explicit retention pass.
     - Concurrent put: simultaneous writes of same content do not corrupt. *)
 
 module B = Tool_blob_store
+module M = Tool_blob_maintenance
 module O = Tool_output
 
 (* --- Helpers --- *)
@@ -25,6 +27,10 @@ let fetch_ok store ~sha256 =
   | Ok value -> value
   | Error error ->
       Alcotest.failf "fetch failed: %s" (B.fetch_error_to_string error)
+
+let stored_ref_exn = function
+  | O.Stored reference -> reference
+  | O.Inline _ -> Alcotest.fail "expected Stored"
 
 let with_temp_dir f =
   let dir = Filename.temp_file "masc_blob_test" "" in
@@ -208,37 +214,251 @@ let test_sharding_layout () =
             (Sys.file_exists expected)
       | O.Inline _ -> Alcotest.fail "put returned Inline")
 
-(* --- GC --- *)
+let maintenance_ok ~base_path ~mode =
+  match M.run ~base_path ~mode with
+  | Ok report -> report
+  | Error error ->
+    Alcotest.failf "maintenance failed: %s" (M.error_to_string error)
 
-let test_gc_deletes_unkept () =
-  with_temp_dir (fun dir ->
-      let store = B.create ~base_path:dir in
-      let stored payload =
-        match B.put store ~bytes:payload ~mime:"text/plain" with
-        | O.Stored { sha256; _ } -> sha256
-        | O.Inline _ -> Alcotest.fail "expected Stored"
+let test_maintenance_keeps_live_and_deletes_stable_dead_after_restart () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let live =
+        B.put store ~bytes:"live shared bridge output" ~mime:"text/plain"
+        |> stored_ref_exn
       in
-      let keep = stored "keep me" in
-      let _drop = stored "drop me" in
-      let _drop2 = stored "drop me too" in
-      Alcotest.(check int) "before gc" 3 (List.length (B.list_all store));
-      let deleted = B.gc store ~keep_set:[ keep ] in
-      Alcotest.(check int) "deleted count" 2 deleted;
-      Alcotest.(check int) "after gc" 1 (List.length (B.list_all store));
+      let dead =
+        B.put store ~bytes:"dead replay sidecar output" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let replay_live =
+        B.put store ~bytes:"live gate replay output" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let durable_consumer =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "shared-tool-bridge/history.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname durable_consumer);
+      Fs_compat.save_file
+        durable_consumer
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "consumer", `String "Tool_bridge"
+             ; "output_ref", `String (O.encode_for_oas (O.Stored live))
+             ])
+         ^ "\n");
+      let replay_sidecar =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "gate/replay-results.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname replay_sidecar);
+      Fs_compat.save_file
+        replay_sidecar
+        (Yojson.Safe.pretty_to_string
+           (`Assoc
+             [ "approval_id", `String "approval-maintenance"
+             ; ( "outcome"
+               , `String (O.encode_for_oas (O.Stored replay_live)) )
+             ]));
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int) "union includes both consumers" 2 observed.live_references;
+      Alcotest.(check int) "three blobs observed" 3 observed.blobs_observed;
+      Alcotest.(check int) "one candidate" 1 observed.candidates_recorded;
+      Alcotest.(check int) "observe deletes none" 0 observed.deleted;
+      Alcotest.(check bool)
+        "dead remains after observation"
+        true
+        (Option.is_some (fetch_ok store ~sha256:dead.sha256));
+      (* The second call deliberately uses only the durable candidate snapshot:
+         this is the restart boundary of the two-state retention policy. *)
+      let swept =
+        maintenance_ok
+          ~base_path
+          ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "stable dead blob deleted" 1 swept.deleted;
       Alcotest.(check (option string))
-        "kept blob still fetchable"
-        (Some "keep me")
-        (fetch_ok store ~sha256:keep))
+        "shared consumer reference remains live"
+        (Some "live shared bridge output")
+        (fetch_ok store ~sha256:live.sha256);
+      Alcotest.(check (option string))
+        "dead blob no longer exists"
+        None
+        (fetch_ok store ~sha256:dead.sha256);
+      Alcotest.(check (option string))
+        "Gate replay sidecar reference remains live"
+        (Some "live gate replay output")
+        (fetch_ok store ~sha256:replay_live.sha256))
 
-let test_gc_empty_keep_clears_all () =
-  with_temp_dir (fun dir ->
-      let store = B.create ~base_path:dir in
-      let _ = B.put store ~bytes:"a" ~mime:"text/plain" in
-      let _ = B.put store ~bytes:"b" ~mime:"text/plain" in
-      let _ = B.put store ~bytes:"c" ~mime:"text/plain" in
-      let deleted = B.gc store ~keep_set:[] in
-      Alcotest.(check int) "deleted all" 3 deleted;
-      Alcotest.(check int) "store empty" 0 (List.length (B.list_all store)))
+let test_maintenance_malformed_reference_fails_closed () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let blob =
+        B.put store ~bytes:"must survive malformed source" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let source =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "gate-replay/malformed.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname source);
+      Fs_compat.save_file source "{\"output\":\"[masc:blob garbage]\"}\n";
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error (M.Malformed_artifact_reference { path; line; _ }) ->
+         Alcotest.(check string) "exact malformed source" source path;
+         Alcotest.(check int) "exact malformed line" 1 line
+       | Error error ->
+         Alcotest.failf
+           "unexpected maintenance error: %s"
+           (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "malformed reference reached deletion");
+      Alcotest.(check (option string))
+        "blob retained on malformed reference"
+        (Some "must survive malformed source")
+        (fetch_ok store ~sha256:blob.sha256))
+
+let test_maintenance_rechecks_candidate_referenced_before_startup () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let candidate =
+        B.put store ~bytes:"referenced before startup sweep" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int) "one candidate observed" 1 observed.candidates_recorded;
+      let durable_consumer =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/history.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname durable_consumer);
+      Fs_compat.save_file
+        durable_consumer
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "output_ref", `String (O.encode_for_oas (O.Stored candidate)) ])
+         ^ "\n");
+      let swept =
+        maintenance_ok
+          ~base_path
+          ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "new live reference prevents deletion" 0 swept.deleted;
+      Alcotest.(check (option string))
+        "newly referenced candidate remains readable"
+        (Some "referenced before startup sweep")
+        (fetch_ok store ~sha256:candidate.sha256))
+
+let test_maintenance_unlink_failure_is_typed () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let sha256 = String.make 64 'a' in
+      let shard_dir =
+        Filename.concat (B.root_dir store) (String.sub sha256 0 2)
+      in
+      Fs_compat.mkdir_p shard_dir;
+      Unix.mkdir (Filename.concat shard_dir sha256) 0o755;
+      ignore (maintenance_ok ~base_path ~mode:M.Observe_only);
+      match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      | Error
+          (M.Blob_delete_failed
+            { Tool_blob_store.sha256 = actual; _ }) ->
+        Alcotest.(check string) "exact failed blob" sha256 actual
+      | Error error ->
+        Alcotest.failf
+          "unexpected unlink error: %s"
+          (M.error_to_string error)
+      | Ok _ -> Alcotest.fail "unlink failure was silently skipped")
+
+let test_maintenance_rejects_symbolic_link_shard () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      Fs_compat.mkdir_p (B.root_dir store);
+      let outside = Filename.concat base_path "outside-blobs" in
+      Unix.mkdir outside 0o755;
+      Fs_compat.save_file
+        (Filename.concat outside (String.make 64 'a'))
+        "outside";
+      Unix.symlink outside (Filename.concat (B.root_dir store) "aa");
+      match M.run ~base_path ~mode:M.Observe_only with
+      | Error (M.Blob_listing_failed { Tool_blob_store.path; _ }) ->
+        Alcotest.(check string)
+          "exact symbolic-link shard"
+          (Filename.concat (B.root_dir store) "aa")
+          path
+      | Error error ->
+        Alcotest.failf
+          "unexpected symbolic-link error: %s"
+          (M.error_to_string error)
+      | Ok _ -> Alcotest.fail "symbolic-link shard crossed blob ownership")
+
+let test_maintenance_rejects_symbolic_link_durable_source () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let blob =
+        B.put store ~bytes:"must survive linked source" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let outside = Filename.concat base_path "outside-consumer.json" in
+      Fs_compat.save_file
+        outside
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "output_ref", `String (O.encode_for_oas (O.Stored blob)) ]));
+      let linked_source =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "linked-consumer.json"
+      in
+      Unix.symlink outside linked_source;
+      (match M.run ~base_path ~mode:M.Observe_only with
+       | Error (M.Durable_source_stat_failed { path; _ }) ->
+         Alcotest.(check string) "exact linked source" linked_source path
+       | Error error ->
+         Alcotest.failf
+           "unexpected linked-source error: %s"
+           (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "symbolic-link source was silently skipped");
+      Alcotest.(check (option string))
+        "blob retained when source ownership is ambiguous"
+        (Some "must survive linked source")
+        (fetch_ok store ~sha256:blob.sha256))
+
+let test_maintenance_rejects_symbolic_link_candidate_snapshot () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let blob =
+        B.put store ~bytes:"must survive linked snapshot" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      ignore (maintenance_ok ~base_path ~mode:M.Observe_only);
+      let candidate_path = M.candidate_snapshot_path ~base_path in
+      let outside = Filename.concat base_path "outside-candidates.json" in
+      Fs_compat.save_file
+        outside
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "schema_version", `Int 1
+             ; "unreferenced_candidates", `List [ `String blob.sha256 ]
+             ]));
+      Sys.remove candidate_path;
+      Unix.symlink outside candidate_path;
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error (M.Candidate_snapshot_read_failed { path; _ }) ->
+         Alcotest.(check string) "exact linked snapshot" candidate_path path
+       | Error error ->
+         Alcotest.failf
+           "unexpected linked-snapshot error: %s"
+           (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "symbolic-link candidate snapshot reached deletion");
+      Alcotest.(check (option string))
+        "blob retained when candidate snapshot ownership is ambiguous"
+        (Some "must survive linked snapshot")
+        (fetch_ok store ~sha256:blob.sha256))
 
 (* --- Repeated put: documents the atomicity contract --- *)
 
@@ -408,9 +628,34 @@ let () =
         ] );
       ( "gc",
         [
-          Alcotest.test_case "deletes unkept" `Quick test_gc_deletes_unkept;
-          Alcotest.test_case "empty keep clears all" `Quick
-            test_gc_empty_keep_clears_all;
+          Alcotest.test_case
+            "maintenance keeps live and deletes stable dead after restart"
+            `Quick
+            test_maintenance_keeps_live_and_deletes_stable_dead_after_restart;
+          Alcotest.test_case
+            "maintenance malformed reference fails closed"
+            `Quick
+            test_maintenance_malformed_reference_fails_closed;
+          Alcotest.test_case
+            "maintenance rechecks candidate referenced before startup"
+            `Quick
+            test_maintenance_rechecks_candidate_referenced_before_startup;
+          Alcotest.test_case
+            "maintenance unlink failure is typed"
+            `Quick
+            test_maintenance_unlink_failure_is_typed;
+          Alcotest.test_case
+            "maintenance rejects symbolic-link shard"
+            `Quick
+            test_maintenance_rejects_symbolic_link_shard;
+          Alcotest.test_case
+            "maintenance rejects symbolic-link durable source"
+            `Quick
+            test_maintenance_rejects_symbolic_link_durable_source;
+          Alcotest.test_case
+            "maintenance rejects symbolic-link candidate snapshot"
+            `Quick
+            test_maintenance_rejects_symbolic_link_candidate_snapshot;
         ] );
       ( "atomicity",
         [

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -362,6 +362,52 @@ let test_maintenance_keeps_wire_capture_reference_within_retention () =
         None
         (fetch_ok store ~sha256:dead.sha256))
 
+let test_maintenance_rejects_uncoordinated_cluster_roots () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let blob =
+        B.put store ~bytes:"cluster-owned output" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let cluster_capture =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "clusters/secondary/wire-capture/2026-07/28.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname cluster_capture);
+      Fs_compat.save_file
+        cluster_capture
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "response_text", `String (O.encode_for_oas (O.Stored blob)) ])
+         ^ "\n");
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error
+           (M.Clustered_durable_roots_uncoordinated
+             { path; entries }) ->
+         Alcotest.(check string)
+           "exact cluster root"
+           (Filename.concat
+              (Common.masc_dir_from_base_path ~base_path)
+              "clusters")
+           path;
+         Alcotest.(check int) "one cluster entry" 1 entries
+       | Error error ->
+         Alcotest.failf
+           "unexpected clustered maintenance error: %s"
+           (M.error_to_string error)
+       | Ok _ ->
+         Alcotest.fail
+           "shared blob maintenance ran without cross-cluster coordination");
+      Alcotest.(check (option string))
+        "cluster-owned blob remains readable"
+        (Some "cluster-owned output")
+        (fetch_ok store ~sha256:blob.sha256);
+      Alcotest.(check bool)
+        "cluster refusal does not publish a candidate snapshot"
+        false
+        (Sys.file_exists (M.candidate_snapshot_path ~base_path)))
+
 let test_maintenance_malformed_reference_fails_closed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -882,6 +928,10 @@ let () =
             "maintenance keeps wire-capture reference within retention"
             `Quick
             test_maintenance_keeps_wire_capture_reference_within_retention;
+          Alcotest.test_case
+            "maintenance rejects uncoordinated cluster roots"
+            `Quick
+            test_maintenance_rejects_uncoordinated_cluster_roots;
           Alcotest.test_case
             "maintenance ignores repository mirrors"
             `Quick

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -312,6 +312,56 @@ let test_maintenance_keeps_live_and_deletes_stable_dead_after_restart () =
         (Some "live gate replay output")
         (fetch_ok store ~sha256:replay_live.sha256))
 
+let test_maintenance_keeps_wire_capture_reference_within_retention () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let captured =
+        B.put store ~bytes:"captured provider response" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let dead =
+        B.put store ~bytes:"unreferenced provider response" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let wire_capture =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "wire-capture/2026-07/28.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname wire_capture);
+      Fs_compat.save_file
+        wire_capture
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "kind", `String "response"
+             ; ( "response_text"
+               , `String (O.encode_for_oas (O.Stored captured)) )
+             ])
+         ^ "\n");
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "wire capture reference is live"
+        1
+        observed.live_references;
+      Alcotest.(check int)
+        "only the unreferenced blob is a candidate"
+        1
+        observed.candidates_recorded;
+      let swept =
+        maintenance_ok
+          ~base_path
+          ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "stable unreferenced blob is deleted" 1 swept.deleted;
+      Alcotest.(check (option string))
+        "wire capture blob remains readable"
+        (Some "captured provider response")
+        (fetch_ok store ~sha256:captured.sha256);
+      Alcotest.(check (option string))
+        "unreferenced blob no longer exists"
+        None
+        (fetch_ok store ~sha256:dead.sha256))
+
 let test_maintenance_malformed_reference_fails_closed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -828,6 +878,10 @@ let () =
             "maintenance malformed reference fails closed"
             `Quick
             test_maintenance_malformed_reference_fails_closed;
+          Alcotest.test_case
+            "maintenance keeps wire-capture reference within retention"
+            `Quick
+            test_maintenance_keeps_wire_capture_reference_within_retention;
           Alcotest.test_case
             "maintenance ignores repository mirrors"
             `Quick


### PR DESCRIPTION
## 변경

- caller keep-set GC를 durable reference ownership maintenance owner로 교체했습니다.
- 닫힌 durable consumer roots에서 exact marker와 strict normalized `_blob` ref를 합집합으로 읽습니다.
- quiescent startup scan 두 번 모두에서 unreferenced인 blob만 삭제합니다.
- malformed/truncated JSONL, partial scan, symlink ownership, invalid candidate, unlink failure, non-default cluster 존재는 모두 fail-closed로 보존합니다.
- wire-capture owner가 같은 retention SSOT로 expired rows를 먼저 prune하며, prune I/O는 Eio systhread로 offload합니다.

## 검증

- 실제 `.masc/tool_calls/...jsonl`의 normalized `_blob` ref, truncated durable rows, repo-mirror 비소유 marker, wire-capture retention, cluster guard를 회귀로 고정했습니다.
- required `Run tool blob retention suite`가 `test_tool_blob_store`, `test_keeper_tool_call_log`, `test_keeper_wire_capture`를 모두 실제 실행합니다.
- 로컬 `@test/runtest-test_keeper_wire_capture`: 17/17 pass.
- `actionlint -ignore SC2129`, changed-file `ocamlformat --check`, `git diff --check` pass.
- Current head: `42a055703b00d34141ed620c32dddd5e6564a2b4`; full current-head CI가 merge authority입니다.

## 후속 범위

base-global blob store와 non-default cluster consumer의 coordinated deletion은 이 PR에서 추측하지 않고 #26178에 별도 추적합니다. 이 PR은 cluster root가 존재하면 삭제와 candidate snapshot 갱신을 중단합니다.
