### PR TITLE
fix(test): resolve unbound Otel_metric_store module error in test_keeper_wake_turn_context

### DIFF
--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -329,13 +329,13 @@ let test_preview_does_not_invent_wake_reason () =
   in
   check bool "fixture has no preview segment metric" true
     (Option.is_none
-       (Otel_metric_store.get_metric_value
+       (Otel_metric_store_core.get_metric_value
           segment_metric
           ~labels:segment_labels
           ()));
   check bool "fixture has no preview hash metric" true
     (Option.is_none
-       (Otel_metric_store.get_metric_value
+       (Otel_metric_store_core.get_metric_value
           instruction_hash_metric
           ~labels:[ "keeper", preview_meta.name ]
           ()));


### PR DESCRIPTION
## Summary
Fixes an `Unbound module Otel_metric_store` compilation error in `test/test_keeper_wake_turn_context.ml`.

### Cause
`Otel_metric_store` module was refactored and renamed to `Otel_metric_store_core` in `lib/otel_metric_store/`, leaving legacy module references in `test/test_keeper_wake_turn_context.ml`.

### Fix
Updated legacy `Otel_metric_store` module references to `Otel_metric_store_core`. All unit tests in `test_keeper_wake_turn_context.exe` pass cleanly.