### PR TITLE
fix(memory-os): key claim identity on stable coordinates, not the window turn

### DIFF
--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -327,12 +327,24 @@ let claim_identity (f : fact) =
   match f.claim_id with
   | Some id when claim_id_is_valid id -> "id:" ^ id
   | Some _ | None ->
+    (* [source.turn] is deliberately excluded: the librarian's turn numbers
+       are indices into the sliding prompt window ([List.mapi] in
+       [Keeper_librarian.format_messages_for_prompt]), so the same event
+       re-extracted after the window moves carries a different number.
+       Including it made write-time dedupe structurally impossible — every
+       re-extraction minted a fresh identity. The stable observation
+       coordinates are the trace, the producing tool call (when any), and
+       the exact claim bytes; [turn] stays on the fact as display
+       provenance only. *)
     "observation:"
     ^ Yojson.Safe.to_string
         (`Assoc
-           [ wire_field_source, provenance_event_to_json f.source
-           ; wire_field_claim, `String f.claim
-           ])
+           ([ wire_field_trace_id, `String f.source.trace_id ]
+            @ (match f.source.tool_call_id with
+               | Some tool_call_id ->
+                 [ wire_field_source_tool_call_id, `String tool_call_id ]
+               | None -> [])
+            @ [ wire_field_claim, `String f.claim ]))
 ;;
 
 let optional_float_field key = function

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4359,12 +4359,54 @@ let test_gc_default_on () =
   Alcotest.(check bool) "gc default is true" true Env_config.KeeperMemoryOs.gc_enabled_default
 ;;
 
+(* Regression for the duplicate-creation root: the librarian's turn numbers
+   are sliding-window indices, so the same observation re-extracted after the
+   window moves used to mint a fresh identity and write-time dedupe never
+   fired. Identity now keys on trace + tool call + exact claim bytes only. *)
+let test_claim_identity_ignores_window_turn () =
+  let now = 1_000_000.0 in
+  let base = fact_fixture ~now () in
+  let early = { base with Types.source = { base.Types.source with Types.turn = 5 } } in
+  let late = { base with Types.source = { base.Types.source with Types.turn = 99 } } in
+  Alcotest.(check string)
+    "same trace + claim across window positions share one identity"
+    (Types.claim_identity early)
+    (Types.claim_identity late);
+  let other_trace =
+    { base with
+      Types.source = { base.Types.source with Types.trace_id = "trace-999" }
+    }
+  in
+  Alcotest.(check bool)
+    "a different trace is a different observation"
+    false
+    (String.equal (Types.claim_identity base) (Types.claim_identity other_trace));
+  let other_claim = { base with Types.claim = "User prefers verbose responses" } in
+  Alcotest.(check bool)
+    "different claim bytes are a different observation"
+    false
+    (String.equal (Types.claim_identity base) (Types.claim_identity other_claim));
+  let tool_call =
+    { base with
+      Types.source = { base.Types.source with Types.tool_call_id = Some "call-1" }
+    }
+  in
+  Alcotest.(check bool)
+    "a tool-produced observation is distinct from a prose one"
+    false
+    (String.equal (Types.claim_identity base) (Types.claim_identity tool_call))
+;;
+
 let () =
   maybe_run_lock_holder_child ();
   Alcotest.run
     "keeper_memory_os"
     [ ( "json"
       , [ Alcotest.test_case "fact and episode round-trip" `Quick test_json_roundtrip
+        ; Alcotest.test_case
+            "claim identity ignores the window turn"
+            `Quick
+            test_claim_identity_ignores_window_turn
         ; Alcotest.test_case
             "fact decoder rejects unsupported schema version"
             `Quick


### PR DESCRIPTION
Memory OS census ①(중복 생성의 실제 뿌리): `claim_identity`의 observation fallback이 `source.turn`을 포함하는데, 이 turn은 librarian 프롬프트의 **슬라이딩 윈도우 인덱스**(`List.mapi`)입니다. 윈도우가 미끄러지면 같은 사건이 다른 번호를 받아 재추출마다 새 identity가 발급 — 쓰기 시점 dedupe(merge_facts·recall ledger 키)가 구조적으로 발화 불가였습니다.

**수정**: identity = trace_id + tool_call_id(있을 때) + 정확한 claim 바이트. turn은 표시용 provenance로 fact에 그대로 남습니다(필드 삭제 아님 — identity 계산에서만 제외).

**반경**:
- identity는 read 시 계산되므로 저장 행 마이그레이션 불필요 — 기존 중복 행들은 다음 재관찰부터 병합되기 시작.
- recall-injection ledger 키가 1회 바뀜 → 배포 직후 fact당 최대 1회 재주입 가능(무해).
- 기존 테스트 영향 0 확인(turn 상이 픽스처들은 claim 텍스트도 상이). 회귀 테스트 추가: 동일 trace+claim의 window 위치 상이 → 동일 identity / trace·claim·tool_call 상이 → 상이 identity.

연관: census ⑤ #26271(소음 생산 중단)과 합쳐 '중복 생성 뿌리 + 소음 생산' 양쪽을 닫음. ③ #26269, ② 후속 이슈. Build and Test 완주 후 머지.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>