### PR TITLE
refactor(recall): require current delta ledger wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
   `origin.fusion_run_id` are now the sole typed identity consumed by the Board
   evidence and Fusion dashboard features; posts without that current origin
   are not admitted to those surfaces.
+- **Breaking (recall injection ledger wire)**: removed the retired
+  `schema_version=1`/missing-version full-snapshot decoder, its public
+  serializer, the unused option compatibility decoder, and the unused
+  read-error labeling facade. Recall injection rows now require exact
+  `schema_version=2` Delta fields. The current writer,
+  full-history outcome-evaluation replay, invalid-row accounting, and
+  retention behavior are unchanged; no migration or repair path was added.
 - **Breaking (keeper failure wire)**: removed the bare
   `fiber_unresolved` failure-reason projection retained for historical log and
   dashboard matching. Unexpected unresolved fibers now serialize as

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -15,8 +15,6 @@ let field_schema_version = "schema_version"
 let field_keeper_id = "keeper_id"
 let field_trace_id = "trace_id"
 let field_turn = "turn"
-let field_injected_fact_keys = "injected_fact_keys"
-let field_injected_episode_keys = "injected_episode_keys"
 let field_added_fact_keys = "added_fact_keys"
 let field_removed_fact_keys = "removed_fact_keys"
 let field_added_episode_keys = "added_episode_keys"
@@ -30,22 +28,15 @@ let failure_reason_read_error = "read_error"
 let failure_reason_prompt_render_error = "prompt_render_error"
 let failure_reason_unknown_label = "unknown_failure_reason"
 
-(* Legacy rows (schema_version absent) are v1. v2 is the first delta schema. *)
-let schema_version_legacy = 1
 let schema_version_delta = 2
 
-type payload =
-  | Full_snapshot of
-      { fact_keys : string list
-      ; episode_keys : string list
-      }
-  | Delta of
-      { added_fact_keys : string list
-      ; removed_fact_keys : string list
-      ; added_episode_keys : string list
-      ; removed_episode_keys : string list
-      ; content_hash : string
-      }
+type delta =
+  { added_fact_keys : string list
+  ; removed_fact_keys : string list
+  ; added_episode_keys : string list
+  ; removed_episode_keys : string list
+  ; content_hash : string
+  }
 
 type record =
   { keeper_id : string
@@ -55,7 +46,7 @@ type record =
   ; failure_reason : string option
   ; n_facts_in_store : int option
   ; n_episodes_in_store : int option
-  ; payload : payload
+  ; delta : delta
   }
 
 type decode_error =
@@ -114,17 +105,10 @@ let json_optional_string_field fields key =
   | None -> Ok None
 ;;
 
-let payload_of_fields fields =
-  match json_optional_int_field fields field_schema_version with
+let delta_of_fields fields =
+  match json_required_int_field fields field_schema_version with
   | Error _ as e -> e
-  | Ok (None | Some 1) ->
-    (match
-       ( json_required_string_list_field fields field_injected_fact_keys
-       , json_required_string_list_field fields field_injected_episode_keys )
-     with
-     | Ok fact_keys, Ok episode_keys -> Ok (Full_snapshot { fact_keys; episode_keys })
-     | Error err, _ | _, Error err -> Error err)
-  | Ok (Some 2) ->
+  | Ok 2 ->
     (match
        ( json_required_string_list_field fields field_added_fact_keys
        , json_required_string_list_field fields field_removed_fact_keys
@@ -138,16 +122,15 @@ let payload_of_fields fields =
        , Ok removed_episode_keys
        , Ok content_hash ) ->
        Ok
-         (Delta
-            { added_fact_keys; removed_fact_keys; added_episode_keys
-            ; removed_episode_keys; content_hash
-            })
+         { added_fact_keys; removed_fact_keys; added_episode_keys
+         ; removed_episode_keys; content_hash
+         }
      | Error err, _, _, _, _
      | _, Error err, _, _, _
      | _, _, Error err, _, _
      | _, _, _, Error err, _
      | _, _, _, _, Error err -> Error err)
-  | Ok (Some other) -> Error (`Unsupported_schema_version other)
+  | Ok other -> Error (`Unsupported_schema_version other)
 ;;
 
 let record_of_json_result = function
@@ -164,14 +147,14 @@ let record_of_json_result = function
           , json_optional_string_field fields field_failure_reason
           , json_optional_int_field fields field_n_facts_in_store
           , json_optional_int_field fields field_n_episodes_in_store
-          , payload_of_fields fields )
+          , delta_of_fields fields )
         with
         | Error err, _, _, _, _
         | _, Error err, _, _, _
         | _, _, Error err, _, _
         | _, _, _, Error err, _
         | _, _, _, _, Error err -> Error err
-        | Ok ts, Ok failure_reason, Ok n_facts_in_store, Ok n_episodes_in_store, Ok payload ->
+        | Ok ts, Ok failure_reason, Ok n_facts_in_store, Ok n_episodes_in_store, Ok delta ->
           Ok
             { keeper_id
             ; trace_id
@@ -180,15 +163,9 @@ let record_of_json_result = function
             ; failure_reason
             ; n_facts_in_store
             ; n_episodes_in_store
-            ; payload
+            ; delta
             }))
   | _ -> Error `Expected_object
-;;
-
-let record_of_json json =
-  match record_of_json_result json with
-  | Ok record -> Some record
-  | Error _ -> None
 ;;
 
 let bounded_failure_reason_label = function
@@ -214,7 +191,7 @@ let apply_delta ~previous ~added ~removed =
 ;;
 
 (* Not a security digest: a cheap, order/duplicate-independent change-detection
-   and self-consistency signal (tests check that replaying a [Delta] row's
+   and self-consistency signal (tests check that replaying a delta row's
    materialized set hashes back to the row's own [content_hash]). *)
 let content_hash_of ~fact_keys ~episode_keys =
   let canon keys = keys |> SS.of_list |> SS.elements |> String.concat "\x1f" in
@@ -239,61 +216,24 @@ let materialize records =
            (Hashtbl.find_opt state record.keeper_id)
            ~default:(SS.empty, SS.empty)
        in
+       let
+         { added_fact_keys
+         ; removed_fact_keys
+         ; added_episode_keys
+         ; removed_episode_keys
+         ; content_hash = _
+         }
+         = record.delta
+       in
        let facts, episodes =
-         match record.payload with
-         | Full_snapshot { fact_keys; episode_keys } ->
-           SS.of_list fact_keys, SS.of_list episode_keys
-         | Delta
-             { added_fact_keys
-             ; removed_fact_keys
-             ; added_episode_keys
-             ; removed_episode_keys
-             ; content_hash = _
-             } ->
-           ( SS.diff (SS.union prev_facts (SS.of_list added_fact_keys)) (SS.of_list removed_fact_keys)
-           , SS.diff
-               (SS.union prev_episodes (SS.of_list added_episode_keys))
-               (SS.of_list removed_episode_keys) )
+         ( SS.diff (SS.union prev_facts (SS.of_list added_fact_keys)) (SS.of_list removed_fact_keys)
+         , SS.diff
+             (SS.union prev_episodes (SS.of_list added_episode_keys))
+             (SS.of_list removed_episode_keys) )
        in
        Hashtbl.replace state record.keeper_id (facts, episodes);
        { record; fact_keys = SS.elements facts; episode_keys = SS.elements episodes })
     records
-;;
-
-(* ── Serialisers ──────────────────────────────────────────────────────── *)
-
-(* Legacy (v1, [Full_snapshot]) serialiser. Pure. Kept for round-trip tests
-   and fixtures; [append] below writes v2 [Delta] rows exclusively. *)
-let to_json
-      ?failure_reason
-      ~keeper_id
-      ~trace_id
-      ~turn
-      ~injected_fact_keys
-      ~injected_episode_keys
-      ~n_facts_in_store
-      ~now
-      ()
-  : Yojson.Safe.t
-  =
-  let fields =
-    [ field_schema_version, `Int schema_version_legacy
-    ; field_keeper_id, `String keeper_id
-    ; field_trace_id, `String trace_id
-    ; field_turn, `Int turn
-    ; field_injected_fact_keys, `List (List.map (fun k -> `String k) injected_fact_keys)
-    ; ( field_injected_episode_keys
-      , `List (List.map (fun k -> `String k) injected_episode_keys) )
-    ; field_n_facts_in_store, `Int n_facts_in_store
-    ; field_ts, `Float now
-    ]
-  in
-  let fields =
-    match failure_reason with
-    | None -> fields
-    | Some reason -> fields @ [ field_failure_reason, `String reason ]
-  in
-  `Assoc fields
 ;;
 
 let to_json_delta
@@ -380,12 +320,6 @@ module Delta_state = struct
 
   let reset_for_testing () = Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset table)
 end
-
-let error_label_of_exn exn =
-  exn
-  |> Keeper_memory_recall_exn_class.classify
-  |> Keeper_memory_recall_exn_class.to_label
-;;
 
 let append
       ?failure_reason

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -17,29 +17,19 @@
     2026-07-17 board_attention_candidate boot-hang incident.
 
     v2 rows instead carry only the fact/episode keys that changed since the
-    keeper's immediately preceding row ({!payload} = [Delta]), plus a
+    keeper's immediately preceding row ({!delta}), plus a
     [content_hash] of the full injected set so a reader can detect "did the
     injected set change" without materializing it, and plus store-size
     counters ([n_facts_in_store] / [n_episodes_in_store]) that were already
     (or are now) O(1) scalars — unrelated to the growth bug and kept as-is.
 
-    Legacy rows (schema_version absent, written before this change) still
-    decode as {!payload} = [Full_snapshot]: the full list they always carried
-    IS the exact injected set at that turn, so no replay is needed for them.
-    {!materialize} treats a [Full_snapshot] row as resetting a keeper's running
-    state to exactly that row's lists, and a [Delta] row as applying
-    added/removed to the running state — so mixed legacy/v2 history for the
-    same keeper replays correctly, and a fresh process's first v2 row for a
-    keeper (diffed against an empty prior state) is automatically a full
-    accounting even though it is tagged [Delta].
+    Current rows require exact [schema_version = 2] and carry a [delta].
+    {!materialize} applies each row to the keeper's running state. A fresh
+    process's first row for a keeper is diffed against the empty set, so it is
+    automatically a full accounting while retaining one current wire shape.
 
-    Two real (non-telemetry) readers exist and are adapted by this change:
-    {!Keeper_recall_outcome_eval} (offline, full-history scan — replay is
-    always exact) and the dashboard memory-quality summary in
-    [Server_dashboard_http_memory_subsystems] (bounded recent-lines sample —
-    replay is exact for any keeper whose sampled window include its own
-    genesis row, which the schema change makes far more likely since v2 rows
-    are only written on an actual change).
+    The read-only consumer is {!Keeper_recall_outcome_eval}, whose full-history
+    scan makes replay exact for the current store.
 
     Properties:
     - Append-only, never read on the hot path -> cannot change recall behaviour.
@@ -59,21 +49,13 @@
 val base_dir : masc_root:string -> string
 (** Directory that stores recall injection JSONL day files. *)
 
-type payload =
-  | Full_snapshot of
-      { fact_keys : string list
-      ; episode_keys : string list
-      }
-  (** The complete injected key sets at this turn. Written by legacy
-      (schema_version absent) rows, and by {!to_json} (kept for round-trip
-      tests and fixtures that need a self-contained row). *)
-  | Delta of
-      { added_fact_keys : string list
-      ; removed_fact_keys : string list
-      ; added_episode_keys : string list
-      ; removed_episode_keys : string list
-      ; content_hash : string
-      }
+type delta =
+  { added_fact_keys : string list
+  ; removed_fact_keys : string list
+  ; added_episode_keys : string list
+  ; removed_episode_keys : string list
+  ; content_hash : string
+  }
   (** Only the fact/episode keys that changed relative to the keeper's
       previous row. [content_hash] is {!content_hash_of} over the full
       injected set at this turn, so a reconstructed set can be checked for
@@ -87,11 +69,11 @@ type record =
   ; failure_reason : string option
   ; n_facts_in_store : int option
   ; n_episodes_in_store : int option
-  ; payload : payload
+  ; delta : delta
   }
-(** Typed subset of the append schema consumed by read-only dashboard/eval
-    surfaces. Field ownership stays here so consumers do not duplicate ledger
-    JSON field names. *)
+(** Typed subset of the append schema consumed by the read-only outcome
+    evaluator. Field ownership stays here so the consumer does not duplicate
+    ledger JSON field names. *)
 
 type decode_error =
   [ `Expected_object
@@ -103,9 +85,6 @@ type decode_error =
     drift instead of silently dropping malformed rows. *)
 
 val record_of_json_result : Yojson.Safe.t -> (record, decode_error) result
-val record_of_json : Yojson.Safe.t -> record option
-(** Compatibility wrapper over {!record_of_json_result}. New read paths that need
-    observability should use the result-returning decoder. *)
 
 val failure_reason_unknown_label : string
 val bounded_failure_reason_label : string -> string
@@ -134,37 +113,18 @@ type materialized =
   ; episode_keys : string list
   }
 (** [record] paired with the full fact/episode key set actually in effect at
-    that row, after replaying {!payload} against the keeper's prior rows. *)
+    that row, after replaying {!delta} against the keeper's prior rows. *)
 
 val materialize : record list -> materialized list
 (** Reconstruct the full injected key set at each record by replaying
-    [payload] per [keeper_id]. Precondition: [records] is already in
-    chronological (oldest-first) order — both {!Keeper_recall_outcome_eval}'s
-    full-tree scan and {!Dated_jsonl.read_recent_lines} already provide this,
-    so no re-sort happens here (a re-sort by [ts] would be *unsound*: [ts] is
-    optional and legacy rows may omit it; true chronology is append order,
-    which the callers already preserve). A [Full_snapshot] row resets the
-    keeper's running state to exactly its own lists; a [Delta] row applies
-    added/removed to the running state (starting from the empty set for a
-    keeper's first appearance in [records], which is exact when [records]
-    covers that keeper's full history, and a documented under-approximation —
-    never an over-approximation — otherwise). Cross-keeper relative order in
-    the output is unspecified; per-keeper relative order matches the input. *)
-
-val to_json
-  :  ?failure_reason:string
-  -> keeper_id:string
-  -> trace_id:string
-  -> turn:int
-  -> injected_fact_keys:string list
-  -> injected_episode_keys:string list
-  -> n_facts_in_store:int
-  -> now:float
-  -> unit
-  -> Yojson.Safe.t
-(** Legacy (schema v1, [Full_snapshot]) pure record serialiser. Exposed for
-    round-trip tests and fixtures that need a self-contained row independent of
-    any keeper's prior state. Not used by {!append} since schema v2. *)
+    [delta] per [keeper_id]. Precondition: [records] is already in
+    chronological (oldest-first) order — {!Keeper_recall_outcome_eval}'s
+    full-tree scan already provides this, so no re-sort happens here (a
+    re-sort by [ts] would be *unsound*: true
+    chronology is append order, which the caller already preserves). Each
+    delta applies added/removed keys to the keeper's state, starting from the
+    empty set for its first appearance. Cross-keeper relative order in the
+    output is unspecified; per-keeper relative order matches the input. *)
 
 val append
   :  ?failure_reason:string
@@ -181,7 +141,7 @@ val append
 (** Append one injection record. Computes the delta against [keeper_id]'s
     previous [injected_fact_keys]/[injected_episode_keys] (in-memory,
     process-local, scoped by [(masc_root, keeper_id)]) and writes a v2
-    [Delta] row: this is the fix for the O(store_size) per-turn growth
+    delta row: this is the fix for the O(store_size) per-turn growth
     ([injected_fact_keys]/[injected_episode_keys] here are still the caller's
     full current sets — computing that live snapshot is not itself the growth
     bug; persisting a full copy of it every turn was). A keeper's first
@@ -201,8 +161,6 @@ type prune_error =
 (** Bounded failure label for recall-ledger prune setup failures. *)
 
 val string_of_prune_error : prune_error -> string
-val error_label_of_exn : exn -> string
-(** Bounded read-side error label for read-only dashboard consumers. *)
 
 val prune_older_than
   :  masc_root:string

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -213,8 +213,8 @@ let parse_json_line ~path ~line_no line =
 
 (* RFC-0264 P3 / masc#25052: decode via the ledger's shared decoder (SSOT for
    field names) instead of re-spelling "keeper_id"/"trace_id"/... here. The
-   ledger now writes v2 delta rows ([Ledger.payload = Delta]) instead of a
-   full key list per turn, so a single decoded [Ledger.record] no longer
+   ledger writes current v2 delta rows ([Ledger.record.delta]), so a
+   single decoded [Ledger.record] does not
    carries the actual injected set on its own -- [evaluate] below replays
    [Ledger.materialize] over the *entire* recall_dir tree (already scanned in
    chronological order by [find_jsonl]) to reconstruct it, which is exact here

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -35,6 +35,45 @@ let with_temp_masc_root name f =
   Unix.mkdir path 0o700;
   Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
 
+let current_row_json
+      ?failure_reason
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~added_fact_keys
+      ~removed_fact_keys
+      ~added_episode_keys
+      ~removed_episode_keys
+      ~n_facts_in_store
+      ~now
+      ()
+  =
+  let fields =
+    [ "schema_version", `Int 2
+    ; "keeper_id", `String keeper_id
+    ; "trace_id", `String trace_id
+    ; "turn", `Int turn
+    ; "added_fact_keys", `List (List.map (fun key -> `String key) added_fact_keys)
+    ; "removed_fact_keys", `List (List.map (fun key -> `String key) removed_fact_keys)
+    ; "added_episode_keys", `List (List.map (fun key -> `String key) added_episode_keys)
+    ; ( "removed_episode_keys"
+      , `List (List.map (fun key -> `String key) removed_episode_keys) )
+    ; ( "content_hash"
+      , `String
+          (Ledger.content_hash_of
+             ~fact_keys:added_fact_keys
+             ~episode_keys:added_episode_keys) )
+    ; "n_facts_in_store", `Int n_facts_in_store
+    ; "n_episodes_in_store", `Int (List.length added_episode_keys)
+    ; "ts", `Float now
+    ]
+  in
+  `Assoc
+    (match failure_reason with
+     | None -> fields
+     | Some reason -> fields @ [ "failure_reason", `String reason ])
+;;
+
 let old_recall_file_path ~masc_root ~retention_days =
   let old_ts =
     Unix.gettimeofday ()
@@ -52,12 +91,14 @@ let old_recall_file_path ~masc_root ~retention_days =
 let write_old_recall_file ~masc_root ~retention_days =
   let old_file = old_recall_file_path ~masc_root ~retention_days in
   let old_row =
-    Ledger.to_json
+    current_row_json
       ~keeper_id:"old-keeper"
       ~trace_id:"old-trace"
       ~turn:1
-      ~injected_fact_keys:[ "old-fact" ]
-      ~injected_episode_keys:[]
+      ~added_fact_keys:[ "old-fact" ]
+      ~removed_fact_keys:[]
+      ~added_episode_keys:[]
+      ~removed_episode_keys:[]
       ~n_facts_in_store:1
       ~now:0.0
       ()
@@ -150,25 +191,26 @@ let test_append_writes_delta_row_and_updates_registry () =
     ();
   match read_all_records ~masc_root with
   | [ first; second ] ->
-    (match first.payload with
-     | Ledger.Delta { added_fact_keys; removed_fact_keys; _ } ->
-       check_string_list
-         "first append (fresh registry) is a full accounting: added = [x; y]"
-         [ "x"; "y" ]
-         added_fact_keys;
-       check "first append has no removals (nothing prior)" (removed_fact_keys = [])
-     | Ledger.Full_snapshot _ ->
-       check "first append is tagged Delta, not Full_snapshot" false);
-    (match second.payload with
-     | Ledger.Delta
-         { added_fact_keys; removed_fact_keys; added_episode_keys; removed_episode_keys; _ } ->
-       check_string_list "second append adds only the new key" [ "z" ] added_fact_keys;
-       check_string_list "second append removes only the dropped key" [ "x" ] removed_fact_keys;
-       check_string_list "second append adds the new episode key" [ "trace-g:g0" ]
-         added_episode_keys;
-       check "second append removes no episode keys" (removed_episode_keys = [])
-     | Ledger.Full_snapshot _ ->
-       check "second append is tagged Delta, not Full_snapshot" false)
+    let { Ledger.added_fact_keys; removed_fact_keys; _ } = first.delta in
+    check_string_list
+      "first append (fresh registry) is a full accounting: added = [x; y]"
+      [ "x"; "y" ]
+      added_fact_keys;
+    check "first append has no removals (nothing prior)" (removed_fact_keys = []);
+    let
+      { Ledger.added_fact_keys
+      ; removed_fact_keys
+      ; added_episode_keys
+      ; removed_episode_keys
+      ; _
+      }
+      = second.delta
+    in
+    check_string_list "second append adds only the new key" [ "z" ] added_fact_keys;
+    check_string_list "second append removes only the dropped key" [ "x" ] removed_fact_keys;
+    check_string_list "second append adds the new episode key" [ "trace-g:g0" ]
+      added_episode_keys;
+    check "second append removes no episode keys" (removed_episode_keys = [])
   | rows ->
     check (Printf.sprintf "expected exactly 2 rows, got %d" (List.length rows)) false
 ;;
@@ -222,18 +264,7 @@ let test_append_no_change_produces_empty_delta_regardless_of_store_size () =
     (large_bytes < small_bytes * 3)
 ;;
 
-let test_materialize_replays_legacy_and_delta_rows () =
-  let full ~keeper_id ~trace_id ~turn ~fact_keys ~episode_keys =
-    { Ledger.keeper_id
-    ; trace_id
-    ; turn
-    ; ts = Some (float_of_int turn)
-    ; failure_reason = None
-    ; n_facts_in_store = None
-    ; n_episodes_in_store = None
-    ; payload = Ledger.Full_snapshot { fact_keys; episode_keys }
-    }
-  in
+let test_materialize_replays_current_delta_rows () =
   let delta
         ~keeper_id
         ~trace_id
@@ -250,19 +281,25 @@ let test_materialize_replays_legacy_and_delta_rows () =
     ; failure_reason = None
     ; n_facts_in_store = None
     ; n_episodes_in_store = None
-    ; payload =
-        Ledger.Delta
-          { added_fact_keys
-          ; removed_fact_keys
-          ; added_episode_keys
-          ; removed_episode_keys
-          ; content_hash =
-              Ledger.content_hash_of ~fact_keys:added_fact_keys ~episode_keys:added_episode_keys
-          }
+    ; delta =
+        { added_fact_keys
+        ; removed_fact_keys
+        ; added_episode_keys
+        ; removed_episode_keys
+        ; content_hash =
+            Ledger.content_hash_of ~fact_keys:added_fact_keys ~episode_keys:added_episode_keys
+        }
     }
   in
   let records =
-    [ full ~keeper_id:"k" ~trace_id:"t1" ~turn:1 ~fact_keys:[ "a"; "b" ] ~episode_keys:[]
+    [ delta
+        ~keeper_id:"k"
+        ~trace_id:"t1"
+        ~turn:1
+        ~added_fact_keys:[ "a"; "b" ]
+        ~removed_fact_keys:[]
+        ~added_episode_keys:[]
+        ~removed_episode_keys:[]
     ; delta
         ~keeper_id:"k"
         ~trace_id:"t1"
@@ -275,7 +312,7 @@ let test_materialize_replays_legacy_and_delta_rows () =
   in
   match Ledger.materialize records with
   | [ first; second ] ->
-    check_string_list "genesis snapshot materializes to its own list" [ "a"; "b" ]
+    check_string_list "first current delta materializes from empty" [ "a"; "b" ]
       first.fact_keys;
     check_string_list "delta row materializes to (prior + added) - removed" [ "b"; "c" ]
       second.fact_keys;
@@ -292,7 +329,13 @@ let test_materialize_keeps_keepers_independent () =
     ; failure_reason = None
     ; n_facts_in_store = None
     ; n_episodes_in_store = None
-    ; payload = Ledger.Full_snapshot { fact_keys = keys; episode_keys = [] }
+    ; delta =
+        { added_fact_keys = keys
+        ; removed_fact_keys = []
+        ; added_episode_keys = []
+        ; removed_episode_keys = []
+        ; content_hash = Ledger.content_hash_of ~fact_keys:keys ~episode_keys:[]
+        }
     }
   in
   let records = [ row "keeper-a" 1 [ "shared" ]; row "keeper-b" 1 [ "other" ] ] in
@@ -305,12 +348,14 @@ let test_materialize_keeps_keepers_independent () =
 
 let () =
   let j =
-    Ledger.to_json
+    current_row_json
       ~keeper_id:"alpha"
       ~trace_id:"trace-1"
       ~turn:3
-      ~injected_fact_keys:[ "fact one"; "fact two" ]
-      ~injected_episode_keys:[ "trace-1:g0" ]
+      ~added_fact_keys:[ "fact one"; "fact two" ]
+      ~removed_fact_keys:[]
+      ~added_episode_keys:[ "trace-1:g0" ]
+      ~removed_episode_keys:[]
       ~n_facts_in_store:42
       ~now:1234.5
       ()
@@ -321,22 +366,24 @@ let () =
   check "n_facts_in_store" (j |> member "n_facts_in_store" |> to_int = 42);
   check "ts" (j |> member "ts" |> to_number = 1234.5);
   check
-    "injected_fact_keys preserved in order"
-    (j |> member "injected_fact_keys" |> to_list |> List.map to_string
+    "added_fact_keys preserved in order"
+    (j |> member "added_fact_keys" |> to_list |> List.map to_string
      = [ "fact one"; "fact two" ]);
   check
-    "injected_episode_keys preserved"
-    (j |> member "injected_episode_keys" |> to_list |> List.map to_string
+    "added_episode_keys preserved"
+    (j |> member "added_episode_keys" |> to_list |> List.map to_string
      = [ "trace-1:g0" ]);
   check "failure_reason omitted by default" (j |> member "failure_reason" = `Null);
   let failure_json =
-    Ledger.to_json
+    current_row_json
       ~failure_reason:"prompt_render_error"
       ~keeper_id:"alpha"
       ~trace_id:"trace-1"
       ~turn:3
-      ~injected_fact_keys:[]
-      ~injected_episode_keys:[]
+      ~added_fact_keys:[]
+      ~removed_fact_keys:[]
+      ~added_episode_keys:[]
+      ~removed_episode_keys:[]
       ~n_facts_in_store:42
       ~now:1234.5
       ()
@@ -346,31 +393,41 @@ let () =
     (failure_json |> member "failure_reason" |> to_string = "prompt_render_error");
   (* Empty key lists serialise to empty JSON arrays, not null. *)
   let empty =
-    Ledger.to_json
+    current_row_json
       ~keeper_id:"k"
       ~trace_id:"t"
       ~turn:0
-      ~injected_fact_keys:[]
-      ~injected_episode_keys:[]
+      ~added_fact_keys:[]
+      ~removed_fact_keys:[]
+      ~added_episode_keys:[]
+      ~removed_episode_keys:[]
       ~n_facts_in_store:0
       ~now:0.0
       ()
   in
   check
     "empty fact keys is []"
-    (empty |> member "injected_fact_keys" |> to_list = []);
+    (empty |> member "added_fact_keys" |> to_list = []);
   (* Deterministic round-trip: serialise then re-parse is structurally equal. *)
   let round_trip = Yojson.Safe.from_string (Yojson.Safe.to_string j) in
   check "round-trip equal" (Yojson.Safe.equal j round_trip);
   (match Ledger.record_of_json_result round_trip with
-   | Ok { payload = Ledger.Full_snapshot { fact_keys; episode_keys }; keeper_id; trace_id; turn; _ } ->
+   | Ok
+       { delta = { added_fact_keys; added_episode_keys; _ }
+       ; keeper_id
+       ; trace_id
+       ; turn
+       ; _
+       } ->
      check "typed decoder preserves keeper_id" (keeper_id = "alpha");
      check "typed decoder preserves trace_id" (trace_id = "trace-1");
      check "typed decoder preserves turn" (turn = 3);
-     check "typed decoder preserves fact keys" (fact_keys = [ "fact one"; "fact two" ]);
-     check "typed decoder preserves episode keys" (episode_keys = [ "trace-1:g0" ])
-   | Ok { payload = Ledger.Delta _; _ } ->
-     check "legacy row decodes as Full_snapshot, not Delta" false
+     check
+       "typed decoder preserves added fact keys"
+       (added_fact_keys = [ "fact one"; "fact two" ]);
+     check
+       "typed decoder preserves added episode keys"
+       (added_episode_keys = [ "trace-1:g0" ])
    | Error _ -> check "typed decoder accepts own schema" false);
   (match Ledger.record_of_json_result (`Assoc []) with
    | Error (`Missing_field "keeper_id") -> check "missing keeper_id is visible" true
@@ -381,11 +438,15 @@ let () =
          [ "keeper_id", `String "alpha"
          ; "trace_id", `String "trace-1"
          ; "turn", `Int 1
-         ; "injected_fact_keys", `List [ `Int 1 ]
-         ; "injected_episode_keys", `List []
+         ; "schema_version", `Int 2
+         ; "added_fact_keys", `List [ `Int 1 ]
+         ; "removed_fact_keys", `List []
+         ; "added_episode_keys", `List []
+         ; "removed_episode_keys", `List []
+         ; "content_hash", `String "hash"
          ])
    with
-   | Error (`Invalid_field "injected_fact_keys") ->
+   | Error (`Invalid_field "added_fact_keys") ->
      check "invalid fact key list is visible" true
    | _ -> check "invalid fact key list is visible" false);
   (match
@@ -395,13 +456,41 @@ let () =
          ; "trace_id", `String "trace-1"
          ; "turn", `Int 1
          ; "schema_version", `Int 99
-         ; "injected_fact_keys", `List []
-         ; "injected_episode_keys", `List []
          ])
    with
    | Error (`Unsupported_schema_version 99) ->
      check "unknown schema_version is a typed error, not a silent fallback" true
    | _ -> check "unknown schema_version is a typed error, not a silent fallback" false);
+  (match
+     Ledger.record_of_json_result
+       (`Assoc
+         [ "keeper_id", `String "alpha"
+         ; "trace_id", `String "trace-1"
+         ; "turn", `Int 1
+         ; "added_fact_keys", `List []
+         ; "removed_fact_keys", `List []
+         ; "added_episode_keys", `List []
+         ; "removed_episode_keys", `List []
+         ; "content_hash", `String "hash"
+         ])
+   with
+   | Error (`Missing_field "schema_version") ->
+     check "missing schema_version is rejected" true
+   | _ -> check "missing schema_version is rejected" false);
+  (match
+     Ledger.record_of_json_result
+       (`Assoc
+         [ "keeper_id", `String "alpha"
+         ; "trace_id", `String "trace-1"
+         ; "turn", `Int 1
+         ; "schema_version", `Int 1
+         ; "injected_fact_keys", `List []
+         ; "injected_episode_keys", `List []
+         ])
+   with
+   | Error (`Unsupported_schema_version 1) ->
+     check "retired schema_version=1 is rejected" true
+   | _ -> check "retired schema_version=1 is rejected" false);
   check
     "known recall failure label stays stable"
     (Ledger.bounded_failure_reason_label "prompt_render_error"
@@ -430,7 +519,7 @@ let () =
     "content_hash_of distinguishes different sets"
     (Ledger.content_hash_of ~fact_keys:[ "a" ] ~episode_keys:[]
      <> Ledger.content_hash_of ~fact_keys:[ "a"; "b" ] ~episode_keys:[]);
-  test_materialize_replays_legacy_and_delta_rows ();
+  test_materialize_replays_current_delta_rows ();
   test_materialize_keeps_keepers_independent ();
   test_append_does_not_prune_old_day_file ();
   test_prune_older_than_removes_old_day_file ();

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -1,5 +1,43 @@
 module Eval = Masc.Keeper_recall_outcome_eval
 
+let recall_row
+      ?failure_reason
+      ?(extra_fields = [])
+      ?(added_fact_keys = [])
+      ?(removed_fact_keys = [])
+      ?(added_episode_keys = [])
+      ?(removed_episode_keys = [])
+      ?(n_facts_in_store = 0)
+      ?(ts = 1.0)
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ()
+  =
+  let strings values = `List (List.map (fun value -> `String value) values) in
+  let fields =
+    [ "schema_version", `Int 2
+    ; "keeper_id", `String keeper_id
+    ; "trace_id", `String trace_id
+    ; "turn", `Int turn
+    ; "added_fact_keys", strings added_fact_keys
+    ; "removed_fact_keys", strings removed_fact_keys
+    ; "added_episode_keys", strings added_episode_keys
+    ; "removed_episode_keys", strings removed_episode_keys
+    ; "content_hash", `String "fixture-hash"
+    ; "n_facts_in_store", `Int n_facts_in_store
+    ; "n_episodes_in_store", `Int (List.length added_episode_keys)
+    ; "ts", `Float ts
+    ]
+  in
+  let fields =
+    match failure_reason with
+    | None -> fields
+    | Some reason -> fields @ [ "failure_reason", `String reason ]
+  in
+  Yojson.Safe.to_string (`Assoc (fields @ extra_fields))
+;;
+
 let write_lines path lines =
   Fs_compat.mkdir_p (Filename.dirname path);
   let oc = open_out_bin path in
@@ -44,9 +82,29 @@ let test_joins_recall_to_receipts () =
   with_temp_masc_root (fun masc_root ->
     write_lines
       (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
-      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":["a","b"],"injected_episode_keys":[],"n_facts_in_store":2,"ts":1.0}|}
-      ; {|{"keeper_id":"alpha","trace_id":"trace-1","turn":2,"injected_fact_keys":["a"],"injected_episode_keys":["trace-1:g0"],"n_facts_in_store":2,"ts":2.0}|}
-      ; {|{"keeper_id":"beta","trace_id":"trace-2","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0,"failure_reason":"prompt_render_error","ts":3.0}|}
+      [ recall_row
+          ~keeper_id:"alpha"
+          ~trace_id:"trace-1"
+          ~turn:1
+          ~added_fact_keys:[ "a"; "b" ]
+          ~n_facts_in_store:2
+          ()
+      ; recall_row
+          ~keeper_id:"alpha"
+          ~trace_id:"trace-1"
+          ~turn:2
+          ~removed_fact_keys:[ "b" ]
+          ~added_episode_keys:[ "trace-1:g0" ]
+          ~n_facts_in_store:1
+          ~ts:2.0
+          ()
+      ; recall_row
+          ~failure_reason:"prompt_render_error"
+          ~keeper_id:"beta"
+          ~trace_id:"trace-2"
+          ~turn:1
+          ~ts:3.0
+          ()
       ];
     write_lines
       (Filename.concat
@@ -100,8 +158,16 @@ let test_surfaces_bad_rows_and_uses_typed_outcome () =
            actual list length: this schema field is dead (masc#25052 —
            no writer ever produced it) and is no longer read, so the
            divergence below asserts it is now IGNORED rather than trusted. *)
-        {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":["a"],"injected_fact_key_count":7,"injected_episode_keys":[],"ts":1.0}|}
-      ; {|{"keeper_id":"alpha","turn":2,"injected_fact_keys":[],"injected_episode_keys":[]}|}
+        recall_row
+          ~extra_fields:[ "injected_fact_key_count", `Int 7 ]
+          ~keeper_id:"alpha"
+          ~trace_id:"trace-1"
+          ~turn:1
+          ~added_fact_keys:[ "a" ]
+          ~n_facts_in_store:1
+          ()
+      ; {|{"schema_version":2,"keeper_id":"alpha","turn":2,"added_fact_keys":[],"removed_fact_keys":[],"added_episode_keys":[],"removed_episode_keys":[],"content_hash":"fixture-hash"}|}
+      ; {|{"schema_version":1,"keeper_id":"legacy","trace_id":"trace-old","turn":1,"injected_fact_keys":["old"],"injected_episode_keys":[]}|}
       ; {|{"keeper_id":|}
       ];
     write_lines
@@ -120,7 +186,8 @@ let test_surfaces_bad_rows_and_uses_typed_outcome () =
     Alcotest.(check int) "count derived from actual list, not the dead override field" 1
       report.injected_fact_keys;
     Alcotest.(check int) "malformed rows" 1 report.malformed_jsonl_rows;
-    Alcotest.(check int) "invalid recall rows" 1 report.invalid_recall_rows;
+    Alcotest.(check int) "invalid recall rows include retired v1" 2
+      report.invalid_recall_rows;
     Alcotest.(check int) "invalid receipt rows" 1 report.invalid_receipt_rows;
     Alcotest.(check int) "receipt metrics rows ignored" 0 report.outcome_error;
     Alcotest.(check bool) "load error details" true (report.load_errors <> []))
@@ -130,8 +197,7 @@ let test_selects_newest_receipt_by_timestamp () =
   with_temp_masc_root (fun masc_root ->
     write_lines
       (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
-      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"ts":1.0}|}
-      ];
+      [ recall_row ~keeper_id:"alpha" ~trace_id:"trace-1" ~turn:1 () ];
     write_lines
       (Filename.concat
          masc_root
@@ -148,8 +214,8 @@ let test_json_respects_trace_limit () =
   with_temp_masc_root (fun masc_root ->
     write_lines
       (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
-      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0}|}
-      ; {|{"keeper_id":"alpha","trace_id":"trace-2","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0}|}
+      [ recall_row ~keeper_id:"alpha" ~trace_id:"trace-1" ~turn:1 ()
+      ; recall_row ~keeper_id:"alpha" ~trace_id:"trace-2" ~turn:1 ()
       ];
     let json =
       Eval.evaluate ~masc_root |> Eval.to_json ~trace_limit:1 ~fact_key_limit:0
@@ -166,8 +232,20 @@ let test_writes_fact_key_summary_index () =
   with_temp_masc_root (fun masc_root ->
     write_lines
       (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
-      [ {|{"keeper_id":"alpha","trace_id":"trace-ok","turn":1,"injected_fact_keys":["shared:a"],"injected_episode_keys":[]}|}
-      ; {|{"keeper_id":"beta","trace_id":"trace-err","turn":1,"injected_fact_keys":["shared:a"],"injected_episode_keys":[]}|}
+      [ recall_row
+          ~keeper_id:"alpha"
+          ~trace_id:"trace-ok"
+          ~turn:1
+          ~added_fact_keys:[ "shared:a" ]
+          ~n_facts_in_store:1
+          ()
+      ; recall_row
+          ~keeper_id:"beta"
+          ~trace_id:"trace-err"
+          ~turn:1
+          ~added_fact_keys:[ "shared:a" ]
+          ~n_facts_in_store:1
+          ()
       ];
     write_lines
       (Filename.concat

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -2,11 +2,8 @@ open Alcotest
 
 module Json = Yojson.Safe.Util
 module Memory_subsystems = Server_dashboard_http_memory_subsystems
-module Memory_io = Masc.Keeper_memory_os_io
-module Recall_ledger = Masc.Keeper_recall_injection_ledger
 module Delegation_request = Masc.Keeper_delegation_request
 module Delegation_store = Masc.Keeper_delegation_request_store
-module Types = Masc.Keeper_memory_os_types
 
 let request target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
@@ -28,22 +25,6 @@ let rm_rf dir =
   in
   try rm dir with
   | _ -> ()
-;;
-
-let fact ?(category = Types.Preference) ?(trace_id = "trace-memory")
-      ?(turn = 3) ?(first_seen = 10.0) ?last_verified_at claim
-  : Types.fact
-  =
-  { claim
-  ; category
-  ; claim_kind = None
-  ; source = { trace_id; turn; tool_call_id = None }
-  ; first_seen
-  ; valid_until = None
-  ; last_verified_at
-  ; schema_version = Types.schema_version
-  ; claim_id = None
-  }
 ;;
 
 let test_http_json_surfaces_delegation_requests () =
@@ -83,53 +64,6 @@ let test_http_json_surfaces_delegation_requests () =
         Json.(item |> member "requester" |> to_string);
       check string "task seed suffix" "TASK_SEED.md"
         (Filename.basename Json.(item |> member "task_seed_md_path" |> to_string)))
-;;
-
-
-let append_recall_record
-      ?failure_reason
-      ~(config : Workspace_utils.config)
-      ~keeper_id
-      ~trace_id
-      ~turn
-      ~injected_fact_keys
-      ~injected_episode_keys
-      ~n_facts_in_store
-      ()
-  =
-  let masc_root = Workspace_utils.masc_dir config in
-  let store =
-    Dated_jsonl.create
-      ~base_dir:(Recall_ledger.base_dir ~masc_root)
-      ()
-  in
-  Recall_ledger.to_json
-    ?failure_reason
-    ~keeper_id
-    ~trace_id
-    ~turn
-    ~injected_fact_keys
-    ~injected_episode_keys
-    ~n_facts_in_store
-    ~now:(float_of_int turn)
-    ()
-  |> Dated_jsonl.append store
-;;
-
-let append_malformed_recall_record ~(config : Workspace_utils.config) =
-  let masc_root = Workspace_utils.masc_dir config in
-  let store =
-    Dated_jsonl.create
-      ~base_dir:(Recall_ledger.base_dir ~masc_root)
-      ()
-  in
-  Dated_jsonl.append
-    store
-    (`Assoc
-      [ "keeper_id", `String "keeper-bad"
-      ; "injected_fact_keys", `List [ `Int 1 ]
-      ; "injected_episode_keys", `List []
-      ])
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- require exact `schema_version = 2` for recall-injection ledger rows
- remove the retired v1/missing-version full-snapshot decoder and serializer
- replace the historical multi-schema `payload` sum with the single current `record.delta`
- remove unused option-decoder and read-error-label facades
- keep the current append, replay, retention, and invalid-row accounting features intact

## Feature relationship / call trace

- producer entry: `Keeper_recall_injection_ledger.append`
- current wire: date-split `recall_injections/YYYY-MM/DD.jsonl`, schema v2 delta fields
- typed reader: `record_of_json_result`
- only feature consumer: `Keeper_recall_outcome_eval.evaluate`
- downstream behavior: full-history `materialize` replay joins injected keys to execution receipts
- maintenance callers: startup/periodic `prune_older_than`

The first current append after process start already diffs against the empty
set, so it is a complete genesis accounting. Current replay does not require a
v1 snapshot or a migration path.

## Contract / gate check

- no new gate was added
- missing, v1, and unknown schema versions use the existing typed decode error
- outcome evaluation continues to count rejected rows as `invalid_recall_rows`
- the current writer remains the wire SSOT; no repair, migration, heuristic, or
  silent fallback was introduced

## Blast radius

- persisted recall-injection rows only
- offline recall outcome evaluation
- ledger-focused tests and removal of stale, unused dashboard fixtures
- recall prompt injection itself is unchanged because the ledger is not read
  on the hot path

## Validation

- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_recall_injection_ledger.exe test/test_keeper_recall_outcome_eval.exe test/test_server_dashboard_http_memory_subsystems.exe`
- `test_keeper_recall_injection_ledger.exe`: all 45 checks passed
- `test_keeper_recall_outcome_eval.exe`: 5/5 passed
- `test_server_dashboard_http_memory_subsystems.exe`: 1/1 passed
- negative coverage rejects missing `schema_version` and retired
  `schema_version = 1`; the evaluator accounts the retired row as invalid

After rebasing onto latest `origin/main`, a second local build attempt was
blocked by unrelated bare Dune processes detected by the repo wrapper. The
recall source/test patch rebased without conflict; CI is the rebased-head build
authority.
