### PR TITLE
refactor(fusion): make typed origin the run authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   fallback reader, and the producer-less `Handoff_triggered` event plus its
   derived `handoff_rate`. Telemetry now reads only the current date-split
   `.masc/telemetry/YYYY-MM/DD.jsonl` store and rejects retired event variants.
+- **Breaking (Fusion board metadata)**: removed duplicate `source` and `run_id`
+  keys from Fusion `meta_json`. Board `origin.source` and
+  `origin.fusion_run_id` are now the sole typed identity consumed by the Board
+  evidence and Fusion dashboard features; posts without that current origin
+  are not admitted to those surfaces.
 - **Breaking (keeper failure wire)**: removed the bare
   `fiber_unresolved` failure-reason projection retained for historical log and
   dashboard matching. Unexpected unresolved fibers now serialize as

--- a/dashboard/src/components/board/fusion-evidence.test.ts
+++ b/dashboard/src/components/board/fusion-evidence.test.ts
@@ -6,18 +6,17 @@ import { FusionBoardEvidence } from './fusion-evidence'
 
 afterEach(() => cleanup())
 
-// Build a fusion board post whose meta carries the RFC-0284 `judges` observation
-// array. `judges === undefined` models an older post that predates the array.
+// Build a current Fusion board post whose typed origin owns run identity and
+// whose meta carries the RFC-0284 `judges` observation array.
 function fusionPost(judges: unknown) {
   return {
     meta: {
-      source: 'fusion',
-      run_id: 'fus-1',
       question: 'q?',
       panel: [{ model: 'gpt-5', status: 'answered', answer: 'panel answer' }],
       judge: { status: 'synthesized', synthesis: '최종 종합' },
       judges,
     },
+    origin: { source: 'fusion', fusion_run_id: 'fus-1' },
   } as Parameters<typeof FusionBoardEvidence>[0]['post']
 }
 
@@ -98,7 +97,12 @@ describe('FusionBoardEvidence judge topology strip (RFC-0284 PR 2)', () => {
 
   it('returns null for non-fusion meta', () => {
     const { container } = render(
-      h(FusionBoardEvidence, { post: { meta: { foo: 'bar' } } as Parameters<typeof FusionBoardEvidence>[0]['post'] }),
+      h(FusionBoardEvidence, {
+        post: {
+          meta: { foo: 'bar' },
+          origin: null,
+        } as Parameters<typeof FusionBoardEvidence>[0]['post'],
+      }),
     )
     expect(container.querySelector('[data-testid="fusion-board-evidence"]')).toBeNull()
   })
@@ -129,8 +133,6 @@ describe('FusionBoardEvidence failure attribution', () => {
   it('renders the panel reason_code chip on a failed panel', () => {
     const post = {
       meta: {
-        source: 'fusion',
-        run_id: 'fus-1',
         question: 'q?',
         panel: [
           { model: 'gpt-5', status: 'answered', answer: 'panel answer' },
@@ -143,6 +145,7 @@ describe('FusionBoardEvidence failure attribution', () => {
         ],
         judge: { status: 'synthesized', synthesis: '최종 종합' },
       },
+      origin: { source: 'fusion', fusion_run_id: 'fus-1' },
     } as Parameters<typeof FusionBoardEvidence>[0]['post']
     render(h(FusionBoardEvidence, { post }))
     const codes = screen.getAllByText('provider_error', { selector: '[data-fusion-panel-code]' })

--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -138,10 +138,10 @@ export function FusionBoardEvidence({
   post,
   class: className,
 }: {
-  post: Pick<BoardPost, 'meta'>
+  post: Pick<BoardPost, 'meta' | 'origin'>
   class?: string
 }) {
-  const evidence = extractFusionEvidence(post.meta)
+  const evidence = extractFusionEvidence(post.meta, post.origin)
   if (!evidence) return null
 
   const answeredCount = evidence.panel.filter((panel) => panel.status === 'answered').length

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -683,9 +683,8 @@ describe('PostDetail', () => {
       comment_count: 0,
       post_kind: 'system',
       comments: [],
+      origin: { source: 'fusion', fusion_run_id: 'fus-1234567890' },
       meta: {
-        source: 'fusion',
-        run_id: 'fus-1234567890',
         question: 'Should we ship the fusion board renderer?',
         panel: [
           {

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -109,9 +109,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-1',
         title: 'Fusion deliberation (run fus-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-1',
           question: 'Which deploy path should we take?',
           panel: [
             {
@@ -137,10 +136,6 @@ describe('FusionSurface', () => {
             input_tokens: 1300,
             output_tokens: 360,
           },
-        },
-        origin: {
-          source: 'fusion',
-          fusion_run_id: 'fus-1',
         },
       }),
     ]
@@ -177,24 +172,22 @@ describe('FusionSurface', () => {
     expect(container.textContent).toContain('panel ×2')
     expect(container.textContent).toContain('board evidence')
     expect(container.querySelector('[data-testid="fusion-sink-linkage"]')?.getAttribute('data-linkage-status')).toBe('verified')
-    expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.getAttribute('data-meta-run-id')).toBe('fus-1')
+    expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.hasAttribute('data-meta-run-id')).toBe(false)
     expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.getAttribute('data-origin-run-id')).toBe('fus-1')
-    expect(container.textContent).toContain('origin verified')
-    expect(container.textContent).toContain('typed origin으로 run linkage 검증')
+    expect(container.textContent).toContain('typed origin')
+    expect(container.textContent).toContain('typed origin이 run identity를 소유')
     expect(container.textContent).not.toContain('chat · board')
   })
 
-  it('warns when a successful fusion board post lacks typed origin linkage', () => {
+  it('rejects a Fusion board post without typed origin', () => {
     fusionBoardPosts.value = [
       boardPost({
-        id: 'post-fus-legacy',
-        title: 'Fusion deliberation (run fus-legacy): answer',
+        id: 'post-fus-unowned',
+        title: 'Unowned deliberation',
         meta: {
-          source: 'fusion',
-          run_id: 'fus-legacy',
-          question: 'Legacy sink?',
-          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Use meta only.' }],
-          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Legacy answer.' },
+          question: 'Missing origin?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'No.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Reject.' },
         },
         origin: null,
       }),
@@ -202,26 +195,19 @@ describe('FusionSurface', () => {
 
     render(html`<${FusionSurface} />`, container)
 
-    const linkage = container.querySelector('[data-testid="fusion-sink-linkage"]')
-    const correlation = container.querySelector('[data-testid="fusion-sink-correlation"]')
-    expect(linkage?.getAttribute('data-linkage-status')).toBe('missing')
-    expect(linkage?.textContent).toContain('origin unverified')
-    expect(linkage?.textContent).toContain('typed board origin is absent')
-    expect(correlation?.getAttribute('data-origin-run-id')).toBe('')
-    expect(correlation?.textContent).toContain('origin unverified')
+    expect(container.querySelector('[data-testid="fusion-detail"]')).toBeNull()
+    expect(container.textContent).not.toContain('Missing origin?')
   })
 
-  it('flags a meta/origin run-id mismatch instead of treating sink projection as verified', () => {
+  it('uses origin.fusion_run_id as the only run identity', () => {
     fusionBoardPosts.value = [
       boardPost({
         id: 'post-fus-drift',
-        title: 'Fusion deliberation (run fus-meta): answer',
+        title: 'Fusion deliberation',
         meta: {
-          source: 'fusion',
-          run_id: 'fus-meta',
-          question: 'Drifted sink?',
-          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Mismatch.' }],
-          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Mismatch answer.' },
+          question: 'Origin-owned sink?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Exact.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Exact answer.' },
         },
         origin: {
           source: 'fusion',
@@ -232,13 +218,10 @@ describe('FusionSurface', () => {
 
     render(html`<${FusionSurface} />`, container)
 
-    const linkage = container.querySelector('[data-testid="fusion-sink-linkage"]')
     const correlation = container.querySelector('[data-testid="fusion-sink-correlation"]')
-    expect(linkage?.getAttribute('data-linkage-status')).toBe('mismatch')
-    expect(linkage?.textContent).toContain('origin mismatch')
-    expect(linkage?.textContent).toContain('origin.fusion_run_id=fus-origin')
-    expect(correlation?.getAttribute('data-meta-run-id')).toBe('fus-meta')
     expect(correlation?.getAttribute('data-origin-run-id')).toBe('fus-origin')
+    expect(container.textContent).toContain('fus-origin')
+    expect(container.textContent).toContain('Origin-owned sink?')
   })
 
   it('renders the RFC-0284 judge-node strip for a judge-of-judges run', () => {
@@ -250,9 +233,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-joj',
         title: 'Fusion deliberation (run joj-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'joj-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'joj-1',
           question: 'Which judge topology?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'reconciled answer' },
@@ -291,9 +273,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-joj-iso',
         title: 'Fusion deliberation (run joj-iso): answer',
+        origin: { source: 'fusion', fusion_run_id: 'joj-iso' },
         meta: {
-          source: 'fusion',
-          run_id: 'joj-iso',
           question: 'Which redesign?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'reconciled answer' },
@@ -336,9 +317,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-joj-cards',
         title: 'Fusion deliberation (run joj-cards): answer',
+        origin: { source: 'fusion', fusion_run_id: 'joj-cards' },
         meta: {
-          source: 'fusion',
-          run_id: 'joj-cards',
           question: 'round.ml redesign?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: {
@@ -417,9 +397,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-simple-nocards',
         title: 'Fusion deliberation (run simple-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'simple-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'simple-1',
           question: 'simple?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'simple answer' },
@@ -438,9 +417,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-refine',
         title: 'Fusion deliberation (run refine-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'refine-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'refine-1',
           question: 'Refine path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'refined answer' },
@@ -467,9 +445,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-legacy',
         title: 'Fusion deliberation (run legacy-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'legacy-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'legacy-1',
           question: 'Legacy?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'legacy answer' },
@@ -495,9 +472,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-long',
         title: 'Fusion deliberation (run long-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'long-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'long-1',
           question: 'Which path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: longAnswer },
@@ -524,9 +500,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-short',
         title: 'Fusion deliberation (run short-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'short-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'short-1',
           question: 'Which path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary first.' },
@@ -545,9 +520,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-structured',
         title: 'Fusion deliberation (run fus-structured): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-structured' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-structured',
           question: 'Which model result should drive the operator note?',
           panel: [
             { model: 'gpt-5', status: 'answered', answer: 'Prefer the canary-backed note.' },
@@ -614,9 +588,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-1',
         title: 'Fusion deliberation (run fus-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-1',
           question: 'Which deploy path should we take?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Use the canary path.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary first.' },
@@ -640,30 +613,26 @@ describe('FusionSurface', () => {
     expect(row?.className).not.toContain('opts')
   })
 
-  it('supports older nested fusion_deliberation metadata and route selection', () => {
+  it('selects a current typed-origin run from the route', () => {
     fusionBoardPosts.value = [
       boardPost({
         id: 'post-fus-1',
         updated_at: '2026-06-19T01:00:00Z',
+        origin: { source: 'fusion', fusion_run_id: 'fus-1' },
         meta: {
-          fusion_deliberation: {
-            run_id: 'fus-1',
-            question: 'older run',
-            panel: [],
-            judge: { status: 'synthesized', resolved_answer: 'older answer' },
-          },
+          question: 'first run',
+          panel: [],
+          judge: { status: 'synthesized', resolved_answer: 'first answer' },
         },
       }),
       boardPost({
         id: 'post-fus-2',
         updated_at: '2026-06-19T02:00:00Z',
+        origin: { source: 'fusion', fusion_run_id: 'fus-2' },
         meta: {
-          fusion_deliberation: {
-            run_id: 'fus-2',
-            question: 'newer run',
-            panel: [],
-            judge: { status: 'synthesized', resolved_answer: 'newer answer' },
-          },
+          question: 'second run',
+          panel: [],
+          judge: { status: 'synthesized', resolved_answer: 'second answer' },
         },
       }),
     ]
@@ -671,7 +640,7 @@ describe('FusionSurface', () => {
 
     render(html`<${FusionSurface} />`, container)
 
-    expect(container.querySelector('[data-testid="fusion-detail"]')?.textContent).toContain('older answer')
+    expect(container.querySelector('[data-testid="fusion-detail"]')?.textContent).toContain('first answer')
 
     const secondRow = Array.from(container.querySelectorAll<HTMLButtonElement>('.fus-run-row'))
       .find(button => button.textContent?.includes('fus-2'))
@@ -715,9 +684,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-cached',
         title: 'Fusion deliberation (run fus-cached): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-cached' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-cached',
           question: 'Cached run?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Use cached evidence.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Cached answer.' },
@@ -774,9 +742,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-evidence',
         created_at: '2026-01-01T00:00:00Z',
+        origin: { source: 'fusion', fusion_run_id: 'fus-evidence' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-evidence',
           question: 'Which evidence is actionable?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Board-backed detail.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Use the evidence pane.' },
@@ -803,9 +770,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-evidence',
         created_at: '2026-01-01T00:00:00Z',
+        origin: { source: 'fusion', fusion_run_id: 'fus-evidence' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-evidence',
           question: 'Which evidence is actionable?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Board-backed detail.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Use the evidence pane.' },
@@ -834,9 +800,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-1',
         title: 'Fusion deliberation (run fus-1): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-1' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-1',
           question: 'Which path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
@@ -875,9 +840,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-statuses',
         title: 'Fusion deliberation (run fus-statuses): mixed',
+        origin: { source: 'fusion', fusion_run_id: 'fus-statuses' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-statuses',
           question: 'Status edge cases?',
           panel: [
             { model: 'm1', status: 'failover', answer: 'Not a failure.' },
@@ -908,9 +872,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-judge-status-substring',
         title: 'Fusion deliberation (run fus-judge-status-substring): pending',
+        origin: { source: 'fusion', fusion_run_id: 'fus-judge-status-substring' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-judge-status-substring',
           question: 'Judge status edge cases?',
           panel: [{ model: 'm1', status: 'answered', answer: 'Panel answer.' }],
           judge: { status: 'failover' },
@@ -931,9 +894,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-fus-reason-code',
         title: 'Fusion deliberation (run fus-reason-code): mixed',
+        origin: { source: 'fusion', fusion_run_id: 'fus-reason-code' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-reason-code',
           question: 'Reason code?',
           panel: [
             { model: 'gpt-5', status: 'answered', answer: 'ok' },
@@ -965,9 +927,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-params',
         title: 'Fusion deliberation (run fus-params): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-params' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-params',
           question: 'Which path?',
           temperature: 0.7,
           top_p: 0.95,
@@ -997,9 +958,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-no-params',
         title: 'Fusion deliberation (run fus-no-params): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-no-params' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-no-params',
           question: 'Which path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
@@ -1018,9 +978,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-rich-prompt',
         title: 'Fusion deliberation (run fus-rich-prompt): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-rich-prompt' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-rich-prompt',
           question: 'Check **this** [link](https://example.com).',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'OK.' }],
           judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Done.' },
@@ -1041,9 +1000,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-rich-panel',
         title: 'Fusion deliberation (run fus-rich-panel): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-rich-panel' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-rich-panel',
           question: 'Which path?',
           panel: [
             {
@@ -1069,9 +1027,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-rich-judge',
         title: 'Fusion deliberation (run fus-rich-judge): answer',
+        origin: { source: 'fusion', fusion_run_id: 'fus-rich-judge' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-rich-judge',
           question: 'Which path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
           judge: {
@@ -1096,9 +1053,8 @@ describe('FusionSurface', () => {
       boardPost({
         id: 'post-rich-resolved',
         title: 'Fusion deliberation (run fus-rich-resolved): recommend',
+        origin: { source: 'fusion', fusion_run_id: 'fus-rich-resolved' },
         meta: {
-          source: 'fusion',
-          run_id: 'fus-rich-resolved',
           question: 'Which path?',
           panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
           judge: {
@@ -1131,9 +1087,8 @@ describe('FusionSurface', () => {
       title: `Fusion deliberation (run ${runId})`,
       created_at: createdAt,
       updated_at: updatedAt,
+      origin: { source: 'fusion', fusion_run_id: runId },
       meta: {
-        source: 'fusion',
-        run_id: runId,
         question: `Question for ${runId}?`,
         panel: [],
         judge: { status: 'synthesized', decision: 'answer', synthesis: 's', resolved_answer: 'r' },

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -122,8 +122,6 @@ interface FusionRunParams {
 interface FusionRunView {
   runId: string
   boardPostId: string
-  boardOriginSource: string | null
-  boardOriginRunId: string | null
   keeperName: string
   title: string
   question: string
@@ -333,27 +331,27 @@ function keeperNameFor(post: BoardPost): string {
     || 'system'
 }
 
-function fusionMeta(post: BoardPost): Record<string, unknown> | null {
+function fusionEvidence(post: BoardPost): {
+  meta: Record<string, unknown>
+  runId: string
+} | null {
   const meta = asRecord(post.meta)
   if (!meta) return null
-  if (asString(meta.source) === FUSION_BOARD_SOURCE) return meta
-
-  const nested = asRecord(meta.fusion_deliberation)
-  if (nested) return { ...nested, source: FUSION_BOARD_SOURCE }
-
-  return null
+  if (post.origin?.source !== FUSION_BOARD_SOURCE) return null
+  const runId = asString(post.origin.fusion_run_id)
+  return runId ? { meta, runId } : null
 }
 
 function fusionRunFromPost(post: BoardPost): FusionRunView | null {
-  const meta = fusionMeta(post)
-  if (!meta) return null
+  const evidence = fusionEvidence(post)
+  if (!evidence) return null
+  const { meta, runId } = evidence
 
   const panel = normalizeFusionPanel(meta.panel)
   const judge = normalizeJudge(meta.judge)
   const judges = normalizeFusionJudgeNodes(meta.judges)
   const usage = normalizeUsage(meta, panel)
   const params = normalizeParams(meta)
-  const runId = firstString(meta, ['run_id', 'runId', 'id']) ?? post.id
   const question = firstString(meta, ['question', 'prompt']) ?? post.body ?? post.content ?? post.title
   const status = statusFor(judge, panel)
   const tone = toneFor(status, judge.decision)
@@ -361,8 +359,6 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
   return {
     runId,
     boardPostId: post.id,
-    boardOriginSource: post.origin?.source ?? null,
-    boardOriginRunId: post.origin?.fusion_run_id ?? null,
     keeperName: keeperNameFor(post),
     title: post.title || `Fusion run ${runId}`,
     question,
@@ -997,50 +993,6 @@ function hasParams(params: FusionRunParams): boolean {
     || params.maxTokens !== null
 }
 
-type FusionSinkLinkageStatus = 'verified' | 'missing' | 'mismatch'
-
-interface FusionSinkLinkage {
-  status: FusionSinkLinkageStatus
-  label: string
-  detail: string
-}
-
-function sinkLinkageFor(run: FusionRunView): FusionSinkLinkage {
-  if (run.boardOriginSource !== FUSION_BOARD_SOURCE || !run.boardOriginRunId) {
-    return {
-      status: 'missing',
-      label: 'origin unverified',
-      detail: 'typed board origin is absent; using meta.run_id only',
-    }
-  }
-  if (run.boardOriginRunId !== run.runId) {
-    return {
-      status: 'mismatch',
-      label: 'origin mismatch',
-      detail: `origin.fusion_run_id=${run.boardOriginRunId}`,
-    }
-  }
-  return {
-    status: 'verified',
-    label: 'origin verified',
-    detail: 'origin.source=fusion and origin.fusion_run_id match meta.run_id',
-  }
-}
-
-function FusionSinkLinkageBadge({ linkage }: { linkage: FusionSinkLinkage }) {
-  return html`
-    <span
-      class=${`fus-sink-linkage ${linkage.status}`}
-      data-testid="fusion-sink-linkage"
-      data-linkage-status=${linkage.status}
-      title=${linkage.detail}
-    >
-      <span class="fus-sink-linkage-k">${linkage.label}</span>
-      <span class="fus-sink-linkage-v">${linkage.detail}</span>
-    </span>
-  `
-}
-
 // Presentation-only thresholds for clamping a long resolved_answer. These are a
 // display heuristic, not a semantic model of the rendered markdown — RichContent
 // owns markdown parsing, so this deliberately avoids counting markdown blocks and
@@ -1085,8 +1037,6 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
   const tokenLabel = combinedTokenLabel(run.usage)
   const preset = run.preset ?? findPreset(run.runId)
   const shape = fusionShapeInfo(run.judges)
-  const sinkLinkage = sinkLinkageFor(run)
-
   return html`
     <div class="fus-run-scroll" data-testid="fusion-detail">
       <div class="fus-run-head">
@@ -1243,8 +1193,16 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
                         class=${`fus-sink-to ${ringFocusClasses()}`}
                         onClick=${() => navigate('board', { post: run.boardPostId })}
                       >보드 포스트 #${run.boardPostId} →</button>
-                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · typed origin으로 run linkage 검증</span>
-                      <${FusionSinkLinkageBadge} linkage=${sinkLinkage} />
+                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · typed origin이 run identity를 소유</span>
+                      <span
+                        class="fus-sink-linkage verified"
+                        data-testid="fusion-sink-linkage"
+                        data-linkage-status="verified"
+                        title="origin.source=fusion and origin.fusion_run_id are the run identity"
+                      >
+                        <span class="fus-sink-linkage-k">typed origin</span>
+                        <span class="fus-sink-linkage-v">origin.fusion_run_id=${run.runId}</span>
+                      </span>
                     </div>
                   </div>
                   <div class="fus-sink-track">
@@ -1258,13 +1216,10 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
                 <div
                   class="fus-corr"
                   data-testid="fusion-sink-correlation"
-                  data-meta-run-id=${run.runId}
-                  data-origin-source=${run.boardOriginSource ?? ''}
-                  data-origin-run-id=${run.boardOriginRunId ?? ''}
+                  data-origin-source=${FUSION_BOARD_SOURCE}
+                  data-origin-run-id=${run.runId}
                 >
-                  correlation · meta <span class="mono">${run.runId}</span>
-                  <span class="fus-corr-sep">/</span>
-                  origin <span class="mono">${run.boardOriginRunId ?? 'unverified'}</span>
+                  correlation · origin <span class="mono">${run.runId}</span>
                 </div>
               </div>
             </div>
@@ -1304,7 +1259,7 @@ function FusionRegistryDetail({ record }: { record: FusionRunRecord }) {
         </div>
         <div class="fus-judge-wait">
           ${record.status === 'running'
-            ? html`<span class="fus-rdot run"></span>심의 진행 중 — 패널·심판 상세는 fusion sink가 <code>meta.source = "fusion"</code> 보드 포스트를 기록한 뒤 이 자리에 나타납니다.`
+            ? html`<span class="fus-rdot run"></span>심의 진행 중 — 패널·심판 상세는 fusion sink가 typed Fusion origin을 가진 보드 포스트를 기록한 뒤 이 자리에 나타납니다.`
             : record.status === 'failed'
               ? html`실패로 종료됨.${record.failureCode ? html` <span class="mono">${record.failureCode}</span>` : null}${record.error ? html` · ${record.error}` : null}`
               : '완료됨 — 보드 sink 기록을 기다리는 중입니다.'}
@@ -1436,7 +1391,7 @@ export function FusionSurface() {
                     ${boardError
                       ? html`보드 sink read path(<code>${'/api/v1/dashboard/board?sort_by=recent&limit=500'}</code>)가 실패했습니다. registry 관측(<code>/api/v1/dashboard/fusion-runs</code>)은 독립 소스이며, 캐시된 보드 sink 행만 상세 리뷰에 표시됩니다.`
                       : html`레지스트리 관측(<code>/api/v1/dashboard/fusion-runs</code>)은 상단 KPI에 집계되고, 진행 중 런은 왼쪽 목록에 표시됩니다.
-                        상세한 패널·심판 리뷰는 fusion sink가 <code>meta.source = "fusion"</code> 보드 포스트를 기록한 뒤 나타납니다.`}
+                        상세한 패널·심판 리뷰는 fusion sink가 typed Fusion origin을 가진 보드 포스트를 기록한 뒤 나타납니다.`}
                   </p>
                 </div>
               </div>

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -181,18 +181,17 @@ describe('normalizeFusionUsage', () => {
 
 describe('extractFusionEvidence', () => {
   it('returns null for non-record meta', () => {
-    expect(extractFusionEvidence(null)).toBeNull()
-    expect(extractFusionEvidence('fusion')).toBeNull()
+    const origin = { source: 'fusion', fusion_run_id: 'fus-1' }
+    expect(extractFusionEvidence(null, origin)).toBeNull()
+    expect(extractFusionEvidence('fusion', origin)).toBeNull()
   })
 
-  it('extracts evidence from explicit source tag', () => {
+  it('extracts evidence using typed Board origin as the run identity', () => {
     const evidence = extractFusionEvidence({
-      source: 'fusion',
-      run_id: 'fus-1',
       question: 'q?',
       panel: [{ model: 'gpt-5', status: 'answered' }],
       judge: { status: 'synthesized' },
-    })
+    }, { source: 'fusion', fusion_run_id: 'fus-1' })
     expect(evidence).toMatchObject({
       source: 'fusion',
       runId: 'fus-1',
@@ -202,31 +201,35 @@ describe('extractFusionEvidence', () => {
     })
   })
 
-  it('unwraps nested fusion_deliberation', () => {
-    const evidence = extractFusionEvidence({
+  it('rejects evidence without the current typed Fusion origin', () => {
+    const meta = {
+      question: 'q?',
+      panel: [{ model: 'gpt-5', status: 'answered' }],
+      judge: { status: 'synthesized' },
+    }
+    expect(extractFusionEvidence(meta, null)).toBeNull()
+    expect(extractFusionEvidence(meta, { source: 'other', fusion_run_id: 'fus-1' }))
+      .toBeNull()
+    expect(extractFusionEvidence(meta, { source: 'fusion' })).toBeNull()
+  })
+
+  it('does not repair nested or identity-bearing metadata', () => {
+    expect(extractFusionEvidence({
       fusion_deliberation: {
-        run_id: 'fus-legacy',
         panel: [{ model: 'gpt-5', status: 'answered' }],
         judge: { status: 'synthesized' },
       },
-    })
-    expect(evidence?.runId).toBe('fus-legacy')
-    expect(evidence?.panel).toHaveLength(1)
-  })
-
-  it('falls back to panel + judge heuristic when source is missing', () => {
-    const evidence = extractFusionEvidence({
+    }, null)).toBeNull()
+    expect(extractFusionEvidence({
+      source: 'fusion',
+      run_id: 'meta-only',
       panel: [{ model: 'gpt-5', status: 'answered' }],
       judge: { status: 'synthesized' },
-    })
-    expect(evidence).not.toBeNull()
-    expect(evidence?.source).toBe('fusion')
+    }, null)).toBeNull()
   })
 
   it('carries the RFC-0284 judges observation array (judge-of-judges)', () => {
     const evidence = extractFusionEvidence({
-      source: 'fusion',
-      run_id: 'fus-joj',
       panel: [{ model: 'gpt-5', status: 'answered' }],
       judge: { status: 'synthesized' },
       judges: [
@@ -234,7 +237,7 @@ describe('extractFusionEvidence', () => {
         { role: 'first', identity: 'claude', status: 'failed', error: 'timeout' },
         { role: 'meta', identity: 'meta' },
       ],
-    })
+    }, { source: 'fusion', fusion_run_id: 'fus-joj' })
     expect(evidence?.judges).toHaveLength(3)
     expect(evidence?.judges[0]).toMatchObject({ role: 'first', identity: 'gpt-5', failed: false })
     // toMatchObject ignores extra keys, so pin that a success node carries no error
@@ -243,12 +246,11 @@ describe('extractFusionEvidence', () => {
     expect(evidence?.judges[2]?.role).toBe('meta')
   })
 
-  it('defaults judges to [] when the meta predates the array', () => {
+  it('defaults judges to [] when the current metadata omits the array', () => {
     const evidence = extractFusionEvidence({
-      source: 'fusion',
       panel: [{ model: 'gpt-5', status: 'answered' }],
       judge: { status: 'synthesized' },
-    })
+    }, { source: 'fusion', fusion_run_id: 'fus-simple' })
     expect(evidence?.judges).toEqual([])
   })
 })

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -1,10 +1,10 @@
-// Fusion sink compatibility helpers shared by Board evidence, the standalone
-// Fusion surface, and keeper chat cards. All consumers parse the same
-// `meta.source === 'fusion'` payload emitted by `fusion_sink.ml`; this module
-// is the single source of truth for that normalization.
+// Fusion sink helpers shared by Board evidence, the standalone Fusion surface,
+// and keeper chat cards. Run identity comes only from the typed Board origin;
+// meta carries deliberation evidence, not a second identity.
 
 import { isRecord } from './type-guards'
 import { asRecord, asString, asBoolean } from './json-coerce'
+import type { BoardPostOrigin } from '../types'
 
 function decodeOcamlStringLiteral(value: string): string {
   return value
@@ -113,7 +113,7 @@ export type FusionUsage = {
 
 export type FusionEvidence = {
   source: 'fusion'
-  runId?: string | null
+  runId: string
   question?: string | null
   panel: FusionPanelEntry[]
   judge: FusionJudgeView | null
@@ -278,31 +278,25 @@ export function normalizeFusionUsage(
   }
 }
 
-export function extractFusionEvidence(meta: unknown): FusionEvidence | null {
+export function extractFusionEvidence(
+  meta: unknown,
+  origin: BoardPostOrigin | null | undefined,
+): FusionEvidence | null {
   if (!isRecord(meta)) return null
+  if (origin?.source !== 'fusion') return null
+  const runId = asString(origin.fusion_run_id)
+  if (!runId) return null
 
-  const nested = asRecord(meta.fusion_deliberation)
-  const effective: Record<string, unknown> = nested ? { ...nested, source: 'fusion' } : meta
-
-  const panel = normalizeFusionPanel(effective.panel)
-  const judge = normalizeFusionJudge(effective.judge)
-  const runId = firstString(effective, ['run_id', 'runId', 'id'])
-
-  // Explicit source tag is canonical. As a defensive fallback, treat any meta
-  // carrying panel + (judge | run_id) as fusion evidence so older payloads or
-  // schema drift still render.
-  const isFusion =
-    asString(effective.source) === 'fusion'
-    || (panel.length > 0 && (judge !== null || Boolean(runId)))
-  if (!isFusion) return null
+  const panel = normalizeFusionPanel(meta.panel)
+  const judge = normalizeFusionJudge(meta.judge)
 
   return {
     source: 'fusion',
     runId,
-    question: firstString(effective, ['question', 'prompt']),
+    question: firstString(meta, ['question', 'prompt']),
     panel,
     judge,
-    judges: normalizeFusionJudgeNodes(effective.judges),
-    usage: normalizeFusionUsage(effective, panel),
+    judges: normalizeFusionJudgeNodes(meta.judges),
+    usage: normalizeFusionUsage(meta, panel),
   }
 }

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -423,9 +423,7 @@ let emit ~base_dir ~keeper ~run_id ~channel ~question ~panel ~judge ~judges ~jud
     let meta_json =
       Some
         (`Assoc
-           [ ("source", `String "fusion")
-           ; ("run_id", `String run_id)
-           ; ("question", `String question)
+           [ ("question", `String question)
            ; ("panel", `List (List.map panel_meta panel))
            ; ("judge", judge_meta judge)
              (* RFC-0284: 실행된 심판 노드 관측 배열 (panel과 동형). 기존 단일 [judge]
@@ -441,14 +439,10 @@ let emit ~base_dir ~keeper ~run_id ~channel ~question ~panel ~judge ~judges ~jud
     in
     (* board post를 *먼저* 만들어 post id를 확보한다 — 이 id가 키퍼 chat의 fusion block
        lazy-fetch 키이기 때문이다(대시보드가 board meta_json에서 패널/심판을 펼친다). *)
-    (* RFC-0233 §7: typed origin. [fusion_run_id] is in scope here ([run_id]),
-       so a real index ([posts_by_run_id]) can key on it instead of the legacy
-       meta_json substring. [turn_ref = None]: fusion is an out-of-band
+    (* RFC-0233 §7: typed origin. [fusion_run_id] is the sole run identity and
+       indexes [posts_by_run_id]. [turn_ref = None]: fusion is an out-of-band
        server-root-switch fork, so the triggering keeper's turn_ref is not in
-       this scope; threading it through [fusion_request] is a separate change.
-       The legacy meta_json [run_id] (above) is kept ADDITIVELY this release —
-       existing dashboard / on-disk readers depend on it; its removal is a
-       later migration, not this PR. *)
+       this scope; threading it through [fusion_request] is a separate change. *)
     let origin : Board.post_origin =
       { turn_ref = None; source = Some "fusion"; fusion_run_id = Some run_id }
     in

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -43,8 +43,9 @@ val judge_node_meta : Fusion_types.judge_outcome -> Yojson.Safe.t
     stimulus는 Running 키퍼에게만 배달되는 일회성 채널이라, chat lane이 비어 있으면
     비-Running 키퍼는 실패 사유에 도달할 tool-reachable 표면이 없다(2026-07-01 사고 —
     bare "judge failed"만 보고 keeper들이 원인을 추측·폴링). board headline도 같은
-    실패 요약을 나른다. board: [Board_dispatch.create_post]로 meta_json(source/run_id/question/panel
-    답변 전체/judge 종합/observed_usage = panel N + judge 1 합산) 증거를 남긴다. [judge_usage]는
+    실패 요약을 나른다. board: [Board_dispatch.create_post]로 typed
+    [origin.source]/[origin.fusion_run_id]와 meta_json(question/panel 답변
+    전체/judge 종합/observed_usage = panel N + judge 1 합산) 증거를 남긴다. [judge_usage]는
     심판이 소비한 토큰(orchestrator가 [Fusion_judge.run]에서 분리해 주입). [judges]는 실제로
     실행된 심판 노드 관측 배열(RFC-0284)로 board meta_json [judges] 키에 panel과 동형으로
     직렬화된다 — canonical 단일 [judge] 키는 ADDITIVE 유지. [base_dir]는 호출자 주입.

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -540,8 +540,8 @@ let test_emit_success_projects_board_chat_and_registry () =
       | Some json -> assoc_fields "board.meta" json
       | None -> fail "fusion board post should carry meta_json"
     in
-    check string "meta.source" "fusion" (string_field "board.meta" meta "source");
-    check string "meta.run_id" run_id (string_field "board.meta" meta "run_id");
+    check bool "meta.source is not duplicated" false (List.mem_assoc "source" meta);
+    check bool "meta.run_id is not duplicated" false (List.mem_assoc "run_id" meta);
     check string "meta.question" question (string_field "board.meta" meta "question");
     (match list_field "board.meta" meta "panel" with
      | [ panel_json ] ->
@@ -586,8 +586,10 @@ let test_emit_success_projects_board_chat_and_registry () =
     let dashboard_meta =
       assoc_fields "dashboard.post.meta" (field "dashboard.post" dashboard_json "meta")
     in
-    check string "dashboard meta run id" run_id
-      (string_field "dashboard.post.meta" dashboard_meta "run_id");
+    check bool "dashboard meta has no duplicate source" false
+      (List.mem_assoc "source" dashboard_meta);
+    check bool "dashboard meta has no duplicate run id" false
+      (List.mem_assoc "run_id" dashboard_meta);
     let messages = Keeper_chat_store.load ~base_dir ~keeper_name:keeper in
     let fusion_block =
       List.find_map


### PR DESCRIPTION
## Scope

- remove duplicate `source` and `run_id` from Fusion Board `meta_json`
- make typed `Board.post_origin` (`source = fusion`, `fusion_run_id`) the sole run identity
- make the standalone Fusion surface and Board evidence require that current origin
- remove nested/heuristic metadata identity repair and the meta-vs-origin comparison Gate

This is a hard cut. It adds no migration reader, compatibility field, inferred id, or facade.

## Feature trace

- producer: `Fusion_sink.emit`
- durable boundary: `Board_dispatch.create_post_once_by_fusion_run_id`
- authority/index: `origin.fusion_run_id` -> `posts_by_run_id`
- wire: `Board_core_json.post_origin_to_yojson`
- consumers: dashboard Board parser -> Fusion surface / `FusionBoardEvidence`

The Board create path already validates that the argument and typed origin carry the same non-empty Fusion run id before persistence. Dashboard consumers now admit a Fusion card only when the parsed Board origin is present, and use that exact id for list dedupe, route selection, linkage display, and evidence chips.

## Blast radius

- current Fusion posts keep the same feature behavior and visible run id
- `meta_json` is now evidence-only (`question`, panel, judge nodes, observed usage)
- posts without a current typed Fusion origin are not rendered as Fusion evidence
- the generic Board wire and non-Fusion posts are unchanged

## Verification

- dashboard `tsc --noEmit`
- 88/88 focused Vitest cases passed:
  - `fusion-meta.test.ts`
  - `fusion-evidence.test.ts`
  - `fusion-surface.test.ts`
- `ocamlformat -i` on changed OCaml files
- `git diff --check`
- focused `test/test_fusion_wake.exe` build/run pending on the shared repo Dune lock
