### PR TITLE
refactor(gate): reject retired retryable snapshot field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Breaking (approval snapshot wire)**: `summary_status.failed.retryable`
+  is no longer accepted and discarded while loading pending approvals. Current
+  snapshots contain only `status` and `reason`; snapshots carrying the retired
+  field fail closed through the existing unavailable-store path. No migration
+  or repair path was added.
 - **Breaking (recall injection ledger)**: schema v3 adds a required typed
   `reset` marker. The first row for each keeper process now resets replay state
   before applying its exact current baseline, so keys deleted across a process

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -688,17 +688,11 @@ let summary_status_of_yojson_with_error json =
        let* () =
          reject_unknown_fields
            ~surface:"summary_status"
-           ~allowed:[ "status"; "reason"; "retryable" ]
+           ~allowed:[ "status"; "reason" ]
            fields
        in
        let* reason = required_string ~surface:"summary_status" "reason" fields in
-       (* Legacy field: pre-#26094 stores persisted a write-only [retryable]
-          bool that no OCaml or dashboard reader consumed, and whose [true]
-          value blanked the dashboard approval queue. Accepted and discarded
-          on load so existing stores keep parsing; never written back. *)
-       (match List.assoc_opt "retryable" fields with
-        | None | Some (`Bool _) -> Ok (Summary_failed { reason })
-        | Some _ -> Error "summary_status.retryable must be a boolean when present")
+       Ok (Summary_failed { reason })
      | other -> Error (Printf.sprintf "summary_status.status %S is unknown" other))
   | _ -> Error "summary_status must be a known string or JSON object"
 ;;

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -148,10 +148,6 @@ let test_rule_parser_rejects_duplicate_fields () =
       reason
 ;;
 
-(* #26094: [retryable] was a write-only bool — OCaml only ever wrote [false],
-   no reader consumed it, and the dashboard blanked the whole approval queue on
-   any other value. The field left the wire contract; stores written before the
-   removal still parse, and the serializer never emits it again. *)
 let test_summary_failed_has_no_retryable () =
   let failed = Q.Summary_failed { reason = "provider down" } in
   (match Q.summary_status_to_yojson failed with
@@ -168,26 +164,24 @@ let test_summary_failed_has_no_retryable () =
    with
    | Ok status -> check bool "modern decode" true (status = failed)
    | Error e -> fail e);
-  (match
-     decode
-       (`Assoc
-           [ "status", `String "failed"
-           ; "reason", `String "provider down"
-           ; "retryable", `Bool true
-           ])
-   with
-   | Ok status -> check bool "legacy retryable discarded" true (status = failed)
-   | Error e -> fail e);
-  match
-    decode
-      (`Assoc
-          [ "status", `String "failed"
-          ; "reason", `String "provider down"
-          ; "retryable", `String "yes"
-          ])
-  with
-  | Ok _ -> fail "non-boolean legacy retryable must reject"
-  | Error _ -> ()
+  List.iter
+    (fun retryable ->
+       match
+         decode
+           (`Assoc
+               [ "status", `String "failed"
+               ; "reason", `String "provider down"
+               ; "retryable", retryable
+               ])
+       with
+       | Ok _ -> fail "removed retryable field must reject"
+       | Error reason ->
+         check
+           string
+           "removed field is explicit"
+           "summary_status contains unsupported field retryable"
+           reason)
+    [ `Bool true; `String "yes" ]
 ;;
 
 let () =
@@ -199,7 +193,7 @@ let () =
         ] )
     ; ( "summary status"
       , [ test_case
-            "retryable is out of the contract, legacy stores still parse"
+            "retryable is rejected by the current contract"
             `Quick
             test_summary_failed_has_no_retryable
         ] )


### PR DESCRIPTION
## Summary

- remove the retired `summary_status.failed.retryable` field from the approval
  snapshot decoder allowlist
- reject both boolean and malformed values as an unsupported current-wire field
- keep the current serializer unchanged (`status` + `reason` only)
- add no migration, repair, default fill, or compatibility branch

## Feature path

`Keeper_approval_queue.load_snapshot_unlocked` decodes every persisted pending
approval through `pending_entry_of_yojson` and
`summary_status_of_yojson_with_error`. A decode error already:

1. records an `invalid_payload` persistence drop,
2. marks the workspace approval store unavailable,
3. rejects further queue mutations, and
4. leaves the original snapshot untouched.

The retired field therefore uses the existing fail-closed recovery behavior
instead of being accepted and discarded or migrated.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper_contract/keeper_approval_queue_rules_types.ml test/test_keeper_approval_queue_rules_types.ml`
- `ocamlc -stop-after parsing -c lib/keeper_contract/keeper_approval_queue_rules_types.ml`
- `ocamlc -stop-after parsing -c test/test_keeper_approval_queue_rules_types.ml`
- focused Dune build requested:
  `scripts/dune-local.sh build test/test_keeper_approval_queue_rules_types.exe`
  but the wrapper correctly refused while unrelated bare Dune processes were
  active; Draft CI is required for typed build/test authority
