### PR TITLE
fix(dashboard): model_map_of_keeper_rows inserts zero rows — agents[].model permanent null

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -878,7 +878,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          operator_targets="@test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache"
+          operator_targets="@test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache @test/runtest-test_model_map_of_keeper_rows"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${operator_targets}"
 
       - name: Run SSE reconnect e2e

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -495,11 +495,13 @@ let model_map_of_keeper_rows keepers =
   List.fold_left
     (fun model_map -> function
       | `Assoc _ as keeper_json ->
-        (match Json_util.assoc_member_opt "name" keeper_json,
+        (match Json_util.assoc_member_opt "agent_name" keeper_json,
                Json_util.assoc_member_opt "active_model" keeper_json with
-         | Some (`String name), Some (`String model) ->
-           (match String_util.trim_to_option name, String_util.trim_to_option model with
-            | Some _, Some model -> Agent_name_map.add name model model_map
+         | Some (`String agent_name), Some (`String raw_model) ->
+           (match String_util.trim_to_option agent_name,
+                 String_util.trim_to_option raw_model with
+            | Some agent_name, Some model ->
+              Agent_name_map.add agent_name model model_map
             | None, _ | _, None -> model_map)
          | Some (`String _), _
          | _, Some (`String _)

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -2,7 +2,7 @@ include Dashboard_execution_helpers
 include Dashboard_execution_fixture
 include Dashboard_execution_builders
 
-module Agent_name_map = Map.Make (String)
+module Agent_name_map = Set_util.StringMap
 
 let workspace_status_json (config : Workspace.config) : Yojson.Safe.t =
   let workspace_state_opt =
@@ -497,12 +497,8 @@ let model_map_of_keeper_rows keepers =
       | `Assoc _ as keeper_json ->
         (match Json_util.assoc_member_opt "agent_name" keeper_json,
                Json_util.assoc_member_opt "active_model" keeper_json with
-         | Some (`String agent_name), Some (`String raw_model) ->
-           (match String_util.trim_to_option agent_name,
-                 String_util.trim_to_option raw_model with
-            | Some agent_name, Some model ->
-              Agent_name_map.add agent_name model model_map
-            | None, _ | _, None -> model_map)
+         | Some (`String agent_name), Some (`String model) ->
+           Agent_name_map.add agent_name model model_map
          | Some (`String _), _
          | _, Some (`String _)
          | _, _ -> model_map)

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -496,7 +496,8 @@ let model_map_of_keeper_rows keepers =
       | `Assoc _ as keeper_json ->
         (match Json_util.assoc_member_opt "name" keeper_json,
                Json_util.assoc_member_opt "active_model" keeper_json with
-         | Some (`String _), Some (`String _)
+         | Some (`String name), Some (`String model) ->
+             Hashtbl.add model_map name model
          | Some (`String _), _
          | _, Some (`String _)
          | _, _ -> ())

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -2,6 +2,8 @@ include Dashboard_execution_helpers
 include Dashboard_execution_fixture
 include Dashboard_execution_builders
 
+module Agent_name_map = Map.Make (String)
+
 let workspace_status_json (config : Workspace.config) : Yojson.Safe.t =
   let workspace_state_opt =
     if Workspace.is_initialized config then Some (Workspace.read_state config) else None
@@ -490,20 +492,22 @@ let merge_execution_queue left right =
 ;;
 
 let model_map_of_keeper_rows keepers =
-  let model_map : (string, string) Hashtbl.t = Hashtbl.create 8 in
-  List.iter
-    (function
+  List.fold_left
+    (fun model_map -> function
       | `Assoc _ as keeper_json ->
         (match Json_util.assoc_member_opt "name" keeper_json,
                Json_util.assoc_member_opt "active_model" keeper_json with
          | Some (`String name), Some (`String model) ->
-             Hashtbl.add model_map name model
+           (match String_util.trim_to_option name, String_util.trim_to_option model with
+            | Some _, Some model -> Agent_name_map.add name model model_map
+            | None, _ | _, None -> model_map)
          | Some (`String _), _
          | _, Some (`String _)
-         | _, _ -> ())
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> ())
-    keepers;
-  model_map
+         | _, _ -> model_map)
+      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+        model_map)
+    Agent_name_map.empty
+    keepers
 ;;
 
 let task_updated_at (task : Masc_domain.task) =
@@ -577,12 +581,12 @@ let task_json ~goal_task_index (task : Masc_domain.task) =
   `Assoc fields
 ;;
 
-let agent_json ~(model_map : (string, string) Hashtbl.t) (agent : Masc_domain.agent) =
+let agent_json ~model_map (agent : Masc_domain.agent) =
   let profile = get_agent_profile agent.name in
   let model_value =
-    match Hashtbl.find_opt model_map agent.name with
-    | Some m when m <> "" -> `String m
-    | _ -> `Null
+    match Agent_name_map.find_opt agent.name model_map with
+    | Some model -> `String model
+    | None -> `Null
   in
   `Assoc
     [ "name", `String agent.name
@@ -596,6 +600,11 @@ let agent_json ~(model_map : (string, string) Hashtbl.t) (agent : Masc_domain.ag
     ; "koreanName", `String profile.korean_name
     ; "model", model_value
     ]
+;;
+
+let agents_json ~keepers ~agents =
+  let model_map = model_map_of_keeper_rows keepers in
+  `List (List.map (agent_json ~model_map) agents)
 ;;
 
 let message_json (message : Masc_domain.message) =
@@ -807,9 +816,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       ; ( "offline_worker_briefs"
         , `List (List.map (fun (row : worker_context) -> row.json) offline_worker_briefs)
         )
-      ; ( "agents"
-        , let model_map = model_map_of_keeper_rows keepers in
-          `List (List.map (agent_json ~model_map) agents) )
+      ; "agents", agents_json ~keepers ~agents
       ; (* pipeline_stage is now included in the snapshot keepers_json,
              so no redundant read_meta + parse_agent_status needed here. *)
         "keepers", `List keepers
@@ -896,3 +903,7 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
          ; "status", workspace_status_json config
          ])
 ;;
+
+module For_test = struct
+  let agents_json = agents_json
+end

--- a/lib/dashboard/dashboard_execution.mli
+++ b/lib/dashboard/dashboard_execution.mli
@@ -45,6 +45,10 @@ val record_render_phase_timings : render_phase_timings_ms -> unit
     slow-render log payload so dashboard N+1 / enrichment cost is visible
     even when the render stays below the warning threshold. *)
 
+val model_map_of_keeper_rows : Yojson.Safe.t list -> (string, string) Hashtbl.t
+(** Build a name→active_model lookup from keeper JSON rows.
+    Exposed for regression testing of the agents[].model wire contract. *)
+
 val terminal_reason_requires_attention : Yojson.Safe.t -> bool
 (** Strict typed projection for a runtime-trust [latest_terminal_reason].
     Missing reason is non-attention; malformed or non-success dispositions are

--- a/lib/dashboard/dashboard_execution.mli
+++ b/lib/dashboard/dashboard_execution.mli
@@ -45,11 +45,15 @@ val record_render_phase_timings : render_phase_timings_ms -> unit
     slow-render log payload so dashboard N+1 / enrichment cost is visible
     even when the render stays below the warning threshold. *)
 
-val model_map_of_keeper_rows : Yojson.Safe.t list -> (string, string) Hashtbl.t
-(** Build a name→active_model lookup from keeper JSON rows.
-    Exposed for regression testing of the agents[].model wire contract. *)
-
 val terminal_reason_requires_attention : Yojson.Safe.t -> bool
 (** Strict typed projection for a runtime-trust [latest_terminal_reason].
     Missing reason is non-attention; malformed or non-success dispositions are
     attention. Exposed for wire-contract regression tests. *)
+
+module For_test : sig
+  val agents_json :
+    keepers:Yojson.Safe.t list ->
+    agents:Masc_domain.agent list ->
+    Yojson.Safe.t
+  (** Exact production projection for the ["agents"] execution-dashboard field. *)
+end

--- a/test/dune
+++ b/test/dune
@@ -980,6 +980,7 @@
   test_local_runtime_pool
   test_dashboard_render_timing_9766
   test_dashboard_keeper_cost_aggregates
+  test_model_map_of_keeper_rows
   test_task_status_label_10421  test_task_cache_invariant_13397
   test_sandbox_inspect_trim_10488
   test_credential_alias_10440
@@ -1142,6 +1143,7 @@
   test_local_runtime_pool
   test_dashboard_render_timing_9766
   test_dashboard_keeper_cost_aggregates
+  test_model_map_of_keeper_rows
   test_task_status_label_10421  test_task_cache_invariant_13397
   test_sandbox_inspect_trim_10488
   test_credential_alias_10440

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -55,6 +55,8 @@ let test_projects_active_models_to_agents_wire () =
 
 let () =
   run "dashboard agent model projection"
-    [ test_case "projects active models to agents wire" `Quick
-        test_projects_active_models_to_agents_wire
+    [ ( "agents wire",
+        [ test_case "projects active models to agents wire" `Quick
+            test_projects_active_models_to_agents_wire
+        ] )
     ]

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -6,10 +6,10 @@ open Alcotest
 
 let json = testable Yojson.Safe.pp Yojson.Safe.equal
 
-let agent name : Masc_domain.agent =
+let agent ~agent_type name : Masc_domain.agent =
   { id = None
   ; name
-  ; agent_type = "test"
+  ; agent_type
   ; status = Masc_domain.Active
   ; capabilities = []
   ; current_task = None
@@ -32,37 +32,28 @@ let model_of_agent name = function
 ;;
 
 let test_projects_active_models_to_agents_wire () =
-  (* Production keeper rows carry both "name" (display) and "agent_name"
-     (canonical keeper identity used by agent.name in the agents list).
-     The model map must join on agent_name. *)
+  let keeper_name = "alice" in
+  let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
   let keepers =
-    [ `Assoc [ "name", `String "Alice Kim"; "agent_name", `String "keeper-alice-agent"; "active_model", `String "old-model" ]
-    ; `Assoc [ "name", `String "Alice Kim"; "agent_name", `String "keeper-alice-agent"; "active_model", `String "current-model" ]
-    ; `Assoc [ "name", `String "Bob Lee"; "agent_name", `String "keeper-bob-agent"; "active_model", `String "   " ]
-    ; `Assoc [ "name", `String "Carol"; "agent_name", `String "keeper-carol-agent" ]
-    ; `Assoc [ "agent_name", `String "keeper-dave-agent"; "active_model", `String "no-display-name" ]
-    ; `Assoc [ "name", `String "Eve"; "active_model", `String "missing-agent-name" ]
-    ; `Null
+    [ `Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String keeper_agent_name
+        ; "active_model", `String "model-x"
+        ]
     ]
   in
   let agents =
-    List.map agent [ "keeper-alice-agent"; "keeper-bob-agent"; "keeper-carol-agent"; "keeper-dave-agent"; "keeper-eve-agent" ]
+    [ agent ~agent_type:"keeper" keeper_agent_name
+    ; agent ~agent_type:"test" keeper_name
+    ]
   in
   let agents_json = Dashboard_execution.For_test.agents_json ~keepers ~agents in
-  (* latest row wins for duplicate agent_name keys *)
-  check json "latest exact keeper row wins"
-    (`String "current-model")
-    (model_of_agent "keeper-alice-agent" agents_json);
-  (* whitespace-only active_model is trimmed to None → null *)
-  List.iter
-    (fun name ->
-       check json (name ^ " has no active model") `Null
-         (model_of_agent name agents_json))
-    [ "keeper-bob-agent"; "keeper-carol-agent"; "keeper-eve-agent" ];
-  (* row with agent_name but no display name still resolves *)
-  check json "row with agent_name only resolves"
-    (`String "no-display-name")
-    (model_of_agent "keeper-dave-agent" agents_json)
+  check json "canonical keeper agent receives its model"
+    (`String "model-x")
+    (model_of_agent keeper_agent_name agents_json);
+  check json "same bare name does not receive the keeper model"
+    `Null
+    (model_of_agent keeper_name agents_json)
 ;;
 
 let () =

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -32,25 +32,37 @@ let model_of_agent name = function
 ;;
 
 let test_projects_active_models_to_agents_wire () =
+  (* Production keeper rows carry both "name" (display) and "agent_name"
+     (canonical keeper identity used by agent.name in the agents list).
+     The model map must join on agent_name. *)
   let keepers =
-    [ `Assoc [ "name", `String "alice"; "active_model", `String "old-model" ]
-    ; `Assoc [ "name", `String "alice"; "active_model", `String "current-model" ]
-    ; `Assoc [ "name", `String "bob"; "active_model", `String "   " ]
-    ; `Assoc [ "name", `String "carol" ]
-    ; `Assoc [ "active_model", `String "no-name" ]
+    [ `Assoc [ "name", `String "Alice Kim"; "agent_name", `String "keeper-alice-agent"; "active_model", `String "old-model" ]
+    ; `Assoc [ "name", `String "Alice Kim"; "agent_name", `String "keeper-alice-agent"; "active_model", `String "current-model" ]
+    ; `Assoc [ "name", `String "Bob Lee"; "agent_name", `String "keeper-bob-agent"; "active_model", `String "   " ]
+    ; `Assoc [ "name", `String "Carol"; "agent_name", `String "keeper-carol-agent" ]
+    ; `Assoc [ "agent_name", `String "keeper-dave-agent"; "active_model", `String "no-display-name" ]
+    ; `Assoc [ "name", `String "Eve"; "active_model", `String "missing-agent-name" ]
     ; `Null
     ]
   in
-  let agents = List.map agent [ "alice"; "bob"; "carol"; "dave" ] in
+  let agents =
+    List.map agent [ "keeper-alice-agent"; "keeper-bob-agent"; "keeper-carol-agent"; "keeper-dave-agent"; "keeper-eve-agent" ]
+  in
   let agents_json = Dashboard_execution.For_test.agents_json ~keepers ~agents in
+  (* latest row wins for duplicate agent_name keys *)
   check json "latest exact keeper row wins"
     (`String "current-model")
-    (model_of_agent "alice" agents_json);
+    (model_of_agent "keeper-alice-agent" agents_json);
+  (* whitespace-only active_model is trimmed to None → null *)
   List.iter
     (fun name ->
        check json (name ^ " has no active model") `Null
          (model_of_agent name agents_json))
-    [ "bob"; "carol"; "dave" ]
+    [ "keeper-bob-agent"; "keeper-carol-agent"; "keeper-eve-agent" ];
+  (* row with agent_name but no display name still resolves *)
+  check json "row with agent_name only resolves"
+    (`String "no-display-name")
+    (model_of_agent "keeper-dave-agent" agents_json)
 ;;
 
 let () =

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -1,0 +1,39 @@
+(** Regression test: model_map_of_keeper_rows must insert into the Hashtbl.
+    Bug: all four match arms ended in () (no Hashtbl.add), so agents[].model
+    was permanently null in the dashboard execution JSON. *)
+
+open Alcotest
+
+let check_equal ~label actual expected =
+  check (option string) label actual expected
+
+let test_inserts_name_and_model () =
+  let keepers =
+    [ `Assoc [ ("name", `String "alice"); ("active_model", `String "gpt-4o") ]
+    ; `Assoc [ ("name", `String "bob"); ("active_model", `String "claude-3.5") ]
+    ; `Assoc [ ("name", `String "carol"); ("active_model", `String "") ]
+    ; `Assoc [ ("name", `String "dave") ]
+    ; `Assoc [("active_model", `String "no-name")]
+    ; `Null
+    ]
+  in
+  let map = Dashboard_execution.model_map_of_keeper_rows keepers in
+  check_equal ~label:"alice model"
+    (Hashtbl.find_opt map "alice") (Some "gpt-4o");
+  check_equal ~label:"bob model"
+    (Hashtbl.find_opt map "bob") (Some "claude-3.5");
+  check_equal ~label:"carol empty model"
+    (Hashtbl.find_opt map "carol") None;
+  check_equal ~label:"dave no model"
+    (Hashtbl.find_opt map "dave") None;
+  check_equal ~label:"no-name row"
+    (Hashtbl.find_opt map "") None;
+  let n = ref 0 in
+  Hashtbl.iter (fun _ _ -> incr n) map;
+  check int "hashtbl length" !n 2
+
+let () =
+  run "model_map_of_keeper_rows"
+    [ test_case "inserts name and active_model into hashtbl" `Quick
+        test_inserts_name_and_model
+    ]

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -1,39 +1,58 @@
-(** Regression test: model_map_of_keeper_rows must insert into the Hashtbl.
-    Bug: all four match arms ended in () (no Hashtbl.add), so agents[].model
-    was permanently null in the dashboard execution JSON. *)
+(** Regression test for the execution-dashboard ["agents"] wire projection.
+    Bug: the keeper-name to active-model index stayed empty, so every
+    ["agents"][].["model"] was null. *)
 
 open Alcotest
 
-let check_equal ~label actual expected =
-  check (option string) label actual expected
+let agent name : Masc_domain.agent =
+  { id = None
+  ; name
+  ; agent_type = "test"
+  ; status = Masc_domain.Active
+  ; capabilities = []
+  ; current_task = None
+  ; session_bound_at = "2026-07-29T00:00:00Z"
+  ; last_seen = "2026-07-29T00:00:00Z"
+  ; meta = None
+  }
+;;
 
-let test_inserts_name_and_model () =
+let model_of_agent name = function
+  | `List agents ->
+    (match
+       List.find_opt
+         (fun agent -> Yojson.Safe.Util.(agent |> member "name" |> to_string) = name)
+         agents
+     with
+     | Some agent -> Yojson.Safe.Util.member "model" agent
+     | None -> failf "missing agent %s" name)
+  | json -> failf "agents field is not a list: %s" (Yojson.Safe.to_string json)
+;;
+
+let test_projects_active_models_to_agents_wire () =
   let keepers =
-    [ `Assoc [ ("name", `String "alice"); ("active_model", `String "gpt-4o") ]
-    ; `Assoc [ ("name", `String "bob"); ("active_model", `String "claude-3.5") ]
-    ; `Assoc [ ("name", `String "carol"); ("active_model", `String "") ]
-    ; `Assoc [ ("name", `String "dave") ]
-    ; `Assoc [("active_model", `String "no-name")]
+    [ `Assoc [ "name", `String "alice"; "active_model", `String "old-model" ]
+    ; `Assoc [ "name", `String "alice"; "active_model", `String "current-model" ]
+    ; `Assoc [ "name", `String "bob"; "active_model", `String "   " ]
+    ; `Assoc [ "name", `String "carol" ]
+    ; `Assoc [ "active_model", `String "no-name" ]
     ; `Null
     ]
   in
-  let map = Dashboard_execution.model_map_of_keeper_rows keepers in
-  check_equal ~label:"alice model"
-    (Hashtbl.find_opt map "alice") (Some "gpt-4o");
-  check_equal ~label:"bob model"
-    (Hashtbl.find_opt map "bob") (Some "claude-3.5");
-  check_equal ~label:"carol empty model"
-    (Hashtbl.find_opt map "carol") None;
-  check_equal ~label:"dave no model"
-    (Hashtbl.find_opt map "dave") None;
-  check_equal ~label:"no-name row"
-    (Hashtbl.find_opt map "") None;
-  let n = ref 0 in
-  Hashtbl.iter (fun _ _ -> incr n) map;
-  check int "hashtbl length" !n 2
+  let agents = List.map agent [ "alice"; "bob"; "carol"; "dave" ] in
+  let agents_json = Dashboard_execution.For_test.agents_json ~keepers ~agents in
+  check Yojson.Safe.equal "latest exact keeper row wins"
+    (`String "current-model")
+    (model_of_agent "alice" agents_json);
+  List.iter
+    (fun name ->
+       check Yojson.Safe.equal (name ^ " has no active model") `Null
+         (model_of_agent name agents_json))
+    [ "bob"; "carol"; "dave" ]
+;;
 
 let () =
-  run "model_map_of_keeper_rows"
-    [ test_case "inserts name and active_model into hashtbl" `Quick
-        test_inserts_name_and_model
+  run "dashboard agent model projection"
+    [ test_case "projects active models to agents wire" `Quick
+        test_projects_active_models_to_agents_wire
     ]

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -33,7 +33,7 @@ let model_of_agent name = function
 
 let test_projects_active_models_to_agents_wire () =
   let keeper_name = "alice" in
-  let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
+  let keeper_agent_name = "keeper-" ^ keeper_name ^ "-agent" in
   let keepers =
     [ `Assoc
         [ "name", `String keeper_name

--- a/test/test_model_map_of_keeper_rows.ml
+++ b/test/test_model_map_of_keeper_rows.ml
@@ -4,6 +4,8 @@
 
 open Alcotest
 
+let json = testable Yojson.Safe.pp Yojson.Safe.equal
+
 let agent name : Masc_domain.agent =
   { id = None
   ; name
@@ -41,12 +43,12 @@ let test_projects_active_models_to_agents_wire () =
   in
   let agents = List.map agent [ "alice"; "bob"; "carol"; "dave" ] in
   let agents_json = Dashboard_execution.For_test.agents_json ~keepers ~agents in
-  check Yojson.Safe.equal "latest exact keeper row wins"
+  check json "latest exact keeper row wins"
     (`String "current-model")
     (model_of_agent "alice" agents_json);
   List.iter
     (fun name ->
-       check Yojson.Safe.equal (name ^ " has no active model") `Null
+       check json (name ^ " has no active model") `Null
          (model_of_agent name agents_json))
     [ "bob"; "carol"; "dave" ]
 ;;


### PR DESCRIPTION
## Bug

`model_map_of_keeper_rows`의 기존 분기는 어떤 Keeper row도 map에 넣지 않아 execution dashboard의 `agents[].model`이 항상 `null`이었습니다.

## Root Cause

모델은 Keeper snapshot row에서 오지만 결합 대상은 Runtime agent입니다. 생산 계약은 다음 두 identity를 구분합니다.

- `name = meta.name`: Keeper 이름
- `agent_name = meta.agent_name`: Runtime agent identity

따라서 `name` 기반 결합은 정상 Keeper를 놓치고, 같은 bare name을 가진 일반 agent에 모델을 잘못 귀속할 수 있습니다.

## Fix

- immutable `Set_util.StringMap`을 사용합니다.
- 별칭 추측이나 legacy fallback 없이 row의 exact `agent_name`으로만 `agent.name`과 결합합니다.
- producer가 제공한 `active_model` 값을 그대로 투영합니다.

## Regression

`test_model_map_of_keeper_rows`가 production-shaped row를 사용해 다음을 검증합니다.

- canonical Keeper agent가 정확한 모델을 받습니다.
- 같은 bare name의 일반 agent는 Keeper 모델을 받지 않습니다.
- 테스트는 기존 operator CI suite의 focused runtest target에서 실제 실행됩니다.

## Validation

- `ocamlformat --check`
- OCaml parser check
- workflow YAML parse
- `git diff --check`
- Dune 실행 결과는 exact-head PR CI를 권위로 사용합니다.

## Task

Closes: task-010