### PR TITLE
test(keeper): verify exact replay blob evidence

### DIFF
--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -390,15 +390,35 @@ let test_large_replay_result_reaches_model_exactly () =
            ~user_message:"continue"
            outcome
        in
+       let rendered_output =
+         message
+         |> String.split_on_char '\n'
+         |> List.rev
+         |> List.hd
+         |> Yojson.Safe.from_string
+         |> Yojson.Safe.Util.member "untrusted_tool_output"
+         |> Yojson.Safe.Util.to_string
+       in
        (* Above the ordinary-tool externalize threshold the rendered turn
           carries the standard blob marker, never the raw half-megabyte body:
           an unbounded injection re-enters the 07-29 request-cap x compaction
           incident class. The exact bytes stay durable (asserted above). *)
-       Alcotest.check
-         Alcotest.bool
-         "rendered evidence is the standard blob marker"
-         true
-         (String_util.contains_substring message Tool_output.marker_prefix);
+       (match Tool_output.decode_from_oas rendered_output with
+        | Tool_output.Decoded rendered ->
+          Alcotest.check
+            Alcotest.string
+            "rendered marker preserves artifact identity"
+            artifact.sha256
+            rendered.sha256;
+          Alcotest.check
+            Alcotest.int
+            "rendered marker preserves byte count"
+            artifact.bytes
+            rendered.bytes
+        | Tool_output.Not_marker ->
+          Alcotest.fail "untrusted_tool_output is not a blob marker"
+        | Tool_output.Invalid_marker { detail } ->
+          Alcotest.failf "untrusted_tool_output has an invalid blob marker: %s" detail);
        Alcotest.check
          Alcotest.bool
          "raw oversized body does not enter the model turn"


### PR DESCRIPTION
대상 head: `9daabca9e02c47f68a70bad1ccf0b97ced220e44`

`main`의 #26294가 컴파일 수정과 프롬프트 경계 수정을 흡수했어용. 이 PR은 그 위에 필요한 증거 테스트만 남겼어용.

- 최종 JSON의 `untrusted_tool_output`을 실제 디코딩해용.
- blob SHA-256과 byte 수를 원본 artifact와 정확히 대조해용.
- 단순 부분 문자열 검사는 제거했어용.

로컬 Dune은 실행하지 않았어용. `ocamlformat --check`, 파싱, `git diff --check`만 통과했고 전체 검증은 CI에서 확인해용.