### PR TITLE
fix(test): chat delivery identity 의존성 복구

### DIFF
--- a/test/deps/dune
+++ b/test/deps/dune
@@ -82,6 +82,7 @@
   ;; RFC-0056 Phase 1H — Tool_call_quality_benchmark family sub-library.
   (re_export masc.tool_call_quality_benchmark)
   (re_export masc.keeper_runtime)
+  (re_export masc.keeper_chat_delivery_identity)
   (re_export masc.keeper_contract)
   ;; RFC-0056 Phase 1K — Compaction_trigger leaf sub-library.
   (re_export masc.compaction_trigger)

--- a/test/dune
+++ b/test/dune
@@ -646,8 +646,7 @@
   test_board_rest_routes
   test_board_context_inference_resolution)
  (libraries
-  masc_test_deps masc.keeper_chat_delivery_identity masc_schedule multimodal
-  bigstringaf masc.keeper_checkpoint_ref))
+  masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref))
 
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test


### PR DESCRIPTION
대상 SHA: `8d6236065e51c168e34e0c1d51d8053dd3431181`예용.

- `test_keeper_chat_admission_contention`이 직접 참조하는 `Keeper_chat_delivery_identity`가 `masc_test_deps`에서 빠져 전체 빌드가 컴파일 실패했어용.
- 테스트 공용 의존성 SSOT인 `test/deps/dune`에서 library를 re-export했어용.
- 개별 grouped test stanza의 중복 직접 의존성은 제거했어용.

`git diff --check`를 통과했어용. Dune 재검증은 CI에서 확인해용.