### PR TITLE
fix(ci): declare request-body cap on release-evidence default runtime

### DIFF
--- a/scripts/fixtures/release-evidence/runtime.toml
+++ b/scripts/fixtures/release-evidence/runtime.toml
@@ -50,3 +50,7 @@ streaming = true
 [ollama_cloud.deepseek-v4-flash]
 is-default = true
 max-concurrent = 1
+# Mandatory since #26175: Keeper dispatch refuses a runtime that has no
+# positive request-body admission ceiling, so the release-evidence server
+# starts at all. Mirrors production config/runtime.toml for this runtime.
+max-request-body-bytes = 524288

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1081,6 +1081,33 @@ let test_release_evidence_fixture_lanes_resolve_without_credentials () =
       "release-evidence smoke runtime.toml should load: %s"
       (render_runtime_toml_errors errors)
   | Ok (config : Runtime_schema.config) ->
+    let default_runtime_id =
+      match config.default_runtime_id with
+      | Some runtime_id -> runtime_id
+      | None -> fail "release-evidence smoke runtime.toml must declare a default runtime"
+    in
+    let default_binding =
+      match
+        List.find_opt
+          (fun (binding : Runtime_schema.binding) ->
+             String.equal
+               (Runtime_schema.binding_key binding)
+               default_runtime_id)
+          config.bindings
+      with
+      | Some binding -> binding
+      | None ->
+        failf
+          "release-evidence smoke default runtime %s must resolve to a binding"
+          default_runtime_id
+    in
+    check
+      bool
+      "release-evidence smoke default runtime has a positive request-body cap"
+      true
+      (match default_binding.max_request_body_bytes with
+       | Some cap -> cap > 0
+       | None -> false);
     List.iter
       (fun lane_id ->
          match


### PR DESCRIPTION
## 뭘 고쳤는지

current `main`은 모든 테스트 뒤의 release-evidence 설치 부트에서
실패합니다.

```text
Keeper-dispatch runtime "ollama_cloud.deepseek-v4-flash" has no positive
max-request-body-bytes
```

`scripts/release-evidence.sh`가 복사하는 전용 fixture의 default binding에
#26175의 새 필수 cap이 빠져 있었습니다.

## 변경

- `scripts/fixtures/release-evidence/runtime.toml`
  - production seed의 동일 runtime과 같은
    `max-request-body-bytes = 524288` 선언
- `test/test_runtime_config_validity.ml`
  - release-evidence fixture의 default runtime이 실제 binding으로 해석되는지
    확인
  - 해당 binding의 request-body cap이 positive인지 확인

Closes #26215.

## 검증

- `ocamlc -stop-after parsing test/test_runtime_config_validity.ml`
- `ocamlformat --check test/test_runtime_config_validity.ml`
- `git diff --check`
- 로컬 Dune은 실행하지 않았고 exact-head CI를 최종 근거로 사용
