### PR TITLE
chore(ci): 스펙을 하나도 검사하지 않는 TLA+ 샤드 2개 제거

### DIFF
--- a/.github/workflows/tla-main.yml
+++ b/.github/workflows/tla-main.yml
@@ -56,8 +56,6 @@ jobs:
       matrix:
         shard:
           - { name: keeper-state-machine, target: check-keeper }
-          - { name: masc-ecosystem,       target: check-ecosystem }
-          - { name: social-state,         target: check-social }
           - { name: others,               target: check-others }
 
     steps:

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -5,7 +5,6 @@
 #   make check-all          Run all specs (clean + buggy)
 #   make check-bug-models   Bug models only
 #   make check-keeper       Keeper state machine only
-#   make check-ecosystem    MASC ecosystem only
 #   make check-boundary     Cross-domain boundary specs only
 #   make list               List all discoverable specs
 
@@ -51,7 +50,7 @@ BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
 clean_cfgs_in = $(shell find $(1) -name '*.cfg' ! -name '*-buggy*.cfg' | sort)
 buggy_cfgs_in = $(shell find $(1) -name '*-buggy*.cfg' | sort)
 
-.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-social check-others check-matrix-coverage list clean clean-artefacts
+.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-boundary check-others check-matrix-coverage list clean clean-artefacts
 
 clean: clean-artefacts
 
@@ -128,27 +127,18 @@ check-keeper: CLEAN_CFGS := $(call clean_cfgs_in,keeper-state-machine/)
 check-keeper: BUGGY_CFGS := $(call buggy_cfgs_in,keeper-state-machine/)
 check-keeper: check-all
 
-check-ecosystem:
-	@echo "No ecosystem policy model; concrete boundary specs run in their owning shards."
-
 check-boundary: CLEAN_CFGS := $(call clean_cfgs_in,boundary/)
 check-boundary: BUGGY_CFGS := $(call buggy_cfgs_in,boundary/)
 check-boundary: check-all
 
-# Sharding groups for CI matrix.  The four targets below partition the same
+# Sharding groups for CI matrix.  The two targets below partition the same
 # spec set that `check-all` walks; verified by the `check-matrix-coverage`
 # target which fails if anything drifts out of sync.  Tuning:
 #
 #   keeper-state-machine   lifecycle and lane-local models
-#   social-and-state-prod  reserved empty shard after state-product retirement
 #   others                 runtime depends on the remaining model set
 #
 # Wall-clock fan-out reduces TLA+ Main from ~22 min monolithic to ~7-8 min.
-
-SOCIAL_DIRS :=
-check-social: CLEAN_CFGS := $(foreach d,$(SOCIAL_DIRS),$(call clean_cfgs_in,$(d)/))
-check-social: BUGGY_CFGS := $(foreach d,$(SOCIAL_DIRS),$(call buggy_cfgs_in,$(d)/))
-check-social: check-all
 
 OTHER_DIRS := auth autonomous boundary bug-models \
               keeper-switch-hierarchy keeper-turn-fsm \
@@ -160,7 +150,7 @@ check-others: check-all
 
 # Coverage check: every spec directory must appear in exactly one shard.
 # Run in CI before sharded jobs to catch silent drops when new dirs land.
-SHARD_DIRS_ALL := keeper-state-machine $(SOCIAL_DIRS) $(OTHER_DIRS)
+SHARD_DIRS_ALL := keeper-state-machine $(OTHER_DIRS)
 check-matrix-coverage: SHELL := /bin/bash
 check-matrix-coverage:
 	@set -euo pipefail; \
@@ -172,7 +162,7 @@ check-matrix-coverage:
 	extra=$$(comm -13 <(printf '%s\n' "$$all_sorted") <(printf '%s\n' "$$shard_sorted")); \
 	if [ -n "$$missing" ]; then echo "::error::Spec dirs missing from CI shards:"; echo "$$missing"; exit 1; fi; \
 	if [ -n "$$extra" ]; then echo "::error::Shard references unknown dirs:"; echo "$$extra"; exit 1; fi; \
-	echo "Matrix coverage OK ($$(printf '%s\n' "$$all_sorted" | wc -l | tr -d ' ') dirs across 4 shards)"
+	echo "Matrix coverage OK ($$(printf '%s\n' "$$all_sorted" | wc -l | tr -d ' ') dirs across 2 shards)"
 
 list:
 	@echo "Clean specs ($(words $(CLEAN_CFGS))):"; \


### PR DESCRIPTION
## 무엇을

TLA+ CI 매트릭스에서 **아무것도 검사하지 않는 샤드 2개**를 제거한다.

## 죽어있음의 증거

`check-ecosystem` 은 본문 전체가 echo 한 줄이었다:

```make
check-ecosystem:
	@echo "No ecosystem policy model; concrete boundary specs run in their owning shards."
```

`specs/ecosystem/` 디렉터리도 `MASCEcosystem.tla` 도 존재하지 않는다 (`ls specs/`, `find . -name 'MASCEcosystem*'` 모두 0건). 스펙은 은퇴했고 타깃만 남았다.

`check-social` 은 빈 변수를 순회한다:

```make
SOCIAL_DIRS :=
check-social: CLEAN_CFGS := $(foreach d,$(SOCIAL_DIRS),...)
```

Makefile 자신의 주석이 상태를 밝히고 있다 — `social-and-state-prod   reserved empty shard after state-product retirement`. 비워둔 것은 의도였고, **CI 매트릭스 엔트리를 함께 걷어내지 않은 것**이 잔존물이다.

## 비용

`.github/workflows/tla-main.yml` 은 main push 마다, 그리고 6 시간 cron 마다 이 매트릭스를 돈다. 두 샤드는 각각 러너를 점유하고 `actions/setup-java` 로 JDK 를 설치한 뒤 TLA+ jar 를 내려받아, 검사할 스펙이 0 개인 상태로 초록을 보고한다.

초록 자체가 문제다. 대시보드에는 4 개 샤드가 통과한 것으로 보이지만 실제로 모델 체킹이 일어난 것은 2 개뿐이다.

## 파티션은 유지된다

`SHARD_DIRS_ALL` 에서 `$(SOCIAL_DIRS)` 를 뺐다. 빈 변수였으므로 전개 결과는 동일하다. `check-matrix-coverage` 를 실제로 실행해 확인했다:

```
$ make check-matrix-coverage
Matrix coverage OK (12 dirs across 2 shards)
```

12 개 스펙 디렉터리 전부가 여전히 정확히 한 샤드에 속한다. 이 가드는 누락(`missing`)과 미지 디렉터리 참조(`extra`) 양쪽을 모두 실패로 만들므로, 스펙이 조용히 빠지면 CI 가 잡는다.

## 함께 정리한 것

`.PHONY` 목록, 파일 상단 usage 주석의 `make check-ecosystem` 줄, 샤딩 주석의 "four targets" → "two targets", 커버리지 메시지의 "4 shards" → "2 shards".

RFC-WAIVED: credential / identity / operator control / sandbox / hooks / workflow 문서를 건드리지 않는다. CI 매트릭스와 spec Makefile 변경이다.

WORKAROUND-WAIVED: 순수 삭제다. 게이트/카운터/스킵 조건을 추가하지 않으며, 남은 두 샤드의 검사 범위는 변하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
