### PR TITLE
chore(oas): refresh v0.231.3 API fingerprint

### DIFF
--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "c3bb4daa7b6e2e5f7c54b0e1a4ade887f876d835",
-  "pinned_version": "v0.231.1",
+  "pinned_sha": "e01940b14d501900b8cbfa2fbb1e0484ada5a42d",
+  "pinned_version": "v0.231.3",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## What changed

- regenerate `scripts/oas-api-surface.json` against the current OAS v0.231.3 pin
- update only fingerprint metadata from v0.231.1 to v0.231.3

## Why

Current `main` pins Agent SDK v0.231.3 but retains the v0.231.1 fingerprint, so `Meta Guards` fails for unrelated PRs. The generated public surface is otherwise byte-identical; this PR does not add a capability gate, compatibility layer, migration, or runtime behavior.

## Validation

- `bash scripts/oas-drift-check.sh --regenerate`
- `bash scripts/oas-drift-check.sh` → matches fingerprint
- `git diff --check`

Closes #26337.