### PR TITLE
test(oas): pin prompt-only exact-output contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,7 +820,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          oas_pin_targets="@test/runtest-test_keeper_hooks_oas_introspection @test/runtest-test_keeper_execution_join"
+          oas_pin_targets="@test/runtest-test_keeper_hooks_oas_introspection @test/runtest-test_keeper_execution_join @test/runtest-test_hitl_summary_worker @test/runtest-test_librarian_exact_output_conformance"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${oas_pin_targets}"
 
       - name: Run tool blob retention suite

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -14,8 +14,9 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.1"
 # v0.231.1 is a patch release on the same hard-cut wave: corrected 0.231.0
 # release-note contracts (#2869) and keeps Exact_output.Json_syntax prompt-only
 # (#2870), appending the JSON instruction and validating locally rather than
-# selecting a provider-native response format. Provider_schema remains explicit;
-# no additional API removals beyond 0.231.0.
+# selecting a provider-native response format. Provider_schema remains
+# explicit. It also removes the public Llm_provider.Complete.gemini_url
+# helper; MASC has no caller.
 # Previous pin: v0.231.0 (2cb7d922); before that v0.230.0 (7a3f2af7).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -367,6 +367,7 @@ let test_json_syntax_request_is_prompt_only_and_carries_canonical_domain_schema 
        publish_lane
          [ "hitl-json-syntax-contract" ]
          (F.resolver_snapshot
+            ~supports_response_format_json:false
             ~supports_structured_output:false
             ~source:"hitl-json-syntax-contract"
             [ { id = "hitl-json-syntax-contract"; base_url = server.base_url } ]);

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -168,15 +168,9 @@ let publish_lane
       : Runtime_exact_output_registry.t)
 ;;
 
-let json_object_response_format body =
+let has_response_format body =
   match Yojson.Safe.from_string body with
-  | `Assoc fields ->
-    (match List.assoc_opt "response_format" fields with
-     | Some (`Assoc response_format) ->
-       (match List.assoc_opt "type" response_format with
-        | Some (`String "json_object") -> true
-        | _ -> false)
-     | _ -> false)
+  | `Assoc fields -> Option.is_some (List.assoc_opt "response_format" fields)
   | _ -> false
 ;;
 
@@ -236,7 +230,7 @@ let run_eio f =
     ~clock:(Eio.Stdenv.clock env)
 ;;
 
-let test_json_only_target_is_admitted_and_persisted () =
+let test_prompt_only_target_is_admitted_and_persisted () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _ ->
       run_eio (fun ~sw ~net ~clock ->
@@ -261,9 +255,9 @@ let test_json_only_target_is_admitted_and_persisted () =
           (match Fixture.request_bodies server with
            | [ body ] ->
              Alcotest.(check bool)
-               "OAS selected json_object for a JSON-only target"
-               true
-               (json_object_response_format body)
+               "Json_syntax stays prompt-only"
+               false
+               (has_response_format body)
            | bodies ->
              Alcotest.failf "expected one request body, got %d" (List.length bodies));
           Alcotest.(check int)
@@ -283,7 +277,7 @@ let test_json_only_target_is_admitted_and_persisted () =
                ~generation:1))))
 ;;
 
-let test_missing_json_capability_fails_before_dispatch () =
+let test_prompt_only_target_needs_no_wire_json_capability () =
   with_prompt_registry (fun () ->
   with_temp_keepers_dir (fun _ ->
     run_eio (fun ~sw ~net ~clock ->
@@ -297,22 +291,23 @@ let test_missing_json_capability_fails_before_dispatch () =
         ~supports_structured_output:false
         [ slot ];
       match
-        extract_with_exact_output_classified
+        extract_and_append_with_exact_output
           ~clock
           ~net
           ~keeper_id:"librarian-no-json-keeper"
-          ~generation:1
           (librarian_input "trace-no-json")
       with
-      | Error error
-        when Librarian_runtime.extraction_error_kind error
-             = Librarian_runtime.Exact_setup_failure ->
-        Alcotest.(check int) "no provider request" 0 (Fixture.post_count server)
-      | Error error ->
-        Alcotest.failf
-          "expected typed exact setup failure, got %s"
-          (Librarian_runtime.extraction_error_to_string error)
-      | Ok _ -> Alcotest.fail "target without a JSON guarantee must fail closed")))
+      | Ok _ ->
+        Alcotest.(check int) "one provider request" 1 (Fixture.post_count server);
+        (match Fixture.request_bodies server with
+         | [ body ] ->
+           Alcotest.(check bool)
+             "no provider-native response format"
+             false
+             (has_response_format body)
+         | bodies ->
+           Alcotest.failf "expected one request body, got %d" (List.length bodies))
+      | Error error -> Alcotest.fail error)))
 ;;
 
 let test_domain_invalid_output_does_not_fail_over () =
@@ -700,11 +695,11 @@ let () =
       , [ Alcotest.test_case
             "JSON-only target is admitted and persisted"
             `Quick
-            test_json_only_target_is_admitted_and_persisted
+            test_prompt_only_target_is_admitted_and_persisted
         ; Alcotest.test_case
             "missing JSON capability fails before dispatch"
             `Quick
-            test_missing_json_capability_fails_before_dispatch
+            test_prompt_only_target_needs_no_wire_json_capability
         ; Alcotest.test_case
             "domain-invalid output does not fail over"
             `Quick


### PR DESCRIPTION
대상 커밋: `bffa025d9e`

- OAS v0.231.1 `Json_syntax`가 wire `response_format` 없이 프롬프트+로컬 검증으로 동작함을 고정했어용.
- wire JSON capability가 없는 대상도 prompt-only 경로로 실행됨을 검증해용.
- HITL/Librarian 실행 테스트를 OAS pin CI에 포함하고 pin 반경 설명을 바로잡았어용.
- 로컬 Dune은 실행하지 않았고 포맷·파싱·diff 검증만 통과했어용. 빌드와 테스트는 CI에서 확인해용.