### PR TITLE
fix(runtime): carry provider config on resume

### DIFF
--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -356,6 +356,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
   let options : Agent_sdk.Agent.options =
     { Agent_sdk.Agent.default_options with
       hooks = Option.value ~default:Agent_sdk.Hooks.empty config.hooks
+    ; provider_config = Some config.provider_cfg
     ; stream_idle_timeout_s = config.stream_idle_timeout_s
     ; body_timeout_s = config.body_timeout_s
     ; context_injector = config.context_injector


### PR DESCRIPTION
## Summary
- carry the exact `config.provider_cfg` in resume `Agent.options`
- keep fresh and resumed construction on the same OAS provider-carrier contract
- preserve the single OAS route-time missing-carrier rejection; add no MASC gate or fallback

## Why
MASC #26292 removed OAS's separate `Agent.resume ~provider_config` argument because provider identity now has one carrier: `Agent.options.provider_config`. Fresh construction already populated that carrier through `Builder.with_provider_config`, but `Runtime_agent_context.prepare_resume` still started from `Agent.default_options` without setting it. Resumed agents therefore failed before native context measurement or dispatch.

This patch closes that wiring gap at the resume options construction point. It does not restore the removed argument, add a facade, compare model strings, or introduce migration/legacy behavior.

## Validation
- `ocamlformat --check lib/runtime/runtime_agent_context.ml`
- `ocamlc -stop-after parsing lib/runtime/runtime_agent_context.ml`
- `git diff --check`
- existing CI cases `runtime resume enforces native context fit` and `resumed projection precedes measurement` reproduce the missing carrier on main
- focused local Dune run was not started because `/tmp/me-dune-local.lock` is held by another MASC worktree; PR CI is the build/test authority
