### PR TITLE
refactor(oas): consume single structured response state

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.230.0`, runtime pin: `main@7a3f2af7aed6fdd19968de3e1637dccb4f867461`, declared base version: `v0.230.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.230.0`, runtime pin: `main@50e1bf1af1af598729c2482e190f8476ecebc3f1`, declared base version: `v0.230.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -3,7 +3,7 @@
     Judge 출력 계약은 **단일 tier**다. [apply_fusion_judge_output_contract]
     (fusion_judge.ml:165-166)는 capability를 읽지 않고
     [Keeper_structured_output_schema.without_response_format]를 무조건 적용한다 —
-    [response_format = Off], [output_schema = None]. 계약은 프롬프트의
+    [response_format = Off]. 계약은 프롬프트의
     {!Fusion_judge_parse.expected_json_doc} 지시로만 나가고, 응답은
     {!Fusion_judge_parse.of_string}의 strict 파싱을 통과해야 하며 위반은
     [Parse_error]로 fail-loud한다.
@@ -39,7 +39,7 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
 
     [judge_model]: runtime_id("provider.model"). [question]/[panel]로 프롬프트를
     구성해 실행하고, [apply_fusion_judge_output_contract](capability 를 읽지 않고
-    무조건 [response_format = Off] / [output_schema = None])를 적용한 응답 텍스트를
+    무조건 [response_format = Off])를 적용한 응답 텍스트를
     {!Fusion_judge_parse.of_string}으로 파싱한다.
     [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
     [max_tokens]는 출력 토큰 예산이다. 생략하면 Runtime_agent 기본값을 보존한다.

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -260,10 +260,7 @@ let fusion_judge_output_schema =
 ;;
 
 let apply_to_provider_config schema (provider_cfg : Llm_provider.Provider_config.t) =
-  { provider_cfg with
-    response_format = Agent_sdk.Types.JsonSchema schema
-  ; output_schema = Some schema
-  }
+  { provider_cfg with response_format = Agent_sdk.Types.JsonSchema schema }
 ;;
 
 (* Ask the provider for no wire response format. The call sites that use this
@@ -286,10 +283,7 @@ let apply_to_provider_config schema (provider_cfg : Llm_provider.Provider_config
    response's visible text, so native and prompt tiers converge on the same
    parser byte for byte. *)
 let without_response_format (provider_cfg : Llm_provider.Provider_config.t) =
-  { provider_cfg with
-    response_format = Agent_sdk.Types.Off
-  ; output_schema = None
-  }
+  { provider_cfg with response_format = Agent_sdk.Types.Off }
 ;;
 
 (* The anti-rationalization reviewer's verdict channel is the
@@ -299,7 +293,7 @@ let without_response_format (provider_cfg : Llm_provider.Provider_config.t) =
    response format constrains only the final assistant text, which this
    surface never parses — while its capability branch rejected every
    json_object-only provider (Glm/DeepSeek/Kimi) as
-   [InvalidConfig "task.anti_rationalization.output_schema"], so the gate
+   [InvalidConfig "task.anti_rationalization.response_format"], so the gate
    never ran and every task stayed nonterminal fleet-wide (live incident
    2026-07-21). Converges with the fusion-judge / consolidation /
    board-attention / librarian surfaces above: no wire

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -1,9 +1,8 @@
 (** Provider-native JSON schemas for MASC LLM sub-call producers.
 
-    These schemas are used as [response_format = JsonSchema _] /
-    [output_schema = Some _] at the OAS provider boundary. The existing
-    domain parsers still own semantic validation after the provider returns
-    JSON. *)
+    These schemas are used as [response_format = JsonSchema _] at the OAS
+    provider boundary. The existing domain parsers still own semantic
+    validation after the provider returns JSON. *)
 
 val librarian_episode_output_schema : Yojson.Safe.t
 (** JSON object the librarian extraction provider must return. *)
@@ -43,12 +42,12 @@ val apply_to_provider_config
   :  Yojson.Safe.t
   -> Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
-(** Set both OAS structured-output fields for [schema]. *)
+(** Set the single OAS structured-output request state for [schema]. *)
 
 val without_response_format
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
-(** Clear both OAS structured-output fields: the request states its output
+(** Clear the OAS structured-output request state: the request states its output
     contract in its prompt and validates the parse downstream, so it asks the
     provider for no wire format at all. Use for call sites whose prompt spells
     out the object shape and whose parser is total — a malformed reply must
@@ -58,8 +57,8 @@ val without_response_format
 val anti_rationalization_reviewer_provider_config
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
-(** Provider config for the task anti-rationalization reviewer: clears both
-    OAS structured-output fields. The verdict channel is the
+(** Provider config for the task anti-rationalization reviewer: clears the OAS
+    structured-output request state. The verdict channel is the
     [report_review_verdict] tool call (exactly-once, total parser in
     [Task.Anti_rationalization]); a wire response format constrained only the
     final assistant text this surface never parses, and its capability branch

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -55,8 +55,8 @@ val provider_for_vision
   -> Llm_provider.Provider_config.t
 (** A one-shot, non-thinking, structured-output vision config: thinking off (avoids the
     2026-06-25 gemma4 thinking-budget exhaustion that produced empty replies),
-    [response_format = JsonSchema _], [output_schema = Some _],
-    [tool_choice = None], the selected provider config's exact temperature
+    [response_format = JsonSchema _], [tool_choice = None], the selected
+    provider config's exact temperature
     (including omission), and a fallback [max_tokens] only when the selected
     runtime has not configured one. *)
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1544,7 +1544,6 @@ let runtime_request_config_json (rt : Runtime.t) =
     ; "tool_choice", tool_choice_json cfg.tool_choice
     ; "disable_parallel_tool_use", `Bool cfg.disable_parallel_tool_use
     ; "response_format", response_format_json cfg.response_format
-    ; "has_output_schema", `Bool (Option.is_some cfg.output_schema)
     ; "cache_system_prompt", `Bool cfg.cache_system_prompt
     ; "supports_tool_choice_override", Json_util.bool_opt_to_json cfg.supports_tool_choice_override
     ; ( "supports_structured_output_override"

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -219,7 +219,7 @@ dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
   "agent_sdk.0.230.0"
-  "git+https://github.com/jeong-sik/oas.git#7a3f2af7aed6fdd19968de3e1637dccb4f867461"
+  "git+https://github.com/jeong-sik/oas.git#50e1bf1af1af598729c2482e190f8476ecebc3f1"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -2,21 +2,19 @@
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.230.0"
-# v0.230.0 makes pre-tool approval a typed, fail-closed boundary:
-# ElicitToolApproval is distinct from generic ElicitInput, and only an exact
-# Approved invocation may execute. The public Exact_output.execute_once
-# shortcut is removed; callers freeze candidates with snapshot_flow, create an
-# affine flow with start_flow, and consume it through execute_flow_once.
-# Previous pin: v0.229.0 (6bf1751a).
+# OAS #2858 hard-cuts the duplicate structured-output state. Provider requests
+# now carry only response_format = Off | JsonMode | JsonSchema; MASC no longer
+# reads or writes the removed output_schema compatibility field.
+# Previous pin: v0.230.0 (7a3f2af7).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
 # main; oas-drift-check.sh also reports the public-surface delta at pin-bump
 # time.
-# Pinned to the v0.230.0 release commit.
+# Pinned to OAS main after #2858/#2862 and the adjacent current-head fixes.
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.230.0"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="7a3f2af7aed6fdd19968de3e1637dccb4f867461"
+readonly OAS_AGENT_SDK_SHA="50e1bf1af1af598729c2482e190f8476ecebc3f1"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.230.0"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,5 +1,5 @@
 {
-  "pinned_sha": "7a3f2af7aed6fdd19968de3e1637dccb4f867461",
+  "pinned_sha": "50e1bf1af1af598729c2482e190f8476ecebc3f1",
   "pinned_version": "v0.230.0",
   "surfaces": {
     "event_bus_payload_variants": [

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -75,10 +75,7 @@ let test_output_contract_keeps_native_schema_when_supported () =
       (match configured.response_format with
        | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal fusion_schema schema
        | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
-    check bool "output_schema mirrors schema" true
-      (match configured.output_schema with
-       | Some schema -> Yojson.Safe.equal fusion_schema schema
-       | None -> false)
+    ()
 
 (* Prompt tier: 기본 카탈로그의 deepseek-v4-pro 항목은 native schema도 json_object
    response format도 선언하지 않으므로, 3-tier 선택기(#25324)에서도 schema 없이
@@ -101,8 +98,7 @@ let test_output_contract_prompt_tier_when_schema_is_not_native () =
       (match configured.response_format with
        | Agent_sdk.Types.Off -> true
        | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
-    check bool "output_schema stays empty (prompt tier)" true
-      (Option.is_none configured.output_schema)
+    ()
 
 (* JSON-mode tier (#25324): json_object response format을 선언한 provider는
    [JsonMode]를 받는다 — 문법 레벨 JSON은 와이어에서 강제되고, 스키마 준수는
@@ -127,8 +123,7 @@ let test_output_contract_json_mode_tier_when_json_object_is_declared () =
       (match configured.response_format with
        | Agent_sdk.Types.JsonMode -> true
        | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
-    check bool "output_schema stays empty (json_mode tier)" true
-      (Option.is_none configured.output_schema)
+    ()
 
 let test_output_contract_prompt_tier_when_no_output_contract_is_known () =
   with_empty_oas_model_catalog @@ fun () ->
@@ -145,8 +140,7 @@ let test_output_contract_prompt_tier_when_no_output_contract_is_known () =
       (match configured.response_format with
        | Agent_sdk.Types.Off -> true
        | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
-    check bool "output_schema stays empty (prompt tier)" true
-      (Option.is_none configured.output_schema)
+    ()
 
 (* 패널 계약 = free text (2026-07-01 사고 회귀 가드). prose가 그대로 답변이 된다 —
    JSON envelope 파싱이 없으므로 "provider가 schema를 무시해 prose를 반환"하는

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -640,7 +640,6 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
           {|{"groups":[{"member_indices":[0,1],"consolidated_claim":"ab","category":"fact"}],"drop_indices":[]}|}
         in
         let seen_response_format = ref None in
-        let seen_output_schema = ref None in
         let seen_prompt_matches_template = ref false in
         let expected_prompt =
           match
@@ -656,7 +655,6 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
             (fun config messages ->
                seen_max_tokens := config.Llm_provider.Provider_config.max_tokens;
                seen_response_format := Some config.Llm_provider.Provider_config.response_format;
-               seen_output_schema := config.Llm_provider.Provider_config.output_schema;
                let rendered_prompt =
                  messages
                  |> List.map text_of_message
@@ -704,10 +702,6 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
                | Atypes.JsonMode | Atypes.JsonSchema _ -> false)
              !seen_response_format);
         Alcotest.(check bool)
-          "no output schema is attached"
-          true
-          (Option.is_none !seen_output_schema);
-        Alcotest.(check bool)
           "prompt registry output is passed through verbatim"
           true
           !seen_prompt_matches_template))))
@@ -738,10 +732,6 @@ let test_resolver_is_capability_independent () =
     (match resolved.Llm_provider.Provider_config.response_format with
      | Atypes.Off -> true
      | Atypes.JsonMode | Atypes.JsonSchema _ -> false);
-  Alcotest.(check bool)
-    "no output_schema is attached"
-    true
-    (Option.is_none resolved.Llm_provider.Provider_config.output_schema);
   Alcotest.(check (option bool))
     "thinking is disabled for the consolidation request"
     (Some false)

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -96,13 +96,6 @@ let test_all_schemas_apply_as_oas_native_json_schema () =
          (match configured.Llm_provider.Provider_config.response_format with
           | Agent_sdk.Types.JsonSchema actual -> Yojson.Safe.equal schema actual
           | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
-       check
-         bool
-         (label ^ " output_schema mirrors schema")
-         true
-         (match configured.Llm_provider.Provider_config.output_schema with
-          | Some actual -> Yojson.Safe.equal schema actual
-          | None -> false);
        match Llm_provider.Provider_config.validate_output_schema_request configured with
        | Ok () -> ()
        | Error msg ->
@@ -121,8 +114,7 @@ let has_json_schema_response_format schema provider_cfg =
 
 let has_no_response_format provider_cfg =
   match provider_cfg.Llm_provider.Provider_config.response_format with
-  | Agent_sdk.Types.Off ->
-    Option.is_none provider_cfg.Llm_provider.Provider_config.output_schema
+  | Agent_sdk.Types.Off -> true
   | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false
 ;;
 

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -248,10 +248,7 @@ let test_provider_for_vision_preserves_configured_max_tokens () =
    | Agent_sdk.Types.JsonSchema schema ->
      assert (Yojson.Safe.equal schema expected_schema)
    | Agent_sdk.Types.JsonMode
-   | Agent_sdk.Types.Off -> failwith "vision provider must request JsonSchema");
-  (match configured.output_schema with
-   | Some schema -> assert (Yojson.Safe.equal schema expected_schema)
-   | None -> failwith "vision provider must mirror output_schema")
+   | Agent_sdk.Types.Off -> failwith "vision provider must request JsonSchema")
 
 let test_max_image_bytes_reads_env_config () =
   with_env "MASC_KEEPER_VISION_MAX_IMAGE_BYTES" "128" (fun () ->

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1406,9 +1406,9 @@ let test_runtime_inventory_surfaces_request_config () =
       "off"
       (request |> J.member "response_format" |> J.member "kind" |> J.to_string);
     Alcotest.(check bool)
-      "no output schema body exposed"
+      "response format carries no schema"
       false
-      (request |> J.member "has_output_schema" |> J.to_bool);
+      (request |> J.member "response_format" |> J.member "has_schema" |> J.to_bool);
     Alcotest.(check bool)
       "no model capabilities override on provider_config"
       false
@@ -1421,7 +1421,7 @@ let test_runtime_inventory_surfaces_request_config () =
               ("secret key omitted: " ^ secret_key)
               false
               (List.mem_assoc secret_key fields))
-         [ "api_key"; "headers"; "system_prompt"; "output_schema"; "previous_response_id" ]
+         [ "api_key"; "headers"; "system_prompt"; "previous_response_id" ]
      | _ -> Alcotest.fail "request_config must be an object"))
 ;;
 

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1312,7 +1312,6 @@ let test_runtime_agent_context_resume_patches_stale_response_format_to_base_cont
     let base = provider_cfg () in
     { base with
       Llm_provider.Provider_config.response_format = Agent_sdk.Types.JsonSchema resume_schema
-    ; output_schema = Some resume_schema
     }
   in
   let config =


### PR DESCRIPTION
## 범위

OAS #2858 hard-cut 이후 MASC current caller를 response_format 단일 계약으로 맞췄어용.

## 변경

- Provider_config.output_schema 읽기/쓰기 전부 제거
- schema 요청은 response_format = JsonSchema만 사용
- format 제거는 response_format = Off만 사용
- dashboard의 중복 has_output_schema 파생 필드 제거; response_format.has_schema가 SSOT
- 테스트와 문서를 현재 계약으로 갱신
- OAS main 50e1bf1af1af598729c2482e190f8476ecebc3f1 pin 및 API surface 재생성

호환 필드, migration adapter, fallback Gate는 추가하지 않았어용.

## 검증

검토 head: dd35f05b07260246713750d747a8f77cee17a470
- changed OCaml format/parse-only 통과
- git diff check 통과
- OAS pin manifest/API surface 검증 통과
- OAS internals/boundary/structure ratchet 통과
- 로컬 Dune은 실행하지 않고 PR CI를 확인해용.