### PR TITLE
fix(test): agent_sdk 가 제거한 schema.name 단언 제거

### DIFF
--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -469,9 +469,12 @@ let test_parse_valid_broadcast_json () =
           check string "message" "Status update" message
       | _ -> fail "expected Broadcast action"
 
-let test_structured_result_schema_metadata () =
-  check string "schema name" "keeper_deliberation_decision"
-    D.structured_result_schema.name;
+(* agent_sdk 0.231.1 dropped [name] and [description] from
+   [Structured.schema]: the SDK now emits a bare object JSON schema
+   ([schema_to_json_schema]) instead of a named tool, so no schema name reaches
+   the provider. The prompt still names the schema in prose for the model, and
+   [test_prompt_contains_tool_input_instruction] pins that string. *)
+let test_structured_result_schema_requires_action () =
   check bool "schema requires action" true
     (List.exists
        (fun (param : Agent_sdk.Types.tool_param) ->
@@ -1145,8 +1148,8 @@ let () =
         ] );
       ( "structured_result_schema",
         [
-          test_case "schema metadata" `Quick
-            test_structured_result_schema_metadata;
+          test_case "schema requires action" `Quick
+            test_structured_result_schema_requires_action;
           test_case "schema parse valid json" `Quick
             test_structured_result_schema_parse_valid_json;
         ] );


### PR DESCRIPTION
## 증상

`dune build .` 가 main 에서 실패한다.

```
File "test/test_keeper_deliberation.ml", line 474, characters 31-35:
474 |     D.structured_result_schema.name;
                                     ^^^^
Error: This expression has type D.structured_result Agent_sdk.Structured.schema
       There is no field name within type Agent_sdk.Structured.schema
```

## 원인

`agent_sdk` 가 `Structured.schema` 에서 `name` 과 `description` 을 제거했다. 타입이 tool 모양에서 **bare object JSON schema** 로 바뀌었고, API 도 `schema_to_tool_json` → `schema_to_json_schema` 로 바뀌었다.

```ocaml
(* 이전 *)                         (* 현재 *)
type 'a schema = {                 type 'a schema =
  name: string;                      { params : tool_param list
  description: string;               ; parse : Yojson.Safe.t -> ('a, string) result
  params: tool_param list;           }
  parse: ...;
}
```

**핀 드리프트가 아니다.** SSOT 핀인 0.231.0 (`2cb7d9226`) 과 0.231.1 (`40ac4c42e`) 의 `lib/structured.mli` 를 각각 확인했고, 둘 다 `name` 이 없다. 즉 현재 핀 기준으로 main 이 깨져 있다.

프로덕션 코드는 이미 이전을 마쳤다 — `lib/keeper/keeper_deliberation.ml:600` 의 생성부는 `params` 와 `parse` 만 채운다. 43828 개 타겟 중 이 테스트 하나만 실패하는 이유다. (`lib/mcp_server_eio_tool_profile.ml` 의 `schema.name` 은 MCP tool schema 로 다른 타입이며 무관하다.)

## 무엇을

죽은 단언을 제거한다. 스키마 이름은 더 이상 SDK 타입에 없고, `schema_to_json_schema` 가 이름 없는 object schema 를 내보내므로 **프로바이더에 스키마 이름이 전달되지 않는다.** 코드가 들고 있지 않은 값을 검증할 수 없다.

`params` 에 필수 `action` 이 있는지 보는 나머지 단언은 유지한다. 함수명과 test_case 라벨을 실제 검증 내용에 맞춰 `..._requires_action` / `"schema requires action"` 으로 정정했다.

프롬프트는 여전히 모델에게 산문으로 스키마 이름을 알려준다 (`config/prompts/keeper.deliberation.md:28`). 그 문자열은 `test_prompt_contains_tool_input_instruction` 이 이미 고정하고 있으므로 프롬프트 쪽 드리프트 가드는 그대로 남는다.

## 검증

**로컬 빌드를 돌리지 않았다.** 작성자가 직접 빌드하기로 하여 이 PR 은 코드 변경만 담는다. CI 결과로 확인이 필요하다.

변경 범위는 테스트 파일 한 개이며 lib 은 건드리지 않았다.

## 범위 밖 발견

- `structured_result_schema` 는 **프로덕션 소비처가 없다**. `keeper_deliberation.ml:600` 에 정의되고 `.mli:50` 으로 노출되지만 `lib/` 안에서 아무도 쓰지 않는다. 실제 응답 파싱은 손으로 쓴 `parse_deliberation_response` (`.mli:152`) 가 한다. 테스트 전용 스캐폴딩이다
- `dune-project` 의 `(agent_sdk (>= 0.231.0))` 은 하한만 있어 0.231.1 이 그대로 들어온다. 이번 건과 별개로, 로컬 opam switch 가 0.231.1 (`40ac4c42e`) 이고 레포 SSOT 핀은 0.231.0 (`2cb7d9226`) 이라 `scripts/dune-local.sh` 의 핀 가드가 드리프트로 판정한다. 복구는 `bash scripts/opam-pin-external-deps.sh`

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. 테스트 파일 한 개의 컴파일 오류 수정이다.

WORKAROUND-WAIVED: SDK 에서 사라진 필드를 읽던 단언을 제거한다. 게이트/카운터/분류기를 추가하지 않으며, 핀을 낮춰 증상을 덮지도 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
