### PR TITLE
fix(keeper): release joined lanes before registry reclaim

### DIFF
--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -490,7 +490,6 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string TurnTimeoutCommitted) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string TurnErrorAfterTools) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string TurnCleanupFailures) |> int_of_float)
-        + (Otel_metric_store.metric_total Keeper_metrics.(to_string CleanupTrackingFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string RuntimeSyncFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string LocalDiscoveryFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string ThinkingPersistFailures) |> int_of_float)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1092,62 +1092,19 @@ let start_keepalive
             then record_stopped "manual stop"
             else record_lane_exception exn
         in
-        (* Lane cleanup is declared outside [run] because [Keeper_lane.fork]
-           invokes it only after the child-owning switch and all children
-           finish. *)
-        let cleanup_tracking outcome =
-          let terminal_result =
-            try
-              terminalize_lane outcome;
-              Ok ()
-            with
-            | exn -> Error (Printexc.to_string exn)
-          in
-          let tracking_result =
+        (* [Keeper_lane] invokes this only after the child-owning switch has
+           joined. The registry entry is discarded when this exact lane is
+           reclaimed, so mutating its observation fields here is both
+           redundant and unsafe: registry mutation reacquires the lifecycle
+           key lock after [done_p] is resolved, leaving a terminal Keeper whose
+           lane never reaches [Exited] when a lifecycle writer owns that lock.
+           Terminalization is the only required cleanup at the join boundary. *)
+        let terminalize_joined_lane outcome =
           try
-            (match Keeper_registry.cleanup_tracking_exact reg with
-             | Keeper_registry.Exact_updated
-             | Keeper_registry.Exact_update_missing -> Ok ()
-             | Keeper_registry.Exact_update_replaced ->
-               Log.Keeper.info
-                 "%s: lane cleanup retained newer same-name registry entry"
-                 live_meta.name;
-               Ok ()
-             | Keeper_registry.Exact_update_invalid validation_error ->
-               Error
-                 (Keeper_registry.registry_entry_validation_error_to_string
-                    validation_error))
+            terminalize_lane outcome;
+            Ok ()
           with
-          | Eio.Cancel.Cancelled _ as exn -> Error (Printexc.to_string exn)
-          | e ->
-            let detail = Printexc.to_string e in
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string CleanupTrackingFailures)
-              ~labels:[ "keeper", live_meta.name; "site", "heartbeat_finally" ]
-              ();
-            Log.Keeper.emit
-              Log.Warn
-              ~category:Log.Heartbeat
-              ~details:
-                (`Assoc
-                  [ "keeper", `String live_meta.name
-                  ; "error", `String detail
-                  ])
-              (Printf.sprintf
-                 "%s: cleanup_tracking in heartbeat finally raised: %s"
-                 live_meta.name
-                 detail);
-            Error detail
-          in
-          match terminal_result, tracking_result with
-          | Ok (), Ok () -> Ok ()
-          | Error detail, Ok () | Ok (), Error detail -> Error detail
-          | Error terminal_detail, Error tracking_detail ->
-            Error
-              (Printf.sprintf
-                 "terminal cleanup failed: %s; tracking cleanup failed: %s"
-                 terminal_detail
-                 tracking_detail)
+          | exn -> Error (Printexc.to_string exn)
         in
         publish_keeper_started ~live_meta;
         (match
@@ -1164,7 +1121,7 @@ let start_keepalive
            Atomic.set reg.grpc_close grpc_close
          | None -> ());
         run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup)
-             ~cleanup:cleanup_tracking
+             ~cleanup:terminalize_joined_lane
          with
          | Ok () -> Keepalive_started reg
          | Error error ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -524,40 +524,6 @@ let board_wakeup_allowed ~base_path name ~dedup_key ~debounce_sec =
        true)
 ;;
 
-let cleanup_tracking ~base_path name =
-  let key = registry_key ~base_path name in
-  match StringMap.find_opt key (Atomic.get registry) with
-  | Some entry ->
-    (match
-       put_entry
-         ~base_path
-         name
-         { entry with
-           board_wakeups = StringMap.empty
-         ; tool_usage = StringMap.empty
-         ; board_cursor_ts = 0.0
-         ; board_cursor_post_id = None
-         }
-     with
-     | Ok () -> ()
-     | Error err ->
-       Log.Keeper.warn
-         "%s: failed to cleanup registry tracking: %s"
-         name
-         (registry_entry_validation_error_to_string err))
-  | None -> ()
-;;
-
-let cleanup_tracking_exact (entry : registry_entry) =
-  update_entry_exact entry (fun current ->
-    { current with
-      board_wakeups = StringMap.empty
-    ; tool_usage = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
-    })
-;;
-
 let clear () =
   Atomic.set registry StringMap.empty;
   Atomic.set running_count_atomic 0

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -502,12 +502,6 @@ val restore_supervisor_state :
   restart_count:int -> last_restart_ts:float ->
   crash_log:(float * string) list -> unit
 
-(** Reset tracking state (agent count + board wakeups) for a keeper. *)
-val cleanup_tracking : base_path:string -> string -> unit
-
-(** Reset tracking only if [entry]'s lane still owns its registry key. *)
-val cleanup_tracking_exact : registry_entry -> exact_update_result
-
 (** Get board event cursor token. Returns [(0.0, None)] if not found. *)
 val get_board_cursor : base_path:string -> string -> float * string option
 

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -380,7 +380,12 @@ let launch_supervised_fiber_body
            everything and log — cleanup is advisory, state-machine events
            already fired on the body's happy/error paths. *)
           match run_cleanup_best_effort (fun () ->
-            Keeper_registry.cleanup_tracking ~base_path meta.name;
+            (* The exact registry entry is removed after the lane joins.
+               Clearing its observation fields here used to reacquire the
+               lifecycle key lock after [done_p] was resolved, which could
+               strand the lane forever between terminal completion and exit.
+               Turn-attempt observation is a separate process-local table and
+               remains the only necessary cleanup. *)
             Keeper_turn_attempt_observer.reset_keeper ~base_path ~keeper:meta.name;
             if not (Atomic.get resolved)
             then

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -52,7 +52,6 @@ type t =
   | KeeperMetaOverlayDrift
   | HeartbeatSuccesses
   | HeartbeatFailures
-  | CleanupTrackingFailures
   | DispatchEventFailures
   | DirectiveFailures
   | ToolCallDuration
@@ -265,7 +264,6 @@ let to_string = function
   | KeeperMetaOverlayDrift -> "masc_keeper_meta_overlay_drift_total"
   | HeartbeatSuccesses -> "masc_keeper_heartbeat_successes_total"
   | HeartbeatFailures -> "masc_keeper_heartbeat_failures_total"
-  | CleanupTrackingFailures -> "masc_keeper_cleanup_tracking_failures_total"
   | DispatchEventFailures -> "masc_keeper_dispatch_event_failures_total"
   | DirectiveFailures -> "masc_keeper_directive_failures_total"
   | ToolCallDuration -> "masc_keeper_tool_call_duration_seconds"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -43,7 +43,6 @@ type t =
   | KeeperMetaOverlayDrift
   | HeartbeatSuccesses
   | HeartbeatFailures
-  | CleanupTrackingFailures
   | DispatchEventFailures
   | DirectiveFailures
   | ToolCallDuration

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -734,6 +734,11 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
         (Masc.Keeper_keepalive.start_keepalive ctx meta
           : Masc.Keeper_keepalive.start_keepalive_outcome);
       Eio.Time.sleep ctx.clock 0.05;
+      R.set_board_cursor
+        ~base_path:config.base_path
+        keeper_name
+        42.0
+        (Some "terminal-entry-cursor");
       (match
          Masc.Keeper_keepalive.stop_keepalive_and_await
            ~base_path:config.base_path
@@ -744,7 +749,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
        | Masc.Keeper_keepalive.Keeper_joined { terminal = `Stopped; _ } -> ()
        | Masc.Keeper_keepalive.Keeper_joined { terminal = `Crashed reason; _ } ->
          fail ("joined stop resolved as crashed: " ^ reason));
-      match R.get ~base_path:config.base_path keeper_name with
+      (match R.get ~base_path:config.base_path keeper_name with
       | None -> fail "expected direct-lifecycle registry entry"
       | Some entry ->
         check string "state stopped" "stopped" (KSM.phase_to_string entry.phase);
@@ -753,7 +758,49 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
          | Some `Stopped -> ()
          | Some (`Crashed reason) ->
            fail ("expected stopped promise, got crashed: " ^ reason)
-         | None -> fail "expected done_p to resolve on stop"))
+         | None -> fail "expected done_p to resolve on stop"));
+      let cursor_ts, cursor_post_id =
+        R.get_board_cursor ~base_path:config.base_path keeper_name
+      in
+      check
+        (float 1e-9)
+        "terminal entry keeps observations until exact reclaim"
+        42.0
+        cursor_ts;
+      check
+        (option string)
+        "terminal entry keeps cursor identity until exact reclaim"
+        (Some "terminal-entry-cursor")
+        cursor_post_id;
+      (match Masc.Keeper_keepalive.start_keepalive ctx meta with
+       | Masc.Keeper_keepalive.Keepalive_started _ -> ()
+       | outcome ->
+         fail
+           ("joined terminal entry was not reclaimed: "
+            ^ Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
+      let fresh_cursor_ts, fresh_cursor_post_id =
+        R.get_board_cursor ~base_path:config.base_path keeper_name
+      in
+      check
+        (float 1e-9)
+        "fresh lane starts with a clean cursor"
+        0.0
+        fresh_cursor_ts;
+      check
+        (option string)
+        "fresh lane starts without the prior cursor identity"
+        None
+        fresh_cursor_post_id;
+      match
+        Masc.Keeper_keepalive.stop_keepalive_and_await
+          ~base_path:config.base_path
+          keeper_name
+      with
+      | Masc.Keeper_keepalive.Keeper_joined { terminal = `Stopped; _ } -> ()
+      | Masc.Keeper_keepalive.Keeper_joined { terminal = `Crashed reason; _ } ->
+        fail ("restarted lane resolved as crashed: " ^ reason)
+      | Masc.Keeper_keepalive.Keeper_not_registered ->
+        fail "restarted lane disappeared before joined stop")
 
 let test_keeper_lane_join_waits_for_children_and_cleanup () =
   Eio_main.run @@ fun _env ->


### PR DESCRIPTION
## Summary

- remove lifecycle-lock registry observation cleanup from joined Keeper lane finalizers
- let exact terminal-entry reclaim own registry replacement
- remove the now producer-less cleanup tracking metric
- prove a stopped direct lane can be reclaimed and restarted with a fresh observation cursor

## Root cause

The lane finalizer resolved the terminal promise and then reacquired the same lifecycle key lock to clear observation fields. A concurrent lifecycle writer could hold that lock, leaving the Keeper terminal in the registry while its lane never reached `Exited`. Message-turn restart then kept reporting `already registered`.

The old observation cleanup was redundant: exact reclaim discards the terminal entry, and a new registry entry starts with clean observation fields.

## Verification

- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- `scripts/dune-local.sh build test/test_heartbeat_integration.exe @test/runtest-test_heartbeat_integration`
- 47/47 heartbeat integration tests passed on rebased current head
