### PR TITLE
fix(keeper): make the turn mutex the admission authority

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -596,14 +596,11 @@ let run ~sw ~clock ~base_path ~handle_turn =
       let admission =
         Keeper_turn_admission.snapshot_for ~base_path ~keeper_name
       in
-      (match
-         admission.snapshot_in_flight,
-         admission.snapshot_shutdown_operation_id
-       with
-       | Some _, _ | _, Some _ ->
+      (match admission.snapshot_shutdown_operation_id with
+       | Some _ ->
          nack_or_warn dispatch_state ~keeper_name ~lease_id;
          release keeper_name
-       | None, None ->
+       | None ->
          (match delivery_key with
           | Error detail ->
             finalize_or_warn dispatch_state ~keeper_name ~lease_id
@@ -661,12 +658,9 @@ let run ~sw ~clock ~base_path ~handle_turn =
         let admission =
           Keeper_turn_admission.snapshot_for ~base_path ~keeper_name
         in
-        (match
-           admission.snapshot_in_flight,
-           admission.snapshot_shutdown_operation_id
-         with
-         | Some _, _ | _, Some _ -> release keeper_name
-         | None, None ->
+        (match admission.snapshot_shutdown_operation_id with
+         | Some _ -> release keeper_name
+         | None ->
            (match Keeper_chat_queue.lease_next ~keeper_name with
             | `Empty -> release keeper_name
             | `Already_leased _ -> release keeper_name

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -58,15 +58,15 @@ type turn_outcome =
     release, and explicit operator reconciliation; it performs no fleet-wide
     timer polling.
 
-    Per Keeper wake: when a turn is in flight
-    ([Keeper_turn_admission.in_flight]), queued messages are left to
-    accumulate; once the slot is free, the exact FIFO head receipt is leased
-    ([Keeper_chat_queue.lease_next]) into one typed turn. User-message identity,
-    multimodal blocks, transcript provenance, and receipt correlation are never
-    flattened into a delimiter string. The turn then runs in a Keeper-scoped child fiber, so a slow queued turn for one
-    keeper does not block wake processing or delivery for other keepers.  A
-    keeper-local dispatch gate preserves the single follow-up turn contract
-    for messages sent during an existing queued turn.
+    Per Keeper wake, the exact FIFO head receipt is leased
+    ([Keeper_chat_queue.lease_next]) and its handler parks on the authoritative
+    Keeper turn mutex even when another turn is in flight. User-message
+    identity, multimodal blocks, transcript provenance, and receipt correlation
+    are never flattened into a delimiter string. The turn then runs in a
+    Keeper-scoped child fiber, so a slow queued turn for one keeper does not
+    block wake processing or delivery for other keepers. A keeper-local
+    dispatch gate preserves the single follow-up turn contract for messages
+    sent during an existing queued turn.
 
     [handle_turn]'s typed terminal outcome is durably finalized as [Delivered]
     or [Failed]. [Deferred] and structured cancellation nack the unchanged

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -227,13 +227,6 @@ let run_keeper_cycle_with
   =
   let busy_outcome block =
     (match block with
-     | Keeper_turn_admission.Chat_backlog { pending_count; inflight_count } ->
-       Log.Keeper.info
-         "%s: yielding autonomous cycle to chat backlog (pending=%d inflight=%d); \
-          skipping until next heartbeat"
-         meta_after_triage.name
-         pending_count
-         inflight_count
      | Keeper_turn_admission.Shutdown_requested operation_id ->
        Log.Keeper.info
          "%s: autonomous turn admission closed by shutdown operation %s"

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -21,10 +21,6 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
-  | Chat_backlog of
-      { pending_count : int
-      ; inflight_count : int
-      }
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 type rejection =
@@ -82,7 +78,6 @@ let lane_to_string = function
 
 let autonomous_block_kind = function
   | Turn_busy _ -> "turn_busy"
-  | Chat_backlog _ -> "chat_backlog"
   | Shutdown_requested _ -> "shutdown_requested"
 ;;
 
@@ -93,11 +88,6 @@ let autonomous_block_to_string = function
       "reason=turn_busy holder_lane=%s holder_started_at=%.17g"
       (lane_to_string lane)
       started_at
-  | Chat_backlog { pending_count; inflight_count } ->
-    Printf.sprintf
-      "reason=chat_backlog pending_count=%d inflight_count=%d"
-      pending_count
-      inflight_count
   | Shutdown_requested operation_id ->
     Printf.sprintf
       "reason=shutdown_requested operation_id=%s"
@@ -116,12 +106,6 @@ let autonomous_block_to_yojson = function
           ]
     in
     `Assoc [ "kind", `String "turn_busy"; "holder", holder_json ]
-  | Chat_backlog { pending_count; inflight_count } ->
-    `Assoc
-      [ "kind", `String "chat_backlog"
-      ; "pending_count", `Int pending_count
-      ; "inflight_count", `Int inflight_count
-      ]
   | Shutdown_requested operation_id ->
     `Assoc
       [ "kind", `String "shutdown_requested"
@@ -302,87 +286,41 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
-let admit_autonomous_with_token ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous_with_token ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  (* Yield to deferred work before touching the lock. [waiting > 0] implies
-     the slot is held (a waiter only parks because a turn is in flight), so
-     [try_lock] would fail here anyway; the explicit check keeps the
-     autonomous lane from competing for a slot a parked chat is already
-     queued on. A non-empty [Keeper_chat_queue] means a busy connector
-     (Slack/Discord) or dashboard message is deferred for this keeper but
-     has not parked on the slot; the standard autonomous lane must yield for
-     it too, otherwise a long or back-to-back autonomous turn starves that
-     queue indefinitely (the busy-ACK loop). Reading the queue length is a
-     lock-only, non-suspending peek and is the SSOT signal that closes the
-     gap: the autonomous lane cooperates on the same backlog the consumer
-     drains, so the consumer's [in_flight = None] window opens
-     deterministically instead of racing the next autonomous cycle. Once a
-     receipt is leased, the actual per-Keeper turn mutex is the authority for
-     whether its chat turn is still executing. An inflight receipt with a free
-     mutex may be between delivery and finalization or stranded after failure;
-     it must not become a second, durable global turn lock.
-
-     [yield_to_chat_backlog:false] (the manual-compaction lane) skips only
-     that queue peek: the backlog yield presumes the chat consumer can make
-     progress, and a context-overflowed keeper violates that premise — its
-     chat turns fail until compaction rewrites the checkpoint, so queueing
-     the compaction cycle behind the backlog inverts the priority and
-     starves both lanes (#24865). *)
+  (* A turn is unavailable only when shutdown owns the lifecycle boundary or
+     the actual per-Keeper mutex is held. Waiting telemetry and durable chat
+     receipts are observations, not independent admission authorities. *)
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
-  | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
-  | None ->
-    let chat_backlog =
-      if yield_to_chat_backlog
-      then (
-        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-        (* Queue persistence/read failures remain typed Chat-boundary
-           failures. They are not evidence of queued work and therefore
-           cannot close an otherwise independent autonomous lane. *)
-        match List.length snapshot.pending, List.length snapshot.inflight with
-        | 0, _ -> None
-        | pending_count, 0 ->
-          Some (Chat_backlog { pending_count; inflight_count = 0 })
-        | _, _ -> None)
-      else None
-    in
-    (match chat_backlog with
-     | Some block -> `Busy block
-     | None ->
-       if Eio.Mutex.try_lock slot.turn_mu
-       then (
-         match run_locked_with_token slot ~lane:Autonomous f with
-         | `Ran value -> `Ran value
-         | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
-       else `Busy (Turn_busy (peek_info slot)))
+  | None when Eio.Mutex.try_lock slot.turn_mu ->
+    (match run_locked_with_token slot ~lane:Autonomous f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+  | None -> `Busy (Turn_busy (peek_info slot))
 ;;
 
-let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous ~base_path ~keeper_name f =
   admit_autonomous_with_token
-    ~yield_to_chat_backlog
     ~base_path
     ~keeper_name
     (fun _token -> f ())
 ;;
 
 let run_if_free_with_token ~base_path ~keeper_name f =
-  admit_autonomous_with_token
-    ~yield_to_chat_backlog:true
-    ~base_path
-    ~keeper_name
-    f
+  admit_autonomous_with_token ~base_path ~keeper_name f
 ;;
 
 let run_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:true ~base_path ~keeper_name f
+  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_compaction_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
+  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_admin_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
+  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_serialized ~base_path ~keeper_name f =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -40,20 +40,6 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
-  | Chat_backlog of
-      { pending_count : int
-      ; inflight_count : int
-      }
-    (** The slot mutex itself is free and pending [Keeper_chat_queue] receipts
-        exist without a currently leased receipt; the standard autonomous lane
-        yields so the chat consumer can drain them. Inflight receipts are not
-        a second turn lock: an executing chat is fenced by the actual slot,
-        while a stranded/finalizing receipt must not halt unrelated progress.
-        Distinct from [Turn_busy None]
-        (a held slot whose holder has not yet published its info): before
-        this variant existed both cases logged as "holder info not yet
-        published", which mis-directed the #24865 diagnosis toward a stale
-        slot when the durable chat backlog was the actual fence. *)
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 val autonomous_block_kind : autonomous_block -> string
@@ -150,55 +136,24 @@ val run_if_free
     [`Busy (Shutdown_requested id)] means a durable shutdown reservation owns
     admission; no slot is acquired and no turn body runs.
     Exceptions from [f] (including [Eio.Cancel.Cancelled]) release the slot and
-    re-raise.
-
-    Also returns [`Busy] without attempting the lock when a chat request is
-    already parked on this slot ([chat_waiting] is true, reported as
-    [Turn_busy]), or when a busy connector/dashboard receipt is active in
-    [Keeper_chat_queue] for this keeper (pending or inflight, reported as
-    [Chat_backlog] with the exact counts). Eio.Mutex hands a released slot
-    directly to the next parked waiter, so a new autonomous cycle would not
-    overtake a queued chat regardless; these pre-checks make the yield
-    explicit and keep a heartbeat-scheduled cycle from competing for a slot
-    a dashboard/connector message is already waiting on or queued behind.
-    The [Keeper_chat_queue] half closes the starvation gap where a long or
-    back-to-back autonomous turn could otherwise busy-ACK a connector
-    forever: the autonomous lane yields on the same backlog the consumer
-    drains, so the consumer's [in_flight = None] window opens
-    deterministically. Queue persistence/read errors remain explicit typed
-    failures at the Chat mutation/consumer boundary; because they are not
-    queued work, they do not close this independent autonomous lane. *)
+    re-raise. Parked and durable chat work is not a second admission source:
+    mutex ownership is the only in-flight turn authority, and the OAS loop
+    observes {!chat_waiting} at turn boundaries so a parked chat can make
+    progress without closing an otherwise free autonomous lane. *)
 
 val run_compaction_if_free
   :  base_path:string
   -> keeper_name:string
   -> (unit -> 'a)
   -> [ `Ran of 'a | `Busy of autonomous_block ]
-(** [run_if_free] for the manual-compaction critical section, differing in
-    exactly one fence: it does not yield to the [Keeper_chat_queue] backlog
-    and therefore never returns [`Busy (Chat_backlog _)].
-
+(** [run_if_free] for the manual-compaction critical section.
     Sole sanctioned caller: [Keeper_manual_compaction.run_admitted]. The
     admitted section must be the compaction commit only — a deterministic
     checkpoint/FSM operation — never a provider turn; any follow-up turn
-    re-enters [run_if_free] and yields to the backlog. This module cannot
+    re-enters [run_if_free]. This module cannot
     name [Keeper_manual_compaction] types without inverting the layering,
     so the closure stays generic here and the compaction-only shape is
-    enforced at that single wrapper.
-
-    The standard lane's backlog yield assumes the chat consumer can drain
-    the queue. When the keeper's context has overflowed its provider
-    window, chat delivery itself fails until compaction rewrites the
-    checkpoint — so yielding parks the remedy behind the very backlog it
-    is meant to unblock, a priority inversion that starved manual
-    compaction indefinitely (#24865: durable pending receipts fenced every
-    cycle across restarts while the slot mutex stayed free).
-
-    Everything else is unchanged from [run_if_free]: a durable shutdown
-    reservation still fences admission, a parked chat waiter still wins,
-    and a genuinely held slot still returns [`Busy (Turn_busy _)] — this
-    lane never interleaves with an in-flight turn, it only stops queueing
-    behind work that cannot progress. *)
+    enforced at that single wrapper. *)
 
 val run_admin_if_free
   :  base_path:string

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1892,9 +1892,8 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
            (Shutdown_types.Operation_id.equal
               corrupt_operation.operation_id
               operation_id)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-       | `Ran () -> fail "corrupt owner admission was reopened");
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "corrupt owner admission was reopened");
       match Shutdown_runtime.recover_operation ~config recoverable_operation with
       | Ok recovered ->
         check bool
@@ -2347,9 +2346,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            "shutdown admission fence retains operation identity"
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
-      | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-      | `Ran () ->
+      | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
 
 let test_keeper_shutdown_prepare_joins_not_started_lane () =
@@ -2462,11 +2459,7 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) ->
         fail
           "failed shutdown prepare left the keeper admission fence closed: \
-           Turn_busy owns the slot"
-      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _) ->
-        fail
-          "failed shutdown prepare left the keeper admission fence closed: \
-           chat backlog fences the slot")
+           Turn_busy owns the slot")
 
 let install_pending_summary ~base_path ~keeper_name ~bind_exact =
   Approval_queue.For_testing.reset_runtime_state ();
@@ -2910,9 +2903,8 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
        | `Busy (Masc.Keeper_turn_admission.Shutdown_requested reserved) ->
          check bool "pending receipt retains exact admission owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-       | `Ran () -> fail "pending completion reopened admission");
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "pending completion reopened admission");
       Masc.Keeper_turn_admission.For_testing.reset ();
       let boot_inventory =
         match Shutdown_store.scan_inventory ~config with
@@ -2940,9 +2932,8 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
        | `Busy (Masc.Keeper_turn_admission.Shutdown_requested reserved) ->
          check bool "boot-restored fence keeps exact completion owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-       | `Ran () -> fail "boot recovery reopened pending completion admission");
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "boot recovery reopened pending completion admission");
       Shutdown_finalize.register_completion_handler
         Tombstone_cleanup.handle_completion;
       let finalized =

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -84,6 +84,21 @@ let await_promise ~clock ~seconds promise =
       Eio.Time.sleep clock seconds;
       false)
 
+let await_until ~clock ~seconds predicate =
+  Eio.Fiber.first
+    (fun () ->
+      let rec loop () =
+        if predicate ()
+        then true
+        else (
+          Eio.Time.sleep clock 0.02;
+          loop ())
+      in
+      loop ())
+    (fun () ->
+      Eio.Time.sleep clock seconds;
+      false)
+
 let await_receipt ~clock ~seconds ~keeper_name ~receipt_id ~accept =
   Eio.Fiber.first
     (fun () ->
@@ -464,9 +479,17 @@ let test_busy_turn_release_wakes_pending_receipt () =
     let release_holder, resolve_release_holder = Eio.Promise.create () in
     let calls = ref 0 in
     let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
-      incr calls;
-      Keeper_chat_consumer.Delivered
-        { outcome_ref = "trace-busy-release#1" }
+      match
+        Keeper_turn_admission.run_serialized
+          ~base_path:base
+          ~keeper_name
+          (fun () ->
+            incr calls;
+            Keeper_chat_consumer.Delivered
+              { outcome_ref = "trace-busy-release#1" })
+      with
+      | `Ran outcome -> outcome
+      | `Rejected rejection -> Keeper_chat_consumer.Deferred { rejection }
     in
     with_consumer_switch (fun sw ->
       Eio.Fiber.fork ~sw (fun () ->
@@ -489,7 +512,9 @@ let test_busy_turn_release_wakes_pending_receipt () =
       with
       | None -> Eio.Promise.resolve resolve_release_holder ()
       | Some accepted ->
-        Eio.Fiber.yield ();
+        check "consumer parks on the held turn slot"
+          (await_until ~clock ~seconds:5.0 (fun () ->
+             Keeper_turn_admission.chat_waiting ~base_path:base ~keeper_name));
         check "consumer never crosses the held turn slot" (!calls = 0);
         Eio.Promise.resolve resolve_release_holder ();
         check "turn release dispatches without fleet polling"

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -404,19 +404,6 @@ let test_admission_busy_http_json_preserves_typed_detail () =
      |> member "holder"
      |> member "started_at"
      |> to_float);
-  let backlog =
-    admission_error_json
-      (Keeper_turn_admission.Chat_backlog
-         { pending_count = 3; inflight_count = 2 })
-  in
-  Alcotest.(check int)
-    "chat pending count"
-    3
-    (backlog |> member "admission" |> member "pending_count" |> to_int);
-  Alcotest.(check int)
-    "chat inflight count"
-    2
-    (backlog |> member "admission" |> member "inflight_count" |> to_int);
   let operation_id = Keeper_shutdown_types.Operation_id.generate () in
   let shutdown =
     admission_error_json

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -598,18 +598,17 @@ let test_idle_loop_yields_to_parked_chat () =
   check "parked chat admitted after the autonomous turn yielded" !chat_ran
 ;;
 
-let test_autonomous_yields_to_queued_connector_message () =
+let test_autonomous_ignores_chat_queue_state () =
   reset ();
   Printf.printf
-    "Test 10: autonomous lane yields while a connector/dashboard message is queued\n%!";
+    "Test 10: durable chat state is not an autonomous admission authority\n%!";
   (* Sanity: an empty queue lets the autonomous lane run. *)
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> 7) with
    | `Ran 7 -> check "run_if_free admits when the chat queue is empty" true
    | `Ran _ | `Busy _ -> check "run_if_free admits when the chat queue is empty" false);
-  (* A busy connector (Slack/Discord) message is deferred on the chat queue
-     without parking on the admission slot, so [chat_waiting] stays false. The
-     autonomous lane must still yield, or a long/back-to-back autonomous turn
-     busy-ACKs the connector forever (the starvation this pins). *)
+  (* A connector message waiting in its own durable queue does not own the
+     per-Keeper turn mutex. Its consumer competes through that mutex when it
+     actually dispatches. *)
   (match
      Keeper_chat_queue.enqueue ~keeper_name
        { Keeper_chat_queue.content = "deferred slack mention"
@@ -638,10 +637,10 @@ let test_autonomous_yields_to_queued_connector_message () =
     "a queued connector message is not a parked chat"
     (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name));
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy _ ->
-     check "run_if_free yields (Busy) while a connector message is queued" true
    | `Ran () ->
-     check "run_if_free must not admit while a connector message is queued" false);
+     check "pending chat receipt does not close autonomous admission" true
+   | `Busy _ ->
+     check "pending chat receipt must not become a second turn lock" false);
   (* Leasing changes the receipt to Inflight but does not make it disappear.
      The actual turn mutex, not that durable receipt, is the execution fence.
      A free mutex plus an inflight receipt must stay progress-capable even when
@@ -680,14 +679,11 @@ let test_autonomous_yields_to_queued_connector_message () =
       | `Finalized _ -> ()
       | `Unknown_lease | `Error _ ->
         check "finalize commits the terminal receipt" false));
-  (* With the inflight receipt gone, the still-pending chat is again the
-     authoritative backlog and the autonomous lane yields to its consumer. *)
+  (* With the inflight receipt gone, the remaining pending receipt still does
+     not become an admission authority. *)
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog
-       { pending_count = 1; inflight_count = 0 }) ->
-     check "pending-only backlog still has chat priority" true
-   | `Busy _ | `Ran () ->
-     check "pending-only backlog must retain chat priority" false);
+   | `Ran () -> check "pending-only chat state leaves the free slot open" true
+   | `Busy _ -> check "pending-only chat state must not fence the slot" false);
   (match Keeper_chat_queue.lease_next ~keeper_name with
    | `Leased lease ->
      (match
@@ -734,9 +730,7 @@ let test_shutdown_reservation_fences_and_rolls_back () =
      check
        "autonomous lane sees typed shutdown fence"
        (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
-   | `Busy (Keeper_turn_admission.Turn_busy _)
-   | `Busy (Keeper_turn_admission.Chat_backlog _)
-   | `Ran () ->
+   | `Busy (Keeper_turn_admission.Turn_busy _) | `Ran () ->
      check "autonomous lane cannot cross shutdown fence" false);
   (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
    | `Rejected { shutdown_operation_id = Some reserved; _ } ->
@@ -821,25 +815,19 @@ let test_shutdown_reservation_restores_durable_owner () =
     check "registration cannot cross restored fence" false
 ;;
 
-let test_compaction_lane_bypasses_chat_backlog () =
+let test_autonomous_lanes_share_mutex_authority () =
   reset ();
   Printf.printf
-    "Test 10b: manual-compaction lane admits despite a durable chat backlog (#24865)\n%!";
+    "Test 10b: autonomous lanes share one mutex authority\n%!";
   (match Keeper_chat_queue.enqueue ~keeper_name queued_message with
    | Ok _ -> ()
    | Error error ->
      check
        ("enqueue succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
        false);
-  (* The standard lane reports the backlog as a typed [Chat_backlog] with the
-     exact counts, not as [Turn_busy None]. Before this variant existed the
-     queue fence logged "holder info not yet published", which mis-directed
-     the #24865 diagnosis toward a stale slot. *)
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog { pending_count = 1; inflight_count = 0 })
-     -> check "standard lane reports the backlog as typed Chat_backlog" true
-   | `Busy _ | `Ran () ->
-     check "standard lane reports the backlog as typed Chat_backlog" false);
+   | `Ran () -> check "standard lane admits despite a pending receipt" true
+   | `Busy _ -> check "pending receipt must not fence the standard lane" false);
   (match
      Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 7)
    with
@@ -907,8 +895,8 @@ let () =
   test_cancelled_waiter_leaves_queue ();
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
-  test_autonomous_yields_to_queued_connector_message ();
-  test_compaction_lane_bypasses_chat_backlog ();
+  test_autonomous_ignores_chat_queue_state ();
+  test_autonomous_lanes_share_mutex_authority ();
   test_shutdown_reservation_fences_and_rolls_back ();
   test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -135,8 +135,7 @@ let test_busy_cycle_records_no_turn_status_or_work_heartbeat () =
   let accounting =
     Masc.Keeper_heartbeat_loop.keepalive_cycle_accounting
       (Masc.Keeper_heartbeat_loop.Turn_cycle_busy
-         (Masc.Keeper_turn_admission.Chat_backlog
-            { pending_count = 2; inflight_count = 1 }))
+         (Masc.Keeper_turn_admission.Turn_busy None))
   in
   check bool "busy cycle records no turn status" false accounting.record_turn_status;
   check


### PR DESCRIPTION
## Problem

Autonomous Keeper work was rejected by queue-derived `Chat_backlog` and `waiting_count` prechecks even when the actual turn slot was free. Queue observation had become a second admission authority in front of the per-Keeper mutex, so durable chat backlog could starve proactive turns without an in-flight turn.

## Change

- remove `Chat_backlog` from the typed admission result
- delete chat-queue snapshot and waiter-count vetoes from autonomous admission
- let shutdown reservation or the actual per-Keeper turn mutex be the only blockers
- remove heartbeat special handling and obsolete tests for the deleted gate

This keeps durable chat delivery ordering in the chat consumer; it no longer decides whether autonomous work may enter a free lane.

## Validation

- `git diff --check`
- `ocamlformat --check` on all changed OCaml files
- focused Dune build queued but could not start because concurrent wrappers deadlocked the machine-wide Dune/opam locks; tracked in #26281
- PR CI is the build authority for this draft

RFC-WAIVED: deletes an overlapping admission gate; no credential, sandbox, hook, or public tool contract changes.

WORKAROUND-WAIVED: removes queue-derived heuristics and branches instead of adding a bypass.