### PR TITLE
test(runtime): use canonical Claude provider fixture

### DIFF
--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -362,9 +362,9 @@ let test_runtime_adapter_uses_canonical_anthropic_headers () =
   let content =
     {|
 [runtime]
-default = "anthropic.claude-opus-4"
+default = "claude.claude-opus-4"
 
-[providers.anthropic]
+[providers.claude]
 display-name = "Anthropic"
 protocol = "messages-http"
 endpoint = "https://api.anthropic.com"
@@ -375,7 +375,7 @@ max-context = 200000
 tools-support = true
 streaming = true
 
-[anthropic.claude-opus-4]
+[claude.claude-opus-4]
 |}
   in
   match Runtime_toml.parse_string content with


### PR DESCRIPTION
## Summary

- use the pinned OAS catalog provider id `claude` in the Anthropic header adapter fixture
- keep the typed `Anthropic` kind, Messages protocol, endpoint, and header assertions unchanged
- leave the production adapter and its unknown-provider rejection unchanged

## Why

Main CI run 30447336483 compiled successfully, then failed only in `test_runtime_provider_auth_headers` because the fixture declared provider id `anthropic`. The pinned OAS catalog has provider id `claude` with typed kind `Anthropic`; it has no registry entry or alias named `anthropic`.

The production adapter correctly rejects an unregistered Messages provider instead of guessing identity from protocol, endpoint, or model name. The test must use the catalog SSOT it claims to exercise.

No gate is loosened, no compatibility alias is added, and no production behavior changes.

## Validation

- `ocamlformat --check test/test_runtime_provider_auth_headers.ml`
- `ocamlc -stop-after parsing -c test/test_runtime_provider_auth_headers.ml`
- `git diff --check`
- `bash scripts/dune-local.sh build test/test_runtime_provider_auth_headers.exe`
- `_build/default/test/test_runtime_provider_auth_headers.exe` — 44/44 passed

RFC-WAIVED: test fixture correction only; no runtime contract or public surface change.
WORKAROUND-WAIVED: removes an impossible fixture identity instead of adding fallback or alias behavior.