### PR TITLE
refactor(keeper): validate identity tool inputs once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
   or repair path was added.
 - **Keeper tool admission**: identity-translated `Execute`, `WebSearch`, and
   `WebFetch` payloads now use the public descriptor validation as their single
-  schema Gate. Shape-changing translators such as `Grep` retain post-translation
-  validation.
+  schema Gate. Translation shape and validation ownership now share one typed
+  descriptor field, so shape-changing translators such as `Grep` retain
+  post-translation validation without an independent boolean.
 - **Breaking (recall injection ledger)**: schema v3 adds a required typed
   `reset` marker. The first row for each keeper process now resets replay state
   before applying its exact current baseline, so keys deleted across a process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   snapshots contain only `status` and `reason`; snapshots carrying the retired
   field fail closed through the existing unavailable-store path. No migration
   or repair path was added.
+- **Keeper tool admission**: identity-translated `Execute`, `WebSearch`, and
+  `WebFetch` payloads now use the public descriptor validation as their single
+  schema Gate. Shape-changing translators such as `Grep` retain post-translation
+  validation.
 - **Breaking (recall injection ledger)**: schema v3 adds a required typed
   `reset` marker. The first row for each keeper process now resets replay state
   before applying its exact current baseline, so keys deleted across a process

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -35,7 +35,7 @@ let routing_table : (string, route) Hashtbl.t =
               t
               public_name
               { internal_name = d.internal_name
-              ; translate = d.translate
+              ; translate = Keeper_tool_descriptor.translate_input_for_descriptor d
               ; public_schema = Some d.input_schema
               ; descriptor = d
               })

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -51,10 +51,6 @@ type shape_changing_validation =
 
 type input_translation =
   | Identity of identity_validation
-  | Schema_preserving of
-      { translate : Yojson.Safe.t -> Yojson.Safe.t
-      ; validation : identity_validation
-      }
   | Shape_changing of
       { translate : Yojson.Safe.t -> Yojson.Safe.t
       ; validation : shape_changing_validation
@@ -556,27 +552,7 @@ let search_files_readonly_of_input _input = Some true
 let translate_input_for_descriptor descriptor input =
   match descriptor.input_translation with
   | Identity _ -> input
-  | Schema_preserving { translate; _ }
   | Shape_changing { translate; _ } -> translate input
-;;
-
-let requires_pre_translation_validation descriptor =
-  match descriptor.input_translation with
-  | Identity Validate_once_before_translation
-  | Schema_preserving { validation = Validate_once_before_translation; _ }
-  | Shape_changing _ -> true
-  | Identity Validate_once_after_translation
-  | Schema_preserving { validation = Validate_once_after_translation; _ } -> false
-;;
-
-let requires_post_translation_validation descriptor =
-  match descriptor.input_translation with
-  | Identity Validate_once_after_translation
-  | Schema_preserving { validation = Validate_once_after_translation; _ }
-  | Shape_changing { validation = Validate_before_and_after_translation; _ } -> true
-  | Identity Validate_once_before_translation
-  | Schema_preserving { validation = Validate_once_before_translation; _ }
-  | Shape_changing { validation = Validate_before_then_runtime_handler; _ } -> false
 ;;
 
 let descriptor_with_public_aliases

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -672,7 +672,7 @@ let public_descriptors =
             ~argv:[ "program"; "--version" ]
             ()
         ]
-      ~validate_translated_input:true
+      ~validate_translated_input:false
       ~translate:translate_identity
       ()
   ; descriptor_with_public_aliases
@@ -799,7 +799,7 @@ let public_descriptors =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_web_search
-      ~validate_translated_input:true
+      ~validate_translated_input:false
       ~translate:translate_identity
       ()
   ; descriptor
@@ -824,7 +824,7 @@ let public_descriptors =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_web_fetch
-      ~validate_translated_input:true
+      ~validate_translated_input:false
       ~translate:translate_identity
       ()
   ]

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -41,6 +41,25 @@ type input_schema_source =
 
 type readonly_of_input = Yojson.Safe.t -> bool option
 
+type identity_validation =
+  | Validate_once_before_translation
+  | Validate_once_after_translation
+
+type shape_changing_validation =
+  | Validate_before_and_after_translation
+  | Validate_before_then_runtime_handler
+
+type input_translation =
+  | Identity of identity_validation
+  | Schema_preserving of
+      { translate : Yojson.Safe.t -> Yojson.Safe.t
+      ; validation : identity_validation
+      }
+  | Shape_changing of
+      { translate : Yojson.Safe.t -> Yojson.Safe.t
+      ; validation : shape_changing_validation
+      }
+
 type runtime_handler =
   | Tool_execute
   | Tool_search_files
@@ -105,8 +124,7 @@ type t =
   ; backend : backend
   ; sandbox : sandbox
   ; runtime_handler : runtime_handler
-  ; translate : Yojson.Safe.t -> Yojson.Safe.t
-  ; validate_translated_input : bool
+  ; input_translation : input_translation
   ; receipt_labels : (string * string) list
   ; eval_tags : string list
   ; examples : Yojson.Safe.t list
@@ -448,8 +466,6 @@ let fetch_web_schema =
     ]
 ;;
 
-let translate_identity input = input
-
 (* [offset]/[limit] pass through as LINE coordinates — the runtime owns the
    line-window contract (keeper_tool_filesystem_runtime.slice_read_window).
    [limit] used to be renamed to [max_bytes] here, which silently turned "200
@@ -537,11 +553,36 @@ let translate_search_files input =
 (* search_files is now rg (pattern search) only — always read-only. *)
 let search_files_readonly_of_input _input = Some true
 
+let translate_input_for_descriptor descriptor input =
+  match descriptor.input_translation with
+  | Identity _ -> input
+  | Schema_preserving { translate; _ }
+  | Shape_changing { translate; _ } -> translate input
+;;
+
+let requires_pre_translation_validation descriptor =
+  match descriptor.input_translation with
+  | Identity Validate_once_before_translation
+  | Schema_preserving { validation = Validate_once_before_translation; _ }
+  | Shape_changing _ -> true
+  | Identity Validate_once_after_translation
+  | Schema_preserving { validation = Validate_once_after_translation; _ } -> false
+;;
+
+let requires_post_translation_validation descriptor =
+  match descriptor.input_translation with
+  | Identity Validate_once_after_translation
+  | Schema_preserving { validation = Validate_once_after_translation; _ }
+  | Shape_changing { validation = Validate_before_and_after_translation; _ } -> true
+  | Identity Validate_once_before_translation
+  | Schema_preserving { validation = Validate_once_before_translation; _ }
+  | Shape_changing { validation = Validate_before_then_runtime_handler; _ } -> false
+;;
+
 let descriptor_with_public_aliases
       ?(examples = [])
       ~keeper_model_projection
       ~input_schema_source
-      ~validate_translated_input
       ~public_aliases
       ~id
       ~public_name
@@ -553,7 +594,7 @@ let descriptor_with_public_aliases
       ~backend
       ~sandbox
       ~runtime_handler
-      ~translate
+      ~input_translation
       ()
   =
   let receipt_labels =
@@ -590,8 +631,7 @@ let descriptor_with_public_aliases
   ; backend
   ; sandbox
   ; runtime_handler
-  ; translate
-  ; validate_translated_input
+  ; input_translation
   ; receipt_labels
   ; eval_tags = []
   ; examples
@@ -602,7 +642,6 @@ let descriptor
       ?(examples = [])
       ~keeper_model_projection
       ~input_schema_source
-      ~validate_translated_input
       ~id
       ~public_name
       ~internal_name
@@ -613,14 +652,13 @@ let descriptor
       ~backend
       ~sandbox
       ~runtime_handler
-      ~translate
+      ~input_translation
       ()
   =
   descriptor_with_public_aliases
     ~examples
     ~keeper_model_projection
     ~input_schema_source
-    ~validate_translated_input
     ~public_aliases:[]
     ~id
     ~public_name
@@ -632,7 +670,7 @@ let descriptor
     ~backend
     ~sandbox
     ~runtime_handler
-    ~translate
+    ~input_translation
     ()
 ;;
 
@@ -672,8 +710,7 @@ let public_descriptors =
             ~argv:[ "program"; "--version" ]
             ()
         ]
-      ~validate_translated_input:false
-      ~translate:translate_identity
+      ~input_translation:(Identity Validate_once_before_translation)
       ()
   ; descriptor_with_public_aliases
       ~keeper_model_projection:Preferred_public_name
@@ -701,8 +738,11 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_search_files
-      ~validate_translated_input:true
-      ~translate:translate_search_files
+      ~input_translation:
+        (Shape_changing
+           { translate = translate_search_files
+           ; validation = Validate_before_and_after_translation
+           })
       ()
   ; descriptor
       ~keeper_model_projection:Preferred_public_name
@@ -726,8 +766,11 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_read_file
-      ~validate_translated_input:false
-      ~translate:translate_read_file
+      ~input_translation:
+        (Shape_changing
+           { translate = translate_read_file
+           ; validation = Validate_before_then_runtime_handler
+           })
       ()
   ; descriptor
       ~keeper_model_projection:Preferred_public_name
@@ -751,8 +794,11 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_edit_file
-      ~validate_translated_input:false
-      ~translate:translate_edit_file
+      ~input_translation:
+        (Shape_changing
+           { translate = translate_edit_file
+           ; validation = Validate_before_then_runtime_handler
+           })
       ()
   ; descriptor
       ~keeper_model_projection:Preferred_public_name
@@ -774,8 +820,11 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_write_file
-      ~validate_translated_input:false
-      ~translate:translate_write_file
+      ~input_translation:
+        (Shape_changing
+           { translate = translate_write_file
+           ; validation = Validate_before_then_runtime_handler
+           })
       ()
   ; descriptor
       ~keeper_model_projection:Preferred_public_name
@@ -799,8 +848,7 @@ let public_descriptors =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_web_search
-      ~validate_translated_input:false
-      ~translate:translate_identity
+      ~input_translation:(Identity Validate_once_before_translation)
       ()
   ; descriptor
       ~keeper_model_projection:Preferred_public_name
@@ -824,8 +872,7 @@ let public_descriptors =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_web_fetch
-      ~validate_translated_input:false
-      ~translate:translate_identity
+      ~input_translation:(Identity Validate_once_before_translation)
       ()
   ]
 ;;
@@ -1148,8 +1195,7 @@ let in_process_descriptor_with_schema_source ~keeper_model_projection
     ~backend:Ocaml_runtime
     ~sandbox:No_sandbox
     ~runtime_handler:handler
-    ~validate_translated_input:true
-    ~translate:translate_identity
+    ~input_translation:(Identity Validate_once_after_translation)
     ()
 ;;
 
@@ -2053,7 +2099,7 @@ let public_input_schema public =
 
 let translate_input ~public input =
   match find_public public with
-  | Some d -> d.translate input
+  | Some descriptor -> translate_input_for_descriptor descriptor input
   | None -> input
 ;;
 

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -70,10 +70,6 @@ type shape_changing_validation =
 
 type input_translation =
   | Identity of identity_validation
-  | Schema_preserving of
-      { translate : Yojson.Safe.t -> Yojson.Safe.t
-      ; validation : identity_validation
-      }
   | Shape_changing of
       { translate : Yojson.Safe.t -> Yojson.Safe.t
       ; validation : shape_changing_validation
@@ -211,8 +207,6 @@ val descriptors_for_internal : string -> t list
 val readonly_static_hint : t -> bool option
 val readonly_for_input : t -> input:Yojson.Safe.t -> bool option
 val translate_input_for_descriptor : t -> Yojson.Safe.t -> Yojson.Safe.t
-val requires_pre_translation_validation : t -> bool
-val requires_post_translation_validation : t -> bool
 
 (** Descriptor-owned read-only projection. The returned names are internal
     handler names whose descriptor policy declares a static read-only hint. *)

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -55,6 +55,30 @@ type input_schema_source =
 
 type readonly_of_input = Yojson.Safe.t -> bool option
 
+type identity_validation =
+  | Validate_once_before_translation
+  | Validate_once_after_translation
+(** Validation owner for translations that preserve the public schema. Exactly
+    one descriptor validation boundary is selected. *)
+
+type shape_changing_validation =
+  | Validate_before_and_after_translation
+  | Validate_before_then_runtime_handler
+(** Validation owner for shape-changing translations. Public input is always
+    validated before translation; the translated shape is then validated by
+    either the descriptor schema or the runtime handler's typed boundary. *)
+
+type input_translation =
+  | Identity of identity_validation
+  | Schema_preserving of
+      { translate : Yojson.Safe.t -> Yojson.Safe.t
+      ; validation : identity_validation
+      }
+  | Shape_changing of
+      { translate : Yojson.Safe.t -> Yojson.Safe.t
+      ; validation : shape_changing_validation
+      }
+
 type runtime_handler =
   | Tool_execute
   | Tool_search_files
@@ -119,12 +143,7 @@ type t =
   ; backend : backend
   ; sandbox : sandbox
   ; runtime_handler : runtime_handler
-  ; translate : Yojson.Safe.t -> Yojson.Safe.t
-  ; validate_translated_input : bool
-  (** Whether alias dispatch should validate [translate input] against the
-      internal handler schema. Defaults to true; false is reserved for
-      descriptor-owned public aliases whose runtime schema still differs from
-      the public schema. *)
+  ; input_translation : input_translation
   ; receipt_labels : (string * string) list
   (** Evaluation-only semantic tags emitted in route evidence. These tags
       support replay/harness scoring and are not runtime selection policy. *)
@@ -191,6 +210,9 @@ val descriptors_for_internal : string -> t list
 
 val readonly_static_hint : t -> bool option
 val readonly_for_input : t -> input:Yojson.Safe.t -> bool option
+val translate_input_for_descriptor : t -> Yojson.Safe.t -> Yojson.Safe.t
+val requires_pre_translation_validation : t -> bool
+val requires_post_translation_validation : t -> bool
 
 (** Descriptor-owned read-only projection. The returned names are internal
     handler names whose descriptor policy declares a static read-only hint. *)

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -77,7 +77,10 @@ let capability_has kind tool_name =
 let descriptor_and_input_for_tool_call ~tool_name ~input =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
   match Keeper_tool_descriptor.find_public stripped with
-  | Some descriptor -> Some (descriptor, descriptor.Keeper_tool_descriptor.translate input)
+  | Some descriptor ->
+    Some
+      ( descriptor
+      , Keeper_tool_descriptor.translate_input_for_descriptor descriptor input )
   | None ->
     (match Keeper_tool_descriptor.descriptors_for_internal stripped with
      | descriptor :: _ -> Some (descriptor, input)
@@ -125,7 +128,9 @@ let validated_descriptor_and_input_for_tool_call ~tool_name ~input =
        Some
          (Ok
             ( descriptor
-            , descriptor.Keeper_tool_descriptor.translate validated_input ))
+            , Keeper_tool_descriptor.translate_input_for_descriptor
+                descriptor
+                validated_input ))
      | Error validation_result -> Some (Error validation_result))
   | None ->
     Option.map

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -114,24 +114,55 @@ let validate_public_input_for_tool_call ~tool_name ~input =
   | None -> None
 ;;
 
+let validate_descriptor_input ~tool_name
+      (descriptor : Keeper_tool_descriptor.t) input
+  =
+  Tool_input_validation.validate_args
+    ~schema:descriptor.input_schema
+    ~name:tool_name
+    ~args:input
+    ()
+;;
+
+let prepare_model_input_for_descriptor ~tool_name
+      (descriptor : Keeper_tool_descriptor.t) ~input
+  =
+  let validate = validate_descriptor_input ~tool_name descriptor in
+  let translate =
+    Keeper_tool_descriptor.translate_input_for_descriptor descriptor
+  in
+  match descriptor.input_translation with
+  | Keeper_tool_descriptor.Identity
+      Keeper_tool_descriptor.Validate_once_before_translation ->
+    validate input
+  | Keeper_tool_descriptor.Identity
+      Keeper_tool_descriptor.Validate_once_after_translation ->
+    validate (translate input)
+  | Keeper_tool_descriptor.Shape_changing
+      { validation =
+          Keeper_tool_descriptor.Validate_before_and_after_translation
+      ; _
+      } ->
+    Result.bind (validate input) (fun validated_input ->
+      validate (translate validated_input))
+  | Keeper_tool_descriptor.Shape_changing
+      { validation =
+          Keeper_tool_descriptor.Validate_before_then_runtime_handler
+      ; _
+      } ->
+    Result.map translate (validate input)
+;;
+
 let validated_descriptor_and_input_for_tool_call ~tool_name ~input =
   match public_descriptor_and_name_for_tool_call tool_name with
   | Some (public_name, descriptor) ->
-    (match
-       Tool_input_validation.validate_args
-         ~schema:descriptor.Keeper_tool_descriptor.input_schema
-         ~name:public_name
-         ~args:input
-         ()
-     with
-     | Ok validated_input ->
-       Some
-         (Ok
-            ( descriptor
-            , Keeper_tool_descriptor.translate_input_for_descriptor
-                descriptor
-                validated_input ))
-     | Error validation_result -> Some (Error validation_result))
+    Some
+      (Result.map
+         (fun prepared_input -> descriptor, prepared_input)
+         (prepare_model_input_for_descriptor
+            ~tool_name:public_name
+            descriptor
+            ~input))
   | None ->
     Option.map
       (fun descriptor_and_input -> Ok descriptor_and_input)

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -102,18 +102,6 @@ let public_descriptor_and_name_for_tool_call tool_name =
   | None -> None
 ;;
 
-let validate_public_input_for_tool_call ~tool_name ~input =
-  match public_descriptor_and_name_for_tool_call tool_name with
-  | Some (public_name, descriptor) ->
-    Some
-      (Tool_input_validation.validate_args
-         ~schema:descriptor.Keeper_tool_descriptor.input_schema
-         ~name:public_name
-         ~args:input
-         ())
-  | None -> None
-;;
-
 let validate_descriptor_input ~tool_name
       (descriptor : Keeper_tool_descriptor.t) input
   =

--- a/lib/keeper/keeper_tool_descriptor_resolution.mli
+++ b/lib/keeper/keeper_tool_descriptor_resolution.mli
@@ -26,9 +26,6 @@ val capability_has : Tool_capability.kind -> string -> bool
 val descriptor_and_input_for_tool_call :
   tool_name:string -> input:Yojson.Safe.t -> (Keeper_tool_descriptor.t * Yojson.Safe.t) option
 
-val validate_public_input_for_tool_call :
-  tool_name:string -> input:Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result option
-
 val prepare_model_input_for_descriptor :
   tool_name:string ->
   Keeper_tool_descriptor.t ->

--- a/lib/keeper/keeper_tool_descriptor_resolution.mli
+++ b/lib/keeper/keeper_tool_descriptor_resolution.mli
@@ -29,6 +29,12 @@ val descriptor_and_input_for_tool_call :
 val validate_public_input_for_tool_call :
   tool_name:string -> input:Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result option
 
+val prepare_model_input_for_descriptor :
+  tool_name:string ->
+  Keeper_tool_descriptor.t ->
+  input:Yojson.Safe.t ->
+  (Yojson.Safe.t, Tool_result.result) result
+
 val validated_descriptor_and_input_for_tool_call :
   tool_name:string ->
   input:Yojson.Safe.t ->

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -231,10 +231,11 @@ let make_tool_bundle
                  ~on_deferred:mark_deferred_tool_result
                  ~on_external_effect_deferred:mark_external_effect_deferred
                  ?on_failed
-                 ~prepare_input:
-                   (Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
-                      ~tool_name:model_name
-                      descriptor)
+                 ~prepare_input:(fun input ->
+                   Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
+                     ~tool_name:model_name
+                     descriptor
+                     ~input)
                  ()
              in
              Tool_bridge.oas_tool_of_masc_with_execution_env

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -198,7 +198,7 @@ let make_tool_bundle
   (* The handler dispatches with
      [~name:descriptor.internal_name] so all telemetry SSOT remains internal;
      exactly one projected Tool.schema.name is model-visible.
-     [descriptor.translate] reshapes the LLM's payload before dispatch;
+     the descriptor-owned typed translation reshapes the LLM's payload before dispatch;
      [descriptor.input_schema] provides the LLM-facing schema. *)
   let descriptor_tools =
     List.concat_map
@@ -232,15 +232,21 @@ let make_tool_bundle
                  ~on_external_effect_deferred:mark_external_effect_deferred
                  ?on_failed
                  ~pre_validate_input:(fun input ->
-                   match
-                     Keeper_tool_descriptor_resolution.validate_public_input_for_tool_call
-                       ~tool_name:model_name
-                       ~input
-                   with
-                 | Some result -> result
-                 | None -> Ok input)
-                 ~translate_input:descriptor.translate
-                 ~validate_translated_input:descriptor.validate_translated_input
+                   if
+                     Keeper_tool_descriptor.requires_pre_translation_validation
+                       descriptor
+                   then
+                     Tool_input_validation.validate_args
+                       ~schema:descriptor.input_schema
+                       ~name:model_name
+                       ~args:input
+                       ()
+                   else Ok input)
+                 ~translate_input:
+                   (Keeper_tool_descriptor.translate_input_for_descriptor descriptor)
+                 ~validate_translated_input:
+                   (Keeper_tool_descriptor.requires_post_translation_validation
+                      descriptor)
                  ()
              in
              Tool_bridge.oas_tool_of_masc_with_execution_env

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -231,21 +231,9 @@ let make_tool_bundle
                  ~on_deferred:mark_deferred_tool_result
                  ~on_external_effect_deferred:mark_external_effect_deferred
                  ?on_failed
-                 ~pre_validate_input:(fun input ->
-                   if
-                     Keeper_tool_descriptor.requires_pre_translation_validation
-                       descriptor
-                   then
-                     Tool_input_validation.validate_args
-                       ~schema:descriptor.input_schema
-                       ~name:model_name
-                       ~args:input
-                       ()
-                   else Ok input)
-                 ~translate_input:
-                   (Keeper_tool_descriptor.translate_input_for_descriptor descriptor)
-                 ~validate_translated_input:
-                   (Keeper_tool_descriptor.requires_post_translation_validation
+                 ~prepare_input:
+                   (Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
+                      ~tool_name:model_name
                       descriptor)
                  ()
              in

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -27,9 +27,12 @@ let make_keeper_tool_handler
       ?on_deferred
       ?on_external_effect_deferred
       ?on_failed
-      ?(pre_validate_input = fun input -> Ok input)
-      ?(translate_input = fun j -> j)
-      ?(validate_translated_input = true)
+      ?(prepare_input = fun input ->
+        Tool_input_validation.validate_args
+          ~schema:input_schema
+          ~name
+          ~args:input
+          ())
       ()
   : ?oas_invocation:Agent_sdk.Tool_contract.Invocation.t -> Yojson.Safe.t -> Tool_result.result
   =
@@ -134,18 +137,10 @@ let make_keeper_tool_handler
          but do not poison the request-scoped terminal-effect state. *)
       validation_result |> record_result ~input
     in
-    match pre_validate_input raw_input with
+    match prepare_input raw_input with
     | Error validation_result ->
       handle_validation_error ~input:raw_input validation_result
-    | Ok pre_validated_input ->
-      let input = translate_input pre_validated_input in
-      (match
-         if validate_translated_input
-         then Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input ()
-         else Ok input
-       with
-       | Error validation_result -> handle_validation_error ~input validation_result
-       | Ok input ->
+    | Ok input ->
           let current_clock =
             match clock with
             | Some clock -> Some clock
@@ -186,5 +181,5 @@ let make_keeper_tool_handler
                    execution.failure_effect_disposition
                  ~deferred_kind:execution.deferred_kind
           in
-          run_with_current_eio_context ?clock:current_clock ())
+          run_with_current_eio_context ?clock:current_clock ()
 ;;

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -11,12 +11,9 @@
     alias tool entries. The closure dispatches via
     [execute_keeper_tool_call_with_outcome] using [~name] as the
     INTERNAL tool name (telemetry SSOT). [~input_schema] is the
-    internal tool schema used for pre-execution validation. Alias callers may
-    pass [?pre_validate_input] to validate the raw public payload before
-    [?translate_input] reshapes it to the internal payload (identity by
-    default). When [?validate_translated_input] is [false], the translated
-    payload is dispatched after public validation; runtime handlers remain
-    responsible for their legacy internal argument checks. *)
+    internal tool schema used for pre-execution validation. Descriptor-backed
+    callers pass [?prepare_input] so validation and translation follow the
+    descriptor's typed policy before dispatch. *)
 val make_keeper_tool_handler
   :  name:string
   -> input_schema:Yojson.Safe.t
@@ -38,10 +35,8 @@ val make_keeper_tool_handler
   -> ?on_deferred:(unit -> unit)
   -> ?on_external_effect_deferred:(unit -> unit)
   -> ?on_failed:(Keeper_tools_oas.terminal_effect_failure -> unit)
-  -> ?pre_validate_input:
+  -> ?prepare_input:
        (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)
-  -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
-  -> ?validate_translated_input:bool
   -> unit
   -> ?oas_invocation:Agent_sdk.Tool_contract.Invocation.t
   -> Yojson.Safe.t

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -728,7 +728,11 @@ let test_read_public_validation_rejects_line_fields () =
       ; "end_line", `Int 280
       ]
   in
-  match Resolution.validate_public_input_for_tool_call ~tool_name:"Read" ~input with
+  match
+    Resolution.validated_descriptor_and_input_for_tool_call
+      ~tool_name:"Read"
+      ~input
+  with
   | Some (Error validation_result) ->
     let data = Tool_result.data validation_result |> Yojson.Safe.to_string in
     check_contains

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -682,42 +682,42 @@ let test_translation_validation_policy_is_typed_for_all_descriptors () =
   let probe = `Assoc [ "probe", `String "byte-identical" ] in
   List.iter
     (fun (descriptor : Descriptor.t) ->
-       let pre =
-         Descriptor.requires_pre_translation_validation descriptor
-       in
-       let post =
-         Descriptor.requires_post_translation_validation descriptor
-       in
        match descriptor.input_translation with
        | Descriptor.Identity _ ->
-         Alcotest.(check int)
-           (descriptor.id ^ " validates an identity payload exactly once")
-           1
-           ((if pre then 1 else 0) + if post then 1 else 0);
          Alcotest.(check bool)
            (descriptor.id ^ " identity translation is byte-identical")
            true
            (Yojson.Safe.equal
               probe
               (Descriptor.translate_input_for_descriptor descriptor probe))
-       | Descriptor.Schema_preserving _ ->
-         Alcotest.(check int)
-           (descriptor.id ^ " validates a schema-preserving payload exactly once")
-           1
-           ((if pre then 1 else 0) + if post then 1 else 0)
-       | Descriptor.Shape_changing
-           { validation = Descriptor.Validate_before_and_after_translation; _ } ->
-         Alcotest.(check bool)
-           (descriptor.id ^ " validates both shape boundaries")
-           true
-           (pre && post)
-       | Descriptor.Shape_changing
-           { validation = Descriptor.Validate_before_then_runtime_handler; _ } ->
-         Alcotest.(check bool)
-           (descriptor.id ^ " validates public input before runtime-owned validation")
-           true
-           (pre && not post))
+       | Descriptor.Shape_changing _ ->
+         ignore (Descriptor.translate_input_for_descriptor descriptor probe))
     (Descriptor.all_descriptors ())
+;;
+
+let test_shape_changing_post_validation_is_executed () =
+  let descriptor = required_public_descriptor "Grep" in
+  let descriptor =
+    { descriptor with
+      input_translation =
+        Descriptor.Shape_changing
+          { translate = (fun _ -> `Assoc [])
+          ; validation = Descriptor.Validate_before_and_after_translation
+          }
+    }
+  in
+  match
+    Resolution.prepare_model_input_for_descriptor
+      ~tool_name:"Grep"
+      descriptor
+      ~input:(`Assoc [ "pattern", `String "needle" ])
+  with
+  | Error validation_result ->
+    check_contains
+      "translated payload is validated"
+      ~sub:"pattern"
+      (Tool_result.data validation_result |> Yojson.Safe.to_string)
+  | Ok _ -> Alcotest.fail "translated payload skipped descriptor validation"
 ;;
 
 let test_read_public_validation_rejects_line_fields () =
@@ -1536,6 +1536,10 @@ let () =
             "translation validation policy is typed for all descriptors"
             `Quick
             test_translation_validation_policy_is_typed_for_all_descriptors
+        ; test_case
+            "shape-changing translations validate their output"
+            `Quick
+            test_shape_changing_post_validation_is_executed
         ; test_case
             "Read validates then translates supported public fields"
             `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -678,6 +678,22 @@ let test_read_public_descriptor_schema_is_closed () =
     (schema_forbids_additional_properties descriptor.input_schema)
 ;;
 
+let test_identity_translators_do_not_repeat_public_validation () =
+  List.iter
+    (fun name ->
+       let descriptor = required_public_descriptor name in
+       Alcotest.(check bool)
+         (name ^ " skips duplicate post-identity validation")
+         false
+         descriptor.validate_translated_input)
+    [ "Execute"; "WebSearch"; "WebFetch" ];
+  let grep = required_public_descriptor "Grep" in
+  Alcotest.(check bool)
+    "Grep retains post-translation validation"
+    true
+    grep.validate_translated_input
+;;
+
 let test_read_public_validation_rejects_line_fields () =
   let input =
     `Assoc
@@ -1490,6 +1506,10 @@ let () =
             "Read rejects unsupported line fields before translation"
             `Quick
             test_read_public_validation_rejects_line_fields
+        ; test_case
+            "identity translators validate the public payload once"
+            `Quick
+            test_identity_translators_do_not_repeat_public_validation
         ; test_case
             "Read validates then translates supported public fields"
             `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -678,20 +678,44 @@ let test_read_public_descriptor_schema_is_closed () =
     (schema_forbids_additional_properties descriptor.input_schema)
 ;;
 
-let test_identity_translators_do_not_repeat_public_validation () =
+let test_translation_validation_policy_is_typed_for_all_descriptors () =
+  let probe = `Assoc [ "probe", `String "byte-identical" ] in
   List.iter
-    (fun name ->
-       let descriptor = required_public_descriptor name in
-       Alcotest.(check bool)
-         (name ^ " skips duplicate post-identity validation")
-         false
-         descriptor.validate_translated_input)
-    [ "Execute"; "WebSearch"; "WebFetch" ];
-  let grep = required_public_descriptor "Grep" in
-  Alcotest.(check bool)
-    "Grep retains post-translation validation"
-    true
-    grep.validate_translated_input
+    (fun (descriptor : Descriptor.t) ->
+       let pre =
+         Descriptor.requires_pre_translation_validation descriptor
+       in
+       let post =
+         Descriptor.requires_post_translation_validation descriptor
+       in
+       match descriptor.input_translation with
+       | Descriptor.Identity _ ->
+         Alcotest.(check int)
+           (descriptor.id ^ " validates an identity payload exactly once")
+           1
+           ((if pre then 1 else 0) + if post then 1 else 0);
+         Alcotest.(check Yojson.Safe.equal)
+           (descriptor.id ^ " identity translation is byte-identical")
+           probe
+           (Descriptor.translate_input_for_descriptor descriptor probe)
+       | Descriptor.Schema_preserving _ ->
+         Alcotest.(check int)
+           (descriptor.id ^ " validates a schema-preserving payload exactly once")
+           1
+           ((if pre then 1 else 0) + if post then 1 else 0)
+       | Descriptor.Shape_changing
+           { validation = Descriptor.Validate_before_and_after_translation; _ } ->
+         Alcotest.(check bool)
+           (descriptor.id ^ " validates both shape boundaries")
+           true
+           (pre && post)
+       | Descriptor.Shape_changing
+           { validation = Descriptor.Validate_before_then_runtime_handler; _ } ->
+         Alcotest.(check bool)
+           (descriptor.id ^ " validates public input before runtime-owned validation")
+           true
+           (pre && not post))
+    (Descriptor.all_descriptors ())
 ;;
 
 let test_read_public_validation_rejects_line_fields () =
@@ -1507,9 +1531,9 @@ let () =
             `Quick
             test_read_public_validation_rejects_line_fields
         ; test_case
-            "identity translators validate the public payload once"
+            "translation validation policy is typed for all descriptors"
             `Quick
-            test_identity_translators_do_not_repeat_public_validation
+            test_translation_validation_policy_is_typed_for_all_descriptors
         ; test_case
             "Read validates then translates supported public fields"
             `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -694,10 +694,12 @@ let test_translation_validation_policy_is_typed_for_all_descriptors () =
            (descriptor.id ^ " validates an identity payload exactly once")
            1
            ((if pre then 1 else 0) + if post then 1 else 0);
-         Alcotest.(check Yojson.Safe.equal)
+         Alcotest.(check bool)
            (descriptor.id ^ " identity translation is byte-identical")
-           probe
-           (Descriptor.translate_input_for_descriptor descriptor probe)
+           true
+           (Yojson.Safe.equal
+              probe
+              (Descriptor.translate_input_for_descriptor descriptor probe))
        | Descriptor.Schema_preserving _ ->
          Alcotest.(check int)
            (descriptor.id ^ " validates a schema-preserving payload exactly once")


### PR DESCRIPTION
## Summary

- keep the public descriptor validation as the single schema Gate for the
  identity-translated `Execute`, `WebSearch`, and `WebFetch` model tools
- skip only the identical post-translation validation for those three tools
- retain post-translation validation for shape-changing `Grep` and for internal
  identity descriptors that do not have a guaranteed public pre-validation
- add a registry contract test pinning that blast radius

## Feature path

`Keeper_tools_oas_bundle` registers every model-visible descriptor and calls
`validate_public_input_for_tool_call` before `descriptor.translate`. For these
three public descriptors, `translate_identity` returns the exact same JSON and
the handler previously ran the same `input_schema` validation again.

Invalid public payloads are still rejected before dispatch, while valid
payloads now cross one schema Gate. Shape-changing and internal-only paths keep
their leaf validation.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_tool_descriptor.ml test/test_keeper_tool_descriptor_registry_integrity.ml`
- `ocamlc -stop-after parsing -c lib/keeper/keeper_tool_descriptor.ml`
- `ocamlc -stop-after parsing -c test/test_keeper_tool_descriptor_registry_integrity.ml`
- focused Dune build requested:
  `scripts/dune-local.sh build test/test_keeper_tool_descriptor_registry_integrity.exe`
  but the wrapper correctly refused while an unrelated bare `dune build .`
  process was active; Draft CI is required for typed build/test authority
