### PR TITLE
fix(keeper): publish selected runtime readmission probe

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -353,6 +353,7 @@ let run_named
     ?temperature
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
+    ?request_shaping_hooks
     ?raw_trace
     ?on_event
     ?on_yield
@@ -371,6 +372,7 @@ let run_named
     ?trace_link
     ?event_bus
     ?on_runtime_observation
+    ?on_capacity_readmission_probe
     ?runtime_manifest_context
     ?runtime_manifest_append
     ?deferred_runtime_lane
@@ -697,6 +699,7 @@ let run_named
             ; temperature
             ; accept
             ; hooks
+            ; request_shaping_hooks
             ; raw_trace
             ; transport_resolved
             ; checkpoint_sidecar
@@ -718,6 +721,7 @@ let run_named
             ; on_resume
             ; agent_ref
             ; on_runtime_observation
+            ; on_capacity_readmission_probe
             ; event_bus
             ; runtime_manifest_context
             ; runtime_manifest_append

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -94,6 +94,7 @@ val run_named :
   ?temperature:float ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?hooks:Agent_sdk.Hooks.hooks ->
+  ?request_shaping_hooks:Agent_sdk.Hooks.hooks ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -112,6 +113,8 @@ val run_named :
   ?trace_link:string * string ->
   ?event_bus:Agent_sdk.Event_bus.t ->
   ?on_runtime_observation:(Runtime_observation.runtime_observation -> unit) ->
+  ?on_capacity_readmission_probe:
+    (Runtime_agent.capacity_readmission_probe -> unit) ->
   ?runtime_manifest_context:Keeper_runtime_manifest.turn_context ->
   ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit) ->
   ?deferred_runtime_lane:deferred_runtime_lane ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -35,6 +35,7 @@ type try_provider_ctx =
   ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
+  ; request_shaping_hooks : Agent_sdk.Hooks.hooks option
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; (* Transport *)
@@ -61,6 +62,8 @@ type try_provider_ctx =
   ; agent_ref : Agent_sdk.Agent.t option ref option
   ; on_runtime_observation :
       (Runtime_observation.runtime_observation -> unit) option
+  ; on_capacity_readmission_probe :
+      (Runtime_agent.capacity_readmission_probe -> unit) option
   ; (* Event bus *)
     event_bus : Agent_sdk.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
@@ -255,6 +258,25 @@ let run_try_provider
   match config_result with
   | Error err -> Error err, None, None
   | Ok config ->
+    let goal_blocks =
+      match ctx.goal_blocks with
+      | Some blocks -> blocks
+      | None -> [ Agent_sdk.Types.Text ctx.goal ]
+    in
+    Option.iter
+      (fun publish ->
+         publish
+           (fun checkpoint ->
+              Runtime_agent.probe_blocks_admission
+                ?request_shaping_hooks:ctx.request_shaping_hooks
+                ~sw:ctx.sw
+                ~net:ctx.net
+                ~config
+                ~checkpoint
+                ~stream:(Option.is_some ctx.on_event)
+                ~continuation:(Atomic.get ctx.checkpoint_stage_observed)
+                goal_blocks))
+      ctx.on_capacity_readmission_probe;
     (* Explicit stream stall detection is handled by OAS's
        [stream_idle_timeout_s]; [None] deliberately leaves it disabled.
        No separate liveness FSM — provider stall is an OAS-level concern.

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -18,6 +18,7 @@ type try_provider_ctx =
   ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
+  ; request_shaping_hooks : Agent_sdk.Hooks.hooks option
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; transport_resolved : Masc_grpc_transport.t
@@ -40,6 +41,8 @@ type try_provider_ctx =
   ; agent_ref : Agent_sdk.Agent.t option ref option
   ; on_runtime_observation :
       (Runtime_observation.runtime_observation -> unit) option
+  ; on_capacity_readmission_probe :
+      (Runtime_agent.capacity_readmission_probe -> unit) option
   ; event_bus : Agent_sdk.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -556,6 +556,51 @@ let test_prior_checkpoint_appends_current_goal_once () =
       1
       current_goal_count)
 
+let test_selected_runtime_publishes_offline_readmission_probe () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    Masc_test_deps.init_eio_clock ~sw env;
+    let published_probe = ref None in
+    let result =
+      Driver.run_named
+        ~runtime_id:"primary.test_model"
+        ~keeper_name:"selected-runtime-readmission-probe"
+        ~base_path:(Filename.get_temp_dir_name ())
+        ~goal:"probe the selected runtime request"
+        ~body_timeout_s:0.5
+        ~on_capacity_readmission_probe:(fun probe ->
+          published_probe := Some probe)
+        ~sw
+        ~net:env#net
+        ()
+    in
+    (match result with
+     | Error _ -> ()
+     | Ok _ ->
+       Alcotest.fail
+         "invalid provider endpoint unexpectedly completed the selected runtime");
+    let probe =
+      match !published_probe with
+      | Some probe -> probe
+      | None ->
+        Alcotest.fail
+          "selected runtime did not publish its capacity re-admission probe"
+    in
+    match probe (checkpoint_with_session_id "readmission-probe-session") with
+    | Error Runtime_agent.Still_over_capacity error
+    | Error Runtime_agent.Readmission_failed error ->
+      Alcotest.failf
+        "offline re-admission probe failed: %s"
+        (Agent_sdk.Error.to_string error)
+    | Ok evidence ->
+      Alcotest.(check (option int))
+        "selected runtime body cap"
+        (Some 65536)
+        evidence.serialized_body_limit_bytes)
+
 let test_deferred_tail_rejects_transformed_uncapped_runtime () =
   with_runtime_config runtime_toml_with_lane (fun () ->
     Eio_main.run
@@ -1350,6 +1395,10 @@ let () =
             "prior checkpoint appends current goal once"
             `Quick
             test_prior_checkpoint_appends_current_goal_once;
+          Alcotest.test_case
+            "selected runtime publishes offline readmission probe"
+            `Quick
+            test_selected_runtime_publishes_offline_readmission_probe;
           Alcotest.test_case
             "deferred tail rejects transformed uncapped runtime"
             `Quick


### PR DESCRIPTION
## Stack

Base: #26182. This is the selected-runtime wiring layer above the typed offline admission probe.

## Change

- Publish one typed capacity re-admission closure from the exact final Runtime candidate config selected for an attempt.
- Preserve the exact goal blocks, sync or stream mode, and post-checkpoint continuation state in that closure.
- Accept a separate request-shaping hook set so later Keeper wiring can reproduce request parameters without replaying live registry, tracing, event, or checkpoint side effects.
- Keep the provider transport disabled: invoking the closure reaches only the local sentinel introduced by #26182.

## Verification

- test_keeper_turn_driver_failover: 31/31 pass, including an end-to-end selected Runtime probe that succeeds after the real test endpoint is unreachable and reports the exact configured 65536-byte cap.
- Changed-file ocamlformat and git diff --check pass.

Current head: e21ad469d8

This remains draft until #26182 and its bases merge, the stack is retargeted to main, full current-head CI is green, and review threads are clear.