### PR TITLE
fix(keeper): type readmission terminal causes

### DIFF
--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -29,6 +29,9 @@ type exact_execution_terminal_cause = Keeper_event_queue_persistence.exact_execu
   | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+  | Failed_request_readmission_unavailable
+  | Failed_request_still_over_capacity
+  | Failed_request_readmission_failed
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.ml
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.ml
@@ -5,9 +5,12 @@ struct
   type exact_execution_terminal_cause = Keeper_event_queue_persistence.exact_execution_terminal_cause =
     | Exact_execution_failed
     | Exact_execution_cancelled
-    | Domain_invalid_output
+  | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+    | Failed_request_readmission_unavailable
+    | Failed_request_still_over_capacity
+    | Failed_request_readmission_failed
     | Invalid_structural_evidence
     | Invalid_structural_source_after_dispatch
     | Commit_admission_unavailable

--- a/lib/keeper/keeper_registry_event_queue_exact_execution.mli
+++ b/lib/keeper/keeper_registry_event_queue_exact_execution.mli
@@ -5,9 +5,12 @@ module Make (Publish : sig
     Keeper_event_queue_persistence.exact_execution_terminal_cause =
     | Exact_execution_failed
     | Exact_execution_cancelled
-    | Domain_invalid_output
+  | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+    | Failed_request_readmission_unavailable
+    | Failed_request_still_over_capacity
+    | Failed_request_readmission_failed
     | Invalid_structural_evidence
     | Invalid_structural_source_after_dispatch
     | Commit_admission_unavailable

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -47,6 +47,9 @@ type exact_execution_terminal_cause = State.exact_execution_terminal_cause =
   | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+  | Failed_request_readmission_unavailable
+  | Failed_request_still_over_capacity
+  | Failed_request_readmission_failed
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -51,6 +51,9 @@ type exact_execution_terminal_cause = Keeper_event_queue_state.exact_execution_t
   | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+  | Failed_request_readmission_unavailable
+  | Failed_request_still_over_capacity
+  | Failed_request_readmission_failed
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -24,6 +24,9 @@ type exact_execution_terminal_cause =
   | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+  | Failed_request_readmission_unavailable
+  | Failed_request_still_over_capacity
+  | Failed_request_readmission_failed
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable
@@ -550,6 +553,12 @@ let exact_execution_terminal_cause_label = function
   | Domain_invalid_output -> "domain_invalid_output"
   | Compaction_produced_no_reduction -> "compaction_produced_no_reduction"
   | Compaction_increased_checkpoint -> "compaction_increased_checkpoint"
+  | Failed_request_readmission_unavailable ->
+    "failed_request_readmission_unavailable"
+  | Failed_request_still_over_capacity ->
+    "failed_request_still_over_capacity"
+  | Failed_request_readmission_failed ->
+    "failed_request_readmission_failed"
   | Invalid_structural_evidence -> "invalid_structural_evidence"
   | Invalid_structural_source_after_dispatch ->
     "invalid_structural_source_after_dispatch"
@@ -567,6 +576,12 @@ let exact_execution_terminal_cause_of_label = function
   | "domain_invalid_output" -> Ok Domain_invalid_output
   | "compaction_produced_no_reduction" -> Ok Compaction_produced_no_reduction
   | "compaction_increased_checkpoint" -> Ok Compaction_increased_checkpoint
+  | "failed_request_readmission_unavailable" ->
+    Ok Failed_request_readmission_unavailable
+  | "failed_request_still_over_capacity" ->
+    Ok Failed_request_still_over_capacity
+  | "failed_request_readmission_failed" ->
+    Ok Failed_request_readmission_failed
   | "invalid_structural_evidence" -> Ok Invalid_structural_evidence
   | "invalid_structural_source_after_dispatch" ->
     Ok Invalid_structural_source_after_dispatch

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -31,6 +31,9 @@ type exact_execution_terminal_cause =
   | Domain_invalid_output
   | Compaction_produced_no_reduction
   | Compaction_increased_checkpoint
+  | Failed_request_readmission_unavailable
+  | Failed_request_still_over_capacity
+  | Failed_request_readmission_failed
   | Invalid_structural_evidence
   | Invalid_structural_source_after_dispatch
   | Commit_admission_unavailable

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -122,6 +122,27 @@ let test_current_schema_round_trip_and_old_schema_rejection () =
   | Ok _ -> Alcotest.fail "old lease schema was accepted"
 ;;
 
+let test_readmission_terminal_causes_round_trip () =
+  let cases =
+    [ ( State.Failed_request_readmission_unavailable
+      , "failed_request_readmission_unavailable" )
+    ; State.Failed_request_still_over_capacity
+      , "failed_request_still_over_capacity"
+    ; State.Failed_request_readmission_failed
+      , "failed_request_readmission_failed"
+    ]
+  in
+  List.iter
+    (fun (cause, expected_label) ->
+       let label = State.exact_execution_terminal_cause_label cause in
+       Alcotest.(check string) "canonical terminal label" expected_label label;
+       match State.exact_execution_terminal_cause_of_label label with
+       | Ok decoded ->
+         Alcotest.(check bool) "terminal cause round trip" true (decoded = cause)
+       | Error detail -> Alcotest.fail detail)
+    cases
+;;
+
 let with_temp_dir prefix f =
   let path = Filename.temp_file prefix "" in
   Sys.remove path;
@@ -173,6 +194,10 @@ let () =
             `Quick
             test_changed_selected_snapshot_fails_closed
         ; Alcotest.test_case "fresh schema only" `Quick test_current_schema_round_trip_and_old_schema_rejection
+        ; Alcotest.test_case
+            "readmission terminal causes round trip"
+            `Quick
+            test_readmission_terminal_causes_round_trip
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case "durable peek ack restart" `Quick test_durable_peek_ack_restart ] )


### PR DESCRIPTION
## Stack

Base: #26185. This is the durable typed-cause layer before post-compaction re-admission gating.

## Change

- Add three closed exact-execution terminal causes: readmission unavailable, still over capacity, and readmission failed.
- Round-trip the canonical labels through the event-queue state codec.
- Thread the variants through persistence and registry facade aliases without changing queue ownership or settlement semantics.

## Verification

- New terminal-cause round-trip regression passes 1/1.
- Full focused event-queue suite is 7/8; the only failure is the pre-existing stale current-schema field assertion now tracked in #26186. It expects no transition_outbox although the current encoder emits it.
- Changed-file ocamlformat and git diff --check pass.

Current head: fdf93c4779

This remains draft until #26185 and its bases merge, the stack is retargeted to main, ACK-only event-queue work is reconciled, full current-head CI is green, and review threads are clear.