### PR TITLE
test(keeper): drive the chat consumer against autonomous turns

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -2600,3 +2600,5 @@
 
 (include stanzas/test_fs_compat_publication_reconciliation.inc)
 (include stanzas/test_eio_resource_scope.inc)
+
+(include stanzas/test_keeper_chat_admission_contention.inc)

--- a/test/stanzas/test_keeper_chat_admission_contention.inc
+++ b/test/stanzas/test_keeper_chat_admission_contention.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_chat_admission_contention)
+ (modules test_keeper_chat_admission_contention)
+ (libraries masc_test_deps))

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -1,0 +1,225 @@
+(* Chat/autonomous turn admission under contention.
+
+   The autonomous lane and the queue consumer compete for one per-Keeper turn
+   slot. Both lanes are covered individually — Keeper_turn_admission's own
+   suite pins the admission predicates, and the consumer suite pins receipt
+   lifecycle — but nothing drives the two against each other. That gap is the
+   reason a change to either lane's admission rule can silently starve the
+   other: the failure only appears when a consumer and a repeating autonomous
+   driver share a slot.
+
+   These tests run the production Keeper_chat_consumer control loop against an
+   autonomous driver on the same slot. The provider call is the only thing
+   replaced: handle_turn calls Keeper_turn_admission.run_serialized, which is
+   what the production handler reaches (keeper_chat_consumer.ml run_leased_turn
+   -> server_bootstrap_loops.ml handle_turn -> ... -> keeper_turn.ml
+   handle_keeper_invocation -> run_serialized).
+
+   Assertions are one-sided on purpose: they pin that a queued receipt is
+   admitted, not which admission rule admitted it. That keeps the tests valid
+   across changes to the admission predicates while still failing if either
+   lane starves the other. *)
+
+open Masc
+
+let failures = ref 0
+
+let check name condition =
+  if condition
+  then Printf.printf "  ✓ %s\n%!" name
+  else (
+    incr failures;
+    Printf.printf "  ✗ %s\n%!" name)
+
+let keeper_name = "chat-admission-contention-keeper"
+
+(* Wall-clock budgets are generous because CI shares cores; the turns
+   themselves are short so a healthy run finishes far inside them. *)
+let turn_seconds = 0.2
+let receipt_count = 3
+let budget_seconds = 20.0
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun n -> rm_rf (Filename.concat path n));
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let with_env body =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-chat-admission-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let clock = Eio.Stdenv.clock env in
+       let config = Workspace.default_config base in
+       ignore (Workspace.init config ~agent_name:(Some keeper_name));
+       Keeper_chat_queue.For_testing.reset ();
+       Keeper_turn_admission.For_testing.reset ();
+       let report = Keeper_chat_queue.configure_persistence ~base_path:base in
+       check "chat queue persistence configured" (report.load_errors = []);
+       Fun.protect
+         ~finally:(fun () ->
+           Keeper_chat_queue.For_testing.reset ();
+           Keeper_turn_admission.For_testing.reset ())
+         (fun () -> body ~base ~clock))
+
+let message content =
+  { Keeper_chat_queue.content
+  ; user_blocks = []
+  ; attachments = []
+  ; timestamp = 0.0
+  ; source = Keeper_chat_queue.Discord { channel_id = "c1"; user_id = "u1" }
+  ; user_row_origin = Keeper_chat_store.Already_persisted_upstream
+  }
+
+(* Wire the same transition observers the runtime installs, so the consumer is
+   edge-woken on durable queue mutations and on turn-slot release. *)
+let install_observers ~base =
+  let canonical = Keeper_registry_types.canonical_base_path_exn base in
+  Keeper_chat_queue.set_transition_observer
+    (Some
+       (fun ~keeper_name ~revision:_ ->
+          Keeper_chat_consumer.notify_transition ~keeper_name));
+  Keeper_turn_admission.set_slot_transition_observer
+    (Some
+       (fun ~base_path ~keeper_name ~transition:_ ->
+          if String.equal base_path canonical
+          then Keeper_chat_consumer.notify_transition ~keeper_name))
+
+exception Budget_reached
+
+(* [gap_seconds = 0.] is the back-to-back shape the autonomous lane can reach:
+   Keeper_keepalive_signal.interruptible_sleep consumes a pre-armed wakeup
+   before sleeping, so the heartbeat cadence is not a floor. *)
+let run_contention ~base ~clock ~gap_seconds ~on_admitted =
+  install_observers ~base;
+  let admitted = ref 0 in
+  let enqueued = ref 0 in
+  let autonomous_turns = ref 0 in
+  let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+    match
+      Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name
+        (fun () ->
+           incr admitted;
+           on_admitted !admitted)
+    with
+    | `Ran () -> Keeper_chat_consumer.Delivered { outcome_ref = "contention-turn" }
+    | `Rejected rejection -> Keeper_chat_consumer.Deferred { rejection }
+  in
+  (try
+     Eio.Switch.run (fun sw ->
+       Eio.Fiber.fork ~sw (fun () ->
+         Keeper_chat_consumer.run ~sw ~clock ~base_path:base ~handle_turn);
+       (* Autonomous driver: keep re-attempting admission for the whole run. *)
+       Eio.Fiber.fork ~sw (fun () ->
+         let rec drive () =
+           (match
+              Keeper_turn_admission.run_if_free ~base_path:base ~keeper_name
+                (fun () -> Eio.Time.sleep clock turn_seconds)
+            with
+            | `Ran () -> incr autonomous_turns
+            | `Busy _ -> ());
+           (* Unconditional: at [gap_seconds = 0.] this is the yield that keeps
+              a Busy result from spinning the driver against the scheduler. *)
+           Eio.Time.sleep clock gap_seconds;
+           drive ()
+         in
+         drive ());
+       Eio.Fiber.fork ~sw (fun () ->
+         for i = 1 to receipt_count do
+           Eio.Time.sleep clock (turn_seconds *. 1.5);
+           match
+             Keeper_chat_queue.enqueue ~keeper_name
+               (message (Printf.sprintf "contention-%d" i))
+           with
+           | Ok _ -> incr enqueued
+           | Error error ->
+             Printf.printf "  enqueue failed: %s\n%!"
+               (Keeper_chat_queue.mutation_error_to_string error)
+         done);
+       (* Stop as soon as every receipt is through, or when the budget runs
+          out — whichever comes first. *)
+       Eio.Fiber.fork ~sw (fun () ->
+         let rec wait elapsed =
+           if !admitted >= receipt_count || elapsed > budget_seconds
+           then ()
+           else (
+             Eio.Time.sleep clock 0.05;
+             wait (elapsed +. 0.05))
+         in
+         wait 0.0;
+         Eio.Switch.fail sw Budget_reached))
+   with
+   | Budget_reached -> ()
+   | Eio.Cancel.Cancelled _ -> ());
+  !enqueued, !admitted, !autonomous_turns
+
+let test_back_to_back_autonomous_does_not_starve_chat () =
+  Printf.printf
+    "Test: back-to-back autonomous turns do not starve the queue consumer\n%!";
+  with_env (fun ~base ~clock ->
+    let enqueued, admitted, autonomous_turns =
+      run_contention ~base ~clock ~gap_seconds:0. ~on_admitted:(fun _ -> ())
+    in
+    check "every receipt was enqueued" (enqueued = receipt_count);
+    check
+      (Printf.sprintf "every receipt was admitted (%d/%d)" admitted receipt_count)
+      (admitted = receipt_count);
+    (* The driver must actually have contended, otherwise the test proves
+       nothing about contention. *)
+    check
+      (Printf.sprintf "autonomous lane ran during the test (%d turns)" autonomous_turns)
+      (autonomous_turns > 0))
+
+let test_heartbeat_shaped_autonomous_does_not_starve_chat () =
+  Printf.printf
+    "Test: heartbeat-shaped autonomous cycles do not starve the queue consumer\n%!";
+  with_env (fun ~base ~clock ->
+    let enqueued, admitted, autonomous_turns =
+      run_contention ~base ~clock ~gap_seconds:(turn_seconds *. 1.5)
+        ~on_admitted:(fun _ -> ())
+    in
+    check "every receipt was enqueued" (enqueued = receipt_count);
+    check
+      (Printf.sprintf "every receipt was admitted (%d/%d)" admitted receipt_count)
+      (admitted = receipt_count);
+    check
+      (Printf.sprintf "autonomous lane ran during the test (%d turns)" autonomous_turns)
+      (autonomous_turns > 0))
+
+let test_receipts_are_admitted_in_fifo_order () =
+  Printf.printf "Test: queued receipts are admitted one at a time, in order\n%!";
+  with_env (fun ~base ~clock ->
+    let concurrent = ref false in
+    let in_turn = ref false in
+    let _, admitted, _ =
+      run_contention ~base ~clock ~gap_seconds:0.
+        ~on_admitted:(fun _ ->
+          if !in_turn then concurrent := true;
+          in_turn := true;
+          in_turn := false)
+    in
+    check "receipts were admitted" (admitted > 0);
+    check "no two chat turns held the slot at once" (not !concurrent))
+
+let () =
+  Printf.printf "=== keeper chat/autonomous admission contention ===\n%!";
+  test_back_to_back_autonomous_does_not_starve_chat ();
+  test_heartbeat_shaped_autonomous_does_not_starve_chat ();
+  test_receipts_are_admitted_in_fifo_order ();
+  if !failures > 0
+  then (
+    Printf.printf "\n%d check(s) failed\n%!" !failures;
+    exit 1)
+  else Printf.printf "\nall checks passed\n%!"


### PR DESCRIPTION
## 목표

autonomous lane 과 queue consumer 가 하나의 per-Keeper turn slot 을 두고 경합하는 상황에 대한 테스트가 없습니다. 두 lane 은 각각 커버돼 있습니다 — `test_keeper_turn_admission.ml` 이 admission 술어를, consumer 스위트가 receipt lifecycle 을 고정합니다 — 하지만 **둘을 서로 붙여 돌리는 테스트가 하나도 없습니다.**

그래서 한쪽 lane 의 admission 규칙을 바꾸면 다른 lane 이 조용히 굶어도 스위트가 통과합니다.

`test_keeper_turn_admission.ml:601-700` 의 Test 10 이 :610-612 에서 `the starvation this pins` 라고 적었지만, 단일 fiber 에서 술어의 반환값만 검사합니다. consumer 도, 반복되는 autonomous 드라이버도 없습니다.

## 변경

`test/test_keeper_chat_admission_contention.ml` 하나를 추가합니다. 프로덕션 `Keeper_chat_consumer.run` 컨트롤 루프를 같은 slot 위의 autonomous 드라이버와 함께 구동합니다. 대체하는 것은 provider 호출 하나뿐이고, `handle_turn` 은 프로덕션 핸들러가 도달하는 것과 같은 `Keeper_turn_admission.run_serialized` 를 호출합니다.

3개 테스트:

| 테스트 | 고정하는 것 |
|---|---|
| back-to-back autonomous | 간격 없이 재시도하는 autonomous 아래에서 큐에 들어온 receipt 가 전부 처리된다 |
| heartbeat-shaped autonomous | 간격이 있는 형태에서도 동일 |
| 순차 admission | 두 chat turn 이 동시에 slot 을 쥐지 않는다 |

단언은 의도적으로 한쪽 방향입니다 — receipt 가 **처리되는지**만 보고 **어떤 규칙이** 처리했는지는 보지 않습니다. admission 술어를 바꿔도 테스트가 유효하게 남고, 그러면서 한 lane 이 다른 lane 을 굶기면 실패합니다.

## 검증

### 현재 main 에서 통과

3회 연속 실행, 턴 수까지 동일하게 재현됩니다.

```
Test: back-to-back autonomous turns do not starve the queue consumer
  ✓ every receipt was admitted (3/3)
  ✓ autonomous lane ran during the test (5 turns)
Test: heartbeat-shaped autonomous cycles do not starve the queue consumer
  ✓ every receipt was admitted (3/3)
  ✓ autonomous lane ran during the test (2 turns)
Test: queued receipts are admitted one at a time, in order
  ✓ no two chat turns held the slot at once

all checks passed
```

### 실제로 회귀를 잡습니다

`#26283` 의 첫 커밋 `5d24401433` (autonomous lane 에서 backlog 게이트를 제거하되 consumer parking 은 없는 상태) 를 적용하고 같은 테스트를 돌리면, 3회 모두 결정론적으로 실패합니다:

```
  ✗ every receipt was admitted (0/3)     ← back-to-back
  ✓ every receipt was admitted (3/3)     ← heartbeat-shaped
  ✗ receipts were admitted
2 check(s) failed
```

back-to-back 형태에서 **20초 예산 안에 chat 이 한 번도 들어가지 못합니다.** 삭제된 주석이 `the busy-ACK loop` 이라고 이름 붙인 실패 모드가 그대로 재현됩니다. heartbeat 형태는 간격이 consumer 에게 여지를 주므로 통과하는데, 이 대비 자체가 이 테스트가 무엇을 고정하는지 보여줍니다.

### 왜 두 조합 모두 통과하는가

| 코드 상태 | back-to-back |
|---|---|
| 현재 main (게이트 있음) | 3/3 |
| `#26283` 두 커밋 (게이트 제거 + consumer parking) | 3/3 |
| `5d24401433` 단독 (게이트 제거만) | **0/3** |

테스트는 특정 설계를 강제하지 않습니다. 게이트로 막든 mutex parking 으로 막든 통과하고, **아무것도 막지 않을 때만** 실패합니다.

## 검증하지 않은 것

- 단일 도메인 Eio. 멀티 도메인 경합은 다루지 않습니다.
- provider 지연 변동 없음 — 턴 길이가 고정 sleep 입니다.
- wall-clock 예산(20초)에 의존합니다. 턴 자체는 0.2초라 정상 실행은 예산 안쪽에서 크게 여유가 있지만, CI 부하가 극단적이면 flaky 할 수 있습니다. 로컬 3회는 결정론적이었습니다.
- 크래시/재시작 경로는 다루지 않습니다.

## 이 PR 이 하지 않는 것

`lib/` 를 건드리지 않습니다. admission 설계에 대한 입장을 담지 않으며, 어떤 규칙이 lane 을 보호해야 하는지도 규정하지 않습니다. 지금 비어 있는 관측을 채우는 것뿐입니다.

RFC-WAIVED: `test/` 에만 변경이 있고 credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 subsystem 도 건드리지 않습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
