### PR TITLE
chore(oas): pin agent_sdk 0.230.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
             tla=true
           fi
 
-          if has_match '^(ci/check-oas-pin\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/sync-oas-pin-docs\.sh$|scripts/sync-oas-pin-manifests\.sh$|dune-project$|.*\.opam$|masc\.opam\.locked$|docs/KEEPER-USER-MANUAL\.md$|docs/OAS-UTILIZATION-AUDIT\.md$)'; then
+          if has_match '^(ci/check-oas-pin\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/oas-drift-check\.sh$|scripts/oas-api-surface\.json$|scripts/sync-oas-pin-docs\.sh$|scripts/sync-oas-pin-manifests\.sh$|dune-project$|.*\.opam$|masc\.opam\.locked$|docs/KEEPER-USER-MANUAL\.md$|docs/OAS-UTILIZATION-AUDIT\.md$)'; then
             oas_pin=true
           fi
 
@@ -388,7 +388,7 @@ jobs:
       - name: Install meta shell dependencies
         run: |
           bash scripts/ci/apt-refresh.sh
-          sudo apt-get install -y -qq ripgrep
+          sudo apt-get install -y -qq jq ripgrep
 
       - name: Check single OCaml compile authority
         run: bash scripts/ci/check-ocaml-compile-authority.sh
@@ -430,8 +430,9 @@ jobs:
       - name: Check OAS pin consistency
         if: needs.changes.outputs.oas_pin == 'true'
         run: |
-          chmod +x scripts/check-oas-pin.sh
+          chmod +x scripts/check-oas-pin.sh scripts/oas-drift-check.sh
           scripts/check-oas-pin.sh --local-only
+          scripts/oas-drift-check.sh
 
       - name: Run report self-test
         if: needs.changes.outputs.lib_deps == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,19 @@ jobs:
       # still compiles every test target; the authoritative runtime, operator,
       # transport, SSE, and contract suites below remain executable gates.
 
+      - name: Run OAS pin behavior suite
+        id: oas_pin_behavior_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' && needs.changes.outputs.oas_pin == 'true' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          oas_pin_targets="@test/runtest-test_keeper_hooks_oas_introspection @test/runtest-test_keeper_execution_join"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${oas_pin_targets}"
+
       - name: Run operator control suite
         id: operator_control_suite
         # Run regardless of earlier test failures, but only after a successful

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.229.0-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.230.0-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.229.0`, runtime pin: `main@6bf1751a56357eecddd088383f0aac65275c6de6`, declared base version: `v0.229.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.230.0`, runtime pin: `main@7a3f2af7aed6fdd19968de3e1637dccb4f867461`, declared base version: `v0.230.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.229.0))
+  (agent_sdk (>= 0.230.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -41,6 +41,12 @@ let payload_agent_name payload =
      | None -> Json_util.get_string payload "keeper_name")
 ;;
 
+let tool_approval_label = function
+  | Agent_sdk.Hooks.Approved -> "approved"
+  | Agent_sdk.Hooks.Denied -> "denied"
+  | Agent_sdk.Hooks.Timed_out -> "timed_out"
+;;
+
 let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.t) =
   let log_at level message =
     Log.Oas_event.emit level ~details:json message
@@ -81,6 +87,14 @@ let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.
   | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
     log_routine
       (Printf.sprintf "tool completed agent=%s tool_name=%s" agent_name tool_name)
+  | Agent_sdk.Event_bus.ToolApprovalCompleted
+      { agent_name; tool_name; approval; _ } ->
+    log_routine
+      (Printf.sprintf
+         "tool approval completed agent=%s tool_name=%s approval=%s"
+         agent_name
+         tool_name
+         (tool_approval_label approval))
   | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
     (* [substrate:tool_surface] — deterministic per-turn snapshot of the
          tool list the LLM actually sees this turn (after guardrails,
@@ -258,6 +272,23 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          @ execution_id_fields)
     in
     Some (wrap ~event_type:"tool_completed" ~payload ~agent_name ~tool_name ())
+  | Agent_sdk.Event_bus.ToolApprovalCompleted
+      { invocation; agent_name; tool_name; approval } ->
+    let payload =
+      `Assoc
+        ([ "agent_name", `String agent_name
+         ; "tool_name", `String tool_name
+         ; "approval", `String (tool_approval_label approval)
+         ]
+         @ invocation_payload_fields invocation)
+    in
+    Some
+      (wrap
+         ~event_type:"tool_approval_completed"
+         ~payload
+         ~agent_name
+         ~tool_name
+         ())
   | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
     let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
     Some (wrap ~event_type:"turn_started" ~payload ~agent_name ~turn ())

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.229.0"}
+  "agent_sdk" {>= "0.230.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.229.0"}
+  "agent_sdk" {= "0.230.0"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.229.0"
-  "git+https://github.com/jeong-sik/oas.git#6bf1751a56357eecddd088383f0aac65275c6de6"
+  "agent_sdk.0.230.0"
+  "git+https://github.com/jeong-sik/oas.git#7a3f2af7aed6fdd19968de3e1637dccb4f867461"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,22 +1,21 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.229.0"
-# v0.229.0 freezes caller-declared Runtime order, requires one semantic
-# validator, advances after strict JSON/domain rejection, and admits ordinary
-# text Runtimes without inventing native schema support. Preference stores and
-# domain settlement/recovery surfaces are removed. MASC consumes only accepted
-# output or typed exhaustion; provider/model resolution, wire parsing, and
-# failover remain OAS-owned.
-# Previous pin: v0.228.0 (0257262d).
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.230.0"
+# v0.230.0 makes pre-tool approval a typed, fail-closed boundary:
+# ElicitToolApproval is distinct from generic ElicitInput, and only an exact
+# Approved invocation may execute. The public Exact_output.execute_once
+# shortcut is removed; callers freeze candidates with snapshot_flow, create an
+# affine flow with start_flow, and consume it through execute_flow_once.
+# Previous pin: v0.229.0 (6bf1751a).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guard in check-oas-pin.sh tracks main; oas-drift-check.sh
 # reports the public-surface delta at pin-bump time.
-# Pinned to the v0.229.0 release commit.
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.229.0"
+# Pinned to the v0.230.0 release commit.
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.230.0"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="6bf1751a56357eecddd088383f0aac65275c6de6"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.229.0"
+readonly OAS_AGENT_SDK_SHA="7a3f2af7aed6fdd19968de3e1637dccb4f867461"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.230.0"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "6bf1751a56357eecddd088383f0aac65275c6de6",
-  "pinned_version": "v0.229.0",
+  "pinned_sha": "7a3f2af7aed6fdd19968de3e1637dccb4f867461",
+  "pinned_version": "v0.230.0",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",
@@ -11,6 +11,7 @@
       "HandoffCompleted",
       "HandoffRequested",
       "InferenceTelemetry",
+      "ToolApprovalCompleted",
       "ToolCalled",
       "ToolCompleted",
       "TurnCompleted",

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -18,6 +18,29 @@
       "TurnReady",
       "TurnStarted"
     ],
+    "hook_decision_variants": [
+      "AdjustParams",
+      "Block",
+      "Continue",
+      "ElicitInput",
+      "ElicitToolApproval",
+      "HookFailed",
+      "Nudge"
+    ],
+    "hook_decision_kind_variants": [
+      "K_AdjustParams",
+      "K_Block",
+      "K_Continue",
+      "K_ElicitInput",
+      "K_ElicitToolApproval",
+      "K_HookFailed",
+      "K_Nudge"
+    ],
+    "tool_approval_variants": [
+      "Approved",
+      "Denied",
+      "Timed_out"
+    ],
     "http_error_variants": [
       "AcceptRejected",
       "HttpError",

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -132,6 +132,25 @@ extract_event_bus_variants() {
   ' "${file}" | sort -u
 }
 
+# Closed Hook variants are control decisions, not telemetry. A new constructor
+# can compile at wildcard consumers while changing whether MASC grants tool
+# execution authority, so keep the decision, decision-kind, and approval
+# result sets in the pin fingerprint.
+extract_hook_variants() {
+  local src="$1"
+  local type_name="$2"
+  local file="${src}/lib/base/hooks.mli"
+  [[ -f "${file}" ]] || { echo "missing ${file}" >&2; return 1; }
+  awk -v type_name="${type_name}" '
+    $0 ~ ("^type " type_name "[[:space:]]*=") { inblock=1; next }
+    inblock && /^(type|val|module|exception) / { inblock=0 }
+    inblock && /^  \| [A-Z]/ {
+      sub(/^  \| /, ""); sub(/[[:space:]].*/, "");
+      print
+    }
+  ' "${file}" | sort -u
+}
+
 # Http_client error variants from the .mli type http_error.
 extract_http_error_variants() {
   local src="$1"
@@ -321,8 +340,11 @@ lines_to_json_array() {
 
 build_fingerprint() {
   local src="$1"
-  local ebv hev irr mf eod eor
+  local ebv hdv hdk tav hev irr mf eod eor
   ebv="$(extract_event_bus_variants   "${src}" | lines_to_json_array)"
+  hdv="$(extract_hook_variants "${src}" hook_decision | lines_to_json_array)"
+  hdk="$(extract_hook_variants "${src}" hook_decision_kind | lines_to_json_array)"
+  tav="$(extract_hook_variants "${src}" tool_approval | lines_to_json_array)"
   hev="$(extract_http_error_variants  "${src}" | lines_to_json_array)"
   irr="$(extract_invalid_request_reasons "${src}" | lines_to_json_array)"
   mf="$( extract_metrics_fields       "${src}" | lines_to_json_array)"
@@ -333,6 +355,9 @@ build_fingerprint() {
     --arg sha "${OAS_AGENT_SDK_SHA}" \
     --arg ver "${OAS_AGENT_SDK_BASE_VERSION}" \
     --argjson ebv "${ebv}" \
+    --argjson hdv "${hdv}" \
+    --argjson hdk "${hdk}" \
+    --argjson tav "${tav}" \
     --argjson hev "${hev}" \
     --argjson irr "${irr}" \
     --argjson mf  "${mf}" \
@@ -343,6 +368,9 @@ build_fingerprint() {
        pinned_version:    $ver,
        surfaces: {
          event_bus_payload_variants: $ebv,
+         hook_decision_variants:      $hdv,
+         hook_decision_kind_variants: $hdk,
+         tool_approval_variants:      $tav,
          http_error_variants:        $hev,
          invalid_request_reasons:    $irr,
          metrics_fields:             $mf,
@@ -461,7 +489,7 @@ case "${MODE}" in
     if ! report_metadata_diff "${prev}" "${current}"; then
       drift=1
     fi
-    for section in event_bus_payload_variants http_error_variants invalid_request_reasons metrics_fields exact_output_declarations exact_output_reexport_declarations; do
+    for section in event_bus_payload_variants hook_decision_variants hook_decision_kind_variants tool_approval_variants http_error_variants invalid_request_reasons metrics_fields exact_output_declarations exact_output_reexport_declarations; do
       prev_arr="$(jq ".surfaces.${section}" <<<"${prev}")"
       curr_arr="$(jq ".surfaces.${section}" <<<"${current}")"
       if ! report_diff "${section}" "${prev_arr}" "${curr_arr}"; then

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -146,6 +146,43 @@ let test_tool_completed_without_entry_omits_execution_id () =
   check (option string) "tool_use_id still present" (Some "tu-5")
     (string_of_field (payload_member "tool_use_id" json))
 
+let test_tool_approval_completed_preserves_exact_occurrence () =
+  let json =
+    Bridge.native_event_to_json
+      (mk_event
+         (Agent_sdk.Event_bus.ToolApprovalCompleted
+            { invocation = invocation ~turn:4 ~planned_index:2 "tu-approved"
+            ; agent_name = "keeper-approval"
+            ; tool_name = "Execute"
+            ; approval = Agent_sdk.Hooks.Approved
+            }))
+    |> Option.get
+  in
+  check (option string)
+    "typed event kind"
+    (Some "tool_approval_completed")
+    (string_of_field (member "event_type" json));
+  check (option string)
+    "closed approval result"
+    (Some "approved")
+    (string_of_field (payload_member "approval" json));
+  check (option string)
+    "exact tool occurrence"
+    (Some "tu-approved")
+    (string_of_field (payload_member "tool_use_id" json));
+  check (option int)
+    "exact invocation turn"
+    (Some 4)
+    (int_of_field (payload_member "turn" json));
+  check (option int)
+    "exact invocation index"
+    (Some 2)
+    (int_of_field (payload_member "planned_index" json));
+  check bool
+    "approval event does not copy tool input"
+    true
+    (payload_member "input" json = None)
+
 let test_empty_tool_use_id_omitted_from_payload () =
   Join.For_testing.clear ();
   let json =
@@ -449,6 +486,8 @@ let () =
             test_tool_completed_stamps_execution_id
         ; test_case "non-keeper completion omits execution_id" `Quick
             test_tool_completed_without_entry_omits_execution_id
+        ; test_case "tool approval preserves exact occurrence" `Quick
+            test_tool_approval_completed_preserves_exact_occurrence
         ; test_case "empty tool_use_id omitted" `Quick
             test_empty_tool_use_id_omitted_from_payload
         ; test_case "agent_failed matches typed constructor" `Quick

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -77,14 +77,7 @@ let test_sources () =
     (slot_string "after_turn" "source")
 
 let make_meta_ref (name : string) : Masc.Keeper_meta_contract.keeper_meta ref =
-  let json : Yojson.Safe.t =
-    `Assoc
-      [
-        "name", `String name;
-        "agent_name", `String name;
-        "trace_id", `String "keeper-hooks-introspection-test";
-      ]
-  in
+  let json : Yojson.Safe.t = `Assoc [ "name", `String name ] in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> ref meta
   | Error e -> failwith ("make_meta_ref: " ^ e)

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -145,6 +145,8 @@ let test_pre_tool_use_is_observation_only () =
   | Agent_sdk.Hooks.Continue -> ()
   | AdjustParams _ -> fail "pre_tool_use timing hook adjusted parameters"
   | ElicitInput _ -> fail "pre_tool_use timing hook elicited input"
+  | ElicitToolApproval _ ->
+    fail "pre_tool_use timing hook elicited tool approval"
   | Nudge _ -> fail "pre_tool_use timing hook returned Nudge"
   | HookFailed _ -> fail "pre_tool_use timing hook failed"
   | Block _ -> fail "pre_tool_use timing hook returned Block"


### PR DESCRIPTION
## Summary

- pin the published OAS v0.230.0 release commit 7a3f2af7aed6fdd19968de3e1637dccb4f867461
- synchronize dependency manifests, generated docs, and the reviewed API fingerprint
- explicitly bridge the new typed ToolApprovalCompleted event with exact invocation identity and a closed approval result
- preserve OAS privacy: the event carries no copied tool input

## Release evidence

- OAS PR #2847 merged at commit 7a3f2af7aed6fdd19968de3e1637dccb4f867461
- release-please run 30399034318 succeeded
- v0.230.0 is published and targets that exact commit

## Validation

- scripts/check-oas-pin.sh --local-only
- scripts/sync-oas-pin-manifests.sh --check --surface
- focused build: test/test_keeper_execution_join.exe and lib/server/masc_server.cmxa
- keeper_execution_join: 15/15 passed
- ocamlformat and git diff --check passed

The separately tracked pre-existing focused dispatch failures remain in #26171; they reproduce before this pin and still reproduce with the exact 0.230.0 pin.