### PR TITLE
fix(memory-os): stop gating consolidation on claim kind

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -34,12 +34,10 @@ let wire_field_claim_kind = Keeper_memory_os_types.wire_field_claim_kind
    into the numbered input list) state the same thing or supersede one another,
    and should collapse into one [consolidated_claim] under [category].
 
-   [claim_kind] is the origin tag the judge assigns to the row it is authoring.
-   A merged row is a new claim, so its tag is a judgement like [category], not a
-   union of the members' tags — there is nothing to represent losslessly. [None]
-   means the judge did not state one, which is a different case from "the judge
-   said untagged" only in that [apply_plan] then falls back to the members'
-   unanimous tag and refuses the group when they disagree. *)
+   [claim_kind] is the optional origin tag the judge assigns to the row it is
+   authoring. A merged row is a new claim, so its tag is a judgement like
+   [category], not a union of the members' tags. [None] means exactly that the
+   judge did not state a tag; it is data, not an admission decision. *)
 type merge_group =
   { member_indices : int list
   ; consolidated_claim : string
@@ -105,46 +103,6 @@ let render_numbered_facts facts =
   |> String.concat "\n"
 ;;
 
-(* The tag the merged row carries, or [Error] when the plan does not determine
-   one and the code must not invent it.
-
-   A stated tag is taken as given, like [category]: both are judgements about the
-   row the LLM is authoring. [merge_group_of_json] has already bounded it to
-   [librarian_claim_kinds] — the three provider-emittable variants, [Diagnostic]
-   excluded — so it is narrower than [category], which admits [Unknown of
-   string]. No further check restricts it to the members' tags.
-
-   An earlier draft added one, justified as RFC-0285's anti-laundering rule. That
-   rule reads "gate at the consolidator / Tier-2 promotion call site: exclude
-   claim_kind = Self_observation before promotion" (RFC-0285 §3.5). The
-   "consolidator" it names is [keeper_memory_os_consolidator], the Tier-2
-   cross-keeper promoter PR #24332 deleted — not this Tier-1 within-keeper merge,
-   which promotes nothing out of the keeper. The rule protects Tier-2 membership,
-   and Tier-2 has no writer today.
-
-   The narrowing also had no harm to prevent: nothing branches on [claim_kind]
-   (RFC-0285 §3.4's [fact_valid_until] arm was specified and never implemented).
-   If §3.4 lands, [claim_kind] starts deciding a horizon and a relabel gains a
-   mechanical effect — reinstate the narrowing then, in the same change.
-
-   The [Undetermined] refusal is not that kind of gate. With nothing stated and
-   members that disagree, there is no value to write: [None] would mean "producer
-   emitted no tag", and the read boundary omits the field for it
-   (server_dashboard_http_keeper_api.ml:236-237), so the row would be
-   indistinguishable from a never-tagged one. The judge clears it by stating a
-   tag — unlike the deleted [valid_until] equality gate, which nothing could. *)
-let claim_kind_for_group ~members (group : merge_group) =
-  match group.claim_kind with
-  | Some stated -> Ok (Some stated)
-  | None ->
-    (match
-       List.sort_uniq compare (List.map (fun (m : fact) -> m.claim_kind) members)
-     with
-     | [ single ] -> Ok single
-     | [] -> Ok None
-     | _ :: _ :: _ -> Error `Undetermined)
-;;
-
 (* ---------- JSON parsing (defensive, like the librarian) ---------- *)
 
 let int_list_of_json = function
@@ -177,14 +135,10 @@ let merge_group_of_json json =
   with
   | Some indices_json, Some claim, Some category_str
     when String.trim claim <> "" ->
-    (* An absent, null, or unparseable tag degrades to "not stated" rather than
-       dropping the group: the claim and members are the judgement that matters,
-       and [apply_plan] still refuses to guess when the members disagree.
-       Deliberately unlike [persisted_claim_kind_of_json], which rejects the
-       whole row on an invalid label — that guards stored schema integrity, while
-       this is a producer boundary where RFC-0285 §7 fixes the degrade direction:
-       "a missed tag degrades to pre-RFC status quo (safe), never to
-       wrong-volatile". Member inheritance IS that status quo. *)
+    (* An absent, null, or unparseable tag means "not stated" rather than
+       dropping the group: the claim and members are the judgement that matters.
+       Unlike persisted fact parsing, this provider boundary does not use an
+       optional annotation as a second admission contract. *)
     let claim_kind =
       match Option.bind (string_field wire_field_claim_kind json) claim_kind_of_string with
       (* [Diagnostic] is system-authored: [librarian_claim_kinds] withholds it
@@ -324,10 +278,10 @@ let shared_claim_id_for_members members =
   | [] | _ :: _ :: _ -> None
 ;;
 
-(* The consolidated fact for one group: claim/category come from the LLM;
-   provenance is reconstructed structurally, [valid_until] is combined by the
-   meet above, and [claim_kind] is whatever [claim_kind_for_group] resolved. *)
-let consolidated_fact ~now:_ ~members ~claim_kind (group : merge_group) =
+(* The consolidated fact for one group: claim/category and the optional
+   [claim_kind] annotation come from the LLM; provenance is reconstructed
+   structurally and [valid_until] is combined by the meet above. *)
+let consolidated_fact ~now:_ ~members (group : merge_group) =
   let earliest =
     match members with
     | [] -> invalid_arg "Keeper_memory_os_consolidation.consolidated_fact: empty members"
@@ -342,7 +296,7 @@ let consolidated_fact ~now:_ ~members ~claim_kind (group : merge_group) =
   in
   { claim = group.consolidated_claim
   ; category = group.category
-  ; claim_kind
+  ; claim_kind = group.claim_kind
   ; source = earliest.source
   ; first_seen
   ; valid_until = valid_until_for_members members
@@ -358,7 +312,6 @@ let consolidated_fact ~now:_ ~members ~claim_kind (group : merge_group) =
    cannot control must not decide whether its judgement applies. *)
 type apply_stats =
   { merged_groups : int
-  ; rejected_kind_mismatch : int
   ; rejected_too_few_members : int
   ; dropped : int
   }
@@ -383,7 +336,6 @@ let apply_plan ~now ~facts plan =
   let in_range i = i >= 0 && i < n in
   let dedup_sorted is = List.sort_uniq compare (List.filter in_range is) in
   let merged_groups = ref 0 in
-  let rejected_kind_mismatch = ref 0 in
   let rejected_too_few_members = ref 0 in
   List.iter
     (fun group ->
@@ -396,28 +348,25 @@ let apply_plan ~now ~facts plan =
        if List.length members >= 2
        then (
          let member_facts = List.map (fun i -> facts_arr.(i)) members in
-         match claim_kind_for_group ~members:member_facts group with
-         | Error `Undetermined -> incr rejected_kind_mismatch
-         | Ok claim_kind ->
-           let anchor =
-             (* members is guaranteed non-empty by the [>= 2] guard above *)
-             match members with
-             | [] -> invalid_arg "Keeper_memory_os_consolidation.apply_plan: empty group"
-             | first :: rest ->
-               List.fold_left
-                 (fun acc i ->
-                    if facts_arr.(i).first_seen < facts_arr.(acc).first_seen
-                    then i
-                    else acc)
-                 first
-                 rest
-           in
-           List.iter (fun i -> slot.(i) <- `Consumed) members;
-           incr merged_groups;
-           Hashtbl.replace
-             consolidated
-             anchor
-             (consolidated_fact ~now ~members:member_facts ~claim_kind group))
+         let anchor =
+           (* members is guaranteed non-empty by the [>= 2] guard above *)
+           match members with
+           | [] -> invalid_arg "Keeper_memory_os_consolidation.apply_plan: empty group"
+           | first :: rest ->
+             List.fold_left
+               (fun acc i ->
+                  if facts_arr.(i).first_seen < facts_arr.(acc).first_seen
+                  then i
+                  else acc)
+               first
+               rest
+         in
+         List.iter (fun i -> slot.(i) <- `Consumed) members;
+         incr merged_groups;
+         Hashtbl.replace
+           consolidated
+           anchor
+           (consolidated_fact ~now ~members:member_facts group))
        else incr rejected_too_few_members)
     plan.groups;
   let dropped = ref 0 in
@@ -442,7 +391,6 @@ let apply_plan ~now ~facts plan =
   done;
   ( !out
   , { merged_groups = !merged_groups
-    ; rejected_kind_mismatch = !rejected_kind_mismatch
     ; rejected_too_few_members = !rejected_too_few_members
     ; dropped = !dropped
     } )

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -9,12 +9,9 @@
     cannot fabricate a survivor; an unreferenced fact is kept unchanged; a group
     needs >= 2 in-range members to merge; out-of-range/duplicate indices skip.
 
-    [valid_until] is no longer a precondition: it is derived from write-time
-    policy, so exact timestamp equality is not a semantic grouping contract. It
-    is combined by a meet at apply time instead. [claim_kind] is no longer a
-    precondition either — the judge states the merged row's tag, and the group is
-    refused only when it states nothing while the members disagree. Every
-    remaining refusal is one the judge can clear by restating its plan. *)
+    [valid_until] and [claim_kind] are not preconditions. The former is combined
+    by a meet at apply time; the latter is an optional annotation on the new row.
+    Neither closes an otherwise structurally valid merge. *)
 
 open Keeper_memory_os_types
 
@@ -25,12 +22,9 @@ val wire_field_groups : string
 val wire_field_drop_indices : string
 val wire_field_claim_kind : string
 
-(** [claim_kind] is the origin tag the judge assigns to the row it authors, like
-    [category] — a merged row is a new claim, not a union needing lossless
-    representation. [None] is "not stated": {!apply_plan} then inherits the
-    members' one distinct tag, or refuses the group when they disagree rather
-    than writing [None], which would mean "producer emitted no tag" and is
-    omitted entirely at the read boundary. *)
+(** [claim_kind] is the optional origin tag the judge assigns to the row it
+    authors, like [category]. [None] means the judge emitted no tag and never
+    changes whether the group is applied. *)
 type merge_group =
   { member_indices : int list
   ; consolidated_claim : string
@@ -76,15 +70,11 @@ val plan_result_of_string :
     empty_plan]-equivalent. *)
 val plan_of_string : string -> consolidation_plan option
 
-(** Typed apply outcome breakdown, so "the judge proposed no merges" does not
-    collapse into the same silent before = after as "the plan was rejected".
-    [rejected_kind_mismatch] is the gate disagreement worth alerting on;
-    [rejected_too_few_members] is expected behavior, since first-group-wins
-    legitimately shrinks a later overlapping group below two free members on
-    ordinary contested-duplicate plans. *)
+(** Typed apply outcome breakdown. [rejected_too_few_members] is structural:
+    first-group-wins can legitimately shrink a later overlapping group below
+    two free members on ordinary contested-duplicate plans. *)
 type apply_stats =
   { merged_groups : int
-  ; rejected_kind_mismatch : int
   ; rejected_too_few_members : int
   ; dropped : int
   }
@@ -102,15 +92,10 @@ type apply_stats =
     That invariant holds unconditionally because expired rows never reach here —
     {!Keeper_memory_os_consolidation_runtime} partitions them out before the
     judge sees the store, so no group can mix a dead row with a live one.
-    The merged row's [claim_kind] is the judge's stated tag, taken as given like
-    [category]; parsing has already bounded it to the closed variants, and no
-    code branches on it, so no admissibility rule narrows it further. When the
-    judge states nothing, one distinct member tag is inherited and disagreement
-    is rejected and counted — the code will not invent a tag, and [None] is not
-    available as a stand-in because it means "producer emitted no tag".
-    [render_numbered_facts] shows the judge each member's tag so that refusal is
-    never hit blind. Explicitly dropped indices are removed; every other fact
-    survives unchanged. *)
+    The merged row's [claim_kind] is the judge's optional stated tag, taken as
+    given like [category]. When absent it remains [None]; no member comparison or
+    fallback decides admission. Explicitly dropped indices are removed; every
+    other fact survives unchanged. *)
 val apply_plan
   :  now:float
   -> facts:fact list

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -235,26 +235,7 @@ let consolidate_keeper
                     Consolidation.apply_plan ~now:plan_now ~facts:live plan
                   in
                   let survivors = live_survivors @ expired in
-                  (* A kind mismatch means the judge and the apply gate disagreed
-                     on a field the prompt renders, so it is loud. The
-                     valid_until arm is gone: that gate compared write instants
-                     the judge could not control, so it fired on ordinary plans
-                     and buried this signal. Below-two-free-members is expected
-                     on contested-duplicate plans and stays at info. *)
-                  if stats.rejected_kind_mismatch > 0
-                  then (
-                    Log.Keeper.warn
-                      "memory_os_keeper_consolidation rejected %d group(s) at the claim_kind gate keeper=%s (merged=%d dropped=%d too_few_members=%d)"
-                      stats.rejected_kind_mismatch
-                      keeper_id
-                      stats.merged_groups
-                      stats.dropped
-                      stats.rejected_too_few_members;
-                    Otel_metric_store.inc_counter
-                      Keeper_metrics.(to_string MemoryOsConsolidationGroupRejected)
-                      ~labels:[ "keeper", keeper_id ]
-                      ())
-                  else if stats.rejected_too_few_members > 0
+                  if stats.rejected_too_few_members > 0
                   then
                     Log.Keeper.info
                       "memory_os_keeper_consolidation skipped %d group(s) below two free members keeper=%s (merged=%d dropped=%d)"

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -194,7 +194,6 @@ type t =
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
-  | MemoryOsConsolidationGroupRejected
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts
@@ -423,8 +422,6 @@ let to_string = function
       "masc_keeper_memory_os_recall_bytes_over_budget_total"
   | MemoryOsEpisodeRetentionPruned ->
       "masc_keeper_memory_os_episode_retention_pruned_total"
-  | MemoryOsConsolidationGroupRejected ->
-      "masc_keeper_memory_os_consolidation_group_rejected_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
   | VisionAnalyze -> "masc_keeper_vision_analyze_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -185,7 +185,6 @@ type t =
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
-  | MemoryOsConsolidationGroupRejected
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -212,14 +212,10 @@ let test_apply_accepts_model_category_selection () =
     (claims (apply_plan_facts ~now ~facts plan))
 ;;
 
-(* RFC-0285 §3.1: category is orthogonal to [claim_kind], so the LLM can group a
-   Self_observation with a durable claim of the SAME category. With no stated
-   [claim_kind] the plan does not determine the merged row's tag, and the code
-   must not pick one: inheriting by first_seen order would either immortalize the
-   self-observation or expire the durable claim, and writing [None] would mean
-   "producer emitted no tag" — a row the read boundary renders identically to a
-   never-tagged one. Refuse instead; the judge can clear this by stating a tag. *)
-let test_apply_rejects_undetermined_claim_kind () =
+(* [claim_kind] is an optional annotation, not a second merge decision. Mixed
+   member tags therefore do not reject an otherwise valid model-selected group
+   when the judge omits the annotation. *)
+let test_apply_accepts_unstated_claim_kind () =
   let facts =
     [ fact
         ~first_seen:100.0
@@ -244,12 +240,9 @@ let test_apply_rejects_undetermined_claim_kind () =
     ; drop_indices = []
     }
   in
-  Alcotest.(check (list string))
-    "undetermined-claim_kind group is skipped; both facts survive unchanged"
-    [ "Bounded retries prevent loop starvation"
-    ; "the agent is stuck in a retry loop this turn"
-    ]
-    (claims (apply_plan_facts ~now ~facts plan))
+  let merged = only_fact (apply_plan_facts ~now ~facts plan) in
+  Alcotest.(check string) "mixed member kinds still merge" "retry loops need bounds" merged.claim;
+  Alcotest.(check bool) "an omitted tag remains absent" true (merged.claim_kind = None)
 ;;
 
 (* The same mixed-kind group merges once the judge states which tag the row it is
@@ -313,10 +306,6 @@ let test_apply_accepts_claim_kind_no_member_carries () =
   in
   let _survivors, stats = Consolidation.apply_plan ~now ~facts plan in
   Alcotest.(check int) "the group merges" 1 stats.Consolidation.merged_groups;
-  Alcotest.(check int)
-    "no kind rejection: a stated tag is not narrowed to the members'"
-    0
-    stats.Consolidation.rejected_kind_mismatch;
   let merged = only_fact (apply_plan_facts ~now ~facts plan) in
   Alcotest.(check bool)
     "the merged row carries the stated tag"
@@ -572,9 +561,8 @@ let test_render_numbered_facts_keeps_one_fact_per_line () =
     (String.split_on_char '\n' rendered)
 ;;
 
-(* The judge must see every field the apply gate compares (claim_kind and
-   valid_until) — hiding them made every gate rejection a blind coin flip. *)
-let test_render_numbered_facts_shows_gate_fields () =
+(* The judge sees kind and validity as claim context, not apply gates. *)
+let test_render_numbered_facts_shows_context_fields () =
   let rendered =
     Consolidation.render_numbered_facts
       [ fact ~claim_kind:(Some Types.External_state) ~valid_until:1_800_000.0 "PR open"
@@ -601,9 +589,7 @@ let test_render_numbered_facts_shows_gate_fields () =
    | other -> Alcotest.failf "expected 2 lines, got %d" (List.length other))
 ;;
 
-(* Structural rejection is typed and counted: 'the judge proposed no merges'
-   and 'every merge was rejected' must not collapse into one silent outcome. *)
-let test_apply_stats_count_rejections () =
+let test_apply_stats_count_structural_skips () =
   let facts =
     [ fact ~claim_kind:(Some Types.Durable_knowledge) "durable rule"
     ; fact ~claim_kind:(Some Types.Self_observation) "transient state"
@@ -633,11 +619,7 @@ let test_apply_stats_count_rejections () =
     }
   in
   let _survivors, stats = Consolidation.apply_plan ~now ~facts plan in
-  Alcotest.(check int) "one merged group" 1 stats.Consolidation.merged_groups;
-  Alcotest.(check int)
-    "one kind-mismatch rejection"
-    1
-    stats.Consolidation.rejected_kind_mismatch;
+  Alcotest.(check int) "both valid groups merge" 2 stats.Consolidation.merged_groups;
   Alcotest.(check int)
     "consumed/short group counted as too few members"
     1
@@ -671,11 +653,7 @@ let test_first_group_wins_lands_in_too_few_bucket () =
   Alcotest.(check int)
     "later overlapping group lands in the too-few bucket"
     1
-    stats.Consolidation.rejected_too_few_members;
-  Alcotest.(check int)
-    "an ordinary contested plan raises no kind-gate rejection"
-    0
-    stats.Consolidation.rejected_kind_mismatch
+    stats.Consolidation.rejected_too_few_members
 ;;
 
 (* The wire path for the judge-stated tag. Without this, a key or token rename
@@ -809,9 +787,9 @@ let () =
 	        ; Alcotest.test_case "accepts model category change" `Quick test_apply_accepts_model_category_change
 	        ; Alcotest.test_case "accepts model category selection" `Quick test_apply_accepts_model_category_selection
         ; Alcotest.test_case
-            "rejects undetermined claim_kind"
+            "accepts an unstated claim_kind"
             `Quick
-            test_apply_rejects_undetermined_claim_kind
+            test_apply_accepts_unstated_claim_kind
         ; Alcotest.test_case
             "merges mixed kinds when the judge states the tag"
             `Quick
@@ -870,13 +848,13 @@ let () =
             `Quick
             test_render_numbered_facts_keeps_one_fact_per_line
         ; Alcotest.test_case
-            "shows kind and until to the judge"
+            "shows kind and until context to the judge"
             `Quick
-            test_render_numbered_facts_shows_gate_fields
+            test_render_numbered_facts_shows_context_fields
         ; Alcotest.test_case
-            "apply stats count rejections"
+            "apply stats count structural skips"
             `Quick
-            test_apply_stats_count_rejections
+            test_apply_stats_count_structural_skips
         ; Alcotest.test_case
             "first-group-wins lands in the too-few bucket"
             `Quick


### PR DESCRIPTION
## Problem

Memory consolidation refused an otherwise valid group when generated `claim_kind` values were missing or differed. That annotation became a merge admission gate, so model output shape could block consolidation even though the group already carried the durable category SSOT.

## Change

- delete `claim_kind_for_group` equality validation and refusal paths
- derive the consolidated fact category from the group authority
- remove rejected-kind stats, warnings, metrics, and tests
- cover mixed or omitted claim annotations consolidating successfully

`claim_kind` remains optional provenance where present; it no longer owns whether facts merge.

## Validation

- `git diff --check`
- `ocamlformat --check` on all changed OCaml files
- focused Dune build was blocked by the machine-wide Dune/opam lock deadlock tracked in #26281
- PR CI is the build authority for this draft

RFC-WAIVED: internal Memory OS consolidation simplification; no credentials, sandbox, hooks, workflow, or public tool schema change.

WORKAROUND-WAIVED: deletes the generated-field gate rather than accepting extra aliases or fallback values.