### PR TITLE
refactor(metrics): hard-cut unlabelled cache read counter

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -256,19 +256,12 @@ let make_hooks
              Otel_metric_store.inc_counter
                Otel_metric_store.metric_provider_prefix_cache_creation_tokens
                ~delta:(Float.of_int cc) ();
-        if cr > 0 then begin
-          Otel_metric_store.inc_counter
-            Otel_metric_store.metric_provider_prefix_cache_read_tokens
-            ~delta:(Float.of_int cr) ();
-          (* Per-provider/model cache-read counter for Otel_metric_store
-             dashboards.  The legacy unlabelled counter above
-             remains for backward compatibility. *)
+        if cr > 0 then
           Otel_metric_store.inc_counter
             Otel_metric_store.metric_llm_provider_cache_read_tokens
             ~labels:[ ("provider", provider_label); ("model", model) ]
             ~delta:(Float.of_int cr)
-            ()
-        end;
+            ();
         (* Per-provider/model reasoning-token counter.  Available via
            [inference_telemetry.reasoning_tokens] on select providers
            (Anthropic extended thinking, DeepSeek, etc.). *)

--- a/lib/otel_metric_store/otel_core_metric_names.ml
+++ b/lib/otel_metric_store/otel_core_metric_names.ml
@@ -35,9 +35,6 @@ let metric_provider_prefix_cache_creation_tokens =
   Otel_metric_store_core.declare_counter "masc_provider_prefix_cache_creation_tokens_total"
 ;;
 
-let metric_provider_prefix_cache_read_tokens =
-  Otel_metric_store_core.declare_counter "masc_provider_prefix_cache_read_tokens_total"
-;;
 let metric_tool_input_validation = Otel_metric_store_core.declare_counter "masc_tool_input_validation_total"
 let metric_llm_provider_http_status = Otel_metric_store_core.declare_counter "masc_llm_provider_http_status_total"
 let metric_llm_provider_request_latency = "masc_llm_provider_request_latency_seconds"

--- a/lib/otel_metric_store/otel_core_metric_names.mli
+++ b/lib/otel_metric_store/otel_core_metric_names.mli
@@ -48,7 +48,6 @@ val metric_sse_reconnects : string
 val metric_sse_idle_evictions : string
 val metric_sse_rejects : string
 val metric_provider_prefix_cache_creation_tokens : string
-val metric_provider_prefix_cache_read_tokens : string
 val metric_tool_input_validation : string
 val metric_llm_provider_http_status : string
 val metric_llm_provider_request_latency : string

--- a/test/test_cache_metrics_wiring.ml
+++ b/test/test_cache_metrics_wiring.ml
@@ -12,8 +12,11 @@ module Otel_metric_store = Masc.Otel_metric_store
 (* ── Helpers ──────────────────────────────────────────── *)
 
 (** Read counter value, defaulting to 0.0 *)
-let counter_value name =
-  Otel_metric_store.metric_value_or_zero name ()
+let counter_value ?(labels = []) name =
+  Otel_metric_store.metric_value_or_zero name ~labels ()
+
+let provider_cache_labels =
+  [ "provider", "test-provider"; "model", "test-model" ]
 
 (* ── Provider prefix cache counter tests ──────────────── *)
 
@@ -31,12 +34,15 @@ let test_prefix_cache_creation_counter () =
 
 let test_prefix_cache_read_counter () =
   let before = counter_value
-    "masc_provider_prefix_cache_read_tokens_total" in
+    ~labels:provider_cache_labels
+    "masc_llm_provider_cache_read_tokens_total" in
   Otel_metric_store.inc_counter
-    "masc_provider_prefix_cache_read_tokens_total"
+    "masc_llm_provider_cache_read_tokens_total"
+    ~labels:provider_cache_labels
     ~delta:3200.0 ();
   let after = counter_value
-    "masc_provider_prefix_cache_read_tokens_total" in
+    ~labels:provider_cache_labels
+    "masc_llm_provider_cache_read_tokens_total" in
   let diff = after -. before in
   check (float 0.1) "read counter incremented by 3200"
     3200.0 diff
@@ -47,7 +53,8 @@ let test_prefix_cache_zero_no_increment () =
   let before_creation = counter_value
     "masc_provider_prefix_cache_creation_tokens_total" in
   let before_read = counter_value
-    "masc_provider_prefix_cache_read_tokens_total" in
+    ~labels:provider_cache_labels
+    "masc_llm_provider_cache_read_tokens_total" in
   (* Simulate the guard in keeper_hooks_oas.ml: only inc if > 0 *)
   let cc = 0 in
   let cr = 0 in
@@ -57,12 +64,14 @@ let test_prefix_cache_zero_no_increment () =
       ~delta:(Float.of_int cc) ();
   if cr > 0 then
     Otel_metric_store.inc_counter
-      "masc_provider_prefix_cache_read_tokens_total"
+      "masc_llm_provider_cache_read_tokens_total"
+      ~labels:provider_cache_labels
       ~delta:(Float.of_int cr) ();
   let after_creation = counter_value
     "masc_provider_prefix_cache_creation_tokens_total" in
   let after_read = counter_value
-    "masc_provider_prefix_cache_read_tokens_total" in
+    ~labels:provider_cache_labels
+    "masc_llm_provider_cache_read_tokens_total" in
   check (float 0.1) "creation unchanged" before_creation after_creation;
   check (float 0.1) "read unchanged" before_read after_read
 
@@ -87,17 +96,20 @@ let test_response_cache_increment () =
 let test_two_layer_independence () =
   (* Incrementing response cache should not affect provider prefix cache *)
   let prefix_before = counter_value
-    "masc_provider_prefix_cache_read_tokens_total" in
+    ~labels:provider_cache_labels
+    "masc_llm_provider_cache_read_tokens_total" in
   Otel_metric_store.inc_counter "masc_inference_cache_hits_total" ();
   let prefix_after = counter_value
-    "masc_provider_prefix_cache_read_tokens_total" in
+    ~labels:provider_cache_labels
+    "masc_llm_provider_cache_read_tokens_total" in
   check (float 0.1) "prefix cache unaffected by response cache"
     prefix_before prefix_after;
   (* Incrementing provider prefix cache should not affect response cache *)
   let response_before = counter_value
     "masc_inference_cache_hits_total" in
   Otel_metric_store.inc_counter
-    "masc_provider_prefix_cache_read_tokens_total"
+    "masc_llm_provider_cache_read_tokens_total"
+    ~labels:provider_cache_labels
     ~delta:100.0 ();
   let response_after = counter_value
     "masc_inference_cache_hits_total" in
@@ -113,7 +125,9 @@ let test_cache_metrics_in_registry () =
   in
   check bool "registry has prefix creation metric" true
     (has "masc_provider_prefix_cache_creation_tokens_total");
-  check bool "registry has prefix read metric" true
+  check bool "registry has labelled provider read metric" true
+    (has "masc_llm_provider_cache_read_tokens_total");
+  check bool "registry omits removed unlabelled read metric" false
     (has "masc_provider_prefix_cache_read_tokens_total")
 
 (* ── Suite ────────────────────────────────────────────── *)


### PR DESCRIPTION
## Summary

- stop double-emitting cache-read tokens into an unlabelled compatibility counter
- remove the retired metric declaration and public binding
- keep the provider/model-labelled cache-read counter as the sole metric authority
- ratchet the removed series out of the metric registry test

## Product impact

- User-visible change: telemetry consumers must use `masc_llm_provider_cache_read_tokens_total{provider,model}`.
- Feature boundary: OAS after-turn usage telemetry projected into the MASC OTel metric store.
- Cache-creation and response-cache metrics are unchanged.

## Evidence

- `scripts/dune-local.sh build test/test_cache_metrics_wiring.exe` — PASS
- `_build/default/test/test_cache_metrics_wiring.exe` — PASS, 7/7
- residue scan for the removed binding/name/comment across `lib`, `test`, `docs`, dashboards, viewer, and scripts — no matches
- `ocamlformat --check` on all changed OCaml files — PASS

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — census found every cache-read sample emitted into labelled and unlabelled counters
- [x] Orient — P0 R1 hard-cut in the inference observability feature
- [x] Decide — retain the provider/model-labelled metric, which has the narrower and useful authority
- [x] Act — removed declaration, emission, and compatibility-focused tests; rollback is a single commit revert
- [x] Verify — focused build/test, format, registry ratchet, and residue scan pass
- [x] Loop — remaining census findings continue in separate scoped PRs

## Review evidence

- Pending GitHub review.

## Linked issue

- Relates to the 2026-07-29 MASC/OAS code-rule census.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant change
- [ ] **TypeScript** — N/A
- [ ] **TLA+ spec** — N/A
- [ ] **Event / JSON schema** — N/A
- [ ] **`make check-variants` passes** — N/A: no variant change
