### PR TITLE
refactor(oas): consume exact provider carrier on resume

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.1`, runtime pin: `main@40ac4c42e0fcd29bb061a874c48faa934b3b91c2`, declared base version: `v0.231.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.1`, runtime pin: `main@701ea39e5c87e7df52724795c449d89b9a815c55`, declared base version: `v0.231.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -411,7 +411,8 @@ let append_worker_completion_log ~base_path ~worker_name
 
 (** Build (config, options) for Agent.resume — the continue_worker path.
     New workers use Worker_oas.build_agent (Builder pattern) instead.
-    The exact provider config is passed directly to [Agent.resume]. *)
+    The caller adds the exact provider config to [options] before
+    [Agent.resume]. *)
 let build_resume_config ~worker_name ~model_id ~system_prompt
     ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
     () =

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -195,5 +195,4 @@ val build_resume_config :
     [Agent_sdk.Agent.resume].  [config] inherits
     {!Agent_sdk.Types.default_config} for the exact [model_id] and overrides
     [name] / [system_prompt] / [enable_thinking]. Provider/model sampling and output defaults remain
-    OAS-owned. The concrete provider config is passed separately through
-    [Agent_sdk.Agent.resume ~provider_config]. *)
+    OAS-owned. The caller adds the concrete provider config to [options]. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -999,7 +999,6 @@ let resume_from_checkpoint
       Ok
         (Agent_sdk.Agent.resume ~net ~checkpoint:prepared_resume.patched_checkpoint
            ~tools:config.tools ?context:config.context
-           ~provider_config:config.provider_cfg
            ~context_fit_admission:prepared_resume.context_fit_admission
            ?model_input_projection:config.model_input_projection
            ~options ~config:prepared_resume.agent_config

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -382,16 +382,6 @@ and resume_worker_via_oas
     make_tool_tracking_hooks ~context:shared_context ()
   in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
-  let* () =
-    if String.equal resume_model_id provider_config.model_id
-    then Ok ()
-    else
-      Error
-        (Printf.sprintf
-           "checkpoint model %S does not match requested provider model %S"
-           resume_model_id
-           provider_config.model_id)
-  in
   let system_prompt =
     Worker_container_types.default_system_prompt
       ~worker_name
@@ -415,6 +405,7 @@ and resume_worker_via_oas
   let options =
     { options with
       Agent_sdk.Agent_types.context_injector = Some context_injector
+    ; provider_config = Some provider_config
     }
   in
   let agent =
@@ -423,7 +414,6 @@ and resume_worker_via_oas
       ~checkpoint
       ~tools
       ~options
-      ~provider_config
       ~config
       ~context:shared_context
       ()

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -219,7 +219,7 @@ dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
   "agent_sdk.0.231.1"
-  "git+https://github.com/jeong-sik/oas.git#40ac4c42e0fcd29bb061a874c48faa934b3b91c2"
+  "git+https://github.com/jeong-sik/oas.git#701ea39e5c87e7df52724795c449d89b9a815c55"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -17,16 +17,19 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.1"
 # selecting a provider-native response format. Provider_schema remains
 # explicit. It also removes the public Llm_provider.Complete.gemini_url
 # helper; MASC has no caller.
+# The pinned post-v0.231.1 head carries the #2873 provider hard-cut:
+# Agent.options.provider_config is the single exact carrier, including resume;
+# the legacy Provider.config island and separate resume argument are removed.
 # Previous pin: v0.231.0 (2cb7d922); before that v0.230.0 (7a3f2af7).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
 # main; oas-drift-check.sh also reports the public-surface delta at pin-bump
 # time.
-# Pinned to the v0.231.1 release commit.
+# Pinned to the merged #2873 commit.
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.1"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="40ac4c42e0fcd29bb061a874c48faa934b3b91c2"
+readonly OAS_AGENT_SDK_SHA="701ea39e5c87e7df52724795c449d89b9a815c55"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.231.1"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,5 +1,5 @@
 {
-  "pinned_sha": "40ac4c42e0fcd29bb061a874c48faa934b3b91c2",
+  "pinned_sha": "701ea39e5c87e7df52724795c449d89b9a815c55",
   "pinned_version": "v0.231.1",
   "surfaces": {
     "event_bus_payload_variants": [


### PR DESCRIPTION
## Summary
- pin OAS to merged provider-carrier hard cut #2873 (`701ea39e5`)
- move both production resume paths from the removed separate `~provider_config` argument to `options.provider_config`
- remove the worker checkpoint-model equality gate; OAS now derives the effective turn config and clears only parent-model capability overrides when models differ

## Flow

checkpoint + caller-owned runtime config + exact provider carrier
-> `Agent.resume ~options`
-> one OAS effective provider projection
-> transport dispatch

The carrier still owns provider identity, endpoint, credential, headers, and request path. The resume config owns the effective model and turn controls. No compatibility adapter, migration path, fallback, or extra facade is added.

## Why remove the equality gate
String equality between checkpoint model and carrier model did not prove provider support. It rejected valid resume/model-rebind cases before OAS could apply its typed projection. The canonical OAS path now preserves provider identity while clearing model-scoped overrides whenever the effective model differs.

## Validation
- OAS pin manifests and generated docs match `701ea39e5`
- OAS API surface fingerprint matches the merged commit
- ocamlformat check on touched OCaml files
- git diff --check
- deleted `Agent.resume ~provider_config` call-site sweep is clean
- focused type/build authority delegated to PR CI because the shared Dune/opam lock is held by unrelated MASC builds