### PR TITLE
fix(librarian): stop truncating message content

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -78,10 +78,6 @@ let message_to_text ~turn (m : Agent_sdk.Types.message) : string =
   else Printf.sprintf "[%s] %s" header body
 ;;
 
-let truncate_text max_len s =
-  if String.length s <= max_len then s else String.sub s 0 max_len ^ "\n...[truncated]"
-;;
-
 let truncate_for_log max_len s =
   if String.length s <= max_len then s else String.sub s 0 max_len ^ "..."
 ;;
@@ -92,7 +88,6 @@ let format_messages_for_prompt messages =
   | _ ->
     messages
     |> List.mapi (fun turn message -> message_to_text ~turn message)
-    |> List.map (truncate_text 4000)
     |> String.concat "\n\n---\n\n"
 ;;
 


### PR DESCRIPTION
## What

Remove the per-message 4,000-character truncation from Librarian prompt formatting. The existing bounded recent-message window remains unchanged.

## Why

The old path cut an individual message mid-content before LLM judgment, so fields and tool evidence could become incomplete or non-identical to the source. Whole selected messages now reach the Librarian projection unchanged.

No replacement MASC byte gate is added. Final serialized request-body admission remains OAS-owned and candidate-specific. This PR does not classify duplicate prose, perform semantic similarity, mutate checkpoints, or add a second compaction owner.

## Validation

- `ocamlformat` on the touched OCaml file
- `git diff --check`
- focused build/test pending behind other workspace Dune users
- CI rerun pending for current head

## Scope

This is Librarian input correctness only, not the 524KiB Keeper checkpoint fix. Live recall was separately reduced through a reversible runtime override (`65,536 -> 49,152`) as an operational Quick Win. Checkpoint O(N) compaction remains single-owned by #25906. Rebuilt-runtime proof is currently blocked by the separate crashed-keeper bootstrap bug tracked in #26323.