### PR TITLE
chore(deps): bump oas pin to v0.231.1

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.1"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -11,16 +11,19 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.0"
 # current response_format-only contract; no compatibility or migration code is
 # retained. Upgrade blast radius: OAS checkpoint artifacts below v9 are
 # rejected and must be reset.
-# Previous pin: v0.230.0 (7a3f2af7).
+# v0.231.1 is a patch release on the same hard-cut wave: corrected 0.231.0
+# release-note contracts (#2869) and keeps exact-output JSON syntax
+# prompt-only (#2870); no additional API removals beyond 0.231.0.
+# Previous pin: v0.231.0 (2cb7d922); before that v0.230.0 (7a3f2af7).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
 # main; oas-drift-check.sh also reports the public-surface delta at pin-bump
 # time.
-# Pinned to the v0.231.0 release commit.
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.0"
+# Pinned to the v0.231.1 release commit.
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.1"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="2cb7d9226a7ba797071cd45733d5b15789f13ff5"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.0"
+readonly OAS_AGENT_SDK_SHA="40ac4c42e0fcd29bb061a874c48faa934b3b91c2"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.1"


### PR DESCRIPTION
v0.231.0 → v0.231.1 (`40ac4c42`). patch 정렬: #2869(0.231.0 릴리즈 노트 계약 정정) + #2870(exact-output JSON syntax prompt-only 유지). **0.231.0 대비 API 델타 없음** — masc측 마이그레이션 불필요(오늘 #26253/#26255로 완료된 상태 그대로). 로컬 opam pin이 이미 40ac4c42를 추적 중이라 SSOT-로컬 정렬 목적. Build and Test 완주 후 머지.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>