### PR TITLE
fix(oas): consume current structured schema

### DIFF
--- a/lib/agent_sdk_response.ml
+++ b/lib/agent_sdk_response.ml
@@ -15,13 +15,9 @@ let visible_text_response (response : api_response) : api_response =
   }
 ;;
 
-let structured_json_of_response ?(schema_name = "masc_structured_response") response =
+let structured_json_of_response response =
   let schema : Yojson.Safe.t Agent_sdk.Structured.schema =
-    { name = schema_name
-    ; description = "MASC structured JSON response"
-    ; params = []
-    ; parse = (fun json -> Ok json)
-    }
+    { params = []; parse = (fun json -> Ok json) }
   in
   Agent_sdk.Structured.schema_extractor schema (visible_text_response response)
 ;;

--- a/lib/agent_sdk_response.mli
+++ b/lib/agent_sdk_response.mli
@@ -10,8 +10,7 @@ val text_of_response : api_response -> string
     ToolUse, ToolResult, and media blocks are intentionally excluded. *)
 
 val structured_json_of_response
-  :  ?schema_name:string
-  -> api_response
+  :  api_response
   -> (Yojson.Safe.t, string) result
 (** Extract provider-native structured JSON from an API response through the
     OAS structured-output extractor. Callers remain responsible for domain

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -599,10 +599,7 @@ let structured_result_of_json (json : Yojson.Safe.t)
 
 let structured_result_schema : structured_result Agent_sdk.Structured.schema =
   {
-    Agent_sdk.Structured.name = "keeper_deliberation_decision";
-    description =
-      "Choose exactly one typed keeper deliberation action and return only the tool input object.";
-    params =
+    Agent_sdk.Structured.params =
       [
         {
           Agent_sdk.Types.name = "action";

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -205,9 +205,7 @@ let consolidate_keeper
            then Empty_response
            else
              (match
-                Agent_sdk_response.structured_json_of_response
-                  ~schema_name:"keeper_memory_consolidation_plan"
-                  response
+                Agent_sdk_response.structured_json_of_response response
               with
               | Error detail -> invalid_structured_response_detail detail
               | Ok (`Assoc _ as json) ->

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -260,9 +260,7 @@ let vision_text_of_json = function
 
 let vision_text_of_response (response : Agent_sdk.Types.api_response) =
   match
-    Agent_sdk_response.structured_json_of_response
-      ~schema_name:"keeper_vision_analyze"
-      response
+    Agent_sdk_response.structured_json_of_response response
   with
   | Ok json -> vision_text_of_json json
   | Error msg -> Error ("vision response is not valid structured JSON: " ^ msg)


### PR DESCRIPTION
## What changed

- consume the current OAS `Structured.schema` shape (`params` + `parse`)
- remove the obsolete `schema_name` facade from MASC response parsing
- update the two callers that only parse visible response JSON

## Why

MASC main already pins OAS `50e1bf1a` after #2858/#2862, but five consumer files still referenced the removed `name` and `description` schema fields. This finishes that pin without restoring compatibility fields or adding migration code.

## Impact

No provider, model, Tool, or content-block behavior changes. This is a current-contract compile repair only.

## Validation

- `bash scripts/check-oas-pin.sh --local-only`
- `bash scripts/sync-oas-pin-manifests.sh --check --surface`
- `bash scripts/oas-drift-check.sh`
- `ocamlformat --check` on all five changed OCaml files
- focused Dune build was attempted through `scripts/dune-local.sh`; the machine guard refused while another session was running bare `dune build .`, so PR CI is the build authority
