### PR TITLE
refactor(keeper): delete duplicate attention claim state

### DIFF
--- a/docs/rfc/RFC-0241-external-attention-store-lifecycle.md
+++ b/docs/rfc/RFC-0241-external-attention-store-lifecycle.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0241"
 title: "external-attention store lifecycle: read-side bound, retention, and typed tail-dedup"
-status: Draft
+status: Retired
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-07-29
 author: vincent
 supersedes: []
 superseded_by: null
@@ -12,6 +12,10 @@ implementation_prs: []
 ---
 
 # RFC-0241 — external-attention store lifecycle
+
+> Retired 2026-07-29. The proposed in-progress claim and stale-timeout model
+> was removed rather than carried forward; exact event-queue selection is the
+> only delivery-completion state.
 
 ## §1 Problem (evidence-grounded, measured)
 

--- a/docs/rfc/RFC-connector-ambient-attention-wake.md
+++ b/docs/rfc/RFC-connector-ambient-attention-wake.md
@@ -132,7 +132,7 @@ synchronous reply path (`lib/server/server_discord_in_process_gateway.ml:310`).
 The first implementation slices have since landed:
 
 - #22818 added the dormant `Connector_attention` stimulus, `Connector_attention_pending`
-  turn reason, intake mapping, and turn-start `claim_for_turn`
+  turn reason and intake mapping
   (`lib/keeper/keeper_heartbeat_stimulus_intake.ml:79`,
   `lib/keeper/keeper_heartbeat_stimulus_intake.ml:146-183`).
 - #22825 added the gated `handle_ambient` producer, wakeup hint, prompt content
@@ -141,23 +141,12 @@ The first implementation slices have since landed:
   (`lib/server/server_discord_in_process_gateway.ml:617-643`,
   `lib/keeper/keeper_heartbeat_loop.ml:140-170`).
 
-The lifecycle contract for every implementation slice remains:
-
-- **Turn start**: `claim_for_turn` the surfaced event_ids, so concurrent cycles
-  and the digest stop re-projecting them as pending for `claim_stale_after`
-  (`default_claim_stale_after_s`, currently 900s).
-- **Turn end**: `mark_resolved` (the keeper replied) or `mark_ignored` (the keeper
-  woke, read, and decided no reply — `mark_ignored` is the existing primitive for
-  exactly this, `lib/keeper/keeper_external_attention.mli:162`).
-- A **claimed-but-never-resolved** item re-surfaces after the stale-claim window
-  and can re-wake forever, so turn execution MUST terminalize via a finally-style
-  guard (`Fun.protect`, `Eio.Switch.on_release`, or the supervisor turn-end hook).
-  Prose intent is not sufficient; cancellation/exception paths must reach
-  `Resolved`/`Ignored` or explicitly requeue/release.
-
-This is shared with the dispatched path's resolution model and must not race the
-gateway fiber writing to the same per-keeper JSONL (`project_pending` is already
-order-robust: `Terminal` is sticky, §3 of the lifecycle).
+The event queue owns delivery completion: intake reads the recorded attention,
+the Keeper runs the exact selected queue entry, and the entry is removed only
+after that turn has completed. Checkpoints, input requests, and non-terminal
+failures leave the queue entry in place. The attention log has no in-progress
+claim or timeout state. `mark_resolved` remains the direct-reply record, while
+`mark_ignored` records a completed no-reply decision for the attention views.
 
 ### 3.5 Outbound: the reply reaches the channel
 
@@ -241,7 +230,7 @@ remaining policy/readiness gaps.
 | Phase | Scope | Independently mergeable? |
 |---|---|---|
 | P1 | `Connector_attention` stimulus + `Connector_attention_pending` turn_reason + intake mapping + affordance gate (§3.1–3.2). | landed in #22818; no producer on its own |
-| P2 | Resolution lifecycle: `claim_for_turn` at turn-start and terminal `mark_resolved`/`mark_ignored` at turn-end (§3.4). | turn-start landed in #22818; turn-end ignore path landed in #22825 |
+| P2 | Exact queue selection remains until its turn completes; direct reply/no-reply history is written after completion (§3.4). | landed |
 | P3 | `handle_ambient` enqueues the stimulus + flips wakeup; prompt content layer; outbound via `Keeper_chat_queue` (§3.1, §3.3, §3.5). | landed behind feature flag in #22825 |
 | P4 | Spurious-wake gating (urgency throttle + debounce, §3.6), then enable. | gating landed in #22825; enabling remains an operator rollout decision |
 

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -17,8 +17,6 @@ let ensure_attention_dir ~base_path =
 
 let persistence_surface = "keeper_external_attention"
 
-let default_claim_stale_after_s = 900.0
-
 (* Dedup scan window for [record]. The store is append-only and
    unbounded, so parsing the whole file on every record is O(file) per
    call — O(N^2) across N inbound messages on the Discord hot path. The
@@ -90,12 +88,6 @@ type item = {
 
 type event =
   | Recorded of item
-  | Claimed_for_turn of {
-      event_id : string;
-      claim_id : string;
-      turn_id : int option;
-      claimed_at : float;
-    }
   | Resolved of {
       event_id : string;
       resolved_at : float;
@@ -133,10 +125,6 @@ let opt_string_field key = function
   | None -> []
   | Some value -> [ (key, `String value) ]
 
-let opt_int_field key = function
-  | None -> []
-  | Some value -> [ (key, `Int value) ]
-
 let string_assoc_json fields =
   `Assoc (List.map (fun (key, value) -> (key, `String value)) fields)
 
@@ -163,14 +151,6 @@ let optional_string key = function
       match List.assoc_opt key fields with
       | Some (`String value) when String.trim value <> "" -> Some value
       | Some (`String _) | Some `Null | None -> None
-      | Some _ -> None)
-  | _ -> None
-
-let optional_int key = function
-  | `Assoc fields -> (
-      match List.assoc_opt key fields with
-      | Some (`Int value) -> Some value
-      | Some `Null | None -> None
       | Some _ -> None)
   | _ -> None
 
@@ -315,14 +295,6 @@ let item_of_json json =
 
 let event_to_json = function
   | Recorded item -> `Assoc [ ("event", `String "recorded"); ("item", item_to_json item) ]
-  | Claimed_for_turn { event_id; claim_id; turn_id; claimed_at } ->
-      `Assoc
-        ([ ("event", `String "claimed_for_turn");
-           ("event_id", `String event_id);
-           ("claim_id", `String claim_id);
-           ("claimed_at", `Float claimed_at);
-         ]
-        @ opt_int_field "turn_id" turn_id)
   | Resolved { event_id; resolved_at; reason } ->
       `Assoc
         [
@@ -347,18 +319,6 @@ let event_of_json json =
       let* item_json = required_object "item" json in
       let* item = item_of_json item_json in
       Ok (Recorded item)
-  | "claimed_for_turn" ->
-      let* event_id = required_string "event_id" json in
-      let* claim_id = required_string "claim_id" json in
-      let* claimed_at = required_float "claimed_at" json in
-      Ok
-        (Claimed_for_turn
-           {
-             event_id;
-             claim_id;
-             turn_id = optional_int "turn_id" json;
-             claimed_at;
-           })
   | "resolved" ->
       let* event_id = required_string "event_id" json in
       let* resolved_at = required_float "resolved_at" json in
@@ -474,7 +434,7 @@ let recorded_item_by_event_id events event_id =
   List.find_map
     (function
       | Recorded item when String.equal item.event_id event_id -> Some item
-      | Recorded _ | Claimed_for_turn _ | Resolved _ | Ignored _ -> None)
+      | Recorded _ | Resolved _ | Ignored _ -> None)
     events
 
 (* Events from the last [dedup_window_bytes] of the store, for the
@@ -536,15 +496,6 @@ let append_many ~base_path ~keeper_name events =
         (sanitize_name keeper_name) detail;
       Error detail
 
-let claim_for_turn ~base_path ~keeper_name ~event_ids ~claim_id ~turn_id ?now () =
-  let claimed_at = now_or_default now in
-  let events =
-    List.map
-      (fun event_id -> Claimed_for_turn { event_id; claim_id; turn_id; claimed_at })
-      event_ids
-  in
-  append_many ~base_path ~keeper_name events
-
 let mark_resolved ~base_path ~keeper_name ~event_ids ~reason ?now () =
   let resolved_at = now_or_default now in
   let events =
@@ -565,22 +516,17 @@ let mark_ignored ~base_path ~keeper_name ~event_ids ~reason ?now () =
 
 type projected_state =
   | Pending of item
-  | Claimed of item * float
   | Terminal
 
-let project_pending events ~now ~claim_stale_after =
+let project_pending events =
   let tbl : (string, projected_state) Hashtbl.t = Hashtbl.create 16 in
   List.iter
     (function
       | Recorded item -> (
           match Hashtbl.find_opt tbl item.event_id with
           | Some Terminal -> ()
-          | Some (Claimed _ | Pending _) | None ->
+          | Some (Pending _) | None ->
               Hashtbl.replace tbl item.event_id (Pending item))
-      | Claimed_for_turn { event_id; claimed_at; _ } -> (
-          match Hashtbl.find_opt tbl event_id with
-          | Some (Pending item) -> Hashtbl.replace tbl event_id (Claimed (item, claimed_at))
-          | Some (Claimed _ | Terminal) | None -> ())
       | Resolved { event_id; _ } | Ignored { event_id; _ } ->
           Hashtbl.replace tbl event_id Terminal)
     events;
@@ -588,10 +534,7 @@ let project_pending events ~now ~claim_stale_after =
     (fun _ state acc ->
       match state with
       | Pending item -> item :: acc
-      | Claimed (item, claimed_at)
-        when now -. claimed_at > claim_stale_after ->
-          item :: acc
-      | Claimed _ | Terminal -> acc)
+      | Terminal -> acc)
     tbl []
   |> List.sort (fun a b -> compare a.received_at b.received_at)
 
@@ -603,20 +546,13 @@ let take limit items =
   in
   loop limit [] items
 
-let pending_for_keeper_result ~base_path ~keeper_name ?now ?claim_stale_after ~limit () =
-  let now = now_or_default now in
-  let claim_stale_after =
-    match claim_stale_after with
-    | Some seconds -> seconds
-    | None -> default_claim_stale_after_s
-  in
+let pending_for_keeper_result ~base_path ~keeper_name ~limit () =
   let* events = load_events_result ~base_path ~keeper_name in
-  Ok (events |> project_pending ~now ~claim_stale_after |> take (max 0 limit))
+  Ok (events |> project_pending |> take (max 0 limit))
 
-let pending_for_keeper ~base_path ~keeper_name ?now ?claim_stale_after ~limit () =
+let pending_for_keeper ~base_path ~keeper_name ~limit () =
   match
-    pending_for_keeper_result ~base_path ~keeper_name ?now ?claim_stale_after
-      ~limit ()
+    pending_for_keeper_result ~base_path ~keeper_name ~limit ()
   with
   | Ok pending -> pending
   | Error msg ->

--- a/lib/keeper/keeper_external_attention.mli
+++ b/lib/keeper/keeper_external_attention.mli
@@ -71,12 +71,6 @@ type item = {
 
 type event =
   | Recorded of item
-  | Claimed_for_turn of {
-      event_id : string;
-      claim_id : string;
-      turn_id : int option;
-      claimed_at : float;
-    }
   | Resolved of {
       event_id : string;
       resolved_at : float;
@@ -87,9 +81,6 @@ type event =
       ignored_at : float;
       reason : string;
     }
-
-(** Default stale claim timeout used by {!pending_for_keeper}. *)
-val default_claim_stale_after_s : float
 
 val event_id_of_dedupe_key : string -> string
 
@@ -141,16 +132,6 @@ val record : base_path:string -> item -> record_result
 
 val attention_path : base_path:string -> keeper_name:string -> string
 
-val claim_for_turn :
-  base_path:string ->
-  keeper_name:string ->
-  event_ids:string list ->
-  claim_id:string ->
-  turn_id:int option ->
-  ?now:float ->
-  unit ->
-  (unit, string) result
-
 val mark_resolved :
   base_path:string ->
   keeper_name:string ->
@@ -177,20 +158,14 @@ val load_events : base_path:string -> keeper_name:string -> event list
 val pending_for_keeper :
   base_path:string ->
   keeper_name:string ->
-  ?now:float ->
-  ?claim_stale_after:float ->
   limit:int ->
   unit ->
   item list
-(** Returns pending items ordered by [received_at], capped to [limit].
-    A non-terminal claim older than [claim_stale_after] is projected back
-    to pending instead of dropped. *)
+(** Returns pending items ordered by [received_at], capped to [limit]. *)
 
 val pending_for_keeper_result :
   base_path:string ->
   keeper_name:string ->
-  ?now:float ->
-  ?claim_stale_after:float ->
   limit:int ->
   unit ->
   (item list, string) result

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -197,121 +197,91 @@ let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
     stimuli
 ;;
 
-(* One turn decides whether to ACK its source selection. Acking the selection
-   and committing the scheduled occurrence terminal are two effects of that
-   single decision, not two decisions: an acked selection whose occurrence is
-   still [dispatched] leaks that row forever, because the stimulus that would
-   have carried it back to a turn is gone. Deriving both from one value keeps
-   them from drifting — a new cycle outcome or source disposition forces one
-   edit here instead of two that no compiler can cross-check. *)
-type scheduled_work_terminal =
-  | Scheduled_work_succeeded
-  | Scheduled_work_failed of string
-
-type turn_source_ack =
-  | Ack_source of scheduled_work_terminal
-  | Keep_source_pending
-
-let turn_source_ack_of_cycle_outcome = function
-  | None -> Keep_source_pending
-  | Some Cycle.Completed _
-  | Some Cycle.Manual_compaction_applied _
-  | Some Cycle.Manual_compaction_not_applied _ ->
-    Ack_source Scheduled_work_succeeded
-  | Some Cycle.Checkpointed _
-  | Some Cycle.Input_required _ ->
-    Keep_source_pending
-  | Some (Cycle.Failed { failure; _ }) ->
-    (match failure.Keeper_unified_turn.source_disposition with
-     | Keeper_unified_turn.Acknowledge_after_in_turn_handling
-     | Keeper_unified_turn.Escalate_after_exact_output_terminal _ ->
-       Ack_source
-         (Scheduled_work_failed
-            (Agent_sdk.Error.to_string failure.Keeper_unified_turn.error))
-     | Keeper_unified_turn.Follow_failure_route
-     | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
-     | Keeper_unified_turn.Requeue_after_context_compaction _
-     | Keeper_unified_turn.Pause_after_transcript_corruption _ ->
-       Keep_source_pending)
-  | Some Cycle.Cancelled _
-  | Some Cycle.Skipped _
-  | Some Cycle.Busy _
-  | Some Cycle.Manual_compaction_failed _ ->
-    Keep_source_pending
+let complete_schedule_due ~ctx ~keeper_name stimuli =
+  let now = Time_compat.now () in
+  let rec loop = function
+    | [] -> Ok ()
+    | (stimulus : Keeper_event_queue.stimulus) :: rest ->
+      (match stimulus.payload with
+       | Keeper_event_queue.Schedule_due wake ->
+         let detail =
+           `Assoc
+             [ "kind", `String "keeper.turn_terminal"
+             ; "keeper_name", `String keeper_name
+             ; "occurrence_id", `String stimulus.post_id
+             ; "outcome", `String "succeeded"
+             ]
+         in
+         (match
+            Schedule_store.complete_dispatched_occurrence
+              ctx.config
+              ~now
+              ~schedule_id:wake.schedule_id
+              ~due_at:wake.due_at
+              ~payload_digest:wake.payload_digest
+              ~detail
+              ()
+          with
+          | Ok _ -> loop rest
+          | Error err ->
+            Error
+              (Printf.sprintf
+                 "schedule completion write failed schedule_id=%s occurrence_id=%s: %s"
+                 wake.schedule_id
+                 stimulus.post_id
+                 (Schedule_store.store_error_to_string err)))
+       | Keeper_event_queue.Board_signal _
+       | Keeper_event_queue.Board_attention _
+       | Keeper_event_queue.Fusion_completed _
+       | Keeper_event_queue.Bg_completed _
+       | Keeper_event_queue.Bootstrap
+       | Keeper_event_queue.Connector_attention _
+       | Keeper_event_queue.Hitl_resolved _
+       | Keeper_event_queue.Manual_compaction_requested
+       | Keeper_event_queue.Goal_assigned _
+       | Keeper_event_queue.Goal_reconciliation_ready _ ->
+         loop rest)
+  in
+  loop stimuli
 ;;
 
-(* A source is released only once its scheduled occurrence has a terminal row
-   on disk. *)
-let source_ack_is_due = function
-  | Ack_source _ -> true
-  | Keep_source_pending -> false
-;;
-
-let persist_scheduled_work_terminal ~ctx ~keeper_name ~source_ack stimuli =
-  match source_ack with
-  | Keep_source_pending -> Ok ()
-  | Ack_source terminal ->
-    let now = Time_compat.now () in
-    let rec loop = function
-      | [] -> Ok ()
-      | (stimulus : Keeper_event_queue.stimulus) :: rest ->
-        (match stimulus.payload with
-         | Keeper_event_queue.Schedule_due wake ->
-           let detail =
-             `Assoc
-               [ "kind", `String "keeper.turn_terminal"
-               ; "keeper_name", `String keeper_name
-               ; "occurrence_id", `String stimulus.post_id
-               ; ( "outcome"
-                 , `String
-                     (match terminal with
-                      | Scheduled_work_succeeded -> "succeeded"
-                      | Scheduled_work_failed _ -> "failed") )
-               ]
-           in
-           let result =
-             match terminal with
-             | Scheduled_work_succeeded ->
-               Schedule_store.complete_dispatched_occurrence
-                 ctx.config
-                 ~now
-                 ~schedule_id:wake.schedule_id
-                 ~due_at:wake.due_at
-                 ~payload_digest:wake.payload_digest
-                 ~detail
-                 ()
-             | Scheduled_work_failed error ->
-               Schedule_store.fail_dispatched_occurrence
-                 ctx.config
-                 ~now
-                 ~schedule_id:wake.schedule_id
-                 ~due_at:wake.due_at
-                 ~payload_digest:wake.payload_digest
-                 ~error
-           in
-           (match result with
-            | Ok _ -> loop rest
-            | Error err ->
-              Error
-                (Printf.sprintf
-                   "schedule occurrence terminal commit failed schedule_id=%s \
-                    occurrence_id=%s: %s"
-                   wake.schedule_id
-                   stimulus.post_id
-                   (Schedule_store.store_error_to_string err)))
-         | Keeper_event_queue.Board_signal _
-         | Keeper_event_queue.Board_attention _
-         | Keeper_event_queue.Fusion_completed _
-         | Keeper_event_queue.Bg_completed _
-         | Keeper_event_queue.Bootstrap
-         | Keeper_event_queue.Connector_attention _
-         | Keeper_event_queue.Hitl_resolved _
-         | Keeper_event_queue.Manual_compaction_requested
-         | Keeper_event_queue.Goal_assigned _
-         | Keeper_event_queue.Goal_reconciliation_ready _ ->
-           loop rest)
-    in
-    loop stimuli
+let fail_schedule_due ~ctx ~error stimuli =
+  let now = Time_compat.now () in
+  let rec loop = function
+    | [] -> Ok ()
+    | (stimulus : Keeper_event_queue.stimulus) :: rest ->
+      (match stimulus.payload with
+       | Keeper_event_queue.Schedule_due wake ->
+         (match
+            Schedule_store.fail_dispatched_occurrence
+              ctx.config
+              ~now
+              ~schedule_id:wake.schedule_id
+              ~due_at:wake.due_at
+              ~payload_digest:wake.payload_digest
+              ~error
+          with
+          | Ok _ -> loop rest
+          | Error err ->
+            Error
+              (Printf.sprintf
+                 "schedule failure write failed schedule_id=%s occurrence_id=%s: %s"
+                 wake.schedule_id
+                 stimulus.post_id
+                 (Schedule_store.store_error_to_string err)))
+       | Keeper_event_queue.Board_signal _
+       | Keeper_event_queue.Board_attention _
+       | Keeper_event_queue.Fusion_completed _
+       | Keeper_event_queue.Bg_completed _
+       | Keeper_event_queue.Bootstrap
+       | Keeper_event_queue.Connector_attention _
+       | Keeper_event_queue.Hitl_resolved _
+       | Keeper_event_queue.Manual_compaction_requested
+       | Keeper_event_queue.Goal_assigned _
+       | Keeper_event_queue.Goal_reconciliation_ready _ ->
+         loop rest)
+  in
+  loop stimuli
 ;;
 
 let mark_connector_attention_ignored_after_turn ~base_path ~keeper_name event_ids =
@@ -434,10 +404,6 @@ module For_testing = struct
     | Transcript_pause_settlement_failed of string
 
   let commit_transcript_corruption = commit_transcript_corruption
-  let cycle_outcome_acks_source cycle_outcome =
-    turn_source_ack_of_cycle_outcome (Some cycle_outcome)
-    |> source_ack_is_due
-  ;;
 
 end
 
@@ -841,45 +807,66 @@ let run_keepalive_unified_turn
           None
       in
       let meta_after_cycle = meta_after_cycle in
-      let turn_source_ack =
-        turn_source_ack_of_cycle_outcome !cycle_outcome_ref
-      in
-      let scheduled_work_terminal_committed =
-        match
-          persist_scheduled_work_terminal
-            ~ctx
-            ~keeper_name:meta_after_triage.name
-            ~source_ack:turn_source_ack
-            !consumed_stimuli
-        with
-        | Ok () -> true
-        | Error message ->
-          record_event_queue_failure message;
-          false
-      in
-      (* Pending remains the authority throughout execution. Remove only an
-         exact selection whose turn completed or handled its source locally. *)
       (if Option.is_none transcript_corruption_commit
        then
          match !pending_selection with
-       | None -> ()
-       | Some selection ->
-         let should_ack = source_ack_is_due turn_source_ack in
-         if should_ack && scheduled_work_terminal_committed
-         then
-           match
-             Keeper_registry_event_queue.ack_pending_result
-               ~base_path:ctx.config.base_path
-               meta_after_triage.name
-               ~selection
-           with
-           | Ok () ->
-             selection_acked := true;
-             mark_connector_attention_ignored_after_turn
-               ~base_path:ctx.config.base_path
-               ~keeper_name:meta_after_triage.name
-               (connector_attention_event_ids_of_stimuli !consumed_stimuli)
-           | Error message -> record_event_queue_failure message);
+         | None -> ()
+         | Some selection ->
+           let remove_completed_selection () =
+             match
+               Keeper_registry_event_queue.ack_pending_result
+                 ~base_path:ctx.config.base_path
+                 meta_after_triage.name
+                 ~selection
+             with
+             | Ok () ->
+               selection_acked := true;
+               mark_connector_attention_ignored_after_turn
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:meta_after_triage.name
+                 (connector_attention_event_ids_of_stimuli !consumed_stimuli)
+             | Error message -> record_event_queue_failure message
+           in
+           match !cycle_outcome_ref with
+           | Some
+               ( Cycle.Completed _
+               | Cycle.Manual_compaction_applied _
+               | Cycle.Manual_compaction_not_applied _ ) ->
+             (match
+                complete_schedule_due
+                  ~ctx
+                  ~keeper_name:meta_after_triage.name
+                  !consumed_stimuli
+              with
+              | Ok () -> remove_completed_selection ()
+              | Error message -> record_event_queue_failure message)
+           | Some (Cycle.Failed { failure; _ }) ->
+             (match failure.Keeper_unified_turn.source_disposition with
+              | Keeper_unified_turn.Acknowledge_after_in_turn_handling
+              | Keeper_unified_turn.Escalate_after_exact_output_terminal _ ->
+                (match
+                   fail_schedule_due
+                     ~ctx
+                     ~error:
+                       (Agent_sdk.Error.to_string failure.Keeper_unified_turn.error)
+                     !consumed_stimuli
+                 with
+                 | Ok () -> remove_completed_selection ()
+                 | Error message -> record_event_queue_failure message)
+              | Keeper_unified_turn.Follow_failure_route
+              | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
+              | Keeper_unified_turn.Requeue_after_context_compaction _
+              | Keeper_unified_turn.Pause_after_transcript_corruption _ ->
+                ())
+           | Some
+               ( Cycle.Checkpointed _
+               | Cycle.Input_required _
+               | Cycle.Cancelled _
+               | Cycle.Skipped _
+               | Cycle.Busy _
+               | Cycle.Manual_compaction_failed _ )
+           | None ->
+             ());
       (* RFC-0351 S0 / #25461: advance the compaction streak read by the trigger.
          [Keeper_post_turn] refuses another compaction once the streak reaches
          [compaction_retry_escalation_threshold]. This update is intentionally

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -245,9 +245,4 @@ module For_testing : sig
     unit ->
     transcript_corruption_commit
 
-  val cycle_outcome_acks_source :
-    Keeper_heartbeat_loop_cycle.cycle_outcome -> bool
-  (** [true] only when the cycle terminally handled its durable source.
-      Checkpoint and input-required outcomes remain replayable. *)
-
 end

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -188,7 +188,6 @@ let recorded_attention_item_by_event_id ~base_path ~keeper_name ~event_id =
          when String.equal item.Keeper_external_attention.event_id event_id ->
          Some item
        | Keeper_external_attention.Recorded _
-       | Keeper_external_attention.Claimed_for_turn _
        | Keeper_external_attention.Resolved _
        | Keeper_external_attention.Ignored _ ->
          None)
@@ -317,22 +316,6 @@ let consume_single_heartbeat_stimulus
             meta_after_triage.name;
           []
       in
-      (match
-         Keeper_external_attention.claim_for_turn
-           ~base_path:ctx.config.base_path
-           ~keeper_name:meta_after_triage.name
-           ~event_ids:[ ca.event_id ]
-           ~claim_id:(Printf.sprintf "heartbeat-wake:%s" stim.post_id)
-           ~turn_id:None
-           ()
-       with
-       | Ok () -> ()
-       | Error err ->
-         Log.Keeper.warn
-           "connector attention claim_for_turn failed event_id=%s (keeper=%s): %s"
-           ca.event_id
-           meta_after_triage.name
-           err);
       Log.Keeper.info
         "turn entry: connector attention stimulus consumed event_id=%s (keeper=%s)"
         ca.event_id

--- a/test/test_keeper_external_attention.ml
+++ b/test/test_keeper_external_attention.ml
@@ -13,10 +13,6 @@ let temp_base_path prefix =
   Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
 
-let expect_ok = function
-  | Ok () -> ()
-  | Error detail -> Alcotest.failf "expected Ok, got Error %s" detail
-
 let discord_surface ?thread_id ?parent_channel_id channel_id =
   A.Discord
     {
@@ -78,14 +74,6 @@ let test_json_roundtrip () =
   check_roundtrip "item" A.item_to_json A.item_of_json att;
   check_roundtrip "recorded event" A.event_to_json A.event_of_json
     (A.Recorded att);
-  check_roundtrip "claimed event" A.event_to_json A.event_of_json
-    (A.Claimed_for_turn
-       {
-         event_id = att.A.event_id;
-         claim_id = "claim-1";
-         turn_id = Some 42;
-         claimed_at = 20.0;
-       });
   check_roundtrip "resolved event" A.event_to_json A.event_of_json
     (A.Resolved
        { event_id = att.A.event_id; resolved_at = 30.0; reason = "replied" })
@@ -168,57 +156,6 @@ let test_record_dedupes_and_reads_pending () =
   | pending ->
       Alcotest.failf "expected 1 pending item, got %d" (List.length pending)
 
-let test_claim_resolution_and_ignore_projection () =
-  with_temp_base "keeper-external-attention-lifecycle" @@ fun base_path ->
-  let one = item ~dedupe_key:"discord:chan-1:msg-1" ~received_at:1.0 () in
-  let two = item ~dedupe_key:"discord:chan-1:msg-2" ~received_at:2.0 () in
-  ignore (A.record ~base_path one : A.record_result);
-  ignore (A.record ~base_path two : A.record_result);
-  expect_ok
-    (A.claim_for_turn ~base_path ~keeper_name:"sangsu"
-       ~event_ids:[ one.A.event_id ] ~claim_id:"claim-1" ~turn_id:(Some 7)
-       ~now:10.0 ());
-  let pending =
-    A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:11.0
-      ~claim_stale_after:60.0 ~limit:10 ()
-  in
-  Alcotest.(check (list string)) "claimed item hidden"
-    [ two.A.event_id ]
-    (List.map (fun i -> i.A.event_id) pending);
-  expect_ok
-    (A.mark_resolved ~base_path ~keeper_name:"sangsu"
-       ~event_ids:[ one.A.event_id ] ~reason:"replied" ~now:12.0 ());
-  expect_ok
-    (A.mark_ignored ~base_path ~keeper_name:"sangsu"
-       ~event_ids:[ two.A.event_id ] ~reason:"silent" ~now:13.0 ());
-  Alcotest.(check int) "all terminal" 0
-    (List.length
-       (A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:14.0
-          ~limit:10 ()))
-
-let test_stale_claim_projects_back_to_pending () =
-  with_temp_base "keeper-external-attention-stale-claim" @@ fun base_path ->
-  let att = item () in
-  ignore (A.record ~base_path att : A.record_result);
-  expect_ok
-    (A.claim_for_turn ~base_path ~keeper_name:"sangsu"
-       ~event_ids:[ att.A.event_id ] ~claim_id:"claim-1" ~turn_id:None
-       ~now:10.0 ());
-  Alcotest.(check int) "fresh claim hidden" 0
-    (List.length
-       (A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:11.0
-          ~claim_stale_after:5.0 ~limit:10 ()));
-  match
-    A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:20.0
-      ~claim_stale_after:5.0 ~limit:10 ()
-  with
-  | [ pending ] ->
-      Alcotest.(check string) "stale claim recovered" att.A.event_id
-        pending.A.event_id
-  | pending ->
-      Alcotest.failf "expected recovered pending item, got %d"
-        (List.length pending)
-
 let test_discord_channel_and_thread_conversation_ids_stay_distinct () =
   let channel =
     conversation ~surface:(discord_surface "chan-1") "discord:guild-1:chan-1"
@@ -245,10 +182,6 @@ let () =
             test_record_dedupes_and_reads_pending;
           Alcotest.test_case "record dedup window is bounded (F943)" `Quick
             test_record_dedup_window_bounded;
-          Alcotest.test_case "claim, resolve, ignore projection" `Quick
-            test_claim_resolution_and_ignore_projection;
-          Alcotest.test_case "stale claim projects back to pending" `Quick
-            test_stale_claim_projects_back_to_pending;
           Alcotest.test_case "Discord channel/thread lanes are distinct" `Quick
             test_discord_channel_and_thread_conversation_ids_stay_distinct;
         ] );

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -16,9 +16,6 @@ open Alcotest
 module TO = Masc.Keeper_turn_outcome
 module Ops = Masc.Keeper_tool_surface_ops
 module Stream = Server_routes_http_keeper_stream
-module UT = Masc.Keeper_unified_turn
-module Cycle = Masc.Keeper_heartbeat_loop_cycle
-module Heartbeat = Masc.Keeper_heartbeat_loop.For_testing
 module Response_text = Masc.Keeper_agent_run_response_text
 
 let outcome : TO.t testable =
@@ -73,64 +70,6 @@ let test_of_stop_reason () =
   check outcome "typed input required -> visible" TO.Visible_reply
     (TO.of_stop_reason
        (Runtime_agent.InputRequired { turns_used = 2; request }))
-
-let test_runtime_stop_reason_controls_durable_source_completion () =
-  let meta =
-    match
-      Masc_test_deps.meta_of_json_fixture
-        (`Assoc
-          [ "name", `String "turn-outcome-source"
-          ; "trace_id", `String "trace-turn-outcome-source"
-          ])
-    with
-    | Ok meta -> meta
-    | Error detail -> fail detail
-  in
-  let request : Agent_sdk.Error.input_required =
-    { request_id = "source-input-1"
-    ; participant_name = None
-    ; question = "Need operator input"
-    ; schema = None
-    ; timeout_s = None
-    ; created_at = 1_000.0
-    }
-  in
-  let cycle_of_stop_reason stop_reason =
-    match UT.turn_success_of_stop_reason ~meta stop_reason with
-    | UT.Turn_completed meta -> Cycle.Completed meta
-    | UT.Turn_checkpointed meta -> Cycle.Checkpointed meta
-    | UT.Turn_input_required meta -> Cycle.Input_required meta
-    | UT.Turn_cancelled _
-    | UT.Turn_skipped _ ->
-      fail "runtime stop reason mapped outside the executed turn outcomes"
-  in
-  check bool "completed turn ACKs durable source" true
-    (Heartbeat.cycle_outcome_acks_source
-       (cycle_of_stop_reason Runtime_agent.Completed));
-  check bool "chat yield retains durable source" false
-    (Heartbeat.cycle_outcome_acks_source
-       (cycle_of_stop_reason
-          (Runtime_agent.Yielded_to_chat_waiting { turns_used = 2 })));
-  check bool "durable stimulus yield retains durable source" false
-    (Heartbeat.cycle_outcome_acks_source
-       (cycle_of_stop_reason
-          (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 })));
-  check bool "external effect wait retains durable source" false
-    (Heartbeat.cycle_outcome_acks_source
-       (cycle_of_stop_reason
-          (Runtime_agent.Awaiting_external_effect { turns_used = 2 })));
-  check bool "repeated tool yield retains durable source" false
-    (Heartbeat.cycle_outcome_acks_source
-       (cycle_of_stop_reason
-          (Runtime_agent.Yielded_after_repeated_tool_call
-             { turns_used = 2
-             ; tool_name = "keeper_tasks_list"
-             ; repeated_count = 3
-             })));
-  check bool "input required retains durable source" false
-    (Heartbeat.cycle_outcome_acks_source
-       (cycle_of_stop_reason
-          (Runtime_agent.InputRequired { turns_used = 2; request })))
 
 let test_of_result_surface () =
   check outcome "completed with text -> visible" TO.Visible_reply
@@ -532,8 +471,6 @@ let () =
       ( "mapping",
         [
           test_case "of_stop_reason" `Quick test_of_stop_reason;
-          test_case "runtime stop reason controls durable source completion" `Quick
-            test_runtime_stop_reason_controls_durable_source_completion;
           test_case "of_result_surface" `Quick test_of_result_surface;
           test_case "external effect wait acknowledgement is visible" `Quick
             test_external_effect_wait_acknowledgement_is_visible;


### PR DESCRIPTION
## What changed
- Remove external-attention in-progress claim events, stale-timeout projection, API, codec, and dedicated tests.
- Remove the generic Keeper source-settlement enum and test facade.
- Keep completion at the one real boundary: remove the exact queue selection only after the turn completed; write schedule completion/failure only for Schedule_due.
- Retire the obsolete lifecycle RFC and update the active connector RFC.

## Why
The queue already owns exact selection and removal. The extra attention claim state could disagree with it and reappear on a timer.

## Validation
- `scripts/dune-local.sh build test/test_keeper_external_attention.exe test/test_keeper_turn_outcome.exe` (passed before final rebase; current-head CI pending)
- `test_keeper_external_attention.exe` — 4 passed
- `test_keeper_turn_outcome.exe` — 18 passed
- `ocamlformat --check` and `git diff --check`