### PR TITLE
fix(keeper): keep restart ownership in supervisor sweep

### DIFF
--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -1,9 +1,10 @@
 (** Keepalive supervision entry-point, extracted from
     [keeper_supervisor.ml] (godfile decomp).
 
-    [supervise_keepalive] is the gate that decides whether to spawn a
-    supervised keepalive fiber for [meta]. Idempotent on already-
-    registered keepers (no-op). On a fresh registration:
+    [supervise_keepalive] decides whether to spawn a supervised
+    keepalive fiber for [meta]. It launches fresh registrations and
+    resumes registrations still in [Offline]. Other registered phases
+    remain owned by the lifecycle sweep. On a fresh registration:
 
     1. Asks [Keeper_registry] for a spawn-slot decision. On [Error
        reason], records the denial and publishes an [Admission_denied]
@@ -165,23 +166,6 @@ let supervise_keepalive
         detail
     | Ok reg -> launch_registered reg
   in
-  let reclaim_finished_entry (entry : Keeper_registry.registry_entry) =
-    if Option.is_some (Eio.Promise.peek entry.done_p)
-       && Keeper_registry.lane_has_exited entry
-    then
-      match Keeper_registry.unregister_exact entry with
-      | Keeper_registry.Exact_unregistered
-      | Keeper_registry.Exact_entry_missing -> ()
-      | Keeper_registry.Exact_entry_replaced ->
-        Log.Keeper.info
-          "supervisor recovery retained newer lane for %s"
-          meta.name
-      | Keeper_registry.Exact_unregister_lifecycle_reserved owner ->
-        Log.Keeper.warn
-          "supervisor recovery could not reclaim %s because lifecycle transaction owns admission: %s"
-          meta.name
-          (Keeper_lifecycle_reservation.snapshot_to_string owner)
-  in
   match execution_truth with
   | Keeper_activation_readiness.Unknown detail ->
     record_recovery_retained "unknown";
@@ -215,9 +199,24 @@ let supervise_keepalive
       reason
   | Keeper_activation_readiness.Executable -> ()
   | Keeper_activation_readiness.Recoverable ->
-    Option.iter reclaim_finished_entry
-      (Keeper_registry.get ~base_path meta.name);
     (match Keeper_registry.get ~base_path meta.name with
-     | Some reg -> launch_registered reg
-     | None -> register_and_launch ())
+     | None -> register_and_launch ()
+     | Some reg ->
+       (match reg.phase with
+        | Keeper_state_machine.Offline -> launch_registered reg
+        | Keeper_state_machine.Running
+        | Keeper_state_machine.Failing
+        | Keeper_state_machine.Overflowed
+        | Keeper_state_machine.Compacting
+        | Keeper_state_machine.HandingOff
+        | Keeper_state_machine.Draining
+        | Keeper_state_machine.Paused
+        | Keeper_state_machine.Stopped
+        | Keeper_state_machine.Crashed
+        | Keeper_state_machine.Restarting
+        | Keeper_state_machine.Dead ->
+          Log.Keeper.debug
+            "%s: supervisor keepalive retained existing %s owner for lifecycle sweep"
+            meta.name
+            (Keeper_state_machine.phase_to_string reg.phase)))
 ;;

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -17,11 +17,11 @@ val supervise_keepalive :
   'a Keeper_types_profile.context ->
   Keeper_meta_contract.keeper_meta ->
   unit
-(** Register or relaunch a supervised keepalive fiber only when the shared
-    closed owner-execution verdict is [Recoverable]. [Executable] is a no-op;
+(** Register or launch an [Offline] supervised keepalive fiber only when the
+    shared closed owner-execution verdict is [Recoverable]. Other registered
+    phases remain owned by the lifecycle sweep. [Executable] is a no-op;
     lifecycle/policy blocks, unreadable owner truth, and a shutdown fence retain
-    durable work without booting. Registered but non-running owners enter the
-    same recovery path instead of being mistaken for executable owners.
+    durable work without booting.
     When the injected launch gate returns [Error _] (registry FSM rejected
     [Fiber_started]), no [Started]/[Running] event is published — the gate
     already resolved the entry through the crash path. *)

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -16,6 +16,7 @@ module KSM = Keeper_state_machine
 module KLH = Masc.Keeper_lifecycle_hooks
 module KA = Masc.Keeper_keepalive
 module KSR = Masc.Keeper_supervisor_reconcile_keepalive
+module KSS = Masc.Keeper_supervisor_supervise_keepalive
 module Supervisor_launch = Masc.Keeper_supervisor_launch
 module Lane = Masc.Keeper_lane
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
@@ -903,6 +904,87 @@ let test_reconcile_supervise_exception_continues () =
     (List.rev !supervised);
   check (float 0.001) "reconcile failure metric increments" (before +. 1.)
     (Masc.Otel_metric_store.metric_total metric)
+
+let test_supervise_keepalive_retains_sweep_owned_entries () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  Eio.Switch.on_release sw (fun () ->
+      Reg.For_testing.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+  let ctx = keeper_runtime_context env sw config in
+  let launched = ref [] in
+  let publish_lifecycle ~event:_ _name _detail () = () in
+  let launch_supervised_fiber
+        ~proactive_warmup_sec:_
+        _ctx
+        _meta
+        (entry : Reg.registry_entry)
+    =
+    launched := (entry.name, entry.phase) :: !launched;
+    Ok ()
+  in
+  let stopped_name = "recoverable-stopped-owner" in
+  let stopped_meta = make_meta stopped_name in
+  let stopped =
+    Reg.For_testing.register ~base_path:config.base_path stopped_name stopped_meta
+  in
+  ignore
+    (Reg.dispatch_event ~base_path:config.base_path stopped_name KSM.Stop_requested);
+  (match
+     Reg.dispatch_event ~base_path:config.base_path stopped_name KSM.Drain_complete
+   with
+   | Ok transition ->
+     check
+       string
+       "stopped fixture phase"
+       "stopped"
+       (KSM.phase_to_string transition.new_phase)
+   | Error error -> fail (KSM.transition_error_to_string error));
+  ignore (Reg.resolve_done stopped ~source:"stopped_owner_fixture" `Stopped);
+  KSS.supervise_keepalive
+    ~publish_lifecycle
+    ~launch_supervised_fiber
+    ~proactive_warmup_sec:0
+    ctx
+    stopped_meta;
+  let crashed_name = "recoverable-crashed-owner" in
+  let crashed_meta = make_meta crashed_name in
+  let _crashed =
+    Reg.For_testing.register ~base_path:config.base_path crashed_name crashed_meta
+  in
+  (match
+     Reg.dispatch_event
+       ~base_path:config.base_path
+       crashed_name
+       (KSM.Fiber_terminated
+          { outcome = "fixture crash"; provider_id = None; http_status = None })
+   with
+   | Ok transition ->
+     check
+       string
+       "crashed fixture phase"
+       "crashed"
+       (KSM.phase_to_string transition.new_phase)
+   | Error error -> fail (KSM.transition_error_to_string error));
+  KSS.supervise_keepalive
+    ~publish_lifecycle
+    ~launch_supervised_fiber
+    ~proactive_warmup_sec:0
+    ctx
+    crashed_meta;
+  check
+    (list (pair string string))
+    "Stopped and Crashed owners remain assigned to the supervisor sweep"
+    []
+    (List.rev_map
+       (fun (name, phase) -> name, KSM.phase_to_string phase)
+       !launched)
 
 let registered_entries names =
   Reg.For_testing.clear ();
@@ -1998,6 +2080,8 @@ let () =
         test_reconcile_materialize_failure_continues_with_metric;
       test_case "reconcile supervise exception is isolated" `Quick
         test_reconcile_supervise_exception_continues;
+      test_case "recoverable sweep-owned entries are not relaunched" `Quick
+        test_supervise_keepalive_retains_sweep_owned_entries;
     ];
     "fiber_health", [
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;


### PR DESCRIPTION
## Summary
- launch recoverable owners only when unregistered or already Offline
- retain Stopped, Crashed, Restarting, and other registered phases for the canonical lifecycle sweep
- cover the reported Stopped/Crashed relaunch regression with a focused supervisor test

## Why
Durable-demand recovery classified registered non-live owners as Recoverable, then passed their existing lane directly to Fiber_started. That bypassed the canonical Crashed -> Supervisor_restart_attempt -> register_restarting path and attempted an invalid relaunch of Stopped/Crashed lanes.

This change adds no compatibility fields, migration path, facade, or lifecycle gate. It narrows the existing entrypoint to its valid launch phases.

## Validation
- ocamlc -stop-after parsing on the changed ML/MLI/test files
- ocamlformat --check on the changed ML/MLI/test files
- git diff --check
- focused Dune target requested through scripts/dune-local.sh; local wrapper currently refuses while unrelated bare Dune processes bypass the machine-wide lock, so Draft PR CI is the build authority for now