### PR TITLE
fix(keeper): lower recall fallback for 256 KiB request bodies

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -83,13 +83,23 @@ let keeper_memory_os_recall_max_episodes () : int =
    Facts are never dropped by this budget; they render an order of magnitude
    smaller than episodes.
 
-   The 64 KiB default is roughly a tenth of a 200k-token context window once
-   rendered, and takes the measured keeper from 222,499 B to under 65,536 B.
-   0 disables enforcement (unbounded), matching the previous behaviour. *)
+   The default is sized against the provider **request body byte limit**
+   (e.g. OAS/Ollama Cloud 262144 B), not a token context window. A measured
+   keeper (analyst) carried ~116 KiB of fixed per-turn overhead (tool
+   definitions ~66 KiB + recall ~40 KiB + base prompt ~8.5 KiB) — 44% of a
+   256 KiB body limit — leaving ~142 KiB for history, just under the
+   compaction floor (~148 KiB), so it looped on request_body_too_large(413)
+   indefinitely (2026-07-29: 796 events in 40 min; compaction hit 227
+   consecutive failures). The prior 64 KiB default ("a tenth of a 200k-token
+   window") was token-derived and oversized for the byte body limit; 16 KiB
+   trims recall from ~40 KiB and reclaims headroom for the history floor.
+   Deriving the budget from provider max-request-body-bytes (rather than a
+   fixed constant) is the durable follow-up. 0 disables enforcement
+   (unbounded). *)
 let keeper_memory_os_recall_max_bytes_rp =
   _rp_int ~key:"keeper.memory_os.recall.max_bytes"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_BYTES"
-                          ~default:65_536 ~min_v:0 ~max_v:50_000_000)
+                          ~default:16_384 ~min_v:0 ~max_v:50_000_000)
     ~min_v:0 ~max_v:50_000_000
     ~description:"Rendered recall block byte budget; oldest episodes are dropped to fit (0 = unbounded)" ()
 let keeper_memory_os_recall_max_bytes () : int =

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -83,19 +83,13 @@ let keeper_memory_os_recall_max_episodes () : int =
    Facts are never dropped by this budget; they render an order of magnitude
    smaller than episodes.
 
-   The default is sized against the provider **request body byte limit**
-   (e.g. OAS/Ollama Cloud 262144 B), not a token context window. A measured
-   keeper (analyst) carried ~116 KiB of fixed per-turn overhead (tool
-   definitions ~66 KiB + recall ~40 KiB + base prompt ~8.5 KiB) — 44% of a
-   256 KiB body limit — leaving ~142 KiB for history, just under the
-   compaction floor (~148 KiB), so it looped on request_body_too_large(413)
-   indefinitely (2026-07-29: 796 events in 40 min; compaction hit 227
-   consecutive failures). The prior 64 KiB default ("a tenth of a 200k-token
-   window") was token-derived and oversized for the byte body limit; 16 KiB
-   trims recall from ~40 KiB and reclaims headroom for the history floor.
-   Deriving the budget from provider max-request-body-bytes (rather than a
-   fixed constant) is the durable follow-up. 0 disables enforcement
-   (unbounded). *)
+   The 16 KiB default is an incident-derived fallback for a 256 KiB provider
+   request-body limit, not a value derived dynamically from the selected
+   runtime. It replaces the previous token-window-derived 64 KiB fallback and
+   leaves more room for history plus fixed request overhead. Operators can
+   still tune the runtime parameter or environment override. The provider
+   request-body cap remains the final authority; deriving this recall budget
+   from that cap is a separate contract. 0 disables enforcement (unbounded). *)
 let keeper_memory_os_recall_max_bytes_rp =
   _rp_int ~key:"keeper.memory_os.recall.max_bytes"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_BYTES"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -109,7 +109,7 @@ val normalize_prompt_text : max_bytes:int -> string -> string
 val keeper_memory_os_recall_max_facts : unit -> int
 val keeper_memory_os_recall_max_episodes : unit -> int
 val keeper_memory_os_recall_max_bytes : unit -> int
-(** Observability-only threshold (see .ml); not itself an enforced drop. *)
+(** Enforced rendered-byte budget. A zero value disables enforcement. *)
 
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -80,6 +80,30 @@ let () =
     Alcotest.(check int) "unchanged after rejection" 5 v
   in
 
+  let test_keeper_memory_os_recall_max_bytes_default () =
+    let env_key = "MASC_KEEPER_MEMORY_OS_RECALL_MAX_BYTES" in
+    let previous = Sys.getenv_opt env_key in
+    Fun.protect
+      ~finally:(fun () ->
+        Unix.putenv env_key (Option.value previous ~default:"");
+        ignore
+          (Runtime_params.clear_by_key
+             "keeper.memory_os.recall.max_bytes"))
+      (fun () ->
+        Unix.putenv env_key "";
+        ignore (Keeper_config.keeper_memory_os_recall_max_bytes ());
+        (match
+           Runtime_params.clear_by_key
+             "keeper.memory_os.recall.max_bytes"
+         with
+         | Ok () -> ()
+         | Error msg -> Alcotest.fail msg);
+        Alcotest.(check int)
+          "request-body-sized fallback"
+          16_384
+          (Keeper_config.keeper_memory_os_recall_max_bytes ()))
+  in
+
   let test_set_by_key () =
     let _p =
       Runtime_params.register
@@ -508,6 +532,10 @@ let () =
           Alcotest.test_case "register_and_get" `Quick test_register_and_get;
           Alcotest.test_case "set_and_get" `Quick test_set_and_get;
           Alcotest.test_case "validation_rejects" `Quick test_validation_rejects;
+          Alcotest.test_case
+            "keeper recall byte budget default"
+            `Quick
+            test_keeper_memory_os_recall_max_bytes_default;
           Alcotest.test_case "set_by_key" `Quick test_set_by_key;
           Alcotest.test_case "set_by_key_unknown" `Quick test_set_by_key_unknown;
           Alcotest.test_case "clear" `Quick test_clear;

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -99,7 +99,7 @@ let () =
          | Ok () -> ()
          | Error msg -> Alcotest.fail msg);
         Alcotest.(check int)
-          "request-body-sized fallback"
+          "incident fallback default"
           16_384
           (Keeper_config.keeper_memory_os_recall_max_bytes ()))
   in


### PR DESCRIPTION
## 요약

`keeper.memory_os.recall.max_bytes` fallback을 64 KiB에서 16 KiB로 낮춰 256 KiB provider request-body 한도 아래에 더 많은 여유를 둬요.

## 변경

- global fallback: 65,536 → 16,384 bytes
- 기존 runtime parameter / environment override 우선순위 유지
- public interface를 실제 계약인 rendered-byte budget으로 교정
- `test_runtime_params`로 기본값 고정

## 범위

이 값은 관측된 256 KiB 사고를 완화하는 보수적 fallback이지, 선택된 provider cap에서 동적으로 계산한 값이 아니에요. 모든 serialized request가 맞는다는 보장도 하지 않아요. typed per-turn cap 계약은 #26194에서 추적해요. Keeper vision assertion 치료는 병합된 #26203에만 있고 이 PR diff에는 없어요.

## 검증

- current head: `b973fe996a303af4b05e0fe0f71265e9eddb362b`
- current main: `51415e0c755be5d1fb0501f2dd28dc5d9ae28e95`
- changed OCaml parse + `ocamlformat --check`: 통과
- `git diff --check`: 통과
- 로컬 Dune은 실행하지 않았고 exact-head PR CI가 build/test 권위예요.

## 배포 후 확인

override가 없다면 새 fallback 반영에 server restart가 필요해요. analyst의 `request_body_too_large(413)` 중단, compaction suspension 해제, recall `bytes_over_budget_total`을 runtime에서 확인해야 해요. PR/CI는 배포 완료를 주장하지 않아요.
