### PR TITLE
refactor(keeper): require exact turn decision

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -470,7 +470,7 @@ let autonomous_trigger_lines
 
 let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
-    ?(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
+    ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
     ?(current_task : Masc_domain.task option)
     ?(active_goal_summaries : (string * string) list option)
     ~(observation : Keeper_world_observation.world_observation)
@@ -640,16 +640,6 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       observation.connected_surfaces
   in
   let connector_presence_failures = observation.connected_surface_failures in
-  let turn_decision =
-    (* RFC-0315: prefer the scheduler's actual decision (threaded through the
-       turn runner) over a local recompute. The recompute cannot see
-       [reactive_wake] or the drained event-queue triggers, so stimulus-driven
-       wakes would render no wake reason. The recompute remains the fallback
-       for callers that predate the threading. *)
-    match turn_decision with
-    | Some decision -> decision
-    | None -> Keeper_world_observation.keeper_cycle_decision ~meta observation
-  in
   let autonomous_trigger =
     autonomous_trigger_lines ~decision:turn_decision ~observation
   in

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -47,7 +47,7 @@ val build_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
   base_path:string ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
-  ?turn_decision:Keeper_world_observation.keeper_cycle_decision ->
+  turn_decision:Keeper_world_observation.keeper_cycle_decision ->
   ?current_task:Masc_domain.task ->
   ?active_goal_summaries:(string * string) list ->
   observation:Keeper_world_observation.world_observation ->
@@ -58,10 +58,8 @@ val build_prompt :
     tests can keep the bare call.
 
     RFC-0315 wake-turn self-description:
-    - [?turn_decision]: the scheduler's actual cycle decision. When present it
-      replaces the internal recompute, so the rendered wake reason matches the
-      decision that fired the turn (the recompute cannot see [reactive_wake]
-      or drained event-queue triggers). Omitted: legacy recompute.
+    - [turn_decision]: the scheduler's actual cycle decision, required so the
+      rendered wake reason matches the decision that fired the turn.
     - [?current_task]: renders a "Current Task" layer for the task the keeper
       holds ([meta.current_task_id] admits scheduled-autonomous turns, so the
       turn must see the work that admitted it). Omitted: layer absent.

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -712,7 +712,7 @@ let run_keeper_cycle
       ~(generation : int)
       ~(wake : Keeper_registry.wake_reason)
       ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
-      ?(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
+      ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
       ?shared_context
       ?event_bus
       ?hitl_resolution
@@ -1007,7 +1007,7 @@ let run_keeper_cycle
                    ~meta
                    ~base_path:config.base_path
                    ~profile_defaults
-                   ?turn_decision
+                   ~turn_decision
                    ?current_task
                    ~active_goal_summaries
                    ~observation

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -254,7 +254,7 @@ val run_keeper_cycle
   -> generation:int
   -> wake:Keeper_registry.wake_reason
   -> ?channel:Keeper_world_observation.keeper_cycle_channel
-  -> ?turn_decision:Keeper_world_observation.keeper_cycle_decision
+  -> turn_decision:Keeper_world_observation.keeper_cycle_decision
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
@@ -281,5 +281,4 @@ val run_keeper_cycle
     prompt text rather than the registry observation.
     @param turn_decision The scheduler's cycle decision that fired this turn
     (RFC-0315). Threaded into [Keeper_unified_prompt.build_prompt] so the
-    prompt renders the real wake reason instead of a context-blind recompute.
-    Callers that predate the threading may omit it. *)
+    prompt renders the real wake reason without a context-blind recompute. *)

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -131,15 +131,17 @@ let init_prompt_config_for_tests () =
       Masc.Keeper_prompt_external.reset_cache ()
 
 let user_message observation =
+  let turn_decision = WO.keeper_cycle_decision ~meta observation in
   let { Prompt.world_state = user; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~observation ()
+    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision ~observation ()
   in
   user
 
 let system_prompt ?profile_defaults observation =
+  let turn_decision = WO.keeper_cycle_decision ~meta observation in
   let { Prompt.system_prompt = system; _ } =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?profile_defaults
-      ~observation ()
+      ~turn_decision ~observation ()
   in
   system
 
@@ -261,8 +263,16 @@ let sandbox_root_for profile =
   let meta = { meta with Masc.Keeper_meta_contract.sandbox_profile = profile } in
   let base_path = "/tmp/unused" in
   let config = Masc.Workspace.default_config base_path in
+  let turn_decision =
+    WO.keeper_cycle_decision ~meta base_observation
+  in
   let { Prompt.system_prompt; _ } =
-    Prompt.build_prompt ~meta ~base_path ~observation:base_observation ()
+    Prompt.build_prompt
+      ~meta
+      ~base_path
+      ~turn_decision
+      ~observation:base_observation
+      ()
   in
   (system_prompt, Masc.Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
 

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -60,6 +60,16 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 
+let build_prompt meta =
+  let turn_decision = WO.keeper_cycle_decision ~meta base_observation in
+  Masc.Keeper_unified_prompt.build_prompt
+    ~meta
+    ~base_path:"/tmp"
+    ~turn_decision
+    ~observation:base_observation
+    ()
+;;
+
 let contains ~affix s =
   let n = String.length affix and m = String.length s in
   let rec go i = i + n <= m && (String.sub s i n = affix || go (i + 1)) in
@@ -117,8 +127,7 @@ let test_persona_reaches_unified_system_prompt () =
     (Filename.concat persona_dir "AGENT.md")
     "집요하고 직설적. 근본 원인을 잡을 때까지 <blame>을 판다.";
   let { Masc.Keeper_unified_prompt.system_prompt; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:(make_meta "test-keeper")
-      ~base_path:"/tmp" ~observation:base_observation ()
+    build_prompt (make_meta "test-keeper")
   in
   check bool "persona block present" true
     (contains ~affix:"<persona>" system_prompt);
@@ -132,8 +141,7 @@ let test_persona_reaches_unified_system_prompt () =
 let test_no_persona_file_means_no_block () =
   with_config_dir @@ fun ~config_dir:_ ->
   let { Masc.Keeper_unified_prompt.system_prompt; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:(make_meta "test-keeper")
-      ~base_path:"/tmp" ~observation:base_observation ()
+    build_prompt (make_meta "test-keeper")
   in
   check bool "no persona block without persona text" false
     (contains ~affix:"<persona>" system_prompt)
@@ -146,8 +154,7 @@ let test_persona_sits_between_identity_and_shared_body () =
   mkdir_p persona_dir;
   write_file (Filename.concat persona_dir "AGENT.md") "차분하고 꼼꼼함.";
   let { Masc.Keeper_unified_prompt.system_prompt; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:(make_meta "test-keeper")
-      ~base_path:"/tmp" ~observation:base_observation ()
+    build_prompt (make_meta "test-keeper")
   in
   let index_of ~affix =
     let n = String.length affix and m = String.length system_prompt in

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -80,6 +80,18 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
 
 let minimal_meta : Masc.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
 
+let build_prompt ~meta observation =
+  let turn_decision =
+    Masc.Keeper_world_observation.keeper_cycle_decision ~meta observation
+  in
+  Masc.Keeper_unified_prompt.build_prompt
+    ~meta
+    ~base_path:"/tmp"
+    ~turn_decision
+    ~observation
+    ()
+;;
+
 let runtime_toml =
   {|
 [runtime]
@@ -174,12 +186,10 @@ let test_board_authors_share_one_neutral_observation_boundary () =
   let obs_peer = { base_observation with pending_board_events = [ peer_event ] } in
   let obs_human = { base_observation with pending_board_events = [ human_event ] } in
   let { Masc.Keeper_unified_prompt.world_state = peer_msg; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
-      ~observation:obs_peer ()
+    build_prompt ~meta:minimal_meta obs_peer
   in
   let { Masc.Keeper_unified_prompt.world_state = human_msg; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
-      ~observation:obs_human ()
+    build_prompt ~meta:minimal_meta obs_human
   in
   let neutral_boundary = "Rows below are Board context." in
   check bool "automation event uses neutral boundary" true
@@ -223,8 +233,7 @@ let test_board_reaction_event_renders_reaction_context () =
   in
   let obs = { base_observation with pending_board_events = [ reaction_event ] } in
   let { Masc.Keeper_unified_prompt.world_state = user_msg; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
-      ~observation:obs ()
+    build_prompt ~meta:minimal_meta obs
   in
   check bool "prompt labels reaction board event" true
     (contains_sub "event=reaction_changed" user_msg);
@@ -250,8 +259,7 @@ let test_observation_tool_names_are_preserved () =
   in
   let obs = { base_observation with pending_board_events = [ event ] } in
   let { Masc.Keeper_unified_prompt.world_state = user_msg; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
-      ~observation:obs ()
+    build_prompt ~meta:minimal_meta obs
   in
   check bool "keeper diagnostic token remains in observation" true
     (contains_sub "keeper_turn_id=turn-1" user_msg);
@@ -329,8 +337,7 @@ let test_scheduled_automation_prompt_section () =
     { base_observation with scheduled_automation = scheduled_automation_observation }
   in
   let { Masc.Keeper_unified_prompt.world_state = user_msg; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
-      ~observation:obs ()
+    build_prompt ~meta:minimal_meta obs
   in
   check bool "prompt includes schedule section" true
     (contains_sub "### Scheduled Automation" user_msg);
@@ -346,11 +353,7 @@ let test_scheduled_wake_is_not_rendered_as_board_activity () =
     }
   in
   let { Masc.Keeper_unified_prompt.world_state; _ } =
-    Masc.Keeper_unified_prompt.build_prompt
-      ~meta:minimal_meta
-      ~base_path:"/tmp"
-      ~observation:obs
-      ()
+    build_prompt ~meta:minimal_meta obs
   in
   check bool "scheduled wake has dedicated section" true
     (contains_sub "### Scheduled Wake (1 due)" world_state);
@@ -416,8 +419,7 @@ let test_scheduled_wake_preserves_complete_message () =
 let test_world_state_never_in_persisted_user_message () =
   let obs = { base_observation with pending_board_events = [ sample_board_event ] } in
   let { Masc.Keeper_unified_prompt.world_state; user_message; _ } =
-    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
-      ~observation:obs ()
+    build_prompt ~meta:minimal_meta obs
   in
   check bool "world_state carries the frame header" true
     (contains_sub "## Current World State" world_state);

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -4,10 +4,8 @@
    acting lost:
    1. [?current_task] renders a "Current Task" layer for the task whose claim
       admitted the turn (before: current_task_id only suppressed guidance).
-   2. [?turn_decision] threads the scheduler's real cycle decision into the
-      wake-reason section (before: build_prompt recomputed with
-      reactive_wake=false / event_queue_triggers=[], so stimulus-driven wakes
-      rendered no reason).
+   2. [turn_decision] threads the scheduler's real cycle decision into the
+      wake-reason section, so stimulus-driven wakes render their reason.
    3. [?active_goal_summaries] renders goal titles next to ids, and a keeper
       WITH goals receives a self-direction directive (parity with the
       pre-existing no-goal branch). *)
@@ -177,8 +175,13 @@ let make_task ?(handoff_context = None) ~task_status () : Masc_domain.task =
   }
 
 let user_message ?turn_decision ?current_task ?active_goal_summaries observation =
+  let turn_decision =
+    Option.value
+      turn_decision
+      ~default:(WO.keeper_cycle_decision ~meta observation)
+  in
   let { Prompt.world_state = user; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?turn_decision
+    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision
       ?current_task ?active_goal_summaries ~observation ()
   in
   user
@@ -280,7 +283,7 @@ let test_direct_turn_has_no_synthetic_task_context () =
 
 let test_threaded_stimulus_decision_renders_wake_reason () =
   (* A bootstrap event-queue stimulus on an otherwise empty world: the real
-     scheduler decision knows the trigger, the legacy recompute cannot. *)
+     scheduler decision knows the trigger; a local recompute cannot. *)
   let decision =
     WO.keeper_cycle_decision
       ~event_queue_triggers:[ WO.Bootstrap_stimulus ]
@@ -294,14 +297,6 @@ let test_threaded_stimulus_decision_renders_wake_reason () =
     (contains ~needle:"- Scheduler: reactive turn (external stimulus)." threaded);
   check bool "bootstrap reason listed" true
     (contains ~needle:"bootstrap" threaded)
-
-let test_unthreaded_recompute_renders_no_reason_on_empty_world () =
-  (* Same empty world without the threaded decision: the recompute sees no
-     trigger, so no wake-reason section renders — the pre-RFC-0315 blindness
-     this change removes for stimulus wakes. *)
-  let user = user_message base_observation in
-  check bool "no reactive scheduler line" false
-    (contains ~needle:"- Scheduler: reactive turn (external stimulus)." user)
 
 (* --- 3. Goal titles + self-direction parity --- *)
 
@@ -346,17 +341,23 @@ let test_goal_holder_gets_self_direction_directive () =
           ("active_goal_ids", `List [ `String "goal-x" ]);
         ])
   in
+  let goal_turn_decision =
+    WO.keeper_cycle_decision ~meta:meta_with_goal base_observation
+  in
   let { Prompt.system_prompt = system; _ } =
     Prompt.build_prompt ~meta:meta_with_goal ~base_path:"/tmp/unused"
-      ~observation:base_observation ()
+      ~turn_decision:goal_turn_decision ~observation:base_observation ()
   in
   check bool "goal-holder directive present" true
     (contains ~needle:"advance one of your active" system);
   check bool "defer is stated as valid" true
     (contains ~needle:"Deferring is a valid choice" system);
+  let no_goal_turn_decision =
+    WO.keeper_cycle_decision ~meta base_observation
+  in
   let { Prompt.system_prompt = no_goal_system; _ } =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused"
-      ~observation:base_observation ()
+      ~turn_decision:no_goal_turn_decision ~observation:base_observation ()
   in
   check bool "no-goal branch keeps its own directive" true
     (contains ~needle:"You have no active goal" no_goal_system);
@@ -383,8 +384,6 @@ let () =
         [
           test_case "stimulus decision renders wake reason" `Quick
             test_threaded_stimulus_decision_renders_wake_reason;
-          test_case "unthreaded recompute stays blind on empty world" `Quick
-            test_unthreaded_recompute_renders_no_reason_on_empty_world;
         ] );
       ( "goal titles and parity directive",
         [


### PR DESCRIPTION
## Scope

Follow-up to merged #26236. Remove the past-caller compatibility path that allowed a Keeper turn to omit the scheduler decision and locally recompute a weaker value.

## Feature trace

- Origin: `Keeper_heartbeat_loop_scheduling` creates the exact `keeper_cycle_decision`.
- Entrypoint: `Keeper_heartbeat_loop` passes it through `Keeper_heartbeat_loop_cycle.run_keeper_cycle`.
- Consumer: `Keeper_unified_turn.run_keeper_cycle` requires it and `Keeper_unified_prompt.build_prompt` renders the exact wake reasons.
- Blast radius: the two current function contracts and prompt-focused tests only.

Every production caller already supplied the decision. The optional arguments, fallback recompute, and test that blessed the missing-decision behavior are removed. No migration, compatibility reader, fallback, new Gate, or facade is added.

## Verification at `19b45a2d2379ce0d3f8b5a6ddf96db2a69314c77`

- `ocamlformat --check` for every changed `.ml`/`.mli` file — PASS
- `ocamlc -stop-after parsing` for every changed `.ml`/`.mli` file — PASS
- `git diff --check` — PASS
- Local Dune intentionally not run; exact-head CI is authoritative.