### PR TITLE
refactor(fusion): remove legacy panel error constant

### DIFF
--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -141,9 +141,6 @@ let judge_skip_reason ~panel ~min_answered : skip_reason option =
     then Some (Quorum_shortfall { answered = answered_count; required = min_answered })
     else None
 
-let no_panel_answers_error =
-  "all panels failed: no answered panel to synthesize"
-
 type claim =
   { text : string
   ; supporting_models : string list

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -132,10 +132,6 @@ val render_skip_reason : skip_reason -> string
 val judge_skip_reason :
   panel:panel_outcome list -> min_answered:int -> skip_reason option
 
-val no_panel_answers_error : string
-(** Legacy canonical string for callers that still need the pre-quorum
-    all-panel-failed message. New code should use {!skip_reason}. *)
-
 (** {1 심판 구조화 출력}
 
     [Structured.extract]의 provider-native JSON schema로 강제 파싱되는 닫힌 타입.


### PR DESCRIPTION
## Scope

Remove the dead pre-quorum Fusion error-string compatibility API.

## Feature relationship

- Runtime Fusion quorum handling is owned by the typed `skip_reason` contract:
  `judge_skip_reason` decides and `render_skip_reason` renders.
- `no_panel_answers_error` had no source, test, dashboard, documentation, or
  script consumer.
- Removing it does not add a Gate or change the current Fusion decision path.

## Changes

- Remove `Fusion_types.no_panel_answers_error` from the interface.
- Remove its legacy canonical string definition.

## Verification

- repo-wide symbol/string scan: no consumers remain
- `scripts/dune-local.sh build test/fusion_core/test_fusion.exe`
- `_build/default/test/fusion_core/test_fusion.exe` — 79/79 PASS
- `ocamlformat --check` on both changed files
- `git diff --check`

## Census provenance

- Downloads census: `lib/fusion_core/fusion_types.mli:136`
- Normalized severity: P0 under the repository hard-cut rule for executable
  compatibility APIs.
