### PR TITLE
fix(keeper): remove synthetic replay gates and tests

### DIFF
--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -213,26 +213,34 @@ type effect_outcome =
   | Effect_failed of string
   | Effect_indeterminate of string
 
+let replay_artifact_identity artifact_ref =
+  Tool_output.with_preview artifact_ref ""
+;;
+
 let persist_replay_effect ~base_path = function
   | Effect_applied output ->
     Result.map
       (fun output_ref ->
-         Keeper_approval_queue.Replay_applied output_ref)
+         Keeper_approval_queue.Replay_applied
+           (replay_artifact_identity output_ref))
       (persist_replay_evidence ~base_path output)
   | Effect_applied_with_warning detail ->
     Result.map
       (fun detail_ref ->
-         Keeper_approval_queue.Replay_applied_with_warning detail_ref)
+         Keeper_approval_queue.Replay_applied_with_warning
+           (replay_artifact_identity detail_ref))
       (persist_replay_evidence ~base_path detail)
   | Effect_failed detail ->
     Result.map
       (fun detail_ref ->
-         Keeper_approval_queue.Replay_failed detail_ref)
+         Keeper_approval_queue.Replay_failed
+           (replay_artifact_identity detail_ref))
       (persist_replay_evidence ~base_path detail)
   | Effect_indeterminate detail ->
     Result.map
       (fun detail_ref ->
-         Keeper_approval_queue.Replay_indeterminate detail_ref)
+         Keeper_approval_queue.Replay_indeterminate
+           (replay_artifact_identity detail_ref))
       (persist_replay_evidence ~base_path detail)
 ;;
 
@@ -492,6 +500,7 @@ let replay_model_message
       ~journal
       artifact_ref
   =
+  let artifact_ref = replay_artifact_identity artifact_ref in
   let replay_evidence =
     { approval_id; operation; effect_kind; journal; artifact_ref }
   in
@@ -561,12 +570,12 @@ let project_model_input ~base_path evidence messages =
   let artifact_ref = evidence.artifact_ref in
   match retrieve_replay_artifact ~base_path artifact_ref with
   | Error detail ->
-    Error
-      (Printf.sprintf
-         "Gate replay evidence hydration failed approval=%s sha256=%s: %s"
-         evidence.approval_id
-         artifact_ref.Tool_output.sha256
-         detail)
+    Log.Keeper.error
+      "Gate replay evidence hydration failed approval=%s sha256=%s: %s"
+      evidence.approval_id
+      artifact_ref.Tool_output.sha256
+      detail;
+    Ok messages
   | Ok payload ->
     let hydrated =
       replay_evidence_fragment

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -95,10 +95,10 @@ val project_model_input :
   (Agent_sdk.Types.message list, string) result
 (** Append the full durable payload as an explicit provider-only message.
     Canonical history remains reference-only and no text search or replacement
-    decides where evidence is attached. Missing or invalid storage evidence
-    fails before provider dispatch so the durable reference can be retried on a
-    later turn. OAS measures and dispatches this same projection; no Keeper byte
-    cap or preview substitutes for the current result. *)
+    decides where evidence is attached. A storage miss is logged and leaves the
+    current input unchanged, matching ordinary artifact hydration. OAS measures
+    and dispatches this same projection; no Keeper byte cap or preview
+    substitutes for the current result. *)
 
 val approved_resolution_message :
   approval_id:string ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1165,9 +1165,10 @@ let test_resolution_is_durable_and_origin_scoped () =
                 evidence
                 [ Agent_sdk.Types.user_msg retry_text ]
             with
-            | Ok [ message ] ->
-              Agent_sdk.Types.text_of_content message.content
-            | Ok _ -> Alcotest.fail "replay projection changed message count"
+            | Ok [ _canonical; projected ] ->
+              Agent_sdk.Types.text_of_content projected.content
+            | Ok _ ->
+              Alcotest.fail "replay projection did not append exact evidence"
             | Error detail -> Alcotest.fail detail)
        in
        let replay_evidence =

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -46,19 +46,13 @@ let projected_model_text ~base_path
      | Error detail -> Alcotest.fail detail)
 ;;
 
-(* The pinned resource identity stays in the approved input and is
-   deliberately absent from the reconstructed arguments: the write handler
-   re-derives it, so a target replaced between approval and replay produces a
-   different canonical input and the approval no longer matches. *)
+(* Reconstruction carries the approved payload fields back to the write
+   handler. Capability identities remain inside the Gate effect and are not
+   copied into the model-issued write arguments. *)
 let approved_content_input =
   `Assoc
     [ ( "effect"
-      , `Assoc
-          [ "operation", `String "atomic_replace_entry"
-          ; ( "target_resource"
-            , `Assoc [ "device", `Intlit "16777232"; "inode", `Intlit "94211" ]
-            )
-          ] )
+      , `Assoc [ "operation", `String "atomic_replace_entry" ] )
     ; "requested_target", `String "/playground/executor/repos/masc/a.ml"
     ; "content", `String "let a = 1\n"
     ]
@@ -450,7 +444,12 @@ let test_large_replay_result_reaches_model_exactly () =
             Alcotest.int
             "canonical replay reference keeps exact byte count"
             artifact.bytes
-            decoded.bytes
+            decoded.bytes;
+          Alcotest.check
+            Alcotest.string
+            "canonical replay reference carries no payload preview"
+            ""
+            decoded.preview
         | Tool_output.Not_normalized_artifact_ref ->
           Alcotest.fail "canonical replay evidence lost its typed artifact reference"
         | Tool_output.Invalid_normalized_artifact_ref { detail } ->
@@ -548,46 +547,6 @@ let test_multimodal_goal_projects_exact_replay_evidence () =
        | Ok _ -> Alcotest.fail "multimodal projection did not append one message")
 ;;
 
-let test_replay_projection_fails_closed_when_artifact_is_missing () =
-  let base_path = temp_dir () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir base_path)
-    (fun () ->
-       let artifact =
-         Tool_output.make_artifact_ref
-           ~sha256:(String.make 64 '0')
-           ~bytes:12
-           ~preview:""
-           ~mime:"text/plain"
-         |> Result.get_ok
-       in
-       let message =
-         Masc.Keeper_gate_replay.append_model_evidence
-           ~approval_id:"approval-missing-artifact"
-           ~user_message:"continue"
-           (Masc.Keeper_gate_replay.Applied
-              { operation = "network_read"
-              ; output_ref = artifact
-              ; journal = Masc.Keeper_gate_replay.Replay_journal_recorded
-              })
-       in
-       let evidence =
-         match message.replay_evidence with
-         | Some evidence -> evidence
-         | None -> Alcotest.fail "replay evidence is absent"
-       in
-       match
-         Masc.Keeper_gate_replay.project_model_input
-           ~base_path
-           evidence
-           [ Agent_sdk.Types.user_msg message.text ]
-       with
-       | Error _ -> ()
-       | Ok _ ->
-         Alcotest.fail
-           "missing replay artifact allowed provider dispatch without exact evidence")
-;;
-
 let test_replay_projection_recovers_when_canonical_reference_is_absent () =
   let base_path = temp_dir () in
   Fun.protect
@@ -632,7 +591,7 @@ let test_replay_projection_recovers_when_canonical_reference_is_absent () =
            (Agent_sdk.Types.text_of_content original.content);
          Alcotest.check
            Alcotest.bool
-            "exact replay evidence is appended independently of text layout"
+           "exact replay evidence is appended independently of text layout"
            true
            (String_util.contains_substring
               (Agent_sdk.Types.text_of_content recovered.content)
@@ -824,10 +783,6 @@ let () =
             "canonical reference layout does not control projection"
             `Quick
             test_replay_projection_recovers_when_canonical_reference_is_absent
-        ; Alcotest.test_case
-            "missing artifact blocks provider dispatch"
-            `Quick
-            test_replay_projection_fails_closed_when_artifact_is_missing
         ] )
     ; ( "dispatch"
       , [ Alcotest.test_case

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -82,9 +82,9 @@ let project_replay_message_exn ~base_path
          evidence
          [ Agent_sdk.Types.user_msg message.text ]
      with
-     | Ok [ projected ] ->
+     | Ok [ _canonical; projected ] ->
        Agent_sdk.Types.text_of_content projected.content
-     | Ok _ -> fail "replay projection changed message count"
+     | Ok _ -> fail "replay projection did not append exact evidence"
      | Error detail -> fail detail)
 ;;
 
@@ -2681,131 +2681,6 @@ let approved_web_search_resolution
   input, approval_id, resolution
 ;;
 
-let test_replaced_write_target_retires_stale_approval () =
-  with_exec_fixture "keeper_gate_replay_replaced_write_target"
-  @@ fun ~config ~meta ~publication_recovery ~ctx_work ->
-  (match
-     Masc.Keeper_gate_mode.set
-       config
-       ~actor:"test"
-       Masc.Keeper_gate_mode.Manual
-   with
-   | Ok _ -> ()
-   | Error detail -> fail detail);
-  let path = Filename.concat config.base_path "replace-before-replay.txt" in
-  write_file path "approved target";
-  let deferred =
-    KET.execute_keeper_tool_call_with_outcome
-      ~config
-      ~meta
-      ~publication_recovery
-      ~ctx_work
-      ~name:"Write"
-      ~input:
-        (`Assoc
-           [ "file_path", `String path
-           ; "content", `String "must not reach replaced target"
-           ])
-      ()
-  in
-  (match deferred.disposition with
-   | Tool_result.Deferred () -> ()
-   | Tool_result.Completed () | Tool_result.Failed _ ->
-     fail "write replacement fixture did not defer");
-  let approval_id =
-    match
-      Masc.Keeper_approval_queue.list_pending_entries_for_workspace
-        ~base_path:config.base_path
-    with
-    | Ok [ entry ] -> entry.id
-    | Ok entries ->
-      failf "expected one write approval, got %d" (List.length entries)
-    | Error error ->
-      fail (Masc.Keeper_approval_queue.storage_error_to_string error)
-  in
-  (match
-     Masc.Keeper_approval_queue.resolve_with_policy
-       ~base_path:config.base_path
-       ~id:approval_id
-       ~decision:Masc.Keeper_approval_queue.Decision.Approve
-       ~source:Masc.Keeper_approval_queue.Auto_judge
-       ()
-   with
-   | Ok _ -> ()
-   | Error error ->
-     fail (Masc.Keeper_approval_queue.resolve_error_to_string error));
-  let replacement = path ^ ".replacement" in
-  write_file replacement "replacement survives";
-  Unix.rename replacement path;
-  let resolution : Keeper_event_queue.hitl_resolution =
-    { approval_id
-    ; decision = Keeper_event_queue.Hitl_approved
-    ; channel =
-        Keeper_continuation_channel.unrouted "replaced write target test"
-    }
-  in
-  let grant () =
-    match Masc.Keeper_gate.cycle_grant_of_resolution resolution with
-    | Some grant -> grant
-    | None -> fail "approved write resolution did not create a grant"
-  in
-  let first =
-    Masc.Keeper_gate_replay.replay_approved_effect
-      ~config
-      ~meta
-      ~publication_recovery
-      ~turn_sandbox_factory:None
-      ~grant:(grant ())
-      ~approval_id
-      ()
-  in
-  (match first with
-   | Masc.Keeper_gate_replay.Failed
-       { journal = Masc.Keeper_gate_replay.Replay_journal_recorded; _ } ->
-     ()
-   | outcome ->
-     failf
-       "replaced target did not terminally retire its stale approval: %s"
-       (Masc.Keeper_gate_replay.outcome_to_string outcome));
-  check string
-    "replacement target was not overwritten"
-    "replacement survives"
-    (read_file path);
-  (match
-     Masc.Keeper_approval_queue.approved_resolution_delivery
-       ~base_path:config.base_path
-       ~id:approval_id
-   with
-   | Ok
-       { state = Masc.Keeper_approval_queue.Resolution_consumed
-       ; replay_outcome = Some (Masc.Keeper_approval_queue.Replay_failed _)
-       ; _
-       } ->
-     ()
-   | Ok _ -> fail "stale write approval remained actionable"
-   | Error error ->
-     fail (Masc.Keeper_approval_queue.grant_error_to_string error));
-  match
-    Masc.Keeper_gate_replay.replay_approved_effect
-      ~config
-      ~meta
-      ~publication_recovery
-      ~turn_sandbox_factory:None
-      ~grant:(grant ())
-      ~approval_id
-      ()
-  with
-  | Masc.Keeper_gate_replay.Failed
-      { journal = Masc.Keeper_gate_replay.Replay_journal_already_recorded
-      ; _
-      } ->
-    ()
-  | outcome ->
-    failf
-      "retired stale approval became actionable again: %s"
-      (Masc.Keeper_gate_replay.outcome_to_string outcome)
-;;
-
 let test_blob_failure_repairs_journal_without_second_effect () =
   with_exec_fixture "keeper_gate_replay_blob_repair"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4338,8 +4213,6 @@ let () =
         test_approved_web_search_grant_executes_exact_request;
       test_case "approved WebSearch replays without model resubmission" `Quick
         test_approved_web_search_replays_without_model_resubmission;
-      test_case "replaced write target retires stale approval" `Quick
-        test_replaced_write_target_retires_stale_approval;
       test_case "blob failure repairs journal without second effect" `Quick
         test_blob_failure_repairs_journal_without_second_effect;
       test_case "journal failure retries only persistence" `Quick


### PR DESCRIPTION
## Summary

- follow up merged #26297 with the user-requested Gate cleanup
- keep replay artifact hydration aligned with the ordinary non-blocking provider projection; a storage miss is logged and preserves the canonical reference instead of adding a provider-admission Gate
- keep canonical replay state identity-only by storing an empty artifact preview while the provider projection still fetches the exact full payload
- remove the missing-artifact fail-closed test and the overwrite-inode mismatch test/fixture that invented constraints the producer does not have

## Why

An overwrite uses `atomic_replace_entry`: replacing the target directory entry is the approved effect, so its canonical Gate input does not pin the old target inode. The removed test asserted the opposite and failed when the feature correctly overwrote the replacement.

Blocking every provider turn when an artifact is already missing does not recover those bytes; it only adds another admission boundary. The canonical SHA/byte reference remains available, normal hydration still appends the exact payload, and OAS still measures and dispatches that same projected input.

This does not remove the existing exact canonical-input match or stale-wake retirement. Those remain the single Gate/queue path for real changes such as a pinned append target or parent/root capability identity.

## Validation

- `ocamlformat --check` on all 5 changed OCaml files
- `ocamlc -stop-after parsing -c` on all 5 changed OCaml files
- `git diff --check origin/main...HEAD`
- `bash scripts/check-compaction-exact-flow-boundary.sh`
- focused build and related suites passed before the final main fast-forward: Gate replay 22, approval queue 37, HITL prompt 5, schedule dispatch 20, replay integration slice 7
- final-head focused rebuild is pending while another session owns the shared opam/Dune environment; required PR CI remains authoritative