### PR TITLE
fix(test-deps): re_export masc.runtime_model — main red (Runtime_provider_binding unbound)

### DIFF
--- a/test/deps/dune
+++ b/test/deps/dune
@@ -98,7 +98,9 @@
   (re_export masc.keeper_usage_trust)
   (re_export masc.event_bus_slots)
   (re_export masc.keeper_toml)
-  ;; Model inference metrics + runtime provider label leaves.
+  ;; Model inference metrics + runtime provider label leaves + binding
+  ;; (Runtime_provider_binding.default_headers_for_kind, centralized by #26326).
+  (re_export masc.runtime_model)
   (re_export masc.runtime_provider_labels)
   (re_export masc.model_inference_metrics)
   ;; RFC-0058 Phase 1 — Declarative runtime TOML parser sub-library.


### PR DESCRIPTION
## main red 수정 (hotfix)

`dune build .`에서 2개 unbound module:
- `test/test_keeper_chat_admission_contention.ml:105` `Keeper_chat_delivery_identity`
- `test/test_runtime_provider_auth_headers.ml:398` `Runtime_provider_binding`

## 원인
`test/deps/dune`(masc_test_deps wrapper)의 re_export 목록에 **`masc.runtime_model`이 빠져 있었다**. #26326(centralize provider header defaults)이 `default_headers_for_kind`을 `Runtime_provider_binding`(`lib/runtime_model`)으로 옮겼는데, test 공통 의존인 masc_test_deps에 `masc.runtime_model` re_export가 갱신되지 않아 → `Runtime_provider_binding` unbound. 그리고 이 masc_test_deps 빌드 실패가 cascading으로 이미 re_export된 `Keeper_chat_delivery_identity`(line 85)까지 unbound로 표출.

## 수정
`test/deps/dune` re_export에 `masc.runtime_model` 한 줄 추가. 두 에러가 같이 풀린다(runtime_model이 근본, keeper_chat_delivery_identity는 cascading).

## 검증
로컬 빌드 fresh worktree에서 진행 중. CI에서 최종 확인.

## 참고
이 main red가 CI를 통과한 채 들어온 건 별개 문제(false-green CI) — runtime_model re_export 누락이 test 빌드에서 잡혔어야 했다.

연관: #26326(provider header centralize → runtime_model 이동).
