### PR TITLE
chore(deps): sync oas pin docs and manifests to v0.231.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.0-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.1-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.0`, runtime pin: `main@2cb7d9226a7ba797071cd45733d5b15789f13ff5`, declared base version: `v0.231.0`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.1`, runtime pin: `main@40ac4c42e0fcd29bb061a874c48faa934b3b91c2`, declared base version: `v0.231.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.0))
+  (agent_sdk (>= 0.231.1))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.0"}
+  "agent_sdk" {>= "0.231.1"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.0"}
+  "agent_sdk" {= "0.231.1"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.0"
-  "git+https://github.com/jeong-sik/oas.git#2cb7d9226a7ba797071cd45733d5b15789f13ff5"
+  "agent_sdk.0.231.1"
+  "git+https://github.com/jeong-sik/oas.git#40ac4c42e0fcd29bb061a874c48faa934b3b91c2"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "2cb7d9226a7ba797071cd45733d5b15789f13ff5",
-  "pinned_version": "v0.231.0",
+  "pinned_sha": "40ac4c42e0fcd29bb061a874c48faa934b3b91c2",
+  "pinned_version": "v0.231.1",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
#26260이 doc sync 없이 머지되어 main Meta Guards의 doc-truth 게이트가 `docs/KEEPER-USER-MANUAL.md`에서 실패합니다. 게이트가 안내하는 repair(`sync-oas-pin-docs.sh`)를 현재 main 기준으로 실행한 결과입니다 — 문서 전용, 코드 델타 0.

참고: 제 이전 docs 커밋(86574d14)은 머지된 #26260 브랜치에 post-merge push돼 main에 도달하지 못했습니다(masc#5303 클래스). 이 PR이 대체합니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>