### PR TITLE
fix(runtime): probe compacted request admission

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -141,6 +141,20 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
+type capacity_readmission_failure =
+  | Still_over_capacity of Agent_sdk.Error.sdk_error
+  | Readmission_failed of Agent_sdk.Error.sdk_error
+
+type capacity_readmission_evidence =
+  { serialized_body_limit_bytes : int option
+  ; token_fit_limit_tokens : int option
+  ; serving_constraint_admitted : bool
+  }
+
+type capacity_readmission_probe =
+  Agent_sdk.Checkpoint.t ->
+  (capacity_readmission_evidence, capacity_readmission_failure) result
+
 type worker_lifecycle_classification =
   { event : string
   ; status : string
@@ -970,6 +984,29 @@ let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =
       Agent.resume state restoration.
     - OAS no longer enforces cost or cumulative-token budgets; cost is
       observe-only telemetry. *)
+let resume_from_checkpoint_with_transport
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+    ~(checkpoint : Agent_sdk.Checkpoint.t)
+    ~(transport : Llm_provider.Llm_transport.t option)
+  =
+  let prepared_resume =
+    Runtime_agent_context.prepare_resume ~config ~checkpoint
+  in
+  Log.Misc.info
+    "oas_worker %s: resume checkpoint_turn_count=%d turn_limit=unlimited"
+    config.name checkpoint.turn_count;
+  let options = { prepared_resume.options with transport } in
+  Agent_sdk.Agent.resume ~net ~checkpoint:prepared_resume.patched_checkpoint
+    ~tools:config.tools ?context:config.context
+    ~provider_config:config.provider_cfg
+    ~context_fit_admission:prepared_resume.context_fit_admission
+    ?model_input_projection:config.model_input_projection
+    ~options ~config:prepared_resume.agent_config
+    ?checkpoint_sink:config.checkpoint_sink
+    ()
+;;
+
 let resume_from_checkpoint
     ~(sw : Eio.Switch.t)
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
@@ -989,22 +1026,244 @@ let resume_from_checkpoint
      with
      | Error _ as e -> e
      | Ok transport ->
-      let prepared_resume =
-        Runtime_agent_context.prepare_resume ~config ~checkpoint
-      in
-      Log.Misc.info
-        "oas_worker %s: resume checkpoint_turn_count=%d turn_limit=unlimited"
-        config.name checkpoint.turn_count;
-      let options = { prepared_resume.options with transport } in
       Ok
-        (Agent_sdk.Agent.resume ~net ~checkpoint:prepared_resume.patched_checkpoint
-           ~tools:config.tools ?context:config.context
-           ~provider_config:config.provider_cfg
-           ~context_fit_admission:prepared_resume.context_fit_admission
-           ?model_input_projection:config.model_input_projection
-           ~options ~config:prepared_resume.agent_config
-           ?checkpoint_sink:config.checkpoint_sink
-           ()))
+        (resume_from_checkpoint_with_transport
+           ~net
+           ~config
+           ~checkpoint
+           ~transport))
+
+let capacity_readmission_failure_of_error error =
+  match error with
+  | Agent_sdk.Error.Api (ContextOverflow _)
+  | Agent_sdk.Error.Api
+      (InvalidRequest
+         { reason =
+             ( Request_body_too_large _
+             | Request_body_refused_by_provider _ )
+         ; _
+         })
+  | Agent_sdk.Error.Api
+      (InputCapacity
+         { reason =
+             Serving_constraint_rejected
+               (Llm_provider.Serving_constraint.Boundary_unknown _
+               | Llm_provider.Serving_constraint.Input_rejected _)
+         ; _
+         }) ->
+    Still_over_capacity error
+  | Agent_sdk.Error.Api
+      (InvalidRequest
+         { reason = Json_parse_error | Unknown_invalid_request; _ })
+  | Agent_sdk.Error.Api
+      (InputCapacity
+         { reason =
+             ( Serving_constraint_rejected
+                 (Llm_provider.Serving_constraint.Evidence_not_yet_valid _
+                 | Llm_provider.Serving_constraint.Evidence_expired _)
+             | Token_measurement_unavailable _ )
+         ; _
+         })
+  | Agent_sdk.Error.Api
+      ( RateLimited _ | Overloaded _ | ServerError _ | AuthError _
+      | AuthorizationError _ | PaymentRequired _ | NotFound _ | NetworkError _
+      | Timeout _ )
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ ->
+    Readmission_failed error
+;;
+
+module Capacity_readmission_for_testing = struct
+  let failure_of_error = capacity_readmission_failure_of_error
+end
+
+let request_enforces_token_fit (config : Llm_provider.Provider_config.t) =
+  Llm_provider.Count_tokens_sync.supports_completion_request_measurement config
+  ||
+    (match Llm_provider.Provider_config.capabilities_for_config_model config with
+     | Some { Llm_provider.Capabilities.serving_constraint = Some _; _ } -> true
+     | Some _ | None -> false)
+;;
+
+let capacity_readmission_evidence ~stream request =
+  let prepared =
+    Llm_provider.Complete.prepare_request
+      ~config:request.Llm_provider.Llm_transport.config
+      ~messages:request.messages
+      ~tools:request.tools
+      ?capture_id:request.capture_id
+      ?stream_idle_timeout_s:request.stream_idle_timeout_s
+      ?first_event_timeout_s:request.first_event_timeout_s
+      ?body_timeout_s:request.body_timeout_s
+      ()
+  in
+  let token_fit_enforced = request_enforces_token_fit request.config in
+  let ( let* ) = Result.bind in
+  let* () =
+    if token_fit_enforced
+    then
+      (* The Enforce_when_supported route serializes and admits this exact body
+         before native measurement, so reaching the transport is already the
+         proof. Re-serializing here would create a second, merely equivalent
+         artifact rather than observe the admitted one. *)
+      Ok ()
+    else
+      (* Injected transports bypass the built-in HTTP serializer on the
+         compatibility route. Admit that exact request once here before the
+         sentinel can claim success. *)
+      Llm_provider.Complete.admit_request_body ~stream prepared
+      |> Result.map (fun _ -> ())
+  in
+  let* token_fit_limit_tokens =
+    if token_fit_enforced
+    then
+      (match Llm_provider.Complete.resolve_context_limit prepared with
+       | Ok limit -> Ok (Some limit)
+       | Error _ ->
+         Error
+           (Llm_provider.Http_client.AcceptRejected
+              { reason =
+                  "capacity re-admission reached the transport without a \
+                   resolvable context limit"
+              }))
+    else Ok None
+  in
+  Ok
+    { serialized_body_limit_bytes = request.config.max_request_body_bytes
+    ; token_fit_limit_tokens
+    ; serving_constraint_admitted =
+        Option.is_some (Llm_provider.Complete.serving_constraint prepared)
+    }
+;;
+
+let capacity_probe_transport observed : Llm_provider.Llm_transport.t =
+  let reject ~stream request =
+    match capacity_readmission_evidence ~stream request with
+    | Error _ as error -> error
+    | Ok evidence ->
+      Atomic.set observed (Some evidence);
+      Error
+        (Llm_provider.Http_client.AcceptRejected
+           { reason =
+               "provider transport is disabled for capacity re-admission"
+           })
+  in
+  { complete_sync =
+      (fun request ->
+         { Llm_provider.Llm_transport.response =
+             reject ~stream:false request
+         ; latency_ms = None
+         })
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event:_ request ->
+         reject ~stream:true request)
+  }
+;;
+
+let probe_blocks_admission
+      ?request_shaping_hooks
+      ~(sw : Eio.Switch.t)
+      ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+      ~(config : config)
+      ~(checkpoint : Agent_sdk.Checkpoint.t)
+      ~(stream : bool)
+      ~(continuation : bool)
+      (goal_blocks : Agent_sdk.Types.content_block list)
+  : (capacity_readmission_evidence, capacity_readmission_failure) result
+  =
+  let admitted_goal_blocks = if continuation then [] else goal_blocks in
+  match
+    validate_content_blocks_for_config
+      ~oas_checkpoint:checkpoint
+      ~config
+      admitted_goal_blocks
+  with
+  | Error error -> Error (capacity_readmission_failure_of_error error)
+  | Ok () when continuation && not stream ->
+    Error
+      (Readmission_failed
+         (Agent_sdk.Error.Config
+            (Agent_sdk.Error.InvalidConfig
+               { field = "capacity_readmission.continuation"
+               ; detail =
+                   "OAS does not expose a synchronous provider-turn \
+                    continuation entry point"
+               })))
+  | Ok () ->
+    (match resolve_clock_for_idle ~stream_idle_timeout_s:config.stream_idle_timeout_s with
+     | Error error -> Error (capacity_readmission_failure_of_error error)
+     | Ok _ ->
+       let observed = Atomic.make None in
+       let transport = capacity_probe_transport observed in
+       let probe_config =
+         { config with
+           hooks = request_shaping_hooks
+         ; context_injector = None
+         ; context = None
+         ; raw_trace = None
+         ; event_bus = None
+         ; on_run_complete = None
+         ; checkpoint_sink = None
+         }
+       in
+       let agent =
+         resume_from_checkpoint_with_transport
+           ~net
+           ~config:probe_config
+           ~checkpoint
+           ~transport:(Some transport)
+       in
+       let run_result : (unit, Agent_sdk.Error.sdk_error) result =
+         Fun.protect
+           ~finally:(fun () ->
+             close_agent_for_cleanup
+               ~propagate_cancel:false
+               ~config:probe_config
+               agent)
+           (fun () ->
+              let clock =
+                match Process_eio.get_clock () with
+                | Ok clock -> Some clock
+                | Error _ -> Eio_context.get_clock_opt ()
+              in
+              if continuation
+              then
+                Agent_sdk.Agent.run_turn_stream
+                  ~sw
+                  ?clock
+                  ~on_event:(fun _ -> ())
+                  agent
+                |> Result.map (fun _ -> ())
+              else if stream
+              then
+                Agent_sdk.Agent.run_stream_blocks
+                  ~sw
+                  ?clock
+                  ~on_event:(fun _ -> ())
+                  agent
+                  goal_blocks
+                |> Result.map (fun _ -> ())
+              else
+                Agent_sdk.Agent.run_blocks ~sw ?clock agent goal_blocks
+                |> Result.map (fun _ -> ()))
+       in
+       (match Atomic.get observed, run_result with
+        | Some evidence, _ -> Ok evidence
+        | None, Error error ->
+          Error (capacity_readmission_failure_of_error error)
+        | None, Ok () ->
+          Error
+            (Readmission_failed
+               (Agent_sdk.Error.Internal
+                  "capacity re-admission completed without reaching the \
+                   provider admission boundary"))))
+;;
 
 (* ================================================================ *)
 (* Run                                                               *)

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -129,6 +129,33 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
+type capacity_readmission_failure =
+  | Still_over_capacity of Agent_sdk.Error.sdk_error
+  | Readmission_failed of Agent_sdk.Error.sdk_error
+
+type capacity_readmission_evidence =
+  { serialized_body_limit_bytes : int option
+  ; token_fit_limit_tokens : int option
+  ; serving_constraint_admitted : bool
+  }
+(** Evidence carried by the exact request that reached the disabled completion
+    transport. A declared [serialized_body_limit_bytes] means the provider body
+    passed that exact byte ceiling. [token_fit_limit_tokens = Some limit] means
+    OAS also measured this request through the provider-native protocol and
+    admitted it against [limit]. *)
+
+type capacity_readmission_probe =
+  Agent_sdk.Checkpoint.t ->
+  (capacity_readmission_evidence, capacity_readmission_failure) result
+(** Rebuild and re-admit one failed Keeper provider request against a candidate
+    checkpoint. The probe may call the provider-native measurement endpoint,
+    but never sends a completion-generation request. *)
+
+module Capacity_readmission_for_testing : sig
+  val failure_of_error :
+    Agent_sdk.Error.sdk_error -> capacity_readmission_failure
+end
+
 type worker_lifecycle_classification =
   { event : string
   ; status : string
@@ -373,6 +400,26 @@ val resume_from_checkpoint :
 (** Resumes from a persisted checkpoint.  Uses
     [Runtime_agent_context.prepare_resume] to reconcile
     [checkpoint.turn_count] with the current config. *)
+
+val probe_blocks_admission :
+  ?request_shaping_hooks:Agent_sdk.Hooks.hooks ->
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  checkpoint:Agent_sdk.Checkpoint.t ->
+  stream:bool ->
+  continuation:bool ->
+  Agent_sdk.Types.content_block list ->
+  (capacity_readmission_evidence, capacity_readmission_failure) result
+(** Execute the same OAS projection, serialization, provider-native
+    measurement, and admission path with a local completion-transport sentinel.
+    [request_shaping_hooks] is the caller-captured, request-only hook set; live
+    Keeper effects, context injection, event publication, tracing, and
+    checkpoint persistence are disabled for the probe.
+
+    [continuation] resumes an already-persisted post-tool stream turn without
+    appending the original user input again. Synchronous continuation fails
+    closed because OAS exposes no equivalent public continuation entry point. *)
 
 val run :
   sw:Eio.Switch.t ->

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1409,7 +1409,7 @@ let fresh_loopback_port () =
   Unix.close socket;
   port
 
-let with_native_count_server f =
+let with_native_count_server ?(input_tokens = 500) f =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -1417,12 +1417,18 @@ let with_native_count_server f =
   let net = Eio.Stdenv.net env in
   let port = fresh_loopback_port () in
   let paths = ref [] in
+  let bodies = ref [] in
   let handler _conn request body =
-    let _body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
     let path = Cohttp.Request.uri request |> Uri.path in
     paths := path :: !paths;
+    bodies := body :: !bodies;
     if String.equal path "/v1/messages/count_tokens"
-    then Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"input_tokens":500}|} ()
+    then
+      Cohttp_eio.Server.respond_string
+        ~status:`OK
+        ~body:(Printf.sprintf {|{"input_tokens":%d}|} input_tokens)
+        ()
     else
       Cohttp_eio.Server.respond_string
         ~status:`Internal_server_error
@@ -1442,7 +1448,7 @@ let with_native_count_server f =
     Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
   let result = f ~sw ~net ~base_url in
-  result, List.rev !paths
+  result, List.rev !paths, List.rev !bodies
 
 let with_native_projection_server f =
   Eio_main.run
@@ -1496,6 +1502,7 @@ let context_fit_provider_config base_url =
     ~request_path:"/v1/messages"
     ~max_tokens:64
     ~max_context:512
+    ~max_request_body_bytes:1_048_576
     ~temperature:0.2
     ()
 
@@ -1541,7 +1548,7 @@ let check_context_fit_overflow = function
   | Ok _ -> fail "overflowed request must not reach completion dispatch"
 
 let test_runtime_agent_fresh_build_enforces_native_context_fit () =
-  let (), paths =
+  let (), paths, _bodies =
     with_native_count_server
     @@ fun ~sw ~net ~base_url ->
     let config = context_fit_runtime_config base_url in
@@ -1557,7 +1564,7 @@ let test_runtime_agent_fresh_build_enforces_native_context_fit () =
   check (list string) "fresh request paths" [ "/v1/messages/count_tokens" ] paths
 
 let test_runtime_agent_resume_enforces_native_context_fit () =
-  let (), paths =
+  let (), paths, _bodies =
     with_native_count_server
     @@ fun ~sw ~net ~base_url ->
     let config = context_fit_runtime_config base_url in
@@ -1577,6 +1584,279 @@ let test_runtime_agent_resume_enforces_native_context_fit () =
       (fun () -> Agent_sdk.Agent.run ~sw agent "overflow" |> check_context_fit_overflow)
   in
   check (list string) "resumed request paths" [ "/v1/messages/count_tokens" ] paths
+
+let test_capacity_readmission_probe_stops_before_transport_when_still_over () =
+  let (), paths, _bodies =
+    with_native_count_server
+    @@ fun ~sw ~net ~base_url ->
+    match
+      Runtime_agent.probe_blocks_admission
+        ~sw
+        ~net
+        ~config:(context_fit_runtime_config base_url)
+        ~checkpoint:(context_fit_checkpoint ())
+        ~stream:false
+        ~continuation:false
+        [ Agent_sdk.Types.Text "same failed request" ]
+    with
+    | Error
+        (Runtime_agent.Still_over_capacity
+           (Agent_sdk.Error.Api
+              (Agent_sdk.Retry.ContextOverflow { limit = Some 512; _ }))) ->
+      ()
+    | Error (Runtime_agent.Still_over_capacity error)
+    | Error (Runtime_agent.Readmission_failed error) ->
+      fail (Agent_sdk.Error.to_string error)
+    | Ok _ -> fail "over-capacity candidate reached the probe transport"
+  in
+  check
+    (list string)
+    "rejected probe performs only provider-native measurement"
+    [ "/v1/messages/count_tokens" ]
+    paths
+
+let test_capacity_readmission_probe_admits_without_completion_dispatch () =
+  let (), paths, _bodies =
+    with_native_count_server
+      ~input_tokens:400
+    @@ fun ~sw ~net ~base_url ->
+    match
+      Runtime_agent.probe_blocks_admission
+        ~sw
+        ~net
+        ~config:(context_fit_runtime_config base_url)
+        ~checkpoint:(context_fit_checkpoint ())
+        ~stream:false
+        ~continuation:false
+        [ Agent_sdk.Types.Text "same failed request" ]
+    with
+    | Ok evidence ->
+      check
+        (option int)
+        "serialized-body proof retains the runtime cap"
+        (Some 1_048_576)
+        evidence.Runtime_agent.serialized_body_limit_bytes;
+      check
+        (option int)
+        "token-fit proof retains the admitted limit"
+        (Some 512)
+        evidence.token_fit_limit_tokens
+    | Error (Runtime_agent.Still_over_capacity error)
+    | Error (Runtime_agent.Readmission_failed error) ->
+      fail (Agent_sdk.Error.to_string error)
+  in
+  check
+    (list string)
+    "admitted probe measures but never dispatches completion HTTP"
+    [ "/v1/messages/count_tokens" ]
+    paths
+
+let test_capacity_readmission_probe_uses_only_captured_request_shaping () =
+  let live_hook_calls = ref 0 in
+  let probe_hook_calls = ref 0 in
+  let shaping_marker = "captured-probe-request-shaping" in
+  let hooks counter decision : Agent_sdk.Hooks.hooks =
+    { Agent_sdk.Hooks.empty with
+      before_turn_params =
+        Some
+          (fun _ ->
+            incr counter;
+            decision)
+    }
+  in
+  let live_hooks = hooks live_hook_calls Agent_sdk.Hooks.Continue in
+  let probe_hooks =
+    hooks
+      probe_hook_calls
+      (Agent_sdk.Hooks.AdjustParams
+         { Agent_sdk.Hooks.default_turn_params with
+           extra_system_context = Some shaping_marker
+         })
+  in
+  let (), paths, bodies =
+    with_native_count_server
+      ~input_tokens:400
+    @@ fun ~sw ~net ~base_url ->
+    let config =
+      { (context_fit_runtime_config base_url) with
+        hooks = Some live_hooks
+      }
+    in
+    match
+      Runtime_agent.probe_blocks_admission
+        ~request_shaping_hooks:probe_hooks
+        ~sw
+        ~net
+        ~config
+        ~checkpoint:(context_fit_checkpoint ())
+        ~stream:false
+        ~continuation:false
+        [ Agent_sdk.Types.Text "same failed request" ]
+    with
+    | Ok _ -> ()
+    | Error (Runtime_agent.Still_over_capacity error)
+    | Error (Runtime_agent.Readmission_failed error) ->
+      fail (Agent_sdk.Error.to_string error)
+  in
+  check int "live keeper hook is not replayed" 0 !live_hook_calls;
+  check int "captured request shaping runs once" 1 !probe_hook_calls;
+  check
+    (list string)
+    "isolated probe performs only native measurement"
+    [ "/v1/messages/count_tokens" ]
+    paths;
+  match bodies with
+  | [ body ] ->
+    check bool "captured shaping reaches exact measured request" true
+      (String_util.contains_substring body shaping_marker)
+  | _ -> fail "isolated probe did not produce one measured request"
+
+let test_capacity_readmission_stream_continuation_does_not_duplicate_goal () =
+  let persisted_marker = "persisted-original-goal" in
+  let duplicate_marker = "must-not-be-appended-again" in
+  let (), paths, bodies =
+    with_native_count_server
+      ~input_tokens:400
+    @@ fun ~sw ~net ~base_url ->
+    let checkpoint =
+      { (context_fit_checkpoint ()) with
+        messages =
+          [ Agent_sdk.Types.text_message
+              Agent_sdk.Types.User
+              persisted_marker
+          ]
+      }
+    in
+    match
+      Runtime_agent.probe_blocks_admission
+        ~sw
+        ~net
+        ~config:(context_fit_runtime_config base_url)
+        ~checkpoint
+        ~stream:true
+        ~continuation:true
+        [ Agent_sdk.Types.Text duplicate_marker ]
+    with
+    | Ok _ -> ()
+    | Error (Runtime_agent.Still_over_capacity error)
+    | Error (Runtime_agent.Readmission_failed error) ->
+      fail (Agent_sdk.Error.to_string error)
+  in
+  check
+    (list string)
+    "continuation performs measurement but no completion HTTP"
+    [ "/v1/messages/count_tokens" ]
+    paths;
+  let count_body =
+    match bodies with
+    | [ body ] -> body
+    | _ -> fail "continuation did not produce exactly one measurement body"
+  in
+  check bool "persisted continuation is measured" true
+    (String_util.contains_substring count_body persisted_marker);
+  check bool "original goal is not appended twice" false
+    (String_util.contains_substring count_body duplicate_marker)
+
+let test_capacity_readmission_sync_continuation_fails_closed () =
+  let (), paths, _bodies =
+    with_native_count_server
+      ~input_tokens:400
+    @@ fun ~sw ~net ~base_url ->
+    match
+      Runtime_agent.probe_blocks_admission
+        ~sw
+        ~net
+        ~config:(context_fit_runtime_config base_url)
+        ~checkpoint:(context_fit_checkpoint ())
+        ~stream:false
+        ~continuation:true
+        [ Agent_sdk.Types.Text "must not be appended" ]
+    with
+    | Error
+        (Runtime_agent.Readmission_failed
+           (Agent_sdk.Error.Config
+              (Agent_sdk.Error.InvalidConfig
+                 { field = "capacity_readmission.continuation"; _ }))) ->
+      ()
+    | Error (Runtime_agent.Still_over_capacity error)
+    | Error (Runtime_agent.Readmission_failed error) ->
+      fail (Agent_sdk.Error.to_string error)
+    | Ok _ -> fail "sync continuation silently changed the failed request"
+  in
+  check
+    (list string)
+    "unsupported sync continuation performs no measurement or completion HTTP"
+    []
+    paths
+
+let test_capacity_readmission_compatibility_path_admits_exact_body () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let checkpoint =
+    { (context_fit_checkpoint ()) with
+      agent_name = "body-cap-fixture"
+    ; model = "qwen"
+    ; system_prompt = Some "stale"
+    }
+  in
+  let config max_request_body_bytes =
+    let provider_cfg =
+      { (provider_cfg ()) with
+        Llm_provider.Provider_config.max_request_body_bytes =
+          max_request_body_bytes
+      }
+    in
+    Runtime_agent.default_config
+      ~name:"body-cap-fixture"
+      ~provider_cfg
+      ~system_prompt:"Exercise the compatibility request serializer."
+      ~tools:[]
+  in
+  let probe max_request_body_bytes text =
+    Runtime_agent.probe_blocks_admission
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~config:(config max_request_body_bytes)
+      ~checkpoint
+      ~stream:false
+      ~continuation:false
+      [ Agent_sdk.Types.Text text ]
+  in
+  (match probe (Some 128) (String.make 1_024 'x') with
+   | Error
+       (Runtime_agent.Still_over_capacity
+          (Agent_sdk.Error.Api
+             (Agent_sdk.Retry.InvalidRequest
+                { reason =
+                    Agent_sdk.Retry.Request_body_too_large
+                      { actual_bytes; limit_bytes = 128 }
+                ; _
+                }))) ->
+     check bool "exact compatibility body exceeds the cap" true
+       (actual_bytes > 128)
+   | Error (Runtime_agent.Still_over_capacity error)
+   | Error (Runtime_agent.Readmission_failed error) ->
+     fail (Agent_sdk.Error.to_string error)
+   | Ok _ ->
+     fail
+       "custom probe transport bypassed compatibility serialized-body admission");
+  match probe (Some 1_048_576) "short candidate" with
+  | Ok evidence ->
+    check
+      (option int)
+      "compatibility body limit is exact"
+      (Some 1_048_576)
+      evidence.Runtime_agent.serialized_body_limit_bytes;
+    check
+      (option int)
+      "compatibility route fabricates no token proof"
+      None
+      evidence.token_fit_limit_tokens
+  | Error (Runtime_agent.Still_over_capacity error)
+  | Error (Runtime_agent.Readmission_failed error) ->
+    fail (Agent_sdk.Error.to_string error)
 
 let projection_messages marker messages =
   let project_block = function
@@ -1870,6 +2150,30 @@ let () =
             "runtime resume enforces native context fit"
             `Quick
             test_runtime_agent_resume_enforces_native_context_fit
+        ; test_case
+            "capacity readmission stops before transport while still over"
+            `Quick
+            test_capacity_readmission_probe_stops_before_transport_when_still_over
+        ; test_case
+            "capacity readmission admits without completion dispatch"
+            `Quick
+            test_capacity_readmission_probe_admits_without_completion_dispatch
+        ; test_case
+            "capacity readmission uses only captured request shaping"
+            `Quick
+            test_capacity_readmission_probe_uses_only_captured_request_shaping
+        ; test_case
+            "capacity readmission continues without duplicate goal"
+            `Quick
+            test_capacity_readmission_stream_continuation_does_not_duplicate_goal
+        ; test_case
+            "capacity readmission fails closed for sync continuation"
+            `Quick
+            test_capacity_readmission_sync_continuation_fails_closed
+        ; test_case
+            "capacity readmission compatibility path admits exact body"
+            `Quick
+            test_capacity_readmission_compatibility_path_admits_exact_body
         ; test_case
             "fresh projection precedes measurement and dispatch"
             `Quick


### PR DESCRIPTION
Stack: based on #26181 (exact provider-input projection).

Scope:
- Resume a candidate Keeper checkpoint through the same OAS projection, provider serialization, native measurement, and context-fit admission path.
- Replace the generation transport with a local sentinel; provider-native count may run, but completion generation never dispatches.
- Preserve stream continuation semantics without appending the original goal again; unsupported synchronous continuation fails closed.
- Disable live Keeper effects during probing and accept only an explicit caller-captured request-shaping hook set.
- Avoid a second serialization on native-fit routes already admitted by OAS; compatibility routes perform their otherwise-bypassed body admission exactly once.

Focused proof:
- scripts/dune-local.sh build lib/masc.cmxa
- scripts/dune-local.sh build @test/runtest-test_runtime_provider_auth_headers (49/49)
- changed-file ocamlformat and git diff --check

Coverage includes over-capacity rejection, admitted no-generation proof, request-shaping isolation, post-tool continuation identity, sync fail-closed behavior, and compatibility-route byte admission.

Local limitation: repository-wide @fmt remains red on unrelated pre-existing Dune stanza formatting; all three changed OCaml files pass the same per-file ocamlformat check used by PR CI.