### PR TITLE
refactor(telemetry): require current wire and store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Removed
+- **Breaking (telemetry wire/storage)**: removed the retired
+  `Agent_joined`/`Agent_left` decoder aliases, the `.masc/telemetry.jsonl`
+  fallback reader, and the producer-less `Handoff_triggered` event plus its
+  derived `handoff_rate`. Telemetry now reads only the current date-split
+  `.masc/telemetry/YYYY-MM/DD.jsonl` store and rejects retired event variants.
 - **Breaking (keeper failure wire)**: removed the bare
   `fiber_unresolved` failure-reason projection retained for historical log and
   dashboard matching. Unexpected unresolved fibers now serialize as

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -218,7 +218,7 @@ let executor_outcomes_json (config : Workspace.config) : Yojson.Safe.t =
         if success then incr successes
       | Telemetry_eio.Tool_called _ -> ()
       | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Task_completed _
-      | Handoff_triggered _ | Error_occurred _ | Tool_assigned _ -> ()
+      | Error_occurred _ | Tool_assigned _ -> ()
     ) events;
     `Assoc [
       ("total_24h", `Int !total);

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -29,7 +29,6 @@ type event =
   | Agent_unbound of { agent_id: string; reason: string }
   | Task_started of { task_id: string; agent_id: string }
   | Task_completed of { task_id: string; duration_ms: int; success: bool }
-  | Handoff_triggered of { from_agent: string; to_agent: string; reason: string }
   | Error_occurred of { code: string; message: string; context: string }
   | Tool_called of {
       tool_name: string;
@@ -75,7 +74,6 @@ type metrics = {
   tasks_in_progress: int;
   tasks_completed_24h: int;
   avg_task_duration_ms: float;
-  handoff_rate: float;
   error_rate: float;
 } [@@deriving yojson, show]
 
@@ -117,10 +115,6 @@ let update_tool_usage stats_by_tool ~tool_name ~success ~timestamp =
         | None -> timestamp);
   } in
   Hashtbl.replace stats_by_tool tool_name updated
-
-(** Legacy single-file path (for fallback reads). *)
-let telemetry_file config =
-  Filename.concat (Workspace_utils.masc_dir config) "telemetry.jsonl"
 
 (** Date-split store: [.masc/telemetry/YYYY-MM/DD.jsonl].
     Cached per base_dir so all callers share the same Eio.Mutex.
@@ -176,40 +170,10 @@ let report_telemetry_drop ~reason ~path ~detail =
     ~on_drop:(fun () -> observe_telemetry_drop ~reason)
     ~surface:telemetry_eio_surface ~reason ~path ~detail
 
-(** Schema migration: map legacy variant names to current ones.
-
-    The [event] type underwent renames ([Agent_joined] → [Agent_session_bound],
-    [Agent_left] → [Agent_unbound]) but stored JSONL records retain the old
-    names in the wire format.  This normalizes the raw JSON so the
-    auto-generated yojson codec can deserialize it.
-
-    Payload fields are identical — this is a pure rename, no field migration. *)
-let legacy_variant_aliases : (string * string) list = [
-  ("Agent_joined", "Agent_session_bound");
-  ("Agent_left", "Agent_unbound");
-]
-
-let migrate_legacy_event_variant (json : Yojson.Safe.t) =
-  match json with
-  | `Assoc fields ->
-    let migrate_field (key, value) =
-      if key <> "event" then (key, value)
-      else
-        match value with
-        | `List [`String variant; payload] ->
-          (match List.assoc_opt variant legacy_variant_aliases with
-           | Some new_name -> (key, `List [`String new_name; payload])
-           | None -> (key, value))
-        | _ -> (key, value)
-    in
-    `Assoc (List.map migrate_field fields)
-  | _ -> json
-
 let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
   List.filter_map
     (fun json ->
-      let migrated = migrate_legacy_event_variant json in
-      match event_record_of_yojson migrated with
+      match event_record_of_yojson json with
       | Ok record -> Some record
       | Error msg ->
           report_telemetry_drop
@@ -217,28 +181,6 @@ let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
             ~path:"<in-memory>" ~detail:msg;
           None)
     jsons
-
-let read_all_events_from_path (file : string) : event_record list =
-  if not (Sys.file_exists file) then []
-  else
-    let content = Fs_compat.load_file file in
-    String.split_on_char '\n' content
-    |> List.filter (fun line -> String.trim line <> "")
-    |> List.filter_map (fun line ->
-           try
-             let json = migrate_legacy_event_variant (Yojson.Safe.from_string line) in
-             match event_record_of_yojson json with
-             | Ok record -> Some record
-             | Error msg ->
-                 report_telemetry_drop
-                   ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-                   ~path:file ~detail:msg;
-                 None
-           with Yojson.Json_error msg ->
-             report_telemetry_drop
-               ~reason:Safe_ops.persistence_read_drop_reason_json_syntax_error
-               ~path:file ~detail:msg;
-             None)
 
 let event_to_json event =
   let record = {
@@ -253,28 +195,16 @@ let track ?fs:_ config event : unit =
   let store = get_telemetry_store config in
   Dated_jsonl.append store (event_to_json event)
 
-(** Read all events.
-    Tries date-split store first; falls back to legacy single file. *)
+(** Read all current date-split events. *)
 let read_all_events ?fs:_ config : event_record list =
   let store = get_telemetry_store config in
-  let jsons = Dated_jsonl.read_recent store 100_000 in
-  if jsons <> [] then
-    parse_event_records jsons
-  else
-    read_all_events_from_path (telemetry_file config)
+  Dated_jsonl.read_recent store 100_000 |> parse_event_records
 
 let read_recent_events ?fs:_ config ~limit : event_record list =
   if limit <= 0 then []
   else
     let store = get_telemetry_store config in
-    let jsons = Dated_jsonl.read_recent store limit in
-    if jsons <> [] then
-      parse_event_records jsons
-    else
-      read_all_events_from_path (telemetry_file config)
-      |> List.rev
-      |> List.filteri (fun i _ -> i < limit)
-      |> List.rev
+    Dated_jsonl.read_recent store limit |> parse_event_records
 
 (* ── Tool usage summary cache ──────────────────────────────────────
    The dashboard refreshes Tool Monitor / Fleet Health / Tool Quality
@@ -297,12 +227,9 @@ let summarize_tool_usage ?fs config : tool_usage_summary =
   | Some entry when now -. entry.cached_at < tool_usage_cache_ttl ->
       entry.cached_summary
   | _ ->
-      let telemetry_path = telemetry_file config in
       let store = get_telemetry_store config in
-      let telemetry_available =
-        Sys.file_exists telemetry_path
-        || Sys.file_exists (Dated_jsonl.base_dir store)
-      in
+      let telemetry_path = Dated_jsonl.base_dir store in
+      let telemetry_available = Sys.file_exists telemetry_path in
       let stats_by_tool = Hashtbl.create 32 in
       let total_calls = ref 0 in
       let records = read_all_events ?fs config in
@@ -313,7 +240,7 @@ let summarize_tool_usage ?fs config : tool_usage_summary =
             update_tool_usage stats_by_tool ~tool_name ~success
               ~timestamp:record.timestamp
         | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Task_completed _
-        | Handoff_triggered _ | Error_occurred _ | Tool_assigned _ -> ()
+        | Error_occurred _ | Tool_assigned _ -> ()
       ) records;
       let summary = {
         telemetry_path;
@@ -362,8 +289,8 @@ let summarize_agent_activity ?fs config ~since : agent_activity list =
             Hashtbl.replace by_agent agent_id
               { agent_id; tool_calls = 0; success_count = 0; failure_count = 0;
                 first_seen = record.timestamp; last_seen = record.timestamp }
-      | Agent_unbound _ | Task_started _ | Task_completed _ | Handoff_triggered _
-      | Error_occurred _ | Tool_assigned _ -> ()
+      | Agent_unbound _ | Task_started _ | Task_completed _ | Error_occurred _
+      | Tool_assigned _ -> ()
   ) records;
   Hashtbl.fold (fun _ v acc -> v :: acc) by_agent []
   |> List.sort (fun a b -> compare b.tool_calls a.tool_calls)
@@ -400,41 +327,41 @@ let count_active_agents events =
     ~present:(fun r ->
       match r.event with
       | Agent_session_bound { agent_id; _ } -> Some agent_id
-      | Agent_unbound _ | Task_started _ | Task_completed _ | Handoff_triggered _
-      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
+      | Agent_unbound _ | Task_started _ | Task_completed _ | Error_occurred _
+      | Tool_called _ | Tool_assigned _ -> None)
     ~absent:(fun r ->
       match r.event with
       | Agent_unbound { agent_id; _ } -> Some agent_id
-      | Agent_session_bound _ | Task_started _ | Task_completed _ | Handoff_triggered _
-      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
+      | Agent_session_bound _ | Task_started _ | Task_completed _ | Error_occurred _
+      | Tool_called _ | Tool_assigned _ -> None)
 
 let count_tasks_in_progress events =
   Set_util.count_difference events
     ~present:(fun r ->
       match r.event with
       | Task_started { task_id; _ } -> Some task_id
-      | Agent_session_bound _ | Agent_unbound _ | Task_completed _ | Handoff_triggered _
-      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
+      | Agent_session_bound _ | Agent_unbound _ | Task_completed _ | Error_occurred _
+      | Tool_called _ | Tool_assigned _ -> None)
     ~absent:(fun r ->
       match r.event with
       | Task_completed { task_id; _ } -> Some task_id
-      | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Handoff_triggered _
-      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
+      | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Error_occurred _
+      | Tool_called _ | Tool_assigned _ -> None)
 
 let count_completed_tasks events =
   List_util.count_if (fun r ->
     match r.event with
     | Task_completed _ -> true
-    | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Handoff_triggered _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
+    | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Error_occurred _
+    | Tool_called _ | Tool_assigned _ -> false
   ) events
 
 let avg_duration events =
   let durations = List.filter_map (fun r ->
     match r.event with
     | Task_completed { duration_ms; _ } -> Some (float_of_int duration_ms)
-    | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Handoff_triggered _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
+    | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Error_occurred _
+    | Tool_called _ | Tool_assigned _ -> None
   ) events in
   match durations with
   | [] -> 0.0
@@ -442,28 +369,12 @@ let avg_duration events =
       let sum = List.fold_left (+.) 0.0 times in
       sum /. float_of_int (List.length times)
 
-let calculate_handoff_rate events =
-  let handoffs = List_util.count_if (fun r ->
-    match r.event with
-    | Handoff_triggered _ -> true
-    | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Task_completed _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
-  ) events in
-  let task_events = List_util.count_if (fun r ->
-    match r.event with
-    | Task_started _ | Task_completed _ -> true
-    | Agent_session_bound _ | Agent_unbound _ | Handoff_triggered _ | Error_occurred _
-    | Tool_called _ | Tool_assigned _ -> false
-  ) events in
-  if task_events = 0 then 0.0
-  else float_of_int handoffs /. float_of_int task_events
-
 let calculate_error_rate events =
   let errors = List_util.count_if (fun r ->
     match r.event with
     | Error_occurred _ -> true
     | Agent_session_bound _ | Agent_unbound _ | Task_started _ | Task_completed _
-    | Handoff_triggered _ | Tool_called _ | Tool_assigned _ -> false
+    | Tool_called _ | Tool_assigned _ -> false
   ) events in
   let total = List.length events in
   if total = 0 then 0.0
@@ -479,7 +390,6 @@ let get_metrics ?fs config : metrics =
     tasks_in_progress = count_tasks_in_progress events;
     tasks_completed_24h = count_completed_tasks events;
     avg_task_duration_ms = avg_duration events;
-    handoff_rate = calculate_handoff_rate events;
     error_rate = calculate_error_rate events;
   }
 
@@ -495,15 +405,6 @@ let track_task_started ?fs config ~task_id ~agent_id =
 
 let track_task_completed ?fs config ~task_id ~duration_ms ~success =
   track ?fs config (Task_completed { task_id; duration_ms; success })
-
-(* [track_handoff] removed: 0 production callers as of #10358 (c2)
-   audit (2026-05-05). masc has no runtime-routing handoff
-   concept; the [Handoff_triggered] event variant is retained for
-   wire-schema compatibility and exhaustive-match coverage in
-   [dashboard_http_monitoring],
-   but the public emitter is dropped to prevent new code from
-   reintroducing unused telemetry. Tests construct the variant
-   directly to validate the wire schema. *)
 
 let track_error ?fs config ~code ~message ~context =
   track ?fs config (Error_occurred { code; message; context })

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -9,11 +9,11 @@
     calculators, plus the [rotate] maintenance entry point.
 
     Internal helpers ([empty_tool_usage_stats], [update_tool_usage],
-    [telemetry_file], the [telemetry_store_cache] Hashtbl + mutex,
+    the [telemetry_store_cache] Hashtbl + mutex,
     [get_telemetry_store], [telemetry_eio_surface] /
     [observe_telemetry_drop] / [report_telemetry_drop],
-    [read_all_events_from_path], [event_to_json], [track], and the
-    [nonempty_opt] string utility) are hidden — callers consume the
+    [event_to_json], [track], and the [nonempty_opt] string utility) are hidden
+    — callers consume the
     typed event ADT and the convenience emitters / readers only.
 
     The date-split telemetry store applies bounded retention by default:
@@ -41,11 +41,6 @@ type event =
       task_id : string;
       duration_ms : int;
       success : bool;
-    }
-  | Handoff_triggered of {
-      from_agent : string;
-      to_agent : string;
-      reason : string;
     }
   | Error_occurred of {
       code : string;
@@ -87,7 +82,6 @@ type metrics = {
   tasks_in_progress : int;
   tasks_completed_24h : int;
   avg_task_duration_ms : float;
-  handoff_rate : float;
   error_rate : float;
 } [@@deriving yojson, show]
 
@@ -148,7 +142,6 @@ val count_active_agents : event_record list -> int
 val count_tasks_in_progress : event_record list -> int
 val count_completed_tasks : event_record list -> int
 val avg_duration : event_record list -> float
-val calculate_handoff_rate : event_record list -> float
 val calculate_error_rate : event_record list -> float
 
 (** {1 Convenience emitters} *)
@@ -174,12 +167,6 @@ val track_task_completed :
   duration_ms:int ->
   success:bool ->
   unit
-
-(* track_handoff intentionally not exposed: 0 production callers as
-   of #10358 (c2) audit. The Handoff_triggered variant remains in
-   [event] above for wire-schema compatibility but no public emitter
-   exists. Add a new emitter only when masc introduces a real
-   runtime-routing handoff concept. *)
 
 val track_error :
   ?fs:'a ->

--- a/lib/tool/tool_registry.ml
+++ b/lib/tool/tool_registry.ml
@@ -24,7 +24,7 @@ module Float = Stdlib.Float
     Usage:
     - record_call is called on every tools/call dispatch
     - get_stats / get_top_n / get_unused_since provide reporting
-    - Data resets on server restart (telemetry.jsonl is the durable store)
+    - Data resets on server restart (the date-split Telemetry_eio store is durable)
 *)
 
 (** Call source for source-aware telemetry.

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -116,18 +116,6 @@ let test_event_task_completed () =
       check bool "success" true r.success
   | _ -> fail "expected Task_completed"
 
-let test_event_handoff_triggered () =
-  let e = Telemetry_eio.Handoff_triggered {
-    from_agent = "claude-001";
-    to_agent = "codex-001";
-    reason = "context limit";
-  } in
-  match e with
-  | Telemetry_eio.Handoff_triggered r ->
-      check string "from_agent" "claude-001" r.from_agent;
-      check string "to_agent" "codex-001" r.to_agent
-  | _ -> fail "expected Handoff_triggered"
-
 let test_event_error_occurred () =
   let e = Telemetry_eio.Error_occurred {
     code = "E001";
@@ -321,14 +309,12 @@ let test_metrics_type () =
     tasks_in_progress = 5;
     tasks_completed_24h = 42;
     avg_task_duration_ms = 3500.0;
-    handoff_rate = 0.15;
     error_rate = 0.02;
   } in
   check int "active_agents" 3 m.active_agents;
   check int "tasks_in_progress" 5 m.tasks_in_progress;
   check int "tasks_completed_24h" 42 m.tasks_completed_24h;
   check (float 0.01) "avg_task_duration_ms" 3500.0 m.avg_task_duration_ms;
-  check (float 0.01) "handoff_rate" 0.15 m.handoff_rate;
   check (float 0.01) "error_rate" 0.02 m.error_rate
 
 (* ============================================================
@@ -351,47 +337,28 @@ let test_event_json_roundtrip () =
        | _ -> fail "wrong event type")
   | Error e -> fail ("json decode failed: " ^ e)
 
-(* Legacy variant migration: Agent_joined → Agent_session_bound.
-   Records written before the rename must still deserialize. *)
-let test_legacy_agent_joined_migration () =
-  let legacy_json =
-    `Assoc [
-      ("timestamp", `Float 1000.0);
-      ("event", `List [
-        `String "Agent_joined";
-        `Assoc [("agent_id", `String "keeper-test"); ("capabilities", `List [])]
-      ]);
+let test_retired_agent_variants_are_rejected () =
+  let row variant payload =
+    `Assoc
+      [ "timestamp", `Float 1000.0
+      ; "event", `List [ `String variant; payload ]
+      ]
+  in
+  let cases =
+    [ ( "Agent_joined"
+      , `Assoc [ "agent_id", `String "keeper-test"; "capabilities", `List [] ] )
+    ; ( "Agent_left"
+      , `Assoc [ "agent_id", `String "keeper-test"; "reason", `String "leave" ] )
     ]
   in
-  let parsed = Telemetry_eio.parse_event_records [ legacy_json ] in
-  check int "legacy Agent_joined produces 1 record" 1 (List.length parsed);
-  let record = List.hd parsed in
-  check bool "event is Agent_session_bound" true
-    (match record.event with
-     | Telemetry_eio.Agent_session_bound r ->
-       String.equal r.agent_id "keeper-test" &&
-       List.length r.capabilities = 0
-     | _ -> false)
-
-let test_legacy_agent_left_migration () =
-  let legacy_json =
-    `Assoc [
-      ("timestamp", `Float 1000.0);
-      ("event", `List [
-        `String "Agent_left";
-        `Assoc [("agent_id", `String "keeper-test"); ("reason", `String "leave")]
-      ]);
-    ]
-  in
-  let parsed = Telemetry_eio.parse_event_records [ legacy_json ] in
-  check int "legacy Agent_left produces 1 record" 1 (List.length parsed);
-  let record = List.hd parsed in
-  check bool "event is Agent_unbound" true
-    (match record.event with
-     | Telemetry_eio.Agent_unbound r ->
-       String.equal r.agent_id "keeper-test" &&
-       String.equal r.reason "leave"
-     | _ -> false)
+  List.iter
+    (fun (variant, payload) ->
+      check
+        int
+        (variant ^ " is not repaired")
+        0
+        (List.length (Telemetry_eio.parse_event_records [ row variant payload ])))
+    cases
 
 (* Drop observability: malformed payload increments
    masc_persistence_read_drops_total{surface=telemetry_eio,reason=invalid_payload}.
@@ -424,7 +391,6 @@ let test_metrics_json_roundtrip () =
     tasks_in_progress = 7;
     tasks_completed_24h = 100;
     avg_task_duration_ms = 2500.0;
-    handoff_rate = 0.1;
     error_rate = 0.01;
   } in
   let json = Telemetry_eio.metrics_to_yojson original in
@@ -556,30 +522,6 @@ let test_avg_duration_multiple () =
   check bool "avg 1500" true (abs_float (avg -. 1500.0) < 0.01)
 
 (* ============================================================
-   calculate_handoff_rate Tests
-   ============================================================ *)
-
-let test_calculate_handoff_rate_empty () =
-  let events : Telemetry_eio.event_record list = [] in
-  let rate = Telemetry_eio.calculate_handoff_rate events in
-  check bool "zero" true (abs_float rate < 0.01)
-
-let test_calculate_handoff_rate_no_handoffs () =
-  let events : Telemetry_eio.event_record list = [
-    { timestamp = 1.0; event = Task_completed { task_id = "t1"; duration_ms = 100; success = true } };
-  ] in
-  let rate = Telemetry_eio.calculate_handoff_rate events in
-  check bool "zero" true (abs_float rate < 0.01)
-
-let test_calculate_handoff_rate_some_handoffs () =
-  let events : Telemetry_eio.event_record list = [
-    { timestamp = 1.0; event = Task_completed { task_id = "t1"; duration_ms = 100; success = true } };
-    { timestamp = 2.0; event = Handoff_triggered { from_agent = "a1"; to_agent = "a2"; reason = "x" } };
-  ] in
-  let rate = Telemetry_eio.calculate_handoff_rate events in
-  check bool "positive" true (rate > 0.0)
-
-(* ============================================================
    calculate_error_rate Tests
    ============================================================ *)
 
@@ -621,7 +563,33 @@ let test_summarize_tool_usage_reads_date_split_store_without_fs () =
         | None -> fail "missing stats for masc_status"
       in
       check int "usage count" 1 stats.count;
-      check bool "telemetry available" true summary.telemetry_available)
+      check bool "telemetry available" true summary.telemetry_available;
+      check
+        string
+        "telemetry path is the current date-split store"
+        (telemetry_dir base_dir)
+        summary.telemetry_path)
+
+let test_legacy_single_file_is_ignored () =
+  with_temp_dir
+  @@ fun base_dir ->
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Workspace.default_config base_dir in
+  let legacy_path =
+    Filename.concat (Filename.concat base_dir ".masc") "telemetry.jsonl"
+  in
+  Fs_compat.mkdir_p (Filename.dirname legacy_path);
+  Fs_compat.append_file
+    legacy_path
+    {|{"timestamp":1000.0,"event":["Agent_session_bound",{"agent_id":"legacy-only","capabilities":[]}]}|}
+  ;
+  check
+    int
+    "legacy single-file telemetry is not read"
+    0
+    (List.length (Telemetry_eio.read_all_events config))
 
 let test_track_applies_default_retention_days () =
   with_env "MASC_TELEMETRY_RETENTION_DAYS" "" (fun () ->
@@ -676,7 +644,6 @@ let () =
       test_case "agent_unbound" `Quick test_event_agent_unbound;
       test_case "task_started" `Quick test_event_task_started;
       test_case "task_completed" `Quick test_event_task_completed;
-      test_case "handoff_triggered" `Quick test_event_handoff_triggered;
       test_case "error_occurred" `Quick test_event_error_occurred;
       test_case "tool_called" `Quick test_event_tool_called;
     ];
@@ -699,10 +666,8 @@ let () =
       test_case "metrics" `Quick test_metrics_json_roundtrip;
       test_case "drop increments persistence_read_drops counter" `Quick
         test_parse_event_records_drop_increments_counter;
-      test_case "legacy Agent_joined migrates to Agent_session_bound" `Quick
-        test_legacy_agent_joined_migration;
-      test_case "legacy Agent_left migrates to Agent_unbound" `Quick
-        test_legacy_agent_left_migration;
+      test_case "retired agent variants are rejected" `Quick
+        test_retired_agent_variants_are_rejected;
     ];
     "event_to_json", [
       test_case "agent_session_bounded" `Quick test_event_to_json_agent_session_bounded;
@@ -729,11 +694,6 @@ let () =
       test_case "one" `Quick test_avg_duration_one;
       test_case "multiple" `Quick test_avg_duration_multiple;
     ];
-    "calculate_handoff_rate", [
-      test_case "empty" `Quick test_calculate_handoff_rate_empty;
-      test_case "no handoffs" `Quick test_calculate_handoff_rate_no_handoffs;
-      test_case "some handoffs" `Quick test_calculate_handoff_rate_some_handoffs;
-    ];
     "calculate_error_rate", [
       test_case "empty" `Quick test_calculate_error_rate_empty;
       test_case "no errors" `Quick test_calculate_error_rate_no_errors;
@@ -742,6 +702,8 @@ let () =
     "store_reads", [
       test_case "summarize_tool_usage reads date-split store" `Quick
         test_summarize_tool_usage_reads_date_split_store_without_fs;
+      test_case "legacy single telemetry file is ignored" `Quick
+        test_legacy_single_file_is_ignored;
       test_case "track applies default retention days" `Quick
         test_track_applies_default_retention_days;
       test_case "track applies telemetry max bytes" `Quick

--- a/test/test_telemetry_eio_pbt.ml
+++ b/test/test_telemetry_eio_pbt.ml
@@ -32,7 +32,7 @@ let opt_int =
     avoids control characters to keep counterexamples readable. *)
 let gen_event : Telemetry_eio.event QCheck.Gen.t =
   let open QCheck.Gen in
-  let* tag = int_range 0 7 in
+  let* tag = int_range 0 6 in
   match tag with
   | 0 ->
       let* agent_id = string_small in
@@ -52,17 +52,11 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
       let* success = bool in
       return (Telemetry_eio.Task_completed { task_id; duration_ms; success })
   | 4 ->
-      let* from_agent = string_small in
-      let* to_agent = string_small in
-      let* reason = string_small in
-      return
-        (Telemetry_eio.Handoff_triggered { from_agent; to_agent; reason })
-  | 5 ->
       let* code = string_small in
       let* message = string_small in
       let* context = string_small in
       return (Telemetry_eio.Error_occurred { code; message; context })
-  | 6 ->
+  | 5 ->
       let* tool_name = string_small in
       let* success = bool in
       let* duration_ms = nat_small in

--- a/test/test_telemetry_error_occurred_wire_10358.ml
+++ b/test/test_telemetry_error_occurred_wire_10358.ml
@@ -74,7 +74,6 @@ let event_kind_tag (e : T.event) =
   | T.Agent_unbound _ -> "Agent_unbound"
   | T.Task_started _ -> "Task_started"
   | T.Task_completed _ -> "Task_completed"
-  | T.Handoff_triggered _ -> "Handoff_triggered"
   | T.Error_occurred _ -> "Error_occurred"
   | T.Tool_called _ -> "Tool_called"
   | T.Tool_assigned _ -> "Tool_assigned"


### PR DESCRIPTION
## Scope

- remove `Agent_joined`/`Agent_left` decoder repair
- remove the `.masc/telemetry.jsonl` fallback reader
- remove producer-less `Handoff_triggered` and its dead `handoff_rate`
- read only the current date-split `.masc/telemetry/YYYY-MM/DD.jsonl` store

This is a hard cut. It adds no migration reader, converter, compatibility alias, or replacement field.

## Feature trace

- producers: workspace metric hooks, MCP/keeper tool-call tracking, dashboard tool-host errors/assignments
- store authority: `Telemetry_eio.track` -> `Dated_jsonl`
- readers: tool usage, agent activity, 24-hour metrics, dashboard executor outcomes
- audited current producers emit only `Agent_session_bound`, `Agent_unbound`, task, error, tool-call, and tool-assignment variants
- repository search found no production constructor or emitter for `Handoff_triggered`

## Blast radius

- retired event names are rejected and reported through the existing persistence-drop diagnostic
- an old single-file telemetry store is ignored
- generated `metrics` JSON no longer contains `handoff_rate`
- the unrelated current handoff-success metric in `Metrics_store_eio` is untouched

## Verification

- `ocamlformat -i` on changed OCaml files
- `git diff --check`
- negative tests reject retired aliases and ignore the old single-file path
- event round-trip/PBT/exhaustive dashboard matches updated
- focused Dune targets pending while an unrelated bare `dune build .` owns the machine-wide build resource
