### PR TITLE
refactor(board): require current persisted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   gRPC root gates now recognize only the current `.masc/root-state.json`
   marker already written by init/bootstrap. No migration or repair path was
   added.
+- **Breaking (board persistence)**: board post rows now require the current
+  `updated_at` and `pinned` fields, and vote rows require their persisted cast
+  `ts`. Missing or malformed current fields are dropped with an explicit
+  warning instead of being repaired as `created_at`, `false`, or `0.0`. The
+  current post and vote writers already emit all three fields; no migration or
+  repair path was added.
 - **Breaking (keeper chat wire)**: removed read-time message-id synthesis for
   rows without a persisted `id` and removed the duplicate persisted `source`
   lane label. Current chat rows require a nonblank producer-assigned `id` and

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -340,36 +340,36 @@ let load_persisted_votes store =
   if not (Fs_compat.file_exists path) then Ok 0
   else begin
     try
-      let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
-      List.iter (fun json ->
-        match Safe_ops.json_string_opt "target" json,
-              Safe_ops.json_string_opt "direction" json with
-        | Some target, Some dir_str ->
-          (match vote_direction_of_string_opt dir_str with
-           | None -> ()
-           | Some direction ->
-             (* #10086: legacy rows persisted before this fix may have
-                [ts] overwritten by a prior flush cycle.  Use the
-                recorded value when present; fall back to 0.0 rather
-                than [Time_compat.now ()] — loading a ledger at server
-                start time must NOT advance the ts of every pre-fix
-                vote to "now".  Downstream readers treat ts=0.0 as
-                "unknown cast time". *)
-             let ts =
-               match Safe_ops.json_float_opt "ts" json with
-               | Some t -> t
-               | None -> 0.0
-             in
-             Hashtbl.replace store.vote_log target (direction, ts);
-             Stdlib.incr loaded)
-        | _ -> ()
-      ) lines;
-      if !loaded > 0 then
-        Log.BoardLog.info "loaded %d vote entries from %s" !loaded path
+      let loaded, invalid =
+        List.fold_left
+          (fun (loaded, invalid) json ->
+             match
+               ( Safe_ops.json_string_opt "target" json
+               , Safe_ops.json_string_opt "direction" json
+               , Safe_ops.json_float_opt "ts" json )
+             with
+             | Some target, Some dir_str, Some ts ->
+               (match vote_direction_of_string_opt dir_str with
+                | None -> loaded, invalid + 1
+                | Some direction ->
+                  Hashtbl.replace store.vote_log target (direction, ts);
+                  loaded + 1, invalid)
+             | _ -> loaded, invalid + 1)
+          (0, 0)
+          lines
+      in
+      if invalid > 0
+      then
+        Log.BoardLog.warn
+          "dropped %d vote rows that do not satisfy the current persisted schema: %s"
+          invalid
+          path;
+      if loaded > 0 then
+        Log.BoardLog.info "loaded %d vote entries from %s" loaded path
       else
         Log.BoardLog.debug "loaded 0 vote entries from %s" path;
-      Ok !loaded
+      Ok loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e -> Error (path, e)

--- a/lib/board/board_votes_json.ml
+++ b/lib/board/board_votes_json.ml
@@ -39,27 +39,25 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
     , Safe_ops.json_string_opt "content" json
     , Safe_ops.json_string_opt "visibility" json
     , Safe_ops.json_float_opt "created_at" json
-    , Safe_ops.json_float_opt "expires_at" json )
+    , Safe_ops.json_float_opt "updated_at" json
+    , Safe_ops.json_float_opt "expires_at" json
+    , Safe_ops.json_bool_opt "pinned" json )
   with
   | ( Some id_str
     , Some author_str
     , Some content
     , Some vis_str
     , Some created_at
-    , Some expires_at ) ->
+    , Some updated_at
+    , Some expires_at
+    , Some pinned ) ->
     let title_opt = Safe_ops.json_string_opt "title" json in
     let body_opt = Safe_ops.json_string_opt "body" json in
-    (* Backward compat: default updated_at to created_at if missing *)
-    let updated_at =
-      Safe_ops.json_float_opt "updated_at" json |> Option.value ~default:created_at
-    in
     let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
     let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
     let reply_count = Safe_ops.json_int ~default:0 "reply_count" json in
     let hearth = Safe_ops.json_string_opt "hearth" json in
     let thread_id = Safe_ops.json_string_opt "thread_id" json in
-    (* Missing on legacy rows persisted before the pin field existed -> default false. *)
-    let pinned = Safe_ops.json_bool ~default:false "pinned" json in
     let post_kind_opt =
       match Safe_ops.json_string_opt "post_kind" json with
       | Some raw -> post_kind_of_string raw
@@ -191,10 +189,10 @@ let load_persisted_posts store =
     try
       let t0 = Time_compat.now () in
       let now = Time_compat.now () in
-      let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
-      List.iter
-        (fun json ->
+      let loaded, invalid =
+        List.fold_left
+          (fun (loaded, invalid) json ->
            match post_of_yojson json with
            | Some p
              when Float.compare p.expires_at 0.0 = 0
@@ -205,15 +203,24 @@ let load_persisted_posts store =
                 find_post_by_run_id survive a restart without a second persisted
                 SSOT that could drift from the post rows. *)
              index_post_origin store p;
-             incr loaded
-           | _ -> ())
-        lines;
+             loaded + 1, invalid
+           | Some _ -> loaded, invalid
+           | None -> loaded, invalid + 1)
+          (0, 0)
+          lines
+      in
+      if invalid > 0
+      then
+        Log.BoardLog.warn
+          "dropped %d board post rows that do not satisfy the current persisted schema: %s"
+          invalid
+          path;
       store.post_count := Hashtbl.length store.posts;
       let elapsed = Time_compat.now () -. t0 in
-      if !loaded > 0
-      then Log.BoardLog.info "loaded %d posts from %s in %.3fs" !loaded path elapsed
+      if loaded > 0
+      then Log.BoardLog.info "loaded %d posts from %s in %.3fs" loaded path elapsed
       else Log.BoardLog.debug "loaded 0 posts from %s in %.3fs" path elapsed;
-      Ok !loaded
+      Ok loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e -> Error (path, e)

--- a/test/test_board_post_origin.ml
+++ b/test/test_board_post_origin.ml
@@ -74,6 +74,13 @@ let replace_key json key value =
   | other -> other
 ;;
 
+let remove_key json key =
+  match json with
+  | `Assoc fields ->
+    `Assoc (List.filter (fun (name, _) -> not (String.equal name key)) fields)
+  | other -> other
+;;
+
 let test_codec_round_trip () =
   let store = Board_core.create_store () in
   let tr = Ids.Turn_ref.make ~trace_id:"trace-abc" ~absolute_turn:42 in
@@ -105,6 +112,20 @@ let test_codec_absent_origin () =
     | None -> Alcotest.fail "round trip dropped origin-less post"
   in
   Alcotest.(check bool) "absent origin decodes to None" true (Option.is_none decoded.origin)
+;;
+
+let test_current_persisted_fields_are_required () =
+  let store = Board_core.create_store () in
+  let post = create_no_origin store ~content:"current fields" in
+  let json = Board_core.post_to_yojson post in
+  Alcotest.(check bool)
+    "missing updated_at is rejected"
+    true
+    (Option.is_none (decode (remove_key json "updated_at")));
+  Alcotest.(check bool)
+    "missing pinned is rejected"
+    true
+    (Option.is_none (decode (remove_key json "pinned")))
 ;;
 
 let test_malformed_origin_preserves_post () =
@@ -234,6 +255,10 @@ let () =
     [ ( "codec"
       , [ Alcotest.test_case "origin round trip" `Quick (with_eio test_codec_round_trip)
         ; Alcotest.test_case "absent origin -> None" `Quick (with_eio test_codec_absent_origin)
+        ; Alcotest.test_case
+            "current persisted fields are required"
+            `Quick
+            (with_eio test_current_persisted_fields_are_required)
         ; Alcotest.test_case
             "malformed origin -> None, post preserved"
             `Quick

--- a/test/test_vote_ts_preservation_10086.ml
+++ b/test/test_vote_ts_preservation_10086.ml
@@ -44,6 +44,14 @@ let with_eio f () =
   Board_dispatch.init_jsonl ();
   f ()
 
+let with_uninitialized_eio f () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = fresh_test_base_path () in
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  f base_path
+
 let read_ts_rows path =
   (* Read each jsonl row as (target, voter, ts). *)
   let ic = open_in path in
@@ -74,6 +82,38 @@ let read_ts_rows path =
 
 let find_row ~target ~voter rows =
   List.find_opt (fun (t, v, _) -> t = target && v = voter) rows
+
+let test_loader_requires_current_vote_timestamp () =
+  with_uninitialized_eio
+    (fun base_path ->
+      Unix.mkdir base_path 0o700;
+      let masc_dir = Common.masc_dir_from_base_path ~base_path in
+      Unix.mkdir masc_dir 0o700;
+      let path = Board_votes.vote_log_path () in
+      Out_channel.with_open_text path (fun output ->
+        output_string output
+          {|{"target":"post:old:old-voter","voter":"old-voter","direction":"up"}|};
+        output_char output '\n';
+        output_string output
+          {|{"target":"post:current:current-voter","voter":"current-voter","direction":"up","ts":42.0}|};
+        output_char output '\n');
+      Board_dispatch.init_jsonl ();
+      match Board_dispatch.backend () with
+      | Board_dispatch.Jsonl store ->
+        Alcotest.(check int)
+          "only the current vote row loads"
+          1
+          (Hashtbl.length store.vote_log);
+        Alcotest.(check bool)
+          "missing-ts row is absent"
+          false
+          (Hashtbl.mem store.vote_log "post:old:old-voter");
+        (match Hashtbl.find_opt store.vote_log "post:current:current-voter" with
+         | Some (Board.Up, ts) ->
+           Alcotest.(check (float 1e-9)) "current timestamp preserved" 42.0 ts
+         | Some (Board.Down, _) -> Alcotest.fail "current vote direction changed"
+         | None -> Alcotest.fail "current vote row was dropped"))
+    ()
 
 let create_post_exn ~author ~content =
   match
@@ -190,5 +230,7 @@ let () =
             (with_eio test_flush_preserves_cast_ts);
           Alcotest.test_case "flip inherits flip-time" `Quick
             (with_eio test_flip_inherits_flip_time);
+          Alcotest.test_case "loader requires current vote timestamp" `Quick
+            test_loader_requires_current_vote_timestamp;
         ] );
     ]


### PR DESCRIPTION
## Summary

- require `updated_at` and `pinned` when loading persisted board posts
- require `ts` when loading persisted votes
- report invalid current-schema rows instead of fabricating timestamps or pin state
- keep valid expiry behavior unchanged

## Feature path checked

- board JSONL load -> post indexes -> dashboard/keeper board reads
- vote JSONL load -> hot ranking, vote recency, karma/dashboard consumers
- current writers already persist every required field

This is a current-schema hard cut. It adds no migration or repair path.

## Validation

- `git diff --check`
- `ocamlformat` check on touched OCaml files
- `ocamlc -stop-after parsing` on touched OCaml files
- `scripts/dune-local.sh build test/test_board_post_origin.exe test/test_vote_ts_preservation_10086.exe`
- `scripts/dune-local.sh exec ./test/test_board_post_origin.exe`
- `scripts/dune-local.sh exec ./test/test_vote_ts_preservation_10086.exe`
