### PR TITLE
refactor(metrics): use current cost ledger store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Breaking (cost ledger storage/schema)**: `masc-cost` now writes and reports
+  only the current date-split `.masc/costs/YYYY-MM/DD.jsonl` store, matching the
+  Keeper producer and inference-metrics consumer. The retired
+  `.masc/costs.jsonl` reader and writer were removed, and current cost rows
+  require an explicit `usage_missing` boolean. Invalid current-store rows are
+  surfaced and excluded instead of receiving default tokens, cost, model, or
+  timestamp values. No migration or repair path was added.
 - **Breaking (approval snapshot wire)**: `summary_status.failed.retryable`
   is no longer accepted and discarded while loading pending approvals. Current
   snapshots contain only `status` and `reason`; snapshots carrying the retired

--- a/bin/dune
+++ b/bin/dune
@@ -97,6 +97,7 @@
   masc_core
   masc.host_config
   masc.config_dir_resolver
+  dated_jsonl
   unix
   yojson
   masc_types

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -1,251 +1,477 @@
 (** MASC Cost Tracking CLI
-    Track token usage and costs per agent/task *)
+    Track token usage and costs per agent/task. *)
 
 open Printf
-open Json_util
 
-(** Cost entry type *)
-type cost_entry = {
-  agent: string;
-  task_id: string option;
-  model: string;
-  input_tokens: int;
-  output_tokens: int;
-  cost_usd: float;
-  timestamp: string;
-}
+type cost_entry =
+  { agent : string
+  ; task_id : string option
+  ; model : string
+  ; input_tokens : int option
+  ; output_tokens : int option
+  ; cost_usd : float option
+  ; timestamp : string
+  ; ts_unix : float
+  }
 
-(** Get MASC root directory *)
+type period =
+  | Hourly
+  | Daily
+  | Weekly
+  | Monthly
+  | All
+
+type agent_total =
+  { agent : string
+  ; tokens : int
+  ; cost_usd : float
+  ; model : string
+  ; usage_missing_entries : int
+  }
+
+let ( let* ) = Result.bind
+
 let get_masc_root () =
   let base_path = Config_dir_resolver.base_path_or_cwd () in
   Config_dir_resolver.masc_root ~base_path
+;;
 
-(** Get costs file path *)
-let costs_file () = Filename.concat (get_masc_root ()) "costs.jsonl"
+let costs_dir () = Filename.concat (get_masc_root ()) "costs"
 
-(** Get current ISO timestamp *)
-let now_iso () =
-  let t = Unix.gettimeofday () in
-  let tm = Unix.gmtime t in
-  sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (1900 + tm.Unix.tm_year) (1 + tm.Unix.tm_mon) tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+let nonblank value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+;;
 
-(** Parse ISO date to Unix time (simplified) *)
-let parse_iso_date s =
-  try
-    Scanf.sscanf s "%d-%d-%dT%d:%d:%dZ" (fun y m d h min sec ->
-      let tm = {
-        Unix.tm_sec = sec; tm_min = min; tm_hour = h;
-        tm_mday = d; tm_mon = m - 1; tm_year = y - 1900;
-        tm_wday = 0; tm_yday = 0; tm_isdst = false
-      } in
-      fst (Unix.mktime tm))
-  with
-  | Scanf.Scan_failure _ | Failure _ | Invalid_argument _ | Unix.Unix_error _ -> 0.0
+let required_string fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) ->
+    (match nonblank value with
+     | Some value -> Ok value
+     | None -> Error (key ^ " must be a non-empty string"))
+  | _ -> Error (key ^ " must be a non-empty string")
+;;
 
-(** Ensure MASC directory exists *)
-let ensure_masc_dir () =
-  let dir = get_masc_root () in
-  if not (Sys.file_exists dir) then
-    Unix.mkdir dir 0o755
+let required_optional_string fields key =
+  match List.assoc_opt key fields with
+  | Some `Null -> Ok None
+  | Some (`String value) ->
+    (match nonblank value with
+     | Some value -> Ok (Some value)
+     | None -> Error (key ^ " must be null or a non-empty string"))
+  | _ -> Error (key ^ " must be null or a non-empty string")
+;;
 
-(** Log a cost entry *)
-let log_cost ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
-  ensure_masc_dir ();
-  let entry = sprintf
-    {|{"agent":"%s","task_id":%s,"model":"%s","input_tokens":%d,"output_tokens":%d,"cost_usd":%.4f,"timestamp":"%s"}|}
-    agent
-    (match task_id with Some t -> sprintf {|"%s"|} t | None -> "null")
-    model input_tokens output_tokens cost_usd (now_iso ())
+let required_bool fields key =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> Ok value
+  | _ -> Error (key ^ " must be a boolean")
+;;
+
+let required_nonnegative_int fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int value) when value >= 0 -> Ok value
+  | _ -> Error (key ^ " must be a non-negative integer")
+;;
+
+let required_nonnegative_float fields key =
+  let value =
+    match List.assoc_opt key fields with
+    | Some (`Float value) -> Some value
+    | Some (`Int value) -> Some (Float.of_int value)
+    | _ -> None
   in
-  let oc = open_out_gen [Open_append; Open_creat] 0o644 (costs_file ()) in
-  Fun.protect
-    ~finally:(fun () -> close_out oc)
-    (fun () -> output_string oc (entry ^ "\n"));
-  printf "Cost logged: %s → $%.4f\n" agent cost_usd
+  match value with
+  | Some value when Float.is_finite value && value >= 0.0 -> Ok value
+  | _ -> Error (key ^ " must be a finite non-negative number")
+;;
 
-(** Parse a JSON line into cost entry *)
-let parse_cost_line line =
-  try
-    let json = Yojson.Safe.from_string line in
-    Some {
-      agent = get_string json "agent" |> Option.value ~default:"";
-      task_id = get_string json "task_id";
-      model = get_string json "model" |> Option.value ~default:"";
-      input_tokens = get_int json "input_tokens" |> Option.value ~default:0;
-      output_tokens = get_int json "output_tokens" |> Option.value ~default:0;
-      cost_usd = get_float json "cost_usd" |> Option.value ~default:0.0;
-      timestamp = get_string json "timestamp" |> Option.value ~default:"";
-    }
-  with
-  | Yojson.Json_error _ | Failure _ | Invalid_argument _ -> None
+let required_null fields key =
+  match List.assoc_opt key fields with
+  | Some `Null -> Ok ()
+  | _ -> Error (key ^ " must be null when usage_missing is true")
+;;
 
-(** Read all cost entries *)
-let read_costs () =
-  let file = costs_file () in
-  if not (Sys.file_exists file) then []
-  else
-    let ic = open_in file in
-    Fun.protect
-      ~finally:(fun () -> close_in ic)
-      (fun () ->
-        let rec read_lines acc =
-          match input_line ic with
-          | line ->
-              let acc' = match parse_cost_line line with
-                | Some e -> e :: acc
-                | None -> acc
-              in
-              read_lines acc'
-          | exception End_of_file -> List.rev acc
-        in
-        read_lines [])
-
-(** Filter entries by time period *)
-let filter_by_period period entries =
-  let now = Unix.gettimeofday () in
-  let cutoff = match period with
-    | "hourly" -> now -. 3600.0
-    | "daily" -> now -. 86400.0
-    | "weekly" -> now -. 604800.0
-    | "monthly" -> now -. 2592000.0
-    | "all" -> 0.0
-    | _ -> now -. 86400.0  (* default: daily *)
-  in
-  List.filter (fun e -> parse_iso_date e.timestamp >= cutoff) entries
-
-(** Filter entries by agent *)
-let filter_by_agent agent entries =
-  if agent = "" then entries
-  else List.filter (fun e -> e.agent = agent) entries
-
-(** Filter entries by task *)
-let filter_by_task task_id entries =
-  if task_id = "" then entries
-  else List.filter (fun e -> e.task_id = Some task_id) entries
-
-(** Aggregate costs by agent *)
-let aggregate_by_agent entries =
-  let tbl = Hashtbl.create 8 in
-  List.iter (fun e ->
-    let (tokens, cost, _model) =
-      try Hashtbl.find tbl e.agent
-      with Not_found -> (0, 0.0, e.model)
+let parse_cost_json = function
+  | `Assoc fields ->
+    let* agent = required_string fields "agent" in
+    let* task_id = required_optional_string fields "task_id" in
+    let* model = required_string fields "model" in
+    let* timestamp = required_string fields "timestamp" in
+    let* _source = required_string fields "source" in
+    let* usage_missing = required_bool fields "usage_missing" in
+    let* ts_unix =
+      match Masc_domain.parse_iso8601_opt timestamp with
+      | Some value -> Ok value
+      | None -> Error "timestamp must be a valid ISO-8601 UTC value"
     in
-    Hashtbl.replace tbl e.agent
-      (tokens + e.input_tokens + e.output_tokens, cost +. e.cost_usd, e.model)
-  ) entries;
-  Hashtbl.fold (fun agent (tokens, cost, model) acc ->
-    (agent, tokens, cost, model) :: acc
-  ) tbl []
+    let* input_tokens, output_tokens, cost_usd =
+      if usage_missing
+      then (
+        let* () = required_null fields "input_tokens" in
+        let* () = required_null fields "output_tokens" in
+        let* () = required_null fields "cost_usd" in
+        Ok (None, None, None))
+      else (
+        let* input_tokens = required_nonnegative_int fields "input_tokens" in
+        let* output_tokens = required_nonnegative_int fields "output_tokens" in
+        let* cost_usd = required_nonnegative_float fields "cost_usd" in
+        Ok (Some input_tokens, Some output_tokens, Some cost_usd))
+    in
+    Ok
+      { agent
+      ; task_id
+      ; model
+      ; input_tokens
+      ; output_tokens
+      ; cost_usd
+      ; timestamp
+      ; ts_unix
+      }
+  | _ -> Error "cost row must be a JSON object"
+;;
 
-(** Print cost report *)
+let cost_json ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
+  `Assoc
+    [ "agent", `String agent
+    ; ( "task_id"
+      , match task_id with
+        | Some value -> `String value
+        | None -> `Null )
+    ; "model", `String model
+    ; "input_tokens", `Int input_tokens
+    ; "output_tokens", `Int output_tokens
+    ; "cost_usd", `Float cost_usd
+    ; "usage_missing", `Bool false
+    ; "timestamp", `String (Masc_domain.now_iso ())
+    ; "source", `String "manual_cli"
+    ]
+;;
+
+let validate_log_input ~agent ~model ~input_tokens ~output_tokens ~cost_usd =
+  if nonblank agent = None
+  then Error "--agent is required for --log"
+  else if nonblank model = None
+  then Error "--model is required for --log"
+  else if input_tokens < 0
+  then Error "--input-tokens must be non-negative"
+  else if output_tokens < 0
+  then Error "--output-tokens must be non-negative"
+  else if not (Float.is_finite cost_usd) || cost_usd < 0.0
+  then Error "--cost must be a finite non-negative number"
+  else Ok ()
+;;
+
+let log_cost ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
+  let store = Dated_jsonl.create ~base_dir:(costs_dir ()) () in
+  Dated_jsonl.append
+    store
+    (cost_json ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd);
+  printf "Cost logged: %s → $%.4f\n" agent cost_usd
+;;
+
+let line_label path line_number =
+  match line_number with
+  | Some line_number -> sprintf "%s:%d" path line_number
+  | None -> path
+;;
+
+let read_costs () =
+  let store = Dated_jsonl.create ~base_dir:(costs_dir ()) () in
+  let entries = ref [] in
+  let invalid_rows = ref 0 in
+  let note_invalid location reason =
+    incr invalid_rows;
+    eprintf "Warning: skipped invalid cost row at %s: %s\n" location reason
+  in
+  match
+    Dated_jsonl.iter_all_entries_result store (function
+      | Dated_jsonl.Malformed_json { path; line_number; detail } ->
+        note_invalid (line_label path line_number) detail
+      | Dated_jsonl.Parsed json ->
+        (match parse_cost_json json with
+         | Ok entry -> entries := entry :: !entries
+         | Error reason ->
+           note_invalid (Dated_jsonl.base_dir store) reason))
+  with
+  | Ok () -> Ok (List.rev !entries, !invalid_rows)
+  | Error error -> Error (Dated_jsonl.read_error_to_string error)
+;;
+
+let period_of_string = function
+  | "hourly" -> Ok Hourly
+  | "daily" -> Ok Daily
+  | "weekly" -> Ok Weekly
+  | "monthly" -> Ok Monthly
+  | "all" -> Ok All
+  | value ->
+    Error
+      (sprintf
+         "invalid --period %S (expected hourly|daily|weekly|monthly|all)"
+         value)
+;;
+
+let period_label = function
+  | Hourly -> "hourly"
+  | Daily -> "daily"
+  | Weekly -> "weekly"
+  | Monthly -> "monthly"
+  | All -> "all"
+;;
+
+let filter_by_period period (entries : cost_entry list) =
+  let now = Unix.gettimeofday () in
+  let cutoff =
+    match period with
+    | Hourly -> now -. 3600.0
+    | Daily -> now -. 86400.0
+    | Weekly -> now -. 604800.0
+    | Monthly -> now -. 2592000.0
+    | All -> 0.0
+  in
+  List.filter (fun (entry : cost_entry) -> entry.ts_unix >= cutoff) entries
+;;
+
+let filter_by_agent agent (entries : cost_entry list) =
+  if String.equal agent ""
+  then entries
+  else
+    List.filter (fun (entry : cost_entry) -> String.equal entry.agent agent) entries
+;;
+
+let filter_by_task task_id (entries : cost_entry list) =
+  if String.equal task_id ""
+  then entries
+  else List.filter (fun (entry : cost_entry) -> entry.task_id = Some task_id) entries
+;;
+
+let known_tokens (entry : cost_entry) =
+  let input =
+    match entry.input_tokens with
+    | Some value -> value
+    | None -> 0
+  in
+  let output =
+    match entry.output_tokens with
+    | Some value -> value
+    | None -> 0
+  in
+  input + output
+;;
+
+let known_cost (entry : cost_entry) =
+  match entry.cost_usd with
+  | Some value -> value
+  | None -> 0.0
+;;
+
+let usage_missing (entry : cost_entry) =
+  entry.input_tokens = None || entry.output_tokens = None || entry.cost_usd = None
+;;
+
+let aggregate_by_agent (entries : cost_entry list) =
+  let totals = Hashtbl.create 8 in
+  List.iter
+    (fun (entry : cost_entry) ->
+       let previous =
+         match Hashtbl.find_opt totals entry.agent with
+         | Some value -> value
+         | None ->
+           { agent = entry.agent
+           ; tokens = 0
+           ; cost_usd = 0.0
+           ; model = entry.model
+           ; usage_missing_entries = 0
+           }
+       in
+       Hashtbl.replace
+         totals
+         entry.agent
+         { previous with
+           tokens = previous.tokens + known_tokens entry
+         ; cost_usd = previous.cost_usd +. known_cost entry
+         ; usage_missing_entries =
+             previous.usage_missing_entries
+             +
+             if usage_missing entry then 1 else 0
+         })
+    entries;
+  Hashtbl.fold (fun _ value acc -> value :: acc) totals []
+;;
+
+let filtered_costs ~agent ~task_id ~period =
+  let* entries, invalid_rows = read_costs () in
+  Ok
+    ( entries
+      |> filter_by_period period
+      |> filter_by_agent agent
+      |> filter_by_task task_id
+    , invalid_rows )
+;;
+
 let print_report ~agent ~task_id ~period =
-  let entries = read_costs () in
-  let filtered = entries
-    |> filter_by_period period
-    |> filter_by_agent agent
-    |> filter_by_task task_id
-  in
+  let* filtered, invalid_rows = filtered_costs ~agent ~task_id ~period in
+  let period_name = period_label period in
+  if filtered = []
+  then (
+    printf "📊 No cost data for period: %s\n" period_name;
+    Ok ())
+  else (
+    let total_tokens =
+      List.fold_left (fun acc entry -> acc + known_tokens entry) 0 filtered
+    in
+    let total_cost =
+      List.fold_left (fun acc entry -> acc +. known_cost entry) 0.0 filtered
+    in
+    let usage_missing_entries =
+      List.fold_left
+        (fun acc entry -> acc + if usage_missing entry then 1 else 0)
+        0
+        filtered
+    in
+    let by_agent = aggregate_by_agent filtered in
+    printf "\n";
+    printf "╔══════════════════════════════════════════════╗\n";
+    printf "║  💰 MASC Cost Report (%s)              \n" period_name;
+    printf "╠══════════════════════════════════════════════╣\n";
+    printf "║  Period: %s                              \n" period_name;
+    printf "║  Entries: %d                              \n" (List.length filtered);
+    printf "║  Usage-missing entries: %d                 \n" usage_missing_entries;
+    printf "║  Invalid rows skipped: %d                  \n" invalid_rows;
+    printf "╠══════════════════════════════════════════════╣\n";
+    printf "║  📊 By Agent:                              \n";
+    by_agent
+    |> List.sort (fun left right -> Float.compare right.cost_usd left.cost_usd)
+    |> List.iter (fun total ->
+      let pct =
+        if total_cost > 0.0 then total.cost_usd /. total_cost *. 100.0 else 0.0
+      in
+      printf
+        "║    %-10s %8d known tokens  $%7.2f (%4.1f%%), missing=%d\n"
+        total.agent
+        total.tokens
+        total.cost_usd
+        pct
+        total.usage_missing_entries);
+    printf "╠══════════════════════════════════════════════╣\n";
+    printf "║  📈 KNOWN TOTAL: %d tokens, $%.2f            \n" total_tokens total_cost;
+    printf "╚══════════════════════════════════════════════╝\n";
+    Ok ())
+;;
 
-  if List.length filtered = 0 then begin
-    printf "📊 No cost data for period: %s\n" period;
-    exit 0
-  end;
+let agent_total_to_json total =
+  `Assoc
+    [ "agent", `String total.agent
+    ; "tokens_known", `Int total.tokens
+    ; "cost_usd_known", `Float total.cost_usd
+    ; "model", `String total.model
+    ; "usage_missing_entries", `Int total.usage_missing_entries
+    ]
+;;
 
-  let total_tokens = List.fold_left (fun acc e ->
-    acc + e.input_tokens + e.output_tokens) 0 filtered in
-  let total_cost = List.fold_left (fun acc e -> acc +. e.cost_usd) 0.0 filtered in
-  let by_agent = aggregate_by_agent filtered in
-
-  printf "\n";
-  printf "╔══════════════════════════════════════════════╗\n";
-  printf "║  💰 MASC Cost Report (%s)              \n" period;
-  printf "╠══════════════════════════════════════════════╣\n";
-  printf "║  Period: %s                              \n" period;
-  printf "║  Entries: %d                              \n" (List.length filtered);
-  printf "╠══════════════════════════════════════════════╣\n";
-
-  (* By agent breakdown *)
-  printf "║  📊 By Agent:                              \n";
-  List.iter (fun (agent, tokens, cost, _model) ->
-    let pct = if total_cost > 0.0 then cost /. total_cost *. 100.0 else 0.0 in
-    printf "║    %-10s %8d tokens  $%7.2f (%4.1f%%)\n"
-      agent tokens cost pct
-  ) (List.sort (fun (_, _, a, _) (_, _, b, _) -> compare b a) by_agent);
-
-  printf "╠══════════════════════════════════════════════╣\n";
-  printf "║  📈 TOTAL: %d tokens, $%.2f            \n" total_tokens total_cost;
-  printf "╚══════════════════════════════════════════════╝\n"
-
-(** Print JSON report *)
 let print_json_report ~agent ~task_id ~period =
-  let entries = read_costs () in
-  let filtered = entries
-    |> filter_by_period period
-    |> filter_by_agent agent
-    |> filter_by_task task_id
-  in
+  let* filtered, invalid_rows = filtered_costs ~agent ~task_id ~period in
   let by_agent = aggregate_by_agent filtered in
-  let total_cost = List.fold_left (fun acc e -> acc +. e.cost_usd) 0.0 filtered in
+  let total_tokens =
+    List.fold_left (fun acc entry -> acc + known_tokens entry) 0 filtered
+  in
+  let total_cost =
+    List.fold_left (fun acc entry -> acc +. known_cost entry) 0.0 filtered
+  in
+  let usage_missing_entries =
+    List.fold_left
+      (fun acc entry -> acc + if usage_missing entry then 1 else 0)
+      0
+      filtered
+  in
+  `Assoc
+    [ "period", `String (period_label period)
+    ; "total_entries", `Int (List.length filtered)
+    ; "total_tokens_known", `Int total_tokens
+    ; "total_cost_usd_known", `Float total_cost
+    ; "usage_missing_entries", `Int usage_missing_entries
+    ; "invalid_rows_skipped", `Int invalid_rows
+    ; "by_agent", `List (List.map agent_total_to_json by_agent)
+    ]
+  |> Yojson.Safe.to_string
+  |> print_endline;
+  Ok ()
+;;
 
-  let agents_json = String.concat ", " (List.map (fun (agent, tokens, cost, model) ->
-    sprintf {|{"agent":"%s","tokens":%d,"cost_usd":%.4f,"model":"%s"}|} agent tokens cost model
-  ) by_agent) in
+type action =
+  | Log
+  | Report
 
-  printf {|{"period":"%s","total_entries":%d,"total_cost_usd":%.4f,"by_agent":[%s]}|}
-    period (List.length filtered) total_cost agents_json;
-  print_newline ()
+let fatal message =
+  eprintf "Error: %s\n" message;
+  exit 1
+;;
 
-(** Parse command line arguments *)
-type action = Log | Report
-
-let () =
+let run () =
   let action = ref Report in
   let agent = ref "" in
   let task_id = ref "" in
-  let model = ref "unknown" in
+  let model = ref "" in
   let input_tokens = ref 0 in
   let output_tokens = ref 0 in
   let cost_usd = ref 0.0 in
   let period = ref "daily" in
   let json_output = ref false in
-
-  let specs = [
-    ("--log", Arg.Unit (fun () -> action := Log), "Log a cost entry");
-    ("--report", Arg.Unit (fun () -> action := Report), "Show cost report");
-    ("--agent", Arg.Set_string agent, "Agent name");
-    ("--task", Arg.Set_string task_id, "Task ID");
-    ("--model", Arg.Set_string model, "Model name");
-    ("--input-tokens", Arg.Set_int input_tokens, "Input tokens");
-    ("--output-tokens", Arg.Set_int output_tokens, "Output tokens");
-    ("--tokens", Arg.Int (fun t -> input_tokens := t), "Total tokens (shorthand)");
-    ("--cost", Arg.Set_float cost_usd, "Cost in USD");
-    ("--period", Arg.Set_string period, "Report period: hourly|daily|weekly|monthly|all");
-    ("--json", Arg.Set json_output, "Output as JSON");
-  ] in
-
+  let specs =
+    [ "--log", Arg.Unit (fun () -> action := Log), "Log a cost entry"
+    ; "--report", Arg.Unit (fun () -> action := Report), "Show cost report"
+    ; "--agent", Arg.Set_string agent, "Agent name"
+    ; "--task", Arg.Set_string task_id, "Task ID"
+    ; "--model", Arg.Set_string model, "Model name"
+    ; "--input-tokens", Arg.Set_int input_tokens, "Input tokens"
+    ; "--output-tokens", Arg.Set_int output_tokens, "Output tokens"
+    ; "--tokens", Arg.Int (fun value -> input_tokens := value), "Input tokens (shorthand)"
+    ; "--cost", Arg.Set_float cost_usd, "Cost in USD"
+    ; "--period", Arg.Set_string period, "Report period: hourly|daily|weekly|monthly|all"
+    ; "--json", Arg.Set json_output, "Output as JSON"
+    ]
+  in
   Arg.parse specs (fun _ -> ()) "masc-cost: Track multi-agent costs\n";
-
   match !action with
   | Log ->
-      if !agent = "" then begin
-        prerr_endline "Error: --agent is required for --log";
-        exit 1
-      end;
-      let task = if !task_id = "" then None else Some !task_id in
-      log_cost
-        ~agent:!agent
-        ~task_id:task
-        ~model:!model
-        ~input_tokens:!input_tokens
-        ~output_tokens:!output_tokens
-        ~cost_usd:!cost_usd
-
+    (match
+       validate_log_input
+         ~agent:!agent
+         ~model:!model
+         ~input_tokens:!input_tokens
+         ~output_tokens:!output_tokens
+         ~cost_usd:!cost_usd
+     with
+     | Error message -> fatal message
+     | Ok () ->
+       let task_id =
+         match nonblank !task_id with
+         | Some value -> Some value
+         | None -> None
+       in
+       log_cost
+         ~agent:(String.trim !agent)
+         ~task_id
+         ~model:(String.trim !model)
+         ~input_tokens:!input_tokens
+         ~output_tokens:!output_tokens
+         ~cost_usd:!cost_usd)
   | Report ->
-      let task = !task_id in
-      if !json_output then
-        print_json_report ~agent:!agent ~task_id:task ~period:!period
-      else
-        print_report ~agent:!agent ~task_id:task ~period:!period
+    (match period_of_string !period with
+     | Error message -> fatal message
+     | Ok period ->
+       let result =
+         if !json_output
+         then print_json_report ~agent:!agent ~task_id:!task_id ~period
+         else print_report ~agent:!agent ~task_id:!task_id ~period
+       in
+       (match result with
+        | Ok () -> ()
+        | Error message -> fatal message))
+;;
+
+let () =
+  Eio_main.run (fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    run ())
+;;

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -315,7 +315,7 @@ Allowed path model:
 - `<runtime_root>/runtime_params.json`
 - `<runtime_root>/param_audit.jsonl`
 - `<runtime_root>/metrics/<agent>/YYYY-MM.jsonl`
-- `<runtime_root>/costs.jsonl`
+- `<runtime_root>/costs/YYYY-MM/DD.jsonl`
 - `<runtime_root>/autonomy_stats.jsonl`
 
 Current host note:

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -203,6 +203,11 @@ let bool_opt_to_json : bool option -> Yojson.Safe.t = function
 let string_opt_field name (opt : string option) : string * Yojson.Safe.t =
   (name, string_opt_to_json opt)
 
+let error_assoc fields : Yojson.Safe.t =
+  let fields =
+    List.filter (fun (key, _) -> not (String.equal key "status")) fields
+  in
+  `Assoc (("status", `String "error") :: fields)
 
 (** {1 Assoc field extraction}
 

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -203,11 +203,14 @@ let bool_opt_to_json : bool option -> Yojson.Safe.t = function
 let string_opt_field name (opt : string option) : string * Yojson.Safe.t =
   (name, string_opt_to_json opt)
 
-let error_assoc fields : Yojson.Safe.t =
+let assoc_with_status status fields : Yojson.Safe.t =
   let fields =
     List.filter (fun (key, _) -> not (String.equal key "status")) fields
   in
-  `Assoc (("status", `String "error") :: fields)
+  `Assoc (("status", `String status) :: fields)
+
+let ok_assoc fields = assoc_with_status "ok" fields
+let error_assoc fields = assoc_with_status "error" fields
 
 (** {1 Assoc field extraction}
 

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -67,6 +67,10 @@ val int_option_to_yojson : int option -> Yojson.Safe.t
 val string_option_to_yojson : string option -> Yojson.Safe.t
 (** [string_option_to_yojson] maps [Some s] to [`String s] or [None] to [`Null]. *)
 
+(** [error_assoc fields] constructs the canonical JSON error envelope.
+    A caller-supplied [status] field is discarded so it cannot override
+    the required ["error"] status. *)
+val error_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
 
 (** {1 Diagnostic helpers} *)
 

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -67,6 +67,11 @@ val int_option_to_yojson : int option -> Yojson.Safe.t
 val string_option_to_yojson : string option -> Yojson.Safe.t
 (** [string_option_to_yojson] maps [Some s] to [`String s] or [None] to [`Null]. *)
 
+(** [ok_assoc fields] constructs the canonical JSON success envelope.
+    A caller-supplied [status] field is discarded so it cannot override
+    the required ["ok"] status. *)
+val ok_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
+
 (** [error_assoc fields] constructs the canonical JSON error envelope.
     A caller-supplied [status] field is discarded so it cannot override
     the required ["error"] status. *)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -107,7 +107,7 @@ include Keeper_hooks_oas_cost_events
 (** Build OAS hooks for a keeper agent.
 
     All keepers receive the full tool set unconditionally.
-    Cost events are emitted per turn to [.masc/costs.jsonl]. Cost is an
+    Cost events are emitted per turn to the date-split [.masc/costs/] store. Cost is an
     observation and is not part of the pre-tool decision surface.
 
     @param meta_ref Mutable ref to keeper metadata

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -139,7 +139,7 @@ val emit_cost_event :
   ?usage_trust:Keeper_usage_trust.t ->
   ?telemetry:Agent_sdk.Types.inference_telemetry ->
   ?model:string -> unit -> unit
-(** Append a structured cost-ledger event to [costs.jsonl]. *)
+(** Append a structured cost-ledger event to [costs/YYYY-MM/DD.jsonl]. *)
 
 (** PR-review / PR-work metric event types live in Keeper_hooks_oas_types
     (intra-library file split, 2026-05-16). Re-exported via include below. *)

--- a/lib/model_inference_metrics/model_inference_metrics.ml
+++ b/lib/model_inference_metrics/model_inference_metrics.ml
@@ -1,7 +1,7 @@
 (** Model_inference_metrics — per-model aggregate inference statistics.
 
     Reads keeper [decisions.jsonl] files plus inference-level
-    [costs.jsonl] samples, extracts telemetry entries within a
+    date-split [costs] samples, extracts telemetry entries within a
     configurable time window, and computes per-model aggregates:
     avg/p50/p95 tok/s, avg/p50/p95 latency, total reasoning tokens,
     cost attribution, tool usage, and success/error rates.

--- a/lib/model_inference_metrics/model_inference_metrics.mli
+++ b/lib/model_inference_metrics/model_inference_metrics.mli
@@ -1,6 +1,6 @@
 (** Model_inference_metrics — per-model aggregate inference statistics.
 
-    Reads keeper decisions.jsonl files plus inference-level costs.jsonl
+    Reads keeper decisions.jsonl files plus inference-level date-split costs
     samples and computes per-model aggregates within a configurable time
     window.
 

--- a/lib/model_inference_metrics/model_inference_metrics.mli
+++ b/lib/model_inference_metrics/model_inference_metrics.mli
@@ -114,6 +114,14 @@ type model_stats = {
   buckets : bucket_metric list;
 }
 
+type cost_read_diagnostics = {
+  malformed_rows : int;
+  schema_violation_rows : int;
+}
+
+type cost_read_result =
+  (cost_read_diagnostics, Dated_jsonl.read_error) result
+
 type aggregate = {
   window_minutes : int;
   bucket_minutes : int;
@@ -121,6 +129,7 @@ type aggregate = {
   total_entries : int;
   total_error_entries : int;
   latency_buckets : latency_bucket list;
+  cost_read : cost_read_result;
 }
 
 val compute : base_path:string -> window_minutes:int -> aggregate
@@ -145,7 +154,7 @@ val aggregate_buckets :
   base_path:string ->
   window_min:int ->
   bucket_min:int ->
-  model_bucketed list
+  (model_bucketed list * cost_read_diagnostics, Dated_jsonl.read_error) result
 (** [aggregate_buckets ~base_path ~window_min ~bucket_min] splits the last
     [window_min] minutes into [bucket_min]-minute buckets, groups entries
     per model, and for each non-empty bucket computes:
@@ -155,7 +164,9 @@ val aggregate_buckets :
     - Only buckets with at least one entry are emitted.
     - Buckets are returned oldest-first within each model.
     - [cache_hit_ratio] is [0.0] when the denominator is zero (never NaN).
-    - A non-positive [bucket_min] is treated as [1]. *)
+    - A non-positive [bucket_min] is treated as [1].
+    - Cost-store read failures are returned instead of being projected as an
+      empty successful cost stream. *)
 
 val to_json : aggregate -> Yojson.Safe.t
 (** Serialize [aggregate] to JSON for API responses. Compatibility fields

--- a/lib/model_inference_metrics/model_inference_metrics_aggregate.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_aggregate.ml
@@ -322,7 +322,7 @@ let latency_histogram (entries : raw_entry list) : latency_bucket list =
 
 let compute ~base_path ~window_minutes : aggregate =
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
-  let entries = read_all_entries ~base_path ~since_unix in
+  let entries, cost_read = read_all_entries ~base_path ~since_unix in
   let models = aggregate_by_model entries in
   let total_error_entries = count_if (fun e -> e.is_error) entries in
   { window_minutes
@@ -331,13 +331,14 @@ let compute ~base_path ~window_minutes : aggregate =
   ; total_entries = List.length entries
   ; total_error_entries
   ; latency_buckets = latency_histogram entries
+  ; cost_read
   }
 ;;
 
 let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate =
   let bucket_minutes = max 1 bucket_minutes in
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
-  let entries = read_all_entries ~base_path ~since_unix in
+  let entries, cost_read = read_all_entries ~base_path ~since_unix in
   let models = aggregate_by_model entries in
   let bucket_sec = bucket_minutes * 60 in
   let by_model_map : raw_entry list StringMap.t =
@@ -364,19 +365,26 @@ let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate 
   ; total_entries = List.length entries
   ; total_error_entries
   ; latency_buckets = latency_histogram entries
+  ; cost_read
   }
 ;;
 
-let aggregate_buckets ~base_path ~window_min ~bucket_min : model_bucketed list =
+let aggregate_buckets ~base_path ~window_min ~bucket_min =
   let since_unix = Time_compat.now () -. (Float.of_int window_min *. 60.0) in
-  let entries = read_all_entries ~base_path ~since_unix in
+  let entries, cost_read = read_all_entries ~base_path ~since_unix in
   let bucket_sec = if bucket_min <= 0 then 60 else bucket_min * 60 in
   let by_model = group_entries_by_model entries in
-  List.map
-    (fun (model_id, es) ->
-       { mb_model_id = model_id; mb_buckets = bucket_entries_for_model es ~bucket_sec })
-    by_model
-  |> List.sort (fun a b -> compare a.mb_model_id b.mb_model_id)
+  Result.map
+    (fun diagnostics ->
+       ( List.map
+           (fun (model_id, es) ->
+              { mb_model_id = model_id
+              ; mb_buckets = bucket_entries_for_model es ~bucket_sec
+              })
+           by_model
+         |> List.sort (fun a b -> compare a.mb_model_id b.mb_model_id)
+       , diagnostics ))
+    cost_read
 ;;
 
 (* ── Runtime-lane rollup ────────────────────────────────────

--- a/lib/model_inference_metrics/model_inference_metrics_aggregate.mli
+++ b/lib/model_inference_metrics/model_inference_metrics_aggregate.mli
@@ -16,6 +16,6 @@ val aggregate_buckets :
   base_path:string ->
   window_min:int ->
   bucket_min:int ->
-  model_bucketed list
+  (model_bucketed list * cost_read_diagnostics, Dated_jsonl.read_error) result
 
 val provider_rollup : aggregate -> provider_stats list

--- a/lib/model_inference_metrics/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_entry.ml
@@ -204,7 +204,8 @@ type parse_error =
   | Missing_outcome                (* telemetry.outcome absent on success-branch row *)
   | Missing_success_model          (* no selected_model / model_used / runtime_id *)
   | Missing_error_model_attribution (* no candidate_models / runtime_id on error turn *)
-  | Missing_cost_model             (* costs.jsonl row without "model" field *)
+  | Missing_cost_model             (* cost row without "model" field *)
+  | Missing_cost_usage_missing     (* costs row without current usage_missing boolean *)
 
 let parse_error_label = function
   | Not_assoc -> "not_assoc"
@@ -215,6 +216,7 @@ let parse_error_label = function
   | Missing_success_model -> "missing_success_model"
   | Missing_error_model_attribution -> "missing_error_model_attribution"
   | Missing_cost_model -> "missing_cost_model"
+  | Missing_cost_usage_missing -> "missing_cost_usage_missing"
 ;;
 
 (* [Out_of_window] and [Not_assoc] are routine in mixed jsonl streams; we never
@@ -227,7 +229,8 @@ let parse_error_is_schema_violation = function
   | Missing_outcome
   | Missing_success_model
   | Missing_error_model_attribution
-  | Missing_cost_model -> true
+  | Missing_cost_model
+  | Missing_cost_usage_missing -> true
 ;;
 
 (* ── Percentile / list helpers ──────────────────────────── *)

--- a/lib/model_inference_metrics/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_entry.ml
@@ -124,6 +124,14 @@ type latency_bucket =
   ; count : int
   }
 
+type cost_read_diagnostics =
+  { malformed_rows : int
+  ; schema_violation_rows : int
+  }
+
+type cost_read_result =
+  (cost_read_diagnostics, Dated_jsonl.read_error) result
+
 type aggregate =
   { window_minutes : int
   ; bucket_minutes : int
@@ -131,6 +139,7 @@ type aggregate =
   ; total_entries : int
   ; total_error_entries : int
   ; latency_buckets : latency_bucket list
+  ; cost_read : cost_read_result
   }
 
 (** Per-provider rollup of {!model_stats} aggregated across every model id

--- a/lib/model_inference_metrics/model_inference_metrics_entry.mli
+++ b/lib/model_inference_metrics/model_inference_metrics_entry.mli
@@ -101,6 +101,14 @@ type latency_bucket =
   ; count : int
   }
 
+type cost_read_diagnostics =
+  { malformed_rows : int
+  ; schema_violation_rows : int
+  }
+
+type cost_read_result =
+  (cost_read_diagnostics, Dated_jsonl.read_error) result
+
 type aggregate =
   { window_minutes : int
   ; bucket_minutes : int
@@ -108,6 +116,7 @@ type aggregate =
   ; total_entries : int
   ; total_error_entries : int
   ; latency_buckets : latency_bucket list
+  ; cost_read : cost_read_result
   }
 
 type provider_stats =

--- a/lib/model_inference_metrics/model_inference_metrics_entry.mli
+++ b/lib/model_inference_metrics/model_inference_metrics_entry.mli
@@ -166,6 +166,7 @@ type parse_error =
   | Missing_success_model
   | Missing_error_model_attribution
   | Missing_cost_model
+  | Missing_cost_usage_missing
 
 val parse_error_label : parse_error -> string
 val parse_error_is_schema_violation : parse_error -> bool

--- a/lib/model_inference_metrics/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_json.ml
@@ -47,10 +47,8 @@ let cost_read_to_json = function
       ; "schema_violation_rows", `Int diagnostics.schema_violation_rows
       ]
   | Error error ->
-    `Assoc
-      [ "status", `String "error"
-      ; "detail", `String (Dated_jsonl.read_error_to_string error)
-      ]
+    Json_util.error_assoc
+      [ "detail", `String (Dated_jsonl.read_error_to_string error) ]
 ;;
 
 let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)

--- a/lib/model_inference_metrics/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_json.ml
@@ -47,8 +47,10 @@ let cost_read_to_json = function
       ; "schema_violation_rows", `Int diagnostics.schema_violation_rows
       ]
   | Error error ->
-    Tool_args.error_assoc
-      [ "detail", `String (Dated_jsonl.read_error_to_string error) ]
+    `Assoc
+      [ "status", `String "error"
+      ; "detail", `String (Dated_jsonl.read_error_to_string error)
+      ]
 ;;
 
 let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)

--- a/lib/model_inference_metrics/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_json.ml
@@ -47,10 +47,8 @@ let cost_read_to_json = function
       ; "schema_violation_rows", `Int diagnostics.schema_violation_rows
       ]
   | Error error ->
-    `Assoc
-      [ "status", `String "error"
-      ; "detail", `String (Dated_jsonl.read_error_to_string error)
-      ]
+    Tool_args.error_assoc
+      [ "detail", `String (Dated_jsonl.read_error_to_string error) ]
 ;;
 
 let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)

--- a/lib/model_inference_metrics/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_json.ml
@@ -39,6 +39,20 @@ let bucket_metric_to_json (b : bucket_metric) : Yojson.Safe.t =
     ]
 ;;
 
+let cost_read_to_json = function
+  | Ok diagnostics ->
+    `Assoc
+      [ "status", `String "ok"
+      ; "malformed_rows", `Int diagnostics.malformed_rows
+      ; "schema_violation_rows", `Int diagnostics.schema_violation_rows
+      ]
+  | Error error ->
+    `Assoc
+      [ "status", `String "error"
+      ; "detail", `String (Dated_jsonl.read_error_to_string error)
+      ]
+;;
+
 let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)
   : Yojson.Safe.t
   =
@@ -144,6 +158,7 @@ let to_json (agg : aggregate) : Yojson.Safe.t =
     ; "bucket_minutes", `Int agg.bucket_minutes
     ; "total_entries", `Int agg.total_entries
     ; "total_error_entries", `Int agg.total_error_entries
+    ; "cost_ledger_read", cost_read_to_json agg.cost_read
     ; "latency_buckets", `List (List.map latency_bucket_to_json agg.latency_buckets)
     ; ( "models"
       , `List
@@ -245,7 +260,7 @@ let provider_stats_to_json (s : provider_stats) : Yojson.Safe.t =
 
 let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
-  let entries = read_all_entries ~base_path ~since_unix in
+  let entries, cost_read = read_all_entries ~base_path ~since_unix in
   let model_stats_list = aggregate_by_model entries in
   (* per-agent rows - sorted by cost descending, skip zero-signal rows *)
   let per_agent =
@@ -330,6 +345,7 @@ let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
     ; "p95", Json_util.float_opt_to_json global_p95
     ; "total_cost_usd", `Float total_cost_usd
     ; "window_minutes", `Int window_minutes
+    ; "cost_ledger_read", cost_read_to_json cost_read
     ; "generated_at", `Float (Time_compat.now ())
     ]
 ;;

--- a/lib/model_inference_metrics/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_parser.ml
@@ -2,7 +2,7 @@
     {!Model_inference_metrics}.
 
     Owns [parse_telemetry_entry] (decisions.jsonl rows) and
-    [parse_cost_entry] (costs.jsonl rows), plus the model-attribution
+    [parse_cost_entry] (date-split cost rows), plus the model-attribution
     helpers (runtime name canonicalization, candidate-model fallback,
     provider hints) that both parsers share. Produces internal
     {!Model_inference_metrics_entry.raw_entry} values tagged with the
@@ -318,7 +318,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
     | _ -> Error Not_assoc)
 ;;
 
-(* ── costs.jsonl parser ─────────────────────────────────── *)
+(* ── date-split cost row parser ─────────────────────────── *)
 
 let read_hw_decode_tok_per_sec (fields : (string * Yojson.Safe.t) list) =
   match List.assoc_opt "hw_decode_tokens_per_second" fields with
@@ -339,15 +339,6 @@ let canonical_cost_model_id ~(provider : string option) model =
     let prefix = provider_key ^ ":" in
     if String.starts_with ~prefix model then model else prefix ^ model
 ;;
-
-(* Three-way decision for the costs.jsonl [usage_missing] field. Previous
-   code compressed [None] (field absent) with [Some false] via [Option.value
-   ~default:false]; absent now contributes a [usage_missing_field_absent]
-   anomaly reason so reconciliation can see the gap. *)
-type usage_missing_decision =
-  | Usage_missing_reported  (* usage_missing = true *)
-  | Usage_present_reported  (* usage_missing = false *)
-  | Usage_missing_field_absent  (* usage_missing field not in row *)
 
 let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
   : (raw_entry, parse_error) result
@@ -378,19 +369,9 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
            ~provider:(private_provider_hint_of_fields fields)
            raw_model
        in
-       let usage_missing_decision =
-         match json_bool_field_opt "usage_missing" fields with
-         | Some true -> Usage_missing_reported
-         | Some false -> Usage_present_reported
-         | None -> Usage_missing_field_absent
-       in
-       let usage_missing =
-         match usage_missing_decision with
-         | Usage_missing_reported -> true
-         (* Field-absent rows preserve the legacy "treat as present" behaviour
-            but are surfaced via [usage_missing_field_absent] anomaly reason. *)
-         | Usage_present_reported | Usage_missing_field_absent -> false
-       in
+       (match json_bool_field_opt "usage_missing" fields with
+        | None -> Error Missing_cost_usage_missing
+        | Some usage_missing ->
        let usage_reported = not usage_missing in
        let input_tokens_raw =
          if usage_missing then None else json_int_field_opt "input_tokens" fields
@@ -403,23 +384,12 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
          | Some _ as v -> v
          | None -> json_int_field_opt "cache_read_input_tokens" fields
        in
-       let usage_trust, base_usage_anomaly_reasons =
+       let usage_trust, usage_anomaly_reasons =
          infer_usage_trust_from_fields
            fields
            ~usage_reported:(Some usage_reported)
            ~input_tokens:input_tokens_raw
            ~output_tokens:output_tokens_raw
-       in
-       (* Surface field-absent rows as an anomaly reason so reconciliation
-          can distinguish them from explicit [usage_missing = false]. *)
-       let usage_anomaly_reasons =
-         match usage_missing_decision with
-         | Usage_missing_field_absent ->
-           if List.mem "usage_missing_field_absent" base_usage_anomaly_reasons
-           then base_usage_anomaly_reasons
-           else base_usage_anomaly_reasons @ [ "usage_missing_field_absent" ]
-         | Usage_missing_reported | Usage_present_reported ->
-           base_usage_anomaly_reasons
        in
        let latency_ms = json_positive_float_field_opt "request_latency_ms" fields in
        let tok_per_sec_raw =
@@ -487,6 +457,6 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
          ; streaming_ttfrc_ms = None
          ; streaming_inter_chunk_count = None
          ; streaming_inter_chunk_avg_ms = None
-         }))
+         })))
   | _ -> Error Not_assoc
 ;;

--- a/lib/model_inference_metrics/model_inference_metrics_reader.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_reader.ml
@@ -2,7 +2,7 @@
     {!Model_inference_metrics}.
 
     Reads keeper [decisions.jsonl] files plus inference-level
-    [costs.jsonl] (legacy single-file + dated subtree), merges duplicate
+    date-split [costs] rows, merges duplicate
     samples between the two sources, and exposes coverage helpers used
     by the aggregate stage.
 
@@ -55,76 +55,55 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
       files)
 ;;
 
-let read_cost_entries_legacy ~base_path ~since_unix : raw_entry list =
-  let path = Filename.concat (Common.masc_dir_from_base_path ~base_path) "costs.jsonl" in
-  if not (Sys.file_exists path)
-  then []
-  else (
-    try
-      Fs_compat.fold_jsonl_lines
-        ~init:[]
-        ~f:(fun acc ~line_no json ->
-          match parse_cost_entry json ~since_unix with
-          | Ok e -> e :: acc
-          | Error err ->
-            if parse_error_is_schema_violation err
-            then
-              Log.Model_inference_metrics.warn "costs.jsonl parse drop: %s:%d reason=%s"
-                path
-                line_no
-                (parse_error_label err);
-            acc)
-        path
-    with
-    | Eio.Cancel.Cancelled _ as exn ->
-      let bt = Printexc.get_raw_backtrace () in
-      Printexc.raise_with_backtrace exn bt
-    | _ -> [])
-;;
-
 let read_cost_entries_dated ~base_path ~since_unix : raw_entry list =
   let dir = Filename.concat (Common.masc_dir_from_base_path ~base_path) "costs" in
   if not (Sys.file_exists dir)
   then []
   else (
     let store = Dated_jsonl.create ~base_dir:dir () in
-    let now = Unix.gettimeofday () in
-    let since = Log.format_utc_date_of since_unix in
-    let until = Log.format_utc_date_of now in
+    let entries = ref [] in
     try
-      Dated_jsonl.read_range store ~since ~until
-      |> List.filter_map (fun json ->
-        match
-          try Ok (parse_cost_entry json ~since_unix) with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | _ -> Error ()
-        with
-        | Ok (Ok e) -> Some e
-        | Ok (Error err) ->
-          if parse_error_is_schema_violation err
-          then
-            Log.Model_inference_metrics.warn "costs/dated parse drop: reason=%s"
-              (parse_error_label err);
-          None
-        | Error () -> None)
+      match
+        Dated_jsonl.iter_all_entries_result store (function
+          | Dated_jsonl.Parsed json ->
+            (match parse_cost_entry json ~since_unix with
+             | Ok entry -> entries := entry :: !entries
+             | Error err ->
+               if parse_error_is_schema_violation err
+               then
+                 Log.Model_inference_metrics.warn
+                   "costs/dated parse drop: reason=%s"
+                   (parse_error_label err))
+          | Dated_jsonl.Malformed_json { path; line_number; detail } ->
+            let location =
+              match line_number with
+              | Some line_number -> Printf.sprintf "%s:%d" path line_number
+              | None -> path
+            in
+            Log.Model_inference_metrics.warn
+              "costs/dated malformed row: %s detail=%s"
+              location
+              detail)
+      with
+      | Ok () -> List.rev !entries
+      | Error error ->
+        Log.Model_inference_metrics.error
+          "costs/dated read failed: %s"
+          (Dated_jsonl.read_error_to_string error);
+        []
     with
     | Eio.Cancel.Cancelled _ as exn ->
       let bt = Printexc.get_raw_backtrace () in
       Printexc.raise_with_backtrace exn bt
-    | _ -> [])
+    | exn ->
+      Log.Model_inference_metrics.error
+        "costs/dated read failed: %s"
+        (Printexc.to_string exn);
+      [])
 ;;
 
-(** Read cost ledger entries from both the legacy single-file
-    [masc_root/costs.jsonl] and the date-split
-    [masc_root/costs/YYYY-MM/DD.jsonl] tree, merging the two streams.
-
-    The public [masc-cost] CLI still owns the single-file writer and reporter.
-    Removing this reader before that documented executable is migrated would
-    split one live cost flow into two mutually invisible stores. *)
 let read_cost_entries ~base_path ~since_unix : raw_entry list =
-  let legacy = read_cost_entries_legacy ~base_path ~since_unix in
-  let dated = read_cost_entries_dated ~base_path ~since_unix in
-  legacy @ dated
+  read_cost_entries_dated ~base_path ~since_unix
 ;;
 
 let same_int_opt a b =

--- a/lib/model_inference_metrics/model_inference_metrics_reader.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_reader.ml
@@ -55,54 +55,50 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
       files)
 ;;
 
-let read_cost_entries_dated ~base_path ~since_unix : raw_entry list =
+let read_cost_entries_dated ~base_path ~since_unix
+  : (raw_entry list * cost_read_diagnostics, Dated_jsonl.read_error) result
+  =
   let dir = Filename.concat (Common.masc_dir_from_base_path ~base_path) "costs" in
   if not (Sys.file_exists dir)
-  then []
+  then Ok ([], { malformed_rows = 0; schema_violation_rows = 0 })
   else (
     let store = Dated_jsonl.create ~base_dir:dir () in
     let entries = ref [] in
-    try
-      match
-        Dated_jsonl.iter_all_entries_result store (function
-          | Dated_jsonl.Parsed json ->
-            (match parse_cost_entry json ~since_unix with
-             | Ok entry -> entries := entry :: !entries
-             | Error err ->
-               if parse_error_is_schema_violation err
-               then
-                 Log.Model_inference_metrics.warn
-                   "costs/dated parse drop: reason=%s"
-                   (parse_error_label err))
-          | Dated_jsonl.Malformed_json { path; line_number; detail } ->
-            let location =
-              match line_number with
-              | Some line_number -> Printf.sprintf "%s:%d" path line_number
-              | None -> path
-            in
-            Log.Model_inference_metrics.warn
-              "costs/dated malformed row: %s detail=%s"
-              location
-              detail)
-      with
-      | Ok () -> List.rev !entries
-      | Error error ->
-        Log.Model_inference_metrics.error
-          "costs/dated read failed: %s"
-          (Dated_jsonl.read_error_to_string error);
-        []
+    let malformed_rows = ref 0 in
+    let schema_violation_rows = ref 0 in
+    match
+      Dated_jsonl.iter_all_entries_result store (function
+        | Dated_jsonl.Parsed json ->
+          (match parse_cost_entry json ~since_unix with
+           | Ok entry -> entries := entry :: !entries
+           | Error Out_of_window -> ()
+           | Error err ->
+             incr schema_violation_rows;
+             Log.Model_inference_metrics.warn
+               "costs/dated schema drop: reason=%s"
+               (parse_error_label err))
+        | Dated_jsonl.Malformed_json { path; line_number; detail } ->
+          incr malformed_rows;
+          let location =
+            match line_number with
+            | Some line_number -> Printf.sprintf "%s:%d" path line_number
+            | None -> path
+          in
+          Log.Model_inference_metrics.warn
+            "costs/dated malformed row: %s detail=%s"
+            location
+            detail)
     with
-    | Eio.Cancel.Cancelled _ as exn ->
-      let bt = Printexc.get_raw_backtrace () in
-      Printexc.raise_with_backtrace exn bt
-    | exn ->
-      Log.Model_inference_metrics.error
-        "costs/dated read failed: %s"
-        (Printexc.to_string exn);
-      [])
+    | Ok () ->
+      Ok
+        ( List.rev !entries
+        , { malformed_rows = !malformed_rows
+          ; schema_violation_rows = !schema_violation_rows
+          } )
+    | Error error -> Error error)
 ;;
 
-let read_cost_entries ~base_path ~since_unix : raw_entry list =
+let read_cost_entries ~base_path ~since_unix =
   read_cost_entries_dated ~base_path ~since_unix
 ;;
 
@@ -135,8 +131,14 @@ let merge_decision_and_cost_entries decisions costs =
 
 let read_all_entries ~base_path ~since_unix =
   let decisions = read_all_decisions ~base_path ~since_unix in
-  let costs = read_cost_entries ~base_path ~since_unix in
-  merge_decision_and_cost_entries decisions costs
+  match read_cost_entries ~base_path ~since_unix with
+  | Ok (costs, diagnostics) ->
+    merge_decision_and_cost_entries decisions costs, Ok diagnostics
+  | Error error ->
+    Log.Model_inference_metrics.error
+      "costs/dated read failed: %s"
+      (Dated_jsonl.read_error_to_string error);
+    decisions, Error error
 ;;
 
 (* ── Coverage helpers (used by aggregate stage) ───────────── *)

--- a/lib/model_inference_metrics/model_inference_metrics_reader.mli
+++ b/lib/model_inference_metrics/model_inference_metrics_reader.mli
@@ -3,8 +3,13 @@
 open Model_inference_metrics_entry
 
 val read_all_decisions : base_path:string -> since_unix:float -> raw_entry list
-val read_cost_entries : base_path:string -> since_unix:float -> raw_entry list
-val read_all_entries : base_path:string -> since_unix:float -> raw_entry list
+val read_cost_entries :
+  base_path:string ->
+  since_unix:float ->
+  (raw_entry list * cost_read_diagnostics, Dated_jsonl.read_error) result
+
+val read_all_entries :
+  base_path:string -> since_unix:float -> raw_entry list * cost_read_result
 val usage_signal_present : raw_entry -> bool
 (** Input, output, cache-read, cache-creation, and reasoning token counters are
     usage evidence. A billing-only [cost_usd] value is not. *)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -145,16 +145,15 @@ let cached_dashboard_json ~sync_first ~sw ~cache ~key ~placeholder ~compute =
   response
 
 let empty_model_metrics_json ~window ~bucket_min =
-  let agg =
-    { Model_inference_metrics.window_minutes = window
-    ; bucket_minutes = bucket_min
-    ; models = []
-    ; total_entries = 0
-    ; total_error_entries = 0
-    ; latency_buckets = []
-    }
-  in
-  Model_inference_metrics.to_json agg
+  `Assoc
+    [ "window_minutes", `Int window
+    ; "bucket_minutes", `Int bucket_min
+    ; "total_entries", `Int 0
+    ; "total_error_entries", `Int 0
+    ; "cost_ledger_read", `Assoc [ "status", `String "pending" ]
+    ; "latency_buckets", `List []
+    ; "models", `List []
+    ]
 
 let empty_cost_latency_json ~window =
   `Assoc
@@ -166,6 +165,7 @@ let empty_cost_latency_json ~window =
     ; "p95", `Null
     ; "total_cost_usd", `Float 0.0
     ; "window_minutes", `Int window
+    ; "cost_ledger_read", `Assoc [ "status", `String "pending" ]
     ; "generated_at", `Float (Unix.gettimeofday ())
     ]
 

--- a/lib/tool_types/tool_args.ml
+++ b/lib/tool_types/tool_args.ml
@@ -99,11 +99,7 @@ let error_code_to_string = function
     but returning the unserialized [Yojson.Safe.t] node so it can be
     composed into a larger structure or returned as
     [(Yojson.Safe.t, _) result]. *)
-let without_status_field fields =
-  List.filter (fun (key, _) -> not (String.equal key "status")) fields
-
-let error_assoc fields : Yojson.Safe.t =
-  `Assoc (("status", `String "error") :: without_status_field fields)
+let error_assoc = Json_util.error_assoc
 
 (** Build a JSON error response string: [\{"status":"error","message":"..."\}] *)
 let error_response message =

--- a/lib/tool_types/tool_args.ml
+++ b/lib/tool_types/tool_args.ml
@@ -129,8 +129,7 @@ let error_response_typed ~code message =
     sub-payloads, or [(Yojson.Safe.t, string) result] pipelines that
     serialize at a later stage.  Same field-order guarantee as
     [ok_response]: status is prepended to the head of the [`Assoc]. *)
-let ok_assoc fields : Yojson.Safe.t =
-  `Assoc (("status", `String "ok") :: without_status_field fields)
+let ok_assoc = Json_util.ok_assoc
 
 (** Build a JSON OK response string with additional fields. *)
 let ok_response fields =

--- a/scripts/lint/no-inline-error-envelope.sh
+++ b/scripts/lint/no-inline-error-envelope.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # lint-no-inline-error-envelope — block inline `("status", `String "error")`
-# in lib/. Mirrors no-inline-ok-envelope. Use Tool_args.error_response /
-# error_response_with / error_assoc / error_result instead.
+# in lib/. Mirrors no-inline-ok-envelope. Use Json_util.error_assoc or the
+# Tool_args response/result helpers instead.
 
 set -euo pipefail
 
@@ -9,8 +9,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 ALLOWLIST=(
   # SSOT definition — canonical helpers themselves.
-  # Moved to lib/tool_types/ in RFC-0086 PR-2H (PR #15531).
-  "lib/tool_types/tool_args.ml"
+  "lib/core/json_util.ml"
 
   # T27 alias backstop (sibling-include runtime for tool_local_runtime_*.ml).
   "lib/tool_local_runtime_core.ml"
@@ -64,7 +63,7 @@ while IFS= read -r match; do
     continue
   fi
 
-  echo "ERROR: inline error-envelope literal (use Tool_args.error_response / error_response_with / error_assoc / error_result): $match"
+  echo "ERROR: inline error-envelope literal (use Json_util.error_assoc or a Tool_args error helper): $match"
   count=$((count + 1))
 done < "$matches_file"
 
@@ -74,7 +73,7 @@ if [[ $count -gt 0 ]]; then
   echo "Migration guide:"
   echo "  - Returns string (msg only)?  Tool_args.error_response msg"
   echo "  - Returns string (+ fields)?  Tool_args.error_response_with fields"
-  echo "  - Returns Yojson.Safe.t?      Tool_args.error_assoc fields"
+  echo "  - Returns Yojson.Safe.t?      Json_util.error_assoc fields"
   echo "  - Returns Tool_result.t?      Tool_args.error_result ~tool_name ~start_time msg"
   exit 1
 fi

--- a/scripts/lint/no-inline-ok-envelope.sh
+++ b/scripts/lint/no-inline-ok-envelope.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # no-inline-ok-envelope.sh — Block inline `("status", `String "ok")` literals
-# in lib/. Use Tool_args.ok_response / ok_assoc / ok_result instead.
+# in lib/. Use Json_util.ok_assoc or Tool_args response/result helpers instead.
 #
 # Rationale: T27/T28/T29 consolidated 11+ inline ok-envelope sites into
 # Tool_args SSOT helpers. Without a lint guard, the inline pattern
@@ -8,7 +8,7 @@
 # remaining intentional sites can be misread as license to add more.
 #
 # Allowlisted files fall into three categories:
-#   1. SSOT definition itself (tool_args.ml).
+#   1. SSOT definition itself (json_util.ml).
 #   2. T27 alias backstop for sibling-include runtime
 #      (tool_local_runtime_core.ml).
 #   3. Tier B/C intentional inline sites where wire format reordering
@@ -21,8 +21,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 ALLOWLIST=(
   # SSOT definition — the canonical helper itself.
-  # Moved to lib/tool_types/ in RFC-0086 PR-2H (PR #15531).
-  "lib/tool_types/tool_args.ml"
+  "lib/core/json_util.ml"
 
   # T27 alias backstop. sibling tool_local_runtime_*.ml modules
   # consume `json_ok` / `json_error` via `include Tool_local_runtime_core`;

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -54,6 +54,31 @@ let write_costs base entries =
   let store = Dated_jsonl.create ~base_dir:costs_dir () in
   List.iter (Dated_jsonl.append store) entries
 
+let cost_day_file base =
+  let costs_dir = Filename.concat base ".masc/costs" in
+  let rec jsonl_files path =
+    if Sys.is_directory path
+    then
+      Sys.readdir path
+      |> Array.to_list
+      |> List.concat_map (fun name -> jsonl_files (Filename.concat path name))
+    else if Filename.check_suffix path ".jsonl"
+    then [ path ]
+    else []
+  in
+  match jsonl_files costs_dir with
+  | [ path ] -> path
+  | paths ->
+    failf "expected one cost day file, found %d" (List.length paths)
+
+let append_raw_line path line =
+  let oc = open_out_gen [ Open_append ] 0o644 path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+       output_string oc line;
+       output_char oc '\n')
+
 let write_retired_costs base entries =
   let masc_dir = Filename.concat base ".masc" in
   let rec mkdir_p dir =
@@ -937,6 +962,48 @@ let test_retired_single_file_cost_store_is_ignored () =
       stats.model_id)
 ;;
 
+let test_cost_read_diagnostics_reach_api () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let ts = now_unix () in
+    write_costs
+      base
+      [ cost_entry ~model:"valid" ~ts ()
+      ; `String "schema-invalid"
+      ];
+    append_raw_line (cost_day_file base) "{";
+    let json = M.compute ~base_path:base ~window_minutes:60 |> M.to_json in
+    let diagnostics = Yojson.Safe.Util.member "cost_ledger_read" json in
+    check string "cost read status" "ok"
+      Yojson.Safe.Util.(diagnostics |> member "status" |> to_string);
+    check int "malformed rows" 1
+      Yojson.Safe.Util.(diagnostics |> member "malformed_rows" |> to_int);
+    check int "schema violation rows" 1
+      Yojson.Safe.Util.(diagnostics |> member "schema_violation_rows" |> to_int))
+;;
+
+let test_cost_read_failure_is_not_empty_success () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let keeper_path = make_keeper_dir base "decision-survives-cost-error" in
+    write_decisions
+      keeper_path
+      [ success_entry ~model:"decision-model" ~ts:(now_unix ()) () ];
+    let costs_dir = Filename.concat base ".masc/costs" in
+    Unix.mkdir costs_dir 0o755;
+    let invalid_entry = Filename.concat costs_dir "not-a-month" in
+    Unix.mkdir invalid_entry 0o755;
+    let json = M.compute ~base_path:base ~window_minutes:60 |> M.to_json in
+    check int "decision metrics remain available" 1
+      Yojson.Safe.Util.(json |> member "total_entries" |> to_int);
+    let diagnostics = Yojson.Safe.Util.member "cost_ledger_read" json in
+    check string "cost read status" "error"
+      Yojson.Safe.Util.(diagnostics |> member "status" |> to_string);
+    check bool "typed read detail is surfaced" true
+      (Yojson.Safe.Util.(diagnostics |> member "detail" |> to_string)
+       |> contains_substring "not-a-month"))
+;;
+
 let test_cost_latency_json_composes_axes_and_percentiles () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
@@ -1180,10 +1247,18 @@ let success_entry_with_cache ~model ~ts ?(input_tokens=100) ~cache_read () =
     ]);
   ]
 
+let bucket_models = function
+  | Ok (models, _diagnostics) -> models
+  | Error error ->
+    failf "cost store read failed: %s" (Dated_jsonl.read_error_to_string error)
+
 let test_buckets_empty_dir () =
   let dir = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
-    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:5 in
+    let result =
+      M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:5
+      |> bucket_models
+    in
     check int "empty → no models" 0 (List.length result))
 
 let test_buckets_single_bucket () =
@@ -1195,7 +1270,10 @@ let test_buckets_single_bucket () =
     success_entry ~model:"claude" ~ts:(now -. 30.0) ();
   ];
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
-    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60 in
+    let result =
+      M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60
+      |> bucket_models
+    in
     check int "one model" 1 (List.length result);
     let m = List.hd result in
     check string "model_id" "claude" m.mb_model_id;
@@ -1210,7 +1288,10 @@ let test_buckets_sparse () =
     success_entry ~model:"model-b" ~ts:(now -. 600.0) ();
   ];
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
-    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:5 in
+    let result =
+      M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:5
+      |> bucket_models
+    in
     check int "one model" 1 (List.length result);
     let m = List.hd result in
     check bool "sparse → 2 distinct buckets (10min apart, 5min width)"
@@ -1224,7 +1305,10 @@ let test_buckets_cache_hit_ratio_zero_denom () =
     success_entry_with_cache ~model:"kimi-k2.6" ~ts:now ~input_tokens:0 ~cache_read:0 ();
   ];
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
-    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60 in
+    let result =
+      M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60
+      |> bucket_models
+    in
     check int "one model" 1 (List.length result);
     let m = List.hd result in
     let b = List.hd m.mb_buckets in
@@ -1301,6 +1385,9 @@ let zero_model_stats (model_id : string) ~provider ~entry_count
     buckets = [];
   }
 
+let successful_cost_read : M.cost_read_result =
+  Ok { malformed_rows = 0; schema_violation_rows = 0 }
+
 let test_provider_rollup_empty_aggregate () =
   let agg : M.aggregate =
     { window_minutes = 30
@@ -1309,6 +1396,7 @@ let test_provider_rollup_empty_aggregate () =
     ; total_entries = 0
     ; total_error_entries = 0
     ; latency_buckets = []
+    ; cost_read = successful_cost_read
     }
   in
   check int "empty models gives empty rollup" 0
@@ -1320,7 +1408,8 @@ let test_provider_rollup_skips_unknown_provider () =
   let m2 = zero_model_stats "bare-model" ~provider:None ~entry_count:3 in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m1; m2]
-    ; total_entries = 8; total_error_entries = 0; latency_buckets = [] }
+    ; total_entries = 8; total_error_entries = 0; latency_buckets = []
+    ; cost_read = successful_cost_read }
   in
   let rollup = M.provider_rollup agg in
   check int "only provider=Some survives" 1 (List.length rollup);
@@ -1344,7 +1433,8 @@ let test_provider_rollup_weighted_mean () =
   in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m1; m2]
-    ; total_entries = 100; total_error_entries = 0; latency_buckets = [] }
+    ; total_entries = 100; total_error_entries = 0; latency_buckets = []
+    ; cost_read = successful_cost_read }
   in
   let rollup = M.provider_rollup agg in
   let stats = List.hd rollup in
@@ -1364,7 +1454,8 @@ let test_provider_rollup_all_none_yields_none () =
   let m2 = zero_model_stats "x:2" ~provider:(Some "x") ~entry_count:5 in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m1; m2]
-    ; total_entries = 10; total_error_entries = 0; latency_buckets = [] }
+    ; total_entries = 10; total_error_entries = 0; latency_buckets = []
+    ; cost_read = successful_cost_read }
   in
   let rollup = M.provider_rollup agg in
   let stats = List.hd rollup in
@@ -1381,7 +1472,8 @@ let test_provider_rollup_sort_by_entry_count_desc () =
   let c = zero_model_stats "c:1" ~provider:(Some "c") ~entry_count:7 in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [a; b; c]
-    ; total_entries = 20; total_error_entries = 0; latency_buckets = [] }
+    ; total_entries = 20; total_error_entries = 0; latency_buckets = []
+    ; cost_read = successful_cost_read }
   in
   let rollup = M.provider_rollup agg in
   let names = List.map (fun s -> s.M.ps_provider) rollup in
@@ -1397,7 +1489,8 @@ let test_provider_rollup_json_shape () =
   in
   let agg : M.aggregate =
     { window_minutes = 30; bucket_minutes = 0; models = [m]
-    ; total_entries = 42; total_error_entries = 0; latency_buckets = [] }
+    ; total_entries = 42; total_error_entries = 0; latency_buckets = []
+    ; cost_read = successful_cost_read }
   in
   let json = M.provider_stats_to_json (List.hd (M.provider_rollup agg)) in
   match json with
@@ -1424,6 +1517,7 @@ let test_prompt_feedback_empty_aggregate () =
     ; total_entries = 0
     ; total_error_entries = 0
     ; latency_buckets = []
+    ; cost_read = successful_cost_read
     }
   in
   check string "empty aggregate renders empty prompt block" ""
@@ -1452,6 +1546,7 @@ let test_prompt_feedback_redacts_provider_model_identity () =
     ; total_entries = 10
     ; total_error_entries = 3
     ; latency_buckets = []
+    ; cost_read = successful_cost_read
     }
   in
   let text = M.render_keeper_prompt_feedback agg in
@@ -1475,6 +1570,7 @@ let test_prompt_feedback_is_cost_independent () =
       ; total_entries = 1
       ; total_error_entries = 0
       ; latency_buckets = []
+      ; cost_read = successful_cost_read
       }
   in
   let baseline = render None in
@@ -1572,6 +1668,10 @@ let () =
       test_case "costs.jsonl dedupes matching decision sample" `Quick test_costs_jsonl_dedupes_matching_decision_sample;
       test_case "retired single-file cost store is ignored" `Quick
         test_retired_single_file_cost_store_is_ignored;
+      test_case "cost read diagnostics reach API" `Quick
+        test_cost_read_diagnostics_reach_api;
+      test_case "cost read failure is not empty success" `Quick
+        test_cost_read_failure_is_not_empty_success;
       test_case "cost latency json composes axes and percentiles" `Quick test_cost_latency_json_composes_axes_and_percentiles;
       test_case "public runtime lane label is stable across windows" `Quick
         test_public_runtime_lane_label_is_stable_across_windows;

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -50,6 +50,11 @@ let iso_of_unix ts =
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
 let write_costs base entries =
+  let costs_dir = Filename.concat base ".masc/costs" in
+  let store = Dated_jsonl.create ~base_dir:costs_dir () in
+  List.iter (Dated_jsonl.append store) entries
+
+let write_retired_costs base entries =
   let masc_dir = Filename.concat base ".masc" in
   let rec mkdir_p dir =
     if not (Sys.file_exists dir) then begin
@@ -326,6 +331,23 @@ let test_cost_parser_uses_current_hw_decode_field_only () =
     (row "hw_decode_tokens_per_second")
     (Some 42.0);
   parse "retired cost alias ignored" (row "provider_tokens_per_second") None
+;;
+
+let test_cost_parser_requires_usage_missing () =
+  let ts = now_unix () in
+  let row =
+    match cost_entry ~model:"model" ~ts () with
+    | `Assoc fields ->
+      `Assoc (List.filter (fun (key, _) -> not (String.equal key "usage_missing")) fields)
+    | _ -> fail "cost entry must be an object"
+  in
+  match Model_inference_metrics_parser.parse_cost_entry row ~since_unix:0.0 with
+  | Error Model_inference_metrics_entry.Missing_cost_usage_missing -> ()
+  | Error error ->
+    fail
+      ("wrong parse error: "
+       ^ Model_inference_metrics_entry.parse_error_label error)
+  | Ok _ -> fail "cost row without usage_missing must be rejected"
 ;;
 
 (* ── Tests ───────────────────────────────────────── *)
@@ -894,6 +916,26 @@ let test_costs_jsonl_dedupes_matching_decision_sample () =
     check int "matching cost sample deduped" 1 s.entry_count;
     check (option (float 0.001)) "decision tok/sec preserved"
       (Some 100.0) s.avg_tok_per_sec)
+
+let test_retired_single_file_cost_store_is_ignored () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let ts = now_unix () in
+    write_retired_costs
+      base
+      [ cost_entry ~model:"retired-single-file" ~ts () ];
+    write_costs
+      base
+      [ cost_entry ~model:"current-dated-store" ~ts () ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    check int "only current store row is loaded" 1 agg.total_entries;
+    let stats = List.hd agg.models in
+    check
+      string
+      "retired single-file row ignored"
+      "ollama:current-dated-store"
+      stats.model_id)
+;;
 
 let test_cost_latency_json_composes_axes_and_percentiles () =
   let base = test_dir () in
@@ -1521,11 +1563,15 @@ let () =
         test_hw_decode_parser_uses_current_field_only;
       test_case "cost parser uses current hw-decode field only" `Quick
         test_cost_parser_uses_current_hw_decode_field_only;
+      test_case "cost parser requires usage_missing" `Quick
+        test_cost_parser_requires_usage_missing;
       test_case "costs.jsonl backfills wall tok/sec" `Quick test_costs_jsonl_backfills_wall_tok_per_sec;
       test_case "costs.jsonl disambiguates matching model names by provider" `Quick
         test_costs_jsonl_disambiguates_matching_model_names_by_provider;
       test_case "costs.jsonl zero latency stays missing" `Quick test_costs_jsonl_zero_latency_is_missing;
       test_case "costs.jsonl dedupes matching decision sample" `Quick test_costs_jsonl_dedupes_matching_decision_sample;
+      test_case "retired single-file cost store is ignored" `Quick
+        test_retired_single_file_cost_store_is_ignored;
       test_case "cost latency json composes axes and percentiles" `Quick test_cost_latency_json_composes_axes_and_percentiles;
       test_case "public runtime lane label is stable across windows" `Quick
         test_public_runtime_lane_label_is_stable_across_windows;


### PR DESCRIPTION
## Summary

- move the public `masc-cost` writer and reporter to `.masc/costs/YYYY-MM/DD.jsonl`
- remove the retired `.masc/costs.jsonl` metrics reader
- require the current `usage_missing` field instead of interpreting absence
- surface and count invalid current-store rows instead of fabricating defaults

## Feature path checked

- manual CLI log -> date-split cost ledger -> CLI report
- Keeper cost emit -> date-split cost ledger -> model inference metrics
- malformed/current-schema rejection remains visible to operators

No migration, repair path, compatibility reader, or new facade is added.

## Validation

- `git diff --check`
- `ocamlformat --check` on touched OCaml files
- `scripts/dune-local.sh build bin/masc_cost.exe test/test_model_inference_metrics.exe`
- `scripts/dune-local.sh exec ./test/test_model_inference_metrics.exe` (45 tests)
- isolated CLI smoke: log 12 input + 3 output tokens at $0.25, then report the same 1 row from `.masc/costs/2026-07/29.jsonl`
