### PR TITLE
fix(keeper): bound default Memory OS recall window

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -34,58 +34,40 @@ include Keeper_config_text
 let keeper_status_fast_default () : bool =
   bool_of_env_default "MASC_KEEPER_STATUS_FAST_DEFAULT" ~default:false
 
-(* masc#25052 P1: Memory OS recall selection budget. Before this,
-   Keeper_memory_os_recall.render_context_exn injected the keeper's ENTIRE
-   current fact/episode store into every turn's prompt -- no selection
-   contract existed, so a keeper that accumulated facts/episodes without
-   bound grew its per-turn prompt injection without limit. (Retention for
-   both stores lives in Keeper_memory_os_gc: run_gc deletes facts and
-   run_episode_gc deletes episode files, each only past the exact
-   producer-declared valid_until, default-on from the maintenance fiber.)
-   These three knobs are the boundary: how many facts, how many episodes,
-   and how many rendered bytes recall may inject per turn.
+(* Memory OS recall is a bounded per-turn projection, not the persisted store.
+   The store remains complete until its explicit typed validity/GC boundary;
+   recall selects the most recent exact rows by reference_time/created_at and
+   does not inspect or rank their prose. Runtime_params can tune the working
+   set live, while every drop remains visible in the gauge, logs, metrics, and
+   recall-injection ledger. *)
+let keeper_memory_os_recall_default_max_facts = 8
+let keeper_memory_os_recall_default_max_episodes = 2
 
-   Defaults are set at/above the largest volume observed in the 2026-07-17
-   lane analysis that diagnosed this (~300 facts, ~380 episode summaries,
-   ~1.5MB rendered per keeper turn), so a typical keeper today is truncated
-   by NONE of these -- this establishes a ceiling, not a retroactive
-   downsizing. Operators tune live via Runtime_params (no restart) as real
-   volumes grow. Truncation, when it does trigger, is always logged and
-   counted (Keeper_metrics.MemoryOsRecallFactsTruncated /
-   RecallEpisodesTruncated / RecallBytesOverBudget) -- never silent. *)
 let keeper_memory_os_recall_max_facts_rp =
   _rp_int ~key:"keeper.memory_os.recall.max_facts"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_FACTS"
-                          ~default:500 ~min_v:0 ~max_v:100_000)
+                          ~default:keeper_memory_os_recall_default_max_facts
+                          ~min_v:0 ~max_v:100_000)
     ~min_v:0 ~max_v:100_000
-    ~description:"Max facts Memory OS recall injects per turn (0 = inject none)" ()
+    ~description:"Most recent exact facts Memory OS recall injects per turn (0 = inject none)" ()
 let keeper_memory_os_recall_max_facts () : int =
   Runtime_params.get keeper_memory_os_recall_max_facts_rp
 
 let keeper_memory_os_recall_max_episodes_rp =
   _rp_int ~key:"keeper.memory_os.recall.max_episodes"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_EPISODES"
-                          ~default:500 ~min_v:0 ~max_v:100_000)
+                          ~default:keeper_memory_os_recall_default_max_episodes
+                          ~min_v:0 ~max_v:100_000)
     ~min_v:0 ~max_v:100_000
-    ~description:"Max episodes Memory OS recall injects per turn (0 = inject none)" ()
+    ~description:"Most recent exact episodes Memory OS recall injects per turn (0 = inject none)" ()
 let keeper_memory_os_recall_max_episodes () : int =
   Runtime_params.get keeper_memory_os_recall_max_episodes_rp
 
-(* RFC-0351 L3: enforced, no longer observability-only. This was a threshold
-   that logged "not truncated" and let the block go out in full, deferring a
-   byte-accurate trim until real overage data existed. That data exists: one
-   keeper rendered 222,499 bytes of recall -- 98.5% of its entire
-   extra_system_context for the turn -- while sitting under both count budgets
-   (62 facts / 432 episodes against 500/500), so neither count budget fired.
-
-   Enforcement drops the oldest episodes until the rendered block fits, keeping
-   survivors in their original order (see [select_pairs_within_byte_budget]).
-   Facts are never dropped by this budget; they render an order of magnitude
-   smaller than episodes.
-
-   The 64 KiB default is roughly a tenth of a 200k-token context window once
-   rendered, and takes the measured keeper from 222,499 B to under 65,536 B.
-   0 disables enforcement (unbounded), matching the previous behaviour. *)
+(* RFC-0351 L3: the count window is the primary selection boundary. This
+   byte-accurate backstop drops the oldest selected episodes when unusually
+   large exact rows still exceed the rendered-block budget. Facts are already
+   bounded by count and are never dropped here. 0 disables only this byte
+   backstop; it does not disable the fact/episode count windows. *)
 let keeper_memory_os_recall_max_bytes_rp =
   _rp_int ~key:"keeper.memory_os.recall.max_bytes"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_BYTES"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -104,12 +104,13 @@ val normalize_prompt_text : max_bytes:int -> string -> string
     Each parameter is registered with [Runtime_params] and can be
     adjusted via the dashboard at runtime. *)
 
-(** Memory OS recall selection budget (masc#25052 P1). See the .ml for the
-    growth problem this bounds and the default-sizing rationale. *)
+(** Memory OS per-turn working-set projection. Defaults to the most recent
+    8 exact facts and 2 exact episodes; persisted stores are not mutated.
+    Selection uses typed time fields only and never inspects claim prose. *)
 val keeper_memory_os_recall_max_facts : unit -> int
 val keeper_memory_os_recall_max_episodes : unit -> int
 val keeper_memory_os_recall_max_bytes : unit -> int
-(** Observability-only threshold (see .ml); not itself an enforced drop. *)
+(** Enforced rendered-byte backstop for selected episodes (see .ml). *)
 
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -144,17 +144,14 @@ type render_result =
   ; failure_reason : unavailable_reason option
   }
 
-(* masc#25052 P1: selection budget. Before this, every current fact/episode
-   in the store was injected every turn -- no selection contract existed.
-   [select_most_recent ~budget ~key ~recency items] keeps the [budget] most
-   recent items (by [recency], descending) and returns them in their
+(* Per-turn working-set selection. [select_most_recent ~budget ~key ~recency
+   items] keeps the [budget] most recent items (by [recency], descending)
+   without mutating the persisted store, and returns them in their
    ORIGINAL relative order (a stable filter over [items], not a reordering)
-   alongside the drop count, so turns that fit within budget see byte-for-
-   byte the same order they always did -- only the truncation CASE picks
-   which items survive, never how the survivors are arranged. [key] must be
-   a stable per-item identity (claim_identity for facts, "trace_id:gN" for
-   episodes) so membership after sorting can be checked without relying on
-   structural/physical equality. *)
+   alongside the drop count. Selection uses typed time fields only; it never
+   inspects claim/summary prose. [key] must be a stable per-item identity
+   (claim_identity for facts, "trace_id:gN" for episodes) so membership after
+   sorting can be checked without relying on structural/physical equality. *)
 let select_most_recent ~budget ~key ~recency items =
   let n = List.length items in
   if n <= budget
@@ -175,11 +172,8 @@ let select_most_recent ~budget ~key ~recency items =
 (* RFC-0351 L3: byte budget on the rendered block.
 
    The count budgets above bound how many items are injected, not how large
-   they render. One keeper sat at 62 facts / 432 episodes -- both under the 500
-   count budgets, so neither truncated -- and still rendered 222,499 bytes,
-   98.5% of that turn's entire extra_system_context. The byte budget existed but
-   was observability-only: it logged "not truncated" and let the block go out in
-   full.
+   unusually long exact rows render. The byte budget remains a backstop after
+   count selection.
 
    Same selection shape as [select_most_recent]: keep the most recent items that
    fit and return them in their ORIGINAL relative order, so a block within

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -4,14 +4,13 @@
     and episodes and returns their exact text in an advisory block suitable for
     OAS [extra_system_context].
 
-    masc#25052 P1: recall used to inject every current fact/episode in the
-    store, unbounded. It now applies a selection budget
+    Recall applies a bounded per-turn working-set projection
     ([Keeper_config.keeper_memory_os_recall_max_facts] /
-    [_max_episodes], live-tunable, default sized above all observed real
-    volumes): within budget, nothing changes (same items, same order); over
-    budget, the most-recent-[reference_time]/[created_at] items survive,
-    still rendered in their original relative order, and the drop is logged
-    plus counted (never silent).
+    [_max_episodes], live-tunable, default 8 facts / 2 episodes). The
+    most-recent-[reference_time]/[created_at] items survive, still rendered in
+    their original relative order, and every drop is visible in the prompt
+    gauge, logs, metrics, and recall-injection ledger. Persisted stores are not
+    mutated, and selection never inspects claim or summary prose.
 
     RFC-0351 L3: the count budgets bound how many items are injected, not how
     large they render. A rendered byte budget
@@ -49,11 +48,9 @@ val render_context
   -> now:float
   -> unit
   -> string
-(** Render every current fact and episode in persisted source order, up to
-    the configured selection budget (see the module doc). Below budget this
-    is byte-for-byte the old "no truncation, ranking, deduplication, or
-    fixed-size slices" behavior; over budget, the most recent items are kept
-    and a truncation is logged and counted. *)
+(** Render the configured working set of current facts and episodes in
+    persisted source order (see the module doc). The most recent items are
+    selected by typed time fields; exact text is preserved. *)
 
 val enabled : unit -> bool
 (** Kill-switch flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [true]).

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2245,7 +2245,8 @@ let test_render_if_enabled_preserves_empty_claim_episode () =
             (contains episode.episode_summary block))))
 ;;
 
-(* Recall reads the complete persisted store in source order. *)
+(* Recall scans the complete persisted candidate store before applying its
+   bounded projection; it must not degrade into a tail-file scan. *)
 let test_recall_reads_complete_store () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
@@ -3046,11 +3047,91 @@ let with_env name value f =
   Fun.protect ~finally:(fun () -> restore_env name old) f
 ;;
 
-(* masc#25052 P1: selection budget. Below budget, recall's behavior is
-   unchanged (asserted throughout the rest of this file, all of which use far
-   fewer than the 500-fact/500-episode default). This proves the truncation
-   case: over budget, only the most-recent-[last_verified_at] facts survive,
-   the drop is counted, and the dropped items are gone from the block. *)
+let without_env name f =
+  let old = Sys.getenv_opt name in
+  unsetenv name;
+  Fun.protect ~finally:(fun () -> restore_env name old) f
+;;
+
+(* Default recall is a compact prompt projection, not a rendering of the whole
+   store. The projection keeps exact text, selects only through typed recency,
+   and leaves all persisted rows intact. *)
+let test_recall_default_selection_window_is_bounded () =
+  without_env "MASC_KEEPER_MEMORY_OS_RECALL_MAX_FACTS" (fun () ->
+    without_env "MASC_KEEPER_MEMORY_OS_RECALL_MAX_EPISODES" (fun () ->
+      without_env "MASC_KEEPER_MEMORY_OS_RECALL_MAX_BYTES" (fun () ->
+        with_prompt_registry (fun () ->
+          with_temp_keepers_dir (fun _keepers_dir ->
+            let keeper_id = "default-selection-window-keeper" in
+            let now = 1_000_000.0 in
+            for i = 1 to 9 do
+              let fact =
+                { (fact_fixture ~now ()) with
+                  Types.claim = Printf.sprintf "default window fact %d" i
+                ; Types.claim_id = Some (Printf.sprintf "default-window-fact-%d" i)
+                ; Types.last_verified_at = Some (now -. float_of_int (9 - i))
+                }
+              in
+              Memory_io.append_fact ~keeper_id fact
+            done;
+            for i = 1 to 3 do
+              let episode =
+                episode_fixture
+                  ~now:(now -. float_of_int (3 - i))
+                  ~trace_id:(Printf.sprintf "default-window-episode-%d" i)
+                  ~generation:i
+                  ~summary:(Printf.sprintf "default window episode %d" i)
+              in
+              Memory_io.append_episode ~keeper_id episode
+            done;
+            let ctx = Recall.render_context ~keeper_id ~now () in
+            Alcotest.(check int)
+              "default fact window"
+              8
+              (Masc.Keeper_config.keeper_memory_os_recall_max_facts ());
+            Alcotest.(check int)
+              "default episode window"
+              2
+              (Masc.Keeper_config.keeper_memory_os_recall_max_episodes ());
+            Alcotest.(check bool)
+              "oldest fact is outside the prompt projection"
+              false
+              (contains "default window fact 1" ctx);
+            List.iter
+              (fun i ->
+                 Alcotest.(check bool)
+                   (Printf.sprintf "recent fact %d is injected" i)
+                   true
+                   (contains (Printf.sprintf "default window fact %d" i) ctx))
+              [ 2; 3; 4; 5; 6; 7; 8; 9 ];
+            Alcotest.(check bool)
+              "oldest episode is outside the prompt projection"
+              false
+              (contains "default window episode 1" ctx);
+            List.iter
+              (fun i ->
+                 Alcotest.(check bool)
+                   (Printf.sprintf "recent episode %d is injected" i)
+                   true
+                   (contains (Printf.sprintf "default window episode %d" i) ctx))
+              [ 2; 3 ];
+            Alcotest.(check bool)
+              "prompt gauge exposes selected versus stored rows"
+              true
+              (contains "facts 8/9 injected, episodes 2/3 injected" ctx);
+            Alcotest.(check int)
+              "fact store remains complete"
+              9
+              (List.length (Memory_io.read_facts_all ~keeper_id));
+            Alcotest.(check int)
+              "episode store remains complete"
+              3
+              (List.length (Memory_io.read_episodes_all ~keeper_id)))))))
+;;
+
+(* Over an explicit budget, only the most-recent-[last_verified_at] facts
+   survive, the drop is counted, and the dropped items are gone from the
+   prompt projection. *)
 let test_recall_selection_budget_truncates_facts_by_recency () =
   with_env "MASC_KEEPER_MEMORY_OS_RECALL_MAX_FACTS" "3" (fun () ->
     with_prompt_registry (fun () ->
@@ -3483,8 +3564,8 @@ let test_merge_keeps_distinct_conclusions () =
 (* RFC-0351 L3: the rendered byte budget drops the oldest episodes until the
    block fits and keeps survivors in their original order. Before this the
    budget only logged "not truncated" and let the block go out whole — one
-   keeper rendered 222,499B of recall while both count budgets (500/500) sat
-   unfired at 62 facts / 432 episodes. *)
+   keeper rendered 222,499B of recall before the default count window became
+   a compact working set. *)
 let test_byte_budget_keeps_newest_in_original_order () =
   (* Pairs arrive oldest-first, the order recall renders them in. Each line is
      4 bytes plus one newline joiner, so a 12-byte budget fits exactly two. *)
@@ -4670,6 +4751,10 @@ let () =
             "preserves repeated claim rows"
             `Quick
             test_recall_preserves_repeated_claims
+        ; Alcotest.test_case
+            "default selection window is bounded"
+            `Quick
+            test_recall_default_selection_window_is_bounded
         ; Alcotest.test_case
             "selection budget truncates by recency"
             `Quick


### PR DESCRIPTION
## Summary

- change the default per-turn Memory OS projection from 500 facts / 500 episodes to 8 / 2
- preserve the complete persisted stores; select exact rows only by typed `reference_time` / `created_at`
- keep existing gauge, truncation logs, metrics, and recall-injection ledger as the visible projection contract
- add a regression proving 9 facts / 3 episodes remain stored while only the newest 8 / 2 reach the prompt

## Current evidence

At 2026-07-29 21:34 KST, the live runtime reported no overrides and defaults of 500 / 500. The kidsnote Memory OS held 14 facts and 115 episode files, so neither count limit selected a subset. With this default, its per-turn gauge becomes 8/14 facts and 2/115 episodes (subject only to explicit runtime overrides).

This is a prompt projection change only: no legacy fields, migration path, store rewrite, semantic string heuristic, extra Gate, or Facade is introduced.

## Verification

- `ocamlformat --check lib/keeper/keeper_config.ml lib/keeper/keeper_config.mli lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_memory_os_recall.mli test/test_keeper_memory_os.ml`
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe`
- `_build/default/test/test_keeper_memory_os.exe` (100 tests passed)
- `git diff --check`