### PR TITLE
test(keeper): derive vision fixture agent identity

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -51,7 +51,6 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [ "name", `String name
-      ; "agent_name", `String (name ^ "-agent")
       ; "trace_id", `String (name ^ "-trace")
       ; "allowed_paths", `List [ `String "*" ]
       ]


### PR DESCRIPTION
## 문제

#26196 병합 뒤 current Keeper meta 검증이 vision fixture의 수동 `agent_name`을 거부했어용. fixture가 `name ^ "-agent"`를 만들었지만 current contract의 canonical identity는 `Keeper_identity.keeper_agent_name name`이 SSOT예용.

## 변경

- fixture의 수동 `agent_name` 필드를 제거했어용.
- `Masc_test_deps.meta_of_json_fixture`가 current schema SSOT에서 canonical agent identity를 채우도록 했어용.

## 검증

- `ocamlc -stop-after parsing test/test_keeper_vision_tool.ml`
- `ocamlformat --check test/test_keeper_vision_tool.ml`
- `git diff --check`
- 로컬 Dune은 실행하지 않았고, 전체 회귀 검증은 PR CI에서 확인할게용.
