### PR TITLE
fix(keeper): preserve cycle channel and preview purity

### DIFF
--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -153,22 +153,17 @@ let record_execution_receipt_gap
    This pattern follows PR #11696 (Cycle 43, KeeperHeartbeat closeout)
    which introduced [Keeper_fsm_guard_runtime]. *)
 
-(* AssignTask: the channel decision picks "turn" when at least one of
-   [pending_mentions], [pending_board_events], or
-   [pending_scope_messages] is non-empty. The post-action guard pins
-   the structural invariant that drove the decision. *)
-let post_assign_task ~(any_pending : bool) ~(channel : string) =
-  ignore any_pending;
+(* AssignTask: the typed channel decision is the authority. Reactive stimuli
+   include event-queue triggers that need not appear in the observation. *)
+let post_assign_task ~(channel : string) =
   ignore channel
-[@@fsm_guard "any_pending = true && channel = \"turn\""]
+[@@fsm_guard "channel = \"turn\""]
 ;;
 
-(* EmptyQueueSleep: complementary branch -- every pending list is empty
-   and the cycle exits without claiming. *)
-let post_empty_queue_sleep ~(any_pending : bool) ~(channel : string) =
-  ignore any_pending;
+(* EmptyQueueSleep: complementary typed scheduled-autonomous branch. *)
+let post_empty_queue_sleep ~(channel : string) =
   ignore channel
-[@@fsm_guard "any_pending = false && channel = \"scheduled_autonomous\""]
+[@@fsm_guard "channel = \"scheduled_autonomous\""]
 ;;
 
 (* TurnComplete (KeeperTaskAcquisition.tla, Cycle 45 follow-up to

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -51,10 +51,10 @@ val record_execution_receipt_gap :
   unit -> unit
 (** Record a coverage gap when an execution receipt could not be appended. *)
 
-val post_assign_task : any_pending:bool -> channel:string -> unit
+val post_assign_task : channel:string -> unit
 (** FSM guard post-action for [AssignTask]. *)
 
-val post_empty_queue_sleep : any_pending:bool -> channel:string -> unit
+val post_empty_queue_sleep : channel:string -> unit
 (** FSM guard post-action for [EmptyQueueSleep]. *)
 
 val post_turn_complete_task : cycle_completed:bool -> unit

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -800,6 +800,13 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
     "## Current World State\n\n" ^ Keeper_context_layers.assemble ~content_of
   in
   let user_message = autonomous_wake_marker in
+  { system_prompt; world_state; user_message }
+;;
+
+let emit_prompt_metrics
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      { system_prompt; world_state; user_message }
+  =
   (* Tool names and availability come exclusively from the typed schemas sent
      with this turn. Prompt markdown describes behaviour rather than attempting
      to mirror that catalog. World-state observations remain byte-for-byte
@@ -836,8 +843,8 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
   Otel_metric_store.set_gauge
     (Keeper_metrics.to_string KeeperTurnInstructionHash)
     ~labels:[("keeper", meta.name)]
-    prompt_hash;
-  { system_prompt; world_state; user_message }
+    prompt_hash
+;;
 
 let build_prompt
       ~meta
@@ -849,15 +856,19 @@ let build_prompt
       ~observation
       ()
   =
-  build_prompt_internal
-    ~meta
-    ~base_path
-    ?profile_defaults
-    ~turn_decision:(Some turn_decision)
-    ?current_task
-    ?active_goal_summaries
-    ~observation
-    ()
+  let prompt =
+    build_prompt_internal
+      ~meta
+      ~base_path
+      ?profile_defaults
+      ~turn_decision:(Some turn_decision)
+      ?current_task
+      ?active_goal_summaries
+      ~observation
+      ()
+  in
+  emit_prompt_metrics ~meta prompt;
+  prompt
 ;;
 
 let build_prompt_preview

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1481,6 +1481,7 @@ dominant source of the observed CAS race exhaustion after
                       ~meta
                       ~turn_ctx_cell
                       ~observation
+                      ~channel
                       ~latency_ms
                       ~degraded_retry_applied
                       ~degraded_retry_runtime

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -42,6 +42,15 @@ type terminal_outcome =
 type handle_result =
   | Completed of Keeper_meta_contract.keeper_meta
 
+type cycle_post_action =
+  | Assign_task
+  | Empty_queue_sleep
+
+let post_action_of_channel = function
+  | Keeper_world_observation.Reactive -> Assign_task
+  | Keeper_world_observation.Scheduled_autonomous -> Empty_queue_sleep
+;;
+
 let acknowledge_pending_messages
       (meta : Keeper_meta_contract.keeper_meta)
       (observation : Keeper_world_observation.world_observation)
@@ -88,29 +97,23 @@ let append_metrics_snapshot
       ~meta
       ~updated_meta
       ~observation
+      ~channel
       ~result
       ~latency_ms
       ~turn_cost
       ~(lifecycle : KEC.post_turn_lifecycle)
       ~terminal_outcome
   =
-  let any_pending =
-    observation.Keeper_world_observation.pending_messages <> []
-    || observation.pending_board_events <> []
-  in
   (* Single typed channel for the whole cycle: post helpers + the metrics
      snapshot + the failure-path label all derive from one value, so the
      reactive/autonomous decision can no longer drift between sites. *)
-  let channel =
-    if any_pending
-    then Keeper_world_observation.Reactive
-    else Keeper_world_observation.Scheduled_autonomous
-  in
   let channel_tag = Keeper_world_observation.channel_to_string channel in
   try
-    if any_pending
-    then Keeper_turn_helpers.post_assign_task ~any_pending ~channel:channel_tag
-    else Keeper_turn_helpers.post_empty_queue_sleep ~any_pending ~channel:channel_tag;
+    (match post_action_of_channel channel with
+     | Assign_task ->
+       Keeper_turn_helpers.post_assign_task ~channel:channel_tag
+     | Empty_queue_sleep ->
+       Keeper_turn_helpers.post_empty_queue_sleep ~channel:channel_tag);
     KUM.append_metrics_snapshot
       ~config
       ~meta:updated_meta
@@ -522,6 +525,12 @@ module For_testing = struct
 
   let reset_turn_failures_for_stop_reason = reset_turn_failures_for_stop_reason
   let acknowledge_pending_messages = acknowledge_pending_messages
+
+  type nonrec cycle_post_action = cycle_post_action =
+    | Assign_task
+    | Empty_queue_sleep
+
+  let post_action_of_channel = post_action_of_channel
 end
 
 let emit_terminal_fsm
@@ -550,6 +559,7 @@ let handle
       ~meta
       ~turn_ctx_cell
       ~observation
+      ~channel
       ~latency_ms
       ~degraded_retry_applied
       ~degraded_retry_runtime
@@ -581,6 +591,7 @@ let handle
     ~meta
     ~updated_meta
     ~observation
+    ~channel
     ~result
     ~latency_ms
     ~turn_cost

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -28,6 +28,14 @@ module For_testing : sig
     :  Keeper_meta_contract.keeper_meta
     -> Keeper_world_observation.world_observation
     -> Keeper_meta_contract.keeper_meta
+
+  type cycle_post_action =
+    | Assign_task
+    | Empty_queue_sleep
+
+  val post_action_of_channel
+    :  Keeper_world_observation.keeper_cycle_channel
+    -> cycle_post_action
 end
 
 type handle_result =
@@ -39,6 +47,7 @@ val handle
   -> meta:Keeper_meta_contract.keeper_meta
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> observation:Keeper_world_observation.world_observation
+  -> channel:Keeper_world_observation.keeper_cycle_channel
   -> latency_ms:int
   -> degraded_retry_applied:bool
   -> degraded_retry_runtime:string option

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -298,16 +298,68 @@ let test_threaded_stimulus_decision_renders_wake_reason () =
   check bool "bootstrap reason listed" true
     (contains ~needle:"bootstrap" threaded)
 
+let test_bootstrap_stimulus_keeps_reactive_post_action () =
+  let decision =
+    WO.keeper_cycle_decision
+      ~event_queue_triggers:[ WO.Bootstrap_stimulus ]
+      ~meta
+      base_observation
+  in
+  match
+    Masc.Keeper_unified_turn_success.For_testing.post_action_of_channel
+      decision.WO.channel
+  with
+  | Masc.Keeper_unified_turn_success.For_testing.Assign_task -> ()
+  | Masc.Keeper_unified_turn_success.For_testing.Empty_queue_sleep ->
+    Alcotest.fail
+      "bootstrap stimulus must not be reclassified from reactive to scheduled"
+
 let test_preview_does_not_invent_wake_reason () =
+  let preview_meta =
+    { meta with
+      Masc.Keeper_meta_contract.name = "preview-must-not-emit-turn-metrics"
+    }
+  in
+  let segment_metric = Keeper_metrics.(to_string PromptSegmentBytes) in
+  let segment_labels =
+    [ "keeper", preview_meta.name; "segment", "system_prompt" ]
+  in
+  let instruction_hash_metric =
+    Keeper_metrics.(to_string KeeperTurnInstructionHash)
+  in
+  check bool "fixture has no preview segment metric" true
+    (Option.is_none
+       (Otel_metric_store.get_metric_value
+          segment_metric
+          ~labels:segment_labels
+          ()));
+  check bool "fixture has no preview hash metric" true
+    (Option.is_none
+       (Otel_metric_store.get_metric_value
+          instruction_hash_metric
+          ~labels:[ "keeper", preview_meta.name ]
+          ()));
   let { Prompt.world_state; _ } =
     Prompt.build_prompt_preview
-      ~meta
+      ~meta:preview_meta
       ~base_path:"/tmp/unused"
       ~observation:base_observation
       ()
   in
   check bool "preview has no scheduler trigger" false
-    (contains ~needle:"### Autonomous Trigger" world_state)
+    (contains ~needle:"### Autonomous Trigger" world_state);
+  check bool "preview does not emit segment metric" true
+    (Option.is_none
+       (Otel_metric_store.get_metric_value
+          segment_metric
+          ~labels:segment_labels
+          ()));
+  check bool "preview does not emit instruction hash" true
+    (Option.is_none
+       (Otel_metric_store.get_metric_value
+          instruction_hash_metric
+          ~labels:[ "keeper", preview_meta.name ]
+          ()))
 
 (* --- 3. Goal titles + self-direction parity --- *)
 
@@ -395,6 +447,8 @@ let () =
         [
           test_case "stimulus decision renders wake reason" `Quick
             test_threaded_stimulus_decision_renders_wake_reason;
+          test_case "bootstrap keeps reactive post-action" `Quick
+            test_bootstrap_stimulus_keeps_reactive_post_action;
           test_case "preview invents no wake reason" `Quick
             test_preview_does_not_invent_wake_reason;
         ] );


### PR DESCRIPTION
대상 커밋: `34286a1dce`

- success 경로가 관찰값으로 채널을 재추론하지 않고 turn decision의 typed channel을 그대로 사용해용.
- dashboard prompt preview가 실제 turn 메트릭을 변경하지 않게 조립과 기록을 분리했어용.
- bootstrap reactive 반례와 preview 무변경 회귀 테스트를 추가했어용.
- 로컬 Dune은 실행하지 않았고 포맷·파싱·diff 검증만 통과했어용. 빌드와 테스트는 CI에서 확인해용.