### PR TITLE
refactor(keeper): expose current fiber failure cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### Removed
+- **Breaking (keeper failure wire)**: removed the bare
+  `fiber_unresolved` failure-reason projection retained for historical log and
+  dashboard matching. Unexpected unresolved fibers now serialize as
+  `fiber_unresolved(unexpected)`, alongside the existing
+  `graceful_shutdown` and `cancelled_by_parent` causes. The current
+  `fiber_unresolved` blocker/cohort class is unchanged.
 - **Breaking (keeper config schema)**: removed the keeper TOML `base = "..."` inheritance mechanism. `keeper.base` is no longer a recognised key, `config/keepers/base.toml` and `presets/classic/keepers/base.toml` are deleted, and every keeper TOML now states its own values. Effective per-keeper profiles are unchanged: each formerly inherited value was written out explicitly (`config/keepers/{taskmaster,issue_king,verifier,adversary}.toml`, `presets/classic/keepers/{backend,frontend,qa,tech_lead}.toml`).
   - Migration order matters. A keeper TOML that still carries `base = "..."` after this build is deployed does **not** fail to boot: `keeper.base` becomes an unrecognised key, so the keeper loads while silently losing every value it used to inherit, with one `Log.Keeper.warn`, a `masc_config_unknown_keys_ignored_total` increment, and a row on the dashboard drift surface. `/health` additionally reports `keeper_config_schema: config_unknown_keys` with status `blocked` and `operator_action_required: true` for the whole server (`server_routes_http_runtime.ml:479-488`). Flatten the deployed TOMLs first, then deploy this build.
   - `merge_keeper_profile_defaults` and `merge_string_list` are retained: they still implement the persona `profile.json` → keeper TOML overlay (`keeper_types_profile.ml:244`), which is a separate mechanism. Note `merge_string_list` is replace-if-non-empty, not union.

--- a/lib/keeper/keeper_registry_types_failure.ml
+++ b/lib/keeper/keeper_registry_types_failure.ml
@@ -79,14 +79,7 @@ let failure_reason_to_string = function
     Printf.sprintf "provider_runtime_error(%s:%s%s%s)" code detail prov http
   | Fiber_unresolved Graceful_shutdown -> "fiber_unresolved(graceful_shutdown)"
   | Fiber_unresolved Cancelled_by_parent -> "fiber_unresolved(cancelled_by_parent)"
-  | Fiber_unresolved Unexpected -> "fiber_unresolved"
-  (* Backward-compat string form: [Unexpected] preserves the legacy
-     "fiber_unresolved" wire value so existing log-line / dashboard
-     greps and persisted crash_log rows continue to match. Graceful
-     and cancelled-by-parent variants get distinct suffixes so 24h
-     fleet audits can split the noise:signal ratio (Issue #18901) and
-     supervisor restart/back-off can treat parent-cancel differently
-     from genuine missed-resolution. *)
+  | Fiber_unresolved Unexpected -> "fiber_unresolved(unexpected)"
   | Exception s -> Printf.sprintf "exception(%s)" s
   | Turn_overflow_failure -> "turn_overflow_failure"
   | Operator_interrupt -> "operator_interrupt"

--- a/test/test_keeper_registry_provenance.ml
+++ b/test/test_keeper_registry_provenance.ml
@@ -107,6 +107,17 @@ let test_provider_runtime_error_carrier_some () =
     true
     (Astring.String.is_infix ~affix:"http=502" s)
 
+let test_fiber_unresolved_failure_reason_is_cause_explicit () =
+  (check string)
+    "unexpected fiber failure has current explicit cause"
+    "fiber_unresolved(unexpected)"
+    (R.failure_reason_to_string (R.Fiber_unresolved R.Unexpected));
+  (check string)
+    "blocker cohort remains the current stable class"
+    "fiber_unresolved"
+    (R.failure_reason_cohort_key (Some (R.Fiber_unresolved R.Unexpected)))
+;;
+
 let test_json_serializer_none () =
   let ev =
     KSM.Fiber_terminated
@@ -160,6 +171,10 @@ let () =
             test_provider_runtime_error_carrier_none
         ; test_case "some/some surfaces both" `Quick
             test_provider_runtime_error_carrier_some
+        ] )
+    ; ( "fiber_failure_reason"
+      , [ test_case "unexpected cause is explicit" `Quick
+            test_fiber_unresolved_failure_reason_is_cause_explicit
         ] )
     ; ( "json_serializer"
       , [ test_case "none omits fields" `Quick test_json_serializer_none


### PR DESCRIPTION
## Scope

- serialize `Fiber_unresolved Unexpected` as
  `fiber_unresolved(unexpected)`
- remove the bare failure-reason string retained for historical log/dashboard
  byte matching
- keep the current `fiber_unresolved` blocker and cohort class unchanged

No migration, compatibility decoder, new field, or replacement Gate was added.

## Feature / Gate audit

- Feature entry: supervisor failure recording calls
  `Keeper_registry.failure_reason_to_string`.
- Typed authority: `Fiber_unresolved of fiber_drop_cause`; all three causes
  already exist and are chosen at the supervisor emit sites.
- The failure-reason string is an observation projection used by logs,
  crash rows, and runtime-status displays. No production caller parses it back
  into control state.
- Blocker/admission behavior uses the separate typed reason and
  `failure_reason_cohort_key`; the current unexpected-fiber cohort remains
  `fiber_unresolved`.
- This changes only the previously cause-erasing projection. It does not add a
  validation Gate or alter lifecycle transitions.

## Blast radius

- New unexpected-fiber log/crash/status strings gain the explicit
  `(unexpected)` cause.
- Graceful-shutdown and parent-cancel strings are unchanged.
- Dashboard blocker class, terminal code, restart/backoff behavior, typed
  registry state, and historical persisted rows are unchanged.

## Verification

- changed OCaml files: `ocamlformat` + parse check — pass
- `git diff --check` — pass
- focused test pins the explicit failure projection and unchanged cohort class
- silent-failure ratchet — pass
- OCaml structure ratchet — pass
- focused Dune build reached the current main base and failed in unrelated
  `keeper_gate_replay.ml:865` (`Unbound record field disposition`). Draft
  #26286 is the existing base repair; this patch does not touch that Feature.
- `@fmt` also reports pre-existing Dune-file formatting drift on current main;
  no unrelated Dune file was modified.
