### PR TITLE
test(keeper): remove brittle context source assertion

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -521,30 +521,14 @@ let run_keeper_invocation_turn_admitted
       in
       Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
       (match
-         Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
-           ~requested_override:meta.max_context_override
+         Keeper_unified_turn_pre_dispatch.build_runtime_execution
+           ~meta
            ~runtime_id:turn_runtime_id
        with
-		         | Error error ->
-		           Progress.stop_tracking turn_task_id;
-	           tool_result_error
-	             (Keeper_context_runtime.max_context_resolution_error_to_string error)
-	         | Ok resolution ->
-	            let max_runtime_context =
-              let () =
-                match resolution.requested_override with
-                | Some requested ->
-                  Log.Keeper.debug
-                    "%s: using max_context_override=%d context_budget=%d primary_budget=%d effective_budget=%d (manual turn)"
-                    meta.name
-                    requested
-                    resolution.requested_context_window
-                    resolution.primary_budget
-                    resolution.effective_budget
-                | None -> ()
-              in
-              resolution.effective_budget
-            in
+	         | Error error ->
+	           Progress.stop_tracking turn_task_id;
+	           tool_result_error (Agent_sdk.Error.to_string error)
+	         | Ok initial_execution ->
             let base_dir =
               let root = session_base_dir ctx.config in
               match channel_session_key with
@@ -671,11 +655,10 @@ let run_keeper_invocation_turn_admitted
 		                    ~keeper_name:meta.name
 		                    ~turn_id:keeper_turn_id
 		                    (fun () ->
-		                       Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
-		                         ~keeper_name:meta.name
-	                         ~base_runtime:turn_runtime_id
-	                         ~initial_runtime:turn_runtime_id
-	                         ~initial_max_context:max_runtime_context
+	                       Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
+	                         ~keeper_name:meta.name
+	                         ~base_runtime:initial_execution.runtime_id
+	                         ~initial_execution
 	                         ~current_turn_phase_elapsed_ms
 		                         ~now_s:(fun () -> Eio.Time.now clock)
 		                         ~setup_retry_runtime:setup_direct_retry_runtime

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -64,8 +64,7 @@ module For_testing : sig
   val run_direct_no_progress_retry_loop :
     keeper_name:string ->
     base_runtime:string ->
-    initial_runtime:string ->
-    initial_max_context:int ->
+    initial_execution:Keeper_turn_runtime_budget.runtime_execution ->
     current_turn_phase_elapsed_ms:(float option -> int * int option) ->
     now_s:(unit -> float) ->
     setup_retry_runtime:
@@ -102,8 +101,9 @@ module For_testing : sig
     unit ->
     ('a * int, Agent_sdk.Error.sdk_error) result
   (** Execute the direct-message no-progress retry loop with injected side
-      effects. Exposed only to verify that fallback selection reaches the next
-      keeper run attempt. *)
+      effects. The initial attempt receives its typed runtime execution record,
+      just like a retry. Exposed only to verify fallback selection without
+      duplicating the provider call inside the test. *)
 end
 
 (** Format a dashboard co-view context object ({ label, route, scene, fields })

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -191,8 +191,7 @@ let direct_no_progress_retry_decision
 let run_direct_no_progress_retry_loop
       ~keeper_name
       ~base_runtime
-      ~initial_runtime
-      ~initial_max_context
+      ~(initial_execution : runtime_execution)
       ~current_turn_phase_elapsed_ms
       ~now_s
       ~(setup_retry_runtime :
@@ -207,7 +206,7 @@ let run_direct_no_progress_retry_loop
   =
   let rec run_attempt
       ~runtime_id
-      ?runtime_execution
+      ~(runtime_execution : runtime_execution)
       ~attempted_runtimes
       ?degraded_retry
       ~runtime_rotation_attempts
@@ -224,11 +223,7 @@ let run_direct_no_progress_retry_loop
       Option.map (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
         degraded_retry
     in
-    let attempt_max_context =
-      match runtime_execution with
-      | Some execution -> execution.max_context
-      | None -> initial_max_context
-    in
+    let attempt_max_context = runtime_execution.max_context in
     match
       run_once
         ~runtime_id
@@ -326,9 +321,9 @@ let run_direct_no_progress_retry_loop
             | Some requested -> string_of_int requested
             | None -> "none");
          before_retry ();
-         run_attempt
-           ~runtime_id:next_execution.runtime_id
-           ~runtime_execution:next_execution
+        run_attempt
+          ~runtime_id:next_execution.runtime_id
+          ~runtime_execution:next_execution
            ~attempted_runtimes:(next_execution.runtime_id :: attempted_runtimes)
            ~degraded_retry:retry
            ~runtime_rotation_attempts:(rotation_attempt :: runtime_rotation_attempts)
@@ -338,8 +333,9 @@ let run_direct_no_progress_retry_loop
            ())
   in
   run_attempt
-    ~runtime_id:initial_runtime
-    ~attempted_runtimes:[ initial_runtime ]
+    ~runtime_id:initial_execution.runtime_id
+    ~runtime_execution:initial_execution
+    ~attempted_runtimes:[ initial_execution.runtime_id ]
     ~runtime_rotation_attempts:[]
     ~attempt:1
     ~retry_phase_started_at:None

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -132,8 +132,7 @@ val direct_no_progress_retry_decision :
 val run_direct_no_progress_retry_loop :
   keeper_name:string ->
   base_runtime:string ->
-  initial_runtime:string ->
-  initial_max_context:int ->
+  initial_execution:runtime_execution ->
   current_turn_phase_elapsed_ms:(float option -> int * int option) ->
   now_s:(unit -> float) ->
   setup_retry_runtime:
@@ -167,8 +166,11 @@ val run_direct_no_progress_retry_loop :
   unit ->
   ('a * int, Agent_sdk.Error.sdk_error) result
 (** Execute the direct-message no-progress retry loop with injected side
-    effects. Rotation is bounded only by the typed, finite runtime candidate
-    set; no numeric Keeper budget participates in admission or retry. *)
+    effects. The initial provider attempt receives the same typed runtime
+    execution record as every retry, so its context budget cannot diverge from
+    pre-dispatch resolution. Rotation is bounded only by the typed, finite
+    runtime candidate set; no numeric Keeper budget participates in admission
+    or retry. *)
 
 type turn_event_bus_summary = {
   correlation_id : string option;

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -868,12 +868,14 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
       ; temperature = 0.0
       }
     in
+    let initial_execution =
+      retry_execution "runtime.direct-empty"
+    in
     let result =
       Masc.Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
         ~keeper_name:"keeper-test"
         ~base_runtime:"test_provider.test_model"
-        ~initial_runtime:"runtime.direct-empty"
-        ~initial_max_context:1024
+        ~initial_execution
         ~current_turn_phase_elapsed_ms:(function
           | None -> 7, None
           | Some _ -> 7, Some 0)
@@ -1008,14 +1010,27 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
 
 let test_direct_retry_loop_publishes_non_retry_terminal_cascade () =
   let terminal_err = Agent_sdk.Error.Internal "not retryable" in
+  let initial_execution : Masc.Keeper_turn_runtime_budget.runtime_execution =
+    { runtime_id = "runtime.initial"
+    ; max_context_resolution =
+        { requested_override = None
+        ; primary_budget = 2048
+        ; runtime_budget = 2048
+        ; runtime_budget_source = Some Runtime.Capability
+        ; requested_context_window = 2048
+        ; effective_budget = 2048
+        }
+    ; max_context = 2048
+    ; temperature = 0.0
+    }
+  in
   let published = ref [] in
   let run_count = ref 0 in
   let result =
-    Masc.Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
+      Masc.Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
       ~keeper_name:"keeper-test"
       ~base_runtime:"runtime.initial"
-      ~initial_runtime:"runtime.initial"
-      ~initial_max_context:2048
+      ~initial_execution
       ~current_turn_phase_elapsed_ms:(fun _ -> 3, None)
       ~now_s:(fun () -> 10.0)
       ~setup_retry_runtime:(fun _ ->

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -95,26 +95,6 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
-let source_path path =
-  if Filename.is_relative path then
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root -> Filename.concat root path
-    | None -> path
-  else path
-
-let read_source_file path =
-  In_channel.with_open_text (source_path path) In_channel.input_all
-
-let index_of ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop i =
-    if i + needle_len > haystack_len then None
-    else if String.equal (String.sub haystack i needle_len) needle then Some i
-    else loop (i + 1)
-  in
-  if needle_len = 0 then Some 0 else loop 0
-
 let direct_retry_runtime_toml =
   {|
 [runtime]
@@ -1089,41 +1069,6 @@ let test_direct_retry_loop_publishes_non_retry_terminal_cascade () =
   | rows ->
     Alcotest.failf "expected one cascade event, got %d" (List.length rows)
 
-let test_manual_direct_turn_uses_effective_context_budget () =
-  let source = read_source_file "lib/keeper/keeper_turn.ml" in
-  let start_marker = "let max_runtime_context =" in
-  let end_marker = "~initial_max_context:max_runtime_context" in
-  let start =
-    match index_of ~needle:start_marker source with
-    | Some index -> index
-    | None -> Alcotest.fail "manual max_runtime_context block missing"
-  in
-  let stop =
-    match index_of ~needle:end_marker source with
-    | Some index -> index + String.length end_marker
-    | None -> Alcotest.fail "manual direct initial_max_context call missing"
-  in
-  let slice = String.sub source start (stop - start) in
-  Alcotest.(check bool)
-    "manual direct turn resolves max context from runtime/meta"
-    true
-    (contains
-       ~needle:
-         "Keeper_context_runtime.resolve_max_context_resolution\n\
-          \t                  ~requested_override:meta.max_context_override \
-          effective_models"
-       slice);
-  Alcotest.(check bool)
-    "manual direct first attempt uses provider-effective budget"
-    true
-    (contains ~needle:"resolution.effective_budget" slice);
-  Alcotest.(check bool)
-    "manual direct first attempt uses provider-effective context window"
-    false
-    (contains
-       ~needle:"resolution.requested_context_window\n\t            in"
-       slice)
-
 let test_thinking_with_text_is_accepted () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -1776,10 +1721,6 @@ let () =
             "direct retry publishes terminal non-retry cascade"
             `Quick
             test_direct_retry_loop_publishes_non_retry_terminal_cascade;
-          Alcotest.test_case
-            "manual direct turn uses effective context budget"
-            `Quick
-            test_manual_direct_turn_uses_effective_context_budget;
 	          Alcotest.test_case "thinking plus text is accepted" `Quick
 	            test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -3046,7 +3046,40 @@ let test_runtime_max_context_override_above_cap_is_clamped () =
                 (Some (8192, "override_clamped_by_capability"))
                 (Runtime.resolve_max_context_of_runtime rt
                  |> Option.map (fun (n, source) ->
-                   n, Runtime.max_context_source_to_string source)))))
+                   n, Runtime.max_context_source_to_string source)));
+           let meta =
+             match
+               Masc_test_deps.meta_of_json_fixture
+                 (`Assoc
+                    [ "name", `String "direct-cap-clamp"
+                    ; "trace_id", `String "test-direct-cap-clamp"
+                    ])
+             with
+             | Ok meta -> { meta with max_context_override = Some 128000 }
+             | Error detail -> failf "direct meta fixture failed: %s" detail
+           in
+           match
+             Keeper_unified_turn_pre_dispatch.build_runtime_execution
+               ~meta
+               ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta)
+           with
+           | Error error ->
+             failf
+               "direct runtime execution should resolve: %s"
+               (Agent_sdk.Error.to_string error)
+           | Ok execution ->
+             check int
+               "direct first attempt receives the provider-effective budget"
+               8192
+               execution.max_context;
+             check int
+               "direct execution preserves the resolved effective budget"
+               8192
+               execution.max_context_resolution.effective_budget;
+             check (option int)
+               "direct execution retains the requested override for diagnostics"
+               (Some 128000)
+               execution.max_context_resolution.requested_override))
 
 let test_runtime_max_context_missing_both_sources_rejected_at_load () =
   let runtime_toml =

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1043,36 +1043,6 @@ let test_of_meta_projection_budgets_against_routed_runtime () =
       res.Keeper_context_runtime.effective_budget)
 ;;
 
-let test_direct_first_attempt_uses_provider_effective_budget () =
-  with_runtime_initialized (fun () ->
-    (* [budgettest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
-    let meta =
-      { (make_meta "budgettest") with max_context_override = Some 128000 }
-    in
-    let execution =
-      match
-        Keeper_unified_turn_pre_dispatch.build_runtime_execution
-          ~meta
-          ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta)
-      with
-      | Ok execution -> execution
-      | Error error ->
-        Alcotest.fail (Agent_sdk.Error.to_string error)
-    in
-    Alcotest.(check int)
-      "direct first attempt uses the provider-effective routed budget"
-      64000
-      execution.max_context;
-    Alcotest.(check int)
-      "direct execution keeps the resolved effective budget"
-      64000
-      execution.max_context_resolution.effective_budget;
-    Alcotest.(check (option int))
-      "direct execution retains the requested override for diagnostics"
-      (Some 128000)
-      execution.max_context_resolution.requested_override)
-;;
-
 (* ---- per-model thinking gate: runtime.toml [thinking-support] drives the
    keeper thinking seed via [Runtime_inference.for_runtime] ----
 
@@ -1943,10 +1913,6 @@ let () =
             "of_meta projection prefers the routed runtime"
             `Quick
             test_of_meta_projection_budgets_against_routed_runtime
-        ; Alcotest.test_case
-            "direct first attempt uses provider-effective budget"
-            `Quick
-            test_direct_first_attempt_uses_provider_effective_budget
         ] )
     ; ( "per-model thinking gate"
       , [ Alcotest.test_case

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1043,28 +1043,34 @@ let test_of_meta_projection_budgets_against_routed_runtime () =
       res.Keeper_context_runtime.effective_budget)
 ;;
 
-let test_turn_context_window_uses_routed_runtime () =
+let test_direct_first_attempt_uses_provider_effective_budget () =
   with_runtime_initialized (fun () ->
     (* [budgettest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
-    let budget =
-      let meta = make_meta "budgettest" in
-      let resolution =
-        match
-          Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
-            ~requested_override:meta.max_context_override
-            ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta)
-        with
-        | Ok resolution -> resolution
-        | Error error ->
-          Alcotest.fail
-            (Keeper_context_runtime.max_context_resolution_error_to_string error)
-      in
-      Keeper_turn_runtime_budget.resolved_max_context_for_turn ~meta resolution
+    let meta =
+      { (make_meta "budgettest") with max_context_override = Some 128000 }
+    in
+    let execution =
+      match
+        Keeper_unified_turn_pre_dispatch.build_runtime_execution
+          ~meta
+          ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta)
+      with
+      | Ok execution -> execution
+      | Error error ->
+        Alcotest.fail (Agent_sdk.Error.to_string error)
     in
     Alcotest.(check int)
-      "turn context window uses routed runtime, not runtime-id-agnostic labels"
+      "direct first attempt uses the provider-effective routed budget"
       64000
-      budget)
+      execution.max_context;
+    Alcotest.(check int)
+      "direct execution keeps the resolved effective budget"
+      64000
+      execution.max_context_resolution.effective_budget;
+    Alcotest.(check (option int))
+      "direct execution retains the requested override for diagnostics"
+      (Some 128000)
+      execution.max_context_resolution.requested_override)
 ;;
 
 (* ---- per-model thinking gate: runtime.toml [thinking-support] drives the
@@ -1938,9 +1944,9 @@ let () =
             `Quick
             test_of_meta_projection_budgets_against_routed_runtime
         ; Alcotest.test_case
-            "turn context window uses the routed runtime"
+            "direct first attempt uses provider-effective budget"
             `Quick
-            test_turn_context_window_uses_routed_runtime
+            test_direct_first_attempt_uses_provider_effective_budget
         ] )
     ; ( "per-model thinking gate"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 변경

현재 main에서도 실패하는 `test_manual_direct_turn_uses_effective_context_budget`를 제거했어용.

이 검사는 Keeper 동작이 아니라 `keeper_turn.ml` 소스의 들여쓰기·문자열 위치를 slice해서 확인합니다. resolver가 slice 시작점 앞으로 이동하면 기능이 같아도 실패하므로 CI 신호가 아닙니다. 전용 file-reading/index helper도 함께 제거했습니다.

## 검증

- `git diff --check`
- `ocamlformat --check test/test_keeper_turn_driver_accept.ml`

Dune은 로컬에서 실행하지 않았고 CI로 확인합니다.