### PR TITLE
fix(keeper): do not block turns on board completion retry

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -492,7 +492,10 @@ let run_keepalive_unified_turn
            ~keeper_name:meta_after_triage.name
        with
        | Error detail ->
-         raise (Keeper_board_attention_candidate.Candidate_unavailable detail)
+         Log.Keeper.error
+           ~keeper_name:meta_after_triage.name
+           "Board attention completion remains pending; it did not block this Keeper turn: %s"
+           detail
        | Ok Keeper_board_attention_worker.No_completed_partition ->
          ()
        | Ok


### PR DESCRIPTION
## What changed
- A failed completed board-attention delivery now remains pending and is logged.
- The same Keeper turn continues into event intake and dispatch instead of raising before it sees its selected queue event.

## Why
Board-attention completion is a separate retryable effect. It must not become a pre-turn gate for unrelated Keeper work.

## Scope
- The exact selected-source validation remains: it is the cancellation/transfer boundary immediately before provider dispatch.
- No new state, protocol, fallback, or test facade.

## Validation
- `ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml`
- `git diff --check origin/main...HEAD`
- Focused Dune build was blocked by an existing bare `dune build .`; current-head CI is the build authority.