### PR TITLE
fix(runtime): GLM exact overlay 스트리밍 dialect 선언

### DIFF
--- a/config/oas-models-overlay.toml
+++ b/config/oas-models-overlay.toml
@@ -28,6 +28,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_response_format_json = true
 supports_native_streaming = true
+reasoning_streaming_format = "delta:reasoning_content"
 input_per_million = 1.2
 output_per_million = 4.0
 cache_write_multiplier = 1.0
@@ -245,6 +246,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_response_format_json = true
 supports_native_streaming = true
+reasoning_streaming_format = "delta:reasoning_content"
 
 [[models]]
 id_prefix = "glm-4.7"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -29,11 +29,12 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.2"
 # The reachability guards in check-oas-pin.sh and oas-drift-check.sh track
 # main; oas-drift-check.sh also reports the public-surface delta at pin-bump
 # time.
-# v0.231.2 is a patch on the hard-cut wave: adds GLM-5-Turbo
-# reasoning_streaming_format (#2880) — recovers streaming reasoning that was
-# falling back to batch (No_streaming_reasoning, ~60s/turn). Also carries the
-# #2875 agent-card current-interface contract hard-cut. MASC consumes the same
-# public Agent SDK contract; no compatibility or migration code retained.
+# v0.231.2 is a patch on the hard-cut wave: the base catalog declares
+# GLM-5-Turbo reasoning_streaming_format (#2880). Deployment exact overlays
+# must declare the same capability explicitly, and parser wiring/runtime proof
+# remain separate concerns. It also carries the #2875 agent-card
+# current-interface contract hard-cut. MASC consumes the same public Agent SDK
+# contract; no compatibility or migration code retained.
 # Pinned to the 0.231.2 release commit (1ea60e7a1).
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.2"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -409,6 +409,31 @@ let test_deployment_oas_model_catalog_covers_live_runpod_mtp () =
        | Some gate_caps -> expect_runpod_caps name gate_caps)
     provider_labels
 
+let test_deployment_oas_model_catalog_covers_glm_streaming_reasoning () =
+  with_deployment_oas_model_catalog @@ fun _catalog ->
+  let model_id = "GLM-5-Turbo" in
+  List.iter
+    (fun provider_label ->
+       match
+         Llm_provider.Capabilities.for_provider_model_id
+           ~allow_bare_fallback:false
+           ~provider_label
+           ~model_id
+       with
+       | None ->
+         failf
+           "expected deployment GLM streaming capability for provider=%s model=%s"
+           provider_label
+           model_id
+       | Some caps ->
+         check bool (provider_label ^ " native streaming") true
+           caps.supports_native_streaming;
+         check bool (provider_label ^ " typed reasoning delta") true
+           (Llm_provider.Capabilities.(
+              caps.reasoning_streaming_format
+              = Delta_reasoning_field "reasoning_content")))
+    [ "glm-coding"; "glm-coding-sb-exact" ]
+
 let test_deployment_oas_model_catalog_covers_live_runpod_rtxa6000_gemma () =
   with_deployment_oas_model_catalog @@ fun catalog ->
   let model_id = "gemma4-coder-fable5-q4km" in
@@ -3248,6 +3273,10 @@ let () =
             test_runtime_json_not_in_repo_config;
           test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
             test_deployment_oas_model_catalog_covers_live_runpod_mtp;
+          test_case
+            "deployment OAS catalog covers GLM typed streaming reasoning"
+            `Quick
+            test_deployment_oas_model_catalog_covers_glm_streaming_reasoning;
           test_case
             "deployment OAS catalog covers live RunPod RTX A6000 Gemma runtime"
             `Quick test_deployment_oas_model_catalog_covers_live_runpod_rtxa6000_gemma;


### PR DESCRIPTION
대상 SHA: `f26eb848daa65a47c0225875540d9455a648f272`예용.

- 두 GLM-5-Turbo provider-scoped overlay에 `delta:reasoning_content`를 명시했어용.
- typed capability가 `Delta_reasoning_field "reasoning_content"`로 해석되는지 검사해용.
- v0.231.2가 런타임 복구까지 보장한다는 잘못된 주석을 제거했어용.
- OAS parser 연계는 jeong-sik/oas#2883에서 처리해용.

로컬 검증: ocamlformat, OCaml parse, bash -n, git diff --check 통과했어용. Dune은 CI에서 확인해용.

근거: https://docs.z.ai/guides/llm/glm-5-turbo

Closes #26327