### PR TITLE
test(keeper): pin contention receipt type

### DIFF
--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -242,7 +242,7 @@ let test_receipts_are_admitted_in_fifo_order () =
     in
     let expected_delivery_keys =
       List.map
-        (fun (receipt, _) ->
+        (fun ((receipt : Keeper_chat_queue.enqueue_receipt), _) ->
            match
              Keeper_chat_delivery_identity.Receipt_ids.of_list
                [ receipt.Keeper_chat_queue.receipt_id ]


### PR DESCRIPTION
## Summary
- annotate the FIFO contention test tuple as Keeper_chat_queue.enqueue_receipt
- keep the production queue and delivery contracts unchanged

## Why
After #26344 kept queued_message in scope, OCaml resolved the shared receipt_id record label to recovery_resolution_report at the List.map consumer. The list is declared as (enqueue_receipt * queued_message) list, but the field projection still needs a local type annotation to close record-label inference.

No legacy field, migration path, facade, or runtime gate is added.

## Validation
- reproduced from the reported dune build error at test/test_keeper_chat_admission_contention.ml:254
- ocamlc -stop-after parsing test/test_keeper_chat_admission_contention.ml
- ocamlformat --check test/test_keeper_chat_admission_contention.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_chat_admission_contention.exe was requested; the wrapper refused while unrelated bare Dune builds were active, so Draft PR CI remains the build authority