### PR TITLE
fix(keeper): project exact input before OAS admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,18 @@ jobs:
           tool_blob_targets="@test/runtest-test_tool_blob_store @test/runtest-test_keeper_tool_call_log @test/runtest-test_keeper_wire_capture"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${tool_blob_targets}"
 
+      - name: Run runtime provider agent suite
+        id: runtime_provider_agent_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_runtime_provider_auth_headers"
+
       - name: Run operator control suite
         id: operator_control_suite
         # Run regardless of earlier test failures, but only after a successful

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -59,8 +59,7 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; hooks : Agent_sdk.Hooks.hooks
-  ; model_input_projection :
-      Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+  ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; acc : hook_accumulator
   ; all_tool_names : string list
   ; receipt_turn_count_ref : int option ref

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -55,8 +55,7 @@ type agent_setup =
   ; cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; hooks : Agent_sdk.Hooks.hooks
-  ; model_input_projection :
-      Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+  ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; acc : hook_accumulator
   ; all_tool_names : string list
   ; receipt_turn_count_ref : int option ref

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -15,8 +15,7 @@ type agent_setup =
   ; cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; hooks : Agent_sdk.Hooks.hooks
-  ; model_input_projection :
-      Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+  ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; acc : hook_accumulator
   ; all_tool_names : string list
   ; receipt_turn_count_ref : int option ref
@@ -553,12 +552,13 @@ let assemble_hooks
       }
     in
     let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
-    let model_input_projection =
+    let hydrate_model_input =
       let store = Tool_blob_store.create ~base_path:ctx.config.base_path in
       Keeper_artifact_hydrator.hydrate_recent
         ~store
         ~keep_recent:(Keeper_artifact_hydrator.keep_recent_from_env ())
     in
+    let model_input_projection messages = Ok (hydrate_model_input messages) in
     Ok
       { tools
       ; cleanup = keeper_tools_cleanup

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -88,8 +88,7 @@ val run_named :
   ?system_prompt:string ->
   ?tools:Agent_sdk.Tool.t list ->
   ?initial_messages:Agent_sdk.Types.message list ->
-  ?model_input_projection:
-    (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) ->
+  ?model_input_projection:Agent_sdk.Agent.model_input_projection ->
   ?stream_idle_timeout_s:float ->
   ?body_timeout_s:float ->
   ?temperature:float ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -29,8 +29,7 @@ type try_provider_ctx =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
-  ; model_input_projection :
-      (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
+  ; model_input_projection : Agent_sdk.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float option

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -12,8 +12,7 @@ type try_provider_ctx =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
-  ; model_input_projection :
-      (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
+  ; model_input_projection : Agent_sdk.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float option

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -109,8 +109,7 @@ type config =
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
-  model_input_projection
-      : (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
+  model_input_projection : Agent_sdk.Agent.model_input_projection option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;
@@ -211,7 +210,6 @@ let observed_http_transport
     ~net
     ?clock
     ?body_timeout_s
-    ?model_input_projection
     ()
   : Llm_provider.Llm_transport.t =
   (* RFC-OAS-026: stream_idle_timeout_s moved off transport construction
@@ -229,16 +227,6 @@ let observed_http_transport
       ~net
       ()
   in
-  let project_request
-      (request : Llm_provider.Llm_transport.completion_request)
-    =
-    let messages =
-      match model_input_projection with
-      | None -> request.messages
-      | Some project -> project request.messages
-    in
-    { request with messages }
-  in
   provider_http_observation_transport
     { complete_sync =
       (fun req ->
@@ -246,7 +234,7 @@ let observed_http_transport
            per turn for each provider. Removed at Phase 0 closeout. *)
         Log.Misc.debug
           "rfc0095-trace: runtime_runner http_transport.complete_sync invoked";
-        http_transport.complete_sync (project_request req));
+        http_transport.complete_sync req);
       complete_stream =
       (fun ?on_telemetry ~on_event req ->
         (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
@@ -256,7 +244,7 @@ let observed_http_transport
         http_transport.complete_stream
           ?on_telemetry
           ~on_event
-          (project_request req));
+          req);
     }
 
 let transport_for_provider
@@ -264,7 +252,6 @@ let transport_for_provider
     ~net
     ?clock
     ?body_timeout_s
-    ?model_input_projection
     ()
   =
   (* CLI subprocess transport removed (2026-05-31); every provider dispatches
@@ -279,7 +266,6 @@ let transport_for_provider
           ~net
           ?clock
           ?body_timeout_s
-          ?model_input_projection
           ()))
 
 let runtime_id_of_config (config : config) =
@@ -913,7 +899,6 @@ let build
          ~net
          ?clock
          ?body_timeout_s:config.body_timeout_s
-         ?model_input_projection:config.model_input_projection
          ()
      with
      | Error _ as e -> e
@@ -1000,7 +985,6 @@ let resume_from_checkpoint
          ~net
          ?clock
          ?body_timeout_s:config.body_timeout_s
-         ?model_input_projection:config.model_input_projection
          ()
      with
      | Error _ as e -> e
@@ -1017,6 +1001,7 @@ let resume_from_checkpoint
            ~tools:config.tools ?context:config.context
            ~provider_config:config.provider_cfg
            ~context_fit_admission:prepared_resume.context_fit_admission
+           ?model_input_projection:config.model_input_projection
            ~options ~config:prepared_resume.agent_config
            ?checkpoint_sink:config.checkpoint_sink
            ()))

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -85,8 +85,7 @@ type config = Runtime_agent_context.config = {
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
-  model_input_projection
-      : (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
+  model_input_projection : Agent_sdk.Agent.model_input_projection option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -53,20 +53,18 @@ type config =
         owned by [stream_idle_timeout_s] plus attempt observation. Non-HTTP
         transports ignore it. *)
   ; max_tokens : int option
-    (** Request-time output token budget. [None] means no [max_tokens] field
-        goes on the request at all — the keeper lane's default (masc#24067 /
-        oas#2517): the OAS capability catalog ceiling is a validation bound,
-        never a synthesized request value. [Some n] is an explicit
-        operator/profile override or a non-keeper caller's deliberate
-        request budget. *)
+    (** Caller-level output-token override. [None] adds no override, so an
+        explicit [provider_cfg.max_tokens] remains authoritative; when both are
+        absent no [max_tokens] field is synthesized from a capability ceiling.
+        [Some n] is an operator/profile override or a non-keeper caller's
+        deliberate request budget. *)
   ; temperature : float option
   ; hooks : Agent_sdk.Hooks.hooks option
   ; event_bus : Agent_sdk.Event_bus.t option
   ; session_id : string option
   ; description : string option
   ; initial_messages : Agent_sdk.Types.message list
-  ; model_input_projection :
-      (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
+  ; model_input_projection : Agent_sdk.Agent.model_input_projection option
     (** Caller-owned projection applied only to provider-bound messages.
         Agent state and checkpoints retain their canonical persisted form. *)
   ; raw_trace : Agent_sdk.Raw_trace.t option
@@ -149,6 +147,47 @@ let set_oas_tracer tracer = Atomic.set oas_tracer_ref tracer
 
 let context_fit_admission = Agent_sdk.Agent.Enforce_when_supported
 
+let configured_or_inherited configured inherited =
+  match configured with
+  | Some _ as configured -> configured
+  | None -> inherited
+;;
+
+(* Fresh Builder construction starts from [provider_cfg] and applies only
+   explicit Runtime_agent overrides. Resume must use that same resolution:
+   otherwise an absent caller override clears provider-owned request fields
+   such as Anthropic's required [max_tokens] and changes admission semantics. *)
+let agent_config_for_request (config : config) : Agent_sdk.Types.agent_config =
+  let provider = config.provider_cfg in
+  { (Agent_sdk.Types.default_config ~model:config.model_id) with
+    name = config.name
+  ; model = config.model_id
+  ; system_prompt = Some config.system_prompt
+  ; max_tokens = configured_or_inherited config.max_tokens provider.max_tokens
+  ; temperature =
+      configured_or_inherited config.temperature provider.temperature
+  ; top_p = configured_or_inherited config.top_p provider.top_p
+  ; top_k = configured_or_inherited config.top_k provider.top_k
+  ; min_p = configured_or_inherited config.min_p provider.min_p
+  ; enable_thinking =
+      configured_or_inherited config.enable_thinking provider.enable_thinking
+  ; preserve_thinking =
+      configured_or_inherited
+        config.preserve_thinking
+        provider.preserve_thinking
+  ; response_format = provider.response_format
+  ; thinking_budget =
+      configured_or_inherited config.thinking_budget provider.thinking_budget
+  ; reasoning_effort = provider.reasoning_effort
+  ; tool_choice = provider.tool_choice
+  ; disable_parallel_tool_use = provider.disable_parallel_tool_use
+  ; cache_system_prompt =
+      config.cache_system_prompt || provider.cache_system_prompt
+  ; initial_messages = config.initial_messages
+  ; yield_on_tool = config.yield_on_tool
+  }
+;;
+
 let builder
       ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
       ~(config : config)
@@ -228,6 +267,11 @@ let builder
     else builder
   in
   let builder =
+    match config.model_input_projection with
+    | Some project -> Agent_sdk.Builder.with_model_input_projection project builder
+    | None -> builder
+  in
+  let builder =
     match config.context_injector with
     | Some injector -> Agent_sdk.Builder.with_context_injector injector builder
     | None -> builder
@@ -290,37 +334,23 @@ type prepared_resume =
 let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
   : prepared_resume
   =
-
+  let agent_config = agent_config_for_request config in
   let patched_checkpoint =
     { checkpoint with
       Agent_sdk.Checkpoint.model = config.model_id
-    ; system_prompt = Some config.system_prompt
-    ; temperature = config.temperature
-    ; top_p = config.top_p
-    ; top_k = config.top_k
-    ; min_p = config.min_p
-    ; enable_thinking = config.enable_thinking
-    ; preserve_thinking = config.preserve_thinking
-    ; thinking_budget = config.thinking_budget
-    ; cache_system_prompt = config.cache_system_prompt
-    ; response_format = config.provider_cfg.response_format
-    }
-  in
-  let agent_config : Agent_sdk.Types.agent_config =
-    { (Agent_sdk.Types.default_config ~model:config.model_id) with
-      name = config.name
-    ; model = config.model_id
-    ; system_prompt = Some config.system_prompt
-    ; max_tokens = config.max_tokens
-    ; temperature = config.temperature
-    ; top_p = config.top_p
-    ; top_k = config.top_k
-    ; min_p = config.min_p
-    ; enable_thinking = config.enable_thinking
-    ; preserve_thinking = config.preserve_thinking
-    ; thinking_budget = config.thinking_budget
-    ; cache_system_prompt = config.cache_system_prompt
-    ; yield_on_tool = config.yield_on_tool
+    ; system_prompt = agent_config.system_prompt
+    ; tool_choice = agent_config.tool_choice
+    ; disable_parallel_tool_use = agent_config.disable_parallel_tool_use
+    ; temperature = agent_config.temperature
+    ; top_p = agent_config.top_p
+    ; top_k = agent_config.top_k
+    ; min_p = agent_config.min_p
+    ; reasoning_effort = agent_config.reasoning_effort
+    ; enable_thinking = agent_config.enable_thinking
+    ; preserve_thinking = agent_config.preserve_thinking
+    ; thinking_budget = agent_config.thinking_budget
+    ; cache_system_prompt = agent_config.cache_system_prompt
+    ; response_format = agent_config.response_format
     }
   in
   let options : Agent_sdk.Agent.options =

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -44,12 +44,11 @@ type config = {
           owned by [stream_idle_timeout_s] and the attempt liveness
           observer. Non-HTTP transports ignore it. *)
   max_tokens : int option;
-      (** Request-time output token budget. [None] means no [max_tokens]
-          field goes on the request at all — the keeper lane's default
-          (masc#24067 / oas#2517): the OAS capability catalog ceiling is a
-          validation bound, never a synthesized request value. [Some n] is
-          an explicit operator/profile override or a non-keeper caller's
-          deliberate request budget. *)
+      (** Caller-level output-token override. [None] adds no override, so an
+          explicit [provider_cfg.max_tokens] remains authoritative; when both
+          are absent no request field is synthesized from a capability
+          ceiling. [Some n] is an operator/profile override or a non-keeper
+          caller's deliberate request budget. *)
   temperature : float option;
       (** Exact caller/model sampling declaration. [None] omits temperature and
           leaves the selected provider's default intact. *)
@@ -58,8 +57,7 @@ type config = {
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
-  model_input_projection
-      : (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
+  model_input_projection : Agent_sdk.Agent.model_input_projection option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;
@@ -130,8 +128,9 @@ type prepared_resume = {
   options : Agent_sdk.Agent.options;
   context_fit_admission : Agent_sdk.Agent.context_fit_admission;
 }
-(** Output of {!prepare_resume}. [patched_checkpoint] has runtime identity
-    fields adjusted. *)
+(** Output of {!prepare_resume}. [patched_checkpoint] and [agent_config] use
+    the same provider-base-plus-explicit-override resolution as a fresh
+    builder. *)
 
 val set_oas_tracer : Agent_sdk.Tracing.t -> unit
 (** Set the OAS tracer used by {!builder}.  Called once

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1444,6 +1444,48 @@ let with_native_count_server f =
   let result = f ~sw ~net ~base_url in
   result, List.rev !paths
 
+let with_native_projection_server f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let port = fresh_loopback_port () in
+  let requests = ref [] in
+  let handler _conn request body =
+    let body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let path = Cohttp.Request.uri request |> Uri.path in
+    requests := (path, body) :: !requests;
+    if String.equal path "/v1/messages/count_tokens"
+    then Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"input_tokens":64}|} ()
+    else if String.equal path "/v1/messages"
+    then
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:
+          {|{"id":"msg-projection","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"context-fit-fixture","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":64,"output_tokens":1}}|}
+        ()
+    else
+      Cohttp_eio.Server.respond_string
+        ~status:`Not_found
+        ~body:{|{"error":"unexpected path"}|}
+        ()
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:4
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let result = f ~sw ~net ~base_url in
+  result, List.rev !requests
+
 let context_fit_provider_config base_url =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.Anthropic
@@ -1535,6 +1577,74 @@ let test_runtime_agent_resume_enforces_native_context_fit () =
       (fun () -> Agent_sdk.Agent.run ~sw agent "overflow" |> check_context_fit_overflow)
   in
   check (list string) "resumed request paths" [ "/v1/messages/count_tokens" ] paths
+
+let projection_messages marker messages =
+  let project_block = function
+    | Agent_sdk.Types.Text _ -> Agent_sdk.Types.Text marker
+    | block -> block
+  in
+  List.map
+    (fun (message : Agent_sdk.Types.message) ->
+      { message with content = List.map project_block message.content })
+    messages
+
+let run_projection_case ~resume =
+  let canonical_marker = "canonical-unprojected-message" in
+  let projected_marker = "projected-provider-message" in
+  let projection_calls = ref 0 in
+  let (), requests =
+    with_native_projection_server
+    @@ fun ~sw ~net ~base_url ->
+    let config =
+      { (context_fit_runtime_config base_url) with
+        model_input_projection =
+          Some
+            (fun messages ->
+               incr projection_calls;
+               Ok (projection_messages projected_marker messages))
+      }
+    in
+    let agent =
+      if resume
+      then
+        Runtime_agent.resume_from_checkpoint
+          ~sw
+          ~net
+          ~config
+          ~checkpoint:(context_fit_checkpoint ())
+      else Runtime_agent.build ~sw ~net ~config
+    in
+    let agent =
+      match agent with
+      | Ok agent -> agent
+      | Error error -> fail (Agent_sdk.Error.to_string error)
+    in
+    Fun.protect
+      ~finally:(fun () -> Agent_sdk.Agent.close agent)
+      (fun () ->
+         match Agent_sdk.Agent.run ~sw agent canonical_marker with
+         | Ok _ -> ()
+         | Error error -> fail (Agent_sdk.Error.to_string error))
+  in
+  check int "projection executes once" 1 !projection_calls;
+  check
+    (list string)
+    "measurement and completion both execute"
+    [ "/v1/messages/count_tokens"; "/v1/messages" ]
+    (List.map fst requests);
+  List.iter
+    (fun (path, body) ->
+       check bool (path ^ " sees projected input") true
+         (String_util.contains_substring body projected_marker);
+       check bool (path ^ " excludes canonical input") false
+         (String_util.contains_substring body canonical_marker))
+    requests
+
+let test_runtime_agent_fresh_projection_precedes_measurement () =
+  run_projection_case ~resume:false
+
+let test_runtime_agent_resume_projection_precedes_measurement () =
+  run_projection_case ~resume:true
 
 (* RFC-OAS-026 §4.6: a configured stream-idle deadline with no resolvable clock
    must fail loudly rather than silently disarm the only I2-legitimate
@@ -1760,6 +1870,14 @@ let () =
             "runtime resume enforces native context fit"
             `Quick
             test_runtime_agent_resume_enforces_native_context_fit
+        ; test_case
+            "fresh projection precedes measurement and dispatch"
+            `Quick
+            test_runtime_agent_fresh_projection_precedes_measurement
+        ; test_case
+            "resumed projection precedes measurement and dispatch"
+            `Quick
+            test_runtime_agent_resume_projection_precedes_measurement
         ; test_case
             "dashboard runtime provider reachability contracts"
             `Quick


### PR DESCRIPTION
## Stack

Base: #26175. This is the first small exact-request foundation above the Keeper runtime request-cap boundary.

## Change

- Move the caller-owned Keeper message projection from the final HTTP transport wrapper into the OAS Agent model-input projection boundary.
- Native token measurement and completion dispatch now consume the same projected message value; the projection executes once for fresh and resumed agents.
- Resolve resumed request fields with the same provider-base plus explicit Runtime_agent override contract as fresh Builder construction. This preserves provider-owned required fields such as Anthropic max_tokens instead of clearing them with an absent caller override.
- Wrap the existing artifact hydrator in the typed OAS projection result; canonical Agent state and checkpoints remain unchanged.

## Verification

- test_runtime_provider_auth_headers: 43/43 pass, including fresh/resume native context admission and new measurement-versus-dispatch projection parity.
- test_keeper_artifact_hydrator: 8/8 pass.
- test_keeper_turn_driver_accept: 36/37 pass; the only failure is the pre-existing source-slice assertion tracked in #26174.
- test_keeper_run_tools_hooks: 19/20 pass; the only failure is the pre-existing ignored Docker fixture argument tracked in #26180.
- ocamlformat and git diff --check pass.

Current head: cdc0be062ac5f81b27f3f0b0c1fff3953d605f96

This remains draft until #26175 is merged, the PR is retargeted to main, full current-head CI is green, and review threads are clear.