### PR TITLE
refactor(memory): remove dead legacy filename API

### DIFF
--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -112,30 +112,6 @@ let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
   Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
 ;;
 
-type legacy_memory_file =
-  | Legacy_facts
-  | Legacy_events
-
-let supported_legacy_memory_files = [ Legacy_facts; Legacy_events ]
-
-let legacy_memory_filename = function
-  | Legacy_facts -> "facts.jsonl"
-  | Legacy_events -> "events.jsonl"
-;;
-
-let legacy_memory_file_of_filename filename =
-  List.find_opt
-    (fun legacy_file -> String.equal filename (legacy_memory_filename legacy_file))
-    supported_legacy_memory_files
-;;
-
-let current_path_for_legacy_memory_filename ~keepers_dir ~keeper_id ~filename =
-  match legacy_memory_file_of_filename filename with
-  | Some Legacy_facts -> Some (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  | Some Legacy_events -> Some (events_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  | None -> None
-;;
-
 let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -32,17 +32,6 @@ val list_fact_store_keeper_ids_for_base_path : base_path:string -> string list
 val events_path : keeper_id:string -> string
 val events_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 
-type legacy_memory_file =
-  | Legacy_facts
-  | Legacy_events
-
-val supported_legacy_memory_files : legacy_memory_file list
-val legacy_memory_filename : legacy_memory_file -> string
-val current_path_for_legacy_memory_filename :
-  keepers_dir:string -> keeper_id:string -> filename:string -> string option
-(** Map a legacy per-keeper Memory OS filename under [.masc/keepers/<keeper>/]
-    to the current store path under [keepers_dir], when the filename is a
-    supported legacy memory artifact. *)
 val episodes_dir : keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string


### PR DESCRIPTION
## Summary

- remove the unused public `legacy_memory_file` type
- remove the unused legacy filename inventory and `facts.jsonl` / `events.jsonl` path translator
- leave current `*.facts.jsonl`, `*.events.jsonl`, episode, and tool-result paths unchanged

## Product impact

- User-visible change: none; repository-wide search found no callers outside the definitions and signature.
- Feature boundary: Keeper Memory OS path helpers and persistence API.

## Evidence

- Repository-wide reference scan after removal — no remaining legacy API symbols
- `scripts/dune-local.sh build test/test_keeper_memory_os_io_fd.exe` — PASS
- `_build/default/test/test_keeper_memory_os_io_fd.exe` — PASS, 2/2
- `ocamlformat --check lib/keeper/keeper_memory_os_io.mli lib/keeper/keeper_memory_os_io.ml` — PASS
- `bash scripts/check-variants.sh` — PASS

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — census found a public legacy migration API with zero callers
- [x] Orient — P0 R1 hard-cut in the Keeper Memory OS persistence boundary
- [x] Decide — delete the dead surface separately from live Memory OS readers/writers
- [x] Act — removed implementation and signature; rollback is a single commit revert
- [x] Verify — focused module build, test, format, and residue scan pass
- [x] Loop — remaining census findings continue in separate scoped PRs

## Review evidence

- Pending GitHub review.

## Linked issue

- Relates to the 2026-07-29 MASC/OAS code-rule census.

## Variant addition checklist

- [x] **OCaml** — removed the unused `legacy_memory_file` variant type and its only exhaustive matches
- [ ] **TypeScript** — N/A
- [ ] **TLA+ spec** — N/A
- [ ] **Event / JSON schema** — N/A
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` passes
