### PR TITLE
chore(oas): pin merged provider cleanup

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.1`, runtime pin: `main@701ea39e5c87e7df52724795c449d89b9a815c55`, declared base version: `v0.231.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.1`, runtime pin: `main@c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835`, declared base version: `v0.231.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -219,7 +219,7 @@ dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
   "agent_sdk.0.231.1"
-  "git+https://github.com/jeong-sik/oas.git#701ea39e5c87e7df52724795c449d89b9a815c55"
+  "git+https://github.com/jeong-sik/oas.git#c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -20,16 +20,19 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.1"
 # The pinned post-v0.231.1 head carries the #2873 provider hard-cut:
 # Agent.options.provider_config is the single exact carrier, including resume;
 # the legacy Provider.config island and separate resume argument are removed.
+# The #2877 follow-up derives the effective turn provider config once, threads
+# that exact value through dispatch and pricing, and removes duplicate Provider
+# auth/pricing facades. MASC consumes the canonical public modules directly.
 # Previous pin: v0.231.0 (2cb7d922); before that v0.230.0 (7a3f2af7).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
 # main; oas-drift-check.sh also reports the public-surface delta at pin-bump
 # time.
-# Pinned to the merged #2873 commit.
+# Pinned to the merged #2877 commit.
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.1"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="701ea39e5c87e7df52724795c449d89b9a815c55"
+readonly OAS_AGENT_SDK_SHA="c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.231.1"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,5 +1,5 @@
 {
-  "pinned_sha": "701ea39e5c87e7df52724795c449d89b9a815c55",
+  "pinned_sha": "c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835",
   "pinned_version": "v0.231.1",
   "surfaces": {
     "event_bus_payload_variants": [


### PR DESCRIPTION
## Summary
- pin OAS to merged #2877 commit `c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835`
- regenerate pin manifests/docs and API fingerprint metadata
- consume the one-effective-config path and canonical provider modules without MASC compatibility code

## Contract review
- #2877 derives the effective turn `Provider_config.t` once and passes the exact dispatched value to collection/pricing
- duplicate `Provider` auth/pricing facades are removed upstream
- MASC has no caller of the removed facade symbols
- tracked OAS public fingerprint sections are unchanged; only `pinned_sha` changes
- MASC #26301's resume carrier fix is already present in this branch base

## Validation
- `bash scripts/sync-oas-pin-manifests.sh --check --surface`
- `bash scripts/oas-drift-check.sh` (surface match after reviewed regeneration)
- removed facade caller sweep under `lib/`, `test/`, and `bin/`: zero hits
- `git diff --check`
- shared local opam remains pinned to #2873 while other sessions build; CI owns isolated compile/test verification for the new SHA
