### PR TITLE
chore(oas): API surface fingerprint 정합화

### DIFF
--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835",
-  "pinned_version": "v0.231.1",
+  "pinned_sha": "e01940b14d501900b8cbfa2fbb1e0484ada5a42d",
+  "pinned_version": "v0.231.3",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
대상 SHA: `2a94c6f4d839e4c182b9dec27837335ef61c4c52`예용.

#26335가 CI 전 병합되면서 OAS v0.231.3 pin은 들어갔지만 API fingerprint metadata가 v0.231.1에 남았어용. `oas-drift-check.sh --regenerate` 결과 public surface 목록은 동일했고 pin SHA/version 두 필드만 바뀌었어용.

pin manifest check와 diff check를 통과했어용. Dune은 CI에서 확인해용.

연계: #26335