### PR TITLE
fix(server): restore missing comment opening delimiter in server_dashboard_http_memory_subsystems.ml

### DIFF
--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -2,7 +2,7 @@
 
 open Server_utils
 
-   existing fixtures in test_server_dashboard_http_memory_subsystems.ml). *)
+(* Memory subsystem fixtures (see existing fixtures in test_server_dashboard_http_memory_subsystems.ml). *)
 
 let dashboard_memory_subsystems_http_json
       ~(config : Workspace_utils.config)


### PR DESCRIPTION
## Summary
Fixes a syntax error in `lib/server/server_dashboard_http_memory_subsystems.ml` caused by a missing comment opening delimiter (`(*`).

### Cause
Line 5 of `lib/server/server_dashboard_http_memory_subsystems.ml` was missing the opening `(*` delimiter in PR #26269, causing the OCaml parser to treat comment text as raw code tokens and fail with `Error: Syntax error`.

### Fix
Restored the opening `(*` delimiter on line 5 so the file compiles cleanly.