### PR TITLE
fix(scripts): dashboard 스모크가 제거된 hebbian 키를 단언하는 문제

### DIFF
--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -172,7 +172,7 @@ check_json "model metrics exposes model list" "$BASE/api/v1/models/metrics?windo
 check_http "keeper costs 200" "$BASE/api/v1/dashboard/keeper-costs?window=60" "200"
 check_json "keeper costs exposes keepers" "$BASE/api/v1/dashboard/keeper-costs?window=60" "'keepers' in d" '^True$'
 check_http "memory subsystems 200" "$BASE/api/v1/dashboard/memory-subsystems" "200"
-check_json "memory subsystems has hebbian block" "$BASE/api/v1/dashboard/memory-subsystems" "'hebbian' in d" '^True$'
+check_json "memory subsystems exposes delegation requests" "$BASE/api/v1/dashboard/memory-subsystems" "'delegation_requests' in d" '^True$'
 check_http "transport health 200" "$BASE/api/v1/dashboard/transport-health" "200"
 check_json "transport health exposes provenance" "$BASE/api/v1/dashboard/transport-health" "'summary' in d and d.get('dashboard_surface') == '/api/v1/dashboard/transport-health' and d.get('source') == 'transport_health_read_model' and d.get('retention', {}).get('scope') == 'dashboard_transport_health' and d.get('query', {}).get('default_snapshot_request') is True and d.get('cache', {}).get('cache_state') in ('fresh', 'stale', 'initializing', 'request_swr_or_inline_compute')" '^True$'
 check_http "attribution summary 200" "$BASE/api/v1/attribution/summary" "200"


### PR DESCRIPTION
## 무엇을

`scripts/verify-dashboard.sh` 의 memory-subsystems 스모크가 `hebbian` 키의 존재를 단언한다. #26250 이 그 키를 제거했으므로, **서버를 재빌드하는 순간 이 검사는 반드시 실패한다.**

```
- check_json "memory subsystems has hebbian block" ... "'hebbian' in d"
+ check_json "memory subsystems exposes delegation requests" ... "'delegation_requests' in d"
```

## 왜 #26250 에서 안 잡혔나

쉘 스크립트라 OCaml 컴파일러도 `tsc` 도 vitest 도 건드리지 않는다. 레포 안에 호출처가 없어 (`rg verify-dashboard` 결과 0) CI 도 돌리지 않는 수동 스모크다. 타입 시스템이 닿지 않는 표면이었다.

## 검증

실행 중인 인스턴스(구 빌드 `2fdb110716`, #26250 이전) 응답:

```
keys: ['delegation_requests', 'generated_at', 'hebbian', 'memory_quality']
```

- `hebbian` 이 아직 있으므로 기존 검사는 오늘까지는 통과한다 — 재빌드 후 깨진다는 뜻이다
- `delegation_requests` 는 존재한다. 소스에서도 조건 없이 방출된다 (`server_dashboard_http_memory_subsystems.ml:305`)

## 같이 발견했으나 손대지 않은 것

- `server_dashboard_http_memory_subsystems.ml:300` 의 `memory_quality` 응답 키는 **레포 전체에서 소비처가 0** 이다 (문서 hit 는 별개 오프라인 하네스 `test/memory_quality_eval.ml` 를 가리킨다). hebbian 과 같은 형태가 한 겹 아래 남아 있다
- `scripts/memory_os_judge_eval.py:398,491-492` 의 `_shared` 분기. `only_shared=True` 는 이제 항상 빈 리스트를 반환한다. 오프라인 eval 하네스의 리포트 구조를 바꿔야 해서 이 수정에 섞지 않았다

둘 다 후속으로 분리한다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. 스모크 스크립트 한 줄 수정이다.

WORKAROUND-WAIVED: #26250 이 제거한 필드를 참조하던 단언을, 실제로 존재하는 필드로 교정한다. 게이트/카운터/분류기를 추가하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
