### PR TITLE
fix(ci): make OAS pin behavior gate durable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
             tla=true
           fi
 
-          if has_match '^(ci/check-oas-pin\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/oas-drift-check\.sh$|scripts/oas-api-surface\.json$|scripts/sync-oas-pin-docs\.sh$|scripts/sync-oas-pin-manifests\.sh$|dune-project$|.*\.opam$|masc\.opam\.locked$|docs/KEEPER-USER-MANUAL\.md$|docs/OAS-UTILIZATION-AUDIT\.md$)'; then
+          if has_match '^(ci/check-oas-pin\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/oas-drift-check\.sh$|scripts/oas-api-surface\.json$|scripts/sync-oas-pin-docs\.sh$|scripts/sync-oas-pin-manifests\.sh$|lib/keeper/keeper_event_bridge\.ml$|test/test_keeper_execution_join\.ml$|test/test_keeper_hooks_oas_introspection\.ml$|dune-project$|.*\.opam$|masc\.opam\.locked$|docs/KEEPER-USER-MANUAL\.md$|docs/OAS-UTILIZATION-AUDIT\.md$)'; then
             oas_pin=true
           fi
 

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -10,8 +10,9 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.230.0"
 # Previous pin: v0.229.0 (6bf1751a).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
-# The reachability guard in check-oas-pin.sh tracks main; oas-drift-check.sh
-# reports the public-surface delta at pin-bump time.
+# The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
+# main; oas-drift-check.sh also reports the public-surface delta at pin-bump
+# time.
 # Pinned to the v0.230.0 release commit.
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.230.0"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -17,7 +17,8 @@
 #
 # Source resolution (first hit wins):
 #   1. $AGENT_SDK_LOCAL_REPO if a git checkout at the pinned SHA
-#   2. git fetch into temp bare clone (reuses check-oas-pin.sh pattern)
+#   2. fetch the full tracking ref into a temp bare clone and prove the pin
+#      remains reachable from it
 
 set -euo pipefail
 
@@ -91,7 +92,7 @@ resolve_source_dir() {
   if ! GIT_DIR="${scratch}/bare" git init -q --bare; then
     echo "git init bare failed" >&2; return 1
   fi
-  if ! GIT_DIR="${scratch}/bare" git fetch -q --no-tags --depth=128 \
+  if ! GIT_DIR="${scratch}/bare" git fetch -q --no-tags \
          "${OAS_AGENT_SDK_URL}" \
          "+refs/heads/${OAS_AGENT_SDK_TRACK_REF}:refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
          2>/dev/null; then
@@ -100,21 +101,13 @@ resolve_source_dir() {
   fi
   if ! GIT_DIR="${scratch}/bare" git cat-file -e "${OAS_AGENT_SDK_SHA}^{commit}" \
         2>/dev/null; then
-    # A valid release pin can be older than the shallow tracking-ref window.
-    # Fetch the pinned immutable object directly instead of treating age as
-    # pin invalidity; check-oas-pin.sh separately proves it is reachable from
-    # the tracking ref.
-    if ! GIT_DIR="${scratch}/bare" git fetch -q --no-tags --depth=1 \
-           "${OAS_AGENT_SDK_URL}" \
-           "+${OAS_AGENT_SDK_SHA}:refs/masc/pinned-oas" \
-           2>/dev/null; then
-      echo "git fetch of pinned OAS SHA ${OAS_AGENT_SDK_SHA} from ${OAS_AGENT_SDK_URL} failed" >&2
-      return 1
-    fi
+    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
+    return 1
   fi
-  if ! GIT_DIR="${scratch}/bare" git cat-file -e "${OAS_AGENT_SDK_SHA}^{commit}" \
-        2>/dev/null; then
-    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is unavailable after direct fetch" >&2
+  if ! GIT_DIR="${scratch}/bare" git merge-base --is-ancestor \
+        "${OAS_AGENT_SDK_SHA}" \
+        "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" 2>/dev/null; then
+    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
     return 1
   fi
   mkdir -p "${scratch}/tree"

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -100,7 +100,21 @@ resolve_source_dir() {
   fi
   if ! GIT_DIR="${scratch}/bare" git cat-file -e "${OAS_AGENT_SDK_SHA}^{commit}" \
         2>/dev/null; then
-    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not present in fetched ${OAS_AGENT_SDK_TRACK_REF}" >&2
+    # A valid release pin can be older than the shallow tracking-ref window.
+    # Fetch the pinned immutable object directly instead of treating age as
+    # pin invalidity; check-oas-pin.sh separately proves it is reachable from
+    # the tracking ref.
+    if ! GIT_DIR="${scratch}/bare" git fetch -q --no-tags --depth=1 \
+           "${OAS_AGENT_SDK_URL}" \
+           "+${OAS_AGENT_SDK_SHA}:refs/masc/pinned-oas" \
+           2>/dev/null; then
+      echo "git fetch of pinned OAS SHA ${OAS_AGENT_SDK_SHA} from ${OAS_AGENT_SDK_URL} failed" >&2
+      return 1
+    fi
+  fi
+  if ! GIT_DIR="${scratch}/bare" git cat-file -e "${OAS_AGENT_SDK_SHA}^{commit}" \
+        2>/dev/null; then
+    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is unavailable after direct fetch" >&2
     return 1
   fi
   mkdir -p "${scratch}/tree"


### PR DESCRIPTION
## What changed

- Fetch the pinned OAS commit directly when it falls outside the shallow tracking-ref window.
- Trigger the OAS behavior suite for changes to its bridge implementation and either executed test target.

## Why

The merged #26172 gate could fail solely because a valid pin aged beyond 128 commits, and behavior changes could skip its only runtime suite.

## Validation

- `git diff --check`
- `bash -n scripts/oas-drift-check.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- depth-1 clone omits previous reachable pin, then direct SHA fetch restores it
- `env -u AGENT_SDK_LOCAL_REPO bash scripts/oas-drift-check.sh`