### PR TITLE
fix(memory): add per-keeper recall projection

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -134,6 +134,7 @@ These are still accepted by the loader, but for consistency they should be used 
 | `active_goal_ids` | string array | Declarative goal scope for task claim eligibility |
 | `telemetry_feedback_enabled` | bool | Surface recent telemetry in the keeper prompt |
 | `telemetry_feedback_window_hours` | int | Window size for telemetry summarization |
+| `memory_os_recall_projection` | string enum | Select persisted Memory OS stores for prompt recall. `facts_only` retains episodes on disk but injects only Librarian facts. |
 
 The retired `shards` field is rejected in both persona `keeper` objects and
 Keeper TOML. Tool-family membership is not a Keeper configuration axis; the
@@ -151,6 +152,7 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 | --- | --- |
 | `sandbox_profile` | `local`, `docker` |
 | `network_mode` | `none`, `inherit` |
+| `memory_os_recall_projection` | `facts_and_episodes`, `facts_only` |
 
 Deprecated personality-state axes are not allowed public keeper TOML values.
 The retired non-public keeper input list is currently empty in code.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -548,6 +548,7 @@ let run_turn
     Keeper_run_tools.prepare_agent_setup
       ~config
       ~meta
+      ~profile_defaults
       ~publication_recovery
       ?continuation_channel
       ?hitl_resolution

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -85,6 +85,7 @@ let render_nonempty_section key variable lines =
    config/prompts/keeper.memory_os_recall.context.md. Counts and byte totals
    only — no advice, no threshold, no verdict. *)
 let render_gauge_line
+      ~projection
       ~facts_injected
       ~facts_stored
       ~episodes_injected
@@ -98,7 +99,8 @@ let render_gauge_line
     else Printf.sprintf "%dB/%dB rendered" rendered_bytes byte_budget
   in
   Printf.sprintf
-    "facts %d/%d injected, episodes %d/%d injected, %s"
+    "projection=%s, facts %d/%d injected, episodes %d/%d injected, %s"
+    (Keeper_memory_os_recall_projection.to_string projection)
     facts_injected
     facts_stored
     episodes_injected
@@ -218,7 +220,7 @@ let log_truncation ~keeper_id ~kind ~metric ~store_count ~injected_count ~droppe
     budget
 ;;
 
-let render_context_exn ~keeper_id ~now () =
+let render_context_exn ~projection ~keeper_id ~now () =
   let all_facts =
     File_lock_eio.with_lock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
       Keeper_memory_os_io.read_facts_all ~keeper_id
@@ -238,11 +240,14 @@ let render_context_exn ~keeper_id ~now () =
     select_most_recent ~budget:max_facts ~key:claim_identity ~recency:reference_time all_facts
   in
   let episodes, episodes_dropped =
-    select_most_recent
-      ~budget:max_episodes
-      ~key:episode_key
-      ~recency:(fun (e : episode) -> e.created_at)
-      all_episodes
+    match projection with
+    | Keeper_memory_os_recall_projection.Facts_and_episodes ->
+      select_most_recent
+        ~budget:max_episodes
+        ~key:episode_key
+        ~recency:(fun (e : episode) -> e.created_at)
+        all_episodes
+    | Keeper_memory_os_recall_projection.Facts_only -> [], 0
   in
   if facts_dropped > 0
   then
@@ -308,6 +313,7 @@ let render_context_exn ~keeper_id ~now () =
   in
   let gauge_line =
     render_gauge_line
+      ~projection
       ~facts_injected:(List.length facts)
       ~facts_stored:n_facts_in_store
       ~episodes_injected:(List.length episodes)
@@ -334,8 +340,8 @@ let render_context_exn ~keeper_id ~now () =
   { block; injected_fact_keys; injected_episode_keys; n_facts_in_store; failure_reason }
 ;;
 
-let render_context ~keeper_id ~now () =
-  try (render_context_exn ~keeper_id ~now ()).block with
+let render_context ~projection ~keeper_id ~now () =
+  try (render_context_exn ~projection ~keeper_id ~now ()).block with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.Keeper.warn
@@ -351,7 +357,7 @@ let enabled () =
   Env_config.KeeperMemoryOs.recall_enabled ()
 ;;
 
-let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
+let render_if_enabled ~projection ~keeper_id ~now ~trace_id ~turn ~masc_root () =
   if not (enabled ())
   then None
   else (
@@ -361,7 +367,7 @@ let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
        and never affects the returned block. *)
     let result =
       try
-        render_context_exn ~keeper_id ~now ()
+        render_context_exn ~projection ~keeper_id ~now ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -31,7 +31,8 @@ val select_pairs_within_byte_budget
     score and no inspection of line content. *)
 
 val render_gauge_line
-  :  facts_injected:int
+  :  projection:Keeper_memory_os_recall_projection.t
+  -> facts_injected:int
   -> facts_stored:int
   -> episodes_injected:int
   -> episodes_stored:int
@@ -45,15 +46,15 @@ val render_gauge_line
     renders as unbounded rather than as a literal zero. *)
 
 val render_context
-  :  keeper_id:string
+  :  projection:Keeper_memory_os_recall_projection.t
+  -> keeper_id:string
   -> now:float
   -> unit
   -> string
-(** Render every current fact and episode in persisted source order, up to
-    the configured selection budget (see the module doc). Below budget this
-    is byte-for-byte the old "no truncation, ranking, deduplication, or
-    fixed-size slices" behavior; over budget, the most recent items are kept
-    and a truncation is logged and counted. *)
+(** Render the stores selected by [projection] in persisted source order, up
+    to the configured selection budget (see the module doc).
+    [Facts_only] keeps persisted episodes available to operators and future
+    turns but excludes them from this prompt without inspecting their prose. *)
 
 val enabled : unit -> bool
 (** Kill-switch flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [true]).
@@ -61,14 +62,16 @@ val enabled : unit -> bool
     separately by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
 val render_if_enabled
-  :  keeper_id:string
+  :  projection:Keeper_memory_os_recall_projection.t
+  -> keeper_id:string
   -> now:float
   -> trace_id:string
   -> turn:int
   -> masc_root:string
   -> unit
   -> string option
-(** [render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root ()] is
+(** [render_if_enabled ~projection ~keeper_id ~now ~trace_id ~turn ~masc_root
+    ()] is
     [Some block] when the flag is on and the store yields advisory content,
     [Some block] with an explicit unavailable advisory when recall fails after
     the flag is on, and [None] when disabled or when no memory exists. Intended

--- a/lib/keeper/keeper_memory_os_recall_projection.ml
+++ b/lib/keeper/keeper_memory_os_recall_projection.ml
@@ -1,0 +1,23 @@
+type t =
+  | Facts_and_episodes
+  | Facts_only
+
+let to_string = function
+  | Facts_and_episodes -> "facts_and_episodes"
+  | Facts_only -> "facts_only"
+;;
+
+let of_string = function
+  | "facts_and_episodes" -> Some Facts_and_episodes
+  | "facts_only" -> Some Facts_only
+  | _ -> None
+;;
+
+let all = [ Facts_and_episodes; Facts_only ]
+let valid_strings = List.map to_string all
+
+let () =
+  List.iter
+    (fun projection -> assert (of_string (to_string projection) = Some projection))
+    all
+;;

--- a/lib/keeper/keeper_memory_os_recall_projection.mli
+++ b/lib/keeper/keeper_memory_os_recall_projection.mli
@@ -1,0 +1,10 @@
+(** Typed projection over the persisted Memory OS stores. *)
+
+type t =
+  | Facts_and_episodes
+  | Facts_only
+
+val to_string : t -> string
+val of_string : string -> t option
+val all : t list
+val valid_strings : string list

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -72,6 +72,7 @@ val prepare_agent_setup
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> ctx_work:working_context
   -> session:Keeper_types.session_context

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -41,6 +41,7 @@ type ctx =
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
   ; manifest_keeper_turn_id : int option
   ; meta : Keeper_meta_contract.keeper_meta
+  ; memory_os_recall_projection : Keeper_memory_os_recall_projection.t
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
     (* RFC-0225 §3.3: per-run carrier; written by the pre-request hook
        below, read by the post-tool hooks in Keeper_hooks_oas. *)
@@ -352,16 +353,18 @@ let assemble_hooks
                     ()
                 in
                 (match
-                   (* Memory OS recall — advisory block rendered from every
-                      persisted facts/episodes (read side; the write side is
-                      the librarian wired in #20897), in persisted source order.
-                      Opt-in via MASC_KEEPER_MEMORY_OS_RECALL. *)
+                   (* Memory OS recall — advisory block rendered from the
+                      keeper profile's typed store projection (read side; the
+                      write side is the librarian wired in #20897), in
+                      persisted source order. Kill-switch:
+                      MASC_KEEPER_MEMORY_OS_RECALL. *)
                    (* Off-main: recall reads persisted facts/episodes via synchronous
                       file I/O, which would starve the main Eio domain and HOL
                       sibling keepers. Read-side only, no module-level mutable
                       state, so it is domain-safe on the shared pool. *)
                    Domain_pool_ref.submit_io_or_inline (fun () ->
                      Keeper_memory_os_recall.render_if_enabled
+                       ~projection:ctx.memory_os_recall_projection
                        ~keeper_id:meta.name
                        ~now:(Time_compat.now ())
                        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -95,6 +95,7 @@ let prepare_agent_setup
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
       ~(ctx_work : working_context)
       ~(session : Keeper_types.session_context)
@@ -125,6 +126,11 @@ let prepare_agent_setup
     match runtime_manifest_context with
     | Some ctx -> ctx.Keeper_runtime_manifest.manifest_keeper_turn_id
     | None -> None
+  in
+  let memory_os_recall_projection =
+    match profile_defaults.memory_os_recall_projection with
+    | Some projection -> projection
+    | None -> Keeper_memory_os_recall_projection.Facts_and_episodes
   in
   let ctx_snapshot = ctx_work in
   let gate_history, gate_history_omitted = gate_history_slice history_messages in
@@ -420,6 +426,7 @@ let prepare_agent_setup
     ; terminal_effect_state
     ; manifest_keeper_turn_id
     ; meta
+    ; memory_os_recall_projection
     ; turn_ctx_cell
     ; receipt_turn_count_ref
     ; receipt_model_used_ref

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -17,6 +17,7 @@ type keeper_profile_defaults = {
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
+  memory_os_recall_projection : Keeper_memory_os_recall_projection.t option;
   (* Per-keeper OAS CLI transport env vars (OAS 0.159+).
      Parsed from [[keeper.oas_env]] table.  Keys MUST match
      ^OAS_[A-Z]+_.+ — any other entries are dropped with
@@ -52,6 +53,7 @@ let empty_keeper_profile_defaults =
     telemetry_feedback_enabled = None;
     telemetry_feedback_window_hours = None;
     always_allow = None;
+    memory_os_recall_projection = None;
     unknown_toml_keys = [];
     oas_env = [];
   }

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -18,6 +18,7 @@ type keeper_profile_defaults = {
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
+  memory_os_recall_projection : Keeper_memory_os_recall_projection.t option;
   (* No per-keeper [model]/[runtime_id] field: keeper→runtime assignment lives
      solely in runtime.toml [[runtime.assignments]] (persona⊥{model,runtime}). *)
   oas_env : (string * string) list;

--- a/lib/keeper/keeper_types_profile_persona_defaults.ml
+++ b/lib/keeper/keeper_types_profile_persona_defaults.ml
@@ -78,6 +78,7 @@ let load_from_path ~name path : (keeper_profile_defaults, load_error) result =
               telemetry_feedback_window_hours =
                 Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
               always_allow = Safe_ops.json_bool_opt "always_allow" keeper_json;
+              memory_os_recall_projection = None;
               oas_env = [];
               unknown_toml_keys = [];
               }

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -81,6 +81,7 @@ type keeper_profile_defaults =
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
+  memory_os_recall_projection : Keeper_memory_os_recall_projection.t option;
   oas_env : (string * string) list;
   unknown_toml_keys : string list;
 }

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -81,6 +81,7 @@ type keeper_profile_defaults =
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
+  memory_os_recall_projection : Keeper_memory_os_recall_projection.t option;
   oas_env : (string * string) list;
   unknown_toml_keys : string list;
 }

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -81,6 +81,7 @@ type keeper_profile_defaults =
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
+  memory_os_recall_projection : Keeper_memory_os_recall_projection.t option;
   oas_env : (string * string) list;
   unknown_toml_keys : string list;
 }

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -104,6 +104,21 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     | false, false -> Ok ()
   in
   let result = Result.bind result (fun () -> runtime_assignment_result) in
+  let memory_os_recall_projection_result =
+    match str "memory_os_recall_projection" with
+    | None -> Ok None
+    | Some raw ->
+      (match Keeper_memory_os_recall_projection.of_string raw with
+       | Some projection -> Ok (Some projection)
+       | None ->
+         Error
+           (Printf.sprintf
+              "invalid memory_os_recall_projection '%s' (allowed: %s)"
+              raw
+              (String.concat
+                 ", "
+                 Keeper_memory_os_recall_projection.valid_strings)))
+  in
   let max_context_override_result =
     match int_ "max_context_override" with
     | None -> Ok None
@@ -112,7 +127,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       |> Result.map Option.some
   in
   Result.bind result (fun () ->
-    Result.map
+    Result.bind memory_os_recall_projection_result (fun memory_os_recall_projection ->
+      Result.map
       (fun max_context_override ->
       {
         id = None;
@@ -140,10 +156,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
         always_allow = bool_ "always_allow";
+        memory_os_recall_projection;
         oas_env;
         unknown_toml_keys = [];
       })
-      max_context_override_result)
+      max_context_override_result))
 
 (** Fields actually read by [profile_defaults_of_toml] from the [[keeper]]
     TOML table.  Keep this in sync with the record construction above — the
@@ -165,6 +182,7 @@ let parsed_field_key_names =
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
   ; "always_allow"
+  ; "memory_os_recall_projection"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -195,6 +213,7 @@ let canonical_keeper_toml_key_names =
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
   ; "always_allow"
+  ; "memory_os_recall_projection"
   ]
 
 let () =
@@ -312,6 +331,10 @@ let merge_keeper_profile_defaults
       prefer overlay.telemetry_feedback_window_hours
         base.telemetry_feedback_window_hours;
     always_allow = prefer overlay.always_allow base.always_allow;
+    memory_os_recall_projection =
+      prefer
+        overlay.memory_os_recall_projection
+        base.memory_os_recall_projection;
     oas_env =
       (let overlay_keys = List.map fst overlay.oas_env in
        let surviving_base =

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -81,6 +81,7 @@ type keeper_profile_defaults =
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
+  memory_os_recall_projection : Keeper_memory_os_recall_projection.t option;
   oas_env : (string * string) list;
   unknown_toml_keys : string list;
 }

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -13,6 +13,7 @@ module Consolidation_runtime = Masc.Keeper_memory_os_consolidation_runtime
 module Domain_pool_ref = Domain_pool_ref
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
+module Recall_projection = Masc.Keeper_memory_os_recall_projection
 module Metrics = Masc.Otel_metric_store
 module Runtime_manifest = Masc.Keeper_runtime_manifest
 
@@ -109,8 +110,15 @@ let write_text_file path contents =
     (fun () -> output_string oc contents)
 ;;
 
-let render_if_enabled_for_test ~keeper_id ~now ~masc_root () =
+let render_if_enabled_for_test
+      ?(projection = Recall_projection.Facts_and_episodes)
+      ~keeper_id
+      ~now
+      ~masc_root
+      ()
+  =
   Recall.render_if_enabled
+    ~projection
     ~keeper_id
     ~now
     ~trace_id:"trace-recall-render-test"
@@ -1981,6 +1989,7 @@ let test_recall_context_empty_store_renders_gauge () =
   with_temp_keepers_dir (fun _keepers_dir ->
     let ctx =
       Recall.render_context
+        ~projection:Recall_projection.Facts_and_episodes
         ~keeper_id:"virtual-memory-keeper"
         ~now:1_000_000.0
         ()
@@ -2129,6 +2138,70 @@ let test_render_if_enabled_renders_persisted_memory () =
             true
             (contains "Gated recall should surface saved facts" block))))
   ;;
+
+let test_facts_only_projection_excludes_episodes_without_deleting_them () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "facts-only-memory-keeper" in
+      let now = 1_000_000.0 in
+      let fact =
+        { (fact_fixture ~now ()) with
+          Types.claim = "Librarian fact remains prompt context"
+        }
+      in
+      let episode =
+        { Types.trace_id = "trace-facts-only"
+        ; Types.generation = 7
+        ; Types.episode_summary = "Repeated turn residue stays out of the prompt"
+        ; Types.claims = [ fact ]
+        ; Types.open_items = []
+        ; Types.constraints = []
+        ; Types.preserved_tool_refs = []
+        ; Types.source_turn_range = Some (1, 2)
+        ; Types.created_at = now
+        ; Types.valid_until = None
+        ; Types.terminal_marker = None
+        ; Types.schema_version = Types.schema_version
+        }
+      in
+      Memory_io.append_episode_bundle ~keeper_id episode;
+      let facts_only =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_only
+          ~keeper_id
+          ~now
+          ()
+      in
+      Alcotest.(check bool)
+        "typed Librarian fact is injected"
+        true
+        (contains fact.claim facts_only);
+      Alcotest.(check bool)
+        "episode summary is excluded without prose inspection"
+        false
+        (contains episode.episode_summary facts_only);
+      Alcotest.(check bool)
+        "gauge exposes the selected projection and retained episode count"
+        true
+        (contains
+           "projection=facts_only, facts 1/1 injected, episodes 0/1 injected"
+           facts_only);
+      Alcotest.(check int)
+        "episode remains persisted"
+        1
+        (List.length (Memory_io.read_episodes_all ~keeper_id));
+      let complete =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
+      Alcotest.(check bool)
+        "the same persisted episode remains available to the complete projection"
+        true
+        (contains episode.episode_summary complete)))
+;;
 
 (* The keeper turn wraps [render_if_enabled] in
    [Domain_pool_ref.submit_io_or_inline] so its synchronous memory file I/O runs
@@ -2417,7 +2490,13 @@ let test_recall_filters_expired_episodes () =
       in
       Memory_io.append_episode_bundle ~keeper_id expired;
       Memory_io.append_episode_bundle ~keeper_id active;
-      let ctx = Recall.render_context ~keeper_id ~now () in
+      let ctx =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
       Alcotest.(check bool)
         "expired episode row is omitted"
         false
@@ -2448,7 +2527,13 @@ let test_recall_renders_terminal_episode_marker () =
         }
       in
       Memory_io.append_episode_bundle ~keeper_id episode;
-      let ctx = Recall.render_context ~keeper_id ~now () in
+      let ctx =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
       Alcotest.(check bool)
         "terminal marker is visible in episode line"
         true
@@ -2500,7 +2585,13 @@ let test_recall_preserves_repeated_claims () =
         }
       in
       Memory_io.append_episode_bundle ~keeper_id episode;
-      let ctx = Recall.render_context ~keeper_id ~now () in
+      let ctx =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
       Alcotest.(check int)
         "all repeated rows remain visible"
         3
@@ -2778,7 +2869,13 @@ let test_recall_context_preserves_semantic_memory_content () =
         }
       in
       Memory_io.append_episode_bundle ~keeper_id episode;
-      let ctx = Recall.render_context ~keeper_id ~now () in
+      let ctx =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
       Alcotest.(check bool)
         "contains recall header"
         true
@@ -2856,7 +2953,13 @@ let test_recall_context_preserves_admission_memory () =
       in
       Memory_io.append_episode_bundle ~keeper_id transient_episode;
       Memory_io.append_episode_bundle ~keeper_id useful_episode;
-      let ctx = Recall.render_context ~keeper_id ~now () in
+      let ctx =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
       Alcotest.(check bool)
         "keeps stale diagnostic fact"
         true
@@ -3070,7 +3173,13 @@ let test_recall_selection_budget_truncates_facts_by_recency () =
             in
             Memory_io.append_fact ~keeper_id f)
           [ 1; 2; 3; 4; 5 ];
-        let ctx = Recall.render_context ~keeper_id ~now () in
+        let ctx =
+          Recall.render_context
+            ~projection:Recall_projection.Facts_and_episodes
+            ~keeper_id
+            ~now
+            ()
+        in
         List.iter
           (fun i ->
             Alcotest.(check bool)
@@ -3112,7 +3221,13 @@ let test_recall_selection_budget_no_truncation_below_budget () =
             in
             Memory_io.append_fact ~keeper_id f)
           [ 1; 2; 3 ];
-        let ctx = Recall.render_context ~keeper_id ~now () in
+        let ctx =
+          Recall.render_context
+            ~projection:Recall_projection.Facts_and_episodes
+            ~keeper_id
+            ~now
+            ()
+        in
         List.iter
           (fun i ->
             Alcotest.(check bool)
@@ -3514,8 +3629,10 @@ let test_byte_budget_keeps_newest_in_original_order () =
 let test_gauge_reports_injected_against_stored () =
   Alcotest.(check string)
     "gauge reports injected against stored plus the byte budget"
-    "facts 62/62 injected, episodes 130/432 injected, 64512B/65536B rendered"
+    "projection=facts_and_episodes, facts 62/62 injected, episodes 130/432 \
+     injected, 64512B/65536B rendered"
     (Masc.Keeper_memory_os_recall.render_gauge_line
+       ~projection:Recall_projection.Facts_and_episodes
        ~facts_injected:62
        ~facts_stored:62
        ~episodes_injected:130
@@ -3524,11 +3641,13 @@ let test_gauge_reports_injected_against_stored () =
        ~byte_budget:65536);
   Alcotest.(check string)
     "a disabled budget reads as unbounded rather than as a literal zero"
-    "facts 1/1 injected, episodes 2/2 injected, 40B rendered (no byte budget)"
+    "projection=facts_only, facts 1/1 injected, episodes 0/2 injected, 40B \
+     rendered (no byte budget)"
     (Masc.Keeper_memory_os_recall.render_gauge_line
+       ~projection:Recall_projection.Facts_only
        ~facts_injected:1
        ~facts_stored:1
-       ~episodes_injected:2
+       ~episodes_injected:0
        ~episodes_stored:2
        ~rendered_bytes:40
        ~byte_budget:0)
@@ -4343,7 +4462,13 @@ let test_claim_kinds_remain_recall_context_in_source_order () =
       List.iter
         (Memory_io.append_fact ~keeper_id)
         [ self_observation; external_state ];
-      let context = Recall.render_context ~keeper_id ~now () in
+      let context =
+        Recall.render_context
+          ~projection:Recall_projection.Facts_and_episodes
+          ~keeper_id
+          ~now
+          ()
+      in
       Alcotest.(check bool)
         "both typed facts remain recall context"
         true
@@ -4630,6 +4755,10 @@ let () =
             "render_if_enabled renders persisted memory"
             `Quick
             test_render_if_enabled_renders_persisted_memory
+        ; Alcotest.test_case
+            "facts-only projection excludes episodes without deleting them"
+            `Quick
+            test_facts_only_projection_excludes_episodes_without_deleting_them
         ; Alcotest.test_case
             "render_if_enabled keeps diagnostic context"
             `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -3,6 +3,7 @@ open Alcotest
 module TL = Keeper_toml_loader
 module KTP = Masc.Keeper_types_profile
 module KEP = Masc.Keeper_tool_persona_runtime
+module Recall_projection = Masc.Keeper_memory_os_recall_projection
 module Runtime = Server_routes_http_runtime
 
 let request_trust_policy =
@@ -542,6 +543,64 @@ max_context_override = 0
      | Error message ->
        check bool "names max_context_override" true
          (contains_substring message "max_context_override"))
+
+let test_profile_parses_memory_os_recall_projection () =
+  let input =
+    {|
+[keeper]
+memory_os_recall_projection = "facts_only"
+|}
+  in
+  match TL.parse_toml input with
+  | Error error -> fail error
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error error -> fail error
+     | Ok defaults ->
+       check bool "typed projection" true
+         (defaults.memory_os_recall_projection
+          = Some Recall_projection.Facts_only);
+       check (list string) "canonical key" []
+         (KTP.detect_unknown_keeper_toml_keys doc))
+
+let test_profile_rejects_invalid_memory_os_recall_projection () =
+  let input =
+    {|
+[keeper]
+memory_os_recall_projection = "latest_useful"
+|}
+  in
+  match TL.parse_toml input with
+  | Error error -> fail error
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Ok _ -> fail "expected invalid memory_os_recall_projection error"
+     | Error message ->
+       check bool "names field" true
+         (contains_substring message "memory_os_recall_projection");
+       check bool "names exact allowed values" true
+         (contains_substring message "facts_and_episodes, facts_only"))
+
+let test_profile_merge_overrides_memory_os_recall_projection () =
+  let base =
+    { KTP.empty_keeper_profile_defaults with
+      memory_os_recall_projection =
+        Some Recall_projection.Facts_and_episodes
+    }
+  in
+  let overlay =
+    { KTP.empty_keeper_profile_defaults with
+      memory_os_recall_projection = Some Recall_projection.Facts_only
+    }
+  in
+  let merged =
+    KTP.merge_keeper_profile_defaults
+      ~agent_name:"projection-test"
+      ~base
+      ~overlay
+  in
+  check bool "overlay projection" true
+    (merged.memory_os_recall_projection = Some Recall_projection.Facts_only)
 
 let test_profile_parses_multimodal_policy () =
   let input = {|
@@ -1431,6 +1490,7 @@ let test_detect_unknown_keys_empty_when_all_canonical () =
 mention_targets = ["a", "b"]
 autoboot_enabled = false
 active_goal_ids = ["goal-runtime"]
+memory_os_recall_projection = "facts_only"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1890,6 +1950,12 @@ let () =
           test_case "full" `Quick test_profile_full;
           test_case "rejects invalid max_context_override" `Quick
             test_profile_rejects_invalid_max_context_override;
+          test_case "parses memory os recall projection" `Quick
+            test_profile_parses_memory_os_recall_projection;
+          test_case "rejects invalid memory os recall projection" `Quick
+            test_profile_rejects_invalid_memory_os_recall_projection;
+          test_case "profile overlay owns memory os recall projection" `Quick
+            test_profile_merge_overrides_memory_os_recall_projection;
           test_case "parses multimodal_policy" `Quick
             test_profile_parses_multimodal_policy;
           test_case "rejects invalid multimodal_policy" `Quick

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -9,6 +9,7 @@
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
 module Recall = Masc.Keeper_memory_os_recall
+module Recall_projection = Masc.Keeper_memory_os_recall_projection
 module Atypes = Agent_sdk.Types
 
 let now = 1_000_000.0
@@ -133,6 +134,7 @@ let test_accumulate_consolidate_recall () =
           (* 3. Recall: the consolidated memory is visible. *)
           let block =
             Recall.render_context
+              ~projection:Recall_projection.Facts_and_episodes
               ~keeper_id
               ~now
               ()


### PR DESCRIPTION
## What

- Add a strict typed `memory_os_recall_projection` keeper TOML setting with `facts_and_episodes` and `facts_only` values.
- Carry the already-loaded pre-dispatch profile snapshot through `Keeper_agent_run` into the recall hook; no second config facade or reload.
- Under `facts_only`, inject typed persisted facts while retaining episode files unchanged.
- Expose the active projection plus injected/stored counts in the recall gauge.

## Why

The global count limits do not help a keeper whose whole episode store fits below those limits. This replaces the closed global latest-N direction with an explicit per-keeper store-tier projection. It does not rank prose, infer usefulness, migrate data, or change defaults for unrelated keepers.

After deployment, `kidsnote.toml` can opt in with:

```toml
[keeper]
memory_os_recall_projection = "facts_only"
```

## Validation

- `scripts/dune-local.sh build test/test_keeper_toml.exe test/test_keeper_memory_os.exe test/test_server_bootstrap_maintenance_memory_os.exe`
- `test_keeper_toml.exe`: 97 passed
- `test_keeper_memory_os.exe`: 100 passed
- `test_server_bootstrap_maintenance_memory_os.exe`: 8 passed
- `ocamlformat --check` on all touched OCaml files
- `git diff --check origin/main...HEAD`