### PR TITLE
refactor(context): remove stored elapsed fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Removed
+- **Breaking (agent context schema)**: removed the stored
+  `session:elapsed_seconds` field and its pre-`session_start` fallback.
+  Temporal summaries now derive elapsed time only from the current immutable
+  `session:session_start` anchor and the render-time clock; contexts missing
+  that anchor do not receive repaired timing.
 - **Breaking (keeper config schema)**: removed the keeper TOML `base = "..."` inheritance mechanism. `keeper.base` is no longer a recognised key, `config/keepers/base.toml` and `presets/classic/keepers/base.toml` are deleted, and every keeper TOML now states its own values. Effective per-keeper profiles are unchanged: each formerly inherited value was written out explicitly (`config/keepers/{taskmaster,issue_king,verifier,adversary}.toml`, `presets/classic/keepers/{backend,frontend,qa,tech_lead}.toml`).
   - Migration order matters. A keeper TOML that still carries `base = "..."` after this build is deployed does **not** fail to boot: `keeper.base` becomes an unrecognised key, so the keeper loads while silently losing every value it used to inherit, with one `Log.Keeper.warn`, a `masc_config_unknown_keys_ignored_total` increment, and a row on the dashboard drift surface. `/health` additionally reports `keeper_config_schema: config_unknown_keys` with status `blocked` and `operator_action_required: true` for the whole server (`server_routes_http_runtime.ml:479-488`). Flatten the deployed TOMLs first, then deploy this build.
   - `merge_keeper_profile_defaults` and `merge_string_list` are retained: they still implement the persona `profile.json` → keeper TOML overlay (`keeper_types_profile.ml:244`), which is a separate mechanism. Note `merge_string_list` is replace-if-non-empty, not union.

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -21,7 +21,6 @@ let iso8601_of_float ts = Masc_domain.iso8601_of_unix_seconds ts
 
 let key_wall_time = "session:wall_time"
 let key_session_start = "session:session_start"
-let key_elapsed_seconds = "session:elapsed_seconds"
 let key_tool_call_count = "session:tool_call_count"
 let key_last_tool_name = "session:last_tool_name"
 let key_last_tool_outcome = "session:last_tool_outcome"
@@ -47,7 +46,6 @@ let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
     if is_ok then ignore (Atomic.fetch_and_add success_count 1)
     else ignore (Atomic.fetch_and_add error_count 1);
     let outcome_str = if is_ok then "ok" else "error" in
-    let elapsed = now -. config.start_time in
     Some Agent_sdk.Hooks.{
       context_updates = [
         (key_wall_time, `String (Masc_domain.iso8601_of_unix_seconds now));
@@ -55,7 +53,6 @@ let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
            fresh elapsed at turn start instead of freezing it at the
            last tool call. Constant across a session (= injector start). *)
         (key_session_start, `Float config.start_time);
-        (key_elapsed_seconds, `Float elapsed);
         (key_tool_call_count, `Int (Atomic.get call_count));
         (key_last_tool_name, `String tool_name);
         (key_last_tool_outcome, `String outcome_str);
@@ -84,15 +81,6 @@ let get_int ctx key =
   match Agent_sdk.Context.get ctx key with
   | Some (`Int i) -> Some i
   | _ -> None
-
-let legacy_elapsed_seconds ctx =
-  match get_float ctx key_elapsed_seconds with
-  | Some elapsed -> Some elapsed
-  | None ->
-    Log.Keeper.warn
-      "Temporal summary skipped: missing %s and legacy %s"
-      key_session_start key_elapsed_seconds;
-    None
 
 let tool_summary_fields ctx =
   match
@@ -124,9 +112,8 @@ let render_temporal_summary ?now (ctx : Agent_sdk.Context.t) : string option =
       match get_float ctx key_session_start with
       | Some session_start -> Some (now -. session_start)
       | None ->
-        (* Backward compat: contexts written before [key_session_start]
-           existed fall back to the stored (possibly stale) elapsed. *)
-        legacy_elapsed_seconds ctx
+        Log.Keeper.warn "Temporal summary skipped: missing %s" key_session_start;
+        None
     in
     match elapsed, tool_summary_fields ctx with
     | Some elapsed, Some (tool_count, last_tool, outcome) ->

--- a/lib/masc_context_injector.mli
+++ b/lib/masc_context_injector.mli
@@ -41,13 +41,13 @@ val render_temporal_summary : ?now:float -> Agent_sdk.Context.t -> string option
 
     [time=] and [elapsed=] are recomputed from [now] (defaulting to
     {!Time_compat.now}) at render time — i.e. turn start — rather than
-    read from the stored [key_wall_time]/[key_elapsed_seconds], which
-    reflect the last tool call and go stale across idle turns. A keeper
+    read from the stored [key_wall_time], which reflects the last tool
+    call and goes stale across idle turns. A keeper
     waking after an idle gap therefore sees the current wall clock, not a
     past tool-call timestamp. For current contexts, [elapsed] is
     [now - key_session_start] (seconds since the injector/session
-    started). Legacy contexts written before [key_session_start] render
-    only when a stored [key_elapsed_seconds] value is available.
+    started). A context without the current [key_session_start] anchor does
+    not render a temporal summary.
 
     [now] is a Unix timestamp in seconds; pass it to inject a fixed clock
     in tests.
@@ -67,7 +67,6 @@ val iso8601_of_float : float -> string
 
 val key_wall_time : string
 val key_session_start : string
-val key_elapsed_seconds : string
 val key_tool_call_count : string
 val key_last_tool_name : string
 val key_last_tool_outcome : string

--- a/test/test_masc_context_injector.ml
+++ b/test/test_masc_context_injector.ml
@@ -80,7 +80,6 @@ let test_context_updates_overwrite_bounded_keys () =
     [
       MCI.key_wall_time;
       MCI.key_session_start;
-      MCI.key_elapsed_seconds;
       MCI.key_tool_call_count;
       MCI.key_last_tool_name;
       MCI.key_last_tool_outcome;
@@ -128,17 +127,18 @@ let test_render_temporal_summary_empty () =
 
 let test_render_temporal_summary_populated () =
   let ctx = Agent_sdk.Context.create_sync () in
+  let now = 1_800_000_000.0 in
   Agent_sdk.Context.set ctx
     MCI.key_wall_time (`String "2026-04-06T12:00:00Z");
   Agent_sdk.Context.set ctx
-    MCI.key_elapsed_seconds (`Float 42.5);
+    MCI.key_session_start (`Float (now -. 42.5));
   Agent_sdk.Context.set ctx
     MCI.key_tool_call_count (`Int 3);
   Agent_sdk.Context.set ctx
     MCI.key_last_tool_name (`String "tool_execute");
   Agent_sdk.Context.set ctx
     MCI.key_last_tool_outcome (`String "ok");
-  match MCI.render_temporal_summary ctx with
+  match MCI.render_temporal_summary ~now ctx with
   | Some summary ->
     check bool "contains time" true
       (Astring.String.is_prefix ~affix:"[Temporal]" summary);
@@ -149,8 +149,8 @@ let test_render_temporal_summary_populated () =
   | None -> fail "expected Some summary"
 
 (* Regression: turn N+1 must render the *fresh* current time, not the
-   last tool call's timestamp frozen in [key_wall_time]/[key_elapsed_seconds]
-   from turn N (the idle-wake bug). Uses a fixed [~now] far in the future
+   last tool call's timestamp frozen in [key_wall_time] from turn N
+   (the idle-wake bug). Uses a fixed [~now] far in the future
    relative to the stored (stale) values. *)
 let test_render_uses_fresh_now_not_stale () =
   let ctx = Agent_sdk.Context.create_sync () in
@@ -161,8 +161,6 @@ let test_render_uses_fresh_now_not_stale () =
     MCI.key_wall_time (`String (MCI.iso8601_of_float stale_now));
   Agent_sdk.Context.set ctx
     MCI.key_session_start (`Float session_start);
-  Agent_sdk.Context.set ctx
-    MCI.key_elapsed_seconds (`Float 100.0);
   Agent_sdk.Context.set ctx
     MCI.key_tool_call_count (`Int 2);
   Agent_sdk.Context.set ctx
@@ -184,28 +182,23 @@ let test_render_uses_fresh_now_not_stale () =
       (Astring.String.is_infix ~affix:"elapsed=100000100s" summary)
   | None -> fail "expected Some summary"
 
-(* When [key_session_start] is absent (context written before the key
-   existed), elapsed falls back to the stored value; time= is still fresh. *)
-let test_render_elapsed_fallback_without_session_start () =
+let test_render_rejects_retired_elapsed_without_session_start () =
   let ctx = Agent_sdk.Context.create_sync () in
   Agent_sdk.Context.set ctx
     MCI.key_wall_time (`String "2023-11-14T22:13:20Z");
   Agent_sdk.Context.set ctx
-    MCI.key_elapsed_seconds (`Float 55.0);
+    "session:elapsed_seconds" (`Float 55.0);
   Agent_sdk.Context.set ctx
     MCI.key_tool_call_count (`Int 1);
   Agent_sdk.Context.set ctx
     MCI.key_last_tool_name (`String "legacy_tool");
   Agent_sdk.Context.set ctx
     MCI.key_last_tool_outcome (`String "ok");
-  match MCI.render_temporal_summary ~now:1_800_000_000.0 ctx with
-  | Some summary ->
-    check bool "time= is fresh" true
-      (Astring.String.is_infix
-         ~affix:("time=" ^ MCI.iso8601_of_float 1_800_000_000.0) summary);
-    check bool "elapsed falls back to stored value" true
-      (Astring.String.is_infix ~affix:"elapsed=55s" summary)
-  | None -> fail "expected Some summary"
+  check
+    (option string)
+    "retired elapsed value is not repaired"
+    None
+    (MCI.render_temporal_summary ~now:1_800_000_000.0 ctx)
 
 let test_render_omits_malformed_elapsed_context () =
   let ctx = Agent_sdk.Context.create_sync () in
@@ -249,8 +242,8 @@ let () =
         test_render_temporal_summary_populated;
       test_case "fresh now, not stale wall_time" `Quick
         test_render_uses_fresh_now_not_stale;
-      test_case "elapsed fallback without session_start" `Quick
-        test_render_elapsed_fallback_without_session_start;
+      test_case "retired elapsed without session_start is rejected" `Quick
+        test_render_rejects_retired_elapsed_without_session_start;
       test_case "malformed elapsed context omitted" `Quick
         test_render_omits_malformed_elapsed_context;
     ];


### PR DESCRIPTION
## Scope

- stop writing the derived `session:elapsed_seconds` context field
- remove its historical fallback from temporal-summary rendering
- derive elapsed time only from the current `session:session_start` anchor and
  the render-time clock
- reject contexts that carry only the retired elapsed value

No migration, compatibility decoder, replacement field, or new Gate was added.

## Feature / contract audit

- Producer entry: `Masc_context_injector.make`, wired into both Keeper and
  Worker OAS agent construction.
- Consumer entry: `render_temporal_summary`, called by the Keeper and Worker
  `before_turn_params` hooks.
- `session:session_start` is the current immutable source fact. The displayed
  elapsed value is a permitted derived state: `now - session_start`.
- `session:elapsed_seconds` duplicated that derivation at the last tool call,
  became stale across idle turns, and existed only to repair pre-anchor
  contexts.
- No downstream production caller reads the retired key directly. Removing it
  does not add an admission/validation Gate or change tool execution.

## Blast radius

- New context updates contain one fewer stored field.
- Current Keeper and Worker turns with `session:session_start` render the same
  temporal summary, using a fresh clock.
- Historical contexts that lack the current anchor no longer receive a
  fabricated/repaired elapsed value; their temporal block is omitted.
- Tool counters, last-tool state, checkpoint copying, OAS context injection,
  and provider dispatch are unchanged.

## Verification

- changed OCaml files: `ocamlformat --check` — pass
- `git diff --check` — pass
- tests pin current-anchor derivation, fresh render-time behavior, and rejection
  of the retired raw key
- focused Dune validation is currently blocked by the unrelated current-main
  compile failure in `keeper_gate_replay.ml:865`
  (`Unbound record field disposition`); Draft #26286 is the existing base
  repair and this patch does not touch Gate replay
