### PR TITLE
fix(keeper): let selected durable source finish before successors

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -769,23 +769,20 @@ let run_keepalive_unified_turn
               Some completion.channel
             | [] | [ _ ] | _ :: _ :: _ -> None
           in
-          (* #16 (38-bug campaign PR-5): [reactive_wake] tells us this cycle
-             was triggered by an external signal rather than the proactive
-             cadence tick, but by itself does not say *which* stimulus (or
-             whether the event queue drained anything at all). Pairing it
-             with [!consumed_stimuli] — already drained above, unchanged
-             until the post-turn ack/requeue below — gives
-             [mark_turn_started] a total, typed answer instead of the
-             boolean the registry previously discarded. *)
+          (* The event intake is the exact turn input. Keep its attribution in
+             the existing wake record even when the cadence, rather than a
+             direct wake signal, discovered it. An empty [Woken] still means a
+             reactive wake with no selected event. *)
           let wake : Keeper_registry.wake_reason =
-            if reactive_wake
-            then
+            match !consumed_stimuli, reactive_wake with
+            | _ :: _, _ ->
               Keeper_registry.Woken
                 (List.map
                    (fun (stim : Keeper_event_queue.stimulus) ->
                       stim.Keeper_event_queue.payload)
                    !consumed_stimuli)
-            else Keeper_registry.Proactive_tick
+            | [], true -> Keeper_registry.Woken []
+            | [], false -> Keeper_registry.Proactive_tick
           in
           let run_cycle () =
             run_keeper_cycle
@@ -795,7 +792,6 @@ let run_keepalive_unified_turn
               ?event_bus
               ?hitl_resolution
               ?continuation_delivery_channel
-              ~active_source_stimuli:!consumed_stimuli
               ~ctx
               ~meta_after_triage
               ~stop

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -112,7 +112,6 @@ let run_keeper_cycle_admitted
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
-      ?active_source_stimuli
       ~ctx
       ~meta_after_triage
       ~stop
@@ -138,7 +137,6 @@ let run_keeper_cycle_admitted
         ~channel:turn_decision.channel
         ?hitl_resolution
         ?continuation_delivery_channel
-        ?active_source_stimuli
         (* RFC-0315: pass the whole decision, not just its channel — the
            prompt renders the verdict reasons so the turn knows why it woke. *)
         ~turn_decision
@@ -218,7 +216,6 @@ let run_keeper_cycle_with
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
-      ?active_source_stimuli
       ~ctx
       ~meta_after_triage
       ~stop
@@ -280,7 +277,6 @@ let run_keeper_cycle_with
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
-      ?active_source_stimuli
       ()
   in
   match manual_compaction_requested with
@@ -331,7 +327,6 @@ let run_keeper_cycle
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
-      ?active_source_stimuli
       ~ctx
       ~meta_after_triage
       ~stop
@@ -366,7 +361,6 @@ run_keeper_cycle_with
     ?event_bus
     ?hitl_resolution
     ?continuation_delivery_channel
-    ?active_source_stimuli
     ~ctx
     ~meta_after_triage
     ~stop

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -51,7 +51,6 @@ val run_keeper_cycle
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> ?continuation_delivery_channel:Keeper_continuation_channel.t
-  -> ?active_source_stimuli:Keeper_event_queue.stimulus list
   -> ctx:_ Keeper_types_profile.context
   -> meta_after_triage:Keeper_meta_contract.keeper_meta
   -> stop:bool Atomic.t

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -335,11 +335,10 @@ type turn_attempt_state = {
   first_started_at : float;
 }
 
-(** #16 (38-bug campaign PR-5): what caused a turn to run — an explicit
-    reactive stimulus batch or the proactive cadence tick (no stimulus).
-    Closed sum over {!Keeper_event_queue.stimulus_payload} so a new wake
-    source cannot silently collapse into a generic "running" label on the
-    operator dashboard. *)
+(** What entered a turn: its exact consumed event batch, an empty external
+    wake, or the proactive cadence tick. Closed over
+    {!Keeper_event_queue.stimulus_payload} so a new source cannot silently
+    collapse into a generic "running" label on the operator dashboard. *)
 type wake_reason =
   | Proactive_tick
   | Woken of Keeper_event_queue.stimulus_payload list

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -120,6 +120,57 @@ let turn_success_of_stop_reason ~meta = function
   | Runtime_agent.InputRequired _ -> Turn_input_required meta
 ;;
 
+let chat_yield_request ~base_path ~keeper_name =
+  match Keeper_registry.get ~base_path keeper_name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" keeper_name)
+  | Some _ ->
+    if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
+    then Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
+    else
+      match Keeper_chat_queue.has_active_receipts ~keeper_name with
+      | Error error ->
+        Error
+          ("chat queue snapshot failed: "
+           ^ Keeper_chat_queue.mutation_error_to_string error)
+      | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
+      | Ok false -> Ok None
+;;
+
+let autonomous_yield_request ~base_path ~keeper_name =
+  match chat_yield_request ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok (Some _) as request -> request
+  | Ok None ->
+    (match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+     | Error _ as error -> error
+     | Ok pending ->
+       if Keeper_event_queue.is_empty pending
+       then Ok None
+       else (
+         let summary =
+           Keeper_agent_run.durable_stimulus_summary ~now:(Time_compat.now ()) pending
+         in
+         Log.Keeper.info
+           ~keeper_name
+           "autonomous turn yields to durable stimulus: %s"
+           (Keeper_agent_run.durable_stimulus_summary_to_string summary);
+         Ok
+           (Some
+              Keeper_agent_run.
+                { reason = Durable_stimulus_waiting summary })))
+;;
+
+let autonomous_yield_request_for_wake ~wake ~base_path ~keeper_name =
+  match wake with
+  (* A nonempty [Woken] is the event queue input already selected for this
+     turn. It may yield for chat delivery, but a queued successor waits until
+     that source reaches its terminal settlement. *)
+  | Keeper_registry.Woken (_ :: _) ->
+    fun () -> chat_yield_request ~base_path ~keeper_name
+  | Keeper_registry.Proactive_tick | Keeper_registry.Woken [] ->
+    fun () -> autonomous_yield_request ~base_path ~keeper_name
+;;
+
 (* RFC-0356: for the operations [Keeper_gate_replay] dispatches to, the runtime
    spends the grant itself during tool-bundle setup (#25947, #26089). That
    happens after this message is composed — [keeper_agent_run.ml:560] runs
@@ -666,7 +717,6 @@ let run_keeper_cycle
       ?event_bus
       ?hitl_resolution
       ?continuation_delivery_channel
-      ?(active_source_stimuli = [])
       ()
   : (turn_success, turn_failure) result
   =
@@ -1164,8 +1214,12 @@ let run_keeper_cycle
                            ; turn_id = keeper_turn_id
                            ; deferred_runtime_lane
                            ; on_deferred_runtime_consumed
-                           ; active_source_stimuli
                            }
+                           ~autonomous_yield_requested:
+                             (autonomous_yield_request_for_wake
+                                ~wake
+                                ~base_path:config.base_path
+                                ~keeper_name:meta.name)
                            ~initial_execution
                            ~turn_state
                            ~before_dispatch_authority

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -259,7 +259,6 @@ val run_keeper_cycle
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> ?continuation_delivery_channel:Keeper_continuation_channel.t
-  -> ?active_source_stimuli:Keeper_event_queue.stimulus list
   -> unit
   -> (turn_success, turn_failure) result
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -41,56 +41,6 @@ let run_provider_dispatch_if_authorized ~before_dispatch_authority dispatch =
   | Ok () -> dispatch ()
 ;;
 
-let pending_without_active_sources ~active_source_stimuli pending =
-  pending
-  |> Keeper_event_queue.to_list
-  |> List.filter (fun candidate ->
-    not
-      (List.exists
-         (fun active ->
-            Keeper_event_queue.stimulus_identity_equal active candidate)
-         active_source_stimuli))
-  |> List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty
-;;
-
-let autonomous_yield_request ~base_path ~keeper_name ~active_source_stimuli =
-  match Keeper_registry.get ~base_path keeper_name with
-  | None -> Error (Printf.sprintf "keeper not registered: %s" keeper_name)
-  | Some _ ->
-    if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
-    then Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-    else
-      (match Keeper_chat_queue.has_active_receipts ~keeper_name with
-       | Error error ->
-         Error
-           ("chat queue snapshot failed: "
-            ^ Keeper_chat_queue.mutation_error_to_string error)
-       | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-       | Ok false ->
-         let* pending =
-           Keeper_registry_event_queue.snapshot_result ~base_path keeper_name
-         in
-         let pending =
-           pending_without_active_sources ~active_source_stimuli pending
-         in
-         if Keeper_event_queue.is_empty pending
-         then Ok None
-         else (
-           let summary =
-             Keeper_agent_run.durable_stimulus_summary
-               ~now:(Time_compat.now ())
-               pending
-           in
-           Log.Keeper.info
-             ~keeper_name
-             "autonomous turn yields to durable stimulus: %s"
-             (Keeper_agent_run.durable_stimulus_summary_to_string summary);
-           Ok
-             (Some
-                Keeper_agent_run.
-                  { reason = Durable_stimulus_waiting summary })))
-;;
-
 (** [run] operates on the immutable [Keeper_unified_turn_types.turn_state]
     accumulator instead of casual [ref] cells. *)
 
@@ -127,10 +77,11 @@ type ctx =
   ; turn_id : int
   ; deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option
   ; on_deferred_runtime_consumed : (unit -> unit) option
-  ; active_source_stimuli : Keeper_event_queue.stimulus list
   }
 
 let run (ctx : ctx)
+      ~(autonomous_yield_requested :
+          unit -> (Keeper_agent_run.autonomous_yield_request option, string) result)
       ~(initial_execution : runtime_execution)
       ~(turn_state : turn_state)
       ~(before_dispatch_authority : unit -> (unit, string) result)
@@ -166,7 +117,6 @@ let run (ctx : ctx)
       ; attempt = _attempt
       ; deferred_runtime_lane
       ; on_deferred_runtime_consumed
-      ; active_source_stimuli
       } =
     ctx
   in
@@ -288,11 +238,7 @@ let run (ctx : ctx)
                       path. Thus the probe is lane-gated and runs only at OAS's
                       post-tool boundary. Its signals come from the exact chat
                       receipt and durable-event queues their consumers drain. *)
-                 ~autonomous_yield_requested:(fun () ->
-                   autonomous_yield_request
-                     ~base_path:config.base_path
-                     ~keeper_name:meta.name
-                     ~active_source_stimuli)
+                 ~autonomous_yield_requested
                  ()
             with
             | Eio.Cancel.Cancelled _ as exn ->
@@ -521,5 +467,4 @@ module For_testing = struct
     | Declared_runtime_lane_exhausted
 
   let declared_lane_failure_of_error = declared_lane_failure_of_error
-  let pending_without_active_sources = pending_without_active_sources
 end

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -132,42 +132,6 @@ let test_runtime_stop_reason_controls_durable_source_completion () =
        (cycle_of_stop_reason
           (Runtime_agent.InputRequired { turns_used = 2; request })))
 
-let test_cooperative_yield_ignores_only_active_source_identity () =
-  let stimulus post_id : Keeper_event_queue.stimulus =
-    { post_id
-    ; urgency = Keeper_event_queue.Normal
-    ; arrived_at = 1_000.0
-    ; payload = Keeper_event_queue.Bootstrap
-    }
-  in
-  let active = stimulus "active-source" in
-  let later = stimulus "later-source" in
-  let filter =
-    Masc.Keeper_unified_turn_execution.For_testing
-    .pending_without_active_sources
-      ~active_source_stimuli:[ active ]
-  in
-  let only_active =
-    Keeper_event_queue.enqueue Keeper_event_queue.empty active
-    |> filter
-  in
-  check int "active source does not yield to itself" 0
-    (Keeper_event_queue.length only_active);
-  let with_later =
-    Keeper_event_queue.empty
-    |> fun queue -> Keeper_event_queue.enqueue queue active
-    |> fun queue -> Keeper_event_queue.enqueue queue later
-    |> filter
-    |> Keeper_event_queue.to_list
-  in
-  match with_later with
-  | [ retained ] ->
-    check string "same payload with a different identity still requests yield"
-      later.post_id
-      retained.post_id
-  | retained ->
-    failf "expected one later durable source, got %d" (List.length retained)
-
 let test_of_result_surface () =
   check outcome "completed with text -> visible" TO.Visible_reply
     (TO.of_result_surface ~response_text:"done" Runtime_agent.Completed);
@@ -570,8 +534,6 @@ let () =
           test_case "of_stop_reason" `Quick test_of_stop_reason;
           test_case "runtime stop reason controls durable source completion" `Quick
             test_runtime_stop_reason_controls_durable_source_completion;
-          test_case "cooperative yield ignores only active source identity" `Quick
-            test_cooperative_yield_ignores_only_active_source_identity;
           test_case "of_result_surface" `Quick test_of_result_surface;
           test_case "external effect wait acknowledgement is visible" `Quick
             test_external_effect_wait_acknowledgement_is_visible;


### PR DESCRIPTION
## Summary
- remove `active_source_stimuli` from the Heartbeat → Cycle → Unified → Execution call chain
- use the existing `wake_reason` attribution as the turn-input SSOT: a nonempty `Woken` only permits chat preemption; an autonomous turn still checks chat, then durable successors
- keep Execution independent of queue/stimulus state by supplying the post-tool callback at the unified-turn boundary

## Incident evidence
On deployed main `95443558dc`, taskmaster repeatedly resumed an OAS checkpoint, selected a durable Board event, then yielded to another already-pending durable event. The selected source never reached its terminal ACK path while successors remained queued.

## Validation
- `git diff --check`
- `ocamlformat --check` on changed OCaml files
- `scripts/dune-local.sh build test/test_keeper_turn_outcome.exe`
- `_build/default/test/test_keeper_turn_outcome.exe` (19 tests)
- source search confirms no `active_source_stimuli`, `durable_stimulus_may_preempt`, or `pending_without_active_sources` remains
- GitHub CI in progress