### PR TITLE
fix(keeper): validate readmission evidence by capacity axis

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -609,6 +609,76 @@ let no_compaction_of_uncommitted_prepared
     Uncommitted_failed error
 ;;
 
+let readmission_terminal_cause_of_failure = function
+  | Runtime_agent.Still_over_capacity _ ->
+    Keeper_event_queue_state.Failed_request_still_over_capacity
+  | Runtime_agent.Readmission_failed _ ->
+    Keeper_event_queue_state.Failed_request_readmission_failed
+;;
+
+let readmission_evidence_failure detail =
+  Runtime_agent.Readmission_failed (Agent_sdk.Error.Internal detail)
+;;
+
+let readmission_evidence_for_trigger
+      trigger
+      (evidence : Runtime_agent.capacity_readmission_evidence)
+  =
+  match trigger with
+  | Compaction_trigger.Manual -> Ok ()
+  | Compaction_trigger.Request_body_over_capacity { limit_bytes; _ } ->
+    (match evidence.serialized_body_limit_bytes with
+     | Some admitted_limit when admitted_limit <= limit_bytes -> Ok ()
+     | Some admitted_limit ->
+       Error
+         (readmission_evidence_failure
+            (Printf.sprintf
+               "runtime request-body admission limit %d is looser than the \
+                failed request limit %d"
+               admitted_limit
+               limit_bytes))
+     | None ->
+       Error
+         (readmission_evidence_failure
+            "runtime route has no serialized request-body admission limit"))
+  | Compaction_trigger.Request_body_refused_by_provider { status } ->
+    Error
+      (readmission_evidence_failure
+         (Printf.sprintf
+            "provider size refusal status %d exposed no byte boundary; local \
+             admission cannot prove provider re-admission"
+            status))
+  | Compaction_trigger.Provider_overflow { limit_tokens = None } ->
+    Error
+      (readmission_evidence_failure
+         "provider context overflow exposed no token boundary; local \
+          admission cannot prove provider re-admission")
+  | Compaction_trigger.Provider_overflow { limit_tokens = Some provider_limit } ->
+    (match evidence.token_fit_limit_tokens with
+     | Some admitted_limit when admitted_limit <= provider_limit -> Ok ()
+     | Some admitted_limit ->
+       Error
+         (readmission_evidence_failure
+            (Printf.sprintf
+               "runtime token admission limit %d is looser than provider \
+                overflow limit %d"
+               admitted_limit
+               provider_limit))
+     | None ->
+       Error
+         (readmission_evidence_failure
+            "runtime route has no supported exact token-fit admission for the \
+             provider overflow boundary"))
+  | Compaction_trigger.Serving_input_capacity _ ->
+    if evidence.serving_constraint_admitted
+    then Ok ()
+    else
+      Error
+        (readmission_evidence_failure
+           "runtime route did not re-admit the candidate against a current \
+            serving constraint")
+;;
+
 let prepare_compaction_admitted
       ~compact_for_request
       ~base_dir
@@ -1021,6 +1091,11 @@ let commit_prepared_compaction prepared =
 ;;
 
 module For_testing = struct
+  let readmission_terminal_cause_of_failure =
+    readmission_terminal_cause_of_failure
+
+  let readmission_evidence_for_trigger = readmission_evidence_for_trigger
+
   let commit_prepared_compaction_with_history
         ?after_checkpoint_installed
         ?complete_post_success_commit

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -148,6 +148,15 @@ val commit_prepared_compaction :
   prepared_compaction -> prepared_commit_outcome
 
 module For_testing : sig
+  val readmission_terminal_cause_of_failure :
+    Runtime_agent.capacity_readmission_failure ->
+    Keeper_event_queue_state.exact_execution_terminal_cause
+
+  val readmission_evidence_for_trigger :
+    Compaction_trigger.t ->
+    Runtime_agent.capacity_readmission_evidence ->
+    (unit, Runtime_agent.capacity_readmission_failure) result
+
   val commit_prepared_compaction_with_history :
     ?after_checkpoint_installed:(unit -> unit) ->
     ?complete_post_success_commit:

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1314,6 +1314,85 @@ let test_suspended_streak_refuses_reactive_prepare () =
     ]
 ;;
 
+let test_readmission_evidence_matches_trigger_axis () =
+  let evidence : Runtime_agent.capacity_readmission_evidence =
+    { serialized_body_limit_bytes = Some 1_048_576
+    ; token_fit_limit_tokens = Some 4_096
+    ; serving_constraint_admitted = false
+    }
+  in
+  let expect_ok label trigger evidence =
+    match
+      Post_turn.For_testing.readmission_evidence_for_trigger trigger evidence
+    with
+    | Ok () -> ()
+    | Error _ -> failf "%s: expected admitted evidence" label
+  in
+  let expect_failed label trigger evidence =
+    match
+      Post_turn.For_testing.readmission_evidence_for_trigger trigger evidence
+    with
+    | Error (Runtime_agent.Readmission_failed _) -> ()
+    | Error (Runtime_agent.Still_over_capacity _) ->
+      failf "%s: evidence mismatch became an observed capacity refusal" label
+    | Ok () -> failf "%s: unproven evidence was admitted" label
+  in
+  expect_ok
+    "body cap matches failed boundary"
+    (Compaction_trigger.Request_body_over_capacity
+       { actual_bytes = 2_000_000; limit_bytes = 1_048_576 })
+    evidence;
+  expect_failed
+    "body cap is looser than failed boundary"
+    (Compaction_trigger.Request_body_over_capacity
+       { actual_bytes = 1_048_577; limit_bytes = 1_048_576 })
+    { evidence with serialized_body_limit_bytes = Some 2_000_000 };
+  expect_failed
+    "body cap is absent"
+    (Compaction_trigger.Request_body_over_capacity
+       { actual_bytes = 1_048_577; limit_bytes = 1_048_576 })
+    { evidence with serialized_body_limit_bytes = None };
+  expect_ok
+    "token admission matches provider boundary"
+    (Compaction_trigger.Provider_overflow { limit_tokens = Some 4_096 })
+    evidence;
+  expect_failed
+    "token admission is looser than provider boundary"
+    (Compaction_trigger.Provider_overflow { limit_tokens = Some 4_095 })
+    evidence;
+  expect_failed
+    "provider boundary is unknown"
+    (Compaction_trigger.Provider_overflow { limit_tokens = None })
+    evidence;
+  expect_failed
+    "provider body refusal exposes no local proof"
+    (Compaction_trigger.Request_body_refused_by_provider { status = 413 })
+    evidence;
+  let serving_trigger =
+    Compaction_trigger.Serving_input_capacity
+      (Compaction_trigger.Input_rejected
+         { input_tokens = 4_097
+         ; accepted_through = 4_095
+         ; rejected_from = 4_096
+         })
+  in
+  expect_failed "serving constraint not admitted" serving_trigger evidence;
+  expect_ok
+    "serving constraint admitted"
+    serving_trigger
+    { evidence with serving_constraint_admitted = true };
+  expect_ok "manual trigger needs no failed-request proof" Compaction_trigger.Manual evidence;
+  let terminal =
+    Post_turn.For_testing.readmission_terminal_cause_of_failure
+      (Runtime_agent.Still_over_capacity
+         (Agent_sdk.Error.Internal "typed capacity refusal"))
+  in
+  check bool
+    "typed capacity refusal keeps its durable cause"
+    true
+    (terminal = Keeper_event_queue_state.Failed_request_still_over_capacity)
+;;
+
 let () =
   run "post-turn durability" [
     "durable compaction", [
@@ -1346,6 +1425,8 @@ let () =
         `Quick test_post_dispatch_non_reducing_output_is_quarantined;
       test_case "suspended streak refuses reactive prepare"
         `Quick test_suspended_streak_refuses_reactive_prepare;
+      test_case "readmission evidence matches trigger axis"
+        `Quick test_readmission_evidence_matches_trigger_axis;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
     ];


### PR DESCRIPTION
## Stack

Base: #26187. This is the pure evidence-policy layer before post-compaction commit gating.

## Change

- Validate serialized-byte, provider-token, and serving-constraint evidence on their own typed axes.
- Accept byte evidence only when the selected Runtime probe cap is no looser than the failed request cap; do not manufacture a second serialized body measurement.
- Accept provider overflow only with native token-fit admission no looser than the provider boundary.
- Reject provider 413-style refusals and unknown provider token limits because local admission cannot prove the remote boundary.
- Map observed probe capacity refusal separately from evidence/probe failure.

## Verification

- New readmission evidence matrix passes 1/1 across byte, token, serving, unknown-boundary, provider-refusal, and manual cases.
- Focused test executable builds through the repo-local wrapper. The known full-suite case-7 hang remains tracked by #26167 and was not invoked.
- Changed-file ocamlformat and git diff --check pass.

Current head: 0e86cb903d

This remains draft until #26187 and its bases merge, the stack is retargeted to main, full current-head CI is green, and review threads are clear.