### PR TITLE
refactor(compaction): keep one plan fingerprint

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -504,8 +504,6 @@ let compact_for_request_typed_with
               (Keeper_compaction_llm_summarizer.exact_execution_evidence_catalog_evidence_sha256 exact)
             ~plan_fingerprint:
               (Keeper_compaction_llm_summarizer.exact_execution_evidence_plan_fingerprint exact)
-            ~receipt_plan_fingerprint:
-              (Keeper_compaction_llm_summarizer.exact_execution_evidence_receipt_plan_fingerprint exact)
             ~receipt_request_body_sha256:
               (Keeper_compaction_llm_summarizer.exact_execution_evidence_receipt_request_body_sha256 exact)
             ~before_checkpoint_bytes:before_bytes

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -50,7 +50,6 @@ type exact_execution_evidence =
   ; catalog_generation_fingerprint : string
   ; catalog_evidence_sha256 : string
   ; plan_fingerprint : string
-  ; receipt_plan_fingerprint : string
   ; receipt_request_body_sha256 : string
   }
 
@@ -1011,7 +1010,6 @@ let exact_execution_evidence (flow_success : Exact_output.flow_success) =
       |> Exact_output.plan_provenance_catalog_evidence
       |> Exact_output.catalog_evidence_sha256
   ; plan_fingerprint = observation.receipt_plan_fingerprint
-  ; receipt_plan_fingerprint = observation.receipt_plan_fingerprint
   ; receipt_request_body_sha256 =
       observation.receipt_request_body_sha256
   }
@@ -1568,11 +1566,6 @@ let exact_execution_evidence_catalog_evidence_sha256
 
 let exact_execution_evidence_plan_fingerprint (evidence : exact_execution_evidence) =
   evidence.plan_fingerprint
-;;
-
-let exact_execution_evidence_receipt_plan_fingerprint
-      (evidence : exact_execution_evidence) =
-  evidence.receipt_plan_fingerprint
 ;;
 
 let exact_execution_evidence_receipt_request_body_sha256

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -211,7 +211,6 @@ val exact_execution_evidence_target_identity_fingerprint : exact_execution_evide
 val exact_execution_evidence_catalog_generation_fingerprint : exact_execution_evidence -> string
 val exact_execution_evidence_catalog_evidence_sha256 : exact_execution_evidence -> string
 val exact_execution_evidence_plan_fingerprint : exact_execution_evidence -> string
-val exact_execution_evidence_receipt_plan_fingerprint : exact_execution_evidence -> string
 val exact_execution_evidence_receipt_request_body_sha256 : exact_execution_evidence -> string
 val apply : compaction_plan -> Agent_sdk.Types.message list
 val summarized_indices : compaction_plan -> int list

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -5,7 +5,6 @@ type t =
   ; catalog_generation_fingerprint : string
   ; catalog_evidence_sha256 : string
   ; plan_fingerprint : string
-  ; receipt_plan_fingerprint : string
   ; receipt_request_body_sha256 : string
   ; before_checkpoint_bytes : int
   ; after_checkpoint_bytes : int
@@ -26,7 +25,6 @@ type field =
   | Catalog_generation_fingerprint
   | Catalog_evidence_sha256
   | Plan_fingerprint
-  | Receipt_plan_fingerprint
   | Receipt_request_body_sha256
   | Before_checkpoint_bytes
   | After_checkpoint_bytes
@@ -57,10 +55,6 @@ type decode_error =
   | Expected_object
   | Unknown_field of string
   | Invalid_field of field * field_error
-  | Plan_fingerprint_mismatch of
-      { plan_fingerprint : string
-      ; receipt_plan_fingerprint : string
-      }
   | Invalid_transition of measure * int * int
   | Invalid_message_accounting of
       { before_message_count : int
@@ -83,7 +77,6 @@ let field_name = function
   | Catalog_generation_fingerprint -> "catalog_generation_fingerprint"
   | Catalog_evidence_sha256 -> "catalog_evidence_sha256"
   | Plan_fingerprint -> "plan_fingerprint"
-  | Receipt_plan_fingerprint -> "receipt_plan_fingerprint"
   | Receipt_request_body_sha256 -> "receipt_request_body_sha256"
   | Before_checkpoint_bytes -> "before_checkpoint_bytes"
   | After_checkpoint_bytes -> "after_checkpoint_bytes"
@@ -104,7 +97,6 @@ let exact_fields =
   ; Catalog_generation_fingerprint
   ; Catalog_evidence_sha256
   ; Plan_fingerprint
-  ; Receipt_plan_fingerprint
   ; Receipt_request_body_sha256
   ]
 ;;
@@ -153,12 +145,6 @@ let decode_error_to_string = function
       "invalid_field:%s:%s"
       (field_name field)
       (field_error_to_string error)
-  | Plan_fingerprint_mismatch
-      { plan_fingerprint; receipt_plan_fingerprint } ->
-    Printf.sprintf
-      "plan_fingerprint_mismatch:plan=%s:receipt=%s"
-      plan_fingerprint
-      receipt_plan_fingerprint
   | Invalid_transition (measure, before, after) ->
     Printf.sprintf
       "invalid_transition:%s:%d:%d"
@@ -241,7 +227,6 @@ let create
       ~catalog_generation_fingerprint
       ~catalog_evidence_sha256
       ~plan_fingerprint
-      ~receipt_plan_fingerprint
       ~receipt_request_body_sha256
       ~before_checkpoint_bytes
       ~after_checkpoint_bytes
@@ -279,18 +264,12 @@ let create
          ; Catalog_generation_fingerprint, catalog_generation_fingerprint
          ; Catalog_evidence_sha256, catalog_evidence_sha256
          ; Plan_fingerprint, plan_fingerprint
-         ; Receipt_plan_fingerprint, receipt_plan_fingerprint
          ; Receipt_request_body_sha256, receipt_request_body_sha256
          ]
      with
      | Some (field, _) -> Error (Invalid_field (field, Blank_string))
      | None ->
-       if not (String.equal plan_fingerprint receipt_plan_fingerprint)
-       then
-         Error
-           (Plan_fingerprint_mismatch
-              { plan_fingerprint; receipt_plan_fingerprint })
-       else if after_checkpoint_bytes >= before_checkpoint_bytes
+       if after_checkpoint_bytes >= before_checkpoint_bytes
        then
          Error
            (Invalid_transition
@@ -344,7 +323,6 @@ let create
            ; catalog_generation_fingerprint
            ; catalog_evidence_sha256
            ; plan_fingerprint
-           ; receipt_plan_fingerprint
            ; receipt_request_body_sha256
            ; before_checkpoint_bytes
            ; after_checkpoint_bytes
@@ -378,7 +356,6 @@ let of_json = function
     let* catalog_generation_fingerprint = string Catalog_generation_fingerprint in
     let* catalog_evidence_sha256 = string Catalog_evidence_sha256 in
     let* plan_fingerprint = string Plan_fingerprint in
-    let* receipt_plan_fingerprint = string Receipt_plan_fingerprint in
     let* receipt_request_body_sha256 = string Receipt_request_body_sha256 in
     let* before_checkpoint_bytes = integer Before_checkpoint_bytes in
     let* after_checkpoint_bytes = integer After_checkpoint_bytes in
@@ -397,7 +374,6 @@ let of_json = function
       ~catalog_generation_fingerprint
       ~catalog_evidence_sha256
       ~plan_fingerprint
-      ~receipt_plan_fingerprint
       ~receipt_request_body_sha256
       ~before_checkpoint_bytes
       ~after_checkpoint_bytes
@@ -420,7 +396,6 @@ let to_json evidence =
     ; "catalog_generation_fingerprint", `String evidence.catalog_generation_fingerprint
     ; "catalog_evidence_sha256", `String evidence.catalog_evidence_sha256
     ; "plan_fingerprint", `String evidence.plan_fingerprint
-    ; "receipt_plan_fingerprint", `String evidence.receipt_plan_fingerprint
     ; "receipt_request_body_sha256", `String evidence.receipt_request_body_sha256
     ; "before_checkpoint_bytes", `Int evidence.before_checkpoint_bytes
     ; "after_checkpoint_bytes", `Int evidence.after_checkpoint_bytes

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -7,7 +7,6 @@ type t =
   ; catalog_generation_fingerprint : string
   ; catalog_evidence_sha256 : string
   ; plan_fingerprint : string
-  ; receipt_plan_fingerprint : string
   ; receipt_request_body_sha256 : string
   ; before_checkpoint_bytes : int
   ; after_checkpoint_bytes : int
@@ -28,7 +27,6 @@ type field =
   | Catalog_generation_fingerprint
   | Catalog_evidence_sha256
   | Plan_fingerprint
-  | Receipt_plan_fingerprint
   | Receipt_request_body_sha256
   | Before_checkpoint_bytes
   | After_checkpoint_bytes
@@ -59,10 +57,6 @@ type decode_error =
   | Expected_object
   | Unknown_field of string
   | Invalid_field of field * field_error
-  | Plan_fingerprint_mismatch of
-      { plan_fingerprint : string
-      ; receipt_plan_fingerprint : string
-      }
   | Invalid_transition of measure * int * int
   | Invalid_message_accounting of
       { before_message_count : int
@@ -94,7 +88,6 @@ val create
   -> catalog_generation_fingerprint:string
   -> catalog_evidence_sha256:string
   -> plan_fingerprint:string
-  -> receipt_plan_fingerprint:string
   -> receipt_request_body_sha256:string
   -> before_checkpoint_bytes:int
   -> after_checkpoint_bytes:int
@@ -120,7 +113,7 @@ val to_json : t -> Yojson.Safe.t
 
 val of_json : Yojson.Safe.t -> (t, decode_error) result
 (** Restore persisted structural and exact-execution evidence from one closed
-    object. Unknown, duplicate, missing, malformed, blank, mismatched, or
+    object. Unknown, duplicate, missing, malformed, blank, or
     objectively impossible evidence is rejected explicitly; no external
     provenance labels or historical shape are inferred or migrated.
     [Checkpoint_bytes] must strictly reduce, message accounting must remain

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -6,7 +6,6 @@ let evidence : Keeper_compaction_evidence.t =
     ~catalog_generation_fingerprint:"catalog-generation"
     ~catalog_evidence_sha256:"catalog-evidence"
     ~plan_fingerprint:"plan-fingerprint"
-    ~receipt_plan_fingerprint:"plan-fingerprint"
     ~receipt_request_body_sha256:"request-body"
     ~before_checkpoint_bytes:4096
     ~after_checkpoint_bytes:1024
@@ -59,7 +58,6 @@ let test_projection_and_roundtrip () =
       ; "catalog_generation_fingerprint", `String "catalog-generation"
       ; "catalog_evidence_sha256", `String "catalog-evidence"
       ; "plan_fingerprint", `String "plan-fingerprint"
-      ; "receipt_plan_fingerprint", `String "plan-fingerprint"
       ; "receipt_request_body_sha256", `String "request-body"
       ; "before_checkpoint_bytes", `Int 4096
       ; "after_checkpoint_bytes", `Int 1024
@@ -123,18 +121,17 @@ let test_rejections () =
     ; ( "blank call id"
       , Invalid_field (Call_id, Blank_string)
       , replace "call_id" (`String "   ") canonical )
-    ; ( "tampered plan fingerprint"
-      , Plan_fingerprint_mismatch
-          { plan_fingerprint = "plan-fingerprint"
-          ; receipt_plan_fingerprint = "tampered-plan"
-          }
-      , replace "receipt_plan_fingerprint" (`String "tampered-plan") canonical )
     ; ( "duplicate"
       , Invalid_field (After_message_count, Duplicate)
       , duplicate )
     ; ( "unknown field"
       , Unknown_field "retired_counter"
       , `Assoc (("retired_counter", `Int 1) :: fields canonical) )
+    ; ( "retired duplicate identity field"
+      , Unknown_field "receipt_plan_fingerprint"
+      , `Assoc
+          (("receipt_plan_fingerprint", `String "plan-fingerprint")
+           :: fields canonical) )
     ; ( "missing field"
       , Invalid_field (Before_tool_use_count, Missing)
       , remove "before_tool_use_count" canonical )
@@ -193,7 +190,6 @@ let test_atomic_cycle_and_normalization_accounting () =
       ~catalog_generation_fingerprint:"catalog-generation"
       ~catalog_evidence_sha256:"catalog-evidence"
       ~plan_fingerprint:"plan-fingerprint"
-      ~receipt_plan_fingerprint:"plan-fingerprint"
       ~receipt_request_body_sha256:"request-body"
       ~before_checkpoint_bytes:4096
       ~after_checkpoint_bytes:1024

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3898,7 +3898,6 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
         ; "catalog_generation_fingerprint", `String "catalog-generation"
         ; "catalog_evidence_sha256", `String "catalog-evidence"
         ; "plan_fingerprint", `String "plan-fingerprint"
-        ; "receipt_plan_fingerprint", `String "plan-fingerprint"
         ; "receipt_request_body_sha256", `String "request-body"
         ; "before_checkpoint_bytes", `Int 4096
         ; "after_checkpoint_bytes", `Int 1024

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -129,7 +129,6 @@ let canonical_compaction_evidence () =
       ~catalog_generation_fingerprint:"catalog-generation"
       ~catalog_evidence_sha256:"catalog-evidence"
       ~plan_fingerprint:"plan-fingerprint"
-      ~receipt_plan_fingerprint:"plan-fingerprint"
       ~receipt_request_body_sha256:"request-body"
       ~before_checkpoint_bytes:4096
       ~after_checkpoint_bytes:1024


### PR DESCRIPTION
## Summary

- keep one canonical `plan_fingerprint` in compaction exact evidence
- remove the duplicate `receipt_plan_fingerprint` projection and its tautological equality gate
- hard-cut the retired duplicate field at the closed manifest boundary

## Why

The exact-output receipt is the single source of the successful plan identity.
Production copied that same receipt value into both `plan_fingerprint` and
`receipt_plan_fingerprint`, then rejected inequality between the two copies.
No independent producer or trust boundary existed between them.

Before:

`OAS receipt -> one fingerprint -> two evidence fields -> equality gate -> two JSON fields`

After:

`OAS receipt -> one fingerprint -> one evidence field -> closed JSON boundary`

The OAS receipt, request-body hash, target identity, catalog generation, catalog
evidence, structural accounting, and checkpoint validation remain unchanged.

## Deployment transition

Pre-change exact-evidence rows still contain the retired
`receipt_plan_fingerprint` field. The current closed decoder therefore reports
those historical rows as `Unknown_field:receipt_plan_fingerprint`.

- the dashboard reader records a row-scoped `read_error`, omits only that
  historical snapshot item, and continues serving current rows (or its
  `keeper_meta` fallback)
- the Keeper-side manifest reader also skips only that undecodable row; the
  execution consumer folds exclusively over provider-attempt started/finished
  rows, so the rejected compaction-evidence row is not restart or FSM authority

This is an intentional hard cut: no legacy decoder or inferred migration path is
retained. New evidence rows use only the canonical field, so the historical
projection error ages out as the tail advances.

## Adversarial cases

- current canonical evidence round-trips through the strict decoder
- the retired duplicate field is rejected explicitly as `Unknown_field`
- blank/missing/duplicate canonical fields and impossible accounting remain rejected

## Validation

- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- `python3 scripts/check_test_coverage.py`
- `python3 scripts/test_check_test_coverage.py` (10/10)
- focused build:
  `scripts/dune-local.sh build test/keeper_compaction_evidence/test_keeper_compaction_evidence.exe test/test_keeper_runtime_manifest_completeness.exe test/test_keeper_memory_os.exe test/test_compaction_exact_output_conformance.exe`
- direct tests:
  - compaction evidence: 5/5
  - runtime manifest completeness: 7/7
  - Memory OS: 98/98
- exact-flow conformance executable remains current-main red at the untouched
  `prepare_lane ~base_path:_` owner check; tracked in #25994/#25997. Its target
  compiles on this head.
