### PR TITLE
fix(operator): check runtime registry for agent.exists when disk file is missing

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -241,10 +241,25 @@ let keepers_json
                     let agent_status_cache_ttl_s = 2.0 in
                     let agent_json =
                       let cache_key = "kas:" ^ meta.agent_name in
-                      Dashboard_cache.get_or_compute cache_key ~ttl:agent_status_cache_ttl_s (fun () ->
-                        Keeper_status_runtime.parse_agent_status
-                          config
-                          ~agent_name:meta.agent_name)
+                      let raw_json =
+                        Dashboard_cache.get_or_compute cache_key ~ttl:agent_status_cache_ttl_s (fun () ->
+                          Keeper_status_runtime.parse_agent_status
+                            config
+                            ~agent_name:meta.agent_name)
+                      in
+                      (* When the on-disk agent file is missing, parse_agent_status
+                         returns an empty Assoc.  A running Keeper may not have a
+                         disk-side agent file, so we enrich the projection with an
+                         [exists] field derived from the live runtime registry. *)
+                      match raw_json with
+                      | `Assoc [] ->
+                          let exists_in_runtime =
+                            Workspace_query.active_runtime_agents config
+                            |> List.exists (fun (a : Masc_domain.agent) ->
+                                   String.equal a.name meta.agent_name)
+                          in
+                          `Assoc [ ("exists", `Bool exists_in_runtime) ]
+                      | _ -> raw_json
                     in
                     dt_agent := Time_compat.now () -. t_agent;
                     let t_ka = Time_compat.now () in


### PR DESCRIPTION
## Problem
`parse_agent_status` returns an empty `Assoc []` when the agent file is not on disk.
A running Keeper may not have a disk-side agent file, causing the frontend to
interpret the missing `exists` field as `false` and display all 9 live
keepers as offline.

## Root Cause
The snapshot caller in `operator_control_snapshot.ml` passes through the
empty projection without enriching it with runtime registry data.

## Fix
When `parse_agent_status` returns an empty `Assoc []`, the caller now checks
`Workspace_query.active_runtime_agents` for the agent name and injects an
`exists` field (`true` if found in the live registry, `false` otherwise).

## Testing
- Build verified locally via `scripts/dune-local.sh` (pending CI)
- Runtime registry trace through `active_runtime_agents` matches the same
  merge source used by `get_active_agents`

Task-007