### PR TITLE
fix(worker): fail closed on checkpoint load errors

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -213,17 +213,54 @@ let load_worker_checkpoint ~base_path ~worker_name =
   let path =
     worker_checkpoint_path ~base_path ~worker_name
   in
-  if Sys.file_exists path then
-    try
-      let raw = In_channel.with_open_text path In_channel.input_all in
-      (match Agent_sdk.Checkpoint.of_string raw with
-       | Ok v -> Some v
+  match Unix.openfile path [ Unix.O_RDONLY ] 0 with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+    (match Unix.lstat path with
+     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+     | exception Unix.Unix_error (error, _, _) ->
+       Error
+         (sprintf
+            "failed to inspect worker checkpoint for %s: %s"
+            worker_name
+            (Unix.error_message error))
+     | _ ->
+       Error
+         (sprintf
+            "failed to open worker checkpoint for %s: path exists after open reported missing"
+            worker_name))
+  | exception Unix.Unix_error (error, _, _) ->
+    Error
+      (sprintf
+         "failed to open worker checkpoint for %s: %s"
+         worker_name
+         (Unix.error_message error))
+  | descriptor ->
+    let channel = Unix.in_channel_of_descr descriptor in
+    (try
+       let raw =
+         Fun.protect
+           ~finally:(fun () -> close_in_noerr channel)
+           (fun () -> In_channel.input_all channel)
+       in
+       match Agent_sdk.Checkpoint.of_string raw with
+       | Ok v -> Ok (Some v)
        | Error detail ->
-         Log.LocalWorker.warn "checkpoint parse error discarded for %s: %s" worker_name (Agent_sdk.Error.to_string detail);
-         None)
-    with Sys_error _ -> None
-  else
-    None
+         Error
+           (sprintf
+              "failed to load worker checkpoint for %s: %s"
+              worker_name
+              (Agent_sdk.Error.to_string detail))
+     with
+     | Sys_error msg ->
+       close_in_noerr channel;
+       Error (sprintf "failed to read worker checkpoint for %s: %s" worker_name msg)
+     | Unix.Unix_error (error, _, _) ->
+       close_in_noerr channel;
+       Error
+         (sprintf
+            "failed to read worker checkpoint for %s: %s"
+            worker_name
+            (Unix.error_message error)))
 
 let save_worker_checkpoint ~base_path ~worker_name checkpoint =
   try

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -105,10 +105,11 @@ val make_worker_meta :
 val load_worker_checkpoint :
   base_path:string ->
   worker_name:string ->
-  Agent_sdk.Checkpoint.t option
+  (Agent_sdk.Checkpoint.t option, string) result
 (** Reads [checkpoint.json] via {!Agent_sdk.Checkpoint.of_string}.
-    Returns [None] on missing file, parse failure, or
-    [Sys_error]. *)
+    Returns [Ok None] only when the file is absent. Decode and I/O failures are
+    returned explicitly so an incompatible checkpoint cannot become a silent
+    cold start. *)
 
 val save_worker_checkpoint :
   base_path:string ->

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -53,7 +53,7 @@ let run_worker_oas ~sw ?net
     let mcp_session_id =
       resolved_mcp_session_id ~base_path ~worker_name
     in
-    let checkpoint = load_worker_checkpoint ~base_path ~worker_name in
+    let* checkpoint = load_worker_checkpoint ~base_path ~worker_name in
     let* provider_config, model_id =
       resolve_oas_provider_of_label spec.model_label
     in

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -11,6 +11,21 @@ let with_env name value f =
       | None -> Unix.putenv name "")
     f
 
+let rec remove_tree path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+  | stat when stat.Unix.st_kind = Unix.S_DIR ->
+    Sys.readdir path
+    |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+    Unix.rmdir path
+  | _ -> Unix.unlink path
+;;
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_dir prefix "" in
+  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
+;;
+
 let worker_usage ?cost_usd ~input_tokens ~output_tokens () :
     Agent_sdk.Types.api_usage =
   {
@@ -207,6 +222,62 @@ let worker_meta ?mcp_client_session_started_at () =
     last_run_at = None;
   }
 
+let test_worker_checkpoint_missing_is_explicitly_empty () =
+  with_temp_dir "worker-checkpoint-missing" @@ fun base_path ->
+  match
+    Worker_container.load_worker_checkpoint
+      ~base_path
+      ~worker_name:"coverage-worker"
+  with
+  | Ok None -> ()
+  | Ok (Some _) | Error _ -> fail "missing checkpoint must be Ok None"
+;;
+
+let test_worker_checkpoint_decode_failure_is_not_cold_start () =
+  with_temp_dir "worker-checkpoint-invalid" @@ fun base_path ->
+  let worker_name = "coverage-worker" in
+  Worker_container.ensure_worker_container_dirs ~base_path ~worker_name;
+  let path =
+    Filename.concat
+      (Worker_container.worker_container_dir ~base_path ~worker_name)
+      "checkpoint.json"
+  in
+  Out_channel.with_open_text path (fun channel -> output_string channel {|{"version":8}|});
+  match Worker_container.load_worker_checkpoint ~base_path ~worker_name with
+  | Error _ -> ()
+  | Ok _ -> fail "incompatible checkpoint must fail explicitly"
+;;
+
+let test_worker_checkpoint_open_failure_is_not_cold_start () =
+  with_temp_dir "worker-checkpoint-open-failure" @@ fun base_path ->
+  let worker_name = "coverage-worker" in
+  Worker_container.ensure_worker_container_dirs ~base_path ~worker_name;
+  let path =
+    Filename.concat
+      (Worker_container.worker_container_dir ~base_path ~worker_name)
+      "checkpoint.json"
+  in
+  Unix.symlink "checkpoint.json" path;
+  match Worker_container.load_worker_checkpoint ~base_path ~worker_name with
+  | Error _ -> ()
+  | Ok _ -> fail "unopenable checkpoint must fail explicitly"
+;;
+
+let test_worker_checkpoint_dangling_link_is_not_cold_start () =
+  with_temp_dir "worker-checkpoint-dangling-link" @@ fun base_path ->
+  let worker_name = "coverage-worker" in
+  Worker_container.ensure_worker_container_dirs ~base_path ~worker_name;
+  let path =
+    Filename.concat
+      (Worker_container.worker_container_dir ~base_path ~worker_name)
+      "checkpoint.json"
+  in
+  Unix.symlink "missing-checkpoint.json" path;
+  match Worker_container.load_worker_checkpoint ~base_path ~worker_name with
+  | Error _ -> ()
+  | Ok _ -> fail "dangling checkpoint link must fail explicitly"
+;;
+
 let test_worker_mcp_client_session_preserves_persisted_start () =
   let started_at = 42.0 in
   let begun =
@@ -263,5 +334,13 @@ let () =
           test_case "worker MCP client session finish clears active start"
             `Quick
             test_worker_mcp_client_session_finish_clears_started_at;
+          test_case "missing checkpoint is explicit empty" `Quick
+            test_worker_checkpoint_missing_is_explicitly_empty;
+          test_case "checkpoint decode failure is not cold start" `Quick
+            test_worker_checkpoint_decode_failure_is_not_cold_start;
+          test_case "checkpoint open failure is not cold start" `Quick
+            test_worker_checkpoint_open_failure_is_not_cold_start;
+          test_case "checkpoint dangling link is not cold start" `Quick
+            test_worker_checkpoint_dangling_link_is_not_cold_start;
         ] );
     ]


### PR DESCRIPTION
## 문제

OAS 체크포인트 v9 hard-cut 뒤에도 worker 복원 실패를 경고 후 cold start로 바꾸는 silent failure가 남아 있었어용.

## 수정

- 실제 파일 부재만 `Ok None`으로 처리했어용.
- open/read/decode/dangling-link 실패는 typed `Error`로 runner까지 전파했어용.
- missing·decode·open·dangling-link 회귀 테스트를 추가했어용.

## 검증

- 대상 SHA: `1f1533a8dd`
- `ocamlformat --check` — PASS
- `ocamlc -stop-after parsing` — PASS
- `git diff --check` — PASS
- fresh adversarial review — P0/P1/P2 없음
- 로컬 Dune은 실행하지 않았고 CI만 실행 근거로 삼아용.

[근거] OAS checkpoint v9 계약 + exact source, 2026-07-29 확인, 신뢰도 High.