### PR TITLE
fix(keeper): isolate readmission request shaping

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -339,6 +339,7 @@ let run_turn
       ?deferred_runtime_lane
       ?on_runtime_retry_deferred
       ?on_deferred_runtime_consumed
+      ?on_capacity_readmission_probe
       ?(is_retry = false)
       ?shared_context
       ?event_bus
@@ -611,6 +612,7 @@ let run_turn
     @@ fun () ->
     let tools = s.Keeper_run_tools.tools in
     let hooks = s.Keeper_run_tools.hooks in
+    let request_shaping_hooks = s.Keeper_run_tools.request_shaping_hooks in
     let model_input_projection =
       s.Keeper_run_tools.model_input_projection
     in
@@ -768,6 +770,7 @@ let run_turn
                       ~initial_messages
                       ~model_input_projection
                       ~hooks
+                      ~request_shaping_hooks
                       ~runtime_manifest_context
                       ~runtime_manifest_append:
                         (fun manifest ->
@@ -801,6 +804,7 @@ let run_turn
                       ~on_runtime_observation:
                         (fun observation ->
                            receipt_runtime_observation_ref := Some observation)
+                      ?on_capacity_readmission_probe
                       ())
          in
          (* Trace-store failure isolation: [raw_trace_for_dispatch]

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -183,6 +183,8 @@ val run_turn
   -> ?on_runtime_retry_deferred:
        (Keeper_turn_driver.deferred_runtime_lane -> unit)
   -> ?on_deferred_runtime_consumed:(unit -> unit)
+  -> ?on_capacity_readmission_probe:
+       (Runtime_agent.capacity_readmission_probe -> unit)
   -> ?is_retry:bool
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -59,6 +59,7 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; hooks : Agent_sdk.Hooks.hooks
+  ; request_shaping_hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; acc : hook_accumulator
   ; all_tool_names : string list

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -55,6 +55,7 @@ type agent_setup =
   ; cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; hooks : Agent_sdk.Hooks.hooks
+  ; request_shaping_hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; acc : hook_accumulator
   ; all_tool_names : string list

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -15,6 +15,7 @@ type agent_setup =
   ; cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; hooks : Agent_sdk.Hooks.hooks
+  ; request_shaping_hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; acc : hook_accumulator
   ; all_tool_names : string list
@@ -54,6 +55,25 @@ let relax_strict_tool_choice_for_keeper = function
   | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) ->
     Some Agent_sdk.Types.Auto
   | other -> other
+
+let request_shaping_hooks_of_captured_turn_params captured_turn_params =
+  { Agent_sdk.Hooks.empty with
+    before_turn_params =
+      Some
+        (fun event ->
+           match event, !captured_turn_params with
+           | Agent_sdk.Hooks.BeforeTurnParams _, Some adjusted_params ->
+             Agent_sdk.Hooks.AdjustParams adjusted_params
+           | Agent_sdk.Hooks.BeforeTurnParams _, None ->
+             Agent_sdk.Hooks.HookFailed
+               { stage = Agent_sdk.Hooks.Before_turn_params
+               ; detail =
+                   "capacity re-admission has no captured request-shaping \
+                    authority"
+               }
+           | _ -> Agent_sdk.Hooks.Continue)
+  }
+;;
 
 let relative_path_has_segment_prefix prefix raw =
   String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw
@@ -283,6 +303,7 @@ let assemble_hooks
              ()))
         ()
     in
+    let captured_turn_params = ref None in
     let before_turn_hook : Agent_sdk.Hooks.hooks =
       { Agent_sdk.Hooks.empty with
         before_turn_params =
@@ -543,15 +564,21 @@ let assemble_hooks
                        ())
                   manifest_keeper_turn_id;
                 Eio.Fiber.yield ();
-                Agent_sdk.Hooks.AdjustParams
+                let adjusted_params =
                   { current_params with
                     extra_system_context = ctx
                   ; tool_choice
                   }
+                in
+                captured_turn_params := Some adjusted_params;
+                Agent_sdk.Hooks.AdjustParams adjusted_params
               | _event -> Agent_sdk.Hooks.Continue)
       }
     in
     let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
+    let request_shaping_hooks =
+      request_shaping_hooks_of_captured_turn_params captured_turn_params
+    in
     let hydrate_model_input =
       let store = Tool_blob_store.create ~base_path:ctx.config.base_path in
       Keeper_artifact_hydrator.hydrate_recent
@@ -564,6 +591,7 @@ let assemble_hooks
       ; cleanup = keeper_tools_cleanup
       ; terminal_effect_state
       ; hooks
+      ; request_shaping_hooks
       ; model_input_projection
       ; acc
       ; all_tool_names

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -297,6 +297,54 @@ let test_partition_bare_relative_outside_repos_is_base_unresolved () =
 
 module Setup = Masc.Keeper_run_tools_setup
 
+let before_turn_params_event current_params =
+  Agent_sdk.Hooks.BeforeTurnParams
+    { turn = 1
+    ; messages = []
+    ; last_tool_results = []
+    ; current_params
+    ; reasoning = Agent_sdk.Hooks.empty_reasoning_summary
+    }
+;;
+
+let test_request_shaping_hooks_fail_closed_then_replay_capture () =
+  let captured_turn_params : Agent_sdk.Hooks.turn_params option ref = ref None in
+  let hooks =
+    Masc.Keeper_run_tools_hooks.request_shaping_hooks_of_captured_turn_params
+      captured_turn_params
+  in
+  let invoke current_params =
+    match hooks.Agent_sdk.Hooks.before_turn_params with
+    | Some hook -> hook (before_turn_params_event current_params)
+    | None -> fail "request-shaping hook is missing"
+  in
+  (match invoke Agent_sdk.Hooks.default_turn_params with
+   | Agent_sdk.Hooks.HookFailed
+       { stage = Agent_sdk.Hooks.Before_turn_params; _ } ->
+     ()
+   | _ -> fail "uncaptured request shaping did not fail closed");
+  let expected =
+    { Agent_sdk.Hooks.default_turn_params with
+      thinking_budget = Some 321
+    ; extra_system_context = Some "captured request-only context"
+    }
+  in
+  captured_turn_params := Some expected;
+  match invoke Agent_sdk.Hooks.default_turn_params with
+  | Agent_sdk.Hooks.AdjustParams actual ->
+    check
+      (option int)
+      "captured thinking budget"
+      expected.thinking_budget
+      actual.thinking_budget;
+    check
+      (option string)
+      "captured extra system context"
+      expected.extra_system_context
+      actual.extra_system_context
+  | _ -> fail "captured request shaping was not replayed"
+;;
+
 let encoded_bytes jsons =
   List.fold_left
     (fun acc json -> acc + String.length (Yojson.Safe.to_string json))
@@ -419,6 +467,12 @@ let () =
             test_files_list_uses_first_object_file_path
         ; test_case "missing path falls back to base_path" `Quick
             test_missing_path_falls_back_to_base_path
+        ] )
+    ; ( "request_shaping"
+      , [ test_case
+            "fails closed before capture and replays exact params"
+            `Quick
+            test_request_shaping_hooks_fail_closed_then_replay_capture
         ] )
     ; ( "gate_history_slice"
       , [ test_case "captures only request-local causal fields" `Quick


### PR DESCRIPTION
## Stack

Base: #26184. This is the request-only hook layer above selected-Runtime probe publication.

## Change

- Capture the exact AdjustParams produced by the live Keeper before-turn request hook after dynamic context, tool policy, and thinking settings are finalized.
- Expose a separate hook set containing only before_turn_params; registry transitions, tool receipts, tracing, event publication, checkpoint sinks, and other live effects are not replayed.
- Fail closed when no live request-shaping authority was captured.
- Pass the isolated hook and typed probe callback through Keeper_agent_run into the selected Runtime boundary.

## Verification

- New request_shaping regression passes: uncaptured use returns HookFailed and captured parameters replay exactly.
- Full test_keeper_run_tools_hooks result is 20/21; the only failure is the pre-existing Docker fixture bug in make_meta tracked by #26180. The changed request_shaping case passes independently 1/1.
- Changed-file ocamlformat and git diff --check pass.

Current head: 0cfc387764

This remains draft until #26184 and its bases merge, the stack is retargeted to main, full current-head CI is green, and review threads are clear.