### PR TITLE
fix(recall): reset delta replay after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Breaking (recall injection ledger)**: schema v3 adds a required typed
+  `reset` marker. The first row for each keeper process now resets replay state
+  before applying its exact current baseline, so keys deleted across a process
+  restart cannot survive durable materialization. Schema v2 rows are rejected;
+  no compatibility reader or migration path was added.
+
 ### Removed
 - **Breaking (telemetry wire/storage)**: removed the retired
   `Agent_joined`/`Agent_left` decoder aliases, the `.masc/telemetry.jsonl`
@@ -17,7 +23,7 @@
   `schema_version=1`/missing-version full-snapshot decoder, its public
   serializer, the unused option compatibility decoder, and the unused
   read-error labeling facade. Recall injection rows now require exact
-  `schema_version=2` Delta fields. The current writer,
+  `schema_version=3` reset/Delta fields. The current writer,
   full-history outcome-evaluation replay, invalid-row accounting, and
   retention behavior are unchanged; no migration or repair path was added.
 - **Breaking (keeper failure wire)**: removed the bare

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -4,8 +4,9 @@
    propagates into the turn. Retention is deliberately kept out of append's hot
    path and handled by server maintenance.
 
-   Schema v2 (masc#25052): see the .mli doc comment for why full key lists were
-   replaced with per-keeper deltas. *)
+   Schema v3 (masc#26314): see the .mli doc comment for why full key lists were
+   replaced with per-keeper deltas and why process baselines are explicit
+   reset rows. *)
 
 module SS = Set_util.StringSet
 
@@ -20,6 +21,7 @@ let field_removed_fact_keys = "removed_fact_keys"
 let field_added_episode_keys = "added_episode_keys"
 let field_removed_episode_keys = "removed_episode_keys"
 let field_content_hash = "content_hash"
+let field_reset = "reset"
 let field_n_facts_in_store = "n_facts_in_store"
 let field_n_episodes_in_store = "n_episodes_in_store"
 let field_ts = "ts"
@@ -28,10 +30,11 @@ let failure_reason_read_error = "read_error"
 let failure_reason_prompt_render_error = "prompt_render_error"
 let failure_reason_unknown_label = "unknown_failure_reason"
 
-let schema_version_delta = 2
+let schema_version_delta = 3
 
 type delta =
-  { added_fact_keys : string list
+  { reset : bool
+  ; added_fact_keys : string list
   ; removed_fact_keys : string list
   ; added_episode_keys : string list
   ; removed_episode_keys : string list
@@ -66,6 +69,13 @@ let json_required_string_field fields key =
 let json_required_int_field fields key =
   match List.assoc_opt key fields with
   | Some (`Int value) -> Ok value
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Error (`Missing_field key)
+;;
+
+let json_required_bool_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> Ok value
   | Some _ -> Error (`Invalid_field key)
   | None -> Error (`Missing_field key)
 ;;
@@ -108,28 +118,31 @@ let json_optional_string_field fields key =
 let delta_of_fields fields =
   match json_required_int_field fields field_schema_version with
   | Error _ as e -> e
-  | Ok 2 ->
+  | Ok 3 ->
     (match
-       ( json_required_string_list_field fields field_added_fact_keys
+       ( json_required_bool_field fields field_reset
+       , json_required_string_list_field fields field_added_fact_keys
        , json_required_string_list_field fields field_removed_fact_keys
        , json_required_string_list_field fields field_added_episode_keys
        , json_required_string_list_field fields field_removed_episode_keys
        , json_required_string_field fields field_content_hash )
      with
-     | ( Ok added_fact_keys
+     | ( Ok reset
+       , Ok added_fact_keys
        , Ok removed_fact_keys
        , Ok added_episode_keys
        , Ok removed_episode_keys
        , Ok content_hash ) ->
        Ok
-         { added_fact_keys; removed_fact_keys; added_episode_keys
+         { reset; added_fact_keys; removed_fact_keys; added_episode_keys
          ; removed_episode_keys; content_hash
          }
-     | Error err, _, _, _, _
-     | _, Error err, _, _, _
-     | _, _, Error err, _, _
-     | _, _, _, Error err, _
-     | _, _, _, _, Error err -> Error err)
+     | Error err, _, _, _, _, _
+     | _, Error err, _, _, _, _
+     | _, _, Error err, _, _, _
+     | _, _, _, Error err, _, _
+     | _, _, _, _, Error err, _
+     | _, _, _, _, _, Error err -> Error err)
   | Ok other -> Error (`Unsupported_schema_version other)
 ;;
 
@@ -218,6 +231,7 @@ let materialize records =
        in
        let
          { added_fact_keys
+         ; reset
          ; removed_fact_keys
          ; added_episode_keys
          ; removed_episode_keys
@@ -225,10 +239,15 @@ let materialize records =
          }
          = record.delta
        in
+       let base_facts, base_episodes =
+         if reset then SS.empty, SS.empty else prev_facts, prev_episodes
+       in
        let facts, episodes =
-         ( SS.diff (SS.union prev_facts (SS.of_list added_fact_keys)) (SS.of_list removed_fact_keys)
+         ( SS.diff
+             (SS.union base_facts (SS.of_list added_fact_keys))
+             (SS.of_list removed_fact_keys)
          , SS.diff
-             (SS.union prev_episodes (SS.of_list added_episode_keys))
+             (SS.union base_episodes (SS.of_list added_episode_keys))
              (SS.of_list removed_episode_keys) )
        in
        Hashtbl.replace state record.keeper_id (facts, episodes);
@@ -238,6 +257,7 @@ let materialize records =
 
 let to_json_delta
       ?failure_reason
+      ~reset
       ~keeper_id
       ~trace_id
       ~turn
@@ -254,6 +274,7 @@ let to_json_delta
   =
   let fields =
     [ field_schema_version, `Int schema_version_delta
+    ; field_reset, `Bool reset
     ; field_keeper_id, `String keeper_id
     ; field_trace_id, `String trace_id
     ; field_turn, `Int turn
@@ -308,9 +329,7 @@ module Delta_state = struct
 
   let peek ~masc_root ~keeper_id =
     Stdlib.Mutex.protect mu (fun () ->
-      Option.value
-        (Hashtbl.find_opt table (masc_root, keeper_id))
-        ~default:(SS.empty, SS.empty))
+      Hashtbl.find_opt table (masc_root, keeper_id))
   ;;
 
   let commit ~masc_root ~keeper_id ~facts ~episodes =
@@ -334,7 +353,11 @@ let append
       ()
   =
   let store = make_store ~masc_root () in
-  let prev_facts, prev_episodes = Delta_state.peek ~masc_root ~keeper_id in
+  let previous = Delta_state.peek ~masc_root ~keeper_id in
+  let reset = Option.is_none previous in
+  let prev_facts, prev_episodes =
+    Option.value previous ~default:(SS.empty, SS.empty)
+  in
   let curr_facts = SS.of_list injected_fact_keys in
   let curr_episodes = SS.of_list injected_episode_keys in
   let added_fact_keys = SS.elements (SS.diff curr_facts prev_facts) in
@@ -347,6 +370,7 @@ let append
   let entry =
     to_json_delta
       ?failure_reason
+      ~reset
       ~keeper_id
       ~trace_id
       ~turn

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -7,7 +7,12 @@
     forge carries PR/CI merge state), consumed offline by recall_outcome_eval
     (RFC-0264 P3) to compute recall_relevance / recall_harm.
 
-    Schema v2 (2026-07-17, masc#25052): the pre-existing schema wrote the FULL
+    Schema v3 (2026-07-29, masc#26314): rows keep the bounded delta shape from
+    v2 and add a required typed [reset] marker. A keeper's first append in each
+    process is a reset row, so replay replaces any durable pre-restart state
+    instead of incorrectly retaining keys deleted while the process was down.
+
+    Schema v2 (2026-07-17, masc#25052) replaced the pre-existing FULL
     injected fact/episode key list on every turn. Because {!Keeper_memory_os_recall}
     injects the store's *entire* current fact/episode set every turn (no
     selection budget existed before this change), every append cost was
@@ -16,14 +21,14 @@
     bytes — the same "append without compaction" class of bug diagnosed in the
     2026-07-17 board_attention_candidate boot-hang incident.
 
-    v2 rows instead carry only the fact/episode keys that changed since the
+    Delta rows instead carry only the fact/episode keys that changed since the
     keeper's immediately preceding row ({!delta}), plus a
     [content_hash] of the full injected set so a reader can detect "did the
     injected set change" without materializing it, and plus store-size
     counters ([n_facts_in_store] / [n_episodes_in_store]) that were already
     (or are now) O(1) scalars — unrelated to the growth bug and kept as-is.
 
-    Current rows require exact [schema_version = 2] and carry a [delta].
+    Current rows require exact [schema_version = 3] and carry a [delta].
     {!materialize} applies each row to the keeper's running state. A fresh
     process's first row for a keeper is diffed against the empty set, so it is
     automatically a full accounting while retaining one current wire shape.
@@ -50,13 +55,15 @@ val base_dir : masc_root:string -> string
 (** Directory that stores recall injection JSONL day files. *)
 
 type delta =
-  { added_fact_keys : string list
+  { reset : bool
+  ; added_fact_keys : string list
   ; removed_fact_keys : string list
   ; added_episode_keys : string list
   ; removed_episode_keys : string list
   ; content_hash : string
   }
-  (** Only the fact/episode keys that changed relative to the keeper's
+  (** [reset = true] clears the keeper's replay state before applying this row.
+      The remaining fields carry only the fact/episode keys that changed relative to the keeper's
       previous row. [content_hash] is {!content_hash_of} over the full
       injected set at this turn, so a reconstructed set can be checked for
       internal consistency without re-deriving it from application state. *)
@@ -140,14 +147,15 @@ val append
   -> unit
 (** Append one injection record. Computes the delta against [keeper_id]'s
     previous [injected_fact_keys]/[injected_episode_keys] (in-memory,
-    process-local, scoped by [(masc_root, keeper_id)]) and writes a v2
+    process-local, scoped by [(masc_root, keeper_id)]) and writes a v3
     delta row: this is the fix for the O(store_size) per-turn growth
     ([injected_fact_keys]/[injected_episode_keys] here are still the caller's
     full current sets — computing that live snapshot is not itself the growth
     bug; persisting a full copy of it every turn was). A keeper's first
-    append in a fresh process (no prior in-memory state) diffs against the
-    empty set, so its row's "delta" is the full current set — an accurate,
-    one-time, bounded-by-keeper-count cost, not a per-turn one.
+    append in a fresh process (no prior in-memory state) writes [reset = true]
+    and diffs against the empty set, so its row is a full current baseline.
+    Replay clears the durable pre-restart state at that row before applying the
+    baseline.
 
     Best-effort: never raises except to re-raise [Eio.Cancel.Cancelled].
     Retention is intentionally handled by server maintenance, not by append. *)
@@ -176,7 +184,6 @@ val prune_older_than
 module For_testing : sig
   val reset_delta_state : unit -> unit
   (** Clear the in-memory per-(masc_root, keeper_id) "previous injected set"
-      registry that {!append} diffs against. Test isolation only — production
-      has no reset path (a lost registry after restart just means the next
-      append per keeper is a one-time full accounting, which is safe). *)
+      registry that {!append} diffs against. Test isolation and restart
+      simulation only; the next append emits an explicit reset baseline. *)
 end

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -1,5 +1,5 @@
 (* RFC-0264 P2 / masc#25052: unit tests for the recall-injection ledger record
-   serialiser, the v2 delta schema, and retention maintenance. The serialiser
+   serialiser, the v3 reset/delta schema, and retention maintenance. The serialiser
    checks are pure; retention checks use a temporary dated JSONL tree to keep
    append-time pruning out of the hot path. *)
 
@@ -37,6 +37,7 @@ let with_temp_masc_root name f =
 
 let current_row_json
       ?failure_reason
+      ?(reset = false)
       ~keeper_id
       ~trace_id
       ~turn
@@ -49,7 +50,8 @@ let current_row_json
       ()
   =
   let fields =
-    [ "schema_version", `Int 2
+    [ "schema_version", `Int 3
+    ; "reset", `Bool reset
     ; "keeper_id", `String keeper_id
     ; "trace_id", `String trace_id
     ; "turn", `Int turn
@@ -145,7 +147,7 @@ let test_prune_older_than_removes_old_day_file () =
        false);
   check "manual retention removes old recall file" (not (Sys.file_exists old_file))
 
-(* ── v2 delta append, via a temp masc_root + Eio (append is the only path
+(* ── v3 reset/delta append, via a temp masc_root + Eio (append is the only path
    that touches the process-local Delta_state registry and Dated_jsonl I/O) ─ *)
 
 (* This file predates Alcotest (see the [check] harness above) and uses a
@@ -191,7 +193,8 @@ let test_append_writes_delta_row_and_updates_registry () =
     ();
   match read_all_records ~masc_root with
   | [ first; second ] ->
-    let { Ledger.added_fact_keys; removed_fact_keys; _ } = first.delta in
+    let { Ledger.reset; added_fact_keys; removed_fact_keys; _ } = first.delta in
+    check "first append is an exact reset baseline" reset;
     check_string_list
       "first append (fresh registry) is a full accounting: added = [x; y]"
       [ "x"; "y" ]
@@ -199,6 +202,7 @@ let test_append_writes_delta_row_and_updates_registry () =
     check "first append has no removals (nothing prior)" (removed_fact_keys = []);
     let
       { Ledger.added_fact_keys
+      ; reset
       ; removed_fact_keys
       ; added_episode_keys
       ; removed_episode_keys
@@ -206,6 +210,7 @@ let test_append_writes_delta_row_and_updates_registry () =
       }
       = second.delta
     in
+    check "subsequent append is a patch" (not reset);
     check_string_list "second append adds only the new key" [ "z" ] added_fact_keys;
     check_string_list "second append removes only the dropped key" [ "x" ] removed_fact_keys;
     check_string_list "second append adds the new episode key" [ "trace-g:g0" ]
@@ -213,6 +218,48 @@ let test_append_writes_delta_row_and_updates_registry () =
     check "second append removes no episode keys" (removed_episode_keys = [])
   | rows ->
     check (Printf.sprintf "expected exactly 2 rows, got %d" (List.length rows)) false
+;;
+
+let test_restart_reset_replaces_durable_state () =
+  with_temp_masc_root "recall-ledger-restart-reset" @@ fun masc_root ->
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Ledger.For_testing.reset_delta_state ();
+  Ledger.append
+    ~masc_root
+    ~keeper_id:"restart-keeper"
+    ~trace_id:"trace-before"
+    ~turn:1
+    ~injected_fact_keys:[ "a"; "b" ]
+    ~injected_episode_keys:[ "trace-before:g0" ]
+    ~n_facts_in_store:2
+    ~now:1.0
+    ();
+  Ledger.For_testing.reset_delta_state ();
+  Ledger.append
+    ~masc_root
+    ~keeper_id:"restart-keeper"
+    ~trace_id:"trace-after"
+    ~turn:2
+    ~injected_fact_keys:[ "b" ]
+    ~injected_episode_keys:[]
+    ~n_facts_in_store:1
+    ~now:2.0
+    ();
+  match read_all_records ~masc_root |> Ledger.materialize with
+  | [ before_restart; after_restart ] ->
+    check_string_list "pre-restart baseline contains both keys" [ "a"; "b" ]
+      before_restart.fact_keys;
+    check "post-restart row is a reset baseline" after_restart.record.delta.reset;
+    check_string_list "post-restart replay drops the deleted key" [ "b" ]
+      after_restart.fact_keys;
+    check_string_list "post-restart replay drops deleted episodes" []
+      after_restart.episode_keys
+  | rows ->
+    check
+      (Printf.sprintf "expected exactly 2 restart rows, got %d" (List.length rows))
+      false
 ;;
 
 let test_append_no_change_produces_empty_delta_regardless_of_store_size () =
@@ -266,6 +313,7 @@ let test_append_no_change_produces_empty_delta_regardless_of_store_size () =
 
 let test_materialize_replays_current_delta_rows () =
   let delta
+        ~reset
         ~keeper_id
         ~trace_id
         ~turn
@@ -282,7 +330,8 @@ let test_materialize_replays_current_delta_rows () =
     ; n_facts_in_store = None
     ; n_episodes_in_store = None
     ; delta =
-        { added_fact_keys
+        { reset
+        ; added_fact_keys
         ; removed_fact_keys
         ; added_episode_keys
         ; removed_episode_keys
@@ -293,6 +342,7 @@ let test_materialize_replays_current_delta_rows () =
   in
   let records =
     [ delta
+        ~reset:true
         ~keeper_id:"k"
         ~trace_id:"t1"
         ~turn:1
@@ -301,6 +351,7 @@ let test_materialize_replays_current_delta_rows () =
         ~added_episode_keys:[]
         ~removed_episode_keys:[]
     ; delta
+        ~reset:false
         ~keeper_id:"k"
         ~trace_id:"t1"
         ~turn:2
@@ -330,7 +381,8 @@ let test_materialize_keeps_keepers_independent () =
     ; n_facts_in_store = None
     ; n_episodes_in_store = None
     ; delta =
-        { added_fact_keys = keys
+        { reset = true
+        ; added_fact_keys = keys
         ; removed_fact_keys = []
         ; added_episode_keys = []
         ; removed_episode_keys = []
@@ -438,7 +490,8 @@ let () =
          [ "keeper_id", `String "alpha"
          ; "trace_id", `String "trace-1"
          ; "turn", `Int 1
-         ; "schema_version", `Int 2
+         ; "schema_version", `Int 3
+         ; "reset", `Bool false
          ; "added_fact_keys", `List [ `Int 1 ]
          ; "removed_fact_keys", `List []
          ; "added_episode_keys", `List []
@@ -524,6 +577,7 @@ let () =
   test_append_does_not_prune_old_day_file ();
   test_prune_older_than_removes_old_day_file ();
   test_append_writes_delta_row_and_updates_registry ();
+  test_restart_reset_replaces_durable_state ();
   test_append_no_change_produces_empty_delta_regardless_of_store_size ();
   if !failed > 0
   then (

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -3,6 +3,7 @@ module Eval = Masc.Keeper_recall_outcome_eval
 let recall_row
       ?failure_reason
       ?(extra_fields = [])
+      ?(reset = false)
       ?(added_fact_keys = [])
       ?(removed_fact_keys = [])
       ?(added_episode_keys = [])
@@ -16,7 +17,8 @@ let recall_row
   =
   let strings values = `List (List.map (fun value -> `String value) values) in
   let fields =
-    [ "schema_version", `Int 2
+    [ "schema_version", `Int 3
+    ; "reset", `Bool reset
     ; "keeper_id", `String keeper_id
     ; "trace_id", `String trace_id
     ; "turn", `Int turn


### PR DESCRIPTION
병합된 #26305의 재시작 replay P1을 고쳤어용.

- 첫 append를 schema v3 typed reset baseline으로 기록해용.
- materialize는 reset row에서 이전 durable state를 교체해용.
- `{a,b}` → 재시작 → `{b}` 회귀 테스트를 추가했어용.
- v2 호환·마이그레이션은 두지 않았어용.

검토 SHA: `b2aec3480d`
추적: #26314

로컬 Dune은 실행하지 않았고 포맷·파싱·diff만 확인했어용. Build는 CI가 권위예용.