### PR TITLE
fix(keeper): share one system prompt across turn entrypoints

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -145,8 +145,11 @@ let keeper_config_json (config : Workspace.config) (name : string)
             ~pending_board_events:(Some pending_board_events) ~config ~meta:m
         in
         let parts =
+          let active_goal_summaries =
+            Keeper_unified_prompt.active_goal_summaries ~config ~meta:m
+          in
           Keeper_unified_prompt.build_prompt_preview ~meta:m ~base_path:config.base_path
-            ~profile_defaults:defaults ~observation ()
+            ~profile_defaults:defaults ~active_goal_summaries ~observation ()
         in
         (* Match what a turn actually sends: the observation frame rides the
            per-turn dynamic context (system side), and the persisted user

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -73,14 +73,6 @@ let keeper_config_json (config : Workspace.config) (name : string)
                | None -> None)
           m.active_goal_ids
       in
-      let default_prompt_string default live =
-        match default with
-        | Some value when String.trim live = "" -> value
-        | _ -> live
-      in
-      let prompt_instructions =
-        default_prompt_string defaults.instructions m.instructions
-      in
       let active_goal_ids_json =
         `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids)
       in

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -158,7 +158,12 @@ let keeper_config_json (config : Workspace.config) (name : string)
       in
       let prompt =
         `Assoc [
-          ("instructions", `String prompt_instructions);
+          ( "instructions",
+            `String
+              (Keeper_unified_prompt.effective_instructions
+                 ~meta:m
+                 ~profile_defaults:defaults
+                 ()) );
           ( "system_prompt_blocks",
             `Assoc
               [

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -63,11 +63,6 @@ let keeper_config_json (config : Workspace.config) (name : string)
                  ~keeper_name:m.name
                  error) )
       in
-      let persona_extended =
-        Keeper_types_profile.resolved_persona_name ~keeper_name:m.name defaults
-        |> Keeper_types_profile.load_persona_extended
-        |> Option.value ~default:""
-      in
       let active_goals =
         List.filter_map
           (fun goal_id ->
@@ -128,11 +123,10 @@ let keeper_config_json (config : Workspace.config) (name : string)
         Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta:m
       in
       let effective_system_prompt =
-        Keeper_prompt.build_keeper_system_prompt
-          ~instructions:prompt_instructions
-          ~persona_extended ~keeper_name:m.name
-          ~active_goals
-          ()
+        Keeper_run_context.build_base_system_prompt
+          ~config
+          ~profile_defaults:defaults
+          ~meta:m
       in
       (* Preview the unified prompt shape a keeper turn uses.
          We build the observation from the current workspace state so the

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -176,9 +176,12 @@ let build_keeper_system_prompt
             (fun (id, title) ->
                (* RFC-0294: available-goals line was "- <id> [<horizon>] <title>";
                   horizon removed, so it is now "- <id> <title>". *)
-               Printf.sprintf "- %s %s"
-                 (String_util.escape_xml id)
-                 (String_util.escape_xml title))
+               match String.trim title with
+               | "" -> Printf.sprintf "- %s" (String_util.escape_xml id)
+               | title ->
+                 Printf.sprintf "- %s %s"
+                   (String_util.escape_xml id)
+                   (String_util.escape_xml title))
             goals
         in
         Printf.sprintf "\n<available_goals>\n%s\n</available_goals>\n"

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -25,43 +25,24 @@ type run_context =
   ; runtime_config_path : string option
   }
 
-let prompt_profile_default default current =
-  (* DET-OK: keeper TOML/persona profile defaults are the declarative
-     prompt-config boundary; persisted meta is the legacy fallback. *)
-  match default with
-  | Some value -> value
-  | None -> current
-
 let build_base_system_prompt
       ~(config : Workspace.config)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ~(meta : keeper_meta)
   =
-  let persona_extended =
-    Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name
-      profile_defaults
-    |> Keeper_types_profile.load_persona_extended
-    |> Option.value ~default:""
-  in
-  let active_goals =
-    List.filter_map
+  let active_goal_summaries =
+    List.map
       (fun goal_id ->
          match Goal_store.get_goal config ~goal_id with
-         (* RFC-0294: active_goals tuple dropped its horizon element. *)
-         | Some { Goal_store.id; title; _ } -> Some (id, title)
-         | None -> None)
+         | Some { Goal_store.title; _ } -> (goal_id, title)
+         | None -> (goal_id, ""))
       meta.active_goal_ids
   in
-  (* RFC-0324 B-1: no catalog-fed repository list is injected into the
-     prompt any more — the filesystem is the repo truth and the prompt's
-     constant <repositories> block instructs self-discovery. *)
-  Keeper_prompt.build_keeper_system_prompt
-    ~instructions:
-      (prompt_profile_default profile_defaults.instructions meta.instructions)
-    ~persona_extended
-    ~keeper_name:meta.name
-    ~active_goals
-    ~home_ground:(Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
+  Keeper_unified_prompt.build_system_prompt
+    ~meta
+    ~base_path:config.base_path
+    ~profile_defaults
+    ~active_goal_summaries
     ()
 
 let prepare_run_context

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -31,12 +31,7 @@ let build_base_system_prompt
       ~(meta : keeper_meta)
   =
   let active_goal_summaries =
-    List.filter_map
-      (fun goal_id ->
-         match Goal_store.get_goal config ~goal_id with
-         | Some { Goal_store.title; _ } -> Some (goal_id, title)
-         | None -> None)
-      meta.active_goal_ids
+    Keeper_unified_prompt.active_goal_summaries ~config ~meta
   in
   Keeper_unified_prompt.build_system_prompt
     ~meta

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -31,11 +31,11 @@ let build_base_system_prompt
       ~(meta : keeper_meta)
   =
   let active_goal_summaries =
-    List.map
+    List.filter_map
       (fun goal_id ->
          match Goal_store.get_goal config ~goal_id with
-         | Some { Goal_store.title; _ } -> (goal_id, title)
-         | None -> (goal_id, ""))
+         | Some { Goal_store.title; _ } -> Some (goal_id, title)
+         | None -> None)
       meta.active_goal_ids
   in
   Keeper_unified_prompt.build_system_prompt

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -107,6 +107,16 @@ let direct_turn_dynamic_context
   |> List.filter (fun text -> String.trim text <> "")
   |> String.concat "\n\n"
 
+let direct_turn_system_prompt
+      ~(base_system_prompt : string)
+      ~(direct_reply : bool)
+  =
+  if direct_reply
+  then
+    Keeper_prompt.append_direct_reply_mode_prompt
+      ~base_prompt:base_system_prompt
+  else base_system_prompt
+
 let direct_owner_conversation_context
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -215,6 +225,7 @@ let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
   let direct_turn_dynamic_context = direct_turn_dynamic_context
+  let direct_turn_system_prompt = direct_turn_system_prompt
   let surface_context_to_instructions = surface_context_to_instructions
   let direct_no_progress_retry_reason =
     Keeper_turn_runtime_budget.direct_no_progress_retry_reason
@@ -635,13 +646,16 @@ let run_keeper_invocation_turn_admitted
                   ~turn_instructions_text
               in
               (* === HARD CONSTRAINTS (stay in system_prompt) === *)
-              (* 1. Direct reply mode *)
+              (* The model-facing stable contract is shared with autonomous
+                 turns. [base_system_prompt] is the checkpoint bootstrap
+                 prompt assembled by [Keeper_run_context]; using it here was
+                 the last production split between direct and autonomous
+                 Keeper behavior. Channel-specific input remains below in
+                 [dynamic_context] and the persisted user message. *)
               let prompt =
-                if direct_reply then
-                  Keeper_prompt.append_direct_reply_mode_prompt
-                    ~base_prompt:base_system_prompt
-                else
-                  base_system_prompt
+                direct_turn_system_prompt
+                  ~base_system_prompt
+                  ~direct_reply
               in
               { system_prompt = prompt; dynamic_context }
             in

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -52,6 +52,13 @@ module For_testing : sig
   (** Production composition boundary for fresh direct-turn context. The
       result is prompt-only and must never enter durable conversation history. *)
 
+  val direct_turn_system_prompt :
+    base_system_prompt:string ->
+    direct_reply:bool ->
+    string
+  (** Stable model-facing contract shared with autonomous turns. Only
+      [direct_reply=true] appends a channel-specific hard constraint. *)
+
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   (** Format a dashboard co-view context object ({ label, route, scene, fields })
       into turn instructions when no explicit [turn_instructions] is supplied. *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -167,27 +167,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           |> Keeper_types_profile.load_persona_extended
           |> Option.value ~default:""
         in
-        let active_goals =
-          List.filter_map
-            (fun goal_id ->
-               match Goal_store.get_goal ctx.config ~goal_id with
-               (* RFC-0294: active_goals tuple dropped its horizon element. *)
-               | Some { Goal_store.id; title; _ } ->
-                   Some (id, title)
-               | None -> None)
-            active_goal_ids
-        in
-        let system_prompt =
-          build_keeper_system_prompt
-            ~instructions
-            ~persona_extended
-            ~keeper_name:p.name
-            ~active_goals
-            ()
-      in
-      let ctx0 =
-        Keeper_context_runtime.create ~eio:true ~system_prompt
-      in
       let nonce = 1 in
       let meta = {
         id = None;
@@ -268,6 +247,15 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       oas_env = p.profile_defaults.oas_env;
       meta_version = 0;
       } in
+      let system_prompt =
+        Keeper_run_context.build_base_system_prompt
+          ~config:ctx.config
+          ~profile_defaults:p.profile_defaults
+          ~meta
+      in
+      let ctx0 =
+        Keeper_context_runtime.create ~eio:true ~system_prompt
+      in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
       let init_save_result =
         try

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -468,20 +468,24 @@ let autonomous_trigger_lines
                [ Printf.sprintf "- Reasons: %s" (String.concat ", " reasons) ]))
   | _ -> []
 
+let effective_instructions ~(meta : Keeper_meta_contract.keeper_meta)
+    ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option) ()
+  =
+  (* Total deterministic resolution between two known instruction sources
+     (profile default else meta), not a permissive unknown-input default;
+     pre-existing pattern, was the 4th tuple element before RFC-0282. *)
+  (* DET-OK: total default between two known sources (RFC-0282). *)
+  match profile_defaults with
+  | Some d -> Option.value d.instructions ~default:meta.instructions
+  | None -> meta.instructions
+;;
+
 let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ?(active_goal_summaries : (string * string) list option)
     ()
   =
-  (* Total deterministic resolution between two known instruction sources
-     (profile default else meta), not a permissive unknown-input default;
-     pre-existing pattern, was the 4th tuple element before RFC-0282. *)
-  let instructions =
-    (* DET-OK: total default between two known sources (RFC-0282). *)
-    match profile_defaults with
-    | Some d -> Option.value d.instructions ~default:meta.instructions
-    | None -> meta.instructions
-  in
+  let instructions = effective_instructions ~meta ?profile_defaults () in
   let instructions_block =
     if instructions = "" then ""
     else Printf.sprintf "\nInstructions:\n%s\n" instructions

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -480,23 +480,25 @@ let effective_instructions ~(meta : Keeper_meta_contract.keeper_meta)
   | None -> meta.instructions
 ;;
 
+let active_goal_summaries
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+  =
+  List.map
+    (fun goal_id ->
+       match Goal_store.get_goal config ~goal_id with
+       | Some { Goal_store.title; _ } -> (goal_id, title)
+       | None -> (goal_id, ""))
+    meta.active_goal_ids
+;;
+
 let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ?(active_goal_summaries : (string * string) list option)
     ()
   =
   let instructions = effective_instructions ~meta ?profile_defaults () in
-  let instructions_block =
-    if instructions = "" then ""
-    else Printf.sprintf "\nInstructions:\n%s\n" instructions
-  in
-  (* D-11 (2026-07-14 prompt-assembly audit): autonomous turns once omitted
-     persona while direct turns used a separate prompt builder. This stable
-     builder now owns both entrypoints and the initial checkpoint, so the same
-     loader and XML-escaped <persona> block reach every turn. With no
-     [profile_defaults], resolution degrades to the keeper name through the
-     same total [resolved_persona_name] fallback. *)
-  let persona_block =
+  let persona_extended =
     let persona_name =
       match profile_defaults with
       | Some defaults ->
@@ -504,111 +506,26 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path :
             defaults
       | None -> meta.name
     in
-    let persona_extended =
-      (* DET-OK: an absent persona file is a valid state — the block is
-         omitted below. Read failures already WARN and count
-         ProfileLoadFailures inside [load_persona_extended]; this is a
-         total default between two known outcomes, not an unknown-input
-         guess. *)
-      match Keeper_types_profile.load_persona_extended persona_name with
-      | Some text -> text
-      | None -> ""
-    in
-    (* Inner bytes are the shared SSOT ([Keeper_persona_block.render]); the
-       surrounding newlines are unified-lane layout. *)
-    match Keeper_persona_block.render ~persona_extended with
-    | None -> ""
-    | Some block -> "\n" ^ block ^ "\n"
+    (* An absent persona is a valid empty block. Read failures are already
+       operator-visible in [load_persona_extended]. *)
+    Option.value
+      ~default:""
+      (Keeper_types_profile.load_persona_extended persona_name)
   in
-  let goal_lines =
-    let primary_goal =
-      match Keeper_runtime_contract.primary_goal_id_opt meta with
-      | None -> None
-      | Some goal_id ->
-        let title =
-          match active_goal_summaries with
-          | Some summaries -> List.assoc_opt goal_id summaries
-          | None -> None
-        in
-        Some
-          (match title with
-           | Some title -> goal_id ^ " — " ^ title
-           | None -> goal_id)
-    in
-    line_block "Primary goal"
-      (Option.value
-         ~default:"(no valid active goal — awaiting assignment)"
-         primary_goal)
+  let active_goals =
+    Option.value
+      ~default:(List.map (fun goal_id -> (goal_id, "")) meta.active_goal_ids)
+      active_goal_summaries
   in
-  (* The section this fills used to say "use the paths returned by the current
-     context capability" and named no path at all. Measured across twelve live
-     checkpoints, the rendered system prompt carried zero path strings, so the
-     only concrete paths a keeper saw arrived inside Gate approval echoes and
-     execution_location payloads — both host-side, and therefore absent inside
-     a Docker keeper's container. That is the shape of #10650.
-
-     Rendered from Keeper_sandbox so this agrees with what the Execute cwd
-     resolver actually accepts, rather than restating it. *)
-  let sandbox_paths =
-    let config = Workspace.default_config base_path in
-    let sandbox = Keeper_sandbox.of_meta ~config ~meta in
-    (* The root line depends on the backend because the two backends make
-       different promises about the absolute spelling:
-
-       - Local ([container_root = None]): every command executes on the
-         host, so the host-absolute root is stable and may appear in a cwd
-         or argv operand.
-       - Docker ([container_root = Some _]): the mount spelling is real
-         only while the command actually runs inside the container.
-         Execute dispatch transparently runs the same sandbox on the host
-         when the image preflight fails
-         ([Keeper_sandbox_shell_ir_target.docker_local_fallback_target]),
-         and the typed cwd resolver confines raw cwds against host roots
-         either way ([Keeper_tool_shared_runtime
-         .resolve_keeper_execute_cwd_typed]) — so the mount path is
-         orientation vocabulary, never an execution operand. The fallback
-         is decided per call at dispatch time, so this statically rendered
-         prompt cannot name the effective target; it can only refuse to
-         promise one. *)
-    let root_line =
-      match sandbox.Keeper_sandbox.container_root with
-      | None ->
-        Printf.sprintf "- Sandbox root: %s" sandbox.Keeper_sandbox.host_root_abs
-      | Some container_root ->
-        Printf.sprintf
-          "- Sandbox root: mounted at %s inside your container. The same \
-           sandbox may execute on the host under a different absolute \
-           spelling when the container backend is unavailable, so never \
-           place this absolute path in a typed cwd or an argv operand."
-          container_root
-    in
-    String.concat
-      "\n"
-      [ root_line
-      ; Printf.sprintf
-          "- Repository clones: %s, relative to that root."
-          sandbox.Keeper_sandbox.repos_arg
-      ; Printf.sprintf
-          "- Pass a relative typed cwd (`%s` for the root, `%s/<repository>` for \
-           a clone). Relative argv path operands resolve from that cwd and are \
-           the only path spelling valid on every execution backend."
-          sandbox.Keeper_sandbox.root_arg
-          sandbox.Keeper_sandbox.repos_arg
-      ]
-  in
+  let config = Workspace.default_config base_path in
   let base_system_prompt =
-    match
-      Prompt_registry.render_prompt_template Keeper_prompt_names.unified_system
-        [
-          ("identity_header", Printf.sprintf "You are %s, a keeper agent." meta.name);
-          ("persona_block", persona_block);
-          ("instructions_block", instructions_block);
-          ("goal_lines", goal_lines);
-          ("sandbox_paths", sandbox_paths);
-        ]
-    with
-    | Ok value -> value
-    | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.unified_system
+    Keeper_prompt.build_keeper_system_prompt
+      ~instructions
+      ~persona_extended
+      ~keeper_name:meta.name
+      ~active_goals
+      ~home_ground:(Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
+      ()
   in
   let turn_intent_block = resolve_turn_intent_block () in
   let system_prompt =

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -468,15 +468,11 @@ let autonomous_trigger_lines
                [ Printf.sprintf "- Reasons: %s" (String.concat ", " reasons) ]))
   | _ -> []
 
-let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
+let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
-    ~(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
-    ?(current_task : Masc_domain.task option)
     ?(active_goal_summaries : (string * string) list option)
-    ~(observation : Keeper_world_observation.world_observation)
-    () : turn_prompt_parts
-    =
-  ignore base_path;
+    ()
+  =
   (* Total deterministic resolution between two known instruction sources
      (profile default else meta), not a permissive unknown-input default;
      pre-existing pattern, was the 4th tuple element before RFC-0282. *)
@@ -490,15 +486,12 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
     if instructions = "" then ""
     else Printf.sprintf "\nInstructions:\n%s\n" instructions
   in
-  (* D-11 (2026-07-14 prompt-assembly audit): the unified lane shipped
-     without any persona injection — identity was the one-line header —
-     while the chat lane injected the persona via
-     [Keeper_prompt.build_keeper_system_prompt]. A keeper therefore only
-     had a personality when spoken to. Mirror the chat lane exactly: same
-     loader (persona file re-read each turn), same XML-escaped <persona>
-     block, so both lanes present one personality. With no
-     [profile_defaults], resolution degrades to the keeper name — the same
-     total fallback [resolved_persona_name] applies. *)
+  (* D-11 (2026-07-14 prompt-assembly audit): autonomous turns once omitted
+     persona while direct turns used a separate prompt builder. This stable
+     builder now owns both entrypoints and the initial checkpoint, so the same
+     loader and XML-escaped <persona> block reach every turn. With no
+     [profile_defaults], resolution degrades to the keeper name through the
+     same total [resolved_persona_name] fallback. *)
   let persona_block =
     let persona_name =
       match profile_defaults with
@@ -616,6 +609,25 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
   let turn_intent_block = resolve_turn_intent_block () in
   let system_prompt =
     Printf.sprintf "%s\n\n## Turn Intent\n%s" base_system_prompt turn_intent_block
+  in
+  system_prompt
+;;
+
+let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
+    ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
+    ~(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
+    ?(current_task : Masc_domain.task option)
+    ?(active_goal_summaries : (string * string) list option)
+    ~(observation : Keeper_world_observation.world_observation)
+    () : turn_prompt_parts
+  =
+  let system_prompt =
+    build_system_prompt
+      ~meta
+      ~base_path
+      ?profile_defaults
+      ?active_goal_summaries
+      ()
   in
   (* User message: structured world observation — reactive triggers + resource state only.
      Runtime telemetry remains on decision_audit and independent observation paths.

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -39,6 +39,17 @@ val format_current_task : Masc_domain.task -> string
     lane reuses this renderer so it sees the same task identity, status, and
     handoff as an autonomous wake without persisting that context. *)
 
+val build_system_prompt :
+  meta:Keeper_meta_contract.keeper_meta ->
+  base_path:string ->
+  ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
+  ?active_goal_summaries:(string * string) list ->
+  unit ->
+  string
+(** Build the model-facing stable Keeper contract shared by direct and
+    autonomous turns. Channel-specific input belongs in dynamic context or the
+    persisted user message, not in a second system-prompt implementation. *)
+
 (** Build the three-channel unified prompt from keeper state.
 
     @param meta Keeper metadata (identity, soul, goals, instructions)

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -47,6 +47,14 @@ val effective_instructions :
 (** Resolve the single instructions value used by every system-prompt
     entrypoint and its dashboard projection. *)
 
+val active_goal_summaries :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  (string * string) list
+(** Resolve every active goal id for the stable prompt contract. Unknown ids
+    remain present with an empty title so every entrypoint renders the same
+    bare-id fallback. *)
+
 val build_system_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
   base_path:string ->

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -39,6 +39,14 @@ val format_current_task : Masc_domain.task -> string
     lane reuses this renderer so it sees the same task identity, status, and
     handoff as an autonomous wake without persisting that context. *)
 
+val effective_instructions :
+  meta:Keeper_meta_contract.keeper_meta ->
+  ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
+  unit ->
+  string
+(** Resolve the single instructions value used by every system-prompt
+    entrypoint and its dashboard projection. *)
+
 val build_system_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
   base_path:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -911,12 +911,7 @@ let run_keeper_cycle
                  Keeper_world_observation_inputs.read_current_task ~config ~meta
                in
                let active_goal_summaries =
-                 List.map
-                   (fun goal_id ->
-                     match Goal_store.get_goal config ~goal_id with
-                     | Some { Goal_store.title; _ } -> (goal_id, title)
-                     | None -> (goal_id, ""))
-                   meta.active_goal_ids
+                 Keeper_unified_prompt.active_goal_summaries ~config ~meta
                in
                let { Keeper_unified_prompt.system_prompt; world_state; user_message } =
                  Keeper_unified_prompt.build_prompt

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -311,6 +311,51 @@ let test_direct_and_autonomous_share_system_prompt () =
        ~needle:"A repository you have not worked on yet has no checkout there"
        direct_system_prompt)
 
+let test_unresolved_goal_keeps_one_stable_safety_contract () =
+  with_repo_prompt_config @@ fun () ->
+  let meta_with_goal =
+    meta_of_json
+      (`Assoc
+        [
+          ("name", `String "wake-context-keeper");
+          ("trace_id", `String "test-trace-wake-context");
+          ("active_goal_ids", `List [ `String "missing-goal" ]);
+        ])
+  in
+  let config = Masc.Workspace.default_config "/tmp/unused" in
+  let active_goal_summaries =
+    Prompt.active_goal_summaries ~config ~meta:meta_with_goal
+  in
+  let decision = WO.keeper_cycle_decision ~meta:meta_with_goal base_observation in
+  let { Prompt.system_prompt = autonomous_system_prompt; _ } =
+    Prompt.build_prompt
+      ~meta:meta_with_goal
+      ~base_path:"/tmp/unused"
+      ~active_goal_summaries
+      ~turn_decision:decision
+      ~observation:base_observation
+      ()
+  in
+  let direct_system_prompt =
+    Masc.Keeper_run_context.build_base_system_prompt
+      ~config
+      ~profile_defaults:
+        Masc.Keeper_types_profile_defaults.empty_keeper_profile_defaults
+      ~meta:meta_with_goal
+  in
+  check string
+    "unresolved goal does not split direct and autonomous prompts"
+    direct_system_prompt
+    autonomous_system_prompt;
+  check bool "unresolved goal remains as a bare id" true
+    (contains ~needle:"- missing-goal\n" direct_system_prompt);
+  check bool "identity anchor is preserved" true
+    (contains ~needle:"<identity_anchor>" direct_system_prompt);
+  check bool "world contract is preserved" true
+    (contains ~needle:"<world>" direct_system_prompt);
+  check bool "capability contract is preserved" true
+    (contains ~needle:"<capabilities>" direct_system_prompt)
+
 (* --- 2. Threaded turn decision --- *)
 
 let test_threaded_stimulus_decision_renders_wake_reason () =
@@ -477,6 +522,8 @@ let () =
           test_case "direct and autonomous turns share the stable contract"
             `Quick
             test_direct_and_autonomous_share_system_prompt;
+          test_case "unresolved goal keeps one stable safety contract" `Quick
+            test_unresolved_goal_keeps_one_stable_safety_contract;
         ] );
       ( "threaded turn decision",
         [

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -279,6 +279,38 @@ let test_direct_turn_has_no_synthetic_task_context () =
     (contains ~needle:"### Current Task" context);
   check string "non-task context remains" "recent owner message" context
 
+let test_direct_and_autonomous_share_system_prompt () =
+  with_repo_prompt_config @@ fun () ->
+  let decision = WO.keeper_cycle_decision ~meta base_observation in
+  let { Prompt.system_prompt = autonomous_system_prompt; _ } =
+    Prompt.build_prompt
+      ~meta
+      ~base_path:"/tmp/unused"
+      ~turn_decision:decision
+      ~observation:base_observation
+      ()
+  in
+  let base_system_prompt =
+    Masc.Keeper_run_context.build_base_system_prompt
+      ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ~profile_defaults:
+        Masc.Keeper_types_profile_defaults.empty_keeper_profile_defaults
+      ~meta
+  in
+  let direct_system_prompt =
+    Turn.For_testing.direct_turn_system_prompt
+      ~base_system_prompt
+      ~direct_reply:false
+  in
+  check string
+    "stable contract is byte-identical across turn entrypoints"
+    autonomous_system_prompt
+    direct_system_prompt;
+  check bool "shared contract carries repository discovery policy" true
+    (contains
+       ~needle:"A repository you have not worked on yet has no checkout there"
+       direct_system_prompt)
+
 (* --- 2. Threaded turn decision --- *)
 
 let test_threaded_stimulus_decision_renders_wake_reason () =
@@ -442,6 +474,9 @@ let () =
             test_direct_turn_reuses_current_task_context;
           test_case "direct reply invents no task when none is held" `Quick
             test_direct_turn_has_no_synthetic_task_context;
+          test_case "direct and autonomous turns share the stable contract"
+            `Quick
+            test_direct_and_autonomous_share_system_prompt;
         ] );
       ( "threaded turn decision",
         [


### PR DESCRIPTION
direct/autonomous/bootstrap/dashboard가 한 stable system prompt contract를 사용하도록 정리했어용.

- `Keeper_prompt.build_keeper_system_prompt`가 safety contract의 단일 renderer예용.
- continuity/world/capabilities/identity anchor/available goals를 모든 turn 경로가 공유해용.
- goal title 해석은 `active_goal_summaries` 하나로 통합했고 unknown id는 bare id로 보존해용.
- `Turn Intent`는 direct/autonomous 공통 stable system prompt에 포함해용.

검토 SHA: `98e0966fb5c2fcdda3f67a68c2f3dd4f102d737c`

로컬 Dune은 실행하지 않았고 포맷·파싱·diff만 확인했어용. Build는 CI가 권위예용.