### PR TITLE
fix(chat): hard-cut legacy source projection

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -619,15 +619,11 @@ let accept_connector ~delivery ~clock ~config ~channel ~channel_user_id
                   (redact_text
                      (Keeper_chat_queue.mutation_error_to_string error))))))
 
-let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
+let persist_connector_assistant_reply ~base_dir ~keeper_name ~surface
     ?conversation_id ?turn_ref ~reply () =
   let content = String.trim reply in
   if content <> "" then begin
-    let surface =
-      match surface with
-      | Some surface -> surface
-      | None -> Surface_ref.Gate { label = source; address = [] }
-    in
+    let source = Surface_ref.lane_label surface in
     (* RFC-0233 §7: [turn_ref] is the join key the keeper minted into the
        reply payload, carried onto this connector turn's assistant row. *)
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
@@ -851,8 +847,8 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
            with Yojson.Json_error _ -> None)
       in
       persist_connector_assistant_reply
-        ~base_dir:config.Workspace.base_path ~keeper_name ~source:lane
-        ~surface ?conversation_id ?turn_ref ~reply ();
+        ~base_dir:config.Workspace.base_path ~keeper_name ~surface
+        ?conversation_id ?turn_ref ~reply ();
       Gate_protocol.Reply { content = reply; structured; stats; message_request = None }
   | `Async_ack (_, Some result) | `Streaming (Some result) ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -123,15 +123,16 @@ val contextualize_message :
 val persist_connector_assistant_reply :
   base_dir:string ->
   keeper_name:string ->
-  source:string ->
-  ?surface:Surface_ref.t ->
+  surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?turn_ref:Ids.Turn_ref.t ->
   reply:string ->
   unit ->
   unit
 (** Persist a completed connector direct reply on the same chat lane that
-    received the inbound user line. Empty replies are ignored.
+    received the inbound user line. The typed [surface] is the sole lane
+    identity; compact broadcast labels are derived from it. Empty replies are
+    ignored.
     [turn_ref] (RFC-0233 §7) is the join key the keeper minted into the
     reply payload, stamped on the assistant row. *)
 

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1919,11 +1919,6 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                      [ ("kind", `String (Row_kind.to_label m.kind)) ])
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
-              @ opt_string_field
-                  "source"
-                  (Option.map Surface_ref.lane_label m.surface)
-              (* Re-emit the typed surface for connector deep-links. [source]
-                 above is only its response projection for compact labels. *)
               @ (match m.surface with
                  | None -> []
                  | Some s -> [ ("surface", Surface_ref.to_json s) ])

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -439,12 +439,10 @@ val load_page :
     [ts] field; [tool_call_id] / [tool_call_name] /
     [conversation_id] / [external_message_id] / [workspace_id] /
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
-    when present. [source] is a response-only label derived from the typed
-    [surface], never a second persisted identity. [delivery_key] appears only
-    on rows persisted by the
-    idempotent append-once paths, verbatim as the typed delivery
-    identity object. When [base_dir] is supplied, the history endpoint
-    marks audio clips as [expired] when the underlying MP3 file is
+    when present. [surface] is the sole lane identity. [delivery_key] appears
+    only on rows persisted by the idempotent append-once paths, verbatim as the
+    typed delivery identity object. When [base_dir] is supplied, the history
+    endpoint marks audio clips as [expired] when the underlying MP3 file is
     gone. *)
 val to_json_array :
   ?base_dir:string ->

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -168,15 +168,13 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
         ~surface
         ~conversation_id:"discord:guild-1:channel:chan-9" ();
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord" ~surface
+        ~keeper_name ~surface
         ~conversation_id:"discord:guild-1:channel:chan-9"
         ~reply:"already answered" ();
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
           check string "user line first" "user" (K.Role.to_label user.K.role);
           check string "assistant reply persisted" "assistant" (K.Role.to_label assistant.K.role);
-          check string "assistant lane" "discord"
-            (Option.value assistant.K.source ~default:"");
           check string "assistant conversation id"
             "discord:guild-1:channel:chan-9"
             (Option.value assistant.K.conversation_id ~default:"");
@@ -194,8 +192,11 @@ let test_persist_connector_assistant_reply_ignores_empty_reply () =
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
       let keeper_name = "discord-empty-reply-keeper" in
+      let surface =
+        Surface_ref.Gate { label = "discord"; address = [] }
+      in
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord" ~reply:"   " ();
+        ~keeper_name ~surface ~reply:"   " ();
       check int "empty reply does not create chat file" 0
         (List.length (K.load ~base_dir ~keeper_name)))
 

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -259,30 +259,6 @@ let test_message_id_minted_unique_and_stable () =
         (List.length (List.sort_uniq String.compare ids));
       Alcotest.(check (list string)) "ids stable across reloads" ids (ids_of ()))
 
-let test_source_field_is_not_a_surface_fallback () =
-  let base_dir = temp_base_path "keeper-chat-store-source-hard-cut" in
-  Fun.protect
-    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
-    (fun () ->
-      let keeper_name = "keeper-chat-source-hard-cut" in
-      let path = chat_path ~base_dir ~keeper_name in
-      write_file path
-        ({|{"id":"row-current","role":"user","content":"hello","ts":1.0,"source":"discord"}|}
-        ^ "\n");
-      match K.load ~base_dir ~keeper_name with
-      | [ row ] ->
-          Alcotest.(check (option string))
-            "retired source does not synthesize typed surface"
-            None
-            (Option.map Masc.Surface_ref.lane_label row.surface);
-          let json = K.to_json_array [ row ] in
-          Alcotest.(check bool)
-            "retired source is not re-emitted"
-            true
-            Yojson.Safe.Util.(json |> index 0 |> member "source" = `Null)
-      | rows ->
-          Alcotest.failf "expected one current-id row, got %d" (List.length rows))
-
 (* R3: the /chat/history payload surfaces the id so the dashboard keys off
    it instead of synthesising one. *)
 let test_to_json_array_exposes_id () =
@@ -624,6 +600,8 @@ let test_append_user_message_roundtrip () =
               (* The typed surface must survive the read-serve emitter so the
                  dashboard rebuilds the connector deep-link on reload. *)
               let user_surface = Yojson.Safe.Util.member "surface" user_json in
+              Alcotest.(check bool) "json omits duplicate source label" true
+                Yojson.Safe.Util.(user_json |> member "source" = `Null);
               Alcotest.(check bool) "json user row carries structured surface"
                 true (user_surface <> `Null);
               (match Masc.Surface_ref.of_json user_surface with
@@ -2170,8 +2148,6 @@ let () =
             test_missing_id_rows_are_rejected;
           Alcotest.test_case "message id minted unique and stable (R3)" `Quick
             test_message_id_minted_unique_and_stable;
-          Alcotest.test_case "source field is not a surface fallback" `Quick
-            test_source_field_is_not_a_surface_fallback;
           Alcotest.test_case "chat_path size grows on append (cache key)" `Quick
             test_chat_path_size_grows_on_append;
           Alcotest.test_case "to_json_array exposes id (R3)" `Quick


### PR DESCRIPTION
## What changed

- require `Surface_ref.t` when persisting connector assistant replies
- derive the compact broadcast label from the typed surface
- remove the duplicate Keeper chat history `source` projection
- remove the stale `K.source` assertion and legacy compatibility fixture

## Root cause

`#26311` removed `Keeper_chat_store.chat_message.source`, but
`test_gate_keeper_backend` still referenced the deleted record field. The reply
adapter also retained an optional typed surface plus string fallback, and the
history response projected the same identity a second time as `source`.

## Impact

Typed `surface` is now the sole connector lane identity across persistence and
history responses. This adds no migration or compatibility path and removes the
build failure:

```text
Error: Unbound record field K.source
```

## Validation

- `ocamlc -stop-after parsing` passed for all four touched
  implementation/interface files and both touched tests
- focused wrapper build queued behind the machine-wide Dune lock; this draft
  will be updated after it completes
