### PR TITLE
test(keeper): use current meta schema in vision fixture

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -54,7 +54,6 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
       ; "agent_name", `String (name ^ "-agent")
       ; "trace_id", `String (name ^ "-trace")
       ; "allowed_paths", `List [ `String "*" ]
-      ; "sandbox_profile", `String "none"
       ]
   in
 match Masc_test_deps.meta_of_json_fixture json with


### PR DESCRIPTION
## 문제

#26175 병합 뒤 main CI에서 `test_keeper_vision_tool`이 폐기된 `sandbox_profile` 필드를 current Keeper meta fixture에 넣어 schema validation이 실패했어용.

## 변경

- vision tool 테스트 fixture에서 폐기된 `sandbox_profile` 필드만 제거했어용.
- `Masc_test_deps.meta_of_json_fixture`가 제공하는 current-schema 기본값을 그대로 사용했어용.

## 검증

- `ocamlc -stop-after parsing test/test_keeper_vision_tool.ml`
- `ocamlformat --check test/test_keeper_vision_tool.ml`
- `git diff --check`
- 로컬 Dune은 실행하지 않았고, 전체 회귀 검증은 PR CI에서 확인할게용.