### PR TITLE
fix(dashboard): thread turn_decision into keeper snapshot prompt preview

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -157,9 +157,16 @@ let keeper_config_json (config : Workspace.config) (name : string)
           Keeper_world_observation.observe
             ~pending_board_events:(Some pending_board_events) ~config ~meta:m
         in
+        (* This is a dashboard preview, not a live turn: no scheduler decision
+           exists to thread through, so the preview declares its own recompute
+           at this boundary (same shape the prompt tests use). A live turn's
+           decision still comes from the scheduler (keeper_unified_turn.ml). *)
+        let turn_decision =
+          Keeper_world_observation.keeper_cycle_decision ~meta:m observation
+        in
         let parts =
           Keeper_unified_prompt.build_prompt ~meta:m ~base_path:config.base_path
-            ~profile_defaults:defaults ~observation ()
+            ~profile_defaults:defaults ~turn_decision ~observation ()
         in
         (* Match what a turn actually sends: the observation frame rides the
            per-turn dynamic context (system side), and the persisted user


### PR DESCRIPTION
## main red 수리 (92299c1b69 이후)

#26243이 `build_prompt`의 `~turn_decision`을 필수화하며 내부 recompute fallback을 제거했는데, 프로덕션 호출부 2곳 중 turn runner만 스레딩되고 **dashboard 스냅샷 프리뷰 호출부가 누락**돼 main이 red가 됐습니다 (`dashboard_http_keeper_snapshot.ml:167` partial-application 타입 에러). #26243의 Build and Test는 cancelled 상태로 머지돼 이 누락이 main에서야 드러났습니다.

## 수정

프리뷰는 라이브 턴이 아니라 스케줄러 결정이 존재하지 않는 자리이므로, **호출부에서 명시적으로 recompute**(`keeper_cycle_decision ~meta observation`)를 계산해 전달합니다 — prompt 테스트 헬퍼들과 같은 형태이며, `build_prompt` 내부의 silent fallback 부활이 아닙니다(#26243의 제거 방향 유지).

- 반경: dashboard 스냅샷 프리뷰 1곳, +8/-1
- 호출부 전수 확인: 프로덕션 2곳(turn runner=완료, 본 수정=프리뷰), 테스트는 #26243이 갱신 완료

## 검증

Build and Test **완주 후** 머지 예정 — 오늘 main red 두 번 모두 CI-미완주 머지에서 나왔습니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
