### PR TITLE
fix(keeper): stop inert turns from growing replay

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -894,8 +894,6 @@ let run_turn
                           ~result ~checkpoint_persistence_error
                           ~post_turn_t0 ~runtime_id_string
                           ~history_messages
-                          ~pre_turn_working_context:
-                            ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
                           ~prompt_metrics ~ctx_composition ~usage
                           ~receipt_response_text_present_ref ~history_assistant_source
                           ~raw_response_text:response_text

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -22,6 +22,17 @@ let replay_response_text_for_capture ~suppress_visible_response ~response_text =
   else Some response_text
 ;;
 
+let replay_response_text_for_persistence
+      ~(turn_effect_record : Keeper_run_prompt.turn_effect_record)
+      ~suppress_visible_response
+      ~response_text
+  =
+  match turn_effect_record with
+  | Keeper_run_prompt.Inert_autonomous_turn -> None
+  | Keeper_run_prompt.Meaningful_turn ->
+    replay_response_text_for_capture ~suppress_visible_response ~response_text
+;;
+
 type wire_capture_response_suppression_reason =
   | Control_checkpoint
 
@@ -65,9 +76,10 @@ let drop_leading_wake_marker ~user_turn_record current_suffix =
        ; _
        }
        :: rest) )
-    when String.equal text Keeper_unified_prompt.autonomous_wake_marker -> rest
+    when String.equal text Keeper_unified_prompt.autonomous_wake_marker ->
+    rest, true
   | (Keeper_run_prompt.Skip_uninformative_wake | Keeper_run_prompt.Record_user_turn), _
-    -> current_suffix
+    -> current_suffix, false
 ;;
 
 let is_trailing_blank_assistant (message : Agent_sdk.Types.message) =
@@ -83,11 +95,11 @@ let is_trailing_blank_assistant (message : Agent_sdk.Types.message) =
 ;;
 
 let drop_trailing_blank_assistants messages =
-  let rec drop = function
-    | message :: rest when is_trailing_blank_assistant message -> drop rest
-    | reversed -> List.rev reversed
+  let rec drop dropped = function
+    | message :: rest when is_trailing_blank_assistant message -> drop true rest
+    | reversed -> List.rev reversed, dropped
   in
-  drop (List.rev messages)
+  drop false (List.rev messages)
 ;;
 
 let canonical_success_replay_checkpoint
@@ -95,6 +107,7 @@ let canonical_success_replay_checkpoint
       ~(session_id : string)
       ~(response_text : string)
       ~(user_turn_record : Keeper_run_prompt.user_turn_record)
+      ~(turn_effect_record : Keeper_run_prompt.turn_effect_record)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match
@@ -103,57 +116,74 @@ let canonical_success_replay_checkpoint
       checkpoint.Agent_sdk.Checkpoint.messages
   with
   | Ok original_current_suffix ->
-    let current_suffix =
-      drop_leading_wake_marker ~user_turn_record original_current_suffix
-    in
-    (* A blank visible response is not authority to erase typed replay. The
-       suffix may contain an actual user input, ToolUse/ToolResult pair,
-       thinking, or media whose effect has already happened. Remove only an
-       inert trailing Assistant shell; the typed skipped-wake rule above owns
-       the autonomous marker independently. *)
-    let current_suffix =
-      if String.trim response_text = ""
-      then drop_trailing_blank_assistants current_suffix
-      else current_suffix
-    in
-    let replay_suffix_pruned =
-      if current_suffix <> original_current_suffix
-      then Some Canonical_success_replay
-      else None
-    in
-    let checkpoint =
-      if String.trim response_text = ""
-      then
-        { checkpoint with
-          Agent_sdk.Checkpoint.session_id
-        ; messages = history_messages @ current_suffix
-        ; working_context = None
-        }
-      else
-        let base_messages = history_messages @ current_suffix in
-        let messages =
-          if
-            List.exists
-              (fun (msg : Agent_sdk.Types.message) ->
-                 msg.role = Agent_sdk.Types.Assistant)
-              current_suffix
-          then base_messages
-          else
-            base_messages
-            @
-            [ Agent_sdk.Types.make_message
-                ~role:Agent_sdk.Types.Assistant
-                [ Agent_sdk.Types.Text response_text ]
-            ]
-        in
-        Keeper_context_core.patch_checkpoint_last_assistant
-          { checkpoint with Agent_sdk.Checkpoint.messages }
-          ~session_id
-          ~response_text
-    in
-    Ok
-      ( checkpoint
-      , replay_suffix_pruned )
+    (match turn_effect_record with
+     | Keeper_run_prompt.Inert_autonomous_turn ->
+       (* The provider may have produced thinking and idle prose, but this turn
+          had no durable input, Keeper tool effect, or external delivery. Keep
+          the canonical pre-turn history byte-for-byte and discard the whole
+          provider-only suffix. The prefix split above remains the safety gate:
+          an unrelated checkpoint can never be rewritten as this history. *)
+       Ok
+         ( { checkpoint with
+             Agent_sdk.Checkpoint.session_id
+           ; messages = history_messages
+           ; working_context = None
+           }
+         , (match original_current_suffix with
+            | [] -> None
+            | _ :: _ -> Some Canonical_success_replay) )
+     | Keeper_run_prompt.Meaningful_turn ->
+       let current_suffix, wake_marker_dropped =
+         drop_leading_wake_marker ~user_turn_record original_current_suffix
+       in
+       (* A blank visible response is not authority to erase typed replay. The
+          suffix may contain an actual user input, ToolUse/ToolResult pair,
+          thinking, or media whose effect has already happened. Remove only an
+          inert trailing Assistant shell; the typed skipped-wake rule above owns
+          the autonomous marker independently. *)
+       let current_suffix, blank_assistant_dropped =
+         if String.trim response_text = ""
+         then drop_trailing_blank_assistants current_suffix
+         else current_suffix, false
+       in
+       let replay_suffix_pruned =
+         if wake_marker_dropped || blank_assistant_dropped
+         then Some Canonical_success_replay
+         else None
+       in
+       let checkpoint =
+         if String.trim response_text = ""
+         then
+           { checkpoint with
+             Agent_sdk.Checkpoint.session_id
+           ; messages = history_messages @ current_suffix
+           ; working_context = None
+           }
+         else
+           let base_messages = history_messages @ current_suffix in
+           let messages =
+             if
+               List.exists
+                 (fun (msg : Agent_sdk.Types.message) ->
+                    msg.role = Agent_sdk.Types.Assistant)
+                 current_suffix
+             then base_messages
+             else
+               base_messages
+               @
+               [ Agent_sdk.Types.make_message
+                   ~role:Agent_sdk.Types.Assistant
+                   [ Agent_sdk.Types.Text response_text ]
+               ]
+           in
+           Keeper_context_core.patch_checkpoint_last_assistant
+             { checkpoint with Agent_sdk.Checkpoint.messages }
+             ~session_id
+             ~response_text
+       in
+       Ok
+         ( checkpoint
+         , replay_suffix_pruned ))
   | Error _ ->
     Error
       "refusing to save checkpoint: canonical replay persistence requires \
@@ -183,12 +213,11 @@ let observation_replay_checkpoint
 
 let checkpoint_for_replay_persistence
       ~(history_messages : Agent_sdk.Types.message list)
-      ~pre_turn_working_context:_
-      ~completion_contract_result:_
       ~(session_id : string)
       ~(response_text : string)
       ?(stop_reason = Runtime_agent.Completed)
       ?(user_turn_record = Keeper_run_prompt.Record_user_turn)
+      ?(turn_effect_record = Keeper_run_prompt.Meaningful_turn)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match stop_reason with
@@ -228,6 +257,7 @@ let checkpoint_for_replay_persistence
       ~session_id
       ~response_text
       ~user_turn_record
+      ~turn_effect_record
       checkpoint
 ;;
 
@@ -237,6 +267,7 @@ module For_testing = struct
 
   let checkpoint_for_replay_persistence = checkpoint_for_replay_persistence
   let replay_response_text_for_capture = replay_response_text_for_capture
+  let replay_response_text_for_persistence = replay_response_text_for_persistence
 
   let wire_capture_response_suppression_reasons =
     wire_capture_response_suppression_reasons
@@ -265,7 +296,6 @@ let finalize
     ~post_turn_t0
     ~runtime_id_string
     ~history_messages
-    ~pre_turn_working_context
     ~prompt_metrics
     ~ctx_composition
     ~usage
@@ -273,9 +303,15 @@ let finalize
     ~history_assistant_source
     ~raw_response_text
     ~capture_replay_response
-    ?continuation_delivery_channel:_
+    ?continuation_delivery_channel
     () =
   let completion_contract_result = acc.receipt_completion_contract_result in
+  let turn_effect_record =
+    Keeper_run_prompt.turn_effect_record_of_turn
+      ~user_turn_record
+      ~tool_calls_made:(actual_keeper_tool_names <> [])
+      ~external_delivery_routed:(Option.is_some continuation_delivery_channel)
+  in
   let control_checkpoint =
     Keeper_agent_run_response_text.stop_reason_suppresses_visible_response
       result.stop_reason
@@ -292,7 +328,6 @@ let finalize
     suppression_reasons;
   let { Keeper_agent_run_response_text.response_text } =
     Keeper_agent_run_response_text.finalize
-      ~completion_contract_result
       ~stop_reason:result.stop_reason
       ~raw_response_text
       ~suppress_response_text:suppress_visible_response
@@ -300,7 +335,10 @@ let finalize
   in
   receipt_response_text_present_ref := raw_response_text_present;
   let replay_response_text =
-    replay_response_text_for_capture ~suppress_visible_response ~response_text
+    replay_response_text_for_persistence
+      ~turn_effect_record
+      ~suppress_visible_response
+      ~response_text
   in
   let assistant_msg =
     Option.map
@@ -324,13 +362,12 @@ let finalize
       let checkpoint_for_save_result =
         checkpoint_for_replay_persistence
           ~history_messages
-          ~pre_turn_working_context
-          ~completion_contract_result
           ~session_id:
             (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~response_text
           ~stop_reason:result.stop_reason
           ~user_turn_record
+          ~turn_effect_record
           checkpoint
       in
       (match checkpoint_for_save_result with
@@ -429,10 +466,7 @@ let finalize
       ~oas_turn_count:result.turns
       ~actual_tools:actual_keeper_tool_names
       ~librarian_messages
-      ~memory_extraction_record:
-        (Keeper_run_prompt.memory_extraction_record_of_turn
-           ~user_turn_record
-           ~tool_calls_made:(actual_keeper_tool_names <> []))
+      ~turn_effect_record
       ~post_turn_t0
       ~inference_telemetry:result.response.telemetry
       ();

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -11,7 +11,7 @@ let run
   ~oas_turn_count
   ~actual_tools
   ~librarian_messages
-  ~(memory_extraction_record : Keeper_run_prompt.memory_extraction_record)
+  ~(turn_effect_record : Keeper_run_prompt.turn_effect_record)
   ~post_turn_t0
   ~inference_telemetry
   ?deliberation_execution
@@ -90,8 +90,8 @@ let run
       ~lane:Keeper_memory_lane.Deterministic
       det_write_series
   in
-  (match memory_extraction_record with
-   | Keeper_run_prompt.Extract_turn ->
+  (match turn_effect_record with
+   | Keeper_run_prompt.Meaningful_turn ->
      let (_ : Keeper_memory_lane.outcome) =
        Keeper_memory_lane.submit
          ~base_path:config.Workspace.base_path
@@ -100,7 +100,7 @@ let run
          librarian_series
      in
      ()
-   | Keeper_run_prompt.Skip_inert_turn ->
+   | Keeper_run_prompt.Inert_autonomous_turn ->
      (* Not submitted at all, so the cadence counter does not advance either:
         an idle stretch leaves the extraction budget untouched instead of
         spending it on prose about the idleness. *)

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -16,7 +16,7 @@ val run :
   oas_turn_count:int ->
   actual_tools:string list ->
   librarian_messages:Agent_sdk.Types.message list ->
-  memory_extraction_record:Keeper_run_prompt.memory_extraction_record ->
+  turn_effect_record:Keeper_run_prompt.turn_effect_record ->
   post_turn_t0:float ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
@@ -35,9 +35,10 @@ val run :
     delegation request artifacts on this post-turn memory lane rather than on
     the decision-record append path.
 
-    [memory_extraction_record] gates only the librarian sub-stage. On
-    [Skip_inert_turn] the librarian unit is never submitted, so its cadence
-    counter does not advance and an idle stretch spends no extraction budget.
+    [turn_effect_record] gates only the librarian sub-stage. On
+    [Inert_autonomous_turn] the librarian unit is never submitted, so its
+    cadence counter does not advance and an idle stretch spends no extraction
+    budget.
     The deterministic write series runs either way: a model-owned
     [keeper_memory_write] on an otherwise inert turn is an explicit decision to
     remember, not an extraction from prose. *)

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -19,9 +19,7 @@ let stop_reason_suppresses_visible_response = function
     false
 ;;
 
-let finalize ~completion_contract_result:_ ~stop_reason ~raw_response_text
-      ?suppress_response_text
-      ()
+let finalize ~stop_reason ~raw_response_text ?suppress_response_text ()
   =
   let control_checkpoint = stop_reason_suppresses_visible_response stop_reason in
   let suppress_response_text =

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -15,7 +15,6 @@ val external_effect_deferred_acknowledgement : string
 val stop_reason_suppresses_visible_response : Runtime_agent.stop_reason -> bool
 
 val finalize :
-  completion_contract_result:Keeper_execution_receipt.completion_contract_result ->
   stop_reason:Runtime_agent.stop_reason ->
   raw_response_text:string ->
   ?suppress_response_text:bool ->

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -42,32 +42,31 @@ let user_turn_record_of_hitl_resolution : _ option -> user_turn_record
   | Some _ -> Record_user_turn
 ;;
 
-type memory_extraction_record =
-  | Extract_turn
-  | Skip_inert_turn
+type turn_effect_record =
+  | Meaningful_turn
+  | Inert_autonomous_turn
 
-(* The librarian fires on a turn cadence, not on activity, so an idle stretch
-   keeps extracting. What it extracts from a bare wake that called no tool is
-   the model's prose about its own idleness, which lands in the fact store as
-   [ephemeral] claims and is recalled on the next turn. Live: 8 of one
-   keeper's 10 most recent claims were "Agent idle across N consecutive
-   autonomous wake cycles", re-injected at 66KB against 3.8KB of world state
-   that reported 122 claimable tasks on the same prompt.
+(* One typed decision owns both replay persistence and librarian extraction.
+   A model response is not itself an external effect: scheduled idle prose has
+   no consumer, yet previously accumulated in the checkpoint and then became
+   librarian input. Existing execution facts are sufficient:
 
-   Both arms are required. A wake that ran a tool changed something; a turn
-   carrying operator or HITL input can hold a durable fact with no tool call.
-   Every pair is listed so a new [user_turn_record] variant fails to compile
-   here rather than defaulting into one side. *)
-let memory_extraction_record_of_turn
+   - operator/HITL input is durable input,
+   - any Keeper tool call may have changed or observed state needed later,
+   - a routed continuation has an external consumer.
+
+   No response-text classifier or duplicate field comparison is involved. *)
+let turn_effect_record_of_turn
       ~(user_turn_record : user_turn_record)
       ~(tool_calls_made : bool)
-  : memory_extraction_record
+      ~(external_delivery_routed : bool)
+  : turn_effect_record
   =
-  match user_turn_record, tool_calls_made with
-  | Skip_uninformative_wake, false -> Skip_inert_turn
-  | Skip_uninformative_wake, true -> Extract_turn
-  | Record_user_turn, false -> Extract_turn
-  | Record_user_turn, true -> Extract_turn
+  match user_turn_record with
+  | Skip_uninformative_wake
+    when not tool_calls_made && not external_delivery_routed ->
+    Inert_autonomous_turn
+  | Skip_uninformative_wake | Record_user_turn -> Meaningful_turn
 ;;
 
 type extra_system_context_assembly =

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -33,31 +33,30 @@ val user_turn_record_of_hitl_resolution : _ option -> user_turn_record
 (** Map the unified lane's HITL resolution slot to a transcript decision.
     Absent resolution means the user turn is the bare wake marker. *)
 
-type memory_extraction_record =
-  | Extract_turn
-  | Skip_inert_turn
-(** Whether this turn is worth running librarian extraction over.
+type turn_effect_record =
+  | Meaningful_turn
+  | Inert_autonomous_turn
+(** Whether the completed turn produced anything that belongs in durable
+    replay or post-turn memory extraction.
 
-    [Skip_inert_turn] is a bare autonomous wake that also called no tool: the
-    input carried nothing forward ({!Skip_uninformative_wake}) and the turn
-    changed nothing observable. The librarian fires on a turn cadence rather
-    than on activity, so an idle stretch keeps extracting, and what it can
-    extract from such a turn is the model's prose about its own idleness.
-    Those land in the fact store as [ephemeral] claims ("Agent idle across 72
-    consecutive autonomous wake cycles"), are recalled the next turn, and are
-    read back as evidence that there is nothing to do — a loop that runs while
-    the world observation on the same prompt reports claimable tasks.
+    [Inert_autonomous_turn] means the input was only the autonomous wake
+    marker, no Keeper tool ran, and no external continuation route exists.
+    Model-authored prose alone is not a durable effect: persisting it makes an
+    idle fleet grow its transcript and then teaches the librarian about that
+    idleness.
 
-    The distinction is typed and derived from the wake decision plus the
-    turn's tool-call list, never from response text. *)
+    The decision uses existing execution facts only. It does not inspect
+    response text, compare rendered messages, or introduce another completion
+    proof contract. *)
 
-val memory_extraction_record_of_turn
+val turn_effect_record_of_turn
   :  user_turn_record:user_turn_record
   -> tool_calls_made:bool
-  -> memory_extraction_record
-(** [Skip_inert_turn] only when the wake was bare {b and} no tool ran. A wake
-    that called a tool did something worth recording; a turn carrying operator
-    or HITL input can hold a durable fact even with no tool call. *)
+  -> external_delivery_routed:bool
+  -> turn_effect_record
+(** [Inert_autonomous_turn] only when the wake was bare, no tool ran, and no
+    external continuation delivery is routed. Operator/HITL input, any tool
+    execution, or a routed continuation makes the turn meaningful. *)
 
 type extra_system_context_assembly =
   { extra_system_context : string option

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -4,7 +4,6 @@
     model-authored prose state is not a checkpoint authority. *)
 
 module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
-module Receipt = Masc.Keeper_execution_receipt
 module Replay_prefix = Masc.Keeper_replay_prefix
 
 let message role content =
@@ -137,8 +136,6 @@ let test_contract_observation_preserves_current_turn_suffix () =
   let patched, reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:history
-      ~pre_turn_working_context:(Some (`Assoc [ "pre_turn", `Bool true ]))
-      ~completion_contract_result:Receipt.Completion_no_visible_output
       ~session_id:"new-session"
       ~response_text:"visible result"
       (checkpoint (history @ current_turn))
@@ -167,8 +164,6 @@ let test_contract_observation_rejects_mismatched_history_prefix () =
   match
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:expected_history
-      ~pre_turn_working_context:None
-      ~completion_contract_result:Receipt.Completion_no_visible_output
       ~session_id:"new-session"
       ~response_text:"suppressed"
       (checkpoint (actual_history @ [ message Assistant [ Text "" ] ]))
@@ -208,8 +203,6 @@ let test_success_preserves_typed_replay_suffix () =
   let patched, reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:history
-      ~pre_turn_working_context:None
-      ~completion_contract_result:Receipt.Completion_tool_execution_observed
       ~session_id:"new-session"
       ~response_text:"visible answer"
       (checkpoint (history @ current_turn))
@@ -240,8 +233,6 @@ let test_success_appends_missing_final_assistant () =
   let patched, _reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:history
-      ~pre_turn_working_context:None
-      ~completion_contract_result:Receipt.Completion_tool_execution_observed
       ~session_id:"new-session"
       ~response_text:"visible answer"
       (checkpoint (history @ [ message User [ Text "current user" ] ]))
@@ -261,8 +252,6 @@ let test_empty_success_preserves_recorded_user_turn () =
   let patched, reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:history
-      ~pre_turn_working_context:(Some (`Assoc [ "pre_turn", `Bool true ]))
-      ~completion_contract_result:Receipt.Completion_tool_execution_observed
       ~session_id:"new-session"
       ~response_text:""
       (checkpoint (history @ [ message User [ Text "current user" ] ]))
@@ -303,8 +292,6 @@ let test_empty_success_preserves_tool_execution_suffix () =
   let patched, reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:history
-      ~pre_turn_working_context:(Some (`Assoc [ "pre_turn", `Bool true ]))
-      ~completion_contract_result:Receipt.Completion_tool_execution_observed
       ~session_id:"new-session"
       ~response_text:""
       (checkpoint (history @ current_turn))
@@ -354,8 +341,6 @@ let test_input_required_preserves_exact_tool_failure_suffix () =
   let patched, reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:history
-      ~pre_turn_working_context:None
-      ~completion_contract_result:Receipt.Completion_observation_unknown
       ~session_id:"new-session"
       ~response_text:request.question
       ~stop_reason:(Runtime_agent.InputRequired { turns_used = 2; request })
@@ -399,8 +384,6 @@ let test_media_degraded_projection_persists_canonical_checkpoint () =
   let checkpoint_for_save, _reason =
     Finalize.checkpoint_for_replay_persistence
       ~history_messages:canonical_history
-      ~pre_turn_working_context:None
-      ~completion_contract_result:Receipt.Completion_tool_execution_observed
       ~session_id:"media-projection-session"
       ~response_text:"completed"
       restored_checkpoint
@@ -429,15 +412,13 @@ let test_media_degraded_projection_persists_canonical_checkpoint () =
         (persisted.messages = canonical_history @ [ current_assistant ]))
 ;;
 
-(* RFC-0351 S1 / #25462: a completed bare-wake turn must not persist the
-   autonomous wake marker the OAS run received as its goal — that was the
-   last accumulation path after #25515 (343 byte-identical markers measured
-   in one checkpoint). The typed [Skip_uninformative_wake] record gates the
-   drop; an identical-looking user message under [Record_user_turn] must
-   survive. *)
+(* RFC-0351 S1 / #25462: a completed bare-wake turn with no tool or external
+   delivery must leave the replay transcript unchanged. The provider still
+   receives the wake marker and may answer with idle prose, but neither is a
+   durable effect. *)
 let wake_marker_text = Masc.Keeper_unified_prompt.autonomous_wake_marker
 
-let wake_persistence ~user_turn_record ~response_text messages =
+let wake_persistence ~user_turn_record ~turn_effect_record ~response_text messages =
   Finalize.checkpoint_for_replay_persistence
     ~history_messages:
       Agent_sdk.Types.
@@ -448,17 +429,33 @@ let wake_persistence ~user_turn_record ~response_text messages =
           ; metadata = []
           }
         ]
-    ~pre_turn_working_context:None
-    ~completion_contract_result:Receipt.Completion_no_visible_output
     ~session_id:"new-session"
     ~response_text
     ~user_turn_record
+    ~turn_effect_record
     (checkpoint messages)
 ;;
 
 let history_seed = [ message Agent_sdk.Types.User [ Agent_sdk.Types.Text "seed" ] ]
 
-let test_skipped_wake_marker_is_not_persisted () =
+let test_inert_wake_does_not_persist_internal_assistant () =
+  Alcotest.(check (option string))
+    "idle prose has no replay authority"
+    None
+    (Finalize.replay_response_text_for_persistence
+       ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
+       ~suppress_visible_response:false
+       ~response_text:"observed, nothing to do");
+  Alcotest.(check (option string))
+    "meaningful turn keeps replay text"
+    (Some "delivered reply")
+    (Finalize.replay_response_text_for_persistence
+       ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
+       ~suppress_visible_response:false
+       ~response_text:"delivered reply")
+;;
+
+let test_inert_wake_does_not_grow_replay () =
   let open Agent_sdk.Types in
   let suffix =
     [ message User [ Text wake_marker_text ]
@@ -468,13 +465,14 @@ let test_skipped_wake_marker_is_not_persisted () =
   let patched, _ =
     wake_persistence
       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+      ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
       ~response_text:"observed, nothing to do"
       (history_seed @ suffix)
     |> expect_ok
   in
   Alcotest.(check int)
-    "marker dropped, assistant reply retained"
-    2
+    "inert wake leaves only the pre-turn history"
+    1
     (List.length patched.messages);
   Alcotest.(check bool)
     "no message carries the wake marker"
@@ -494,6 +492,7 @@ let test_recorded_turn_keeps_identical_marker_text () =
   let patched, _ =
     wake_persistence
       ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
+      ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
       ~response_text:"reply"
       (history_seed @ suffix)
     |> expect_ok
@@ -514,6 +513,7 @@ let test_skipped_wake_leaves_non_marker_suffix_untouched () =
   let patched, _ =
     wake_persistence
       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+      ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
       ~response_text:"reply"
       (history_seed @ suffix)
     |> expect_ok
@@ -532,6 +532,7 @@ let test_skipped_wake_blank_response_drops_only_inert_suffix () =
   let patched, _ =
     wake_persistence
       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+      ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
       ~response_text:""
       (history_seed @ suffix)
     |> expect_ok
@@ -583,9 +584,13 @@ let () =
             `Quick
             test_media_degraded_projection_persists_canonical_checkpoint
         ; Alcotest.test_case
-            "skipped wake marker is not persisted"
+            "inert wake does not persist internal assistant"
             `Quick
-            test_skipped_wake_marker_is_not_persisted
+            test_inert_wake_does_not_persist_internal_assistant
+        ; Alcotest.test_case
+            "inert wake does not grow replay"
+            `Quick
+            test_inert_wake_does_not_grow_replay
         ; Alcotest.test_case
             "recorded turn keeps identical marker text"
             `Quick

--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -4,7 +4,6 @@ open Alcotest
 
 module Task = Masc.Keeper_tool_task_runtime
 module Response_text = Masc.Keeper_agent_run_response_text
-module Receipt = Masc.Keeper_execution_receipt
 module U = Yojson.Safe.Util
 (* Tool_result lives in the leaf [masc_tool_types] lib (wrapped false), so
    it is referenced bare — not under [Masc.] — matching existing tests. *)
@@ -100,7 +99,6 @@ let test_tasks_list_returns_producer_owned_typed_data () =
 let test_response_finalization_keeps_visible_reply_only () =
   let finalized =
     Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_response_observed
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text:"Completed with typed tool evidence."
       ()
@@ -111,7 +109,6 @@ let test_response_finalization_keeps_visible_reply_only () =
     finalized.response_text;
   let suppressed =
     Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_response_observed
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text:"Internal completion text"
       ~suppress_response_text:true

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -443,38 +443,44 @@ let test_bare_autonomous_wake_is_not_recorded () =
     (Masc.Keeper_run_prompt.user_turn_record_of_hitl_resolution (Some ())
      = Masc.Keeper_run_prompt.Record_user_turn)
 
-(* The transcript fix above stopped the wake marker from accumulating, but the
-   librarian reads the checkpoint window on a turn cadence, so an idle stretch
-   kept extracting and kept storing the idleness. Live: 8 of one keeper's 10
-   most recent claims were "Agent idle across N consecutive autonomous wake
-   cycles", recalled at 66KB against 3.8KB of world state reporting 122
-   claimable tasks on the same prompt. Only the bare-wake-and-no-tool pair is
-   inert; the other three carry something a later turn can use. *)
-let test_inert_turn_skips_librarian_extraction () =
-  let decide ~user_turn_record ~tool_calls_made =
-    Masc.Keeper_run_prompt.memory_extraction_record_of_turn
-      ~user_turn_record ~tool_calls_made
+(* One execution-fact decision now owns both replay persistence and librarian
+   extraction. A routed continuation is meaningful without a tool call; idle
+   model prose on a scheduled bare wake is not. *)
+let test_turn_effect_record () =
+  let decide ~user_turn_record ~tool_calls_made ~external_delivery_routed =
+    Masc.Keeper_run_prompt.turn_effect_record_of_turn
+      ~user_turn_record ~tool_calls_made ~external_delivery_routed
   in
-  check bool "bare wake with no tool call is inert" true
+  check bool "bare wake with no effect is inert" true
     (decide
        ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
        ~tool_calls_made:false
-     = Masc.Keeper_run_prompt.Skip_inert_turn);
-  check bool "bare wake that ran a tool still extracts" true
+       ~external_delivery_routed:false
+     = Masc.Keeper_run_prompt.Inert_autonomous_turn);
+  check bool "bare wake that ran a tool is meaningful" true
     (decide
        ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
        ~tool_calls_made:true
-     = Masc.Keeper_run_prompt.Extract_turn);
-  check bool "operator/HITL input extracts even with no tool call" true
+       ~external_delivery_routed:false
+     = Masc.Keeper_run_prompt.Meaningful_turn);
+  check bool "routed continuation is meaningful without a tool" true
+    (decide
+       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
+       ~tool_calls_made:false
+       ~external_delivery_routed:true
+     = Masc.Keeper_run_prompt.Meaningful_turn);
+  check bool "operator/HITL input is meaningful without a tool" true
     (decide
        ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
        ~tool_calls_made:false
-     = Masc.Keeper_run_prompt.Extract_turn);
-  check bool "operator/HITL input with a tool call extracts" true
+       ~external_delivery_routed:false
+     = Masc.Keeper_run_prompt.Meaningful_turn);
+  check bool "operator/HITL input with a tool call is meaningful" true
     (decide
        ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
        ~tool_calls_made:true
-     = Masc.Keeper_run_prompt.Extract_turn)
+       ~external_delivery_routed:true
+     = Masc.Keeper_run_prompt.Meaningful_turn)
 
 let () =
   run "keeper_unified_verification_surface"
@@ -532,7 +538,7 @@ let () =
             "invariant: a bare autonomous wake is not recorded in the transcript"
             `Quick test_bare_autonomous_wake_is_not_recorded;
           test_case
-            "invariant: an inert turn does not feed the librarian"
-            `Quick test_inert_turn_skips_librarian_extraction;
+            "invariant: one turn-effect record owns replay and librarian"
+            `Quick test_turn_effect_record;
         ] );
     ]

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -3,7 +3,6 @@
 
 module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
 module Response_text = Masc.Keeper_agent_run_response_text
-module Receipt = Masc.Keeper_execution_receipt
 module Keeper_metrics = Keeper_metrics
 module Metrics = Masc.Otel_metric_store
 
@@ -83,7 +82,6 @@ let test_replay_capture_omits_blank_response_text () =
 let test_replay_capture_preserves_model_reply_before_visible_capture () =
   let finalized =
     Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_response_observed
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text:"First line from model\nVisible reply"
       ()
@@ -105,7 +103,6 @@ let test_input_required_question_is_not_suppressed_for_internal_source () =
   let stop_reason = Runtime_agent.InputRequired { turns_used = 2; request } in
   let finalized =
     Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_observation_unknown
       ~stop_reason
       ~raw_response_text:request.question
       ()
@@ -124,45 +121,12 @@ let test_direct_response_observation_preserves_raw_response_text () =
   in
   let finalized =
     Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_response_observed
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text
       ()
   in
   Alcotest.(check string)
     "direct response observation keeps visible response"
-    raw_response_text
-    finalized.response_text
-;;
-
-let test_internal_response_observation_preserves_raw_response_text () =
-  let raw_response_text =
-    "No actionable signal. I will wait for a future autonomous cycle."
-  in
-  let finalized =
-    Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_response_observed
-      ~stop_reason:Runtime_agent.Completed
-      ~raw_response_text
-      ()
-  in
-  Alcotest.(check string)
-    "response observation preserves visible response"
-    raw_response_text
-    finalized.response_text
-;;
-
-let test_contract_observation_finalizer_preserves_response_text_by_default () =
-  let raw_response_text = "Attempted work but produced no tool call." in
-  let finalized =
-    Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_no_visible_output
-      ~stop_reason:Runtime_agent.Completed
-      ~raw_response_text
-      ()
-  in
-  Alcotest.(check string)
-    "completion-contract observation preserves response text"
     raw_response_text
     finalized.response_text
 ;;
@@ -205,14 +169,6 @@ let () =
             "direct response observation preserves raw response text"
             `Quick
             test_direct_response_observation_preserves_raw_response_text
-        ; Alcotest.test_case
-            "response observation preserves raw response text"
-            `Quick
-            test_internal_response_observation_preserves_raw_response_text
-        ; Alcotest.test_case
-            "contract observation preserves by default"
-            `Quick
-            test_contract_observation_finalizer_preserves_response_text_by_default
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

RFC-0351 S1 Quick Win: a scheduled Keeper wake that receives no operator/HITL input, runs no Keeper tool, and has no routed continuation now leaves durable replay unchanged and skips Librarian extraction. Provider thinking and idle prose still exist for the current run, but they no longer become future context authority.

## Step 1 -> N

1. Classify the input using the existing typed wake record.
2. Observe actual Keeper tool execution and whether a continuation route exists.
3. Fold those existing facts once into Meaningful_turn or Inert_autonomous_turn.
4. Return the current response normally.
5. For an inert autonomous turn only, discard the provider-only checkpoint suffix and omit internal assistant replay capture.
6. Feed the same turn-effect decision to the Librarian boundary, so replay and extraction cannot disagree.
7. Save through the existing prefix-validation and checkpoint CAS paths.

## Removed non-authorities

- Removed ignored completion_contract_result parameters from response finalization and replay canonicalization.
- Removed ignored pre_turn_working_context plumbing.
- Removed structural current_suffix equality comparison; pruning is now reported from the exact operations that occurred.
- Removed tests whose only difference was an ignored completion enum.

## Safety gates intentionally retained

- Canonical history-prefix validation remains fail-closed.
- InputRequired, MaxTurns, and repeated-tool-call control checkpoints retain their exact current-turn tool suffix.
- Checkpoint save CAS/stale-noop behavior is unchanged.
- Any actual Keeper tool call is conservatively meaningful, including read-only calls.
- Operator/HITL input and routed continuations remain replayable without requiring a tool call.

## Verification

- scripts/dune-local.sh build test/test_keeper_replay_checkpoint.exe test/test_keeper_unified_verification_surface.exe test/test_keeper_task_outcomes.exe test/test_keeper_wire_capture_suppression.exe
- replay checkpoint: 14/14
- unified verification surface: 21/21
- task outcomes: 8/8
- wire capture suppression: 7/7
- python3 scripts/check_test_coverage.py
- python3 scripts/test_check_test_coverage.py
- ocamlformat --check on all touched OCaml files
- git diff --check

## Deliberate scope boundary

This is the functional S1 loop closure, not the L5 provider-bound assembly rewrite. The next slice should collapse exact-plan/full-coverage/fingerprint-style proof gates at the provider boundary while preserving only tool-cycle atomicity, exact final-body admission, and source-CAS persistence.