### PR TITLE
refactor(dashboard): drop the task gate and workspace FSM surfaces

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -562,19 +562,6 @@ function bootstrapInitializingPayload(path: string): unknown | null {
           done: 0,
           cancelled: 0,
         },
-        workspace_fsm: {
-          schema_version: 1,
-          mode: 'advisory',
-          summary: {
-            products: 0,
-            violations: 0,
-            evidence: 0,
-            severity_counts: { info: 0, warn: 0, error: 0 },
-          },
-          products: [],
-          evidence: [],
-          violations: [],
-        },
       }
     case '/api/v1/dashboard/briefing':
       return {

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
       postId: null,
     },
   },
-  workspaceFsmSnapshot: { value: null },
 }))
 
 vi.mock('../../api/dashboard', () => ({
@@ -38,10 +37,6 @@ vi.mock('../../api/mcp', () => ({
 
 vi.mock('../../router', () => ({
   route: mocks.route,
-}))
-
-vi.mock('../../store', () => ({
-  workspaceFsmSnapshot: mocks.workspaceFsmSnapshot,
 }))
 
 vi.mock('../task-manage/task-create-form', () => ({
@@ -117,7 +112,6 @@ describe('GoalTree', () => {
       params: { section: 'planning' },
       postId: null,
     }
-    mocks.workspaceFsmSnapshot.value = null
     hydrateGoalTreeSnapshot({
       approval_queue_state: { state: 'ready' },
       tree: [],

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -16,7 +16,6 @@ import {
   hydrateGoalTreeObservationError,
   hydrateGoalTreeSnapshot,
 } from '../../goal-tree-state'
-import { workspaceFsmSnapshot } from '../../store'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
@@ -30,7 +29,6 @@ import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 import type {
   DashboardGoalDetailResponse,
-  DashboardWorkspaceFsmViolation,
   GoalCompletionSummary,
   GoalDetailKeeper,
   GoalDetailTimelineEvent,
@@ -405,11 +403,6 @@ function TreeSummary({
   `
 }
 
-function workspaceViolationsForGoal(goalId: string): DashboardWorkspaceFsmViolation[] {
-  const violations = workspaceFsmSnapshot.value?.violations ?? []
-  return violations.filter(violation => violation.refs?.goal_id === goalId)
-}
-
 function TreeTask({ task }: { task: GoalTreeTask }) {
   return html`
     <div class="flex flex-wrap items-center gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] px-2 py-1.5 text-xs">
@@ -672,8 +665,6 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
   const isExpanded = expandedNodes.value.has(node.id)
   const hasContent = node.children.length > 0 || node.tasks.length > 0
   const isSelected = selectedGoalId.value === node.id
-  const workspaceViolations = workspaceViolationsForGoal(node.id)
-  const workspaceHasError = workspaceViolations.some(v => v.severity === 'error')
   const indent = depth * 20
   const headerBase = isSelected
     ? TREE_NODE_CARD_ACTIVE
@@ -729,14 +720,6 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
             ${node.pending_approval_count > 0 ? html`
               <span class="rounded-[var(--r-1)] border border-warn/30 bg-warn/10 px-2 py-0.5 text-3xs font-medium text-warn">
                 approval ${node.pending_approval_count}
-              </span>
-            ` : null}
-            ${workspaceViolations.length > 0 ? html`
-              <span
-                class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-medium ${workspaceHasError ? 'border-bad/30 bg-bad/10 text-bad' : 'border-warn/30 bg-warn/10 text-warn'}"
-                title="Goal x Task x Board x Reward"
-              >
-                FSM ${workspaceViolations.length}
               </span>
             ` : null}
             ${node.latest_keeper_ref ? html`

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -38,7 +38,7 @@ import {
 } from './task-detail-state'
 import { TaskActivityList } from './task-activity-list'
 import { effectiveTaskPriority, goalById, priorityLabel } from './goal-helpers'
-import type { Task, TaskGateEvaluation } from '../../types'
+import type { Task } from '../../types'
 
 const CARD_BOX = 'v2-workspace-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-3'
 
@@ -267,41 +267,6 @@ function VerdictLineageSection() {
   `
 }
 
-function gateTone(status?: string | null): string {
-  switch (status) {
-    case 'ready': return 'text-ok border-ok/25 bg-ok/10'
-    case 'blocked': return 'text-bad border-bad/25 bg-bad/10'
-    case 'inconclusive': return 'text-warn border-warn/25 bg-warn/10'
-    default: return 'text-text-muted border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'
-  }
-}
-
-function GateSection({
-  title,
-  gate,
-}: {
-  title: string
-  gate?: TaskGateEvaluation | null
-}) {
-  if (!gate) return null
-
-  return html`
-    <div class=${CARD_BOX}>
-      <div class="flex items-center justify-between gap-3">
-        <div class="text-xs font-medium text-text-strong">${title}</div>
-        <span class=${`rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] ${gateTone(gate.status)}`}>${gate.status}</span>
-      </div>
-      ${gate.reasons && gate.reasons.length > 0 ? html`
-        <div class="mt-2 flex flex-col gap-1">
-          ${gate.reasons.slice(0, 4).map(reason => html`
-            <div key=${reason} class="text-2xs leading-relaxed text-text-muted">${reason}</div>
-          `)}
-        </div>
-      ` : null}
-    </div>
-  `
-}
-
 // RFC-0323 G-9: linked re-run lineage. A task created as a re-run carries
 // the write-once predecessor_task_id (G-8); surface it as a link so the
 // operator can walk back to the original. Clicking opens the predecessor's
@@ -334,12 +299,10 @@ function PredecessorSection({ task }: { task: Task }) {
 
 function ContractSection({ task }: { task: Task }) {
   const contract = task.contract
-  const gate = task.gate
-  if (!contract && !gate) return null
+  if (!contract) return null
 
-  const completionItems = gate?.completion_contract ?? contract?.completion_contract ?? []
-  const unmetItems = gate?.unmet_completion_contract ?? []
-  const requiredEvidence = contract?.required_evidence ?? []
+  const completionItems = contract.completion_contract ?? []
+  const requiredEvidence = contract.required_evidence ?? []
   const isAwaitingVerification = task.status === 'awaiting_verification'
   const verifierAssignee = isAwaitingVerification ? task.assignee : undefined
 
@@ -347,7 +310,7 @@ function ContractSection({ task }: { task: Task }) {
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
         <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted">계약 게이트</div>
-        <span class=${`rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] ${contract?.strict ? 'text-accent-fg border-[var(--accent-25)] bg-[var(--accent-10)]' : 'text-text-muted border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'}`}>${contract?.strict ? 'strict' : 'advisory'}</span>
+        <span class=${`rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] ${contract.strict ? 'text-accent-fg border-[var(--accent-25)] bg-[var(--accent-10)]' : 'text-text-muted border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'}`}>${contract.strict ? 'strict' : 'advisory'}</span>
         ${isAwaitingVerification ? html`
           <span class="rounded-[var(--r-1)] border border-[var(--accent-40)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-accent-fg">
             검증 대기
@@ -376,16 +339,12 @@ function ContractSection({ task }: { task: Task }) {
         </div>
       ` : null}
 
-      <${GateSection} title="완료 게이트" gate=${gate?.done} />
-      <${GateSection} title="검수 → 구현" gate=${gate?.inspect_to_implement} />
-      <${GateSection} title="검증 → 리뷰" gate=${gate?.verify_to_review} />
-
       ${completionItems.length > 0 ? html`
         <div class=${CARD_BOX}>
           <div class="text-xs font-medium text-text-strong">완료 계약</div>
           <div class="mt-2 flex flex-col gap-1">
             ${completionItems.map((item: string) => html`
-              <div key=${item} class=${`text-2xs ${unmetItems.includes(item) ? 'text-bad' : 'text-text-body'}`}>${item}</div>
+              <div key=${item} class="text-2xs text-text-body">${item}</div>
             `)}
           </div>
         </div>

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -21,12 +21,10 @@ vi.mock('../router', () => ({
   }),
 }))
 
-const workspaceSignal = signal<unknown>(null)
 const tasksSignal = signal<unknown[]>([])
 const goalsSignal = signal<unknown[]>([])
 
 vi.mock('../store', () => ({
-  get workspaceFsmSnapshot() { return workspaceSignal },
   get tasks() { return tasksSignal },
   get goals() { return goalsSignal },
 }))
@@ -53,7 +51,6 @@ function setRoute(view?: string, focus?: string) {
 describe('PlanningPanel', () => {
   beforeEach(() => {
     setRoute()
-    workspaceSignal.value = null
     tasksSignal.value = []
     goalsSignal.value = []
     openTaskDetailMock.mockReset()
@@ -86,60 +83,6 @@ describe('PlanningPanel', () => {
     setRoute('nonexistent')
     render(html`<${PlanningPanel} />`)
     expect(screen.getByTestId('goal-tree')).toBeTruthy()
-  })
-
-  it('renders workspace health violations', () => {
-    workspaceSignal.value = {
-      mode: 'advisory',
-      summary: {
-        products: 1,
-        violations: 1,
-        evidence: 2,
-        severity_counts: { info: 0, warn: 0, error: 1 },
-      },
-      evidence: [
-        {
-          source: 'telemetry',
-          kind: 'task_completed',
-          label: 'task completed',
-          detail: 'success=true; duration_ms=42',
-          refs: { goal_id: 'goal-1', task_ids: ['task-1'] },
-        },
-        {
-          source: 'board',
-          kind: 'post',
-          label: 'Board post',
-          detail: 'author=keeper',
-          refs: { goal_id: 'goal-1' },
-        },
-      ],
-      violations: [
-        {
-          severity: 'error',
-          code: 'reward_without_evidence',
-          message: 'Reward missing evidence',
-          refs: { goal_id: 'goal-1', task_ids: ['task-1'] },
-          evidence: [
-            {
-              source: 'telemetry',
-              kind: 'task_completed',
-              label: 'task completed',
-              detail: 'success=true; duration_ms=42',
-            },
-          ],
-        },
-      ],
-    }
-
-    render(html`<${PlanningPanel} />`)
-
-    expect(screen.getByText('협력 상태')).toBeTruthy()
-    expect(screen.getByText('reward_without_evidence')).toBeTruthy()
-    expect(screen.getByText(/Reward missing evidence/)).toBeTruthy()
-    expect(screen.getByText(/goal: goal-1/)).toBeTruthy()
-    expect(screen.getAllByText('telemetry/task_completed').length).toBeGreaterThan(0)
-    expect(screen.getByText('board/post')).toBeTruthy()
-    expect(screen.getAllByText('task completed').length).toBeGreaterThan(0)
   })
 
   it('renders stale task focus from route param', () => {

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -7,18 +7,12 @@ import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { replaceRoute, route } from '../router'
-import { workspaceFsmSnapshot, goals, tasks } from '../store'
+import { goals, tasks } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals/planning'
 import { GoalTree } from './goals/goal-tree'
 import { PlanningFocusPanel } from './planning-focus-panel'
 import { openTaskDetail } from './goals/task-detail-state'
-import type {
-  DashboardWorkspaceFsmEvidence,
-  DashboardWorkspaceFsmRefs,
-  DashboardWorkspaceFsmSnapshot,
-  DashboardWorkspaceFsmViolation,
-} from '../types'
 
 type PlanningView = 'default' | 'goal-tree'
 
@@ -46,44 +40,6 @@ function updateViewParam(view: PlanningView): void {
     params.view = view
   }
   replaceRoute('workspace', params)
-}
-
-function workspaceCount(
-  snapshot: DashboardWorkspaceFsmSnapshot | null,
-  key: 'products' | 'violations' | 'evidence' | 'warn' | 'error',
-): number {
-  if (!snapshot?.summary) return 0
-  if (key === 'products') return snapshot.summary.products ?? 0
-  if (key === 'violations') return snapshot.summary.violations ?? 0
-  if (key === 'evidence') return snapshot.summary.evidence ?? snapshot.evidence?.length ?? 0
-  return snapshot.summary.severity_counts?.[key] ?? 0
-}
-
-function severityToneClass(severity: string | undefined): string {
-  switch (severity) {
-    case 'error':
-      return 'border-bad/35 bg-bad/10 text-bad'
-    case 'warn':
-      return 'border-warn/35 bg-warn/10 text-warn'
-    default:
-      return 'border-[var(--accent-25)] bg-[var(--accent-10)] text-accent-fg'
-  }
-}
-
-function refsLabel(refs: DashboardWorkspaceFsmRefs | undefined): string {
-  if (!refs) return 'refs: -'
-  const parts: string[] = []
-  if (refs.goal_id) parts.push(`goal: ${refs.goal_id}`)
-  if (refs.task_ids && refs.task_ids.length > 0) parts.push(`tasks: ${refs.task_ids.join(', ')}`)
-  if (refs.post_ids && refs.post_ids.length > 0) parts.push(`posts: ${refs.post_ids.join(', ')}`)
-  if (refs.agent_name) parts.push(`agent: ${refs.agent_name}`)
-  return parts.length > 0 ? parts.join(' · ') : 'refs: -'
-}
-
-function evidenceLabel(evidence: DashboardWorkspaceFsmEvidence): string {
-  const source = evidence.source ?? '(unknown source)'
-  const kind = evidence.kind ? `/${evidence.kind}` : ''
-  return `${source}${kind}`
 }
 
 function cleanRouteFocusId(value: string | undefined): string | null {
@@ -157,109 +113,6 @@ function PlanningRouteFocusPanel() {
   `
 }
 
-function WorkspaceEvidenceRow({ evidence }: { evidence: DashboardWorkspaceFsmEvidence }) {
-  return html`
-    <li class="min-w-0 rounded-[var(--r-1)] border border-card-border/40 bg-white/[0.03] px-2 py-1">
-      <div class="flex min-w-0 flex-wrap items-center gap-2">
-        <span class="rounded-[var(--r-1)] border border-card-border/50 bg-black/15 px-1.5 py-0.5 text-3xs font-semibold uppercase text-text-muted">
-          ${evidenceLabel(evidence)}
-        </span>
-        <span class="min-w-0 truncate text-2xs font-medium text-text-strong">
-          ${evidence.label ?? evidence.id ?? '(unlabeled evidence)'}
-        </span>
-      </div>
-      ${evidence.detail ? html`
-        <div class="mt-0.5 truncate text-3xs text-text-dim" title=${evidence.detail}>${evidence.detail}</div>
-      ` : null}
-    </li>
-  `
-}
-
-function WorkspaceViolationRow({ violation }: { violation: DashboardWorkspaceFsmViolation }) {
-  const evidence = (violation.evidence ?? []).slice(0, 3)
-  return html`
-    <li class="rounded-[var(--r-1)] border border-card-border/60 bg-black/10 p-2">
-      <div class="flex flex-wrap items-center gap-2 text-xs">
-        <span class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase ${severityToneClass(violation.severity)}">
-          ${violation.severity ?? '(unknown severity)'}
-        </span>
-        <span class="font-mono text-2xs text-text-strong">${violation.code ?? violation.axis ?? '(unknown violation)'}</span>
-        ${violation.axis ? html`<span class="text-3xs text-text-dim">${violation.axis}</span>` : null}
-      </div>
-      <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'workspace invariant 검토 필요.'}</div>
-      <div class="mt-1 truncate text-3xs text-text-dim" title=${refsLabel(violation.refs)}>${refsLabel(violation.refs)}</div>
-      ${evidence.length > 0 ? html`
-        <ul class="mt-2 grid gap-1">
-          ${evidence.map((item, index) => html`
-            <${WorkspaceEvidenceRow} key=${`${item.source ?? 'evidence'}-${item.kind ?? 'kind'}-${item.id ?? index}`} evidence=${item} />
-          `)}
-        </ul>
-      ` : null}
-    </li>
-  `
-}
-
-function WorkspaceHealthPanel() {
-  const snapshot = workspaceFsmSnapshot.value
-  if (!snapshot) return null
-  const violations = snapshot.violations ?? []
-  const topViolations = violations.slice(0, 5)
-  const topEvidence = (snapshot.evidence ?? []).slice(0, 5)
-  const errorCount = workspaceCount(snapshot, 'error')
-  const warnCount = workspaceCount(snapshot, 'warn')
-  const evidenceCount = workspaceCount(snapshot, 'evidence')
-  return html`
-    <section class="v2-workspace-panel rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label="협력 상태">
-      <div class="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <div class="text-sm font-semibold text-text-strong">협력 상태</div>
-        </div>
-        <div class="flex flex-wrap items-center gap-2 text-3xs font-medium">
-          <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
-            products ${workspaceCount(snapshot, 'products')}
-          </span>
-          <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
-            violations ${workspaceCount(snapshot, 'violations')}
-          </span>
-          <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
-            evidence ${evidenceCount}
-          </span>
-          ${errorCount > 0 ? html`
-            <span class="rounded-[var(--r-1)] border border-bad/35 bg-bad/10 px-2 py-1 text-bad">error ${errorCount}</span>
-          ` : null}
-          ${warnCount > 0 ? html`
-            <span class="rounded-[var(--r-1)] border border-warn/35 bg-warn/10 px-2 py-1 text-warn">warn ${warnCount}</span>
-          ` : null}
-        </div>
-      </div>
-      ${snapshot.projection_error ? html`
-        <div class="mt-2 rounded-[var(--r-1)] border border-warn/30 bg-warn/10 px-2 py-1 text-xs text-warn">
-          projection: ${snapshot.projection_error}
-        </div>
-      ` : null}
-      ${violations.length === 0 ? html`
-        <div class="mt-2 text-xs text-text-muted">위반 없음</div>
-      ` : html`
-        <ul class="mt-2 grid gap-2">
-          ${topViolations.map((violation, index) => html`
-            <${WorkspaceViolationRow} key=${`${violation.code ?? violation.axis ?? 'workspace'}-${index}`} violation=${violation} />
-          `)}
-        </ul>
-      `}
-      ${violations.length > 0 && topEvidence.length > 0 ? html`
-        <div class="mt-3">
-          <div class="mb-1 text-3xs font-semibold uppercase text-text-muted">근거</div>
-          <ul class="grid gap-1 md:grid-cols-2">
-            ${topEvidence.map((item, index) => html`
-              <${WorkspaceEvidenceRow} key=${`${item.source ?? 'evidence'}-${item.kind ?? 'kind'}-${item.id ?? index}`} evidence=${item} />
-            `)}
-          </ul>
-        </div>
-      ` : null}
-    </section>
-  `
-}
-
 export function PlanningPanel() {
   const view = activeView.value
 
@@ -273,7 +126,6 @@ export function PlanningPanel() {
         tone="accent"
       />
       <${PlanningRouteFocusPanel} />
-      <${WorkspaceHealthPanel} />
       <${PlanningFocusPanel} />
       ${view === 'goal-tree' ? html`<${GoalTree} />` : html`<${Planning} />`}
     </div>

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -459,7 +459,7 @@ describe('Work', () => {
       expect(backlog.textContent).toContain('Backlog task 1')
     })
 
-    it('expands inline task detail for gate evidence and handoff context', () => {
+    it('expands inline task detail for handoff context', () => {
       goals.value = [
         { id: 'G-1', title: 'Goal One', priority: 2, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
@@ -470,12 +470,6 @@ describe('Work', () => {
           goal_id: 'G-1',
           status: 'todo',
           assignee: 'dev',
-          gate: {
-            done: {
-              status: 'ready',
-              checks: [{ evidence: 'unit tests pass', outcome: 'satisfied', detail: 'ci green' }],
-            },
-          },
           handoff_context: {
             summary: 'Handoff summary text',
             next_step: 'Deploy to staging',
@@ -493,7 +487,6 @@ describe('Work', () => {
 
       const detail = screen.getByTestId('job-row').querySelector('.wk-task-detail')
       expect(detail).toBeTruthy()
-      expect(detail?.textContent).toContain('unit tests pass')
       expect(detail?.textContent).toContain('Handoff summary text')
       expect(detail?.textContent).toContain('Deploy to staging')
     })
@@ -548,36 +541,6 @@ describe('Work', () => {
       expect(ledger.textContent).toContain('sangsu')
       expect(ledger.textContent).toContain('2026-01-02T00:00:00Z')
       expect(ledger.textContent).not.toContain('활동 흐름')
-    })
-
-    it('renders all defined gate evaluations including verify_to_review', () => {
-      goals.value = [
-        { id: 'G-1', title: 'Goal One', priority: 2, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
-      ]
-      tasks.value = [
-        {
-          id: 'J-1',
-          title: 'Gated job',
-          goal_id: 'G-1',
-          status: 'todo',
-          gate: {
-            done: { status: 'ready', checks: [{ evidence: 'done check', outcome: 'satisfied', detail: 'done detail' }] },
-            inspect_to_implement: { status: 'blocked', checks: [{ evidence: 'inspect check', outcome: 'failed', detail: 'inspect detail' }] },
-            verify_to_review: { status: 'inconclusive', checks: [{ evidence: 'verify check', outcome: 'missing', detail: 'verify detail' }] },
-          },
-        },
-      ]
-
-      const { container } = render(html`<${Work} />`)
-
-      fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
-      fireEvent.click(container.querySelector('[data-job-id="J-1"] .wk-task-main')!)
-
-      const detail = screen.getByTestId('job-row').querySelector('.wk-task-detail')
-      expect(detail?.textContent).toContain('done gate')
-      expect(detail?.textContent).toContain('inspect gate')
-      expect(detail?.textContent).toContain('verify gate')
-      expect(detail?.textContent).toContain('verify check')
     })
 
     it('maps known goal phase IDs to Korean labels', () => {
@@ -770,7 +733,7 @@ describe('Work', () => {
         expect(aside.querySelector('[data-testid="wka-flagged-calm"]')).toBeNull()
       })
 
-      it('surfaces verify tasks (awaiting_verification status) with unsatisfied gate count', () => {
+      it('surfaces verify tasks (awaiting_verification status)', () => {
         goals.value = [
           { id: 'G-1', title: 'Goal One', priority: 1, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
         ]
@@ -780,10 +743,6 @@ describe('Work', () => {
             title: 'Verify Me',
             goal_id: 'G-1',
             status: 'awaiting_verification',
-            gate: {
-              done: { status: 'blocked', checks: [], reasons: ['ci failing'] },
-              inspect_to_implement: { status: 'ready', checks: [], reasons: [] },
-            },
           },
         ]
 
@@ -794,8 +753,7 @@ describe('Work', () => {
         expect(verifyItems.length).toBe(1)
         expect(verifyItems[0]?.classList.contains('verify')).toBe(true)
         expect(verifyItems[0]?.textContent).toContain('Verify Me')
-        // 1 unsatisfied gate (done=blocked, inspect=ready → 1 open)
-        expect(verifyItems[0]?.textContent).toContain('1 미충족')
+        expect(verifyItems[0]?.textContent).toContain('검증 대기')
       })
 
       it('surfaces tasks with a blocker note (cancelled with handoff_context.reason)', () => {

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -116,28 +116,6 @@ function blockerNoteForTask(task: Task): string | null {
   return task.handoff_context?.failure_mode ?? null
 }
 
-function taskGateRows(task: Task): Array<{ label: string; outcome: 'satisfied' | 'missing' | 'failed'; detail: string }> {
-  const rows: Array<{ label: string; outcome: 'satisfied' | 'missing' | 'failed'; detail: string }> = []
-  const addEvaluation = (label: string, evaluation: NonNullable<Task['gate']>['done'] | null | undefined) => {
-    if (!evaluation) return
-    const outcome = evaluation.status === 'ready'
-      ? 'satisfied'
-      : evaluation.status === 'blocked'
-        ? 'failed'
-        : 'missing'
-    const check = evaluation.checks?.[0]
-    const detail = check?.evidence
-      ?? evaluation.reasons?.[0]
-      ?? check?.detail
-      ?? evaluation.status
-    rows.push({ label, outcome, detail })
-  }
-  addEvaluation('done gate', task.gate?.done)
-  addEvaluation('inspect gate', task.gate?.inspect_to_implement)
-  addEvaluation('verify gate', task.gate?.verify_to_review)
-  return rows
-}
-
 // Keyed by Goal_phase values — the only lifecycle representation after
 // RFC-0352 slice 1 (the legacy status duplicate is gone).
 // Labels come from the goalPhaseLabel SSOT (goals/goal-helpers.ts).
@@ -155,15 +133,6 @@ const GOAL_PHASE_CLASS: Record<string, 'neutral' | 'ok' | 'warn' | 'bad'> = {
 
 function goalPhaseClass(phase: string): 'neutral' | 'ok' | 'warn' | 'bad' {
   return GOAL_PHASE_CLASS[phase] ?? 'neutral'
-}
-
-// Gate evidence outcome → Korean outcome word for the right-aligned
-// .wk-gate-out column. Mirrors the prototype GATE_OUTCOME map
-// (data.jsx:369): satisfied 충족 / missing 누락 / failed 실패.
-const GATE_OUTCOME_LABEL: Record<'satisfied' | 'missing' | 'failed', string> = {
-  satisfied: '충족',
-  missing: '누락',
-  failed: '실패',
 }
 
 // ── Keeper lookup ───────────────────────────────────────────────────────────
@@ -339,7 +308,6 @@ function mergeTaskRecord(goalStoreTask: Task, executionTask: Task): Task {
     completed_at: executionTask.completed_at || goalStoreTask.completed_at,
     contract: executionTask.contract ?? goalStoreTask.contract,
     handoff_context: executionTask.handoff_context ?? goalStoreTask.handoff_context,
-    gate: executionTask.gate ?? goalStoreTask.gate,
     execution_links: executionTask.execution_links ?? goalStoreTask.execution_links,
   }
 }
@@ -365,29 +333,6 @@ function GoalProgressBar({ counts }: { counts: GoalProgressCounts }) {
       ${counts.verify > 0 ? html`<span class="wk-seg verify" style=${{ width: `${pct(counts.verify)}%` }}></span>` : null}
       ${counts.wip > 0 ? html`<span class="wk-seg wip" style=${{ width: `${pct(counts.wip)}%` }}></span>` : null}
       ${counts.blocked > 0 ? html`<span class="wk-seg blocked" style=${{ width: `${pct(counts.blocked)}%` }}></span>` : null}
-    </div>
-  `
-}
-
-function TaskGate({ rows }: { rows: ReturnType<typeof taskGateRows> }) {
-  const open = rows.filter(g => g.outcome !== 'satisfied').length
-  return html`
-    <div class="wk-gate">
-      <div class="wk-gate-h">
-        완료 계약 · 게이트 증거
-        ${open > 0
-          ? html`<span class="wk-gate-open">${open} 미충족</span>`
-          : html`<span class="wk-gate-ok">전부 충족</span>`}
-      </div>
-      ${rows.map((g, i) => html`
-        <div key=${i} class=${`wk-gate-row ${g.outcome}`}>
-          <span class="wk-gate-mark">
-            ${g.outcome === 'satisfied' ? '✓' : g.outcome === 'failed' ? '✕' : '○'}
-          </span>
-          <span class="wk-gate-ev"><span class="mono">${g.label}</span> · ${g.detail}</span>
-          <span class="wk-gate-out">${GATE_OUTCOME_LABEL[g.outcome]}</span>
-        </div>
-      `)}
     </div>
   `
 }
@@ -539,12 +484,10 @@ function TaskRow({ task, onClaim }: { task: Task; onClaim: (id: string) => void 
   const state = jobStateForTask(task)
   const keeper = keeperByName(task.assignee)
   const blocker = blockerNoteForTask(task)
-  const gateRows = taskGateRows(task)
   const handoff = task.handoff_context
   const evidenceRows = taskEvidenceLedgerRows(task)
   const hasDetail =
-    gateRows.length > 0
-    || evidenceRows.length > 0
+    evidenceRows.length > 0
     || !!handoff?.summary
     || !!handoff?.next_step
     || !!handoff?.failure_mode
@@ -595,7 +538,6 @@ function TaskRow({ task, onClaim }: { task: Task; onClaim: (id: string) => void 
       </div>
       ${open && hasDetail ? html`
         <div class="wk-task-detail">
-          ${gateRows.length > 0 ? html`<${TaskGate} rows=${gateRows} />` : null}
           ${evidenceRows.length > 0 ? html`<${TaskEvidenceLedger} rows=${evidenceRows} />` : null}
           ${handoff ? html`
             <div class="wk-handoff">
@@ -680,7 +622,6 @@ function GoalCard({
 //     `completed` | `dropped` = terminal — excluded (already closed out).
 //
 //   • "verifyTasks" (게이트): tasks with status=awaiting_verification.
-//     open-gate count from taskGateRows().
 //
 //   • "blockers": tasks where handoff_context.failure_mode or handoff_context.reason
 //     indicates blockage (status=cancelled OR explicit blocker via blockerNoteForTask).
@@ -743,7 +684,6 @@ interface WkaVerifyTask {
   readonly id: string
   readonly title: string
   readonly goalId: string
-  readonly open: number // unsatisfied gates
 }
 
 interface WkaBlockerTask {
@@ -1147,7 +1087,7 @@ function WorkAside({
               >
                 <span class="wka-todo-k">게이트</span>
                 <span class="wka-todo-t">${t.title}</span>
-                <span class="wka-todo-m mono">${t.open > 0 ? `${t.open} 미충족` : '검증 대기'}</span>
+                <span class="wka-todo-m mono">검증 대기</span>
               </button>
             `)}
             ${blockers.map(t => html`
@@ -1390,7 +1330,6 @@ function WorkSurfaceV2() {
         id: t.id,
         title: t.title,
         goalId: t.goal_id ?? '',
-        open: taskGateRows(t).filter(r => r.outcome !== 'satisfied').length,
       })),
   [claimedTasks])
 

--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -84,7 +84,6 @@ describe('refreshDashboard bootstrap', () => {
         generated_at: '2026-05-14T06:00:01Z',
         goals: [],
         rollup: {},
-        workspace_fsm: null,
       },
       namespace_truth: {
         generated_at: '2026-05-14T06:00:02Z',
@@ -155,7 +154,6 @@ describe('refreshDashboard bootstrap', () => {
         generated_at: '2026-06-26T00:00:01Z',
         goals: [],
         rollup: {},
-        workspace_fsm: null,
       },
       namespace_truth: {
         generated_at: '2026-06-26T00:00:02Z',
@@ -184,7 +182,6 @@ describe('refreshDashboard bootstrap', () => {
       generated_at: '2026-06-25T00:00:00Z',
       goals: [],
       rollup: {},
-      workspace_fsm: null,
     })
     apiMocks.fetchDashboardGoalsTree.mockResolvedValue({
       generated_at: '2026-06-25T00:00:01Z',
@@ -210,7 +207,6 @@ describe('refreshDashboard bootstrap', () => {
       generated_at: '2026-06-25T00:00:00Z',
       goals: [],
       rollup: {},
-      workspace_fsm: null,
     })
     const treePayload = {
       generated_at: '2026-06-25T00:00:01Z',
@@ -239,7 +235,6 @@ describe('refreshDashboard bootstrap', () => {
       generated_at: '2026-06-25T00:00:00Z',
       goals: [],
       rollup: {},
-      workspace_fsm: null,
     })
     apiMocks.fetchDashboardGoalsTree.mockRejectedValue(new Error('tree offline'))
 
@@ -289,7 +284,6 @@ describe('refreshDashboard bootstrap', () => {
       generated_at: '2026-06-25T00:00:00Z',
       goals: [],
       rollup: {},
-      workspace_fsm: null,
     })
     apiMocks.fetchDashboardGoalsTree.mockResolvedValue({
       generated_at: '2026-06-25T00:00:01Z',

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -167,61 +167,6 @@ describe('normalizeTaskStatus', () => {
     })
   })
 
-  it('preserves task gate snapshots from execution task payloads', () => {
-    expect(normalizeTask({
-      id: 'task-gate',
-      title: 'Execution task with gate',
-      status: 'awaiting_verification',
-      gate: {
-        strict: true,
-        completion_contract: ['unit tests pass'],
-        unmet_completion_contract: ['manual approval'],
-        done: {
-          status: 'blocked',
-          checks: [
-            { evidence: 'unit tests pass', outcome: 'satisfied', detail: 'vitest green' },
-            { evidence: 'manual approval', outcome: 'missing', detail: 'operator pending' },
-          ],
-          reasons: ['operator approval pending'],
-        },
-        inspect_to_implement: {
-          status: 'inconclusive',
-          checks: [
-            { evidence: 'diff review', outcome: 'unsupported', detail: 'not collected' },
-          ],
-        },
-        verify_to_review: {
-          status: 'not-a-known-status',
-          reasons: ['backend drift fixture'],
-        },
-      },
-    })).toMatchObject({
-      gate: {
-        strict: true,
-        completion_contract: ['unit tests pass'],
-        unmet_completion_contract: ['manual approval'],
-        done: {
-          status: 'blocked',
-          checks: [
-            { evidence: 'unit tests pass', outcome: 'satisfied', detail: 'vitest green' },
-            { evidence: 'manual approval', outcome: 'missing', detail: 'operator pending' },
-          ],
-          reasons: ['operator approval pending'],
-        },
-        inspect_to_implement: {
-          status: 'inconclusive',
-          checks: [
-            { evidence: 'diff review', outcome: 'unsupported', detail: 'not collected' },
-          ],
-        },
-        verify_to_review: {
-          status: 'unknown',
-          status_raw: 'not-a-known-status',
-          reasons: ['unknown gate status: not-a-known-status', 'backend drift fixture'],
-        },
-      },
-    })
-  })
 })
 
 describe('normalizeMessage', () => {

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -1,4 +1,4 @@
-import { isRecord, asString, asNumber, asBoolean, asStringArray, asRecordArray, toIsoTimestamp } from './components/common/normalize'
+import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import {
   parseTaskStatus,
   parseExecutionTone,
@@ -16,7 +16,7 @@ import {
   DASHBOARD_KEEPER_NON_EXECUTABLE_CAUSES,
 } from './types/dashboard-execution'
 import type {
-  Agent, Task, TaskGateEvaluation, Message, ServerStatus,
+  Agent, Task, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
   DashboardExecutionQueueItem, DashboardExecutionSessionBrief,
   DashboardExecutionWorkerSupportBrief,
@@ -58,79 +58,6 @@ export function normalizeAgentStatus(value: unknown): Agent['status'] {
 
 export function normalizeTaskStatus(value: unknown): Task['status'] {
   return parseTaskStatus(value)
-}
-
-function normalizeTaskGateStatus(value: unknown): {
-  readonly status: TaskGateEvaluation['status']
-  readonly raw: string | null
-} {
-  const raw = asString(value)?.trim() ?? null
-  if (raw === 'ready' || raw === 'blocked' || raw === 'inconclusive') {
-    return { status: raw, raw: null }
-  }
-  return { status: 'unknown', raw }
-}
-
-function normalizeTaskGateCheckOutcome(value: unknown): 'satisfied' | 'missing' | 'failed' | 'unsupported' | null {
-  const raw = asString(value)?.trim()
-  if (raw === 'satisfied' || raw === 'missing' || raw === 'failed' || raw === 'unsupported') return raw
-  return null
-}
-
-function normalizeTaskGateCheck(raw: unknown): NonNullable<TaskGateEvaluation['checks']>[number] | null {
-  if (!isRecord(raw)) return null
-  const outcome = normalizeTaskGateCheckOutcome(raw.outcome)
-  if (!outcome) return null
-  const evidence = asString(raw.evidence, '')
-  const detail = asString(raw.detail, '')
-  if (!evidence && !detail) return null
-  return { evidence, outcome, detail }
-}
-
-function normalizeTaskGateEvaluation(raw: unknown): TaskGateEvaluation | null {
-  if (!isRecord(raw)) return null
-  const statusInput = asString(raw.status)
-  const { status, raw: statusRaw } = normalizeTaskGateStatus(raw.status)
-  const checks = asRecordArray(raw.checks)
-    .map(normalizeTaskGateCheck)
-    .filter((check): check is NonNullable<TaskGateEvaluation['checks']>[number] => check !== null)
-  const reasons = asStringArray(raw.reasons)
-  if (statusRaw) reasons.unshift(`unknown gate status: ${statusRaw}`)
-  if (!statusInput && checks.length === 0 && reasons.length === 0) return null
-  return {
-    status,
-    status_raw: statusRaw,
-    checks,
-    reasons,
-  }
-}
-
-function normalizeTaskGateSnapshot(raw: unknown): Task['gate'] {
-  if (!isRecord(raw)) return null
-  const done = normalizeTaskGateEvaluation(raw.done)
-  const inspect = normalizeTaskGateEvaluation(raw.inspect_to_implement)
-  const verify = normalizeTaskGateEvaluation(raw.verify_to_review)
-  const completionContract = asStringArray(raw.completion_contract)
-  const unmetCompletionContract = asStringArray(raw.unmet_completion_contract)
-  const strict = asBoolean(raw.strict)
-  if (
-    done === null
-    && inspect === null
-    && verify === null
-    && completionContract.length === 0
-    && unmetCompletionContract.length === 0
-    && strict === undefined
-  ) {
-    return null
-  }
-  return {
-    strict,
-    completion_contract: completionContract,
-    unmet_completion_contract: unmetCompletionContract,
-    done: done ?? undefined,
-    inspect_to_implement: inspect,
-    verify_to_review: verify,
-  }
 }
 
 export function normalizeAgent(raw: unknown): Agent | null {
@@ -194,7 +121,6 @@ export function normalizeTask(raw: unknown): Task | null {
         session_id: asString(raw.execution_links.session_id) ?? null,
       }
     : null
-  const gate = normalizeTaskGateSnapshot(raw.gate)
   return {
     id,
     title,
@@ -210,7 +136,6 @@ export function normalizeTask(raw: unknown): Task | null {
     completed_at: asString(raw.completed_at),
     contract,
     handoff_context: handoffContext,
-    gate,
     execution_links: executionLinks,
   }
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -24,11 +24,6 @@ import type {
   DashboardRuntimeResolution,
   DashboardShellAuthSummary,
   DashboardShellResponse,
-  DashboardWorkspaceFsmEvidence,
-  DashboardWorkspaceFsmProduct,
-  DashboardWorkspaceFsmRefs,
-  DashboardWorkspaceFsmSnapshot,
-  DashboardWorkspaceFsmViolation,
 } from './types'
 import { fetchDashboardBootstrap, fetchDashboardShell } from './api/dashboard-hot'
 import { journal } from './sse'
@@ -47,7 +42,7 @@ import {
 import { groupByKey } from './components/common/collection'
 import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
-import { isRecord, asString, asNumber, asStringArray } from './components/common/normalize'
+import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
 import { timeBoardRequest } from './board-metrics'
 import { namespaceTruth, namespaceTruthError, namespaceTruthInitializing } from './namespace-truth-signals'
@@ -323,7 +318,6 @@ export function removeBoardPost(postId: string | undefined): void {
 
 export const goals = signal<Goal[]>([])
 export const goalsLoading = signal(false)
-export const workspaceFsmSnapshot = signal<DashboardWorkspaceFsmSnapshot | null>(null)
 
 // --- Fusion run registry state (RFC-0266 §7 Phase 4) ---
 
@@ -754,128 +748,7 @@ export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   return inflightDashboardRefresh
 }
 
-function normalizeWorkspaceFsmRefs(raw: unknown): DashboardWorkspaceFsmRefs {
-  const refsRecord = isRecord(raw) ? raw : {}
-  return {
-    goal_id: asString(refsRecord.goal_id) ?? null,
-    task_ids: asStringArray(refsRecord.task_ids),
-    post_ids: asStringArray(refsRecord.post_ids),
-    agent_name: asString(refsRecord.agent_name) ?? null,
-  }
-}
-
-function normalizeWorkspaceFsmEvidence(raw: unknown): DashboardWorkspaceFsmEvidence | null {
-  if (!isRecord(raw)) return null
-  return {
-    source: asString(raw.source) ?? undefined,
-    kind: asString(raw.kind) ?? undefined,
-    id: asString(raw.id) ?? null,
-    label: asString(raw.label) ?? undefined,
-    detail: asString(raw.detail) ?? undefined,
-    timestamp: asNumber(raw.timestamp) ?? null,
-    refs: normalizeWorkspaceFsmRefs(raw.refs),
-  }
-}
-
-function normalizeWorkspaceFsmEvidenceList(raw: unknown): DashboardWorkspaceFsmEvidence[] {
-  return Array.isArray(raw)
-    ? raw
-      .map(normalizeWorkspaceFsmEvidence)
-      .filter((row): row is DashboardWorkspaceFsmEvidence => row !== null)
-    : []
-}
-
-function refsOverlap(
-  left: DashboardWorkspaceFsmRefs | undefined,
-  right: DashboardWorkspaceFsmRefs | undefined,
-): boolean {
-  if (!left || !right) return false
-  if (left.goal_id && left.goal_id === right.goal_id) return true
-  if (left.agent_name && left.agent_name === right.agent_name) return true
-  if ((left.task_ids ?? []).some(taskId => (right.task_ids ?? []).includes(taskId))) return true
-  return (left.post_ids ?? []).some(postId => (right.post_ids ?? []).includes(postId))
-}
-
-function normalizeWorkspaceFsmSnapshot(raw: unknown): DashboardWorkspaceFsmSnapshot | null {
-  if (!isRecord(raw)) return null
-  const summaryRecord = isRecord(raw.summary) ? raw.summary : {}
-  const severityRecord = isRecord(summaryRecord.severity_counts)
-    ? summaryRecord.severity_counts
-    : {}
-  const products: DashboardWorkspaceFsmProduct[] = Array.isArray(raw.products)
-    ? raw.products
-      .map((row): DashboardWorkspaceFsmProduct | null => {
-        if (!isRecord(row)) return null
-        return {
-          refs: normalizeWorkspaceFsmRefs(row.refs),
-          goal: asString(row.goal) ?? null,
-          task: asString(row.task) ?? undefined,
-          board: asString(row.board) ?? undefined,
-          reward: asString(row.reward) ?? undefined,
-          evidence: normalizeWorkspaceFsmEvidenceList(row.evidence),
-          violations: Array.isArray(row.violations)
-            ? row.violations
-              .map((violation): DashboardWorkspaceFsmViolation | null => {
-                if (!isRecord(violation)) return null
-                return {
-                  axis: asString(violation.axis) ?? undefined,
-                  code: asString(violation.code) ?? undefined,
-                  severity: asString(violation.severity) ?? undefined,
-                  message: asString(violation.message) ?? undefined,
-                  refs: normalizeWorkspaceFsmRefs(violation.refs),
-                  evidence: normalizeWorkspaceFsmEvidenceList(violation.evidence),
-                }
-              })
-              .filter((violation): violation is DashboardWorkspaceFsmViolation => violation !== null)
-            : [],
-        }
-      })
-      .filter((row): row is DashboardWorkspaceFsmProduct => row !== null)
-    : []
-  const fallbackEvidence = products.flatMap(product => product.evidence ?? [])
-  const snapshotEvidence = normalizeWorkspaceFsmEvidenceList(raw.evidence)
-  const evidence = snapshotEvidence.length > 0 ? snapshotEvidence : fallbackEvidence
-  const violations = Array.isArray(raw.violations)
-    ? raw.violations
-      .map((row): DashboardWorkspaceFsmViolation | null => {
-        if (!isRecord(row)) return null
-        const refs = normalizeWorkspaceFsmRefs(row.refs)
-        const rowEvidence = normalizeWorkspaceFsmEvidenceList(row.evidence)
-        return {
-          axis: asString(row.axis) ?? undefined,
-          code: asString(row.code) ?? undefined,
-          severity: asString(row.severity) ?? undefined,
-          message: asString(row.message) ?? undefined,
-          refs,
-          evidence: rowEvidence.length > 0
-            ? rowEvidence
-            : fallbackEvidence.filter(item => refsOverlap(refs, item.refs)).slice(0, 5),
-        }
-      })
-      .filter((row): row is DashboardWorkspaceFsmViolation => row !== null)
-    : []
-  return {
-    schema_version: asNumber(raw.schema_version) ?? undefined,
-    mode: asString(raw.mode) ?? undefined,
-    summary: {
-      products: asNumber(summaryRecord.products) ?? undefined,
-      violations: asNumber(summaryRecord.violations) ?? undefined,
-      evidence: asNumber(summaryRecord.evidence) ?? evidence.length,
-      severity_counts: {
-        info: asNumber(severityRecord.info) ?? 0,
-        warn: asNumber(severityRecord.warn) ?? 0,
-        error: asNumber(severityRecord.error) ?? 0,
-      },
-    },
-    products,
-    evidence,
-    violations,
-    projection_error: asString(raw.projection_error) ?? null,
-  }
-}
-
 function applyPlanningEnvelope(data: DashboardPlanningResponse): void {
-  workspaceFsmSnapshot.value = normalizeWorkspaceFsmSnapshot(data.workspace_fsm)
   goals.value = (Array.isArray(data.goals) ? data.goals : [])
     .map((row): Goal | null => {
       if (!isRecord(row)) return null

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -851,21 +851,6 @@
 .wk-task-claim:hover { background: color-mix(in oklab, var(--volt) 18%, transparent); color: var(--text-bright); }
 
 .wk-task-detail { padding: 4px 8px 10px 25px; }
-.wk-gate { border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); background: var(--bg-sunken); padding: 10px 12px; }
-.wk-gate-h { font-size: var(--fs-11); color: var(--text-mid); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
-.wk-gate-open { font-size: 9.5px; color: var(--status-warn); border: 1px solid color-mix(in oklab, var(--status-warn) 38%, transparent); border-radius: var(--radius-pill); padding: 1px 7px; }
-.wk-gate-ok { font-size: 9.5px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 38%, transparent); border-radius: var(--radius-pill); padding: 1px 7px; }
-.wk-gate-row { display: flex; align-items: center; gap: 9px; padding: 4px 0; border-top: 1px solid var(--border-soft); }
-.wk-gate-row:first-of-type { border-top: 0; }
-.wk-gate-mark { flex: none; width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%; font-size: var(--fs-9); }
-.wk-gate-row.satisfied .wk-gate-mark { color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); }
-.wk-gate-row.missing .wk-gate-mark { color: var(--text-dim); border: 1px solid var(--border-highlight); }
-.wk-gate-row.failed .wk-gate-mark { color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 45%, transparent); }
-.wk-gate-ev { flex: 1; font-size: var(--fs-12); color: var(--text-primary); }
-.wk-gate-row.missing .wk-gate-ev { color: var(--text-mid); }
-.wk-gate-out { flex: none; font-size: var(--fs-10); font-family: var(--font-mono); color: var(--text-dim); }
-.wk-gate-row.satisfied .wk-gate-out { color: var(--status-ok); }
-.wk-gate-row.failed .wk-gate-out { color: var(--status-bad); }
 
 .wk-handoff { margin-top: 8px; border: 1px solid var(--border-soft); border-left: 2px solid var(--info); border-radius: var(--radius-sm); background: color-mix(in oklab, var(--info) 5%, var(--bg-sunken)); padding: 10px 12px; }
 .wk-handoff-h { font-size: var(--fs-11); color: var(--info); margin-bottom: 7px; }

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -592,7 +592,7 @@
   color: var(--text-bright);
 }
 
-/* ── Inline task detail (gate + handoff) ──────────────────────────────────── */
+/* ── Inline task detail (handoff) ──────────────────────────────────── */
 .wk-task-detail {
   width: calc(100% - 24px);
   margin-left: 24px;
@@ -600,89 +600,6 @@
   flex-direction: column;
   gap: 10px;
   padding-top: 6px;
-}
-
-.wk-gate {
-  /* No row gap — the prototype's gate rows sit flush, separated by the
-     border-top the vendored keeper-v2/v2.css supplies. */
-  display: flex;
-  flex-direction: column;
-}
-
-.wk-gate-h {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-dim);
-}
-
-.wk-gate-open {
-  font-size: var(--fs-10);
-  padding: 1px 6px;
-  border-radius: var(--radius-pill);
-  border: 1px solid color-mix(in oklab, var(--status-warn) 35%, transparent);
-  background: color-mix(in oklab, var(--status-warn) 10%, transparent);
-  color: var(--status-warn);
-}
-
-.wk-gate-ok {
-  font-size: var(--fs-10);
-  padding: 1px 6px;
-  border-radius: var(--radius-pill);
-  border: 1px solid color-mix(in oklab, var(--status-ok) 35%, transparent);
-  background: color-mix(in oklab, var(--status-ok) 10%, transparent);
-  color: var(--status-ok);
-}
-
-.wk-gate-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  max-width: 100%;
-  padding: 4px 8px;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--border-soft);
-  color: var(--text-mid);
-  font-size: var(--fs-11);
-  line-height: 1.3;
-  width: fit-content;
-}
-
-.wk-gate-row.satisfied {
-  color: var(--status-ok);
-  border-color: color-mix(in oklab, var(--status-ok) 30%, transparent);
-}
-
-.wk-gate-row.missing {
-  color: var(--status-warn);
-  border-color: color-mix(in oklab, var(--status-warn) 30%, transparent);
-}
-
-.wk-gate-row.failed {
-  color: var(--status-bad);
-  border-color: color-mix(in oklab, var(--status-bad) 30%, transparent);
-}
-
-.wk-gate-mark {
-  flex: none;
-  font-size: var(--fs-11);
-  width: 14px;
-  text-align: center;
-}
-
-.wk-gate-label {
-  flex: none;
-  text-transform: uppercase;
-}
-
-.wk-gate-detail {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .wk-handoff {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -65,7 +65,6 @@ export interface Task {
   predecessor_task_id?: string | null
   contract?: TaskContract | null
   handoff_context?: TaskHandoffContext | null
-  gate?: TaskGateSnapshot | null
   execution_links?: TaskExecutionLinks | null
 }
 
@@ -91,28 +90,6 @@ interface TaskHandoffContext {
   evidence_refs?: string[]
   updated_at?: string | null
   updated_by?: string | null
-}
-
-interface TaskGateCheck {
-  evidence: string
-  outcome: 'satisfied' | 'missing' | 'failed' | 'unsupported'
-  detail: string
-}
-
-export interface TaskGateEvaluation {
-  status: 'ready' | 'blocked' | 'inconclusive' | 'unknown'
-  status_raw?: string | null
-  checks?: TaskGateCheck[]
-  reasons?: string[]
-}
-
-interface TaskGateSnapshot {
-  strict?: boolean
-  completion_contract?: string[]
-  unmet_completion_contract?: string[]
-  done?: TaskGateEvaluation
-  inspect_to_implement?: TaskGateEvaluation | null
-  verify_to_review?: TaskGateEvaluation | null
 }
 
 export interface Message {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -647,64 +647,6 @@ export interface DashboardPlanningResponse {
     done?: number
     cancelled?: number
   }
-  workspace_fsm?: DashboardWorkspaceFsmSnapshot | null
-}
-
-export interface DashboardWorkspaceFsmRefs {
-  goal_id?: string | null
-  task_ids?: string[]
-  post_ids?: string[]
-  agent_name?: string | null
-}
-
-export interface DashboardWorkspaceFsmEvidence {
-  source?: string
-  kind?: string
-  id?: string | null
-  label?: string
-  detail?: string
-  timestamp?: number | null
-  refs?: DashboardWorkspaceFsmRefs
-}
-
-export interface DashboardWorkspaceFsmViolation {
-  axis?: string
-  code?: string
-  severity?: 'info' | 'warn' | 'error' | string
-  message?: string
-  refs?: DashboardWorkspaceFsmRefs
-  evidence?: DashboardWorkspaceFsmEvidence[]
-}
-
-export interface DashboardWorkspaceFsmProduct {
-  refs?: DashboardWorkspaceFsmRefs
-  goal?: string | null
-  task?: string
-  board?: string
-  reward?: string
-  evidence?: DashboardWorkspaceFsmEvidence[]
-  violations?: DashboardWorkspaceFsmViolation[]
-}
-
-export interface DashboardWorkspaceFsmSummary {
-  products?: number
-  violations?: number
-  evidence?: number
-  severity_counts?: {
-    info?: number
-    warn?: number
-    error?: number
-  }
-}
-
-export interface DashboardWorkspaceFsmSnapshot {
-  schema_version?: number
-  mode?: string
-  summary?: DashboardWorkspaceFsmSummary
-  products?: DashboardWorkspaceFsmProduct[]
-  evidence?: DashboardWorkspaceFsmEvidence[]
-  violations?: DashboardWorkspaceFsmViolation[]
-  projection_error?: string | null
 }
 
 // --- Goal Tree (hierarchical goal decomposition) ---


### PR DESCRIPTION
## 근거 — 프로듀서가 없습니다

`Task.gate` 와 그 하위 타입(`TaskGateSnapshot`, `TaskGateEvaluation`)이 읽는 wire 키를 내보내는 곳이 없습니다.

taskboard 스키마는 persisted contract 를 **`contract`** 키로 내보냅니다:

```
lib/tool_surface/tool_shard_types_schemas_taskboard.ml:217
  ( "contract"
  , `Assoc [ "type", `String "object"
           ; "properties", `Assoc [ "strict"; "completion_contract"
                                  ; "required_evidence"; "inspect_gate_evidence"; ... ] ] )
```

대시보드가 읽던 건 `gate` 입니다. 키가 다릅니다.

그리고 대시보드가 구조분해하던 필드 중 둘은 `lib/` 전체에 **0건**입니다:

| 필드 | `lib/` 프로듀서 |
|---|---|
| `unmet_completion_contract` | **0** |
| `inspect_to_implement` | **0** |
| `workspace_fsm` | **0** |

즉 이 패널들은 도착한 적 없는 데이터로 렌더링하고 있었습니다.

## 변경

```
16 files changed, 16 insertions(+), 843 deletions(-)
```

`Task.gate` 계열 타입, `workspace_fsm`, 그리고 이들을 위해서만 존재하던 store normalizer 와 스타일을 제거합니다.

## 검증

- `dashboard/src` 에 `workspace_fsm` · gate 타입 잔여 참조 **0**
- `npx tsc --noEmit -p tsconfig.json` 통과
- 변경된 테스트 5개 파일 **99 tests passed**
  (`goal-tree`, `planning-panel`, `work`, `store-dashboard-bootstrap`, `store-normalizers`)

전체 vitest 스위트는 로컬에서 20분+ 소요라 CI 에 맡깁니다.

## 하지 않은 것

`lib/` 을 건드리지 않습니다. `contract` 키로 실제 전달되는 데이터를 대시보드가 소비해야 하는지는 별개 판단이며, 이 PR 은 도착하지 않는 데이터를 기다리던 코드만 걷어냅니다.

RFC-WAIVED: `dashboard/src` 의 dead consumer 제거이며 credential 관련 component 를 건드리지 않습니다.

Co-Authored-By: MASC Agent <agent@masc.local>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>