### PR TITLE
chore(oas): typed GLM stream dialect 릴리스 pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@
   - `merge_keeper_profile_defaults` and `merge_string_list` are retained: they still implement the persona `profile.json` → keeper TOML overlay (`keeper_types_profile.ml:244`), which is a separate mechanism. Note `merge_string_list` is replace-if-non-empty, not union.
 
 ### Changed
+- Bumped the OAS Agent SDK pin to v0.231.3
+  (`e01940b14d501900b8cbfa2fbb1e0484ada5a42d`). The GLM streaming backend now
+  consumes the catalog-resolved typed reasoning dialect instead of hardcoding
+  `reasoning_content`; MASC's deployment overlay declares the exact
+  `delta:reasoning_content` capability for both GLM-5-Turbo provider bindings.
 - Provider materialization and registry/model-string resolution now share
   `Runtime_provider_binding.default_headers_for_kind` as the sole owner of
   non-credential provider header defaults. The duplicate Runtime adapter

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.2-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.3-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.2`, runtime pin: `main@1ea60e7a1d379d0229eb1c83cfd5005b429eca81`, declared base version: `v0.231.2`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.3`, runtime pin: `main@e01940b14d501900b8cbfa2fbb1e0484ada5a42d`, declared base version: `v0.231.3`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.2))
+  (agent_sdk (>= 0.231.3))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.2"}
+  "agent_sdk" {>= "0.231.3"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.2"}
+  "agent_sdk" {= "0.231.3"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.2"
-  "git+https://github.com/jeong-sik/oas.git#1ea60e7a1d379d0229eb1c83cfd5005b429eca81"
+  "agent_sdk.0.231.3"
+  "git+https://github.com/jeong-sik/oas.git#e01940b14d501900b8cbfa2fbb1e0484ada5a42d"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.2"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.3"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -35,10 +35,15 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.2"
 # remain separate concerns. It also carries the #2875 agent-card
 # current-interface contract hard-cut. MASC consumes the same public Agent SDK
 # contract; no compatibility or migration code retained.
-# Pinned to the 0.231.2 release commit (1ea60e7a1).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.2"
+# v0.231.3 resolves the catalog-declared streaming reasoning dialect once and
+# passes that typed value to the GLM stream parser (#2883). This removes the
+# backend's hardcoded reasoning_content field without adding model-name or
+# provider heuristics. MASC's exact overlay declares the corresponding
+# delta:reasoning_content capability.
+# Previous pin: v0.231.2 (1ea60e7a1).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.3"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="1ea60e7a1d379d0229eb1c83cfd5005b429eca81"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.2"
+readonly OAS_AGENT_SDK_SHA="e01940b14d501900b8cbfa2fbb1e0484ada5a42d"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.3"


### PR DESCRIPTION
대상 SHA: `145657a0f68b5e41fa4025084c0a28a6b787be5b`예용.

- OAS v0.231.3 `e01940b14d501900b8cbfa2fbb1e0484ada5a42d`로 pin을 올렸어용.
- #2883의 typed GLM stream dialect parser를 MASC가 실제 소비하게 했어용.
- pin SSOT에서 dune/opam/locked/doc manifest를 재생성했어용.

OAS v0.231.3의 OCaml 5.4.1, 5.5.0, Eio 1.3/1.4 포함 CI는 모두 성공했어용. 로컬은 pin manifest check, bash -n, diff check만 수행했고 Dune은 MASC CI에서 확인해용.

연계: jeong-sik/oas#2883, jeong-sik/masc#26329
근거: https://docs.z.ai/guides/llm/glm-5-turbo