### PR TITLE
refactor(viewer): remove legacy TRPG EventSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   the compact source label from that typed field. The unused
   `Gate_surface.of_source` compatibility facade was also removed. No migration,
   repair, or string-to-surface fallback was added.
+- **Breaking (viewer TRPG transport)**: removed the compiled but unreachable
+  legacy TRPG EventSource transport, event vocabulary, reconnect state, and
+  teardown branch. The TRPG viewer now has one transport: the existing MASC
+  `/api/v1/trpg/stream` JSON polling loop. Monitor, Social, and Experiment SSE
+  remain owned by the separate MASC SSE client.
 - **Breaking (telemetry wire/storage)**: removed the retired
   `Agent_joined`/`Agent_left` decoder aliases, the `.masc/telemetry.jsonl`
   fallback reader, and the producer-less `Handoff_triggered` event plus its

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -481,13 +481,6 @@ fn parse_query_param(search: &str, key: &str) -> Option<String> {
 
 // ─── Endpoints ──────────────────────────────
 
-pub fn trpg_uses_polling() -> bool {
-    // MASC exposes both poll JSON and SSE endpoints.
-    // Current viewer runtime uses polling reliably because stream responses are
-    // JSON payloads and SSE is optional when available.
-    true
-}
-
 pub fn trpg_state_url() -> String {
     build_masc_url(&format!(
         "api/v1/trpg/state?workspace_id={}",
@@ -495,7 +488,7 @@ pub fn trpg_state_url() -> String {
     ))
 }
 
-/// Legacy JSON poll endpoint.
+/// Current TRPG event polling endpoint.
 pub fn trpg_stream_poll_url(after_seq: i64) -> String {
     build_masc_url(&format!(
         "api/v1/trpg/stream?workspace_id={}&after_seq={}",

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -65,9 +65,7 @@ pub enum ViewerMode {
     Home,
 
     /// D&D 5e game session viewer (그림란드 연대기).
-    /// Data source:
-    /// - default: MASC `/api/v1/trpg/stream` JSON polling
-    /// - optional: legacy TRPG Engine `/workspaces/:id/stream` SSE
+    /// Data source: MASC `/api/v1/trpg/stream` JSON polling.
     Trpg,
 
     /// Experiment visualization — Sankey diagrams, network graphs, A/B metrics.

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -10,63 +10,20 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::JsFuture;
-#[cfg(target_arch = "wasm32")]
-use web_sys::{EventSource, MessageEvent};
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
 use crate::game::state::ConnectionStatus;
 
-#[cfg(target_arch = "wasm32")]
-use super::reconnect::{self, ConnectionStatusProxy, ReconnectState};
-use super::reconnect::{ConnectionStatusBridge, SseReconnectManager};
-
-/// Wrapper around `EventSource` that is `Send + Sync`.
-/// Safe because WASM is single-threaded — there are no real threads to race with.
-#[cfg(target_arch = "wasm32")]
-struct SendEventSource(EventSource);
-
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for SendEventSource {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for SendEventSource {}
-
-/// Shared buffer for incoming TRPG messages.
-///
-/// For `LegacyEngine` mode, messages are fed by EventSource callbacks.
-/// For `MascApi` mode, messages are fed by periodic JSON polling.
+/// Shared buffer for incoming TRPG messages fed by periodic JSON polling.
 #[derive(Resource, Clone)]
 pub struct SseReceiver {
     pub messages: Arc<Mutex<Vec<(String, String)>>>,
     polling_active: Arc<AtomicBool>,
-    #[cfg(target_arch = "wasm32")]
-    event_source: Arc<Mutex<Option<SendEventSource>>>,
-    /// Shared reconnect state for the legacy EventSource path.
-    /// Kept alive so the Arc clones in EventSource callbacks remain valid.
-    #[cfg(target_arch = "wasm32")]
-    #[allow(dead_code)]
-    reconnect: Arc<Mutex<ReconnectState>>,
 }
-
-/// Legacy SSE event names (used only with LegacyEngine mode).
-#[cfg(target_arch = "wasm32")]
-const LEGACY_SSE_EVENT_TYPES: &[&str] = &[
-    "dice_roll",
-    "hp_change",
-    "narrative",
-    "area_move",
-    "turn_advance",
-    "choice_available",
-    "choice_resolved",
-    "item_acquired",
-    "character_death",
-    "combat_start",
-];
 
 #[derive(Debug, Clone, Deserialize)]
 #[cfg(any(target_arch = "wasm32", test))]
@@ -1419,207 +1376,28 @@ fn start_polling_loop(messages: Arc<Mutex<Vec<(String, String)>>>, active: Arc<A
     });
 }
 
-/// Create a legacy EventSource with reconnect support.
+/// Startup system that creates the current TRPG polling input.
 #[cfg(target_arch = "wasm32")]
-fn create_legacy_event_source(
-    url: &str,
-    messages: Arc<Mutex<Vec<(String, String)>>>,
-    es_handle: Arc<Mutex<Option<SendEventSource>>>,
-    reconnect_state: Arc<Mutex<ReconnectState>>,
-    status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
-) {
-    let safe_url = config::redact_auth_query(url);
-    let es = match EventSource::new(url) {
-        Ok(es) => es,
-        Err(e) => {
-            log::warn!("Failed to create EventSource at {}: {:?}", safe_url, e);
-            attempt_trpg_reconnect(messages, es_handle, reconnect_state, status_proxy);
-            return;
-        }
-    };
-
-    for &event_type in LEGACY_SSE_EVENT_TYPES {
-        let msgs = messages.clone();
-        let etype = event_type.to_string();
-        let rs = reconnect_state.clone();
-        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
-            if let Some(data) = e.data().as_string() {
-                if let Ok(mut buf) = msgs.lock() {
-                    buf.push((etype.clone(), data));
-                }
-            }
-            let event_id = e.last_event_id();
-            if !event_id.is_empty() {
-                if let Ok(mut state) = rs.lock() {
-                    state.record_event_id(&event_id);
-                }
-            }
-        });
-        let _ = es.add_event_listener_with_callback(event_type, callback.as_ref().unchecked_ref());
-        callback.forget();
-    }
-
-    {
-        let connected_url = safe_url.clone();
-        let rs = reconnect_state.clone();
-        let sp = status_proxy.clone();
-        let callback = Closure::<dyn FnMut()>::new(move || {
-            log::info!("Legacy TRPG SSE connected to {}", connected_url);
-            if let Ok(mut state) = rs.lock() {
-                state.reset();
-            }
-            if let Ok(mut proxy) = sp.lock() {
-                proxy.set(ConnectionStatus::Connected);
-            }
-        });
-        es.set_onopen(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    {
-        let msgs = messages.clone();
-        let esh = es_handle.clone();
-        let rs = reconnect_state.clone();
-        let sp = status_proxy.clone();
-        let callback = Closure::<dyn FnMut()>::new(move || {
-            log::warn!("Legacy TRPG SSE connection error — scheduling reconnect");
-            if let Ok(guard) = esh.lock() {
-                if let Some(es) = guard.as_ref() {
-                    es.0.close();
-                }
-            }
-            attempt_trpg_reconnect(msgs.clone(), esh.clone(), rs.clone(), sp.clone());
-        });
-        es.set_onerror(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    if let Ok(mut guard) = es_handle.lock() {
-        *guard = Some(SendEventSource(es));
-    }
-}
-
-/// Attempt TRPG legacy EventSource reconnection with backoff.
-#[cfg(target_arch = "wasm32")]
-fn attempt_trpg_reconnect(
-    messages: Arc<Mutex<Vec<(String, String)>>>,
-    es_handle: Arc<Mutex<Option<SendEventSource>>>,
-    reconnect_state: Arc<Mutex<ReconnectState>>,
-    status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
-) {
-    let (delay, attempt, max_retries, last_event_id) = {
-        let mut state = match reconnect_state.lock() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        match state.next_delay() {
-            Some(d) => (
-                d,
-                state.attempt,
-                state.max_retries,
-                state.last_event_id.clone(),
-            ),
-            None => {
-                log::error!(
-                    "TRPG SSE reconnect exhausted ({} attempts) — giving up",
-                    state.max_retries
-                );
-                if let Ok(mut proxy) = status_proxy.lock() {
-                    proxy.set(ConnectionStatus::Failed);
-                }
-                return;
-            }
-        }
-    };
-
-    log::info!(
-        "TRPG SSE reconnect attempt {}/{} in {}ms",
-        attempt,
-        max_retries,
-        delay
-    );
-
-    reconnect::schedule_reconnect(
-        delay,
-        attempt,
-        max_retries,
-        status_proxy.clone(),
-        move || {
-            let base_url = config::trpg_stream_poll_url(0);
-            let url = reconnect::url_with_last_event_id(&base_url, &last_event_id);
-            let authed_url = config::attach_auth_query(&url);
-            create_legacy_event_source(
-                &authed_url,
-                messages,
-                es_handle,
-                reconnect_state,
-                status_proxy,
-            );
-        },
-    );
-}
-
-/// Startup system that creates TRPG stream input (polling or legacy EventSource).
-#[cfg(target_arch = "wasm32")]
-pub fn setup_sse(
-    mut commands: Commands,
-    mut connection: ResMut<ConnectionStatus>,
-    bridge: Res<ConnectionStatusBridge>,
-    mut reconnect_mgr: ResMut<SseReconnectManager>,
-) {
+pub fn setup_sse(mut commands: Commands, mut connection: ResMut<ConnectionStatus>) {
     *connection = ConnectionStatus::Connecting;
     let messages = Arc::new(Mutex::new(Vec::new()));
     let active = Arc::new(AtomicBool::new(true));
-    let es_handle: Arc<Mutex<Option<SendEventSource>>> = Arc::new(Mutex::new(None));
-
-    // Reset TRPG reconnect state
-    reconnect_mgr.trpg = ReconnectState::default();
-    let reconnect_state = Arc::new(Mutex::new(reconnect_mgr.trpg.clone()));
-
-    if config::trpg_uses_polling() {
-        start_polling_loop(messages.clone(), active.clone());
-        commands.insert_resource(SseReceiver {
-            messages,
-            polling_active: active,
-            event_source: es_handle,
-            reconnect: reconnect_state,
-        });
-        log::info!(
-            "TRPG poll client initialized: {}",
-            config::trpg_stream_poll_url(0)
-        );
-        return;
-    }
-
-    let url = config::attach_auth_query(&config::trpg_stream_poll_url(0));
-
-    create_legacy_event_source(
-        &url,
-        messages.clone(),
-        es_handle.clone(),
-        reconnect_state.clone(),
-        bridge.proxy.clone(),
-    );
-
+    start_polling_loop(messages.clone(), active.clone());
     commands.insert_resource(SseReceiver {
         messages,
         polling_active: active,
-        event_source: es_handle,
-        reconnect: reconnect_state,
     });
+    log::info!(
+        "TRPG poll client initialized: {}",
+        config::trpg_stream_poll_url(0)
+    );
 }
 
 /// Native no-op for setup_sse.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn setup_sse(
-    mut _commands: Commands,
-    mut _connection: ResMut<ConnectionStatus>,
-    _bridge: Res<ConnectionStatusBridge>,
-    _reconnect_mgr: ResMut<SseReconnectManager>,
-) {
-}
+pub fn setup_sse(mut _commands: Commands, mut _connection: ResMut<ConnectionStatus>) {}
 
-/// OnExit(Trpg) system: stops polling, closes EventSource, and removes resource.
+/// OnExit(Trpg) system: stops polling and removes the resource.
 pub fn teardown_sse(
     mut commands: Commands,
     receiver: Option<Res<SseReceiver>>,
@@ -1627,15 +1405,6 @@ pub fn teardown_sse(
 ) {
     if let Some(recv) = receiver {
         recv.polling_active.store(false, Ordering::Relaxed);
-        #[cfg(target_arch = "wasm32")]
-        {
-            if let Ok(guard) = recv.event_source.lock() {
-                if let Some(es) = guard.as_ref() {
-                    es.0.close();
-                    log::info!("Legacy TRPG EventSource closed");
-                }
-            }
-        }
     }
     if let Some(mut status) = connection {
         *status = ConnectionStatus::Disconnected;

--- a/viewer/src/sse/reconnect.rs
+++ b/viewer/src/sse/reconnect.rs
@@ -79,10 +79,9 @@ impl ReconnectState {
     }
 }
 
-/// Bevy resource holding reconnect state for TRPG and MASC connections.
+/// Bevy resource holding reconnect state for MASC connections.
 #[derive(Resource, Default)]
 pub struct SseReconnectManager {
-    pub trpg: ReconnectState,
     pub masc: ReconnectState,
 }
 


### PR DESCRIPTION
## Summary

- remove the compiled but unreachable legacy TRPG `EventSource` transport
- make the existing `/api/v1/trpg/stream` JSON polling loop the sole TRPG input
- remove TRPG-only reconnect and teardown state
- preserve the separate current MASC SSE client used by Monitor, Social, and
  Experiment modes

## Feature path

`SsePlugin` enters `ViewerMode::Trpg` through `client::setup_sse`. The previous
entrypoint always branched through `config::trpg_uses_polling()`, which returned
the constant `true`, so the legacy `EventSource` constructor and reconnect path
could never run.

This change removes that dead branch and calls the same polling loop directly.
Polling bootstrap, sequence tracking, event mapping, message buffering, and
teardown of `polling_active` are unchanged.

No migration, compatibility selector, or replacement transport was added.

## Validation

- `git diff --check`
- no remaining TRPG references to `trpg_uses_polling`,
  `LEGACY_SSE_EVENT_TYPES`, `create_legacy_event_source`, or
  `attempt_trpg_reconnect`
- the separate `viewer/src/sse/masc_client.rs` `EventSource` and
  `SseReconnectManager.masc` owner remain
- `cargo check --manifest-path viewer/Cargo.toml` was run on both this branch
  and clean current main; both reach the same pre-existing four `E0425`
  `social_board` errors. Tracked in #26345.
- `cargo fmt --manifest-path viewer/Cargo.toml -- --check` cannot traverse the
  current repository because `archive/trpg/viewer/trpg_controls.rs` is absent;
  also recorded on #26345. A direct changed-file rustfmt check reports only
  formatting drift already present on current main; the semantic diff keeps
  those lines byte-identical.
