### PR TITLE
refactor(workspace): require current root state marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   no compatibility reader or migration path was added.
 
 ### Removed
+- **Breaking (workspace root state)**: removed the pre-rename
+  `.masc/state.json` fallback from the cluster-root initialization check and
+  removed its public path helper. Workspace, dashboard, keeper-directive, and
+  gRPC root gates now recognize only the current `.masc/root-state.json`
+  marker already written by init/bootstrap. No migration or repair path was
+  added.
 - **Breaking (keeper chat wire)**: removed read-time message-id synthesis for
   rows without a persisted `id` and removed the duplicate persisted `source`
   lane label. Current chat rows require a nonblank producer-assigned `id` and

--- a/lib/workspace/workspace_utils_paths_backend.ml
+++ b/lib/workspace/workspace_utils_paths_backend.ml
@@ -223,28 +223,18 @@ let list_dir config path =
 
 let root_state_path config = Filename.concat (masc_root_dir config) "root-state.json"
 
-(* Legacy root marker before root/workspace split lived at .masc/state.json. *)
-let legacy_root_state_path config = Filename.concat (masc_root_dir config) "state.json"
-
 (** Root initialization check - independent of current workspace.
     Used by workspace/cluster management features. *)
 let root_is_initialized config =
   match config.backend with
   | Memory _ ->
-      let exists_root path ~fallback_key =
-        let key =
-          match root_key_of_path config path with
-          | Some k -> k
-          | None -> fallback_key
-        in
-        backend_exists config ~key
-      in
-      exists_root (root_state_path config) ~fallback_key:"root-state.json" ||
-      exists_root (legacy_root_state_path config) ~fallback_key:"state.json"
+      (match root_key_of_path config (root_state_path config) with
+       | Some key -> backend_exists config ~key
+       | None -> false)
   | FileSystem _ ->
       Sys.file_exists (masc_root_dir config) &&
       Sys.is_directory (masc_root_dir config) &&
-      (Sys.file_exists (root_state_path config) || Sys.file_exists (legacy_root_state_path config))
+      Sys.file_exists (root_state_path config)
 
 (* Server-level cache for is_initialized — avoids 3 syscalls per request.
    Cache key is (base_path, cluster_name) to handle multi-config scenarios. *)

--- a/lib/workspace/workspace_utils_paths_backend.mli
+++ b/lib/workspace/workspace_utils_paths_backend.mli
@@ -37,10 +37,6 @@ val keepers_runtime_dir : config -> string
     one-time root setup. *)
 val root_state_path : config -> string
 
-(** Pre-rename cluster-root state path (legacy [.masc/state.json]).
-    Kept exposed for fallback existence checks during migration. *)
-val legacy_root_state_path : config -> string
-
 (** Project-scoped key prefix for backend keys (e.g.
     ["proj:default"]). Used by broadcast/pubsub channel naming. *)
 val project_prefix : config -> string

--- a/test/test_workspace_utils_coverage.ml
+++ b/test/test_workspace_utils_coverage.ml
@@ -556,6 +556,55 @@ let test_masc_root_dir_with_cluster_nested () =
   let result = Workspace_utils.masc_root_dir cfg in
   check string "nested with cluster" "/a/b/c/.masc/clusters/prod" result
 
+let test_memory_root_initialization_requires_current_marker () =
+  let scratch = Filename.temp_dir "workspace-utils-root-state-memory" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      let cfg = make_test_config ~base_path:scratch ~cluster_name:"default" in
+      Workspace_utils.write_json cfg
+        (Workspace_utils.state_path cfg)
+        (`Assoc [ "protocol_version", `String "retired" ]);
+      check bool "scoped state is not a root marker" false
+        (Workspace_utils.root_is_initialized cfg);
+      Workspace_utils.write_json cfg
+        (Workspace_utils.root_state_path cfg)
+        (`Assoc [ "protocol_version", `String "current" ]);
+      check bool "current root marker initializes root" true
+        (Workspace_utils.root_is_initialized cfg))
+
+let test_filesystem_root_initialization_requires_current_marker () =
+  Eio_main.run @@ fun env ->
+  let scratch = Filename.temp_dir "workspace-utils-root-state-filesystem" "" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      let root = Filename.concat scratch Common.masc_dirname in
+      Unix.mkdir root 0o700;
+      let backend_config : Backend_types.config =
+        { base_path = root
+        ; node_id = "test-node"
+        ; cluster_name = "default"
+        ; pubsub_max_messages = 1000
+        }
+      in
+      let cfg : Workspace_utils.config =
+        { base_path = scratch
+        ; workspace_path = scratch
+        ; lock_expiry_minutes = 30
+        ; backend_config
+        ; backend =
+            Workspace_utils.FileSystem
+              (Backend.FileSystem.create ~fs:(Eio.Stdenv.fs env) backend_config)
+        }
+      in
+      write_file (Workspace_utils.state_path cfg) "{}";
+      check bool "scoped state is not a root marker" false
+        (Workspace_utils.root_is_initialized cfg);
+      write_file (Workspace_utils.root_state_path cfg) "{}";
+      check bool "current root marker initializes root" true
+        (Workspace_utils.root_is_initialized cfg))
+
 let test_list_dir_prefers_backend_for_memory_keys () =
   let scratch = Filename.temp_dir "workspace-utils-list-dir-memory" "" in
   Fun.protect
@@ -777,6 +826,10 @@ let () =
       test_case "masc_root_dir empty cluster" `Quick test_masc_root_dir_empty_cluster;
       test_case "masc_root_dir custom cluster" `Quick test_masc_root_dir_custom_cluster;
       test_case "masc_root_dir nested with cluster" `Quick test_masc_root_dir_with_cluster_nested;
+      test_case "memory root initialization requires current marker" `Quick
+        test_memory_root_initialization_requires_current_marker;
+      test_case "filesystem root initialization requires current marker" `Quick
+        test_filesystem_root_initialization_requires_current_marker;
       test_case "list_dir prefers backend for memory keys" `Quick
         test_list_dir_prefers_backend_for_memory_keys;
       test_case "memory commit distinguishes local mirror failure" `Quick


### PR DESCRIPTION
## Scope

- remove the public pre-rename root-state path helper
- make root_is_initialized recognize only .masc/root-state.json on Memory and FileSystem backends
- pin both backends so .masc/state.json alone cannot open root-level feature gates
- add no migration, repair, or compatibility path

## Feature path checked

root_is_initialized gates dashboard task/agent/message reads, Keeper directive assignment, gRPC directive computation, and workspace/cluster management. Workspace init and bootstrap already create and read only root-state.json, so this removes a false compatibility Gate without changing the current feature writer.

## Validation

- git diff --check
- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on implementation and test
- focused scripts/dune-local.sh build test/test_workspace_utils_coverage.exe attempted, but the wrapper refused because an unrelated bare Dune process was active; no bypass was used
- PR CI is the type/build authority while local Dune remains contended