### PR TITLE
feat(keeper): report typed provider input composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.3-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.4-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/dashboard/src/components/keeper-detail-ctx-composition.ts
+++ b/dashboard/src/components/keeper-detail-ctx-composition.ts
@@ -19,7 +19,7 @@ export const ctxCompositionSearch = signal('')
 export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   const points = series.filter(
-    (p: KeeperMetricPoint) => (p.ctx_composition?.attributed_bytes ?? 0) > 0,
+    (p: KeeperMetricPoint) => (p.ctx_composition?.prepared_component_bytes ?? 0) > 0,
   )
   if (points.length === 0) return null
 
@@ -27,22 +27,29 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const latestComposition = latest?.ctx_composition ?? null
   if (!latestComposition) return null
 
-  const latestTotalBytes = latestComposition.attributed_bytes
+  const latestTotalBytes = latestComposition.prepared_component_bytes
   const latestActual = latestComposition.actual_input_tokens
-  const latestEntries = Object.entries(latestComposition.segments)
+  const latestEntries = Object.entries(latestComposition.origin_segments)
     .filter(([, segment]) => (segment?.bytes ?? 0) > 0)
     .sort(([, left], [, right]) => (right.bytes ?? 0) - (left.bytes ?? 0))
   if (latestEntries.length === 0 || latestTotalBytes <= 0) return null
-  const visibleCtxEntries = filterCtxCompositionEntries(latestEntries, ctxCompositionSearch.value)
+  const detailEntries = [
+    ...Object.entries(latestComposition.content_segments),
+    ...Object.entries(latestComposition.context_block_segments)
+      .map(([key, segment]) => [`context_block.${key}`, segment] as const),
+  ]
+    .filter(([, segment]) => (segment?.bytes ?? 0) > 0)
+    .sort(([, left], [, right]) => (right.bytes ?? 0) - (left.bytes ?? 0))
+  const visibleCtxEntries = filterCtxCompositionEntries(detailEntries, ctxCompositionSearch.value)
 
   const allKeys = Array.from(
-    new Set(points.flatMap((point: KeeperMetricPoint) => Object.keys(point.ctx_composition?.segments ?? {}))),
+    new Set(points.flatMap((point: KeeperMetricPoint) => Object.keys(point.ctx_composition?.origin_segments ?? {}))),
   )
   const sortedKeys = allKeys
-    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.bytes ?? 0) > 0))
+    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.origin_segments?.[key]?.bytes ?? 0) > 0))
     .sort((left, right) => {
-      const rightLatest = latestComposition.segments[right]?.bytes ?? 0
-      const leftLatest = latestComposition.segments[left]?.bytes ?? 0
+      const rightLatest = latestComposition.origin_segments[right]?.bytes ?? 0
+      const leftLatest = latestComposition.origin_segments[left]?.bytes ?? 0
       if (rightLatest !== leftLatest) return rightLatest - leftLatest
       return left.localeCompare(right)
     })
@@ -61,10 +68,10 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">CTX Composition</span>
         <${MutedSpan}>${points.length} snapshots</${MutedSpan}>
       </div>
-      <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
+      <div class="grid grid-cols-1 md:grid-cols-5 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <div class="flex items-center justify-between mb-2 gap-3">
-            <${Eyebrow}>attributed content bytes</${Eyebrow}>
+            <${Eyebrow}>prepared components</${Eyebrow}>
             <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotalBytes.toLocaleString()} bytes</span>
           </div>
           <div class="h-3 rounded-[var(--r-0)] overflow-hidden border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] flex">
@@ -77,7 +84,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
             })}
           </div>
           <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            <span>${latestTotalBytes.toLocaleString()} exact bytes represented</span>
+            <span>typed origins · SDK turn ${latestComposition.sdk_turn}</span>
           </div>
         <//>
 
@@ -90,9 +97,17 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         <//>
 
         <${DetailCard} class="flex flex-col justify-between">
+          <${Eyebrow}>wire body</${Eyebrow}>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-accent-fg)]">${latestComposition.request_body_bytes != null ? `${latestComposition.request_body_bytes.toLocaleString()} bytes` : '-'}</span>
+          <${MutedSpan}>${latestComposition.request_body_sha256
+            ? `sha256 ${latestComposition.request_body_sha256.slice(0, 12)}…`
+            : 'exact pre-dispatch serialization'}</${MutedSpan}>
+        <//>
+
+        <${DetailCard} class="flex flex-col justify-between">
           <${Eyebrow}>provider input</${Eyebrow}>
           <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${latestActual != null ? `${formatTokens(latestActual)} tokens` : '-'}</span>
-          <${MutedSpan}>reported separately; not byte-attributed</${MutedSpan}>
+          <${MutedSpan}>provider-reported; not estimated</${MutedSpan}>
         <//>
       </div>
 
@@ -105,13 +120,13 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="컨텍스트 구성 스택 히스토리" style="background:var(--bg-deepest);">
             ${points.map((point: KeeperMetricPoint, index: number) => {
               const comp = point.ctx_composition
-              if (!comp || comp.attributed_bytes <= 0) return null
+              if (!comp || comp.prepared_component_bytes <= 0) return null
               const x = pad + (index * barStep) + Math.max(0, (barStep - barWidth) / 2)
               let yCursor = H - pad
               return sortedKeys.map((key) => {
-                const bytes = comp.segments[key]?.bytes ?? 0
+                const bytes = comp.origin_segments[key]?.bytes ?? 0
                 if (bytes <= 0) return null
-                const height = (bytes / comp.attributed_bytes) * innerH
+                const height = (bytes / comp.prepared_component_bytes) * innerH
                 yCursor -= height
                 return html`<rect
                   x="${x.toFixed(1)}"
@@ -129,19 +144,19 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         <${DetailCard}>
           <div class="flex items-center justify-between gap-2 mb-2">
             <${Eyebrow}>latest breakdown</${Eyebrow}>
-            <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
+            <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">${visibleCtxEntries.length}/${detailEntries.length}</span>
           </div>
           <${TextInput}
             type="search"
             class="mb-2 !px-2 !py-1 !text-2xs"
             value=${ctxCompositionSearch.value}
-            placeholder="세그먼트 필터 (예: history, memory)"
+            placeholder="세그먼트 필터 (예: tool result, memory)"
             ariaLabel="context composition 세그먼트 필터"
             onInput=${(e: Event) => { ctxCompositionSearch.value = (e.target as HTMLInputElement).value }}
           />
           ${visibleCtxEntries.length === 0 ? html`
             <div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">
-              필터 결과 없음 (${latestEntries.length} items)
+              필터 결과 없음 (${detailEntries.length} items)
             </div>
           ` : null}
           <div class="flex flex-col gap-1.5 v2-monitoring-row">
@@ -159,6 +174,9 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
                 </div>
               `
             })}
+          </div>
+          <div class="mt-2 text-3xs text-[var(--color-fg-disabled)]">
+            content와 주입 블록은 origin 구성의 하위 drill-down이며 합계에 다시 더하지 않습니다.
           </div>
         <//>
       </div>

--- a/dashboard/src/components/keeper-detail-ctx-utils.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.ts
@@ -18,37 +18,50 @@ export function autonomyHint(count: number | undefined, proactiveEnabled: boolea
 
 export const CTX_SEGMENT_LABELS: Record<string, string> = {
   system_prompt: '시스템 프롬프트',
-  dynamic_context: '턴 컨텍스트',
-  memory_context: '메모리',
-  temporal_context: '시간',
-  user_message: '현재 입력',
-  history_user: '히스토리 · user',
-  history_assistant_text: '히스토리 · assistant',
-  history_tool_use: '히스토리 · tool use',
-  history_tool_result: '히스토리 · tool result',
-  history_other: '히스토리 · 기타',
-  unattributed: '미할당',
+  tool_schemas: '도구 스키마',
+  canonical_history: '정식 히스토리',
+  current_user: '현재 사용자 입력',
+  extra_system_context: '추가 시스템 컨텍스트',
+  'context_block.dynamic_context': '주입 블록 · 턴 컨텍스트',
+  'context_block.temporal_summary': '주입 블록 · 시간 요약',
+  'context_block.memory_os_recall': '주입 블록 · Memory OS recall',
 }
 
 export const CTX_SEGMENT_COLORS: Record<string, string> = {
   system_prompt: 'var(--amber-bright)',
-  dynamic_context: 'var(--purple)',
-  memory_context: 'var(--rose-light)',
-  temporal_context: 'var(--cyan)',
-  user_message: 'var(--sky-400)',
-  history_user: 'var(--purple)',
-  history_assistant_text: 'var(--blue-400)',
-  history_tool_use: 'var(--color-status-ok)',
-  history_tool_result: 'var(--bad-light)',
-  history_other: 'var(--color-fg-muted)',
-  unattributed: 'var(--color-border-default)',
+  tool_schemas: 'var(--color-status-ok)',
+  canonical_history: 'var(--blue-400)',
+  current_user: 'var(--sky-400)',
+  extra_system_context: 'var(--rose-light)',
+  'context_block.dynamic_context': 'var(--purple)',
+  'context_block.temporal_summary': 'var(--cyan)',
+  'context_block.memory_os_recall': 'var(--rose-light)',
 }
 
 export function ctxSegmentLabel(key: string): string {
+  if (key.startsWith('caller_projection.')) {
+    return `호출자 projection · ${key.slice('caller_projection.'.length)}`
+  }
+  if (key.startsWith('context_block.')) {
+    return CTX_SEGMENT_LABELS[key] ?? `주입 블록 · ${key.slice('context_block.'.length).replace(/[_-]+/g, ' ')}`
+  }
+  const parts = key.split('.')
+  if (parts.length > 1) {
+    const origin = ctxSegmentLabel(parts.slice(0, -1).join('.'))
+    return `${origin} · ${parts[parts.length - 1]?.replace(/[_-]+/g, ' ')}`
+  }
   return CTX_SEGMENT_LABELS[key] ?? key.replace(/[_-]+/g, ' ')
 }
 
 export function ctxSegmentColor(key: string): string {
+  if (key.startsWith('canonical_history.')) {
+    if (key.endsWith('.tool_result')) return 'var(--bad-light)'
+    if (key.endsWith('.tool_use')) return 'var(--color-status-ok)'
+    if (key.endsWith('.thinking') || key.endsWith('.reasoning_details')) return 'var(--purple)'
+    return CTX_SEGMENT_COLORS.canonical_history ?? 'var(--blue-400)'
+  }
+  if (key.startsWith('context_block.memory_os_recall')) return 'var(--rose-light)'
+  if (key.startsWith('caller_projection.')) return 'var(--cyan)'
   return CTX_SEGMENT_COLORS[key] ?? 'var(--color-fg-muted)'
 }
 

--- a/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
+++ b/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
@@ -78,10 +78,19 @@ describe('keeper prompt byte telemetry', () => {
       metrics_series: [metricPoint({
         ctx_composition: {
           actual_input_tokens: 1000,
-          attributed_bytes: 1160,
-          segments: {
+          sdk_turn: 4,
+          prepared_component_bytes: 1160,
+          request_body_bytes: 1320,
+          request_body_sha256: 'abc123',
+          origin_segments: {
             system_prompt: { bytes: 320, fingerprint: null },
-            history_tool_result: { bytes: 840, fingerprint: null },
+            canonical_history: { bytes: 840, fingerprint: null },
+          },
+          content_segments: {
+            'canonical_history.tool_result': { bytes: 780, fingerprint: null },
+          },
+          context_block_segments: {
+            memory_os_recall: { bytes: 500, fingerprint: null },
           },
         },
       })],
@@ -89,10 +98,13 @@ describe('keeper prompt byte telemetry', () => {
 
     render(html`<${CtxCompositionPanel} keeper=${keeper} />`, container)
 
-    expect(container.textContent).toContain('attributed content bytes')
+    expect(container.textContent).toContain('prepared components')
     expect(container.textContent).toContain('1,160 bytes')
+    expect(container.textContent).toContain('1,320 bytes')
+    expect(container.textContent).toContain('sha256 abc123')
     expect(container.textContent).toContain('provider input')
-    expect(container.textContent).toContain('reported separately; not byte-attributed')
+    expect(container.textContent).toContain('provider-reported; not estimated')
+    expect(container.textContent).toContain('Memory OS recall')
     expect(container.textContent).not.toContain('residual')
   })
 })

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -683,12 +683,20 @@ describe('normalizeKeepers lifecycle metrics', () => {
             compacted: false,
             ctx_composition: {
               actual_input_tokens: 1000,
-              attributed_bytes: 1160,
-              segments: {
+              sdk_turn: 4,
+              prepared_component_bytes: 1160,
+              request_body_bytes: 1320,
+              request_body_sha256: 'abc123',
+              origin_segments: {
                 system_prompt: { bytes: 320, fingerprint: null },
-                history_user: { bytes: 210, fingerprint: null },
-                history_tool_use: { bytes: 90, fingerprint: null },
-                history_tool_result: { bytes: 540, fingerprint: null },
+                canonical_history: { bytes: 840, fingerprint: null },
+              },
+              content_segments: {
+                'canonical_history.tool_use': { bytes: 90, fingerprint: null },
+                'canonical_history.tool_result': { bytes: 540, fingerprint: null },
+              },
+              context_block_segments: {
+                memory_os_recall: { bytes: 210, fingerprint: null },
               },
             },
           },
@@ -700,12 +708,20 @@ describe('normalizeKeepers lifecycle metrics', () => {
     const metric = keeper?.metrics_series?.[0]
     expect(metric?.ctx_composition).toEqual({
       actual_input_tokens: 1000,
-      attributed_bytes: 1160,
-      segments: {
+      sdk_turn: 4,
+      prepared_component_bytes: 1160,
+      request_body_bytes: 1320,
+      request_body_sha256: 'abc123',
+      origin_segments: {
         system_prompt: { bytes: 320, fingerprint: null },
-        history_user: { bytes: 210, fingerprint: null },
-        history_tool_use: { bytes: 90, fingerprint: null },
-        history_tool_result: { bytes: 540, fingerprint: null },
+        canonical_history: { bytes: 840, fingerprint: null },
+      },
+      content_segments: {
+        'canonical_history.tool_use': { bytes: 90, fingerprint: null },
+        'canonical_history.tool_result': { bytes: 540, fingerprint: null },
+      },
+      context_block_segments: {
+        memory_os_recall: { bytes: 210, fingerprint: null },
       },
     })
   })

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -453,16 +453,41 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
             }
           : null
       const rawCtxComposition = isRecord(item.ctx_composition) ? item.ctx_composition : null
-      const rawCtxSegments =
-        rawCtxComposition && isRecord(rawCtxComposition.segments) ? rawCtxComposition.segments : null
-      const ctxSegments =
-        normalizePromptSegments(rawCtxSegments, new Set())
+      const originSegments = normalizePromptSegments(
+        rawCtxComposition && isRecord(rawCtxComposition.origin_segments)
+          ? rawCtxComposition.origin_segments
+          : null,
+        new Set(),
+      )
+      const contentSegments = normalizePromptSegments(
+        rawCtxComposition && isRecord(rawCtxComposition.content_segments)
+          ? rawCtxComposition.content_segments
+          : null,
+        new Set(),
+      )
+      const contextBlockSegments = normalizePromptSegments(
+        rawCtxComposition && isRecord(rawCtxComposition.context_block_segments)
+          ? rawCtxComposition.context_block_segments
+          : null,
+        new Set(),
+      )
       const ctx_composition: CtxCompositionTelemetry | null =
-        rawCtxComposition != null || Object.keys(ctxSegments).length > 0
+        rawCtxComposition != null
           ? {
               actual_input_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.actual_input_tokens) ?? null) : null,
-              attributed_bytes: rawCtxComposition ? (asNumber(rawCtxComposition.attributed_bytes) ?? 0) : 0,
-              segments: ctxSegments,
+              sdk_turn: rawCtxComposition ? (asNumber(rawCtxComposition.sdk_turn) ?? 0) : 0,
+              prepared_component_bytes: rawCtxComposition
+                ? (asNumber(rawCtxComposition.prepared_component_bytes) ?? 0)
+                : 0,
+              request_body_bytes: rawCtxComposition
+                ? (asNumber(rawCtxComposition.request_body_bytes) ?? null)
+                : null,
+              request_body_sha256: rawCtxComposition && typeof rawCtxComposition.request_body_sha256 === 'string'
+                ? rawCtxComposition.request_body_sha256
+                : null,
+              origin_segments: originSegments,
+              content_segments: contentSegments,
+              context_block_segments: contextBlockSegments,
             }
           : null
       const rawTel = isRecord(item.inference_telemetry) ? item.inference_telemetry : null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -361,8 +361,13 @@ export interface PromptTelemetry {
 
 export interface CtxCompositionTelemetry {
   actual_input_tokens: number | null
-  attributed_bytes: number
-  segments: Record<string, PromptSegmentTelemetry>
+  sdk_turn: number
+  prepared_component_bytes: number
+  request_body_bytes: number | null
+  request_body_sha256: string | null
+  origin_segments: Record<string, PromptSegmentTelemetry>
+  content_segments: Record<string, PromptSegmentTelemetry>
+  context_block_segments: Record<string, PromptSegmentTelemetry>
 }
 
 export interface KeeperMetricPoint {

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.3`, runtime pin: `main@e01940b14d501900b8cbfa2fbb1e0484ada5a42d`, declared base version: `v0.231.3`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.4`, runtime pin: `main@7d4bac917b9897dd347bbe8ff1edb9fc8c35e2ca`, declared base version: `v0.231.4`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.3))
+  (agent_sdk (>= 0.231.4))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -32,8 +32,24 @@ type prompt_metrics =
 
 type ctx_composition_metrics =
   { actual_input_tokens : int option
-  ; attributed_bytes : int
-  ; segments : (string * prompt_segment_metrics) list
+  ; sdk_turn : int
+  ; prepared_component_bytes : int
+  ; request_body_bytes : int option
+  ; request_body_sha256 : string option
+  ; origin_segments : (string * prompt_segment_metrics) list
+  ; content_segments : (string * prompt_segment_metrics) list
+  ; context_block_segments : (string * prompt_segment_metrics) list
+  }
+
+type prepared_input_snapshot =
+  { sdk_turn : int
+  ; messages : Agent_sdk.Agent.prepared_message list
+  ; context_blocks : Turn_record.prompt_block list
+  }
+
+type request_wire_snapshot =
+  { sdk_turn : int
+  ; observation : Agent_sdk.Llm_provider.Request_wire_observer.observation
   }
 
 let empty_prompt_segment_metrics =
@@ -171,42 +187,104 @@ let history_bucket_of_block
   | Agent_sdk.Types.Document _ -> "history_document"
   | Agent_sdk.Types.Audio _ -> "history_audio"
 
+let prepared_origin_name = function
+  | Agent_sdk.Agent.Canonical_history -> "canonical_history"
+  | Agent_sdk.Agent.Current_user -> "current_user"
+  | Agent_sdk.Agent.Extra_system_context -> "extra_system_context"
+  | Agent_sdk.Agent.Caller_projection { source } ->
+    "caller_projection." ^ source
+;;
+
+let content_kind = function
+  | Agent_sdk.Types.Text _ -> "text"
+  | Agent_sdk.Types.Thinking _ -> "thinking"
+  | Agent_sdk.Types.ReasoningDetails _ -> "reasoning_details"
+  | Agent_sdk.Types.RedactedThinking _ -> "redacted_thinking"
+  | Agent_sdk.Types.ToolUse _ -> "tool_use"
+  | Agent_sdk.Types.ToolResult _ -> "tool_result"
+  | Agent_sdk.Types.Image _ -> "image"
+  | Agent_sdk.Types.Document _ -> "document"
+  | Agent_sdk.Types.Audio _ -> "audio"
+;;
+
+let serialized_json_metric json =
+  prompt_segment_metrics_of_text (Yojson.Safe.to_string json)
+;;
+
+let sorted_segments totals =
+  Hashtbl.to_seq totals
+  |> List.of_seq
+  |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+;;
+
+let sum_segments segments =
+  List.fold_left (fun acc (_, metric) -> acc + metric.bytes) 0 segments
+;;
+
 let build_ctx_composition_metrics
+    ~(sdk_turn : int)
     ~(system_prompt : string)
-    ~(dynamic_context : string)
-    ~(memory_context : string)
-    ~(temporal_context : string)
-    ~(user_message : string)
-    ~(history_messages : Agent_sdk.Types.message list)
+    ~(tools : Agent_sdk.Tool.t list)
+    ~(prepared_messages : Agent_sdk.Agent.prepared_message list)
+    ~(context_blocks : Turn_record.prompt_block list)
+    ~(request_wire :
+        Agent_sdk.Llm_provider.Request_wire_observer.observation option)
     ~(actual_input_tokens : int option) : ctx_composition_metrics =
-  let totals : (string, prompt_segment_metrics) Hashtbl.t = Hashtbl.create 16 in
-  let add_text_segment bucket text =
-    let metric = prompt_segment_metrics_of_text text in
-    if metric.bytes > 0 then add_segment_metric totals ~bucket metric
+  let origin_totals : (string, prompt_segment_metrics) Hashtbl.t =
+    Hashtbl.create 8
   in
-  add_text_segment "system_prompt" system_prompt;
-  add_text_segment "dynamic_context" dynamic_context;
-  add_text_segment "memory_context" memory_context;
-  add_text_segment "temporal_context" temporal_context;
-  add_text_segment "user_message" user_message;
+  let content_totals : (string, prompt_segment_metrics) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  let system_prompt_metric = prompt_segment_metrics_of_text system_prompt in
+  if system_prompt_metric.bytes > 0
+  then add_segment_metric origin_totals ~bucket:"system_prompt" system_prompt_metric;
+  let tools_metric =
+    tools
+    |> List.map Agent_sdk.Tool.schema_to_json
+    |> fun schemas -> serialized_json_metric (`List schemas)
+  in
+  if tools_metric.bytes > 0
+  then add_segment_metric origin_totals ~bucket:"tool_schemas" tools_metric;
   List.iter
-    (fun (message : Agent_sdk.Types.message) ->
-      List.iter
-        (fun block ->
-          let bucket = history_bucket_of_block ~role:message.role block in
-          let metric = metric_of_block ~role:message.role block in
-          if metric.bytes > 0 then add_segment_metric totals ~bucket metric)
-        message.content)
-    history_messages;
-  let segments =
-    Hashtbl.to_seq totals
-    |> List.of_seq
-    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+    (fun prepared ->
+       let origin =
+         Agent_sdk.Agent.prepared_message_origin prepared
+         |> prepared_origin_name
+       in
+       let message = Agent_sdk.Agent.prepared_message_value prepared in
+       let message_metric =
+         Agent_sdk.Llm_provider.Api_common.message_to_json message
+         |> serialized_json_metric
+       in
+       add_segment_metric origin_totals ~bucket:origin message_metric;
+       List.iter
+         (fun block ->
+            let bucket = origin ^ "." ^ content_kind block in
+            let metric =
+              Agent_sdk.Llm_provider.Api_common.content_block_to_json block
+              |> serialized_json_metric
+            in
+            add_segment_metric content_totals ~bucket metric)
+         message.content)
+    prepared_messages;
+  let origin_segments = sorted_segments origin_totals in
+  let content_segments = sorted_segments content_totals in
+  let context_block_segments =
+    context_blocks
+    |> List.filter_map (fun (block : Turn_record.prompt_block) ->
+      if Prompt_block_id.equal block.block Prompt_block_id.Persona
+      then None
+      else
+        Some
+          ( Prompt_block_id.to_string block.block
+          , { bytes = block.bytes; fingerprint = Some block.digest } ))
   in
-  let attributed_bytes =
-    List.fold_left
-      (fun acc (_, metric) -> acc + metric.bytes)
-      0 segments
+  let request_body_bytes, request_body_sha256 =
+    match request_wire with
+    | Some observation ->
+      Some observation.body_bytes, Some observation.body_sha256
+    | None -> None, None
   in
   let actual_input_tokens =
     match actual_input_tokens with
@@ -215,18 +293,36 @@ let build_ctx_composition_metrics
   in
   {
     actual_input_tokens;
-    attributed_bytes;
-    segments;
+    sdk_turn;
+    prepared_component_bytes = sum_segments origin_segments;
+    request_body_bytes;
+    request_body_sha256;
+    origin_segments;
+    content_segments;
+    context_block_segments;
   }
 
 let ctx_composition_to_json (metrics : ctx_composition_metrics) : Yojson.Safe.t =
   `Assoc
     [
       ("actual_input_tokens", Json_util.int_opt_to_json metrics.actual_input_tokens);
-      ("attributed_bytes", `Int metrics.attributed_bytes);
-      ( "segments",
+      ("sdk_turn", `Int metrics.sdk_turn);
+      ("prepared_component_bytes", `Int metrics.prepared_component_bytes);
+      ("request_body_bytes", Json_util.int_opt_to_json metrics.request_body_bytes);
+      ("request_body_sha256", Json_util.string_opt_to_json metrics.request_body_sha256);
+      ( "origin_segments",
         `Assoc
           (List.map
              (fun (key, value) -> (key, prompt_segment_metrics_to_json value))
-             metrics.segments) );
+             metrics.origin_segments) );
+      ( "content_segments",
+        `Assoc
+          (List.map
+             (fun (key, value) -> (key, prompt_segment_metrics_to_json value))
+             metrics.content_segments) );
+      ( "context_block_segments",
+        `Assoc
+          (List.map
+             (fun (key, value) -> (key, prompt_segment_metrics_to_json value))
+             metrics.context_block_segments) );
     ]

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -28,8 +28,24 @@ type prompt_metrics =
 (** Per-bucket attribution of an Agent.run input window. *)
 type ctx_composition_metrics =
   { actual_input_tokens : int option
-  ; attributed_bytes : int
-  ; segments : (string * prompt_segment_metrics) list
+  ; sdk_turn : int
+  ; prepared_component_bytes : int
+  ; request_body_bytes : int option
+  ; request_body_sha256 : string option
+  ; origin_segments : (string * prompt_segment_metrics) list
+  ; content_segments : (string * prompt_segment_metrics) list
+  ; context_block_segments : (string * prompt_segment_metrics) list
+  }
+
+type prepared_input_snapshot =
+  { sdk_turn : int
+  ; messages : Agent_sdk.Agent.prepared_message list
+  ; context_blocks : Turn_record.prompt_block list
+  }
+
+type request_wire_snapshot =
+  { sdk_turn : int
+  ; observation : Agent_sdk.Llm_provider.Request_wire_observer.observation
   }
 
 val empty_prompt_segment_metrics : prompt_segment_metrics
@@ -66,16 +82,20 @@ val metric_of_block :
 val history_bucket_of_block :
   role:Agent_sdk.Types.role -> Agent_sdk.Types.content_block -> string
 
-(** [actual_input_tokens] is provider-reported and only known after a response.
-    It is not attributed to byte segments. [attributed_bytes] sums only the
-    exact textual/JSON components represented by [segments]. *)
+(** Build the last SDK turn's prepared-input composition from OAS typed
+    origins. [prepared_component_bytes] is the sum of the system prompt, the
+    canonical tool-schema array, and canonical serialized prepared messages.
+    It is not the provider wire size. [request_wire], when present, is the
+    independently observed exact provider serialization prepared before
+    dispatch. [context_blocks] is a drill-down of the extra-system assembly
+    and is intentionally not added again to [prepared_component_bytes]. *)
 val build_ctx_composition_metrics :
+  sdk_turn:int ->
   system_prompt:string ->
-  dynamic_context:string ->
-  memory_context:string ->
-  temporal_context:string ->
-  user_message:string ->
-  history_messages:Agent_sdk.Types.message list ->
+  tools:Agent_sdk.Tool.t list ->
+  prepared_messages:Agent_sdk.Agent.prepared_message list ->
+  context_blocks:Turn_record.prompt_block list ->
+  request_wire:Agent_sdk.Llm_provider.Request_wire_observer.observation option ->
   actual_input_tokens:int option ->
   ctx_composition_metrics
 

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -73,7 +73,7 @@ type run_result =
   { response_text : string
   ; model_used : string
   ; prompt_metrics : prompt_metrics
-  ; ctx_composition : ctx_composition_metrics
+  ; ctx_composition : ctx_composition_metrics option
   ; runtime_observation : Runtime_observation.runtime_observation option
   ; turn_count : int
   ; usage : Agent_sdk.Types.api_usage

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -28,7 +28,7 @@ type run_result =
   { response_text : string
   ; model_used : string
   ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
-  ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics
+  ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics option
   ; runtime_observation : Runtime_observation.runtime_observation option
   ; turn_count : int
   ; usage : Agent_sdk.Types.api_usage

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -646,6 +646,15 @@ let run_turn
     let model_input_projection =
       s.Keeper_run_tools.model_input_projection
     in
+    let pre_dispatch_serialization_observer =
+      s.Keeper_run_tools.pre_dispatch_serialization_observer
+    in
+    let prepared_input_snapshot_ref =
+      s.Keeper_run_tools.prepared_input_snapshot_ref
+    in
+    let request_wire_snapshot_ref =
+      s.Keeper_run_tools.request_wire_snapshot_ref
+    in
     let acc = s.Keeper_run_tools.acc in
     let agent_ref : Agent_sdk.Agent.t option ref = ref None in
     let receipt_turn_count_ref = s.Keeper_run_tools.receipt_turn_count_ref in
@@ -799,6 +808,7 @@ let run_turn
                       ~checkpoint_sink
                       ~initial_messages
                       ~model_input_projection
+                      ~pre_dispatch_serialization_observer
                       ~hooks
                       ~runtime_manifest_context
                       ~runtime_manifest_append:
@@ -876,14 +886,24 @@ let run_turn
                  in
                  let usage = Keeper_context_runtime.usage_of_response result.response in
                  let ctx_composition =
-                   build_ctx_composition_metrics
-                     ~system_prompt:turn_system_prompt
-                     ~dynamic_context
-                     ~memory_context
-                     ~temporal_context
-                     ~user_message
-                     ~history_messages
-                     ~actual_input_tokens:(Some usage.input_tokens)
+                   match !prepared_input_snapshot_ref with
+                   | None -> None
+                   | Some snapshot ->
+                     let request_wire =
+                       match !request_wire_snapshot_ref with
+                       | Some wire when wire.sdk_turn = snapshot.sdk_turn ->
+                         Some wire.observation
+                       | Some _ | None -> None
+                     in
+                     Some
+                       (build_ctx_composition_metrics
+                          ~sdk_turn:snapshot.sdk_turn
+                          ~system_prompt:turn_system_prompt
+                          ~tools
+                          ~prepared_messages:snapshot.messages
+                          ~context_blocks:snapshot.context_blocks
+                          ~request_wire
+                          ~actual_input_tokens:(Some usage.input_tokens))
                  in
                  let completion_observation ()
                      : Keeper_execution_receipt.completion_contract_result =

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -59,7 +59,8 @@ let hydrate_block ~store ~remaining
   | _ -> block
 
 let hydrate_messages ~store ~keep_recent
-    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+    (messages : Agent_sdk.Agent.prepared_message list)
+  : Agent_sdk.Agent.prepared_message list =
   let remaining = ref keep_recent in
   (* "Recent" = tail of the message list. Reverse first so iteration
      visits the LAST message first; the counter then ticks down on the
@@ -72,11 +73,12 @@ let hydrate_messages ~store ~keep_recent
   let reversed = List.rev messages in
   let mapped =
     List.map
-      (fun (msg : Agent_sdk.Types.message) ->
-        let new_content =
-          List.map (hydrate_block ~store ~remaining) msg.content
-        in
-        { msg with content = new_content })
+      (Agent_sdk.Agent.map_prepared_message
+         (fun (msg : Agent_sdk.Types.message) ->
+            let new_content =
+              List.map (hydrate_block ~store ~remaining) msg.content
+            in
+            { msg with content = new_content }))
       reversed
   in
   List.rev mapped

--- a/lib/keeper/keeper_artifact_hydrator.mli
+++ b/lib/keeper/keeper_artifact_hydrator.mli
@@ -18,8 +18,8 @@ val keep_recent_from_env : unit -> int
 val hydrate_recent :
   store:Tool_blob_store.t ->
   keep_recent:int ->
-  Agent_sdk.Types.message list ->
-  Agent_sdk.Types.message list
+  Agent_sdk.Agent.prepared_message list ->
+  Agent_sdk.Agent.prepared_message list
 (** Walk the message list right-to-left
     and hydrates the last [keep_recent] [Stored] markers it encounters.
 

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -582,7 +582,11 @@ let project_model_input ~base_path evidence messages =
         evidence
         (`Hydrated (Inference_utils.sanitize_text_utf8 payload))
     in
-    Ok (messages @ [ Agent_sdk.Types.user_msg hydrated ])
+    Result.map
+      (fun message -> messages @ [ message ])
+      (Agent_sdk.Agent.caller_projected_message
+         ~source:"keeper_gate_replay"
+         (Agent_sdk.Types.user_msg hydrated))
 ;;
 
 let approved_resolution_message ~approval_id ~tool_name ~input ~user_message =

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -94,8 +94,8 @@ val append_model_evidence_block :
 val project_model_input :
   base_path:string ->
   model_evidence ->
-  Agent_sdk.Types.message list ->
-  (Agent_sdk.Types.message list, string) result
+  Agent_sdk.Agent.prepared_message list ->
+  (Agent_sdk.Agent.prepared_message list, string) result
 (** Append the full durable payload as an explicit provider-only message.
     Canonical history remains reference-only and no text search or replacement
     decides where evidence is attached. A storage miss is logged and leaves the

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -61,6 +61,10 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; user_message : string
   ; hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer
+  ; prepared_input_snapshot_ref : prepared_input_snapshot option ref
+  ; request_wire_snapshot_ref : request_wire_snapshot option ref
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
   ; all_tool_names : string list

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -57,6 +57,12 @@ type agent_setup =
   ; user_message : string
   ; hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer
+  ; prepared_input_snapshot_ref :
+      Keeper_agent_prompt_metrics.prepared_input_snapshot option ref
+  ; request_wire_snapshot_ref :
+      Keeper_agent_prompt_metrics.request_wire_snapshot option ref
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
   ; all_tool_names : string list

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -17,6 +17,10 @@ type agent_setup =
   ; user_message : string
   ; hooks : Agent_sdk.Hooks.hooks
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer
+  ; prepared_input_snapshot_ref : prepared_input_snapshot option ref
+  ; request_wire_snapshot_ref : request_wire_snapshot option ref
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
   ; all_tool_names : string list
@@ -526,9 +530,11 @@ let assemble_hooks
                                ]))
                         ())
                  | _ -> ());
-                (* Phase O observability: capture the effective OAS request
-                   boundary after keeper-owned context injection has finalized
-                   [extra_system_context]. *)
+                (* Redacted diagnostic content capture before OAS prepares and
+                   projects provider messages. Exact prepared origins and the
+                   provider serialization boundary are observed separately by
+                   [model_input_projection] and
+                   [pre_dispatch_serialization_observer] below. *)
                 Option.iter
                   (fun turn_id ->
                      Keeper_wire_capture.capture_request
@@ -561,15 +567,34 @@ let assemble_hooks
         ~store
         ~keep_recent:(Keeper_artifact_hydrator.keep_recent_from_env ())
     in
+    let prepared_input_snapshot_ref = ref None in
+    let request_wire_snapshot_ref = ref None in
     let model_input_projection messages =
       let messages = hydrate_model_input messages in
-      match gate_replay_evidence with
-      | None -> Ok messages
-      | Some evidence ->
-        Keeper_gate_replay.project_model_input
-          ~base_path:ctx.config.base_path
-          evidence
-          messages
+      let projected =
+        match gate_replay_evidence with
+        | None -> Ok messages
+        | Some evidence ->
+          Keeper_gate_replay.project_model_input
+            ~base_path:ctx.config.base_path
+            evidence
+            messages
+      in
+      Result.map
+        (fun messages ->
+           prepared_input_snapshot_ref :=
+             Some
+               { sdk_turn = acc.current_turn
+               ; messages
+               ; context_blocks = acc.prompt_blocks
+               };
+           messages)
+        projected
+    in
+    let pre_dispatch_serialization_observer observation =
+      request_wire_snapshot_ref :=
+        Some { sdk_turn = acc.current_turn; observation };
+      Ok ()
     in
     Ok
       { tools
@@ -578,6 +603,9 @@ let assemble_hooks
       ; user_message
       ; hooks
       ; model_input_projection
+      ; pre_dispatch_serialization_observer
+      ; prepared_input_snapshot_ref
+      ; request_wire_snapshot_ref
       ; gate_replay_evidence
       ; acc
       ; all_tool_names

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -345,6 +345,7 @@ let run_named
     ?(tools = [])
     ?(initial_messages = [])
     ?model_input_projection
+    ?pre_dispatch_serialization_observer
     ?stream_idle_timeout_s
     ?body_timeout_s
     ?temperature
@@ -689,6 +690,7 @@ let run_named
             ; tools
             ; initial_messages
             ; model_input_projection
+            ; pre_dispatch_serialization_observer
             ; stream_idle_timeout_s
             ; body_timeout_s
             ; temperature

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -91,6 +91,8 @@ val run_named :
   ?tools:Agent_sdk.Tool.t list ->
   ?initial_messages:Agent_sdk.Types.message list ->
   ?model_input_projection:Agent_sdk.Agent.model_input_projection ->
+  ?pre_dispatch_serialization_observer:
+    Agent_sdk.Agent.pre_dispatch_serialization_observer ->
   ?stream_idle_timeout_s:float ->
   ?body_timeout_s:float ->
   ?temperature:float ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -30,6 +30,8 @@ type try_provider_ctx =
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
   ; model_input_projection : Agent_sdk.Agent.model_input_projection option
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float option
@@ -246,6 +248,8 @@ let run_try_provider
           ; event_bus = ctx.event_bus
           ; initial_messages = ctx.initial_messages
           ; model_input_projection = ctx.model_input_projection
+          ; pre_dispatch_serialization_observer =
+              ctx.pre_dispatch_serialization_observer
           ; raw_trace = ctx.raw_trace
           ; trace_link = ctx.trace_link
           ; yield_on_tool = ctx.yield_on_tool

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -13,6 +13,8 @@ type try_provider_ctx =
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
   ; model_input_projection : Agent_sdk.Agent.model_input_projection option
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float option

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -100,7 +100,11 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("resolved_model_id", `Null);
         ("prompt_fingerprint", `String result.prompt_metrics.fingerprint);
         ("prompt", Keeper_agent_run.prompt_metrics_to_json result.prompt_metrics);
-        ("ctx_composition", Keeper_agent_run.ctx_composition_to_json result.ctx_composition);
+        ( "ctx_composition"
+        , match result.ctx_composition with
+          | Some composition ->
+            Keeper_agent_run.ctx_composition_to_json composition
+          | None -> `Null );
         ("usage", usage_json);
         ("usage_trust", `String (usage_trust_to_string usage_trust));
         ( "usage_anomaly_reasons",

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -1,10 +1,12 @@
-(** Env-gated capture of the MASC->OAS request boundary (redacted).
+(** Env-gated capture of MASC's pre-projection request material (redacted).
 
-    Records the effective request parameters MASC hands to OAS per SDK turn —
+    Records the canonical request parameters MASC hands to OAS per SDK turn —
     system prompt, extra system context, tool schemas, user message, and the
-    replayed conversation history ([initial_messages]) — so
+    replayed conversation history ([initial_messages]) before OAS marks typed
+    origins, applies the caller projection, or serializes a provider body — so
     degenerate-repetition feedback loops can be diagnosed from the actual
-    input rather than from digests/sizes. Tool schemas use the same
+    source material rather than from digests/sizes. This is not provider-wire
+    evidence. Tool schemas use the same
     {!Agent_sdk.Tool.schema_to_json} projection OAS prepares for the provider.
     String content is passed through {!Llm_provider.Secret_redactor} and the exact
     {!Keeper_secret_redaction} projection snapshot before it is written.

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -110,6 +110,8 @@ type config =
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   model_input_projection : Agent_sdk.Agent.model_input_projection option;
+  pre_dispatch_serialization_observer :
+    Agent_sdk.Agent.pre_dispatch_serialization_observer option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;
@@ -1001,6 +1003,8 @@ let resume_from_checkpoint
            ~tools:config.tools ?context:config.context
            ~context_fit_admission:prepared_resume.context_fit_admission
            ?model_input_projection:config.model_input_projection
+           ?pre_dispatch_serialization_observer:
+             config.pre_dispatch_serialization_observer
            ~options ~config:prepared_resume.agent_config
            ?checkpoint_sink:config.checkpoint_sink
            ()))

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -86,6 +86,8 @@ type config = Runtime_agent_context.config = {
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   model_input_projection : Agent_sdk.Agent.model_input_projection option;
+  pre_dispatch_serialization_observer :
+    Agent_sdk.Agent.pre_dispatch_serialization_observer option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -67,6 +67,10 @@ type config =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection option
     (** Caller-owned projection applied only to provider-bound messages.
         Agent state and checkpoints retain their canonical persisted form. *)
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer option
+    (** Metadata-only evidence for the exact provider body prepared before
+        dispatch. This is observation, not transport completion evidence. *)
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; enable_thinking : bool option
@@ -123,6 +127,7 @@ let default_config
   ; description = None
   ; initial_messages = []
   ; model_input_projection = None
+  ; pre_dispatch_serialization_observer = None
   ; raw_trace = None
   ; trace_link = None
   ; enable_thinking = None
@@ -269,6 +274,12 @@ let builder
   let builder =
     match config.model_input_projection with
     | Some project -> Agent_sdk.Builder.with_model_input_projection project builder
+    | None -> builder
+  in
+  let builder =
+    match config.pre_dispatch_serialization_observer with
+    | Some observer ->
+      Agent_sdk.Builder.with_pre_dispatch_serialization_observer observer builder
     | None -> builder
   in
   let builder =

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -58,6 +58,8 @@ type config = {
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   model_input_projection : Agent_sdk.Agent.model_input_projection option;
+  pre_dispatch_serialization_observer :
+    Agent_sdk.Agent.pre_dispatch_serialization_observer option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.3"}
+  "agent_sdk" {>= "0.231.4"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.3"}
+  "agent_sdk" {= "0.231.4"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.3"
-  "git+https://github.com/jeong-sik/oas.git#e01940b14d501900b8cbfa2fbb1e0484ada5a42d"
+  "agent_sdk.0.231.4"
+  "git+https://github.com/jeong-sik/oas.git#7d4bac917b9897dd347bbe8ff1edb9fc8c35e2ca"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.3"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.4"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -41,9 +41,16 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.3"
 # provider heuristics. MASC's exact overlay declares the corresponding
 # delta:reasoning_content capability.
 # Previous pin: v0.231.2 (1ea60e7a1).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.3"
+# v0.231.4 exposes typed origins for the final provider-bound prepared
+# messages and preserves those origins through caller projections. The same
+# request is observed after provider serialization through the existing
+# metadata-only pre-dispatch observer. MASC consumes both contracts directly;
+# it does not infer the current user from list position or reconstruct the
+# provider body from partial byte counts.
+# Previous pin: v0.231.3 (e01940b14).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.4"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="e01940b14d501900b8cbfa2fbb1e0484ada5a42d"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.3"
+readonly OAS_AGENT_SDK_SHA="7d4bac917b9897dd347bbe8ff1edb9fc8c35e2ca"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.4"

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1160,10 +1160,21 @@ let test_resolution_is_durable_and_origin_scoped () =
          | None -> Alcotest.fail "retry lost its replay evidence projection"
          | Some evidence ->
            (match
+              let prepared =
+                match
+                  Agent_sdk.Agent.caller_projected_message
+                    ~source:"test_keeper_approval_queue"
+                    (Agent_sdk.Types.user_msg retry_text)
+                with
+                | Ok prepared -> prepared
+                | Error detail -> Alcotest.fail detail
+              in
               Masc.Keeper_gate_replay.project_model_input
                 ~base_path
                 evidence
-                [ Agent_sdk.Types.user_msg retry_text ]
+                [ prepared ]
+              |> Result.map
+                   (List.map Agent_sdk.Agent.prepared_message_value)
             with
             | Ok [ _canonical; projected ] ->
               Agent_sdk.Types.text_of_content projected.content

--- a/test/test_keeper_artifact_hydrator.ml
+++ b/test/test_keeper_artifact_hydrator.ml
@@ -68,6 +68,23 @@ let extract_tool_content (msg : T.message) : string =
   | [ T.ToolResult { content; _ } ] -> content
   | _ -> failwith "expected single ToolResult block"
 
+let hydrate_messages ~store ~keep_recent messages =
+  let prepared =
+    List.map
+      (fun message ->
+         match
+           Agent_sdk.Agent.caller_projected_message
+             ~source:"test_keeper_artifact_hydrator"
+             message
+         with
+         | Ok prepared -> prepared
+         | Error detail -> Alcotest.fail detail)
+      messages
+  in
+  H.hydrate_recent ~store ~keep_recent prepared
+  |> List.map Agent_sdk.Agent.prepared_message_value
+;;
+
 (* --- Basic hydration --- *)
 
 let test_hydrates_recent_marker () =
@@ -76,7 +93,7 @@ let test_hydrates_recent_marker () =
       let payload = String.make 5000 'x' in
       let _sha, marker = store_a_blob store payload in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:marker in
-      let r = H.hydrate_recent ~store ~keep_recent:3 in
+      let r = hydrate_messages ~store ~keep_recent:3 in
       let result = r [ msg ] in
       Alcotest.(check int) "single message back" 1 (List.length result);
       Alcotest.(check string) "hydrated" payload
@@ -112,7 +129,7 @@ let test_hydration_preserves_tool_failure_provenance () =
         }
       in
       let result =
-        H.hydrate_recent ~store ~keep_recent:1 [ msg ]
+        hydrate_messages ~store ~keep_recent:1 [ msg ]
       in
       match (List.hd result).content with
       | [ T.ToolResult { content; outcome; _ } ] ->
@@ -131,7 +148,7 @@ let test_keep_recent_zero_no_hydration () =
       let store = B.create ~base_path:dir in
       let _sha, marker = store_a_blob store "hello payload" in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:marker in
-      let r = H.hydrate_recent ~store ~keep_recent:0 in
+      let r = hydrate_messages ~store ~keep_recent:0 in
       let result = r [ msg ] in
       Alcotest.(check string) "marker unchanged" marker
         (extract_tool_content (List.hd result)))
@@ -151,7 +168,7 @@ let test_only_last_k_hydrated () =
           make_tool_message ~tool_use_id:"t4" ~content:m4;
         ]
       in
-      let r = H.hydrate_recent ~store ~keep_recent:2 in
+      let r = hydrate_messages ~store ~keep_recent:2 in
       let result = r msgs in
       Alcotest.(check int) "msg count preserved" 4 (List.length result);
       let contents = List.map extract_tool_content result in
@@ -173,7 +190,7 @@ let test_inline_unchanged () =
       let store = B.create ~base_path:dir in
       let inline_payload = "small inline payload" in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:inline_payload in
-      let r = H.hydrate_recent ~store ~keep_recent:3 in
+      let r = hydrate_messages ~store ~keep_recent:3 in
       let result = r [ msg ] in
       Alcotest.(check string) "inline preserved" inline_payload
         (extract_tool_content (List.hd result)))
@@ -190,7 +207,7 @@ let test_non_tool_result_unchanged () =
       metadata = [];
         }
       in
-      let r = H.hydrate_recent ~store ~keep_recent:3 in
+      let r = hydrate_messages ~store ~keep_recent:3 in
       let result = r [ msg ] in
       Alcotest.(check int) "still one block" 1
         (List.length (List.hd result).content);
@@ -214,7 +231,7 @@ let test_hydration_miss_keeps_marker () =
                 ~mime:"text/plain"))
       in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:phantom in
-      let r = H.hydrate_recent ~store ~keep_recent:3 in
+      let r = hydrate_messages ~store ~keep_recent:3 in
       let result = r [ msg ] in
       Alcotest.(check string) "marker untouched" phantom
         (extract_tool_content (List.hd result)))

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -8,6 +8,24 @@ let result_json =
   Alcotest.result json (Alcotest.testable Fmt.string String.equal)
 ;;
 
+let project_model_input ~base_path evidence messages =
+  let prepared =
+    List.map
+      (fun message ->
+         match
+           Agent_sdk.Agent.caller_projected_message
+             ~source:"test_keeper_gate_replay"
+             message
+         with
+         | Ok prepared -> prepared
+         | Error detail -> Alcotest.fail detail)
+      messages
+  in
+  Masc.Keeper_gate_replay.project_model_input ~base_path evidence prepared
+  |> Result.map
+       (List.map Agent_sdk.Agent.prepared_message_value)
+;;
+
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_gate_replay_" "" in
   Unix.unlink dir;
@@ -35,7 +53,7 @@ let projected_model_text ~base_path
   | None -> Alcotest.fail "model message has no replay evidence"
   | Some evidence ->
     (match
-       Masc.Keeper_gate_replay.project_model_input
+       project_model_input
          ~base_path
          evidence
          [ Agent_sdk.Types.user_msg message.text ]
@@ -526,7 +544,7 @@ let test_multimodal_goal_projects_exact_replay_evidence () =
             (Agent_sdk.Types.text_of_content canonical_message.content)
             raw_output);
        match
-         Masc.Keeper_gate_replay.project_model_input
+         project_model_input
            ~base_path
            evidence
            [ canonical_message ]
@@ -577,7 +595,7 @@ let test_replay_projection_recovers_when_canonical_reference_is_absent () =
          | None -> Alcotest.fail "replay evidence is absent"
        in
        match
-         Masc.Keeper_gate_replay.project_model_input
+         project_model_input
            ~base_path
            evidence
            [ Agent_sdk.Types.user_msg "reference was dropped" ]

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -303,7 +303,7 @@ let test_user_message_sanitizer_preserves_semantic_content () =
     (has_in sanitized "Please inspect the current board status.")
 
 let test_ctx_composition_splits_history_bytes () =
-  let history_messages =
+  let messages =
     [
       {
         Agent_sdk.Types.role = Agent_sdk.Types.User;
@@ -347,38 +347,80 @@ let test_ctx_composition_splits_history_bytes () =
       };
     ]
   in
+  let prepared_messages =
+    List.map
+      (fun message ->
+         match
+           Agent_sdk.Agent.caller_projected_message
+             ~source:"test_history"
+             message
+         with
+         | Ok prepared -> prepared
+         | Error detail -> fail detail)
+      messages
+  in
+  let request_wire =
+    Agent_sdk.Llm_provider.Request_wire_observer.observation
+      ~capture_id:None
+      ~provider:"test"
+      ~model:"test"
+      ~http_codec:"test"
+      ~stream:false
+      ~body:"{\"request\":\"body\"}"
+  in
   let metrics =
     KAR.build_ctx_composition_metrics
+      ~sdk_turn:7
       ~system_prompt:"System prompt"
-      ~dynamic_context:"Dynamic context"
-      ~memory_context:"Memory context"
-      ~temporal_context:"Temporal context"
-      ~user_message:"Current user message"
-      ~history_messages
+      ~tools:[]
+      ~prepared_messages
+      ~context_blocks:
+        [ { Turn_record.block = Prompt_block_id.Memory_os_recall
+          ; bytes = 55_055
+          ; digest = String.make 64 'a'
+          }
+        ]
+      ~request_wire:(Some request_wire)
       ~actual_input_tokens:(Some 1000)
   in
-  let segment_bytes key =
-    metrics.segments
+  let segment_bytes segments key =
+    segments
     |> List.assoc_opt key
-    |> Option.map (fun segment -> segment.KAR.bytes)
-    |> Option.value ~default:0
+    |> function
+    | Some segment -> segment.KAR.bytes
+    | None -> 0
   in
   check bool "system prompt bucket present" true
-    (segment_bytes "system_prompt" > 0);
-  check bool "history user bucket present" true
-    (segment_bytes "history_user" > 0);
-  check bool "history assistant text bucket present" true
-    (segment_bytes "history_assistant_text" > 0);
-  check bool "history tool use bucket present" true
-    (segment_bytes "history_tool_use" > 0);
-  check bool "history tool result bucket present" true
-    (segment_bytes "history_tool_result" > 0);
+    (segment_bytes metrics.origin_segments "system_prompt" > 0);
+  check bool "typed caller origin present" true
+    (segment_bytes metrics.origin_segments "caller_projection.test_history" > 0);
+  check bool "history text content present" true
+    (segment_bytes
+       metrics.content_segments
+       "caller_projection.test_history.text"
+     > 0);
+  check bool "history tool use content present" true
+    (segment_bytes
+       metrics.content_segments
+       "caller_projection.test_history.tool_use"
+     > 0);
+  check bool "history tool result content present" true
+    (segment_bytes
+       metrics.content_segments
+       "caller_projection.test_history.tool_result"
+     > 0);
+  check int "sdk turn preserved" 7 metrics.sdk_turn;
+  check (option int) "exact body byte observation"
+    (Some (String.length "{\"request\":\"body\"}"))
+    metrics.request_body_bytes;
+  check int "memory drill-down is not lost" 55_055
+    (segment_bytes metrics.context_block_segments "memory_os_recall");
   check (option int) "provider token observation remains separate" (Some 1000)
     metrics.actual_input_tokens;
-  check int "total bytes equal segment sum"
+  check int "component bytes equal origin sum"
     (List.fold_left (fun total (_, segment) -> total + segment.KAR.bytes) 0
-       metrics.segments)
-    metrics.attributed_bytes
+       metrics.origin_segments)
+    metrics.prepared_component_bytes
 
 (* ── Suite ────────────────────────────────────────────── *)
 

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -802,12 +802,6 @@ let () =
         ~dynamic_context:""
         ~user_message:""
     in
-    let ctx_composition : Masc.Keeper_agent_prompt_metrics.ctx_composition_metrics =
-      { actual_input_tokens = None
-      ; attributed_bytes = 0
-      ; segments = []
-      }
-    in
     let tool_surface : Masc.Keeper_agent_tool_surface.tool_surface_metrics =
       { turn_lane = Masc.Keeper_agent_tool_surface.Lane_tool_optional
       ; config_root = ""
@@ -817,7 +811,7 @@ let () =
     { response_text = "completed"
     ; model_used = "test-model"
     ; prompt_metrics
-    ; ctx_composition
+    ; ctx_composition = None
     ; runtime_observation = None
     ; turn_count = 1
     ; usage = Masc.Inference_utils.zero_usage

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -77,10 +77,21 @@ let project_replay_message_exn ~base_path
   | None -> fail "model message has no replay evidence"
   | Some evidence ->
     (match
+       let prepared =
+         match
+           Agent_sdk.Agent.caller_projected_message
+             ~source:"test_keeper_tool_dispatch_runtime"
+             (Agent_sdk.Types.user_msg message.text)
+         with
+         | Ok prepared -> prepared
+         | Error detail -> fail detail
+       in
        Masc.Keeper_gate_replay.project_model_input
          ~base_path
          evidence
-         [ Agent_sdk.Types.user_msg message.text ]
+         [ prepared ]
+       |> Result.map
+            (List.map Agent_sdk.Agent.prepared_message_value)
      with
      | Ok [ _canonical; projected ] ->
        Agent_sdk.Types.text_of_content projected.content

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1623,14 +1623,16 @@ let projection_messages marker messages =
     | block -> block
   in
   List.map
-    (fun (message : Agent_sdk.Types.message) ->
-      { message with content = List.map project_block message.content })
+    (Agent_sdk.Agent.map_prepared_message
+       (fun (message : Agent_sdk.Types.message) ->
+          { message with content = List.map project_block message.content }))
     messages
 
 let run_projection_case ~resume =
   let canonical_marker = "canonical-unprojected-message" in
   let projected_marker = "projected-provider-message" in
   let projection_calls = ref 0 in
+  let wire_observations = ref [] in
   let (), requests =
     with_native_projection_server
     @@ fun ~sw ~net ~base_url ->
@@ -1641,6 +1643,11 @@ let run_projection_case ~resume =
             (fun messages ->
                incr projection_calls;
                Ok (projection_messages projected_marker messages))
+      ; pre_dispatch_serialization_observer =
+          Some
+            (fun observation ->
+               wire_observations := observation :: !wire_observations;
+               Ok ())
       }
     in
     let agent =
@@ -1678,6 +1685,23 @@ let run_projection_case ~resume =
        check bool (path ^ " excludes canonical input") false
          (String_util.contains_substring body canonical_marker))
     requests
+  ;
+  let completion_body =
+    match List.assoc_opt "/v1/messages" requests with
+    | Some body -> body
+    | None -> fail "completion request body is absent"
+  in
+  (match !wire_observations with
+   | [ observation ] ->
+     check int "observer sees exact completion bytes"
+       (String.length completion_body)
+       observation.body_bytes;
+     check string "observer sees exact completion digest"
+       Digestif.SHA256.(digest_string completion_body |> to_hex)
+       observation.body_sha256
+   | observations ->
+     failf "expected one pre-dispatch observation, got %d"
+       (List.length observations))
 
 let test_runtime_agent_fresh_projection_precedes_measurement () =
   run_projection_case ~resume:false

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -57,6 +57,23 @@ let extract_tool_content (msg : T.message) : string =
   | [ T.ToolResult { content; _ } ] -> content
   | _ -> Alcotest.fail "expected single ToolResult block"
 
+let hydrate_messages ~store ~keep_recent messages =
+  let prepared =
+    List.map
+      (fun message ->
+         match
+           Agent_sdk.Agent.caller_projected_message
+             ~source:"test_tool_output_washing_e2e"
+             message
+         with
+         | Ok prepared -> prepared
+         | Error detail -> Alcotest.fail detail)
+      messages
+  in
+  H.hydrate_recent ~store ~keep_recent prepared
+  |> List.map Agent_sdk.Agent.prepared_message_value
+;;
+
 (* --- The full data flow in one test --- *)
 
 let test_full_flow_externalize_hydrate_serve () =
@@ -117,7 +134,7 @@ let test_full_flow_externalize_hydrate_serve () =
         }
       in
       let hydrated_msgs =
-        H.hydrate_recent ~store ~keep_recent:3 [ msg ]
+        hydrate_messages ~store ~keep_recent:3 [ msg ]
       in
       Alcotest.(check string) "hydrated content matches original payload"
         payload
@@ -183,7 +200,7 @@ let test_recency_budget_holds_across_modules () =
           make_msg ~id:"t4" m4;
         ]
       in
-      let result = H.hydrate_recent ~store ~keep_recent:2 msgs in
+      let result = hydrate_messages ~store ~keep_recent:2 msgs in
       let contents = List.map extract_tool_content result in
       match contents with
       | [ c1; c2; c3; c4 ] ->


### PR DESCRIPTION
## What

- Hard-cut keeper model-input projections to OAS typed prepared-message origins; artifact hydration preserves origin and Gate replay declares its caller source.
- Capture exact pre-dispatch provider body bytes/SHA through OAS's existing observer and carry it through fresh and resumed runtime paths.
- Replace inferred `ctx_composition` fields with typed origin totals, content-kind drill-down, injected-context block drill-down, exact wire size/hash, and provider-reported input tokens.
- Render those distinct quantities in the Keeper detail UI without residual-byte inference or double-counting Memory OS blocks.
- Pin the reviewed OAS 0.231.4 head that provides the typed prepared-message contract.

## Dependency

- Depends on OAS draft PR https://github.com/jeong-sik/oas/pull/2889 (`7d4bac917b9897dd347bbe8ff1edb9fc8c35e2ca`).
- Until that PR lands on OAS `main`, MASC's OAS reachability/drift guard is expected to reject the pin. No compatibility fallback is included.

## Validation

- OAS #2889: all CI green on OCaml 5.4.1/5.5.0 and Eio 1.3/1.4.
- Focused MASC build against OAS worktree install: 8 touched test executables compiled.
- Passing focused suites: prompt metrics 16, artifact hydrator 8, Gate replay 22, approval queue 37, runtime provider/auth 44, tool-output E2E 3.
- Strengthened fresh/resume runtime tests prove the observer body bytes/SHA equal the actual completion HTTP body.
- Dashboard: 41 focused tests, `tsc --noEmit`, touched-file ESLint, and production Vite build pass.
- Existing unrelated failures reproduced unchanged on the current-main binaries: `test_keeper_tool_dispatch_runtime` cases 1/17/42 and `test_keeper_terminal_reason_typed` stale canonical `agent_name` fixture.
