### PR TITLE
fix(ci): cap release-evidence runtime requests

### DIFF
--- a/scripts/fixtures/release-evidence/runtime.toml
+++ b/scripts/fixtures/release-evidence/runtime.toml
@@ -50,3 +50,7 @@ streaming = true
 [ollama_cloud.deepseek-v4-flash]
 is-default = true
 max-concurrent = 1
+# This binding reaches the Keeper dispatch boundary even though the smoke
+# disables autonomous bootstrap. Startup admission therefore requires an
+# explicit positive serialized-request ceiling.
+max-request-body-bytes = 65536

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1081,6 +1081,33 @@ let test_release_evidence_fixture_lanes_resolve_without_credentials () =
       "release-evidence smoke runtime.toml should load: %s"
       (render_runtime_toml_errors errors)
   | Ok (config : Runtime_schema.config) ->
+    let default_runtime_id =
+      match config.default_runtime_id with
+      | Some runtime_id -> runtime_id
+      | None -> fail "release-evidence smoke runtime.toml must declare a default runtime"
+    in
+    let default_binding =
+      match
+        List.find_opt
+          (fun (binding : Runtime_schema.binding) ->
+             String.equal
+               (Runtime_schema.binding_key binding)
+               default_runtime_id)
+          config.bindings
+      with
+      | Some binding -> binding
+      | None ->
+        failf
+          "release-evidence smoke default runtime %s must resolve to a binding"
+          default_runtime_id
+    in
+    check
+      bool
+      "release-evidence smoke default runtime has a positive request-body cap"
+      true
+      (match default_binding.max_request_body_bytes with
+       | Some cap -> cap > 0
+       | None -> false);
     List.iter
       (fun lane_id ->
          match


### PR DESCRIPTION
## What

- add a positive request-body ceiling to the isolated release-evidence runtime
- make the existing boot-fixture test assert that its default binding has a
  positive ceiling

## Why

Current `main` run 30421697123 passes the build and runtime suites, then fails
the installed-binary boot smoke because #26175 made the cap mandatory at
Keeper-dispatch admission. The checked-in release-evidence fixture was not
updated, so every unrelated PR ends red at the same final step.

The fixture disables autonomous Keeper bootstrap and points at a dead local
provider endpoint. `65536` is an admission value for this isolated boot smoke,
not a production model-capacity policy.

Closes #26215.

## Validation

- `ocamlc -stop-after parsing test/test_runtime_config_validity.ml`
- `ocamlformat --check test/test_runtime_config_validity.ml`
- `git diff --check`
- exact-head CI is the runtime proof; no local Dune was run
