### PR TITLE
test(vision): pin prompt-only JSON contract

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -196,7 +196,8 @@ let test_truncated_of_stop_reason () =
 
 (* One User message [text query; image]; image data is base64 of the raw bytes
    (NOT the raw bytes), media_type preserved, source_type "base64". The JSON
-   response contract is carried by [provider_for_vision], not prompt prose. *)
+   response contract is explicit prompt prose because the provider request has
+   [response_format = Off]. *)
 let test_message_of_request () =
   let bytes = "\x89PNG\r\n\x1a\n\x00raw\xffbytes" in
   match
@@ -210,6 +211,8 @@ let test_message_of_request () =
     (match msg.Agent_sdk.Types.content with
      | [ Agent_sdk.Types.Text q; Agent_sdk.Types.Image img ] ->
        assert (contains_substring q "what color?");
+       assert (contains_substring q "Return only a JSON object");
+       assert (contains_substring q "field named text");
        assert (String.equal img.media_type "image/png");
        assert (
          String.equal


### PR DESCRIPTION
Follow-up to #26266.

With `provider_for_vision` forcing `response_format = Off`, Vision correctness depends on the request prompt carrying the JSON contract. This test now asserts that `message_of_request` includes both `Return only a JSON object` and the required `text` field instruction, in addition to the user query and image encoding assertions.

Local format and diff checks pass. The focused executable rebuild is queued behind another worktree using the shared Dune lock; CI is the next build authority.