### PR TITLE
fix(keeper): superseded checkpoint 세대를 fatal 이 아니라 교체로 처리

### DIFF
--- a/bin/masc_checkpoint_purge.ml
+++ b/bin/masc_checkpoint_purge.ml
@@ -68,6 +68,8 @@ let purge_error_text = function
 
 let load_error_text = function
   | Store.Not_found -> "canonical checkpoint file not found"
+  | Store.Schema_version_mismatch { expected; got } ->
+    Printf.sprintf "schema v%d is not this build's v%d" got expected
   | Store.Store_error detail -> "store error: " ^ detail
   | Store.Parse_error detail -> "parse error: " ^ detail
   | Store.Io_error detail -> "io error: " ^ detail

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -192,6 +192,16 @@ let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string lis
 
 type checkpoint_load_error =
   | Not_found
+  | Schema_version_mismatch of
+      { expected : int
+      ; got : int
+      }
+      (** The artifact parsed, but its schema generation is not this build's.
+          [Agent_sdk.Error.Serialization] reports both numbers; keeping them
+          typed here is what lets a caller tell a superseded generation
+          ([got < expected], written by an older build) apart from a downgrade
+          ([got > expected], written by a newer one). Flattening this into
+          [Parse_error] would put that decision behind a string. *)
   | Store_error of string
   | Parse_error of string
   | Io_error of string
@@ -231,7 +241,7 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   | Io (ValidationFailed r) -> Store_error r.detail
   | Serialization (JsonParseError r) -> Parse_error r.detail
   | Serialization (VersionMismatch r) ->
-      Parse_error (sprintf "version mismatch: expected %d, got %d" r.expected r.got)
+      Schema_version_mismatch { expected = r.expected; got = r.got }
   | Serialization (UnknownVariant r) ->
       Parse_error (sprintf "unknown variant %s: %s" r.type_name r.value)
   | Api _ | Provider _ | Agent _ | Mcp _ | Config _
@@ -326,6 +336,8 @@ type save_oas_error =
 
 let checkpoint_load_error_to_string = function
   | Not_found -> "checkpoint not found"
+  | Schema_version_mismatch { expected; got } ->
+    Printf.sprintf "version mismatch: expected %d, got %d" expected got
   | Store_error detail
   | Parse_error detail
   | Io_error detail
@@ -924,6 +936,28 @@ module For_testing = struct
   ;;
 end
 
+(* The durable write both admission paths share. [known] is the watermark this
+   write advances from: [None] when there is nothing readable on disk, whether
+   because no file exists or because its schema generation is superseded. *)
+let write_canonical ~session_dir ~canonical_path ~known (ckpt : Agent_sdk.Checkpoint.t) =
+  let ownership_root = Filename.dirname session_dir in
+  match
+    Keeper_fs.save_json_durable_atomic_from
+      ~ownership_root
+      ~pretty:false
+      canonical_path
+      (fun () -> Agent_sdk.Checkpoint.to_json ckpt)
+  with
+  | Error error -> Error (Canonical_write_failed error)
+  | Ok () ->
+    archive_oas_history_best_effort ~session_dir ckpt;
+    Ok
+      (Saved
+         { relation = save_relation ~known ~incoming:ckpt.turn_count
+         ; turn_count = ckpt.turn_count
+         })
+;;
+
 let save_oas_classified_typed
     ~(session_dir : string)
     (ckpt : Agent_sdk.Checkpoint.t)
@@ -935,6 +969,37 @@ let save_oas_classified_typed
       let session_id = Keeper_id.Trace_id.to_string trace_id in
       let canonical_path = oas_checkpoint_path ~session_dir ~session_id in
       match known_watermark ~canonical_path with
+      (* A checkpoint from a superseded schema generation carries no watermark
+         this build can read, which is the same position as having no
+         checkpoint at all: neither guard below has an input. Identity is
+         already fixed by [canonical_path], which is keyed by [session_id], and
+         the monotonicity guard exists to avoid regressing to an older turn —
+         an artifact this build cannot parse cannot be resumed from at any
+         turn, so there is no state to regress to.
+
+         Direction is the whole decision, which is why [Schema_version_mismatch]
+         keeps both numbers instead of a message. [got < expected] is an older
+         build's artifact and is safe to replace. [got > expected] means a
+         NEWER build wrote it: that state is live for the build that owns it,
+         so overwriting it would destroy readable work and stays an error.
+
+         The hard cut this handles is contractual, not exceptional — the OAS
+         pin records it ("checkpoint artifacts below v9 are rejected and must
+         be reset", scripts/oas-agent-sdk-pin.sh). Before this, the unreadable
+         artifact failed [persist_for_state] on every turn, and the keeper hit
+         consecutive turn failures until an operator deleted the file by hand.
+         Logged at warn with both generations so the replacement is visible. *)
+      | Error (Schema_version_mismatch { expected; got }) when got < expected ->
+        Log.Keeper.warn
+          "replacing superseded OAS checkpoint for %s: on-disk schema v%d, this build reads v%d"
+          session_id
+          got
+          expected;
+        Otel_metric_store.inc_counter
+          "masc_keeper_checkpoint_superseded_schema_replaced_total"
+          ~labels:[ ("site", "store_watermark") ]
+          ();
+        write_canonical ~session_dir ~canonical_path ~known:None ckpt
       | Error error -> Error (Existing_checkpoint_unreadable error)
       | Ok (Some existing) when not (String.equal existing.session_id session_id) ->
         Error
@@ -958,22 +1023,7 @@ let save_oas_classified_typed
              })
       | Ok existing ->
         let known = Option.map (fun (w : watermark) -> w.turn_count) existing in
-        let ownership_root = Filename.dirname session_dir in
-        (match
-           Keeper_fs.save_json_durable_atomic_from
-             ~ownership_root
-             ~pretty:false
-             canonical_path
-             (fun () -> Agent_sdk.Checkpoint.to_json ckpt)
-         with
-         | Error error -> Error (Canonical_write_failed error)
-         | Ok () ->
-           archive_oas_history_best_effort ~session_dir ckpt;
-           Ok
-             (Saved
-                { relation = save_relation ~known ~incoming:ckpt.turn_count
-                ; turn_count = ckpt.turn_count
-                })))
+        write_canonical ~session_dir ~canonical_path ~known ckpt)
 
 let save_oas_classified ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
   : (save_oas_outcome, string) result =

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -95,6 +95,19 @@ val with_session_lock :
     cold-start absence from real I/O / parse / SDK errors. *)
 type checkpoint_load_error =
   | Not_found
+  | Schema_version_mismatch of
+      { expected : int
+      ; got : int
+      }
+      (** The artifact parsed but belongs to another schema generation.
+          [expected] is what this build reads; [got] is what is on disk. Both
+          are kept because the direction decides the outcome: [got < expected]
+          is a superseded artifact an older build wrote, which
+          {!save_oas_classified_typed} replaces; [got > expected] is a
+          downgrade against state a newer build still reads, which stays an
+          error. Same reason [Not_found] is not string-matched — the SDK
+          reports this typed, and flattening it puts the decision behind a
+          message. *)
   | Store_error of string
   | Parse_error of string
   | Io_error of string

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -235,13 +235,23 @@ let load_context_from_checkpoint ~trace_id ~base_dir =
          ~labels:[("operation", Keeper_checkpoint_failure_operation.(to_label Oas_sdk))]
          ();
        Log.Keeper.error "keeper:%s OAS checkpoint SDK error: %s" trace_id detail
+   (* Not a load failure and deliberately not counted under
+      [CheckpointFailures]: the artifact belongs to a different schema
+      generation, so there was never anything this build could resume. Same
+      outcome as [Not_found] — cold start — but logged with both generations,
+      because unlike an absent file this one still occupies disk and an
+      operator may want it reset. *)
+   | Error (Schema_version_mismatch { expected; got }) ->
+       Log.Keeper.warn
+         "keeper:%s OAS checkpoint schema v%d is not this build's v%d; starting cold"
+         trace_id got expected
    | Error Not_found ->
        Log.Keeper.debug "keeper:%s OAS checkpoint not found" trace_id
    | Ok _ -> ());
   let oas_checkpoint =
     (match oas_result with
      | Ok v -> Some v
-     | Error Not_found -> None
+     | Error Not_found | Error (Schema_version_mismatch _) -> None
      | Error _ ->
        Log.Keeper.warn
          "keeper:%s OAS checkpoint unavailable after explicit load diagnostics"

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -116,6 +116,8 @@ let compaction_recovery_error_to_tag = function
 
 let checkpoint_load_error_detail = function
   | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
+  | Schema_version_mismatch { expected; got } ->
+    Printf.sprintf "checkpoint schema v%d is not this build's v%d" got expected
   | Store_error detail
   | Parse_error detail
   | Io_error detail

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -45,6 +45,13 @@ let checkpoint_load_error_json
   let status, kind, detail =
     match error with
     | Not_found -> "missing", "not_found", `Null
+    (* Not "missing": the file is on disk, this build just reads another schema
+       generation. An operator seeing "missing" would look for a write failure
+       that never happened. *)
+    | Schema_version_mismatch { expected; got } ->
+      ( "unavailable"
+      , "schema_version_mismatch"
+      , `String (Printf.sprintf "schema v%d is not this build's v%d" got expected) )
     | Store_error detail -> "unavailable", "store_error", `String detail
     | Parse_error detail -> "unavailable", "parse_error", `String detail
     | Io_error detail -> "unavailable", "io_error", `String detail
@@ -63,6 +70,12 @@ let current_checkpoint_error_json
   =
   match error with
   | Not_found -> `Null
+  | Schema_version_mismatch { expected; got } ->
+    `Assoc
+      [ "kind", `String "schema_version_mismatch"
+      ; ( "detail"
+        , `String (Printf.sprintf "schema v%d is not this build's v%d" got expected) )
+      ]
   | Store_error detail ->
     `Assoc [ "kind", `String "store_error"; "detail", `String detail ]
   | Parse_error detail ->
@@ -125,6 +138,7 @@ let inventory_json (config : Workspace.config) (name : string)
         let status =
           match error with
           | Keeper_checkpoint_store.Not_found -> "missing"
+          | Schema_version_mismatch _
           | Store_error _ | Parse_error _ | Io_error _ | Sdk_other_error _ ->
             "unavailable"
         in


### PR DESCRIPTION
## 증상

fleet 전체가 turn 마다 실패했다.

```
Keeper request failed: Internal error: checkpoint sink failed at
after_assistant_collected: existing checkpoint unreadable:
version mismatch: expected 9, got 8
```

`verifier: turn failure observed (consecutive=5)`, `lane-smith: turn terminal (non-exhaustion error)` 로 이어졌고, 로그에 **261 건** 이 쌓였다. 운영자가 손으로 아티팩트를 지운 뒤에야 멈췄다 (`~/me/.masc/backups-v8-fleet-hard-cut-…`). 디스크 실측: `oas-snapshot-*.json` 117 개가 전부 `version=8`.

## 이건 예외가 아니라 계약이다

`scripts/oas-agent-sdk-pin.sh:5,12-13` 이 이미 적어 두었다:

> `v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8 rejected; #2867)`
> **`Upgrade blast radius: OAS checkpoint artifacts below v9 are rejected and must be reset.`**

계약이 "리셋된다" 인데 코드가 `Internal error` 로 다뤘다. 리셋이 예정된 사건이라면 그 경로에 사람 손이 필요해서는 안 된다.

## 근본 원인 — 타입 정보를 문자열로 뭉갰다

SDK 는 이 사건을 **구조로** 준다. masc 가 경계에서 납작하게 만들었다:

```ocaml
(* 이전 — keeper_checkpoint_store.ml:233 *)
| Serialization (VersionMismatch r) ->
    Parse_error (sprintf "version mismatch: expected %d, got %d" r.expected r.got)
```

그 결과 호출자는 "구세대 아티팩트" 와 "손상된 JSON" 을 구분할 수 없고, 둘 다 fatal 이 된다.

**같은 파일이 같은 실수를 이미 한 번 기록해 두었다.** `keeper_checkpoint_store.ml:206` 의 RFC-0089 G4 주석:

> `[Not_found]` classification was previously string-matched … This was a **string classifier workaround (CLAUDE.md §워크어라운드 #2)**: `Agent_sdk.Error` is already a closed sum type, but `FileOpFailed.detail` flattens the underlying filesystem exception, **throwing away typed provenance.**

`VersionMismatch` 에 똑같은 일이 벌어져 있었다. 같은 근본 수정을 적용한다.

## 변경

**1. 타입을 되돌린다** — `Schema_version_mismatch of { expected : int; got : int }` 를 `checkpoint_load_error` 에 추가하고, SDK 가 준 두 숫자를 그대로 보존한다.

**방향이 결정의 전부이기 때문에** 숫자를 남긴다:

| 관계 | 의미 | 처리 |
|---|---|---|
| `got < expected` | 구 빌드가 쓴 superseded 아티팩트 | 교체 |
| `got > expected` | **신** 빌드가 쓴 것 — 그 빌드에는 살아있는 상태 | 계속 에러 |

**2. save 경로가 판단한다** (`save_oas_classified_typed`). `known_watermark` 가 구세대 아티팩트를 만나면 파일이 없는 것과 같은 위치다 — 두 가드 모두 입력이 없다:

- identity 가드: 경로 자체가 `session_id` 로 키잉되므로 이미 고정
- 단조성 가드: 파싱조차 안 되는 아티팩트는 어떤 turn 에서도 resume 할 수 없으니 되돌아갈 상태가 없다

그래서 `known:None` 으로 정상 쓰기 경로에 합류한다. 두 admission 경로가 `write_canonical` 하나를 공유하도록 추출했다 — 새 분기가 별도 쓰기 코드를 갖지 않는다.

**3. load 경로는 이미 옳았다.** `keeper_context_core.ml` 은 이미 모든 load 실패를 cold start 로 강등하고 있었다. 실패하던 것은 save 뿐이다. `Schema_version_mismatch` 는 `CheckpointFailures` 로 세지 않는다 — 실패가 아니라 세대 교체다. 다만 `Not_found` 와 달리 파일이 디스크를 점유하므로 warn 으로 두 세대를 남긴다.

**4. 소비자 4곳이 컴파일러에 의해 강제되었다** — 대시보드 3곳, `keeper_post_turn`, `masc_checkpoint_purge`. catch-all 을 넣지 않았고, 대시보드는 `"missing"` 이 아니라 `"schema_version_mismatch"` 로 보고한다. 파일은 있고 이 빌드가 다른 세대를 읽을 뿐인데 `"missing"` 으로 보이면 운영자가 일어나지도 않은 쓰기 실패를 찾게 된다.

## 검증

**로컬 빌드를 돌리지 않았다.** 작성자가 직접 빌드하기로 했다. CI 결과 확인이 필요하다.

작업 중 사용자 셸의 bare `dune build` 가 machine-wide 락을 잡고 있어 `scripts/dune-local.sh` 가 거부되었다. 그 거부 메시지를 성공으로 오독한 시점이 있었고, 그 뒤 소비 지점 2곳이 미처리 상태였음을 grep 으로 발견해 수정했다. 현재 6개 소비 지점 전부가 새 variant 를 명시적으로 다룬다 (`grep -c 'Schema_version_mismatch'`: 대시보드 3, context_core 2, post_turn 1, purge 1).

## 다루지 않은 것

이번 사건에서 이미 디스크에 있던 v8 아티팩트는 운영자가 리셋했다. 이 변경은 **앞으로의** 하드컷에서 같은 일이 반복되지 않게 한다 — 다음 세대 전환 때 fleet 이 스스로 넘어간다.

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. checkpoint 저장소의 에러 분류 변경이다.

WORKAROUND-WAIVED: 문자열 분류기를 **제거**하고 타입을 복원한다. 게이트/카운터/캡을 추가하지 않으며, 새 분기는 SDK 가 이미 typed 로 주는 정보를 그대로 쓴다. 핀을 낮추거나 검사를 우회하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
