### PR TITLE
test(keeper): cap schema-capable vision fixtures

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -558,8 +558,10 @@ supports-multimodal-inputs = true
 supports-structured-output = true
 
 [p1.vision-a]
+max-request-body-bytes = 65536
 
 [p2.vision-b]
+max-request-body-bytes = 65536
 |}
 
 let single_vision_runtime_toml =
@@ -583,6 +585,7 @@ supports-multimodal-inputs = true
 supports-structured-output = true
 
 [p3.vision-c]
+max-request-body-bytes = 65536
 |}
 
 (* Vision falls back to every schema-capable image runtime after explicit


### PR DESCRIPTION
## 문제

#26203 병합 후 `test_keeper_vision_tool`의 정상 schema-capable fixture 세 곳이 provider `max-request-body-bytes` 없이 남았습니다.

그 결과 정상 provider 응답/invalid structured response를 검증해야 하는 테스트가 provider 호출 전에 uncapped runtime으로 거절됩니다. #26192와 #26197의 exact-head CI가 모두 같은 `test/test_keeper_vision_tool.ml:743` assertion에서 실패했습니다.

## 변경

- 정상 failover fixture의 `p1.vision-a`, `p2.vision-b`에 `max-request-body-bytes = 65536`을 명시합니다.
- 정상 single-runtime fixture의 `p3.vision-c`에도 같은 cap을 명시합니다.
- uncapped runtime 거절을 검증하는 전용 `uncapped_vision_fallback_runtime_toml`은 그대로 둡니다.

## 검증

- head: `56107b1ccd667cafc99ade64f54ed8ca0a130d5c`
- `ocamlc -stop-after parsing test/test_keeper_vision_tool.ml`: 통과
- `ocamlformat --check test/test_keeper_vision_tool.ml`: 통과
- `git diff --check`: 통과
- 로컬 Dune은 공유 빌드 자원 정책상 실행하지 않았고 exact-head CI에 맡깁니다.

## 범위

테스트 fixture의 provider cap 세 줄만 수정합니다. production runtime 선택/실행 로직은 변경하지 않습니다.
