### PR TITLE
test(keeper): derive vision fixture meta from current schema

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -48,14 +48,7 @@ let assoc_string key = function
   | other -> failwith ("expected object: " ^ Yojson.Safe.to_string other)
 
 let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
-  let json =
-    `Assoc
-      [ "name", `String name
-      ; "agent_name", `String (name ^ "-agent")
-      ; "trace_id", `String (name ^ "-trace")
-      ; "allowed_paths", `List [ `String "*" ]
-      ]
-  in
+  let json = `Assoc [ "name", `String name ] in
 match Masc_test_deps.meta_of_json_fixture json with
 | Ok meta -> meta
 | Error e -> failwith e


### PR DESCRIPTION
## 원인

main CI run [30417591560](https://github.com/jeong-sik/masc/actions/runs/30417591560)는 `test_keeper_vision_tool`에서 `agent_name does not match canonical keeper identity`로 실패했습니다. #26196이 제거한 `sandbox_profile` 다음의 stale fixture field입니다.

## 변경

vision test fixture JSON은 `name`만 제공하고, current meta parser가 canonical `agent_name`·`trace_id`·기본 경로를 유일하게 파생하도록 했습니다. fixture가 파생 필드를 독자적으로 재구현하지 않습니다.

## 검증

- `ocamlformat --check test/test_keeper_vision_tool.ml`
- `git diff --check`
- 로컬 Dune 미실행; current-head CI의 Keeper request-cap suite가 최종 근거입니다.