### PR TITLE
fix(chat): let users control pending Keeper messages

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -17,6 +17,7 @@ vi.mock('./core', async (importOriginal) => {
 import {
   bootKeeper,
   bulkKeeperDirective,
+  cancelKeeperChatPendingReceipt,
   cancelQueuedKeeperMessage,
   clearKeeper,
   deleteKeeperHistorySnapshots,
@@ -290,6 +291,44 @@ describe('Keeper chat durable receipt API', () => {
           expected_revision: '9223372036854775805',
           lease_id: leaseId,
           decision: { kind: 'requeue_unconfirmed' },
+        }),
+      }),
+    )
+  })
+
+  it('cancels one exact pending receipt with its observed revision', async () => {
+    const receiptId = 'chatq_00000000-0000-4000-8000-000000000003'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        schema: 'keeper_chat_queue.pending_cancel.result.v1',
+        ok: true,
+        receipt: {
+          schema: 'keeper_chat_queue.receipt.v2',
+          keeper_name: 'sangsu',
+          receipt_id: receiptId,
+          revision: '10',
+          state: {
+            kind: 'failed',
+            failure_kind: 'cancelled',
+            detail: 'cancelled by dashboard user before delivery',
+            completed_at: 42,
+            outcome_ref: null,
+          },
+        },
+        audit: { recorded: true },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await cancelKeeperChatPendingReceipt('sangsu', receiptId)
+
+    expect(result.receipt.state.kind).toBe('failed')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/v1/keepers/sangsu/chat/receipts/${receiptId}/cancel`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          schema: 'keeper_chat_queue.pending_cancel.request.v1',
         }),
       }),
     )

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -745,6 +745,11 @@ export interface KeeperChatRecoveryResult {
   audit: { recorded: true } | { recorded: false; error: string }
 }
 
+export interface KeeperChatPendingCancelResult {
+  receipt: KeeperChatReceipt
+  audit: { recorded: true } | { recorded: false; error: string }
+}
+
 const KEEPER_CHAT_RECEIPT_FAILURE_KINDS = new Set<KeeperChatReceiptFailureKind>([
   'turn_failed',
   'no_visible_reply',
@@ -854,6 +859,41 @@ export async function fetchKeeperChatReceipt(
     throw new Error(`fetchKeeperChatReceipt: HTTP ${resp.status} ${resp.statusText}`)
   }
   return parseKeeperChatReceipt(data)
+}
+
+export async function cancelKeeperChatPendingReceipt(
+  keeperName: string,
+  receiptId: string,
+): Promise<KeeperChatPendingCancelResult> {
+  const raw = await post<unknown>(
+    `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/receipts/${encodeURIComponent(receiptId)}/cancel`,
+    {
+      schema: 'keeper_chat_queue.pending_cancel.request.v1',
+    },
+  )
+  if (
+    !isRecord(raw)
+    || raw.schema !== 'keeper_chat_queue.pending_cancel.result.v1'
+    || raw.ok !== true
+    || !isRecord(raw.audit)
+    || typeof raw.audit.recorded !== 'boolean'
+  ) {
+    throw new Error('cancelKeeperChatPendingReceipt: invalid response envelope')
+  }
+  const receipt = parseKeeperChatReceipt(raw.receipt)
+  if (receipt.keeperName !== keeperName || receipt.receiptId !== receiptId) {
+    throw new Error('cancelKeeperChatPendingReceipt: response identity mismatch')
+  }
+  if (receipt.state.kind !== 'failed' || receipt.state.failureKind !== 'cancelled') {
+    throw new Error('cancelKeeperChatPendingReceipt: response is not cancelled')
+  }
+  const audit = raw.audit.recorded
+    ? { recorded: true as const }
+    : {
+        recorded: false as const,
+        error: asString(raw.audit.error, '').trim() || 'pending cancellation audit persistence failed',
+      }
+  return { receipt, audit }
 }
 
 export async function resolveKeeperChatRecovery(

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -798,6 +798,50 @@ describe('ChatTranscript', () => {
     expect(prompt).toHaveBeenCalledTimes(1)
   })
 
+  it('offers edit and cancel only while a durable receipt is pending', async () => {
+    const onPendingEdit = vi.fn().mockResolvedValue(undefined)
+    const onPendingCancel = vi.fn().mockResolvedValue(undefined)
+    const target = entry({
+      id: 'pending-receipt',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '메시지는 대기 중입니다.',
+      delivery: 'queued',
+      details: {
+        queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000002',
+        queueRevision: '9',
+        queueState: 'pending',
+        queueInFlightLane: 'autonomous',
+        queueInFlightStartedAt: 42,
+      },
+    })
+
+    render(
+      html`<${ChatTranscript}
+        entries=${[target]}
+        emptyText="empty"
+        variant="messenger"
+        action=${{ onPendingEdit, onPendingCancel }}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('자율 작업 처리 중')
+    const edit = container.querySelector(
+      '[data-chat-queue-pending-action="edit"]',
+    ) as HTMLButtonElement
+    const cancel = container.querySelector(
+      '[data-chat-queue-pending-action="cancel"]',
+    ) as HTMLButtonElement
+    expect(edit).not.toBeNull()
+    expect(cancel).not.toBeNull()
+    fireEvent.click(edit)
+    await waitFor(() => expect(onPendingEdit).toHaveBeenCalledWith(target))
+    fireEvent.click(cancel)
+    await waitFor(() => expect(onPendingCancel).toHaveBeenCalledWith(target))
+  })
+
   it('copies the message text from an assistant message copy button', () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(globalThis.navigator, { clipboard: { writeText } })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -381,6 +381,8 @@ type ChatTranscriptAction = {
   label?: string
   title?: string
   onClick?: (entry: KeeperConversationEntry) => void
+  onPendingCancel?: (entry: KeeperConversationEntry) => Promise<void>
+  onPendingEdit?: (entry: KeeperConversationEntry) => Promise<void>
   onRecoveryRequeue?: (entry: KeeperConversationEntry) => Promise<void>
   onRecoveryCancel?: (entry: KeeperConversationEntry, detail: string) => Promise<void>
 }
@@ -451,14 +453,15 @@ function QueueReceiptBadge({ entry, action }: {
   action?: ChatTranscriptAction
 }) {
   const [recoveryPending, setRecoveryPending] = useState<'requeue' | 'cancel' | null>(null)
+  const [pendingAction, setPendingAction] = useState<'edit' | 'cancel' | null>(null)
   const receiptId = entry.details?.queueReceiptId?.trim()
   const shutdownOperationId = entry.details?.queueShutdownOperationId?.trim()
   const queueState = entry.details?.queueState
   if (!receiptId || !queueState) return null
   const label = (() => {
     switch (queueState) {
-      case 'pending': return '서버 대기'
-      case 'inflight': return 'Keeper 처리 중'
+      case 'pending': return '대기 중'
+      case 'inflight': return '처리 중'
       case 'recovery_required': return '복구 확인 필요'
       case 'delivered': return '처리 완료'
       case 'failed': return '처리 실패'
@@ -466,6 +469,19 @@ function QueueReceiptBadge({ entry, action }: {
     }
   })()
   const shutdownLabel = shutdownOperationId ? ' · 종료 후 처리' : ''
+  const currentWorkLabel = (() => {
+    const lane = entry.details?.queueInFlightLane?.trim()
+    if (!lane) return null
+    const work = lane === 'autonomous'
+      ? '자율 작업 처리 중'
+      : lane === 'chat'
+        ? '다른 대화 처리 중'
+        : `${lane} 처리 중`
+    const startedAt = entry.details?.queueInFlightStartedAt
+    return typeof startedAt === 'number'
+      ? `${work} · ${formatTimeHms(startedAt)}부터`
+      : work
+  })()
   const title = [
     `receipt ${receiptId}`,
     label,
@@ -494,6 +510,19 @@ function QueueReceiptBadge({ entry, action }: {
     }
     void runRecovery('cancel', () => action.onRecoveryCancel!(entry, detail))
   }
+  const runPendingAction = async (
+    kind: 'edit' | 'cancel',
+    operation: () => Promise<void>,
+  ) => {
+    setPendingAction(kind)
+    try {
+      await operation()
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : String(error), 'error')
+    } finally {
+      setPendingAction(null)
+    }
+  }
   return html`
     <span class="inline-flex flex-wrap items-center gap-1.5">
       <span
@@ -505,6 +534,35 @@ function QueueReceiptBadge({ entry, action }: {
       >
         ${label}${shutdownLabel}
       </span>
+      ${currentWorkLabel
+        ? html`<span class="text-2xs text-[var(--color-fg-muted)]">${currentWorkLabel}</span>`
+        : null}
+      ${queueState === 'pending' && action?.onPendingEdit
+        ? html`
+            <button
+              type="button"
+              disabled=${pendingAction !== null}
+              class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-fg-secondary)] disabled:opacity-50"
+              data-chat-queue-pending-action="edit"
+              onClick=${() => {
+                void runPendingAction('edit', () => action.onPendingEdit!(entry))
+              }}
+            >${pendingAction === 'edit' ? '불러오는 중...' : '수정'}</button>
+          `
+        : null}
+      ${queueState === 'pending' && action?.onPendingCancel
+        ? html`
+            <button
+              type="button"
+              disabled=${pendingAction !== null}
+              class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-status-err)] disabled:opacity-50"
+              data-chat-queue-pending-action="cancel"
+              onClick=${() => {
+                void runPendingAction('cancel', () => action.onPendingCancel!(entry))
+              }}
+            >${pendingAction === 'cancel' ? '취소 중...' : '취소'}</button>
+          `
+        : null}
       ${queueState === 'recovery_required' && action?.onRecoveryRequeue
         ? html`
             <button

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1026,8 +1026,8 @@ describe('KeeperConversationPanel', () => {
     )
 
     await waitFor(() => {
-      expect(container.querySelector('[data-chat-queue-state-badge="pending"]')?.textContent).toContain('서버 대기')
-      expect(container.querySelector('[data-chat-queue-state-badge="inflight"]')?.textContent).toContain('Keeper 처리 중')
+      expect(container.querySelector('[data-chat-queue-state-badge="pending"]')?.textContent).toContain('대기 중')
+      expect(container.querySelector('[data-chat-queue-state-badge="inflight"]')?.textContent).toContain('처리 중')
       expect(container.querySelector('[data-chat-queue-state-badge="recovery_required"]')?.textContent).toContain('복구 확인 필요')
       expect(container.querySelector('[data-chat-queue-state-badge="delivered"]')?.textContent).toContain('처리 완료')
       expect(container.querySelector('[data-chat-queue-state-badge="failed"]')?.textContent).toContain('처리 실패')

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -23,6 +23,7 @@ import {
   isKeeperThreadMessageSendInFlight,
   probeKeeperRuntime,
   reconcileKeeperChatReceipts,
+  cancelKeeperChatPendingEntry,
   requeueKeeperChatRecoveryEntry,
   cancelKeeperChatRecoveryEntry,
   recoverKeeperRuntime,
@@ -422,10 +423,11 @@ interface QueueItemCardProps {
   keeperName: string
   msg: QueuedMessage
   onMutate: () => void
+  onSave: () => void
 }
 
-function QueueItemCard({ keeperName, msg, onMutate }: QueueItemCardProps) {
-  const [editing, setEditing] = useState(false)
+function QueueItemCard({ keeperName, msg, onMutate, onSave }: QueueItemCardProps) {
+  const [editing, setEditing] = useState(msg.editOnOpen === true)
   const [text, setText] = useState(msg.content)
   const [attachments, setAttachments] = useState(msg.attachments ?? [])
 
@@ -433,14 +435,17 @@ function QueueItemCard({ keeperName, msg, onMutate }: QueueItemCardProps) {
     updateQueuedMessage(keeperName, msg.id, {
       content: text.trim(),
       attachments: attachments.length > 0 ? attachments : undefined,
+      editOnOpen: false,
     })
     setEditing(false)
     onMutate()
+    onSave()
   }
 
   const cancel = () => {
     setText(msg.content)
     setAttachments(msg.attachments ?? [])
+    updateQueuedMessage(keeperName, msg.id, { editOnOpen: false })
     setEditing(false)
   }
 
@@ -769,6 +774,31 @@ export function KeeperConversationPanel({
       ...(onInspectTurn
         ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn }
         : {}),
+      onPendingCancel: async (entry: KeeperConversationEntry) => {
+        await cancelKeeperChatPendingEntry(keeperName, entry)
+        showToast('대기 메시지를 취소했습니다.', 'success')
+      },
+      onPendingEdit: async (entry: KeeperConversationEntry) => {
+        const original = await cancelKeeperChatPendingEntry(
+          keeperName,
+          entry,
+          { requireUserInput: true },
+        )
+        if (!original) {
+          throw new Error('수정할 원문을 찾지 못했습니다.')
+        }
+        enqueueInput(
+          keeperName,
+          original.text,
+          original.attachments,
+          undefined,
+          original.blocks,
+          undefined,
+          true,
+        )
+        setQueueVersion(value => value + 1)
+        showToast('서버 대기를 취소하고 편집 화면으로 옮겼습니다.', 'success')
+      },
       onRecoveryRequeue: (entry: KeeperConversationEntry) =>
         requeueKeeperChatRecoveryEntry(keeperName, entry),
       onRecoveryCancel: (entry: KeeperConversationEntry, detail: string) =>
@@ -966,6 +996,28 @@ export function KeeperConversationPanel({
     />
   `
 
+  const browserDraftQueue = queueCount > 0
+    ? html`
+        <div class="mb-3 flex flex-col gap-2" data-chat-queue-list>
+          <div class="flex items-center justify-between gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
+            <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
+            <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
+          </div>
+          ${queuedMessages.map(msg => html`
+            <${QueueItemCard}
+              key=${msg.id}
+              keeperName=${keeperName}
+              msg=${msg}
+              onMutate=${bumpQueue}
+              onSave=${() => {
+                if (!sending) void drainQueue()
+              }}
+            />
+          `)}
+        </div>
+      `
+    : null
+
   if (layout === 'workspace') {
     // 3-pane workspace: identity + lifecycle live in the ChatHeader above
     // this panel, so the workspace layout drops the panel's own header and
@@ -1057,24 +1109,7 @@ export function KeeperConversationPanel({
         <div class="kw-composer-wrap v2-monitoring-panel">
           <div class="kw-composer-inner v2-monitoring-panel">
             ${serverQueueStatus}
-            ${queueCount > 0
-              ? html`
-                  <div class="mb-3 flex flex-col gap-2" data-chat-queue-list>
-                    <div class="flex items-center justify-between gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                      <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
-                      <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
-                    </div>
-                    ${queuedMessages.map(msg => html`
-                      <${QueueItemCard}
-                        key=${msg.id}
-                        keeperName=${keeperName}
-                        msg=${msg}
-                        onMutate=${bumpQueue}
-                      />
-                    `)}
-                  </div>
-                `
-              : null}
+            ${browserDraftQueue}
             ${isKeeperBusy ? renderBusyToolbar() : null}
             <${ChatComposer}
               key=${keeperName}
@@ -1185,14 +1220,7 @@ export function KeeperConversationPanel({
 
         <div class="shrink-0 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 shadow-none v2-monitoring-panel">
         ${serverQueueStatus}
-        ${queueCount > 0
-            ? html`
-                <div class="mb-2 flex items-center gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                  <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
-                  <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
-                </div>
-              `
-            : null}
+        ${browserDraftQueue}
           ${isKeeperBusy ? renderBusyToolbar() : null}
           <${ChatComposer}
             key=${keeperName}
@@ -1299,14 +1327,7 @@ export function KeeperConversationPanel({
 
         <div class="border-t border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 v2-monitoring-panel">
         ${serverQueueStatus}
-        ${queueCount > 0
-            ? html`
-                <div class="mb-2 flex items-center gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                  <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
-                  <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
-                </div>
-              `
-            : null}
+        ${browserDraftQueue}
           ${isKeeperBusy ? renderBusyToolbar() : null}
           <${ChatComposer}
             key=${keeperName}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -7,6 +7,7 @@ const { invalidateDashboardCache, refreshDashboard } = vi.hoisted(() => ({
   refreshDashboard: vi.fn(async () => undefined),
 }))
 const {
+  cancelKeeperChatPendingReceipt,
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
@@ -17,6 +18,7 @@ const {
   queuedKeeperMessageToReply,
   streamKeeperMessage,
 } = vi.hoisted(() => ({
+  cancelKeeperChatPendingReceipt: vi.fn(),
   cancelQueuedKeeperMessage: vi.fn(
     async (requestId: string): Promise<{
       requestId: string
@@ -51,6 +53,7 @@ const { fetchKeeperToolCalls } = vi.hoisted(() => ({
 vi.mock('./api/mcp', () => ({ callMcpTool }))
 vi.mock('./api/core', () => ({ runOperatorAction }))
 vi.mock('./api/keeper', () => ({
+  cancelKeeperChatPendingReceipt,
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
@@ -84,6 +87,7 @@ import {
   _resetKeeperThreadMessageSendGuardsForTests,
   _resetChatHydrationForTests,
   cancelActiveKeeperThreadMessage,
+  cancelKeeperChatPendingEntry,
   dispatchKeeperInterjectAction,
   hydrateKeeperChatHistory,
   hydrateKeeperStatus,
@@ -239,6 +243,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatHistory.mockReset()
     fetchKeeperChatHistory.mockResolvedValue([])
     fetchKeeperChatReceipt.mockReset()
+    cancelKeeperChatPendingReceipt.mockReset()
     resolveKeeperChatRecovery.mockReset()
   })
 
@@ -263,6 +268,52 @@ describe('reconcileKeeperChatReceipts', () => {
     expect(entry?.delivery).toBe('queued')
     expect(entry?.details?.queueState).toBe('recovery_required')
     expect(entry?.error).toBeFalsy()
+  })
+
+  it('cancels a pending receipt and returns its optimistic user input for editing', async () => {
+    const receiptId = 'chatq_00000000-0000-4000-8000-000000000001'
+    keeperThreads.value = {
+      echo: [
+        {
+          id: 'queued-user-1',
+          role: 'user',
+          source: 'direct_user',
+          label: 'You',
+          text: '원문',
+          timestamp: null,
+          delivery: 'queued',
+          details: { queueReceiptId: receiptId },
+        },
+        keeperThreads.value.echo![0]!,
+      ],
+    }
+    cancelKeeperChatPendingReceipt.mockResolvedValue({
+      receipt: {
+        keeperName: 'echo',
+        receiptId,
+        revision: '2',
+        state: {
+          kind: 'failed',
+          failureKind: 'cancelled',
+          detail: 'cancelled by dashboard user before delivery',
+          completedAt: 42,
+          outcomeRef: null,
+        },
+      },
+      audit: { recorded: true },
+    })
+
+    const original = await cancelKeeperChatPendingEntry(
+      'echo',
+      keeperThreads.value.echo![1]!,
+    )
+
+    expect(cancelKeeperChatPendingReceipt).toHaveBeenCalledWith(
+      'echo',
+      receiptId,
+    )
+    expect(original?.text).toBe('원문')
+    expect(keeperThreads.value.echo).toEqual([])
   })
 
   it('requeues only with the freshly observed revision and lease', async () => {
@@ -1679,7 +1730,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       'chatq_00000000-0000-4000-8000-000000000001',
     )
     expect(reply?.delivery).toBe('queued')
-    expect(reply?.text).toContain('message is queued')
+    expect(reply?.text).toContain('메시지는 대기열에 추가했습니다')
     expect(reply?.details).toMatchObject({
       queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       queueRevision: '4',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1,6 +1,7 @@
 import { callMcpTool } from './api/mcp'
 import { runOperatorAction } from './api/core'
 import {
+  cancelKeeperChatPendingReceipt,
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
@@ -1080,6 +1081,49 @@ export async function cancelKeeperChatRecoveryEntry(
     detail,
     outcomeRef: null,
   })
+}
+
+export async function cancelKeeperChatPendingEntry(
+  keeperName: string,
+  entry: KeeperConversationEntry,
+  options: { requireUserInput?: boolean } = {},
+): Promise<KeeperConversationEntry | null> {
+  const receiptId = entry.details?.queueReceiptId?.trim() ?? ''
+  if (!receiptId || entry.details?.queueState !== 'pending') {
+    throw new Error('취소할 대기 메시지의 최신 상태가 없습니다.')
+  }
+  setRecordValue(keeperActionErrors, keeperName, null)
+  try {
+    const thread = keeperThreads.value[keeperName] ?? []
+    const userEntry = thread.find(candidate => (
+      candidate.role === 'user'
+      && candidate.details?.queueReceiptId === receiptId
+    )) ?? null
+    if (options.requireUserInput && !userEntry) {
+      throw new Error('수정할 원문을 찾지 못해 서버 대기를 취소하지 않았습니다.')
+    }
+    const result = await cancelKeeperChatPendingReceipt(
+      keeperName,
+      receiptId,
+    )
+    const matchingEntryIds = thread
+      .filter(candidate => candidate.details?.queueReceiptId === receiptId)
+      .map(candidate => candidate.id)
+    removeThreadEntries(keeperName, matchingEntryIds)
+    if (!result.audit.recorded) {
+      setRecordValue(
+        keeperActionErrors,
+        keeperName,
+        `메시지는 취소됐지만 audit 기록에 실패했습니다: ${result.audit.error}`,
+      )
+    }
+    return userEntry
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    setRecordValue(keeperActionErrors, keeperName, `대기 메시지 취소 실패: ${message}`)
+    void reconcileKeeperChatReceipts(keeperName)
+    throw error
+  }
 }
 
 /** React to a server `keeper_chat_appended` push: re-merge the

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -20,6 +20,7 @@ export interface QueuedMessage {
   blocks?: ChatBlock[]
   userBlocks?: KeeperUserInputBlock[]
   clientActionId?: string
+  editOnOpen?: boolean
 }
 
 export interface InputQueue {
@@ -85,6 +86,7 @@ export function enqueueInput(
   clientActionId?: string,
   blocks?: ChatBlock[],
   userBlocks?: KeeperUserInputBlock[],
+  editOnOpen = false,
 ): QueuedMessage {
   const q = _ensureQueue(keeperName)
   const actionId = clientActionId?.trim()
@@ -102,6 +104,7 @@ export function enqueueInput(
     ...(blocks && blocks.length > 0 ? { blocks } : {}),
     ...(userBlocks && userBlocks.length > 0 ? { userBlocks } : {}),
     ...(actionId ? { clientActionId: actionId } : {}),
+    ...(editOnOpen ? { editOnOpen: true } : {}),
   }
   q.items.push(msg)
   return msg
@@ -123,16 +126,22 @@ export function getQueuedMessages(keeperName: string): QueuedMessage[] {
   return q ? q.items.slice() : []
 }
 
-/** Update the content/attachments of a queued message. */
+/** Update the editable fields or editor presentation of a queued message. */
 export function updateQueuedMessage(
   keeperName: string,
   id: string,
-  updates: Partial<Pick<QueuedMessage, 'content' | 'attachments' | 'blocks' | 'userBlocks'>>,
+  updates: Partial<
+    Pick<QueuedMessage, 'content' | 'attachments' | 'blocks' | 'userBlocks' | 'editOnOpen'>
+  >,
 ): QueuedMessage | null {
   const q = _queues.get(keeperName)
   if (!q) return null
   const item = q.items.find(i => i.id === id)
   if (!item) return null
+  if ('editOnOpen' in updates) {
+    if (updates.editOnOpen) item.editOnOpen = true
+    else delete item.editOnOpen
+  }
   let changed = false
   if (typeof updates.content === 'string') item.content = updates.content
   if (typeof updates.content === 'string') changed = true

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -105,6 +105,8 @@ describe('applyKeeperStreamEvent', () => {
         inflight_count: 1,
         recovery_required_count: 1,
         shutdown_operation_id: ' shutdown-op-7 ',
+        in_flight_lane: 'autonomous',
+        in_flight_started_at: 42,
       },
     })).toBeNull()
 
@@ -118,7 +120,12 @@ describe('applyKeeperStreamEvent', () => {
       queuePendingCount: 3,
       queueInflightCount: 1,
       queueRecoveryRequiredCount: 1,
+      queueInFlightLane: 'autonomous',
+      queueInFlightStartedAt: 42,
     })
+    expect(entry?.text).toBe(
+      'sangsu의 이전 메시지 상태를 확인해야 해요. 새 메시지는 안전하게 대기 중입니다.',
+    )
     expect(entry?.streamContract).toMatchObject({
       source: 'queue_event',
       eventName: 'KEEPER_CHAT_QUEUED',

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -682,6 +682,10 @@ export function applyKeeperStreamEvent(
         const pendingCount = asNumber(queued?.pending_count)
         const inflightCount = asNumber(queued?.inflight_count)
         const recoveryRequiredCount = asNumber(queued?.recovery_required_count)
+        const inFlightLane = asString(queued?.in_flight_lane, '').trim()
+        const inFlightStartedAt = asNumber(queued?.in_flight_started_at)
+        const hasInFlightMetadata =
+          inFlightLane.length > 0 || typeof inFlightStartedAt === 'number'
         const shutdownOperationId = (() => {
           const raw = queued?.shutdown_operation_id
           if (raw === null) return null
@@ -701,6 +705,13 @@ export function applyKeeperStreamEvent(
           || typeof recoveryRequiredCount !== 'number'
           || !Number.isSafeInteger(recoveryRequiredCount)
           || recoveryRequiredCount < 0
+          || (hasInFlightMetadata
+            && (
+              inFlightLane.length === 0
+              || typeof inFlightStartedAt !== 'number'
+              || !Number.isFinite(inFlightStartedAt)
+              || inFlightStartedAt < 0
+            ))
         ) {
           return 'Keeper queue acceptance is missing its durable receipt metadata.'
         }
@@ -709,6 +720,11 @@ export function applyKeeperStreamEvent(
         }
         updateThreadEntry(keeperName, assistantEntryId, entry => ({
           ...entry,
+          text: recoveryRequiredCount > 0
+            ? `${keeperName}의 이전 메시지 상태를 확인해야 해요. 새 메시지는 안전하게 대기 중입니다.`
+            : shutdownOperationId
+              ? `${keeperName}가 종료 중이에요. 다시 활동을 시작하면 이 메시지를 처리합니다.`
+              : `${keeperName}가 다른 작업을 처리 중이에요. 메시지는 대기열에 추가했습니다.`,
           delivery: 'queued',
           streamState: null,
           details: {
@@ -719,6 +735,9 @@ export function applyKeeperStreamEvent(
             queuePendingCount: pendingCount,
             queueInflightCount: inflightCount,
             queueRecoveryRequiredCount: recoveryRequiredCount,
+            queueInFlightLane: inFlightLane || null,
+            queueInFlightStartedAt:
+              typeof inFlightStartedAt === 'number' ? inFlightStartedAt : null,
             queueState: 'pending',
           },
           streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -729,6 +729,8 @@ export interface KeeperConversationDetails {
   queuePendingCount?: number | null
   queueInflightCount?: number | null
   queueRecoveryRequiredCount?: number | null
+  queueInFlightLane?: string | null
+  queueInFlightStartedAt?: number | null
   queueState?: KeeperQueueReceiptLifecycle | null
   queueFailureKind?: KeeperQueueReceiptFailureKind | null
   queueCorrelationError?: 'missing_outcome_ref' | null

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -121,6 +121,10 @@ type persistence_publication =
       ; receipt_id : Receipt_id.t
       ; lease_id : string
       }
+  | Pending_cancel_indeterminate of
+      { revision : int64
+      ; receipt_id : Receipt_id.t
+      }
 
 type persistence_failure =
   { publication : persistence_publication
@@ -136,6 +140,10 @@ type mutation_error =
       ; state : receipt_state
       }
   | Receipt_not_recovery_required of
+      { receipt_id : Receipt_id.t
+      ; observed_state : receipt_state option
+      }
+  | Receipt_not_pending of
       { receipt_id : Receipt_id.t
       ; observed_state : receipt_state option
       }
@@ -178,6 +186,7 @@ type persistence_transition =
       { receipt_id : Receipt_id.t
       ; lease_id : string
       }
+  | Pending_cancel_transition of { receipt_id : Receipt_id.t }
 
 let persistence_transition_to_string = function
   | Enqueue_transition _ -> "enqueue"
@@ -187,6 +196,7 @@ let persistence_transition_to_string = function
   | Startup_recovery_transition _ -> "startup_recovery"
   | Recovery_requeue_transition _ -> "recovery_requeue"
   | Recovery_cancel_transition _ -> "recovery_cancel"
+  | Pending_cancel_transition _ -> "pending_cancel"
 
 let transition_receipt_id = function
   | Enqueue_transition { receipt_id }
@@ -195,7 +205,8 @@ let transition_receipt_id = function
   | Nack_transition { receipt_id; _ }
   | Startup_recovery_transition { receipt_id; _ }
   | Recovery_requeue_transition { receipt_id; _ }
-  | Recovery_cancel_transition { receipt_id; _ } -> receipt_id
+  | Recovery_cancel_transition { receipt_id; _ }
+  | Pending_cancel_transition { receipt_id } -> receipt_id
 
 let publication_transition = function
   | Not_published -> None
@@ -206,6 +217,7 @@ let publication_transition = function
   | Startup_recovery_indeterminate _ -> Some "startup_recovery"
   | Recovery_requeue_indeterminate _ -> Some "recovery_requeue"
   | Recovery_cancel_indeterminate _ -> Some "recovery_cancel"
+  | Pending_cancel_indeterminate _ -> Some "pending_cancel"
 
 let publication_evidence = function
   | Not_published -> None
@@ -215,7 +227,8 @@ let publication_evidence = function
   | Nack_indeterminate { revision; receipt_id; _ }
   | Startup_recovery_indeterminate { revision; receipt_id; _ }
   | Recovery_requeue_indeterminate { revision; receipt_id; _ }
-  | Recovery_cancel_indeterminate { revision; receipt_id; _ } ->
+  | Recovery_cancel_indeterminate { revision; receipt_id; _ }
+  | Pending_cancel_indeterminate { revision; receipt_id } ->
     Some (revision, receipt_id)
 
 let publication_lease_id = function
@@ -225,7 +238,9 @@ let publication_lease_id = function
   | Startup_recovery_indeterminate { lease_id; _ }
   | Recovery_requeue_indeterminate { lease_id; _ }
   | Recovery_cancel_indeterminate { lease_id; _ } -> Some lease_id
-  | Not_published | Enqueue_indeterminate _ -> None
+  | Not_published
+  | Enqueue_indeterminate _
+  | Pending_cancel_indeterminate _ -> None
 
 let receipt_state_kind_to_string = function
   | Pending -> "pending"
@@ -261,6 +276,13 @@ let mutation_error_to_string = function
   | Receipt_not_recovery_required { receipt_id; observed_state } ->
     Printf.sprintf
       "chat queue receipt %s is not recovery-required (observed=%s)"
+      (Receipt_id.to_string receipt_id)
+      (match observed_state with
+       | None -> "absent"
+       | Some state -> receipt_state_kind_to_string state)
+  | Receipt_not_pending { receipt_id; observed_state } ->
+    Printf.sprintf
+      "chat queue receipt %s is not pending (observed=%s)"
       (Receipt_id.to_string receipt_id)
       (match observed_state with
        | None -> "absent"
@@ -315,6 +337,16 @@ let mutation_error_to_json = function
           | None -> `Null
           | Some state -> `String (receipt_state_kind_to_string state) )
       ; "message", `String "chat queue receipt is not recovery-required"
+      ]
+  | Receipt_not_pending { receipt_id; observed_state } ->
+    `Assoc
+      [ "error", `String "chat_queue_receipt_not_pending"
+      ; "receipt_id", `String (Receipt_id.to_string receipt_id)
+      ; ( "observed_state"
+        , match observed_state with
+          | None -> `Null
+          | Some state -> `String (receipt_state_kind_to_string state) )
+      ; "message", `String "chat queue receipt is not pending"
       ]
   | Recovery_revision_mismatch
       { receipt_id; expected_revision; observed_revision } ->
@@ -2009,6 +2041,8 @@ let indeterminate_publication revision = function
     Recovery_requeue_indeterminate { revision; receipt_id; lease_id }
   | Recovery_cancel_transition { receipt_id; lease_id } ->
     Recovery_cancel_indeterminate { revision; receipt_id; lease_id }
+  | Pending_cancel_transition { receipt_id } ->
+    Pending_cancel_indeterminate { revision; receipt_id }
 
 let published_indeterminate_failure plan detail =
   { publication =
@@ -3009,6 +3043,125 @@ let lookup_receipt ~keeper_name ~receipt_id =
                 | Ok (revision, _, _, row) ->
                   Ok (receipt_lookup_of_row revision row))))
 
+type pending_cancellation =
+  { cancelled_at : float
+  ; detail : string
+  }
+
+type pending_cancellation_report =
+  { receipt_id : Receipt_id.t
+  ; revision : int64
+  ; state : receipt_state
+  }
+
+let find_pending_row entry receipt_id =
+  Sequence_map.fold
+    (fun _ row found ->
+       match found with
+       | Some _ -> found
+       | None ->
+         if Receipt_id.equal row.receipt.receipt_id receipt_id
+         then Some row
+         else None)
+    entry.pending
+    None
+
+let receipt_not_pending ~base_path ~path entry ~receipt_id =
+  match observe_receipt_in_store ~base_path ~path receipt_id with
+  | Error detail ->
+    quarantine_entry entry (load_error Read_failed ~path detail)
+  | Ok (revision, next_sequence, terminal_count, row) ->
+    if not (cache_matches_meta entry revision next_sequence terminal_count)
+    then
+      quarantine_entry entry
+        (load_error Reconciliation_failed ~path
+           "chat queue database metadata diverged during pending cancellation")
+    else
+      Error
+        (Receipt_not_pending
+           { receipt_id
+           ; observed_state =
+               Option.map
+                 (fun row -> receipt_state_of_stored row.receipt.state)
+                 row
+           })
+
+let cancel_pending
+    ~keeper_name
+    ~receipt_id
+    ~cancellation =
+  match
+    canonical_terminal_state
+      (Mark_failed
+         { completed_at = cancellation.cancelled_at
+         ; kind = Cancelled
+         ; detail = cancellation.detail
+         ; outcome_ref = None
+         })
+  with
+  | Error detail -> Error (Invalid_input detail)
+  | Ok terminal_state ->
+    (match mutation_context ~keeper_name ~create:false with
+       | Error _ as error -> error
+       | Ok (_, _, None) ->
+         Error (Receipt_not_pending { receipt_id; observed_state = None })
+       | Ok (base_path, path, Some entry) ->
+         let result =
+           with_entry_lock keeper_name entry (fun () ->
+               match check_entry_store ~base_path ~path entry ~allow_absent:false with
+               | Error _ as error -> error
+               | Ok Store_absent ->
+                 quarantine_entry entry
+                   (load_error Read_failed ~path
+                      "chat queue database is absent during pending cancellation")
+               | Ok Store_present ->
+                 match find_pending_row entry receipt_id with
+                   | None ->
+                     receipt_not_pending
+                       ~base_path ~path entry ~receipt_id
+                   | Some row ->
+                     if Int64.equal entry.terminal_count Int64.max_int
+                     then Error Revision_exhausted
+                     else
+                       let target_row =
+                         { row with
+                           receipt = { receipt_id; state = terminal_state }
+                         }
+                       in
+                       (match
+                          make_plan entry
+                            ~before_row:(Some row)
+                            ~target_row:(Some target_row)
+                            ~target_next_sequence:entry.next_sequence
+                            ~target_terminal_count:(Int64.succ entry.terminal_count)
+                            ~transition:(Pending_cancel_transition { receipt_id })
+                        with
+                        | Error _ as error -> error
+                        | Ok plan ->
+                          let execution =
+                            run_transaction
+                              ~ownership_root:base_path
+                              ~path
+                              ~create_if_missing:false
+                              plan
+                          in
+                          Result.map
+                            (fun revision ->
+                               { receipt_id
+                               ; revision
+                               ; state = receipt_state_of_stored terminal_state
+                               })
+                            (apply_transaction_result
+                               ~path entry plan execution)))
+         in
+         (match result with
+          | Ok ({ revision; _ } as report) ->
+            notify_transition ~keeper_name ~revision;
+            Ok report
+          | Error _ as error ->
+            notify_indeterminate ~keeper_name error;
+            error))
+
 type reconciliation_outcome =
   | Already_consistent
   | Reconciled
@@ -3199,7 +3352,8 @@ let reconcile_persistence ~keeper_name =
                        | Nack_transition _
                        | Startup_recovery_transition _
                        | Recovery_requeue_transition _
-                       | Recovery_cancel_transition _ ), false, true ->
+                       | Recovery_cancel_transition _
+                       | Pending_cancel_transition _ ), false, true ->
                        set_entry_to_plan_target entry plan;
                        entry.load_errors <- [];
                        entry.reconciliation_plan <- None;
@@ -3209,7 +3363,8 @@ let reconcile_persistence ~keeper_name =
                        | Nack_transition _
                        | Startup_recovery_transition _
                        | Recovery_requeue_transition _
-                       | Recovery_cancel_transition _ ), true, false ->
+                       | Recovery_cancel_transition _
+                       | Pending_cancel_transition _ ), true, false ->
                        let execution =
                          run_transaction
                            ~ownership_root:base_path

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -137,6 +137,10 @@ type persistence_publication =
       ; receipt_id : Receipt_id.t
       ; lease_id : string
       }
+  | Pending_cancel_indeterminate of
+      { revision : int64
+      ; receipt_id : Receipt_id.t
+      }
 
 type persistence_failure =
   { publication : persistence_publication
@@ -152,6 +156,10 @@ type mutation_error =
       ; state : receipt_state
       }
   | Receipt_not_recovery_required of
+      { receipt_id : Receipt_id.t
+      ; observed_state : receipt_state option
+      }
+  | Receipt_not_pending of
       { receipt_id : Receipt_id.t
       ; observed_state : receipt_state option
       }
@@ -306,6 +314,25 @@ val lookup_receipt :
 (** Atomically return the receipt observation with the queue revision that
     produced it. A [Durability_uncertain] lane remains observable by receipt id
     even though further mutations are rejected until reconciliation. *)
+
+type pending_cancellation =
+  { cancelled_at : float
+  ; detail : string
+  }
+
+type pending_cancellation_report =
+  { receipt_id : Receipt_id.t
+  ; revision : int64
+  ; state : receipt_state
+  }
+
+(** Cancel exactly one durable [Pending] receipt. A receipt that has already
+    started delivery is rejected without mutation. *)
+val cancel_pending :
+  keeper_name:string ->
+  receipt_id:Receipt_id.t ->
+  cancellation:pending_cancellation ->
+  (pending_cancellation_report, mutation_error) result
 
 type reconciliation_outcome =
   | Already_consistent

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -391,6 +391,7 @@ let recovery_mutation_failure_class = function
   | Keeper_chat_queue.Invalid_input _
   | Keeper_chat_queue.Receipt_already_terminal _
   | Keeper_chat_queue.Receipt_not_recovery_required _
+  | Keeper_chat_queue.Receipt_not_pending _
   | Keeper_chat_queue.Recovery_revision_mismatch _
   | Keeper_chat_queue.Recovery_lease_mismatch _ ->
     Tool_result.Workflow_rejection

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -76,6 +76,18 @@ val handle_keeper_chat_recovery_post :
     revision and lease evidence. The route is wired only behind token-bound
     [CanAdmin] authorization. *)
 
+val handle_keeper_chat_pending_cancel_post :
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  keeper_name:string ->
+  raw_receipt_id:string ->
+  string ->
+  unit
+(** Cancel exactly one still-pending chat receipt. The route is token-bound
+    [CanAdmin]. *)
+
 val handle_keeper_board_attention_quarantine_recovery_post :
   Mcp_server.server_state ->
   string ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -442,6 +442,7 @@ let keeper_chat_recovery_error_status = function
   | Keeper_chat_queue.Invalid_input _ -> `Bad_request
   | Keeper_chat_queue.Receipt_already_terminal _
   | Keeper_chat_queue.Receipt_not_recovery_required _
+  | Keeper_chat_queue.Receipt_not_pending _
   | Keeper_chat_queue.Recovery_revision_mismatch _
   | Keeper_chat_queue.Recovery_lease_mismatch _ ->
       `Conflict
@@ -450,6 +451,141 @@ let keeper_chat_recovery_error_status = function
   | Keeper_chat_queue.Revision_exhausted
   | Keeper_chat_queue.Persist_failed _ ->
       `Service_unavailable
+
+let keeper_chat_pending_cancel_request_schema =
+  "keeper_chat_queue.pending_cancel.request.v1"
+
+let keeper_chat_pending_cancel_result_schema =
+  "keeper_chat_queue.pending_cancel.result.v1"
+
+let parse_keeper_chat_pending_cancel_request body_str =
+  let ( let* ) = Result.bind in
+  let* fields =
+    match Yojson.Safe.from_string body_str with
+    | `Assoc fields -> Ok fields
+    | value ->
+      Error
+        (Printf.sprintf
+           "request body must be an object, received %s"
+           (Json_util.kind_name value))
+    | exception Yojson.Json_error detail -> Error ("invalid JSON: " ^ detail)
+  in
+  let* () =
+    match duplicate_assoc_keys fields with
+    | [] -> Ok ()
+    | keys -> Error ("duplicate field(s): " ^ String.concat ", " keys)
+  in
+  let observed_keys = List.map fst fields |> List.sort String.compare in
+  let expected_keys = [ "schema" ] in
+  let* () =
+    if observed_keys = expected_keys
+    then Ok ()
+    else
+      Error
+        "request must contain exactly schema"
+  in
+  let* schema =
+    match List.assoc "schema" fields with
+    | `String value -> Ok value
+    | _ -> Error "schema must be a string"
+  in
+  if String.equal schema keeper_chat_pending_cancel_request_schema
+  then Ok ()
+  else Error ("unsupported schema: " ^ schema)
+
+let keeper_chat_pending_cancel_audit config ~actor ~keeper_name ~receipt_id
+    ~outcome =
+  try
+    Audit_log.log_action
+      config
+      ~agent_id:actor
+      ~action:(Audit_log.Custom "keeper_chat_queue_pending_cancel")
+      ~details:
+        (`Assoc
+          [ "keeper_name", `String keeper_name
+          ; "receipt_id", `String (Keeper_chat_queue.Receipt_id.to_string receipt_id)
+          ])
+      ~outcome
+      ();
+    `Assoc [ "recorded", `Bool true ]
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    `Assoc
+      [ "recorded", `Bool false
+      ; "error", `String (Observability_redact.redact_text (Printexc.to_string exn))
+      ]
+
+let handle_keeper_chat_pending_cancel_post state agent_name req reqd ~keeper_name
+    ~raw_receipt_id body_str =
+  let respond ?(status = `OK) json =
+    Http.Response.json_value ~status ~request:req json reqd
+  in
+  let bad_request message =
+    respond
+      ~status:`Bad_request
+      (`Assoc
+        [ "schema", `String keeper_chat_pending_cancel_result_schema
+        ; "ok", `Bool false
+        ; "error", `Assoc [ "message", `String message ]
+        ])
+  in
+  if not (Keeper_config.validate_name keeper_name)
+  then bad_request (Printf.sprintf "invalid keeper name: %s" keeper_name)
+  else
+    match Keeper_chat_queue.Receipt_id.of_string raw_receipt_id with
+    | Error message -> bad_request message
+    | Ok receipt_id ->
+      (match parse_keeper_chat_pending_cancel_request body_str with
+       | Error message -> bad_request message
+       | Ok () ->
+         let result =
+           Keeper_chat_queue.cancel_pending
+             ~keeper_name
+             ~receipt_id
+             ~cancellation:
+               { cancelled_at = Time_compat.now ()
+               ; detail = "cancelled by dashboard user before delivery"
+               }
+         in
+         let audit =
+           keeper_chat_pending_cancel_audit
+             (Mcp_server.workspace_config state)
+             ~actor:agent_name
+             ~keeper_name
+             ~receipt_id
+             ~outcome:
+               (match result with
+                | Ok _ -> Audit_log.Success
+                | Error error ->
+                  Audit_log.Failure
+                    (Keeper_chat_queue.mutation_error_to_string error))
+         in
+         match result with
+         | Ok report ->
+           let receipt : Keeper_chat_queue.receipt_view =
+             { receipt_id = report.receipt_id; state = report.state }
+           in
+           respond
+             (`Assoc
+               [ "schema", `String keeper_chat_pending_cancel_result_schema
+               ; "ok", `Bool true
+               ; ( "receipt"
+                 , keeper_chat_receipt_json
+                     ~keeper_name
+                     ~revision:report.revision
+                     receipt )
+               ; "audit", audit
+               ])
+         | Error error ->
+           respond
+             ~status:(keeper_chat_recovery_error_status error)
+             (`Assoc
+               [ "schema", `String keeper_chat_pending_cancel_result_schema
+               ; "ok", `Bool false
+               ; "error", Keeper_chat_queue.mutation_error_to_json error
+               ; "audit", audit
+               ]))
 
 let handle_keeper_chat_recovery_post state agent_name req reqd ~keeper_name
     ~raw_receipt_id body_str =

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -38,6 +38,16 @@ val handle_keeper_chat_recovery_post :
   string ->
   unit
 
+val handle_keeper_chat_pending_cancel_post :
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  keeper_name:string ->
+  raw_receipt_id:string ->
+  string ->
+  unit
+
 val handle_keeper_board_attention_quarantine_recovery_post :
   Mcp_server.server_state ->
   string ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -64,6 +64,11 @@ type keeper_chat_recovery_route =
   ; receipt_id : string
   }
 
+type keeper_chat_pending_cancel_route =
+  { keeper_name : string
+  ; receipt_id : string
+  }
+
 type keeper_board_attention_quarantine_route =
   { keeper_name : string
   ; partition_id : string
@@ -81,11 +86,12 @@ type keeper_post_route_kind =
   | Keeper_post_paused_work
   | Keeper_post_catchup_judge
   | Keeper_post_chat_recovery of keeper_chat_recovery_route
+  | Keeper_post_chat_pending_cancel of keeper_chat_pending_cancel_route
   | Keeper_post_board_attention_quarantine_recovery of
       keeper_board_attention_quarantine_route
   | Keeper_post_unknown
 
-let keeper_chat_recovery_route req_path =
+let keeper_chat_recovery_route req_path : keeper_chat_recovery_route option =
   if not (String.starts_with ~prefix:keeper_api_prefix req_path)
   then None
   else
@@ -97,6 +103,24 @@ let keeper_chat_recovery_route req_path =
     in
     match String.split_on_char '/' rest with
     | [ keeper_name; "chat"; "receipts"; receipt_id; "recovery" ]
+      when not (String.equal keeper_name "") && not (String.equal receipt_id "") ->
+      Some { keeper_name; receipt_id }
+    | _ -> None
+;;
+
+let keeper_chat_pending_cancel_route req_path
+    : keeper_chat_pending_cancel_route option =
+  if not (String.starts_with ~prefix:keeper_api_prefix req_path)
+  then None
+  else
+    let rest =
+      String.sub
+        req_path
+        (String.length keeper_api_prefix)
+        (String.length req_path - String.length keeper_api_prefix)
+    in
+    match String.split_on_char '/' rest with
+    | [ keeper_name; "chat"; "receipts"; receipt_id; "cancel" ]
       when not (String.equal keeper_name "") && not (String.equal receipt_id "") ->
       Some { keeper_name; receipt_id }
     | _ -> None
@@ -128,14 +152,17 @@ let keeper_board_attention_quarantine_route req_path =
 let classify_keeper_post_route req_path =
   match
     keeper_chat_recovery_route req_path,
+    keeper_chat_pending_cancel_route req_path,
     keeper_board_attention_quarantine_route req_path
   with
-  | Some route, _ -> Keeper_post_chat_recovery route
-  | None, Some route ->
+  | Some route, _, _ -> Keeper_post_chat_recovery route
+  | None, Some route, _ -> Keeper_post_chat_pending_cancel route
+  | None, None, Some route ->
     Keeper_post_board_attention_quarantine_recovery route
-  | None, None when not (String.starts_with ~prefix:keeper_api_prefix req_path) ->
+  | None, None, None
+    when not (String.starts_with ~prefix:keeper_api_prefix req_path) ->
     Keeper_post_unknown
-  | None, None ->
+  | None, None, None ->
     let plen = String.length keeper_api_prefix in
     let tlen = String.length req_path in
     let ends_with suffix =

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -65,6 +65,11 @@ type keeper_chat_recovery_route =
   ; receipt_id : string
   }
 
+type keeper_chat_pending_cancel_route =
+  { keeper_name : string
+  ; receipt_id : string
+  }
+
 type keeper_board_attention_quarantine_route =
   { keeper_name : string
   ; partition_id : string
@@ -82,6 +87,7 @@ type keeper_post_route_kind =
   | Keeper_post_paused_work
   | Keeper_post_catchup_judge
   | Keeper_post_chat_recovery of keeper_chat_recovery_route
+  | Keeper_post_chat_pending_cancel of keeper_chat_pending_cancel_route
   | Keeper_post_board_attention_quarantine_recovery of
       keeper_board_attention_quarantine_route
   | Keeper_post_unknown

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -207,37 +207,18 @@ let dashboard_deferred_ack_text ~keeper_name deferred =
   else if deferred.recovery_required_count > 0
   then
     Printf.sprintf
-      "%s accepted your message durably (receipt_id=%s, pending_count=%d, \
-       inflight_count=%d, recovery_required_count=%d). This Keeper lane has an \
-       earlier delivery whose external effect is unconfirmed; it will remain \
-       non-dispatchable until an operator resolves that exact receipt."
+      "%s의 이전 메시지 상태를 확인해야 해요. 새 메시지는 안전하게 대기 중입니다."
       keeper_name
-      deferred.receipt_id
-      deferred.pending_count
-      deferred.inflight_count
-      deferred.recovery_required_count
   else
     match deferred.shutdown_operation_id with
-    | Some operation_id ->
+    | Some _ ->
       Printf.sprintf
-        "%s is stopping under operation %s; your message was durably accepted \
-         (receipt_id=%s, pending_count=%d, inflight_count=%d) for the next active \
-         lane. The Dashboard will track it through Pending, Inflight, and a \
-         terminal Delivered or Failed state."
+        "%s가 종료 중이에요. 다시 활동을 시작하면 이 메시지를 처리합니다."
         keeper_name
-        (Keeper_shutdown_types.Operation_id.to_string operation_id)
-        deferred.receipt_id
-        deferred.pending_count
-        deferred.inflight_count
     | None ->
       Printf.sprintf
-        "%s is busy; your message was durably accepted (receipt_id=%s, \
-         pending_count=%d, inflight_count=%d). The Dashboard will track it through \
-         Pending, Inflight, and a terminal Delivered or Failed state."
+        "%s가 다른 작업을 처리 중이에요. 메시지는 대기열에 추가했습니다."
         keeper_name
-        deferred.receipt_id
-        deferred.pending_count
-        deferred.inflight_count
 
 let dashboard_deferred_chat_to_json ~keeper_name
     ({ in_flight

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1664,6 +1664,19 @@ let add_routes ~sw ~clock router =
                    ~raw_receipt_id:receipt_id
                    body_str))
              request reqd
+       | Keeper_api.Keeper_post_chat_pending_cancel { keeper_name; receipt_id } ->
+           with_token_permission_auth ~permission:Masc_domain.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_chat_pending_cancel_post
+                   state
+                   agent_name
+                   req
+                   reqd
+                   ~keeper_name
+                   ~raw_receipt_id:receipt_id
+                   body_str))
+             request reqd
        | Keeper_api.Keeper_post_board_attention_quarantine_recovery
            { keeper_name; partition_id } ->
            with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -231,6 +231,21 @@ let test_keeper_chat_recovery_route_is_exact () =
     (Server_dashboard_http_keeper_api.classify_keeper_post_route (path ^ "/bulk")
      = Server_dashboard_http_keeper_api.Keeper_post_unknown)
   ;
+  let cancel_path =
+    "/api/v1/keepers/idealist/chat/receipts/" ^ receipt_id ^ "/cancel"
+  in
+  (match
+     Server_dashboard_http_keeper_api.classify_keeper_post_route cancel_path
+   with
+   | Server_dashboard_http_keeper_api.Keeper_post_chat_pending_cancel route ->
+     check string "pending cancel route keeper" "idealist" route.keeper_name;
+     check string "pending cancel route receipt" receipt_id route.receipt_id
+   | _ -> fail "exact pending cancel route was not classified");
+  check bool "pending cancel route rejects extra segments" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route
+       (cancel_path ^ "/bulk")
+     = Server_dashboard_http_keeper_api.Keeper_post_unknown)
+  ;
   let quarantine_path =
     "/api/v1/keepers/idealist/board-attention/quarantines/ba-root-123/recovery"
   in

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -247,8 +247,77 @@ let test_preallocated_receipt_convergence () =
           { receipt_id = observed; state = Failed _ }) ->
      check "terminal preallocated receipt converges without payload equality claim"
        (Keeper_chat_queue.Receipt_id.equal receipt_id observed)
-   | Ok _ | Error _ ->
+  | Ok _ | Error _ ->
      check "terminal preallocated receipt converges without payload equality claim" false)
+
+let test_pending_cancellation_is_state_guarded () =
+  Printf.printf "Test: pending cancellation is exact and state-guarded\n%!";
+  with_base "keeper-chat-pending-cancel" @@ fun base_path ->
+  let keeper_name = "pending-cancel" in
+  ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
+  let first = enqueue_exn ~keeper_name (message "first") in
+  let second = enqueue_exn ~keeper_name (message "second") in
+  (match
+     Keeper_chat_queue.cancel_pending
+       ~keeper_name
+       ~receipt_id:first.receipt_id
+       ~cancellation:
+         { cancelled_at = 3.0
+         ; detail = "cancelled by dashboard user before delivery"
+         }
+   with
+   | Ok { revision = 3L; state = Failed { kind = Cancelled; _ }; _ } ->
+     check "exact pending receipt becomes terminal once" true
+   | Ok _ | Error _ ->
+     check "exact pending receipt becomes terminal once" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "cancellation removes only the selected pending receipt"
+    (active_ids snapshot.pending = [ receipt_wire second.receipt_id ]);
+  check "cancellation increments terminal count"
+    (Int64.equal snapshot.terminal_count 1L);
+  ignore
+    (enqueue_exn ~keeper_name (message "unrelated") :
+      Keeper_chat_queue.enqueue_receipt);
+  (match
+     Keeper_chat_queue.cancel_pending
+       ~keeper_name
+       ~receipt_id:second.receipt_id
+       ~cancellation:{ cancelled_at = 4.0; detail = "cancel after unrelated enqueue" }
+   with
+   | Ok { revision = 5L; state = Failed { kind = Cancelled; _ }; _ } ->
+     check "unrelated queue revision does not gate exact cancellation" true
+   | Ok _ | Error _ ->
+     check "unrelated queue revision does not gate exact cancellation" false);
+  let lease = lease_exn ~keeper_name in
+  (match
+     Keeper_chat_queue.cancel_pending
+       ~keeper_name
+       ~receipt_id:lease.item.receipt_id
+       ~cancellation:{ cancelled_at = 5.0; detail = "too late" }
+   with
+   | Error
+       (Keeper_chat_queue.Receipt_not_pending
+          { observed_state = Some (Inflight _); _ }) ->
+     check "delivery start closes the pending cancellation window" true
+   | Ok _ | Error _ ->
+     check "delivery start closes the pending cancellation window" false);
+  check "rejected inflight cancellation does not mutate the queue"
+    (Int64.equal (Keeper_chat_queue.snapshot ~keeper_name).revision 6L);
+  ignore
+    (Keeper_chat_queue.finalize
+       ~keeper_name
+       ~lease_id:lease.lease_id
+       ~outcome:
+         (Mark_failed
+            { completed_at = 6.0
+            ; kind = Delivery_failed
+            ; detail = "test cleanup"
+            ; outcome_ref = None
+            }) :
+      [ `Finalized of Keeper_chat_queue.Receipt_id.t
+      | `Unknown_lease
+      | `Error of Keeper_chat_queue.mutation_error
+      ])
 
 let expect_enqueue_indeterminate label expected_receipt_id = function
   | Error
@@ -925,6 +994,7 @@ let () =
   test_first_enqueue_with_runtime_eio_guard ();
   test_lifecycle_fifo_terminal_pk_and_restart ();
   test_preallocated_receipt_convergence ();
+  test_pending_cancellation_is_state_guarded ();
   test_transaction_publication_boundaries ();
   test_commit_observer_exception_and_cancellation ();
   test_transition_observer_outside_lock_exactly_once ();


### PR DESCRIPTION
## What changed

- replace the technical busy receipt prose with operator-friendly queued status
- expose the current autonomous/chat lane and start time beside queued messages
- add an authenticated exact-receipt cancel endpoint for messages that are still `Pending`
- let the Dashboard cancel a pending message or cancel-and-move it into a new editable browser draft
- retain durable cancellation audit evidence and reject cancellation once delivery has started

## Why

A busy Keeper accepted messages durably, but the Dashboard surfaced internal receipt/count terminology, did not make the busy work visible enough, and provided no way to cancel or revise a server-accepted pending input. Operators could see that a message was waiting without being able to control it.

The cancellation condition is deliberately state-based: the exact receipt may be cancelled only while it is currently `Pending`. No caller-visible queue revision gate, settlement, claim, or new lease contract is introduced. SQLite revision handling remains an internal durability mechanism.

## User impact

- queued acknowledgements are readable without transport internals
- pending inputs have `수정` and `취소` controls
- `수정` does not reuse the old receipt or idempotency identity; it cancels the server receipt and creates a new browser draft
- saving the draft submits it through the normal chat path
- inflight inputs remain immutable

## Validation

- `scripts/dune-local.sh build test/test_keeper_chat_coalescing.exe test/test_dashboard_http_core.exe`
- `_build/default/test/test_keeper_chat_coalescing.exe`
- `_build/default/test/test_dashboard_http_core.exe test '^executor_pool$' 49`
- Dashboard TypeScript: `tsc --noEmit`
- Dashboard focused Vitest: 5 files, 355 tests passed
- `ocamlformat --check` on changed OCaml files
- `git diff --check`
