### PR TITLE
refactor(runtime): centralize provider header defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@
   - `merge_keeper_profile_defaults` and `merge_string_list` are retained: they still implement the persona `profile.json` → keeper TOML overlay (`keeper_types_profile.ml:244`), which is a separate mechanism. Note `merge_string_list` is replace-if-non-empty, not union.
 
 ### Changed
+- Provider materialization and registry/model-string resolution now share
+  `Runtime_provider_binding.default_headers_for_kind` as the sole owner of
+  non-credential provider header defaults. The duplicate Runtime adapter
+  table and unused `headers_with_auth` public surface were removed; auth
+  tokens remain carried only through OAS `api_key`.
 - Workspace broadcast delivery now returns the canonical content, mention, and
   message type produced by its single terminal-task invariant check. MCP
   session/SSE/notification/audit consumers reuse that exact result instead of

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -11,14 +11,13 @@
     Runtime is one pre-selected binding. Errors are surfaced as
     [(_, string) result] so the caller fails fast (no silent fallback).
 
-    The identity helpers ([normalize_provider_id], [default_headers_for_kind],
-    [normalize_openai_compat_request_path]) lived only in the deleted
-    [Runtime_config_provider_binding] and are inlined here so this module has
-    no [Runtime_*] dependency.
+    Provider header defaults are owned by {!Runtime_provider_binding}; this
+    adapter owns only binding materialization and custom-header filtering.
 
     @stability Internal *)
 
 module Runtime_binding = Agent_sdk.Provider_runtime_binding
+module Provider_binding = Runtime_provider_binding
 
 (* --- Inlined from the deleted [Runtime_config_provider_binding] --- *)
 
@@ -28,23 +27,6 @@ let normalize_provider_id provider_id =
   String.trim provider_id
   |> String.lowercase_ascii
   |> String.map (fun c -> if c = '-' then '_' else c)
-;;
-
-(* Returns the non-credential request headers only. The auth credential
-   (Authorization / x-api-key) is intentionally NOT emitted here: the OAS
-   transport derives it from [~api_key] at request time, and its contract is
-   that the header list "never carries sensitive tokens" (oas api.ml auth_hdrs).
-   Emitting the credential here too produced a DUPLICATE Authorization header
-   that RunPod's cloudflare edge rejected with an opaque 400 before the origin
-   (diagnosed 2026-06-01 via the http_client_4xx_request_header_profile log:
-   2 x Authorization, 74 B each). The token still travels to OAS via [~api_key];
-   only Content-Type (OAS does not set it) and the non-credential Anthropic
-   version header belong here. *)
-let default_headers_for_kind (kind : Llm_provider.Provider_config.provider_kind) =
-  let base = [ ("Content-Type", "application/json") ] in
-  match kind with
-  | Anthropic -> ("anthropic-version", "2023-06-01") :: base
-  | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
 ;;
 
 let normalize_header_key key = String.lowercase_ascii (String.trim key)
@@ -362,7 +344,7 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_
          request_path_for_http_provider ~provider ~registry_entry ~kind ~base_url
        in
        let api_key = api_key_of_credential ?registry_entry provider.credentials in
-       let default_headers = default_headers_for_kind kind in
+       let default_headers = Provider_binding.default_headers_for_kind kind in
        let custom_headers =
          match provider.headers with
          | None -> []

--- a/lib/runtime_model/runtime_provider_binding.ml
+++ b/lib/runtime_model/runtime_provider_binding.ml
@@ -183,32 +183,11 @@ let display_provider_name provider_name =
 ;;
 
 let default_headers_for_kind (kind : Llm_provider.Provider_config.provider_kind) =
-  let base = [("Content-Type", "application/json")] in
+  let base = [ ("Content-Type", "application/json") ] in
   match kind with
   | Anthropic -> ("anthropic-version", "2023-06-01") :: base
   | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
 ;;
-
-(* Build headers list with Authorization when api_key is present.
-   Anthropic/Anthropic use x-api-key; OpenAI-compat (including GLM) uses Bearer. *)
-(* Returns the non-credential request headers only. The auth credential
-   (Authorization / x-api-key) is intentionally NOT emitted here: the OAS
-   transport derives it from [~api_key] at request time, and its contract is
-   that the header list "never carries sensitive tokens" (oas api.ml auth_hdrs).
-   Emitting the credential here too produced a DUPLICATE Authorization header
-   that RunPod's cloudflare edge rejected with an opaque 400 before the origin
-   (diagnosed 2026-06-01 via the http_client_4xx_request_header_profile log:
-   2 x Authorization). The token still travels to OAS via [~api_key]; only
-   Content-Type (OAS does not set it) and the non-credential Anthropic version
-   header belong here. Mirror of [Runtime_adapter.headers_with_auth] — keep in
-   sync (tracked for de-duplication). *)
-let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
-  let base = [("Content-Type", "application/json")] in
-  if api_key = "" then base
-    else match kind with
-    | Anthropic ->
-        ("anthropic-version", "2023-06-01") :: base
-    | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
 
 let trim_trailing_slash path =
   if String.length path > 1 && String.ends_with ~suffix:"/" path then

--- a/lib/runtime_model/runtime_provider_binding.mli
+++ b/lib/runtime_model/runtime_provider_binding.mli
@@ -62,10 +62,5 @@ val display_provider_name : string -> string
 val default_headers_for_kind :
   Llm_provider.Provider_config.provider_kind -> (string * string) list
 
-val headers_with_auth :
-  kind:Llm_provider.Provider_config.provider_kind ->
-  api_key:string ->
-  (string * string) list
-
 val normalize_openai_compat_request_path :
   base_url:string -> request_path:string -> string

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -358,6 +358,57 @@ max-concurrent = 2
         | None -> fail "expected provider capabilities")
      | _ -> fail "expected one provider")
 
+let test_runtime_adapter_uses_canonical_anthropic_headers () =
+  let content =
+    {|
+[runtime]
+default = "anthropic.claude-opus-4"
+
+[providers.anthropic]
+display-name = "Anthropic"
+protocol = "messages-http"
+endpoint = "https://api.anthropic.com"
+
+[models.claude-opus-4]
+api-name = "claude-opus-4"
+max-context = 200000
+tools-support = true
+streaming = true
+
+[anthropic.claude-opus-4]
+|}
+  in
+  match Runtime_toml.parse_string content with
+  | Error errors ->
+    fail
+      (errors
+       |> List.map (fun (err : Runtime_toml.parse_error) ->
+         err.path ^ ": " ^ err.message)
+       |> String.concat "; ")
+  | Ok config ->
+    let expected =
+      [ "anthropic-version", "2023-06-01"
+      ; "Content-Type", "application/json"
+      ]
+    in
+    check
+      (list (pair string string))
+      "canonical Anthropic defaults"
+      expected
+      (Runtime_provider_binding.default_headers_for_kind
+         Llm_provider.Provider_config.Anthropic);
+    (match config.bindings with
+     | [ binding ] ->
+       (match Runtime_adapter.binding_to_provider_config config binding with
+        | Error message -> fail message
+        | Ok provider_config ->
+          check
+            (list (pair string string))
+            "adapter uses canonical non-auth header defaults"
+            expected
+            provider_config.headers)
+     | bindings -> failf "expected one binding, got %d" (List.length bindings))
+
 let kimi_runtime_toml =
   {|
 [runtime]
@@ -1742,6 +1793,10 @@ let () =
             "runtime adapter filters TOML auth headers"
             `Quick
             test_runtime_adapter_filters_toml_auth_headers
+        ; test_case
+            "runtime adapter uses canonical Anthropic headers"
+            `Quick
+            test_runtime_adapter_uses_canonical_anthropic_headers
         ; test_case
             "runtime TOML rejects blank env credential key"
             `Quick


### PR DESCRIPTION
## Summary

- make `Runtime_provider_binding.default_headers_for_kind` the sole owner of generated non-credential provider headers
- route `runtime.toml` provider materialization through that owner
- remove the unused public `headers_with_auth` surface
- pin the Anthropic header projection at the real `Runtime_adapter.binding_to_provider_config` entrypoint

## Feature path / blast radius

`runtime.toml` → `Runtime_adapter.binding_to_provider_config` → `Provider_config.headers` → OAS HTTP request.

The registry/model-string path already used `Runtime_provider_binding`. Both entrypoints now share one table. Custom TOML headers still override generated non-auth headers, and `Authorization` / `x-api-key` remain filtered because credentials travel through `Provider_config.api_key`.

Blast radius is limited to generated `Content-Type` and `anthropic-version` defaults plus removal of a zero-caller internal API.

## Validation

- `ocamlformat` on all touched OCaml files
- `git diff --check`
- source audit: one remaining `default_headers_for_kind` definition; zero `headers_with_auth` definitions/callers
- focused build attempted through `scripts/dune-local.sh`, but correctly refused while another session owns a bare machine-wide `dune exec ... main_eio.exe -- --help`
- Draft CI is the build/test authority until that unrelated process releases the lock
