### PR TITLE
test(oas): align prompt-only conformance labels

### DIFF
--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -693,11 +693,11 @@ let () =
     "librarian_exact_output_conformance"
     [ ( "exact output"
       , [ Alcotest.test_case
-            "JSON-only target is admitted and persisted"
+            "prompt-only target is admitted and persisted"
             `Quick
             test_prompt_only_target_is_admitted_and_persisted
         ; Alcotest.test_case
-            "missing JSON capability fails before dispatch"
+            "prompt-only target needs no wire JSON capability"
             `Quick
             test_prompt_only_target_needs_no_wire_json_capability
         ; Alcotest.test_case


### PR DESCRIPTION
대상 커밋: `56a612702c4993b2a40757c7b58b1fbc0de1ccf8`

#26272에서 동작은 prompt-only로 바뀌었지만 남아 있던 반대 의미 테스트 표시명 2개를 바로잡았어용. 실행 로직은 건드리지 않았어용.

검증:
- `ocamlformat --inplace test/test_librarian_exact_output_conformance.ml`
- `ocamlc -stop-after parsing -impl test/test_librarian_exact_output_conformance.ml`
- `git diff --check`

Dune 빌드와 테스트는 CI에서 확인해용.