### PR TITLE
test(keeper): fix queued message scope in contention test

### DIFF
--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -159,10 +159,8 @@ let run_contention ~base ~clock ~gap_seconds =
        Eio.Fiber.fork ~sw (fun () ->
          for i = 1 to receipt_count do
            Eio.Time.sleep clock (turn_seconds *. 1.5);
-           match
-             let queued_message = message (Printf.sprintf "contention-%d" i) in
-             Keeper_chat_queue.enqueue ~keeper_name queued_message
-           with
+           let queued_message = message (Printf.sprintf "contention-%d" i) in
+           match Keeper_chat_queue.enqueue ~keeper_name queued_message with
            | Ok receipt -> enqueued := (receipt, queued_message) :: !enqueued
            | Error error ->
              Printf.printf "  enqueue failed: %s\n%!"


### PR DESCRIPTION
## Summary

- bind `queued_message` outside the `match` scrutinee
- keep the exact queued message available when recording a successful enqueue receipt

## Root cause

#26317 introduced `queued_message` inside a `let ... in` expression used as the `match` scrutinee, then referenced it from the `Ok` branch where it is out of scope. Current `main` therefore fails with `Error: Unbound value queued_message`.

## Validation

- `ocamlformat --check test/test_keeper_chat_admission_contention.ml`
- `ocamlc -stop-after parsing -c test/test_keeper_chat_admission_contention.ml`
- `git diff --check`
- focused wrapper build will be re-run after the two pre-existing bare Dune processes release the machine-wide build slot; CI is started in parallel