### PR TITLE
refactor(workspace): make broadcast invariant single-owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   - `merge_keeper_profile_defaults` and `merge_string_list` are retained: they still implement the persona `profile.json` → keeper TOML overlay (`keeper_types_profile.ml:244`), which is a separate mechanism. Note `merge_string_list` is replace-if-non-empty, not union.
 
 ### Changed
+- Workspace broadcast delivery now returns the canonical content, mention, and
+  message type produced by its single terminal-task invariant check. MCP
+  session/SSE/notification/audit consumers reuse that exact result instead of
+  pre-running the invariant through a bypass flag.
 - Bumped the OAS Agent SDK pin to `ca7a02b7` (oas#2766). Supports non-standard stop_reason provider dialects (e.g. `context_length_exceeded`, `max_context_length`) and preserves empty completion stop_reason in GLM parser to prevent orphan retries on context overflow.
 - Bumped the OAS Agent SDK pin to `c1eaa88b` (oas#2764). Allows empty delta `id` and `name` strings as `Ok None` in the SSE stream parser to prevent stream failure crashes on GLM-5-Turbo and OpenAI-compatible backends emitting empty initial delta fragments.
 

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -68,14 +68,15 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
       Workspace.broadcast ?trace_context config
         ~from_agent:agent_name ~content:message
     in
+    let from_agent = delivery.from_agent in
     let mention = delivery.mention in
     let message = delivery.content in
     let _ =
-      Session.push_message registry ~from_agent:agent_name ~content:message ~mention
+      Session.push_message registry ~from_agent ~content:message ~mention
     in
     let notification_fields =
       [ ("type", `String "masc/broadcast")
-      ; ("from", `String agent_name)
+      ; ("from", `String from_agent)
       ; ("content", `String message)
       ; ("mention", Json_util.string_opt_to_json mention)
       ; ("timestamp", `Float (Time_compat.now ()))
@@ -88,9 +89,9 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
     Subscriptions.push_event_to_sessions notification;
     (match mention with
      | Some target ->
-       Notify.notify_mention ~from_agent:agent_name ~target_agent:target ~message ()
+       Notify.notify_mention ~from_agent ~target_agent:target ~message ()
      | None -> ());
-    Audit_log.log_broadcast config ~agent_id:agent_name ~message_preview:message ();
+    Audit_log.log_broadcast config ~agent_id:from_agent ~message_preview:message ();
     Some (Tool_result.ok ~tool_name ~start_time delivery.rendered)
 
 (** masc_messages — retrieve recent messages *)

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -62,39 +62,36 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
             ~failure_class:(Some Tool_result.Transient_error)
             ~tool_name ~start_time
             (Printf.sprintf "Rate limited. %d sec remaining." wait_secs))
-  else begin
-    let message =
-      Workspace_task_cache_invariant.rewrite_broadcast_content
-        ~config
-        ~from_agent:agent_name
-        ~module_name:"mcp_tool_runtime_comm"
-        ~content:message
-    in
+  else
     let trace_context = Otel_trace_context.from_ambient () in
-    let broadcast_result =
-      Workspace.broadcast ?trace_context ~task_cache_invariant_checked:true config
+    let delivery =
+      Workspace.broadcast ?trace_context config
         ~from_agent:agent_name ~content:message
     in
-        let mention = Mention.extract message in
-        let _ = Session.push_message registry ~from_agent:agent_name ~content:message ~mention in
-        let notification_fields = [
-          ("type", `String "masc/broadcast");
-          ("from", `String agent_name);
-          ("content", `String message);
-          ("mention", Json_util.string_opt_to_json mention);
-          ("timestamp", `Float (Time_compat.now ()));
-        ] in
-        let notification = `Assoc (Otel_trace_context.inject_json notification_fields trace_context) in
-        Mcp_server.sse_broadcast state notification;
-        Subscriptions.push_event_to_sessions notification;
-        (match mention with
-         | Some target -> Notify.notify_mention ~from_agent:agent_name ~target_agent:target ~message ()
-         | None -> ());
-        ignore (config, agent_name);
-        Audit_log.log_broadcast config ~agent_id:agent_name
-          ~message_preview:message ();
-        Some (Tool_result.ok ~tool_name ~start_time broadcast_result)
-  end
+    let mention = delivery.mention in
+    let message = delivery.content in
+    let _ =
+      Session.push_message registry ~from_agent:agent_name ~content:message ~mention
+    in
+    let notification_fields =
+      [ ("type", `String "masc/broadcast")
+      ; ("from", `String agent_name)
+      ; ("content", `String message)
+      ; ("mention", Json_util.string_opt_to_json mention)
+      ; ("timestamp", `Float (Time_compat.now ()))
+      ]
+    in
+    let notification =
+      `Assoc (Otel_trace_context.inject_json notification_fields trace_context)
+    in
+    Mcp_server.sse_broadcast state notification;
+    Subscriptions.push_event_to_sessions notification;
+    (match mention with
+     | Some target ->
+       Notify.notify_mention ~from_agent:agent_name ~target_agent:target ~message ()
+     | None -> ());
+    Audit_log.log_broadcast config ~agent_id:agent_name ~message_preview:message ();
+    Some (Tool_result.ok ~tool_name ~start_time delivery.rendered)
 
 (** masc_messages — retrieve recent messages *)
 let handle_messages ~tool_name ~start_time (ctx : context) : tool_result option =

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -85,7 +85,7 @@ let execute_workspace_action (ctx : 'a context) (request : action_request) =
         | None -> Error "payload.message is required"
       in
       let result = Workspace.broadcast ctx.config ~from_agent:request.actor ~content:message in
-      workspace_action_result request (`String result)
+      workspace_action_result request (`String result.rendered)
   | "namespace_pause" ->
       let* () = validate_target_type Operator_action_constants.Workspace request in
       let reason =

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -25,6 +25,7 @@ type msg_type_typed =
 
 type broadcast_delivery =
   { rendered : string
+  ; from_agent : string
   ; content : string
   ; mention : string option
   ; msg_type : string
@@ -215,6 +216,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
        (Printexc.to_string exn));
   observe safe_msg_type;
   { rendered = Printf.sprintf "\xF0\x9F\x93\xA2 [%s] %s" safe_agent safe_content
+  ; from_agent = safe_agent
   ; content = safe_content
   ; mention
   ; msg_type = safe_msg_type

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -23,6 +23,13 @@ type msg_type_typed =
   | Broadcast
   | Cache_invalidated of { task_id : string; status : string }
 
+type broadcast_delivery =
+  { rendered : string
+  ; content : string
+  ; mention : string option
+  ; msg_type : string
+  }
+
 let string_of_msg_type_typed = function
   | Broadcast -> "broadcast"
   | Cache_invalidated _ -> "cache_invalidated"
@@ -70,8 +77,7 @@ let broadcast_channel config =
 let on_broadcast_mention : (string option -> unit) ref =
   ref (fun _mention -> ())
 
-let broadcast ?trace_context ?(msg_type = "broadcast")
-    ?(task_cache_invariant_checked = false) config ~from_agent ~content =
+let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~content =
   let started_at = Time_compat.now () in
   let observe final_msg_type =
     let elapsed_s = Float.max 0.0 (Time_compat.now () -. started_at) in
@@ -91,8 +97,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
      cache_invalidated notice and clear the stale state (issue #13397).
      Only applied to regular "broadcast" messages to avoid recursion. *)
   let content, msg_type, _rewrites =
-    if task_cache_invariant_checked then (content, msg_type, [])
-    else if String.equal msg_type "broadcast" then
+    if String.equal msg_type "broadcast" then
       let agent_file =
         Filename.concat (agents_dir config) (safe_filename from_agent ^ ".json")
       in
@@ -209,4 +214,8 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
      Log.Misc.warn "on_broadcast_mention callback failed: %s"
        (Printexc.to_string exn));
   observe safe_msg_type;
-  Printf.sprintf "\xF0\x9F\x93\xA2 [%s] %s" safe_agent safe_content
+  { rendered = Printf.sprintf "\xF0\x9F\x93\xA2 [%s] %s" safe_agent safe_content
+  ; content = safe_content
+  ; mention
+  ; msg_type = safe_msg_type
+  }

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -20,6 +20,7 @@ type msg_type_typed =
 
 type broadcast_delivery =
   { rendered : string
+  ; from_agent : string
   ; content : string
   ; mention : string option
   ; msg_type : string

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -18,6 +18,13 @@ type msg_type_typed =
   | Broadcast
   | Cache_invalidated of { task_id : string; status : string }
 
+type broadcast_delivery =
+  { rendered : string
+  ; content : string
+  ; mention : string option
+  ; msg_type : string
+  }
+
 val string_of_msg_type_typed : msg_type_typed -> string
 
 val emit_message_activity : Workspace_utils_backend_setup.config ->
@@ -32,6 +39,5 @@ val broadcast_channel : Workspace_utils_backend_setup.config -> string
 val on_broadcast_mention : (string option -> unit) ref
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
-           ?task_cache_invariant_checked:bool ->
            Workspace_utils_backend_setup.config ->
-           from_agent:string -> content:string -> string
+           from_agent:string -> content:string -> broadcast_delivery

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -219,7 +219,7 @@ let test_broadcast_message () =
 
   (* Broadcast *)
   let result = Workspace.broadcast config ~from_agent:"claude" ~content:"Hello @gemini!" in
-  Alcotest.(check bool) "broadcast success" true (String.contains result '[');
+  Alcotest.(check bool) "broadcast success" true (String.contains result.rendered '[');
 
   (* Get messages *)
   let msgs = Workspace.get_messages config ~since_seq:0 ~limit:10 in
@@ -288,7 +288,15 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Alcotest.(check bool)
     "broadcast reports invalidation"
     true
-    (str_contains result "[cache_invalidated]");
+    (str_contains result.rendered "[cache_invalidated]");
+  Alcotest.(check bool)
+    "delivery exposes the canonical replacement"
+    true
+    (str_contains result.content "[cache_invalidated]");
+  Alcotest.(check (option string))
+    "delivery preserves the original mention"
+    (Some "nick0cave")
+    result.mention;
   let messages = Workspace.get_all_messages_raw config ~since_seq in
   (match messages with
    | [ msg ] ->
@@ -316,14 +324,14 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Alcotest.(check bool)
     "normal task mention is not invalidated"
     false
-    (str_contains normal_result "[cache_invalidated]");
+    (str_contains normal_result.rendered "[cache_invalidated]");
   let operator_result =
     Workspace.broadcast config ~from_agent:"operator" ~content:stale_message
   in
   Alcotest.(check bool)
     "non-taskmaster stale-looking prose is not invalidated"
     false
-    (str_contains operator_result "[cache_invalidated]");
+    (str_contains operator_result.rendered "[cache_invalidated]");
 
   let _ = Workspace.reset config in
   Unix.rmdir tmp_dir
@@ -342,8 +350,8 @@ let test_event_log () =
   let result = Workspace.broadcast config ~from_agent:"claude" ~content:"Test event" in
 
   (* Verify broadcast returned a valid response (contains timestamp marker) *)
-  Alcotest.(check bool) "broadcast returns response" true (String.length result > 0);
-  Alcotest.(check bool) "broadcast has timestamp" true (String.contains result '[');
+  Alcotest.(check bool) "broadcast returns response" true (String.length result.rendered > 0);
+  Alcotest.(check bool) "broadcast has timestamp" true (String.contains result.rendered '[');
 
   (* Cleanup *)
   let _ = Workspace.reset config in
@@ -551,7 +559,7 @@ let test_special_chars_in_message () =
     (* Test special characters, unicode, JSON-unsafe chars *)
     let msg = "Hello \"world\" with 'quotes' and\nnewlines\tand\t한글!" in
     let result = Workspace.broadcast config ~from_agent:"claude" ~content:msg in
-    Alcotest.(check bool) "special chars handled" true (String.length result > 0)
+    Alcotest.(check bool) "special chars handled" true (String.length result.rendered > 0)
   )
 
 let test_agent_name_with_special_chars () =
@@ -895,7 +903,7 @@ let test_emoji_in_message () =
     (* Emoji characters should be preserved *)
     let msg = "🚀 Launching feature! 🎉" in
     let result = Workspace.broadcast config ~from_agent:"claude" ~content:msg in
-    Alcotest.(check bool) "emoji preserved" true (str_contains result "🚀")
+    Alcotest.(check bool) "emoji preserved" true (str_contains result.rendered "🚀")
   )
 
 let test_unicode_task_title () =
@@ -953,7 +961,7 @@ let test_very_long_message () =
   with_test_env (fun config ->
     let long_msg = String.make 10000 'x' in
     let result = Workspace.broadcast config ~from_agent:"claude" ~content:long_msg in
-    Alcotest.(check bool) "long message handled" true (String.length result > 0)
+    Alcotest.(check bool) "long message handled" true (String.length result.rendered > 0)
   )
 
 let test_message_with_json_chars () =
@@ -961,7 +969,7 @@ let test_message_with_json_chars () =
     (* JSON special characters should be escaped properly *)
     let msg = "{\"key\": \"value\", \"array\": [1,2,3]}" in
     let result = Workspace.broadcast config ~from_agent:"claude" ~content:msg in
-    Alcotest.(check bool) "json chars handled" true (String.length result > 0)
+    Alcotest.(check bool) "json chars handled" true (String.length result.rendered > 0)
   )
 
 let test_message_sequence () =
@@ -1021,7 +1029,10 @@ let test_xss_in_message () =
     let xss_payload = "<script>alert('xss')</script>" in
     let result = Workspace.broadcast config ~from_agent:"tester" ~content:xss_payload in
     (* Check that raw script tags are not in the result *)
-    let has_raw_script = str_contains result "<script>" || str_contains result "</script>" in
+    let has_raw_script =
+      str_contains result.rendered "<script>"
+      || str_contains result.rendered "</script>"
+    in
     Alcotest.(check bool) "xss sanitized" false has_raw_script
   )
 

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -297,6 +297,10 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     "delivery preserves the original mention"
     (Some "nick0cave")
     result.mention;
+  Alcotest.(check string)
+    "delivery exposes the canonical persisted sender"
+    "taskmaster-jade-heron"
+    result.from_agent;
   let messages = Workspace.get_all_messages_raw config ~since_seq in
   (match messages with
    | [ msg ] ->


### PR DESCRIPTION
## Scope

- make `Workspace.broadcast` the sole owner of the terminal-task cache invariant
- remove the caller-controlled `task_cache_invariant_checked` bypass
- return the canonical persisted delivery (`content`, `mention`, `msg_type`, rendered response)
- make MCP session, SSE, subscription, mention notification, and audit consumers reuse that delivery

## Feature trace

- entry: `masc_broadcast` -> `Mcp_tool_runtime_comm.handle_broadcast`
- authority: `Workspace.broadcast`
- downstream: workspace JSON row/backend publication/activity hook, then MCP Session/SSE/subscriptions/Notify/Audit
- operator entry: `Operator_control.execute_workspace_action` consumes only `delivery.rendered`

The terminal-task check is not a new Gate. It is the existing feature invariant moved behind one unavoidable entry point. There is no facade-from-facade call and no second preflight/rewrite path.

## Blast radius

- breaking internal OCaml return type: `string` -> `broadcast_delivery`
- external MCP/operator rendered response remains unchanged
- on terminal cache invalidation, every downstream consumer now sees the same rewritten content and preserved original mention as the persisted workspace row

## Verification

- `ocamlformat -i` on changed OCaml files
- `git diff --check`
- `scripts/dune-local.sh build test/test_workspace.exe`
- `_build/default/test/test_workspace.exe test messages 0-2` — 6/6 passed, including the canonical replacement content and preserved mention
- the unfiltered executable also reaches all broadcast tests successfully, then fails 9 unrelated pre-existing keeper-meta fixture identity cases (`agent_name does not match canonical keeper identity`)
