### PR TITLE
refactor(chat): require current id and typed surface wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Removed
+- **Breaking (keeper chat wire)**: removed read-time message-id synthesis for
+  rows without a persisted `id` and removed the duplicate persisted `source`
+  lane label. Current chat rows require a nonblank producer-assigned `id` and
+  persist only typed `surface` identity; history/timeline/lane consumers derive
+  the compact source label from that typed field. The unused
+  `Gate_surface.of_source` compatibility facade was also removed. No migration,
+  repair, or string-to-surface fallback was added.
 - **Breaking (telemetry wire/storage)**: removed the retired
   `Agent_joined`/`Agent_left` decoder aliases, the `.masc/telemetry.jsonl`
   fallback reader, and the producer-less `Handoff_triggered` event plus its

--- a/lib/gate/gate_surface.ml
+++ b/lib/gate/gate_surface.ml
@@ -14,14 +14,6 @@ let label = function
   | Slack _ -> slack_label
   | Gate { channel; _ } -> channel
 
-let of_source ~source ~workspace_id ~channel_id =
-  if String.equal source dashboard_label then Dashboard
-  else if String.equal source discord_label then
-    Discord { workspace_id; channel_id }
-  else if String.equal source slack_label then
-    Slack { workspace_id; channel_id }
-  else Gate { channel = source; channel_id }
-
 type surface_presence = { surface : t; alive : bool }
 
 type presence_failure =
@@ -35,7 +27,12 @@ type presence_snapshot =
   }
 
 let surface_of_connector ~channel ~channel_id =
-  of_source ~source:channel ~workspace_id:None ~channel_id:(Some channel_id)
+  if String.equal channel dashboard_label then Dashboard
+  else if String.equal channel discord_label then
+    Discord { workspace_id = None; channel_id = Some channel_id }
+  else if String.equal channel slack_label then
+    Slack { workspace_id = None; channel_id = Some channel_id }
+  else Gate { channel; channel_id = Some channel_id }
 
 let connected_surfaces_for_keeper ~keeper_name =
   let connector_surfaces, failures =

--- a/lib/gate/gate_surface.mli
+++ b/lib/gate/gate_surface.mli
@@ -2,10 +2,8 @@
 
     A surface is one lane a keeper can hear from or speak to: the
     dashboard, a bound Discord/Slack channel, or any other connector
-    speaking the generic gate protocol. The type round-trips to the
-    on-disk [source] labels written by {!Keeper_chat_store.append_turn}
-    producers ("dashboard" / "discord" / "slack" / connector channel
-    labels).
+    speaking the generic gate protocol. Presence is derived from the current
+    connector registry, not from persisted chat labels.
 
     RFC names this module [Surface]; the [Gate_] prefix follows the
     masc_gate convention ([(wrapped false)] puts modules in the global
@@ -18,20 +16,12 @@ type t =
   | Gate of { channel : string; channel_id : string option }
       (** Any other connector speaking the generic gate protocol;
           [channel] is the connector's registered label, verbatim.
-          [workspace_id]/[channel_id] are [option] because chat rows
-          persist only the [source] label today — a row-derived
-          surface knows its lane label but not always the lane id. *)
+          [workspace_id]/[channel_id] are [option] because a connector
+          registry may expose only the lane label. *)
 
 val label : t -> string
-(** Round-trips to today's on-disk [source] strings: ["dashboard"],
-    ["discord"], ["slack"], or the gate channel label verbatim. *)
-
-val of_source :
-  source:string -> workspace_id:string option -> channel_id:string option -> t
-(** Parse a persisted [source] label. Unknown labels map to
-    [Gate { channel = source; _ }] — the honest reading (every
-    non-builtin source IS a gate channel label), not a permissive
-    default. *)
+(** Current connector label: ["dashboard"], ["discord"], ["slack"], or the
+    generic gate channel label verbatim. *)
 
 (** {1 Presence (RFC-0223 P2)} *)
 

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -4,12 +4,13 @@
     Lines are append-only with timestamps.
 
     Line format:
-    {v {"role":"user","content":"hello","ts":1774000000.0} v}
+    {v {"id":"msg-...","role":"user","content":"hello","ts":1774000000.0} v}
 
     Tool-call lines (persisted between the user and assistant lines of a
     turn) carry the executed tool name and accumulated arguments:
-    {v {"role":"tool","content":"{\"path\":\"x\"}","ts":...,
-        "tool_call_id":"toolu_1","tool_call_name":"Read","source":"dashboard"} v}
+    {v {"id":"msg-...","role":"tool","content":"{\"path\":\"x\"}","ts":...,
+        "tool_call_id":"toolu_1","tool_call_name":"Read",
+        "surface":{"kind":"dashboard"}} v}
 
     Connector rows may additionally carry opaque route coordinates:
     [conversation_id] for channel/thread grouping and [external_message_id]
@@ -183,19 +184,14 @@ type chat_message = {
       (* R3: producer-assigned stable message id.  Minted once at append
          by [encode_line] (the sole writer) and read back verbatim, so the
          dashboard keys off a server identity instead of synthesising an
-         index-derived id at render.  Rows written before R3 carry no
-         persisted id and are given a deterministic one at the read
-         boundary ([legacy_message_id]); the field is therefore total. *)
+         index-derived id at render. Rows without a nonblank persisted id
+         are rejected at the read boundary. *)
   role : Role.t;
   content : string;
   ts : float option;
   attachments : attachment list option;
   tool_call_id : string option;
   tool_call_name : string option;
-  source : string option;
-      (* Legacy lane label.  Derived from [surface] at write since
-         RFC-0232 P5 (writers no longer pass label strings); read
-         verbatim from the wire so pre-P5 rows keep their label. *)
   surface : Surface_ref.t option;
       (* RFC-0232 P5: the typed surface, persisted as a structured
          [surface] field.  [None] on rows written before P5. *)
@@ -508,31 +504,12 @@ let mint_message_id ~ts =
   let n = Atomic.fetch_and_add message_id_counter 1 in
   Printf.sprintf "msg-%016.0f-%d" (ts *. 1_000_000.) n
 
-(* Rows written before R3 carry no persisted id.  Derive a stable one at
-   the read boundary from the row's timestamp and content so the dashboard
-   keys off a single deterministic id and never synthesises an
-   index-derived one that shifts when history pages are merged.  Two
-   byte-identical legacy rows collapse to the same id, which is acceptable:
-   they are indistinguishable and predate the per-row identity. *)
-let legacy_message_id ~ts ~content =
-  let ts_part =
-    match ts with
-    | Some t -> Printf.sprintf "%016.0f" (t *. 1_000_000.)
-    | None -> "nots"
-  in
-  Printf.sprintf "legacy-%s-%s" ts_part
-    (String.sub (Digest.to_hex (Digest.string content)) 0 12)
-
 let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?workspace_id
     ?speaker
     ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref
     ?stream_lifecycle ?delivery_key ?transcript_slot ()
     : string =
-  (* RFC-0232 P5: the label is a derivation of the typed surface — the
-     single site that turns a [Surface_ref.t] into the legacy [source]
-     string. *)
-  let source = Option.map Surface_ref.lane_label surface in
   let surface_field =
     match surface with
     | None -> []
@@ -603,7 +580,6 @@ let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_cal
     @ kind_field
     @ opt_string_field "tool_call_id" tool_call_id
     @ opt_string_field "tool_call_name" tool_call_name
-    @ opt_string_field "source" source
     @ surface_field
     @ opt_string_field "conversation_id" conversation_id
     @ opt_string_field "external_message_id" external_message_id
@@ -1353,7 +1329,6 @@ let parse_line ~file_path (line : string) : chat_message option =
     in
     let tool_call_id = opt_string "tool_call_id" in
     let tool_call_name = opt_string "tool_call_name" in
-    let source = opt_string "source" in
     let surface =
       match Json_util.assoc_member_opt "surface" json with
       | None -> None
@@ -1361,8 +1336,8 @@ let parse_line ~file_path (line : string) : chat_message option =
           match Surface_ref.of_json surface_json with
           | Ok s -> Some s
           | Error detail ->
-              (* Unknown/invalid surface payload: surface it, keep the
-                 row (the label in [source] still renders). *)
+              (* Unknown/invalid surface payload: surface it and keep the
+                 row as unscoped chat content. *)
               report_persistence_read_drop
                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
                 ~path:file_path
@@ -1593,17 +1568,19 @@ let parse_line ~file_path (line : string) : chat_message option =
             ~detail:"tool chat row missing non-empty tool_call_name";
           None
       | Some role ->
-          let id =
-            match opt_string "id" with
-            | Some persisted -> persisted
-            | None -> legacy_message_id ~ts ~content
-          in
-          Some
-            { id; role; content; ts; attachments; tool_call_id; tool_call_name;
-              source; surface; conversation_id; external_message_id;
-              workspace_id; speaker;
-              audio; blocks; mentions; kind; turn_ref; stream_lifecycle;
-              delivery_key }
+          (match opt_string "id" with
+           | None ->
+               report_persistence_read_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~path:file_path
+                 ~detail:"chat row missing nonblank id";
+               None
+           | Some id ->
+               Some
+                 { id; role; content; ts; attachments; tool_call_id;
+                   tool_call_name; surface; conversation_id;
+                   external_message_id; workspace_id; speaker; audio; blocks;
+                   mentions; kind; turn_ref; stream_lifecycle; delivery_key })
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -1942,13 +1919,11 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                      [ ("kind", `String (Row_kind.to_label m.kind)) ])
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
-              @ opt_string_field "source" m.source
-              (* RFC-0232 P5: re-emit the structured surface so a history
-                 reload restores the connector deep-link, not only the
-                 derived [source] lane label. [encode_line] persists it with
-                 the same [Surface_ref.to_json] and [load] decodes it back
-                 into [m.surface]; this read-serve site had dropped it, so
-                 [surfaceLink] in the dashboard rendered nothing on reload. *)
+              @ opt_string_field
+                  "source"
+                  (Option.map Surface_ref.lane_label m.surface)
+              (* Re-emit the typed surface for connector deep-links. [source]
+                 above is only its response projection for compact labels. *)
               @ (match m.surface with
                  | None -> []
                  | Some s -> [ ("surface", Surface_ref.to_json s) ])

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -4,13 +4,13 @@
     Each keeper owns an append-only file at
     [<base_dir>/.masc/keeper_chat/<sanitized-name>.jsonl]. Lines are
     JSON objects of the form
-    {v {"role":"user","content":"hello","ts":1774000000.0} v}
+    {v {"id":"msg-...","role":"user","content":"hello","ts":1774000000.0} v}
 
     Tool-call lines persisted between a turn's user and assistant lines
     additionally carry [tool_call_id] / [tool_call_name]; every line of
-    a turn may carry the originating connector in [source]
-    (e.g. "dashboard", "discord", "slack", "agent"). Connector rows may
-    also carry [conversation_id] / [external_message_id], opaque route
+    a turn may carry the originating connector as a typed [surface].
+    Connector rows may also carry [conversation_id] /
+    [external_message_id], opaque route
     coordinates used by dashboards to group platform channels/threads
     without giving this store platform-specific knowledge.
 
@@ -142,19 +142,14 @@ type chat_message = {
       (** R3: producer-assigned stable message id, minted once at append by
           the sole writer ({!encode_line}) and read back verbatim, so the
           dashboard keys off a server identity rather than synthesising an
-          index-derived id at render.  Rows written before R3 carry no
-          persisted id and are given a deterministic one at the read
-          boundary, so the field is total. *)
+          index-derived id at render. Rows without a nonblank persisted id
+          are rejected at the read boundary. *)
   role : Role.t;
   content : string;
   ts : float option;
   attachments : attachment list option;
   tool_call_id : string option;
   tool_call_name : string option;
-  source : string option;
-      (** Legacy lane label.  Since RFC-0232 P5 it is derived from
-          [surface] at write ({!Surface_ref.lane_label}); pre-P5 rows
-          carry their original label verbatim. *)
   surface : Surface_ref.t option;
       (** The typed surface (RFC-0232 §3.6).  [None] on rows written
           before P5 and on rows whose persisted surface payload fails
@@ -219,7 +214,7 @@ type chat_message = {
 (** {1 I/O} *)
 
 (** [append_turn ~base_dir ~keeper_name ~user_content ~user_attachments
-    ?tool_calls ?source ?conversation_id ?external_message_id ?speaker
+    ?tool_calls ?surface ?conversation_id ?external_message_id ?speaker
     ~assistant_content ()] appends one
     completed turn as consecutive lines — user, one line per tool call,
     assistant — sharing a single timestamp, in one write. [speaker]
@@ -351,7 +346,7 @@ val append_tool_calls_once :
   unit ->
   (append_once_result, string) result
 
-(** [append_assistant_message ~base_dir ~keeper_name ~content ?source
+(** [append_assistant_message ~base_dir ~keeper_name ~content ?surface
     ?conversation_id ()]
     appends one keeper-initiated assistant line with no paired user
     turn (RFC-0223 P4 [keeper_surface_post]). Same failure policy as
@@ -441,10 +436,12 @@ val load_page :
 (** {1 Serialisation} *)
 
 (** JSON array of messages. Entries without a timestamp omit the
-    [ts] field; [tool_call_id] / [tool_call_name] / [source] /
+    [ts] field; [tool_call_id] / [tool_call_name] /
     [conversation_id] / [external_message_id] / [workspace_id] /
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
-    when present. [delivery_key] appears only on rows persisted by the
+    when present. [source] is a response-only label derived from the typed
+    [surface], never a second persisted identity. [delivery_key] appears only
+    on rows persisted by the
     idempotent append-once paths, verbatim as the typed delivery
     identity object. When [base_dir] is supplied, the history endpoint
     marks audio clips as [expired] when the underlying MP3 file is

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -47,7 +47,7 @@ let message_json (m : Store.chat_message) : Yojson.Safe.t =
        ("content", `String m.content) ]
     @ kind_fields
     @ opt_float_field "ts" m.ts
-    @ opt_string_field "source" m.source
+    @ opt_string_field "source" (Option.map Surface_ref.lane_label m.surface)
     @ opt_string_field "conversation_id" m.conversation_id
     @ opt_string_field "external_message_id" m.external_message_id
     @ opt_string_field "tool_call_name" m.tool_call_name
@@ -187,8 +187,11 @@ let respond ~surface ~limit ~has_more ~notes
     let lane =
       List.filter
         (fun (m : Store.chat_message) ->
-          match m.source with
-          | Some s -> String.equal (String.trim s) surface
+          match m.surface with
+          | Some typed_surface ->
+              String.equal
+                (Surface_ref.lane_label typed_surface |> String.trim)
+                surface
           | None -> false)
         messages
     in

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -92,8 +92,9 @@ let speaker_display (m : Keeper_chat_store.chat_message) : string =
   match from_speaker with
   | Some name when String.trim name <> "" -> name
   | _ ->
-    (match m.source with
-     | Some src when String.trim src <> "" -> src
+    (match m.surface with
+     | Some surface when String.trim (Surface_ref.lane_label surface) <> "" ->
+         Surface_ref.lane_label surface
      | _ -> "someone")
 ;;
 

--- a/lib/keeper_chat_timeline_source.ml
+++ b/lib/keeper_chat_timeline_source.ml
@@ -28,7 +28,8 @@ let lines_for ~base_dir ~keeper_name : Tool_agent_timeline.chat_line list =
                  Tool_agent_timeline.cl_role = Keeper_chat_store.Role.to_label role;
                  cl_content = m.content;
                  cl_ts = ts;
-                 cl_connector = m.source;
+                 cl_connector =
+                   Option.map Surface_ref.lane_label m.surface;
                  cl_conversation_id = m.conversation_id;
                })
 

--- a/test/test_gate_surface.ml
+++ b/test/test_gate_surface.ml
@@ -1,7 +1,6 @@
 (* RFC-0223 P2 — Gate_surface unit tests.
 
-   - [label]/[of_source] round-trip over known labels and the
-     unknown-label -> [Gate] case (RFC-0223 §6).
+   - [label] projects the current typed presence variants.
    - [connected_surfaces_for_keeper] presence derivation against a
      temp Discord binding store: dashboard always present, bound
      channel listed, liveness false while no gateway runs.
@@ -36,48 +35,21 @@ let presence_pp fmt (p : Surface.surface_presence) =
 let presence : Surface.surface_presence testable = testable presence_pp ( = )
 
 (* ---------------------------------------------------------------- *)
-(* label / of_source round-trip                                     *)
+(* label projection                                                 *)
 (* ---------------------------------------------------------------- *)
 
-let of_source_plain source =
-  Surface.of_source ~source ~workspace_id:None ~channel_id:None
-
-let test_builtin_labels_parse_to_builtin_variants () =
-  check surface "dashboard" Surface.Dashboard (of_source_plain "dashboard");
-  check surface "discord"
-    (Surface.Discord { workspace_id = None; channel_id = None })
-    (of_source_plain "discord");
-  check surface "slack"
-    (Surface.Slack { workspace_id = None; channel_id = None })
-    (of_source_plain "slack")
-
-let test_unknown_label_maps_to_gate_not_a_builtin () =
-  (* Honest reading: every non-builtin source IS a gate channel
-     label. "agent" (keeper's own output) and connector labels both
-     land here. *)
+let test_current_variant_labels () =
+  let cases =
+    [ Surface.Dashboard, "dashboard"
+    ; Surface.Discord { workspace_id = None; channel_id = Some "d1" }, "discord"
+    ; Surface.Slack { workspace_id = None; channel_id = Some "s1" }, "slack"
+    ; Surface.Gate { channel = "openclaw"; channel_id = Some "g1" }, "openclaw"
+    ]
+  in
   List.iter
-    (fun source ->
-      check surface source
-        (Surface.Gate { channel = source; channel_id = None })
-        (of_source_plain source))
-    [ "openclaw"; "agent"; "imessage"; "telegram" ]
-
-let test_label_round_trips_every_source () =
-  List.iter
-    (fun source ->
-      check string source source (Surface.label (of_source_plain source)))
-    [ "dashboard"; "discord"; "slack"; "openclaw"; "agent"; "imessage" ]
-
-let test_of_source_carries_lane_ids () =
-  check surface "discord lane"
-    (Surface.Discord
-       { workspace_id = Some "guild-1"; channel_id = Some "chan-1" })
-    (Surface.of_source ~source:"discord" ~workspace_id:(Some "guild-1")
-       ~channel_id:(Some "chan-1"));
-  check surface "gate lane"
-    (Surface.Gate { channel = "openclaw"; channel_id = Some "room-9" })
-    (Surface.of_source ~source:"openclaw" ~workspace_id:None
-       ~channel_id:(Some "room-9"))
+    (fun (surface, expected) ->
+      check string expected expected (Surface.label surface))
+    cases
 
 (* ---------------------------------------------------------------- *)
 (* connected_surfaces_for_keeper                                    *)
@@ -171,17 +143,8 @@ let test_discord_not_connected_without_run_loop () =
 let () =
   run "gate_surface"
     [
-      ( "of_source/label",
-        [
-          test_case "builtin labels parse to builtin variants" `Quick
-            test_builtin_labels_parse_to_builtin_variants;
-          test_case "unknown label maps to Gate" `Quick
-            test_unknown_label_maps_to_gate_not_a_builtin;
-          test_case "label round-trips every source" `Quick
-            test_label_round_trips_every_source;
-          test_case "of_source carries lane ids" `Quick
-            test_of_source_carries_lane_ids;
-        ] );
+      ( "label",
+        [ test_case "current variant labels" `Quick test_current_variant_labels ] );
       ( "presence",
         [
           test_case "dashboard always present" `Quick

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -102,8 +102,8 @@ let test_load_records_malformed_row_drops () =
            [
              Yojson.Safe.to_string
                (`Assoc
-                  [
-                    ("role", `String "user");
+                  [ ("id", `String "valid-user")
+                  ; ("role", `String "user");
                     ("content", `String "hello");
                     ("ts", `Float 1.0);
                   ]);
@@ -111,8 +111,8 @@ let test_load_records_malformed_row_drops () =
              Yojson.Safe.to_string (`Assoc [("role", `String "assistant")]);
              Yojson.Safe.to_string
                (`Assoc
-                  [
-                    ("role", `String "assistant");
+                  [ ("id", `String "valid-assistant")
+                  ; ("role", `String "assistant");
                     ("content", `String "world");
                     ("ts", `Float 2.0);
                   ]);
@@ -172,8 +172,9 @@ let test_append_turn_roundtrip () =
       Alcotest.(check (option string)) "empty tool id gets positional fallback"
         (Some "tc-1") tool2.tool_call_id;
       Alcotest.(check string) "empty args normalised" "{}" tool2.content;
-      Alcotest.(check (option string)) "source persisted on every line"
-        (Some "dashboard") asst.source;
+      Alcotest.(check (option string)) "surface label derives on every line"
+        (Some "dashboard")
+        (Option.map Masc.Surface_ref.lane_label asst.surface);
       Alcotest.(check (option string)) "assistant has no tool id"
         None asst.tool_call_id)
 
@@ -223,23 +224,18 @@ let test_structured_only_assistant_row_survives_reload () =
         Alcotest.failf "expected one structured-only row, got %d"
           (List.length messages))
 
-let test_legacy_lines_parse_without_new_fields () =
-  let base_dir = temp_base_path "keeper-chat-store-legacy" in
+let test_missing_id_rows_are_rejected () =
+  let base_dir = temp_base_path "keeper-chat-store-missing-id" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
-      let keeper_name = "keeper-chat-legacy" in
+      let keeper_name = "keeper-chat-missing-id" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
         ({|{"role":"user","content":"hello","ts":1.0}|} ^ "\n"
         ^ {|{"role":"assistant","content":"world","ts":1.0}|} ^ "\n");
-      match K.load ~base_dir ~keeper_name with
-      | [ user; assistant ] ->
-          Alcotest.(check (option string)) "legacy user has no source" None user.source;
-          Alcotest.(check (option string)) "legacy assistant has no tool id"
-            None assistant.tool_call_id
-      | messages ->
-          Alcotest.failf "expected 2 messages, got %d" (List.length messages))
+      Alcotest.(check int) "rows without current id are dropped" 0
+        (K.load ~base_dir ~keeper_name |> List.length))
 
 (* R3: every persisted row carries a producer-assigned id that is
    non-empty, unique within a turn, and stable across reloads. *)
@@ -263,34 +259,29 @@ let test_message_id_minted_unique_and_stable () =
         (List.length (List.sort_uniq String.compare ids));
       Alcotest.(check (list string)) "ids stable across reloads" ids (ids_of ()))
 
-(* R3: rows written before the id field load with a deterministic id
-   derived at the read boundary, so it is stable across reloads and two
-   distinct rows get distinct ids — no index-derived synthesis. *)
-let test_legacy_row_gets_deterministic_id () =
-  let base_dir = temp_base_path "keeper-chat-store-legacy-id" in
+let test_source_field_is_not_a_surface_fallback () =
+  let base_dir = temp_base_path "keeper-chat-store-source-hard-cut" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
-      let keeper_name = "keeper-chat-legacy-id" in
+      let keeper_name = "keeper-chat-source-hard-cut" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"user","content":"hello","ts":1.0}|} ^ "\n"
-        ^ {|{"role":"assistant","content":"world","ts":1.0}|} ^ "\n");
-      let ids_of () =
-        List.map (fun (m : K.chat_message) -> m.id) (K.load ~base_dir ~keeper_name)
-      in
-      let first = ids_of () in
-      Alcotest.(check int) "two legacy rows loaded" 2 (List.length first);
-      List.iter
-        (fun id ->
-          Alcotest.(check bool) "legacy id non-empty" true (String.length id > 0))
-        first;
-      Alcotest.(check (list string)) "legacy ids deterministic across reloads"
-        first (ids_of ());
-      match first with
-      | [ a; b ] ->
-          Alcotest.(check bool) "distinct legacy rows get distinct ids" true (a <> b)
-      | _ -> Alcotest.fail "expected 2 legacy ids")
+        ({|{"id":"row-current","role":"user","content":"hello","ts":1.0,"source":"discord"}|}
+        ^ "\n");
+      match K.load ~base_dir ~keeper_name with
+      | [ row ] ->
+          Alcotest.(check (option string))
+            "retired source does not synthesize typed surface"
+            None
+            (Option.map Masc.Surface_ref.lane_label row.surface);
+          let json = K.to_json_array [ row ] in
+          Alcotest.(check bool)
+            "retired source is not re-emitted"
+            true
+            Yojson.Safe.Util.(json |> index 0 |> member "source" = `Null)
+      | rows ->
+          Alcotest.failf "expected one current-id row, got %d" (List.length rows))
 
 (* R3: the /chat/history payload surfaces the id so the dashboard keys off
    it instead of synthesising one. *)
@@ -494,7 +485,7 @@ let test_append_turn_redacts_projected_secrets () =
       Alcotest.(check bool) "redaction marker present" true
         (contains_substring rendered "[REDACTED]"))
 
-let test_load_redacts_legacy_raw_secret_rows () =
+let test_load_redacts_raw_persisted_secret_rows () =
   let base_dir = temp_base_path "keeper-chat-store-read-redact" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
@@ -502,19 +493,20 @@ let test_load_redacts_legacy_raw_secret_rows () =
       with_env "MASC_SECRET_DIR" "" @@ fun () ->
       let keeper_name = "keeper-chat-read-redact" in
       let root = secret_root_default ~base_dir ~keeper_name in
-      let secret = "legacy.secret!" in
+      let secret = "persisted.secret!" in
       write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
         (Yojson.Safe.to_string
            (`Assoc
-              [ ("role", `String "assistant");
+              [ ("id", `String "raw-secret-row")
+              ; ("role", `String "assistant");
                 ("content", `String ("old row " ^ secret));
                 ("ts", `Float 1.0) ])
          ^ "\n");
       match K.load ~base_dir ~keeper_name with
       | [ msg ] ->
-          Alcotest.(check bool) "legacy raw value hidden on read" false
+          Alcotest.(check bool) "raw persisted value hidden on read" false
             (contains_substring msg.K.content secret);
           Alcotest.(check bool) "marker present on read" true
             (contains_substring msg.K.content "[REDACTED]")
@@ -588,8 +580,9 @@ let test_append_user_message_roundtrip () =
           Alcotest.(check string) "lone user line first" "user" (K.Role.to_label user.K.role);
           Alcotest.(check string) "content"
             "two humans chatting, no mention" user.K.content;
-          Alcotest.(check (option string)) "source"
-            (Some "discord") user.K.source;
+          Alcotest.(check (option string)) "surface-derived label"
+            (Some "discord")
+            (Option.map Masc.Surface_ref.lane_label user.K.surface);
           Alcotest.(check (option string)) "conversation id"
             (Some "discord:guild-1:channel:chan-7") user.K.conversation_id;
           Alcotest.(check (option string)) "external message id"
@@ -628,10 +621,8 @@ let test_append_user_message_roundtrip () =
               Alcotest.(check bool) "json assistant omits inbound message id" true
                 Yojson.Safe.Util.(
                   assistant_json |> member "external_message_id" = `Null);
-              (* RFC-0232 P5: the structured surface must survive the
-                 read-serve emitter, not only the derived [source] label, so
-                 the dashboard rebuilds the connector deep-link on a history
-                 reload instead of dropping it. *)
+              (* The typed surface must survive the read-serve emitter so the
+                 dashboard rebuilds the connector deep-link on reload. *)
               let user_surface = Yojson.Safe.Util.member "surface" user_json in
               Alcotest.(check bool) "json user row carries structured surface"
                 true (user_surface <> `Null);
@@ -686,7 +677,7 @@ let test_unknown_speaker_authority_reported_not_guessed () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"role":"user","content":"hi","ts":1.0,"speaker_id":"x","speaker_authority":"admin"}|}
+        ({|{"id":"unknown-authority","role":"user","content":"hi","ts":1.0,"speaker_id":"x","speaker_authority":"admin"}|}
         ^ "\n");
       (match K.load ~base_dir ~keeper_name with
        | [ user ] ->
@@ -711,9 +702,9 @@ let test_unknown_role_row_dropped () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"role":"user","content":"hi","ts":1.0}|} ^ "\n"
-        ^ {|{"role":"system","content":"injected","ts":2.0}|} ^ "\n"
-        ^ {|{"role":"assistant","content":"done","ts":3.0}|} ^ "\n");
+        ({|{"id":"role-user","role":"user","content":"hi","ts":1.0}|} ^ "\n"
+        ^ {|{"id":"role-system","role":"system","content":"injected","ts":2.0}|} ^ "\n"
+        ^ {|{"id":"role-assistant","role":"assistant","content":"done","ts":3.0}|} ^ "\n");
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check (list string)) "unknown role row dropped"
         [ "user"; "assistant" ] (roles messages);
@@ -731,9 +722,9 @@ let test_tool_row_missing_name_dropped () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"role":"user","content":"hi","ts":1.0}|} ^ "\n"
-        ^ {|{"role":"tool","content":"{}","ts":1.0,"tool_call_id":"toolu_9"}|} ^ "\n"
-        ^ {|{"role":"assistant","content":"done","ts":1.0}|} ^ "\n");
+        ({|{"id":"tool-name-user","role":"user","content":"hi","ts":1.0}|} ^ "\n"
+        ^ {|{"id":"tool-name-missing","role":"tool","content":"{}","ts":1.0,"tool_call_id":"toolu_9"}|} ^ "\n"
+        ^ {|{"id":"tool-name-assistant","role":"assistant","content":"done","ts":1.0}|} ^ "\n");
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check (list string)) "nameless tool row dropped"
         [ "user"; "assistant" ] (roles messages);
@@ -780,10 +771,10 @@ let test_orphan_leading_tool_lines_trimmed () =
       let keeper_name = "keeper-chat-orphan" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"tool","content":"{}","ts":1.0,"tool_call_id":"t0","tool_call_name":"Read"}|}
-         ^ "\n"
-        ^ {|{"role":"user","content":"hi","ts":2.0}|} ^ "\n"
-        ^ {|{"role":"assistant","content":"yo","ts":2.0}|} ^ "\n");
+        ({|{"id":"orphan-tool","role":"tool","content":"{}","ts":1.0,"tool_call_id":"t0","tool_call_name":"Read"}|}
+        ^ "\n"
+        ^ {|{"id":"orphan-user","role":"user","content":"hi","ts":2.0}|} ^ "\n"
+        ^ {|{"id":"orphan-assistant","role":"assistant","content":"yo","ts":2.0}|} ^ "\n");
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check (list string)) "leading orphan tool trimmed"
         [ "user"; "assistant" ] (roles messages))
@@ -878,7 +869,8 @@ let test_tail_bounded_load_matches_full_scan_window () =
         let line =
           Yojson.Safe.to_string
             (`Assoc
-               [ ("role", `String role);
+               [ ("id", `String (Printf.sprintf "tail-%04d" i))
+               ; ("role", `String role);
                  ("content", `String (Printf.sprintf "msg-%04d %s" i padding));
                  ("ts", `Float (float_of_int i));
                ])
@@ -913,8 +905,8 @@ let write_numbered_lane ~path ~total ~pad_bytes =
     Buffer.add_string buf
       (Yojson.Safe.to_string
          (`Assoc
-            [
-              ("role", `String (if i mod 2 = 1 then "user" else "assistant"));
+            [ ("id", `String (Printf.sprintf "page-%04d" i))
+            ; ("role", `String (if i mod 2 = 1 then "user" else "assistant"));
               ("content", `String (Printf.sprintf "msg-%04d %s" i padding));
               ("ts", `Float (float_of_int i));
             ]));
@@ -1038,7 +1030,8 @@ let test_unknown_kind_reported_reads_utterance () =
       let before = drop_value invalid_payload in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"assistant","content":"hi","ts":1.0,"kind":"weird"}|} ^ "\n");
+        ({|{"id":"unknown-kind","role":"assistant","content":"hi","ts":1.0,"kind":"weird"}|}
+        ^ "\n");
       match K.load ~base_dir ~keeper_name with
       | [ asst ] ->
           Alcotest.(check bool)
@@ -1108,7 +1101,7 @@ let test_audio_clip_expired_persists_roundtrip () =
       let keeper_name = "keeper-chat-audio-expired-rt" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"assistant","content":"hello","ts":1.0,"audio":{|}
+        ({|{"id":"audio-redact","role":"assistant","content":"hello","ts":1.0,"audio":{|}
         ^ {|"token":"voice-token-rt","mime":"audio/mpeg","message_text":"hello","expired":true}|}
         ^ "}\n");
       match K.load ~base_dir ~keeper_name with
@@ -1247,7 +1240,7 @@ let test_blocks_roundtrip_and_drop_malformed () =
       let keeper_name = "keeper-chat-blocks-rt" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"assistant","content":"hello","ts":1.0,"blocks":[{|}
+        ({|{"id":"block-redact","role":"assistant","content":"hello","ts":1.0,"blocks":[{|}
         ^ {|"t":"p","html":"hello"},{"t":"image","src":"https://x.com/a.png","cap":"a"},{|}
         ^ {|"t":"link","url":"https://x.com","title":"x.com","meta":"x.com"},{|}
         ^ {|"t":"unknown","x":1}]}|}
@@ -1441,20 +1434,20 @@ let test_append_turn_preserves_fusion_lookup_ids () =
 (* Read-boundary redaction: rows written before this PR (or by any path that
    bypasses the write-boundary redactors) must still have caller-supplied
    blocks and audio scrubbed before they are served by [load] / [to_json_array]. *)
-let test_load_redacts_legacy_raw_blocks_and_audio () =
-  let base_dir = temp_base_path "keeper-chat-store-legacy-blocks-audio-redact" in
+let test_load_redacts_raw_persisted_blocks_and_audio () =
+  let base_dir = temp_base_path "keeper-chat-store-raw-blocks-audio-redact" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
       with_env "MASC_SECRET_DIR" "" @@ fun () ->
-      let keeper_name = "keeper-chat-legacy-blocks-audio-redact" in
+      let keeper_name = "keeper-chat-raw-blocks-audio-redact" in
       let root = secret_root_default ~base_dir ~keeper_name in
-      let secret = "legacy-blocks-audio.secret!" in
+      let secret = "raw-blocks-audio.secret!" in
       write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
       let path = chat_path ~base_dir ~keeper_name in
       let audio_json =
         `Assoc
-          [ ("token", `String "voice-token-legacy")
+          [ ("token", `String "voice-token-raw")
           ; ("mime", `String "audio/mpeg")
           ; ("message_text", `String ("caption " ^ secret))
           ; ("audio_url", `String ("https://cdn.example.com/audio?sig=" ^ secret))
@@ -1468,7 +1461,8 @@ let test_load_redacts_legacy_raw_blocks_and_audio () =
       in
       let row =
         `Assoc
-          [ ("role", `String "assistant")
+          [ ("id", `String "raw-rich-secret-row")
+          ; ("role", `String "assistant")
           ; ("content", `String ("content " ^ secret))
           ; ("ts", `Float 1.0)
           ; ("audio", audio_json)
@@ -1479,28 +1473,28 @@ let test_load_redacts_legacy_raw_blocks_and_audio () =
       let messages = K.load ~base_dir ~keeper_name in
       match messages with
       | [ msg ] ->
-        Alcotest.(check bool) "legacy content redacted on load" false
+        Alcotest.(check bool) "raw content redacted on load" false
           (contains_substring msg.K.content secret);
         (match msg.K.audio with
          | Some audio ->
-           Alcotest.(check bool) "legacy audio message_text redacted on load" false
+           Alcotest.(check bool) "raw audio message_text redacted on load" false
              (contains_substring audio.message_text secret);
            let audio_url_contains_secret =
              match audio.audio_url with
              | Some url -> contains_substring url secret
              | None -> false
            in
-           Alcotest.(check bool) "legacy audio audio_url redacted on load" false
+           Alcotest.(check bool) "raw audio audio_url redacted on load" false
              audio_url_contains_secret
-         | None -> Alcotest.fail "legacy audio missing");
-        Alcotest.(check bool) "legacy blocks redacted on load" false
+         | None -> Alcotest.fail "raw audio missing");
+        Alcotest.(check bool) "raw blocks redacted on load" false
           (match msg.K.blocks with
            | Some blocks ->
              contains_substring (Yojson.Safe.to_string (B.blocks_to_yojson blocks)) secret
            | None -> true);
         let json = K.to_json_array messages in
         let s = Yojson.Safe.to_string json in
-        Alcotest.(check bool) "to_json_array hides legacy secret" false
+        Alcotest.(check bool) "to_json_array hides raw persisted secret" false
           (contains_substring s secret);
         Alcotest.(check bool) "redaction marker present in served payload" true
           (contains_substring s "[REDACTED]")
@@ -1670,12 +1664,12 @@ let stream_contract_of row =
   member "stream_contract" row
 
 let test_to_json_array_stream_contract_without_turn_ref () =
-  let base_dir = temp_base_path "keeper-chat-store-stream-contract-legacy" in
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-unjoined" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
-      let keeper_name = "keeper-chat-stream-contract-legacy" in
-      K.append_user_message ~base_dir ~keeper_name ~content:"legacy hi" ();
+      let keeper_name = "keeper-chat-stream-contract-unjoined" in
+      K.append_user_message ~base_dir ~keeper_name ~content:"unjoined hi" ();
       let rows =
         Yojson.Safe.Util.to_list
           (K.to_json_array (K.load ~base_dir ~keeper_name))
@@ -1869,7 +1863,7 @@ let test_malformed_stream_lifecycle_reads_none () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"role":"assistant","content":"x","ts":1.0,"turn_ref":"trace-life#7","stream_lifecycle":["RUN_STARTED","NOT_A_REAL_EVENT"]}|}
+        ({|{"id":"bad-lifecycle","role":"assistant","content":"x","ts":1.0,"turn_ref":"trace-life#7","stream_lifecycle":["RUN_STARTED","NOT_A_REAL_EVENT"]}|}
         ^ "\n");
       (match K.load ~base_dir ~keeper_name with
        | [ m ] ->
@@ -1893,7 +1887,7 @@ let test_turn_ref_malformed_reads_none () =
       let keeper_name = "keeper-chat-turnref-bad" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"assistant","content":"x","ts":1.0,"turn_ref":"no-separator"}|}
+        ({|{"id":"bad-turn-ref","role":"assistant","content":"x","ts":1.0,"turn_ref":"no-separator"}|}
         ^ "\n");
       match K.load ~base_dir ~keeper_name with
       | [ m ] ->
@@ -2007,7 +2001,7 @@ let test_delivery_key_malformed_reads_none () =
       in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"role":"user","content":"x","ts":1.0,"delivery_key":{"kind":"not_a_kind","request_id":"kmsg-1"}}|}
+        ({|{"id":"bad-delivery-key","role":"user","content":"x","ts":1.0,"delivery_key":{"kind":"not_a_kind","request_id":"kmsg-1"}}|}
         ^ "\n");
       (match K.load ~base_dir ~keeper_name with
        | [ m ] ->
@@ -2127,8 +2121,8 @@ let () =
             test_append_turn_redacts_all_supplied_block_strings;
           Alcotest.test_case "fusion lookup ids survive redaction" `Quick
             test_append_turn_preserves_fusion_lookup_ids;
-          Alcotest.test_case "legacy raw blocks and audio redacted on load" `Quick
-            test_load_redacts_legacy_raw_blocks_and_audio;
+          Alcotest.test_case "raw persisted blocks and audio redacted on load"
+            `Quick test_load_redacts_raw_persisted_blocks_and_audio;
           Alcotest.test_case "assistant message audio redacted on append" `Quick
             test_append_assistant_message_redacts_audio;
           Alcotest.test_case "assistant history appends trace block" `Quick
@@ -2172,12 +2166,12 @@ let () =
             test_tool_only_continuations_do_not_fabricate_assistant_rows;
           Alcotest.test_case "structured-only assistant rows survive reload"
             `Quick test_structured_only_assistant_row_survives_reload;
-          Alcotest.test_case "legacy lines parse" `Quick
-            test_legacy_lines_parse_without_new_fields;
+          Alcotest.test_case "missing-id rows rejected" `Quick
+            test_missing_id_rows_are_rejected;
           Alcotest.test_case "message id minted unique and stable (R3)" `Quick
             test_message_id_minted_unique_and_stable;
-          Alcotest.test_case "legacy row gets deterministic id (R3)" `Quick
-            test_legacy_row_gets_deterministic_id;
+          Alcotest.test_case "source field is not a surface fallback" `Quick
+            test_source_field_is_not_a_surface_fallback;
           Alcotest.test_case "chat_path size grows on append (cache key)" `Quick
             test_chat_path_size_grows_on_append;
           Alcotest.test_case "to_json_array exposes id (R3)" `Quick
@@ -2192,8 +2186,8 @@ let () =
             test_direct_owner_context_excludes_connector_turns;
           Alcotest.test_case "append_turn redacts projected secrets" `Quick
             test_append_turn_redacts_projected_secrets;
-          Alcotest.test_case "load redacts legacy raw secret rows" `Quick
-            test_load_redacts_legacy_raw_secret_rows;
+          Alcotest.test_case "load redacts raw persisted secret rows" `Quick
+            test_load_redacts_raw_persisted_secret_rows;
           Alcotest.test_case "window counts primaries only" `Quick
             test_window_keeps_tool_lines_of_retained_turns;
           Alcotest.test_case "orphan leading tool lines trimmed" `Quick

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -43,7 +43,7 @@ let test_empty_targets () =
        (Lane.mention_ids_of_content "@alice"))
 ;;
 
-let msg ~role ?(id = "test-msg") ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
+let msg ~role ?(id = "test-msg") ?(ts = Some 1.0) ?(surface = None) ?(speaker = None)
     ?(audio = None)
     ?(kind = Store.Row_kind.Utterance) ?(turn_ref = None) content
   : Store.chat_message
@@ -55,8 +55,7 @@ let msg ~role ?(id = "test-msg") ?(ts = Some 1.0) ?(source = None) ?(speaker = N
   ; attachments = None
   ; tool_call_id = None
   ; tool_call_name = None
-  ; source
-  ; surface = None
+  ; surface
   ; conversation_id = None
   ; external_message_id = None
   ; workspace_id = None
@@ -206,7 +205,6 @@ let tool_line : Store.chat_message =
   ; attachments = None
   ; tool_call_id = Some "tc-0"
   ; tool_call_name = Some "Read"
-  ; source = None
   ; surface = None
   ; conversation_id = None
   ; external_message_id = None

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -156,7 +156,7 @@ let with_temp_base_dir f =
         (try Sys.readdir keeper_chat with Sys_error _ -> [||]))
     (fun () -> f dir)
 
-let test_assistant_message_persists_with_source () =
+let test_assistant_message_persists_with_typed_surface () =
   with_temp_base_dir (fun base_dir ->
       Store.append_assistant_message ~base_dir ~keeper_name:"post-keeper"
         ~content:"keeper-initiated hello"
@@ -174,7 +174,10 @@ let test_assistant_message_persists_with_source () =
       let m = List.hd messages in
       check string "role" "assistant" (Store.Role.to_label m.Store.role);
       check string "content" "keeper-initiated hello" m.Store.content;
-      check (option string) "source" (Some "discord") m.Store.source;
+      check (option string)
+        "surface-derived label"
+        (Some "discord")
+        (Option.map Masc.Surface_ref.lane_label m.Store.surface);
       check bool "no speaker on keeper output" true (m.Store.speaker = None))
 
 let () =
@@ -212,7 +215,7 @@ let () =
         ] );
       ( "assistant append",
         [
-          test_case "persists assistant line with source" `Quick
-            test_assistant_message_persists_with_source;
+          test_case "persists assistant line with typed surface" `Quick
+            test_assistant_message_persists_with_typed_surface;
         ] );
     ]

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -10,7 +10,12 @@ open Alcotest
 module Store = Masc.Keeper_chat_store
 module SR = Masc.Keeper_surface_read
 
-let msg ?ts ?source ?speaker ~role content : Store.chat_message =
+let msg ?ts ?lane ?speaker ~role content : Store.chat_message =
+  let surface =
+    Option.map
+      (fun label -> Masc.Surface_ref.Gate { label; address = [] })
+      lane
+  in
   {
     id = "test-msg";
     role;
@@ -19,8 +24,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     attachments = None;
     tool_call_id = None;
     tool_call_name = None;
-    source;
-    surface = None;
+    surface;
     conversation_id = None;
     external_message_id = None;
     workspace_id = None;
@@ -49,21 +53,21 @@ let to_string_j json = Yojson.Safe.Util.to_string json
 
 let discord_fixture : Store.chat_message list =
   [
-    msg ~ts:1.0 ~source:"dashboard" ~role:Store.Role.User "hello from owner";
-    msg ~ts:2.0 ~source:"discord"
+    msg ~ts:1.0 ~lane:"dashboard" ~role:Store.Role.User "hello from owner";
+    msg ~ts:2.0 ~lane:"discord"
       ~speaker:(external_speaker ~name:"minsu_old" "98791450001")
       ~role:Store.Role.User "first discord message";
-    msg ~ts:2.5 ~source:"discord" ~role:Store.Role.Assistant "keeper reply";
-    msg ~ts:3.0 ~source:"discord"
+    msg ~ts:2.5 ~lane:"discord" ~role:Store.Role.Assistant "keeper reply";
+    msg ~ts:3.0 ~lane:"discord"
       ~speaker:(external_speaker ~name:"Minsu" "98791450001")
       ~role:Store.Role.User "second discord message";
-    msg ~ts:4.0 ~source:"discord"
+    msg ~ts:4.0 ~lane:"discord"
       ~speaker:(external_speaker "55500001111")
       ~role:Store.Role.User "drive-by, no display name";
-    msg ~role:Store.Role.User "legacy row without source";
+    msg ~role:Store.Role.User "unscoped row";
   ]
 
-let test_lane_filter_excludes_other_sources_and_legacy () =
+let test_lane_filter_excludes_other_surfaces_and_unscoped () =
   let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false ~notes:[] discord_fixture) in
   check int "lane rows" 4 (to_int (member "lane_row_count" json));
   check int "returned" 4 (to_int (member "returned" json));
@@ -178,7 +182,7 @@ let test_oldest_ts_absent_when_page_unstamped () =
   let json =
     parse
       (SR.respond ~surface:"discord" ~limit:10 ~has_more:false ~notes:[]
-         [ msg ~source:"discord" ~role:Store.Role.User "no ts row" ])
+         [ msg ~lane:"discord" ~role:Store.Role.User "no ts row" ])
   in
   check bool "oldest_ts omitted" true (member "oldest_ts" json = `Null)
 
@@ -196,8 +200,8 @@ let () =
         ] );
       ( "lane filter",
         [
-          test_case "excludes other sources and legacy rows" `Quick
-            test_lane_filter_excludes_other_sources_and_legacy;
+          test_case "excludes other surfaces and unscoped rows" `Quick
+            test_lane_filter_excludes_other_surfaces_and_unscoped;
           test_case "limit truncates messages, not roster" `Quick
             test_limit_truncates_messages_not_roster;
           test_case "blank surface is an error" `Quick

--- a/test/test_surface_ref.ml
+++ b/test/test_surface_ref.ml
@@ -3,14 +3,11 @@
    Pinned here:
    1. Codec totality — every variant round-trips through JSON; unknown
       kinds are an Error, never a default.
-   2. lane_label goldens — the single derivation that replaced
-      writer-invented [source] strings, byte-identical to the legacy
-      labels ("dashboard" / "discord" / "agent" / gate channel).
-   3. Lane roundtrip — a typed write persists both the structured
-      [surface] field and the derived [source] label; legacy label-only
-      rows read back as [surface = None] with their label intact;
-      an invalid persisted surface payload is reported and dropped
-      without losing the row. *)
+   2. lane_label goldens — the single response-label derivation.
+   3. Lane roundtrip — a typed write persists only the structured
+      [surface] identity; a retired label-only field never restores it;
+      an invalid persisted surface payload is reported without losing
+      the row. *)
 
 open Alcotest
 
@@ -98,25 +95,23 @@ let test_typed_write_round_trips () =
       match Store.load ~base_dir:base ~keeper_name:"alice" with
       | [ m ] ->
           check (option surface) "typed surface read back" (Some ref_)
-            m.surface;
-          check (option string) "label derived from the typed surface"
-            (Some "discord") m.source
+            m.surface
       | other -> failf "expected 1 line, got %d" (List.length other))
 
-let test_legacy_label_row_reads_back () =
-  with_base "surface-ref-legacy" (fun base ->
+let test_source_only_row_does_not_restore_surface () =
+  with_base "surface-ref-source-hard-cut" (fun base ->
       Store.append_user_message ~base_dir:base ~keeper_name:"alice"
         ~content:"seed" ();
       let oc = open_out_gen [ Open_append ] 0o644 (lane_path base) in
       output_string oc
-        "{\"role\":\"user\",\"content\":\"old row\",\"ts\":2.0,\"source\":\"discord\"}\n";
+        "{\"id\":\"source-only\",\"role\":\"user\",\"content\":\"old row\",\"ts\":2.0,\"source\":\"discord\"}\n";
       close_out oc;
       match Store.load ~base_dir:base ~keeper_name:"alice" with
-      | [ _seed; legacy ] ->
-          check (option surface) "no typed surface on pre-P5 row" None
-            legacy.surface;
-          check (option string) "legacy label kept verbatim"
-            (Some "discord") legacy.source
+      | [ _seed; source_only ] ->
+          check (option surface)
+            "retired source label does not restore a typed surface"
+            None
+            source_only.surface
       | other -> failf "expected 2 lines, got %d" (List.length other))
 
 let test_invalid_surface_payload_keeps_row () =
@@ -125,7 +120,7 @@ let test_invalid_surface_payload_keeps_row () =
         ~content:"seed" ();
       let oc = open_out_gen [ Open_append ] 0o644 (lane_path base) in
       output_string oc
-        "{\"role\":\"user\",\"content\":\"bad surface\",\"ts\":2.0,\"surface\":{\"kind\":\"telepathy\"}}\n";
+        "{\"id\":\"bad-surface\",\"role\":\"user\",\"content\":\"bad surface\",\"ts\":2.0,\"surface\":{\"kind\":\"telepathy\"}}\n";
       close_out oc;
       match Store.load ~base_dir:base ~keeper_name:"alice" with
       | [ _seed; bad ] ->
@@ -148,7 +143,8 @@ let () =
         [
           test_case "typed write round trips" `Quick
             test_typed_write_round_trips;
-          test_case "legacy label row" `Quick test_legacy_label_row_reads_back;
+          test_case "source-only row does not restore surface" `Quick
+            test_source_only_row_does_not_restore_surface;
           test_case "invalid payload keeps row" `Quick
             test_invalid_surface_payload_keeps_row;
         ] );


### PR DESCRIPTION
## Summary

- reject persisted keeper-chat rows without a nonblank producer-assigned `id`
- stop writing and reading the duplicate `source` lane-label field
- keep typed `surface` as the persisted identity SSOT
- derive compact source labels at response/consumer boundaries only
- remove the test-only `Gate_surface.of_source` compatibility facade

No migration, repair, string-to-surface fallback, or new gate was added.

## Feature relationship / call trace

- write entry: `Keeper_chat_store.encode_line`, reached by turn, user,
  assistant, tool, and idempotent append paths
- read entry: `Keeper_chat_store.parse_line`, reached by `load_page`, `load`,
  and `load_all`
- history: `to_json_array` derives response `source` from `surface`
- lane feature: `Keeper_surface_read.respond` filters by
  `Surface_ref.lane_label`
- observation feature: speaker fallback derives the same label
- timeline feature: `Keeper_chat_timeline_source.lines_for` derives
  `cl_connector` from the typed surface
- connector presence remains registry-derived through `Gate_surface`

Current writers already mint `id` at the sole serialization boundary and take
only typed `Surface_ref.t`; therefore the removed branches serve past rows, not
the current chat feature.

## SSOT / blast radius

`source` remains in history/tool JSON only as an explicit derived projection:

`chat_message.surface -> Surface_ref.lane_label -> response source`

It is no longer persisted or stored as a second field on `chat_message`.
Affected consumers are history JSON, keeper surface reads, recent-direct
speaker labels, and tool timelines. Connector routing and deep links continue
to use the full typed surface.

## Contract / gate check

- missing id uses the existing persistence read-drop path and drops the row
- source-only rows do not restore or guess a typed surface
- invalid typed surface behavior is unchanged: report the field and keep the
  row as unscoped chat content
- no validation is duplicated at a second layer

## Validation

- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- focused build:
  - `test_keeper_chat_store.exe`
  - `test_keeper_surface_read.exe`
  - `test_keeper_surface_post.exe`
  - `test_surface_ref.exe`
  - `test_gate_surface.exe`
  - `test_keeper_mention_scope.exe`
- focused execution:
  - keeper chat store: 56/56
  - keeper surface read: 9/9
  - keeper surface post: 13/13
  - surface ref: 6/6
  - gate surface: 6/6
  - keeper mention scope: 24/24
- timeline build/execution: `test_tool_agent_timeline_build.exe`, 12/12

The patch rebased cleanly onto latest `origin/main`. A post-rebase repeat build
was blocked by an unrelated bare `dune build .` detected by the repo wrapper;
CI is the rebased-head build authority.
