### PR TITLE
fix(recall): make reset baseline branch explicit

### DIFF
--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -353,10 +353,10 @@ let append
       ()
   =
   let store = make_store ~masc_root () in
-  let previous = Delta_state.peek ~masc_root ~keeper_id in
-  let reset = Option.is_none previous in
-  let prev_facts, prev_episodes =
-    Option.value previous ~default:(SS.empty, SS.empty)
+  let reset, (prev_facts, prev_episodes) =
+    match Delta_state.peek ~masc_root ~keeper_id with
+    | Some state -> false, state
+    | None -> true, (SS.empty, SS.empty)
   in
   let curr_facts = SS.of_list injected_fact_keys in
   let curr_episodes = SS.of_list injected_episode_keys in


### PR DESCRIPTION
#26315 병합 후 남은 Meta Guard P2를 고쳤어용.

- optional registry state를 `Some/None`으로 명시 분기해용.
- reset 여부와 baseline을 한 match에서 함께 정해 SSOT를 유지해용.
- permissive default는 없앴어용.

검토 SHA: `859c53bff5`
추적: #26314

로컬 Dune은 실행하지 않았고 포맷·파싱·determinism gate·diff를 확인했어용. Build는 CI가 권위예용.