### PR TITLE
refactor(auth): hard-cut credential admin alias

### DIFF
--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -75,7 +75,6 @@ let agent_credential_to_yojson (c : agent_credential) =
     ("agent_name", `String c.agent_name);
     ("token", `String c.token);
     ("role", `String (agent_role_to_string c.role));
-    ("admin", `Bool (c.role = Admin));
     ("created_at", `String c.created_at);
     ("expires_at", Json_util.string_opt_to_json c.expires_at);
   ]
@@ -87,9 +86,7 @@ let agent_credential_of_yojson json =
     let role =
       match Json_util.get_string json "role" with
       | Some s -> agent_role_of_string s
-      | None ->
-        let is_admin = Json_util.get_bool json "admin" |> Option.value ~default:false in
-        Ok (if is_admin then Admin else Worker)
+      | None -> Error "agent_credential_of_yojson: missing required string field \"role\""
     in
     (match role with
      | Error e -> Error e

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -79,24 +79,75 @@ let agent_credential_to_yojson (c : agent_credential) =
     ("expires_at", Json_util.string_opt_to_json c.expires_at);
   ]
 
-let agent_credential_of_yojson json =
-  try
-    let agent_name = Json_util.get_string_with_default json ~key:"agent_name" ~default:"" in
-    let token = Json_util.get_string_with_default json ~key:"token" ~default:"" in
-    let role =
-      match Json_util.get_string json "role" with
-      | Some s -> agent_role_of_string s
-      | None -> Error "agent_credential_of_yojson: missing required string field \"role\""
+let agent_credential_field_names =
+  [ "id"; "agent_id"; "agent_name"; "token"; "role"; "created_at"; "expires_at" ]
+
+let validate_agent_credential_fields = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok fields
+      | (name, _) :: rest ->
+        if not (List.mem name agent_credential_field_names)
+        then Error (Printf.sprintf "agent_credential_of_yojson: unknown field %S" name)
+        else if List.mem name seen
+        then Error (Printf.sprintf "agent_credential_of_yojson: duplicate field %S" name)
+        else loop (name :: seen) rest
     in
-    (match role with
-     | Error e -> Error e
-     | Ok role ->
-       let created_at = Json_util.get_string_with_default json ~key:"created_at" ~default:"" in
-       let expires_at = Json_util.get_string json "expires_at" in
-       let id = Json_util.get_string json "id" |> Option.map Credential_id.of_string in
-       let agent_id = Json_util.get_string json "agent_id" |> Option.map Agent_id.of_string in
-       Ok { id; agent_id; agent_name; token; role; created_at; expires_at })
-  with e -> Error (Printexc.to_string e)
+    loop [] fields
+  | other ->
+    Error
+      (Printf.sprintf
+         "agent_credential_of_yojson: expected JSON object, got %s"
+         (Json_util.kind_name other))
+
+let require_credential_string fields name =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "agent_credential_of_yojson: field %S must be a string, got %s"
+         name
+         (Json_util.kind_name value))
+  | None ->
+    Error
+      (Printf.sprintf "agent_credential_of_yojson: missing required field %S" name)
+
+let require_credential_optional_string fields name =
+  match List.assoc_opt name fields with
+  | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "agent_credential_of_yojson: field %S must be a string or null, got %s"
+         name
+         (Json_util.kind_name value))
+  | None ->
+    Error
+      (Printf.sprintf "agent_credential_of_yojson: missing required field %S" name)
+
+let agent_credential_of_yojson json =
+  let ( let* ) = Result.bind in
+  let* fields = validate_agent_credential_fields json in
+  let* id = require_credential_optional_string fields "id" in
+  let* agent_id = require_credential_optional_string fields "agent_id" in
+  let* agent_name = require_credential_string fields "agent_name" in
+  let* token = require_credential_string fields "token" in
+  let* role_name = require_credential_string fields "role" in
+  let* role = agent_role_of_string role_name in
+  let* created_at = require_credential_string fields "created_at" in
+  let* expires_at = require_credential_optional_string fields "expires_at" in
+  Ok
+    {
+      id = Option.map Credential_id.of_string id;
+      agent_id = Option.map Agent_id.of_string agent_id;
+      agent_name;
+      token;
+      role;
+      created_at;
+      expires_at;
+    }
 
 (** Auth configuration *)
 type auth_config = {

--- a/lib/types/types_auth.mli
+++ b/lib/types/types_auth.mli
@@ -84,13 +84,11 @@ type agent_credential = {
 (** Token-based authentication record. *)
 
 val agent_credential_to_yojson : agent_credential -> Yojson.Safe.t
-(** Emits one extra denormalised field for backward-compat:
-    [admin = (role = Admin)]. *)
+(** Emits the current credential schema. [role] is the sole role authority. *)
 
 val agent_credential_of_yojson :
   Yojson.Safe.t -> (agent_credential, string) result
-(** Accepts both [role] (string) and the legacy [admin] (bool)
-    field; missing role + [admin = true] -> [Admin], else [Worker]. *)
+(** Requires the current [role] string field. *)
 
 (** {1 Auth configuration} *)
 

--- a/lib/types/types_auth.mli
+++ b/lib/types/types_auth.mli
@@ -88,7 +88,8 @@ val agent_credential_to_yojson : agent_credential -> Yojson.Safe.t
 
 val agent_credential_of_yojson :
   Yojson.Safe.t -> (agent_credential, string) result
-(** Requires the current [role] string field. *)
+(** Requires the exact current credential object. Unknown, duplicate, missing,
+    or mistyped fields are rejected; [role] is the sole role authority. *)
 
 (** {1 Auth configuration} *)
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -79,6 +79,12 @@ let read_file path =
     ~finally:(fun () -> close_in_noerr ic)
     (fun () -> really_input_string ic (in_channel_length ic))
 
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
 let test_parent_auth_facade_is_leaf_reexport () =
   let parent = read_file (source_file "lib/auth.ml") in
   let leaf_reexport = read_file (source_file "lib/auth/auth_leaf.ml") in
@@ -234,6 +240,40 @@ let test_credential_saved_private () =
           fail
             (Printf.sprintf "create_token should succeed: %s"
                (Masc_domain.masc_error_to_string e)))
+
+let test_removed_admin_field_fails_closed_through_authorization () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      match Auth.create_token dir ~agent_name:"stale-admin" ~role:Masc_domain.Admin with
+      | Error e ->
+        fail
+          (Printf.sprintf "create_token should succeed: %s"
+             (Masc_domain.masc_error_to_string e))
+      | Ok (raw_token, _) ->
+        let path = Auth.credential_file dir "stale-admin" in
+        let stale_json =
+          match Yojson.Safe.from_string (read_file path) with
+          | `Assoc fields -> `Assoc (("admin", `Bool true) :: fields)
+          | _ -> fail "credential writer must emit an object"
+        in
+        write_file path (Yojson.Safe.to_string stale_json);
+        check
+          bool
+          "load rejects removed field"
+          true
+          (Option.is_none (Auth.load_credential dir "stale-admin"));
+        check
+          bool
+          "authorization fails closed"
+          true
+          (Result.is_error
+             (Auth.authorize_tool_v2
+                dir
+                ~agent_name:"stale-admin"
+                ~token:(Some raw_token)
+                ~tool_name:"masc_status")))
 
 let test_workspace_secret_saved_private () =
   let dir = setup_test_workspace () in
@@ -1134,6 +1174,8 @@ let () =
       test_case "create credential" `Quick test_create_credential;
       test_case "credential saved private" `Quick
         test_credential_saved_private;
+      test_case "removed admin field fails closed through authorization" `Quick
+        test_removed_admin_field_fails_closed_through_authorization;
       test_case "verify token" `Quick test_verify_token;
       test_case "verify wrong token" `Quick test_verify_wrong_token;
       test_case "verify token reports token owner on agent mismatch" `Quick

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -819,7 +819,8 @@ let test_agent_credential_to_yojson () =
   | `Assoc fields ->
     check bool "has agent_name" true (List.mem_assoc "agent_name" fields);
     check bool "has token" true (List.mem_assoc "token" fields);
-    check bool "has admin" true (List.mem_assoc "admin" fields)
+    check bool "has role" true (List.mem_assoc "role" fields);
+    check bool "omits removed admin field" false (List.mem_assoc "admin" fields)
   | _ -> fail "expected Assoc"
 
 let test_agent_credential_to_yojson_with_expiry () =
@@ -841,31 +842,23 @@ let test_agent_credential_of_yojson_ok () =
   let json = `Assoc [
     ("agent_name", `String "gemini");
     ("token", `String "xyz");
-    ("admin", `Bool false);
+    ("role", `String "worker");
     ("created_at", `String "2024-01-15T12:00:00Z");
   ] in
   match Masc_domain.agent_credential_of_yojson json with
   | Ok cred ->
     check string "agent_name" "gemini" cred.agent_name;
-    check bool "admin=false maps to worker" true (cred.role = Masc_domain.Worker)
+    check bool "role=worker maps to Worker" true (cred.role = Masc_domain.Worker)
   | Error e -> fail ("expected Ok, got: " ^ e)
 
 let test_agent_credential_of_yojson_error () =
   let json = `String "not an object" in
   match Masc_domain.agent_credential_of_yojson json with
-  | Ok cred ->
-    check string "agent_name defaults empty" "" cred.agent_name;
-    check string "token defaults empty" "" cred.token;
-    check bool "role defaults worker" true (cred.role = Masc_domain.Worker)
-  | Error e -> fail ("expected tolerant default, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for missing role"
 
-(* Regression: live fleet credential files stored role as a string field
-   (["role": "admin"|"worker"]) while the original parser only inspected
-   the legacy bool field (["admin"]). Missing lookup silently downgraded
-   admin credentials to Worker, producing Forbidden on CanAdmin tools
-   such as masc_board_delete for janitor / dashboard / qa-king. The
-   parser now reads the canonical string first, falling back to the
-   legacy bool. *)
+(* The current credential schema stores role as a required string field.
+   Permission checks must never infer it from another field. *)
 let test_agent_credential_of_yojson_role_string_admin () =
   let json = `Assoc [
     ("agent_name", `String "janitor");
@@ -890,9 +883,8 @@ let test_agent_credential_of_yojson_role_string_worker () =
     check bool "role:\"worker\" parses to Worker" true (cred.role = Masc_domain.Worker)
   | Error e -> fail ("expected Ok, got: " ^ e)
 
-let test_agent_credential_of_yojson_role_string_wins_over_admin_bool () =
-  (* If a file has both fields, the canonical string wins. This covers the
-     transitional period where writers emit both. *)
+let test_agent_credential_of_yojson_role_is_authoritative () =
+  (* Unknown fields do not override the sole role authority. *)
   let json = `Assoc [
     ("agent_name", `String "mixed");
     ("token", `String "t");
@@ -905,8 +897,8 @@ let test_agent_credential_of_yojson_role_string_wins_over_admin_bool () =
     check bool "role string wins" true (cred.role = Masc_domain.Admin)
   | Error e -> fail ("expected Ok, got: " ^ e)
 
-let test_agent_credential_of_yojson_admin_bool_legacy () =
-  (* Older admin.json files use only the bool field; must still parse. *)
+let test_agent_credential_of_yojson_rejects_admin_only () =
+  (* A removed role alias must not silently grant Admin. *)
   let json = `Assoc [
     ("agent_name", `String "admin");
     ("token", `String "t");
@@ -914,9 +906,8 @@ let test_agent_credential_of_yojson_admin_bool_legacy () =
     ("created_at", `String "2026-04-24T01:00:11Z");
   ] in
   match Masc_domain.agent_credential_of_yojson json with
-  | Ok cred ->
-    check bool "admin:true legacy parses to Admin" true (cred.role = Masc_domain.Admin)
-  | Error e -> fail ("expected Ok, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error when required role is absent"
 
 let test_agent_credential_of_yojson_unknown_role_fails_closed () =
   (* Fail-closed: unknown role strings return Error, never silently downgrade. *)
@@ -930,9 +921,7 @@ let test_agent_credential_of_yojson_unknown_role_fails_closed () =
   | Error _ -> ()
   | Ok _ -> fail "expected Error for unknown role"
 
-let test_agent_credential_to_yojson_emits_role_and_admin () =
-  (* Writer emits both fields during the transition so downstream readers
-     in either vintage see a consistent role. *)
+let test_agent_credential_to_yojson_emits_role_only () =
   let cred : Masc_domain.agent_credential = {
     id = None;
     agent_id = None;
@@ -945,11 +934,9 @@ let test_agent_credential_to_yojson_emits_role_and_admin () =
   match Masc_domain.agent_credential_to_yojson cred with
   | `Assoc fields ->
     check bool "has role" true (List.mem_assoc "role" fields);
-    check bool "has admin" true (List.mem_assoc "admin" fields);
+    check bool "omits removed admin field" false (List.mem_assoc "admin" fields);
     let role_val = List.assoc "role" fields in
-    let admin_val = List.assoc "admin" fields in
-    check bool "role=\"admin\"" true (role_val = `String "admin");
-    check bool "admin=true" true (admin_val = `Bool true)
+    check bool "role=\"admin\"" true (role_val = `String "admin")
   | _ -> fail "expected Assoc"
 
 (* ============================================================
@@ -1612,14 +1599,14 @@ let () =
         test_agent_credential_of_yojson_role_string_admin;
       test_case "of_yojson role=\"worker\" -> Worker" `Quick
         test_agent_credential_of_yojson_role_string_worker;
-      test_case "of_yojson role string wins over admin bool" `Quick
-        test_agent_credential_of_yojson_role_string_wins_over_admin_bool;
-      test_case "of_yojson legacy admin=true -> Admin" `Quick
-        test_agent_credential_of_yojson_admin_bool_legacy;
-      test_case "of_yojson unknown role fails closed to Worker" `Quick
+      test_case "of_yojson role is authoritative" `Quick
+        test_agent_credential_of_yojson_role_is_authoritative;
+      test_case "of_yojson rejects removed admin-only schema" `Quick
+        test_agent_credential_of_yojson_rejects_admin_only;
+      test_case "of_yojson rejects unknown role" `Quick
         test_agent_credential_of_yojson_unknown_role_fails_closed;
-      test_case "to_yojson emits both role and admin fields" `Quick
-        test_agent_credential_to_yojson_emits_role_and_admin;
+      test_case "to_yojson emits role only" `Quick
+        test_agent_credential_to_yojson_emits_role_only;
     ];
     "auth_config", [
       test_case "to_yojson" `Quick test_auth_config_to_yojson;

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -804,6 +804,29 @@ let test_agent_role_of_yojson_wrong_type () =
    agent_credential Tests
    ============================================================ *)
 
+let current_agent_credential_json
+      ?(id = `Null)
+      ?(agent_id = `Null)
+      ?(expires_at = `Null)
+      ?(extra_fields = [])
+      ~agent_name
+      ~token
+      ~role
+      ~created_at
+      ()
+  =
+  `Assoc
+    ([
+       "id", id;
+       "agent_id", agent_id;
+       "agent_name", `String agent_name;
+       "token", `String token;
+       "role", `String role;
+       "created_at", `String created_at;
+       "expires_at", expires_at;
+     ]
+     @ extra_fields)
+
 let test_agent_credential_to_yojson () =
   let cred : Masc_domain.agent_credential = {
     id = None;
@@ -839,12 +862,14 @@ let test_agent_credential_to_yojson_with_expiry () =
   | _ -> fail "expected Assoc"
 
 let test_agent_credential_of_yojson_ok () =
-  let json = `Assoc [
-    ("agent_name", `String "gemini");
-    ("token", `String "xyz");
-    ("role", `String "worker");
-    ("created_at", `String "2024-01-15T12:00:00Z");
-  ] in
+  let json =
+    current_agent_credential_json
+      ~agent_name:"gemini"
+      ~token:"xyz"
+      ~role:"worker"
+      ~created_at:"2024-01-15T12:00:00Z"
+      ()
+  in
   match Masc_domain.agent_credential_of_yojson json with
   | Ok cred ->
     check string "agent_name" "gemini" cred.agent_name;
@@ -857,45 +882,51 @@ let test_agent_credential_of_yojson_error () =
   | Error _ -> ()
   | Ok _ -> fail "expected Error for missing role"
 
-(* The current credential schema stores role as a required string field.
-   Permission checks must never infer it from another field. *)
+(* The current credential schema stores role as a required string field and is
+   closed to removed or unknown fields. *)
 let test_agent_credential_of_yojson_role_string_admin () =
-  let json = `Assoc [
-    ("agent_name", `String "janitor");
-    ("token", `String "t");
-    ("role", `String "admin");
-    ("created_at", `String "2026-04-23T12:50:47Z");
-  ] in
+  let json =
+    current_agent_credential_json
+      ~agent_name:"janitor"
+      ~token:"t"
+      ~role:"admin"
+      ~created_at:"2026-04-23T12:50:47Z"
+      ()
+  in
   match Masc_domain.agent_credential_of_yojson json with
   | Ok cred ->
     check bool "role:\"admin\" parses to Admin" true (cred.role = Masc_domain.Admin)
   | Error e -> fail ("expected Ok, got: " ^ e)
 
 let test_agent_credential_of_yojson_role_string_worker () =
-  let json = `Assoc [
-    ("agent_name", `String "nick0cave");
-    ("token", `String "t");
-    ("role", `String "worker");
-    ("created_at", `String "2026-04-23T08:07:00Z");
-  ] in
+  let json =
+    current_agent_credential_json
+      ~agent_name:"nick0cave"
+      ~token:"t"
+      ~role:"worker"
+      ~created_at:"2026-04-23T08:07:00Z"
+      ()
+  in
   match Masc_domain.agent_credential_of_yojson json with
   | Ok cred ->
     check bool "role:\"worker\" parses to Worker" true (cred.role = Masc_domain.Worker)
   | Error e -> fail ("expected Ok, got: " ^ e)
 
-let test_agent_credential_of_yojson_role_is_authoritative () =
-  (* Unknown fields do not override the sole role authority. *)
-  let json = `Assoc [
-    ("agent_name", `String "mixed");
-    ("token", `String "t");
-    ("role", `String "admin");
-    ("admin", `Bool false);
-    ("created_at", `String "2026-04-23T00:00:00Z");
-  ] in
+let test_agent_credential_of_yojson_rejects_removed_admin_field () =
+  let json =
+    current_agent_credential_json
+      ~agent_name:"mixed"
+      ~token:"t"
+      ~role:"admin"
+      ~created_at:"2026-04-23T00:00:00Z"
+      ~extra_fields:[ "admin", `Bool false ]
+      ()
+  in
   match Masc_domain.agent_credential_of_yojson json with
-  | Ok cred ->
-    check bool "role string wins" true (cred.role = Masc_domain.Admin)
-  | Error e -> fail ("expected Ok, got: " ^ e)
+  | Error e ->
+    check bool "names removed field" true
+      (String_util.contains_substring e "unknown field \"admin\"")
+  | Ok _ -> fail "expected Error for removed admin field"
 
 let test_agent_credential_of_yojson_rejects_admin_only () =
   (* A removed role alias must not silently grant Admin. *)
@@ -911,12 +942,14 @@ let test_agent_credential_of_yojson_rejects_admin_only () =
 
 let test_agent_credential_of_yojson_unknown_role_fails_closed () =
   (* Fail-closed: unknown role strings return Error, never silently downgrade. *)
-  let json = `Assoc [
-    ("agent_name", `String "evil");
-    ("token", `String "t");
-    ("role", `String "root");
-    ("created_at", `String "2026-04-23T00:00:00Z");
-  ] in
+  let json =
+    current_agent_credential_json
+      ~agent_name:"evil"
+      ~token:"t"
+      ~role:"root"
+      ~created_at:"2026-04-23T00:00:00Z"
+      ()
+  in
   match Masc_domain.agent_credential_of_yojson json with
   | Error _ -> ()
   | Ok _ -> fail "expected Error for unknown role"
@@ -1599,8 +1632,8 @@ let () =
         test_agent_credential_of_yojson_role_string_admin;
       test_case "of_yojson role=\"worker\" -> Worker" `Quick
         test_agent_credential_of_yojson_role_string_worker;
-      test_case "of_yojson role is authoritative" `Quick
-        test_agent_credential_of_yojson_role_is_authoritative;
+      test_case "of_yojson rejects removed admin field" `Quick
+        test_agent_credential_of_yojson_rejects_removed_admin_field;
       test_case "of_yojson rejects removed admin-only schema" `Quick
         test_agent_credential_of_yojson_rejects_admin_only;
       test_case "of_yojson rejects unknown role" `Quick


### PR DESCRIPTION
## Summary

- stop emitting the removed credential `admin` alias
- require the exact current credential object with `role` as the sole role authority
- reject unknown, duplicate, missing, and mistyped fields at the codec boundary
- replace transition-era tests with current-schema rejection and round-trip coverage

## Product impact

- User-visible change: credential JSON without a valid `role` no longer loads; newly written credentials contain `role` only.
- Deployment precondition: all 13 non-redirect credentials currently contain both `role` and the removed `admin` field. They must be regenerated by the current-only writer before deploying this exact decoder; this PR intentionally contains no legacy migration path.

## Evidence

- `scripts/dune-local.sh build test/test_types_coverage.exe` — PASS
- `scripts/dune-local.sh exec test/test_types_coverage.exe -- test '^agent_credential$' --color=never` — PASS, 10/10
- `_build/default/test/test_auth.exe` — PASS, 55/55, including `Auth.load_credential → authorize_tool_v2` fail-closed proof
- `ocamlformat --check lib/types/types_auth.mli lib/types/types_auth.ml test/test_types_coverage.ml test/test_auth.ml` — PASS
- Full `test_types_coverage.exe` exposed one unrelated pre-existing stale `NotClaimed` wording assertion; tracked in #26218.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — census finding identified self-propagating `admin` writes and a decoder fallback
- [x] Orient — P0 R1 hard-cut; credential role controls authorization
- [x] Decide — bounded auth codec feature slice with no overlap with current open PRs
- [x] Act — removed the writer alias and decoder fallback; rollback is a single commit revert
- [x] Verify — focused codec and auth suites pass
- [x] Loop — unrelated main-branch test drift is tracked in #26218; remaining census findings continue in separate scoped PRs

## Review evidence

- Pending GitHub review.

## Linked issue

- Relates #26218 only as unrelated test-suite drift discovered during verification.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed
- [ ] **TypeScript** — N/A
- [ ] **TLA+ spec** — N/A
- [ ] **Event / JSON schema** — N/A: credential object field removal, not an enum change
- [ ] **`make check-variants` passes** — N/A: no variant change
