### PR TITLE
fix(task-009): remove last_compaction_ago_s end-to-end

### DIFF
--- a/dashboard/src/components/common/agent-motion.ts
+++ b/dashboard/src/components/common/agent-motion.ts
@@ -41,7 +41,6 @@ function keeperSignalTimestamp(keeper: Keeper): string | null {
     ?? timestampFromAgeSeconds(keeper.last_turn_ago_s)
     ?? timestampFromAgeSeconds(keeper.last_proactive_ago_s)
     ?? timestampFromAgeSeconds(keeper.last_handoff_ago_s)
-    ?? timestampFromAgeSeconds(keeper.last_compaction_ago_s)
 }
 
 function boardPreview(post: BoardPost): string {

--- a/dashboard/src/components/keeper-detail-kpi.test.ts
+++ b/dashboard/src/components/keeper-detail-kpi.test.ts
@@ -44,6 +44,24 @@ function metricPoint(overrides: Partial<KeeperMetricPoint>): KeeperMetricPoint {
 }
 
 describe('KpiGrid', () => {
+  it('does not render the removed last-compaction-age KPI', () => {
+    const keeper = {
+      name: 'sangsu',
+      status: 'active',
+      last_heartbeat: '2026-07-29T10:00:00Z',
+      metrics_window: {
+        compaction_saved_ratio: 0.4,
+        avg_compaction_saved_tokens: 120,
+      },
+    } as Keeper
+
+    render(h(KpiGrid, { keeper }))
+
+    expect(screen.getByText('하트비트')).toBeInTheDocument()
+    expect(screen.getByText('압축 절감률')).toBeInTheDocument()
+    expect(screen.queryByText('마지막 압축')).not.toBeInTheDocument()
+  })
+
   it('surfaces latest keeper tok/sec in the detail KPI grid', () => {
     const keeper = {
       name: 'sangsu',

--- a/dashboard/src/components/keeper-detail-kpi.ts
+++ b/dashboard/src/components/keeper-detail-kpi.ts
@@ -62,13 +62,12 @@ export function OperationalHealth({ keeper }: { keeper: Keeper }) {
   const hb = keeper.last_heartbeat
   const compSavedRatio = mw?.compaction_saved_ratio
   const avgSaved = mw?.avg_compaction_saved_tokens
-  const lastCompAgo = keeper.last_compaction_ago_s
 
   const hbTone: KpiTone = !hb ? 'default' : 'ok'
   const compTone: KpiTone = compSavedRatio == null ? 'default'
     : compSavedRatio >= 0.4 ? 'ok' : compSavedRatio >= 0.2 ? 'warn' : 'bad'
 
-  const hasAny = hb || compSavedRatio != null || lastCompAgo != null
+  const hasAny = hb || compSavedRatio != null
   if (!hasAny) return null
 
   return html`

--- a/dashboard/src/components/keeper-detail-kpi.ts
+++ b/dashboard/src/components/keeper-detail-kpi.ts
@@ -1,6 +1,5 @@
 import { html } from 'htm/preact'
 import { formatPct1, formatTokens, formatTokPerSec, isFiniteMetricValue } from '../lib/format-number'
-import { formatDurationCompound } from '../lib/format-time'
 import { Eyebrow } from './common/eyebrow'
 import { StatTile } from './common/stat-tile'
 import type { Keeper, KeeperMetricPoint } from '../types'
@@ -85,12 +84,6 @@ export function OperationalHealth({ keeper }: { keeper: Keeper }) {
             <${Eyebrow}>압축 절감률</${Eyebrow}>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[compTone]}">${formatPct1(compSavedRatio)}</span>
             ${avgSaved != null ? html`<${MutedSpan}>avg ${formatTokens(avgSaved)} saved</${MutedSpan}>` : null}
-          </div>
-        ` : null}
-        ${lastCompAgo != null ? html`
-          <div class="p-2 rounded-[var(--r-1)] border ${KPI_TONE['default']} flex flex-col gap-0.5 v2-monitoring-card">
-            <${Eyebrow}>마지막 압축</${Eyebrow}>
-            <span class="text-xs font-mono text-[var(--color-fg-secondary)]">${formatDurationCompound(lastCompAgo)} 전</span>
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -771,7 +771,7 @@ describe('KeeperWorkspaceRail', () => {
   })
 
   it('renders context metrics as missing when only a zero default exists', () => {
-    const k = mkKeeper({ context_ratio: 0, compaction_count: 0, last_compaction_ago_s: 0 })
+    const k = mkKeeper({ context_ratio: 0, compaction_count: 0 })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
     // v2 collapses the missing-context state into a single "윈도우 사용률 미수신"
     // empty card (.ctx-empty); no fake usage meter and no usage percentage.

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -306,7 +306,6 @@ export function keeperFreshnessTs(keeper: Keeper, heartbeats: Map<string, number
     keeper.last_turn_ago_s,
     keeper.last_proactive_ago_s,
     keeper.last_handoff_ago_s,
-    keeper.last_compaction_ago_s,
   ].find(value => typeof value === 'number' && Number.isFinite(value) && value >= 0)
 
   return typeof ageSeconds === 'number'
@@ -734,7 +733,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         keeper_age_s: asNumber(row.keeper_age_s),
         last_turn_ago_s: asNumber(row.last_turn_ago_s),
         last_handoff_ago_s: asNumber(row.last_handoff_ago_s),
-        last_compaction_ago_s: asNumber(row.last_compaction_ago_s),
         last_proactive_ago_s: asNumber(row.last_proactive_ago_s),
         last_proactive_reason: asString(row.last_proactive_reason) ?? null,
         last_activity_ago_s: asNumber(row.last_activity_ago_s),

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -201,7 +201,6 @@ const KEEPER_RELATIVE_AGE_FIELDS = new Set<string>([
   'last_activity_ago_s',
   'last_turn_ago_s',
   'last_handoff_ago_s',
-  'last_compaction_ago_s',
   'last_proactive_ago_s',
   'next_eligible_at_s',
 ])

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1198,7 +1198,6 @@ export interface Keeper {
   keeper_age_s?: number
   last_turn_ago_s?: number
   last_handoff_ago_s?: number
-  last_compaction_ago_s?: number
   last_proactive_ago_s?: number
   last_proactive_reason?: string | null
   last_proactive_preview?: string | null

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -384,9 +384,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
           let last_handoff_ago_s =
             Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.last_handoff_ts
           in
-          let last_compaction_ago_s =
-            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.compaction_rt.last_ts
-          in
           let last_proactive_ago_s =
             Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_ts
           in
@@ -887,7 +884,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                   keeper_age_s );
               ("last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s);
               ("last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s);
-              ("last_compaction_ago_s", Json_util.float_opt_to_json last_compaction_ago_s);
               ("last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s);
               ("last_visible_proactive_ago_s", Json_util.float_opt_to_json last_visible_proactive_ago_s);
               ("last_activity_ago_s", Json_util.float_opt_to_json last_activity_ago_s);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -408,9 +408,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          let last_handoff_ago_s =
            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.last_handoff_ts
          in
-         let last_compaction_ago_s =
-           Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.compaction_rt.last_ts
-         in
          let last_proactive_ago_s =
            Keeper_status_metrics.age_seconds_opt ~now_ts m.runtime.proactive_rt.last_ts
          in
@@ -723,7 +720,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            ("keeper_age_s", Json_util.float_opt_to_json keeper_age_s);
            ("last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s);
            ("last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s);
-           ("last_compaction_ago_s", Json_util.float_opt_to_json last_compaction_ago_s);
            ("last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s);
            ("last_visible_proactive_ago_s", Json_util.float_opt_to_json last_visible_proactive_ago_s);
            ("active_model", `Null);

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -268,10 +268,6 @@ let keepers_json
                       Keeper_status_metrics.age_seconds_opt
                         ~now_ts meta.runtime.last_handoff_ts
                     in
-                    let last_compaction_ago_s =
-                      Keeper_status_metrics.age_seconds_opt
-                        ~now_ts meta.runtime.compaction_rt.last_ts
-                    in
                     let last_proactive_ago_s =
                       Keeper_status_metrics.age_seconds_opt
                         ~now_ts meta.runtime.proactive_rt.last_ts
@@ -401,7 +397,6 @@ let keepers_json
                          ; "turn_count", `Int meta.runtime.usage.total_turns
                          ; "last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s
                          ; "last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s
-                         ; "last_compaction_ago_s", Json_util.float_opt_to_json last_compaction_ago_s
                          ; "last_proactive_ago_s", Json_util.float_opt_to_json last_proactive_ago_s
                          ; "last_activity_ago_s", Json_util.float_opt_to_json last_activity_ago_s
                          ; "last_model_used", `String (Keeper_status_runtime.active_model_of_meta meta)

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -1353,6 +1353,25 @@ let test_operator_digest_severity_rank_supports_critical () =
 (* test_snapshot_and_digest_expose_role_runtime_census removed:
    depended on team session start/update which is no longer available. *)
 
+let test_last_compaction_ago_s_removed_from_backend_serializers () =
+  let root = Masc_test_deps.find_project_root () in
+  let files =
+    [ "lib/operator/operator_control_snapshot.ml"
+    ; "lib/dashboard/dashboard_http_keeper.ml"
+    ; "lib/keeper/keeper_status_detail.ml" ]
+  in
+  List.iter
+    (fun rel ->
+       let path = Filename.concat root rel in
+       match Safe_ops.read_file_safe path with
+       | Error err -> Alcotest.failf "read %s failed: %s" rel err
+       | Ok text ->
+           Alcotest.(check bool)
+             (Printf.sprintf "%s does not contain last_compaction_ago_s" rel)
+             true
+             (Option.is_none (last_substring_index text "last_compaction_ago_s")))
+    files
+
 let () =
   Alcotest.run
     "operator_control_snapshot"
@@ -1389,6 +1408,12 @@ let () =
             "storage failure is typed unavailable"
             `Quick
             test_context_snapshot_storage_failure_is_unavailable
+        ] );
+      ( "last_compaction_ago_s removal"
+      , [ Alcotest.test_case
+            "backend serializers do not emit last_compaction_ago_s"
+            `Quick
+            test_last_compaction_ago_s_removed_from_backend_serializers
         ] );
     ]
 ;;


### PR DESCRIPTION
## Summary
Removes the presentation-derived `last_compaction_ago_s` field end-to-end. The field duplicated compaction timing information that is already available via `last_activity_ago_s` / `last_activity_at` / `last_activity_source`.

## Backend changes
- `lib/operator/operator_control_snapshot.ml`
- `lib/dashboard/dashboard_http_keeper.ml`
- `lib/keeper/keeper_status_detail.ml`

## Frontend changes
- `dashboard/src/types/core.ts`
- `dashboard/src/store.ts`
- `dashboard/src/keeper-store-normalize.ts`
- `dashboard/src/components/keeper-detail-kpi.ts`
- `dashboard/src/components/common/agent-motion.ts`
- `dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts`

## Regression coverage
- `test/test_operator_control_snapshot.ml`: asserts that the three backend serializer source files no longer emit `last_compaction_ago_s`.

## Preserved
- `compaction_count`
- `last_compaction_saved_tokens`
- Runtime compaction behavior, decisions, snapshots

## Blast radius
Dashboard keeper status display only. No API contract replacement field added.

## Validation
- `dune-local.sh build test/test_operator_control_snapshot.exe` ✅
- `test_operator_control_snapshot.exe test` ✅ (8/8)
- Frontend `pnpm typecheck` could not run because `node_modules` is not installed in this worktree; changes are limited to straightforward field/variable deletions.