### PR TITLE
chore(oas-pin): OAS pin bump v0.231.2 (GLM streaming 회복)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.1-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.2-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.1`, runtime pin: `main@c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835`, declared base version: `v0.231.1`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.2`, runtime pin: `main@1ea60e7a1d379d0229eb1c83cfd5005b429eca81`, declared base version: `v0.231.2`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.1))
+  (agent_sdk (>= 0.231.2))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.1"}
+  "agent_sdk" {>= "0.231.2"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.1"}
+  "agent_sdk" {= "0.231.2"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.1"
-  "git+https://github.com/jeong-sik/oas.git#c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835"
+  "agent_sdk.0.231.2"
+  "git+https://github.com/jeong-sik/oas.git#1ea60e7a1d379d0229eb1c83cfd5005b429eca81"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.1"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.2"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -23,16 +23,21 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.1"
 # The #2877 follow-up derives the effective turn provider config once, threads
 # that exact value through dispatch and pricing, and removes duplicate Provider
 # auth/pricing facades. MASC consumes the canonical public modules directly.
-# Previous pin: v0.231.0 (2cb7d922); before that v0.230.0 (7a3f2af7).
+# Previous pin: v0.231.1 (c3bb4daa7); before that v0.231.0 (2cb7d922).
 # MASC consumes only the public Agent SDK contract; Keeper, Gate, Board, and
 # product operation ownership remain MASC concepts.
 # The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
 # main; oas-drift-check.sh also reports the public-surface delta at pin-bump
 # time.
-# Pinned to the merged #2877 commit.
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.1"
+# v0.231.2 is a patch on the hard-cut wave: adds GLM-5-Turbo
+# reasoning_streaming_format (#2880) — recovers streaming reasoning that was
+# falling back to batch (No_streaming_reasoning, ~60s/turn). Also carries the
+# #2875 agent-card current-interface contract hard-cut. MASC consumes the same
+# public Agent SDK contract; no compatibility or migration code retained.
+# Pinned to the 0.231.2 release commit (1ea60e7a1).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.2"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.1"
+readonly OAS_AGENT_SDK_SHA="1ea60e7a1d379d0229eb1c83cfd5005b429eca81"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.2"


### PR DESCRIPTION
## OAS pin bump: v0.231.1 → v0.231.2

OAS 0.231.2(release commit `1ea60e7a1`)가 GLM-5-Turbo `reasoning_streaming_format` fix(oas #2880)를 포함한다. streaming reasoning이 batch로 폴백하던 latency 회귀(`No_streaming_reasoning`, ~60s/turn)를 해소한다.

## 변경
- SHA: `c3bb4daa7`(#2877) → `1ea60e7a1d379d0229eb1c83cfd5005b429eca81`(0.231.2 release)
- `agent_sdk` pin: `>= 0.231.2`(dune-project, masc.opam, masc.opam.locked)
- pin script 주석(0.231.2 설명) + README/KEEPER-USER-MANUAL 동기화(`sync-oas-pin-{manifests,docs}.sh`)

## 검증
- `check-oas-pin.sh`: "OAS pin manifests match v0.231.2 (1ea60e7a1...)" 통과
- API surface drift: metadata 2 only (added/removed 0) — 무해

연관: oas #2880(GLM streaming 회복), oas release 0.231.2 (#2879).
