### PR TITLE
fix(runtime): require Keeper request body caps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,6 +837,19 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_runtime_provider_auth_headers"
 
+      - name: Run Keeper request-cap suite
+        id: keeper_request_cap_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+           request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover"
+           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
+
       - name: Run operator control suite
         id: operator_control_suite
         # Run regardless of earlier test failures, but only after a successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -847,8 +847,8 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-           request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover"
-           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
+          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_vision_tool @test/runtest-test_keeper_memory_os_consolidation_runtime @test/runtest-test_server_bootstrap_maintenance_memory_os"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
 
       - name: Run operator control suite
         id: operator_control_suite

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -207,14 +207,24 @@ supports-multimodal-inputs = true
 
 [ollama_cloud.deepseek-v4-flash]
 wizard-default = true
+# Keeper application working set, not the provider's 1M-token capability.
+# The exact final JSON body (system/tail + tools + lossless transcript) must
+# remain bounded so durable canonical history cannot become an n,n+1,... wire
+# replay. OAS rejects an oversized serialized body locally before POST; the
+# Keeper turn policy owns any subsequent recovery decision.
+max-request-body-bytes = 524288
 
 [deepseek.deepseek-v4-pro]
+max-request-body-bytes = 524288
 
 [deepseek.deepseek-v4-flash]
 wizard-default = true
+max-request-body-bytes = 524288
 
 [glm-coding.glm-4-7-coding]
 wizard-default = true
+# GLM's smaller serving window gets a smaller explicit wire working set.
+max-request-body-bytes = 262144
 
 [models.glm-5-turbo]
 api-name = "GLM-5-Turbo"
@@ -236,6 +246,7 @@ supports-response-format-json = true
 supports-structured-output = false
 
 [glm-coding.glm-5-turbo]
+max-request-body-bytes = 262144
 
 # MiniMax M3 (Ollama Cloud) — chat/runtime binding retained for explicit
 # operator use. Do not route provider-native structured-output lanes here unless
@@ -376,6 +387,7 @@ supports-image-input = false
 supports-multimodal-inputs = false
 
 [ollama_cloud.ollama-cloud-deepseek-v4-flash]
+max-request-body-bytes = 524288
 
 [models.ollama-cloud-deepseek-v4-pro]
 api-name = "deepseek-v4-pro"

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -301,6 +301,9 @@ supports-multimodal-inputs = true
 
 [ollama_cloud_native.minimax-m3-native-structured]
 wizard-default = true
+# This is the explicit Memory OS consolidation route. It bypasses the normal
+# turn driver, so it must carry its own exact serialized-request ceiling.
+max-request-body-bytes = 524288
 
 # Kimi K2.7 Code (Ollama Cloud) — vision-capable Cloud runtime. The model name
 # is kept separate from Kimi's direct API route; OAS owns provider/model wire

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -26,6 +26,8 @@ let consolidation_max_tokens = 8192
 
 type outcome =
   | Skipped_too_few of int
+  | Provider_config_invalid of Runtime.request_body_cap_error
+  | Provider_transport_failed of string
   | Transport_failed of string
   | Unparseable of string
   | Empty_response
@@ -144,21 +146,24 @@ let consolidate_keeper
       ~keeper_id
       ()
   =
-  match Io.read_facts_all_strict ~keeper_id with
-  | Error msg -> Unparseable ("consolidation fact store read failed: " ^ msg)
-  | Ok facts ->
-    let before = List.length facts in
-    if before = 0
-    then Skipped_too_few before
-    else
-      match messages_for_consolidation facts with
-      | Error msg -> Unparseable msg
-      | Ok messages ->
-        (match
+  match Runtime.validate_request_body_cap ~runtime_id provider_cfg with
+  | Error error -> Provider_config_invalid error
+  | Ok () ->
+    match Io.read_facts_all_strict ~keeper_id with
+    | Error msg -> Unparseable ("consolidation fact store read failed: " ^ msg)
+    | Ok facts ->
+      let before = List.length facts in
+      if before = 0
+      then Skipped_too_few before
+      else
+        match messages_for_consolidation facts with
+        | Error msg -> Unparseable msg
+        | Ok messages ->
+          (match
            Keeper_provider_subcall.complete ?override:complete ~sw ~net ?clock
              ~config:provider_cfg ~messages ()
          with
-         | Error _ -> Transport_failed "consolidation provider transport error"
+         | Error _ -> Provider_transport_failed "consolidation provider transport error"
          | Ok response ->
            if String.trim (Agent_sdk_response.text_of_response response) = ""
            then Empty_response
@@ -228,5 +233,5 @@ let consolidate_keeper
                     ~after
                     ()
               | Ok _ -> invalid_structured_response Consolidation.Non_object_json)
-        )
+          )
 ;;

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -163,7 +163,11 @@ let consolidate_keeper
            Keeper_provider_subcall.complete ?override:complete ~sw ~net ?clock
              ~config:provider_cfg ~messages ()
          with
-         | Error _ -> Provider_transport_failed "consolidation provider transport error"
+         | Error error ->
+           let detail = Provider_http_error.to_message error in
+           if Runtime_attempt_fsm.should_try_next error
+           then Provider_transport_failed detail
+           else Transport_failed detail
          | Ok response ->
            if String.trim (Agent_sdk_response.text_of_response response) = ""
            then Empty_response

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -9,6 +9,12 @@ type complete_fn = Keeper_provider_subcall.complete_fn
 
 type outcome =
   | Skipped_too_few of int
+  | Provider_config_invalid of Runtime.request_body_cap_error
+      (** The resolved direct provider config lacks a positive serialized-request
+          body ceiling. No provider call was made. *)
+  | Provider_transport_failed of string
+      (** The provider boundary failed. Callers may try the next configured lane
+          candidate without reclassifying local clock or store failures. *)
   | Transport_failed of string
   | Unparseable of string
   | Empty_response

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -239,21 +239,18 @@ let runtime_candidate_missing_error id =
        "keeper_turn_driver: lane candidate %S disappeared from runtimes"
        id)
 
-let runtime_candidate_missing_request_cap_error ~runtime_id =
+let runtime_candidate_missing_request_cap_error error =
   Agent_sdk.Error.Config
     (Agent_sdk.Error.InvalidConfig
        { field = "max-request-body-bytes"
-       ; detail =
-           Printf.sprintf
-             "Keeper runtime %S has no positive serialized-request ceiling"
-             runtime_id
+       ; detail = Runtime.request_body_cap_error_to_string error
        })
 
 let validate_provider_request_cap ~runtime_id
     (provider_config : Llm_provider.Provider_config.t) =
-  match provider_config.max_request_body_bytes with
-  | Some cap when cap > 0 -> Ok ()
-  | None | Some _ -> Error (runtime_candidate_missing_request_cap_error ~runtime_id)
+  match Runtime.validate_request_body_cap ~runtime_id provider_config with
+  | Ok () -> Ok ()
+  | Error error -> Error (runtime_candidate_missing_request_cap_error error)
 
 let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -239,9 +239,22 @@ let runtime_candidate_missing_error id =
        "keeper_turn_driver: lane candidate %S disappeared from runtimes"
        id)
 
+let runtime_candidate_missing_request_cap_error (runtime : Runtime.t) =
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig
+       { field = "max-request-body-bytes"
+       ; detail =
+           Printf.sprintf
+             "Keeper runtime %S has no positive serialized-request ceiling"
+             runtime.id
+       })
+
 let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
-  | Some runtime -> Ok runtime
+  | Some runtime ->
+    (match runtime.Runtime.binding.max_request_body_bytes with
+     | Some cap when cap > 0 -> Ok runtime
+     | None | Some _ -> Error (runtime_candidate_missing_request_cap_error runtime))
   | None -> Error (runtime_candidate_missing_error id)
 
 let resolve_runtime_candidate_for_attempt ?on_missing id =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -239,22 +239,31 @@ let runtime_candidate_missing_error id =
        "keeper_turn_driver: lane candidate %S disappeared from runtimes"
        id)
 
-let runtime_candidate_missing_request_cap_error (runtime : Runtime.t) =
+let runtime_candidate_missing_request_cap_error ~runtime_id =
   Agent_sdk.Error.Config
     (Agent_sdk.Error.InvalidConfig
        { field = "max-request-body-bytes"
        ; detail =
            Printf.sprintf
              "Keeper runtime %S has no positive serialized-request ceiling"
-             runtime.id
+             runtime_id
        })
+
+let validate_provider_request_cap ~runtime_id
+    (provider_config : Llm_provider.Provider_config.t) =
+  match provider_config.max_request_body_bytes with
+  | Some cap when cap > 0 -> Ok ()
+  | None | Some _ -> Error (runtime_candidate_missing_request_cap_error ~runtime_id)
 
 let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
-    (match runtime.Runtime.binding.max_request_body_bytes with
-     | Some cap when cap > 0 -> Ok runtime
-     | None | Some _ -> Error (runtime_candidate_missing_request_cap_error runtime))
+    let* () =
+      validate_provider_request_cap
+        ~runtime_id:runtime.id
+        runtime.Runtime.provider_config
+    in
+    Ok runtime
   | None -> Error (runtime_candidate_missing_error id)
 
 let resolve_runtime_candidate_for_attempt ?on_missing id =
@@ -656,11 +665,20 @@ let run_named
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         Error err, None
       | Ok provider_config ->
-        let candidate = Runtime_candidate.of_provider_config provider_config in
-        (* Cached provider health is observation only. Every eligible runtime
-           reaches the real provider boundary; only the resulting typed error
-           may drive fallback. *)
-        let name = Printf.sprintf "oas-%s" attempt_runtime_id in
+        (match
+           validate_provider_request_cap
+             ~runtime_id:attempt_runtime_id
+             provider_config
+         with
+         | Error err ->
+           Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+           Error err, None
+         | Ok () ->
+          let candidate = Runtime_candidate.of_provider_config provider_config in
+          (* Cached provider health is observation only. Every eligible runtime
+             reaches the real provider boundary; only the resulting typed error
+             may drive fallback. *)
+          let name = Printf.sprintf "oas-%s" attempt_runtime_id in
           let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
             { runtime_id = attempt_runtime_id
             ; error_runtime_id
@@ -717,7 +735,7 @@ let run_named
               ~replay_prefix_projection
               provider_result
           in
-          outcomes.turn_result, checkpoint_after)
+          outcomes.turn_result, checkpoint_after))
     attempt_candidates
 
 

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -332,10 +332,21 @@ let run_candidates_outcome
           rest
       in
       let config = provider_for_vision rt.Runtime.provider_config in
-      (match
-         Keeper_provider_subcall.complete ?override:complete ~sw ~net ~clock
-           ~config ~messages ()
-       with
+      match Runtime.validate_request_body_cap ~runtime_id config with
+      | Error error ->
+        record_vision_candidate_attempt
+          ~runtime_id
+          ~result:"error"
+          ~reason:"missing_request_body_cap";
+        Vo_provider
+          { failure_class = Tool_result.Runtime_failure
+          ; detail = Runtime.request_body_cap_error_to_string error
+          }
+      | Ok () ->
+        (match
+           Keeper_provider_subcall.complete ?override:complete ~sw ~net ~clock
+             ~config ~messages ()
+         with
        | Error (Llm_provider.Http_client.TimeoutError _) ->
             record_vision_candidate_attempt
               ~runtime_id

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -533,12 +533,15 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
          r.model.id)
 ;;
 
-(* Keeper provider attempts can originate at the configured default, an
-   explicit keeper assignment, or any declared failover lane. Explicit media
-   failover runtimes are separate request-producing Keeper paths and therefore
-   share the same serialized-request admission contract. Expand lane ids with
-   the same lane-over-runtime precedence as [resolve_assignment], then preserve
-   first occurrence order. No provider/model names live in this policy. *)
+(* Keeper provider attempts originate at the configured default, an explicit
+   keeper assignment, or an explicit media-failover runtime. A lane is
+   reachable only when its id shadows one of the default/assignment runtime
+   roots; a merely declared lane is dormant until a routed root names it.
+   Expand routed roots with the same lane-over-runtime precedence as
+   [resolve_assignment], keep media_failover runtime-only, then preserve first
+   occurrence order. Every attempt is checked again after its final provider
+   config transform in Keeper_turn_driver. No provider/model names live in
+   this policy. *)
 let keeper_dispatch_runtime_ids
     ~(default_runtime_id : string)
     ~(assignments : (string * string) list)
@@ -554,15 +557,12 @@ let keeper_dispatch_runtime_ids
     default_runtime_id :: List.map snd assignments
     |> List.concat_map expand
   in
-  let declared_lane_candidates =
-    lanes |> List.concat_map Runtime_lane.ordered_candidates
-  in
   let rec dedupe seen acc = function
     | [] -> List.rev acc
     | id :: rest when List.mem id seen -> dedupe seen acc rest
     | id :: rest -> dedupe (id :: seen) (id :: acc) rest
   in
-  dedupe [] [] (routed_roots @ declared_lane_candidates @ media_failover)
+  dedupe [] [] (routed_roots @ media_failover)
 ;;
 
 let validate_keeper_dispatch_request_caps

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -533,10 +533,34 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
          r.model.id)
 ;;
 
+type request_body_cap_error = Missing_or_non_positive_request_body_cap of
+  { runtime_id : string
+  }
+
+let request_body_cap_error_to_string = function
+  | Missing_or_non_positive_request_body_cap { runtime_id } ->
+    Printf.sprintf
+      "Keeper runtime %S has no positive serialized-request ceiling"
+      runtime_id
+;;
+
+(* The capability is checked at configuration admission and again immediately
+   before each concrete provider call. The latter is required because feature
+   owners may transform a materialized provider config after runtime.toml has
+   been accepted. *)
+let validate_request_body_cap ~runtime_id
+    (provider_config : Llm_provider.Provider_config.t) =
+  match provider_config.max_request_body_bytes with
+  | Some cap when cap > 0 -> Ok ()
+  | None | Some _ ->
+    Error (Missing_or_non_positive_request_body_cap { runtime_id })
+;;
+
 (* Keeper provider attempts originate at the configured default, an explicit
-   keeper assignment, or an explicit media-failover runtime. A lane is
-   reachable only when its id shadows one of the default/assignment runtime
-   roots; a merely declared lane is dormant until a routed root names it.
+   keeper assignment, an explicit media-failover runtime, or the periodic
+   Memory OS consolidation runtime. A lane is reachable only when its id
+   shadows one of the default/assignment runtime roots; a merely declared lane
+   is dormant until a routed root names it.
    Expand routed roots with the same lane-over-runtime precedence as
    [resolve_assignment], keep media_failover runtime-only, then preserve first
    occurrence order. Every attempt is checked again after its final provider
@@ -546,6 +570,7 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
 let keeper_dispatch_runtime_ids
     ~(default_runtime_id : string)
     ~(assignments : (string * string) list)
+    ~(memory_os_consolidation_runtime_id : string option)
     ~(media_failover : string list)
     ~(lanes : Runtime_lane.t list)
   =
@@ -563,7 +588,17 @@ let keeper_dispatch_runtime_ids
     | id :: rest when List.mem id seen -> dedupe seen acc rest
     | id :: rest -> dedupe (id :: seen) (id :: acc) rest
   in
-  dedupe [] [] (routed_roots @ media_failover)
+  (* The maintenance route reaches the provider outside Keeper_turn_driver, so
+     startup must admit every configured lane candidate's request cap here as
+     well. *)
+  dedupe
+    []
+    []
+    ( routed_roots
+      @ media_failover
+      @ (memory_os_consolidation_runtime_id
+         |> Option.to_list
+         |> List.concat_map expand) )
 ;;
 
 (* TEL-OK: pure fail-closed validation; the load boundary surfaces its error. *)
@@ -572,7 +607,7 @@ let validate_keeper_dispatch_request_caps
     ( runtimes
     , (default_runtime : t)
     , assignments
-    , _memory_os_consolidation_id
+    , memory_os_consolidation_runtime_id
     , _structured_judge_id
     , _cross_verifier_id
     , media_failover
@@ -582,6 +617,7 @@ let validate_keeper_dispatch_request_caps
     keeper_dispatch_runtime_ids
       ~default_runtime_id:default_runtime.id
       ~assignments
+      ~memory_os_consolidation_runtime_id
       ~media_failover
       ~lanes
   in
@@ -594,9 +630,13 @@ let validate_keeper_dispatch_request_caps
          match runtime_by_id id with
          | None -> None
          | Some runtime ->
-           (match runtime.binding.max_request_body_bytes with
-            | Some cap when cap > 0 -> None
-            | None | Some _ -> Some runtime))
+           (match
+              validate_request_body_cap
+                ~runtime_id:runtime.id
+                runtime.provider_config
+            with
+            | Ok () -> None
+            | Error _ -> Some runtime))
       ids
   with
   | None -> Ok ()
@@ -1227,38 +1267,60 @@ type dashboard_runtime_defaults_snapshot =
    immutable loaded-state snapshot. Only an absent task route inherits the
    default. A configured id missing from the same snapshot is an invariant
    violation, never permission to execute on a different runtime. *)
-let resolve_memory_os_consolidation_from_state (state : loaded_state) =
+let resolve_memory_os_consolidation_runtime_candidates_from_state
+    (state : loaded_state)
+  =
   match state.default_runtime, state.memory_os_consolidation_runtime_id with
   | None, _ ->
     Error
       "Memory OS consolidation runtime cannot resolve before runtime initialization"
   | Some default_runtime, None ->
-    Ok
-      { effective_runtime = default_runtime
-      ; resolution_source = Consolidation_inherited_default
-      }
-  | Some _, Some runtime_id ->
-    (match
-       List.find_opt
-         (fun (runtime : t) -> String.equal runtime.id runtime_id)
-         state.runtimes
-     with
-     | Some runtime ->
-       Ok
-         { effective_runtime = runtime
-         ; resolution_source = Consolidation_configured
-         }
-     | None ->
-       Error
-         (Printf.sprintf
-            "configured [runtime].memory_os_consolidation id %S is absent from \
-             the loaded runtime snapshot"
-            runtime_id))
+    Ok [ default_runtime ]
+  | Some _, Some route_id ->
+    let candidate_ids =
+      match find_declared_lane state.lanes route_id with
+      | Some lane -> Runtime_lane.ordered_candidates lane
+      | None -> [ route_id ]
+    in
+    let rec resolve acc = function
+      | [] -> Ok (List.rev acc)
+      | runtime_id :: rest ->
+        (match
+           List.find_opt
+             (fun (runtime : t) -> String.equal runtime.id runtime_id)
+             state.runtimes
+         with
+         | Some runtime -> resolve (runtime :: acc) rest
+         | None ->
+           Error
+             (Printf.sprintf
+                "configured [runtime].memory_os_consolidation candidate %S is \
+                 absent from the loaded runtime snapshot"
+                runtime_id))
+    in
+    resolve [] candidate_ids
+;;
+
+let resolve_memory_os_consolidation_from_state (state : loaded_state) =
+  let source =
+    match state.memory_os_consolidation_runtime_id with
+    | None -> Consolidation_inherited_default
+    | Some _ -> Consolidation_configured
+  in
+  match resolve_memory_os_consolidation_runtime_candidates_from_state state with
+  | Error _ as error -> error
+  | Ok [] ->
+    Error "Memory OS consolidation route resolved to an empty runtime candidate list"
+  | Ok (effective_runtime :: _) -> Ok { effective_runtime; resolution_source = source }
 ;;
 
 let resolve_memory_os_consolidation_runtime () =
   resolve_memory_os_consolidation_from_state (runtime_state ())
   |> Result.map (fun resolution -> resolution.effective_runtime)
+;;
+
+let resolve_memory_os_consolidation_runtime_candidates () =
+  resolve_memory_os_consolidation_runtime_candidates_from_state (runtime_state ())
 ;;
 
 let dashboard_runtime_defaults_snapshot () =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -533,6 +533,84 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
          r.model.id)
 ;;
 
+(* Keeper provider attempts can originate at the configured default, an
+   explicit keeper assignment, or any declared failover lane. Explicit media
+   failover runtimes are separate request-producing Keeper paths and therefore
+   share the same serialized-request admission contract. Expand lane ids with
+   the same lane-over-runtime precedence as [resolve_assignment], then preserve
+   first occurrence order. No provider/model names live in this policy. *)
+let keeper_dispatch_runtime_ids
+    ~(default_runtime_id : string)
+    ~(assignments : (string * string) list)
+    ~(media_failover : string list)
+    ~(lanes : Runtime_lane.t list)
+  =
+  let expand id =
+    match find_declared_lane lanes id with
+    | Some lane -> Runtime_lane.ordered_candidates lane
+    | None -> [ id ]
+  in
+  let routed_roots =
+    default_runtime_id :: List.map snd assignments
+    |> List.concat_map expand
+  in
+  let declared_lane_candidates =
+    lanes |> List.concat_map Runtime_lane.ordered_candidates
+  in
+  let rec dedupe seen acc = function
+    | [] -> List.rev acc
+    | id :: rest when List.mem id seen -> dedupe seen acc rest
+    | id :: rest -> dedupe (id :: seen) (id :: acc) rest
+  in
+  dedupe [] [] (routed_roots @ declared_lane_candidates @ media_failover)
+;;
+
+let validate_keeper_dispatch_request_caps
+    ~(config_path : string)
+    ( runtimes
+    , (default_runtime : t)
+    , assignments
+    , _memory_os_consolidation_id
+    , _structured_judge_id
+    , _cross_verifier_id
+    , media_failover
+    , lanes )
+  =
+  let ids =
+    keeper_dispatch_runtime_ids
+      ~default_runtime_id:default_runtime.id
+      ~assignments
+      ~media_failover
+      ~lanes
+  in
+  let runtime_by_id id =
+    List.find_opt (fun (runtime : t) -> String.equal runtime.id id) runtimes
+  in
+  match
+    List.find_map
+      (fun id ->
+         match runtime_by_id id with
+         | None -> None
+         | Some runtime ->
+           (match runtime.binding.max_request_body_bytes with
+            | Some cap when cap > 0 -> None
+            | None | Some _ -> Some runtime))
+      ids
+  with
+  | None -> Ok ()
+  | Some runtime ->
+    Error
+      (Printf.sprintf
+         "%s: Keeper-dispatch runtime %S has no positive \
+          max-request-body-bytes; declare [%s.%s].max-request-body-bytes before \
+          dispatch so the exact serialized request has an explicit admission \
+          ceiling"
+         config_path
+         runtime.id
+         runtime.binding.provider_id
+         runtime.binding.model_id)
+;;
+
 (* Every runtime binding's provider/model pair must be known to the OAS
    capability catalog. Use the materialized [Provider_config.t] so
    provider-qualified catalog rows are considered before bare model rows; this
@@ -1043,8 +1121,11 @@ let init_default_strict_report ~config_path =
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | Some report -> Error (Missing_catalog_models report)
      | None ->
-       set_loaded ~config_path loaded;
-       Ok ())
+       (match validate_keeper_dispatch_request_caps ~config_path loaded with
+        | Error msg -> Error (Runtime_config_error msg)
+        | Ok () ->
+          set_loaded ~config_path loaded;
+          Ok ()))
 
 let init_default_strict ~config_path =
   init_default_strict_report ~config_path
@@ -1059,8 +1140,11 @@ let init_default_degraded_report ~config_path =
        (match validate_runtime_max_context ~config_path runtimes with
         | Error msg -> Error (Runtime_config_error msg)
         | Ok () ->
-          set_loaded ~config_path loaded;
-          Ok Initialized)
+          (match validate_keeper_dispatch_request_caps ~config_path loaded with
+           | Error msg -> Error (Runtime_config_error msg)
+           | Ok () ->
+             set_loaded ~config_path loaded;
+             Ok Initialized))
      | Some report ->
        (match degrade_loaded_for_missing_catalog loaded report with
         | Error msg -> Error (Runtime_config_error msg)
@@ -1070,11 +1154,18 @@ let init_default_degraded_report ~config_path =
           (match validate_runtime_max_context ~config_path active_runtimes with
            | Error msg -> Error (Runtime_config_error msg)
            | Ok () ->
-             set_loaded
-               ~startup_degradation:degradation
-               ~config_path
-               degraded_loaded;
-             Ok (Initialized_degraded degradation))))
+             (match
+                validate_keeper_dispatch_request_caps
+                  ~config_path
+                  degraded_loaded
+              with
+              | Error msg -> Error (Runtime_config_error msg)
+              | Ok () ->
+                set_loaded
+                  ~startup_degradation:degradation
+                  ~config_path
+                  degraded_loaded;
+                Ok (Initialized_degraded degradation)))))
 
 let runtime_state () = Atomic.get loaded_state_ref
 
@@ -1636,8 +1727,10 @@ let materialize_runtime_config_text ~config_path content =
 ;;
 
 let validate_runtime_config_text ~config_path content =
-  let* _loaded = materialize_runtime_config_text ~config_path content in
-  Ok ()
+  let* loaded, _exact_output_lanes =
+    materialize_runtime_config_text ~config_path content
+  in
+  validate_keeper_dispatch_request_caps ~config_path loaded
 ;;
 
 let runtime_config_write_mutex = Mutex.create ()
@@ -1693,6 +1786,7 @@ let commit_runtime_config_text
   let* loaded, exact_output_lanes =
     materialize_runtime_config_text ~config_path:path content
   in
+  let* () = validate_keeper_dispatch_request_caps ~config_path:path loaded in
   match
     Runtime_exact_output_registry.prepare_replacement ~lanes:exact_output_lanes
   with
@@ -1760,6 +1854,7 @@ module For_testing = struct
 
   let snapshot () = runtime_state ()
   let restore snapshot = Atomic.set loaded_state_ref snapshot
+  let keeper_dispatch_runtime_ids = keeper_dispatch_runtime_ids
 
   let save_config_text_with_sync_parent
       ?runtime_config_path

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -542,6 +542,7 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
    occurrence order. Every attempt is checked again after its final provider
    config transform in Keeper_turn_driver. No provider/model names live in
    this policy. *)
+(* TEL-OK: pure reachability projection; callers own config-load diagnostics. *)
 let keeper_dispatch_runtime_ids
     ~(default_runtime_id : string)
     ~(assignments : (string * string) list)
@@ -565,6 +566,7 @@ let keeper_dispatch_runtime_ids
   dedupe [] [] (routed_roots @ media_failover)
 ;;
 
+(* TEL-OK: pure fail-closed validation; the load boundary surfaces its error. *)
 let validate_keeper_dispatch_request_caps
     ~(config_path : string)
     ( runtimes
@@ -1786,6 +1788,7 @@ let commit_runtime_config_text
   let* loaded, exact_output_lanes =
     materialize_runtime_config_text ~config_path:path content
   in
+  (* TEL-OK: validation is pure; config commit owns visible failure reporting. *)
   let* () = validate_keeper_dispatch_request_caps ~config_path:path loaded in
   match
     Runtime_exact_output_registry.prepare_replacement ~lanes:exact_output_lanes
@@ -1851,9 +1854,11 @@ let save_config_text ?runtime_config_path content =
 
 module For_testing = struct
   type snapshot = loaded_state
+  (* TEL-OK: this module only exposes pure state and validation test helpers. *)
 
   let snapshot () = runtime_state ()
   let restore snapshot = Atomic.set loaded_state_ref snapshot
+  (* TEL-OK: test-only alias of the pure reachability projection above. *)
   let keeper_dispatch_runtime_ids = keeper_dispatch_runtime_ids
 
   let save_config_text_with_sync_parent

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -557,11 +557,11 @@ let validate_request_body_cap ~runtime_id
 ;;
 
 (* Keeper provider attempts originate at the configured default, an explicit
-   keeper assignment, an explicit media-failover runtime, or the periodic
-   Memory OS consolidation runtime. A lane is reachable only when its id
-   shadows one of the default/assignment runtime roots; a merely declared lane
-   is dormant until a routed root names it.
-   Expand routed roots with the same lane-over-runtime precedence as
+   keeper assignment, an explicit media-failover runtime, the periodic Memory
+   OS consolidation runtime, structured judge, or cross verifier. A lane is
+   reachable only when its id shadows one of the configured routes; a merely
+   declared lane is dormant until a routed root names it.
+   Expand each lane-capable route with the same lane-over-runtime precedence as
    [resolve_assignment], keep media_failover runtime-only, then preserve first
    occurrence order. Every attempt is checked again after its final provider
    config transform in Keeper_turn_driver. No provider/model names live in
@@ -571,6 +571,8 @@ let keeper_dispatch_runtime_ids
     ~(default_runtime_id : string)
     ~(assignments : (string * string) list)
     ~(memory_os_consolidation_runtime_id : string option)
+    ~(structured_judge_runtime_id : string option)
+    ~(cross_verifier_runtime_id : string option)
     ~(media_failover : string list)
     ~(lanes : Runtime_lane.t list)
   =
@@ -588,9 +590,9 @@ let keeper_dispatch_runtime_ids
     | id :: rest when List.mem id seen -> dedupe seen acc rest
     | id :: rest -> dedupe (id :: seen) (id :: acc) rest
   in
-  (* The maintenance route reaches the provider outside Keeper_turn_driver, so
-     startup must admit every configured lane candidate's request cap here as
-     well. *)
+  (* These special routes reach providers outside the ordinary keeper default
+     and assignment dispatch, so startup must admit every configured lane
+     candidate's request cap here as well. *)
   dedupe
     []
     []
@@ -598,7 +600,9 @@ let keeper_dispatch_runtime_ids
       @ media_failover
       @ (memory_os_consolidation_runtime_id
          |> Option.to_list
-         |> List.concat_map expand) )
+         |> List.concat_map expand)
+      @ (structured_judge_runtime_id |> Option.to_list |> List.concat_map expand)
+      @ (cross_verifier_runtime_id |> Option.to_list |> List.concat_map expand) )
 ;;
 
 (* TEL-OK: pure fail-closed validation; the load boundary surfaces its error. *)
@@ -608,8 +612,8 @@ let validate_keeper_dispatch_request_caps
     , (default_runtime : t)
     , assignments
     , memory_os_consolidation_runtime_id
-    , _structured_judge_id
-    , _cross_verifier_id
+    , structured_judge_runtime_id
+    , cross_verifier_runtime_id
     , media_failover
     , lanes )
   =
@@ -618,6 +622,8 @@ let validate_keeper_dispatch_request_caps
       ~default_runtime_id:default_runtime.id
       ~assignments
       ~memory_os_consolidation_runtime_id
+      ~structured_judge_runtime_id
+      ~cross_verifier_runtime_id
       ~media_failover
       ~lanes
   in

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -180,8 +180,9 @@ module For_testing : sig
     media_failover:string list ->
     lanes:Runtime_lane.t list ->
     string list
-  (** Ordered, deduplicated runtime ids reachable by Keeper default/assignment,
-      declared lane failover, and explicit media failover routing. *)
+  (** Ordered, deduplicated runtime ids reachable by Keeper default/assignment
+      roots (including a same-named lane's candidates) and explicit
+      runtime-only media failover routing. Dormant declared lanes are excluded. *)
 
   val save_config_text_with_sync_parent :
     ?runtime_config_path:string ->

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -174,6 +174,15 @@ module For_testing : sig
   val snapshot : unit -> snapshot
   val restore : snapshot -> unit
 
+  val keeper_dispatch_runtime_ids :
+    default_runtime_id:string ->
+    assignments:(string * string) list ->
+    media_failover:string list ->
+    lanes:Runtime_lane.t list ->
+    string list
+  (** Ordered, deduplicated runtime ids reachable by Keeper default/assignment,
+      declared lane failover, and explicit media failover routing. *)
+
   val save_config_text_with_sync_parent :
     ?runtime_config_path:string ->
     sync_parent:(string -> unit) ->

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -128,6 +128,22 @@ val load_list :
 
 val runtime_ids : t list -> string list
 
+type request_body_cap_error = Missing_or_non_positive_request_body_cap of
+  { runtime_id : string
+  }
+(** A materialized runtime configuration reaches a Keeper provider boundary
+    without a positive serialized-request body ceiling. *)
+
+val request_body_cap_error_to_string : request_body_cap_error -> string
+
+val validate_request_body_cap :
+  runtime_id:string
+  -> Llm_provider.Provider_config.t
+  -> (unit, request_body_cap_error) result
+(** Pure final-provider-config guard shared by every Keeper provider-call
+    boundary. Config admission uses it for statically reachable routes; call
+    sites must invoke it again after feature-local transforms. *)
+
 (** {1 Lazy default runtime singleton}
 
     Initialized once at startup via {!init_default}.  All consumer
@@ -177,12 +193,14 @@ module For_testing : sig
   val keeper_dispatch_runtime_ids :
     default_runtime_id:string ->
     assignments:(string * string) list ->
+    memory_os_consolidation_runtime_id:string option ->
     media_failover:string list ->
     lanes:Runtime_lane.t list ->
     string list
   (** Ordered, deduplicated runtime ids reachable by Keeper default/assignment
-      roots (including a same-named lane's candidates) and explicit
-      runtime-only media failover routing. Dormant declared lanes are excluded. *)
+      roots (including a same-named lane's candidates), the explicit
+      Memory OS consolidation runtime, and explicit runtime-only media failover
+      routing. Dormant declared lanes are excluded. *)
 
   val save_config_text_with_sync_parent :
     ?runtime_config_path:string ->
@@ -225,6 +243,12 @@ val resolve_memory_os_consolidation_runtime : unit -> (t, string) result
     [\[runtime\].memory_os_consolidation] inherits [\[runtime\].default].
     An uninitialized state or an explicit id missing from the same snapshot is
     [Error], never a fallback to another runtime. *)
+
+val resolve_memory_os_consolidation_runtime_candidates : unit -> (t list, string) result
+(** Ordered candidates for the periodic Memory OS fact-survival consolidation
+    pass. An absent route inherits the default as a singleton; a configured
+    lane expands to its declared ordered candidates. The maintenance caller
+    retries only provider transport failures across this list. *)
 
 type memory_os_consolidation_source =
   | Consolidation_configured

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -194,13 +194,16 @@ module For_testing : sig
     default_runtime_id:string ->
     assignments:(string * string) list ->
     memory_os_consolidation_runtime_id:string option ->
+    structured_judge_runtime_id:string option ->
+    cross_verifier_runtime_id:string option ->
     media_failover:string list ->
     lanes:Runtime_lane.t list ->
     string list
   (** Ordered, deduplicated runtime ids reachable by Keeper default/assignment
       roots (including a same-named lane's candidates), the explicit
-      Memory OS consolidation runtime, and explicit runtime-only media failover
-      routing. Dormant declared lanes are excluded. *)
+      Memory OS consolidation, structured-judge, and cross-verifier runtimes,
+      and explicit runtime-only media failover routing. Dormant declared lanes
+      are excluded. *)
 
   val save_config_text_with_sync_parent :
     ?runtime_config_path:string ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -310,24 +310,28 @@ end
    Provider transport owns the only LLM timeout boundary. The output contract is
    resolved once here — not per keeper — because the tier is a function of the
    provider capabilities and the plan schema only. *)
-let run_memory_os_consolidation_tick
+let run_memory_os_consolidation_tick_with_candidates
       ?complete
       ~sw
       ~net
       ?clock
-      ~runtime_id
-      ~provider_cfg
+      ~runtime_candidates
       ~now
       ()
   =
-  let provider_cfg =
-    Keeper_memory_os_consolidation_runtime.resolve_provider_for_consolidation
-      provider_cfg
+  let runtime_candidates =
+    List.map
+      (fun (runtime_id, provider_cfg) ->
+         ( runtime_id
+         , Keeper_memory_os_consolidation_runtime.resolve_provider_for_consolidation
+             provider_cfg ))
+      runtime_candidates
   in
   let keeper_ids = Keeper_memory_os_io.list_fact_store_keeper_ids () in
-  let consolidate_one keeper_id () =
-    try
-      match
+  let rec consolidate_with_candidates keeper_id = function
+    | [] -> None
+    | (runtime_id, provider_cfg) :: rest ->
+      let outcome =
         Keeper_memory_os_consolidation_runtime.consolidate_keeper
           ?complete
           ~sw
@@ -338,14 +342,32 @@ let run_memory_os_consolidation_tick
           ~now
           ~keeper_id
           ()
-      with
-      | Keeper_memory_os_consolidation_runtime.Consolidated { before; after } ->
+      in
+      (match outcome, rest with
+       | Provider_transport_failed msg, (next_runtime_id, _) :: _ ->
+         Log.Server.warn
+           "memory_os_keeper_consolidation: keeper=%s runtime=%s transport_failed: %s; retrying runtime=%s"
+           keeper_id
+           runtime_id
+           msg
+           next_runtime_id;
+         consolidate_with_candidates keeper_id rest
+       | _ -> Some outcome)
+  in
+  let consolidate_one keeper_id () =
+    try
+      match consolidate_with_candidates keeper_id runtime_candidates with
+      | None ->
+        Log.Server.error
+          "memory_os_keeper_consolidation: keeper=%s has no configured runtime candidate"
+          keeper_id
+      | Some (Keeper_memory_os_consolidation_runtime.Consolidated { before; after }) ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s before=%d after=%d"
           keeper_id
           before
           after
-      | Plan_rejected_total_deletion { before } ->
+      | Some (Plan_rejected_total_deletion { before }) ->
         (* Warn, not info: the store survived, but the model asked to erase it.
            A recurring rejection for one keeper means its plans are malformed
            (truncation is the likely cause), which info-level volume would bury. *)
@@ -354,31 +376,41 @@ let run_memory_os_consolidation_tick
            before=%d"
           keeper_id
           before
-      | Skipped_too_few n ->
+      | Some (Skipped_too_few n) ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s skipped_too_few=%d"
           keeper_id
           n
-      | Transport_failed msg ->
+      | Some (Provider_config_invalid error) ->
+        Log.Server.error
+          "memory_os_keeper_consolidation: keeper=%s provider_config_invalid: %s"
+          keeper_id
+          (Runtime.request_body_cap_error_to_string error)
+      | Some (Provider_transport_failed msg) ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s provider_transport_failed: %s"
+          keeper_id
+          msg
+      | Some (Transport_failed msg) ->
         Log.Server.warn
           "memory_os_keeper_consolidation: keeper=%s transport_failed: %s"
           keeper_id
           msg
-      | Unparseable msg ->
+      | Some (Unparseable msg) ->
         Log.Server.warn
           "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
           keeper_id
           msg
-      | Empty_response ->
+      | Some Empty_response ->
         Log.Server.warn
           "memory_os_keeper_consolidation: keeper=%s empty_response"
           keeper_id
-      | Invalid_structured_response msg ->
+      | Some (Invalid_structured_response msg) ->
         Log.Server.warn
           "memory_os_keeper_consolidation: keeper=%s invalid_structured_response: %s"
           keeper_id
           msg
-      | Snapshot_changed { before; current } ->
+      | Some (Snapshot_changed { before; current }) ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"
           keeper_id
@@ -398,6 +430,26 @@ let run_memory_os_consolidation_tick
      whole burst (#25401). The tick cadence (600s) dwarfs a serial sweep, and
      [consolidate_one] already contains per-keeper failures. *)
   List.iter (fun keeper_id -> consolidate_one keeper_id ()) keeper_ids
+;;
+
+let run_memory_os_consolidation_tick
+      ?complete
+      ~sw
+      ~net
+      ?clock
+      ~runtime_id
+      ~provider_cfg
+      ~now
+      ()
+  =
+  run_memory_os_consolidation_tick_with_candidates
+    ?complete
+    ~sw
+    ~net
+    ?clock
+    ~runtime_candidates:[ runtime_id, provider_cfg ]
+    ~now
+    ()
 ;;
 
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
@@ -633,18 +685,21 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            so a 10-minute cadence bounds cost while still shrinking stores. *)
         let interval = 600.0 in
         let rec loop () =
-          (match Runtime.resolve_memory_os_consolidation_runtime () with
+          (match Runtime.resolve_memory_os_consolidation_runtime_candidates () with
            | Error msg ->
              Log.Server.warn
                "memory_os_keeper_consolidation: %s; skipping tick"
                msg
-           | Ok runtime ->
-             run_memory_os_consolidation_tick
+           | Ok runtime_candidates ->
+             run_memory_os_consolidation_tick_with_candidates
                ~sw
                ~net:env#net
                ~clock
-               ~runtime_id:runtime.Runtime.id
-               ~provider_cfg:runtime.Runtime.provider_config
+               ~runtime_candidates:
+                 (List.map
+                    (fun (runtime : Runtime.t) ->
+                       runtime.Runtime.id, runtime.Runtime.provider_config)
+                    runtime_candidates)
                ~now:(Time_compat.now ())
                ());
           Eio.Time.sleep clock interval;

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -360,6 +360,7 @@ let run_memory_os_consolidation_tick_with_candidates
        | Empty_response, _
        | Invalid_structured_response _, _
        | Snapshot_changed _, _
+       | Plan_rejected_total_deletion _, _
        | Consolidated _, _ ->
          Some outcome)
   in

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -352,7 +352,16 @@ let run_memory_os_consolidation_tick_with_candidates
            msg
            next_runtime_id;
          consolidate_with_candidates keeper_id rest
-       | _ -> Some outcome)
+       | Provider_transport_failed _, []
+       | Skipped_too_few _, _
+       | Provider_config_invalid _, _
+       | Transport_failed _, _
+       | Unparseable _, _
+       | Empty_response, _
+       | Invalid_structured_response _, _
+       | Snapshot_changed _, _
+       | Consolidated _, _ ->
+         Some outcome)
   in
   let consolidate_one keeper_id () =
     try

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -13,6 +13,19 @@ val run_memory_os_consolidation_tick :
   unit ->
   unit
 
+val run_memory_os_consolidation_tick_with_candidates :
+  ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  runtime_candidates:(string * Llm_provider.Provider_config.t) list ->
+  now:float ->
+  unit ->
+  unit
+(** Run a consolidation tick across ordered runtime candidates. Only a provider
+    transport failure advances to the next candidate; parser, policy, and
+    config failures remain terminal for that keeper's tick. *)
+
 val wake_enqueue_counts_of_dispatches :
   Schedule_runner.dispatch_result list -> Schedule_runner_status.wake_enqueue_counts
 (** Derive keeper-wake delivery counts from typed production consumer receipts. *)

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -154,6 +154,7 @@ supports-tool-choice = true
 [deepseek.smoke]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 EOF
     seeded_runtime=1
   fi

--- a/scripts/harness/perf/keeper_load_gate.sh
+++ b/scripts/harness/perf/keeper_load_gate.sh
@@ -247,6 +247,7 @@ emits-usage-tokens = true
 [mock.mockmodel]
 is-default = true
 max-concurrent = 64
+max-request-body-bytes = 524288
 EOF
 
 cat > "$BASE_PATH/.masc/config/oas-models-overlay.toml" <<EOF

--- a/test/test_exact_output_catalog_precedence_fixture.ml
+++ b/test/test_exact_output_catalog_precedence_fixture.ml
@@ -176,6 +176,7 @@ supports-response-format-json = true
 supports-structured-output = true
 
 [replacement_provider.replacement]
+max-request-body-bytes = 65536
 
 [replacement_provider.secondary]
 
@@ -205,6 +206,7 @@ api-name = "replacement-model"
 max-context = 8192
 
 [replacement_provider.alternate]
+max-request-body-bytes = 65536
 
 [runtime]
 default = "replacement_provider.alternate"
@@ -314,6 +316,7 @@ api-name = "replacement-model"
 max-context = 8192
 
 [replacement_provider.%s]
+max-request-body-bytes = 65536
 
 [runtime]
 default = %S

--- a/test/test_exact_output_catalog_precedence_fixture.ml
+++ b/test/test_exact_output_catalog_precedence_fixture.ml
@@ -179,6 +179,7 @@ supports-structured-output = true
 max-request-body-bytes = 65536
 
 [replacement_provider.secondary]
+max-request-body-bytes = 65536
 
 [runtime]
 default = "replacement_provider.replacement"

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -446,7 +446,7 @@ let test_consolidate_classifies_invalid_structured_response () =
             "expected Invalid_structured_response for malformed provider output"))))
 ;;
 
-let test_consolidate_requires_clock_before_provider_call () =
+let test_consolidate_keeps_non_retryable_provider_admission_terminal () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       with_prompts (fun () ->
@@ -459,7 +459,9 @@ let test_consolidate_requires_clock_before_provider_call () =
         let complete : Runtime.complete_fn =
           fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () ->
           called := true;
-          Ok (fake_response {|{"groups":[],"drop_indices":[]}|})
+          Error
+            (Llm_provider.Http_client.AcceptRejected
+               { reason = "local request admission rejected" })
         in
         let outcome =
           Runtime.consolidate_keeper
@@ -472,18 +474,15 @@ let test_consolidate_requires_clock_before_provider_call () =
             ~keeper_id
             ()
         in
-        Alcotest.(check bool) "provider was not called" false !called;
+        Alcotest.(check bool) "provider boundary was called" true !called;
         match outcome with
         | Runtime.Transport_failed msg ->
           Alcotest.(check bool)
-            "message names unavailable clock"
+            "message preserves local admission reason"
             true
-            (contains "clock unavailable" msg);
-          Alcotest.(check bool)
-            "message names timeout"
-            true
-            (contains "timeout_sec=1.0" msg)
-        | _ -> Alcotest.fail "expected Transport_failed for missing clock"))))
+            (contains "local request admission rejected" msg)
+        | _ ->
+          Alcotest.fail "non-retryable admission failure must remain terminal"))))
 ;;
 
 let test_consolidate_rejects_uncapped_provider_before_call () =
@@ -705,9 +704,9 @@ let () =
             `Quick
             test_consolidate_classifies_invalid_structured_response
         ; Alcotest.test_case
-            "requires clock before provider call"
+            "keeps non-retryable provider admission terminal"
             `Quick
-            test_consolidate_requires_clock_before_provider_call
+            test_consolidate_keeps_non_retryable_provider_admission_terminal
         ; Alcotest.test_case
             "rejects uncapped provider before call"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -525,7 +525,7 @@ let test_consolidate_rejects_uncapped_provider_before_call () =
             true
             (contains
                "serialized-request ceiling"
-               (Masc.Runtime.request_body_cap_error_to_string error))
+               (Runtime.request_body_cap_error_to_string error))
         | _ ->
           Alcotest.fail
             "uncapped consolidation config must fail before provider dispatch"))))

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -525,7 +525,7 @@ let test_consolidate_rejects_uncapped_provider_before_call () =
             true
             (contains
                "serialized-request ceiling"
-               (Runtime.request_body_cap_error_to_string error))
+               (Masc.Runtime.request_body_cap_error_to_string error))
         | _ ->
           Alcotest.fail
             "uncapped consolidation config must fail before provider dispatch"))))

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -71,12 +71,14 @@ let text_of_message (message : Atypes.message) =
 
 (* The fake completion ignores the config, so any valid one works. *)
 let provider_cfg ?max_tokens () =
-  Llm_provider.Provider_config.make
-    ~kind:Llm_provider.Provider_config.Anthropic
-    ~model_id:"fake"
-    ~base_url:"http://localhost"
-    ?max_tokens
-    ()
+  { (Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"fake"
+      ~base_url:"http://localhost"
+      ?max_tokens
+      ()) with
+    max_request_body_bytes = Some 65_536
+  }
 ;;
 
 let with_temp_keepers f =
@@ -484,6 +486,52 @@ let test_consolidate_requires_clock_before_provider_call () =
         | _ -> Alcotest.fail "expected Transport_failed for missing clock"))))
 ;;
 
+let test_consolidate_rejects_uncapped_provider_before_call () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let called = ref false in
+        let complete : Runtime.complete_fn =
+          fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () ->
+          called := true;
+          Ok (fake_response {|{"groups":[],"drop_indices":[]}|})
+        in
+        let uncapped_provider_cfg =
+          { (provider_cfg ()) with
+            Llm_provider.Provider_config.max_request_body_bytes = None
+          }
+        in
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
+            ~provider_cfg:uncapped_provider_cfg
+            ~now
+            ~keeper_id
+            ()
+        in
+        Alcotest.(check bool) "provider was not called" false !called;
+        match outcome with
+        | Runtime.Provider_config_invalid error ->
+          Alcotest.(check bool)
+            "message names request body cap"
+            true
+            (contains
+               "serialized-request ceiling"
+               (Masc.Runtime.request_body_cap_error_to_string error))
+        | _ ->
+          Alcotest.fail
+            "uncapped consolidation config must fail before provider dispatch"))))
+;;
+
 let test_consolidate_respects_provider_config_and_prompt_template () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -660,6 +708,10 @@ let () =
             "requires clock before provider call"
             `Quick
             test_consolidate_requires_clock_before_provider_call
+        ; Alcotest.test_case
+            "rejects uncapped provider before call"
+            `Quick
+            test_consolidate_rejects_uncapped_provider_before_call
         ; Alcotest.test_case
             "respects provider config and prompt template"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -4,6 +4,7 @@
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
 module Consolidation = Masc.Keeper_memory_os_consolidation
+module Runtime_config = Runtime
 module Runtime = Masc.Keeper_memory_os_consolidation_runtime
 module Structured_schema = Masc.Keeper_structured_output_schema
 module Agent_sdk_response = Masc.Agent_sdk_response
@@ -525,7 +526,7 @@ let test_consolidate_rejects_uncapped_provider_before_call () =
             true
             (contains
                "serialized-request ceiling"
-               (Masc.Runtime.request_body_cap_error_to_string error))
+               (Runtime_config.request_body_cap_error_to_string error))
         | _ ->
           Alcotest.fail
             "uncapped consolidation config must fail before provider dispatch"))))

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -114,6 +114,7 @@ streaming = true
 [test_provider.test_model]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 let with_direct_retry_runtime f =
@@ -135,6 +136,54 @@ let direct_no_progress_retry_decision err =
     ~effective_runtime:"runtime.direct-empty"
     ~attempted_runtimes:[ "runtime.direct-empty" ]
     err
+
+let test_dispatch_rejects_runtime_without_serialized_request_cap () =
+  let snapshot = Runtime.For_testing.snapshot () in
+  let path = Filename.temp_file "uncapped_keeper_runtime_" ".toml" in
+  let uncapped =
+    String.concat
+      "\n"
+      [ "[runtime]"
+      ; "default = \"test_provider.test_model\""
+      ; ""
+      ; "[providers.test_provider]"
+      ; "protocol = \"openai-compatible-http\""
+      ; "endpoint = \"http://127.0.0.1:1/v1\""
+      ; ""
+      ; "[models.test_model]"
+      ; "api-name = \"test-model\""
+      ; "max-context = 8192"
+      ; "tools-support = true"
+      ; "streaming = true"
+      ; ""
+      ; "[test_provider.test_model]"
+      ]
+  in
+  write_file path uncapped;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       match Runtime.init_default ~config_path:path with
+       | Error error -> Alcotest.failf "fixture load failed: %s" error
+       | Ok () ->
+         (match
+            Masc.Keeper_turn_driver.For_testing.resolve_runtime_candidate_for_attempt
+              "test_provider.test_model"
+          with
+          | Error
+              (Agent_sdk.Error.Config
+                (Agent_sdk.Error.InvalidConfig
+                  { field = "max-request-body-bytes"; _ })) ->
+            ()
+          | Error error ->
+            Alcotest.failf
+              "wrong typed cap rejection: %s"
+              (Agent_sdk.Error.to_string error)
+          | Ok _ ->
+            Alcotest.fail
+              "uncapped Keeper runtime must be rejected before provider dispatch"))
 
 type direct_retry_observed_attempt =
   { observed_runtime_id : string
@@ -1790,6 +1839,10 @@ let () =
             "session conflict preserves typed terminal exhaustion"
             `Quick
             test_session_conflict_exhaustion_preserves_typed_terminal_reason;
+          Alcotest.test_case
+            "dispatch rejects runtime without serialized-request cap"
+            `Quick
+            test_dispatch_rejects_runtime_without_serialized_request_cap;
           Alcotest.test_case
             "runtime exhaustion labels cap free-text detail"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -109,9 +109,11 @@ streaming = true
 [primary.test_model]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [fallback.test_model]
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 let runtime_toml_thinking_lane =
@@ -153,9 +155,11 @@ streaming = true
 [thinking.reasoning_big]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [plain.non_reasoning]
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 let runtime_thinking_lane_model_catalog =
@@ -214,12 +218,15 @@ supports-image-input = true
 [primary.text_model]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [lanevision.vision_model]
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [outsidevision.vision_model]
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 let runtime_toml_unknown_lane_candidate =
@@ -275,9 +282,11 @@ streaming = true
 [primary.test_model]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [fallback.test_model]
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 let with_runtime_config toml f =
@@ -424,9 +433,11 @@ streaming = true
 [primary.test_model]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [fallback.test_model]
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 (* Pins the current assignment contract: [runtime.assignments] targets must be
@@ -544,6 +555,60 @@ let test_prior_checkpoint_appends_current_goal_once () =
       "current goal appended exactly once"
       1
       current_goal_count)
+
+let test_deferred_tail_rejects_transformed_uncapped_runtime () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    Masc_test_deps.init_eio_clock ~sw env;
+    let transformed_urls = ref [] in
+    let deferred_runtime_lane =
+      Driver.For_testing.make_deferred_runtime_lane
+        ~assignment_id:"resilient"
+        ~failed_runtime_id:"previous.test_model"
+        ~next_runtime_id:"primary.test_model"
+        ~later_runtime_ids:[ "fallback.test_model" ]
+        ~failure:(retryable_network_error "previous cycle failed")
+    in
+    let result =
+      Driver.run_named
+        ~runtime_id:"resilient"
+        ~keeper_name:"deferred-request-cap"
+        ~base_path:(Filename.get_temp_dir_name ())
+        ~goal:"prove final provider request admission"
+        ~deferred_runtime_lane
+        ~provider_config_transform:(fun provider_config ->
+          transformed_urls := provider_config.base_url :: !transformed_urls;
+          if String.equal provider_config.base_url "http://127.0.0.1:2"
+          then Ok { provider_config with max_request_body_bytes = None }
+          else Ok provider_config)
+        ~body_timeout_s:0.5
+        ~sw
+        ~net:env#net
+        ()
+    in
+    (match result with
+     | Error
+         (Agent_sdk.Error.Config
+           (Agent_sdk.Error.InvalidConfig
+             { field = "max-request-body-bytes"; detail })) ->
+       Alcotest.(check bool)
+         "typed rejection names the deferred tail runtime"
+         true
+         (contains ~needle:"fallback.test_model" detail)
+     | Error error ->
+       Alcotest.failf
+         "expected final request-cap rejection, got %s"
+         (Agent_sdk.Error.to_string error)
+     | Ok _ ->
+       Alcotest.fail
+         "transformed uncapped deferred runtime reached provider execution");
+    Alcotest.(check (list string))
+      "capped next candidate runs, then transformed tail is checked"
+      [ "http://127.0.0.1:1"; "http://127.0.0.1:2" ]
+      (List.rev !transformed_urls))
 
 let test_lane_media_degrade_uses_first_candidate_runtime_id () =
   with_runtime_config runtime_toml_with_lane (fun () ->
@@ -1285,6 +1350,10 @@ let () =
             "prior checkpoint appends current goal once"
             `Quick
             test_prior_checkpoint_appends_current_goal_once;
+          Alcotest.test_case
+            "deferred tail rejects transformed uncapped runtime"
+            `Quick
+            test_deferred_tail_rejects_transformed_uncapped_runtime;
           Alcotest.test_case
             "attempt loop stops on nonretryable failure"
             `Quick

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -593,6 +593,46 @@ supports-structured-output = true
 [p3.vision-c]
 |}
 
+(* Vision falls back to every schema-capable image runtime after explicit
+   media_failover ordering. The uncapped fallback is therefore genuinely
+   reachable even though neither [runtime].default nor media_failover names it. *)
+let uncapped_vision_fallback_runtime_toml =
+  {|
+[runtime]
+default = "p0.text"
+media_failover = ["p0.text"]
+
+[providers.p0]
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1/v1"
+
+[providers.p4]
+protocol = "ollama-http"
+endpoint = "http://127.0.0.1:2/v1"
+
+[models.text]
+api-name = "text"
+max-context = 4096
+
+[models.text.capabilities]
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[models.vision-a]
+api-name = "vision-a"
+max-context = 4096
+
+[models.vision-a.capabilities]
+supports-image-input = true
+supports-multimodal-inputs = true
+supports-structured-output = true
+
+[p0.text]
+max-request-body-bytes = 65536
+
+[p4.vision-a]
+|}
+
 let test_provider_for_vision_uses_runtime_temperature () =
   with_temp_runtime_toml single_vision_runtime_toml (fun () ->
     match Vt.first_vision_runtime_id () with
@@ -605,6 +645,32 @@ let test_provider_for_vision_uses_runtime_temperature () =
            Vt.provider_for_vision runtime.Runtime.provider_config
          in
          assert (configured.temperature = Some 1.0)))
+
+let test_uncapped_vision_fallback_rejects_before_provider_call () =
+  with_temp_runtime_toml uncapped_vision_fallback_runtime_toml (fun () ->
+    let provider_calls = ref 0 in
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+      incr provider_calls;
+      Ok (ok_response "provider call must not happen")
+    in
+    let outcome =
+      Eio_main.run (fun env ->
+        Eio.Switch.run (fun sw ->
+          Vt.run_vision
+            ~complete
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~query:"describe"
+            ~media_type:"image/png"
+            ~bytes:"\x89PNG\r\n\x1a\nraw"
+            ()))
+    in
+    assert (!provider_calls = 0);
+    match outcome with
+    | Vt.Vo_provider { failure_class = Tool_result.Runtime_failure; detail } ->
+      assert (contains_substring detail "max-request-body-bytes")
+    | _ -> failwith "uncapped vision fallback must fail before provider dispatch")
 
 let schema_unsupported_vision_runtime_toml =
   {|
@@ -1114,6 +1180,7 @@ let () =
      [with_vision_model_catalog]). *)
   with_vision_model_catalog (fun () ->
     test_provider_for_vision_uses_runtime_temperature ();
+    test_uncapped_vision_fallback_rejects_before_provider_call ();
     test_invalid_structured_vision_response_is_runtime_failure ();
     test_run_vision_invalid_structured_response_is_typed ();
     test_retryable_provider_error_tries_next_runtime ();

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -744,7 +744,7 @@ let test_repo_runtime_toml_loads () =
       , assignments
       , memory_os_consolidation
       , structured_judge
-      , _cross_verifier
+      , cross_verifier
       , media_failover
       , lanes ) ->
     check bool "at least one runtime" true (List.length runtimes > 0);
@@ -808,6 +808,8 @@ List.iter
         ~default_runtime_id:default.id
         ~assignments
         ~memory_os_consolidation_runtime_id:memory_os_consolidation
+        ~structured_judge_runtime_id:structured_judge
+        ~cross_verifier_runtime_id:cross_verifier
         ~media_failover
         ~lanes
     in
@@ -1541,6 +1543,14 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
         ~id:"dormant-lane"
         ~strategy:Runtime_lane.Ordered
         [ "lane-c"; "lane-b" ]
+    ; Runtime_lane.make
+        ~id:"structured-d"
+        ~strategy:Runtime_lane.Ordered
+        [ "structured-a"; "lane-b" ]
+    ; Runtime_lane.make
+        ~id:"cross-e"
+        ~strategy:Runtime_lane.Ordered
+        [ "cross-a"; "lane-b" ]
     ]
   in
   let actual =
@@ -1548,14 +1558,23 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
       ~default_runtime_id:"default-a"
       ~assignments:[ "keeper-a", "assigned-b" ]
       ~memory_os_consolidation_runtime_id:(Some "memory-os-d")
+      ~structured_judge_runtime_id:(Some "structured-d")
+      ~cross_verifier_runtime_id:(Some "cross-e")
       ~media_failover:[ "media-c"; "lane-a" ]
       ~lanes
   in
   check
     (list string)
-    "routed lane candidates, assignments, and media failover are deduplicated \
+    "routed lane candidates, special routes, and media failover are deduplicated \
      without admitting a dormant lane"
-    [ "lane-a"; "lane-b"; "assigned-b"; "media-c"; "memory-os-d" ]
+    [ "lane-a"
+    ; "lane-b"
+    ; "assigned-b"
+    ; "media-c"
+    ; "memory-os-d"
+    ; "structured-a"
+    ; "cross-a"
+    ]
     actual
 ;;
 
@@ -1649,6 +1668,56 @@ let test_runtime_config_validation_rejects_uncapped_memory_os_runtime () =
            (String_util.contains_substring detail "max-request-body-bytes");
          check bool "typed config diagnostic names the direct runtime" true
            (String_util.contains_substring detail "local.consolidation"))
+;;
+
+let test_runtime_config_validation_rejects_uncapped_special_runtime () =
+  let content route =
+    Printf.sprintf
+      "[providers.local]\n\
+       protocol = \"openai-compatible-http\"\n\
+       endpoint = \"http://127.0.0.1:1/v1\"\n\
+       \n\
+       [models.default]\n\
+       api-name = \"default\"\n\
+       max-context = 1024\n\
+       \n\
+       [models.special]\n\
+       api-name = \"special\"\n\
+       max-context = 1024\n\
+       \n\
+       [local.default]\n\
+       max-request-body-bytes = 65536\n\
+       \n\
+       [local.special]\n\
+       \n\
+       [runtime]\n\
+       default = \"local.default\"\n\
+       %s = \"local.special\"\n"
+      route
+  in
+  List.iter
+    (fun route ->
+       let snapshot = Runtime.For_testing.snapshot () in
+       let path = Filename.temp_file "uncapped_special_runtime_" ".toml" in
+       let config = content route in
+       let oc = open_out path in
+       output_string oc config;
+       close_out oc;
+       Fun.protect
+         ~finally:(fun () ->
+           Runtime.For_testing.restore snapshot;
+           try Sys.remove path with
+           | Sys_error _ -> ())
+         (fun () ->
+            match Runtime.save_config_text ~runtime_config_path:path config with
+            | Ok () ->
+              failf "uncapped %s runtime must fail runtime config validation" route
+            | Error detail ->
+              check bool "typed config diagnostic names the cap" true
+                (String_util.contains_substring detail "max-request-body-bytes");
+              check bool "typed config diagnostic names the special runtime" true
+                (String_util.contains_substring detail "local.special")))
+    [ "structured_judge"; "cross_verifier" ]
 ;;
 
 let test_runtime_config_validation_allows_uncapped_dormant_lane_candidate () =
@@ -2602,6 +2671,7 @@ let test_structured_judge_runtime_routing () =
      max-request-body-bytes = 65536\n\
      \n\
      [local.judge]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [runtime]\n\
      default = \"local.chat\"\n"
@@ -2921,6 +2991,7 @@ let test_save_config_text_refreshes_cross_verifier_runtime () =
      max-request-body-bytes = 65536\n\
      \n\
      [local.libr]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [runtime]\n\
      default = \"local.chat\"\n\
@@ -3470,6 +3541,10 @@ let () =
             "runtime config rejects uncapped Memory OS consolidation runtime"
             `Quick
             test_runtime_config_validation_rejects_uncapped_memory_os_runtime;
+          test_case
+            "runtime config rejects uncapped structured-judge and cross-verifier runtimes"
+            `Quick
+            test_runtime_config_validation_rejects_uncapped_special_runtime;
           test_case
             "runtime config allows uncapped dormant lane candidate"
             `Quick

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -745,7 +745,8 @@ let test_repo_runtime_toml_loads () =
       , memory_os_consolidation
       , structured_judge
       , _cross_verifier
-      , _media_failover , _lanes ) ->
+      , media_failover
+      , lanes ) ->
     check bool "at least one runtime" true (List.length runtimes > 0);
     check string "default runtime" "ollama_cloud.deepseek-v4-flash"
       default.Runtime.id;
@@ -802,6 +803,29 @@ List.iter
       default.provider_config.connect_timeout_s;
     check int "public seed has no keeper assignments" 0
       (List.length assignments);
+    let keeper_dispatch_ids =
+      Runtime.For_testing.keeper_dispatch_runtime_ids
+        ~default_runtime_id:default.id
+        ~assignments
+        ~media_failover
+        ~lanes
+    in
+    List.iter
+      (fun runtime_id ->
+         match
+           List.find_opt
+             (fun (runtime : Runtime.t) -> String.equal runtime.id runtime_id)
+             runtimes
+         with
+         | None -> failf "expected bounded Keeper runtime in seed: %s" runtime_id
+         | Some runtime ->
+           (match runtime.provider_config.max_request_body_bytes with
+            | Some cap when cap > 0 -> ()
+            | None | Some _ ->
+              failf
+                "%s must declare a positive exact request body budget"
+                runtime_id))
+      keeper_dispatch_ids;
     check int "Ollama Cloud canonical seed count"
       (List.length ollama_cloud_seed_cases)
       (List.length
@@ -1506,6 +1530,80 @@ let test_runtime_toml_omitted_max_request_body_bytes_is_none () =
          binding.Runtime_schema.max_request_body_bytes
      | bindings -> failf "expected one binding, got %d" (List.length bindings))
 
+let test_keeper_dispatch_runtime_graph_enumeration () =
+  let lanes =
+    [ Runtime_lane.make
+        ~id:"lane-primary"
+        ~strategy:Runtime_lane.Ordered
+        [ "lane-a"; "lane-b"; "default-a" ]
+    ; Runtime_lane.make
+        ~id:"lane-secondary"
+        ~strategy:Runtime_lane.Ordered
+        [ "lane-c"; "lane-b" ]
+    ]
+  in
+  let actual =
+    Runtime.For_testing.keeper_dispatch_runtime_ids
+      ~default_runtime_id:"default-a"
+      ~assignments:[ "keeper-a", "assigned-b"; "keeper-b", "lane-primary" ]
+      ~media_failover:[ "media-c"; "lane-a" ]
+      ~lanes
+  in
+  check
+    (list string)
+    "default, assignments, every lane candidate, and media failover are \
+     deduplicated in dispatch order"
+    [ "default-a"; "assigned-b"; "lane-a"; "lane-b"; "lane-c"; "media-c" ]
+    actual
+;;
+
+let test_runtime_config_validation_rejects_uncapped_keeper_candidate () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.lane]\n\
+     api-name = \"lane\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     max-request-body-bytes = 65536\n\
+     \n\
+     [local.lane]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n\
+     \n\
+     [runtime.lanes.routed]\n\
+     strategy = \"ordered\"\n\
+     candidates = [\"local.lane\"]\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  let path = Filename.temp_file "uncapped_runtime_" ".toml" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       match Runtime.save_config_text ~runtime_config_path:path content with
+       | Ok () ->
+         fail "uncapped Keeper lane candidate must fail runtime config validation"
+       | Error detail ->
+         check bool "typed config diagnostic names the cap" true
+           (String_util.contains_substring detail "max-request-body-bytes");
+         check bool "typed config diagnostic names the candidate" true
+           (String_util.contains_substring detail "local.lane"))
+;;
+
 let test_runtime_toml_rejects_non_positive_max_request_body_bytes () =
   let template n =
     Printf.sprintf
@@ -1765,6 +1863,7 @@ let test_runtime_capability_gate_uses_provider_qualified_catalog () =
      thinking-support = true\n\
      \n\
      [ollama_cloud.shared]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [runtime]\n\
      default = \"ollama_cloud.shared\"\n"
@@ -1926,6 +2025,7 @@ let test_strict_init_rejects_assigned_runtime_absent_from_oas_catalog () =
      max-context = 1024\n\
      \n\
      [ollama.good]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [ollama.missing]\n\
      \n\
@@ -2087,6 +2187,7 @@ let test_server_degraded_init_disables_unreferenced_uncatalogued_runtimes () =
      api-name = \"missing-from-oas-catalog\"\n\
      \n\
      [ollama.good]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [ollama.missing]\n\
      \n\
@@ -2406,6 +2507,7 @@ let test_structured_judge_runtime_routing () =
      supports-structured-output = true\n\
      \n\
      [local.chat]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [local.judge]\n\
      \n\
@@ -2724,6 +2826,7 @@ let test_save_config_text_refreshes_cross_verifier_runtime () =
      supports-response-format-json = true\n\
      \n\
      [local.chat]\n\
+     max-request-body-bytes = 65536\n\
      \n\
      [local.libr]\n\
      \n\
@@ -2774,8 +2877,10 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
        max-context = 1024\n\
        \n\
        [local.chat]\n\
+       max-request-body-bytes = 65536\n\
        \n\
        [local.libr]\n\
+       max-request-body-bytes = 65536\n\
        \n\
        [runtime]\n\
        default = \"%s\"\n\
@@ -3263,6 +3368,12 @@ let () =
             test_runtime_toml_parses_optional_max_request_body_bytes;
           test_case "omitted max-request-body-bytes stays None" `Quick
             test_runtime_toml_omitted_max_request_body_bytes_is_none;
+          test_case
+            "keeper dispatch graph enumeration"
+            `Quick test_keeper_dispatch_runtime_graph_enumeration;
+          test_case
+            "runtime config rejects uncapped keeper candidate"
+            `Quick test_runtime_config_validation_rejects_uncapped_keeper_candidate;
           test_case "non-positive max-request-body-bytes is rejected" `Quick
             test_runtime_toml_rejects_non_positive_max_request_body_bytes;
           test_case

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -807,6 +807,7 @@ List.iter
       Runtime.For_testing.keeper_dispatch_runtime_ids
         ~default_runtime_id:default.id
         ~assignments
+        ~memory_os_consolidation_runtime_id:memory_os_consolidation
         ~media_failover
         ~lanes
     in
@@ -1546,6 +1547,7 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
     Runtime.For_testing.keeper_dispatch_runtime_ids
       ~default_runtime_id:"default-a"
       ~assignments:[ "keeper-a", "assigned-b" ]
+      ~memory_os_consolidation_runtime_id:(Some "memory-os-d")
       ~media_failover:[ "media-c"; "lane-a" ]
       ~lanes
   in
@@ -1553,7 +1555,7 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
     (list string)
     "routed lane candidates, assignments, and media failover are deduplicated \
      without admitting a dormant lane"
-    [ "lane-a"; "lane-b"; "assigned-b"; "media-c" ]
+    [ "lane-a"; "lane-b"; "assigned-b"; "media-c"; "memory-os-d" ]
     actual
 ;;
 
@@ -1602,6 +1604,51 @@ let test_runtime_config_validation_rejects_uncapped_keeper_candidate () =
            (String_util.contains_substring detail "max-request-body-bytes");
          check bool "typed config diagnostic names the candidate" true
            (String_util.contains_substring detail "local.lane"))
+;;
+
+let test_runtime_config_validation_rejects_uncapped_memory_os_runtime () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.default]\n\
+     api-name = \"default\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.consolidation]\n\
+     api-name = \"consolidation\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.default]\n\
+     max-request-body-bytes = 65536\n\
+     \n\
+     [local.consolidation]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.default\"\n\
+     memory_os_consolidation = \"local.consolidation\"\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  let path = Filename.temp_file "uncapped_memory_os_runtime_" ".toml" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       match Runtime.save_config_text ~runtime_config_path:path content with
+       | Ok () ->
+         fail
+           "uncapped Memory OS consolidation runtime must fail runtime config validation"
+       | Error detail ->
+         check bool "typed config diagnostic names the cap" true
+           (String_util.contains_substring detail "max-request-body-bytes");
+         check bool "typed config diagnostic names the direct runtime" true
+           (String_util.contains_substring detail "local.consolidation"))
 ;;
 
 let test_runtime_config_validation_allows_uncapped_dormant_lane_candidate () =
@@ -3419,6 +3466,10 @@ let () =
           test_case
             "runtime config rejects uncapped keeper candidate"
             `Quick test_runtime_config_validation_rejects_uncapped_keeper_candidate;
+          test_case
+            "runtime config rejects uncapped Memory OS consolidation runtime"
+            `Quick
+            test_runtime_config_validation_rejects_uncapped_memory_os_runtime;
           test_case
             "runtime config allows uncapped dormant lane candidate"
             `Quick

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1533,11 +1533,11 @@ let test_runtime_toml_omitted_max_request_body_bytes_is_none () =
 let test_keeper_dispatch_runtime_graph_enumeration () =
   let lanes =
     [ Runtime_lane.make
-        ~id:"lane-primary"
+        ~id:"default-a"
         ~strategy:Runtime_lane.Ordered
-        [ "lane-a"; "lane-b"; "default-a" ]
+        [ "lane-a"; "lane-b" ]
     ; Runtime_lane.make
-        ~id:"lane-secondary"
+        ~id:"dormant-lane"
         ~strategy:Runtime_lane.Ordered
         [ "lane-c"; "lane-b" ]
     ]
@@ -1545,15 +1545,15 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
   let actual =
     Runtime.For_testing.keeper_dispatch_runtime_ids
       ~default_runtime_id:"default-a"
-      ~assignments:[ "keeper-a", "assigned-b"; "keeper-b", "lane-primary" ]
+      ~assignments:[ "keeper-a", "assigned-b" ]
       ~media_failover:[ "media-c"; "lane-a" ]
       ~lanes
   in
   check
     (list string)
-    "default, assignments, every lane candidate, and media failover are \
-     deduplicated in dispatch order"
-    [ "default-a"; "assigned-b"; "lane-a"; "lane-b"; "lane-c"; "media-c" ]
+    "routed lane candidates, assignments, and media failover are deduplicated \
+     without admitting a dormant lane"
+    [ "lane-a"; "lane-b"; "assigned-b"; "media-c" ]
     actual
 ;;
 
@@ -1579,7 +1579,7 @@ let test_runtime_config_validation_rejects_uncapped_keeper_candidate () =
      [runtime]\n\
      default = \"local.sample\"\n\
      \n\
-     [runtime.lanes.routed]\n\
+     [runtime.lanes.\"local.sample\"]\n\
      strategy = \"ordered\"\n\
      candidates = [\"local.lane\"]\n"
   in
@@ -1602,6 +1602,51 @@ let test_runtime_config_validation_rejects_uncapped_keeper_candidate () =
            (String_util.contains_substring detail "max-request-body-bytes");
          check bool "typed config diagnostic names the candidate" true
            (String_util.contains_substring detail "local.lane"))
+;;
+
+let test_runtime_config_validation_allows_uncapped_dormant_lane_candidate () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.dormant]\n\
+     api-name = \"dormant\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     max-request-body-bytes = 65536\n\
+     \n\
+     [local.dormant]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n\
+     \n\
+     [runtime.lanes.dormant]\n\
+     strategy = \"ordered\"\n\
+     candidates = [\"local.dormant\"]\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  let path = Filename.temp_file "dormant_uncapped_runtime_" ".toml" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       match Runtime.save_config_text ~runtime_config_path:path content with
+       | Ok () -> ()
+       | Error detail ->
+         failf
+           "uncapped dormant lane must not block unrelated Keeper routing: %s"
+           detail)
 ;;
 
 let test_runtime_toml_rejects_non_positive_max_request_body_bytes () =
@@ -3374,6 +3419,10 @@ let () =
           test_case
             "runtime config rejects uncapped keeper candidate"
             `Quick test_runtime_config_validation_rejects_uncapped_keeper_candidate;
+          test_case
+            "runtime config allows uncapped dormant lane candidate"
+            `Quick
+            test_runtime_config_validation_allows_uncapped_dormant_lane_candidate;
           test_case "non-positive max-request-body-bytes is rejected" `Quick
             test_runtime_toml_rejects_non_positive_max_request_body_bytes;
           test_case

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -202,13 +202,16 @@ supports-code-execution = true
 [runpod_mtp.qwen]
 is-default = true
 max-concurrent = 4
+max-request-body-bytes = 65536
 
 [openai.gpt]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 
 [openai.small]
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 ;;
 
@@ -254,10 +257,12 @@ supports-code-execution = true
 [runpod_mtp.qwen]
 is-default = true
 max-concurrent = 4
+max-request-body-bytes = 65536
 
 [openai.gpt]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
   |}
 ;;
 

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -413,6 +413,38 @@ let test_consolidation_tick_retries_next_lane_candidate_on_transport_failure () 
           (List.rev !calls)))))
 ;;
 
+let test_consolidation_tick_stops_on_non_retryable_provider_failure () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        Io.append_fact ~keeper_id (fact "only fact");
+        let calls = ref [] in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
+          let model_id = config.Llm_provider.Provider_config.model_id in
+          calls := model_id :: !calls;
+          Error
+            (Llm_provider.Http_client.AcceptRejected
+               { reason = "local request admission rejected" })
+        in
+        let cfg model_id =
+          { (provider_cfg ()) with Llm_provider.Provider_config.model_id }
+        in
+        Server_bootstrap_maintenance.run_memory_os_consolidation_tick_with_candidates
+          ~complete
+          ~sw
+          ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~runtime_candidates:[ "local.first", cfg "first"; "local.second", cfg "second" ]
+          ~now
+          ();
+        Alcotest.(check (list string))
+          "non-retryable failure does not advance candidate authority"
+          [ "first" ]
+          (List.rev !calls)))))
+;;
+
 let () =
   Alcotest.run
     "server_bootstrap_maintenance_memory_os"
@@ -445,6 +477,10 @@ let () =
             "transport failure retries the next lane candidate"
             `Quick
             test_consolidation_tick_retries_next_lane_candidate_on_transport_failure
+        ; Alcotest.test_case
+            "non-retryable provider failure stops candidate traversal"
+            `Quick
+            test_consolidation_tick_stops_on_non_retryable_provider_failure
         ] )
     ]
 ;;

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -43,11 +43,13 @@ let fake_complete canned : Masc.Keeper_memory_os_consolidation_runtime.complete_
 ;;
 
 let provider_cfg () =
-  Llm_provider.Provider_config.make
-    ~kind:Llm_provider.Provider_config.Anthropic
-    ~model_id:"fake"
-    ~base_url:"http://localhost"
-    ()
+  { (Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"fake"
+      ~base_url:"http://localhost"
+      ()) with
+    max_request_body_bytes = Some 65_536
+  }
 ;;
 
 let with_runtime_config content f =
@@ -233,7 +235,9 @@ api-name = "consolidation"
 max-context = 1024
 
 [local.chat]
+max-request-body-bytes = 65536
 [local.consolidation]
+max-request-body-bytes = 65536
 
 [runtime]
 default = "local.chat"
@@ -287,6 +291,7 @@ api-name = "chat"
 max-context = 1024
 
 [local.chat]
+max-request-body-bytes = 65536
 
 [runtime]
 default = "local.chat"
@@ -327,6 +332,87 @@ default = "local.chat"
          | _ -> Alcotest.fail "dashboard changed inherited snapshot resolution"))
 ;;
 
+let test_consolidation_runtime_lane_expands_to_all_candidates () =
+  let config =
+    {|
+[providers.local]
+display-name = "Local"
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.default]
+api-name = "default"
+max-context = 1024
+
+[models.first]
+api-name = "first"
+max-context = 1024
+
+[models.second]
+api-name = "second"
+max-context = 1024
+
+[local.default]
+max-request-body-bytes = 65536
+[local.first]
+max-request-body-bytes = 65536
+[local.second]
+max-request-body-bytes = 65536
+
+[runtime]
+default = "local.default"
+memory_os_consolidation = "consolidation"
+
+[runtime.lanes.consolidation]
+strategy = "ordered"
+candidates = ["local.first", "local.second"]
+|}
+  in
+  with_runtime_config config (fun () ->
+    match Runtime.resolve_memory_os_consolidation_runtime_candidates () with
+    | Error msg -> Alcotest.failf "consolidation lane should resolve: %s" msg
+    | Ok runtimes ->
+      Alcotest.(check (list string))
+        "lane candidate order"
+        [ "local.first"; "local.second" ]
+        (List.map (fun (runtime : Runtime.t) -> runtime.Runtime.id) runtimes))
+;;
+
+let test_consolidation_tick_retries_next_lane_candidate_on_transport_failure () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        Io.append_fact ~keeper_id (fact "only fact");
+        let calls = ref [] in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
+          let model_id = config.Llm_provider.Provider_config.model_id in
+          calls := model_id :: !calls;
+          if String.equal model_id "first"
+          then
+            Error
+              (Llm_provider.Http_client.HttpError
+                 { code = 503; body = "first provider unavailable"; retry_after_header = None })
+          else Ok (fake_response {|{"groups":[],"drop_indices":[]}|})
+        in
+        let cfg model_id =
+          { (provider_cfg ()) with Llm_provider.Provider_config.model_id }
+        in
+        Server_bootstrap_maintenance.run_memory_os_consolidation_tick_with_candidates
+          ~complete
+          ~sw
+          ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~runtime_candidates:[ "local.first", cfg "first"; "local.second", cfg "second" ]
+          ~now
+          ();
+        Alcotest.(check (list string))
+          "transport failure retries the next candidate"
+          [ "first"; "second" ]
+          (List.rev !calls)))))
+;;
+
 let () =
   Alcotest.run
     "server_bootstrap_maintenance_memory_os"
@@ -351,6 +437,14 @@ let () =
             "absent route inherits default runtime"
             `Quick
             test_consolidation_runtime_inherits_default
+        ; Alcotest.test_case
+            "lane route expands to all runtime candidates"
+            `Quick
+            test_consolidation_runtime_lane_expands_to_all_candidates
+        ; Alcotest.test_case
+            "transport failure retries the next lane candidate"
+            `Quick
+            test_consolidation_tick_retries_next_lane_candidate_on_transport_failure
         ] )
     ]
 ;;

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -344,6 +344,7 @@ streaming = true
 [deepseek.smoke]
 is-default = true
 max-concurrent = 1
+max-request-body-bytes = 65536
 |}
 
 let catalog_overlay_seed =


### PR DESCRIPTION
## Summary

- Require a positive max-request-body-bytes at config admission and at every final Keeper provider boundary.
- Close direct-subcall bypasses: vision fallback candidates and Memory OS consolidation reject an uncapped final config before any provider call.
- Make a configured Memory OS lane executable: resolve its declared candidates and retry only a typed retryable provider failure on the next candidate.
- Give the public seed explicit coverage for its configured Memory OS consolidation runtime.

## Base

This draft targets main directly.

## Verification

- Changed-file formatting, parsing, workflow lint, and PR hygiene pass locally.
- The request-cap CI suite executes runtime-config validity, normal turn failover, vision, Memory OS direct-boundary, and Memory OS maintenance-candidate tests.
- Current head: b237e625b4d803dc3809d531c314092917e4f56b. Full current-head CI is the merge authority.

## Deployment order

- Before rollout, inventory live paused Keeper backlog and request sizes. Drain or explicitly reset any Keeper whose retained request already exceeds its configured cap; do not deploy the hard rejection over an unknown over-cap backlog.
- Confirm compaction is not suspended and complete the pre-rollout compaction step before enabling the strict boundary.
- Canary one Keeper first, proving capped normal turns plus Memory OS consolidation progress before broad rollout. This PR and CI do not claim current live-runtime deployment.