### PR TITLE
refactor(dashboard): remove dead credential monitor API

### DIFF
--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -176,18 +176,6 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("slo_breached", `Bool false);
     ], false)
 
-let credential_monitoring_json () : Yojson.Safe.t =
-  (* Bare-form credential alias archive logic was removed; the legacy
-     starvation counter is always zero.  The dashboard field is retained
-     for API compatibility. *)
-  `Assoc [
-    ("alert_level", `String "ok");
-    ("needs_attention", `Bool false);
-    ("credential_archived_starvation_total", `Int 0);
-    ("metric_name", `String "masc_config_credential_archived_starvation_total");
-    ("reason", `Null);
-  ]
-
 let slot_monitoring_json () : Yojson.Safe.t =
   try
     let idle = Discovery_cache.idle_slot_count () in

--- a/lib/dashboard/dashboard_http_monitoring.mli
+++ b/lib/dashboard/dashboard_http_monitoring.mli
@@ -16,11 +16,6 @@ val tool_call_health_json :
     internal board plus a boolean [needs_attention] flag. *)
 val board_monitoring_json : now_ts:float -> Yojson.Safe.t * bool
 
-(** Snapshot of auth/credential runtime drift counters that should
-    page an operator, including keeper credential archival after
-    starvation recovery. *)
-val credential_monitoring_json : unit -> Yojson.Safe.t
-
 (** Point-in-time slot occupancy / queue depth snapshot. *)
 val slot_monitoring_json : unit -> Yojson.Safe.t
 


### PR DESCRIPTION
## Scope

Remove the dead dashboard credential-monitor compatibility API.

## Feature relationship

- `credential_monitoring_json` had no runtime, dashboard, test, documentation,
  or script caller.
- The removed payload exposed only constant healthy state plus the retired
  `credential_archived_starvation_total = 0` metric.
- Current credential lifecycle and Keeper state-machine archival behavior are
  separate live features and are unchanged.

## Changes

- Remove `Dashboard_http_monitoring.credential_monitoring_json`.
- Remove the always-zero legacy metric name and compatibility payload.

## Verification

- repository scan: no function, field, or metric-name consumer remains
- `scripts/dune-local.sh build lib/dashboard/masc_dashboard.cmxa`
- `ocamlformat --check` on both changed files
- `git diff --check`

## Census provenance

- Downloads census: `lib/dashboard/dashboard_http_monitoring.ml:180`
- Normalized severity: P0 under the repository hard-cut rule for executable
  compatibility code.
