### PR TITLE
fix(oas): sync v0.231.0 pin manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.230.0-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.0-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.230.0`, runtime pin: `main@50e1bf1af1af598729c2482e190f8476ecebc3f1`, declared base version: `v0.230.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.0`, runtime pin: `main@2cb7d9226a7ba797071cd45733d5b15789f13ff5`, declared base version: `v0.231.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.230.0))
+  (agent_sdk (>= 0.231.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.230.0"}
+  "agent_sdk" {>= "0.231.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.230.0"}
+  "agent_sdk" {= "0.231.0"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.230.0"
-  "git+https://github.com/jeong-sik/oas.git#50e1bf1af1af598729c2482e190f8476ecebc3f1"
+  "agent_sdk.0.231.0"
+  "git+https://github.com/jeong-sik/oas.git#2cb7d9226a7ba797071cd45733d5b15789f13ff5"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -7,10 +7,10 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.0"
 # response_format = JsonSchema as the single structured-output request state
 # (#2858), legacy tool/checkpoint shapes and the typed-compat runtime are
 # removed (#2851/#2853), and eval requires explicit metric policies with
-# incomplete comparisons rejected (#2854/#2866). masc-side output_schema
-# migration lands in the same PR as this bump. Deploy note: live v8
-# checkpoints are rejected after this pin — keeper contexts rebuild from
-# Memory OS facts + board (facts/episodes stores are unaffected).
+# incomplete comparisons rejected (#2854/#2866). MASC already consumes the
+# current response_format-only contract; no compatibility or migration code is
+# retained. Upgrade blast radius: OAS checkpoint artifacts below v9 are
+# rejected and must be reset.
 # Previous pin: v0.230.0 (7a3f2af7).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "50e1bf1af1af598729c2482e190f8476ecebc3f1",
-  "pinned_version": "v0.230.0",
+  "pinned_sha": "2cb7d9226a7ba797071cd45733d5b15789f13ff5",
+  "pinned_version": "v0.231.0",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## 문제

병합된 #26253은 pin SSOT를 v0.231.0으로 올렸지만 dune-project, opam/lock, 문서, API surface를 0.230.0/50e1bf1에 남겨 현재 main의 생성 manifest가 불일치해용. 주석도 현재 계약 제거를 migration이라고 부르고 pin 범위를 넘는 keeper 재구축을 보장했어용.

## 수정

- repo sync 스크립트로 dependency floor, lock, 문서, API surface를 v0.231.0/2cb7d922에 맞췄어용.
- MASC가 이미 response_format-only 현재 계약을 소비한다고 명시했어용.
- compatibility/migration 코드는 보존하지 않는다고 명시했어용.
- blast radius는 OAS v9 미만 checkpoint 거부 및 reset 필요로 한정했어용.

코드 Gate, Facade, migration 구현은 추가하지 않았어용.

## 검증

- scripts/sync-oas-pin-manifests.sh --check --surface — PASS
- scripts/check-oas-internals.sh — PASS
- scripts/ci/check-masc-oas-boundary.sh — PASS
- scripts/ocaml-structure-ratchet.sh — PASS
- bash -n scripts/oas-agent-sdk-pin.sh — PASS
- git diff --check — PASS
- 로컬 Dune/build는 실행하지 않았어용.

[근거] origin/main 324cd9a22a 및 repo pin 검증 스크립트, 2026-07-29 확인, 신뢰도 High.