### PR TITLE
test(vision): cap provider-reaching fixture

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -558,8 +558,10 @@ supports-multimodal-inputs = true
 supports-structured-output = true
 
 [p1.vision-a]
+max-request-body-bytes = 65536
 
 [p2.vision-b]
+max-request-body-bytes = 65536
 |}
 
 let single_vision_runtime_toml =
@@ -583,6 +585,7 @@ supports-multimodal-inputs = true
 supports-structured-output = true
 
 [p3.vision-c]
+max-request-body-bytes = 65536
 |}
 
 (* Vision falls back to every schema-capable image runtime after explicit


### PR DESCRIPTION
Closes #26209.

## Summary

- add the required serialized request-body cap to provider-reaching vision fixtures
- let invalid-structured-response tests reach their provider stub again

## Root cause

#26175 made `max-request-body-bytes` mandatory before provider dispatch.
`single_vision_runtime_toml` and `vision_failover_runtime_toml` still left
`p1.vision-a`, `p2.vision-b`, and `p3.vision-c` uncapped, so tests that expected
provider responses instead failed at pre-dispatch admission.

The deliberately uncapped fallback fixture remains uncapped. This is
intentionally a fixture-only three-line change.

## Validation

- `ocamlc -stop-after parsing test/test_keeper_vision_tool.ml`
- `ocamlformat --check test/test_keeper_vision_tool.ml`
- `git diff --check`
- `python3 scripts/check_test_coverage.py`
- `scripts/dune-local.sh build test/test_keeper_vision_tool.exe`
- `./_build/default/test/test_keeper_vision_tool.exe`
  (`test_keeper_vision_tool: all assertions passed`)
